### PR TITLE
fix: persist training numerics scan

### DIFF
--- a/.github/issue-evidence/12319-stage2-training-numerics.md
+++ b/.github/issue-evidence/12319-stage2-training-numerics.md
@@ -1,0 +1,40 @@
+# Issue #12319 — Stage 2 training numerics evidence
+
+## What changed
+
+- `train_local.py` persists the existing finite checkpoint scan as `final/numerics_scan.json` immediately after saving the model.
+- Added a CPU-safe one-step smoke test that builds a tiny local Transformers causal LM, runs the real `train_local.py` forward/backward/save path, and verifies the emitted checkpoint numerics report.
+
+Current `develop` already contains the Stage 2 finite-loss boundary, finite-weights callback, checkpoint scan gate in `run_pipeline.py`, registry `train_dtype`, per-tier `max_grad_norm`, and Gemma Liger allowlist. This chunk adds the missing persisted artifact and real entrypoint smoke around those gates.
+
+## Verification
+
+Commands run in `/tmp/eliza-12318-stage1-corpus` on branch `fix/12319-training-numerics`:
+
+```bash
+python -m py_compile \
+  packages/training/scripts/train_local.py \
+  packages/training/scripts/run_pipeline.py \
+  packages/training/scripts/training/model_registry.py \
+  packages/training/scripts/training/instrumentation.py \
+  packages/training/scripts/test_train_local_stage2_smoke.py
+uv run --project packages/training --with pytest -- python -m pytest \
+  packages/training/scripts/training/test_finite_guard.py \
+  packages/training/scripts/training/test_model_registry.py \
+  packages/training/scripts/test_train_local_low_vram_smoke.py \
+  packages/training/scripts/test_train_local_stage2_smoke.py
+```
+
+Observed result:
+
+- Python compile check passed.
+- Pytest: 59 passed, 3 skipped, 1 pytest config warning about `asyncio_mode`.
+- Finite guard tests covered non-finite loss and checkpoint tensor rejection.
+- Registry/low-vram tests covered tier dtype and gradient clipping defaults plus explicit override behavior.
+- Stage 2 smoke test covered the real `train_local.py` one-step path and asserted `final/numerics_scan.json` had `passed: true`, nonzero `tensor_files`, and nonzero `tensors`.
+
+## Evidence N/A
+
+- Full Gemma-4 + Liger hardware trajectory: not captured in this local chunk because the host does not expose CUDA/H200-class hardware. The existing Liger allowlist intentionally fails closed for unsupported architectures.
+- Screenshots/video: N/A, non-UI training tooling.
+- Benchmarks: N/A, this change verifies fail-closed numerics behavior rather than model quality/throughput.

--- a/packages/training/scripts/test_train_local_stage2_smoke.py
+++ b/packages/training/scripts/test_train_local_stage2_smoke.py
@@ -1,0 +1,158 @@
+"""Real Stage 2 forward/backward smoke for the local SFT entrypoint.
+
+The default test builds a tiny local Transformers causal LM, trains one step
+through `train_local.py` on the tracked smoke corpus, and verifies the saved
+checkpoint numerics report. The full Gemma-4 + Liger hardware run is captured
+as evidence outside this CPU-safe test lane.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = ROOT / "scripts"
+SMOKE_DATA = ROOT / "data" / "final-eliza1-smoke"
+
+
+def _write_tiny_causal_lm(model_dir: Path) -> None:
+    tokenizers = pytest.importorskip("tokenizers")
+    transformers = pytest.importorskip("transformers")
+    torch = pytest.importorskip("torch")
+
+    vocab = {
+        "[PAD]": 0,
+        "[UNK]": 1,
+        "[BOS]": 2,
+        "[EOS]": 3,
+        "system": 4,
+        "user": 5,
+        "assistant": 6,
+        "tool": 7,
+        "hello": 8,
+        "reply": 9,
+        "json": 10,
+        "text": 11,
+        "agent": 12,
+        "content": 13,
+        "the": 14,
+        "a": 15,
+        "to": 16,
+        "and": 17,
+        "I": 18,
+        "you": 19,
+    }
+    raw = tokenizers.Tokenizer(
+        tokenizers.models.WordLevel(vocab=vocab, unk_token="[UNK]"),
+    )
+    raw.pre_tokenizer = tokenizers.pre_tokenizers.Whitespace()
+    tokenizer = transformers.PreTrainedTokenizerFast(
+        tokenizer_object=raw,
+        unk_token="[UNK]",
+        pad_token="[PAD]",
+        bos_token="[BOS]",
+        eos_token="[EOS]",
+    )
+    tokenizer.chat_template = (
+        "{% for message in messages %}"
+        "{{ message['role'] }}: "
+        "{% if message['content'] is string %}{{ message['content'] }}{% endif %}\n"
+        "{% endfor %}{{ eos_token }}"
+    )
+    config = transformers.GPT2Config(
+        vocab_size=len(vocab),
+        n_positions=64,
+        n_ctx=64,
+        n_embd=32,
+        n_layer=1,
+        n_head=2,
+        bos_token_id=2,
+        eos_token_id=3,
+        pad_token_id=0,
+    )
+    torch.manual_seed(0)
+    model = transformers.GPT2LMHeadModel(config)
+    model.save_pretrained(model_dir)
+    tokenizer.save_pretrained(model_dir)
+
+
+def test_train_local_runs_real_forward_backward_and_scans_checkpoint(
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("trl")
+    pytest.importorskip("datasets")
+    pytest.importorskip("apollo_torch")
+
+    model_dir = tmp_path / "tiny-model"
+    out_dir = tmp_path / "out"
+    _write_tiny_causal_lm(model_dir)
+
+    cmd = [
+        sys.executable,
+        str(SCRIPTS / "train_local.py"),
+        "--model",
+        str(model_dir),
+        "--train-file",
+        str(SMOKE_DATA / "train.jsonl"),
+        "--val-file",
+        str(SMOKE_DATA / "val.jsonl"),
+        "--out-dir",
+        str(out_dir),
+        "--run-name",
+        "stage2-tiny-smoke",
+        "--max-samples",
+        "1",
+        "--epochs",
+        "1",
+        "--max-steps",
+        "1",
+        "--batch-size",
+        "1",
+        "--grad-accum",
+        "1",
+        "--max-seq-len",
+        "64",
+        "--optimizer",
+        "apollo_mini",
+        "--apollo-rank",
+        "1",
+        "--train-dtype",
+        "bf16",
+        "--max-grad-norm",
+        "1.0",
+        "--use-liger",
+        "off",
+    ]
+    env = {
+        **os.environ,
+        "TOKENIZERS_PARALLELISM": "false",
+        "WANDB_DISABLED": "true",
+    }
+    proc = subprocess.run(
+        cmd,
+        cwd=str(ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, (
+        "train_local.py tiny smoke failed\n"
+        f"stdout tail:\n{proc.stdout[-2000:]}\n"
+        f"stderr tail:\n{proc.stderr[-4000:]}"
+    )
+
+    final_dir = out_dir / "stage2-tiny-smoke" / "final"
+    report_path = final_dir / "numerics_scan.json"
+    assert report_path.exists(), f"missing checkpoint numerics report at {report_path}"
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["passed"] is True
+    assert report["tensor_files"] > 0
+    assert report["tensors"] > 0
+    assert "checkpoint numerics scan passed" in proc.stderr

--- a/packages/training/scripts/train_local.py
+++ b/packages/training/scripts/train_local.py
@@ -979,7 +979,10 @@ def main() -> int:
         trainer.training_step = _fp8_training_step  # type: ignore[assignment]
 
     from training.instrumentation import (
-        InstrumentationConfig, log_environment, make_finite_weights_callback,
+        InstrumentationConfig,
+        assert_finite_checkpoint,
+        log_environment,
+        make_finite_weights_callback,
         make_hf_callback,
     )
     # Materialize the exact tokenizer this run trains with (including any chat-
@@ -1027,6 +1030,15 @@ def main() -> int:
     )
     trainer.save_model(str(out_dir / "final"))
     tokenizer.save_pretrained(str(out_dir / "final"))
+    numerics_report = assert_finite_checkpoint(out_dir / "final")
+    (out_dir / "final" / "numerics_scan.json").write_text(
+        json.dumps(numerics_report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    log.info(
+        "checkpoint numerics scan passed: %s",
+        out_dir / "final" / "numerics_scan.json",
+    )
     log.info("done. full-parameter APOLLO checkpoint at %s", out_dir / "final")
     return 0
 


### PR DESCRIPTION
## Summary
- Persist the existing finite checkpoint scan from `train_local.py` as `final/numerics_scan.json` after saving the final checkpoint.
- Add a CPU-safe one-step `train_local.py` smoke that exercises the real forward/backward/save path and verifies the numerics scan artifact.
- Attach Stage 2 evidence and explicitly mark full Gemma-4/Liger hardware evidence as not captured locally.

Relates to #12319.

## Verification
- `python -m py_compile packages/training/scripts/train_local.py packages/training/scripts/run_pipeline.py packages/training/scripts/training/model_registry.py packages/training/scripts/training/instrumentation.py packages/training/scripts/test_train_local_stage2_smoke.py`
- `uv run --project packages/training --with pytest -- python -m pytest packages/training/scripts/training/test_finite_guard.py packages/training/scripts/training/test_model_registry.py packages/training/scripts/test_train_local_low_vram_smoke.py packages/training/scripts/test_train_local_stage2_smoke.py` — 59 passed, 3 skipped, 1 pytest config warning (`asyncio_mode`)

## Evidence
- `.github/issue-evidence/12319-stage2-training-numerics.md`

## Evidence N/A
- Screenshots/video: N/A, non-UI training tooling.
- Full Gemma-4 + Liger hardware trajectory: not captured on this local host; no CUDA/H200-class hardware exposed.
- Benchmarks: N/A, this verifies fail-closed numerics behavior rather than quality/throughput.
