### PR TITLE
fix(#12320): align quant recipe docs and llama.cpp paths

### DIFF
--- a/.github/issue-evidence/12216-stage3-quant-recipe-paths/README.md
+++ b/.github/issue-evidence/12216-stage3-quant-recipe-paths/README.md
@@ -1,0 +1,68 @@
+# Stage 3 Quant Recipe Path + Doc Parity Evidence
+
+Issue: #12320, Local LLM pipeline Stage 3.
+
+Slice covered here:
+
+- Reconcile the training quantization contract with the active Gemma shipping path:
+  TurboQuant is KV-cache compression, PolarQuant is weight quantization, and the
+  shipped Gemma text GGUF is stock `llama-quantize` `Q4_K_M` unless a tier
+  manifest proves a recipe was actually applied to the bytes.
+- Repoint stale converter defaults and runbook hints from the removed
+  `packages/inference/llama.cpp` path to the real runtime submodule:
+  `plugins/plugin-local-inference/native/llama.cpp`.
+- Add CI-friendly regression coverage so wrapper defaults cannot drift back to
+  the removed path.
+
+Verification run from repo root:
+
+```bash
+cmp -s packages/training/CLAUDE.md packages/training/AGENTS.md && echo training-docs-identical
+# training-docs-identical
+
+git diff --check
+# exit 0
+
+python3 -m py_compile \
+  packages/training/scripts/quantization/gguf-q3_k_m_apply.py \
+  packages/training/scripts/quantization/gguf-q4_k_m_apply.py \
+  packages/training/scripts/quantization/gguf-q5_k_m_apply.py \
+  packages/training/scripts/quantization/gguf-q6_k_apply.py \
+  packages/training/scripts/quantization/gguf_asr_apply.py \
+  packages/training/scripts/quantization/gguf_kokoro_apply.py \
+  packages/training/scripts/quantization/gguf_eliza1_apply.py \
+  packages/training/scripts/turn_detector/convert_to_gguf.py \
+  packages/training/scripts/run_pipeline.py \
+  packages/training/scripts/quantization/test_recipes_smoke.py
+# exit 0
+
+python3 -m pytest packages/training/scripts/quantization/test_recipes_smoke.py \
+  -q -k 'gguf_wrappers_default or eliza_typed_gguf'
+# 7 passed
+
+rg -n 'packages/inference/llama\.cpp|"packages" / "inference" / "llama\.cpp"|packages/native-plugins' \
+  packages/training/scripts/quantization \
+  packages/training/scripts/turn_detector \
+  packages/training/scripts/run_pipeline.py \
+  packages/training/AGENTS.md \
+  packages/training/CLAUDE.md \
+  packages/training/pyproject.toml \
+  packages/shared/src/local-inference/catalog.ts
+# Only the new negative assertions in test_recipes_smoke.py match.
+```
+
+Full `test_recipes_smoke.py` was attempted with system Python and failed before
+the changed assertions because the host environment has incompatible Python
+packages:
+
+```text
+transformers requires huggingface-hub>=0.23.2,<1.0, but huggingface-hub==1.15.0 is installed
+```
+
+`uv run --project packages/training --extra train ...` was also attempted, but
+the macOS arm64 environment cannot install `triton==3.6.0`; that wheel is Linux
+only. CI/Linux training workers remain the correct verifier for the full train
+extra.
+
+Screenshots / recordings: N/A. This is a docs + Python script path-resolution
+slice with no UI, device, or browser surface.

--- a/packages/shared/src/local-inference/catalog.ts
+++ b/packages/shared/src/local-inference/catalog.ts
@@ -9,8 +9,9 @@
  * hybrid line — see #9033 and packages/training/scripts/training/model_registry.py
  * for the active registry). Gemma 4 is a dense SWA + shared-KV + per-layer-embedding
  * (PLE) + MQA architecture; KV is already minimal so the legacy
- * QJL/PolarQuant KV kernels are not used (stock KV), while TurboQuant
- * weight-quant remains active. External Hub search remains custom/opt-in and
+ * QJL/TurboQuant KV kernels are not used (stock KV), and the shipping
+ * GGUF weight quant is stock Q4_K_M unless a manifest proves a tier-specific
+ * PolarQuant recipe was actually applied. External Hub search remains custom/opt-in and
  * never enters first-run or default eligibility.
  * Separate-drafter MTP is still the required release shape, but runtime
  * metadata is gated until the Gemma drafter GGUFs are actually hosted.

--- a/packages/training/AGENTS.md
+++ b/packages/training/AGENTS.md
@@ -83,24 +83,32 @@ is published.
 ## 3. Quantization (mandatory recipes)
 
 Quantization is not optional for Eliza-1. Every published bundle MUST
-flow through every applicable recipe.
+flow through every recipe that is actually applicable to the tier and
+runtime. The active Gemma 4 release path uses stock llama.cpp GGUF
+weight quantization (`llama-quantize` Q4_K_M today) for the shipped
+text GGUF unless a recipe below is explicitly applied and verified for
+that tier. Sidecar presence is not proof that a recipe touched the
+bytes.
 
 Pipeline order (binding):
 
 ```
 fp16/bf16 checkpoint
    │
-   ├── TurboQuant Q3 or Q4 (text + drafter weights)
+   ├── Stock GGUF weight quantization (shipping Gemma path today)
+   │     convert_hf_to_gguf.py → llama-quantize Q4_K_M
+   │
+   ├── TurboQuant Q3 or Q4 KV-cache compression (V-cache)
    │     scripts/quantization/turboquant_apply.py
    │     scripts/quantization/fused_turboquant_apply.py
    │
    ├── QJL projection matrices baked into KV-cache layout
    │     scripts/quantization/qjl_apply.py
    │
-   ├── PolarQuant centroids + sign vectors baked into KV-cache layout
+   ├── PolarQuant weight quantization (linear weights)
    │     scripts/quantization/polarquant_apply.py
    │
-   └── (long-context-only) Trellis-coded TCQ on the largest variant
+   └── (long-context-only) Trellis-coded TCQ KV K-type
          scripts/quantization/turboquant_apply.py --trellis
 ```
 
@@ -115,9 +123,13 @@ Hard rules:
   preconditions (wrong layer count, wrong dtype, missing rotation), it
   MUST fail loudly. No silent passes, no skip-and-continue.
 
-Gemma note: QJL/PolarQuant are low-ROI on Gemma 4's already-minimal KV
-(MQA + windowed-SWA + shared-KV), so TurboQuant weight-quant remains the
-primary recipe; the KV-cache QJL/Polar passes are optional for Gemma tiers.
+Gemma note: Gemma 4's KV cache is already minimal (MQA + windowed-SWA +
+shared-KV), and its dual head dims do not match the older head_dim=128
+QJL/Polar KV assumptions. QJL and TurboQuant KV passes are optional for
+Gemma tiers until revalidated per tier. PolarQuant is a weight recipe,
+not a KV-cache recipe. The shipping Gemma text GGUF currently uses stock
+Q4_K_M weight quantization; if PolarQuant is enabled for a tier, the
+produced GGUF and manifest must prove those bytes are PolarQuant bytes.
 
 The reference implementations and on-device kernels live in
 `packages/native/plugins/{qjl-cpu,polarquant-cpu}`. The Python recipes here

--- a/packages/training/CLAUDE.md
+++ b/packages/training/CLAUDE.md
@@ -83,24 +83,32 @@ is published.
 ## 3. Quantization (mandatory recipes)
 
 Quantization is not optional for Eliza-1. Every published bundle MUST
-flow through every applicable recipe.
+flow through every recipe that is actually applicable to the tier and
+runtime. The active Gemma 4 release path uses stock llama.cpp GGUF
+weight quantization (`llama-quantize` Q4_K_M today) for the shipped
+text GGUF unless a recipe below is explicitly applied and verified for
+that tier. Sidecar presence is not proof that a recipe touched the
+bytes.
 
 Pipeline order (binding):
 
 ```
 fp16/bf16 checkpoint
    │
-   ├── TurboQuant Q3 or Q4 (text + drafter weights)
+   ├── Stock GGUF weight quantization (shipping Gemma path today)
+   │     convert_hf_to_gguf.py → llama-quantize Q4_K_M
+   │
+   ├── TurboQuant Q3 or Q4 KV-cache compression (V-cache)
    │     scripts/quantization/turboquant_apply.py
    │     scripts/quantization/fused_turboquant_apply.py
    │
    ├── QJL projection matrices baked into KV-cache layout
    │     scripts/quantization/qjl_apply.py
    │
-   ├── PolarQuant centroids + sign vectors baked into KV-cache layout
+   ├── PolarQuant weight quantization (linear weights)
    │     scripts/quantization/polarquant_apply.py
    │
-   └── (long-context-only) Trellis-coded TCQ on the largest variant
+   └── (long-context-only) Trellis-coded TCQ KV K-type
          scripts/quantization/turboquant_apply.py --trellis
 ```
 
@@ -115,9 +123,13 @@ Hard rules:
   preconditions (wrong layer count, wrong dtype, missing rotation), it
   MUST fail loudly. No silent passes, no skip-and-continue.
 
-Gemma note: QJL/PolarQuant are low-ROI on Gemma 4's already-minimal KV
-(MQA + windowed-SWA + shared-KV), so TurboQuant weight-quant remains the
-primary recipe; the KV-cache QJL/Polar passes are optional for Gemma tiers.
+Gemma note: Gemma 4's KV cache is already minimal (MQA + windowed-SWA +
+shared-KV), and its dual head dims do not match the older head_dim=128
+QJL/Polar KV assumptions. QJL and TurboQuant KV passes are optional for
+Gemma tiers until revalidated per tier. PolarQuant is a weight recipe,
+not a KV-cache recipe. The shipping Gemma text GGUF currently uses stock
+Q4_K_M weight quantization; if PolarQuant is enabled for a tier, the
+produced GGUF and manifest must prove those bytes are PolarQuant bytes.
 
 The reference implementations and on-device kernels live in
 `packages/native/plugins/{qjl-cpu,polarquant-cpu}`. The Python recipes here

--- a/packages/training/pyproject.toml
+++ b/packages/training/pyproject.toml
@@ -74,7 +74,7 @@ train = [
   "liger-kernel>=0.5.0",
   # GGUF Q4_K_M quantization (scripts/quantization/gguf-q4_k_m_apply.py).
   # The wrapper uses the in-repo llama.cpp fork submodule at
-  # packages/inference/llama.cpp (its convert_hf_to_gguf.py + a one-shot
+  # plugins/plugin-local-inference/native/llama.cpp (its convert_hf_to_gguf.py + a one-shot
   # CPU cmake build of llama-quantize/llama-cli — see the script's
   # _VENDOR_HINT), but the llama-cpp-python wheel also ships a usable
   # `gguf` python module so the HF→f16 GGUF convert step works even

--- a/packages/training/scripts/publish/stage_base_v1_candidate.py
+++ b/packages/training/scripts/publish/stage_base_v1_candidate.py
@@ -545,7 +545,7 @@ def main(argv: list[str] | None = None) -> int:
         "sourceModels": {
             "text": {
                 "repo": base_repo,
-                "convertedVia": "packages/inference/llama.cpp/convert_hf_to_gguf.py + scripts/optimize_for_eliza1.py (PolarQuant/QJL/TurboQuant)",
+                "convertedVia": "plugins/plugin-local-inference/native/llama.cpp/convert_hf_to_gguf.py + scripts/optimize_for_eliza1.py (PolarQuant/QJL/TurboQuant)",
                 "note": "Fine-tuned (APOLLO full-parameter SFT) then optimized; NOT strictly base-v1 semantics — this is a finetuned candidate.",
             },
             "voice": {

--- a/packages/training/scripts/quantization/gguf-q3_k_m_apply.py
+++ b/packages/training/scripts/quantization/gguf-q3_k_m_apply.py
@@ -15,7 +15,7 @@ sibling K-quant levels (``-Q4_K_M``, ``-Q5_K_M``, ``-Q6_K``) so the publish
 layer can upload them under the single ``elizaos/eliza-1`` bundle repo.
 
 The converter + binary come from the in-repo llama.cpp fork submodule at
-``packages/inference/llama.cpp`` — the single canonical llama.cpp checkout
+``plugins/plugin-local-inference/native/llama.cpp`` — the single canonical llama.cpp checkout
 for the whole repo. ``convert_hf_to_gguf.py`` is the fork's own script
 (the fork is itself a llama.cpp fork, so it carries all the standard
 tooling). ``llama-quantize`` is built from that submodule with a one-shot
@@ -59,27 +59,29 @@ QUANT_LEVEL = "Q3_K_M"
 
 
 # The in-repo llama.cpp fork submodule — the single canonical llama.cpp
-# checkout for the whole repo (.gitmodules: packages/inference/llama.cpp,
+# checkout for the whole repo (.gitmodules: plugins/plugin-local-inference/native/llama.cpp,
 # url=https://github.com/elizaOS/llama.cpp.git). From this file
 # (packages/training/scripts/quantization/) the repo root is four parents up.
 _REPO_ROOT = _HERE.parents[3]
-_FORK_LLAMA_CPP = _REPO_ROOT / "packages" / "inference" / "llama.cpp"
+_FORK_LLAMA_CPP = (
+    _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
+)
 
 _VENDOR_HINT = (
     "The llama.cpp fork submodule should already be checked out. If it's "
     "missing:\n"
-    "  git submodule update --init packages/inference/llama.cpp\n"
+    "  git submodule update --init plugins/plugin-local-inference/native/llama.cpp\n"
     "Then build the llama-quantize + llama-cli binaries from it (one-shot, "
     "CPU-only is enough):\n"
-    "  cmake -S packages/inference/llama.cpp -B packages/inference/llama.cpp/build \\\n"
+    "  cmake -S plugins/plugin-local-inference/native/llama.cpp -B plugins/plugin-local-inference/native/llama.cpp/build \\\n"
     "        -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF "
     "-DBUILD_SHARED_LIBS=OFF\n"
-    "  cmake --build packages/inference/llama.cpp/build --target llama-quantize "
+    "  cmake --build plugins/plugin-local-inference/native/llama.cpp/build --target llama-quantize "
     "llama-cli -j\"$(nproc)\"\n"
     "Or pass --llama-cpp-dir <path-to-checkout> / set LLAMA_CPP_DIR / put the "
     "binaries on PATH.\n"
     "(convert_hf_to_gguf.py needs the `gguf` + `mistral_common` python deps; "
-    "`uv pip install -r packages/inference/llama.cpp/requirements/"
+    "`uv pip install -r plugins/plugin-local-inference/native/llama.cpp/requirements/"
     "requirements-convert_hf_to_gguf.txt`.)"
 )
 
@@ -89,7 +91,7 @@ def _find_convert_script(llama_cpp_dir: Path | None) -> Path:
 
     Resolution order: ``--llama-cpp-dir`` (explicit), ``$LLAMA_CPP_DIR``
     (env override), the in-repo llama.cpp fork submodule
-    (``packages/inference/llama.cpp``, the canonical checkout), then a
+    (``plugins/plugin-local-inference/native/llama.cpp``, the canonical checkout), then a
     system PATH install (e.g. the llama-cpp-python wheel).
     """
     candidates: list[Path] = []

--- a/packages/training/scripts/quantization/gguf-q4_k_m_apply.py
+++ b/packages/training/scripts/quantization/gguf-q4_k_m_apply.py
@@ -12,7 +12,7 @@ sibling K-quant levels (``-Q5_K_M``, ``-Q6_K``) so the publish layer can
 upload them under the single ``elizaos/eliza-1`` bundle repo.
 
 The converter + binary come from the in-repo llama.cpp fork submodule at
-``packages/inference/llama.cpp`` — the single canonical llama.cpp checkout
+``plugins/plugin-local-inference/native/llama.cpp`` — the single canonical llama.cpp checkout
 for the whole repo. ``convert_hf_to_gguf.py`` is the fork's own script
 (the fork is itself a llama.cpp fork, so it carries all the standard
 tooling). ``llama-quantize`` is built from that submodule with a one-shot
@@ -55,27 +55,29 @@ QUANT_LEVEL = "Q4_K_M"
 
 
 # The in-repo llama.cpp fork submodule — the single canonical llama.cpp
-# checkout for the whole repo (.gitmodules: packages/inference/llama.cpp,
+# checkout for the whole repo (.gitmodules: plugins/plugin-local-inference/native/llama.cpp,
 # url=https://github.com/elizaOS/llama.cpp.git). From this file
 # (packages/training/scripts/quantization/) the repo root is four parents up.
 _REPO_ROOT = _HERE.parents[3]
-_FORK_LLAMA_CPP = _REPO_ROOT / "packages" / "inference" / "llama.cpp"
+_FORK_LLAMA_CPP = (
+    _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
+)
 
 _VENDOR_HINT = (
     "The llama.cpp fork submodule should already be checked out. If it's "
     "missing:\n"
-    "  git submodule update --init packages/inference/llama.cpp\n"
+    "  git submodule update --init plugins/plugin-local-inference/native/llama.cpp\n"
     "Then build the llama-quantize + llama-cli binaries from it (one-shot, "
     "CPU-only is enough):\n"
-    "  cmake -S packages/inference/llama.cpp -B packages/inference/llama.cpp/build \\\n"
+    "  cmake -S plugins/plugin-local-inference/native/llama.cpp -B plugins/plugin-local-inference/native/llama.cpp/build \\\n"
     "        -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF "
     "-DBUILD_SHARED_LIBS=OFF\n"
-    "  cmake --build packages/inference/llama.cpp/build --target llama-quantize "
+    "  cmake --build plugins/plugin-local-inference/native/llama.cpp/build --target llama-quantize "
     "llama-cli -j\"$(nproc)\"\n"
     "Or pass --llama-cpp-dir <path-to-checkout> / set LLAMA_CPP_DIR / put the "
     "binaries on PATH.\n"
     "(convert_hf_to_gguf.py needs the `gguf` + `mistral_common` python deps; "
-    "`uv pip install -r packages/inference/llama.cpp/requirements/"
+    "`uv pip install -r plugins/plugin-local-inference/native/llama.cpp/requirements/"
     "requirements-convert_hf_to_gguf.txt`.)"
 )
 
@@ -85,7 +87,7 @@ def _find_convert_script(llama_cpp_dir: Path | None) -> Path:
 
     Resolution order: ``--llama-cpp-dir`` (explicit), ``$LLAMA_CPP_DIR``
     (env override), the in-repo llama.cpp fork submodule
-    (``packages/inference/llama.cpp``, the canonical checkout), then a
+    (``plugins/plugin-local-inference/native/llama.cpp``, the canonical checkout), then a
     system PATH install (e.g. the llama-cpp-python wheel).
     """
     candidates: list[Path] = []

--- a/packages/training/scripts/quantization/gguf-q5_k_m_apply.py
+++ b/packages/training/scripts/quantization/gguf-q5_k_m_apply.py
@@ -14,7 +14,7 @@ sibling K-quant levels (``-Q3_K_M``, ``-Q4_K_M``, ``-Q6_K``) so the publish
 layer can upload them under the single ``elizaos/eliza-1`` bundle repo.
 
 The converter + binary come from the in-repo llama.cpp fork submodule at
-``packages/inference/llama.cpp`` — the single canonical llama.cpp checkout
+``plugins/plugin-local-inference/native/llama.cpp`` — the single canonical llama.cpp checkout
 for the whole repo. ``convert_hf_to_gguf.py`` is the fork's own script
 (the fork is itself a llama.cpp fork, so it carries all the standard
 tooling). ``llama-quantize`` is built from that submodule with a one-shot
@@ -59,23 +59,25 @@ QUANT_LEVEL = "Q5_K_M"
 # full vendor hint. From this file (packages/training/scripts/quantization/)
 # the repo root is four parents up.
 _REPO_ROOT = _HERE.parents[3]
-_FORK_LLAMA_CPP = _REPO_ROOT / "packages" / "inference" / "llama.cpp"
+_FORK_LLAMA_CPP = (
+    _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
+)
 
 _VENDOR_HINT = (
     "The llama.cpp fork submodule should already be checked out. If it's "
     "missing:\n"
-    "  git submodule update --init packages/inference/llama.cpp\n"
+    "  git submodule update --init plugins/plugin-local-inference/native/llama.cpp\n"
     "Then build the llama-quantize + llama-cli binaries from it (one-shot, "
     "CPU-only is enough):\n"
-    "  cmake -S packages/inference/llama.cpp -B packages/inference/llama.cpp/build \\\n"
+    "  cmake -S plugins/plugin-local-inference/native/llama.cpp -B plugins/plugin-local-inference/native/llama.cpp/build \\\n"
     "        -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF "
     "-DBUILD_SHARED_LIBS=OFF\n"
-    "  cmake --build packages/inference/llama.cpp/build --target llama-quantize "
+    "  cmake --build plugins/plugin-local-inference/native/llama.cpp/build --target llama-quantize "
     "llama-cli -j\"$(nproc)\"\n"
     "Or pass --llama-cpp-dir <path-to-checkout> / set LLAMA_CPP_DIR / put the "
     "binaries on PATH.\n"
     "(convert_hf_to_gguf.py needs the `gguf` + `mistral_common` python deps; "
-    "`uv pip install -r packages/inference/llama.cpp/requirements/"
+    "`uv pip install -r plugins/plugin-local-inference/native/llama.cpp/requirements/"
     "requirements-convert_hf_to_gguf.txt`.)"
 )
 

--- a/packages/training/scripts/quantization/gguf-q6_k_apply.py
+++ b/packages/training/scripts/quantization/gguf-q6_k_apply.py
@@ -16,7 +16,7 @@ publish layer can upload them under the single ``elizaos/eliza-1`` bundle
 repo.
 
 The converter + binary come from the in-repo llama.cpp fork submodule at
-``packages/inference/llama.cpp`` — the single canonical llama.cpp checkout
+``plugins/plugin-local-inference/native/llama.cpp`` — the single canonical llama.cpp checkout
 for the whole repo. ``convert_hf_to_gguf.py`` is the fork's own script
 (the fork is itself a llama.cpp fork, so it carries all the standard
 tooling). ``llama-quantize`` is built from that submodule with a one-shot
@@ -61,23 +61,25 @@ QUANT_LEVEL = "Q6_K"
 # full vendor hint. From this file (packages/training/scripts/quantization/)
 # the repo root is four parents up.
 _REPO_ROOT = _HERE.parents[3]
-_FORK_LLAMA_CPP = _REPO_ROOT / "packages" / "inference" / "llama.cpp"
+_FORK_LLAMA_CPP = (
+    _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
+)
 
 _VENDOR_HINT = (
     "The llama.cpp fork submodule should already be checked out. If it's "
     "missing:\n"
-    "  git submodule update --init packages/inference/llama.cpp\n"
+    "  git submodule update --init plugins/plugin-local-inference/native/llama.cpp\n"
     "Then build the llama-quantize + llama-cli binaries from it (one-shot, "
     "CPU-only is enough):\n"
-    "  cmake -S packages/inference/llama.cpp -B packages/inference/llama.cpp/build \\\n"
+    "  cmake -S plugins/plugin-local-inference/native/llama.cpp -B plugins/plugin-local-inference/native/llama.cpp/build \\\n"
     "        -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF "
     "-DBUILD_SHARED_LIBS=OFF\n"
-    "  cmake --build packages/inference/llama.cpp/build --target llama-quantize "
+    "  cmake --build plugins/plugin-local-inference/native/llama.cpp/build --target llama-quantize "
     "llama-cli -j\"$(nproc)\"\n"
     "Or pass --llama-cpp-dir <path-to-checkout> / set LLAMA_CPP_DIR / put the "
     "binaries on PATH.\n"
     "(convert_hf_to_gguf.py needs the `gguf` + `mistral_common` python deps; "
-    "`uv pip install -r packages/inference/llama.cpp/requirements/"
+    "`uv pip install -r plugins/plugin-local-inference/native/llama.cpp/requirements/"
     "requirements-convert_hf_to_gguf.txt`.)"
 )
 

--- a/packages/training/scripts/quantization/gguf_asr_apply.py
+++ b/packages/training/scripts/quantization/gguf_asr_apply.py
@@ -62,18 +62,20 @@ DEFAULT_MMPROJ_QUANT = "Q8_0"
 # Repo root — four parents up from this file
 # (packages/training/scripts/quantization/).
 _REPO_ROOT = _HERE.parents[3]
-_FORK_LLAMA_CPP = _REPO_ROOT / "packages" / "inference" / "llama.cpp"
+_FORK_LLAMA_CPP = (
+    _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
+)
 
 _VENDOR_HINT = (
     "The llama.cpp fork submodule should already be checked out. If it's "
     "missing:\n"
-    "  git submodule update --init packages/inference/llama.cpp\n"
+    "  git submodule update --init plugins/plugin-local-inference/native/llama.cpp\n"
     "Then build the llama-quantize + llama-cli binaries from it (one-shot, "
     "CPU-only is enough):\n"
-    "  cmake -S packages/inference/llama.cpp -B packages/inference/llama.cpp/build \\\n"
+    "  cmake -S plugins/plugin-local-inference/native/llama.cpp -B plugins/plugin-local-inference/native/llama.cpp/build \\\n"
     "        -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF "
     "-DBUILD_SHARED_LIBS=OFF\n"
-    "  cmake --build packages/inference/llama.cpp/build --target llama-quantize "
+    "  cmake --build plugins/plugin-local-inference/native/llama.cpp/build --target llama-quantize "
     "llama-cli -j\"$(nproc)\"\n"
     "Or pass --llama-cpp-dir <path-to-checkout> / set LLAMA_CPP_DIR / put the "
     "binaries on PATH."

--- a/packages/training/scripts/quantization/gguf_eliza1_apply.py
+++ b/packages/training/scripts/quantization/gguf_eliza1_apply.py
@@ -66,6 +66,11 @@ logging.basicConfig(
 )
 log = logging.getLogger("gguf_eliza1_apply")
 
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_FORK_LLAMA_CPP = (
+    _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
+)
+
 
 # Source-of-truth slot numbers for the Eliza-added GGML types. Mirrors
 # packages/app-core/scripts/aosp/compile-libllama.mjs (preamble) and the
@@ -93,7 +98,7 @@ def _resolve_convert_script(llama_cpp_dir: Path | None) -> Path:
     """Locate ``convert_hf_to_gguf.py`` in the elizaOS/llama.cpp fork checkout.
 
     Resolution order: --llama-cpp-dir → $LLAMA_CPP_DIR → the in-repo fork
-    submodule (``packages/inference/llama.cpp``, the single canonical
+    submodule (``plugins/plugin-local-inference/native/llama.cpp``, the single canonical
     llama.cpp checkout) → the standalone clone at
     ``~/.cache/eliza-mtp/eliza-llama-cpp`` (used when the build scripts'
     ELIZA_MTP_LLAMA_CPP_REMOTE/_REF override forces one) → $PATH.
@@ -104,14 +109,10 @@ def _resolve_convert_script(llama_cpp_dir: Path | None) -> Path:
     env_dir = os.environ.get("LLAMA_CPP_DIR")
     if env_dir:
         cands.append(Path(env_dir))
-    # packages/inference/llama.cpp is the canonical fork submodule
-    # (.gitmodules: url=https://github.com/elizaOS/llama.cpp.git).
-    here = Path(__file__).resolve()
-    for p in here.parents:
-        cand = p / "packages" / "inference" / "llama.cpp"
-        if cand.is_dir():
-            cands.append(cand)
-            break
+    # plugins/plugin-local-inference/native/llama.cpp is the canonical fork
+    # submodule (.gitmodules: url=https://github.com/elizaOS/llama.cpp.git).
+    if _FORK_LLAMA_CPP.is_dir():
+        cands.append(_FORK_LLAMA_CPP)
     cands.append(Path.home() / ".cache" / "eliza-mtp" / "eliza-llama-cpp")
     for c in cands:
         cand = c / "convert_hf_to_gguf.py"
@@ -123,7 +124,7 @@ def _resolve_convert_script(llama_cpp_dir: Path | None) -> Path:
     raise FileNotFoundError(
         "convert_hf_to_gguf.py not found. Pass --llama-cpp-dir <path>, set "
         "LLAMA_CPP_DIR=<elizaOS/llama.cpp checkout>, or run "
-        "`git submodule update --init packages/inference/llama.cpp`."
+        "`git submodule update --init plugins/plugin-local-inference/native/llama.cpp`."
     )
 
 
@@ -251,7 +252,7 @@ def main(argv: list[str] | None = None) -> int:
         "--llama-cpp-dir",
         type=Path,
         default=None,
-        help="Path to the elizaOS/llama.cpp v1.0.0-eliza checkout (defaults to the in-repo submodule packages/inference/llama.cpp).",
+        help="Path to the elizaOS/llama.cpp v1.0.0-eliza checkout (defaults to the in-repo submodule plugins/plugin-local-inference/native/llama.cpp).",
     )
     ap.add_argument(
         "--polarquant-sidecar",

--- a/packages/training/scripts/quantization/gguf_kokoro_apply.py
+++ b/packages/training/scripts/quantization/gguf_kokoro_apply.py
@@ -51,8 +51,10 @@ import sys
 from pathlib import Path
 
 _HERE = Path(__file__).resolve().parent
+# packages/training/scripts/quantization/ -> repo root is four parents up.
+_REPO_ROOT = _HERE.parents[3]
 _FORK_LLAMA_CPP = (
-    _HERE.parent.parent.parent / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
+    _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
 )
 _VENDOR_HINT = (
     "Build the Eliza-1 llama.cpp fork first:\n"

--- a/packages/training/scripts/quantization/polar_xorshift32.py
+++ b/packages/training/scripts/quantization/polar_xorshift32.py
@@ -2,8 +2,8 @@
 
 This is the Python port of the C reference implementation that lives in:
 
-    eliza/packages/native-plugins/polarquant-cpu/src/polar_qjl.c
-    eliza/packages/inference/verify/qjl_polar_ref.c          (eliza_polar_qjl_signs)
+    eliza/packages/native/plugins/polarquant-cpu/src/polar_qjl.c
+    eliza/plugins/plugin-local-inference/native/verify/qjl_polar_ref.c          (eliza_polar_qjl_signs)
 
 Per packages/training/AGENTS.md S3 ("kernel side wins") the C reference is
 canonical. The Python recipe must produce a sign sequence that is bit-exact

--- a/packages/training/scripts/quantization/qjl/qjl_quant.py
+++ b/packages/training/scripts/quantization/qjl/qjl_quant.py
@@ -4,10 +4,10 @@ Strongly-typed numpy helpers for the recipe and tests. Layout is the
 canonical ``(head_dim, proj_dim)`` row-major form mandated by the kernel
 references at:
 
-  * ``eliza/packages/native-plugins/qjl-cpu/include/qjl/qjl.h``
-  * ``eliza/packages/native-plugins/qjl-cpu/src/qjl_quantize_ref.c``
-  * ``eliza/packages/native-plugins/qjl-cpu/src/qjl_score_ref.c``
-  * ``eliza/packages/inference/verify/qjl_polar_ref.c`` (verify harness)
+  * ``eliza/packages/native/plugins/qjl-cpu/include/qjl/qjl.h``
+  * ``eliza/packages/native/plugins/qjl-cpu/src/qjl_quantize_ref.c``
+  * ``eliza/packages/native/plugins/qjl-cpu/src/qjl_score_ref.c``
+  * ``eliza/plugins/plugin-local-inference/native/verify/qjl_polar_ref.c`` (verify harness)
 
 The ``block_qjl1_256`` on-cache layout is 32 packed sign bytes (LSB-first
 within each byte) followed by a uint16 bf16 norm — 34 bytes total. The

--- a/packages/training/scripts/quantization/qjl_apply.py
+++ b/packages/training/scripts/quantization/qjl_apply.py
@@ -235,9 +235,9 @@ def _build_jl_projections(
     """Per-layer ``(head_dim, proj_dim)`` row-major JL projection matrices.
 
     Layout matches the canonical kernel reference at
-    ``eliza/packages/native-plugins/qjl-cpu/include/qjl/qjl.h`` (Π row-major,
+    ``eliza/packages/native/plugins/qjl-cpu/include/qjl/qjl.h`` (Π row-major,
     indexed as ``prj[i*proj_dim + j]``) and the verify harness reference at
-    ``eliza/packages/inference/verify/qjl_polar_ref.c``. A row of the matrix
+    ``eliza/plugins/plugin-local-inference/native/verify/qjl_polar_ref.c``. A row of the matrix
     is ``proj_dim`` floats; with the canonical (head_dim=128, proj_dim=256)
     that's 1024 bytes per row and 131072 bytes (128 KiB) per matrix.
 

--- a/packages/training/scripts/quantization/test_recipes_smoke.py
+++ b/packages/training/scripts/quantization/test_recipes_smoke.py
@@ -814,26 +814,32 @@ _KQUANT_SIBLINGS = (
     ("gguf-q6_k_apply",   "Q6_K"),
 )
 
+_CANONICAL_LLAMA_CPP_SUFFIX = Path(
+    "plugins/plugin-local-inference/native/llama.cpp"
+)
+
+
+def _load_module_from_quantization_file(module_basename: str):
+    import importlib.util
+
+    importable = module_basename.replace("-", "_")
+    quant_dir = Path(__file__).resolve().parent
+    spec_path = quant_dir / f"{module_basename}.py"
+    assert spec_path.exists(), f"missing quantization module: {spec_path}"
+
+    spec = importlib.util.spec_from_file_location(importable, spec_path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
 
 @pytest.mark.parametrize("module_basename,expected_level", _KQUANT_SIBLINGS)
 def test_kquant_sibling_exports_constant(module_basename: str, expected_level: str):
     """Every K-quant ladder sibling exports a `QUANT_LEVEL` constant matching
     its filename. The publish path keys on this constant to pick the
     llama-quantize target type."""
-    import importlib
-
-    # Module names use hyphens on disk; importlib needs the underscore form.
-    importable = module_basename.replace("-", "_")
-    # Add the quantization dir to sys.path so the modules import on their
-    # own (they do `from _common import ...`).
-    quant_dir = Path(__file__).resolve().parent
-    spec_path = quant_dir / f"{module_basename}.py"
-    assert spec_path.exists(), f"missing K-quant sibling: {spec_path}"
-
-    spec = importlib.util.spec_from_file_location(importable, spec_path)
-    assert spec is not None and spec.loader is not None
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
+    mod = _load_module_from_quantization_file(module_basename)
     assert getattr(mod, "QUANT_LEVEL") == expected_level
 
 
@@ -844,16 +850,7 @@ def test_kquant_sibling_dry_run_prints_quant_level(
     """Every K-quant sibling supports the same --dry-run surface as the
     Q4_K_M baseline. Output is JSON and contains the recipe-level
     metadata."""
-    import importlib
-
-    importable = module_basename.replace("-", "_")
-    quant_dir = Path(__file__).resolve().parent
-    spec_path = quant_dir / f"{module_basename}.py"
-
-    spec = importlib.util.spec_from_file_location(importable, spec_path)
-    assert spec is not None and spec.loader is not None
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
+    mod = _load_module_from_quantization_file(module_basename)
     rc = mod.main([
         "--model", "google/gemma-4-E2B",
         "--output", str(tmp_path),
@@ -863,6 +860,46 @@ def test_kquant_sibling_dry_run_prints_quant_level(
     payload = json.loads(capsys.readouterr().out)
     assert payload["quant_level"] == _expected_level
     assert payload["dry_run"] is True
+
+
+@pytest.mark.parametrize(
+    "module_basename",
+    (
+        "gguf-q3_k_m_apply",
+        "gguf-q4_k_m_apply",
+        "gguf-q5_k_m_apply",
+        "gguf-q6_k_apply",
+        "gguf_asr_apply",
+        "gguf_kokoro_apply",
+    ),
+)
+def test_gguf_wrappers_default_to_runtime_llama_cpp_submodule(module_basename: str):
+    """Converter wrappers must default to the real in-repo llama.cpp fork.
+
+    The old `packages/inference/llama.cpp` path no longer exists; resolving it
+    made publish recipes fail unless callers remembered to set LLAMA_CPP_DIR.
+    """
+    source = (Path(__file__).resolve().parent / f"{module_basename}.py").read_text(
+        encoding="utf-8"
+    )
+    assert (
+        _CANONICAL_LLAMA_CPP_SUFFIX.as_posix() in source
+        or '"plugins" / "plugin-local-inference" / "native" / "llama.cpp"' in source
+    )
+    assert '"packages" / "inference" / "llama.cpp"' not in source
+    assert "packages/inference/llama.cpp" not in source
+
+
+def test_eliza_typed_gguf_resolver_uses_runtime_llama_cpp_submodule():
+    source = (Path(__file__).resolve().parent / "gguf_eliza1_apply.py").read_text(
+        encoding="utf-8"
+    )
+    assert (
+        _CANONICAL_LLAMA_CPP_SUFFIX.as_posix() in source
+        or '"plugins" / "plugin-local-inference" / "native" / "llama.cpp"' in source
+    )
+    assert '"packages" / "inference" / "llama.cpp"' not in source
+    assert "packages/inference/llama.cpp" not in source
 
 
 def test_gguf_asr_apply_dry_run_single_quant(capsys, tmp_path):

--- a/packages/training/scripts/run_pipeline.py
+++ b/packages/training/scripts/run_pipeline.py
@@ -86,7 +86,7 @@ def _read_json(path: Path) -> dict | None:
 def _resolve_eliza1_llama_cpp() -> Path | None:
     """Locate the elizaOS/llama.cpp fork (Q4_POLAR / QJL1_256 / mtp GGML
     types). Order: $LLAMA_CPP_DIR → in-repo fork submodule
-    (packages/inference/llama.cpp) → ~/.cache/eliza-mtp/eliza-llama-cpp →
+    (plugins/plugin-local-inference/native/llama.cpp) → ~/.cache/eliza-mtp/eliza-llama-cpp →
     ~/src/eliza-llama.cpp. Returns None if none has a convert_hf_to_gguf.py."""
     import os
     cands: list[Path] = []
@@ -94,7 +94,7 @@ def _resolve_eliza1_llama_cpp() -> Path | None:
     if env:
         cands.append(Path(env))
     for p in Path(__file__).resolve().parents:
-        cand = p / "packages" / "inference" / "llama.cpp"
+        cand = p / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
         if cand.is_dir():
             cands.append(cand)
             break

--- a/packages/training/scripts/smoke_full_stack.sh
+++ b/packages/training/scripts/smoke_full_stack.sh
@@ -297,7 +297,7 @@ if [[ $HAS_LLAMA_CPP -eq 1 ]]; then
         2>&1 | tee "$LOG_DIR/05-gguf.log"
     mark_pass "gguf"
 else
-    echo "[smoke]   SKIP: llama.cpp not on PATH (need llama-quantize + convert_hf_to_gguf.py; set LLAMA_CPP_DIR or build the packages/inference/llama.cpp submodule — see gguf-q4_k_m_apply.py _VENDOR_HINT)"
+    echo "[smoke]   SKIP: llama.cpp not on PATH (need llama-quantize + convert_hf_to_gguf.py; set LLAMA_CPP_DIR or build the plugins/plugin-local-inference/native/llama.cpp submodule — see gguf-q4_k_m_apply.py _VENDOR_HINT)"
     mark_skip_tooling "gguf"
 fi
 

--- a/packages/training/scripts/turn_detector/convert_to_gguf.py
+++ b/packages/training/scripts/turn_detector/convert_to_gguf.py
@@ -12,7 +12,7 @@ The two ship targets for the semantic end-of-turn detector are:
 R8 §3.2 / §6.5 / §7.4: all three candidates are Llama-shaped (SmolLM2 is
 a LLaMA-2-style arch by Hugging Face's classification) or qwen2-shaped
 (pruned Qwen2.5), and the in-repo llama.cpp fork at
-``packages/inference/llama.cpp`` already supports both via
+``plugins/plugin-local-inference/native/llama.cpp`` already supports both via
 ``LLM_ARCH_LLAMA`` and ``LLM_ARCH_QWEN2``. ``convert_hf_to_gguf.py``
 handles the LM body conversion natively; the sequence-classification head
 is exposed through the standard ``forward()`` path so the runtime reads
@@ -74,17 +74,19 @@ SUPPORTED_QUANTS = ("Q3_K_M", "Q4_K_M", "Q5_K_M", "Q6_K", "Q8_0")
 DEFAULT_QUANT = "Q4_K_M"
 
 # In-repo llama.cpp fork submodule. Same path the K-quant LM siblings use.
-_FORK_LLAMA_CPP = _REPO_ROOT / "packages" / "inference" / "llama.cpp"
+_FORK_LLAMA_CPP = (
+    _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
+)
 
 _VENDOR_HINT = (
     "The llama.cpp fork submodule should already be checked out. If it's "
     "missing:\n"
-    "  git submodule update --init packages/inference/llama.cpp\n"
+    "  git submodule update --init plugins/plugin-local-inference/native/llama.cpp\n"
     "Then build the llama-quantize binary from it:\n"
-    "  cmake -S packages/inference/llama.cpp -B packages/inference/llama.cpp/build \\\n"
+    "  cmake -S plugins/plugin-local-inference/native/llama.cpp -B plugins/plugin-local-inference/native/llama.cpp/build \\\n"
     "        -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF "
     "-DBUILD_SHARED_LIBS=OFF\n"
-    "  cmake --build packages/inference/llama.cpp/build --target llama-quantize "
+    "  cmake --build plugins/plugin-local-inference/native/llama.cpp/build --target llama-quantize "
     "-j\"$(nproc)\""
 )
 


### PR DESCRIPTION
## Summary

- Corrects the Stage 3 quantization contract so TurboQuant is described as KV-cache compression, PolarQuant as weight quantization, and the active Gemma shipping GGUF path as stock `llama-quantize` `Q4_K_M` unless a manifest proves a tier-specific recipe was applied to the bytes.
- Repoints stale training-side converter defaults and runbook hints from the removed `packages/inference/llama.cpp` path to the real runtime submodule at `plugins/plugin-local-inference/native/llama.cpp`; updates local verify comments away from the removed `packages/inference/verify` path.
- Adds regression coverage in `test_recipes_smoke.py` so GGUF wrapper defaults cannot drift back to the removed path.

## Evidence

Evidence artifact: `.github/issue-evidence/12216-stage3-quant-recipe-paths/README.md`

Validation run after rebasing onto latest `origin/develop`:

```bash
cmp -s packages/training/CLAUDE.md packages/training/AGENTS.md && echo training-docs-identical
git diff --check HEAD~1..HEAD
python3 -m py_compile packages/training/scripts/quantization/gguf-q3_k_m_apply.py packages/training/scripts/quantization/gguf-q4_k_m_apply.py packages/training/scripts/quantization/gguf-q5_k_m_apply.py packages/training/scripts/quantization/gguf-q6_k_apply.py packages/training/scripts/quantization/gguf_asr_apply.py packages/training/scripts/quantization/gguf_kokoro_apply.py packages/training/scripts/quantization/gguf_eliza1_apply.py packages/training/scripts/turn_detector/convert_to_gguf.py packages/training/scripts/run_pipeline.py packages/training/scripts/quantization/test_recipes_smoke.py
python3 -m pytest packages/training/scripts/quantization/test_recipes_smoke.py -q -k "gguf_wrappers_default or eliza_typed_gguf"
```

Results: docs identical, diff check clean, py_compile clean, focused pytest `7 passed`.

Full `test_recipes_smoke.py` with system Python is blocked by the host Python environment (`transformers` requires `huggingface-hub<1.0` but `huggingface-hub==1.15.0` is installed). `uv run --project packages/training --extra train ...` is also not runnable on this macOS arm64 host because `triton==3.6.0` has Linux-only wheels.

Screenshots/recordings: N/A, this is a docs + Python script path-resolution slice with no UI/device/browser surface.

## Scope Notes

This is a Stage 3 slice, not the full closure of #12320. Remaining Stage 3 work still includes making applied recipe real-artifact tests publish-blocking, deciding the legacy fused Qwen path fate, and replacing descriptive codebook identifiers with measured content hashes.