### PR TITLE
fix(cloud-api): restore cloud API typecheck

### DIFF
--- a/packages/cloud/api/__tests__/hf-proxy-route.test.ts
+++ b/packages/cloud/api/__tests__/hf-proxy-route.test.ts
@@ -256,7 +256,12 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
     });
 
     expect(res.status).toBe(403);
-    expect(await res.json()).toEqual({
+    const body = (await res.json()) as {
+      error: string;
+      code: string;
+      repo: string;
+    };
+    expect(body).toEqual({
       error: "HuggingFace repo is gated or unauthorized.",
       code: "HF_GATED",
       repo: "elizaos/eliza-1",

--- a/packages/cloud/api/types/workspace-shims.d.ts
+++ b/packages/cloud/api/types/workspace-shims.d.ts
@@ -1,4 +1,22 @@
+/**
+ * Type-only workspace shims for cloud API typechecking.
+ *
+ * `tsgo` treats this ambient module as the local `@elizaos/shared` surface when
+ * checking the Cloudflare Worker package. Keep these declarations aligned with
+ * the real shared exports used through cloud-shared aliases.
+ */
+
 declare module "@elizaos/shared" {
+  export interface CoinGeckoMarketRecord {
+    id: string;
+    symbol: string;
+    name: string;
+    currentPriceUsd: number;
+    change24hPct: number;
+    marketCapRank: number | null;
+    imageUrl: string | null;
+  }
+
   export interface WalletMarketPriceSnapshot {
     id: string;
     symbol: string;
@@ -54,4 +72,30 @@ declare module "@elizaos/shared" {
     movers: WalletMarketMover[];
     predictions: WalletMarketPrediction[];
   }
+
+  export const COINGECKO_MARKET_PROVIDER: {
+    providerId: "coingecko";
+    providerName: "CoinGecko";
+    providerUrl: "https://www.coingecko.com/";
+  };
+
+  export const POLYMARKET_MARKET_PROVIDER: {
+    providerId: "polymarket";
+    providerName: "Polymarket";
+    providerUrl: "https://polymarket.com/";
+  };
+
+  export function buildCoinGeckoMarketsUrl(): URL;
+
+  export function buildMarketMovers(
+    markets: CoinGeckoMarketRecord[],
+  ): WalletMarketMover[];
+
+  export function buildMarketPriceSnapshots(
+    markets: CoinGeckoMarketRecord[],
+  ): WalletMarketPriceSnapshot[];
+
+  export function parseCoinGeckoMarkets(
+    payload: unknown,
+  ): CoinGeckoMarketRecord[];
 }


### PR DESCRIPTION
## Summary
- align the cloud API `@elizaos/shared` workspace shim with the market-preview helpers now imported by cloud-shared
- type the HF proxy gated-response JSON assertion so Bun's `expect` overload resolves under `tsgo`

## Evidence
- PASS: `bun run --cwd packages/shared build:i18n && bun run --cwd packages/auth build && bun run --cwd packages/cloud/api typecheck`
- PASS: `bunx @biomejs/biome check packages/cloud/api/types/workspace-shims.d.ts packages/cloud/api/__tests__/hf-proxy-route.test.ts`
- PASS: `git diff --check HEAD~1..HEAD`
- PARTIAL: `bun run verify` failed before this change's full lane completed unless `@elizaos/cloud-routing` was prebuilt; after `bun run --cwd packages/cloud/routing build`, it got past `@elizaos/cloud-api:typecheck` and later failed on unrelated Electrobun formatting checks in `packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts`, `src/native/desktop.ts`, `src/tray-popover-position.test.ts`, and `src/tray-popover-position.ts`.

## Evidence N/A
- Screenshots/video: N/A - typecheck-only backend/test typing fix, no UI behavior.
- Real LLM trajectories: N/A - no agent/model/prompt behavior changes.
- Domain artifacts/log captures: N/A - no runtime product flow changes.