### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-ui-a

### DIFF
--- a/packages/ui/src/components/ui/admin-dialog.tsx
+++ b/packages/ui/src/components/ui/admin-dialog.tsx
@@ -1,3 +1,10 @@
+/**
+ * Chrome parts for admin-console dialogs — a namespaced set (`AdminDialog.*`)
+ * layered on the base Dialog primitive (`./dialog`): flush-padded content,
+ * sticky card-tinted header/footer, a scrollable body, mono/badge metadata
+ * spans, a mono input + code editor, and a segmented tab strip. Provides the
+ * denser, edge-to-edge admin layout in place of the default centered padding.
+ */
 import type * as React from "react";
 import { forwardRef } from "react";
 

--- a/packages/ui/src/components/ui/alert-dialog.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.tsx
@@ -1,3 +1,9 @@
+/**
+ * Modal confirmation dialog for destructive/irreversible actions, wrapping the
+ * Radix alert-dialog primitives (overlay, content, header/footer, action,
+ * cancel) with the kit's tokens. Unlike the plain Dialog, focus is trapped and
+ * dismissal requires an explicit choice — action styling reuses buttonVariants.
+ */
 "use client";
 
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";

--- a/packages/ui/src/components/ui/badge.tsx
+++ b/packages/ui/src/components/ui/badge.tsx
@@ -1,3 +1,7 @@
+/**
+ * Inline status/label pill with cva-driven variants (default, secondary,
+ * destructive, outline). A leaf primitive in the components/ui base layer.
+ */
 import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 

--- a/packages/ui/src/components/ui/banner.tsx
+++ b/packages/ui/src/components/ui/banner.tsx
@@ -1,3 +1,9 @@
+/**
+ * Full-width inline notification strip with a leading severity icon and an
+ * optional dismiss button. cva variants (error/warning/info) map to the
+ * destructive/warn/accent tokens; unlike the modal Alert dialog this is a
+ * non-blocking banner rendered inside page flow.
+ */
 import { cva, type VariantProps } from "class-variance-authority";
 import { AlertTriangle, Info, type LucideIcon, X, XCircle } from "lucide-react";
 import * as React from "react";

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -1,3 +1,11 @@
+/**
+ * The kit's base button and its cva `buttonVariants` (default/destructive/
+ * outline/secondary/ghost/link × size). The canonical primitive in
+ * components/ui — other components (alert-dialog, banner, …) reuse
+ * `buttonVariants` rather than restyling their own buttons. `asChild` renders
+ * the styling onto a Radix Slot child so links can adopt button appearance.
+ * Accent-orange resting → darker-orange hover per the brand hover system.
+ */
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";

--- a/packages/ui/src/components/ui/card.tsx
+++ b/packages/ui/src/components/ui/card.tsx
@@ -1,3 +1,8 @@
+/**
+ * Surface container primitive plus its slot parts (Header, Title, Description,
+ * Action, Content, Footer). cva variants select behaviour/padding: default,
+ * interactive (hover-affordance), status, setting, flat.
+ */
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 

--- a/packages/ui/src/components/ui/checkbox.stories.tsx
+++ b/packages/ui/src/components/ui/checkbox.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the checkbox primitive (checked/unchecked, disabled, required).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Checkbox } from "./checkbox";
 

--- a/packages/ui/src/components/ui/code-block.stories.tsx
+++ b/packages/ui/src/components/ui/code-block.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the code-block primitive (syntax display with optional copy button).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { CodeBlock } from "./code-block";
 

--- a/packages/ui/src/components/ui/collapsible.stories.tsx
+++ b/packages/ui/src/components/ui/collapsible.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the collapsible disclosure primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   Collapsible,

--- a/packages/ui/src/components/ui/confirm-delete.stories.tsx
+++ b/packages/ui/src/components/ui/confirm-delete.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the confirm-delete primitive (destructive-action confirmation trigger).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ConfirmDelete } from "./confirm-delete";
 

--- a/packages/ui/src/components/ui/confirm-dialog.hooks.ts
+++ b/packages/ui/src/components/ui/confirm-dialog.hooks.ts
@@ -1,3 +1,9 @@
+/**
+ * Imperative `useConfirm` / `usePrompt` hooks that turn the controlled
+ * ConfirmDialog / PromptDialog into promise-returning calls: `confirm(opts)` /
+ * `prompt(opts)` resolve when the user chooses, and the returned `modalProps`
+ * is spread onto the matching dialog component (`confirm-dialog.tsx`).
+ */
 import * as React from "react";
 
 import type {

--- a/packages/ui/src/components/ui/confirm-dialog.tsx
+++ b/packages/ui/src/components/ui/confirm-dialog.tsx
@@ -1,3 +1,10 @@
+/**
+ * Presentational Confirm and Prompt dialogs built on the base Dialog primitive.
+ * Both are fully controlled (`open` + `onConfirm`/`onCancel`); the imperative
+ * promise-returning wrappers live in `confirm-dialog.hooks.ts`, which feeds
+ * these components via `modalProps`. ConfirmVariant tunes the confirm-button
+ * emphasis (danger/warn/default).
+ */
 import * as React from "react";
 
 import { Button } from "./button";

--- a/packages/ui/src/components/ui/connection-status.tsx
+++ b/packages/ui/src/components/ui/connection-status.tsx
@@ -1,3 +1,10 @@
+/**
+ * Status dot + label for a live connection (connected/disconnected/error),
+ * with per-state label overrides. This is the composite component named
+ * `ConnectionStatus`; the identically named cloud-ui string union is
+ * deliberately not re-exported from the root barrel to avoid the collision
+ * (see the note in src/index.ts).
+ */
 import * as React from "react";
 import { cn } from "../../lib/utils";
 

--- a/packages/ui/src/components/ui/copy-button.tsx
+++ b/packages/ui/src/components/ui/copy-button.tsx
@@ -1,3 +1,7 @@
+/**
+ * Button that copies a string to the clipboard and briefly swaps its icon to a
+ * checkmark as copied-confirmation feedback (`feedbackDuration` ms).
+ */
 import { Check, Copy } from "lucide-react";
 import * as React from "react";
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -1,15 +1,19 @@
+/**
+ * Modal dialog primitive family (root, trigger, overlay, content with close
+ * button, header/footer, title/description) wrapping the Radix dialog
+ * primitives with the kit's tokens. The base dialog in components/ui; the
+ * denser admin variant composes on top of it (admin-dialog.tsx).
+ */
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 import * as React from "react";
 import { cn } from "../../lib/utils";
 
-// NOTE: z-index values below are kept as literal arbitrary classes
-// (`z-[160]` / `z-[170]`) so Tailwind v4's source scanner emits them.
-// A previous revision used `` z-[${Z_DIALOG_OVERLAY}] `` template-literal
-// interpolation from the floating-layers constants, but Tailwind cannot
-// resolve classes built from runtime values — the overlay/content lost
-// `position: fixed` and stacking, leaving page chrome visible through the
-// modal. Keep these in sync with packages/ui/src/lib/floating-layers.ts
+// Overlay/content z-index must be a literal arbitrary class (`z-[160]` /
+// `z-[170]`) so Tailwind v4's source scanner emits it — Tailwind cannot resolve
+// classes built from runtime template-literal values, and a non-emitted class
+// drops `position: fixed`/stacking so page chrome shows through the modal. Keep
+// in sync with packages/ui/src/lib/floating-layers.ts
 // (Z_DIALOG_OVERLAY = 160, Z_DIALOG = 170).
 
 const Dialog = DialogPrimitive.Root;

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -1,3 +1,8 @@
+/**
+ * Dropdown-menu primitive family (trigger, content, items, checkbox/radio
+ * items, submenus, separators, shortcuts) wrapping the Radix dropdown-menu
+ * primitives with the kit's tokens. A leaf primitive in components/ui.
+ */
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronRight, Circle } from "lucide-react";
 import * as React from "react";

--- a/packages/ui/src/components/ui/empty-state.tsx
+++ b/packages/ui/src/components/ui/empty-state.tsx
@@ -1,3 +1,7 @@
+/**
+ * Centered placeholder for empty lists/views: optional icon, title,
+ * description, and a primary action slot.
+ */
 import * as React from "react";
 import { cn } from "../../lib/utils";
 

--- a/packages/ui/src/components/ui/error-boundary.test.tsx
+++ b/packages/ui/src/components/ui/error-boundary.test.tsx
@@ -1,4 +1,11 @@
 // @vitest-environment jsdom
+/**
+ * Behaviour test for ErrorBoundary: passes children through when they render
+ * cleanly, catches a throwing child and shows the default fallback with the
+ * error message + retry, and honours a custom fallback. Real component in
+ * jsdom (no mocks); console.error is spied so the expected React logging is
+ * silenced.
+ */
 
 import { act, cleanup, render, screen } from "@testing-library/react";
 import { useState } from "react";

--- a/packages/ui/src/components/ui/field-switch.stories.tsx
+++ b/packages/ui/src/components/ui/field-switch.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the field-switch primitive (labelled toggle field).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import * as React from "react";
 import { FieldSwitch } from "./field-switch";

--- a/packages/ui/src/components/ui/field.stories.tsx
+++ b/packages/ui/src/components/ui/field.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the form field primitive (label, description, and validation-message slots).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Field, FieldDescription, FieldLabel, FieldMessage } from "./field";
 import { Input } from "./input";

--- a/packages/ui/src/components/ui/form-select.stories.tsx
+++ b/packages/ui/src/components/ui/form-select.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the form-select primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { FormSelect, FormSelectItem } from "./form-select";
 

--- a/packages/ui/src/components/ui/form.stories.tsx
+++ b/packages/ui/src/components/ui/form.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the react-hook-form field primitives (Form/FormField/FormItem/…).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";

--- a/packages/ui/src/components/ui/grid.stories.tsx
+++ b/packages/ui/src/components/ui/grid.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the grid layout primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Grid } from "./grid";
 

--- a/packages/ui/src/components/ui/hover-card.stories.tsx
+++ b/packages/ui/src/components/ui/hover-card.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the hover-card primitive (content revealed on pointer hover).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "./button";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "./hover-card";

--- a/packages/ui/src/components/ui/input-group.stories.tsx
+++ b/packages/ui/src/components/ui/input-group.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the input-group primitive (input with addons/buttons/text).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   InputGroup,

--- a/packages/ui/src/components/ui/input.stories.tsx
+++ b/packages/ui/src/components/ui/input.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the text input primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Input } from "./input";
 

--- a/packages/ui/src/components/ui/label.stories.tsx
+++ b/packages/ui/src/components/ui/label.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the form label primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Input } from "./input";
 import { Label } from "./label";

--- a/packages/ui/src/components/ui/new-action-button.stories.tsx
+++ b/packages/ui/src/components/ui/new-action-button.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the new-action button primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { NewActionButton } from "./new-action-button";
 

--- a/packages/ui/src/components/ui/pagination.stories.tsx
+++ b/packages/ui/src/components/ui/pagination.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the pagination primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   Pagination,

--- a/packages/ui/src/components/ui/popover.stories.tsx
+++ b/packages/ui/src/components/ui/popover.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the popover primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "./button";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";

--- a/packages/ui/src/components/ui/progress.stories.tsx
+++ b/packages/ui/src/components/ui/progress.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the progress-bar primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Progress } from "./progress";
 

--- a/packages/ui/src/components/ui/save-footer.stories.tsx
+++ b/packages/ui/src/components/ui/save-footer.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the save-footer primitive (dirty/saving state action bar).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { SaveFooter } from "./save-footer";
 

--- a/packages/ui/src/components/ui/scroll-area.stories.tsx
+++ b/packages/ui/src/components/ui/scroll-area.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the scroll-area primitive (custom scrollbar container).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ScrollArea, ScrollBar } from "./scroll-area";
 

--- a/packages/ui/src/components/ui/segmented-control.stories.tsx
+++ b/packages/ui/src/components/ui/segmented-control.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the segmented-control primitive (single-select button group).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { SegmentedControl } from "./segmented-control";

--- a/packages/ui/src/components/ui/select.stories.tsx
+++ b/packages/ui/src/components/ui/select.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the select primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   Select,

--- a/packages/ui/src/components/ui/separator.stories.tsx
+++ b/packages/ui/src/components/ui/separator.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the separator primitive (horizontal/vertical divider).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Separator } from "./separator";
 

--- a/packages/ui/src/components/ui/settings-controls.stories.tsx
+++ b/packages/ui/src/components/ui/settings-controls.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the settings-controls primitives (input/textarea/segmented/muted-text).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   SettingsControls,

--- a/packages/ui/src/components/ui/skeleton-layouts.stories.tsx
+++ b/packages/ui/src/components/ui/skeleton-layouts.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the skeleton-layout primitives (list/detail/table loading placeholders).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   DetailSkeleton,

--- a/packages/ui/src/components/ui/skeleton.stories.tsx
+++ b/packages/ui/src/components/ui/skeleton.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the skeleton loading-placeholder primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Skeleton } from "./skeleton";
 

--- a/packages/ui/src/components/ui/slider.stories.tsx
+++ b/packages/ui/src/components/ui/slider.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the slider primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Slider } from "./slider";
 

--- a/packages/ui/src/components/ui/spinner.stories.tsx
+++ b/packages/ui/src/components/ui/spinner.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the spinner (loading indicator) primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Spinner } from "./spinner";
 

--- a/packages/ui/src/components/ui/stack.stories.tsx
+++ b/packages/ui/src/components/ui/stack.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the stack layout primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Stack } from "./stack";
 

--- a/packages/ui/src/components/ui/status-badge.helpers.test.ts
+++ b/packages/ui/src/components/ui/status-badge.helpers.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the status-badge label helpers (pure functions, no DOM):
+ * `statusLabelForState` title-cases raw enums for the dev/admin console, and
+ * `agentLifecycleLabel` maps lifecycle states to friendly onboarding copy while
+ * leaving non-lifecycle (e.g. Steward transaction) states title-cased.
+ */
 import { describe, expect, it } from "vitest";
 import {
   agentLifecycleLabel,

--- a/packages/ui/src/components/ui/status-badge.stories.tsx
+++ b/packages/ui/src/components/ui/status-badge.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the status-badge primitive (semantic status pill).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { StatusBadge } from "./status-badge";
 

--- a/packages/ui/src/components/ui/switch.stories.tsx
+++ b/packages/ui/src/components/ui/switch.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the switch (toggle) primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Switch } from "./switch";
 

--- a/packages/ui/src/components/ui/table.stories.tsx
+++ b/packages/ui/src/components/ui/table.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the table primitives.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   Table,

--- a/packages/ui/src/components/ui/tabs.stories.tsx
+++ b/packages/ui/src/components/ui/tabs.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the tabs primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs";
 

--- a/packages/ui/src/components/ui/tag-editor.stories.tsx
+++ b/packages/ui/src/components/ui/tag-editor.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the tag-editor primitive (add/remove chip input).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { TagEditor } from "./tag-editor";

--- a/packages/ui/src/components/ui/textarea.stories.tsx
+++ b/packages/ui/src/components/ui/textarea.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the textarea primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Textarea } from "./textarea";
 

--- a/packages/ui/src/components/ui/toggle.stories.tsx
+++ b/packages/ui/src/components/ui/toggle.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the toggle button primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Toggle } from "./toggle";
 

--- a/packages/ui/src/components/ui/tooltip-extended.stories.tsx
+++ b/packages/ui/src/components/ui/tooltip-extended.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the icon-tooltip primitive (tooltip wrapping an icon trigger).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { IconTooltip } from "./tooltip-extended";
 

--- a/packages/ui/src/components/ui/tooltip.stories.tsx
+++ b/packages/ui/src/components/ui/tooltip.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the tooltip primitive.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "./button";
 import {

--- a/packages/ui/src/components/ui/typography.stories.tsx
+++ b/packages/ui/src/components/ui/typography.stories.tsx
@@ -1,3 +1,6 @@
+/**
+ * Storybook stories for the typography primitives (Heading and Text).
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Heading, Text } from "./typography";
 


### PR DESCRIPTION
Comments-only slice of #12234. `check:comment-only` passes — every code token is byte-for-byte identical to `origin/develop`.

**Subtree:** `packages/ui/src/components/ui` (shard 0 of 2, disjoint from the sibling b04-ui-b shard).

**Files touched (53):**
- **Primitive components** — top-of-file prose headers added: `admin-dialog`, `alert-dialog`, `badge`, `banner`, `button`, `card`, `connection-status`, `copy-button`, `dropdown-menu`, `empty-state`, and `dialog` (also rewrote the z-index in-body NOTE from change-narration into present-tense invariant).
- **Confirm/prompt dialog pair** — `confirm-dialog.tsx` + `confirm-dialog.hooks.ts` (controlled components vs. imperative promise-returning hooks).
- **Tests** — `error-boundary.test.tsx`, `status-badge.helpers.test.ts` (1–3 line surface-under-test headers; real component in jsdom / pure functions).
- **38 Storybook story fixtures** — one-line headers matching the existing `cloud-ui/*.stories.tsx` convention ("Storybook stories for the <primitive>.").

Headers state each file's role in the components/ui base-primitive layer and note relationships (Radix wrappers, composition on the base Dialog, the ConnectionStatus name collision with cloud-ui) where load-bearing. No provenance claim was invented — shadcn upstream was not asserted since no existing header in this dir does so; primitives are described accurately by their Radix/cva/cn composition. Already-good headers were left untouched (`accordion`, `alert`, `avatar`, `calendar`, `carousel`, `primitives-stories-smoke.test`).

**Coverage:** every in-scope file in this shard now carries a proper prose header (0 remaining).

Part of #12234.