### PR TITLE
fix(#12319): fail closed on non-finite SFT loss

### DIFF
--- a/.github/issue-evidence/12216-stage2-finite-loss-guard/README.md
+++ b/.github/issue-evidence/12216-stage2-finite-loss-guard/README.md
@@ -1,0 +1,38 @@
+# Stage 2 Finite Loss Guard Evidence
+
+Issue: #12319, Local LLM pipeline Stage 2.
+
+Slice covered here:
+
+- Adds `assert_finite_loss()` to the training instrumentation module.
+- Wires `train_local.py` so both direct model loss and fallback trainer loss
+  hard-fail when the loss tensor contains NaN or Inf.
+- Extends CPU-only finite-guard tests to cover finite scalar loss, NaN scalar
+  loss, and mixed finite/Inf/NaN vector loss.
+
+Verification run from repo root:
+
+```bash
+python3 -m pytest packages/training/scripts/training/test_finite_guard.py \
+  -q -k 'finite_loss or finite_weights or callback'
+# 5 passed, 2 skipped
+
+python3 -m py_compile \
+  packages/training/scripts/train_local.py \
+  packages/training/scripts/training/instrumentation.py \
+  packages/training/scripts/training/test_finite_guard.py
+# exit 0
+
+git diff --check
+# exit 0
+```
+
+The two skipped tests are the existing `transformers` callback-factory tests.
+They skip because the host system Python environment has incompatible packages:
+
+```text
+transformers requires huggingface-hub>=0.23.2,<1.0, but huggingface-hub==1.15.0 is installed
+```
+
+Screenshots / recordings: N/A. This is a training-script numerics guard with no
+UI, device, or browser surface.

--- a/packages/training/scripts/train_local.py
+++ b/packages/training/scripts/train_local.py
@@ -857,6 +857,8 @@ def main() -> int:
     # which fails when Liger fused chunked-CE returns logits=None. When the
     # model already produces `outputs.loss` (Liger or model-side loss), use
     # that directly. Also handles the FSDP+APOLLO `create_optimizer` rebuild.
+    from training.instrumentation import assert_finite_loss
+
     class _ElizaSFTTrainer(SFTTrainer):
         def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
             # Forward — pass labels so the model computes loss internally
@@ -867,9 +869,17 @@ def main() -> int:
             outputs = model(**inputs)
             if outputs.loss is not None:
                 loss = outputs.loss
+                assert_finite_loss(loss, context="SFT model loss")
                 return (loss, outputs) if return_outputs else loss
-            return super().compute_loss(model, inputs, return_outputs=return_outputs,
-                                        num_items_in_batch=num_items_in_batch)
+            computed = super().compute_loss(
+                model,
+                inputs,
+                return_outputs=return_outputs,
+                num_items_in_batch=num_items_in_batch,
+            )
+            loss = computed[0] if return_outputs else computed
+            assert_finite_loss(loss, context="SFT trainer loss")
+            return computed
 
         def create_optimizer(self, model=None):
             # transformers 5.7 calls `create_optimizer(model)`; older releases

--- a/packages/training/scripts/training/instrumentation.py
+++ b/packages/training/scripts/training/instrumentation.py
@@ -393,6 +393,32 @@ def assert_finite_step(model: Any, *, step: int, max_reported: int = 5) -> None:
         )
 
 
+def assert_finite_loss(loss: Any, *, context: str = "training loss") -> None:
+    """Raise ``RuntimeError`` if a trainer loss tensor is NaN or Inf.
+
+    This guard sits at the loss boundary, before optimizer state or checkpoint
+    bytes can be polluted. It complements :func:`assert_finite_step`, which
+    catches any non-finite trainable weight that appears after a step.
+    """
+    import torch
+
+    if not torch.is_tensor(loss):
+        return
+    if torch.isfinite(loss).all():
+        return
+    detached = loss.detach()
+    if detached.numel() == 1:
+        observed = str(detached.item())
+    else:
+        finite = torch.isfinite(detached)
+        bad_count = int((~finite).sum().item())
+        observed = f"{bad_count}/{detached.numel()} non-finite element(s)"
+    raise RuntimeError(
+        f"non-finite (NaN/Inf) {context}: {observed}. "
+        "Training diverged — aborting before optimizer step or checkpoint save."
+    )
+
+
 class FiniteWeightsCallback:
     """HF Trainer callback that hard-fails a divergent run.
 
@@ -448,6 +474,7 @@ __all__ = [
     "InstrumentationCallback",
     "InstrumentationConfig",
     "MemorySnapshot",
+    "assert_finite_loss",
     "assert_finite_step",
     "gpu_memory",
     "log_environment",

--- a/packages/training/scripts/training/test_finite_guard.py
+++ b/packages/training/scripts/training/test_finite_guard.py
@@ -19,6 +19,7 @@ from torch import nn
 from scripts.training.instrumentation import (
     FiniteWeightsCallback,
     InstrumentationConfig,
+    assert_finite_loss,
     assert_finite_step,
     make_finite_weights_callback,
     make_hf_callback,
@@ -58,6 +59,21 @@ def test_passes_on_finite_weights() -> None:
     model = _TinyLM()
     # No exception on healthy weights.
     assert_finite_step(model, step=10)
+
+
+def test_passes_on_finite_loss() -> None:
+    assert_finite_loss(torch.tensor(0.1234), context="unit-test loss")
+
+
+def test_raises_on_nan_loss() -> None:
+    with pytest.raises(RuntimeError, match="non-finite .*unit-test loss"):
+        assert_finite_loss(torch.tensor(float("nan")), context="unit-test loss")
+
+
+def test_raises_on_inf_loss_vector() -> None:
+    loss = torch.tensor([0.1, float("inf"), float("nan")])
+    with pytest.raises(RuntimeError, match="2/3 non-finite"):
+        assert_finite_loss(loss, context="vector loss")
 
 
 def test_raises_on_nan_weight() -> None:


### PR DESCRIPTION
## Summary

- Adds `assert_finite_loss()` to the training instrumentation module.
- Wires `train_local.py` so both direct model loss and fallback trainer loss hard-fail when the loss tensor contains NaN or Inf.
- Extends CPU-only finite-guard tests for finite scalar loss, NaN scalar loss, and mixed finite/Inf/NaN vector loss.

## Evidence

Evidence artifact: `.github/issue-evidence/12216-stage2-finite-loss-guard/README.md`

Validation run after rebase onto latest `origin/develop`:

```bash
python3 -m pytest packages/training/scripts/training/test_finite_guard.py -q -k "finite_loss or finite_weights or callback"
python3 -m py_compile packages/training/scripts/train_local.py packages/training/scripts/training/instrumentation.py packages/training/scripts/training/test_finite_guard.py
git diff --check HEAD~1..HEAD
```

Results: focused pytest `5 passed, 2 skipped`; py_compile clean; diff check clean.

The two skipped tests are existing `transformers` callback-factory tests. This host Python has incompatible packages (`transformers` requires `huggingface-hub<1.0` but `huggingface-hub==1.15.0` is installed), so those remain CI/Linux training-environment coverage.

Screenshots/recordings: N/A, this is a training-script numerics guard with no UI/device/browser surface.

## Scope Notes

This is a Stage 2 fail-closed numerics slice, not the full closure of #12319. Remaining Stage 2 work still includes checkpoint tensor scanning in `run_pipeline`, per-tier grad clip enforcement, and broader real forward/backward smoke evidence.