### PR TITLE
[codex] Add fallback slop error reporting contracts

### DIFF
--- a/.github/issue-evidence/12263-foundation-contracts.md
+++ b/.github/issue-evidence/12263-foundation-contracts.md
@@ -1,0 +1,45 @@
+# #12263 foundation contracts evidence
+
+Chunk: policy docs, `ElizaError`, `EventType.ERROR_REPORTED`, and
+`runtime.reportError(scope, error, context)`.
+
+## Commands run
+
+```bash
+bun run --cwd packages/core prebuild
+bun run --cwd packages/cloud/routing build
+bunx biome check AGENTS.md CLAUDE.md packages/core/src/errors.ts packages/core/src/errors.test.ts packages/core/src/index.node.ts packages/core/src/index.browser.ts packages/core/src/index.edge.ts packages/core/src/runtime.ts packages/core/src/types/events.ts packages/core/src/types/runtime.ts
+bun run --cwd packages/core test -- errors.test.ts
+bun run --cwd packages/core typecheck
+bun run verify
+bun run --cwd packages/cloud/shared typecheck
+bun run --cwd packages/cloud/api typecheck
+```
+
+## Results reviewed
+
+- Biome touched-file check: passed, no fixes pending.
+- Focused core test: passed, 1 file / 4 tests.
+- Core typecheck: passed.
+- Root verify: failed outside this chunk in cloud typecheck. The first failed
+  lane was `@elizaos/cloud-shared#typecheck` while build artifacts were still
+  being produced; rerunning `bun run --cwd packages/cloud/shared typecheck`
+  passed after the build lane completed.
+- Remaining unrelated failure: `bun run --cwd packages/cloud/api typecheck`
+  fails in `packages/cloud/shared/src/lib/services/market-preview.ts` because
+  `@elizaos/shared` does not currently export `CoinGeckoMarketRecord`,
+  `buildCoinGeckoMarketsUrl`, `buildMarketMovers`, `buildMarketPriceSnapshots`,
+  `COINGECKO_MARKET_PROVIDER`, `POLYMARKET_MARKET_PROVIDER`, or
+  `parseCoinGeckoMarkets`.
+
+## Evidence rows
+
+- Backend logs: N/A - this chunk introduces the diagnostic API and validates the
+  emitted typed payload in-process; follow-up chunks will attach runtime logs
+  from an induced live failure.
+- Real-LLM trajectory: N/A - no prompt/provider/action behavior is registered in
+  this chunk; the `RECENT_ERRORS` provider PR will include live trajectory
+  evidence.
+- Screenshots/video: N/A - no UI surface changes.
+- Domain artifacts: typed `ERROR_REPORTED` payload is asserted in
+  `packages/core/src/errors.test.ts`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,55 @@ To build on the runtime from your own TypeScript with no CLI/UI, import
 - Keep weak types (`any` / `unknown` / unsafe casts) out; validate at runtime
   boundaries and type the validated result.
 
+## Error-Handling Simplification
+
+elizaOS follows fail-fast-inside / handle-at-boundary error handling: inner
+code throws typed errors, while the nearest designated boundary translates them
+into structured HTTP responses, CLI exits, visible UI error states, or owner /
+developer escalation. Silent fallback paths are not recovery; they make broken
+pipelines look healthy. This policy implements the #12182 cleanup and follows
+the repo precedent from #9324 and `plugins/plugin-embeddings/AGENTS.md`:
+THROW, never fabricate.
+
+Justified categories may be kept only when annotated with a grep-able
+`// error-policy:J<N> <reason>` comment:
+
+- **J1 boundary translation** — one outermost handler per process/transport
+  boundary producing a structured failure.
+- **J2 context-adding rethrow** — must use `cause`.
+- **J3 untrusted-input sanitizing** — parse failures produce an explicit typed
+  "invalid" result, never a fake-valid default.
+- **J4 explicit user-facing degrade** — designed, visually-distinguishable
+  unavailable/error states; only expected error shapes degrade.
+- **J5 unhandled-rejection suppression** — with a comment naming where the
+  rejection IS observed.
+- **J6 best-effort teardown** — debug/warn, teardown paths only.
+- **J7 diagnostics-must-not-kill-the-loop** — trajectory/telemetry writes may
+  catch but must warn + `runtime.reportError`.
+
+Everything else is slop: empty catches, log-and-continue that fabricates the
+function's result, `return <default>` from catch, `.catch(() => {})` on writes
+that matter, `?? <literal>` substituting for failed/missing data,
+optional-chaining-as-guard on required collaborators, and fallback paths whose
+only purpose is masking a primary failure. A justified handler still may not
+fabricate a success value: J1 returns a failure, J3 returns an explicit invalid
+signal, and J4 renders an unavailable/error state.
+
+Code that cannot proceed should throw `ElizaError` from `@elizaos/core` with a
+stable `code`, human-readable message, structured `context`, and `cause` where
+available. Failures with no caller to throw to should call
+`runtime.reportError(scope, error, context)` so the logger, event bus, agent
+prompt surface, and escalation wiring can observe the same failure. Do not
+conflate "not loaded" with zero, empty, false, or a healthy empty DTO.
+
+UI code follows the three-state rule: loading, designed-empty, and error are
+three distinguishable renders. A 404 from an unloaded plugin may degrade to a
+designed "unavailable" state, as in
+`packages/ui/src/components/pages/StreamView.tsx`; 5xx, transport, and parse
+failures render an error state. The view-audit findings in
+`scripts/view-audit/output/MASTER-REPORT.md` are the standing reference for why
+healthy-empty-from-catch is banned.
+
 ## Slop and Comment Cleanup
 
 Every file is legible on its own: a purpose-explaining prose header at the top,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,55 @@ To build on the runtime from your own TypeScript with no CLI/UI, import
 - Keep weak types (`any` / `unknown` / unsafe casts) out; validate at runtime
   boundaries and type the validated result.
 
+## Error-Handling Simplification
+
+elizaOS follows fail-fast-inside / handle-at-boundary error handling: inner
+code throws typed errors, while the nearest designated boundary translates them
+into structured HTTP responses, CLI exits, visible UI error states, or owner /
+developer escalation. Silent fallback paths are not recovery; they make broken
+pipelines look healthy. This policy implements the #12182 cleanup and follows
+the repo precedent from #9324 and `plugins/plugin-embeddings/AGENTS.md`:
+THROW, never fabricate.
+
+Justified categories may be kept only when annotated with a grep-able
+`// error-policy:J<N> <reason>` comment:
+
+- **J1 boundary translation** — one outermost handler per process/transport
+  boundary producing a structured failure.
+- **J2 context-adding rethrow** — must use `cause`.
+- **J3 untrusted-input sanitizing** — parse failures produce an explicit typed
+  "invalid" result, never a fake-valid default.
+- **J4 explicit user-facing degrade** — designed, visually-distinguishable
+  unavailable/error states; only expected error shapes degrade.
+- **J5 unhandled-rejection suppression** — with a comment naming where the
+  rejection IS observed.
+- **J6 best-effort teardown** — debug/warn, teardown paths only.
+- **J7 diagnostics-must-not-kill-the-loop** — trajectory/telemetry writes may
+  catch but must warn + `runtime.reportError`.
+
+Everything else is slop: empty catches, log-and-continue that fabricates the
+function's result, `return <default>` from catch, `.catch(() => {})` on writes
+that matter, `?? <literal>` substituting for failed/missing data,
+optional-chaining-as-guard on required collaborators, and fallback paths whose
+only purpose is masking a primary failure. A justified handler still may not
+fabricate a success value: J1 returns a failure, J3 returns an explicit invalid
+signal, and J4 renders an unavailable/error state.
+
+Code that cannot proceed should throw `ElizaError` from `@elizaos/core` with a
+stable `code`, human-readable message, structured `context`, and `cause` where
+available. Failures with no caller to throw to should call
+`runtime.reportError(scope, error, context)` so the logger, event bus, agent
+prompt surface, and escalation wiring can observe the same failure. Do not
+conflate "not loaded" with zero, empty, false, or a healthy empty DTO.
+
+UI code follows the three-state rule: loading, designed-empty, and error are
+three distinguishable renders. A 404 from an unloaded plugin may degrade to a
+designed "unavailable" state, as in
+`packages/ui/src/components/pages/StreamView.tsx`; 5xx, transport, and parse
+failures render an error state. The view-audit findings in
+`scripts/view-audit/output/MASTER-REPORT.md` are the standing reference for why
+healthy-empty-from-catch is banned.
+
 ## Slop and Comment Cleanup
 
 Every file is legible on its own: a purpose-explaining prose header at the top,

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Contract tests for structured runtime errors and the first diagnostic
+ * reporting primitive used by the fallback-slop cleanup batches.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ElizaError } from "./errors";
+import { AgentRuntime } from "./runtime";
+import { EventType } from "./types/events";
+
+describe("ElizaError", () => {
+	it("preserves code, context, severity, and cause", () => {
+		const cause = new Error("database closed");
+		const error = new ElizaError("DB_COUNT_UNAVAILABLE", "count failed", {
+			context: { table: "agents" },
+			cause,
+			severity: "fatal",
+		});
+
+		expect(error).toBeInstanceOf(Error);
+		expect(error.name).toBe("ElizaError");
+		expect(error.message).toBe("count failed");
+		expect(error.code).toBe("DB_COUNT_UNAVAILABLE");
+		expect(error.context).toEqual({ table: "agents" });
+		expect(error.severity).toBe("fatal");
+		expect(error.cause).toBe(cause);
+	});
+
+	it("supports option-object construction", () => {
+		const error = new ElizaError("config corrupt", {
+			code: "PROJECT_METADATA_CORRUPT",
+			context: { file: ".elizaos/template.json" },
+		});
+
+		expect(error.code).toBe("PROJECT_METADATA_CORRUPT");
+		expect(error.message).toBe("config corrupt");
+		expect(error.context).toEqual({ file: ".elizaos/template.json" });
+	});
+});
+
+describe("AgentRuntime.reportError", () => {
+	it("emits a typed ERROR_REPORTED payload for structured errors", async () => {
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+		const received: Array<{
+			scope: string;
+			code: string;
+			message: string;
+			context?: Record<string, unknown>;
+			severity?: string;
+		}> = [];
+
+		runtime.registerEvent(EventType.ERROR_REPORTED, async (payload) => {
+			received.push({
+				scope: payload.scope,
+				code: payload.code,
+				message: payload.message,
+				context: payload.context,
+				severity: payload.severity,
+			});
+		});
+
+		await runtime.reportError(
+			"DatabaseRows.count",
+			new ElizaError("DB_COUNT_UNAVAILABLE", "count failed", {
+				context: { table: "agents" },
+				severity: "fatal",
+			}),
+			{ query: "select count(*)" },
+		);
+
+		expect(received).toEqual([
+			{
+				scope: "DatabaseRows.count",
+				code: "DB_COUNT_UNAVAILABLE",
+				message: "count failed",
+				context: { table: "agents", query: "select count(*)" },
+				severity: "fatal",
+			},
+		]);
+	});
+
+	it("never throws when ERROR_REPORTED handlers fail", async () => {
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+		runtime.registerEvent(EventType.ERROR_REPORTED, async () => {
+			throw new Error("listener failed");
+		});
+
+		await expect(
+			runtime.reportError("Diagnostics.test", new Error("boom")),
+		).resolves.toBeUndefined();
+	});
+});

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,52 @@
+/**
+ * Structured runtime errors carry stable machine-readable codes without
+ * discarding the original cause chain. Sweep work uses this as the common
+ * fast-fail shape while boundary handlers remain responsible for translating
+ * failures into user-facing responses.
+ */
+
+export type ElizaErrorSeverity = "ephemeral" | "fatal";
+
+export interface ElizaErrorOptions {
+	code: string;
+	context?: Record<string, unknown>;
+	cause?: unknown;
+	severity?: ElizaErrorSeverity;
+}
+
+export class ElizaError extends Error {
+	readonly code: string;
+	readonly context?: Record<string, unknown>;
+	readonly severity?: ElizaErrorSeverity;
+
+	constructor(message: string, options: ElizaErrorOptions);
+	constructor(
+		code: string,
+		message: string,
+		options?: Omit<ElizaErrorOptions, "code">,
+	);
+	constructor(
+		codeOrMessage: string,
+		messageOrOptions: string | ElizaErrorOptions,
+		options: Omit<ElizaErrorOptions, "code"> = {},
+	) {
+		const code =
+			typeof messageOrOptions === "string"
+				? codeOrMessage
+				: messageOrOptions.code;
+		const message =
+			typeof messageOrOptions === "string" ? messageOrOptions : codeOrMessage;
+		const resolvedOptions =
+			typeof messageOrOptions === "string" ? options : messageOrOptions;
+
+		super(message, { cause: resolvedOptions.cause });
+		this.name = "ElizaError";
+		this.code = code;
+		this.context = resolvedOptions.context;
+		this.severity = resolvedOptions.severity;
+	}
+}
+
+export function isElizaError(error: unknown): error is ElizaError {
+	return error instanceof ElizaError;
+}

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -37,6 +37,7 @@ export * from "./entities";
 // and exported from both barrels. @elizaos/shared re-exports it from the core
 // barrel so browser consumers resolve the same canonical truthy set.
 export * from "./env-utils";
+export * from "./errors";
 export * from "./features/advanced-memory";
 export { AutonomyService } from "./features/autonomy/index";
 export {

--- a/packages/core/src/index.edge.ts
+++ b/packages/core/src/index.edge.ts
@@ -37,6 +37,7 @@ export {
 export * from "./database";
 export * from "./database/inMemoryAdapter";
 export * from "./entities";
+export * from "./errors";
 export * from "./features/basic-capabilities/index";
 export * from "./generated/action-docs";
 export * from "./generated/spec-helpers";

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -68,6 +68,7 @@ export * from "./database";
 export * from "./database/inMemoryAdapter";
 export * from "./entities";
 export * from "./env-utils";
+export * from "./errors";
 export {
 	roleAction,
 	updateRoleAction,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -8,6 +8,7 @@ import { ensureConnection as ensureConnectionStandalone } from "./connection";
 import { registerConnectorSourceDefinitions } from "./connectors";
 import { deriveKnownSecrets } from "./constants/secrets";
 import { InMemoryDatabaseAdapter } from "./database/inMemoryAdapter";
+import { isElizaError } from "./errors";
 import {
 	type CapabilityConfig,
 	createBasicCapabilitiesPlugin,
@@ -8194,6 +8195,53 @@ ${section_end}`;
 					params: EventPayloadMap[keyof EventPayloadMap] | EventPayload,
 			  ) => Promise<void>)[]
 			| undefined;
+	}
+
+	async reportError(
+		scope: string,
+		error: unknown,
+		context: Record<string, unknown> = {},
+	): Promise<void> {
+		const code = isElizaError(error) ? error.code : "UNCLASSIFIED";
+		const message =
+			error instanceof Error
+				? error.message
+				: typeof error === "string"
+					? error
+					: "Unknown runtime error";
+		const payloadContext = isElizaError(error)
+			? { ...error.context, ...context }
+			: context;
+		const severity = isElizaError(error) ? error.severity : undefined;
+
+		try {
+			this.logger.error(
+				{ error, code, context: payloadContext, severity },
+				`[${scope}] ${message}`,
+			);
+		} catch {
+			// error-policy:J7 diagnostic boundary; reportError must never throw.
+		}
+
+		try {
+			await this.emitEvent(EventType.ERROR_REPORTED, {
+				scope,
+				code,
+				message,
+				context: payloadContext,
+				severity,
+			});
+		} catch (emitError) {
+			// error-policy:J7 diagnostic boundary; event-bus failures cannot recurse.
+			try {
+				this.logger.error(
+					{ error: emitError, code, scope },
+					"[AgentRuntime] failed to emit ERROR_REPORTED",
+				);
+			} catch {
+				// error-policy:J7 final diagnostic sink.
+			}
+		}
 	}
 
 	async emitEvent(event: string | string[], params: JsonValue | object) {

--- a/packages/core/src/types/events.ts
+++ b/packages/core/src/types/events.ts
@@ -74,6 +74,9 @@ export enum EventType {
 	EMBEDDING_GENERATION_COMPLETED = "EMBEDDING_GENERATION_COMPLETED",
 	EMBEDDING_GENERATION_FAILED = "EMBEDDING_GENERATION_FAILED",
 
+	// Runtime diagnostics
+	ERROR_REPORTED = "ERROR_REPORTED",
+
 	// Control events
 	CONTROL_MESSAGE = "CONTROL_MESSAGE",
 
@@ -270,6 +273,19 @@ export interface EmbeddingGenerationPayload extends EventPayload {
 	runId?: UUID;
 	retryCount?: number;
 	maxRetries?: number;
+}
+
+/**
+ * Payload for runtime failures reported outside a single action result.
+ */
+export interface ErrorReportedPayload extends EventPayload {
+	scope: string;
+	code: string;
+	message: string;
+	context?: Record<string, unknown>;
+	runId?: UUID;
+	roomId?: UUID;
+	severity?: "ephemeral" | "fatal";
 }
 
 /**
@@ -585,6 +601,7 @@ export interface EventPayloadMap {
 	[EventType.EMBEDDING_GENERATION_REQUESTED]: EmbeddingGenerationPayload;
 	[EventType.EMBEDDING_GENERATION_COMPLETED]: EmbeddingGenerationPayload;
 	[EventType.EMBEDDING_GENERATION_FAILED]: EmbeddingGenerationPayload;
+	[EventType.ERROR_REPORTED]: ErrorReportedPayload;
 	[EventType.CONTROL_MESSAGE]: ControlMessagePayload;
 	[EventType.FORM_FIELD_CONFIRMED]: FormFieldEventPayload;
 	[EventType.FORM_FIELD_CANCELLED]: FormFieldEventPayload;

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -951,6 +951,19 @@ export interface IAgentRuntime extends IDatabaseAdapter<object> {
 		event: string,
 	): ((params: EventPayload) => Promise<void>)[] | undefined;
 
+	/**
+	 * Report a runtime failure that occurs outside a single action result.
+	 *
+	 * Implementations log the failure and emit {@link EventType.ERROR_REPORTED}
+	 * for agent-visible diagnostics. This method is a diagnostic boundary and
+	 * must not throw.
+	 */
+	reportError(
+		scope: string,
+		error: unknown,
+		context?: Record<string, unknown>,
+	): Promise<void>;
+
 	emitEvent<T extends keyof EventPayloadMap>(
 		event: T | T[],
 		params: EventPayloadMap[T],


### PR DESCRIPTION
## Summary

Relates to #12263 and unblocks the #12182 sweep batches in small chunks.

This first integration slice adds the shared contracts that follow-up PRs and sweep branches can rebase onto:

- Adds the root `Error-Handling Simplification` policy to `AGENTS.md` and mirrors it into `CLAUDE.md`.
- Adds `ElizaError` with stable `code`, structured `context`, optional `severity`, and preserved `cause`.
- Adds `EventType.ERROR_REPORTED` and its typed payload.
- Adds `runtime.reportError(scope, error, context)` as a non-throwing diagnostic boundary that logs and emits the typed event.
- Adds focused tests and evidence for the new contracts.

## Why this is chunked

#12263 also requires the `RECENT_ERRORS` provider, owner-escalation threshold wiring, and lint guard rollout. Those are intentionally left for follow-up PRs so other agents can integrate this API quickly instead of waiting on one oversized foundation branch.

## Evidence

See `.github/issue-evidence/12263-foundation-contracts.md`.

Commands run and reviewed:

```bash
bun run --cwd packages/core prebuild
bun run --cwd packages/cloud/routing build
bunx biome check AGENTS.md CLAUDE.md packages/core/src/errors.ts packages/core/src/errors.test.ts packages/core/src/index.node.ts packages/core/src/index.browser.ts packages/core/src/index.edge.ts packages/core/src/runtime.ts packages/core/src/types/events.ts packages/core/src/types/runtime.ts
bun run --cwd packages/core test -- errors.test.ts
bun run --cwd packages/core typecheck
bun run verify
bun run --cwd packages/cloud/shared typecheck
bun run --cwd packages/cloud/api typecheck
```

Results:

- Focused Biome check: passed.
- Focused core test: passed, 1 file / 4 tests.
- Core typecheck: passed.
- `bun run verify`: failed outside this chunk in cloud typecheck. `packages/cloud/shared typecheck` passes when rerun after build artifacts exist. `packages/cloud/api typecheck` still fails on missing `@elizaos/shared` market-preview exports (`CoinGeckoMarketRecord`, `buildCoinGeckoMarketsUrl`, `buildMarketMovers`, `buildMarketPriceSnapshots`, `COINGECKO_MARKET_PROVIDER`, `POLYMARKET_MARKET_PROVIDER`, `parseCoinGeckoMarkets`).

Evidence rows:

- Backend logs: N/A - this chunk introduces the diagnostic API and validates the emitted typed payload in-process; provider/escalation follow-ups will attach runtime logs from an induced live failure.
- Real-LLM trajectory: N/A - no prompt/provider/action behavior is registered in this chunk; the `RECENT_ERRORS` provider PR will include live trajectory evidence.
- Screenshots/video: N/A - no UI surface changes.
- Domain artifacts: typed `ERROR_REPORTED` payload asserted in `packages/core/src/errors.test.ts`.
