### PR TITLE
docs(#12234): correct hover-card.tsx header — Derived, not Verbatim, from shadcn/ui

### DIFF
--- a/packages/ui/src/components/ui/hover-card.tsx
+++ b/packages/ui/src/components/ui/hover-card.tsx
@@ -1,5 +1,5 @@
 /**
- * Hover-triggered popover over Radix `@radix-ui/react-hover-card`. Verbatim
+ * Hover-triggered popover over Radix `@radix-ui/react-hover-card`. Derived
  * from shadcn/ui `hover-card` (https://ui.shadcn.com/docs/components/hover-card).
  */
 "use client";


### PR DESCRIPTION
Follow-up to #12549 (B04 UI-B slice). Post-merge review caught one inaccurate header: `packages/ui/src/components/ui/hover-card.tsx` says **"Verbatim from shadcn/ui"**, but `HoverCardContent` is re-tokenized to this kit's theme — `bg-card text-txt border-border rounded-sm` vs shadcn's `bg-popover text-popover-foreground rounded-md`. It is **derived**, not verbatim. Every sibling primitive in the same slice correctly says "Derived from"; this aligns hover-card with them.

Comment-only (code token stream unchanged; `check:comment-only` clean). Per the repo doctrine, "a wrong header is worse than no header."

🤖 Generated with [Claude Code](https://claude.com/claude-code)