### PR TITLE
chore(#12242): comment cleanup B12 — prose headers, churn removal (goals + reminders)

### DIFF
--- a/plugins/plugin-goals/src/components/goals/GoalsSpatialView.test.tsx
+++ b/plugins/plugin-goals/src/components/goals/GoalsSpatialView.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders `GoalsSpatialView` through the TUI spatial registry to static markup
+ * and asserts the terminal layout — deterministic, no live model or DB.
+ */
 import { visibleWidth } from "@elizaos/tui";
 import { SpatialSurface } from "@elizaos/ui/spatial";
 import {

--- a/plugins/plugin-goals/src/db/index.ts
+++ b/plugins/plugin-goals/src/db/index.ts
@@ -1,1 +1,2 @@
+/** Re-export barrel for the goals drizzle schema (`app_goals`). */
 export * from "./schema.ts";

--- a/plugins/plugin-goals/src/db/schema.ts
+++ b/plugins/plugin-goals/src/db/schema.ts
@@ -1,15 +1,13 @@
+/**
+ * Drizzle definitions for the `app_goals` schema — the goal tables
+ * (`life_goal_definitions`, `life_goal_links`) this plugin owns.
+ *
+ * Table and column names (and column order) mirror the `app_lifeops` originals
+ * verbatim so the non-destructive `GoalsMigrationService` can copy existing rows
+ * across on first boot. Registered with the runtime through `@elizaos/plugin-sql`.
+ */
 import { index, pgSchema, text, unique } from "drizzle-orm/pg-core";
 
-/**
- * Drizzle schema for plugin-goals.
- *
- * The goal tables (`life_goal_definitions`, `life_goal_links`) were carved out
- * of `@elizaos/plugin-personal-assistant`'s `app_lifeops` schema into
- * `app_goals`, owned by this plugin. Table + column names (and column order) are
- * preserved verbatim so the non-destructive `GoalsMigrationService` can copy
- * existing `app_lifeops` rows across on first boot. The runtime registers this
- * schema through `@elizaos/plugin-sql`.
- */
 export const goalsSchema = pgSchema("app_goals");
 
 export const lifeGoalDefinitions = goalsSchema.table(

--- a/plugins/plugin-goals/src/db/sql.ts
+++ b/plugins/plugin-goals/src/db/sql.ts
@@ -1,11 +1,13 @@
-import type { IAgentRuntime } from "@elizaos/core";
-
 /**
- * Self-contained raw-SQL helpers for the goals back-end. Copied verbatim from
- * the PA LifeOps sql helpers (renamed error prefixes) so this plugin carries no
- * dependency on `@elizaos/plugin-personal-assistant`. Keep in sync only when a
- * correctness fix applies to both; do not add goals-specific logic here.
+ * Self-contained raw-SQL helpers for the goals back-end — value coercers and a
+ * cached `sql.raw` accessor over the runtime DB handle.
+ *
+ * A verbatim copy of the PA LifeOps SQL helpers (only the error prefixes differ)
+ * so this plugin carries no dependency on `@elizaos/plugin-personal-assistant`.
+ * Keep in sync only when a correctness fix applies to both; do not add
+ * goals-specific logic here.
  */
+import type { IAgentRuntime } from "@elizaos/core";
 
 export type RawSqlQuery = {
   queryChunks: Array<{ value?: unknown }>;

--- a/plugins/plugin-goals/src/goal-grounding.ts
+++ b/plugins/plugin-goals/src/goal-grounding.ts
@@ -1,3 +1,11 @@
+/**
+ * Grounding and semantic-review metadata for goals: the grounding-state
+ * vocabulary and the pure builders that shape a goal's grounding /
+ * semantic-review metadata records.
+ *
+ * Consumed by `goal-semantic-evaluator.ts` (which fills these from an LLM pass);
+ * PA re-exports this module for back-compat, so keep the exported shapes stable.
+ */
 import type { LifeOpsGoalReviewState } from "@elizaos/shared";
 import { LIFEOPS_REVIEW_STATES } from "@elizaos/shared";
 

--- a/plugins/plugin-goals/src/goal-normalize.test.ts
+++ b/plugins/plugin-goals/src/goal-normalize.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the `goal-normalize` input coercers and `GoalsServiceError`,
+ * asserting the HTTP status each rejection carries. Pure functions, no runtime.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-goals/src/goal-semantic-evaluator.ts
+++ b/plugins/plugin-goals/src/goal-semantic-evaluator.ts
@@ -1,3 +1,12 @@
+/**
+ * LLM-backed goal progress review (`evaluateGoalProgressWithLlm`): prompts a
+ * model to judge a goal's review state and emit semantic suggestions, then
+ * validates the output against the allowed review-state / suggestion-kind sets
+ * before shaping it into the metadata from `goal-grounding.ts`.
+ *
+ * PA re-exports this for back-compat. Model output is untrusted — unknown enum
+ * values are rejected rather than passed through.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import {
   logger,

--- a/plugins/plugin-goals/src/services/migration.test.ts
+++ b/plugins/plugin-goals/src/services/migration.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the non-destructive `app_lifeops` → `app_goals` table copy,
+ * driven by a scripted in-memory `SqlExecutor` (no real database): asserts the
+ * skip-when-source-missing / skip-when-target-non-empty / copy paths.
+ */
 import { describe, expect, it } from "vitest";
 import {
   MIGRATED_GOAL_TABLES,

--- a/plugins/plugin-goals/vite.config.views.ts
+++ b/plugins/plugin-goals/vite.config.views.ts
@@ -1,3 +1,4 @@
+/** Vite build config for the standalone `goals` view bundle (`dist/views`). */
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
 export default createViewBundleConfig({

--- a/plugins/plugin-goals/vitest.config.ts
+++ b/plugins/plugin-goals/vitest.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Vitest config for plugin-goals. The alias block anchors the leaf DB subpaths
+ * of sibling LifeOps plugins to source so the keyless node test graph
+ * (`goals.real-db.test.ts` drives PA's repository) never pulls in React views.
+ */
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";

--- a/plugins/plugin-reminders/src/db/schema.ts
+++ b/plugins/plugin-reminders/src/db/schema.ts
@@ -1,15 +1,14 @@
+/**
+ * Drizzle definitions for the `app_reminders` schema — the reminder tables
+ * (`life_reminder_plans`, `life_reminder_attempts`, `life_escalation_states`)
+ * this plugin owns.
+ *
+ * Table and column names mirror the `app_lifeops` originals verbatim so the
+ * non-destructive `RemindersMigrationService` can copy existing rows across.
+ * Registered with the runtime through `@elizaos/plugin-sql`.
+ */
 import { boolean, index, integer, pgSchema, text } from "drizzle-orm/pg-core";
 
-/**
- * Drizzle schema for plugin-reminders.
- *
- * The reminder tables (`life_reminder_plans`, `life_reminder_attempts`,
- * `life_escalation_states`) were carved out of
- * `@elizaos/plugin-personal-assistant`'s `app_lifeops` schema. Table + column
- * names are preserved verbatim so the non-destructive `RemindersMigrationService`
- * can copy existing `app_lifeops` rows into `app_reminders`. The runtime
- * registers this schema through `@elizaos/plugin-sql`.
- */
 export const remindersSchema = pgSchema("app_reminders");
 
 export const lifeReminderPlans = remindersSchema.table(

--- a/plugins/plugin-reminders/src/plugin.ts
+++ b/plugins/plugin-reminders/src/plugin.ts
@@ -1,20 +1,18 @@
+/**
+ * Plugin object for the reminder delivery/escalation data layer: registers the
+ * `app_reminders` schema (reminder plans, per-channel delivery attempts,
+ * escalation states) and the non-destructive `app_lifeops` → `app_reminders`
+ * migration service.
+ *
+ * PA auto-registers this plugin so the schema + migration run, and PA's reminder
+ * repository reads/writes `app_reminders`. The delivery/escalation engine itself
+ * stays PA-resident, writing through these tables. See
+ * `plugins/plugin-personal-assistant/docs/lifeops-extraction-plan.md`.
+ */
 import type { Plugin } from "@elizaos/core";
 import { remindersDbSchema } from "./db/schema.ts";
 import { RemindersMigrationService } from "./services/migration.ts";
 
-/**
- * `@elizaos/plugin-reminders` — the reminder delivery/escalation data layer.
- *
- * Owns the `app_reminders` schema (reminder plans, per-channel delivery
- * attempts, escalation states) carved out of
- * `@elizaos/plugin-personal-assistant`, plus a non-destructive migration from
- * `app_lifeops`. PA auto-registers this plugin (so the schema + migration run)
- * and its reminder repository now reads/writes `app_reminders`. The
- * delivery/escalation ENGINE stays PA-resident during the decomposition,
- * writing through the carved tables.
- *
- * See `plugins/plugin-personal-assistant/docs/lifeops-extraction-plan.md`.
- */
 export const remindersPlugin: Plugin = {
   name: "@elizaos/plugin-reminders",
   description:


### PR DESCRIPTION
Part of #12181 (comment-cleanup swarm), batch **B12** (LifeOps + assistant plugins). Refs #12242.

**Comment-only change; `check:comment-only` PASSES** — the TypeScript token stream is byte-for-byte identical to `origin/develop` (`scripts/assert-comment-only-diff.mjs`: *"12 source file(s) changed; every code token identical to origin/develop. Comments only."*).

## Slice
LifeOps data-layer plugins **plugin-goals** + **plugin-reminders** — 12 files.

## What changed
- **Prose file headers** added/repaired at the very top (moved above imports where the header sat below them), written from reading each file against the package `CLAUDE.md`:
  - `plugin-goals`: `db/index.ts` (1-line barrel), `db/schema.ts`, `db/sql.ts`, `goal-grounding.ts`, `goal-semantic-evaluator.ts`, `goal-normalize.test.ts`, `services/migration.test.ts`, `components/goals/GoalsSpatialView.test.tsx`, `vite.config.views.ts`, `vitest.config.ts`
  - `plugin-reminders`: `db/schema.ts`, `plugin.ts`
- **Churn rewritten to present tense.** `db/schema.ts` (both plugins) and `reminders/plugin.ts` headers reworded from "were carved out of… / now reads/writes… / during the decomposition" to durable present-tense facts (the `app_lifeops` mirror + migration invariant is kept because it explains why column shape is verbatim).
- **Test headers** state the surface under test and harness realness (deterministic/in-memory scripted SQL executor, static-markup TUI render — no live model/DB).

## Churn triage in slice
- `plugin-goals/src/services/checkin.ts:11` "dismiss slots the cadence no longer declares" — **kept**: durable reconcile semantic, not a diff annotation.

## filesFlagged
None — every file's purpose was determinable from the package `CLAUDE.md`.

## Verify
- `node scripts/assert-comment-only-diff.mjs origin/develop` -> OK, comments only.
- Header self-audit over both plugins prints nothing (no in-scope file opens with code).

Evidence rows — trajectory / screenshot / video / audio / domain-artifact: **N/A — comments-only change, zero functional diff (machine-checked by `scripts/assert-comment-only-diff.mjs`).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
