### PR TITLE
fix(#12587): restore Containers host port publishing

### DIFF
--- a/.github/issue-evidence/12587-containers-port-publish.md
+++ b/.github/issue-evidence/12587-containers-port-publish.md
@@ -1,0 +1,56 @@
+# Issue #12587 Evidence: Containers Product Port Publishing
+
+## Scope
+
+- Restored the Containers product Hetzner lane to publish Docker host ports as `-p hostPort:containerPort`.
+- Kept Apps/Product 2 loopback-only publishing unchanged; Apps still use node-local Caddy to dial `127.0.0.1:hostPort`.
+- Kept the #12468 container hardening flags (`--cap-drop=ALL`, `no-new-privileges`, `--pids-limit`) in the Containers `docker create` paths.
+- No database schema, route DTO, UI, billing, model, native, wallet, audio, or on-chain behavior changed.
+
+## Commands Reviewed
+
+```bash
+bun test packages/cloud/shared/src/lib/services/containers/hetzner-client/port-publish.test.ts
+```
+
+Result: passed; 2 tests passed.
+
+```bash
+bunx @biomejs/biome check packages/cloud/shared/src/lib/services/containers/hetzner-client/port-publish.ts packages/cloud/shared/src/lib/services/containers/hetzner-client/port-publish.test.ts packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
+```
+
+Result: passed; 3 files checked, no fixes applied.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+```bash
+rg -n "buildLoopbackPortPublishFlag|127\\.0\\.0\\.1:.*hostPort|buildContainerPortPublishFlag" packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts packages/cloud/shared/src/lib/services/containers/hetzner-client/port-publish.ts packages/cloud/shared/src/lib/services/containers/hetzner-client/port-publish.test.ts
+```
+
+Result: reviewed; `client.ts` calls `buildContainerPortPublishFlag(...)` in both initial create and `setEnv` recreate paths, and no longer references `buildLoopbackPortPublishFlag`.
+
+## Blocked Or Unrelated Gates
+
+```bash
+bun test packages/cloud/shared/src/lib/services/containers/hetzner-client/port-publish.test.ts packages/cloud/shared/src/lib/services/__tests__/app-network-utils.test.ts packages/cloud/shared/src/lib/services/__tests__/app-docker-cmd.test.ts
+```
+
+Result: the new Containers test passed, but the broader related Apps tests could not load in this checkout because importing the shared helpers pulled `packages/core/src/cloud-routing.ts`, which failed to resolve `@elizaos/cloud-routing`.
+
+```bash
+bun run --cwd packages/cloud/shared typecheck
+```
+
+Result: blocked by broad existing workspace dependency declaration failures, including missing declarations for `drizzle-orm`, `pg`, and `@elizaos/auth/*` modules resolved from the linked root install. Filtered output showed no errors in `containers/hetzner-client/client.ts` or `containers/hetzner-client/port-publish.ts`.
+
+## N/A Evidence
+
+- Live Hetzner deployment: N/A - no Hetzner node or production cloud credentials are available in this environment.
+- UI screenshots, video, frontend logs, and app audit: N/A - no UI code changed.
+- Real-LLM trajectories: N/A - no agent prompt, model, provider, evaluator, or action behavior changed.
+- Backend request traces and DB rows: N/A - this change is pure Docker command construction for the remote node execution path; no route or persistence logic changed.
+- Native/mobile/desktop capture, audio, wallet, and on-chain evidence: N/A - those surfaces are untouched.

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
@@ -15,10 +15,7 @@ import { containers as containersTable } from "../../../../db/schemas/containers
 import type { DockerNode } from "../../../../db/schemas/docker-nodes";
 import { containersEnv } from "../../../config/containers-env";
 import { logger } from "../../../utils/logger";
-import {
-  buildAppContainerSecurityFlags,
-  buildLoopbackPortPublishFlag,
-} from "../../app-network-utils";
+import { buildAppContainerSecurityFlags } from "../../app-network-utils";
 import { dockerNodeManager } from "../../docker-node-manager";
 import { getUsedDockerHostPorts } from "../../docker-port-allocation";
 import {
@@ -47,6 +44,7 @@ import {
   validateContainerMountPath,
   validateEnvKey,
 } from "./paths";
+import { buildContainerPortPublishFlag } from "./port-publish";
 import { ensureRegistryAccess, readPulledImageDigest } from "./registry";
 import { findNodeInLocation, findStickyNodeForProject, getDockerNodeLocation } from "./scheduling";
 import {
@@ -272,7 +270,7 @@ export class HetznerContainersClient {
           `--memory ${input.memoryMb}m`,
           ...buildAppContainerSecurityFlags(),
           ...(volumePath ? [`-v ${shellQuote(volumePath)}:${shellQuote(volumeMountPath)}`] : []),
-          buildLoopbackPortPublishFlag(hostPort, input.port),
+          buildContainerPortPublishFlag(hostPort, input.port),
           envFlags,
           shellQuote(input.image),
         ]
@@ -628,7 +626,7 @@ export class HetznerContainersClient {
                 `-v ${shellQuote(meta.volumePath)}:${shellQuote(meta.volumeMountPath ?? DEFAULT_VOLUME_MOUNT_PATH)}`,
               ]
             : []),
-          buildLoopbackPortPublishFlag(meta.hostPort, meta.containerPort),
+          buildContainerPortPublishFlag(meta.hostPort, meta.containerPort),
           envFlags,
           shellQuote(meta.image),
         ]

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/port-publish.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/port-publish.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Regression coverage for the Containers product's externally reachable Docker
+ * port publishing contract.
+ *
+ * Apps use loopback publishing behind a node-local proxy. Plain Containers do
+ * not provision that proxy; their ingress map points an off-node proxy at
+ * `node.hostname:hostPort`, so the Docker host port must not be loopback-only.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { buildContainerPortPublishFlag } from "./port-publish";
+
+describe("buildContainerPortPublishFlag", () => {
+  test("keeps plain Containers reachable from the documented off-node ingress", () => {
+    expect(buildContainerPortPublishFlag(49001, 3000)).toBe("-p 49001:3000");
+    expect(buildContainerPortPublishFlag(49002, "8080")).toBe("-p 49002:8080");
+  });
+
+  test("does not use the Apps loopback-only publish form", () => {
+    const flag = buildContainerPortPublishFlag(49001, 3000);
+    expect(flag).not.toContain("127.0.0.1");
+    expect(flag).not.toContain("0.0.0.0:");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/port-publish.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/port-publish.ts
@@ -1,0 +1,16 @@
+/**
+ * Docker port-publish helpers for the Containers product's Hetzner node lane.
+ *
+ * Unlike Apps, this lane is reached by an off-node proxy through
+ * `node.hostname:hostPort`; there is no node-local Caddy process that can dial
+ * host loopback. The Docker publish flag therefore intentionally keeps Docker's
+ * default all-interface bind so the documented off-node ingress can connect.
+ */
+
+/** Publish a container port on the Docker host's externally reachable interfaces. */
+export function buildContainerPortPublishFlag(
+  hostPort: number,
+  containerPort: number | string,
+): string {
+  return `-p ${hostPort}:${containerPort}`;
+}


### PR DESCRIPTION
## Summary

Closes #12587.

- restores the Containers product Hetzner lane to publish Docker ports as `-p hostPort:containerPort`, matching the documented off-node ingress path `node.hostname:hostPort`
- keeps Apps/Product 2 loopback-only publishing unchanged; Apps still rely on node-local Caddy to dial `127.0.0.1:hostPort`
- keeps the #12468 hardening flags in both Containers `docker create` paths
- adds a focused regression test for the Containers publish flag

## Evidence

Evidence artifact: `.github/issue-evidence/12587-containers-port-publish.md`

Passed after rebasing on current `origin/develop`:

```bash
bun test packages/cloud/shared/src/lib/services/containers/hetzner-client/port-publish.test.ts
bunx @biomejs/biome check packages/cloud/shared/src/lib/services/containers/hetzner-client/port-publish.ts packages/cloud/shared/src/lib/services/containers/hetzner-client/port-publish.test.ts packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts .github/issue-evidence/12587-containers-port-publish.md
git diff --check origin/develop...HEAD
rg -n "buildLoopbackPortPublishFlag|127\\.0\\.0\\.1:.*hostPort|buildContainerPortPublishFlag" packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts packages/cloud/shared/src/lib/services/containers/hetzner-client/port-publish.ts packages/cloud/shared/src/lib/services/containers/hetzner-client/port-publish.test.ts
```

Blocked in this checkout, documented in the evidence file:

- broader related Apps tests cannot load because importing shared helpers pulls `packages/core/src/cloud-routing.ts`, which cannot resolve `@elizaos/cloud-routing` here
- `packages/cloud/shared` typecheck is blocked by broad existing workspace dependency declaration failures; filtered output showed no touched-file errors
- no live Hetzner deployment proof because this environment has no Hetzner node/production cloud credentials

## N/A

- UI screenshots/video/frontend logs: N/A - no UI code changed
- real-LLM trajectories: N/A - no prompt/model/agent behavior changed
- DB/backend request traces: N/A - no route or persistence logic changed; this is Docker command construction
- native/audio/wallet/on-chain evidence: N/A - untouched surfaces
