### PR TITLE
docs(#12241): add root script headers

### DIFF
--- a/scripts/cloud/verify-8756-launch-hardening.mjs
+++ b/scripts/cloud/verify-8756-launch-hardening.mjs
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
-// Read-only evidence collector for the launch-hardening operator lane
-// (#12081, superseding #8756). It gathers the public GitHub state that proves
-// whether closeout is ready without printing secret values or mutating live
-// infrastructure.
+/**
+ * Read-only evidence collector for the launch-hardening operator lane.
+ *
+ * Gathers the public GitHub state for #12081, superseding #8756, so reviewers
+ * can decide whether closeout is ready without printing secret values or
+ * mutating live infrastructure.
+ */
 import { spawnSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";

--- a/scripts/release-set-public-access.mjs
+++ b/scripts/release-set-public-access.mjs
@@ -1,10 +1,12 @@
-// Stamp publishConfig.access="public" onto every public @elizaos/* package
-// before `lerna publish from-package`. New scoped packages default to
-// "restricted" access, which fails with `E402 You must sign up for private
-// packages` on the free @elizaos org and aborts the whole release mid-stream.
-// lerna publishes via libnpmpublish and honours each package's
-// publishConfig.access (NOT the npmrc `access` key), so it must be set
-// per-package. Private packages are skipped by lerna entirely and left alone.
+/**
+ * Release helper that stamps publishConfig.access="public" onto public @elizaos packages.
+ *
+ * Scoped packages default to restricted access, which fails on the free @elizaos
+ * npm organization during `lerna publish from-package`. Lerna publishes through
+ * libnpmpublish and honors each package's publishConfig.access rather than the
+ * npmrc access key, so this script sets the per-package field and leaves private
+ * packages untouched.
+ */
 
 import { execSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";

--- a/scripts/testing-coverage-matrix.mjs
+++ b/scripts/testing-coverage-matrix.mjs
@@ -1,19 +1,21 @@
 #!/usr/bin/env node
-// Per-package testing coverage matrix generator (issue #9943).
-//
-// Walks every workspace package (tracked files only, via `git ls-files`), counts
-// its test/spec files and skipped tests, and reads whether the package exposes a
-// `test` script — the signal the root workspace test runner (run-all-tests.mjs)
-// uses to decide whether to sweep it. Emits docs/TESTING_COVERAGE_MATRIX.md.
-//
-// "In CI" is a heuristic, not a proof: a package is swept by the root runner iff
-// it is a workspace member with a `test` script AND is not excluded from the root
-// workspace. packages/feed is excluded from the root workspace (`!packages/feed`)
-// and runs via its own path-gated feed-test.yml lane (test:unit) instead.
-//
-// Usage:
-//   node scripts/testing-coverage-matrix.mjs            # write the doc
-//   node scripts/testing-coverage-matrix.mjs --check    # fail if the doc is stale
+/**
+ * Per-package testing coverage matrix generator for issue #9943.
+ *
+ * Walks every workspace package using tracked files from `git ls-files`, counts
+ * test/spec files and skipped tests, and records whether the package exposes the
+ * `test` script used by the root workspace runner. Emits
+ * docs/TESTING_COVERAGE_MATRIX.md.
+ *
+ * "In CI" is a heuristic: a package is swept by the root runner when it is a
+ * workspace member with a `test` script and is not excluded from the root
+ * workspace. packages/feed is excluded from the root workspace and runs through
+ * its own path-gated feed-test.yml lane instead.
+ *
+ * Usage:
+ *   node scripts/testing-coverage-matrix.mjs
+ *   node scripts/testing-coverage-matrix.mjs --check
+ */
 
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";


### PR DESCRIPTION
## Summary
- Converts the remaining root `scripts/` B11 top comments to required prose `/** ... */` file headers.
- Leaves all code tokens unchanged.

## Verification
- PASS: `bun run check:comment-only` ([assert-comment-only-diff] OK — 3 source file(s) changed; every code token identical to origin/develop. Comments only.)
- PASS: `node --check scripts/cloud/verify-8756-launch-hardening.mjs && node --check scripts/release-set-public-access.mjs && node --check scripts/testing-coverage-matrix.mjs`
- PASS: corrected B11 first-line audit for `scripts/` printed nothing.
- FAIL: `bun run verify` failed outside this comment-only slice in `@elizaos/cloud-shared#typecheck`: TypeScript resolved `drizzle-orm` from `dist/node_modules` and reported missing declarations plus implicit-any fallout in `plugins/plugin-sql/src/schema/*`.

## Evidence
- Real-LLM trajectories: N/A — comments-only change, zero functional diff.
- Screenshots/video/audio/domain artifacts: N/A — comments-only change, zero functional diff.