### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-settings-b

### DIFF
--- a/packages/ui/src/components/settings/AdvancedSection.test.tsx
+++ b/packages/ui/src/components/settings/AdvancedSection.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Covers AdvancedSection's reset-confirmation modal (no reset until confirmed;
+ * runs exactly once) and the encrypted local-backup flow (list/create/restore).
+ * jsdom render with the app store and API client mocked.
+ */
+
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/settings/AdvancedToggle.test.tsx
+++ b/packages/ui/src/components/settings/AdvancedToggle.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * Covers AdvancedToggle + useAdvancedSettingsEnabled: localStorage-backed
+ * persistence, the onChange callback, and the module-level listener cascade that
+ * keeps multiple toggles/subscribers in sync. jsdom render against real
+ * localStorage.
+ */
+
 import {
   act,
   cleanup,

--- a/packages/ui/src/components/settings/ApiKeyConfig.stories.tsx
+++ b/packages/ui/src/components/settings/ApiKeyConfig.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook fixtures for `ApiKeyConfig`: configured, needs-setup, saving, saved, and validation-issue states of a provider's API-key form. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { ApiKeyConfig, type ApiKeyConfigProps } from "./ApiKeyConfig";

--- a/packages/ui/src/components/settings/AppearanceSettingsSection.background.test.tsx
+++ b/packages/ui/src/components/settings/AppearanceSettingsSection.background.test.tsx
@@ -1,4 +1,11 @@
 // @vitest-environment jsdom
+
+/**
+ * Pins that AppearanceSettingsSection does NOT render the wallpaper controls —
+ * they live in the dedicated Background settings section. jsdom render with the
+ * app store seeded via `__setAppValueForTests`.
+ */
+
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { __setAppValueForTests } from "../../state/app-store";

--- a/packages/ui/src/components/settings/AppearanceSettingsSection.tsx
+++ b/packages/ui/src/components/settings/AppearanceSettingsSection.tsx
@@ -1,3 +1,11 @@
+/**
+ * Settings → Appearance section: theme mode, brand accent preset, UI language,
+ * the home time/date widget toggle, loaded content packs, and the advanced
+ * toggle. All choices persist through the app store (`useAppSelector` setters);
+ * every tile is agent-addressable via `useAgentElement`. The advanced toggle
+ * reveals the content-pack loader.
+ */
+
 import type { LucideIcon } from "lucide-react";
 import { Check, Monitor, Moon, Sun } from "lucide-react";
 import { useAgentElement } from "../../agent-surface";

--- a/packages/ui/src/components/settings/BackgroundSettingsControls.tsx
+++ b/packages/ui/src/components/settings/BackgroundSettingsControls.tsx
@@ -1,3 +1,11 @@
+/**
+ * The wallpaper picker rendered inside the Background settings subview: shader
+ * color presets + custom picker, image upload, and cloud image generation, with
+ * undo/redo. Writes to the shared background store (`useBackgroundConfig` /
+ * `ui-preferences`) that drives Home, Launcher, chat, and every view, so choices
+ * apply live. Every control is agent-addressable via `useAgentElement`.
+ */
+
 import {
   ArrowUp,
   Check,

--- a/packages/ui/src/components/settings/CapabilitiesSection.test.tsx
+++ b/packages/ui/src/components/settings/CapabilitiesSection.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * Covers CapabilitiesSection's proactive-suggestions control: it reflects the
+ * persisted `ELIZA_PROACTIVE_INTERACTIONS` config value and persists the picked
+ * level via `updateConfig`. jsdom render with the app store and API client
+ * mocked.
+ */
+
 import {
   cleanup,
   render,

--- a/packages/ui/src/components/settings/ChatHotkeySettingsGroup.test.tsx
+++ b/packages/ui/src/components/settings/ChatHotkeySettingsGroup.test.tsx
@@ -1,4 +1,13 @@
 // @vitest-environment jsdom
+
+/**
+ * Covers ChatHotkeySettingsGroup: default accelerator + enabled toggle,
+ * disabling (persist + unregister shortcut), recording a keystroke to rebind,
+ * Escape-cancels-recording, and surfacing an OS-rejected accelerator without
+ * persisting. jsdom render with the desktop bridge mocked and the real hotkey
+ * store.
+ */
+
 import {
   act,
   cleanup,

--- a/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * Covers CloudAgentsSection rename (client call + persisted active-server label
+ * sync, no-op on unchanged/empty names, error revert) and suspend/resume
+ * lifecycle (direct-path client calls, error surfacing, status re-sync). jsdom
+ * render with the app store, cloud API client, and persistence mocked.
+ */
+
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/settings/CloudOverviewSection.tsx
+++ b/packages/ui/src/components/settings/CloudOverviewSection.tsx
@@ -1,3 +1,10 @@
+/**
+ * Settings → Cloud overview: the marketing summary of Eliza Cloud (hosted
+ * connectors, cloud agents, API keys/publishing, billing, marketplace) plus the
+ * connect/open CTA. Reads connection + login-busy state from the app store and
+ * drives `handleCloudLogin`; the CTA is agent-addressable via `useAgentElement`.
+ */
+
 import {
   Bot,
   Cloud,

--- a/packages/ui/src/components/settings/ConnectorsSection.stories.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook fixtures for `ConnectorsSection`: default list, single/all-disabled connectors, a validation-error row, and the empty state. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { PluginInfo } from "../../api";
 import { mockApp } from "../../storybook/mock-providers.helpers";

--- a/packages/ui/src/components/settings/DesktopWorkspaceDisplay.stories.tsx
+++ b/packages/ui/src/components/settings/DesktopWorkspaceDisplay.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook fixtures for `DesktopWorkspaceDisplay`: populated, empty, short, and long-wrapping diagnostics output. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { DesktopWorkspaceDisplay } from "./DesktopWorkspaceDisplay";

--- a/packages/ui/src/components/settings/IdentitySettingsSection.stories.tsx
+++ b/packages/ui/src/components/settings/IdentitySettingsSection.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook fixtures for `IdentitySettingsSection`: default, populated, dirty (unsaved edits), loading, and cloud-connected states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { mockApp, withMockApp } from "../../storybook/mock-providers.helpers";
 import { IdentitySettingsSection } from "./IdentitySettingsSection";

--- a/packages/ui/src/components/settings/LoadContentPackForm.tsx
+++ b/packages/ui/src/components/settings/LoadContentPackForm.tsx
@@ -1,3 +1,11 @@
+/**
+ * Content-pack loader form for the Appearance settings section: load a pack from
+ * a URL or (where the platform supports directory picking) a local folder, and
+ * deactivate the active pack. Drives the `useContentPack` store; inputs and
+ * buttons are agent-addressable via `useAgentElement`. Mounted only when the
+ * advanced toggle is on.
+ */
+
 import { FolderOpen } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useAgentElement } from "../../agent-surface";

--- a/packages/ui/src/components/settings/ProviderCard.stories.tsx
+++ b/packages/ui/src/components/settings/ProviderCard.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook fixtures for `ProviderCard`: default, active, selected, warning, and not-configured states, plus a list layout. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { Cloud, KeyRound, Server, Sparkles } from "lucide-react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";

--- a/packages/ui/src/components/settings/ProviderPanels.tsx
+++ b/packages/ui/src/components/settings/ProviderPanels.tsx
@@ -1,3 +1,11 @@
+/**
+ * The four per-provider panel bodies rendered by ProviderSwitcher inside the AI
+ * Model settings section: Local (on-device inference), Eliza Cloud (routing +
+ * model selection), Subscription (Claude/Codex plans), and API-key providers.
+ * Each renders a shared header with an agent-addressable "use this" activation
+ * button; ProviderSwitcher owns the selection state and passes it in as props.
+ */
+
 import type {
   LinkedAccountProviderId,
   ModelOption,

--- a/packages/ui/src/components/settings/SecretsManagerSection.tsx
+++ b/packages/ui/src/components/settings/SecretsManagerSection.tsx
@@ -1,3 +1,17 @@
+/**
+ * Settings → Vault section.
+ *
+ *  - `SecretsManagerSection` — the inline launcher row in Settings;
+ *    clicking dispatches the global open event for the modal.
+ *  - `VaultModal` — the modal itself. App root mounts it lazily on the
+ *    first global open dispatch (launcher, ⌘⌥⌃V chord, menu accelerator)
+ *    via `SecretsManagerModalMount` in `App.tsx`, keeping this module off
+ *    the eager boot graph (#11351).
+ *
+ * The modal is a tabbed Vault interface (Overview / Secrets / Logins /
+ * Routing). Data is fetched once per open and shared across tabs.
+ */
+
 import { KeyRound, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 // All requests go through the shared client (never bare `fetch`) so they hit
@@ -37,20 +51,6 @@ import type {
   VaultEntryMeta,
   VaultTabNavigate,
 } from "./vault-tabs/types";
-
-/**
- * Settings → Vault section.
- *
- *  - `SecretsManagerSection` — the inline launcher row in Settings;
- *    clicking dispatches the global open event for the modal.
- *  - `VaultModal` — the modal itself. App root mounts it lazily on the
- *    first global open dispatch (launcher, ⌘⌥⌃V chord, menu accelerator)
- *    via `SecretsManagerModalMount` in `App.tsx`, keeping this module off
- *    the eager boot graph (#11351).
- *
- * The modal is a tabbed Vault interface (Overview / Secrets / Logins /
- * Routing). Data is fetched once per open and shared across tabs.
- */
 
 const HASH_PREFIX = "vault";
 

--- a/packages/ui/src/components/settings/SubscriptionStatus.tsx
+++ b/packages/ui/src/components/settings/SubscriptionStatus.tsx
@@ -1,3 +1,11 @@
+/**
+ * Connect/disconnect UI for coding-plan subscription providers (Claude,
+ * Codex/OpenAI) inside the AI Model settings section. Renders the current
+ * subscription status and drives the paste-the-code OAuth exchange shell —
+ * start login, submit the callback code, sign out — against the shared client.
+ * Mounted by SubscriptionPanel (ProviderPanels.tsx).
+ */
+
 import { AlertTriangle, CheckCircle2, Loader2, LogOut } from "lucide-react";
 import {
   type ReactNode,

--- a/packages/ui/src/components/settings/VoiceConfigView.test.tsx
+++ b/packages/ui/src/components/settings/VoiceConfigView.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * Covers VoiceConfigView's Swabble audio-meter listener lifecycle: an
+ * `audioLevel` listener that resolves after the component unmounts is still
+ * removed (no leaked native listener). jsdom render with the API, agent-surface,
+ * and native-plugin bridge mocked.
+ */
+
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getSwabblePlugin } from "../../bridge/native-plugins";

--- a/packages/ui/src/components/settings/VoiceProfileSection.test.tsx
+++ b/packages/ui/src/components/settings/VoiceProfileSection.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * Covers VoiceProfileSection: OWNER pinned at top with the Crown badge, the
+ * empty state, inline rename + relationship-label edits, delete of a non-owner
+ * row, and refusal to delete OWNER. jsdom render against a real
+ * `VoiceProfilesClient` backed by a fake in-memory fetch.
+ */
+
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/settings/VoiceSection.helpers.ts
+++ b/packages/ui/src/components/settings/VoiceSection.helpers.ts
@@ -1,3 +1,9 @@
+/**
+ * Default voice-preference values for VoiceSection: continuous-chat mode and the
+ * VAD auto-stop thresholds, sourced from the voice capture defaults so the
+ * settings UI and the capture pipeline agree.
+ */
+
 import { DEFAULT_LOCAL_ASR_AUTO_STOP } from "../../voice/local-asr-capture";
 import { DEFAULT_VOICE_CONTINUOUS_MODE } from "../../voice/voice-chat-types";
 import type { VadAutoStopPrefs, VoiceSectionPrefs } from "./VoiceSection";

--- a/packages/ui/src/components/settings/VoiceTierBanner.test.tsx
+++ b/packages/ui/src/components/settings/VoiceTierBanner.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Covers VoiceTierBanner: per-device-tier copy/data attributes and the optional
+ * summary line (rendered when supplied, omitted otherwise). jsdom render, no
+ * mocks.
+ */
+
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { VoiceTierBanner } from "./VoiceTierBanner";

--- a/packages/ui/src/components/settings/WalletRpcSection.tsx
+++ b/packages/ui/src/components/settings/WalletRpcSection.tsx
@@ -1,3 +1,8 @@
+/**
+ * Settings → Wallet section: composes the wallet-keys manager with the embedded
+ * RPC/network config page (`ConfigPageView`) in one stack.
+ */
+
 import { ConfigPageView } from "../pages/ConfigPageView";
 import { SettingsStack } from "./settings-layout";
 import { WalletKeysSection } from "./WalletKeysSection";

--- a/packages/ui/src/components/settings/appearance-primitives.helpers.ts
+++ b/packages/ui/src/components/settings/appearance-primitives.helpers.ts
@@ -1,3 +1,4 @@
+/** Shared Tailwind class string for a selectable tile in the Appearance settings section (active vs resting states). */
 export function selectableTileClass(active: boolean): string {
   return `relative flex min-h-11 flex-col items-center justify-center gap-1.5 whitespace-normal rounded-sm border p-3 transition-colors ${
     active

--- a/packages/ui/src/components/settings/no-native-select.test.ts
+++ b/packages/ui/src/components/settings/no-native-select.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Static source-scan guard: fails if any `.tsx` under settings/ (plus
+ * RoutingMatrix) hand-rolls a raw `<select>` instead of the canonical settings
+ * controls. Reads files off disk — no render. Rationale below.
+ */
+
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/packages/ui/src/components/settings/permission-controls.tsx
+++ b/packages/ui/src/components/settings/permission-controls.tsx
@@ -1,3 +1,11 @@
+/**
+ * Presentational rows for the Permissions settings section. `PermissionRow`
+ * renders one OS/app permission (icon, name, status badge, request/open-settings
+ * action, and the optional shell-enable switch); `CapabilityToggle` renders a
+ * capability on/off row. Status/badge/action copy is resolved through
+ * `permission-types`; the controls are agent-addressable via `useAgentElement`.
+ */
+
 import {
   AppWindow,
   Battery,

--- a/packages/ui/src/components/settings/settings-agent-rows.tsx
+++ b/packages/ui/src/components/settings/settings-agent-rows.tsx
@@ -1,3 +1,16 @@
+/**
+ * Agent-addressable settings controls.
+ *
+ * These pair a {@link SettingsRow} with a control that registers itself on the
+ * active view's agent surface (`useAgentElement`). Because the Settings view is
+ * itself an agent surface (`ShellViewAgentSurface viewId="settings"`), any row
+ * built with these is editable straight from chat/voice — the agent can
+ * `list-elements` and `agent-click` / `agent-fill` them with no extra plumbing.
+ *
+ * Use these instead of a bare `SettingsRow + Switch/Select` whenever the setting
+ * should be configurable from chat (which is the default for settings).
+ */
+
 import type { LucideIcon } from "lucide-react";
 import * as React from "react";
 import { useAgentElement } from "../../agent-surface";
@@ -13,19 +26,6 @@ import {
 } from "../ui/settings-controls";
 import { Switch } from "../ui/switch";
 import { SettingsRow } from "./settings-layout";
-
-/**
- * Agent-addressable settings controls.
- *
- * These pair a {@link SettingsRow} with a control that registers itself on the
- * active view's agent surface (`useAgentElement`). Because the Settings view is
- * itself an agent surface (`ShellViewAgentSurface viewId="settings"`), any row
- * built with these is editable straight from chat/voice — the agent can
- * `list-elements` and `agent-click` / `agent-fill` them with no extra plumbing.
- *
- * Use these instead of a bare `SettingsRow + Switch/Select` whenever the setting
- * should be configurable from chat (which is the default for settings).
- */
 
 function labelToString(label: React.ReactNode, fallback: string): string {
   return typeof label === "string" ? label : fallback;

--- a/packages/ui/src/components/settings/settings-control-primitives.tsx
+++ b/packages/ui/src/components/settings/settings-control-primitives.tsx
@@ -1,3 +1,10 @@
+/**
+ * Compatibility re-export of the field primitives plus the
+ * `AdvancedSettingsDisclosure` collapsible for settings sections. The canonical
+ * `SettingsField*` primitives live in `../ui/settings-controls`; this module
+ * re-exports them for `./settings-control-primitives` importers.
+ */
+
 import type * as React from "react";
 import { useState } from "react";
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/settings/settings-section-registry.test.ts
+++ b/packages/ui/src/components/settings/settings-section-registry.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers the settings-section registry: register + list back (so apps can add
+ * sections), re-registering an id replaces the prior entry, and sections sort by
+ * explicit order before registration sequence. Pure in-memory registry, no
+ * render.
+ */
+
 import { Cog } from "lucide-react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { resetUiRegistryHostForTests } from "../../registry-host";

--- a/packages/ui/src/components/settings/settings-sections.ts
+++ b/packages/ui/src/components/settings/settings-sections.ts
@@ -1,3 +1,13 @@
+/**
+ * Declares and registers every built-in settings section into the
+ * settings-section registry (`settings-section-registry.ts`), which SettingsView
+ * reads to build its nav + render the active section. Section bodies are lazy
+ * chunks (see the note below); metadata/order/grouping come from
+ * `settings-section-meta.ts`. Also owns the tone/hue icon-class maps and the
+ * `#settings/<section>` hash-routing helpers. Importing this module for its side
+ * effect is what populates the registry, so it is imported once at app boot.
+ */
+
 import {
   Archive,
   Bot,

--- a/packages/ui/src/components/settings/useDesktopWindowControls.ts
+++ b/packages/ui/src/components/settings/useDesktopWindowControls.ts
@@ -1,3 +1,11 @@
+/**
+ * Hook backing the DesktopWorkspaceSection window controls: show/hide/focus,
+ * minimize/maximize toggles, and a test notification. Each action goes through
+ * the desktop bridge (`invokeDesktopBridgeRequest`, Electrobun RPC + IPC
+ * fallback); the minimize/maximize toggles read the current window state from
+ * the passed snapshot to pick the RPC method.
+ */
+
 import { useMemo } from "react";
 import { invokeDesktopBridgeRequest } from "../../bridge";
 import type { TranslateFn } from "../../types";

--- a/packages/ui/src/components/settings/useProviderEntries.order.test.tsx
+++ b/packages/ui/src/components/settings/useProviderEntries.order.test.tsx
@@ -1,4 +1,12 @@
 // @vitest-environment jsdom
+
+/**
+ * Pins useProviderEntries' provider ordering by platform: on mobile the local
+ * provider sits right after cloud (before subscriptions); on desktop/web it
+ * comes after the subscription providers. renderHook with the platform guard
+ * mocked.
+ */
+
 import { renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useProviderEntries } from "./useProviderEntries";


### PR DESCRIPTION
Comments-only slice of #12234 (repo-wide comment cleanup, Work Item 2).

**Subtree:** \`packages/ui/src/components/settings\` (shard 1 of 2 — files at odd zero-based index in the sorted in-scope list; disjoint from the sibling shard).

**What changed:** added a top-of-file `/** … */` prose header (per the root CLAUDE.md convention) to settings components, hooks, helpers, Storybook fixtures, and tests that lacked one — or that carried a real header positioned below the import block, which was moved to the top. Test headers state the surface under test and how real the harness is (jsdom render, which deps are mocked vs. real client). No files already at the bar were touched.

**Files touched (32):**
- Components: AppearanceSettingsSection, BackgroundSettingsControls, CloudOverviewSection, LoadContentPackForm, ProviderPanels, SubscriptionStatus, WalletRpcSection, permission-controls, settings-agent-rows (header moved to top), settings-control-primitives, settings-sections, SecretsManagerSection (header moved to top)
- Hooks/helpers: VoiceSection.helpers, appearance-primitives.helpers, useDesktopWindowControls
- Stories: ApiKeyConfig, ConnectorsSection, DesktopWorkspaceDisplay, IdentitySettingsSection, ProviderCard
- Tests: AdvancedSection, AdvancedToggle, AppearanceSettingsSection.background, CapabilitiesSection, ChatHotkeySettingsGroup, CloudAgentsSection, VoiceConfigView, VoiceProfileSection, VoiceTierBanner, useProviderEntries.order, no-native-select, settings-section-registry

**Verification:** \`node scripts/assert-comment-only-diff.mjs origin/develop\` → OK, 32 source files changed, every code token identical to develop. Zero functional diff.

Part of #12234.