### PR TITLE
docs(#12235): prose headers + churn cleanup — b05-cloudui

### DIFF
--- a/packages/ui/src/cloud-ui/components/auth/authorize-content.test.tsx
+++ b/packages/ui/src/cloud-ui/components/auth/authorize-content.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Component tests for AuthorizeContent, the app-authorize consent screen. Drives
+ * the signed-in and signed-out branches and the OAuth-start / cancel-redirect
+ * paths against a mocked `@stwd/react` auth hook (deterministic; no live Steward
+ * backend), asserting on rendered controls and redirect behaviour in jsdom.
+ */
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/cloud-ui/components/code/prism-light.ts
+++ b/packages/ui/src/cloud-ui/components/code/prism-light.ts
@@ -1,10 +1,12 @@
 /// <reference path="../../types/react-syntax-highlighter.d.ts" />
 
-// Subset of grammars registered for the cloud-frontend code surfaces
-// (docs, blog, api-explorer, sensitive requests, chat code blocks,
-// character JSON editor). The full Prism bundle ships ~280 grammars and
-// dominates the docs vendor chunk; registering only what we use cuts the
-// shipped grammars by ~95%.
+/**
+ * PrismLight syntax highlighter with only the grammars the cloud-frontend code
+ * surfaces use (docs, blog, api-explorer, sensitive requests, chat code blocks,
+ * character JSON editor). The full Prism bundle ships ~280 grammars and dominates
+ * the docs vendor chunk; registering only what we use cuts the shipped grammars
+ * by ~95%.
+ */
 
 import bash from "react-syntax-highlighter/dist/esm/languages/prism/bash";
 import css from "react-syntax-highlighter/dist/esm/languages/prism/css";

--- a/packages/ui/src/cloud-ui/runtime/render-telemetry.tsx
+++ b/packages/ui/src/cloud-ui/runtime/render-telemetry.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 /**
- * Only the RenderTelemetryProfiler component lives here so Vite React Fast
- * Refresh can hot-patch it. The telemetry primitives (constants, types,
- * setRenderTelemetrySink, useRenderGuard) live in hooks/useRenderGuard.
+ * RenderTelemetryProfiler: wraps children in a React `<Profiler>` and emits
+ * render-frequency telemetry (info/error severities over a sliding window) so
+ * runaway re-renders in the cloud dashboard surface become observable.
+ *
+ * Only the component lives here so Vite React Fast Refresh can hot-patch it; the
+ * telemetry primitives (constants, types, setRenderTelemetrySink, useRenderGuard)
+ * live in hooks/useRenderGuard.
  */
-
 import {
   Profiler,
   type ProfilerOnRenderCallback,


### PR DESCRIPTION
Comments-only slice of #12235 for chunk **b05-cloudui** (`packages/ui/src/cloud-ui`).

## What changed
Adds/repairs top-of-file prose headers on the three in-scope files that lacked a proper `/** */` header. All other files in the subtree already met the header bar and were left untouched.

- `components/auth/authorize-content.test.tsx` — add a test header (surface under test = `AuthorizeContent`; drives a mocked `@stwd/react` auth hook in jsdom, no live Steward backend). Header sits after the required `// @vitest-environment jsdom` directive.
- `components/code/prism-light.ts` — promote the leading `//` grammar-subset note to a `/** */` prose header (below the `/// <reference>` directive, which must stay first).
- `runtime/render-telemetry.tsx` — promote the leading `//` note to a `/** */` header and state what `RenderTelemetryProfiler` renders (below `"use client"`).

## Scope / coverage
- Subtree: `packages/ui/src/cloud-ui` (~150 in-scope `.ts`/`.tsx` files).
- Files touched: 3. Remaining in-scope files already carry a proper prose header — 0 lacking.

## Verification
`node scripts/assert-comment-only-diff.mjs` passes: `OK — 3 source file(s) changed; every code token identical to origin/develop. Comments only.` Code token stream byte-for-byte unchanged.

Part of #12235.