### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-shell-b

### DIFF
--- a/packages/ui/src/components/shell/CommandPalette.tsx
+++ b/packages/ui/src/components/shell/CommandPalette.tsx
@@ -1,3 +1,18 @@
+/**
+ * Cmd/Ctrl+K command palette for the app shell: a search-as-you-type dialog
+ * that lists agent lifecycle actions (start/stop/restart), a clear-chat entry,
+ * a bug report, and a nav entry for every registered, user-visible GUI view —
+ * so it doubles as a complete cross-plugin launcher. Command construction lives
+ * in `buildCommands` (../../chat); this component owns the dialog, the query
+ * filter, keyboard navigation, and dispatch.
+ *
+ * The palette opens on the COMMAND_PALETTE_EVENT (desktop shortcut) or a
+ * Ctrl/Meta+K keydown in the browser; view switches route through the shared
+ * `eliza:navigate:view` dispatcher and report VIEW_SWITCHED so the proactive
+ * decider sees the same signal a manual nav produces. Visible-view gating
+ * mirrors the view catalog, so hidden developer/preview views never leak.
+ */
+
 import {
   type KeyboardEvent as ReactKeyboardEvent,
   useCallback,

--- a/packages/ui/src/components/shell/PairingCommandHint.tsx
+++ b/packages/ui/src/components/shell/PairingCommandHint.tsx
@@ -1,3 +1,12 @@
+/**
+ * Pairing-code helper card for the startup/pairing flow: shows the copyable
+ * shell command(s) that mint a one-time pairing code on the agent host. For a
+ * loopback URL it shows just the on-server `curl`; for a remote URL it also
+ * offers the wrapped `ssh` form and hints where to substitute the real SSH
+ * target. Command strings come from `buildPairingCodeCommandInfo`
+ * (./pairing-command); this only renders and handles clipboard copy.
+ */
+
 import { Copy, Server } from "lucide-react";
 import { useMemo } from "react";
 import { useAppSelector } from "../../state";

--- a/packages/ui/src/components/shell/ShellControllerContext.hooks.ts
+++ b/packages/ui/src/components/shell/ShellControllerContext.hooks.ts
@@ -1,3 +1,5 @@
+/** React context + accessor for the shared shell controller (useShellController). */
+
 import * as React from "react";
 
 import type { ShellController } from "./useShellController";

--- a/packages/ui/src/components/shell/ShellHeaderControls.tsx
+++ b/packages/ui/src/components/shell/ShellHeaderControls.tsx
@@ -1,3 +1,16 @@
+/**
+ * The shell header's right-hand control cluster: theme + language toggles, a
+ * desktop/mobile shell-view segmented control, voice mute, new-chat, and save.
+ * Purely presentational — the parent passes every value and handler in and this
+ * only renders the buttons and lays them out (centered vs split) per surface.
+ *
+ * Exports the shared header-button class + inline style
+ * (`HEADER_ICON_BUTTON_CLASSNAME`, `HEADER_BUTTON_STYLE`) so header extras
+ * injected by the host match these controls exactly. All hover is neutral →
+ * neutral-with-opacity; selection is a single accent-tinted fill (no borders,
+ * no gradients, no orange→black).
+ */
+
 import {
   Check,
   Loader2,

--- a/packages/ui/src/components/shell/StartupFailureView.tsx
+++ b/packages/ui/src/components/shell/StartupFailureView.tsx
@@ -1,3 +1,11 @@
+/**
+ * Terminal-state screen shown when startup can't reach the main shell: names the
+ * failure reason (backend timeout/unreachable, agent timeout/error, missing
+ * asset, unknown), offers a retry, and — where a bug reporter is mounted —
+ * pre-fills a startup bug report from the error + captured logs. One of the
+ * `StartupShell` views; rendered by `StartupShell` when `view.kind === "error"`.
+ */
+
 import { AlertCircle } from "lucide-react";
 import { useBranding } from "../../config/branding";
 import { type BugReportDraft, useOptionalBugReport } from "../../hooks";

--- a/packages/ui/src/components/shell/StartupScreen.tsx
+++ b/packages/ui/src/components/shell/StartupScreen.tsx
@@ -1,3 +1,10 @@
+/**
+ * Live entry point for the startup splash: resolves the current
+ * `StartupShellView` from the startup-shell controller and renders `StartupShell`
+ * with it, wiring the retry handler. The stateful counterpart to the pure
+ * `StartupShell`, which takes its view as a prop.
+ */
+
 import { useStartupShellController } from "../../state/use-startup-shell-controller";
 import { StartupShell } from "./StartupShell";
 

--- a/packages/ui/src/components/shell/TrayLauncher.test.tsx
+++ b/packages/ui/src/components/shell/TrayLauncher.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+//
+// TrayLauncher: one row per desktop launcher entry, and a click dispatches
+// TRAY_ACTION_EVENT with that row's itemId (the shared tray-handling path).
+// Deterministic jsdom render via testing-library — no desktop bridge, no runtime.
 
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.catalog-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.catalog-stub.ts
@@ -1,3 +1,6 @@
+// Stub for the view catalog in the home-screen e2e: reports a single static
+// "weather" app entry (with a generated hero SVG) so gated home tiles render
+// deterministically without hitting the live catalog service.
 import { generateViewHeroSvgFor } from "@elizaos/shared";
 
 const WEATHER_HERO = `data:image/svg+xml,${encodeURIComponent(

--- a/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
@@ -1,4 +1,7 @@
 // @vitest-environment jsdom
+//
+// HomePill rendering + phase→interaction wiring (label, mark, open/close on
+// click). Deterministic jsdom render via testing-library — no runtime, no model.
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/shell/pairing-command.ts
+++ b/packages/ui/src/components/shell/pairing-command.ts
@@ -1,3 +1,11 @@
+/**
+ * Builds the shell commands that mint a one-time pairing code on the agent host,
+ * derived from the app's remote URL. Pure string logic behind
+ * `PairingCommandHint`: parses the URL for host/port, always emits the on-server
+ * `curl`, and — for a non-loopback host — an `ssh`-wrapped form plus the SSH
+ * target to edit. A bare/loopback/unparseable URL yields the local-only form.
+ */
+
 const DEFAULT_PAIRING_PORT = "2138";
 const PAIRING_CODE_PATH = "/api/auth/pair-code";
 const PLACEHOLDER_SSH_TARGET = "user@your-server";

--- a/packages/ui/src/components/shell/startup-shell-types.ts
+++ b/packages/ui/src/components/shell/startup-shell-types.ts
@@ -1,3 +1,5 @@
+/** Shared view/prop types for the startup shell (StartupScreen ↔ StartupShell). */
+
 import type { StartupErrorState } from "../../state/types";
 
 export type StartupShellView =


### PR DESCRIPTION
Comments-only slice of #12234 (chunk b04-shell-b, shard 1 of 2).

**Subtree:** `packages/ui/src/components/shell/`

**What changed:** Added top-of-file prose headers to shell files that lacked any
purpose statement, plus 1-3 line headers to test/stub files. Files already
carrying a thorough JSDoc on their exported symbol (e.g. `AssistantOverlay`,
`CloudHandoffBanner`, `ContinuousChatOverlay`, `HomeScreen`, `NotificationCenter`,
`HomeLauncherSurface`, `DefaultHomeWidgets`, `SlashCommandMenu`, `KioskViewCanvas`)
were left untouched — that JSDoc-on-the-symbol pattern is the package's existing
"at the bar" house style.

**Files touched (11):**
- `CommandPalette.tsx` — palette/launcher purpose header
- `ShellHeaderControls.tsx` — header control-cluster purpose + exported-class note
- `StartupFailureView.tsx` — startup failure-screen header
- `StartupScreen.tsx` — live-entry-point header (pure `StartupShell` counterpart)
- `PairingCommandHint.tsx` — pairing-code card header
- `pairing-command.ts` — pure command-builder header
- `startup-shell-types.ts` — 1-line shared-types header
- `ShellControllerContext.hooks.ts` — 1-line context/accessor header
- `__e2e__/home-screen-fixture.catalog-stub.ts` — stub header
- `__tests__/HomePill.test.tsx` — test header (surface + jsdom harness)
- `TrayLauncher.test.tsx` — test header (surface + jsdom harness)

**Coverage:** This shard's remaining in-scope files already carry proper headers
and were left as-is.

**Verification:** `node scripts/assert-comment-only-diff.mjs` → OK, 11 files
changed, every code token identical to origin/develop. Zero functional diff.

Part of #12234.