### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-chat-b

### DIFF
--- a/packages/ui/src/components/chat/AccountRequiredCard.tsx
+++ b/packages/ui/src/components/chat/AccountRequiredCard.tsx
@@ -1,3 +1,13 @@
+/**
+ * Inline chat card shown when an action hits a connector "account wall" — no
+ * usable account for the target provider, or the selected one needs reauth. It
+ * lists the caller's accounts with per-account status, lets the user pick or
+ * connect one, and (when a `retryAction` is supplied) drives the reconnect →
+ * reauth → retry loop that re-issues the blocked action once an account flips
+ * to "connected". Presentation-only: reconnect progress comes from
+ * `useConnectorReconnect`; account state is polled by the caller via the live
+ * `accounts` prop.
+ */
 import { CheckCircle2, RefreshCw, ShieldAlert, UserRound } from "lucide-react";
 import { useRef } from "react";
 import type { ConnectorAccountRecord } from "../../api/client-agent";

--- a/packages/ui/src/components/chat/AgentActivityBox.tsx
+++ b/packages/ui/src/components/chat/AgentActivityBox.tsx
@@ -1,3 +1,10 @@
+/**
+ * Compact row of active coding-agent sessions rendered above the chat thread:
+ * per-session status dot, label, and derived activity text, each clickable to
+ * open that session. Activity text for server-hydrated sessions is synthesized
+ * through the canonical `activityEventToPlaintext` serializer so this rail reads
+ * the same as the live WebSocket activity stream. Renders nothing when idle.
+ */
 import { activityEventToPlaintext } from "@elizaos/core";
 import type { CodingAgentSession } from "../../api/client-types-cloud";
 import {

--- a/packages/ui/src/components/chat/ConnectorAccountPicker.stories.tsx
+++ b/packages/ui/src/components/chat/ConnectorAccountPicker.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook + story-gate visual states for ConnectorAccountPicker. */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ConnectorAccountRecord } from "../../api/client-agent";
 import { ConnectorAccountPicker } from "./ConnectorAccountPicker";

--- a/packages/ui/src/components/chat/MessageAttachments.tsx
+++ b/packages/ui/src/components/chat/MessageAttachments.tsx
@@ -1,3 +1,16 @@
+/**
+ * Renders the attachment previews under a chat message. `attachmentPreviewKind`
+ * derives a fine-grained preview kind (image / audio / video / PDF inline vs
+ * download-fallback / text-code / generic document) from mime + extension at
+ * read time — the store keeps a frozen `ContentType`, so the kind is computed
+ * here, not persisted (#8876). `resolveAttachmentUrl` normalises served
+ * `/api/media/<hash>` paths against the active API base for the dev proxy, prod
+ * same-origin, and desktop/native shells; every URL passes the scheme-allowlist
+ * guard (`isSafeAttachmentUrl`) before rendering.
+ *
+ * See the "Files / attachments" note in this package's CLAUDE.md — don't add a
+ * second attachment download path or URL guard; reuse the ones referenced here.
+ */
 import {
   Box,
   Code2,

--- a/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
@@ -1,4 +1,12 @@
 // @vitest-environment jsdom
+//
+// SensitiveRequestBlock in MessageContent: public requests render status-only
+// (no input); owner-private ones render a secret form; success shows status
+// without leaking the submitted value; tunneled sub-agent credentials go through
+// the tunnel endpoint (not global secrets); image/file fields upload via
+// updateSecrets and enforce maxBytes; OAuth requests show a Connect button that
+// opens the auth URL in a popup and never prints the URL in chat. jsdom render
+// with the typed ElizaClient mocked (no backend).
 
 import type { PermissionState } from "@elizaos/shared";
 import {

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -1,3 +1,18 @@
+/**
+ * Renderer for a single chat message body in the full ChatView. Parses the
+ * message text into segments (`parseSegments`) — plain text with inline code,
+ * fenced code blocks, `[CONFIG:…]` plugin cards, fenced UiSpec JSON, sensitive
+ * secret requests, permission cards, account-connect blocks, and inline widget
+ * markers (choice/form/followups/task) — and renders each with the matching
+ * sub-component or registry entry, plus any attachments.
+ *
+ * This is the load-bearing chat surface: it shares the parser + inline-widget
+ * registry with the overlay renderer (`InlineWidgetText`), so both stay in sync
+ * (parser parity: parser-parity.contract.test.ts; tree parity:
+ * render-parity.contract.test.tsx). The self-contained `InlinePluginConfig`,
+ * `MessageUiSpecBlock`, `SensitiveRequestBlock`, and `MessagePermissionCard`
+ * exports here drive their own mutations through the typed `ElizaClient`.
+ */
 import {
   type FormEvent,
   type ReactNode,

--- a/packages/ui/src/components/chat/SaveCommandModal.tsx
+++ b/packages/ui/src/components/chat/SaveCommandModal.tsx
@@ -1,3 +1,9 @@
+/**
+ * Dialog for naming a chat message so it can be saved as a reusable slash
+ * command. Validates the name (leading letter, alphanumeric/hyphen), previews
+ * the message text, and hands the chosen name back via `onSave`; the caller
+ * owns the actual persistence.
+ */
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { useAppSelector } from "../../state";
 import { Button } from "../ui/button";

--- a/packages/ui/src/components/chat/ThinkingBlock.test.tsx
+++ b/packages/ui/src/components/chat/ThinkingBlock.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+//
+// ThinkingBlock: collapsed by default and toggles the reasoning body, renders
+// nothing for empty/whitespace reasoning, and uses the shared accent treatment
+// with no blue classes. Pure jsdom render — presentational component, no backend.
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/packages/ui/src/components/chat/WidgetVisibilityPanel.helpers.tsx
+++ b/packages/ui/src/components/chat/WidgetVisibilityPanel.helpers.tsx
@@ -1,3 +1,9 @@
+/**
+ * Synthesizes the "Apps" section as a toggleable row in WidgetVisibilityPanel.
+ * The apps section is not a registered widget, so its visibility candidate is
+ * built here from `APPS_SECTION_VISIBILITY_KEY` and listed alongside the real
+ * widgets. Split from the panel so the JSX-carrying helper can be tested apart.
+ */
 import { LayoutGrid } from "lucide-react";
 import { APPS_SECTION_VISIBILITY_KEY } from "../../widgets/visibility";
 import type { WidgetVisibilityCandidate } from "./WidgetVisibilityPanel";

--- a/packages/ui/src/components/chat/connector-send-as.ts
+++ b/packages/ui/src/components/chat/connector-send-as.ts
@@ -1,3 +1,13 @@
+/**
+ * Pure "send-as" logic for choosing which connector account a chat write goes
+ * out on. Provides the `connectorSendAs` metadata shape, helpers to normalize a
+ * send-as context, name/usability checks for an account, whether the account
+ * picker should show (>1 usable account), and building/merging the metadata a
+ * message carries. `isLikelyAccountRequiredError` classifies backend errors
+ * that mean "pick an account first" so the UI can surface `AccountRequiredCard`.
+ * Framework-free so it unit-tests without the React graph; consumed by
+ * `AccountRequiredCard`, `ConnectorAccountPicker`, and the composer.
+ */
 import type { ConnectorAccountRecord } from "../../api/client-agent";
 
 export const CONNECTOR_SEND_AS_METADATA_KEY = "connectorSendAs";

--- a/packages/ui/src/components/chat/message-parser-edge.test.ts
+++ b/packages/ui/src/components/chat/message-parser-edge.test.ts
@@ -1,3 +1,7 @@
+// Edge cases for the inline-widget region finders (choice / followups / form /
+// task): adjacent markers, unicode payloads, duplicate ids, stable offsets in
+// long messages, title capping, and rejection of malformed lookalike markers.
+// Pure functions — no React, no jsdom.
 import { describe, expect, it } from "vitest";
 import { findChoiceRegions } from "./message-choice-parser";
 import { findFollowupsRegions } from "./message-followups-parser";

--- a/packages/ui/src/components/chat/message-parser-streaming.test.ts
+++ b/packages/ui/src/components/chat/message-parser-streaming.test.ts
@@ -1,3 +1,6 @@
+// Streaming guarantee for the inline-widget region finders: a partially streamed
+// block emits no region until its closing marker has fully arrived, so half-typed
+// markers never flash a broken widget mid-stream. Pure functions — no jsdom.
 import { describe, expect, it } from "vitest";
 import { findChoiceRegions } from "./message-choice-parser";
 import { findFollowupsRegions } from "./message-followups-parser";

--- a/packages/ui/src/components/chat/widgets/agent-activity.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-activity.tsx
@@ -1,3 +1,9 @@
+/**
+ * Home tile summarizing the agent's recent feed activity — the latest few
+ * `FeedActivityItem`s with a total count, fetched through the API client and
+ * validated at the boundary. The fetch is bounded by a timeout so a hung agent
+ * channel settles the tile to empty rather than spinning on "Loading…" forever.
+ */
 import { Activity } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { client } from "../../../api";

--- a/packages/ui/src/components/chat/widgets/agent-orchestrator-app-runs.test.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator-app-runs.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+//
+// AppRunsWidget polling gates: skips the app-run poll on limited cloud agent
+// bases and while unauthenticated, and starts once the session authenticates.
+// jsdom render with the API client + auth hook + app store mocked (no backend).
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/ui/src/components/chat/widgets/agent-orchestrator-room-view.test.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator-room-view.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// OrchestratorRoomView presentation: empty state, hiding terminal rooms from the
+// live board, surfacing the active tool + live count, ordering live sub-agents
+// ahead of idle ones, and drill-in only when `onSelectRoom` is set. Pure jsdom
+// render over fixture props — presentational component, no backend.
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/chat/widgets/agent-orchestrator.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook + story-gate visual states for OrchestratorAccountsView (the
+ * coding-accounts + per-room roster sidebar widget): empty, accounts,
+ * assignments, and room-roster. Mirrors the __e2e__ render fixture.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ReactNode } from "react";
 import type {

--- a/packages/ui/src/components/chat/widgets/agent-provisioning.test.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-provisioning.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// AgentProvisioningWidget lifecycle: renders the migrating state (opening chat on
+// tap), a Retry control on a failed handoff (dispatching the retry event), and
+// self-hides once the dedicated agent attaches or for a local/non-shared runtime.
+// jsdom render with the cloud-compat agent helpers + events mocked (no backend).
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CloudHandoffPhaseDetail } from "../../../events";

--- a/packages/ui/src/components/chat/widgets/automations.test.tsx
+++ b/packages/ui/src/components/chat/widgets/automations.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// AutomationsWidget: loading card before the fetch, the "Automations" glossary
+// label (never "Tasks"), surfacing the top running scheduled task while excluding
+// paused/manual ones, and the +N overflow badge. jsdom render with the API client
+// mocked to return seeded scheduled tasks (no backend).
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/chat/widgets/browser-launch-widget.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/browser-launch-widget.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook + story-gate visual states for the BrowserLaunchWidget. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { BrowserLaunchWidget } from "./browser-launch-widget";
 

--- a/packages/ui/src/components/chat/widgets/browser-status.helpers.ts
+++ b/packages/ui/src/components/chat/widgets/browser-status.helpers.ts
@@ -1,3 +1,8 @@
+/**
+ * Chat-sidebar widget registration for the browser-workspace status widget.
+ * Split from the component so the registry entry imports without pulling the
+ * component's render dependencies.
+ */
 import { BrowserStatusSidebarWidget } from "./browser-status";
 import type { ChatSidebarWidgetDefinition } from "./types";
 

--- a/packages/ui/src/components/chat/widgets/calendar-upcoming.test.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-upcoming.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// CalendarUpcomingWidget self-hide rules: renders nothing (and skips full-shell
+// probes) on limited cloud bases, when no Google account is linked, or when there
+// are no upcoming events; otherwise shows the single soonest event with a +N
+// badge and applies its grid span. jsdom render with the API client mocked.
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/chat/widgets/finances-alerts.tsx
+++ b/packages/ui/src/components/chat/widgets/finances-alerts.tsx
@@ -1,3 +1,12 @@
+/**
+ * FINANCES "Bills & Balance" home widget — a glanceable summary of money
+ * attention: an overdrawn-balance escalation row plus the next few recurring
+ * bills landing within a week. Fetches the same `/api/lifeops/money/*` routes
+ * FinancesView reads (dashboard + recurring + sources; transactions skipped),
+ * polling quietly while the document is visible. One of the home-attention
+ * widget family; publishes escalation/reminder signals into the shared
+ * home-attention store to rank itself on the home surface.
+ */
 import { Wallet } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { client } from "../../../api";
@@ -163,13 +172,6 @@ function billsDueWithin7Days(
     });
 }
 
-/**
- * FINANCES "Bills & Balance" home widget (#9143). Glanceable summary of money
- * attention: an overdrawn-balance escalation row plus the next few recurring
- * bills landing within a week. Fetches the same `/api/lifeops/money/*` routes
- * FinancesView reads (dashboard + recurring + sources; transactions skipped),
- * polling quietly while the document is visible.
- */
 /** Shallow content equality so an unchanged 30s poll doesn't re-render. */
 function financesEqual(
   a: FinancesWidgetData | null,

--- a/packages/ui/src/components/chat/widgets/followups.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/followups.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook + story-gate visual states for the FollowupsWidget chips. */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { FollowupOption } from "./followups";
 import { FollowupsWidget } from "./followups";

--- a/packages/ui/src/components/chat/widgets/form-request.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook + story-gate visual states for the inline chat FormRequest widget. */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { FormRequestSpec } from "../message-form-parser";
 import { FormRequest } from "./form-request";

--- a/packages/ui/src/components/chat/widgets/ftu-welcome.test.tsx
+++ b/packages/ui/src/components/chat/widgets/ftu-welcome.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// FtuWelcomeWidget: renders only on the home slot (greeting + suggestion chips),
+// prefills the chat and marks the card acted when a chip is tapped, retires on
+// dismiss, and ignores unrelated activity. jsdom render; prompt suggestions and
+// the home-dismissal store are mocked (no backend).
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { __resetHomeDismissalsForTests } from "../../../widgets/home-dismissal-store";

--- a/packages/ui/src/components/chat/widgets/goals-attention.tsx
+++ b/packages/ui/src/components/chat/widgets/goals-attention.tsx
@@ -1,3 +1,9 @@
+/**
+ * Icon-first home widget surfacing the single most-urgent LifeOps goal (see the
+ * `GoalsAttentionWidget` JSDoc below). One of the home-attention widget family
+ * ({goals,inbox,finances,relationships,needs}-attention) that publish into the
+ * shared home-attention store to rank themselves on the home surface.
+ */
 import { Target } from "lucide-react";
 import type { ComponentType } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";

--- a/packages/ui/src/components/chat/widgets/health-sleep.test.tsx
+++ b/packages/ui/src/components/chat/widgets/health-sleep.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// HealthSleepWidget: one high-priority datum (latest sleep duration) on a
+// clickable card, an off-rhythm badge and published check-in weight when sleep is
+// irregular, navigation to the Health view on tap, and self-hide when no sleep
+// episodes fall in the window. jsdom render with the API client mocked.
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/chat/widgets/home-widget-card.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/home-widget-card.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook + story-gate visual states for the shared HomeWidgetCard shell. */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   CalendarDays,

--- a/packages/ui/src/components/chat/widgets/inbox-unread.tsx
+++ b/packages/ui/src/components/chat/widgets/inbox-unread.tsx
@@ -1,3 +1,10 @@
+/**
+ * Icon-first home widget surfacing the highest-priority unread inbox thread
+ * (sender + subject, with a count badge), tapping opens the Inbox view. One of
+ * the home-attention widget family; publishes into the shared home-attention
+ * store so it ranks itself on the home surface. Polls only while authenticated
+ * and the document is visible.
+ */
 import { Inbox } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { client } from "../../../api";

--- a/packages/ui/src/components/chat/widgets/model-download.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/model-download.stories.tsx
@@ -1,3 +1,9 @@
+/**
+ * Storybook + story-gate visual states for the ModelDownloadWidget across its
+ * queued / downloading / loading / failed / ready phases. Stories seed an
+ * authenticated session and a mock ModelHub snapshot so the widget renders each
+ * phase without a backend.
+ */
 import type { Decorator, Meta, StoryObj } from "@storybook/react";
 import { __setAuthStatusForTests } from "../../../hooks/useAuthStatus";
 import type {

--- a/packages/ui/src/components/chat/widgets/model-download.tsx
+++ b/packages/ui/src/components/chat/widgets/model-download.tsx
@@ -1,3 +1,10 @@
+/**
+ * Home widget with a real progress track for the recommended local model's
+ * download (see the `ModelDownloadWidget` JSDoc below). `useLocalModelDownloads`
+ * subscribes to the local-inference download stream and derives the home model
+ * status; the widget is the ONLY model-loading status surface (the chat overlay
+ * shows no floating pill) and self-hides when no local slot needs a download.
+ */
 import { Download, Loader2, TriangleAlert } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../../../api";

--- a/packages/ui/src/components/chat/widgets/needs-attention.tsx
+++ b/packages/ui/src/components/chat/widgets/needs-attention.tsx
@@ -1,3 +1,10 @@
+/**
+ * Icon-first home widget surfacing the oldest pending approval the user still
+ * owes the agent (waiting longest = most overdue), tapping prefills the chat to
+ * resolve it. One of the home-attention widget family; `useApprovals` reads the
+ * shared pending-actions source and the widget publishes into the home-attention
+ * store to rank itself on the home surface.
+ */
 import type { PendingUserAction } from "@elizaos/core";
 import { CircleHelp } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";

--- a/packages/ui/src/components/chat/widgets/notifications.tsx
+++ b/packages/ui/src/components/chat/widgets/notifications.tsx
@@ -1,3 +1,9 @@
+/**
+ * Home Notifications widget: shows the most recent, highest-attention agent
+ * notifications (see the `NotificationsWidget` JSDoc below), reading the shared
+ * notification store directly rather than polling. Renders nothing until there
+ * is real activity so the always-visible home surface stays quiet when empty.
+ */
 import type { AgentNotification } from "@elizaos/core";
 import { Bell } from "lucide-react";
 import { categoryIcon } from "../../../state/notifications/category-icon";

--- a/packages/ui/src/components/chat/widgets/orchestrator-grilling-card.test.tsx
+++ b/packages/ui/src/components/chat/widgets/orchestrator-grilling-card.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// OrchestratorGrillingCard: renders the goal, verdict, and one row per criterion,
+// stamps each criterion's state (for icon selection), shows a note only when
+// present, and shows the reviewing verdict for the pending status. Pure jsdom
+// render over fixture props — presentational component, no backend.
 
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/packages/ui/src/components/chat/widgets/relationships-attention.tsx
+++ b/packages/ui/src/components/chat/widgets/relationships-attention.tsx
@@ -1,3 +1,10 @@
+/**
+ * Icon-first home widget surfacing the top relationship signal — a pending
+ * identity-merge to confirm, else the stalest contact to reach out to (see the
+ * `RelationshipsAttentionWidget` JSDoc below). One of the home-attention widget
+ * family; publishes into the shared home-attention store to rank itself on the
+ * home surface.
+ */
 import { Users } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { client } from "../../../api";

--- a/packages/ui/src/components/chat/widgets/shared.tsx
+++ b/packages/ui/src/components/chat/widgets/shared.tsx
@@ -1,3 +1,9 @@
+/**
+ * Shared layout primitives for chat-sidebar widgets: `WidgetSection` (labelled
+ * section with an icon, optional navigating title, and trailing action) and
+ * `EmptyWidgetState` (centered empty placeholder). Every sidebar widget renders
+ * through these so the rail stays visually consistent.
+ */
 import type { ReactNode } from "react";
 import { Button } from "../../ui/button";
 

--- a/packages/ui/src/components/chat/widgets/task-widget.test.tsx
+++ b/packages/ui/src/components/chat/widgets/task-widget.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// TaskWidget: fallback title until the first fetch, then the fetched title /
+// status / agents / token count, "Task removed." when the detail fetch is null,
+// navigation to /orchestrator on click, and no pulse animation for terminal
+// status. jsdom render with the orchestrator task detail fetch mocked (no backend).
 
 import {
   cleanup,

--- a/packages/ui/src/components/chat/widgets/todo.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.tsx
@@ -1,3 +1,9 @@
+/**
+ * Chat-sidebar (and home-grid) TODO widget: lists the agent workbench's todos,
+ * seeded from the app store's `workbench.todos` and refreshed by a poll that
+ * runs only while authenticated and the document is visible. Exports
+ * `TODO_PLUGIN_WIDGETS`, the widget-registry entry consumed by the sidebar.
+ */
 import { ListTodo } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../../../api";

--- a/packages/ui/src/components/chat/widgets/topic-chips-bar.test.tsx
+++ b/packages/ui/src/components/chat/widgets/topic-chips-bar.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+//
+// TopicChipsBar: empty state with no topics, one chip per topic with selection
+// reporting, marking the active chip selected, and collapsing chips beyond
+// maxVisible into a +N overflow chip. Pure jsdom render over props (no backend).
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/chat/widgets/topic-grouped-transcript.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/topic-grouped-transcript.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook + story-gate visual states for the TopicGroupedTranscript. */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { TopicGroup } from "./topic-grouped-transcript";
 import { TopicGroupedTranscript } from "./topic-grouped-transcript";

--- a/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// WalletBalanceWidget (price-only): loading placeholder until data resolves,
+// price-only rows for held assets (no amounts/holding value), skipping holdings
+// under $1, self-hide on empty balances, and opening the wallet view on tap.
+// jsdom render with the wallet balances/market API mocked (no backend).
 import type {
   WalletBalancesResponse,
   WalletMarketOverviewResponse,

--- a/packages/ui/src/components/chat/widgets/wallet-price-holdings.test.ts
+++ b/packages/ui/src/components/chat/widgets/wallet-price-holdings.test.ts
@@ -1,3 +1,7 @@
+// `selectPricedHoldings` selection logic: empty on missing balances, price-only
+// rows with no amount/holding value leaked, dust (<$1) skipped, capped at the top
+// 5 by holding value, only priced symbols included, same symbol aggregated across
+// chains (case-insensitive), native SOL/ETH counted. Pure function — no jsdom.
 import type {
   WalletBalancesResponse,
   WalletMarketPriceSnapshot,


### PR DESCRIPTION
Comments-only slice of #12234. `check:comment-only` passes — every code token is byte-for-byte identical to `origin/develop`.

**Subtree:** `packages/ui/src/components/chat` (shard 1 of 2 — files whose sorted-list index is odd; disjoint from the sibling shard).

**Coverage:** 42 files touched — added a top-of-file prose header to chat components, sidebar/home widgets, Storybook stories, and jsdom/pure-function test files that lacked one (or carried only a `// @vitest-environment jsdom` pragma). Component headers state what the surface renders and where it mounts; test headers state the surface under test and how real the harness is (jsdom + mocked API client, or pure function — no live backend). One structural cleanup: lifted a misplaced widget-description JSDoc block in `finances-alerts.tsx` (it sat above an unrelated helper) up to the file header. The empty `chat-source-registration.tsx` (0 bytes) was intentionally left untouched.

No code tokens, string/template literals, or generated files were modified.

Part of #12234.