### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-shared-conv-acct

### DIFF
--- a/packages/ui/src/components/accounts/AccountCard.stories.tsx
+++ b/packages/ui/src/components/accounts/AccountCard.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for AccountCard across provider/health/usage states, under a stub AppContext supplying `t`. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { AccountWithCredentialFlag } from "../../api/client-agent";
 import type { AppContextValue } from "../../state/types";

--- a/packages/ui/src/components/accounts/AddAccountDialog.stories.tsx
+++ b/packages/ui/src/components/accounts/AddAccountDialog.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for AddAccountDialog across its credential-entry paths, under a stub AppContext supplying `t`. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { AppContextValue } from "../../state/types";
 import { AppContext } from "../../state/useApp";

--- a/packages/ui/src/components/accounts/EditableAccountLabel.stories.tsx
+++ b/packages/ui/src/components/accounts/EditableAccountLabel.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for EditableAccountLabel: display, edit, and disabled states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { EditableAccountLabel } from "./EditableAccountLabel";
 

--- a/packages/ui/src/components/accounts/EditableAccountLabel.tsx
+++ b/packages/ui/src/components/accounts/EditableAccountLabel.tsx
@@ -1,3 +1,11 @@
+/**
+ * Click-to-edit label used for an account's display name inside `AccountCard`.
+ * Shows the value with a pencil affordance; entering edit mode swaps in an
+ * inline input that commits on Enter/blur and reverts on Escape. Persistence is
+ * the caller's — `onSubmit(label)` may be async; an empty, unchanged, or
+ * rejected value reverts to the previous label.
+ */
+
 import { Pencil } from "lucide-react";
 import {
   type FormEvent,

--- a/packages/ui/src/components/accounts/RotationStrategyPicker.stories.tsx
+++ b/packages/ui/src/components/accounts/RotationStrategyPicker.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for RotationStrategyPicker across the account rotation strategies, under a stub AppContext supplying `t`. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { AppContextValue } from "../../state/types";
 import { AppContext } from "../../state/useApp";

--- a/packages/ui/src/components/accounts/__tests__/accounts-stories-smoke.test.tsx
+++ b/packages/ui/src/components/accounts/__tests__/accounts-stories-smoke.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+/** jsdom smoke gate: renders every accounts/ Storybook story and asserts it mounts without throwing. */
 import { smokeStoryModules } from "../../../../test/portable-stories";
 
 const modules = import.meta.glob("../**/*.stories.tsx", { eager: true });

--- a/packages/ui/src/components/conversations/ConversationRenameDialog.tsx
+++ b/packages/ui/src/components/conversations/ConversationRenameDialog.tsx
@@ -1,3 +1,11 @@
+/**
+ * Stateful rename dialog for a conversation: owns the draft title and the
+ * suggest/save pending flags, wiring the presentational
+ * `ChatConversationRenameDialog` to the app-store `handleRenameConversation` /
+ * `suggestConversationTitle` handlers. "Suggest" asks the agent for a title and
+ * fills the draft; "Save" persists a non-empty trimmed title and closes.
+ */
+
 import { useEffect, useState } from "react";
 import { useAppSelector } from "../../state";
 import { ChatConversationRenameDialog } from "../composites/chat/chat-conversation-rename-dialog";

--- a/packages/ui/src/components/conversations/ConversationsSidebar.stories.tsx
+++ b/packages/ui/src/components/conversations/ConversationsSidebar.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for ConversationsSidebar over a seeded app-context conversation set (fixed clock for stable relative-time buckets). */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { Conversation } from "../../api/client-types-chat";
 import { seedAppValue } from "../../state/app-store";

--- a/packages/ui/src/components/conversations/ConversationsSidebar.test.tsx
+++ b/packages/ui/src/components/conversations/ConversationsSidebar.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * Render + interaction tests for ConversationsSidebar's dashboard-conversation
+ * path: list render, new-chat, selection, and the rename/delete menu flows,
+ * plus the mobile variant. Drives the real component with mocked app state +
+ * client and an inert inbox poll so only the conversation path is exercised.
+ */
+
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/components/conversations/ConversationsSidebar.tsx
+++ b/packages/ui/src/components/conversations/ConversationsSidebar.tsx
@@ -1,3 +1,19 @@
+/**
+ * The chat surface's left rail: a unified, source-scoped list of conversations.
+ * It merges three streams into one flat, time-bucketed model — dashboard
+ * conversations, connector inbox chats (Discord, Telegram, …, polled every few
+ * seconds), and Terminal PTY sessions — each carrying a namespaced id
+ * (`inbox:` / `terminal:`) so selection stays unambiguous against dashboard
+ * UUIDs. A source/world scope dropdown filters the list; the keyword-search
+ * panel (`MessageSearchPanel`) can jump to a message, loading a window centered
+ * on an out-of-view hit before scrolling to it.
+ *
+ * List shaping (sections, scope options, bucket ranks) lives in
+ * `conversation-sidebar-model.ts`; this component owns fetching, polling,
+ * selection, rename/delete, collapsed/expanded rail rendering, and the mobile
+ * drawer. Barrel-exported and mounted inside the chat panel layout.
+ */
+
 import {
   MessagesSquare,
   Plus,

--- a/packages/ui/src/components/conversations/brand-icons.tsx
+++ b/packages/ui/src/components/conversations/brand-icons.tsx
@@ -1,3 +1,10 @@
+/**
+ * `currentColor` SVG glyphs for connector brands (Discord, Slack, Teams,
+ * Signal, Google Chat, …) and `getBrandIcon`, which resolves a free-form source
+ * string to one by stripping non-alphanumerics. Used by the conversations
+ * sidebar to badge inbox chats by their connector.
+ */
+
 import type * as React from "react";
 
 type BrandIconProps = {

--- a/packages/ui/src/components/conversations/conversation-sidebar-model.test.ts
+++ b/packages/ui/src/components/conversations/conversation-sidebar-model.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for `buildConversationsSidebarModel`: row shaping, time-bucketed sections, and source/world scope options over synthetic conversations + inbox chats (no rendering). */
+
 import { describe, expect, it } from "vitest";
 import type { Conversation } from "../../api/client-types-chat";
 import type { TranslateFn } from "../../types";

--- a/packages/ui/src/components/conversations/conversation-sidebar-model.ts
+++ b/packages/ui/src/components/conversations/conversation-sidebar-model.ts
@@ -1,3 +1,14 @@
+/**
+ * Pure view-model builder for the conversations sidebar. Given raw dashboard
+ * conversations, connector inbox chats, and the active source/world scope,
+ * `buildConversationsSidebarModel` produces the flat row list, its time-bucketed
+ * sections, and the source/world filter options with counts. Kept separate from
+ * `ConversationsSidebar.tsx` so the shaping logic is unit-testable without
+ * rendering. The `*_SCOPE` string constants are the sentinel scope values shared
+ * with the component; bucket-rank ceilings keep day/week/month/year groups
+ * ordered under a single numeric `sortKey`.
+ */
+
 import { normalizeConnectorSource } from "@elizaos/shared";
 import type * as React from "react";
 import type { Conversation } from "../../api/client-types-chat";

--- a/packages/ui/src/components/conversations/conversation-utils.ts
+++ b/packages/ui/src/components/conversations/conversation-utils.ts
@@ -1,3 +1,11 @@
+/**
+ * Presentation helpers for the conversations sidebar: localized title fallback
+ * ("New Chat"), a stable avatar index hashed from a conversation id, provider
+ * label resolution from a model string, an embedding/utility-model classifier,
+ * and the browser/computer capability plugin-id sets used to badge rows. Pure
+ * and framework-free (re-exports `formatRelativeTime` for callers).
+ */
+
 import { VRM_COUNT } from "../../state";
 import { formatRelativeTime } from "../../utils/format";
 

--- a/packages/ui/src/components/custom-actions/CustomActionEditor.stories.tsx
+++ b/packages/ui/src/components/custom-actions/CustomActionEditor.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for CustomActionEditor across handler types and create/edit modes, under a stub AppContext supplying `t`. */
+
 import type { CustomActionDef } from "@elizaos/shared";
 import type { Meta, StoryObj } from "@storybook/react";
 import type { AppContextValue } from "../../state/types";

--- a/packages/ui/src/components/custom-actions/CustomActionEditor.tsx
+++ b/packages/ui/src/components/custom-actions/CustomActionEditor.tsx
@@ -1,3 +1,12 @@
+/**
+ * Modal form for authoring/editing a single custom action: name, similes,
+ * description, parameters, and the handler (HTTP request, shell command, or
+ * inline code). Field parsing/validation lives in `custom-action-form.ts`; this
+ * component owns the form state and calls `onSave` with the assembled
+ * `CustomActionDef`. It can seed itself from a natural-language description via
+ * the client's action generation, then let the user refine the parsed result.
+ */
+
 import type { CustomActionDef, CustomActionHandler } from "@elizaos/shared";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useEffect, useState } from "react";

--- a/packages/ui/src/components/custom-actions/CustomActionsPanel.stories.tsx
+++ b/packages/ui/src/components/custom-actions/CustomActionsPanel.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for CustomActionsPanel (the slide-out list) under a MockAppProvider supplying `t` and a stubbed client. */
+
 import type { Decorator, Meta, StoryObj } from "@storybook/react";
 import { type ReactElement, useEffect, useRef } from "react";
 import {

--- a/packages/ui/src/components/custom-actions/CustomActionsPanel.tsx
+++ b/packages/ui/src/components/custom-actions/CustomActionsPanel.tsx
@@ -1,3 +1,11 @@
+/**
+ * Slide-out panel listing the agent's custom actions with search, an
+ * enable/disable switch per action, and delete. Fetches via
+ * `client.listCustomActions` when opened; editing is delegated upward through
+ * `onOpenEditor` (the parent owns the `CustomActionEditor` modal). This is the
+ * overlay presentation of the same data the full-page `CustomActionsView` owns.
+ */
+
 import type { CustomActionDef } from "@elizaos/shared";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { client } from "../../api/client";

--- a/packages/ui/src/components/custom-actions/CustomActionsView.tsx
+++ b/packages/ui/src/components/custom-actions/CustomActionsView.tsx
@@ -1,3 +1,11 @@
+/**
+ * Full-page management view for custom actions (barrel-exported, routed as an
+ * app surface). Lists actions with search, per-row enable/disable and delete,
+ * bulk JSON import/export, and hosts the `CustomActionEditor` modal for
+ * create/edit. All persistence goes through `client.*CustomAction*`; the list
+ * refreshes after each mutation.
+ */
+
 import type { CustomActionDef } from "@elizaos/shared";
 import { useCallback, useEffect, useId, useState } from "react";
 import { client } from "../../api/client";

--- a/packages/ui/src/components/custom-actions/__tests__/customactions-stories-smoke.test.tsx
+++ b/packages/ui/src/components/custom-actions/__tests__/customactions-stories-smoke.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+/** jsdom smoke gate: renders every custom-actions/ Storybook story and asserts it mounts without throwing. */
 import { smokeStoryModules } from "../../../../test/portable-stories";
 
 const modules = import.meta.glob("../**/*.stories.tsx", { eager: true });

--- a/packages/ui/src/components/custom-actions/custom-action-form.ts
+++ b/packages/ui/src/components/custom-actions/custom-action-form.ts
@@ -1,3 +1,12 @@
+/**
+ * Pure form model behind the custom-action editor: field types, the editor's
+ * shared class names, name/alias/parameter/method normalizers, and parsers that
+ * coerce a loosely-typed generated payload into a validated `ParsedGeneration`
+ * (one branch per handler kind: http/shell/code, each rejecting missing required
+ * fields). No React — the editor imports these to normalize input and to seed
+ * itself from `client.generateCustomAction`.
+ */
+
 import type { CustomActionHandler } from "@elizaos/shared";
 
 /* ── Types ─────────────────────────────────────────────────────────── */

--- a/packages/ui/src/components/release-center/__tests__/releasecenter-stories-smoke.test.tsx
+++ b/packages/ui/src/components/release-center/__tests__/releasecenter-stories-smoke.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+/** jsdom smoke gate: renders every release-center/ Storybook story and asserts it mounts without throwing. */
 import { smokeStoryModules } from "../../../../test/portable-stories";
 
 const modules = import.meta.glob("../**/*.stories.tsx", { eager: true });

--- a/packages/ui/src/components/release-center/sections.stories.tsx
+++ b/packages/ui/src/components/release-center/sections.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for the Release Center sections (status, notes, build/runtime, session, WebGPU), under a stub AppContext supplying `t`. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { useRef } from "react";
 import type { AppContextValue } from "../../state/internal";

--- a/packages/ui/src/components/release-center/sections.tsx
+++ b/packages/ui/src/components/release-center/sections.tsx
@@ -1,3 +1,11 @@
+/**
+ * The individual sections composed by `ReleaseCenterView` (desktop Release
+ * Center): update status/check, release notes, build + runtime info, desktop
+ * session controls (renderer, restart), and the WebGPU surface probe. Each is a
+ * presentational section driven by props the view supplies; shared row/pill
+ * primitives come from `./shared` and text/URL helpers from `./shared.helpers`.
+ */
+
 import { createElement } from "react";
 import { useBranding } from "../../config/branding";
 import { useAppSelector } from "../../state";

--- a/packages/ui/src/components/release-center/shared.helpers.ts
+++ b/packages/ui/src/components/release-center/shared.helpers.ts
@@ -1,3 +1,10 @@
+/**
+ * Pure text/URL helpers for the Release Center: `summarizeError` (message from
+ * an unknown throwable), `normalizeReleaseNotesUrl` (validated URL, falling back
+ * to the GitHub releases page), and `partitionDescription` (localized label for
+ * a desktop session partition). No React.
+ */
+
 import { EXTERNAL_URLS } from "@elizaos/shared/brand";
 
 const DEFAULT_RELEASE_NOTES_URL = `${EXTERNAL_URLS.github}/releases`;

--- a/packages/ui/src/components/release-center/shared.stories.tsx
+++ b/packages/ui/src/components/release-center/shared.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for the Release Center shared primitives (StatusPill tones, DefinitionRow), under a stub AppContext supplying `t`. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { AppContextValue } from "../../state/types";
 import { AppContext } from "../../state/useApp";

--- a/packages/ui/src/components/release-center/shared.tsx
+++ b/packages/ui/src/components/release-center/shared.tsx
@@ -1,3 +1,10 @@
+/**
+ * Small presentational primitives shared across the Release Center sections: a
+ * `StatusPill` mapping a neutral/good/warning tone onto the `StatusBadge`
+ * variants, and a `DefinitionRow` (label + value with an "Unavailable"
+ * fallback).
+ */
+
 import { useAppSelector } from "../../state";
 import { StatusBadge, type StatusVariant } from "../ui/status-badge";
 

--- a/packages/ui/src/components/release-center/types.ts
+++ b/packages/ui/src/components/release-center/types.ts
@@ -1,3 +1,5 @@
+/** Shared shapes for the Release Center: app/updater release status, desktop build+session snapshots, WebGPU probe types, and the session-partition constants. */
+
 export type AppReleaseStatus = {
   currentVersion?: string;
   latestVersion?: string | null;

--- a/packages/ui/src/components/shared/AppPageSidebar.stories.tsx
+++ b/packages/ui/src/components/shared/AppPageSidebar.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for AppPageSidebar: default/collapsible/header+action/mobile variants over a stub nav list. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { AppPageSidebar } from "./AppPageSidebar";
 

--- a/packages/ui/src/components/shared/AppPageSidebar.tsx
+++ b/packages/ui/src/components/shared/AppPageSidebar.tsx
@@ -1,3 +1,13 @@
+/**
+ * Opinionated wrapper over the composite `Sidebar` for in-page left rails
+ * (conversations, wallet, config, etc.), applying the app's chromeless page
+ * skin: no right-edge hairline, transparent background, an inline collapse
+ * button in the footer. Adds width + collapsed persistence keyed by
+ * `contentIdentity`/`syncId` in localStorage, and supports both controlled and
+ * uncontrolled collapsed/width. The desktop `default` variant resizes and
+ * persists; `mobile`/`game-modal` variants inherit the base sidebar behavior.
+ */
+
 import { PanelLeftClose } from "lucide-react";
 import * as React from "react";
 import { useCallback, useMemo, useState } from "react";

--- a/packages/ui/src/components/shared/CollapsibleSidebarSection.stories.tsx
+++ b/packages/ui/src/components/shared/CollapsibleSidebarSection.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for CollapsibleSidebarSection: expanded/collapsed, add-action, icon+indicator, and empty state. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { Folder } from "lucide-react";
 import { CollapsibleSidebarSection } from "./CollapsibleSidebarSection";

--- a/packages/ui/src/components/shared/CollapsibleSidebarSection.tsx
+++ b/packages/ui/src/components/shared/CollapsibleSidebarSection.tsx
@@ -1,3 +1,12 @@
+/**
+ * A collapsible labeled group inside a sidebar: a toggle header (chevron +
+ * optional icon/indicator + optional add-action), and a body that shows its
+ * children, an empty-state label, or nothing when collapsed. Collapse state is
+ * owned by the caller (`collapsed` + `onToggleCollapsed(sectionKey)`) so a
+ * sidebar can persist many sections under one key. On desktop the chevron and
+ * add-button fade in on section hover unless `hoverActionsOnDesktop` is off.
+ */
+
 import { ChevronDown, ChevronRight, Plus } from "lucide-react";
 import * as React from "react";
 import { Button } from "../ui/button";

--- a/packages/ui/src/components/shared/LanguageDropdown.helpers.ts
+++ b/packages/ui/src/components/shared/LanguageDropdown.helpers.ts
@@ -1,3 +1,5 @@
+/** Supported UI languages (flag + native label) and shared trigger styling for the LanguageDropdown. */
+
 import type { UiLanguage } from "../../i18n/messages";
 
 /** Language metadata with flag emoji and native label. */

--- a/packages/ui/src/components/shared/LanguageDropdown.stories.tsx
+++ b/packages/ui/src/components/shared/LanguageDropdown.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for LanguageDropdown across languages and the native/titlebar/companion variants (decorator holds local language state). */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import type { UiLanguage } from "../../i18n/messages";

--- a/packages/ui/src/components/shared/LanguageDropdown.tsx
+++ b/packages/ui/src/components/shared/LanguageDropdown.tsx
@@ -1,3 +1,12 @@
+/**
+ * UI-language picker: a flag + language-code trigger opening a checkmarked
+ * dropdown of the supported `UiLanguage`s. The host owns the value —
+ * `setUiLanguage` is called on select. `variant` skins it for the three mount
+ * contexts (native settings, in-chat companion overlay, window titlebar); the
+ * companion variant raises z-index above overlay chrome. `data-no-camera-drag`
+ * exempts the control from the home-screen pan gesture.
+ */
+
 import { Check, ChevronDown } from "lucide-react";
 import { useState } from "react";
 import type { UiLanguage } from "../../i18n/messages";

--- a/packages/ui/src/components/shared/ThemeToggle.stories.tsx
+++ b/packages/ui/src/components/shared/ThemeToggle.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for ThemeToggle: light/dark and the titlebar variant (render fn holds local theme state so the icon flips on click). */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import type { UiTheme } from "../../state/persistence";

--- a/packages/ui/src/components/shared/ThemeToggle.tsx
+++ b/packages/ui/src/components/shared/ThemeToggle.tsx
@@ -1,3 +1,11 @@
+/**
+ * Sun/moon icon button that flips the UI between light and dark. The host owns
+ * the value — `setUiTheme` is called with the opposite theme on click.
+ * `variant` skins it for the native settings, in-chat companion, and titlebar
+ * mount contexts; `data-no-camera-drag` exempts it from the home-screen pan
+ * gesture.
+ */
+
 import { Moon, Sun } from "lucide-react";
 import { useCallback } from "react";
 import type { UiTheme } from "../../state/persistence";

--- a/packages/ui/src/components/shared/__tests__/shared-stories-smoke.test.tsx
+++ b/packages/ui/src/components/shared/__tests__/shared-stories-smoke.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+/** jsdom smoke gate: renders every shared/ Storybook story and asserts it mounts without throwing. */
 import { smokeStoryModules } from "../../../../test/portable-stories";
 
 const modules = import.meta.glob("../**/*.stories.tsx", { eager: true });

--- a/packages/ui/src/components/shared/confirm-delete-control.stories.tsx
+++ b/packages/ui/src/components/shared/confirm-delete-control.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for ConfirmDeleteControl: default, custom labels, ghost/outline variants, disabled, and busy state, under a stub AppContext supplying `t`. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ReactNode } from "react";
 import type { AppContextValue } from "../../state/types";

--- a/packages/ui/src/components/shared/confirm-delete-control.tsx
+++ b/packages/ui/src/components/shared/confirm-delete-control.tsx
@@ -1,3 +1,12 @@
+/**
+ * Inline two-step delete confirmation: a trigger button that, once clicked,
+ * swaps in place for a prompt + Confirm/Cancel pair (no modal). Each of the
+ * three buttons registers as an agent element via `useAgentElement` so the
+ * agent can drive the flow; labels fall back to the i18n `common.*` /
+ * `conversations.deleteConfirm` keys. Class names for each button are supplied
+ * by the caller so it inherits the host surface's styling.
+ */
+
 import { type ReactNode, useId, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import { useAppSelector } from "../../state";


### PR DESCRIPTION
Comments-only slice of #12234. `check:comment-only` passes (every code token byte-for-byte identical to `origin/develop`).

## Scope
Chunk **b04-shared-conv-acct** — `packages/ui/src/components/` under:
`shared/`, `conversations/`, `accounts/`, `custom-actions/`, `release-center/`.

## What changed
Added top-of-file `/** … */` prose headers per the repo comment convention (first sentence = what the file does in system terms; then relationships/invariants as warranted). A handful of in-body clarifications only; no restatement, no churn narration, no commented-out code.

- **shared/**: `AppPageSidebar`, `CollapsibleSidebarSection`, `LanguageDropdown`(+`.helpers`), `ThemeToggle`, `confirm-delete-control` + their stories; shared stories smoke test.
- **conversations/**: `ConversationsSidebar` (load-bearing header), `ConversationRenameDialog`, `brand-icons`, `conversation-sidebar-model`, `conversation-utils` + stories/tests.
- **accounts/**: `EditableAccountLabel` + the story files and stories-smoke test (component files here already had headers and were left untouched).
- **custom-actions/**: `CustomActionEditor`, `CustomActionsPanel`, `CustomActionsView`, `custom-action-form` + stories/smoke test.
- **release-center/**: `sections`, `shared`, `shared.helpers`, `types` + stories/smoke test.

## Coverage
40 files touched of 49 in-scope. The 9 untouched files already carried proper prose headers (`ViewHeader`, `ViewHeaderSidebarTrigger`, `AccountCard`, `AccountList`, `AddAccountDialog`, `RotationStrategyPicker`, `AccountList.stories`, `ConversationsSidebar.jump.test`, `conversations.stories.test`). Chunk fully covered — 0 files remaining without a proper header.

## Verification
`node scripts/assert-comment-only-diff.mjs` → OK, 40 source files changed, comments only. Rebased clean onto current `origin/develop`.

Part of #12234.