### PR TITLE
fix(training): require passed privacy attestations

### DIFF
--- a/packages/training/scripts/format_for_training.py
+++ b/packages/training/scripts/format_for_training.py
@@ -180,9 +180,9 @@ def _is_privacy_attested(record: dict[str, Any]) -> bool:
         if (
             schema == PRIVACY_ATTESTATION_SCHEMA
             and version == PRIVACY_ATTESTATION_VERSION
+            and passed is True
             and (
-                passed is True
-                or reviewed is True
+                reviewed is True
                 or redacted is True
                 or privacy.get("reviewed") is True
             )

--- a/packages/training/scripts/test_format_for_training.py
+++ b/packages/training/scripts/test_format_for_training.py
@@ -4,7 +4,7 @@ from format_for_training import format_record
 from privacy_filter_trajectories import PrivacyFilterError
 
 
-def _attested(row):
+def _attested(row, *, passed: bool = True):
     metadata = row.setdefault("metadata", {})
     metadata["privacy_attestation"] = {
         "schema": "eliza.privacy_filter_attestation.v1",
@@ -12,7 +12,7 @@ def _attested(row):
         "source": "unit",
         "redacted": True,
         "reviewed": True,
-        "passed": True,
+        "passed": passed,
     }
     return row
 
@@ -177,6 +177,22 @@ def test_format_record_rejects_unattested_native_rows():
         "response": {"text": "hi"},
         "metadata": {"task_type": "response"},
     }
+
+    with pytest.raises(PrivacyFilterError, match="lacks privacy attestation"):
+        format_record(row)
+
+
+def test_format_record_rejects_failed_native_privacy_attestation():
+    row = _attested(
+        {
+            "format": "eliza_native_v1",
+            "boundary": "vercel_ai_sdk.generateText",
+            "request": {"messages": [{"role": "user", "content": "hello"}]},
+            "response": {"text": "hi"},
+            "metadata": {"task_type": "response"},
+        },
+        passed=False,
+    )
 
     with pytest.raises(PrivacyFilterError, match="lacks privacy attestation"):
         format_record(row)

--- a/packages/training/scripts/test_validate_corpus.py
+++ b/packages/training/scripts/test_validate_corpus.py
@@ -12,14 +12,14 @@ sys.path.insert(0, str(SCRIPT_DIR.parent))
 from validate_corpus import run as validate_corpus_run  # noqa: E402
 
 
-def _attestation() -> dict[str, Any]:
+def _attestation(*, passed: bool = True) -> dict[str, Any]:
     return {
         "schema": "eliza.privacy_filter_attestation.v1",
         "version": 1,
         "source": "unit",
         "redacted": True,
         "reviewed": True,
-        "passed": True,
+        "passed": passed,
     }
 
 
@@ -36,6 +36,7 @@ def _native_row(
     text: str = "what is 2+2?",
     response_text: str = "4",
     attested: bool = True,
+    attestation_passed: bool = True,
 ) -> dict[str, Any]:
     row: dict[str, Any] = {
         "format": "eliza_native_v1",
@@ -49,7 +50,9 @@ def _native_row(
         },
     }
     if attested:
-        row["metadata"]["privacy_attestation"] = _attestation()
+        row["metadata"]["privacy_attestation"] = _attestation(
+            passed=attestation_passed
+        )
     return row
 
 
@@ -59,6 +62,26 @@ def test_validate_corpus_rejects_missing_native_privacy_attestation(
     corpus = tmp_path / "native.jsonl"
     report = tmp_path / "report.json"
     _write_jsonl(corpus, [_native_row(attested=False)])
+
+    code = validate_corpus_run(corpus, report, strict=True, max_records=None)
+
+    assert code == 1
+    parsed = json.loads(report.read_text(encoding="utf-8"))
+    assert parsed["invalid_records"] == 1
+    assert (
+        parsed["errors_by_task_type"]["response"][
+            "native_v1_missing_privacy_attestation"
+        ]
+        == 1
+    )
+
+
+def test_validate_corpus_rejects_failed_native_privacy_attestation(
+    tmp_path: Path,
+) -> None:
+    corpus = tmp_path / "native.jsonl"
+    report = tmp_path / "report.json"
+    _write_jsonl(corpus, [_native_row(attestation_passed=False)])
 
     code = validate_corpus_run(corpus, report, strict=True, max_records=None)
 

--- a/packages/training/scripts/validate_corpus.py
+++ b/packages/training/scripts/validate_corpus.py
@@ -145,9 +145,9 @@ def _has_privacy_attestation(record: dict[str, Any]) -> bool:
         if (
             attestation.get("schema") == PRIVACY_ATTESTATION_SCHEMA
             and attestation.get("version") == PRIVACY_ATTESTATION_VERSION
+            and attestation.get("passed") is True
             and (
-                attestation.get("passed") is True
-                or attestation.get("reviewed") is True
+                attestation.get("reviewed") is True
                 or attestation.get("redacted") is True
                 or privacy.get("reviewed") is True
             )


### PR DESCRIPTION
## Summary
- Tightens native training privacy-attestation checks so rows are accepted only when the v1 attestation has `passed: true` and a reviewed/redacted signal.
- Adds regression coverage for failed attestations in both `format_for_training.py` and `validate_corpus.py`.

## Verification
- `python -m py_compile packages/training/scripts/format_for_training.py packages/training/scripts/validate_corpus.py packages/training/scripts/test_format_for_training.py packages/training/scripts/test_validate_corpus.py`
- `uv run --project packages/training --with pytest -- python -m pytest packages/training/scripts/test_format_for_training.py packages/training/scripts/test_validate_corpus.py` — 17 passed, 1 existing pytest config warning (`asyncio_mode`)
- `bunx biome check packages/scenario-runner/src/native-export.ts packages/scenario-runner/src/native-export.test.ts`

## Context
Follow-up to #12597. During review, the merged gate accepted attestations with `redacted: true` or `reviewed: true` even if `passed` was false or absent. That weakened strict privacy validation for native rows.

Screenshots/video/live trajectories: N/A — non-UI training validation change.
