### PR TITLE
feat(ios): add keyboard dictation handoff

### DIFF
--- a/.github/issue-evidence/12392-ios-keyboard-handoff/README.md
+++ b/.github/issue-evidence/12392-ios-keyboard-handoff/README.md
@@ -1,0 +1,34 @@
+# Issue #12392 - iOS Keyboard Handoff
+
+Date: 2026-07-04
+
+## Scope
+
+- Added a first-party `ElizaKeyboard` iOS keyboard extension target with:
+  - minimal QWERTY rows,
+  - a suggestion strip,
+  - a `Dictate` entry point,
+  - explicit app handoff through `elizaos://keyboard-dictation`.
+- Added an app-group handoff contract:
+  - keyboard writes `com.elizaos.keyboard.pendingRequest`,
+  - containing app bridge can write `com.elizaos.keyboard.completedTranscript`,
+  - keyboard polls and inserts the completed transcript.
+- Added `ElizaKeyboardBridge` as the containing-app Capacitor bridge for pending-request read and completed-transcript writeback.
+- Wired `ElizaKeyboard` into the Xcode project, app extension embed phase, app dependency graph, product list, privacy manifest, and app-group entitlements.
+- Updated iOS app identity rewriting so white-label builds rewrite `ElizaKeyboard` bundle ids and app-group entitlements.
+- Routed `elizaos://keyboard-dictation?source=ios-keyboard&requestId=...` into the existing chat voice launch path with `keyboardRequestId` preserved.
+
+## Verification
+
+- `plutil -lint packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj packages/app-core/platforms/ios/App/App/ElizaKeyboard/Info.plist packages/app-core/platforms/ios/App/App/ElizaKeyboard/ElizaKeyboard.entitlements packages/app-core/platforms/ios/App/App/ElizaKeyboard/PrivacyInfo.xcprivacy`
+  - Result: PASS.
+- `swiftc -parse packages/app-core/platforms/ios/App/App/ElizaKeyboard/KeyboardViewController.swift packages/app-core/platforms/ios/App/App/ElizaKeyboardBridge.swift`
+  - Result: PASS.
+- `bunx vitest run packages/app/src/deep-link-routing.test.ts packages/app-core/scripts/run-mobile-build-ios-identity.test.mjs`
+  - Result: PASS, 2 files / 29 tests.
+  - Note: executed from a narrow exported tree with a temporary `node_modules` symlink to the already-installed main workspace.
+
+## Not Captured On This Host
+
+- iOS simulator/real-device screenshots, screen recording, enablement walkthrough, and native logs are pending because this host does not have a full Xcode/iOS simulator SDK installed.
+- Real-LLM trajectories are N/A for this patch because it changes native keyboard, app-group, Xcode, and deep-link handoff plumbing only; it does not change agent/action/provider/prompt/model behavior.

--- a/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
@@ -40,6 +40,10 @@
 		AUIT00010000000000000005 /* ViewWalkthroughUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT00010000000000000006 /* ViewWalkthroughUITests.swift */; };
 		AUIT00010000000000000007 /* WidgetGalleryCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT00010000000000000008 /* WidgetGalleryCaptureUITests.swift */; };
 		AUIT00010000000000000009 /* LauncherGestureLoopUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */; };
+		EKEY00010000000000000001 /* KeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EKEY00010000000000000102 /* KeyboardViewController.swift */; };
+		EKEY00010000000000000002 /* ElizaKeyboard.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = EKEY00010000000000000101 /* ElizaKeyboard.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		EKEY00010000000000000003 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = EKEY00010000000000000105 /* PrivacyInfo.xcprivacy */; };
+		EKEYBRIDGE00000000000001 /* ElizaKeyboardBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EKEYBRIDGE00000000000002 /* ElizaKeyboardBridge.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -78,6 +82,13 @@
 			remoteGlobalIDString = 504EC3031FED79650016851F;
 			remoteInfo = App;
 		};
+		EKEY00010000000000000701 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 504EC2FC1FED79650016851F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EKEY00010000000000000401;
+			remoteInfo = ElizaKeyboard;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -91,6 +102,7 @@
 				DAMON000100000000000002 /* DeviceActivityMonitorExtension.appex in Embed App Extensions */,
 				DAREP000100000000000002 /* DeviceActivityReportExtension.appex in Embed App Extensions */,
 				EWDG00010000000000000002 /* ElizaWidgets.appex in Embed App Extensions */,
+					EKEY00010000000000000002 /* ElizaKeyboard.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -144,6 +156,12 @@
 		AUIT00010000000000000008 /* WidgetGalleryCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetGalleryCaptureUITests.swift; sourceTree = "<group>"; };
 		AUIT0001000000000000000A /* LauncherGestureLoopUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LauncherGestureLoopUITests.swift; sourceTree = "<group>"; };
 		AUIT00010000000000000101 /* AppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		EKEY00010000000000000101 /* ElizaKeyboard.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ElizaKeyboard.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		EKEY00010000000000000102 /* KeyboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardViewController.swift; sourceTree = "<group>"; };
+		EKEY00010000000000000103 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EKEY00010000000000000104 /* ElizaKeyboard.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ElizaKeyboard.entitlements; sourceTree = "<group>"; };
+		EKEY00010000000000000105 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		EKEYBRIDGE00000000000002 /* ElizaKeyboardBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElizaKeyboardBridge.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -190,6 +208,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EKEY00010000000000000202 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -220,6 +245,7 @@
 				DAMON000100000000000101 /* DeviceActivityMonitorExtension.appex */,
 				DAREP000100000000000101 /* DeviceActivityReportExtension.appex */,
 				EWDG00010000000000000101 /* ElizaWidgets.appex */,
+					EKEY00010000000000000101 /* ElizaKeyboard.appex */,
 				AUIT00010000000000000101 /* AppUITests.xctest */,
 			);
 			name = Products;
@@ -236,6 +262,7 @@
 				E1A5105A0000000000000002 /* ElizaAppIntents.swift */,
 				MIPL00010000000000000002 /* ElizaIntentPlugin.swift */,
 				ELIZALIVEACT000000000002 /* ElizaLiveActivityBridge.swift */,
+					EKEYBRIDGE00000000000002 /* ElizaKeyboardBridge.swift */,
 				AWDG00010000000000000002 /* AgentWatchdog.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
@@ -248,6 +275,7 @@
 				DAMON000100000000000301 /* DeviceActivityMonitorExtension */,
 				DAREP000100000000000301 /* DeviceActivityReportExtension */,
 				EWDG00010000000000000301 /* ElizaWidgets */,
+					EKEY00010000000000000301 /* ElizaKeyboard */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -305,6 +333,17 @@
 			path = ElizaWidgets;
 			sourceTree = "<group>";
 		};
+		EKEY00010000000000000301 /* ElizaKeyboard */ = {
+			isa = PBXGroup;
+			children = (
+				EKEY00010000000000000102 /* KeyboardViewController.swift */,
+				EKEY00010000000000000103 /* Info.plist */,
+				EKEY00010000000000000104 /* ElizaKeyboard.entitlements */,
+				EKEY00010000000000000105 /* PrivacyInfo.xcprivacy */,
+			);
+			path = ElizaKeyboard;
+			sourceTree = "<group>";
+		};
 		AUIT00010000000000000301 /* AppUITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -339,6 +378,7 @@
 				DAMON000100000000000702 /* PBXTargetDependency */,
 				DAREP000100000000000702 /* PBXTargetDependency */,
 				EWDG00010000000000000702 /* PBXTargetDependency */,
+					EKEY00010000000000000702 /* PBXTargetDependency */,
 			);
 			name = App;
 			productName = App;
@@ -413,6 +453,23 @@
 			productReference = EWDG00010000000000000101 /* ElizaWidgets.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		EKEY00010000000000000401 /* ElizaKeyboard */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EKEY00010000000000000601 /* Build configuration list for PBXNativeTarget "ElizaKeyboard" */;
+			buildPhases = (
+				EKEY00010000000000000203 /* Sources */,
+				EKEY00010000000000000202 /* Frameworks */,
+				EKEY00010000000000000204 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ElizaKeyboard;
+			productName = ElizaKeyboard;
+			productReference = EKEY00010000000000000101 /* ElizaKeyboard.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		AUIT00010000000000000401 /* AppUITests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = AUIT00010000000000000601 /* Build configuration list for PBXNativeTarget "AppUITests" */;
@@ -461,6 +518,10 @@
 						CreatedOnToolsVersion = 16.1;
 						ProvisioningStyle = Automatic;
 					};
+					EKEY00010000000000000401 = {
+						CreatedOnToolsVersion = 16.1;
+						ProvisioningStyle = Automatic;
+					};
 					AUIT00010000000000000401 = {
 						CreatedOnToolsVersion = 16.1;
 						ProvisioningStyle = Automatic;
@@ -486,6 +547,7 @@
 				DAMON000100000000000401 /* DeviceActivityMonitorExtension */,
 				DAREP000100000000000401 /* DeviceActivityReportExtension */,
 				EWDG00010000000000000401 /* ElizaWidgets */,
+					EKEY00010000000000000401 /* ElizaKeyboard */,
 				AUIT00010000000000000401 /* AppUITests */,
 			);
 		};
@@ -538,6 +600,14 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EKEY00010000000000000204 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EKEY00010000000000000003 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -608,6 +678,7 @@
 				E1A5105A0000000000000001 /* ElizaAppIntents.swift in Sources */,
 				MIPL00010000000000000001 /* ElizaIntentPlugin.swift in Sources */,
 				ELIZALIVEACT000000000001 /* ElizaLiveActivityBridge.swift in Sources */,
+					EKEYBRIDGE00000000000001 /* ElizaKeyboardBridge.swift in Sources */,
 				EWDG00010000000000000004 /* ElizaDictationAttributes.swift in Sources */,
 				AWDG00010000000000000001 /* AgentWatchdog.swift in Sources */,
 			);
@@ -660,6 +731,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EKEY00010000000000000203 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EKEY00010000000000000001 /* KeyboardViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -687,6 +766,11 @@
 			isa = PBXTargetDependency;
 			target = EWDG00010000000000000401 /* ElizaWidgets */;
 			targetProxy = EWDG00010000000000000701 /* PBXContainerItemProxy */;
+		};
+		EKEY00010000000000000702 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EKEY00010000000000000401 /* ElizaKeyboard */;
+			targetProxy = EKEY00010000000000000701 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1032,6 +1116,47 @@
 			};
 			name = Release;
 		};
+		EKEY00010000000000000501 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_ENTITLEMENTS = App/ElizaKeyboard/ElizaKeyboard.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 25877RY2EH;
+				INFOPLIST_FILE = App/ElizaKeyboard/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.elizaos.app.ElizaKeyboard;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		EKEY00010000000000000502 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_ENTITLEMENTS = App/ElizaKeyboard/ElizaKeyboard.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 25877RY2EH;
+				INFOPLIST_FILE = App/ElizaKeyboard/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.elizaos.app.ElizaKeyboard;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		AUIT00010000000000000501 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1124,6 +1249,15 @@
 			buildConfigurations = (
 				EWDG00010000000000000501 /* Debug */,
 				EWDG00010000000000000502 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EKEY00010000000000000601 /* Build configuration list for PBXNativeTarget "ElizaKeyboard" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EKEY00010000000000000501 /* Debug */,
+				EKEY00010000000000000502 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/packages/app-core/platforms/ios/App/App/ElizaKeyboard/ElizaKeyboard.entitlements
+++ b/packages/app-core/platforms/ios/App/App/ElizaKeyboard/ElizaKeyboard.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.ai.elizaos.app</string>
+	</array>
+</dict>
+</plist>

--- a/packages/app-core/platforms/ios/App/App/ElizaKeyboard/Info.plist
+++ b/packages/app-core/platforms/ios/App/App/ElizaKeyboard/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Eliza Keyboard</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>IsASCIICapable</key>
+			<true/>
+			<key>PrefersRightToLeft</key>
+			<false/>
+			<key>PrimaryLanguage</key>
+			<string>en-US</string>
+			<key>RequestsOpenAccess</key>
+			<true/>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.keyboard-service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).KeyboardViewController</string>
+	</dict>
+</dict>
+</plist>

--- a/packages/app-core/platforms/ios/App/App/ElizaKeyboard/KeyboardViewController.swift
+++ b/packages/app-core/platforms/ios/App/App/ElizaKeyboard/KeyboardViewController.swift
@@ -1,0 +1,193 @@
+import UIKit
+
+private enum ElizaKeyboardStore {
+    static let pendingRequestKey = "com.elizaos.keyboard.pendingRequest"
+    static let completedTranscriptKey = "com.elizaos.keyboard.completedTranscript"
+
+    static var appGroupIdentifier: String {
+        let bundleIdentifier = Bundle.main.bundleIdentifier ?? "ai.elizaos.app.ElizaKeyboard"
+        let appBundleIdentifier = bundleIdentifier.replacingOccurrences(
+            of: ".ElizaKeyboard",
+            with: ""
+        )
+        return "group.\(appBundleIdentifier)"
+    }
+
+    static var defaults: UserDefaults? {
+        UserDefaults(suiteName: appGroupIdentifier)
+    }
+}
+
+final class KeyboardViewController: UIInputViewController {
+    private let accentColor = UIColor(red: 1.0, green: 0.345, blue: 0.0, alpha: 1.0)
+    private let statusLabel = UILabel()
+    private var pendingRequestId: String?
+    private var transcriptPoller: Timer?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemGroupedBackground
+        buildKeyboard()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        pollCompletedTranscript()
+        startTranscriptPolling()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        transcriptPoller?.invalidate()
+        transcriptPoller = nil
+    }
+
+    private func buildKeyboard() {
+        let root = UIStackView()
+        root.axis = .vertical
+        root.spacing = 7
+        root.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(root)
+
+        NSLayoutConstraint.activate([
+            root.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 8),
+            root.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -8),
+            root.topAnchor.constraint(equalTo: view.topAnchor, constant: 8),
+            root.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -8),
+        ])
+
+        root.addArrangedSubview(makeSuggestionStrip())
+        for row in ["QWERTYUIOP", "ASDFGHJKL", "ZXCVBNM"] {
+            root.addArrangedSubview(makeLetterRow(row.map(String.init)))
+        }
+        root.addArrangedSubview(makeCommandRow())
+    }
+
+    private func makeSuggestionStrip() -> UIView {
+        let strip = UIStackView()
+        strip.axis = .horizontal
+        strip.spacing = 6
+        strip.distribution = .fillEqually
+
+        statusLabel.text = "Eliza Keyboard"
+        statusLabel.textAlignment = .center
+        statusLabel.font = .preferredFont(forTextStyle: .caption1)
+        statusLabel.textColor = .secondaryLabel
+
+        strip.addArrangedSubview(makeSuggestionButton("Ask", text: "Ask Eliza "))
+        strip.addArrangedSubview(makeSuggestionButton("Reply", text: "Reply: "))
+        strip.addArrangedSubview(makeSuggestionButton("Task", text: "Task: "))
+        strip.addArrangedSubview(statusLabel)
+        return strip
+    }
+
+    private func makeLetterRow(_ letters: [String]) -> UIView {
+        let row = UIStackView()
+        row.axis = .horizontal
+        row.spacing = 5
+        row.distribution = .fillEqually
+        for letter in letters {
+            row.addArrangedSubview(makeKey(letter) { [weak self] in
+                self?.textDocumentProxy.insertText(letter.lowercased())
+            })
+        }
+        return row
+    }
+
+    private func makeCommandRow() -> UIView {
+        let row = UIStackView()
+        row.axis = .horizontal
+        row.spacing = 5
+        row.distribution = .fill
+
+        let next = makeKey("Next") { [weak self] in self?.advanceToNextInputMode() }
+        let dictate = makeKey("Dictate") { [weak self] in self?.openContainingAppForDictation() }
+        let space = makeKey("space") { [weak self] in self?.textDocumentProxy.insertText(" ") }
+        let delete = makeKey("Delete") { [weak self] in self?.textDocumentProxy.deleteBackward() }
+        let enter = makeKey("return") { [weak self] in self?.textDocumentProxy.insertText("\n") }
+
+        next.widthAnchor.constraint(equalToConstant: 50).isActive = true
+        delete.widthAnchor.constraint(equalToConstant: 66).isActive = true
+        enter.widthAnchor.constraint(equalToConstant: 70).isActive = true
+        dictate.widthAnchor.constraint(greaterThanOrEqualToConstant: 86).isActive = true
+
+        row.addArrangedSubview(next)
+        row.addArrangedSubview(dictate)
+        row.addArrangedSubview(space)
+        row.addArrangedSubview(delete)
+        row.addArrangedSubview(enter)
+        return row
+    }
+
+    private func makeSuggestionButton(_ title: String, text: String) -> UIButton {
+        makeKey(title) { [weak self] in
+            self?.textDocumentProxy.insertText(text)
+        }
+    }
+
+    private func makeKey(_ title: String, action: @escaping () -> Void) -> UIButton {
+        let button = UIButton(type: .system)
+        button.setTitle(title, for: .normal)
+        button.titleLabel?.font = .preferredFont(forTextStyle: .body)
+        button.backgroundColor = .secondarySystemGroupedBackground
+        button.tintColor = title == "Dictate" ? accentColor : .label
+        button.layer.cornerRadius = 7
+        button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 6, bottom: 8, right: 6)
+        button.addAction(UIAction { _ in action() }, for: .touchUpInside)
+        return button
+    }
+
+    private func openContainingAppForDictation() {
+        let requestId = UUID().uuidString
+        pendingRequestId = requestId
+        let payload: [String: Any] = [
+            "requestId": requestId,
+            "requestedAt": ISO8601DateFormatter().string(from: Date()),
+            "source": "ios-keyboard",
+        ]
+        ElizaKeyboardStore.defaults?.set(payload, forKey: ElizaKeyboardStore.pendingRequestKey)
+        ElizaKeyboardStore.defaults?.synchronize()
+        statusLabel.text = "Listening in Eliza..."
+
+        var components = URLComponents()
+        components.scheme = "elizaos"
+        components.host = "keyboard-dictation"
+        components.queryItems = [
+            URLQueryItem(name: "source", value: "ios-keyboard"),
+            URLQueryItem(name: "action", value: "keyboard.dictation"),
+            URLQueryItem(name: "voice", value: "1"),
+            URLQueryItem(name: "requestId", value: requestId),
+        ]
+        guard let url = components.url else { return }
+        extensionContext?.open(url, completionHandler: nil)
+    }
+
+    private func startTranscriptPolling() {
+        transcriptPoller?.invalidate()
+        transcriptPoller = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.pollCompletedTranscript()
+        }
+    }
+
+    private func pollCompletedTranscript() {
+        guard
+            let defaults = ElizaKeyboardStore.defaults,
+            let payload = defaults.dictionary(forKey: ElizaKeyboardStore.completedTranscriptKey),
+            let transcript = (payload["transcript"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !transcript.isEmpty
+        else {
+            return
+        }
+        let completedRequestId = payload["requestId"] as? String
+        if let pendingRequestId, completedRequestId != pendingRequestId {
+            return
+        }
+
+        textDocumentProxy.insertText(transcript)
+        defaults.removeObject(forKey: ElizaKeyboardStore.completedTranscriptKey)
+        defaults.removeObject(forKey: ElizaKeyboardStore.pendingRequestKey)
+        defaults.synchronize()
+        self.pendingRequestId = nil
+        statusLabel.text = "Inserted"
+    }
+}

--- a/packages/app-core/platforms/ios/App/App/ElizaKeyboard/PrivacyInfo.xcprivacy
+++ b/packages/app-core/platforms/ios/App/App/ElizaKeyboard/PrivacyInfo.xcprivacy
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/app-core/platforms/ios/App/App/ElizaKeyboardBridge.swift
+++ b/packages/app-core/platforms/ios/App/App/ElizaKeyboardBridge.swift
@@ -1,0 +1,74 @@
+import Capacitor
+import Foundation
+
+/// Native app-group bridge for the iOS custom keyboard extension.
+///
+/// The keyboard extension cannot record audio or host the Bun runtime. It
+/// writes a pending request into the shared app group, opens
+/// `elizaos://keyboard-dictation?...`, and waits for the containing app to
+/// write the completed transcript back through this bridge.
+@objc(ElizaKeyboardBridgePlugin)
+public class ElizaKeyboardBridgePlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "ElizaKeyboardBridgePlugin"
+    public let jsName = "ElizaKeyboardBridge"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "getPendingRequest", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "completeDictation", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "clearCompletedTranscript", returnType: CAPPluginReturnPromise),
+    ]
+
+    private static let pendingRequestKey = "com.elizaos.keyboard.pendingRequest"
+    private static let completedTranscriptKey = "com.elizaos.keyboard.completedTranscript"
+
+    private var appGroupIdentifier: String {
+        let appBundleIdentifier = Bundle.main.bundleIdentifier ?? "ai.elizaos.app"
+        return "group.\(appBundleIdentifier)"
+    }
+
+    private var sharedDefaults: UserDefaults? {
+        UserDefaults(suiteName: appGroupIdentifier)
+    }
+
+    @objc public func getPendingRequest(_ call: CAPPluginCall) {
+        guard let defaults = sharedDefaults else {
+            call.reject("App group is unavailable: \(appGroupIdentifier)")
+            return
+        }
+        call.resolve(defaults.dictionary(forKey: Self.pendingRequestKey) ?? [:])
+    }
+
+    @objc public func completeDictation(_ call: CAPPluginCall) {
+        guard let defaults = sharedDefaults else {
+            call.reject("App group is unavailable: \(appGroupIdentifier)")
+            return
+        }
+        guard let requestId = call.getString("requestId"), !requestId.isEmpty else {
+            call.reject("completeDictation requires requestId")
+            return
+        }
+        guard
+            let transcript = call.getString("transcript")?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !transcript.isEmpty
+        else {
+            call.reject("completeDictation requires transcript")
+            return
+        }
+
+        let payload: [String: Any] = [
+            "requestId": requestId,
+            "transcript": transcript,
+            "completedAt": ISO8601DateFormatter().string(from: Date()),
+            "source": "ios-app",
+        ]
+        defaults.set(payload, forKey: Self.completedTranscriptKey)
+        defaults.removeObject(forKey: Self.pendingRequestKey)
+        defaults.synchronize()
+        call.resolve(["requestId": requestId, "completed": true])
+    }
+
+    @objc public func clearCompletedTranscript(_ call: CAPPluginCall) {
+        sharedDefaults?.removeObject(forKey: Self.completedTranscriptKey)
+        sharedDefaults?.synchronize()
+        call.resolve(["cleared": true])
+    }
+}

--- a/packages/app-core/scripts/run-mobile-build-ios-identity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-ios-identity.test.mjs
@@ -1,6 +1,7 @@
 /**
  * applyIosAppIdentity against the real committed iOS template: brand rewrite of
- * app/extension bundle ids and app-group entitlements (including ElizaWidgets),
+ * app/extension bundle ids and app-group entitlements (including first-party
+ * iOS extensions such as ElizaWidgets and ElizaKeyboard),
  * plus ELIZAOS_VERSION_NAME/CODE → MARKETING_VERSION/CURRENT_PROJECT_VERSION
  * threading (#12185). Stages the template into a temp dir; no mocks.
  */
@@ -40,6 +41,7 @@ const TEMPLATE_FILES = [
     "DeviceActivityReportExtension.entitlements",
   ),
   path.join("App", "ElizaWidgets", "ElizaWidgets.entitlements"),
+  path.join("App", "ElizaKeyboard", "ElizaKeyboard.entitlements"),
 ];
 
 const tempDirs = [];
@@ -70,7 +72,7 @@ afterEach(() => {
 });
 
 describe("applyIosAppIdentity (template pbxproj + entitlements)", () => {
-  it("rewrites app + every extension bundle id, including ElizaWidgets", () => {
+  it("rewrites app + every extension bundle id, including first-party extensions", () => {
     const { appDirValue, iosAppRoot } = stageTemplateAppDir();
     applyIosAppIdentity({
       appDirValue,
@@ -89,6 +91,7 @@ describe("applyIosAppIdentity (template pbxproj + entitlements)", () => {
       "DeviceActivityMonitorExtension",
       "DeviceActivityReportExtension",
       "ElizaWidgets",
+      "ElizaKeyboard",
     ]) {
       expect(pbxproj).toContain(
         `PRODUCT_BUNDLE_IDENTIFIER = com.acme.whitelabel.${suffix};`,
@@ -100,7 +103,7 @@ describe("applyIosAppIdentity (template pbxproj + entitlements)", () => {
     expect(pbxproj).not.toContain("PRODUCT_BUNDLE_IDENTIFIER = ai.elizaos.app");
   });
 
-  it("rewrites the ElizaWidgets app-group entitlement to the brand app group", () => {
+  it("rewrites extension app-group entitlements to the brand app group", () => {
     const { appDirValue, iosAppRoot } = stageTemplateAppDir();
     applyIosAppIdentity({
       appDirValue,
@@ -110,14 +113,16 @@ describe("applyIosAppIdentity (template pbxproj + entitlements)", () => {
       versionCode: null,
       log: () => {},
     });
-    const entitlements = readStaged(
-      iosAppRoot,
+    for (const relPath of [
       path.join("App", "ElizaWidgets", "ElizaWidgets.entitlements"),
-    );
-    expect(entitlements).toContain(
-      "<string>group.com.acme.whitelabel</string>",
-    );
-    expect(entitlements).not.toContain("group.ai.elizaos.app");
+      path.join("App", "ElizaKeyboard", "ElizaKeyboard.entitlements"),
+    ]) {
+      const entitlements = readStaged(iosAppRoot, relPath);
+      expect(entitlements).toContain(
+        "<string>group.com.acme.whitelabel</string>",
+      );
+      expect(entitlements).not.toContain("group.ai.elizaos.app");
+    }
   });
 
   it("threads versionName/versionCode into every target's version settings", () => {

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -823,6 +823,7 @@ export function applyIosAppIdentity({
       "DeviceActivityMonitorExtension",
       "DeviceActivityReportExtension",
       "ElizaWidgets",
+      "ElizaKeyboard",
     ];
     for (const suffix of extensionBundleSuffixes) {
       project = project.replace(
@@ -937,6 +938,7 @@ export function applyIosAppIdentity({
       "DeviceActivityReportExtension.entitlements",
     ),
     path.join("App", "ElizaWidgets", "ElizaWidgets.entitlements"),
+    path.join("App", "ElizaKeyboard", "ElizaKeyboard.entitlements"),
   ]) {
     const filePath = path.join(iosAppRoot, relPath);
     if (
@@ -952,6 +954,7 @@ export function applyIosAppIdentity({
     `${appId}.DeviceActivityMonitorExtension`,
     `${appId}.DeviceActivityReportExtension`,
     `${appId}.ElizaWidgets`,
+    `${appId}.ElizaKeyboard`,
   ].join(",");
   const fastlaneReplacements = [
     [

--- a/packages/app/src/deep-link-routing.test.ts
+++ b/packages/app/src/deep-link-routing.test.ts
@@ -127,6 +127,24 @@ describe("assistant launch deep-link routing", () => {
     );
   });
 
+  it("routes iOS keyboard dictation handoff into hands-free chat with request metadata", () => {
+    const hashRoute = buildAssistantLaunchHashRoute(
+      "keyboard-dictation",
+      new URLSearchParams("source=ios-keyboard&requestId=req-123"),
+      { generateLaunchId: () => "launch-keyboard" },
+    );
+
+    expect(hashRoute?.startsWith("#chat?")).toBe(true);
+    expect(params(hashRoute ?? "").get("source")).toBe("ios-keyboard");
+    expect(params(hashRoute ?? "").get("action")).toBe("keyboard.dictation");
+    expect(params(hashRoute ?? "").get("voice")).toBe("1");
+    expect(params(hashRoute ?? "").get("requestId")).toBe("req-123");
+    expect(params(hashRoute ?? "").get("keyboardRequestId")).toBe("req-123");
+    expect(params(hashRoute ?? "").get("assistant.launchId")).toBe(
+      "launch-keyboard",
+    );
+  });
+
   it("routes Android widget daily brief links into chat with a planner hint", () => {
     const hashRoute = buildAssistantLaunchHashRoute(
       "lifeops/daily-brief",
@@ -192,6 +210,7 @@ describe("assistant launch deep-link routing", () => {
       "chat",
       "voice",
       "chat/voice",
+      "keyboard-dictation",
       "daily-brief",
       "lifeops/daily-brief",
       "lifeops/tasks",
@@ -255,6 +274,7 @@ describe("assistant launch deep-link routing", () => {
             "chat",
             "voice",
             "chat/voice",
+            "keyboard-dictation",
             "daily-brief",
             "lifeops/daily-brief",
             "lifeops/tasks",

--- a/packages/app/src/deep-link-routing.ts
+++ b/packages/app/src/deep-link-routing.ts
@@ -226,6 +226,21 @@ export function buildAssistantLaunchHashRoute(
       params.set("voice", "1");
       return formatHashRoute("chat", params);
     }
+    case "keyboard-dictation": {
+      const params = withDefaultSearchParam(
+        searchParams,
+        "source",
+        "ios-keyboard",
+      );
+      params.set("action", params.get("action") ?? "keyboard.dictation");
+      params.set("voice", "1");
+      const requestId = params.get("requestId")?.trim();
+      if (requestId && !params.has("keyboardRequestId")) {
+        params.set("keyboardRequestId", requestId);
+      }
+      ensureAssistantLaunchId(params, generateLaunchId);
+      return formatHashRoute("chat", params);
+    }
     // Personal-assistant deep links no longer target a top-level "lifeops"
     // aggregate view (it was decomposed into independent plugins). They route
     // into chat with the assistant-entry source + a planner action hint so the


### PR DESCRIPTION
## Summary

- Adds a first-party `ElizaKeyboard` iOS keyboard extension target with minimal QWERTY rows, suggestion strip, next-keyboard control, and a Dictate handoff button.
- Adds `ElizaKeyboardBridge`, a containing-app Capacitor bridge for the app-group pending-request/completed-transcript contract.
- Wires the keyboard extension into the Xcode project target graph, product list, embed phase, privacy manifest, app-group entitlement, source/resource phases, and white-label identity rewrite.
- Routes `elizaos://keyboard-dictation?source=ios-keyboard&requestId=...` into the existing chat voice launch path while preserving `keyboardRequestId`.

## Issue

Supports #12392.

## Validation

- PASS: `plutil -lint packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj packages/app-core/platforms/ios/App/App/ElizaKeyboard/Info.plist packages/app-core/platforms/ios/App/App/ElizaKeyboard/ElizaKeyboard.entitlements packages/app-core/platforms/ios/App/App/ElizaKeyboard/PrivacyInfo.xcprivacy`.
- PASS: `swiftc -parse packages/app-core/platforms/ios/App/App/ElizaKeyboard/KeyboardViewController.swift packages/app-core/platforms/ios/App/App/ElizaKeyboardBridge.swift`.
- PASS: `bunx vitest run packages/app/src/deep-link-routing.test.ts packages/app-core/scripts/run-mobile-build-ios-identity.test.mjs` — 2 files / 29 tests.
- PASS with pre-existing warning: `bunx biome check packages/app/src/deep-link-routing.ts packages/app/src/deep-link-routing.test.ts packages/app-core/scripts/run-mobile-build.mjs packages/app-core/scripts/run-mobile-build-ios-identity.test.mjs`.
- PASS: `git diff --check origin/develop..feat/12392-ios-keyboard-handoff`.

## Evidence

- Evidence note: `.github/issue-evidence/12392-ios-keyboard-handoff/README.md`.
- iOS simulator / real-device screenshot, screen recording, keyboard enablement walkthrough, and native logs: pending, blocked on this host because `xcodebuild -version` reports only Command Line Tools selected and `xcrun --sdk iphonesimulator --show-sdk-path` cannot locate the simulator SDK.
- Real-LLM trajectories: N/A — this patch changes native keyboard, app-group, Xcode, and deep-link handoff plumbing only and does not change agent/action/provider/prompt/model behavior.
