### PR TITLE
docs(#12241): add research robot headers

### DIFF
--- a/packages/research/robot/build.ts
+++ b/packages/research/robot/build.ts
@@ -1,4 +1,11 @@
 #!/usr/bin/env bun
+/**
+ * Bun build entrypoint for the thin TypeScript surface of @elizaos/robot.
+ *
+ * Clears generated output, bundles the TS exports, emits declarations, and
+ * rewrites relative imports while the Python robotics stack remains unbundled.
+ */
+
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { externalsFromPackageJson } from "../../../plugins/plugin-build-externals.ts";

--- a/packages/research/robot/scripts/_retention_tournament_verify.workflow.js
+++ b/packages/research/robot/scripts/_retention_tournament_verify.workflow.js
@@ -1,3 +1,10 @@
+/**
+ * Multi-agent verification workflow for the Alberta retention tournament.
+ *
+ * Each verifier recomputes continual-learning metrics from raw benchmark JSON
+ * before the synthesis phase writes the retention/capacity comparison report.
+ */
+
 export const meta = {
   name: "alberta-retention-tournament-verify",
   description:

--- a/packages/research/robot/src/index.ts
+++ b/packages/research/robot/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Public TypeScript exports for the robot research package.
+ */
+
 export const ROBOT_PACKAGE_VERSION = "2.0.0-beta.0" as const;
 
 export * from "./types";

--- a/packages/research/robot/vitest.config.ts
+++ b/packages/research/robot/vitest.config.ts
@@ -1,3 +1,10 @@
+/**
+ * Vitest config for the robot package's thin TypeScript surface.
+ *
+ * Python and live robotics tests are excluded here; package scripts run those
+ * through the separate pytest lane.
+ */
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Adds purpose prose headers to the remaining headerless `packages/research/robot` source files in the B11 scope:

- `packages/research/robot/build.ts`
- `packages/research/robot/scripts/_retention_tournament_verify.workflow.js`
- `packages/research/robot/src/index.ts`
- `packages/research/robot/vitest.config.ts`

The churn-grep hit in `packages/research/chip/scripts/tee/verify_cove_quote_roundtrip.mjs` was reviewed and left unchanged because “signature no longer covers the mutated body” describes the current tamper-rejection invariant, not change narration.

## Verification

- `bun run check:comment-only` — PASS (`4 source file(s) changed; every code token identical to origin/develop`)
- `bun run --cwd packages/research/robot typecheck` — PASS
- `bunx @biomejs/biome check packages/research/robot/build.ts packages/research/robot/src/index.ts packages/research/robot/vitest.config.ts` — PASS
- `git diff --check` — PASS
- Header self-audit for the seven B11 `packages/research` source files — PASS (prints nothing)

Note: `_retention_tournament_verify.workflow.js` is a workflow DSL file with top-level `return`; generic Biome parse fails on that existing syntax, so it was excluded from the targeted Biome invocation. The comment-only guard covers it.

## Evidence

- Diffstat: `4 files changed, 25 insertions(+)`
- Real-LLM trajectories: N/A — comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- Screenshots/video/audio/device logs: N/A — no UI, audio, hardware, robotics runtime, or device behavior changed.
- Backend/frontend logs: N/A — no runtime path changed.
- Domain artifacts: N/A — robot/research comments only; no generated artifacts, model outputs, trajectories, or hardware state changed.
