### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-pages-b

### DIFF
--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -1,3 +1,12 @@
+/**
+ * The Browser workspace view (`/browser`): a tabbed embedded-browser surface
+ * with a collapsible sidebar for tab management and companion-bridge status.
+ *
+ * Tabs, navigation, and snapshots flow through the `client` browser API; on
+ * native the tabs render via a registered renderer impl
+ * (`browser-tabs-renderer-registry`), while desktop/web fall back to the
+ * companion bridge. Mounted in `App.tsx` under the `browser` route key.
+ */
 import { Capacitor } from "@capacitor/core";
 import {
   ExternalLink,

--- a/packages/ui/src/components/pages/CameraPageView.tsx
+++ b/packages/ui/src/components/pages/CameraPageView.tsx
@@ -1,15 +1,3 @@
-import {
-  Camera,
-  type CameraDirection,
-  type PhotoResult,
-} from "@elizaos/capacitor-camera";
-import { AlertTriangle, Loader2, RotateCcw, SwitchCamera } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { appNameInterpolationVars, useBranding } from "../../config/branding";
-import { useTranslation } from "../../state/TranslationContext.hooks";
-import { PermissionRecoveryCallout } from "../permissions/PermissionRecoveryCallout";
-import { Button } from "../ui/button";
-
 /**
  * The Camera surface — a live preview with capture and front/back switching,
  * backed by the `@elizaos/capacitor-camera` bridge. On the AOSP ElizaOS fork the
@@ -21,6 +9,17 @@ import { Button } from "../ui/button";
  * itself is platform-agnostic — it degrades to a permission/error state when no
  * camera is reachable rather than dead-ending.
  */
+import {
+  Camera,
+  type CameraDirection,
+  type PhotoResult,
+} from "@elizaos/capacitor-camera";
+import { AlertTriangle, Loader2, RotateCcw, SwitchCamera } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { appNameInterpolationVars, useBranding } from "../../config/branding";
+import { useTranslation } from "../../state/TranslationContext.hooks";
+import { PermissionRecoveryCallout } from "../permissions/PermissionRecoveryCallout";
+import { Button } from "../ui/button";
 
 type PreviewStatus = "starting" | "live" | "denied" | "error";
 

--- a/packages/ui/src/components/pages/ChatView.stories.tsx
+++ b/packages/ui/src/components/pages/ChatView.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook stories for `ChatView`. Runs against `mockApp` (no backend); sample
+ * messages use a fixed epoch (`NOW`) so story-gate screenshots stay byte-stable.
+ */
 import type { Decorator, Meta, StoryObj } from "@storybook/react";
 import type { ConversationMessage } from "../../api/client-types-chat";
 import { ConversationMessagesCtx } from "../../state/ConversationMessagesContext.hooks";

--- a/packages/ui/src/components/pages/ConfigPageView.stories.tsx
+++ b/packages/ui/src/components/pages/ConfigPageView.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook stories for `ConfigPageView` (RPC provider + Cloud config). Runs
+ * against `mockApp`; the Cloud-connected and signed-out states are driven by the
+ * `elizaCloudConnected` mock flag, with static wallet-config fixtures.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { mockApp } from "../../storybook/mock-providers.helpers";
 import { ConfigPageView } from "./ConfigPageView";

--- a/packages/ui/src/components/pages/DatabaseView.tsx
+++ b/packages/ui/src/components/pages/DatabaseView.tsx
@@ -1,3 +1,12 @@
+/**
+ * The Database view (`/database`): browse the agent's SQL store — tables, rows,
+ * and an ad-hoc query editor — behind a segmented Tables/SQL control.
+ *
+ * Status, table list, and rows are read through the `client` database API and
+ * seeded from `resource-cache` so a revisit paints the last-known shape while it
+ * revalidates. Segmented tabs register with the agent surface via ref-less
+ * `ViewModeTab` children (the SegmentedControl doesn't forward refs).
+ */
 import {
   ChevronLeft,
   ChevronRight,

--- a/packages/ui/src/components/pages/DocumentsView.tsx
+++ b/packages/ui/src/components/pages/DocumentsView.tsx
@@ -1,3 +1,13 @@
+/**
+ * The knowledge-documents surface: lists, searches, uploads, and deletes the
+ * agent's knowledge documents, scoped by ownership (agent / user / shared).
+ *
+ * Rendered inside `KnowledgeView` (the `/documents` route) and also reusable in
+ * embedded/modal form. Reads/writes through the `client` documents API, seeds
+ * from `resource-cache` for instant revisits, and binds the floating chat
+ * composer as its search box via `useRegisterViewChatBinding`. Upload compresses
+ * large images (`documents-upload-image`) before sending.
+ */
 import {
   BadgeCheck,
   Bot,

--- a/packages/ui/src/components/pages/ElizaCloudDashboard.tsx
+++ b/packages/ui/src/components/pages/ElizaCloudDashboard.tsx
@@ -1,3 +1,14 @@
+/**
+ * The Eliza Cloud account dashboard: billing summary, balance top-up (Stripe
+ * embedded checkout), auto-top-up settings, spend limits, and managed
+ * Discord/GitHub connection callbacks.
+ *
+ * Reads and mutates through the `client` cloud-billing API; the pure shaping and
+ * normalization helpers live in `cloud-dashboard-utils`. Mounted as the
+ * `CloudDashboard` route in the desktop detached shell (`DetachedShellRoot`).
+ * Locks itself out when the mobile runtime is Cloud-locked
+ * (`isElizaCloudRuntimeLocked`).
+ */
 import {
   ArrowLeft,
   CreditCard,

--- a/packages/ui/src/components/pages/Launcher.stories.tsx
+++ b/packages/ui/src/components/pages/Launcher.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook stories for `Launcher` — the presentational tile grid. Drives it
+ * with hand-built `ViewEntry` fixtures (no data hooks), covering the populated
+ * grid and the launch interaction.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ViewEntry } from "../../hooks/view-catalog";
 import { assert } from "../../storybook/home-widget-decorator";

--- a/packages/ui/src/components/pages/LauncherSurface.tsx
+++ b/packages/ui/src/components/pages/LauncherSurface.tsx
@@ -1,3 +1,10 @@
+/**
+ * Data + state wrapper around `Launcher`: pulls the routable views, filters them
+ * by the user's enabled view kinds and active modality, curates them into pages
+ * (`curateLauncherPages`), and wires tile taps to view navigation, chat-open,
+ * and the tutorial start. `Launcher` itself is pure presentation; this component
+ * owns the runtime data so the rail/home shell can mount it directly.
+ */
 import * as React from "react";
 import { dispatchChatOpen } from "../../events";
 import { useRoutableViews } from "../../hooks/useAvailableViews";

--- a/packages/ui/src/components/pages/LogsView.test.tsx
+++ b/packages/ui/src/components/pages/LogsView.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Renders `LogsView` in jsdom with mocked state/agent-surface to verify the
+ * loading skeleton reserves tall row-shaped space and that the first hydration
+ * swap is flagged transient (no layout-shift flash on initial paint).
+ */
+
 import { act, cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/pages/MediaGalleryView.stories.tsx
+++ b/packages/ui/src/components/pages/MediaGalleryView.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook stories for `MediaGalleryView` under `withMockApp` (no backend). */
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { MediaGalleryView } from "./MediaGalleryView";

--- a/packages/ui/src/components/pages/MemoryDetailPanel.tsx
+++ b/packages/ui/src/components/pages/MemoryDetailPanel.tsx
@@ -1,3 +1,8 @@
+/**
+ * Read-only detail panel for a single memory record: renders its metadata and
+ * pretty-printed content as a `CodeBlock`. Sits beside the memory list in the
+ * Memory Viewer view; shows an empty state when no record is selected.
+ */
 import { useMemo } from "react";
 import { useTranslation } from "../../state";
 import { PagePanel } from "../composites/page-panel";

--- a/packages/ui/src/components/pages/PluginCard.tsx
+++ b/packages/ui/src/components/pages/PluginCard.tsx
@@ -1,3 +1,10 @@
+/**
+ * One row/tile in `PluginsView`: shows a plugin's visual, name, and description,
+ * an enable/disable toggle (agent-controllable via `useAgentElement`), an
+ * expandable settings section (`PluginConfigForm`), and drag handles for
+ * reordering. Pure presentation — all state and mutation callbacks are owned by
+ * `PluginsView` and passed in as props.
+ */
 import { memo } from "react";
 import { useAgentElement } from "../../agent-surface";
 import type { PluginInfo, PluginParamDef } from "../../api";

--- a/packages/ui/src/components/pages/PluginConfigForm.tsx
+++ b/packages/ui/src/components/pages/PluginConfigForm.tsx
@@ -1,3 +1,10 @@
+/**
+ * Renders a plugin's configurable parameters as a form, inside the expanded
+ * settings section of a `PluginCard`. Derives a config schema from the plugin's
+ * declared parameters, merges server-provided `configUiHints` over the
+ * auto-generated ones (server wins), and drives the shared `ConfigRenderer`.
+ * Value changes flow back out through `onParamChange`.
+ */
 import { useCallback, useMemo, useRef, useState } from "react";
 import type { PluginInfo, PluginParamDef } from "../../api";
 import { ConfigRenderer } from "../../components/config-ui/config-renderer";

--- a/packages/ui/src/components/pages/PluginsView.reorder.test.tsx
+++ b/packages/ui/src/components/pages/PluginsView.reorder.test.tsx
@@ -1,16 +1,16 @@
 // @vitest-environment jsdom
-//
-// Native HTML5 drag-to-reorder coverage for the plugin catalog (#10722). The
-// PluginCard rows are `draggable` and the reorder is driven entirely by native
-// dragstart → dragover → drop events wired through PluginListView. Before this
-// there was zero coverage, so a regression in the splice/persist logic (dropped
-// order, a duplicated id, an `undefined` slot, or a lost localStorage write)
-// would ship silently.
-//
-// These tests dispatch real drag events and assert the SEMANTIC outcome: the
-// rendered card order actually changes, the new order persists to
-// localStorage, the persisted list has no duplicate/undefined ids, and a drop
-// onto the same card is a no-op (nothing reordered, nothing persisted).
+
+/**
+ * Native HTML5 drag-to-reorder coverage for the plugin catalog (#10722). The
+ * `PluginCard` rows are `draggable` and reorder is driven by native
+ * dragstart → dragover → drop events through `PluginListView`.
+ *
+ * The tests dispatch real drag events and assert the SEMANTIC outcome: the
+ * rendered card order changes, the new order persists to localStorage, the
+ * persisted list has no duplicate/undefined ids, and a drop onto the same card
+ * is a no-op — guarding the splice/persist logic against dropped order,
+ * duplicated/undefined slots, or a lost write.
+ */
 
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/pages/PluginsView.tsx
+++ b/packages/ui/src/components/pages/PluginsView.tsx
@@ -1,3 +1,15 @@
+/**
+ * The Plugins / Connectors view (`/plugins`): lists installed plugins, filters
+ * them by tag, and lets the user enable/disable, reorder, and configure each one.
+ * The same component serves multiple modes (`all` / `connectors` / `social`),
+ * driven by the `mode` prop, so the plugins and connectors surfaces share one
+ * data path.
+ *
+ * Rows are rendered by `PluginCard`; connector-specific setup (OAuth, credential
+ * dialogs) is delegated to the `plugin-view-connectors` / `plugin-view-dialogs`
+ * helpers. Plugin data and toggle/reorder mutations flow through the `client`
+ * plugins API. Reorder persistence is gated by the developer-order toggle.
+ */
 import { Package, Puzzle } from "lucide-react";
 import {
   type ReactNode,

--- a/packages/ui/src/components/pages/RelationshipsIdentityCluster.tsx
+++ b/packages/ui/src/components/pages/RelationshipsIdentityCluster.tsx
@@ -1,3 +1,8 @@
+/**
+ * Lists the linked identities of a person in the Relationships view — one row
+ * per merged identity, showing its platform, primary name, and handle/entity id.
+ * Renders nothing when the person has no identities.
+ */
 import { Fingerprint } from "lucide-react";
 import type { RelationshipsPersonDetail } from "../../api/client-types-relationships";
 

--- a/packages/ui/src/components/pages/ReleaseCenterView.tsx
+++ b/packages/ui/src/components/pages/ReleaseCenterView.tsx
@@ -1,3 +1,11 @@
+/**
+ * The Release Center view: surfaces the agent runtime and desktop-app update
+ * state — current versions, available updates, and check/apply actions — plus a
+ * configurable release-notes link. Desktop update controls only appear under the
+ * Electrobun runtime; elsewhere the view degrades to runtime-update status only.
+ * State flows through the app store's update snapshots and the desktop updater
+ * bridge.
+ */
 import {
   AlertTriangle,
   CheckCircle2,

--- a/packages/ui/src/components/pages/ScheduledTaskEditor.test.tsx
+++ b/packages/ui/src/components/pages/ScheduledTaskEditor.test.tsx
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+
+/**
+ * jsdom tests for `ScheduledTaskEditor` over a mocked `applyScheduledTask` client:
+ * verifies verb routing (run-now / acknowledge / snooze / complete / dismiss),
+ * the correct label per task kind, and error surfacing when a verb fails.
+ */
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/pages/SecretsView.tsx
+++ b/packages/ui/src/components/pages/SecretsView.tsx
@@ -1,3 +1,10 @@
+/**
+ * The Secrets view: lists, edits, and saves the agent's secret/env values,
+ * grouped and pinnable, with masked reveal-on-demand and a picker for adding
+ * known keys. Reads/writes through the `client` secrets API; seeds from
+ * `resource-cache` for instant revisits. Pinned keys persist in localStorage
+ * (best-effort — pinning is cosmetic, so a storage failure is swallowed).
+ */
 import { ChevronDown } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import type { SecretInfo } from "../../api";

--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -1,3 +1,10 @@
+/**
+ * The Settings view (`/settings`): a sectioned settings surface that adapts
+ * between a two-pane rail+detail layout on wide/landscape viewports and a
+ * single-column hub on narrow ones. Section content is lazy-loaded and gated by
+ * `isViewVisible`; `initialSection` deep-links a specific pane. Also reusable in
+ * modal form (`inModal`).
+ */
 import { isViewVisible } from "@elizaos/core";
 import { ArrowLeft } from "lucide-react";
 import type * as React from "react";

--- a/packages/ui/src/components/pages/SkillsView.tsx
+++ b/packages/ui/src/components/pages/SkillsView.tsx
@@ -1,3 +1,10 @@
+/**
+ * The Skills view (`/skills`): browses the agent's installed runtime skills and
+ * the skill marketplace for installing new ones. Renders a full-page layout or a
+ * compact modal variant depending on the `inModal` prop. Skill data and
+ * install/create mutations come from the app store; tiles register with the
+ * agent surface via `useAgentElement`.
+ */
 import { Brain, Store } from "lucide-react";
 import { memo, type ReactNode, useEffect, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";

--- a/packages/ui/src/components/pages/StreamView.tsx
+++ b/packages/ui/src/components/pages/StreamView.tsx
@@ -1,3 +1,9 @@
+/**
+ * The Stream view: shows the agent's live ffmpeg stream status (running,
+ * uptime, frame count) and controls to start/stop it. Polls `client.streamStatus`
+ * and seeds from `resource-cache` for instant revisits; degrades to an
+ * unavailable state when no stream backend responds. Reusable in modal form.
+ */
 import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../../api/client";
 import { isApiError } from "../../api/client-types-core";

--- a/packages/ui/src/components/pages/TrajectoriesView.tsx
+++ b/packages/ui/src/components/pages/TrajectoriesView.tsx
@@ -1,3 +1,10 @@
+/**
+ * The Trajectories view: a paginated, searchable list of recorded model
+ * trajectories (scenario/batch runs) with per-row select, download, and delete.
+ * Selection can be controlled by a parent (master/detail) or self-managed
+ * standalone. Binds the floating chat composer as its search box; data and
+ * mutations flow through the trajectories API.
+ */
 import { Download, Route, Trash2, XCircle } from "lucide-react";
 import {
   type ComponentProps,

--- a/packages/ui/src/components/pages/TriggerForm.tsx
+++ b/packages/ui/src/components/pages/TriggerForm.tsx
@@ -1,3 +1,10 @@
+/**
+ * Create/edit form for a workflow trigger (cron or event), with run-history,
+ * enable toggle, run-now, save-as-template, and delete affordances. Fully
+ * controlled: all form state and mutation callbacks are owned by the parent
+ * (`TriggersView`) and passed in, so this file is presentation plus local
+ * validation (e.g. cron-expression checking) only.
+ */
 import { useEffect, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import { client } from "../../api";

--- a/packages/ui/src/components/pages/WalletSectionNav.test.tsx
+++ b/packages/ui/src/components/pages/WalletSectionNav.test.tsx
@@ -1,4 +1,11 @@
 // @vitest-environment jsdom
+
+/**
+ * jsdom tests for `WalletSectionNav` and `isWalletSectionPath`: exercises the
+ * real app-shell page registry to confirm active-route matching, alias
+ * resolution to Wallet, and that a sub-view stops matching when its registration
+ * is absent.
+ */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { registerAppShellPage } from "../../app-shell-registry";

--- a/packages/ui/src/components/pages/WorkflowEditor.test.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * jsdom tests for `WorkflowEditor` over a mocked `client` API: renders the graph,
+ * runs a saved workflow and shows node output, keeps the editor open after a new
+ * save, and restores a selected version from history.
+ */
+
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/pages/WorkflowGraphViewer.tsx
+++ b/packages/ui/src/components/pages/WorkflowGraphViewer.tsx
@@ -1,3 +1,11 @@
+/**
+ * Renders a workflow definition as an interactive node graph via `@xyflow/react`
+ * (React Flow) — nodes, edges, minimap, controls, and a full-screen mode. Used in
+ * the workflow editor to visualize a workflow's trigger + steps; node clicks and
+ * the empty-state CTA route back to the parent editor. Loading and generating
+ * states are distinct so an in-flight AI generation reads differently from a
+ * plain fetch.
+ */
 import {
   Background,
   Controls,

--- a/packages/ui/src/components/pages/__e2e__/connectors-fixture.tsx
+++ b/packages/ui/src/components/pages/__e2e__/connectors-fixture.tsx
@@ -1,13 +1,14 @@
-// Self-contained fixture for the connectors-card e2e: mounts the REAL
-// `ConnectorPluginGroups` (plugin-view-connectors.tsx) with one expanded
-// Signal connector. Signal's default mode is `plugin-managed`, whose setup
-// panel is delegated to `connector-account-management:signal:signal` — a
-// different plugin id than the card's own — which is exactly the
-// `setupPanelPluginId !== plugin.id` case #10705 fixes. The real
-// `PluginConfigForm` and the real `ConnectorSetupPanel` (account list fed by
-// the canned api stub) both render; only the `state`/`api` barrels are
-// stubbed (see connectors-fixture-*-stub.ts). No app server, no network.
-// Paired with run-connectors-e2e.mjs.
+/**
+ * Self-contained fixture for the connectors-card e2e: mounts the REAL
+ * `ConnectorPluginGroups` (plugin-view-connectors.tsx) with one expanded Signal
+ * connector. Signal's default mode is `plugin-managed`, whose setup panel is
+ * delegated to `connector-account-management:signal:signal` — a different plugin
+ * id than the card's own — which is exactly the `setupPanelPluginId !== plugin.id`
+ * case (#10705). The real `PluginConfigForm` and `ConnectorSetupPanel` (account
+ * list fed by the canned api stub) both render; only the `state`/`api` barrels
+ * are stubbed (see connectors-fixture-*-stub.ts). No app server, no network.
+ * Paired with run-connectors-e2e.mjs.
+ */
 
 import * as React from "react";
 import { createRoot } from "react-dom/client";

--- a/packages/ui/src/components/pages/__e2e__/suggestions-fixture.tsx
+++ b/packages/ui/src/components/pages/__e2e__/suggestions-fixture.tsx
@@ -1,19 +1,21 @@
-// Browser fixture for the proactive-suggestions e2e (#8792) — phase 2 of
-// run-suggestions-e2e.mjs.
-//
-// Renders the REAL transcript pipeline a governed proactive comment flows
-// through on the client: the real `parseProactiveMessageEvent` WS-frame parser
-// (state/parsers — the exact function the shell's `proactive-message` WS
-// subscriber calls) feeding the real `ChatTranscript` → `ChatMessage`
-// composites, which render the #8792 suggestion affordance (Suggestion chip +
-// "Do it" + dismiss) for `source: "proactive-interaction"` messages.
-//
-// The dismiss/accept handlers mirror ChatView's wiring exactly: dismiss removes
-// the bubble locally; accept sends "Yes, let's do it." as a normal turn and
-// then clears the bubble. The runner feeds this fixture REAL frames captured
-// from the real server pipeline (views/interactions routes → decider → gate →
-// routeAutonomyTextToUser → broadcast) in phase 1 — no hand-written frames for
-// the happy path.
+/**
+ * Browser fixture for the proactive-suggestions e2e (#8792) — phase 2 of
+ * run-suggestions-e2e.mjs.
+ *
+ * Renders the REAL transcript pipeline a governed proactive comment flows
+ * through on the client: the real `parseProactiveMessageEvent` WS-frame parser
+ * (state/parsers — the exact function the shell's `proactive-message` WS
+ * subscriber calls) feeding the real `ChatTranscript` → `ChatMessage`
+ * composites, which render the #8792 suggestion affordance (Suggestion chip +
+ * "Do it" + dismiss) for `source: "proactive-interaction"` messages.
+ *
+ * The dismiss/accept handlers mirror ChatView's wiring exactly: dismiss removes
+ * the bubble locally; accept sends "Yes, let's do it." as a normal turn and then
+ * clears the bubble. The runner feeds this fixture REAL frames captured from the
+ * real server pipeline (views/interactions routes → decider → gate →
+ * routeAutonomyTextToUser → broadcast) in phase 1 — no hand-written frames for
+ * the happy path.
+ */
 
 import * as React from "react";
 import { useCallback, useLayoutEffect, useState } from "react";

--- a/packages/ui/src/components/pages/background-image.test.ts
+++ b/packages/ui/src/components/pages/background-image.test.ts
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+
+/**
+ * Unit tests for `fileToBackgroundDataUrl` — the image-to-data-URL conversion
+ * behind the background picker. jsdom decodes no images and has no canvas, so
+ * the harness stubs `Image` (see `FakeImage`) and asserts the pass-through path.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   BackgroundImageError,

--- a/packages/ui/src/components/pages/browser-workspace-wallet.test.ts
+++ b/packages/ui/src/components/pages/browser-workspace-wallet.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the browser-workspace wallet helpers: EVM chain-id parsing,
+ * unsupported-chain error shaping, and request dispatch. Pure functions with a
+ * stubbed dispatch target — no browser, no bridge.
+ */
 import { describe, expect, it, vi } from "vitest";
 import type { BrowserWorkspaceTab } from "../../api";
 import {

--- a/packages/ui/src/components/pages/chat-view-hooks.test.tsx
+++ b/packages/ui/src/components/pages/chat-view-hooks.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * jsdom `renderHook` tests for `useChatVoiceController` over a mocked
+ * `useVoiceChat`: pins the audio-unlock ordering (speech queued by the same
+ * gesture that unlocks audio is not cancelled) and message-play telemetry.
+ */
+
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useVoiceChat } from "../../hooks/useVoiceChat";

--- a/packages/ui/src/components/pages/cloud-dashboard-utils.ts
+++ b/packages/ui/src/components/pages/cloud-dashboard-utils.ts
@@ -1,3 +1,10 @@
+/**
+ * Pure shaping, normalization, and callback-parsing helpers for
+ * `ElizaCloudDashboard` — billing summary/settings normalizers, the auto-top-up
+ * form reducer, checkout-URL resolution, status-badge maps, and the managed
+ * Discord/GitHub OAuth callback-URL consumers. No React, no network: the view
+ * owns the `client` calls; this module keeps the derivation out of the component.
+ */
 import type {
   CloudBillingCheckoutResponse,
   CloudBillingSettings,

--- a/packages/ui/src/components/pages/config-page-sections.tsx
+++ b/packages/ui/src/components/pages/config-page-sections.tsx
@@ -1,6 +1,8 @@
 /**
- * Sub-components and helpers for ConfigPageView.
- * Extracted from ConfigPageView.tsx.
+ * Section sub-components and their shared types for `ConfigPageView`: the RPC
+ * provider config section (per-chain provider selection + key entry), the cloud
+ * RPC status readout, and the cloud-services section. Types (`RpcFieldGroup`,
+ * `RpcSectionConfigMap`, translate-fn aliases) are exported for the parent view.
  */
 
 import { normalizeFirstRunProviderId } from "@elizaos/shared";

--- a/packages/ui/src/components/pages/database-utils.tsx
+++ b/packages/ui/src/components/pages/database-utils.tsx
@@ -1,3 +1,9 @@
+/**
+ * Presentational building blocks for `DatabaseView`: the results grid, a cell
+ * value popover, the pagination bar, and the shared `DbView`/`SortDir` types.
+ * These render query/table results the view fetches; they hold no data of their
+ * own.
+ */
 import type { ColumnInfo } from "../../api";
 import { useAppSelector } from "../../state";
 import { Badge } from "../ui/badge";

--- a/packages/ui/src/components/pages/documents-detail.test.tsx
+++ b/packages/ui/src/components/pages/documents-detail.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
-//
-// Regression coverage for the document detail (knowledge) viewer load path.
-// The #8876 screenshot review of the populated Knowledge view surfaced a real
-// bug: when the detail response lacked a `document`, the viewer read `.content`
-// of `undefined` and leaked a raw "Cannot read properties of undefined
-// (reading 'content')" TypeError as the user-facing error. These tests pin the
-// clean degraded message and the happy path.
+
+/**
+ * Regression coverage for the document detail (knowledge) viewer load path
+ * (#8876). When the detail response lacks a `document`, the viewer must not read
+ * `.content` of `undefined` and leak a raw TypeError as the user-facing error;
+ * these tests pin the clean degraded message and the happy path.
+ */
 
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/pages/documents-upload.dnd.test.tsx
+++ b/packages/ui/src/components/pages/documents-upload.dnd.test.tsx
@@ -1,18 +1,19 @@
 // @vitest-environment jsdom
-//
-// Native HTML5 file-drop coverage for the Knowledge/Documents upload surface
-// (#10722). Before this, the drag-and-drop upload path — the ONLY drag-drop
-// affordance on the shipped documents surface — had zero tests. These drive a
-// real `drop` DOM event carrying a populated `dataTransfer.files` and assert
-// the SEMANTIC outcome:
-//
-//   • UploadZone.handleDrop  → onFilesUpload fires with the dropped File(s) and
-//     the zone's live scope options; a same-node drop does not bubble into the
-//     DocumentsView root (stopPropagation), so it never double-uploads.
-//   • DocumentsView root drop → the real handleFilesUpload validation +
-//     batching path runs and client.uploadDocumentsBulk is called with the
-//     dropped file's decoded content. Wrong-type / empty / no-file drops are
-//     rejected before any network call.
+
+/**
+ * Native HTML5 file-drop coverage for the Knowledge/Documents upload surface
+ * (#10722) — the only drag-drop upload affordance on the documents surface. The
+ * tests drive a real `drop` DOM event carrying a populated `dataTransfer.files`
+ * and assert the SEMANTIC outcome:
+ *
+ *   • UploadZone.handleDrop  → onFilesUpload fires with the dropped File(s) and
+ *     the zone's live scope options; a same-node drop does not bubble into the
+ *     DocumentsView root (stopPropagation), so it never double-uploads.
+ *   • DocumentsView root drop → the real handleFilesUpload validation +
+ *     batching path runs and client.uploadDocumentsBulk is called with the
+ *     dropped file's decoded content. Wrong-type / empty / no-file drops are
+ *     rejected before any network call.
+ */
 
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/pages/documents-upload.tsx
+++ b/packages/ui/src/components/pages/documents-upload.tsx
@@ -1,3 +1,9 @@
+/**
+ * The document-upload UI for `DocumentsView`: the `UploadZone` (file picker,
+ * drag-drop, pasted-text, and URL ingestion) plus its scope controls. Upload
+ * intents are handed back to the parent view's handlers; this file owns the
+ * input surface, not the network call.
+ */
 import {
   Bot,
   FileUp,

--- a/packages/ui/src/components/pages/help/HelpView.tsx
+++ b/packages/ui/src/components/pages/help/HelpView.tsx
@@ -1,3 +1,10 @@
+/**
+ * Help — a knowledge base searched through the floating chat. There's no search
+ * box of its own: while Help is open it takes over the chat composer (placeholder
+ * "Ask a question about Eliza…") and receives the live draft, pulling up the best
+ * matching answer here as you type. You can also browse the common questions and
+ * deep-link straight to the relevant screen.
+ */
 import { LifeBuoy } from "lucide-react";
 import * as React from "react";
 
@@ -15,14 +22,6 @@ import {
   type HelpDeepLink,
   type HelpEntry,
 } from "./help-content";
-
-/**
- * Help — a knowledge base searched through the floating chat. There's no search
- * box of its own: while Help is open it takes over the chat composer (placeholder
- * "Ask a question about Eliza…") and receives the live draft, pulling up the best
- * matching answer here as you type. You can also browse the common questions and
- * deep-link straight to the relevant screen.
- */
 
 function scoreEntry(entry: HelpEntry, q: string): number {
   if (!q) return 1;

--- a/packages/ui/src/components/pages/launcher-curation.test.ts
+++ b/packages/ui/src/components/pages/launcher-curation.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for `curateLauncherPages` / `canonicalLauncherId` — the pure
+ * launcher-page composition (system + release always, developer + preview gated
+ * by their toggles) that `LauncherSurface` feeds into `Launcher`.
+ */
 import { describe, expect, it } from "vitest";
 import type { ViewEntry } from "../../hooks/view-catalog";
 import { canonicalLauncherId, curateLauncherPages } from "./launcher-curation";

--- a/packages/ui/src/components/pages/page-scoped-conversations.ts
+++ b/packages/ui/src/components/pages/page-scoped-conversations.ts
@@ -1,3 +1,11 @@
+/**
+ * Page-scoped conversation model: maps each page scope (browser, character,
+ * plugins, wallet, …) to its routing contexts and empty-state intro copy, and
+ * provides the helpers that tag, detect, and build metadata for conversations
+ * bound to a specific page. `PAGE_SCOPE_VERSION` stamps trajectories so later
+ * prompt-optimization passes can cohort by surface contract; bump it when a
+ * scope's brief, copy, or live-state shape changes meaningfully.
+ */
 import type { PageScope } from "@elizaos/shared/contracts";
 import { client } from "../../api";
 import type {

--- a/packages/ui/src/components/pages/plugin-view-connectors.test.ts
+++ b/packages/ui/src/components/pages/plugin-view-connectors.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for `shouldRenderConnectorPluginConfig` — the pure predicate that
+ * decides whether a connector's local config params render alongside a companion
+ * setup panel in `PluginsView`.
+ */
 import { describe, expect, it } from "vitest";
 import { shouldRenderConnectorPluginConfig } from "./plugin-view-connectors";
 

--- a/packages/ui/src/components/pages/plugin-view-dialogs.tsx
+++ b/packages/ui/src/components/pages/plugin-view-dialogs.tsx
@@ -1,3 +1,9 @@
+/**
+ * The plugin settings dialog for `PluginsView`: shows a plugin's config form,
+ * install progress, save/test results, and install/reset/save actions in a
+ * modal. Fully controlled — all state and callbacks are owned by the parent
+ * view and passed in as props.
+ */
 import { CheckCircle2 } from "lucide-react";
 import { useAgentElement } from "../../agent-surface";
 import type { PluginInfo } from "../../api";

--- a/packages/ui/src/components/pages/plugin-view-sidebar.tsx
+++ b/packages/ui/src/components/pages/plugin-view-sidebar.tsx
@@ -1,3 +1,10 @@
+/**
+ * The connector-mode sidebar for `PluginsView`: a collapsible rail/panel that
+ * lists connector plugins, groups them by subgroup tag, and drives selection +
+ * per-connector enable toggles. Registers its rail/viewport/items with the agent
+ * surface so the sidebar is agent-navigable. Presentation only — state lives in
+ * the parent view.
+ */
 import { ChevronRight } from "lucide-react";
 import type { ReactNode, RefCallback, RefObject } from "react";
 import { useAgentElement } from "../../agent-surface";

--- a/packages/ui/src/components/pages/relationships/RelationshipsCandidateMergesPanel.tsx
+++ b/packages/ui/src/components/pages/relationships/RelationshipsCandidateMergesPanel.tsx
@@ -1,3 +1,10 @@
+/**
+ * Panel in the Relationships view listing candidate identity merges the merge
+ * engine has proposed, each with its evidence summary and Accept/Reject buttons
+ * (`client.acceptRelationshipsCandidate` / `rejectRelationshipsCandidate`).
+ * Resolving one calls back to the parent to refresh the graph. Renders nothing
+ * when there are no candidates.
+ */
 import {
   CalendarClock,
   Check,

--- a/packages/ui/src/components/pages/relationships/RelationshipsSidebar.tsx
+++ b/packages/ui/src/components/pages/relationships/RelationshipsSidebar.tsx
@@ -1,3 +1,8 @@
+/**
+ * The person-list sidebar for the Relationships view: renders the graph's people
+ * as a selectable list and forwards `PageLayout`'s layout-injected sidebar props
+ * (variant/close/className) so the mobile drawer renders its chrome correctly.
+ */
 import { Crown } from "lucide-react";
 import type { RelationshipsGraphSnapshot } from "../../../api/client-types-relationships";
 import { SidebarContent } from "../../composites/sidebar/sidebar-content";

--- a/packages/ui/src/components/pages/relationships/relationships-utils.ts
+++ b/packages/ui/src/components/pages/relationships/relationships-utils.ts
@@ -1,3 +1,8 @@
+/**
+ * Pure formatting and derivation helpers shared across the Relationships view
+ * components: builds the graph query, sorts/labels people, summarizes handles
+ * and contacts, and renders merge-candidate evidence. No React, no I/O.
+ */
 import type {
   RelationshipsGraphQuery,
   RelationshipsGraphSnapshot,

--- a/packages/ui/src/components/pages/tutorial/TutorialNarrator.tsx
+++ b/packages/ui/src/components/pages/tutorial/TutorialNarrator.tsx
@@ -1,8 +1,3 @@
-import * as React from "react";
-import { useVoiceChat } from "../../../hooks/useVoiceChat";
-import { useAppSelector } from "../../../state";
-import { useVoiceConfig } from "../../../voice/useVoiceConfig";
-
 /**
  * Speaks the current tour frame aloud through the app's REAL voice pipeline
  * (the same {@link useVoiceChat} engine that voices assistant replies — cloud /
@@ -10,6 +5,11 @@ import { useVoiceConfig } from "../../../voice/useVoiceConfig";
  * hack. Mounted only while the tour is active, so the engine isn't spun up when
  * idle. Renders nothing; `utteranceId` changing (re)speaks `text`.
  */
+import * as React from "react";
+import { useVoiceChat } from "../../../hooks/useVoiceChat";
+import { useAppSelector } from "../../../state";
+import { useVoiceConfig } from "../../../voice/useVoiceConfig";
+
 export function TutorialNarrator({
   utteranceId,
   text,

--- a/packages/ui/src/components/pages/tutorial/TutorialSpotlight.tsx
+++ b/packages/ui/src/components/pages/tutorial/TutorialSpotlight.tsx
@@ -1,9 +1,3 @@
-import { Volume2, VolumeX } from "lucide-react";
-import * as React from "react";
-import { createPortal } from "react-dom";
-import { Z_TUTORIAL } from "../../../lib/floating-layers";
-import { Button } from "../../ui/button";
-
 /**
  * The tour spotlight: a full-screen overlay that
  *  - draws a breathing glow around the target (the indicator that points at the
@@ -16,6 +10,11 @@ import { Button } from "../../ui/button";
  * orange in the default theme, white/black in the mono themes, gold on the
  * classic brand — instead of hardcoding one accent.
  */
+import { Volume2, VolumeX } from "lucide-react";
+import * as React from "react";
+import { createPortal } from "react-dom";
+import { Z_TUTORIAL } from "../../../lib/floating-layers";
+import { Button } from "../../ui/button";
 
 const PAD = 8; // glow  inset around the target
 

--- a/packages/ui/src/components/pages/tutorial/tutorial-controller.ts
+++ b/packages/ui/src/components/pages/tutorial/tutorial-controller.ts
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 /**
  * Global tutorial controller. The interactive tour is a persistent OVERLAY (not
  * a tab view) because it navigates the user around the real app — to Settings,
@@ -10,6 +8,7 @@ import * as React from "react";
  * Module-level store (shared via globalThis so a single instance survives HMR
  * and is reachable from the tile handler outside React) + useSyncExternalStore.
  */
+import * as React from "react";
 
 const COMPLETED_KEY = "eliza:tutorial-completed";
 

--- a/packages/ui/src/components/pages/workflow-action-handoff.test.ts
+++ b/packages/ui/src/components/pages/workflow-action-handoff.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * jsdom tests for the workflow action-handoff helpers: `findWorkflowIdForActionHandoff`
+ * (resolving the target workflow from a chat action result) and
+ * `dispatchWorkflowActionHandoff` (emitting the handoff event).
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ChatActionResultSummary } from "../../api/client-types-chat";
 import {


### PR DESCRIPTION
Comments-only slice of #12234. `check:comment-only` passes — the code token stream is byte-for-byte unchanged vs `origin/develop`.

## Scope

- **Subtree:** `packages/ui/src/components/pages/**` (shard 1 of 2; disjoint from the sibling shard by lexical-sort index parity).
- **Files touched:** 52.
- **Change:** top-of-file prose headers per the root `CLAUDE.md` convention — added where missing, moved above imports where a good purpose block already sat below them, and rewrote change-narration (`Extracted from…`, `Before this there was zero coverage…`) into present-tense fact. Converted a few load-bearing `//` headers to the standard `/** … */` prose block. Already-at-the-bar files (story/util files whose purpose block documents `meta`/the sole export, e.g. `PluginVisual.tsx`, `FilesView.stories.tsx`) were left untouched.

## What got headers

- **Page-view components:** `BrowserWorkspaceView`, `DatabaseView`, `DocumentsView`, `ElizaCloudDashboard`, `LauncherSurface`, `MemoryDetailPanel`, `PluginsView`, `ReleaseCenterView`, `SecretsView`, `SettingsView`, `SkillsView`, `StreamView`, `TrajectoriesView`, `WorkflowGraphViewer`, `help/HelpView`, and the plugin/relationships/tutorial sub-components.
- **Pure helpers:** `cloud-dashboard-utils`, `config-page-sections`, `database-utils`, `documents-upload`, `page-scoped-conversations`, `relationships/relationships-utils`.
- **Story files:** `ChatView`, `ConfigPageView`, `Launcher`, `MediaGalleryView`.
- **Test files:** `LogsView`, `WalletSectionNav`, `WorkflowEditor`, `ScheduledTaskEditor`, `chat-view-hooks`, `background-image`, `browser-workspace-wallet`, `launcher-curation`, `plugin-view-connectors`, `workflow-action-handoff`, plus present-tense rewrites of `PluginsView.reorder`, `documents-detail`, `documents-upload.dnd`.
- **E2E fixtures:** `connectors-fixture`, `suggestions-fixture` (`//` → `/** */`).

## Verification

```
node scripts/assert-comment-only-diff.mjs
[assert-comment-only-diff] OK — 52 source file(s) changed; every code token identical to origin/develop. Comments only.
```

Part of #12234.