### PR TITLE
docs(#12241): add homepage plumbing headers

### DIFF
--- a/packages/homepage/playwright.config.ts
+++ b/packages/homepage/playwright.config.ts
@@ -1,3 +1,6 @@
+/**
+ * Playwright configuration for the homepage route, visual, and recording suites.
+ */
 import path from "node:path";
 import { defineConfig, devices } from "playwright/test";
 

--- a/packages/homepage/scripts/run-playwright-web-server.mjs
+++ b/packages/homepage/scripts/run-playwright-web-server.mjs
@@ -1,3 +1,10 @@
+/**
+ * Playwright web-server launcher for homepage e2e tests.
+ *
+ * The script syncs shared public assets before starting Vite on the fixed
+ * homepage port so route and visual tests exercise the same static assets as
+ * local development.
+ */
 import { spawn, spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/homepage/src/App.tsx
+++ b/packages/homepage/src/App.tsx
@@ -1,3 +1,7 @@
+/**
+ * Client-side route table for the public homepage and authenticated onboarding
+ * surfaces.
+ */
 import { BRAND_COLORS } from "@elizaos/shared/brand";
 import { Loader2 } from "lucide-react";
 import { lazy, Suspense } from "react";

--- a/packages/homepage/src/components/authed-shell.tsx
+++ b/packages/homepage/src/components/authed-shell.tsx
@@ -1,3 +1,7 @@
+/**
+ * Authenticated route shell that installs query and session providers around
+ * nested homepage routes.
+ */
 import { Outlet } from "react-router-dom";
 import { QueryProvider } from "@/components/providers/query-provider";
 import { AuthProvider } from "@/lib/context/auth-context";

--- a/packages/homepage/src/components/providers/query-provider.tsx
+++ b/packages/homepage/src/components/providers/query-provider.tsx
@@ -1,3 +1,6 @@
+/**
+ * React Query provider that gives each homepage app mount its own client.
+ */
 import { QueryClientProvider } from "@tanstack/react-query";
 import { type ReactNode, useState } from "react";
 import { createQueryClient } from "@/lib/query-client";

--- a/packages/homepage/src/lib/api/client.ts
+++ b/packages/homepage/src/lib/api/client.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser fetch helpers for calling the Eliza Cloud API from the static
+ * homepage.
+ */
 const ELIZACLOUD_DEFAULT_URL = "https://www.elizacloud.ai";
 
 function getBaseUrl(): string {

--- a/packages/homepage/src/lib/contact.ts
+++ b/packages/homepage/src/lib/contact.ts
@@ -1,3 +1,6 @@
+/**
+ * Contact constants and link builders for homepage messaging entrypoints.
+ */
 export const ELIZA_PHONE_NUMBER = "+14159611510";
 export const ELIZA_PHONE_FORMATTED = "+1 (415) 961-1510";
 const IMESSAGE_GREETING = "Hey Eliza, what can you do?";

--- a/packages/homepage/src/lib/context/auth-context.tsx
+++ b/packages/homepage/src/lib/context/auth-context.tsx
@@ -1,3 +1,7 @@
+/**
+ * Homepage authentication context for Cloud-backed login, session persistence,
+ * and linked account state.
+ */
 import {
   createContext,
   type ReactNode,

--- a/packages/homepage/src/lib/hooks/use-eliza-app-provisioning-chat.ts
+++ b/packages/homepage/src/lib/hooks/use-eliza-app-provisioning-chat.ts
@@ -1,3 +1,9 @@
+/**
+ * React hook for the authenticated homepage provisioning chat.
+ *
+ * It supports both the current shared onboarding session API and the legacy
+ * provisioning-agent endpoint while exposing one chat-shaped client state.
+ */
 import { useCallback, useEffect, useRef, useState } from "react";
 import { elizacloudAuthFetch } from "@/lib/api/client";
 

--- a/packages/homepage/src/lib/query-client.ts
+++ b/packages/homepage/src/lib/query-client.ts
@@ -1,3 +1,6 @@
+/**
+ * TanStack Query client factory for homepage API state.
+ */
 import { QueryClient } from "@tanstack/react-query";
 
 const defaultOptions = {

--- a/packages/homepage/src/lib/spring-types.ts
+++ b/packages/homepage/src/lib/spring-types.ts
@@ -1,3 +1,7 @@
+/**
+ * Shared structural type for react-spring animated style objects in homepage
+ * components.
+ */
 export type SpringAnimatedStyle = Record<
   string,
   string | number | boolean | null | undefined | object

--- a/packages/homepage/src/lib/utils.ts
+++ b/packages/homepage/src/lib/utils.ts
@@ -1,3 +1,6 @@
+/**
+ * Tailwind class-name merger used by homepage components.
+ */
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 

--- a/packages/homepage/src/main.tsx
+++ b/packages/homepage/src/main.tsx
@@ -1,3 +1,6 @@
+/**
+ * Browser entrypoint for the homepage SPA.
+ */
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";

--- a/packages/homepage/src/providers/I18nProvider.tsx
+++ b/packages/homepage/src/providers/I18nProvider.tsx
@@ -1,3 +1,10 @@
+/**
+ * Minimal i18n provider for the elizaOS marketing homepage.
+ *
+ * English is inlined as `defaultValue` at every call site; non-English locales
+ * load lazily from `src/i18n/locales/*` while matching the hook contract used by
+ * shared UI packages.
+ */
 import { detectClientLanguage } from "@elizaos/ui/i18n/region";
 import {
   createContext,
@@ -7,17 +14,6 @@ import {
   useMemo,
   useState,
 } from "react";
-
-/**
- * Minimal i18n for the elizaOS marketing homepage. Mirrors the contract used by
- * other packages so call sites look identical:
- *
- *   const t = useT();
- *   t("homepage_eliza.hero.title", { defaultValue: "Your Eliza, everywhere." });
- *
- * English is inlined as `defaultValue` at every call site; non-English locales
- * load lazily from `src/i18n/locales/*`.
- */
 
 export const UI_LANGUAGES = [
   "en",

--- a/packages/homepage/src/types/speech-recognition.d.ts
+++ b/packages/homepage/src/types/speech-recognition.d.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser speech-recognition ambient declarations used by homepage voice
+ * controls.
+ */
 interface SpeechRecognitionEvent extends Event {
   readonly results: SpeechRecognitionResultList;
   readonly resultIndex: number;

--- a/packages/homepage/src/vite-env.d.ts
+++ b/packages/homepage/src/vite-env.d.ts
@@ -1,3 +1,6 @@
+/**
+ * Vite environment declarations for homepage browser configuration.
+ */
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {

--- a/packages/homepage/vite.config.ts
+++ b/packages/homepage/vite.config.ts
@@ -1,3 +1,9 @@
+/**
+ * Vite build configuration for the static homepage application.
+ *
+ * The aliases keep workspace UI imports pointed at source files so the homepage
+ * bundle avoids unrelated package barrels.
+ */
 import fs from "node:fs";
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";


### PR DESCRIPTION
## Summary
- Add required top-of-file prose headers to homepage config, entrypoint, provider, API/auth utility, hook, and type shim files.
- Move the existing homepage i18n module prose block to the required top-of-file position.
- Comment-only cleanup for #12241; no code or string literal behavior changed.

## Verification
- `bun run check:comment-only` PASS: 17 source files changed; every code token identical to `origin/develop`.
- `bun run --cwd packages/homepage test` PASS: 2 tests.
- `bunx @biomejs/biome check <17 touched files>` PASS.
- `git diff --check` PASS.
- First-line header audit for touched files PASS.
- `bun run --cwd packages/homepage typecheck` FAILS outside this change: `packages/ui/src/i18n/index.ts` and `packages/ui/src/i18n/messages.ts` import `normalizeLanguage`, `DEFAULT_UI_LANGUAGE`, `UI_LANGUAGES`, and `UiLanguage` from `@elizaos/shared`, but the current local workspace resolution does not export those members.

## Evidence
- Screenshots/video: N/A - comment-only header cleanup; `check:comment-only` proves runtime tokens are unchanged.
- Backend/frontend logs: N/A - no executable behavior changed.
- Real-LLM trajectories: N/A - no agent, prompt, model, provider, or evaluator behavior changed.
