### PR TITLE
chore(#12240): comment cleanup B10 — scenario-runner prose headers (comment-only)

### DIFF
--- a/packages/scenario-runner/schema/index.js
+++ b/packages/scenario-runner/schema/index.js
@@ -1,3 +1,9 @@
+/**
+ * Runtime schema module for `@elizaos/scenario-runner/schema`: the final-check key
+ * table (FINAL_CHECK_KEYS) and the `scenario` / `scenarioLane` / `scenarioDeferral`
+ * validators that scenario files import to declare and validate their definitions.
+ * Types live in the paired index.d.ts.
+ */
 export const FINAL_CHECK_KEYS = new Map(
   Object.entries({
     custom: ["type", "name", "predicate"],

--- a/packages/scenario-runner/test/fixtures/mcp-stdio-fixture.mjs
+++ b/packages/scenario-runner/test/fixtures/mcp-stdio-fixture.mjs
@@ -1,3 +1,9 @@
+/**
+ * Standalone stdio MCP server used as a fixture by the MCP scenarios: exposes a
+ * deterministic echo tool and a fixed resource over the Model Context Protocol
+ * stdio transport. Spawned as a child process so plugin-mcp connects to a real
+ * server rather than a mock.
+ */
 const sdkRoot = new URL(
   "../../../../plugins/plugin-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/",
   import.meta.url,

--- a/packages/scenario-runner/test/scenarios/_helpers/app-control-http-loopback.ts
+++ b/packages/scenario-runner/test/scenarios/_helpers/app-control-http-loopback.ts
@@ -1,3 +1,9 @@
+/**
+ * In-process HTTP loopback for scenarios that assert app-control network calls.
+ * Monkeypatches global `fetch` to record requests and let handlers stub responses,
+ * so scenarios can inspect the exact payloads a plugin posts (e.g.
+ * `/api/views/events/broadcast`) without a real server. Reset per scenario.
+ */
 export type AppControlHttpRequest = {
   body: unknown;
   method: string;

--- a/packages/scenario-runner/test/scenarios/background-live.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/background-live.scenario.ts
@@ -1,3 +1,9 @@
+/**
+ * Live-lane scenario: a real LLM drives plugin-app-control BACKGROUND
+ * set/undo/redo/reset from chat and the handler emits the `background:apply`
+ * broadcasts the renderer consumes. Runs against a real model (live-only lane);
+ * deterministic-background-actions pins the same payload contract keyless.
+ */
 import type { ScenarioTurnExecution } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {

--- a/packages/scenario-runner/test/scenarios/cloud-apps-read-core.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/cloud-apps-read-core.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Live-lane scenario: a real LLM answers "what apps do I have?" against the
+ * Eliza Cloud Apps read surface. Needs live model credentials (live-only lane).
+ */
 import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
 

--- a/packages/scenario-runner/test/scenarios/deterministic-active-view-agent-surface.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-active-view-agent-surface.scenario.ts
@@ -1,3 +1,8 @@
+/**
+ * Keyless scenario asserting the agent-addressable surface of an active view:
+ * the agent reaches a scenario ledger view's registered controls and produces a
+ * trajectory over them. Runs on the pr-deterministic lane under the LLM proxy.
+ */
 import {
   registerPluginViews,
   unregisterPluginViews,

--- a/packages/scenario-runner/test/scenarios/deterministic-agent-skills-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-agent-skills-actions.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless catalog coverage for the plugin-agent-skills action surface
+ * (USE_SKILL and similes). Runs on the pr-deterministic lane under the LLM proxy.
+ */
 import type {
   CapturedAction,
   ScenarioContext,

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless catalog coverage for the plugin-app-control action surface against a
+ * seeded set of scenario views. Runs on the pr-deterministic lane under the LLM proxy.
+ */
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import type {

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
@@ -1,3 +1,8 @@
+/**
+ * Keyless coverage that natural-language requests route to the correct
+ * plugin-app-control action against seeded scenario views. Runs on the
+ * pr-deterministic lane under the LLM proxy (fixtures pin the routing).
+ */
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { ModelType } from "@elizaos/core";

--- a/packages/scenario-runner/test/scenarios/deterministic-background-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-background-actions.scenario.ts
@@ -1,3 +1,8 @@
+/**
+ * Keyless catalog coverage for the plugin-app-control BACKGROUND action and the
+ * `background:apply` payload contract. Runs on the pr-deterministic lane under
+ * the LLM proxy; background-live proves a real model drives the same path.
+ */
 import type { ScenarioTurnExecution } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {

--- a/packages/scenario-runner/test/scenarios/deterministic-browser-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-browser-actions.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless catalog coverage for the browser-workspace action surface against a
+ * seeded browser tab. Runs on the pr-deterministic lane under the LLM proxy.
+ */
 import type {
   CapturedAction,
   ScenarioTurnExecution,

--- a/packages/scenario-runner/test/scenarios/deterministic-browser-computeruse-progress.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-browser-computeruse-progress.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless coverage that browser and computer-use progress events stream through
+ * to the scenario surface. Runs on the pr-deterministic lane under the LLM proxy.
+ */
 import type { Action, AgentRuntime } from "@elizaos/core";
 import type {
   ScenarioContext,

--- a/packages/scenario-runner/test/scenarios/deterministic-coding-tools-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-coding-tools-actions.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless coverage exercising the coding-tools action execution surface end to
+ * end. Runs on the pr-deterministic lane under the LLM proxy.
+ */
 import { execFile } from "node:child_process";
 import { promises as fs, realpathSync } from "node:fs";
 import os from "node:os";

--- a/packages/scenario-runner/test/scenarios/deterministic-computeruse-progress-approvals.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-computeruse-progress-approvals.scenario.ts
@@ -1,3 +1,8 @@
+/**
+ * Keyless coverage of computer-use approval-relay buttons: progress events raise
+ * approval requests and relay their responses. Runs on the pr-deterministic lane
+ * under the LLM proxy.
+ */
 import type { Plugin } from "@elizaos/core";
 import type {
   ScenarioContext,

--- a/packages/scenario-runner/test/scenarios/deterministic-generated-app-routes.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-generated-app-routes.scenario.ts
@@ -1,3 +1,8 @@
+/**
+ * Keyless coverage that a generated app lands in the real registry with a catalog
+ * tile, hero, and dispatchable routes. Runs on the pr-deterministic lane under the
+ * LLM proxy.
+ */
 import { promises as fs } from "node:fs";
 import type http from "node:http";
 import os from "node:os";

--- a/packages/scenario-runner/test/scenarios/deterministic-github-actions-routes.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-github-actions-routes.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless catalog coverage for the plugin-github action and route surface against
+ * a mocked GitHub API. Runs on the pr-deterministic lane under the LLM proxy.
+ */
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/packages/scenario-runner/test/scenarios/deterministic-gitpathology-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-gitpathology-actions.scenario.ts
@@ -1,3 +1,8 @@
+/**
+ * Keyless coverage of the plugin-gitpathologist GIT_PATHOLOGY action, exercising
+ * its `list` op against an isolated empty cache. Runs on the pr-deterministic lane
+ * under the LLM proxy.
+ */
 import { promises as fs, realpathSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/packages/scenario-runner/test/scenarios/deterministic-inbound-attachment-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-inbound-attachment-actions.scenario.ts
@@ -1,3 +1,8 @@
+/**
+ * Keyless coverage that an inbound text attachment flows through the message
+ * pipeline to a reply. Runs on the pr-deterministic lane under the LLM proxy;
+ * live-inbound-attachment proves a real model reads and summarizes it.
+ */
 import { ModelType } from "@elizaos/core";
 import type { ScenarioTurnExecution } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";

--- a/packages/scenario-runner/test/scenarios/deterministic-lifeops-scheduled-tasks.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-lifeops-scheduled-tasks.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless coverage for the LifeOps ScheduledTask action surface. Runs on the
+ * pr-deterministic lane under the LLM proxy.
+ */
 import type {
   CapturedAction,
   ScenarioContext,

--- a/packages/scenario-runner/test/scenarios/deterministic-mcp-actions-routes.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-mcp-actions-routes.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless catalog coverage for the plugin-mcp action and route surface. Runs on
+ * the pr-deterministic lane under the LLM proxy.
+ */
 import { readFileSync } from "node:fs";
 import type http from "node:http";
 import { dirname, resolve } from "node:path";

--- a/packages/scenario-runner/test/scenarios/deterministic-media-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-media-actions.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless coverage for the media-generation action surface. Runs on the
+ * pr-deterministic lane under the LLM proxy.
+ */
 import { ModelType, type Plugin } from "@elizaos/core";
 import type {
   CapturedAction,

--- a/packages/scenario-runner/test/scenarios/deterministic-pr-smoke.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-pr-smoke.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Fast keyless smoke covering the core scenario surfaces (views, actions, routing)
+ * in one pass. Runs on the pr-deterministic lane under the LLM proxy.
+ */
 import { ModelType } from "@elizaos/core";
 import type {
   CapturedAction,

--- a/packages/scenario-runner/test/scenarios/deterministic-settings-subview.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-settings-subview.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless coverage that the VIEWS action deep-links into a Settings subview. Runs
+ * on the pr-deterministic lane under the LLM proxy.
+ */
 import type { ScenarioTurnExecution } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {

--- a/packages/scenario-runner/test/scenarios/deterministic-slash-commands.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-slash-commands.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless catalog coverage for the slash-command surface. Runs on the
+ * pr-deterministic lane under the LLM proxy.
+ */
 import type http from "node:http";
 import type { AgentRuntime } from "@elizaos/core";
 import type { ScenarioContext } from "@elizaos/scenario-runner/schema";

--- a/packages/scenario-runner/test/scenarios/deterministic-streaming-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-streaming-actions.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless catalog coverage for the STREAM action and route surface. Runs on the
+ * pr-deterministic lane under the LLM proxy.
+ */
 import { createServer, type Server, type ServerResponse } from "node:http";
 import type { Plugin } from "@elizaos/core";
 import type {

--- a/packages/scenario-runner/test/scenarios/deterministic-sub-agent-credential-request.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-sub-agent-credential-request.scenario.ts
@@ -1,3 +1,8 @@
+/**
+ * Keyless coverage of the sub-agent credential-request bridge: a sub-agent's
+ * credential request relays back to its origin. Runs on the pr-deterministic lane
+ * under the LLM proxy; live-sub-agent-credential-request is the real-model twin.
+ */
 import type http from "node:http";
 import {
   type AgentRuntime,

--- a/packages/scenario-runner/test/scenarios/deterministic-todos-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-todos-actions.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless coverage for the plugin-todos action surface and the CURRENT_TODOS
+ * provider. Runs on the pr-deterministic lane under the LLM proxy.
+ */
 import { ModelType, stringToUuid, type UUID } from "@elizaos/core";
 import type {
   CapturedAction,

--- a/packages/scenario-runner/test/scenarios/deterministic-view-switching-multilingual.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-view-switching-multilingual.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless coverage that view switching resolves across the navigable views in
+ * every supported language. Runs on the pr-deterministic lane under the LLM proxy.
+ */
 import type {
   CapturedAction,
   ScenarioTurnExecution,

--- a/packages/scenario-runner/test/scenarios/deterministic-view-switching.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-view-switching.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless coverage that view switching resolves across every built-in view. Runs
+ * on the pr-deterministic lane under the LLM proxy.
+ */
 import type {
   CapturedAction,
   ScenarioTurnExecution,

--- a/packages/scenario-runner/test/scenarios/deterministic-view-voice.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-view-voice.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless coverage of per-view voice-transcript navigation. Runs on the
+ * pr-deterministic lane under the LLM proxy.
+ */
 import type {
   CapturedAction,
   ScenarioTurnExecution,

--- a/packages/scenario-runner/test/scenarios/deterministic-workflow-actions-routes.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-workflow-actions-routes.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless catalog coverage for the plugin-workflow action and route surface. Runs
+ * on the pr-deterministic lane under the LLM proxy.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import type {
   CapturedAction,

--- a/packages/scenario-runner/test/scenarios/deterministic-xr-view-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-xr-view-actions.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyless coverage for XR view actions backed by a real WebSocket service. Runs on
+ * the pr-deterministic lane under the LLM proxy.
+ */
 import {
   registerPluginViews,
   unregisterPluginViews,

--- a/packages/scenario-runner/test/scenarios/live-active-view-agent-surface.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-active-view-agent-surface.scenario.ts
@@ -1,3 +1,8 @@
+/**
+ * Live-lane twin of deterministic-active-view-agent-surface: a real LLM drives a
+ * scenario ledger view's agent-addressable controls. Needs live model credentials
+ * (live-only lane).
+ */
 import {
   registerPluginViews,
   unregisterPluginViews,

--- a/packages/scenario-runner/test/scenarios/live-background-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-background-actions.scenario.ts
@@ -1,3 +1,13 @@
+/**
+ * Live-lane counterpart of deterministic-background-actions (#10694): a real
+ * model routes natural background requests to the plugin-app-control BACKGROUND
+ * handler (solid color, programmable GLSL shader preset, undo) and the handler
+ * emits the `background:apply` broadcasts the renderer consumes. The
+ * deterministic scenario pins the payload contract on the keyless PR lane; this
+ * proves a live model drives the same model → action → broadcast path. Needs
+ * live model credentials (live-only lane).
+ */
+
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {
   jsonResponse,
@@ -5,15 +15,6 @@ import {
   registerAppControlHttpHandler,
   resetAppControlHttpLoopback,
 } from "./_helpers/app-control-http-loopback";
-
-// Real-LLM (live lane) counterpart of deterministic-background-actions
-// (#10694). A REAL model must route natural background requests to the real
-// plugin-app-control BACKGROUND handler — solid color, programmable GLSL
-// shader preset, and undo — and the handler must emit the real
-// `background:apply` broadcasts the renderer consumes. The deterministic
-// catalog pins the exact payload contract on the keyless PR lane; this proves
-// a live model actually drives the same path (model → action → broadcast),
-// turnkey as soon as model keys are present.
 
 function backgroundApplyPayloads(): Record<string, unknown>[] {
   return readAppControlHttpRequests(

--- a/packages/scenario-runner/test/scenarios/live-inbound-attachment.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-inbound-attachment.scenario.ts
@@ -1,3 +1,8 @@
+/**
+ * Live-lane scenario: a real LLM reads and summarizes an inbound text attachment.
+ * Needs live model credentials (live-only lane); the deterministic twin is
+ * deterministic-inbound-attachment-actions.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 // Real-LLM (live lane) counterpart of deterministic-inbound-attachment-actions

--- a/packages/scenario-runner/test/scenarios/live-sub-agent-credential-request.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-sub-agent-credential-request.scenario.ts
@@ -1,3 +1,8 @@
+/**
+ * Live-lane twin of deterministic-sub-agent-credential-request: a real LLM drives
+ * the sub-agent credential-request bridge. Needs live model credentials
+ * (live-only lane).
+ */
 import {
   existsSync,
   mkdirSync,

--- a/packages/scenario-runner/vitest.config.ts
+++ b/packages/scenario-runner/vitest.config.ts
@@ -1,3 +1,9 @@
+/**
+ * Vitest config for the scenario-runner package. Aliases every workspace
+ * `@elizaos/*` package to its TypeScript source so the scenario runtime resolves
+ * optional plugins independent of build order (test:server only builds core); see
+ * the inline note on the dynamic-import failure this avoids.
+ */
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";


### PR DESCRIPTION
Part of #12181, batch **B10** (#12240): comment-only cleanup of `packages/scenario-runner`.

## What this slice does

Adds a purpose-explaining prose header to every header-less file in the
`packages/scenario-runner` scenario corpus and its harness support files — the
slice of B10 that lives under this package. **Comment-only; zero functional diff.**

- **33 `*.scenario.ts` files** — 1–3 line test-file headers stating the surface
  under test and how real the harness is: `pr-deterministic` scenarios run keyless
  under the deterministic LLM proxy; `live-only` scenarios run against a real
  model. Deterministic/live twins cross-reference each other.
- **`test/scenarios/_helpers/app-control-http-loopback.ts`** — the in-process
  `fetch` loopback used to assert app-control network payloads.
- **`test/fixtures/mcp-stdio-fixture.mjs`** — the standalone stdio MCP server
  fixture the MCP scenarios connect to.
- **`schema/index.js`** — the `@elizaos/scenario-runner/schema` runtime module
  (FINAL_CHECK_KEYS + `scenario`/`scenarioLane`/`scenarioDeferral` validators).
- **`vitest.config.ts`** — the package's Vitest config and its source-alias rationale.
- **`live-background-actions.scenario.ts`** — promoted an existing explanatory
  `//` block after the imports to a proper top-of-file `/** */` header (deletes
  the churn-phrased duplicate, states the contract present-tense).

Headers were written from reading each file and its `title`/`lane`/`description`
metadata plus the package `CLAUDE.md` — not pattern-stamped.

## Tallies

- Files touched: **37** (36 headers added + 1 header promoted).
- Headers added: **37**.
- Churn: the `live-background-actions` block rewritten present-tense into its header.
- `filesFlagged` (purpose undeterminable): **none**.

## Verification

- `bun run check:comment-only` → **PASSES**: `OK — 37 source file(s) changed; every code token identical to origin/develop. Comments only.`
- Biome check on all 37 touched files → clean.
- Header self-audit for `packages/scenario-runner/**` prints nothing.

Scope note: this PR is one package-slice of B10 (per the batch's ≤~50-files, one-subtree-per-PR rule). The `packages/test` and `packages/benchmarks` subtrees are separate slices.

## Evidence

N/A — comments-only change, zero functional diff (machine-checked by `scripts/assert-comment-only-diff.mjs`). No trajectory / screenshot / video / audio / domain-artifact rows apply.

Refs #12240, #12181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)