### PR TITLE
docs(#12244): prose file headers + churn cleanup — model/inference plugins (B14)

### DIFF
--- a/plugins/plugin-anthropic-proxy/__tests__/auto-enable.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/auto-enable.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the `shouldEnable` opt-in predicate: only CLAUDE_MAX_PROXY_MODE
+ * `inline`/`shared` enable the plugin; `off`/unset/unknown do not, with
+ * case-folding and whitespace trimming. Pure logic, no network.
+ */
+
 import { describe, expect, it } from "vitest";
 import { shouldEnable } from "../auto-enable";
 

--- a/plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Edge-case tests for `processBody`: billing/system/metadata insertion, trailing
+ * assistant-prefill and thinking-block stripping, and malformed-body handling.
+ * Pure string transforms, no network.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   type ProcessBodyConfig,

--- a/plugins/plugin-anthropic-proxy/__tests__/proxy-server.routing.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/proxy-server.routing.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Routing tests for `ProxyServer` with `node:https` mocked: the auth-token gate,
+ * `/health`, header rewriting, SSE vs JSON reverse-mapping, and non-200
+ * error passthrough. Captures the outbound upstream request; no live upstream.
+ */
+
 import { EventEmitter } from "node:events";
 import type { ClientRequest, RequestOptions } from "node:https";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-anthropic-proxy/__tests__/proxy.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/proxy.test.ts
@@ -1,3 +1,10 @@
+/**
+ * End-to-end tests for the forward/reverse transform pipeline and `ProxyServer`,
+ * driven against a local `node:http` stub standing in for api.anthropic.com plus
+ * a temp credentials file — deterministic, no live Anthropic call. Also covers
+ * the sanitize/reverse-map round-trip, billing fingerprint, and `resolveConfig`.
+ */
+
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";

--- a/plugins/plugin-anthropic-proxy/__tests__/sse-rewrite.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/sse-rewrite.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests for `createSseStream`: reverse-map patterns and multi-byte UTF-8 /
+ * surrogate-pair sequences split across chunk boundaries flush intact. Pure,
+ * no network.
+ */
+
 import { describe, expect, it } from "vitest";
 import { createSseStream } from "../src/proxy/sse-rewrite.js";
 

--- a/plugins/plugin-anthropic-proxy/index.node.ts
+++ b/plugins/plugin-anthropic-proxy/index.node.ts
@@ -1,3 +1,5 @@
+/** Node platform entry: re-exports the full plugin (service, action, route, transforms) from `index.ts`. */
+
 import pluginDefault from "./index";
 
 export * from "./index";

--- a/plugins/plugin-anthropic-proxy/index.ts
+++ b/plugins/plugin-anthropic-proxy/index.ts
@@ -1,9 +1,10 @@
 /**
- * @elizaos/plugin-anthropic-proxy
- *
- * Routes Anthropic API traffic through a Claude Max/Pro subscription via
- * Claude Code OAuth tokens. Ports Shadow's existing standalone proxy
- * (ocplatform-routing-layer/proxy.js v2.2.3) into the eliza plugin shape.
+ * Plugin definition and `init()` for routing Anthropic API traffic through a
+ * Claude Max/Pro subscription via Claude Code OAuth tokens. Registers the
+ * proxy service, the `PROXY_STATUS` action, and the status route, re-exports
+ * the transform primitives for downstream consumers, and self-declares
+ * `autoEnable`. On start the service self-injects `ANTHROPIC_BASE_URL` so
+ * plugin-anthropic routes transparently through the proxy.
  *
  * Modes (env CLAUDE_MAX_PROXY_MODE):
  *   inline (default): start an in-process proxy on this agent

--- a/plugins/plugin-anthropic-proxy/src/proxy/constants.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/constants.ts
@@ -1,26 +1,18 @@
 /**
- * Plugin constants — algorithm parameters + default fingerprint dictionaries.
- *
- * The 7-layer transformation algorithm itself was ported byte-for-byte from
- * Shadow's `openclaw-routing-layer/proxy.js` v2.2.3. The constants in this
- * file split into two groups:
+ * Algorithm parameters and default fingerprint dictionaries for the transform
+ * pipeline. The constants split into two groups:
  *
  *   1. **Algorithm parameters** (BILLING_HASH_*, REQUIRED_BETAS,
- *      CC_SYNTHETIC_TOOLS, CC_VERSION, etc.) — these are
- *      upstream-detection-bypass surface and
- *      MUST NOT change. They produce the byte-stable identity that makes the
- *      proxy look like a real Claude Code session to Anthropic.
+ *      CC_SYNTHETIC_TOOLS, CC_VERSION, etc.) — upstream-detection-bypass
+ *      surface that MUST stay byte-for-byte accurate: they produce the stable
+ *      identity that makes the proxy look like a real Claude Code session to
+ *      Anthropic.
  *
  *   2. **Fingerprint dictionaries** (DEFAULT_REPLACEMENTS, DEFAULT_TOOL_RENAMES,
  *      DEFAULT_PROP_RENAMES, DEFAULT_REVERSE_MAP, SYSTEM_CONFIG_PARAPHRASE) —
- *      these are *framework-shaped*. v0.2.0 ships eliza defaults derived from
- *      profiling `@elizaos/native-reasoning` outbound calls. Non-eliza users
- *      override via `config.json` or `CLAUDE_MAX_PROXY_CONFIG_PATH` (see
- *      config.json.example).
- *
- * The OpenClaw-specific dictionary that v0.1.0 inherited from proxy.js was
- * removed in v0.2.0 — it leaked OC-specific tool names like `sessions_spawn`
- * mapping to `TaskCreate` for the wrong reasons.
+ *      framework-shaped, defaulting to eliza values derived from profiling
+ *      `@elizaos/native-reasoning` outbound calls. Non-eliza users override via
+ *      `config.json` or `CLAUDE_MAX_PROXY_CONFIG_PATH` (see config.json.example).
  */
 
 import {

--- a/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
@@ -5,7 +5,7 @@
  * Layers (in processing order):
  *   2. String trigger sanitization       (sanitize.ts)
  *   3. Tool name renames                 (tool-rename.ts)
- *   6. Property name renames             (property-rename.ts)
+ *   6. Property name renames             (tool-rename.ts)
  *   4. System prompt template strip      (system-prompt.ts)
  *   5. Tool description strip + synthetic CC tools (cc-tool-injection.ts)
  *   1. Billing fingerprint injection     (billing-fingerprint.ts)

--- a/plugins/plugin-anthropic-proxy/vitest.config.ts
+++ b/plugins/plugin-anthropic-proxy/vitest.config.ts
@@ -1,3 +1,5 @@
+/** Vitest config for the anthropic-proxy plugin: node environment, `__tests__/**` suite, `dist`/`node_modules`/`.live.test.ts` excluded. */
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-anthropic/__tests__/credential-store.test.ts
+++ b/plugins/plugin-anthropic/__tests__/credential-store.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for OAuth token resolution in the credential store; uses real temp dirs and env-var manipulation, no live API. */
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-anthropic/__tests__/image-description.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/image-description.shape.test.ts
@@ -1,3 +1,4 @@
+/** Shape tests for `handleImageDescription` title/description parsing, with the `ai` `generateText` mocked. */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { handleImageDescription } from "../models/image";

--- a/plugins/plugin-anthropic/__tests__/model-capabilities.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/model-capabilities.shape.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Shape tests for the temperature-lock and max-output-token cap resolution:
+ * asserts `ANTHROPIC_TEMPERATURE_LOCKED_MODELS`, per-model / bare-number
+ * `ANTHROPIC_MAX_OUTPUT_TOKENS`, and the built-in opus-4 substring rule against
+ * a mocked runtime, capturing the params passed to the AI SDK. No live API.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-anthropic/__tests__/native-plumbing.live.test.ts
+++ b/plugins/plugin-anthropic/__tests__/native-plumbing.live.test.ts
@@ -1,3 +1,4 @@
+/** Live test: `handleTextSmall` against the real Anthropic API (gated by `describeLive`), asserting real text and populated token usage. */
 import { expect, it } from "vitest";
 
 import { describeLive } from "../../../packages/app-core/test/helpers/live-agent-test";

--- a/plugins/plugin-anthropic/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/native-plumbing.shape.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Shape tests for the native text path: tool-request streaming fallback, prompt
+ * cache-metadata emission and breakpoint capping, per-call model override, AI
+ * SDK v6 usage normalization, and system-message handling. Drives the real
+ * handlers against a mocked runtime and AI SDK — no live API.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-anthropic/__tests__/provider-fetch.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/provider-fetch.shape.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Shape tests for the custom fetch wrapper in the client factory: verifies it
+ * survives malformed JSON request bodies and strips `temperature` only when a
+ * JSON body carries both `top_p` and a zero temperature. `@ai-sdk/anthropic` is
+ * mocked to capture the wrapped fetch; no live API.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-anthropic/index.browser.ts
+++ b/plugins/plugin-anthropic/index.browser.ts
@@ -1,3 +1,4 @@
+/** Browser build entrypoint — re-exports the plugin; `build.ts` emits it to dist/browser (no node:* / process.env). */
 import pluginDefault from "./index";
 
 export * from "./index";

--- a/plugins/plugin-anthropic/index.node.ts
+++ b/plugins/plugin-anthropic/index.node.ts
@@ -1,3 +1,4 @@
+/** Node/Bun build entrypoint — re-exports the plugin; `build.ts` emits it to dist/node. */
 import pluginDefault from "./index";
 
 export * from "./index";

--- a/plugins/plugin-anthropic/index.ts
+++ b/plugins/plugin-anthropic/index.ts
@@ -1,3 +1,16 @@
+/**
+ * Plugin definition for the Anthropic Claude model provider: builds the
+ * `anthropicPlugin` object that registers a handler for every text, reasoning,
+ * image-description, response-handler, and action-planner `ModelType` into the
+ * elizaOS model dispatch layer. Each handler delegates to the functions in
+ * `models/`; no actions, providers, evaluators, services, routes, or events are
+ * registered.
+ *
+ * Also carries the built-in `TestSuite` that exercises key validation and a few
+ * live `useModel()` calls, and the `config` block declaring every supported env
+ * var. `initializeAnthropic` (init.ts) runs at plugin init to detect the auth
+ * mode. The Node and browser build entrypoints re-export this module.
+ */
 import type {
   GenerateTextParams,
   IAgentRuntime,

--- a/plugins/plugin-anthropic/init.ts
+++ b/plugins/plugin-anthropic/init.ts
@@ -1,3 +1,9 @@
+/**
+ * Plugin init step: `initializeAnthropic` resolves the effective `PluginConfig`
+ * from runtime settings, detects the auth mode (apikey / oauth / cli) via the
+ * config and credential-store helpers, and logs the chosen mode at startup. Runs
+ * once when `anthropicPlugin` is loaded; performs no network calls.
+ */
 import { type IAgentRuntime, logger } from "@elizaos/core";
 import { getApiKeyOptional, getAuthMode, isBrowser } from "./utils/config";
 import { getClaudeOAuthMeta, getClaudeOAuthToken } from "./utils/credential-store";

--- a/plugins/plugin-anthropic/models/image.ts
+++ b/plugins/plugin-anthropic/models/image.ts
@@ -1,3 +1,9 @@
+/**
+ * `IMAGE_DESCRIPTION` handler: sends an image URL to the configured small model
+ * and parses the `Title:` / `Description:` response into an
+ * `ImageDescriptionResult`. Uses the shared client factory, retry wrapper, and
+ * usage-event emitter; the small-model default comes from `getSmallModel`.
+ */
 import type { IAgentRuntime, ImageDescriptionParams, ImageDescriptionResult } from "@elizaos/core";
 import { logger, ModelType } from "@elizaos/core";
 import { generateText } from "ai";

--- a/plugins/plugin-anthropic/models/index.ts
+++ b/plugins/plugin-anthropic/models/index.ts
@@ -1,3 +1,4 @@
+/** Barrel re-exporting every model handler wired into `anthropicPlugin`. */
 export { handleImageDescription } from "./image";
 export {
   handleActionPlanner,

--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -1,3 +1,21 @@
+/**
+ * Text-generation core for every Anthropic text/reasoning `ModelType`. Exposes
+ * the per-slot handlers (`handleTextSmall`, `handleTextLarge`,
+ * `handleReasoningLarge`, `handleActionPlanner`, …), each of which resolves its
+ * default model from `utils/config` and calls the shared `generateTextWithModel`.
+ *
+ * `resolveTextParams` normalizes the request before it reaches the AI SDK:
+ * builds the canonical system prompt, applies prompt-cache breakpoints, forces
+ * `temperature=1` for opus-4 / temperature-locked models, drops `topP` when
+ * both topP and temperature are set (the API rejects both), and caps
+ * `maxTokens`. Streaming vs non-streaming is chosen per request; tool-using and
+ * `ELIZA_ANTHROPIC_DISABLE_STREAM` requests take the non-streaming path to avoid
+ * `AI_NoOutputGeneratedError` on tool_use-only responses. `responseSchema`
+ * requests build a native AI SDK `output` object and return parsed JSON.
+ *
+ * When the auth mode is `cli`, generation is delegated to `claude -p` via
+ * `generateViaCli` / `streamViaCli` instead of the SDK client.
+ */
 import type {
   GenerateTextParams,
   IAgentRuntime,

--- a/plugins/plugin-anthropic/providers/anthropic.ts
+++ b/plugins/plugin-anthropic/providers/anthropic.ts
@@ -1,3 +1,15 @@
+/**
+ * AI SDK client factory for the Anthropic provider. `createAnthropicClientWithTopPSupport`
+ * builds a `@ai-sdk/anthropic` client wired to the resolved auth mode: API key,
+ * OAuth bearer (via the credential store, with async refresh and 401/429
+ * failover reporting into the multi-account pool), or the browser proxy base URL.
+ *
+ * The name reflects a custom fetch wrapper that preserves `top_p` alongside
+ * `temperature` handling and injects OAuth headers per request. Consumed by the
+ * text and image handlers; the credential-store failover hooks
+ * (`reportClaudeOAuthInvalid` / `reportClaudeOAuthRateLimited`) let a bad token
+ * be retired without killing the call.
+ */
 import { createAnthropic } from "@ai-sdk/anthropic";
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";

--- a/plugins/plugin-anthropic/types/index.ts
+++ b/plugins/plugin-anthropic/types/index.ts
@@ -1,3 +1,4 @@
+/** Branded string types (`ModelName`, `ValidatedApiKey`, `ModelSize`) and their constructors. */
 export type ValidatedApiKey = string & { readonly __brand: "ValidatedApiKey" };
 
 export type ModelName = string & { readonly __brand: "ModelName" };

--- a/plugins/plugin-anthropic/utils/claude-cli.ts
+++ b/plugins/plugin-anthropic/utils/claude-cli.ts
@@ -1,3 +1,10 @@
+/**
+ * CLI auth mode: `generateViaCli` / `streamViaCli` shell out to `claude -p` via
+ * `Bun.spawn` when `ANTHROPIC_AUTH_MODE=claude-cli`, parsing the CLI's JSON
+ * result into text plus token usage and emitting a usage event. Bun-only (fails
+ * on Node runtimes); does not support `messages`, `tools`, `toolChoice`, or
+ * `responseSchema`.
+ */
 import type { IAgentRuntime, ModelTypeName, TextStreamResult } from "@elizaos/core";
 import { buildCanonicalSystemPrompt, logger } from "@elizaos/core";
 import { emitModelUsageEvent } from "./events";

--- a/plugins/plugin-anthropic/utils/config.ts
+++ b/plugins/plugin-anthropic/utils/config.ts
@@ -1,3 +1,12 @@
+/**
+ * Central settings layer for the plugin. Every accessor reads
+ * `runtime.getSetting(key)` first, then `process.env[key]`, with the `ANTHROPIC_`
+ * prefix taking priority over bare-name cross-provider fallbacks. Provides the
+ * per-slot model selectors (`getSmallModel`, `getLargeModel`, `getNanoModel`, …)
+ * with their small/large fallback chains, auth-mode / API-key / base-URL
+ * resolution, the `isBrowser` guard, and the CoT-budget, temperature-lock, and
+ * max-output-token override parsers documented in this package's CLAUDE.md.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import type { ModelName, ModelSize, ValidatedApiKey } from "../types";
 import { createModelName } from "../types";

--- a/plugins/plugin-anthropic/utils/events.ts
+++ b/plugins/plugin-anthropic/utils/events.ts
@@ -1,3 +1,9 @@
+/**
+ * `emitModelUsageEvent` fires `EventType.MODEL_USED` after each successful
+ * Anthropic call, normalizing the SDK's usage shape (prompt/completion vs
+ * input/output token names, plus cache read/write counts) into the runtime's
+ * usage payload so billing and telemetry consumers see one consistent record.
+ */
 import type { EventPayload, IAgentRuntime, ModelTypeName } from "@elizaos/core";
 import { EventType } from "@elizaos/core";
 

--- a/plugins/plugin-anthropic/utils/retry.ts
+++ b/plugins/plugin-anthropic/utils/retry.ts
@@ -1,3 +1,9 @@
+/**
+ * Retry and error-formatting helpers shared by the model handlers.
+ * `executeWithRetry` wraps a call with exponential backoff on transient
+ * failures; `formatModelError` produces a caller-facing message and
+ * `sanitizeUrlForLogs` strips secrets from URLs before they reach the logger.
+ */
 import { logger } from "@elizaos/core";
 
 interface RetryConfig {

--- a/plugins/plugin-anthropic/vitest.config.ts
+++ b/plugins/plugin-anthropic/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Default vitest config: runs the `__tests__/**` shape/unit suite in Node, excluding the live and harness lanes. */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-anthropic/vitest.live.config.ts
+++ b/plugins/plugin-anthropic/vitest.live.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Vitest config for the live-API lane (`*.live.test.ts`): resolves the
+ * workspace `@elizaos/*` packages (core, plugin-sql) to source so a real
+ * runtime can boot against the live Anthropic API.
+ */
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 

--- a/plugins/plugin-aosp-local-inference/__tests__/aosp-local-inference-bootstrap.test.ts
+++ b/plugins/plugin-aosp-local-inference/__tests__/aosp-local-inference-bootstrap.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for the pure bootstrap helpers — load-arg building, generate
+ * token-budget resolution, embedding gating, bundled-model resolution, and
+ * memory-eviction thresholds. No native library or model is loaded; the
+ * helpers run against real filesystem tempdirs and env overrides, so the
+ * assertions cover the deterministic JS logic rather than the FFI boundary.
+ */
+
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-aosp-local-inference/src/aosp-debug-log.ts
+++ b/plugins/plugin-aosp-local-inference/src/aosp-debug-log.ts
@@ -1,3 +1,14 @@
+/**
+ * Append-only, line-delimited debug trace for the AOSP fused-inference loader.
+ *
+ * Gated by `ELIZA_AOSP_LLAMA_DEBUG_LOG`: `"1"`/`"true"` targets
+ * `$ELIZA_STATE_DIR/aosp-llama-debug.log`, any other non-falsy value is an
+ * explicit path, and unset/`"0"`/`"false"` disables writes entirely. Each
+ * record is an ISO timestamp, an event name, and an optional bigint-safe JSON
+ * detail blob. Writes are best-effort and swallow all errors so diagnostics
+ * can never perturb the inference path.
+ */
+
 import { appendFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 

--- a/plugins/plugin-aosp-local-inference/src/aosp-local-inference-bootstrap.ts
+++ b/plugins/plugin-aosp-local-inference/src/aosp-local-inference-bootstrap.ts
@@ -61,9 +61,9 @@ import {
   type TextToSpeechParams,
   type TranscriptionParams,
 } from "@elizaos/core";
-// @elizaos/shared/local-inference is no longer imported here: every AOSP TTS
-// path now flows through `makeAospFusedKokoroTextToSpeechHandler` below,
-// which dlopen's `libelizainference.so` via bun:ffi and synthesizes Kokoro
+// @elizaos/shared/local-inference is intentionally not imported here: every
+// AOSP TTS path flows through `makeAospFusedKokoroTextToSpeechHandler` below,
+// which dlopens `libelizainference.so` via bun:ffi and synthesizes Kokoro
 // TTS in-process through the fused `eliza_inference_kokoro_*` ABI.
 import { writeAospLlamaDebugLog } from "./aosp-debug-log.js";
 import {

--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit and opportunistic real-binary tests for the CLI inference route: the
+ * `ELIZA_CHAT_VIA_CLI` auto-enable gate, backend resolution, the large-tier
+ * model map, and the claude/codex spawn plus JSONL-parse and prompt-flatten
+ * paths. The child-process spawn seam is mocked so no real model runs; the few
+ * real-binary cases are skipped unless `claude`/`codex` resolve through the SOC2
+ * allowlist on this box.
+ */
 import type { ChatMessage, PluginAutoEnableContext } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 import { shouldEnable } from "../auto-enable";

--- a/plugins/plugin-cli-inference/__tests__/sdk-dependencies.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/sdk-dependencies.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Static-source guard: every `SDK_PACKAGE` a session file lazily imports must be
+ * declared as an `optionalDependency` in package.json (scans the source text; no
+ * real SDK loaded), so the variable dynamic import can resolve when the backend
+ * is enabled while the plugin stays inert otherwise.
+ */
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-cli-inference/index.node.ts
+++ b/plugins/plugin-cli-inference/index.node.ts
@@ -1,3 +1,4 @@
+/** Node entry point: re-exports the full plugin (the real CLI/SDK handlers). */
 import pluginDefault from "./index";
 
 export * from "./index";

--- a/plugins/plugin-cli-inference/src/provider-errors.ts
+++ b/plugins/plugin-cli-inference/src/provider-errors.ts
@@ -1,3 +1,12 @@
+/**
+ * Typed upstream-provider failure plus retryability classification, shared by the
+ * CLI and SDK handlers. `ProviderApiError` carries the upstream status so
+ * `useModel` / AccountPool failover classify 429/529/5xx as retryable.
+ * `parseProviderApiErrorText` recognizes the SDK's own streamed error envelope
+ * ("API Error: <status> …") that Claude Code emits as assistant text, so a leaked
+ * error string is thrown to failover instead of relayed to the user as a reply.
+ */
+
 export class ProviderApiError extends Error {
   readonly statusCode?: number;
   readonly retryable: boolean;

--- a/plugins/plugin-cli-inference/vitest.config.ts
+++ b/plugins/plugin-cli-inference/vitest.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Vitest config for the unit suite (mock spawn / fake SDK — no real CLI process
+ * or live model). Aliases `@elizaos/core` to its built node bundle and excludes
+ * the live/real lanes.
+ */
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 

--- a/plugins/plugin-google-genai/__tests__/config.test.ts
+++ b/plugins/plugin-google-genai/__tests__/config.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the settings-resolution helpers in `utils/config` — runtime vs
+ * env precedence, blank trimming, model-alias fallback, and client creation.
+ * `@google/genai` and the logger are mocked; no network.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/embedding.shape.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for `handleTextEmbedding`: the null-probe marker vector, usage
+ * emission, and the throw paths (empty input, empty API response). The config,
+ * events, tokenization, and `@google/genai` layers are mocked — no live call.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-google-genai/__tests__/integration/google-genai.live.test.ts
+++ b/plugins/plugin-google-genai/__tests__/integration/google-genai.live.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Live integration smoke test hitting the real Google Generative Language API
+ * directly (model list, text generation, embeddings, JSON output). Self-skips
+ * when `GOOGLE_GENERATIVE_AI_API_KEY` is unset.
+ */
 import { config } from "dotenv";
 import { beforeAll, describe, expect, it } from "vitest";
 

--- a/plugins/plugin-google-genai/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/native-plumbing.shape.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the generic-to-Google request/response plumbing in
+ * `models/text`: tool + toolChoice + responseSchema + attachment mapping into
+ * `generateContent`, native tool-call extraction, duplicate-system-message
+ * elision, and the unnamed-tool / uninitialized-client error paths. The core
+ * runtime and `generateContent` are mocked — no live model.
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({

--- a/plugins/plugin-google-genai/__tests__/trajectory.test.ts
+++ b/plugins/plugin-google-genai/__tests__/trajectory.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Live test that real `TEXT_SMALL`/`TEXT_LARGE` and native tool-call generation
+ * flow through `recordLlmCall` into the trajectory logger with correct step id,
+ * action type, token counts, and response. Hits the real Gemini API and
+ * self-skips when `GOOGLE_GENERATIVE_AI_API_KEY` is unset.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { runWithTrajectoryContext } from "@elizaos/core";
 import { describe, expect, it } from "vitest";

--- a/plugins/plugin-google-genai/index.browser.ts
+++ b/plugins/plugin-google-genai/index.browser.ts
@@ -1,3 +1,4 @@
+/** Browser build entrypoint — re-exports the plugin from `./index`. */
 import pluginDefault from "./index";
 
 export * from "./index";

--- a/plugins/plugin-google-genai/index.node.ts
+++ b/plugins/plugin-google-genai/index.node.ts
@@ -1,3 +1,4 @@
+/** Node/Bun build entrypoint — re-exports the plugin from `./index`. */
 import pluginDefault from "./index";
 
 export * from "./index";

--- a/plugins/plugin-google-genai/index.ts
+++ b/plugins/plugin-google-genai/index.ts
@@ -1,3 +1,15 @@
+/**
+ * Assembles the `googleGenAIPlugin` object: the plugin's entire surface is a
+ * `models` map binding each elizaOS `ModelType` (nano/small/medium/large/mega,
+ * response-handler, action-planner, embedding, image-description) to a handler
+ * from `./models`. No actions, providers, evaluators, or routes are registered.
+ *
+ * `init` validates the API key at startup, `config` mirrors every supported env
+ * var (both `GOOGLE_*` and generic aliases) into the runtime setting store, and
+ * `tests` carries a live TestSuite that drives real Gemini calls through
+ * `runtime.useModel`. The `index.node.ts` / `index.browser.ts` entrypoints
+ * re-export this for the dual build targets.
+ */
 import type {
   GenerateTextParams,
   IAgentRuntime,

--- a/plugins/plugin-google-genai/init.ts
+++ b/plugins/plugin-google-genai/init.ts
@@ -1,3 +1,11 @@
+/**
+ * Startup validation for the Gemini provider: `initializeGoogleGenAI` reads the
+ * API key and lists available models to confirm the credential works, logging a
+ * warning (never throwing) when the key is missing or the check fails so a
+ * misconfigured key degrades to "no models registered" rather than crashing
+ * boot. Invoked from the plugin's `init` hook. `PluginConfig` is the shape of
+ * the settings object elizaOS passes in.
+ */
 import { type IAgentRuntime, logger } from "@elizaos/core";
 import { GoogleGenAI } from "@google/genai";
 import { getApiKey } from "./utils/config";

--- a/plugins/plugin-google-genai/models/embedding.ts
+++ b/plugins/plugin-google-genai/models/embedding.ts
@@ -1,3 +1,11 @@
+/**
+ * `TEXT_EMBEDDING` handler backed by Google's `text-embedding-004` (768-dim).
+ * A `null`/empty-object input is treated as an initialization probe and answered
+ * with a fixed 768-length marker vector so the runtime can size its embedding
+ * column without a network call; real text is truncated to the model's ~8192
+ * token limit, embedded, and reported via `emitModelUsageEvent`. Throws on empty
+ * text and on an empty API response rather than fabricating a vector.
+ */
 import type { IAgentRuntime, TextEmbeddingParams } from "@elizaos/core";
 import * as ElizaCore from "@elizaos/core";
 import { logger } from "@elizaos/core";

--- a/plugins/plugin-google-genai/models/image.ts
+++ b/plugins/plugin-google-genai/models/image.ts
@@ -1,3 +1,9 @@
+/**
+ * `IMAGE_DESCRIPTION` handler: fetches an image by URL, encodes it inline, and
+ * asks the multimodal Gemini model for a `{ title, description }`. Prefers the
+ * model's JSON output and falls back to regex title extraction from prose. The
+ * call is wrapped in `recordLlmCall` for trajectory capture.
+ */
 import type {
   IAgentRuntime,
   ImageDescriptionParams,

--- a/plugins/plugin-google-genai/models/index.ts
+++ b/plugins/plugin-google-genai/models/index.ts
@@ -1,3 +1,4 @@
+/** Barrel re-exporting every model handler for the plugin's `models` map. */
 export { handleTextEmbedding } from "./embedding";
 export { handleImageDescription } from "./image";
 export {

--- a/plugins/plugin-google-genai/models/text.ts
+++ b/plugins/plugin-google-genai/models/text.ts
@@ -1,3 +1,21 @@
+/**
+ * Text-generation handlers backing every text `ModelType` tier
+ * (nano/small/medium/large/mega, response-handler, action-planner). Each
+ * handler resolves its concrete Gemini model name via `../utils/config`, builds
+ * a `generateContent` request, and runs it through `recordLlmCall` so the call
+ * lands in the trajectory log before returning.
+ *
+ * This module owns the translation between elizaOS's generic call shape and
+ * Google's native `@google/genai` protocol: `normalizeToolsForGoogle` /
+ * `normalizeToolConfigForGoogle` convert generic or native tool definitions to
+ * `functionDeclarations` + `functionCallingConfig`, `resolveResponseJsonSchema`
+ * routes structured-output schemas into `responseJsonSchema`, and
+ * `buildPromptParts` inlines attachments (data URLs, remote URIs, raw bytes).
+ * On the way back, `buildGoogleNativeTextResult` folds text, tool calls, finish
+ * reason, and token usage into a single object that is returned as a
+ * string-with-attached-fields (`GoogleTextModelResult`) whenever the caller
+ * passed messages/tools/toolChoice/responseSchema, else as plain text.
+ */
 import type {
   GenerateTextParams,
   IAgentRuntime,

--- a/plugins/plugin-google-genai/types/index.ts
+++ b/plugins/plugin-google-genai/types/index.ts
@@ -1,3 +1,4 @@
+/** Local transport/DTO interfaces for the Gemini provider's request and response shapes. */
 export interface TokenUsage {
   promptTokens: number;
   completionTokens: number;

--- a/plugins/plugin-google-genai/utils/config.ts
+++ b/plugins/plugin-google-genai/utils/config.ts
@@ -1,3 +1,12 @@
+/**
+ * Settings resolution for the Gemini provider. `getSetting` reads
+ * `runtime.getSetting` first, then `process.env` (guarding `typeof process` so
+ * the browser build stays Node-free), trimming blanks to `undefined`. The
+ * `get*Model` helpers layer the model-name fallback chain: each tier prefers its
+ * `GOOGLE_*` key, then the generic alias, then a coarser tier's default.
+ * `createGoogleGenAI` builds an authenticated client (null when no key), and
+ * `getSafetySettings` returns the hardcoded block-medium-and-above thresholds.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import { GoogleGenAI, HarmBlockThreshold, HarmCategory } from "@google/genai";

--- a/plugins/plugin-google-genai/utils/events.ts
+++ b/plugins/plugin-google-genai/utils/events.ts
@@ -1,3 +1,4 @@
+/** Emits the `MODEL_USED` runtime event with per-call token usage after each model call. */
 import type { EventPayload, IAgentRuntime, ModelTypeName } from "@elizaos/core";
 
 const MODEL_USED_EVENT = "MODEL_USED";

--- a/plugins/plugin-google-genai/utils/index.ts
+++ b/plugins/plugin-google-genai/utils/index.ts
@@ -1,3 +1,4 @@
+/** Barrel re-exporting the config, event, and tokenization utilities. */
 export * from "./config";
 export * from "./events";
 export * from "./tokenization";

--- a/plugins/plugin-google-genai/utils/tokenization.ts
+++ b/plugins/plugin-google-genai/utils/tokenization.ts
@@ -1,3 +1,7 @@
+/**
+ * Char-length token estimate (`length / 4`) used for telemetry only — not a real
+ * tokenizer; do not rely on it for context-window management.
+ */
 export async function countTokens(text: string): Promise<number> {
   return Math.ceil(text.length / 4);
 }

--- a/plugins/plugin-google-genai/vitest.config.ts
+++ b/plugins/plugin-google-genai/vitest.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Default unit-test config: runs `__tests__/**\/*.test.ts`, excluding the
+ * PGLite-backed `*.harness.test.ts` suite (see `vitest.harness.config.ts`) and
+ * the live `*.live.test.ts` suite outside the post-merge lane.
+ */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-lmstudio/__tests__/config.test.ts
+++ b/plugins/plugin-lmstudio/__tests__/config.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for setting resolution — base URL normalization, api key trimming,
+ * per-tier model fallbacks, and auto-detect parsing. Pure, no network.
+ */
+
 import { afterEach, describe, expect, it } from "vitest";
 
 import {

--- a/plugins/plugin-lmstudio/__tests__/detect.test.ts
+++ b/plugins/plugin-lmstudio/__tests__/detect.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for detectLMStudio and parseModelsResponse, driven through an
+ * injected fake fetch — no live LM Studio server.
+ */
+
 import { describe, expect, it, vi } from "vitest";
 
 import { detectLMStudio, parseModelsResponse } from "../utils/detect";

--- a/plugins/plugin-lmstudio/__tests__/embedding.test.ts
+++ b/plugins/plugin-lmstudio/__tests__/embedding.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for handleTextEmbedding with the AI SDK `embed` and the provider
+ * factory mocked — covers the unset-model zero vector, the empty-input probe
+ * substitution, oversized-input truncation, and throw-on-provider-failure.
+ */
+
 import type { IAgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-lmstudio/__tests__/text.shape.test.ts
+++ b/plugins/plugin-lmstudio/__tests__/text.shape.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the text-generation plumbing — model resolution, native tool
+ * and message normalization, structured-output vs tools precedence, and
+ * streaming vs generateText routing. The AI SDK, provider factory, and
+ * detection are all mocked, so no live model is called.
+ */
+
 import type { GenerateTextResult, IAgentRuntime, TextStreamResult } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-lmstudio/index.browser.ts
+++ b/plugins/plugin-lmstudio/index.browser.ts
@@ -1,3 +1,8 @@
+/**
+ * Browser build entry — re-exports the LM Studio plugin surface for the browser
+ * bundle. Only usable when LM Studio sits behind a CORS-permissive proxy.
+ */
+
 import { lmStudioPlugin } from "./plugin";
 
 export * from "./types";

--- a/plugins/plugin-lmstudio/index.node.ts
+++ b/plugins/plugin-lmstudio/index.node.ts
@@ -1,3 +1,7 @@
+/**
+ * Node/Bun build entry — re-exports the LM Studio plugin surface for the server bundle.
+ */
+
 import { lmStudioPlugin } from "./plugin";
 
 export * from "./types";

--- a/plugins/plugin-lmstudio/index.ts
+++ b/plugins/plugin-lmstudio/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Package entry — re-exports the LM Studio plugin, its public types, and the
+ * config/detect utilities, and exposes the plugin as the default export.
+ */
+
 import { lmStudioPlugin } from "./plugin";
 
 export * from "./types";

--- a/plugins/plugin-lmstudio/models/index.ts
+++ b/plugins/plugin-lmstudio/models/index.ts
@@ -1,3 +1,5 @@
+/** Barrel for the LM Studio model handlers — text tiers plus embeddings. */
+
 export { handleTextEmbedding } from "./embedding";
 export {
   handleActionPlanner,

--- a/plugins/plugin-lmstudio/utils/index.ts
+++ b/plugins/plugin-lmstudio/utils/index.ts
@@ -1,3 +1,5 @@
+/** Barrel for the LM Studio config, detection, and model-usage utilities. */
+
 export * from "./config";
 export * from "./detect";
 export * from "./model-usage";

--- a/plugins/plugin-lmstudio/vitest.config.ts
+++ b/plugins/plugin-lmstudio/vitest.config.ts
@@ -1,3 +1,5 @@
+/** Vitest config for the plugin's unit tests (node environment). */
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-local-inference/__tests__/apple-foundation.test.ts
+++ b/plugins/plugin-local-inference/__tests__/apple-foundation.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Registration and singleton lifecycle of the Apple Foundation Models backend
+ * adapter. Drives the adapter against a stubbed iOS computer-use bridge rather
+ * than a real on-device model.
+ */
 import { beforeEach, describe, expect, it } from "vitest";
 import type {
   IosBridgeResult,

--- a/plugins/plugin-local-inference/__tests__/assignments-fallback.test.ts
+++ b/plugins/plugin-local-inference/__tests__/assignments-fallback.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Deterministic coverage for `buildRecommendedAssignments`, the fallback that
+ * maps installed models onto per-model-type slots when no explicit assignment
+ * exists. Pure function; no model or filesystem access.
+ */
 import { describe, expect, it } from "vitest";
 import type { InstalledModel } from "@elizaos/shared";
 import { buildRecommendedAssignments } from "../src/services/assignments.ts";

--- a/plugins/plugin-local-inference/__tests__/ensure-assigned-model-loaded.test.ts
+++ b/plugins/plugin-local-inference/__tests__/ensure-assigned-model-loaded.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Coverage for the "load the assigned model before a model call" boot path,
+ * exercising the assignments/installed-model/loader state via hoisted mocks
+ * rather than a real backend load.
+ */
 import { type AgentRuntime, ModelType } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-local-inference/__tests__/first-line-cache.test.ts
+++ b/plugins/plugin-local-inference/__tests__/first-line-cache.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Coverage for `FirstLineCache`, the on-disk cache of pre-synthesized first
+ * TTS sentences plus its voice-revision fingerprint/invalidation helpers.
+ * Exercises the real filesystem against a temp directory.
+ */
 import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-inference/__tests__/local-inference-tts-route.test.ts
+++ b/plugins/plugin-local-inference/__tests__/local-inference-tts-route.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Coverage for the local-inference TTS HTTP route handler and its speech-text
+ * sanitizer, driving requests through mocked node:http objects rather than a
+ * live TTS backend.
+ */
 import * as http from "node:http";
 import { Socket } from "node:net";
 import { describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-local-inference/__tests__/provider.test.ts
+++ b/plugins/plugin-local-inference/__tests__/provider.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Coverage for the plugin's model-handler factory and the
+ * `LocalInferenceUnavailableError` contract: which model types register and how
+ * handlers behave when no backend service is present. Uses a mock runtime.
+ */
 import { ModelType } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-local-inference/__tests__/wrap-with-first-line-cache.test.ts
+++ b/plugins/plugin-local-inference/__tests__/wrap-with-first-line-cache.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Coverage for `wrapWithFirstLineCache`, which decorates a TTS handler so the
+ * first synthesized sentence is served from `FirstLineCache`. Exercises the
+ * real cache against a temp directory with a stub runtime and handler.
+ */
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-inference/build.ts
+++ b/plugins/plugin-local-inference/build.ts
@@ -1,4 +1,10 @@
 #!/usr/bin/env bun
+/**
+ * Bundles the plugin's public entrypoints with `Bun.build` (ESM, workspace and
+ * native deps kept external) and emits `.d.ts` declarations via tsc, then
+ * smoke-imports the built route/voice barrels to catch resolution breaks the
+ * bundler does not surface on its own.
+ */
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { $ } from "bun";
@@ -23,8 +29,7 @@ function rmRecursive(target: string) {
 const external = await externalsFromPackageJson("./package.json", {
 	// Transitive workspace deps + native sub-packages + wildcards the prior
 	// hand-list relied on. `llama-cpp-capacitor` is the canonical mobile
-	// binding; bun:* covers the desktop bun:ffi loader. node-llama-cpp has
-	// been removed.
+	// binding; bun:* covers the desktop bun:ffi loader.
 	extra: [
 		"@elizaos/agent",
 		"llama-cpp-capacitor",

--- a/plugins/plugin-local-inference/native/verify/asr_bench.test.ts
+++ b/plugins/plugin-local-inference/native/verify/asr_bench.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for the ASR-bench labelled-set provenance classifier: asserts
+ * that TTS-loopback and unknown-provenance WAV sets are marked
+ * publish-gate-ineligible so self-labelled or generated audio never counts as
+ * real-recorded WER. Pure, no model or audio backend.
+ */
 import { describe, expect, test } from "bun:test";
 
 import {

--- a/plugins/plugin-local-inference/native/verify/bargein_endurance_harness.test.mjs
+++ b/plugins/plugin-local-inference/native/verify/bargein_endurance_harness.test.mjs
@@ -1,3 +1,9 @@
+/**
+ * Deterministic checks over the barge-in and thirty-turn endurance report
+ * builders: feeds canned e2e-loop runs and asserts cancel-latency, RSS-growth,
+ * and required-optimization gates pass and fail as designed. No model or audio
+ * backend.
+ */
 import assert from "node:assert/strict";
 import test from "node:test";
 

--- a/plugins/plugin-local-inference/native/verify/check_kernel_contract.mjs
+++ b/plugins/plugin-local-inference/native/verify/check_kernel_contract.mjs
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
 
+/**
+ * Validates native/verify/kernel-contract.json against the llama.cpp MTP build
+ * script, the Eliza-1 manifest schema, and the per-backend runtime-dispatch
+ * evidence (metal, vulkan, cuda, cpu) — fails when the declared kernel contract
+ * and the build/manifest/dispatch artifacts drift apart.
+ */
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-local-inference/native/verify/eagle3_drafter_runtime_smoke.mjs
+++ b/plugins/plugin-local-inference/native/verify/eagle3_drafter_runtime_smoke.mjs
@@ -1,4 +1,10 @@
 #!/usr/bin/env node
+/**
+ * Runtime smoke for EAGLE3 speculative decoding: spawns the spec-capable
+ * llama-cli against a real Eliza-1 bundle with and without the EAGLE3 drafter and
+ * writes a speculative benchmark report (acceptance rate, speedup) via
+ * speculative_benchmark_report.mjs. Hits a real native backend and model files.
+ */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";

--- a/plugins/plugin-local-inference/native/verify/eliza1_vision_smoke.mjs
+++ b/plugins/plugin-local-inference/native/verify/eliza1_vision_smoke.mjs
@@ -1,4 +1,10 @@
 #!/usr/bin/env node
+/**
+ * Inspects an Eliza-1 bundle for its per-tier vision (mmproj) asset and, when
+ * present, runs llama-mtmd-cli on an image to confirm the multimodal describe
+ * path answers. Emits a report used as vision-capability gate evidence; hits a
+ * real native binary and model files when a bundle is supplied.
+ */
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";

--- a/plugins/plugin-local-inference/native/verify/eliza1_vision_smoke.test.mjs
+++ b/plugins/plugin-local-inference/native/verify/eliza1_vision_smoke.test.mjs
@@ -1,3 +1,8 @@
+/**
+ * Deterministic coverage for the eliza1_vision_smoke report builder and
+ * vision-artifact resolver, exercised over temp bundles with a missing mtmd
+ * binary. No real model — verifies the fail-closed report shape only.
+ */
 import assert from "node:assert/strict";
 import {
   mkdirSync,

--- a/plugins/plugin-local-inference/native/verify/mtp_runtime_smoke.mjs
+++ b/plugins/plugin-local-inference/native/verify/mtp_runtime_smoke.mjs
@@ -1,4 +1,10 @@
 #!/usr/bin/env node
+/**
+ * Runtime smoke for MTP (multi-token-prediction) speculative decoding: runs the
+ * spec-capable llama-cli against a real Eliza-1 target model, parses throughput,
+ * and writes a speculative benchmark report via speculative_benchmark_report.mjs.
+ * Hits a real native backend and model files.
+ */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";

--- a/plugins/plugin-local-inference/native/verify/mtp_runtime_smoke.test.mjs
+++ b/plugins/plugin-local-inference/native/verify/mtp_runtime_smoke.test.mjs
@@ -1,3 +1,8 @@
+/**
+ * Unit coverage for parseBenchOutput: asserts tokens-per-second is read from both
+ * the llama-cli bracket summary and the llama.cpp eval performance counters. Pure
+ * string parsing, no model.
+ */
 import assert from "node:assert/strict";
 import test from "node:test";
 

--- a/plugins/plugin-local-inference/native/verify/speculative_benchmark_report.mjs
+++ b/plugins/plugin-local-inference/native/verify/speculative_benchmark_report.mjs
@@ -1,3 +1,9 @@
+/**
+ * Shared report shape for speculative-decode benchmarks (MTP, EAGLE3): builds the
+ * eliza.speculative-benchmark.v1 record — acceptance rate, speedup, timestamped
+ * report paths — from with/without-drafter runs. Consumed by mtp_runtime_smoke.mjs
+ * and eagle3_drafter_runtime_smoke.mjs.
+ */
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";

--- a/plugins/plugin-local-inference/native/verify/speculative_benchmark_report.test.mjs
+++ b/plugins/plugin-local-inference/native/verify/speculative_benchmark_report.test.mjs
@@ -1,3 +1,8 @@
+/**
+ * Unit coverage for the shared speculative benchmark report builder and its
+ * report-path helpers: asserts acceptance rate, speedup, and on-disk report shape
+ * for each speculator. Deterministic, writes to a temp dir.
+ */
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";

--- a/plugins/plugin-local-inference/native/verify/voice_profile_emotion_status.mjs
+++ b/plugins/plugin-local-inference/native/verify/voice_profile_emotion_status.mjs
@@ -1,4 +1,12 @@
 #!/usr/bin/env node
+/**
+ * Derives a fail-closed product-status report for the reference-voice-profile and
+ * native-emotion features: inspects the default voice-preset binary (magic and
+ * version header, zero-filled placeholder detection), scans bundle assets, and
+ * checks for the required native ASR/emotion runtime symbols. Writes status
+ * evidence used as a publish gate; a missing or placeholder asset yields an
+ * explicit "not ready" rather than a passing default.
+ */
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {

--- a/plugins/plugin-local-inference/native/verify/voice_profile_emotion_status.test.mjs
+++ b/plugins/plugin-local-inference/native/verify/voice_profile_emotion_status.test.mjs
@@ -1,3 +1,9 @@
+/**
+ * Deterministic coverage for the voice-profile/emotion status deriver: builds
+ * placeholder and valid voice-preset binaries in a temp dir and asserts the
+ * fail-closed report flags zero-filled Samantha placeholders and missing native
+ * emotion evidence. No real model.
+ */
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/plugins/plugin-local-inference/native/voice-bench/src/__tests__/audio-source.test.ts
+++ b/plugins/plugin-local-inference/native/voice-bench/src/__tests__/audio-source.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit coverage for the voice-bench audio source: WAV encode/decode round-trip
+ * fidelity and SyntheticAudioSource frame generation over fixture utterances,
+ * silence, and barge-in overlays. Pure DSP, no audio device.
+ */
 import { describe, it, expect } from "bun:test";
 import {
   SyntheticAudioSource,

--- a/plugins/plugin-local-inference/native/voice-bench/src/__tests__/metrics.test.ts
+++ b/plugins/plugin-local-inference/native/voice-bench/src/__tests__/metrics.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for the voice-bench MetricsCollector and percentile helper:
+ * asserts first-observation timestamps and derived latencies (TTFA,
+ * speech-end to first-audio) from probed events. Deterministic, stub driver
+ * result.
+ */
 import { describe, it, expect } from "bun:test";
 import { MetricsCollector, percentile } from "../metrics.ts";
 import type { BenchDriverResult } from "../types.ts";

--- a/plugins/plugin-local-inference/native/voice-bench/src/__tests__/scenarios.test.ts
+++ b/plugins/plugin-local-inference/native/voice-bench/src/__tests__/scenarios.test.ts
@@ -1,3 +1,8 @@
+/**
+ * End-to-end coverage of the voice-bench harness wiring — scenario build, runner,
+ * metrics, and gate evaluation/aggregation — driven by the deterministic
+ * MockPipelineDriver rather than a real voice pipeline.
+ */
 import { describe, it, expect } from "bun:test";
 import { buildScenarios, SCENARIO_IDS } from "../scenarios.ts";
 import { MockPipelineDriver } from "../mock-driver.ts";

--- a/plugins/plugin-local-inference/scripts/asr-real-smoke.ts
+++ b/plugins/plugin-local-inference/scripts/asr-real-smoke.ts
@@ -94,7 +94,8 @@ try {
 	if (trimmed.length === 0) fail("empty transcript");
 	if ((words?.length ?? 0) < 5) fail(`too few words (${words?.length ?? 0})`);
 	// freeman.wav is several sentences. >=2 sentence-final marks proves the
-	// decode loop no longer early-stops at the first '.'/'?'/'!'.
+	// decode loop runs to completion rather than early-stopping at the first
+	// '.'/'?'/'!'.
 	if (sentenceCount < 2) {
 		fail(
 			`transcript has ${sentenceCount} sentence-final marks — looks truncated ` +

--- a/plugins/plugin-local-inference/scripts/local-model-lifecycle-matrix.ts
+++ b/plugins/plugin-local-inference/scripts/local-model-lifecycle-matrix.ts
@@ -1,4 +1,11 @@
 #!/usr/bin/env bun
+/**
+ * CLI that builds the local-model lifecycle matrix: runs file, bundle, remote,
+ * and optional load-run checks across the Eliza-1 model catalog against the
+ * installed registry and detected hardware, then emits JSON or Markdown. A
+ * --require-complete run is the gate that every catalog model can be resolved,
+ * downloaded, loaded, and run on this host.
+ */
 import fs from "node:fs/promises";
 import path from "node:path";
 import { MODEL_CATALOG } from "../src/services/catalog";

--- a/plugins/plugin-local-inference/scripts/memory-benchmark.ts
+++ b/plugins/plugin-local-inference/scripts/memory-benchmark.ts
@@ -1,4 +1,9 @@
 #!/usr/bin/env bun
+/**
+ * CLI wrapper around the memory-benchmark service: loads a local model (optionally
+ * the installed default) and measures peak RSS across a generation run, printing a
+ * summary or JSON report. Tracks the on-device memory budget for Eliza-1 tiers.
+ */
 import {
 	runMemoryBenchmark,
 	summarizeMemoryBenchmark,

--- a/plugins/plugin-local-inference/src/actions/transcription-control.test.ts
+++ b/plugins/plugin-local-inference/src/actions/transcription-control.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the START/STOP_TRANSCRIPTION actions and `emitVoiceControl`.
+ * A fake runtime with a stubbed agent-event bus stands in for the real service;
+ * asserts the one-way voice-control command is emitted, and reported as
+ * undeliverable when no bus is connected.
+ */
+
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/__tests__/compat-behavior.test.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/__tests__/compat-behavior.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Behavioral tests for the Capacitor-llama `local-ai` plugin's model handlers.
+ * The loader is mocked and a hand-built `CapacitorLlamaContext` fake drives
+ * completion/streaming, so the handler wiring — not a real native model — is
+ * under test.
+ */
+
 import type { IAgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/__tests__/index.test.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/__tests__/index.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Structural tests for the Capacitor-llama `local-ai` plugin's metadata and
+ * handler registration (name, description, init, model-handler presence). No
+ * native model — pure object-shape assertions.
+ */
+
 import { ModelType } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { configSchema } from "../environment";

--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/__tests__/memory-admission.test.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/__tests__/memory-admission.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Deterministic fit-math tests for the mobile GPU memory-admission planner
+ * (#11612). Feeds the measured iPhone 16 Pro Max (A18) numbers into
+ * `planMobileGpuAdmission` and pins the n_ubatch=256 fit against the pre-fix
+ * OOM configuration; arithmetic only, no device.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
 	extractLayerCount,

--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/__tests__/structured-output.test.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/__tests__/structured-output.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests the Capacitor structured-output planning: grammar / JSON-schema request
+ * shaping and OpenAI-shaped tool-call extraction back into the elizaOS
+ * `ToolCallResult`. Deterministic, no native model.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
 	applyStructuredPlan,

--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/__tests__/text-streaming.test.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/__tests__/text-streaming.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests the Capacitor push→pull streaming bridge (`streamCapacitorPrompt`). A
+ * fake context replays token callbacks; asserts the assembled `TextStreamResult`
+ * text, usage, and finish reason. No native model.
+ */
+
 import type { TokenUsage } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { streamCapacitorPrompt } from "../text-streaming";

--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/environment.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/environment.ts
@@ -1,3 +1,12 @@
+/**
+ * Environment-config validation for the Capacitor/mobile local-AI adapter.
+ * Parses the model-filename and embedding-dimension overrides
+ * (`LOCAL_SMALL_MODEL`, `LOCAL_LARGE_MODEL`, `LOCAL_EMBEDDING_MODEL`,
+ * `MODELS_DIR`, `CACHE_DIR`, `LOCAL_EMBEDDING_DIMENSIONS`) from `process.env`
+ * through a zod schema, defaulting to the bundled Eliza-1 GGUF filenames and
+ * throwing a readable aggregated error on invalid input.
+ */
+
 import { logger } from "@elizaos/core";
 import { z } from "zod";
 

--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/text-streaming.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/text-streaming.ts
@@ -4,8 +4,7 @@
  * The Capacitor `LlamaContext.completion(params, callback)` API is push-based:
  * `callback` fires once per token. The elizaOS runtime consumes a pull-based
  * `TextStreamResult` (`{ textStream, text, usage, finishReason }`). We bridge
- * the two with a queue-backed async iterator, identical in shape to the
- * legacy node-llama-cpp bridge.
+ * the two with a queue-backed async iterator.
  */
 
 import type { TextStreamResult, TokenUsage } from "@elizaos/core";

--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/types.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/types.ts
@@ -322,7 +322,7 @@ export class CapacitorLlamaUnsupportedError extends Error {
 	}
 }
 
-// === Model registry (re-exported from legacy types.ts) =====================
+// === Model registry =======================================================
 
 export interface ModelSpec {
 	name: string;

--- a/plugins/plugin-local-inference/src/local-inference-routes.test.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Exercises the local-inference route handler (catalog / download / status /
+ * chat-command) against mocked service and device-bridge seams — no real model
+ * or FFI backend is loaded.
+ */
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import type http from "node:http";
 import { tmpdir } from "node:os";

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -1,3 +1,11 @@
+/**
+ * HTTP handler for the local-inference catalog, download orchestration, active-
+ * model status, hardware detection, and chat-command routes — the root
+ * `@elizaos/plugin-local-inference` subpath (app-core mounts the compat variant
+ * in `routes/local-inference-compat-routes.ts`). The heavy service graph
+ * (engine / voice / catalog / downloader) is imported lazily on first route use
+ * to keep it off the boot critical path (#9565).
+ */
 import crypto from "node:crypto";
 import * as dns from "node:dns";
 import fs from "node:fs";

--- a/plugins/plugin-local-inference/src/provider.ts
+++ b/plugins/plugin-local-inference/src/provider.ts
@@ -1,3 +1,19 @@
+/**
+ * Defines the local-inference `Plugin` object and the model-handler factory that
+ * fronts every Eliza-1 model slot (`TEXT_SMALL`/`TEXT_LARGE`/`TEXT_EMBEDDING`/
+ * `IMAGE`/`IMAGE_DESCRIPTION`/`TEXT_TO_SPEECH`/`TRANSCRIPTION`). Each handler
+ * resolves the runtime loader service (bionic host / AOSP adapter / device
+ * bridge) and dispatches through it, gating text generation on the process-wide
+ * interactive-over-background priority lane; vision and image generation route
+ * through the MemoryArbiter capability when it is registered.
+ *
+ * When no backend service is exposed, or an active service lacks a capability,
+ * calls raise a typed {@link LocalInferenceUnavailableError} (code
+ * `LOCAL_INFERENCE_UNAVAILABLE`) rather than fabricating output — embeddings in
+ * particular refuse to synthesize zero-vectors. `TEXT_EMBEDDING` is deliberately
+ * absent from the static plugin `models` map and wired later at boot by
+ * `ensureLocalInferenceHandler()`.
+ */
 import {
 	type AudioStreamResult,
 	applyBackgroundInferenceBudget,

--- a/plugins/plugin-local-inference/src/routes/compat-helpers.ts
+++ b/plugins/plugin-local-inference/src/routes/compat-helpers.ts
@@ -1,3 +1,14 @@
+/**
+ * Shared auth and I/O helpers for the local-inference compat HTTP routes.
+ *
+ * Every `*-compat-routes.ts` handler authorizes through here: a request is
+ * trusted when it arrives on loopback with no proxy-forwarding header and a
+ * same-origin/loopback Host (`isTrustedLocalRequest`), otherwise it must present
+ * the configured API token (`getCompatApiToken`, constant-time `tokenMatches`).
+ * Also provides bounded JSON body reading and the JSON responders, which scrub
+ * `Error`/`stack` fields so a route failure never leaks a stack trace to callers.
+ */
+
 import crypto from "node:crypto";
 import type http from "node:http";
 import { isIP } from "node:net";

--- a/plugins/plugin-local-inference/src/routes/local-inference-asr-route.test.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-asr-route.test.ts
@@ -1,3 +1,9 @@
+/**
+ * HTTP-contract tests for the ASR route: auth, audio-body decoding, and the
+ * status probe. `transcribeWavWithWords` and the engine are stubbed — no real
+ * model runs.
+ */
+
 import * as http from "node:http";
 import { Socket } from "node:net";
 import { ModelType } from "@elizaos/core";

--- a/plugins/plugin-local-inference/src/routes/local-inference-asr-route.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-asr-route.ts
@@ -1,3 +1,15 @@
+/**
+ * HTTP route for on-device speech-to-text — `POST /api/asr/local-inference`
+ * plus its `…/status` readiness probe.
+ *
+ * Accepts raw audio bytes or a base64 `audioBase64` JSON body and transcribes
+ * through the registered TRANSCRIPTION model handler via `transcribeWavWithWords`
+ * (fused Gemma ASR runtime). Status reports ready only when both a TRANSCRIPTION
+ * handler is registered and the active Eliza-1 bundle can transcribe locally.
+ * Request/response `close` events abort the in-flight decode so a disconnecting
+ * client frees the model promptly.
+ */
+
 import type http from "node:http";
 import { ModelType } from "@elizaos/core";
 import { localInferenceEngine } from "../services/engine";

--- a/plugins/plugin-local-inference/src/routes/local-inference-asr-transcribe.test.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-asr-transcribe.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `transcribeWavWithWords`: the fused-engine timed path vs the
+ * `useModel` provider-chain fallback and its missing-provider skip logic. The
+ * engine is mocked; no GGUF/FFI runs.
+ */
+
 import { type AgentRuntime, ModelType } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { localInferenceEngine } from "../services/engine";

--- a/plugins/plugin-local-inference/src/routes/local-inference-compat-routes.test.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-compat-routes.test.ts
@@ -1,3 +1,9 @@
+/**
+ * HTTP-contract tests for the `/api/local-inference/*` compat routes (catalog,
+ * downloads, hardware, routing) covering auth and response shape. The service
+ * layer is mocked; no models are downloaded or loaded.
+ */
+
 import * as http from "node:http";
 import { Socket } from "node:net";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-local-inference/src/routes/local-inference-tts-route.test.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-tts-route.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests for the TTS route and `sanitizeLocalInferenceSpeechText`: markup/tag
+ * stripping and the provider-chain dispatch. The TEXT_TO_SPEECH model is stubbed
+ * via a fake runtime; no audio is synthesized.
+ */
+
 import * as http from "node:http";
 import { Socket } from "node:net";
 import { describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-local-inference/src/routes/local-inference-tts-route.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-tts-route.ts
@@ -1,3 +1,14 @@
+/**
+ * HTTP route for on-device text-to-speech — `POST /api/tts/local-inference`.
+ *
+ * `sanitizeLocalInferenceSpeechText` strips reasoning/tool tags, code fences,
+ * markdown, and URLs so the synthesizer never voices markup; the handler then
+ * drives the TEXT_TO_SPEECH model over the platform provider chain
+ * (`eliza-local-inference` → capacitor → device-bridge → AOSP) and returns the
+ * first provider's audio. The sanitizer and `normalizeAudioBytes` are exported
+ * as pure helpers for the route-contract fuzz tests.
+ */
+
 import type http from "node:http";
 import { type AgentRuntime, ModelType } from "@elizaos/core";
 import {

--- a/plugins/plugin-local-inference/src/routes/native-pcm-turn-route.test.ts
+++ b/plugins/plugin-local-inference/src/routes/native-pcm-turn-route.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Tests for the native-PCM voice-turn route: PCM/sample-rate validation and
+ * engine dispatch. `localInferenceEngine` is mocked, so no real voice turn runs.
+ */
+
 import type http from "node:http";
 import { Readable } from "node:stream";
 import { logger } from "@elizaos/core";

--- a/plugins/plugin-local-inference/src/routes/native-pcm-turn-route.ts
+++ b/plugins/plugin-local-inference/src/routes/native-pcm-turn-route.ts
@@ -1,3 +1,13 @@
+/**
+ * HTTP route for a native-captured voice turn — `POST /api/voice/native-pcm-turn`.
+ *
+ * Decodes a base64 Float32 mono PCM buffer plus its sample rate, then hands the
+ * turn to `localInferenceEngine.runVoiceTurn` (after staging the active bundle's
+ * ASR model) so a mobile WebView that captured audio natively can drive the full
+ * on-device voice pipeline. Turn lifecycle events are logged; engine failure
+ * surfaces as a 503.
+ */
+
 import type http from "node:http";
 import { logger, readJsonBody, sendJson, sendJsonError } from "@elizaos/core";
 import { localInferenceEngine } from "../services/engine";

--- a/plugins/plugin-local-inference/src/routes/transcripts-routes.test.ts
+++ b/plugins/plugin-local-inference/src/routes/transcripts-routes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the `/api/transcripts*` rawPath routes — request-to-`Transcript`
+ * shaping via `buildTranscriptFromRequest` and the handler contract.
+ */
+
 import type { Memory, RouteHandlerContext, UUID } from "@elizaos/core";
 import type { TranscriptSegment } from "@elizaos/shared/transcripts";
 import { describe, expect, it } from "vitest";

--- a/plugins/plugin-local-inference/src/runtime/embedding-presets.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/embedding-presets.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for embedding-preset/tier selection across hardware probes
+ * (Apple Silicon / GPU / RAM). Pure-function assertions.
+ */
+
 import { describe, expect, it } from "vitest";
 import type { HardwareProbe } from "../services/types";
 import {

--- a/plugins/plugin-local-inference/src/runtime/embedding-presets.ts
+++ b/plugins/plugin-local-inference/src/runtime/embedding-presets.ts
@@ -1,3 +1,13 @@
+/**
+ * Hardware-tiered presets for the local `TEXT_EMBEDDING` model.
+ *
+ * Maps a device's probe (Apple Silicon / GPU / RAM) to one of three tiers —
+ * all currently gte-small (384-dim, ~64MB fp16 GGUF), differing only in GPU
+ * offload. The dimension is fixed at 384 to match plugin-sql's `dim384` column
+ * exactly, so no per-device model juggling or truncation is needed. Consumed by
+ * `ensureLocalInferenceHandler` and the embedding warm-up path.
+ */
+
 import os from "node:os";
 import type { HardwareProbe } from "../services/types.js";
 

--- a/plugins/plugin-local-inference/src/runtime/embedding-warmup-policy.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/embedding-warmup-policy.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for `shouldWarmupLocalEmbeddingModel`: the env-flag matrix that
+ * gates GGUF embedding prefetch (skip/disable plus cloud-embeddings interplay).
+ */
+
 import { afterEach, describe, expect, it } from "vitest";
 import { shouldWarmupLocalEmbeddingModel } from "./embedding-warmup-policy";
 

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests that `ensureLocalInferenceHandler` registers the TEXT_SMALL/TEXT_LARGE/
+ * TEXT_EMBEDDING handlers and wires the router at boot. Routing mode,
+ * assignments, and the registry are mocked; no model loads.
+ */
+
 import { type AgentRuntime, ModelType } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -10,14 +10,13 @@
  * the router sits at MAX_SAFE_INTEGER and consults the user's policy
  * (manual / cheapest / fastest / prefer-local / round-robin) on every call.
  *
- * Until the cuttlefish smoke landed this was -1 to "let cloud win by default,"
- * but that conflated routing-policy (a user preference) with handler
- * priority (a registration ordinal). The runtime's getModel() returns
- * undefined when no priority-0 handler is registered, which manifested as
- * "No handler found for delegate type: TEXT_SMALL" on AOSP builds where
- * the AOSP local inference loader is the only provider. Both cloud-only and
- * local-only deployments now have a registered priority-0 handler; the
- * router decides which one fires per request.
+ * Priority must not be negative: the runtime's getModel() returns undefined
+ * when no priority-0 handler is registered, which on AOSP builds — where the
+ * AOSP local inference loader is the only provider — surfaces as "No handler
+ * found for delegate type: TEXT_SMALL". A negative priority would conflate
+ * routing-policy (a user preference) with handler priority (a registration
+ * ordinal). Both cloud-only and local-only deployments register a priority-0
+ * handler; the router decides which one fires per request.
  *
  * Parallels `ensure-text-to-speech-handler.ts` — same shape, same guards.
  */
@@ -430,11 +429,10 @@ function engineGenerateArgsFromParams(
 					.join("\n\n")
 			: "";
 	const streamStructured = params.streamStructured === true;
-	// Surface per-token chunks to the caller. The runtime passes the agent
-	// reply path's `onStreamChunk` here when it wants the LLM→TTS handoff —
-	// previously dropped at this layer. Only wire it when the caller asked
-	// for streaming (`stream` or `streamStructured`) so non-streaming callers
-	// don't pay the chunk-callback overhead.
+	// Surface per-token chunks to the caller: the runtime passes the agent
+	// reply path's `onStreamChunk` here for the LLM→TTS handoff. Wire it only
+	// when the caller asked for streaming (`stream` or `streamStructured`) so
+	// non-streaming callers don't pay the chunk-callback overhead.
 	const onTextChunk =
 		(params.stream === true || streamStructured) &&
 		typeof params.onStreamChunk === "function"

--- a/plugins/plugin-local-inference/src/runtime/mobile-local-inference-gate.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/mobile-local-inference-gate.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the mobile inference gate: which combinations of
+ * `ELIZA_DEVICE_BRIDGE_ENABLED` / `ELIZA_LOCAL_LLAMA` / riscv64 arch enable the
+ * on-device path, and the without-platform warning.
+ */
+
 import { describe, expect, it, vi } from "vitest";
 import {
 	shouldEnableMobileLocalInference,

--- a/plugins/plugin-local-inference/src/runtime/voice-entity-binding.transcript.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/voice-entity-binding.transcript.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests that `handleLiveVoiceAttribution` emits `VOICE_TURN_OBSERVED` carrying
+ * the turn transcript for the merge engine. Uses a fake runtime event sink; no
+ * real attribution pipeline or model runs.
+ */
+
 import type { IAgentRuntime } from "@elizaos/core";
 import { EventType } from "@elizaos/core";
 import { describe, expect, it } from "vitest";

--- a/plugins/plugin-local-inference/src/runtime/voice-entity-binding.ts
+++ b/plugins/plugin-local-inference/src/runtime/voice-entity-binding.ts
@@ -135,8 +135,8 @@ export interface HandleLiveVoiceAttributionOptions {
 	 * The ASR transcript for this turn, joined from the streaming-ASR path. When
 	 * provided it rides on `VOICE_TURN_OBSERVED` (and the turn signal) so the
 	 * merge engine's name/partner extraction (`VoiceObserver.ingestTurn`) runs
-	 * from LIVE audio — previously this was hardcoded `""`, so live recognition
-	 * could identify *who* spoke but never *what* they said (#8786). Diarization-
+	 * from LIVE audio, so live recognition identifies both *who* spoke and
+	 * *what* they said (#8786). Diarization-
 	 * only callers (audio-frame path) leave it unset; the in-process voice engine
 	 * (which has both ASR + diarization) passes the real transcript.
 	 */

--- a/plugins/plugin-local-inference/src/services/__tests__/backend-selector.test.ts
+++ b/plugins/plugin-local-inference/src/services/__tests__/backend-selector.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `selectBackend` / `readBackendEnvOverride`: platform + FFI-support → backend id, and env-override parsing. Deterministic, no model. */
 import { describe, expect, it } from "vitest";
 
 import { readBackendEnvOverride, selectBackend } from "../backend-selector";

--- a/plugins/plugin-local-inference/src/services/__tests__/gpu-autotune.test.ts
+++ b/plugins/plugin-local-inference/src/services/__tests__/gpu-autotune.test.ts
@@ -1,3 +1,4 @@
+/** Covers the GPU autotune config table and llama-server flag mapping, reading the real `native/configs/gpu` JSON profiles off disk. Deterministic. */
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-local-inference/src/services/__tests__/runtime-target.test.ts
+++ b/plugins/plugin-local-inference/src/services/__tests__/runtime-target.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for runtime-mode / platform-class inference from env, including that removed spawn/http aliases resolve to null. Deterministic. */
 import { describe, expect, it } from "vitest";
 
 import {

--- a/plugins/plugin-local-inference/src/services/active-model-context-fit.test.ts
+++ b/plugins/plugin-local-inference/src/services/active-model-context-fit.test.ts
@@ -1,3 +1,4 @@
+/** Verifies `resolveLocalInferenceLoadArgs` sizes the context window to the hardware probe's RAM across model sizes. Deterministic, synthetic probes. */
 import { describe, expect, it } from "vitest";
 import { resolveLocalInferenceLoadArgs } from "./active-model";
 import type { HardwareProbe, InstalledModel } from "./types";

--- a/plugins/plugin-local-inference/src/services/active-model-switch-rollback.test.ts
+++ b/plugins/plugin-local-inference/src/services/active-model-switch-rollback.test.ts
@@ -1,3 +1,4 @@
+/** Verifies `ActiveModelCoordinator.switchTo` rolls back to the prior active model when the loader throws mid-swap. Deterministic, fake loader. */
 import type { AgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-local-inference/src/services/active-model.ts
+++ b/plugins/plugin-local-inference/src/services/active-model.ts
@@ -73,7 +73,7 @@ import type { KvOffloadMode, LocalInferenceLoadArgs } from "./load-args.js";
  * (v3.18.1-eliza.3+) extends `GgmlType` with TBQ3_0 (43), TBQ4_0 (44),
  * QJL1_256 (46), Q4_POLAR (47) so the binding accepts the lowercase
  * aliases below. Whether the C++ kernel actually runs depends on the
- * loaded the legacy node-llama-cpp NAPI prebuild (no longer used) binary — the elizaOS/llama.cpp
+ * loaded binary — the elizaOS/llama.cpp
  * prebuild ships the kernels; upstream's prebuild does not.
  *
  * `validateLocalInferenceLoadArgs({ allowFork: false })` (the route-layer

--- a/plugins/plugin-local-inference/src/services/asr-provenance.ts
+++ b/plugins/plugin-local-inference/src/services/asr-provenance.ts
@@ -1,3 +1,11 @@
+/**
+ * Scans a bundle manifest for ASR lineage/provenance fields that reveal Qwen
+ * heritage, returning human-readable blocker strings. Eliza-1 is a Gemma-4
+ * release; the strict-release gate rejects any default-eligible bundle whose
+ * ASR base or source models still carry Qwen provenance (a pre-cutover
+ * stand-in). Paired with `text-provenance.ts`, which reads the same guarantee
+ * out of the GGUF header bytes.
+ */
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 

--- a/plugins/plugin-local-inference/src/services/assignment-validation.test.ts
+++ b/plugins/plugin-local-inference/src/services/assignment-validation.test.ts
@@ -1,3 +1,4 @@
+/** Exercises `setAssignment` validation — rejecting unfit/unservable model assignments — against a real temp state dir. No model. */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-inference/src/services/assignments.test.ts
+++ b/plugins/plugin-local-inference/src/services/assignments.test.ts
@@ -1,3 +1,4 @@
+/** Covers reading/writing model-slot assignments and building recommended defaults against a real temp state dir. No model. */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-inference/src/services/cache-bridge.test.ts
+++ b/plugins/plugin-local-inference/src/services/cache-bridge.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the prompt/KV cache bridge: slot derivation, prefix hashing, cache-key resolution, and TTL-based eviction against a real temp cache dir. */
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-inference/src/services/catalog.test.ts
+++ b/plugins/plugin-local-inference/src/services/catalog.test.ts
@@ -1,3 +1,4 @@
+/** Asserts MODEL_CATALOG invariants (tier ids, default-eligible/MTP sets) and HuggingFace resolve-URL construction. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	buildHuggingFaceResolveUrl,

--- a/plugins/plugin-local-inference/src/services/context-fit.test.ts
+++ b/plugins/plugin-local-inference/src/services/context-fit.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `computeRuntimeContextFit`: context-window sizing under RAM budgets and the opt-in f16-KV precision upgrade. Deterministic. */
 import { describe, expect, it } from "vitest";
 import { computeRuntimeContextFit } from "./context-fit";
 

--- a/plugins/plugin-local-inference/src/services/context-fit.ts
+++ b/plugins/plugin-local-inference/src/services/context-fit.ts
@@ -1,3 +1,11 @@
+/**
+ * Computes the largest usable context window a text model can run on a given
+ * host, trading model weights against KV-cache growth inside the RAM budget.
+ * Sizes the KV cache in the q8_0 quant the device-fit contract keys to, and
+ * optionally upgrades to the more accurate f16 KV when the host has headroom to
+ * do so without shrinking the window (#8809). Consumed by load-args and
+ * recommendation to pick the boot context.
+ */
 import { ELIZA_1_MIN_LOCAL_CONTEXT } from "@elizaos/shared/local-inference";
 import { estimateQuantizedKvBytesPerToken } from "./kv-spill";
 

--- a/plugins/plugin-local-inference/src/services/conversation-registry.test.ts
+++ b/plugins/plugin-local-inference/src/services/conversation-registry.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `ConversationRegistry`: opening/tracking per-conversation inference sessions. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	ConversationRegistry,

--- a/plugins/plugin-local-inference/src/services/device-resource-metrics.test.ts
+++ b/plugins/plugin-local-inference/src/services/device-resource-metrics.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `DeviceResourceMetrics` RAM/CPU/thermal sampling. Deterministic. */
 import { describe, expect, it } from "vitest";
 import { DeviceResourceMetrics } from "./device-resource-metrics";
 

--- a/plugins/plugin-local-inference/src/services/device-tier.test.ts
+++ b/plugins/plugin-local-inference/src/services/device-tier.test.ts
@@ -1,3 +1,4 @@
+/** Covers device-tier classification and the mobile guard that keeps a phone from being assigned a 9B model. Deterministic, synthetic probes. */
 import { describe, expect, it } from "vitest";
 import {
 	classifyDeviceTier,

--- a/plugins/plugin-local-inference/src/services/downloader.test.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.test.ts
@@ -1,3 +1,4 @@
+/** Exercises the curated Eliza-1 `Downloader`: disk preflight, gated-repo handling, and registry writes on completion, against a real temp state dir with a fake HardwareProbe. No network. */
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";

--- a/plugins/plugin-local-inference/src/services/engine-direct-bundle.test.ts
+++ b/plugins/plugin-local-inference/src/services/engine-direct-bundle.test.ts
@@ -1,3 +1,4 @@
+/** Covers `LocalInferenceEngine` loading a direct Eliza-1 bundle from disk (manifest resolution, backend plan). Real fs temp bundles; no live model forward pass. */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-inference/src/services/ffi-streaming-runner.test.ts
+++ b/plugins/plugin-local-inference/src/services/ffi-streaming-runner.test.ts
@@ -1,3 +1,4 @@
+/** Covers the FFI streaming runner's per-step token loop and `maxTokensPerStep` resolution against a fake streaming binding. Deterministic, no native lib. */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	FfiStreamingRunner,

--- a/plugins/plugin-local-inference/src/services/ffi-unload-ordering.test.ts
+++ b/plugins/plugin-local-inference/src/services/ffi-unload-ordering.test.ts
@@ -1,3 +1,4 @@
+/** Verifies the fused-lib FFI backend frees the native library exactly once during acquire/release, with the bindings module mocked so no real lib is dlopened. */
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BackendPlan } from "./backend";

--- a/plugins/plugin-local-inference/src/services/handler-registry.test.ts
+++ b/plugins/plugin-local-inference/src/services/handler-registry.test.ts
@@ -1,3 +1,4 @@
+/** Proves the handler registry populates via the core `getModelRegistrations()` snapshot plus the `MODEL_REGISTERED` event, never by monkey-patching `registerModel`. Fake runtime double, deterministic. */
 import type {
 	IAgentRuntime,
 	ModelRegisteredEventPayload,

--- a/plugins/plugin-local-inference/src/services/hardware.test.ts
+++ b/plugins/plugin-local-inference/src/services/hardware.test.ts
@@ -1,3 +1,4 @@
+/** Covers the hardware probe: OpenVino/GPU device detection and device-tier classification, driven by a synthetic sysfs-file detector. Deterministic. */
 import { afterEach, describe, expect, it } from "vitest";
 import { classifyDeviceTier } from "./device-tier";
 import {

--- a/plugins/plugin-local-inference/src/services/image-description-runtime.test.ts
+++ b/plugins/plugin-local-inference/src/services/image-description-runtime.test.ts
@@ -1,3 +1,4 @@
+/** Covers `createImageDescriptionRuntime` resolving the bundle's vision file and dispatching a describe pass, with the engine mocked. Real fs temp bundles. */
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-inference/src/services/image-description-runtime.ts
+++ b/plugins/plugin-local-inference/src/services/image-description-runtime.ts
@@ -1,3 +1,8 @@
+/**
+ * Backs the `IMAGE_DESCRIPTION` model handler with the active Eliza-1 bundle's
+ * vision GGUF: resolves the vision file from the bundle manifest, loads it
+ * through `localInferenceEngine`, and runs a describe pass over an image path.
+ */
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { localInferenceEngine } from "./engine";

--- a/plugins/plugin-local-inference/src/services/index.ts
+++ b/plugins/plugin-local-inference/src/services/index.ts
@@ -1,3 +1,4 @@
+/** Public surface of the local-inference service layer: backend dispatch, catalog, engine, arbiter, downloader, routing, and registry helpers. */
 export type { LocalInferenceLoader } from "./active-model";
 export {
 	assertVoiceBundleFitsHost,

--- a/plugins/plugin-local-inference/src/services/inference-capabilities.test.ts
+++ b/plugins/plugin-local-inference/src/services/inference-capabilities.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for inference-capability helpers including the thermal-throttle decision. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	defaultsForNoBinding,

--- a/plugins/plugin-local-inference/src/services/kv-spill.test.ts
+++ b/plugins/plugin-local-inference/src/services/kv-spill.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `planKvSpill`: deciding how much KV cache spills to disk given geometry and the RAM budget. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	estimateQuantizedKvBytesPerToken,

--- a/plugins/plugin-local-inference/src/services/latency-trace.test.ts
+++ b/plugins/plugin-local-inference/src/services/latency-trace.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the latency-trace recorder spanning the local-inference request timeline. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	buildVoiceLatencyDevPayload,

--- a/plugins/plugin-local-inference/src/services/lib-target.test.ts
+++ b/plugins/plugin-local-inference/src/services/lib-target.test.ts
@@ -1,3 +1,4 @@
+/** Covers host lib-target resolution and bundle lib-file selection/staging naming for the FFI backend. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	libStagedName,

--- a/plugins/plugin-local-inference/src/services/lifecycle-loadrun.test.ts
+++ b/plugins/plugin-local-inference/src/services/lifecycle-loadrun.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `collectLifecycleLoadRunChecks`, the model load/run lifecycle preflight checks. Deterministic. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { collectLifecycleLoadRunChecks } from "./lifecycle-loadrun";

--- a/plugins/plugin-local-inference/src/services/lifecycle-remote-checks.test.ts
+++ b/plugins/plugin-local-inference/src/services/lifecycle-remote-checks.test.ts
@@ -1,3 +1,4 @@
+/** Covers remote lifecycle checks: request headers, URL validation, and manifest file-path flattening for hosted bundles. Deterministic. */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	checkLifecycleUrl,

--- a/plugins/plugin-local-inference/src/services/live-signals.test.ts
+++ b/plugins/plugin-local-inference/src/services/live-signals.test.ts
@@ -1,3 +1,4 @@
+/** Covers live device-signal reads (decode-token estimation, local demotion on pressure) feeding the routing policy. Deterministic, injected signal source. */
 import { afterEach, describe, expect, it } from "vitest";
 import { inferenceTelemetry } from "./inference-telemetry";
 import {

--- a/plugins/plugin-local-inference/src/services/llama-server-metrics.test.ts
+++ b/plugins/plugin-local-inference/src/services/llama-server-metrics.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for parsing llama-server Prometheus metrics and diffing snapshots. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	diffSnapshots,

--- a/plugins/plugin-local-inference/src/services/llm-streaming-binding.ts
+++ b/plugins/plugin-local-inference/src/services/llm-streaming-binding.ts
@@ -1,12 +1,12 @@
 /**
  * Narrow streaming-LLM binding.
  *
- * `FfiStreamingRunner` (`services/ffi-streaming-runner.ts`) used to require
- * the full `ElizaInferenceFfi` surface (TTS + ASR + VAD + mmap regions +
- * the entire fused libelizainference) just to run text generation. That
- * surface implies a *bundle-anchored* runtime — libelizainference owns a
- * context built from a bundle root, not a single GGUF — and ~25 methods
- * that have nothing to do with LLM streaming.
+ * `FfiStreamingRunner` (`services/ffi-streaming-runner.ts`) needs only a
+ * narrow slice of the FFI to run text generation, not the full
+ * `ElizaInferenceFfi` surface (TTS + ASR + VAD + mmap regions + the entire
+ * fused libelizainference). That full surface implies a *bundle-anchored*
+ * runtime — libelizainference owns a context built from a bundle root, not a
+ * single GGUF — and ~25 methods that have nothing to do with LLM streaming.
  *
  * This file extracts the actual contract the runner depends on: the seven
  * `llmStream*` methods plus the (optional) two slot save/restore methods.

--- a/plugins/plugin-local-inference/src/services/local-model-lifecycle-matrix.test.ts
+++ b/plugins/plugin-local-inference/src/services/local-model-lifecycle-matrix.test.ts
@@ -1,3 +1,4 @@
+/** Covers building the per-tier model lifecycle matrix and its markdown rendering. Deterministic, synthetic catalog/probe. */
 import { describe, expect, it } from "vitest";
 import {
 	buildLocalModelLifecycleMatrix,

--- a/plugins/plugin-local-inference/src/services/local-model-lifecycle-matrix.ts
+++ b/plugins/plugin-local-inference/src/services/local-model-lifecycle-matrix.ts
@@ -1,3 +1,10 @@
+/**
+ * Builds the per-tier, per-component (text / vision / MTP / embedding) lifecycle
+ * matrix that reports each Eliza-1 model's install, download, and assignment
+ * state against the current hardware probe. Cross-references the catalog,
+ * installed registry, supported backends, and recommendation logic to tell the
+ * UI which components are ready, downloadable, or unfit on this device.
+ */
 import fs from "node:fs/promises";
 import path from "node:path";
 import { EMBEDDING_PRESETS } from "../runtime/embedding-presets";

--- a/plugins/plugin-local-inference/src/services/manifest/manifest.test.ts
+++ b/plugins/plugin-local-inference/src/services/manifest/manifest.test.ts
@@ -1,3 +1,4 @@
+/** Validates the Eliza-1 bundle manifest schema constants and `validateManifest` accept/reject behavior. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	canSetAsDefault,

--- a/plugins/plugin-local-inference/src/services/memory-arbiter.test.ts
+++ b/plugins/plugin-local-inference/src/services/memory-arbiter.test.ts
@@ -1,3 +1,4 @@
+/** Exercises the `MemoryArbiter`: acquire/reuse/release, one-model-per-role swap, and fit-to-budget LRU eviction. Deterministic, fake loaders. */
 import { beforeEach, describe, expect, it } from "vitest";
 import {
 	type ArbiterCapability,

--- a/plugins/plugin-local-inference/src/services/memory-benchmark.test.ts
+++ b/plugins/plugin-local-inference/src/services/memory-benchmark.test.ts
@@ -1,3 +1,4 @@
+/** Covers the resident-memory benchmark report planner against synthetic catalog/probe data. Deterministic. */
 import { MODEL_CATALOG } from "@elizaos/shared/local-inference";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-local-inference/src/services/memory-benchmark.ts
+++ b/plugins/plugin-local-inference/src/services/memory-benchmark.ts
@@ -1,3 +1,9 @@
+/**
+ * Plans and measures resident-memory footprints for candidate models against a
+ * hardware probe, so the recommender and diagnostics can compare estimated vs.
+ * actual RAM cost per tier. Writes benchmark reports and reacts to arbiter
+ * events for the currently loaded model.
+ */
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { performance } from "node:perf_hooks";

--- a/plugins/plugin-local-inference/src/services/memory-monitor.test.ts
+++ b/plugins/plugin-local-inference/src/services/memory-monitor.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `MemoryMonitor` pressure sampling over shared voice resources. Deterministic. */
 import { describe, expect, it } from "vitest";
 import { MemoryMonitor } from "./memory-monitor";
 import {

--- a/plugins/plugin-local-inference/src/services/mtp-doctor.ts
+++ b/plugins/plugin-local-inference/src/services/mtp-doctor.ts
@@ -1,3 +1,9 @@
+/**
+ * Diagnostic that reports whether multi-token-prediction (MTP) tiers are
+ * runnable on this host: it walks the MTP catalog entries, checks the hardware
+ * probe, and emits pass/warn/fail checks with fix hints for the model settings
+ * UI and CLI doctor.
+ */
 import {
 	ELIZA_1_HOSTED_MTP_TIER_IDS,
 	ELIZA_1_MTP_TIER_IDS,

--- a/plugins/plugin-local-inference/src/services/paths.ts
+++ b/plugins/plugin-local-inference/src/services/paths.ts
@@ -1,3 +1,9 @@
+/**
+ * Filesystem path resolvers for the local-inference state tree (root, models
+ * dir, registry.json, downloads staging), all anchored under `resolveStateDir()`
+ * so `ELIZA_STATE_DIR` relocates them. Includes the containment check used to
+ * keep downloads and registry writes inside the local-inference root.
+ */
 import path from "node:path";
 import { resolveStateDir } from "@elizaos/core";
 

--- a/plugins/plugin-local-inference/src/services/readiness.test.ts
+++ b/plugins/plugin-local-inference/src/services/readiness.test.ts
@@ -1,3 +1,4 @@
+/** Covers `LocalInferenceReadiness` derivation for the text slot from catalog/installed/active/download state. Deterministic. */
 import { describe, expect, it } from "vitest";
 import { buildTextGenerationReadiness } from "./readiness";
 import type { ActiveModelState, DownloadJob, InstalledModel } from "./types";

--- a/plugins/plugin-local-inference/src/services/readiness.ts
+++ b/plugins/plugin-local-inference/src/services/readiness.ts
@@ -1,3 +1,9 @@
+/**
+ * Derives the `LocalInferenceReadiness` DTO — per-slot (text/embedding/…) status
+ * the dashboard renders — by folding the catalog, installed registry, active
+ * model, and in-flight download state into one snapshot. Pure computation; the
+ * client displays these fields without re-deriving them.
+ */
 import { MODEL_CATALOG } from "./catalog";
 import { catalogDownloadSizeBytes } from "./recommendation";
 import type {

--- a/plugins/plugin-local-inference/src/services/recommendation.test.ts
+++ b/plugins/plugin-local-inference/src/services/recommendation.test.ts
@@ -1,3 +1,4 @@
+/** Covers recommendation-platform classification, device-caps derivation, and catalog download sizing. Deterministic, synthetic probes. */
 import type { CatalogModel, HardwareProbe } from "@elizaos/shared";
 import { describe, expect, it } from "vitest";
 import { MODEL_CATALOG } from "./catalog.js";

--- a/plugins/plugin-local-inference/src/services/recommendation.ts
+++ b/plugins/plugin-local-inference/src/services/recommendation.ts
@@ -1,3 +1,10 @@
+/**
+ * Picks the Eliza-1 tiers and quantization variants to recommend for a given
+ * hardware probe: `selectRecommendedModels` / `recommendForFirstRun` rank
+ * catalog tiers by RAM fit, and `selectBestQuantizationVariant` chooses the
+ * heaviest quant that still fits. Only default-eligible, publish-ready tiers are
+ * ever auto-recommended; generic GGUF is never auto-assigned.
+ */
 import {
 	DEFAULT_ELIGIBLE_MODEL_IDS,
 	type Eliza1TierId,

--- a/plugins/plugin-local-inference/src/services/registry.test.ts
+++ b/plugins/plugin-local-inference/src/services/registry.test.ts
@@ -1,3 +1,4 @@
+/** Covers installed-model registry removal against a real temp state dir. No model. */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-inference/src/services/required-kernels-gate.test.ts
+++ b/plugins/plugin-local-inference/src/services/required-kernels-gate.test.ts
@@ -1,3 +1,4 @@
+/** Verifies `assertRequiredKernelsPresent` fails closed when a manifest omits a required native kernel (native/CLAUDE.md §3#5). Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	assertRequiredKernelsPresent,

--- a/plugins/plugin-local-inference/src/services/router-dispatch.test.ts
+++ b/plugins/plugin-local-inference/src/services/router-dispatch.test.ts
@@ -1,3 +1,4 @@
+/** Proves the router dispatches via runtime introspection rather than a prototype patch. Deterministic, fake runtime. */
 import {
 	type AgentRuntime,
 	type IAgentRuntime,

--- a/plugins/plugin-local-inference/src/services/router-handler.test.ts
+++ b/plugins/plugin-local-inference/src/services/router-handler.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `installRouterHandler` wiring the routing-policy layer onto the runtime. Deterministic, fake runtime. */
 import { type AgentRuntime, ModelType } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { installRouterHandler, ROUTER_PROVIDER } from "./router-handler";

--- a/plugins/plugin-local-inference/src/services/routing-policy.test.ts
+++ b/plugins/plugin-local-inference/src/services/routing-policy.test.ts
@@ -1,3 +1,4 @@
+/** Covers the `PolicyEngine` auto policy: static tier selection, live-signal demotion, and per-modality independence. Deterministic, injected signals. */
 import { describe, expect, it } from "vitest";
 import { classifyDeviceTier, type DeviceTierAssessment } from "./device-tier";
 import type { HandlerRegistration } from "./handler-registry";

--- a/plugins/plugin-local-inference/src/services/service.test.ts
+++ b/plugins/plugin-local-inference/src/services/service.test.ts
@@ -1,3 +1,4 @@
+/** Covers `LocalInferenceService` orchestration: activation prewarm and image-gen GPU vendor detection (#10727). Deterministic, mocked engine/hardware. */
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-local-inference/src/services/structured-output.test.ts
+++ b/plugins/plugin-local-inference/src/services/structured-output.test.ts
@@ -1,3 +1,4 @@
+/** Covers skeleton collapsing, GBNF grammar compilation, and grammar-resolution precedence for constrained local decoding. Deterministic. */
 import type { ResponseSkeleton } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-local-inference/src/services/structured-output/deterministic-repair.test.ts
+++ b/plugins/plugin-local-inference/src/services/structured-output/deterministic-repair.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the deterministic structured-output repair against skeleton/schema. Deterministic. */
 import type { JSONSchema, ResponseSkeleton } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-local-inference/src/services/structured-output/deterministic-repair.ts
+++ b/plugins/plugin-local-inference/src/services/structured-output/deterministic-repair.ts
@@ -1,3 +1,10 @@
+/**
+ * Deterministically repairs a local model's raw text into schema-valid
+ * structured output without a second model pass: it reconciles the emitted text
+ * against the response skeleton and JSON schema(s), returning a status
+ * (`unchanged` / `repaired` / `ambiguous` / `invalid`) so callers can tell a
+ * clean parse from an unrecoverable one rather than fabricating a default.
+ */
 import type {
 	JSONSchema,
 	ResponseSkeleton,

--- a/plugins/plugin-local-inference/src/services/system-memory.test.ts
+++ b/plugins/plugin-local-inference/src/services/system-memory.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `readSystemMemory` host-RAM sampling. Deterministic. */
 import { describe, expect, it } from "vitest";
 import { readSystemMemory } from "./system-memory.js";
 

--- a/plugins/plugin-local-inference/src/services/text-provenance.test.ts
+++ b/plugins/plugin-local-inference/src/services/text-provenance.test.ts
@@ -1,3 +1,4 @@
+/** Covers reading the GGUF `general.architecture` bytes and the Gemma-4 strict-release architecture blockers. Deterministic, synthetic GGUF headers. */
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-inference/src/services/text-provenance.ts
+++ b/plugins/plugin-local-inference/src/services/text-provenance.ts
@@ -1,3 +1,10 @@
+/**
+ * Reads the `general.architecture` value out of a text GGUF's header bytes to
+ * confirm a bundle actually ships a Gemma-4 text model, not a pre-cutover Qwen
+ * stand-in. The GGUF header is authoritative where the operator-authored
+ * manifest `lineage.text` can drift; this is the byte-level half of the
+ * strict-release gate whose manifest half is `asr-provenance.ts`.
+ */
 import { closeSync, openSync, readdirSync, readSync, statSync } from "node:fs";
 import path from "node:path";
 import { QWEN_PROVENANCE_RE } from "./asr-provenance";

--- a/plugins/plugin-local-inference/src/services/verify-on-device.test.ts
+++ b/plugins/plugin-local-inference/src/services/verify-on-device.test.ts
@@ -1,3 +1,4 @@
+/** Covers `verifyBundleOnDevice` bundle self-check. Deterministic. */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createVerifyBundleOnDevice } from "./verify-on-device";
 

--- a/plugins/plugin-local-inference/src/services/vision/augmenter.test.ts
+++ b/plugins/plugin-local-inference/src/services/vision/augmenter.test.ts
@@ -1,3 +1,4 @@
+/** Covers the vision context-augmenter registry and `augmentVisionRequest`. Deterministic. */
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	augmentVisionRequest,

--- a/plugins/plugin-local-inference/src/services/vision/fallback-chain.test.ts
+++ b/plugins/plugin-local-inference/src/services/vision/fallback-chain.test.ts
@@ -1,3 +1,4 @@
+/** Covers the vision describe fallback chain (local → cloud) ordering. Deterministic, fake backends. */
 import type { ImageDescriptionResult } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import type { LocalImageDescriptionHandler } from "./cloud-fallback";

--- a/plugins/plugin-local-inference/src/services/voice-prewarm.ts
+++ b/plugins/plugin-local-inference/src/services/voice-prewarm.ts
@@ -1,3 +1,9 @@
+/**
+ * Warms the local voice stack (ASR + Kokoro TTS) once an Eliza-1 bundle becomes
+ * active, so the first real voice turn does not eat the model-load latency. Runs
+ * a throwaway transcribe + synthesize pass, deduped per model id so concurrent
+ * activations share one prewarm promise.
+ */
 import { logger } from "@elizaos/core";
 import { localInferenceEngine } from "./engine";
 

--- a/plugins/plugin-local-inference/src/services/voice/acoustic-speaker-attribution.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/acoustic-speaker-attribution.test.ts
@@ -1,3 +1,4 @@
+/** Covers acoustic speaker attribution: timbre-embedding extraction, online clustering, and self-voice similarity, driven by synthetic speech. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	AGENT_VOICE_TIMBRE,

--- a/plugins/plugin-local-inference/src/services/voice/acoustic-speaker-attribution.ts
+++ b/plugins/plugin-local-inference/src/services/voice/acoustic-speaker-attribution.ts
@@ -1,10 +1,9 @@
 /**
  * Model-free acoustic speaker attribution for the Voice Workbench (#9147, #9427).
  *
- * The headless decision-logic lane used to copy the ground-truth speaker label
- * straight into `predictedSpeakerLabel`, so the DER gate compared ground truth
- * to itself and could never fail (#9427). This module is the real thing it
- * needed: it derives a speaker label from the AUDIO and nothing else.
+ * The DER gate must score a label derived from the AUDIO against ground truth,
+ * never ground truth against itself — a tautology that can never fail (#9427).
+ * This module derives that speaker label from the audio and nothing else.
  *
  *   extractTimbreEmbedding  — a deterministic mean-MFCC voice embedding (the
  *                             speaker's timbre), via a dependency-free FFT +

--- a/plugins/plugin-local-inference/src/services/voice/acoustic-speaker-isolation-noise.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/acoustic-speaker-isolation-noise.test.ts
@@ -1,3 +1,4 @@
+/** Speaker isolation under babble, overlap, and transient bystanders (#10726), driven by synthetic mixed speech. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	makeSpeechWithSilenceFixture,

--- a/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
@@ -201,9 +201,9 @@ export interface RuntimeEventSink {
 /**
  * Transcribe a finalized turn's buffered PCM to text (#8786). When injected, the
  * consumer joins the ASR transcript into the diarization attribution so
- * `VOICE_TURN_OBSERVED` carries the real text — previously the live audio-frame
- * path attributed *who* spoke but always emitted `text: ""`, so name/partner
- * extraction (`VoiceObserver.ingestTurn`) could never fire from live audio.
+ * `VOICE_TURN_OBSERVED` carries the real text, letting name/partner extraction
+ * (`VoiceObserver.ingestTurn`) fire from live audio. Without a transcriber the
+ * live audio-frame path attributes *who* spoke but emits `text: ""`.
  *
  * Returns the transcript, or `null`/empty for silence / no decode. Best-effort:
  * the consumer swallows a rejection (counted in `transcriptionErrors`) and falls

--- a/plugins/plugin-local-inference/src/services/voice/bench-utils.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/bench-utils.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for voice bench helpers: SNR mixing, monotonicity violations, and speaker-timeline building. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	attributeByEnrollment,

--- a/plugins/plugin-local-inference/src/services/voice/cancellation-coordinator.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/cancellation-coordinator.test.ts
@@ -1,3 +1,4 @@
+/** Covers `VoiceCancellationCoordinator` fanning out barge-in cancellation to registered consumers. Deterministic. */
 import { describe, expect, it, vi } from "vitest";
 import { BargeInController } from "./barge-in";
 import {

--- a/plugins/plugin-local-inference/src/services/voice/composite-eot-classifier.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/composite-eot-classifier.test.ts
@@ -1,3 +1,4 @@
+/** Covers the composite end-of-turn classifier combining the fused scorer with heuristic signals. Deterministic. */
 import { describe, expect, it, vi } from "vitest";
 import { CompositeEotClassifier } from "./eot-classifier";
 import type { FfiEotScorer } from "./fused-eot-scorer";

--- a/plugins/plugin-local-inference/src/services/voice/corpus-augment.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/corpus-augment.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for corpus augmentation: dB helpers and additive noise (babble/music). Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	addNoise,

--- a/plugins/plugin-local-inference/src/services/voice/corpus-generator.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/corpus-generator.test.ts
@@ -1,3 +1,4 @@
+/** Covers voice-corpus generation on both the synthetic and real-TTS paths plus ground-truth read/write. Real-TTS path exercises a live backend when present. */
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-inference/src/services/voice/diarization-error-rate.greedy.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/diarization-error-rate.greedy.test.ts
@@ -1,3 +1,4 @@
+/** Covers the greedy speaker-mapping fallback in `computeDiarizationErrorRate`. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	computeDiarizationErrorRate,

--- a/plugins/plugin-local-inference/src/services/voice/diarization-error-rate.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/diarization-error-rate.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for diarization-error-rate computation and the within-budget gate. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	computeDiarizationErrorRate,

--- a/plugins/plugin-local-inference/src/services/voice/e2e-harness.der.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/e2e-harness.der.test.ts
@@ -1,3 +1,4 @@
+/** Covers the voice E2E harness diarization scoring (#9147). Deterministic, fixture inputs. */
 import { describe, expect, it } from "vitest";
 import { type DiarizationSample, scoreDiarization } from "./e2e-harness";
 

--- a/plugins/plugin-local-inference/src/services/voice/e2e-harness.respond-eot-entity.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/e2e-harness.respond-eot-entity.test.ts
@@ -1,3 +1,4 @@
+/** Covers the voice E2E harness EOT / respond / entity-extraction scoring (#9147). Deterministic, fixture inputs. */
 import { describe, expect, it } from "vitest";
 import {
 	type EotDecisionSample,

--- a/plugins/plugin-local-inference/src/services/voice/e2e-harness.security-echo.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/e2e-harness.security-echo.test.ts
@@ -1,3 +1,4 @@
+/** Covers the voice E2E harness echo-rejection and owner-security scoring (#9147). Deterministic, fixture inputs. */
 import { describe, expect, it } from "vitest";
 import {
 	type EchoRejectionSample,

--- a/plugins/plugin-local-inference/src/services/voice/e2e-harness.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/e2e-harness.test.ts
@@ -1,3 +1,4 @@
+/** Covers the voice E2E harness core scoring: WER, artifact validation, and barge-in. Deterministic, fixture inputs. */
 import { describe, expect, it } from "vitest";
 import {
 	assertRequiredVoiceArtifacts,

--- a/plugins/plugin-local-inference/src/services/voice/echo-delay.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-delay.test.ts
@@ -1,3 +1,4 @@
+/** Covers echo playback-delay estimation and per-platform seed defaults (#9583). Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	DEFAULT_PLAYBACK_DELAY_MS,

--- a/plugins/plugin-local-inference/src/services/voice/echo-delay.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-delay.ts
@@ -1,3 +1,4 @@
+/** Re-exports the acoustic-echo-cancellation playback-delay estimators from `@elizaos/shared/voice/aec`. */
 export {
 	DEFAULT_PLAYBACK_DELAY_MS,
 	type EchoDelayEstimate,

--- a/plugins/plugin-local-inference/src/services/voice/echo-metrics.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-metrics.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `computeErle` echo-return-loss-enhancement metrics. Deterministic. */
 import { describe, expect, it } from "vitest";
 import { computeErle } from "./echo-metrics";
 

--- a/plugins/plugin-local-inference/src/services/voice/echo-reference-buffer.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-reference-buffer.test.ts
@@ -1,3 +1,4 @@
+/** Covers the AEC far-end reference buffer (#9583). Deterministic. */
 import { describe, expect, it } from "vitest";
 import { EchoReferenceBuffer } from "./echo-reference-buffer.ts";
 

--- a/plugins/plugin-local-inference/src/services/voice/echo-reference-buffer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/echo-reference-buffer.ts
@@ -1,3 +1,4 @@
+/** Re-exports the AEC far-end reference buffer from `@elizaos/shared/voice/aec`. */
 export {
 	EchoReferenceBuffer,
 	type EchoReferenceBufferOptions,

--- a/plugins/plugin-local-inference/src/services/voice/emotion-attribution.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/emotion-attribution.test.ts
@@ -1,3 +1,4 @@
+/** Covers fused text/acoustic emotion attribution for a voice turn. Deterministic. */
 import { describe, expect, it } from "vitest";
 import { attributeVoiceEmotion } from "./emotion-attribution";
 import { WAV2SMALL_INT8_MODEL_ID } from "./voice-emotion-classifier";

--- a/plugins/plugin-local-inference/src/services/voice/emotion-attribution.ts
+++ b/plugins/plugin-local-inference/src/services/voice/emotion-attribution.ts
@@ -1,3 +1,9 @@
+/**
+ * Fuses text-tag, ASR-metadata, and acoustic-feature signals into a single
+ * emotion label for a voice turn, recording which method produced it so
+ * downstream consumers know how confident the attribution is. Sits between the
+ * expressive-tag parser and the acoustic emotion classifier.
+ */
 import {
 	asrEmotionToTag,
 	EXPRESSIVE_EMOTION_TAGS,

--- a/plugins/plugin-local-inference/src/services/voice/engine-bridge-transcript-join.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/engine-bridge-transcript-join.test.ts
@@ -183,7 +183,7 @@ describe("EngineVoiceBridge runVoiceTurn — transcript join (#8786)", () => {
 		const payload = await observed;
 
 		// The whole point of #8786: the merge engine needs the words, not just
-		// the speaker. Previously this was hardcoded "".
+		// the speaker.
 		expect(payload.text).toBe("I'm Jill");
 	});
 

--- a/plugins/plugin-local-inference/src/services/voice/engine-bridge.attribution-degrade.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/engine-bridge.attribution-degrade.test.ts
@@ -67,8 +67,8 @@ describe("engine-bridge attribution degradation (#12257)", () => {
 	it("starts voice WITHOUT attribution, warns exactly once, never throws", async () => {
 		const warn = vi.spyOn(logger, "warn");
 
-		// profileStore wired, but useFfiBackend:false → no fused handle. Previously
-		// this threw VoiceStartupError; now it degrades.
+		// profileStore wired, but useFfiBackend:false → no fused handle, so start()
+		// degrades instead of throwing VoiceStartupError.
 		const first = EngineVoiceBridge.start({
 			bundleRoot,
 			useFfiBackend: false,

--- a/plugins/plugin-local-inference/src/services/voice/expressive-tags.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/expressive-tags.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for parsing, detecting, and stripping expressive emotion tags in text. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	emotionToEnum,

--- a/plugins/plugin-local-inference/src/services/voice/fused-wake-bridge.ts
+++ b/plugins/plugin-local-inference/src/services/voice/fused-wake-bridge.ts
@@ -5,11 +5,10 @@
  * `wake-word-ggml.ts`, wrapped by {@link OpenWakeWordDetector}) runs in the
  * agent/native (Bun) process. Its firing must reach the renderer, where
  * `useWakeController` (`@elizaos/ui`) activates the bottom bar and starts a
- * turn. Previously the detector fired only into `prewarmConversation`; nothing
- * forwarded the firing to the renderer, so the bar was driven only by the
- * Swabble Web-Speech fallback.
+ * turn. Without this seam nothing forwards the native detector's firing to the
+ * renderer, and the bar is driven only by the Swabble Web-Speech fallback.
  *
- * This module is the missing seam: it adapts an {@link OpenWakeWordDetector}
+ * This module supplies that seam: it adapts an {@link OpenWakeWordDetector}
  * firing into a canonical {@link FusedWakeEventDetail} and hands it to a
  * {@link FusedWakeSink}. The host wires the sink to its renderer transport
  * (Capacitor event / Electrobun RPC / WebSocket push) where the renderer's

--- a/plugins/plugin-local-inference/src/services/voice/index.ts
+++ b/plugins/plugin-local-inference/src/services/voice/index.ts
@@ -1,3 +1,4 @@
+/** Public surface of the local voice pipeline: audio ingest, barge-in, cancellation, streaming ASR, phrase scheduling, speaker attribution, and the engine bridge. */
 export {
 	type AttributedTurn,
 	type AttributedTurnListener,

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-backend.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-backend.test.ts
@@ -1,3 +1,4 @@
+/** Covers the Kokoro TTS backend including streaming time-to-first-audio. Deterministic, mock runtime. */
 import { describe, expect, it } from "vitest";
 import { scoreFirstResponseLatency } from "../../e2e-harness";
 import type {

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-engine-discovery.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-engine-discovery.test.ts
@@ -1,3 +1,4 @@
+/** Covers Kokoro engine config resolution and GGUF/model-dir discovery. Deterministic. */
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-ffi-runtime.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-ffi-runtime.test.ts
@@ -1,3 +1,4 @@
+/** Covers `KokoroFfiRuntime` against the voice FFI bindings. Deterministic, mock bindings. */
 import {
 	mkdirSync,
 	mkdtempSync,

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-runtime.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-runtime.test.ts
@@ -1,3 +1,4 @@
+/** Covers the Kokoro mock runtime used by the TTS backend tests. Deterministic. */
 import { afterEach, describe, expect, it } from "vitest";
 
 import { KokoroMockRuntime } from "../kokoro-runtime";

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/phonemizer.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/phonemizer.test.ts
@@ -1,3 +1,4 @@
+/** Covers the fallback G2P phonemizer. Deterministic. */
 import { describe, expect, it } from "vitest";
 
 import {

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/runtime-selection.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/runtime-selection.test.ts
@@ -1,3 +1,4 @@
+/** Covers Kokoro voice-backend selection and env-mode parsing. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	readVoiceBackendModeFromEnv,

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/voices.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/voices.test.ts
@@ -1,3 +1,4 @@
+/** Covers the `KOKORO_VOICE_PACKS` catalog invariants. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	findKokoroVoice,

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/pick-runtime.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/pick-runtime.test.ts
@@ -1,3 +1,4 @@
+/** Covers `pickKokoroRuntimeBackend` runtime selection against the FFI bindings. Deterministic. */
 import { describe, expect, it } from "vitest";
 
 import type { ElizaInferenceFfi } from "../ffi-bindings";

--- a/plugins/plugin-local-inference/src/services/voice/metric-math.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/metric-math.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for voice metric-math helpers (rounding, percentiles). Deterministic. */
 import { describe, expect, it } from "vitest";
 import { percentile, round1, round4 } from "./metric-math";
 

--- a/plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.test.ts
@@ -1,3 +1,4 @@
+/** Covers the NLMS adaptive echo canceller and its opt-in residual suppressor (#9583/#9649). Deterministic. */
 import { describe, expect, it } from "vitest";
 import { NlmsEchoCanceller } from "./nlms-echo-canceller";
 

--- a/plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.ts
+++ b/plugins/plugin-local-inference/src/services/voice/nlms-echo-canceller.ts
@@ -1,3 +1,4 @@
+/** Re-exports the NLMS adaptive echo canceller from `@elizaos/shared/voice/aec`. */
 export {
 	NlmsEchoCanceller,
 	type NlmsEchoCancellerOptions,

--- a/plugins/plugin-local-inference/src/services/voice/optimistic-policy.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/optimistic-policy.test.ts
@@ -1,3 +1,4 @@
+/** Covers optimistic-generation policy resolution and the power-source-aware gating. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	DEFAULT_OPTIMISTIC_EOT_THRESHOLD,

--- a/plugins/plugin-local-inference/src/services/voice/partial-stabilizer.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/partial-stabilizer.test.ts
@@ -1,3 +1,4 @@
+/** Covers the LocalAgreement-n partial-transcript stabilizer. Deterministic. */
 import { describe, expect, it } from "vitest";
 import { PartialStabilizer } from "./partial-stabilizer";
 

--- a/plugins/plugin-local-inference/src/services/voice/phrase-cache.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/phrase-cache.test.ts
@@ -1,3 +1,4 @@
+/** Covers the phrase cache seed list, first-audio fillers, and LRU behavior. Deterministic. */
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-inference/src/services/voice/phrase-cache.ts
+++ b/plugins/plugin-local-inference/src/services/voice/phrase-cache.ts
@@ -1,3 +1,9 @@
+/**
+ * Holds pre-synthesized PCM for the assistant's most common short utterances
+ * (openers, fillers, acknowledgements) so the scheduler can emit first audio
+ * without waiting on a TTS forward pass. The seed list below is the canonical
+ * source of truth shared byte-for-byte with the preset generator.
+ */
 export interface CachedPhraseAudio {
 	text: string;
 	pcm: Float32Array;

--- a/plugins/plugin-local-inference/src/services/voice/phrase-chunker.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/phrase-chunker.test.ts
@@ -1,3 +1,4 @@
+/** Covers `PhraseChunker` punctuation boundaries, time-budget flush, and first-phrase TTFA budget. Deterministic. */
 import { describe, expect, it } from "vitest";
 import { type ClockMs, chunkTokens, PhraseChunker } from "./phrase-chunker";
 import type { TextToken } from "./types";

--- a/plugins/plugin-local-inference/src/services/voice/phrase-chunker.ts
+++ b/plugins/plugin-local-inference/src/services/voice/phrase-chunker.ts
@@ -1,3 +1,9 @@
+/**
+ * Cuts the streaming token feed into speakable phrases so TTS can start before
+ * the model finishes a sentence: it breaks at the first clause/sentence-final
+ * punctuation or a hard word cap, whichever comes first. Feeds the voice
+ * scheduler's phrase pipeline.
+ */
 import type { PhonemeTokenizer } from "./phoneme-tokenizer";
 import type {
 	AcceptedToken,

--- a/plugins/plugin-local-inference/src/services/voice/real-audio-decode.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/real-audio-decode.test.ts
@@ -1,3 +1,4 @@
+/** Covers `decodeMonoPcm16Wav` against a committed corpus of real WAV files. Real audio fixtures. */
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-local-inference/src/services/voice/ring-buffer.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/ring-buffer.test.ts
@@ -1,3 +1,4 @@
+/** Covers `PcmRingBuffer` bulk-copy read/write and overflow signaling. Deterministic. */
 import { describe, expect, it } from "vitest";
 import { InMemoryAudioSink, PcmRingBuffer } from "./ring-buffer";
 

--- a/plugins/plugin-local-inference/src/services/voice/ring-buffer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/ring-buffer.ts
@@ -1,3 +1,9 @@
+/**
+ * Fixed-capacity PCM ring buffer between the phrase scheduler and the audio
+ * sink: writes wrap and overwrite the oldest unread samples, firing `onOverflow`
+ * so the scheduler can apply upstream backpressure instead of glitching. Also
+ * exports the in-memory sink used in tests.
+ */
 import type { AudioSink } from "./types";
 
 export interface PcmRingBufferOptions {

--- a/plugins/plugin-local-inference/src/services/voice/rollback-queue.ts
+++ b/plugins/plugin-local-inference/src/services/voice/rollback-queue.ts
@@ -1,3 +1,8 @@
+/**
+ * Tracks in-flight phrases through their synthesis lifecycle so that when the
+ * speculative token stream rejects a range, the scheduler can roll back any
+ * phrase not yet played. Emits a `RollbackEvent` per affected phrase.
+ */
 import type { Phrase, RejectedTokenRange } from "./types";
 
 type PhraseState = "queued" | "synthesizing" | "ringbuffered" | "played";

--- a/plugins/plugin-local-inference/src/services/voice/scheduler.ts
+++ b/plugins/plugin-local-inference/src/services/voice/scheduler.ts
@@ -1,3 +1,10 @@
+/**
+ * Orchestrates the streaming text-to-speech path: it consumes accepted tokens,
+ * chunks them into phrases, drives the TTS backend, and writes synthesized PCM
+ * into the ring buffer while honoring barge-in and speculative-token rollback.
+ * The hub that ties together the phrase chunker, phrase cache, prefix-preserving
+ * queue, rollback queue, and barge-in controller, emitting per-phrase telemetry.
+ */
 import { inferenceTelemetry } from "../inference-telemetry";
 import { BargeInController } from "./barge-in";
 import type { PhonemeTokenizer } from "./phoneme-tokenizer";
@@ -213,9 +220,8 @@ export class VoiceScheduler {
 			1,
 			config.maxInFlightPhrases ?? DEFAULT_MAX_IN_FLIGHT_PHRASES,
 		);
-		// streamingTtsActive defaults true. The Metal ggml_conv_transpose_1d stall
-		// that previously required disabling this on macOS is fixed in the
-		// llama.cpp merge (native Metal kernels; CPU fallback no longer triggers).
+		// streamingTtsActive defaults true; the native Metal ggml_conv_transpose_1d
+		// kernel runs the streaming path on macOS without the CPU-fallback stall.
 		this.streamingTtsActive = config.streamingTtsActive ?? true;
 		// Legacy hard-stop hook (`bargeIn.onMicActive()` / `attach.onCancel`).
 		this.bargeIn.attach({

--- a/plugins/plugin-local-inference/src/services/voice/self-voice-imprint.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/self-voice-imprint.test.ts
@@ -1,3 +1,4 @@
+/** Covers `AgentSelfVoiceImprint` building the agent's own voice centroid from TTS output. Deterministic, fake encoder. */
 import { describe, expect, it } from "vitest";
 import { AgentSelfVoiceImprint } from "./self-voice-imprint";
 import type { SpeakerEncoder } from "./speaker/encoder";

--- a/plugins/plugin-local-inference/src/services/voice/self-voice-imprint.ts
+++ b/plugins/plugin-local-inference/src/services/voice/self-voice-imprint.ts
@@ -1,3 +1,9 @@
+/**
+ * Builds and maintains the agent's own voice centroid from its TTS output, so
+ * the speaker-attribution pipeline can recognize (and exclude) the assistant's
+ * playback as self rather than mis-attributing it to a human speaker. Encodes
+ * recent agent-TTS segments through the speaker encoder into a running centroid.
+ */
 import { averageEmbeddings, type SpeakerEncoder } from "./speaker/encoder";
 import {
 	SPEAKER_GGML_MIN_SAMPLES,

--- a/plugins/plugin-local-inference/src/services/voice/speaker-imprint.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/speaker-imprint.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for speaker-imprint cosine matching and centroid updates. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	attributeVoiceImprintObservations,

--- a/plugins/plugin-local-inference/src/services/voice/speaker-imprint.ts
+++ b/plugins/plugin-local-inference/src/services/voice/speaker-imprint.ts
@@ -1,3 +1,8 @@
+/**
+ * Matches a voice segment's speaker embedding against known imprint profiles by
+ * cosine similarity and folds accepted segments into a running centroid. The
+ * pure math behind `VoiceProfileStore` speaker recognition; carries no I/O.
+ */
 import type { VoiceInputSource, VoiceSegment, VoiceSpeaker } from "./types";
 
 export const DEFAULT_VOICE_IMPRINT_MATCH_THRESHOLD = 0.78;

--- a/plugins/plugin-local-inference/src/services/voice/speaker-preset-cache.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/speaker-preset-cache.test.ts
@@ -1,3 +1,4 @@
+/** Covers speaker-preset path resolution and the `SpeakerPresetCache` LRU. Deterministic, temp fixtures. */
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-inference/src/services/voice/speaker-preset-cache.ts
+++ b/plugins/plugin-local-inference/src/services/voice/speaker-preset-cache.ts
@@ -1,3 +1,8 @@
+/**
+ * LRU cache of speaker presets (embedding + seed-phrase PCM) loaded from voice
+ * bundles, so switching voices per connector does not re-read and re-parse the
+ * preset file each time. Presets are KB-scale, so the default bound is generous.
+ */
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import type { SpeakerPreset } from "./types";

--- a/plugins/plugin-local-inference/src/services/voice/speaker/attribution-pipeline.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/speaker/attribution-pipeline.test.ts
@@ -1,3 +1,4 @@
+/** Covers `VoiceAttributionPipeline` end-to-end over diarizer + encoder + profile store. Deterministic, fake components. */
 import { describe, expect, it } from "vitest";
 import {
 	VOICE_PROFILE_RECORD_SCHEMA_VERSION,

--- a/plugins/plugin-local-inference/src/services/voice/speaker/encoder-ggml.ts
+++ b/plugins/plugin-local-inference/src/services/voice/speaker/encoder-ggml.ts
@@ -4,8 +4,8 @@
  *
  * The speaker encoder runs EXCLUSIVELY through the fused `libelizainference`
  * `eliza_inference_speaker_*` ABI (`FusedSpeakerEncoder` in `encoder-fused.ts`).
- * The standalone `libvoice_classifier` binding that previously lived here has
- * been removed — there is one on-device voice runtime.
+ * There is one on-device voice runtime — no standalone `libvoice_classifier`
+ * binding.
  *
  * This module retains the pieces the fused path shares:
  *   - the canonical dims (`SPEAKER_GGML_*`), pinned at 256 to match the C-side

--- a/plugins/plugin-local-inference/src/services/voice/speaker/profile-store-factory.ts
+++ b/plugins/plugin-local-inference/src/services/voice/speaker/profile-store-factory.ts
@@ -5,8 +5,8 @@
  * Pipeline A (the Android live-frames path, `live-diarization-session.ts`) and
  * Pipeline B (the desktop speak-back loop, `engine.ts` → `engine-bridge.ts`)
  * must attribute the *same* person to the *same* profile regardless of which
- * path heard them. Both used to be free to `new VoiceProfileStore(...)` at their
- * own `$ELIZA_STATE_DIR/voice-profiles/` root; two stores over one dir race on
+ * path heard them. If each were free to `new VoiceProfileStore(...)` at its own
+ * `$ELIZA_STATE_DIR/voice-profiles/` root, two stores over one dir would race on
  * the shared `index.json` + `vp_*.json` records. This factory memoizes one
  * initialized store per resolved root so the two consumers share centroids,
  * Welford refinement, LRU state, and entity bindings.

--- a/plugins/plugin-local-inference/src/services/voice/system-audio-sink.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/system-audio-sink.test.ts
@@ -1,3 +1,4 @@
+/** Covers `WavFileAudioSink` writing PCM out to a WAV file. Real fs temp files. */
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-inference/src/services/voice/transcript-knowledge.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-knowledge.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `transcriptKnowledgePayload` shaping transcripts into knowledge items. Deterministic. */
 import type { Transcript } from "@elizaos/shared/transcripts";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-local-inference/src/services/voice/transcript-service.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-service.test.ts
@@ -1,3 +1,4 @@
+/** Covers `TranscriptService` transcript lifecycle. Deterministic. */
 import type { Memory, UUID } from "@elizaos/core";
 import type { Transcript } from "@elizaos/shared/transcripts";
 import { describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-local-inference/src/services/voice/transcript-store.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-store.test.ts
@@ -1,3 +1,4 @@
+/** Covers `TranscriptStore` persistence. Deterministic, temp store. */
 import type { Memory, UUID } from "@elizaos/core";
 import type { Transcript } from "@elizaos/shared/transcripts";
 import { describe, expect, it } from "vitest";

--- a/plugins/plugin-local-inference/src/services/voice/types.ts
+++ b/plugins/plugin-local-inference/src/services/voice/types.ts
@@ -1,3 +1,4 @@
+/** Shared type vocabulary for the voice pipeline: tokens, phrases, audio chunks/sinks, speakers, and scheduler/TTS-backend contracts. */
 export interface TextToken {
 	index: number;
 	text: string;
@@ -566,12 +567,10 @@ export interface SchedulerConfig {
 	 * before the full phrase finishes synthesizing and enabling per-chunk
 	 * prefix-preserving barge-in rollback.
 	 *
-	 * Previously this was implicitly gated by `ttsStreamSupported()` from the
-	 * native FFI layer. On macOS, a `ggml_conv_transpose_1d` stall in the
-	 * DAC codec region caused the Metal path to hang — that stall is now
-	 * fixed in the llama.cpp merge (native Metal kernels for
-	 * `ggml_conv_transpose_1d`; the CPU fallback causing the hang is gone).
-	 * The flag is therefore `true` by default. Set to `false` only when
+	 * The flag is `true` by default: native Metal kernels for
+	 * `ggml_conv_transpose_1d` in the DAC codec region keep the macOS Metal path
+	 * from stalling, so the streaming ABI is safe to use whenever the backend
+	 * supports it. Set to `false` only when
 	 * testing against a non-streaming build or reproducing the pre-fix
 	 * behaviour.
 	 */

--- a/plugins/plugin-local-inference/src/services/voice/voice-budget.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-budget.test.ts
@@ -1,3 +1,4 @@
+/** Covers voice-budget role priority classification and reservation accounting. Deterministic. */
 import { describe, expect, it } from "vitest";
 import { classifyDeviceTier } from "../device-tier";
 import type { HardwareProbe } from "../types";

--- a/plugins/plugin-local-inference/src/services/voice/voice-preset-generator.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-preset-generator.test.ts
@@ -1,3 +1,4 @@
+/** Covers the default voice-preset build script's preset format output. Deterministic. */
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/plugins/plugin-local-inference/src/services/voice/voice-profile-artifact.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-profile-artifact.test.ts
@@ -1,3 +1,4 @@
+/** Covers voice-profile artifact construction, consent gating, and status. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	analyzeVoiceProfileWav,

--- a/plugins/plugin-local-inference/src/services/voice/voice-profile-artifact.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-profile-artifact.ts
@@ -1,3 +1,10 @@
+/**
+ * Defines and builds the persisted voice-profile artifact (schema
+ * `eliza.voice_profile.v1`): the speaker embedding, reference metadata, and
+ * consent record that let a recognized voice be reused for attribution and,
+ * with explicit consent, synthesis. Consent flags gate what the profile may be
+ * used for.
+ */
 import { createHash } from "node:crypto";
 import type { VoiceInputSource } from "./types";
 

--- a/plugins/plugin-local-inference/src/services/voice/voice-workbench-report.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-workbench-report.test.ts
@@ -1,3 +1,4 @@
+/** Covers building the voice-workbench report, its markdown rendering, and baseline regression detection. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	scoreBargeInGating,

--- a/plugins/plugin-local-inference/src/services/voice/voice-workbench.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-workbench.test.ts
@@ -1,3 +1,4 @@
+/** Covers voice-workbench scoring wiring (EOT / respond / diarization) over the scenario matrix. Deterministic. */
 import { describe, expect, it } from "vitest";
 import {
 	scoreDiarization,

--- a/plugins/plugin-local-inference/src/services/voice/voice.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice.test.ts
@@ -1,3 +1,4 @@
+/** Integration-style coverage of the voice scheduler pipeline: phrase chunking, rollback, and barge-in wired together. Deterministic. */
 import { describe, expect, it, vi } from "vitest";
 import { BargeInController } from "./barge-in";
 import { RuleBasedEnglishPhonemeTokenizer } from "./phoneme-tokenizer";

--- a/plugins/plugin-local-inference/src/services/voice/wake-word-staging.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/wake-word-staging.test.ts
@@ -1,3 +1,4 @@
+/** Covers the wake-word staging plan (#9880). Deterministic. */
 import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";

--- a/plugins/plugin-local-inference/src/services/voice/wav-codec.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/wav-codec.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for WAV encode/decode round-trips. Deterministic. */
 import { describe, expect, it } from "vitest";
 import { decodeMonoPcm16Wav, encodeMonoPcm16Wav } from "./wav-codec";
 

--- a/plugins/plugin-local-inference/src/services/voice/workbench-entrypoint.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-entrypoint.test.ts
@@ -1,3 +1,4 @@
+/** Covers building and running the voice workbench and writing its result. Deterministic. */
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-inference/src/services/voice/workbench-headless-runner.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-headless-runner.test.ts
@@ -1,3 +1,4 @@
+/** Covers the headless voice-scenario runner: honesty contract, scoring, and audio-capture sink (#8934). Deterministic. */
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-inference/src/services/voice/workbench-logic-services.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-logic-services.test.ts
@@ -1,3 +1,4 @@
+/** Covers `realDecisionLogicServices` across the built-in scenario matrix. Deterministic. */
 import { describe, expect, it } from "vitest";
 import { generateVoiceCorpus } from "./corpus-generator";
 import type { VoiceScenario } from "./voice-scenario";

--- a/plugins/plugin-local-inference/vitest.audit.config.ts
+++ b/plugins/plugin-local-inference/vitest.audit.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Vitest config for the audit lane: a trimmed `@elizaos/*` alias set that runs
+ * only the co-located `src/**` `.test.ts` suites, skipping the `__tests__/**`
+ * legacy glob and the post-merge real-model lane.
+ */
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 

--- a/plugins/plugin-local-inference/vitest.config.ts
+++ b/plugins/plugin-local-inference/vitest.config.ts
@@ -1,3 +1,9 @@
+/**
+ * Vitest config: aliases the `@elizaos/*` packages to their workspace sources and
+ * runs both the legacy `__tests__/**` suites and the co-located `src/**`
+ * `.test.ts` siblings. Real-FFI / real-model `*.real.test.ts` files run only in
+ * the post-merge lane (`TEST_LANE=post-merge`).
+ */
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 

--- a/plugins/plugin-native-llama/rollup.config.mjs
+++ b/plugins/plugin-native-llama/rollup.config.mjs
@@ -1,3 +1,5 @@
+/** Rollup config that wraps the tsc ESM output into IIFE + CJS `dist/plugin` bundles with dynamic imports inlined; `@capacitor/core` and `llama-cpp-capacitor` stay external. */
+
 export default {
   input: "dist/esm/index.js",
   output: [

--- a/plugins/plugin-native-llama/src/capacitor-llama-adapter.test.ts
+++ b/plugins/plugin-native-llama/src/capacitor-llama-adapter.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `CapacitorLlamaAdapter` against a mocked `llama-cpp-capacitor`
+ * (no live model): context-id isolation between chat and embedding instances,
+ * reload behavior, and platform-aware load-param wiring.
+ */
+
 import { describe, expect, it, vi } from "vitest";
 
 interface InitContextCall {
@@ -207,9 +213,8 @@ describe("CapacitorLlamaAdapter context-id allocation (issue #7681)", () => {
     await chatAdapter.load({ modelPath: "/tmp/llama.gguf" });
     await embeddingAdapter.load({ modelPath: "/tmp/bge.gguf" });
 
-    // Loading two adapters back-to-back used to release-all; the fix
-    // releases only the adapter's own contextId (if any) and leaves the
-    // sibling's context intact.
+    // Loading a second adapter releases only that adapter's own contextId
+    // (if any) and leaves the sibling's context intact.
     expect(state.releaseAllCalls).toBe(0);
   });
 

--- a/plugins/plugin-native-llama/src/capacitor-llama-adapter.ts
+++ b/plugins/plugin-native-llama/src/capacitor-llama-adapter.ts
@@ -1,3 +1,21 @@
+/**
+ * Core native bridge for mobile llama.cpp: the `CapacitorLlamaAdapter` class,
+ * the `capacitorLlama` back-compat singleton, and `registerCapacitorLlamaLoader`.
+ *
+ * Maps `llama-cpp-capacitor`'s contextId-based native API onto Eliza's
+ * `LlamaAdapter` contract (load/unload/generate/generateStream/embed/formatChat
+ * and the hardware probe). Each instance owns one native context allocated from
+ * a module-level counter, so chat and embedding must run on separate instances;
+ * `registerCapacitorLlamaLoader` creates both and wires them in as the runtime's
+ * `localInferenceLoader` service (fix for eliza#7681).
+ *
+ * The native plugin is dynamically imported and feature-detected — fork-only
+ * methods (`setCacheType`, `setSpecType`, `getNativeKernels`) warn and skip on
+ * stock builds. `generateStream` is the canonical generation path and
+ * `generate` drains it into a single result; mobile `maxTokens` is clamped to
+ * `MOBILE_MAX_TOKENS_CAP` to avoid OOM.
+ */
+
 import type { PluginListenerHandle } from "@capacitor/core";
 import type {
   NativeCompletionParams,
@@ -752,10 +770,10 @@ export class CapacitorLlamaAdapter implements LlamaAdapter {
     try {
       await this.plugin.releaseContext({ contextId: this.contextId });
     } catch {
-      // Fall back to a targeted release-all only when the per-context
-      // release fails; this used to be the always-path but it now risks
-      // tearing down sibling adapter instances and is reserved for the
-      // pathological case where the native side has lost track of our id.
+      // Fall back to a release-all only when the per-context release fails:
+      // it risks tearing down sibling adapter instances, so it is reserved
+      // for the pathological case where the native side has lost track of
+      // our contextId.
       await this.plugin.releaseAllContexts();
     }
     this.loadedPath = null;

--- a/plugins/plugin-native-llama/src/definitions.ts
+++ b/plugins/plugin-native-llama/src/definitions.ts
@@ -233,8 +233,8 @@ export interface LlamaAdapter {
   generate(options: GenerateOptions): Promise<GenerateResult>;
   /**
    * Streaming generation surface. Emits typed events (token, tool_call,
-   * decision, telemetry, error, done) instead of bare strings. The legacy
-   * `generate(...)` is now a wrapper that drains the stream into a single
+   * decision, telemetry, error, done) instead of bare strings.
+   * `generate(...)` is a wrapper that drains the stream into a single
    * `GenerateResult` for callers that don't care about per-event detail.
    *
    * The stream is single-use and must terminate with exactly one `done`

--- a/plugins/plugin-native-llama/src/kv-cache-resolver.test.ts
+++ b/plugins/plugin-native-llama/src/kv-cache-resolver.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the pure KV-cache type resolver: env-var parsing
+ * (`readEnvKvCacheType`) and the explicit > env > default precedence chain
+ * (`resolveKvCacheType`). Fully deterministic, no native binding.
+ */
+
 import { describe, expect, it, vi } from "vitest";
 import {
   type EnvLike,

--- a/plugins/plugin-native-llama/src/load-capacitor-llama.ts
+++ b/plugins/plugin-native-llama/src/load-capacitor-llama.ts
@@ -1,3 +1,5 @@
+/** Module-level singleton cache returning the default `capacitorLlama` adapter. */
+
 import { capacitorLlama } from "./capacitor-llama-adapter";
 import type { LlamaAdapter } from "./definitions";
 

--- a/plugins/plugin-native-llama/vitest.config.ts
+++ b/plugins/plugin-native-llama/vitest.config.ts
@@ -1,3 +1,5 @@
+/** Vitest config: runs this package's src test suites in a node environment, rooted at the package dir. */
+
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";

--- a/plugins/plugin-nearai/__tests__/auto-enable.test.ts
+++ b/plugins/plugin-nearai/__tests__/auto-enable.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `shouldEnable` — asserts auto-enable keys on a non-empty NEARAI_API_KEY. */
 import { describe, expect, it } from "vitest";
 import { shouldEnable } from "../auto-enable";
 

--- a/plugins/plugin-nearai/__tests__/config.test.ts
+++ b/plugins/plugin-nearai/__tests__/config.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `utils/config` setting resolution against a stubbed runtime and
+ * mutated `process.env`: setting-over-env precedence, base-URL/model defaults and
+ * trailing-slash normalisation, browser-proxy switching, telemetry parsing, and
+ * fail-fast on a missing key.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-nearai/__tests__/openai-compatible-provider.test.ts
+++ b/plugins/plugin-nearai/__tests__/openai-compatible-provider.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for `createNearAIClient` with `@ai-sdk/openai-compatible` mocked:
+ * asserts the endpoint/key/usage settings passed to the provider and that an
+ * injected runtime fetch is forwarded.
+ */
 import { describe, expect, it, vi } from "vitest";
 
 const createOpenAICompatibleMock = vi.fn((config: unknown) => config);

--- a/plugins/plugin-nearai/__tests__/text-params.test.ts
+++ b/plugins/plugin-nearai/__tests__/text-params.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the text handlers with the AI SDK, provider, and core mocked:
+ * asserts param pass-through (topP/temperature/stopSequences), the request-body
+ * normalisation shim (max_completion_tokens→max_tokens, dropped fields, developer→
+ * system role, malformed-JSON passthrough), and MODEL_USED usage emission.
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const generateTextMock = vi.fn(async () => ({ text: "ok", usage: undefined }));

--- a/plugins/plugin-nearai/index.browser.ts
+++ b/plugins/plugin-nearai/index.browser.ts
@@ -1,3 +1,4 @@
+/** Browser build entry point — re-exports the plugin from `index.ts`. */
 import pluginDefault from "./index";
 
 export * from "./index";

--- a/plugins/plugin-nearai/index.node.ts
+++ b/plugins/plugin-nearai/index.node.ts
@@ -1,3 +1,4 @@
+/** Node build entry point — re-exports the plugin from `index.ts`. */
 import pluginDefault from "./index";
 
 export * from "./index";

--- a/plugins/plugin-nearai/index.ts
+++ b/plugins/plugin-nearai/index.ts
@@ -1,3 +1,14 @@
+/**
+ * Assembles the `nearaiPlugin` Plugin object: registers `TEXT_SMALL` and
+ * `TEXT_LARGE` model handlers that route text generation through NEAR AI
+ * Cloud's OpenAI-compatible inference API, seeds `config` from the `NEARAI_*`
+ * environment variables, and wires initialization via `initializeNearAI`.
+ *
+ * The plugin registers no actions, providers, evaluators, or routes — only the
+ * two text-model handlers (delegated to `models/text.ts`). The bundled
+ * `tests` suite drives both handlers against a live NEAR AI key when present.
+ * Node and browser entry points re-export from here.
+ */
 import type {
   GenerateTextParams,
   IAgentRuntime,

--- a/plugins/plugin-nearai/init.ts
+++ b/plugins/plugin-nearai/init.ts
@@ -1,3 +1,10 @@
+/**
+ * Plugin `init` hook: warns (on Node) when no NEAR AI API key is resolvable, so
+ * text generation degrades to a limited state rather than failing silently.
+ * Browser builds skip the warning since the key is expected to live behind a
+ * proxy. Also defines `PluginConfig`, the typed shape of the `NEARAI_*` env
+ * passthrough declared in `index.ts`.
+ */
 import { type IAgentRuntime, logger } from "@elizaos/core";
 import { getApiKeyOptional, isBrowser } from "./utils/config";
 

--- a/plugins/plugin-nearai/models/index.ts
+++ b/plugins/plugin-nearai/models/index.ts
@@ -1,1 +1,2 @@
+/** Barrel for the text-model handlers. */
 export { handleTextLarge, handleTextSmall } from "./text";

--- a/plugins/plugin-nearai/models/text.ts
+++ b/plugins/plugin-nearai/models/text.ts
@@ -1,3 +1,15 @@
+/**
+ * The `TEXT_SMALL` / `TEXT_LARGE` handlers backing the plugin's model map.
+ * Each resolves the configured model name, builds a NEAR AI client, runs the
+ * Vercel AI SDK `generateText`, and emits a `MODEL_USED` event with token usage.
+ *
+ * NEAR AI's OpenAI-compatible endpoint diverges from OpenAI proper, so
+ * `createNearAIRequestFetch` wraps the request fetch to normalise each JSON body
+ * before it leaves: `max_completion_tokens` → `max_tokens` (without clobbering an
+ * explicit `max_tokens`), the `store` / `reasoning_effort` / `strict` fields are
+ * dropped, and any `developer`-role message is rewritten to `system`. Update
+ * that shim if the upstream API changes what it accepts.
+ */
 import type { GenerateTextParams, IAgentRuntime } from "@elizaos/core";
 import { logger, ModelType } from "@elizaos/core";
 import { generateText, type ToolSet } from "ai";

--- a/plugins/plugin-nearai/providers/index.ts
+++ b/plugins/plugin-nearai/providers/index.ts
@@ -1,1 +1,2 @@
+/** Barrel for the NEAR AI OpenAI-compatible client factory and its types. */
 export { createNearAIClient, type NearAIFetch, type NearAIProvider } from "./openai-compatible";

--- a/plugins/plugin-nearai/providers/openai-compatible.ts
+++ b/plugins/plugin-nearai/providers/openai-compatible.ts
@@ -1,3 +1,9 @@
+/**
+ * Builds the `@ai-sdk/openai-compatible` provider aimed at NEAR AI Cloud,
+ * resolving the API key and base URL from runtime settings and preferring an
+ * injected fetch (the request-normalising wrapper from `models/text.ts`) over
+ * `runtime.fetch`. Usage accounting is requested via `includeUsage`.
+ */
 import {
   createOpenAICompatible,
   type OpenAICompatibleProvider,

--- a/plugins/plugin-nearai/types/index.ts
+++ b/plugins/plugin-nearai/types/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Nominal string brands (`ValidatedApiKey`, `ModelName`) plus their
+ * constructing assertions, and the `ProviderOptions` shape for nearai-specific
+ * request fields. Construct branded values only through `assertValidApiKey` /
+ * `createModelName` — never cast.
+ */
 export type ValidatedApiKey = string & { readonly __brand: "ValidatedApiKey" };
 
 export type ModelName = string & { readonly __brand: "ModelName" };

--- a/plugins/plugin-nearai/utils/config.ts
+++ b/plugins/plugin-nearai/utils/config.ts
@@ -1,3 +1,10 @@
+/**
+ * Single source for every runtime setting / env read in the plugin. Each getter
+ * consults `runtime.getSetting(key)` first, then `process.env[key]` (guarded so
+ * browser builds never touch an undefined `process`), applying the `NEARAI_*`
+ * defaults. `getBaseURL` swaps to `NEARAI_BROWSER_BASE_URL` under `isBrowser()`;
+ * API-key and model getters return the branded types from `../types`.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import type { ModelName, ValidatedApiKey } from "../types";
 import { assertValidApiKey, createModelName } from "../types";

--- a/plugins/plugin-nearai/utils/events.ts
+++ b/plugins/plugin-nearai/utils/events.ts
@@ -1,3 +1,8 @@
+/**
+ * Emits `EventType.MODEL_USED` after a NEAR AI inference call, normalising the
+ * AI SDK's varying usage shape (prompt/completion vs input/output tokens) into
+ * a `{ prompt, completion, total }` count for downstream billing/telemetry.
+ */
 import type { IAgentRuntime, ModelTypeName } from "@elizaos/core";
 import { EventType } from "@elizaos/core";
 

--- a/plugins/plugin-nearai/vitest.config.ts
+++ b/plugins/plugin-nearai/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the plugin's `__tests__` suite (node env, 60s timeouts). */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-ollama/__tests__/config-init.shape.test.ts
+++ b/plugins/plugin-ollama/__tests__/config-init.shape.test.ts
@@ -1,3 +1,4 @@
+/** Deterministic unit tests for base-URL/endpoint resolution and the init validation fetch (fetch mocked, no live server). */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { shouldEnable } from "../auto-enable";

--- a/plugins/plugin-ollama/__tests__/embedding.shape.test.ts
+++ b/plugins/plugin-ollama/__tests__/embedding.shape.test.ts
@@ -1,3 +1,4 @@
+/** Deterministic unit tests for `handleTextEmbedding` with the AI SDK `embed` and provider mocked: init probe, usage emit, truncation, and error paths. */
 import type { IAgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-ollama/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-ollama/__tests__/native-plumbing.shape.test.ts
@@ -1,3 +1,4 @@
+/** Deterministic unit tests for text-generation routing — generateText vs streamText across the tools/schema/toolChoice/stream branches — with the `ai` boundary mocked. */
 import type { GenerateTextResult, IAgentRuntime, TextStreamResult } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-ollama/index.browser.ts
+++ b/plugins/plugin-ollama/index.browser.ts
@@ -1,3 +1,4 @@
+/** Browser build entry (`dist/browser`): re-exports the Ollama plugin, config helpers, and transport types. */
 import { ollamaPlugin } from "./plugin";
 
 export * from "./types";

--- a/plugins/plugin-ollama/index.node.ts
+++ b/plugins/plugin-ollama/index.node.ts
@@ -1,3 +1,4 @@
+/** Node/Bun build entry (`dist/node`): re-exports the Ollama plugin, config helpers, and transport types. */
 import { ollamaPlugin } from "./plugin";
 
 export * from "./types";

--- a/plugins/plugin-ollama/index.ts
+++ b/plugins/plugin-ollama/index.ts
@@ -1,3 +1,4 @@
+/** Package entry: re-exports the Ollama plugin, its config helpers, and transport types; default export is the plugin. */
 import { ollamaPlugin } from "./plugin";
 
 export * from "./types";

--- a/plugins/plugin-ollama/models/availability.ts
+++ b/plugins/plugin-ollama/models/availability.ts
@@ -1,3 +1,8 @@
+/**
+ * Ensures a model exists on the Ollama server before inference: probes `/api/show` and, when the
+ * model is absent, issues a blocking `/api/pull`. Runs ahead of every text and embedding call
+ * (`models/text.ts`, `models/embedding.ts`), so a first-use miss adds download latency.
+ */
 import { logger } from "@elizaos/core";
 
 export async function ensureModelAvailable(

--- a/plugins/plugin-ollama/models/index.ts
+++ b/plugins/plugin-ollama/models/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the Ollama model handlers: text (small/large), embedding, and the model-availability pull. */
 export { ensureModelAvailable } from "./availability";
 export { handleTextEmbedding } from "./embedding";
 export { handleTextLarge, handleTextSmall } from "./text";

--- a/plugins/plugin-ollama/types/index.ts
+++ b/plugins/plugin-ollama/types/index.ts
@@ -1,3 +1,4 @@
+/** Config and Ollama wire-protocol shapes (tags, text/object generation params, embeddings) used by the plugin. */
 export interface OllamaConfig {
   baseUrl: string;
   smallModel: string;

--- a/plugins/plugin-ollama/utils/modelUsage.ts
+++ b/plugins/plugin-ollama/utils/modelUsage.ts
@@ -1,3 +1,9 @@
+/**
+ * Token-usage accounting for the Ollama handlers: normalizes the provider's varied `usage` shapes
+ * into `{ promptTokens, completionTokens, totalTokens }`, estimates counts (~4 chars/token) when the
+ * provider omits them, and emits the `MODEL_USED` runtime event that feeds billing and trajectory
+ * telemetry.
+ */
 import type { EventPayload, IAgentRuntime, ModelTypeName } from "@elizaos/core";
 import { EventType } from "@elizaos/core";
 

--- a/plugins/plugin-ollama/vitest.config.ts
+++ b/plugins/plugin-ollama/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest setup for the Ollama plugin unit suite (node environment, `__tests__` + `src` test globs). */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-openai/__tests__/auto-enable.test.ts
+++ b/plugins/plugin-openai/__tests__/auto-enable.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit test for `shouldEnable`: the provider auto-enables only when one of the
+ * OpenAI-compatible API keys is present. Pure function, no runtime.
+ */
 import type { PluginAutoEnableContext } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 

--- a/plugins/plugin-openai/__tests__/cerebras-capability-gating.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-capability-gating.shape.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Shape test asserting that in Cerebras mode the media model types (image /
+ * transcription / TTS) stay unregistered absent an explicit per-capability
+ * endpoint override. Deterministic, mocked runtime.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-openai/__tests__/cerebras-config.live.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-config.live.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Live test hitting a real Cerebras endpoint through the plugin to verify
+ * provider-mode detection and text generation. Runs only in the post-merge lane
+ * with credentials.
+ */
 import { ModelType } from "@elizaos/core";
 import { expect, it } from "vitest";
 

--- a/plugins/plugin-openai/__tests__/cerebras-config.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-config.shape.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Shape tests for Cerebras-mode config resolution (base URL, key, model getters)
+ * and the deterministic local embedding fallback. Mocked runtime, no network.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-openai/__tests__/native-plumbing.live.test.ts
+++ b/plugins/plugin-openai/__tests__/native-plumbing.live.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Live smoke test that `handleTextSmall` reaches a real endpoint and returns text
+ * plus usage. Post-merge lane only.
+ */
 import { expect, it } from "vitest";
 
 import { describeLive } from "../../../packages/app-core/test/helpers/live-agent-test";

--- a/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Shape tests exercising the text handler's plumbing — message normalization,
+ * model-usage events, and trajectory recording — against a mocked `ai` SDK
+ * (`generateText`/`streamText`), no network.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { EventType, ModelType, runWithTrajectoryContext } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-openai/__tests__/openai.live.test.ts
+++ b/plugins/plugin-openai/__tests__/openai.live.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Live end-to-end suite driving the real OpenAI endpoints through the registered
+ * plugin handlers. Runs only when credentials are present.
+ */
 import { ModelType } from "@elizaos/core";
 import { expect, it } from "vitest";
 

--- a/plugins/plugin-openai/__tests__/reasoning-effort.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/reasoning-effort.shape.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Shape test verifying `OPENAI_REASONING_EFFORT` forwards into
+ * `providerOptions.openai.reasoningEffort` for the four valid efforts. Mocked
+ * runtime.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-openai/__tests__/rest-handlers.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/rest-handlers.shape.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Shape tests for the media/embedding handlers (TTS, embedding, image
+ * generation/description): assert request construction and response parsing
+ * against a mocked runtime and fetch, no network.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { handleTextToSpeech } from "../models/audio";

--- a/plugins/plugin-openai/__tests__/trajectory.live.test.ts
+++ b/plugins/plugin-openai/__tests__/trajectory.live.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Live test asserting that the text handlers record their LLM call into the
+ * active trajectory context. Post-merge lane, real model.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { runWithTrajectoryContext } from "@elizaos/core";
 import { describe, expect, it } from "vitest";

--- a/plugins/plugin-openai/index.browser.ts
+++ b/plugins/plugin-openai/index.browser.ts
@@ -1,3 +1,4 @@
+/** Browser build entrypoint: re-exports the plugin from `./index` unchanged. */
 import pluginDefault from "./index";
 
 export * from "./index";

--- a/plugins/plugin-openai/index.node.ts
+++ b/plugins/plugin-openai/index.node.ts
@@ -1,3 +1,4 @@
+/** Node build entrypoint: re-exports the plugin from `./index` unchanged. */
 import pluginDefault from "./index";
 
 export * from "./index";

--- a/plugins/plugin-openai/index.ts
+++ b/plugins/plugin-openai/index.ts
@@ -1,3 +1,16 @@
+/**
+ * Assembles `openaiPlugin` — the elizaOS `Plugin` object that registers every
+ * OpenAI-backed model handler on the `AgentRuntime`: text tiers (small→mega,
+ * response-handler, action-planner), embeddings, tokenizer, image
+ * generation/description, transcription, TTS, and deep research.
+ *
+ * Text/embedding/tokenizer/research handlers register statically via `models`.
+ * The media handlers (IMAGE, IMAGE_DESCRIPTION, TRANSCRIPTION, TEXT_TO_SPEECH)
+ * register in `init()` through `registerMediaModels`, which skips them in
+ * Cerebras mode unless a per-capability endpoint override points at a server
+ * that serves them. `tests` carries the live connectivity/round-trip suite the
+ * plugin loader runs against a real endpoint.
+ */
 import type {
   TextToSpeechParams as CoreTextToSpeechParams,
   TranscriptionParams as CoreTranscriptionParams,

--- a/plugins/plugin-openai/init.ts
+++ b/plugins/plugin-openai/init.ts
@@ -1,3 +1,10 @@
+/**
+ * Startup validation for the OpenAI provider, run from the plugin's `init`: it
+ * fires a best-effort `GET /models` against the resolved base URL so a missing
+ * or invalid key surfaces as an early warning rather than a first-call failure.
+ * Browser builds skip the check (no server-side key). Also silences the AI SDK
+ * warning log globally.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import type { OpenAIPluginConfig } from "./types";

--- a/plugins/plugin-openai/models/audio.ts
+++ b/plugins/plugin-openai/models/audio.ts
@@ -1,3 +1,9 @@
+/**
+ * Audio model handlers: `handleTranscription` uploads audio to the transcription
+ * endpoint (sniffing the container via `detectAudioMimeType` to pick an upload
+ * filename), and `handleTextToSpeech` synthesizes speech via the TTS endpoint.
+ * Both accept the core param shapes as well as raw Blob/File/Buffer input.
+ */
 import type {
   TextToSpeechParams as CoreTextToSpeechParams,
   TranscriptionParams as CoreTranscriptionParams,

--- a/plugins/plugin-openai/models/embedding.ts
+++ b/plugins/plugin-openai/models/embedding.ts
@@ -1,3 +1,10 @@
+/**
+ * `handleTextEmbedding`: calls the OpenAI embeddings endpoint and validates the
+ * returned vector dimension against `VECTOR_DIMS`. In Cerebras mode without an
+ * explicit embedding endpoint it substitutes a deterministic local hash
+ * embedding (Cerebras serves no embeddings), keeping recall functional when no
+ * real embedding server is reachable.
+ */
 import type { IAgentRuntime, TextEmbeddingParams } from "@elizaos/core";
 import { logger, ModelType, VECTOR_DIMS } from "@elizaos/core";
 

--- a/plugins/plugin-openai/models/image.ts
+++ b/plugins/plugin-openai/models/image.ts
@@ -1,3 +1,8 @@
+/**
+ * Image model handlers: `handleImageGeneration` (dall-e-3 `/images/generations`)
+ * and `handleImageDescription`, which sends the image to a vision chat model and
+ * returns a `{ title, description }` pair.
+ */
 import type {
   IAgentRuntime,
   ImageDescriptionParams,

--- a/plugins/plugin-openai/models/index.ts
+++ b/plugins/plugin-openai/models/index.ts
@@ -1,3 +1,4 @@
+/** Barrel re-exporting every OpenAI model handler for registration in the plugin. */
 export { handleTextToSpeech, handleTranscription } from "./audio";
 export { handleTextEmbedding } from "./embedding";
 export { handleImageDescription, handleImageGeneration } from "./image";

--- a/plugins/plugin-openai/models/tokenizer.ts
+++ b/plugins/plugin-openai/models/tokenizer.ts
@@ -1,3 +1,8 @@
+/**
+ * `TEXT_TOKENIZER_ENCODE`/`DECODE` handlers backed by js-tiktoken: they validate
+ * params and delegate to the offline tokenization helpers, never hitting the
+ * network.
+ */
 import type { DetokenizeTextParams, IAgentRuntime, TokenizeTextParams } from "@elizaos/core";
 import { detokenizeText, tokenizeText } from "../utils/tokenization";
 

--- a/plugins/plugin-openai/providers/index.ts
+++ b/plugins/plugin-openai/providers/index.ts
@@ -1,1 +1,2 @@
+/** Barrel re-exporting the OpenAI client factory. */
 export { createOpenAIClient } from "./openai";

--- a/plugins/plugin-openai/providers/openai.ts
+++ b/plugins/plugin-openai/providers/openai.ts
@@ -1,3 +1,8 @@
+/**
+ * `createOpenAIClient`: builds the `@ai-sdk/openai` provider bound to the
+ * runtime's resolved base URL and key. In proxy mode with no key it uses a
+ * placeholder key (auth is injected upstream); otherwise a missing key throws.
+ */
 import { createOpenAI, type OpenAIProvider } from "@ai-sdk/openai";
 import type { IAgentRuntime } from "@elizaos/core";
 import { getApiKey, getBaseURL, isProxyMode } from "../utils/config";

--- a/plugins/plugin-openai/utils/audio.ts
+++ b/plugins/plugin-openai/utils/audio.ts
@@ -1,3 +1,9 @@
+/**
+ * Container sniffing for audio bytes: `detectAudioMimeType` matches magic-byte
+ * signatures (WAV/MP3/OGG/FLAC/M4A/WebM) to a MIME type, and the helpers derive
+ * an upload filename/extension from it. Used by the transcription handler to
+ * label multipart uploads.
+ */
 import { logger } from "@elizaos/core";
 
 const MAGIC_BYTES = {

--- a/plugins/plugin-openai/utils/config.ts
+++ b/plugins/plugin-openai/utils/config.ts
@@ -1,3 +1,11 @@
+/**
+ * Central settings and endpoint resolution for the plugin: `getSetting` reads
+ * runtime config first then `process.env`, and the typed getters here resolve
+ * every model slot, base URL, auth header, embedding dimension, and timeout with
+ * their documented fallback chains. Also home to provider-mode detection
+ * (Cerebras / EvoLink / proxy) and the browser-vs-node branch that decides
+ * whether an `Authorization` header is sent.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { DEFAULT_CEREBRAS_TEXT_MODEL, logger } from "@elizaos/core";
 

--- a/plugins/plugin-openai/utils/events.ts
+++ b/plugins/plugin-openai/utils/events.ts
@@ -1,3 +1,9 @@
+/**
+ * `emitModelUsageEvent`: normalizes token-usage counts from the three shapes the
+ * plugin encounters (local `TokenUsage`, AI SDK usage, raw OpenAI API usage) into
+ * one payload and emits `EventType.MODEL_USED` for telemetry, truncating the
+ * prompt to keep event payloads small.
+ */
 import type { IAgentRuntime, ModelTypeName } from "@elizaos/core";
 import { EventType } from "@elizaos/core";
 import type { TokenUsage } from "../types";

--- a/plugins/plugin-openai/utils/index.ts
+++ b/plugins/plugin-openai/utils/index.ts
@@ -1,3 +1,4 @@
+/** Barrel re-exporting the util modules (audio, config, events, tokenization). */
 export * from "./audio";
 export * from "./config";
 export * from "./events";

--- a/plugins/plugin-openai/utils/tokenization.ts
+++ b/plugins/plugin-openai/utils/tokenization.ts
@@ -1,3 +1,8 @@
+/**
+ * js-tiktoken wrappers for offline token math — encode/decode/count/truncate
+ * keyed to a runtime model slot. Resolves the tiktoken encoding from the model
+ * name, falling back to o200k_base for 4o-family models else cl100k_base.
+ */
 import type { IAgentRuntime, ModelTypeName } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import {

--- a/plugins/plugin-openai/vitest.config.ts
+++ b/plugins/plugin-openai/vitest.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Vitest config for the default unit/shape suite: aliases `@elizaos/plugin-sql`
+ * to workspace source and excludes the live, real-drift, and PGLite-harness
+ * lanes (each has its own config or gated invocation).
+ */
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 

--- a/plugins/plugin-openai/vitest.live.config.ts
+++ b/plugins/plugin-openai/vitest.live.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Vitest config for the `*.live.test.ts` lane: aliases `@elizaos/core` and
+ * `@elizaos/plugin-sql` to workspace source and includes only the live suites,
+ * which hit a real OpenAI-compatible endpoint.
+ */
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 

--- a/plugins/plugin-openrouter/__tests__/embedding.edge.test.ts
+++ b/plugins/plugin-openrouter/__tests__/embedding.edge.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Edge-case coverage for the embedding handler with a stubbed `fetch` (no live
+ * API): asserts the null-probe marker vector, malformed/empty-input rejections,
+ * and unsupported-dimension validation all short-circuit before any network call.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-openrouter/__tests__/image-description.shape.test.ts
+++ b/plugins/plugin-openrouter/__tests__/image-description.shape.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Shape test for the image handlers with the `ai` SDK and provider mocked (no
+ * live API): checks IMAGE_DESCRIPTION parses title/description from the model
+ * text and that blank image URLs and prompts are rejected before the provider is
+ * called.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-openrouter/__tests__/models.live.test.ts
+++ b/plugins/plugin-openrouter/__tests__/models.live.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Live integration test (real OpenRouter API, gated on `OPENROUTER_API_KEY`):
+ * boots a real AgentRuntime with `@elizaos/plugin-sql` and exercises TEXT_SMALL,
+ * TEXT_LARGE, structured output via responseSchema, IMAGE_DESCRIPTION, and
+ * TEXT_EMBEDDING through `runtime.useModel`.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { openrouterPlugin } from "../index";

--- a/plugins/plugin-openrouter/__tests__/native-plumbing.live.test.ts
+++ b/plugins/plugin-openrouter/__tests__/native-plumbing.live.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Live test (real OpenRouter API via `describeLive`, self-skips without a key):
+ * drives `handleTextSmall` with native messages and asserts it returns real text
+ * with populated token usage.
+ */
 import { expect, it } from "vitest";
 
 import { describeLive } from "../../../packages/app-core/test/helpers/live-agent-test";

--- a/plugins/plugin-openrouter/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-openrouter/__tests__/native-plumbing.shape.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Shape test for the native text path (`ai` SDK mocked, no live API): covers
+ * tool-set normalization from runtime ToolDefinition arrays, attachment/message
+ * merging, system-prompt de-duplication, cache providerOptions forwarding,
+ * sampling-param suppression for reasoning models, and that malformed params and
+ * streaming provider errors surface rather than resolving empty.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-openrouter/__tests__/setup.ts
+++ b/plugins/plugin-openrouter/__tests__/setup.ts
@@ -1,3 +1,4 @@
+/** Global test setup: loads `.env` before the suite so real-API tests can find `OPENROUTER_API_KEY`. */
 import { resolve } from "node:path";
 import { config } from "dotenv";
 import { beforeAll } from "vitest";

--- a/plugins/plugin-openrouter/__tests__/transcription.shape.test.ts
+++ b/plugins/plugin-openrouter/__tests__/transcription.shape.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Shape test for the TRANSCRIPTION handler with a stubbed `fetch` (no live API):
+ * verifies the handler registers, posts Buffer audio as base64 `input_audio`, and
+ * fetches http `audioUrl` inputs while preserving the response content type.
+ */
 import { type IAgentRuntime, ModelType } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-openrouter/index.browser.ts
+++ b/plugins/plugin-openrouter/index.browser.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser build entry point — re-exports the same plugin as `index.ts`. The
+ * behavioral difference is enforced downstream: `providers/openrouter.ts` omits
+ * the Authorization header when `document` is present, so browser bundles must
+ * route through an `OPENROUTER_BROWSER_BASE_URL` proxy that injects the key.
+ */
 import pluginDefault from "./index";
 
 export * from "./index";

--- a/plugins/plugin-openrouter/index.ts
+++ b/plugins/plugin-openrouter/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Public entry point for the OpenRouter provider plugin: re-exports the plugin
+ * object (both named and default), the plugin-local types, and the `utils/config`
+ * setting helpers. Consumers add `@elizaos/plugin-openrouter` to a character's
+ * plugin list; `plugin.ts` holds the actual model registrations.
+ */
 import openrouterPluginImpl from "./plugin";
 
 const openrouterPlugin = openrouterPluginImpl;

--- a/plugins/plugin-openrouter/init.ts
+++ b/plugins/plugin-openrouter/init.ts
@@ -1,3 +1,10 @@
+/**
+ * Boot-time API key validation for the plugin's `init` hook (node builds only).
+ * Warns rather than throws when `OPENROUTER_API_KEY` is missing so the agent can
+ * still start with limited functionality, and no-ops in browser environments
+ * where the key lives behind the proxy. Also silences the AI SDK warning log
+ * before any provider is constructed.
+ */
 import { type IAgentRuntime, logger } from "@elizaos/core";
 import { getApiKey, getBaseURL } from "./utils/config";
 

--- a/plugins/plugin-openrouter/models/audio.ts
+++ b/plugins/plugin-openrouter/models/audio.ts
@@ -1,3 +1,12 @@
+/**
+ * The `TRANSCRIPTION` model handler. Normalizes the several accepted input
+ * shapes — URL string, `Buffer`, `Blob`/`File`, core `{ audioUrl }`, and the
+ * local `{ audio, language?, model?, ... }` object — into base64 plus a detected
+ * container format, then POSTs directly to OpenRouter's `/audio/transcriptions`
+ * endpoint (not through the AI SDK). Format is sniffed from mime type, URL
+ * extension, then magic bytes (`detectBufferFormat`). Emits a `MODEL_USED` event
+ * from the response usage. URL inputs are constrained to http/https.
+ */
 import type { TranscriptionParams as CoreTranscriptionParams, IAgentRuntime } from "@elizaos/core";
 import { logger, ModelType } from "@elizaos/core";
 

--- a/plugins/plugin-openrouter/models/embedding.ts
+++ b/plugins/plugin-openrouter/models/embedding.ts
@@ -1,3 +1,10 @@
+/**
+ * The `TEXT_EMBEDDING` model handler, POSTing directly to OpenRouter's
+ * `/embeddings` endpoint. Validates the configured dimension against
+ * `VECTOR_DIMS` and rejects a returned vector whose length disagrees — no silent
+ * truncation. A `null` param yields a deterministic marker probe vector; oversized
+ * input is truncated to ~8000 tokens with a warning. Emits a `MODEL_USED` event.
+ */
 import type { IAgentRuntime, TextEmbeddingParams } from "@elizaos/core";
 import { logger, ModelType, VECTOR_DIMS } from "@elizaos/core";
 

--- a/plugins/plugin-openrouter/models/image.ts
+++ b/plugins/plugin-openrouter/models/image.ts
@@ -1,3 +1,10 @@
+/**
+ * The `IMAGE_DESCRIPTION` and `IMAGE` (generation) model handlers, both routed
+ * through the AI SDK `generateText` against the OpenRouter chat model. Description
+ * sends the image URL as a multimodal user message and parses the model's
+ * Title/Description text; generation returns the model's text response as the
+ * image URL. Both emit a `MODEL_USED` event from the response usage.
+ */
 import type {
   IAgentRuntime,
   ImageDescriptionParams,

--- a/plugins/plugin-openrouter/models/index.ts
+++ b/plugins/plugin-openrouter/models/index.ts
@@ -1,3 +1,4 @@
+/** Barrel re-exporting the model handlers registered by `plugin.ts`. */
 export { handleTranscription } from "./audio";
 export { handleTextEmbedding } from "./embedding";
 export { handleImageDescription, handleImageGeneration } from "./image";

--- a/plugins/plugin-openrouter/models/text.ts
+++ b/plugins/plugin-openrouter/models/text.ts
@@ -1,3 +1,19 @@
+/**
+ * Every text `ModelType` handler (nano, small, medium, large, mega, response
+ * handler, action planner) routed through a single `generateTextWithModel`
+ * against the `@openrouter/ai-sdk-provider` chat model. Resolves the configured
+ * model name per type, builds AI SDK `generateText`/`streamText` params, and
+ * emits a `MODEL_USED` usage event after each call.
+ *
+ * Load-bearing normalization lives here: `readToolSet` rekeys runtime
+ * ToolDefinition arrays into a provider-safe `ToolSet` (bare arrays give Google
+ * function names like "0"); `supportsSamplingParameters` suppresses
+ * temperature/frequency/presence for `openai/*`, `anthropic/*`, and reasoning
+ * models that reject them; `buildStructuredOutput` wraps a `responseSchema` into
+ * the SDK `output` field; and prompt/messages/attachments are reconciled into a
+ * single wire shape. Callers that pass messages/tools/toolChoice/responseSchema
+ * get the richer native result object; plain prompts get a string.
+ */
 import type {
   GenerateTextParams,
   IAgentRuntime,

--- a/plugins/plugin-openrouter/plugin.ts
+++ b/plugins/plugin-openrouter/plugin.ts
@@ -1,3 +1,13 @@
+/**
+ * The `Plugin` object definition — the plugin's sole surface. It registers a
+ * model handler per `ModelType` (text nano/small/medium/large/mega, response
+ * handler, action planner, image description, image generation, embedding,
+ * transcription), delegating each to the `models/*` implementations; declares
+ * the auto-enable env key and the full `config` map of `OPENROUTER_*` and
+ * generic-fallback settings; and carries the in-runtime `tests` that exercise
+ * text, structured-output, and embedding handlers against the live provider.
+ * No actions, providers, services, evaluators, or routes.
+ */
 import {
   type GenerateTextParams,
   type IAgentRuntime,

--- a/plugins/plugin-openrouter/providers/index.ts
+++ b/plugins/plugin-openrouter/providers/index.ts
@@ -1,1 +1,2 @@
+/** Barrel re-exporting the OpenRouter provider factory. */
 export { createOpenRouterProvider } from "./openrouter";

--- a/plugins/plugin-openrouter/providers/openrouter.ts
+++ b/plugins/plugin-openrouter/providers/openrouter.ts
@@ -1,3 +1,9 @@
+/**
+ * Constructs the `@openrouter/ai-sdk-provider` client the model handlers call.
+ * Omits the API key in browser environments (where `document` exists) so the
+ * key never ships to the client — browser builds must point `getBaseURL` at a
+ * key-injecting proxy via `OPENROUTER_BROWSER_BASE_URL`.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { getApiKey, getBaseURL } from "../utils/config";

--- a/plugins/plugin-openrouter/types/index.ts
+++ b/plugins/plugin-openrouter/types/index.ts
@@ -1,3 +1,4 @@
+/** Plugin-local TypeScript interfaces for OpenRouter config and generation params. */
 export interface OpenRouterConfig {
   apiKey: string;
   baseUrl: string;

--- a/plugins/plugin-openrouter/utils/config.ts
+++ b/plugins/plugin-openrouter/utils/config.ts
@@ -1,3 +1,12 @@
+/**
+ * Setting resolution for the plugin. `getSetting` reads character settings first
+ * (`runtime.getSetting`), then `process.env`, then a caller default. The
+ * `get*Model` helpers layer the priority the README documents: `OPENROUTER_*`
+ * variant, then the generic (`SMALL_MODEL`, …) fallback, then a hard default —
+ * with nano/medium/mega/response-handler/action-planner cascading onto their
+ * base tier when unset. Also holds the default model constants and the
+ * base-URL/dimension/cleanup accessors.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 
 export const DEFAULT_BASE_URL = "https://openrouter.ai/api/v1";

--- a/plugins/plugin-openrouter/utils/events.ts
+++ b/plugins/plugin-openrouter/utils/events.ts
@@ -1,3 +1,10 @@
+/**
+ * Emits `EventType.MODEL_USED` after every model call, normalizing the AI SDK's
+ * varied usage field names (`inputTokens`/`promptTokens`, …) into a single
+ * prompt/completion/total token shape and returning it to the caller. Every
+ * `models/*` handler routes its usage through here so billing/telemetry sees one
+ * consistent event.
+ */
 import type { EventPayload, IAgentRuntime, ModelTypeName } from "@elizaos/core";
 import { EventType } from "@elizaos/core";
 

--- a/plugins/plugin-openrouter/utils/helpers.ts
+++ b/plugins/plugin-openrouter/utils/helpers.ts
@@ -1,3 +1,10 @@
+/**
+ * Structured-output recovery helpers: `extractJsonFromText` walks a fallback
+ * chain (raw JSON, fenced blocks, first `{...}` span) to salvage an object from a
+ * chatty model completion, and `handleObjectGenerationError` turns a failure into
+ * an `{ error }` object. `getJsonRepairFunction` optionally loads `jsonrepair`
+ * when installed.
+ */
 import { type JsonValue, logger } from "@elizaos/core";
 
 export function getJsonRepairFunction(): ((text: string) => string) | undefined {

--- a/plugins/plugin-openrouter/utils/index.ts
+++ b/plugins/plugin-openrouter/utils/index.ts
@@ -1,3 +1,4 @@
+/** Barrel re-exporting the config, events, and helper utilities. */
 export * from "./config";
 export * from "./events";
 export * from "./helpers";

--- a/plugins/plugin-openrouter/vitest.config.ts
+++ b/plugins/plugin-openrouter/vitest.config.ts
@@ -1,3 +1,10 @@
+/**
+ * Default vitest config for the unit suite (`__tests__/**\/*.test.ts`). Excludes
+ * the `*.harness.test.ts` (real-PGLite) and `*.live.test.ts` (real-API) files —
+ * the guarded `models.live` suite runs only in the `post-merge` lane, and the
+ * unguarded native-plumbing live file stays excluded everywhere. Runs files
+ * sequentially and isolated, and redirects PGlite data to the OS temp dir.
+ */
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { defineConfig } from "vitest/config";
@@ -25,7 +32,6 @@ export default defineConfig({
     sequence: {
       shuffle: false,
     },
-    // Isolate test files
     isolate: true,
     fileParallelism: false,
     // Redirect PGlite data dir to OS temp so :memory: artifacts

--- a/plugins/plugin-openrouter/vitest.live.config.ts
+++ b/plugins/plugin-openrouter/vitest.live.config.ts
@@ -1,3 +1,9 @@
+/**
+ * Vitest config for the live suite (`__tests__/**\/*.live.test.ts`), which hits
+ * the real OpenRouter API and boots a real `@elizaos/plugin-sql` runtime. Aliases
+ * `@elizaos/core` and `@elizaos/plugin-sql` to workspace source so the live tests
+ * run against the checkout rather than built artifacts.
+ */
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 

--- a/plugins/plugin-zai/__tests__/auto-enable.test.ts
+++ b/plugins/plugin-zai/__tests__/auto-enable.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `shouldEnable`: deterministic env-map checks over `ZAI_API_KEY` and the legacy `Z_AI_API_KEY` alias. */
 import { describe, expect, it } from "vitest";
 import { shouldEnable } from "../auto-enable";
 

--- a/plugins/plugin-zai/__tests__/config.test.ts
+++ b/plugins/plugin-zai/__tests__/config.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the config resolvers, exercising setting-vs-env precedence, model/base-URL defaults, and the deprecated CoT-budget-to-thinking mapping against a stub runtime (no live API). */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-zai/__tests__/events.test.ts
+++ b/plugins/plugin-zai/__tests__/events.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `emitModelUsageEvent` token normalization, asserting the `MODEL_USED` payload against a mocked `runtime.emitEvent`. */
 import { EventType } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { emitModelUsageEvent } from "../utils/events";

--- a/plugins/plugin-zai/__tests__/openai-compatible-provider.test.ts
+++ b/plugins/plugin-zai/__tests__/openai-compatible-provider.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `createZaiClient`, verifying the base URL and API key passed into a mocked `@ai-sdk/openai-compatible` factory (no live API). */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const createOpenAICompatibleMock = vi.fn((config: unknown) => config);

--- a/plugins/plugin-zai/__tests__/text-params.test.ts
+++ b/plugins/plugin-zai/__tests__/text-params.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for text-param resolution (model selection, max-token caps, thinking body) driving mocked `ai.generateText` and the z.ai client — no live model. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const generateTextMock = vi.fn(async () => ({ text: "ok", usage: undefined }));

--- a/plugins/plugin-zai/index.browser.ts
+++ b/plugins/plugin-zai/index.browser.ts
@@ -1,3 +1,4 @@
+/** Browser build entrypoint — re-exports the plugin definition; browser routes through `ZAI_BROWSER_BASE_URL` rather than holding the API key. */
 import pluginDefault from "./index";
 
 export * from "./index";

--- a/plugins/plugin-zai/index.node.ts
+++ b/plugins/plugin-zai/index.node.ts
@@ -1,3 +1,4 @@
+/** Node build entrypoint — re-exports the plugin definition unchanged. */
 import pluginDefault from "./index";
 
 export * from "./index";

--- a/plugins/plugin-zai/index.ts
+++ b/plugins/plugin-zai/index.ts
@@ -1,3 +1,13 @@
+/**
+ * Plugin definition for @elizaos/plugin-zai: registers z.ai's `TEXT_SMALL` and
+ * `TEXT_LARGE` model handlers against its OpenAI-compatible API. Registers no
+ * actions, providers, evaluators, or routes.
+ *
+ * `init` validates the API key via `initializeZai`; the `models` map wires
+ * `handleTextSmall`/`handleTextLarge`. The bundled `tests` suite exercises key
+ * validation and handler dispatch. Auto-enabled from `auto-enable.ts` when
+ * `ZAI_API_KEY` (or legacy `Z_AI_API_KEY`) is set.
+ */
 import type {
   GenerateTextParams,
   IAgentRuntime,

--- a/plugins/plugin-zai/init.ts
+++ b/plugins/plugin-zai/init.ts
@@ -1,3 +1,9 @@
+/**
+ * Startup validation for the z.ai plugin: confirms an API key is present (except
+ * in browser builds, which route through a proxy base URL) and silences the
+ * Vercel AI SDK warning channel once per process. `PluginConfig` mirrors the
+ * recognized `ZAI_*` env vars.
+ */
 import { type IAgentRuntime, logger } from "@elizaos/core";
 import { getApiKeyOptional, isBrowser } from "./utils/config";
 

--- a/plugins/plugin-zai/models/index.ts
+++ b/plugins/plugin-zai/models/index.ts
@@ -1,1 +1,2 @@
+/** Barrel for the z.ai text model handlers registered on `Plugin.models`. */
 export { handleTextLarge, handleTextSmall } from "./text";

--- a/plugins/plugin-zai/models/text.ts
+++ b/plugins/plugin-zai/models/text.ts
@@ -1,3 +1,14 @@
+/**
+ * Core text generation for the z.ai handlers. `resolveTextParams` maps
+ * `GenerateTextParams` to the AI SDK call — selecting the per-size model, caching
+ * per-size max-token caps (4096 for `air`/`flash`, 8192 otherwise), and folding
+ * in the resolved thinking config. `generateTextWithModel` runs the call and
+ * emits `MODEL_USED` with token usage.
+ *
+ * Thinking mode is injected at the HTTP fetch layer via `createZaiRequestFetch`
+ * rather than as an AI SDK parameter, because z.ai's OpenAI-compatible endpoint
+ * expects a top-level `thinking` body field the SDK does not natively emit.
+ */
 import type { GenerateTextParams, IAgentRuntime } from "@elizaos/core";
 import { logger, ModelType } from "@elizaos/core";
 import { generateText } from "ai";

--- a/plugins/plugin-zai/providers/index.ts
+++ b/plugins/plugin-zai/providers/index.ts
@@ -1,1 +1,2 @@
+/** Barrel for the z.ai OpenAI-compatible client factory and its fetch/provider types. */
 export { createZaiClient, type ZaiFetch, type ZaiProvider } from "./openai-compatible";

--- a/plugins/plugin-zai/providers/openai-compatible.ts
+++ b/plugins/plugin-zai/providers/openai-compatible.ts
@@ -1,3 +1,9 @@
+/**
+ * Builds the `@ai-sdk/openai-compatible` client pointed at z.ai's general API
+ * (base URL from config, validated against the blocked Coding/Anthropic paths).
+ * Accepts an optional custom `fetch` so the text handlers can splice in the
+ * `thinking` request body.
+ */
 import {
   createOpenAICompatible,
   type OpenAICompatibleProvider,

--- a/plugins/plugin-zai/types/index.ts
+++ b/plugins/plugin-zai/types/index.ts
@@ -1,3 +1,4 @@
+/** Branded string types and guards shared across the z.ai plugin: `ValidatedApiKey`, `ModelName`, `ModelSize`, and `ProviderOptions`. */
 export type ValidatedApiKey = string & { readonly __brand: "ValidatedApiKey" };
 
 export type ModelName = string & { readonly __brand: "ModelName" };

--- a/plugins/plugin-zai/utils/config.ts
+++ b/plugins/plugin-zai/utils/config.ts
@@ -1,3 +1,10 @@
+/**
+ * Central resolver for every z.ai setting: reads `runtime.getSetting(key)` first,
+ * then `process.env[key]`, applying defaults (base URL, small/large model IDs).
+ * Owns API-key resolution (with the legacy `Z_AI_API_KEY` alias), strict base-URL
+ * normalization that rejects the Coding/Anthropic endpoints, browser detection,
+ * and the deprecated CoT-budget shims that map onto `ZAI_THINKING_TYPE`.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import type { ModelName, ModelSize, ValidatedApiKey } from "../types";
 import { assertValidApiKey, createModelName } from "../types";

--- a/plugins/plugin-zai/utils/events.ts
+++ b/plugins/plugin-zai/utils/events.ts
@@ -1,3 +1,7 @@
+/**
+ * Normalizes AI SDK token usage (prompt/completion or input/output naming) and
+ * emits `EventType.MODEL_USED` so the runtime can meter each z.ai call.
+ */
 import type { IAgentRuntime, ModelTypeName } from "@elizaos/core";
 import { EventType } from "@elizaos/core";
 

--- a/plugins/plugin-zai/vitest.config.ts
+++ b/plugins/plugin-zai/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the z.ai plugin unit suite (node environment, 60s timeouts). */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Comment-cleanup batch **B14** (parent #12181, sub-issue #12244): purpose-explaining prose file headers on previously header-less files + churn/change-narration removal across the model-provider and inference plugins.

**Comments and whitespace only — zero functional diff.** No code token changes, no file adds/deletes/renames, no license-block edits.

### Scope covered (this PR)
`plugin-openai`, `plugin-anthropic`, `plugin-anthropic-proxy`, `plugin-google-genai`, `plugin-openrouter`, `plugin-ollama`, `plugin-lmstudio`, `plugin-zai`, `plugin-nearai`, `plugin-cli-inference`, `plugin-local-inference` (incl. `native/`, `scripts/`, backends/routes/runtime/services/actions/adapters), `plugin-native-llama`, `plugin-aosp-local-inference`.

Plugins already headered upstream by a sibling pass (`groq`, `xai`, `edge-tts`, `elevenlabs`, `suno`, `embeddings`) were skipped — this PR defers to develop there. One genuinely empty, unreferenced `plugin-openai/__tests__/setup.ts` (0 bytes, no `setupFiles`) is left un-headed per accuracy-over-coverage.

### What changed per file
- Header-less files now open with one accurate `/** … */` block phrased in each plugin's architecture terms (model handler/router registration, backend FFI, download/quant, streaming, ASR/voice bench, CLI-subscription inference via claude/codex SDK sessions), guided by each plugin's `CLAUDE.md`. Placement: after any `#!` shebang, below any license block, before imports. JSDoc-after-import files left as-is.
- Churn removed/rewritten: change-narration, next-line restatement, commented-out code, migration stories → present-tense fact where useful, else deleted.

## Validation

- **`bun run check:comment-only` → PASS**: `368 source file(s) changed; every code token identical to origin/develop. Comments only.` (TS-parser code-token equality — machine proof of zero functional diff, per parent #12181 WI-2).
- Rebased onto current `develop`, clean.

## Evidence rows
- Real-LLM trajectory / backend logs / screenshots — **N/A** (no runtime/UI/prompt behavior changed; comments only, machine-proven).

Closes #12244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)