### PR TITLE
feat(voice): TTS-reference AEC on the desktop loop + production self-voice imprint + ERLE telemetry (#12256)

### DIFF
--- a/.github/issue-evidence/12256-echo/README.md
+++ b/.github/issue-evidence/12256-echo/README.md
@@ -1,0 +1,93 @@
+# #12256 — Echo: TTS-reference AEC on the desktop loop + production self-voice imprint + ERLE telemetry
+
+Part of #12187. Layered echo defense in the settled order (parent decision #7):
+**cooldown gate → NLMS-with-reference on the desktop loop → embedding self-voice**,
+gated by measured ERLE before considering AEC3 (escalation only — not vendored here).
+
+## Artifacts
+
+| File | What it is |
+| --- | --- |
+| `echo-aec-evidence.json` | Real NLMS + desktop `FarEndReference` + MFCC self-voice imprint over the deterministic synthetic echo corpus. Regenerate: `bun run --cwd plugins/plugin-local-inference scripts/echo-aec-evidence.ts` |
+| `workbench-logic-report.json` | `voice:workbench --logic` full report (24 scenarios, `overall: pass`, no regressions vs the #12258 baseline). Includes `desktop-aec-echo` (10 cases, pass) and `speaker-gated-barge-in` (14 cases, pass). |
+| `real-lane-hardfail.txt` | Proof the `--real` lane hard-fails (exit 1) without staged GGUFs — no false pass. |
+
+## ERLE numbers vs the #12258 ceiling (`minErleDb` 18)
+
+Real `NlmsEchoCanceller` (256 taps, µ 0.3, double-talk freeze) over the agent's
+own synthetic TTS as the far-end reference, plus far-field attenuation + early
+reflections within the filter span:
+
+| Condition | delay | far-field | reflections | ERLE (far-active) | vs 18 dB |
+| --- | --- | --- | --- | --- | --- |
+| clean-echo | 20 ms | 6 dB | 0 | **31.71 dB** | PASS |
+| early-reflections | 45 ms | 9 dB | 2 | **29.25 dB** | PASS |
+| long-transport | 380 ms | 9 dB | 1 | **30.05 dB** | PASS |
+
+Desktop `FarEndReference` end-to-end (whole-utterance cross-correlation align +
+warm-pass cancel of a WAV, timestamped renderer playback frames delivered as the
+pump does, history surviving a `reset`): **applied, ERLE 33.67 dB, alignment
+confidence 0.954, offset 14880 samples** — clears 18 dB with headroom, matching
+the ~29 dB synthetic target.
+
+**Before:** the desktop ASR ingest (`/api/asr/local-inference`) had NO AEC
+(grep `echo|aec` → empty); the agent transcribed its own playback. **After:**
+every WAV utterance is echo-cancelled before transcription when a correlated
+far-end reference exists (bit-exact passthrough otherwise).
+
+## Self-voice rejection (layer 3)
+
+`AgentSelfVoiceImprint` centroid over 8 agent utterances, then probed:
+
+- **Agent echoes:** self-similarity mean **1.0** → all rejected.
+- **Human turns (4 scenario participants):** mean **0.091** (max 0.573) → all passed.
+
+Threshold note: the imprint's production default is **0.28** for the fused
+WeSpeaker embedding (self ~0.37 vs human ~0.15, `research/VOICE_8785_ASSESSMENT.md`
+§6 — **NOT** the 0.78/0.7 human bars). The fused WeSpeaker GGUF is unstaged in
+this worktree, so the corpus evidence uses the deterministic **MFCC-timbre-13d**
+proxy encoder, whose honest operating point is the workbench's 0.7 bar; the
+imprint's `selfVoiceThreshold` travels with the measurement source precisely so
+each encoder is gated on its own scale. The unit tests
+(`self-voice-imprint.test.ts`) exercise the 0.28 WeSpeaker operating point
+directly with controlled embeddings at the measured §6 margins.
+
+## N/A with reason
+
+- **Real-hardware ERLE** (`packages/benchmarks/voice/device-acoustic-erle.mjs`):
+  N/A — no loaded acoustic host / device in this worktree. The synthetic ERLE
+  (~30 dB) exceeds the 18 dB bar with margin; if measured device ERLE after the
+  NLMS layer is <18 dB, the AEC3 / `webrtc-audio-processing` follow-up is the
+  escalation path (not implemented here — the ERLE the dev route now surfaces is
+  the gate for that decision).
+- **Fused WeSpeaker embedding self-voice margin** (self ~0.37): N/A — the fused
+  `libelizainference` speaker GGUF is not provisioned; the MFCC proxy stands in
+  for the corpus run and the unit tests cover the 0.28 operating point.
+- **Captured real STT→TTS round-trip audio / narrated walkthrough**: N/A — no
+  audio device or fused Kokoro/ASR bundle in this worktree. The synthetic corpus
+  drives the identical production DSP path end to end.
+
+## Self-voice-gate handle contract for #12255 (speaker-gated barge-in)
+
+Mirrors #12257's `getSharedVoiceProfileStore()` handle. #12255 calls
+`getAgentSelfVoiceImprint()` (no args) from `services/voice/self-voice-imprint.ts`
+to get the live production imprint the voice pipeline registered, then gates
+barge-in with `await imprint.isAgentSelfVoice(embedding)`:
+
+- returns `true` → the turn is the agent's own echo; do **not** hard-stop TTS.
+- returns `false` → a real speaker; barge-in may proceed.
+- returns `null` → no centroid yet (agent hasn't spoken enough); **fail open**
+  (treat as not-self), never as self-voice.
+
+The speak-back loop's imprint (`engine-bridge`, registered `"speak-back-loop"`)
+takes precedence over Pipeline A's (`"live-frames"`). #12255 never constructs
+its own imprint or re-derives the threshold — `imprint.threshold` is the
+agent-specific bar, and the raw similarity + that threshold flow into the
+respond-gate via `selfVoiceThreshold` so the fold compares on the right scale.
+
+## Telemetry (layer 4)
+
+`GET /api/dev/voice-latency` now carries an `aec` block
+(`echoReferenceWired`, playback delivery counters, per-utterance ERLE ring);
+`GET /api/voice/aec-capture` returns the measured ERLE by replaying the armed
+near/far window through the real canceller (`replayAecCaptureErle`).

--- a/.github/issue-evidence/12256-echo/echo-aec-evidence.json
+++ b/.github/issue-evidence/12256-echo/echo-aec-evidence.json
@@ -1,0 +1,156 @@
+{
+  "generatedAt": "2026-07-04T03:59:45.729Z",
+  "minErleDbCeiling": 18,
+  "note": "Real NlmsEchoCanceller + FarEndReference + MFCC AgentSelfVoiceImprint over the deterministic synthetic echo corpus. The fused WeSpeaker GGUF is unstaged in this worktree, so the embedding encoder is MFCC-timbre (13d); real-hardware ERLE (device-acoustic-erle.mjs) is N/A without a loaded acoustic host.",
+  "directNlms": [
+    {
+      "condition": "clean-echo",
+      "delayMs": 20,
+      "farFieldDb": 6,
+      "earlyReflections": [],
+      "erleDb": 31.71,
+      "farActiveErleDb": 31.71,
+      "meetsCeiling": true
+    },
+    {
+      "condition": "early-reflections",
+      "delayMs": 45,
+      "farFieldDb": 9,
+      "earlyReflections": [
+        [
+          64,
+          0.35
+        ],
+        [
+          150,
+          0.18
+        ]
+      ],
+      "erleDb": 29.25,
+      "farActiveErleDb": 29.25,
+      "meetsCeiling": true
+    },
+    {
+      "condition": "long-transport",
+      "delayMs": 380,
+      "farFieldDb": 9,
+      "earlyReflections": [
+        [
+          80,
+          0.3
+        ]
+      ],
+      "erleDb": 30.05,
+      "farActiveErleDb": 30.05,
+      "meetsCeiling": true
+    }
+  ],
+  "desktopFarEndReference": {
+    "applied": true,
+    "reason": null,
+    "erleDb": 33.67,
+    "offsetSamples": 14880,
+    "confidence": 0.954,
+    "farActiveSamples": 38720,
+    "meetsCeiling": true,
+    "status": {
+      "echoReferenceWired": true,
+      "playbackFramesReceived": 124,
+      "playbackSamplesReceived": 39680,
+      "lastPlaybackFrameAt": 1007465,
+      "playbackResets": 1,
+      "epochOffsetKnown": true,
+      "utterancesCancelled": 1,
+      "utterancesPassedThrough": 0,
+      "lastErleDb": 33.671537350996715,
+      "lastCancellation": {
+        "atEpochMs": 1007606.9375,
+        "applied": true,
+        "erleDb": 33.671537350996715,
+        "offsetSamples": 14880,
+        "confidence": 0.9540810693800255,
+        "farActiveSamples": 38720,
+        "nearSamples": 41471
+      },
+      "recentCancellations": [
+        {
+          "atEpochMs": 1007606.9375,
+          "applied": true,
+          "erleDb": 33.671537350996715,
+          "offsetSamples": 14880,
+          "confidence": 0.9540810693800255,
+          "farActiveSamples": 38720,
+          "nearSamples": 41471
+        }
+      ]
+    }
+  },
+  "selfVoiceImprint": {
+    "mfccOperatingThreshold": 0.7,
+    "productionWeSpeakerThreshold": 0.28,
+    "productionMarginsFromAssessmentSection6": {
+      "agentSelf": 0.37,
+      "human": 0.15
+    },
+    "encoder": "mfcc-timbre-13d (fused WeSpeaker GGUF unstaged in this worktree)",
+    "agentSelfSimilarityMean": 1,
+    "humanSimilarityMean": 0.091,
+    "humanSimilarityMax": 0.573,
+    "allAgentRejected": true,
+    "allHumanPassed": true,
+    "agentProbes": [
+      {
+        "seed": 16384,
+        "similarity": 1,
+        "rejected": true
+      },
+      {
+        "seed": 16385,
+        "similarity": 1,
+        "rejected": true
+      },
+      {
+        "seed": 16386,
+        "similarity": 1,
+        "rejected": true
+      },
+      {
+        "seed": 16387,
+        "similarity": 1,
+        "rejected": true
+      },
+      {
+        "seed": 16388,
+        "similarity": 1,
+        "rejected": true
+      }
+    ],
+    "humanProbes": [
+      {
+        "seed": 20480,
+        "index": 0,
+        "similarity": 0.153,
+        "rejected": false
+      },
+      {
+        "seed": 20481,
+        "index": 1,
+        "similarity": 0.573,
+        "rejected": false
+      },
+      {
+        "seed": 20482,
+        "index": 2,
+        "similarity": -0.31,
+        "rejected": false
+      },
+      {
+        "seed": 20483,
+        "index": 3,
+        "similarity": -0.053,
+        "rejected": false
+      }
+    ]
+  },
+  "verdict": "PASS"
+}

--- a/.github/issue-evidence/12256-echo/real-lane-hardfail.txt
+++ b/.github/issue-evidence/12256-echo/real-lane-hardfail.txt
@@ -1,0 +1,7 @@
+Error: [voice:workbench --real] missing speaker GGUF: (unset)
+    at requirePath (/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/agent-a5b7507e7bedabe25/plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts:106:13)
+    at createRealVoiceWorkbenchRuntimeFromEnv (/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/agent-a5b7507e7bedabe25/plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts:601:22)
+    at main (/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/agent-a5b7507e7bedabe25/plugins/plugin-local-inference/scripts/voice-workbench.ts:56:11)
+    at /Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/agent-a5b7507e7bedabe25/plugins/plugin-local-inference/scripts/voice-workbench.ts:111
+    at processTicksAndRejections (native:7:39)
+real exit=1

--- a/.github/issue-evidence/12256-echo/workbench-logic-report.json
+++ b/.github/issue-evidence/12256-echo/workbench-logic-report.json
@@ -1,0 +1,360 @@
+{
+  "schemaVersion": 1,
+  "overall": "pass",
+  "scenariosTotal": 24,
+  "scenariosRan": 24,
+  "scenariosSkipped": 0,
+  "scenarios": [
+    {
+      "scenarioId": "multi-voice-greeting",
+      "classes": [
+        "multi-voice",
+        "diarization"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "respond-vs-bystander",
+      "classes": [
+        "respond-no-respond",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 9,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "pauses-midutterance",
+      "classes": [
+        "pauses",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "entity-from-speech",
+      "classes": [
+        "entity-extraction",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "transcription-mode-dictation",
+      "classes": [
+        "transcription-mode",
+        "long-form-monologue"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 5,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "multi-agent-room-address",
+      "classes": [
+        "multi-agent-room",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "noisy-room-commands",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "music-background-commands",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "far-field-reverb",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "background-talkers",
+      "classes": [
+        "robustness",
+        "overlapping-speech",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "echo-self-trigger",
+      "classes": [
+        "echo-rejection",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "multi-speaker-name-capture",
+      "classes": [
+        "diarization",
+        "entity-extraction",
+        "multi-speaker",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 13,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-names-clean",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition",
+        "diarization"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 11,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-names-noisy",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition",
+        "robustness"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 13,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-name-garbled-transcript",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 11,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "echo-mistranscribed",
+      "classes": [
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "owner-enrollment-inference",
+      "classes": [
+        "owner-security",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 15,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "owner-vs-intruder",
+      "classes": [
+        "owner-security",
+        "respond-no-respond",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "endpoint-latency",
+      "classes": [
+        "endpoint-latency",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "tail-off-thinking",
+      "classes": [
+        "tail-off",
+        "eot",
+        "pauses"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "streaming-partials-monotonic",
+      "classes": [
+        "streaming-partials",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "speaker-gated-barge-in",
+      "classes": [
+        "speaker-gated-barge-in",
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 14,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "desktop-aec-echo",
+      "classes": [
+        "desktop-aec",
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "long-turn-diarization",
+      "classes": [
+        "long-turn-diarization",
+        "diarization",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 20,
+      "failedCaseKinds": []
+    }
+  ],
+  "metrics": {
+    "wer": {
+      "count": 65,
+      "mean": 0,
+      "worst": 0
+    },
+    "eotFalseTriggerRate": {
+      "count": 24,
+      "mean": 0,
+      "worst": 0
+    },
+    "eotLatencyP50Ms": null,
+    "eotLatencyP95Ms": null,
+    "der": {
+      "count": 24,
+      "mean": 0.01,
+      "worst": 0.2394
+    },
+    "respondAccuracy": {
+      "count": 24,
+      "mean": 1,
+      "worst": 1
+    },
+    "entityF1": {
+      "count": 5,
+      "mean": 1,
+      "worst": 1
+    },
+    "voiceEntityMatchRate": {
+      "count": 24,
+      "mean": 1,
+      "worst": 1
+    },
+    "firstAudioMs": {
+      "count": 55,
+      "mean": 250,
+      "worst": 250
+    },
+    "echoRejectionRate": {
+      "count": 4,
+      "mean": 1,
+      "worst": 1
+    },
+    "ownerAccuracy": {
+      "count": 2,
+      "mean": 1,
+      "worst": 1
+    },
+    "impostorAcceptRate": {
+      "count": 2,
+      "mean": 0,
+      "worst": 0
+    },
+    "bargeInGatingAccuracy": {
+      "count": 1,
+      "mean": 1,
+      "worst": 1
+    },
+    "bargeInCancelMs": {
+      "count": 1,
+      "mean": 120,
+      "worst": 120
+    },
+    "erleDb": {
+      "count": 0,
+      "mean": null,
+      "worst": null
+    },
+    "partialRetractions": {
+      "count": 0,
+      "mean": null,
+      "worst": null
+    }
+  }
+}

--- a/packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts
@@ -487,6 +487,52 @@ describe("VoiceService", () => {
     expect(String(signal?.source)).toMatch(/^client-ambient/);
   });
 
+  it("suppresses the agent's own echo while TTS playback is within the post-TTS cooldown (#12256 layer 1)", async () => {
+    // A controllable clock so the reply's age can exceed ECHO_WINDOW_MS (9 s)
+    // while playback stays recent — the case the age-only guard misses and the
+    // playback-cooldown catches.
+    let clockMs = Date.parse("2026-05-17T12:00:00.000Z");
+    const adapter = new MockVoiceRuntimeAdapter();
+    const voice = new VoiceService({
+      env: { ELIZA_VOICE_LIVE_RUNTIME: "1", ELIZA_VOICE_POST_TTS_COOLDOWN_MS: "1500" },
+      now: () => new Date(clockMs),
+      runtimeAdapter: adapter,
+    });
+    await voice.start({ mode: "local-runtime" });
+
+    // Turn 1: the agent replies, so lastAgentReply = "response:the capital…".
+    adapter.emitAsrFinal({ text: "the capital of france" });
+    await flushVoiceEvents();
+
+    // A long reply plays for 12 s — its message age now exceeds ECHO_WINDOW_MS,
+    // so the age-only echo guard would MISS a late echo. The playback stamp is
+    // fresh (this is what the cooldown catches). The mock reply text is
+    // "response:the capital of france"; the echo transcribes the clean tail.
+    clockMs += 12_000;
+    await voice.synthesizeSpeech({ text: "the capital of france" });
+    clockMs += 500; // echo returns 500 ms into playback (inside the 1500 cooldown)
+
+    adapter.emitAsrFinal({ text: "capital of france" });
+    await flushVoiceEvents();
+    const signalDuring = adapter.lastHandoffParams?.metadata
+      ?.voiceTurnSignal as Record<string, unknown> | undefined;
+    expect(signalDuring?.agentShouldSpeak).toBe(false); // echo suppressed
+    expect(signalDuring?.nextSpeaker).toBe("user");
+
+    // Close the echo turn with a playback so the next ASR-final opens a fresh
+    // turn (an unfinished turn would short-circuit on runtimeCommitTurnId).
+    await voice.synthesizeSpeech({ text: "anything else" });
+
+    // Well past the cooldown AND the age window: the same words now read as a
+    // genuine (repeated) user turn — the gate no longer suppresses on echo.
+    clockMs += 12_000;
+    adapter.emitAsrFinal({ text: "capital of france" });
+    await flushVoiceEvents();
+    const signalAfter = adapter.lastHandoffParams?.metadata
+      ?.voiceTurnSignal as Record<string, unknown> | undefined;
+    expect(signalAfter?.agentShouldSpeak).toBe(true);
+  });
+
   it("starts live audio mode with a mocked adapter", async () => {
     const { voice, adapter } = harness({
       ELIZA_VOICE_LIVE_AUDIO: "1",

--- a/packages/app-core/platforms/electrobun/src/voice/voice-service.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-service.ts
@@ -76,6 +76,18 @@ function isTruthy(value: string | undefined): boolean {
   );
 }
 
+/** Default post-TTS echo cooldown (ms) — the VOICE_WORKBENCH.md half-duplex
+ * recommendation, shared with the renderer capture gate. */
+const DEFAULT_POST_TTS_COOLDOWN_MS = 1500;
+
+function resolvePostTtsCooldownMs(
+  env: Record<string, string | undefined>,
+): number {
+  const raw = Number(env.ELIZA_VOICE_POST_TTS_COOLDOWN_MS);
+  if (!Number.isFinite(raw) || raw < 0) return DEFAULT_POST_TTS_COOLDOWN_MS;
+  return raw;
+}
+
 function requireNonEmpty(value: string, field: string): string {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -170,6 +182,12 @@ export class VoiceService {
   /** Agent's most recent spoken reply + when it landed — feeds the echo guard. */
   private lastAgentReply: string | undefined;
   private lastAgentReplyAtMs: number | undefined;
+  /** Wall-clock ms of the most recent TTS playback-started mark — anchors the
+   * post-TTS echo cooldown (#12256 layer 1). */
+  private lastPlaybackStartedAtMs: number | undefined;
+  /** Post-TTS cooldown window (ms). `ELIZA_VOICE_POST_TTS_COOLDOWN_MS`, default
+   * 1500 — the VOICE_WORKBENCH.md half-duplex recommendation. */
+  private readonly postTtsCooldownMs: number;
 
   constructor(options: VoiceServiceOptions = {}) {
     this.traceService = options.traceService ?? null;
@@ -196,6 +214,21 @@ export class VoiceService {
       });
     this.pipelineId = this.pipelineIdFactory();
     this.latencyBudget = getVoiceLatencyBudgetFromEnv(this.env);
+    this.postTtsCooldownMs = resolvePostTtsCooldownMs(this.env);
+  }
+
+  /**
+   * True while the agent's TTS is playing, or within the post-TTS cooldown
+   * after the last playback started — the window in which the transcript echo
+   * guard must be forced on so the agent's own tail bleeding into an always-on
+   * mic doesn't self-trigger a turn (#12256 layer 1).
+   */
+  private isPostTtsEchoCooldownActive(): boolean {
+    if (this.lastPlaybackStartedAtMs === undefined) return false;
+    return (
+      this.now().getTime() - this.lastPlaybackStartedAtMs <=
+      this.postTtsCooldownMs
+    );
   }
 
   async status(): Promise<VoicePipelineSnapshot> {
@@ -794,6 +827,10 @@ export class VoiceService {
         this.lastAgentReplyAtMs !== undefined
           ? this.now().getTime() - this.lastAgentReplyAtMs
           : undefined,
+      // Force the echo guard on while TTS is still playing (or just did): a
+      // long reply's playback outlives the age-only ECHO_WINDOW_MS, so without
+      // this an echo captured mid-speech would slip the guard (#12256 layer 1).
+      agentSpeaking: this.isPostTtsEchoCooldownActive(),
     });
     const handoff: VoiceRuntimeHandoffParams = {
       text,
@@ -973,6 +1010,9 @@ export class VoiceService {
     metadata?: Record<string, JsonValue>;
   }): Promise<void> {
     if (!event.started || !this.activeTurn) return;
+    // Anchor the post-TTS echo cooldown (#12256 layer 1): from here the guard
+    // treats a following near-verbatim turn as the agent's own echo.
+    this.lastPlaybackStartedAtMs = this.now().getTime();
     await this.updateTurn("playback_started");
     const playback = await this.mark("playback", "started", event.metadata);
     await this.trace(

--- a/packages/shared/src/voice/aec/delay-calibrator.test.ts
+++ b/packages/shared/src/voice/aec/delay-calibrator.test.ts
@@ -1,0 +1,86 @@
+/** Streaming one-shot echo-delay calibrator (#12256) — pure-DSP harness. */
+
+import { describe, expect, it } from "vitest";
+import {
+  ECHO_CAL_MAX_LAG_SAMPLES,
+  ECHO_CAL_TARGET_SAMPLES,
+  StreamingEchoDelayCalibrator,
+} from "./delay-calibrator.js";
+
+function tone(n: number, seed: number): Float32Array {
+  const out = new Float32Array(n);
+  let state = seed >>> 0 || 1;
+  const rand = () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0xffffffff - 0.5;
+  };
+  for (let i = 0; i < n; i++) {
+    const t = i / 16000;
+    out[i] =
+      0.4 * Math.sin(2 * Math.PI * 300 * t + seed) +
+      0.3 * Math.sin(2 * Math.PI * 730 * t) +
+      0.2 * rand();
+  }
+  return out;
+}
+
+describe("StreamingEchoDelayCalibrator", () => {
+  it("locks the true delay from accumulated playback-active frames", () => {
+    const delay = 800; // 50 ms @16 kHz
+    const far = tone(ECHO_CAL_TARGET_SAMPLES + delay + 4000, 3);
+    const cal = new StreamingEchoDelayCalibrator(0);
+    const frame = 320;
+    for (
+      let start = delay;
+      start + frame <= far.length && !cal.calibrated;
+      start += frame
+    ) {
+      const near = new Float32Array(frame);
+      for (let i = 0; i < frame; i++) near[i] = 0.2 * far[start - delay + i];
+      // The raw (delay-0) far read for the same window.
+      cal.observe(near, far.subarray(start, start + frame));
+    }
+    expect(cal.calibrated).toBe(true);
+    expect(Math.abs(cal.delaySamples - delay)).toBeLessThanOrEqual(2);
+    expect(cal.confidence).toBeGreaterThanOrEqual(0.3);
+  });
+
+  it("keeps the seed when the far-end is silent", () => {
+    const cal = new StreamingEchoDelayCalibrator(400);
+    for (let i = 0; i < 100; i++) {
+      cal.observe(tone(320, i + 1), new Float32Array(320));
+    }
+    expect(cal.calibrated).toBe(false);
+    expect(cal.delaySamples).toBe(400);
+  });
+
+  it("does not lock on independent (echo-free) near/far audio", () => {
+    const cal = new StreamingEchoDelayCalibrator(0);
+    const far = tone(ECHO_CAL_TARGET_SAMPLES * 3, 5);
+    let cursor = 0;
+    while (cursor + 320 <= far.length) {
+      cal.observe(tone(320, cursor + 77), far.subarray(cursor, cursor + 320));
+      cursor += 320;
+    }
+    // Independent signals: either it never locked, or the (unlikely) lock had
+    // to clear the 0.3 confidence bar — assert the strong invariant.
+    expect(cal.calibrated).toBe(false);
+  });
+
+  it("resetWindow drops accumulation but keeps a learned delay", () => {
+    const cal = new StreamingEchoDelayCalibrator(160);
+    cal.observe(tone(8000, 9), tone(8000, 9));
+    cal.resetWindow();
+    expect(cal.calibrated).toBe(false);
+    expect(cal.delaySamples).toBe(160);
+    expect(cal.state()).toEqual({
+      delaySamples: 160,
+      confidence: 0,
+      calibrated: false,
+    });
+  });
+
+  it("exposes the shared Pipeline A search ceiling", () => {
+    expect(ECHO_CAL_MAX_LAG_SAMPLES).toBe(8000);
+  });
+});

--- a/packages/shared/src/voice/aec/delay-calibrator.ts
+++ b/packages/shared/src/voice/aec/delay-calibrator.ts
@@ -1,0 +1,142 @@
+/**
+ * Streaming one-shot playback→mic delay calibration (#9583/#9586, extracted
+ * from the live diarization session for the desktop AEC work in #12256).
+ *
+ * While the far-end (agent TTS playback) is active, near/far windows are
+ * accumulated; once ~1 s of playback-active audio is buffered, the bulk
+ * transport lag is recovered by normalized cross-correlation
+ * (`estimateEchoDelaySamples`) and — if confident and not pinned at the search
+ * ceiling — replaces the static seed. One-shot: a device's speaker→mic path is
+ * stable, so the first confident estimate is locked and re-measurement stops.
+ *
+ * Constants are shared verbatim with Pipeline A's historical values; both the
+ * live diarization session and the desktop far-end service calibrate through
+ * this class so the contract (confidence ≥0.3, 500 ms search, cap-edge
+ * rejection) cannot drift between consumers.
+ */
+
+import { estimateEchoDelaySamples } from "./echo-delay.js";
+
+/** Accumulate this many playback-active samples before estimating the delay
+ * (1 s @16 kHz — enough correlated echo overlap for a stable cross-correlation
+ * even when the transport lag eats several hundred ms of the window). */
+export const ECHO_CAL_TARGET_SAMPLES = 16_000;
+/** Bound the rolling calibration window so a long talk-over doesn't grow it. */
+export const ECHO_CAL_MAX_SAMPLES = 24_000;
+/** Accept a calibrated delay only above this normalized cross-correlation; below
+ * it the near/far are independent (user talking, no echo) — keep the seed. */
+export const ECHO_CAL_MIN_CONFIDENCE = 0.3;
+/** Largest playback→mic delay to search (500 ms @16 kHz). The Pixel 6a WebView
+ * pump path measured ~381–408 ms end-to-end (#11373 device evidence). */
+export const ECHO_CAL_MAX_LAG_SAMPLES = 8_000;
+/** Reject locks within one frame of the search ceiling: a cap-edge peak means
+ * the true delay is likely beyond the searched range, and a one-shot lock on
+ * it would pin a wrong alignment forever. Keep observing instead. */
+export const ECHO_CAL_CAP_EDGE_SAMPLES = 320;
+/** Far-end mean-square floor below which a frame is "no playback" (skip). */
+export const ECHO_CAL_FAR_ENERGY_FLOOR = 1e-7;
+
+function concatFloat32(chunks: Float32Array[]): Float32Array {
+  let total = 0;
+  for (const c of chunks) total += c.length;
+  const out = new Float32Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    out.set(c, off);
+    off += c.length;
+  }
+  return out;
+}
+
+export interface EchoDelayState {
+  delaySamples: number;
+  confidence: number;
+  calibrated: boolean;
+}
+
+export class StreamingEchoDelayCalibrator {
+  private delay: number;
+  private conf = 0;
+  private locked = false;
+  /** Rolling near/far windows accumulated only while the far-end is active,
+   * used once to estimate the delay. Cleared after an estimate and on
+   * {@link resetWindow}. */
+  private calNear: Float32Array[] = [];
+  private calFar: Float32Array[] = [];
+  private calSampleCount = 0;
+
+  constructor(seedDelaySamples: number) {
+    this.delay = Math.max(0, Math.floor(seedDelaySamples));
+  }
+
+  get delaySamples(): number {
+    return this.delay;
+  }
+
+  get confidence(): number {
+    return this.conf;
+  }
+
+  get calibrated(): boolean {
+    return this.locked;
+  }
+
+  state(): EchoDelayState {
+    return {
+      delaySamples: this.delay,
+      confidence: this.conf,
+      calibrated: this.locked,
+    };
+  }
+
+  /**
+   * Feed one mic frame plus the RAW (delay-0) far-end read for the same window.
+   * Calibration recovers the delay, so callers must not pre-apply the value
+   * under measurement. No-op once locked or when the far-end is silent.
+   */
+  observe(nearPcm: Float32Array, farPcm: Float32Array): void {
+    if (this.locked || nearPcm.length === 0) return;
+    let farEnergy = 0;
+    for (let i = 0; i < farPcm.length; i++) farEnergy += farPcm[i] * farPcm[i];
+    if (farEnergy / Math.max(1, farPcm.length) < ECHO_CAL_FAR_ENERGY_FLOOR) {
+      return; // no playback → nothing to calibrate against
+    }
+
+    this.calNear.push(nearPcm.slice());
+    this.calFar.push(farPcm);
+    this.calSampleCount += nearPcm.length;
+    while (
+      this.calSampleCount > ECHO_CAL_MAX_SAMPLES &&
+      this.calNear.length > 1
+    ) {
+      this.calSampleCount -= (this.calNear.shift() as Float32Array).length;
+      this.calFar.shift();
+    }
+    if (this.calSampleCount < ECHO_CAL_TARGET_SAMPLES) return;
+
+    const near = concatFloat32(this.calNear);
+    const farWin = concatFloat32(this.calFar);
+    const est = estimateEchoDelaySamples(near, farWin, {
+      maxLagSamples: ECHO_CAL_MAX_LAG_SAMPLES,
+    });
+    if (
+      est.confidence >= ECHO_CAL_MIN_CONFIDENCE &&
+      est.lagSamples < ECHO_CAL_MAX_LAG_SAMPLES - ECHO_CAL_CAP_EDGE_SAMPLES
+    ) {
+      this.delay = est.lagSamples;
+      this.conf = est.confidence;
+      this.locked = true;
+    }
+    this.calNear = [];
+    this.calFar = [];
+    this.calSampleCount = 0;
+  }
+
+  /** Drop the in-progress accumulation window (playback stopped / barge-in —
+   * it would otherwise straddle a playback gap). The learned delay is kept. */
+  resetWindow(): void {
+    this.calNear = [];
+    this.calFar = [];
+    this.calSampleCount = 0;
+  }
+}

--- a/packages/shared/src/voice/aec/echo-alignment.test.ts
+++ b/packages/shared/src/voice/aec/echo-alignment.test.ts
@@ -1,0 +1,74 @@
+/** Offline near↔far echo alignment (#12256) — deterministic synthetic DSP. */
+
+import { describe, expect, it } from "vitest";
+import { estimateEchoAlignment } from "./echo-alignment.js";
+
+/**
+ * Deterministic pseudo-speech: seeded noise through a one-pole low-pass with a
+ * slow amplitude envelope. Noise-based (not shared sinusoids) so two different
+ * seeds are genuinely uncorrelated — pure tones at common frequencies would
+ * phase-align at some offset and fake a high NCC.
+ */
+function speechLike(n: number, seed: number): Float32Array {
+  const out = new Float32Array(n);
+  let state = seed >>> 0 || 1;
+  const rand = () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0xffffffff - 0.5;
+  };
+  let lp = 0;
+  for (let i = 0; i < n; i++) {
+    const t = i / 16000;
+    lp = 0.85 * lp + 0.15 * rand();
+    const envelope = 0.55 + 0.45 * Math.sin(2 * Math.PI * 2.3 * t + seed);
+    out[i] = envelope * lp * 2.5;
+  }
+  return out;
+}
+
+describe("estimateEchoAlignment", () => {
+  it("recovers the true offset of an attenuated echo inside a longer far window", () => {
+    const far = speechLike(48_000, 7); // 3 s of playback
+    const trueOffset = 6_400; // near begins 400 ms into the far window
+    const nearLen = 32_000; // 2 s utterance
+    const near = new Float32Array(nearLen);
+    for (let i = 0; i < nearLen; i++) near[i] = 0.22 * far[i + trueOffset];
+
+    const est = estimateEchoAlignment(near, far, { maxOffsetSamples: 16_000 });
+    expect(Math.abs(est.offsetSamples - trueOffset)).toBeLessThanOrEqual(2);
+    expect(est.confidence).toBeGreaterThan(0.9);
+    expect(est.overlapSamples).toBe(nearLen);
+  });
+
+  it("recovers the offset under double-talk (user speech mixed over the echo)", () => {
+    const far = speechLike(48_000, 11);
+    const user = speechLike(32_000, 999);
+    const trueOffset = 9_600; // 600 ms
+    const near = new Float32Array(32_000);
+    for (let i = 0; i < near.length; i++) {
+      near[i] = 0.25 * far[i + trueOffset] + 0.3 * user[i];
+    }
+    const est = estimateEchoAlignment(near, far, { maxOffsetSamples: 16_000 });
+    expect(Math.abs(est.offsetSamples - trueOffset)).toBeLessThanOrEqual(4);
+    expect(est.confidence).toBeGreaterThan(0.3);
+  });
+
+  it("reports low confidence when near and far are independent (no echo)", () => {
+    const far = speechLike(48_000, 21);
+    const near = speechLike(32_000, 12345);
+    const est = estimateEchoAlignment(near, far, { maxOffsetSamples: 16_000 });
+    expect(est.confidence).toBeLessThan(0.3);
+  });
+
+  it("handles degenerate inputs without throwing", () => {
+    expect(
+      estimateEchoAlignment(new Float32Array(0), new Float32Array(0)),
+    ).toEqual({ offsetSamples: 0, confidence: 0, overlapSamples: 0 });
+    const tiny = estimateEchoAlignment(
+      new Float32Array(10),
+      new Float32Array(10),
+      { minOverlapSamples: 4000 },
+    );
+    expect(tiny.confidence).toBe(0);
+  });
+});

--- a/packages/shared/src/voice/aec/echo-alignment.ts
+++ b/packages/shared/src/voice/aec/echo-alignment.ts
@@ -1,0 +1,147 @@
+/**
+ * Whole-utterance echo alignment for the desktop batch ASR path (#12256).
+ *
+ * The streaming AEC path (Pipeline A) aligns per mic frame because both mic
+ * and playback frames carry timestamps in the same clock. The desktop loop's
+ * ASR ingest instead receives a whole recorded utterance with NO per-sample
+ * timestamps, while the far-end (TTS playback tapped in the renderer) is
+ * timestamped in the renderer's `performance.now()` domain — an epoch the
+ * server does not share. The bulk near↔far alignment therefore has to be
+ * recovered from the audio itself: this module finds the offset that best
+ * places the near-end inside a far-end window by normalized cross-correlation,
+ * decimated for a cheap coarse pass and refined at full rate.
+ *
+ * `estimateEchoDelaySamples` (echo-delay.ts) stays the per-frame streaming
+ * calibrator; this is its offline, long-window sibling. Same confidence
+ * contract: a low peak correlation means the two signals are independent (no
+ * echo present) and the caller must not cancel against a spurious alignment.
+ */
+
+export interface EchoAlignmentEstimate {
+  /** Best placement of the near-end inside `far`: near[i] ≈ g · far[i + offsetSamples]. */
+  offsetSamples: number;
+  /** Peak normalized cross-correlation at that offset, clamped to [0, 1]. */
+  confidence: number;
+  /** Samples of genuine near/far overlap at the winning offset. */
+  overlapSamples: number;
+}
+
+export interface EchoAlignmentOptions {
+  /** Largest `offsetSamples` to search. Default `far.length − minOverlapSamples`. */
+  maxOffsetSamples?: number;
+  /** Minimum near/far overlap for an offset to be considered. Default 4000 (250 ms @16 kHz). */
+  minOverlapSamples?: number;
+  /** Coarse-pass decimation factor (box mean). Default 16 (16 kHz → 1 kHz envelope). */
+  coarseDecimation?: number;
+}
+
+/** Box-mean decimation by `factor` — a crude low-pass + downsample that keeps
+ * the speech energy envelope, which is what the coarse correlation locks onto. */
+function decimate(signal: Float32Array, factor: number): Float32Array {
+  if (factor <= 1) return signal;
+  const out = new Float32Array(Math.floor(signal.length / factor));
+  for (let i = 0; i < out.length; i++) {
+    let sum = 0;
+    const base = i * factor;
+    for (let k = 0; k < factor; k++) sum += signal[base + k];
+    out[i] = sum / factor;
+  }
+  return out;
+}
+
+/** Normalized cross-correlation of `near` against `far` shifted by `offset`,
+ * over their overlap. Returns `{ corr: -1 }` when the overlap is too short. */
+function nccAtOffset(
+  near: Float32Array,
+  far: Float32Array,
+  offset: number,
+  minOverlap: number,
+): { corr: number; overlap: number } {
+  const overlap = Math.min(near.length, far.length - offset);
+  if (overlap < minOverlap) return { corr: -1, overlap: Math.max(0, overlap) };
+  let dot = 0;
+  let nearEnergy = 0;
+  let farEnergy = 0;
+  for (let i = 0; i < overlap; i++) {
+    const a = near[i];
+    const b = far[i + offset];
+    dot += a * b;
+    nearEnergy += a * a;
+    farEnergy += b * b;
+  }
+  const denom = Math.sqrt(nearEnergy * farEnergy);
+  return { corr: denom > 0 ? dot / denom : 0, overlap };
+}
+
+/**
+ * Find where the near-end utterance sits inside the far-end window:
+ * `near[i] ≈ g · far[i + offset]`, searching `offset ∈ [0, maxOffsetSamples]`.
+ * Two passes — decimated coarse search over the whole range, then a full-rate
+ * refinement around the coarse peak — so a multi-second utterance against a
+ * multi-second window stays tens of milliseconds of CPU, not seconds.
+ */
+export function estimateEchoAlignment(
+  near: Float32Array,
+  far: Float32Array,
+  options: EchoAlignmentOptions = {},
+): EchoAlignmentEstimate {
+  const minOverlap = Math.max(
+    1,
+    Math.floor(options.minOverlapSamples ?? 4000),
+  );
+  const maxOffset = Math.max(
+    0,
+    Math.floor(options.maxOffsetSamples ?? far.length - minOverlap),
+  );
+  if (near.length === 0 || far.length < minOverlap) {
+    return { offsetSamples: 0, confidence: 0, overlapSamples: 0 };
+  }
+
+  const decimation = Math.max(1, Math.floor(options.coarseDecimation ?? 16));
+  const nearCoarse = decimate(near, decimation);
+  const farCoarse = decimate(far, decimation);
+  const coarseMinOverlap = Math.max(1, Math.floor(minOverlap / decimation));
+  const coarseMaxOffset = Math.floor(maxOffset / decimation);
+
+  let bestCoarse = 0;
+  let bestCoarseCorr = -Infinity;
+  for (let offset = 0; offset <= coarseMaxOffset; offset++) {
+    const { corr } = nccAtOffset(
+      nearCoarse,
+      farCoarse,
+      offset,
+      coarseMinOverlap,
+    );
+    if (corr > bestCoarseCorr) {
+      bestCoarseCorr = corr;
+      bestCoarse = offset;
+    }
+  }
+
+  // Full-rate refinement: the coarse (envelope) peak locates the offset to
+  // within ~±1 decimated sample; sweep ±2 decimated samples at sample rate.
+  const center = bestCoarse * decimation;
+  const radius = 2 * decimation;
+  const from = Math.max(0, center - radius);
+  const to = Math.min(maxOffset, center + radius);
+  let bestOffset = center;
+  let bestCorr = -Infinity;
+  let bestOverlap = 0;
+  for (let offset = from; offset <= to; offset++) {
+    const { corr, overlap } = nccAtOffset(near, far, offset, minOverlap);
+    if (corr > bestCorr) {
+      bestCorr = corr;
+      bestOffset = offset;
+      bestOverlap = overlap;
+    }
+  }
+
+  if (bestCorr === -Infinity) {
+    return { offsetSamples: 0, confidence: 0, overlapSamples: 0 };
+  }
+  return {
+    offsetSamples: bestOffset,
+    confidence: Math.max(0, Math.min(1, bestCorr)),
+    overlapSamples: bestOverlap,
+  };
+}

--- a/packages/shared/src/voice/aec/echo-metrics.test.ts
+++ b/packages/shared/src/voice/aec/echo-metrics.test.ts
@@ -1,0 +1,50 @@
+/** ERLE metrics (#12256) — pure math, edge cases + far-active masking. */
+
+import { describe, expect, it } from "vitest";
+import { computeErle, computeFarActiveErle } from "./echo-metrics.js";
+
+describe("computeErle", () => {
+  it("returns dB and handles edge cases", () => {
+    const near = new Float32Array([1, 1, 1, 1]);
+    const halfResidual = new Float32Array([0.5, 0.5, 0.5, 0.5]);
+    expect(computeErle(near, halfResidual)).toBeCloseTo(6.0206, 2);
+    expect(
+      computeErle(new Float32Array([0, 0]), new Float32Array([1, 1])),
+    ).toBe(0);
+    expect(
+      computeErle(new Float32Array([1, 1]), new Float32Array([0, 0])),
+    ).toBe(Number.POSITIVE_INFINITY);
+  });
+});
+
+describe("computeFarActiveErle", () => {
+  it("measures only far-active blocks", () => {
+    // Two 4-sample blocks: the first has far energy (echo cancelled 1 → 0.1),
+    // the second is far-silent user speech that passed through untouched. The
+    // whole-window ERLE would be diluted by the passthrough block; the masked
+    // ERLE reads the true 20 dB of the active block.
+    const near = new Float32Array([1, 1, 1, 1, 0.8, 0.8, 0.8, 0.8]);
+    const residual = new Float32Array([0.1, 0.1, 0.1, 0.1, 0.8, 0.8, 0.8, 0.8]);
+    const far = new Float32Array([0.5, 0.5, 0.5, 0.5, 0, 0, 0, 0]);
+    const { erleDb, farActiveSamples } = computeFarActiveErle(
+      near,
+      residual,
+      far,
+      { blockSamples: 4 },
+    );
+    expect(farActiveSamples).toBe(4);
+    expect(erleDb).toBeCloseTo(20, 5);
+  });
+
+  it("returns null ERLE when no block is far-active", () => {
+    const silentFar = new Float32Array(8);
+    const { erleDb, farActiveSamples } = computeFarActiveErle(
+      new Float32Array(8).fill(0.5),
+      new Float32Array(8).fill(0.5),
+      silentFar,
+      { blockSamples: 4 },
+    );
+    expect(erleDb).toBeNull();
+    expect(farActiveSamples).toBe(0);
+  });
+});

--- a/packages/shared/src/voice/aec/echo-metrics.ts
+++ b/packages/shared/src/voice/aec/echo-metrics.ts
@@ -1,0 +1,78 @@
+/**
+ * Echo-return-loss-enhancement (ERLE) measurement for the AEC stack (#12256).
+ *
+ * ERLE compares the near-end (raw mic) energy against the canceller's residual
+ * over the same window: 10·log10(Σnear² / Σresidual²). It is the single number
+ * the layered echo defense is gated on (workbench ceiling: ≥18 dB on the
+ * desktop loop; the NLMS canceller reaches ~29 dB on echo-only synthetic).
+ * Meaningful only over windows where the far-end (agent playback) was actually
+ * driving an echo — measuring over user-speech-only audio reads ~0 dB by
+ * design, since the canceller must not touch the user's voice.
+ */
+
+/**
+ * ERLE in dB: 10·log10(Σnear² / Σresidual²) over the overlapping length.
+ * Higher is better. Returns +Infinity when the residual is silent and 0 when
+ * there is no near-end energy to enhance.
+ */
+export function computeErle(
+  nearEnd: Float32Array,
+  residual: Float32Array,
+): number {
+  let nearEnergy = 0;
+  let residualEnergy = 0;
+  const len = Math.min(nearEnd.length, residual.length);
+  for (let i = 0; i < len; i++) {
+    nearEnergy += nearEnd[i] * nearEnd[i];
+    residualEnergy += residual[i] * residual[i];
+  }
+  if (nearEnergy === 0) return 0;
+  if (residualEnergy === 0) return Number.POSITIVE_INFINITY;
+  return 10 * Math.log10(nearEnergy / residualEnergy);
+}
+
+/**
+ * ERLE restricted to far-end-active blocks: only spans where the (aligned)
+ * far-end reference carries energy contribute to the ratio. This is the honest
+ * per-utterance measurement for double-talk audio — outside the far-active
+ * region there is no echo, the canceller is passthrough, and folding those
+ * samples in would dilute the number toward 0 dB.
+ *
+ * Returns `erleDb: null` when no block was far-active (no echo present).
+ */
+export function computeFarActiveErle(
+  nearEnd: Float32Array,
+  residual: Float32Array,
+  alignedFarEnd: Float32Array,
+  options: { blockSamples?: number; farEnergyFloor?: number } = {},
+): { erleDb: number | null; farActiveSamples: number } {
+  const block = Math.max(1, Math.floor(options.blockSamples ?? 320));
+  const floor = options.farEnergyFloor ?? 1e-7;
+  const len = Math.min(nearEnd.length, residual.length, alignedFarEnd.length);
+  let nearEnergy = 0;
+  let residualEnergy = 0;
+  let farActiveSamples = 0;
+  for (let start = 0; start < len; start += block) {
+    const end = Math.min(len, start + block);
+    let farEnergy = 0;
+    for (let i = start; i < end; i++) {
+      farEnergy += alignedFarEnd[i] * alignedFarEnd[i];
+    }
+    if (farEnergy / (end - start) < floor) continue;
+    farActiveSamples += end - start;
+    for (let i = start; i < end; i++) {
+      nearEnergy += nearEnd[i] * nearEnd[i];
+      residualEnergy += residual[i] * residual[i];
+    }
+  }
+  if (farActiveSamples === 0 || nearEnergy === 0) {
+    return { erleDb: null, farActiveSamples };
+  }
+  if (residualEnergy === 0) {
+    return { erleDb: Number.POSITIVE_INFINITY, farActiveSamples };
+  }
+  return {
+    erleDb: 10 * Math.log10(nearEnergy / residualEnergy),
+    farActiveSamples,
+  };
+}

--- a/packages/shared/src/voice/aec/index.ts
+++ b/packages/shared/src/voice/aec/index.ts
@@ -1,5 +1,20 @@
 /** Barrel for the acoustic echo cancellation (AEC) primitives: echo-delay estimation, the echo reference buffer, and the NLMS canceller. */
 export {
+  ECHO_CAL_CAP_EDGE_SAMPLES,
+  ECHO_CAL_FAR_ENERGY_FLOOR,
+  ECHO_CAL_MAX_LAG_SAMPLES,
+  ECHO_CAL_MAX_SAMPLES,
+  ECHO_CAL_MIN_CONFIDENCE,
+  ECHO_CAL_TARGET_SAMPLES,
+  type EchoDelayState,
+  StreamingEchoDelayCalibrator,
+} from "./delay-calibrator.js";
+export {
+  type EchoAlignmentEstimate,
+  type EchoAlignmentOptions,
+  estimateEchoAlignment,
+} from "./echo-alignment.js";
+export {
   DEFAULT_PLAYBACK_DELAY_MS,
   type EchoDelayEstimate,
   type EchoDelayOptions,
@@ -8,6 +23,7 @@ export {
   platformPlaybackDelayMs,
   platformPlaybackDelaySamples,
 } from "./echo-delay.js";
+export { computeErle, computeFarActiveErle } from "./echo-metrics.js";
 export {
   EchoReferenceBuffer,
   type EchoReferenceBufferOptions,

--- a/packages/shared/src/voice/respond-gate.ts
+++ b/packages/shared/src/voice/respond-gate.ts
@@ -131,6 +131,16 @@ export interface BuildVoiceTurnSignalContext extends ShouldRespondContext {
    * guard misses (a mis-transcribed echo whose words don't match the reply).
    */
   selfVoiceSimilarity?: number;
+  /**
+   * Decision threshold for `selfVoiceSimilarity`. The threshold is a property
+   * of the MEASUREMENT SOURCE, so it travels with the value: the MFCC-timbre
+   * workbench measure clears {@link AGENT_SELF_VOICE_THRESHOLD} (the default),
+   * while a WeSpeaker-embedding cosine against the agent's TTS centroid sits on
+   * a much lower scale (self ~0.37 vs human ~0.15) and must be gated at
+   * {@link AGENT_SELF_VOICE_IMPRINT_THRESHOLD} instead — at the 0.7 bar the
+   * production imprint could never fire.
+   */
+  selfVoiceThreshold?: number;
 }
 
 /** Server SUPPRESS threshold for EOT — below this reads as "user still talking". */
@@ -144,6 +154,16 @@ export const BYSTANDER_SUPPRESS_CONFIDENCE = 0.7;
  * safe and catches echo the transcript guard cannot.
  */
 export const AGENT_SELF_VOICE_THRESHOLD = 0.7;
+/**
+ * Agent-specific decision threshold for a **WeSpeaker-embedding** cosine
+ * against the agent's own TTS-voice centroid (`AgentSelfVoiceImprint`).
+ * Measured margins (`research/VOICE_8785_ASSESSMENT.md` §6, real on-device
+ * encoder): the agent's synthesized voice embeds ~0.37 self-similar while
+ * human speech lands ~0.15 (down to −0.13) — a clear but LOW-scale margin, so
+ * the 0.78 human-enrollment bar (and the 0.7 MFCC bar above) can never fire on
+ * it. 0.28 splits the measured margin; the documented safe range is 0.25–0.30.
+ */
+export const AGENT_SELF_VOICE_IMPRINT_THRESHOLD = 0.28;
 
 export function buildVoiceTurnSignal(
   transcript: string,
@@ -187,7 +207,8 @@ export function buildVoiceTurnSignal(
     (context.replyAgeMs ?? Number.POSITIVE_INFINITY) <= ECHO_WINDOW_MS;
   const isSelfVoice =
     context.selfVoiceSimilarity !== undefined &&
-    context.selfVoiceSimilarity >= AGENT_SELF_VOICE_THRESHOLD &&
+    context.selfVoiceSimilarity >=
+      (context.selfVoiceThreshold ?? AGENT_SELF_VOICE_THRESHOLD) &&
     replyRecent;
   if (isSelfVoice) agentShouldSpeak = false;
 

--- a/packages/ui/src/voice/local-asr-capture.test.ts
+++ b/packages/ui/src/voice/local-asr-capture.test.ts
@@ -69,4 +69,47 @@ describe("local ASR capture", () => {
       shouldStop: true,
     });
   });
+
+  it("suppresses quiet echo while the TTS echo gate is active (#12256 layer 1)", () => {
+    // Gate always on: the multiplier (4x) lifts the peak bar from 0.012 to
+    // 0.048, so a quiet 0.02-peak echo tail no longer reads as speech.
+    const detect = createLocalAsrAutoStopDetector(
+      { startGraceMs: 0, isTtsEchoGateActive: () => true },
+      0,
+    );
+    if (!detect) throw new Error("auto-stop detector was not created");
+    const quietEcho = new Float32Array([0.02, -0.02, 0.018]);
+    expect(detect(quietEcho, 100)).toEqual({
+      shouldBuffer: false,
+      shouldStop: false,
+    });
+  });
+
+  it("still hears a loud barge-in through the active echo gate", () => {
+    const detect = createLocalAsrAutoStopDetector(
+      { startGraceMs: 0, isTtsEchoGateActive: () => true },
+      0,
+    );
+    if (!detect) throw new Error("auto-stop detector was not created");
+    // A loud, close interjection (0.2 peak) clears even the raised 0.048 bar.
+    const loudInterjection = new Float32Array([0.2, -0.22, 0.19]);
+    expect(detect(loudInterjection, 100)).toEqual({
+      shouldBuffer: true,
+      shouldStop: false,
+    });
+  });
+
+  it("returns to the normal bar once the gate is inactive", () => {
+    const detect = createLocalAsrAutoStopDetector(
+      { startGraceMs: 0, isTtsEchoGateActive: () => false },
+      0,
+    );
+    if (!detect) throw new Error("auto-stop detector was not created");
+    // Same quiet echo, gate off → now above the default 0.012 peak bar.
+    const quiet = new Float32Array([0.02, -0.02, 0.018]);
+    expect(detect(quiet, 100)).toEqual({
+      shouldBuffer: true,
+      shouldStop: false,
+    });
+  });
 });

--- a/packages/ui/src/voice/local-asr-capture.test.ts
+++ b/packages/ui/src/voice/local-asr-capture.test.ts
@@ -71,14 +71,15 @@ describe("local ASR capture", () => {
   });
 
   it("suppresses quiet echo while the TTS echo gate is active (#12256 layer 1)", () => {
-    // Gate always on: the multiplier (4x) lifts the peak bar from 0.012 to
-    // 0.048, so a quiet 0.02-peak echo tail no longer reads as speech.
+    // Gate always on: the 4x multiplier lifts the RMS bar 0.003→0.012 and the
+    // peak bar 0.012→0.048. The echo below (rms ~0.0077, peak 0.008) is above
+    // the DEFAULT bar (would be heard) but below the raised gate → suppressed.
     const detect = createLocalAsrAutoStopDetector(
       { startGraceMs: 0, isTtsEchoGateActive: () => true },
       0,
     );
     if (!detect) throw new Error("auto-stop detector was not created");
-    const quietEcho = new Float32Array([0.02, -0.02, 0.018]);
+    const quietEcho = new Float32Array([0.008, -0.008, 0.007]);
     expect(detect(quietEcho, 100)).toEqual({
       shouldBuffer: false,
       shouldStop: false,
@@ -105,8 +106,8 @@ describe("local ASR capture", () => {
       0,
     );
     if (!detect) throw new Error("auto-stop detector was not created");
-    // Same quiet echo, gate off → now above the default 0.012 peak bar.
-    const quiet = new Float32Array([0.02, -0.02, 0.018]);
+    // Same quiet echo, gate off → now above the default 0.003 RMS bar.
+    const quiet = new Float32Array([0.008, -0.008, 0.007]);
     expect(detect(quiet, 100)).toEqual({
       shouldBuffer: true,
       shouldStop: false,

--- a/packages/ui/src/voice/local-asr-capture.ts
+++ b/packages/ui/src/voice/local-asr-capture.ts
@@ -2,6 +2,11 @@
  * Mic-capture recorder for local ASR: records mono PCM16, exposes a live analyser
  * for amplitude visualization, and stops/cancels the audio context cleanly.
  */
+import {
+  DEFAULT_POST_TTS_COOLDOWN_MS,
+  isTtsEchoGateActive as sharedTtsEchoGateActive,
+} from "./tts-playback-activity";
+
 export interface LocalAsrRecorder {
   stop(): Promise<Uint8Array>;
   cancel(): void;
@@ -19,6 +24,12 @@ export interface LocalAsrAutoStopOptions {
   maxSpeechMs?: number;
   speechRmsThreshold?: number;
   speechPeakThreshold?: number;
+  /** Post-TTS cooldown (ms) during which the raised echo gate stays active.
+   * Default {@link DEFAULT_POST_TTS_COOLDOWN_MS} (1500). */
+  postTtsCooldownMs?: number;
+  /** Injectable playback-activity probe (tests). Defaults to the shared
+   * renderer signal in tts-playback-activity.ts. */
+  isTtsEchoGateActive?: (nowMs: number) => boolean;
 }
 
 export interface LocalAsrRecorderOptions {
@@ -116,6 +127,15 @@ export function isSilentPcmAudio(pcm: Float32Array): boolean {
   return measurePcmAudio(pcm).peak < 0.0005;
 }
 
+/**
+ * Speech-threshold multiplier applied while the TTS echo gate is active
+ * (#12256 layer 1): during agent playback + the post-TTS cooldown, quiet
+ * far-field echo must not read as speech, while loud close speech (a real
+ * barge-in) still clears the raised bar. 4x lifts the default RMS gate from
+ * 0.003 to 0.012 and the peak gate from 0.012 to 0.048.
+ */
+export const POST_TTS_ECHO_THRESHOLD_MULTIPLIER = 4;
+
 export const DEFAULT_LOCAL_ASR_AUTO_STOP: LocalAsrAutoStopConfig = {
   startGraceMs: 250,
   minSpeechMs: 180,
@@ -137,6 +157,10 @@ export function createLocalAsrAutoStopDetector(
     ...DEFAULT_LOCAL_ASR_AUTO_STOP,
     ...options,
   };
+  const cooldownMs = options.postTtsCooldownMs ?? DEFAULT_POST_TTS_COOLDOWN_MS;
+  const echoGateActive =
+    options.isTtsEchoGateActive ??
+    ((atMs: number) => sharedTtsEchoGateActive(atMs, cooldownMs));
   let firstSpeechAtMs: number | null = null;
   let lastSpeechAtMs: number | null = null;
   let stopped = false;
@@ -150,9 +174,16 @@ export function createLocalAsrAutoStopDetector(
     }
 
     const stats = measurePcmAudio(pcm);
+    // Echo gate (#12256 layer 1): while the agent's TTS is playing (and for a
+    // short cooldown after), demand louder speech before treating the frame as
+    // a turn — the agent's own tail must not self-trigger an ASR submission,
+    // but a loud, close interjection (real barge-in) still clears the bar.
+    const gateMultiplier = echoGateActive(sampleTimeMs)
+      ? POST_TTS_ECHO_THRESHOLD_MULTIPLIER
+      : 1;
     const speechDetected =
-      stats.rms >= config.speechRmsThreshold ||
-      stats.peak >= config.speechPeakThreshold;
+      stats.rms >= config.speechRmsThreshold * gateMultiplier ||
+      stats.peak >= config.speechPeakThreshold * gateMultiplier;
 
     if (speechDetected) {
       if (firstSpeechAtMs === null) firstSpeechAtMs = sampleTimeMs;

--- a/packages/ui/src/voice/playback-frame-pump.ts
+++ b/packages/ui/src/voice/playback-frame-pump.ts
@@ -10,6 +10,10 @@
 
 import { fetchWithCsrf } from "../api/csrf-client";
 import { resolveApiUrl } from "../utils";
+import {
+  markTtsPlaybackEnded,
+  markTtsPlaybackStarted,
+} from "./tts-playback-activity";
 
 const PLAYBACK_FRAMES_PATH = "/api/voice/playback-frames";
 const TARGET_SAMPLE_RATE = 16_000;
@@ -274,6 +278,9 @@ class PlaybackFrameSession implements PlaybackFrameTap {
     if (this.running) return;
     this.running = true;
     this.startTimestampMs = startTimestampMs;
+    // The session brackets real audible playback — raise the capture-side
+    // echo gate for its duration + cooldown (#12256 layer 1).
+    markTtsPlaybackStarted();
     this.flushTimer = setInterval(() => {
       void this.flush(false);
     }, this.flushIntervalMs);
@@ -305,6 +312,7 @@ class PlaybackFrameSession implements PlaybackFrameTap {
     options: { reset?: boolean; drain?: boolean } = {},
   ): Promise<void> {
     if (!this.running && !options.reset) return;
+    if (this.running) markTtsPlaybackEnded(this.nowMs());
     this.running = false;
     if (this.flushTimer) {
       clearInterval(this.flushTimer);

--- a/packages/ui/src/voice/tts-playback-activity.test.ts
+++ b/packages/ui/src/voice/tts-playback-activity.test.ts
@@ -1,0 +1,45 @@
+/** Renderer TTS echo-gate signal (#12256 layer 1) — pure timing state. */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __resetTtsPlaybackActivityForTest,
+  DEFAULT_POST_TTS_COOLDOWN_MS,
+  isTtsEchoGateActive,
+  markTtsPlaybackEnded,
+  markTtsPlaybackStarted,
+} from "./tts-playback-activity";
+
+afterEach(() => __resetTtsPlaybackActivityForTest());
+
+describe("tts-playback-activity", () => {
+  it("gate is off with no playback", () => {
+    expect(isTtsEchoGateActive(1000)).toBe(false);
+  });
+
+  it("gate is active while any playback session runs", () => {
+    markTtsPlaybackStarted();
+    expect(isTtsEchoGateActive(1000)).toBe(true);
+    // A second overlapping session keeps it active until both end.
+    markTtsPlaybackStarted();
+    markTtsPlaybackEnded(1000);
+    expect(isTtsEchoGateActive(1000)).toBe(true);
+    markTtsPlaybackEnded(1000);
+    expect(isTtsEchoGateActive(1000)).toBe(true); // still inside cooldown
+  });
+
+  it("stays active through the cooldown window, then clears", () => {
+    markTtsPlaybackStarted();
+    markTtsPlaybackEnded(5000);
+    expect(isTtsEchoGateActive(5000 + DEFAULT_POST_TTS_COOLDOWN_MS)).toBe(true);
+    expect(
+      isTtsEchoGateActive(5000 + DEFAULT_POST_TTS_COOLDOWN_MS + 1),
+    ).toBe(false);
+  });
+
+  it("honors a custom cooldown", () => {
+    markTtsPlaybackStarted();
+    markTtsPlaybackEnded(0);
+    expect(isTtsEchoGateActive(400, 500)).toBe(true);
+    expect(isTtsEchoGateActive(600, 500)).toBe(false);
+  });
+});

--- a/packages/ui/src/voice/tts-playback-activity.ts
+++ b/packages/ui/src/voice/tts-playback-activity.ts
@@ -1,0 +1,58 @@
+/**
+ * Renderer-wide TTS playback-activity signal — the first (cheapest) layer of
+ * the echo defense (#12256): while the agent's TTS is playing, and for a short
+ * cooldown after it ends, the always-on capture raises its speech thresholds
+ * so the agent's own tail can't self-trigger an ASR submission.
+ *
+ * The playback-frame pump sessions (playback-frame-pump.ts) bracket real
+ * audible playback on the local-inference/cloud paths, so they mark this
+ * signal on start/stop; the local ASR capture's auto-stop detector reads it.
+ * All timestamps are in the renderer's `performance.now()` domain. Pure
+ * module state, no DOM.
+ */
+
+/** Post-TTS cooldown window (ms) during which the raised gate stays on —
+ * the `VOICE_WORKBENCH.md` half-duplex recommendation. The server side reads
+ * `ELIZA_VOICE_POST_TTS_COOLDOWN_MS`; the renderer uses this default. */
+export const DEFAULT_POST_TTS_COOLDOWN_MS = 1500;
+
+function nowMsDefault(): number {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+let activePlaybackSessions = 0;
+let lastPlaybackEndedAtMs: number | null = null;
+
+/** A TTS playback session began rendering audio. */
+export function markTtsPlaybackStarted(): void {
+  activePlaybackSessions += 1;
+}
+
+/** A TTS playback session finished (or was interrupted). */
+export function markTtsPlaybackEnded(nowMs = nowMsDefault()): void {
+  activePlaybackSessions = Math.max(0, activePlaybackSessions - 1);
+  lastPlaybackEndedAtMs = nowMs;
+}
+
+/**
+ * True while TTS playback is active, or within `cooldownMs` after the last
+ * playback ended — the window in which the capture side must demand louder
+ * (closer) speech before starting an ASR submission. Barge-in still works:
+ * the gate raises thresholds, it never mutes.
+ */
+export function isTtsEchoGateActive(
+  nowMs = nowMsDefault(),
+  cooldownMs = DEFAULT_POST_TTS_COOLDOWN_MS,
+): boolean {
+  if (activePlaybackSessions > 0) return true;
+  return (
+    lastPlaybackEndedAtMs !== null &&
+    nowMs - lastPlaybackEndedAtMs <= cooldownMs
+  );
+}
+
+/** Clear all playback-activity state. Test-only. */
+export function __resetTtsPlaybackActivityForTest(): void {
+  activePlaybackSessions = 0;
+  lastPlaybackEndedAtMs = null;
+}

--- a/plugins/plugin-local-inference/scripts/echo-aec-evidence.ts
+++ b/plugins/plugin-local-inference/scripts/echo-aec-evidence.ts
@@ -1,0 +1,352 @@
+/**
+ * Domain evidence for #12256: drives the synthetic echo corpus through the REAL
+ * production echo defense — the NlmsEchoCanceller, the desktop FarEndReference
+ * (whole-utterance align + cancel), and an MFCC-embedding AgentSelfVoiceImprint
+ * — and prints the ERLE + self-voice-rejection numbers against the #12258
+ * workbench ceilings (minErleDb 18). No models, no network, no device: the DSP
+ * is real, the speech is deterministic synthesis (synthetic-speech.ts +
+ * corpus-augment.ts). Writes a JSON report for the PR evidence bundle.
+ *
+ *   bun run scripts/echo-aec-evidence.ts [--json <path>]
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { computeErle, computeFarActiveErle } from "@elizaos/shared/voice/aec";
+import {
+	AGENT_VOICE_TIMBRE,
+	makeSpeechWithSilenceFixture,
+	speakerTimbreForIndex,
+} from "../src/services/voice/__test-helpers__/synthetic-speech.js";
+import { extractTimbreEmbedding } from "../src/services/voice/acoustic-speaker-attribution.js";
+import { applyGainDb, applyReverb } from "../src/services/voice/corpus-augment.js";
+import {
+	cancelEchoInWavUtterance,
+	FarEndReference,
+} from "../src/services/voice/far-end-reference.js";
+import { AgentSelfVoiceImprint } from "../src/services/voice/self-voice-imprint.js";
+import type { SpeakerEncoder } from "../src/services/voice/speaker/encoder.js";
+import { NlmsEchoCanceller } from "../src/services/voice/nlms-echo-canceller.js";
+import { encodeMonoPcm16Wav } from "../src/services/voice/wav-codec.js";
+
+const SR = 16_000;
+const MIN_ERLE_DB = 18; // #12258 desktop-aec ceiling.
+
+/** The agent's rendered TTS for a turn (its own synthetic voice). */
+function agentTts(seed: number, sec = 1.6): Float32Array {
+	return makeSpeechWithSilenceFixture({
+		sampleRate: SR,
+		leadSilenceSec: 0.05,
+		speechSec: sec,
+		tailSilenceSec: 0.05,
+		seed,
+		timbre: AGENT_VOICE_TIMBRE,
+	}).pcm;
+}
+
+/** A human turn (a scenario participant's voice, acoustically distinct). */
+function humanTurn(seed: number, index: number, sec = 1.6): Float32Array {
+	return makeSpeechWithSilenceFixture({
+		sampleRate: SR,
+		leadSilenceSec: 0.05,
+		speechSec: sec,
+		tailSilenceSec: 0.05,
+		seed,
+		timbre: speakerTimbreForIndex(index, 4),
+	}).pcm;
+}
+
+/**
+ * The agent's playback as it returns through the room into the mic: a bulk
+ * transport delay + far-field attenuation, plus an optional SHORT room impulse
+ * (a few early reflections within the 256-tap / 16 ms adaptive span — a longer
+ * reverb tail is AEC3-class work and out of the NLMS filter's reach). `near`
+ * has `far` starting at `delaySamples`; index 0..delay is pre-echo silence.
+ */
+function roomEcho(
+	far: Float32Array,
+	delaySamples: number,
+	farFieldDb: number,
+	earlyReflections: ReadonlyArray<readonly [number, number]> = [],
+): Float32Array {
+	const attenuated = applyGainDb(far, -Math.abs(farFieldDb));
+	const near = new Float32Array(far.length + delaySamples + 512);
+	// Direct echo path.
+	for (let i = 0; i < attenuated.length; i++) near[delaySamples + i] += attenuated[i];
+	// A few early reflections (tapDelaySamples, gain) within the filter span.
+	for (const [tap, gain] of earlyReflections) {
+		for (let i = 0; i < attenuated.length; i++) {
+			near[delaySamples + tap + i] += attenuated[i] * gain;
+		}
+	}
+	return near;
+}
+
+/** Far-end reference aligned sample-for-sample to `near` (far starts at
+ * `delaySamples`), for far-active ERLE masking. */
+function alignedReference(far: Float32Array, nearLen: number, delaySamples: number): Float32Array {
+	const aligned = new Float32Array(nearLen);
+	for (let i = 0; i < far.length && delaySamples + i < nearLen; i++) {
+		aligned[delaySamples + i] = far[i];
+	}
+	return aligned;
+}
+
+/**
+ * Direct per-utterance NLMS ERLE (echo-only). The canceller pre-delays the raw
+ * `far` reference by `delaySamples` itself, so we pass raw `far` (NOT a shifted
+ * copy) — pre-shifting AND setting delaySamples would double the delay. A warm
+ * pass converges the adaptive filter before the measured pass.
+ */
+function directNlmsErle(
+	far: Float32Array,
+	delaySamples: number,
+	farFieldDb: number,
+	earlyReflections: ReadonlyArray<readonly [number, number]>,
+): { erleDb: number; farActiveErleDb: number | null } {
+	const near = roomEcho(far, delaySamples, farFieldDb, earlyReflections);
+	const reference = new Float32Array(near.length);
+	reference.set(far.subarray(0, Math.min(far.length, near.length)));
+	const canceller = new NlmsEchoCanceller({ delaySamples });
+	canceller.process(near, reference); // warm the adaptive filter
+	const residual = canceller.process(near, reference); // measured (converged)
+	const aligned = alignedReference(far, near.length, delaySamples);
+	const masked = computeFarActiveErle(near, residual, aligned);
+	return { erleDb: computeErle(near, residual), farActiveErleDb: masked.erleDb };
+}
+
+/** An MFCC-timbre SpeakerEncoder — the real acoustic embedding, encoder-free
+ * (no fused WeSpeaker GGUF in this worktree; labelled honestly in the report). */
+const mfccEncoder: SpeakerEncoder = {
+	embeddingDim: 13,
+	sampleRate: SR,
+	async encode(pcm: Float32Array): Promise<Float32Array> {
+		return Float32Array.from(extractTimbreEmbedding(pcm, SR));
+	},
+};
+
+async function main(): Promise<void> {
+	const report: Record<string, unknown> = {
+		generatedAt: new Date().toISOString(),
+		minErleDbCeiling: MIN_ERLE_DB,
+		note:
+			"Real NlmsEchoCanceller + FarEndReference + MFCC AgentSelfVoiceImprint over the deterministic synthetic echo corpus. The fused WeSpeaker GGUF is unstaged in this worktree, so the embedding encoder is MFCC-timbre (13d); real-hardware ERLE (device-acoustic-erle.mjs) is N/A without a loaded acoustic host.",
+	};
+
+	// ── 1. Direct NLMS ERLE across echo conditions ─────────────────────────
+	// Early reflections are [tapSamples, gain] within the 256-tap span.
+	const conditions = [
+		{ name: "clean-echo", delayMs: 20, farFieldDb: 6, reflections: [] as ReadonlyArray<readonly [number, number]> },
+		{ name: "early-reflections", delayMs: 45, farFieldDb: 9, reflections: [[64, 0.35], [150, 0.18]] as ReadonlyArray<readonly [number, number]> },
+		{ name: "long-transport", delayMs: 380, farFieldDb: 9, reflections: [[80, 0.3]] as ReadonlyArray<readonly [number, number]> },
+	];
+	const nlms = conditions.map((c) => {
+		const far = agentTts(0x1000 + Math.round(c.delayMs));
+		const { erleDb, farActiveErleDb } = directNlmsErle(
+			far,
+			Math.round((c.delayMs / 1000) * SR),
+			c.farFieldDb,
+			c.reflections,
+		);
+		return {
+			condition: c.name,
+			delayMs: c.delayMs,
+			farFieldDb: c.farFieldDb,
+			earlyReflections: c.reflections,
+			erleDb: Number(erleDb.toFixed(2)),
+			farActiveErleDb:
+				farActiveErleDb === null ? null : Number(farActiveErleDb.toFixed(2)),
+			meetsCeiling: (farActiveErleDb ?? erleDb) >= MIN_ERLE_DB,
+		};
+	});
+	report.directNlms = nlms;
+
+	// ── 2. Desktop FarEndReference end-to-end (align + cancel a WAV) ────────
+	const far = agentTts(0x2222, 2.4);
+	const farEnd = new FarEndReference();
+	const baseTs = 5_000;
+	const epoch = 1_000_000;
+	// Deliver the playback as timestamped renderer frames (20 ms), as the pump does.
+	const frameSamples = 320;
+	for (let i = 0; (i + 1) * frameSamples <= far.length; i += 1) {
+		const framePcm = far.subarray(i * frameSamples, (i + 1) * frameSamples);
+		const bytes = Buffer.alloc(frameSamples * 2);
+		for (let k = 0; k < frameSamples; k++) {
+			bytes.writeInt16LE(
+				Math.round(Math.max(-1, Math.min(1, framePcm[k])) * 32767),
+				k * 2,
+			);
+		}
+		farEnd.pushPlayback(
+			[
+				{
+					pcm16: bytes.toString("base64"),
+					sampleRate: SR,
+					channels: 1,
+					samples: frameSamples,
+					rms: 0.1,
+					timestamp: baseTs + i * 20,
+					frameIndex: i,
+				},
+			],
+			baseTs + i * 20 + epoch + 5,
+		);
+	}
+	farEnd.notePlaybackReset(); // the pump resets before the echoed WAV arrives
+	// The mic hears the far playback delayed 60 ms + far-field + early reflections.
+	const delaySamples = Math.round(0.06 * SR);
+	const nearFull = roomEcho(far, delaySamples, 10, [
+		[70, 0.3],
+		[160, 0.15],
+	]);
+	const nearWav = encodeMonoPcm16Wav(nearFull, SR);
+	const nearEndTs = baseTs + (nearFull.length / SR) * 1000;
+	const outcome = cancelEchoInWavUtterance(
+		farEnd,
+		nearWav,
+		nearEndTs + epoch + 15,
+	);
+	report.desktopFarEndReference = {
+		applied: outcome.result?.applied ?? false,
+		reason: outcome.result?.reason ?? null,
+		erleDb:
+			outcome.result?.erleDb == null
+				? null
+				: Number(outcome.result.erleDb.toFixed(2)),
+		offsetSamples: outcome.result?.offsetSamples ?? null,
+		confidence:
+			outcome.result?.confidence == null
+				? null
+				: Number(outcome.result.confidence.toFixed(3)),
+		farActiveSamples: outcome.result?.farActiveSamples ?? 0,
+		meetsCeiling: (outcome.result?.erleDb ?? 0) >= MIN_ERLE_DB,
+		status: farEnd.status(),
+	};
+
+	// ── 3. Self-voice imprint: agent rejected, humans passed ────────────────
+	// NOTE on thresholds: the imprint's 0.28 default is calibrated for the fused
+	// WeSpeaker embedding (self ~0.37 vs human ~0.15, §6) — unstaged here. The
+	// deterministic MFCC-timbre-13d proxy encoder sits on a DIFFERENT scale
+	// (same-timbre ~1.0), so the honest operating point for THIS encoder is the
+	// workbench's MFCC bar (0.7), not 0.28. The gate LOGIC is identical; only the
+	// per-encoder threshold differs — which is exactly why `selfVoiceThreshold`
+	// travels with the measurement. We report separation at the MFCC operating
+	// point AND cite the production WeSpeaker margins from §6.
+	const MFCC_THRESHOLD = 0.7;
+	const imprint = new AgentSelfVoiceImprint({
+		encoder: mfccEncoder,
+		minSamples: SR,
+		similarityThreshold: MFCC_THRESHOLD,
+	});
+	// Enroll the imprint from many agent utterances (a centroid, not one clip).
+	for (let i = 0; i < 8; i++) {
+		await imprint.observeAudio(agentTts(0x3000 + i, 1.6), SR);
+	}
+	const agentProbes = [] as { seed: number; similarity: number; rejected: boolean | null }[];
+	for (let i = 0; i < 5; i++) {
+		const emb = await mfccEncoder.encode(agentTts(0x4000 + i, 1.6));
+		const similarity = await imprint.similarity(emb);
+		agentProbes.push({
+			seed: 0x4000 + i,
+			similarity: similarity === null ? Number.NaN : Number(similarity.toFixed(3)),
+			rejected: await imprint.isAgentSelfVoice(emb),
+		});
+	}
+	const humanProbes = [] as { seed: number; index: number; similarity: number; rejected: boolean | null }[];
+	for (let i = 0; i < 4; i++) {
+		const emb = await mfccEncoder.encode(humanTurn(0x5000 + i, i, 1.6));
+		const similarity = await imprint.similarity(emb);
+		humanProbes.push({
+			seed: 0x5000 + i,
+			index: i,
+			similarity: similarity === null ? Number.NaN : Number(similarity.toFixed(3)),
+			rejected: await imprint.isAgentSelfVoice(emb),
+		});
+	}
+	const agentSelfMean =
+		agentProbes.reduce((s, p) => s + p.similarity, 0) / agentProbes.length;
+	const humanMean =
+		humanProbes.reduce((s, p) => s + p.similarity, 0) / humanProbes.length;
+	report.selfVoiceImprint = {
+		mfccOperatingThreshold: MFCC_THRESHOLD,
+		productionWeSpeakerThreshold: 0.28,
+		productionMarginsFromAssessmentSection6: { agentSelf: 0.37, human: 0.15 },
+		encoder: "mfcc-timbre-13d (fused WeSpeaker GGUF unstaged in this worktree)",
+		agentSelfSimilarityMean: Number(agentSelfMean.toFixed(3)),
+		humanSimilarityMean: Number(humanMean.toFixed(3)),
+		humanSimilarityMax: Number(
+			Math.max(...humanProbes.map((p) => p.similarity)).toFixed(3),
+		),
+		allAgentRejected: agentProbes.every((p) => p.rejected === true),
+		allHumanPassed: humanProbes.every((p) => p.rejected === false),
+		agentProbes,
+		humanProbes,
+	};
+
+	// ── verdict ─────────────────────────────────────────────────────────────
+	const nlmsPass = nlms.every((n) => n.meetsCeiling);
+	const desktopPass =
+		(report.desktopFarEndReference as { meetsCeiling: boolean }).meetsCeiling;
+	const selfVoicePass =
+		(report.selfVoiceImprint as { allAgentRejected: boolean; allHumanPassed: boolean }).allAgentRejected &&
+		(report.selfVoiceImprint as { allHumanPassed: boolean }).allHumanPassed;
+	report.verdict = nlmsPass && desktopPass && selfVoicePass ? "PASS" : "FAIL";
+
+	// ── print ────────────────────────────────────────────────────────────────
+	console.log("=== #12256 echo/AEC domain evidence (real DSP over synthetic corpus) ===\n");
+	console.log("Direct NLMS ERLE (ceiling: minErleDb 18):");
+	for (const n of nlms) {
+		console.log(
+			`  ${n.condition.padEnd(18)} delay=${n.delayMs}ms farField=${n.farFieldDb}dB reflections=${n.earlyReflections.length}  ERLE=${n.erleDb}dB  far-active=${n.farActiveErleDb}dB  ${n.meetsCeiling ? "PASS" : "FAIL"}`,
+		);
+	}
+	const d = report.desktopFarEndReference as {
+		applied: boolean;
+		erleDb: number | null;
+		confidence: number | null;
+		offsetSamples: number | null;
+		meetsCeiling: boolean;
+	};
+	console.log(
+		`\nDesktop FarEndReference (whole-utterance align+cancel): applied=${d.applied} ERLE=${d.erleDb}dB confidence=${d.confidence} offset=${d.offsetSamples}samples  ${d.meetsCeiling ? "PASS" : "FAIL"}`,
+	);
+	const s = report.selfVoiceImprint as {
+		mfccOperatingThreshold: number;
+		productionWeSpeakerThreshold: number;
+		agentSelfSimilarityMean: number;
+		humanSimilarityMean: number;
+		humanSimilarityMax: number;
+		allAgentRejected: boolean;
+		allHumanPassed: boolean;
+	};
+	console.log(
+		`\nSelf-voice imprint (MFCC proxy threshold ${s.mfccOperatingThreshold}; production WeSpeaker ${s.productionWeSpeakerThreshold}):`,
+	);
+	console.log(
+		`  agent-self mean=${s.agentSelfSimilarityMean}  human mean=${s.humanSimilarityMean} (max ${s.humanSimilarityMax})`,
+	);
+	console.log(
+		`  all agent echoes rejected: ${s.allAgentRejected}   all humans passed: ${s.allHumanPassed}`,
+	);
+	console.log(`\nVERDICT: ${report.verdict}\n`);
+
+	const jsonFlag = process.argv.indexOf("--json");
+	const jsonPath =
+		jsonFlag >= 0 && process.argv[jsonFlag + 1]
+			? process.argv[jsonFlag + 1]
+			: path.join(
+					process.cwd(),
+					"..",
+					"..",
+					".github",
+					"issue-evidence",
+					"12256-echo",
+					"echo-aec-evidence.json",
+				);
+	mkdirSync(path.dirname(jsonPath), { recursive: true });
+	writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`);
+	console.log(`Report written: ${jsonPath}`);
+	if (report.verdict !== "PASS") process.exitCode = 1;
+}
+
+void main();

--- a/plugins/plugin-local-inference/src/routes/live-diarization-route.ts
+++ b/plugins/plugin-local-inference/src/routes/live-diarization-route.ts
@@ -41,6 +41,8 @@ import type {
 	AudioFrameEvent,
 	EchoReferenceProvider,
 } from "../services/voice/audio-frame-consumer.js";
+import { replayAecCaptureErle } from "../services/voice/echo-metrics.js";
+import { getSharedFarEndReference } from "../services/voice/far-end-reference.js";
 import {
 	LiveDiarizationSession,
 	type RuntimeEventSink,
@@ -238,7 +240,11 @@ export async function handleLiveDiarizationRoute(
 		// $ELIZA_STATE_DIR, which host tooling pulls with
 		// `devicectl device copy from` — the robust, bridge-free retrieval path.
 		await persistAecEvidence(capture, await current.status());
-		sendJson(res, 200, { ok: true, capture });
+		// On-demand ERLE (#12256): replay the captured near/far window through
+		// the production canceller so the capture read carries the measured
+		// number, not just raw PCM. Null when nothing was captured.
+		const erle = capture.sampleCount > 0 ? replayAecCaptureErle(capture) : null;
+		sendJson(res, 200, { ok: true, capture, erle });
 		return true;
 	}
 
@@ -251,7 +257,10 @@ export async function handleLiveDiarizationRoute(
 		}
 		const body = await readCompatJsonBody(req, res);
 		if (!body) return true;
-		if (body.reset === true) current.resetPlayback();
+		if (body.reset === true) {
+			current.resetPlayback();
+			getSharedFarEndReference().notePlaybackReset();
+		}
 		const rawFrames = body.frames;
 		if (rawFrames !== undefined && !Array.isArray(rawFrames)) {
 			sendJsonError(
@@ -273,6 +282,10 @@ export async function handleLiveDiarizationRoute(
 			return true;
 		}
 		current.pushPlayback(frames);
+		// One ingest, two consumers (#12256): the same rendered-playback frames
+		// feed Pipeline A's per-frame canceller (above) and the desktop
+		// utterance-level far-end reference used by /api/asr/local-inference.
+		getSharedFarEndReference().pushPlayback(frames);
 		sendJson(res, 200, { ok: true, framesPushed: frames.length });
 		return true;
 	}

--- a/plugins/plugin-local-inference/src/routes/local-inference-asr-route.test.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-asr-route.test.ts
@@ -8,6 +8,12 @@ import * as http from "node:http";
 import { Socket } from "node:net";
 import { ModelType } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AudioFrameEvent } from "../services/voice/audio-frame-consumer";
+import {
+	__resetSharedFarEndReferenceForTest,
+	getSharedFarEndReference,
+} from "../services/voice/far-end-reference";
+import { encodeMonoPcm16Wav } from "../services/voice/wav-codec";
 import type { CompatRuntimeState } from "./compat-helpers";
 import { handleLocalInferenceAsrRoute } from "./local-inference-asr-route";
 import { transcribeWavWithWords } from "./local-inference-asr-transcribe";
@@ -29,7 +35,17 @@ const transcribeWavWithWordsMock = vi.mocked(transcribeWavWithWords);
 beforeEach(() => {
 	vi.clearAllMocks();
 	engineMock.canTranscribeLocally.mockResolvedValue(true);
+	__resetSharedFarEndReferenceForTest();
 });
+
+/** The desktop AEC verdict attached to every WAV transcription response when
+ * no playback reference exists (the honest passthrough case). */
+const AEC_NO_FAR_END = {
+	applied: false,
+	reason: "no-far-end",
+	erleDb: null,
+	confidence: null,
+};
 
 function wavBytes(): Uint8Array {
 	const pcm = new Int16Array([0, 900, -900, 0]);
@@ -225,6 +241,7 @@ describe("local inference ASR route", () => {
 				{ text: "local", startMs: 400, endMs: 700 },
 				{ text: "voice", startMs: 700, endMs: 1000 },
 			],
+			aec: AEC_NO_FAR_END,
 		});
 	});
 
@@ -247,6 +264,94 @@ describe("local inference ASR route", () => {
 		expect(
 			Array.from(transcribeWavWithWordsMock.mock.calls[0]?.[1] as Uint8Array),
 		).toEqual(Array.from(wavBytes()));
-		expect(out.bodyJson()).toEqual({ text: "hello from json", words: [] });
+		expect(out.bodyJson()).toEqual({
+			text: "hello from json",
+			words: [],
+			aec: AEC_NO_FAR_END,
+		});
+	});
+
+	it("cancels the desktop echo before transcription when the far-end reference is live (#12256)", async () => {
+		transcribeWavWithWordsMock.mockResolvedValue({ text: "", words: [] });
+		// 3 s of deterministic pseudo-speech playback, delivered as timestamped
+		// renderer frames; the mic WAV is that playback attenuated + delayed.
+		const SR = 16_000;
+		const speech = (n: number, seed: number): Float32Array => {
+			const outPcm = new Float32Array(n);
+			let state = seed >>> 0 || 1;
+			let lp = 0;
+			for (let i = 0; i < n; i++) {
+				state = (state * 1664525 + 1013904223) >>> 0;
+				lp = 0.85 * lp + 0.15 * (state / 0xffffffff - 0.5);
+				outPcm[i] =
+					(0.55 + 0.45 * Math.sin((2 * Math.PI * 2.3 * i) / SR)) * lp * 2.5;
+			}
+			return outPcm;
+		};
+		const far = speech(48_000, 7);
+		const baseTs = 5_000;
+		const epochOffset = 1_000_000;
+		const farEnd = getSharedFarEndReference();
+		const frames: AudioFrameEvent[] = [];
+		for (let index = 0; (index + 1) * 320 <= far.length; index += 1) {
+			const framePcm = far.subarray(index * 320, (index + 1) * 320);
+			const bytes = Buffer.alloc(320 * 2);
+			for (let i = 0; i < 320; i++) {
+				bytes.writeInt16LE(
+					Math.round(Math.max(-1, Math.min(1, framePcm[i])) * 32767),
+					i * 2,
+				);
+			}
+			frames.push({
+				pcm16: bytes.toString("base64"),
+				sampleRate: SR,
+				channels: 1,
+				samples: 320,
+				rms: 0.1,
+				timestamp: baseTs + index * 20,
+				frameIndex: index,
+			});
+		}
+		for (let i = 0; i < frames.length; i += 12) {
+			const batch = frames.slice(i, i + 12);
+			farEnd.pushPlayback(
+				batch,
+				batch[batch.length - 1].timestamp + epochOffset + 5,
+			);
+		}
+		const nearStartTs = 5_100;
+		const nearLen = 40_000;
+		const near = new Float32Array(nearLen);
+		const srcBase = Math.round(((nearStartTs - 60 - baseTs) / 1000) * SR);
+		for (let i = 0; i < nearLen; i++) {
+			const k = srcBase + i;
+			if (k >= 0 && k < far.length) near[i] = 0.22 * far[k];
+		}
+		const wav = encodeMonoPcm16Wav(near, SR);
+		const nearEndTs = nearStartTs + (nearLen / SR) * 1000;
+		const nowSpy = vi
+			.spyOn(Date, "now")
+			.mockReturnValue(nearEndTs + epochOffset + 15);
+		try {
+			const state: CompatRuntimeState = {
+				current: {} as unknown as CompatRuntimeState["current"],
+			};
+			const out = fakeRes();
+			await handleLocalInferenceAsrRoute(fakeReq(wav), out.res, state);
+
+			expect(out.status()).toBe(200);
+			const body = out.bodyJson() as {
+				aec: { applied: boolean; erleDb: number };
+			};
+			expect(body.aec.applied).toBe(true);
+			expect(body.aec.erleDb).toBeGreaterThanOrEqual(18);
+			// The transcriber received the CANCELLED bytes, not the raw echo.
+			const forwarded = transcribeWavWithWordsMock.mock
+				.calls[0]?.[1] as Uint8Array;
+			expect(forwarded).not.toEqual(wav);
+			expect(forwarded.byteLength).toBe(wav.byteLength);
+		} finally {
+			nowSpy.mockRestore();
+		}
 	});
 });

--- a/plugins/plugin-local-inference/src/routes/local-inference-asr-route.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-asr-route.ts
@@ -11,8 +11,12 @@
  */
 
 import type http from "node:http";
-import { ModelType } from "@elizaos/core";
+import { logger, ModelType } from "@elizaos/core";
 import { localInferenceEngine } from "../services/engine";
+import {
+	cancelEchoInWavUtterance,
+	getSharedFarEndReference,
+} from "../services/voice/far-end-reference";
 import {
 	type CompatRuntimeState,
 	ensureRouteAuthorized,
@@ -153,13 +157,43 @@ export async function handleLocalInferenceAsrRoute(
 			});
 			return true;
 		}
+		// Desktop speak-back AEC (#12256 layer 2): cancel the agent's own TTS
+		// playback (streamed to /api/voice/playback-frames by the renderer) out
+		// of the utterance before transcription, so the agent stops transcribing
+		// its echo. Passthrough is bit-exact whenever no correlated far-end
+		// reference exists — cancellation is never applied speculatively.
+		const aec = cancelEchoInWavUtterance(getSharedFarEndReference(), audio);
+		if (aec.result?.applied) {
+			logger.info(
+				{
+					erleDb: aec.result.erleDb,
+					offsetSamples: aec.result.offsetSamples,
+					confidence: aec.result.confidence,
+					farActiveSamples: aec.result.farActiveSamples,
+				},
+				"[LocalInferenceAsrRoute] echo-cancelled utterance before ASR",
+			);
+		}
 		const { text, words } = await transcribeWavWithWords(
 			runtime,
-			audio,
+			aec.bytes,
 			abortController.signal,
 		);
 		completed = true;
-		sendJson(res, 200, { text, words });
+		sendJson(res, 200, {
+			text,
+			words,
+			...(aec.result
+				? {
+						aec: {
+							applied: aec.result.applied,
+							...(aec.result.reason ? { reason: aec.result.reason } : {}),
+							erleDb: aec.result.erleDb,
+							confidence: aec.result.confidence,
+						},
+					}
+				: {}),
+		});
 	} catch (err) {
 		if (!clientClosed && !abortController.signal.aborted && !isClosed(res)) {
 			sendJson(res, 502, {

--- a/plugins/plugin-local-inference/src/runtime/voice-entity-binding.ts
+++ b/plugins/plugin-local-inference/src/runtime/voice-entity-binding.ts
@@ -147,6 +147,13 @@ export interface HandleLiveVoiceAttributionOptions {
 	 * agent's playback, not a human user.
 	 */
 	selfVoiceSimilarity?: number | null;
+	/**
+	 * Decision threshold for `selfVoiceSimilarity`. Travels with the value: a
+	 * WeSpeaker-embedding cosine against the agent's TTS centroid is decided at
+	 * `AGENT_SELF_VOICE_IMPRINT_THRESHOLD` (~0.28), not the 0.7 MFCC default —
+	 * at the default bar the production imprint (self ~0.37) could never fire.
+	 */
+	selfVoiceThreshold?: number;
 	/** True while the agent is currently playing TTS. */
 	agentSpeaking?: boolean;
 	/** Age of the most recent agent-spoken reply in ms. */
@@ -216,7 +223,8 @@ function foldSpeakerIntoSignal(
 		(opts.replyAgeMs ?? Number.POSITIVE_INFINITY) <= ECHO_WINDOW_MS;
 	const isSelfVoice =
 		typeof opts.selfVoiceSimilarity === "number" &&
-		opts.selfVoiceSimilarity >= AGENT_SELF_VOICE_THRESHOLD &&
+		opts.selfVoiceSimilarity >=
+			(opts.selfVoiceThreshold ?? AGENT_SELF_VOICE_THRESHOLD) &&
 		replyRecent;
 	if (isSelfVoice) agentShouldSpeak = false;
 

--- a/plugins/plugin-local-inference/src/services/latency-trace.ts
+++ b/plugins/plugin-local-inference/src/services/latency-trace.ts
@@ -57,6 +57,10 @@
  */
 
 import { logger } from "@elizaos/core";
+import {
+	type FarEndReferenceStatus,
+	getSharedFarEndReference,
+} from "./voice/far-end-reference.js";
 import type { VadEvent, VadEventSource } from "./voice/types";
 
 // ---------------------------------------------------------------------------
@@ -675,6 +679,14 @@ export interface VoiceLatencyDevPayload {
 	openTurnCount: number;
 	traces: LatencyTrace[];
 	histograms: Record<LatencyDerivedKey, HistogramSummary>;
+	/**
+	 * Desktop-loop AEC observability (#12256): the far-end reference's honest
+	 * wiring flag, playback delivery counters, and per-utterance ERLE results —
+	 * the number the AEC3 escalation decision is gated on (<18 dB measured on
+	 * real hardware → file the webrtc-audio-processing evaluation follow-up;
+	 * do not vendor it preemptively).
+	 */
+	aec: FarEndReferenceStatus;
 }
 
 /** Build the JSON body for `GET /api/dev/voice-latency`. */
@@ -689,6 +701,7 @@ export function buildVoiceLatencyDevPayload(
 		openTurnCount: tracer.openTurnCount,
 		traces: tracer.recentTraces(limit),
 		histograms: tracer.histogramSummaries(),
+		aec: getSharedFarEndReference().status(),
 	};
 }
 

--- a/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
@@ -243,6 +243,12 @@ export interface AudioFrameConsumerDeps {
 	 */
 	resolveSelfVoiceSimilarity?: SelfVoiceSimilarityResolver;
 	/**
+	 * Decision threshold for the resolver's similarity, forwarded with the value
+	 * so the gate compares it on the right scale (a WeSpeaker-embedding cosine
+	 * sits far below the MFCC default — see AGENT_SELF_VOICE_IMPRINT_THRESHOLD).
+	 */
+	selfVoiceThreshold?: number;
+	/**
 	 * Optional agent-playback (far-end) reference for acoustic echo cancellation
 	 * (#9455). Given a mic frame's clock timestamp and sample count, returns the
 	 * agent's TTS playback PCM for that exact window (Float32 16 kHz), or null
@@ -317,6 +323,7 @@ export class AudioFrameConsumer {
 	private readonly runtime: RuntimeEventSink;
 	private readonly transcribe: TurnTranscriber | null;
 	private readonly resolveSelfVoiceSimilarity: SelfVoiceSimilarityResolver | null;
+	private readonly selfVoiceThreshold: number | null;
 	private readonly echoReference: EchoReferenceProvider | null;
 	/** NLMS echo canceller, instantiated only when an `echoReference` is wired. */
 	private readonly echoCanceller: NlmsEchoCanceller | null;
@@ -374,6 +381,7 @@ export class AudioFrameConsumer {
 		this.runtime = deps.runtime;
 		this.transcribe = deps.transcribe ?? null;
 		this.resolveSelfVoiceSimilarity = deps.resolveSelfVoiceSimilarity ?? null;
+		this.selfVoiceThreshold = deps.selfVoiceThreshold ?? null;
 		this.echoReference = deps.echoReference ?? null;
 		this.echoCanceller = this.echoReference
 			? new NlmsEchoCanceller(
@@ -716,7 +724,13 @@ export class AudioFrameConsumer {
 				output,
 			);
 			if (typeof similarity === "number" && Number.isFinite(similarity)) {
-				options = { ...options, selfVoiceSimilarity: similarity };
+				options = {
+					...options,
+					selfVoiceSimilarity: similarity,
+					...(this.selfVoiceThreshold !== null
+						? { selfVoiceThreshold: this.selfVoiceThreshold }
+						: {}),
+				};
 			}
 		}
 		return options;

--- a/plugins/plugin-local-inference/src/services/voice/echo-metrics.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-metrics.ts
@@ -6,39 +6,39 @@
  */
 
 import {
-  computeErle,
-  computeFarActiveErle,
-  NlmsEchoCanceller,
+	computeErle,
+	computeFarActiveErle,
+	NlmsEchoCanceller,
 } from "@elizaos/shared/voice/aec";
 
 export { computeErle, computeFarActiveErle };
 
 /** The slice of {@link AecCaptureSnapshot} the replay needs. */
 export interface AecCaptureReplayInput {
-  /** Base64 LE-s16 near-end (raw mic, pre-AEC) @16 kHz. */
-  nearPcm16: string;
-  /** Base64 LE-s16 far-end reference read at delay 0 @16 kHz. */
-  farPcm16: string;
-  /** Playback→mic delay (samples) the live canceller applied. */
-  echoDelaySamples: number;
+	/** Base64 LE-s16 near-end (raw mic, pre-AEC) @16 kHz. */
+	nearPcm16: string;
+	/** Base64 LE-s16 far-end reference read at delay 0 @16 kHz. */
+	farPcm16: string;
+	/** Playback→mic delay (samples) the live canceller applied. */
+	echoDelaySamples: number;
 }
 
 export interface AecCaptureReplayResult {
-  /** Whole-window ERLE of the replayed canceller (10·log10 near²/residual²). */
-  erleDb: number;
-  /** ERLE over far-active blocks only (null when the far-end was silent). */
-  farActiveErleDb: number | null;
-  sampleCount: number;
-  farActiveSamples: number;
+	/** Whole-window ERLE of the replayed canceller (10·log10 near²/residual²). */
+	erleDb: number;
+	/** ERLE over far-active blocks only (null when the far-end was silent). */
+	farActiveErleDb: number | null;
+	sampleCount: number;
+	farActiveSamples: number;
 }
 
 function decodePcm16Base64(b64: string): Float32Array {
-  const bytes = Buffer.from(b64, "base64");
-  const out = new Float32Array(bytes.length >> 1);
-  for (let i = 0; i < out.length; i++) {
-    out[i] = bytes.readInt16LE(i * 2) / 32_768;
-  }
-  return out;
+	const bytes = Buffer.from(b64, "base64");
+	const out = new Float32Array(bytes.length >> 1);
+	for (let i = 0; i < out.length; i++) {
+		out[i] = bytes.readInt16LE(i * 2) / 32_768;
+	}
+	return out;
 }
 
 /**
@@ -50,20 +50,20 @@ function decodePcm16Base64(b64: string): Float32Array {
  * an unwired path look healthy.
  */
 export function replayAecCaptureErle(
-  capture: AecCaptureReplayInput,
+	capture: AecCaptureReplayInput,
 ): AecCaptureReplayResult | null {
-  const near = decodePcm16Base64(capture.nearPcm16);
-  const far = decodePcm16Base64(capture.farPcm16);
-  if (near.length === 0) return null;
-  const canceller = new NlmsEchoCanceller({
-    delaySamples: Math.max(0, Math.floor(capture.echoDelaySamples)),
-  });
-  const residual = canceller.process(near, far);
-  const masked = computeFarActiveErle(near, residual, far);
-  return {
-    erleDb: computeErle(near, residual),
-    farActiveErleDb: masked.erleDb,
-    sampleCount: near.length,
-    farActiveSamples: masked.farActiveSamples,
-  };
+	const near = decodePcm16Base64(capture.nearPcm16);
+	const far = decodePcm16Base64(capture.farPcm16);
+	if (near.length === 0) return null;
+	const canceller = new NlmsEchoCanceller({
+		delaySamples: Math.max(0, Math.floor(capture.echoDelaySamples)),
+	});
+	const residual = canceller.process(near, far);
+	const masked = computeFarActiveErle(near, residual, far);
+	return {
+		erleDb: computeErle(near, residual),
+		farActiveErleDb: masked.erleDb,
+		sampleCount: near.length,
+		farActiveSamples: masked.farActiveSamples,
+	};
 }

--- a/plugins/plugin-local-inference/src/services/voice/echo-metrics.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-metrics.ts
@@ -1,20 +1,69 @@
 /**
- * Echo-return-loss-enhancement in dB: 10*log10(sum(near^2) / sum(residual^2)).
- * Higher is better. Returns +Infinity when the residual is silent and 0 when
- * there is no near-end energy to enhance.
+ * ERLE metrics for the voice pipeline. The math is canonical in
+ * `@elizaos/shared/voice/aec`; this module re-exports it and adds the
+ * capture-replay helper that turns an armed AEC evidence window (#11373)
+ * into an offline ERLE measurement using the exact production canceller.
  */
-export function computeErle(
-	nearEnd: Float32Array,
-	residual: Float32Array,
-): number {
-	let nearEnergy = 0;
-	let residualEnergy = 0;
-	const len = Math.min(nearEnd.length, residual.length);
-	for (let i = 0; i < len; i++) {
-		nearEnergy += nearEnd[i] * nearEnd[i];
-		residualEnergy += residual[i] * residual[i];
-	}
-	if (nearEnergy === 0) return 0;
-	if (residualEnergy === 0) return Number.POSITIVE_INFINITY;
-	return 10 * Math.log10(nearEnergy / residualEnergy);
+
+import {
+  computeErle,
+  computeFarActiveErle,
+  NlmsEchoCanceller,
+} from "@elizaos/shared/voice/aec";
+
+export { computeErle, computeFarActiveErle };
+
+/** The slice of {@link AecCaptureSnapshot} the replay needs. */
+export interface AecCaptureReplayInput {
+  /** Base64 LE-s16 near-end (raw mic, pre-AEC) @16 kHz. */
+  nearPcm16: string;
+  /** Base64 LE-s16 far-end reference read at delay 0 @16 kHz. */
+  farPcm16: string;
+  /** Playback→mic delay (samples) the live canceller applied. */
+  echoDelaySamples: number;
+}
+
+export interface AecCaptureReplayResult {
+  /** Whole-window ERLE of the replayed canceller (10·log10 near²/residual²). */
+  erleDb: number;
+  /** ERLE over far-active blocks only (null when the far-end was silent). */
+  farActiveErleDb: number | null;
+  sampleCount: number;
+  farActiveSamples: number;
+}
+
+function decodePcm16Base64(b64: string): Float32Array {
+  const bytes = Buffer.from(b64, "base64");
+  const out = new Float32Array(bytes.length >> 1);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = bytes.readInt16LE(i * 2) / 32_768;
+  }
+  return out;
+}
+
+/**
+ * Replay a captured near/far window through a fresh production
+ * `NlmsEchoCanceller` (applying the live delay the capture recorded) and
+ * measure the resulting ERLE — the on-demand number `GET /api/voice/aec-capture`
+ * and the dev telemetry surface report. Returns null when the capture holds no
+ * samples: an empty window has no measurement, and fabricating one would make
+ * an unwired path look healthy.
+ */
+export function replayAecCaptureErle(
+  capture: AecCaptureReplayInput,
+): AecCaptureReplayResult | null {
+  const near = decodePcm16Base64(capture.nearPcm16);
+  const far = decodePcm16Base64(capture.farPcm16);
+  if (near.length === 0) return null;
+  const canceller = new NlmsEchoCanceller({
+    delaySamples: Math.max(0, Math.floor(capture.echoDelaySamples)),
+  });
+  const residual = canceller.process(near, far);
+  const masked = computeFarActiveErle(near, residual, far);
+  return {
+    erleDb: computeErle(near, residual),
+    farActiveErleDb: masked.erleDb,
+    sampleCount: near.length,
+    farActiveSamples: masked.farActiveSamples,
+  };
 }

--- a/plugins/plugin-local-inference/src/services/voice/engine-bridge.ts
+++ b/plugins/plugin-local-inference/src/services/voice/engine-bridge.ts
@@ -78,7 +78,10 @@ import {
 } from "./pipeline-impls";
 import type { VoiceProfileStore } from "./profile-store";
 import { type SchedulerEvents, VoiceScheduler } from "./scheduler";
-import { AgentSelfVoiceImprint } from "./self-voice-imprint";
+import {
+	AgentSelfVoiceImprint,
+	registerAgentSelfVoiceImprint,
+} from "./self-voice-imprint";
 import {
 	type MmapRegionHandle,
 	SharedResourceRegistry,
@@ -1267,6 +1270,10 @@ export class EngineVoiceBridge {
 				selfVoiceImprint = new AgentSelfVoiceImprint({
 					encoder: lazyEncoder,
 				});
+				// #12255's speaker-gated barge-in reads the live imprint through the
+				// shared handle (getAgentSelfVoiceImprint) — the speak-back loop's
+				// registration takes precedence over Pipeline A's.
+				registerAgentSelfVoiceImprint("speak-back-loop", selfVoiceImprint);
 				// Fused diarizer (optional). When the build does not advertise the
 				// diarizer ABI, attribution runs without it — a single-speaker turn
 				// collapses to one segment (the attribution-pipeline localSpeakerId=0
@@ -2056,8 +2063,15 @@ export class EngineVoiceBridge {
 						await handleLiveVoiceAttribution(eventRuntime, output, {
 							...resolveLiveAttributionOptions(liveAttribution, transcript),
 							agentSpeaking: this.scheduler.bargeIn.isAgentSpeaking,
-							...(typeof selfVoiceSimilarity === "number"
-								? { selfVoiceSimilarity }
+							// The imprint's cosine is on the WeSpeaker-embedding scale —
+							// its own threshold (~0.28) travels with it so the fold does
+							// not compare it against the 0.7 MFCC bar (#12256).
+							...(typeof selfVoiceSimilarity === "number" &&
+							this.selfVoiceImprint
+								? {
+										selfVoiceSimilarity,
+										selfVoiceThreshold: this.selfVoiceImprint.threshold,
+									}
 								: {}),
 						});
 					}

--- a/plugins/plugin-local-inference/src/services/voice/far-end-reference.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/far-end-reference.test.ts
@@ -7,10 +7,7 @@
 
 import { describe, expect, it } from "vitest";
 import type { AudioFrameEvent } from "./audio-frame-consumer";
-import {
-	cancelEchoInWavUtterance,
-	FarEndReference,
-} from "./far-end-reference";
+import { cancelEchoInWavUtterance, FarEndReference } from "./far-end-reference";
 import { encodeMonoPcm16Wav } from "./wav-codec";
 
 const SAMPLE_RATE = 16_000;

--- a/plugins/plugin-local-inference/src/services/voice/far-end-reference.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/far-end-reference.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Desktop far-end reference + utterance-level AEC (#12256) — real DSP end to
+ * end: real EchoReferenceBuffer, real alignment estimator, real NLMS
+ * canceller; only the clocks are simulated (renderer performance.now() vs
+ * server Date.now() epochs, delivery jitter, POST latency).
+ */
+
+import { describe, expect, it } from "vitest";
+import type { AudioFrameEvent } from "./audio-frame-consumer";
+import {
+	cancelEchoInWavUtterance,
+	FarEndReference,
+} from "./far-end-reference";
+import { encodeMonoPcm16Wav } from "./wav-codec";
+
+const SAMPLE_RATE = 16_000;
+const FRAME_SAMPLES = 320; // 20 ms
+/** Simulated renderer→server clock epoch difference (performance.now() is
+ * page-relative, so the real offset is huge; any constant works). */
+const EPOCH_OFFSET_MS = 1_000_000;
+/** Minimum simulated delivery latency — the epoch anchor converges to it. */
+const MIN_DELIVERY_MS = 5;
+
+/** Deterministic pseudo-speech (seeded noise → low-pass → slow envelope). */
+function speechLike(n: number, seed: number): Float32Array {
+	const out = new Float32Array(n);
+	let state = seed >>> 0 || 1;
+	const rand = () => {
+		state = (state * 1664525 + 1013904223) >>> 0;
+		return state / 0xffffffff - 0.5;
+	};
+	let lp = 0;
+	for (let i = 0; i < n; i++) {
+		const t = i / SAMPLE_RATE;
+		lp = 0.85 * lp + 0.15 * rand();
+		out[i] = (0.55 + 0.45 * Math.sin(2 * Math.PI * 2.3 * t + seed)) * lp * 2.5;
+	}
+	return out;
+}
+
+function encodePcm16Base64(pcm: Float32Array): string {
+	const bytes = Buffer.alloc(pcm.length * 2);
+	for (let i = 0; i < pcm.length; i++) {
+		const v = Math.max(-1, Math.min(1, pcm[i]));
+		bytes.writeInt16LE(Math.round(v * 32767), i * 2);
+	}
+	return bytes.toString("base64");
+}
+
+/** Slice a far stream into 20 ms wire frames timestamped in renderer clock. */
+function toFrames(stream: Float32Array, baseTsMs: number): AudioFrameEvent[] {
+	const frames: AudioFrameEvent[] = [];
+	for (
+		let index = 0;
+		(index + 1) * FRAME_SAMPLES <= stream.length;
+		index += 1
+	) {
+		const pcm = stream.subarray(
+			index * FRAME_SAMPLES,
+			(index + 1) * FRAME_SAMPLES,
+		);
+		frames.push({
+			pcm16: encodePcm16Base64(pcm),
+			sampleRate: SAMPLE_RATE,
+			channels: 1,
+			samples: FRAME_SAMPLES,
+			rms: 0.1,
+			timestamp: baseTsMs + index * 20,
+			frameIndex: index,
+		});
+	}
+	return frames;
+}
+
+/** Push a far stream with realistic per-batch delivery jitter (≥ MIN_DELIVERY). */
+function deliver(
+	farEnd: FarEndReference,
+	stream: Float32Array,
+	baseTsMs: number,
+): void {
+	const frames = toFrames(stream, baseTsMs);
+	for (let i = 0; i < frames.length; i += 12) {
+		const batch = frames.slice(i, i + 12);
+		const last = batch[batch.length - 1];
+		const jitter = MIN_DELIVERY_MS + ((i / 12) % 4) * 60; // 5..185 ms
+		farEnd.pushPlayback(batch, last.timestamp + EPOCH_OFFSET_MS + jitter);
+	}
+}
+
+/** The mic hears the far stream attenuated + delayed by `acousticDelayMs`. */
+function echoOf(
+	stream: Float32Array,
+	baseTsMs: number,
+	nearStartTsMs: number,
+	lengthSamples: number,
+	acousticDelayMs: number,
+	gain = 0.22,
+): Float32Array {
+	const near = new Float32Array(lengthSamples);
+	const srcBase = Math.round(
+		((nearStartTsMs - acousticDelayMs - baseTsMs) / 1000) * SAMPLE_RATE,
+	);
+	for (let i = 0; i < lengthSamples; i++) {
+		const k = srcBase + i;
+		if (k >= 0 && k < stream.length) near[i] = gain * stream[k];
+	}
+	return near;
+}
+
+describe("FarEndReference.cancelUtterance", () => {
+	it("cancels an echo-only utterance with ERLE >= 18 dB", () => {
+		const farEnd = new FarEndReference();
+		const far = speechLike(48_000, 7); // 3 s of playback
+		const baseTs = 5_000;
+		deliver(farEnd, far, baseTs);
+
+		const nearStartTs = 5_100;
+		const nearLen = 40_000; // 2.5 s utterance
+		const near = echoOf(far, baseTs, nearStartTs, nearLen, 60);
+		const nearEndTs = nearStartTs + (nearLen / SAMPLE_RATE) * 1000;
+		const result = farEnd.cancelUtterance(
+			near,
+			nearEndTs + EPOCH_OFFSET_MS + 15, // POST arrival latency
+		);
+
+		expect(result.applied).toBe(true);
+		expect(result.confidence ?? 0).toBeGreaterThanOrEqual(0.3);
+		expect(result.erleDb).not.toBeNull();
+		expect(result.erleDb as number).toBeGreaterThanOrEqual(18);
+		expect(result.farActiveSamples).toBeGreaterThan(SAMPLE_RATE);
+		expect(farEnd.status().lastErleDb).toBe(result.erleDb);
+	});
+
+	it("passes through bit-exact when no playback was ever delivered", () => {
+		const farEnd = new FarEndReference();
+		const near = speechLike(16_000, 3);
+		const result = farEnd.cancelUtterance(near, Date.now());
+		expect(result.applied).toBe(false);
+		expect(result.reason).toBe("no-far-end");
+		expect(result.pcm).toBe(near); // the untouched input array
+	});
+
+	it("passes through bit-exact when the utterance carries no correlated echo", () => {
+		const farEnd = new FarEndReference();
+		const far = speechLike(48_000, 11);
+		const baseTs = 9_000;
+		deliver(farEnd, far, baseTs);
+		// Independent user speech overlapping the playback window in time.
+		const near = speechLike(32_000, 987_654);
+		const nearEndTs = baseTs + 2_800;
+		const result = farEnd.cancelUtterance(
+			near,
+			nearEndTs + EPOCH_OFFSET_MS + 15,
+		);
+		expect(result.applied).toBe(false);
+		expect(result.reason).toBe("low-confidence");
+		expect(result.pcm).toBe(near);
+	});
+
+	it("preserves double-talk user speech while cancelling the echo underneath", () => {
+		const farEnd = new FarEndReference();
+		const far = speechLike(48_000, 21);
+		const baseTs = 40_000;
+		deliver(farEnd, far, baseTs);
+
+		const nearStartTs = 40_200;
+		const nearLen = 40_000;
+		const echo = echoOf(far, baseTs, nearStartTs, nearLen, 45, 0.25);
+		const user = speechLike(nearLen, 4242);
+		const near = new Float32Array(nearLen);
+		for (let i = 0; i < nearLen; i++) near[i] = echo[i] + 0.3 * user[i];
+
+		const nearEndTs = nearStartTs + (nearLen / SAMPLE_RATE) * 1000;
+		const result = farEnd.cancelUtterance(
+			near,
+			nearEndTs + EPOCH_OFFSET_MS + 10,
+		);
+		expect(result.applied).toBe(true);
+
+		// The user's speech must survive (residual stays user-dominated) while
+		// the echo component shrinks. Continuous double-talk perturbs the NLMS
+		// gradient, so the user correlation is high-but-not-perfect by design.
+		const corr = (a: Float32Array, b: Float32Array): number => {
+			let dot = 0;
+			let ea = 0;
+			let eb = 0;
+			for (let i = 0; i < nearLen; i++) {
+				dot += a[i] * b[i];
+				ea += a[i] * a[i];
+				eb += b[i] * b[i];
+			}
+			return dot / Math.sqrt(ea * eb);
+		};
+		expect(corr(result.pcm, user)).toBeGreaterThan(0.7);
+		expect(Math.abs(corr(result.pcm, echo))).toBeLessThan(
+			0.5 * corr(near, echo),
+		);
+	});
+
+	it("keeps the far-end history across playback resets (the pump resets before the WAV arrives)", () => {
+		const farEnd = new FarEndReference();
+		const far = speechLike(48_000, 31);
+		const baseTs = 70_000;
+		deliver(farEnd, far, baseTs);
+		farEnd.notePlaybackReset(); // playback segment ended
+		const nearStartTs = 70_150;
+		const nearLen = 32_000;
+		const near = echoOf(far, baseTs, nearStartTs, nearLen, 70);
+		const nearEndTs = nearStartTs + (nearLen / SAMPLE_RATE) * 1000;
+		const result = farEnd.cancelUtterance(
+			near,
+			nearEndTs + EPOCH_OFFSET_MS + 20,
+		);
+		expect(result.applied).toBe(true);
+		expect(farEnd.status().playbackResets).toBe(1);
+	});
+
+	it("reports honest wiring status", () => {
+		const farEnd = new FarEndReference();
+		expect(farEnd.status().echoReferenceWired).toBe(false);
+		deliver(farEnd, speechLike(16_000, 5), 1_000);
+		const status = farEnd.status();
+		expect(status.echoReferenceWired).toBe(true);
+		expect(status.playbackSamplesReceived).toBeGreaterThan(0);
+		expect(status.epochOffsetKnown).toBe(true);
+	});
+});
+
+describe("cancelEchoInWavUtterance", () => {
+	it("cancels a 16 kHz WAV utterance and re-encodes the residual", () => {
+		const farEnd = new FarEndReference();
+		const far = speechLike(48_000, 51);
+		const baseTs = 100_000;
+		deliver(farEnd, far, baseTs);
+		const nearStartTs = 100_120;
+		const near = echoOf(far, baseTs, nearStartTs, 40_000, 55);
+		const wav = encodeMonoPcm16Wav(near, SAMPLE_RATE);
+		const nearEndTs = nearStartTs + (near.length / SAMPLE_RATE) * 1000;
+
+		const outcome = cancelEchoInWavUtterance(
+			farEnd,
+			wav,
+			nearEndTs + EPOCH_OFFSET_MS + 12,
+		);
+		expect(outcome.result?.applied).toBe(true);
+		expect(outcome.bytes).not.toBe(wav);
+		// Residual WAV is dramatically quieter than the echo it replaced.
+		expect(outcome.result?.erleDb as number).toBeGreaterThanOrEqual(18);
+	});
+
+	it("passes non-WAV payloads through untouched with no AEC verdict", () => {
+		const farEnd = new FarEndReference();
+		const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+		const outcome = cancelEchoInWavUtterance(farEnd, bytes);
+		expect(outcome.bytes).toBe(bytes);
+		expect(outcome.result).toBeNull();
+	});
+
+	it("passes RIFF-tagged but non-PCM16-mono payloads through untouched", () => {
+		const farEnd = new FarEndReference();
+		// Valid RIFF/WAVE magic, garbage format chunk.
+		const bytes = new Uint8Array(64);
+		bytes.set([0x52, 0x49, 0x46, 0x46], 0); // RIFF
+		bytes.set([0x57, 0x41, 0x56, 0x45], 8); // WAVE
+		const outcome = cancelEchoInWavUtterance(farEnd, bytes);
+		expect(outcome.bytes).toBe(bytes);
+		expect(outcome.result).toBeNull();
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/far-end-reference.ts
+++ b/plugins/plugin-local-inference/src/services/voice/far-end-reference.ts
@@ -1,0 +1,445 @@
+/**
+ * Shared per-process far-end (agent TTS playback) reference for the desktop
+ * speak-back loop's echo cancellation (#12256).
+ *
+ * The renderer already POSTs rendered playback as 16 kHz LE-s16 frames to
+ * `/api/voice/playback-frames` (packages/ui playback-frame-pump). Pipeline A
+ * (live diarization) consumes them per mic frame; the desktop ASR ingest
+ * (`/api/asr/local-inference`) had NO consumer, so the agent transcribed its
+ * own echo. This service is the second consumer: it retains a 30 s timestamped
+ * history of playback PCM and cancels the echo out of whole recorded
+ * utterances before transcription.
+ *
+ * Alignment: playback frames are timestamped in the renderer's
+ * `performance.now()` domain; the mic WAV carries no timestamps at all. The
+ * epoch offset between the two clocks is tracked as the running minimum of
+ * (server arrival − frame timestamp) — a tight anchor on loopback — and the
+ * residual (acoustic + transport + anchor-jitter) alignment is recovered from
+ * the audio itself per utterance via `estimateEchoAlignment`. A low peak
+ * correlation means the utterance carries no detectable echo, in which case
+ * the input is passed through BIT-EXACT (same honesty contract as Pipeline A:
+ * cancellation is only ever applied against a proven reference, and
+ * `echoReferenceWired` flips only once real playback samples arrived).
+ *
+ * Unlike Pipeline A's streaming buffer, the history here deliberately survives
+ * `playback reset` (the pump posts `reset:true` at the end of every playback
+ * segment — usually BEFORE the echoed utterance's WAV arrives). Timestamped
+ * writes zero-fill gaps, so stale audio can never masquerade as a live
+ * reference, and a renderer reload (timestamps jumping backwards) re-origins
+ * the buffer and drops the learned epoch offset.
+ */
+
+import { logger } from "@elizaos/core";
+import {
+  computeFarActiveErle,
+  ECHO_CAL_FAR_ENERGY_FLOOR,
+  ECHO_CAL_MIN_CONFIDENCE,
+  estimateEchoAlignment,
+} from "@elizaos/shared/voice/aec";
+import {
+  type AudioFrameEvent,
+  decodeAudioFramePcm,
+} from "./audio-frame-consumer.js";
+import { EchoReferenceBuffer } from "./echo-reference-buffer.js";
+import { NlmsEchoCanceller } from "./nlms-echo-canceller.js";
+import { resampleLinear } from "./transcriber.js";
+import { decodeMonoPcm16Wav, encodeMonoPcm16Wav } from "./wav-codec.js";
+
+const SAMPLE_RATE = 16_000;
+/** Playback history retained for utterance-level cancellation (30 s @16 kHz). */
+const FAR_HISTORY_SAMPLES = 30 * SAMPLE_RATE;
+/** Half-width of the per-utterance alignment search: covers the acoustic +
+ * transport delay (≤500 ms measured on device paths) plus the epoch-anchor
+ * jitter of the arrival-clock mapping. */
+const ALIGN_SLACK_MS = 1000;
+const ALIGN_SLACK_SAMPLES = (ALIGN_SLACK_MS / 1000) * SAMPLE_RATE;
+/** Cap the audio used for alignment/cancellation context to the utterance's
+ * trailing 15 s — the far history only holds 30 s and clocks don't drift
+ * meaningfully over a single utterance. */
+const MAX_ALIGN_NEAR_SAMPLES = 15 * SAMPLE_RATE;
+/** A renderer reload restarts performance.now(); a backwards jump larger than
+ * this invalidates the learned epoch offset. */
+const TIMESTAMP_BACKWARD_JUMP_MS = 10_000;
+/** Recent per-utterance cancellation results retained for telemetry. */
+const MAX_RECENT_CANCELLATIONS = 20;
+
+/**
+ * Opt-in residual-echo suppressor, off by default (#9583/#9649). Device-tunable
+ * via `ELIZA_VOICE_RESIDUAL_SUPPRESSION`:
+ *   - `"1"` / `"true"` / `"on"` → enable with the canceller's default gain;
+ *   - a number in (0,1] → enable with that residual gain (lower = stronger);
+ *   - unset / anything else → disabled (the canceller does linear NLMS only).
+ */
+export function resolveResidualSuppression():
+  | boolean
+  | { gain: number }
+  | undefined {
+  const raw =
+    process.env.ELIZA_VOICE_RESIDUAL_SUPPRESSION?.trim().toLowerCase();
+  if (!raw) return undefined;
+  if (raw === "1" || raw === "true" || raw === "on") return true;
+  const gain = Number(raw);
+  if (Number.isFinite(gain) && gain > 0 && gain <= 1) return { gain };
+  return undefined;
+}
+
+/** Why an utterance was passed through instead of cancelled. */
+export type DesktopAecPassthroughReason =
+  | "no-far-end"
+  | "no-overlap"
+  | "low-confidence";
+
+export interface DesktopAecResult {
+  /** True when the NLMS canceller ran and `pcm` is the residual. */
+  applied: boolean;
+  /** Set when `applied` is false — the honest no-cancel reason. */
+  reason?: DesktopAecPassthroughReason;
+  /** The echo-cancelled residual, or the UNTOUCHED input when not applied. */
+  pcm: Float32Array;
+  /** Far-active-masked ERLE for this utterance (null when not applied or the
+   * aligned reference carried no active blocks). */
+  erleDb: number | null;
+  /** Winning near-inside-far alignment offset (samples), when estimated. */
+  offsetSamples: number | null;
+  /** Peak alignment correlation [0,1], when estimated. */
+  confidence: number | null;
+  /** Samples of the utterance where the aligned far-end was active. */
+  farActiveSamples: number;
+}
+
+/** JSON-safe telemetry snapshot for the dev observability surface. */
+export interface FarEndReferenceStatus {
+  /** True only once real playback samples were delivered (#9583 honesty). */
+  echoReferenceWired: boolean;
+  playbackFramesReceived: number;
+  playbackSamplesReceived: number;
+  lastPlaybackFrameAt: number | null;
+  playbackResets: number;
+  /** True once the renderer↔server clock anchor has been learned. */
+  epochOffsetKnown: boolean;
+  utterancesCancelled: number;
+  utterancesPassedThrough: number;
+  /** ERLE of the most recent cancelled utterance (null before any). */
+  lastErleDb: number | null;
+  lastCancellation: DesktopAecUtteranceSummary | null;
+  recentCancellations: DesktopAecUtteranceSummary[];
+}
+
+export interface DesktopAecUtteranceSummary {
+  atEpochMs: number;
+  applied: boolean;
+  reason?: DesktopAecPassthroughReason;
+  erleDb: number | null;
+  offsetSamples: number | null;
+  confidence: number | null;
+  farActiveSamples: number;
+  nearSamples: number;
+}
+
+export class FarEndReference {
+  private readonly buffer = new EchoReferenceBuffer({
+    capacitySamples: FAR_HISTORY_SAMPLES,
+    sampleRateHz: SAMPLE_RATE,
+  });
+  private readonly canceller: NlmsEchoCanceller;
+  private playbackFramesReceived = 0;
+  private playbackSamplesReceived = 0;
+  private lastPlaybackFrameAt: number | null = null;
+  private lastFrameTimestampMs: number | null = null;
+  private playbackResets = 0;
+  /** Running min of (server arrival − renderer frame timestamp): the tightest
+   * observed delivery maps the renderer clock into the server clock. */
+  private epochOffsetMs: number | null = null;
+  private utterancesCancelled = 0;
+  private utterancesPassedThrough = 0;
+  private readonly recent: DesktopAecUtteranceSummary[] = [];
+
+  constructor() {
+    const residualSuppression = resolveResidualSuppression();
+    this.canceller = new NlmsEchoCanceller(
+      residualSuppression ? { residualSuppression } : {},
+    );
+  }
+
+  /** Feed a batch of rendered-playback frames (base64 LE-s16 16 kHz mono). */
+  pushPlayback(frames: AudioFrameEvent[], nowMs = Date.now()): void {
+    for (const frame of frames) {
+      const pcm = decodeAudioFramePcm(frame);
+      if (
+        this.lastFrameTimestampMs !== null &&
+        frame.timestamp < this.lastFrameTimestampMs - TIMESTAMP_BACKWARD_JUMP_MS
+      ) {
+        // Renderer reload: new performance.now() epoch. The buffer re-origins
+        // itself on the backwards write; the learned anchor must be dropped.
+        this.epochOffsetMs = null;
+      }
+      this.lastFrameTimestampMs = frame.timestamp;
+      this.buffer.pushAt(frame.timestamp, pcm);
+      const offset = nowMs - frame.timestamp;
+      if (this.epochOffsetMs === null || offset < this.epochOffsetMs) {
+        this.epochOffsetMs = offset;
+      }
+      this.playbackFramesReceived += 1;
+      this.playbackSamplesReceived += pcm.length;
+      this.lastPlaybackFrameAt = nowMs;
+    }
+  }
+
+  /**
+   * A playback segment ended (the pump posts `reset:true`). The history is
+   * deliberately KEPT — the echoed utterance's WAV usually arrives after this
+   * signal, and timestamped writes already zero-fill the silence gap.
+   */
+  notePlaybackReset(): void {
+    this.playbackResets += 1;
+  }
+
+  /**
+   * Cancel the agent's playback echo out of one whole recorded utterance
+   * (Float32 16 kHz mono, most recent sample ≈ `nowMs`). Passthrough contract:
+   * when no playback was ever delivered, when the anchored far window carries
+   * no energy, or when the alignment correlation stays under the Pipeline A
+   * confidence bar (no detectable echo), the INPUT array is returned untouched.
+   */
+  cancelUtterance(near: Float32Array, nowMs = Date.now()): DesktopAecResult {
+    if (
+      near.length === 0 ||
+      this.playbackSamplesReceived === 0 ||
+      this.epochOffsetMs === null
+    ) {
+      return this.recordPassthrough(near, "no-far-end");
+    }
+
+    const trim = Math.max(0, near.length - MAX_ALIGN_NEAR_SAMPLES);
+    const alignNear = trim > 0 ? near.subarray(trim) : near;
+    const nearEndTs = nowMs - this.epochOffsetMs;
+    const nearStartTs = nearEndTs - (near.length / SAMPLE_RATE) * 1000;
+    const alignStartTs = nearStartTs + (trim / SAMPLE_RATE) * 1000;
+
+    const farWindow = this.buffer.referenceAt(
+      alignStartTs - ALIGN_SLACK_MS,
+      alignNear.length + 2 * ALIGN_SLACK_SAMPLES,
+      0,
+    );
+    let farEnergy = 0;
+    for (let i = 0; i < farWindow.length; i++) {
+      farEnergy += farWindow[i] * farWindow[i];
+    }
+    if (farEnergy / Math.max(1, farWindow.length) < ECHO_CAL_FAR_ENERGY_FLOOR) {
+      return this.recordPassthrough(near, "no-overlap");
+    }
+
+    const alignment = estimateEchoAlignment(alignNear, farWindow, {
+      maxOffsetSamples: 2 * ALIGN_SLACK_SAMPLES,
+    });
+    if (alignment.confidence < ECHO_CAL_MIN_CONFIDENCE) {
+      return this.recordPassthrough(near, "low-confidence", alignment);
+    }
+
+    // Re-read the reference aligned to the FULL utterance at the winning
+    // offset. farWindow[0] sits at (alignStartTs − slack); near[0] maps to
+    // window index (offset − trim), which may be negative for a long
+    // utterance whose head predates the window — referenceAt zero-fills it.
+    const alignedFarStartTs =
+      alignStartTs -
+      ALIGN_SLACK_MS +
+      ((alignment.offsetSamples - trim) / SAMPLE_RATE) * 1000;
+    const alignedFar = this.buffer.referenceAt(
+      alignedFarStartTs,
+      near.length,
+      0,
+    );
+
+    // Warm-up pass over the far-active span, then the real pass. The batch
+    // path can afford this offline luxury: the NLMS filter converges on the
+    // echo before the samples that matter are produced, instead of leaking
+    // the first few hundred ms of echo while adapting from cold.
+    const activeSpan = farActiveSpan(alignedFar);
+    if (!activeSpan) {
+      return this.recordPassthrough(near, "no-overlap", alignment);
+    }
+    this.canceller.observeFarEndSilence(new Float32Array(0));
+    this.canceller.process(
+      near.subarray(activeSpan.start, activeSpan.end),
+      alignedFar.subarray(activeSpan.start, activeSpan.end),
+    );
+    this.canceller.observeFarEndSilence(new Float32Array(0));
+    const residual = this.canceller.process(near, alignedFar);
+
+    const { erleDb, farActiveSamples } = computeFarActiveErle(
+      near,
+      residual,
+      alignedFar,
+    );
+    this.utterancesCancelled += 1;
+    const summary: DesktopAecUtteranceSummary = {
+      atEpochMs: nowMs,
+      applied: true,
+      erleDb,
+      offsetSamples: alignment.offsetSamples,
+      confidence: alignment.confidence,
+      farActiveSamples,
+      nearSamples: near.length,
+    };
+    this.pushRecent(summary);
+    return {
+      applied: true,
+      pcm: residual,
+      erleDb,
+      offsetSamples: alignment.offsetSamples,
+      confidence: alignment.confidence,
+      farActiveSamples,
+    };
+  }
+
+  status(): FarEndReferenceStatus {
+    const lastCancellation = this.recent[this.recent.length - 1] ?? null;
+    const lastApplied = [...this.recent]
+      .reverse()
+      .find((entry) => entry.applied);
+    return {
+      echoReferenceWired: this.playbackSamplesReceived > 0,
+      playbackFramesReceived: this.playbackFramesReceived,
+      playbackSamplesReceived: this.playbackSamplesReceived,
+      lastPlaybackFrameAt: this.lastPlaybackFrameAt,
+      playbackResets: this.playbackResets,
+      epochOffsetKnown: this.epochOffsetMs !== null,
+      utterancesCancelled: this.utterancesCancelled,
+      utterancesPassedThrough: this.utterancesPassedThrough,
+      lastErleDb: lastApplied?.erleDb ?? null,
+      lastCancellation,
+      recentCancellations: [...this.recent],
+    };
+  }
+
+  private recordPassthrough(
+    near: Float32Array,
+    reason: DesktopAecPassthroughReason,
+    alignment?: { offsetSamples: number; confidence: number },
+  ): DesktopAecResult {
+    this.utterancesPassedThrough += 1;
+    this.pushRecent({
+      atEpochMs: Date.now(),
+      applied: false,
+      reason,
+      erleDb: null,
+      offsetSamples: alignment?.offsetSamples ?? null,
+      confidence: alignment?.confidence ?? null,
+      farActiveSamples: 0,
+      nearSamples: near.length,
+    });
+    return {
+      applied: false,
+      reason,
+      pcm: near,
+      erleDb: null,
+      offsetSamples: alignment?.offsetSamples ?? null,
+      confidence: alignment?.confidence ?? null,
+      farActiveSamples: 0,
+    };
+  }
+
+  private pushRecent(summary: DesktopAecUtteranceSummary): void {
+    this.recent.push(summary);
+    if (this.recent.length > MAX_RECENT_CANCELLATIONS) this.recent.shift();
+  }
+}
+
+/** First..last 20 ms block where the aligned far-end carries energy, or null
+ * when it is silent throughout (nothing to cancel). */
+function farActiveSpan(
+  alignedFar: Float32Array,
+): { start: number; end: number } | null {
+  const block = 320;
+  let start = -1;
+  let end = -1;
+  for (let at = 0; at < alignedFar.length; at += block) {
+    const to = Math.min(alignedFar.length, at + block);
+    let energy = 0;
+    for (let i = at; i < to; i++) energy += alignedFar[i] * alignedFar[i];
+    if (energy / (to - at) >= ECHO_CAL_FAR_ENERGY_FLOOR) {
+      if (start === -1) start = at;
+      end = to;
+    }
+  }
+  return start === -1 ? null : { start, end };
+}
+
+/** RIFF/WAVE magic probe — cheap shape check before attempting a decode. */
+function looksLikeRiffWav(bytes: Uint8Array): boolean {
+  return (
+    bytes.length > 44 &&
+    bytes[0] === 0x52 && // R
+    bytes[1] === 0x49 && // I
+    bytes[2] === 0x46 && // F
+    bytes[3] === 0x46 && // F
+    bytes[8] === 0x57 && // W
+    bytes[9] === 0x41 && // A
+    bytes[10] === 0x56 && // V
+    bytes[11] === 0x45 // E
+  );
+}
+
+export interface WavAecOutcome {
+  /** The bytes to transcribe: cancelled 16 kHz WAV, or the ORIGINAL input. */
+  bytes: Uint8Array;
+  /** Cancellation detail, or null when the payload was not a mono PCM16 WAV. */
+  result: DesktopAecResult | null;
+}
+
+/**
+ * Cancel the desktop playback echo out of a WAV utterance before ASR. Non-WAV
+ * payloads (the model-chain fallback accepts other containers) and non-mono/
+ * non-PCM16 WAVs skip AEC and pass the original bytes through untouched.
+ * When cancellation applies, the residual is re-encoded as 16 kHz mono WAV.
+ */
+export function cancelEchoInWavUtterance(
+  farEnd: FarEndReference,
+  bytes: Uint8Array,
+  nowMs = Date.now(),
+): WavAecOutcome {
+  if (!looksLikeRiffWav(bytes)) return { bytes, result: null };
+  let pcm: Float32Array;
+  let sampleRate: number;
+  try {
+    ({ pcm, sampleRate } = decodeMonoPcm16Wav(bytes));
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — a RIFF-tagged payload that
+    // is not mono PCM16 (or is malformed) is typed "not AEC-able"; the original
+    // bytes flow to the transcription boundary, which owns rejecting them.
+    return { bytes, result: null };
+  }
+  const near =
+    sampleRate === SAMPLE_RATE
+      ? pcm
+      : resampleLinear(pcm, sampleRate, SAMPLE_RATE);
+  const result = farEnd.cancelUtterance(near, nowMs);
+  if (!result.applied) {
+    return { bytes, result };
+  }
+  return { bytes: encodeMonoPcm16Wav(result.pcm, SAMPLE_RATE), result };
+}
+
+// ---------------------------------------------------------------------------
+// Shared per-process instance
+// ---------------------------------------------------------------------------
+
+let shared: FarEndReference | null = null;
+
+/**
+ * The one far-end reference for this agent process. `/api/voice/playback-frames`
+ * feeds it; `/api/asr/local-inference` cancels against it; the dev voice
+ * telemetry payload reads `status()`.
+ */
+export function getSharedFarEndReference(): FarEndReference {
+  if (!shared) {
+    shared = new FarEndReference();
+    logger.info("[FarEndReference] desktop far-end echo reference created");
+  }
+  return shared;
+}
+
+/** Drop the shared instance. Test-only. */
+export function __resetSharedFarEndReferenceForTest(): void {
+  shared = null;
+}

--- a/plugins/plugin-local-inference/src/services/voice/far-end-reference.ts
+++ b/plugins/plugin-local-inference/src/services/voice/far-end-reference.ts
@@ -31,14 +31,14 @@
 
 import { logger } from "@elizaos/core";
 import {
-  computeFarActiveErle,
-  ECHO_CAL_FAR_ENERGY_FLOOR,
-  ECHO_CAL_MIN_CONFIDENCE,
-  estimateEchoAlignment,
+	computeFarActiveErle,
+	ECHO_CAL_FAR_ENERGY_FLOOR,
+	ECHO_CAL_MIN_CONFIDENCE,
+	estimateEchoAlignment,
 } from "@elizaos/shared/voice/aec";
 import {
-  type AudioFrameEvent,
-  decodeAudioFramePcm,
+	type AudioFrameEvent,
+	decodeAudioFramePcm,
 } from "./audio-frame-consumer.js";
 import { EchoReferenceBuffer } from "./echo-reference-buffer.js";
 import { NlmsEchoCanceller } from "./nlms-echo-canceller.js";
@@ -71,320 +71,320 @@ const MAX_RECENT_CANCELLATIONS = 20;
  *   - unset / anything else → disabled (the canceller does linear NLMS only).
  */
 export function resolveResidualSuppression():
-  | boolean
-  | { gain: number }
-  | undefined {
-  const raw =
-    process.env.ELIZA_VOICE_RESIDUAL_SUPPRESSION?.trim().toLowerCase();
-  if (!raw) return undefined;
-  if (raw === "1" || raw === "true" || raw === "on") return true;
-  const gain = Number(raw);
-  if (Number.isFinite(gain) && gain > 0 && gain <= 1) return { gain };
-  return undefined;
+	| boolean
+	| { gain: number }
+	| undefined {
+	const raw =
+		process.env.ELIZA_VOICE_RESIDUAL_SUPPRESSION?.trim().toLowerCase();
+	if (!raw) return undefined;
+	if (raw === "1" || raw === "true" || raw === "on") return true;
+	const gain = Number(raw);
+	if (Number.isFinite(gain) && gain > 0 && gain <= 1) return { gain };
+	return undefined;
 }
 
 /** Why an utterance was passed through instead of cancelled. */
 export type DesktopAecPassthroughReason =
-  | "no-far-end"
-  | "no-overlap"
-  | "low-confidence";
+	| "no-far-end"
+	| "no-overlap"
+	| "low-confidence";
 
 export interface DesktopAecResult {
-  /** True when the NLMS canceller ran and `pcm` is the residual. */
-  applied: boolean;
-  /** Set when `applied` is false — the honest no-cancel reason. */
-  reason?: DesktopAecPassthroughReason;
-  /** The echo-cancelled residual, or the UNTOUCHED input when not applied. */
-  pcm: Float32Array;
-  /** Far-active-masked ERLE for this utterance (null when not applied or the
-   * aligned reference carried no active blocks). */
-  erleDb: number | null;
-  /** Winning near-inside-far alignment offset (samples), when estimated. */
-  offsetSamples: number | null;
-  /** Peak alignment correlation [0,1], when estimated. */
-  confidence: number | null;
-  /** Samples of the utterance where the aligned far-end was active. */
-  farActiveSamples: number;
+	/** True when the NLMS canceller ran and `pcm` is the residual. */
+	applied: boolean;
+	/** Set when `applied` is false — the honest no-cancel reason. */
+	reason?: DesktopAecPassthroughReason;
+	/** The echo-cancelled residual, or the UNTOUCHED input when not applied. */
+	pcm: Float32Array;
+	/** Far-active-masked ERLE for this utterance (null when not applied or the
+	 * aligned reference carried no active blocks). */
+	erleDb: number | null;
+	/** Winning near-inside-far alignment offset (samples), when estimated. */
+	offsetSamples: number | null;
+	/** Peak alignment correlation [0,1], when estimated. */
+	confidence: number | null;
+	/** Samples of the utterance where the aligned far-end was active. */
+	farActiveSamples: number;
 }
 
 /** JSON-safe telemetry snapshot for the dev observability surface. */
 export interface FarEndReferenceStatus {
-  /** True only once real playback samples were delivered (#9583 honesty). */
-  echoReferenceWired: boolean;
-  playbackFramesReceived: number;
-  playbackSamplesReceived: number;
-  lastPlaybackFrameAt: number | null;
-  playbackResets: number;
-  /** True once the renderer↔server clock anchor has been learned. */
-  epochOffsetKnown: boolean;
-  utterancesCancelled: number;
-  utterancesPassedThrough: number;
-  /** ERLE of the most recent cancelled utterance (null before any). */
-  lastErleDb: number | null;
-  lastCancellation: DesktopAecUtteranceSummary | null;
-  recentCancellations: DesktopAecUtteranceSummary[];
+	/** True only once real playback samples were delivered (#9583 honesty). */
+	echoReferenceWired: boolean;
+	playbackFramesReceived: number;
+	playbackSamplesReceived: number;
+	lastPlaybackFrameAt: number | null;
+	playbackResets: number;
+	/** True once the renderer↔server clock anchor has been learned. */
+	epochOffsetKnown: boolean;
+	utterancesCancelled: number;
+	utterancesPassedThrough: number;
+	/** ERLE of the most recent cancelled utterance (null before any). */
+	lastErleDb: number | null;
+	lastCancellation: DesktopAecUtteranceSummary | null;
+	recentCancellations: DesktopAecUtteranceSummary[];
 }
 
 export interface DesktopAecUtteranceSummary {
-  atEpochMs: number;
-  applied: boolean;
-  reason?: DesktopAecPassthroughReason;
-  erleDb: number | null;
-  offsetSamples: number | null;
-  confidence: number | null;
-  farActiveSamples: number;
-  nearSamples: number;
+	atEpochMs: number;
+	applied: boolean;
+	reason?: DesktopAecPassthroughReason;
+	erleDb: number | null;
+	offsetSamples: number | null;
+	confidence: number | null;
+	farActiveSamples: number;
+	nearSamples: number;
 }
 
 export class FarEndReference {
-  private readonly buffer = new EchoReferenceBuffer({
-    capacitySamples: FAR_HISTORY_SAMPLES,
-    sampleRateHz: SAMPLE_RATE,
-  });
-  private readonly canceller: NlmsEchoCanceller;
-  private playbackFramesReceived = 0;
-  private playbackSamplesReceived = 0;
-  private lastPlaybackFrameAt: number | null = null;
-  private lastFrameTimestampMs: number | null = null;
-  private playbackResets = 0;
-  /** Running min of (server arrival − renderer frame timestamp): the tightest
-   * observed delivery maps the renderer clock into the server clock. */
-  private epochOffsetMs: number | null = null;
-  private utterancesCancelled = 0;
-  private utterancesPassedThrough = 0;
-  private readonly recent: DesktopAecUtteranceSummary[] = [];
+	private readonly buffer = new EchoReferenceBuffer({
+		capacitySamples: FAR_HISTORY_SAMPLES,
+		sampleRateHz: SAMPLE_RATE,
+	});
+	private readonly canceller: NlmsEchoCanceller;
+	private playbackFramesReceived = 0;
+	private playbackSamplesReceived = 0;
+	private lastPlaybackFrameAt: number | null = null;
+	private lastFrameTimestampMs: number | null = null;
+	private playbackResets = 0;
+	/** Running min of (server arrival − renderer frame timestamp): the tightest
+	 * observed delivery maps the renderer clock into the server clock. */
+	private epochOffsetMs: number | null = null;
+	private utterancesCancelled = 0;
+	private utterancesPassedThrough = 0;
+	private readonly recent: DesktopAecUtteranceSummary[] = [];
 
-  constructor() {
-    const residualSuppression = resolveResidualSuppression();
-    this.canceller = new NlmsEchoCanceller(
-      residualSuppression ? { residualSuppression } : {},
-    );
-  }
+	constructor() {
+		const residualSuppression = resolveResidualSuppression();
+		this.canceller = new NlmsEchoCanceller(
+			residualSuppression ? { residualSuppression } : {},
+		);
+	}
 
-  /** Feed a batch of rendered-playback frames (base64 LE-s16 16 kHz mono). */
-  pushPlayback(frames: AudioFrameEvent[], nowMs = Date.now()): void {
-    for (const frame of frames) {
-      const pcm = decodeAudioFramePcm(frame);
-      if (
-        this.lastFrameTimestampMs !== null &&
-        frame.timestamp < this.lastFrameTimestampMs - TIMESTAMP_BACKWARD_JUMP_MS
-      ) {
-        // Renderer reload: new performance.now() epoch. The buffer re-origins
-        // itself on the backwards write; the learned anchor must be dropped.
-        this.epochOffsetMs = null;
-      }
-      this.lastFrameTimestampMs = frame.timestamp;
-      this.buffer.pushAt(frame.timestamp, pcm);
-      const offset = nowMs - frame.timestamp;
-      if (this.epochOffsetMs === null || offset < this.epochOffsetMs) {
-        this.epochOffsetMs = offset;
-      }
-      this.playbackFramesReceived += 1;
-      this.playbackSamplesReceived += pcm.length;
-      this.lastPlaybackFrameAt = nowMs;
-    }
-  }
+	/** Feed a batch of rendered-playback frames (base64 LE-s16 16 kHz mono). */
+	pushPlayback(frames: AudioFrameEvent[], nowMs = Date.now()): void {
+		for (const frame of frames) {
+			const pcm = decodeAudioFramePcm(frame);
+			if (
+				this.lastFrameTimestampMs !== null &&
+				frame.timestamp < this.lastFrameTimestampMs - TIMESTAMP_BACKWARD_JUMP_MS
+			) {
+				// Renderer reload: new performance.now() epoch. The buffer re-origins
+				// itself on the backwards write; the learned anchor must be dropped.
+				this.epochOffsetMs = null;
+			}
+			this.lastFrameTimestampMs = frame.timestamp;
+			this.buffer.pushAt(frame.timestamp, pcm);
+			const offset = nowMs - frame.timestamp;
+			if (this.epochOffsetMs === null || offset < this.epochOffsetMs) {
+				this.epochOffsetMs = offset;
+			}
+			this.playbackFramesReceived += 1;
+			this.playbackSamplesReceived += pcm.length;
+			this.lastPlaybackFrameAt = nowMs;
+		}
+	}
 
-  /**
-   * A playback segment ended (the pump posts `reset:true`). The history is
-   * deliberately KEPT — the echoed utterance's WAV usually arrives after this
-   * signal, and timestamped writes already zero-fill the silence gap.
-   */
-  notePlaybackReset(): void {
-    this.playbackResets += 1;
-  }
+	/**
+	 * A playback segment ended (the pump posts `reset:true`). The history is
+	 * deliberately KEPT — the echoed utterance's WAV usually arrives after this
+	 * signal, and timestamped writes already zero-fill the silence gap.
+	 */
+	notePlaybackReset(): void {
+		this.playbackResets += 1;
+	}
 
-  /**
-   * Cancel the agent's playback echo out of one whole recorded utterance
-   * (Float32 16 kHz mono, most recent sample ≈ `nowMs`). Passthrough contract:
-   * when no playback was ever delivered, when the anchored far window carries
-   * no energy, or when the alignment correlation stays under the Pipeline A
-   * confidence bar (no detectable echo), the INPUT array is returned untouched.
-   */
-  cancelUtterance(near: Float32Array, nowMs = Date.now()): DesktopAecResult {
-    if (
-      near.length === 0 ||
-      this.playbackSamplesReceived === 0 ||
-      this.epochOffsetMs === null
-    ) {
-      return this.recordPassthrough(near, "no-far-end");
-    }
+	/**
+	 * Cancel the agent's playback echo out of one whole recorded utterance
+	 * (Float32 16 kHz mono, most recent sample ≈ `nowMs`). Passthrough contract:
+	 * when no playback was ever delivered, when the anchored far window carries
+	 * no energy, or when the alignment correlation stays under the Pipeline A
+	 * confidence bar (no detectable echo), the INPUT array is returned untouched.
+	 */
+	cancelUtterance(near: Float32Array, nowMs = Date.now()): DesktopAecResult {
+		if (
+			near.length === 0 ||
+			this.playbackSamplesReceived === 0 ||
+			this.epochOffsetMs === null
+		) {
+			return this.recordPassthrough(near, "no-far-end");
+		}
 
-    const trim = Math.max(0, near.length - MAX_ALIGN_NEAR_SAMPLES);
-    const alignNear = trim > 0 ? near.subarray(trim) : near;
-    const nearEndTs = nowMs - this.epochOffsetMs;
-    const nearStartTs = nearEndTs - (near.length / SAMPLE_RATE) * 1000;
-    const alignStartTs = nearStartTs + (trim / SAMPLE_RATE) * 1000;
+		const trim = Math.max(0, near.length - MAX_ALIGN_NEAR_SAMPLES);
+		const alignNear = trim > 0 ? near.subarray(trim) : near;
+		const nearEndTs = nowMs - this.epochOffsetMs;
+		const nearStartTs = nearEndTs - (near.length / SAMPLE_RATE) * 1000;
+		const alignStartTs = nearStartTs + (trim / SAMPLE_RATE) * 1000;
 
-    const farWindow = this.buffer.referenceAt(
-      alignStartTs - ALIGN_SLACK_MS,
-      alignNear.length + 2 * ALIGN_SLACK_SAMPLES,
-      0,
-    );
-    let farEnergy = 0;
-    for (let i = 0; i < farWindow.length; i++) {
-      farEnergy += farWindow[i] * farWindow[i];
-    }
-    if (farEnergy / Math.max(1, farWindow.length) < ECHO_CAL_FAR_ENERGY_FLOOR) {
-      return this.recordPassthrough(near, "no-overlap");
-    }
+		const farWindow = this.buffer.referenceAt(
+			alignStartTs - ALIGN_SLACK_MS,
+			alignNear.length + 2 * ALIGN_SLACK_SAMPLES,
+			0,
+		);
+		let farEnergy = 0;
+		for (let i = 0; i < farWindow.length; i++) {
+			farEnergy += farWindow[i] * farWindow[i];
+		}
+		if (farEnergy / Math.max(1, farWindow.length) < ECHO_CAL_FAR_ENERGY_FLOOR) {
+			return this.recordPassthrough(near, "no-overlap");
+		}
 
-    const alignment = estimateEchoAlignment(alignNear, farWindow, {
-      maxOffsetSamples: 2 * ALIGN_SLACK_SAMPLES,
-    });
-    if (alignment.confidence < ECHO_CAL_MIN_CONFIDENCE) {
-      return this.recordPassthrough(near, "low-confidence", alignment);
-    }
+		const alignment = estimateEchoAlignment(alignNear, farWindow, {
+			maxOffsetSamples: 2 * ALIGN_SLACK_SAMPLES,
+		});
+		if (alignment.confidence < ECHO_CAL_MIN_CONFIDENCE) {
+			return this.recordPassthrough(near, "low-confidence", alignment);
+		}
 
-    // Re-read the reference aligned to the FULL utterance at the winning
-    // offset. farWindow[0] sits at (alignStartTs − slack); near[0] maps to
-    // window index (offset − trim), which may be negative for a long
-    // utterance whose head predates the window — referenceAt zero-fills it.
-    const alignedFarStartTs =
-      alignStartTs -
-      ALIGN_SLACK_MS +
-      ((alignment.offsetSamples - trim) / SAMPLE_RATE) * 1000;
-    const alignedFar = this.buffer.referenceAt(
-      alignedFarStartTs,
-      near.length,
-      0,
-    );
+		// Re-read the reference aligned to the FULL utterance at the winning
+		// offset. farWindow[0] sits at (alignStartTs − slack); near[0] maps to
+		// window index (offset − trim), which may be negative for a long
+		// utterance whose head predates the window — referenceAt zero-fills it.
+		const alignedFarStartTs =
+			alignStartTs -
+			ALIGN_SLACK_MS +
+			((alignment.offsetSamples - trim) / SAMPLE_RATE) * 1000;
+		const alignedFar = this.buffer.referenceAt(
+			alignedFarStartTs,
+			near.length,
+			0,
+		);
 
-    // Warm-up pass over the far-active span, then the real pass. The batch
-    // path can afford this offline luxury: the NLMS filter converges on the
-    // echo before the samples that matter are produced, instead of leaking
-    // the first few hundred ms of echo while adapting from cold.
-    const activeSpan = farActiveSpan(alignedFar);
-    if (!activeSpan) {
-      return this.recordPassthrough(near, "no-overlap", alignment);
-    }
-    this.canceller.observeFarEndSilence(new Float32Array(0));
-    this.canceller.process(
-      near.subarray(activeSpan.start, activeSpan.end),
-      alignedFar.subarray(activeSpan.start, activeSpan.end),
-    );
-    this.canceller.observeFarEndSilence(new Float32Array(0));
-    const residual = this.canceller.process(near, alignedFar);
+		// Warm-up pass over the far-active span, then the real pass. The batch
+		// path can afford this offline luxury: the NLMS filter converges on the
+		// echo before the samples that matter are produced, instead of leaking
+		// the first few hundred ms of echo while adapting from cold.
+		const activeSpan = farActiveSpan(alignedFar);
+		if (!activeSpan) {
+			return this.recordPassthrough(near, "no-overlap", alignment);
+		}
+		this.canceller.observeFarEndSilence(new Float32Array(0));
+		this.canceller.process(
+			near.subarray(activeSpan.start, activeSpan.end),
+			alignedFar.subarray(activeSpan.start, activeSpan.end),
+		);
+		this.canceller.observeFarEndSilence(new Float32Array(0));
+		const residual = this.canceller.process(near, alignedFar);
 
-    const { erleDb, farActiveSamples } = computeFarActiveErle(
-      near,
-      residual,
-      alignedFar,
-    );
-    this.utterancesCancelled += 1;
-    const summary: DesktopAecUtteranceSummary = {
-      atEpochMs: nowMs,
-      applied: true,
-      erleDb,
-      offsetSamples: alignment.offsetSamples,
-      confidence: alignment.confidence,
-      farActiveSamples,
-      nearSamples: near.length,
-    };
-    this.pushRecent(summary);
-    return {
-      applied: true,
-      pcm: residual,
-      erleDb,
-      offsetSamples: alignment.offsetSamples,
-      confidence: alignment.confidence,
-      farActiveSamples,
-    };
-  }
+		const { erleDb, farActiveSamples } = computeFarActiveErle(
+			near,
+			residual,
+			alignedFar,
+		);
+		this.utterancesCancelled += 1;
+		const summary: DesktopAecUtteranceSummary = {
+			atEpochMs: nowMs,
+			applied: true,
+			erleDb,
+			offsetSamples: alignment.offsetSamples,
+			confidence: alignment.confidence,
+			farActiveSamples,
+			nearSamples: near.length,
+		};
+		this.pushRecent(summary);
+		return {
+			applied: true,
+			pcm: residual,
+			erleDb,
+			offsetSamples: alignment.offsetSamples,
+			confidence: alignment.confidence,
+			farActiveSamples,
+		};
+	}
 
-  status(): FarEndReferenceStatus {
-    const lastCancellation = this.recent[this.recent.length - 1] ?? null;
-    const lastApplied = [...this.recent]
-      .reverse()
-      .find((entry) => entry.applied);
-    return {
-      echoReferenceWired: this.playbackSamplesReceived > 0,
-      playbackFramesReceived: this.playbackFramesReceived,
-      playbackSamplesReceived: this.playbackSamplesReceived,
-      lastPlaybackFrameAt: this.lastPlaybackFrameAt,
-      playbackResets: this.playbackResets,
-      epochOffsetKnown: this.epochOffsetMs !== null,
-      utterancesCancelled: this.utterancesCancelled,
-      utterancesPassedThrough: this.utterancesPassedThrough,
-      lastErleDb: lastApplied?.erleDb ?? null,
-      lastCancellation,
-      recentCancellations: [...this.recent],
-    };
-  }
+	status(): FarEndReferenceStatus {
+		const lastCancellation = this.recent[this.recent.length - 1] ?? null;
+		const lastApplied = [...this.recent]
+			.reverse()
+			.find((entry) => entry.applied);
+		return {
+			echoReferenceWired: this.playbackSamplesReceived > 0,
+			playbackFramesReceived: this.playbackFramesReceived,
+			playbackSamplesReceived: this.playbackSamplesReceived,
+			lastPlaybackFrameAt: this.lastPlaybackFrameAt,
+			playbackResets: this.playbackResets,
+			epochOffsetKnown: this.epochOffsetMs !== null,
+			utterancesCancelled: this.utterancesCancelled,
+			utterancesPassedThrough: this.utterancesPassedThrough,
+			lastErleDb: lastApplied?.erleDb ?? null,
+			lastCancellation,
+			recentCancellations: [...this.recent],
+		};
+	}
 
-  private recordPassthrough(
-    near: Float32Array,
-    reason: DesktopAecPassthroughReason,
-    alignment?: { offsetSamples: number; confidence: number },
-  ): DesktopAecResult {
-    this.utterancesPassedThrough += 1;
-    this.pushRecent({
-      atEpochMs: Date.now(),
-      applied: false,
-      reason,
-      erleDb: null,
-      offsetSamples: alignment?.offsetSamples ?? null,
-      confidence: alignment?.confidence ?? null,
-      farActiveSamples: 0,
-      nearSamples: near.length,
-    });
-    return {
-      applied: false,
-      reason,
-      pcm: near,
-      erleDb: null,
-      offsetSamples: alignment?.offsetSamples ?? null,
-      confidence: alignment?.confidence ?? null,
-      farActiveSamples: 0,
-    };
-  }
+	private recordPassthrough(
+		near: Float32Array,
+		reason: DesktopAecPassthroughReason,
+		alignment?: { offsetSamples: number; confidence: number },
+	): DesktopAecResult {
+		this.utterancesPassedThrough += 1;
+		this.pushRecent({
+			atEpochMs: Date.now(),
+			applied: false,
+			reason,
+			erleDb: null,
+			offsetSamples: alignment?.offsetSamples ?? null,
+			confidence: alignment?.confidence ?? null,
+			farActiveSamples: 0,
+			nearSamples: near.length,
+		});
+		return {
+			applied: false,
+			reason,
+			pcm: near,
+			erleDb: null,
+			offsetSamples: alignment?.offsetSamples ?? null,
+			confidence: alignment?.confidence ?? null,
+			farActiveSamples: 0,
+		};
+	}
 
-  private pushRecent(summary: DesktopAecUtteranceSummary): void {
-    this.recent.push(summary);
-    if (this.recent.length > MAX_RECENT_CANCELLATIONS) this.recent.shift();
-  }
+	private pushRecent(summary: DesktopAecUtteranceSummary): void {
+		this.recent.push(summary);
+		if (this.recent.length > MAX_RECENT_CANCELLATIONS) this.recent.shift();
+	}
 }
 
 /** First..last 20 ms block where the aligned far-end carries energy, or null
  * when it is silent throughout (nothing to cancel). */
 function farActiveSpan(
-  alignedFar: Float32Array,
+	alignedFar: Float32Array,
 ): { start: number; end: number } | null {
-  const block = 320;
-  let start = -1;
-  let end = -1;
-  for (let at = 0; at < alignedFar.length; at += block) {
-    const to = Math.min(alignedFar.length, at + block);
-    let energy = 0;
-    for (let i = at; i < to; i++) energy += alignedFar[i] * alignedFar[i];
-    if (energy / (to - at) >= ECHO_CAL_FAR_ENERGY_FLOOR) {
-      if (start === -1) start = at;
-      end = to;
-    }
-  }
-  return start === -1 ? null : { start, end };
+	const block = 320;
+	let start = -1;
+	let end = -1;
+	for (let at = 0; at < alignedFar.length; at += block) {
+		const to = Math.min(alignedFar.length, at + block);
+		let energy = 0;
+		for (let i = at; i < to; i++) energy += alignedFar[i] * alignedFar[i];
+		if (energy / (to - at) >= ECHO_CAL_FAR_ENERGY_FLOOR) {
+			if (start === -1) start = at;
+			end = to;
+		}
+	}
+	return start === -1 ? null : { start, end };
 }
 
 /** RIFF/WAVE magic probe — cheap shape check before attempting a decode. */
 function looksLikeRiffWav(bytes: Uint8Array): boolean {
-  return (
-    bytes.length > 44 &&
-    bytes[0] === 0x52 && // R
-    bytes[1] === 0x49 && // I
-    bytes[2] === 0x46 && // F
-    bytes[3] === 0x46 && // F
-    bytes[8] === 0x57 && // W
-    bytes[9] === 0x41 && // A
-    bytes[10] === 0x56 && // V
-    bytes[11] === 0x45 // E
-  );
+	return (
+		bytes.length > 44 &&
+		bytes[0] === 0x52 && // R
+		bytes[1] === 0x49 && // I
+		bytes[2] === 0x46 && // F
+		bytes[3] === 0x46 && // F
+		bytes[8] === 0x57 && // W
+		bytes[9] === 0x41 && // A
+		bytes[10] === 0x56 && // V
+		bytes[11] === 0x45 // E
+	);
 }
 
 export interface WavAecOutcome {
-  /** The bytes to transcribe: cancelled 16 kHz WAV, or the ORIGINAL input. */
-  bytes: Uint8Array;
-  /** Cancellation detail, or null when the payload was not a mono PCM16 WAV. */
-  result: DesktopAecResult | null;
+	/** The bytes to transcribe: cancelled 16 kHz WAV, or the ORIGINAL input. */
+	bytes: Uint8Array;
+	/** Cancellation detail, or null when the payload was not a mono PCM16 WAV. */
+	result: DesktopAecResult | null;
 }
 
 /**
@@ -394,30 +394,30 @@ export interface WavAecOutcome {
  * When cancellation applies, the residual is re-encoded as 16 kHz mono WAV.
  */
 export function cancelEchoInWavUtterance(
-  farEnd: FarEndReference,
-  bytes: Uint8Array,
-  nowMs = Date.now(),
+	farEnd: FarEndReference,
+	bytes: Uint8Array,
+	nowMs = Date.now(),
 ): WavAecOutcome {
-  if (!looksLikeRiffWav(bytes)) return { bytes, result: null };
-  let pcm: Float32Array;
-  let sampleRate: number;
-  try {
-    ({ pcm, sampleRate } = decodeMonoPcm16Wav(bytes));
-  } catch {
-    // error-policy:J3 untrusted-input sanitizing — a RIFF-tagged payload that
-    // is not mono PCM16 (or is malformed) is typed "not AEC-able"; the original
-    // bytes flow to the transcription boundary, which owns rejecting them.
-    return { bytes, result: null };
-  }
-  const near =
-    sampleRate === SAMPLE_RATE
-      ? pcm
-      : resampleLinear(pcm, sampleRate, SAMPLE_RATE);
-  const result = farEnd.cancelUtterance(near, nowMs);
-  if (!result.applied) {
-    return { bytes, result };
-  }
-  return { bytes: encodeMonoPcm16Wav(result.pcm, SAMPLE_RATE), result };
+	if (!looksLikeRiffWav(bytes)) return { bytes, result: null };
+	let pcm: Float32Array;
+	let sampleRate: number;
+	try {
+		({ pcm, sampleRate } = decodeMonoPcm16Wav(bytes));
+	} catch {
+		// error-policy:J3 untrusted-input sanitizing — a RIFF-tagged payload that
+		// is not mono PCM16 (or is malformed) is typed "not AEC-able"; the original
+		// bytes flow to the transcription boundary, which owns rejecting them.
+		return { bytes, result: null };
+	}
+	const near =
+		sampleRate === SAMPLE_RATE
+			? pcm
+			: resampleLinear(pcm, sampleRate, SAMPLE_RATE);
+	const result = farEnd.cancelUtterance(near, nowMs);
+	if (!result.applied) {
+		return { bytes, result };
+	}
+	return { bytes: encodeMonoPcm16Wav(result.pcm, SAMPLE_RATE), result };
 }
 
 // ---------------------------------------------------------------------------
@@ -432,14 +432,14 @@ let shared: FarEndReference | null = null;
  * telemetry payload reads `status()`.
  */
 export function getSharedFarEndReference(): FarEndReference {
-  if (!shared) {
-    shared = new FarEndReference();
-    logger.info("[FarEndReference] desktop far-end echo reference created");
-  }
-  return shared;
+	if (!shared) {
+		shared = new FarEndReference();
+		logger.info("[FarEndReference] desktop far-end echo reference created");
+	}
+	return shared;
 }
 
 /** Drop the shared instance. Test-only. */
 export function __resetSharedFarEndReferenceForTest(): void {
-  shared = null;
+	shared = null;
 }

--- a/plugins/plugin-local-inference/src/services/voice/index.ts
+++ b/plugins/plugin-local-inference/src/services/voice/index.ts
@@ -70,15 +70,6 @@ export {
 	EchoReferenceBuffer,
 	type EchoReferenceBufferOptions,
 } from "./echo-reference-buffer";
-export {
-	cancelEchoInWavUtterance,
-	type DesktopAecPassthroughReason,
-	type DesktopAecResult,
-	type DesktopAecUtteranceSummary,
-	FarEndReference,
-	type FarEndReferenceStatus,
-	getSharedFarEndReference,
-} from "./far-end-reference";
 export type {
 	LlamaContextLike as Eliza1EotLlamaContext,
 	LlamaContextSequenceLike as Eliza1EotLlamaSequence,
@@ -153,6 +144,15 @@ export {
 	turnDetectorGgufForTier,
 } from "./eot-classifier-ggml";
 export { VoiceStartupError } from "./errors";
+export {
+	cancelEchoInWavUtterance,
+	type DesktopAecPassthroughReason,
+	type DesktopAecResult,
+	type DesktopAecUtteranceSummary,
+	FarEndReference,
+	type FarEndReferenceStatus,
+	getSharedFarEndReference,
+} from "./far-end-reference";
 export * from "./ffi-bindings";
 export {
 	_resetSharedFirstLineCacheForTesting,
@@ -271,6 +271,14 @@ export {
 	VoiceScheduler,
 } from "./scheduler";
 export {
+	AGENT_SELF_VOICE_IMPRINT_THRESHOLD,
+	AgentSelfVoiceImprint,
+	type AgentSelfVoiceImprintOptions,
+	type AgentSelfVoiceImprintSource,
+	getAgentSelfVoiceImprint,
+	registerAgentSelfVoiceImprint,
+} from "./self-voice-imprint";
+export {
 	createMtpDraftHandle,
 	type KernelSet,
 	type MmapRegionHandle,
@@ -280,14 +288,6 @@ export {
 	SharedResourceRegistry,
 	type SharedTokenizer,
 } from "./shared-resources";
-export {
-	AGENT_SELF_VOICE_IMPRINT_THRESHOLD,
-	AgentSelfVoiceImprint,
-	type AgentSelfVoiceImprintOptions,
-	type AgentSelfVoiceImprintSource,
-	getAgentSelfVoiceImprint,
-	registerAgentSelfVoiceImprint,
-} from "./self-voice-imprint";
 export {
 	type VoiceAttributionOutput,
 	VoiceAttributionPipeline,

--- a/plugins/plugin-local-inference/src/services/voice/index.ts
+++ b/plugins/plugin-local-inference/src/services/voice/index.ts
@@ -59,11 +59,26 @@ export {
 	platformPlaybackDelayMs,
 	platformPlaybackDelaySamples,
 } from "./echo-delay";
-export { computeErle } from "./echo-metrics";
+export {
+	type AecCaptureReplayInput,
+	type AecCaptureReplayResult,
+	computeErle,
+	computeFarActiveErle,
+	replayAecCaptureErle,
+} from "./echo-metrics";
 export {
 	EchoReferenceBuffer,
 	type EchoReferenceBufferOptions,
 } from "./echo-reference-buffer";
+export {
+	cancelEchoInWavUtterance,
+	type DesktopAecPassthroughReason,
+	type DesktopAecResult,
+	type DesktopAecUtteranceSummary,
+	FarEndReference,
+	type FarEndReferenceStatus,
+	getSharedFarEndReference,
+} from "./far-end-reference";
 export type {
 	LlamaContextLike as Eliza1EotLlamaContext,
 	LlamaContextSequenceLike as Eliza1EotLlamaSequence,
@@ -265,6 +280,14 @@ export {
 	SharedResourceRegistry,
 	type SharedTokenizer,
 } from "./shared-resources";
+export {
+	AGENT_SELF_VOICE_IMPRINT_THRESHOLD,
+	AgentSelfVoiceImprint,
+	type AgentSelfVoiceImprintOptions,
+	type AgentSelfVoiceImprintSource,
+	getAgentSelfVoiceImprint,
+	registerAgentSelfVoiceImprint,
+} from "./self-voice-imprint";
 export {
 	type VoiceAttributionOutput,
 	VoiceAttributionPipeline,

--- a/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
+++ b/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
@@ -26,7 +26,8 @@
 
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { resolveStateDir } from "@elizaos/core";
+import { logger, resolveStateDir } from "@elizaos/core";
+import { StreamingEchoDelayCalibrator } from "@elizaos/shared/voice/aec";
 import {
 	type AttributedTurn,
 	type AttributionPipelineLike,
@@ -37,19 +38,22 @@ import {
 	decodeAudioFramePcm,
 	type EchoReferenceProvider,
 	type RuntimeEventSink,
+	type SelfVoiceSimilarityResolver,
 	type TurnTranscriber,
 	type VadSegmenter,
 } from "./audio-frame-consumer.js";
-import {
-	estimateEchoDelaySamples,
-	platformPlaybackDelaySamples,
-} from "./echo-delay.js";
+import { platformPlaybackDelaySamples } from "./echo-delay.js";
 import { EchoReferenceBuffer } from "./echo-reference-buffer.js";
+import { resolveResidualSuppression } from "./far-end-reference.js";
 import type {
 	ElizaInferenceContextHandle,
 	ElizaInferenceFfi,
 } from "./ffi-bindings.js";
 import { loadElizaInferenceFfi } from "./ffi-bindings.js";
+import {
+	AgentSelfVoiceImprint,
+	registerAgentSelfVoiceImprint,
+} from "./self-voice-imprint.js";
 import { VoiceAttributionPipeline } from "./speaker/attribution-pipeline.js";
 import { FusedDiarizer } from "./speaker/diarizer-fused.js";
 import { FusedSpeakerEncoder } from "./speaker/encoder-fused.js";
@@ -172,6 +176,10 @@ export interface LiveDiarizationConsumerDepsInput {
 	runtime: RuntimeEventSink;
 	transcribe?: TurnTranscriber | null;
 	echoReference?: EchoReferenceProvider | null;
+	/** Live agent-TTS self-voice matcher (#12256 layer 3) + its decision
+	 * threshold (WeSpeaker-embedding scale — see AGENT_SELF_VOICE_IMPRINT_THRESHOLD). */
+	resolveSelfVoiceSimilarity?: SelfVoiceSimilarityResolver | null;
+	selfVoiceThreshold?: number;
 }
 
 export function buildLiveDiarizationConsumerDeps({
@@ -180,6 +188,8 @@ export function buildLiveDiarizationConsumerDeps({
 	runtime,
 	transcribe,
 	echoReference,
+	resolveSelfVoiceSimilarity,
+	selfVoiceThreshold,
 }: LiveDiarizationConsumerDepsInput): AudioFrameConsumerDeps {
 	return {
 		vad,
@@ -187,6 +197,8 @@ export function buildLiveDiarizationConsumerDeps({
 		runtime,
 		...(transcribe ? { transcribe } : {}),
 		...(echoReference ? { echoReference } : {}),
+		...(resolveSelfVoiceSimilarity ? { resolveSelfVoiceSimilarity } : {}),
+		...(selfVoiceThreshold !== undefined ? { selfVoiceThreshold } : {}),
 	};
 }
 
@@ -239,40 +251,6 @@ function encodePcm16Base64(chunks: Float32Array[]): string {
 	return bytes.toString("base64");
 }
 
-/** Echo-delay self-calibration (#9583/#9586). */
-/** Accumulate this many playback-active samples before estimating the delay
- * (1 s @16 kHz — enough correlated echo overlap for a stable cross-correlation
- * even when the transport lag eats several hundred ms of the window). */
-const ECHO_CAL_TARGET_SAMPLES = 16_000;
-/** Bound the rolling calibration window so a long talk-over doesn't grow it. */
-const ECHO_CAL_MAX_SAMPLES = 24_000;
-/** Accept a calibrated delay only above this normalized cross-correlation; below
- * it the near/far are independent (user talking, no echo) — keep the seed. */
-const ECHO_CAL_MIN_CONFIDENCE = 0.3;
-/** Largest playback→mic delay to search (500 ms @16 kHz). The Pixel 6a WebView
- * pump path measured ~381–408 ms end-to-end (#11373 device evidence) — beyond
- * the previous 300 ms ceiling, which made the one-shot calibration lock a
- * wrong cap-edge lag (~298 ms) and permanently misalign the NLMS reference. */
-const ECHO_CAL_MAX_LAG_SAMPLES = 8_000;
-/** Reject locks within one frame of the search ceiling: a cap-edge peak means
- * the true delay is likely beyond the searched range, and a one-shot lock on
- * it would pin a wrong alignment forever. Keep observing instead. */
-const ECHO_CAL_CAP_EDGE_SAMPLES = 320;
-/** Far-end mean-square floor below which a frame is "no playback" (skip). */
-const ECHO_CAL_FAR_ENERGY_FLOOR = 1e-7;
-
-function concatFloat32(chunks: Float32Array[]): Float32Array {
-	let total = 0;
-	for (const c of chunks) total += c.length;
-	const out = new Float32Array(total);
-	let off = 0;
-	for (const c of chunks) {
-		out.set(c, off);
-		off += c.length;
-	}
-	return out;
-}
-
 /**
  * Playback→mic transport delay used to time-align the far-end echo reference,
  * in samples @ 16 kHz. Device-tunable via `ELIZA_VOICE_ECHO_DELAY_MS`:
@@ -309,24 +287,6 @@ function resolveEchoDelaySamples(): number {
 }
 
 /**
- * Opt-in residual-echo suppressor, off by default (#9583/#9649). Device-tunable
- * via `ELIZA_VOICE_RESIDUAL_SUPPRESSION`:
- *   - `"1"` / `"true"` / `"on"` → enable with the canceller's default gain;
- *   - a number in (0,1] → enable with that residual gain (lower = stronger);
- *   - unset / anything else → disabled (the canceller does linear NLMS only).
- * Left off until validated with real device audio, per #9649 item 2.
- */
-function resolveResidualSuppression(): boolean | { gain: number } | undefined {
-	const raw =
-		process.env.ELIZA_VOICE_RESIDUAL_SUPPRESSION?.trim().toLowerCase();
-	if (!raw) return undefined;
-	if (raw === "1" || raw === "true" || raw === "on") return true;
-	const gain = Number(raw);
-	if (Number.isFinite(gain) && gain > 0 && gain <= 1) return { gain };
-	return undefined;
-}
-
-/**
  * Owns the single live diarization consumer for the agent process. Built
  * lazily on first frame batch so it does not load voice models at boot.
  */
@@ -354,15 +314,15 @@ export class LiveDiarizationSession {
 	 */
 	private readonly echoBuffer = new EchoReferenceBuffer();
 	/**
-	 * Playback→mic delay applied when reading the far-end reference. Seeded from
-	 * `ELIZA_VOICE_ECHO_DELAY_MS` (default 0) and then SELF-CALIBRATED on the live
-	 * path: once enough playback-active echo is observed, `estimateEchoDelaySamples`
-	 * (#9586) recovers the bulk transport lag by cross-correlation and replaces the
-	 * seed (#9583). Mutable for that reason.
+	 * Playback→mic delay calibration. Seeded from `ELIZA_VOICE_ECHO_DELAY_MS`
+	 * (default 0) and then SELF-CALIBRATED on the live path by the shared
+	 * `StreamingEchoDelayCalibrator` (#9583/#9586): once enough playback-active
+	 * echo is observed, cross-correlation recovers the bulk transport lag and
+	 * replaces the seed — one-shot lock, same constants as the desktop path.
 	 */
-	private echoDelaySamples = resolveEchoDelaySamples();
-	private echoDelayConfidence = 0;
-	private echoDelayCalibrated = false;
+	private readonly delayCalibrator = new StreamingEchoDelayCalibrator(
+		resolveEchoDelaySamples(),
+	);
 	/**
 	 * Far-end delivery evidence (#9583): frames/samples actually pushed through
 	 * {@link pushPlayback} and the wall-clock time of the last one. These drive
@@ -373,12 +333,10 @@ export class LiveDiarizationSession {
 	private playbackFramesReceived = 0;
 	private playbackSamplesReceived = 0;
 	private lastPlaybackFrameAt: number | null = null;
-	/** Rolling near/far windows accumulated only while the far-end is active, used
-	 * once to estimate the playback→mic delay. Cleared after a confident estimate
-	 * and on {@link resetPlayback}. */
-	private calNear: Float32Array[] = [];
-	private calFar: Float32Array[] = [];
-	private calSampleCount = 0;
+	/** Agent self-voice imprint (#12256 layer 3): built with the fused encoder,
+	 * fed the agent's rendered playback (the same frames the AEC reference
+	 * consumes), and threaded into the consumer as the live self-voice gate. */
+	private selfVoiceImprint: AgentSelfVoiceImprint | null = null;
 	/** Bounded AEC evidence capture (#11373): while armed, every ingested mic
 	 * frame (near) and the delay-0 far-end reference at its timestamp are
 	 * buffered so real on-device ERLE/double-talk measurements can replay the
@@ -448,6 +406,13 @@ export class LiveDiarizationSession {
 		});
 		const encoder = await FusedSpeakerEncoder.load({ ffi, ctx });
 		this.encoder = encoder;
+		// Agent self-voice imprint (#12256 layer 3): the same fused encoder that
+		// embeds mic turns embeds the agent's rendered playback, so the cosine
+		// between them is meaningful. Registered under "live-frames" for the
+		// shared #12255 handle (the speak-back loop's imprint takes precedence).
+		const selfVoiceImprint = new AgentSelfVoiceImprint({ encoder });
+		this.selfVoiceImprint = selfVoiceImprint;
+		registerAgentSelfVoiceImprint("live-frames", selfVoiceImprint);
 		const diarizer = await FusedDiarizer.load({ ffi, ctx });
 		this.diarizer = diarizer;
 		// One shared store per state dir so Pipeline A (here) and Pipeline B
@@ -484,6 +449,13 @@ export class LiveDiarizationSession {
 					this.options.echoReference ??
 					((timestampMs, samples) =>
 						this.echoReferenceFrame(timestampMs, samples)),
+				// Embedding self-voice (#12256 layer 3): match each turn's WeSpeaker
+				// embedding against the agent's TTS centroid so the ambient gate can
+				// hard-suppress the agent hearing itself, at the agent-specific
+				// threshold (NOT the 0.78/0.7 human bars).
+				resolveSelfVoiceSimilarity: (embedding) =>
+					selfVoiceImprint.similarity(embedding),
+				selfVoiceThreshold: selfVoiceImprint.threshold,
 			}),
 			config,
 		);
@@ -548,7 +520,7 @@ export class LiveDiarizationSession {
 		return this.echoBuffer.referenceAt(
 			timestampMs,
 			samples,
-			this.echoDelaySamples,
+			this.delayCalibrator.delaySamples,
 		);
 	}
 
@@ -558,61 +530,20 @@ export class LiveDiarizationSession {
 		confidence: number;
 		calibrated: boolean;
 	} {
-		return {
-			delaySamples: this.echoDelaySamples,
-			confidence: this.echoDelayConfidence,
-			calibrated: this.echoDelayCalibrated,
-		};
+		return this.delayCalibrator.state();
 	}
 
 	/**
-	 * Self-calibrate the playback→mic delay (#9583/#9586) from real echo. Called
-	 * per mic frame while uncalibrated: when the far-end is active (the agent is
-	 * playing TTS), accumulate the time-aligned near/far windows; once ~0.75 s of
-	 * playback-active audio is buffered, recover the bulk transport lag by
-	 * cross-correlation and, if confident, replace the static seed. One-shot — the
-	 * device's speaker→mic path is stable, so we lock the first confident estimate
-	 * and stop re-measuring. Public so it can be unit-tested without the fused FFI.
+	 * Self-calibrate the playback→mic delay (#9583/#9586) from real echo via the
+	 * shared `StreamingEchoDelayCalibrator`. Called per mic frame while
+	 * uncalibrated; reads the RAW far-end at this frame (delay 0 — calibration
+	 * must not pre-apply the value it is trying to measure). Public so it can be
+	 * unit-tested without the fused FFI.
 	 */
 	observeForDelayCalibration(nearPcm: Float32Array, timestampMs: number): void {
-		if (this.echoDelayCalibrated || nearPcm.length === 0) return;
-		// Read the RAW far-end at this frame (delay 0) — calibration recovers the
-		// delay, so it must not pre-apply the value it is trying to measure.
+		if (this.delayCalibrator.calibrated || nearPcm.length === 0) return;
 		const far = this.echoBuffer.referenceAt(timestampMs, nearPcm.length, 0);
-		let farEnergy = 0;
-		for (let i = 0; i < far.length; i++) farEnergy += far[i] * far[i];
-		if (farEnergy / Math.max(1, far.length) < ECHO_CAL_FAR_ENERGY_FLOOR) {
-			return; // no playback → nothing to calibrate against
-		}
-
-		this.calNear.push(nearPcm.slice());
-		this.calFar.push(far);
-		this.calSampleCount += nearPcm.length;
-		while (
-			this.calSampleCount > ECHO_CAL_MAX_SAMPLES &&
-			this.calNear.length > 1
-		) {
-			this.calSampleCount -= (this.calNear.shift() as Float32Array).length;
-			this.calFar.shift();
-		}
-		if (this.calSampleCount < ECHO_CAL_TARGET_SAMPLES) return;
-
-		const near = concatFloat32(this.calNear);
-		const farWin = concatFloat32(this.calFar);
-		const est = estimateEchoDelaySamples(near, farWin, {
-			maxLagSamples: ECHO_CAL_MAX_LAG_SAMPLES,
-		});
-		if (
-			est.confidence >= ECHO_CAL_MIN_CONFIDENCE &&
-			est.lagSamples < ECHO_CAL_MAX_LAG_SAMPLES - ECHO_CAL_CAP_EDGE_SAMPLES
-		) {
-			this.echoDelaySamples = est.lagSamples;
-			this.echoDelayConfidence = est.confidence;
-			this.echoDelayCalibrated = true;
-		}
-		this.calNear = [];
-		this.calFar = [];
-		this.calSampleCount = 0;
+		this.delayCalibrator.observe(nearPcm, far);
 	}
 
 	/**
@@ -657,9 +588,9 @@ export class LiveDiarizationSession {
 			sampleRate: AUDIO_FRAME_SAMPLE_RATE,
 			nearPcm16: encodePcm16Base64(this.aecCaptureNear),
 			farPcm16: encodePcm16Base64(this.aecCaptureFar),
-			echoDelaySamples: this.echoDelaySamples,
-			echoDelayConfidence: this.echoDelayConfidence,
-			echoDelayCalibrated: this.echoDelayCalibrated,
+			echoDelaySamples: this.delayCalibrator.delaySamples,
+			echoDelayConfidence: this.delayCalibrator.confidence,
+			echoDelayCalibrated: this.delayCalibrator.calibrated,
 		};
 	}
 
@@ -701,6 +632,21 @@ export class LiveDiarizationSession {
 			this.playbackFramesReceived += 1;
 			this.playbackSamplesReceived += pcm.length;
 			this.lastPlaybackFrameAt = Date.now();
+			// The same rendered-playback PCM is the agent's own voice — feed the
+			// self-voice imprint (#12256 layer 3) so future mic turns can be gated
+			// against the agent's TTS centroid. The imprint exists only once the
+			// fused consumer built (it needs the encoder); frames before that are
+			// AEC-reference-only.
+			if (this.selfVoiceImprint) {
+				void this.selfVoiceImprint
+					.observeAudio(pcm, AUDIO_FRAME_SAMPLE_RATE)
+					.catch((err: unknown) => {
+						logger.warn(
+							{ error: err instanceof Error ? err.message : String(err) },
+							"[LiveDiarizationSession] self-voice imprint update failed",
+						);
+					});
+			}
 		}
 	}
 
@@ -709,9 +655,7 @@ export class LiveDiarizationSession {
 	 * playback gap); the already-learned delay is kept. */
 	resetPlayback(): void {
 		this.echoBuffer.reset();
-		this.calNear = [];
-		this.calFar = [];
-		this.calSampleCount = 0;
+		this.delayCalibrator.resetWindow();
 	}
 
 	/** Feed a batch of WebView-captured frames; resolves once VAD has processed them. */
@@ -732,10 +676,10 @@ export class LiveDiarizationSession {
 		}
 		for (const frame of frames) {
 			this.framesReceived += 1;
-			if (!this.echoDelayCalibrated || this.aecCaptureArmed) {
+			if (!this.delayCalibrator.calibrated || this.aecCaptureArmed) {
 				try {
 					const near = decodeAudioFramePcm(frame);
-					if (!this.echoDelayCalibrated) {
+					if (!this.delayCalibrator.calibrated) {
 						this.observeForDelayCalibration(near, frame.timestamp);
 					}
 					this.captureAecFrame(near, frame.timestamp);
@@ -779,8 +723,8 @@ export class LiveDiarizationSession {
 				playbackFramesReceived: this.playbackFramesReceived,
 				playbackSamplesReceived: this.playbackSamplesReceived,
 				lastPlaybackFrameAt: this.lastPlaybackFrameAt,
-				echoDelaySamples: this.echoDelaySamples,
-				echoDelayConfidence: this.echoDelayConfidence,
+				echoDelaySamples: this.delayCalibrator.delaySamples,
+				echoDelayConfidence: this.delayCalibrator.confidence,
 			},
 			recentTurns: [...this.recentTurns],
 			...(this.buildError ? { error: this.buildError } : {}),

--- a/plugins/plugin-local-inference/src/services/voice/self-voice-imprint.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/self-voice-imprint.test.ts
@@ -1,6 +1,13 @@
-/** Covers `AgentSelfVoiceImprint` building the agent's own voice centroid from TTS output. Deterministic, fake encoder. */
-import { describe, expect, it } from "vitest";
-import { AgentSelfVoiceImprint } from "./self-voice-imprint";
+/** Covers `AgentSelfVoiceImprint`: TTS-centroid building, the agent-specific
+ * self-voice decision gate, and the shared #12255 handle. Deterministic, fake encoder. */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	__resetAgentSelfVoiceImprintsForTest,
+	AGENT_SELF_VOICE_IMPRINT_THRESHOLD,
+	AgentSelfVoiceImprint,
+	getAgentSelfVoiceImprint,
+	registerAgentSelfVoiceImprint,
+} from "./self-voice-imprint";
 import type { SpeakerEncoder } from "./speaker/encoder";
 
 function unitEmbedding(index: number): Float32Array {
@@ -56,5 +63,54 @@ describe("AgentSelfVoiceImprint", () => {
 		diagonal[0] = Math.SQRT1_2;
 		diagonal[1] = Math.SQRT1_2;
 		await expect(imprint.similarity(diagonal)).resolves.toBeCloseTo(1);
+	});
+});
+
+describe("AgentSelfVoiceImprint decision gate (#12256)", () => {
+	it("decides self-voice at the agent-specific threshold, not the 0.78 human bar", async () => {
+		const imprint = new AgentSelfVoiceImprint({
+			encoder: queuedEncoder([unitEmbedding(0)]),
+			minSamples: 16_000,
+		});
+		await imprint.observeAudio(new Float32Array(16_000).fill(0.1), 16_000);
+		expect(imprint.ready).toBe(true);
+		expect(imprint.threshold).toBe(AGENT_SELF_VOICE_IMPRINT_THRESHOLD);
+
+		// The measured production margins: agent-self cosine ~0.37, human ~0.15.
+		const selfLike = new Float32Array(256);
+		selfLike[0] = 0.37;
+		selfLike[2] = Math.sqrt(1 - 0.37 ** 2);
+		const humanLike = new Float32Array(256);
+		humanLike[0] = 0.15;
+		humanLike[3] = Math.sqrt(1 - 0.15 ** 2);
+		await expect(imprint.isAgentSelfVoice(selfLike)).resolves.toBe(true);
+		await expect(imprint.isAgentSelfVoice(humanLike)).resolves.toBe(false);
+	});
+
+	it("returns null (fail-open) before any centroid exists", async () => {
+		const imprint = new AgentSelfVoiceImprint({
+			encoder: queuedEncoder([unitEmbedding(0)]),
+		});
+		expect(imprint.ready).toBe(false);
+		await expect(imprint.isAgentSelfVoice(unitEmbedding(0))).resolves.toBeNull();
+	});
+});
+
+describe("shared imprint handle (#12255 contract)", () => {
+	afterEach(() => __resetAgentSelfVoiceImprintsForTest());
+
+	it("prefers the speak-back loop's registration over live-frames", () => {
+		expect(getAgentSelfVoiceImprint()).toBeNull();
+		const liveFrames = new AgentSelfVoiceImprint({
+			encoder: queuedEncoder([unitEmbedding(0)]),
+		});
+		registerAgentSelfVoiceImprint("live-frames", liveFrames);
+		expect(getAgentSelfVoiceImprint()).toBe(liveFrames);
+
+		const speakBack = new AgentSelfVoiceImprint({
+			encoder: queuedEncoder([unitEmbedding(1)]),
+		});
+		registerAgentSelfVoiceImprint("speak-back-loop", speakBack);
+		expect(getAgentSelfVoiceImprint()).toBe(speakBack);
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/self-voice-imprint.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/self-voice-imprint.test.ts
@@ -92,7 +92,9 @@ describe("AgentSelfVoiceImprint decision gate (#12256)", () => {
 			encoder: queuedEncoder([unitEmbedding(0)]),
 		});
 		expect(imprint.ready).toBe(false);
-		await expect(imprint.isAgentSelfVoice(unitEmbedding(0))).resolves.toBeNull();
+		await expect(
+			imprint.isAgentSelfVoice(unitEmbedding(0)),
+		).resolves.toBeNull();
 	});
 });
 

--- a/plugins/plugin-local-inference/src/services/voice/self-voice-imprint.ts
+++ b/plugins/plugin-local-inference/src/services/voice/self-voice-imprint.ts
@@ -1,9 +1,28 @@
 /**
- * Builds and maintains the agent's own voice centroid from its TTS output, so
- * the speaker-attribution pipeline can recognize (and exclude) the assistant's
- * playback as self rather than mis-attributing it to a human speaker. Encodes
- * recent agent-TTS segments through the speaker encoder into a running centroid.
+ * Bounded centroid of the agent's own synthesized voice, with the
+ * agent-specific self-voice decision the echo defense's third layer gates on
+ * (#12256, layered after the cooldown gate and the NLMS canceller).
+ *
+ * The live mic path already gets WeSpeaker embeddings from attribution. This
+ * helper observes the PCM the agent actually renders (Pipeline B: the
+ * scheduler's audio chunks; Pipeline A: the playback frames the renderer
+ * streams back), embeds that audio, and exposes cosine similarity of future
+ * mic turns against the centroid. The decision threshold is
+ * `AGENT_SELF_VOICE_IMPRINT_THRESHOLD` (0.28): the agent's synthetic voice
+ * embeds ~0.37 self-similar vs ~0.15 for humans (VOICE_8785_ASSESSMENT §6) —
+ * a real margin, but far below the 0.78 human-enrollment bar, which is why the
+ * imprint carries its own threshold instead of reusing the profile store's.
+ *
+ * Handle contract for #12255 (speaker-gated barge-in), mirroring the
+ * profile-store factory's (#12257): the production pipelines register their
+ * live imprint here at construction; barge-in gating calls
+ * `getAgentSelfVoiceImprint()` (no args) and uses `isAgentSelfVoice(embedding)`
+ * — never constructs its own imprint or re-derives the threshold. A `null`
+ * gate result means "no centroid yet" (the agent has not spoken enough) and
+ * MUST fail open (treat as not-self), never as self-voice.
  */
+
+import { AGENT_SELF_VOICE_IMPRINT_THRESHOLD } from "@elizaos/shared/voice/respond-gate";
 import { averageEmbeddings, type SpeakerEncoder } from "./speaker/encoder";
 import {
 	SPEAKER_GGML_MIN_SAMPLES,
@@ -11,6 +30,8 @@ import {
 } from "./speaker/encoder-ggml";
 import { cosineSimilarity } from "./speaker-imprint";
 import { resampleLinear } from "./transcriber";
+
+export { AGENT_SELF_VOICE_IMPRINT_THRESHOLD };
 
 export interface AgentSelfVoiceImprintOptions {
 	encoder: SpeakerEncoder;
@@ -20,6 +41,12 @@ export interface AgentSelfVoiceImprintOptions {
 	maxSamples?: number;
 	/** Number of recent agent-TTS embeddings retained in the centroid. */
 	maxEmbeddings?: number;
+	/**
+	 * Cosine at/above which a turn embedding is decided to be the agent's own
+	 * voice. Default {@link AGENT_SELF_VOICE_IMPRINT_THRESHOLD} (0.28; safe
+	 * range 0.25–0.30 per the measured self/human margins).
+	 */
+	similarityThreshold?: number;
 }
 
 function concatSegments(
@@ -35,18 +62,12 @@ function concatSegments(
 	return out;
 }
 
-/**
- * Maintains a bounded centroid of the agent's own synthesized voice.
- *
- * The live mic path already gets WeSpeaker embeddings from attribution. This
- * helper observes the PCM that the scheduler hands to audio output, embeds that
- * actual TTS audio, and exposes cosine similarity against future mic turns.
- */
 export class AgentSelfVoiceImprint {
 	private readonly encoder: SpeakerEncoder;
 	private readonly minSamples: number;
 	private readonly maxSamples: number;
 	private readonly maxEmbeddings: number;
+	private readonly similarityThreshold: number;
 	private readonly pendingSegments: Float32Array[] = [];
 	private pendingSamples = 0;
 	private readonly embeddings: Float32Array[] = [];
@@ -58,6 +79,19 @@ export class AgentSelfVoiceImprint {
 		this.minSamples = options.minSamples ?? SPEAKER_GGML_MIN_SAMPLES;
 		this.maxSamples = options.maxSamples ?? SPEAKER_GGML_SAMPLE_RATE * 6;
 		this.maxEmbeddings = Math.max(1, options.maxEmbeddings ?? 8);
+		this.similarityThreshold =
+			options.similarityThreshold ?? AGENT_SELF_VOICE_IMPRINT_THRESHOLD;
+	}
+
+	/** The agent-specific decision threshold this imprint applies. Consumers
+	 * that forward the raw similarity into a gate pass this alongside it. */
+	get threshold(): number {
+		return this.similarityThreshold;
+	}
+
+	/** True once at least one centroid update has been encoded. */
+	get ready(): boolean {
+		return this.centroid !== null;
 	}
 
 	observeAudio(pcm: Float32Array, sampleRate: number): Promise<void> {
@@ -73,6 +107,17 @@ export class AgentSelfVoiceImprint {
 		if (!this.centroid) return null;
 		if (embedding.length !== this.centroid.length) return null;
 		return cosineSimilarity(embedding, this.centroid);
+	}
+
+	/**
+	 * The speaker-gate decision for #12255: does this turn embedding match the
+	 * agent's own TTS voice? `null` while no centroid exists yet (or on a
+	 * dimension mismatch) — callers MUST fail open on `null`.
+	 */
+	async isAgentSelfVoice(embedding: Float32Array): Promise<boolean | null> {
+		const similarity = await this.similarity(embedding);
+		if (similarity === null) return null;
+		return similarity >= this.similarityThreshold;
 	}
 
 	private async observeAudioLocked(
@@ -105,4 +150,44 @@ export class AgentSelfVoiceImprint {
 		}
 		this.centroid = averageEmbeddings(this.embeddings);
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Shared per-process handle (#12255 consumes this)
+// ---------------------------------------------------------------------------
+
+/** Which production pipeline registered an imprint. The speak-back loop's is
+ * preferred: barge-in runs inside it, and its imprint observes the exact PCM
+ * the scheduler hands to audio output. */
+export type AgentSelfVoiceImprintSource = "speak-back-loop" | "live-frames";
+
+const registeredImprints = new Map<
+	AgentSelfVoiceImprintSource,
+	AgentSelfVoiceImprint
+>();
+
+/** Register a production imprint under its pipeline source. Re-registration
+ * (a voice restart) replaces the previous instance for that source. */
+export function registerAgentSelfVoiceImprint(
+	source: AgentSelfVoiceImprintSource,
+	imprint: AgentSelfVoiceImprint,
+): void {
+	registeredImprints.set(source, imprint);
+}
+
+/**
+ * The live production imprint, or null when no voice pipeline has constructed
+ * one yet. Prefers the speak-back loop's (see {@link AgentSelfVoiceImprintSource}).
+ */
+export function getAgentSelfVoiceImprint(): AgentSelfVoiceImprint | null {
+	return (
+		registeredImprints.get("speak-back-loop") ??
+		registeredImprints.get("live-frames") ??
+		null
+	);
+}
+
+/** Drop all registered imprints. Test-only. */
+export function __resetAgentSelfVoiceImprintsForTest(): void {
+	registeredImprints.clear();
 }

--- a/plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts
@@ -14,7 +14,10 @@ import {
 	type OwnerObservation,
 	resolveOwnerCandidate,
 } from "@elizaos/shared/voice/owner-inference";
-import { buildVoiceTurnSignal } from "@elizaos/shared/voice/respond-gate";
+import {
+	AGENT_SELF_VOICE_IMPRINT_THRESHOLD,
+	buildVoiceTurnSignal,
+} from "@elizaos/shared/voice/respond-gate";
 import { scoreEndOfTurnHeuristic } from "@elizaos/shared/voice-eot";
 import { resolveFusedLibraryPath } from "../desktop-fused-ffi-backend-runtime";
 import type {
@@ -422,8 +425,13 @@ class RealVoiceWorkbenchAdapter implements RealVoiceWorkbenchRuntime {
 				? { recentAgentReply: this.lastAgentReply, replyAgeMs: 500 }
 				: {}),
 			agentSpeaking: args.label.isAgentEcho === true,
+			// WeSpeaker-embedding scale: the agent-specific threshold travels with
+			// the measurement (self ~0.37 vs human ~0.15 — never the 0.7 MFCC bar).
 			...(typeof selfVoiceSimilarity === "number"
-				? { selfVoiceSimilarity }
+				? {
+						selfVoiceSimilarity,
+						selfVoiceThreshold: AGENT_SELF_VOICE_IMPRINT_THRESHOLD,
+					}
 				: {}),
 			speaker: {
 				entityId: matchedEntityId,


### PR DESCRIPTION
Closes #12256. Part of #12187. Unblocks #12255 speaker-gated barge-in.

The agent must not hear itself. This lands the layered echo defense in the settled order (parent decision #7): **cooldown gate → NLMS-with-reference on the desktop loop → embedding self-voice**, gated by measured ERLE before considering AEC3 (escalation only — not vendored here). It builds directly on #12257's merged `getSharedVoiceProfileStore()` wiring.

## Layered defense

**Layer 1 — cooldown gate (cheapest).** While TTS is playing and for `ELIZA_VOICE_POST_TTS_COOLDOWN_MS` (default 1500 ms) after, the capture side demands louder/closer speech before starting an ASR submission — the agent's own tail can't self-trigger, but a loud close interjection (real barge-in) still clears the raised bar. It never mutes.
- `packages/ui/src/voice/tts-playback-activity.ts` — renderer-wide playback-activity signal; the playback-frame pump marks start/stop around real audible playback.
- `packages/ui/src/voice/local-asr-capture.ts` — the auto-stop detector multiplies its RMS + peak thresholds by 4x while the gate is active (0.003→0.012 RMS, 0.012→0.048 peak).
- `packages/app-core/platforms/electrobun/src/voice/voice-service.ts` — a post-TTS cooldown anchored on the playback mark forces the transcript echo guard on at handoff, catching an echo that returns mid-playback after the reply's message age already passed the 9 s `ECHO_WINDOW_MS`.

**Layer 2 — TTS-reference NLMS AEC on the desktop ASR path.** Before: `/api/asr/local-inference` had NO AEC (grep `echo|aec` → empty); the agent transcribed its own playback. After: every WAV utterance is echo-cancelled before transcription when a correlated far-end reference exists (bit-exact passthrough otherwise).
- New `packages/shared/src/voice/aec/`: `echo-metrics.ts` (canonical `computeErle` + far-active-masked ERLE), `echo-alignment.ts` (offline whole-utterance coarse+fine cross-correlation align — the batch sibling of the streaming `estimateEchoDelaySamples`), `delay-calibrator.ts` (`StreamingEchoDelayCalibrator` extracted 1:1 from the live session so both pipelines share one implementation).
- New `plugins/plugin-local-inference/src/services/voice/far-end-reference.ts`: shared per-process `FarEndReference` — 30 s timestamped playback history fed by the same `/api/voice/playback-frames` the renderer pump already POSTs to, renderer↔server clock anchoring, per-utterance align + warm-pass NLMS cancel, far-active ERLE. History survives playback resets (the pump resets before the echoed WAV lands). Reuses the existing `NlmsEchoCanceller` / `EchoReferenceBuffer` — **no new DSP lib**.

**Layer 3 — production `AgentSelfVoiceImprint`.** Constructed off the fused encoder (both pipelines), fed the agent's rendered playback, exposes `isAgentSelfVoice(embedding)` at the **agent-specific 0.28 threshold** (self ~0.37 vs human ~0.15, `VOICE_8785_ASSESSMENT` §6 — NOT the 0.78/0.7 human bars). `selfVoiceThreshold` travels with the measurement through the respond-gate so a WeSpeaker cosine is never compared against the MFCC bar. Pipeline A now builds + consumes the imprint; the engine-bridge fold passes the imprint threshold.

**Layer 4 — ERLE telemetry.** `GET /api/dev/voice-latency` gains an `aec` block (`echoReferenceWired`, delivery counters, per-utterance ERLE ring); `GET /api/voice/aec-capture` returns the measured ERLE by replaying the armed near/far window through the real canceller (`replayAecCaptureErle`, promoting the test-only `computeErle`).

## ERLE numbers vs #12258 ceilings (`minErleDb` 18)

Real `NlmsEchoCanceller` over the agent's synthetic TTS as far-end reference + far-field + early reflections:

| Condition | ERLE (far-active) | vs 18 dB |
| --- | --- | --- |
| clean-echo (20 ms, −6 dB) | **31.71 dB** | PASS |
| early-reflections (45 ms, −9 dB, 2 taps) | **29.25 dB** | PASS |
| long-transport (380 ms, −9 dB) | **30.05 dB** | PASS |

Desktop `FarEndReference` end-to-end (whole-utterance align + cancel of a WAV): **applied, ERLE 33.67 dB, alignment confidence 0.954**. Before → after: mic path uncancelled (agent transcribed its echo) → ~30 dB ERLE, matching the ~29 dB synthetic target with margin over the 18 dB bar. Self-voice: agent echoes rejected (similarity 1.0), 4 human turns passed.

## Self-voice-gate handle contract for #12255 (speaker-gated barge-in)

Mirrors #12257's store handle. #12255 calls `getAgentSelfVoiceImprint()` (no args) from `services/voice/self-voice-imprint.ts` to get the live production imprint the pipeline registered, then gates barge-in with `await imprint.isAgentSelfVoice(embedding)`:
- `true` → the agent's own echo; do **not** hard-stop TTS.
- `false` → a real speaker; barge-in may proceed.
- `null` → no centroid yet; **fail open** (treat as not-self), never as self-voice.

The speak-back loop's imprint (registered `"speak-back-loop"`) takes precedence over Pipeline A's (`"live-frames"`). #12255 never constructs its own imprint or re-derives the threshold — `imprint.threshold` is the agent-specific bar.

## Wired vs escalation-deferred

Wired: all four layers. **AEC3 / `webrtc-audio-processing` is NOT vendored** — it is the escalation path only, taken only if measured device ERLE after layer 2 is <18 dB. The ERLE the dev route now surfaces is precisely the gate for that decision. Real-hardware `device-acoustic-erle.mjs` is N/A here (no loaded acoustic host); synthetic ERLE (~30 dB) clears the bar with margin.

## Verification

- `bun run --cwd plugins/plugin-local-inference test` (touched: aec, echo, self-voice, far-end-reference, audio-frame-consumer, engine-bridge, asr-route, live-diarization-route suites): **82 passed**.
- `bun run --cwd packages/shared test -- voice/aec` + respond-gate: **21 passed**.
- `packages/ui` voice (tts-playback-activity, local-asr-capture, playback-frame-pump): green. `packages/app-core` electrobun voice-service: **17 passed**.
- Workbench `voice:workbench --logic`: **24 scenarios, overall pass, no regressions vs the #12258 baseline** (`desktop-aec-echo` 10 cases + `speaker-gated-barge-in` 14 cases green). `--real` hard-fails exit 1 without staged GGUFs (no false pass).
- `bun run audit:error-policy-ratchet`: no new fallback-slop in touched files. Typecheck/biome clean on touched files (pre-existing unrelated `downloader.ts` / `iwer` errors excepted).

## Evidence

`.github/issue-evidence/12256-echo/` — real NLMS + desktop `FarEndReference` + self-voice imprint over the deterministic synthetic echo corpus (ERLE table above), workbench `--logic` report, `--real` hard-fail proof, and README. N/A with reasons: real-hardware ERLE (no device), fused WeSpeaker margin (GGUF unstaged — MFCC proxy + unit tests cover the 0.28 operating point), captured real audio (no audio device/fused bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
