### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-shell-a

### DIFF
--- a/packages/ui/src/components/shell/BugReportModal.tsx
+++ b/packages/ui/src/components/shell/BugReportModal.tsx
@@ -1,3 +1,10 @@
+/**
+ * Bug-report dialog mounted in the shell overlay stack (ShellOverlays), gated on
+ * the shared `useBugReport` open state. Collects a structured report
+ * (description, repro, expected/actual, environment) and submits it via the API
+ * client. On the Electrobun desktop it can additionally attach local diagnostics
+ * — collected via `../../utils/desktop-bug-report` — and open the logs folder.
+ */
 import { ChevronRight } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../../api";

--- a/packages/ui/src/components/shell/ChatSurface.tsx
+++ b/packages/ui/src/components/shell/ChatSurface.tsx
@@ -1,3 +1,13 @@
+/**
+ * Presentational chat transcript + glass composer for the shell surfaces.
+ *
+ * Renders a scrollable list of `ShellMessage`s (via the shared ChatBubble /
+ * TypingIndicator composites) plus an input row with optional mic and VISION
+ * buttons. It owns only local draft + scroll state; message data, send, and
+ * capabilities arrive as props (driven by useShellController). Tail-following
+ * and the jump-to-latest control come from the one shared `useThreadAutoScroll`
+ * engine, not a local scroll handler.
+ */
 import { ArrowDown } from "lucide-react";
 import * as React from "react";
 

--- a/packages/ui/src/components/shell/ComputerUseApprovalOverlay.tsx
+++ b/packages/ui/src/components/shell/ComputerUseApprovalOverlay.tsx
@@ -1,3 +1,12 @@
+/**
+ * Approval prompt for pending computer-use (agent screen-control) actions,
+ * mounted in the shell overlay stack (ShellOverlays). Subscribes to the
+ * `/api/computer-use/approvals/stream` SSE feed (with a 1.5s polling fallback
+ * on native IPC bases where EventSource cannot reach) and lets the user approve
+ * or deny each request. Dormant until the shared auth snapshot reports
+ * authenticated — the shell mounts it before the auth probe resolves, so
+ * without that gate every unauthenticated tab would fire 401s (#11084).
+ */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { supportsFullAppShellRoutes } from "../../api/app-shell-capabilities";
 import { type ComputerUseApprovalSnapshot, client } from "../../api/client";

--- a/packages/ui/src/components/shell/ConnectionLostOverlay.tsx
+++ b/packages/ui/src/components/shell/ConnectionLostOverlay.tsx
@@ -1,3 +1,9 @@
+/**
+ * Full-screen blocking overlay shown when the backend connection has failed and
+ * realtime reconnect attempts are exhausted (`backendConnection.state` ===
+ * "failed" with `showDisconnectedUI`). Offers a restart affordance: relaunch the
+ * Electrobun desktop app when running under it, else reload the page.
+ */
 import { useState } from "react";
 import { isElectrobunRuntime } from "../../bridge";
 import { useAppSelectorShallow } from "../../state";

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// Core behavior of the floating chat overlay: the mic ↔ send composer swap,
+// draft persistence, thread rendering, back-intent/prefill events, and the
+// press-and-hold copy gesture. Renders the real overlay in jsdom with the API
+// client + clipboard mocked (no network).
 
 import {
   act,

--- a/packages/ui/src/components/shell/HomeLauncherSurface.test.tsx
+++ b/packages/ui/src/components/shell/HomeLauncherSurface.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// HomeLauncherSurface's Home ↔ Launcher paging: both pages stay mounted, flicks
+// and store navigation flip between them, and the fine-pointer rail edge buttons
+// hide on coarse pointers. Real component in jsdom with matchMedia stubbed to
+// simulate pointer capabilities.
 import {
   act,
   cleanup,

--- a/packages/ui/src/components/shell/NotificationCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationCenter.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// NotificationCenter list rendering and per-item actions (read / mark-all /
+// remove / clear) over the real notification store. The API client, WS event
+// feed, and desktop/native notification bridges are mocked; store ingestion uses
+// the real reducer via the test-only ingest helper.
 import type { AgentNotification } from "@elizaos/core";
 import {
   cleanup,

--- a/packages/ui/src/components/shell/PairingView.tsx
+++ b/packages/ui/src/components/shell/PairingView.tsx
@@ -1,3 +1,9 @@
+/**
+ * Full-screen gate shown when the backend requires a device-pairing code before
+ * the shell will connect. Reads pairing state (enabled, expiry, input, error,
+ * busy) from the app store and submits the entered code via
+ * `handlePairingSubmit`. Blocks the rest of the shell until pairing succeeds.
+ */
 import { client } from "../../api";
 import { appNameInterpolationVars, useBranding } from "../../config/branding";
 import { startFreshFirstRunReload } from "../../platform";

--- a/packages/ui/src/components/shell/RestartBanner.tsx
+++ b/packages/ui/src/components/shell/RestartBanner.tsx
@@ -1,3 +1,9 @@
+/**
+ * Bottom-right banner prompting the user to restart the agent when config
+ * changes have marked one pending. Mounted in the shell overlay stack; renders
+ * null unless `pendingRestart` is set and the banner hasn't been dismissed. Lists
+ * the pending reasons and offers "Restart now" (via `triggerRestart`) or "Later".
+ */
 import { useCallback, useState } from "react";
 import { useAppSelectorShallow } from "../../state";
 import { Button } from "../ui/button";

--- a/packages/ui/src/components/shell/ShellOverlays.tsx
+++ b/packages/ui/src/components/shell/ShellOverlays.tsx
@@ -1,3 +1,13 @@
+/**
+ * Aggregates the shell's floating overlays into one render slot: the dev perf
+ * HUD, command palette, restart banner, bug-report modal, computer-use approval
+ * overlay, keyboard-shortcuts overlay, and the transient action-notice toast.
+ *
+ * Also owns the share-target sink: drains any queued OS share payloads and
+ * subscribes to SHARE_TARGET_EVENT, routing shared text into the chat composer
+ * when the chat tab is active or surfacing it as a toast otherwise. Mounts the
+ * layout-shift + frame-budget monitors that feed the perf HUD.
+ */
 import { useEffect } from "react";
 import { SHARE_TARGET_EVENT } from "../../events";
 import { useFrameBudgetMonitor, useLayoutShiftMonitor } from "../../hooks";

--- a/packages/ui/src/components/shell/ShortcutsOverlay.tsx
+++ b/packages/ui/src/components/shell/ShortcutsOverlay.tsx
@@ -1,3 +1,8 @@
+/**
+ * Keyboard-shortcuts reference dialog mounted in the shell overlay stack. Toggles
+ * on Shift+? (ignored while typing in an input/textarea/select) and closes on
+ * Escape, and lists the `COMMON_SHORTCUTS` table with platform-formatted keys.
+ */
 import { useEffect, useState } from "react";
 import { reportShortcutFired } from "../../chat/useSlashCommandController";
 import { COMMON_SHORTCUTS } from "../../hooks";

--- a/packages/ui/src/components/shell/StartupFailureView.test.tsx
+++ b/packages/ui/src/components/shell/StartupFailureView.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+//
+// StartupFailureView recovery affordances per failure reason (e.g. an
+// unreachable saved backend offers a cloud-first reset). Real component in jsdom;
+// branding, bug-report, platform reload, and translation are mocked.
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/shell/StartupShell.test.tsx
+++ b/packages/ui/src/components/shell/StartupShell.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+//
+// StartupShell's view gating (loading vs failure vs pairing vs bootstrap) and
+// its splash-delay + first-paint telemetry mark. Child surfaces are stubbed so
+// only the shell's own gating runs; the telemetry module is real.
 
 import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.core-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.core-stub.ts
@@ -1,3 +1,6 @@
+// Stubs the @elizaos/core view helpers the home-screen e2e bundle reaches:
+// every seeded view counts as visible, and dedupeModalities just uniques the
+// list. Keeps the browser bundle off the full core graph.
 export function isViewVisible() {
   return true;
 }

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.platform-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.platform-stub.ts
@@ -1,3 +1,6 @@
+// Stubs platform-guards for the home-screen e2e: the fixture always runs as a
+// web/GUI surface, so pin the modality + platform instead of probing the (absent)
+// native bridge.
 export function getActiveViewModality() {
   return "gui";
 }

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.view-kinds-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.view-kinds-stub.ts
@@ -1,3 +1,6 @@
+// Stubs useViewKinds for the home-screen e2e: enable developer + preview kinds
+// so the launcher curation exercises the full view set without the live
+// preferences store.
 export function useEnabledViewKinds() {
   return { developer: true, preview: true };
 }

--- a/packages/ui/src/components/shell/__tests__/AssistantOverlay.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/AssistantOverlay.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+//
+// AssistantOverlay's phase gating: renders nothing while idle/booting and shows
+// its children once the shell phase reaches summoned/listening/responding. Real
+// component in jsdom.
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/shell/__tests__/ChatSurface.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/ChatSurface.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+//
+// ChatSurface presentation + send wiring: renders the greeting on an empty
+// thread, bubbles for prior messages, and gates the send button on non-empty
+// input (firing onSend with the trimmed text). Real component in jsdom.
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/shell/__tests__/shell-assistant-flow.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/shell-assistant-flow.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// End-to-end open→send→close flow across the shell trio (HomePill +
+// AssistantOverlay + ChatSurface) wired through a local phase/message harness:
+// open from the pill, send by button and Enter, keep real output visible, and
+// close with Escape/pill restoring focus. Real components in jsdom, no server.
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -1,4 +1,11 @@
 // @vitest-environment jsdom
+//
+// The shell controller hook end to end in jsdom: conversation load watchdog,
+// swipe interleaving (#9954), turnStatus derivation, voice-capture routing,
+// transcription mode, TTS reset on conversation change, mic-failure notices,
+// wake-word gating, and the no-provider path. The voice-capture factory, app
+// store, and voice-output hook are mocked; localStorage is backed by an
+// in-memory Storage so hands-free persistence is real.
 
 import { act, cleanup, renderHook } from "@testing-library/react";
 import {

--- a/packages/ui/src/components/shell/conversation-nav.ts
+++ b/packages/ui/src/components/shell/conversation-nav.ts
@@ -1,3 +1,9 @@
+/**
+ * Pure adjacent-conversation resolution for the chat overlay's horizontal swipe.
+ * The list is most-recent-first, so "prev" is the newer neighbor and "next" the
+ * older; useShellController wraps these into the `ConversationNav` the overlay
+ * consumes. No React, no state — just index math over the conversation list.
+ */
 import type { Conversation } from "../../api/client-types-chat";
 
 /** Adjacent-conversation navigation for the overlay's horizontal swipe. */

--- a/packages/ui/src/components/shell/pairing-command.test.ts
+++ b/packages/ui/src/components/shell/pairing-command.test.ts
@@ -1,3 +1,7 @@
+// Unit coverage for buildPairingCodeCommandInfo — the pure builder that turns a
+// backend URL into the pairing-code fetch command (SSH-wrapped for remote hosts,
+// bare for loopback, with the local agent port defaulted). Pure string math, no
+// harness.
 import { describe, expect, it } from "vitest";
 import { buildPairingCodeCommandInfo } from "./pairing-command";
 

--- a/packages/ui/src/components/shell/shell-state.test.ts
+++ b/packages/ui/src/components/shell/shell-state.test.ts
@@ -1,3 +1,7 @@
+// Unit coverage for selectVisibleShellMessages — the pure selector that windows
+// the rendered shell transcript (dropping empty turns except an in-flight
+// assistant turn while responding, capped at MAX_RENDERED_SHELL_MESSAGES).
+// Pure reducer/selector, no harness.
 import { describe, expect, it } from "vitest";
 import type { ShellMessage, ShellPhase } from "./shell-state";
 import {

--- a/packages/ui/src/components/shell/startup-shell-assets.test.ts
+++ b/packages/ui/src/components/shell/startup-shell-assets.test.ts
@@ -1,3 +1,6 @@
+// Source-grep guard: asserts StartupShell.tsx stays a pure pre-boot renderer —
+// free of app-state/API/bridge/voice behavior imports and of references to
+// removed legacy startup background images. Reads the file off disk; no render.
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/ui/src/components/shell/topic-grouping.test.ts
+++ b/packages/ui/src/components/shell/topic-grouping.test.ts
@@ -1,3 +1,7 @@
+// Unit coverage for the pure topic-clustering helpers (#8928): groupMessagesByTopic
+// segments a transcript by dominant topic (untagged messages extend the current
+// run, no fragmentation) and deriveChannelTopics ranks the channel's chips.
+// Pure functions, no harness.
 import { describe, expect, it } from "vitest";
 import {
   deriveChannelTopics,

--- a/packages/ui/src/components/shell/topic-views.test.tsx
+++ b/packages/ui/src/components/shell/topic-views.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+//
+// Rendering + interaction for the topic UI (#8928): TopicChipsBar renders a chip
+// per topic and reports selection (nothing when empty); TopicGroup collapses to a
+// count pill and expands on click. Real components in jsdom.
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/shell/use-notification-pull.test.ts
+++ b/packages/ui/src/components/shell/use-notification-pull.test.ts
@@ -1,3 +1,6 @@
+// Unit coverage for revealOffsetForTravel — the pure pull-to-reveal easing for
+// the notification pull gesture: clamps to 0 below zero travel, tracks 1:1 to a
+// soft cap, then rubber-bands (monotonic, diminishing). Pure math, no harness.
 import { describe, expect, it } from "vitest";
 import { revealOffsetForTravel } from "./use-notification-pull";
 

--- a/packages/ui/src/components/shell/usePromptSuggestions.test.ts
+++ b/packages/ui/src/components/shell/usePromptSuggestions.test.ts
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// The prompt-suggestion strip: the pure computePromptSuggestions fallback (always
+// 3, deduped, daypart-/page-aware) plus the usePromptSuggestions hook that fetches
+// model suggestions. The API client is mocked, so the hook exercises the static
+// fallback path in jsdom.
 
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -1,3 +1,18 @@
+/**
+ * The single stateful engine behind the shell's chat + voice surface, exposed as
+ * the `ShellController` returned by `useShellController`. It drives the shell
+ * phase (booting → summoned → listening → responding), the rendered message
+ * list, send + vision-capture, and the whole voice stack: mic capture (via the
+ * voice-capture factory), wake-word listening, end-of-turn aggregation,
+ * hands-free conversation looping, transcription-mode long-form recording, and
+ * spoken assistant output (through useShellVoiceOutput). Conversation switching
+ * and horizontal swipe navigation resolve through conversation-nav.
+ *
+ * ChatSurface / AssistantOverlay / ContinuousChatOverlay and the home surfaces
+ * are the consumers; they read the controller and render, holding no chat/voice
+ * state of their own. ShellControllerContext provides one instance so the pill
+ * and the overlay stay in lock-step without double-mounting this hook.
+ */
 import type { TranscriptSegment } from "@elizaos/shared/transcripts";
 import * as React from "react";
 import type {


### PR DESCRIPTION
Comments-only slice of #12234. `check:comment-only` passes — the code token stream is byte-for-byte unchanged vs `origin/develop` (159 insertions, 0 deletions, all comments).

**Subtree:** `packages/ui/src/components/shell` (shard 0 of 2 — disjoint from the sibling shard).

**Coverage:** Added top-of-file prose headers to the in-scope files that lacked one (or carried only impl-note comments with no module header). Left files already at the bar untouched (e.g. `ActionBanner.tsx`, `HomePill.tsx`, `useBarSurfaceWindows.ts`, `useShellVoiceOutput.ts`, `chat-panel-layout.ts`, `ShellControllerContext.tsx`, and stories files whose `meta.title` is self-documenting).

**Files touched (29):**
- Components/hooks: `BugReportModal.tsx`, `ChatSurface.tsx`, `ComputerUseApprovalOverlay.tsx`, `ConnectionLostOverlay.tsx`, `PairingView.tsx`, `RestartBanner.tsx`, `ShellOverlays.tsx`, `ShortcutsOverlay.tsx`, `useShellController.ts`, `conversation-nav.ts`
- Tests: `ContinuousChatOverlay.test.tsx`, `HomeLauncherSurface.test.tsx`, `NotificationCenter.test.tsx`, `StartupFailureView.test.tsx`, `StartupShell.test.tsx`, `pairing-command.test.ts`, `shell-state.test.ts`, `startup-shell-assets.test.ts`, `topic-grouping.test.ts`, `topic-views.test.tsx`, `use-notification-pull.test.ts`, `usePromptSuggestions.test.ts`, `__tests__/AssistantOverlay.test.tsx`, `__tests__/ChatSurface.test.tsx`, `__tests__/shell-assistant-flow.test.tsx`, `__tests__/useShellController.test.tsx`
- E2E stubs: `__e2e__/home-screen-fixture.core-stub.ts`, `__e2e__/home-screen-fixture.platform-stub.ts`, `__e2e__/home-screen-fixture.view-kinds-stub.ts`

Test headers state the surface under test + harness realness (real component in jsdom vs pure function vs source-grep guard; what's mocked). Part of #12234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)