### PR TITLE
chore(#12239): comment cleanup B09 — Feed e2e prose headers (comment-only)

### DIFF
--- a/packages/feed/tools/e2e/playwright.config.mjs
+++ b/packages/feed/tools/e2e/playwright.config.mjs
@@ -1,3 +1,11 @@
+/**
+ * Playwright configuration for the Feed web end-to-end suite. Runs the tests/
+ * specs serially (single worker, one retry) under desktop Chromium against a
+ * live app. The webServer block boots the keyless localnet harness (anvil +
+ * contracts + app via tools/chroma/dev-server.ts) when the target port is free
+ * and reuses an already-running server otherwise, gating readiness on
+ * /api/health returning 200.
+ */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig, devices } from "@playwright/test";

--- a/packages/feed/tools/e2e/tests/01-authentication.spec.ts
+++ b/packages/feed/tools/e2e/tests/01-authentication.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Exercises the wallet login and logout flow and the authenticated/unauthenticated view split.
+ */
 import { expect, test } from "./fixtures";
 import { pageContainsText } from "./helpers/interaction-helpers";
 import {

--- a/packages/feed/tools/e2e/tests/02-page-navigation.spec.ts
+++ b/packages/feed/tools/e2e/tests/02-page-navigation.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Covers routing across public and authenticated pages.
+ */
 import { expect, test } from "./fixtures";
 import { pageContainsText } from "./helpers/interaction-helpers";
 import {

--- a/packages/feed/tools/e2e/tests/03-feed-interactions.spec.ts
+++ b/packages/feed/tools/e2e/tests/03-feed-interactions.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Exercises the social feed: post rendering, like/comment interactions, and scroll-to-load-more.
+ */
 import { expect, test } from "./fixtures";
 import {
   clickTab,

--- a/packages/feed/tools/e2e/tests/04-markets.spec.ts
+++ b/packages/feed/tools/e2e/tests/04-markets.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Covers the markets dashboard — prediction markets and perpetuals, including trade modals.
+ */
 import { expect, test } from "./fixtures";
 import {
   clickTab,

--- a/packages/feed/tools/e2e/tests/05-profile.spec.ts
+++ b/packages/feed/tools/e2e/tests/05-profile.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Covers the profile pages (own profile and other users) and their tabs.
+ */
 import { expect, test } from "./fixtures";
 import { clickTab, pageContainsText } from "./helpers/interaction-helpers";
 import {

--- a/packages/feed/tools/e2e/tests/06-settings.spec.ts
+++ b/packages/feed/tools/e2e/tests/06-settings.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Covers the settings tabs: profile, theme, notifications, privacy, security, API keys, and social linking.
+ */
 import { expect, test } from "./fixtures";
 import {
   clickTab,
@@ -297,10 +302,6 @@ test.describe("Settings - Security Tab", () => {
     );
     expect(hasContent).toBe(true);
   });
-
-  // "2FA option present" was deleted: the SecurityTab component has no 2FA /
-  // two-factor feature, so the spec tested a feature that does not exist and
-  // could only ever pass vacuously.
 });
 
 test.describe("Settings - API Keys Tab", () => {

--- a/packages/feed/tools/e2e/tests/07-chats.spec.ts
+++ b/packages/feed/tools/e2e/tests/07-chats.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Covers the chats layout and messaging surface.
+ */
 import { expect, test } from "./fixtures";
 import {
   clickTab,

--- a/packages/feed/tools/e2e/tests/08-admin-panel.spec.ts
+++ b/packages/feed/tools/e2e/tests/08-admin-panel.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Covers the admin panel dashboard and its controls.
+ */
 import { expect, test } from "./fixtures";
 import {
   clickTab,

--- a/packages/feed/tools/e2e/tests/09-edge-cases.spec.ts
+++ b/packages/feed/tools/e2e/tests/09-edge-cases.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Security and edge-case coverage — XSS prevention, malformed URLs, and invalid input handling.
+ */
 import { expect, test } from "./fixtures";
 import { fillAndVerify, pageContainsText } from "./helpers/interaction-helpers";
 import {

--- a/packages/feed/tools/e2e/tests/10-mobile-responsive.spec.ts
+++ b/packages/feed/tools/e2e/tests/10-mobile-responsive.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Asserts core pages have no horizontal overflow at the mobile viewport.
+ */
 import { expect, test } from "./fixtures";
 import { clickTab, pageContainsText } from "./helpers/interaction-helpers";
 import {

--- a/packages/feed/tools/e2e/tests/12-wallet.spec.ts
+++ b/packages/feed/tools/e2e/tests/12-wallet.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Covers the wallet page tabs and balance/holdings views.
+ */
 import { expect, test } from "./fixtures";
 import {
   clickTab,

--- a/packages/feed/tools/e2e/tests/13-rewards.spec.ts
+++ b/packages/feed/tools/e2e/tests/13-rewards.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Covers the rewards page.
+ */
 import { expect, test } from "./fixtures";
 import { clickTab, pageContainsText } from "./helpers/interaction-helpers";
 import {

--- a/packages/feed/tools/e2e/tests/14-leaderboard.spec.ts
+++ b/packages/feed/tools/e2e/tests/14-leaderboard.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Covers the leaderboard — tab toggles, pagination, and row interactions.
+ */
 import { expect, test } from "./fixtures";
 import { clickTab, pageContainsText } from "./helpers/interaction-helpers";
 import {

--- a/packages/feed/tools/e2e/tests/16-agents-deep.spec.ts
+++ b/packages/feed/tools/e2e/tests/16-agents-deep.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Deep coverage of the agents surface: list, creation, and detail views.
+ */
 import { expect, test } from "./fixtures";
 import {
   clickTab,

--- a/packages/feed/tools/e2e/tests/17-post-detail.spec.ts
+++ b/packages/feed/tools/e2e/tests/17-post-detail.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Covers the post-detail page: load, interactions, and comment threads.
+ */
 import type { Page } from "@playwright/test";
 import { expect, test } from "./fixtures";
 import { pageContainsText } from "./helpers/interaction-helpers";

--- a/packages/feed/tools/e2e/tests/18-research.spec.ts
+++ b/packages/feed/tools/e2e/tests/18-research.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Covers the research request form.
+ */
 import { expect, test } from "./fixtures";
 import { fillAndVerify } from "./helpers/interaction-helpers";
 import {

--- a/packages/feed/tools/e2e/tests/19-uncovered-pages.spec.ts
+++ b/packages/feed/tools/e2e/tests/19-uncovered-pages.spec.ts
@@ -1,3 +1,8 @@
+/**
+ * Playwright e2e coverage driving a real MetaMask wallet (@avalix/chroma + Privy) against a live Feed dev server; every spec skips when the /api/health check fails.
+ *
+ * Smoke coverage of otherwise-uncovered user, misc, and admin sub-routes.
+ */
 import { expect, test } from "./fixtures";
 import { pageContainsText } from "./helpers/interaction-helpers";
 import {


### PR DESCRIPTION
## Comment cleanup B09 (slice: `packages/feed/tools/e2e`)

Part of #12239 (batch B09 of the repo-wide comment cleanup, parent #12181).

**Comment-only; `check:comment-only` PASSES** — the code token stream is byte-for-byte identical to `origin/develop` (`node scripts/assert-comment-only-diff.mjs origin/develop`: *"18 source file(s) changed; every code token identical to origin/develop. Comments only."*).

### What changed
- **Prose file headers added: 18** — the Feed web Playwright e2e suite (`playwright.config.mjs` + 17 spec files). Test-file headers are 1–3 lines stating the surface under test and how real the harness is: live Feed dev server, real MetaMask wallet via `@avalix/chroma` + Privy, gated on `/api/health`. The config header describes the serial single-worker run and the keyless-localnet `webServer` boot.
- **Churn removed: 1 comment (3 lines)** — a `"2FA option present" was deleted…` change-narration block in `tests/06-settings.spec.ts` (diff annotation for a removed spec; history lives in git).

### Scope note
Batch B09 is large (~1,264 files). This PR is one bounded, coherent slice (`tools/e2e`, ≤50 files per the parent's merge-pain rule). Other slices of B09 (`apps/web`, `scripts`, `tools/chroma`, `apps/mobile`) are separate PRs.

### Files flagged
None — every file in this slice is a Playwright e2e spec/config with a clear, determinable purpose.

Refs #12239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
