### PR TITLE
chore(#12244): comment cleanup B14 — audio/TTS + embedding provider plugins (comment-only)

### DIFF
--- a/plugins/plugin-edge-tts/__tests__/core-test-mock.ts
+++ b/plugins/plugin-edge-tts/__tests__/core-test-mock.ts
@@ -1,3 +1,8 @@
+/**
+ * Vitest setup module mocking @elizaos/core for the Edge TTS suite, so the
+ * handler runs without booting a runtime. Loaded via setupFiles in
+ * vitest.config.ts.
+ */
 import { vi } from "vitest";
 
 // Faithful re-implementation of core `resolveSetting` (runtime per-agent setting

--- a/plugins/plugin-edge-tts/__tests__/smoke.test.ts
+++ b/plugins/plugin-edge-tts/__tests__/smoke.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Smoke test for the Edge TTS handler with node-edge-tts mocked: asserts the
+ * synthesis request wiring and temp-file read/cleanup without hitting the live
+ * Edge voice service.
+ */
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-edge-tts/index.browser.ts
+++ b/plugins/plugin-edge-tts/index.browser.ts
@@ -1,2 +1,3 @@
+/** Browser build entrypoint; re-exports the browser plugin implementation. */
 export * from "./src/index.browser";
 export { default } from "./src/index.browser";

--- a/plugins/plugin-edge-tts/index.node.ts
+++ b/plugins/plugin-edge-tts/index.node.ts
@@ -1,3 +1,4 @@
+/** Node build entrypoint; re-exports the node plugin implementation. */
 import edgeTTSPlugin from "./src/index";
 
 export * from "./src/index.node";

--- a/plugins/plugin-edge-tts/index.ts
+++ b/plugins/plugin-edge-tts/index.ts
@@ -1,2 +1,3 @@
+/** Package entrypoint; re-exports the shared plugin implementation from src. */
 export * from "./src/index";
 export { default } from "./src/index";

--- a/plugins/plugin-edge-tts/src/index.ts
+++ b/plugins/plugin-edge-tts/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Edge TTS plugin: registers a TEXT_TO_SPEECH ModelType handler backed by
+ * Microsoft Edge's online voices via the node-edge-tts library (no API key).
+ * Synthesizes to a temp file, reads the bytes back, and cleans up; voice, lang,
+ * output format, and SSML-style rate/pitch/volume are resolved from settings.
+ */
 import { mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-edge-tts/vitest.config.ts
+++ b/plugins/plugin-edge-tts/vitest.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Vitest config for the Edge TTS plugin. Runs serially (fileParallelism off,
+ * single worker) because the synthesis smoke test races on shared temp-dir
+ * state, and mocks core via the setupFiles module.
+ */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-elevenlabs/src/index.browser.ts
+++ b/plugins/plugin-elevenlabs/src/index.browser.ts
@@ -1,3 +1,4 @@
+/** Browser build entrypoint; re-exports the shared plugin implementation. */
 export * from "./index";
 
 import elevenLabsPlugin from "./index";

--- a/plugins/plugin-elevenlabs/src/index.node.ts
+++ b/plugins/plugin-elevenlabs/src/index.node.ts
@@ -1,3 +1,4 @@
+/** Node build entrypoint; re-exports the shared plugin implementation. */
 export * from "./index";
 
 import elevenLabsPlugin from "./index";

--- a/plugins/plugin-elevenlabs/src/index.ts
+++ b/plugins/plugin-elevenlabs/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * ElevenLabs plugin: registers TEXT_TO_SPEECH and TRANSCRIPTION (speech-to-text)
+ * model handlers backed by the @elevenlabs/elevenlabs-js SDK. Validates the
+ * configured TTS output format and STT model/timestamp granularity against the
+ * SDK's enums before calling the API.
+ */
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
 import type {
   BodySpeechToTextV1SpeechToTextPost,

--- a/plugins/plugin-embeddings/__tests__/auto-enable.test.ts
+++ b/plugins/plugin-embeddings/__tests__/auto-enable.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the embeddings auto-enable predicate: on only when EMBEDDING_BASE_URL or EMBEDDING_API_KEY is set. */
 import type { PluginAutoEnableContext } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 

--- a/plugins/plugin-embeddings/__tests__/config.test.ts
+++ b/plugins/plugin-embeddings/__tests__/config.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for EMBEDDING_* config resolution (base URL, key, model, dimensions) against a stubbed runtime. */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/plugins/plugin-embeddings/__tests__/embedding.test.ts
+++ b/plugins/plugin-embeddings/__tests__/embedding.test.ts
@@ -1,3 +1,4 @@
+/** Tests for the embedding handlers against a mocked fetch: request shape, dimension validation, and batch handling (no live endpoint). */
 import type { IAgentRuntime } from "@elizaos/core";
 import { VECTOR_DIMS } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-embeddings/index.browser.ts
+++ b/plugins/plugin-embeddings/index.browser.ts
@@ -1,3 +1,4 @@
+/** Browser build entrypoint; re-exports the shared plugin implementation from src. */
 import { embeddingsPlugin } from "./src/index";
 
 export * from "./src/index";

--- a/plugins/plugin-embeddings/index.node.ts
+++ b/plugins/plugin-embeddings/index.node.ts
@@ -1,3 +1,4 @@
+/** Node build entrypoint; re-exports the shared plugin implementation from src. */
 import { embeddingsPlugin } from "./src/index";
 
 export * from "./src/index";

--- a/plugins/plugin-embeddings/index.ts
+++ b/plugins/plugin-embeddings/index.ts
@@ -1,3 +1,4 @@
+/** Package entrypoint; re-exports the shared plugin implementation from src. */
 import { embeddingsPlugin } from "./src/index";
 
 export * from "./src/index";

--- a/plugins/plugin-embeddings/src/models/embedding.ts
+++ b/plugins/plugin-embeddings/src/models/embedding.ts
@@ -1,3 +1,10 @@
+/**
+ * TEXT_EMBEDDING and TEXT_EMBEDDING_BATCH handlers: POST to an OpenAI-compatible
+ * `${EMBEDDING_BASE_URL}/embeddings` with raw fetch (no @ai-sdk), validate the
+ * returned vector width against the configured VECTOR_DIMS dimension, and emit a
+ * MODEL_USED event. Input is capped at MAX_EMBEDDING_CHARS. Registered by the
+ * plugin in ../index.ts; see the package CLAUDE.md for the routing priority.
+ */
 import type { IAgentRuntime, TextEmbeddingParams } from "@elizaos/core";
 import { logger, ModelType, VECTOR_DIMS } from "@elizaos/core";
 

--- a/plugins/plugin-embeddings/src/models/index.ts
+++ b/plugins/plugin-embeddings/src/models/index.ts
@@ -1,1 +1,2 @@
+/** Barrel for the embedding model handlers. */
 export { handleBatchTextEmbedding, handleTextEmbedding } from "./embedding";

--- a/plugins/plugin-embeddings/src/utils/events.ts
+++ b/plugins/plugin-embeddings/src/utils/events.ts
@@ -1,3 +1,8 @@
+/**
+ * Emits MODEL_USED events for embedding calls so usage accounting sees the
+ * provider, model type, token counts, and a truncated prompt (capped at
+ * MAX_PROMPT_LENGTH). Consumed by the embedding handlers in ../models/embedding.
+ */
 import type { IAgentRuntime, ModelTypeName } from "@elizaos/core";
 import { EventType } from "@elizaos/core";
 

--- a/plugins/plugin-embeddings/vitest.config.ts
+++ b/plugins/plugin-embeddings/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the embeddings plugin unit tests (node environment). */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-groq/__tests__/behavior.test.ts
+++ b/plugins/plugin-groq/__tests__/behavior.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Behavior tests for the Groq plugin: init key requirement, model-handler
+ * registration, and retry classification, against a stubbed runtime and mocked
+ * globals (no live Groq API).
+ */
 import { type IAgentRuntime, ModelType } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import groqPlugin, { classifyRetryError } from "../index";

--- a/plugins/plugin-groq/__tests__/core-test-mock.ts
+++ b/plugins/plugin-groq/__tests__/core-test-mock.ts
@@ -1,3 +1,8 @@
+/**
+ * Vitest setup module that mocks @elizaos/core for the Groq unit suite, so the
+ * plugin's model handlers can be exercised without booting a runtime. Loaded via
+ * setupFiles in vitest.config.ts.
+ */
 import { vi } from "vitest";
 
 vi.mock("@elizaos/core", () => {

--- a/plugins/plugin-groq/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-groq/__tests__/native-plumbing.shape.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies the Groq text-handler request plumbing against a mocked ai /
+ * @ai-sdk/groq layer: settings resolve to the right model and the handler wires
+ * the request without a live Groq API call.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-groq/__tests__/retry.test.ts
+++ b/plugins/plugin-groq/__tests__/retry.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for classifyRetryError: maps AI SDK APICallError status codes and
+ * flags into the plugin's rate-limit / transient / fatal retry categories.
+ */
 import { APICallError } from "ai";
 import { describe, expect, it } from "vitest";
 import { classifyRetryError } from "../index";

--- a/plugins/plugin-groq/index.browser.ts
+++ b/plugins/plugin-groq/index.browser.ts
@@ -1,3 +1,4 @@
+/** Browser build entrypoint; re-exports the shared plugin implementation. */
 import pluginDefault from "./index";
 
 export * from "./index";

--- a/plugins/plugin-groq/index.node.ts
+++ b/plugins/plugin-groq/index.node.ts
@@ -1,3 +1,4 @@
+/** Node build entrypoint; re-exports the shared plugin implementation. */
 import pluginDefault from "./index";
 
 export * from "./index";

--- a/plugins/plugin-groq/index.ts
+++ b/plugins/plugin-groq/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Groq plugin: registers the text-generation ModelType handlers (nano through
+ * mega, plus RESPONSE_HANDLER and ACTION_PLANNER) as well as TRANSCRIPTION and
+ * TEXT_TO_SPEECH, all via the Vercel AI SDK's @ai-sdk/groq provider. Init
+ * requires GROQ_API_KEY. Calls go through a shared retry loop that classifies
+ * failures (classifyRetryError) into rate-limit / transient / fatal and backs
+ * off on the first two.
+ */
 import { createGroq } from "@ai-sdk/groq";
 import type {
   EventPayload,

--- a/plugins/plugin-groq/vitest.config.ts
+++ b/plugins/plugin-groq/vitest.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Vitest config for the Groq plugin unit tests. `*.harness.test.ts` files are
+ * excluded here (they need a real PGLite runtime + workspace aliases) and run
+ * separately via vitest.harness.config.ts.
+ */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-suno/src/actions/musicGeneration.i18n.test.ts
+++ b/plugins/plugin-suno/src/actions/musicGeneration.i18n.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests asserting Suno subaction routing is i18n-safe: enum/params only, never text keywords. */
 import { describe, expect, it } from 'vitest';
 import { inferSubaction } from './musicGeneration';
 

--- a/plugins/plugin-suno/src/actions/musicGeneration.ts
+++ b/plugins/plugin-suno/src/actions/musicGeneration.ts
@@ -1,3 +1,10 @@
+/**
+ * Suno music-generation handler behind the MUSIC umbrella action. Resolves the
+ * subaction (generate | custom_generate | extend) from planner-emitted enum or
+ * structured params — never from English keywords (#10471) — and calls the
+ * SunoProvider. Responses are truncated to MAX_SUNO_RESPONSE_BYTES and calls are
+ * bounded by SUNO_ACTION_TIMEOUT_MS.
+ */
 import type { ActionResult, HandlerCallback, IAgentRuntime, Memory, State } from '@elizaos/core';
 import { SunoProvider } from '../providers/suno';
 

--- a/plugins/plugin-suno/src/index.test.ts
+++ b/plugins/plugin-suno/src/index.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the Suno plugin's exports and auto-enable predicate (no live API). */
 import { describe, expect, it } from 'vitest';
 
 import sunoPlugin, { SunoProvider, sunoStatusProvider } from './index';

--- a/plugins/plugin-suno/src/index.ts
+++ b/plugins/plugin-suno/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Suno music-generation plugin: contributes the Suno client and a status
+ * provider to the shared MUSIC umbrella action (generation is dispatched as
+ * action=generate|extend|custom_generate elsewhere, not registered here).
+ * Auto-enables when SUNO_API_KEY is set or media.audio is configured for the
+ * suno own-key provider.
+ */
 import type { Plugin } from '@elizaos/core';
 import { sunoGenerateMusicHandler, type SunoMusicSubaction } from './actions/musicGeneration';
 import { SunoProvider, sunoStatusProvider } from './providers/suno';

--- a/plugins/plugin-suno/src/providers/suno.ts
+++ b/plugins/plugin-suno/src/providers/suno.ts
@@ -1,3 +1,9 @@
+/**
+ * Suno API client and status provider. `SunoProvider` wraps the Suno REST
+ * endpoints (keyed by SUNO_API_KEY) for generate/extend/custom flows and routes
+ * calls through recordLlmCall for usage accounting; `sunoStatusProvider` surfaces
+ * key-presence and reachability as prompt context.
+ */
 import {
     type IAgentRuntime,
     type Memory,

--- a/plugins/plugin-suno/src/suno.behavior.test.ts
+++ b/plugins/plugin-suno/src/suno.behavior.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Behavior tests for the Suno generation handler against a stubbed runtime with
+ * recordLlmCall mocked to a pass-through — exercises subaction routing and
+ * usage-accounting wiring without a live Suno API.
+ */
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { IAgentRuntime, Memory, State } from '@elizaos/core';
 import { recordLlmCall } from '@elizaos/core';

--- a/plugins/plugin-suno/src/types/index.ts
+++ b/plugins/plugin-suno/src/types/index.ts
@@ -1,3 +1,4 @@
+/** Request parameter shapes for the Suno generate / custom-generate / extend flows. */
 export interface GenerateParams {
     prompt: string;
     duration?: number;

--- a/plugins/plugin-suno/tsup.config.ts
+++ b/plugins/plugin-suno/tsup.config.ts
@@ -1,3 +1,4 @@
+/** tsup build config for the Suno plugin (CJS + ESM, @elizaos/core external). */
 import { defineConfig } from 'tsup';
 
 export default defineConfig({

--- a/plugins/plugin-suno/vitest.config.ts
+++ b/plugins/plugin-suno/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the Suno plugin unit tests (node environment). */
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({

--- a/plugins/plugin-xai/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-xai/__tests__/native-plumbing.shape.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies the xAI text/embedding handler request shape against a mocked fetch:
+ * the GROK_API_KEY auto-enable alias resolves, and requests carry the expected
+ * model/auth wiring. No live API — the OpenAI-compatible response is stubbed.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-xai/index.browser.ts
+++ b/plugins/plugin-xai/index.browser.ts
@@ -1,2 +1,3 @@
+/** Browser build entrypoint; re-exports the shared plugin implementation. */
 export * from "./index";
 export { default } from "./index";

--- a/plugins/plugin-xai/index.node.ts
+++ b/plugins/plugin-xai/index.node.ts
@@ -1,2 +1,3 @@
+/** Node build entrypoint; re-exports the shared plugin implementation. */
 export * from "./index";
 export { default } from "./index";

--- a/plugins/plugin-xai/index.ts
+++ b/plugins/plugin-xai/index.ts
@@ -1,3 +1,9 @@
+/**
+ * xAI Grok plugin: registers TEXT_SMALL, TEXT_LARGE, and TEXT_EMBEDDING model
+ * handlers backed by the xAI OpenAI-compatible API (api.x.ai/v1). Auto-enables
+ * when XAI_API_KEY or GROK_API_KEY is present; the handlers live in
+ * ./models/grok.
+ */
 import {
   type IAgentRuntime,
   logger,

--- a/plugins/plugin-xai/models/grok.ts
+++ b/plugins/plugin-xai/models/grok.ts
@@ -1,3 +1,10 @@
+/**
+ * xAI Grok model handlers for text generation (small/large) and embeddings,
+ * calling the xAI OpenAI-compatible chat/embeddings endpoints (api.x.ai/v1).
+ * Normalizes base URL and model-name settings, emits MODEL_USED events, and
+ * records LLM calls for usage accounting. Consumed by the plugin in
+ * ../index.ts.
+ */
 import {
   type EventPayload,
   EventType,

--- a/plugins/plugin-xai/vitest.config.ts
+++ b/plugins/plugin-xai/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the xAI plugin unit tests (node environment). */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Comment cleanup B14 (subset) — model-provider audio/TTS + embedding plugins

Part of #12244 (batch B14 of the repo-wide comment cleanup, parent #12181).
**Comment-only; `check:comment-only` PASSES** — the parsed code-token stream is
byte-for-byte identical to `origin/develop` (proved by
`scripts/assert-comment-only-diff.mjs`).

### Scope of this PR
A cohesive slice of B14's model-provider plugins — the audio/TTS and embedding
providers, where the code was small and legible enough to write accurate
headers from reading each file:

- `plugin-groq` (8 files)
- `plugin-xai` (6 files)
- `plugin-elevenlabs` (3 files)
- `plugin-suno` (11 files)
- `plugin-edge-tts` (7 files)
- `plugin-embeddings` (8 files)

### What changed
- **Prose file headers** added to every touched source/test file per the parent
  convention: first sentence states what the file does in system terms (which
  provider/API, which `ModelType` handlers it registers, provider quirks), then
  relationships/invariants as warranted. Test files get a 1–3 line header naming
  the surface under test and how real the harness is (all mocked — no live APIs).
- Barrel/entrypoint/config files get a single-line header.
- No in-body churn/restatement comments were present to remove in this slice;
  existing durable explanatory comments (e.g. suno `#10471` i18n rationale,
  edge-tts `resolveSetting` note) were left intact.

### Tallies
- Files touched: **43** (all comment-only)
- Headers added: **43**
- Churn lines removed: **0** (none in this slice's files)
- filesFlagged (purpose undeterminable): **none**

### Not in this PR
The rest of B14 (openai, anthropic, google-genai, openrouter, ollama, lmstudio,
zai, nearai, cli-inference, local-inference's 541 files, native-llama,
aosp-local-inference) remains for follow-up slices per the batch's ~50-file /
one-subtree-per-PR rule.

### Verify
```
node scripts/assert-comment-only-diff.mjs
[assert-comment-only-diff] OK — 43 source file(s) changed; every code token identical to origin/develop. Comments only.
```

### PR evidence (`PR_EVIDENCE.md`)
- Real-LLM trajectory / screenshots / video / audio / domain artifacts:
  **N/A — comments-only change, zero functional diff (machine-checked by
  `scripts/assert-comment-only-diff.mjs`).**

Refs #12244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
