### PR TITLE
fix(plugin-sql): fail init on adapter readiness errors

### DIFF
--- a/.github/issue-evidence/12269-plugin-sql-init-error-policy.md
+++ b/.github/issue-evidence/12269-plugin-sql-init-error-policy.md
@@ -1,0 +1,90 @@
+# #12269 Plugin SQL Init Error Policy
+
+## Scope
+
+This chunk covers the `plugin-sql` entry points that decide whether to create a
+database adapter during plugin initialization:
+
+- `plugins/plugin-sql/src/index.ts`
+- `plugins/plugin-sql/src/index.node.ts`
+- `plugins/plugin-sql/src/index.browser.ts`
+
+Before this change, unexpected adapter detection/readiness errors could be
+treated like "no adapter registered", causing plugin init to create a replacement
+adapter and hide the original failure. The entry points now only treat the known
+`Database adapter not registered` runtime error as an absent-adapter signal.
+Other failures are logged and rethrown as `ElizaError` with
+`DB_ADAPTER_READY_CHECK_FAILED`.
+
+## Error Path Evidence
+
+Command run after rebasing on `origin/develop`:
+
+```bash
+bun run --cwd plugins/plugin-sql test -- __tests__/unit/plugin-init-error-policy.test.ts
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       3 passed (3)
+```
+
+The test induces unexpected adapter detection/readiness failures for all three
+entry points and asserts:
+
+- plugin init throws `ElizaError`;
+- the error code is `DB_ADAPTER_READY_CHECK_FAILED`;
+- the original failure is preserved on `.cause`;
+- `registerDatabaseAdapter` is not called after a real readiness/detection
+  failure.
+
+The browser entry point also emitted the structured backend log line:
+
+```text
+[PLUGIN:SQL] Browser database adapter readiness check failed
+```
+
+## Verification Commands
+
+Passed:
+
+```bash
+git fetch origin && git rebase --autostash origin/develop
+bun run --cwd plugins/plugin-sql test -- __tests__/unit/plugin-init-error-policy.test.ts
+bun run --cwd plugins/plugin-sql typecheck
+bun run --cwd plugins/plugin-sql lint:check
+bun run --cwd plugins/plugin-sql build
+bun run audit:error-policy-ratchet
+```
+
+Root verify was attempted:
+
+```bash
+bun run verify
+```
+
+It progressed through the initial AGENTS/CLAUDE check, type-safety ratchet,
+error-policy ratchet, and 88 Turbo tasks before failing in unrelated cloud API
+typecheck:
+
+```text
+Failed: @elizaos/cloud-api#typecheck
+packages/cloud/api/__tests__/hf-proxy-route.test.ts(259,38): error TS2769
+packages/cloud/shared/src/lib/services/market-preview.ts: missing exports from @elizaos/shared
+```
+
+The touched SQL package passed its focused test, typecheck, lint, build, and
+the error-policy ratchet.
+
+## Evidence Matrix
+
+- Screenshots: N/A - no UI surface changed.
+- Video walkthrough: N/A - no UI flow changed.
+- Frontend console/network logs: N/A - no frontend surface changed.
+- Real-LLM trajectories: N/A - no prompt, model, action, provider, or agent
+  behavior changed.
+- Backend logs: included above from the induced plugin init failure.
+- Domain artifacts: plugin init does not create persistent domain artifacts;
+  the test proves adapter registration is skipped when readiness fails.

--- a/plugins/plugin-sql/src/__tests__/unit/plugin-init-error-policy.test.ts
+++ b/plugins/plugin-sql/src/__tests__/unit/plugin-init-error-policy.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit coverage for plugin-sql init error classification. These tests keep
+ * unexpected runtime adapter-readiness failures from being misclassified as an
+ * absent adapter and hidden behind a replacement registration.
+ */
+import type { IAgentRuntime, Plugin, UUID } from "@elizaos/core";
+import { ElizaError } from "@elizaos/core";
+import { v4 as uuidv4 } from "uuid";
+import { describe, expect, it, vi } from "vitest";
+import { plugin as defaultPlugin } from "../../index";
+import { plugin as browserPlugin } from "../../index.browser";
+import { plugin as nodePlugin } from "../../index.node";
+
+type RuntimeStub = IAgentRuntime & {
+  getDatabaseAdapter?: () => never;
+  registerDatabaseAdapter: ReturnType<typeof vi.fn>;
+};
+
+function createRuntimeStub(error: Error): RuntimeStub {
+  const logger = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  return {
+    agentId: uuidv4() as UUID,
+    getDatabaseAdapter: vi.fn(() => {
+      throw error;
+    }),
+    getService: vi.fn(),
+    getSetting: vi.fn(),
+    isReady: vi.fn().mockRejectedValue(error),
+    logger,
+    registerDatabaseAdapter: vi.fn(),
+  } as unknown as RuntimeStub;
+}
+
+async function expectInitReadinessError(plugin: Plugin, runtime: RuntimeStub): Promise<void> {
+  if (!plugin.init) {
+    throw new Error("plugin init is required for this test");
+  }
+
+  let thrown: unknown;
+  try {
+    await plugin.init({}, runtime);
+  } catch (error) {
+    thrown = error;
+  }
+
+  expect(thrown).toBeInstanceOf(ElizaError);
+  expect(thrown).toMatchObject({ code: "DB_ADAPTER_READY_CHECK_FAILED" });
+  expect((thrown as ElizaError).cause).toBeDefined();
+  expect(runtime.registerDatabaseAdapter).not.toHaveBeenCalled();
+}
+
+describe("plugin-sql init error policy", () => {
+  it("throws unexpected default entry adapter detection failures", async () => {
+    const runtime = createRuntimeStub(new Error("adapter registry unavailable"));
+
+    await expectInitReadinessError(defaultPlugin, runtime);
+    expect(runtime.logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "adapter registry unavailable" }),
+      "Database adapter detection failed"
+    );
+  });
+
+  it("throws unexpected node entry adapter readiness failures", async () => {
+    const runtime = createRuntimeStub(new Error("adapter health probe exploded"));
+
+    await expectInitReadinessError(nodePlugin, runtime);
+    expect(runtime.logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "adapter health probe exploded" }),
+      "Database adapter readiness check failed"
+    );
+  });
+
+  it("throws unexpected browser entry adapter readiness failures", async () => {
+    const runtime = createRuntimeStub(new Error("browser adapter probe exploded"));
+
+    await expectInitReadinessError(browserPlugin, runtime);
+  });
+});

--- a/plugins/plugin-sql/src/adapter-readiness.ts
+++ b/plugins/plugin-sql/src/adapter-readiness.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared classification for plugin-sql adapter readiness checks. The entry
+ * points may create a database adapter when none is registered, but other
+ * readiness failures must stay visible as typed initialization errors.
+ */
+import { ElizaError, type UUID } from "@elizaos/core";
+
+const MISSING_ADAPTER_MESSAGE = "Database adapter not registered";
+
+export function describeAdapterReadinessError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function isMissingDatabaseAdapterError(error: unknown): boolean {
+  return describeAdapterReadinessError(error).includes(MISSING_ADAPTER_MESSAGE);
+}
+
+export function createAdapterReadinessError(
+  error: unknown,
+  context: {
+    agentId: UUID;
+    entrypoint: "browser" | "default" | "node";
+  }
+): ElizaError {
+  return new ElizaError("Database adapter readiness check failed", {
+    code: "DB_ADAPTER_READY_CHECK_FAILED",
+    cause: error,
+    context,
+  });
+}

--- a/plugins/plugin-sql/src/index.browser.ts
+++ b/plugins/plugin-sql/src/index.browser.ts
@@ -12,6 +12,11 @@ import {
   type Plugin,
   type UUID,
 } from "@elizaos/core";
+import {
+  createAdapterReadinessError,
+  describeAdapterReadinessError,
+  isMissingDatabaseAdapterError,
+} from "./adapter-readiness";
 import { PgliteDatabaseAdapter } from "./pglite/adapter";
 import { PGliteClientManager } from "./pglite/manager";
 import {
@@ -123,7 +128,27 @@ export const plugin: Plugin = {
         );
         return;
       }
-    } catch (_error) {}
+    } catch (error) {
+      if (isMissingDatabaseAdapterError(error)) {
+        logger.info(
+          { src: "plugin:sql", agentId: runtime.agentId },
+          "No pre-registered database adapter detected; registering browser adapter"
+        );
+      } else {
+        logger.error(
+          {
+            src: "plugin:sql",
+            agentId: runtime.agentId,
+            error: describeAdapterReadinessError(error),
+          },
+          "Browser database adapter readiness check failed"
+        );
+        throw createAdapterReadinessError(error, {
+          agentId: runtime.agentId,
+          entrypoint: "browser",
+        });
+      }
+    }
 
     const dbAdapter = createDatabaseAdapter({}, runtime.agentId);
     runtimeWithAdapter.registerDatabaseAdapter(dbAdapter);

--- a/plugins/plugin-sql/src/index.node.ts
+++ b/plugins/plugin-sql/src/index.node.ts
@@ -10,6 +10,11 @@
 import { mkdirSync } from "node:fs";
 import type { IDatabaseAdapter, UUID } from "@elizaos/core";
 import { type IAgentRuntime, logger, type Plugin } from "@elizaos/core";
+import {
+  createAdapterReadinessError,
+  describeAdapterReadinessError,
+  isMissingDatabaseAdapterError,
+} from "./adapter-readiness";
 
 export {
   and,
@@ -186,19 +191,22 @@ export const plugin: Plugin = {
       .isReady()
       .then(() => true)
       .catch((error: unknown) => {
-        const message = error instanceof Error ? error.message : String(error);
-        if (message.includes("Database adapter not registered")) {
+        const message = describeAdapterReadinessError(error);
+        if (isMissingDatabaseAdapterError(error)) {
           runtime.logger.info(
             { src: "plugin:sql", agentId: runtime.agentId },
             "No pre-registered database adapter detected; registering adapter"
           );
-        } else {
-          runtime.logger.warn(
-            { src: "plugin:sql", agentId: runtime.agentId, error: message },
-            "Database adapter readiness check error; proceeding to register adapter"
-          );
+          return false;
         }
-        return false;
+        runtime.logger.error(
+          { src: "plugin:sql", agentId: runtime.agentId, error: message },
+          "Database adapter readiness check failed"
+        );
+        throw createAdapterReadinessError(error, {
+          agentId: runtime.agentId,
+          entrypoint: "node",
+        });
       });
     if (adapterRegistered) {
       runtime.logger.info(

--- a/plugins/plugin-sql/src/index.ts
+++ b/plugins/plugin-sql/src/index.ts
@@ -29,6 +29,11 @@ export {
   sql,
 } from "drizzle-orm";
 
+import {
+  createAdapterReadinessError,
+  describeAdapterReadinessError,
+  isMissingDatabaseAdapterError,
+} from "./adapter-readiness";
 import { PgDatabaseAdapter } from "./pg/adapter";
 import { PostgresConnectionManager } from "./pg/manager";
 import { PgliteDatabaseAdapter } from "./pglite/adapter";
@@ -187,8 +192,22 @@ export const plugin: Plugin = {
                 runtimeWithAdapter.databaseAdapter ??
                 runtimeWithAdapter.adapter;
               return Boolean(existing);
-            } catch {
-              return false;
+            } catch (error) {
+              if (isMissingDatabaseAdapterError(error)) {
+                return false;
+              }
+              runtime.logger.error(
+                {
+                  src: "plugin:sql",
+                  agentId: runtime.agentId,
+                  error: describeAdapterReadinessError(error),
+                },
+                "Database adapter detection failed"
+              );
+              throw createAdapterReadinessError(error, {
+                agentId: runtime.agentId,
+                entrypoint: "default",
+              });
             }
           })();
 


### PR DESCRIPTION
## Summary

Relates #12269. Second small integration chunk for plugin-sql fallback/error-policy cleanup.

- adds shared adapter-readiness error classification for the plugin-sql entry points
- treats only `Database adapter not registered` as the allowed absent-adapter signal
- rethrows unexpected adapter detection/readiness failures as `ElizaError` with `DB_ADAPTER_READY_CHECK_FAILED`
- adds focused init error-policy coverage for default, Node, and browser entry points

## Evidence

Evidence file: `.github/issue-evidence/12269-plugin-sql-init-error-policy.md`

Passed locally after rebasing on `origin/develop`:

```bash
git fetch origin && git rebase --autostash origin/develop
bun run --cwd plugins/plugin-sql test -- __tests__/unit/plugin-init-error-policy.test.ts
bun run --cwd plugins/plugin-sql typecheck
bun run --cwd plugins/plugin-sql lint:check
bun run --cwd plugins/plugin-sql build
bun run audit:error-policy-ratchet
```

Root verify was attempted and got much farther than the prior local resource-kill run, but failed in unrelated cloud API typecheck after 88 successful Turbo tasks:

```text
Failed: @elizaos/cloud-api#typecheck
packages/cloud/api/__tests__/hf-proxy-route.test.ts(259,38): error TS2769
packages/cloud/shared/src/lib/services/market-preview.ts: missing exports from @elizaos/shared
```

## UI / trajectory evidence

N/A - no UI, frontend, prompt/model/action/provider, or agent behavior changed. Backend evidence is the induced plugin init failure test and structured log in the evidence file.
