### PR TITLE
fix(shared): resolve duplicate platform export (aosp-user-agent vs eliza-os) — develop-red

### DIFF
--- a/packages/shared/src/platform/eliza-os.ts
+++ b/packages/shared/src/platform/eliza-os.ts
@@ -1,22 +1,18 @@
 /**
- * AOSP ElizaOS renderer detection. Pure user-agent matching plus a `navigator`
- * probe, React-free so Node/Bun-reachable update-policy code can ask "is this
- * device an ElizaOS system image?" without importing the renderer's platform
- * barrel (Capacitor + bridge modules). `@elizaos/ui/platform` re-exports these.
- *
- * The Android framework appends `ElizaOS/<tag>` to the WebView user-agent only
- * on Eliza-derived AOSP system images (see MainActivity user-agent suffix);
- * stock Android and non-Android platforms never carry it.
+ * AOSP ElizaOS renderer detection. Re-exports the pure user-agent matcher from
+ * `./aosp-user-agent` (the canonical, path-imported definition) and adds a
+ * `navigator` probe, React-free so Node/Bun-reachable update-policy code can ask
+ * "is this device an ElizaOS system image?" without importing the renderer's
+ * platform barrel (Capacitor + bridge modules). `@elizaos/ui/platform`
+ * re-exports these.
  */
 
-export function userAgentHasElizaOSMarker(
-  userAgent: string | null | undefined,
-): boolean {
-  if (typeof userAgent !== "string" || userAgent.length === 0) return false;
-  return /\bElizaOS\/\S/.test(userAgent);
-}
+export {
+  isAospElizaUserAgent,
+  userAgentHasElizaOSMarker,
+} from "./aosp-user-agent.js";
 
-export const isAospElizaUserAgent = userAgentHasElizaOSMarker;
+import { userAgentHasElizaOSMarker } from "./aosp-user-agent.js";
 
 /**
  * True when the current runtime is an ElizaOS AOSP system image, detected via


### PR DESCRIPTION
Develop-red: `@elizaos/shared` barrel `export *`s both `platform/aosp-user-agent.ts` and `platform/eliza-os.ts`, which each declared `userAgentHasElizaOSMarker` + `isAospElizaUserAgent` → duplicate-export build/typecheck failure (flagged by the #12464 and #12465 verify lanes). Fix: `eliza-os.ts` re-exports the matcher from the canonical `aosp-user-agent.ts` (which is the one imported by path) and keeps only its own `isElizaOS()`. `packages/shared` `build:dist` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)