### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-ui-b

### DIFF
--- a/packages/ui/src/components/ui/accordion.stories.tsx
+++ b/packages/ui/src/components/ui/accordion.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture exercising the Accordion primitive states; also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import type * as React from "react";
 import {

--- a/packages/ui/src/components/ui/admin-dialog.stories.tsx
+++ b/packages/ui/src/components/ui/admin-dialog.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture composing the admin-dialog chrome pieces; also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   AdminDialogBodyScroll,

--- a/packages/ui/src/components/ui/alert-dialog.stories.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture exercising the AlertDialog primitive states; also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   AlertDialog,

--- a/packages/ui/src/components/ui/alert.stories.tsx
+++ b/packages/ui/src/components/ui/alert.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture exercising the Alert primitive variants; also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Alert, AlertDescription, AlertTitle } from "./alert";
 

--- a/packages/ui/src/components/ui/avatar.stories.tsx
+++ b/packages/ui/src/components/ui/avatar.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture exercising the Avatar primitive (image + fallback); also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Avatar, AvatarFallback, AvatarImage } from "./avatar";
 

--- a/packages/ui/src/components/ui/badge.stories.tsx
+++ b/packages/ui/src/components/ui/badge.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture exercising the Badge primitive variants; also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Badge } from "./badge";
 

--- a/packages/ui/src/components/ui/banner.stories.tsx
+++ b/packages/ui/src/components/ui/banner.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture exercising the Banner primitive variants + dismiss action; also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Banner } from "./banner";
 import { Button } from "./button";

--- a/packages/ui/src/components/ui/button.stories.tsx
+++ b/packages/ui/src/components/ui/button.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture exercising the Button primitive variants and sizes; also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "./button";
 

--- a/packages/ui/src/components/ui/calendar.stories.tsx
+++ b/packages/ui/src/components/ui/calendar.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture exercising the Calendar primitive (single + range selection); also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import type { DateRange } from "react-day-picker";

--- a/packages/ui/src/components/ui/card.stories.tsx
+++ b/packages/ui/src/components/ui/card.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture composing the Card primitive parts (header/content/footer/action); also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   Card,

--- a/packages/ui/src/components/ui/carousel.stories.tsx
+++ b/packages/ui/src/components/ui/carousel.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture exercising the Carousel primitive (slides + prev/next controls); also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   Carousel,

--- a/packages/ui/src/components/ui/chart.tsx
+++ b/packages/ui/src/components/ui/chart.tsx
@@ -1,6 +1,10 @@
 /**
- * Chart components wrapping Recharts with theme support.
- * Provides chart container, legend, tooltip, and axis components with light/dark theme support.
+ * Recharts wrapper set: a context-carrying container plus tooltip and legend
+ * chrome that resolve series color/label from a `ChartConfig`, emitting
+ * per-series CSS variables scoped by light/dark theme selector.
+ *
+ * Derived from shadcn/ui `chart` (https://ui.shadcn.com/docs/components/chart);
+ * colors are wired to this package's theme tokens.
  */
 
 "use client";

--- a/packages/ui/src/components/ui/checkbox.tsx
+++ b/packages/ui/src/components/ui/checkbox.tsx
@@ -1,3 +1,8 @@
+/**
+ * Checkbox primitive over Radix `@radix-ui/react-checkbox`, styled with this
+ * package's theme tokens. Derived from shadcn/ui `checkbox`
+ * (https://ui.shadcn.com/docs/components/checkbox).
+ */
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { Check } from "lucide-react";
 import * as React from "react";

--- a/packages/ui/src/components/ui/code-block.tsx
+++ b/packages/ui/src/components/ui/code-block.tsx
@@ -1,3 +1,8 @@
+/**
+ * Monospace code renderer with an optional inline `CopyButton`. `variant`
+ * switches between a block `<pre>` and an inline `<code>` span; `copyable`
+ * requires a string value to copy.
+ */
 import * as React from "react";
 import { cn } from "../../lib/utils";
 import { CopyButton } from "./copy-button";

--- a/packages/ui/src/components/ui/collapsible.tsx
+++ b/packages/ui/src/components/ui/collapsible.tsx
@@ -1,6 +1,7 @@
 /**
- * Collapsible component system for expandable/collapsible content.
- * Built on Radix UI primitives with trigger and content components.
+ * Thin `data-slot` pass-throughs over Radix `@radix-ui/react-collapsible`.
+ * Verbatim from shadcn/ui `collapsible`
+ * (https://ui.shadcn.com/docs/components/collapsible).
  */
 "use client";
 

--- a/packages/ui/src/components/ui/confirm-delete.tsx
+++ b/packages/ui/src/components/ui/confirm-delete.tsx
@@ -1,3 +1,8 @@
+/**
+ * Inline two-step delete confirm: a trigger button that swaps in place for a
+ * prompt + confirm/cancel pair, so a destructive action needs a second click
+ * without opening a dialog.
+ */
 import * as React from "react";
 import { cn } from "../../lib/utils";
 

--- a/packages/ui/src/components/ui/confirm-dialog.stories.tsx
+++ b/packages/ui/src/components/ui/confirm-dialog.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture exercising the ConfirmDialog primitive variants (default/warn/danger); also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import * as React from "react";
 import { Button } from "./button";

--- a/packages/ui/src/components/ui/connection-status.stories.tsx
+++ b/packages/ui/src/components/ui/connection-status.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture exercising the ConnectionStatus composite states; also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ConnectionStatus } from "./connection-status";
 

--- a/packages/ui/src/components/ui/copy-button.stories.tsx
+++ b/packages/ui/src/components/ui/copy-button.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture exercising the CopyButton primitive (copy + copied-feedback state); also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { CopyButton } from "./copy-button";
 

--- a/packages/ui/src/components/ui/dialog.stories.tsx
+++ b/packages/ui/src/components/ui/dialog.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture composing the Dialog primitive parts (trigger/content/header/footer/close); also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "./button";
 import {

--- a/packages/ui/src/components/ui/dropdown-menu.stories.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture composing the DropdownMenu primitive parts (items, checkbox/radio groups, labels); also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { Button } from "./button";

--- a/packages/ui/src/components/ui/empty-state.stories.tsx
+++ b/packages/ui/src/components/ui/empty-state.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture exercising the EmptyState composite (icon + copy + action); also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "./button";
 import { EmptyState } from "./empty-state";

--- a/packages/ui/src/components/ui/error-boundary.stories.tsx
+++ b/packages/ui/src/components/ui/error-boundary.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook fixture driving the ErrorBoundary fallback via a child that throws on render; also feeds the story-gate render check. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ErrorBoundary } from "./error-boundary";
 

--- a/packages/ui/src/components/ui/error-boundary.tsx
+++ b/packages/ui/src/components/ui/error-boundary.tsx
@@ -1,3 +1,9 @@
+/**
+ * Class error boundary that catches render throws in its subtree and shows a
+ * heading + retry-button fallback (overridable via `fallback`). The optional
+ * `onError` hook lets a wrapper such as ViewErrorBoundary fire crash telemetry
+ * without re-implementing the boundary.
+ */
 import * as React from "react";
 import { Button } from "./button";
 

--- a/packages/ui/src/components/ui/field-switch.tsx
+++ b/packages/ui/src/components/ui/field-switch.tsx
@@ -1,3 +1,8 @@
+/**
+ * Controlled switch rendered as a labelled `<button role="switch">` — the toggle
+ * affordance used inside settings fields, where the whole row (label + control)
+ * is clickable.
+ */
 import * as React from "react";
 
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/ui/field.tsx
+++ b/packages/ui/src/components/ui/field.tsx
@@ -1,3 +1,8 @@
+/**
+ * Form-field layout primitives — `Field` wrapper plus `FieldLabel` /
+ * `FieldDescription` chrome — that give labelled inputs consistent spacing and
+ * label variants across settings and config forms.
+ */
 import type * as LabelPrimitive from "@radix-ui/react-label";
 import * as React from "react";
 

--- a/packages/ui/src/components/ui/form-select.tsx
+++ b/packages/ui/src/components/ui/form-select.tsx
@@ -1,3 +1,8 @@
+/**
+ * Convenience wrapper that assembles the Select primitive parts (trigger +
+ * placeholder + content) into a single labelled control for forms, so callers
+ * pass children items and a value instead of wiring the sub-parts each time.
+ */
 import type * as SelectPrimitive from "@radix-ui/react-select";
 import * as React from "react";
 

--- a/packages/ui/src/components/ui/form.tsx
+++ b/packages/ui/src/components/ui/form.tsx
@@ -1,3 +1,9 @@
+/**
+ * react-hook-form field primitives — `Form` provider plus `FormField` /
+ * `FormItem` / `FormLabel` / `FormControl` / `FormMessage` — that wire field
+ * state, ids, and aria wiring through context. Derived from shadcn/ui `form`
+ * (https://ui.shadcn.com/docs/components/form).
+ */
 "use client";
 
 import type * as LabelPrimitive from "@radix-ui/react-label";

--- a/packages/ui/src/components/ui/grid.tsx
+++ b/packages/ui/src/components/ui/grid.tsx
@@ -1,3 +1,8 @@
+/**
+ * CSS-grid layout primitive with cva variants for column count and gap — the
+ * declarative grid used to lay out cards and settings rows without hand-written
+ * grid classes.
+ */
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/ui/hover-card.tsx
+++ b/packages/ui/src/components/ui/hover-card.tsx
@@ -1,6 +1,6 @@
 /**
- * Hover card component displaying content on hover.
- * Built on Radix UI primitives with configurable positioning and animations.
+ * Hover-triggered popover over Radix `@radix-ui/react-hover-card`. Verbatim
+ * from shadcn/ui `hover-card` (https://ui.shadcn.com/docs/components/hover-card).
  */
 "use client";
 

--- a/packages/ui/src/components/ui/input-group.tsx
+++ b/packages/ui/src/components/ui/input-group.tsx
@@ -1,3 +1,8 @@
+/**
+ * Horizontal input+addon container: joins an input with leading/trailing slots
+ * (buttons, icons, text) into one bordered control with shared focus ring and
+ * density variants.
+ */
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";

--- a/packages/ui/src/components/ui/input.tsx
+++ b/packages/ui/src/components/ui/input.tsx
@@ -1,3 +1,8 @@
+/**
+ * Text-input primitive with cva variants (default, and skins used across
+ * settings/config forms). The canonical single-line input for the kit; other
+ * inputs compose it rather than re-styling a bare `<input>`.
+ */
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 

--- a/packages/ui/src/components/ui/label.tsx
+++ b/packages/ui/src/components/ui/label.tsx
@@ -1,3 +1,8 @@
+/**
+ * Form label primitive over Radix `@radix-ui/react-label`, carrying the shared
+ * disabled/peer styling. Derived from shadcn/ui `label`
+ * (https://ui.shadcn.com/docs/components/label).
+ */
 import * as LabelPrimitive from "@radix-ui/react-label";
 import * as React from "react";
 

--- a/packages/ui/src/components/ui/new-action-button.tsx
+++ b/packages/ui/src/components/ui/new-action-button.tsx
@@ -1,3 +1,8 @@
+/**
+ * Full-width "new item" Button with a leading plus icon — the create affordance
+ * at the top of list/panel views. Strips a leading "+ " from string children so
+ * the icon is not doubled.
+ */
 import { Plus } from "lucide-react";
 import * as React from "react";
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/ui/pagination.tsx
+++ b/packages/ui/src/components/ui/pagination.tsx
@@ -1,6 +1,7 @@
 /**
- * Pagination component system for navigating through pages.
- * Provides previous/next navigation, page numbers, and ellipsis for large page counts.
+ * Page-navigation primitives — prev/next links, numbered page items, and an
+ * ellipsis for large ranges. Derived from shadcn/ui `pagination`
+ * (https://ui.shadcn.com/docs/components/pagination).
  */
 
 import {

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -1,3 +1,8 @@
+/**
+ * Popover primitives over Radix `@radix-ui/react-popover`, with themed,
+ * portal-rendered content. Derived from shadcn/ui `popover`
+ * (https://ui.shadcn.com/docs/components/popover).
+ */
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import * as React from "react";
 

--- a/packages/ui/src/components/ui/progress.tsx
+++ b/packages/ui/src/components/ui/progress.tsx
@@ -1,3 +1,8 @@
+/**
+ * Determinate progress bar over Radix `@radix-ui/react-progress`, themed to the
+ * kit tokens. Derived from shadcn/ui `progress`
+ * (https://ui.shadcn.com/docs/components/progress).
+ */
 "use client";
 
 import * as ProgressPrimitive from "@radix-ui/react-progress";

--- a/packages/ui/src/components/ui/save-footer.tsx
+++ b/packages/ui/src/components/ui/save-footer.tsx
@@ -1,3 +1,7 @@
+/**
+ * Sticky settings-form footer that reflects dirty/saving/saved/error state on a
+ * single Save button — the shared bottom bar for editable config panels.
+ */
 import * as React from "react";
 import { cn } from "../../lib/utils";
 import { Button } from "./button";

--- a/packages/ui/src/components/ui/scroll-area.tsx
+++ b/packages/ui/src/components/ui/scroll-area.tsx
@@ -1,6 +1,7 @@
 /**
- * Scroll area component with custom scrollbar styling.
- * Built on Radix UI primitives with horizontal and vertical scrollbar support.
+ * Custom-scrollbar scroll container over Radix `@radix-ui/react-scroll-area`,
+ * with horizontal and vertical bars. Derived from shadcn/ui `scroll-area`
+ * (https://ui.shadcn.com/docs/components/scroll-area).
  */
 "use client";
 

--- a/packages/ui/src/components/ui/segmented-control.tsx
+++ b/packages/ui/src/components/ui/segmented-control.tsx
@@ -1,3 +1,8 @@
+/**
+ * Single-select segmented button group (generic over the value union) — the
+ * inline toggle used for small mutually-exclusive choices where tabs would be
+ * too heavy. Items may carry a badge and a per-item test id.
+ */
 import type * as React from "react";
 
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -1,3 +1,9 @@
+/**
+ * Select primitives over Radix `@radix-ui/react-select`, with themed trigger,
+ * portal content, and items. Derived from shadcn/ui `select`
+ * (https://ui.shadcn.com/docs/components/select); content is tagged with the
+ * config-select floating-layer name so it stacks correctly inside config dialogs.
+ */
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp } from "lucide-react";
 import * as React from "react";

--- a/packages/ui/src/components/ui/separator.tsx
+++ b/packages/ui/src/components/ui/separator.tsx
@@ -1,3 +1,7 @@
+/**
+ * Horizontal/vertical divider over Radix `@radix-ui/react-separator`. Derived
+ * from shadcn/ui `separator` (https://ui.shadcn.com/docs/components/separator).
+ */
 import * as SeparatorPrimitive from "@radix-ui/react-separator";
 import * as React from "react";
 

--- a/packages/ui/src/components/ui/settings-controls.tsx
+++ b/packages/ui/src/components/ui/settings-controls.tsx
@@ -1,3 +1,8 @@
+/**
+ * Settings-form control skins that wrap the Field/Input/Select/Textarea
+ * primitives with the compact variants used across settings and config panels,
+ * so each panel doesn't re-derive the same trigger/label styling.
+ */
 import * as React from "react";
 
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/ui/skeleton.tsx
+++ b/packages/ui/src/components/ui/skeleton.tsx
@@ -3,10 +3,9 @@ import * as React from "react";
 import { cn } from "../../lib/utils";
 
 /**
- * The only Skeleton primitive with consumers. The other variants
- * (SkeletonLine, SkeletonText, SkeletonCard, SkeletonChat,
- * SkeletonMessage, SkeletonSidebar) were deleted in the Layer 5b sweep
- * — none had consumers outside this file.
+ * Base skeleton block: an aria-hidden pulsing placeholder. The single skeleton
+ * primitive in the kit — composite shapes live in `skeleton-layouts.tsx`, built
+ * on this.
  */
 const Skeleton = React.forwardRef<
   HTMLDivElement,

--- a/packages/ui/src/components/ui/slider.tsx
+++ b/packages/ui/src/components/ui/slider.tsx
@@ -1,3 +1,7 @@
+/**
+ * Range slider over Radix `@radix-ui/react-slider`, themed to the kit tokens.
+ * Derived from shadcn/ui `slider` (https://ui.shadcn.com/docs/components/slider).
+ */
 import * as SliderPrimitive from "@radix-ui/react-slider";
 import * as React from "react";
 

--- a/packages/ui/src/components/ui/spinner.tsx
+++ b/packages/ui/src/components/ui/spinner.tsx
@@ -1,3 +1,7 @@
+/**
+ * Spinning `Loader2` icon at a configurable size — the kit's inline loading
+ * indicator for buttons and small in-flight regions.
+ */
 import { Loader2 } from "lucide-react";
 import * as React from "react";
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/ui/stack.tsx
+++ b/packages/ui/src/components/ui/stack.tsx
@@ -1,3 +1,8 @@
+/**
+ * Flexbox layout primitive with cva variants for direction, gap, and alignment
+ * — the declarative row/column used to compose spacing without hand-written
+ * flex classes.
+ */
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/ui/status-badge.helpers.ts
+++ b/packages/ui/src/components/ui/status-badge.helpers.ts
@@ -1,3 +1,10 @@
+/**
+ * Pure mappers from raw status strings to StatusBadge tone + display label,
+ * split out from the component so they can be unit-tested and reused without a
+ * React render. `statusToneForState` classifies success/warning/danger/muted;
+ * `agentLifecycleLabel` maps the cloud-agent lifecycle enum to friendlier
+ * first-run copy while `statusLabelForState` stays a generic title-caser.
+ */
 import type { StatusVariant } from "./status-badge";
 
 export function statusToneForBoolean(

--- a/packages/ui/src/components/ui/status-badge.tsx
+++ b/packages/ui/src/components/ui/status-badge.tsx
@@ -1,3 +1,8 @@
+/**
+ * Small status pill in one of a fixed tone set (success/warning/danger/…), with
+ * a spinning variant for in-flight states. Tone/label derivation from raw status
+ * strings lives in `status-badge.helpers.ts`.
+ */
 import { Loader2 } from "lucide-react";
 import * as React from "react";
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/ui/switch.tsx
+++ b/packages/ui/src/components/ui/switch.tsx
@@ -1,3 +1,8 @@
+/**
+ * On/off switch rendered as a `<button role="switch">` (controlled or
+ * uncontrolled) — a dependency-free toggle that does not pull in Radix, used
+ * wherever a bare boolean switch is needed.
+ */
 import * as React from "react";
 
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/ui/table.tsx
+++ b/packages/ui/src/components/ui/table.tsx
@@ -1,6 +1,7 @@
 /**
- * Table component system for displaying tabular data.
- * Provides table, header, body, footer, row, and cell components with consistent styling.
+ * Table primitives — `Table` wrapper plus header/body/footer/row/head/cell parts
+ * with shared styling. Derived from shadcn/ui `table`
+ * (https://ui.shadcn.com/docs/components/table).
  */
 import * as React from "react";
 

--- a/packages/ui/src/components/ui/tabs.tsx
+++ b/packages/ui/src/components/ui/tabs.tsx
@@ -1,3 +1,8 @@
+/**
+ * Tabs primitives over Radix `@radix-ui/react-tabs` (list, trigger, content),
+ * themed to the kit tokens. Derived from shadcn/ui `tabs`
+ * (https://ui.shadcn.com/docs/components/tabs).
+ */
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 import * as React from "react";
 

--- a/packages/ui/src/components/ui/tag-editor.tsx
+++ b/packages/ui/src/components/ui/tag-editor.tsx
@@ -1,3 +1,8 @@
+/**
+ * Editable list of string tags: an input that adds items on enter and renders
+ * each as a removable chip — the tag/keyword editor used in settings and
+ * config forms. De-duplicates and reports the full list via `onChange`.
+ */
 import { X } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 

--- a/packages/ui/src/components/ui/textarea.tsx
+++ b/packages/ui/src/components/ui/textarea.tsx
@@ -1,3 +1,7 @@
+/**
+ * Multi-line text-input primitive with cva variants, mirroring the Input skins
+ * so single- and multi-line fields share styling across settings/config forms.
+ */
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 

--- a/packages/ui/src/components/ui/toggle.tsx
+++ b/packages/ui/src/components/ui/toggle.tsx
@@ -1,6 +1,7 @@
 /**
- * Toggle component for toggling states with visual feedback.
- * Built on Radix UI primitives with variant and size support.
+ * Two-state toggle button over Radix `@radix-ui/react-toggle`, with cva variant
+ * and size options. Derived from shadcn/ui `toggle`
+ * (https://ui.shadcn.com/docs/components/toggle).
  */
 "use client";
 

--- a/packages/ui/src/components/ui/tooltip-extended.tsx
+++ b/packages/ui/src/components/ui/tooltip-extended.tsx
@@ -5,11 +5,9 @@ import { cn } from "../../lib/utils";
 // is kept inline so the scanner emits the utility.
 
 /**
- * Hover-only tooltip with optional shortcut hint — the icon-button affordance
- * primitive exported from the kit. The other extended-tooltip primitives
- * (HoverTooltip, Spotlight, useGuidedTour, TourStep) were deleted as
- * zero-consumer in the Layer 5b sweep — their last shipping surface was a
- * guided-tour feature that was never wired up.
+ * Hover-only tooltip with an optional shortcut hint — the icon-button
+ * affordance primitive exported from the kit, sitting above the base Radix
+ * `tooltip.tsx` primitives.
  */
 export function IconTooltip({
   children,

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -1,3 +1,9 @@
+/**
+ * Tooltip primitives over Radix `@radix-ui/react-tooltip` (provider, root,
+ * trigger, themed content). Derived from shadcn/ui `tooltip`
+ * (https://ui.shadcn.com/docs/components/tooltip). Richer affordances
+ * (icon-button tooltip with shortcut hint) live in `tooltip-extended.tsx`.
+ */
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import * as React from "react";
 

--- a/packages/ui/src/components/ui/typography.tsx
+++ b/packages/ui/src/components/ui/typography.tsx
@@ -1,3 +1,8 @@
+/**
+ * Text/typography primitive with cva variants for the kit's type scale — the
+ * canonical way to render headings and body copy so font size/weight/color
+ * come from tokens instead of ad-hoc classes.
+ */
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 


### PR DESCRIPTION
Comments-only slice of #12234 (chunk **b04-ui-b**, shard 2 of 2), scoped to `packages/ui/src/components/ui`.

`check:comment-only` passes — the code token stream is byte-for-byte unchanged vs `origin/develop` (58 source files changed, comments only).

## What changed
Adds a top-of-file `/** … */` prose header to the shadcn-derived primitives and Storybook fixtures in this shard that lacked one, and repairs headers that were template boilerplate or change-narration:

- **Churn/narration removed:** `skeleton.tsx` ("Layer 5b sweep" deletion story), `tooltip-extended.tsx` (deleted-variants story) — rewritten to present-tense fact.
- **Template boilerplate replaced** (was repeating the filename): `chart.tsx`, `collapsible.tsx`, `hover-card.tsx`, `pagination.tsx`, `scroll-area.tsx`, `table.tsx`, `toggle.tsx`.
- **Provenance noted** on the Radix-backed primitives that are shadcn/ui-derived (checkbox, collapsible, form, hover-card, label, pagination, popover, progress, scroll-area, select, separator, slider, table, tabs, toggle, tooltip, chart) with a link to the upstream shadcn/ui component. Milady-specific composites (code-block, confirm-delete, save-footer, segmented-control, settings-controls, tag-editor, new-action-button, error-boundary, field/field-switch, form-select, grid/stack/typography, spinner, status-badge*, switch) carry no provenance claim.
- **Story fixtures** get a 1-line header stating the primitive under test and that they also feed the story-gate render check.

## Coverage
- Subtree: `packages/ui/src/components/ui` (shard 2 of 2 — disjoint from the sibling shard).
- Files touched: **58** (headers/in-body comments only).
- `skeleton-layouts.tsx` left untouched — already carries a durable prose header.
- Files remaining in this shard still lacking a proper header: **0**.

Part of #12234.