### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-chat-a

### DIFF
--- a/packages/ui/src/components/chat/AccountConnectBlock.test.tsx
+++ b/packages/ui/src/components/chat/AccountConnectBlock.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// Render test for AccountConnectBlock: a provider row + Add-account button per
+// offered connector, the live per-provider account count, and opening the
+// AddAccountDialog on click. jsdom + Testing Library with the API client
+// (listAccounts) hoisted-mocked — no network.
 
 import {
   cleanup,

--- a/packages/ui/src/components/chat/ConnectorAccountPicker.tsx
+++ b/packages/ui/src/components/chat/ConnectorAccountPicker.tsx
@@ -1,3 +1,11 @@
+/**
+ * Dropdown that lets the user pick which connected connector account a chat
+ * message is sent "as" (e.g. which Telegram/X identity), plus connect/reconnect
+ * affordances for unusable accounts. Presentational and controlled: the caller
+ * owns the account list and selection and wires the connect/reconnect/select
+ * callbacks. Mounted in the chat composer via `useConnectorSendAsAccount`;
+ * account usability/status labels come from `./connector-send-as`.
+ */
 import { Check, ChevronDown, RefreshCw, UserRound } from "lucide-react";
 import type { ConnectorAccountRecord } from "../../api/client-agent";
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/chat/MessageContent.uispec-crash.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.uispec-crash.test.tsx
@@ -1,14 +1,12 @@
 // @vitest-environment jsdom
 //
-// Regression for the HIGH-severity demo-killer: a model-emitted UiSpec that is
-// malformed in a way the renderer can't fully normalize (element missing
-// `props`/`children`, or an array prop that isn't an array) used to throw out
-// of MessageUiSpecBlock — past every view boundary to the app ROOT error
-// screen. Because the offending message re-hydrates from conversation history,
-// "Try Again" and full restarts re-crashed it, bricking the app until the
-// conversation was cleared. The fix defaults missing props/children in
-// ElementRenderer and wraps the UiRenderer in an ErrorBoundary, so any residual
-// render throw is contained to the single widget with a "View JSON" fallback.
+// Regression guard: a malformed model-emitted UiSpec (element missing
+// `props`/`children`, or an array prop that isn't an array) must NOT throw out
+// of MessageUiSpecBlock and reach the app-root error screen — which would brick
+// the app, since the offending message re-hydrates from conversation history.
+// Asserts that ElementRenderer defaults missing props/children and the
+// UiRenderer's ErrorBoundary contains any residual render throw to the single
+// widget with a "View JSON" fallback. jsdom + Testing Library.
 
 import { cleanup, render, screen } from "@testing-library/react";
 import * as React from "react";

--- a/packages/ui/src/components/chat/TranscriptViewerOverlay.tsx
+++ b/packages/ui/src/components/chat/TranscriptViewerOverlay.tsx
@@ -1,3 +1,14 @@
+/**
+ * Full-screen overlay that opens a voice-transcript chat attachment: shows the
+ * per-speaker segments (or plain text), plays the recorded audio, and supports
+ * copy / download / share / inline edit / delete of the stored transcript record.
+ *
+ * The stored `transcriptId` is not always carried on the re-served attachment,
+ * so it is also embedded as a leading HTML comment in the transcript markdown
+ * (`TRANSCRIPT_MARKER`) that round-trips through the server's extracted `text`;
+ * the viewer strips it for display and uses it to persist edits. Mounted from a
+ * transcript attachment via `createPortal` at the shell-overlay z-layer.
+ */
 import type { TranscriptSegment } from "@elizaos/shared/transcripts";
 import { transcriptPlainText } from "@elizaos/shared/transcripts";
 import {

--- a/packages/ui/src/components/chat/connector-send-as.test.ts
+++ b/packages/ui/src/components/chat/connector-send-as.test.ts
@@ -1,3 +1,7 @@
+// Unit tests for the connector-send-as helpers (account usability, picker-show
+// gating, send-as metadata build/merge, account-required error detection).
+// Pure functions over fixture records — no model, no network.
+
 import { describe, expect, it } from "vitest";
 import type { ConnectorAccountRecord } from "../../api/client-agent";
 import {

--- a/packages/ui/src/components/chat/message-choice-parser.test.ts
+++ b/packages/ui/src/components/chat/message-choice-parser.test.ts
@@ -1,3 +1,7 @@
+// Unit tests for the `[CHOICE]` marker parser: option body parsing
+// (value=label, equals-in-label) and region detection. Pure functions over
+// string fixtures — no model, no render.
+
 import { describe, expect, it } from "vitest";
 import { findChoiceRegions, parseChoiceBody } from "./message-choice-parser";
 

--- a/packages/ui/src/components/chat/message-followups-parser.test.ts
+++ b/packages/ui/src/components/chat/message-followups-parser.test.ts
@@ -1,3 +1,7 @@
+// Unit tests for the `[FOLLOWUPS]` marker parser: chip body parsing (reply /
+// navigate / prompt kinds, defaulting, MAX_FOLLOWUPS cap) and region detection.
+// Pure functions over string fixtures — no model, no render.
+
 import { describe, expect, it } from "vitest";
 import {
   findFollowupsRegions,

--- a/packages/ui/src/components/chat/message-form-parser.test.ts
+++ b/packages/ui/src/components/chat/message-form-parser.test.ts
@@ -1,3 +1,7 @@
+// Unit tests for the `[FORM]` marker parser: JSON form-body parsing (mixed
+// field types, MAX_FORM_FIELDS cap, malformed input) and region detection.
+// Pure functions over string fixtures — no model, no render.
+
 import { describe, expect, it } from "vitest";
 import {
   findFormRegions,

--- a/packages/ui/src/components/chat/message-parser-code.test.ts
+++ b/packages/ui/src/components/chat/message-parser-code.test.ts
@@ -1,3 +1,7 @@
+// Unit tests for `parseSegments` code handling: lifting fenced code blocks into
+// code segments (with language) and splitting inline `code` spans out of prose.
+// Pure functions over string fixtures — no model, no render.
+
 import { describe, expect, it } from "vitest";
 import {
   conversationTranscriptText,

--- a/packages/ui/src/components/chat/message-parser-helpers.ts
+++ b/packages/ui/src/components/chat/message-parser-helpers.ts
@@ -1,3 +1,19 @@
+/**
+ * Canonical parser that turns a raw assistant/user message string into the
+ * ordered `Segment[]` the chat surfaces render: prose, fenced/inline code,
+ * `[CONFIG:…]` blocks, UiSpec JSON, JSONL patches, permission cards, hidden
+ * reasoning/tool tags, and any registry-driven inline widget
+ * (`[CHOICE]`/`[FOLLOWUPS]`/`[FORM]`/`[TASK]`/plugin markers). `parseSegments`
+ * is the single entry point both `MessageContent` (ChatView) and
+ * `InlineWidgetText` (ContinuousChatOverlay) delegate to, so the same agent
+ * output renders identically on every surface.
+ *
+ * The message string is UNTRUSTED agent output, so the patch/UiSpec path is the
+ * attack surface: `sanitizePatchValue` / `createSafeRecord` strip
+ * prototype-pollution keys (`__proto__`/`constructor`/`prototype`) and return
+ * null-prototype containers. See `message-parser-helpers.fuzz.test.ts` for the
+ * hardening invariants.
+ */
 import { stripAssistantStageDirections } from "@elizaos/shared";
 import type { ConversationMessage } from "../../api/client-types-chat";
 import type { PluginInfo } from "../../api/client-types-config";

--- a/packages/ui/src/components/chat/message-search/MessageSearchPanel.test.tsx
+++ b/packages/ui/src/components/chat/message-search/MessageSearchPanel.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// Render test for MessageSearchPanel: min-query gating, debounced search with
+// ranked snippet results, jump-to-result (closes the panel), empty/error
+// states, and Escape-to-close. jsdom + Testing Library with the search API
+// mocked — no network.
 
 import {
   cleanup,

--- a/packages/ui/src/components/chat/message-task-parser.test.ts
+++ b/packages/ui/src/components/chat/message-task-parser.test.ts
@@ -1,3 +1,7 @@
+// Unit tests for the `[TASK:<id>]<title>[/TASK]` marker parser: region
+// detection, id/title extraction, and the MAX_TASK_TITLE_LEN cap. Pure
+// functions over string fixtures — no model, no render.
+
 import { describe, expect, it } from "vitest";
 import { findTaskRegions, MAX_TASK_TITLE_LEN } from "./message-task-parser";
 

--- a/packages/ui/src/components/chat/widgets/automations.tsx
+++ b/packages/ui/src/components/chat/widgets/automations.tsx
@@ -1,11 +1,12 @@
+/**
+ * Home widget summarizing the automations the agent is actively running. The
+ * unified set (`useUnifiedTasks`) merges automations (GET /api/automations) with
+ * LifeOps scheduled items (GET /api/lifeops/scheduled-tasks) client-side — this
+ * widget is a read-only surface over that merge, never a second scheduler or a
+ * store mutation. Tapping navigates to the full Automations view.
+ */
 import { Workflow } from "lucide-react";
 import { useCallback } from "react";
-// Real wire types (READ, not guessed):
-//   - AutomationItem: packages/ui/src/api/client-types-config.ts
-//   - AutomationStatus = "active" | "paused" | "completed" | "draft" | "system"
-// The unified set merges automations (GET /api/automations) with LifeOps
-// scheduled items (GET /api/lifeops/scheduled-tasks) client-side — see
-// hooks/useUnifiedTasks.ts. No second scheduler, no store touch.
 import type { AutomationItem } from "../../../api/client-types-config";
 import { useUnifiedTasks } from "../../../hooks/useUnifiedTasks";
 import type { WidgetProps } from "../../../widgets/types";

--- a/packages/ui/src/components/chat/widgets/calendar-upcoming.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-upcoming.tsx
@@ -1,3 +1,11 @@
+/**
+ * Icon-first home Calendar widget: surfaces the single most imminent upcoming
+ * event with a tight relative-time meta ("in 45m") and self-hides when nothing
+ * is near. Polls the calendar feed only while the document is visible and the
+ * session is authenticated, and publishes a home-attention weight so the tile
+ * rises on the home grid when an event is imminent. Registered as
+ * `CALENDAR_HOME_WIDGET`; tapping navigates to the full calendar surface.
+ */
 import { CalendarClock } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { client } from "../../../api";

--- a/packages/ui/src/components/chat/widgets/health-sleep.tsx
+++ b/packages/ui/src/components/chat/widgets/health-sleep.tsx
@@ -1,3 +1,10 @@
+/**
+ * Icon-first home Sleep widget: shows last night's sleep duration plus an
+ * "Irregular" status badge when the rhythm is off, and self-hides when the
+ * sleep pattern is healthy or there is no episode yet. Polls the health sleep
+ * feed only while the document is visible and the session is authenticated.
+ * Registered as `HEALTH_HOME_WIDGET`; tapping navigates to the health surface.
+ */
 import { Moon } from "lucide-react";
 import type { ComponentType } from "react";
 import { useCallback, useEffect, useState } from "react";

--- a/packages/ui/src/components/chat/widgets/music-player.helpers.ts
+++ b/packages/ui/src/components/chat/widgets/music-player.helpers.ts
@@ -1,3 +1,4 @@
+/** Chat-sidebar widget-registry definition for the music player (id, order, component). */
 import { MusicPlayerSidebarWidget } from "./music-player";
 import type { ChatSidebarWidgetDefinition } from "./types";
 

--- a/packages/ui/src/components/chat/widgets/music-player.tsx
+++ b/packages/ui/src/components/chat/widgets/music-player.tsx
@@ -1,3 +1,11 @@
+/**
+ * Chat-sidebar Music widget: polls `/music-player/status` (only while the
+ * document is visible and the session is authenticated) and renders the
+ * currently-streaming track with play/pause controls backed by a single
+ * `<audio>` element. Renders an empty state when nothing is streaming so the
+ * right rail stays quiet. Registered via `MUSIC_PLAYER_WIDGET` in
+ * `music-player.helpers.ts`.
+ */
 import { Music, Pause, Play, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { fetchWithCsrf } from "../../../api/csrf-client";

--- a/packages/ui/src/components/chat/widgets/topic-grouped-transcript.test.tsx
+++ b/packages/ui/src/components/chat/widgets/topic-grouped-transcript.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+//
+// Render test for TopicGroupedTranscript: empty state, per-group header with
+// message count, expand/collapse of a group's preview lines, and the
+// collapsed-state toggle callback. jsdom + Testing Library over fixture groups.
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/chat/widgets/types.ts
+++ b/packages/ui/src/components/chat/widgets/types.ts
@@ -1,3 +1,4 @@
+/** Props + registration shape for chat-sidebar / home-slot widgets. */
 import type { ComponentType } from "react";
 import type { PluginInfo } from "../../../api";
 import type { ActivityEvent } from "../../../hooks/useActivityEvents";

--- a/packages/ui/src/components/chat/widgets/use-inline-widget-context.ts
+++ b/packages/ui/src/components/chat/widgets/use-inline-widget-context.ts
@@ -5,9 +5,8 @@
  * `InlineWidgetContext` from THIS hook, so a CHOICE pick, a FOLLOWUPS chip, and
  * a FORM submit behave identically no matter where the reply is rendered.
  *
- * The two surfaces previously each defined these four handlers inline, byte for
- * byte the same. Two copies of one contract is a drift hazard (the issue's #1
- * surface-parity risk, #9304), unify them here.
+ * Keeping the four handlers single-sourced here avoids duplicating one contract
+ * across the two surfaces, which would be a surface-parity drift hazard (#9304).
  *
  * Callers pass the already-subscribed store setters rather than re-subscribing,
  * because `MessageContent` reads `sendActionMessage`/`setChatInput` for other


### PR DESCRIPTION
Comments-only slice of #12234, chunk `b04-chat-a` (shard 0 of 2).

**Subtree:** `packages/ui/src/components/chat` (+ `widgets/`, `message-search/`).

**What changed (comments only — `check:comment-only` passes, code token stream byte-for-byte unchanged vs `origin/develop`):**

- Added top-of-file prose headers to in-scope files that lacked one:
  - Components: `ConnectorAccountPicker.tsx`, `TranscriptViewerOverlay.tsx`, `widgets/automations.tsx`, `widgets/calendar-upcoming.tsx`, `widgets/health-sleep.tsx`, `widgets/music-player.tsx`.
  - Modules/types: `message-parser-helpers.ts` (canonical parser), `widgets/types.ts`, `widgets/music-player.helpers.ts`.
  - Tests (1–3 line surface + harness realness): `connector-send-as.test.ts`, `message-choice/followups/form/task-parser.test.ts`, `message-parser-code.test.ts`, `AccountConnectBlock.test.tsx`, `message-search/MessageSearchPanel.test.tsx`, `widgets/topic-grouped-transcript.test.tsx`.
- Rewrote churn/diff-narration headers into durable present-tense fact:
  - `widgets/use-inline-widget-context.ts` (dropped "previously each defined … byte for byte").
  - `MessageContent.uispec-crash.test.tsx` ("used to throw … the fix …" → present-tense regression-guard statement).
  - `widgets/automations.tsx` (folded the mid-import "READ, not guessed" note into a proper header).

**Coverage:** 20 files touched. Files already at the bar (good header on the export, or a story whose `meta` already names the component) were left untouched.

Verification: `node scripts/assert-comment-only-diff.mjs` → `OK — 20 source file(s) changed; every code token identical to origin/develop. Comments only.`

Part of #12234.