### PR TITLE
fix(elizaos): fail capability router on invalid JSON

### DIFF
--- a/.github/issue-evidence/12275-elizaos-capability-router-invalid-json.md
+++ b/.github/issue-evidence/12275-elizaos-capability-router-invalid-json.md
@@ -1,0 +1,73 @@
+# #12275 capability-router invalid JSON response evidence
+
+## Scope
+
+- Chunk for issue #12275.
+- `elizaos capability-router connect` no longer treats a malformed JSON body from a successful agent API response as an empty success object.
+- Non-2xx responses with malformed JSON bodies still surface the HTTP status fallback instead of hiding the API failure.
+
+## Verification
+
+```bash
+bun run --cwd packages/elizaos test -- src/commands/capability-router.test.ts
+```
+
+Result: passed, 1 file / 21 tests.
+
+```bash
+bun run --cwd packages/elizaos typecheck
+```
+
+Result: passed.
+
+```bash
+bun run --cwd packages/elizaos lint:check
+```
+
+Result: passed.
+
+```bash
+bun run --cwd packages/elizaos build
+```
+
+Result: passed.
+
+```bash
+bun run audit:error-policy-ratchet
+```
+
+Result: passed.
+
+```bash
+bun run verify
+```
+
+Result: failed in unrelated `@elizaos/cloud-shared#lint` formatting check:
+
+```text
+packages/cloud/shared/src/lib/types/cloud-api.ts:451
+Formatter would print:
+return value === "super_admin" || value === "moderator" || value === "viewer";
+```
+
+The root verify run reached 125 successful Turbo tasks before this lint failure.
+
+## Built CLI Transcript
+
+This used the built `packages/elizaos/dist/cli.js` against a local HTTP server
+that returned malformed JSON from the real `/api/capability-router/connect`
+path.
+
+```text
+$ NO_COLOR=1 node /Users/shawwalters/.codex/worktrees/8855/eliza/packages/elizaos/dist/cli.js capability-router connect --api-base http://127.0.0.1:56132 --endpoint-url https://capability.example.test
+server POST /api/capability-router/connect
+Agent API returned invalid JSON: Expected property name or '}' in JSON at position 1 (line 1 column 2)
+exit=1
+```
+
+## Evidence Matrix
+
+- Backend logs: N/A - CLI command boundary only; transcript includes the local agent API request and response path.
+- Frontend screenshots/video: N/A - no UI changes.
+- Real-LLM trajectories: N/A - no model, prompt, provider, action, or evaluator behavior changed.
+- Domain artifacts: N/A - no database, memory, wallet, scheduled task, generated file, or connector artifact changed.

--- a/packages/elizaos/src/commands/capability-router.test.ts
+++ b/packages/elizaos/src/commands/capability-router.test.ts
@@ -20,6 +20,16 @@ function mockFetch(response: unknown, status = 200): ReturnType<typeof vi.fn> {
   return fetchMock;
 }
 
+function mockFetchText(text: string, status = 200): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: vi.fn().mockResolvedValue(text),
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
 describe("runCapabilityRouterConnect", () => {
   it("posts a direct endpoint payload to the local agent API", async () => {
     const fetchMock = mockFetch({
@@ -227,5 +237,33 @@ describe("runCapabilityRouterConnect", () => {
     expect(error.mock.calls[0]?.[0]).toContain("Unauthorized");
     expect(JSON.stringify(error.mock.calls)).not.toContain("api-secret");
     expect(JSON.stringify(error.mock.calls)).not.toContain("endpoint-secret");
+  });
+
+  it("fails successful API calls that return malformed JSON", async () => {
+    mockFetchText("{not-json");
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const code = await runCapabilityRouterConnect({
+      endpointUrl: "https://capability.example.test",
+    });
+
+    expect(code).toBe(1);
+    expect(error.mock.calls[0]?.[0]).toContain(
+      "Agent API returned invalid JSON",
+    );
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("keeps HTTP status fallback when an API error body is malformed JSON", async () => {
+    mockFetchText("{not-json", 502);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const code = await runCapabilityRouterConnect({
+      endpointUrl: "https://capability.example.test",
+    });
+
+    expect(code).toBe(1);
+    expect(error.mock.calls[0]?.[0]).toContain("Agent API returned HTTP 502.");
   });
 });

--- a/packages/elizaos/src/commands/capability-router.ts
+++ b/packages/elizaos/src/commands/capability-router.ts
@@ -88,9 +88,13 @@ export async function runCapabilityRouterConnect(
 
   const text = await response.text();
   const data = parseJson(text);
+  if (data instanceof Error && response.ok) {
+    return fail(options, data.message);
+  }
   if (!response.ok) {
     const message =
-      readErrorMessage(data) || `Agent API returned HTTP ${response.status}.`;
+      (data instanceof Error ? null : readErrorMessage(data)) ||
+      `Agent API returned HTTP ${response.status}.`;
     return fail(options, message);
   }
 
@@ -276,12 +280,13 @@ function nonEmpty(value: string | undefined): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function parseJson(text: string): unknown {
-  if (!text) return null;
+function parseJson(text: string): unknown | Error {
+  if (!text.trim()) return null;
   try {
     return JSON.parse(text);
-  } catch {
-    return null;
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return new Error(`Agent API returned invalid JSON: ${reason}`);
   }
 }
 


### PR DESCRIPTION
Part of #12275.

## Summary

- Treat malformed JSON from a successful `elizaos capability-router connect` agent API response as a command failure instead of an empty success object.
- Preserve the existing non-2xx fallback behavior when the API error body itself is malformed JSON.
- Add focused command tests and issue evidence for the built CLI path.

## Evidence

- `bun run --cwd packages/elizaos test -- src/commands/capability-router.test.ts` passed, 1 file / 21 tests.
- `bun run --cwd packages/elizaos typecheck` passed.
- `bun run --cwd packages/elizaos lint:check` passed.
- `bun run --cwd packages/elizaos build` passed.
- `bun run audit:error-policy-ratchet` passed.
- Built CLI transcript captured in `.github/issue-evidence/12275-elizaos-capability-router-invalid-json.md`: local server returned malformed JSON from `/api/capability-router/connect`; CLI printed `Agent API returned invalid JSON...` and exited `1`.

## Root Verify

`bun run verify` was attempted after `bun install` and failed in an unrelated `@elizaos/cloud-shared#lint` formatting check:

```text
packages/cloud/shared/src/lib/types/cloud-api.ts:451
Formatter would print:
return value === "super_admin" || value === "moderator" || value === "viewer";
```

The root verify run reached 125 successful Turbo tasks before this unrelated lint failure.

## Evidence Matrix

- Backend logs: N/A - CLI command boundary only; transcript shows the local agent API request and response path.
- Frontend screenshots/video: N/A - no UI changes.
- Real-LLM trajectories: N/A - no model, prompt, provider, action, or evaluator behavior changed.
- Domain artifacts: N/A - no database, memory, wallet, scheduled task, generated file, or connector artifact changed.
