### PR TITLE
docs(#12241): fix root plugin test config header

### DIFF
--- a/plugins/__tests__/vitest.config.ts
+++ b/plugins/__tests__/vitest.config.ts
@@ -1,16 +1,16 @@
+/**
+ * Standalone Vitest config for the root plugin contract suite.
+ *
+ * These tests parse plugin setup-route source files as text without importing
+ * plugin code, so the config stays minimal and independent of the wider test
+ * harness.
+ */
+
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-/**
- * Standalone vitest config for the plugins/__tests__ contract suite.
- *
- * These tests parse plugin setup-route source files as text — no plugin
- * code is actually imported or executed — so the config can stay minimal
- * and independent of the wider eliza test harness.
- */
 export default defineConfig({
   test: {
     dir: __dirname,


### PR DESCRIPTION
## Summary

Moves the existing `plugins/__tests__/vitest.config.ts` explanatory comment into the required top-of-file prose header position and rewrites it slightly to match the repository convention.

This is part of B11 in #12241 and is comment-only.

## Verification

- `bun run check:comment-only` — PASS (`1 source file(s) changed; every code token identical to origin/develop`)
- `bunx vitest run --config plugins/__tests__/vitest.config.ts` — PASS (1 file, 57 tests)
- `git diff --check` — PASS
- Header self-audit for `plugins/__tests__/{setup-routes-contract.test.ts,vitest.config.ts}` — PASS (prints nothing)

## Evidence

- Diffstat: `1 file changed, 8 insertions(+), 8 deletions(-)`
- Real-LLM trajectories: N/A — comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- Screenshots/video/audio: N/A — no UI, audio, or runtime behavior changed.
- Backend/frontend logs: N/A — no runtime path changed.
- Domain artifacts: N/A — test config comment only; no generated artifacts or setup-route behavior changed.
