### PR TITLE
fix(#12321): gate manifests on text gguf architecture

### DIFF
--- a/.github/issue-evidence/12216-stage4-manifest-arch-gate/README.md
+++ b/.github/issue-evidence/12216-stage4-manifest-arch-gate/README.md
@@ -1,0 +1,52 @@
+# Stage 4 manifest text-architecture gate evidence
+
+Issue: #12321
+PR: TBD
+
+## Scope
+
+This slice adds a Python-side byte metadata gate for Eliza-1 text GGUFs.
+
+`packages/training/scripts/manifest/eliza1_manifest.py` now reads
+`general.architecture` from the GGUF header, carries that architecture on
+internal `FileEntry` records, and rejects manifest builds when a text GGUF
+reports a non-Gemma architecture such as `qwen35`.
+
+The real staging paths that have access to actual GGUF paths now populate this
+field:
+
+- `packages/training/scripts/manifest/stage_real_eliza1_bundle.py`
+- `packages/training/scripts/manifest/stage_local_eliza1_bundle.py`
+- `packages/training/scripts/publish/orchestrator.py`
+- `packages/training/scripts/publish/stage_base_v1_candidate.py`
+
+## Verification
+
+```bash
+python3 -m pytest packages/training/scripts/manifest/test_eliza1_manifest.py -q
+```
+
+Result:
+
+```text
+........................................................................ [100%]
+```
+
+```bash
+python3 -m py_compile \
+  packages/training/scripts/manifest/eliza1_manifest.py \
+  packages/training/scripts/manifest/test_eliza1_manifest.py \
+  packages/training/scripts/manifest/stage_real_eliza1_bundle.py \
+  packages/training/scripts/manifest/stage_local_eliza1_bundle.py \
+  packages/training/scripts/publish/orchestrator.py \
+  packages/training/scripts/publish/stage_base_v1_candidate.py
+```
+
+Result: exit 0.
+
+## Notes
+
+The regression uses a minimal GGUF header fixture with
+`general.architecture=qwen35` and confirms `build_manifest()` raises
+`Eliza1ManifestError`. A full live HF qwen35 bundle audit remains part of the
+broader Stage 4 HF-audit checklist item.

--- a/packages/training/scripts/manifest/eliza1_manifest.py
+++ b/packages/training/scripts/manifest/eliza1_manifest.py
@@ -387,6 +387,36 @@ def _read_gguf_int_value(fh: BinaryIO, value_type: int) -> int | None:
     return None
 
 
+def _read_gguf_string_value(fh: BinaryIO, value_type: int) -> str | None:
+    if value_type == 8:
+        return _read_gguf_string(fh)
+    _skip_gguf_value(fh, value_type)
+    return None
+
+
+def read_gguf_architecture(path: Path) -> str | None:
+    """Return GGUF ``general.architecture`` when the header is readable."""
+
+    try:
+        with path.open("rb") as fh:
+            if _read_exact(fh, 4) != b"GGUF":
+                return None
+            _version = _read_u32(fh)
+            _tensor_count = _read_u64(fh)
+            metadata_count = _read_u64(fh)
+            if metadata_count > 1_000_000:
+                return None
+            for _ in range(metadata_count):
+                key = _read_gguf_string(fh)
+                value_type = _read_u32(fh)
+                if key == "general.architecture":
+                    return _read_gguf_string_value(fh, value_type)
+                _skip_gguf_value(fh, value_type)
+    except Exception:
+        return None
+    return None
+
+
 def read_gguf_context_length(path: Path) -> int | None:
     """Return the declared GGUF training/native context length, if readable.
 
@@ -441,6 +471,12 @@ def text_context_for_manifest(path: Path) -> int | None:
     return read_gguf_context_length(path) or parse_text_ctx_from_filename(path)
 
 
+def text_architecture_for_manifest(path: Path) -> str | None:
+    """Byte-level text GGUF architecture for publish-gate manifest checks."""
+
+    return read_gguf_architecture(path)
+
+
 class Eliza1ManifestError(ValueError):
     """Raised when manifest input violates schema or §3/§6 contract.
 
@@ -466,6 +502,7 @@ class FileEntry:
     path: str
     sha256: str
     ctx: int | None = None
+    architecture: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -1489,6 +1526,30 @@ def _file_dict(entry: FileEntry) -> dict[str, Any]:
     return out
 
 
+def _tokenizer_family_from_text_files(
+    text_files: Sequence[FileEntry],
+    requested_family: str,
+) -> str:
+    architectures = [
+        (entry.path, entry.architecture)
+        for entry in text_files
+        if entry.architecture is not None
+    ]
+    if not architectures:
+        return requested_family
+
+    errors: list[str] = []
+    for path, architecture in architectures:
+        arch_norm = architecture.lower()
+        if not arch_norm.startswith("gemma"):
+            errors.append(
+                f"files.text[{path}].architecture: must be gemma*, got {architecture!r}"
+            )
+    if errors:
+        raise Eliza1ManifestError(errors)
+    return ELIZA_1_TOKENIZER_FAMILY
+
+
 def _verified_backend_dict(v: KernelVerification) -> dict[str, Any]:
     out: dict[str, Any] = {
         "status": v.status,
@@ -1579,6 +1640,11 @@ def build_manifest(
 
     if tier not in ELIZA_1_TIERS:
         raise Eliza1ManifestError([f"tier: unknown tier {tier!r}"])
+
+    tokenizer_family = _tokenizer_family_from_text_files(
+        files.get("text", ()),
+        tokenizer_family,
+    )
 
     if tokenizer_family != ELIZA_1_TOKENIZER_FAMILY:
         raise Eliza1ManifestError(

--- a/packages/training/scripts/manifest/stage_local_eliza1_bundle.py
+++ b/packages/training/scripts/manifest/stage_local_eliza1_bundle.py
@@ -40,6 +40,7 @@ try:
         KernelVerification,
         LineageEntry,
         build_manifest,
+        text_architecture_for_manifest,
         text_context_for_manifest,
         validate_manifest,
         write_manifest,
@@ -59,6 +60,7 @@ except ImportError:  # pragma: no cover - direct script execution path
         KernelVerification,
         LineageEntry,
         build_manifest,
+        text_architecture_for_manifest,
         text_context_for_manifest,
         validate_manifest,
         write_manifest,
@@ -819,6 +821,9 @@ def _collect_files(bundle_dir: Path, *, tier: str) -> dict[str, list[FileEntry]]
                     path=str(path.relative_to(bundle_dir)),
                     sha256=sha256_file(path),
                     ctx=text_context_for_manifest(path) if text else None,
+                    architecture=(
+                        text_architecture_for_manifest(path) if text else None
+                    ),
                 )
             )
         return out

--- a/packages/training/scripts/manifest/stage_real_eliza1_bundle.py
+++ b/packages/training/scripts/manifest/stage_real_eliza1_bundle.py
@@ -59,6 +59,7 @@ try:
         KernelVerification,
         LineageEntry,
         build_manifest,
+        text_architecture_for_manifest,
         text_context_for_manifest,
         validate_manifest,
         write_manifest,
@@ -83,6 +84,7 @@ except ImportError:  # pragma: no cover - direct script execution path
         KernelVerification,
         LineageEntry,
         build_manifest,
+        text_architecture_for_manifest,
         text_context_for_manifest,
         validate_manifest,
         write_manifest,
@@ -755,6 +757,9 @@ def _collect_files(bundle_dir: Path, *, tier: str) -> dict[str, list[FileEntry]]
                     path=str(path.relative_to(bundle_dir)),
                     sha256=sha256_file(path),
                     ctx=text_context_for_manifest(path) if text else None,
+                    architecture=(
+                        text_architecture_for_manifest(path) if text else None
+                    ),
                 )
             )
         return out

--- a/packages/training/scripts/manifest/test_eliza1_manifest.py
+++ b/packages/training/scripts/manifest/test_eliza1_manifest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import struct
 from pathlib import Path
 
 import pytest
@@ -24,6 +25,7 @@ from scripts.manifest.eliza1_manifest import (
     build_manifest,
     parse_ctx_string,
     parse_text_ctx_from_filename,
+    read_gguf_architecture,
     text_context_for_manifest,
     validate_manifest,
     write_manifest,
@@ -31,6 +33,29 @@ from scripts.manifest.eliza1_manifest import (
 from scripts.quantization._kernel_manifest import kernel_manifest_fragment
 
 SHA = "0" * 64
+
+
+def _gguf_string(value: str) -> bytes:
+    data = value.encode("utf-8")
+    return struct.pack("<Q", len(data)) + data
+
+
+def _write_fake_gguf(path: Path, metadata: dict[str, tuple[int, object]]) -> None:
+    payload = bytearray()
+    payload += b"GGUF"
+    payload += struct.pack("<I", 3)
+    payload += struct.pack("<Q", 0)
+    payload += struct.pack("<Q", len(metadata))
+    for key, (value_type, value) in metadata.items():
+        payload += _gguf_string(key)
+        payload += struct.pack("<I", value_type)
+        if value_type == 8:
+            payload += _gguf_string(str(value))
+        elif value_type == 4:
+            payload += struct.pack("<I", int(value))
+        else:
+            raise AssertionError(f"unsupported fake GGUF value type {value_type}")
+    path.write_bytes(bytes(payload))
 
 
 def passing_backends() -> dict[str, KernelVerification]:
@@ -137,6 +162,20 @@ def test_text_context_prefers_gguf_metadata_over_filename(
     assert text_context_for_manifest(text_path) == 262144
 
 
+def test_read_gguf_architecture_reads_general_architecture(tmp_path: Path):
+    text_path = tmp_path / "eliza-1-2b-128k.gguf"
+    _write_fake_gguf(
+        text_path,
+        {
+            "general.architecture": (8, "gemma4"),
+            "gemma4.context_length": (4, 131072),
+        },
+    )
+
+    assert read_gguf_architecture(text_path) == "gemma4"
+    assert text_context_for_manifest(text_path) == 131072
+
+
 def test_eliza1_tier_ids_are_canonical():
     assert ELIZA_1_TIERS == (
         "2b",
@@ -214,6 +253,40 @@ def test_build_manifest_happy_path():
     }
     # Validates against itself.
     assert validate_manifest(manifest) == ()
+
+
+def test_build_manifest_blocks_non_gemma_text_architecture():
+    kwargs = base_kwargs("9b")
+    kwargs["files"]["text"] = [
+        FileEntry(
+            path="text/eliza-1-9b-128k.gguf",
+            sha256=SHA,
+            ctx=131072,
+            architecture="qwen35",
+        )
+    ]
+
+    with pytest.raises(Eliza1ManifestError) as excinfo:
+        build_manifest(**kwargs)
+
+    assert "architecture: must be gemma*" in str(excinfo.value)
+
+
+def test_build_manifest_uses_gemma_text_architecture_without_emitting_it():
+    kwargs = base_kwargs("2b")
+    kwargs["files"]["text"] = [
+        FileEntry(
+            path="text/eliza-1-2b-128k.gguf",
+            sha256=SHA,
+            ctx=131072,
+            architecture="gemma4",
+        )
+    ]
+
+    manifest = build_manifest(**kwargs)
+
+    assert manifest["tokenizer"]["family"] == "gemma4"
+    assert "architecture" not in manifest["files"]["text"][0]
 
 
 def test_legacy_onnx_vad_manifest_remains_compatible():

--- a/packages/training/scripts/publish/orchestrator.py
+++ b/packages/training/scripts/publish/orchestrator.py
@@ -88,6 +88,7 @@ from scripts.manifest.eliza1_manifest import (  # noqa: E402
     build_manifest,
     canonical_source_repo_error,
     required_voice_artifacts_for_tier,
+    text_architecture_for_manifest,
     text_context_for_manifest,
 )
 from scripts.manifest.eliza1_platform_plan import (  # noqa: E402
@@ -1987,6 +1988,9 @@ def _collect_files_for_manifest(
                 path=rel(p),
                 sha256=_sha256_file(p),
                 ctx=text_context_for_manifest(p) if kind_src == "text" else None,
+                architecture=(
+                    text_architecture_for_manifest(p) if kind_src == "text" else None
+                ),
             )
             files[kind_dst].append(entry)
 

--- a/packages/training/scripts/publish/stage_base_v1_candidate.py
+++ b/packages/training/scripts/publish/stage_base_v1_candidate.py
@@ -421,6 +421,7 @@ def main(argv: list[str] | None = None) -> int:
             "path": text_rel,
             "sha256": text_sha,
             "ctx": M.text_context_for_manifest(text_dest) or TEXT_CTX_BY_TIER[tier],
+            "architecture": M.text_architecture_for_manifest(text_dest),
         }
     ]
 


### PR DESCRIPTION
## Summary
- add a lightweight GGUF `general.architecture` reader beside the existing context reader
- carry text GGUF architecture through real staging/orchestrator `FileEntry`s
- fail `build_manifest()` when staged text GGUF bytes report a non-Gemma architecture such as `qwen35`
- add parser and fail-closed manifest regressions

## Evidence
- `python3 -m pytest packages/training/scripts/manifest/test_eliza1_manifest.py -q` -> 72 passed
- `python3 -m py_compile packages/training/scripts/manifest/eliza1_manifest.py packages/training/scripts/manifest/test_eliza1_manifest.py packages/training/scripts/manifest/stage_real_eliza1_bundle.py packages/training/scripts/manifest/stage_local_eliza1_bundle.py packages/training/scripts/publish/orchestrator.py packages/training/scripts/publish/stage_base_v1_candidate.py` -> exit 0
- `git diff --check origin/develop..HEAD` -> exit 0

Evidence file: `.github/issue-evidence/12216-stage4-manifest-arch-gate/README.md`

## N/A
- Live HF qwen35 audit: remains part of the broader Stage 4 HF audit/checklist item; this PR proves the manifest build gate with a minimal GGUF header fixture.
- Screenshots/video: CLI-only training/publish script change.

Fixes part of #12321.