### PR TITLE
fix(agent): 416 on suffix Range against a zero-byte media file

### DIFF
--- a/packages/agent/src/api/media-store.test.ts
+++ b/packages/agent/src/api/media-store.test.ts
@@ -442,6 +442,16 @@ describe("handleMediaRouteRequest (in-process / iOS path)", () => {
     expect(res.headers["Content-Range"]).toBe("bytes */10");
   });
 
+  it("416s a suffix Range (bytes=-N) against a zero-byte file", () => {
+    // Regression (#12351 follow-up): the suffix branch used to skip the
+    // satisfiability guard and return {start:0,end:-1} for a 0-length file,
+    // yielding an invalid 206 (Content-Range: bytes 0--1/0) instead of 416.
+    const { url } = persistMediaBytes(Buffer.alloc(0), "audio/mpeg");
+    const res = handleMediaRouteRequest(url, "GET", "bytes=-5");
+    expect(res.status).toBe(416);
+    expect(res.headers["Content-Range"]).toBe("bytes */0");
+  });
+
   it("ignores a malformed Range and serves the full 200", () => {
     const bytes = Buffer.from("0123456789");
     const { url } = persistMediaBytes(bytes, "audio/mpeg");
@@ -488,6 +498,23 @@ describe("serveMediaFile Range (HTTP path)", () => {
     const out = get();
     expect(out.status).toBe(416);
     expect(out.headers["Content-Range"]).toBe("bytes */10");
+  });
+
+  it("answers a suffix Range against a zero-byte file with 416 (not a mid-stream throw)", () => {
+    // Regression (#12351 follow-up): for a 0-length file the suffix branch
+    // returned {start:0,end:-1}; the HTTP path wrote the 206 head then
+    // createReadStream({end:-1}) threw ERR_OUT_OF_RANGE after the response had
+    // already started. It must return a clean 416 up front instead.
+    const { url } = persistMediaBytes(Buffer.alloc(0), "audio/mpeg");
+    const { res, get } = makeRes();
+    serveMediaFile(
+      { method: "GET", headers: { range: "bytes=-5" } } as never,
+      res,
+      url,
+    );
+    const out = get();
+    expect(out.status).toBe(416);
+    expect(out.headers["Content-Range"]).toBe("bytes */0");
   });
 });
 

--- a/packages/agent/src/api/media-store.ts
+++ b/packages/agent/src/api/media-store.ts
@@ -649,10 +649,16 @@ function parseByteRange(
   if (!match) return null;
   const startRaw = match[1];
   const endRaw = match[2];
-  // `bytes=-N` is a suffix range: the last N bytes.
+  // `bytes=-N` is a suffix range: the last N bytes. A suffix range against a
+  // zero-length representation (size 0) is unsatisfiable → 416; without the
+  // `size <= 0` guard this returned {start:0,end:-1}, which the 206 path then
+  // streams as `createReadStream(end:-1)` (throws ERR_OUT_OF_RANGE after the
+  // head is already sent) or emits as an invalid `Content-Range: bytes 0--1/0`.
   if (!startRaw && endRaw) {
     const suffix = Number.parseInt(endRaw, 10);
-    if (Number.isNaN(suffix) || suffix <= 0) return { unsatisfiable: true };
+    if (Number.isNaN(suffix) || suffix <= 0 || size <= 0) {
+      return { unsatisfiable: true };
+    }
     return { start: Math.max(0, size - suffix), end: size - 1 };
   }
   const start = startRaw ? Number.parseInt(startRaw, 10) : 0;


### PR DESCRIPTION
## What & why

`parseByteRange` (in `packages/agent/src/api/media-store.ts`) has a **suffix-range regression** introduced by #12351 (merged as #12482). The suffix branch (`Range: bytes=-N`) `return`s **early**, before the `start > end / start >= size` satisfiability guard that the explicit-range branch applies. For a **zero-length** representation it computes `{ start: Math.max(0, 0 - N) = 0, end: 0 - 1 = -1 }` and treats it as *satisfiable*.

A zero-byte media file is genuinely reachable: `persistMediaBytes` has no empty-buffer guard, so an empty upload (`LocalFileStorageService.store`) or a rehosted 0-byte remote body (`rehostRemoteMediaUrl` → `fetchRemoteMedia`, which accepts a 200/0-byte body) writes a file at the well-known empty-content sha256 URL. A normal end-of-file metadata probe (`Range: bytes=-5`) then hits it:

- **HTTP path** (`serveMediaFile`): writes the `206` head, then `fs.createReadStream(path, { start: 0, end: -1 })` throws `ERR_OUT_OF_RANGE` **after the response has already started** — aborting mid-stream instead of returning `416`.
- **IPC path** (`handleMediaRouteRequest`, iOS/desktop/Android native scheme handlers): emits an **invalid 206** with `Content-Range: bytes 0--1/0`.

The pre-#12351 code let the suffix case fall through to the shared guard, which returned a clean `416`. This restores that: fold `size <= 0` into the suffix branch's unsatisfiable guard.

## The fix

One guard in the suffix branch of `parseByteRange` — `|| size <= 0` — so both serve paths return `416 Range Not Satisfiable` (`Content-Range: bytes */0`) for a suffix range against a zero-byte file.

## Evidence

Found by an independent adversarial review of recent merges; verified by reproduction.

**Tests fail without the fix, pass with it** (`packages/agent/src/api/media-store.test.ts`, 2 new tests — one per serve path):

Without the guard:
```
× 416s a suffix Range (bytes=-N) against a zero-byte file
    AssertionError: expected 206 to be 416
× answers a suffix Range against a zero-byte file with 416 (not a mid-stream throw)
    RangeError: The value of "end" is out of range. It must be >= 0 ... Received -1
```

With the guard:
```
Test Files  1 passed (1)
      Tests  44 passed (44)
```

The tests drive the **real** code path (`persistMediaBytes(Buffer.alloc(0), …)` → real zero-byte file on disk → real `serveMediaFile` / `handleMediaRouteRequest`), not a mock.

- Backend `[ClassName]` logs / model trajectories: **N/A** — pure HTTP-range branch, no agent/model/log path involved.
- Screenshots / video / device capture: **N/A** — no UI surface; both serve paths covered by unit tests above.
- `bun run --cwd packages/agent typecheck`: no new errors from this change (the 2 pre-existing `plugin-discord/voice-meetings.ts` `@elizaos/plugin-meetings` module-resolution errors on `develop` are unrelated).