### PR TITLE
fix(ui): keep chat auto-scroll following after a large single-commit growth

### DIFF
--- a/packages/ui/src/hooks/useThreadAutoScroll.test.tsx
+++ b/packages/ui/src/hooks/useThreadAutoScroll.test.tsx
@@ -41,6 +41,40 @@ function makeScroller(
   return el;
 }
 
+// Like makeScroller but clamps scrollTop to [0, scrollHeight - clientHeight]
+// (real browser behaviour, where "at the bottom" is scrollTop === that max, not
+// === scrollHeight) and reads scrollHeight from a live getter so a test can grow
+// the thread between renders. The unclamped makeScroller hides the >80px-growth
+// bug because it lets scrollTop rest at the full height.
+function makeClampingScroller(
+  getHeight: () => number,
+  clientHeight: number,
+): HTMLDivElement {
+  const el = document.createElement("div");
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    get: getHeight,
+  });
+  Object.defineProperty(el, "clientHeight", {
+    configurable: true,
+    get: () => clientHeight,
+  });
+  let top = 0;
+  const clamp = (v: number) =>
+    Math.max(0, Math.min(v, getHeight() - clientHeight));
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    get: () => top,
+    set: (v: number) => {
+      top = clamp(v);
+    },
+  });
+  el.scrollTo = ((opts: ScrollToOptions) => {
+    top = clamp(opts.top ?? top);
+  }) as HTMLElement["scrollTo"];
+  return el;
+}
+
 interface SurfaceState {
   atBottom: boolean;
   jumpToLatest: () => void;
@@ -153,6 +187,32 @@ describe("useThreadAutoScroll", () => {
     // Their position is untouched; the jump control should be offered.
     expect(scroller.scrollTop).toBe(100);
     expect(cap.get().atBottom).toBe(false);
+  });
+
+  it("keeps following after a single large (>80px) growth while at the bottom (#12348 regression)", () => {
+    // Real browsers clamp scrollTop, so a reader at the bottom sits at
+    // scrollHeight - clientHeight, not at scrollHeight.
+    let height = 1000;
+    const clientHeight = 400;
+    const scroller = makeClampingScroller(() => height, clientHeight);
+    const cap = capture();
+    const { rerender } = render(
+      <Harness growthKey={1} scroller={scroller} onState={cap.onState} />,
+    );
+    flushRaf();
+    // First pin lands at the clamped bottom (1000 - 400).
+    expect(scroller.scrollTop).toBe(600);
+    expect(cap.get().atBottom).toBe(true);
+    // A single commit appends a block far taller than the 80px threshold — a
+    // multi-line paste or a batched stream burst — growing 1000 -> 1300 while
+    // scrollTop stays at 600. A live re-measure reads 1300-600-400=300 > 80 and
+    // wrongly stops following; the pre-growth measure (1000-600-400=0) follows.
+    height = 1300;
+    rerender(<Harness growthKey={2} scroller={scroller} onState={cap.onState} />);
+    flushRaf();
+    // Followed to the new clamped bottom (1300 - 400); reader stays pinned.
+    expect(scroller.scrollTop).toBe(900);
+    expect(cap.get().atBottom).toBe(true);
   });
 
   it("jumpToLatest scrolls to the newest line and re-pins atBottom", () => {

--- a/packages/ui/src/hooks/useThreadAutoScroll.ts
+++ b/packages/ui/src/hooks/useThreadAutoScroll.ts
@@ -75,6 +75,13 @@ export function useThreadAutoScroll<T extends HTMLElement = HTMLDivElement>({
   const [atBottom, setAtBottom] = useState(true);
   const followRaf = useRef<number | null>(null);
   const hasPinnedRef = useRef(false);
+  // Scroll height as of the previous follow pass. The growth effect runs AFTER
+  // the DOM has grown, so a live measureAtBottom(el) there uses the new (larger)
+  // scrollHeight against the preserved (old) scrollTop and misreads a reader
+  // pinned to the bottom as "scrolled up" whenever a single commit appends more
+  // than AT_BOTTOM_THRESHOLD_PX. Measuring against this pre-growth height instead
+  // recovers the true pre-growth position (#12348).
+  const lastGrowthHeightRef = useRef(0);
 
   const syncAtBottom = useCallback(() => {
     const el = scrollRef.current;
@@ -100,6 +107,7 @@ export function useThreadAutoScroll<T extends HTMLElement = HTMLDivElement>({
     } else {
       el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
     }
+    lastGrowthHeightRef.current = el.scrollHeight;
     setAtBottom(true);
   }, [reduceMotion]);
 
@@ -114,13 +122,23 @@ export function useThreadAutoScroll<T extends HTMLElement = HTMLDivElement>({
     const firstPin = !hasPinnedRef.current;
     hasPinnedRef.current = true;
 
-    if (firstPin || measureAtBottom(el)) {
+    // Decide follow against the PRE-growth geometry: the DOM has already grown,
+    // so measure the reader's position against the previous scroll height (with
+    // the preserved scrollTop) instead of a live re-measure that would misread a
+    // big single-commit append as "scrolled up". First growth always pins.
+    const prevHeight = lastGrowthHeightRef.current;
+    const wasAtBottom =
+      prevHeight - el.scrollTop - el.clientHeight < AT_BOTTOM_THRESHOLD_PX;
+    lastGrowthHeightRef.current = el.scrollHeight;
+
+    if (firstPin || wasAtBottom) {
       if (followRaf.current != null) cancelAnimationFrame(followRaf.current);
       followRaf.current = requestAnimationFrame(() => {
         followRaf.current = null;
         const node = scrollRef.current;
         if (!node) return;
         node.scrollTop = node.scrollHeight;
+        lastGrowthHeightRef.current = node.scrollHeight;
         setAtBottom(true);
       });
     } else {


### PR DESCRIPTION
## What & why

`useThreadAutoScroll` (the shared chat auto-scroll engine, #12348 / #12458) decided whether to follow the thread tail by re-measuring `measureAtBottom(el)` inside its growth `useLayoutEffect`. But a layout effect runs **after** React commits the DOM, so `el.scrollHeight` already reports the new (larger) height while `scrollTop` is still the preserved old position.

When a single commit appends content taller than `AT_BOTTOM_THRESHOLD_PX` (80px) — a multi-line / pasted message, or a fast stream landing several wrapped lines in one React 19 batched commit — the live measure computes `scrollHeight(new) - scrollTop(old) - clientHeight` ≈ the appended block height (>80), so a reader who was **pinned to the bottom** is misclassified as "scrolled up". The thread stops following, the new content never scrolls into view, and a jump-to-latest control appears even though the reader never scrolled away — with no recovery until a later growth happens to land within 80px.

Found by an independent adversarial review of recent merges; verified against the real code path.

## The fix

Decide against the **pre-growth** geometry: measure the reader's position against the *previous* scroll height (with the preserved `scrollTop`) rather than re-measuring live after the DOM has grown. That recovers the true pre-growth at-bottom status. A small `lastGrowthHeightRef` tracks the height as of the last follow pass.

This is more robust than reading the `atBottom` state/ref, because that only updates on scroll **events**; measuring against the prior height is correct even for a position change that hasn't emitted a scroll event yet, so the existing "don't yank a reader who scrolled up" contract is preserved.

## Evidence

Regression test added (`useThreadAutoScroll.test.tsx`) using a `scrollTop`-clamping scroller that models a real browser (bottom = `scrollHeight - clientHeight`, not `= scrollHeight` — the existing unclamped harness hid the bug):

Without the fix (old live re-measure):
```
× keeps following after a single large (>80px) growth while at the bottom (#12348 regression)
    AssertionError: expected 600 to be 900   // thread stuck at the old bottom
 Tests  1 failed | 6 passed (7)
```

With the fix:
```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

The test drives the real hook: first-pin lands at the clamped bottom (600), a single 1000→1300 growth (>80px) with `scrollTop` preserved at 600 must still follow to the new bottom (900) and stay `atBottom`.

- `bun run --cwd packages/ui typecheck`: no new errors from this change (the 2 pre-existing `src/testing/e2e-runner/fixture-bundle.ts` errors on `develop` are unrelated).
- Full-page screenshots / video (`audit:app`): **N/A here** — this is scroll-math in a shared hook covered deterministically by the jsdom unit test above (jsdom does not lay out); the behaviour is asserted on the exact `scrollTop` writes and derived `atBottom`, which is the contract every chat surface consumes.