### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-settings-a

### DIFF
--- a/packages/ui/src/components/settings/AdvancedSection.stories.tsx
+++ b/packages/ui/src/components/settings/AdvancedSection.stories.tsx
@@ -1,3 +1,9 @@
+/**
+ * Storybook stories for the Settings → Backup & Reset section, covering the
+ * export/import dialogs across resting, primed, busy, error, and success states
+ * with a mock App context (no backend).
+ */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { mockApp, withMockApp } from "../../storybook/mock-providers.helpers";
 import { AdvancedSection } from "./AdvancedSection";

--- a/packages/ui/src/components/settings/AdvancedSection.tsx
+++ b/packages/ui/src/components/settings/AdvancedSection.tsx
@@ -1,3 +1,10 @@
+/**
+ * Settings → "Backup & Reset" section body (the `advanced` section registered
+ * in settings-sections.ts). Drives local-agent backup export/import — create,
+ * list, and restore via the typed API client — alongside developer- and
+ * preview-mode toggles and a confirmed reset-to-defaults action.
+ */
+
 import { AlertTriangle, Download, Trash2, Upload } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useAgentElement } from "../../agent-surface";

--- a/packages/ui/src/components/settings/AdvancedToggle.stories.tsx
+++ b/packages/ui/src/components/settings/AdvancedToggle.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook stories for the AdvancedToggle switch that gates advanced settings
+ * sections, rendered under a mock App context.
+ */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { AdvancedToggle } from "./AdvancedToggle";

--- a/packages/ui/src/components/settings/ApiKeyConfig.tsx
+++ b/packages/ui/src/components/settings/ApiKeyConfig.tsx
@@ -1,3 +1,11 @@
+/**
+ * Provider API-key / credential form for the Models & Providers settings.
+ * Partitions a plugin's parameters into a Credentials group (required or
+ * sensitive keys) and an Advanced disclosure, renders them through
+ * ConfigRenderer, and gates saving behind OWNER role. Server-side validation
+ * warnings/errors flow in as props and surface inline.
+ */
+
 import { useCallback, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import { client, type PluginParamDef } from "../../api";

--- a/packages/ui/src/components/settings/AppearanceSettingsSection.stories.tsx
+++ b/packages/ui/src/components/settings/AppearanceSettingsSection.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook stories for the Settings → Appearance section across theme modes
+ * (system/dark/light) and UI language, using a mock App context.
+ */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { mockApp } from "../../storybook/mock-providers.helpers";
 import { AppearanceSettingsSection } from "./AppearanceSettingsSection";

--- a/packages/ui/src/components/settings/BackgroundSettingsControls.test.tsx
+++ b/packages/ui/src/components/settings/BackgroundSettingsControls.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/**
+ * Renders BackgroundSettingsControls against a seeded in-memory App store to
+ * assert undo/redo affordances appear only when history exists and fire the
+ * store callbacks. jsdom, no backend.
+ */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { __setAppValueForTests } from "../../state/app-store";

--- a/packages/ui/src/components/settings/BackgroundSettingsSection.test.tsx
+++ b/packages/ui/src/components/settings/BackgroundSettingsSection.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/**
+ * Renders BackgroundSettingsSection against a seeded in-memory App store and
+ * asserts it mounts the unified background controls and forwards a preset pick
+ * to `setBackgroundConfig`. jsdom; the background-image module is mocked.
+ */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { __setAppValueForTests } from "../../state/app-store";

--- a/packages/ui/src/components/settings/CapabilitiesSection.stories.tsx
+++ b/packages/ui/src/components/settings/CapabilitiesSection.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook stories for the Settings → Capabilities section, toggling the
+ * wallet / browser / computer-use capabilities under a mock App context.
+ */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { mockApp, withMockApp } from "../../storybook/mock-providers.helpers";
 import { CapabilitiesSection } from "./CapabilitiesSection";

--- a/packages/ui/src/components/settings/CapabilitiesSection.tsx
+++ b/packages/ui/src/components/settings/CapabilitiesSection.tsx
@@ -1,3 +1,12 @@
+/**
+ * Settings → Capabilities section (the `capabilities` section id). Toggles the
+ * wallet / browser / computer-use capabilities on the App state, sets the
+ * proactive-interaction chattiness (persisted to `config.env` under
+ * ELIZA_PROACTIVE_INTERACTIONS), manages auto-training config, and hosts the
+ * Capability Router connect form for endpoint- or cloud-hosted capability
+ * providers.
+ */
+
 import {
   AlertTriangle,
   Cloud,

--- a/packages/ui/src/components/settings/ChatHotkeySettingsGroup.tsx
+++ b/packages/ui/src/components/settings/ChatHotkeySettingsGroup.tsx
@@ -1,3 +1,10 @@
+/**
+ * Desktop settings control for the programmable chat-overlay summon hotkey
+ * (#10716), embedded in the Desktop Workspace section. Persists the accelerator
+ * via `setChatOverlayHotkey` and re-registers the OS shortcut through the
+ * desktop bridge so a change takes effect without relaunching the shell.
+ */
+
 import { Keyboard } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { invokeDesktopBridgeRequest } from "../../bridge";
@@ -41,12 +48,8 @@ async function syncChatOverlayShortcut(
   }
 }
 
-/**
- * Desktop settings control for the programmable chat-overlay summon hotkey
- * (#10716): an enable toggle plus a keystroke recorder that captures the next
- * key combination as the accelerator. Persists via `setChatOverlayHotkey` and
- * re-registers the OS shortcut through the desktop bridge immediately.
- */
+/** Enable toggle plus a keystroke recorder that captures the next key
+ * combination as the chat-overlay accelerator. */
 export function ChatHotkeySettingsGroup() {
   const t = useAppSelector((s) => s.t);
   const hotkey = useChatOverlayHotkey();

--- a/packages/ui/src/components/settings/CloudAgentsSection.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.tsx
@@ -1,3 +1,11 @@
+/**
+ * Cloud-agents management panel for the Cloud settings group. Lists the
+ * signed-in user's Eliza Cloud agents and drives their lifecycle — create,
+ * rename, suspend/resume (with status polling), delete (with job polling), and
+ * "wake then switch to" — through the typed cloud API client. The active cloud
+ * server is tracked in persisted App state so the current agent is highlighted.
+ */
+
 import {
   Bot,
   Check,

--- a/packages/ui/src/components/settings/ConnectorsSection.test.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/**
+ * Renders ConnectorsSection with a mocked App context and connector-mode
+ * registry to assert icon fallbacks (no raw emoji glyphs) and the setup-panel
+ * routing. jsdom, no backend.
+ */
 
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/settings/DesktopWorkspaceDisplay.hooks.ts
+++ b/packages/ui/src/components/settings/DesktopWorkspaceDisplay.hooks.ts
@@ -1,3 +1,10 @@
+/**
+ * Formats a DesktopWorkspaceSnapshot into the multi-line diagnostics blob shown
+ * by DesktopWorkspaceDisplay — one line per display, plus power/idle, primary
+ * display, clipboard formats, and resolved paths. `useDesktopDiagnosticsText`
+ * memoizes the render.
+ */
+
 import { useMemo } from "react";
 import type { TranslateFn } from "../../types";
 import {

--- a/packages/ui/src/components/settings/DesktopWorkspaceDisplay.tsx
+++ b/packages/ui/src/components/settings/DesktopWorkspaceDisplay.tsx
@@ -1,3 +1,9 @@
+/**
+ * Read-only diagnostics card for the Desktop Workspace section — renders the
+ * pre-formatted `diagnosticsText` (built by DesktopWorkspaceDisplay.hooks) in a
+ * scrollable `<pre>` inside the settings layout.
+ */
+
 import type { TranslateFn } from "../../types";
 import { SettingsGroup, SettingsRow } from "./settings-layout";
 

--- a/packages/ui/src/components/settings/DesktopWorkspaceSection.tsx
+++ b/packages/ui/src/components/settings/DesktopWorkspaceSection.tsx
@@ -1,3 +1,12 @@
+/**
+ * Desktop-only workspace section: loads the DesktopWorkspaceSnapshot (displays,
+ * power/idle, clipboard, paths) from the desktop bridge, exposes actions to open
+ * companion surface windows, relaunch the shell / restart the backend, and read
+ * the clipboard, and embeds the chat-overlay hotkey control and the diagnostics
+ * card. Only active under the Electrobun runtime; renders nothing meaningful in
+ * the browser.
+ */
+
 import { Monitor, RefreshCw } from "lucide-react";
 import {
   type ReactNode,

--- a/packages/ui/src/components/settings/IdentitySettingsSection.tsx
+++ b/packages/ui/src/components/settings/IdentitySettingsSection.tsx
@@ -1,3 +1,12 @@
+/**
+ * Settings → "Basics" section (the `identity` section id). Edits the agent's
+ * character identity (name/bio draft, saved via App state) and its voice
+ * configuration — TTS provider, model, and voice pick, with an in-panel test
+ * playback. When Eliza Cloud is connected (or the voice proxy is available) the
+ * ElevenLabs voice groups are offered; otherwise it falls back to the edge/
+ * premade voices.
+ */
+
 import { Volume2, VolumeX } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAgentElement } from "../../agent-surface";

--- a/packages/ui/src/components/settings/LoadedPacksList.tsx
+++ b/packages/ui/src/components/settings/LoadedPacksList.tsx
@@ -1,3 +1,9 @@
+/**
+ * Renders the loaded content packs as toggleable settings rows (in the
+ * Appearance section), marking the active pack and calling back on toggle. Each
+ * row is agent-addressable via `useAgentElement`.
+ */
+
 import type { ResolvedContentPack } from "@elizaos/shared";
 import { Check } from "lucide-react";
 import { useAgentElement } from "../../agent-surface";

--- a/packages/ui/src/components/settings/PermissionsSection.tsx
+++ b/packages/ui/src/components/settings/PermissionsSection.tsx
@@ -1,3 +1,11 @@
+/**
+ * Settings → Permissions section (the `permissions` section id). Lists the OS-
+ * level permissions the agent depends on (from SYSTEM_PERMISSIONS/CAPABILITIES),
+ * shows each one's granted/denied status, and requests or reconciles them across
+ * platforms — mobile via the native mobile-signals plugin, desktop via the
+ * bridge. Also hosts the permission-priming card.
+ */
+
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { PermissionId, PermissionState } from "../../api";
 import {

--- a/packages/ui/src/components/settings/ProviderCard.tsx
+++ b/packages/ui/src/components/settings/ProviderCard.tsx
@@ -1,3 +1,10 @@
+/**
+ * Selectable provider chip used by ProviderSwitcher — a pill button showing a
+ * provider's icon, label, and status (active/selected/current). Agent-
+ * addressable via `useAgentElement`; selection is fully controlled by the
+ * parent.
+ */
+
 import { CheckCircle2 } from "lucide-react";
 import type { ComponentType } from "react";
 import { useAgentElement } from "../../agent-surface";

--- a/packages/ui/src/components/settings/ProviderRoutingPanel.tsx
+++ b/packages/ui/src/components/settings/ProviderRoutingPanel.tsx
@@ -1,3 +1,10 @@
+/**
+ * Presentational Eliza Cloud model-routing panel for ProviderSwitcher: a primary
+ * large-tier model dropdown plus an "Model overrides" disclosure that renders
+ * the per-tier ConfigRenderer schema. All state (options, values, save status)
+ * is controlled by the parent via `useCloudModelConfig`.
+ */
+
 import type { ModelOption } from "@elizaos/shared";
 import { CheckCircle2, Loader2 } from "lucide-react";
 import { ConfigRenderer } from "../../components/config-ui/config-renderer";

--- a/packages/ui/src/components/settings/ProviderSwitcher.tsx
+++ b/packages/ui/src/components/settings/ProviderSwitcher.tsx
@@ -1,3 +1,13 @@
+/**
+ * Settings → "Models & Providers" section (the `ai-model` section id). Thin
+ * compositional shell that wires the provider hooks
+ * (useProviderEntries/useProviderSelection/useProviderBootstrap/
+ * useCloudModelConfig) to the presentational pieces: the ProviderCard grid, the
+ * per-provider panels (cloud tier dropdowns, API-key form, local models), and
+ * the routing matrix. `ActiveProviderSummary` renders the single active-provider
+ * row for other surfaces. Section body lazy-loaded via settings-sections.ts.
+ */
+
 import { useCallback, useMemo } from "react";
 import { useDefaultProviderPresets } from "../../hooks/useDefaultProviderPresets";
 import {

--- a/packages/ui/src/components/settings/RuntimeSettingsSection.tsx
+++ b/packages/ui/src/components/settings/RuntimeSettingsSection.tsx
@@ -1,3 +1,12 @@
+/**
+ * Settings → Runtime section (the `runtime` section id). Shows where the agent
+ * currently runs (local / remote / cloud, from `GET /api/runtime/mode` with a
+ * local heuristic fallback) and lets the user switch targets: connect to a
+ * remote agent URL+token, or migrate the desktop state dir / pick a workspace
+ * folder via the Electrobun bridge. The Local option is hidden on builds that
+ * ship without an on-device runtime (store build, Android cloud build).
+ */
+
 import { Cloud, Laptop, type LucideIcon, RadioTower } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";

--- a/packages/ui/src/components/settings/SecuritySettingsSection.tsx
+++ b/packages/ui/src/components/settings/SecuritySettingsSection.tsx
@@ -1,3 +1,10 @@
+/**
+ * Settings → Security section (the `security` section id), OWNER-only behind a
+ * RoleGate. Surfaces the access mode / bind endpoint (loopback vs all-
+ * interfaces, with private/public host warnings), the remote-access password,
+ * and the active device sessions with per-session revoke.
+ */
+
 import {
   KeyRound,
   Laptop,

--- a/packages/ui/src/components/settings/VoiceConfigView.helpers.ts
+++ b/packages/ui/src/components/settings/VoiceConfigView.helpers.ts
@@ -1,3 +1,9 @@
+/**
+ * Click-audit manifest for VoiceConfigView's desktop Talk Mode panel — the
+ * expected desktop-only interactive controls and their coverage, consumed by
+ * the desktop click-audit tooling.
+ */
+
 import type { DesktopClickAuditItem } from "../../utils";
 
 export const DESKTOP_TALKMODE_CLICK_AUDIT: readonly DesktopClickAuditItem[] = [

--- a/packages/ui/src/components/settings/VoiceConfigView.tsx
+++ b/packages/ui/src/components/settings/VoiceConfigView.tsx
@@ -1,3 +1,11 @@
+/**
+ * Full voice-configuration view: TTS/ASR provider + model selection persisted
+ * to `config.messages` via the API client, an in-panel test-playback, the
+ * wake-word section, and the desktop-only Talk Mode panel (Electrobun bridge).
+ * Barrel-exported from components/index.ts for consumers outside the Settings
+ * section registry.
+ */
+
 import { ASR_PROVIDERS } from "@elizaos/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAgentElement } from "../../agent-surface";

--- a/packages/ui/src/components/settings/VoiceSection.test.tsx
+++ b/packages/ui/src/components/settings/VoiceSection.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/**
+ * Renders the presentational VoiceSection with default prefs and asserts its
+ * sub-panels mount and that the removed strategy/privacy controls stay absent.
+ * jsdom, no backend.
+ */
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
+++ b/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+/**
+ * Mounts VoiceSectionMount (the fetch-and-persist wrapper around VoiceSection)
+ * and asserts the wake-word toggle wiring, the continuous-chat localStorage
+ * mirror, and that mount-time fetch failures fall back to default prefs.
+ * jsdom, with an in-memory localStorage shim.
+ */
 
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/packages/ui/src/components/settings/VoiceTierBanner.helpers.ts
+++ b/packages/ui/src/components/settings/VoiceTierBanner.helpers.ts
@@ -1,3 +1,8 @@
+/**
+ * The ordered voice device-tier list and the default tier, used by
+ * VoiceTierBanner and its tier-selection UI.
+ */
+
 import type { VoiceDeviceTier } from "./VoiceTierBanner";
 
 export const VOICE_DEVICE_TIERS: readonly VoiceDeviceTier[] = [

--- a/packages/ui/src/components/settings/permission-controls.hooks.ts
+++ b/packages/ui/src/components/settings/permission-controls.hooks.ts
@@ -1,3 +1,11 @@
+/**
+ * Desktop permission state for the Permissions settings. Loads the full
+ * permission snapshot from the API, subscribes to bridge permission events, and
+ * reconciles it with renderer-side probes (camera/microphone/location/
+ * notifications) whose true grant state the OS layer can't see. Exposes
+ * `useDesktopPermissionsState` to the settings UI.
+ */
+
 import { PERMISSION_IDS } from "@elizaos/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {

--- a/packages/ui/src/components/settings/permission-types.ts
+++ b/packages/ui/src/components/settings/permission-types.ts
@@ -1,3 +1,10 @@
+/**
+ * Static catalog + presentation constants for the Permissions settings: the
+ * system-permission and capability definitions (labels, icons, platforms), the
+ * per-status badge labels, shared panel class names, refresh delays, and a
+ * translate-with-fallback helper. Pure data; the section components render it.
+ */
+
 import type { PermissionId, PermissionStatus } from "../../api";
 
 /** Permission definition for UI rendering. */

--- a/packages/ui/src/components/settings/settings-control-primitives.hooks.ts
+++ b/packages/ui/src/components/settings/settings-control-primitives.hooks.ts
@@ -1,3 +1,9 @@
+/**
+ * `useSettingsSave` — shared save-button state machine for settings panels:
+ * runs the caller's async `onSave`, tracks saving/error/success, and clears the
+ * transient success flag after a timeout.
+ */
+
 import { useCallback, useEffect, useRef, useState } from "react";
 
 export interface UseSettingsSaveOptions {

--- a/packages/ui/src/components/settings/settings-layout.test.tsx
+++ b/packages/ui/src/components/settings/settings-layout.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/**
+ * Renders the settings-layout primitives (SettingsRow/Group/Stack) and the
+ * agent-addressable rows (SettingsSelectRow/SettingsSwitchRow) to assert label
+ * + inline-control structure and agent-surface wiring. jsdom, no backend.
+ */
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { Bell } from "lucide-react";

--- a/packages/ui/src/components/settings/useProviderBootstrap.ts
+++ b/packages/ui/src/components/settings/useProviderBootstrap.ts
@@ -1,3 +1,10 @@
+/**
+ * Boot hook for ProviderSwitcher: on mount it loads subscription status,
+ * first-run model options, and the saved LLM-text routing, then seeds the
+ * selection + cloud-model hooks. Fetches are best-effort — a failure leaves the
+ * panel on empty/default state rather than blocking render.
+ */
+
 import {
   resolveServiceRoutingInConfig,
   type SubscriptionProviderStatus,

--- a/packages/ui/src/components/settings/useProviderEntries.ts
+++ b/packages/ui/src/components/settings/useProviderEntries.ts
@@ -1,3 +1,10 @@
+/**
+ * Builds the ordered provider list ProviderSwitcher renders — merging enabled
+ * AI-provider plugins, account-managed direct providers, and subscription
+ * selections into a deduped, sorted set of entries with icons and categories.
+ * Also exports the plugin-id normalizer, sorter, and available-id computation.
+ */
+
 import type { SubscriptionProviderStatus } from "@elizaos/shared";
 import { Cloud, Cpu, KeyRound } from "lucide-react";
 import { type ComponentType, useCallback, useMemo } from "react";


### PR DESCRIPTION
Comments-only slice of #12234 covering `packages/ui/src/components/settings`, **shard 0 of 2** (disjoint from the sibling shard).

## What changed
Added top-of-file `/** … */` prose headers (and, where warranted, tightened in-body comments) to in-scope settings files that lacked a proper header. Each header states what the file does in `@elizaos/ui` architecture terms — which settings-section id it registers under (e.g. `advanced`, `capabilities`, `ai-model`, `runtime`, `permissions`, `security`), which boundary/hooks it wires, and, for tests/stories, the surface under test and how real the harness is (all jsdom, no backend).

33 files touched, all under `packages/ui/src/components/settings`:
- Section components: `AdvancedSection`, `ApiKeyConfig`, `CapabilitiesSection`, `CloudAgentsSection`, `DesktopWorkspaceSection`/`Display`(+hooks), `IdentitySettingsSection`, `LoadedPacksList`, `PermissionsSection`, `ProviderCard`, `ProviderRoutingPanel`, `ProviderSwitcher`, `RuntimeSettingsSection`, `SecuritySettingsSection`, `VoiceConfigView`.
- Hooks/helpers/types: `VoiceConfigView.helpers`, `VoiceTierBanner.helpers`, `permission-controls.hooks`, `permission-types`, `settings-control-primitives.hooks`, `useProviderBootstrap`, `useProviderEntries`.
- Story fixtures: `AdvancedSection`/`AdvancedToggle`/`AppearanceSettingsSection`/`CapabilitiesSection` `.stories.tsx`.
- jsdom tests: `BackgroundSettingsControls`, `BackgroundSettingsSection`, `ConnectorsSection`, `VoiceSection`, `VoiceSectionMount`, `settings-layout`.

Files already at the bar (existing accurate headers) were left untouched.

## Verification
`node scripts/assert-comment-only-diff.mjs` → `OK — 33 source file(s) changed; every code token identical to origin/develop. Comments only.`

Part of #12234.