### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-apps

### DIFF
--- a/packages/ui/src/components/apps/AppIdentity.stories.tsx
+++ b/packages/ui/src/components/apps/AppIdentity.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook stories for `AppIdentityTile` (and `AppHero`) across categories,
+ * sizes, active/image-only/glyph variants, and the art-less monogram fallback.
+ */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   AppHero,

--- a/packages/ui/src/components/apps/AppWindowRenderer.helpers.test.tsx
+++ b/packages/ui/src/components/apps/AppWindowRenderer.helpers.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Covers `getOverlayAppLazyComponent` — the per-loader lazy-component cache and
+ * its retained-lazy warm-up — in jsdom with a stubbed `requestIdleCallback`.
+ * Overlay apps are in-memory fixtures; no real plugin modules are loaded.
+ */
+
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ComponentType } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/apps/AppWindowRenderer.helpers.ts
+++ b/packages/ui/src/components/apps/AppWindowRenderer.helpers.ts
@@ -1,3 +1,10 @@
+/**
+ * Builds and memoizes the lazily-loaded component for an overlay app, wrapping
+ * its loader in a `RetainedLazyComponent` (so the module stays warm across
+ * remounts) with shared loading/error fallbacks. Results are cached per loader
+ * in a `WeakMap` so repeated renders of the same app reuse one lazy component.
+ */
+
 import { type ComponentType, createElement } from "react";
 import { RetainedLazyComponent } from "../../retained-lazy";
 import {

--- a/packages/ui/src/components/apps/AppWindowRenderer.stories.tsx
+++ b/packages/ui/src/components/apps/AppWindowRenderer.stories.tsx
@@ -1,3 +1,9 @@
+/**
+ * Storybook stories for `AppWindowRenderer`: renders a registered mock overlay
+ * app through the slug-resolution + Suspense path, plus the not-found and
+ * case-insensitive-slug states.
+ */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ReactElement } from "react";
 import { AppWindowRenderer } from "./AppWindowRenderer";

--- a/packages/ui/src/components/apps/AppWindowRenderer.tsx
+++ b/packages/ui/src/components/apps/AppWindowRenderer.tsx
@@ -1,3 +1,11 @@
+/**
+ * Resolves an overlay app by slug and mounts its lazily-loaded component in a
+ * Suspense boundary — the render path behind an `/apps/<slug>` window route.
+ * Because overlay apps register asynchronously off the first-paint critical
+ * path, a deep-linked window can mount before its app registers, so this
+ * re-resolves on a short bounded poll before settling on "App not found".
+ */
+
 import {
   type ComponentType,
   Suspense,

--- a/packages/ui/src/components/apps/AppsCatalogGrid.stories.tsx
+++ b/packages/ui/src/components/apps/AppsCatalogGrid.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook stories for `AppsCatalogGrid`, wrapped in a stub `AppContext`, across
+ * populated, loading, error, and search-filtered states.
+ */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ReactNode } from "react";
 import type { RegistryAppInfo } from "../../api";

--- a/packages/ui/src/components/apps/AppsCatalogGrid.tsx
+++ b/packages/ui/src/components/apps/AppsCatalogGrid.tsx
@@ -1,3 +1,10 @@
+/**
+ * Renders the apps catalog as favorited/section-grouped hero cards, packing
+ * sections into responsive rows sized to the measured container width (1–5
+ * cards per row). Shows skeletons while loading, an error state with retry, and
+ * a per-card favorite toggle; launching a card is delegated to `onLaunch`.
+ */
+
 import { Star } from "lucide-react";
 import {
   type MouseEvent,

--- a/packages/ui/src/components/apps/AppsSidebar.stories.tsx
+++ b/packages/ui/src/components/apps/AppsSidebar.stories.tsx
@@ -1,3 +1,9 @@
+/**
+ * Storybook stories for `AppsSidebar`, wrapped in a stub translation context,
+ * across populated, starred/active, empty, and selected-item states with
+ * controlled collapse/width wired through local state.
+ */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ReactNode } from "react";
 import { useState } from "react";

--- a/packages/ui/src/components/apps/AppsSidebar.tsx
+++ b/packages/ui/src/components/apps/AppsSidebar.tsx
@@ -1,3 +1,11 @@
+/**
+ * Collapsible, resizable sidebar for the apps surface: lists running runs,
+ * favorites, and genre-grouped catalog apps, with launch and open-run actions.
+ * Collapsed/expanded state and width are controlled by the parent; genre
+ * ordering follows the fixed `GENRE_ORDER`. Built on the shared sidebar
+ * composites (`SidebarPanel`/`SidebarContent`/`SidebarScrollRegion`).
+ */
+
 import { Play, Star } from "lucide-react";
 import { memo, type ReactNode, useCallback, useMemo } from "react";
 import type { AppRunSummary, RegistryAppInfo } from "../../api";

--- a/packages/ui/src/components/apps/EmbeddedAppViewer.test.tsx
+++ b/packages/ui/src/components/apps/EmbeddedAppViewer.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Covers `EmbeddedAppViewer`'s `*_READY` → auth postMessage handshake and its
+ * origin-pinning: runs in jsdom with hand-dispatched `MessageEvent`s standing in
+ * for the iframe, asserting the auth payload only posts to a verified origin.
+ */
+
 import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { EmbeddedAppViewer } from "./EmbeddedAppViewer";

--- a/packages/ui/src/components/apps/FullscreenView.helpers.ts
+++ b/packages/ui/src/components/apps/FullscreenView.helpers.ts
@@ -1,3 +1,9 @@
+/**
+ * Static audit manifest of the desktop-only click targets in the game view
+ * (native window refresh, focus, ...), consumed by the desktop-workspace click
+ * audit to assert each expected native action has coverage.
+ */
+
 import type { DesktopClickAuditItem } from "../../utils/desktop-workspace";
 
 export const DESKTOP_GAME_CLICK_AUDIT: readonly DesktopClickAuditItem[] = [

--- a/packages/ui/src/components/apps/FullscreenView.tsx
+++ b/packages/ui/src/components/apps/FullscreenView.tsx
@@ -1,11 +1,9 @@
 /**
- * Game View — embeds a running app's game client in an iframe.
- *
- * Features:
- * - Full-screen iframe for game client
- * - PostMessage auth for embedded app viewers
- * - Split-screen mode with agent logs panel
- * - Connection status indicator
+ * Full-screen game/app view mounted by AppsPageView: hosts the active run's
+ * client in a full-window iframe, runs the postMessage auth handshake for
+ * embedded viewers, and offers a split-screen mode with an agent-logs panel and
+ * a connection-status indicator. Auth-payload delivery is delegated to
+ * `EmbeddedAppViewer` when `shouldUseEmbeddedAppViewer` selects it.
  */
 
 import { packageNameToAppRouteSlug } from "@elizaos/shared";

--- a/packages/ui/src/components/apps/GameViewOverlay.tsx
+++ b/packages/ui/src/components/apps/GameViewOverlay.tsx
@@ -1,3 +1,12 @@
+/**
+ * Draggable floating "kiosk" overlay that keeps the active game run's iframe
+ * visible across non-Views tabs — mounted once at the App shell root and driven
+ * by the active-game fields on the app store. Delegates the authenticated
+ * viewer path to `EmbeddedAppViewer` via `shouldUseEmbeddedAppViewer`, and tears
+ * the iframe down when the document is backgrounded so the game loop and its
+ * postMessage auth listener stop running even if the overlay stays mounted.
+ */
+
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDocumentVisibility } from "../../hooks/useDocumentVisibility";
 import { useAppSelectorShallow } from "../../state";

--- a/packages/ui/src/components/apps/RunningAppsRow.stories.tsx
+++ b/packages/ui/src/components/apps/RunningAppsRow.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook stories for `RunningAppsRow` across multiple runs, a single healthy
+ * run, and the stop-button-enabled variant.
+ */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import type { AppRunSummary, RegistryAppInfo } from "../../api";

--- a/packages/ui/src/components/apps/RunningAppsRow.tsx
+++ b/packages/ui/src/components/apps/RunningAppsRow.tsx
@@ -1,3 +1,11 @@
+/**
+ * Horizontal strip of currently-running app runs: each entry shows the app's
+ * hero, a health-tone status dot, any attention reasons from
+ * `getRunAttentionReasons`, and a stop button. Opening or stopping a run is
+ * delegated to `onOpenRun`/`onStopRun`; `busyRunId`/`stoppingRunId` disable the
+ * affected entry while an action is in flight.
+ */
+
 import { Square } from "lucide-react";
 import { type MouseEvent, memo, useMemo } from "react";
 import type { AppRunSummary, RegistryAppInfo } from "../../api";

--- a/packages/ui/src/components/apps/__tests__/apps-stories-smoke.test.tsx
+++ b/packages/ui/src/components/apps/__tests__/apps-stories-smoke.test.tsx
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+
+/**
+ * Smoke-renders every `apps/**` Storybook story in jsdom to catch import/render
+ * crashes; the stories are the real modules, glob-loaded eagerly.
+ */
+
 import { smokeStoryModules } from "../../../../test/portable-stories";
 
 const modules = import.meta.glob("../**/*.stories.tsx", { eager: true });

--- a/packages/ui/src/components/apps/app-identity.helpers.test.ts
+++ b/packages/ui/src/components/apps/app-identity.helpers.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers `resolveRuntimeImageUrl` — how runtime-relative icon/hero paths resolve
+ * to fetchable URLs. The api client and asset-url resolvers are mocked so URL
+ * routing is asserted without a running server.
+ */
+
 import { describe, expect, it, vi } from "vitest";
 
 const clientMock = vi.hoisted(() => ({

--- a/packages/ui/src/components/apps/app-identity.helpers.ts
+++ b/packages/ui/src/components/apps/app-identity.helpers.ts
@@ -1,3 +1,12 @@
+/**
+ * Icon/image resolution helpers for the app-identity tiles: maps an app's
+ * category to a Lucide icon, resolves a raw icon/hero value to a renderable
+ * source, and rewrites runtime-relative image paths to a fetchable URL. The
+ * runtime resolver routes API-resource paths to `resolveApiUrl` vs asset paths
+ * to `resolveAppAssetUrl` based on the host's app-shell capability flags, so
+ * limited cloud-agent hosts don't request routes they can't serve.
+ */
+
 import { getAppHeroThemeKey } from "@elizaos/shared";
 import {
   Bot,

--- a/packages/ui/src/components/apps/app-identity.stories.tsx
+++ b/packages/ui/src/components/apps/app-identity.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook stories for `AppIdentityTile` variants — apps with an icon, a hero
+ * image, and no art — exercising the tile's asset-fallback rendering.
+ */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   AppHero,

--- a/packages/ui/src/components/apps/app-identity.tsx
+++ b/packages/ui/src/components/apps/app-identity.tsx
@@ -1,3 +1,11 @@
+/**
+ * Presentational app-branding primitives shared by every apps surface (catalog
+ * grid, sidebar, running-apps row, home tiles): `AppIdentityTile` renders an
+ * app's icon and `AppHero` renders its hero image. Both fall back through
+ * category-icon → generated hero data URL → monogram when no real asset is
+ * available, so an app without art still gets a stable, themed placeholder.
+ */
+
 import {
   createGeneratedAppHeroDataUrl,
   getAppHeroMonogram,

--- a/packages/ui/src/components/apps/apps-cache.ts
+++ b/packages/ui/src/components/apps/apps-cache.ts
@@ -1,3 +1,10 @@
+/**
+ * localStorage-backed cache of the last-fetched apps catalog, used to paint the
+ * apps grid instantly on boot before the network fetch resolves. Reads validate
+ * each entry against a minimal `RegistryAppInfo` shape guard and drop the whole
+ * cache on any malformed or unparseable payload.
+ */
+
 import type { RegistryAppInfo } from "@elizaos/shared";
 
 const CACHE_KEY = "eliza:apps:catalog:v1";

--- a/packages/ui/src/components/apps/catalog-loader.test.ts
+++ b/packages/ui/src/components/apps/catalog-loader.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers `loadMergedCatalogApps`, focusing on the AOSP overlay-app filter: the
+ * api client, Capacitor platform, and navigator user-agent are mocked so the
+ * androidOnly-tile gating is asserted across Eliza-AOSP vs stock-Android hosts.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ELIZAOS_AOSP_UA =

--- a/packages/ui/src/components/apps/catalog-loader.ts
+++ b/packages/ui/src/components/apps/catalog-loader.ts
@@ -1,3 +1,12 @@
+/**
+ * Merges the four app sources — registry catalog, installed apps, view-derived
+ * internal tools, and available overlay apps — into one deduped `RegistryAppInfo`
+ * list for the chat surfaces (AppsSection, agent-orchestrator widget). Each
+ * source is fetched with `allSettled` so a single failing endpoint degrades to
+ * an empty slice rather than failing the whole load. `AppsView` uses the sibling
+ * `load-apps-catalog.ts` instead.
+ */
+
 import { client, type RegistryAppInfo } from "../../api";
 import { fetchAvailableViews } from "../../hooks/useAvailableViews";
 import { isHiddenFromAppsView } from "./helpers";

--- a/packages/ui/src/components/apps/extensions/registry.ts
+++ b/packages/ui/src/components/apps/extensions/registry.ts
@@ -1,6 +1,8 @@
-// Re-export shim: the detail-extension registry now lives in `@elizaos/shared`
-// so Node app-registration code shares one canonical registry without importing
-// the React package.
+/**
+ * Re-export of the app detail-extension registry. The canonical registry lives
+ * in `@elizaos/shared` so Node app-registration code shares it without importing
+ * this React package.
+ */
 export {
   getAppDetailExtension,
   registerDetailExtension,

--- a/packages/ui/src/components/apps/extensions/surface.helpers.ts
+++ b/packages/ui/src/components/apps/extensions/surface.helpers.ts
@@ -1,3 +1,10 @@
+/**
+ * Pure selectors and tone mappers backing the detail-extension surfaces: picks
+ * the latest run for an app (newest of `updatedAt`/`startedAt`), formats detail
+ * timestamps, and maps run health, viewer attachment, and free-form status text
+ * to a `SurfaceTone`. Kept free of JSX so extension logic stays unit-testable.
+ */
+
 import type {
   AppRunHealthState,
   AppRunSummary,

--- a/packages/ui/src/components/apps/extensions/surface.stories.tsx
+++ b/packages/ui/src/components/apps/extensions/surface.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook stories for the detail-extension surface primitives — section,
+ * badge tones, card grid, empty state, and a mixed composition.
+ */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   SurfaceBadge,

--- a/packages/ui/src/components/apps/extensions/surface.tsx
+++ b/packages/ui/src/components/apps/extensions/surface.tsx
@@ -1,3 +1,10 @@
+/**
+ * Presentational building blocks for app detail-extension surfaces — section,
+ * card, grid, badge, and empty-state components plus the shared `SurfaceTone`
+ * palette. Registered detail extensions compose these so third-party app detail
+ * panels render with consistent chrome without re-implementing base styling.
+ */
+
 import type React from "react";
 import type { AppRunSummary } from "../../../api";
 

--- a/packages/ui/src/components/apps/extensions/types.ts
+++ b/packages/ui/src/components/apps/extensions/types.ts
@@ -1,4 +1,4 @@
-// Re-export shim: detail-extension types now live in `@elizaos/shared`.
+/** Re-export of the app detail-extension contract types from `@elizaos/shared`. */
 export type {
   AppDetailExtensionComponent,
   AppDetailExtensionProps,

--- a/packages/ui/src/components/apps/helpers-catalog-curation.test.ts
+++ b/packages/ui/src/components/apps/helpers-catalog-curation.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers the manifest-driven catalog curation in `helpers.ts`
+ * (`shouldShowAppInAppsView`, `getAppCatalogSectionKey`, `groupAppsForCatalog`)
+ * over in-memory `RegistryAppInfo` fixtures — pure functions, no I/O.
+ */
+
 import { describe, expect, it } from "vitest";
 import type { RegistryAppInfo } from "../../api";
 import {
@@ -9,7 +15,7 @@ import {
 // Curation is driven entirely by manifest-declared fields
 // (`package.json` → `elizaos.app.{catalogSection,featured,defaultHidden,scope}`),
 // not by hardcoded package-name sets. These cases assert the declared metadata
-// reproduces the classifications that were previously hardcoded in helpers.ts.
+// yields the expected section/visibility classifications.
 
 function app(overrides: Partial<RegistryAppInfo>): RegistryAppInfo {
   return {

--- a/packages/ui/src/components/apps/helpers-icons.test.ts
+++ b/packages/ui/src/components/apps/helpers-icons.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers the catalog icon helpers `getAppEmoji` / `getAppIconName` in `helpers.ts`,
+ * asserting section apps resolve to Lucide icon names rather than raw emoji glyphs.
+ * Pure functions over in-memory `RegistryAppInfo` fixtures.
+ */
+
 import { describe, expect, it } from "vitest";
 import type { RegistryAppInfo } from "../../api";
 import { getAppEmoji, getAppIconName } from "./helpers";

--- a/packages/ui/src/components/apps/helpers.ts
+++ b/packages/ui/src/components/apps/helpers.ts
@@ -1,3 +1,11 @@
+/**
+ * Pure catalog helpers shared across the apps surfaces: category/section
+ * labels, visibility and curation filters, catalog grouping/ordering, slug and
+ * short-name derivation, and session-mode/feature label formatting. Curation is
+ * driven by manifest-declared fields (`elizaos.app.*`) plus the Eliza-curated
+ * order and internal-tool ordering — never by ad-hoc package-name sets here.
+ */
+
 import { type EnabledViewKinds, isViewVisible } from "@elizaos/core";
 import {
   getElizaCuratedAppCatalogOrder,

--- a/packages/ui/src/components/apps/home-grid-apps.test.ts
+++ b/packages/ui/src/components/apps/home-grid-apps.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers `getHomeGridApps` / `getPinnableInternalApps`: the four default tiles,
+ * their order, and how user-pinned internal-tool apps append and resolve to
+ * navigation tabs. Pure functions over in-memory view fixtures.
+ */
+
 import { describe, expect, it } from "vitest";
 import type { ViewRegistryEntry } from "../../hooks/useAvailableViews";
 import { getHomeGridApps, getPinnableInternalApps } from "./home-grid-apps";

--- a/packages/ui/src/components/apps/home-grid-apps.ts
+++ b/packages/ui/src/components/apps/home-grid-apps.ts
@@ -1,3 +1,9 @@
+/**
+ * Builds the homescreen launcher grid: the four default-pinned tiles plus any
+ * user-pinned internal-tool apps, each resolved to the navigation `Tab` that
+ * tapping it opens.
+ */
+
 import type { ViewRegistryEntry } from "../../hooks/useAvailableViews";
 import type { Tab } from "../../navigation";
 import type { AppIdentitySource } from "./app-identity";

--- a/packages/ui/src/components/apps/internal-tool-apps.test.ts
+++ b/packages/ui/src/components/apps/internal-tool-apps.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers `internal-tool-apps.ts`: how ViewDeclaration-derived internal apps map
+ * to catalog descriptors, target tabs, window paths, and pinnable names, and how
+ * routes bridge to tool tabs. Pure functions over in-memory view fixtures.
+ */
+
 import { describe, expect, it } from "vitest";
 import type { ViewRegistryEntry } from "../../hooks/useAvailableViews";
 import { pathForTab, tabFromPath } from "../../navigation";

--- a/packages/ui/src/components/apps/internal-tool-apps.ts
+++ b/packages/ui/src/components/apps/internal-tool-apps.ts
@@ -3,12 +3,11 @@
  * derived from the `GET /api/views` ViewDeclaration feed.
  *
  * The catalog and pinnable list are built from a single declarative source of
- * `ViewDeclaration` records — the same shape plugins register — instead of the
- * old hardcoded `INTERNAL_TOOL_APPS` / `PINNABLE_INTERNAL_APPS` package-name
- * tables. `pinnable` is a declared flag on each declaration. When a plugin owns
- * the view (fine-tuning, automations), its live network `ViewRegistryEntry`
- * overlays label/description/hero at read time, so renaming a plugin app's
- * `displayName` in its ViewDeclaration updates the catalog with no edit here.
+ * `ViewDeclaration` records — the same shape plugins register — with `pinnable`
+ * a declared flag on each declaration. When a plugin owns the view (fine-tuning,
+ * automations), its live network `ViewRegistryEntry` overlays
+ * label/description/hero at read time, so renaming a plugin app's `displayName`
+ * in its ViewDeclaration updates the catalog with no edit here.
  */
 
 import type { RegistryAppInfo } from "../../api";

--- a/packages/ui/src/components/apps/overlay-app-api.ts
+++ b/packages/ui/src/components/apps/overlay-app-api.ts
@@ -1,3 +1,6 @@
-// Re-export shim: the overlay-app contract now lives in `@elizaos/shared` so
-// Node app-registration code references it without importing the React package.
+/**
+ * Re-export of the overlay-app contract types. The canonical definitions live in
+ * `@elizaos/shared` so Node app-registration code can reference them without
+ * importing this React package; this shim keeps the in-package import path stable.
+ */
 export type { OverlayApp, OverlayAppContext } from "@elizaos/shared";

--- a/packages/ui/src/components/apps/overlay-app-registry.test.ts
+++ b/packages/ui/src/components/apps/overlay-app-registry.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers overlay-app registration and the `isAospAndroid` / androidOnly
+ * availability gating across user agents (Eliza-AOSP, white-label AOSP, stock
+ * Android, desktop Linux). Registry host state is reset between cases; UAs are
+ * in-memory fixtures.
+ */
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resetUiRegistryHostForTests } from "../../registry-host";
 import type { OverlayApp } from "./overlay-app-api";

--- a/packages/ui/src/components/apps/overlay-app-registry.ts
+++ b/packages/ui/src/components/apps/overlay-app-registry.ts
@@ -1,6 +1,8 @@
-// Re-export shim: the overlay-app registry now lives in `@elizaos/shared` so
-// Node app-registration code shares one canonical registry without importing
-// the React package. See `@elizaos/shared/src/apps/overlay-app-registry.ts`.
+/**
+ * Re-export of the overlay-app registry. The single canonical registry lives in
+ * `@elizaos/shared/src/apps/overlay-app-registry.ts` so Node app-registration
+ * code shares it without importing this React package.
+ */
 export {
   getAllOverlayApps,
   getAvailableOverlayApps,

--- a/packages/ui/src/components/apps/run-attention.ts
+++ b/packages/ui/src/components/apps/run-attention.ts
@@ -1,3 +1,11 @@
+/**
+ * Derives the human-readable list of reasons a running app needs attention
+ * (offline/degraded health, detached or missing viewer, a down session status,
+ * a stale heartbeat past `HEARTBEAT_STALE_MS`), consumed by the running-apps UI
+ * to surface warning badges. Status strings are matched case-insensitively
+ * against down/ready keyword sets since connectors report free-form statuses.
+ */
+
 import type { AppRunSummary } from "../../api";
 
 const HEARTBEAT_STALE_MS = 2 * 60 * 1000;

--- a/packages/ui/src/components/apps/viewer-auth.ts
+++ b/packages/ui/src/components/apps/viewer-auth.ts
@@ -1,3 +1,12 @@
+/**
+ * Pure resolvers for embedding a running app's viewer in an iframe: turns a
+ * viewer URL into an absolute origin, derives the postMessage target origin and
+ * `*_READY` handshake event type from the auth message, builds a per-run viewer
+ * session key, and decides whether a run should use the embedded viewer path.
+ * Shared by `EmbeddedAppViewer`, `GameViewOverlay`, and `FullscreenView` so the
+ * origin-pinning rules that keep the auth token from leaking are defined once.
+ */
+
 import type {
   AppRunSummary,
   AppViewerAuthMessage,


### PR DESCRIPTION
Comments-only slice of #12234. `check:comment-only` passes — every code token is byte-for-byte identical to `origin/develop`.

**Subtree:** `packages/ui/src/components/apps` (the overlay/game app surfaces, catalog loaders, app-identity primitives, and detail-extension surfaces).

**Coverage:** 46 in-scope files; 40 edited, 6 already at the bar and left untouched (`EmbeddedAppViewer.tsx`, `launch-history.ts`, `load-apps-catalog.ts`, `per-app-config.ts`, `provenance.ts`, `useRegistryCatalog.ts`). filesRemainingInChunk = 0.

**What changed (comments only):**
- Added top-of-file prose headers to header-less modules (`helpers.ts`, `catalog-loader.ts`, `viewer-auth.ts`, `apps-cache.ts`, `run-attention.ts`, `app-identity{,.helpers}.tsx/.ts`, `AppWindowRenderer{,.helpers}.tsx/.ts`, `AppsCatalogGrid.tsx`, `AppsSidebar.tsx`, `RunningAppsRow.tsx`, `GameViewOverlay.tsx`, `FullscreenView.helpers.ts`, `home-grid-apps.ts`, `extensions/surface{,.helpers}.tsx/.ts`).
- Rewrote churn/narration headers into present-tense fact: the re-export shims (`overlay-app-api.ts`, `overlay-app-registry.ts`, `extensions/registry.ts`, `extensions/types.ts`) dropped 'now lives in' phrasing; `FullscreenView.tsx` replaced its 'Features:' bullet template with prose; `internal-tool-apps.ts` and a curation-test comment dropped 'old hardcoded' / 'previously hardcoded' narration.
- Added 1–3 line test-file headers (surface under test + harness reality: jsdom + mocks / in-memory fixtures) and one-line story-file headers (states exercised).

Part of #12234.