### PR TITLE
chore(#12246): comment cleanup B16 — plugin-coding-tools prose headers (comment-only)

### DIFF
--- a/plugins/plugin-coding-tools/__tests__/plugin-integration.test.ts
+++ b/plugins/plugin-coding-tools/__tests__/plugin-integration.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Integration tests for the assembled `codingToolsPlugin` — service registration,
+ * action wiring, and auto-enable gating — exercised in-process against the real
+ * filesystem.
+ */
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/plugins/plugin-coding-tools/src/actions/_test-helpers.ts
+++ b/plugins/plugin-coding-tools/src/actions/_test-helpers.ts
@@ -1,3 +1,8 @@
+/**
+ * Shared setup for the action test files: builds a temp workspace and a minimal
+ * runtime stub wired with the SandboxService and FileStateService the handlers
+ * require, over the real filesystem.
+ */
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Tests for the SHELL action: command execution, timeout clamping, history, and the
+ * CHAT command-rewrite behaviour, driven against a real shell and a local HTTP
+ * server in-process.
+ */
 import { execFile } from "node:child_process";
 import * as fs from "node:fs/promises";
 import { createServer } from "node:http";

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -1,3 +1,12 @@
+/**
+ * SHELL action: runs a command via the host shell (`action=run`) and reads/clears
+ * per-conversation command history. Resolves the shell binary and tool
+ * availability through terminal-capabilities, enforces the per-call timeout clamp,
+ * and — for interactive CHAT use only — rewrites a handful of weak probe commands
+ * (disk/memory/source-search/crypto) into bounded equivalents. The eliza-code
+ * coding sub-agent is exempted from those rewrites so its explicit commands run
+ * verbatim. Gated to coding contexts with OWNER role.
+ */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import {
@@ -1310,12 +1319,12 @@ export const shellAction: Action = {
     // CHAT conveniences keyed on the *message text*: when a user asks "check
     // disk space", a weak probe is rewritten into a good bounded one. The
     // eliza-code coding sub-agent (ELIZA_PLANNER_FULL_ACTION_SURFACE) instead
-    // issues precise explicit commands (ls / mkdir / git / …) and must NEVER
-    // have them rewritten — when the build task incidentally mentioned a trigger
-    // word, EVERY `ls`/`mkdir` was replaced by an ~19s `df` cleanup scan, so the
-    // shell produced no real output, the model gave up on SHELL, and a 30s build
-    // took 90s+. Skip all message-text-keyed rewrites for the coding sub-agent;
-    // its commands run verbatim.
+    // issues precise explicit commands (ls / mkdir / git / …) that must NEVER be
+    // rewritten: a task that incidentally mentions a trigger word would otherwise
+    // turn every `ls`/`mkdir` into an ~19s `df` cleanup scan, starving the model
+    // of real output and inflating a 30s build past 90s. Skip all
+    // message-text-keyed rewrites for the coding sub-agent; its commands run
+    // verbatim.
     const codingSubAgentShell = ((): boolean => {
       const v =
         process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase();

--- a/plugins/plugin-coding-tools/src/actions/edit.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/edit.test.ts
@@ -1,3 +1,4 @@
+/** Tests for the FILE `edit` handler over the real filesystem, including the read-before-write staleness guard. */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import {

--- a/plugins/plugin-coding-tools/src/actions/edit.ts
+++ b/plugins/plugin-coding-tools/src/actions/edit.ts
@@ -1,3 +1,8 @@
+/**
+ * FILE `edit` handler: applies a find/replace edit to an existing file after
+ * validating the path and confirming (via FileStateService) it was not modified
+ * externally since the last read. Flags secrets in the new content before writing.
+ */
 import * as fs from "node:fs/promises";
 
 import {

--- a/plugins/plugin-coding-tools/src/actions/enter-worktree.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/enter-worktree.test.ts
@@ -1,3 +1,4 @@
+/** Tests for the WORKTREE `enter` handler against a real git worktree in a temp repo. */
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";

--- a/plugins/plugin-coding-tools/src/actions/enter-worktree.ts
+++ b/plugins/plugin-coding-tools/src/actions/enter-worktree.ts
@@ -1,3 +1,8 @@
+/**
+ * WORKTREE `enter` handler: creates/attaches a git worktree, registers its root
+ * with SandboxService, and pushes it onto the SessionCwdService stack so
+ * subsequent glob/grep/ls/shell operations run inside it.
+ */
 import * as crypto from "node:crypto";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/plugins/plugin-coding-tools/src/actions/exit-worktree.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/exit-worktree.test.ts
@@ -1,3 +1,4 @@
+/** Tests for the WORKTREE `exit` handler and the SessionCwdService stack pop. */
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";

--- a/plugins/plugin-coding-tools/src/actions/exit-worktree.ts
+++ b/plugins/plugin-coding-tools/src/actions/exit-worktree.ts
@@ -1,3 +1,7 @@
+/**
+ * WORKTREE `exit` handler: pops the current worktree root off the SessionCwdService
+ * stack, returning subsequent operations to the previous working directory.
+ */
 import {
   type ActionResult,
   logger as coreLogger,

--- a/plugins/plugin-coding-tools/src/actions/file.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/file.test.ts
@@ -1,3 +1,4 @@
+/** Tests for the FILE umbrella action's operation dispatch, including the `device_filesystem` bridge path via a fake bridge service. */
 import type { IAgentRuntime, Memory, Service } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 

--- a/plugins/plugin-coding-tools/src/actions/file.ts
+++ b/plugins/plugin-coding-tools/src/actions/file.ts
@@ -1,3 +1,9 @@
+/**
+ * FILE umbrella action: a single agent-facing tool that dispatches to the
+ * read/write/edit/grep/glob/ls handlers by operation name. Reads and writes route
+ * through the local filesystem, or through a `device_filesystem` bridge service
+ * when `target=device` (mobile). Gated to coding contexts with ADMIN role.
+ */
 import type {
   Action,
   ActionResult,

--- a/plugins/plugin-coding-tools/src/actions/glob.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/glob.test.ts
@@ -1,3 +1,4 @@
+/** Tests for the FILE `glob` handler over a real temp directory tree. */
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/plugins/plugin-coding-tools/src/actions/glob.ts
+++ b/plugins/plugin-coding-tools/src/actions/glob.ts
@@ -1,3 +1,8 @@
+/**
+ * FILE `glob` handler: expands a glob pattern to matching file paths, rooted at an
+ * explicit path or the conversation's SessionCwdService cwd, with SandboxService
+ * validation on the search root.
+ */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 

--- a/plugins/plugin-coding-tools/src/actions/grep.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/grep.test.ts
@@ -1,3 +1,4 @@
+/** Tests for the FILE `grep` handler driving RipgrepService over a real temp workspace. */
 import { existsSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";

--- a/plugins/plugin-coding-tools/src/actions/grep.ts
+++ b/plugins/plugin-coding-tools/src/actions/grep.ts
@@ -1,3 +1,8 @@
+/**
+ * FILE `grep` handler: content search over the workspace via RipgrepService,
+ * rooted at an explicit path or the conversation's SessionCwdService cwd. Output is
+ * capped by `head_limit` (default `CODING_TOOLS_GREP_HEAD_LIMIT`).
+ */
 import {
   type ActionResult,
   logger as coreLogger,

--- a/plugins/plugin-coding-tools/src/actions/index.ts
+++ b/plugins/plugin-coding-tools/src/actions/index.ts
@@ -1,3 +1,4 @@
+/** Re-exports the FILE/SHELL/WORKTREE actions and their per-operation handlers. */
 export { shellAction } from "./bash.js";
 export { editFileHandler } from "./edit.js";
 export { enterWorktreeHandler } from "./enter-worktree.js";

--- a/plugins/plugin-coding-tools/src/actions/ls.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/ls.test.ts
@@ -1,3 +1,4 @@
+/** Tests for the FILE `ls` handler over the real filesystem. */
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/plugins/plugin-coding-tools/src/actions/ls.ts
+++ b/plugins/plugin-coding-tools/src/actions/ls.ts
@@ -1,3 +1,8 @@
+/**
+ * FILE `ls` handler: lists a directory's entries after SandboxService validation,
+ * rooted at an explicit path or the conversation's SessionCwdService cwd. Supports
+ * the `device_filesystem` bridge for device targets.
+ */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 

--- a/plugins/plugin-coding-tools/src/actions/read.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/read.test.ts
@@ -1,3 +1,4 @@
+/** Tests for the FILE `read` handler: line/size caps and read recording, over the real filesystem. */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import {

--- a/plugins/plugin-coding-tools/src/actions/read.ts
+++ b/plugins/plugin-coding-tools/src/actions/read.ts
@@ -1,3 +1,9 @@
+/**
+ * FILE `read` handler: returns file contents (line-numbered, size- and
+ * line-capped) after validating the path through SandboxService, and records the
+ * read with FileStateService so a later write/edit can detect external
+ * modification. Supports the `device_filesystem` bridge when reading device files.
+ */
 import * as fs from "node:fs/promises";
 
 import {

--- a/plugins/plugin-coding-tools/src/actions/summaries.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/summaries.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the operation-summary string helpers. */
 import { describe, expect, it } from "vitest";
 import {
   compactSummaryText,

--- a/plugins/plugin-coding-tools/src/actions/summaries.ts
+++ b/plugins/plugin-coding-tools/src/actions/summaries.ts
@@ -1,3 +1,8 @@
+/**
+ * Text helpers that turn a completed FILE or SHELL operation into a short
+ * human-readable summary line for action results. Pure string formatting, shared
+ * by the file and bash actions.
+ */
 export function basename(path: string): string {
   return path.split("/").pop() || path;
 }

--- a/plugins/plugin-coding-tools/src/actions/worktree.ts
+++ b/plugins/plugin-coding-tools/src/actions/worktree.ts
@@ -1,3 +1,9 @@
+/**
+ * WORKTREE umbrella action: dispatches enter/exit git-worktree operations to their
+ * handlers. Entering registers the new root in SandboxService and pushes it onto
+ * the SessionCwdService stack; exiting pops it. Gated to coding contexts with
+ * ADMIN role.
+ */
 import type {
   Action,
   ActionResult,

--- a/plugins/plugin-coding-tools/src/actions/write.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/write.test.ts
@@ -1,3 +1,4 @@
+/** Tests for the FILE `write` handler over the real filesystem, including the writability guard and secret detection. */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import {

--- a/plugins/plugin-coding-tools/src/actions/write.ts
+++ b/plugins/plugin-coding-tools/src/actions/write.ts
@@ -1,3 +1,9 @@
+/**
+ * FILE `write` handler: writes full file contents after a SandboxService path
+ * check and a FileStateService writability check (rejects if the file changed
+ * since the last read). Flags secrets in the payload via lib/secrets before
+ * writing. Supports the `device_filesystem` bridge for device targets.
+ */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 

--- a/plugins/plugin-coding-tools/src/index.ts
+++ b/plugins/plugin-coding-tools/src/index.ts
@@ -1,3 +1,13 @@
+/**
+ * Plugin entry for @elizaos/plugin-coding-tools: assembles the FILE, SHELL, and
+ * WORKTREE actions, the AVAILABLE_CODING_TOOLS provider, and the sandbox /
+ * file-state / session-cwd / ripgrep services into the `codingToolsPlugin`
+ * object, and declares the auto-enable predicate that turns the plugin on only
+ * when a coding feature flag is set and the environment supports a terminal.
+ * `terminalSupportedByEnv` mirrors the gating in auto-enable.ts (disabled on the
+ * store build variant and iOS; Android only in local-yolo mode). Also re-exports
+ * the services and types for external consumers.
+ */
 import type { Plugin } from "@elizaos/core";
 import { fileAction, shellAction, worktreeAction } from "./actions/index.js";
 import { availableToolsProvider } from "./providers/available-tools.js";
@@ -57,7 +67,7 @@ export const codingToolsPlugin: Plugin = {
       ?.stop();
   },
   // Self-declared auto-enable: activate when features.codingTools is enabled,
-  // or via the legacy "coding-agent" feature key (the plugin was renamed).
+  // or via the legacy "coding-agent" feature key kept as an alias.
   autoEnable: {
     shouldEnable: (env, config) => {
       const features = config.features as Record<string, unknown> | undefined;

--- a/plugins/plugin-coding-tools/src/lib/format.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the action-result and parameter-reader helpers. */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { FAILURE_TEXT_PREFIX, type ToolFailure } from "../types.js";

--- a/plugins/plugin-coding-tools/src/lib/format.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.ts
@@ -1,3 +1,10 @@
+/**
+ * Result and parameter helpers shared by the action handlers: the
+ * `failureToActionResult`/`successActionResult` builders that produce the
+ * `ActionResult` envelope, and the `readStringParam`/`readNumberParam` readers that
+ * coerce loosely-typed handler options into validated values. Keeps every action's
+ * success/failure shape identical.
+ */
 import type { ActionResult, IAgentRuntime } from "@elizaos/core";
 import {
   type ActionResultData,

--- a/plugins/plugin-coding-tools/src/lib/path-utils.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/path-utils.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the path predicates and blocklist resolution. */
 import { describe, expect, it } from "vitest";
 import {
   isAbsolutePath,

--- a/plugins/plugin-coding-tools/src/lib/path-utils.ts
+++ b/plugins/plugin-coding-tools/src/lib/path-utils.ts
@@ -1,3 +1,8 @@
+/**
+ * Path predicates and resolution used by the sandbox policy and file handlers:
+ * `isAbsolutePath`, `isWithin`, `resolveRealPath`, `isUncPath`, plus a blocklist of
+ * device and `/proc/<pid>/fd` pseudo-paths that must never be opened.
+ */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 

--- a/plugins/plugin-coding-tools/src/lib/run-git-command.ts
+++ b/plugins/plugin-coding-tools/src/lib/run-git-command.ts
@@ -1,3 +1,8 @@
+/**
+ * `runGitCommand` helper: runs a git subcommand with `execFile` (no shell) under a
+ * given cwd and timeout, brokered through the core capability router so git access
+ * can be gated or denied by the host. Used by the worktree actions.
+ */
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 

--- a/plugins/plugin-coding-tools/src/lib/run-shell.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/run-shell.test.ts
@@ -1,3 +1,4 @@
+/** Tests for the `runShell` child-process wrapper, using the core capability router doubles. */
 import {
   CAPABILITY_ROUTER_SERVICE_TYPE,
   type ElizaCapabilityRouter,

--- a/plugins/plugin-coding-tools/src/lib/secrets.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/secrets.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the secret-token detector used to gate WRITE/EDIT. */
 import { describe, expect, it } from "vitest";
 import { detectSecrets } from "./secrets.js";
 

--- a/plugins/plugin-coding-tools/src/lib/terminal-capabilities.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/terminal-capabilities.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for shell resolution and coding-tool capability detection. */
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-coding-tools/src/lib/terminal-capabilities.ts
+++ b/plugins/plugin-coding-tools/src/lib/terminal-capabilities.ts
@@ -1,3 +1,10 @@
+/**
+ * Platform terminal capability detection: resolves the host shell and probes the
+ * PATH for the binaries the coding tools depend on (sh, git, rg, bun, codex,
+ * claude, opencode, …), and reports Android/AOSP runtime constraints. Consumed by
+ * the SHELL action and run-shell to decide what can execute and to produce
+ * missing-tool messages.
+ */
 import { accessSync, constants } from "node:fs";
 import path from "node:path";
 

--- a/plugins/plugin-coding-tools/src/providers/available-tools.ts
+++ b/plugins/plugin-coding-tools/src/providers/available-tools.ts
@@ -1,3 +1,8 @@
+/**
+ * AVAILABLE_CODING_TOOLS provider: injects the list of tool names the plugin
+ * exposes (FILE, SHELL, WORKTREE) into agent state at position -10 so the model
+ * knows which coding actions it can call.
+ */
 import type {
   IAgentRuntime,
   Memory,

--- a/plugins/plugin-coding-tools/src/services/coding-agent-context.test.ts
+++ b/plugins/plugin-coding-tools/src/services/coding-agent-context.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the coding-agent-context Zod schemas. */
 import { describe, expect, it } from "vitest";
 import {
   addIteration,

--- a/plugins/plugin-coding-tools/src/services/coding-task-executor.ts
+++ b/plugins/plugin-coding-tools/src/services/coding-task-executor.ts
@@ -1,3 +1,8 @@
+/**
+ * `CodingTaskExecutor`: maps a coding-related task spec into the agent action that
+ * fulfils it, resolving the delegation action name via the core registry. Consumed
+ * by orchestration plugins that hand coding work to a coding-capable agent.
+ */
 import crypto from "node:crypto";
 import type { Content, IAgentRuntime, Memory, UUID } from "@elizaos/core";
 import { findCodingDelegationActionName, ModelType } from "@elizaos/core";

--- a/plugins/plugin-coding-tools/src/services/file-state-service.ts
+++ b/plugins/plugin-coding-tools/src/services/file-state-service.ts
@@ -1,3 +1,10 @@
+/**
+ * `FileStateService` (serviceType `CODING_TOOLS_FILE_STATE`): tracks the mtime and
+ * size of each file per conversation at read time so write/edit handlers can reject
+ * a write when the file was modified externally since the last read — the
+ * read-before-write invariant that keeps agent edits from clobbering outside
+ * changes.
+ */
 import * as fs from "node:fs/promises";
 import {
   logger as coreLogger,

--- a/plugins/plugin-coding-tools/src/services/index.ts
+++ b/plugins/plugin-coding-tools/src/services/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the coding-tools services and the coding-agent-context Zod schemas. */
 export * from "./coding-agent-context.js";
 export { CodingTaskExecutor } from "./coding-task-executor.js";
 export { FileStateService } from "./file-state-service.js";

--- a/plugins/plugin-coding-tools/src/services/ripgrep-service.ts
+++ b/plugins/plugin-coding-tools/src/services/ripgrep-service.ts
@@ -1,3 +1,8 @@
+/**
+ * `RipgrepService` (serviceType `CODING_TOOLS_RIPGREP`): wraps the
+ * `@vscode/ripgrep` binary (falling back to a system `rg` on PATH) for the FILE
+ * `grep` operation. Always excludes VCS directories and enforces a hard 30 s cap.
+ */
 import { execFile } from "node:child_process";
 import { statSync } from "node:fs";
 import * as path from "node:path";

--- a/plugins/plugin-coding-tools/src/services/sandbox-service.test.ts
+++ b/plugins/plugin-coding-tools/src/services/sandbox-service.test.ts
@@ -1,3 +1,4 @@
+/** Tests for the SandboxService path policy: blocklist defaults and allow-root enforcement. */
 import { homedir } from "node:os";
 import * as path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";

--- a/plugins/plugin-coding-tools/src/services/sandbox-service.ts
+++ b/plugins/plugin-coding-tools/src/services/sandbox-service.ts
@@ -1,3 +1,10 @@
+/**
+ * `SandboxService` (serviceType `CODING_TOOLS_SANDBOX`): the path-access policy for
+ * every filesystem operation. `validatePath` rejects paths on the blocklist
+ * (defaults cover `~/.ssh`, `~/.aws`, `~/.gnupg`, credential stores, and per-OS
+ * system paths) and, when `CODING_TOOLS_WORKSPACE_ROOTS` is set, any path outside
+ * the allow-roots. No file handler may touch disk without passing through here.
+ */
 import { homedir } from "node:os";
 import * as path from "node:path";
 import {

--- a/plugins/plugin-coding-tools/src/services/session-cwd-service.ts
+++ b/plugins/plugin-coding-tools/src/services/session-cwd-service.ts
@@ -1,3 +1,9 @@
+/**
+ * `SessionCwdService` (serviceType `CODING_TOOLS_SESSION_CWD`): the per-conversation
+ * working directory, defaulting to `process.cwd()`. Glob/grep/ls/shell use it when
+ * no explicit path is given; the worktree actions push/pop it as a stack when
+ * entering and leaving worktrees.
+ */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import {

--- a/plugins/plugin-coding-tools/src/test-helpers/capability-router.ts
+++ b/plugins/plugin-coding-tools/src/test-helpers/capability-router.ts
@@ -1,3 +1,8 @@
+/**
+ * Test double for the core capability router that reports every plugin capability
+ * as unavailable, so tests can exercise the coding tools' plugin-absent code paths
+ * without wiring a real router.
+ */
 import {
   CapabilityError,
   type ElizaCapabilityRouter,

--- a/plugins/plugin-coding-tools/src/types.ts
+++ b/plugins/plugin-coding-tools/src/types.ts
@@ -1,3 +1,10 @@
+/**
+ * Shared constants and result types for the coding-tools plugin: the
+ * `CODING_TOOLS_*` service-type identifiers, the `CODING_TOOLS_CONTEXTS` list, the
+ * log prefix, and the `ToolResult`/`ToolFailure` shapes (plus `success`/`failure`
+ * constructors) that every action handler returns. Imported across actions,
+ * services, and lib so all layers agree on one set of names and envelopes.
+ */
 import type { ActionResult, UUID } from "@elizaos/core";
 
 export const CODING_TOOLS_LOG_PREFIX = "[CodingTools]";

--- a/plugins/plugin-coding-tools/vitest.config.ts
+++ b/plugins/plugin-coding-tools/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the coding-tools package: resolves `@elizaos/*` to workspace source. */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";


### PR DESCRIPTION
## What

Batch B16 (of #12246 / parent #12181) comment cleanup for the **`plugins/plugin-coding-tools`** subtree — one directory slice, 48 files.

- Added purpose-explaining **prose file headers** to every in-scope file that lacked one: the plugin entry, `types.ts`, the FILE/SHELL/WORKTREE actions and their per-operation handlers (read/write/edit/grep/glob/ls, enter/exit-worktree), the sandbox / file-state / session-cwd / ripgrep / task-executor services, the `AVAILABLE_CODING_TOOLS` provider, the `lib/` helpers, barrels (1-line), and the co-located `*.test.ts` files (1-line, noting the real-filesystem/in-process harness). Headers were written from reading each file against the package `CLAUDE.md`, not pattern-stamped.
- Rewrote **2 churn-phrased comments** to present-tense durable facts:
  - `src/index.ts` — "(the plugin was renamed)" → "kept as an alias" (durable: why the legacy `coding-agent` feature key exists).
  - `src/actions/bash.ts` — past-tense incident narrative ("EVERY `ls`/`mkdir` was replaced by … a 30s build took 90s+") → present-tense rationale for why the coding sub-agent is exempted from message-text command rewrites.

No restatement/commented-out code found to delete in this slice.

## Comment-only guarantee

**`check:comment-only` PASSES** — the code token stream is byte-for-byte identical to `origin/develop`:

```
[assert-comment-only-diff] OK — 48 source file(s) changed; every code token identical to origin/develop. Comments only.
```

Header self-audit (every in-scope file now opens with a comment) prints nothing.

## Tally

- Files touched: **48** (all under `plugins/plugin-coding-tools/`)
- Prose headers added: **48**
- Churn comments rewritten: **2** · deleted: **0**
- Files flagged (purpose undeterminable): **0**

## Evidence

- Trajectory / screenshot / video / audio / domain-artifact: **N/A — comments-only change, zero functional diff** (machine-checked by `scripts/assert-comment-only-diff.mjs`).
- `bun run verify`: N/A to run here for a comment-only diff — the token-stream guard is the binding proof that no code changed; no code tokens moved, so typecheck/lint output is unchanged from develop.

Refs #12246. Part of #12181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
