### PR TITLE
fix(#12229): route Feed A2A fetch through SSRF guard + converge log redaction

### DIFF
--- a/packages/cloud/shared/src/lib/security/safe-fetch.ts
+++ b/packages/cloud/shared/src/lib/security/safe-fetch.ts
@@ -46,6 +46,11 @@ export function createPinnedLookup(address: string, family: number) {
  * daemon/Node sinks — where the SSRF-sensitive provisioning webhooks run — get
  * true IP pinning below.
  */
+// EDGE-SSRF: no socket pinning on workerd — egress network policy required.
+// The false branch below (edge fetch) cannot pin to the validated IP, so the
+// residual DNS-rebinding TOCTOU (#12229 M5) must be closed at the Cloudflare
+// egress: deny RFC1918/link-local, or route edge outbound through a
+// resolve-and-connect-by-IP proxy. Operator follow-up — tracked in the PR.
 function canPinSockets(): boolean {
   const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : undefined;
   if (userAgent === "Cloudflare-Workers") {
@@ -255,6 +260,10 @@ export async function safeFetch(rawUrl: string, init: RequestInit = {}): Promise
     // workerd we cannot pin an arbitrary IP, so the platform fetch re-resolves
     // — a residual rebinding window documented on canPinSockets().
     const { url, address, family } = await resolveSafeOutboundTarget(currentUrl);
+    // EDGE-SSRF: no socket pinning on workerd — egress network policy required.
+    // The edge branch re-resolves DNS (a rebinding window between validate and
+    // connect, #12229 M5); it stays safe only behind a Cloudflare egress policy
+    // that blocks private ranges. The Node branch pins to the validated IP.
     const response = canPinSockets()
       ? await nodePinnedFetch(url, address, family, { ...currentInit, redirect: "manual" })
       : await fetch(url.toString(), { ...currentInit, redirect: "manual" });

--- a/packages/cloud/shared/src/lib/utils/logger.test.ts
+++ b/packages/cloud/shared/src/lib/utils/logger.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { logger } from "./logger";
+
+/**
+ * Proves #12229 M6: the cloud logger redacts at the sink, so a secret is masked
+ * whether or not the caller wrapped context in `redact.context()`. Runs against
+ * the real logger, capturing `console.error/warn` — no mock of the redactor.
+ */
+describe("cloud logger sink redaction (#12229 M6)", () => {
+  const original = { error: console.error, warn: console.warn };
+
+  afterEach(() => {
+    console.error = original.error;
+    console.warn = original.warn;
+  });
+
+  test("masks a value under a credential-named key with no redact.context()", () => {
+    const calls: unknown[][] = [];
+    console.error = mock((...args: unknown[]) => {
+      calls.push(args);
+    });
+
+    logger.error("boot failed", {
+      apiKey: "eliza_supersecretvalue1234567890",
+      userId: "u-1",
+    });
+
+    const serialized = JSON.stringify(calls);
+    expect(serialized).not.toContain("eliza_supersecretvalue1234567890");
+    expect(serialized).toContain("[REDACTED]");
+    // Non-secret context is preserved.
+    expect(serialized).toContain("u-1");
+  });
+
+  test("masks a value-shaped secret in a plain string argument", () => {
+    const calls: unknown[][] = [];
+    console.error = mock((...args: unknown[]) => {
+      calls.push(args);
+    });
+
+    logger.error("key is sk-abcdefghijklmnop1234 leaked");
+
+    expect(JSON.stringify(calls)).not.toContain("sk-abcdefghijklmnop1234");
+  });
+
+  test("redact.context() still works and agrees with the sink predicate", () => {
+    const ctx = logger.redact.context({
+      password: "hunter2-supersecret-value",
+      count: 3,
+    });
+    expect(ctx.password).toBe("[REDACTED]");
+    expect(ctx.count).toBe(3);
+  });
+});

--- a/packages/cloud/shared/src/lib/utils/logger.ts
+++ b/packages/cloud/shared/src/lib/utils/logger.ts
@@ -1,8 +1,17 @@
 /**
- * Conditional logging utility with sensitive data redaction
- * Debug/info logs only show when VERBOSE_LOGGING=true to reduce console noise
- * Provides utilities to redact sensitive data like transaction hashes and IDs
+ * Conditional cloud logging utility with structural sensitive-data redaction.
+ *
+ * Debug/info logs only show when VERBOSE_LOGGING=true to reduce console noise.
+ * Every sink pipes its arguments through the core log-sink redactor
+ * ({@link redactLogArgs}) before writing, so a secret is masked whether or not
+ * the caller wrapped context in {@link redact.context}. Name-based redaction
+ * (which field names are secret) is delegated to core's {@link isSensitiveKeyName}
+ * so the definition lives in exactly one module shared with the runtime; the
+ * `redact.*` helpers below add cloud-specific *display truncation* (tx hashes,
+ * IDs, IPs, wallet addresses) that is not a security masking concern.
  */
+
+import { isSensitiveKeyName, redactLogArgs } from "@elizaos/core";
 
 const isDev = process.env.NODE_ENV === "development";
 // Only show debug/info logs when explicitly enabled via VERBOSE_LOGGING=true
@@ -112,20 +121,11 @@ export const redact = {
       // Auto-redact based on field name patterns
       const lowerKey = key.toLowerCase();
 
-      // Sensitive credential fields — always fully redacted
-      if (
-        lowerKey.includes("privatekey") ||
-        lowerKey.includes("private_key") ||
-        lowerKey.includes("secret") ||
-        lowerKey.includes("password") ||
-        lowerKey.includes("authkey") ||
-        lowerKey.includes("auth_key") ||
-        lowerKey === "apikey" ||
-        lowerKey === "api_key" ||
-        (lowerKey.includes("token") && !lowerKey.includes("tokenid")) ||
-        (lowerKey.includes("key") &&
-          (lowerKey.includes("ssh") || lowerKey.includes("api") || lowerKey.includes("signing")))
-      ) {
+      // Sensitive credential fields — always fully redacted. The predicate is
+      // owned by core (isSensitiveKeyName) so cloud and runtime agree on which
+      // field names are secret; the display-truncation branches below are
+      // cloud-specific and stay here.
+      if (isSensitiveKeyName(key)) {
         redacted[key] = "[REDACTED]";
       } else if (lowerKey.includes("txhash") || lowerKey.includes("transaction_hash")) {
         redacted[key] = redact.txHash(value);
@@ -164,7 +164,7 @@ export const logger = {
    */
   debug: (...args: unknown[]) => {
     if (isVerbose) {
-      console.log(...args);
+      console.log(...redactLogArgs(args));
     }
   },
 
@@ -173,7 +173,7 @@ export const logger = {
    */
   info: (...args: unknown[]) => {
     if (isVerbose) {
-      console.info(...args);
+      console.info(...redactLogArgs(args));
     }
   },
 
@@ -181,7 +181,7 @@ export const logger = {
    * Error-level logs - always shown (critical for production monitoring)
    */
   error: (...args: unknown[]) => {
-    console.error(...args);
+    console.error(...redactLogArgs(args));
   },
 
   /**
@@ -190,7 +190,7 @@ export const logger = {
    */
   warn: (...args: unknown[]) => {
     if (!isBuildPhase) {
-      console.warn(...args);
+      console.warn(...redactLogArgs(args));
     }
   },
 

--- a/packages/core/src/network/fetch-guard.a2a-card.test.ts
+++ b/packages/core/src/network/fetch-guard.a2a-card.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchWithSsrfGuard } from "./fetch-guard.ts";
+import { nodePinnedFetch } from "./node-pinned-fetch.ts";
+import { SsrfBlockedError } from "./ssrf.ts";
+
+/**
+ * Regression guard for #12229 L9: the Feed A2A agent-card fetch routes through
+ * fetchWithSsrfGuard, so an operator/agent-supplied card URL cannot reach a
+ * private/link-local target. Deterministic — a stub lookupFn stands in for DNS,
+ * so no real resolution/egress happens; asserts the guard refuses (throws) and
+ * never calls the pinned transport for a private-resolving host.
+ */
+describe("fetchWithSsrfGuard for the A2A agent-card URL (#12229 L9)", () => {
+	it.each([
+		"http://169.254.169.254/.well-known/agent-card.json",
+		"http://10.0.0.5/.well-known/agent-card.json",
+		"http://127.0.0.1:3000/.well-known/agent-card.json",
+		"http://[::1]/.well-known/agent-card.json",
+	])("blocks a card URL at the literal internal target %s", async (url) => {
+		const pinnedFetchImpl = vi.fn(nodePinnedFetch);
+		await expect(
+			fetchWithSsrfGuard({ url, pinnedFetchImpl }),
+		).rejects.toBeInstanceOf(SsrfBlockedError);
+		expect(pinnedFetchImpl).not.toHaveBeenCalled();
+	});
+
+	it("blocks a public card hostname that resolves to the metadata IP (rebinding)", async () => {
+		// Attacker controls DNS for a public-looking card host and points it at the
+		// cloud metadata address. A raw fetch would connect; the guard resolves +
+		// screens the address and refuses before any socket is opened.
+		const lookupFn = vi.fn(async () => [
+			{ address: "169.254.169.254", family: 4 },
+		]);
+		const pinnedFetchImpl = vi.fn(nodePinnedFetch);
+		await expect(
+			fetchWithSsrfGuard({
+				url: "https://cards.attacker.example/.well-known/agent-card.json",
+				lookupFn,
+				pinnedFetchImpl,
+			}),
+		).rejects.toBeInstanceOf(SsrfBlockedError);
+		expect(lookupFn).toHaveBeenCalledTimes(1);
+		expect(pinnedFetchImpl).not.toHaveBeenCalled();
+	});
+
+	it("allows a public card host that resolves to a public IP", async () => {
+		const lookupFn = vi.fn(async () => [
+			{ address: "93.184.216.34", family: 4 },
+		]);
+		const pinnedFetchImpl = vi.fn(
+			async () => new Response('{"name":"feed"}', { status: 200 }),
+		);
+		const { response, release } = await fetchWithSsrfGuard({
+			url: "https://cards.example.com/.well-known/agent-card.json",
+			lookupFn,
+			pinnedFetchImpl,
+		});
+		expect(response.status).toBe(200);
+		expect(pinnedFetchImpl).toHaveBeenCalledTimes(1);
+		await release();
+	});
+});

--- a/packages/core/src/network/fetch-guard.ts
+++ b/packages/core/src/network/fetch-guard.ts
@@ -324,14 +324,21 @@ export async function fetchWithSsrfGuard(
 						})
 					: await resolvePinnedHostname(parsedUrl.hostname, lookupFn);
 			} else {
-				// No lookupFn (e.g. environment-agnostic core, which has no node:dns
-				// to pin with): fall back to synchronous literal-host checks — block
+				// EDGE-SSRF: no socket pinning on workerd — egress network policy
+				// required. This branch runs where there is no node:dns to pin with
+				// (Cloudflare Workers / environment-agnostic core). It blocks literal
+				// internal targets but CANNOT defend against DNS rebinding (a public
+				// name that flips to a private address between check and connect,
+				// #12229 M5); on the edge that residual must be closed by a Cloudflare
+				// egress policy denying RFC1918/link-local, or by routing outbound
+				// through a resolve-and-connect-by-IP proxy. Operator follow-up.
+				//
+				// No lookupFn: fall back to synchronous literal-host checks — block
 				// literal private/loopback/link-local IPs (including the
 				// octal/hex/decimal forms the OS resolver honors) and blocked
 				// internal hostnames. The redirect loop below re-runs this check for
-				// every hop, so redirect-to-internal is caught too. This does NOT
-				// defend against DNS rebinding (a public name that resolves to a
-				// private address) — pass a lookupFn where that matters.
+				// every hop, so redirect-to-internal is caught too. Pass a lookupFn
+				// where rebinding protection matters.
 				const allowPrivate = Boolean(params.policy?.allowPrivateNetwork);
 				const host = parsedUrl.hostname.trim().toLowerCase().replace(/\.$/, "");
 				const allowed = new Set(

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -76,8 +76,12 @@ export {
 	createSecretsRedactor,
 	// Pattern-based redaction
 	getDefaultRedactPatterns,
+	// Name-based redaction (single source of truth for credential key names)
+	isSensitiveKeyName,
 	type RedactOptions,
 	type RedactSensitiveMode,
+	// Log-sink redaction (structural, not opt-in)
+	redactLogArgs,
 	redactObjectSecrets,
 	redactSecrets,
 	redactSensitiveText,

--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
 	createSecretsRedactor,
 	getDefaultRedactPatterns,
+	isSensitiveKeyName,
+	redactLogArgs,
 	redactObjectSecrets,
 	redactSecrets,
 	redactSensitiveText,
@@ -124,5 +126,94 @@ describe("replacement-pattern safety ($-expansion)", () => {
 		});
 		expect(out).toBe("value is [REDACTED:WEIRD$&NAME]");
 		expect(out).not.toContain("supersecretvalue123");
+	});
+});
+
+/**
+ * Name-based key detection (isSensitiveKeyName) is the single source of truth
+ * shared by the cloud logger's redact.context and the log-sink redactor, so
+ * "which field names are secret" is defined once (#12229 M6).
+ */
+describe("isSensitiveKeyName", () => {
+	it("flags credential-named keys regardless of case/separator", () => {
+		for (const key of [
+			"apiKey",
+			"api_key",
+			"password",
+			"secret",
+			"privateKey",
+			"private_key",
+			"accessToken",
+			"refreshToken",
+			"authorization",
+			"mnemonic",
+			"seedPhrase",
+			"sshKey",
+			"signingKey",
+			"credential",
+		]) {
+			expect(isSensitiveKeyName(key)).toBe(true);
+		}
+	});
+
+	it("does not flag benign keys, including tokenId", () => {
+		for (const key of ["userId", "count", "tokenId", "name", "url", "status"]) {
+			expect(isSensitiveKeyName(key)).toBe(false);
+		}
+	});
+});
+
+/**
+ * redactLogArgs is the sink-level redactor: it masks secrets structurally so a
+ * logger that pipes its args through it protects `{ apiKey }` with no
+ * redact.context() at the call site (#12229 M6).
+ */
+describe("redactLogArgs (log-sink redaction, not opt-in)", () => {
+	it("masks a value under a credential-named key without any wrapping", () => {
+		const [msg, ctx] = redactLogArgs([
+			"boot",
+			{ apiKey: "eliza_supersecretvalue123456", userId: "u-1" },
+		]) as [string, Record<string, unknown>];
+		expect(msg).toBe("boot");
+		expect(ctx.apiKey).toBe("[REDACTED]");
+		expect(ctx.userId).toBe("u-1");
+		expect(JSON.stringify(ctx)).not.toContain("eliza_supersecretvalue123456");
+	});
+
+	it("masks a value-shaped secret in a plain string argument", () => {
+		const [msg] = redactLogArgs(["key is sk-abcdefghijklmnop1234"]) as [string];
+		expect(msg).not.toContain("sk-abcdefghijklmnop1234");
+	});
+
+	it("masks a nested credential-named key", () => {
+		const [ctx] = redactLogArgs([
+			{ config: { db: { password: "hunter2-supersecret" } } },
+		]) as [Record<string, unknown>];
+		expect(JSON.stringify(ctx)).not.toContain("hunter2-supersecret");
+		expect(JSON.stringify(ctx)).toContain("[REDACTED]");
+	});
+
+	it("scrubs a secret interpolated into an Error message", () => {
+		const [err] = redactLogArgs([
+			new Error("failed with token=sk-abcdefghijklmnop1234"),
+		]) as [Error];
+		expect(err).toBeInstanceOf(Error);
+		expect(err.message).not.toContain("sk-abcdefghijklmnop1234");
+	});
+
+	it("does not hang or throw on a cyclic object", () => {
+		const cyclic: Record<string, unknown> = { name: "x" };
+		cyclic.self = cyclic;
+		const [out] = redactLogArgs([cyclic]) as [Record<string, unknown>];
+		expect(out.name).toBe("x");
+	});
+
+	it("leaves non-string, non-object arguments untouched", () => {
+		expect(redactLogArgs([1, true, null, undefined])).toEqual([
+			1,
+			true,
+			null,
+			undefined,
+		]);
 	});
 });

--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -193,6 +193,19 @@ describe("redactLogArgs (log-sink redaction, not opt-in)", () => {
 		expect(JSON.stringify(ctx)).toContain("[REDACTED]");
 	});
 
+	it("masks the whole value under a credential-named key, even when it is not a string", () => {
+		const [ctx] = redactLogArgs([
+			{
+				authorization: {
+					scheme: "Bearer",
+					value: "nested-supersecret-value",
+				},
+			},
+		]) as [Record<string, unknown>];
+		expect(ctx.authorization).toBe("[REDACTED]");
+		expect(JSON.stringify(ctx)).not.toContain("nested-supersecret-value");
+	});
+
 	it("scrubs a secret interpolated into an Error message", () => {
 		const [err] = redactLogArgs([
 			new Error("failed with token=sk-abcdefghijklmnop1234"),

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -56,6 +56,61 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
 ];
 
 /**
+ * Substrings that mark an object key as holding a credential. Case-insensitive.
+ * This is the single source of truth for *name-based* redaction — the cloud
+ * logger's `redact.context()` and the log-sink redactor below both consult
+ * {@link isSensitiveKeyName}, so "which field names are secret" is defined once.
+ * Value-shape detection (sk-, ghp_, Bearer, PEM, …) lives in
+ * {@link DEFAULT_REDACT_PATTERNS}; the two are complementary, not duplicated.
+ */
+const SENSITIVE_KEY_SUBSTRINGS: readonly string[] = [
+	"privatekey",
+	"private_key",
+	"secret",
+	"password",
+	"passwd",
+	"passphrase",
+	"mnemonic",
+	"seedphrase",
+	"seed_phrase",
+	"apikey",
+	"api_key",
+	"accesstoken",
+	"access_token",
+	"refreshtoken",
+	"refresh_token",
+	"authkey",
+	"auth_key",
+	"credential",
+	"authorization",
+];
+
+/**
+ * Whether an object key names a credential and its value must be fully masked.
+ * Matches the substrings in {@link SENSITIVE_KEY_SUBSTRINGS} plus `token`
+ * (excluding `tokenId`) and the `*key` forms the cloud logger recognized
+ * (ssh/api/signing key). Callers redact the *value* under a matching key.
+ */
+export function isSensitiveKeyName(key: string): boolean {
+	const lower = key.toLowerCase();
+	if (SENSITIVE_KEY_SUBSTRINGS.some((needle) => lower.includes(needle))) {
+		return true;
+	}
+	if (lower.includes("token") && !lower.includes("tokenid")) {
+		return true;
+	}
+	if (
+		lower.includes("key") &&
+		(lower.includes("ssh") ||
+			lower.includes("api") ||
+			lower.includes("signing"))
+	) {
+		return true;
+	}
+	return false;
+}
+
+/**
  * Options for redacting sensitive text.
  */
 export type RedactOptions = {
@@ -372,4 +427,72 @@ export function redactObjectSecrets<T>(
 	}
 
 	return obj;
+}
+
+// ============================================================================
+// Log-Sink Redaction (applied to every log line, not opt-in per call)
+// ============================================================================
+
+const REDACTED_MASK = "[REDACTED]";
+const MAX_LOG_REDACT_DEPTH = 8;
+
+/**
+ * Redact one log argument for output at the sink. A string is scrubbed with the
+ * value-shape patterns ({@link redactSensitiveText}); an object/array is walked
+ * so any value under a credential-named key ({@link isSensitiveKeyName}) is
+ * fully masked and every remaining string is pattern-scrubbed. This is the
+ * mechanism that makes redaction structural rather than opt-in: a logger that
+ * pipes its arguments through {@link redactLogArgs} masks `{ apiKey }` whether
+ * or not the caller wrapped the context first.
+ *
+ * Depth is bounded and cycles are broken (returning the mask) so a pathological
+ * log payload cannot hang or blow the stack — a redactor must never be the thing
+ * that takes the process down.
+ */
+function redactLogArg(
+	value: unknown,
+	seen: WeakSet<object>,
+	depth: number,
+): unknown {
+	if (typeof value === "string") {
+		return redactSensitiveText(value);
+	}
+	if (value === null || typeof value !== "object") {
+		return value;
+	}
+	if (depth >= MAX_LOG_REDACT_DEPTH || seen.has(value)) {
+		return REDACTED_MASK;
+	}
+	seen.add(value);
+	if (Array.isArray(value)) {
+		return value.map((item) => redactLogArg(item, seen, depth + 1));
+	}
+	if (value instanceof Error) {
+		// Preserve the Error shape (name/stack) callers rely on, but scrub the
+		// message — thrown errors routinely interpolate the offending secret.
+		const redacted = new Error(redactSensitiveText(value.message));
+		redacted.name = value.name;
+		redacted.stack = value.stack ? redactSensitiveText(value.stack) : undefined;
+		return redacted;
+	}
+	const result: Record<string, unknown> = {};
+	for (const [key, entry] of Object.entries(value)) {
+		if (isSensitiveKeyName(key) && typeof entry === "string") {
+			result[key] = REDACTED_MASK;
+			continue;
+		}
+		result[key] = redactLogArg(entry, seen, depth + 1);
+	}
+	return result;
+}
+
+/**
+ * Redact every argument in a `logger.error(...args)` call before it reaches the
+ * transport. Consumed by log sinks so secret masking is structural, not opt-in:
+ * `logger.error("msg", { apiKey })` masks the key with no `redact.context()` at
+ * the call site. Value-shape and credential-named-key redaction converge here on
+ * the one core module ({@link redactSensitiveText} + {@link isSensitiveKeyName}).
+ */
+export function redactLogArgs(args: readonly unknown[]): unknown[] {
+	return args.map((arg) => redactLogArg(arg, new WeakSet<object>(), 0));
 }

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -477,7 +477,7 @@ function redactLogArg(
 	}
 	const result: Record<string, unknown> = {};
 	for (const [key, entry] of Object.entries(value)) {
-		if (isSensitiveKeyName(key) && typeof entry === "string") {
+		if (isSensitiveKeyName(key)) {
 			result[key] = REDACTED_MASK;
 			continue;
 		}

--- a/packages/feed/packages/agents/src/plugins/feed/a2a-client-integration.ts
+++ b/packages/feed/packages/agents/src/plugins/feed/a2a-client-integration.ts
@@ -8,6 +8,7 @@ import type { AgentCard, Message, Task } from "@a2a-js/sdk";
 import { A2AClient } from "@a2a-js/sdk/client";
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger } from "../../shared/logger";
+import { createGuardedFetchImpl } from "./guarded-fetch";
 
 export interface FeedA2ARuntime extends IAgentRuntime {
   feedA2AClient?: A2AClient;
@@ -35,20 +36,15 @@ export async function initializeA2AClient(
     hasApiKey: !!effectiveApiKey,
   });
 
-  // Create custom fetch that includes API key header for authentication
-  const authenticatedFetch = async (
-    url: string | URL | Request,
-    init?: RequestInit,
-  ): Promise<Response> => {
-    const headers = new Headers(init?.headers);
-
+  // Custom fetch that injects the API key and routes through the SSRF guard:
+  // the card URL is operator/agent-supplied, so it must not be able to reach a
+  // private/rebinding target.
+  const authenticatedFetch = createGuardedFetchImpl((headers) => {
     // Add API key for A2A authentication
     if (effectiveApiKey) {
       headers.set("x-feed-api-key", effectiveApiKey);
     }
-
-    return fetch(url, { ...init, headers });
-  };
+  });
 
   // Use SDK to create client from agent card with authenticated fetch
   const client = await A2AClient.fromCardUrl(feedEndpoint, {

--- a/packages/feed/packages/agents/src/plugins/feed/guarded-fetch.test.ts
+++ b/packages/feed/packages/agents/src/plugins/feed/guarded-fetch.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { createGuardedFetchImpl, guardedFetch } from "./guarded-fetch";
+
+/**
+ * Proves #12229 L9: the Feed A2A agent-card fetch routes through the core SSRF
+ * guard, so an operator/agent-supplied card URL cannot reach a private/
+ * link-local target. Runs the real guard against literal internal IPs (no DNS,
+ * no egress); asserts the request is refused rather than silently fetched.
+ */
+describe("Feed A2A guardedFetch SSRF guard (#12229 L9)", () => {
+  const privateCardUrls = [
+    "http://169.254.169.254/.well-known/agent-card.json",
+    "http://10.0.0.5/.well-known/agent-card.json",
+    "http://127.0.0.1:3000/.well-known/agent-card.json",
+    "http://[::1]/.well-known/agent-card.json",
+  ];
+
+  for (const url of privateCardUrls) {
+    test(`guardedFetch blocks the private card URL ${url}`, async () => {
+      await expect(guardedFetch(url)).rejects.toThrow(
+        /private|internal|Blocked/i,
+      );
+    });
+  }
+
+  test("createGuardedFetchImpl also blocks a private card URL and injects headers", async () => {
+    let injected: string | null = null;
+    const impl = createGuardedFetchImpl((headers) => {
+      headers.set("x-feed-api-key", "k");
+      injected = headers.get("x-feed-api-key");
+    });
+    await expect(
+      impl("http://169.254.169.254/tasks"),
+    ).rejects.toThrow(/private|internal|Blocked/i);
+    // Header injection runs before the guard refuses the connect.
+    expect(injected).toBe("k");
+  });
+
+  test("blocks a blocked internal hostname", async () => {
+    await expect(
+      guardedFetch("http://metadata.google.internal/agent-card.json"),
+    ).rejects.toThrow(/Blocked|internal/i);
+  });
+});

--- a/packages/feed/packages/agents/src/plugins/feed/guarded-fetch.ts
+++ b/packages/feed/packages/agents/src/plugins/feed/guarded-fetch.ts
@@ -1,0 +1,64 @@
+/**
+ * SSRF-guarded fetch for the Feed A2A integration.
+ *
+ * The A2A agent-card endpoint is operator/agent-supplied
+ * (`FEED_A2A_ENDPOINT` / `NEXT_PUBLIC_APP_URL` and, for `A2AClient`, the URL the
+ * card advertises), so a raw `fetch` of it is an SSRF sink: a card URL that
+ * resolves to `169.254.169.254`, `10.x`, or the mesh network would let the
+ * request reach cloud metadata or internal services. Every outbound A2A request
+ * routes through {@link fetchWithSsrfGuard} (from `@elizaos/core`), which
+ * validates the URL, blocks private/loopback/link-local targets, and — on
+ * Node/Bun — pins DNS to the validated IP so the host cannot rebind between the
+ * check and the connect. Redirects are re-validated on every hop.
+ *
+ * Identity headers are merged into the guard's request init rather than handed
+ * off through a custom `fetchImpl`, which keeps the guard's auto-loaded pinned
+ * transport (the DNS-rebinding defense) in force.
+ */
+
+import { fetchWithSsrfGuard } from "@elizaos/core";
+
+/** Guarded replacement for `fetch(url, init)` used for all A2A outbound calls. */
+export async function guardedFetch(
+  url: string | URL | Request,
+  init?: RequestInit,
+): Promise<Response> {
+  const target = a2aRequestUrl(url);
+  const { response, release } = await fetchWithSsrfGuard({
+    url: target,
+    ...(init ? { init } : {}),
+  });
+  // The guard's release() only clears the abort timer we did not set here, so it
+  // is a no-op cleanup; call it to honor the contract without holding the socket.
+  await release();
+  return response;
+}
+
+/**
+ * Build a `fetchImpl` (matching the `A2AClient` fetch contract) that injects the
+ * given headers and routes every request through {@link guardedFetch}. Used so
+ * `A2AClient` cannot fetch an unguarded, attacker-controllable card/task URL.
+ */
+export function createGuardedFetchImpl(
+  injectHeaders: (headers: Headers) => void,
+): typeof fetch {
+  const impl = async (
+    url: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const headers = new Headers(init?.headers);
+    injectHeaders(headers);
+    return guardedFetch(url, { ...init, headers });
+  };
+  return impl as typeof fetch;
+}
+
+function a2aRequestUrl(url: string | URL | Request): string {
+  if (typeof url === "string") {
+    return url;
+  }
+  if (url instanceof URL) {
+    return url.toString();
+  }
+  return url.url;
+}

--- a/packages/feed/packages/agents/src/plugins/feed/integration-a2a-sdk.ts
+++ b/packages/feed/packages/agents/src/plugins/feed/integration-a2a-sdk.ts
@@ -16,6 +16,7 @@ import { db } from "@feed/db";
 import { StaticDataRegistry } from "@feed/engine";
 import { logger } from "../../shared/logger";
 import type { JsonValue } from "../../types/common";
+import { createGuardedFetchImpl, guardedFetch } from "./guarded-fetch";
 
 type FeedRuntime = AgentRuntime & { a2aClient?: FeedA2AClient };
 
@@ -180,7 +181,7 @@ async function fetchAgentCard(): Promise<CachedAgentCard | null> {
       "FeedIntegration",
     );
 
-    const response = await fetch(agentCardUrl);
+    const response = await guardedFetch(agentCardUrl);
     if (!response.ok) {
       throw new Error(`Failed to fetch agent card: ${response.status}`);
     }
@@ -217,18 +218,15 @@ async function fetchAgentCard(): Promise<CachedAgentCard | null> {
 // =============================================================================
 
 /**
- * Create authenticated fetch for an agent that injects identity headers
- * Headers come from cached identity (refreshed every 5 minutes max)
+ * Create authenticated fetch for an agent that injects identity headers and
+ * routes through the SSRF guard. Headers come from cached identity (refreshed
+ * every 5 minutes max); the guard blocks private/rebinding targets so a
+ * malicious agent-card URL cannot reach internal services.
  */
 function createAuthenticatedFetchForAgent(
   identity: CachedAgentIdentity,
 ): typeof fetch {
-  const customFetch = async (
-    url: string | URL | Request,
-    init?: RequestInit,
-  ): Promise<Response> => {
-    const headers = new Headers(init?.headers);
-
+  return createGuardedFetchImpl((headers) => {
     // Always set agent ID for request correlation
     headers.set("x-agent-id", identity.agentUserId);
 
@@ -237,19 +235,7 @@ function createAuthenticatedFetchForAgent(
     if (apiKey) {
       headers.set("x-feed-api-key", apiKey);
     }
-
-    return fetch(url, { ...init, headers });
-  };
-
-  // Bun may expose a non-standard `fetch.preconnect`; preserve it when present.
-  const maybePreconnect = (fetch as { preconnect?: unknown })
-    .preconnect;
-  if (maybePreconnect) {
-    (customFetch as { preconnect?: unknown }).preconnect =
-      maybePreconnect;
-  }
-
-  return customFetch as typeof fetch;
+  });
 }
 
 /**


### PR DESCRIPTION
Closes #12229 (code parts; M5 network-policy half is operator N/A — non-blocking).

Security remediation for the auth+secrets surface — the Linux-provable code items. Scope is **L9 + M6 + the M5 marker**; the other items (M4/L6/L7/L8) were already landed on develop (L8's lookupFn-without-pin throw is present at `fetch-guard.ts:260-267`) or are out of this sub-issue's assigned slice.

## What changed

### L9 — Feed A2A agent-card fetch now routes through the SSRF guard
The A2A card endpoint is operator/agent-supplied (`FEED_A2A_ENDPOINT` / `NEXT_PUBLIC_APP_URL`, and the URL `A2AClient.fromCardUrl` fetches), so a raw `fetch` was an SSRF sink into `169.254.169.254` / `10.x` / the mesh.

- New `packages/feed/packages/agents/src/plugins/feed/guarded-fetch.ts` wraps `fetchWithSsrfGuard` (`@elizaos/core`): validates the URL, blocks private/loopback/link-local, and on Node/Bun pins DNS to the validated IP (rebinding defense), re-validating each redirect hop.
- `integration-a2a-sdk.ts`: the raw `fetch(agentCardUrl)` (was ~L183) and the per-agent authenticated fetch (was ~L241) now go through the guard.
- `a2a-client-integration.ts`: the authenticated fetch (was ~L50) now goes through the guard.
- Identity headers are merged into the guard's request `init` rather than a custom `fetchImpl`, so the auto-loaded pinned transport stays in force.

### M6 — log redaction is structural (not opt-in) and single-sourced
- `packages/core/src/security/redact.ts` gains **`isSensitiveKeyName`** (the one definition of "which field names are secret") and **`redactLogArgs`** (a sink-level redactor: name-based masking on object keys + value-shape scrub on strings, recursively; depth-bounded, cycle-safe, scrubs `Error` messages/stacks).
- `packages/cloud/shared/src/lib/utils/logger.ts`: all four sinks now `console.*(...redactLogArgs(args))`, and `redact.context()`'s credential-name check delegates to core's `isSensitiveKeyName`. Cloud's name-based and core's value-regex redaction now converge on the one core module. Cloud-specific *display truncation* (tx hash / id / ip / address) stays local — it isn't security masking.
- Net effect: `logger.error("x", { apiKey })` masks the key with **no** `redact.context()` at the call site.

### M5 (marker only) — edge-SSRF residual documented in code
`// EDGE-SSRF: no socket pinning on workerd — egress network policy required` markers added at the two workerd fallbacks (`safe-fetch.ts` `canPinSockets` + the workerd `fetch` branch; core `fetch-guard.ts` no-`lookupFn` branch). **Operator follow-up (non-blocking):** deny RFC1918/link-local at the Cloudflare egress, or route edge outbound through a resolve-and-connect-by-IP proxy. The network-policy half is operator action — captured here, not implemented in code.

## Verification (real output)

Core (vitest, `packages/core`):
```
$ bunx vitest run packages/core/src/network/fetch-guard.a2a-card.test.ts packages/core/src/security/redact.test.ts
 Test Files  2 passed (2)
      Tests  27 passed (27)
```
- `fetch-guard.a2a-card.test.ts` (L9 guarantee): a private-IP **and** a rebinding card host (public name -> `169.254.169.254`) are refused before any socket; a public IP is allowed.
- `redact.test.ts` (M6): `redactLogArgs` masks `{ apiKey }` with no wrapping, scrubs value-shaped secrets in plain strings and `Error` messages, and is cycle-safe; `isSensitiveKeyName` flags credentials, not `tokenId`.

Cloud (bun, `packages/cloud/shared`, `--conditions=eliza-source`):
```
$ bun --conditions=eliza-source test src/lib/utils/logger.test.ts src/lib/security/safe-fetch.test.ts
 20 pass  0 fail  35 expect() calls
```
- `logger.test.ts` (M6): drives the real logger, captures `console.error/warn` — `logger.error("boot failed", { apiKey })` masks the key with no `redact.context()`; non-secret context preserved.

Feed (bun, `packages/feed/packages/agents`, `--conditions=eliza-source`):
```
$ bun --conditions=eliza-source test src/plugins/feed/guarded-fetch.test.ts
 6 pass  0 fail  7 expect() calls
```
- `guarded-fetch.test.ts` (L9): private-IP + blocked-hostname card URLs are refused (throw); header injection still runs before the guard refuses.

Typecheck (touched files clean; pre-existing base errors only):
- `packages/core`: 0 errors in touched files; the only errors are the pre-existing `@elizaos/cloud-routing` resolution ones (file untouched).
- `packages/cloud/shared` (tsgo): 0 errors in touched files; 13 pre-existing errors all in untouched `app-core/src/services/*` (`@elizaos/auth/*`).
- `packages/feed/packages/agents`: 0 errors in touched files (1 pre-existing tsconfig `--ignoreDeprecations` quirk).

Error-policy ratchet: `[error-policy-ratchet] no new fallback-slop in touched files`.

## Notes / N/A
- **M5 network-policy half — N/A (operator action, non-blocking).** Code marker + this checklist item are the deliverable; the Cloudflare egress policy / proxy is infra.
- Test lanes use `--conditions=eliza-source` for cloud/feed because those packages resolve the `@elizaos/core` source barrel only under that condition in a fresh worktree (pre-existing harness behavior); the core suite already runs with it.
- `packages/feed` is excluded from the repo Biome config (feed owns its formatting); new feed files match the existing 2-space feed style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
