### PR TITLE
fix: harden HF proxy downloads

### DIFF
--- a/.github/issue-evidence/12322-hf-proxy-hardening.md
+++ b/.github/issue-evidence/12322-hf-proxy-hardening.md
@@ -1,0 +1,34 @@
+# Issue #12322 — HF proxy and downloader hardening
+
+## What changed
+
+- HuggingFace resolve URLs now carry ordered download candidates so a cloud-linked proxy URL can be tried before direct HuggingFace, with direct fallback for transient failures.
+- The Cloudflare HF proxy now refuses out-of-catalog repos, returns structured `HF_GATED` responses for 401/403, records per-org egress usage, and enforces a configurable monthly egress budget before streaming large responses.
+- The local downloader now retries/fails over across candidate bases for foreground and native-background downloads while preserving typed gated-repo failures through the consumer-facing job status.
+
+## Verification
+
+Commands run in `/tmp/eliza-12322-hf-proxy` on branch `fix/12322-hf-proxy-hardening`:
+
+```bash
+bun install
+bun run --cwd packages/shared test src/local-inference/hf-proxy.test.ts
+bun run --cwd packages/cloud/routing build
+node packages/shared/scripts/generate-keywords.mjs --target ts
+bun run --cwd packages/cloud/api test __tests__/hf-proxy-route.test.ts
+bun run --cwd plugins/plugin-local-inference test src/services/downloader.test.ts
+```
+
+Results reviewed:
+
+- `packages/shared` HF proxy URL tests: 1 file, 5 tests passed.
+- `packages/cloud/api` HF proxy route tests: 1 file, 8 tests passed, including auth, allowlist rejection, cloud-token forwarding, structured `HF_GATED`, and monthly egress-budget enforcement.
+- `plugins/plugin-local-inference` downloader tests: 1 file, 26 tests passed, including transient hub retry, candidate failover, typed gated-repo status propagation, bundle install/resume/stale-content handling, keep-awake behavior, and native background download coverage.
+
+## Evidence Matrix
+
+- Backend logs: covered by route assertions against structured `[hf-proxy] proxied download` and `[hf-proxy] egress metric` logger payloads.
+- Frontend screenshots/video: N/A — this chunk changes backend proxy/runtime download behavior only; no UI surfaces were modified.
+- Real-LLM trajectories: N/A — no prompts, actions, providers, model selection, or agent-response behavior changed.
+- Domain artifacts: N/A — no persisted model bundle was downloaded from the live gated repo in this local evidence run; tests exercise the real downloader state machine with deterministic local HTTP responses.
+- Benchmarks: N/A — no performance-sensitive decoding/training path changed.

--- a/packages/cloud/api/__tests__/hf-proxy-route.test.ts
+++ b/packages/cloud/api/__tests__/hf-proxy-route.test.ts
@@ -27,9 +27,9 @@ import * as loggerActual from "@/lib/utils/logger";
 
 const requireUserOrApiKeyWithOrg =
   mock<(c: unknown) => Promise<{ id: string; organization_id: string }>>();
-
 const loggerInfo = mock<(...args: unknown[]) => void>();
 const loggerWarn = mock<(...args: unknown[]) => void>();
+const loggerError = mock<(...args: unknown[]) => void>();
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   ...workersHonoAuthActual,
@@ -42,7 +42,7 @@ mock.module("@/lib/utils/logger", () => ({
     ...loggerActual.logger,
     info: loggerInfo,
     warn: loggerWarn,
-    error: () => undefined,
+    error: loggerError,
     debug: () => undefined,
   },
 }));
@@ -64,6 +64,9 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+  loggerInfo.mockClear();
+  loggerWarn.mockClear();
+  loggerError.mockClear();
   requireUserOrApiKeyWithOrg.mockResolvedValue({
     id: "user-1",
     organization_id: "org-1",
@@ -74,6 +77,7 @@ afterEach(() => {
   requireUserOrApiKeyWithOrg.mockReset();
   loggerInfo.mockReset();
   loggerWarn.mockReset();
+  loggerError.mockReset();
   globalThis.fetch = realFetch;
 });
 
@@ -82,6 +86,23 @@ afterAll(() => {
 });
 
 const RESOLVE_PATH = "elizaos/eliza-1/resolve/main/model.gguf";
+
+function fakeKv() {
+  const map = new Map<string, string>();
+  return {
+    get: async (key: string) => map.get(key) ?? null,
+    put: async (key: string, value: string) => {
+      map.set(key, value);
+    },
+    delete: async (key: string) => {
+      map.delete(key);
+    },
+    list: async () => ({
+      keys: [...map.keys()].map((name) => ({ name })),
+      list_complete: true,
+    }),
+  };
+}
 
 function makeRequest(
   path: string,
@@ -209,6 +230,71 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
     // Identity is attached (redacted) so usage is attributable.
     expect(usagePayload.orgId).toBeDefined();
     expect(usagePayload.userId).toBeDefined();
+
+    expect(loggerInfo).toHaveBeenCalledWith(
+      "[hf-proxy] egress metric",
+      expect.objectContaining({
+        organizationId: "org-1",
+        repo: "elizaos/eliza-1",
+        bytes: 10,
+        status: 200,
+      }),
+    );
+  });
+
+  test("returns structured HF_GATED for upstream 401/403", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response("private", {
+          status: 403,
+          headers: { "content-type": "text/plain" },
+        }),
+    ) as unknown as typeof fetch;
+
+    const res = await app.fetch(makeRequest(RESOLVE_PATH), {
+      HF_TOKEN: "hf-secret",
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({
+      error: "HuggingFace repo is gated or unauthorized.",
+      code: "HF_GATED",
+      repo: "elizaos/eliza-1",
+    });
+  });
+
+  test("enforces per-org monthly egress budget before streaming the next response", async () => {
+    const kv = fakeKv();
+    globalThis.fetch = mock(
+      async () =>
+        new Response("12345678", {
+          status: 200,
+          headers: {
+            "content-type": "application/octet-stream",
+            "content-length": "8",
+          },
+        }),
+    ) as unknown as typeof fetch;
+
+    const env = {
+      HF_TOKEN: "hf-secret",
+      CACHE_KV: kv,
+      HF_PROXY_MONTHLY_EGRESS_LIMIT_BYTES: "12",
+    };
+    const first = await app.fetch(makeRequest(RESOLVE_PATH), env);
+    expect(first.status).toBe(200);
+    expect(await first.text()).toBe("12345678");
+
+    const second = await app.fetch(makeRequest(RESOLVE_PATH), env);
+    expect(second.status).toBe(429);
+    const body = (await second.json()) as {
+      code?: string;
+      limit_bytes?: number;
+      used_bytes?: number;
+    };
+    expect(body.code).toBe("HF_PROXY_EGRESS_LIMIT");
+    expect(body.limit_bytes).toBe(12);
+    expect(body.used_bytes).toBe(8);
   });
 });
 

--- a/packages/cloud/api/v1/hf-proxy/[...path]/route.ts
+++ b/packages/cloud/api/v1/hf-proxy/[...path]/route.ts
@@ -27,6 +27,8 @@ import { logger, redact } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const HF_UPSTREAM_HOST = "https://huggingface.co";
+const DEFAULT_MONTHLY_EGRESS_LIMIT_BYTES = 500 * 1024 ** 3;
+const MONTHLY_EGRESS_TTL_SECONDS = 35 * 24 * 60 * 60;
 
 /**
  * Only repos under this org may be proxied. The curated eliza-1 catalog lives at
@@ -72,6 +74,151 @@ const PASSTHROUGH_RESPONSE_HEADERS = [
 
 const app = new Hono<AppEnv>();
 
+interface EgressCounter {
+  bytes: number;
+  expiresAt: number;
+}
+
+const inMemoryEgressCounters = new Map<string, EgressCounter>();
+
+function monthlyEgressLimitBytes(env: AppEnv["Bindings"]): number {
+  const raw = env.HF_PROXY_MONTHLY_EGRESS_LIMIT_BYTES;
+  const parsed =
+    typeof raw === "string" ? Number.parseInt(raw.trim(), 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_MONTHLY_EGRESS_LIMIT_BYTES;
+}
+
+function monthBucket(now = new Date()): string {
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function egressKey(organizationId: string, now = new Date()): string {
+  return `hf-proxy:egress:${organizationId}:${monthBucket(now)}`;
+}
+
+async function readMonthlyEgress(
+  env: AppEnv["Bindings"],
+  organizationId: string,
+): Promise<number> {
+  const key = egressKey(organizationId);
+  const kv = env.CACHE_KV;
+  if (kv) {
+    const raw = await kv.get(key);
+    if (!raw) return 0;
+    try {
+      const parsed = JSON.parse(raw) as { bytes?: unknown };
+      return typeof parsed.bytes === "number" ? parsed.bytes : 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  const now = Date.now();
+  const counter = inMemoryEgressCounters.get(key);
+  if (!counter || counter.expiresAt <= now) {
+    inMemoryEgressCounters.delete(key);
+    return 0;
+  }
+  return counter.bytes;
+}
+
+async function addMonthlyEgress(
+  env: AppEnv["Bindings"],
+  organizationId: string,
+  bytes: number,
+): Promise<number> {
+  if (bytes <= 0) return readMonthlyEgress(env, organizationId);
+
+  const key = egressKey(organizationId);
+  const kv = env.CACHE_KV;
+  const current = await readMonthlyEgress(env, organizationId);
+  const next = current + bytes;
+  const value = JSON.stringify({
+    bytes: next,
+    updatedAt: new Date().toISOString(),
+  });
+  if (kv) {
+    await kv.put(key, value, { expirationTtl: MONTHLY_EGRESS_TTL_SECONDS });
+  } else {
+    inMemoryEgressCounters.set(key, {
+      bytes: next,
+      expiresAt: Date.now() + MONTHLY_EGRESS_TTL_SECONDS * 1000,
+    });
+  }
+  return next;
+}
+
+function parseContentLength(headers: Headers): number | null {
+  const value = headers.get("content-length");
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function cacheStatus(headers: Headers): string | null {
+  return headers.get("cf-cache-status") ?? headers.get("x-cache") ?? null;
+}
+
+function cacheHit(value: string | null): boolean | null {
+  if (!value) return null;
+  return /\bhit\b/i.test(value);
+}
+
+function egressLimitResponse(
+  organizationId: string,
+  limitBytes: number,
+  usedBytes: number,
+) {
+  return {
+    error: "HuggingFace proxy monthly egress budget exceeded.",
+    code: "HF_PROXY_EGRESS_LIMIT",
+    organization_id: organizationId,
+    limit_bytes: limitBytes,
+    used_bytes: usedBytes,
+  };
+}
+
+function streamWithEgressAccounting(args: {
+  body: ReadableStream<Uint8Array>;
+  env: AppEnv["Bindings"];
+  organizationId: string;
+  repo: string;
+  path: string;
+  status: number;
+  cacheStatus: string | null;
+}): ReadableStream<Uint8Array> {
+  let bytes = 0;
+  return args.body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        bytes += chunk.byteLength;
+        controller.enqueue(chunk);
+      },
+      async flush() {
+        const record = addMonthlyEgress(
+          args.env,
+          args.organizationId,
+          bytes,
+        ).then((usedBytes) => {
+          logger.info("[hf-proxy] egress metric", {
+            organizationId: args.organizationId,
+            repo: args.repo,
+            path: args.path,
+            bytes,
+            status: args.status,
+            cacheStatus: args.cacheStatus,
+            cacheHit: cacheHit(args.cacheStatus),
+            usedBytes,
+          });
+        });
+        await record;
+      },
+    }),
+  );
+}
+
 app.get("/*", async (c) => {
   try {
     // Auth: a real cloud session or org API key. We require a valid linked
@@ -79,6 +226,9 @@ app.get("/*", async (c) => {
     const account = await requireUserOrApiKeyWithOrg(c);
     const userId = account.id;
     const orgId = account.organization_id;
+    if (!orgId) {
+      return c.json({ error: "Organization is required." }, 403);
+    }
 
     const hfToken = c.env.HF_TOKEN?.trim();
     if (!hfToken) {
@@ -114,6 +264,12 @@ app.get("/*", async (c) => {
       );
     }
 
+    const limitBytes = monthlyEgressLimitBytes(c.env);
+    const usedBytes = await readMonthlyEgress(c.env, orgId);
+    if (usedBytes >= limitBytes) {
+      return c.json(egressLimitResponse(orgId, limitBytes, usedBytes), 429);
+    }
+
     const incomingUrl = new URL(c.req.url);
     const upstream = new URL(`${HF_UPSTREAM_HOST}/${path}`);
     // Preserve the original query (e.g. ?download=true) verbatim.
@@ -141,15 +297,41 @@ app.get("/*", async (c) => {
     // Cost/usage observability: a single GGUF proxied here can be multiple GB on
     // the cloud's bandwidth and HF quota. Record who pulled what and how large,
     // so an operator has visibility into an otherwise-unmetered transfer.
-    const contentLength = upstreamResponse.headers.get("content-length");
+    const contentLength = parseContentLength(upstreamResponse.headers);
     logger.info("[hf-proxy] proxied download", {
       repo,
       path,
       status: upstreamResponse.status,
-      bytes: contentLength ? Number(contentLength) : null,
+      bytes: contentLength,
       orgId: redact.orgId(orgId),
       userId: redact.userId(userId),
     });
+
+    if (upstreamResponse.status === 401 || upstreamResponse.status === 403) {
+      const upstreamCacheStatus = cacheStatus(upstreamResponse.headers);
+      logger.info("[hf-proxy] egress metric", {
+        organizationId: orgId,
+        repo,
+        path,
+        bytes: 0,
+        status: upstreamResponse.status,
+        cacheStatus: upstreamCacheStatus,
+        cacheHit: cacheHit(upstreamCacheStatus),
+        usedBytes,
+      });
+      return c.json(
+        {
+          error: "HuggingFace repo is gated or unauthorized.",
+          code: "HF_GATED",
+          repo,
+        },
+        upstreamResponse.status as 401 | 403,
+      );
+    }
+
+    if (contentLength !== null && usedBytes + contentLength > limitBytes) {
+      return c.json(egressLimitResponse(orgId, limitBytes, usedBytes), 429);
+    }
 
     const responseHeaders = new Headers();
     for (const name of PASSTHROUGH_RESPONSE_HEADERS) {
@@ -157,8 +339,20 @@ app.get("/*", async (c) => {
       if (value) responseHeaders.set(name, value);
     }
 
+    const body = upstreamResponse.body
+      ? streamWithEgressAccounting({
+          body: upstreamResponse.body,
+          env: c.env,
+          organizationId: orgId,
+          repo,
+          path,
+          status: upstreamResponse.status,
+          cacheStatus: cacheStatus(upstreamResponse.headers),
+        })
+      : null;
+
     // Stream the body straight through — never buffer a multi-GB GGUF.
-    return new Response(upstreamResponse.body, {
+    return new Response(body, {
       status: upstreamResponse.status,
       headers: responseHeaders,
     });

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -65,6 +65,11 @@ export interface Bindings {
    * Deploy as a `wrangler secret`; never returned to clients.
    */
   HF_TOKEN?: string;
+  /**
+   * Optional monthly per-organization egress cap for the HuggingFace proxy, in
+   * bytes. Unset uses the route default.
+   */
+  HF_PROXY_MONTHLY_EGRESS_LIMIT_BYTES?: string;
   AI_GATEWAY_API_KEY?: string;
   AIGATEWAY_API_KEY?: string;
   AI_GATEWAY_BASE_URL?: string;

--- a/packages/shared/src/local-inference/catalog.ts
+++ b/packages/shared/src/local-inference/catalog.ts
@@ -17,7 +17,7 @@
  * metadata is gated until the Gemma drafter GGUFs are actually hosted.
  */
 
-import { resolveHfDownloadBase } from "./hf-proxy.js";
+import { type HfDownloadBase, resolveHfDownloadBases } from "./hf-proxy.js";
 import type {
   CatalogModel,
   CatalogQuantizationId,
@@ -643,6 +643,18 @@ export function buildHuggingFaceResolveUrlForPath(
   model: CatalogModel,
   filePath: string,
 ): string {
+  return buildHuggingFaceResolveUrlCandidatesForPath(model, filePath)[0].url;
+}
+
+export interface HfResolveUrlCandidate extends HfDownloadBase {
+  /** Fully-qualified URL for this candidate base. */
+  url: string;
+}
+
+export function buildHuggingFaceResolveUrlCandidatesForPath(
+  model: CatalogModel,
+  filePath: string,
+): HfResolveUrlCandidate[] {
   const cleanFilePath = filePath.replace(/^\/+/, "");
   const cleanPrefix = model.hfPathPrefix?.replace(/^\/+|\/+$/g, "");
   const pathWithPrefix =
@@ -659,14 +671,23 @@ export function buildHuggingFaceResolveUrlForPath(
       .split("/")
       .map((segment) => encodeURIComponent(segment))
       .join("/");
-    return `${base}/models/${model.hfRepo}/resolve/master/${encodedPath}`;
+    return [
+      {
+        base,
+        url: `${base}/models/${model.hfRepo}/resolve/master/${encodedPath}`,
+        viaCloud: false,
+        label: "direct",
+      },
+    ];
   }
-  const { base } = resolveHfDownloadBase();
   const encodedPath = pathWithPrefix
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/");
-  return `${base}/${model.hfRepo}/resolve/main/${encodedPath}?download=true`;
+  return resolveHfDownloadBases().map((candidate) => ({
+    ...candidate,
+    url: `${candidate.base}/${model.hfRepo}/resolve/main/${encodedPath}?download=true`,
+  }));
 }
 
 export function buildHuggingFaceResolveUrl(model: CatalogModel): string {

--- a/packages/shared/src/local-inference/hf-proxy.test.ts
+++ b/packages/shared/src/local-inference/hf-proxy.test.ts
@@ -1,17 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { _resetCloudSecretsForTesting } from "../elizacloud/cloud-secrets.js";
-import { resolveHfDownloadBase } from "./hf-proxy.js";
+import { resolveHfDownloadBase, resolveHfDownloadBases } from "./hf-proxy.js";
 
 /**
  * `resolveHfDownloadBase` decides where local-inference bundle `resolve`
  * traffic goes. Precedence (highest first):
- *   1. `ELIZA_HF_BASE_URL` override — always wins, no auth.
+ *   1. `ELIZA_HF_BASE_URLS` / `ELIZA_HF_BASE_URL` mirrors.
  *   2. Eliza Cloud HF proxy — when `ELIZAOS_CLOUD_API_KEY` is present.
  *   3. Direct public huggingface.co — no auth.
  */
 describe("resolveHfDownloadBase", () => {
   const savedEnv = {
     ELIZA_HF_BASE_URL: process.env.ELIZA_HF_BASE_URL,
+    ELIZA_HF_BASE_URLS: process.env.ELIZA_HF_BASE_URLS,
     ELIZAOS_CLOUD_API_KEY: process.env.ELIZAOS_CLOUD_API_KEY,
     ELIZAOS_CLOUD_BASE_URL: process.env.ELIZAOS_CLOUD_BASE_URL,
   };
@@ -19,6 +20,7 @@ describe("resolveHfDownloadBase", () => {
   beforeEach(() => {
     _resetCloudSecretsForTesting();
     delete process.env.ELIZA_HF_BASE_URL;
+    delete process.env.ELIZA_HF_BASE_URLS;
     delete process.env.ELIZAOS_CLOUD_API_KEY;
     delete process.env.ELIZAOS_CLOUD_BASE_URL;
   });
@@ -35,6 +37,7 @@ describe("resolveHfDownloadBase", () => {
     expect(resolveHfDownloadBase()).toEqual({
       base: "https://huggingface.co",
       viaCloud: false,
+      label: "direct",
     });
   });
 
@@ -46,26 +49,44 @@ describe("resolveHfDownloadBase", () => {
       base: "https://elizacloud.ai/api/v1/hf-proxy",
       authHeader: { authorization: "Bearer key-123" },
       viaCloud: true,
+      label: "cloud",
     });
   });
 
-  it("prefers the explicit ELIZA_HF_BASE_URL override over the cloud proxy", () => {
+  it("tries explicit mirrors before the cloud proxy and public host", () => {
     process.env.ELIZAOS_CLOUD_API_KEY = "key-123";
-    process.env.ELIZA_HF_BASE_URL = "https://hf-mirror.example.com/";
+    process.env.ELIZA_HF_BASE_URLS =
+      "https://hf-mirror-a.example.com/, https://hf-mirror-b.example.com";
 
-    // Override wins, trailing slash trimmed, no auth header, not via cloud.
-    expect(resolveHfDownloadBase()).toEqual({
-      base: "https://hf-mirror.example.com",
-      viaCloud: false,
-    });
+    expect(resolveHfDownloadBases()).toEqual([
+      {
+        base: "https://hf-mirror-a.example.com",
+        viaCloud: false,
+        label: "mirror",
+      },
+      {
+        base: "https://hf-mirror-b.example.com",
+        viaCloud: false,
+        label: "mirror",
+      },
+      {
+        base: "https://elizacloud.ai/api/v1/hf-proxy",
+        authHeader: { authorization: "Bearer key-123" },
+        viaCloud: true,
+        label: "cloud",
+      },
+      { base: "https://huggingface.co", viaCloud: false, label: "direct" },
+    ]);
   });
 
-  it("trims a trailing slash from the override base", () => {
+  it("keeps the legacy single-base API on the first candidate", () => {
     process.env.ELIZA_HF_BASE_URL = "https://hf-mirror.example.com/sub/";
 
-    expect(resolveHfDownloadBase().base).toBe(
-      "https://hf-mirror.example.com/sub",
-    );
+    expect(resolveHfDownloadBase()).toEqual({
+      base: "https://hf-mirror.example.com/sub",
+      viaCloud: false,
+      label: "mirror",
+    });
   });
 
   it("ignores a whitespace-only override and falls through to the next tier", () => {
@@ -74,6 +95,7 @@ describe("resolveHfDownloadBase", () => {
     expect(resolveHfDownloadBase()).toEqual({
       base: "https://huggingface.co",
       viaCloud: false,
+      label: "direct",
     });
   });
 });

--- a/packages/shared/src/local-inference/hf-proxy.ts
+++ b/packages/shared/src/local-inference/hf-proxy.ts
@@ -1,15 +1,15 @@
 /**
  * HuggingFace download routing for local-inference bundle fetches.
  *
- * The product never holds a local HuggingFace token. When the device is linked
- * to Eliza Cloud, ALL HuggingFace `resolve` traffic is routed through the cloud
- * HF proxy (`/api/v1/hf-proxy/<repo>/resolve/<rev>/<path>`), which attaches the
+ * The product never holds a local HuggingFace token. Explicit mirrors are tried
+ * first, then a cloud-linked device can route through the Eliza Cloud HF proxy
+ * (`/api/v1/hf-proxy/<repo>/resolve/<rev>/<path>`), which attaches the
  * cloud-side `HF_TOKEN` so gated repos resolve without exposing a token to the
- * client. When the device is not cloud-linked, downloads go directly to the
- * public (ungated) HuggingFace host — the shipping eliza-1 bundles are public.
+ * client. Direct public HuggingFace remains the final fallback for public
+ * bundles and local-only devices.
  *
  * Precedence:
- *   1. `ELIZA_HF_BASE_URL` override (explicit mirror/base) — always wins.
+ *   1. `ELIZA_HF_BASE_URLS` / `ELIZA_HF_BASE_URL` mirrors — first in order.
  *   2. Cloud proxy base + bearer — when an Eliza Cloud API key is present.
  *   3. Direct public HuggingFace host — no auth header.
  *
@@ -38,10 +38,22 @@ export interface HfDownloadBase {
   authHeader?: { authorization: string };
   /** True when traffic is routed through the Eliza Cloud HF proxy. */
   viaCloud: boolean;
+  /** Stable diagnostic label for logs and failover reporting. */
+  label?: "mirror" | "cloud" | "direct";
 }
 
 function trimTrailingSlash(value: string): string {
   return value.replace(/\/+$/, "");
+}
+
+function parseMirrorBases(): string[] {
+  const list = [process.env.ELIZA_HF_BASE_URLS, process.env.ELIZA_HF_BASE_URL]
+    .filter((value): value is string => typeof value === "string")
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map(trimTrailingSlash);
+  return [...new Set(list)];
 }
 
 /** Read the Eliza Cloud API key from the sealed store (falls back to env). */
@@ -50,24 +62,35 @@ function cloudApiKey(): string {
 }
 
 /**
- * Resolve where HuggingFace `resolve` traffic should go and how it should
- * authenticate. See the module doc for precedence.
+ * Resolve every HuggingFace `resolve` base in the order downloads should try
+ * them. See the module doc for precedence.
  */
-export function resolveHfDownloadBase(): HfDownloadBase {
-  const override = process.env.ELIZA_HF_BASE_URL?.trim();
-  if (override) {
-    return { base: trimTrailingSlash(override), viaCloud: false };
-  }
+export function resolveHfDownloadBases(): HfDownloadBase[] {
+  const bases: HfDownloadBase[] = parseMirrorBases().map((base) => ({
+    base,
+    viaCloud: false,
+    label: "mirror",
+  }));
 
   const apiKey = cloudApiKey();
   if (apiKey) {
     const cloudApi = resolveCloudApiBaseUrl(process.env.ELIZAOS_CLOUD_BASE_URL);
-    return {
+    bases.push({
       base: `${trimTrailingSlash(cloudApi)}/hf-proxy`,
       authHeader: { authorization: `Bearer ${apiKey}` },
       viaCloud: true,
-    };
+      label: "cloud",
+    });
   }
 
-  return { base: DEFAULT_HF_HOST, viaCloud: false };
+  bases.push({ base: DEFAULT_HF_HOST, viaCloud: false, label: "direct" });
+  return bases;
+}
+
+/**
+ * Backward-compatible single-base resolver for callers that do not implement
+ * failover. New download paths should use {@link resolveHfDownloadBases}.
+ */
+export function resolveHfDownloadBase(): HfDownloadBase {
+  return resolveHfDownloadBases()[0];
 }

--- a/packages/shared/src/local-inference/index.ts
+++ b/packages/shared/src/local-inference/index.ts
@@ -11,6 +11,7 @@
 
 export {
   buildHuggingFaceResolveUrl,
+  buildHuggingFaceResolveUrlCandidatesForPath,
   buildHuggingFaceResolveUrlForPath,
   DEFAULT_ELIGIBLE_MODEL_IDS,
   ELIZA_1_HF_REPO,
@@ -26,6 +27,7 @@ export {
   eliza1TierPublishStatus,
   FIRST_RUN_DEFAULT_MODEL_ID,
   findCatalogModel,
+  type HfResolveUrlCandidate,
   isDefaultEligibleId,
   isOnDeviceTier,
   MODEL_CATALOG,
@@ -49,6 +51,7 @@ export {
 export {
   type HfDownloadBase,
   resolveHfDownloadBase,
+  resolveHfDownloadBases,
 } from "./hf-proxy.js";
 export {
   hasHuggingFaceToken,

--- a/plugins/plugin-local-inference/src/services/catalog.ts
+++ b/plugins/plugin-local-inference/src/services/catalog.ts
@@ -9,6 +9,7 @@
 
 export {
 	buildHuggingFaceResolveUrl,
+	buildHuggingFaceResolveUrlCandidatesForPath,
 	buildHuggingFaceResolveUrlForPath,
 	DEFAULT_ELIGIBLE_MODEL_IDS,
 	ELIZA_1_HF_REPO,
@@ -24,6 +25,7 @@ export {
 	eliza1TierPublishStatus,
 	FIRST_RUN_DEFAULT_MODEL_ID,
 	findCatalogModel,
+	type HfResolveUrlCandidate,
 	hasHuggingFaceToken,
 	isDefaultEligibleId,
 	isHuggingFaceHost,

--- a/plugins/plugin-local-inference/src/services/downloader.test.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.test.ts
@@ -1103,6 +1103,110 @@ describe("local inference downloader status", () => {
 		}
 	});
 
+	it("fails over from an explicit mirror to direct HuggingFace on transient 5xx", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-download-test-"));
+		process.env.ELIZA_STATE_DIR = root;
+		process.env.ELIZA_HF_BASE_URLS = "https://mirror.example.com";
+
+		const base = findCatalogModel("eliza-1-2b");
+		if (!base) throw new Error("missing test catalog model");
+		const singleFileSpec: CatalogModel = {
+			...base,
+			hfRepo: "test/single-file",
+			ggufFile: "model.gguf",
+			sizeGb: 0.000001,
+			bundleManifestFile: undefined,
+			bundleManifestSha256: undefined,
+			companionModelIds: [],
+			runtimeRole: undefined,
+		};
+
+		const ggufBody = Buffer.concat([Buffer.from("GGUF"), Buffer.alloc(60, 0)]);
+		const hosts: string[] = [];
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const href =
+				typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+			const host = new URL(href).host;
+			hosts.push(host);
+			if (host === "mirror.example.com") {
+				return new Response("temporary mirror failure", { status: 503 });
+			}
+			return new Response(ggufBody, {
+				status: 200,
+				headers: { "content-length": String(ggufBody.length) },
+			});
+		}) as unknown as typeof fetch;
+
+		const downloader = new Downloader({
+			probeDeviceCaps: async () => cpuOnlyCaps,
+			probeHardware: async () => fakeProbe(100),
+		});
+		const completed = new Promise<DownloadJob>((resolve) => {
+			const unsub = downloader.subscribe((event) => {
+				if (event.job.modelId === base.id && event.type === "completed") {
+					unsub();
+					resolve(event.job);
+				}
+			});
+		});
+
+		await downloader.start(singleFileSpec);
+		await completed;
+		expect(hosts).toContain("mirror.example.com");
+		expect(hosts.at(-1)).toBe("huggingface.co");
+	});
+
+	it("turns structured HF_GATED proxy errors into authorize guidance", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-download-test-"));
+		process.env.ELIZA_STATE_DIR = root;
+		process.env.ELIZAOS_CLOUD_API_KEY = "secret-token";
+
+		const base = findCatalogModel("eliza-1-2b");
+		if (!base) throw new Error("missing test catalog model");
+		const singleFileSpec: CatalogModel = {
+			...base,
+			hfRepo: "private/gated-model",
+			ggufFile: "model.gguf",
+			sizeGb: 0.000001,
+			bundleManifestFile: undefined,
+			bundleManifestSha256: undefined,
+			companionModelIds: [],
+			runtimeRole: undefined,
+		};
+
+		globalThis.fetch = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({ code: "HF_GATED", repo: "private/gated-model" }),
+					{
+						status: 403,
+						headers: { "content-type": "application/json" },
+					},
+				),
+		) as unknown as typeof fetch;
+
+		const downloader = new Downloader({
+			probeDeviceCaps: async () => cpuOnlyCaps,
+			probeHardware: async () => fakeProbe(100),
+		});
+		const failed = new Promise<DownloadJob>((resolve) => {
+			const unsub = downloader.subscribe((event) => {
+				if (event.job.modelId === base.id && event.type === "failed") {
+					unsub();
+					resolve(event.job);
+				}
+			});
+		});
+
+		await downloader.start(singleFileSpec);
+		const job = await failed;
+
+		expect(job.error).toContain("private/gated-model");
+		expect(job.error).toContain(
+			"Link or authorize this device with Eliza Cloud",
+		);
+	});
+
 	it("blocks a download that does not fit on the models volume", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-download-test-"));
 		process.env.ELIZA_STATE_DIR = root;

--- a/plugins/plugin-local-inference/src/services/downloader.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.ts
@@ -24,11 +24,10 @@ import { pipeline } from "node:stream/promises";
 import { logger } from "@elizaos/core";
 import { ensureDefaultAssignment } from "./assignments";
 import {
-	buildHuggingFaceResolveUrl,
-	buildHuggingFaceResolveUrlForPath,
+	buildHuggingFaceResolveUrlCandidatesForPath,
 	findCatalogModel,
+	type HfResolveUrlCandidate,
 	isDefaultEligibleId,
-	resolveHfDownloadBase,
 } from "./catalog";
 import { deviceCapsFromProbe, probeHardware } from "./hardware";
 import {
@@ -70,6 +69,8 @@ interface ActiveJob {
 
 type DownloadListener = (event: DownloadEvent) => void;
 type BundleFileKind = keyof Eliza1Files;
+const HUB_FAILOVER_BASE_BACKOFF_MS = 25;
+const HUB_ERROR_BODY_LIMIT_BYTES = 64 * 1024;
 
 /**
  * Thrown before any weight byte is fetched when an Eliza-1 bundle's manifest
@@ -322,6 +323,53 @@ async function hasGgufMagic(filePath: string): Promise<boolean> {
 	} catch {
 		return false;
 	}
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function failoverBackoffMs(attemptIndex: number): number {
+	return HUB_FAILOVER_BASE_BACKOFF_MS * 2 ** attemptIndex;
+}
+
+function isTransientHubStatus(statusCode: number): boolean {
+	return statusCode >= 500;
+}
+
+async function readHubErrorBody(body: AsyncIterable<Buffer>): Promise<string> {
+	const chunks: Buffer[] = [];
+	let total = 0;
+	for await (const chunk of body) {
+		const remaining = HUB_ERROR_BODY_LIMIT_BYTES - total;
+		if (remaining <= 0) break;
+		const slice =
+			chunk.length > remaining ? chunk.subarray(0, remaining) : chunk;
+		chunks.push(slice);
+		total += slice.length;
+		if (total >= HUB_ERROR_BODY_LIMIT_BYTES) break;
+	}
+	return Buffer.concat(chunks).toString("utf8");
+}
+
+function parseGatedHubError(body: string): { repo: string } | null {
+	try {
+		const parsed = JSON.parse(body) as { code?: unknown; repo?: unknown };
+		if (parsed.code === "HF_GATED" && typeof parsed.repo === "string") {
+			return { repo: parsed.repo };
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+function gatedRepoMessage(repo: string, httpStatus: number): string {
+	return (
+		`HuggingFace repo ${repo} is gated or private (HTTP ${httpStatus}). ` +
+		"Link or authorize this device with Eliza Cloud, then retry — gated downloads route " +
+		"through the cloud HuggingFace proxy."
+	);
 }
 
 function bundleDirname(modelId: string): string {
@@ -871,6 +919,148 @@ export class Downloader {
 		}
 	}
 
+	private async requestHubFile(args: {
+		catalogEntry: CatalogModel;
+		remotePath: string;
+		headers: Record<string, string>;
+		signal: AbortSignal;
+	}): Promise<{
+		response: {
+			statusCode: number;
+			headers: Record<string, string | string[] | undefined>;
+			body: AsyncIterable<Buffer>;
+		};
+		candidate: HfResolveUrlCandidate;
+	}> {
+		const candidates = buildHuggingFaceResolveUrlCandidatesForPath(
+			args.catalogEntry,
+			args.remotePath,
+		);
+		const httpClient = await this.loadHttpClient();
+		let lastError: unknown;
+
+		for (let index = 0; index < candidates.length; index += 1) {
+			const candidate = candidates[index];
+			const headers = {
+				...args.headers,
+				...candidate.authHeader,
+			};
+
+			let response: Awaited<ReturnType<typeof httpClient.request>>;
+			try {
+				response = await httpClient.request(candidate.url, {
+					method: "GET",
+					headers,
+					signal: args.signal,
+				});
+			} catch (error) {
+				lastError = error;
+				if (args.signal.aborted || index === candidates.length - 1) {
+					throw error;
+				}
+				logger.warn(
+					`[Downloader] model hub request failed via ${candidate.label ?? candidate.base}; trying next base`,
+					{ error },
+				);
+				await sleep(failoverBackoffMs(index));
+				continue;
+			}
+
+			if (
+				isTransientHubStatus(response.statusCode) &&
+				index < candidates.length - 1
+			) {
+				lastError = new Error(
+					`HTTP ${response.statusCode} from model hub via ${candidate.label ?? candidate.base}`,
+				);
+				logger.warn(
+					`[Downloader] transient model hub HTTP ${response.statusCode} via ${candidate.label ?? candidate.base}; trying next base`,
+				);
+				await sleep(failoverBackoffMs(index));
+				continue;
+			}
+
+			if (response.statusCode >= 400) {
+				const body = await readHubErrorBody(response.body);
+				if (response.statusCode === 401 || response.statusCode === 403) {
+					const gated = parseGatedHubError(body);
+					throw new GatedRepoError(
+						gatedRepoMessage(
+							gated?.repo ?? args.catalogEntry.hfRepo,
+							response.statusCode,
+						),
+						response.statusCode,
+					);
+				}
+				throw new Error(
+					`HTTP ${response.statusCode} from model hub for ${args.catalogEntry.hfRepo}/${args.remotePath}`,
+				);
+			}
+
+			return { response, candidate };
+		}
+
+		throw lastError instanceof Error
+			? lastError
+			: new Error(
+					`Failed to download ${args.catalogEntry.hfRepo}/${args.remotePath}`,
+				);
+	}
+
+	private async transferViaBackgroundSessionWithFailover(args: {
+		bridge: NativeBackgroundDownloadBridge;
+		catalogEntry: CatalogModel;
+		remotePath: string;
+		headers: Record<string, string>;
+		downloadId: string;
+		targetPath: string;
+		record: ActiveJob;
+		baseBytes: number;
+		expectedTotalBytes: number;
+		forceFresh: boolean;
+	}): Promise<void> {
+		const candidates = buildHuggingFaceResolveUrlCandidatesForPath(
+			args.catalogEntry,
+			args.remotePath,
+		);
+		let lastError: unknown;
+		for (let index = 0; index < candidates.length; index += 1) {
+			const candidate = candidates[index];
+			try {
+				await this.transferViaBackgroundSession({
+					bridge: args.bridge,
+					downloadId: args.downloadId,
+					url: candidate.url,
+					headers: { ...args.headers, ...candidate.authHeader },
+					targetPath: args.targetPath,
+					record: args.record,
+					baseBytes: args.baseBytes,
+					expectedTotalBytes: args.expectedTotalBytes,
+					forceFresh: args.forceFresh || index > 0,
+				});
+				return;
+			} catch (error) {
+				lastError = error;
+				if (
+					args.record.abortController.signal.aborted ||
+					index === candidates.length - 1
+				) {
+					throw error;
+				}
+				logger.warn(
+					`[Downloader] background model hub request failed via ${candidate.label ?? candidate.base}; trying next base`,
+					{ error },
+				);
+				await sleep(failoverBackoffMs(index));
+			}
+		}
+		throw lastError instanceof Error
+			? lastError
+			: new Error(
+					`Failed to download ${args.catalogEntry.hfRepo}/${args.remotePath}`,
+				);
+	}
+
 	private async runJob(
 		catalogEntry: CatalogModel,
 		record: ActiveJob,
@@ -884,10 +1074,8 @@ export class Downloader {
 				return;
 			}
 
-			const url = buildHuggingFaceResolveUrl(catalogEntry);
 			const headers: Record<string, string> = {
 				"user-agent": "Eliza-LocalInference/1.0",
-				...resolveHfDownloadBase().authHeader,
 			};
 
 			const backgroundBridge = this.backgroundDownloadBridge();
@@ -896,10 +1084,11 @@ export class Downloader {
 				// URLSession so it survives the app backgrounding / device lock
 				// (#11841). The native session owns resume, so no Range header.
 				record.job.received = 0;
-				await this.transferViaBackgroundSession({
+				await this.transferViaBackgroundSessionWithFailover({
 					bridge: backgroundBridge,
+					catalogEntry,
+					remotePath: catalogEntry.ggufFile,
 					downloadId: stagingFilename(record.job.modelId),
-					url,
 					headers,
 					targetPath: record.stagingPath,
 					record,
@@ -908,31 +1097,18 @@ export class Downloader {
 					forceFresh: false,
 				});
 			} else {
-				const httpClient = await this.loadHttpClient();
 				const startByte = record.job.received;
 
 				if (startByte > 0) {
 					headers.range = `bytes=${startByte}-`;
 				}
 
-				const response = await httpClient.request(url, {
-					method: "GET",
+				const { response } = await this.requestHubFile({
+					catalogEntry,
+					remotePath: catalogEntry.ggufFile,
 					headers,
 					signal: record.abortController.signal,
 				});
-
-				if (response.statusCode === 401 || response.statusCode === 403) {
-					throw new GatedRepoError(
-						`HuggingFace repo ${catalogEntry.hfRepo} is gated or private (HTTP ${response.statusCode}). ` +
-							"Link this device to Eliza Cloud and retry — gated downloads route through the cloud HuggingFace proxy.",
-						response.statusCode,
-					);
-				}
-				if (response.statusCode >= 400) {
-					throw new Error(
-						`HTTP ${response.statusCode} from model hub for ${catalogEntry.hfRepo}`,
-					);
-				}
 				let effectiveStartByte = startByte;
 				if (effectiveStartByte > 0 && response.statusCode !== 206) {
 					effectiveStartByte = 0;
@@ -1281,10 +1457,8 @@ export class Downloader {
 		const backgroundBridge = this.backgroundDownloadBridge();
 		const maxAttempts = expectedSha256 ? SHA_MISMATCH_MAX_ATTEMPTS : 1;
 		for (let attempt = 1; ; attempt++) {
-			const url = buildHuggingFaceResolveUrlForPath(catalogEntry, remotePath);
 			const headers: Record<string, string> = {
 				"user-agent": "Eliza-LocalInference/1.0",
-				...resolveHfDownloadBase().authHeader,
 			};
 
 			if (backgroundBridge) {
@@ -1294,10 +1468,11 @@ export class Downloader {
 				// from zero; the first attempt may reuse a completed transfer
 				// that outlived a runtime restart.
 				record.job.received = baseBytes;
-				await this.transferViaBackgroundSession({
+				await this.transferViaBackgroundSessionWithFailover({
 					bridge: backgroundBridge,
+					catalogEntry,
+					remotePath,
 					downloadId: path.basename(stagingPath),
-					url,
 					headers,
 					targetPath: stagingPath,
 					record,
@@ -1325,25 +1500,12 @@ export class Downloader {
 					headers.range = `bytes=${startByte}-`;
 				}
 
-				const httpClient = await this.loadHttpClient();
-				const response = await httpClient.request(url, {
-					method: "GET",
+				const { response } = await this.requestHubFile({
+					catalogEntry,
+					remotePath,
 					headers,
 					signal: record.abortController.signal,
 				});
-
-				if (response.statusCode === 401 || response.statusCode === 403) {
-					throw new GatedRepoError(
-						`HuggingFace repo ${catalogEntry.hfRepo}/${remotePath} is gated or private (HTTP ${response.statusCode}). ` +
-							"Link this device to Eliza Cloud and retry — gated downloads route through the cloud HuggingFace proxy.",
-						response.statusCode,
-					);
-				}
-				if (response.statusCode >= 400) {
-					throw new Error(
-						`HTTP ${response.statusCode} from model hub for ${catalogEntry.hfRepo}/${remotePath}`,
-					);
-				}
 				if (startByte > 0 && response.statusCode !== 206) {
 					startByte = 0;
 					record.job.received = baseBytes;


### PR DESCRIPTION
## Summary
- Add ordered HuggingFace download candidates so mirrors/cloud proxy can fail over to direct HuggingFace on transient failures.
- Harden the Cloudflare HF proxy with curated-repo allowlisting, structured `HF_GATED` responses, per-org egress accounting, and configurable monthly egress limits.
- Preserve typed gated-repo failures through local downloader job status and cover foreground/native-background candidate failover.

Relates to #12322.

## Verification
- `bun install`
- `bun run --cwd packages/shared test src/local-inference/hf-proxy.test.ts` — 5 passed
- `bun run --cwd packages/cloud/routing build`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/cloud/api test __tests__/hf-proxy-route.test.ts` — 8 passed
- `bun run --cwd plugins/plugin-local-inference test src/services/downloader.test.ts` — 26 passed

## Evidence
- `.github/issue-evidence/12322-hf-proxy-hardening.md`

## Evidence N/A
- Screenshots/video: N/A, backend/runtime downloader change only.
- Real-LLM trajectories: N/A, no prompt/action/provider/model-response behavior changed.
- Benchmarks: N/A, no decoding/training hot path changed.
