### PR TITLE
fix(feed): preserve Request data in guarded A2A fetch

### DIFF
--- a/packages/feed/packages/agents/src/plugins/feed/guarded-fetch.test.ts
+++ b/packages/feed/packages/agents/src/plugins/feed/guarded-fetch.test.ts
@@ -36,6 +36,29 @@ describe("Feed A2A guardedFetch SSRF guard (#12229 L9)", () => {
     expect(injected).toBe("k");
   });
 
+  test("createGuardedFetchImpl preserves Request headers before applying auth headers", async () => {
+    let existing: string | null = null;
+    let injected: string | null = null;
+    const impl = createGuardedFetchImpl((headers) => {
+      existing = headers.get("x-existing");
+      headers.set("x-feed-api-key", "k");
+      injected = headers.get("x-feed-api-key");
+    });
+
+    await expect(
+      impl(
+        new Request("http://169.254.169.254/tasks", {
+          method: "POST",
+          headers: { "x-existing": "v" },
+          body: "payload",
+        }),
+      ),
+    ).rejects.toThrow(/private|internal|Blocked/i);
+
+    expect(existing).toBe("v");
+    expect(injected).toBe("k");
+  });
+
   test("blocks a blocked internal hostname", async () => {
     await expect(
       guardedFetch("http://metadata.google.internal/agent-card.json"),

--- a/packages/feed/packages/agents/src/plugins/feed/guarded-fetch.ts
+++ b/packages/feed/packages/agents/src/plugins/feed/guarded-fetch.ts
@@ -23,10 +23,10 @@ export async function guardedFetch(
   url: string | URL | Request,
   init?: RequestInit,
 ): Promise<Response> {
-  const target = a2aRequestUrl(url);
+  const { target, requestInit } = a2aRequestParts(url, init);
   const { response, release } = await fetchWithSsrfGuard({
     url: target,
-    ...(init ? { init } : {}),
+    ...(requestInit ? { init: requestInit } : {}),
   });
   // The guard's release() only clears the abort timer we did not set here, so it
   // is a no-op cleanup; call it to honor the contract without holding the socket.
@@ -46,19 +46,35 @@ export function createGuardedFetchImpl(
     url: string | URL | Request,
     init?: RequestInit,
   ): Promise<Response> => {
-    const headers = new Headers(init?.headers);
+    const headers = new Headers(url instanceof Request ? url.headers : undefined);
+    for (const [key, value] of new Headers(init?.headers)) {
+      headers.set(key, value);
+    }
     injectHeaders(headers);
     return guardedFetch(url, { ...init, headers });
   };
   return impl as typeof fetch;
 }
 
-function a2aRequestUrl(url: string | URL | Request): string {
+function a2aRequestParts(
+  url: string | URL | Request,
+  init?: RequestInit,
+): { target: string; requestInit?: RequestInit } {
   if (typeof url === "string") {
-    return url;
+    return { target: url, requestInit: init };
   }
   if (url instanceof URL) {
-    return url.toString();
+    return { target: url.toString(), requestInit: init };
   }
-  return url.url;
+  return {
+    target: url.url,
+    requestInit: {
+      method: url.method,
+      headers: url.headers,
+      body: url.body,
+      signal: url.signal,
+      redirect: url.redirect,
+      ...init,
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- Follow-up to #12572: preserve method/body/signal/redirect and existing Request headers when Feed's A2A guarded fetch receives a Request object.
- Keep injected identity/auth headers layered on top while still routing through the SSRF guard.
- Add a regression test proving Request headers survive before the private-target guard rejects the request.

## Verification
- `bun --conditions=eliza-source test src/plugins/feed/guarded-fetch.test.ts` from `packages/feed/packages/agents`: 7 pass / 0 fail.
- `git diff --check origin/develop...HEAD`: clean.

## Evidence N/A
- Screenshots/video: N/A, server-side Feed A2A fetch wrapper only.
- Real-LLM trajectory: N/A, no prompt/action/model behavior changed.

Refs #12572, #12229