### PR TITLE
fix(#12320): gate unoptimized gguf fallbacks

### DIFF
--- a/.github/issue-evidence/12216-stage3-fallback-gate/README.md
+++ b/.github/issue-evidence/12216-stage3-fallback-gate/README.md
@@ -1,0 +1,47 @@
+# Stage 3 GGUF fallback gate evidence
+
+Issue: #12320
+PR: TBD
+
+## Scope
+
+This slice removes the release escape hatch from
+`packages/training/scripts/quantization/gguf_eliza1_apply.py
+--allow-unoptimized-fallback`.
+
+The flag remains available for local debugging, but fallback output is now
+marked `weight_quant.releaseEligible=false` and is rejected whenever
+`--release-state` is present. A release-labeled GGUF can no longer fall back
+from `q4_polar` to `f16`/`q8_0`.
+
+## Verification
+
+```bash
+bun install
+```
+
+Result: exit 0; artifacts synced to `2026-06-18.1`.
+
+```bash
+python3 -m pytest packages/training/scripts/quantization/test_gguf_eliza1_apply.py -q
+```
+
+Result:
+
+```text
+.....                                                                    [100%]
+```
+
+```bash
+python3 -m py_compile \
+  packages/training/scripts/quantization/gguf_eliza1_apply.py \
+  packages/training/scripts/quantization/test_gguf_eliza1_apply.py
+```
+
+Result: exit 0.
+
+## Notes
+
+This is a flag-gating regression, not a full artifact conversion. Full real-GGUF
+recipe/publish evidence remains with the broader Stage 3 and Stage 4 checklist
+items.

--- a/packages/training/scripts/quantization/gguf_eliza1_apply.py
+++ b/packages/training/scripts/quantization/gguf_eliza1_apply.py
@@ -299,7 +299,7 @@ def main(argv: list[str] | None = None) -> int:
         help=(
             "Local-debug escape hatch: when q4_polar cannot be emitted, "
             "fall back to f16/q8_0 and mark the sidecar as deferred. "
-            "Do not use for Eliza-1 release artifacts."
+            "Rejected when --release-state is set."
         ),
     )
     # Eliza-1 v1 = the upstream BASE models, GGUF-converted + fully optimized
@@ -432,6 +432,14 @@ def main(argv: list[str] | None = None) -> int:
         log.warning("Q4_POLAR conversion unavailable: %s", fallback_reason)
         args.outtype = "q8_0"
 
+    if fallback_reason is not None and args.release_state is not None:
+        log.error(
+            "refusing --allow-unoptimized-fallback with --release-state=%s: "
+            "fallback GGUFs are local-debug artifacts and are not release-eligible",
+            args.release_state,
+        )
+        return 2
+
     base_model = args.checkpoint.name
     if polar_sidecar:
         base_model = str(polar_sidecar.get("source_model") or base_model)
@@ -462,6 +470,7 @@ def main(argv: list[str] | None = None) -> int:
         "actual": args.outtype,
         "deferred": requested_outtype != args.outtype,
         "deferral_reason": fallback_reason,
+        "releaseEligible": fallback_reason is None,
         # PolarQuant codebook is still available as a sidecar even when the GGUF
         # body is q8_0/f16 — the runtime can apply it once the fork's converter
         # (or a runtime-side path) lands.

--- a/packages/training/scripts/quantization/test_gguf_eliza1_apply.py
+++ b/packages/training/scripts/quantization/test_gguf_eliza1_apply.py
@@ -31,7 +31,10 @@ def test_q4_polar_refuses_missing_polar_sidecar_by_default(tmp_path: Path) -> No
     assert rc == 2
 
 
-def test_q4_polar_fallback_requires_explicit_escape_hatch(tmp_path: Path) -> None:
+def test_q4_polar_fallback_requires_explicit_escape_hatch(
+    tmp_path: Path,
+    capsys,
+) -> None:
     checkpoint = tmp_path / "checkpoint"
     checkpoint.mkdir()
 
@@ -49,6 +52,40 @@ def test_q4_polar_fallback_requires_explicit_escape_hatch(tmp_path: Path) -> Non
     )
 
     assert rc == 0
+    plan = json.loads(capsys.readouterr().out)
+    assert plan["outtype"] == "f16"
+    assert plan["ext_metadata"]["weight_quant"] == {
+        "requested": "q4_polar",
+        "actual": "f16",
+        "deferred": True,
+        "deferral_reason": (
+            f"polarquant codebook ({checkpoint / 'polarquant_config.json'}) missing"
+        ),
+        "releaseEligible": False,
+        "polarquant_artifacts": None,
+    }
+
+
+def test_q4_polar_fallback_is_rejected_for_release_state(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "checkpoint"
+    checkpoint.mkdir()
+
+    rc = main(
+        [
+            "--checkpoint",
+            str(checkpoint),
+            "--output",
+            str(tmp_path / "model.gguf"),
+            "--outtype",
+            "q4_polar",
+            "--allow-unoptimized-fallback",
+            "--release-state",
+            "base-v1",
+            "--dry-run",
+        ]
+    )
+
+    assert rc == 2
 
 
 def test_dry_run_merges_all_quantization_recipe_sidecars(


### PR DESCRIPTION
## Summary
- reject `--allow-unoptimized-fallback` whenever `--release-state` is set
- mark local fallback sidecars as `weight_quant.releaseEligible=false`
- extend GGUF fallback regression tests and add Stage 3 evidence

## Evidence
- `bun install` (exit 0; artifacts synced to 2026-06-18.1)
- `python3 -m pytest packages/training/scripts/quantization/test_gguf_eliza1_apply.py -q` -> 5 passed
- `python3 -m py_compile packages/training/scripts/quantization/gguf_eliza1_apply.py packages/training/scripts/quantization/test_gguf_eliza1_apply.py` -> exit 0
- `git diff --check origin/develop..HEAD` -> exit 0

Evidence file: `.github/issue-evidence/12216-stage3-fallback-gate/README.md`

## N/A
- Full GGUF conversion: this slice hardens CLI fallback semantics only; real-artifact recipe and publish gate proof remain on the broader Stage 3/4 checklist.
- Screenshots/video: CLI-only training script change.

Fixes part of #12320.