### PR TITLE
chore(#12245): comment cleanup B15 — storage plugins slice (comment-only)

### DIFF
--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -8,9 +8,8 @@
  * one-shot runs where speed and zero setup matter more than durability.
  *
  * Implements the full batch-first interface from `@elizaos/core`'s
- * `DatabaseAdapter`. Single-item helpers from earlier revisions of this plugin
- * have been removed — call sites should use the batch APIs (`createEntities`,
- * `getMemoriesByIds`, etc.).
+ * `DatabaseAdapter`; there are no single-item helpers — call sites use the
+ * batch APIs (`createEntities`, `getMemoriesByIds`, etc.).
  */
 
 import { randomUUID } from "node:crypto";

--- a/plugins/plugin-inmemorydb/build.ts
+++ b/plugins/plugin-inmemorydb/build.ts
@@ -2,39 +2,10 @@
 /**
  * Build script for @elizaos/plugin-inmemorydb (Node + Browser). Orchestration
  * lives in the shared driver (plugins/plugin-build.ts); this lists only what
- * differs.
- *
- * Migrated from the legacy `runBuild`/`generateDts` (packages/core/build)
- * driver to the shared `buildPlugin` driver as part of issue #10078 (one build
- * helper). The emitted `dist/` is byte-identical to the previous output.
- *
- * runBuild → buildPlugin mapping:
- *  - Two `runBuild` calls → two `targets[]`: Node (entry "./index.ts",
- *    outSubdir "node", target "node") and Browser (entry "./index.browser.ts",
- *    outSubdir "browser", target "browser"), both esm.
- *  - sourcemap: true → "linked": runBuild forwards the boolean `true` to
- *    Bun.build, which emits an external `.js.map` + `//# sourceMappingURL=` /
- *    `//# debugId=` comments — exactly Bun's "linked" mode (verified, including
- *    debugId).
- *  - naming: createElizaBuildConfig sets a fixed naming template; it determines
- *    the sourcemap bytes (and thus the debugId), so it is reproduced verbatim
- *    here to keep the `.js` + `.js.map` byte-identical.
- *  - external: both runBuild calls pass ["@elizaos/core"]; the plugin's only
- *    non-builtin import is @elizaos/core (everything else is `node:*`), so the
- *    single explicit entry reproduces both bundles byte-for-byte. buildPlugin
- *    applies one externals list to every target; that is fine here because both
- *    targets share the same effective set.
- *  - generateDts("tsconfig.build.json", false) [false = throwOnError] →
- *    dtsProject "tsconfig.build.json" + dtsEmitDeclarationOnly (runBuild's
- *    generateDts runs `tsc --emitDeclarationOnly --noCheck …`) + dtsTolerant
- *    (the `false` throwOnError = warn-and-continue). runBuild additionally
- *    passed `--composite false --incremental false`, which suppressed the
- *    `dist/tsconfig.tsbuildinfo` emit; buildPlugin cannot pass extra tsc flags,
- *    so that suppression is now encoded directly in tsconfig.build.json
- *    (composite:false, tsBuildInfoFile removed). The per-file `.d.ts` tree is
- *    byte-identical either way; this only avoids the stray tsbuildinfo.
- *  - The two post-emit alias writes (root + node) → dtsShims, reproduced
- *    byte-for-byte (double-quoted specifiers, trailing newline).
+ * differs: the dual Node/Browser targets, a fixed `naming` template and
+ * `linked` sourcemaps (both determine the emitted bytes, so they are pinned
+ * here), and `dtsShims` that write root + node `.d.ts` aliases re-exporting
+ * the browser build.
  */
 import { buildPlugin } from "../plugin-build";
 


### PR DESCRIPTION
## Batch B15 comment cleanup — storage plugins slice (comment-only)

Part of #12245 / parent #12181. Slice: `plugins/plugin-localdb`, `plugins/plugin-local-storage`, `plugins/plugin-inmemorydb` (22 in-scope non-generated `.ts` files).

**comment-only; `check:comment-only` PASSES** — every code token is byte-for-byte identical to `origin/develop` (machine-checked by `scripts/assert-comment-only-diff.mjs`).

### What changed
- `plugins/plugin-inmemorydb/build.ts` — replaced the ~35-line `runBuild → buildPlugin` migration story (change-narration for a completed, byte-identical migration) with a 6-line present-tense header stating what the build does and why `naming`/`linked` sourcemaps and `dtsShims` are pinned.
- `plugins/plugin-inmemorydb/adapter.ts` — rewrote "Single-item helpers … have been removed" (diff annotation) to present-tense fact: "there are no single-item helpers — call sites use the batch APIs".

### Tallies
- Files touched: 2
- Headers added: 0 (all 22 in-scope files already carried prose headers per the header self-audit, which prints nothing on this slice — the desert measured at `8a2b993282` was filled upstream)
- Churn comments removed/rewritten: 2 blocks
- Kept-with-reason: the `@brighter`/S3-parity notes in `local-storage.ts` and `types.ts` and the `_unusedBucket … API parity` param note are durable why-this-not-that invariants (drop-in replacement for the removed `AwsS3Service`), not churn — left as-is.
- filesFlagged: none

### Evidence
- `check:comment-only`: `OK — 2 source file(s) changed; every code token identical to origin/develop. Comments only.`
- Trajectory / screenshot / video / audio / domain-artifact: N/A — comments-only change, zero functional diff (machine-checked by `scripts/assert-comment-only-diff.mjs`).

Refs #12245

🤖 Generated with [Claude Code](https://claude.com/claude-code)
