### PR TITLE
fix(elizaos): surface plugin submit git config errors

### DIFF
--- a/.github/issue-evidence/12275-elizaos-plugins-git-config.md
+++ b/.github/issue-evidence/12275-elizaos-plugins-git-config.md
@@ -1,0 +1,72 @@
+# #12275 plugins submit git config evidence
+
+## Scope
+
+- Chunk for issue #12275.
+- `elizaos plugins submit` no longer treats git config read failures as missing repository metadata.
+- A missing `remote.origin.url` still falls through to the existing explicit repository-metadata error.
+- The actual CLI command now handles `plugins submit` errors at the command boundary with a concise stderr message and exit `1`.
+
+## Verification
+
+```bash
+bun run --cwd packages/elizaos test -- src/commands/plugins.test.ts
+```
+
+Result: passed, 1 file / 8 tests.
+
+```bash
+bun run --cwd packages/elizaos typecheck
+```
+
+Result: passed.
+
+```bash
+bun run --cwd packages/elizaos lint:check
+```
+
+Result: passed.
+
+```bash
+bun run --cwd packages/elizaos build
+```
+
+Result: passed.
+
+```bash
+bun run audit:error-policy-ratchet
+```
+
+Result: passed.
+
+```bash
+bun run verify
+```
+
+Result: failed in unrelated `@elizaos/ui#lint` diagnostics after 142 successful Turbo tasks. The first reported diagnostics were:
+
+```text
+packages/ui/src/cloud/shell/cloud-route-gate.test.tsx:28 lint/complexity/noUselessFragments
+packages/ui/src/api/desktop-local-agent-transport.ts:5 assist/source/organizeImports
+packages/ui/src/cloud/admin/admin-role.test.ts format
+```
+
+The verify run also surfaced additional unrelated UI formatting/hook diagnostics before Turbo stopped.
+
+## Built CLI Transcript
+
+This used the built `packages/elizaos/dist/cli.js` against a real temporary
+plugin package while `GIT_CONFIG_GLOBAL` pointed at malformed git config.
+
+```text
+$ NO_COLOR=1 GIT_CONFIG_GLOBAL=/var/folders/1g/77s889gx10n7mtl6z1nfrxzm0000gn/T/elizaos-plugin-submit-bad-config-SnJlMe/bad-git-config node /Users/shawwalters/.codex/worktrees/8855/eliza/packages/elizaos/dist/cli.js plugins submit /var/folders/1g/77s889gx10n7mtl6z1nfrxzm0000gn/T/elizaos-plugin-submit-bad-config-SnJlMe --dry-run
+Failed to read git remote.origin.url: fatal: bad config line 1 in file /var/folders/1g/77s889gx10n7mtl6z1nfrxzm0000gn/T/elizaos-plugin-submit-bad-config-SnJlMe/bad-git-config
+exit=1
+```
+
+## Evidence Matrix
+
+- Backend logs: N/A - CLI command boundary only; transcript includes the real git config failure path.
+- Frontend screenshots/video: N/A - no UI changes.
+- Real-LLM trajectories: N/A - no model, prompt, provider, action, or evaluator behavior changed.
+- Domain artifacts: N/A - no database, memory, wallet, scheduled task, generated file, or connector artifact changed.

--- a/packages/elizaos/src/commands/plugins.test.ts
+++ b/packages/elizaos/src/commands/plugins.test.ts
@@ -98,4 +98,42 @@ describe("submitPluginToRegistry", () => {
       }),
     ).rejects.toThrow(/Invalid registry repository/);
   });
+
+  it("reports missing repository metadata when git has no origin remote", async () => {
+    const dir = makePluginPackage({
+      name: "@acme/plugin-weather",
+      version: "1.0.0",
+      keywords: ["elizaos", "plugin"],
+    });
+
+    await expect(
+      submitPluginToRegistry(dir, { base: "main", dryRun: true }),
+    ).rejects.toThrow(
+      /Could not infer a GitHub repository\. Add repository\.url to package\.json\./,
+    );
+  });
+
+  it("surfaces corrupt git config when repository metadata must be inferred", async () => {
+    const dir = makePluginPackage({
+      name: "@acme/plugin-weather",
+      version: "1.0.0",
+      keywords: ["elizaos", "plugin"],
+    });
+    const badConfig = path.join(dir, "bad-git-config");
+    writeFileSync(badConfig, "[bad\n");
+    const previousConfig = process.env.GIT_CONFIG_GLOBAL;
+    process.env.GIT_CONFIG_GLOBAL = badConfig;
+
+    try {
+      await expect(
+        submitPluginToRegistry(dir, { base: "main", dryRun: true }),
+      ).rejects.toThrow(/Failed to read git remote\.origin\.url:/);
+    } finally {
+      if (previousConfig === undefined) {
+        delete process.env.GIT_CONFIG_GLOBAL;
+      } else {
+        process.env.GIT_CONFIG_GLOBAL = previousConfig;
+      }
+    }
+  });
 });

--- a/packages/elizaos/src/commands/plugins.ts
+++ b/packages/elizaos/src/commands/plugins.ts
@@ -68,7 +68,15 @@ export function registerPluginsCommand(program: Command): void {
     .option("--no-pr", "Create and push the branch but do not open a PR")
     .option("-y, --yes", "Skip confirmation prompts")
     .option("--skip-validation", "Skip npm and GitHub existence checks")
-    .action(submitPluginToRegistry);
+    .action(async (projectPath: string | undefined, options: SubmitOptions) => {
+      try {
+        await submitPluginToRegistry(projectPath, options);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(pc.red(message));
+        process.exit(1);
+      }
+    });
 }
 
 export async function submitPluginToRegistry(
@@ -280,15 +288,32 @@ function repositoryValue(repository: PackageJson["repository"]): string | null {
 }
 
 function inferGithubRepoFromGit(projectDir: string): string | null {
-  try {
-    const remote = capture("git", ["config", "--get", "remote.origin.url"], {
-      cwd: projectDir,
-      quiet: true,
-    });
+  const result = spawnSync("git", ["config", "--get", "remote.origin.url"], {
+    cwd: projectDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) {
+    throw new Error(
+      `Failed to read git remote.origin.url: ${result.error.message}`,
+    );
+  }
+  if (result.status === 0) {
+    const remote = result.stdout;
     return normalizeGithubRepo(remote);
-  } catch {
+  }
+
+  const output = `${result.stdout || ""}\n${result.stderr || ""}`.trim();
+  if (result.status === 1 && !output) {
     return null;
   }
+  throw new Error(
+    output
+      ? `Failed to read git remote.origin.url: ${output}`
+      : `git config --get remote.origin.url failed with status ${
+          result.status ?? "unknown"
+        }`,
+  );
 }
 
 function normalizeKind(


### PR DESCRIPTION
Part of #12275.

## Summary

- Keep the expected missing-git-remote path as ordinary missing repository metadata.
- Surface actual `git config --get remote.origin.url` failures instead of treating them as no repository.
- Make the `plugins submit` Commander boundary print a concise error and exit `1` instead of leaking an uncaught stack trace.

## Evidence

- `bun run --cwd packages/elizaos test -- src/commands/plugins.test.ts` passed, 1 file / 8 tests.
- `bun run --cwd packages/elizaos typecheck` passed.
- `bun run --cwd packages/elizaos lint:check` passed.
- `bun run --cwd packages/elizaos build` passed.
- `bun run audit:error-policy-ratchet` passed.
- Built CLI transcript captured in `.github/issue-evidence/12275-elizaos-plugins-git-config.md`: malformed `GIT_CONFIG_GLOBAL` makes `plugins submit --dry-run` print the git config error and exit `1` without a stack trace.

## Root Verify

`bun run verify` was attempted after `bun install` and failed in unrelated `@elizaos/ui#lint` diagnostics after 142 successful Turbo tasks. First reported diagnostics:

```text
packages/ui/src/cloud/shell/cloud-route-gate.test.tsx:28 lint/complexity/noUselessFragments
packages/ui/src/api/desktop-local-agent-transport.ts:5 assist/source/organizeImports
packages/ui/src/cloud/admin/admin-role.test.ts format
```

The verify run also reported additional unrelated UI formatting/hook diagnostics before Turbo stopped.

## Evidence Matrix

- Backend logs: N/A - CLI command boundary only; transcript includes the real git config failure path.
- Frontend screenshots/video: N/A - no UI changes.
- Real-LLM trajectories: N/A - no model, prompt, provider, action, or evaluator behavior changed.
- Domain artifacts: N/A - no database, memory, wallet, scheduled task, generated file, or connector artifact changed.
