### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-composites-b

### DIFF
--- a/packages/ui/src/components/composites/OwnerBadge.test.tsx
+++ b/packages/ui/src/components/composites/OwnerBadge.test.tsx
@@ -1,5 +1,9 @@
 // @vitest-environment jsdom
-
+/**
+ * Renders OwnerBadge in jsdom (real component, no model/network) to assert the
+ * crown shows only when isOwner, the inline/overlay/card variants, tooltip, and
+ * test-id passthrough.
+ */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/packages/ui/src/components/composites/chat/ChatEmptyStateWithRecommendations.tsx
+++ b/packages/ui/src/components/composites/chat/ChatEmptyStateWithRecommendations.tsx
@@ -1,3 +1,8 @@
+/**
+ * Chat empty-state that offers tappable recommendation chips; tapping a chip
+ * loads its prompt into the composer via {@link useChatPrefill}. Rendered by
+ * the chat surface when a conversation has no messages yet.
+ */
 import type { LucideIcon } from "lucide-react";
 import { useChatPrefill } from "../../../hooks/useChatPrefill";
 import { cn } from "../../../lib/utils";

--- a/packages/ui/src/components/composites/chat/ChatVoiceStatusBar.test.tsx
+++ b/packages/ui/src/components/composites/chat/ChatVoiceStatusBar.test.tsx
@@ -1,5 +1,9 @@
 // @vitest-environment jsdom
-
+/**
+ * Renders ChatVoiceStatusBar in jsdom (real component, no live voice pipeline)
+ * to assert visibility gating, status dot/label, interim transcript, the OWNER
+ * crown on matching entityId, and the traffic-light latency badge tones.
+ */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/ui/src/components/composites/chat/chat-attachment-strip.tsx
+++ b/packages/ui/src/components/composites/chat/chat-attachment-strip.tsx
@@ -1,3 +1,8 @@
+/**
+ * Horizontal strip of pending attachment thumbnails shown above the chat
+ * composer, each with a remove control. Image items render a preview tile;
+ * audio/video/document items render a labelled icon tile.
+ */
 import { FileText, Film, Music } from "lucide-react";
 import type * as React from "react";
 import { Button } from "../../ui/button";

--- a/packages/ui/src/components/composites/chat/chat-bubble.tsx
+++ b/packages/ui/src/components/composites/chat/chat-bubble.tsx
@@ -1,3 +1,8 @@
+/**
+ * Message bubble surface for a single chat line, toned for assistant vs user.
+ * When a connector `source` is set it draws a source-colored outline so
+ * cross-channel messages stay visually distinct without a repeated text badge.
+ */
 import type * as React from "react";
 
 import { cn } from "../../../lib/utils";

--- a/packages/ui/src/components/composites/chat/chat-composer-shell.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer-shell.test.tsx
@@ -1,5 +1,8 @@
 // @vitest-environment jsdom
-
+/**
+ * Renders ChatComposerShell in jsdom to lock its flex layout: the default
+ * composer must not collapse when placed inside a flex chat column.
+ */
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { ChatComposerShell } from "./chat-composer-shell";

--- a/packages/ui/src/components/composites/chat/chat-composer.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer.test.tsx
@@ -1,5 +1,8 @@
 // @vitest-environment jsdom
-
+/**
+ * Renders ChatComposer in jsdom (real component, mocked voice state) to cover
+ * its input/send/mic wiring and ref forwarding without a live voice pipeline.
+ */
 import { cleanup, render, screen } from "@testing-library/react";
 import { type ComponentProps, createRef } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/composites/chat/chat-conversation-item.tsx
+++ b/packages/ui/src/components/composites/chat/chat-conversation-item.tsx
@@ -1,3 +1,9 @@
+/**
+ * One conversation row in the chat sidebar: title (truncated with tooltip when
+ * clipped), rename/delete actions, and active-state styling. On touch devices
+ * the row's action menu opens via press-and-hold; click suppression keeps a
+ * completed long-press from also firing the row's select handler.
+ */
 import { MoreHorizontal, PencilLine, X } from "lucide-react";
 import type React from "react";
 import { memo, useCallback, useLayoutEffect, useRef, useState } from "react";

--- a/packages/ui/src/components/composites/chat/chat-conversation-rename-dialog.tsx
+++ b/packages/ui/src/components/composites/chat/chat-conversation-rename-dialog.tsx
@@ -1,3 +1,8 @@
+/**
+ * Modal dialog for renaming a chat conversation, with an optional "suggest a
+ * title" affordance backed by the caller's `onSuggest` handler. The parent
+ * owns the draft value and open state; this component is purely controlled.
+ */
 import { Sparkles } from "lucide-react";
 
 import { Button } from "../../ui/button";

--- a/packages/ui/src/components/composites/chat/chat-empty-state.tsx
+++ b/packages/ui/src/components/composites/chat/chat-empty-state.tsx
@@ -1,3 +1,8 @@
+/**
+ * Bare "no messages yet" placeholder for a chat pane: an agent glyph, a hint,
+ * and an optional call-to-action. The recommendation-chip variant lives in
+ * ChatEmptyStateWithRecommendations; this is the minimal form.
+ */
 import type * as React from "react";
 import { cn } from "../../../lib/utils";
 import { Button } from "../../ui/button";

--- a/packages/ui/src/components/composites/chat/chat-message.voice-speaker.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.voice-speaker.test.tsx
@@ -1,5 +1,9 @@
 // @vitest-environment jsdom
-
+/**
+ * Renders ChatMessage in jsdom to assert voice-speaker surfacing: the speaker
+ * badge appears only when a distinct speaker name is present, the owner gets a
+ * crown, and assistant messages never show the badge.
+ */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/packages/ui/src/components/composites/chat/chat-source.tsx
+++ b/packages/ui/src/components/composites/chat/chat-source.tsx
@@ -1,3 +1,8 @@
+/**
+ * Small connector-source glyph (iMessage, Telegram, Discord, voice, owner…)
+ * shown on a chat line, plus voice-speaker labelling. Source metadata and key
+ * normalization come from chat-source.helpers so icon and bubble outline agree.
+ */
 import { Crown, Mic } from "lucide-react";
 
 import { cn } from "../../../lib/utils";

--- a/packages/ui/src/components/composites/chat/chat-thread-layout.tsx
+++ b/packages/ui/src/components/composites/chat/chat-thread-layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Layout scaffold for a chat thread: a scrolling messages region above a fixed
+ * composer, with a footer stack slot. Reserves bottom space equal to
+ * `composerHeight` so the last message never hides behind the composer, and
+ * carries the game-modal spacing variant. Consumed by ChatView.
+ */
 import * as React from "react";
 
 import { cn } from "../../../lib/utils";

--- a/packages/ui/src/components/composites/chat/chat-transcript.tsx
+++ b/packages/ui/src/components/composites/chat/chat-transcript.tsx
@@ -1,3 +1,10 @@
+/**
+ * Renders the ordered list of chat messages, keying rows by stable message id
+ * and wrapping each in memoized ChatMessage so streaming a token into the last
+ * row re-renders only that row (perf lock in chat-transcript.render-count.test).
+ * Supports carryover (faded prior-turn) messages and proactive suggestion
+ * bubbles with accept/dismiss handlers.
+ */
 import type * as React from "react";
 
 import { memo, useEffect, useMemo, useRef } from "react";

--- a/packages/ui/src/components/composites/chat/index.ts
+++ b/packages/ui/src/components/composites/chat/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the chat composite parts (bubble, transcript, composer, sidebar rows, permission card). */
 export * from "./ChatEmptyStateWithRecommendations";
 export * from "./chat-attachment-strip";
 export * from "./chat-bubble";

--- a/packages/ui/src/components/composites/chat/permission-card.render.tsx
+++ b/packages/ui/src/components/composites/chat/permission-card.render.tsx
@@ -1,3 +1,8 @@
+/**
+ * Bridges a parsed permission-request payload to a rendered PermissionCard,
+ * returning null when the payload's permission id is unknown so callers can
+ * inline-render permission prompts detected in message text without guarding.
+ */
 import { isPermissionId } from "@elizaos/shared";
 import type * as React from "react";
 

--- a/packages/ui/src/components/composites/chat/permission-card.test.tsx
+++ b/packages/ui/src/components/composites/chat/permission-card.test.tsx
@@ -1,5 +1,9 @@
 // @vitest-environment jsdom
-
+/**
+ * Renders PermissionCard in jsdom against a stub permissions registry to cover
+ * each permission state (not-determined/granted/denied/restricted) and its CTA:
+ * request, open-settings, coming-soon, unavailable, and auto-collapse on grant.
+ */
 import type {
   IPermissionsRegistry,
   PermissionId,

--- a/packages/ui/src/components/composites/code/DiffReviewPanel.test.tsx
+++ b/packages/ui/src/components/composites/code/DiffReviewPanel.test.tsx
@@ -1,5 +1,9 @@
 // @vitest-environment jsdom
-
+/**
+ * Renders DiffReviewPanel in jsdom over ChangeSetData fixtures to cover empty
+ * states, per-file collapsible sections, added/removed line classification, and
+ * the truncation warning.
+ */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import type { ChangeSetData } from "../../../api/client-types-cloud";

--- a/packages/ui/src/components/composites/page-panel/index.ts
+++ b/packages/ui/src/components/composites/page-panel/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Barrel for the page-panel surface. Re-exports every sub-part and assembles
+ * the compound `PagePanel` (Root + Header/Frame/ContentArea/Empty/Loading/…)
+ * that view pages use as their standard content chrome.
+ */
 import { PagePanelCollapsibleSection } from "./page-panel-collapsible-section";
 import { PageEmptyState } from "./page-panel-empty";
 import { PagePanelFeatureEmpty } from "./page-panel-feature-empty";

--- a/packages/ui/src/components/composites/page-panel/page-panel-collapsible-section.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-collapsible-section.tsx
@@ -1,3 +1,9 @@
+/**
+ * A page-panel section that expands/collapses a body under its header, usable
+ * controlled (`expanded`) or uncontrolled (`defaultExpanded`). Clicks on the
+ * header action slot never toggle the section, and the whole collapsed surface
+ * can act as the expand trigger when `expandOnCollapsedSurfaceClick` is set.
+ */
 import * as React from "react";
 
 import { cn } from "../../../lib/utils";

--- a/packages/ui/src/components/composites/page-panel/page-panel-empty.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-empty.tsx
@@ -1,3 +1,7 @@
+/**
+ * Generic "nothing here yet" state for a page panel: wraps the primitive
+ * EmptyState in a PagePanelRoot so the placeholder inherits panel spacing.
+ */
 import { cn } from "../../../lib/utils";
 import { EmptyState } from "../../ui/empty-state";
 import { PagePanelRoot } from "./page-panel-root";

--- a/packages/ui/src/components/composites/page-panel/page-panel-feature-empty.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-feature-empty.tsx
@@ -1,3 +1,8 @@
+/**
+ * Empty-state for a feature page: a lead icon, title, and description over a
+ * list of feature bullets (each with its own icon). Shown when a feature has
+ * no data yet, to preview what it will offer.
+ */
 import type { ComponentType, HTMLAttributes, ReactNode } from "react";
 import { cn } from "../../../lib/utils";
 import { PagePanelRoot } from "./page-panel-root";

--- a/packages/ui/src/components/composites/page-panel/page-panel-frame.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-frame.tsx
@@ -1,3 +1,8 @@
+/**
+ * Full-height flex frame for a page and its scrollable content column:
+ * `PagePanelFrame` is the outer full-bleed container, `PagePanelContentArea`
+ * the scrolling main column inside it.
+ */
 import * as React from "react";
 
 import { cn } from "../../../lib/utils";

--- a/packages/ui/src/components/composites/page-panel/page-panel-header.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-header.tsx
@@ -1,3 +1,8 @@
+/**
+ * Header building blocks for a page panel: PanelHeader (heading + description +
+ * actions row), plus the small trim pieces — MetaPill, PageActionRail,
+ * PanelNotice, and SummaryCard — composed by pages via the PagePanel compound.
+ */
 import { cn } from "../../../lib/utils";
 import type {
   MetaPillProps,

--- a/packages/ui/src/components/composites/page-panel/page-panel-loading.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-loading.tsx
@@ -1,3 +1,7 @@
+/**
+ * Loading placeholder for a page panel: a centered spinner with optional
+ * heading/description, wrapped in a PagePanelRoot for consistent panel spacing.
+ */
 import { cn } from "../../../lib/utils";
 import { Spinner } from "../../ui/spinner";
 import { PagePanelRoot } from "./page-panel-root";

--- a/packages/ui/src/components/composites/page-panel/page-panel-root.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-root.tsx
@@ -1,3 +1,9 @@
+/**
+ * Base container element every page-panel part builds on, mapping the `variant`
+ * prop (surface/workspace/section/padded/shell) to layout classes over a shared
+ * transparent surface. Polymorphic via `as`; the rest of the panel chrome
+ * composes on top of it.
+ */
 import * as React from "react";
 
 import { cn } from "../../../lib/utils";

--- a/packages/ui/src/components/composites/page-panel/page-panel-toolbar.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-toolbar.tsx
@@ -1,3 +1,7 @@
+/**
+ * Wrapping action bar for a page panel — a flex row of controls (filters,
+ * buttons, search) laid out above the panel body.
+ */
 import * as React from "react";
 
 import { cn } from "../../../lib/utils";

--- a/packages/ui/src/components/composites/search/searchbar.tsx
+++ b/packages/ui/src/components/composites/search/searchbar.tsx
@@ -1,3 +1,8 @@
+/**
+ * Text search input with a leading magnifier and a trailing clear button that
+ * appears once there is a value; can show a loading spinner in place of the
+ * icon. Used for filter fields inside sidebars (e.g. the chat conversation list).
+ */
 import { Search, X } from "lucide-react";
 import * as React from "react";
 import { cn } from "../../../lib/utils";

--- a/packages/ui/src/components/composites/sidebar/sidebar-types.ts
+++ b/packages/ui/src/components/composites/sidebar/sidebar-types.ts
@@ -1,3 +1,8 @@
+/**
+ * Shared prop and variant types for the sidebar composite parts (root, header,
+ * body, content, panel, rails). Kept separate so components import contracts
+ * without cross-importing each other's modules.
+ */
 import type * as React from "react";
 
 export type SidebarVariant = "default" | "game-modal" | "mobile";

--- a/packages/ui/src/components/composites/trajectories/index.ts
+++ b/packages/ui/src/components/composites/trajectories/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the trajectory-viewer composites (agent run inspection panels). */
 export * from "./trajectory-cache-stats";
 export * from "./trajectory-code-block";
 export * from "./trajectory-context-diff-list";

--- a/packages/ui/src/components/composites/trajectories/trajectory-cache-stats.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-cache-stats.tsx
@@ -1,3 +1,8 @@
+/**
+ * Trajectory-viewer panel listing prompt-cache metrics (hits, tokens saved,
+ * etc.) for one agent run. Presentational: the parent formats and passes the
+ * metric rows; renders an empty-state when none were captured.
+ */
 import type * as React from "react";
 
 import { PagePanel } from "../page-panel";

--- a/packages/ui/src/components/composites/trajectories/trajectory-code-block.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-code-block.tsx
@@ -1,3 +1,8 @@
+/**
+ * Labelled, copyable code block used across the trajectory viewer for prompt
+ * and response payloads. Collapses to a preview past 20 lines with an
+ * expand/collapse toggle and a copy-to-clipboard button.
+ */
 import * as React from "react";
 
 import { Button } from "../../ui/button";

--- a/packages/ui/src/components/composites/trajectories/trajectory-context-diff-list.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-context-diff-list.tsx
@@ -1,3 +1,8 @@
+/**
+ * Trajectory-viewer panel summarizing per-step context diffs (items added,
+ * removed, changed, and token delta) across an agent run. Presentational; shows
+ * an empty-state when the trajectory carries no diff data.
+ */
 import {
   Activity,
   type LucideIcon,

--- a/packages/ui/src/components/composites/trajectories/trajectory-event-timeline.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-event-timeline.tsx
@@ -1,3 +1,8 @@
+/**
+ * Vertical timeline of trajectory events (per stage), each with a status glyph
+ * (queued/running/success/failure/skipped/info), label, and timestamp. The
+ * parent supplies formatted events; this renders the ordered list.
+ */
 import { CheckCircle, Circle, Clock3, XCircle } from "lucide-react";
 import type * as React from "react";
 

--- a/packages/ui/src/components/composites/trajectories/trajectory-llm-call-card.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-llm-call-card.tsx
@@ -1,3 +1,8 @@
+/**
+ * Expandable card for one LLM call within a trajectory: model, latency, and
+ * token metrics up top, then the system/input prompts and response rendered as
+ * copyable TrajectoryCodeBlocks. The system prompt collapses independently.
+ */
 import { ChevronDown, ChevronRight } from "lucide-react";
 import * as React from "react";
 

--- a/packages/ui/src/components/composites/trajectories/trajectory-sidebar-item.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-sidebar-item.tsx
@@ -1,3 +1,8 @@
+/**
+ * One selectable row in the trajectory list sidebar: source label, status and
+ * source color dots, call count, and duration. Selecting it drives which run
+ * the trajectory viewer shows.
+ */
 import type * as React from "react";
 
 import { SidebarContent } from "../sidebar";


### PR DESCRIPTION
Comments-only slice of #12234 (chunk `b04-composites-b`, shard 1 of 2).

**Subtree:** `packages/ui/src/components/composites` (chat, page-panel, trajectories, search, sidebar, code).

**What changed:** added top-of-file prose headers to composite modules that lacked one, and 1-3 line intent headers to their jsdom render tests. No code tokens touched — `scripts/assert-comment-only-diff.mjs` confirms the code token stream is byte-for-byte unchanged (36 files, comments only).

**Coverage:** headers added to the weight-bearing components/tests/barrels/type files in this shard (chat bubble/transcript/composer-shell/conversation-item/rename-dialog/empty-state/source/thread-layout, ChatEmptyStateWithRecommendations, chat-attachment-strip, permission-card.render, page-panel root/frame/header/toolbar/loading/empty/feature-empty/collapsible-section + barrel, trajectory cache-stats/code-block/context-diff-list/event-timeline/llm-call-card/sidebar-item + barrel, searchbar, sidebar-types, and the OwnerBadge/ChatVoiceStatusBar/chat-composer/permission-card/DiffReviewPanel/voice-speaker render tests). Already-at-bar files (`ContinuousChatToggle.tsx`, `trajectory-pipeline-graph.tsx`, `nav-active.ts`, self-documenting `.stories.tsx`, trivial single-line barrels, and tests that already carry headers) were left untouched.

**Verification:** `node scripts/assert-comment-only-diff.mjs` → OK, 36 files, comments only.

Part of #12234.