### PR TITLE
refactor(#12264): surface swallowed core build failures + annotate justified catches (fallback-slop sweep)

### DIFF
--- a/packages/core/src/features/plugin-manager/services/coreManagerService.ts
+++ b/packages/core/src/features/plugin-manager/services/coreManagerService.ts
@@ -584,7 +584,10 @@ export class CoreManagerService extends Service {
 				if ((await fs.readdir(this.coreBaseDir())).length === 0) {
 					await fs.rmdir(this.coreBaseDir());
 				}
-			} catch {}
+			} catch (err) {
+				// error-policy:J6 best-effort teardown of an empty core dir
+				logger.debug("[CoreManager] best-effort empty coreBaseDir cleanup failed", err);
+			}
 
 			await this.writeTsconfigCorePaths(null);
 

--- a/packages/core/src/features/plugin-manager/services/coreManagerService.ts
+++ b/packages/core/src/features/plugin-manager/services/coreManagerService.ts
@@ -6,6 +6,7 @@ import { logger } from "../../../logger.ts";
 import type { IAgentRuntime } from "../../../types/runtime.ts";
 import type { ServiceTypeName } from "../../../types/service.ts";
 import { Service } from "../../../types/service.ts";
+import { formatError } from "../../../utils/format-error.ts";
 import { resolveStateDir } from "../utils/paths.ts";
 import { getRegistryEntry } from "./pluginRegistryService.ts";
 
@@ -586,7 +587,9 @@ export class CoreManagerService extends Service {
 				}
 			} catch (err) {
 				// error-policy:J6 best-effort teardown of an empty core dir
-				logger.debug("[CoreManager] best-effort empty coreBaseDir cleanup failed", err);
+				logger.debug(
+					`[CoreManager] best-effort empty coreBaseDir cleanup failed: ${formatError(err)}`,
+				);
 			}
 
 			await this.writeTsconfigCorePaths(null);

--- a/packages/core/src/features/plugin-manager/services/pluginManagerService.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginManagerService.ts
@@ -980,7 +980,12 @@ export class PluginManagerService extends Service implements PluginRegistry {
 
 		try {
 			await execAsync(`${pm} run build`, { cwd: targetDir });
-		} catch {} // Build might fail or not exist, continue
+		} catch (err) {
+			// A plugin may legitimately have no build script; surface a real build
+			// failure observably instead of silently masking it as a healthy install.
+			logger.warn(`[PluginManager] build step did not complete for ${targetDir}`, err);
+			this.runtime.reportError("PluginManager", err, { targetDir, step: "build" });
+		}
 	}
 
 	/**
@@ -1157,7 +1162,11 @@ export class PluginManagerService extends Service implements PluginRegistry {
 				await execAsync(`${pm} install`, { cwd: targetDir });
 				try {
 					await execAsync(`${pm} run build`, { cwd: targetDir });
-				} catch {}
+				} catch (err) {
+					// Surface a real build failure observably instead of masking it (see above).
+					logger.warn(`[PluginManager] build step did not complete for ${targetDir}`, err);
+					this.runtime.reportError("PluginManager", err, { targetDir, step: "build" });
+				}
 
 				const commitHash = (
 					await execAsync("git rev-parse HEAD", { cwd: targetDir })

--- a/packages/core/src/features/plugin-manager/services/pluginManagerService.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginManagerService.ts
@@ -9,6 +9,7 @@ import type { Plugin as ElizaPlugin } from "../../../types/plugin.ts";
 import type { IAgentRuntime } from "../../../types/runtime.ts";
 import type { ServiceTypeName } from "../../../types/service.ts";
 import { Service } from "../../../types/service.ts";
+import { formatError } from "../../../utils/format-error.ts";
 import {
 	applyRuntimeExtensions,
 	type ExtendedRuntime,
@@ -983,8 +984,13 @@ export class PluginManagerService extends Service implements PluginRegistry {
 		} catch (err) {
 			// A plugin may legitimately have no build script; surface a real build
 			// failure observably instead of silently masking it as a healthy install.
-			logger.warn(`[PluginManager] build step did not complete for ${targetDir}`, err);
-			this.runtime.reportError("PluginManager", err, { targetDir, step: "build" });
+			logger.warn(
+				`[PluginManager] build step did not complete for ${targetDir}: ${formatError(err)}`,
+			);
+			this.runtime.reportError("PluginManager", err, {
+				targetDir,
+				step: "build",
+			});
 		}
 	}
 
@@ -1164,8 +1170,13 @@ export class PluginManagerService extends Service implements PluginRegistry {
 					await execAsync(`${pm} run build`, { cwd: targetDir });
 				} catch (err) {
 					// Surface a real build failure observably instead of masking it (see above).
-					logger.warn(`[PluginManager] build step did not complete for ${targetDir}`, err);
-					this.runtime.reportError("PluginManager", err, { targetDir, step: "build" });
+					logger.warn(
+						`[PluginManager] build step did not complete for ${targetDir}: ${formatError(err)}`,
+					);
+					this.runtime.reportError("PluginManager", err, {
+						targetDir,
+						step: "build",
+					});
 				}
 
 				const commitHash = (

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -610,7 +610,9 @@ function containsToolAttemptObject(text: string): boolean {
 		try {
 			const parsed = JSON.parse(objectText);
 			if (isToolAttemptObject(parsed)) return true;
-		} catch {}
+		} catch {
+			// error-policy:J3 unparseable/mismatched text is simply not a tool-attempt object
+		}
 	}
 	return false;
 }

--- a/packages/core/src/services/optimized-prompt.ts
+++ b/packages/core/src/services/optimized-prompt.ts
@@ -786,7 +786,9 @@ async function listCompleteVersionNumbers(dir: string): Promise<number[]> {
 			const payload = await readFile(path, "utf-8");
 			const macHex = (await readFile(macPathFor(path), "utf-8")).trim();
 			if (verifyArtifactMac(payload, macHex)) versions.push(n);
-		} catch {}
+		} catch {
+			// error-policy:J3 an absent or unverifiable artifact version is simply not available to the scan
+		}
 	}
 	versions.sort((a, b) => a - b);
 	return versions;


### PR DESCRIPTION
## Fallback slop sweep (#12182) — `packages/core` slice: the empty-catch cluster

First slice of the **packages/core** batch (#12264). Handles the four non-test files in `packages/core/**` that contained empty `catch {}` blocks, applying the #12263 error-policy rubric per site.

### Changes

**Genuine slop — surfaced observably (was silently masking failure):**
- `plugin-manager/services/pluginManagerService.ts` — the two `pm run build` steps used `} catch {}` (one literally commented *"Build might fail or not exist, continue"*). A real build failure was swallowed silently, so a **broken plugin looked like a healthy install**. Now each `catch` does `logger.warn(...)` + `this.runtime.reportError("PluginManager", err, { targetDir, step: "build" })`, so the failure reaches the agent (RECENT_ERRORS provider) and owner escalation. A plugin that legitimately has no build script surfaces the same way — visibly, not silently.

**Justified handlers — kept + annotated `// error-policy:J<N>`:**
- `runtime/evaluator.ts` — `JSON.parse` inside a shape-detector; unparseable/mismatched text simply *is not* a tool-attempt object → **J3** (parse-to-invalid), annotated.
- `services/optimized-prompt.ts` — artifact-version scan; an absent/unverifiable version *is not available* to the scan → **J3**, annotated.
- `features/plugin-manager/services/coreManagerService.ts` — best-effort teardown of an empty core dir → **J6**, annotated + a `logger.debug` instead of a fully silent catch.

### Why this is correct
- `reportError(scope: string, error: unknown, context?: Record<string, unknown>): void` — signature matches (verified on `IAgentRuntime`).
- `logger.warn(...args: unknown[])` — matches the existing convention in this file.
- No control-flow change except making previously-silent build failures **observable**; the J-annotated catches keep their (correct) swallow-and-continue behavior, now documented and grep-able.

### Verification
- Diff-scoped **error-policy ratchet** passes — this branch only *removes* empty catches (never adds), so `audit:error-policy-ratchet` is green on the touched files; the repo-wide `--report` total drops by the four cleared empty catches.
- Branch is a clean 4-file diff off `develop`; the four files are unchanged on `develop` since the branch point (no conflict).

Refs #12264 · #12182
