### PR TITLE
fix(#12264): fallback-slop sweep — fail-fast over fabricated defaults, annotate justified handlers

### DIFF
--- a/packages/core/src/media/image-description-cache.test.ts
+++ b/packages/core/src/media/image-description-cache.test.ts
@@ -3,8 +3,10 @@ import { createMockRuntime } from "../testing/mock-runtime";
 import type { IAgentRuntime } from "../types/index.ts";
 import {
 	describeImageCached,
+	getCachedImageDescription,
 	imageDescriptionCacheKey,
 	normalizeImageDescription,
+	setCachedImageDescription,
 } from "./image-description-cache.ts";
 
 function fakeRuntime(overrides: {
@@ -118,5 +120,52 @@ describe("describeImageCached", () => {
 		const { runtime, useModel } = fakeRuntime({});
 		expect(await describeImageCached(runtime, "  ", "p")).toBeNull();
 		expect(useModel).not.toHaveBeenCalled();
+	});
+});
+
+// Real-error-path coverage for the #12264 fast-fail sweep: a broken cache must
+// surface via runtime.reportError, not vanish. The dependency is broken for
+// real (a rejecting getCache/setCache), and the assertion is that the failure
+// is reported — never that a fabricated default was returned silently.
+describe("image cache failures surface via reportError", () => {
+	it("reports a read failure and degrades to a cache miss (undefined)", async () => {
+		const reportError = vi.fn();
+		const runtime = createMockRuntime({
+			getCache: vi.fn(async () => {
+				throw new Error("cache read exploded");
+			}),
+			reportError,
+		});
+		const result = await getCachedImageDescription(runtime, "https://x/a.png");
+		expect(result).toBeUndefined();
+		expect(reportError).toHaveBeenCalledTimes(1);
+		expect(reportError).toHaveBeenCalledWith(
+			"ImageDescriptionCache.get",
+			expect.any(Error),
+			{ imageUrl: "https://x/a.png" },
+		);
+	});
+
+	it("reports a write failure without throwing", async () => {
+		const reportError = vi.fn();
+		const runtime = createMockRuntime({
+			setCache: vi.fn(async () => {
+				throw new Error("cache write exploded");
+			}),
+			reportError,
+		});
+		await expect(
+			setCachedImageDescription(runtime, "https://x/b.png", {
+				title: "B",
+				description: "d",
+				text: "d",
+			}),
+		).resolves.toBeUndefined();
+		expect(reportError).toHaveBeenCalledTimes(1);
+		expect(reportError).toHaveBeenCalledWith(
+			"ImageDescriptionCache.set",
+			expect.any(Error),
+			{ imageUrl: "https://x/b.png" },
+		);
 	});
 });

--- a/packages/core/src/media/image-description-cache.ts
+++ b/packages/core/src/media/image-description-cache.ts
@@ -91,7 +91,13 @@ export async function getCachedImageDescription(
 ): Promise<CachedImageDescription | undefined> {
 	const cached = await runtime
 		.getCache<CachedImageDescription>(imageDescriptionCacheKey(imageUrl))
-		.catch(() => undefined);
+		// error-policy:J7 diagnostics-must-not-kill-the-loop — a read failure
+		// degrades to a cache miss (re-describe), but a dead cache melts model
+		// spend silently, so surface it. `undefined` = treat as miss.
+		.catch((err) => {
+			runtime.reportError("ImageDescriptionCache.get", err, { imageUrl });
+			return undefined;
+		});
 	if (cached && (cached.description || cached.text)) {
 		return {
 			title: cached.title || "Image",
@@ -110,7 +116,12 @@ export async function setCachedImageDescription(
 	if (!value.description && !value.text) return;
 	await runtime
 		.setCache(imageDescriptionCacheKey(imageUrl), value)
-		.catch(() => {});
+		// error-policy:J7 diagnostics-must-not-kill-the-loop — a failed cache
+		// write must not abort the describe call, but a dead cache melts model
+		// spend silently, so surface it.
+		.catch((err) =>
+			runtime.reportError("ImageDescriptionCache.set", err, { imageUrl }),
+		);
 }
 
 /**

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -2277,8 +2277,9 @@ export class AgentRuntime implements IAgentRuntime {
 			handler.reject(stopError);
 			const promise = this.servicePromises.get(serviceType);
 			if (promise) {
-				// Prevent unhandled rejection noise when runtimes are cleaned up with
-				// unresolved service-load promises during shutdown.
+				// error-policy:J5 unhandled-rejection suppression — the rejection is
+				// delivered to getServiceLoadPromise() awaiters via handler.reject
+				// above; this only silences unhandled-rejection noise at shutdown.
 				void promise.catch(() => {});
 			}
 		}
@@ -3594,7 +3595,14 @@ export class AgentRuntime implements IAgentRuntime {
 					actionStatus: "executing",
 					source: message.content.source,
 				},
-			}).catch(() => {});
+			}).catch((err) =>
+				// error-policy:J7 diagnostics-must-not-kill-the-loop — a broken
+				// event bus must not abort the action, but it must surface.
+				this.reportError("AgentRuntime.emitEvent", err, {
+					event: EventType.ACTION_STARTED,
+					messageId,
+				}),
+			);
 
 			let success = true;
 			let errorMsg: string | undefined;
@@ -3640,7 +3648,14 @@ export class AgentRuntime implements IAgentRuntime {
 					source: message.content.source,
 					error: errorMsg,
 				},
-			}).catch(() => {});
+			}).catch((err) =>
+				// error-policy:J7 diagnostics-must-not-kill-the-loop — a broken
+				// event bus must not abort the action, but it must surface.
+				this.reportError("AgentRuntime.emitEvent", err, {
+					event: EventType.ACTION_COMPLETED,
+					messageId,
+				}),
+			);
 		};
 
 		const isDuring =
@@ -4637,9 +4652,9 @@ export class AgentRuntime implements IAgentRuntime {
 			resolver = resolve;
 			rejecter = reject;
 		});
-		// Prevent unhandled rejection if the service fails before anyone
-		// awaits this promise.  Callers of getServiceLoadPromise() will
-		// still observe the rejection when they await.
+		// error-policy:J5 unhandled-rejection suppression — callers of
+		// getServiceLoadPromise() still observe the rejection when they await;
+		// this only prevents an unhandled rejection if the service fails first.
 		svcPromise.catch(() => {});
 		this.servicePromises.set(serviceType, svcPromise);
 		if (!resolver) {
@@ -8843,7 +8858,15 @@ ${section_end}`;
 					priority,
 					runId: this.getCurrentRunId(),
 				}),
-			}).catch(() => {});
+			}).catch((err) =>
+				// error-policy:J7 diagnostics-must-not-kill-the-loop — offloading
+				// embedding generation to the companion is fire-and-forget, but a
+				// dead companion must surface (embeddings would silently stop).
+				this.reportError("AgentRuntime.companionEmbedding", err, {
+					url,
+					agentId: this.agentId,
+				}),
+			);
 			return;
 		}
 
@@ -9287,7 +9310,15 @@ ${section_end}`;
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ agentId: this.agentId }),
-		}).catch(() => {});
+		}).catch((err) =>
+			// error-policy:J7 diagnostics-must-not-kill-the-loop — the notify is
+			// fire-and-forget (no need to block), but a dead companion means tasks
+			// stop being processed, so the failure must surface.
+			this.reportError("AgentRuntime.companionTasksDirty", err, {
+				url,
+				agentId: this.agentId,
+			}),
+		);
 	}
 
 	/**

--- a/packages/core/src/runtime/facts-and-relationships.ts
+++ b/packages/core/src/runtime/facts-and-relationships.ts
@@ -2,7 +2,6 @@ import {
 	buildFactKeywordsForStorage,
 	scoreFactKeywordRelevance,
 } from "../features/advanced-capabilities/fact-keywords.ts";
-import { logger } from "../logger";
 import { isMobilePlatform } from "../runtime-env";
 import type {
 	MessageHandlerExtract,
@@ -370,14 +369,13 @@ async function searchSimilarFacts(
 			.slice(0, 8)
 			.map((entry) => entry.memory);
 	} catch (error) {
-		// Failing to load existing facts disables dedup for this turn, which
-		// risks duplicate facts in the knowledge graph. Degrade to no dedup, but
-		// surface the read failure so a broken `getMemories` pipeline is visible.
-		logger.warn(
-			`[FactsAndRelationships] searchSimilarFacts read failed; skipping fact dedup: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		// error-policy:J7 diagnostics-must-not-kill-the-loop — failing to load
+		// existing facts disables dedup for this turn (risking duplicate facts),
+		// so degrade to no dedup, but surface the read failure via reportError so a
+		// broken `getMemories` pipeline reaches the agent, not just the log.
+		runtime.reportError("FactsAndRelationships.searchSimilarFacts", error, {
+			roomId: message.roomId,
+		});
 		return [];
 	}
 }
@@ -399,13 +397,16 @@ async function fetchExistingRelationships(
 		});
 		return Array.isArray(results) ? results : [];
 	} catch (error) {
-		// Failing to load existing relationships disables dedup for this turn,
-		// risking duplicate relationships. Degrade to no dedup, but surface the
-		// read failure so a broken `getRelationships` pipeline is visible.
-		logger.warn(
-			`[FactsAndRelationships] fetchExistingRelationships read failed; skipping relationship dedup: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
+		// error-policy:J7 diagnostics-must-not-kill-the-loop — failing to load
+		// existing relationships disables dedup for this turn (risking duplicate
+		// relationships), so degrade to no dedup, but surface the read failure via
+		// reportError so a broken `getRelationships` pipeline reaches the agent.
+		runtime.reportError(
+			"FactsAndRelationships.fetchExistingRelationships",
+			error,
+			{
+				entityIds,
+			},
 		);
 		return [];
 	}

--- a/packages/core/src/runtime/json-output.ts
+++ b/packages/core/src/runtime/json-output.ts
@@ -35,6 +35,9 @@ function parseObjectCandidate<T extends object>(candidate: string): T | null {
 			return parsed as T;
 		}
 	} catch {
+		// error-policy:J3 untrusted-input sanitizing — raw model output that isn't
+		// a bare JSON object is expected; retry once against the first embedded
+		// object substring before reporting the candidate as invalid.
 		const objectText = extractJsonObjects(candidate)[0];
 		if (!objectText) return null;
 		try {
@@ -43,6 +46,8 @@ function parseObjectCandidate<T extends object>(candidate: string): T | null {
 				return parsed as T;
 			}
 		} catch {
+			// error-policy:J3 untrusted-input sanitizing — unparseable model output;
+			// null is the explicit "invalid" signal, never a fake-valid default.
 			return null;
 		}
 	}


### PR DESCRIPTION
## Fallback-slop sweep — `packages/core` (batch of #12182, foundation #12263)

Behavior-changing precision sweep of `packages/core/src` per the binding J1–J7 rubric. Every converted site fails fast / surfaces observably (`runtime.reportError`) instead of fabricating a healthy result; every kept handler is annotated `// error-policy:J<N> <reason>`. Maximally conservative — a large `sitesLeft` was deliberately left untouched rather than risk a wrong removal in the highest-risk tree.

Three files the parent sweep already landed on `develop` in parallel (`plugin-manager/coreManagerService.ts`, `plugin-manager/pluginManagerService.ts`, `services/optimized-prompt.ts`) were resolved to develop's version during rebase — this PR does not re-litigate them.

### Re-derived suspect sites → verdict (this PR's files)

| Site | Pattern | Verdict |
|---|---|---|
| `runtime.ts` ACTION_STARTED emit `.catch(()=>{})` | promise-swallow | **converted → J7 reportError** |
| `runtime.ts` ACTION_COMPLETED emit `.catch(()=>{})` | promise-swallow | **converted → J7 reportError** |
| `runtime.ts` companion embedding-generation notify `.catch(()=>{})` | promise-swallow | **converted → J7 reportError** |
| `runtime.ts` companion tasks-dirty notify `.catch(()=>{})` | promise-swallow | **converted → J7 reportError** |
| `runtime.ts` shutdown `void promise.catch(()=>{})` | promise-swallow | keep — **J5 annotated** (rejection delivered to `handler.reject` awaiters) |
| `runtime.ts` `svcPromise.catch(()=>{})` | promise-swallow | keep — **J5 annotated** (observed by `getServiceLoadPromise` awaiters) |
| `media/image-description-cache.ts:get` `.catch(()=>undefined)` | promise-swallow | **converted → J7 reportError** (still degrades to a miss) |
| `media/image-description-cache.ts:set` `.catch(()=>{})` | promise-swallow | **converted → J7 reportError** |
| `runtime/facts-and-relationships.ts` searchSimilarFacts catch (was warn-only) | log-and-continue | **converted → J7 reportError** (the issue names this the required upgrade) |
| `runtime/facts-and-relationships.ts` fetchExistingRelationships catch (was warn-only) | log-and-continue | **converted → J7 reportError** |
| `runtime/json-output.ts` two `JSON.parse` probe catches | log-only / empty | keep — **J3 annotated** (`null` = explicit invalid; unparseable model output is expected) |

### Per-category tally (this PR)

- **Converted (slop → fast-fail / J7 reportError):** 8
- **Annotated justified (KEEP):** 4 (2× J5, 2× J3)
- **Left untouched (`sitesLeft`, counted, not masked):** the remaining `~230` calibration candidates across `packages/core` — legitimate not-found→`null`/`[]` absence, provider failover / retry / backoff, designed user-facing degrade, teardown paths already handled on develop, and any site where "masking a failure" could not be cleanly distinguished from "legitimate absent value". Precision over completeness, per the batch's highest-risk note.

### Exemplar before → after

```ts
// media/image-description-cache.ts — a dead cache melts model spend silently
// BEFORE
await runtime.setCache(imageDescriptionCacheKey(imageUrl), value).catch(() => {});
// AFTER — error-policy:J7 (write must not abort the describe call, but must surface)
await runtime
  .setCache(imageDescriptionCacheKey(imageUrl), value)
  .catch((err) => runtime.reportError("ImageDescriptionCache.set", err, { imageUrl }));
```

### Real-error-path test (no mock-swallow)

`media/image-description-cache.test.ts` gains two tests that break the dependency for real (a **rejecting** `getCache`/`setCache`) and assert the failure now **surfaces** via `runtime.reportError` — the read still degrades to a miss (`undefined`), the write still doesn't throw — never asserting the old fabricated-silent default.

```
Test Files  3 passed (3)
      Tests  32 passed (32)   # image-description-cache + facts-and-relationships + runtime-report-error
```

### Verification

- `bun run --cwd packages/core typecheck` — clean.
- `bunx biome check` on the 5 touched files — no findings.
- `bun run audit:error-policy-ratchet` — **passes**, net slop reduction, none added:
  ```
  base origin/develop (cf7efa14e0); 4 changed production source file(s)
  ... no new fallback-slop in touched files
  ```
- Full `packages/core` suite: the only reds are **7 pre-existing, environmental failures** in two files this PR does not touch — `media/fetch.test.ts` (SSRF guard requires a `pinnedFetchImpl` alongside `lookupFn` in this env) and `basic-capabilities/evaluators/__tests__/link-extraction.test.ts` (live TEXT_SMALL summarize). Both fail at the merge-base; no test went red as a result of this change.

Refs #12264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
