### PR TITLE
chore(electrobun): format desktop positioning code

### DIFF
--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts
@@ -166,8 +166,12 @@ describe("desktop bottom-bar config", () => {
     });
 
     it("re-anchors on a width/height change (dock or resolution change)", () => {
-      expect(shouldReanchorBottomBar(base, { ...base, width: 1440 })).toBe(true);
-      expect(shouldReanchorBottomBar(base, { ...base, height: 900 })).toBe(true);
+      expect(shouldReanchorBottomBar(base, { ...base, width: 1440 })).toBe(
+        true,
+      );
+      expect(shouldReanchorBottomBar(base, { ...base, height: 900 })).toBe(
+        true,
+      );
     });
 
     it("re-anchors on an origin change (display plug/unplug, monitor swap)", () => {

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -2096,8 +2096,7 @@ X-GNOME-Autostart-enabled=true
     try {
       const display = Screen.getPrimaryDisplay();
       if (display?.workArea) workArea = display.workArea;
-      primaryHeight =
-        display?.bounds?.height ?? workArea.y + workArea.height;
+      primaryHeight = display?.bounds?.height ?? workArea.y + workArea.height;
     } catch (err) {
       logger.warn(
         `[Desktop] tray popover Screen.getPrimaryDisplay() failed; using default anchor: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/app-core/platforms/electrobun/src/tray-popover-position.test.ts
+++ b/packages/app-core/platforms/electrobun/src/tray-popover-position.test.ts
@@ -90,12 +90,7 @@ describe("computeTrayPopoverFrame", () => {
   it("honors the work-area origin on a secondary display (multi-monitor)", () => {
     const secondary = { x: 1920, y: 24, width: 1920, height: 1056 };
     const trayBounds = { x: 3200, y: 1058, width: 30, height: 22 };
-    const frame = computeTrayPopoverFrame(
-      trayBounds,
-      secondary,
-      SIZE,
-      1080,
-    );
+    const frame = computeTrayPopoverFrame(trayBounds, secondary, SIZE, 1080);
     // x centered: 3200 + 15 - 180 = 3035, inside [1928, 3552].
     expect(frame.x).toBe(3035);
     expect(frame.x).toBeGreaterThanOrEqual(secondary.x + SIZE.margin);

--- a/packages/app-core/platforms/electrobun/src/tray-popover-position.ts
+++ b/packages/app-core/platforms/electrobun/src/tray-popover-position.ts
@@ -28,9 +28,7 @@ export interface TrayPopoverSize {
 }
 
 function isZeroRect(rect: Rect): boolean {
-  return (
-    rect.x === 0 && rect.y === 0 && rect.width === 0 && rect.height === 0
-  );
+  return rect.x === 0 && rect.y === 0 && rect.width === 0 && rect.height === 0;
 }
 
 function clamp(value: number, min: number, max: number): number {


### PR DESCRIPTION
## Summary
- apply Biome formatting to Electrobun desktop positioning files that were failing the root verify lint lane
- no behavior changes; formatter-only diff around bottom-bar and tray-popover positioning code/tests

## Evidence
- PASS: `bunx @biomejs/biome check packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts packages/app-core/platforms/electrobun/src/native/desktop.ts packages/app-core/platforms/electrobun/src/tray-popover-position.test.ts packages/app-core/platforms/electrobun/src/tray-popover-position.ts`
- PASS: `bun test packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts packages/app-core/platforms/electrobun/src/tray-popover-position.test.ts` (22 tests)
- PASS: `bun run --cwd packages/app-core/platforms/electrobun lint`
- PASS: `git diff --check HEAD~1..HEAD`

## Evidence N/A
- Screenshots/video: N/A - formatter-only change, no rendered UI behavior.
- Real LLM trajectories: N/A - no agent/model/prompt behavior changes.
- Domain artifacts/log captures: N/A - no runtime product flow changes.