### PR TITLE
docs(#12235): prose headers + churn cleanup — b05-state

### DIFF
--- a/packages/ui/src/state/AppContext.resync.test.tsx
+++ b/packages/ui/src/state/AppContext.resync.test.tsx
@@ -9,9 +9,9 @@ import { useResyncReconcile } from "./useResyncReconcile";
 
 /**
  * AppContext dispatches RESYNC_EVENT after a WebSocket reconnect so the active
- * conversation can be reconciled. Historically the event had NO listener — the
- * reconcile was dead code. These tests pin the live wiring: on resync the active
- * conversation is reloaded, and only the active one.
+ * conversation can be reconciled. Pins the `useResyncReconcile` wiring: on
+ * resync the active conversation is reloaded, and only the active one. Real hook
+ * under jsdom.
  */
 function dispatchResync(conversationId: string | null): void {
   window.dispatchEvent(

--- a/packages/ui/src/state/AppContext.tsx
+++ b/packages/ui/src/state/AppContext.tsx
@@ -146,7 +146,7 @@ function AppProviderInner({
   }, []);
   // uiLanguage + t live in TranslationContext; consumed via useTranslation()
   const { t, uiLanguage, setUiLanguage } = useTranslation();
-  // --- Display preferences (extracted to useDisplayPreferences) ---
+  // --- Display preferences (via useDisplayPreferences) ---
   const displayPrefs = useDisplayPreferences();
   const {
     state: {
@@ -281,7 +281,7 @@ function AppProviderInner({
   const uiShellMode = deriveUiShellModeForTab(tab);
 
   // --- Pairing ---
-  // --- Pairing (extracted to usePairingState) ---
+  // --- Pairing (via usePairingState) ---
   const pairingHook = usePairingState();
   const {
     state: {
@@ -389,7 +389,7 @@ function AppProviderInner({
     [addUnread, removeUnread],
   );
 
-  // --- Triggers (extracted to useTriggersState) ---
+  // --- Triggers (via useTriggersState) ---
   const triggersHook = useTriggersState();
   const {
     state: {
@@ -411,7 +411,7 @@ function AppProviderInner({
     runTriggerNow,
   } = triggersHook;
 
-  // --- Plugins / Skills / Store / Catalog (extracted to usePluginsSkillsState) ---
+  // --- Plugins / Skills / Store / Catalog (via usePluginsSkillsState) ---
   const pluginsSkillsHook = usePluginsSkillsState({
     setActionNotice,
     setPendingRestart,
@@ -523,7 +523,7 @@ function AppProviderInner({
     setCatalogUninstalling,
   } = pluginsSkillsHook;
 
-  // --- Logs (extracted to useLogsState) ---
+  // --- Logs (via useLogsState) ---
   const logsHook = useLogsState();
   const {
     state: {
@@ -542,7 +542,7 @@ function AppProviderInner({
     loadLogs,
   } = logsHook;
 
-  // --- Character (extracted to useCharacterState) ---
+  // --- Character (via useCharacterState) ---
   const characterHook = useCharacterState({ agentStatus, setAgentStatus });
   const {
     state: {
@@ -606,7 +606,7 @@ function AppProviderInner({
 
   // Updates, Extension, and Workbench state are now in useDataLoaders (dataLoaders).
 
-  // --- Agent export/import (extracted to useExportImportState) ---
+  // --- Agent export/import (via useExportImportState) ---
   const exportImportHook = useExportImportState();
   const {
     state: {
@@ -736,7 +736,7 @@ function AppProviderInner({
 
   // startupStatus is now derived in useLifecycleState
 
-  // --- Command palette / emote picker / MCP / game / dropped files (extracted to useMiscUiState) ---
+  // --- Command palette / emote picker / MCP / game / dropped files (via useMiscUiState) ---
   const miscUiHook = useMiscUiState();
   const {
     state: {
@@ -798,28 +798,16 @@ function AppProviderInner({
     closeEmotePicker,
   } = miscUiHook;
 
-  // chatPendingImages now comes from useChatState
-
   // --- Refs for timers ---
-  // actionNoticeTimer, shownOnceNotices, agentStatusRef, lifecycleBusyRef,
-  // lifecycleActionRef, setAgentStatusIfChanged are now in useLifecycleState
-  // elizaCloudPollInterval, elizaCloudDisconnectInFlightRef,
-  // elizaCloudPreferDisconnectedUntilLoginRef, lastElizaCloudPollConnectedRef,
-  // elizaCloudLoginPollTimer are now in useCloudState (cloudHook)
   const _restartNotificationSignatureRef = useRef<string | null>(null);
   const _heartbeatNotificationKeyRef = useRef<string | null>(null);
-  // First-run refs now come from useFirstRunState
   const firstRunCompletionCommittedRef = firstRunCompletionCommittedRefFromHook;
-  // exportBusyRef and importBusyRef are now managed inside useExportImportState (exportImportHook)
-  // walletApiKeySavingRef is now managed inside useWalletState (walletHook)
-  // elizaCloudLoginBusyRef, elizaCloudAuthNoticeSentRef
-  // are now managed inside useCloudState (cloudHook)
 
   // --- Confirm Modal ---
   const { modalProps } = useConfirm();
   const { prompt: promptModal, modalProps: promptModalProps } = usePrompt();
 
-  // --- Wallet / Inventory / Registry / Drop / Whitelist (extracted to useWalletState) ---
+  // --- Wallet / Inventory / Registry / Drop / Whitelist (via useWalletState) ---
   // Placed after characterHook (characterDraft) and promptModal — both are required params.
   const walletHook = useWalletState({
     setActionNotice,
@@ -890,7 +878,7 @@ function AppProviderInner({
 
   // setActionNotice is now provided by useLifecycleState
 
-  // ── Cloud state (extracted to useCloudState) ───────────────────────
+  // ── Cloud state (via useCloudState) ───────────────────────
   // Placed after walletHook so loadWalletConfig is available.
   const cloudHook = useCloudState({
     setActionNotice,
@@ -947,7 +935,7 @@ function AppProviderInner({
 
   // Language is managed by TranslationProvider (see useTranslation() above)
 
-  // ── Navigation (extracted to useNavigationState) ──────────────────
+  // ── Navigation (via useNavigationState) ──────────────────
   const navHook = useNavigationState({
     tab,
     setTabRaw,
@@ -967,7 +955,7 @@ function AppProviderInner({
 
   // loadLogs is now in useLogsState (logsHook)
 
-  // ── Data loading (extracted to useDataLoaders) ────────────────────
+  // ── Data loading (via useDataLoaders) ────────────────────
   const dataLoaders = useDataLoaders({
     autonomousStoreRef,
     autonomousEventsRef,
@@ -1039,7 +1027,7 @@ function AppProviderInner({
 
   // beginLifecycleAction / finishLifecycleAction are now provided by useLifecycleState
 
-  // ── Chat callbacks (extracted to useChatCallbacks) ──────────────────
+  // ── Chat callbacks (via useChatCallbacks) ──────────────────
   const chatCallbacks = useChatCallbacks({
     t,
     uiLanguage,
@@ -1275,7 +1263,7 @@ function AppProviderInner({
   // ── Inventory / Registry / Drop / Whitelist actions are provided by useWalletState (walletHook) ──
   // ── Character actions are provided by useCharacterState (characterHook) ──
 
-  // ── First-run callbacks (extracted to useFirstRunCallbacks) ──────
+  // ── First-run callbacks (via useFirstRunCallbacks) ──────
   const firstRunCallbacks = useFirstRunCallbacks({
     firstRun,
     setPostFirstRunChecklistDismissed,

--- a/packages/ui/src/state/ChatComposerContext.test.tsx
+++ b/packages/ui/src/state/ChatComposerContext.test.tsx
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+/**
+ * Per-conversation composer draft persistence (`ChatComposerContext.hooks`):
+ * the localStorage-keyed read/write/clear helpers and the debounced hook that
+ * saves and restores drafts across conversation switches. Real hook under
+ * jsdom + real `localStorage`; no live model or network.
+ */
 import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {

--- a/packages/ui/src/state/agent-profiles.test.ts
+++ b/packages/ui/src/state/agent-profiles.test.ts
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * The agent-profile registry (`agent-profiles`): token scrub on sign-out,
+ * add/upsert/activate, and query resolution over jsdom `localStorage`. Pure
+ * store logic — no live model or network.
+ */
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   addAgentProfile,

--- a/packages/ui/src/state/app-store.test.ts
+++ b/packages/ui/src/state/app-store.test.ts
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * The AppContext selector store (`app-store`): field-level subscriptions via
+ * `useAppSelector` / `useAppSelectorShallow` and the shallow-equality gate that
+ * suppresses re-renders. Real hooks under jsdom; no live model.
+ */
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/ui/src/state/bounded-view-lru.ts
+++ b/packages/ui/src/state/bounded-view-lru.ts
@@ -2,14 +2,13 @@
  * Shared device-memory sizing + LRU helpers for every bounded view cache in the
  * shell.
  *
- * Both `retained-lazy.tsx` (route-chunk module cache) and
- * `components/views/DynamicViewLoader.tsx` (remote-bundle module cache)
- * previously each carried their OWN copy of the `navigator.deviceMemory` tier
- * resolution and the default/low-memory cap+TTL constants. The new
- * keep-alive view-instance cache (`KeepAliveViewHost` via `ViewLifecycleController`)
- * needs the same tiering, so this module is the single home for it. The two
- * module caches import the sizing from here so all three bounded caches scale
- * off one device-memory read and one place to tune the thresholds.
+ * Single home for the `navigator.deviceMemory` tier resolution and the
+ * default/low-memory cap+TTL constants shared by all three bounded caches:
+ * `retained-lazy.tsx` (route-chunk module cache),
+ * `components/views/DynamicViewLoader.tsx` (remote-bundle module cache), and
+ * the keep-alive view-instance cache (`KeepAliveViewHost` via
+ * `ViewLifecycleController`). They import the sizing from here so all three
+ * scale off one device-memory read and one place to tune the thresholds.
  *
  * Pure + dependency-free (no React, no DOM beyond a defensive `navigator`
  * read), so it unit-tests trivially and stays importable from Node test envs.

--- a/packages/ui/src/state/cloud-steward-login.test.ts
+++ b/packages/ui/src/state/cloud-steward-login.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * The Steward login seam (`cloud-steward-login`): stored-JWT usability checks
+ * (expiry parsing), launcher registration, and `launchStewardLogin` dispatch.
+ * jsdom + real `localStorage`; JWTs are synthetic (unsigned) — no real Steward
+ * service.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   hasStewardLoginLauncher,

--- a/packages/ui/src/state/heap-pressure-monitor.test.ts
+++ b/packages/ui/src/state/heap-pressure-monitor.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * The JS-heap-pressure monitor (`heap-pressure-monitor`): its poll loop reads
+ * `performance.memory` and emits `HEAP_PRESSURE_EVENT` past the threshold.
+ * jsdom with fake timers and a stubbed `performance.memory` — deterministic, no
+ * real heap.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { HEAP_PRESSURE_EVENT } from "./bounded-view-lru";
 import {

--- a/packages/ui/src/state/notifications/navigate-deep-link.test.ts
+++ b/packages/ui/src/state/notifications/navigate-deep-link.test.ts
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/**
+ * The notification deep-link guard (`navigate-deep-link`): `isSafeDeepLink`
+ * scheme allowlisting and `navigateDeepLink` routing (new-tab for http(s),
+ * in-app event for root-relative). jsdom; pure guard logic, no network.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isSafeDeepLink, navigateDeepLink } from "./navigate-deep-link";
 

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/**
+ * The notification store (`notification-store`): list/read/remove/clear flows,
+ * unread counting, and WebSocket-event ingestion. jsdom with the API client and
+ * desktop bridge mocked — deterministic, no real server or WS.
+ */
 import type { AgentNotification } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/ui/src/state/ocr-bridge.test.ts
+++ b/packages/ui/src/state/ocr-bridge.test.ts
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * The renderer OCR bridge (`ocr-bridge`): its interval poll of the Tesseract
+ * Capacitor plugin and the request/frame round-trip. jsdom with fake timers;
+ * the Capacitor core and Tesseract plugin are mocked — no native OCR.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __resetOcrBridgeForTests, initOcrBridge } from "./ocr-bridge";
 

--- a/packages/ui/src/state/parsers.test.ts
+++ b/packages/ui/src/state/parsers.test.ts
@@ -1,7 +1,7 @@
 // Unit coverage for the pure chat-input/streaming parsers in state/parsers.ts.
 // These drive slash commands, custom-action argument binding, streamed-text
 // reconciliation, and startup-error formatting — all chat-surface behavior with
-// real branching and no co-located test until now.
+// real branching. Pure functions, no harness.
 
 import { describe, expect, it } from "vitest";
 import type { CustomActionDef } from "../api/client";

--- a/packages/ui/src/state/persistence-cloud-active-server.test.ts
+++ b/packages/ui/src/state/persistence-cloud-active-server.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Active-server persistence for the Cloud path (`persistence` +
+ * `startup-phase-restore`): the invariant that the Eliza Cloud control plane is
+ * never persisted or restored as a runtime API base, plus token scrub. jsdom +
+ * real `localStorage`; no network.
+ */
 import { logger } from "@elizaos/logger";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_BOOT_CONFIG, setBootConfig } from "../config/boot-config";

--- a/packages/ui/src/state/persistence-vad-auto-stop.test.ts
+++ b/packages/ui/src/state/persistence-vad-auto-stop.test.ts
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * VAD auto-stop persistence (`persistence`): `loadVadAutoStop` /
+ * `saveVadAutoStop` round-trip and the canonical defaults returned when nothing
+ * is stored. jsdom + real `localStorage`.
+ */
 import { beforeEach, describe, expect, it } from "vitest";
 import { DEFAULT_LOCAL_ASR_AUTO_STOP } from "../voice/local-asr-capture";
 import { loadVadAutoStop, saveVadAutoStop } from "./persistence";

--- a/packages/ui/src/state/persistence.background.test.ts
+++ b/packages/ui/src/state/persistence.background.test.ts
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/**
+ * Background-config persistence (`persistence`): load/save round-trip and
+ * `normalizeBackgroundConfig` clamping of malformed stored values. jsdom + real
+ * `localStorage`.
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import {
   loadBackgroundConfig,

--- a/packages/ui/src/state/startup-phase-hydrate.view-interact.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.view-interact.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * The ready-phase view-interact wiring (`startup-phase-hydrate.bindReadyPhase`):
+ * agent-driven navigate-view WS events are dispatched to the shell and
+ * view-interact requests are forwarded. jsdom with the API client and
+ * view-interact dispatch mocked — no live agent.
+ */
 import {
   NAVIGATE_VIEW_EVENT,
   SHELL_NAVIGATE_VIEW_WS_EVENT,

--- a/packages/ui/src/state/startup-phase-restore.desktop-rpc.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.desktop-rpc.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * The restoring-session phase over the desktop RPC bridge
+ * (`startup-phase-restore.runRestoringSession`): backend-startup timeout
+ * handling and the force-fresh-first-run gate under Electrobun. jsdom with the
+ * desktop bridge and first-run bootstrap mocked — no real host process.
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   enableForceFreshFirstRun,

--- a/packages/ui/src/state/startup-telemetry.test.ts
+++ b/packages/ui/src/state/startup-telemetry.test.ts
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/**
+ * The startup trace recorder (`startup-telemetry`): mark/measure accumulation,
+ * the window-mirrored trace, and per-window trace-id isolation. jsdom; pure
+ * in-memory + `window` state, no real timers or backend.
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import {
   __resetStartupTraceForTests,

--- a/packages/ui/src/state/switch-runtime.test.ts
+++ b/packages/ui/src/state/switch-runtime.test.ts
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+/**
+ * Non-destructive runtime switching (`switch-runtime`): repointing the client
+ * base URL / token, updating the active agent profile, and clearing composer
+ * drafts on switch. jsdom with the API client, profile registry, and platform
+ * probes mocked — no live agent.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AgentProfile } from "./agent-profile-types";

--- a/packages/ui/src/state/useCharacterState.ts
+++ b/packages/ui/src/state/useCharacterState.ts
@@ -1,5 +1,5 @@
 /**
- * Character / avatar state — extracted from AppContext.
+ * Character / avatar state, one of the domain hooks AppContext composes.
  *
  * Manages character data, draft editing, VRM avatar selection, and save
  * callbacks. The handleSaveCharacter callback depends on lifecycle state

--- a/packages/ui/src/state/useChatCallbacks.draft-handoff.test.tsx
+++ b/packages/ui/src/state/useChatCallbacks.draft-handoff.test.tsx
@@ -1,20 +1,16 @@
 // @vitest-environment jsdom
 //
-// Per-conversation composer draft handoff on switch (#FIX2).
+// Per-conversation composer draft handoff on switch (`useChatCallbacks`).
 //
 // Composer drafts are persisted per conversation (localStorage, keyed by id).
-// Switching conversations must repaint the composer for the TARGET: restore
-// the target's own saved draft, or CLEAR the composer when it has none.
+// Switching conversations must repaint the composer for the TARGET — restore
+// the target's own saved draft, or CLEAR the composer when it has none — so a
+// half-typed message can never leak into (and be sent to) the wrong
+// conversation. The handoff runs inside handleSelectConversation: persist the
+// leaving conversation's text under ITS key, then restore the target's draft or
+// clear the composer.
 //
-// The bug: switching to a conversation with NO saved draft left the PREVIOUS
-// conversation's composer text in place. The debounced per-conversation
-// persister then saved that leaked text under the TARGET's key — so a
-// half-typed message silently reappeared in, and would be sent to, the wrong
-// conversation. The fix does the draft handoff inside handleSelectConversation:
-// persist the leaving conversation's text under ITS key, then restore the
-// target's draft or clear the composer when the target has none.
-//
-// This drives the REAL handleSelectConversation composed with the REAL
+// Drives the REAL handleSelectConversation composed with the REAL
 // useDataLoaders.loadConversationMessages (like the sibling select-race suite),
 // with a real setChatInput that mirrors useChatState (syncs chatInputRef), and
 // the real localStorage-backed draft helpers.

--- a/packages/ui/src/state/useChatCallbacks.ts
+++ b/packages/ui/src/state/useChatCallbacks.ts
@@ -1,5 +1,5 @@
 /**
- * Chat callbacks — extracted from AppContext.
+ * Chat callbacks, one of the domain hooks AppContext composes.
  *
  * Assembler hook: composes useChatLifecycle + useChatSend and owns the
  * greeting / conversation-management callbacks that depend on both.

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * Core coverage of the chat send lifecycle (`useChatSend`): Stop/abort
+ * handling, 404 conversation-gone recovery, always-streaming delivery,
+ * transient send-failure notices, and the cloud shared→dedicated handoff queue.
+ * Real hook under jsdom with a fake API client — deterministic, no live model
+ * or network.
+ */
 import { act, renderHook } from "@testing-library/react";
 import type { MutableRefObject } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/state/useChatState.unread.test.ts
+++ b/packages/ui/src/state/useChatState.unread.test.ts
@@ -1,14 +1,11 @@
 // @vitest-environment jsdom
 //
-// Regression (#FIX3): opening a conversation must clear its unread badge.
-//
-// `unreadConversations` is a reducer field. The provider's functional
-// `setUnreadConversations` wrapper can only re-ADD ids (it iterates the
-// next set and calls `addUnread`) — it never removes — so REMOVE_UNREAD was
-// effectively unreachable and the "delete this id" updaters were no-ops:
-// badges never cleared. The fix clears the opened conversation's unread on the
-// SET_ACTIVE_CONVERSATION_ID transition, the single dispatch that always fires
-// when a conversation is opened.
+// `useChatState` unread-badge clearing: opening a conversation must clear its
+// unread badge. `unreadConversations` is a reducer field whose functional
+// `setUnreadConversations` wrapper can only re-ADD ids, so clearing rides the
+// SET_ACTIVE_CONVERSATION_ID transition (the single dispatch that always fires
+// on open) rather than a remove-updater. Real hook under jsdom + real
+// localStorage.
 
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";

--- a/packages/ui/src/state/useCloudState.steward-refresh-electrobun.test.tsx
+++ b/packages/ui/src/state/useCloudState.steward-refresh-electrobun.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Steward token-refresh arming under Electrobun (`useCloudState`): the
+ * desktop-runtime branch of the stored-token lifecycle refresh. jsdom with the
+ * cloud client, desktop bridge, and boot config mocked — no real Steward
+ * service.
+ */
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/state/useCloudState.steward-stale-login.test.tsx
+++ b/packages/ui/src/state/useCloudState.steward-stale-login.test.tsx
@@ -1,15 +1,13 @@
 // @vitest-environment jsdom
 //
-// Sign-in first-click dead-end regression. With a stored-but-EXPIRED Steward
-// JWT and NO mounted Steward launcher (registerStewardLoginLauncher has no
-// production caller today, so the dashboard always runs launcher-less),
-// handleCloudLogin used to enter the Steward branch anyway: launchStewardLogin
-// drained the stale token and then threw "the Steward login surface is not
-// mounted", so the FIRST click surfaced a sign-in error and only the SECOND
-// click (token now gone) reached the working device-code flow. These tests
-// lock the fix: the first click drains the stale token and proceeds straight
-// to the device-code flow, while a still-usable token and a mounted launcher
-// keep their existing Steward-branch behavior.
+// `useCloudState.handleCloudLogin` sign-in first-click behavior. With a
+// stored-but-EXPIRED Steward JWT and NO mounted Steward launcher
+// (registerStewardLoginLauncher has no production caller today, so the
+// dashboard runs launcher-less), the first click must drain the stale token and
+// proceed straight to the device-code flow — not enter the Steward branch,
+// which would throw "the Steward login surface is not mounted" and dead-end the
+// first click. A still-usable token and a mounted launcher keep the
+// Steward-branch behavior. jsdom with the API client mocked.
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -1,5 +1,5 @@
 /**
- * Eliza Cloud state — extracted from AppContext.
+ * Eliza Cloud state, one of the domain hooks AppContext composes.
  *
  * Manages:
  * - Cloud connection state (enabled, connected, persisted key, user ID)

--- a/packages/ui/src/state/useDataLoaders.ts
+++ b/packages/ui/src/state/useDataLoaders.ts
@@ -1,5 +1,5 @@
 /**
- * Data-loading callbacks — extracted from AppContext.
+ * Data-loading callbacks, one of the domain hooks AppContext composes.
  *
  * Covers: autonomy event merge / replay / append, conversation loaders,
  * BSC trade + steward wrappers, loadInventory, ownerName hydration,

--- a/packages/ui/src/state/useDisplayPreferences.accent.test.tsx
+++ b/packages/ui/src/state/useDisplayPreferences.accent.test.tsx
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+/**
+ * Accent-preset selection in `useDisplayPreferences`: id normalization, color
+ * resolution, `localStorage` persistence, and applying the resolved `--accent`
+ * CSS variable to the document root. Real hook under jsdom + real
+ * `localStorage`.
+ */
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { applyUiAccent, loadUiAccentId, saveUiAccentId } from "./persistence";

--- a/packages/ui/src/state/useDisplayPreferences.background.test.tsx
+++ b/packages/ui/src/state/useDisplayPreferences.background.test.tsx
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+/**
+ * Background config + undo/redo history in `useDisplayPreferences`: the
+ * versioned push/undo/redo semantics, the history/data-URL caps, and
+ * home-time-widget visibility persistence. Real hook under jsdom + real
+ * `localStorage`.
+ */
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {

--- a/packages/ui/src/state/useExportImportState.ts
+++ b/packages/ui/src/state/useExportImportState.ts
@@ -1,5 +1,5 @@
 /**
- * Agent export/import state — extracted from AppContext.
+ * Agent export/import state, one of the domain hooks AppContext composes.
  *
  * Manages the export/import UI state and the download/upload
  * callbacks. Uses the client singleton directly, matching the

--- a/packages/ui/src/state/useLifecycleState.canRespond.test.tsx
+++ b/packages/ui/src/state/useLifecycleState.canRespond.test.tsx
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * `useLifecycleState.setAgentStatusIfChanged` change detection: a
+ * `canRespond`-only flip must apply rather than being deduped away. Real hook
+ * under jsdom; no live agent.
+ */
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { AgentStatus } from "../api";

--- a/packages/ui/src/state/useLogsState.ts
+++ b/packages/ui/src/state/useLogsState.ts
@@ -1,5 +1,5 @@
 /**
- * Logs state — extracted from AppContext.
+ * Logs state, one of the domain hooks AppContext composes.
  *
  * Manages log entries, sources, tags, and filter state.
  * The loadLogs callback reads all three filter values from state.

--- a/packages/ui/src/state/useMiscUiState.ts
+++ b/packages/ui/src/state/useMiscUiState.ts
@@ -1,5 +1,5 @@
 /**
- * Miscellaneous UI state — extracted from AppContext.
+ * Miscellaneous UI state, one of the domain hooks AppContext composes.
  *
  * Covers three loosely-coupled UI domains that don't warrant their
  * own dedicated hook files:

--- a/packages/ui/src/state/useNavigationState.ts
+++ b/packages/ui/src/state/useNavigationState.ts
@@ -1,5 +1,5 @@
 /**
- * Navigation state — extracted from AppContext.
+ * Navigation state, one of the domain hooks AppContext composes.
  *
  * Owns: setTab wrappers, switchShellView, switchUiShellMode, setUiShellMode,
  * deferred post-tab-commit work, uiShellMode persist, lastNativeTab persist,

--- a/packages/ui/src/state/usePairingState.ts
+++ b/packages/ui/src/state/usePairingState.ts
@@ -1,5 +1,5 @@
 /**
- * Pairing / auth state — extracted from AppContext.
+ * Pairing / auth state, one of the domain hooks AppContext composes.
  *
  * Manages the pairing code UI (input, submit, error, busy). The startup
  * effect sets pairingEnabled/pairingExpiresAt from the backend — those

--- a/packages/ui/src/state/usePluginsSkillsState.ts
+++ b/packages/ui/src/state/usePluginsSkillsState.ts
@@ -1,5 +1,5 @@
 /**
- * Plugins / Skills / Store / Catalog state — extracted from AppContext.
+ * Plugins / Skills / Store / Catalog state, one of the domain hooks AppContext composes.
  *
  * Manages plugin list and config, skill list and create/delete/review/marketplace
  * flows, the store (registry plugins), and the catalog (marketplace skills).

--- a/packages/ui/src/state/usePreviewMode.test.ts
+++ b/packages/ui/src/state/usePreviewMode.test.ts
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/**
+ * The preview-mode toggle (`usePreviewMode`): default-off, `localStorage`
+ * persistence, and the in-memory cache that mirrors it. jsdom + real
+ * `localStorage`.
+ */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { isPreviewModeEnabled, setPreviewMode } from "./usePreviewMode";
 

--- a/packages/ui/src/state/useResyncReconcile.ts
+++ b/packages/ui/src/state/useResyncReconcile.ts
@@ -2,10 +2,9 @@
  * Live consumer for the WebSocket-reconnect resync signal.
  *
  * `AppContext` dispatches {@link RESYNC_EVENT} on `client.onReconnect` after a
- * dropped socket comes back. Historically that event had NO listener, so the
- * reconcile it was meant to trigger never ran: messages the agent emitted while
- * the socket was down stayed hidden until a manual refresh. This hook wires the
- * missing listener and performs the reconcile.
+ * dropped socket comes back; this hook is its listener and performs the
+ * reconcile. Without it, messages the agent emitted while the socket was down
+ * stay hidden until a manual refresh.
  */
 
 import { type MutableRefObject, useEffect } from "react";

--- a/packages/ui/src/state/useTriggersState.ts
+++ b/packages/ui/src/state/useTriggersState.ts
@@ -1,5 +1,5 @@
 /**
- * Trigger (heartbeat) state — extracted from AppContext.
+ * Trigger (heartbeat) state, one of the domain hooks AppContext composes.
  *
  * Manages trigger CRUD, run history, and health polling. Zero coupling to
  * the startup sequence — triggers are only loaded post-ready.

--- a/packages/ui/src/state/useWalletState.ts
+++ b/packages/ui/src/state/useWalletState.ts
@@ -1,5 +1,5 @@
 /**
- * Wallet / Inventory / Registry / Drop / Whitelist state — extracted from AppContext.
+ * Wallet / Inventory / Registry / Drop / Whitelist state, one of the domain hooks AppContext composes.
  *
  * Manages:
  * - Wallet addresses, config, balances, NFTs, export flow

--- a/packages/ui/src/state/view-chat-binding.test.ts
+++ b/packages/ui/src/state/view-chat-binding.test.ts
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/**
+ * The view↔chat binding registry (`view-chat-binding`): the module-level
+ * current binding and the `useRegisterViewChatBinding` hook that sets it on
+ * mount and clears it on unmount. Real hook under jsdom.
+ */
 import { cleanup, render } from "@testing-library/react";
 import { createElement } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/state/view-lifecycle.hidden-resume.test.tsx
+++ b/packages/ui/src/state/view-lifecycle.hidden-resume.test.tsx
@@ -1,18 +1,17 @@
 // @vitest-environment jsdom
 //
-// Hidden keep-alive views must STAY paused across app-resume / tab refocus.
+// Hidden keep-alive views must STAY paused across app-resume / tab refocus;
+// only the ACTIVE view may wake on resume.
 //
 // A pausable keep-alive view's resting phase while hidden IS "paused" —
 // `setActive` pauses it the moment another view becomes active (see the
 // "retains + pauses a keep-alive view when hidden" case in
-// view-lifecycle.test.tsx). The bug: `resumeAll` (fired on APP_RESUME and on
-// every `visibilitychange` back to visible) transitioned EVERY paused record,
-// flipping hidden retained views to "inactive" — un-pausing them. Concretely:
-// open Calendar (keepAlive+pausable), go Home (calendar retained+paused, its
-// polling stopped), switch browser tabs away and back — calendar's timers/
-// polling/media restarted (`usePausableInterval` gates on `isPaused`, and its
-// `onResume` handler fired) while the view was still hidden. Only the ACTIVE
-// view may wake on resume.
+// view-lifecycle.test.tsx). `resumeAll` fires on APP_RESUME and on every
+// `visibilitychange` back to visible; it must skip hidden retained records so
+// their timers/polling/media (gated by `usePausableInterval` on `isPaused`)
+// stay stopped. Concretely: open Calendar (keepAlive+pausable), go Home
+// (calendar retained+paused, polling stopped), tab away and back — calendar
+// must NOT restart while still hidden.
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { APP_PAUSE_EVENT, APP_RESUME_EVENT } from "../events";


### PR DESCRIPTION
Comments-only slice of #12235 for chunk **b05-state** (`packages/ui/src/state`). Zero functional diff.

## What changed
43 files touched, all in `packages/ui/src/state`:

- **Test headers (new).** ~22 test files that opened with `// @vitest-environment jsdom` then went straight to imports now carry a concise `/** … */` header stating the surface under test and how real the harness is (jsdom + real `localStorage` vs mocked client/bridge; deterministic, no live model). Examples: `agent-profiles.test.ts`, `app-store.test.ts`, `cloud-steward-login.test.ts`, `heap-pressure-monitor.test.ts`, `ocr-bridge.test.ts`, the three `persistence*.test.ts`, `startup-telemetry.test.ts`, `switch-runtime.test.ts`, `useChatSend.test.tsx`, `useDisplayPreferences.{accent,background}.test.tsx`, `view-chat-binding.test.ts`, both `notifications/*.test.ts`, and more.
- **Churn → present-tense fact.** Dropped the "— extracted from AppContext" migration framing from the 12 domain-state hook headers (`useCharacterState`, `useCloudState`, `useWalletState`, `useDataLoaders`, `usePluginsSkillsState`, `useMiscUiState`, `useChatCallbacks`, `useNavigationState`, `usePairingState`, `useTriggersState`, `useLogsState`, `useExportImportState`) → "one of the domain hooks AppContext composes." De-churned `bounded-view-lru.ts`, `useResyncReconcile.ts`, and several test headers that narrated a bug/fix story (`useChatState.unread`, `useChatCallbacks.draft-handoff`, `useCloudState.steward-stale-login`, `view-lifecycle.hidden-resume`, `AppContext.resync`, `parsers.test`).
- **AppContext.tsx in-body cleanup.** Deleted migration-bookkeeping ref comments ("X is now in / now managed inside Y") and rephrased the `(extracted to <hook>)` section markers to present-tense `(via <hook>)`.

## Verification
`bun run check:comment-only` passes:

```
[assert-comment-only-diff] OK — 43 source file(s) changed; every code token identical to origin/develop. Comments only.
```

Part of #12235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)