### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-composites-a

### DIFF
--- a/packages/ui/src/components/composites/chat-search-hint.tsx
+++ b/packages/ui/src/components/composites/chat-search-hint.tsx
@@ -1,3 +1,7 @@
+/**
+ * In-view hint telling the user that a view's search is routed through the
+ * floating chat rather than a local search box. Lives in the view's own header.
+ */
 import type * as React from "react";
 
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/composites/chat/ChatEmptyStateWithRecommendations.test.tsx
+++ b/packages/ui/src/components/composites/chat/ChatEmptyStateWithRecommendations.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/**
+ * Renders ChatEmptyStateWithRecommendations in jsdom and asserts that tapping a
+ * recommendation prefills the composer (via CHAT_PREFILL_EVENT) and that the
+ * primary setup action fires. React Testing Library, no live model.
+ */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {

--- a/packages/ui/src/components/composites/chat/ContinuousChatToggle.test.tsx
+++ b/packages/ui/src/components/composites/chat/ContinuousChatToggle.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/**
+ * Renders ContinuousChatToggle in jsdom and asserts the three-segment mode
+ * switch: active-mode marking, onChange emit/suppression, disabled-state
+ * click handling, and the compact variant's click-to-cycle. RTL, no live model.
+ */
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/composites/chat/chat-composer-shell.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer-shell.tsx
@@ -1,3 +1,10 @@
+/**
+ * Positioning shell that anchors the chat composer to the bottom of the chat
+ * surface: the sticky wrapper handling safe-area / mobile-nav insets and the
+ * optional `before` slot (e.g. voice status bar). Presentation only — the
+ * `default` and `game-modal` variants are separate render paths, not a param
+ * switch on the input itself.
+ */
 import type * as React from "react";
 
 import { cn } from "../../../lib/utils";

--- a/packages/ui/src/components/composites/chat/chat-composer.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer.tsx
@@ -1,3 +1,11 @@
+/**
+ * The chat message composer: auto-growing textarea plus send / attach / voice
+ * controls, driving the primary text-and-voice input for every chat surface.
+ * Owns the textarea auto-resize measurement, push-to-talk wiring
+ * (`usePushToTalk`), and the send/stop/voice affordance state derived from the
+ * passed voice-session mode. Pure presentation — the parent owns the value and
+ * the actual send/voice actions.
+ */
 import {
   ArrowUp,
   Mic,

--- a/packages/ui/src/components/composites/chat/chat-conversation-item.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-conversation-item.test.tsx
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+/**
+ * Renders ChatConversationItem in jsdom and asserts row selection, the
+ * more-actions/right-click menus, the game-modal inline rename+delete, the
+ * delete-confirm flow, and mobile long-press (with trailing-click suppression).
+ * RTL, no live model.
+ */
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/composites/chat/chat-message-actions.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.tsx
@@ -1,3 +1,8 @@
+/**
+ * Hover action rail for a chat message (copy / play / edit / delete), rendered
+ * as a `PagePanel.ActionRail` overlay on the bubble. Each control is opt-in via
+ * its `can*` flag; copy shows a transient confirmed state. Wired by ChatMessage.
+ */
 import { Check, Copy, Pencil, Trash2, Volume2 } from "lucide-react";
 
 import { Button } from "../../ui/button";

--- a/packages/ui/src/components/composites/chat/chat-message.suggestion.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.suggestion.test.tsx
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+/**
+ * Renders ChatMessage in jsdom and asserts the proactive-suggestion affordance
+ * (#8792): it appears only for the proactive-interaction source on an assistant
+ * turn, offers one-tap dismiss and accept ("Do it"), and stays hidden without
+ * the corresponding handlers. RTL, no live model.
+ */
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -1,3 +1,11 @@
+/**
+ * A single chat turn row: avatar/name grouping, the message bubble, source and
+ * voice-speaker badges, inline edit, hover action rail, and the accept/dismiss
+ * controls for proactive suggestion bubbles (#8792). Memoized with a custom
+ * equality check so streamed-token re-renders stay cheap; the mount-time
+ * entrance animation is deliberately excluded from that check (see
+ * `enterOnMount`). Presentation only — actions are delegated to callbacks.
+ */
 import { Sparkles, X } from "lucide-react";
 import type * as React from "react";
 import {

--- a/packages/ui/src/components/composites/chat/chat-source.helpers.ts
+++ b/packages/ui/src/components/composites/chat/chat-source.helpers.ts
@@ -1,3 +1,11 @@
+/**
+ * Non-JSX helpers for chat message provenance and voice speakers: a pluggable
+ * registry mapping a source key (imessage/telegram/…) to badge styling + icon,
+ * a pluggable reaction-emoji renderer, source-key normalization, and
+ * speaker-label resolution. The registry/renderer are injected by the host app
+ * so this UI package carries no connector-specific assets; consumed by
+ * chat-source.tsx and chat-message.tsx.
+ */
 import { MessageSquareText } from "lucide-react";
 import type * as React from "react";
 

--- a/packages/ui/src/components/composites/chat/chat-source.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-source.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/**
+ * Covers chat voice-speaker provenance: `resolveChatVoiceSpeakerLabel` name/
+ * userName fallbacks and the ChatVoiceSpeakerBadge render (label presence, the
+ * OWNER crown affordance). RTL in jsdom, no live model.
+ */
 
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/packages/ui/src/components/composites/chat/chat-transcript.memoization.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-transcript.memoization.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/**
+ * Guards ChatTranscript's row memoization: unchanged historical rows must not
+ * re-render while a streamed update mutates the tail. RTL in jsdom, no live
+ * model — asserts render behavior, not model output.
+ */
 
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/composites/chat/chat-types.ts
+++ b/packages/ui/src/components/composites/chat/chat-types.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared prop and data shapes for the chat composites: the `ChatVariant` skin,
+ * the localizable `ChatLabelSet`, message/attachment/conversation records, and
+ * voice-speaker types. The single source these sibling components import their
+ * types from so their contracts stay in sync.
+ */
 export type ChatVariant = "default" | "game-modal";
 
 export interface ChatLabelSet {

--- a/packages/ui/src/components/composites/chat/chat-typing-indicator.tsx
+++ b/packages/ui/src/components/composites/chat/chat-typing-indicator.tsx
@@ -1,3 +1,7 @@
+/**
+ * Animated "agent is typing" indicator shown as an assistant bubble while a
+ * response is pending, with `default` and `game-modal` render paths.
+ */
 import { ChatBubble } from "./chat-bubble";
 import type { ChatVariant } from "./chat-types";
 

--- a/packages/ui/src/components/composites/chat/permission-card.helpers.ts
+++ b/packages/ui/src/components/composites/chat/permission-card.helpers.ts
@@ -1,3 +1,10 @@
+/**
+ * Non-JSX support for the in-chat permission card: display labels per permission
+ * id, default/parse helpers for permission state and feature refs, a client-side
+ * `IPermissionsRegistry` implementation backed by an injected permission client,
+ * and a parser that recovers a structured permission request from agent text.
+ * Consumed by permission-card.tsx.
+ */
 import {
   type IPermissionsRegistry,
   isPermissionId,

--- a/packages/ui/src/components/composites/chat/permission-card.tsx
+++ b/packages/ui/src/components/composites/chat/permission-card.tsx
@@ -1,3 +1,12 @@
+/**
+ * In-chat card the agent renders when an action needs an OS permission
+ * (reminders, screen-recording, …): explains why, requests it through the
+ * injected permissions registry, tracks the resulting state, and offers a
+ * fallback or an open-settings path when the permission is denied. When no
+ * registry is supplied it renders a passive not-determined state so it still
+ * shows in stories/tests. Label copy and helpers live in
+ * permission-card.helpers.
+ */
 import {
   type IPermissionsRegistry,
   openPermissionSettings,

--- a/packages/ui/src/components/composites/form-field/form-field.tsx
+++ b/packages/ui/src/components/composites/form-field/form-field.tsx
@@ -1,3 +1,8 @@
+/**
+ * Labeled form-field wrapper: composes the `Field` primitives (label,
+ * description, control slot, error messages) with a density option, so form
+ * rows across the app share one spacing/label layout.
+ */
 import type * as React from "react";
 import { cn } from "../../../lib/utils";
 import {

--- a/packages/ui/src/components/composites/index.ts
+++ b/packages/ui/src/components/composites/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Barrel for the composites layer — higher-level pieces (chat, sidebar,
+ * page-panel, search, skills, trajectories, form-field) plus the handful of
+ * base `ui/` primitives re-exported here for convenience.
+ */
 export * from "../ui/admin-dialog";
 export * from "../ui/banner";
 export * from "../ui/code-block";

--- a/packages/ui/src/components/composites/page-panel/page-panel-types.ts
+++ b/packages/ui/src/components/composites/page-panel/page-panel-types.ts
@@ -1,3 +1,8 @@
+/**
+ * Shared prop and variant types for the page-panel composite (root, header,
+ * toolbar, empty/loading states, meta pill). The single source the page-panel
+ * pieces import their contracts from.
+ */
 import type * as React from "react";
 
 import type { EmptyStateProps } from "../../ui/empty-state";

--- a/packages/ui/src/components/composites/sidebar/index.ts
+++ b/packages/ui/src/components/composites/sidebar/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the sidebar composite: shell root, body regions, and item primitives. */
 export * from "./nav-active";
 export * from "./sidebar-body";
 export * from "./sidebar-collapsed-rail";

--- a/packages/ui/src/components/composites/sidebar/sidebar-auto-rail.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-auto-rail.tsx
@@ -1,3 +1,11 @@
+/**
+ * Derives the collapsed sidebar rail's icon buttons from the expanded sidebar's
+ * own items, so the two stay in sync without the caller declaring the rail
+ * twice. `buildSidebarAutoRailItems` walks the React children tree;
+ * `buildSidebarAutoRailItemsFromDom` reads an already-mounted DOM subtree
+ * (the fallback when children aren't statically inspectable). Consumed by the
+ * sidebar root when it renders the collapsed variant.
+ */
 import * as React from "react";
 
 import { SegmentedControl } from "../../ui/segmented-control";

--- a/packages/ui/src/components/composites/sidebar/sidebar-body.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-body.tsx
@@ -1,3 +1,7 @@
+/**
+ * Scroll/flex column that wraps a sidebar's header + content between the shell
+ * frame and the resize edge, carrying the expand/collapse crossfade transition.
+ */
 import * as React from "react";
 import { cn } from "../../../lib/utils";
 import type { SidebarBodyProps } from "./sidebar-types";

--- a/packages/ui/src/components/composites/sidebar/sidebar-collapsed-rail.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-collapsed-rail.tsx
@@ -1,3 +1,8 @@
+/**
+ * The narrow icon-only strip shown when a sidebar is collapsed: a primary
+ * action slot above a scrollable column of icon buttons. Used by the sidebar
+ * root when it renders the rail built by sidebar-auto-rail.
+ */
 import type * as React from "react";
 
 import { cn } from "../../../lib/utils";

--- a/packages/ui/src/components/composites/sidebar/sidebar-content.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-content.tsx
@@ -1,3 +1,11 @@
+/**
+ * The primitive parts a sidebar body is composed from: section labels/headers,
+ * empty/notice states, toolbars, and the row primitives (item, icon, body,
+ * title, description, action) plus the collapsed-rail item variant. Each part
+ * is exported individually and bundled under the `SidebarContent` namespace
+ * object so callers can write `SidebarContent.Item`; higher-level pieces
+ * (skill-sidebar-item, the sidebar root) build on these.
+ */
 import * as React from "react";
 
 import { cn } from "../../../lib/utils";

--- a/packages/ui/src/components/composites/sidebar/sidebar-header-stack.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-header-stack.tsx
@@ -1,3 +1,7 @@
+/**
+ * Vertically-spaced container for a sidebar header's stacked rows, carrying the
+ * expand/collapse transition. The bare layout primitive under `SidebarHeader`.
+ */
 import { cn } from "../../../lib/utils";
 import type { SidebarHeaderStackProps } from "./sidebar-types";
 

--- a/packages/ui/src/components/composites/sidebar/sidebar-header.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-header.tsx
@@ -1,3 +1,7 @@
+/**
+ * Sidebar header row: an optional search box above caller-supplied header
+ * children, laid out on a `SidebarHeaderStack`.
+ */
 import type * as React from "react";
 
 import type { SidebarSearchBarProps } from "../search";

--- a/packages/ui/src/components/composites/sidebar/sidebar-panel.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-panel.tsx
@@ -1,3 +1,7 @@
+/**
+ * Inset panel surface for grouped sidebar content, with default/mobile/game-modal
+ * skins. Sits inside the sidebar body to visually bracket a section of items.
+ */
 import { cva } from "class-variance-authority";
 // biome-ignore lint/correctness/noUnusedImports: Required for this package's JSX transform in tests.
 import * as React from "react";

--- a/packages/ui/src/components/composites/sidebar/sidebar-root.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-root.tsx
@@ -1,3 +1,11 @@
+/**
+ * Top-level `Sidebar` shell: the resizable/collapsible outer frame that hosts a
+ * sidebar body across desktop, mobile, and game-modal variants. Owns the
+ * expand/collapse control, drag-to-resize width persistence, and the
+ * auto-generated collapsed rail (built from the body's items via
+ * sidebar-auto-rail). Body content is composed from the sidebar-content
+ * primitives; layout tokens live in sidebar-types.
+ */
 import { cva } from "class-variance-authority";
 import { PanelLeftClose, PanelLeftOpen, X } from "lucide-react";
 import * as React from "react";

--- a/packages/ui/src/components/composites/sidebar/sidebar-scroll-region.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-scroll-region.tsx
@@ -1,3 +1,7 @@
+/**
+ * The scrolling region of a sidebar body — the overflow container that holds the
+ * item list with a custom scrollbar and stable gutter, per variant.
+ */
 import { cva } from "class-variance-authority";
 // biome-ignore lint/correctness/noUnusedImports: Required for this package's JSX transform in tests.
 import * as React from "react";

--- a/packages/ui/src/components/composites/skills/index.ts
+++ b/packages/ui/src/components/composites/skills/index.ts
@@ -1,1 +1,2 @@
+/** Barrel for the skills sidebar composites. */
 export * from "./skill-sidebar-item";

--- a/packages/ui/src/components/composites/skills/skill-sidebar-item.tsx
+++ b/packages/ui/src/components/composites/skills/skill-sidebar-item.tsx
@@ -1,3 +1,8 @@
+/**
+ * One skill row in a skills sidebar: icon, name/description, and an on/off state
+ * badge with an optional attention pill. Built from the sidebar-content item
+ * primitives so it matches other sidebar rows.
+ */
 import type * as React from "react";
 
 import { SidebarContent } from "../sidebar";


### PR DESCRIPTION
Comments-only slice of #12234 — chunk **b04-composites-a**, shard 0 of 2 (even-index files; disjoint from the sibling shard).

**Subtree:** `packages/ui/src/components/composites/` — the composites layer of the `@elizaos/ui` design system (chat, sidebar, page-panel, form-field, skills, code, trajectories).

**Coverage:** Added a top-of-file prose header to every in-scope non-story file that lacked one, per the root `CLAUDE.md` header convention (one `/** … */` prose block at the very top; first sentence states what the file does in system terms). Files touched:

- **chat:** `chat-composer.tsx`, `chat-composer-shell.tsx`, `chat-message.tsx`, `chat-message-actions.tsx`, `chat-source.helpers.ts`, `chat-types.ts`, `chat-typing-indicator.tsx`, `permission-card.tsx`, `permission-card.helpers.ts`
- **chat (test headers, 1–3 lines):** `ChatEmptyStateWithRecommendations.test.tsx`, `ContinuousChatToggle.test.tsx`, `chat-conversation-item.test.tsx`, `chat-message.suggestion.test.tsx`, `chat-source.test.tsx`, `chat-transcript.memoization.test.tsx`
- **sidebar:** `sidebar-root.tsx`, `sidebar-content.tsx`, `sidebar-auto-rail.tsx`, `sidebar-body.tsx`, `sidebar-collapsed-rail.tsx`, `sidebar-header.tsx`, `sidebar-header-stack.tsx`, `sidebar-panel.tsx`, `sidebar-scroll-region.tsx`
- **skills:** `skill-sidebar-item.tsx`
- **misc:** `chat-search-hint.tsx`, `form-field/form-field.tsx`, `page-panel/page-panel-types.ts`
- **barrels (1-line):** `composites/index.ts`, `sidebar/index.ts`, `skills/index.ts`

**Left as-is (already at the bar):** `OwnerBadge.tsx`, `ChatVoiceStatusBar.tsx`, `code/DiffReviewPanel.tsx`, `__e2e__/resize-handles.e2e.test.ts`.

**Deliberately not touched:** the `*.stories.tsx` Storybook fixtures — each already self-titles via its `title`/`component` meta, so a 1-line "stories for X" header would be pure restatement (the convention warns against blanket-commenting clear code).

**Zero functional diff:** `check:comment-only` passes — 31 source files changed, every code token byte-for-byte identical to `origin/develop`. 169 insertions, 0 deletions (purely additive comment headers).

Part of #12234.