### PR TITLE
fix(agent): format media range handler after #12585

### DIFF
--- a/packages/agent/src/api/media-store.ts
+++ b/packages/agent/src/api/media-store.ts
@@ -663,7 +663,12 @@ function parseByteRange(
   }
   const start = startRaw ? Number.parseInt(startRaw, 10) : 0;
   let end = endRaw ? Number.parseInt(endRaw, 10) : size - 1;
-  if (Number.isNaN(start) || Number.isNaN(end) || start > end || start >= size) {
+  if (
+    Number.isNaN(start) ||
+    Number.isNaN(end) ||
+    start > end ||
+    start >= size
+  ) {
     return { unsatisfiable: true };
   }
   end = Math.min(end, size - 1);
@@ -712,7 +717,8 @@ export function handleMediaRouteRequest(
     ...mediaSecurityHeaders(resolved.name, resolved.contentType),
   };
 
-  const range = method === "GET" ? parseByteRange(rangeHeader, resolved.size) : null;
+  const range =
+    method === "GET" ? parseByteRange(rangeHeader, resolved.size) : null;
   if (range && "unsatisfiable" in range) {
     return {
       status: 416,
@@ -733,10 +739,9 @@ export function handleMediaRouteRequest(
         "Content-Range": `bytes ${range.start}-${range.end}/${resolved.size}`,
         "Content-Length": String(length),
       },
-      body: fs.readFileSync(resolved.filePath).subarray(
-        range.start,
-        range.end + 1,
-      ),
+      body: fs
+        .readFileSync(resolved.filePath)
+        .subarray(range.start, range.end + 1),
     };
   }
 
@@ -777,7 +782,8 @@ export function serveMediaFile(
     ...mediaSecurityHeaders(resolved.name, contentType),
   };
 
-  const range = method === "GET" ? parseByteRange(req.headers.range, size) : null;
+  const range =
+    method === "GET" ? parseByteRange(req.headers.range, size) : null;
   if (range && "unsatisfiable" in range) {
     res.writeHead(416, {
       "Content-Range": `bytes */${size}`,


### PR DESCRIPTION
Follow-up to #12585.

## Summary
- Applies the repository formatter to `packages/agent/src/api/media-store.ts` after #12585 merged with a Biome formatting failure in the touched file.
- No behavior change; whitespace/line wrapping only.

## Verification
- PASS: `bunx biome check packages/agent/src/api/media-store.ts packages/agent/src/api/media-store.test.ts`
- PASS: `bun run --cwd packages/agent test -- src/api/media-store.test.ts` -> 44 passed
- PASS: `git diff --check origin/develop...HEAD`
- PASS: `git merge-tree --write-tree HEAD origin/develop`

## Evidence N/A
- Screenshots/video: N/A, formatting-only follow-up.
- Real-LLM trajectories: N/A, no agent/model behavior.
