### PR TITLE
docs(#12235): prose headers + churn cleanup — b05-cloud

### DIFF
--- a/packages/ui/src/cloud/admin/data/use-admin-gate.test.tsx
+++ b/packages/ui/src/cloud/admin/data/use-admin-gate.test.tsx
@@ -1,16 +1,18 @@
 // @vitest-environment jsdom
 
+/**
+ * `useAdminGate` session resolution. The Steward SDK context keeps its session
+ * in MemoryStorage — empty on every full page load — so the gate must resolve
+ * from the persisted localStorage JWT like the rest of the console, or a fully
+ * signed-in user is locked out with "Sign in required" after a reload. These
+ * tests exercise the gate with ONLY the persisted token present (no Steward
+ * provider mounted), which is the reload reality.
+ */
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-// The admin gate must resolve the session the same way the rest of the console
-// does. The Steward SDK context keeps its session in MemoryStorage — empty on
-// every full page load — so gating on the raw context locked fully signed-in
-// users out with "Sign in required" while billing/org rendered fine off the
-// localStorage JWT. These tests exercise the gate with ONLY the persisted
-// token present (no Steward provider mounted), which is the reload reality.
 
 import { useAdminGate } from "./use-admin-gate";
 

--- a/packages/ui/src/cloud/analytics/lib/auth-query.test.tsx
+++ b/packages/ui/src/cloud/analytics/lib/auth-query.test.tsx
@@ -1,14 +1,16 @@
 // @vitest-environment jsdom
 
+/**
+ * `useAuthenticatedQueryGate` as used by the analytics + api-keys surfaces. The
+ * gate must resolve the session from the persisted localStorage JWT like the
+ * rest of the console; gating on the raw Steward SDK context (MemoryStorage,
+ * empty on every full page load) leaves it permanently disabled for a signed-in
+ * user — analytics stuck on its skeleton, keys never fetched. These tests
+ * reproduce the page-reload reality: ONLY a persisted JWT, no Steward provider.
+ */
+
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-// The analytics + api-keys query gates must resolve the session the same way
-// the rest of the console does. Gating on the raw Steward SDK context (whose
-// MemoryStorage session is empty on every full page load) left the gate
-// permanently disabled for a signed-in user — analytics stuck on its loading
-// skeleton, keys never fetched. These tests reproduce the page-reload reality:
-// ONLY a persisted localStorage JWT, no Steward provider mounted.
 
 import { useAuthenticatedQueryGate } from "../../lib/auth-query";
 

--- a/packages/ui/src/cloud/applications/components/BuyDomainCard.test.tsx
+++ b/packages/ui/src/cloud/applications/components/BuyDomainCard.test.tsx
@@ -1,5 +1,14 @@
 // @vitest-environment jsdom
 
+/**
+ * `BuyDomainCard` availability→purchase flow (#10246): the Check button gates on
+ * a domain-shaped input, a lookup shows the price + renewal quote (or a
+ * no-Buy "not available"), a buy only fires after explicit confirm and refreshes
+ * the domain list, and a 402 surfaces an insufficient-credits error with an
+ * Add-credits CTA to the system browser. The api-client, `openExternalUrl`, and
+ * `sonner` toast are doubled; the card renders for real.
+ */
+
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/cloud/applications/components/app-analytics.test.tsx
+++ b/packages/ui/src/cloud/applications/components/app-analytics.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * `AppAnalytics` sessions tab (#11349): it loads and renders the session
+ * summary, funnel, and recent-sessions list straight from the analytics DTO.
+ * The api-client, `sonner`, and `recharts` are doubled; the component renders
+ * for real against the mocked DTO.
+ */
+
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/cloud/applications/components/app-domains.tsx
+++ b/packages/ui/src/cloud/applications/components/app-domains.tsx
@@ -752,7 +752,7 @@ function DomainCard({
                   onClick={(e) => {
                     // Native studio: open the verified domain in the system
                     // browser (WebView target="_blank" is unreliable). No-op on
-                    // web — the anchor opens a new tab as before.
+                    // web — the anchor opens a new tab normally.
                     if (openExternalUrlOnNative(url)) {
                       e.preventDefault();
                     }

--- a/packages/ui/src/cloud/applications/components/app-frontend-hosting.test.tsx
+++ b/packages/ui/src/cloud/applications/components/app-frontend-hosting.test.tsx
@@ -1,5 +1,14 @@
 // @vitest-environment jsdom
 
+/**
+ * `AppFrontendHosting` deployment tab (#10690): lists deployments newest-first
+ * with a live badge, shows the empty state, recovers a load error via Retry,
+ * publishes picked files as a base64 bundle (with/without activate) and
+ * refreshes, and surfaces a publish failure via toast without losing the
+ * selection. Also unit-covers `filesToBundle` / `stripCommonRootDir`. The
+ * api-client, `sonner`, and i18n provider are doubled; the component is real.
+ */
+
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/cloud/applications/components/app-monetization-settings.test.tsx
+++ b/packages/ui/src/cloud/applications/components/app-monetization-settings.test.tsx
@@ -1,5 +1,14 @@
 // @vitest-environment jsdom
 
+/**
+ * `AppMonetizationSettings` review gate: a draft app must be submitted for
+ * review before monetization can be enabled, an approved app renders an enabled
+ * toggle with no submit button, and a rejected/pending app stays gated (with
+ * resubmission offered). A legacy enabled-but-unapproved app can always be
+ * turned OFF — never trapped ON. The api-client, `sonner`, i18n provider, and
+ * native nav are doubled; the component renders for real.
+ */
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/packages/ui/src/cloud/applications/components/app-promote.test.tsx
+++ b/packages/ui/src/cloud/applications/components/app-promote.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * `AppPromote` asset-generation error surfacing (#9323): a failed
+ * `/promote/assets` call surfaces the error to the user (no silent swallow),
+ * and a successful generation shows none. The api-client, router, i18n
+ * provider, and promote-dialog are doubled; the component renders for real.
+ */
+
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/cloud/applications/components/app-promote.tsx
+++ b/packages/ui/src/cloud/applications/components/app-promote.tsx
@@ -1,16 +1,9 @@
 /**
  * Application detail — Promote tab.
  *
- * Two larp blocks from the original are dropped (per the migration scope):
- *   - the hard-coded "Quick Stats" tiles (Social Posts: 0 / SEO Score: -- /
- *     Ad Campaigns: 0) which never reflected real data, and
- *   - the static "Promotional Assets" placeholder grid (four dashed boxes with
- *     no behaviour).
- *
- * The real surfaces are kept and wired to the typed `api` client: the
- * promotion-suggestions GET, the connected-ad-accounts GET, the
- * generate-assets POST (now re-fetching instead of `window.location.reload()`),
- * and the shared `PromoteAppDialog` from cloud-ui.
+ * Renders the live promotion surfaces wired to the typed `api` client:
+ * promotion-suggestions (GET), connected ad accounts (GET), asset generation
+ * (POST, then re-fetch), and the shared `PromoteAppDialog` from cloud-ui.
  */
 
 import { ExternalLink, Loader2, Megaphone, Plus, Sparkles } from "lucide-react";

--- a/packages/ui/src/cloud/applications/lib/native-cloud-nav.ts
+++ b/packages/ui/src/cloud/applications/lib/native-cloud-nav.ts
@@ -54,7 +54,7 @@ export function resolveCloudConsoleUrl(path: string): string {
  * On native, open a cross-domain cloud dashboard route (one the studio's
  * MemoryRouter does not mount) in the system browser and report that we handled
  * the navigation. On web, returns `false` so the caller's in-router
- * `<Link>` / `navigate()` runs exactly as before.
+ * `<Link>` / `navigate()` handles it.
  */
 export function openCloudConsoleRouteExternally(path: string): boolean {
   if (!isNativeAppsStudioRuntime()) return false;
@@ -67,7 +67,7 @@ export function openCloudConsoleRouteExternally(path: string): boolean {
  * website, or support link) in the system browser — a WebView `target="_blank"`
  * is dropped or hijacks the studio's WebView. Returns `true` when handled.
  * `mailto:` / `tel:` are left to the anchor on both platforms (the OS handles
- * them), and web always returns `false` (the anchor opens a new tab as before).
+ * them), and web always returns `false` (the anchor opens a new tab normally).
  */
 export function openExternalUrlOnNative(href: string): boolean {
   if (!isNativeAppsStudioRuntime()) return false;

--- a/packages/ui/src/cloud/connectors/CloudConnectorsSection.tsx
+++ b/packages/ui/src/cloud/connectors/CloudConnectorsSection.tsx
@@ -2,9 +2,7 @@
  * Cloud connectors surface (Messaging & Communication + Channels groups).
  *
  * These are the CLOUD-hosted connectors (OAuth-redirect + token-credential),
- * distinct from the local-process `ConnectorsSection`. The surface is designed
- * so it can later branch by active-server kind; for now it always renders the
- * cloud variant.
+ * distinct from the local-process `ConnectorsSection`.
  */
 
 "use client";

--- a/packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts
+++ b/packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts
@@ -1,5 +1,13 @@
 // @vitest-environment jsdom
 
+/**
+ * Boot-time resume of a persisted shared→dedicated cloud-agent handoff that was
+ * interrupted by a reload. Collaborators (the handoff supervisor, bridge
+ * delete, cloud auth, runtime state) are doubled so the test drives the
+ * decision logic deterministically: same dedicated target on resume, repoint +
+ * bridge-delete on success, no delete on failure, and stale-marker clearing.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type HandoffResult = {

--- a/packages/ui/src/cloud/handoff/run-cloud-agent-handoff.test.ts
+++ b/packages/ui/src/cloud/handoff/run-cloud-agent-handoff.test.ts
@@ -1,5 +1,13 @@
 // @vitest-environment jsdom
 
+/**
+ * Phase-event and terminal-status contract of the cloud-agent handoff runner.
+ * The supervisor is stubbed so the test can assert the emitted phase sequence
+ * (migrating → terminal), retry arming on failure, and that `onSwitchSucceeded`
+ * fires only on the success statuses (`switched` / `switched-empty`) — never on
+ * `failed` or `timed-out`, where the user stays on the shared bridge.
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CLOUD_HANDOFF_PHASE_EVENT,

--- a/packages/ui/src/cloud/handoff/silent-repoint.test.ts
+++ b/packages/ui/src/cloud/handoff/silent-repoint.test.ts
@@ -1,5 +1,13 @@
 // @vitest-environment jsdom
 
+/**
+ * `silentlyRepointToDedicated` seamlessly moves the live client onto the
+ * dedicated agent without a visible reconnect. Client, state, and profile
+ * collaborators are doubled to assert it repoints via `repointBaseUrl` (not the
+ * hard `setBaseUrl`) and persists the dedicated agent as the restorable active
+ * server + active profile.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({

--- a/packages/ui/src/cloud/lib/api-client.test.ts
+++ b/packages/ui/src/cloud/lib/api-client.test.ts
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
-//
-// Transport-bridge regression for the cloud dashboard's `api-client`. The
-// load-bearing guarantee: the WEB path stays same-origin-only and STILL throws
-// `CROSS_ORIGIN_API_URL` on any cross-origin absolute URL, while native /
-// Electrobun resolves to the single allowlisted Eliza Cloud API host and rides
-// `CapacitorHttp` — but ONLY that one host (every other cross-origin target
-// still throws, even on native).
+
+/**
+ * Transport-bridge contract for the cloud dashboard's `api-client`. The
+ * load-bearing guarantee: the WEB path stays same-origin-only and throws
+ * `CROSS_ORIGIN_API_URL` on any cross-origin absolute URL, while native /
+ * Electrobun resolves to the single allowlisted Eliza Cloud API host and rides
+ * `CapacitorHttp` — but ONLY that one host (every other cross-origin target
+ * still throws, even on native). `@capacitor/core` is doubled to toggle native.
+ */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/ui/src/cloud/lib/api-client.ts
+++ b/packages/ui/src/cloud/lib/api-client.ts
@@ -189,8 +189,8 @@ function readLiveNativeStewardToken(token: string): string | null {
  * Authorization header and 401'd (#11930). The chain mirrors the canonical
  * `getCloudAuthToken()` in `../../api/client-cloud.ts` (steward JWT → owner cloud
  * API key), read here from boot config because this module has no client handle.
- * The Cloud API accepts both a Steward JWT and the owner API key. Web stays
- * byte-identical (steward token or nothing, exactly as before).
+ * The Cloud API accepts both a Steward JWT and the owner API key. On web the
+ * fallback never applies — it resolves to the steward token or nothing.
  */
 function readCloudBearerToken(): string | null {
   const stewardToken = readStewardToken()?.trim();
@@ -416,9 +416,9 @@ export async function apiFetch(
     // A 401 on an authed call means our session was rejected (token revoked or
     // expired out from under the proactive refresh). Nudge the Steward runtime
     // to refresh-or-clear so a stale session self-heals instead of leaving the
-    // UI "authed" until the next interaction. Purely additive — the call still
-    // throws ApiError exactly as before; the listener is single-flight and never
-    // retries the request.
+    // UI "authed" until the next interaction. The nudge is a side effect only:
+    // the call still throws ApiError, and the listener is single-flight and
+    // never retries the request.
     if (res.status === 401 && !skipAuth && typeof window !== "undefined") {
       try {
         window.dispatchEvent(new CustomEvent("steward-unauthorized"));

--- a/packages/ui/src/cloud/lib/auth-query.test.tsx
+++ b/packages/ui/src/cloud/lib/auth-query.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * The shared `useAuthenticatedQueryGate` resolving its session from the
+ * persisted localStorage JWT only — the page-reload reality where the Steward
+ * SDK context's MemoryStorage session is empty and no provider is mounted.
+ * `@capacitor/core` is doubled to exercise both web and native platforms.
+ */
+
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/ui/src/cloud/lib/jwt.ts
+++ b/packages/ui/src/cloud/lib/jwt.ts
@@ -4,8 +4,8 @@
  * The cloud surfaces only ever inspect the *unverified* payload (its `exp` plus
  * a few identity claims) to decide whether a locally stored session still looks
  * live before the server confirms it. Signature verification is the server's
- * job. Every cloud domain previously reimplemented the same base64url decode;
- * they all delegate here now so the null/expired semantics stay identical.
+ * job. Every cloud domain delegates here so the null/expired semantics stay
+ * identical across surfaces.
  */
 
 /** Claims the cloud surfaces read off a Steward session token. */

--- a/packages/ui/src/cloud/mcps/McpsRoute.test.tsx
+++ b/packages/ui/src/cloud/mcps/McpsRoute.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * `McpsSurface` session resolution: the MCPs view renders when the session
+ * exists only as the persisted JWT (the page-reload reality, no Steward
+ * provider mounted), stays gated with no persisted session, and rejects an
+ * expired token. The i18n provider and `McpsView` are stubbed to isolate the gate.
+ */
+
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/cloud/public-pages/pages/app-auth/app-authorize-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/app-auth/app-authorize-page.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * `AppAuthAuthorizePage` mounts `AuthorizeContent` inside `StewardAuthProvider`
+ * so `useAuth()` resolves on this public route (#9881). The provider,
+ * authorize-content, i18n provider, and page-title hook are doubled to isolate
+ * the wiring.
+ */
+
 import { cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/ui/src/cloud/public-pages/pages/auth/auth-success-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/auth-success-page.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * `AuthSuccessPage` opener handling: it auto-closes and shows close
+ * instructions only when the page has a live `window.opener`, and otherwise
+ * never calls `window.close`. The router and i18n provider are doubled.
+ */
+
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
@@ -1,5 +1,14 @@
 // @vitest-environment jsdom
 
+/**
+ * `CliLoginPage` device-login flow: an unauthenticated visitor is redirected
+ * straight to /login (no CLI interstitial) with a per-session guard so it never
+ * loops; an authenticated visitor POSTs /complete, notifies the opener, and
+ * shows success without redirecting or closing; a missing session id or a
+ * completion failure renders the error panel with no POST. The router,
+ * session-auth hook, api-client, Steward provider, and i18n are doubled.
+ */
+
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * `EmailCallbackPage` mounts the magic-link callback inside `StewardAuthProvider`
+ * so the verify actually runs instead of dead-ending on "unavailable". The
+ * Steward provider, i18n provider, page-title hook, session helper, and
+ * authorize-return/brand-button are doubled to isolate the mount.
+ */
+
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
@@ -14,11 +21,11 @@ const { verifyEmailCallback } = vi.hoisted(() => ({
 }));
 
 // Stub StewardAuthProvider with a marker that ALSO supplies the Steward context
-// — what the real provider does once its runtime mounts. This lets us assert
-// both halves of the fix: (a) the callback renders INSIDE the self-mounted
-// provider, and (b) the context reaches it so the magic-link verify runs,
-// instead of the "Sign-in is unavailable" dead-end a first-time visitor hit
-// when this public route had no provider at all (#9881-class).
+// — what the real provider does once its runtime mounts. This lets the test
+// assert both halves: (a) the callback renders INSIDE the self-mounted
+// provider, and (b) the context reaches it so the magic-link verify runs rather
+// than hitting the "Sign-in is unavailable" dead-end that a provider-less
+// public route produces (#9881-class).
 vi.mock("../../../shell/StewardProvider", async () => {
   const { createContext } = await import("react");
   const LocalStewardAuthContext = createContext<unknown>(null);

--- a/packages/ui/src/cloud/public-pages/pages/sensitive-requests/sensitive-request-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/sensitive-requests/sensitive-request-page.test.tsx
@@ -1,5 +1,13 @@
 // @vitest-environment jsdom
 
+/**
+ * `SensitiveRequestPage` image/file upload (#8910): an image field renders as a
+ * file input with camera capture (not filtered out) and delivers the upload as
+ * a base64 data URL through the existing submit path, an over-`maxBytes` upload
+ * is rejected and never submitted, and a non-image field renders without
+ * forcing the camera. The router and api-client are doubled; the page is real.
+ */
+
 import {
   cleanup,
   fireEvent,

--- a/packages/ui/src/cloud/settings/register-cloud-settings.test.ts
+++ b/packages/ui/src/cloud/settings/register-cloud-settings.test.ts
@@ -1,5 +1,13 @@
 // @vitest-environment jsdom
 
+/**
+ * `registerCloudSettingsSections` populates the shared settings-section
+ * registry: the Cloud group lands between System and Security and Developer
+ * between Cloud and Security, plain users see the cloud sections while the
+ * developer sections stay gated, and the cloud Security additions merge into
+ * the security group with non-colliding ids.
+ */
+
 import { beforeAll, describe, expect, it } from "vitest";
 import { listSettingsSections } from "../../components/settings/settings-section-registry";
 import {

--- a/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
@@ -98,7 +98,7 @@ describe("CloudRouterShell apex catch-all (Gate B)", () => {
 
   it("redirects an unauthenticated staging apex visitor to /login", () => {
     // staging.elizacloud.ai is a control-plane apex too — it must behave like
-    // prod (redirect to /login), so staging can validate the fix before prod.
+    // prod and redirect an unauthenticated visitor to /login.
     setHostname("staging.elizacloud.ai");
     renderCatchAll();
     expect(screen.getByTestId("login-page")).toBeTruthy();

--- a/packages/ui/src/cloud/shell/StewardProvider.test.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * `StewardAuthProvider` route-gating: it lazy-loads the Steward auth runtime
+ * only on routes that need auth (app-auth), fails loud on an invalid Steward
+ * URL there, bypasses the runtime entirely on public routes, and shows a
+ * loading state instead of auth-consuming children during the lazy-load (#10680).
+ */
+
 import { act, cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * `AuthTokenSync` 401 handling in the Steward runtime: a still-valid token
+ * survives a session-sync/refresh 401 (no re-login loop) and retries the cookie
+ * sync on the next trigger, while a genuinely expired — or exp-less, thus
+ * never-ageable — token is cleared on a refresh 401 so the session self-heals.
+ */
+
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
@@ -1,15 +1,22 @@
 // @vitest-environment jsdom
 
+/**
+ * Steward auth-endpoint resolution and token-expiry helpers: staging/prod app
+ * hosts route directly to their api worker (never same-origin), unknown hosts
+ * fall back to the same-origin relative path, and `tokenIsExpired` reads the
+ * JWT `exp` claim.
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { tokenIsExpired } from "./StewardProviderShared";
 
 // The Steward auth endpoints are resolved per browser host: co-hosted cloud
 // surfaces bypass the Pages/Worker proxy and call the matching API worker
-// directly. The regression this guards: `staging.elizacloud.ai` used to have no
-// direct mapping, so session-sync + refresh fell through to the same-origin
-// relative path and a stale worker proxy 401'd (then wiped) a valid session —
-// the sign-in loop. Staging MUST resolve to api-staging, not prod api.
+// directly. The invariant under guard: `staging.elizacloud.ai` MUST map to
+// api-staging (not prod api, not the same-origin relative path). Without a
+// direct mapping, session-sync + refresh fall through to a stale worker proxy
+// that 401s and wipes a valid session — the sign-in loop.
 
 function setHostname(hostname: string): void {
   Object.defineProperty(window, "location", {


### PR DESCRIPTION
Comments-only slice of #12235 over `packages/ui/src/cloud` (the app-hosted Eliza Cloud dashboard surfaces in `@elizaos/ui`).

`check:comment-only` passes — every code token is byte-for-byte identical to `origin/develop`; only comments changed.

## What changed (29 files)

**Test files** — added a `/** */` prose header to files that carried only a `// @vitest-environment jsdom` pragma (or a mid-file `//` note), one for each surface under test. Each header states the surface and how real the harness is (which collaborators are doubled vs the real mock-cloud-stack e2e):
- `handoff/{resume-pending-handoff,run-cloud-agent-handoff,silent-repoint}.test.ts`
- `shell/{StewardProvider,StewardProviderRuntime,StewardProviderShared,CloudRouterShell}.test.*`
- `settings/register-cloud-settings.test.ts`, `mcps/McpsRoute.test.tsx`
- `admin/data/use-admin-gate.test.tsx`, `analytics/lib/auth-query.test.tsx`, `lib/{api-client,auth-query}.test.*`
- `applications/components/{BuyDomainCard,app-analytics,app-frontend-hosting,app-monetization-settings,app-promote}.test.tsx`
- `public-pages/pages/{app-auth,auth,sensitive-requests}/*.test.tsx`

**Source files** — rewrote churn/migration-narration headers and in-body comments into present-tense durable fact:
- `applications/components/app-promote.tsx` — dropped the "two larp blocks dropped per the migration scope" story; header now states what the tab renders.
- `lib/jwt.ts`, `lib/api-client.ts` — removed "previously reimplemented" / "byte-identical … exactly as before" narration.
- `applications/lib/native-cloud-nav.ts`, `applications/components/app-domains.tsx` — "as before" → plain present tense.
- `connectors/CloudConnectorsSection.tsx` — dropped the speculative "designed so it can later branch … for now" note.
- `shell/StewardProviderShared.test.ts`, `shell/CloudRouterShell.test.tsx` — regression rationale phrased as the present invariant under guard.

## Scope notes
- `handoff/pending-handoff-store.ts` was left to `origin/develop` — a concurrent chunk already converted its `//` header to `/** */`.
- Files already at the header bar (e.g. `NativeAppsStudio.test.tsx`, the `__e2e__` mock-stack test, `register-all.ts`, `organization/*.test.tsx`) were left untouched.

Part of #12235.