### PR TITLE
docs(#12235): prose headers + churn cleanup — b05-nonsrc

### DIFF
--- a/packages/ui/scripts/reconnecting-shift-proof.mjs
+++ b/packages/ui/scripts/reconnecting-shift-proof.mjs
@@ -1,17 +1,18 @@
 #!/usr/bin/env node
 
 /**
- * Real-browser proof that the reconnecting indicator no longer shifts content.
+ * Real-browser proof that the reconnecting indicator does not shift page content.
  *
  * Reproduces the shell's content column (App.tsx:2479 — a `position: relative`
  * flex-column with the banner as the first child, then the header + page) and
- * measures the header's viewport Y in three states:
- *   1. no banner              (baseline)
- *   2. OLD in-flow bar shown  (the bug: `shrink-0` flex item pushes content)
- *   3. NEW overlay pill shown (the fix: absolutely-positioned, out of flow)
+ * measures the header's viewport Y across three banner treatments:
+ *   1. no banner            (baseline)
+ *   2. in-flow bar shown    (`shrink-0` flex item that pushes content down)
+ *   3. overlay pill shown   (absolutely-positioned, out of flow)
  *
- * A shift of 0px in state 3 vs. baseline proves the fix; the non-zero shift in
- * state 2 documents the bug it replaces. Screenshots are written for review.
+ * A 0px shift in state 3 vs. baseline proves the overlay pill is layout-neutral;
+ * the non-zero shift in state 2 shows the in-flow variant it avoids. Screenshots
+ * are written for review.
  *
  * Usage: node packages/ui/scripts/reconnecting-shift-proof.mjs [--out <dir>]
  */

--- a/packages/ui/stories/registered-views/registered-views.config.ts
+++ b/packages/ui/stories/registered-views/registered-views.config.ts
@@ -1,14 +1,11 @@
 /**
- * Playwright config for the registered-views story harness.
- */
-import { resolve } from "node:path";
-import { defineConfig, devices } from "@playwright/test";
-
-/**
  * Playwright config for the registered-views GUI/XR screenshot harness. Boots
  * the ui stories dev server (serves /registered-views.html keyless) and runs the
  * capture spec against it.
  */
+import { resolve } from "node:path";
+import { defineConfig, devices } from "@playwright/test";
+
 export default defineConfig({
   testDir: ".",
   testMatch: /registered-views\.spec\.ts/,

--- a/packages/ui/stories/view-screens-tui.gen.test.ts
+++ b/packages/ui/stories/view-screens-tui.gen.test.ts
@@ -3,11 +3,11 @@
  *
  * Drives the SAME registration path the parity gate uses — an `import.meta.glob`
  * of every `register-terminal-view.tsx`, run through vite's transform — so it
- * covers ALL registered ids (the raw-bun `review-plugins.mjs` silently dropped
- * the files whose `as`-cast syntax Bun's loader can't parse; this fixes that by
- * never doing a raw import). For each id it renders the authored view to
- * terminal lines at two widths and writes a plain-text "screenshot" to
- * `stories/__screens__/tui/<id>.txt` for human review.
+ * covers ALL registered ids. Going through vite (never a raw Bun import) is
+ * deliberate: Bun's loader can't parse the `as`-cast syntax some of these files
+ * use, so a raw import would silently drop them. For each id it renders the
+ * authored view to terminal lines at two widths and writes a plain-text
+ * "screenshot" to `stories/__screens__/tui/<id>.txt` for human review.
  *
  * Not part of the default suite (it lives outside the `src`/`__tests__` include
  * globs). Run it explicitly via `bun run test:view-screens` /

--- a/packages/ui/stories/xr/xr-sim.config.ts
+++ b/packages/ui/stories/xr/xr-sim.config.ts
@@ -1,11 +1,10 @@
 /**
- * Playwright config for the XR simulation harness (see block below).
+ * Playwright config for the XR simulation harness. Boots the ui stories dev
+ * server (which serves /xr-sim.html) and runs the spec against it.
  */
 import { resolve } from "node:path";
 import { defineConfig, devices } from "@playwright/test";
 
-/** Playwright config for the XR simulation harness. Boots the ui stories dev
- *  server (which serves /xr-sim.html) and runs the spec against it. */
 export default defineConfig({
   testDir: ".",
   testMatch: /xr-sim\.spec\.ts/,


### PR DESCRIPTION
Comments-only slice of #12235 for chunk **b05-nonsrc** (`packages/ui/test`, `packages/ui/stories`, `packages/ui/scripts`).

## What changed
Every in-scope file under these three subtrees already carried a top-of-file prose header (the stubs, story-gate helpers, browser shims, orb concepts, and story groups are all accurate and at the bar — left untouched). This slice only repairs the handful of headers phrased as diff-annotations or carrying duplicate blocks:

- `packages/ui/scripts/reconnecting-shift-proof.mjs` — rewrote "no longer shifts" / OLD-NEW / "the bug it replaces" framing into present-tense fact describing the three banner treatments the harness measures.
- `packages/ui/stories/check-catalog.mjs` — first sentence stated a past incident; now states the checker's purpose in present tense.
- `packages/ui/stories/view-screens-tui.gen.test.ts` — removed change-narration about a prior `review-plugins.mjs` tool; kept the durable "go through vite, never a raw Bun import (Bun can't parse the `as`-casts)" rationale.
- `packages/ui/stories/registered-views/registered-views.config.ts` — consolidated a terse top JSDoc + fuller export JSDoc into one header at the top.
- `packages/ui/stories/xr/xr-sim.config.ts` — same consolidation; dropped the "see block below" pointer.

## Verification
`check:comment-only` passes — 5 source files changed, every code token identical to `origin/develop`. Comments only.

Coverage: all 92 in-scope files under the three subtrees were reviewed; the rest were already at the bar. filesRemainingInChunk = 0.

Part of #12235.