### PR TITLE
[codex] Add LifeOps final merged validation evidence

### DIFF
--- a/.github/issue-evidence/12186-final-live-probe/lifeops_gemma-4-31b_20260703_232110.json
+++ b/.github/issue-evidence/12186-final-live-probe/lifeops_gemma-4-31b_20260703_232110.json
@@ -1,0 +1,94 @@
+{
+  "scenarios": [
+    {
+      "scenario_id": "adhd.capture.buried_commitment_in_ramble",
+      "seed": 2026,
+      "turns": [
+        {
+          "turn_number": 1,
+          "agent_message": "",
+          "agent_actions": [
+            {
+              "name": "LIFE_CREATE",
+              "kwargs": {
+                "details": {
+                  "due": "2026-05-14T17:00:00Z",
+                  "listId": "list_personal"
+                },
+                "intent": "Remind user to send the renewal form back to the landlord by Thursday.",
+                "kind": "reminder",
+                "subaction": "create",
+                "title": "Send renewal form to landlord"
+              }
+            }
+          ],
+          "user_response": "",
+          "latency_ms": 2169,
+          "input_tokens": 41319,
+          "output_tokens": 88,
+          "cost_usd": null,
+          "tool_results": [
+            {
+              "name": "LIFE_CREATE",
+              "tool_call_id": "ba0a97455",
+              "content": "{\"id\": \"reminder_auto_ac9ad2bcf8a2\", \"title\": \"Send renewal form to landlord\"}",
+              "payload": {
+                "id": "reminder_auto_ac9ad2bcf8a2",
+                "title": "Send renewal form to landlord"
+              }
+            }
+          ],
+          "cache_read_input_tokens": 0,
+          "cache_creation_input_tokens": null,
+          "cache_hit_pct": null,
+          "cache_supported": true,
+          "model_tier": null,
+          "prompt_cache_key": null,
+          "model_name": null
+        },
+        {
+          "turn_number": 2,
+          "agent_message": "OK. I've set a reminder for you to send that renewal form to your landlord by this Thursday (May 14th).",
+          "agent_actions": [],
+          "user_response": "",
+          "latency_ms": 1897,
+          "input_tokens": 41447,
+          "output_tokens": 29,
+          "cost_usd": null,
+          "tool_results": [],
+          "cache_read_input_tokens": 0,
+          "cache_creation_input_tokens": null,
+          "cache_hit_pct": null,
+          "cache_supported": true,
+          "model_tier": null,
+          "prompt_cache_key": null,
+          "model_name": null
+        }
+      ],
+      "state_hash_match": false,
+      "output_substring_matches": [
+        true,
+        true
+      ],
+      "total_score": 0.0,
+      "max_score": 1.0,
+      "terminated_reason": "respond",
+      "total_cost_usd": 0,
+      "total_latency_ms": 4066,
+      "error": null
+    }
+  ],
+  "pass_at_1": 0.0,
+  "pass_at_k": 0.0,
+  "mean_score_per_domain": {
+    "reminders": 0.0
+  },
+  "total_cost_usd": 0.0,
+  "total_latency_ms": 4066,
+  "model_name": "gemma-4-31b",
+  "judge_model_name": "claude-opus-4-7",
+  "timestamp": "2026-07-04T03:21:10.500599+00:00",
+  "seeds": 1,
+  "agent_cost_usd": 0.0,
+  "eval_cost_usd": 0.0
+}

--- a/.github/issue-evidence/12186-final-merged-validation.md
+++ b/.github/issue-evidence/12186-final-merged-validation.md
@@ -1,0 +1,84 @@
+# Issue #12186 Final Merged Validation
+
+Date: 2026-07-04
+
+Merged PRs:
+
+- #12531: traveler timezone pack plus collapsed lower-stack changes into `develop`
+- #12534: neurotypical control pack, merged into the traveler stack branch
+- #12568: comms flood pack plus collapsed upper-stack changes, merged into the traveler stack branch
+- #12584: night-owl + shift-rotation packs, merged into the comms stack branch
+- #12595: ADHD + low-activation packs, merged into the sleep/shift stack branch
+
+## Merged Corpus Validation
+
+Ran on `origin/develop` after #12531 merged:
+
+```bash
+PYTHONPATH=packages/benchmarks/lifeops-bench python3 -m pytest \
+  packages/benchmarks/lifeops-bench/tests/test_scenarios_corpus.py::test_corpus_expands_current_core_by_exactly_10x -q
+```
+
+Observed:
+
+```text
+.                                                                        [100%]
+```
+
+Ran:
+
+```bash
+PYTHONPATH=packages/benchmarks/lifeops-bench python3 - <<'PY'
+from eliza_lifeops_bench.scenarios import count_lifeops_scenarios, validate_lifeops_scenarios
+print(count_lifeops_scenarios())
+print(validate_lifeops_scenarios())
+PY
+```
+
+Observed:
+
+```text
+{'suite': 'lifeops-bench', 'existing': 1400, 'added': 14000, 'total': 15400, 'multiplierAdded': 10.0, 'base': 1400, 'variantsPerBase': 10, 'totalRuns': 15400, 'summary': '1400 base scenarios; 10x prompt-prefix robustness variants = 15400 runs'}
+{'valid': True, 'total': 15400, 'uniqueIds': 15400, 'duplicateIds': [], 'emptyInstructions': [], 'expansionMatches': True}
+```
+
+## Live Model Probe
+
+Ran a bounded Cerebras static probe on the merged corpus:
+
+```bash
+PYTHONPATH=packages/benchmarks/lifeops-bench python3 -m eliza_lifeops_bench \
+  --agent cerebras-direct \
+  --scenario adhd.capture.buried_commitment_in_ramble \
+  --mode static \
+  --limit 1 \
+  --max-cost-usd 0.50 \
+  --concurrency 1 \
+  --output-dir .github/issue-evidence/12186-final-live-probe
+```
+
+Observed:
+
+```text
+Starting LifeOpsBench with 1 scenarios x 1 seeds...
+Agent:           cerebras-direct
+Model tier:      large (cerebras -> gemma-4-31b)
+Scenarios run:      1
+pass@1:             0.000
+Total latency:      4.07s
+Full results saved to: .github/issue-evidence/12186-final-live-probe/lifeops_gemma-4-31b_20260703_232110.json
+```
+
+Manual artifact review: the live model executed the real Cerebras path and
+created a `LIFE_CREATE` reminder for the ADHD buried-commitment scenario. The
+required output substrings matched, but the benchmark scored 0 because the model
+used a different reminder shape from the exact ground truth, so this is a valid
+pre-optimization baseline failure rather than a harness failure.
+
+## Known Limits
+
+- The full `tests/test_scenarios_corpus.py` suite still cannot run in this
+  worktree because `packages/benchmarks/lifeops-bench/data/snapshots/` is absent.
+- LIVE-mode judged runs require both `CEREBRAS_API_KEY` and `ANTHROPIC_API_KEY`;
+  this environment only exposed Cerebras credentials, so the durable real-model
+  proof is a static Cerebras probe.


### PR DESCRIPTION
## Summary

Adds final durable evidence after the LifeOps persona-pack stack merged into `develop`.

Includes:
- merged PR list for #12186 / #12278 / #12279 / #12280 / #12281 / #12282
- final merged corpus validation: `1400` base scenarios and `15400` total runs
- a bounded real Cerebras static probe artifact for `adhd.capture.buried_commitment_in_ramble`

## Validation

- `python3 -m json.tool .github/issue-evidence/12186-final-live-probe/lifeops_gemma-4-31b_20260703_232110.json`
- `git diff --check`

The merged corpus validation and live probe command/output are recorded in `.github/issue-evidence/12186-final-merged-validation.md`.
