### PR TITLE
fix(#12323): gate Gemma native dispatch contract

### DIFF
--- a/.github/issue-evidence/12323-stage6-native-contract.md
+++ b/.github/issue-evidence/12323-stage6-native-contract.md
@@ -1,0 +1,50 @@
+# #12323 Stage 6 Native Runtime Contract Evidence
+
+## Scope
+
+- Enforces the shipped Gemma dispatch path for managed Eliza-1 bundles: `turboquant_q4`, Gemma flash attention, stock KV cache, and drafter-backed MTP.
+- Fails closed when a managed hosted-MTP bundle is missing its drafter GGUF instead of silently degrading to non-speculative decode.
+- Marks QJL, PolarQuant, and turbo3_tcq as legacy/non-Gemma KV routes in the native kernel contract.
+- Adds an MTP doctor check for hosted drafter coverage.
+
+## Verification
+
+Command:
+
+```bash
+bun run --cwd plugins/plugin-local-inference test \
+  src/services/manifest/manifest.test.ts \
+  src/services/required-kernels-gate.test.ts \
+  src/services/load-args-drafter.fuzz.test.ts \
+  src/services/mtp-doctor.test.ts
+```
+
+Result:
+
+```text
+Test Files  4 passed (4)
+Tests  84 passed (84)
+Duration  79.13s
+```
+
+Additional checks:
+
+```bash
+git diff --cached --check
+```
+
+Result: passed.
+
+## Native Contract Verifier
+
+Command:
+
+```bash
+node plugins/plugin-local-inference/native/verify/check_kernel_contract.mjs
+```
+
+Result: failed before hardware execution because the existing native contract still reports unrelated verifier drift: missing checked-in Metal/Vulkan source paths, stale platform target names, and missing historical report files. This PR adds the Gemma runtime dispatch contract and tests the TypeScript activation gate; it does not claim the full native hardware matrix is green.
+
+## Screenshots / Recordings / Live Model Trajectories
+
+N/A - this chunk changes local native inference activation contracts and tests, not UI, audio, or model prompt behavior. Real on-device/platform capture remains required to fully close #12323 after the native kernel verifier drift and hardware matrix are resolved.

--- a/plugins/plugin-local-inference/native/verify/HARDWARE_VERIFICATION.md
+++ b/plugins/plugin-local-inference/native/verify/HARDWARE_VERIFICATION.md
@@ -12,6 +12,15 @@ The required distinction:
   a real GGUF model, then grep the backend log. That is the minimum acceptable
   runtime graph-dispatch smoke until a deeper per-op profiler is wired.
 
+Stage 6 Gemma caveat (2026-07-04): the cache-family graph smokes below are
+legacy KV-cache route evidence. Shipped Gemma 4 tiers do **not** route QJL,
+PolarQuant, or `turbo3_tcq` KV at runtime; they use stock KV plus Gemma
+flash-attention and drafter-backed MTP. The enforceable local gate for that
+path is `assertGemmaRuntimeDispatchContract` in
+`plugins/plugin-local-inference/src/services/active-model.ts`; real device
+evidence must still include a Gemma bundle load log showing flash-attention,
+stock KV, `--spec-type draft-mtp`, and non-zero MTP acceptance.
+
 ## Shared graph-smoke contract
 
 All GPU runners require a small GGUF model:

--- a/plugins/plugin-local-inference/native/verify/PLATFORM_MATRIX.md
+++ b/plugins/plugin-local-inference/native/verify/PLATFORM_MATRIX.md
@@ -13,6 +13,27 @@
 
 ## Verify status as of 2026-05-12 (post multi-agent wave)
 
+### 2026-07-04 Stage 6 contract update — Gemma runtime path
+
+The 8/8 QJL / PolarQuant / `turbo3_tcq` fixture gates remain valuable
+regression coverage for legacy head_dim=128 KV-cache routes and shared FFI
+symbols, but they are **not** evidence that the shipped Gemma 4 product graph
+runs those KV kernels. The Gemma path is now represented separately in the
+machine-readable contract (`kernel-contract.json` `gemmaRuntimeDispatch`) and
+in code by
+`plugins/plugin-local-inference/src/services/active-model.ts::assertGemmaRuntimeDispatchContract`:
+managed Eliza-1 bundles must resolve to `turboquant_q4` in the manifest,
+flash-attention on, stock KV (`q8_0` / f16 headroom upgrade), and drafter-backed
+`draft-mtp` whenever the manifest/catalog claims MTP.
+
+Current MTP artifact coverage is partial: `eliza-1-2b` and `eliza-1-4b` host
+`mtp/drafter-<tier>.gguf`; `9b`, `27b`, and `27b-256k` still need hosted
+Gemma drafter GGUFs plus non-zero acceptance evidence. `runMtpDoctor()` now
+fails the "Gemma MTP drafter coverage" check until all five tiers are hosted.
+Android Adreno/Mali, iOS weight-backed, native Windows, ROCm, linux-aarch64,
+and LiteRT NPU rows remain real-device blockers until recordable JSON evidence
+with `passRecordable: true` is produced on those targets.
+
 Re-ran the full integration verify matrix on this box (Intel Arrow Lake CPU +
 Intel ARL/ANV Vulkan + RTX 5080 / sm_120 CUDA, with a full-corpus SFT job
 holding ~12 GB VRAM concurrently — no OOM contention on the short verify runs):

--- a/plugins/plugin-local-inference/native/verify/check_kernel_contract.mjs
+++ b/plugins/plugin-local-inference/native/verify/check_kernel_contract.mjs
@@ -467,11 +467,10 @@ if (!listEq(sortedUnique(mappedRuntimeKeys), sortedUnique(contract.requiredRunti
 }
 
 // 2. Build-script capability gate must stay aligned with the inference contract.
-const requiredMarker = "function requiredKernelsMissing";
 const requiredCapabilityKeys = extractStringArrayAfter(
-  buildScript.slice(buildScript.indexOf(requiredMarker)),
-  "const required",
-  "requiredKernelsMissing required",
+  buildScript,
+  "const REQUIRED_KERNELS",
+  "REQUIRED_KERNELS",
 );
 if (
   !listEq(

--- a/plugins/plugin-local-inference/native/verify/kernel-contract.json
+++ b/plugins/plugin-local-inference/native/verify/kernel-contract.json
@@ -56,6 +56,17 @@
       "windows": "verify/windows_runner.ps1 -Report <path>"
     }
   },
+  "gemmaRuntimeDispatch": {
+    "status": "code-gated-pending-hardware",
+    "requiredPath": [
+      "turboquant_q4_manifest",
+      "flash_attention_head_dim_512",
+      "stock_kv_q8_0_or_f16",
+      "draft_mtp"
+    ],
+    "assertion": "plugins/plugin-local-inference/src/services/active-model.ts assertGemmaRuntimeDispatchContract refuses managed Gemma bundles that omit turboquant_q4/mtp, disable flash attention, select legacy head_dim=128 KV cache types, or claim MTP without drafter-backed load args.",
+    "legacyKvScope": "QJL, PolarQuant, and turbo3_tcq 8/8 fixture/runtime gates remain valid only for legacy/non-Gemma KV-cache routes and shared FFI symbols. They do not prove the shipped Gemma decode graph, which uses stock KV plus Gemma flash attention."
+  },
   "runtimeSmoke": {
     "vulkanBuiltForkGraph": {
       "makeTarget": "vulkan-dispatch-smoke",
@@ -338,6 +349,8 @@
         "turbo3_tcq"
       ],
       "requiredWhen": "ctx > 65536",
+      "runtimeRouteScope": "legacy-tier-only",
+      "gemma4Status": "not-routed; Gemma uses stock KV with flash attention, not the head_dim=128 TCQ KV-cache path",
       "fixtures": [
         {
           "path": "verify/fixtures/turbo3_tcq.json",
@@ -386,6 +399,8 @@
       "runtimeCapabilityKeys": [
         "qjl_full"
       ],
+      "runtimeRouteScope": "legacy-tier-only",
+      "gemma4Status": "not-routed; Gemma uses stock KV with flash attention, not the head_dim=128 QJL K-cache path",
       "fixtures": [
         {
           "path": "verify/fixtures/qjl.json",
@@ -434,6 +449,8 @@
       "runtimeCapabilityKeys": [
         "polarquant"
       ],
+      "runtimeRouteScope": "legacy-tier-only",
+      "gemma4Status": "not-routed; Gemma uses stock KV with flash attention, not the head_dim=128 PolarQuant V-cache path",
       "fixtures": [
         {
           "path": "verify/fixtures/polar.json",

--- a/plugins/plugin-local-inference/src/services/active-model.ts
+++ b/plugins/plugin-local-inference/src/services/active-model.ts
@@ -466,6 +466,11 @@ function applyCatalogDefaults(
 	if (runtime?.optimizations?.mlock !== undefined && args.mlock === undefined) {
 		args.mlock = runtime.optimizations.mlock;
 	}
+
+	if (isEliza1GemmaCatalogEntry(installed, catalog)) {
+		args.cacheTypeK ??= "q8_0";
+		args.cacheTypeV ??= "q8_0";
+	}
 }
 
 function installedWeightMb(
@@ -603,6 +608,63 @@ function resolveMtpDrafterPath(
 	return candidate;
 }
 
+function expectedMtpDrafterPath(
+	installed: InstalledModel,
+	catalog: CatalogModel | undefined,
+	manifest: Eliza1Manifest | null,
+): string | undefined {
+	const manifestPath = manifest?.files?.mtp?.[0]?.path;
+	const catalogFile =
+		catalog?.runtime?.mtp?.drafterFile ??
+		catalog?.sourceModel?.components?.mtp?.file;
+	const expected = manifestPath ?? catalogFile;
+	if (!expected) return undefined;
+	const local = stripBundlePrefix(expected, installed.id);
+	return installed.bundleRoot ? pathJoin(installed.bundleRoot, local) : local;
+}
+
+function isEliza1GemmaCatalogEntry(
+	installed: InstalledModel,
+	catalog: CatalogModel | undefined,
+): boolean {
+	return (
+		installed.id.startsWith("eliza-1-") && catalog?.tokenizerFamily === "gemma4"
+	);
+}
+
+function shouldRequireMtpDrafterOnDisk(
+	installed: InstalledModel,
+	catalog: CatalogModel | undefined,
+	manifest: Eliza1Manifest | null,
+): boolean {
+	return Boolean(
+		manifest?.files?.mtp?.length ||
+			(catalog?.runtime?.mtp?.drafterFile &&
+				installed.source === "eliza-download" &&
+				installed.bundleRoot),
+	);
+}
+
+/**
+ * Refusal raised when a managed Eliza-1 bundle advertises separate-drafter MTP
+ * but the drafter GGUF is absent from disk. Hosted Gemma tiers must not degrade
+ * from `--spec-type draft-mtp` into plain greedy decode; external single-file
+ * scans remain outside this bundle contract.
+ */
+export class MissingMtpDrafterError extends Error {
+	readonly modelId: string;
+	readonly expectedPath: string | undefined;
+
+	constructor(args: { modelId: string; expectedPath: string | undefined }) {
+		super(
+			`Model "${args.modelId}" declares drafter-backed MTP but the drafter GGUF was not found${args.expectedPath ? ` at ${args.expectedPath}` : ""}. Refusing to activate a degraded Gemma path; re-download the complete Eliza-1 bundle.`,
+		);
+		this.name = "MissingMtpDrafterError";
+		this.modelId = args.modelId;
+		this.expectedPath = args.expectedPath;
+	}
+}
+
 /**
  * Strip the `bundles/<tier-slug>/` prefix the catalog uses for HF
  * paths so the remaining string is bundle-root-relative. When the
@@ -656,6 +718,7 @@ export async function resolveLocalInferenceLoadArgs(
 	const catalog = findCatalogModel(installed.id);
 	const runtime = catalog?.runtime;
 	const manifestLoader = options.manifestLoader ?? defaultManifestLoader;
+	const manifest = manifestLoader(installed.id, installed);
 
 	applyCatalogDefaults(
 		args,
@@ -689,17 +752,19 @@ export async function resolveLocalInferenceLoadArgs(
 			? undefined
 			: resolveMtpDrafterPath(installed, catalog, manifestLoader);
 		if (!sameFileMtp && !drafterPath) {
-			// Back-compat with pre-MTP-cutover installs (#11517): bundles
-			// downloaded before the tier's gemma4-assistant drafter was hosted
-			// (and single-file installs with no bundleRoot) have no
-			// `mtp/drafter-<tier>.gguf` on disk. The drafter is a perf-only
-			// speculative-decoding artifact — never brick an installed model
-			// over it. Load without MTP; re-downloading the bundle picks the
-			// drafter up.
+			if (shouldRequireMtpDrafterOnDisk(installed, catalog, manifest)) {
+				throw new MissingMtpDrafterError({
+					modelId: installed.id,
+					expectedPath: expectedMtpDrafterPath(installed, catalog, manifest),
+				});
+			}
+			// Back-compat with external/bare installs that reuse an Eliza-1 id but
+			// are not managed bundles: no bundle root means no manifest contract to
+			// satisfy, so leave MTP unset rather than half-configuring a drafter.
 			console.warn(
 				`[local-inference] ${installed.id} declares a separate-drafter MTP but no drafter GGUF was found${
 					installed.bundleRoot ? ` under ${installed.bundleRoot}` : ""
-				}; loading without speculative decoding. Re-download the model to enable the MTP drafter.`,
+				}; loading external/bare model without speculative decoding. Install the complete Eliza-1 bundle to enable the MTP drafter.`,
 			);
 		} else {
 			args.useGpu = true;
@@ -733,6 +798,11 @@ export async function resolveLocalInferenceLoadArgs(
 
 	if (args.cacheTypeK) args.cacheTypeK = args.cacheTypeK.trim().toLowerCase();
 	if (args.cacheTypeV) args.cacheTypeV = args.cacheTypeV.trim().toLowerCase();
+
+	assertGemmaRuntimeDispatchContract(installed, args, {
+		catalog,
+		manifest,
+	});
 
 	// Validate the final merged args. The route layer is the one
 	// that calls `validateLocalInferenceLoadArgs` with `allowFork: false`
@@ -1040,6 +1110,27 @@ export class MissingRequiredKernelsError extends Error {
 }
 
 /**
+ * Refusal raised when the resolved load arguments for a Gemma-backed Eliza-1
+ * bundle would dispatch a path other than the shipped product graph:
+ * TurboQuant weight-quant from the manifest, flash-attention on Gemma's
+ * 512-dim attention path, stock KV cache, and drafter-backed MTP when the
+ * manifest/catalog declares it.
+ */
+export class GemmaRuntimeDispatchContractError extends Error {
+	readonly modelId: string;
+	readonly failures: ReadonlyArray<string>;
+
+	constructor(args: { modelId: string; failures: ReadonlyArray<string> }) {
+		super(
+			`Model "${args.modelId}" resolved a non-shipping Gemma dispatch path: ${args.failures.join("; ")}`,
+		);
+		this.name = "GemmaRuntimeDispatchContractError";
+		this.modelId = args.modelId;
+		this.failures = args.failures;
+	}
+}
+
+/**
  * Activation kernel gate (native/CLAUDE.md §3#5). When the installed bundle
  * ships a manifest, verify it declares every kernel its tier requires; throw
  * `MissingRequiredKernelsError` otherwise. A bundle with no manifest (bare
@@ -1061,6 +1152,73 @@ export function assertRequiredKernelsPresent(
 		modelId: installed.id,
 		tier: manifest.tier,
 		missing,
+	});
+}
+
+export function assertGemmaRuntimeDispatchContract(
+	installed: InstalledModel,
+	args: LocalInferenceLoadArgs,
+	options: {
+		catalog?: CatalogModel | undefined;
+		manifest?: Eliza1Manifest | null;
+	} = {},
+): void {
+	const catalog = options.catalog ?? findCatalogModel(installed.id);
+	if (!isEliza1GemmaCatalogEntry(installed, catalog)) return;
+
+	const manifest = options.manifest ?? null;
+	const failures: string[] = [];
+	const manifestRequired = new Set(manifest?.kernels.required ?? []);
+	if (manifest) {
+		if (!manifestRequired.has("turboquant_q4")) {
+			failures.push("manifest kernels.required must include turboquant_q4");
+		}
+		if (!manifestRequired.has("mtp")) {
+			failures.push("manifest kernels.required must include mtp");
+		}
+	}
+	if (args.flashAttention !== true) {
+		failures.push("flashAttention=true is required for the Gemma FA path");
+	}
+	for (const field of ["cacheTypeK", "cacheTypeV"] as const) {
+		const value = args[field];
+		if (value && isForkOnlyKvCacheType(value)) {
+			failures.push(
+				`${field}=${value} selects a head_dim=128 legacy KV path; Gemma must use stock KV`,
+			);
+		}
+	}
+
+	const manifestClaimsMtp =
+		manifestRequired.has("mtp") || Boolean(manifest?.files?.mtp?.length);
+	const requiresDrafterBackedMtp =
+		shouldRequireMtpDrafterOnDisk(installed, catalog, manifest) ||
+		manifestClaimsMtp ||
+		Boolean(args.draftModelPath);
+	if (requiresDrafterBackedMtp) {
+		if (!args.draftModelPath) {
+			failures.push("draftModelPath is required for --spec-type draft-mtp");
+		}
+		if (
+			typeof args.draftMin !== "number" ||
+			typeof args.draftMax !== "number" ||
+			args.draftMin <= 0 ||
+			args.draftMax < args.draftMin
+		) {
+			failures.push("draftMin/draftMax must describe a positive MTP window");
+		}
+		if (args.speculativeSamples !== args.draftMax) {
+			failures.push("speculativeSamples must match the MTP draftMax window");
+		}
+		if (args.mobileSpeculative !== true) {
+			failures.push("mobileSpeculative=true is required for MTP dispatch");
+		}
+	}
+
+	if (failures.length === 0) return;
+	throw new GemmaRuntimeDispatchContractError({
+		modelId: installed.id,
+		failures,
 	});
 }
 
@@ -1351,6 +1509,7 @@ export class ActiveModelCoordinator {
 		}
 		const resolved = await resolveLocalInferenceLoadArgs(installed, overrides, {
 			hardware: probe,
+			manifestLoader: opts.manifestLoader,
 		});
 		// WS2: warn one-shot when the tier declares vision but the
 		// per-tier mmproj GGUF isn't on disk yet. The text load still

--- a/plugins/plugin-local-inference/src/services/load-args-drafter.fuzz.test.ts
+++ b/plugins/plugin-local-inference/src/services/load-args-drafter.fuzz.test.ts
@@ -5,10 +5,9 @@
 //
 //   - `resolveLocalInferenceLoadArgs` — catalog + manifest + overrides merge,
 //     including the separate-drafter MTP rule: a hosted-MTP tier (eliza-1-2b
-//     declares `runtime.mtp.drafterFile`) with NO drafter GGUF on disk falls
-//     back to a plain non-speculative load (warn, no MTP args) — a
-//     pre-cutover install must never be bricked over the perf-only drafter
-//     (#11517 back-compat).
+//     declares `runtime.mtp.drafterFile`) with NO drafter GGUF on disk fails
+//     closed for managed Eliza-1 bundles, while external/bare installs remain
+//     outside the bundle contract and load without speculative args.
 //   - `validateLocalInferenceLoadArgs` — differential fuzz against an oracle
 //     mirroring the documented acceptance rules (stock vs fork KV cache
 //     types, contextSize/gpuLayers integrality, kvOffload shapes).
@@ -30,6 +29,7 @@ import {
 	isForkOnlyKvCacheType,
 	isStockKvCacheType,
 	type LocalInferenceLoadArgs,
+	MissingMtpDrafterError,
 	resolveLocalInferenceLoadArgs,
 	validateLocalInferenceLoadArgs,
 } from "./active-model";
@@ -123,7 +123,11 @@ function manifestWithMtp(mtpPaths: string[]): Eliza1Manifest {
 			cache: [{ path: "cache/voice-preset-default.bin", sha256: SHA_A }],
 			vad: [{ path: "vad/silero-vad-v5.gguf", sha256: SHA_A }],
 		},
-		kernels: { required: [], optional: [], verifiedBackends: {} },
+		kernels: {
+			required: ["turboquant_q4", "mtp"],
+			optional: [],
+			verifiedBackends: {},
+		},
 		evals: {
 			textEval: { score: 0.71, passed: true },
 			voiceRtf: { rtf: 0.42, passed: true },
@@ -151,32 +155,16 @@ describe("resolveLocalInferenceLoadArgs — separate-drafter MTP resolution", ()
 		expect(catalog2b?.runtime?.mtp?.drafterFile).toMatch(/drafter-2b\.gguf$/);
 	});
 
-	it("falls back to a non-speculative load when the declared drafter GGUF is missing under bundleRoot", async () => {
-		// #11517 back-compat: a bundle installed before the Gemma-4 MTP cutover
-		// has no mtp/drafter-2b.gguf. The drafter is perf-only — the text model
-		// must still load (warn + plain decode), never throw.
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-		try {
-			const bundle = makeTempBundle({ tier: "2b", hasDrafter: false });
-			const installed = installedModel({
-				id: "eliza-1-2b",
-				path: bundle.textPath,
-				bundleRoot: bundle.bundleRoot,
-			});
-			const resolved = await resolveLocalInferenceLoadArgs(installed);
-			expect(resolved.modelPath).toBe(bundle.textPath);
-			expect(resolved.draftModelPath).toBeUndefined();
-			expect(resolved.draftMin).toBeUndefined();
-			expect(resolved.draftMax).toBeUndefined();
-			expect(resolved.mobileSpeculative).toBeUndefined();
-			expect(warnSpy).toHaveBeenCalledWith(
-				expect.stringContaining(
-					"Re-download the model to enable the MTP drafter",
-				),
-			);
-		} finally {
-			warnSpy.mockRestore();
-		}
+	it("fails closed when a managed hosted-MTP bundle is missing its drafter GGUF", async () => {
+		const bundle = makeTempBundle({ tier: "2b", hasDrafter: false });
+		const installed = installedModel({
+			id: "eliza-1-2b",
+			path: bundle.textPath,
+			bundleRoot: bundle.bundleRoot,
+		});
+		await expect(resolveLocalInferenceLoadArgs(installed)).rejects.toThrow(
+			MissingMtpDrafterError,
+		);
 	});
 
 	it("does not throw for an external-scan install (no bundleRoot); MTP stays fully unset", async () => {
@@ -253,10 +241,25 @@ describe("resolveLocalInferenceLoadArgs — separate-drafter MTP resolution", ()
 		).rejects.toThrow(/gpuLayers/);
 	});
 
-	it("accepts fork-only KV cache types at resolve time (allowFork) and normalizes case/space", async () => {
+	it("rejects legacy head_dim-coupled KV cache overrides for Gemma tiers", async () => {
 		const bundle = makeTempBundle({ tier: "2b", hasDrafter: true });
 		const installed = installedModel({
 			id: "eliza-1-2b",
+			path: bundle.textPath,
+			bundleRoot: bundle.bundleRoot,
+		});
+		await expect(
+			resolveLocalInferenceLoadArgs(installed, {
+				cacheTypeK: "q4_polar",
+				cacheTypeV: "  Q8_0  ",
+			}),
+		).rejects.toThrow(/Gemma.*stock KV/);
+	});
+
+	it("accepts fork-only KV cache types for non-Gemma dev models at resolve time", async () => {
+		const bundle = makeTempBundle({ tier: "2b", hasDrafter: false });
+		const installed = installedModel({
+			id: "custom-generic-gguf",
 			path: bundle.textPath,
 			bundleRoot: bundle.bundleRoot,
 		});

--- a/plugins/plugin-local-inference/src/services/manifest/eliza-1.manifest.v1.json
+++ b/plugins/plugin-local-inference/src/services/manifest/eliza-1.manifest.v1.json
@@ -756,6 +756,7 @@
 				"turboquant_q4",
 				"qjl",
 				"polarquant",
+				"mtp",
 				"turbo3_tcq"
 			]
 		},

--- a/plugins/plugin-local-inference/src/services/manifest/manifest.test.ts
+++ b/plugins/plugin-local-inference/src/services/manifest/manifest.test.ts
@@ -115,12 +115,12 @@ describe("Eliza-1 manifest schema constants", () => {
 		expect(Object.keys(REQUIRED_KERNELS_BY_TIER)).toEqual(
 			expect.arrayContaining(["2b", "4b"]),
 		);
-		// Gemma 4 cutover: the only REQUIRED kernel is the geometry-agnostic
-		// turboquant_q4 weight-quant. The KV-cache kernels (qjl/polarquant/
+		// Gemma 4 cutover: REQUIRED is the geometry-agnostic turboquant_q4
+		// weight-quant plus native MTP. The KV-cache kernels (qjl/polarquant/
 		// turbo3_tcq) are head_dim=128-coupled and OPTIONAL for Gemma's stock
 		// q8_0 KV path.
 		for (const tier of ELIZA_1_TIERS) {
-			expect(REQUIRED_KERNELS_BY_TIER[tier]).toEqual(["turboquant_q4"]);
+			expect(REQUIRED_KERNELS_BY_TIER[tier]).toEqual(["turboquant_q4", "mtp"]);
 			expect(REQUIRED_KERNELS_BY_TIER[tier]).not.toContain("turbo3_tcq");
 		}
 	});
@@ -203,6 +203,7 @@ describe("validateManifest — valid input", () => {
 		expect([...REQUIRED_KERNELS_BY_TIER["2b"]] as string[]).not.toContain(
 			"specDecode",
 		);
+		expect([...REQUIRED_KERNELS_BY_TIER["2b"]] as string[]).toContain("mtp");
 		expect(result.ok).toBe(true);
 		if (result.ok) {
 			expect(result.manifest.kernels.specDecode?.capability).toBe(
@@ -364,13 +365,14 @@ describe("validateManifest — schema-level rejections", () => {
 describe("validateManifest — contract rejections", () => {
 	it("rejects a manifest missing a required kernel for its tier", () => {
 		const m = baseManifest("9b");
-		// Gemma required set is turboquant_q4; drop it (leaving only optional
-		// KV kernels) to trip the missing-required-kernel check.
+		// Gemma required set is turboquant_q4 + mtp; drop both (leaving only
+		// optional KV kernels) to trip the missing-required-kernel check.
 		m.kernels.required = ["qjl", "polarquant"];
 		const result = validateManifest(m);
 		expect(result.ok).toBe(false);
 		if (!result.ok) {
 			expect(result.errors.some((e) => e.includes("turboquant_q4"))).toBe(true);
+			expect(result.errors.some((e) => e.includes("mtp"))).toBe(true);
 		}
 	});
 

--- a/plugins/plugin-local-inference/src/services/manifest/schema.ts
+++ b/plugins/plugin-local-inference/src/services/manifest/schema.ts
@@ -58,9 +58,9 @@ export const ELIZA_1_TIERS = ["2b", "4b", "9b", "27b", "27b-256k"] as const;
 export type Eliza1Tier = (typeof ELIZA_1_TIERS)[number];
 
 // Manifest-level kernel capability names. Per AGENTS.md §3:
-// `turboquant_q3`, `turboquant_q4`, `qjl`, `polarquant` are
-// the named optimizations the bundle declares. `turbo3_tcq` is required
-// for any long-context text variant. The C-level llama.cpp kernel handles in
+// `turboquant_q3`, `turboquant_q4`, `qjl`, `polarquant`, and `mtp` are
+// the named optimizations the bundle declares. `turbo3_tcq` is required for
+// legacy long-context text variants. The C-level llama.cpp kernel handles in
 // `../types.ts` are an implementation detail of the runtime; the manifest
 // speaks in terms of the optimization, not the .metal/.comp file.
 //
@@ -74,13 +74,13 @@ export const ELIZA_1_KERNELS = [
 	"turboquant_q4",
 	"qjl",
 	"polarquant",
+	"mtp",
 	"turbo3_tcq",
 ] as const;
 export type Eliza1Kernel = (typeof ELIZA_1_KERNELS)[number];
-export type Eliza1RequiredRuntimeKernel = Exclude<
-	LocalRuntimeKernel,
-	"openvino"
->;
+export type Eliza1RequiredRuntimeKernel =
+	| Exclude<LocalRuntimeKernel, "openvino">
+	| "mtp";
 
 // Manifest-kernel ↔ runtime-kernel bridge.
 //
@@ -94,6 +94,7 @@ export type Eliza1RequiredRuntimeKernel = Exclude<
 //   turboquant_q4  ↔ turbo4       (Q4 KV-cache quant kernel)
 //   qjl            ↔ qjl_full     (QuIP#-JL fused-attention kernel)
 //   polarquant     ↔ polarquant   (same name on both layers)
+//   mtp            ↔ mtp          (native speculative-decode capability)
 //   turbo3_tcq     ↔ turbo3_tcq   (same name on both layers)
 //
 // Every Eliza-1 custom-kernel member is covered (both are total maps over the
@@ -109,6 +110,7 @@ export const ELIZA1_TO_RUNTIME_KERNEL: Readonly<
 	turboquant_q4: "turbo4",
 	qjl: "qjl_full",
 	polarquant: "polarquant",
+	mtp: "mtp",
 	turbo3_tcq: "turbo3_tcq",
 };
 
@@ -119,6 +121,7 @@ export const RUNTIME_TO_ELIZA1_KERNEL: Readonly<
 	turbo4: "turboquant_q4",
 	qjl_full: "qjl",
 	polarquant: "polarquant",
+	mtp: "mtp",
 	turbo3_tcq: "turbo3_tcq",
 };
 
@@ -133,10 +136,13 @@ export type Eliza1Backend = (typeof ELIZA_1_BACKENDS)[number];
 
 // Required-kernel set per tier. Mirrors the active Gemma 4 Eliza-1 release
 // policy:
-// - Every tier requires only the geometry-agnostic GGUF weight-quant
-//   (`turboquant_q4`). Weight quant operates on (out_features, in_features)
-//   matmul tensors and is independent of attention head geometry, so it
-//   applies to Gemma's dense MQA backbone unchanged.
+// - Every tier requires the geometry-agnostic GGUF weight-quant
+//   (`turboquant_q4`) plus native MTP speculative decoding (`mtp`). Weight
+//   quant operates on (out_features, in_features) matmul tensors and is
+//   independent of attention head geometry, so it applies to Gemma's dense
+//   MQA backbone unchanged. MTP is not a KV-cache kernel; it is listed here
+//   because the shipped Gemma path must load a drafter-backed speculative
+//   decode graph rather than silently running plain greedy decode.
 // - The KV-cache kernels (`qjl`, `polarquant`, `turbo3_tcq`, and the
 //   `turbo3`/`turbo4` runtime handles) are 128-element FWHT-group kernels
 //   that are head_dim-coupled. They do NOT match Gemma's MQA geometry
@@ -148,11 +154,11 @@ export type Eliza1Backend = (typeof ELIZA_1_BACKENDS)[number];
 export const REQUIRED_KERNELS_BY_TIER: Readonly<
 	Record<Eliza1Tier, ReadonlyArray<Eliza1Kernel>>
 > = {
-	"2b": ["turboquant_q4"],
-	"4b": ["turboquant_q4"],
-	"9b": ["turboquant_q4"],
-	"27b": ["turboquant_q4"],
-	"27b-256k": ["turboquant_q4"],
+	"2b": ["turboquant_q4", "mtp"],
+	"4b": ["turboquant_q4", "mtp"],
+	"9b": ["turboquant_q4", "mtp"],
+	"27b": ["turboquant_q4", "mtp"],
+	"27b-256k": ["turboquant_q4", "mtp"],
 };
 
 // KV-cache kernels that remain available but are NOT required for any Gemma 4

--- a/plugins/plugin-local-inference/src/services/mtp-doctor.test.ts
+++ b/plugins/plugin-local-inference/src/services/mtp-doctor.test.ts
@@ -1,0 +1,21 @@
+/**
+ * MTP doctor coverage checks for the Gemma drafter rollout.
+ *
+ * The hardware probe may vary by host; this test pins the artifact-coverage
+ * check that must fail until every Eliza-1 tier hosts a drafter GGUF.
+ */
+
+import { describe, expect, it } from "vitest";
+import { runMtpDoctor } from "./mtp-doctor";
+
+describe("runMtpDoctor", () => {
+	it("fails the coverage check while Gemma drafter hosting is partial", async () => {
+		const report = await runMtpDoctor();
+		const coverage = report.checks.find(
+			(check) => check.label === "Gemma MTP drafter coverage",
+		);
+		expect(coverage?.status).toBe("fail");
+		expect(coverage?.detail).toContain("2/5");
+		expect(report.ok).toBe(false);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/mtp-doctor.ts
+++ b/plugins/plugin-local-inference/src/services/mtp-doctor.ts
@@ -30,6 +30,9 @@ export async function runMtpDoctor(): Promise<MtpDoctorReport> {
 	const mtpCatalogEntries = MODEL_CATALOG.filter(
 		(entry) => entry.runtime?.mtp !== undefined,
 	);
+	const hostedMtpTierCount: number = ELIZA_1_HOSTED_MTP_TIER_IDS.length;
+	const mtpTierCount: number = ELIZA_1_MTP_TIER_IDS.length;
+	const allMtpDraftersHosted = hostedMtpTierCount === mtpTierCount;
 
 	checks.push({
 		label: "catalog metadata",
@@ -42,6 +45,14 @@ export async function runMtpDoctor(): Promise<MtpDoctorReport> {
 			mtpCatalogEntries.length > 0
 				? undefined
 				: "publish Gemma drafter GGUFs at bundles/<tier>/mtp/drafter-<tier>.gguf before enabling runtime MTP",
+	});
+	checks.push({
+		label: "Gemma MTP drafter coverage",
+		status: allMtpDraftersHosted ? "pass" : "fail",
+		detail: `${hostedMtpTierCount}/${mtpTierCount} Eliza-1 tiers host drafter GGUFs (${ELIZA_1_HOSTED_MTP_TIER_IDS.join(", ") || "none"})`,
+		fix: allMtpDraftersHosted
+			? undefined
+			: "publish and manifest mtp/drafter-<tier>.gguf for every remaining Eliza-1 tier before claiming full Stage 6 MTP coverage",
 	});
 
 	try {

--- a/plugins/plugin-local-inference/src/services/required-kernels-gate.test.ts
+++ b/plugins/plugin-local-inference/src/services/required-kernels-gate.test.ts
@@ -1,9 +1,12 @@
 /** Verifies `assertRequiredKernelsPresent` fails closed when a manifest omits a required native kernel (native/CLAUDE.md §3#5). Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
+	assertGemmaRuntimeDispatchContract,
 	assertRequiredKernelsPresent,
+	GemmaRuntimeDispatchContractError,
 	MissingRequiredKernelsError,
 } from "./active-model";
+import { findCatalogModel } from "./catalog";
 import type { Eliza1Manifest } from "./manifest";
 import { REQUIRED_KERNELS_BY_TIER } from "./manifest";
 import type { ManifestLoader } from "./ram-budget";
@@ -47,8 +50,8 @@ describe("assertRequiredKernelsPresent (native/CLAUDE.md §3#5)", () => {
 	});
 
 	it("throws MissingRequiredKernelsError when a required kernel is absent", () => {
-		// The 2B tier requires `turboquant_q4`; a manifest that only declares an
-		// optional KV kernel is missing it.
+		// The 2B tier requires `turboquant_q4` + `mtp`; a manifest that only
+		// declares an optional KV kernel is missing both.
 		const broken: ManifestLoader = () => manifestWithKernels(["qjl"]);
 		let thrown: unknown;
 		try {
@@ -60,17 +63,19 @@ describe("assertRequiredKernelsPresent (native/CLAUDE.md §3#5)", () => {
 		const err = thrown as MissingRequiredKernelsError;
 		expect(err.tier).toBe("2b");
 		expect(err.missing).toContain("turboquant_q4");
+		expect(err.missing).toContain("mtp");
 		expect(err.modelId).toBe("eliza-1-2b");
 	});
 
 	// AGENTS.md §3 "Gemma 4 exception": the head_dim=128 QJL/PolarQuant KV
 	// kernels are OPTIONAL on Gemma (its MQA/SWA/shared-KV geometry never routes
-	// through them). Only TurboQuant weight-quant is required. Enforce that
-	// contract at the manifest-gate level.
+	// through them). TurboQuant weight-quant and MTP are required; the legacy KV
+	// kernels remain optional. Enforce that contract at the manifest-gate level.
 	it("does NOT throw for a Gemma-tier manifest that omits QJL/PolarQuant (Gemma exception)", () => {
-		// A real Gemma bundle declares only `turboquant_q4` and ships stock KV —
-		// no qjl / polarquant / turbo3_tcq. The gate must accept it.
-		const gemma: ManifestLoader = () => manifestWithKernels(["turboquant_q4"]);
+		// A real Gemma bundle declares `turboquant_q4` + `mtp` and ships stock KV
+		// — no qjl / polarquant / turbo3_tcq. The gate must accept it.
+		const gemma: ManifestLoader = () =>
+			manifestWithKernels(["turboquant_q4", "mtp"]);
 		expect(() =>
 			assertRequiredKernelsPresent(installed2b(), gemma),
 		).not.toThrow();
@@ -92,5 +97,54 @@ describe("assertRequiredKernelsPresent (native/CLAUDE.md §3#5)", () => {
 		expect((thrown as MissingRequiredKernelsError).missing).toContain(
 			"turboquant_q4",
 		);
+	});
+});
+
+describe("assertGemmaRuntimeDispatchContract", () => {
+	const manifest = manifestWithKernels(REQUIRED_KERNELS_BY_TIER["2b"]);
+	const catalog = findCatalogModel("eliza-1-2b");
+
+	it("accepts the shipped Gemma dispatch shape", () => {
+		expect(() =>
+			assertGemmaRuntimeDispatchContract(
+				installed2b(),
+				{
+					modelPath: "/tmp/eliza-1-2b/text/model.gguf",
+					cacheTypeK: "q8_0",
+					cacheTypeV: "q8_0",
+					flashAttention: true,
+					draftModelPath: "/tmp/eliza-1-2b/mtp/drafter-2b.gguf",
+					draftMin: 1,
+					draftMax: 1,
+					speculativeSamples: 1,
+					mobileSpeculative: true,
+				},
+				{ catalog, manifest },
+			),
+		).not.toThrow();
+	});
+
+	it("rejects legacy KV kernels and missing drafter-backed MTP", () => {
+		let thrown: unknown;
+		try {
+			assertGemmaRuntimeDispatchContract(
+				installed2b(),
+				{
+					modelPath: "/tmp/eliza-1-2b/text/model.gguf",
+					cacheTypeK: "qjl1_256",
+					cacheTypeV: "q4_polar",
+					flashAttention: false,
+				},
+				{ catalog, manifest },
+			);
+		} catch (err) {
+			thrown = err;
+		}
+		expect(thrown).toBeInstanceOf(GemmaRuntimeDispatchContractError);
+		const err = thrown as GemmaRuntimeDispatchContractError;
+		expect(err.failures.join("\n")).toMatch(/cacheTypeK=qjl1_256/);
+		expect(err.failures.join("\n")).toMatch(/cacheTypeV=q4_polar/);
+		expect(err.failures.join("\n")).toMatch(/draftModelPath/);
+		expect(err.failures.join("\n")).toMatch(/flashAttention=true/);
 	});
 });


### PR DESCRIPTION
## Summary
- enforce managed Eliza-1 Gemma runtime dispatch: turboquant_q4, flash attention, stock KV, and drafter-backed MTP
- fail closed when a managed hosted-MTP bundle is missing its drafter GGUF instead of silently degrading
- document legacy QJL/PolarQuant/turbo3_tcq scope and add MTP doctor coverage

## Evidence
- Added .github/issue-evidence/12323-stage6-native-contract.md
- bun run --cwd plugins/plugin-local-inference test src/services/manifest/manifest.test.ts src/services/required-kernels-gate.test.ts src/services/load-args-drafter.fuzz.test.ts src/services/mtp-doctor.test.ts
  - Test Files 4 passed (4)
  - Tests 84 passed (84)
  - Duration 79.13s
- git diff --check passed

## Notes
- Native contract verifier still reports pre-existing drift in checked-in native kernel source/report/platform-target evidence. This PR gates the TypeScript activation path and records that remaining hardware-matrix work explicitly.

Refs #12323