### PR TITLE
fix(elizaos): fail deploy on corrupt local json

### DIFF
--- a/.github/issue-evidence/12275-elizaos-deploy-corrupt-input.md
+++ b/.github/issue-evidence/12275-elizaos-deploy-corrupt-input.md
@@ -1,0 +1,95 @@
+# #12275 elizaOS Deploy Corrupt Input
+
+## Scope
+
+This chunk covers the CLI deploy command's corrupt local-input handling:
+
+- `packages/elizaos/src/commands/deploy.ts`
+- `packages/elizaos/src/commands/deploy.test.ts`
+
+`elizaos deploy` no longer treats corrupt `.elizaos/template.json` or corrupt
+`~/.elizaos/credentials.json` as simply missing. It now fails fast with a clear
+invalid JSON message and exits non-zero before app lookup or deploy requests.
+
+## Built CLI Evidence
+
+After rebasing on `origin/develop` and rebuilding `packages/elizaos`, I ran the
+actual built CLI against real temporary files.
+
+Corrupt project metadata:
+
+```bash
+tmp=$(mktemp -d)
+mkdir -p "$tmp/.elizaos"
+printf '{not-json' > "$tmp/.elizaos/template.json"
+(cd "$tmp" && NO_COLOR=1 ELIZAOS_CLOUD_API_KEY=eliza_test_key node /Users/shawwalters/.codex/worktrees/8855/eliza/packages/elizaos/dist/cli.js deploy)
+```
+
+Observed:
+
+```text
+exit=1
+Invalid project metadata JSON at .../.elizaos/template.json: Expected property name or '}' in JSON at position 1 (line 1 column 2)
+```
+
+Corrupt credentials:
+
+```bash
+home=$(mktemp -d)
+mkdir -p "$home/.elizaos"
+printf '{not-json' > "$home/.elizaos/credentials.json"
+NO_COLOR=1 HOME="$home" node /Users/shawwalters/.codex/worktrees/8855/eliza/packages/elizaos/dist/cli.js deploy --app-id app-1
+```
+
+Observed:
+
+```text
+exit=1
+Invalid Eliza Cloud credentials JSON at .../.elizaos/credentials.json: Expected property name or '}' in JSON at position 1 (line 1 column 2)
+```
+
+## Verification Commands
+
+Passed:
+
+```bash
+git fetch origin && git rebase --autostash origin/develop
+bun run --cwd packages/elizaos test -- src/commands/deploy.test.ts
+bun run --cwd packages/elizaos typecheck
+bun run --cwd packages/elizaos lint:check
+bun run --cwd packages/elizaos build
+bun run audit:error-policy-ratchet
+```
+
+The focused deploy test passed:
+
+```text
+Test Files  1 passed (1)
+Tests       9 passed (9)
+```
+
+Root verify was attempted:
+
+```bash
+bun run verify
+```
+
+It passed the AGENTS/CLAUDE check, type-safety ratchet, error-policy ratchet,
+and 79 Turbo tasks before failing in unrelated cloud API typecheck:
+
+```text
+Failed: @elizaos/cloud-api#typecheck
+packages/cloud/api/__tests__/hf-proxy-route.test.ts(259,38): error TS2769
+packages/cloud/shared/src/lib/services/market-preview.ts: missing exports from @elizaos/shared
+```
+
+## Evidence Matrix
+
+- Screenshots: N/A - CLI-only change with no UI surface.
+- Video walkthrough: N/A - CLI transcript above captures the end-to-end command.
+- Frontend console/network logs: N/A - no frontend surface changed.
+- Backend logs: N/A - the command fails before network/backend interaction.
+- Real-LLM trajectories: N/A - no prompt, model, action, provider, or agent
+  behavior changed.
+- Domain artifacts: real temporary `.elizaos/template.json` and
+  `.elizaos/credentials.json` corrupt files were used in the CLI transcript.

--- a/packages/elizaos/src/commands/deploy.test.ts
+++ b/packages/elizaos/src/commands/deploy.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEPLOY_COMMAND_DESCRIPTION,
@@ -7,10 +10,12 @@ import {
 
 const originalFetch = globalThis.fetch;
 const originalEnv = { ...process.env };
+const originalCwd = process.cwd();
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
   process.env = { ...originalEnv };
+  process.chdir(originalCwd);
   vi.restoreAllMocks();
 });
 
@@ -148,6 +153,69 @@ describe("runDeploy", () => {
 
     expect(code).toBe(1);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails corrupt project metadata before app lookup", async () => {
+    process.env.ELIZAOS_CLOUD_API_KEY = "eliza_test_key";
+    const projectDir = mkdtempSync(
+      path.join(os.tmpdir(), "elizaos-deploy-project-"),
+    );
+    mkdirSync(path.join(projectDir, ".elizaos"));
+    writeFileSync(
+      path.join(projectDir, ".elizaos", "template.json"),
+      "{not-json",
+    );
+    process.chdir(projectDir);
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const code = await runDeploy({});
+
+      expect(code).toBe(1);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid project metadata JSON"),
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(".elizaos/template.json"),
+      );
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails corrupt credentials before deploy request", async () => {
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    delete process.env.ELIZA_CLOUD_API_KEY;
+    delete process.env.ELIZACLOUD_API_KEY;
+    const homeDir = mkdtempSync(path.join(os.tmpdir(), "elizaos-deploy-home-"));
+    mkdirSync(path.join(homeDir, ".elizaos"));
+    writeFileSync(
+      path.join(homeDir, ".elizaos", "credentials.json"),
+      "{not-json",
+    );
+    vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const code = await runDeploy({ appId: "app-1" });
+
+      expect(code).toBe(1);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid Eliza Cloud credentials JSON"),
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(".elizaos/credentials.json"),
+      );
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
   });
 
   // `runDeploy` validates `--domain` against DOMAIN_REGEX as its very first step,

--- a/packages/elizaos/src/commands/deploy.ts
+++ b/packages/elizaos/src/commands/deploy.ts
@@ -134,17 +134,25 @@ function normalizeApiBaseUrl(value: string | null): string {
   return `${raw}/api/v1`;
 }
 
+function parseJsonFile(file: string, label: string): unknown {
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid ${label} JSON at ${file}: ${detail}`);
+  }
+}
+
 function readProjectMetadata(cwd: string): ProjectMetadataLike | null {
   const file = path.join(cwd, ".elizaos", "template.json");
   if (!existsSync(file)) return null;
-  try {
-    const parsed = JSON.parse(readFileSync(file, "utf8"));
-    return parsed && typeof parsed === "object"
-      ? (parsed as ProjectMetadataLike)
-      : null;
-  } catch {
-    return null;
+  const parsed = parseJsonFile(file, "project metadata");
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `Invalid project metadata JSON at ${file}: expected an object.`,
+    );
   }
+  return parsed as ProjectMetadataLike;
 }
 
 function credentialCandidates(value: unknown): string[] {
@@ -171,12 +179,8 @@ function credentialCandidates(value: unknown): string[] {
 function readCredentialsApiKey(): string | null {
   const file = path.join(os.homedir(), ".elizaos", "credentials.json");
   if (!existsSync(file)) return null;
-  try {
-    const parsed = JSON.parse(readFileSync(file, "utf8"));
-    return credentialCandidates(parsed).find((candidate) => candidate) ?? null;
-  } catch {
-    return null;
-  }
+  const parsed = parseJsonFile(file, "Eliza Cloud credentials");
+  return credentialCandidates(parsed).find((candidate) => candidate) ?? null;
 }
 
 function resolveApiKey(): string | null {


### PR DESCRIPTION
## Summary

Relates #12275. Small CLI corrupt-input chunk for the long-tail fallback sweep.

- makes `elizaos deploy` fail fast on corrupt `.elizaos/template.json` instead of treating it as missing metadata
- makes corrupt `~/.elizaos/credentials.json` fail fast instead of falling through to a generic missing-key error
- adds real temp-file command tests proving no network request is made after corrupt local input

## Evidence

Evidence file: `.github/issue-evidence/12275-elizaos-deploy-corrupt-input.md`

Passed locally after rebasing on `origin/develop`:

```bash
git fetch origin && git rebase --autostash origin/develop
bun run --cwd packages/elizaos test -- src/commands/deploy.test.ts
bun run --cwd packages/elizaos typecheck
bun run --cwd packages/elizaos lint:check
bun run --cwd packages/elizaos build
bun run audit:error-policy-ratchet
```

Built CLI transcripts were captured for both corrupt metadata and corrupt credentials. Both exited 1 with explicit invalid JSON messages before any network/backend interaction.

`bun run verify` was attempted and failed in unrelated `@elizaos/cloud-api#typecheck` after 79 successful Turbo tasks. The failure was the existing `hf-proxy-route.test.ts` overload plus missing `market-preview.ts` exports from `@elizaos/shared`; details are in the evidence file.

## UI / trajectory evidence

N/A - CLI-only change. No UI, frontend, prompt/model/action/provider, or agent behavior changed.
