### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-pages-a

### DIFF
--- a/packages/ui/src/components/pages/AutomationsFeed.test.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.test.tsx
@@ -1,5 +1,9 @@
 // @vitest-environment jsdom
 
+// Renders the real AutomationsFeed against a mocked `../../api` client to cover
+// its status overview, truthful run action, and the new-automation → chat
+// hand-off. jsdom + in-memory client stub; no live backend.
+
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/pages/BackgroundView.test.tsx
+++ b/packages/ui/src/components/pages/BackgroundView.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// Renders the real BackgroundView to cover swatch selection (shader config),
+// undo/redo visibility + revert against the persisted history, and gating the
+// cloud "Generate" control on cloud availability. jsdom; only background-image
+// (canvas downscale) is stubbed.
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/pages/CameraPageView.test.tsx
+++ b/packages/ui/src/components/pages/CameraPageView.test.tsx
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+// Renders the real CameraPageView against a mocked @elizaos/capacitor-camera to
+// cover the capture lifecycle: permission request + live preview on mount,
+// photo capture/review/retake, front/back switch, preview teardown on unmount,
+// and the permission-denied state. jsdom; the native camera plugin is stubbed.
+
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/pages/ChatView.terminal-focus.test.tsx
+++ b/packages/ui/src/components/pages/ChatView.terminal-focus.test.tsx
@@ -1,19 +1,17 @@
 // @vitest-environment jsdom
 
-// Regression coverage for the terminal auto-focus loop: a blocked/errored
-// coding-agent session used to permanently hijack the chat surface. The
-// ChatView effect auto-focused ANY error/blocked session whenever
-// `activeTerminalSessionId` was null, and "blocked" (waiting for input) is a
-// routine long-lived state — so closing the terminal panel or selecting a
-// conversation (both clear `activeTerminalSessionId`) re-triggered the effect
-// and bounced the user straight back to the terminal.
+// Guards ChatView's terminal auto-focus against a re-focus loop. A
+// blocked/errored coding-agent session auto-focuses at most once per transition
+// into a problem state — decided through pickProblemSessionToAutoFocus with a
+// ref-held Set of handled session ids — so clearing `activeTerminalSessionId`
+// (closing the terminal panel or selecting a conversation) never re-triggers
+// the effect, and a user-initiated dismissal sticks. "Blocked" (waiting for
+// input) is a routine long-lived state, which is why once-per-transition rather
+// than while-blocked is the correct rule.
 //
-// ChatView now wires the decision through pickProblemSessionToAutoFocus with a
-// ref-held Set of handled session ids: a session auto-focuses at most once per
-// transition into a problem state, and a user-initiated dismissal sticks. The
-// harness below mirrors ChatView's exact wiring (ref + effect + focus sets the
-// active id) so the once-per-transition semantics are proven under React's
-// real effect scheduling, not just as pure-function calls.
+// The harness mirrors ChatView's exact wiring (ref + effect + focus sets the
+// active id) so the semantics are proven under React's real effect scheduling,
+// not just as pure-function calls.
 
 import {
   act,

--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -1,3 +1,17 @@
+/**
+ * The primary chat surface: the transcript, composer, voice/avatar bridge, and
+ * the coding-agent terminal channel. It wires the real send pipeline (message
+ * edit/resend, attachments via clipboard/drag-drop, continuous chat mode) and
+ * the per-conversation voice controller, and hosts the PTY console for coding
+ * sessions (`TerminalChannelPanel`).
+ *
+ * Terminal auto-focus is deliberately once-per-transition: a blocked/errored
+ * coding session is auto-focused at most once (tracked via a ref-held Set of
+ * handled ids) so closing the terminal or switching conversations — both of
+ * which clear `activeTerminalSessionId` — never bounces the user back into the
+ * terminal, and a user-initiated dismissal sticks.
+ */
+
 import { logger } from "@elizaos/logger";
 import { RotateCcw } from "lucide-react";
 import {

--- a/packages/ui/src/components/pages/DatabasePageView.tsx
+++ b/packages/ui/src/components/pages/DatabasePageView.tsx
@@ -1,3 +1,10 @@
+/**
+ * The Database nav tab: a segmented control switching between the SQL/table
+ * DatabaseView, the MediaGalleryView, and the heavy vector-browser surface. The
+ * vector browser is a three.js/WebGL view that ships in its own plugin bundle
+ * and loads dynamically, so THREE only downloads when the user opens that tab.
+ */
+
 import type { ReactNode } from "react";
 import { useAgentElement } from "../../agent-surface";
 import { useAppSelector } from "../../state";

--- a/packages/ui/src/components/pages/DatabaseView.test.tsx
+++ b/packages/ui/src/components/pages/DatabaseView.test.tsx
@@ -1,5 +1,9 @@
 // @vitest-environment jsdom
 
+// Renders the real DatabaseView against a mocked `../../api` client to cover the
+// connect → load-tables → select-table → render-rows flow plus the unavailable,
+// status-error, and empty-table states. jsdom; in-memory client stub.
+
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/pages/ElizaOsAppsView.tsx
+++ b/packages/ui/src/components/pages/ElizaOsAppsView.tsx
@@ -1,3 +1,12 @@
+/**
+ * Native-OS app surfaces for the AOSP ElizaOS fork: the Phone (dialer + call
+ * log), Messages (SMS threads), and Contacts pages. Each reads through the
+ * native-plugins bridge and gates every read behind `ensureNativeReadGranted`
+ * so a known permission-denied state never reaches Capacitor as a raw console
+ * error. On web the native plugins report "granted", so these render as inert
+ * placeholders rather than failing.
+ */
+
 import {
   Clock3,
   ContactRound,

--- a/packages/ui/src/components/pages/FilesView.test.tsx
+++ b/packages/ui/src/components/pages/FilesView.test.tsx
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+// Renders the real FilesView against a mocked `../../api` client to cover the
+// stored-file grid: per-file rows with kind facets, facet filtering, and the
+// download/share hand-off (with the Share control hidden when unsupported).
+// jsdom; the api client and the download/share helper are stubbed.
+
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/pages/KnowledgeView.tsx
+++ b/packages/ui/src/components/pages/KnowledgeView.tsx
@@ -1,12 +1,13 @@
+/**
+ * Knowledge — a top-level nav view that renders the standalone documents
+ * manager under a chromeless "Knowledge" header, outside the character editor
+ * chrome.
+ */
+
 import { ViewHeader } from "../shared/ViewHeader";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 import { DocumentsView } from "./DocumentsView";
 
-/**
- * Knowledge — a top-level view (promoted out of the old Character hub, where it
- * was a nested sub-page). Renders the standalone documents manager under a
- * chromeless "Knowledge" header, not inside the character editor chrome.
- */
 export function KnowledgeView() {
   return (
     <ShellViewAgentSurface viewId="documents">

--- a/packages/ui/src/components/pages/Launcher.test.tsx
+++ b/packages/ui/src/components/pages/Launcher.test.tsx
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+//
+// Renders the real Launcher over deterministic mock ViewEntry catalogs to prove
+// it is a single scrolling page of tiles (no dock, no page dots) in caller
+// order, that tap emits exactly one launch telemetry event, that the tile set
+// tracks catalog changes on re-render, and that image tiles fall back to a
+// glyph (never probing API heroes) for dedicated cloud agents.
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { client } from "../../api";

--- a/packages/ui/src/components/pages/LauncherSurface.test.tsx
+++ b/packages/ui/src/components/pages/LauncherSurface.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// Renders the real LauncherSurface with mocked view/platform hooks to cover
+// curation: which surfaces show (curated apps yes; shell/sub-view/removed no),
+// collapsing duplicate wallet registrations to one tile, gating native-OS tiles
+// on the AOSP fork and developer tools on Developer Mode, and route navigation.
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/pages/LogsView.stories.tsx
+++ b/packages/ui/src/components/pages/LogsView.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for LogsView, seeded with static sample log entries across levels/sources. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { mockApp, withMockApp } from "../../storybook/mock-providers.helpers";
 import { LogsView } from "./LogsView";

--- a/packages/ui/src/components/pages/LogsView.tsx
+++ b/packages/ui/src/components/pages/LogsView.tsx
@@ -1,3 +1,10 @@
+/**
+ * Logs page: renders the agent's structured server log stream as a searchable,
+ * auto-refreshing list. Polls the logs store only while the document is
+ * visible, and gates the first paint on a local loading flag so the empty state
+ * never flashes mid-hydration. Mountable standalone or inside a modal.
+ */
+
 import { ScrollText } from "lucide-react";
 import { memo, type ReactNode, useEffect, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";

--- a/packages/ui/src/components/pages/MediaGalleryView.tsx
+++ b/packages/ui/src/components/pages/MediaGalleryView.tsx
@@ -1,3 +1,11 @@
+/**
+ * Media gallery view: scans agent database tables for attachment/media rows and
+ * renders them as a filterable, searchable grid with a full-size detail modal
+ * plus download/share affordances. Search is driven by the floating chat via
+ * useRegisterViewChatBinding rather than an in-view input. Mounted as a tab of
+ * the Database page surface.
+ */
+
 import { Download, Share2 } from "lucide-react";
 import type { ReactNode } from "react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";

--- a/packages/ui/src/components/pages/MemoryViewerView.mobile-sidebar.test.tsx
+++ b/packages/ui/src/components/pages/MemoryViewerView.mobile-sidebar.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
 //
-// Memories on mobile: the people/filter sidebar opens from a compact "People"
-// control in the view header's right slot — never from the orphan inline
-// trigger PageLayout used to render between the centered header and the
-// content. Guards the `WorkspaceMobileSidebarScope` + `ViewHeaderSidebarTrigger`
-// wiring in MemoryViewerView.
+// Memories on mobile: guards that the people/filter sidebar opens from the
+// compact "People" control in the view header's right slot, not from an inline
+// trigger between the centered header and the content. Covers the
+// `WorkspaceMobileSidebarScope` + `ViewHeaderSidebarTrigger` wiring in
+// MemoryViewerView.
 
 import {
   cleanup,

--- a/packages/ui/src/components/pages/MemoryViewerView.tsx
+++ b/packages/ui/src/components/pages/MemoryViewerView.tsx
@@ -1,3 +1,12 @@
+/**
+ * Memories page: browses the agent's memory store in three modes — a recent
+ * feed, a filtered browse list, and a person-centric view scoped to a
+ * relationship's member entity ids. Pulls stats, people (via the relationships
+ * API), and memory rows from the typed client. On mobile the people/filter
+ * sidebar is opened from a compact control in the view header rather than an
+ * inline trigger.
+ */
+
 import {
   Brain,
   FileText,

--- a/packages/ui/src/components/pages/PluginConfigForm.test.tsx
+++ b/packages/ui/src/components/pages/PluginConfigForm.test.tsx
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+// Renders the real PluginConfigForm to cover the modeToggle `configUiHint`:
+// the backing field is hidden while the hidden-mode value is active and its
+// last non-hidden value is restored when the mode toggles back. jsdom; state
+// barrel stubbed.
+
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginInfo, PluginParamDef } from "../../api";

--- a/packages/ui/src/components/pages/PluginVisual.stories.tsx
+++ b/packages/ui/src/components/pages/PluginVisual.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for PluginVisual, rendering its icon/artwork across sample PluginInfo shapes. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { PluginInfo } from "../../api";
 import { PluginVisual } from "./PluginVisual";

--- a/packages/ui/src/components/pages/PluginsView.test.tsx
+++ b/packages/ui/src/components/pages/PluginsView.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+// Renders the real PluginsView against mocked state + api to cover the plugin
+// catalog: load-once on mount (stable even when ensurePluginsLoaded identity
+// churns), card rendering from context (no raw emoji icon strings), the
+// enable-toggle dispatch with inverted state, and install-progress WS
+// subscription. jsdom; in-memory stubs.
+
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/pages/RelationshipsGraphPanel.tsx
+++ b/packages/ui/src/components/pages/RelationshipsGraphPanel.tsx
@@ -1,3 +1,11 @@
+/**
+ * Force-laid-out node/edge graph of the relationships snapshot: renders people
+ * as draggable nodes and their relationships as edges (labelled with sentiment
+ * and interaction count), with zoom controls and hover tooltips. Layout
+ * positions are computed from the snapshot; selecting a group filters the
+ * visible subgraph. Mounted inside the Relationships workspace.
+ */
+
 import {
   Crown,
   Fingerprint,

--- a/packages/ui/src/components/pages/RelationshipsView.tsx
+++ b/packages/ui/src/components/pages/RelationshipsView.tsx
@@ -1,3 +1,10 @@
+/**
+ * Relationships — a top-level nav view: a chromeless "Relationships" header over
+ * the relationship-graph workspace. On mobile the people sidebar opens from a
+ * compact "People" control in the header, never an inline trigger between the
+ * header and the content.
+ */
+
 import type { ReactNode } from "react";
 import { useWorkspaceMobileSidebarHeader } from "../../layouts/workspace-layout/workspace-mobile-sidebar-controls.hooks";
 import { WorkspaceMobileSidebarScope } from "../../layouts/workspace-layout/workspace-mobile-sidebar-scope";
@@ -5,13 +12,6 @@ import { ViewHeader } from "../shared/ViewHeader";
 import { ViewHeaderSidebarTrigger } from "../shared/ViewHeaderSidebarTrigger";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 import { RelationshipsWorkspaceView } from "./relationships/RelationshipsWorkspaceView";
-
-/**
- * Relationships — a top-level view (promoted out of the old Character hub).
- * Chromeless "Relationships" header over the relationship-graph workspace.
- * On mobile the people sidebar opens from a compact "People" control in the
- * header (never an inline trigger between the header and the content).
- */
 export function RelationshipsView({
   contentHeader,
 }: {

--- a/packages/ui/src/components/pages/RuntimeView.tsx
+++ b/packages/ui/src/components/pages/RuntimeView.tsx
@@ -1,3 +1,11 @@
+/**
+ * Runtime inspector page: fetches a deep snapshot of the live AgentRuntime
+ * (services, actions, providers, evaluators, plugins, and their registration
+ * order) and renders it as a sidebar-navigated, expandable object tree. Depth
+ * and array/object caps are user-adjustable and encoded into the cache key so
+ * distinct fetch parameters revalidate independently instead of colliding.
+ */
+
 import {
   type ReactNode,
   useCallback,

--- a/packages/ui/src/components/pages/SettingsView.test.tsx
+++ b/packages/ui/src/components/pages/SettingsView.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+// Renders the real SettingsView against mocked state + stub sections to cover
+// hub navigation (tile → full-width section → back), the initialSection prop,
+// per-section error boundaries (isolate a throwing section, recover on retry),
+// and the responsive layout switch (single-column hub vs two-pane rail by
+// width/orientation). jsdom; sections and state barrel are stubbed.
+
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/pages/SkillsView.test.tsx
+++ b/packages/ui/src/components/pages/SkillsView.test.tsx
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+// Renders the real SkillsView against a mocked state barrel to cover load-on-
+// mount + empty state, rendering installed skills from context, the enable
+// toggle calling handleSkillToggle with the new value, background refresh
+// polling (no manual refresh control), and search filtering to the empty state.
+
 import {
   act,
   cleanup,

--- a/packages/ui/src/components/pages/SqlEditorPanel.tsx
+++ b/packages/ui/src/components/pages/SqlEditorPanel.tsx
@@ -1,3 +1,10 @@
+/**
+ * Presentational SQL editor panel for the Database view: a query textarea
+ * (Cmd/Ctrl+Enter runs) plus the results grid rendered from a QueryResult. All
+ * query state and execution are owned by the parent and passed in as props; this
+ * component holds no data-fetching logic of its own.
+ */
+
 import { SearchX } from "lucide-react";
 import type { QueryResult } from "../../api";
 import { useAppSelector } from "../../state";

--- a/packages/ui/src/components/pages/TaskEditor.test.tsx
+++ b/packages/ui/src/components/pages/TaskEditor.test.tsx
@@ -1,10 +1,9 @@
 // @vitest-environment jsdom
 /**
- * TaskEditor cross-boundary migration (#12177 review fix #2).
- *
- * When an existing simple automation's schedule kind is changed across the
- * trigger <-> workbench boundary, the editor must MIGRATE (create the new type,
- * then delete the stale one) — never leave a duplicate that keeps firing.
+ * Guards TaskEditor's cross-boundary schedule migration (#12177): when an
+ * existing simple automation's schedule kind changes across the trigger ↔
+ * workbench boundary, the editor MIGRATES — creates the new type, then deletes
+ * the stale one — rather than leaving a duplicate that keeps firing.
  */
 import {
   cleanup,

--- a/packages/ui/src/components/pages/TrajectoryDetailView.tsx
+++ b/packages/ui/src/components/pages/TrajectoryDetailView.tsx
@@ -1,3 +1,10 @@
+/**
+ * Trajectory detail view: loads one recorded agent-run trajectory by id and
+ * renders its pipeline stages, per-stage context diffs, and token deltas as a
+ * stage-navigated inspector. Consumed by the Trajectories list surface when a
+ * run is opened.
+ */
+
 import {
   Brain,
   CheckCircle,

--- a/packages/ui/src/components/pages/TriggersView.tsx
+++ b/packages/ui/src/components/pages/TriggersView.tsx
@@ -1,3 +1,12 @@
+/**
+ * Triggers page: create/list/delete scheduled triggers that fire agent runs
+ * (cron, interval, and one-time schedules). Shared state flows through a
+ * context provider consumed by the list and the detail/edit panel; pure form
+ * and schedule-label helpers live in trigger-form-utils. Warns once per session
+ * when scheduled triggers exist but the host is not long-running (so they may
+ * not fire). `TriggersView` and `TriggersDesktopShell` are the same layout.
+ */
+
 import { CheckCircle2, Plus, X, XCircle } from "lucide-react";
 import {
   createContext,

--- a/packages/ui/src/components/pages/__e2e__/background-fixture.tsx
+++ b/packages/ui/src/components/pages/__e2e__/background-fixture.tsx
@@ -5,9 +5,9 @@
 // undo/redo buttons.
 //
 // The set/undo/redo history uses the SAME pure reducer production does
-// (state/background-history: applyBackgroundSet/Undo/Redo) — it no longer
-// hand-mirrors the semantics, so mirror-vs-real drift is impossible (#10694).
-// That reducer is deliberately persistence-free, so this stays a browser-safe
+// (state/background-history: applyBackgroundSet/Undo/Redo) rather than a
+// hand-mirrored copy, so mirror-vs-real drift is impossible (#10694). That
+// reducer is deliberately persistence-free, so this stays a browser-safe
 // import graph esbuild can bundle (no `client`/`persistence`). The real
 // BackgroundView DOM is covered by BackgroundView.test.tsx; the reducer math by
 // state/__tests__/background-history.test.ts; the persisted round-trip by

--- a/packages/ui/src/components/pages/browser-workspace-wallet-injection.test.ts
+++ b/packages/ui/src/components/pages/browser-workspace-wallet-injection.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Runs the real BROWSER_TAB_PRELOAD_SCRIPT inside a JSDOM window to verify the
+ * wallet-injection contract seen by embedded browser tabs: EIP-1193 + EIP-6963
+ * announce without disclosing accounts, and EIP-1193 connect / message signing
+ * and the Wallet Standard Solana path all route through host consent rather than
+ * exposing keys or broadcasting. Real preload script, synthetic DOM.
+ */
+
 import { JSDOM } from "jsdom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BROWSER_TAB_PRELOAD_SCRIPT } from "../../utils/browser-tabs-renderer-registry";

--- a/packages/ui/src/components/pages/browser-workspace-wallet.ts
+++ b/packages/ui/src/components/pages/browser-workspace-wallet.ts
@@ -1,3 +1,11 @@
+/**
+ * Message protocol + wallet-state model shared by the browser-workspace host
+ * and the wallet bridge hook. Defines the postMessage request/response/ready
+ * message types, the supported EVM chain ids, and the
+ * BrowserWorkspaceWalletState shape (EVM + Solana address/connected/signing
+ * capability flags) that embedded iframes read to talk to the host wallet.
+ */
+
 import type { WalletAddresses, WalletConfigStatus } from "@elizaos/shared";
 import type {
   StewardSignResponse,

--- a/packages/ui/src/components/pages/chat-view-hooks.tsx
+++ b/packages/ui/src/components/pages/chat-view-hooks.tsx
@@ -1,3 +1,12 @@
+/**
+ * Hooks extracted from ChatView so they can be tested in isolation: the voice
+ * controller (`useChatVoiceController`) that resolves cloud-vs-own-key TTS/STT
+ * and speaks assistant turns, and the game-modal message bridge
+ * (`useGameModalMessages`) that carries conversation state into overlay app
+ * surfaces. Locale mapping and companion-speech memory reset helpers round out
+ * the file. See per-export JSDoc for the cloud-voice availability ordering.
+ */
+
 import {
   useCallback,
   useEffect,

--- a/packages/ui/src/components/pages/config-page-sections.helpers.ts
+++ b/packages/ui/src/components/pages/config-page-sections.helpers.ts
@@ -1,3 +1,5 @@
+/** Per-chain RPC provider option lists surfaced by the Config page's wallet/RPC section. */
+
 import { WALLET_RPC_PROVIDER_OPTIONS } from "@elizaos/shared";
 
 export const EVM_RPC_OPTIONS = WALLET_RPC_PROVIDER_OPTIONS.evm;

--- a/packages/ui/src/components/pages/database-utils.test.ts
+++ b/packages/ui/src/components/pages/database-utils.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `buildResultsGridRowKey`: composite keys use every primary-key
+ * column, and rows without a complete primary key fall back to the row index.
+ * Pure function; no DOM or backend.
+ */
+
 import { describe, expect, it } from "vitest";
 
 import type { ColumnInfo } from "../../api";

--- a/packages/ui/src/components/pages/documents-detail.helpers.ts
+++ b/packages/ui/src/components/pages/documents-detail.helpers.ts
@@ -1,3 +1,9 @@
+/**
+ * Pure label formatters for the Documents detail view: derives a type label
+ * from a content type, a translated source label (YouTube/URL/upload), and a
+ * one-line summary (source, fragment count, byte size) for a document record.
+ */
+
 import type { DocumentRecord } from "../../api/client-types-chat";
 import { formatByteSize } from "../../utils/format";
 

--- a/packages/ui/src/components/pages/documents-detail.tsx
+++ b/packages/ui/src/components/pages/documents-detail.tsx
@@ -1,3 +1,10 @@
+/**
+ * Document detail viewer for the Documents/Knowledge page: loads one document
+ * by id, shows its metadata and source/scope badges, renders its fragments, and
+ * supports inline text editing with save. Pure formatting helpers live in
+ * documents-detail.helpers; this file owns the fetch/edit/save lifecycle.
+ */
+
 import {
   BadgeCheck,
   Bot,

--- a/packages/ui/src/components/pages/documents-upload.helpers.ts
+++ b/packages/ui/src/components/pages/documents-upload.helpers.ts
@@ -1,3 +1,11 @@
+/**
+ * Upload limits, accepted extensions, and pure file-classification helpers for
+ * the Documents upload flow: request/bulk byte budgets, the supported-extension
+ * set and its `accept` string, and predicates deciding whether a file is
+ * supported and whether it should be read as text vs binary. Shared by the
+ * upload UI and its tests.
+ */
+
 import type { DocumentScope } from "../../api/client-types-chat";
 
 export const MAX_UPLOAD_REQUEST_BYTES = 32 * 1_048_576;

--- a/packages/ui/src/components/pages/help/HelpView.test.tsx
+++ b/packages/ui/src/components/pages/help/HelpView.test.tsx
@@ -3,15 +3,13 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Help's deep links must survive the tab switch. The settings-section links
-// ("Open AI Model settings" → the ai-model section) previously wrote the
-// section into `window.location.hash` and then called `setTab("settings")` —
-// but setTab pushes the bare `/settings` path, clearing the fragment BEFORE
-// SettingsView mounts and reads it, so the user always landed on the generic
-// Settings hub instead of the promised section. The fix routes the section
-// through the `eliza:navigate:view` `subview` channel (the same sanctioned path
-// the agent + slash-command flows use; App.tsx maps it to SettingsView's
-// `initialSection`). These tests pin that contract.
+// Pins Help's deep-link contract: settings-section links ("Open AI Model
+// settings" → the ai-model section) must land the user on the target section,
+// not the generic Settings hub. The section is routed through the
+// `eliza:navigate:view` `subview` channel (the same path the agent +
+// slash-command flows use; App.tsx maps it to SettingsView's `initialSection`)
+// rather than `window.location.hash`, since setTab pushes the bare `/settings`
+// path and would clear a fragment before SettingsView mounts to read it.
 
 const appMock = vi.hoisted(() => ({
   value: {} as Record<string, unknown>,

--- a/packages/ui/src/components/pages/plugin-list-utils.test.ts
+++ b/packages/ui/src/components/pages/plugin-list-utils.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for plugin-list-utils: icon resolution precedence (image icons
+ * before lucide names, raw labels rejected; only URL/path-like image sources
+ * accepted) and buildPluginListState (hides db/always-on plugins, applies mode
+ * + search + status + subgroup filters and custom order, and sorts ready
+ * plugins before those needing config before disabled). Pure functions.
+ */
+
 import { Puzzle } from "lucide-react";
 import { describe, expect, it } from "vitest";
 import type { PluginInfo } from "../../api";

--- a/packages/ui/src/components/pages/plugin-view-connectors.tsx
+++ b/packages/ui/src/components/pages/plugin-view-connectors.tsx
@@ -1,3 +1,12 @@
+/**
+ * Connector cards for the Plugins view: renders each connector plugin (Discord,
+ * Telegram, Signal, cloud OAuth connections, …) as an expandable card that
+ * co-renders its config form and its setup/account-management panel — including
+ * the case where a mode delegates its setup panel to a *different* plugin id.
+ * `ConnectorPluginGroups` groups the visible connectors and lays them out flat
+ * (no card chrome; group labels + whitespace do the separation).
+ */
+
 import {
   AlertCircle,
   Bot,

--- a/packages/ui/src/components/pages/plugin-view-modal.tsx
+++ b/packages/ui/src/components/pages/plugin-view-modal.tsx
@@ -1,3 +1,11 @@
+/**
+ * Full-screen "game/app" plugin modal for the Plugins view: a master/detail
+ * surface listing installable plugin apps on the left and the selected plugin's
+ * config, connector setup, and enable/disable toggle on the right. Purely
+ * presentational — all plugin state, config values, and action callbacks are
+ * passed in as props by the parent PluginsView.
+ */
+
 import { CheckCircle2, Puzzle, XCircle } from "lucide-react";
 import type { CSSProperties, ReactNode } from "react";
 import { useAgentElement } from "../../agent-surface";

--- a/packages/ui/src/components/pages/relationships/RelationshipsActivityFeed.tsx
+++ b/packages/ui/src/components/pages/relationships/RelationshipsActivityFeed.tsx
@@ -1,3 +1,10 @@
+/**
+ * Paginated activity feed for the Relationships workspace: streams recent
+ * relationship events (new identities, links, tag changes) from the
+ * relationships API and renders them grouped by day with type icons. A sidebar
+ * panel within RelationshipsWorkspaceView.
+ */
+
 import { Fingerprint, Link2, Tags } from "lucide-react";
 import { type ComponentType, useEffect, useRef, useState } from "react";
 import { client } from "../../../api/client";

--- a/packages/ui/src/components/pages/relationships/RelationshipsPersonPanels.tsx
+++ b/packages/ui/src/components/pages/relationships/RelationshipsPersonPanels.tsx
@@ -1,3 +1,11 @@
+/**
+ * Detail panels for a selected person in the Relationships workspace: the
+ * summary header plus the facts, connections, conversations, relevant-memories,
+ * user-preferences, and documents sections. Each panel fetches its slice from
+ * the relationships API scoped to the person's member entity ids. Rendered in
+ * the right pane of RelationshipsWorkspaceView.
+ */
+
 import {
   AtSign,
   BadgeCheck,

--- a/packages/ui/src/components/pages/relationships/RelationshipsWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/relationships/RelationshipsWorkspaceView.tsx
@@ -1,3 +1,11 @@
+/**
+ * Top-level workspace for the Relationships page: a master/detail layout with a
+ * searchable people sidebar, the force-directed graph panel, and the selected
+ * person's detail panels. Owns people/graph data loading, selection state, and
+ * group filtering; delegates rendering to RelationshipsSidebar,
+ * RelationshipsGraphPanel, and the person panels. Mounted by RelationshipsView.
+ */
+
 import { Filter, Network } from "lucide-react";
 import {
   type ReactNode,

--- a/packages/ui/src/components/pages/skill-detail-panel.tsx
+++ b/packages/ui/src/components/pages/skill-detail-panel.tsx
@@ -1,7 +1,7 @@
 /**
- * Skill detail panel — edit modal and companion modal view.
- *
- * Extracted from SkillsView.tsx to keep individual files under ~500 LOC.
+ * Skill detail surfaces for the Skills page: the edit modal
+ * (`EditSkillModal`, backed by the api client) and the read-only companion
+ * modal view (`SkillsModalView`). Sibling to SkillsView, which owns the list.
  */
 
 import { Brain } from "lucide-react";

--- a/packages/ui/src/components/pages/trigger-form-utils.ts
+++ b/packages/ui/src/components/pages/trigger-form-utils.ts
@@ -1,8 +1,9 @@
 /**
- * trigger-form-utils.ts — Pure functions, types, and constants for the Triggers feature.
- *
- * Extracted from TriggersView.tsx so tests and sibling components can
- * import them directly instead of duplicating logic.
+ * Pure form model and constants for the Triggers feature: the trigger form
+ * state shape and empty default, duration-unit math (best-fit unit, ms
+ * conversion, labels), the built-in and user-defined template catalog (with
+ * localStorage load/save), and schedule/event-kind label formatting. Imported
+ * by TriggersView and its tests so neither duplicates the logic.
  */
 
 import type {

--- a/packages/ui/src/components/pages/tutorial/TutorialOverlay.tsx
+++ b/packages/ui/src/components/pages/tutorial/TutorialOverlay.tsx
@@ -1,3 +1,13 @@
+/**
+ * The interactive tour overlay mounted at the shell root: watches the live tab
+ * and chat transcript, spotlights the target element for the current step,
+ * narrates each frame aloud (TutorialNarrator), and advances when the user
+ * performs the step's action. Completion is tracked by step id (never a
+ * lingering boolean) so one frame's success cannot bleed into the next frame's
+ * auto-navigation during the advance render. Drives navigation and chat via the
+ * shell controller and locks nav while a step is active.
+ */
+
 import * as React from "react";
 import { useBranding } from "../../../config/branding";
 import { dispatchTutorialChatControl } from "../../../events";

--- a/packages/ui/src/components/pages/tutorial/TutorialView.tsx
+++ b/packages/ui/src/components/pages/tutorial/TutorialView.tsx
@@ -1,3 +1,10 @@
+/**
+ * The tour launcher — the view the home "Tutorial" tile opens. Pressing Start
+ * activates the global TutorialOverlay (the interactive tour) and drops the user
+ * back on the home base so the tour can spotlight the real chat. Eliza narrates
+ * each frame aloud; the tour can be muted from its card.
+ */
+
 import { Sparkles } from "lucide-react";
 import * as React from "react";
 
@@ -6,13 +13,6 @@ import { useAppSelector } from "../../../state";
 import { Button } from "../../ui/button";
 import { ShellViewAgentSurface } from "../../views/ShellViewAgentSurface";
 import { startTutorial } from "./tutorial-controller";
-
-/**
- * The tour launcher — the view the home "Tutorial" tile opens. Pressing Start
- * activates the global TutorialOverlay (the interactive tour) and drops the user
- * back on the home base so the tour can spotlight the real chat. Eliza narrates
- * each frame aloud; the tour can be muted from its card.
- */
 
 export function TutorialView(): React.ReactElement {
   return (

--- a/packages/ui/src/components/pages/tutorial/tutorial-steps.test.ts
+++ b/packages/ui/src/components/pages/tutorial/tutorial-steps.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for the tutorial step model: buildTutorialSteps returns the eight
+ * frames in order (branded with the app name, targeting real controls), the
+ * new-chat and swipe auto-advance predicates fire only on the right
+ * conversation transition, and each frame's capability lock permits its own
+ * tabs while blocking off-path ones. Pure functions + nav-lock state.
+ */
+
 import { afterEach, describe, expect, it } from "vitest";
 import { isNavAllowed, setNavLock } from "../../../navigation/nav-lock";
 import {

--- a/packages/ui/src/components/pages/view-glyph-cleanup.test.ts
+++ b/packages/ui/src/components/pages/view-glyph-cleanup.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Source-scanning guard (#8796) over every built-in `*View.tsx` in this folder:
+ * asserts no raw check/cross glyphs appear in the source so status and
+ * close/delete controls stay on Lucide icon components. Reads files from disk;
+ * asserts on string content, not rendered output.
+ */
+
 import { readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/packages/ui/src/components/pages/workflow-action-handoff.ts
+++ b/packages/ui/src/components/pages/workflow-action-handoff.ts
@@ -1,3 +1,9 @@
+/**
+ * Bridges a chat action result that produced a workflow into the workflow graph
+ * viewer: scans action results (most-recent-successful first) for a `workflowId`
+ * value and dispatches the visualize-workflow event so the graph opens on it.
+ */
+
 import type { ChatActionResultSummary } from "../../api/client-types-chat";
 import { dispatchVisualizeWorkflow } from "./workflow-graph-events";
 


### PR DESCRIPTION
Comments-only slice of #12234.

## Scope
Subtree `packages/ui/src/components/pages` (@elizaos/ui shared UI library — the agent dashboard page surfaces). Shard 0 of 2 (disjoint from the sibling shard).

## What changed
- Added top-of-file `/** … */` prose headers to component, hook, util, test, and story files that lacked one (e.g. `ChatView.tsx`, `MediaGalleryView.tsx`, `MemoryViewerView.tsx`, `LogsView.tsx`, `RuntimeView.tsx`, `TriggersView.tsx`, `RelationshipsGraphPanel.tsx`, `ElizaOsAppsView.tsx`, `WalletSectionNav.tsx`, the relationships/tutorial subtrees, and the `*.test.tsx` view tests).
- Rewrote churn/narration headers into present-tense fact: `ChatView.terminal-focus.test.tsx` ("used to"/"now wires"), `TaskEditor.test.tsx` ("review fix #2"), `help/HelpView.test.tsx` ("previously wrote…"), `MemoryViewerView.mobile-sidebar.test.tsx` ("used to render"), `__e2e__/background-fixture.tsx` ("no longer hand-mirrors"), `skill-detail-panel.tsx` / `trigger-form-utils.ts` ("Extracted from…").
- Moved a few good-content headers from below the import block to the very top (`TutorialView`, `KnowledgeView`, `RelationshipsView`) per the position convention.
- Test headers state the surface under test and harness realism (real component vs mocked `../../api` client; jsdom; in-memory stubs).

## Coverage
53 files touched. Every in-scope shard file now carries a durable top-of-file prose header (Storybook stories that idiomatically place their JSDoc directly above `meta` were left in place).

## Verification
`node scripts/assert-comment-only-diff.mjs` → `OK — 53 source file(s) changed; every code token identical to origin/develop. Comments only.` No code tokens, string/template literals, or generated files touched.

Part of #12234.