### PR TITLE
chore(#12243): comment cleanup B13 — connector plugin prose headers (comment-only)

### DIFF
--- a/plugins/plugin-google-chat/src/accounts.test.ts
+++ b/plugins/plugin-google-chat/src/accounts.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for Google Chat multi-account resolution, the connector account
+ * provider, and the workflow credential provider, against an in-memory
+ * `getSetting` stub — no Google API calls.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-google-chat/src/accounts.ts
+++ b/plugins/plugin-google-chat/src/accounts.ts
@@ -1,3 +1,10 @@
+/**
+ * Resolves per-account Google Chat connector settings from top-level
+ * env/character values (the implicit `default` account), a
+ * `GOOGLE_CHAT_ACCOUNTS` JSON map, and `character.settings.googleChat` (or the
+ * `google-chat` alias), merging per field. Supplies the service the space list
+ * and service-account credentials for each configured account.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import type { GoogleChatAudienceType, GoogleChatSettings } from "./types.js";
 

--- a/plugins/plugin-google-chat/src/connector.test.ts
+++ b/plugins/plugin-google-chat/src/connector.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies the Google Chat message connector registers with the runtime and
+ * routes outbound sends correctly, against a mocked runtime — no Google API
+ * calls.
+ */
 import type { Content, IAgentRuntime, TargetInfo } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { GoogleChatService } from "./service.js";

--- a/plugins/plugin-google-chat/src/workflow-credential-provider.ts
+++ b/plugins/plugin-google-chat/src/workflow-credential-provider.ts
@@ -1,3 +1,10 @@
+/**
+ * Bridges Google Chat credentials to `@elizaos/plugin-workflow` so workflow
+ * nodes can call the Google Chat API authenticated. Registered under the
+ * duck-typed `workflow_credential_provider` serviceType; on request for
+ * `googleChatOAuth2Api` it returns the service-account key, read either inline
+ * from `GOOGLE_CHAT_SERVICE_ACCOUNT` or from a file path.
+ */
 import { promises as fs } from "node:fs";
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
 

--- a/plugins/plugin-google-chat/vitest.config.ts
+++ b/plugins/plugin-google-chat/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the Google Chat connector; aliases provider SDKs to shims and excludes live/e2e suites so unit tests run offline. */
 import { defineConfig } from "vitest/config";
 import {
   providerSdkAliases,

--- a/plugins/plugin-instagram/index.browser.ts
+++ b/plugins/plugin-instagram/index.browser.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser-target entry for the Instagram plugin: a stub whose `init()` only
+ * warns that Instagram is unsupported in-browser. The real connector (private
+ * API + Meta Graph API) needs a server; browser bundles resolve this export
+ * instead of `src/index.ts` so the app builds without pulling in server-only code.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 

--- a/plugins/plugin-instagram/src/__tests__/accounts.test.ts
+++ b/plugins/plugin-instagram/src/__tests__/accounts.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for Instagram account-config resolution (`accounts.ts`) against a
+ * mocked runtime — legacy default account, named `INSTAGRAM_ACCOUNTS`, and
+ * character-settings sources. No live Instagram API.
+ */
 import type { Content, IAgentRuntime, TargetInfo } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-instagram/src/accounts.ts
+++ b/plugins/plugin-instagram/src/accounts.ts
@@ -1,3 +1,9 @@
+/**
+ * Resolves per-account Instagram connector config from three sources — top-level
+ * env/character values (the implicit `default` account), an `INSTAGRAM_ACCOUNTS`
+ * JSON map, and `character.settings.instagram` — merging per field. Supplies
+ * `InstagramService` the account id list and credentials for each configured account.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import type { InstagramConfig } from "./types";
 

--- a/plugins/plugin-instagram/src/index.ts
+++ b/plugins/plugin-instagram/src/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Plugin entry for the Instagram connector: assembles the `Plugin` object
+ * (registering `InstagramService` and the workflow credential provider) and
+ * re-exports the package's public surface. The `init()` hook registers the
+ * connector-account provider with the runtime's `ConnectorAccountManager`,
+ * warning rather than throwing when the manager is absent. DMs route through the
+ * `MESSAGE` connector and comments through `POST`; no actions are registered.
+ */
 import { getConnectorAccountManager, logger, type Plugin } from "@elizaos/core";
 import { createInstagramConnectorAccountProvider } from "./connector-account-provider";
 import { INSTAGRAM_SERVICE_NAME } from "./constants";

--- a/plugins/plugin-instagram/src/service.ts
+++ b/plugins/plugin-instagram/src/service.ts
@@ -1,3 +1,13 @@
+/**
+ * `InstagramService` — lifecycle manager for one or more Instagram accounts and
+ * the boundary between the runtime and the Instagram API backend. On start it
+ * resolves each account's config, validates credentials, and registers both the
+ * DM `MessageConnector` (source `"instagram"`) and the feed `PostConnector` with
+ * the runtime. Handles inbound DM/comment ingestion into memory and outbound
+ * sending, comment posting/replies, likes, and follow/unfollow. Degrades
+ * gracefully when credentials are absent. Also exports `splitMessage`, the
+ * length-aware chunker used for DM and comment limits.
+ */
 import {
   ChannelType,
   type Content,

--- a/plugins/plugin-instagram/src/tests.ts
+++ b/plugins/plugin-instagram/src/tests.ts
@@ -1,3 +1,8 @@
+/**
+ * In-process `TestCase[]` suite (runnable via the runtime's test surface, not
+ * Vitest) exercising `splitMessage` and service internals against deterministic
+ * inputs — no live Instagram API.
+ */
 import type { TestCase } from "@elizaos/core";
 import { MAX_DM_LENGTH } from "./constants";
 import { splitMessage } from "./service";

--- a/plugins/plugin-instagram/src/workflow-credential-provider.ts
+++ b/plugins/plugin-instagram/src/workflow-credential-provider.ts
@@ -1,3 +1,9 @@
+/**
+ * Supplies Instagram (Meta Graph API) credentials to the workflow plugin. A
+ * duck-typed `workflow_credential_provider` service: the workflow runtime looks
+ * up by `serviceType` and calls `resolve(userId, credType)`, so this package
+ * takes no compile-time dependency on `@elizaos/plugin-workflow`.
+ */
 import { type IAgentRuntime, Service } from "@elizaos/core";
 
 // Inlined to avoid adding @elizaos/plugin-workflow as a compile-time dependency.

--- a/plugins/plugin-instagram/vitest.config.ts
+++ b/plugins/plugin-instagram/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the Instagram plugin; aliases provider SDKs to test shims. */
 import { defineConfig } from "vitest/config";
 import {
   providerSdkAliases,

--- a/plugins/plugin-line/__tests__/integration.test.ts
+++ b/plugins/plugin-line/__tests__/integration.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Exercises the LINE plugin surface and its message-formatting helpers (text
+ * chunking, markdown/code-block/table extraction, user + chat id shaping)
+ * against a mocked runtime — no live LINE Messaging API calls.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { normalizeAccountId } from "../src/accounts";

--- a/plugins/plugin-line/src/accounts.ts
+++ b/plugins/plugin-line/src/accounts.ts
@@ -1,3 +1,10 @@
+/**
+ * Multi-account configuration layer for the LINE connector: resolves channel
+ * access tokens and secrets (from inline config, env, character settings, or
+ * on-disk token files), enumerates enabled accounts, and answers per-group
+ * access and mention-requirement questions. `LineService` uses these to decide
+ * which accounts to start and whether to respond to a given inbound message.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 
 /**

--- a/plugins/plugin-line/src/connector.test.ts
+++ b/plugins/plugin-line/src/connector.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies the LINE message connector registers its metadata and routes
+ * outbound sends (including location messages) through the local router,
+ * against a mocked runtime — no live LINE API calls.
+ */
 import type { Content, IAgentRuntime, TargetInfo } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { LineService } from "./service.js";

--- a/plugins/plugin-line/src/messaging.test.ts
+++ b/plugins/plugin-line/src/messaging.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Pure-function unit tests for LINE message shaping (`messaging.ts`): text
+ * chunking, markdown stripping, link extraction, and chat-type detection. No
+ * runtime or network.
+ */
 import { describe, expect, it } from "vitest";
 import {
   chunkLineText,

--- a/plugins/plugin-line/src/outbound-media.test.ts
+++ b/plugins/plugin-line/src/outbound-media.test.ts
@@ -1,11 +1,14 @@
+/**
+ * Verifies the LINE connector sends image attachments as native image messages
+ * and appends non-image media to the text as a link rather than dropping it
+ * (#8876). Mocked send/push — runs offline.
+ */
 import type { Content } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { LineService } from "./service.js";
 
-// Outbound media coverage for the LINE connector (#8876). LINE has a dedicated
-// url-based image message but no generic file message, so image attachments are
-// sent as image messages and non-image media is appended to the text as a link
-// (rather than dropped). Mocked send/push → runs offline.
+// LINE has a dedicated url-based image message but no generic file message,
+// which is why non-image media degrades to a text link.
 
 type SendableService = LineService & {
   sendConnectorContent: (to: string, content: Content) => Promise<void>;

--- a/plugins/plugin-line/src/workflow-credential-provider.ts
+++ b/plugins/plugin-line/src/workflow-credential-provider.ts
@@ -1,3 +1,10 @@
+/**
+ * Bridges LINE credentials to `@elizaos/plugin-workflow` so a workflow HTTP
+ * Request node can call the LINE Messaging API authenticated. Registered under
+ * the duck-typed `workflow_credential_provider` serviceType; on request for
+ * `httpHeaderAuth` it returns the channel access token as an
+ * `Authorization: Bearer` header.
+ */
 import { type IAgentRuntime, Service } from "@elizaos/core";
 
 // Inlined to avoid adding @elizaos/plugin-workflow as a compile-time dependency.

--- a/plugins/plugin-line/vitest.config.ts
+++ b/plugins/plugin-line/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the LINE connector; runs the src + __tests__ unit suites and excludes live/e2e tests. */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-matrix/src/__tests__/accounts.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/accounts.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit + property tests (fast-check) for Matrix multi-account resolution
+ * (`accounts.ts`) against an in-memory `getSetting` stub — no homeserver.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import fc from "fast-check";
 import { describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-matrix/src/__tests__/connector.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/connector.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies the Matrix message connector's read/target-resolution path against a
+ * mocked runtime — no live homeserver. Locks that `read_channel` reaches the
+ * live read via a Matrix target carrying only `channelId`.
+ */
 import type { Content, IAgentRuntime, Memory, TargetInfo } from "@elizaos/core";
 import { createUniqueUuid } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-matrix/src/__tests__/crypto-store.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/crypto-store.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Round-trips the Matrix E2E crypto store snapshot/restore (`snapshotDb` /
+ * `restoreDb`) using `fake-indexeddb` and a temp dir — no real homeserver or
+ * on-disk browser IndexedDB.
+ */
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-matrix/src/__tests__/service-hardening.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/service-hardening.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Hardening tests for `MatrixService`, focused on the passive-connector
+ * auto-reply gate. Mocks `@elizaos/core` to supply
+ * `lifeOpsPassiveConnectorsEnabled` (omitted by the vitest core shim) so the
+ * gate is exercised deterministically — no live homeserver.
+ */
 import { type Content, EventType, type HandlerCallback, type IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-matrix/src/__tests__/workflow-credential-provider.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/workflow-credential-provider.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for `MatrixWorkflowCredentialProvider`: asserts it yields Matrix
+ * credentials only when both access token and homeserver are set, against an
+ * in-memory `getSetting` stub.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { MatrixWorkflowCredentialProvider } from "../workflow-credential-provider.js";

--- a/plugins/plugin-matrix/src/accounts.ts
+++ b/plugins/plugin-matrix/src/accounts.ts
@@ -1,3 +1,9 @@
+/**
+ * Resolves per-account Matrix connector settings from top-level env/character
+ * values (the implicit `default` account), a `MATRIX_ACCOUNTS` JSON map, and
+ * `character.settings.matrix`, merging per field. Supplies the Matrix service
+ * the homeserver, access token, and room list for each configured account.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import type { MatrixSettings } from "./types.js";
 

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -1266,8 +1266,7 @@ export class MatrixService extends Service implements IMatrixService {
       `Matrix message from ${message.senderInfo.displayName || message.sender} in ${room.name || roomId}: ${message.content.slice(0, 50)}...`
     );
 
-    // Plugin-local event (kept for backward compatibility — other code may
-    // listen for the MatrixMessage/MatrixRoom payload).
+    // Plugin-local event other code may listen for (the MatrixMessage/MatrixRoom payload).
     this.runtime.emitEvent(MatrixEventTypes.MESSAGE_RECEIVED, {
       message,
       room: matrixRoom,

--- a/plugins/plugin-matrix/src/workflow-credential-provider.ts
+++ b/plugins/plugin-matrix/src/workflow-credential-provider.ts
@@ -1,3 +1,9 @@
+/**
+ * Bridges Matrix credentials to `@elizaos/plugin-workflow` so workflow nodes can
+ * call a Matrix homeserver authenticated. Registered under the duck-typed
+ * `workflow_credential_provider` serviceType; on request for `matrixApi` it
+ * returns the access token and homeserver URL, and only when both are set.
+ */
 import { type IAgentRuntime, Service } from "@elizaos/core";
 
 // Inlined to avoid adding @elizaos/plugin-workflow as a compile-time dependency.

--- a/plugins/plugin-matrix/vitest.config.ts
+++ b/plugins/plugin-matrix/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the Matrix connector; aliases provider SDKs to shims so the suite runs offline. */
 import { defineConfig } from "vitest/config";
 import {
   providerSdkAliases,

--- a/plugins/plugin-nostr/src/__tests__/accounts.test.ts
+++ b/plugins/plugin-nostr/src/__tests__/accounts.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for Nostr multi-account resolution (`accounts.ts`) against an
+ * in-memory `getSetting` stub — no relays, fully offline.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { resolveDefaultNostrAccountId, resolveNostrAccountSettings } from "../accounts.js";

--- a/plugins/plugin-nostr/src/__tests__/outbound-media.test.ts
+++ b/plugins/plugin-nostr/src/__tests__/outbound-media.test.ts
@@ -1,11 +1,14 @@
+/**
+ * Verifies the Nostr connector appends agent-generated attachments as inline
+ * URLs in note/DM text rather than dropping them (#8876). Mocked send paths —
+ * runs offline.
+ */
 import type { Content, IAgentRuntime, TargetInfo } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { NostrService } from "../service.js";
 
-// Outbound media coverage for the Nostr connector (#8876). Nostr has no separate
-// attachment field — kind:1 notes and DMs carry media as URLs in the content
-// (clients render them inline). So agent-generated attachments are appended to
-// the text as URLs rather than dropped. Mocked send paths → runs offline.
+// Nostr has no separate attachment field: kind:1 notes and DMs carry media as
+// URLs in the content, which clients render inline — hence the URL-append path.
 
 function runtime(): IAgentRuntime {
   return {

--- a/plugins/plugin-nostr/src/__tests__/service-hardening.test.ts
+++ b/plugins/plugin-nostr/src/__tests__/service-hardening.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Hardening tests for `NostrService` configuration and edge cases (e.g. missing
+ * keys raising `NostrConfigurationError`), against a mocked runtime — no relays,
+ * runs offline.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-nostr/src/accounts.ts
+++ b/plugins/plugin-nostr/src/accounts.ts
@@ -1,3 +1,11 @@
+/**
+ * Resolves per-account Nostr connector settings from three config sources:
+ * legacy top-level env/character values (the implicit `default` account), a
+ * `NOSTR_ACCOUNTS` JSON map/array, and `character.settings.nostr`, merging per
+ * field so later sources override earlier ones. `NostrService` uses these to
+ * start one relay pool and subscription set per configured account; the
+ * normalized account id also keys connector target resolution.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { DEFAULT_NOSTR_RELAYS, type NostrDmPolicy, type NostrSettings } from "./types.js";
 

--- a/plugins/plugin-nostr/vitest.config.ts
+++ b/plugins/plugin-nostr/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the Nostr connector; aliases provider SDKs to shims so the suite runs offline. */
 import { defineConfig } from "vitest/config";
 import {
   providerSdkAliases,

--- a/plugins/plugin-twitch/__tests__/integration.test.ts
+++ b/plugins/plugin-twitch/__tests__/integration.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Exercises the Twitch plugin surface and its chat-formatting helpers (channel
+ * normalization, message splitting/length caps, markdown stripping) against a
+ * mocked runtime — no live Twitch/IRC connection.
+ */
 import type {
   Content,
   IAgentRuntime,
@@ -442,10 +447,8 @@ describe("Twitch message connector accounts", () => {
 // ===========================================================================
 // 7. sendMessage path
 // ===========================================================================
-// Twitch send used to be a standalone action; now the Twitch
-// MessageConnector (registered by TwitchService.registerSendHandlers) is the
-// canonical send path through MESSAGE operation=send. Action-shape and handler
-// tests retired with the action.
+// The Twitch MessageConnector (registered by TwitchService.registerSendHandlers)
+// is the canonical send path, via MESSAGE operation=send.
 
 // ===========================================================================
 // 12. Type Construction

--- a/plugins/plugin-twitch/src/accounts.ts
+++ b/plugins/plugin-twitch/src/accounts.ts
@@ -1,3 +1,10 @@
+/**
+ * Resolves per-account Twitch connector settings from top-level env/character
+ * values (the implicit `default` account), a `TWITCH_ACCOUNTS` JSON map, and
+ * `character.settings.twitch`, merging per field. Supplies the Twitch service
+ * the channel list, allowed chat roles, and allowed user ids for each
+ * configured account.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import type { TwitchRole, TwitchSettings } from "./types.js";
 

--- a/plugins/plugin-twitch/src/workflow-credential-provider.ts
+++ b/plugins/plugin-twitch/src/workflow-credential-provider.ts
@@ -1,3 +1,9 @@
+/**
+ * Bridges Twitch credentials to `@elizaos/plugin-workflow` so workflow nodes can
+ * call the Twitch API authenticated. Registered under the duck-typed
+ * `workflow_credential_provider` serviceType; on request for `httpHeaderAuth` it
+ * returns the configured access token as an `Authorization: Bearer` header.
+ */
 import { type IAgentRuntime, Service } from "@elizaos/core";
 
 // Inlined to avoid adding @elizaos/plugin-workflow as a compile-time dependency.

--- a/plugins/plugin-wechat/src/bot.ts
+++ b/plugins/plugin-wechat/src/bot.ts
@@ -1,3 +1,9 @@
+/**
+ * Inbound gate for WeChat messages: deduplicates repeat deliveries within a
+ * sliding window and feature-gates group/image messages before handing each
+ * message to the `onMessage` callback. Sits between `callback-server` (which
+ * normalizes proxy payloads) and the channel's dispatch into the runtime.
+ */
 import type { WechatMessageContext } from "./types";
 
 const DEFAULT_DEDUP_WINDOW_MS = 30 * 60 * 1000; // 30 minutes

--- a/plugins/plugin-wechat/src/callback-server.ts
+++ b/plugins/plugin-wechat/src/callback-server.ts
@@ -1,3 +1,10 @@
+/**
+ * Local HTTP webhook server that receives inbound messages POSTed by the WeChat
+ * proxy service, authenticates them (constant-time token compare), and
+ * normalizes the raw proxy payloads into `WechatMessageContext` for the bot.
+ * `WECHAT_TYPE_MAP` translates the proxy's numeric message types into the
+ * plugin's message-type + private/group scope.
+ */
 import { timingSafeEqual } from "node:crypto";
 import {
   createServer,

--- a/plugins/plugin-wechat/src/channel.ts
+++ b/plugins/plugin-wechat/src/channel.ts
@@ -1,3 +1,10 @@
+/**
+ * Per-account lifecycle orchestrator for one WeChat connection: drives QR login
+ * (polling the proxy until logged in, printing the login URL to the terminal),
+ * starts the callback webhook server, wires the `Bot` dedup/gate to inbound
+ * dispatch, runs periodic health checks, and owns outbound sends via the
+ * `ReplyDispatcher`. One `WechatChannel` exists per configured account.
+ */
 import { Bot } from "./bot";
 import { startCallbackServer } from "./callback-server";
 import { LoginExpiredError, ProxyClient } from "./proxy-client";

--- a/plugins/plugin-wechat/src/connector-account-provider.test.ts
+++ b/plugins/plugin-wechat/src/connector-account-provider.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the WeChat `ConnectorAccountProvider` against a mocked runtime:
+ * account discovery from config/env and the unconfigured (no-accounts) case.
+ */
 import type { ConnectorAccountManager, IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { createWechatConnectorAccountProvider } from "./connector-account-provider";

--- a/plugins/plugin-wechat/src/index.test.ts
+++ b/plugins/plugin-wechat/src/index.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for WeChat inbound/outbound internals with mocked collaborators:
+ * webhook payload normalization, `Bot` dedup/gating, and `ReplyDispatcher`
+ * chunking. No live proxy service.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { Bot } from "./bot";
 import { normalizePayload } from "./callback-server";

--- a/plugins/plugin-wechat/src/index.ts
+++ b/plugins/plugin-wechat/src/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Plugin entry for the WeChat connector: resolves account config (from
+ * `character.settings.connectors.wechat` or env), starts a `WechatChannel` per
+ * account, and registers a `MessageConnector` (source `"wechat"`) plus a
+ * `ConnectorAccountProvider` with the runtime. The connector resolves contacts,
+ * lists rooms, fetches history, and sends text/images; inbound messages arrive
+ * via the channel's webhook and flow through `deliverIncomingWechatMessage`.
+ */
 import {
   type Content,
   getConnectorAccountManager,

--- a/plugins/plugin-wechat/src/proxy-client.ts
+++ b/plugins/plugin-wechat/src/proxy-client.ts
@@ -1,3 +1,9 @@
+/**
+ * HTTPS client for the third-party WeChat proxy service (not the official WeChat
+ * API): login/status polling and outbound text/image sends over the proxy's API
+ * key. Maps the proxy's numeric result codes — success `1000`, login-needed
+ * `1001` (surfaced as `LoginExpiredError`) — into typed results the channel acts on.
+ */
 import type {
   AccountStatus,
   ProxyApiResponse,

--- a/plugins/plugin-wechat/src/reply-dispatcher.ts
+++ b/plugins/plugin-wechat/src/reply-dispatcher.ts
@@ -1,3 +1,7 @@
+/**
+ * Outbound send path for WeChat replies: splits long text into proxy-safe chunks
+ * and sends each chunk (and images) through the `ProxyClient`.
+ */
 import type { ProxyClient } from "./proxy-client";
 
 const DEFAULT_CHUNK_SIZE = 2000;

--- a/plugins/plugin-wechat/src/runtime-bridge.ts
+++ b/plugins/plugin-wechat/src/runtime-bridge.ts
@@ -1,3 +1,10 @@
+/**
+ * Bridges a normalized inbound WeChat message into the elizaOS message pipeline:
+ * `deliverIncomingWechatMessage` ensures the connection, builds the `Memory`,
+ * and dispatches through `elizaOS.sendMessage`, routing the agent's reply back
+ * out via the supplied response callback. Duck-types the runtime (`RuntimeLike`)
+ * so this module stays decoupled from the full runtime type.
+ */
 import { type Content, type Memory, stringToUuid } from "@elizaos/core";
 import type { WechatMessageContext } from "./types";
 

--- a/plugins/plugin-wechat/src/types.ts
+++ b/plugins/plugin-wechat/src/types.ts
@@ -1,3 +1,4 @@
+/** Shared types for the WeChat connector: account/config shapes, resolved account state, inbound message context, and the proxy API response envelope. */
 type DeviceType = "ipad" | "mac";
 type LoginStatus = "waiting" | "need_verify" | "logged_in";
 

--- a/plugins/plugin-wechat/tsup.config.ts
+++ b/plugins/plugin-wechat/tsup.config.ts
@@ -1,3 +1,4 @@
+/** tsup build config for the WeChat plugin: ESM bundle from src/index.ts to dist/. */
 import { defineConfig } from "tsup";
 
 export default defineConfig({

--- a/plugins/plugin-wechat/vitest.config.ts
+++ b/plugins/plugin-wechat/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the WeChat plugin unit tests. */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
Part of #12181 (comment cleanup). This is batch **B13** (connector plugins) — a slice covering seven small connectors.

## What this does — comment-only

Adds one prose file header to every in-scope file across these plugins, and rewrites change-narration comments to present-tense durable fact. No code changes.

| plugin | files |
|---|---|
| plugin-google-chat | 5 |
| plugin-instagram | 8 |
| plugin-line | 7 |
| plugin-matrix | 9 |
| plugin-nostr | 5 |
| plugin-twitch | 3 |
| plugin-wechat | 12 |
| **total** | **49** |

Headers were written from reading each file plus its package `CLAUDE.md`, and describe the file in that connector's architecture terms — which platform surface it talks to, inbound vs outbound role, where it sits in the envelope/service pattern.

## Churn handled (2 rewrites)

- `plugin-matrix/src/service.ts` — "(kept for backward compatibility …)" rewritten to a present-tense statement of the plugin-local event contract.
- `plugin-twitch/__tests__/integration.test.ts` — "used to be a standalone action; now …" rewritten to a present-tense statement that the MessageConnector is the canonical send path.

## Comment-only proof

`bun run check:comment-only` PASSES — the code token stream is byte-for-byte identical to `origin/develop` across all 49 files:

```
[assert-comment-only-diff] OK — 49 source file(s) changed; every code token identical to origin/develop. Comments only.
```

Header self-audit (files lacking a top-of-file header) prints nothing for all seven plugins.

## Evidence

- Trajectory / screenshot / video / audio / domain-artifact: **N/A — comments-only change, zero functional diff** (machine-checked by `scripts/assert-comment-only-diff.mjs`).

Refs #12243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
