### PR TITLE
chore(#12237): comment cleanup B07 — packages/cloud/sdk prose headers (comment-only)

### DIFF
--- a/packages/cloud/sdk/build.ts
+++ b/packages/cloud/sdk/build.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 
+/**
+ * Bun build script for the SDK: compiles `src/` to ESM in `dist/`, wiping any
+ * prior output first. Invoked by the package's `build` script.
+ */
+
 import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 

--- a/packages/cloud/sdk/scripts/audit-api-routes.mjs
+++ b/packages/cloud/sdk/scripts/audit-api-routes.mjs
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 
+/**
+ * Audits the generated `src/public-routes.ts` wrappers against the live Cloud
+ * API route tree, reporting public routes that are missing a wrapper, stale, or
+ * have drifted. Read-only companion to generate-public-routes.mjs; both share
+ * route-discovery.mjs.
+ */
+
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import {

--- a/packages/cloud/sdk/scripts/generate-public-routes.mjs
+++ b/packages/cloud/sdk/scripts/generate-public-routes.mjs
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 
+/**
+ * Regenerates `src/public-routes.ts` from the Cloud API route tree — the sole
+ * writer of that generated file, which must never be hand-edited. Discovers
+ * public routes via route-discovery.mjs and emits typed wrappers plus the
+ * `ELIZA_CLOUD_PUBLIC_ENDPOINTS` descriptor map.
+ */
+
 import { spawnSync } from "node:child_process";
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";

--- a/packages/cloud/sdk/scripts/route-discovery.mjs
+++ b/packages/cloud/sdk/scripts/route-discovery.mjs
@@ -1,3 +1,10 @@
+/**
+ * Shared route-discovery helpers for the two public-route scripts: locates the
+ * Cloud API root, walks its route modules, and extracts the HTTP methods each
+ * exposes. Consumed by generate-public-routes.mjs and audit-api-routes.mjs so
+ * both agree on what counts as a public route.
+ */
+
 import { existsSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";

--- a/packages/cloud/sdk/src/app-auth.test.ts
+++ b/packages/cloud/sdk/src/app-auth.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for `buildAppAuthorizeUrl` — asserts the canonical app-authorize URL shape and query params. Pure, no network. */
+
 import { describe, expect, it } from "vitest";
 import { APP_AUTHORIZE_PATH, buildAppAuthorizeUrl } from "./app-auth.js";
 

--- a/packages/cloud/sdk/src/app-auth.ts
+++ b/packages/cloud/sdk/src/app-auth.ts
@@ -1,3 +1,9 @@
+/**
+ * Builds the canonical third-party app authorize URL for the Eliza Cloud
+ * app-auth (OAuth-style) flow — the redirect a host app sends a user to so
+ * Cloud can grant it scoped access. Pure URL construction; no network calls.
+ */
+
 import { DEFAULT_ELIZA_CLOUD_BASE_URL } from "./types.js";
 
 export const APP_AUTHORIZE_PATH = "/app-auth/authorize";

--- a/packages/cloud/sdk/src/apps.client.test.ts
+++ b/packages/cloud/sdk/src/apps.client.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for `ElizaCloudClient`'s apps (Eliza Cloud Apps) methods, asserting route/verb/body against a recording mock fetch. */
+
 import { describe, expect, it } from "vitest";
 import { ElizaCloudClient } from "./client.js";
 

--- a/packages/cloud/sdk/src/client.test.ts
+++ b/packages/cloud/sdk/src/client.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for `ElizaCloudClient` against a recording mock fetch: auth-header injection, request shaping, and `CloudApiError` on non-2xx. */
+
 import { describe, expect, it } from "vitest";
 import { ElizaCloudClient } from "./client.js";
 import { CloudApiError } from "./http.js";

--- a/packages/cloud/sdk/src/client.ts
+++ b/packages/cloud/sdk/src/client.ts
@@ -1,3 +1,14 @@
+/**
+ * `ElizaCloudClient` — the SDK's primary class: a typed fetch wrapper over every
+ * endpoint of `api.elizacloud.ai` (auth, inference, credits, containers, Eliza
+ * agents, earnings, workflows, and more). Wraps the low-level `ElizaCloudHttpClient`
+ * and exposes the generated `.routes` public-route client. Consumed by
+ * `plugins/plugin-elizacloud` and `packages/ui`.
+ *
+ * Two auth surfaces coexist: `bearerToken` (session) wins over `apiKey` when both
+ * are set. Every method returns a concrete DTO — no `unknown` in public signatures.
+ */
+
 import { CloudApiClient, CloudApiError, ElizaCloudHttpClient } from "./http.js";
 import { ElizaCloudPublicRoutesClient } from "./public-routes.js";
 import {

--- a/packages/cloud/sdk/src/cloud-setup-session/__tests__/mock-service.test.ts
+++ b/packages/cloud/sdk/src/cloud-setup-session/__tests__/mock-service.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for `MockCloudSetupSessionService`: scripted-tour progression, transcript/fact accumulation, and the provisioning→ready transition, driven by injected clock/id. */
+
 import { describe, expect, it } from "vitest";
 import { MockCloudSetupSessionService } from "../mock-service.js";
 

--- a/packages/cloud/sdk/src/cloud-setup-session/__tests__/policy.test.ts
+++ b/packages/cloud/sdk/src/cloud-setup-session/__tests__/policy.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for `DEFAULT_SETUP_POLICY` and `isActionAllowed`: the allowed setup action types and the reject path for anything outside the allow-list. */
+
 import { describe, expect, it } from "vitest";
 import { DEFAULT_SETUP_POLICY, isActionAllowed } from "../policy.js";
 import type { SetupActionPolicy } from "../types.js";

--- a/packages/cloud/sdk/src/cloud-setup-session/index.ts
+++ b/packages/cloud/sdk/src/cloud-setup-session/index.ts
@@ -1,3 +1,5 @@
+/** Barrel for the `@elizaos/cloud-sdk/cloud-setup-session` sub-export: guided-setup service interface, mock implementation, policy, and types. */
+
 export {
   MockCloudSetupSessionService,
   type MockCloudSetupSessionServiceOptions,

--- a/packages/cloud/sdk/src/cloud-setup-session/mock-service.ts
+++ b/packages/cloud/sdk/src/cloud-setup-session/mock-service.ts
@@ -1,3 +1,11 @@
+/**
+ * In-memory `CloudSetupSessionService` implementation for tests and dev without a
+ * live session: runs a scripted setup tour, accumulates transcript and extracted
+ * facts, and flips the container from provisioning to ready after a configurable
+ * number of `getStatus` polls. Clock and id generation are injectable for
+ * deterministic tests.
+ */
+
 import type {
   CloudSetupSessionService,
   FinalizeHandoffInput,

--- a/packages/cloud/sdk/src/cloud-setup-session/policy.ts
+++ b/packages/cloud/sdk/src/cloud-setup-session/policy.ts
@@ -1,3 +1,9 @@
+/**
+ * `DEFAULT_SETUP_POLICY` and `isActionAllowed`: the allow-list of action types
+ * and the token/turn budgets a setup session may take before container handoff.
+ * Enforced by setup-session implementations to keep the guided flow scoped.
+ */
+
 import type { SetupActionPolicy } from "./types.js";
 
 export const DEFAULT_SETUP_POLICY: SetupActionPolicy = {

--- a/packages/cloud/sdk/src/cloud-setup-session/service-interface.ts
+++ b/packages/cloud/sdk/src/cloud-setup-session/service-interface.ts
@@ -1,3 +1,10 @@
+/**
+ * `CloudSetupSessionService` interface: the five operations
+ * (startSession / sendMessage / getStatus / finalizeHandoff / cancel) a guided
+ * cloud-setup backend must implement. `MockCloudSetupSessionService` is the
+ * reference implementation; production backends implement this contract.
+ */
+
 import type {
   ContainerHandoffEnvelope,
   SetupExtractedFact,

--- a/packages/cloud/sdk/src/cloud-setup-session/types.ts
+++ b/packages/cloud/sdk/src/cloud-setup-session/types.ts
@@ -1,3 +1,10 @@
+/**
+ * Wire types for the guided cloud-setup session: the session envelope,
+ * transcript messages, extracted owner facts, the container-handoff envelope,
+ * and the action policy. Shared by the service interface, the mock service, and
+ * production implementations of the setup flow.
+ */
+
 export type SetupSessionId = string;
 export type TenantId = string;
 export type ContainerStatus = "provisioning" | "ready" | "failed";

--- a/packages/cloud/sdk/src/http.test.ts
+++ b/packages/cloud/sdk/src/http.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for `ElizaCloudHttpClient` with an injected fake fetch: verb/URL/query/header construction and error mapping. */
+
 import { describe, expect, it } from "vitest";
 
 import { type CloudApiError, ElizaCloudHttpClient } from "./http.js";

--- a/packages/cloud/sdk/src/http.ts
+++ b/packages/cloud/sdk/src/http.ts
@@ -1,3 +1,11 @@
+/**
+ * Low-level HTTP layer for the SDK: `ElizaCloudHttpClient` (GET/POST/PUT/PATCH/
+ * DELETE with auth-header injection and query building), the `CloudApiClient`
+ * subclass scoped to `/api/v1`, and the error types `CloudApiError` (thrown on
+ * any non-2xx) and its 402 specialisation `InsufficientCreditsError`.
+ * `ElizaCloudClient` builds on top of this.
+ */
+
 import {
   type CloudApiErrorBody,
   type CloudRequestOptions,

--- a/packages/cloud/sdk/src/index.ts
+++ b/packages/cloud/sdk/src/index.ts
@@ -1,3 +1,5 @@
+/** Main barrel for `@elizaos/cloud-sdk`: re-exports the client, HTTP layer, errors, types, and generated public-route surface. */
+
 export {
   APP_AUTHORIZE_PATH,
   type BuildAppAuthorizeUrlOptions,

--- a/packages/cloud/sdk/src/live.e2e.test.ts
+++ b/packages/cloud/sdk/src/live.e2e.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Live integration tests that hit the real Eliza Cloud API — every block is
+ * gated by an `ELIZA_CLOUD_SDK_LIVE*` env flag and skips when unset (see the
+ * package CLAUDE.md for the full flag matrix). Not a mocked suite: these exercise
+ * real auth, generation, containers, and agent lifecycle against live endpoints.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   CloudApiClient,

--- a/packages/cloud/sdk/src/public-routes.test.ts
+++ b/packages/cloud/sdk/src/public-routes.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for `ElizaCloudPublicRoutesClient` (the generated route wrappers) against a stub transport, checking method/path dispatch and the `Raw` variants. */
+
 import { describe, expect, it } from "vitest";
 import { ElizaCloudPublicRoutesClient } from "./public-routes.js";
 import type { CloudRequestOptions, HttpMethod } from "./types.js";

--- a/packages/cloud/sdk/src/types.cloud-api.ts
+++ b/packages/cloud/sdk/src/types.cloud-api.ts
@@ -1,3 +1,10 @@
+/**
+ * DTOs mirrored from the Cloud API schema (`CurrentUserDto`, `AgentDetailDto`,
+ * the `ApiSuccessEnvelope`/`ApiErrorEnvelope` wrappers, etc.). These must stay in
+ * exact sync with the actual API responses — do not add computed or client-only
+ * fields here.
+ */
+
 export type IsoDateString = string;
 type DateLike = Date | IsoDateString;
 

--- a/packages/cloud/sdk/src/types.ts
+++ b/packages/cloud/sdk/src/types.ts
@@ -1,3 +1,11 @@
+/**
+ * Request/response interfaces and `ElizaCloudClientOptions` for every SDK method,
+ * plus the base-URL constants and re-exports of the Cloud API DTOs from
+ * `types.cloud-api.ts`. Field names on request bodies must match the server zod
+ * schemas verbatim (see `CreateContainerRequest`) — the server strips unknown
+ * keys, so a mismatched casing is silently dropped.
+ */
+
 export type {
   AgentDatabaseStatus,
   AgentDetailDto,
@@ -646,10 +654,10 @@ export interface CloudContainer {
  * `packages/cloud/api/v1/containers/route.ts`) verbatim — the server is
  * camelCase. The server validates with `z.object`, which strips unknown keys,
  * so a snake_case body (`project_name`, `environment_vars`, …) is silently
- * dropped before the handler ever runs. That previously discarded
- * `environmentVars.ELIZA_APP_ID` (per-app monetization attribution) and
- * `projectName` (the sticky deploy key) on every container create, even on the
- * happy path. Keep this in exact camelCase agreement with the server.
+ * dropped before the handler ever runs — losing `environmentVars.ELIZA_APP_ID`
+ * (per-app monetization attribution) and `projectName` (the sticky deploy key)
+ * on every container create, even on the happy path. Keep this in exact
+ * camelCase agreement with the server.
  */
 export interface CreateContainerRequest {
   /** Human-readable container name (1–100 chars). */

--- a/packages/cloud/sdk/src/wallet-provision-challenge.test.ts
+++ b/packages/cloud/sdk/src/wallet-provision-challenge.test.ts
@@ -1,3 +1,5 @@
+/** Golden-bytes test for `buildWalletProvisionChallenge`: pins the exact client↔server wire string so the signing/recovery contract cannot drift. */
+
 import { describe, expect, test } from "bun:test";
 import {
   buildWalletProvisionChallenge,

--- a/packages/cloud/sdk/vitest.live.config.ts
+++ b/packages/cloud/sdk/vitest.live.config.ts
@@ -1,3 +1,5 @@
+/** Vitest config for the live e2e suite (`live.e2e.test.ts`), gated by the `ELIZA_CLOUD_SDK_LIVE` env flags. */
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Comment cleanup B07 — slice: `packages/cloud/sdk`

Part of #12237 (batch B07 of the repo-wide comment cleanup, #12181). **Comment-only; zero functional diff — machine-checked** by `scripts/assert-comment-only-diff.mjs`.

Batch B07 is large (~1120 files); this PR is one coherent, self-contained subtree slice: the `@elizaos/cloud-sdk` package (`packages/cloud/sdk`). Headers were written from reading each file plus the package `CLAUDE.md`, using the SDK's own architecture terms (client / http / public-routes / cloud-setup-session).

### What changed
- **Prose file headers added to all 25 header-less `.ts`/`.mjs` files** in the subtree (client, http, types, app-auth, the four cloud-setup-session modules, both barrels, the three `scripts/`, `build.ts`, `vitest.live.config.ts`, and all test files). Barrels get a 1-line header; test headers state the surface under test and how real the harness is (mock fetch vs the env-gated live e2e suite).
- **1 churn line rewritten to present tense**: `src/types.ts` `CreateContainerRequest` — "That previously discarded `environmentVars.ELIZA_APP_ID`…" rewritten as a present-tense statement of the durable camelCase-agreement invariant. No described behavior was lost.

### Not touched
- `src/public-routes.ts` (generated — `DO NOT EDIT`) left alone. The one churn hit inside `generate-public-routes.mjs:166` is inside an emitted template-literal string (generated file content), not a comment — correctly left as-is.

### Tallies
- Files touched: **25** · Headers added: **25** · Churn lines rewritten: **1** (0 deleted — no restatement/change-narration comments present in this subtree) · Files flagged (purpose undeterminable): **0**

### Verify
```
[assert-comment-only-diff] OK — 25 source file(s) changed; every code token identical to origin/develop. Comments only.
```
Header self-audit over `packages/cloud/sdk/**` prints nothing (every in-scope file now opens with a header).

### Evidence (per PR_EVIDENCE.md)
- Trajectory / screenshot / video / audio / domain-artifact rows: **N/A — comments-only change, zero functional diff (machine-checked by `scripts/assert-comment-only-diff.mjs`)**.

Refs #12237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
