### PR TITLE
docs(#12241): add vault package headers

### DIFF
--- a/packages/vault/src/audit.ts
+++ b/packages/vault/src/audit.ts
@@ -1,3 +1,10 @@
+/**
+ * Append-only audit logging for vault operations.
+ *
+ * Records operation metadata and key names to JSONL while never persisting
+ * secret values in the audit trail.
+ */
+
 import { promises as fs } from "node:fs";
 import { dirname } from "node:path";
 import type { AuditRecord, VaultLogger } from "./types.js";

--- a/packages/vault/src/crypto.ts
+++ b/packages/vault/src/crypto.ts
@@ -1,3 +1,10 @@
+/**
+ * AES-256-GCM envelope helpers for vault secret values.
+ *
+ * The vault key is bound as authenticated data so encrypted blobs cannot be
+ * moved between key slots without failing decryption.
+ */
+
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 
 /**

--- a/packages/vault/src/internal-utils.ts
+++ b/packages/vault/src/internal-utils.ts
@@ -1,3 +1,7 @@
+/**
+ * Internal runtime validation helpers shared by vault implementations.
+ */
+
 import type { SetOptions } from "./vault-types.js";
 
 export function assertKey(key: string): void {

--- a/packages/vault/src/manager.ts
+++ b/packages/vault/src/manager.ts
@@ -1,3 +1,10 @@
+/**
+ * Secrets-manager routing layer over the vault storage API.
+ *
+ * Detects password-manager backends, applies user preferences, and combines
+ * in-house saved logins with external credential listings.
+ */
+
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import {

--- a/packages/vault/src/master-key.ts
+++ b/packages/vault/src/master-key.ts
@@ -1,3 +1,10 @@
+/**
+ * Master-key resolvers for vault encryption.
+ *
+ * Supports OS keychain storage, passphrase-derived keys, in-memory test keys,
+ * and fail-closed TEE attestation before releasing sealed-volume keys.
+ */
+
 import { execFile, spawn } from "node:child_process";
 import { scryptSync } from "node:crypto";
 import { existsSync } from "node:fs";

--- a/packages/vault/src/password-managers.ts
+++ b/packages/vault/src/password-managers.ts
@@ -1,3 +1,10 @@
+/**
+ * Password-manager reference resolver for external vault entries.
+ *
+ * Resolves 1Password and Proton Pass pointers through their CLIs when callers
+ * explicitly request the referenced secret value.
+ */
+
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { PasswordManagerReference } from "./types.js";

--- a/packages/vault/src/pglite-vault.ts
+++ b/packages/vault/src/pglite-vault.ts
@@ -1,3 +1,11 @@
+/**
+ * PGlite-backed vault storage engine.
+ *
+ * Stores non-sensitive values and encrypted secrets in a dedicated PGlite DB,
+ * migrates the legacy JSON store once, and heals provably stale single-writer
+ * locks before opening the database.
+ */
+
 import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -29,8 +37,8 @@ import { VaultMissError } from "./vault-types.js";
  *     registers at step 7b — no ordering contortions
  *   - keeps vault corruption isolated from chat/memory corruption
  *
- * Crypto + master-key flow are unchanged from VaultImpl: AES-256-GCM with
- * the key as AAD, master key from OS Keychain via `@napi-rs/keyring`. The
+ * Crypto + master-key flow matches the Vault contract: AES-256-GCM with the
+ * key as AAD, master key from OS Keychain via `@napi-rs/keyring`. The
  * DB stores opaque ciphertext; PGlite never sees plaintext or the master
  * key.
  *
@@ -78,7 +86,7 @@ export interface PgliteVaultOptions {
 
 /**
  * Outcome of inspecting a PGlite data dir's `postmaster.pid`. `cleared-*`
- * means a provably-stale lock was removed and the open may be retried;
+ * means the lock is provably stale and the open may be retried;
  * `active` means a live process owns the dir; `missing` / `unconfirmed` mean
  * there is nothing safe to remove.
  */
@@ -526,7 +534,7 @@ export class PgliteVaultImpl implements Vault {
   }
 
   /**
-   * One-shot migration from `vault.json` → vault_entries. Runs on first
+   * One-shot import from `vault.json` to vault_entries. Runs on first
    * PgliteVaultImpl boot when the table is empty AND the legacy file
    * exists. Copies entries verbatim — ciphertext stays opaque, master
    * key unchanged. Writes a sentinel row so we never re-run.

--- a/packages/vault/src/store.ts
+++ b/packages/vault/src/store.ts
@@ -1,3 +1,10 @@
+/**
+ * Legacy JSON vault store helpers used by one-shot migration.
+ *
+ * Reads and writes the pre-PGlite `vault.json` shape with atomic 0600 writes
+ * so old installs can be imported into the current storage engine.
+ */
+
 import { randomBytes } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { dirname } from "node:path";

--- a/packages/vault/src/vault-types.ts
+++ b/packages/vault/src/vault-types.ts
@@ -1,3 +1,7 @@
+/**
+ * Core vault API types shared by factories, managers, and storage engines.
+ */
+
 import type { MasterKeyResolver } from "./master-key.js";
 import type {
   PasswordManagerReference,

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -1,3 +1,10 @@
+/**
+ * Vault factory wired to the default PGlite storage engine and master key.
+ *
+ * Resolves the elizaOS state directory, audit log path, legacy JSON store, and
+ * default master-key resolver before constructing the vault implementation.
+ */
+
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { defaultMasterKey } from "./master-key.js";

--- a/packages/vault/test/credentials.test.ts
+++ b/packages/vault/test/credentials.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests saved-login helpers against a real encrypted test vault.
+ */
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   deleteSavedLogin,

--- a/packages/vault/test/crypto.test.ts
+++ b/packages/vault/test/crypto.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests the vault ciphertext envelope and authenticated-data binding.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   CryptoError,

--- a/packages/vault/test/external-credentials.test.ts
+++ b/packages/vault/test/external-credentials.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests external credential adapters with injected command executors.
+ */
+
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/packages/vault/test/install.test.ts
+++ b/packages/vault/test/install.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests password-manager install metadata and generated install commands.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   BACKEND_INSTALL_SPECS,

--- a/packages/vault/test/inventory.test.ts
+++ b/packages/vault/test/inventory.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests inventory categorization, metadata profiles, and UI-safe listings.
+ */
+
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -24,9 +28,8 @@ describe("inventory — categorization heuristics", () => {
     expect(categorizeKey("GOOGLE_GENERATIVE_AI_API_KEY")).toBe("provider");
     expect(categorizeKey("GEMINI_API_KEY")).toBe("provider");
     expect(categorizeKey("PERPLEXITY_API_KEY")).toBe("provider");
-    // OpenAI-compatible + previously-unpatterned providers must also classify
-    // as first-party providers (regression guard: CEREBRAS/NEARAI were missing
-    // from the old pattern list and fell through to "plugin").
+    // OpenAI-compatible providers classify as first-party providers, including
+    // providers that do not share the original provider-name pattern.
     expect(categorizeKey("CEREBRAS_API_KEY")).toBe("provider");
     expect(categorizeKey("MOONSHOT_API_KEY")).toBe("provider");
     expect(categorizeKey("KIMI_API_KEY")).toBe("provider");

--- a/packages/vault/test/manager.test.ts
+++ b/packages/vault/test/manager.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests the secrets-manager routing layer with encrypted temp vaults.
+ */
+
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/packages/vault/test/master-key.test.ts
+++ b/packages/vault/test/master-key.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests master-key resolver behavior without touching the host keychain.
+ */
+
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { generateMasterKey, KEY_BYTES } from "../src/crypto.js";
 import {

--- a/packages/vault/test/password-managers.test.ts
+++ b/packages/vault/test/password-managers.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests password-manager reference resolution with mocked CLI subprocesses.
+ */
+
 import { execFile } from "node:child_process";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveReference } from "../src/password-managers.js";

--- a/packages/vault/test/profiles.test.ts
+++ b/packages/vault/test/profiles.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests per-key profile and routing resolution against encrypted temp vaults.
+ */
+
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/packages/vault/test/vault.test.ts
+++ b/packages/vault/test/vault.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests the public vault contract using real encryption and temporary storage.
+ */
+
 import { promises as fs } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createTestVault, type TestVault } from "../src/testing.js";

--- a/packages/vault/test/vitest-assertion-shim.ts
+++ b/packages/vault/test/vitest-assertion-shim.ts
@@ -1,3 +1,7 @@
+/**
+ * Runtime-cast helpers for asserting invalid calls against typed vault APIs.
+ */
+
 import "vitest";
 import type { MasterKeyResolver } from "../src/master-key.js";
 import type { Vault } from "../src/vault-types.js";

--- a/packages/vault/vitest.config.ts
+++ b/packages/vault/vitest.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Vitest config for the vault package test suite.
+ */
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Adds purpose prose headers to the B11 `packages/vault` source slice and rewrites churn-phrased comments in `inventory.test.ts` / `pglite-vault.ts` to present-tense invariants.

Remaining churn-grep hits were reviewed and left unchanged because they are user-facing strings, generated `dist` declarations, or a durable master-key warning.

## Verification

- `bun run check:comment-only` — PASS (`22 source file(s) changed; every code token identical to origin/develop`)
- `bun run --cwd packages/vault test` — PASS (11 files, 192 passed, 1 skipped)
- `bun run --cwd packages/vault typecheck` — PASS
- `bunx @biomejs/biome check packages/vault/src packages/vault/test packages/vault/vitest.config.ts` — PASS
- `git diff --check` — PASS
- Header self-audit for `packages/vault` B11 source files — PASS (prints nothing)

## Evidence

- Diffstat: `22 files changed, 119 insertions(+), 7 deletions(-)`
- Real-LLM trajectories: N/A — comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- Screenshots/video/audio: N/A — no UI, audio, or runtime behavior changed.
- Backend/frontend logs: N/A — no runtime path changed.
- Domain artifacts: N/A — vault comments only; no DB rows, secrets, audit records, generated artifacts, or key material changed.
