### PR TITLE
docs(#12235): prose headers + churn cleanup — b05-api-firstrun-root

### DIFF
--- a/packages/ui/src/App.chat-overlay-first-run.test.tsx
+++ b/packages/ui/src/App.chat-overlay-first-run.test.tsx
@@ -5,10 +5,10 @@
  *
  * The desktop bottom bar boots the renderer with `?shellMode=chat-overlay`,
  * which takes App's early chat-overlay return — it never reaches the full-shell
- * return where `FirstRunConductorMount` (the ONLY thing that seeds the in-chat
- * onboarding greeting/runtime/provider/tutorial turns) used to be mounted. A
- * fresh desktop install therefore booted into the bottom bar with no runtime
- * configured and no onboarding ever seeded.
+ * return. `FirstRunConductorMount` (the ONLY thing that seeds the in-chat
+ * onboarding greeting/runtime/provider/tutorial turns) must therefore mount on
+ * the chat-overlay branch too, or a fresh desktop install boots into the bottom
+ * bar with no runtime configured and no onboarding ever seeded.
  *
  * These tests mount the REAL App with `?shellMode=chat-overlay` and pin the
  * composition contract:

--- a/packages/ui/src/App.cloud-shell.test.tsx
+++ b/packages/ui/src/App.cloud-shell.test.tsx
@@ -2,9 +2,8 @@
  * Standalone chat-overlay window-shell wiring test.
  *
  * Source-level invariants for the detached chat-overlay shell and how it is
- * classified and navigated. (The former pre-agent crystal-ball home backdrop
- * and the home screen have been removed; the app now lands on /onboarding and
- * then /chat.)
+ * classified and navigated: the app lands on /onboarding and then /chat, with
+ * no pre-agent home backdrop or home screen. Scans App source, no runtime.
  */
 
 import { readFileSync } from "node:fs";

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Unit coverage for App-level navigate-view event wiring: a dispatched
+ * navigate-view event drives the tab switch through the rendered shell. Boot
+ * config + desktop tabs mocked, no runtime.
+ */
+
 import { createNavigateViewEvent } from "@elizaos/shared/events";
 import {
   cleanup,

--- a/packages/ui/src/App.safe-area-fill.test.ts
+++ b/packages/ui/src/App.safe-area-fill.test.ts
@@ -1,21 +1,22 @@
-// Source-level guard for the SAFE-AREA FILL INVARIANT (see the big comment on
-// the shell root in App.tsx). Every view must fill edge-to-edge UNDER the notch
-// while content stays notch-aware. That works because:
-//   1. the shell root reserves the notch via `paddingTop: var(--safe-area-top)`
-//      (so content is pushed below the notch), and
-//   2. the background layers (`app-opaque-background` underlay + the shared
-//      AppBackground wallpaper + the settings scrim) are `fixed inset-0`, so they
-//      anchor to the VIEWPORT and paint the full notch band — NOT the padded box.
-//
-// The whole guarantee collapses the instant the shell root acquires a property
-// that establishes a containing block for `position: fixed` descendants
-// (transform / filter / backdrop-filter / perspective / will-change / paint or
-// layout `contain`). Then the fixed layers anchor to the padded root box
-// (top = safe-area-top) and an unfilled band re-appears under the notch (the
-// WKWebView host color — brand orange — shows through). This is exactly the bug
-// the old build had before the opaque underlay landed. This test fails CI if any
-// of those properties creep onto the root, or if a background layer stops being
-// `fixed inset-0`.
+/**
+ * Source-level guard for the SAFE-AREA FILL INVARIANT (see the big comment on
+ * the shell root in App.tsx). Every view must fill edge-to-edge UNDER the notch
+ * while content stays notch-aware. That works because:
+ *   1. the shell root reserves the notch via `paddingTop: var(--safe-area-top)`
+ *      (so content is pushed below the notch), and
+ *   2. the background layers (`app-opaque-background` underlay + the shared
+ *      AppBackground wallpaper + the settings scrim) are `fixed inset-0`, so they
+ *      anchor to the VIEWPORT and paint the full notch band — NOT the padded box.
+ *
+ * The whole guarantee collapses the instant the shell root acquires a property
+ * that establishes a containing block for `position: fixed` descendants
+ * (transform / filter / backdrop-filter / perspective / will-change / paint or
+ * layout `contain`). Then the fixed layers anchor to the padded root box
+ * (top = safe-area-top) and an unfilled band re-appears under the notch (the
+ * WKWebView host color — brand orange — shows through). This test fails CI if
+ * any of those properties creep onto the root, or if a background layer stops
+ * being `fixed inset-0`. Scans App.tsx source, no runtime.
+ */
 
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";

--- a/packages/ui/src/App.screen-background-fuzz.test.tsx
+++ b/packages/ui/src/App.screen-background-fuzz.test.tsx
@@ -1,34 +1,36 @@
 // @vitest-environment jsdom
-//
-// Fuzz test for the screen / background color invariant across view switching.
-//
-// The unified app background (`AppBackground`) is mounted ONCE at the shell root
-// and is driven purely by the persisted background config — so navigating
-// between views must NEVER change the screen color. Each route resolves a
-// background policy (`useActiveScreenBackgroundPolicy`) to exactly one painted
-// layer:
-//
-//   • `app-background-shader` / `app-background-image` / `app-background-glsl`
-//     — the persisted wallpaper shows through (policy "shared"). The screen
-//     color === the user's chosen background color.
-//   • `app-opaque-background` — an opaque `bg-bg` underlay covers the wallpaper
-//     (policy "opaque"). The screen color === the theme base.
-//
-// This file mounts the REAL <App/> (same harness as App.navigate-view-wiring)
-// and fuzzes randomized walks over EVERY builtin tab, returning to the launcher
-// (`/views`) between every view, asserting after every transition:
-//
-//   A. Exactly one background layer renders (shader/image/glsl XOR opaque) —
-//      the screen color is always defined; never blank, never two conflicting layers.
-//   B. When the wallpaper shows, its color === the seeded persisted color —
-//      switching views never mutates the user's background color.
-//   C. The known-shared surfaces (chat, background, settings, /views,
-//      /apps) always show the wallpaper — never the opaque underlay.
-//   D. Returning to the launcher (`/views`) always restores the wallpaper,
-//      regardless of which (possibly opaque) view preceded it.
-//
-// Runs the whole fuzz under shader, image, and programmable GLSL configs so
-// every wallpaper kind is proven to survive every transition.
+
+/**
+ * Fuzz test for the screen / background color invariant across view switching.
+ *
+ * The unified app background (`AppBackground`) is mounted ONCE at the shell root
+ * and is driven purely by the persisted background config — so navigating
+ * between views must NEVER change the screen color. Each route resolves a
+ * background policy (`useActiveScreenBackgroundPolicy`) to exactly one painted
+ * layer:
+ *
+ *   • `app-background-shader` / `app-background-image` / `app-background-glsl`
+ *     — the persisted wallpaper shows through (policy "shared"). The screen
+ *     color === the user's chosen background color.
+ *   • `app-opaque-background` — an opaque `bg-bg` underlay covers the wallpaper
+ *     (policy "opaque"). The screen color === the theme base.
+ *
+ * Mounts the REAL <App/> (same harness as App.navigate-view-wiring) and fuzzes
+ * randomized walks over EVERY builtin tab, returning to the launcher (`/views`)
+ * between every view, asserting after every transition:
+ *
+ *   A. Exactly one background layer renders (shader/image/glsl XOR opaque) —
+ *      the screen color is always defined; never blank, never two conflicting layers.
+ *   B. When the wallpaper shows, its color === the seeded persisted color —
+ *      switching views never mutates the user's background color.
+ *   C. The known-shared surfaces (chat, background, settings, /views,
+ *      /apps) always show the wallpaper — never the opaque underlay.
+ *   D. Returning to the launcher (`/views`) always restores the wallpaper,
+ *      regardless of which (possibly opaque) view preceded it.
+ *
+ * Runs the whole fuzz under shader, image, and programmable GLSL configs so
+ * every wallpaper kind is proven to survive every transition.
+ */
 
 import { act, cleanup, render } from "@testing-library/react";
 import type * as React from "react";

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,5 +1,9 @@
 /**
- * Root App component — routing shell.
+ * Root App component and the dashboard routing shell mounted by every elizaOS
+ * front-end. It resolves the shell mode from the URL (`?shellMode=` — `full`,
+ * `chat-overlay`, `voice-*`), gates boot/pairing behind `StartupScreen`, mounts
+ * the shared `AppBackground` and first-run conductor once, and renders either
+ * the floating chat-overlay surface or the full tabbed shell.
  */
 
 import {

--- a/packages/ui/src/api/client-agent-pty-input.test.ts
+++ b/packages/ui/src/api/client-agent-pty-input.test.ts
@@ -1,9 +1,11 @@
-// Regression: pasting >4096 chars into the web terminal was silently
-// discarded. xterm delivers a paste as ONE onData chunk, the client sent it
-// as ONE ws message, and the agent server drops any pty-input whose data
-// exceeds its 4096-char per-message cap (DoS protection) with only a server
-// log. sendPtyInput must therefore split oversized input into ordered
-// <=4096-char messages that reassemble to the full paste.
+/**
+ * Unit coverage for `chunkPtyInput` / `sendPtyInput` splitting oversized web-
+ * terminal input into ordered <=4096-char WS messages. xterm delivers a paste
+ * as ONE onData chunk and the agent server silently drops any pty-input over
+ * its 4096-char per-message cap (DoS protection), so a large paste must be
+ * split into pieces that reassemble to the full paste. Transport stubbed, no
+ * live agent.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setBootConfig } from "../config/boot-config";
 import { chunkPtyInput, MAX_PTY_INPUT_CHUNK_LENGTH } from "./client-agent";

--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * Unit coverage for the base client's WebSocket lifecycle and the
+ * network-status-change event it emits. WebSocket stubbed, no live server.
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { NETWORK_STATUS_CHANGE_EVENT } from "../events";
 import { __resetNetworkStatusForTests, ElizaClient } from "./client-base";

--- a/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
+++ b/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
@@ -1,25 +1,28 @@
 // @vitest-environment jsdom
-// Mock-cloud connect e2e (#8621 / #8387): the REAL client connect path —
-// selectOrProvisionCloudAgent → cold-boot wait → base resolution → chat REST
-// round-trip — driven against a REAL HTTP server that implements the cloud
-// control plane + dedicated-agent-proxy semantics (202/Retry-After) + the
-// shared-runtime REST adapter. Nothing on the client side is stubbed except
-// @capacitor/core platform detection (this lane is the non-native web path;
-// CapacitorHttp is never used on it).
-//
-// Covered:
-//  - G1: a reused DEDICATED agent that is not `running` triggers a resume kick
-//    and a control-plane poll (progress streamed via onProgress) before the
-//    dedicated base is bound; the post-wake record's fresh URL wins.
-//  - error path: a terminal `error` status fails fast with the agent's
-//    error_message; timeout path: a never-booting agent fails with an
-//    actionable message instead of hanging.
-//  - composition with the 202 honor in client-base: the dedicated proxy
-//    answering 202 + Retry-After on the first authed call after wake is
-//    retried transparently.
-//  - G2 (#8387): a SHARED agent with no URLs in the list DTO derives the
-//    REST-adapter base and completes a real conversation round-trip
-//    (health → create → send → list messages) with the cloud bearer token.
+
+/**
+ * Mock-cloud connect e2e (#8621 / #8387): the REAL client connect path —
+ * selectOrProvisionCloudAgent → cold-boot wait → base resolution → chat REST
+ * round-trip — driven against a REAL HTTP server that implements the cloud
+ * control plane + dedicated-agent-proxy semantics (202/Retry-After) + the
+ * shared-runtime REST adapter. Nothing on the client side is stubbed except
+ * @capacitor/core platform detection (this lane is the non-native web path;
+ * CapacitorHttp is never used on it).
+ *
+ * Covered:
+ *  - G1: a reused DEDICATED agent that is not `running` triggers a resume kick
+ *    and a control-plane poll (progress streamed via onProgress) before the
+ *    dedicated base is bound; the post-wake record's fresh URL wins.
+ *  - error path: a terminal `error` status fails fast with the agent's
+ *    error_message; timeout path: a never-booting agent fails with an
+ *    actionable message instead of hanging.
+ *  - composition with the 202 honor in client-base: the dedicated proxy
+ *    answering 202 + Retry-After on the first authed call after wake is
+ *    retried transparently.
+ *  - G2 (#8387): a SHARED agent with no URLs in the list DTO derives the
+ *    REST-adapter base and completes a real conversation round-trip
+ *    (health → create → send → list messages) with the cloud bearer token.
+ */
 
 import { createServer, type Server } from "node:http";
 import {

--- a/packages/ui/src/api/client-cloud-direct-auth-web.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth-web.test.ts
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * Unit coverage for direct-Cloud auth on hosted web (non-native path). Capacitor
+ * forced to web + CapacitorHttp mocked, fetch stubbed, no live cloud.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@capacitor/core", () => ({

--- a/packages/ui/src/api/client-cloud-steward-refresh-native.test.ts
+++ b/packages/ui/src/api/client-cloud-steward-refresh-native.test.ts
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * Unit coverage for refreshing the Steward session token on native builds.
+ * Capacitor forced native + CapacitorHttp mocked, no live cloud.
+ */
+
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/ui/src/api/client-cloud-steward-token.test.ts
+++ b/packages/ui/src/api/client-cloud-steward-token.test.ts
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * Unit coverage for reading the Steward session token and computing its
+ * seconds-remaining from the JWT `exp`. Tokens hand-built, no live cloud.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ElizaClient } from "./client-base";
 import { cloudTokenSecsRemaining, getCloudAuthToken } from "./client-cloud";

--- a/packages/ui/src/api/client-cloud-web-join-base.test.ts
+++ b/packages/ui/src/api/client-cloud-web-join-base.test.ts
@@ -1,5 +1,14 @@
 // @vitest-environment jsdom
 
+/**
+ * Unit coverage for direct-Cloud base resolution during the hosted-web `/join`
+ * flow: a signed-in Steward session with NO agent baseUrl yet. The base must
+ * resolve from the PAGE host so `getCloudCompatAgents` hits the cloud worker
+ * rather than the agent-proxy path (`/api/cloud/compat/agents`), which only
+ * agent servers mount. Capacitor forced web + CapacitorHttp mocked, fetch
+ * stubbed, no live cloud.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@capacitor/core", () => ({
@@ -15,14 +24,6 @@ vi.mock("@capacitor/core", () => ({
 
 import { ElizaClient } from "./client-base";
 import "./client-cloud";
-
-// The /join flow's exact client state on hosted web: a signed-in Steward
-// session (token global set by selectOrProvisionCloudAgent) but NO agent
-// baseUrl yet. The direct-cloud base must resolve from the PAGE host — when it
-// resolved to null, getCloudCompatAgents fell through to the agent-proxy path
-// /api/cloud/compat/agents, which only agent servers mount; the cloud worker
-// 404s it and every web sign-in dead-ended on "Couldn't connect to your
-// agent".
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {

--- a/packages/ui/src/api/desktop-external-api-base.test.ts
+++ b/packages/ui/src/api/desktop-external-api-base.test.ts
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * Unit coverage for reading and validating the desktop-injected external API
+ * base origin from the window global. Window global stubbed, no real shell.
+ */
+
 import { afterEach, describe, expect, it } from "vitest";
 import {
   getDesktopExternalApiBaseOrigin,

--- a/packages/ui/src/app-navigate-view.branches.test.ts
+++ b/packages/ui/src/app-navigate-view.branches.test.ts
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * Branch coverage for `createNavigateViewHandler()` beyond `app-navigate-
+ * view.test.ts`: the early-return guards, viewPath-only navigation, and viewId
+ * navigation resolving a registry entry that is neither pin-tab nor
+ * desktopTabEnabled (navigates without opening a desktop tab). No runtime.
+ */
+
 import {
   createNavigateViewEvent,
   NAVIGATE_VIEW_EVENT,
@@ -10,11 +17,6 @@ import {
   type DesktopBridgeRequest,
 } from "./app-navigate-view";
 import type { ViewRegistryEntry } from "./hooks/useAvailableViews";
-
-// Branch coverage for createNavigateViewHandler() that app-navigate-view.test.ts
-// does not exercise: the early-return guards, viewPath-only navigation, and
-// viewId navigation that resolves a registry entry which is neither pin-tab nor
-// desktopTabEnabled (must navigate without opening a desktop tab).
 
 function view(patch: Partial<ViewRegistryEntry> = {}): ViewRegistryEntry {
   return {

--- a/packages/ui/src/app-navigate-view.test.ts
+++ b/packages/ui/src/app-navigate-view.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Unit coverage for the navigate-view helpers: payload consume, path
+ * derivation, direct-tab resolution, and the handler that opens registered
+ * views or desktop tabs. Pure functions + injected bridge, no runtime.
+ */
+
 import { createNavigateViewEvent } from "@elizaos/shared/events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {

--- a/packages/ui/src/cache-telemetry.test.ts
+++ b/packages/ui/src/cache-telemetry.test.ts
@@ -1,4 +1,11 @@
 // @vitest-environment jsdom
+
+/**
+ * Unit coverage for the module-cache eviction telemetry stream (#10196): heap-
+ * pressure accounting and bounded dispatch of the eviction events emitted by
+ * the retained-lazy loader. In-memory ring, no real modules.
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   emitModuleCacheTelemetry,
@@ -6,12 +13,6 @@ import {
   type ModuleCacheTelemetryEvent,
 } from "./cache-telemetry";
 
-/**
- * Consumes the module-cache eviction telemetry (#10196). This is the stream that
- * is supposed to prove module eviction tracks REAL heap growth (not just the
- * static device-RAM tier); it was emitted but asserted by no test, so the
- * heap-pressure accounting + bounded dispatch were unverified.
- */
 type Ring = ModuleCacheTelemetryEvent[];
 type CacheGlobal = typeof globalThis & {
   __ELIZA_MODULE_CACHE_TELEMETRY__?: Ring;

--- a/packages/ui/src/first-run/first-run.test.ts
+++ b/packages/ui/src/first-run/first-run.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment jsdom
 
-// Deterministic first-run helpers: draft normalization, runtime-target
-// mapping, submit validation, and the /api/first-run payload builder.
+/**
+ * Unit coverage for the deterministic first-run helpers: draft normalization,
+ * runtime-target mapping, submit validation, and the /api/first-run payload
+ * builder. Pure functions, no runtime.
+ */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {

--- a/packages/ui/src/first-run/first-run.ts
+++ b/packages/ui/src/first-run/first-run.ts
@@ -1,10 +1,9 @@
 /**
  * Deterministic first-run helpers shared by the in-chat onboarding conductor
  * and the headless finish path: draft normalization, runtime-target mapping,
- * submit validation, and the POST /api/first-run payload builder. The old
- * wizard's step machine, persisted step/draft state, and voice-transcript
- * routing were deleted with the wizard itself (#12178); onboarding state now
- * lives in the conductor's refs plus `firstRunComplete`.
+ * submit validation, and the POST /api/first-run payload builder. Onboarding
+ * is in-chat (#12178): there is no wizard step machine or persisted step/draft
+ * state — onboarding state lives in the conductor's refs plus `firstRunComplete`.
  */
 
 import {

--- a/packages/ui/src/first-run/mobile-runtime-mode.test.ts
+++ b/packages/ui/src/first-run/mobile-runtime-mode.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Unit coverage for persisting the mobile runtime mode (including the
+ * server-target derivation). Capacitor Preferences + native detection mocked,
+ * no real device.
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   MOBILE_RUNTIME_MODE_STORAGE_KEY,

--- a/packages/ui/src/first-run/pre-seed-local-runtime.test.ts
+++ b/packages/ui/src/first-run/pre-seed-local-runtime.test.ts
@@ -1,10 +1,13 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+/**
+ * Unit coverage for the decision matrix in `preSeedAndroidLocalRuntimeIfFresh`:
+ * it seeds the on-device local agent only when the device IS the local agent
+ * and nothing has already chosen a server/runtime. Capacitor + platform mocked,
+ * no real device.
+ */
 
-// Decision matrix for `preSeedAndroidLocalRuntimeIfFresh`: it should seed the
-// on-device local agent only when the device IS the local agent and nothing
-// has already chosen a server/runtime.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   capacitorPlatform: "web" as string,

--- a/packages/ui/src/first-run/probe-local-agent.ts
+++ b/packages/ui/src/first-run/probe-local-agent.ts
@@ -1,6 +1,4 @@
 /**
- * probe-local-agent.ts
- *
  * Liveness probe for an on-device Eliza agent.
  *
  * Android reaches the bundled foreground service over loopback. iOS reaches

--- a/packages/ui/src/first-run/reconcile-mobile-runtime-mode.test.ts
+++ b/packages/ui/src/first-run/reconcile-mobile-runtime-mode.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Unit coverage for boot-time reconciliation of a stale persisted mobile
+ * runtime mode against the build's native truth (the #11030 splash-hang guard).
+ * Capacitor Preferences + native detection mocked, no real device.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MOBILE_RUNTIME_MODE_STORAGE_KEY } from "./mobile-runtime-mode";
 import {

--- a/packages/ui/src/first-run/reconcile-mobile-runtime-mode.ts
+++ b/packages/ui/src/first-run/reconcile-mobile-runtime-mode.ts
@@ -1,6 +1,4 @@
 /**
- * reconcile-mobile-runtime-mode.ts
- *
  * Boot-time reconciliation between the persisted `eliza:mobile-runtime-mode`
  * and the runtime truth stamped into this build (issue #11030).
  *

--- a/packages/ui/src/first-run/use-first-run-conductor.fuzz.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.fuzz.test.ts
@@ -1,25 +1,27 @@
 // @vitest-environment jsdom
 
-// Confused-user fuzz for the in-chat first-run conductor: seeded random storms
-// of valid, duplicated, out-of-order, and malformed picks — exactly what a
-// user who doesn't understand the flow (or a flaky trackpad) produces. The
-// REAL conductor + REAL finish use case run underneath; mocks sit only at the
-// network boundary. Deterministic: every storm derives from a fixed seed, so a
-// failure reproduces exactly.
-//
-// The storm also interleaves free-text sends (#12178 composer unlock): typed
-// text is answered by the conductor's local echo persona and must NEVER reach
-// the server, so the pick invariants below hold under mixed pick+text storms.
-//
-// Invariants (the "rock solid" contract):
-//   I1  POST /api/first-run fires at most once per onboarding session.
-//   I2  At most one cloud provisioning call per session.
-//   I3  completeFirstRun (the real gate flip) fires at most once.
-//   I4  Every reserved-prefix value is consumed (never falls through to chat).
-//   I5  Pick spam adds no turns beyond the bounded set; each free text adds
-//       exactly one user + one reply (both acknowledged, never deduped away).
-//   I6  No unhandled rejection escapes (vitest fails the file if one does).
-//   I7  Typed free text never triggers a server send (folded into I1/I2).
+/**
+ * Confused-user fuzz for the in-chat first-run conductor: seeded random storms
+ * of valid, duplicated, out-of-order, and malformed picks — exactly what a
+ * user who doesn't understand the flow (or a flaky trackpad) produces. The
+ * REAL conductor + REAL finish use case run underneath; mocks sit only at the
+ * network boundary. Deterministic: every storm derives from a fixed seed, so a
+ * failure reproduces exactly.
+ *
+ * The storm also interleaves free-text sends (#12178 composer unlock): typed
+ * text is answered by the conductor's local echo persona and must NEVER reach
+ * the server, so the pick invariants below hold under mixed pick+text storms.
+ *
+ * Invariants (the "rock solid" contract):
+ *   I1  POST /api/first-run fires at most once per onboarding session.
+ *   I2  At most one cloud provisioning call per session.
+ *   I3  completeFirstRun (the real gate flip) fires at most once.
+ *   I4  Every reserved-prefix value is consumed (never falls through to chat).
+ *   I5  Pick spam adds no turns beyond the bounded set; each free text adds
+ *       exactly one user + one reply (both acknowledged, never deduped away).
+ *   I6  No unhandled rejection escapes (vitest fails the file if one does).
+ *   I7  Typed free text never triggers a server send (folded into I1/I2).
+ */
 
 import { renderHook, waitFor } from "@testing-library/react";
 import * as React from "react";

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
 
-// The in-chat first-run conductor, driven through its REAL public seams: the
-// hook is mounted (registering its handler on the first-run action channel),
-// picks arrive via `tryHandleFirstRunAction` exactly as the chat send funnel
-// delivers them, and the REAL finish use case (`first-run-finish.ts`) runs
-// underneath. Mocks sit only at the network boundary (the shared `client`
-// singleton + the background model download).
+/**
+ * The in-chat first-run conductor, driven through its REAL public seams: the
+ * hook is mounted (registering its handler on the first-run action channel),
+ * picks arrive via `tryHandleFirstRunAction` exactly as the chat send funnel
+ * delivers them, and the REAL finish use case (`first-run-finish.ts`) runs
+ * underneath. Mocks sit only at the network boundary (the shared `client`
+ * singleton + the background model download).
+ */
 
 import { renderHook, waitFor } from "@testing-library/react";
 import * as React from "react";

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -12,12 +12,11 @@
  * channel so the chat's single send funnel short-circuits first-run picks
  * before they hit the server.
  *
- * The composer is UNLOCKED during onboarding (#12178, a deliberate reversal of
- * the #9952 onboarding lock): the user can type freely, and a second channel
- * handler (`setFirstRunTextHandler`) answers that free text with a local user
- * turn + a deterministic assistant reply that varies by flow position. Free
- * text NEVER reaches the server pre-completion — the AppContext funnel enforces
- * that; this hook only renders the local echo.
+ * The composer is UNLOCKED during onboarding (#12178): the user can type
+ * freely, and a second channel handler (`setFirstRunTextHandler`) answers that
+ * free text with a local user turn + a deterministic assistant reply that
+ * varies by flow position. Free text NEVER reaches the server pre-completion —
+ * the AppContext funnel enforces that; this hook only renders the local echo.
  *
  * Provisioning runs exactly once and POSTs /api/first-run exactly once (the
  * finish module funnels + idempotency-guards it). The real `firstRunComplete`

--- a/packages/ui/src/first-run/use-microphone-permission.ts
+++ b/packages/ui/src/first-run/use-microphone-permission.ts
@@ -1,11 +1,4 @@
 /**
- * Hook for microphone permission in voice-first onboarding (see block below).
- */
-import type { PermissionStatus } from "@elizaos/shared";
-import * as React from "react";
-import { client } from "../api";
-
-/**
  * Microphone permission for voice-first onboarding.
  *
  * Wraps the cross-platform permission client (`client.requestPermission` /
@@ -17,6 +10,9 @@ import { client } from "../api";
  * None of these paths throw: every failure resolves to a concrete state so the
  * onboarding UI can always render an actionable affordance.
  */
+import type { PermissionStatus } from "@elizaos/shared";
+import * as React from "react";
+import { client } from "../api";
 
 const MICROPHONE = "microphone" as const;
 

--- a/packages/ui/src/first-run/use-model-status-conductor.test.ts
+++ b/packages/ui/src/first-run/use-model-status-conductor.test.ts
@@ -1,10 +1,12 @@
 // @vitest-environment jsdom
 
-// The in-chat model-status conductor, driven through its real seams: the hook
-// is mounted with a HomeModelStatus, seeds/refreshes ONE `model:download-status`
-// turn into the transcript, and its `__model__:` controls arrive via
-// `tryHandleModelAction` exactly as the chat send funnel delivers them. Mocks
-// sit only at the network boundary (the shared `client` singleton).
+/**
+ * The in-chat model-status conductor, driven through its real seams: the hook
+ * is mounted with a HomeModelStatus, seeds/refreshes ONE `model:download-status`
+ * turn into the transcript, and its `__model__:` controls arrive via
+ * `tryHandleModelAction` exactly as the chat send funnel delivers them. Mocks
+ * sit only at the network boundary (the shared `client` singleton).
+ */
 
 import { renderHook, waitFor } from "@testing-library/react";
 import * as React from "react";

--- a/packages/ui/src/first-run/use-model-status-conductor.ts
+++ b/packages/ui/src/first-run/use-model-status-conductor.ts
@@ -1,5 +1,5 @@
 /**
- * In-chat model-status conductor (headless) — #12178 WI-4.
+ * In-chat model-status conductor (headless) (#12178).
  *
  * While the local text model is not yet ready (missing / downloading / loading
  * / error), this hook keeps ONE live system turn (`model:download-status`) in

--- a/packages/ui/src/retained-lazy.test.tsx
+++ b/packages/ui/src/retained-lazy.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Unit coverage for the retained-lazy loader: modules stay resolved across
+ * unmount/remount, cache-eviction telemetry fires, and app-pause frees them.
+ * React Testing Library render, no real module graph.
+ */
+
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {

--- a/packages/ui/src/view-runtime-telemetry.test.ts
+++ b/packages/ui/src/view-runtime-telemetry.test.ts
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+
+/**
+ * Unit coverage for per-view runtime telemetry: the bounded event ring, its
+ * install/reset, and the emit/read surface (#10202). In-memory ring, no runtime.
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   __resetViewRuntimeTelemetryForTests,

--- a/packages/ui/src/view-telemetry.test.ts
+++ b/packages/ui/src/view-telemetry.test.ts
@@ -1,4 +1,11 @@
 // @vitest-environment jsdom
+
+/**
+ * Unit coverage for view-launcher interaction telemetry: the bounded event ring
+ * and the emit/read surface (including conversation-swipe jank). In-memory ring,
+ * no runtime.
+ */
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { FrameBudgetSummary } from "./hooks/frame-budget";
 import {


### PR DESCRIPTION
Comments-only slice of #12235 covering chunk **b05-api-firstrun-root**:
`packages/ui/src/api`, `packages/ui/src/first-run`, and top-level
`packages/ui/src/` root files not owned by another chunk.

## What changed (39 files, comments only)

- **Banner → prose headers.** Converted `// ----` / `// ====` top-of-file
  banners to single `/** … */` prose blocks: `api/client-types-*` partitions +
  barrel, the first-run conductors (`use-first-run-conductor`,
  `use-model-status-conductor`, `first-run-finish`, `first-run-cloud-resume`),
  and root `index.ts` / `styles.ts` / `registry-host.ts` /
  `App.safe-area-fill` / `App.screen-background-fuzz`.
- **Missing test headers.** Added 1–3 line surface/harness headers to test
  files that had only a `@vitest-environment` pragma + imports
  (cloud direct-auth-web / steward-token / steward-refresh-native / web-join /
  websocket / pty-input / desktop-external-api-base / navigate-view / cache- &
  view-telemetry / retained-lazy / mobile-runtime-mode / reconcile / pre-seed).
- **De-churn.** Rewrote change-narration into durable present-tense fact
  (`first-run.ts` wizard-removal note, `first-run-finish.ts` extraction note,
  `cache-telemetry` / `client-agent-pty-input` / `client-cloud-web-join-base`
  regression prose, `App.chat-overlay-first-run` / `App.cloud-shell` tests).
- **Trim.** Removed filename-repeating first lines
  (`probe-local-agent`, `reconcile-mobile-runtime-mode`) and a redundant
  "see block below" pointer (`use-microphone-permission`); enriched the thin
  `App.tsx` shell header.

## Verification

`node scripts/assert-comment-only-diff.mjs` → **OK, 39 source files changed,
every code token identical to `origin/develop`. Comments only.** Zero
functional diff.

Part of #12235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)