### PR TITLE
docs(#12235): prose headers + churn cleanup — b05-small-src

### DIFF
--- a/packages/ui/src/agent-surface/__tests__/agentsurface-stories-smoke.test.tsx
+++ b/packages/ui/src/agent-surface/__tests__/agentsurface-stories-smoke.test.tsx
@@ -1,4 +1,6 @@
 // @vitest-environment jsdom
+
+/** Smoke-renders every agent-surface Storybook story under jsdom to catch a story that throws on mount. */
 import { smokeStoryModules } from "../../../test/portable-stories";
 
 const modules = import.meta.glob("../**/*.stories.tsx", { eager: true });

--- a/packages/ui/src/agent-surface/registry.test.ts
+++ b/packages/ui/src/agent-surface/registry.test.ts
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+
+/**
+ * Covers ViewAgentRegistry: registering/snapshotting/unregistering agent
+ * elements per (view, modality) and routing agent-surface capabilities against
+ * the registered snapshot. Uses real DOM nodes under jsdom.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { handleAgentSurfaceCapability } from "./capabilities";
 import {

--- a/packages/ui/src/backgrounds/AppBackground.test.tsx
+++ b/packages/ui/src/backgrounds/AppBackground.test.tsx
@@ -1,4 +1,11 @@
 // @vitest-environment jsdom
+
+/**
+ * Verifies AppBackground reads the persisted BackgroundConfig from app state
+ * and renders the matching surface: a shader host in the configured color for
+ * `mode: shader`, an image host for `mode: image`. jsdom render over a seeded
+ * store double.
+ */
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { __setAppValueForTests } from "../state/app-store";

--- a/packages/ui/src/backgrounds/__tests__/BackgroundHost.test.tsx
+++ b/packages/ui/src/backgrounds/__tests__/BackgroundHost.test.tsx
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+
+/**
+ * Pins BackgroundHost as the static solid host for marketing/login pages: it
+ * renders exactly one solid background element and never mounts a video,
+ * canvas, or animation surface. jsdom render.
+ */
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/packages/ui/src/backgrounds/__tests__/backgrounds-stories-smoke.test.tsx
+++ b/packages/ui/src/backgrounds/__tests__/backgrounds-stories-smoke.test.tsx
@@ -1,4 +1,6 @@
 // @vitest-environment jsdom
+
+/** Smoke-renders every backgrounds Storybook story under jsdom to catch a story that throws on mount. */
 import { smokeStoryModules } from "../../../test/portable-stories";
 
 const modules = import.meta.glob("../**/*.stories.tsx", { eager: true });

--- a/packages/ui/src/chat/report-shortcut-fired.test.ts
+++ b/packages/ui/src/chat/report-shortcut-fired.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Covers `reportShortcutFired` (#8792): a fired shortcut POSTs to
+ * `/api/interactions/shortcut` with the auth header and shortcut/source body.
+ * `fetch` and the eliza-globals base/token are stubbed under jsdom.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../utils/eliza-globals", () => ({

--- a/packages/ui/src/events/cloud-handoff-phase.test.ts
+++ b/packages/ui/src/events/cloud-handoff-phase.test.ts
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+
+/**
+ * Covers `dispatchCloudHandoffPhase`: each phase (migrating, done, …) is emitted
+ * on the window as a CLOUD_HANDOFF_PHASE_EVENT CustomEvent carrying the agent id
+ * and phase. Listens on the jsdom window.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CLOUD_HANDOFF_PHASE_EVENT,

--- a/packages/ui/src/genui/genui-action-registry.ts
+++ b/packages/ui/src/genui/genui-action-registry.ts
@@ -1,13 +1,12 @@
 /**
- * Boot-time generated-UI action registry (#12087 Item 26).
+ * Boot-time registry of the action names a generated-UI component may dispatch
+ * (#12087 Item 26).
  *
- * Which action names a generated-UI component may dispatch used to be a single
- * hardcoded prefix list in `catalog.ts`, so a feature/plugin that introduced a
- * new action family had to edit that shared constant. This registry — keyed on a
- * global symbol, mirroring `settings-section-registry` / `app-shell-registry` —
- * lets each feature/plugin module contribute its allowed action names/prefixes
- * at import time; the gate (`routeElizaGenUiAction`) reads the registry, and an
- * unregistered name still throws.
+ * Keyed on a global symbol, mirroring `settings-section-registry` /
+ * `app-shell-registry`: each feature/plugin module contributes its allowed
+ * action names/prefixes at import time, so a new action family needs no edit to
+ * a shared constant in `catalog.ts`. The gate (`routeElizaGenUiAction`) reads
+ * the registry, and an unregistered name still throws.
  *
  * The store self-seeds with the built-in prefixes ({@link
  * ELIZA_GENUI_ALLOWED_ACTION_PREFIXES}) so the default surface keeps working

--- a/packages/ui/src/genui/genui.test.tsx
+++ b/packages/ui/src/genui/genui.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * End-to-end genUI render: validate an agent-authored spec, render it with
+ * ElizaGenUiRenderer, dispatch prefix actions through the action handler, and
+ * apply a streaming patch. jsdom render over the real validator/renderer/streaming.
+ */
+
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/layouts/workspace-layout/workspace-mobile-sidebar-header.test.tsx
+++ b/packages/ui/src/layouts/workspace-layout/workspace-mobile-sidebar-header.test.tsx
@@ -1,13 +1,13 @@
 // @vitest-environment jsdom
-//
-// The mobile sidebar trigger belongs in the view header, not the content flow.
-// A `PageLayout` with a sidebar used to render a lone outlined "Browse" button
-// (`page-layout-mobile-sidebar-trigger`) between a view's centered `ViewHeader`
-// and its content on mobile — the orphan control this suite pins down the
-// replacement for: `useWorkspaceMobileSidebarHeader` +
-// `WorkspaceMobileSidebarScope` suppress the inline button and surface the
-// registered drawer as a compact `ViewHeaderSidebarTrigger` in the header's
-// right slot, keeping the documented testid for drawer-opening helpers.
+
+/**
+ * Verifies the mobile sidebar trigger lives in the view header, not the content
+ * flow: `useWorkspaceMobileSidebarHeader` + `WorkspaceMobileSidebarScope`
+ * suppress the inline `page-layout-mobile-sidebar-trigger` button and surface
+ * the registered drawer as a compact `ViewHeaderSidebarTrigger` in the header's
+ * right slot, keeping the documented testid for drawer-opening helpers.
+ * Renders against jsdom (no real viewport).
+ */
 
 import {
   cleanup,

--- a/packages/ui/src/perf/perf-hud-control.test.ts
+++ b/packages/ui/src/perf/perf-hud-control.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Covers the perf-HUD enable affordance: boot-from-flag/pref, the hotkey and
+ * console-handle toggles, and that each path flips `window.__ELIZA_PERF_HUD__`
+ * and emits PERF_TOGGLE_EVENT. Drives window globals + localStorage under jsdom.
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   bootPerfHud,

--- a/packages/ui/src/platform/assistant-launch-payload.test.ts
+++ b/packages/ui/src/platform/assistant-launch-payload.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Covers assistant launch payloads: reading text/source/action/id out of a
+ * `#chat?…` hash route, building launch metadata, and the claim/consume/clear
+ * single-use lifecycle keyed on the hash. Reads/writes window.history under jsdom.
+ */
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetAssistantLaunchPayloadClaimsForTests,

--- a/packages/ui/src/platform/browser-launch.test.ts
+++ b/packages/ui/src/platform/browser-launch.test.ts
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * Covers `applyLaunchConnectionFromUrl`: a launch URL's connection params are
+ * parsed into a persisted active server + agent profile and pushed into the API
+ * client (base URL + token). The API client, boot-config, and persistence
+ * layers are mocked so the URL→connection wiring is under test in isolation.
+ */
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { applyLaunchConnectionFromUrl } from "./browser-launch";
 

--- a/packages/ui/src/platform/init.test.ts
+++ b/packages/ui/src/platform/init.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Covers `injectPopoutApiBase`: a hosted-chat launch URL's `waifu_access_token`
+ * is lifted into the API bearer token in boot config. Builds its own JSDOM
+ * window so the URL/history plumbing is real.
+ */
+
 import { JSDOM } from "jsdom";
 import { beforeEach, describe, expect, it } from "vitest";
 import { getBootConfig, setBootConfig } from "../config/boot-config";

--- a/packages/ui/src/spatial/__tests__/integration.test.tsx
+++ b/packages/ui/src/spatial/__tests__/integration.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * End-to-end parity check for the spatial framework: one primitive tree
+ * (Stack/Text/Card/…) evaluated to the layout IR, then rendered to both the DOM
+ * modality (auto-switching to xr when the XR host global is present) and the TUI
+ * modality. Static/string render (no live headset).
+ */
+
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it } from "vitest";
 import {

--- a/packages/ui/src/spatial/dom.modality-owner.test.tsx
+++ b/packages/ui/src/spatial/dom.modality-owner.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Covers `detectDomModality` / `setShellModality` (#9946): a shell owns the
+ * active modality (gui/tui), a present XR context wins over it, and an invalid
+ * shell value falls back to gui. Reads window globals under jsdom.
+ */
+
 import { afterEach, describe, expect, it } from "vitest";
 import { detectDomModality, setShellModality } from "./dom.tsx";
 

--- a/packages/ui/src/voice/voice-provider-defaults.ts
+++ b/packages/ui/src/voice/voice-provider-defaults.ts
@@ -13,8 +13,8 @@
  *     heavier than TTS.
  *   - Cloud agents (any device) → fast free Microsoft Edge neural TTS
  *     (`edge`) for speech, Eliza Cloud (`eliza-cloud`) for ASR. ElevenLabs is
- *     no longer a default — it is slow and key-gated; users can still opt into
- *     it from the advanced voice picker.
+ *     not a default (slow and key-gated); users can still opt into it from the
+ *     advanced voice picker.
  *   - Remote-controller surfaces (UI hitting a remote API base) → same as
  *     cloud agents (`edge` TTS, Eliza Cloud ASR).
  *

--- a/packages/ui/src/widgets/WidgetHost.test.tsx
+++ b/packages/ui/src/widgets/WidgetHost.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Renders WidgetHost against mocked app state + a stubbed widget resolver to
+ * verify it mounts the resolved widgets for a slot and forwards widget UI
+ * actions via the WIDGET_UI_ACTION_EVENT. jsdom render (no real backend).
+ */
+
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WidgetHost } from "./WidgetHost";

--- a/packages/ui/src/widgets/home-dismissal-store.test.ts
+++ b/packages/ui/src/widgets/home-dismissal-store.test.ts
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+
+/**
+ * Covers the home-widget dismissal/sunset store: seen counts, acted/dismissed
+ * flags, and `isHomeWidgetSunset` policy resolution. Pure logic over the
+ * in-memory store (localStorage-backed at runtime; reset between cases).
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import {
   __resetHomeDismissalsForTests,


### PR DESCRIPTION
Comments-only slice of #12235 (chunk **b05-small-src**). `check:comment-only` passes — every code token is byte-for-byte identical to `origin/develop`.

## Scope
Small-source subtrees under `packages/ui/src`: `widgets`, `spatial`, `voice`, `backgrounds`, `platform`, `agent-surface`, `perf`, `chat`, `genui`, `utils`, `bridge`, `config`, `events`, `gestures`, `layouts`, `lib`, `testing`. The vast majority (312 files) already carried proper `/**  */` prose headers and were left untouched.

## Changes (22 files, comments only)
- **Added top-of-file test headers** to 15 bare `*.test.{ts,tsx}` files that had only a `// @vitest-environment jsdom` directive + imports and no prose header. Each new header states the surface under test and how real the harness is (jsdom render, mocked backend, stubbed transport, real DOM nodes, etc.), per the test-file convention.
- **Repaired churn / migration-narration headers** and rewrote them to present-tense fact:
  - `config/index.ts` — replaced a `Phase 5C … moved to …` migration banner with a barrel prose header.
  - `platform/aosp-user-agent.ts` — `now lives in @elizaos/shared` → present-tense re-export description.
  - `lib/floating-layers.ts` — decorative `── Z-index scale ──` divider → prose header (durable rationale kept).
  - `genui/genui-action-registry.ts` — dropped "used to be a hardcoded list …" narration.
  - `voice/voice-provider-defaults.ts` — "ElevenLabs is no longer a default" → "is not a default".
  - `layouts/workspace-layout/workspace-mobile-sidebar-header.test.tsx` — "used to render a lone … the replacement for" narration → present-tense statement of what the suite asserts.

No code tokens, string/template literals, license blocks, or generated files were touched. Verified with `node scripts/assert-comment-only-diff.mjs` (OK — 22 files, comments only).

Part of #12235.