### PR TITLE
refactor(scripts): migrate duplicated workspace walkers to shared seam (#12333)

### DIFF
--- a/.github/issue-evidence/12333-migrate-walkers-to-seam.md
+++ b/.github/issue-evidence/12333-migrate-walkers-to-seam.md
@@ -1,0 +1,220 @@
+# #12333 — Migrate duplicated workspace walkers to the shared seam
+
+Behavior-preserving migration of duplicated workspace/package glob walkers onto
+`packages/scripts/lib/workspaces.mjs` (`expandWorkspaceGlobs`, `listWorkspaceDirs`,
+`listPackages`), plus the 5 copy-pasted `findWorkspaceRoot` helpers folded into
+`packages/scripts/lib/repo-root.mjs`.
+
+Each migration is proven identical by capturing the pre-migration walker's output
+and the post-migration seam output and diffing them (order-insensitive where the
+caller doesn't depend on order). The one intended behavior change —
+`fix-workspace-deps` no longer scanning the excluded `packages/feed` monorepo —
+is proven to be the ONLY difference for that file.
+
+N/A for UI screenshots, model trajectories, audio, and domain artifacts
+(script-layer refactor).
+
+---
+
+## Seam bug fixed first (prerequisite)
+
+`expandPositiveGlob` applied the hidden/build-dir skip only inside `**`
+(`walkDirs`); an explicit `*` segment enumerated every child, so a build-output
+dir that carries a `package.json` marker leaked in as a "workspace" — concretely
+`packages/examples/cloud/clone-ur-crush/.next` (a Next.js `{"type":"commonjs"}`
+marker), which bun install itself ignores.
+
+Fix: extract `isTraversableChild(name)` and apply it uniformly to `*`, `**`, and
+the recursive walk. Added a regression test.
+
+```
+# live-repo leak check, before vs after the seam fix
+BEFORE: TOTAL workspace dirs: 280   LEAKED hidden/build dirs (1): packages/examples/cloud/clone-ur-crush/.next
+AFTER:  TOTAL workspace dirs: 279   LEAKED hidden/build dirs (0):
+```
+
+Seam tests (incl. the new `*`-skip case): `16 pass, 0 fail`.
+
+---
+
+## 1. `fix-workspace-deps.mjs` — the negation-ignoring walker (documented fix)
+
+Local `expandPattern`/`collectWorkspaceDirs` treated a leading `!` as a literal
+path segment that never matched, so `!packages/feed` was ignored and
+`packages/feed` (+ its whole nested monorepo) was scanned via `packages/*`.
+Migrated to `listWorkspaceDirs` (which honors negation); caller keeps its local
+"always include the repo root" policy.
+
+Enumeration dir-set diff (before = local walker, after = seam + root):
+
+```
+81d80
+< packages/feed
+```
+
+Exactly one line removed — the excluded feed root. The `packages/feed/packages/*`,
+`packages/feed/apps/*`, `packages/feed/tools/*` members stay (they are positive
+workspace patterns = bun install truth).
+
+`--check` output: scan count `281 -> 280` (feed root no longer scanned; it had no
+dep issues), and the reported issue SET is byte-for-byte identical
+(order-insensitive):
+
+```
+=== issue lines only, sorted, diff ===
+(empty — ISSUE SET IDENTICAL)
+```
+
+---
+
+## 2. `turbo-cache-key.mjs`
+
+Local `workspaceGlobToRegExp`/`expandWorkspaceGlob`/`listWorkspaceDirs` replaced
+with the seam. The exported `listWorkspaceDirs` keeps its longest-path-first sort
+(load-bearing for `owningWorkspace`, which must attribute a file to its
+most-specific enclosing workspace).
+
+```
+turbo-cache-key listWorkspaceDirs before=279 after=279
+diff before after -> IDENTICAL (order-sensitive, longest-first)
+```
+
+Tests: `turbo-cache-key.test.ts` 5 pass, 0 fail.
+
+(Note: a full `turbo-cache-key --list`/`--json` run is slow in this large
+worktree because its unrelated `listGitFiles` hits `spawnSync`'s 1 MB `maxBuffer`
+on `git ls-files -z` and falls back to a full FS walk — a pre-existing issue in
+`listGitFiles`, not touched by this migration. The migration touches only
+`listWorkspaceDirs`, whose output is proven identical above.)
+
+---
+
+## 3. `run-examples-benchmarks.mjs`
+
+Local regex matcher + recursive `collectPackageJsons` + `isWorkspaceMember`
+replaced with `listPackages`, scoped locally to `packages/examples` /
+`packages/benchmarks` and filtered by "declares the requested script".
+
+Discovered package set, before vs after, per script name:
+
+```
+lint:      before=47  after=47  IDENTICAL SET
+typecheck: before=53  after=53  IDENTICAL SET
+build:     before=47  after=47  IDENTICAL SET
+```
+
+---
+
+## 4. `generate-dist-paths-config.mjs`
+
+Local `workspacePatternToRegExp` include/exclude matcher +
+`childWorkspaceDirs`/`expandWorkspacePattern`/`workspacePackageManifests` replaced
+with `listWorkspaceDirs`; the redundant `matchesWorkspace` re-check in
+`packageAliases` dropped (every manifest now comes from the seam).
+
+Manifest set: `before=279 after=279`, IDENTICAL. Strongest proof — the generated
+`tsconfig.dist-paths.json` is byte-for-byte identical when produced by the
+original vs migrated walker:
+
+```
+diff gdpc-out-original.json gdpc-out-migrated.json
+GENERATED CONFIG BYTE-IDENTICAL   (204 path aliases)
+```
+
+(Pre-existing note: `--check` reports the committed `tsconfig.dist-paths.json` as
+stale on current `develop` because packages were added after it was last
+committed — the ORIGINAL generator reports the same staleness, so it is not a
+regression from this migration and is out of scope for #12333.)
+
+---
+
+## 5. `audit-turbo-build-deps.mjs`
+
+Local `expandGlob` + `buildWorkspaceMap` replaced with `listPackages`
+(name -> absolute dir). `readdirSync`/`statSync` remain for the source scan.
+
+```
+name->dir map before=279 after=279  IDENTICAL
+audit output before vs after -> IDENTICAL  ("✓ no phantom #build dependency edges", exit 0)
+```
+
+---
+
+## 6. `run-all-tests.mjs`
+
+Local `expandWorkspacePattern` + `collectPackageJsonPaths` replaced with the
+seam. The deliberate **whole-subtree** exclusion of every `!`-negated root
+(feed's nested members can't resolve under a plain root install and belong to
+feed's own CI lane) stays a **caller-local policy filter**, computed from
+`expandWorkspaceGlobs([negated])` and applied prefix-wise over the seam output.
+`ADDITIONAL_PACKAGE_DIRS` unchanged.
+
+Package set: `before=254 after=254`, IDENTICAL (0 under `packages/feed`, as before).
+Full `run-all-tests --plan=text` output is byte-for-byte identical for both lanes:
+
+```
+lane=pr:          PLAN IDENTICAL   (266 tasks, 241 packages, parallel-safe=238 serial=28)
+lane=post-merge:  PLAN IDENTICAL
+```
+
+---
+
+## 7. `findWorkspaceRoot` x5 -> `lib/repo-root.mjs`
+
+The five identical walk-up-to-`workspaces` helpers in
+`ensure-tsc-nested-output-dir`, `flatten-tsc-package-output`,
+`rewrite-dist-relative-imports-node-esm`, `verify-package-runtime-exports`, and
+`with-package-build-lock` folded into one exported `findWorkspaceRoot(startDir)`
+(sync). All callers pass `process.cwd()`, for which the fallback is identical to
+the old `process.cwd()` literal.
+
+```
+findWorkspaceRoot(cwd) -> /…/<repo root>   (correct)
+verify-package-runtime-exports packages/logger:   original and migrated both print the
+  same "1 missing runtime export ./dist/index.js" and exit 1
+```
+
+---
+
+## Deferred (NOT migrated — different query, not a seam duplicate)
+
+Each was inspected and left in place with a proven reason:
+
+- **`ensure-workspace-symlinks.mjs`** — hardcoded `WORKSPACE_DIRS` walked to
+  depth 3 over arbitrary roots (not the `workspaces` globs). The seam's member
+  set differs: it would STOP linking 7 `packages/benchmarks/*` packages (the
+  hardcoded walk catches them via a depth-3 `packages` sweep; the globs list only
+  specific benchmark subdirs) and newly link 15 others. That is a behavior change
+  with a regression risk, not a behavior-preserving swap. `before(@elizaos)=231
+  after=239`, 7 only-in-before. Deferred.
+- **`prepare-package-dist.mjs`** — `collectWorkspaceVersions` is an **unbounded**
+  recursive walk of `packages/` + `plugins/` that intentionally collects nested,
+  non-workspace `package.json`s (e.g. `plugins/plugin-sql/src/package.json`) for
+  publish-time version resolution. `before COUNT=303` vs seam `274`. Different
+  query. Deferred.
+- **`replace-workspace-versions.js`** — reads globs from **`lerna.json`**
+  (`packages`), a deliberately narrower publish set, not the root `workspaces`.
+  Different source of truth. Deferred.
+- **`ensure-native-plugins-linked.mjs`** — single-dir `readdirSync` prefix scan
+  of `packages/native/plugins` for `plugin-native-*` (a plugin subset over a
+  non-workspace dir), not a workspace-glob walker. Deferred.
+- **`scripts/testing-coverage-matrix.mjs`** — derives package dirs from
+  `git ls-files` (every dir with a `package.json`, by design), not from the
+  `workspaces` globs. It only reads the negations as a small "in-CI" stat helper.
+  No `listWorkspaceDirs`-shaped duplicate. Deferred.
+
+---
+
+## Verification summary
+
+```
+bun test packages/scripts/__tests__/workspaces-lib.test.ts packages/scripts/__tests__/turbo-cache-key.test.ts
+  21 pass, 0 fail
+
+node packages/scripts/audit-turbo-build-deps.mjs            -> ✓ exit 0
+node packages/scripts/run-all-tests.mjs --plan=text --no-cloud  -> byte-identical to original
+node packages/scripts/run-examples-benchmarks.mjs <script>  -> identical discovery set
+node packages/scripts/fix-workspace-deps.mjs --check        -> issue set identical (feed root excluded)
+generate-dist-paths-config: generated config byte-identical (original vs migrated)
+findWorkspaceRoot: resolves the repo root; migrated scripts behave identically
+```

--- a/packages/scripts/__tests__/workspaces-lib.test.ts
+++ b/packages/scripts/__tests__/workspaces-lib.test.ts
@@ -97,6 +97,22 @@ describe("expandWorkspaceGlobs — glob semantics", () => {
     ]);
   });
 
+  test("`*` skips hidden and build-output dirs (e.g. a stray `.next` marker)", () => {
+    const root = makeRepo();
+    fs.mkdirSync(path.join(root, "examples/real"), { recursive: true });
+    // A Next.js build dir carries a `{"type":"commonjs"}` package.json marker;
+    // it is not a workspace member and must not be matched by a `*` segment.
+    fs.mkdirSync(path.join(root, "examples/real/.next"), { recursive: true });
+    fs.mkdirSync(path.join(root, "examples/real/dist"), { recursive: true });
+
+    expect(expandWorkspaceGlobs(["examples/*"], { repoRoot: root })).toEqual([
+      "examples/real",
+    ]);
+    expect(expandWorkspaceGlobs(["examples/*/*"], { repoRoot: root })).toEqual(
+      [],
+    );
+  });
+
   test("negation subtracts an earlier match (exclude-wins)", () => {
     const root = makeRepo();
     fs.mkdirSync(path.join(root, "packages/keep"), { recursive: true });

--- a/packages/scripts/audit-turbo-build-deps.mjs
+++ b/packages/scripts/audit-turbo-build-deps.mjs
@@ -27,6 +27,7 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { listPackages } from "./lib/workspaces.mjs";
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -38,57 +39,15 @@ function readJson(p) {
   return JSON.parse(readFileSync(p, "utf8"));
 }
 
-/** Expand a workspace glob (only whole-segment `*` wildcards) to real dirs. */
-function expandGlob(pattern) {
-  let dirs = [repoRoot];
-  for (const part of pattern.split("/")) {
-    const next = [];
-    for (const d of dirs) {
-      if (part === "*") {
-        let ents;
-        try {
-          ents = readdirSync(d, { withFileTypes: true });
-        } catch {
-          continue;
-        }
-        for (const e of ents)
-          if (e.isDirectory()) next.push(path.join(d, e.name));
-      } else {
-        const p = path.join(d, part);
-        try {
-          if (statSync(p).isDirectory()) next.push(p);
-        } catch {}
-      }
-    }
-    dirs = next;
-  }
-  return dirs;
-}
-
 /**
- * Map every workspace package name → its directory by expanding the root
- * `workspaces` globs. Resolves against THIS repo (not node_modules, which in a
- * worktree may symlink elsewhere) and handles nested workspaces like
- * `packages/app-core/platforms/*`.
+ * Map every named workspace package → its absolute directory in THIS repo (not
+ * node_modules, which in a worktree may symlink elsewhere). Discovery is the
+ * shared seam; unnamed private packages carry no `#build` override to audit.
  */
 function buildWorkspaceMap() {
-  const root = readJson(path.join(repoRoot, "package.json"));
-  const globs = root.workspaces ?? [];
-  const excludes = new Set(
-    globs
-      .filter((g) => g.startsWith("!"))
-      .map((g) => path.join(repoRoot, g.slice(1))),
-  );
   const map = new Map();
-  for (const g of globs) {
-    if (g.startsWith("!")) continue;
-    for (const dir of expandGlob(g)) {
-      if (excludes.has(dir)) continue;
-      try {
-        const pkg = readJson(path.join(dir, "package.json"));
-        if (pkg.name) map.set(pkg.name, dir);
-      } catch {}
-    }
+  for (const pkg of listPackages({ repoRoot })) {
+    if (pkg.name) map.set(pkg.name, path.join(repoRoot, pkg.dir));
   }
   return map;
 }

--- a/packages/scripts/ensure-tsc-nested-output-dir.mjs
+++ b/packages/scripts/ensure-tsc-nested-output-dir.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from "node:fs/promises";
 import path from "node:path";
+import { findWorkspaceRoot } from "./lib/repo-root.mjs";
 
 const packageDirArg = process.argv[2];
 if (!packageDirArg) {
@@ -10,23 +11,7 @@ if (!packageDirArg) {
   process.exit(1);
 }
 
-async function findWorkspaceRoot(startDir) {
-  let current = path.resolve(startDir);
-  while (true) {
-    try {
-      const raw = await fs.readFile(path.join(current, "package.json"), "utf8");
-      const parsed = JSON.parse(raw);
-      if (parsed?.workspaces) return current;
-    } catch {
-      // keep walking
-    }
-    const parent = path.dirname(current);
-    if (parent === current) return process.cwd();
-    current = parent;
-  }
-}
-
-const root = await findWorkspaceRoot(process.cwd());
+const root = findWorkspaceRoot(process.cwd());
 const packageDir = path.resolve(root, packageDirArg);
 const relPackageDir = path.relative(root, packageDir);
 

--- a/packages/scripts/fix-workspace-deps.mjs
+++ b/packages/scripts/fix-workspace-deps.mjs
@@ -32,14 +32,9 @@
  */
 
 import { execFileSync } from "node:child_process";
-import {
-  existsSync,
-  readdirSync,
-  readFileSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
+import { listWorkspaceDirs } from "./lib/workspaces.mjs";
 
 // ── Config ──────────────────────────────────────────────────────────────────
 
@@ -59,76 +54,17 @@ function getRestoreRef() {
 
 const DEP_SECTIONS = ["dependencies", "devDependencies", "peerDependencies"];
 
-// ── Glob expansion ──────────────────────────────────────────────────────────
-
-/**
- * Expand a single workspace pattern (e.g. "plugins/plugin-*")
- * into a list of directories that actually exist and contain a package.json.
- */
-function expandPattern(pattern) {
-  const dirs = [];
-  const parts = pattern.split("/");
-
-  function walk(base, partIndex) {
-    if (partIndex >= parts.length) {
-      if (existsSync(join(base, "package.json"))) {
-        dirs.push(base);
-      }
-      return;
-    }
-
-    const segment = parts[partIndex];
-
-    if (segment.includes("*")) {
-      // Glob segment — list the directory and match
-      if (!existsSync(base) || !statSync(base).isDirectory()) return;
-      const regex = new RegExp(
-        "^" + segment.replace(/\*/g, ".*").replace(/\?/g, ".") + "$",
-      );
-      for (const entry of readdirSync(base)) {
-        // Never walk into node_modules, dist, or hidden directories
-        if (
-          entry === "node_modules" ||
-          entry === "dist" ||
-          entry.startsWith(".")
-        )
-          continue;
-        if (regex.test(entry)) {
-          const full = join(base, entry);
-          if (statSync(full).isDirectory()) {
-            walk(full, partIndex + 1);
-          }
-        }
-      }
-    } else {
-      // Literal segment — but still skip node_modules
-      if (segment === "node_modules") return;
-      walk(join(base, segment), partIndex + 1);
-    }
-  }
-
-  walk(ROOT, 0);
-  return dirs;
-}
-
 // ── Main ────────────────────────────────────────────────────────────────────
 
-const rootPkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
-const patterns = rootPkg.workspaces || [];
-
-// 1. Discover all workspace directories and package names (dedup overlapping globs)
-function collectWorkspaceDirs(patterns) {
-  const dirs = new Set();
-  for (const pattern of patterns) {
-    for (const dir of expandPattern(pattern)) {
-      dirs.add(dir);
-    }
-  }
-  dirs.add(ROOT); // Always include the root itself
-  return Array.from(dirs);
-}
-
-const workspaceDirs = collectWorkspaceDirs(patterns);
+// Every workspace member's directory, plus the repo root itself — the root
+// manifest carries workspace-dep references too. Discovery honors the root
+// `workspaces` negations (e.g. `!packages/feed`), so the excluded feed monorepo
+// is no longer scanned; the previous local walker ignored negation and leaked
+// `packages/feed` in via `packages/*`.
+const workspaceDirs = [
+  ROOT,
+  ...listWorkspaceDirs({ repoRoot: ROOT }).map((dir) => join(ROOT, dir)),
+];
 
 const nameToDir = new Map(); // package name -> directory
 for (const dir of workspaceDirs) {

--- a/packages/scripts/flatten-tsc-package-output.mjs
+++ b/packages/scripts/flatten-tsc-package-output.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { promisify } from "node:util";
+import { findWorkspaceRoot } from "./lib/repo-root.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -15,23 +16,7 @@ if (!packageDirArg) {
   process.exit(1);
 }
 
-async function findWorkspaceRoot(startDir) {
-  let current = path.resolve(startDir);
-  while (true) {
-    try {
-      const raw = await fs.readFile(path.join(current, "package.json"), "utf8");
-      const parsed = JSON.parse(raw);
-      if (parsed?.workspaces) return current;
-    } catch {
-      // keep walking
-    }
-    const parent = path.dirname(current);
-    if (parent === current) return process.cwd();
-    current = parent;
-  }
-}
-
-const root = await findWorkspaceRoot(process.cwd());
+const root = findWorkspaceRoot(process.cwd());
 const packageDir = path.resolve(root, packageDirArg);
 const relPackageDir = path.relative(root, packageDir).split(path.sep).join("/");
 const distDir = path.join(packageDir, "dist");

--- a/packages/scripts/generate-dist-paths-config.mjs
+++ b/packages/scripts/generate-dist-paths-config.mjs
@@ -1,13 +1,8 @@
 #!/usr/bin/env node
-import {
-  existsSync,
-  lstatSync,
-  readdirSync,
-  readFileSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { listWorkspaceDirs } from "./lib/workspaces.mjs";
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -16,18 +11,6 @@ const repoRoot = path.resolve(
 );
 const outPath = path.join(repoRoot, "tsconfig.dist-paths.json");
 const checkOnly = process.argv.includes("--check");
-
-const ignoredDirs = new Set([
-  ".git",
-  ".next",
-  ".turbo",
-  ".venv",
-  "build",
-  "coverage",
-  "dist",
-  "node_modules",
-  "vendor",
-]);
 
 const explicitAliases = new Map([
   ["@elizaos/agent/*", ["./packages/agent/dist/*.d.ts"]],
@@ -70,96 +53,13 @@ function toPosix(value) {
   return value.split(path.sep).join("/");
 }
 
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function workspacePatternToRegExp(pattern) {
-  const source = pattern
-    .split("/")
-    .map((segment) => (segment === "*" ? "[^/]+" : escapeRegExp(segment)))
-    .join("/");
-  return new RegExp(`^${source}$`);
-}
-
-const rootPackage = readJson(path.join(repoRoot, "package.json"));
-const workspacePatterns = (rootPackage.workspaces ?? []).filter(
-  (entry) => typeof entry === "string",
-);
-const workspaceIncludes = workspacePatterns
-  .filter((pattern) => !pattern.startsWith("!"))
-  .map(workspacePatternToRegExp);
-const workspaceExcludes = workspacePatterns
-  .filter((pattern) => pattern.startsWith("!"))
-  .map((pattern) => workspacePatternToRegExp(pattern.slice(1)));
-
-function matchesWorkspace(relDir) {
-  return (
-    workspaceIncludes.some((pattern) => pattern.test(relDir)) &&
-    !workspaceExcludes.some((pattern) => pattern.test(relDir))
-  );
-}
-
-function childWorkspaceDirs(baseDir, baseRel) {
-  let entries;
-  try {
-    entries = readdirSync(baseDir, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-  const dirs = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory() || ignoredDirs.has(entry.name)) continue;
-    const fullPath = path.join(baseDir, entry.name);
-    let stat;
-    try {
-      stat = lstatSync(fullPath);
-    } catch {
-      continue;
-    }
-    if (stat.isSymbolicLink()) continue;
-    dirs.push({
-      abs: fullPath,
-      rel: baseRel ? `${baseRel}/${entry.name}` : entry.name,
-    });
-  }
-  return dirs;
-}
-
-function expandWorkspacePattern(pattern) {
-  let dirs = [{ abs: repoRoot, rel: "" }];
-  for (const segment of pattern.split("/")) {
-    const next = [];
-    for (const dir of dirs) {
-      if (segment === "*") {
-        next.push(...childWorkspaceDirs(dir.abs, dir.rel));
-        continue;
-      }
-      const abs = path.join(dir.abs, segment);
-      if (!existsSync(abs)) continue;
-      next.push({
-        abs,
-        rel: dir.rel ? `${dir.rel}/${segment}` : segment,
-      });
-    }
-    dirs = next;
-  }
-  return dirs;
-}
-
+// Absolute package.json paths of every workspace member, sorted. Discovery is
+// the shared seam (root `workspaces` globs, negation applied, members carry a
+// package.json).
 function workspacePackageManifests() {
-  const manifests = new Set();
-  for (const pattern of workspacePatterns) {
-    if (pattern.startsWith("!")) continue;
-    for (const dir of expandWorkspacePattern(pattern)) {
-      if (!matchesWorkspace(dir.rel)) continue;
-      const manifestPath = path.join(dir.abs, "package.json");
-      if (existsSync(manifestPath)) {
-        manifests.add(manifestPath);
-      }
-    }
-  }
-  return [...manifests].sort((left, right) => left.localeCompare(right));
+  return listWorkspaceDirs({ repoRoot })
+    .map((relDir) => path.join(repoRoot, relDir, "package.json"))
+    .sort((left, right) => left.localeCompare(right));
 }
 
 function findTypes(exportValue) {
@@ -204,8 +104,6 @@ function aliasTarget(packageDir, typesPath) {
 
 function packageAliases(manifestPath) {
   const packageDir = path.dirname(manifestPath);
-  const relDir = toPosix(path.relative(repoRoot, packageDir));
-  if (!matchesWorkspace(relDir)) return [];
 
   const pkg = readJson(manifestPath);
   if (!pkg.name) return [];

--- a/packages/scripts/lib/repo-root.d.ts
+++ b/packages/scripts/lib/repo-root.d.ts
@@ -3,3 +3,4 @@ export declare function resolveRepoRoot(
   importMetaUrl: string,
   depth?: number,
 ): string;
+export declare function findWorkspaceRoot(startDir: string): string;

--- a/packages/scripts/lib/repo-root.mjs
+++ b/packages/scripts/lib/repo-root.mjs
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -10,4 +11,28 @@ export function resolveRepoRoot(importMetaUrl, depth = 1) {
     getModuleDir(importMetaUrl),
     ...Array.from({ length: depth }, () => ".."),
   );
+}
+
+/**
+ * Walk up from `startDir` and return the first directory whose package.json
+ * declares a `workspaces` key (the monorepo root). Falls back to `startDir`
+ * (resolved) when no such manifest is found before the filesystem root — this
+ * is the runtime-invariant root finder scripts use when their cwd is arbitrary
+ * (postinstall, per-package build steps).
+ */
+export function findWorkspaceRoot(startDir) {
+  let current = path.resolve(startDir);
+  while (true) {
+    try {
+      const parsed = JSON.parse(
+        readFileSync(path.join(current, "package.json"), "utf8"),
+      );
+      if (parsed?.workspaces) return current;
+    } catch {
+      // error-policy:J3 no/invalid manifest here — keep walking up
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return path.resolve(startDir);
+    current = parent;
+  }
 }

--- a/packages/scripts/lib/workspaces.mjs
+++ b/packages/scripts/lib/workspaces.mjs
@@ -72,6 +72,29 @@ function workspaceGlobToRegExp(glob) {
   return new RegExp(`^${pattern}$`);
 }
 
+// Hidden and heavy build/vendor dir names that are never workspace members and
+// never worth descending into. Bun/npm workspace resolution likewise ignores
+// dotfile dirs, and these build outputs (e.g. a Next.js `.next/package.json`
+// marker) are not real packages — so a `*` segment must skip them just as a
+// `**` walk does, or a stray `.next` gets matched as a workspace.
+const WALK_SKIP_DIRS = new Set([
+  ".git",
+  ".next",
+  ".turbo",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "storybook-static",
+]);
+
+// A directory child is traversable/matchable as a workspace only if it is not
+// hidden and not a build/vendor dir. Applied uniformly to `*` and `**` so both
+// segment kinds agree on membership.
+function isTraversableChild(name) {
+  return !name.startsWith(".") && !WALK_SKIP_DIRS.has(name);
+}
+
 // Walk the tree expanding one positive glob into concrete directories. A `*`
 // segment enumerates children; a `**` segment matches this directory and every
 // descendant directory; a literal segment descends by name.
@@ -89,7 +112,9 @@ function expandPositiveGlob(repoRoot, pattern) {
       }
       if (part === "*") {
         for (const entry of readDirEntries(dir)) {
-          if (entry.isDirectory()) next.push(path.join(dir, entry.name));
+          if (entry.isDirectory() && isTraversableChild(entry.name)) {
+            next.push(path.join(dir, entry.name));
+          }
         }
         continue;
       }
@@ -116,23 +141,11 @@ function readDirEntries(dir) {
 
 // Depth-first directory list rooted at `start` (inclusive), skipping hidden and
 // heavy build/vendor dirs so `**` expansion stays bounded and deterministic.
-const WALK_SKIP_DIRS = new Set([
-  ".git",
-  ".next",
-  ".turbo",
-  "build",
-  "coverage",
-  "dist",
-  "node_modules",
-  "storybook-static",
-]);
-
 function walkDirs(start) {
   const out = [start];
   for (const entry of readDirEntries(start)) {
     if (!entry.isDirectory()) continue;
-    if (entry.name.startsWith(".")) continue;
-    if (WALK_SKIP_DIRS.has(entry.name)) continue;
+    if (!isTraversableChild(entry.name)) continue;
     out.push(...walkDirs(path.join(start, entry.name)));
   }
   return out;

--- a/packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+++ b/packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
@@ -1,28 +1,9 @@
 #!/usr/bin/env node
 import { readdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { findWorkspaceRoot } from "./lib/repo-root.mjs";
 
-async function findWorkspaceRoot(startDir) {
-  let current = path.resolve(startDir);
-  while (true) {
-    try {
-      const raw = await readFile(path.join(current, "package.json"), "utf8");
-      const parsed = JSON.parse(raw);
-      if (parsed?.workspaces) {
-        return current;
-      }
-    } catch {
-      // keep walking
-    }
-    const parent = path.dirname(current);
-    if (parent === current) {
-      return process.cwd();
-    }
-    current = parent;
-  }
-}
-
-const workspaceRoot = await findWorkspaceRoot(process.cwd());
+const workspaceRoot = findWorkspaceRoot(process.cwd());
 const packageDir = process.argv[2]
   ? path.resolve(workspaceRoot, process.argv[2])
   : process.cwd();

--- a/packages/scripts/run-all-tests.mjs
+++ b/packages/scripts/run-all-tests.mjs
@@ -90,6 +90,10 @@ import {
   runPool,
   taskBelongsToShard,
 } from "./lib/test-task-pool.mjs";
+import {
+  expandWorkspaceGlobs,
+  listWorkspaceDirs,
+} from "./lib/workspaces.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..", "..");
@@ -368,88 +372,40 @@ const POSTGRES_INIT_SQL_PATH = path.join(
 );
 
 // ---------------------------------------------------------------------------
-// Workspace discovery (unchanged from original)
+// Workspace discovery
 // ---------------------------------------------------------------------------
 
-function expandWorkspacePattern(pattern) {
-  const segments = pattern.split("/").filter(Boolean);
-  let currentPaths = [repoRoot];
-
-  for (const segment of segments) {
-    const nextPaths = [];
-    for (const currentPath of currentPaths) {
-      if (segment === "*") {
-        if (!fs.existsSync(currentPath)) {
-          continue;
-        }
-        const entries = fs
-          .readdirSync(currentPath, { withFileTypes: true })
-          .filter((entry) => entry.isDirectory())
-          .sort((left, right) => left.name.localeCompare(right.name));
-        for (const entry of entries) {
-          nextPaths.push(path.join(currentPath, entry.name));
-        }
-        continue;
-      }
-      nextPaths.push(path.join(currentPath, segment));
-    }
-    currentPaths = nextPaths;
-  }
-
-  return currentPaths;
-}
-
 function collectPackageJsonPaths() {
+  // Whole-subtree exclusion of every `!`-negated workspace root. bun/npm/yarn
+  // exclude only the exact negated dir (so `packages/feed/packages/*` stay
+  // members), but the test lane must additionally drop feed's nested members:
+  // their tests need feed's own install/environment (its postinstall pulls
+  // python + agent-framework deps, and shared deps like drizzle-orm live in the
+  // excluded `@feed/root`), so they can't resolve under a plain root install and
+  // structurally belong to feed's own CI lane. Membership itself is the shared
+  // seam; this whole-subtree policy is a caller-local filter over its output.
   const rootPackageJson = JSON.parse(
     fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"),
   );
-  const packageJsonPaths = new Set();
-
-  // Honor `!`-negated workspace patterns the same way bun/npm/yarn do: a
-  // negated dir is NOT a workspace member even if an earlier glob matched it
-  // (e.g. `packages/*` + `!packages/feed` keeps the nested feed monorepo root
-  // out — it has its own install/CI and its `test` runs the full feed suite).
-  //
-  // The exclusion covers the WHOLE excluded subtree, not just the literal dir:
-  // the root workspace also lists `packages/feed/packages/*` (so feed's
-  // sub-packages build alongside the rest), but those tests require feed's own
-  // install/environment (its postinstall pulls python + agent-framework deps,
-  // and shared deps like drizzle-orm live in the excluded `@feed/root`). They
-  // can't resolve under a plain root install, so honoring `!packages/feed` for
-  // the nested children keeps the full root `bun run test` from running tests
-  // that structurally belong to feed's own CI lane.
   const patterns = rootPackageJson.workspaces ?? [];
-  const excludedDirs = new Set();
-  for (const pattern of patterns) {
-    if (!pattern.startsWith("!")) {
-      continue;
-    }
-    for (const packageDir of expandWorkspacePattern(pattern.slice(1))) {
-      excludedDirs.add(packageDir);
-    }
-  }
-  const isExcluded = (packageDir) => {
-    for (const excluded of excludedDirs) {
-      if (packageDir === excluded || packageDir.startsWith(`${excluded}/`)) {
-        return true;
-      }
+  const excludedRoots = new Set(
+    patterns
+      .filter((pattern) => pattern.startsWith("!"))
+      .flatMap((pattern) =>
+        expandWorkspaceGlobs([pattern.slice(1)], { repoRoot }),
+      ),
+  );
+  const inExcludedSubtree = (relDir) => {
+    for (const excluded of excludedRoots) {
+      if (relDir === excluded || relDir.startsWith(`${excluded}/`)) return true;
     }
     return false;
   };
 
-  for (const pattern of patterns) {
-    if (pattern.startsWith("!")) {
-      continue;
-    }
-    for (const packageDir of expandWorkspacePattern(pattern)) {
-      if (isExcluded(packageDir)) {
-        continue;
-      }
-      const packageJsonPath = path.join(packageDir, "package.json");
-      if (fs.existsSync(packageJsonPath)) {
-        packageJsonPaths.add(packageJsonPath);
-      }
-    }
+  const packageJsonPaths = new Set();
+  for (const relDir of listWorkspaceDirs({ repoRoot })) {
+    if (inExcludedSubtree(relDir)) continue;
+    packageJsonPaths.add(path.join(repoRoot, relDir, "package.json"));
   }
 
   for (const packageDir of ADDITIONAL_PACKAGE_DIRS) {

--- a/packages/scripts/run-examples-benchmarks.mjs
+++ b/packages/scripts/run-examples-benchmarks.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { existsSync, lstatSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
+import { listPackages } from "./lib/workspaces.mjs";
 
 const scriptName = process.argv[2];
 if (!scriptName) {
@@ -14,110 +14,33 @@ if (!scriptName) {
 
 const root = process.cwd();
 const roots = ["packages/examples", "packages/benchmarks"];
-const ignoredDirs = new Set([
-  ".git",
-  ".next",
-  ".turbo",
-  ".venv",
-  "build",
-  "dist",
-  "node_modules",
-]);
 
-// Only build packages that the root `bun install` provisions, i.e. packages
-// matched by the root `workspaces` globs. Self-contained sub-projects under
-// these roots (own lockfile + toolchain, e.g. the standalone
-// `@solana-gauntlet/sdk` with its external `@solana/web3.js` dep) are not
-// workspace members, so their dependencies are never installed by the
-// monorepo and `tsc` fails with TS2307 in CI. They are meant to be built
-// standalone, not swept here. turbo already builds every real member.
-const workspaceGlobs = JSON.parse(
-  readFileSync(path.join(root, "package.json"), "utf8"),
-).workspaces;
+// Only run the target script for real workspace members under these roots.
+// Self-contained sub-projects here (own lockfile + toolchain, e.g. the
+// standalone `@solana-gauntlet/sdk` with its external `@solana/web3.js` dep)
+// are excluded by the root `workspaces` globs — their deps are never installed
+// by the monorepo, so a `tsc` sweep would fail with TS2307. They build
+// standalone; turbo already builds every real member. Discovery is the shared
+// seam (honors `workspaces` negation); the caller keeps its examples/benchmarks
+// scope and "has this script" filter.
+const isUnderRoots = (dir) =>
+  roots.some((entry) => dir === entry || dir.startsWith(`${entry}/`));
 
-function workspaceGlobToRegExp(glob) {
-  let pattern = "";
-  for (let i = 0; i < glob.length; i += 1) {
-    const char = glob[i];
-    if (char === "*") {
-      if (glob[i + 1] === "*") {
-        pattern += ".*";
-        i += 1;
-      } else {
-        pattern += "[^/]*";
-      }
-    } else if (/[.+^${}()|[\]\\]/.test(char)) {
-      pattern += `\\${char}`;
-    } else {
-      pattern += char;
-    }
-  }
-  return new RegExp(`^${pattern}$`);
-}
-
-const workspaceMatchers = workspaceGlobs.map((glob) => {
-  const negated = glob.startsWith("!");
-  return {
-    negated,
-    regExp: workspaceGlobToRegExp(negated ? glob.slice(1) : glob),
-  };
-});
-
-function isWorkspaceMember(packageDir) {
-  const relative = path.relative(root, packageDir);
-  let member = false;
-  for (const { negated, regExp } of workspaceMatchers) {
-    if (regExp.test(relative)) {
-      member = !negated;
-    }
-  }
-  return member;
-}
-
-function collectPackageJsons(dir, out = []) {
-  if (!existsSync(dir)) return out;
-  for (const name of readdirSync(dir)) {
-    if (ignoredDirs.has(name)) continue;
-    const fullPath = path.join(dir, name);
-    let stat;
-    try {
-      stat = lstatSync(fullPath);
-    } catch {
-      continue;
-    }
-    if (stat.isSymbolicLink()) continue;
-    if (stat.isDirectory()) {
-      collectPackageJsons(fullPath, out);
-      continue;
-    }
-    if (name === "package.json") {
-      out.push(fullPath);
-    }
-  }
-  return out;
-}
-
-const packages = roots
-  .flatMap((entry) => collectPackageJsons(path.join(root, entry)))
-  .sort()
-  .map((packageJsonPath) => {
-    const packageDir = path.dirname(packageJsonPath);
-    const manifest = JSON.parse(readFileSync(packageJsonPath, "utf8"));
-    return {
-      dir: packageDir,
-      name: manifest.name ?? path.relative(root, packageDir),
-      scripts: manifest.scripts ?? {},
-    };
-  })
-  .filter((pkg) => Object.hasOwn(pkg.scripts, scriptName))
-  .filter((pkg) => isWorkspaceMember(pkg.dir));
+const packages = listPackages({ repoRoot: root })
+  .filter((pkg) => isUnderRoots(pkg.dir))
+  .map((pkg) => ({
+    dir: pkg.dir,
+    name: pkg.packageJson.name ?? pkg.dir,
+    scripts: pkg.packageJson.scripts ?? {},
+  }))
+  .filter((pkg) => Object.hasOwn(pkg.scripts, scriptName));
 
 let failed = false;
 for (const pkg of packages) {
-  const relativeDir = path.relative(root, pkg.dir);
+  const relativeDir = pkg.dir;
   console.log(`\n[${scriptName}] ${pkg.name} (${relativeDir})`);
   const result = spawnSync("bun", ["run", scriptName], {
-    cwd: pkg.dir,
+    cwd: path.join(root, pkg.dir),
     env: process.env,
     stdio: "inherit",
   });

--- a/packages/scripts/turbo-cache-key.mjs
+++ b/packages/scripts/turbo-cache-key.mjs
@@ -8,10 +8,10 @@ import {
   lstatSync,
   readdirSync,
   readFileSync,
-  statSync,
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { listWorkspaceDirs as listWorkspaceDirsFromSeam } from "./lib/workspaces.mjs";
 
 const DEFAULT_REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -80,87 +80,13 @@ function normalizePath(value) {
   return value.split(path.sep).join("/");
 }
 
-function readJson(filePath) {
-  return JSON.parse(readFileSync(filePath, "utf8"));
-}
-
-function workspaceGlobToRegExp(glob) {
-  let pattern = "";
-  for (let i = 0; i < glob.length; i += 1) {
-    const char = glob[i];
-    if (char === "*") {
-      if (glob[i + 1] === "*") {
-        pattern += ".*";
-        i += 1;
-      } else {
-        pattern += "[^/]*";
-      }
-    } else if (/[.+^${}()|[\]\\]/.test(char)) {
-      pattern += `\\${char}`;
-    } else {
-      pattern += char;
-    }
-  }
-  return new RegExp(`^${pattern}$`);
-}
-
-function expandWorkspaceGlob(repoRoot, pattern) {
-  let dirs = [repoRoot];
-  for (const part of pattern.split("/")) {
-    const next = [];
-    for (const dir of dirs) {
-      if (part === "*") {
-        let entries;
-        try {
-          entries = readdirSync(dir, { withFileTypes: true });
-        } catch {
-          continue;
-        }
-        for (const entry of entries) {
-          if (entry.isDirectory()) next.push(path.join(dir, entry.name));
-        }
-        continue;
-      }
-      const candidate = path.join(dir, part);
-      try {
-        if (statSync(candidate).isDirectory()) next.push(candidate);
-      } catch {}
-    }
-    dirs = next;
-  }
-  return dirs;
-}
-
+// Workspace members, sorted longest-path-first so `owningWorkspace` attributes a
+// file to its most-specific enclosing workspace (a nested member wins over its
+// ancestor). Discovery itself is the shared seam.
 export function listWorkspaceDirs(repoRoot = DEFAULT_REPO_ROOT) {
-  const rootPackage = readJson(path.join(repoRoot, "package.json"));
-  const workspaceGlobs = rootPackage.workspaces ?? [];
-  const matchers = workspaceGlobs.map((glob) => {
-    const negated = glob.startsWith("!");
-    return {
-      negated,
-      regExp: workspaceGlobToRegExp(negated ? glob.slice(1) : glob),
-    };
-  });
-
-  function isWorkspaceMember(relativeDir) {
-    let member = false;
-    for (const { negated, regExp } of matchers) {
-      if (regExp.test(relativeDir)) member = !negated;
-    }
-    return member;
-  }
-
-  const dirs = new Set();
-  for (const glob of workspaceGlobs) {
-    if (glob.startsWith("!")) continue;
-    for (const dir of expandWorkspaceGlob(repoRoot, glob)) {
-      const relativeDir = normalizePath(path.relative(repoRoot, dir));
-      if (!relativeDir || !isWorkspaceMember(relativeDir)) continue;
-      if (!existsSync(path.join(dir, "package.json"))) continue;
-      dirs.add(relativeDir);
-    }
-  }
-  return [...dirs].sort((a, b) => b.length - a.length || a.localeCompare(b));
+  return listWorkspaceDirsFromSeam({ repoRoot }).sort(
+    (a, b) => b.length - a.length || a.localeCompare(b),
+  );
 }
 
 function packageRootInput(fileName) {

--- a/packages/scripts/verify-package-runtime-exports.mjs
+++ b/packages/scripts/verify-package-runtime-exports.mjs
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { findWorkspaceRoot } from "./lib/repo-root.mjs";
 
 const packageDirArg = process.argv[2];
 if (!packageDirArg) {
@@ -9,22 +10,6 @@ if (!packageDirArg) {
     "Usage: node packages/scripts/verify-package-runtime-exports.mjs <package-dir>",
   );
   process.exit(1);
-}
-
-function findWorkspaceRoot(startDir) {
-  let current = path.resolve(startDir);
-  while (true) {
-    try {
-      const raw = fs.readFileSync(path.join(current, "package.json"), "utf8");
-      const parsed = JSON.parse(raw);
-      if (parsed?.workspaces) return current;
-    } catch {
-      // keep walking
-    }
-    const parent = path.dirname(current);
-    if (parent === current) return process.cwd();
-    current = parent;
-  }
 }
 
 const root = findWorkspaceRoot(process.cwd());

--- a/packages/scripts/with-package-build-lock.mjs
+++ b/packages/scripts/with-package-build-lock.mjs
@@ -3,6 +3,7 @@ import { execFile, spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
+import { findWorkspaceRoot } from "./lib/repo-root.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -15,23 +16,7 @@ if (!packageDirArg || separator !== "--" || command.length === 0) {
   process.exit(1);
 }
 
-async function findWorkspaceRoot(startDir) {
-  let current = path.resolve(startDir);
-  while (true) {
-    try {
-      const raw = await fs.readFile(path.join(current, "package.json"), "utf8");
-      const parsed = JSON.parse(raw);
-      if (parsed?.workspaces) return current;
-    } catch {
-      // keep walking
-    }
-    const parent = path.dirname(current);
-    if (parent === current) return process.cwd();
-    current = parent;
-  }
-}
-
-const root = await findWorkspaceRoot(process.cwd());
+const root = findWorkspaceRoot(process.cwd());
 const packageDir = path.resolve(root, packageDirArg);
 // Keep transient lock state out of package directories so cancelled Turbo builds
 // do not leave untracked `.build-lock` folders across the workspace.


### PR DESCRIPTION
Closes #12333

Migrates the duplicated workspace/package glob walkers in the script layer onto
the shared discovery seam that landed in #12520
(`packages/scripts/lib/workspaces.mjs`), and folds the five copy-pasted
`findWorkspaceRoot` helpers into `packages/scripts/lib/repo-root.mjs`. Every
migration is a **behavior-preserving** swap — proven by capturing each walker's
pre-migration output and diffing it against the seam output — with the single
documented exception noted below.

## Important behavior change (documented, intended)

`fix-workspace-deps.mjs`'s local walker treated a leading `!` as a literal path
segment that never matched, so `!packages/feed` was silently ignored and the
excluded `packages/feed` nested monorepo was scanned via `packages/*`. After
migrating to `listWorkspaceDirs` (which honors negation), `packages/feed` is
correctly excluded. **This is the only intended output difference across the
whole PR**, and it is proven to be the only difference:

```
# fix-workspace-deps enumeration dir-set diff (before = local walker, after = seam)
81d80
< packages/feed
```

The `packages/feed/packages/*`, `.../apps/*`, `.../tools/*` members remain
(they are positive workspace patterns = bun install truth). `--check`: scan count
`281 -> 280`, reported issue SET byte-for-byte identical (order-insensitive).

## Seam bug fixed first (prerequisite)

`expandPositiveGlob` skipped hidden/build dirs only inside `**`, so a `*` segment
could match a build-output dir carrying a `package.json` marker —
`packages/examples/cloud/clone-ur-crush/.next` (a Next.js `{"type":"commonjs"}`
marker) leaked in as a "workspace". Extracted `isTraversableChild` and applied it
uniformly to `*`/`**`/recursive walk (matching bun's real resolution). Added a
regression test. Live-repo leak: `1 -> 0`.

## Migrated (each proven identical)

| File | Proof |
|------|-------|
| `fix-workspace-deps.mjs` | enumeration diff = only `packages/feed` removed; `--check` issue set identical |
| `turbo-cache-key.mjs` | `listWorkspaceDirs` output byte-identical (same set + longest-first order); tests pass |
| `run-examples-benchmarks.mjs` | discovered set identical for `lint` (47), `typecheck` (53), `build` (47) |
| `generate-dist-paths-config.mjs` | generated `tsconfig.dist-paths.json` **byte-identical** (204 aliases) |
| `audit-turbo-build-deps.mjs` | name→dir map identical (279); audit output identical |
| `run-all-tests.mjs` | full `--plan=text` **byte-identical** for `pr` + `post-merge` lanes (266 tasks / 241 packages); whole-subtree feed exclusion kept as a caller-local policy filter |
| `findWorkspaceRoot` ×5 → `lib/repo-root.mjs` | resolves same root; migrated scripts behave identically |

## Deferred (NOT a seam duplicate — different query, proven)

- **`ensure-workspace-symlinks.mjs`** — hardcoded depth-3 walk over arbitrary
  roots; seam set differs (would stop linking 7 `packages/benchmarks/*`, add 15).
  Behavior change, not a swap.
- **`prepare-package-dist.mjs`** — unbounded recursive walk of `packages/`+`plugins/`
  that intentionally collects nested non-workspace manifests for version
  resolution (`303` vs seam `274`).
- **`replace-workspace-versions.js`** — reads `lerna.json` (narrower publish set),
  not root `workspaces`.
- **`ensure-native-plugins-linked.mjs`** — single-dir `plugin-native-*` prefix scan
  over a non-workspace dir.
- **`scripts/testing-coverage-matrix.mjs`** — derives packages from `git ls-files`
  (every `package.json`, by design); only reads negations as a stat helper.

Rationale for each is in the issue-evidence file.

## Verification

```
bun test packages/scripts/__tests__/workspaces-lib.test.ts packages/scripts/__tests__/turbo-cache-key.test.ts
  -> 21 pass, 0 fail
node packages/scripts/audit-scripts.mjs            -> OK
node packages/scripts/audit-turbo-build-deps.mjs   -> ✓ no phantom edges (exit 0)
node packages/scripts/run-all-tests.mjs --plan=text --no-cloud  -> byte-identical to original (pr + post-merge)
biome lint <14 changed scripts>                    -> 0 errors (pre-existing warnings only; net -1 warning)
```

Full identical-output transcripts:
`.github/issue-evidence/12333-migrate-walkers-to-seam.md`.

Evidence rows N/A (script-layer refactor): UI screenshots, real-LLM
trajectories, audio, domain artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
