### PR TITLE
fix(#12321): cover 27b-256k publish metadata maps

### DIFF
--- a/.github/issue-evidence/12216-stage4-27b-256k-maps/README.md
+++ b/.github/issue-evidence/12216-stage4-27b-256k-maps/README.md
@@ -1,0 +1,53 @@
+# Stage 4 27b-256k Publish Map Evidence
+
+Issue: #12321
+
+## Change Proven
+
+- `publish/orchestrator.py` now includes `27b-256k` in both publish-time maps
+  that were previously missing the tier:
+  - `TIER_TAGLINES`
+  - `DEFAULT_RAM_BUDGET_MB`
+- `test_orchestrator.py` asserts the orchestrator maps cover the complete
+  release tier matrix: `2b`, `4b`, `9b`, `27b`, `27b-256k`.
+
+## Verification
+
+Run from `/Users/shawwalters/eliza-stage4-27b-256k` on July 4, 2026:
+
+```bash
+python3 -m pytest packages/training/scripts/publish/test_orchestrator.py -q -k 'tier_maps_cover_release_matrix'
+```
+
+Result:
+
+```text
+.                                                                        [100%]
+```
+
+```bash
+python3 -m pytest packages/training/scripts/publish/test_orchestrator.py -q
+```
+
+Result:
+
+```text
+....................................................                     [100%]
+```
+
+```bash
+python3 -m py_compile \
+  packages/training/scripts/publish/orchestrator.py \
+  packages/training/scripts/publish/test_orchestrator.py
+```
+
+Result: exit code 0.
+
+## Evidence Applicability
+
+- Screenshots/video: N/A. This is a CLI publish-orchestrator metadata fix with
+  no UI surface.
+- Live LLM trajectory: N/A. This change does not alter agent behavior,
+  prompts, actions, providers, or model outputs.
+- Backend/frontend logs: N/A. The relevant observable artifact is the
+  orchestrator no longer being able to KeyError on missing `27b-256k` map data.

--- a/packages/training/scripts/publish/orchestrator.py
+++ b/packages/training/scripts/publish/orchestrator.py
@@ -210,6 +210,7 @@ TIER_TAGLINES: Mapping[str, str] = {
     "4b": "flagship phones, small desktops",
     "9b": "workstations, tablets, and high-memory local hosts",
     "27b": "GPU workstations",
+    "27b-256k": "long-context GPU workstations",
 }
 
 DEFAULT_VOICE_CAPABILITIES: tuple[str, ...] = ("tts", "emotion-tags", "singing")
@@ -226,6 +227,7 @@ DEFAULT_RAM_BUDGET_MB: Mapping[str, tuple[int, int]] = {
     "4b": (10000, 12000),
     "9b": (12000, 16000),
     "27b": (32000, 48000),
+    "27b-256k": (24000, 32000),
 }
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")

--- a/packages/training/scripts/publish/test_orchestrator.py
+++ b/packages/training/scripts/publish/test_orchestrator.py
@@ -27,6 +27,7 @@ if str(_TRAINING_ROOT) not in sys.path:
     sys.path.insert(0, str(_TRAINING_ROOT))
 
 from scripts.publish.orchestrator import (  # noqa: E402
+    DEFAULT_RAM_BUDGET_MB,
     ELIZA_1_HF_REPO,
     EXIT_BUNDLE_LAYOUT_FAIL,
     EXIT_EVAL_GATE_FAIL,
@@ -37,6 +38,7 @@ from scripts.publish.orchestrator import (  # noqa: E402
     EXIT_USAGE,
     OrchestratorError,
     PublishContext,
+    TIER_TAGLINES,
     run,
     validate_bundle_layout,
 )
@@ -686,6 +688,17 @@ def _disable_mtp_for_tier(bundle: Path, tier: str) -> None:
 # ---------------------------------------------------------------------------
 # (a) Dry-run happy path
 # ---------------------------------------------------------------------------
+
+
+def test_orchestrator_tier_maps_cover_release_matrix() -> None:
+    expected = ("2b", "4b", "9b", "27b", "27b-256k")
+
+    assert tuple(TIER_TAGLINES) == expected
+    assert tuple(DEFAULT_RAM_BUDGET_MB) == expected
+    for tier in expected:
+        ram_min, ram_rec = DEFAULT_RAM_BUDGET_MB[tier]
+        assert TIER_TAGLINES[tier]
+        assert 0 < ram_min <= ram_rec
 
 
 def test_layout_rejects_empty_mtp_dir_on_mtp_enabled_tier(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add `27b-256k` to publish orchestrator tagline and RAM-budget maps
- add a regression that the orchestrator maps cover the full release tier matrix
- records CLI evidence for the Stage 4 KeyError slice

Relates to #12321.

## Evidence
- `python3 -m pytest packages/training/scripts/publish/test_orchestrator.py -q` -> 52 passed
- `python3 -m py_compile packages/training/scripts/publish/orchestrator.py packages/training/scripts/publish/test_orchestrator.py` -> exit 0
- `git diff --check origin/develop..HEAD` -> exit 0
- Evidence note: `.github/issue-evidence/12216-stage4-27b-256k-maps/README.md`

## Screenshots / Recordings
N/A: CLI publish-orchestrator metadata fix, no UI surface.

## Live LLM Trajectory
N/A: no agent behavior, prompt, provider, action, or model-output changes.