### PR TITLE
fix(#12321): derive catalog tokenizer family from manifest

### DIFF
--- a/.github/issue-evidence/12216-stage4-emit-catalog-tokenizer/README.md
+++ b/.github/issue-evidence/12216-stage4-emit-catalog-tokenizer/README.md
@@ -1,0 +1,50 @@
+# Stage 4 emit catalog tokenizer-family evidence
+
+Issue: #12321
+PR: TBD
+
+## Scope
+
+This slice removes the catalog emitter's hardcoded tokenizer-family table.
+
+`packages/training/scripts/emit_eliza1_catalog.py` now requires
+`manifest.tokenizer.family` and emits that value into `tokenizerFamily`.
+The tier metadata table still owns display/catalog sizing defaults, but it no
+longer stamps every tier as `gemma4`. This keeps the emitter aligned with the
+manifest builder's byte-level tokenizer/architecture gate instead of inventing
+tokenizer identity locally.
+
+## Verification
+
+```bash
+python3 -m pytest packages/training/scripts/test_emit_eliza1_catalog.py -q
+```
+
+Result:
+
+```text
+....                                                                     [100%]
+```
+
+```bash
+python3 -m py_compile \
+  packages/training/scripts/emit_eliza1_catalog.py \
+  packages/training/scripts/test_emit_eliza1_catalog.py
+```
+
+Result: exit 0.
+
+```bash
+grep -RIn "tokenizer_family.*gemma4\\|tokenizerFamily.*gemma4" \
+  packages/training/scripts/emit_eliza1_catalog.py \
+  packages/training/scripts/test_emit_eliza1_catalog.py
+```
+
+Result: only the positive Gemma fixture assertion remains; the emitter has no
+hardcoded `tokenizer_family = gemma4` table entry.
+
+## Notes
+
+The emitter receives a manifest path, not a GGUF path. It now consumes tokenizer
+identity from the manifest so the separate manifest byte-architecture gate can
+be the source of truth.

--- a/packages/training/scripts/emit_eliza1_catalog.py
+++ b/packages/training/scripts/emit_eliza1_catalog.py
@@ -86,12 +86,13 @@ ACTIVE_BUNDLE_REPOS = tuple(_bundle_repo(tier) for tier in ELIZA_1_TIERS)
 
 
 # Heuristic mapping from base model name → catalog metadata. New
-# entries go here when adding a new optimization target.
+# entries go here when adding a new optimization target. Tokenizer identity is
+# deliberately not part of this tier table; it must come from the manifest,
+# whose publisher-side gate owns byte-level GGUF provenance.
 KNOWN_BASE_MODELS = {
     _bundle_repo("2b"): {
         "params": "2B",
         "context_length": 131072,
-        "tokenizer_family": "gemma4",
         "category": "chat",
         "bucket": "small",
         "min_ram_gb": 4,
@@ -100,7 +101,6 @@ KNOWN_BASE_MODELS = {
     _bundle_repo("4b"): {
         "params": "4B",
         "context_length": 131072,
-        "tokenizer_family": "gemma4",
         "category": "chat",
         "bucket": "mid",
         "min_ram_gb": 6,
@@ -109,7 +109,6 @@ KNOWN_BASE_MODELS = {
     _bundle_repo("9b"): {
         "params": "9B",
         "context_length": 131072,
-        "tokenizer_family": "gemma4",
         "category": "chat",
         "bucket": "large",
         "min_ram_gb": 12,
@@ -118,7 +117,6 @@ KNOWN_BASE_MODELS = {
     _bundle_repo("27b"): {
         "params": "27B",
         "context_length": 131072,
-        "tokenizer_family": "gemma4",
         "category": "chat",
         "bucket": "large",
         "min_ram_gb": 32,
@@ -127,7 +125,6 @@ KNOWN_BASE_MODELS = {
     _bundle_repo("27b-256k"): {
         "params": "27B",
         "context_length": 262144,
-        "tokenizer_family": "gemma4",
         "category": "chat",
         "bucket": "large",
         "min_ram_gb": 48,
@@ -216,6 +213,16 @@ def _slug_from_repo(hf_repo: str) -> str:
     return last.lower()
 
 
+def _tokenizer_family_from_manifest(manifest: dict[str, object]) -> str:
+    tokenizer = manifest.get("tokenizer")
+    if not isinstance(tokenizer, dict):
+        raise SystemExit("manifest.tokenizer must be an object")
+    family = tokenizer.get("family")
+    if not isinstance(family, str) or not family:
+        raise SystemExit("manifest.tokenizer.family is required")
+    return family
+
+
 def build_catalog_entry(manifest: dict[str, object]) -> Eliza1CatalogEntry:
     base_model = str(manifest.get("base_model", ""))
     base_meta = KNOWN_BASE_MODELS.get(base_model)
@@ -271,7 +278,7 @@ def build_catalog_entry(manifest: dict[str, object]) -> Eliza1CatalogEntry:
         category=str(base_meta["category"]),
         bucket=str(base_meta["bucket"]),
         context_length=int(base_meta["context_length"]),
-        tokenizer_family=str(base_meta["tokenizer_family"]),
+        tokenizer_family=_tokenizer_family_from_manifest(manifest),
         cache_type_k=cache_type_k,
         cache_type_v=cache_type_v,
         spec_type=spec_type,

--- a/packages/training/scripts/test_emit_eliza1_catalog.py
+++ b/packages/training/scripts/test_emit_eliza1_catalog.py
@@ -21,8 +21,7 @@ def test_known_base_models_match_active_eliza1_tiers() -> None:
     assert set(emit.KNOWN_BASE_MODELS) == expected
     assert "elizaos/eliza-1/bundles/0_8b" not in emit.KNOWN_BASE_MODELS
     assert all(
-        meta["tokenizer_family"] == "gemma4"
-        for meta in emit.KNOWN_BASE_MODELS.values()
+        "tokenizer_family" not in meta for meta in emit.KNOWN_BASE_MODELS.values()
     )
 
 
@@ -32,6 +31,7 @@ def test_27b_256k_catalog_defaults_match_gemma_cutover() -> None:
             "base_model": "elizaos/eliza-1/bundles/27b-256k",
             "target_repo": "elizaos/eliza-1/bundles/27b-256k",
             "gguf": {"filename": "text/eliza-1-27b-256k.gguf"},
+            "tokenizer": {"family": "gemma4"},
             "runtime": {"args": []},
         }
     )
@@ -42,3 +42,34 @@ def test_27b_256k_catalog_defaults_match_gemma_cutover() -> None:
     assert entry.tokenizer_family == "gemma4"
     assert entry.cache_type_k == "q8_0"
     assert entry.cache_type_v == "q8_0"
+
+
+def test_catalog_tokenizer_family_comes_from_manifest() -> None:
+    entry = emit.build_catalog_entry(
+        {
+            "base_model": "elizaos/eliza-1/bundles/9b",
+            "target_repo": "elizaos/eliza-1/bundles/9b",
+            "gguf": {"filename": "text/eliza-1-9b-128k.gguf"},
+            "tokenizer": {"family": "qwen35"},
+            "runtime": {"args": []},
+        }
+    )
+
+    assert entry.id == "eliza-1-9b"
+    assert entry.tokenizer_family == "qwen35"
+
+
+def test_catalog_requires_manifest_tokenizer_family() -> None:
+    try:
+        emit.build_catalog_entry(
+            {
+                "base_model": "elizaos/eliza-1/bundles/2b",
+                "target_repo": "elizaos/eliza-1/bundles/2b",
+                "gguf": {"filename": "text/eliza-1-2b-128k.gguf"},
+                "runtime": {"args": []},
+            }
+        )
+    except SystemExit as exc:
+        assert "manifest.tokenizer must be an object" in str(exc)
+    else:
+        raise AssertionError("build_catalog_entry accepted a manifest without tokenizer")


### PR DESCRIPTION
## Summary
- remove `tokenizer_family` from the catalog emitter tier metadata table
- require `manifest.tokenizer.family` when rendering `tokenizerFamily`
- add regressions proving a qwen35 manifest is not rewritten as gemma4 and missing tokenizer metadata fails loudly

## Evidence
- `python3 -m pytest packages/training/scripts/test_emit_eliza1_catalog.py -q` -> 4 passed
- `python3 -m py_compile packages/training/scripts/emit_eliza1_catalog.py packages/training/scripts/test_emit_eliza1_catalog.py` -> exit 0
- `git diff --check origin/develop..HEAD` -> exit 0

Evidence file: `.github/issue-evidence/12216-stage4-emit-catalog-tokenizer/README.md`

## N/A
- Live GGUF read: this emitter accepts a manifest path and GGUF filename, not a GGUF path. It now consumes tokenizer identity from the manifest so the manifest byte-architecture gate remains the source of truth.
- Screenshots/video: CLI-only training script change.

Fixes part of #12321.