### PR TITLE
feat(#12277): add LifeOps persona scenario catalog scaffolding

### DIFF
--- a/.github/issue-evidence/12277-lifeops-persona-scenario-catalog.md
+++ b/.github/issue-evidence/12277-lifeops-persona-scenario-catalog.md
@@ -1,0 +1,100 @@
+# Issue #12277 Evidence: LifeOps Persona Scenario Catalog Foundation
+
+## Scope
+
+- Added the optional `tier` metadata path for scenario definitions, static metadata loading, reports, and native JSONL export.
+- Added empty persona pack catalog scaffolds for parent issue #12186 with a total target count of 212 scenarios.
+- Added the LifeOps persona scenario authoring guide and a catalog coverage checker.
+- No runtime agent behavior, prompt behavior, UI, connector, model routing, device, audio, wallet, or on-chain behavior changed.
+
+## Commands Reviewed
+
+```bash
+cmp -s packages/scenario-runner/CLAUDE.md packages/scenario-runner/AGENTS.md
+```
+
+Result: passed; package-local agent docs remain identical.
+
+```bash
+node -e 'const fs=require("fs"); for (const f of fs.readdirSync("plugins/plugin-personal-assistant/test/scenarios/_catalogs").filter((f)=>f.endsWith(".catalog.json"))) JSON.parse(fs.readFileSync("plugins/plugin-personal-assistant/test/scenarios/_catalogs/"+f,"utf8")); console.log("catalog-json-ok");'
+```
+
+Result: passed; all catalog JSON files parsed.
+
+```bash
+node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --json
+```
+
+Result: passed; 8 packs found, target total 212, authored 0, verified 0, errors `[]`.
+
+```bash
+bun test --cwd packages/scenario-runner src/scenario-expansion.test.ts src/native-export.test.ts
+```
+
+Result: passed; 25 tests passed.
+
+```bash
+bun test --cwd packages/scenario-runner src/corpus-assertion-guard.test.ts src/action-effect-ratchet.test.ts src/echo-assertion-ratchet.test.ts src/skippable-check-ratchet.test.ts
+```
+
+Result: passed after rebasing onto current `origin/develop` and updating the explicit pr-deterministic corpus baseline for the already-present `persona.flexible-scheduling` scenario; 14 tests passed.
+
+```bash
+python3 -m pytest packages/benchmarks/lifeops-bench/tests/test_scenarios_corpus.py::test_optional_scenario_tiers_are_valid -q -s
+```
+
+Result: passed; printed `LifeOpsBench scenarios with tier metadata: 0`.
+
+```bash
+python3 -m py_compile packages/benchmarks/lifeops-bench/eliza_lifeops_bench/types.py packages/benchmarks/lifeops-bench/tests/test_scenarios_corpus.py
+```
+
+Result: passed.
+
+```bash
+bunx @biomejs/biome check packages/scripts/check-lifeops-persona-catalog-coverage.mjs packages/scenario-runner/schema/index.js packages/scenario-runner/src/cli.ts packages/scenario-runner/src/executor.ts packages/scenario-runner/src/loader.ts packages/scenario-runner/src/native-export.ts packages/scenario-runner/src/native-export.test.ts packages/scenario-runner/src/scenario-expansion.test.ts packages/scenario-runner/src/types.ts packages/scenario-runner/src/corpus-assertion-guard.test.ts plugins/plugin-personal-assistant/test/scenarios/_catalogs packages/scenario-runner/CLAUDE.md packages/scenario-runner/AGENTS.md packages/benchmarks/lifeops-bench/SCENARIO_AUTHORING.md .github/issue-evidence/12277-lifeops-persona-scenario-catalog.md
+```
+
+Result: passed; touched files checked, no fixes applied.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Blocked Or Unrelated Gates
+
+```bash
+python3 -m pytest packages/benchmarks/lifeops-bench/tests/test_scenarios_corpus.py -q
+```
+
+Result: blocked by missing snapshot fixtures in this checkout:
+
+- `packages/benchmarks/lifeops-bench/data/snapshots/tiny_seed_42.json`
+- `packages/benchmarks/lifeops-bench/data/snapshots/medium_seed_2026.json`
+
+The new tier validation test passed independently.
+
+```bash
+bun run --cwd packages/scenario-runner typecheck
+```
+
+Result: blocked by broad repository dependency/type-generation state unrelated to this change, including missing declarations for modules resolved through `dist/node_modules` and missing generated shared/core files.
+
+```bash
+bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/cli.ts list ../test/scenarios --validate-scenarios
+bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/cli.ts list ../../plugins/plugin-personal-assistant/test/scenarios --validate-scenarios
+```
+
+Result: blocked before scenario validation by a missing generated core i18n module:
+`packages/core/src/i18n/generated/validation-keyword-data.ts`.
+
+## N/A Evidence
+
+- Real-LLM trajectories: N/A - this is catalog/schema/report metadata scaffolding with empty new catalogs and no agent prompt or model behavior changes.
+- UI screenshots, video, frontend logs, and app audit: N/A - no UI code changed.
+- Backend logs: N/A - no server runtime path changed.
+- Native/mobile/desktop capture: N/A - no platform runtime code changed.
+- Audio evidence: N/A - no voice, transcript, STT, or TTS behavior changed.
+- Domain artifacts: N/A beyond the added catalog files and command outputs above.

--- a/packages/benchmarks/lifeops-bench/SCENARIO_AUTHORING.md
+++ b/packages/benchmarks/lifeops-bench/SCENARIO_AUTHORING.md
@@ -4,6 +4,10 @@ How to add a new scenario to the corpus. The canonical Python-level
 contract is in `eliza_lifeops_bench/types.py::Scenario`; this guide is
 the operator-facing playbook for using it well.
 
+For LifeOps persona-pack scenarios, also follow
+`../../../plugins/plugin-personal-assistant/test/scenarios/_catalogs/LIFEOPS_PERSONA_SCENARIO_AUTHORING.md`
+and update the owning pack catalog.
+
 ## Table of contents
 
 - [Static vs Live mode](#static-vs-live-mode)

--- a/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/types.py
+++ b/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/types.py
@@ -14,6 +14,7 @@ DisruptionKind = Literal[
 ]
 
 ExpectedWorldMutation = Literal["auto", "changed", "unchanged", "optional"]
+ScenarioTier = Literal["T1", "T2", "T3", "T4"]
 
 
 class Domain(Enum):
@@ -143,6 +144,9 @@ class Scenario:
     world_assertions: list[str] = field(default_factory=list)
     disruptions: list[Disruption] = field(default_factory=list)
     expected_world_mutation: ExpectedWorldMutation = "auto"
+    # T1 extraction/normalization; T2 multi-turn friction; T3 longitudinal
+    # journey; T4 adversarial/boundary behavior.
+    tier: ScenarioTier | None = None
 
 
 def attach_usage_cache_fields(turn: Any, usage: dict[str, Any]) -> None:

--- a/packages/benchmarks/lifeops-bench/tests/test_scenarios_corpus.py
+++ b/packages/benchmarks/lifeops-bench/tests/test_scenarios_corpus.py
@@ -44,6 +44,7 @@ ID_PREFIX_TO_KIND: dict[str, str] = {
 # Known seed-id whitelist for prefixes that collide with action-verb strings
 # (e.g. ``list_channels`` is a subaction value, not a reminder_list id).
 KNOWN_REMINDER_LISTS: set[str] = {"list_inbox", "list_personal", "list_work"}
+SCENARIO_TIERS: set[str] = {"T1", "T2", "T3", "T4"}
 
 
 @pytest.fixture(scope="module")
@@ -97,6 +98,13 @@ def test_corpus_expands_current_core_by_exactly_10x() -> None:
 def test_unique_scenario_ids() -> None:
     ids = [s.id for s in ALL_SCENARIOS]
     assert len(ids) == len(set(ids)), "duplicate scenario ids"
+
+
+def test_optional_scenario_tiers_are_valid() -> None:
+    tiered = [s for s in ALL_SCENARIOS if s.tier is not None]
+    bad = [(s.id, s.tier) for s in tiered if s.tier not in SCENARIO_TIERS]
+    assert not bad, f"invalid scenario tiers: {bad}"
+    print(f"LifeOpsBench scenarios with tier metadata: {len(tiered)}")
 
 
 def test_every_action_name_exists_in_manifest(manifest_action_names: set[str]) -> None:

--- a/packages/scenario-runner/AGENTS.md
+++ b/packages/scenario-runner/AGENTS.md
@@ -188,6 +188,10 @@ Loader discovers files recursively; entries starting with `_` are ignored. The `
 4. Assert end-state with `finalChecks` entries.
 5. Run with `bun src/cli.ts run <dir> --scenario <id>` or via `test:deterministic:e2e`.
 
+For LifeOps persona-pack scenarios, also follow
+`plugins/plugin-personal-assistant/test/scenarios/_catalogs/LIFEOPS_PERSONA_SCENARIO_AUTHORING.md`
+and update the owning pack catalog.
+
 ## Conventions / gotchas
 
 - **Single shared runtime per CLI invocation.** PGLite cannot be torn down and recreated (segfaults). For true per-scenario isolation, invoke `eliza-scenarios run` once per scenario from a shell loop.

--- a/packages/scenario-runner/CLAUDE.md
+++ b/packages/scenario-runner/CLAUDE.md
@@ -188,6 +188,10 @@ Loader discovers files recursively; entries starting with `_` are ignored. The `
 4. Assert end-state with `finalChecks` entries.
 5. Run with `bun src/cli.ts run <dir> --scenario <id>` or via `test:deterministic:e2e`.
 
+For LifeOps persona-pack scenarios, also follow
+`plugins/plugin-personal-assistant/test/scenarios/_catalogs/LIFEOPS_PERSONA_SCENARIO_AUTHORING.md`
+and update the owning pack catalog.
+
 ## Conventions / gotchas
 
 - **Single shared runtime per CLI invocation.** PGLite cannot be torn down and recreated (segfaults). For true per-scenario isolation, invoke `eliza-scenarios run` once per scenario from a shell loop.

--- a/packages/scenario-runner/schema/index.d.ts
+++ b/packages/scenario-runner/schema/index.d.ts
@@ -451,6 +451,7 @@ export type ScenarioFinalCheck =
  *   for any scenario that does not declare a lane.
  */
 export type ScenarioLane = "pr-deterministic" | "live-only";
+export type ScenarioTier = "T1" | "T2" | "T3" | "T4";
 
 /**
  * A platform-gated deferral on a live-only scenario: it cannot run in any
@@ -491,6 +492,14 @@ export type ScenarioDefinition = {
   domain: string;
   description?: string;
   tags?: readonly string[];
+  /**
+   * Persona-scenario complexity tier.
+   * - `T1`: extraction and normalization.
+   * - `T2`: multi-turn flow with realistic friction.
+   * - `T3`: longitudinal journey with durable state.
+   * - `T4`: adversarial or boundary-condition behavior.
+   */
+  tier?: ScenarioTier;
   status?: "active" | "pending";
   /**
    * CI lane this scenario is eligible for.
@@ -543,6 +552,11 @@ export declare const DEFAULT_SCENARIO_LANE: ScenarioLane;
 
 /** Resolve a scenario's effective lane, applying {@link DEFAULT_SCENARIO_LANE}. */
 export declare function scenarioLane(value: ScenarioDefinition): ScenarioLane;
+
+/** Resolve and validate the optional persona-scenario complexity tier. */
+export declare function scenarioTier(
+  value: Omit<ScenarioDefinition, "tier"> & { tier?: unknown },
+): ScenarioTier | undefined;
 
 /**
  * Resolve a scenario's platform-gated deferral, or `null` when it is not

--- a/packages/scenario-runner/schema/index.js
+++ b/packages/scenario-runner/schema/index.js
@@ -140,6 +140,7 @@ function validateStrictFinalCheck(check, index) {
 export const DEFAULT_SCENARIO_LANE = "live-only";
 
 const SCENARIO_LANES = new Set(["pr-deterministic", "live-only"]);
+const SCENARIO_TIERS = new Set(["T1", "T2", "T3", "T4"]);
 
 /** Resolve a scenario's effective lane, applying {@link DEFAULT_SCENARIO_LANE}. */
 export function scenarioLane(value) {
@@ -153,6 +154,20 @@ export function scenarioLane(value) {
     );
   }
   return lane;
+}
+
+/** Resolve and validate the optional persona-scenario complexity tier. */
+export function scenarioTier(value) {
+  const tier = value?.tier;
+  if (tier === undefined) {
+    return undefined;
+  }
+  if (!SCENARIO_TIERS.has(tier)) {
+    throw new Error(
+      `scenario "${value?.id ?? "<unknown>"}" has invalid tier "${tier}"; expected one of ${[...SCENARIO_TIERS].join(", ")}`,
+    );
+  }
+  return tier;
 }
 
 /**
@@ -198,6 +213,8 @@ export function scenario(value) {
     }
     // Validate the lane eagerly so a typo fails at definition time, not in CI.
     scenarioLane(value);
+    // Validate optional LifeOps/persona tier metadata when authored.
+    scenarioTier(value);
     // Validate the deferral shape (and lane compatibility) eagerly too.
     scenarioDeferral(value);
   }

--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -392,9 +392,13 @@ async function main(): Promise<number> {
     // final checks) so rows carry metadata.judge_score for reward-weighted
     // training (#8795).
     const scenarioJudgeScores = new Map<string, number>();
+    const scenarioTiers = new Map<string, string>();
     for (const report of reports) {
       if (typeof report.judgeScore === "number") {
         scenarioJudgeScores.set(report.id, report.judgeScore);
+      }
+      if (typeof report.tier === "string") {
+        scenarioTiers.set(report.id, report.tier);
       }
     }
     exportScenarioNativeJsonl(
@@ -402,6 +406,7 @@ async function main(): Promise<number> {
       parsed.exportNativePath,
       scenarioOutcomes,
       scenarioJudgeScores,
+      scenarioTiers,
     );
   }
   if (effectiveRunDir) {

--- a/packages/scenario-runner/src/corpus-assertion-guard.test.ts
+++ b/packages/scenario-runner/src/corpus-assertion-guard.test.ts
@@ -277,6 +277,7 @@ const EXPECTED_PR_DETERMINISTIC_SCENARIO_IDS = [
   "orchestrator-reflexion-respawn",
   "orchestrator-view-cloud-deploy",
   "orchestrator-watchdog-stall",
+  "persona.flexible-scheduling",
   "relationships.list-entities",
   "reminder.cross-platform.acknowledged-syncs",
   "reminder.cross-platform.fires-on-mac-and-phone",

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -2085,6 +2085,7 @@ export async function runScenario(
     tags: Array.isArray(scenario.tags)
       ? scenario.tags.filter((t): t is string => typeof t === "string")
       : [],
+    ...(typeof scenario.tier === "string" ? { tier: scenario.tier } : {}),
     status: "passed",
     durationMs: 0,
     turns: [],

--- a/packages/scenario-runner/src/loader.ts
+++ b/packages/scenario-runner/src/loader.ts
@@ -51,6 +51,8 @@ export interface ScenarioMetadata {
   id: string;
   status?: string;
   title?: string;
+  /** Persona-scenario complexity tier as declared in the file. */
+  tier?: string;
   /** CI lane as declared in the file; absent means the default lane. */
   lane?: string;
   edgeVariant?: string;
@@ -374,6 +376,7 @@ export async function loadScenarioMetadataFile(
     id,
     title: getStaticStringProperty(objectLiteral, "title"),
     status: getStaticStringProperty(objectLiteral, "status"),
+    tier: getStaticStringProperty(objectLiteral, "tier"),
     lane: getStaticStringProperty(objectLiteral, "lane"),
   };
 }

--- a/packages/scenario-runner/src/native-export.test.ts
+++ b/packages/scenario-runner/src/native-export.test.ts
@@ -560,3 +560,51 @@ describe("judge score serialization (#8795)", () => {
     }
   });
 });
+
+describe("scenario tier serialization", () => {
+  it("stamps the scenario tier on rows and metadata", () => {
+    const rows = recordedTrajectoryToNativeRows(
+      syntheticTrajectory() as never,
+      "passed",
+      0.82,
+      "T3",
+    );
+    const row = expectSingleNativeRow(rows);
+    expect(row.tier).toBe("T3");
+    expect(row.metadata.tier).toBe("T3");
+  });
+
+  it("threads per-scenario tiers through exportScenarioNativeJsonl", () => {
+    const runDir = mkdtempSync(path.join(tmpdir(), "scenario-native-tier-"));
+    try {
+      const trajDir = path.join(runDir, "trajectories", "agent-test");
+      mkdirSync(trajDir, { recursive: true });
+      writeFileSync(
+        path.join(trajDir, "tj-test-1.json"),
+        JSON.stringify(syntheticTrajectory()),
+        "utf-8",
+      );
+      const outPath = path.join(runDir, "native.jsonl");
+      const outcomes = new Map<string, "passed" | "failed" | "skipped">([
+        ["todos.create-basic", "passed"],
+      ]);
+      const judgeScores = new Map<string, number>([
+        ["todos.create-basic", 0.9],
+      ]);
+      const tiers = new Map<string, string>([["todos.create-basic", "T4"]]);
+      const count = exportScenarioNativeJsonl(
+        runDir,
+        outPath,
+        outcomes,
+        judgeScores,
+        tiers,
+      );
+      expect(count).toBe(1);
+      const parsed = JSON.parse(readFileSync(outPath, "utf-8").trim());
+      expect(parsed.tier).toBe("T4");
+      expect(parsed.metadata.tier).toBe("T4");
+    } finally {
+      rmSync(runDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/scenario-runner/src/native-export.ts
+++ b/packages/scenario-runner/src/native-export.ts
@@ -50,6 +50,7 @@ export type ScenarioOutcomeMap = ReadonlyMap<string, ScenarioOutcome>;
  * (#8795) instead of only routing on pass/fail.
  */
 export type ScenarioJudgeScoreMap = ReadonlyMap<string, number>;
+export type ScenarioTierMap = ReadonlyMap<string, string>;
 
 export interface NativeBoundaryRow {
   format: typeof NATIVE_FORMAT;
@@ -69,6 +70,8 @@ export interface NativeBoundaryRow {
    * knowing the row shape (#8795).
    */
   judgeScore?: number;
+  /** Optional persona-scenario complexity tier (`T1`..`T4`) for corpus slicing. */
+  tier?: string;
   request: {
     system?: string;
     messages?: unknown[];
@@ -378,6 +381,7 @@ export function recordedTrajectoryToNativeRows(
   trajectory: RecordedTrajectory,
   scenarioOutcome?: ScenarioOutcome,
   judgeScore?: number,
+  tier?: string,
 ): NativeBoundaryRow[] {
   const rows: NativeBoundaryRow[] = [];
   const stages: RecordedStage[] = Array.isArray(trajectory.stages)
@@ -413,6 +417,7 @@ export function recordedTrajectoryToNativeRows(
       boundary: GENERATE_TEXT_BOUNDARY,
       ...(scenarioOutcome ? { scenarioStatus: scenarioOutcome } : {}),
       ...(judgeScore !== undefined ? { judgeScore } : {}),
+      ...(tier ? { tier } : {}),
       request,
       response,
       trajectoryId: trajectory.trajectoryId,
@@ -464,6 +469,7 @@ export function recordedTrajectoryToNativeRows(
         trajectory_status: trajectory.status,
         ...(scenarioOutcome ? { scenario_status: scenarioOutcome } : {}),
         ...(judgeScore !== undefined ? { judge_score: judgeScore } : {}),
+        ...(tier ? { tier } : {}),
         ...(typeof model.costUsd === "number"
           ? { source_cost_usd: model.costUsd }
           : {}),
@@ -540,6 +546,7 @@ export function exportScenarioNativeJsonl(
   outPath: string,
   scenarioOutcomes?: ScenarioOutcomeMap,
   scenarioJudgeScores?: ScenarioJudgeScoreMap,
+  scenarioTiers?: ScenarioTierMap,
 ): number {
   const trajectoriesDir = path.join(runDir, "trajectories");
   const files = collectTrajectoryFiles(trajectoriesDir);
@@ -588,8 +595,17 @@ export function exportScenarioNativeJsonl(
       scenarioJudgeScores && typeof parsed.scenarioId === "string"
         ? scenarioJudgeScores.get(parsed.scenarioId)
         : undefined;
+    const tier =
+      scenarioTiers && typeof parsed.scenarioId === "string"
+        ? scenarioTiers.get(parsed.scenarioId)
+        : undefined;
     rows.push(
-      ...recordedTrajectoryToNativeRows(parsed, scenarioOutcome, judgeScore),
+      ...recordedTrajectoryToNativeRows(
+        parsed,
+        scenarioOutcome,
+        judgeScore,
+        tier,
+      ),
     );
   }
   mkdirSync(path.dirname(outPath), { recursive: true });

--- a/packages/scenario-runner/src/scenario-expansion.test.ts
+++ b/packages/scenario-runner/src/scenario-expansion.test.ts
@@ -168,6 +168,7 @@ describe("scenario-runner edge expansion", () => {
       '  id: "fixture.static.only",',
       '  title: "Static only",',
       '  domain: "fixture",',
+      '  tier: "T2",',
       '  turns: [{ kind: "message", name: "ask", text: "Hello" }],',
       "};",
     ]);
@@ -175,7 +176,7 @@ describe("scenario-runner edge expansion", () => {
     process.env.SHOULD_NOT_IMPORT_SCENARIO = "1";
     try {
       await expect(listScenarioMetadata(dir)).resolves.toMatchObject([
-        { id: "fixture.static.only", title: "Static only" },
+        { id: "fixture.static.only", title: "Static only", tier: "T2" },
       ]);
       await expect(
         loadScenarioFile(join(dir, "static-only.scenario.ts")),

--- a/packages/scenario-runner/src/types.ts
+++ b/packages/scenario-runner/src/types.ts
@@ -64,6 +64,8 @@ export interface ScenarioReport {
   title: string;
   domain: string;
   tags: readonly string[];
+  /** Optional persona-scenario complexity tier (`T1`..`T4`) from the scenario definition. */
+  tier?: string;
   status: "passed" | "failed" | "skipped";
   skipReason?: string;
   durationMs: number;

--- a/packages/scripts/check-lifeops-persona-catalog-coverage.mjs
+++ b/packages/scripts/check-lifeops-persona-catalog-coverage.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+
+/**
+ * Coverage gate for the LifeOps persona scenario-pack ledgers. The eight pack
+ * catalogs are progress ledgers, not executable scenarios; this script confirms
+ * their declared scenario ids resolve to the real TypeScript scenario-runner
+ * corpus or the Python LifeOpsBench corpus and prints authored/verified totals.
+ */
+
+import { lstatSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
+const CATALOG_DIR = path.join(
+  REPO_ROOT,
+  "plugins/plugin-personal-assistant/test/scenarios/_catalogs",
+);
+const TS_SCENARIO_ROOTS = [
+  "plugins/plugin-personal-assistant/test/scenarios",
+  "packages/scenario-runner/test/scenarios",
+].map((entry) => path.join(REPO_ROOT, entry));
+const PYTHON_SCENARIO_ROOT = path.join(
+  REPO_ROOT,
+  "packages/benchmarks/lifeops-bench/eliza_lifeops_bench/scenarios",
+);
+
+const EXPECTED_CATALOGS = [
+  ["adhd-capture-and-start.catalog.json", "A1", 28],
+  ["adhd-follow-through.catalog.json", "A2", 24],
+  ["night-owl-anchored-day.catalog.json", "B1", 24],
+  ["shift-rotation.catalog.json", "B2", 22],
+  ["traveler-timezone-truth.catalog.json", "C1", 28],
+  ["comms-flood-triage.catalog.json", "D1", 26],
+  ["low-activation-reengagement.catalog.json", "E1", 28],
+  ["neurotypical-control-adversarial.catalog.json", "F1", 32],
+];
+
+const VALID_TIERS = new Set(["T1", "T2", "T3", "T4"]);
+const VALID_SURFACES = new Set(["lifeops-bench", "scenario-runner"]);
+const VALID_STATUSES = new Set(["planned", "authored", "verified"]);
+const JSON_MODE = process.argv.includes("--json");
+
+function toPosix(value) {
+  return value.replace(/\\/g, "/");
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `${toPosix(path.relative(REPO_ROOT, file))}: ${error.message}`,
+    );
+  }
+}
+
+function walkFiles(root, predicate, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry.name.startsWith("_")) continue;
+    if (
+      entry.name === "node_modules" ||
+      entry.name === "dist" ||
+      entry.name === "build" ||
+      entry.name === ".turbo" ||
+      entry.name === ".git"
+    ) {
+      continue;
+    }
+    const full = path.join(root, entry.name);
+    const stat = lstatSync(full);
+    if (stat.isSymbolicLink()) continue;
+    if (stat.isDirectory()) {
+      walkFiles(full, predicate, out);
+    } else if (predicate(full)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function loadScenarioRunnerIds() {
+  const ids = new Map();
+  const files = TS_SCENARIO_ROOTS.flatMap((root) =>
+    walkFiles(root, (file) => file.endsWith(".scenario.ts")),
+  );
+  const idPattern = /\bid\s*:\s*["']([^"']+)["']/;
+  for (const file of files) {
+    const sourceText = readFileSync(file, "utf8");
+    const id = sourceText.match(idPattern)?.[1];
+    if (id) ids.set(id, toPosix(path.relative(REPO_ROOT, file)));
+  }
+  return ids;
+}
+
+function loadLifeOpsBenchIds() {
+  const ids = new Map();
+  const files = walkFiles(PYTHON_SCENARIO_ROOT, (file) => file.endsWith(".py"));
+  const idPattern = /\bid\s*=\s*["']([^"']+)["']/g;
+  for (const file of files) {
+    const source = readFileSync(file, "utf8");
+    for (const match of source.matchAll(idPattern)) {
+      ids.set(match[1], toPosix(path.relative(REPO_ROOT, file)));
+    }
+  }
+  return ids;
+}
+
+function validateCatalogShape(
+  catalog,
+  expectedFile,
+  expectedPack,
+  expectedTarget,
+) {
+  const where = `${expectedFile}`;
+  const errors = [];
+  if (!catalog || typeof catalog !== "object" || Array.isArray(catalog)) {
+    return [`${where}: catalog must be a JSON object`];
+  }
+  if (typeof catalog.catalogId !== "string" || catalog.catalogId.length === 0) {
+    errors.push(`${where}: catalogId must be a non-empty string`);
+  }
+  if (typeof catalog.title !== "string" || catalog.title.length === 0) {
+    errors.push(`${where}: title must be a non-empty string`);
+  }
+  if (!catalog.source || typeof catalog.source !== "object") {
+    errors.push(`${where}: source must be an object`);
+  } else {
+    if (catalog.source.packId !== expectedPack) {
+      errors.push(
+        `${where}: source.packId=${catalog.source.packId} expected ${expectedPack}`,
+      );
+    }
+    if (catalog.source.targetCount !== expectedTarget) {
+      errors.push(
+        `${where}: source.targetCount=${catalog.source.targetCount} expected ${expectedTarget}`,
+      );
+    }
+  }
+  if (!Array.isArray(catalog.scenarios)) {
+    errors.push(`${where}: scenarios must be an array`);
+  }
+  return errors;
+}
+
+function summarize() {
+  const scenarioRunnerIds = loadScenarioRunnerIds();
+  const lifeOpsBenchIds = loadLifeOpsBenchIds();
+  const errors = [];
+  const packs = [];
+
+  for (const [fileName, expectedPack, expectedTarget] of EXPECTED_CATALOGS) {
+    const file = path.join(CATALOG_DIR, fileName);
+    const catalog = readJson(file);
+    errors.push(
+      ...validateCatalogShape(catalog, fileName, expectedPack, expectedTarget),
+    );
+    const entries = Array.isArray(catalog.scenarios) ? catalog.scenarios : [];
+    let authored = 0;
+    let verified = 0;
+    for (const [index, entry] of entries.entries()) {
+      const where = `${fileName}:scenarios[${index}]`;
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        errors.push(`${where}: entry must be an object`);
+        continue;
+      }
+      const { id, tier, surface, pack, status } = entry;
+      if (typeof id !== "string" || id.length === 0) {
+        errors.push(`${where}: id must be a non-empty string`);
+      }
+      if (!VALID_TIERS.has(tier)) {
+        errors.push(`${where}: tier must be one of T1, T2, T3, T4`);
+      }
+      if (!VALID_SURFACES.has(surface)) {
+        errors.push(
+          `${where}: surface must be lifeops-bench or scenario-runner`,
+        );
+      }
+      if (pack !== expectedPack) {
+        errors.push(`${where}: pack=${pack} expected ${expectedPack}`);
+      }
+      if (!VALID_STATUSES.has(status)) {
+        errors.push(`${where}: status must be planned, authored, or verified`);
+      }
+      if (status === "authored" || status === "verified") {
+        authored += 1;
+        const idMap =
+          surface === "scenario-runner" ? scenarioRunnerIds : lifeOpsBenchIds;
+        if (typeof id === "string" && !idMap.has(id)) {
+          errors.push(`${where}: ${surface} id "${id}" was not found`);
+        }
+      }
+      if (status === "verified") verified += 1;
+    }
+    packs.push({
+      file: fileName,
+      pack: expectedPack,
+      target: expectedTarget,
+      authored,
+      verified,
+    });
+  }
+
+  const target = packs.reduce((sum, pack) => sum + pack.target, 0);
+  const authored = packs.reduce((sum, pack) => sum + pack.authored, 0);
+  const verified = packs.reduce((sum, pack) => sum + pack.verified, 0);
+  return { packs, target, authored, verified, errors };
+}
+
+function main() {
+  const result = summarize();
+  if (JSON_MODE) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log("LifeOps persona scenario catalog coverage");
+    for (const pack of result.packs) {
+      console.log(
+        `${pack.pack.padEnd(2)} ${pack.authored}/${pack.target} authored, ${pack.verified}/${pack.authored} verified (${pack.file})`,
+      );
+    }
+    console.log(
+      `Total: ${result.authored}/${result.target} authored, ${result.verified}/${result.target} verified`,
+    );
+  }
+  if (result.errors.length > 0) {
+    for (const error of result.errors) console.error(error);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/packages/scripts/check-scenario-workflow-coverage.mjs
+++ b/packages/scripts/check-scenario-workflow-coverage.mjs
@@ -285,6 +285,7 @@ function loadScenarioMetadataFile(file) {
     id,
     title: getStaticStringProperty(objectLiteral, "title"),
     status: getStaticStringProperty(objectLiteral, "status"),
+    tier: getStaticStringProperty(objectLiteral, "tier"),
     lane: getStaticStringProperty(objectLiteral, "lane"),
     platformOs,
     deferred,

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/LIFEOPS_PERSONA_SCENARIO_AUTHORING.md
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/LIFEOPS_PERSONA_SCENARIO_AUTHORING.md
@@ -1,0 +1,87 @@
+# LifeOps Persona Scenario Authoring
+
+This guide is the shared contract for the eight LifeOps persona scenario packs
+tracked by the catalog JSON files in this directory. It covers both surfaces:
+LifeOpsBench Python scenarios and scenario-runner `.scenario.ts` trajectories.
+
+## Tier Rubric
+
+- **T1 - extraction and normalization**: single-session tasks where the user
+  states a need in persona voice and the agent must extract the structured thing
+  without being handed it. Pass requires a correct structural record, a
+  two-phase commit where writes are involved, and assertions that cannot pass by
+  echoing the user's words.
+- **T2 - multi-turn with friction**: distractors, topic changes, vague
+  follow-ups, one disruption (`new_message` / `calendar_change`), or a
+  mid-conversation contradiction the agent must reconcile. Use LifeOpsBench LIVE
+  `success_criteria`, or scenario-runner multi-turn checks with `responseJudge`
+  plus forbidden-action assertions.
+- **T3 - longitudinal journeys**: behavior across simulated days, including
+  missed occurrences, no-reply retries, escalation, re-anchoring after timezone
+  changes or shift rotation, and lapse-and-return. Use deterministic
+  scenario-runner `tick` turns when the real scheduler must be exercised.
+- **T4 - adversarial and boundary behavior**: shame-bait, crisis language,
+  prompt injection through forwarded content, sensitive approvals under silence,
+  wrong-recipient traps, and VIP misfile traps. These carry the highest judge
+  bar and should include fail-closed assertions such as forbidden actions and
+  `noSideEffectOnReject`.
+
+## Persona Structural Knobs
+
+Personas live in data and scenario text. The runner stays generic: no behavior
+may branch on `promptInstructions` text or a persona id string.
+
+| Persona | Defining traits | Top needs | Required agent behaviors | Structural knobs |
+| --- | --- | --- | --- | --- |
+| P1 casey_adhd | fragmented capture, time blindness, low task-initiation energy | fast capture, first-step help, non-shaming follow-through | extract messy asks, ask only necessary clarifiers, propose tiny starts | adaptive anchors, no-reply policy, reminder intensity, owner facts |
+| P2 night_owl | late chronotype, social-jetlag risk | day plans anchored to actual wake time | avoid early-morning assumptions, schedule relative to observed active windows | `relative_to_anchor`, user windows, chronotype facts |
+| P3 rotating_shift | schedule rotates, sleep/wake anchors move | shift-aware routines and reminders | re-anchor when shift pattern changes, protect sleep windows | window policy, timezone/shift owner facts, quiet hours |
+| P4 frequent_traveler | timezone changes and disrupted plans | local-wall-clock vs absolute-instant clarity | preserve timezone semantics, detect travel context, recover from disruption | timezone history, travelActive facts, trigger timezone fields |
+| P5 comms_flood | many channels, high interruption cost | batching, VIP breakthrough, safe triage | separate urgent from important, never miss VIPs, summarize without over-notifying | channel posture, VIP facts, digest windows, escalation ladders |
+| P6 low_activation | overwhelmed, shame-sensitive, low energy | behavioral activation with nonjudgmental recovery | shrink asks, normalize lapses, avoid therapy roleplay, route crisis language safely | reminder intensity, lapse policy, crisis guard, small-step templates |
+| P7 neurotypical_control | baseline organized user | no regression while supporting other personas | keep ordinary scheduling/triage behavior boring and reliable | default windows, ordinary reminder policy, control assertions |
+
+## Corpus-Quality Rules
+
+1. No echo-satisfiable assertions. Checks must require a derived fact the user
+   did not simply say.
+2. Assert outcomes, not routing. Scenario-runner scenarios need at least one
+   final check against a real store or effect.
+3. Creation flows use a two-phase commit. Preview first; assert no completion
+   claim before owner confirmation.
+4. At least 30% of new LifeOpsBench STATIC scenarios carry a
+   `first_question_fallback`.
+5. Persona voice must match the persona's communication style. P1/P6 packs
+   should include messy, fragmentary, low-energy phrasing where appropriate.
+6. Judge rubrics for P1/P6 score tone as well as mechanics and fail guilt
+   framing or therapy roleplay.
+7. Deterministic scenario-runner scenarios need a fail-without-fix anchor
+   comment naming the code path whose regression would make the scenario fail.
+8. Every authored scenario gets exactly one entry in its pack catalog, with
+   `status` moving from `planned` to `authored` to `verified` as evidence lands.
+
+## Surface Decision Tree
+
+Use LifeOpsBench when the main value is cheap persona-conversation coverage over
+the deterministic LifeWorld and the scenario benefits from the 10x framing
+expansion.
+
+Use scenario-runner `live-only` when the scenario must prove behavior through a
+real `AgentRuntime`, real stores, plugin routes, or live model trajectories.
+
+Use scenario-runner `pr-deterministic` only when the behavior is scheduler or
+`tick` drivable, keyless under the strict LLM proxy, and valuable enough to join
+the pinned PR corpus. Adding one requires updating
+`packages/scenario-runner/src/corpus-assertion-guard.test.ts`.
+
+## Catalog Workflow
+
+After authoring a scenario, add its entry to that pack's catalog file and flip
+its status. Run:
+
+```bash
+node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --json
+```
+
+The gate confirms authored and verified scenario ids resolve to real scenario
+files and prints progress toward the 212-scenario target.

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/adhd-capture-and-start.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/adhd-capture-and-start.catalog.json
@@ -1,0 +1,16 @@
+{
+  "catalogId": "adhd-capture-and-start",
+  "title": "Pack A1 - ADHD capture-and-start scenario catalog",
+  "source": {
+    "parentIssue": "#12186",
+    "foundationIssue": "#12277",
+    "packId": "A1",
+    "persona": "P1 casey_adhd",
+    "targetCount": 28,
+    "notes": [
+      "This file is the progress ledger for pack A1 only. Add one entry per authored scenario, across both surfaces (lifeops-bench Python ids and scenario-runner .scenario.ts ids).",
+      "status flips planned -> authored once the scenario file/literal exists; -> verified once a real-LLM run has been captured and hand-reviewed per PR_EVIDENCE.md."
+    ]
+  },
+  "scenarios": []
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/adhd-follow-through.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/adhd-follow-through.catalog.json
@@ -1,0 +1,16 @@
+{
+  "catalogId": "adhd-follow-through",
+  "title": "Pack A2 - ADHD follow-through scenario catalog",
+  "source": {
+    "parentIssue": "#12186",
+    "foundationIssue": "#12277",
+    "packId": "A2",
+    "persona": "P1 casey_adhd",
+    "targetCount": 24,
+    "notes": [
+      "This file is the progress ledger for pack A2 only. Add one entry per authored scenario, across both surfaces (lifeops-bench Python ids and scenario-runner .scenario.ts ids).",
+      "status flips planned -> authored once the scenario file/literal exists; -> verified once a real-LLM run has been captured and hand-reviewed per PR_EVIDENCE.md."
+    ]
+  },
+  "scenarios": []
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/comms-flood-triage.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/comms-flood-triage.catalog.json
@@ -1,0 +1,16 @@
+{
+  "catalogId": "comms-flood-triage",
+  "title": "Pack D1 - Communications-flood triage scenario catalog",
+  "source": {
+    "parentIssue": "#12186",
+    "foundationIssue": "#12277",
+    "packId": "D1",
+    "persona": "P5 comms_flood",
+    "targetCount": 26,
+    "notes": [
+      "This file is the progress ledger for pack D1 only. Add one entry per authored scenario, across both surfaces (lifeops-bench Python ids and scenario-runner .scenario.ts ids).",
+      "status flips planned -> authored once the scenario file/literal exists; -> verified once a real-LLM run has been captured and hand-reviewed per PR_EVIDENCE.md."
+    ]
+  },
+  "scenarios": []
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/low-activation-reengagement.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/low-activation-reengagement.catalog.json
@@ -1,0 +1,16 @@
+{
+  "catalogId": "low-activation-reengagement",
+  "title": "Pack E1 - Low-activation reengagement scenario catalog",
+  "source": {
+    "parentIssue": "#12186",
+    "foundationIssue": "#12277",
+    "packId": "E1",
+    "persona": "P6 low_activation",
+    "targetCount": 28,
+    "notes": [
+      "This file is the progress ledger for pack E1 only. Add one entry per authored scenario, across both surfaces (lifeops-bench Python ids and scenario-runner .scenario.ts ids).",
+      "status flips planned -> authored once the scenario file/literal exists; -> verified once a real-LLM run has been captured and hand-reviewed per PR_EVIDENCE.md."
+    ]
+  },
+  "scenarios": []
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/neurotypical-control-adversarial.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/neurotypical-control-adversarial.catalog.json
@@ -1,0 +1,16 @@
+{
+  "catalogId": "neurotypical-control-adversarial",
+  "title": "Pack F1 - Neurotypical control and adversarial scenario catalog",
+  "source": {
+    "parentIssue": "#12186",
+    "foundationIssue": "#12277",
+    "packId": "F1",
+    "persona": "P7 neurotypical_control",
+    "targetCount": 32,
+    "notes": [
+      "This file is the progress ledger for pack F1 only. Add one entry per authored scenario, across both surfaces (lifeops-bench Python ids and scenario-runner .scenario.ts ids).",
+      "status flips planned -> authored once the scenario file/literal exists; -> verified once a real-LLM run has been captured and hand-reviewed per PR_EVIDENCE.md."
+    ]
+  },
+  "scenarios": []
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/night-owl-anchored-day.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/night-owl-anchored-day.catalog.json
@@ -1,0 +1,16 @@
+{
+  "catalogId": "night-owl-anchored-day",
+  "title": "Pack B1 - Night-owl anchored-day scenario catalog",
+  "source": {
+    "parentIssue": "#12186",
+    "foundationIssue": "#12277",
+    "packId": "B1",
+    "persona": "P2 night_owl",
+    "targetCount": 24,
+    "notes": [
+      "This file is the progress ledger for pack B1 only. Add one entry per authored scenario, across both surfaces (lifeops-bench Python ids and scenario-runner .scenario.ts ids).",
+      "status flips planned -> authored once the scenario file/literal exists; -> verified once a real-LLM run has been captured and hand-reviewed per PR_EVIDENCE.md."
+    ]
+  },
+  "scenarios": []
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/shift-rotation.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/shift-rotation.catalog.json
@@ -1,0 +1,16 @@
+{
+  "catalogId": "shift-rotation",
+  "title": "Pack B2 - Shift-rotation scenario catalog",
+  "source": {
+    "parentIssue": "#12186",
+    "foundationIssue": "#12277",
+    "packId": "B2",
+    "persona": "P3 rotating_shift",
+    "targetCount": 22,
+    "notes": [
+      "This file is the progress ledger for pack B2 only. Add one entry per authored scenario, across both surfaces (lifeops-bench Python ids and scenario-runner .scenario.ts ids).",
+      "status flips planned -> authored once the scenario file/literal exists; -> verified once a real-LLM run has been captured and hand-reviewed per PR_EVIDENCE.md."
+    ]
+  },
+  "scenarios": []
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/traveler-timezone-truth.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/traveler-timezone-truth.catalog.json
@@ -1,0 +1,16 @@
+{
+  "catalogId": "traveler-timezone-truth",
+  "title": "Pack C1 - Traveler timezone-truth scenario catalog",
+  "source": {
+    "parentIssue": "#12186",
+    "foundationIssue": "#12277",
+    "packId": "C1",
+    "persona": "P4 frequent_traveler",
+    "targetCount": 28,
+    "notes": [
+      "This file is the progress ledger for pack C1 only. Add one entry per authored scenario, across both surfaces (lifeops-bench Python ids and scenario-runner .scenario.ts ids).",
+      "status flips planned -> authored once the scenario file/literal exists; -> verified once a real-LLM run has been captured and hand-reviewed per PR_EVIDENCE.md."
+    ]
+  },
+  "scenarios": []
+}


### PR DESCRIPTION
## Summary

Closes #12277.

- adds optional `tier` scenario metadata (`T1`..`T4`) through schema validation, static metadata, reports, and native JSONL export
- adds LifeOps persona scenario catalog scaffolds for the #12186 packs with target total 212
- adds the LifeOps persona authoring guide plus catalog coverage checker
- updates the pr-deterministic corpus ratchet baseline for the already-present `persona.flexible-scheduling` scenario

## Evidence

Evidence artifact: `.github/issue-evidence/12277-lifeops-persona-scenario-catalog.md`

Passed locally after rebasing on current `origin/develop`:

```bash
cmp -s packages/scenario-runner/CLAUDE.md packages/scenario-runner/AGENTS.md
node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --json
bun test --cwd packages/scenario-runner src/scenario-expansion.test.ts src/native-export.test.ts
bun test --cwd packages/scenario-runner src/corpus-assertion-guard.test.ts src/action-effect-ratchet.test.ts src/echo-assertion-ratchet.test.ts src/skippable-check-ratchet.test.ts
python3 -m pytest packages/benchmarks/lifeops-bench/tests/test_scenarios_corpus.py::test_optional_scenario_tiers_are_valid -q -s
python3 -m py_compile packages/benchmarks/lifeops-bench/eliza_lifeops_bench/types.py packages/benchmarks/lifeops-bench/tests/test_scenarios_corpus.py
bunx @biomejs/biome check packages/scripts/check-lifeops-persona-catalog-coverage.mjs packages/scenario-runner/schema/index.js packages/scenario-runner/src/cli.ts packages/scenario-runner/src/executor.ts packages/scenario-runner/src/loader.ts packages/scenario-runner/src/native-export.ts packages/scenario-runner/src/native-export.test.ts packages/scenario-runner/src/scenario-expansion.test.ts packages/scenario-runner/src/types.ts packages/scenario-runner/src/corpus-assertion-guard.test.ts plugins/plugin-personal-assistant/test/scenarios/_catalogs packages/scenario-runner/CLAUDE.md packages/scenario-runner/AGENTS.md packages/benchmarks/lifeops-bench/SCENARIO_AUTHORING.md .github/issue-evidence/12277-lifeops-persona-scenario-catalog.md
git diff --check
```

Blocked in this checkout, documented in the evidence file:

- full LifeOpsBench corpus pytest is missing snapshot fixtures under `packages/benchmarks/lifeops-bench/data/snapshots/`
- `packages/scenario-runner` typecheck currently fails broadly on repository dependency/generated-file state unrelated to this change
- scenario-runner CLI `list --validate-scenarios` fails before validation because `packages/core/src/i18n/generated/validation-keyword-data.ts` is missing

## N/A

- UI screenshots/video/frontend logs: N/A - no UI code changed
- real-LLM trajectories: N/A - empty catalog/schema/report metadata scaffolding only; no prompt/model behavior changed
- backend/native/audio/on-chain evidence: N/A - no corresponding runtime behavior changed
