### PR TITLE
fix(#12228): restrict public:true routes to reads; opt-in publicWrite for authenticated webhooks (L11)

### DIFF
--- a/packages/agent/src/api/runtime-plugin-routes.test.ts
+++ b/packages/agent/src/api/runtime-plugin-routes.test.ts
@@ -41,6 +41,8 @@ describe("isPublicRuntimePluginRoute", () => {
         public: true,
         name: "whatsapp-webhook",
         publicReason: "WhatsApp webhook callback is externally delivered.",
+        publicWrite:
+          "Inbound Meta webhook POST authenticated by the WhatsApp payload signature, not the local gate.",
       },
       {
         type: "POST",
@@ -48,6 +50,8 @@ describe("isPublicRuntimePluginRoute", () => {
         public: true,
         name: "bluebubbles-webhook",
         publicReason: "BlueBubbles webhook callback is externally delivered.",
+        publicWrite:
+          "Inbound BlueBubbles webhook POST authenticated by payload validation, not the local gate.",
       },
     ] as Route[]);
 

--- a/packages/agent/src/api/server-helpers-auth.ts
+++ b/packages/agent/src/api/server-helpers-auth.ts
@@ -517,6 +517,13 @@ export function isTrustedLocalRequest(req: http.IncomingMessage): boolean {
  *
  * Returns an empty string when unconfigured, in which case the X-Server-Token
  * path is disabled and existing Bearer / loopback auth is unaffected.
+ *
+ * Security: a matching `X-Server-Token` grants full authority (`isAuthorized`),
+ * so this secret is a bearer credential — it MUST be a high-entropy random
+ * value of at least 32 bytes (≥256 bits; e.g. `openssl rand -hex 32`). Never a
+ * human-chosen or dictionary string. The comparison is timing-safe
+ * (`tokenMatches`), but that does not protect a low-entropy secret from being
+ * guessed offline; entropy is the only defense here. (#12228 L11)
  */
 function getServerSharedSecret(): string {
   const raw = process.env.AGENT_SERVER_SHARED_SECRET;

--- a/packages/agent/src/services/remote-plugin-adapter.test.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.test.ts
@@ -3617,6 +3617,8 @@ describe("remote plugin adapter", () => {
                   name: "localhost-route",
                   publicReason:
                     "Remote adapter localhost fixture public route.",
+                  publicWrite:
+                    "Remote capability POST authenticated by the endpoint's own bearer token, not the local gate.",
                 },
               ],
               views: [

--- a/packages/agent/src/services/remote-plugin-adapter.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.ts
@@ -255,6 +255,9 @@ export function createRemoteCapabilityPlugin(
         public: true,
         name: route.name ?? `${module.name}:${route.path}`,
         publicReason: route.publicReason,
+        ...(route.publicWrite === undefined
+          ? {}
+          : { publicWrite: route.publicWrite }),
       };
     }
     return {

--- a/packages/agent/src/services/remote-plugin-bridge.ts
+++ b/packages/agent/src/services/remote-plugin-bridge.ts
@@ -251,6 +251,7 @@ const RouteDescriptorSchema = z
     name: z.string().optional(),
     public: z.boolean().optional(),
     publicReason: z.string().optional(),
+    publicWrite: z.string().optional(),
     isMultipart: z.boolean().optional(),
   })
   .passthrough();
@@ -872,6 +873,9 @@ export class RemotePluginBridge {
         public: true,
         name: descriptor.name,
         publicReason: descriptor.publicReason,
+        ...(descriptor.publicWrite
+          ? { publicWrite: descriptor.publicWrite }
+          : {}),
       };
     }
     return {

--- a/packages/cloud/shared/.env.example
+++ b/packages/cloud/shared/.env.example
@@ -869,6 +869,9 @@ ELIZA_APP_WHATSAPP_PHONE_NUMBER=
 
 # Shared secret required by the internal agent-server control API.
 # Add this to the Kubernetes secret referenced by Server.spec.secretRef.
+# A matching X-Server-Token grants full agent-server authority, so this is a
+# bearer credential: use a high-entropy random value of at least 32 bytes
+# (>=256 bits), e.g. `openssl rand -hex 32`. Never a human-chosen string.
 # AGENT_SERVER_SHARED_SECRET=replace_with_long_random_shared_secret
 
 # ============================================================================

--- a/packages/core/src/capabilities/index.ts
+++ b/packages/core/src/capabilities/index.ts
@@ -217,6 +217,7 @@ export type RemotePluginRouteManifest = {
 	name?: string;
 	public?: boolean;
 	publicReason?: string;
+	publicWrite?: string;
 	description?: string;
 };
 
@@ -3312,6 +3313,7 @@ function requireRemotePluginRoute(
 	const name = optionalString(object, "name", method);
 	const isPublic = optionalBoolean(object, "public", method);
 	const publicReason = optionalString(object, "publicReason", method);
+	const publicWrite = optionalString(object, "publicWrite", method);
 	const description = optionalString(object, "description", method);
 	const path = requireNonEmptyString(object, "path", method);
 	validateRemotePluginPath(path, "path", method);
@@ -3327,6 +3329,7 @@ function requireRemotePluginRoute(
 		...(name === undefined ? {} : { name }),
 		...(isPublic === undefined ? {} : { public: isPublic }),
 		...(publicReason === undefined ? {} : { publicReason }),
+		...(publicWrite === undefined ? {} : { publicWrite }),
 		...(description === undefined ? {} : { description }),
 	};
 }

--- a/packages/core/src/features/oauth/plugin.ts
+++ b/packages/core/src/features/oauth/plugin.ts
@@ -65,6 +65,8 @@ export const oauthLocalCallbackRoute: Route = {
 	public: true,
 	publicReason:
 		"OAuth provider callback uses the unguessable intent id as capability.",
+	publicWrite:
+		"Provider redirect POSTs the bind result; the unguessable oauthIntentId is the capability token.",
 	rawPath: true,
 	handler: async (req, res, runtime) => {
 		const body = (req.body ?? {}) as Record<string, unknown>;

--- a/packages/core/src/types/plugin.test.ts
+++ b/packages/core/src/types/plugin.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Registration guard for `public: true` routes (#12228 L11). A public route
+ * bypasses the central auth gate, so `assertPublicRouteIntent` rejects one that
+ * omits `publicReason` and — defense-in-depth — one that uses a write method
+ * (POST/PUT/PATCH/DELETE) without declaring `publicWrite` (the out-of-band auth
+ * that stands in for the gate). GET/STATIC public reads need no opt-in.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { Route } from "./plugin";
+import { assertPublicRouteIntent } from "./plugin";
+
+const READ_REASON = "Read-only public surface for unauthenticated clients.";
+const WRITE_REASON =
+	"Inbound webhook POST authenticated by payload signature, not the local gate.";
+
+describe("assertPublicRouteIntent — public read routes", () => {
+	it("accepts a public GET route with a publicReason", () => {
+		const route: Route = {
+			type: "GET",
+			path: "/api/plugin/status",
+			public: true,
+			name: "plugin-status",
+			publicReason: READ_REASON,
+		};
+		expect(() => assertPublicRouteIntent(route)).not.toThrow();
+	});
+
+	it("accepts a public STATIC route with a publicReason", () => {
+		const route: Route = {
+			type: "STATIC",
+			path: "/assets/app.js",
+			public: true,
+			name: "plugin-asset",
+			publicReason: READ_REASON,
+		};
+		expect(() => assertPublicRouteIntent(route)).not.toThrow();
+	});
+
+	it("rejects a public route missing publicReason", () => {
+		const route = {
+			type: "GET",
+			path: "/api/plugin/status",
+			public: true,
+			name: "plugin-status",
+		} as unknown as Route;
+		expect(() => assertPublicRouteIntent(route)).toThrow(
+			/must declare publicReason/,
+		);
+	});
+});
+
+describe("assertPublicRouteIntent — public write routes need publicWrite", () => {
+	const writeMethods = ["POST", "PUT", "PATCH", "DELETE"] as const;
+
+	for (const type of writeMethods) {
+		it(`rejects a public ${type} route without publicWrite`, () => {
+			const route = {
+				type,
+				path: "/api/plugin/webhook",
+				public: true,
+				name: "plugin-webhook",
+				publicReason: WRITE_REASON,
+			} as unknown as Route;
+			expect(() => assertPublicRouteIntent(route)).toThrow(
+				/must declare publicWrite/,
+			);
+		});
+
+		it(`accepts a public ${type} route that declares publicWrite`, () => {
+			const route: Route = {
+				type,
+				path: "/api/plugin/webhook",
+				public: true,
+				name: "plugin-webhook",
+				publicReason: WRITE_REASON,
+				publicWrite: WRITE_REASON,
+			};
+			expect(() => assertPublicRouteIntent(route)).not.toThrow();
+		});
+	}
+
+	it("rejects a public write route whose publicWrite is blank", () => {
+		const route = {
+			type: "POST",
+			path: "/api/plugin/webhook",
+			public: true,
+			name: "plugin-webhook",
+			publicReason: WRITE_REASON,
+			publicWrite: "   ",
+		} as unknown as Route;
+		expect(() => assertPublicRouteIntent(route)).toThrow(
+			/must declare publicWrite/,
+		);
+	});
+});
+
+describe("assertPublicRouteIntent — private routes are unaffected", () => {
+	it("accepts a private POST route without any public fields", () => {
+		const route: Route = {
+			type: "POST",
+			path: "/api/plugin/mutate",
+		};
+		expect(() => assertPublicRouteIntent(route)).not.toThrow();
+	});
+
+	it("accepts a private GET route", () => {
+		const route: Route = { type: "GET", path: "/api/plugin/read" };
+		expect(() => assertPublicRouteIntent(route)).not.toThrow();
+	});
+});

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -195,6 +195,17 @@ interface PublicRoute extends BaseRoute {
 	 * dispatchers.
 	 */
 	publicReason: string;
+	/**
+	 * A public route is unauthenticated by the central gate, so it defaults to
+	 * read-only (`GET`/`STATIC`): defense-in-depth against a mutating endpoint
+	 * being shipped world-reachable. A non-GET public route (an inbound webhook,
+	 * an OAuth redirect exchange, a companion-bridge callback) is authenticated
+	 * out-of-band instead of by the gate, so it must opt in here by naming that
+	 * mechanism (signature check, unguessable capability token, …). Without this,
+	 * a `public: true` route with a write method is rejected at registration and
+	 * dispatch. GET/STATIC public routes never need it.
+	 */
+	publicWrite?: string;
 }
 
 interface PrivateRoute extends BaseRoute {
@@ -204,13 +215,25 @@ interface PrivateRoute extends BaseRoute {
 
 export type Route = PublicRoute | PrivateRoute;
 
+/** Write methods a public route may only use when it self-authenticates. */
+const PUBLIC_WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
 export function assertPublicRouteIntent(route: Route, source = "plugin"): void {
 	if (route.public !== true) return;
 	const reason = (route as { publicReason?: unknown }).publicReason;
-	if (typeof reason === "string" && reason.trim().length > 0) return;
-	throw new Error(
-		`[RouteAuth] Public route ${source}:${route.type} ${route.path} must declare publicReason`,
-	);
+	if (typeof reason !== "string" || reason.trim().length === 0) {
+		throw new Error(
+			`[RouteAuth] Public route ${source}:${route.type} ${route.path} must declare publicReason`,
+		);
+	}
+	if (PUBLIC_WRITE_METHODS.has(route.type)) {
+		const publicWrite = (route as { publicWrite?: unknown }).publicWrite;
+		if (typeof publicWrite !== "string" || publicWrite.trim().length === 0) {
+			throw new Error(
+				`[RouteAuth] Public ${route.type} route ${source}:${route.path} is unauthenticated by the central gate; a write-method public route must declare publicWrite naming its out-of-band auth (signature, capability token, …). Make it GET, gate it, or declare publicWrite.`,
+			);
+		}
+	}
 }
 
 /** Route that may include x402 payment fields (alias for authoring clarity) */

--- a/packages/plugin-remote-manifest/src/worker-runtime/descriptor.ts
+++ b/packages/plugin-remote-manifest/src/worker-runtime/descriptor.ts
@@ -110,6 +110,7 @@ export type WorkerPluginShape = {
     path: string;
     public?: boolean;
     publicReason?: string;
+    publicWrite?: string;
     isMultipart?: boolean;
     routeHandler?: AnyHandler;
   }>;
@@ -307,6 +308,7 @@ export function buildAnnounceDescriptor(
       if (route.name) entry.name = route.name;
       if (route.public !== undefined) entry.public = route.public;
       if (route.publicReason) entry.publicReason = route.publicReason;
+      if (route.publicWrite) entry.publicWrite = route.publicWrite;
       if (route.isMultipart !== undefined)
         entry.isMultipart = route.isMultipart;
       if (route.routeHandler) {

--- a/plugins/plugin-bluebubbles/src/data-routes.ts
+++ b/plugins/plugin-bluebubbles/src/data-routes.ts
@@ -264,5 +264,7 @@ export const blueBubblesDataRoutes: Route[] = [
 		name: "bluebubbles-webhook",
 		publicReason:
 			"BlueBubbles webhook delivery is authenticated by webhook payload validation.",
+		publicWrite:
+			"Inbound BlueBubbles webhook POST authenticated by payload validation, not the local gate.",
 	},
 ];

--- a/plugins/plugin-browser/src/plugin.ts
+++ b/plugins/plugin-browser/src/plugin.ts
@@ -111,12 +111,15 @@ function buildRouteContext(
 
 const COMPANION_ROUTE_REASON =
   "Browser companion callbacks use companion session identifiers as capability tokens.";
+const COMPANION_WRITE_REASON =
+  "Companion callback POST authenticated by the unguessable companion session id, not the local gate.";
 
 const STATIC_ROUTES: Array<{
   type: string;
   path: string;
   public?: boolean;
   publicReason?: string;
+  publicWrite?: string;
 }> = [
   { type: "GET", path: "/api/browser-bridge/sessions" },
   { type: "GET", path: "/api/browser-bridge/settings" },
@@ -129,6 +132,7 @@ const STATIC_ROUTES: Array<{
     path: "/api/browser-bridge/companions/revoke",
     public: true,
     publicReason: COMPANION_ROUTE_REASON,
+    publicWrite: COMPANION_WRITE_REASON,
   },
   { type: "GET", path: "/api/browser-bridge/packages" },
   { type: "POST", path: "/api/browser-bridge/packages/open-path" },
@@ -137,6 +141,7 @@ const STATIC_ROUTES: Array<{
     path: "/api/browser-bridge/companions/sync",
     public: true,
     publicReason: COMPANION_ROUTE_REASON,
+    publicWrite: COMPANION_WRITE_REASON,
   },
   { type: "GET", path: "/api/browser-bridge/tabs" },
   { type: "GET", path: "/api/browser-bridge/current-page" },
@@ -149,6 +154,7 @@ const DYNAMIC_ROUTES: Array<{
   path: string;
   public?: boolean;
   publicReason?: string;
+  publicWrite?: string;
 }> = [
   { type: "GET", path: "/api/browser-bridge/sessions/:id" },
   { type: "POST", path: "/api/browser-bridge/sessions/:id/confirm" },
@@ -160,12 +166,14 @@ const DYNAMIC_ROUTES: Array<{
     path: "/api/browser-bridge/companions/sessions/:id/progress",
     public: true,
     publicReason: COMPANION_ROUTE_REASON,
+    publicWrite: COMPANION_WRITE_REASON,
   },
   {
     type: "POST",
     path: "/api/browser-bridge/companions/sessions/:id/complete",
     public: true,
     publicReason: COMPANION_ROUTE_REASON,
+    publicWrite: COMPANION_WRITE_REASON,
   },
   { type: "POST", path: "/api/browser-bridge/packages/:browser/build" },
   {
@@ -200,7 +208,11 @@ const browserBridgePluginRoutes: Route[] = [
         path: r.path,
         rawPath: true as const,
         ...(r.public
-          ? ({ public: true, publicReason: r.publicReason ?? "" } as const)
+          ? ({
+              public: true,
+              publicReason: r.publicReason ?? "",
+              ...(r.publicWrite ? { publicWrite: r.publicWrite } : {}),
+            } as const)
           : {}),
         handler: routeHandler(),
       }) as Route,
@@ -212,7 +224,11 @@ const browserBridgePluginRoutes: Route[] = [
         path: r.path,
         rawPath: true as const,
         ...(r.public
-          ? ({ public: true, publicReason: r.publicReason ?? "" } as const)
+          ? ({
+              public: true,
+              publicReason: r.publicReason ?? "",
+              ...(r.publicWrite ? { publicWrite: r.publicWrite } : {}),
+            } as const)
           : {}),
         handler: routeHandler(),
       }) as Route,

--- a/plugins/plugin-personal-assistant/src/routes/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/routes/plugin.ts
@@ -255,6 +255,8 @@ interface PublicRouteSpec {
   public: true;
   name: string;
   publicReason: string;
+  /** Required for non-GET public routes: names the out-of-band auth. */
+  publicWrite?: string;
 }
 
 type RouteSpec = PrivateRouteSpec | PublicRouteSpec;
@@ -499,6 +501,8 @@ const GOOGLE_CONNECTOR_ACCOUNT_ROUTES: RouteSpec[] = [
     name: "connectors.google.oauth.callback.post",
     publicReason:
       "Google OAuth callback POST must accept provider redirect exchanges.",
+    publicWrite:
+      "Provider redirect exchange POST authenticated by the OAuth state/code, not the local gate.",
   },
   { type: "GET", path: "/api/connectors/google/audit/events" },
 ];
@@ -549,6 +553,7 @@ function buildRawRoutes(
         public: true,
         name: spec.name,
         publicReason: spec.publicReason,
+        ...(spec.publicWrite ? { publicWrite: spec.publicWrite } : {}),
         handler,
       };
     }

--- a/plugins/plugin-whatsapp/src/setup-routes.ts
+++ b/plugins/plugin-whatsapp/src/setup-routes.ts
@@ -439,6 +439,8 @@ export const whatsappSetupRoutes: Route[] = [
     rawPath: true,
     public: true, // Meta webhook delivery must bypass auth
     publicReason: "Meta webhook delivery is authenticated by WhatsApp signature checks.",
+    publicWrite:
+      "Inbound Meta webhook POST authenticated by the WhatsApp payload signature, not the local gate.",
   },
   {
     type: "POST",


### PR DESCRIPTION
Closes #12228

## L11 hardening — restrict `public:true` routes to reads; opt-in `publicWrite` for authenticated writes

A `public:true` plugin route bypasses the central `isAuthorized()` gate, so shipping one with a write method (POST/PUT/PATCH/DELETE) exposes an unauthenticated mutation to the world. This change makes that impossible by construction: `assertPublicRouteIntent` (called at **both registration and dispatch** — `runtime.ts`, `app-route-plugin-registry.ts`, `runtime-plugin-routes.ts`, `dispatch-route.ts`) now **throws at registration/dispatch** for a write-method public route unless it declares the new `publicWrite` field naming its out-of-band auth. GET/STATIC public reads are unchanged.

Legitimate unauthenticated write surfaces (webhooks, OAuth redirect exchanges, companion-bridge callbacks) are **not converted or broken** — they opt in via `publicWrite`, which is threaded through the remote-plugin manifest → bridge → worker-runtime pipeline so remote plugins can declare it too.

The issue's L11 also asked to document a minimum entropy for `AGENT_SERVER_SHARED_SECRET` (a matching `X-Server-Token` grants full authority). Added: `>=32 bytes (>=256 bits)`, JSDoc on the resolver + `.env.example`.

## Public-route audit — every `public:true` route + method (whole repo)

Enumerated with `git grep -nE 'public:\s*true' -- packages plugins`, each declaration inspected. **No read route needs `publicWrite`; every write route now declares it.**

| Route | Method | `publicWrite`? | Notes |
|---|---|---|---|
| `packages/agent/src/api/media-runtime.ts` `/api/media/:filename` | GET | n/a | content-addressed capability read |
| `packages/core/src/features/oauth/plugin.ts` OAuth local callback | **POST** | **added** | provider redirect; unguessable `oauthIntentId` is the capability |
| `plugins/plugin-wallet` `/api/wallet/market-overview` | GET | n/a | cached public market data |
| `plugins/plugin-computeruse` `/api/computer-use/approvals/stream` | GET | n/a | local approval UI stream |
| `plugins/plugin-music` `/stream`, `/stream/:g`, `/now-playing`, `/now-playing/:g`, `/queue`, `/queue/:g`, `/status` | GET (×7) | n/a | public radio reads (control routes are `public:false`) |
| `plugins/plugin-personal-assistant` health `…/:provider/callback`, `…/:provider/success` | GET | n/a | OAuth landing reads |
| `plugins/plugin-personal-assistant` google `…/oauth/callback` | GET | n/a | OAuth landing read |
| `plugins/plugin-personal-assistant` google `…/oauth/callback` | **POST** | **added** | provider redirect exchange (OAuth state/code) |
| `plugins/plugin-bluebubbles` webhook | **POST** | **added** | payload-validation authenticated |
| `plugins/plugin-whatsapp` `/api/whatsapp/webhook` verify | GET | n/a | Meta verification read |
| `plugins/plugin-whatsapp` `/api/whatsapp/webhook` event | **POST** | **added** | Meta payload-signature authenticated |
| `plugins/plugin-browser` companions `revoke`, `sync`, `sessions/:id/progress`, `sessions/:id/complete` | **POST (×4)** | **added** | companion session id is the capability token |
| `packages/core/src/capabilities/index.ts:844` (`CAPABILITY_ROUTER_PROTOCOL_FIXTURE`) | `method:POST` | n/a | **test fixture**, remote-manifest wire shape (`method:`), never a runtime `Route` → not gated by `assertPublicRouteIntent` |

Non-route `public:true` occurrences (secret-config `public:true` flags, cloud `is_public:true` DB fields, `ui/` cloud public-pages, docs) were reviewed and are unrelated to route auth.

## What changed

- **`packages/core/src/types/plugin.ts`** — `PublicRoute.publicWrite?: string`; `assertPublicRouteIntent` rejects write-method public routes without it. Message tells the author to make it GET, gate it, or declare `publicWrite`.
- **Manifest pipeline** — `publicWrite` threaded through `capabilities/index.ts` (`RemotePluginRouteManifest` + `requireRemotePluginRoute`), `remote-plugin-adapter.ts`, `remote-plugin-bridge.ts` (+ zod schema), `plugin-remote-manifest/worker-runtime/descriptor.ts`.
- **Opt-ins** — OAuth callback, bluebubbles, whatsapp, browser companions, personal-assistant google-OAuth POST.
- **Doc** — `AGENT_SERVER_SHARED_SECRET` min-entropy note (`server-helpers-auth.ts` JSDoc + `cloud/shared/.env.example`).
- **Tests** — new `packages/core/src/types/plugin.test.ts` (14 cases: read ok, write throws w/o `publicWrite`, write ok with it, blank rejected, private unaffected). Updated two existing fixtures (`runtime-plugin-routes.test.ts`, `remote-plugin-adapter.test.ts`) whose public POST webhook fixtures now correctly carry `publicWrite`.

## Verification

Source-based (full monorepo build fails on `develop` for unrelated cloud-routing/ui unbuilt-dist reasons; not chased per issue scope).

```
$ bunx vitest run packages/core/src/types/plugin.test.ts
 Test Files  1 passed (1)   Tests  14 passed (14)

$ bunx vitest run plugin.test.ts runtime-plugin-routes.test.ts public-route-audit.test.ts \
    remote-plugin-adapter.test.ts app-route-plugin-registry.test.ts
 Test Files  5 passed (5)   Tests  78 passed | 3 skipped (81)

$ bun test packages/plugin-remote-manifest/src/worker-runtime/descriptor.test.ts   # native bun runner
 3 pass  0 fail  45 expect() calls

$ bunx vitest run packages/agent/test/api/server-helpers-auth.test.ts
 Test Files  1 passed (1)   Tests  21 passed (21)
```

- `bunx biome check` on all 15 touched files → clean.
- `@elizaos/core` typecheck → clean. `@elizaos/agent` typecheck: only pre-existing `@elizaos/ui`/`contracts`/`plugin-meetings` errors (this branch touches none of those; `packages/ui` has 64 identical errors on `develop`).
- `bun run audit:error-policy-ratchet` → "no new fallback-slop in touched files".
- `public-route-audit.test.ts` passes → no new unauthenticated route surface added (baseline unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
