### PR TITLE
chore(#12247): comment cleanup B17 — prose headers, churn removal (comment-only)

### DIFF
--- a/plugins/plugin-app-manager/build.ts
+++ b/plugins/plugin-app-manager/build.ts
@@ -3,10 +3,10 @@
  * Build script for @elizaos/plugin-app-manager (Node). Orchestration lives in the
  * shared driver (plugins/plugin-build.ts); this lists only what differs.
  *
- * Declarations are emitted via tsconfig.build.json, which bakes in the
- * noEmit:false / rootDir:src / declarationDir overrides the hand-rolled build
- * previously passed on the tsc CLI (the base tsconfig has noEmit:true because
- * allowImportingTsExtensions forces it).
+ * Declarations are emitted via tsconfig.build.json, which supplies the
+ * noEmit:false / rootDir:src / declarationDir overrides needed for declaration
+ * output (the base tsconfig sets noEmit:true because allowImportingTsExtensions
+ * forces it).
  */
 import { buildPlugin } from "../plugin-build";
 

--- a/plugins/plugin-app-manager/src/api/apps-routes.test.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Property and unit tests for `handleAppsRoutes`, driving the `/api/apps/*`
+ * dispatcher against a mock AppManager/plugin-manager (AppsRouteContext) over a
+ * real temp state dir on disk — no live agent runtime.
+ */
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import type http from "node:http";
 import os from "node:os";

--- a/plugins/plugin-app-manager/src/api/apps-routes.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.ts
@@ -1,3 +1,14 @@
+/**
+ * HTTP route dispatcher for the agent's `/api/apps/*` surface: app discovery
+ * and search, launch/stop/relaunch, run and favorite state, per-app permission
+ * views, hero-image streaming, and registry plugin queries. `handleAppsRoutes`
+ * returns true when it matched and handled a route, false to let the caller
+ * keep routing.
+ *
+ * Consumed by @elizaos/agent's API server. The AppManager service, plugin
+ * manager, favorites store, and runtime arrive through AppsRouteContext so
+ * tests can substitute mocks (see apps-routes.test.ts).
+ */
 import type { Dirent } from "node:fs";
 import { promises as fs } from "node:fs";
 import type http from "node:http";

--- a/plugins/plugin-app-manager/src/services/app-run-store.test.ts
+++ b/plugins/plugin-app-manager/src/services/app-run-store.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the app run store's read/write/migrate paths against real
+ * temp state dirs on disk (no mocks), including v1→v2 migration.
+ */
 import fs from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";

--- a/plugins/plugin-app-manager/src/services/app-run-store.ts
+++ b/plugins/plugin-app-manager/src/services/app-run-store.ts
@@ -1,3 +1,10 @@
+/**
+ * Persistent JSON store for hosted-app run records at
+ * `<stateDir>/apps/runs.v2.json`. Serializes AppManager's in-memory run
+ * registry, normalizing and migrating v1 files on read and writing atomically.
+ * Consumed by AppManager (the live registry) and AppSessionService (the
+ * in-runtime session gate).
+ */
 import * as fs from "node:fs";
 import path from "node:path";
 import { resolveStateDir } from "@elizaos/agent/config/paths";

--- a/plugins/plugin-app-manager/src/services/app-session-service.test.ts
+++ b/plugins/plugin-app-manager/src/services/app-session-service.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for AppSessionService: verifies it reports AppManager run state
+ * read from a real temp state dir via the run store, with no live agent runtime.
+ */
 import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-app-manager/src/services/app-session-service.ts
+++ b/plugins/plugin-app-manager/src/services/app-session-service.ts
@@ -1,3 +1,9 @@
+/**
+ * Runtime service exposing the AppManager run store to in-runtime consumers
+ * (the agent's hosted-app session gate) via `runtime.getService`. The agent
+ * queries this service rather than statically importing `readAppRunStore` from
+ * this plugin, and treats the service's absence as "no active runs".
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { Service } from "@elizaos/core";
 import {
@@ -7,13 +13,6 @@ import {
 } from "@elizaos/shared";
 import { readAppRunStore } from "./app-run-store.ts";
 
-/**
- * Runtime service exposing the AppManager run store to in-runtime consumers
- * (the agent's hosted-app session gate) via `runtime.getService`. This inverts
- * the previous host→plugin static import: the agent no longer imports
- * `readAppRunStore` from this plugin; it queries this service instead, and
- * treats its absence as "no active runs".
- */
 export class AppSessionService
   extends Service
   implements AppSessionServiceLike

--- a/plugins/plugin-app-manager/test/stubs/agent-app-package-modules.ts
+++ b/plugins/plugin-app-manager/test/stubs/agent-app-package-modules.ts
@@ -1,3 +1,4 @@
+/** Test stub for `@elizaos/agent/services/app-package-modules`: app route modules and workspace dirs always resolve to null. */
 import type { AppPackageRouteContext } from "@elizaos/core";
 
 export type AppRouteModule = {

--- a/plugins/plugin-app-manager/test/stubs/agent-overlay-app-presence.ts
+++ b/plugins/plugin-app-manager/test/stubs/agent-overlay-app-presence.ts
@@ -1,1 +1,2 @@
+/** Test stub for `@elizaos/agent/services/overlay-app-presence`: no-op presence recorder. */
 export function setOverlayAppPresence(): void {}

--- a/plugins/plugin-app-manager/test/stubs/agent-registry-client-queries.ts
+++ b/plugins/plugin-app-manager/test/stubs/agent-registry-client-queries.ts
@@ -1,3 +1,4 @@
+/** Test stub for `@elizaos/agent/services/registry-client-queries`: scoring and search return empty results. */
 export function scoreEntries<T>(): Array<{ p: T; s: number }> {
   return [];
 }

--- a/plugins/plugin-app-manager/vitest.config.ts
+++ b/plugins/plugin-app-manager/vitest.config.ts
@@ -1,3 +1,9 @@
+/**
+ * Vitest config for plugin-app-manager: aliases the `@elizaos/agent/*` and
+ * `@elizaos/auth/*` host imports to local test stubs (test/stubs/) so the
+ * library's route and service code runs under test without the full agent
+ * package.
+ */
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 

--- a/plugins/plugin-background-runner/__tests__/unit/bg-scheduler.test.ts
+++ b/plugins/plugin-background-runner/__tests__/unit/bg-scheduler.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for BgTaskSchedulerService and both scheduler implementations,
+ * using a fake BackgroundRunner and in-memory runtime (bun:test) — no native
+ * Capacitor bridge or real OS scheduler.
+ */
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import {
   BACKGROUND_RUNNER_SERVICE_TYPE,

--- a/plugins/plugin-background-runner/src/capacitor/capacitor-scheduler.ts
+++ b/plugins/plugin-background-runner/src/capacitor/capacitor-scheduler.ts
@@ -1,7 +1,3 @@
-import { elizaLogger } from '@elizaos/core';
-import type { BgSchedulerKind, IBgTaskScheduler, ScheduleOptions } from '../types.js';
-import type { BackgroundRunnerLike, CapacitorEnvironment } from './bridge.js';
-
 /**
  * Capacitor-backed background scheduler.
  *
@@ -16,6 +12,10 @@ import type { BackgroundRunnerLike, CapacitorEnvironment } from './bridge.js';
  * expected to call back into the JS context via the standard Capacitor
  * runner-event protocol. See INSTALL.md.
  */
+import { elizaLogger } from '@elizaos/core';
+import type { BgSchedulerKind, IBgTaskScheduler, ScheduleOptions } from '../types.js';
+import type { BackgroundRunnerLike, CapacitorEnvironment } from './bridge.js';
+
 export class CapacitorBgScheduler implements IBgTaskScheduler {
   readonly kind: BgSchedulerKind = 'capacitor';
 

--- a/plugins/plugin-background-runner/src/index.ts
+++ b/plugins/plugin-background-runner/src/index.ts
@@ -1,3 +1,4 @@
+/** Plugin entry: registers BgTaskSchedulerService and re-exports the scheduler types and implementations. */
 import { elizaLogger, type Plugin } from '@elizaos/core';
 import { BgTaskSchedulerService } from './services/BgTaskSchedulerService.js';
 

--- a/plugins/plugin-background-runner/src/services/BgTaskSchedulerService.ts
+++ b/plugins/plugin-background-runner/src/services/BgTaskSchedulerService.ts
@@ -1,3 +1,10 @@
+/**
+ * The plugin's service. On start it probes the Capacitor environment and picks
+ * a scheduler (CapacitorBgScheduler when native background execution is
+ * available, else IntervalBgScheduler), sets `runtime.serverless = true` so
+ * core's TaskService defers its own timer to the OS, and schedules a single
+ * periodic wake that calls `TaskService.runDueTasks()` on each fire.
+ */
 import { elizaLogger, type IAgentRuntime, Service, ServiceType } from '@elizaos/core';
 import {
   type BackgroundRunnerLike,

--- a/plugins/plugin-background-runner/src/services/IntervalBgScheduler.ts
+++ b/plugins/plugin-background-runner/src/services/IntervalBgScheduler.ts
@@ -1,6 +1,3 @@
-import { elizaLogger } from '@elizaos/core';
-import type { BgSchedulerKind, IBgTaskScheduler, ScheduleOptions } from '../types';
-
 /**
  * Pure setInterval fallback. Used when Capacitor is unavailable AND the host
  * has explicitly opted into the background runner anyway (server/desktop dev
@@ -10,6 +7,9 @@ import type { BgSchedulerKind, IBgTaskScheduler, ScheduleOptions } from '../type
  * this fallback exists so the same plugin can be loaded uniformly without
  * having to special-case mobile.
  */
+import { elizaLogger } from '@elizaos/core';
+import type { BgSchedulerKind, IBgTaskScheduler, ScheduleOptions } from '../types';
+
 export class IntervalBgScheduler implements IBgTaskScheduler {
   readonly kind: BgSchedulerKind = 'interval';
 

--- a/plugins/plugin-native-screencapture/rollup.config.mjs
+++ b/plugins/plugin-native-screencapture/rollup.config.mjs
@@ -1,3 +1,7 @@
+/**
+ * Rollup config bundling the built ESM into a single IIFE (`dist/plugin.js`)
+ * for the Capacitor native runtime, with @capacitor/core left external.
+ */
 import nodeResolve from "@rollup/plugin-node-resolve";
 
 const external = ["@capacitor/core"];

--- a/plugins/plugin-native-screencapture/src/definitions.ts
+++ b/plugins/plugin-native-screencapture/src/definitions.ts
@@ -1,3 +1,8 @@
+/**
+ * TypeScript contract for the ScreenCapture Capacitor plugin: the option,
+ * result, state, and permission interfaces plus the `ScreenCapturePlugin`
+ * method surface shared by the web, iOS, and Android implementations.
+ */
 import type { PluginListenerHandle } from "@capacitor/core";
 
 export interface ScreenshotOptions {

--- a/plugins/plugin-native-screencapture/src/index.ts
+++ b/plugins/plugin-native-screencapture/src/index.ts
@@ -1,3 +1,4 @@
+/** Entry point: registers the `ScreenCapture` Capacitor plugin, lazy-loading the web implementation, and re-exports the type contract. */
 import { registerPlugin } from "@capacitor/core";
 
 import type { ScreenCapturePlugin } from "./definitions";

--- a/plugins/plugin-native-screencapture/src/web.test.ts
+++ b/plugins/plugin-native-screencapture/src/web.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for ScreenCaptureWeb using fake MediaRecorder, track, and
+ * getDisplayMedia doubles — no real browser capture APIs.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ScreenCaptureWeb } from "./web";

--- a/plugins/plugin-native-screencapture/src/web.ts
+++ b/plugins/plugin-native-screencapture/src/web.ts
@@ -1,3 +1,10 @@
+/**
+ * Browser implementation of the ScreenCapture plugin, backed by getDisplayMedia,
+ * MediaRecorder, and the ImageCapture API. Used directly in browsers and, via
+ * the Node runtime path, in the Electrobun desktop shell. getDisplayMedia always
+ * prompts the user, so permission state is reported as prompt/not_supported
+ * rather than queried.
+ */
 import { WebPlugin } from "@capacitor/core";
 
 import type {


### PR DESCRIPTION
Part of #12181 (comment-cleanup swarm). Batch **B17** slice: three device/app plugins — `plugin-app-manager`, `plugin-background-runner`, `plugin-native-screencapture`.

## What changed (comment-only)
- **Prose file headers** added to every in-scope file in these three plugins that lacked one (20 files), written from reading the code and each plugin's `CLAUDE.md` — stating the file's system role, not the filename.
- **Churn removed / rewritten** to present-tense fact:
  - `plugin-app-manager/build.ts` — "overrides the hand-rolled build previously passed on the tsc CLI" rewritten to a present-tense description of the tsconfig.build.json overrides.
  - `plugin-app-manager/src/services/app-session-service.ts` — dropped the "this inverts the previous host→plugin static import / the agent no longer imports…" narration; the durable fact (agent queries the service instead of importing `readAppRunStore`) now lives in the new file header.
  - `capacitor-scheduler.ts` / `IntervalBgScheduler.ts` — existing class JSDoc relocated above the imports to serve as the file header (no wording change).
- **Kept as-is** (durable, not churn): `plugin-background-runner/src/types.ts:17` "a second call replaces the previous registration" (idempotency contract); `plugin-native-screencapture/src/web.ts` "no way to check if permission was previously granted" (present-tense getDisplayMedia API limitation).

## Tallies
- Files touched: **21** (11 app-manager, 5 background-runner, 5 screencapture).
- Headers added: **20**; churn comments rewritten/removed: **2**; comment blocks relocated: **2**.
- filesFlagged (purpose undeterminable): **none**.

## Verification
- **comment-only; `check:comment-only` PASSES:** `[assert-comment-only-diff] OK — 21 source file(s) changed; every code token identical to origin/develop. Comments only.`
- Header self-audit over the three plugins prints nothing (every in-scope file now opens with a comment).

Trajectory / screenshot / video / audio / domain-artifact evidence: **N/A — comments-only change, zero functional diff (machine-checked by `scripts/assert-comment-only-diff.mjs`).**

Refs #12247

🤖 Generated with [Claude Code](https://claude.com/claude-code)
