### PR TITLE
docs(#12234): prose headers + churn cleanup — b04-rest-small

### DIFF
--- a/packages/ui/src/components/RoleGate.stories.tsx
+++ b/packages/ui/src/components/RoleGate.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for RoleGate — showing which gated children render for the owner, admin, user, and guest roles. */
+
 import type { RoleGateRole } from "@elizaos/core";
 import type { Meta, StoryObj } from "@storybook/react";
 import { RoleProvider, useRole } from "../hooks/useRole.tsx";

--- a/packages/ui/src/components/RoleGate.test.tsx
+++ b/packages/ui/src/components/RoleGate.test.tsx
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * Behaviour coverage for RoleGate: renders children only when the current role
+ * (from `RoleProvider`) meets the gate. Real render in jsdom.
+ */
+
 import type { RoleGateRole } from "@elizaos/core";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/packages/ui/src/components/ShellRoleProvider.test.tsx
+++ b/packages/ui/src/components/ShellRoleProvider.test.tsx
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * Unit coverage for `deriveShellRole` — the pure mapping from auth status to the
+ * shell's canonical role (local/loopback authenticated → OWNER, etc.).
+ */
+
 import { describe, expect, it } from "vitest";
 import { deriveShellRole } from "./ShellRoleProvider.tsx";
 

--- a/packages/ui/src/components/auth/LoginView.stories.tsx
+++ b/packages/ui/src/components/auth/LoginView.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for LoginView — default sign-in, remote-auth-required, password-not-configured, invalid-credentials, and slow-network states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { TranslationCtx } from "../../state/TranslationContext.hooks";
 import { LoginView } from "./LoginView";

--- a/packages/ui/src/components/auth/LoginView.tsx
+++ b/packages/ui/src/components/auth/LoginView.tsx
@@ -1,3 +1,11 @@
+/**
+ * Password sign-in screen shown when a remote agent requires owner
+ * authentication. Posts credentials via `authLoginPassword` and calls
+ * `onLoginSuccess` so the shell can redirect to the dashboard. When the host
+ * reports `remote_password_not_configured`, it swaps the form for setup
+ * instructions (there is no owner password to authenticate against yet) instead
+ * of accepting a login. Styled with the shared first-run/setup tokens.
+ */
 import { type FormEvent, useCallback, useId, useState } from "react";
 import { type AuthLoginResult, authLoginPassword } from "../../api/auth-client";
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/auth/__tests__/authcomp-stories-smoke.test.tsx
+++ b/packages/ui/src/components/auth/__tests__/authcomp-stories-smoke.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+/**
+ * Portable-stories smoke test for the auth surface. Composes every auth
+ * *.stories.tsx and renders it in jsdom. See test/portable-stories.tsx.
+ */
 import { smokeStoryModules } from "../../../../test/portable-stories";
 
 const modules = import.meta.glob("../**/*.stories.tsx", { eager: true });

--- a/packages/ui/src/components/cloud/CloudSourceControls.stories.tsx
+++ b/packages/ui/src/components/cloud/CloudSourceControls.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for the cloud-source controls — mode toggle (cloud/own-key/custom-labels/interactive) and connection status (connected/disconnected/custom-label). */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { MockAppProvider } from "../../storybook/mock-providers";

--- a/packages/ui/src/components/cloud/CloudSourceControls.tsx
+++ b/packages/ui/src/components/cloud/CloudSourceControls.tsx
@@ -1,3 +1,10 @@
+/**
+ * Cloud-source controls: a segmented toggle between using Eliza Cloud and a
+ * user-supplied API key (`CloudSourceModeToggle`), and a live Eliza Cloud
+ * connection indicator (`CloudConnectionStatus`). Rendered in the config/setup
+ * surfaces where a feature can be backed by either the managed cloud or the
+ * user's own provider key.
+ */
 import { CheckCircle2, WifiOff } from "lucide-react";
 import { useAppSelector } from "../../state";
 import { Button } from "../ui/button";

--- a/packages/ui/src/components/cloud/CloudStatusBadge.stories.tsx
+++ b/packages/ui/src/components/cloud/CloudStatusBadge.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for CloudStatusBadge — low/critical credits, large-balance-low, auth-rejected, credits-error, and shell-appearance states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { CloudStatusBadge } from "./CloudStatusBadge";
 

--- a/packages/ui/src/components/cloud/CloudStatusBadge.tsx
+++ b/packages/ui/src/components/cloud/CloudStatusBadge.tsx
@@ -1,3 +1,10 @@
+/**
+ * Header status badge for the Eliza Cloud connection. Renders only when there is
+ * something worth surfacing — auth rejection, a credits-fetch error, or a
+ * low/critical credit balance — and stays hidden for a healthy balance. Balances
+ * are formatted compactly ($1.2k / $3.4m) for the header. The `shell` appearance
+ * matches the app shell's chrome; the default is a lighter inline button.
+ */
 import type { CSSProperties } from "react";
 import { Button } from "../ui/button";
 

--- a/packages/ui/src/components/cloud/StripeEmbeddedCheckout.tsx
+++ b/packages/ui/src/components/cloud/StripeEmbeddedCheckout.tsx
@@ -1,3 +1,10 @@
+/**
+ * Mounts Stripe's Embedded Checkout for a given publishable key + client secret.
+ * Lazily loads `https://js.stripe.com/v3/` once (deduped via a module-level
+ * promise and a marker script tag), initializes the embedded checkout, and
+ * mounts it into a container ref. Surfaces load/init failures inline and tears
+ * the checkout down on unmount.
+ */
 import { useEffect, useRef, useState } from "react";
 
 interface StripeEmbeddedCheckoutProps {

--- a/packages/ui/src/components/cloud/__tests__/cloudcomp-stories-smoke.test.tsx
+++ b/packages/ui/src/components/cloud/__tests__/cloudcomp-stories-smoke.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+/**
+ * Portable-stories smoke test for the cloud surface. Composes every cloud
+ * *.stories.tsx and renders it in jsdom. See test/portable-stories.tsx.
+ */
 import { smokeStoryModules } from "../../../../test/portable-stories";
 
 const modules = import.meta.glob("../**/*.stories.tsx", { eager: true });

--- a/packages/ui/src/components/connectors/connector-setup-panel-registry.ts
+++ b/packages/ui/src/components/connectors/connector-setup-panel-registry.ts
@@ -2,28 +2,23 @@ import { getBootConfig } from "../../config/boot-config";
 
 /**
  * Registry that resolves a connector setup-plugin id to the token of the
- * built-in setup panel that renders it. This replaces the per-connector-id
- * `switch` that used to live in both `ConnectorSetupPanel.helpers.ts`
- * (`hasConnectorSetupPanel`) and `ConnectorSetupPanel.tsx` (component render).
+ * built-in setup panel that renders it. One pure (React-free) module holds the
+ * id → token rules so the boolean `hasConnectorSetupPanel` check
+ * (`ConnectorSetupPanel.helpers.ts`) and the component render
+ * (`ConnectorSetupPanel.tsx`) share a single source of truth.
  *
- * Keeping the id → token rules in one pure module (no React) lets the boolean
- * `hasConnectorSetupPanel` check and the component render share a single source
- * of truth instead of two parallel switches that had to be kept in sync.
- *
- * Matching preserves the historical semantics exactly:
- *  - `exact`: the normalized id equals the needle (the old `switch` cases).
- *  - `substring`: the normalized id contains the needle (the old `.includes`
- *    checks that catch namespaced plugin ids such as
- *    `@elizaos/plugin-telegram` → `elizaosplugintelegram`).
+ * Match kinds:
+ *  - `exact`: the normalized id equals the needle.
+ *  - `substring`: the normalized id contains the needle, catching namespaced
+ *    plugin ids such as `@elizaos/plugin-telegram` → `elizaosplugintelegram`.
  * Rules are evaluated in registration order; the first match wins.
  *
  * A rule may carry an optional `available` predicate for panels whose backing
  * component is supplied at runtime rather than statically bundled (e.g. the
  * host-provided LifeOps browser-bridge panel). When present, the rule only
- * matches while the predicate returns true — this is what keeps the boolean
- * `hasConnectorSetupPanel` gate connector-id-free in the helper: the id → panel
- * knowledge (including its availability condition) lives entirely in this
- * registry, not in a per-connector branch in `ConnectorSetupPanel.helpers.ts`.
+ * matches while the predicate returns true — which keeps `hasConnectorSetupPanel`
+ * connector-id-free: the id → panel knowledge, including its availability
+ * condition, lives entirely here rather than in a per-connector branch.
  */
 export type ConnectorSetupPanelToken =
   | "telegram-account"
@@ -73,9 +68,8 @@ export function resolveConnectorSetupPanelToken(
   return null;
 }
 
-// Built-in rules. Order mirrors the previous `hasConnectorSetupPanel`
-// evaluation order (telegram-account and namespaced telegram bot ids before
-// the exact switch cases).
+// Built-in rules. Order matters: telegram-account and namespaced telegram bot
+// ids are matched before the exact single-word cases.
 registerConnectorSetupPanelRule({
   token: "telegram-account",
   needle: "telegramaccount",
@@ -120,7 +114,7 @@ registerConnectorSetupPanelRule({
 // The LifeOps browser-bridge panel is a host-provided component (boot-config
 // slot), not a statically bundled one, so its rule only resolves while the host
 // has supplied it. Both namespaced (`lifeopsbrowser`) and short (`browserbridg`)
-// connector ids route to it — matching the ids the previous helper branch tested.
+// connector ids route to it.
 registerConnectorSetupPanelRule({
   token: "lifeops-browser",
   needle: "lifeopsbrowser",

--- a/packages/ui/src/components/desktop/DesktopTabBar.stories.tsx
+++ b/packages/ui/src/components/desktop/DesktopTabBar.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for DesktopTabBar — default, single-tab, many-tabs, and no-active-tab states (under an Electrobun-runtime decorator). */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { DesktopTab } from "../../hooks/useDesktopTabs";
 import { DesktopTabBar } from "./DesktopTabBar";

--- a/packages/ui/src/components/desktop/DesktopTabBar.test.tsx
+++ b/packages/ui/src/components/desktop/DesktopTabBar.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Behaviour coverage for DesktopTabBar: real render in jsdom with the Electrobun
+ * runtime guard mocked on, driving tab switch/close and the view-manager trigger
+ * through the actual buttons.
+ */
+
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DesktopTab } from "../../hooks/useDesktopTabs";

--- a/packages/ui/src/components/desktop/__tests__/desktop-stories-smoke.test.tsx
+++ b/packages/ui/src/components/desktop/__tests__/desktop-stories-smoke.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+/**
+ * Portable-stories smoke test for the desktop surface. Composes every desktop
+ * *.stories.tsx and renders it in jsdom. See test/portable-stories.tsx.
+ */
 import { smokeStoryModules } from "../../../../test/portable-stories";
 
 const modules = import.meta.glob("../**/*.stories.tsx", { eager: true });

--- a/packages/ui/src/components/primitives/index.ts
+++ b/packages/ui/src/components/primitives/index.ts
@@ -1,3 +1,4 @@
+/** Curated re-export barrel of the base UI primitives from `components/ui/*`. */
 export * from "../ui/alert";
 export * from "../ui/alert-dialog";
 export * from "../ui/badge";

--- a/packages/ui/src/components/setup/BootstrapStep.stories.tsx
+++ b/packages/ui/src/components/setup/BootstrapStep.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for BootstrapStep — default, invalid-token, rate-limited, server-not-ready, and verifying states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ReactNode } from "react";
 import type { BootstrapExchangeResult } from "../../api/client-agent";

--- a/packages/ui/src/components/setup/__tests__/setup-stories-smoke.test.tsx
+++ b/packages/ui/src/components/setup/__tests__/setup-stories-smoke.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+/**
+ * Portable-stories smoke test for the setup surface. Composes every setup
+ * *.stories.tsx and renders it in jsdom. See test/portable-stories.tsx.
+ */
 import { smokeStoryModules } from "../../../../test/portable-stories";
 
 const modules = import.meta.glob("../**/*.stories.tsx", { eager: true });

--- a/packages/ui/src/components/setup/setup-form-primitives.stories.tsx
+++ b/packages/ui/src/components/setup/setup-form-primitives.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for SetupField — default, with-error, with-success, centered, and no-label states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { Input } from "../ui/input";
 import { SetupField } from "./setup-form-primitives";

--- a/packages/ui/src/components/setup/setup-form-primitives.tsx
+++ b/packages/ui/src/components/setup/setup-form-primitives.tsx
@@ -1,3 +1,10 @@
+/**
+ * `SetupField` — the labeled form-field wrapper for first-run / setup steps.
+ * Wraps the base `Field` primitive with setup-specific label/helper styling and
+ * wires up description/message ids so the control (supplied via render-prop) gets
+ * the right `aria-describedby` and invalid state. Danger messages are announced
+ * assertively.
+ */
 import type * as React from "react";
 import { cn } from "../../lib/utils";
 import { Field, FieldDescription, FieldLabel, FieldMessage } from "../ui/field";

--- a/packages/ui/src/components/setup/setup-step-chrome.stories.tsx
+++ b/packages/ui/src/components/setup/setup-step-chrome.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for SetupStepDivider — default, between-steps, on-light-background, and stacked states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { SetupStepDivider } from "./setup-step-chrome";
 

--- a/packages/ui/src/components/setup/setup-step-chrome.tsx
+++ b/packages/ui/src/components/setup/setup-step-chrome.tsx
@@ -1,3 +1,7 @@
+/**
+ * `SetupStepDivider` — the ornamental horizontal rule (thin lines flanking a
+ * brand-orange diamond) between sections of a first-run / setup step.
+ */
 export function SetupStepDivider() {
   return (
     <div className="my-4 flex items-center gap-3 before:h-px before:flex-1 before: before:from-transparent before:via-[var(--first-run-divider)] before:to-transparent after:h-px after:flex-1 after: after:from-transparent after:via-[var(--first-run-divider)] after:to-transparent">

--- a/packages/ui/src/components/stream/StatusBar.stories.tsx
+++ b/packages/ui/src/components/stream/StatusBar.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for StatusBar — offline, live, stream-unavailable, loading, and long-agent-name states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { mockApp } from "../../storybook/mock-providers.helpers";
 import { StatusBar } from "./StatusBar";

--- a/packages/ui/src/components/stream/StatusBar.tsx
+++ b/packages/ui/src/components/stream/StatusBar.tsx
@@ -1,3 +1,10 @@
+/**
+ * Bottom status bar for the agent screen-stream view: agent name, live/idle
+ * indicator, uptime, frame count, and the start/stop-stream toggle. On the web
+ * it also offers a pop-out button that opens the stream in a separate window
+ * (`openStreamPopout`); the Electrobun desktop runtime uses its own native
+ * window path, so the web pop-out is suppressed there.
+ */
 import { ExternalLink } from "lucide-react";
 import { type CSSProperties, useEffect, useRef } from "react";
 import { isElectrobunRuntime } from "../../bridge/electrobun-runtime";

--- a/packages/ui/src/components/stream/__tests__/streamcomp-stories-smoke.test.tsx
+++ b/packages/ui/src/components/stream/__tests__/streamcomp-stories-smoke.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+/**
+ * Portable-stories smoke test for the stream surface. Composes every stream
+ * *.stories.tsx and renders it in jsdom. See test/portable-stories.tsx.
+ */
 import { smokeStoryModules } from "../../../../test/portable-stories";
 
 const modules = import.meta.glob("../**/*.stories.tsx", { eager: true });

--- a/packages/ui/src/components/stream/helpers.ts
+++ b/packages/ui/src/components/stream/helpers.ts
@@ -1,10 +1,9 @@
 /**
- * Shared helpers and constants for StreamView.
+ * Shared window-size constants and the pop-out-mode detector for the agent
+ * screen-stream view (StreamView). `IS_POPOUT` reads the `popout` flag that
+ * `openStreamPopout` (popout-url.ts) sets, from either the query string or the
+ * hash (file:/electrobun: origins route it through the hash).
  */
-
-// ---------------------------------------------------------------------------
-// Popout / Window sizes
-// ---------------------------------------------------------------------------
 
 /** PIP window dimensions (640x360 → captures at 1280x720 on Retina 2x displays). */
 export const PIP_SIZE = { width: 640, height: 360 };

--- a/packages/ui/src/components/stream/popout-url.test.ts
+++ b/packages/ui/src/components/stream/popout-url.test.ts
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * Unit coverage for the stream pop-out URL builder + opener: query vs. hash
+ * routing across origins and the `apiBase` param. Uses jsdom's `window`.
+ */
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildStreamPopoutUrl, openStreamPopout } from "./popout-url";
 

--- a/packages/ui/src/components/stream/popout-url.ts
+++ b/packages/ui/src/components/stream/popout-url.ts
@@ -1,3 +1,9 @@
+/**
+ * Builds the URL and opens the pop-out window for the agent screen-stream view.
+ * The URL carries a `popout` query flag (read by `stream/helpers.ts` `IS_POPOUT`)
+ * and, on `file:`/`electrobun:` origins where a query string on the path is not
+ * navigable, routes it through the hash so the SPA still resolves the route.
+ */
 const STREAM_POPOUT_WINDOW_TARGET = "elizaos-stream";
 const STREAM_POPOUT_WINDOW_FEATURES =
   "width=1280,height=720,menubar=no,toolbar=no,location=no,status=no";

--- a/packages/ui/src/components/tool-events/ToolCallEventLog.helpers.ts
+++ b/packages/ui/src/components/tool-events/ToolCallEventLog.helpers.ts
@@ -1,3 +1,9 @@
+/**
+ * Pure derivations for `ToolCallEventLog`: maps a `NativeToolCallEvent` to its
+ * running/success/failure display state and resolves a human-readable tool name
+ * from whichever of the event's name/id fields is populated. Kept
+ * component-free so the mapping can be unit-tested without a DOM.
+ */
 import type { NativeToolCallEvent } from "../../api/client-types-cloud";
 import type { ToolCallEventDisplayState } from "./ToolCallEventLog";
 

--- a/packages/ui/src/components/tool-events/ToolCallEventLog.stories.tsx
+++ b/packages/ui/src/components/tool-events/ToolCallEventLog.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for ToolCallEventLog — success, running, failure, long-args-and-result, and minimal-fields states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { NativeToolCallEvent } from "../../api/client-types-cloud";
 import { ToolCallEventLog } from "./ToolCallEventLog";

--- a/packages/ui/src/components/tool-events/ToolCallEventLog.test.tsx
+++ b/packages/ui/src/components/tool-events/ToolCallEventLog.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Behaviour coverage for ToolCallEventLog + its display-state helper: real render
+ * in jsdom (lucide icons stubbed) asserting the tool name, arg/result previews,
+ * and success/running/failure states.
+ */
+
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/packages/ui/src/components/tool-events/ToolCallEventLog.tsx
+++ b/packages/ui/src/components/tool-events/ToolCallEventLog.tsx
@@ -1,3 +1,10 @@
+/**
+ * Renders one native tool-call event (a `NativeToolCallEvent` from the agent's
+ * activity stream) as a collapsible log row: a running/success/failure status
+ * icon and the tool name, expanding to show the truncated argument/result
+ * previews and pretty-printed JSON. State + name derivation live in
+ * `ToolCallEventLog.helpers`.
+ */
 import { CheckCircle, ChevronDown, Clock3, XCircle } from "lucide-react";
 import type { ReactNode } from "react";
 

--- a/packages/ui/src/components/tool-events/__tests__/toolevents-stories-smoke.test.tsx
+++ b/packages/ui/src/components/tool-events/__tests__/toolevents-stories-smoke.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+/**
+ * Portable-stories smoke test for the tool-events surface. Composes every
+ * tool-events *.stories.tsx and renders it in jsdom. See test/portable-stories.tsx.
+ */
 import { smokeStoryModules } from "../../../../test/portable-stories";
 
 const modules = import.meta.glob("../**/*.stories.tsx", { eager: true });

--- a/packages/ui/src/components/training/injected.test.tsx
+++ b/packages/ui/src/components/training/injected.test.tsx
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/**
+ * Behaviour coverage for the injected FineTuningView: renders the host-supplied
+ * `bootConfig.fineTuningView` when present, and the install hint when absent.
+ * Real render in jsdom with a stubbed boot context.
+ */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { DEFAULT_BOOT_CONFIG } from "../../config/boot-config";

--- a/packages/ui/src/components/transcripts/MeetingJoinBar.test.tsx
+++ b/packages/ui/src/components/transcripts/MeetingJoinBar.test.tsx
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * Behaviour coverage for MeetingJoinBar: real render in jsdom driving the
+ * meeting-URL paste/validation and join flow.
+ */
+
 import type { MeetingSession } from "@elizaos/shared";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/transcripts/TranscriptBody.test.tsx
+++ b/packages/ui/src/components/transcripts/TranscriptBody.test.tsx
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * Behaviour coverage for TranscriptBody: real render in jsdom asserting the
+ * read + word-sync surface for a given transcript and playback position.
+ */
+
 import type { Transcript } from "@elizaos/shared/transcripts";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/components/transcripts/TranscriptPlayer.test.tsx
+++ b/packages/ui/src/components/transcripts/TranscriptPlayer.test.tsx
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * Behaviour coverage for TranscriptPlayer: real render in jsdom driving
+ * play/pause/scrub and the word-synced highlighting.
+ */
+
 import type { Transcript } from "@elizaos/shared/transcripts";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/packages/ui/src/components/transcripts/TranscriptsView.test.tsx
+++ b/packages/ui/src/components/transcripts/TranscriptsView.test.tsx
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * Behaviour coverage for TranscriptsView: real render in jsdom asserting the
+ * recordings list + player pairing and meeting-aware summary handling.
+ */
+
 import type {
   Transcript,
   TranscriptSummary,

--- a/packages/ui/src/components/transcripts/index.ts
+++ b/packages/ui/src/components/transcripts/index.ts
@@ -1,3 +1,4 @@
+/** Public barrel for the Transcripts surface (player, live meeting pane, reducer). */
 export {
   LiveMeetingPane,
   type LiveMeetingPaneProps,

--- a/packages/ui/src/components/transcripts/meeting-live.test.ts
+++ b/packages/ui/src/components/transcripts/meeting-live.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit coverage for the live-meeting transcript reducer + metadata readers
+ * (pure functions, no DOM): folding streamed events and polled snapshots into
+ * the live transcript state.
+ */
 import type { MeetingTranscriptEvent } from "@elizaos/shared";
 import type {
   Transcript,

--- a/packages/ui/src/components/workspace/AppWorkspaceChrome.stories.tsx
+++ b/packages/ui/src/components/workspace/AppWorkspaceChrome.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for AppWorkspaceChrome — default (with nav) and no-nav layouts. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { AppWorkspaceChrome } from "./AppWorkspaceChrome";
 

--- a/packages/ui/src/components/workspace/__tests__/workspace-stories-smoke.test.tsx
+++ b/packages/ui/src/components/workspace/__tests__/workspace-stories-smoke.test.tsx
@@ -1,4 +1,8 @@
 // @vitest-environment jsdom
+/**
+ * Portable-stories smoke test for the workspace surface. Composes every
+ * workspace *.stories.tsx and renders it in jsdom. See test/portable-stories.tsx.
+ */
 import { smokeStoryModules } from "../../../../test/portable-stories";
 
 const modules = import.meta.glob("../**/*.stories.tsx", { eager: true });


### PR DESCRIPTION
Comments-only slice of #12234 (repo-wide file-header / comment cleanup). No functional change — `check:comment-only` passes (code token stream byte-for-byte identical to `origin/develop`).

## Subtree / coverage
Chunk **b04-rest-small**: the smaller `packages/ui/src/components/` surfaces plus top-level component files.

- **Component modules** given top-of-file prose headers: `auth/LoginView`, `cloud/CloudSourceControls`, `cloud/CloudStatusBadge`, `cloud/StripeEmbeddedCheckout`, `setup/setup-form-primitives`, `setup/setup-step-chrome`, `stream/StatusBar`, `stream/popout-url`, `stream/helpers` (also dropped a redundant banner), `tool-events/ToolCallEventLog` + `.helpers`.
- **Barrels** given a 1-line header: `primitives/index.ts`, `transcripts/index.ts`.
- **Churn/narration rewrite → present-tense fact**: `connectors/connector-setup-panel-registry.ts` (removed "replaces the old switch", "used to live in", "the previous helper branch tested", etc.).
- **Story files** given a 1-line `Storybook stories for X — states` header: RoleGate, LoginView, CloudSourceControls, CloudStatusBadge, DesktopTabBar, BootstrapStep, setup-form-primitives, setup-step-chrome, StatusBar, ToolCallEventLog, AppWorkspaceChrome.
- **Test files** given a 1–3 line surface-under-test header (real render in jsdom vs. pure-fn unit noted): the 8 `*-stories-smoke` portable-stories tests, RoleGate/ShellRoleProvider/DesktopTabBar/ToolCallEventLog/training-injected tests, the four transcripts tests + meeting-live reducer test, and stream/popout-url test.

Already-good files (most `connectors/*`, most `transcripts/*` components, most `local-inference/*`) were left untouched. Eight single-export modules whose export-level JSDoc already states the file purpose (`brand/eliza-mark`, `DevicesPanel`, `DownloadQueue`, `SlotAssignments`, `useHomeModelStatus`, `training/injected`, `AppWorkspaceChrome`, and the registry's type export) were left as-is rather than duplicating their doc into a redundant top block.

**Files touched:** 43.

Part of #12234.