### PR TITLE
chore(#12238): comment cleanup B08 — feed/packages/shared prose headers + churn removal (comment-only)

### DIFF
--- a/packages/feed/packages/shared/src/config/index.ts
+++ b/packages/feed/packages/shared/src/config/index.ts
@@ -8,8 +8,7 @@
 import type { Address } from "viem";
 import configData from "./public-config.json";
 
-// Re-export viem chain objects for NFT services (chains.ts was removed in Phase 1).
-// Remove these exports once NFT code is fully deleted in a future phase.
+// Viem chain objects re-exported for the NFT services that still consume them.
 const etherCurrency = {
   decimals: 18,
   name: "Ether",

--- a/packages/feed/packages/shared/src/game-types.ts
+++ b/packages/feed/packages/shared/src/game-types.ts
@@ -309,12 +309,12 @@ export interface WorldEvent {
   relatedQuestion?: number | null;
   /**
    * @deprecated Use sentimentSignal instead for more nuanced signal direction.
-   * Kept for backwards compatibility - will be derived from sentimentSignal if not set.
+   * Derived from sentimentSignal when not set.
    */
   pointsToward?: "YES" | "NO" | null;
   visibility: "public" | "leaked" | "secret" | "private" | "group";
 
-  // New sentiment-based signal fields (preferred over pointsToward)
+  // Sentiment-based signal fields, preferred over pointsToward.
   /** Sentiment signal from -1.0 (negative) to 1.0 (positive) */
   sentimentSignal?: number;
   /** How clear/strong the signal is (0 to 1) */

--- a/packages/feed/packages/shared/src/onboarding/types.ts
+++ b/packages/feed/packages/shared/src/onboarding/types.ts
@@ -1,3 +1,7 @@
+/**
+ * Payload shape submitted when a new player completes the onboarding profile step —
+ * carries identity fields, optional imported social accounts, and legal acceptance flags.
+ */
 export interface OnboardingProfilePayload {
   username: string;
   displayName?: string;

--- a/packages/feed/packages/shared/src/types/notifications.ts
+++ b/packages/feed/packages/shared/src/types/notifications.ts
@@ -1,3 +1,8 @@
+/**
+ * Notification transport types: digest delivery settings and the per-event data
+ * payloads (market resolution, performance digest, achievement/challenge rewards)
+ * carried on a stored notification.
+ */
 import type {
   AchievementUnlockedNotificationData,
   ChallengeCompletedNotificationData,

--- a/packages/feed/packages/shared/src/utils/chain-utils.ts
+++ b/packages/feed/packages/shared/src/utils/chain-utils.ts
@@ -1,3 +1,4 @@
+/** Maps EVM chain IDs to human-readable display names for the chains Feed operates on. */
 export const CHAIN_NAMES: Record<number, string> = {
   31337: "Local",
   84532: "Base Sepolia",

--- a/packages/feed/packages/shared/src/utils/post-utils.ts
+++ b/packages/feed/packages/shared/src/utils/post-utils.ts
@@ -1,3 +1,4 @@
+/** Predicate distinguishing a bare repost (references an original, no added content) from a quote-post. */
 export function isPureRepost(post: {
   originalPostId?: string | null;
   content: string;

--- a/packages/feed/packages/shared/src/utils/reward-notifications.ts
+++ b/packages/feed/packages/shared/src/utils/reward-notifications.ts
@@ -1,3 +1,8 @@
+/**
+ * Builders and payload types for reward notifications (achievement unlocks, challenge
+ * completions) — produce the title/message/data triple stored on a notification so the
+ * copy stays consistent across the callers that award them.
+ */
 export interface AchievementUnlockedNotificationData {
   [key: string]: string | number;
   kind: "achievement_unlocked";

--- a/packages/feed/packages/shared/src/utils/transactions.ts
+++ b/packages/feed/packages/shared/src/utils/transactions.ts
@@ -1,3 +1,7 @@
+/**
+ * Chain-aware confirmation depth for awaiting transaction receipts: zero on the local
+ * dev chain (instant mining), one on live networks.
+ */
 import { getCurrentChainId } from "../config";
 
 export function getTransactionReceiptConfirmations(

--- a/packages/feed/packages/shared/src/utils/username.ts
+++ b/packages/feed/packages/shared/src/utils/username.ts
@@ -1,3 +1,7 @@
+/**
+ * Sanitize and validate proposed onboarding usernames, matching the
+ * onboarding/check-username endpoint's normalization so client and server agree.
+ */
 const ONBOARDING_USERNAME_MIN_LENGTH = 3;
 
 /**

--- a/packages/feed/packages/shared/src/utils/wallet.ts
+++ b/packages/feed/packages/shared/src/utils/wallet.ts
@@ -1,3 +1,7 @@
+/**
+ * Wallet display helpers: block-explorer transaction URLs for the active chain and
+ * fixed-point formatting of raw token balances for the UI.
+ */
 import { getCurrentChainId } from "../config";
 
 /**

--- a/packages/feed/packages/shared/src/validation/schemas/notifications.ts
+++ b/packages/feed/packages/shared/src/validation/schemas/notifications.ts
@@ -1,3 +1,7 @@
+/**
+ * Runtime type guards narrowing untrusted DB/external strings to the
+ * NotificationDigestFrequency and NotificationDeliveryChannel unions.
+ */
 import type {
   NotificationDeliveryChannel,
   NotificationDigestFrequency,

--- a/packages/feed/packages/shared/src/validation/schemas/onboarding.ts
+++ b/packages/feed/packages/shared/src/validation/schemas/onboarding.ts
@@ -1,3 +1,8 @@
+/**
+ * Zod schema validating the onboarding profile submission — identity fields, optional
+ * imported social accounts, and legal-acceptance flags. Runtime counterpart to the
+ * OnboardingProfilePayload type.
+ */
 import { z } from "zod";
 import { AssetOrUrlSchema, UsernameSchema } from "./common";
 


### PR DESCRIPTION
## Comment cleanup B08 — `packages/feed/packages/shared` slice

Part of #12238 (batch B08 of the repo-wide comment cleanup, parent #12181).

**Comment-only change — `check:comment-only` PASSES** (the code token stream is
byte-for-byte identical to `origin/develop`; machine-checked by
`scripts/assert-comment-only-diff.mjs`).

### What this does
Slice = the `packages/feed/packages/shared` subtree (12 files, all describing
Feed's shared types/utils/validation layer per `packages/feed/CLAUDE.md`).

- **Prose headers added to the 10 no-header source files** in `shared/`
  (onboarding payload/schema, notification transport types + guards, reward-
  notification builders, chain/username/wallet/transaction utils). Each header
  was written from reading the file, describes it in Feed's architecture terms,
  and is length-scaled (tiny type/util files get 1-line headers).
- **2 churn-phrased comments rewritten to present-tense durable fact** (no
  header change to those files, which already had headers):
  - `config/index.ts` — dropped the "chains.ts was removed in Phase 1 / remove
    once NFT code is deleted" migration-story + status line; kept the durable
    fact that the viem chain objects are re-exported for the NFT services.
  - `game-types.ts` — `pointsToward` "Kept for backwards compatibility - will be
    derived…" → "Derived from sentimentSignal when not set." (`@deprecated` tag
    already carries the deprecation); "New sentiment-based signal fields" → drop
    the churn word "New".

No restatement comments or commented-out code were present in these files.

### Tallies
- Files touched: **12** (all `packages/feed/packages/shared/**`)
- Headers added: **10**
- Churn comments rewritten: **2** · deleted narration lines: **1** (`config/index.ts` "Remove these exports once…")
- filesFlagged (purpose undeterminable): **0**

### Verify
```
$ bun run check:comment-only
[assert-comment-only-diff] OK — 12 source file(s) changed; every code token identical to origin/develop. Comments only.
```
Header self-audit over `shared/**` prints nothing (every file now opens with a header).

### Evidence
Trajectory / screenshot / video / audio / domain-artifact rows: **N/A — comments-only
change, zero functional diff** (machine-checked by `scripts/assert-comment-only-diff.mjs`).
`bun run verify` (typecheck + lint) is N/A to run in this comment-only slice — the token
stream is provably unchanged, so behavior/types are identical to `develop`.

Refs #12238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
