### PR TITLE
docs(#12241): add security package headers

### DIFF
--- a/packages/security/soc2-verify/src/__tests__/dynamic.test.ts
+++ b/packages/security/soc2-verify/src/__tests__/dynamic.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests the dynamic SOC2 checks against real in-memory security adapters.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   auditDispatcherEmits,

--- a/packages/security/soc2-verify/src/__tests__/report.test.ts
+++ b/packages/security/soc2-verify/src/__tests__/report.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests SOC2 evidence report rendering and file output with temporary local artifacts.
+ */
+
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";

--- a/packages/security/soc2-verify/src/__tests__/runner.test.ts
+++ b/packages/security/soc2-verify/src/__tests__/runner.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests the SOC2 verification orchestrator and critical-failure summary logic.
+ */
+
 import { describe, expect, it } from "vitest";
 import { hasCriticalFailures, runVerification } from "../runners/run.js";
 

--- a/packages/security/soc2-verify/src/cli.ts
+++ b/packages/security/soc2-verify/src/cli.ts
@@ -1,4 +1,8 @@
 #!/usr/bin/env bun
+/**
+ * CLI entrypoint for running SOC2 control verification and writing evidence reports.
+ */
+
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import {

--- a/packages/security/soc2-verify/src/controls/audit-actions.ts
+++ b/packages/security/soc2-verify/src/controls/audit-actions.ts
@@ -1,3 +1,7 @@
+/**
+ * SOC2 checks for the security audit action registry's required event coverage.
+ */
+
 import { join } from "node:path";
 import type { Check, CheckResult } from "../types.js";
 import { readUtf8Safe } from "../util/fs.js";

--- a/packages/security/soc2-verify/src/controls/codeowners.ts
+++ b/packages/security/soc2-verify/src/controls/codeowners.ts
@@ -1,3 +1,7 @@
+/**
+ * SOC2 checks for ownership, branch-protection, and security-policy repository controls.
+ */
+
 import { join } from "node:path";
 import type { Check, CheckResult } from "../types.js";
 import { fileExists, readUtf8 } from "../util/fs.js";

--- a/packages/security/soc2-verify/src/controls/db-and-pii.ts
+++ b/packages/security/soc2-verify/src/controls/db-and-pii.ts
@@ -1,3 +1,7 @@
+/**
+ * SOC2 checks for database transport security, encryption columns, and PII retention controls.
+ */
+
 import { join } from "node:path";
 import type { Check, CheckResult } from "../types.js";
 import { fileExists, readUtf8Safe } from "../util/fs.js";

--- a/packages/security/soc2-verify/src/controls/dynamic.ts
+++ b/packages/security/soc2-verify/src/controls/dynamic.ts
@@ -1,3 +1,7 @@
+/**
+ * Dynamic SOC2 checks that exercise live security adapters instead of static source inspection.
+ */
+
 import {
   AuditDispatcher,
   InMemorySink,

--- a/packages/security/soc2-verify/src/controls/index.ts
+++ b/packages/security/soc2-verify/src/controls/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Ordered SOC2 check registry grouped by Trust Service Criteria category.
+ */
+
 import type { Check } from "../types.js";
 import { auditActionsComprehensive } from "./audit-actions.js";
 import {

--- a/packages/security/soc2-verify/src/controls/k8s.ts
+++ b/packages/security/soc2-verify/src/controls/k8s.ts
@@ -1,3 +1,7 @@
+/**
+ * SOC2 checks for Kubernetes workload hardening and network policy coverage.
+ */
+
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import type { Check, CheckResult } from "../types.js";

--- a/packages/security/soc2-verify/src/controls/observability.ts
+++ b/packages/security/soc2-verify/src/controls/observability.ts
@@ -1,3 +1,7 @@
+/**
+ * SOC2 checks for monitoring configuration and security alert-rule availability.
+ */
+
 import { join } from "node:path";
 import type { Check, CheckResult } from "../types.js";
 import { fileExists, readUtf8Safe } from "../util/fs.js";

--- a/packages/security/soc2-verify/src/controls/plugins.ts
+++ b/packages/security/soc2-verify/src/controls/plugins.ts
@@ -1,3 +1,7 @@
+/**
+ * SOC2 checks for plugin integrity, subagent environment boundaries, and firmware signing.
+ */
+
 import { join } from "node:path";
 import type { Check, CheckResult } from "../types.js";
 import { dirExists, readUtf8Safe, walk } from "../util/fs.js";

--- a/packages/security/soc2-verify/src/controls/supply-chain.ts
+++ b/packages/security/soc2-verify/src/controls/supply-chain.ts
@@ -1,3 +1,7 @@
+/**
+ * SOC2 checks for secret scanning and pinned GitHub Actions supply-chain controls.
+ */
+
 import { execSync } from "node:child_process";
 import { join } from "node:path";
 import type { Check, CheckResult } from "../types.js";

--- a/packages/security/soc2-verify/src/controls/training.ts
+++ b/packages/security/soc2-verify/src/controls/training.ts
@@ -1,3 +1,7 @@
+/**
+ * SOC2 checks for training data consent and signed model publishing evidence.
+ */
+
 import { join } from "node:path";
 import type { Check, CheckResult } from "../types.js";
 import { readUtf8Safe } from "../util/fs.js";

--- a/packages/security/soc2-verify/src/evidence/report.ts
+++ b/packages/security/soc2-verify/src/evidence/report.ts
@@ -1,3 +1,7 @@
+/**
+ * SOC2 evidence report rendering and persistence for auditor-readable artifacts.
+ */
+
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { EvidenceReport } from "../types.js";

--- a/packages/security/soc2-verify/src/index.ts
+++ b/packages/security/soc2-verify/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Public SOC2 verification harness exports for checks, runners, report writers, and types.
+ */
+
 export { ALL_CHECKS } from "./controls/index.js";
 export {
   defaultOutDir,

--- a/packages/security/soc2-verify/src/runners/run.ts
+++ b/packages/security/soc2-verify/src/runners/run.ts
@@ -1,3 +1,7 @@
+/**
+ * SOC2 verification runner that executes selected checks and aggregates evidence by control.
+ */
+
 import { execSync } from "node:child_process";
 import { ALL_CHECKS } from "../controls/index.js";
 import type {

--- a/packages/security/soc2-verify/src/types.ts
+++ b/packages/security/soc2-verify/src/types.ts
@@ -1,3 +1,7 @@
+/**
+ * Shared SOC2 verification types for checks, evidence reports, and runner configuration.
+ */
+
 export type CheckStatus = "pass" | "fail" | "warn" | "skip";
 export type CheckSeverity = "critical" | "high" | "medium" | "low";
 

--- a/packages/security/soc2-verify/src/util/fs.ts
+++ b/packages/security/soc2-verify/src/util/fs.ts
@@ -1,3 +1,7 @@
+/**
+ * Filesystem helpers for SOC2 checks that inspect repository evidence paths.
+ */
+
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";

--- a/packages/security/soc2-verify/vitest.config.ts
+++ b/packages/security/soc2-verify/vitest.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Vitest configuration for the SOC2 verification harness tests.
+ */
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/packages/security/src/__tests__/dispatcher.test.ts
+++ b/packages/security/src/__tests__/dispatcher.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests audit dispatcher fan-out, validation, metadata redaction, and HTTP delivery behavior.
+ */
+
 import { describe, expect, it, vi } from "vitest";
 import { AuditDispatcher } from "../audit/dispatcher.js";
 import { type AuditSink, HttpSink, InMemorySink } from "../audit/sink.js";

--- a/packages/security/src/__tests__/key-namespace.test.ts
+++ b/packages/security/src/__tests__/key-namespace.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests the KMS key namespace builders, parser, validation, and version helpers.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   baseKeyId,

--- a/packages/security/src/__tests__/local-adapter.test.ts
+++ b/packages/security/src/__tests__/local-adapter.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests the desktop local KMS adapter against deterministic root-key derivation and restart behavior.
+ */
+
 import { describe, expect, it } from "vitest";
 import { orgKey, systemKey } from "../kms/key-namespace.js";
 import { LocalKmsAdapter, randomRootKey } from "../kms/local-adapter.js";

--- a/packages/security/src/__tests__/memory-adapter.test.ts
+++ b/packages/security/src/__tests__/memory-adapter.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests the in-memory KMS adapter's AEAD, HMAC, signing, and rotation contracts.
+ */
+
 import { describe, expect, it } from "vitest";
 import { orgKey, systemKey } from "../kms/key-namespace.js";
 import { MemoryKmsAdapter } from "../kms/memory-adapter.js";

--- a/packages/security/src/__tests__/steward-adapter.test.ts
+++ b/packages/security/src/__tests__/steward-adapter.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests the Steward KMS client wire contract with an injected fetch implementation.
+ */
+
 import { describe, expect, it } from "vitest";
 import { StewardKmsAdapter } from "../kms/steward-adapter.js";
 import { KmsError } from "../kms/types.js";

--- a/packages/security/src/audit/dispatcher.ts
+++ b/packages/security/src/audit/dispatcher.ts
@@ -1,3 +1,7 @@
+/**
+ * Audit dispatcher for validating privileged-action events and fanning them out to sinks.
+ */
+
 import { type AuditAction, isAuditAction } from "./actions.js";
 import type { AuditSink } from "./sink.js";
 import {

--- a/packages/security/src/audit/index.ts
+++ b/packages/security/src/audit/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Public audit-event exports for callers that emit or persist security audit records.
+ */
+
 export * from "./actions.js";
 export * from "./dispatcher.js";
 export * from "./sink.js";

--- a/packages/security/src/audit/sink.ts
+++ b/packages/security/src/audit/sink.ts
@@ -1,3 +1,7 @@
+/**
+ * Audit sink implementations for in-memory tests, structured logs, files, and HTTP collectors.
+ */
+
 import { appendFile } from "node:fs/promises";
 import type { AuditEvent } from "./types.js";
 

--- a/packages/security/src/audit/types.ts
+++ b/packages/security/src/audit/types.ts
@@ -1,3 +1,7 @@
+/**
+ * Audit-event schemas and primitives shared by the dispatcher and downstream audit sinks.
+ */
+
 import { z } from "zod";
 import { AUDIT_ACTIONS, type AuditAction } from "./actions.js";
 

--- a/packages/security/src/crypto/aead.test.ts
+++ b/packages/security/src/crypto/aead.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests the AES-256-GCM helper against authenticated round-trips and rejection paths.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   AEAD_KEY_BYTES,

--- a/packages/security/src/crypto/aead.ts
+++ b/packages/security/src/crypto/aead.ts
@@ -1,3 +1,7 @@
+/**
+ * AES-256-GCM helpers for KMS adapters that require authenticated associated data.
+ */
+
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 
 export const AEAD_KEY_BYTES = 32;

--- a/packages/security/src/crypto/hkdf.test.ts
+++ b/packages/security/src/crypto/hkdf.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests HKDF-SHA256 output against an independent RFC 5869 reference implementation.
+ */
+
 import { createHmac } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { hkdfSha256 } from "./hkdf.js";

--- a/packages/security/src/crypto/hkdf.ts
+++ b/packages/security/src/crypto/hkdf.ts
@@ -1,3 +1,7 @@
+/**
+ * HKDF-SHA256 derivation primitive used by KMS adapters to derive scoped subkeys.
+ */
+
 import { hkdfSync } from "node:crypto";
 
 /**

--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Public security foundation exports for KMS, audit dispatch, and key derivation primitives.
+ */
+
 export * from "./audit/index.js";
 export { hkdfSha256 } from "./crypto/hkdf.js";
 export * from "./kms/index.js";

--- a/packages/security/src/kms/index.ts
+++ b/packages/security/src/kms/index.ts
@@ -1,3 +1,7 @@
+/**
+ * KMS client factory and backend resolver for memory, local desktop, and Steward-backed deployments.
+ */
+
 import { LocalKmsAdapter, randomRootKey } from "./local-adapter.js";
 import { MemoryKmsAdapter } from "./memory-adapter.js";
 import { StewardKmsAdapter } from "./steward-adapter.js";

--- a/packages/security/src/kms/key-namespace.ts
+++ b/packages/security/src/kms/key-namespace.ts
@@ -1,3 +1,7 @@
+/**
+ * Structured KMS key identifiers for system, organization, and user-scoped security material.
+ */
+
 import type { KeyId, KeyVersion } from "./types.js";
 import { KmsError } from "./types.js";
 

--- a/packages/security/src/kms/local-adapter.ts
+++ b/packages/security/src/kms/local-adapter.ts
@@ -1,3 +1,7 @@
+/**
+ * Local desktop KMS adapter that derives persistent symmetric keys from a caller-provided root key.
+ */
+
 import {
   createHmac,
   createPrivateKey,

--- a/packages/security/src/kms/memory-adapter.ts
+++ b/packages/security/src/kms/memory-adapter.ts
@@ -1,3 +1,7 @@
+/**
+ * In-process KMS adapter for tests and development that keeps key versions in memory.
+ */
+
 import {
   createHmac,
   generateKeyPairSync,

--- a/packages/security/src/kms/steward-adapter.ts
+++ b/packages/security/src/kms/steward-adapter.ts
@@ -1,3 +1,7 @@
+/**
+ * Steward KMS HTTP client that implements the production key-management wire contract.
+ */
+
 import {
   type EncryptResult,
   type GetOrCreateKeyOptions,

--- a/packages/security/src/kms/types.ts
+++ b/packages/security/src/kms/types.ts
@@ -1,3 +1,7 @@
+/**
+ * KMS client types and error classes shared by every backend implementation.
+ */
+
 export type KeyId = string;
 export type KeyVersion = number;
 export type SignatureAlgorithm = "ed25519" | "rsa-pss-sha256";

--- a/packages/security/src/network-policy.ts
+++ b/packages/security/src/network-policy.ts
@@ -1,3 +1,7 @@
+/**
+ * Network-policy helpers for normalizing host-like values and blocking private/link-local IPs.
+ */
+
 import net from "node:net";
 
 const ALWAYS_BLOCKED_IP_PATTERNS: RegExp[] = [

--- a/packages/security/vitest.config.ts
+++ b/packages/security/vitest.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Vitest configuration for the security package's unit tests.
+ */
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Adds B11 prose headers to @elizaos/security source, tests, config, and SOC2 verifier files.
- Keeps the change comment-only; no code tokens changed.

## Verification
- PASS: `bun run check:comment-only` ([assert-comment-only-diff] OK — 42 source file(s) changed; every code token identical to origin/develop. Comments only.)
- PASS: `bun run --cwd packages/security test` (8 files, 53 tests)
- PASS: `bun run --cwd packages/security typecheck`
- PASS: `bun run --cwd packages/security/soc2-verify test` (3 files, 13 tests)
- PASS: `bun run --cwd packages/security/soc2-verify typecheck`
- FAIL: `bun run verify` failed outside this comment-only slice in `@elizaos/cloud-shared#typecheck`: TypeScript resolved `drizzle-orm` from `dist/node_modules` and reported missing declarations plus implicit-any fallout in `plugins/plugin-sql/src/schema/*`. The security header diff is machine-checked comment-only.

## Evidence
- Real-LLM trajectories: N/A — comments-only change, zero functional diff.
- Screenshots/video/audio/domain artifacts: N/A — comments-only change, zero functional diff.