### PR TITLE
docs(#12234): prose header — PermissionPrimingModal.stories (b04 follow-up)

### DIFF
--- a/packages/ui/src/components/permissions/PermissionPrimingModal.stories.tsx
+++ b/packages/ui/src/components/permissions/PermissionPrimingModal.stories.tsx
@@ -1,3 +1,9 @@
+/**
+ * Storybook states for the post-login PermissionPrimingModal, driven by injected
+ * controller stubs: the per-permission soft-ask cards (microphone / location /
+ * notifications), the requesting state, the two denied variants (retryable vs
+ * settings-only), and the initial loading state.
+ */
 import type { PermissionId } from "@elizaos/shared/contracts/permissions";
 import type { Meta, StoryObj } from "@storybook/react";
 import { MockAppProvider } from "../../storybook/mock-providers";


### PR DESCRIPTION
Follow-up to #12573 (squash-merged as `c7a0a6cbb5c`), which covered the rest of chunk **b04-views-config-perms**. This file's top-of-file prose header was staged after that PR merged, so it lands here.

## Scope
Single file: `packages/ui/src/components/permissions/PermissionPrimingModal.stories.tsx`.

Adds a prose header describing the modal's Storybook states (soft-ask cards, requesting, denied-retryable vs denied-settings-only, loading) — driven by injected controller stubs.

## Verification
`node scripts/assert-comment-only-diff.mjs` → OK (1 file changed; every code token identical to origin/develop). Comment-only; zero functional diff.

Part of #12234.