### PR TITLE
chore(#12236): comment cleanup B06 — cloud/shared cache subtree (comment-only)

### DIFF
--- a/packages/cloud/shared/src/lib/cache/__tests__/client-mock.test.ts
+++ b/packages/cloud/shared/src/lib/cache/__tests__/client-mock.test.ts
@@ -1,3 +1,5 @@
+/** Exercises CacheClient against the in-memory mock backend (MOCK_REDIS=1); no real Redis. */
+
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
 const PREV_MOCK = process.env.MOCK_REDIS;

--- a/packages/cloud/shared/src/lib/cache/__tests__/client-worker-rest.test.ts
+++ b/packages/cloud/shared/src/lib/cache/__tests__/client-worker-rest.test.ts
@@ -1,3 +1,5 @@
+/** Verifies CacheClient selects the Upstash REST backend in Worker envs, with the Upstash client mocked. */
+
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const constructedClients: Array<{ url: string; token: string }> = [];

--- a/packages/cloud/shared/src/lib/cache/__tests__/redis-factory-mock.test.ts
+++ b/packages/cloud/shared/src/lib/cache/__tests__/redis-factory-mock.test.ts
@@ -1,3 +1,5 @@
+/** Covers buildRedisClient/hasRedisConfig under MOCK_REDIS=1; no real Redis connection. */
+
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
 const PREV_MOCK = process.env.MOCK_REDIS;

--- a/packages/cloud/shared/src/lib/cache/adapters/kv-cache-adapter.ts
+++ b/packages/cloud/shared/src/lib/cache/adapters/kv-cache-adapter.ts
@@ -1,3 +1,8 @@
+/**
+ * CacheRedisClient adapter backed by a Cloudflare KV namespace binding, for
+ * Worker environments where a KV store stands in for Redis.
+ */
+
 import type { CacheRedisClient } from "./types";
 
 /**

--- a/packages/cloud/shared/src/lib/cache/adapters/memory-cache-adapter.ts
+++ b/packages/cloud/shared/src/lib/cache/adapters/memory-cache-adapter.ts
@@ -1,3 +1,9 @@
+/**
+ * In-process CacheRedisClient with no external backend, used for tests and
+ * single-process local runs. Holds string values and lists in Maps with manual
+ * TTL expiry checked on read.
+ */
+
 import type { CacheRedisClient } from "./types";
 
 export class MemoryCacheAdapter implements CacheRedisClient {

--- a/packages/cloud/shared/src/lib/cache/adapters/node-redis-adapter.ts
+++ b/packages/cloud/shared/src/lib/cache/adapters/node-redis-adapter.ts
@@ -1,3 +1,8 @@
+/**
+ * CacheRedisClient adapter over the node `redis` package, used by Node/Bun
+ * services (Railway) that can open a native TCP connection.
+ */
+
 import type { createClient } from "redis";
 import type { CacheRedisClient } from "./types";
 

--- a/packages/cloud/shared/src/lib/cache/adapters/socket-redis-adapter.ts
+++ b/packages/cloud/shared/src/lib/cache/adapters/socket-redis-adapter.ts
@@ -1,3 +1,8 @@
+/**
+ * CacheRedisClient adapter over the RESP2 SocketRedis client, used on
+ * Cloudflare Workers where only `cloudflare:sockets` TCP is available.
+ */
+
 import type { SocketRedis } from "../socket-redis";
 import type { CacheRedisClient } from "./types";
 

--- a/packages/cloud/shared/src/lib/cache/adapters/upstash-redis-adapter.ts
+++ b/packages/cloud/shared/src/lib/cache/adapters/upstash-redis-adapter.ts
@@ -1,3 +1,8 @@
+/**
+ * CacheRedisClient adapter over the Upstash REST Redis client, for environments
+ * that reach Redis over HTTP rather than a raw socket.
+ */
+
 import type { Redis as UpstashRedis } from "@upstash/redis";
 import type { CacheRedisClient } from "./types";
 

--- a/packages/cloud/shared/src/lib/cache/adapters/wadis-redis-adapter.ts
+++ b/packages/cloud/shared/src/lib/cache/adapters/wadis-redis-adapter.ts
@@ -1,3 +1,9 @@
+/**
+ * CacheRedisClient adapter over Wadis, the in-process WASM Redis used as the
+ * local-dev default (no Docker) in non-Worker environments. WadisClientLike is
+ * the structural subset this adapter depends on, avoiding a hard `wadis` import.
+ */
+
 import type { CacheRedisClient } from "./types";
 
 export interface WadisClientLike {

--- a/packages/cloud/shared/src/lib/cache/connection-cache.ts
+++ b/packages/cloud/shared/src/lib/cache/connection-cache.ts
@@ -1,13 +1,14 @@
+/**
+ * Two-tier cache of established Eliza room-entity connections, keeping the
+ * message path from re-running ensureConnection() (a DB write) on every turn.
+ */
+
 import { logger } from "../utils/logger";
 import { cache } from "./client";
 
 /**
- * Connection Cache Service
- *
- * Tracks established Eliza room-entity connections to avoid redundant
- * ensureConnection() calls which hit the database on every message.
- *
- * Architecture: Service-layer caching with Redis backend
+ * Tracks established room-entity connections behind an in-memory map plus a
+ * Redis second level, so repeat messages skip the ensureConnection() DB round-trip.
  */
 export class ConnectionCache {
   private static instance: ConnectionCache;

--- a/packages/cloud/shared/src/lib/cache/organizations-cache.ts
+++ b/packages/cloud/shared/src/lib/cache/organizations-cache.ts
@@ -1,14 +1,10 @@
 /**
- * Organization Cache Layer
+ * Read-through cache for organization records fetched during MCP tool calls.
  *
- * Provides caching for organization data to reduce database load in MCP operations.
- * Each MCP tool call previously hit the database to fetch organization data.
- * With this cache, we reduce DB queries by ~90% for organization lookups.
- *
- * Performance Impact:
- * - Before: 20+ DB queries per MCP request
- * - After: 0-2 DB queries per MCP request (depending on cache state)
- * - Cache hit latency: ~5ms (vs 50-100ms DB query)
+ * MCP requests resolve organization data repeatedly; caching collapses the
+ * per-request DB lookups (20+ down to 0-2 depending on cache state) and serves
+ * hits at ~5ms versus a 50-100ms query. Backed by the shared Redis cache
+ * client and sourced from organizationsService.
  */
 
 import type { Organization } from "../../db/repositories";

--- a/packages/cloud/shared/src/lib/cache/socket-redis.ts
+++ b/packages/cloud/shared/src/lib/cache/socket-redis.ts
@@ -3,7 +3,7 @@
  *
  * Why this exists: Workers cannot use the `redis` or `ioredis` npm packages
  * (both depend on Node's `net` module). Upstash REST is the usual workaround
- * but we now run Redis on Railway (TCP only), so we speak RESP2 directly via
+ * but Redis runs on Railway (TCP only), so we speak RESP2 directly via
  * the Workers `connect()` API.
  *
  * One socket per CacheClient instance; reused across pipelined ops within


### PR DESCRIPTION
Part of #12181 (repo-wide comment cleanup). Batch B06 — `packages/cloud/shared`.

**Comment-only; `check:comment-only` PASSES** (`node scripts/assert-comment-only-diff.mjs origin/develop` → "OK — 12 source file(s) changed; every code token identical to origin/develop. Comments only."). The code token stream is byte-for-byte unchanged.

## Slice

`packages/cloud/shared/src/lib/cache` — the churn-flagged cache subtree (Redis adapters + tests). One coherent subtree, 12 files.

## What changed

- **Prose file headers added (9 files):** the six `adapters/*.ts` backends (KV, memory, node-redis, socket-redis, Upstash REST, Wadis WASM), `connection-cache.ts`, and the three `__tests__/*.test.ts` (1-line headers naming the surface under test and that the harness is mock/in-memory, not real Redis).
- **Churn rewritten to present tense (2 files):** `organizations-cache.ts` header ("previously…", "Before/After" narrative → durable present-tense statement of the caching contract) and `socket-redis.ts` ("but we now run Redis on Railway" → "but Redis runs on Railway").
- Files already at the bar (e.g. `client.ts`, `types.ts`, `mock-redis.ts`, `redis-factory.ts`, `billing/*`) were left alone.

## Tallies

- Files touched: 12
- Headers added: 9
- Churn comments rewritten: 2
- filesFlagged: none

Refs #12236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
