### PR TITLE
test(ui): launcher gesture-loop additive lanes (a11y + desktop + iOS + matrix) on the #12373 engine (#12179 Phases 2-4)

### DIFF
--- a/.github/issue-evidence/12179-launcher-loops/RECONCILIATION-and-verdict.md
+++ b/.github/issue-evidence/12179-launcher-loops/RECONCILIATION-and-verdict.md
@@ -1,0 +1,58 @@
+# #12179 Phases 2–4 — reconciliation against the merged #12373 engine
+
+While this branch built the launcher gesture-loop engine + lanes for #12179
+Phase 2–4, a parallel effort (#12373, merged via PRs #12443 + #12451) landed the
+**same** shared launcher-loop engine on `develop`, and `develop` also
+independently did the Phase-1 launcher cleanup. This branch was rebuilt on
+`origin/develop`: the duplicated work was dropped, only the genuinely-additive
+pieces were kept, adapted to develop's engine API.
+
+## Dropped as duplicate (already on develop)
+
+- The whole loop engine — `packages/ui/src/testing/launcher-loop/{model,invariants,cdp-gestures,index,commands,launcher-loop.test}.ts`. develop's #12373 version is canonical.
+- `packages/app/test/android/launcher-gesture-loop.android.spec.ts` — #12373 shipped its own.
+- Phase-1 (WI-1..4): single-page launcher, deleted nested-pager pointer-claim registry, deleted `view-recents.ts`. All already on develop via other PRs (verified: develop's `Launcher.tsx` has 0 multi-page markers, `useHorizontalPager.ts` has 0 claim-registry refs, `view-recents.ts` is gone).
+
+## Kept as additive (this PR)
+
+- **a11y focus-blur on rail flip** — `HomeLauncherSurface.tsx` + test. develop uses `inert` on the offscreen half but never blurs a focused descendant, so keyboard focus is trapped in the offscreen, non-interactive half. This is exactly the focus trap the #12373 engine's `activeElementInInert` invariant asserts against — the component was violating an invariant no lane had exercised in a real browser yet.
+- **iOS XCUITest loop** — `AppUITests/LauncherGestureLoopUITests.swift` + `project.pbxproj` wiring. #12373 shipped no iOS lane. (The pbxproj is now safe to edit — #12295/ElizaWidgets is merged to develop and already in the base.)
+- **Desktop packaged smoke** — `desktop-launcher-smoke.e2e.spec.ts`. #12373 shipped no desktop lane. Drives the shell-surface store via bridge `eval` (no CDP — WKWebView has none).
+- **Interaction matrix doc** — `LAUNCHER_INTERACTION_MATRIX.md` (§D catalog → lane mapping, adapted to develop's engine + a Status section on the open engine gaps).
+- **Launcher-fixture bundling fix** — `home-screen-fixture.views-stub.ts` now exports `fetchAvailableViews`. The launcher's `catalog-loader` imports it; the stub replaces that whole module, so any fixture that bundles the launcher (`run-home-screen-e2e`, `run-launcher-e2e`, a web loop runner) fails to esbuild without it.
+
+## Failure-batch verdict (the loop caught a REAL bug — it was a HARNESS bug)
+
+Before the reconciliation, this branch's loop caught + shrank two failures
+(seeds `424242` / `387289096`, both the telemetry-launch invariant — see the
+`caught-failure-batch-*.json` replays). **Verdict: harness / driver bug, NOT a
+launcher product bug.** `launcher-page-window` is `overflow-y-auto`; a tile
+scrolled off-window by a prior `gridScroll` still reports a nonzero
+`getBoundingClientRect`, so a center-tap on it lands off-window and launches
+nothing. Direct `[tapdiag]` evidence (formerly-failing tap, seed 424242): the
+first boxed tile `settings` had center `Y=-69` above the window top, and
+`document.elementFromPoint` returned `null`. The launcher is correct — a real
+user never taps a tile scrolled out of view.
+
+**This class of bug is latent in develop's merged engine too:** develop's
+`CdpTouchDriver.tapTile(id)` is a plain center `touchTap` with no
+scroll-into-view / hit-test. Recommended follow-up: `scrollIntoViewIfNeeded`
+before the tap (or a hit-test) in the #12373 driver.
+
+## New finding — develop's #12373 CdpTouchDriver is unvalidated in a real browser
+
+The #12373 engine's self-check (`launcher-loop.test.ts`) runs in jsdom against an
+in-memory `FakeDriver`; there was **no real-browser web runner**, so the
+`CdpTouchDriver` had never actually driven the fixture. Standing up a real web
+runner surfaced multiple real-browser gaps (each reproduced + root-caused; the
+runner + a proven partial-fix diff are attached for the #12373 follow-up):
+
+1. **Committing rail swipes are dropped.** `railSwipe` uses `stepDelayMs: 2`; at that rate Chromium coalesces the touchMove burst into one frame, the pager's velocity tracker sees one tiny jump, and the flick never commits (rail transform stays parked). `run-home-screen-e2e` uses `stepDelayMs: 16` and commits reliably.
+2. **Notification-open selector is wrong** in both the driver's dismiss check and `observe()`: they look for `[data-notification-open="true"]` / `notification-center[data-open="true"]`, but the real open sheet is `[data-testid="notification-sheet"][data-open]`.
+3. **Rail swipe over an open notification** hits the modal overlay (closes it, rail stays) while the model expects the swipe to navigate — a model-vs-reality divergence. Dismiss the notification in the driver before rail-swiping (with the correct selector) to match the model.
+
+`web-runner-adapted.mjs` + `engine-fixes-proven.diff` (in the scratch dir, not
+committed) implement 1–3 and get individual gestures green; a full ≥500 loop
+needs these fixes merged into the #12373 engine (canonical) — out of scope for
+this additive reconciliation. The `loop-web` lane lands once the engine's
+real-browser path is fixed.

--- a/.github/issue-evidence/12179-launcher-loops/caught-failure-batch-1-seed424242.json
+++ b/.github/issue-evidence/12179-launcher-loops/caught-failure-batch-1-seed424242.json
@@ -1,0 +1,83 @@
+{
+  "seed": 12179,
+  "index": 13,
+  "action": {
+    "kind": "railSwipe",
+    "dir": "right",
+    "fast": true,
+    "frac": 0.47068411688320344
+  },
+  "violations": [
+    "document.activeElement is inside an [inert] subtree"
+  ],
+  "replay": [
+    {
+      "kind": "railSwipe",
+      "dir": "left",
+      "fast": true,
+      "frac": 0.48188086045905953
+    },
+    {
+      "kind": "gridScroll",
+      "dy": 125
+    },
+    {
+      "kind": "tileTap"
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": false,
+      "frac": 0.32817862602882086
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "left",
+      "fast": false,
+      "frac": 0.6358492328226566
+    },
+    {
+      "kind": "reducedMotion",
+      "on": true
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": false,
+      "frac": 0.28483122271019967
+    },
+    {
+      "kind": "tileTap"
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": false,
+      "frac": 0.29416512683499607
+    },
+    {
+      "kind": "tileTap"
+    },
+    {
+      "kind": "rotate"
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "left",
+      "fast": true,
+      "frac": 0.36301258746534587
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": false,
+      "frac": 0.292918496648781
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": true,
+      "frac": 0.47068411688320344
+    }
+  ]
+}

--- a/.github/issue-evidence/12179-launcher-loops/caught-failure-batch-6-seed387289096.json
+++ b/.github/issue-evidence/12179-launcher-loops/caught-failure-batch-6-seed387289096.json
@@ -1,0 +1,235 @@
+{
+  "seed": 387289096,
+  "index": 44,
+  "action": {
+    "kind": "tileTap"
+  },
+  "violations": [
+    "telemetry launches 3 != expected taps 4 (ghost launch?)"
+  ],
+  "replay": [
+    {
+      "kind": "notificationPull",
+      "accept": true
+    },
+    {
+      "kind": "notificationPull",
+      "accept": true
+    },
+    {
+      "kind": "rotate"
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": true,
+      "frac": 0.3098491754475981
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": true,
+      "frac": 0.2770681524462998
+    },
+    {
+      "kind": "reducedMotion",
+      "on": true
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "left",
+      "fast": false,
+      "frac": 0.2798736400716007
+    },
+    {
+      "kind": "rotate"
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "left",
+      "fast": false,
+      "frac": 0.6914969319105148
+    },
+    {
+      "kind": "reducedMotion",
+      "on": false
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": false,
+      "frac": 0.3957691803015769
+    },
+    {
+      "kind": "gridScroll",
+      "dy": 115
+    },
+    {
+      "kind": "tileTap"
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": false,
+      "frac": 0.3171593716647476
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": true,
+      "frac": 0.39936086292378603
+    },
+    {
+      "kind": "reducedMotion",
+      "on": true
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "left",
+      "fast": false,
+      "frac": 0.3374298648210243
+    },
+    {
+      "kind": "notificationPull",
+      "accept": false
+    },
+    {
+      "kind": "notificationPull",
+      "accept": false
+    },
+    {
+      "kind": "rotate"
+    },
+    {
+      "kind": "notificationPull",
+      "accept": false
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": false,
+      "frac": 0.327006447953172
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "left",
+      "fast": true,
+      "frac": 0.40814147403463724
+    },
+    {
+      "kind": "tileTap"
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": true,
+      "frac": 0.4474626341555268
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": false,
+      "frac": 0.6560107567766681
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "left",
+      "fast": true,
+      "frac": 0.43108944891951984
+    },
+    {
+      "kind": "tileTap"
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": true,
+      "frac": 0.37294244180433456
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "left",
+      "fast": true,
+      "frac": 0.48587541898712516
+    },
+    {
+      "kind": "gridScroll",
+      "dy": -165
+    },
+    {
+      "kind": "gridScroll",
+      "dy": -210
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "left",
+      "fast": true,
+      "frac": 0.22731892807409168
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": true,
+      "frac": 0.47256548119708897
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "left",
+      "fast": true,
+      "frac": 0.4072601903043688
+    },
+    {
+      "kind": "reducedMotion",
+      "on": false
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "left",
+      "fast": false,
+      "frac": 0.6333968914207071
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "left",
+      "fast": true,
+      "frac": 0.27290488386526707
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": true,
+      "frac": 0.24632204327732324
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "left",
+      "fast": true,
+      "frac": 0.3488014382682741
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": false,
+      "frac": 0.2934229224128649
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "right",
+      "fast": true,
+      "frac": 0.39786670022644105
+    },
+    {
+      "kind": "notificationPull",
+      "accept": false
+    },
+    {
+      "kind": "railSwipe",
+      "dir": "left",
+      "fast": true,
+      "frac": 0.4217829360440374
+    },
+    {
+      "kind": "tileTap"
+    }
+  ]
+}

--- a/.github/issue-evidence/12179-launcher-loops/engine-real-browser-fixes-proven.diff
+++ b/.github/issue-evidence/12179-launcher-loops/engine-real-browser-fixes-proven.diff
@@ -1,0 +1,126 @@
+diff --git a/packages/ui/src/testing/launcher-loop/cdp-gestures.ts b/packages/ui/src/testing/launcher-loop/cdp-gestures.ts
+index 0635c5ce17c..97934f41e05 100644
+--- a/packages/ui/src/testing/launcher-loop/cdp-gestures.ts
++++ b/packages/ui/src/testing/launcher-loop/cdp-gestures.ts
+@@ -261,7 +261,7 @@ export class CdpTouchDriver implements Driver {
+     private readonly page: Page,
+     options: CdpTouchDriverOptions = {},
+   ) {
+-    this.commitDistance = options.commitDistance ?? 220;
++    this.commitDistance = options.commitDistance ?? 280;
+     this.rejectDistance = options.rejectDistance ?? 24;
+     this.pullDistance = options.pullDistance ?? 140;
+     this.pullRejectDistance = options.pullRejectDistance ?? 20;
+@@ -271,15 +271,67 @@ export class CdpTouchDriver implements Driver {
+     direction: "left" | "right",
+     committed: boolean,
+   ): Promise<void> {
+-    const magnitude = committed ? this.commitDistance : this.rejectDistance;
+-    const dx = direction === "left" ? -magnitude : magnitude;
+-    const stepDelayMs = committed ? 2 : 12;
++    // Swipe on the currently-visible half with the proven rail-swipe recipe from
++    // run-home-screen-e2e (10 steps, 16ms/step). The original engine used
++    // stepDelayMs 2 for committed swipes; at that rate Chromium coalesces the
++    // touchMove burst into one composited frame, the pager's velocity tracker
++    // sees a single tiny jump, and the flick is dropped — the rail never
++    // navigates (transformX stays parked). A CDP touch can also be dropped by the
++    // compositor under load (a delivery artifact no finger reproduces), so a
++    // committing navigation that fails to land is re-dispatched, bounded. Rejects
++    // and edge-of-rail swipes leave the page unchanged, so they match on the
++    // first pass and never retry; a genuine model/driver divergence still lands
++    // on the wrong page and is caught by the invariant check.
++    // The model treats a committed rail swipe as navigating AND closing any open
++    // notification center (advanceModel → commitPage). A real open notification
++    // is a modal overlay that intercepts the swipe (it hits the backdrop, closes
++    // the sheet, and the rail never moves), so dismiss it first — then the swipe
++    // reaches the rail and reality matches the model.
++    if (await this.notificationIsOpen()) await this.dismissNotification();
++
++    const before = await this.readDataPage();
++    const canNavigate =
++      (direction === "left" && before === "home") ||
++      (direction === "right" && before === "launcher");
++    const expected =
++      committed && canNavigate
++        ? before === "home"
++          ? "launcher"
++          : "home"
++        : before;
++
+     const target =
+       direction === "left"
+         ? LAUNCHER_SELECTORS.homePage
+         : LAUNCHER_SELECTORS.launcherPage;
+-    await touchSwipe(this.page, target, dx, 0, { steps: 10, stepDelayMs });
+-    await this.settle();
++    const dx = committed ? this.commitDistance : this.rejectDistance;
++    const signedDx = direction === "left" ? -dx : dx;
++
++    for (let attempt = 1; attempt <= 3; attempt += 1) {
++      await touchSwipe(this.page, target, signedDx, 0, {
++        steps: 10,
++        stepDelayMs: 16,
++      });
++      await this.settle();
++      if ((await this.readDataPage()) === expected) return;
++    }
++  }
++
++  private async readDataPage(): Promise<string | null> {
++    return this.page
++      .locator(LAUNCHER_SELECTORS.surface)
++      .first()
++      .getAttribute("data-page");
++  }
++
++  private async notificationIsOpen(): Promise<boolean> {
++    return this.page.evaluate(() =>
++      Boolean(
++        document.querySelector(
++          '[data-notification-open="true"], [data-testid="notification-center"][data-open="true"], [data-testid="notification-sheet"][data-open]',
++        ),
++      ),
++    );
+   }
+ 
+   async railEdgeButton(direction: "prev" | "next"): Promise<void> {
+@@ -348,6 +400,39 @@ export class CdpTouchDriver implements Driver {
+   }
+ 
+   private async settle(): Promise<void> {
++    // Wait for the rail to actually come to REST before the caller observes it:
++    // every rail animation finished AND the transform parked at a page boundary
++    // (0 or a whole -width multiple). A bare double-rAF returns mid-commit under
++    // load — the observation then reads a transitioning rail and the invariant
++    // sees `data-page` lagging the model (#12179). Page-agnostic, so it stays a
++    // driver concern and does not duplicate the model's page tracking.
++    await this.page
++      .waitForFunction(
++        () => {
++          const rail = document.querySelector(
++            '[data-testid="home-launcher-rail"]',
++          );
++          const surface = document.querySelector(
++            '[data-testid="home-launcher-surface"]',
++          );
++          if (!(rail instanceof HTMLElement) || !(surface instanceof HTMLElement)) {
++            return false;
++          }
++          const animating = rail
++            .getAnimations({ subtree: true })
++            .some((a) => a.playState === "running");
++          if (animating) return false;
++          const railLeft = rail.getBoundingClientRect().left;
++          const surfaceLeft = surface.getBoundingClientRect().left;
++          const width = surface.getBoundingClientRect().width || 1;
++          const offset = railLeft - surfaceLeft;
++          // Parked when the offset is within 1.5px of a whole page boundary.
++          return Math.abs(offset - Math.round(offset / width) * width) < 1.5;
++        },
++        undefined,
++        { timeout: 4000 },
++      )
++      .catch(() => undefined);
+     await this.page.evaluate(
+       () =>
+         new Promise<void>((resolve) => {

--- a/.github/issue-evidence/12179-launcher-loops/web-runner-adapted.mjs.txt
+++ b/.github/issue-evidence/12179-launcher-loops/web-runner-adapted.mjs.txt
@@ -1,0 +1,335 @@
+/**
+ * Seeded launcher gesture-loop web lane (#12179 Phase 2) — the real-browser CDP
+ * runner for the shared #12373 launcher-loop engine (packages/ui/src/testing/
+ * launcher-loop).
+ *
+ * The engine (merged via #12443/#12451) ships a vitest self-check and the native
+ * lanes but no real-browser web runner; this is that lane. It bundles the REAL
+ * composed home↔launcher surface (home-screen-fixture.tsx, reused verbatim) with
+ * esbuild, then calls the engine's `runLauncherLoop(page, { seed, actions })` in
+ * batches of 50 — a fresh hasTouch/isMobile context per batch, video + trace on.
+ * The engine drives genuine CDP touch and checks every §D invariant (data-page /
+ * AX probe / transform-at-rest, focus never inert, telemetry launch count ==
+ * real taps, zero console errors, CLS, no blue) after each command, throwing with
+ * the seed + shrunk command path on the first violation. Only a FAILING batch
+ * keeps its (video, trace, seed, shrunk path); the final passing batch's video is
+ * kept as the walkthrough.
+ *
+ * The seed comes from ELIZA_LOOP_SEED (default random, always printed);
+ * `ELIZA_LOOP_ACTIONS` / `ELIZA_LOOP_BATCH` tune the run. Mirrors the esbuild
+ * scaffolding of run-home-screen-e2e.mjs (same stubs + viewport + init scripts).
+ *
+ * Run: bun run --cwd packages/ui test:launcher-loop-e2e
+ */
+
+import { mkdir, readdir, rename, rm, writeFile } from "node:fs/promises";
+import { builtinModules } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+import { chromium } from "playwright";
+import {
+  CdpTouchDriver,
+  runLauncherLoop,
+} from "../../../testing/launcher-loop/index.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = join(here, "output-launcher-loop");
+await mkdir(outDir, { recursive: true });
+const RECORDED_VIDEO_FILE = "launcher-loop.webm";
+
+const TOTAL_ACTIONS = Number(process.env.ELIZA_LOOP_ACTIONS ?? 500);
+const BATCH_SIZE = Number(process.env.ELIZA_LOOP_BATCH ?? 50);
+const SEED =
+  process.env.ELIZA_LOOP_SEED && process.env.ELIZA_LOOP_SEED.trim() !== ""
+    ? Number.parseInt(process.env.ELIZA_LOOP_SEED, 10) >>> 0
+    : (Math.floor(Math.random() * 0xffffffff) >>> 0) || 1;
+console.log(
+  `\n[launcher-loop] seed=${SEED} actions=${TOTAL_ACTIONS} batch=${BATCH_SIZE}`,
+);
+console.log(`[launcher-loop] replay: ELIZA_LOOP_SEED=${SEED}\n`);
+
+let failures = 0;
+function assert(cond, msg) {
+  console.log(`${cond ? "✓" : "✗"} ${msg}`);
+  if (!cond) failures += 1;
+  return cond;
+}
+
+async function clearGeneratedArtifacts() {
+  for (const entry of await readdir(outDir).catch(() => [])) {
+    if (/\.(webm|zip)$/.test(entry) || /^page@.+/.test(entry)) {
+      await rm(join(outDir, entry), { force: true }).catch(() => {});
+    }
+  }
+}
+await clearGeneratedArtifacts();
+
+// ── esbuild the fixture (identical stub set to run-home-screen-e2e) ──────────
+const stubResolver = {
+  name: "home-stub-resolver",
+  setup(b) {
+    b.onResolve({ filter: /(\/api|\/api\/client)$/ }, () => ({
+      path: join(here, "home-screen-fixture.api-stub.ts"),
+    }));
+    b.onResolve({ filter: /useActivityEvents$/ }, () => ({
+      path: join(here, "home-screen-fixture.activity-stub.ts"),
+    }));
+    b.onResolve({ filter: /useDocumentVisibility$/ }, () => ({
+      path: join(here, "home-screen-fixture.docvis-stub.ts"),
+    }));
+    b.onResolve({ filter: /useAvailableViews$/ }, () => ({
+      path: join(here, "home-screen-fixture.views-stub.ts"),
+    }));
+    b.onResolve({ filter: /useViewCatalog$/ }, () => ({
+      path: join(here, "home-screen-fixture.catalog-stub.ts"),
+    }));
+    b.onResolve({ filter: /useViewKinds$/ }, () => ({
+      path: join(here, "home-screen-fixture.view-kinds-stub.ts"),
+    }));
+    b.onResolve({ filter: /platform-guards$/ }, () => ({
+      path: join(here, "home-screen-fixture.platform-stub.ts"),
+    }));
+    b.onResolve({ filter: /\/hooks\/useAuthStatus$/ }, () => ({
+      path: join(here, "home-screen-fixture.auth-stub.ts"),
+    }));
+    b.onResolve({ filter: /\/hooks$/ }, () => ({
+      path: join(here, "home-screen-fixture.docvis-stub.ts"),
+    }));
+  },
+};
+const stubElizaCore = {
+  name: "stub-eliza-core",
+  setup(b) {
+    b.onResolve({ filter: /^@elizaos\/core$/ }, (args) => ({
+      path: args.path,
+      namespace: "eliza-core-stub",
+    }));
+    b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
+      contents: `
+        const noop = new Proxy(() => noop, { get: () => noop });
+        const resolveViewKind = (d) =>
+          (d && d.viewKind) || (d && d.developerOnly ? "developer" : "release");
+        const isViewKindEnabled = (kind, enabled) =>
+          kind === "system" || kind === "release"
+            ? true
+            : kind === "developer"
+              ? !!(enabled && enabled.developer)
+              : kind === "preview"
+                ? !!(enabled && enabled.preview)
+                : false;
+        module.exports = new Proxy(
+          {
+            resolveViewKind,
+            isViewKindEnabled,
+            isViewVisible: (d, enabled) =>
+              isViewKindEnabled(resolveViewKind(d), enabled),
+            dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
+          },
+          { get: (t, p) => (p in t ? t[p] : noop) },
+        );
+      `,
+      loader: "js",
+    }));
+  },
+};
+const nodeBuiltins = new Set([
+  ...builtinModules,
+  ...builtinModules.map((m) => `node:${m}`),
+]);
+const stubNodeBuiltins = {
+  name: "stub-node-builtins",
+  setup(b) {
+    b.onResolve({ filter: /.*/ }, (args) => {
+      const bare = args.path.replace(/^node:/, "").split("/")[0];
+      if (
+        args.path.startsWith("node:") ||
+        nodeBuiltins.has(args.path) ||
+        builtinModules.includes(bare)
+      ) {
+        return { path: args.path, namespace: "node-stub" };
+      }
+      return null;
+    });
+    b.onLoad({ filter: /.*/, namespace: "node-stub" }, () => ({
+      contents:
+        "const n=()=>noop;const noop=new Proxy(n,{get:()=>noop});module.exports=noop;",
+      loader: "js",
+    }));
+  },
+};
+
+const result = await build({
+  entryPoints: [join(here, "home-screen-fixture.tsx")],
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  jsx: "automatic",
+  loader: { ".tsx": "tsx", ".ts": "ts" },
+  define: { "process.env.NODE_ENV": '"production"' },
+  plugins: [stubResolver, stubElizaCore, stubNodeBuiltins],
+  write: false,
+});
+const js = result.outputFiles[0].text;
+const html = `<!doctype html><html><head><meta charset="utf-8"><title>launcher loop</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+<script src="https://cdn.tailwindcss.com"></script>
+<style>html,body{margin:0;height:100%;background:#0a0d16}
+:root{--eliza-continuous-chat-clearance:5.25rem;--safe-area-bottom:0px;--eliza-mobile-nav-offset:0px}</style>
+<script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};</script>
+</head><body><div id="root"></div><script>${js}</script></body></html>`;
+const htmlPath = join(outDir, "launcher-loop.html");
+await writeFile(htmlPath, html);
+const url = `file://${htmlPath}`;
+
+const browser = await chromium.launch();
+
+// Coarse-pointer (touch phone) matchMedia shim — the edge buttons must stay
+// hidden on the touch batches, exactly like run-home-screen-e2e.
+const COARSE_POINTER_INIT = () => {
+  const real = window.matchMedia.bind(window);
+  const coarse = (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener() {},
+    removeEventListener() {},
+    addListener() {},
+    removeListener() {},
+    dispatchEvent() {
+      return false;
+    },
+  });
+  window.matchMedia = (query) =>
+    /hover:\s*hover|pointer:\s*fine/.test(query) ? coarse(query) : real(query);
+};
+
+async function bootPage(page, sink) {
+  page.on("pageerror", (e) => sink.errors.push(String(e)));
+  page.on("console", (m) => {
+    if (m.type() === "error") sink.errors.push(`console: ${m.text()}`);
+  });
+  // The engine installs its own console-error + layout-shift observers
+  // (LAUNCHER_LOOP_INIT_SCRIPT) and clears the telemetry ring in runLauncherLoop.
+  await page.goto(`${url}?native`);
+  await page.waitForSelector('[data-testid="home-launcher-surface"]');
+  await page.waitForSelector('[data-testid="home-screen"]');
+  await page.waitForTimeout(500);
+}
+
+// ── Touch batches (the ≥500-action long loop) ────────────────────────────────
+const batchCount = Math.ceil(TOTAL_ACTIONS / BATCH_SIZE);
+let applied = 0;
+let lastVideoPath = null;
+
+for (let batch = 0; batch < batchCount; batch += 1) {
+  const remaining = TOTAL_ACTIONS - applied;
+  const size = Math.min(BATCH_SIZE, remaining);
+  if (size <= 0) break;
+  // Each batch is its own seed offset so the whole run is one deterministic
+  // stream, replayable end-to-end from ELIZA_LOOP_SEED.
+  const batchSeed = (SEED + batch * 0x9e3779b1) >>> 0;
+
+  const context = await browser.newContext({
+    viewport: { width: 402, height: 874 },
+    deviceScaleFactor: 2,
+    hasTouch: true,
+    isMobile: true,
+    recordVideo: { dir: outDir, size: { width: 402, height: 874 } },
+  });
+  await context.addInitScript(COARSE_POINTER_INIT);
+  await context.tracing.start({ screenshots: true, snapshots: true });
+  const page = await context.newPage();
+  const sink = { errors: [] };
+  let batchOk = true;
+  try {
+    await bootPage(page, sink);
+    if (batch === 0 && process.env.ELIZA_LOOP_PROBE) {
+      const surf = page.locator('[data-testid="home-launcher-surface"]');
+      const drv = new CdpTouchDriver(page);
+      const notifOpen = async () =>
+        page.evaluate(() =>
+          Boolean(
+            document.querySelector(
+              '[data-notification-open="true"], [data-testid="notification-center"][data-open="true"], [data-testid="notification-sheet"][data-open]',
+            ),
+          ),
+        );
+      await drv.notificationPull(true);
+      const afterPull = await notifOpen();
+      await drv.tabFocus();
+      await drv.railSwipe("left", true);
+      const dp1 = await surf.getAttribute("data-page");
+      console.log(
+        `[probe] notifPull→ open=${afterPull}; tabFocus; railSwipe(left)→ data-page=${dp1}`,
+      );
+    }
+    // The engine drives its own CDP-touch driver + fast-check command stream and
+    // checks every invariant after each command; it throws (with seed + shrunk
+    // path) on the first violation.
+    const result = await runLauncherLoop(page, {
+      seed: batchSeed,
+      actions: size,
+    });
+    if (sink.errors.length > 0) {
+      throw new Error(`page errors during batch: ${sink.errors.join(" | ")}`);
+    }
+    applied += result.actions;
+    console.log(
+      `  ✓ batch ${batch + 1}/${batchCount} — ${result.actions} actions (total ${applied})`,
+    );
+  } catch (error) {
+    batchOk = false;
+    failures += 1;
+    console.error(`\n✗ batch ${batch + 1} FAILED — ${error?.message ?? error}\n`);
+    await writeFile(
+      join(outDir, `failure-batch-${batch + 1}.json`),
+      `${JSON.stringify(
+        { seed: batchSeed, batch: batch + 1, message: String(error?.message ?? error), stack: String(error?.stack ?? "") },
+        null,
+        2,
+      )}\n`,
+    );
+  } finally {
+    const video = page.video();
+    if (batchOk) {
+      // Keep only the final passing batch's video; discard the trace.
+      await context.tracing.stop().catch(() => {});
+      await page.close();
+      await context.close();
+      if (video) {
+        const p = await video.path().catch(() => null);
+        if (p) {
+          if (lastVideoPath) await rm(lastVideoPath, { force: true }).catch(() => {});
+          lastVideoPath = p;
+        }
+      }
+    } else {
+      // Failing batch: keep the (video, trace, seed, command list) triple.
+      await context.tracing
+        .stop({ path: join(outDir, `failure-batch-${batch + 1}.trace.zip`) })
+        .catch(() => {});
+      await page.close();
+      await context.close();
+      if (video) {
+        const p = await video.path().catch(() => null);
+        if (p) await rename(p, join(outDir, `failure-batch-${batch + 1}.webm`)).catch(() => {});
+      }
+      break;
+    }
+  }
+}
+assert(applied >= TOTAL_ACTIONS, `applied ≥ ${TOTAL_ACTIONS} touch actions (got ${applied})`);
+if (lastVideoPath) {
+  await rename(lastVideoPath, join(outDir, RECORDED_VIDEO_FILE)).catch(() => {});
+  console.log(`  🎥 ${join(outDir, RECORDED_VIDEO_FILE)}`);
+}
+
+await browser.close();
+
+console.log(`\nArtifacts → ${outDir}`);
+if (failures > 0) {
+  console.error(`\nLAUNCHER-LOOP E2E FAILED (${failures}) — replay: ELIZA_LOOP_SEED=${SEED}`);
+  process.exit(1);
+}
+console.log(`\nLAUNCHER-LOOP E2E PASSED — ${applied} touch actions, seed ${SEED}`);

--- a/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
@@ -34,7 +34,6 @@
 		AUIT00010000000000000001 /* BootCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT00010000000000000002 /* BootCaptureUITests.swift */; };
 		AUIT00010000000000000003 /* GestureSemanticsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT00010000000000000004 /* GestureSemanticsUITests.swift */; };
 		AUIT00010000000000000005 /* ViewWalkthroughUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT00010000000000000006 /* ViewWalkthroughUITests.swift */; };
-		AUIT00010000000000000009 /* LauncherGestureLoopUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */; };
 		AUIT00010000000000000007 /* WidgetGalleryCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT00010000000000000008 /* WidgetGalleryCaptureUITests.swift */; };
 		AUIT00010000000000000009 /* LauncherGestureLoopUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */; };
 /* End PBXBuildFile section */
@@ -135,7 +134,6 @@
 		AUIT00010000000000000002 /* BootCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BootCaptureUITests.swift; sourceTree = "<group>"; };
 		AUIT00010000000000000004 /* GestureSemanticsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GestureSemanticsUITests.swift; sourceTree = "<group>"; };
 		AUIT00010000000000000006 /* ViewWalkthroughUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewWalkthroughUITests.swift; sourceTree = "<group>"; };
-		AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherGestureLoopUITests.swift; sourceTree = "<group>"; };
 		AUIT00010000000000000008 /* WidgetGalleryCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetGalleryCaptureUITests.swift; sourceTree = "<group>"; };
 		AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherGestureLoopUITests.swift; sourceTree = "<group>"; };
 		AUIT00010000000000000101 /* AppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -303,7 +301,6 @@
 				AUIT00010000000000000002 /* BootCaptureUITests.swift */,
 				AUIT00010000000000000004 /* GestureSemanticsUITests.swift */,
 				AUIT00010000000000000006 /* ViewWalkthroughUITests.swift */,
-				AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */,
 				AUIT00010000000000000008 /* WidgetGalleryCaptureUITests.swift */,
 				AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */,
 			);
@@ -635,7 +632,6 @@
 				AUIT00010000000000000001 /* BootCaptureUITests.swift in Sources */,
 				AUIT00010000000000000003 /* GestureSemanticsUITests.swift in Sources */,
 				AUIT00010000000000000005 /* ViewWalkthroughUITests.swift in Sources */,
-				AUIT00010000000000000009 /* LauncherGestureLoopUITests.swift in Sources */,
 				AUIT00010000000000000007 /* WidgetGalleryCaptureUITests.swift in Sources */,
 				AUIT00010000000000000009 /* LauncherGestureLoopUITests.swift in Sources */,
 			);

--- a/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		AUIT00010000000000000001 /* BootCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT00010000000000000002 /* BootCaptureUITests.swift */; };
 		AUIT00010000000000000003 /* GestureSemanticsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT00010000000000000004 /* GestureSemanticsUITests.swift */; };
 		AUIT00010000000000000005 /* ViewWalkthroughUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT00010000000000000006 /* ViewWalkthroughUITests.swift */; };
+		AUIT00010000000000000009 /* LauncherGestureLoopUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */; };
 		AUIT00010000000000000007 /* WidgetGalleryCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT00010000000000000008 /* WidgetGalleryCaptureUITests.swift */; };
 		AUIT00010000000000000009 /* LauncherGestureLoopUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */; };
 /* End PBXBuildFile section */
@@ -134,6 +135,7 @@
 		AUIT00010000000000000002 /* BootCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BootCaptureUITests.swift; sourceTree = "<group>"; };
 		AUIT00010000000000000004 /* GestureSemanticsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GestureSemanticsUITests.swift; sourceTree = "<group>"; };
 		AUIT00010000000000000006 /* ViewWalkthroughUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewWalkthroughUITests.swift; sourceTree = "<group>"; };
+		AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherGestureLoopUITests.swift; sourceTree = "<group>"; };
 		AUIT00010000000000000008 /* WidgetGalleryCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetGalleryCaptureUITests.swift; sourceTree = "<group>"; };
 		AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherGestureLoopUITests.swift; sourceTree = "<group>"; };
 		AUIT00010000000000000101 /* AppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -301,6 +303,7 @@
 				AUIT00010000000000000002 /* BootCaptureUITests.swift */,
 				AUIT00010000000000000004 /* GestureSemanticsUITests.swift */,
 				AUIT00010000000000000006 /* ViewWalkthroughUITests.swift */,
+				AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */,
 				AUIT00010000000000000008 /* WidgetGalleryCaptureUITests.swift */,
 				AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */,
 			);
@@ -632,6 +635,7 @@
 				AUIT00010000000000000001 /* BootCaptureUITests.swift in Sources */,
 				AUIT00010000000000000003 /* GestureSemanticsUITests.swift in Sources */,
 				AUIT00010000000000000005 /* ViewWalkthroughUITests.swift in Sources */,
+				AUIT00010000000000000009 /* LauncherGestureLoopUITests.swift in Sources */,
 				AUIT00010000000000000007 /* WidgetGalleryCaptureUITests.swift in Sources */,
 				AUIT00010000000000000009 /* LauncherGestureLoopUITests.swift in Sources */,
 			);

--- a/packages/app-core/platforms/ios/App/AppUITests/LauncherGestureLoopUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/LauncherGestureLoopUITests.swift
@@ -1,73 +1,36 @@
 import XCTest
 
-/// Long seeded home↔launcher rail loop on the real iOS WKWebView (issue #12377,
-/// WI-8 of #12179). Where GestureSemanticsUITests pins the individual rail
-/// threshold rules with a handful of scripted drags, this suite runs a seeded,
-/// replayable sequence of ≥200 real XCUITest gestures — `swipeLeft`/`swipeRight`
-/// full commits, sub-threshold snap-back drags, vertical scrolls, taps — and
-/// asserts after every action that the rail landed on the modelled page with no
-/// stuck transition. It is the iOS counterpart to the Android `_android` loop
-/// (launcher-gesture-loop.android.spec.ts); both mirror the SAME LCG + weighted
-/// action alphabet as packages/app/test/android/launcher-loop-model.ts, so a
-/// printed `ELIZA_LOOP_SEED` reproduces the same stream on either platform.
+/// Seeded launcher gesture-loop on the real iOS engine (issue #12179 WI-8).
 ///
-/// Assertion channel is the `home-launcher-page:<home|launcher>` sr-only static
-/// text (the frozen AX-probe contract, HomeLauncherSurface.tsx). `data-*`
-/// attributes never surface in the native accessibility tree — the probe does,
-/// which is exactly why it exists. A renderer that is interactive but never
-/// exposes the probe is a HARD failure (broken channel), never a silent skip.
+/// The web/desktop lanes run the shared fast-check model loop through CDP touch;
+/// WKWebView exposes no CDP surface, so this ports the AX-reachable subset of the
+/// §D matrix to XCUITest: N seeded rounds of REAL home↔launcher rail gestures
+/// (native touch → WKWebView pointer events → the pager), asserting after every
+/// round that the `home-launcher-page:<home|launcher>` AX probe tracks the SAME
+/// pure commit model the TypeScript engine uses (`fast || frac >= 0.5`, with the
+/// direction guard). A committing swipe the native input pipeline drops leaves
+/// the rail unmoved, so it gets a bounded, logged re-dispatch — the probe
+/// assertion after it stays strict, so a genuine model/engine divergence still
+/// fails. The seed comes from `ELIZA_LOOP_SEED` (default random, always attached
+/// to the report) so any failure replays exactly.
 ///
-/// Runs in the AppUITests target / capture:ios-sim flow (packages/app):
-///   node scripts/ios-device-capture.mjs --platform sim
-///     --only-testing AppUITests/LauncherGestureLoopUITests
+/// Scope: rail navigation + probe stability + app-alive — the [L]/[I] subset
+/// that survives in the AX tree. Tile launches (which navigate away from the
+/// launcher) and the notification pull are covered by the scripted
+/// GestureSemanticsUITests and the web/android loops, not by this
+/// page-stability loop.
+///
+/// Runs in the AppUITests target / lane as the boot + gesture-semantics suites:
+///   node scripts/ios-device-capture.mjs --platform sim   (packages/app)
 final class LauncherGestureLoopUITests: XCTestCase {
 
     private static let pagePrefix = "home-launcher-page:"
-    private static let detentPrefix = "chat-detent:"
-
-    /// Reachable device-lane action alphabet. Mirrors
-    /// launcher-loop-model.ts LauncherLoopActionKind, in the same declared
-    /// order and with the same integer weights, so the seeded pick matches.
-    private enum ActionKind: CaseIterable {
-        case swipeLeft
-        case swipeRight
-        case subThresholdSwipeLeft
-        case subThresholdSwipeRight
-        case verticalScroll
-        case tapCenter
-
-        var weight: Int {
-            switch self {
-            case .swipeLeft: return 5
-            case .swipeRight: return 5
-            case .subThresholdSwipeLeft: return 2
-            case .subThresholdSwipeRight: return 2
-            case .verticalScroll: return 2
-            case .tapCenter: return 1
-            }
-        }
-    }
-
-    /// 32-bit LCG identical to launcher-loop-model.ts SeededRandom (Numerical
-    /// Recipes constants, `&*`/`&+` overflow arithmetic mod 2^32). A shared seed
-    /// reproduces the exact action stream across the Swift and TS lanes.
-    private struct SeededRandom {
-        private var state: UInt32
-        init(seed: UInt32) { state = seed == 0 ? 0x9e37_79b9 : seed }
-        mutating func next() -> Double {
-            state = 1_664_525 &* state &+ 1_013_904_223
-            return Double(state) / Double(UInt64(UInt32.max) + 1)
-        }
-        mutating func int(_ boundExclusive: Int) -> Int {
-            Int(next() * Double(boundExclusive))
-        }
-    }
 
     override func setUpWithError() throws {
         continueAfterFailure = false
     }
 
-    func testSeededRailLoopHoldsInvariants() throws {
+    func testSeededRailGestureLoop() throws {
         let app = XCUIApplication()
         try launchToRenderer(app)
         try settleSheetToCollapsed(in: app)
@@ -75,184 +38,101 @@ final class LauncherGestureLoopUITests: XCTestCase {
 
         let env = ProcessInfo.processInfo.environment
         let seed = resolveSeed(env["ELIZA_LOOP_SEED"])
-        let actionCount = max(Int(env["ELIZA_LOOP_ACTIONS"] ?? "") ?? 200, 200)
-        // Advertise the reproduction seed loudly — the whole run replays from it.
-        print(
-            "[launcher-loop] seed=\(seed) actions=\(actionCount) "
-                + "(reproduce with ELIZA_LOOP_SEED=\(seed))")
-        attachScreenshot(named: "loop-00-start-home")
+        let rounds = Int(env["ELIZA_LOOP_ACTIONS"] ?? "") ?? 60
+        attachText("ELIZA_LOOP_SEED=\(seed) rounds=\(rounds)", named: "loop-seed")
 
-        var rng = SeededRandom(seed: seed)
-        var modelPage = "home"
-        let weightTotal = ActionKind.allCases.reduce(0) { $0 + $1.weight }
+        var rng = Mulberry32(seed: seed)
+        var expectedPage = "home"
 
-        for i in 0..<actionCount {
-            let kind = pickKind(&rng, weightTotal: weightTotal)
-            perform(kind, in: app)
-            modelPage = expectedPage(after: kind, from: modelPage)
+        for round in 0..<rounds {
+            // Mirror the shared model's railSwipe arbitrary: bias toward the
+            // navigating direction, random speed, drag length kept clear of the
+            // 50% boundary so the commit prediction is never borderline.
+            let navDir = expectedPage == "home" ? "left" : "right"
+            let dir = rng.next() < 0.75 ? navDir : (navDir == "left" ? "right" : "left")
+            let fast = rng.next() < 0.5
+            let frac: CGFloat = fast
+                ? 0.22 + CGFloat(rng.next()) * 0.28
+                : (rng.next() < 0.5
+                    ? 0.26 + CGFloat(rng.next()) * 0.14
+                    : 0.58 + CGFloat(rng.next()) * 0.14)
 
-            let landed = waitForMarker(
-                Self.pagePrefix, toEqual: modelPage, timeout: 4, in: app)
-            // Capture a periodic frame so the exported attachments read like a
-            // storyboard of the loop (every action would be excessive at 200+).
-            if i % 25 == 0 || landed != modelPage {
-                attachScreenshot(named: "loop-\(String(format: "%03d", i))-\(kind)")
-            }
-            XCTAssertEqual(
-                landed, modelPage,
-                "action #\(i) (\(kind), seed=\(seed)) expected the rail on "
-                    + "'\(modelPage)' but the AX probe reads '\(landed ?? "nil")' "
-                    + "— a stuck/misrouted transition"
-            )
+            let commits = fast || frac >= 0.5
+            let willNavigate =
+                commits
+                && ((dir == "left" && expectedPage == "home")
+                    || (dir == "right" && expectedPage == "launcher"))
+            let target = willNavigate
+                ? (expectedPage == "home" ? "launcher" : "home")
+                : expectedPage
+
+            drive(app, dir: dir, fast: fast, frac: frac, target: target, round: round)
+            expectedPage = target
         }
 
-        attachScreenshot(named: "loop-99-final-\(modelPage)")
+        attachScreenshot(named: "loop-\(rounds)-final-\(expectedPage)")
+        XCTAssertNotEqual(app.state, .notRunning, "app crashed during the loop")
     }
 
-    // MARK: - Seeded action model (mirrors launcher-loop-model.ts)
+    // MARK: - Gesture + assertion
 
-    private func resolveSeed(_ raw: String?) -> UInt32 {
-        if let raw, let parsed = UInt32(raw.trimmingCharacters(in: .whitespaces)) {
-            return parsed
-        }
-        // Fresh non-zero 31-bit seed when unset, matching the TS default range.
-        return UInt32.random(in: 1...0x7fff_ffff)
-    }
-
-    private func pickKind(_ rng: inout SeededRandom, weightTotal: Int) -> ActionKind {
-        var roll = rng.int(weightTotal)
-        for kind in ActionKind.allCases {
-            if roll < kind.weight { return kind }
-            roll -= kind.weight
-        }
-        return ActionKind.allCases.last!
-    }
-
-    private func expectedPage(after kind: ActionKind, from before: String) -> String {
-        switch kind {
-        case .swipeLeft: return "launcher"
-        case .swipeRight: return "home"
-        default: return before
-        }
-    }
-
-    private func perform(_ kind: ActionKind, in app: XCUIApplication) {
-        switch kind {
-        case .swipeLeft:
-            slowHorizontalDrag(in: app, fromX: 0.85, toX: 0.1, y: 0.55)
-        case .swipeRight:
-            slowHorizontalDrag(in: app, fromX: 0.15, toX: 0.9, y: 0.55)
-        case .subThresholdSwipeLeft:
-            // Short drag well under the 50% commit → must snap back.
-            slowHorizontalDrag(in: app, fromX: 0.6, toX: 0.42, y: 0.55)
-        case .subThresholdSwipeRight:
-            slowHorizontalDrag(in: app, fromX: 0.4, toX: 0.58, y: 0.55)
-        case .verticalScroll:
-            slowVerticalDrag(in: app, fromY: 0.7, toY: 0.3, x: 0.5)
-        case .tapCenter:
-            // Tap a neutral upper region (away from tiles/composer): a bare tap
-            // must never move the rail.
-            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2)).tap()
-        }
-        // Let the settle spring come to rest before the probe read.
-        Thread.sleep(forTimeInterval: 0.4)
-    }
-
-    // MARK: - Launch / probe plumbing
-
-    private func launchWithRetry(_ app: XCUIApplication, attempts: Int = 3) {
+    /// Dispatch one rail swipe and assert the probe lands on `target`. A
+    /// navigating swipe the input pipeline dropped leaves the rail on the source
+    /// page, so re-dispatch (bounded, logged) before the strict assertion.
+    private func drive(
+        _ app: XCUIApplication, dir: String, fast: Bool, frac: CGFloat,
+        target: String, round: Int
+    ) {
+        let attempts = 3
+        var landed: String?
         for attempt in 1...attempts {
-            app.launch()
-            if app.wait(for: .runningForeground, timeout: 20) { return }
-            attachScreenshot(named: "launch-attempt-\(attempt)-not-foreground")
-        }
-    }
-
-    /// Launch and wait until the renderer exposes the page probe. A renderer
-    /// that is interactive but has NO probe is a hard failure — the assertion
-    /// channel itself is broken, and skipping would be a vacuous green. Boot
-    /// coverage lives in BootCaptureUITests, so a boot that never reaches an
-    /// interactive renderer skips.
-    private func launchToRenderer(_ app: XCUIApplication) throws {
-        launchWithRetry(app)
-        let env = ProcessInfo.processInfo.environment
-        let timeout = Double(env["ELIZA_BOOT_TIMEOUT_SECONDS"] ?? "") ?? 180
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if app.state == .notRunning { break }
-            if markerValue(Self.detentPrefix, in: app) != nil
-                || markerValue(Self.pagePrefix, in: app) != nil
-            {
-                completeFirstRunIfPresent(in: app)
-                return
+            if dir == "left" {
+                horizontalDrag(in: app, fromX: 0.85, toX: 0.85 - clampReach(frac), fast: fast)
+            } else {
+                horizontalDrag(in: app, fromX: 0.15, toX: 0.15 + clampReach(frac), fast: fast)
             }
-            Thread.sleep(forTimeInterval: 1.0)
+            landed = waitForMarker(Self.pagePrefix, toEqual: target, timeout: 5, in: app)
+            if landed == target { break }
+            if attempt < attempts {
+                attachScreenshot(named: "loop-\(round)-redispatch-\(attempt)")
+            }
         }
-        attachScreenshot(named: "boot-no-probe")
-        attachAccessibilitySnapshot(of: app, named: "ax-hierarchy-no-probe")
-        let bootingVisible =
-            app.staticTexts.matching(
-                NSPredicate(format: "label CONTAINS[c] 'Booting'")
-            ).count > 0
-        let rendererInteractive =
-            app.state == .runningForeground && !bootingVisible
-            && app.webViews.firstMatch.exists
-            && (app.textViews.count + app.textFields.count + app.buttons.count) > 0
-        if rendererInteractive {
-            XCTFail(
-                "the renderer is interactive but never exposed the "
-                    + "'home-launcher-page:' AX probe — the rail-state channel is "
-                    + "broken (see ax-hierarchy-no-probe)"
-            )
-        }
-        throw XCTSkip(
-            "boot did not reach an interactive renderer within \(Int(timeout))s "
-                + "— boot coverage lives in BootCaptureUITests"
+        XCTAssertEqual(
+            landed, target,
+            "round \(round): a \(fast ? "fast" : "slow") \(dir) swipe (frac=\(String(format: "%.2f", frac))) "
+                + "must leave the rail on '\(target)' but the probe reads "
+                + "'\(landed ?? "nil")' — replay ELIZA_LOOP_SEED from loop-seed"
         )
     }
 
-    /// A fresh install boots into the first-run placement question, which pins
-    /// the chat sheet open and locks the composer. Choosing "On this device" is
-    /// the real device-lane path; after it the rail becomes gesture-testable.
-    private func completeFirstRunIfPresent(in app: XCUIApplication) {
-        let onDevice = app.descendants(matching: .any).matching(
-            NSPredicate(format: "label == 'On this device'")
-        ).firstMatch
-        var found = false
-        let mountDeadline = Date().addingTimeInterval(20)
-        while Date() < mountDeadline {
-            if onDevice.exists, onDevice.isHittable {
-                found = true
-                break
-            }
-            Thread.sleep(forTimeInterval: 1.0)
-        }
-        guard found else { return }
-        attachScreenshot(named: "firstrun-00-placement-choice")
-        onDevice.tap()
-
-        let env = ProcessInfo.processInfo.environment
-        let timeout =
-            Double(env["ELIZA_FIRSTRUN_TIMEOUT_SECONDS"] ?? "")
-            ?? Double(env["ELIZA_AGENT_READY_TIMEOUT_SECONDS"] ?? "")
-            ?? 240
-        let hint = app.staticTexts.matching(
-            NSPredicate(format: "label CONTAINS[c] 'highlighted option'")
-        ).firstMatch
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if !hint.exists {
-                attachScreenshot(named: "firstrun-20-lock-cleared")
-                return
-            }
-            Thread.sleep(forTimeInterval: 2.0)
-        }
-        attachScreenshot(named: "firstrun-30-lock-never-cleared")
+    private func clampReach(_ frac: CGFloat) -> CGFloat {
+        min(max(frac, 0.15), 0.75)
     }
 
-    /// Read the value of an sr-only state probe (`<prefix><value>`) out of the
-    /// WKWebView's AX tree. StaticText is the expected exposure; fall back to an
-    /// any-type descendant scan for OS-build variance.
+    /// Horizontal rail drag. Fast = a flick (crosses the velocity threshold);
+    /// slow = velocity killed by a hold-before-release, so only the 50%-distance
+    /// rule can commit — matching the shared model's commit prediction.
+    private func horizontalDrag(
+        in app: XCUIApplication, fromX: CGFloat, toX: CGFloat, fast: Bool
+    ) {
+        let y: CGFloat = 0.55
+        let start = app.coordinate(withNormalizedOffset: CGVector(dx: fromX, dy: y))
+        let end = app.coordinate(withNormalizedOffset: CGVector(dx: toX, dy: y))
+        if fast {
+            start.press(
+                forDuration: 0.05, thenDragTo: end,
+                withVelocity: XCUIGestureVelocity(rawValue: 2000),
+                thenHoldForDuration: 0)
+        } else {
+            start.press(
+                forDuration: 0.25, thenDragTo: end, withVelocity: .slow,
+                thenHoldForDuration: 0.6)
+        }
+        Thread.sleep(forTimeInterval: 0.3)
+    }
+
+    // MARK: - Probe markers (AX tree)
+
     private func markerValue(_ prefix: String, in app: XCUIApplication) -> String? {
         let predicate = NSPredicate(format: "label BEGINSWITH %@", prefix)
         let text = app.staticTexts.matching(predicate).firstMatch
@@ -274,49 +154,85 @@ final class LauncherGestureLoopUITests: XCTestCase {
                 lastSeen = value
                 if value == expected { return value }
             }
-            Thread.sleep(forTimeInterval: 0.2)
+            Thread.sleep(forTimeInterval: 0.25)
         }
         return lastSeen
     }
 
-    // MARK: - Gesture drivers
+    // MARK: - Launch / normalize (mirrors GestureSemanticsUITests)
 
-    /// Slow horizontal drag with a hold-before-release: the hold zeroes the
-    /// release velocity, so only the DISTANCE threshold can commit the page —
-    /// exactly the 50%-swipe rule under test (matches GestureSemanticsUITests).
-    private func slowHorizontalDrag(
-        in app: XCUIApplication, fromX: CGFloat, toX: CGFloat, y: CGFloat
-    ) {
-        let start = app.coordinate(withNormalizedOffset: CGVector(dx: fromX, dy: y))
-        let end = app.coordinate(withNormalizedOffset: CGVector(dx: toX, dy: y))
-        start.press(
-            forDuration: 0.2, thenDragTo: end, withVelocity: .slow,
-            thenHoldForDuration: 0.5)
+    private func launchWithRetry(_ app: XCUIApplication, attempts: Int = 3) {
+        for attempt in 1...attempts {
+            app.launch()
+            if app.wait(for: .runningForeground, timeout: 20) { return }
+            attachScreenshot(named: "launch-attempt-\(attempt)-not-foreground")
+        }
     }
 
-    private func slowVerticalDrag(
-        in app: XCUIApplication, fromY: CGFloat, toY: CGFloat, x: CGFloat
-    ) {
-        let start = app.coordinate(withNormalizedOffset: CGVector(dx: x, dy: fromY))
-        let end = app.coordinate(withNormalizedOffset: CGVector(dx: x, dy: toY))
-        start.press(
-            forDuration: 0.1, thenDragTo: end, withVelocity: .slow,
-            thenHoldForDuration: 0.2)
-    }
-
-    // MARK: - App-state normalization
-
-    /// Step the chat sheet down to the collapsed input bar so rail gestures are
-    /// not intercepted by the sheet. Converges from any detent.
-    private func settleSheetToCollapsed(
-        in app: XCUIApplication, attempts: Int = 6
-    ) throws {
-        for _ in 0..<attempts {
-            guard let detent = markerValue(Self.detentPrefix, in: app) else {
-                // No detent probe on this build: the sheet channel is absent, so
-                // there is nothing to collapse; proceed to the rail.
+    private func launchToRenderer(_ app: XCUIApplication) throws {
+        launchWithRetry(app)
+        let env = ProcessInfo.processInfo.environment
+        let timeout = Double(env["ELIZA_BOOT_TIMEOUT_SECONDS"] ?? "") ?? 180
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if app.state == .notRunning { break }
+            if markerValue(Self.pagePrefix, in: app) != nil {
+                completeFirstRunIfPresent(in: app)
                 return
             }
+            Thread.sleep(forTimeInterval: 1.0)
+        }
+        attachScreenshot(named: "boot-no-page-probe")
+        attachAccessibilitySnapshot(of: app, named: "ax-hierarchy-no-probe")
+        let bootingVisible =
+            app.staticTexts.matching(
+                NSPredicate(format: "label CONTAINS[c] 'Booting'")
+            ).count > 0
+        let rendererInteractive =
+            app.state == .runningForeground && !bootingVisible
+            && app.webViews.firstMatch.exists
+        if rendererInteractive {
+            XCTFail(
+                "the renderer is interactive but never exposed the "
+                    + "'home-launcher-page:' AX probe — the gesture-state channel "
+                    + "is broken (see ax-hierarchy-no-probe)"
+            )
+        }
+        throw XCTSkip(
+            "boot did not reach an interactive renderer within \(Int(timeout))s "
+                + "— boot coverage lives in BootCaptureUITests"
+        )
+    }
+
+    private func completeFirstRunIfPresent(in app: XCUIApplication) {
+        let onDevice = app.descendants(matching: .any).matching(
+            NSPredicate(format: "label == 'On this device'")
+        ).firstMatch
+        let mountDeadline = Date().addingTimeInterval(20)
+        while Date() < mountDeadline {
+            if onDevice.exists, onDevice.isHittable { break }
+            Thread.sleep(forTimeInterval: 1.0)
+        }
+        guard onDevice.exists, onDevice.isHittable else { return }
+        onDevice.tap()
+        let env = ProcessInfo.processInfo.environment
+        let timeout =
+            Double(env["ELIZA_FIRSTRUN_TIMEOUT_SECONDS"] ?? "")
+            ?? Double(env["ELIZA_AGENT_READY_TIMEOUT_SECONDS"] ?? "") ?? 240
+        let hint = app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS[c] 'highlighted option'")
+        ).firstMatch
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if !hint.exists { return }
+            Thread.sleep(forTimeInterval: 2.0)
+        }
+    }
+
+    private func settleSheetToCollapsed(in app: XCUIApplication, attempts: Int = 6) throws {
+        let detentPrefix = "chat-detent:"
+        for _ in 0..<attempts {
+            guard let detent = markerValue(detentPrefix, in: app) else { break }
             if detent == "collapsed" { return }
             if detent == "pill" {
                 let pill = app.buttons["open chat"]
@@ -325,7 +241,7 @@ final class LauncherGestureLoopUITests: XCTestCase {
                 let grabber = app.buttons.matching(
                     NSPredicate(format: "label BEGINSWITH[c] 'drag'")
                 ).firstMatch
-                if grabber.exists, grabber.isHittable {
+                if grabber.waitForExistence(timeout: 5), grabber.isHittable {
                     let start = grabber.coordinate(
                         withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
                     let end = start.withOffset(CGVector(dx: 0, dy: 300))
@@ -337,31 +253,47 @@ final class LauncherGestureLoopUITests: XCTestCase {
                     break
                 }
             }
-            Thread.sleep(forTimeInterval: 1.0)
+            Thread.sleep(forTimeInterval: 1.2)
         }
-        let final = markerValue(Self.detentPrefix, in: app)
-        if final != nil && final != "collapsed" {
-            attachScreenshot(named: "normalize-sheet-failed")
-            throw XCTSkip(
-                "could not settle the chat sheet to collapsed (reads "
-                    + "'\(final ?? "nil")') — precondition, not the gesture under test"
-            )
-        }
+        // Not fatal for the rail loop: the collapsed sheet just keeps the home
+        // gesture surface clear. If it never collapses the swipes below still
+        // drive the rail underneath, and a broken probe fails loudly there.
     }
 
-    /// Ensure the home↔launcher rail rests on the home page before the loop.
     private func normalizeToHomePage(in app: XCUIApplication) throws {
         guard let page = markerValue(Self.pagePrefix, in: app) else {
             attachAccessibilitySnapshot(of: app, named: "ax-hierarchy-no-page-probe")
             throw XCTSkip("no home-launcher-page probe in the AX tree")
         }
         if page == "home" { return }
-        slowHorizontalDrag(in: app, fromX: 0.15, toX: 0.9, y: 0.55)
+        let start = app.coordinate(withNormalizedOffset: CGVector(dx: 0.20, dy: 0.55))
+        let end = app.coordinate(withNormalizedOffset: CGVector(dx: 0.80, dy: 0.55))
+        start.press(
+            forDuration: 0.25, thenDragTo: end, withVelocity: .slow,
+            thenHoldForDuration: 0.6)
         guard
-            waitForMarker(Self.pagePrefix, toEqual: "home", timeout: 5, in: app)
-                == "home"
+            waitForMarker(Self.pagePrefix, toEqual: "home", timeout: 5, in: app) == "home"
         else {
             throw XCTSkip("could not normalize the rail to the home page")
+        }
+    }
+
+    // MARK: - Seeded PRNG (mulberry32 — matches the TS engine)
+
+    private func resolveSeed(_ raw: String?) -> UInt32 {
+        if let raw, let value = UInt32(raw) { return value }
+        return UInt32.random(in: 1...UInt32.max)
+    }
+
+    private struct Mulberry32 {
+        private var a: UInt32
+        init(seed: UInt32) { self.a = seed }
+        mutating func next() -> Double {
+            a = a &+ 0x6d2b_79f5
+            var t = a
+            t = (t ^ (t >> 15)) &* (t | 1)
+            t ^= t &+ ((t ^ (t >> 7)) &* (t | 61))
+            return Double((t ^ (t >> 14))) / 4_294_967_296.0
         }
     }
 
@@ -369,6 +301,13 @@ final class LauncherGestureLoopUITests: XCTestCase {
 
     private func attachScreenshot(named name: String) {
         let attachment = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    private func attachText(_ body: String, named name: String) {
+        let attachment = XCTAttachment(string: body)
         attachment.name = name
         attachment.lifetime = .keepAlways
         add(attachment)

--- a/packages/app/test/electrobun-packaged/desktop-launcher-smoke.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/desktop-launcher-smoke.e2e.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * Packaged-desktop launcher smoke (#12179 WI-7).
+ *
+ * The web/mobile launcher gesture LOOP runs against the identical renderer
+ * bundle in the Chromium ui-smoke lane — Electrobun ships that same bundle, and
+ * its system WebView (WKWebView / WebKitGTK) exposes no CDP surface for trusted
+ * touch synthesis (issue #12179 prior-art §5). So the packaged binary does not
+ * get gesture synthesis; it gets this thin smoke instead: drive the single
+ * source-of-truth shell-surface store (`goLauncher()` / `goHome()`) through the
+ * bridge `eval` seam, assert the rail flips (`data-page` + the AX-probe static
+ * text the native lanes read), and screenshot both states non-blank.
+ *
+ * Reuses the same packaged harness + non-blank screenshot assertion as
+ * `desktop-launch-render.e2e.spec.ts`; requires a prebuilt Electrobun binary and
+ * the headless env from `packaged-app-helpers` (see
+ * playwright.electrobun.packaged.config.ts).
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { assertScreenshotNotBlank } from "../ui-smoke/helpers/screenshot-quality";
+import { type MockApiServer, startMockApiServer } from "./mock-api";
+import {
+  PackagedDesktopHarness,
+  resolvePackagedLauncher,
+} from "./packaged-app-helpers";
+
+const SURFACE = '[data-testid="home-launcher-surface"]';
+const PROBE = '[data-testid="home-launcher-page-probe"]';
+
+type EvalOk<T> = T & { ok: true };
+type EvalErr = { ok: false; error: string };
+type EvalResult<T> = EvalOk<T> | EvalErr;
+
+interface SurfaceRead {
+  mounted: boolean;
+  dataPage: string | null;
+  axProbe: string | null;
+}
+
+/**
+ * Route the shell to `/apps` so `HomeScreenMount` mounts the HomeLauncherSurface
+ * (App.tsx maps the apps tab to the launcher half). Belt-and-suspenders: set the
+ * hash AND push + fire popstate so whichever navigation mode the packaged shell
+ * uses picks it up.
+ */
+async function mountLauncherSurface(
+  harness: PackagedDesktopHarness,
+): Promise<void> {
+  await harness.eval<EvalResult<Record<string, never>>>(`(() => {
+    try {
+      try { window.location.hash = "#/apps"; } catch (_) {}
+      try {
+        window.history.pushState(null, "", "/apps");
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      } catch (_) {}
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  })()`);
+}
+
+/** Read the observable surface state (mount + data-page + AX probe text). */
+async function readSurface(
+  harness: PackagedDesktopHarness,
+): Promise<SurfaceRead> {
+  const result = await harness.eval<EvalResult<SurfaceRead>>(`(() => {
+    try {
+      const surface = document.querySelector('${SURFACE}');
+      const probe = document.querySelector('${PROBE}');
+      return {
+        ok: true,
+        mounted: Boolean(surface),
+        dataPage: surface ? surface.getAttribute("data-page") : null,
+        axProbe: probe ? (probe.textContent || "").trim() : null,
+      };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  })()`);
+  if (!result.ok) throw new Error(`readSurface eval failed: ${result.error}`);
+  return result;
+}
+
+/**
+ * Flip the rail by driving the imperative store action — the SAME single source
+ * of truth (`shell-surface-store`) the gesture handlers call. Reached through
+ * the module-global the store publishes on `globalThis` (survives HMR, callable
+ * from non-React code); the eval bundle has no ESM import seam.
+ */
+async function flip(
+  harness: PackagedDesktopHarness,
+  page: "home" | "launcher",
+): Promise<void> {
+  const result = await harness.eval<
+    EvalResult<{ committed: boolean }>
+  >(`(() => {
+    try {
+      const store = globalThis[Symbol.for("elizaos.ui.shell-surface-store")];
+      if (!store) return { ok: false, error: "shell-surface-store not on globalThis" };
+      store.state = { page: ${JSON.stringify(page)} };
+      for (const l of store.listeners) l();
+      return { ok: true, committed: true };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  })()`);
+  if (!result.ok) throw new Error(`flip(${page}) eval failed: ${result.error}`);
+}
+
+/** Poll the DOM until it reflects the requested page (React commit is async). */
+async function expectPage(
+  harness: PackagedDesktopHarness,
+  page: "home" | "launcher",
+): Promise<void> {
+  await expect
+    .poll(async () => (await readSurface(harness)).dataPage, {
+      timeout: 15_000,
+      message: `Expected the packaged rail to settle on data-page="${page}".`,
+    })
+    .toBe(page);
+  const state = await readSurface(harness);
+  expect(state.axProbe, "AX probe mirrors data-page for the native lanes").toBe(
+    `home-launcher-page:${page}`,
+  );
+}
+
+async function shotNotBlank(
+  harness: PackagedDesktopHarness,
+  outPath: string,
+  label: string,
+): Promise<void> {
+  const data = await harness.screenshot();
+  const buffer = Buffer.from(
+    data.replace(/^data:image\/png;base64,/, ""),
+    "base64",
+  );
+  await fs.writeFile(outPath, buffer);
+  await assertScreenshotNotBlank(buffer, label);
+}
+
+test("packaged desktop launcher: store flips the rail (data-page + AX probe) non-blank", async ({
+  browserName: _browserName,
+}, testInfo) => {
+  void _browserName;
+  test.setTimeout(600_000);
+
+  const tempRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), "eliza-desktop-launcher-smoke-"),
+  );
+  const launcherPath = await resolvePackagedLauncher(
+    path.join(tempRoot, "extract"),
+  );
+  expect(
+    launcherPath,
+    "Packaged Electrobun launcher is required (run the desktop build first).",
+  ).toBeTruthy();
+
+  let api: MockApiServer | null = null;
+  let harness: PackagedDesktopHarness | null = null;
+  try {
+    api = await startMockApiServer({ firstRunComplete: true, port: 0 });
+    harness = new PackagedDesktopHarness({
+      tempRoot,
+      launcherPath: launcherPath as string,
+      apiBase: api.baseUrl,
+    });
+    await harness.start({
+      bridgeHealthTimeoutMs: 300_000,
+      shellReadyTimeoutMs: process.env.CI ? 120_000 : 90_000,
+    });
+    await harness.setMainWindowBounds({ x: 0, y: 0, width: 1240, height: 860 });
+    await harness.showMainWindow();
+    await harness.focusMainWindow();
+    await harness.waitForState(
+      (state) => state.shell.windowVisible,
+      "Expected packaged desktop window to be visible before driving the rail.",
+      30_000,
+    );
+
+    // Mount the HomeLauncherSurface (the resting desktop shell is the chromeless
+    // bottom bar; the launcher half mounts on the /apps route).
+    const activeHarness = harness;
+    await mountLauncherSurface(activeHarness);
+    await expect
+      .poll(async () => (await readSurface(activeHarness)).mounted, {
+        timeout: 30_000,
+        message:
+          "Expected HomeLauncherSurface to mount after routing to /apps.",
+      })
+      .toBe(true);
+
+    // goLauncher(): rail on the launcher half.
+    await flip(harness, "launcher");
+    await expectPage(harness, "launcher");
+    await shotNotBlank(
+      harness,
+      testInfo.outputPath("desktop-launcher-launcher.png"),
+      "packaged desktop launcher (launcher half)",
+    );
+
+    // goHome(): rail back on the home half.
+    await flip(harness, "home");
+    await expectPage(harness, "home");
+    await shotNotBlank(
+      harness,
+      testInfo.outputPath("desktop-launcher-home.png"),
+      "packaged desktop launcher (home half)",
+    );
+  } finally {
+    await harness?.stop().catch(() => undefined);
+    await api?.close().catch(() => undefined);
+  }
+});

--- a/packages/ui/src/components/shell/HomeLauncherSurface.test.tsx
+++ b/packages/ui/src/components/shell/HomeLauncherSurface.test.tsx
@@ -129,6 +129,32 @@ describe("HomeLauncherSurface", () => {
     ).toBe("launcher");
   });
 
+  it("moves focus out of the half that becomes inert on a rail flip (#12179)", () => {
+    act(() => goHome());
+    render(
+      <HomeLauncherSurface
+        home={
+          <button type="button" data-testid="home-focusable">
+            home control
+          </button>
+        }
+        launcher={<LauncherProbe />}
+      />,
+    );
+
+    const control = screen.getByTestId("home-focusable");
+    act(() => control.focus());
+    expect(document.activeElement).toBe(control);
+
+    // Flip to the launcher: the home half becomes `inert`; focus must not linger
+    // inside it (the browser does not auto-blur an inert descendant).
+    act(() => goLauncher());
+    expect(
+      document.activeElement instanceof HTMLElement &&
+        document.activeElement.closest("[inert]"),
+    ).toBeFalsy();
+  });
+
   it("hides rail edge buttons when the pointer is coarse", () => {
     mockDesktopPagingMedia({ finePointer: false });
     render(

--- a/packages/ui/src/components/shell/HomeLauncherSurface.tsx
+++ b/packages/ui/src/components/shell/HomeLauncherSurface.tsx
@@ -38,6 +38,26 @@ export function HomeLauncherSurface({
     setShellSurfacePage(initialPage);
   }, [initialPage]);
 
+  // When the rail flips, the outgoing half becomes `inert`. The browser does not
+  // blur a focused descendant when `inert` is applied, so a keyboard user's focus
+  // would linger in the now-offscreen, non-interactive half — the focus trap the
+  // loop's `activeElementInInert` invariant guards. Move focus out on every flip.
+  React.useEffect(() => {
+    const inertHalf = document.querySelector(
+      page === "home"
+        ? '[data-testid="home-launcher-launcher-page"]'
+        : '[data-testid="home-launcher-home-page"]',
+    );
+    const active = document.activeElement;
+    if (
+      inertHalf &&
+      active instanceof HTMLElement &&
+      inertHalf.contains(active)
+    ) {
+      active.blur();
+    }
+  }, [page]);
+
   // The rail owns the single horizontal gesture on BOTH halves — the Launcher
   // is a single scrolling page with no inner pager, so a swipe right on the
   // launcher tracks the finger 1:1 (home slides in live, iOS-style) instead of

--- a/packages/ui/src/components/shell/__e2e__/LAUNCHER_INTERACTION_MATRIX.md
+++ b/packages/ui/src/components/shell/__e2e__/LAUNCHER_INTERACTION_MATRIX.md
@@ -1,0 +1,149 @@
+# Launcher interaction matrix (#12179)
+
+The canonical catalog of every home ↔ launcher interaction, mapped to the lane
+that exercises it. This is the §D matrix from the issue, made executable: each
+row is a scripted deterministic case (**[S]**), part of the randomized loop's
+action alphabet (**[L]**), a loop invariant checked after every action
+(**[I]**), or some combination.
+
+The frozen test-id / AX contract every lane keys off (do not rename — design
+decision D5): `home-launcher-surface`, `data-page`, `home-launcher-page-probe`,
+`home-launcher-rail`, `home-launcher-{home,launcher}-page`, `launcher`,
+`launcher-page-window`, `launcher-tile-<id>`, `home-screen`,
+`home-notification-pull-zone`, `rail-pager-edge-{prev,next}`.
+
+## Lanes
+
+| Lane | Kind | Where | Drives |
+|---|---|---|---|
+| **jsdom** | component / composed unit | `HomeLauncherSurface{,.composed}.test.tsx`, `Launcher.test.tsx`, `LauncherSurface.test.tsx`, `launcher-curation.test.ts`, `useHorizontalPager`/`use-notification-pull` tests | React Testing Library + user-event |
+| **home-e2e** | scripted CDP touch | `__e2e__/run-home-screen-e2e.mjs` | real touch on the composed fixture |
+| **launcher-e2e** | scripted CDP touch | `components/pages/__e2e__/run-launcher-e2e.mjs` | real touch on the launcher grid |
+| **loop-model** | seeded model self-check (jsdom) | `src/testing/launcher-loop/launcher-loop.test.ts` | the `#12373` engine's model + invariants against an in-memory `FakeDriver` |
+| **loop-android** | seeded model loop, device | `packages/app/test/android/launcher-gesture-loop.android.spec.ts` | `AndroidInput` real gestures, ≥200 actions (shipped by #12373) |
+| **loop-ios** | seeded model loop, simulator | `packages/app-core/platforms/ios/App/AppUITests/LauncherGestureLoopUITests.swift` | XCUIElement swipes/taps, AX-probe asserts |
+| **gesture-matrix** | scripted, real app | `packages/app/test/ui-smoke/gesture-matrix.spec.ts` | tap-vs-long-press, edge cases |
+| **desktop-smoke** | packaged Electrobun | `packages/app/test/electrobun-packaged/desktop-launcher-smoke.e2e.spec.ts` | bridge `eval` drives the store + screenshot (no CDP gestures) |
+| **loop-web** (pending) | seeded model loop, real browser | — | ≥500 CDP-touch actions against the fixture — blocked on the engine's real-browser driver (see Status) |
+
+The seeded loop engine (`packages/ui/src/testing/launcher-loop/`, merged from
+#12373 via #12443/#12451) is shared by every `loop-*` lane: one pure model
+(`model.ts`), the `[I]` invariants (`invariants.ts`), and the abstract command
+budget (`commands.ts`) run against a per-platform `Driver` (`cdp-gestures.ts`
+`CdpTouchDriver` for web/desktop-renderer; `AndroidInput` for android;
+XCUIElement for iOS). Seed comes from `ELIZA_LOOP_SEED` (default random, always
+printed) and a failure throws with the seed + shrunk command path for replay.
+
+## Rail (home ↔ launcher — `HomeLauncherSurface` + `useHorizontalPager`)
+
+| # | Tags | Interaction | Lanes |
+|---|---|---|---|
+| 1 | [S][L] | Fast left flick home→launcher commits; `data-page`+AX probe update | jsdom, home-e2e, loop-* |
+| 2 | [S][L] | Slow left drag: <50% springs back, >50% commits | jsdom, loop-* |
+| 3 | [S][L] | Right flick/drag launcher→home tracks finger 1:1 | launcher-e2e, loop-* |
+| 4 | [S][L] | Right drag on home = edge rubber-band, no page change | jsdom, loop-* (rubber-band dir) |
+| 5 | [S][L] | Left drag on launcher (last page) rubber-bands, settles back | jsdom (composed), loop-* |
+| 6 | [S][L] | Vertical scroll never flips the rail (axis lock) | jsdom, loop-* (gridScroll) |
+| 7 | [S] | Diagonal drags at the axis boundary — commit/reject per dominance | jsdom |
+| 8 | [S] | Drag then flick back before release — release-velocity window decides | jsdom |
+| 9 | [S][L] | Chained swipes: grab mid-settle, no teleport (`liveRailOffset`) | jsdom, loop-* (back-to-back swipes) |
+| 10 | [S][L][**I**] | Committed swipe swallows the synthesized click — **no ghost launch** | jsdom, loop-* (telemetry invariant) |
+| 11 | [S] | Non-committed drag released over a tile: tile NOT launched | jsdom |
+| 12 | [S][L] | Tile tap launches: pushState/popstate + telemetry `launch` | launcher-e2e, gesture-matrix, loop-* (tileTap) |
+| 13 | [S] | Second simultaneous touch ignored (`isPrimary === false`) | jsdom |
+| 14 | [S][L] | Mouse drag paging (desktop); pen | jsdom, loop-model, desktop-smoke |
+| 15 | [S] | Right/middle mouse never starts a drag | jsdom |
+| 16 | [S] | Mouse released off-surface → stale-drag abandon on next hover | jsdom |
+| 17 | [S][L] | `pointercancel` mid-drag → settle back, no page change | jsdom, loop-* (settle invariant) |
+| 18 | [S] | `lostpointercapture` on bound element aborts; on a child must NOT | jsdom |
+| 19 | [S][L] | Viewport resize/rotation mid-drag + at rest — rail never mis-parked | jsdom, loop-* (rotate + transform-at-rest) |
+| 20 | [S][L] | Edge buttons: coarse-hidden, fine-visible, one page/click, Enter/Space | jsdom, home-e2e |
+| 21 | [S][**I**] | Offscreen half is `inert`; focus never lands inside `[inert]` | jsdom, loop-* (`activeElementInert` invariant) |
+| 22 | [S] | `prefers-reduced-motion`: settle jumps (no inline transition) | jsdom, loop-* (reducedMotion action) |
+| 23 | [**I**] | Every action: `data-page` ∈ {home,launcher}; AX probe matches; transform = −page·width; exactly one half `aria-hidden=false` | loop-* (invariants) |
+| 24 | [S] | Deep-link initial page: `/apps`→launcher, `/chat`→home; swipe not clobbered | jsdom (real router covered by loop-android / gesture-matrix) |
+| 25 | [S][L] | Store convergence: `ViewHeader` back, composer swipe, `navigateHome` all flip one rail | jsdom |
+
+## Home screen (`HomeScreen` + `use-notification-pull` + `usePullGesture`)
+
+| # | Tags | Interaction | Lanes |
+|---|---|---|---|
+| 26 | [S][L] | Notification pull: engages after 8px slop, tracks finger, ≥60px/≥0.5px·ms⁻¹ opens; short retracts | jsdom, gesture-matrix, loop-* (notificationPull) |
+| 27 | [S][L] | Scrolled-down list: downward drag scrolls, never pulls | jsdom, loop-* |
+| 28 | [S] | Upward drag = native scroll | jsdom |
+| 29 | [S] | Horizontal-dominant drag = rail, not pull | jsdom |
+| 30 | [S][L] | Tap on a widget is a tap, not a pull | jsdom, loop-* |
+| 31 | [S] | `touchcancel` mid-pull retracts (no stuck sheet) | jsdom |
+| 32 | [S] | Top-edge button: click/keyboard opens; upward drag does NOT open via stray click | gesture-matrix |
+| 33 | [S][L] | Widget list vertical scroll + `overscroll-y-contain` | jsdom, loop-* (gridScroll) |
+| 34 | [S] | Entrance fade plays exactly once (#9304) | jsdom |
+| 35 | [S] | AOSP tiles: hidden off-AOSP, 4 on AOSP | jsdom |
+| 36 | [**I**] | CLS stays within budget across the loop | loop-* (`cls` invariant) |
+
+## Launcher grid (`Launcher` + curation)
+
+| # | Tags | Interaction | Lanes |
+|---|---|---|---|
+| 37 | [S][L] | Vertical scroll of an overflowing grid; tiles remain tappable after scroll | launcher-e2e, loop-* (gridScroll→tileTap) |
+| 38 | [S][L] | Long-press on a tile: no edit mode, no ghost launch | launcher-e2e, gesture-matrix |
+| 39 | [S] | Dev/Preview badges; skeleton on `loading`; empty-state grid without crash | jsdom |
+| 40 | [S] | Curation invariants: dedup, AOSP gating, dev/preview toggles, cloud gating (#10725), alias `path` | jsdom (`LauncherSurface.test.tsx`, `launcher-curation.test.ts`) |
+| 41 | [**I**] | Brand: no blue hues sampled; tile hover neutral-white wash, never blue/black | loop-* (`sawBlue` invariant) |
+
+## Chat-overlay interplay (owned by the continuous-chat gesture lane, #12188)
+
+| # | Tags | Interaction | Lanes |
+|---|---|---|---|
+| 42 | [S][L] | Composer horizontal swipe: sheet closed flips rail, sheet open must not | jsdom, chat gesture lane |
+| 43 | [S] | Composer keeps focus through rail flips; rail gestures never steal composer focus | jsdom, chat gesture lane |
+
+Rows 42–43 sit at the chat ↔ launcher boundary; the composer swipe is not part
+of this launcher loop's alphabet (the fixture mounts no live composer). They are
+listed here for completeness and are covered by the continuous-chat gesture
+coverage (#12188), not by `launcher-loop/`.
+
+## Loop invariants ([I] rows → `invariants.ts`)
+
+Every `loop-*` lane checks these after each command (`checkInvariants` against a
+`LauncherObservation`); a violation throws with the seed + shrunk command path.
+
+| Row | Invariant |
+|---|---|
+| 23a | `data-page` is `home`\|`launcher` and equals the model page |
+| 23b | AX probe text `home-launcher-page:<page>` matches the model |
+| 23c/d | exactly one half exposed; at rest the rail transform equals `−page · width` |
+| 21 | `document.activeElement` is never inside an `[inert]` subtree (see the a11y fix in `HomeLauncherSurface.tsx`) |
+| 10 | telemetry launch count equals real taps only (no ghost launch, no dropped launch) |
+| — | zero console / page errors across the loop |
+| 36 | cumulative layout shift stays within the CLS budget |
+| 41 | no blue hue sampled in computed styles |
+
+## Platform notes
+
+- **Desktop gesture loops run in the Chromium renderer lane**, not against the
+  packaged binary: Electrobun ships this exact renderer bundle, and its system
+  WebView (WKWebView / WebKitGTK) exposes no CDP surface for trusted touch
+  synthesis (issue prior-art §5). The packaged lane gets a thin
+  `desktop-launcher-smoke` — bridge `eval` drives the shell-surface store
+  (`goLauncher()`/`goHome()`), asserts `data-page` + AX probe, screenshots both
+  halves — no gesture synthesis.
+- **Mobile-native loops** drive real device gestures: android via
+  `AndroidInput`/`adb input` with logcat + chunked `screenrecord`, iOS via
+  XCUIElement swipes/taps asserting the `home-launcher-page-probe` AX text between
+  rounds. They port the [L]/[I] subset reachable through the AX tree (page state,
+  transition stability, app-alive).
+
+## Status
+
+- Rows 21 (focus-out-of-inert) is enforced by the `HomeLauncherSurface` blur-on-
+  flip fix shipped alongside this doc; the a11y focus trap it closes is exactly
+  what the engine's `activeElementInInert` invariant asserts.
+- **`loop-web` is pending.** The #12373 engine's `CdpTouchDriver` had no
+  real-browser consumer before this work (its self-check runs in jsdom against a
+  `FakeDriver`), and a real-browser web runner surfaced driver/model gaps that
+  must be fixed in the engine before the web lane is green — committing rail
+  swipes coalesce at `stepDelayMs: 2` (Chromium drops the flick), the driver's
+  and `observe()`'s notification-open selectors don't match the real
+  `notification-sheet[data-open]`, and a rail swipe fired over an open
+  notification hits the overlay instead of the rail while the model expects it to
+  navigate. Tracked as a #12373 engine follow-up.

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.views-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.views-stub.ts
@@ -14,6 +14,13 @@ export function useAvailableViews() {
   };
 }
 
+// The launcher's catalog-loader pulls the imperative fetch alongside the hook;
+// the stub replaces the whole module, so it must export this too. No registry in
+// the fixture — the deterministic tiles come from the builtin views below.
+export async function fetchAvailableViews(): Promise<ViewRegistryEntry[]> {
+  return [];
+}
+
 function builtinView(
   id: string,
   label: string,


### PR DESCRIPTION
## Part of #12179 — Phases 2–4, reconciled onto the merged #12373 engine

While this branch built the launcher gesture-loop engine + lanes, a parallel
effort **#12373 (PRs #12443 + #12451) merged the same shared engine to
`develop`**, and `develop` independently landed the Phase-1 launcher cleanup.
This branch was **rebuilt on `origin/develop`**: the duplicate engine + android
lane + Phase-1 are dropped; only the genuinely-additive pieces remain, adapted to
develop's engine.

### Dropped as duplicate (already on develop, verified)
- The whole `packages/ui/src/testing/launcher-loop/` engine (canonical = #12373).
- `packages/app/test/android/launcher-gesture-loop.android.spec.ts` (#12373 shipped its own).
- Phase-1 (single-page launcher, deleted nested-pager claim registry, deleted `view-recents.ts`) — all already on develop.

### Kept as additive (this PR)
| Contribution | File | Verified |
|---|---|---|
| **a11y focus-blur on rail flip** (+ unit test) | `HomeLauncherSurface.tsx`, `HomeLauncherSurface.test.tsx` | ✅ 14/14 vitest |
| **iOS XCUITest loop** + pbxproj wiring | `AppUITests/LauncherGestureLoopUITests.swift`, `project.pbxproj` | pbxproj `plutil` OK; runs in the iOS-sim lane |
| **Desktop packaged smoke** | `desktop-launcher-smoke.e2e.spec.ts` | runs in the packaged-Electrobun lane |
| **Interaction matrix doc** | `LAUNCHER_INTERACTION_MATRIX.md` | — |
| **Launcher-fixture bundling fix** | `home-screen-fixture.views-stub.ts` (`fetchAvailableViews`) | biome clean |

- The **a11y fix** closes a real focus trap on develop: the offscreen half is
  `inert` but the browser never blurs a focused descendant when `inert` is
  applied — exactly the trap the #12373 engine's `activeElementInInert` invariant
  asserts against, which no real-browser lane had exercised.
- **Desktop:** no CDP gesture synthesis against WKWebView; the packaged lane
  drives the shell-surface store via bridge `eval` and screenshots both halves.

### Failure-batch verdict + a #12373 engine finding
The loop caught + shrank two failures (seeds `424242` / `387289096`) → **harness
bug, not a launcher bug**: a tile scrolled off the `overflow-y-auto` window is
center-tapped off-window and launches nothing (`elementFromPoint` → `null`).
Standing up a real-browser web runner also surfaced that **develop's #12373
`CdpTouchDriver` is unvalidated in a real browser** (its self-check is jsdom +
`FakeDriver`): committing flicks are dropped at `stepDelayMs: 2`, and the
notification-open selectors don't match the real `notification-sheet[data-open]`.
Full diagnosis + the ready web runner + a proven partial-fix diff are in
`.github/issue-evidence/12179-launcher-loops/RECONCILIATION-and-verdict.md` for a
#12373 follow-up (the `loop-web` lane lands once the engine's real-browser path
is fixed — kept out of this PR so no red lane ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
