### PR TITLE
docs(#12241): add homepage test headers

### DIFF
--- a/packages/homepage/tests/contact.test.ts
+++ b/packages/homepage/tests/contact.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests homepage SMS contact link constants and href generation for the shared Eliza gateway.
+ */
+
 import { describe, expect, test } from "bun:test";
 import {
   buildElizaSmsHref,

--- a/packages/homepage/tests/e2e/app-routes-flow.spec.ts
+++ b/packages/homepage/tests/e2e/app-routes-flow.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright route-flow coverage for mocked homepage auth, linking, and provisioning paths.
+ */
+
 import { expect, type Page, test } from "playwright/test";
 
 const TEST_TOKEN = "homepage-e2e-token";

--- a/packages/homepage/tests/e2e/live-onboarding-controls.spec.ts
+++ b/packages/homepage/tests/e2e/live-onboarding-controls.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Live Playwright coverage for public onboarding controls that do not require API mocks.
+ */
+
 import { expect, test } from "playwright/test";
 
 test.setTimeout(180_000);

--- a/packages/homepage/tests/e2e/live-routes.spec.ts
+++ b/packages/homepage/tests/e2e/live-routes.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Live route smoke coverage for homepage pages, console errors, network failures, and screenshots.
+ */
+
 import { expect, type Page, test } from "playwright/test";
 import { captureScreenshotWithQualityRetry } from "./screenshot-quality";
 

--- a/packages/homepage/tests/e2e/marketing-cloud-download.spec.ts
+++ b/packages/homepage/tests/e2e/marketing-cloud-download.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright coverage for marketing download CTAs and cloud/app link targets.
+ */
+
 import { EXTERNAL_URLS } from "@elizaos/shared/brand";
 import {
   type APIRequestContext,

--- a/packages/homepage/tests/e2e/route-coverage.spec.ts
+++ b/packages/homepage/tests/e2e/route-coverage.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Static route-matrix coverage guard for homepage live and visual Playwright specs.
+ */
+
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/homepage/tests/e2e/routing-hardening.spec.ts
+++ b/packages/homepage/tests/e2e/routing-hardening.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright hardening tests for hostile route inputs and browser history restoration.
+ */
+
 import { expect, type Page, test } from "playwright/test";
 
 function collectPageErrors(page: Page): string[] {

--- a/packages/homepage/tests/e2e/screenshot-quality.ts
+++ b/packages/homepage/tests/e2e/screenshot-quality.ts
@@ -1,3 +1,7 @@
+/**
+ * Screenshot quality helpers for rejecting blank or effectively single-color homepage captures.
+ */
+
 import { expect, type Page } from "playwright/test";
 import sharp from "sharp";
 

--- a/packages/homepage/tests/e2e/visual.spec.ts
+++ b/packages/homepage/tests/e2e/visual.spec.ts
@@ -1,13 +1,11 @@
-// Visual regression for the marketing homepage (#9310 §3.16).
-//
-// Every route × viewport is compared against a committed baseline in
-// visual.spec.ts-snapshots/ via toHaveScreenshot (threshold in
-// playwright.config.ts), mirroring packages/os/homepage/tests/visual.spec.ts.
-// The quality-retry capture stays as a pre-check so a blank/half-painted page
-// fails with a clear "screenshot is one color" message instead of a noisy
-// pixel diff. Regenerate baselines per platform with
-// scripts/regenerate-baselines.sh; quality.yml / deploy-homepage.yml
-// auto-regenerate + commit the 10 linux baselines when missing.
+/**
+ * Visual regression coverage for the marketing homepage routes.
+ *
+ * Every route and viewport is compared against committed baselines via
+ * toHaveScreenshot, while the quality-retry pre-check rejects blank or
+ * half-painted captures with a clear diagnostic before pixel diffing.
+ * Baselines regenerate per platform through scripts/regenerate-baselines.sh.
+ */
 
 import { expect, type Page, test } from "playwright/test";
 import { captureScreenshotWithQualityRetry } from "./screenshot-quality";

--- a/packages/homepage/tests/smoke.node.test.mjs
+++ b/packages/homepage/tests/smoke.node.test.mjs
@@ -1,7 +1,9 @@
-// Source-level smoke: don't import the React tree (pulls three.js, etc.); just
-// assert the entry module exports a default function via static inspection.
-// Runs under `node --test` so the homepage `test` script exits clean without
-// adding vitest as a dep.
+/**
+ * Source-level smoke test for the marketing page export without importing the React tree.
+ *
+ * The package test script runs under node:test, so this avoids pulling three.js
+ * or adding Vitest just to confirm the entry component remains exportable.
+ */
 
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";


### PR DESCRIPTION
## Summary
- Adds B11 prose file headers to homepage test and Playwright helper files.
- Converts existing top comments in visual/smoke tests to the required `/** ... */` form.
- Leaves all code tokens unchanged.

## Verification
- PASS: `bun run check:comment-only` ([assert-comment-only-diff] OK — 10 source file(s) changed; every code token identical to origin/develop. Comments only.)
- PASS: `bun run --cwd packages/homepage test` (2 tests)
- PASS: `bunx @biomejs/biome check packages/homepage/tests/contact.test.ts packages/homepage/tests/e2e/app-routes-flow.spec.ts packages/homepage/tests/e2e/live-onboarding-controls.spec.ts packages/homepage/tests/e2e/live-routes.spec.ts packages/homepage/tests/e2e/marketing-cloud-download.spec.ts packages/homepage/tests/e2e/route-coverage.spec.ts packages/homepage/tests/e2e/routing-hardening.spec.ts packages/homepage/tests/e2e/screenshot-quality.ts packages/homepage/tests/e2e/visual.spec.ts packages/homepage/tests/smoke.node.test.mjs`
- FAIL: `bun run --cwd packages/homepage typecheck` failed outside this comment-only test-header slice: `packages/ui/src/i18n/*` imports `normalizeLanguage`, `DEFAULT_UI_LANGUAGE`, `UI_LANGUAGES`, and `UiLanguage` from `@elizaos/shared`, but those exports are not present in the current local resolution.

## Evidence
- Real-LLM trajectories: N/A — comments-only change, zero functional diff.
- Screenshots/video/audio/domain artifacts: N/A — comments-only change, zero functional diff.