### PR TITLE
fix(#12321): default HF catalog sync to elizaos

### DIFF
--- a/.github/issue-evidence/12216-stage4-hf-sync-org/README.md
+++ b/.github/issue-evidence/12216-stage4-hf-sync-org/README.md
@@ -1,0 +1,49 @@
+# Stage 4 HF catalog sync org evidence
+
+Issue: #12321
+PR: TBD
+
+## Scope
+
+This slice fixes the HF catalog sync slop item for
+`packages/training/scripts/sync_catalog_from_hf.py`.
+
+The script now defaults to the live Eliza-1 Hugging Face org, `elizaos`, and
+the usage examples/diff schema documentation no longer point operators at the
+stale `elizalabs` org.
+
+## Verification
+
+```bash
+python3 -m pytest packages/training/scripts/test_hf_publish.py -q -k 'sync_catalog'
+```
+
+Result:
+
+```text
+....                                                                     [100%]
+```
+
+```bash
+python3 -m py_compile \
+  packages/training/scripts/sync_catalog_from_hf.py \
+  packages/training/scripts/test_hf_publish.py
+```
+
+Result: exit 0.
+
+```bash
+grep -RIn "default: elizalabs\\|--org elizalabs\\|\\\"org\\\": \\\"elizalabs\\\"\\|under the elizalabs" \
+  packages/training/scripts/sync_catalog_from_hf.py \
+  packages/training/scripts/test_hf_publish.py \
+  packages/training/CLAUDE.md \
+  packages/training/AGENTS.md
+```
+
+Result: exit 0 with no matches.
+
+## Notes
+
+No live Hugging Face scan was needed for this slice; the regression test mocks
+collection and verifies the CLI default passed into `collect_entries` and
+`write_diff`.

--- a/packages/training/scripts/sync_catalog_from_hf.py
+++ b/packages/training/scripts/sync_catalog_from_hf.py
@@ -4,7 +4,7 @@ The local-inference catalog (`packages/app-core/src/services/local-inference/cat
 is the source of truth for which models the phone offers and where it
 downloads them from. This script:
 
-  1. Lists the Eliza-1 bundle repo under the elizalabs HF org.
+  1. Lists the Eliza-1 bundle repo under the elizaos HF org.
   2. Reads each `bundles/<tier>/eliza-1.manifest.json` plus legacy
      per-tier `eliza-1-*` manifests when present.
      and the GGUF metadata (via the `huggingface_hub` repo_info API;
@@ -19,7 +19,7 @@ schema is intentionally tiny:
     {
       "version": 1,
       "generatedAt": "<UTC ISO>",
-      "org": "elizalabs",
+      "org": "elizaos",
       "entries": [
         {
           "id": "eliza-1-2b",
@@ -40,12 +40,12 @@ Usage::
 
     # No HF_TOKEN required for public repos.
     uv run python scripts/sync_catalog_from_hf.py \\
-        --org elizalabs \\
+        --org elizaos \\
         --out reports/porting/2026-05-10/catalog-diff.json
 
     # Limit to a specific naming convention.
     uv run python scripts/sync_catalog_from_hf.py \\
-        --org elizalabs \\
+        --org elizaos \\
         --filter-prefix eliza-1- \\
         --out diff.json
 """
@@ -393,7 +393,7 @@ def write_diff(entries: list[CatalogEntry], out_path: Path, *, org: str) -> None
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     ap.add_argument(
-        "--org", default="elizalabs", help="HF org to scan (default: elizalabs)."
+        "--org", default="elizaos", help="HF org to scan (default: elizaos)."
     )
     ap.add_argument(
         "--filter-prefix",

--- a/packages/training/scripts/test_hf_publish.py
+++ b/packages/training/scripts/test_hf_publish.py
@@ -788,6 +788,31 @@ def test_sync_catalog_writes_diff(sync_catalog, tmp_path, monkeypatch):
     assert e["manifest"]["kind"] == "eliza-1-optimized"
 
 
+def test_sync_catalog_main_defaults_to_elizaos(sync_catalog, tmp_path, monkeypatch):
+    out = tmp_path / "diff.json"
+    calls: dict[str, object] = {}
+
+    def fake_collect_entries(**kwargs):
+        calls["collect"] = kwargs
+        return []
+
+    def fake_write_diff(entries, out_path, *, org):
+        calls["write"] = {"entries": entries, "out_path": out_path, "org": org}
+
+    monkeypatch.setattr(sync_catalog, "collect_entries", fake_collect_entries)
+    monkeypatch.setattr(sync_catalog, "write_diff", fake_write_diff)
+
+    rc = sync_catalog.main(["--out", str(out)])
+
+    assert rc == 0
+    assert calls["collect"] == {
+        "org": "elizaos",
+        "filter_prefix": "eliza-1-",
+        "filter_suffix": None,
+    }
+    assert calls["write"] == {"entries": [], "out_path": out, "org": "elizaos"}
+
+
 def test_sync_catalog_selects_manifest_text_file(sync_catalog):
     manifest = {
         "files": {


### PR DESCRIPTION
## Summary
- change `sync_catalog_from_hf.py --org` default from stale `elizalabs` to `elizaos`
- update the script docstring, sample JSON, and usage examples to match the live Eliza-1 HF org
- add a no-network regression test for the CLI default

## Evidence
- `python3 -m pytest packages/training/scripts/test_hf_publish.py -q -k 'sync_catalog'` -> 4 passed
- `python3 -m py_compile packages/training/scripts/sync_catalog_from_hf.py packages/training/scripts/test_hf_publish.py` -> exit 0
- stale string scan for `elizalabs` defaults/examples -> no matches
- `git diff --check origin/develop..HEAD` -> exit 0

Evidence file: `.github/issue-evidence/12216-stage4-hf-sync-org/README.md`

## N/A
- Live Hugging Face scan: not needed for the default/doc regression; test mocks `collect_entries` and `write_diff`.
- Screenshots/video: CLI-only training script change.

Fixes part of #12321.