### PR TITLE
fix(#12319): fail closed on FSDP APOLLO routing drift

### DIFF
--- a/.github/issue-evidence/12216-stage2-fsdp-routing/README.md
+++ b/.github/issue-evidence/12216-stage2-fsdp-routing/README.md
@@ -1,0 +1,45 @@
+# Stage 2 FSDP/APOLLO Routing Sanity Evidence
+
+Issue: #12319
+
+## Change Proven
+
+- `train_local.py` now fails closed if APOLLO's pre-FSDP 2-D low-rank
+  parameter names disappear before optimizer construction.
+- The guard catches FSDP flatten/rename cases that would silently route all
+  trainable weights into the non-projected APOLLO group.
+- CPU-only regression tests cover:
+  - normal unwrapped names,
+  - `_fsdp_wrapped_module.` prefix stripping,
+  - flattened FSDP names raising a loud `RuntimeError`.
+
+## Verification
+
+Run from `/Users/shawwalters/eliza-stage2-fsdp-routing` on July 4, 2026:
+
+```bash
+python3 -m pytest packages/training/scripts/test_train_local_low_vram_smoke.py -q
+```
+
+Result:
+
+```text
+.........................                                                [100%]
+```
+
+```bash
+python3 -m py_compile \
+  packages/training/scripts/train_local.py \
+  packages/training/scripts/test_train_local_low_vram_smoke.py
+```
+
+Result: exit code 0.
+
+## Evidence Applicability
+
+- Screenshots/video: N/A. This is a CLI trainer optimizer-routing guard with no
+  UI surface.
+- Live LLM trajectory: N/A. This change does not alter agent behavior,
+  prompts, actions, providers, or model outputs.
+- Backend/frontend logs: N/A. The relevant observable artifact is the trainer
+  failing before optimizer construction on a bad FSDP parameter-name shape.

--- a/packages/training/scripts/test_train_local_low_vram_smoke.py
+++ b/packages/training/scripts/test_train_local_low_vram_smoke.py
@@ -25,6 +25,19 @@ if str(SCRIPTS) not in sys.path:
 train_local = importlib.import_module("train_local")
 
 
+class _FakeParam:
+    def __init__(self, *, requires_grad: bool = True) -> None:
+        self.requires_grad = requires_grad
+
+
+class _FakeModel:
+    def __init__(self, named_params: list[tuple[str, _FakeParam]]) -> None:
+        self._named_params = named_params
+
+    def named_parameters(self):
+        return iter(self._named_params)
+
+
 def _resolve(argv):
     """Drive the same parser + merge pipeline that `train_local.main()` uses.
 
@@ -160,6 +173,42 @@ def test_liger_arch_gate_fails_loud_for_requested_gemma4_unified() -> None:
             requested_mode="on",
             model_type="gemma4_unified",
             architectures=["Gemma4UnifiedForCausalLM"],
+        )
+
+
+def test_apollo_split_preserves_pre_fsdp_lowrank_names() -> None:
+    lowrank, other = train_local._split_named(
+        _FakeModel([
+            ("model.layers.0.mlp.up_proj.weight", _FakeParam()),
+            ("model.layers.0.input_layernorm.weight", _FakeParam()),
+            ("model.layers.0.self_attn.q_proj.weight", _FakeParam(requires_grad=False)),
+        ]),
+        {"model.layers.0.mlp.up_proj.weight"},
+    )
+    assert len(lowrank) == 1
+    assert len(other) == 1
+
+
+def test_apollo_split_strips_fsdp_wrapped_module_prefix() -> None:
+    lowrank, other = train_local._split_named(
+        _FakeModel([
+            ("_fsdp_wrapped_module.model.layers.0.mlp.up_proj.weight", _FakeParam()),
+            ("_fsdp_wrapped_module.model.layers.0.input_layernorm.weight", _FakeParam()),
+        ]),
+        {"model.layers.0.mlp.up_proj.weight"},
+    )
+    assert len(lowrank) == 1
+    assert len(other) == 1
+
+
+def test_apollo_split_fails_when_fsdp_flattens_lowrank_names() -> None:
+    with pytest.raises(RuntimeError, match="APOLLO low-rank routing mismatch"):
+        train_local._split_named(
+            _FakeModel([
+                ("_fsdp_wrapped_module.flat_param", _FakeParam()),
+                ("_fsdp_wrapped_module.model.layers.0.input_layernorm.weight", _FakeParam()),
+            ]),
+            {"model.layers.0.mlp.up_proj.weight"},
         )
 
 

--- a/packages/training/scripts/train_local.py
+++ b/packages/training/scripts/train_local.py
@@ -51,6 +51,7 @@ def _split_named(
     """
     lowrank: list[Any] = []
     other: list[Any] = []
+    matched_lowrank_names: set[str] = set()
     for name, p in model.named_parameters():
         if not p.requires_grad:
             continue
@@ -59,8 +60,20 @@ def _split_named(
         clean = name.replace("_fsdp_wrapped_module.", "")
         if clean in lowrank_names:
             lowrank.append(p)
+            matched_lowrank_names.add(clean)
         else:
             other.append(p)
+    missing_lowrank_names = lowrank_names - matched_lowrank_names
+    if missing_lowrank_names:
+        examples = ", ".join(sorted(missing_lowrank_names)[:5])
+        raise RuntimeError(
+            "APOLLO low-rank routing mismatch after FSDP wrap: "
+            f"matched {len(matched_lowrank_names)}/{len(lowrank_names)} "
+            "pre-FSDP 2-D parameter names. Missing examples: "
+            f"{examples}. This usually means FSDP flattened or renamed "
+            "parameters before optimizer construction; fix FSDP name "
+            "preservation before training."
+        )
     return lowrank, other
 
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- fail closed when pre-FSDP APOLLO low-rank parameter names disappear before optimizer construction
- keep `_fsdp_wrapped_module.` name stripping for valid FSDP-preserved names
- add CPU-only regression coverage for unwrapped, wrapped, and flattened-name routing

Relates to #12319.

## Evidence
- `python3 -m pytest packages/training/scripts/test_train_local_low_vram_smoke.py -q` -> 25 passed
- `python3 -m py_compile packages/training/scripts/train_local.py packages/training/scripts/test_train_local_low_vram_smoke.py` -> exit 0
- `git diff --check origin/develop..HEAD` -> exit 0
- Evidence note: `.github/issue-evidence/12216-stage2-fsdp-routing/README.md`

## Screenshots / Recordings
N/A: CLI trainer optimizer-routing guard, no UI surface.

## Live LLM Trajectory
N/A: no agent behavior, prompt, provider, action, or model-output changes.