### PR TITLE
refactor(#12250): replace dynamic-view globalThis import hook with a typed host-external factory contract

### DIFF
--- a/packages/agent/src/api/dynamic-view-host-external.d.mts
+++ b/packages/agent/src/api/dynamic-view-host-external.d.mts
@@ -1,5 +1,5 @@
-/** globalThis hook the rewritten imports call to resolve a host-external module. */
-export declare const DYNAMIC_VIEW_IMPORT_GLOBAL: "__ELIZA_DYNAMIC_VIEW_IMPORT__";
+/** Factory parameter name the wrapped bundle resolves host externals through. */
+export declare const HOST_IMPORT_PARAM: "__elizaHostImport";
 
 export declare function convertNamedImportsToDestructuring(
   namedImports: string,
@@ -11,7 +11,7 @@ export declare function buildHostExternalImportReplacement(
   index: number,
 ): string;
 
-export declare function rewriteHostExternalImports(
+export declare function wrapBundleAsHostExternalFactory(
   source: string,
   specifiers: readonly string[],
 ): string;

--- a/packages/agent/src/api/dynamic-view-host-external.mjs
+++ b/packages/agent/src/api/dynamic-view-host-external.mjs
@@ -1,23 +1,34 @@
 /**
- * Host-external view-import rewrite — single source of truth.
+ * Host-external view-bundle factory transform — single source of truth.
  *
  * A plugin view bundle is built with `@elizaos/ui`, `react`, three, … left as
- * *external* bare imports. At serve time the bare imports are rewritten into
- * `globalThis.__ELIZA_DYNAMIC_VIEW_IMPORT__("<specifier>")` calls that
- * `DynamicViewLoader` resolves against its `HOST_EXTERNAL_IMPORTERS` map, so the
- * view shares the host's singletons instead of loading a second copy.
+ * *external* bare imports. Those specifiers must resolve to the host shell's own
+ * singletons (one React instance, the live app-core client, plugins registered
+ * at runtime), not to a second copy the browser fetches on its own. A separately
+ * imported ES module cannot reach the shell's live modules by itself, so at
+ * serve time the bundle is wrapped into a **factory**: its bare host-external
+ * imports become bindings resolved from an injected `hostImport(specifier)`
+ * function, and its trailing `export { … }` list becomes the factory's return
+ * namespace. The shell's `DynamicViewLoader` imports the wrapped module, calls
+ * the default-exported factory with a `hostImport` closure backed by its
+ * host-external importer map, and gets the view namespace back — sharing the
+ * host realm without any `globalThis` bridge or import-map indirection.
  *
  * Both the agent bundle route (`views-routes.ts`) and the Playwright UI-smoke
- * stub (`playwright-ui-smoke-api-stub.mjs`) must apply the identical transform,
- * so it lives here once. Plain ESM (no deps, no build step) so the node-run
- * smoke stub can import it directly by path while the agent bundles it normally.
+ * stub (`playwright-ui-smoke-api-stub.mjs`) apply the identical transform, so it
+ * lives here once. Plain ESM (no deps, no build step) so the node-run smoke stub
+ * can import it directly by path while the agent bundles it normally. The typed
+ * factory/importer contract lives in `@elizaos/shared` (`src/views/
+ * host-external-contract.ts`); this module is its runtime implementation.
  *
- * NOTE: this is the legacy `globalThis`-hook transform; replacing it with a
- * native import map is tracked separately (arch-audit #12091 item 13).
+ * The transform relies on the fixed shape the view-bundle build emits (single
+ * self-contained ES module, host externals as bare top-level imports, every
+ * export collected into one trailing `export { … }` list — see
+ * `view-bundle-vite.config.ts` and `view-bundle-single-chunk.test.ts`).
  */
 
-/** globalThis hook the rewritten imports call to resolve a host-external module. */
-export const DYNAMIC_VIEW_IMPORT_GLOBAL = "__ELIZA_DYNAMIC_VIEW_IMPORT__";
+/** Factory parameter name the wrapped bundle resolves host externals through. */
+export const HOST_IMPORT_PARAM = "__elizaHostImport";
 
 /** @param {string} namedImports @returns {string} */
 export function convertNamedImportsToDestructuring(namedImports) {
@@ -30,6 +41,9 @@ export function convertNamedImportsToDestructuring(namedImports) {
 }
 
 /**
+ * Build the binding statements that replace one host-external `import` clause,
+ * resolving the module through the injected `hostImport` factory parameter.
+ *
  * @param {string} importClause
  * @param {string} specifier
  * @param {number} index
@@ -42,7 +56,7 @@ export function buildHostExternalImportReplacement(
 ) {
   const moduleVar = `__eliza_dynamic_view_host_external_${index}`;
   const lines = [
-    `const ${moduleVar} = await globalThis.${DYNAMIC_VIEW_IMPORT_GLOBAL}(${JSON.stringify(specifier)});`,
+    `const ${moduleVar} = await ${HOST_IMPORT_PARAM}(${JSON.stringify(specifier)});`,
   ];
   const trimmed = importClause.trim();
   if (trimmed.startsWith("* as ")) {
@@ -74,25 +88,30 @@ export function buildHostExternalImportReplacement(
 }
 
 /**
- * Rewrite every bare `import … from "<specifier>"` (and side-effect
- * `import "<specifier>"`) whose specifier is host-external into a
- * `globalThis.__ELIZA_DYNAMIC_VIEW_IMPORT__` call.
+ * Replace every bare `import … from "<specifier>"` (and side-effect
+ * `import "<specifier>"`) whose specifier is host-external with bindings that
+ * resolve the module through the injected `hostImport` parameter.
  *
  * @param {string} source
  * @param {readonly string[]} specifiers
  * @returns {string}
  */
-export function rewriteHostExternalImports(source, specifiers) {
+function bindHostExternalImports(source, specifiers) {
   if (specifiers.length === 0) return source;
   const specifierPattern = specifiers
     .map((item) => item.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"))
     .join("|");
+  // `import` is followed by whitespace before a bare default identifier, but by
+  // no whitespace at all when the clause starts with `{`/`*` or the specifier
+  // quote (minified `import{x}from"y"` / `import"y"`). Match both so the
+  // transform holds whether the view bundle ships minified or not.
+  const afterImport = `(?:\\s+|(?=[{*"']))`;
   const fromImportPattern = new RegExp(
-    `import\\s+([^;]*?)\\s+from\\s+["'](${specifierPattern})["'];?`,
+    `import${afterImport}([^;]*?)\\s*from\\s*["'](${specifierPattern})["'];?`,
     "gu",
   );
   const sideEffectPattern = new RegExp(
-    `import\\s+["'](${specifierPattern})["'];?`,
+    `import${afterImport}["'](${specifierPattern})["'];?`,
     "gu",
   );
   let replacementIndex = 0;
@@ -108,8 +127,64 @@ export function rewriteHostExternalImports(source, specifiers) {
     .replace(
       sideEffectPattern,
       (_match, specifier) =>
-        `await globalThis.${DYNAMIC_VIEW_IMPORT_GLOBAL}(${JSON.stringify(String(specifier))});`,
+        `await ${HOST_IMPORT_PARAM}(${JSON.stringify(String(specifier))});`,
     );
+}
+
+/** One `<local> as <exported>` (or bare `<local>`) entry of an export list. */
+function parseExportEntry(entry) {
+  const trimmed = entry.trim();
+  if (!trimmed) return null;
+  const asMatch = trimmed.match(/^([\S]+)\s+as\s+(.+)$/u);
+  if (asMatch) {
+    const exported = asMatch[2].trim().replace(/^["']|["']$/gu, "");
+    return { local: asMatch[1].trim(), exported };
+  }
+  return { local: trimmed, exported: trimmed };
+}
+
+/**
+ * Convert the bundle's single trailing `export { a as X, b as default }` list
+ * into a `return { X: a, default: b }` object and strip the `export` keyword.
+ * The view-bundle build always collects every export into one trailing list, so
+ * a body with no such list simply returns an empty namespace.
+ *
+ * @param {string} source
+ * @returns {string}
+ */
+function collectTrailingExports(source) {
+  const exportListPattern = /export\s*\{([\s\S]*?)\}\s*;?/gu;
+  const entries = [];
+  const body = source.replace(exportListPattern, (_match, inner) => {
+    for (const raw of String(inner).split(",")) {
+      const parsed = parseExportEntry(raw);
+      if (parsed) entries.push(parsed);
+    }
+    return "";
+  });
+  const namespace = entries
+    .map(({ local, exported }) => `${JSON.stringify(exported)}: ${local}`)
+    .join(", ");
+  return `${body}\nreturn { ${namespace} };\n`;
+}
+
+/**
+ * Wrap a served view bundle as a host-external factory module: bind its
+ * host-external imports to an injected `hostImport` parameter and return its
+ * exports as a namespace. The module's sole export is a default async factory
+ * matching the `HostExternalBundleFactory` contract in `@elizaos/shared`.
+ *
+ * @param {string} source
+ * @param {readonly string[]} specifiers
+ * @returns {string}
+ */
+export function wrapBundleAsHostExternalFactory(source, specifiers) {
+  const bound = bindHostExternalImports(source, specifiers);
+  const factoryBody = collectTrailingExports(bound);
+  return (
+    `export default async function ${HOST_IMPORT_PARAM}Factory(${HOST_IMPORT_PARAM}) {\n` +
+    `${factoryBody}}\n`
+  );
 }
 
 /**

--- a/packages/agent/src/api/dynamic-view-host-external.test.ts
+++ b/packages/agent/src/api/dynamic-view-host-external.test.ts
@@ -1,87 +1,147 @@
 import { describe, expect, it } from "vitest";
 import {
-  DYNAMIC_VIEW_IMPORT_GLOBAL,
+  HOST_IMPORT_PARAM,
   parseHostExternalSpecifiers,
-  rewriteHostExternalImports,
+  wrapBundleAsHostExternalFactory,
 } from "./dynamic-view-host-external.mjs";
+
+// Mirror of the shared contract's query-param names (@elizaos/shared). Kept as
+// literals here so this dependency-free transform test never pulls the shared
+// package graph in; a drift check against the shared constants lives in
+// host-external-contract.test.ts.
+const HOST_EXTERNAL_RUNTIME_PARAM = "hostExternalRuntime";
+const HOST_EXTERNAL_SPECIFIERS_PARAM = "hostExternalSpecifiers";
 
 /**
  * `dynamic-view-host-external.mjs` is the single source of the host-external
- * view-import rewrite consumed by BOTH the agent bundle route
+ * view-bundle factory transform consumed by BOTH the agent bundle route
  * (`views-routes.ts`) and the Playwright UI-smoke stub. Locking the transform
- * here keeps the two serve paths byte-identical.
+ * here keeps the two serve paths byte-identical. The transform wraps a served
+ * bundle as a `HostExternalBundleFactory` (default export) that resolves its
+ * host externals through an injected `hostImport` parameter and returns the
+ * bundle's export namespace — no `globalThis` bridge.
  */
-describe("rewriteHostExternalImports", () => {
+describe("wrapBundleAsHostExternalFactory", () => {
   const specifiers = ["@elizaos/ui", "react", "react/jsx-runtime"];
 
-  it("returns the source unchanged when no specifiers are host-external", () => {
-    const src = `import { foo } from "@elizaos/ui";`;
-    expect(rewriteHostExternalImports(src, [])).toBe(src);
-  });
+  function evalFactory(source: string) {
+    const wrapped = wrapBundleAsHostExternalFactory(source, specifiers);
+    // The wrapped module's default export is the factory. Evaluate the module
+    // body as a function returning that default so the test can call it with a
+    // stub host importer, exactly as the loader does.
+    const factory = new Function(
+      `${wrapped.replace(/^export default /u, "return ")}`,
+    )() as (
+      hostImport: (specifier: string) => Promise<Record<string, unknown>>,
+    ) => Promise<Record<string, unknown>>;
+    return factory;
+  }
 
-  it("rewrites a named import into a destructured host-external call", () => {
-    const out = rewriteHostExternalImports(
-      `import { Button, Input as TextInput } from "@elizaos/ui";`,
+  it("emits a default-exported async factory taking the host-import param", () => {
+    const wrapped = wrapBundleAsHostExternalFactory(
+      `export { X as default };`,
       specifiers,
     );
-    expect(out).toContain(
-      `await globalThis.${DYNAMIC_VIEW_IMPORT_GLOBAL}("@elizaos/ui")`,
+    expect(wrapped).toContain(
+      `export default async function ${HOST_IMPORT_PARAM}Factory(${HOST_IMPORT_PARAM})`,
     );
-    expect(out).toContain("const { Button, Input: TextInput } =");
-    expect(out).not.toContain(`from "@elizaos/ui"`);
+    expect(wrapped).not.toContain("globalThis");
   });
 
-  it("rewrites a namespace import", () => {
-    const out = rewriteHostExternalImports(
-      `import * as React from "react";`,
+  it("binds a named import via the injected host-import param", async () => {
+    const hostImport = async (specifier: string) => {
+      if (specifier === "@elizaos/ui")
+        return { Button: "BTN", Input: "IN" } as Record<string, unknown>;
+      return {};
+    };
+    const factory = evalFactory(
+      `import { Button, Input as TextInput } from "@elizaos/ui";\nexport { Button as ButtonEcho, TextInput as InputEcho };`,
+    );
+    await expect(factory(hostImport)).resolves.toEqual({
+      ButtonEcho: "BTN",
+      InputEcho: "IN",
+    });
+  });
+
+  it("binds a namespace import", async () => {
+    const react = { useState: () => 0 } as Record<string, unknown>;
+    const factory = evalFactory(
+      `import * as React from "react";\nexport { React as ReactNs };`,
+    );
+    await expect(factory(async () => react)).resolves.toEqual({
+      ReactNs: react,
+    });
+  });
+
+  it("binds a default + named import with a .default fallback", async () => {
+    const react = {
+      default: "REACT_DEFAULT",
+      useState: "USE_STATE",
+    } as Record<string, unknown>;
+    const factory = evalFactory(
+      `import React, { useState } from "react";\nexport { React as R, useState as U };`,
+    );
+    await expect(factory(async () => react)).resolves.toEqual({
+      R: "REACT_DEFAULT",
+      U: "USE_STATE",
+    });
+  });
+
+  it("preserves a side-effect import as a bare host-import call", () => {
+    const wrapped = wrapBundleAsHostExternalFactory(
+      `import "react/jsx-runtime";\nexport {};`,
       specifiers,
     );
-    expect(out).toContain(
-      `await globalThis.${DYNAMIC_VIEW_IMPORT_GLOBAL}("react")`,
-    );
-    expect(out).toMatch(
-      /const React = __eliza_dynamic_view_host_external_\d+;/,
+    expect(wrapped).toContain(
+      `await ${HOST_IMPORT_PARAM}("react/jsx-runtime");`,
     );
   });
 
-  it("rewrites a default + named import with a .default fallback", () => {
-    const out = rewriteHostExternalImports(
-      `import React, { useState } from "react";`,
+  it("collects the trailing export list into the returned namespace", async () => {
+    const factory = evalFactory(
+      `const view = "VIEW";\nconst interact = "INTERACT";\nexport { view as default, interact };`,
+    );
+    await expect(factory(async () => ({}))).resolves.toEqual({
+      default: "VIEW",
+      interact: "INTERACT",
+    });
+  });
+
+  it('binds minified no-space imports (import{x}from"y")', async () => {
+    // Rollup/esbuild-minified view bundles emit imports with no interior spaces
+    // on one line; the transform must bind those too.
+    const react = { default: "R", useState: "US" } as Record<string, unknown>;
+    const ui = { Button: "BTN" } as Record<string, unknown>;
+    const factory = evalFactory(
+      `import{Button as b}from"@elizaos/ui";import r,{useState as u}from"react";import"react/jsx-runtime";var v=1;export{b as Btn,r as R,u as U};`,
+    );
+    await expect(
+      factory(async (specifier) =>
+        specifier === "react" ? react : specifier === "@elizaos/ui" ? ui : {},
+      ),
+    ).resolves.toEqual({ Btn: "BTN", R: "R", U: "US" });
+  });
+
+  it("leaves non-host-external imports untouched", () => {
+    const wrapped = wrapBundleAsHostExternalFactory(
+      `import { local } from "./local.js";\nexport { local };`,
       specifiers,
     );
-    expect(out).toMatch(
-      /const React = __eliza_dynamic_view_host_external_\d+\.default \?\? __eliza_dynamic_view_host_external_\d+;/,
-    );
-    expect(out).toContain("const { useState } =");
-  });
-
-  it("rewrites a side-effect import", () => {
-    const out = rewriteHostExternalImports(
-      `import "react/jsx-runtime";`,
-      specifiers,
-    );
-    expect(out).toBe(
-      `await globalThis.${DYNAMIC_VIEW_IMPORT_GLOBAL}("react/jsx-runtime");`,
-    );
-  });
-
-  it("leaves non-host-external imports alone", () => {
-    const src = `import { local } from "./local.js";`;
-    expect(rewriteHostExternalImports(src, specifiers)).toBe(src);
+    expect(wrapped).toContain(`import { local } from "./local.js";`);
   });
 });
 
 describe("parseHostExternalSpecifiers", () => {
-  it("returns [] unless hostExternalRuntime=1", () => {
+  it(`returns [] unless ${HOST_EXTERNAL_RUNTIME_PARAM}=1`, () => {
     const url = new URL(
-      "http://x/bundle.js?hostExternalSpecifiers=react,@elizaos/ui",
+      `http://x/bundle.js?${HOST_EXTERNAL_SPECIFIERS_PARAM}=react,@elizaos/ui`,
     );
     expect(parseHostExternalSpecifiers(url)).toEqual([]);
   });
 
   it("splits and trims the specifier list when enabled", () => {
     const url = new URL(
-      "http://x/bundle.js?hostExternalRuntime=1&hostExternalSpecifiers=react, @elizaos/ui ,",
+      `http://x/bundle.js?${HOST_EXTERNAL_RUNTIME_PARAM}=1&${HOST_EXTERNAL_SPECIFIERS_PARAM}=react, @elizaos/ui ,`,
     );
     expect(parseHostExternalSpecifiers(url)).toEqual(["react", "@elizaos/ui"]);
   });

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -49,7 +49,7 @@ import {
 } from "../runtime/view-action-affinity.ts";
 import {
   parseHostExternalSpecifiers,
-  rewriteHostExternalImports,
+  wrapBundleAsHostExternalFactory,
 } from "./dynamic-view-host-external.mjs";
 import {
   PendingRequestMap,
@@ -527,7 +527,7 @@ export async function handleViewsRoutes(
 
     if (hostExternalSpecifiers.length > 0 && method !== "HEAD") {
       data = Buffer.from(
-        rewriteHostExternalImports(
+        wrapBundleAsHostExternalFactory(
           data.toString("utf8"),
           hostExternalSpecifiers,
         ),

--- a/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
+++ b/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
@@ -7,7 +7,7 @@ import { WebSocketServer } from "ws";
 // bundle route). Plain ESM so this node-run stub can import it without a build.
 import {
   parseHostExternalSpecifiers,
-  rewriteHostExternalImports,
+  wrapBundleAsHostExternalFactory,
 } from "../../agent/src/api/dynamic-view-host-external.mjs";
 
 const port = Number(process.env.ELIZA_UI_SMOKE_API_PORT || "31337");
@@ -1962,7 +1962,7 @@ function sendSmokeViewAsset(req, res, url, view, subResource) {
       const source = smokeViewBundleSource(view);
       const body =
         hostExternalSpecifiers.length > 0
-          ? rewriteHostExternalImports(source, hostExternalSpecifiers)
+          ? wrapBundleAsHostExternalFactory(source, hostExternalSpecifiers)
           : source;
       sendBinary(
         req,
@@ -1981,7 +1981,7 @@ function sendSmokeViewAsset(req, res, url, view, subResource) {
     hostExternalSpecifiers.length > 0 &&
     contentTypeForSmokeViewAsset(assetPath).startsWith("application/javascript")
       ? Buffer.from(
-          rewriteHostExternalImports(
+          wrapBundleAsHostExternalFactory(
             rawBody.toString("utf8"),
             hostExternalSpecifiers,
           ),

--- a/packages/app/test/ui-smoke/remote-capability-view.spec.ts
+++ b/packages/app/test/ui-smoke/remote-capability-view.spec.ts
@@ -24,15 +24,6 @@ type RemoteCapabilityServer = {
   close: () => Promise<void>;
 };
 
-type DynamicViewImportWindow = Window & {
-  __ELIZA_DYNAMIC_VIEW_IMPORT__?: (
-    specifier: string,
-  ) => Promise<Record<string, unknown>>;
-  __ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__?: (
-    bundleUrl: string,
-  ) => Promise<Record<string, unknown>>;
-};
-
 const ADVANCED_SETTINGS_STORAGE_KEY = "eliza:settings-advanced";
 const REMOTE_CAPABILITY_BUNDLE_PATH =
   "/api/views/remote-capability-live/bundle.js";
@@ -306,66 +297,12 @@ async function installRemoteCapabilityViewRoutes(
   page: Page,
   remote: RemoteCapabilityServer,
 ): Promise<void> {
-  await page.addInitScript(
-    ({ bundlePath, remoteBaseUrl }) => {
-      const dynamicWindow = window as DynamicViewImportWindow;
-      dynamicWindow.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__ = async (
-        bundleUrl,
-      ) => {
-        const url = new URL(bundleUrl, window.location.href);
-        if (
-          url.origin !== window.location.origin ||
-          url.pathname !== bundlePath
-        ) {
-          throw new Error(`Unexpected dynamic view bundle URL: ${bundleUrl}`);
-        }
-
-        const response = await fetch(
-          `${remoteBaseUrl}/assets/remote-capability-live.js`,
-          { cache: "no-store" },
-        );
-        if (!response.ok) {
-          throw new Error(
-            `Failed to fetch dynamic view bundle: ${response.status}`,
-          );
-        }
-
-        const React = (await dynamicWindow.__ELIZA_DYNAMIC_VIEW_IMPORT__?.(
-          "react",
-        )) as { createElement?: (...args: unknown[]) => unknown } | undefined;
-        const createElement = React?.createElement;
-        if (!createElement) {
-          throw new Error("Dynamic view React host external unavailable");
-        }
-
-        return {
-          default(props: {
-            t?: (key: string, options?: { defaultValue?: string }) => string;
-          }) {
-            return createElement(
-              "section",
-              { "data-testid": "remote-capability-live-view" },
-              createElement("h1", null, "Remote capability live view"),
-              createElement(
-                "p",
-                null,
-                `Exit label: ${
-                  props.t?.("remote.exit", {
-                    defaultValue: "Leave remote view",
-                  }) ?? "Leave remote view"
-                }`,
-              ),
-            );
-          },
-        };
-      };
-    },
-    {
-      bundlePath: REMOTE_CAPABILITY_BUNDLE_PATH,
-      remoteBaseUrl: remote.baseUrl,
-    },
-  );
-
+  // No `__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__` test hook: the shell's real
+  // same-origin DynamicViewLoader path loads the routed bundle, appends the
+  // host-external runtime query, imports the served factory module, and calls
+  // its default factory with the host `react` singleton (#12250). The remote
+  // server already serves the bundle in that factory shape, so this exercises
+  // the production loading path end to end.
   await page.route(
     "**/api/views/remote-capability-live/bundle.js**",
     async (route) => {
@@ -481,20 +418,25 @@ async function handleRemoteRequest(
       "content-type": "text/javascript; charset=utf-8",
       "cache-control": "no-store",
     });
+    // Served in the new host-external factory shape: the module's default export
+    // is a factory the shell's DynamicViewLoader calls with a `hostImport` that
+    // resolves the host React singleton. No `globalThis` bridge (#12250).
     res.end(`
-const React = await window.__ELIZA_DYNAMIC_VIEW_IMPORT__("react");
-
-export default function RemoteCapabilityLiveView(props) {
-  return React.createElement(
-    "section",
-    { "data-testid": "remote-capability-live-view" },
-    React.createElement("h1", null, "Remote capability live view"),
-    React.createElement(
-      "p",
-      null,
-      "Exit label: " + props.t("remote.exit", { defaultValue: "Leave remote view" })
-    )
-  );
+export default async function RemoteCapabilityLiveFactory(__elizaHostImport) {
+  const React = await __elizaHostImport("react");
+  function RemoteCapabilityLiveView(props) {
+    return React.createElement(
+      "section",
+      { "data-testid": "remote-capability-live-view" },
+      React.createElement("h1", null, "Remote capability live view"),
+      React.createElement(
+        "p",
+        null,
+        "Exit label: " + props.t("remote.exit", { defaultValue: "Leave remote view" })
+      )
+    );
+  }
+  return { default: RemoteCapabilityLiveView };
 }
 `);
     return;

--- a/packages/scripts/view-bundle-import-guard.mjs
+++ b/packages/scripts/view-bundle-import-guard.mjs
@@ -4,15 +4,15 @@
  * A plugin view bundle is built with `@elizaos/ui`, `react`, etc. left as
  * *external* bare imports (see `view-bundle-vite.config.ts`). At runtime the
  * shell's `DynamicViewLoader` does NOT load those bare specifiers directly —
- * the agent's bundle route rewrites each one into a
- * `globalThis.__ELIZA_DYNAMIC_VIEW_IMPORT__("<specifier>")` call, resolved by
- * the loader's `HOST_EXTERNAL_IMPORTERS` map so the view shares the host's
+ * the agent's bundle route wraps the bundle as a host-external factory
+ * (`wrapBundleAsHostExternalFactory`), binding each external specifier to the
+ * loader's `HOST_EXTERNAL_IMPORTERS` map so the view shares the host's
  * singletons.
  *
- * That rewrite is an EXACT-STRING match against the map's keys. The Vite build,
+ * That binding is an EXACT-STRING match against the map's keys. The Vite build,
  * however, externalises by PREFIX (`@elizaos/ui` and anything under it). The two
  * therefore disagree: a view that imports an `@elizaos/ui/<subpath>` the loader
- * does not list is externalised by the build but never rewritten by the loader,
+ * does not list is externalised by the build but never bound by the loader,
  * so the browser receives a bare `import … from "@elizaos/ui/<subpath>"` it
  * cannot resolve and the view fails to load with "Failed to resolve module
  * specifier".

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -326,6 +326,7 @@ export * from "./utils/trajectory-format.js";
 export * from "./utils/tts-debug.js";
 export * from "./validation-keywords.js";
 export * from "./view-hero-art.js";
+export * from "./views/host-external-contract.js";
 export * from "./views/view-interact-protocol.js";
 export * from "./voice/first-sentence-snip.js";
 export * from "./voice/voice-cancellation-token.js";

--- a/packages/shared/src/views/host-external-contract.test.ts
+++ b/packages/shared/src/views/host-external-contract.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  HOST_EXTERNAL_RUNTIME_PARAM,
+  HOST_EXTERNAL_SPECIFIERS_PARAM,
+} from "./host-external-contract.js";
+
+/**
+ * Guards that the dependency-free runtime transform
+ * (`packages/agent/src/api/dynamic-view-host-external.mjs`) reads the same URL
+ * query-param names this shared contract declares. The `.mjs` can't import
+ * `@elizaos/shared` (it is loaded by path with no build), so it mirrors the
+ * names as literals; this test asserts the literals still match the contract.
+ */
+describe("host-external contract param names", () => {
+  const mjs = readFileSync(
+    fileURLToPath(
+      new URL(
+        "../../../agent/src/api/dynamic-view-host-external.mjs",
+        import.meta.url,
+      ),
+    ),
+    "utf8",
+  );
+
+  it("the runtime transform reads the contract's runtime param", () => {
+    expect(HOST_EXTERNAL_RUNTIME_PARAM).toBe("hostExternalRuntime");
+    expect(mjs).toContain(`get("${HOST_EXTERNAL_RUNTIME_PARAM}")`);
+  });
+
+  it("the runtime transform reads the contract's specifiers param", () => {
+    expect(HOST_EXTERNAL_SPECIFIERS_PARAM).toBe("hostExternalSpecifiers");
+    expect(mjs).toContain(`get("${HOST_EXTERNAL_SPECIFIERS_PARAM}")`);
+  });
+});

--- a/packages/shared/src/views/host-external-contract.ts
+++ b/packages/shared/src/views/host-external-contract.ts
@@ -1,0 +1,40 @@
+/**
+ * Contract for the host-external view-bundle factory shared by the agent server
+ * and the UI shell. A plugin view bundle is built with framework/host packages
+ * (`@elizaos/ui`, `react`, three, …) left as external bare imports; those must
+ * resolve to the host shell's live singletons, not to a second copy. The agent
+ * bundle route serves each view wrapped as a factory (see
+ * `packages/agent/src/api/dynamic-view-host-external.mjs`) whose default export
+ * matches {@link HostExternalBundleFactory}: it takes a {@link HostModuleImporter}
+ * and returns the view's export namespace. The shell's `DynamicViewLoader`
+ * imports the wrapped module and calls the factory with an importer backed by
+ * its host-external map — sharing the host realm with no `globalThis` bridge.
+ *
+ * This is the typed contract only; the runtime transform is the `.mjs` above
+ * (kept dependency-free so the node-run Playwright smoke stub can import it by
+ * path without a build).
+ */
+
+/**
+ * Resolve a host-external module specifier to the host shell's live module
+ * namespace (e.g. the singleton `react`, `@elizaos/ui`). Rejects when the
+ * specifier is neither a framework trunk external nor a registered one.
+ */
+export type HostModuleImporter = (
+  specifier: string,
+) => Promise<Record<string, unknown>>;
+
+/**
+ * The default export of a served view bundle. Called once by the loader with a
+ * {@link HostModuleImporter}; resolves to the bundle's export namespace (the
+ * view component plus any `interact` / `cleanup` exports).
+ */
+export type HostExternalBundleFactory = (
+  hostImport: HostModuleImporter,
+) => Promise<Record<string, unknown>>;
+
+/** URL query flag the loader sets to request the host-external factory serve. */
+export const HOST_EXTERNAL_RUNTIME_PARAM = "hostExternalRuntime";
+
+/** URL query key carrying the comma-joined host-external specifier list. */
+export const HOST_EXTERNAL_SPECIFIERS_PARAM = "hostExternalSpecifiers";

--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -19,6 +19,7 @@ import { APP_PAUSE_EVENT } from "../../events";
 import {
   __resetDynamicViewLoaderCacheForTests,
   DynamicViewLoader,
+  hostImport,
   isSameOriginBundleUrl,
 } from "./DynamicViewLoader";
 
@@ -61,14 +62,13 @@ describe("isSameOriginBundleUrl (view-bundle origin gate)", () => {
   });
 });
 
-describe("host-external importer resolution (__ELIZA_DYNAMIC_VIEW_IMPORT__)", () => {
-  async function resolveHostExternal(
+describe("host-external importer resolution (factory hostImport)", () => {
+  // The served view-bundle factory receives `hostImport` as its parameter; it
+  // resolves a specifier to the host shell's live singleton with no globalThis
+  // bridge. Exercise that resolver directly here.
+  const resolveHostExternal = (
     specifier: string,
-  ): Promise<Record<string, unknown>> {
-    const importFn = window.__ELIZA_DYNAMIC_VIEW_IMPORT__;
-    if (!importFn) throw new Error("import hook not installed");
-    return importFn(specifier);
-  }
+  ): Promise<Record<string, unknown>> => hostImport(specifier);
 
   it("consults an importer contributed through registerHostExternalImporter", async () => {
     const { registerHostExternalImporter } = await import(

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -19,7 +19,13 @@
  * module has no interact export.
  */
 
-import { resolveAppBranding } from "@elizaos/shared";
+import {
+  HOST_EXTERNAL_RUNTIME_PARAM,
+  HOST_EXTERNAL_SPECIFIERS_PARAM,
+  type HostExternalBundleFactory,
+  type HostModuleImporter,
+  resolveAppBranding,
+} from "@elizaos/shared";
 import {
   type ComponentType,
   memo,
@@ -503,25 +509,41 @@ function hostExternalSpecifiers(): string[] {
 
 declare global {
   interface Window {
-    __ELIZA_DYNAMIC_VIEW_IMPORT__?: (
-      specifier: string,
-    ) => Promise<Record<string, unknown>>;
     __ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__?: (
       bundleUrl: string,
     ) => Promise<Record<string, unknown>>;
   }
 }
 
-if (typeof window !== "undefined" && !window.__ELIZA_DYNAMIC_VIEW_IMPORT__) {
-  window.__ELIZA_DYNAMIC_VIEW_IMPORT__ = async (specifier) => {
-    const importer = resolveHostExternalImporter(specifier);
-    if (!importer) {
-      throw new Error(
-        `DynamicViewLoader: unsupported host external "${specifier}"`,
-      );
-    }
-    return importer();
-  };
+/**
+ * Resolve one host-external specifier to the host shell's live singleton (the
+ * framework trunk map first, then registered plugin/build-variant specifiers).
+ * Passed to a served view bundle's factory (its default export) as the {@link
+ * HostModuleImporter} it resolves its externals through — no `globalThis` bridge.
+ * Exported so tests can exercise the resolver the factory receives.
+ */
+export const hostImport: HostModuleImporter = async (specifier) => {
+  const importer = resolveHostExternalImporter(specifier);
+  if (!importer) {
+    throw new Error(
+      `DynamicViewLoader: unsupported host external "${specifier}"`,
+    );
+  }
+  return importer();
+};
+
+/**
+ * A served view bundle's default export is a `HostExternalBundleFactory`: call
+ * it with {@link hostImport} to get the view's export namespace. Test/dev bundle
+ * modules injected through `__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__` already return
+ * a namespace directly, so a non-function default passes through unchanged.
+ */
+async function resolveBundleNamespace(
+  mod: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const factory = mod.default;
+  if (typeof factory !== "function") return mod;
+  return (factory as HostExternalBundleFactory)(hostImport);
 }
 
 /** Dev-mode polling interval in ms. Not used in production builds. */
@@ -569,7 +591,9 @@ async function importViewBundle(
 
   const hostExternalUrl = buildHostExternalBundleUrl(bundleUrl);
   if (hostExternalUrl) {
-    return import(/* @vite-ignore */ hostExternalUrl);
+    return resolveBundleNamespace(
+      await import(/* @vite-ignore */ hostExternalUrl),
+    );
   }
 
   try {
@@ -587,7 +611,7 @@ async function importViewBundle(
       `DynamicViewLoader: bundle at ${bundleUrl} could not use host externals`,
     );
   }
-  return import(/* @vite-ignore */ rewrittenUrl);
+  return resolveBundleNamespace(await import(/* @vite-ignore */ rewrittenUrl));
 }
 
 function buildHostExternalBundleUrl(bundleUrl: string): string | null {
@@ -595,9 +619,9 @@ function buildHostExternalBundleUrl(bundleUrl: string): string | null {
   const rewrittenUrl = new URL(bundleUrl, window.location.href);
   if (rewrittenUrl.origin !== window.location.origin) return null;
   if (!rewrittenUrl.pathname.startsWith("/api/views/")) return null;
-  rewrittenUrl.searchParams.set("hostExternalRuntime", "1");
+  rewrittenUrl.searchParams.set(HOST_EXTERNAL_RUNTIME_PARAM, "1");
   rewrittenUrl.searchParams.set(
-    "hostExternalSpecifiers",
+    HOST_EXTERNAL_SPECIFIERS_PARAM,
     hostExternalSpecifiers().join(","),
   );
   return rewrittenUrl.href;


### PR DESCRIPTION
Closes #12250

## What changed

Migrates the dynamic-view host-external mechanism off the
`globalThis.__ELIZA_DYNAMIC_VIEW_IMPORT__` window-hook + regex import-rewrite
(#12091 item 13 follow-up; the safe single-sourcing slice landed in #12208).

**Before:** the agent bundle route regex-rewrote each bare host-external import
(`import { Button } from "@elizaos/ui"`) into
`const x = await globalThis.__ELIZA_DYNAMIC_VIEW_IMPORT__("@elizaos/ui")`, and
`DynamicViewLoader` installed `window.__ELIZA_DYNAMIC_VIEW_IMPORT__` as the
resolver.

**After:** the served bundle is wrapped as a **host-external factory module** —
its default export is `async function(hostImport) { … return <namespace> }`.
Bare host-external imports are bound to the injected `hostImport(specifier)`
parameter; the bundle's trailing `export { … }` list becomes the factory's
return namespace. `DynamicViewLoader` imports the wrapped module and calls the
factory with an importer backed by its `HOST_EXTERNAL_IMPORTERS` map, so views
share the host realm's live singletons (one React, the app-core client, plugins
registered at runtime) with **no `globalThis` bridge and no import-map
indirection**. A pure browser import map can't share live host singletons or
runtime-registered plugin specifiers; the issue's "blob-module receiving host
modules as explicit parameters" is the correct browser-native replacement, so
that is what this implements.

The typed contract — `HostExternalBundleFactory`, `HostModuleImporter`, and the
`hostExternalRuntime` / `hostExternalSpecifiers` query-param names — now lives in
`@elizaos/shared` (`src/views/host-external-contract.ts`), consumed by the
loader. The runtime transform stays in the dependency-free
`packages/agent/src/api/dynamic-view-host-external.mjs` (imported by path by the
node-run Playwright smoke stub, no build step); a drift test asserts the `.mjs`
query-param literals still match the shared contract constants.

Also hardens the import matcher to bind both spaced (`import { x } from "y"`) and
minified no-space (`import{x}from"y"`) forms — the previous `import\s+` pattern
silently skipped esbuild-minified imports.

### Files
- `packages/agent/src/api/dynamic-view-host-external.mjs` / `.d.mts` — transform now `wrapBundleAsHostExternalFactory` (was `rewriteHostExternalImports`); `HOST_IMPORT_PARAM` replaces `DYNAMIC_VIEW_IMPORT_GLOBAL`.
- `packages/shared/src/views/host-external-contract.ts` (+ barrel export in `src/index.ts`) — new typed contract.
- `packages/ui/src/components/views/DynamicViewLoader.tsx` — removed the `window.__ELIZA_DYNAMIC_VIEW_IMPORT__` install; added `hostImport` + `resolveBundleNamespace`; param names now sourced from the shared contract.
- `packages/agent/src/api/views-routes.ts`, `packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs` — call the factory wrapper.
- `packages/scripts/view-bundle-import-guard.mjs` — header prose updated (map-reading logic unchanged).
- Tests: transform unit test, shared contract drift test, loader host-external test, remote-capability e2e spec updated to the factory contract.

## Verification

**Done condition — the globalThis hook is gone:**
```
$ git grep -nE '__ELIZA_DYNAMIC_VIEW_IMPORT__|rewriteHostExternalImports|DYNAMIC_VIEW_IMPORT_GLOBAL' -- packages/
(zero matches — production, tests, and docs)
```

**Transform + contract unit tests (10 + 2):**
```
$ bunx vitest run packages/agent/src/api/dynamic-view-host-external.test.ts \
    packages/shared/src/views/host-external-contract.test.ts
 Test Files  2 passed (2)
      Tests  12 passed (12)
```

**End-to-end on a real esbuild-minified bundle** (no-space imports — the harder
case), wrapped and the factory executed with stub host modules:
```
RAW MINIFIED: import{Button as o}from"@elizaos/ui";import r,{useState as n}from"react";import"react/jsx-runtime";…export{c as MyView,u as default,p as interact};
WRAPPED:      export default async function __elizaHostImportFactory(__elizaHostImport){ const … = await __elizaHostImport("@elizaos/ui"); … return { "MyView": c, "default": u, "interact": p }; }
NAMESPACE KEYS: [ 'MyView', 'default', 'interact' ]
RENDERED:  {"type":"BUTTON","props":{"count":42}}   ← used the injected host Button singleton + useState
interact(): {"cap":"refresh"}
```

**Build guard** still parses the loader map (61 specifiers, framework + registered) and validates against the new factory contract:
```
$ node -e 'import("./packages/scripts/view-bundle-import-guard.mjs").then(m=>m.getHostExternalSpecifiers()).then(s=>console.log(s.size, s.has("react"), s.has("@elizaos/plugin-training")))'
61 true true
```
A full `node packages/scripts/view-bundle-import-guard.mjs` reports only *missing built bundles* — nothing is built in this worktree — never import violations.

**Typecheck (touched packages):** agent `tsc -p packages/agent/tsconfig.json` → 0 errors in touched files; `DynamicViewLoader.tsx` / `.test.tsx` and the shared contract typecheck clean. Pre-existing, unrelated errors remain (`@elizaos/cloud-routing` resolution in `packages/core`; a PostCSS type-depth error in `packages/ui/src/testing/e2e-runner/fixture-bundle.ts`; `get-free-port.mjs` no-decl on untouched import lines) — all present identically on `origin/develop`.

**Biome:** `bunx biome check` clean on all 12 changed files.

### N/A evidence
- Rendered UI walkthrough / screenshots — **N/A**: `DynamicViewLoader.test.tsx` and the `remote-capability-view` Playwright spec can't execute in this headless worktree (esbuild-in-jsdom hits a `TextEncoder`/`Uint8Array` cross-realm invariant break; Playwright needs a browser). Both are typecheck-clean and were migrated to the factory contract; the transform is proven end-to-end above against real minified bundler output.
- Real-LLM trajectories — **N/A**: no agent/action/prompt/model behavior changed; this is a view-bundle module-loading transform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
