### PR TITLE
chore(#12241): comment cleanup B11 — browser-extension prose headers (comment-only)

### DIFF
--- a/packages/browser-extension/entrypoints/background.ts
+++ b/packages/browser-extension/entrypoints/background.ts
@@ -1,3 +1,13 @@
+/**
+ * Extension service worker — the always-on coordinator. Runs the periodic sync
+ * loop, auto-pairs with the local agent, pulls agent-directed browser sessions
+ * and executes them via the content script, and enforces the website blocklist
+ * through declarativeNetRequest. Bridges popup requests and content-script
+ * responses to the BrowserBridgeRelayClient.
+ *
+ * Under MV3 the worker can be evicted between events, so durable state lives in
+ * chrome.storage.local via src/storage.ts rather than in module scope.
+ */
 import type { LifeOpsBrowserSession } from "@elizaos/shared";
 import { BrowserBridgeRelayClient, RelayApiError } from "../src/api-client";
 import type {

--- a/packages/browser-extension/entrypoints/blocked.ts
+++ b/packages/browser-extension/entrypoints/blocked.ts
@@ -1,3 +1,9 @@
+/**
+ * Controller for the block interstitial (blocked.html) shown when
+ * declarativeNetRequest redirects a blocked site. Reads the blocked URL/host
+ * and agent base from the query string, then polls the agent for the group's
+ * required tasks and links back to LifeOps so the user can clear the block.
+ */
 const POLL_INTERVAL_MS = 30_000;
 
 interface RequiredTask {

--- a/packages/browser-extension/entrypoints/content.ts
+++ b/packages/browser-extension/entrypoints/content.ts
@@ -1,3 +1,8 @@
+/**
+ * Content script injected into allowlisted pages: routes capture-page and
+ * DOM-action messages from the background worker to page-extract / dom-actions
+ * and returns the result. Thin adapter — all logic lives in src/.
+ */
 import { runDomAction } from "../src/dom-actions";
 import { capturePageContext } from "../src/page-extract";
 import type {

--- a/packages/browser-extension/entrypoints/popup.ts
+++ b/packages/browser-extension/entrypoints/popup.ts
@@ -1,3 +1,8 @@
+/**
+ * Popup UI controller: renders the status model from derivePopupStatusModel,
+ * drives the settings form (agent API URL, companion id, tracking mode), and
+ * triggers auto-pair or manual sync by messaging the background worker.
+ */
 import { derivePopupStatusModel } from "../src/popup-model";
 import type {
   BackgroundState,

--- a/packages/browser-extension/entrypoints/wallet-shim.ts
+++ b/packages/browser-extension/entrypoints/wallet-shim.ts
@@ -1,3 +1,9 @@
+/**
+ * Content script injected at document_start that installs an EVM + Solana
+ * wallet provider into the page's JS context, routing dapp signing requests
+ * through the agent's wallet over the companion API. The in-page provider body
+ * is inlined at build time via the __WALLET_SHIM_TEMPLATE__ define.
+ */
 declare const __WALLET_SHIM_TEMPLATE__: string;
 
 interface WalletShimStored {

--- a/packages/browser-extension/scripts/build.mjs
+++ b/packages/browser-extension/scripts/build.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env bun
+/**
+ * Bun build for the extension: bundles the entrypoints to IIFE, stamps the
+ * versioned manifest.json, and emits per-browser output under
+ * dist/<chrome|safari>/. Exports BROWSER_BRIDGE_HOST_ALLOWLIST — the
+ * SOC2-scoped default host grant baked into the manifest and checked by the
+ * smoke tests.
+ */
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,7 +15,7 @@ import {
 } from "./release-version.mjs";
 import { run } from "./script-utils.mjs";
 
-// SOC2 L-4: explicit host allowlist replacing the legacy `<all_urls>` grant.
+// SOC2 L-4: explicit host allowlist instead of a blanket `<all_urls>` grant.
 // Documented in README.md. Hosts beyond this list require runtime opt-in
 // through chrome.permissions.request against `optional_host_permissions`.
 export const BROWSER_BRIDGE_HOST_ALLOWLIST = [

--- a/packages/browser-extension/scripts/extension-smoke-safari.mjs
+++ b/packages/browser-extension/scripts/extension-smoke-safari.mjs
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
+/**
+ * Node smoke test for the Safari Web Extension build: checks the dist/safari
+ * artifacts and, on macOS, inspects Safari's Extensions.plist to confirm the
+ * extension registered. The plist checks require a real macOS/Safari host.
+ */
 import { spawn } from "node:child_process";
 import http from "node:http";
 import os from "node:os";

--- a/packages/browser-extension/scripts/extension-smoke.mjs
+++ b/packages/browser-extension/scripts/extension-smoke.mjs
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
+/**
+ * Node smoke test for the Chrome build: verifies the dist/chrome artifacts
+ * (manifest, bundles, host allowlist) and exercises the pairing/sync flow
+ * against a stub agent HTTP server. Real build output, mocked agent.
+ */
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import http from "node:http";

--- a/packages/browser-extension/scripts/package-chrome.mjs
+++ b/packages/browser-extension/scripts/package-chrome.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env bun
+/**
+ * Packages dist/chrome into a versioned .zip for Chrome Web Store upload.
+ */
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/browser-extension/scripts/package-release.mjs
+++ b/packages/browser-extension/scripts/package-release.mjs
@@ -1,4 +1,9 @@
 #!/usr/bin/env bun
+/**
+ * Orchestrates a full extension release: builds, packages the Chrome and Safari
+ * artifacts and store assets, and emits release metadata (GitHub release URLs
+ * and versioned artifact names) for the publish step.
+ */
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/browser-extension/scripts/package-safari.mjs
+++ b/packages/browser-extension/scripts/package-safari.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env bun
+/**
+ * Wraps dist/safari into a Safari Web Extension via xcrun, producing the
+ * versioned app bundle for the Safari release.
+ */
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/browser-extension/scripts/package-store-assets.mjs
+++ b/packages/browser-extension/scripts/package-store-assets.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env bun
+/**
+ * Assembles the store-listing bundle — screenshots, descriptions, and
+ * release-metadata JSON — for the Chrome and Safari store submissions.
+ */
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/browser-extension/scripts/release-version.mjs
+++ b/packages/browser-extension/scripts/release-version.mjs
@@ -1,4 +1,10 @@
 #!/usr/bin/env node
+/**
+ * Version resolution for the release pipeline: derives the release version from
+ * package.json (with a nightly-epoch fallback), converts semver to Chrome's
+ * 4-part scheme and Safari's build versions, and builds GitHub release and
+ * store URLs. Shared by every packaging script.
+ */
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/browser-extension/scripts/script-utils.mjs
+++ b/packages/browser-extension/scripts/script-utils.mjs
@@ -1,3 +1,7 @@
+/**
+ * Shared helpers for the extension build/packaging scripts: a promisified
+ * child-process `run` and small fs utilities.
+ */
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";

--- a/packages/browser-extension/src/api-client.test.ts
+++ b/packages/browser-extension/src/api-client.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for BrowserBridgeRelayClient: URL joining, Bearer auth, and
+ * RelayApiError mapping, driven against a mocked fetch.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BrowserBridgeRelayClient, type RelayApiError } from "./api-client";
 import type {

--- a/packages/browser-extension/src/api-client.ts
+++ b/packages/browser-extension/src/api-client.ts
@@ -1,3 +1,9 @@
+/**
+ * BrowserBridgeRelayClient — typed HTTP client for the companion endpoints on
+ * the agent API (`/companions/sync`, `/progress`, `/complete`), authenticated
+ * with the Bearer pairing token from the companion config. Non-2xx responses
+ * are wrapped in RelayApiError carrying the HTTP status and server error code.
+ */
 import type { LifeOpsBrowserCompanionSyncResponse } from "@elizaos/shared";
 import type {
   CompanionConfig,

--- a/packages/browser-extension/src/browser-bridge-contracts.ts
+++ b/packages/browser-extension/src/browser-bridge-contracts.ts
@@ -1,3 +1,9 @@
+/**
+ * Data contracts shared between the extension and the agent's
+ * `/api/browser-bridge/*` routes: bridge settings, action kinds, and the sync
+ * request/response shapes. Both sides depend on these types to agree on the
+ * wire format; type-only, no runtime code.
+ */
 export type BrowserBridgeKind = "chrome" | "safari";
 
 export type BrowserBridgeTrackingMode = "off" | "current_tab" | "active_tabs";

--- a/packages/browser-extension/src/dom-actions.test.ts
+++ b/packages/browser-extension/src/dom-actions.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for runDomAction over a jsdom DOM (test-dom-setup): click / type /
+ * submit behavior and handling of hostile input and invalid targets.
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-dom-setup";
 import { runDomAction } from "./dom-actions";

--- a/packages/browser-extension/src/dom-actions.ts
+++ b/packages/browser-extension/src/dom-actions.ts
@@ -1,3 +1,9 @@
+/**
+ * Executes agent-directed DOM actions — click, type, submit, history
+ * back/forward — inside a page's content-script context. Because it acts on
+ * live untrusted pages, it validates selectors and refuses missing, non-element,
+ * or disabled targets before mutating anything.
+ */
 import type { DomActionRequest } from "./protocol";
 
 function requireElement(selector?: string | null): HTMLElement {

--- a/packages/browser-extension/src/page-extract.test.ts
+++ b/packages/browser-extension/src/page-extract.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for capturePageContext over a jsdom DOM (test-dom-setup): field
+ * extraction, visibility filtering, and length caps.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-dom-setup";
 import { capturePageContext } from "./page-extract";

--- a/packages/browser-extension/src/page-extract.ts
+++ b/packages/browser-extension/src/page-extract.ts
@@ -1,3 +1,9 @@
+/**
+ * capturePageContext() — snapshots the live DOM (title, visible text, headings,
+ * links, forms) so the agent can read the current page. Runs in the
+ * content-script context; every field is whitespace-normalized and length-capped
+ * so a large page cannot bloat the sync payload.
+ */
 import type { PageContextSnapshot } from "./protocol";
 
 function normalizeText(

--- a/packages/browser-extension/src/popup-model.test.ts
+++ b/packages/browser-extension/src/popup-model.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for derivePopupStatusModel across the connection states; pure
+ * model, no browser environment.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { derivePopupStatusModel } from "./popup-model";
 import type { BackgroundState } from "./protocol";

--- a/packages/browser-extension/src/popup-model.ts
+++ b/packages/browser-extension/src/popup-model.ts
@@ -1,3 +1,9 @@
+/**
+ * Pure derivation of the popup's status model from BackgroundState — badge,
+ * title, checklist, and which primary action (auto-pair vs sync) to offer for
+ * each connection state. Keeps popup.ts free of branching and makes the
+ * connected / needs-pairing / error states unit-testable in isolation.
+ */
 import type { BackgroundState } from "./protocol";
 
 export type PopupStatusKind =

--- a/packages/browser-extension/src/protocol.ts
+++ b/packages/browser-extension/src/protocol.ts
@@ -1,3 +1,9 @@
+/**
+ * Runtime message contracts exchanged between the extension's contexts —
+ * popup UI, background service worker, and content script — plus the
+ * companion-sync aliases re-exported from `@elizaos/shared` and the local
+ * browser-bridge contracts. Type-only; no runtime code.
+ */
 import type {
   CompleteLifeOpsBrowserSessionRequest,
   LifeOpsBrowserSession,

--- a/packages/browser-extension/src/storage.test.ts
+++ b/packages/browser-extension/src/storage.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for config normalization and loopback API-discovery candidate
+ * ordering; pure functions, no chrome.storage.
+ */
 import { describe, expect, it } from "vitest";
 import {
   candidateApiBaseUrlsFromTabs,

--- a/packages/browser-extension/src/storage.ts
+++ b/packages/browser-extension/src/storage.ts
@@ -1,3 +1,9 @@
+/**
+ * Persistence and agent-API discovery over chrome.storage.local. Loads and
+ * normalizes the companion pairing config and cached background state, and
+ * probes loopback candidates — likely-Eliza open tabs first, then the default
+ * ports — to locate the local agent API (default http://127.0.0.1:31337).
+ */
 import type { BackgroundState, CompanionConfig } from "./protocol";
 import {
   type ExtensionTab,

--- a/packages/browser-extension/src/tab-cache.ts
+++ b/packages/browser-extension/src/tab-cache.ts
@@ -1,3 +1,9 @@
+/**
+ * Tab bookkeeping for the background sync loop: merges freshly queried tabs
+ * into the remembered set, ranks them by focus then recency, and selects the
+ * subset to sync according to the tracking mode (current tab vs active tabs).
+ * Pure functions over RememberedTab — no browser API calls.
+ */
 import type { BrowserBridgeSettings } from "./browser-bridge-contracts";
 import type { CompanionSyncRequest } from "./protocol";
 

--- a/packages/browser-extension/src/url.test.ts
+++ b/packages/browser-extension/src/url.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the URL normalization helpers, including rejection of unsafe
+ * URL forms (credentials, non-http schemes).
+ */
 import { describe, expect, it } from "vitest";
 import { normalizeHttpBaseUrl, normalizeHttpOrigin } from "./url";
 

--- a/packages/browser-extension/src/url.ts
+++ b/packages/browser-extension/src/url.ts
@@ -1,3 +1,9 @@
+/**
+ * URL normalization helpers shared across the extension: coerce a user-entered
+ * agent API URL or a page origin to a canonical, safe http(s) form. Rejects
+ * non-http(s) schemes and credentials-in-URL so downstream code can trust the
+ * result. Pure functions with no browser dependencies.
+ */
 export function normalizeHttpBaseUrl(
   value: unknown,
   defaultValue: string | null = null,

--- a/packages/browser-extension/src/webextension.ts
+++ b/packages/browser-extension/src/webextension.ts
@@ -1,3 +1,10 @@
+/**
+ * Promise-based facade over the raw `chrome.*` / `browser.*` extension APIs
+ * (runtime messaging, storage, tabs, windows, alarms, scripting, permissions,
+ * declarativeNetRequest). Every extension-API call in the package routes through
+ * here so Chrome/Safari differences and callback-vs-promise quirks are
+ * normalized in one place.
+ */
 type Callback<T> = (value: T) => void;
 
 type RawRuntime = {

--- a/packages/browser-extension/vitest.extension.config.ts
+++ b/packages/browser-extension/vitest.extension.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Vitest config for the extension's src/ unit tests; loads the jsdom DOM shim
+ * (test-dom-setup) so DOM-dependent modules run under Node.
+ */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
Part of #12241 (comment cleanup batch B11). Slice: **`packages/browser-extension`** — one coherent, self-contained subtree (31 header-less source files).

## What changed
- Added a prose file header to every in-scope header-less file in the package: the 5 `entrypoints/*`, the 10 `src/*` modules, the 6 `src/*.test.ts` unit tests, the 9 build/packaging `scripts/*.mjs`, and `vitest.extension.config.ts`.
- Headers were written from reading each file **and** the package `CLAUDE.md`/`README.md` (which document every module's role), so they describe files in this package's architecture terms.
- Rewrote one churn-phrased comment in `scripts/build.mjs` to present tense: `explicit host allowlist replacing the legacy` → `explicit host allowlist instead of a blanket <all_urls> grant` (durable SOC2-L4 fact kept; churn phrasing removed).

## Tallies
- Files touched: **31** (all in `packages/browser-extension/`)
- Headers added: **31**
- Churn lines rewritten: **1** (build.mjs); churn lines deleted: 0
- Restatement/commented-out code removed: 0 (none present)
- filesFlagged (purpose undeterminable): **0**
- The other two churn-grep hits in the slice (`package-store-assets.mjs:122`, `background.ts:178`) are **string literals**, not comments — left untouched.

## Comment-only proof
```
[assert-comment-only-diff] OK — 31 source file(s) changed; every code token identical to origin/develop. Comments only.
```
`bun run check:comment-only` **PASSES** — the code token stream is byte-for-byte unchanged (scripts/assert-comment-only-diff.mjs, TypeScript-scanner token comparison).

Evidence rows (trajectory / screenshot / video / audio / domain-artifact): **N/A — comments-only change, zero functional diff, machine-checked by `scripts/assert-comment-only-diff.mjs`.**

Refs #12241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
