### PR TITLE
chore(#12235): comment cleanup B05 — prose headers + churn removal (comment-only)

### DIFF
--- a/packages/ui/scripts/bake-view-icons.mjs
+++ b/packages/ui/scripts/bake-view-icons.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
-// Bake the generated launcher view icons (PNG) into a committed TS file as
-// base64 data URIs, so every tile is preloaded in the JS bundle — no network,
-// no /api/views hero 404 on native, no client-SVG fallback, no loading/empty
-// state. Source PNGs are generated via codex CLI (see scripts/gen-view-icons).
-//
-// Usage: node scripts/bake-view-icons.mjs [srcDir]   (default /tmp/view-icons)
+/**
+ * Bakes the generated launcher view icons (PNG) into a committed TS file as
+ * base64 data URIs, so every tile is preloaded in the JS bundle — no network,
+ * no /api/views hero 404 on native, no client-SVG fallback, no loading/empty
+ * state. Source PNGs are generated via codex CLI (see scripts/gen-view-icons).
+ *
+ * Usage: node scripts/bake-view-icons.mjs [srcDir]   (default /tmp/view-icons)
+ */
 import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";

--- a/packages/ui/scripts/find-duplicate-components.mjs
+++ b/packages/ui/scripts/find-duplicate-components.mjs
@@ -1,19 +1,21 @@
 #!/usr/bin/env node
-// Find candidate duplicate React components in @elizaos/ui.
-//
-// Walks packages/ui/src for .ts/.tsx files. Extracts:
-//   - filename basename (e.g. button)
-//   - exported React component identifiers (default + named PascalCase exports)
-//
-// Groups by:
-//   1. EXACT name (case-insensitive) — same component name in multiple files
-//   2. PARTIAL name — components whose normalized name is a token-subset of
-//      another, or differ only by a common suffix/prefix (Card / CardLite,
-//      ChatHeader / ChatHeaderCompact, etc.)
-//
-// Output is markdown to stdout + JSON report to scripts/duplicate-components-report.json
-//
-// Usage: bun run scripts/find-duplicate-components.mjs [--min N]
+/**
+ * Finds candidate duplicate React components in @elizaos/ui.
+ *
+ * Walks packages/ui/src for .ts/.tsx files. Extracts:
+ *   - filename basename (e.g. button)
+ *   - exported React component identifiers (default + named PascalCase exports)
+ *
+ * Groups by:
+ *   1. EXACT name (case-insensitive) — same component name in multiple files
+ *   2. PARTIAL name — components whose normalized name is a token-subset of
+ *      another, or differ only by a common suffix/prefix (Card / CardLite,
+ *      ChatHeader / ChatHeaderCompact, etc.)
+ *
+ * Output is markdown to stdout + JSON report to scripts/duplicate-components-report.json
+ *
+ * Usage: bun run scripts/find-duplicate-components.mjs [--min N]
+ */
 
 import fs from "node:fs";
 import path from "node:path";

--- a/packages/ui/scripts/serve-static.mjs
+++ b/packages/ui/scripts/serve-static.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
-// Simple multi-threaded static file server for storybook-static/.
-// Python's http.server is single-threaded and chokes when Playwright
-// loads ~1300 stories in sequence; this stays responsive.
+/**
+ * Multi-threaded static file server for storybook-static/. Python's http.server
+ * is single-threaded and chokes when Playwright loads ~1300 stories in
+ * sequence; this stays responsive.
+ */
 import { readFile, stat } from "node:fs/promises";
 import { createServer } from "node:http";
 import { extname, join, resolve } from "node:path";

--- a/packages/ui/scripts/stories-coverage.mjs
+++ b/packages/ui/scripts/stories-coverage.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
-// Story coverage: for every .tsx in packages/ui/src/components/ that defines
-// a React component, check if a sibling *.stories.tsx exists.
-//
-// Output: markdown report + JSON.
-// Usage: bun run scripts/stories-coverage.mjs [--all]
-//   --all   include non-/components/ files (chat, apps, etc.)
+/**
+ * Story-coverage report: for every .tsx in packages/ui/src/components/ that
+ * defines a React component, checks whether a sibling *.stories.tsx exists.
+ * Emits a markdown report + JSON.
+ *
+ * Usage: bun run scripts/stories-coverage.mjs [--all]
+ *   --all   include non-/components/ files (chat, apps, etc.)
+ */
 
 import fs from "node:fs";
 import path from "node:path";

--- a/packages/ui/src/api/auth/sessions.ts
+++ b/packages/ui/src/api/auth/sessions.ts
@@ -1,5 +1,7 @@
-// Client-side auth constants shared with the node auth implementation in
-// @elizaos/app-core.
+/**
+ * Client-side auth constants (session/CSRF cookie + header names) shared with
+ * the node auth implementation in @elizaos/app-core.
+ */
 export const SESSION_COOKIE_NAME = "eliza_session";
 export const CSRF_COOKIE_NAME = "eliza_csrf";
 export const CSRF_HEADER_NAME = "x-eliza-csrf";

--- a/packages/ui/src/api/client-types-chat.ts
+++ b/packages/ui/src/api/client-types-chat.ts
@@ -1,7 +1,8 @@
-// ---------------------------------------------------------------------------
-// Chat types — Conversation*, Chat*, Message*, Stream*, Action*, Emote*,
-// Document*, Memory*, MCP*, Share*
-// ---------------------------------------------------------------------------
+/**
+ * Chat-domain client DTOs: Conversation*, Chat*, Message*, Stream*, Action*,
+ * Emote*, Document*, Memory*, MCP*, Share*. One slice of the ElizaClient type
+ * surface, re-exported through client-types.ts.
+ */
 
 import type {
   ChatFailureKind,

--- a/packages/ui/src/api/client-types-cloud.ts
+++ b/packages/ui/src/api/client-types-cloud.ts
@@ -1,7 +1,8 @@
-// ---------------------------------------------------------------------------
-// Cloud types — Cloud*, App*, Trajectory*, Registry*, Whitelist*,
-// Verification*, Wallet display types, CodingAgent*, Pty*
-// ---------------------------------------------------------------------------
+/**
+ * Cloud-domain client DTOs: Cloud*, App*, Trajectory*, Registry*, Whitelist*,
+ * Verification*, wallet display types, CodingAgent*, Pty*. One slice of the
+ * ElizaClient type surface, re-exported through client-types.ts.
+ */
 
 import type {
   TrajectoryExportOptions as CoreTrajectoryExportOptions,

--- a/packages/ui/src/api/client-types-config.ts
+++ b/packages/ui/src/api/client-types-config.ts
@@ -1,7 +1,8 @@
-// ---------------------------------------------------------------------------
-// Config types — Config*, Plugin*, Secret*, Connector*, Trigger*, Training*,
-// Update*, Extension*, Workbench*, Character*, Voice*, Skill*
-// ---------------------------------------------------------------------------
+/**
+ * Config-domain client DTOs: Config*, Plugin*, Secret*, Connector*, Trigger*,
+ * Training*, Update*, Extension*, Workbench*, Character*, Voice*, Skill*. One
+ * slice of the ElizaClient type surface, re-exported through client-types.ts.
+ */
 
 import type { AppShellBackgroundPolicy, ViewKind } from "@elizaos/core";
 import type { MessageExampleContent, PluginParamDef } from "@elizaos/shared";

--- a/packages/ui/src/api/client-types-core.ts
+++ b/packages/ui/src/api/client-types-core.ts
@@ -1,6 +1,8 @@
-// ---------------------------------------------------------------------------
-// Core types — Database*, Agent*, ApiError, Runtime*, WebSocket*, ConnectionState*, Sandbox*
-// ---------------------------------------------------------------------------
+/**
+ * Core-domain client DTOs: Database*, Agent*, ApiError, Runtime*, WebSocket*,
+ * ConnectionState*, Sandbox*. One slice of the ElizaClient type surface,
+ * re-exported through client-types.ts.
+ */
 
 import type {
   TrajectoryExportFormat,

--- a/packages/ui/src/api/client-types.ts
+++ b/packages/ui/src/api/client-types.ts
@@ -1,7 +1,7 @@
-// ---------------------------------------------------------------------------
-// Types barrel — re-exports all domain type modules so consumers can continue
-// importing from this single path without changes.
-// ---------------------------------------------------------------------------
+/**
+ * Barrel for the ElizaClient DTO surface: re-exports every client-types-*
+ * domain module so consumers import the whole type surface from one path.
+ */
 
 export * from "./client-types-character";
 export * from "./client-types-chat";

--- a/packages/ui/src/cloud-ui/runtime/render-telemetry.tsx
+++ b/packages/ui/src/cloud-ui/runtime/render-telemetry.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-// Only the RenderTelemetryProfiler component lives here so Vite React Fast
-// Refresh can hot-patch it. The telemetry primitives (constants, types,
-// setRenderTelemetrySink, useRenderGuard) live in hooks/useRenderGuard.
+/**
+ * Only the RenderTelemetryProfiler component lives here so Vite React Fast
+ * Refresh can hot-patch it. The telemetry primitives (constants, types,
+ * setRenderTelemetrySink, useRenderGuard) live in hooks/useRenderGuard.
+ */
 
 import {
   Profiler,

--- a/packages/ui/src/cloud/handoff/pending-handoff-store.ts
+++ b/packages/ui/src/cloud/handoff/pending-handoff-store.ts
@@ -1,16 +1,18 @@
-// Persistence marker for an in-flight shared→dedicated cloud-agent handoff.
-//
-// The handoff supervisor is in-memory: a reload (or app relaunch) while the
-// dedicated container boots would otherwise strand the user on the shared
-// adapter forever — the persisted active server still points at the shared
-// bridge, the provisioning widget shows "Setting up…" with no live phase, and
-// the retry event has no listener. This marker records the deterministic
-// handoff target (the dedicated agent already created for this shared bridge)
-// so boot can RESUME the same migration instead of guessing or re-creating.
-//
-// Lifecycle: saved when the handoff starts (the dedicated target id is known),
-// cleared by `silentlyRepointToDedicated` (repointed ⇒ nothing pending) and by
-// the TTL (a marker that never resolves must not outlive the handoff story).
+/**
+ * Persistence marker for an in-flight shared→dedicated cloud-agent handoff.
+ *
+ * The handoff supervisor is in-memory: a reload (or app relaunch) while the
+ * dedicated container boots would otherwise strand the user on the shared
+ * adapter forever — the persisted active server still points at the shared
+ * bridge, the provisioning widget shows "Setting up…" with no live phase, and
+ * the retry event has no listener. This marker records the deterministic
+ * handoff target (the dedicated agent already created for this shared bridge)
+ * so boot can RESUME the same migration instead of guessing or re-creating.
+ *
+ * Lifecycle: saved when the handoff starts (the dedicated target id is known),
+ * cleared by `silentlyRepointToDedicated` (repointed ⇒ nothing pending) and by
+ * the TTL (a marker that never resolves must not outlive the handoff story).
+ */
 
 export interface PendingCloudHandoff {
   sharedAgentId: string;

--- a/packages/ui/src/config/index.ts
+++ b/packages/ui/src/config/index.ts
@@ -1,5 +1,8 @@
-// === Phase 5C: ./app-config moved to @elizaos/app-core/config/app-config ===
-// Re-export the app-config types from @elizaos/shared for backward compat.
+/**
+ * Barrel for the config surface. Re-exports the app-config types from
+ * `@elizaos/shared` (the canonical app-config lives in
+ * `@elizaos/app-core/config/app-config`) alongside the local config modules.
+ */
 export type {
   AndroidUserAgentMarker,
   AospVariantConfig,

--- a/packages/ui/src/first-run/first-run-cloud-resume.ts
+++ b/packages/ui/src/first-run/first-run-cloud-resume.ts
@@ -1,19 +1,19 @@
-// ============================================================================
-// Cloud-login resume marker (device WebView-eviction survival).
-//
-// On a native device the first-run cloud login opens an EXTERNAL browser
-// (SFSafariViewController), which backgrounds the WebView; iOS frequently
-// cold-launches the app on return, wiping the conductor's in-memory flow state
-// (draftRef / pendingCloudResumeRef / the transcript). Without a durable marker
-// the conductor re-mounts and re-seeds the greeting — the user experiences a
-// "restart" back to "where should your agent run?".
-//
-// This marker persists the minimum needed to RESUME the interrupted cloud flow
-// after the relaunch: the runtime intent + the draft fields the provision step
-// reads. Paired with the durable cloud token (steward-session), on return the
-// conductor re-arms the existing auto-resume path and completes onboarding into
-// chat instead of restarting. Cleared on completion or a fresh runtime pick.
-// ============================================================================
+/**
+ * Cloud-login resume marker (device WebView-eviction survival).
+ *
+ * On a native device the first-run cloud login opens an EXTERNAL browser
+ * (SFSafariViewController), which backgrounds the WebView; iOS frequently
+ * cold-launches the app on return, wiping the conductor's in-memory flow state
+ * (draftRef / pendingCloudResumeRef / the transcript). Without a durable marker
+ * the conductor re-mounts and re-seeds the greeting — the user experiences a
+ * "restart" back to "where should your agent run?".
+ *
+ * This marker persists the minimum needed to RESUME the interrupted cloud flow
+ * after the relaunch: the runtime intent + the draft fields the provision step
+ * reads. Paired with the durable cloud token (steward-session), on return the
+ * conductor re-arms the existing auto-resume path and completes onboarding into
+ * chat instead of restarting. Cleared on completion or a fresh runtime pick.
+ */
 
 import type { FirstRunLocalInference, FirstRunProfileDraft } from "./first-run";
 

--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -1,19 +1,16 @@
-// ============================================================================
-// Headless first-run "finish" use case.
-//
-// This is the SINGLE provisioning implementation for completing onboarding.
-// It owns no presentation — the in-chat first-run conductor
-// (`use-first-run-conductor.ts`) calls these functions and renders the seeded
-// chat messages. All product decisions (default provider, needsProviderSetup,
-// the POST body) live in the pure config layer (`first-run-config.ts` /
-// `first-run.ts`); this module wires the ports.
-//
-// Extracted from the former `use-first-run-controller.ts` React hook (the
-// full-screen onboarding wizard, now deleted). The finish bodies are moved
-// here verbatim apart from replacing React state/setters with injected ports
-// and funneling EVERY `POST /api/first-run` through the single `persistFirstRun`
-// helper (idempotency-guarded), so a completed onboarding posts exactly once.
-// ============================================================================
+/**
+ * Headless first-run "finish" use case.
+ *
+ * This is the SINGLE provisioning implementation for completing onboarding. It
+ * owns no presentation — the in-chat first-run conductor
+ * (`use-first-run-conductor.ts`) calls these functions and renders the seeded
+ * chat messages. All product decisions (default provider, needsProviderSetup,
+ * the POST body) live in the pure config layer (`first-run-config.ts` /
+ * `first-run.ts`); this module wires the ports.
+ *
+ * Every `POST /api/first-run` funnels through the single, idempotency-guarded
+ * `persistFirstRun` helper, so a completed onboarding posts exactly once.
+ */
 
 import { client } from "../api";
 import { supportsFullAppShellRoutes } from "../api/app-shell-capabilities";

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -1,39 +1,39 @@
-// ============================================================================
-// In-chat first-run conductor (headless).
-//
-// Onboarding is PART OF THE CHAT. When `firstRunComplete === false` this hook
-// seeds synthetic assistant turns into the SAME live transcript the floating
-// `ContinuousChatOverlay` renders (greeting → runtime CHOICE → Cloud OAuth via
-// the message `secretRequest` field → provider CHOICE → tutorial CHOICE), and
-// routes the user's first-run-scoped picks to the headless finish use case
-// (`first-run-finish.ts`). It owns NO presentation — the existing
-// `InlineWidgetText` + `SensitiveRequestBlock` renderers draw the widgets for
-// free from message fields. It registers an action handler on the first-run
-// channel so the chat's single send funnel short-circuits first-run picks
-// before they hit the server.
-//
-// The composer is UNLOCKED during onboarding (#12178, a deliberate reversal of
-// the #9952 onboarding lock): the user can type freely, and a second channel
-// handler (`setFirstRunTextHandler`) answers that free text with a local user
-// turn + a deterministic assistant reply that varies by flow position. Free
-// text NEVER reaches the server pre-completion — the AppContext funnel enforces
-// that; this hook only renders the local echo.
-//
-// Provisioning runs exactly once and POSTs /api/first-run exactly once (the
-// finish module funnels + idempotency-guards it). The real
-// `firstRunComplete` flip is DEFERRED to the tutorial-or-skip pick, so the
-// tutorial step is reachable after every runtime path.
-//
-// Confused-user guards (spam taps, stale widgets, out-of-order picks):
-// - `busyRef` — one finish/provision flow at a time; extra picks are consumed
-//   as no-ops while one is in flight.
-// - `provisionedRef` latch — after provisioning succeeds only the tutorial
-//   pick is live; leftover runtime/provider/cloud-agent widgets no-op.
-// - Strict id validation per group — garbage under the reserved prefix is
-//   consumed, never acted on and never forwarded to the server.
-// - needs-cloud-login re-offers an UNLOCKED runtime choice and arms a
-//   connect-and-resume continuation (`pendingCloudResumeRef`).
-// ============================================================================
+/**
+ * In-chat first-run conductor (headless).
+ *
+ * Onboarding is PART OF THE CHAT. When `firstRunComplete === false` this hook
+ * seeds synthetic assistant turns into the SAME live transcript the floating
+ * `ContinuousChatOverlay` renders (greeting → runtime CHOICE → Cloud OAuth via
+ * the message `secretRequest` field → provider CHOICE → tutorial CHOICE), and
+ * routes the user's first-run-scoped picks to the headless finish use case
+ * (`first-run-finish.ts`). It owns NO presentation — the existing
+ * `InlineWidgetText` + `SensitiveRequestBlock` renderers draw the widgets for
+ * free from message fields. It registers an action handler on the first-run
+ * channel so the chat's single send funnel short-circuits first-run picks
+ * before they hit the server.
+ *
+ * The composer is UNLOCKED during onboarding (#12178, a deliberate reversal of
+ * the #9952 onboarding lock): the user can type freely, and a second channel
+ * handler (`setFirstRunTextHandler`) answers that free text with a local user
+ * turn + a deterministic assistant reply that varies by flow position. Free
+ * text NEVER reaches the server pre-completion — the AppContext funnel enforces
+ * that; this hook only renders the local echo.
+ *
+ * Provisioning runs exactly once and POSTs /api/first-run exactly once (the
+ * finish module funnels + idempotency-guards it). The real `firstRunComplete`
+ * flip is DEFERRED to the tutorial-or-skip pick, so the tutorial step is
+ * reachable after every runtime path.
+ *
+ * Confused-user guards (spam taps, stale widgets, out-of-order picks):
+ * - `busyRef` — one finish/provision flow at a time; extra picks are consumed
+ *   as no-ops while one is in flight.
+ * - `provisionedRef` latch — after provisioning succeeds only the tutorial
+ *   pick is live; leftover runtime/provider/cloud-agent widgets no-op.
+ * - Strict id validation per group — garbage under the reserved prefix is
+ *   consumed, never acted on and never forwarded to the server.
+ * - needs-cloud-login re-offers an UNLOCKED runtime choice and arms a
+ *   connect-and-resume continuation (`pendingCloudResumeRef`).
+ */
 
 import * as React from "react";
 import type {
@@ -483,11 +483,11 @@ export function useFirstRunConductor(): void {
   const seedError = React.useCallback(
     (message: string) => {
       erroredRef.current = true;
-      // A DISTINCT, non-looping error surface. Previously this re-appended the
-      // runtime CHOICE, so a persistent finish error (e.g. the /api/first-run
-      // 404) re-offered the same runtime question forever with no way out. Now
-      // the error turn carries its own recovery choice (retry / restart /
-      // Settings escape) so onboarding is always recoverable.
+      // A DISTINCT, non-looping error surface: the error turn carries its own
+      // recovery choice (retry / restart / Settings escape) so onboarding is
+      // always recoverable. It must NOT re-append the runtime CHOICE — that
+      // would re-offer the same runtime question forever with no way out on a
+      // persistent finish error (e.g. the /api/first-run 404).
       seedTurn(
         makeTurn(
           `first-run:error:${Date.now()}`,

--- a/packages/ui/src/first-run/use-model-status-conductor.ts
+++ b/packages/ui/src/first-run/use-model-status-conductor.ts
@@ -1,20 +1,20 @@
-// ============================================================================
-// In-chat model-status conductor (headless) — #12178 WI-4.
-//
-// While the local text model is not yet ready (missing / downloading / loading
-// / error), this hook keeps ONE live system turn (`model:download-status`) in
-// the SAME transcript the floating chat renders, so download progress is
-// visible INSIDE the chat — the home widget is invisible while the full-screen
-// onboarding chat covers home. The card updates in place (never one bubble per
-// tick), shows name / % / ETA, clamps the displayed percent monotonically, and
-// carries `__model__:` controls (cancel / switch to cloud / retry / download)
-// that route through the model action channel — never to the server.
-//
-// It reads the already-plumbed `controller.modelStatus`
-// (`deriveHomeModelStatus`) — nothing new is fetched. It coexists with the
-// first-run conductor (separate turn id) and stays mounted after onboarding, so
-// a later boot where the model isn't ready still surfaces the card.
-// ============================================================================
+/**
+ * In-chat model-status conductor (headless) — #12178 WI-4.
+ *
+ * While the local text model is not yet ready (missing / downloading / loading
+ * / error), this hook keeps ONE live system turn (`model:download-status`) in
+ * the SAME transcript the floating chat renders, so download progress is
+ * visible INSIDE the chat — the home widget is invisible while the full-screen
+ * onboarding chat covers home. The card updates in place (never one bubble per
+ * tick), shows name / % / ETA, clamps the displayed percent monotonically, and
+ * carries `__model__:` controls (cancel / switch to cloud / retry / download)
+ * that route through the model action channel — never to the server.
+ *
+ * It reads the already-plumbed `controller.modelStatus`
+ * (`deriveHomeModelStatus`) — nothing new is fetched. It coexists with the
+ * first-run conductor (separate turn id) and stays mounted after onboarding, so
+ * a later boot where the model isn't ready still surfaces the card.
+ */
 
 import * as React from "react";
 import type { ConversationMessage } from "../api";

--- a/packages/ui/src/hooks/frame-budget.ts
+++ b/packages/ui/src/hooks/frame-budget.ts
@@ -1,15 +1,17 @@
-// Frame-budget measurement for the dashboard shell (issue #9141, task 1).
-//
-// The render-telemetry stack (useRenderGuard / RenderTelemetryProfiler) detects
-// runaway *render loops* — too many React commits per second. It says nothing
-// about *dropped frames*: a single expensive layout/paint or a main-thread long
-// task blows the 60/120fps budget without ever tripping a commit-rate threshold.
-// This module is the missing measurement — a pure summarizer over a window of
-// requestAnimationFrame deltas plus PerformanceObserver('longtask') counts, so
-// the live HUD and any KPI spec can read the same numbers from the same math.
-//
-// Everything here is pure and deterministic (no rAF, no DOM) so it unit-tests
-// cleanly; the rAF/observer glue lives in ./useFrameBudgetMonitor.
+/**
+ * Frame-budget measurement for the dashboard shell (issue #9141, task 1).
+ *
+ * The render-telemetry stack (useRenderGuard / RenderTelemetryProfiler) detects
+ * runaway *render loops* — too many React commits per second. It says nothing
+ * about *dropped frames*: a single expensive layout/paint or a main-thread long
+ * task blows the 60/120fps budget without ever tripping a commit-rate threshold.
+ * This module is the missing measurement — a pure summarizer over a window of
+ * requestAnimationFrame deltas plus PerformanceObserver('longtask') counts, so
+ * the live HUD and any KPI spec can read the same numbers from the same math.
+ *
+ * Everything here is pure and deterministic (no rAF, no DOM) so it unit-tests
+ * cleanly; the rAF/observer glue lives in ./useFrameBudgetMonitor.
+ */
 
 /** A frame-rate target. 60 → a 16.67ms budget; 120 → 8.33ms (ProMotion). */
 export interface FrameBudget {

--- a/packages/ui/src/hooks/useConversationSwipeJank.ts
+++ b/packages/ui/src/hooks/useConversationSwipeJank.ts
@@ -1,16 +1,18 @@
-// Conversation-swipe jank telemetry (#9954).
-//
-// The frame-budget HUD (useFrameBudgetMonitor) only runs behind the explicit
-// `__ELIZA_PERF_HUD__` dev opt-in, so a swipe-jank regression is invisible
-// outside a dev session. This hook scopes a FrameBudgetSampler to the lifetime
-// of a single conversation-swipe gesture: it starts sampling rAF deltas +
-// long-tasks when the gesture begins and, on release, flushes the summary into
-// the bounded view-interaction telemetry ring as a `conversation-swipe-jank`
-// event. The drop-frame %, p95 frame time, and fps are therefore observable in
-// the same ring every other interaction lands in — no HUD required.
-//
-// The math is the shared, unit-tested frame-budget summarizer; this file is
-// only the per-gesture lifecycle glue.
+/**
+ * Conversation-swipe jank telemetry (#9954).
+ *
+ * The frame-budget HUD (useFrameBudgetMonitor) only runs behind the explicit
+ * `__ELIZA_PERF_HUD__` dev opt-in, so a swipe-jank regression is invisible
+ * outside a dev session. This hook scopes a FrameBudgetSampler to the lifetime
+ * of a single conversation-swipe gesture: it starts sampling rAF deltas +
+ * long-tasks when the gesture begins and, on release, flushes the summary into
+ * the bounded view-interaction telemetry ring as a `conversation-swipe-jank`
+ * event. The drop-frame %, p95 frame time, and fps are therefore observable in
+ * the same ring every other interaction lands in — no HUD required.
+ *
+ * The math is the shared, unit-tested frame-budget summarizer; this file is
+ * only the per-gesture lifecycle glue.
+ */
 
 import { useCallback, useEffect, useRef } from "react";
 import { emitConversationSwipeJank } from "../view-telemetry";

--- a/packages/ui/src/hooks/useFrameBudgetMonitor.ts
+++ b/packages/ui/src/hooks/useFrameBudgetMonitor.ts
@@ -1,14 +1,16 @@
-// Dev-only frame-budget HUD wiring (issue #9141, task 1).
-//
-// Samples requestAnimationFrame deltas + PerformanceObserver('longtask') over a
-// rolling window and emits a FrameBudgetTelemetryEvent on the SAME
-// RENDER_TELEMETRY_EVENT channel the render-guard already uses (no second
-// channel — the issue is explicit about this). Off by default: only runs when
-// `globalThis.__ELIZA_PERF_HUD__` is truthy AND render telemetry is enabled, so
-// it never costs production a single rAF tick.
-//
-// The math lives in ./frame-budget (pure, unit-tested); this file is just the
-// browser glue and is intentionally thin.
+/**
+ * Dev-only frame-budget HUD wiring (issue #9141, task 1).
+ *
+ * Samples requestAnimationFrame deltas + PerformanceObserver('longtask') over a
+ * rolling window and emits a FrameBudgetTelemetryEvent on the SAME
+ * RENDER_TELEMETRY_EVENT channel the render-guard already uses (no second
+ * channel — the issue is explicit about this). Off by default: only runs when
+ * `globalThis.__ELIZA_PERF_HUD__` is truthy AND render telemetry is enabled, so
+ * it never costs production a single rAF tick.
+ *
+ * The math lives in ./frame-budget (pure, unit-tested); this file is just the
+ * browser glue and is intentionally thin.
+ */
 
 import { useEffect } from "react";
 import { PERF_TOGGLE_EVENT } from "../perf/perf-hud-control";

--- a/packages/ui/src/hooks/useLayoutShiftMonitor.ts
+++ b/packages/ui/src/hooks/useLayoutShiftMonitor.ts
@@ -1,24 +1,26 @@
-// Runtime reflow (layout-shift) telemetry (issue #9141).
-//
-// useRenderGuard catches runaway *re-renders*; useFrameBudgetMonitor catches
-// dropped *frames*. Neither catches a *reflow*: content jumping after paint (a
-// ranked widget list reordering, a card popping in and pushing siblings down,
-// an avatar loading with no reserved box). That visible "blip" is exactly a
-// `layout-shift` PerformanceEntry, the same signal Chrome sums into CLS.
-//
-// This module is the missing runtime glue: a passive PerformanceObserver that
-// windows the shifts and emits a LayoutShiftTelemetryEvent on the SAME
-// `eliza:render-telemetry` channel the render-guard and frame-budget monitor
-// use (one channel, by design). The pure CLS math lives in
-// ../testing/layout-stability (shared with the unit tests + the e2e observer),
-// so this file is only the browser glue and stays thin.
-//
-// A layout-shift observer is passive: it fires only when the layout actually
-// shifts, with no rAF/poll, so unlike the frame-budget sampler it is cheap
-// enough to run always-on in dev. It therefore gates on the same
-// isRenderTelemetryEnabled() switch as useRenderGuard (on in dev/test, off in
-// production, killable via __ELIZA_RENDER_TELEMETRY_DISABLED__ or the env), not
-// the opt-in perf-HUD flag.
+/**
+ * Runtime reflow (layout-shift) telemetry (issue #9141).
+ *
+ * useRenderGuard catches runaway *re-renders*; useFrameBudgetMonitor catches
+ * dropped *frames*. Neither catches a *reflow*: content jumping after paint (a
+ * ranked widget list reordering, a card popping in and pushing siblings down,
+ * an avatar loading with no reserved box). That visible "blip" is exactly a
+ * `layout-shift` PerformanceEntry, the same signal Chrome sums into CLS.
+ *
+ * This module is the missing runtime glue: a passive PerformanceObserver that
+ * windows the shifts and emits a LayoutShiftTelemetryEvent on the SAME
+ * `eliza:render-telemetry` channel the render-guard and frame-budget monitor
+ * use (one channel, by design). The pure CLS math lives in
+ * ../testing/layout-stability (shared with the unit tests + the e2e observer),
+ * so this file is only the browser glue and stays thin.
+ *
+ * A layout-shift observer is passive: it fires only when the layout actually
+ * shifts, with no rAF/poll, so unlike the frame-budget sampler it is cheap
+ * enough to run always-on in dev. It therefore gates on the same
+ * isRenderTelemetryEnabled() switch as useRenderGuard (on in dev/test, off in
+ * production, killable via __ELIZA_RENDER_TELEMETRY_DISABLED__ or the env), not
+ * the opt-in perf-HUD flag.
+ */
 
 import { useEffect } from "react";
 import {

--- a/packages/ui/src/hooks/useRenderGuard.ts
+++ b/packages/ui/src/hooks/useRenderGuard.ts
@@ -1,7 +1,9 @@
-// Canonical render-loop telemetry for every elizaOS front-end (app shell and
-// cloud dashboard alike). The RenderTelemetryProfiler component lives in
-// ../cloud-ui/runtime/render-telemetry.tsx so it stays Fast Refresh-compatible;
-// everything else (constants, types, sink, useRenderGuard) is here.
+/**
+ * Canonical render-loop telemetry for every elizaOS front-end (app shell and
+ * cloud dashboard alike). The RenderTelemetryProfiler component lives in
+ * ../cloud-ui/runtime/render-telemetry.tsx so it stays Fast Refresh-compatible;
+ * everything else (constants, types, sink, useRenderGuard) is here.
+ */
 
 import { useEffect, useRef } from "react";
 

--- a/packages/ui/src/hooks/useThreadAutoScroll.ts
+++ b/packages/ui/src/hooks/useThreadAutoScroll.ts
@@ -1,17 +1,18 @@
-// Single auto-scroll / at-bottom / jump-to-latest engine for chat threads (#12348).
-//
-// Both chat surfaces that own their own scroller — the homescreen `ChatSurface`
-// mini-chat and (to follow) the continuous overlay — used to hand-roll the same
-// three behaviours: pin to the newest line while the reader rests at the bottom,
-// do NOT yank a reader who has scrolled up to read history, and coalesce the
-// bottom-follow write into a single rAF so a streamed token never forces a
-// synchronous reflow. This hook is that logic, once, with the at-bottom state
-// promoted to a real value so a "jump to latest" affordance can render when the
-// reader has scrolled away (previously no surface had one).
-//
-// It is scroll math only — no chrome, no message shape. The caller wires the
-// returned `scrollRef` to its scroller, reads `atBottom` to gate a jump control,
-// and calls `jumpToLatest()` from that control.
+/**
+ * Single auto-scroll / at-bottom / jump-to-latest engine for chat threads (#12348).
+ *
+ * The chat surfaces that own their own scroller — the homescreen `ChatSurface`
+ * mini-chat and the continuous overlay — share the same three behaviours through
+ * this one hook: pin to the newest line while the reader rests at the bottom, do
+ * NOT yank a reader who has scrolled up to read history, and coalesce the
+ * bottom-follow write into a single rAF so a streamed token never forces a
+ * synchronous reflow. The at-bottom state is a real value so a "jump to latest"
+ * affordance can render when the reader has scrolled away.
+ *
+ * It is scroll math only — no chrome, no message shape. The caller wires the
+ * returned `scrollRef` to its scroller, reads `atBottom` to gate a jump control,
+ * and calls `jumpToLatest()` from that control.
+ */
 
 import {
   useCallback,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,9 @@
-// Stylesheets live in `./styles.ts` (`@elizaos/ui/styles`) so the barrel can be
-// imported by Node-side plugin loaders without forcing a CSS evaluation
-// (Node refuses ".css" extensions). Renderers must opt-in explicitly.
+/**
+ * Main barrel for @elizaos/ui: the package's public export surface. Stylesheets
+ * live in `./styles.ts` (`@elizaos/ui/styles`) so this barrel can be imported by
+ * Node-side plugin loaders without forcing a CSS evaluation (Node refuses ".css"
+ * extensions); renderers must opt into styles explicitly.
+ */
 
 export { resolveAppBranding } from "@elizaos/shared";
 export * from "./App";

--- a/packages/ui/src/lib/floating-layers.ts
+++ b/packages/ui/src/lib/floating-layers.ts
@@ -1,6 +1,8 @@
-// ── Z-index scale ──────────────────────────────────────────────
-// Every z-index in the app must come from this file.
-// Values are intentionally sparse so new layers can be inserted.
+/**
+ * Canonical z-index scale for floating layers. Every z-index in the app must
+ * come from this file; values are intentionally sparse so new layers can be
+ * inserted between existing ones without renumbering.
+ */
 
 export const Z_BASE = 0;
 export const Z_DROPDOWN = 10;

--- a/packages/ui/src/perf/perf-hud-control.ts
+++ b/packages/ui/src/perf/perf-hud-control.ts
@@ -1,15 +1,17 @@
-// Enable affordance for the dev perf HUD + frame-budget telemetry (issue #9141).
-//
-// The frame-budget monitor + PerfOverlay self-gate on `window.__ELIZA_PERF_HUD__`
-// so they cost production nothing. This module is the single place that flips it:
-// - boot enable from a Vite env (`VITE_ELIZA_PERF_HUD`) or a persisted pref,
-// - a runtime hotkey (Cmd/Ctrl+Shift+P),
-// - a console handle (`window.__elizaPerfHud()`),
-// each dispatching PERF_TOGGLE_EVENT so live consumers react.
-//
-// Reflow + re-render telemetry gates separately on isRenderTelemetryEnabled().
-// Only the rAF-driven FPS/jank sampler is opt-in here, to honor the battery
-// decision that removed permanent rAF loops.
+/**
+ * Enable affordance for the dev perf HUD + frame-budget telemetry (issue #9141).
+ *
+ * The frame-budget monitor + PerfOverlay self-gate on `window.__ELIZA_PERF_HUD__`
+ * so they cost production nothing. This module is the single place that flips it:
+ * - boot enable from a Vite env (`VITE_ELIZA_PERF_HUD`) or a persisted pref,
+ * - a runtime hotkey (Cmd/Ctrl+Shift+P),
+ * - a console handle (`window.__elizaPerfHud()`),
+ * each dispatching PERF_TOGGLE_EVENT so live consumers react.
+ *
+ * Reflow + re-render telemetry gates separately on isRenderTelemetryEnabled().
+ * Only the rAF-driven FPS/jank sampler is opt-in here, to honor the battery
+ * decision that removed permanent rAF loops.
+ */
 
 import { isRenderTelemetryEnabled } from "../hooks/useRenderGuard";
 

--- a/packages/ui/src/platform/aosp-user-agent.ts
+++ b/packages/ui/src/platform/aosp-user-agent.ts
@@ -1,4 +1,4 @@
-// Re-export shim: AOSP renderer detection now lives in `@elizaos/shared`.
+/** Re-export shim for AOSP renderer detection, which lives in `@elizaos/shared`. */
 export {
   isAospElizaUserAgent,
   userAgentHasElizaOSMarker,

--- a/packages/ui/src/registry-host.ts
+++ b/packages/ui/src/registry-host.ts
@@ -1,6 +1,8 @@
-// Re-export shim: the UI registry host now lives in `@elizaos/shared` so Node
-// app-registration code shares one canonical store singleton without importing
-// the React package. See `@elizaos/shared/src/registry-host.ts`.
+/**
+ * Re-export shim for the UI registry host, which lives in `@elizaos/shared` so
+ * Node app-registration code shares one canonical store singleton without
+ * importing the React package. See `@elizaos/shared/src/registry-host.ts`.
+ */
 export {
   getUiRegistryStore,
   provideUiRegistryHost,

--- a/packages/ui/src/spatial/webxr-polyfill.types.ts
+++ b/packages/ui/src/spatial/webxr-polyfill.types.ts
@@ -1,8 +1,10 @@
-// Ambient types for the untyped `webxr-polyfill` package (no @types package
-// exists). A plain `.ts` rather than `.d.ts` because `packages/ui/src/**/*.d.ts`
-// is gitignored for generated declarations. Only the default export's
-// constructor is used: `ensureWebXR()` instantiates the polyfill once to install
-// `navigator.xr` where the API is missing, then discards it (see webxr-runtime.ts).
+/**
+ * Ambient types for the untyped `webxr-polyfill` package (no @types package
+ * exists). A plain `.ts` rather than `.d.ts` because generated `.d.ts`
+ * declarations under `packages/ui/src` are gitignored. Only the default export's
+ * constructor is used: `ensureWebXR()` instantiates the polyfill once to install
+ * `navigator.xr` where the API is missing, then discards it (see webxr-runtime.ts).
+ */
 declare module "webxr-polyfill" {
   export default class WebXRPolyfill {
     constructor(config?: { allowCardboardOnDesktop?: boolean });

--- a/packages/ui/src/styles.ts
+++ b/packages/ui/src/styles.ts
@@ -1,9 +1,10 @@
-// Renderer-only entry point for @elizaos/ui's bundled stylesheets.
-// Apps that need the default UI stylesheets must import this module
-// explicitly (e.g. `import "@elizaos/ui/styles"`). It is intentionally
-// separate from `./index.ts` so that Node-side plugin loaders can
-// import the UI barrel without triggering a CSS module evaluation
-// (Node refuses ".css" extensions out of the box).
+/**
+ * Renderer-only entry point (`@elizaos/ui/styles`) for the package's bundled
+ * stylesheets. Apps that want the default UI styles import this module
+ * explicitly. Kept separate from `./index.ts` so Node-side plugin loaders can
+ * import the UI barrel without triggering a CSS module evaluation (Node refuses
+ * ".css" extensions out of the box).
+ */
 import "./styles/styles.css";
 import "./styles/brand-gold.css";
 import "./cloud-ui/index.css";

--- a/packages/ui/stories/check-catalog.mjs
+++ b/packages/ui/stories/check-catalog.mjs
@@ -1,5 +1,7 @@
-// Serve the built catalog dist and load index.html headless to surface the
-// runtime errors that made the dev server redirect `/` away.
+/**
+ * Serves the built catalog dist and loads index.html headless to surface the
+ * runtime errors that made the dev server redirect `/` away.
+ */
 
 import { readFile } from "node:fs/promises";
 import { createServer } from "node:http";

--- a/packages/ui/stories/check-stories.mjs
+++ b/packages/ui/stories/check-stories.mjs
@@ -1,6 +1,10 @@
-// Headless checker: load every Storybook story in isolation, capture render
-// errors (SB error overlay, page errors, console.error). Usage:
-//   node stories/check-stories.mjs [--base http://localhost:6006] [--limit N] [--filter substr] [--globals theme:light]
+/**
+ * Headless checker: loads every Storybook story in isolation and captures
+ * render errors (SB error overlay, page errors, console.error).
+ *
+ * Usage:
+ *   node stories/check-stories.mjs [--base http://localhost:6006] [--limit N] [--filter substr] [--globals theme:light]
+ */
 import { chromium } from "playwright";
 
 const arg = (name, def) => {

--- a/packages/ui/stories/src/concepts/lattice.ts
+++ b/packages/ui/stories/src/concepts/lattice.ts
@@ -1,11 +1,13 @@
-// Geodesic strut frame — a glowing architectural wireframe cage.
-//
-// Takes an IcosahedronGeometry(1,2), renders its edges as cool-white/cyan
-// LineSegments (the "struts"), and places a small emissive node sphere at
-// every unique vertex via a single InstancedMesh. A brightness wave phases
-// each node by its dot with a sweep axis so a pulse visibly rolls across the
-// lattice. Reacts to voice: nodes brighten on energy, pulse speeds up and
-// the whole frame scales/breathes on respond, accent tint on respond.
+/**
+ * Geodesic strut frame — a glowing architectural wireframe cage.
+ *
+ * Takes an IcosahedronGeometry(1,2), renders its edges as cool-white/cyan
+ * LineSegments (the "struts"), and places a small emissive node sphere at
+ * every unique vertex via a single InstancedMesh. A brightness wave phases
+ * each node by its dot with a sweep axis so a pulse visibly rolls across the
+ * lattice. Reacts to voice: nodes brighten on energy, pulse speeds up and
+ * the whole frame scales/breathes on respond, accent tint on respond.
+ */
 
 import type {
   ConceptDescriptor,

--- a/packages/ui/stories/src/concepts/platonic.ts
+++ b/packages/ui/stories/src/concepts/platonic.ts
@@ -1,10 +1,12 @@
-// Morphing platonic solids — sacred geometry transmutation.
-//
-// Five platonic solids (tetra → cube → octa → dodeca → icosa) each rendered as
-// a faint crystal-glass body + crisp glowing edge lines. One solid is visible at
-// a time; every few seconds they cross-fade: the outgoing solid scales/fades to 0
-// while the incoming scales/fades from 0. The whole form slow-rotates, quickening
-// on energy. On respond the transition snaps and edges flare brighter.
+/**
+ * Morphing platonic solids — sacred geometry transmutation.
+ *
+ * Five platonic solids (tetra → cube → octa → dodeca → icosa) each rendered as
+ * a faint crystal-glass body + crisp glowing edge lines. One solid is visible at
+ * a time; every few seconds they cross-fade: the outgoing solid scales/fades to 0
+ * while the incoming scales/fades from 0. The whole form slow-rotates, quickening
+ * on energy. On respond the transition snaps and edges flare brighter.
+ */
 
 import type {
   ConceptDescriptor,

--- a/packages/ui/stories/src/concepts/spirograph.ts
+++ b/packages/ui/stories/src/concepts/spirograph.ts
@@ -1,16 +1,18 @@
-// Harmonic Lissajous / spirograph curves — thick white glass tubes over the
-// solid orange field, each with a per-tube fresnel rim glow.
-//
-// 5 closed 3D curves, each traced by parametric harmonics over t in [0, 2π]:
-//   x = sin(a*t + φx), y = sin(b*t + φy), z = sin(c*t + φz)
-// Each closed curve is resampled into a CatmullRom path and swept into a real
-// TubeGeometry (so the strands have genuine thickness — THREE.Line ignores
-// linewidth on WebGPU). An unlit white material drives its opacity from a
-// view-angle fresnel term: opaque bright silhouette, translucent core letting
-// the orange show through, so every thread reads as a glowing glass tube.
-//
-// The whole bundle turns very slowly; each tube also drifts on its own axis.
-// Respond spreads the tubes apart and pumps overall opacity. Hue stays white.
+/**
+ * Harmonic Lissajous / spirograph curves — thick white glass tubes over the
+ * solid orange field, each with a per-tube fresnel rim glow.
+ *
+ * 5 closed 3D curves, each traced by parametric harmonics over t in [0, 2π]:
+ *   x = sin(a*t + φx), y = sin(b*t + φy), z = sin(c*t + φz)
+ * Each closed curve is resampled into a CatmullRom path and swept into a real
+ * TubeGeometry (so the strands have genuine thickness — THREE.Line ignores
+ * linewidth on WebGPU). An unlit white material drives its opacity from a
+ * view-angle fresnel term: opaque bright silhouette, translucent core letting
+ * the orange show through, so every thread reads as a glowing glass tube.
+ *
+ * The whole bundle turns very slowly; each tube also drifts on its own axis.
+ * Respond spreads the tubes apart and pumps overall opacity. Hue stays white.
+ */
 
 import type {
   ConceptDescriptor,

--- a/packages/ui/stories/src/concepts/tessellation.ts
+++ b/packages/ui/stories/src/concepts/tessellation.ts
@@ -1,12 +1,14 @@
-// Tessellation — tectonic facets breathing in traveling sine waves.
-//
-// IcosahedronGeometry(1,2), non-indexed, flat-shaded. At build, base vertex
-// positions and their normalized radial directions are cached in Float32Arrays.
-// Each frame, every vertex is displaced outward along its direction by the sum
-// of two traveling sine waves whose ridgelines sweep across the globe over time.
-// computeVertexNormals() after each update keeps the flat facets crisp.
-// Wave amplitude and speed grow with energy; a sharp pulse on respond flares
-// emissive intensity and spikes amplitude briefly; accent tint bleeds in on respond.
+/**
+ * Tessellation — tectonic facets breathing in traveling sine waves.
+ *
+ * IcosahedronGeometry(1,2), non-indexed, flat-shaded. At build, base vertex
+ * positions and their normalized radial directions are cached in Float32Arrays.
+ * Each frame, every vertex is displaced outward along its direction by the sum
+ * of two traveling sine waves whose ridgelines sweep across the globe over time.
+ * computeVertexNormals() after each update keeps the flat facets crisp.
+ * Wave amplitude and speed grow with energy; a sharp pulse on respond flares
+ * emissive intensity and spikes amplitude briefly; accent tint bleeds in on respond.
+ */
 
 import type {
   ConceptDescriptor,

--- a/packages/ui/stories/src/node-builtins-browser-shim.ts
+++ b/packages/ui/stories/src/node-builtins-browser-shim.ts
@@ -1,11 +1,13 @@
-// Browser shim for the Node built-ins (`node:fs`, `node:fs/promises`,
-// `node:path`, `node:url`, `node:os`) that leak into the catalog through the
-// `@elizaos/shared` barrel and `@elizaos/ui` services (package-root resolution,
-// local-inference disk-space probing, etc.). The catalog never invokes those
-// code paths, but Vite's dev server externalizes `node:*` to a proxy that
-// throws on the named-import binding, so we supply non-throwing shims. The
-// pure path/url helpers do real string work; the fs helpers throw only if
-// actually called (which the catalog never does).
+/**
+ * Browser shim for the Node built-ins (`node:fs`, `node:fs/promises`,
+ * `node:path`, `node:url`, `node:os`) that leak into the catalog through the
+ * `@elizaos/shared` barrel and `@elizaos/ui` services (package-root resolution,
+ * local-inference disk-space probing, etc.). The catalog never invokes those
+ * code paths, but Vite's dev server externalizes `node:*` to a proxy that
+ * throws on the named-import binding, so this supplies non-throwing shims. The
+ * pure path/url helpers do real string work; the fs helpers throw only if
+ * actually called (which the catalog never does).
+ */
 
 // ── node:url ──────────────────────────────────────────────────────────────
 export function fileURLToPath(input: string | URL): string {

--- a/packages/ui/stories/src/orb-kit.ts
+++ b/packages/ui/stories/src/orb-kit.ts
@@ -1,12 +1,14 @@
-// Shared kit for the voice-orb comparison harness.
-//
-// Concept files (./concepts/<id>.ts) import the types + helpers from HERE, never
-// from voice-main.tsx — importing the entry module would re-run its
-// `createRoot`/`root.render` and mount a second React tree onto the canvas.
-//
-// TSL's node API is a runtime proxy with no usable static types, so the
-// three/tsl modules are typed loosely at this boundary and nowhere else.
-// Concepts receive `THREE`/`TSL` already imported.
+/**
+ * Shared kit for the voice-orb comparison harness.
+ *
+ * Concept files (./concepts/<id>.ts) import the types + helpers from HERE, never
+ * from voice-main.tsx — importing the entry module would re-run its
+ * `createRoot`/`root.render` and mount a second React tree onto the canvas.
+ *
+ * TSL's node API is a runtime proxy with no usable static types, so the
+ * three/tsl modules are typed loosely at this boundary and nowhere else.
+ * Concepts receive `THREE`/`TSL` already imported.
+ */
 
 export type WebGPUModule = Record<string, any>;
 export type TSLModule = Record<string, any>;


### PR DESCRIPTION
## Comment cleanup B05 — packages/ui (api / first-run / hooks / config / spatial / perf / platform / scripts / stories)

Part of the repo-wide comment cleanup (parent #12181, batch #12235). **Comment-only; `check:comment-only` PASSES** — the code token stream is byte-for-byte identical to `origin/develop` (proven by `scripts/assert-comment-only-diff.mjs`).

### What changed
- Converted `//` banner-style file headers to single `/** … */` prose headers per the settled convention (position is the signal; no `@fileoverview`/`@author`).
- Rewrote churn-phrased comments ("now lives in…", "Previously… Now…") into present-tense durable facts, preserving the why-this-not-that rationale.
- No restatement comments added; clear files left with a header and nothing else.

Headers in `packages/ui/**` (excl. `src/components/**`, owned by sibling batch B04) already landed via #12478; this slice finishes the remaining `//`→`/**` header conversions and churn rewrites on the api/first-run/hooks/config/spatial/perf/platform/registry-host/styles/scripts/stories files.

### Tallies
- Files touched: **38** (all `packages/ui`, none under `src/components/**`).
- Headers converted/repaired: 38 files (banner `//` → `/** */` prose).
- Churn rewritten to present tense: `platform/aosp-user-agent.ts`, `index.ts`, `first-run/use-first-run-conductor.ts` (error-surface rationale), plus the `//`→`/**` set.
- filesFlagged (purpose could not be determined): **none**.

### Verification
```
$ node scripts/assert-comment-only-diff.mjs
[assert-comment-only-diff] OK — 38 source file(s) changed; every code token identical to origin/develop. Comments only.
```

### Evidence
- Real-LLM trajectories — N/A: comments-only change, zero functional diff (machine-checked by scripts/assert-comment-only-diff.mjs).
- Screenshots / video / audio / domain artifacts — N/A: same reason.
- Backend/frontend logs — N/A: no runtime code path changes.

Refs #12235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
