### PR TITLE
fix(#12319): add Stage 2 training numerics gates

### DIFF
--- a/.github/issue-evidence/12216-stage2-finite-loss-guard/README.md
+++ b/.github/issue-evidence/12216-stage2-finite-loss-guard/README.md
@@ -15,6 +15,11 @@ Slice covered here:
 - Extends CPU-only registry/default-merge tests so the per-tier clip is
   explicit, large tiers do not inherit HF defaults accidentally, and an
   explicit `--max-grad-norm` still wins over the registry.
+- Adds a post-finetune checkpoint finite-tensor scan in `run_pipeline.py`.
+  A checkpoint containing NaN/Inf tensors now aborts before benchmark,
+  quantization, or publish stages.
+- Extends finite-guard tests with tiny local checkpoint shards covering finite
+  checkpoints, non-finite tensors, and missing tensor-shard failures.
 
 Verification run from repo root:
 
@@ -42,6 +47,16 @@ python3 -m py_compile \
   packages/training/scripts/training/model_registry.py \
   packages/training/scripts/training/test_model_registry.py \
   packages/training/scripts/test_train_local_low_vram_smoke.py
+# exit 0
+
+python3 -m pytest packages/training/scripts/training/test_finite_guard.py \
+  -q -k 'finite_loss or finite_weights or callback or checkpoint_scan'
+# 8 passed, 2 skipped
+
+python3 -m py_compile \
+  packages/training/scripts/run_pipeline.py \
+  packages/training/scripts/training/instrumentation.py \
+  packages/training/scripts/training/test_finite_guard.py
 # exit 0
 ```
 

--- a/.github/issue-evidence/12216-stage2-finite-loss-guard/README.md
+++ b/.github/issue-evidence/12216-stage2-finite-loss-guard/README.md
@@ -22,6 +22,9 @@ Slice covered here:
   checkpoints, non-finite tensors, and missing tensor-shard failures.
 - Threads registry-owned `train_dtype` through `train_local.py` and fails loud
   for unsupported future dtype declarations instead of silently training bf16.
+- Adds a Liger architecture allowlist gate: the validated `gemma4` path can use
+  fused kernels, unsupported archs disable in auto mode, and explicit
+  `--use-liger on` fails loud for unsupported / `gemma4_unified` configs.
 
 Verification run from repo root:
 
@@ -42,7 +45,7 @@ git diff --check
 python3 -m pytest \
   packages/training/scripts/training/test_model_registry.py \
   packages/training/scripts/test_train_local_low_vram_smoke.py -q
-# 40 passed
+# 44 passed
 
 python3 -m py_compile \
   packages/training/scripts/train_local.py \

--- a/.github/issue-evidence/12216-stage2-finite-loss-guard/README.md
+++ b/.github/issue-evidence/12216-stage2-finite-loss-guard/README.md
@@ -9,6 +9,12 @@ Slice covered here:
   hard-fail when the loss tensor contains NaN or Inf.
 - Extends CPU-only finite-guard tests to cover finite scalar loss, NaN scalar
   loss, and mixed finite/Inf/NaN vector loss.
+- Adds a registry-owned `max_grad_norm` per Gemma 4 tier and wires it through
+  `train_local.py` into TRL's `SFTConfig`, with tighter clipping on the
+  12B/31B tiers.
+- Extends CPU-only registry/default-merge tests so the per-tier clip is
+  explicit, large tiers do not inherit HF defaults accidentally, and an
+  explicit `--max-grad-norm` still wins over the registry.
 
 Verification run from repo root:
 
@@ -24,6 +30,18 @@ python3 -m py_compile \
 # exit 0
 
 git diff --check
+# exit 0
+
+python3 -m pytest \
+  packages/training/scripts/training/test_model_registry.py \
+  packages/training/scripts/test_train_local_low_vram_smoke.py -q
+# 37 passed
+
+python3 -m py_compile \
+  packages/training/scripts/train_local.py \
+  packages/training/scripts/training/model_registry.py \
+  packages/training/scripts/training/test_model_registry.py \
+  packages/training/scripts/test_train_local_low_vram_smoke.py
 # exit 0
 ```
 

--- a/.github/issue-evidence/12216-stage2-finite-loss-guard/README.md
+++ b/.github/issue-evidence/12216-stage2-finite-loss-guard/README.md
@@ -20,6 +20,8 @@ Slice covered here:
   quantization, or publish stages.
 - Extends finite-guard tests with tiny local checkpoint shards covering finite
   checkpoints, non-finite tensors, and missing tensor-shard failures.
+- Threads registry-owned `train_dtype` through `train_local.py` and fails loud
+  for unsupported future dtype declarations instead of silently training bf16.
 
 Verification run from repo root:
 
@@ -40,7 +42,7 @@ git diff --check
 python3 -m pytest \
   packages/training/scripts/training/test_model_registry.py \
   packages/training/scripts/test_train_local_low_vram_smoke.py -q
-# 37 passed
+# 40 passed
 
 python3 -m py_compile \
   packages/training/scripts/train_local.py \

--- a/packages/training/scripts/run_pipeline.py
+++ b/packages/training/scripts/run_pipeline.py
@@ -61,6 +61,7 @@ sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "scripts"))
 
 from training.model_registry import get as registry_get  # noqa: E402
+from training.instrumentation import assert_finite_checkpoint  # noqa: E402
 from benchmarks.eliza1_gates import apply_gates, normalize_tier  # noqa: E402
 
 logging.basicConfig(level=logging.INFO,
@@ -597,6 +598,34 @@ def main() -> int:
             log.error("finetune failed; aborting")
             (bench_dir / "pipeline-summary.json").write_text(json.dumps(summary, indent=2))
             return 1
+
+    # Hard numerics gate: a trainer can exit zero even after producing NaN/Inf
+    # weights. Scan the saved HF checkpoint before any benchmark, quantize, or
+    # publish stage consumes it.
+    if finetuned_model.exists():
+        try:
+            summary["stages"]["checkpoint_finite_scan"] = assert_finite_checkpoint(
+                finetuned_model
+            )
+            log.info("checkpoint finite scan passed: %s", finetuned_model)
+        except RuntimeError as e:
+            log.error("checkpoint finite scan failed: %s", e)
+            summary["stages"]["checkpoint_finite_scan"] = {
+                "checkpoint": str(finetuned_model),
+                "passed": False,
+                "error": str(e),
+            }
+            (bench_dir / "pipeline-summary.json").write_text(json.dumps(summary, indent=2))
+            return 1
+    elif not args.skip_finetune:
+        log.error("finetune reported success but checkpoint is missing: %s", finetuned_model)
+        summary["stages"]["checkpoint_finite_scan"] = {
+            "checkpoint": str(finetuned_model),
+            "passed": False,
+            "error": "checkpoint missing",
+        }
+        (bench_dir / "pipeline-summary.json").write_text(json.dumps(summary, indent=2))
+        return 1
 
     # ───────────── stage 3: fine-tuned benchmark ──────────────────────
     if not args.skip_bench:

--- a/packages/training/scripts/test_train_local_low_vram_smoke.py
+++ b/packages/training/scripts/test_train_local_low_vram_smoke.py
@@ -98,8 +98,20 @@ def test_no_low_vram_smoke_leaves_registry_defaults_alone() -> None:
     assert args.batch_size == 1
     assert args.grad_accum == 16  # same as preset, coincidence at 2B
     assert args.memory_budget_gb == pytest.approx(15.5)
+    assert args.max_grad_norm == pytest.approx(1.0)
     assert args.max_samples == 0
     assert args.epochs == 3.0
+
+
+def test_large_registry_tier_sets_tighter_grad_clip() -> None:
+    """The 12B/31B tiers must not silently inherit HF's global clip default."""
+    args = _resolve(["--registry-key", "gemma4-12b"])
+    assert args.max_grad_norm == pytest.approx(0.5)
+
+
+def test_explicit_max_grad_norm_wins_over_registry() -> None:
+    args = _resolve(["--registry-key", "gemma4-12b", "--max-grad-norm", "0.25"])
+    assert args.max_grad_norm == pytest.approx(0.25)
 
 
 def test_low_vram_smoke_flag_lives_on_train_local_parser() -> None:
@@ -128,6 +140,7 @@ def test_low_vram_smoke_flag_lives_on_train_local_parser() -> None:
         ("--batch-size", "4", "batch_size", 4),
         ("--grad-accum", "8", "grad_accum", 8),
         ("--max-seq-len", "4096", "max_seq_len", 4096),
+        ("--max-grad-norm", "1.0", "max_grad_norm", 1.0),
     ],
 )
 def test_low_vram_smoke_respects_explicit_default_equal_value(

--- a/packages/training/scripts/test_train_local_low_vram_smoke.py
+++ b/packages/training/scripts/test_train_local_low_vram_smoke.py
@@ -99,6 +99,7 @@ def test_no_low_vram_smoke_leaves_registry_defaults_alone() -> None:
     assert args.grad_accum == 16  # same as preset, coincidence at 2B
     assert args.memory_budget_gb == pytest.approx(15.5)
     assert args.max_grad_norm == pytest.approx(1.0)
+    assert args.train_dtype == "bf16"
     assert args.max_samples == 0
     assert args.epochs == 3.0
 
@@ -112,6 +113,16 @@ def test_large_registry_tier_sets_tighter_grad_clip() -> None:
 def test_explicit_max_grad_norm_wins_over_registry() -> None:
     args = _resolve(["--registry-key", "gemma4-12b", "--max-grad-norm", "0.25"])
     assert args.max_grad_norm == pytest.approx(0.25)
+
+
+def test_explicit_train_dtype_wins_when_supported() -> None:
+    args = _resolve(["--registry-key", "gemma4-12b", "--train-dtype", "bf16"])
+    assert args.train_dtype == "bf16"
+
+
+def test_unsupported_train_dtype_fails_loud() -> None:
+    with pytest.raises(SystemExit, match="not implemented"):
+        _resolve(["--registry-key", "gemma4-e2b", "--train-dtype", "fp16"])
 
 
 def test_low_vram_smoke_flag_lives_on_train_local_parser() -> None:

--- a/packages/training/scripts/test_train_local_low_vram_smoke.py
+++ b/packages/training/scripts/test_train_local_low_vram_smoke.py
@@ -125,6 +125,44 @@ def test_unsupported_train_dtype_fails_loud() -> None:
         _resolve(["--registry-key", "gemma4-e2b", "--train-dtype", "fp16"])
 
 
+def test_liger_arch_gate_allows_validated_gemma4() -> None:
+    assert train_local.resolve_liger_arch_gate(
+        use_liger=True,
+        requested_mode="auto",
+        model_type="gemma4",
+        architectures=["Gemma4ForCausalLM"],
+    ) is True
+
+
+def test_liger_arch_gate_disables_unsupported_auto() -> None:
+    assert train_local.resolve_liger_arch_gate(
+        use_liger=True,
+        requested_mode="auto",
+        model_type="qwen3",
+        architectures=["Qwen3ForCausalLM"],
+    ) is False
+
+
+def test_liger_arch_gate_fails_loud_for_requested_unsupported() -> None:
+    with pytest.raises(SystemExit, match="not allowlisted"):
+        train_local.resolve_liger_arch_gate(
+            use_liger=True,
+            requested_mode="on",
+            model_type="qwen3",
+            architectures=["Qwen3ForCausalLM"],
+        )
+
+
+def test_liger_arch_gate_fails_loud_for_requested_gemma4_unified() -> None:
+    with pytest.raises(SystemExit, match="gemma4_unified"):
+        train_local.resolve_liger_arch_gate(
+            use_liger=True,
+            requested_mode="on",
+            model_type="gemma4_unified",
+            architectures=["Gemma4UnifiedForCausalLM"],
+        )
+
+
 def test_low_vram_smoke_flag_lives_on_train_local_parser() -> None:
     """The flag must actually exist on the real parser. Catches the
     regression where someone removes the option but leaves the override

--- a/packages/training/scripts/train_local.py
+++ b/packages/training/scripts/train_local.py
@@ -257,6 +257,7 @@ def build_dataset(
 _TRACKED_DESTS = (
     "model", "batch_size", "grad_accum", "max_seq_len", "optimizer",
     "apollo_rank", "max_samples", "epochs", "memory_budget_gb",
+    "max_grad_norm",
 )
 
 _FALLBACK_DEFAULTS: dict[str, Any] = {
@@ -268,6 +269,7 @@ _FALLBACK_DEFAULTS: dict[str, Any] = {
     "apollo_rank": 256,
     "max_samples": 0,
     "epochs": 3.0,
+    "max_grad_norm": 1.0,
     # memory_budget_gb intentionally stays None — downstream treats None
     # as "no enforcement", matching the original behavior.
 }
@@ -317,6 +319,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     ap.add_argument("--batch-size", type=int, default=None)
     ap.add_argument("--grad-accum", type=int, default=None)
+    ap.add_argument(
+        "--max-grad-norm", type=float, default=None,
+        help="Gradient clipping norm forwarded to TRL SFTConfig. Default "
+             "None falls back to the registry tier value, or 1.0 when no "
+             "registry key is set. Pass 0 to disable HF Trainer clipping."
+    )
     ap.add_argument("--lr", type=float, default=2e-4)
     ap.add_argument(
         "--max-seq-len", type=int, default=None,
@@ -442,9 +450,12 @@ def apply_resolved_defaults(args: argparse.Namespace) -> None:
             args.apollo_rank = entry.optimizer_rank
         if not user_passed["memory_budget_gb"]:
             args.memory_budget_gb = entry.train_mem_gb_budget
-        log.info("registry %s → model=%s batch=%d accum=%d seq=%d optimizer=%s budget=%.0fGB",
+        if not user_passed["max_grad_norm"]:
+            args.max_grad_norm = entry.max_grad_norm
+        log.info("registry %s → model=%s batch=%d accum=%d seq=%d optimizer=%s budget=%.0fGB max_grad_norm=%.3g",
                  entry.short_name, args.model, args.batch_size, args.grad_accum,
-                 args.max_seq_len, args.optimizer, args.memory_budget_gb or 0)
+                 args.max_seq_len, args.optimizer, args.memory_budget_gb or 0,
+                 args.max_grad_norm)
 
     # --low-vram-smoke overrides applied AFTER the registry merge so the
     # preset wins regardless of which registry key was passed. The numbers
@@ -767,6 +778,7 @@ def main() -> int:
         per_device_train_batch_size=args.batch_size,
         per_device_eval_batch_size=max(1, args.batch_size // 2),
         gradient_accumulation_steps=args.grad_accum,
+        max_grad_norm=args.max_grad_norm,
         learning_rate=args.lr,
         lr_scheduler_type="cosine",
         warmup_ratio=0.03,

--- a/packages/training/scripts/train_local.py
+++ b/packages/training/scripts/train_local.py
@@ -260,6 +260,7 @@ _TRACKED_DESTS = (
     "max_grad_norm", "train_dtype",
 )
 _SUPPORTED_TRAIN_DTYPES = {"bf16"}
+_LIGER_SUPPORTED_MODEL_TYPES = {"gemma4"}
 
 _FALLBACK_DEFAULTS: dict[str, Any] = {
     "model": "google/gemma-4-E2B",
@@ -514,6 +515,39 @@ def apply_resolved_defaults(args: argparse.Namespace) -> None:
         )
 
 
+def resolve_liger_arch_gate(
+    *,
+    use_liger: bool,
+    requested_mode: str,
+    model_type: str,
+    architectures: list[str],
+) -> bool:
+    """Apply the Gemma 4 Liger allowlist after model config is loaded."""
+    if not use_liger:
+        return False
+    normalized_model_type = model_type.lower()
+    if (
+        "gemma4_unified" in normalized_model_type
+        or any("Gemma4Unified" in arch for arch in architectures)
+    ):
+        reason = (
+            "Liger kernel is not validated for gemma4_unified; fused kernels "
+            "can corrupt the 12B/31B forward and produce NaN checkpoints."
+        )
+    elif normalized_model_type not in _LIGER_SUPPORTED_MODEL_TYPES:
+        reason = (
+            f"Liger kernel is not allowlisted for model_type={model_type!r}. "
+            "Add an explicit validation before enabling fused kernels for this arch."
+        )
+    else:
+        return True
+
+    if requested_mode == "on":
+        raise SystemExit(f"--use-liger=on requested but {reason}")
+    log.warning("%s Disabling Liger for this run.", reason)
+    return False
+
+
 def main() -> int:
     args = build_parser().parse_args()
     apply_resolved_defaults(args)
@@ -691,25 +725,14 @@ def main() -> int:
         else:
             log.warning(msg)
         use_liger = False
-    # Liger has no validated gemma4_unified (dense 12B/31B) kernel path. Its
-    # fused RMSNorm/RoPE/CE assume the Gemma2/3 layer layout and silently
-    # corrupt the gemma4_unified forward — which adds per-layer q_norm/k_norm,
-    # a layer_scalar, and logit softcapping the Gemma3 kernels don't model — so
-    # the loss NaNs within the first optimizer steps and the saved checkpoint is
-    # all-NaN. Force Liger off for this arch (E2B/E4B "gemma4" stay on). The
-    # generic finite-weights guard (make_finite_weights_callback) is the second
-    # line of defense; this is the specific known-arch prevention.
     _model_type = str(getattr(model.config, "model_type", "")).lower()
     _arch_names = getattr(model.config, "architectures", None) or []
-    if use_liger and (
-        "gemma4_unified" in _model_type
-        or any("Gemma4Unified" in a for a in _arch_names)
-    ):
-        log.warning(
-            "Liger kernel disabled for gemma4_unified arch (no validated fused "
-            "kernel path; avoids NaN divergence in 12B/31B SFT)."
-        )
-        use_liger = False
+    use_liger = resolve_liger_arch_gate(
+        use_liger=use_liger,
+        requested_mode=args.use_liger,
+        model_type=_model_type,
+        architectures=list(_arch_names),
+    )
     if use_liger and device == "cuda":
         try:
             from liger_kernel.transformers import _apply_liger_kernel_to_instance

--- a/packages/training/scripts/train_local.py
+++ b/packages/training/scripts/train_local.py
@@ -257,8 +257,9 @@ def build_dataset(
 _TRACKED_DESTS = (
     "model", "batch_size", "grad_accum", "max_seq_len", "optimizer",
     "apollo_rank", "max_samples", "epochs", "memory_budget_gb",
-    "max_grad_norm",
+    "max_grad_norm", "train_dtype",
 )
+_SUPPORTED_TRAIN_DTYPES = {"bf16"}
 
 _FALLBACK_DEFAULTS: dict[str, Any] = {
     "model": "google/gemma-4-E2B",
@@ -270,6 +271,7 @@ _FALLBACK_DEFAULTS: dict[str, Any] = {
     "max_samples": 0,
     "epochs": 3.0,
     "max_grad_norm": 1.0,
+    "train_dtype": "bf16",
     # memory_budget_gb intentionally stays None — downstream treats None
     # as "no enforcement", matching the original behavior.
 }
@@ -324,6 +326,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Gradient clipping norm forwarded to TRL SFTConfig. Default "
              "None falls back to the registry tier value, or 1.0 when no "
              "registry key is set. Pass 0 to disable HF Trainer clipping."
+    )
+    ap.add_argument(
+        "--train-dtype", default=None,
+        help="Training dtype. Default None falls back to the registry tier "
+             "value, or bf16 when no registry key is set. Only bf16 is "
+             "implemented in this entrypoint; other values fail loud."
     )
     ap.add_argument("--lr", type=float, default=2e-4)
     ap.add_argument(
@@ -452,10 +460,12 @@ def apply_resolved_defaults(args: argparse.Namespace) -> None:
             args.memory_budget_gb = entry.train_mem_gb_budget
         if not user_passed["max_grad_norm"]:
             args.max_grad_norm = entry.max_grad_norm
-        log.info("registry %s → model=%s batch=%d accum=%d seq=%d optimizer=%s budget=%.0fGB max_grad_norm=%.3g",
+        if not user_passed["train_dtype"]:
+            args.train_dtype = entry.train_dtype
+        log.info("registry %s → model=%s batch=%d accum=%d seq=%d optimizer=%s budget=%.0fGB max_grad_norm=%.3g dtype=%s",
                  entry.short_name, args.model, args.batch_size, args.grad_accum,
                  args.max_seq_len, args.optimizer, args.memory_budget_gb or 0,
-                 args.max_grad_norm)
+                 args.max_grad_norm, args.train_dtype)
 
     # --low-vram-smoke overrides applied AFTER the registry merge so the
     # preset wins regardless of which registry key was passed. The numbers
@@ -486,6 +496,14 @@ def apply_resolved_defaults(args: argparse.Namespace) -> None:
     for dest, fallback in _FALLBACK_DEFAULTS.items():
         if getattr(args, dest) is None:
             setattr(args, dest, fallback)
+
+    if args.train_dtype not in _SUPPORTED_TRAIN_DTYPES:
+        raise SystemExit(
+            f"--train-dtype {args.train_dtype!r} is not implemented in "
+            "train_local.py. Supported dtype(s): "
+            + ", ".join(sorted(_SUPPORTED_TRAIN_DTYPES))
+            + ". Update the dtype path before changing the registry."
+        )
 
     if args.low_vram_smoke:
         log.info(
@@ -631,8 +649,9 @@ def main() -> int:
     # to its own GPU before FSDP shards, causing avoidable OOM risk.
     in_distributed = "RANK" in os.environ
     use_device_map = device == "cuda" and not in_distributed
-    # MPS supports bfloat16 on PyTorch 2.x; cpu falls back to float32
-    train_dtype = torch.bfloat16 if device in ("cuda", "mps") else torch.float32
+    # bf16 is the only implemented training dtype; CPU still loads fp32 so the
+    # preflight/test path does not pretend to exercise bf16 kernels.
+    train_dtype = torch.bfloat16 if args.train_dtype == "bf16" and device in ("cuda", "mps") else torch.float32
     model_kwargs = dict(
         torch_dtype=train_dtype,
         trust_remote_code=True,
@@ -783,7 +802,7 @@ def main() -> int:
         lr_scheduler_type="cosine",
         warmup_ratio=0.03,
         weight_decay=0.0,
-        bf16=device == "cuda",
+        bf16=args.train_dtype == "bf16" and device == "cuda",
         logging_steps=10,
         save_steps=500,
         save_total_limit=3,

--- a/packages/training/scripts/training/instrumentation.py
+++ b/packages/training/scripts/training/instrumentation.py
@@ -419,6 +419,97 @@ def assert_finite_loss(loss: Any, *, context: str = "training loss") -> None:
     )
 
 
+def _checkpoint_tensor_files(checkpoint_dir: Path) -> list[Path]:
+    patterns = ("*.safetensors", "*.bin", "*.pt", "*.pth")
+    return sorted(
+        path
+        for pattern in patterns
+        for path in checkpoint_dir.rglob(pattern)
+        if path.is_file()
+    )
+
+
+def _load_checkpoint_tensors(path: Path) -> dict[str, Any]:
+    if path.suffix == ".safetensors":
+        try:
+            from safetensors.torch import load_file
+        except ImportError as exc:
+            raise RuntimeError(
+                f"cannot scan {path}: safetensors is not installed"
+            ) from exc
+        return load_file(str(path), device="cpu")
+
+    import torch
+
+    try:
+        loaded = torch.load(path, map_location="cpu", weights_only=True)
+    except TypeError:
+        loaded = torch.load(path, map_location="cpu")
+    if isinstance(loaded, dict):
+        return loaded
+    return {"<root>": loaded}
+
+
+def assert_finite_checkpoint(
+    checkpoint_dir: Path | str,
+    *,
+    max_reported: int = 10,
+) -> dict[str, Any]:
+    """Scan a saved checkpoint directory and fail on any non-finite tensor.
+
+    This is the publish-blocking post-train gate for ``run_pipeline.py``:
+    even if a trainer process exits zero, a NaN/Inf tensor in the saved HF
+    checkpoint aborts before benchmark, quantization, or publish stages.
+    """
+    import torch
+
+    root = Path(checkpoint_dir)
+    if not root.is_dir():
+        raise RuntimeError(f"checkpoint finite scan target is not a directory: {root}")
+
+    files = _checkpoint_tensor_files(root)
+    if not files:
+        raise RuntimeError(
+            f"checkpoint finite scan found no tensor shards under {root}"
+        )
+
+    scanned_tensors = 0
+    offenders: list[str] = []
+    for file_path in files:
+        state = _load_checkpoint_tensors(file_path)
+        for name, tensor in state.items():
+            if not torch.is_tensor(tensor):
+                continue
+            scanned_tensors += 1
+            if torch.isfinite(tensor).all():
+                continue
+            finite = torch.isfinite(tensor)
+            bad_count = int((~finite).sum().item())
+            offenders.append(
+                f"{file_path.relative_to(root)}:{name} "
+                f"({bad_count}/{tensor.numel()} non-finite)"
+            )
+            if len(offenders) >= max_reported:
+                break
+        if len(offenders) >= max_reported:
+            break
+
+    if offenders:
+        raise RuntimeError(
+            "non-finite (NaN/Inf) checkpoint tensor(s): "
+            + "; ".join(offenders)
+            + (" …" if len(offenders) >= max_reported else "")
+            + ". Training diverged — aborting before benchmark, quantize, or publish."
+        )
+
+    return {
+        "checkpoint": str(root),
+        "tensor_files": len(files),
+        "tensors": scanned_tensors,
+        "passed": True,
+    }
+
+
 class FiniteWeightsCallback:
     """HF Trainer callback that hard-fails a divergent run.
 
@@ -475,6 +566,7 @@ __all__ = [
     "InstrumentationConfig",
     "MemorySnapshot",
     "assert_finite_loss",
+    "assert_finite_checkpoint",
     "assert_finite_step",
     "gpu_memory",
     "log_environment",

--- a/packages/training/scripts/training/model_registry.py
+++ b/packages/training/scripts/training/model_registry.py
@@ -98,6 +98,12 @@ class ModelEntry:
 
     micro_batch: int
     grad_accum: int
+    max_grad_norm: float
+    """Per-tier gradient clipping norm forwarded to TRL's ``SFTConfig``.
+
+    Larger Gemma 4 unified tiers get tighter clipping than the local tiers so
+    transient gradient spikes cannot silently rely on HF's global default.
+    """
 
     train_mem_gb_budget: float
     """Predicted peak GPU memory for training, world-aggregate across the FSDP
@@ -332,6 +338,7 @@ REGISTRY: dict[str, ModelEntry] = {
         optimizer_rank=1,
         micro_batch=1,
         grad_accum=16,
+        max_grad_norm=1.0,
         train_mem_gb_budget=15.5,
         train_dtype="bf16",
         infer_max_in=131072,
@@ -368,6 +375,7 @@ REGISTRY: dict[str, ModelEntry] = {
         optimizer_rank=1,
         micro_batch=1,
         grad_accum=16,
+        max_grad_norm=1.0,
         train_mem_gb_budget=28.0,
         train_dtype="bf16",
         infer_max_in=131072,
@@ -401,6 +409,7 @@ REGISTRY: dict[str, ModelEntry] = {
         optimizer_rank=512,
         micro_batch=2,
         grad_accum=8,
+        max_grad_norm=0.5,
         train_mem_gb_budget=80.0,
         train_dtype="bf16",
         # gemma4_unified (dense 12B/31B) has no validated Liger kernel path —
@@ -439,6 +448,7 @@ REGISTRY: dict[str, ModelEntry] = {
         optimizer_rank=512,
         micro_batch=1,
         grad_accum=8,
+        max_grad_norm=0.5,
         train_mem_gb_budget=210.0,
         train_dtype="bf16",
         # See gemma4-12b: gemma4_unified has no validated Liger path; keep it

--- a/packages/training/scripts/training/test_finite_guard.py
+++ b/packages/training/scripts/training/test_finite_guard.py
@@ -19,6 +19,7 @@ from torch import nn
 from scripts.training.instrumentation import (
     FiniteWeightsCallback,
     InstrumentationConfig,
+    assert_finite_checkpoint,
     assert_finite_loss,
     assert_finite_step,
     make_finite_weights_callback,
@@ -74,6 +75,39 @@ def test_raises_on_inf_loss_vector() -> None:
     loss = torch.tensor([0.1, float("inf"), float("nan")])
     with pytest.raises(RuntimeError, match="2/3 non-finite"):
         assert_finite_loss(loss, context="vector loss")
+
+
+def test_checkpoint_scan_passes_on_finite_torch_shard(tmp_path) -> None:
+    ckpt = tmp_path / "final"
+    ckpt.mkdir()
+    torch.save({"model.layers.0.weight": torch.ones(2, 3)}, ckpt / "pytorch_model.bin")
+
+    result = assert_finite_checkpoint(ckpt)
+
+    assert result["passed"] is True
+    assert result["tensor_files"] == 1
+    assert result["tensors"] == 1
+
+
+def test_checkpoint_scan_raises_on_non_finite_torch_shard(tmp_path) -> None:
+    ckpt = tmp_path / "final"
+    ckpt.mkdir()
+    torch.save(
+        {"model.layers.0.weight": torch.tensor([[1.0, float("nan")]])},
+        ckpt / "pytorch_model.bin",
+    )
+
+    with pytest.raises(RuntimeError, match="pytorch_model.bin:model.layers.0.weight"):
+        assert_finite_checkpoint(ckpt)
+
+
+def test_checkpoint_scan_requires_tensor_shards(tmp_path) -> None:
+    ckpt = tmp_path / "final"
+    ckpt.mkdir()
+    (ckpt / "config.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="no tensor shards"):
+        assert_finite_checkpoint(ckpt)
 
 
 def test_raises_on_nan_weight() -> None:

--- a/packages/training/scripts/training/test_model_registry.py
+++ b/packages/training/scripts/training/test_model_registry.py
@@ -240,3 +240,8 @@ def test_registry_owns_per_tier_grad_clip() -> None:
     assert get("gemma4-e4b").max_grad_norm == 1.0
     assert get("gemma4-12b").max_grad_norm == 0.5
     assert get("gemma4-31b").max_grad_norm == 0.5
+
+
+def test_registry_train_dtype_is_explicit_and_supported() -> None:
+    for key in VERIFIED_KEYS:
+        assert get(key).train_dtype == "bf16"

--- a/packages/training/scripts/training/test_model_registry.py
+++ b/packages/training/scripts/training/test_model_registry.py
@@ -228,3 +228,15 @@ def test_local_gemma4_tiers_keep_liger() -> None:
     rely on it for their seq_len budgets — they must stay enabled."""
     assert REGISTRY["gemma4-e2b"].use_liger is True
     assert REGISTRY["gemma4-e4b"].use_liger is True
+
+
+def test_registry_owns_per_tier_grad_clip() -> None:
+    """Stage 2 numerics guard: every tier must carry an explicit gradient
+    clipping norm instead of inheriting TRL/HF defaults by accident."""
+    for key in VERIFIED_KEYS:
+        assert get(key).max_grad_norm > 0
+
+    assert get("gemma4-e2b").max_grad_norm == 1.0
+    assert get("gemma4-e4b").max_grad_norm == 1.0
+    assert get("gemma4-12b").max_grad_norm == 0.5
+    assert get("gemma4-31b").max_grad_norm == 0.5


### PR DESCRIPTION
## Summary
- add registry-owned `max_grad_norm` for each Gemma 4 training tier
- merge `--max-grad-norm` through `train_local.py` and forward it to TRL `SFTConfig`
- add a hard post-finetune checkpoint finite-tensor scan in `run_pipeline.py` before benchmark, quantize, or publish
- thread registry-owned `train_dtype` through `train_local.py` and fail loud for unsupported dtype declarations
- gate Liger to the validated `gemma4` model type; unsupported archs disable in auto mode and fail loud when `--use-liger on` is requested
- cover registry/default merge behavior, Liger arch gating, and tiny local checkpoint finite/non-finite/missing-shard cases

## Evidence
- `python3 -m pytest packages/training/scripts/training/test_model_registry.py packages/training/scripts/test_train_local_low_vram_smoke.py -q` -> 44 passed
- `python3 -m py_compile packages/training/scripts/train_local.py packages/training/scripts/training/model_registry.py packages/training/scripts/training/test_model_registry.py packages/training/scripts/test_train_local_low_vram_smoke.py` -> exit 0
- `python3 -m pytest packages/training/scripts/training/test_finite_guard.py -q -k 'finite_loss or finite_weights or callback or checkpoint_scan'` -> 8 passed, 2 skipped
- `python3 -m py_compile packages/training/scripts/run_pipeline.py packages/training/scripts/training/instrumentation.py packages/training/scripts/training/test_finite_guard.py` -> exit 0
- `git diff --check` -> exit 0

The two skipped tests are the existing `transformers` callback-factory tests in this host Python environment: `transformers` requires `huggingface-hub>=0.23.2,<1.0`, but `huggingface-hub==1.15.0` is installed.

## Screenshots / Recordings
N/A: training-script numerics gates only; no UI, browser, native, or device surface.

Evidence file: `.github/issue-evidence/12216-stage2-finite-loss-guard/README.md`