### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-char-cockpit

### DIFF
--- a/packages/ui/src/components/character/CharacterEditor.tsx
+++ b/packages/ui/src/components/character/CharacterEditor.tsx
@@ -1,3 +1,11 @@
+/**
+ * The character/persona editor mounted as the top-level "Character" view in the
+ * dashboard shell (App.tsx). Renders the roster picker plus the identity, style,
+ * examples, and voice panels, and writes edits back through the API client;
+ * greeting animation and voice config are resolved from the selected roster
+ * entry. Kept statically imported in App.tsx (not lazy) so first-run onboarding
+ * can land here without a chunk fetch.
+ */
 import { getStylePresets } from "@elizaos/shared";
 import { useAgentElement } from "../../agent-surface";
 import type { CharacterData } from "../../api/client";

--- a/packages/ui/src/components/character/CharacterEditorPanels.stories.tsx
+++ b/packages/ui/src/components/character/CharacterEditorPanels.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook stories for the character editor's identity/style/examples panels. */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { CharacterData } from "../../api/client-types-config";
 import {

--- a/packages/ui/src/components/character/CharacterEditorPanels.tsx
+++ b/packages/ui/src/components/character/CharacterEditorPanels.tsx
@@ -1,3 +1,9 @@
+/**
+ * The three editable panels of the character editor — identity, style, and
+ * message examples — split out from CharacterEditor/CharacterHubView so each is
+ * independently composable and story-testable. Each is a controlled component:
+ * it renders the given draft and reports edits upward; it owns no fetches.
+ */
 import type { MessageExampleGroup } from "@elizaos/core";
 import {
   type ChangeEvent,

--- a/packages/ui/src/components/character/CharacterExperienceWorkspace.tsx
+++ b/packages/ui/src/components/character/CharacterExperienceWorkspace.tsx
@@ -1,3 +1,11 @@
+/**
+ * Master/detail editor for the agent's learned experiences, driving both the
+ * promoted top-level Experience view and the experience section of the
+ * character hub. Renders the review-status filter, the experience list, and the
+ * editable draft pane; it is fully controlled — the parent owns the records and
+ * the save/delete/select callbacks (and the save/delete-in-flight ids). Pass
+ * `showTitle={false}` when the host view already supplies a ViewHeader.
+ */
 import { memo, useEffect, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import { useTranslation } from "../../state/TranslationContext.hooks";

--- a/packages/ui/src/components/character/CharacterHubView.tsx
+++ b/packages/ui/src/components/character/CharacterHubView.tsx
@@ -1,3 +1,12 @@
+/**
+ * The top-level "Character" view: the identity/style/examples editor plus the
+ * overview grid, wired to the five hub reads via useCharacterHubData and routed
+ * by URL path to its sections. Knowledge, Relationships, Skills, and Experience
+ * are now separate top-level views (promoted out of the old multi-tab hub), so
+ * this view keeps only the personality/editor surface plus the overview that
+ * links out to them. Deep-links resolve through the navigation helpers; a
+ * ViewHeader supplies the in-context back affordance for the shell.
+ */
 import type { MessageExampleGroup } from "@elizaos/core";
 import {
   type ReactNode,

--- a/packages/ui/src/components/character/CharacterLearnedSkillsSection.tsx
+++ b/packages/ui/src/components/character/CharacterLearnedSkillsSection.tsx
@@ -1,3 +1,11 @@
+/**
+ * Lists and curates the skills the agent has learned or refined from its own
+ * trajectories — the agent-authored curated skills (source !== "human") read
+ * from `/api/skills/curated` and grouped by status (proposed / active /
+ * disabled). Backs the promoted top-level Skills view and the skills section of
+ * the character hub; distinct from the installable developer skill catalog.
+ * Pass `showTitle={false}` when a host ViewHeader already renders the title.
+ */
 import { useCallback, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import { client } from "../../api/client";

--- a/packages/ui/src/components/character/CharacterOverviewSection.stories.tsx
+++ b/packages/ui/src/components/character/CharacterOverviewSection.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook stories for the character hub's overview grid (full + empty states). */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   CharacterOverviewSection,

--- a/packages/ui/src/components/character/CharacterOverviewSection.tsx
+++ b/packages/ui/src/components/character/CharacterOverviewSection.tsx
@@ -1,3 +1,9 @@
+/**
+ * The overview grid of the character hub: a card per hub section (personality,
+ * documents, skills, experience, relationships) showing a preview body or an
+ * empty state, each opening its section. Pure presentation — the caller passes
+ * the widgets and the open handler.
+ */
 import {
   BookOpen,
   Brain,

--- a/packages/ui/src/components/character/CharacterPersonalityTimeline.stories.tsx
+++ b/packages/ui/src/components/character/CharacterPersonalityTimeline.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook stories for the character personality-history timeline. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { CharacterPersonalityTimeline } from "./CharacterPersonalityTimeline";
 import type { CharacterPersonalityHistoryItem } from "./character-hub-types";

--- a/packages/ui/src/components/character/CharacterPersonalityTimeline.tsx
+++ b/packages/ui/src/components/character/CharacterPersonalityTimeline.tsx
@@ -1,3 +1,8 @@
+/**
+ * Renders the character's personality-change history as an expandable timeline:
+ * each entry shows the edited field, scope, actor, and a before/after diff of
+ * the change. Pure presentation over the items the hub passes in.
+ */
 import { useState } from "react";
 import { Button } from "../ui/button";
 import type { CharacterPersonalityHistoryItem } from "./character-hub-types";

--- a/packages/ui/src/components/character/CharacterRoster.helpers.ts
+++ b/packages/ui/src/components/character/CharacterRoster.helpers.ts
@@ -1,3 +1,8 @@
+/**
+ * Pure helpers for CharacterRoster: the tile-clip polygons (slant + inset) and
+ * the projection from shared StylePresets to roster entries. Kept out of the
+ * component so the mapping is unit-testable and reused by the editor.
+ */
 import type { StylePreset } from "@elizaos/shared";
 import type { CharacterRosterEntry } from "./CharacterRoster";
 

--- a/packages/ui/src/components/character/CharacterRoster.stories.tsx
+++ b/packages/ui/src/components/character/CharacterRoster.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook stories for the character roster preset picker. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import type { AppContextValue } from "../../state/types";

--- a/packages/ui/src/components/character/CharacterRoster.tsx
+++ b/packages/ui/src/components/character/CharacterRoster.tsx
@@ -1,3 +1,9 @@
+/**
+ * Horizontal picker of available character presets, each shown as a slanted
+ * clipped tile with a VRM avatar preview; selecting one drives the character
+ * editor. Entries derive from the shared style presets (see
+ * CharacterRoster.helpers); preview URLs resolve lazily from the VRM state.
+ */
 import type { StylePreset } from "@elizaos/shared";
 import { useEffect, useState } from "react";
 import { useAppSelector } from "../../state";

--- a/packages/ui/src/components/character/MusicLibraryCharacterWidget.stories.tsx
+++ b/packages/ui/src/components/character/MusicLibraryCharacterWidget.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook stories for the music-library chat-sidebar widget. */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { PluginInfo } from "../../api/client-types-config";
 import { MusicLibraryCharacterWidget } from "./MusicLibraryCharacterWidget";

--- a/packages/ui/src/components/character/MusicLibraryCharacterWidget.tsx
+++ b/packages/ui/src/components/character/MusicLibraryCharacterWidget.tsx
@@ -1,3 +1,9 @@
+/**
+ * Chat-sidebar widget for the music-library plugin (registered in
+ * widgets/registry as `music-library.playlists`): a compact panel of quick
+ * commands that seed the chat composer with prompts like "show my playlists".
+ * It only issues prompts — it holds no music state of its own.
+ */
 import { ListMusic, Music, Plus, Search } from "lucide-react";
 import type { WidgetProps } from "../../widgets/types";
 

--- a/packages/ui/src/components/character/character-editor-helpers.ts
+++ b/packages/ui/src/components/character/character-editor-helpers.ts
@@ -1,6 +1,9 @@
 /**
- * Pure helpers extracted from CharacterEditor and AppContext
- * for testability and reuse.
+ * Pure, side-effect-free helpers backing the character editor: resolving
+ * first-run preset styles, building a character draft from a roster preset,
+ * and deciding when preset defaults should overwrite user edits. Kept separate
+ * from the CharacterEditor component so the logic is unit-testable and shared
+ * with AppContext without pulling in React.
  */
 
 import type { StylePreset } from "@elizaos/shared";

--- a/packages/ui/src/components/character/character-greeting.ts
+++ b/packages/ui/src/components/character/character-greeting.ts
@@ -1,3 +1,9 @@
+/**
+ * Resolves the greeting-animation asset path for a character: an explicit
+ * override wins, otherwise it falls back to the greetingAnimation of the style
+ * preset matching the character's avatar index. Paths are normalized to be
+ * root-relative (leading slashes stripped) so callers can join them uniformly.
+ */
 import { getStylePresets } from "@elizaos/shared";
 
 function normalizeGreetingAnimationPath(path: string | null | undefined) {

--- a/packages/ui/src/components/character/character-hub-helpers.ts
+++ b/packages/ui/src/components/character/character-hub-helpers.ts
@@ -1,3 +1,10 @@
+/**
+ * Section metadata and record-shaping helpers for the character hub: the
+ * ordered section list + labels, and the mappers that turn API records
+ * (history, experiences, relationship activity, documents) into the view-model
+ * shapes the hub components render (timeline items, overview widgets, activity
+ * items). Pure, no React — the hub view calls these on fetched data.
+ */
 import type {
   CharacterHistoryEntry,
   DocumentRecord,

--- a/packages/ui/src/components/character/character-hub-types.ts
+++ b/packages/ui/src/components/character/character-hub-types.ts
@@ -1,3 +1,8 @@
+/**
+ * View-model types shared across the character hub components — activity items,
+ * personality-history entries, and the experience record/draft shapes — kept
+ * separate from the API transport types so the hub renders a stable UI shape.
+ */
 export type CharacterHubActivityKind =
   | "personality"
   | "documents"

--- a/packages/ui/src/components/character/character-voice-config.ts
+++ b/packages/ui/src/components/character/character-voice-config.ts
@@ -1,5 +1,8 @@
 /**
- * Voice-related constants and helpers extracted from CharacterEditor.
+ * Voice-picker constants and defaults for the character editor: the grouped
+ * ElevenLabs / Edge voice catalogs shown in the dropdown, the default fast
+ * ElevenLabs model, and the helper that derives a `VoiceConfig` from a selected
+ * character roster entry (honoring whether an API key is configured).
  */
 
 import type { VoiceConfig } from "../../api/client";

--- a/packages/ui/src/components/cockpit/CockpitModePicker.stories.tsx
+++ b/packages/ui/src/components/cockpit/CockpitModePicker.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook stories for the cockpit per-session mode picker. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 

--- a/packages/ui/src/components/cockpit/CockpitModePicker.test.tsx
+++ b/packages/ui/src/components/cockpit/CockpitModePicker.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+//
+// Interaction tests for CockpitModePicker: selecting a mode emits the right
+// config, the Fast/Smart tier toggle only shows for Eliza Cloud, and the
+// experimental modes stay hidden unless armed. Deterministic RTL/jsdom, no network.
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";

--- a/packages/ui/src/components/cockpit/CockpitNewSessionForm.stories.tsx
+++ b/packages/ui/src/components/cockpit/CockpitNewSessionForm.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook stories for the cockpit new-session (spawn) form. */
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { CockpitNewSessionForm } from "./CockpitNewSessionForm";

--- a/packages/ui/src/components/cockpit/CockpitNewSessionForm.test.tsx
+++ b/packages/ui/src/components/cockpit/CockpitNewSessionForm.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+//
+// Interaction tests for CockpitNewSessionForm: submit stays disabled until a
+// goal is entered, and submitting hands the parent a lowered create-task input.
+// Deterministic RTL/jsdom, no network.
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/cockpit/CockpitTierToggle.stories.tsx
+++ b/packages/ui/src/components/cockpit/CockpitTierToggle.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook stories for the running-session Fast/Smart tier toggle. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 

--- a/packages/ui/src/components/cockpit/CockpitTierToggle.test.tsx
+++ b/packages/ui/src/components/cockpit/CockpitTierToggle.test.tsx
@@ -1,4 +1,7 @@
 // @vitest-environment jsdom
+//
+// Interaction tests for CockpitTierToggle: flipping the segmented control emits
+// the selected Eliza Cloud tier. Deterministic RTL/jsdom, no network.
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/ui/src/components/cockpit/CockpitView.stories.tsx
+++ b/packages/ui/src/components/cockpit/CockpitView.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook stories for the coding cockpit view (deck + spawn form). */
 import type { Meta, StoryObj } from "@storybook/react";
 
 import type { OrchestratorRoomRosterOverview } from "../../api/client-types-cloud";

--- a/packages/ui/src/components/cockpit/CockpitView.test.tsx
+++ b/packages/ui/src/components/cockpit/CockpitView.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+//
+// Interaction tests for CockpitView: it renders the live room-deck from the
+// roster prop and the spawn form, and surfaces select/create callbacks.
+// Deterministic RTL/jsdom, no network.
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/cockpit/MyRuntimesContainer.test.tsx
+++ b/packages/ui/src/components/cockpit/MyRuntimesContainer.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// Interaction tests for MyRuntimesContainer: the runtime switch/add flow with
+// the agent-profile registry and the non-destructive re-point mocked, covering
+// both the trusted switch and the untrusted-remote refusal. Deterministic
+// RTL/jsdom; the registry + re-point are vi mocks, not real state.
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/cockpit/MyRuntimesSection.stories.tsx
+++ b/packages/ui/src/components/cockpit/MyRuntimesSection.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook stories for the "My Runtimes" runtime-switcher section. */
 import type { Meta, StoryObj } from "@storybook/react";
 
 import type { AgentProfile } from "../../state/agent-profile-types";

--- a/packages/ui/src/components/cockpit/MyRuntimesSection.test.tsx
+++ b/packages/ui/src/components/cockpit/MyRuntimesSection.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+//
+// Interaction tests for MyRuntimesSection: it lists the runtimes, marks the
+// active one, and fires switch/add-remote callbacks. Deterministic RTL/jsdom,
+// no network.
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/cockpit/cockpit-modes.test.ts
+++ b/packages/ui/src/components/cockpit/cockpit-modes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the cockpit mode → providerPolicy lowering (cockpit-modes):
+ * that each of the four modes resolves to the right provider source, model, and
+ * create-task input. Pure functions, no DOM or network.
+ */
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/ui/src/components/cockpit/cockpit-modes.ts
+++ b/packages/ui/src/components/cockpit/cockpit-modes.ts
@@ -3,9 +3,8 @@
  * `providerPolicy` lowering. The picker lives in the UI library (it must not
  * import a node plugin), and the orchestrator create-task route accepts the
  * `{preferredFramework, providerSource, model}` policy this file emits — so the
- * lowering and the display metadata both live here, unambiguously. (There is no
- * separate "canonical" server copy; that earlier duplicate was unused and was
- * removed to avoid two-sources-of-truth drift.)
+ * lowering and the display metadata both live here, unambiguously. There is no
+ * server-side copy to drift against.
  *
  * The four modes (locked product vision):
  *   1. Eliza Cloud = eliza-code on Cerebras, fast/smart tier (gemma-4-31b)

--- a/packages/ui/src/components/cockpit/index.ts
+++ b/packages/ui/src/components/cockpit/index.ts
@@ -1,3 +1,4 @@
+/** Public barrel for the coding-cockpit deck primitives (consumed by plugin-task-coordinator's /cockpit route). */
 export type { CockpitModePickerProps } from "./CockpitModePicker";
 export { CockpitModePicker } from "./CockpitModePicker";
 export type { CockpitNewSessionFormProps } from "./CockpitNewSessionForm";


### PR DESCRIPTION
Comments-only slice of #12234. `check:comment-only` passes (34 source files changed; every code token byte-for-byte identical to `origin/develop`).

## Subtree
`packages/ui/src/components/character` and `packages/ui/src/components/cockpit` — the character/persona editor surface and the coding-cockpit deck primitives.

## Coverage (34 files)
- **Added top-of-file prose headers** to the component/helper/type files that lacked one: `CharacterEditor`, `CharacterEditorPanels`, `CharacterExperienceWorkspace`, `CharacterHubView`, `CharacterLearnedSkillsSection`, `CharacterOverviewSection`, `CharacterPersonalityTimeline`, `CharacterRoster`, `CharacterRoster.helpers`, `MusicLibraryCharacterWidget`, `character-greeting`, `character-hub-helpers`, `character-hub-types`, plus the `cockpit/index` barrel.
- **Rewrote extraction / churn-narration headers into present-tense fact**: `character-editor-helpers` and `character-voice-config` (dropped "extracted from …"), and `cockpit-modes` (dropped the "that earlier duplicate was removed" change-narration, kept the single-source-of-truth invariant).
- **Concise surface-under-test / story lines** for the character + cockpit `*.stories.tsx` and cockpit `*.test.{ts,tsx}` files, noting the harness is deterministic RTL/jsdom (no network).

The six cockpit component files (`CockpitModePicker`, `CockpitNewSessionForm`, `CockpitTierToggle`, `CockpitView`, `MyRuntimesContainer`, `MyRuntimesSection`) already carry strong present-tense JSDoc on their primary export and were left untouched, as were the character files already at the bar (`CharacterExperienceView`, `CharacterSkillsView`, `CharacterHubView.back-button.test`, `useCharacterHubData`, `__tests__/character-stories-smoke.test`).

Part of #12234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)