### PR TITLE
docs(#12241): add browser extension headers

### DIFF
--- a/packages/browser-extension/entrypoints/background.ts
+++ b/packages/browser-extension/entrypoints/background.ts
@@ -1,3 +1,10 @@
+/**
+ * Browser extension service worker for pairing, sync, session execution, and site blocking.
+ *
+ * This is the long-lived bridge between browser APIs, content scripts, popup
+ * controls, and the elizaOS browser-bridge API.
+ */
+
 import type { LifeOpsBrowserSession } from "@elizaos/shared";
 import { BrowserBridgeRelayClient, RelayApiError } from "../src/api-client";
 import type {

--- a/packages/browser-extension/entrypoints/blocked.ts
+++ b/packages/browser-extension/entrypoints/blocked.ts
@@ -1,3 +1,10 @@
+/**
+ * Blocked-site page controller for LifeOps website-blocker redirects.
+ *
+ * It renders the blocked host, polls the agent API for required tasks, and
+ * returns the user to the original URL once the block is lifted.
+ */
+
 const POLL_INTERVAL_MS = 30_000;
 
 interface RequiredTask {

--- a/packages/browser-extension/entrypoints/content.ts
+++ b/packages/browser-extension/entrypoints/content.ts
@@ -1,3 +1,10 @@
+/**
+ * Content script message bridge for page capture and DOM actions.
+ *
+ * Runs inside allowlisted pages and keeps all page-reading and in-page action
+ * execution behind typed messages from the background service worker.
+ */
+
 import { runDomAction } from "../src/dom-actions";
 import { capturePageContext } from "../src/page-extract";
 import type {

--- a/packages/browser-extension/entrypoints/popup.ts
+++ b/packages/browser-extension/entrypoints/popup.ts
@@ -1,3 +1,10 @@
+/**
+ * Popup UI controller for browser-bridge pairing, status, and manual sync.
+ *
+ * Reads form state, talks to the background service worker, and renders the
+ * pure popup status model into the extension popup DOM.
+ */
+
 import { derivePopupStatusModel } from "../src/popup-model";
 import type {
   BackgroundState,

--- a/packages/browser-extension/entrypoints/wallet-shim.ts
+++ b/packages/browser-extension/entrypoints/wallet-shim.ts
@@ -1,3 +1,10 @@
+/**
+ * Document-start wallet shim injector for pages granted browser-bridge access.
+ *
+ * Reads the stored wallet bridge config and bakes it into the wallet shim
+ * template before injecting the script into the page's main world.
+ */
+
 declare const __WALLET_SHIM_TEMPLATE__: string;
 
 interface WalletShimStored {

--- a/packages/browser-extension/scripts/build.mjs
+++ b/packages/browser-extension/scripts/build.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env bun
+/**
+ * Build script for Chrome and Safari browser-bridge extension bundles.
+ *
+ * Produces IIFE entrypoint bundles, generated manifests, static assets, and
+ * wallet-shim template defines under dist/<chrome|safari>/.
+ */
+
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/browser-extension/scripts/extension-smoke-safari.mjs
+++ b/packages/browser-extension/scripts/extension-smoke-safari.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+/**
+ * Safari Web Extension smoke test for the Agent Browser Bridge package.
+ *
+ * Builds the Safari target, drives Safari developer tooling through local
+ * commands and AppleScript, and verifies the generated extension can load.
+ */
+
 import { spawn } from "node:child_process";
 import http from "node:http";
 import os from "node:os";

--- a/packages/browser-extension/scripts/extension-smoke.mjs
+++ b/packages/browser-extension/scripts/extension-smoke.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+/**
+ * Chrome smoke test for built Agent Browser Bridge artifacts.
+ *
+ * Builds the Chrome extension, starts a local agent-compatible HTTP fixture,
+ * and uses Playwright to verify the packaged extension can pair and sync.
+ */
+
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import http from "node:http";

--- a/packages/browser-extension/scripts/package-chrome.mjs
+++ b/packages/browser-extension/scripts/package-chrome.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env bun
+/**
+ * Chrome Web Store packaging script for the browser-bridge extension.
+ *
+ * Rebuilds the Chrome target and writes both stable and versioned zip
+ * artifacts under dist/artifacts/.
+ */
+
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/browser-extension/scripts/package-release.mjs
+++ b/packages/browser-extension/scripts/package-release.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env bun
+/**
+ * Release packaging orchestrator for browser-bridge store artifacts.
+ *
+ * Runs the Chrome, Safari, and store-metadata packagers, then writes a release
+ * manifest with install URLs and versioned artifact names.
+ */
+
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/browser-extension/scripts/package-safari.mjs
+++ b/packages/browser-extension/scripts/package-safari.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env bun
+/**
+ * Safari packaging script for the browser-bridge extension.
+ *
+ * Builds the Safari Web Extension target, generates an Xcode wrapper project,
+ * patches bundle versions, and archives versioned release artifacts.
+ */
+
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/browser-extension/scripts/package-store-assets.mjs
+++ b/packages/browser-extension/scripts/package-store-assets.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env bun
+/**
+ * Store-listing metadata generator for browser-bridge release submissions.
+ *
+ * Writes Chrome and Safari submission JSON that describes permissions,
+ * artifact names, support URLs, and listing copy for the packaged extension.
+ */
+
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/browser-extension/scripts/release-version.mjs
+++ b/packages/browser-extension/scripts/release-version.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+/**
+ * Release-version helpers for browser-bridge package and store artifacts.
+ *
+ * Normalizes semver tags, derives Chrome/Safari-compatible version numbers,
+ * and builds versioned artifact names and GitHub release URLs.
+ */
+
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/browser-extension/scripts/script-utils.mjs
+++ b/packages/browser-extension/scripts/script-utils.mjs
@@ -1,3 +1,7 @@
+/**
+ * Shared process and filesystem helpers for browser-extension packaging scripts.
+ */
+
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";

--- a/packages/browser-extension/src/api-client.test.ts
+++ b/packages/browser-extension/src/api-client.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the browser-bridge relay HTTP client.
+ *
+ * The harness stubs fetch to verify endpoint construction, pairing headers,
+ * and API error normalization without contacting an agent.
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BrowserBridgeRelayClient, type RelayApiError } from "./api-client";
 import type {

--- a/packages/browser-extension/src/api-client.ts
+++ b/packages/browser-extension/src/api-client.ts
@@ -1,3 +1,10 @@
+/**
+ * Typed HTTP client for browser-bridge companion sync and session endpoints.
+ *
+ * All requests carry the pairing token and companion ID expected by the agent
+ * API routes mounted by the browser plugin.
+ */
+
 import type { LifeOpsBrowserCompanionSyncResponse } from "@elizaos/shared";
 import type {
   CompanionConfig,

--- a/packages/browser-extension/src/browser-bridge-contracts.ts
+++ b/packages/browser-extension/src/browser-bridge-contracts.ts
@@ -1,3 +1,7 @@
+/**
+ * Data contracts shared between the browser extension and browser-bridge API.
+ */
+
 export type BrowserBridgeKind = "chrome" | "safari";
 
 export type BrowserBridgeTrackingMode = "off" | "current_tab" | "active_tabs";

--- a/packages/browser-extension/src/dom-actions.test.ts
+++ b/packages/browser-extension/src/dom-actions.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for in-page browser action execution.
+ *
+ * The jsdom harness checks hostile text handling, selector validation, and
+ * DOM event dispatch without loading a real extension context.
+ */
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-dom-setup";
 import { runDomAction } from "./dom-actions";

--- a/packages/browser-extension/src/dom-actions.ts
+++ b/packages/browser-extension/src/dom-actions.ts
@@ -1,3 +1,10 @@
+/**
+ * In-page DOM action executor for browser-bridge content scripts.
+ *
+ * Handles click, type, submit, and history actions against the live page while
+ * rejecting invalid selectors and unsupported targets.
+ */
+
 import type { DomActionRequest } from "./protocol";
 
 function requireElement(selector?: string | null): HTMLElement {

--- a/packages/browser-extension/src/page-extract.test.ts
+++ b/packages/browser-extension/src/page-extract.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for page-context extraction from a live DOM.
+ *
+ * The jsdom harness verifies visible text, headings, links, and form metadata
+ * while guarding against hidden or password-field leakage.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-dom-setup";
 import { capturePageContext } from "./page-extract";

--- a/packages/browser-extension/src/page-extract.ts
+++ b/packages/browser-extension/src/page-extract.ts
@@ -1,3 +1,10 @@
+/**
+ * Page-context extractor for browser-bridge content scripts.
+ *
+ * Captures visible text, headings, links, and form field labels from the page
+ * while excluding hidden content and sensitive field types.
+ */
+
 import type { PageContextSnapshot } from "./protocol";
 
 function normalizeText(

--- a/packages/browser-extension/src/popup-model.test.ts
+++ b/packages/browser-extension/src/popup-model.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the pure popup status model.
+ *
+ * Fake timers make pause and last-sync state deterministic while covering the
+ * connected, pairing, disabled, paused, and error UI classifications.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { derivePopupStatusModel } from "./popup-model";
 import type { BackgroundState } from "./protocol";

--- a/packages/browser-extension/src/popup-model.ts
+++ b/packages/browser-extension/src/popup-model.ts
@@ -1,3 +1,10 @@
+/**
+ * Pure status model for rendering the browser-bridge popup.
+ *
+ * Converts background sync state and local API discovery into badges,
+ * checklist copy, primary actions, and summary pills.
+ */
+
 import type { BackgroundState } from "./protocol";
 
 export type PopupStatusKind =

--- a/packages/browser-extension/src/protocol.ts
+++ b/packages/browser-extension/src/protocol.ts
@@ -1,3 +1,10 @@
+/**
+ * Message and state contracts shared by browser-extension contexts.
+ *
+ * Popup, background, and content scripts import these unions so runtime
+ * messages stay aligned without importing extension entrypoints.
+ */
+
 import type {
   CompleteLifeOpsBrowserSessionRequest,
   LifeOpsBrowserSession,

--- a/packages/browser-extension/src/storage.test.ts
+++ b/packages/browser-extension/src/storage.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for companion config normalization and agent API discovery inputs.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   candidateApiBaseUrlsFromTabs,

--- a/packages/browser-extension/src/storage.ts
+++ b/packages/browser-extension/src/storage.ts
@@ -1,3 +1,10 @@
+/**
+ * Browser-extension storage and local agent API discovery helpers.
+ *
+ * Persists companion pairing state in extension storage and normalizes
+ * loopback or discovered agent API base URLs before background sync uses them.
+ */
+
 import type { BackgroundState, CompanionConfig } from "./protocol";
 import {
   type ExtensionTab,

--- a/packages/browser-extension/src/tab-cache.ts
+++ b/packages/browser-extension/src/tab-cache.ts
@@ -1,3 +1,10 @@
+/**
+ * Tab snapshot merge and filtering logic for browser-bridge sync.
+ *
+ * Keeps a bounded remembered-tab list, applies site-access policy, and selects
+ * the focused tab plus allowed context for the companion heartbeat.
+ */
+
 import type { BrowserBridgeSettings } from "./browser-bridge-contracts";
 import type { CompanionSyncRequest } from "./protocol";
 

--- a/packages/browser-extension/src/test-dom-setup.ts
+++ b/packages/browser-extension/src/test-dom-setup.ts
@@ -1,5 +1,7 @@
-// Preload for bun test: install a minimal jsdom DOM on globalThis.
-// Loaded via `bun test --preload ./src/test-dom-setup.ts`.
+/**
+ * Vitest preload that installs a minimal jsdom DOM on globalThis.
+ */
+
 import { JSDOM } from "jsdom";
 
 const dom = new JSDOM(

--- a/packages/browser-extension/src/url.test.ts
+++ b/packages/browser-extension/src/url.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for safe HTTP URL and origin normalization helpers.
+ */
+
 import { describe, expect, it } from "vitest";
 import { normalizeHttpBaseUrl, normalizeHttpOrigin } from "./url";
 

--- a/packages/browser-extension/src/url.ts
+++ b/packages/browser-extension/src/url.ts
@@ -1,3 +1,7 @@
+/**
+ * Safe HTTP URL normalization helpers for extension configuration and discovery.
+ */
+
 export function normalizeHttpBaseUrl(
   value: unknown,
   defaultValue: string | null = null,

--- a/packages/browser-extension/src/webextension.ts
+++ b/packages/browser-extension/src/webextension.ts
@@ -1,3 +1,10 @@
+/**
+ * Promise-based adapter over Chrome and WebExtension browser APIs.
+ *
+ * Centralizes browser API differences so entrypoints avoid direct chrome.*
+ * calls and can share error handling across Chrome and Safari builds.
+ */
+
 type Callback<T> = (value: T) => void;
 
 type RawRuntime = {

--- a/packages/browser-extension/vitest.extension.config.ts
+++ b/packages/browser-extension/vitest.extension.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Vitest config for browser-extension unit tests.
+ */
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Adds purpose prose headers to the B11 `packages/browser-extension` source slice:

- extension entrypoints
- packaging/smoke scripts
- browser-bridge source modules and unit tests
- package Vitest config

The two churn-grep hits in this subtree are user-facing strings, not comments, so they were reviewed and left unchanged.

## Verification

- `bun run check:comment-only` — PASS (`32 source file(s) changed; every code token identical to origin/develop`)
- `bun run --cwd packages/browser-extension test` — PASS (6 files, 25 tests)
- `bun run --cwd packages/browser-extension build` — PASS (built Chrome extension to `dist/chrome`)
- `bunx @biomejs/biome check packages/browser-extension/entrypoints packages/browser-extension/scripts packages/browser-extension/src packages/browser-extension/vitest.extension.config.ts` — PASS
- `git diff --check` — PASS
- Header self-audit for `packages/browser-extension` B11 source files — PASS (prints nothing)

## Evidence

- Diffstat: `32 files changed, 203 insertions(+), 2 deletions(-)`
- Real-LLM trajectories: N/A — comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- Screenshots/video/audio: N/A — no UI, audio, or runtime behavior changed.
- Backend/frontend logs: N/A — no runtime path changed.
- Domain artifacts: Chrome build output was generated by `bun run --cwd packages/browser-extension build`; no tracked generated artifacts changed.
