### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-views-config-perms

### DIFF
--- a/packages/ui/src/components/config-ui/config-control-primitives.helpers.ts
+++ b/packages/ui/src/components/config-ui/config-control-primitives.helpers.ts
@@ -1,3 +1,8 @@
+/**
+ * Tailwind class builders for config-form input and textarea controls, shared by
+ * `ConfigRenderer`'s field renderers and `UiRenderer`. Centralizes the density
+ * (compact/regular) and error-state styling so every config control looks the same.
+ */
 import { cn } from "../../lib/utils";
 
 export function getConfigInputClassName({

--- a/packages/ui/src/components/config-ui/config-control-primitives.stories.tsx
+++ b/packages/ui/src/components/config-ui/config-control-primitives.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook state for the ConfigFieldErrors control primitive (the stacked field-error list). */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ConfigFieldErrors } from "./config-control-primitives";
 

--- a/packages/ui/src/components/config-ui/config-control-primitives.tsx
+++ b/packages/ui/src/components/config-ui/config-control-primitives.tsx
@@ -1,3 +1,4 @@
+/** Shared config-form control primitive: the stacked list of field validation errors, rendered by both `ConfigRenderer` and `UiRenderer`. */
 export function ConfigFieldErrors({
   errors,
 }: {

--- a/packages/ui/src/components/config-ui/config-field.helpers.tsx
+++ b/packages/ui/src/components/config-ui/config-field.helpers.tsx
@@ -1,3 +1,12 @@
+/**
+ * Per-field-type control renderers for the plugin-config form (text, password,
+ * number, boolean, url, select, textarea, email, color, radio, multiselect,
+ * date, json, code, array, key-value, datetime, file, markdown, custom) plus the
+ * `defaultRenderers` map keyed by field type. `ConfigField` picks a renderer from
+ * this map; each renderer reads `FieldRenderProps` and can fire hint-bound actions
+ * via `fireAction`. Controls share the config-input styling from
+ * config-control-primitives.helpers.
+ */
 import { ChevronDown, X } from "lucide-react";
 import React, {
   useCallback,

--- a/packages/ui/src/components/config-ui/config-field.stories.tsx
+++ b/packages/ui/src/components/config-ui/config-field.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook states for ConfigField — the label/help/error wrapper around a field
+ * renderer — across required-empty, configured, error, and help-text cases. A
+ * mock `t` supplies the label/status copy.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import type {
   FieldRenderer,

--- a/packages/ui/src/components/config-ui/config-renderer.helpers.ts
+++ b/packages/ui/src/components/config-ui/config-renderer.helpers.ts
@@ -1,3 +1,4 @@
+/** Default field registry (catalog wired to the default renderers) and the `useConfigValidation` hook that lets a parent form call `ConfigRenderer.validateAll()` before submitting. */
 import { useCallback, useRef } from "react";
 import type { FieldRegistry } from "../../config/config-catalog";
 import { defaultCatalog, defineRegistry } from "../../config/config-catalog";

--- a/packages/ui/src/components/config-ui/config-renderer.stories.tsx
+++ b/packages/ui/src/components/config-ui/config-renderer.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook states for ConfigRenderer driven by a sample JSON Schema: default,
+ * missing-required, partially configured, fully configured, and the no-schema
+ * empty case. Uses the default registry so real field renderers mount.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { JsonSchemaObject } from "../../config/config-catalog";
 import { mockApp } from "../../storybook/mock-providers.helpers";

--- a/packages/ui/src/components/config-ui/config-renderer.tsx
+++ b/packages/ui/src/components/config-ui/config-renderer.tsx
@@ -1,3 +1,11 @@
+/**
+ * Renders a JSON-Schema-described plugin config as a form: resolves the schema
+ * into ordered fields (basic + advanced groups), evaluates per-field visibility,
+ * delegates each field to `ConfigField` + the registry's renderer, and surfaces
+ * a validation summary. Exposes an imperative `validateAll()` via
+ * `ConfigRendererHandle` so a parent form can gate submission. Group icons and
+ * plugin theme tokens style the output; secret reveal is delegated to the caller.
+ */
 import type React from "react";
 import {
   forwardRef,

--- a/packages/ui/src/components/config-ui/index.ts
+++ b/packages/ui/src/components/config-ui/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the config-ui surface: plugin-config form renderers (schema-driven `ConfigRenderer`), the agent-spec `UiRenderer`, and their shared field controls. */
 export * from "./config-control-primitives";
 export * from "./config-control-primitives.helpers";
 export * from "./config-field";

--- a/packages/ui/src/components/config-ui/ui-renderer.helpers.ts
+++ b/packages/ui/src/components/config-ui/ui-renderer.helpers.ts
@@ -1,3 +1,10 @@
+/**
+ * Pure evaluation helpers for `UiRenderer`: resolves a spec's visibility
+ * conditions and validation checks against state/auth, sanitizes link hrefs
+ * against a protocol denylist (blocks javascript/data/vbscript/file to prevent
+ * XSS from agent-authored specs), and enumerates the supported component types.
+ * No React — logic only, so it can be unit-tested in isolation.
+ */
 import { getByPath } from "../../config/config-catalog";
 import type {
   AuthState,

--- a/packages/ui/src/components/config-ui/ui-renderer.stories.tsx
+++ b/packages/ui/src/components/config-ui/ui-renderer.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook states for UiRenderer over sample `UiSpec`s: a form spec, a
+ * dashboard spec, the loading skeleton, and auth-gated visibility for an
+ * unauthenticated viewer.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { UiSpec } from "../../config/ui-spec";
 import { withMockApp } from "../../storybook/mock-providers.helpers";

--- a/packages/ui/src/components/config-ui/ui-renderer.tsx
+++ b/packages/ui/src/components/config-ui/ui-renderer.tsx
@@ -1,3 +1,12 @@
+/**
+ * Renders a declarative `UiSpec` (the plugin-config UI-spec engine's element
+ * tree) into React. Walks the spec's element graph from its root, resolves
+ * bound props / state paths / visibility conditions against a live state store,
+ * runs field validators, and fires `UiAction`s back through the `onAction`
+ * callback. Link hrefs are sanitized (`sanitizeLinkHref`) and only supported
+ * component types render; the spec is data, not code. Contrast with
+ * `ConfigRenderer`, which drives a JSON-Schema config form rather than a spec tree.
+ */
 import type React from "react";
 import {
   createContext,

--- a/packages/ui/src/components/permissions/PermissionIcon.stories.tsx
+++ b/packages/ui/src/components/permissions/PermissionIcon.stories.tsx
@@ -1,3 +1,4 @@
+/** Storybook states for PermissionIcon, one per known icon key plus the unknown-key fallback. */
 import type { Meta, StoryObj } from "@storybook/react";
 import { PermissionIcon } from "./PermissionIcon";
 

--- a/packages/ui/src/components/permissions/PermissionIcon.tsx
+++ b/packages/ui/src/components/permissions/PermissionIcon.tsx
@@ -1,3 +1,8 @@
+/**
+ * Maps a permission's string icon key (cursor, mic, camera, calendar, …) to its
+ * lucide glyph for permission rows across the settings + streaming surfaces.
+ * Unknown keys fall back to the Settings gear.
+ */
 import {
   Bell,
   Calendar,

--- a/packages/ui/src/components/permissions/PermissionPrimingModal.test.tsx
+++ b/packages/ui/src/components/permissions/PermissionPrimingModal.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// PermissionPrimingModal rendering: the active card's rationale + Enable/Not now,
+// the recovery callout for a denied card, the loading state, single onComplete
+// firing, and Skip-for-now. Drives the modal through an injected
+// `controllerOverride` stub (the live hook is covered by use-permission-priming.test).
 import type { PermissionId } from "@elizaos/shared/contracts/permissions";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";

--- a/packages/ui/src/components/permissions/PermissionRecoveryCallout.tsx
+++ b/packages/ui/src/components/permissions/PermissionRecoveryCallout.tsx
@@ -1,3 +1,10 @@
+/**
+ * Alert callout shown when a permission is denied — offers Retry (`onRetry`) and
+ * an "Open Settings" affordance that deep-links to the OS permission screen.
+ * Routes to the native mobile deep-link on Capacitor (non-Electrobun) and the
+ * shared web/desktop deep-link elsewhere. Consumed by the permission-priming
+ * modal and permission settings rows.
+ */
 import { Capacitor } from "@capacitor/core";
 import type { PermissionId } from "@elizaos/shared/contracts/permissions";
 import { openPermissionSettings } from "@elizaos/shared/utils/permission-deep-links";

--- a/packages/ui/src/components/permissions/StreamingPermissions.tsx
+++ b/packages/ui/src/components/permissions/StreamingPermissions.tsx
@@ -1,3 +1,11 @@
+/**
+ * Settings view listing the Camera / Microphone / Screen media permissions for
+ * live-streaming, with a status badge and request button per row. The internal
+ * `useStreamingPermissions` hook checks and requests state through
+ * `navigator.permissions` / `navigator.mediaDevices` on web and the `ElizaCamera`
+ * Capacitor plugin on mobile; the `mode` ("web" | "mobile") also gates which rows
+ * show (Screen is web-only). Falls back to a "Not Set" state when those APIs are absent.
+ */
 import { Check, Cloud, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useAppSelector } from "../../state";

--- a/packages/ui/src/components/permissions/__tests__/permissions-stories-smoke.test.tsx
+++ b/packages/ui/src/components/permissions/__tests__/permissions-stories-smoke.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+/**
+ * Portable-stories smoke test for the permissions surface. Composes every
+ * permissions *.stories.tsx and renders it in jsdom. See test/portable-stories.tsx.
+ */
 import { smokeStoryModules } from "../../../../test/portable-stories";
 
 const modules = import.meta.glob("../**/*.stories.tsx", { eager: true });

--- a/packages/ui/src/components/permissions/permission-priming.test.ts
+++ b/packages/ui/src/components/permissions/permission-priming.test.ts
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// permission-priming policy: the per-platform priming set (voice-first on iOS,
+// etc.), the presence of rationale copy for every primed permission, and the
+// localStorage-backed "already primed" flag. Pure logic + real localStorage — no
+// OS calls.
 import { afterEach, describe, expect, it } from "vitest";
 import {
   hasPrimedPermissions,

--- a/packages/ui/src/components/permissions/use-permission-priming.test.ts
+++ b/packages/ui/src/components/permissions/use-permission-priming.test.ts
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// usePermissionPriming sequencing: mount-time status check skips already-granted
+// items, "Enable" fires exactly one OS request (soft-ask), denial keeps the card
+// active for recovery, and the sequence advances/completes correctly. The
+// permissions client (`getPermission`/`requestPermission`) is mocked; the hook is real.
 import type {
   PermissionId,
   PermissionState,

--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
-
+//
+// DynamicViewLoader: the same-origin bundle-URL gate (the RCE guard), that the
+// test-only import hook is stripped from minified production builds, and the
+// runtime load/cache/error behavior. The origin gate and the production-strip
+// check compile the REAL DynamicViewLoader.tsx source with esbuild rather than
+// asserting against a mock.
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";

--- a/packages/ui/src/components/views/ShellViewAgentSurface.stories.tsx
+++ b/packages/ui/src/components/views/ShellViewAgentSurface.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook states for ShellViewAgentSurface — the wrapper that makes a builtin
+ * shell page agent-controllable. Stories render placeholder page content across
+ * the gui / terminal / voice view types.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ShellViewAgentSurface } from "./ShellViewAgentSurface";
 

--- a/packages/ui/src/components/views/ShellViewAgentSurface.test.tsx
+++ b/packages/ui/src/components/views/ShellViewAgentSurface.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+//
+// ShellViewAgentSurface: a wrapped shell page answers list-elements / agent-click
+// through the WS interact dispatch, and reports an error for an unsupported
+// capability. The `client` WS transport is mocked; the surface + registry are real.
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/ui/src/components/views/TerminalPluginView.stories.tsx
+++ b/packages/ui/src/components/views/TerminalPluginView.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for TerminalPluginView — the TUI plugin-view surface — across
+ * command/endpoint counts and the no-commands default fallback.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { TerminalPluginView } from "./TerminalPluginView";
 

--- a/packages/ui/src/components/views/TerminalPluginView.test.tsx
+++ b/packages/ui/src/components/views/TerminalPluginView.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// TerminalPluginView: renders the typed TUI status surface, falls back to
+// default commands, runs a command via keyboard/click (asserting the POST body
+// and the `eliza:tui-command` event), and shows failures in the transcript.
+// `fetchWithCsrf` is mocked; the component and its interact wiring are real.
 
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/packages/ui/src/components/views/TerminalPluginView.tsx
+++ b/packages/ui/src/components/views/TerminalPluginView.tsx
@@ -1,3 +1,11 @@
+/**
+ * Terminal-style surface for a plugin view whose interact protocol is TUI
+ * rather than GUI. Renders the view's declared capabilities as clickable
+ * commands and its endpoints as chips, then POSTs each command to
+ * `/api/views/:id/interact?viewType=tui` (via CSRF-guarded fetch) and appends
+ * the JSON result to an in-panel transcript. Also emits an `eliza:tui-command`
+ * DOM event per run for host-side observers.
+ */
 import {
   Activity,
   CheckCircle2,

--- a/packages/ui/src/components/views/ViewIcon.stories.tsx
+++ b/packages/ui/src/components/views/ViewIcon.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook states for ViewIcon covering each resolution path: a named lucide
+ * glyph, an image source (URL / data URI), the keyword fallback, and a size
+ * override via className.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ViewIcon } from "./ViewIcon";
 
@@ -27,7 +32,7 @@ export const ImageSource: Story = {
   },
 };
 
-/** Unknown / missing icon falls back to the first letter of the label. */
+/** Unknown / missing icon falls back to a keyword-inferred glyph from the label. */
 export const LetterFallback: Story = {
   args: { icon: null, label: "Wallet" },
 };

--- a/packages/ui/src/components/views/ViewIcon.test.tsx
+++ b/packages/ui/src/components/views/ViewIcon.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+//
+// ViewIcon resolution paths: image sources render an <img>; known lucide names
+// render the named glyph with the passed className; unknown/absent icons fall
+// through to keyword inference and finally the grid glyph. Locks the #5
+// regression where distinct system views collapsed onto the same placeholder.
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { ViewIcon } from "./ViewIcon";

--- a/packages/ui/src/components/views/ViewIcon.tsx
+++ b/packages/ui/src/components/views/ViewIcon.tsx
@@ -1,3 +1,11 @@
+/**
+ * Resolves a view's icon to a rendered glyph for launcher tiles and nav rows.
+ * An `icon` that is a data-URI / URL / absolute path renders as an `<img>`; a
+ * named lucide key resolves from the ICONS map; anything unknown (or absent)
+ * falls back to a keyword match against the view's label/id (KEYWORD_ICONS,
+ * first-match-wins) so every view still gets a distinct, meaningful glyph
+ * rather than a generic grid fallback.
+ */
 import {
   Activity,
   AppWindow,

--- a/packages/ui/src/components/views/ViewTileImage.tsx
+++ b/packages/ui/src/components/views/ViewTileImage.tsx
@@ -11,8 +11,7 @@ import { emitViewInteraction } from "../../view-telemetry";
 import { ViewIcon } from "./ViewIcon";
 
 // Brand rule: no blue anywhere — the deterministic tile gradients stay in the
-// warm/neutral/green range (former blue + indigo entries were recolored to
-// gold + fuchsia).
+// warm/neutral/green/gold/fuchsia range.
 const LAUNCHER_ICON_PALETTES: ReadonlyArray<{
   from: string;
   to: string;

--- a/packages/ui/src/components/views/__tests__/views-stories-smoke.test.tsx
+++ b/packages/ui/src/components/views/__tests__/views-stories-smoke.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+/**
+ * Portable-stories smoke test for the views surface. Composes every views
+ * *.stories.tsx and renders it in jsdom. See test/portable-stories.tsx.
+ */
 import { smokeStoryModules } from "../../../../test/portable-stories";
 
 const modules = import.meta.glob("../**/*.stories.tsx", { eager: true });

--- a/packages/ui/src/components/views/view-icon-aliases.test.ts
+++ b/packages/ui/src/components/views/view-icon-aliases.test.ts
@@ -1,3 +1,6 @@
+// resolveViewIconId maps plugin/builtin view ids onto their nearest baked icon,
+// passes through ids that resolve directly, and every alias target is verified
+// against the real generated VIEW_ICONS map so no alias points at a missing icon.
 import { describe, expect, it } from "vitest";
 import { resolveViewIconId, VIEW_ICON_ALIASES } from "./view-icon-aliases";
 import { VIEW_ICONS } from "./view-icons.generated";

--- a/packages/ui/src/components/views/view-interact-registry.test.ts
+++ b/packages/ui/src/components/views/view-interact-registry.test.ts
@@ -1,3 +1,6 @@
+// view-interact-registry: dispatchViewInteract routes to handlers keyed by view
+// type + logical view id and returns results over the WS transport. The `client`
+// transport is mocked; the registry itself is the real module under test.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const sendWsMessage = vi.fn();


### PR DESCRIPTION
Comments-only slice of #12234. `check:comment-only` passes (33 files changed; every code token identical to origin/develop).

## Scope
Chunk **b04-views-config-perms** — three `@elizaos/ui` component subtrees:
- `packages/ui/src/components/views`
- `packages/ui/src/components/config-ui`
- `packages/ui/src/components/permissions`

## What changed
- Added top-of-file prose headers to in-scope files that lacked one (components, helpers, stories, tests). Headers state what the file does in system terms per the root CLAUDE.md convention (React components: what they render + where they mount + design constraints; tests: surface under test + how real the harness is — real module vs mocked transport).
- Rewrote churn-phrased comments into present-tense fact (e.g. `ViewTileImage` brand-rule note).
- Corrected an inaccurate story-doc comment in `ViewIcon.stories.tsx` (the fallback is a keyword-inferred glyph, not a "first letter").
- Left already-good headers untouched (e.g. `DynamicViewLoader.tsx`, `KeepAliveViewHost.tsx`, `ViewErrorBoundary.tsx`, `permission-priming.ts`, `use-permission-priming.ts`, `PermissionPrimingModal.tsx`, `PermissionPrimingOverlay.tsx`, both `__e2e__` files).

## Verification
`node scripts/assert-comment-only-diff.mjs` → OK; every code token byte-for-byte identical to `origin/develop`. Comments only; zero functional diff.

Part of #12234.