### PR TITLE
fix(snap): build cloud routing before core

### DIFF
--- a/.github/issue-evidence/12589-snap-cloud-routing/README.md
+++ b/.github/issue-evidence/12589-snap-cloud-routing/README.md
@@ -1,0 +1,25 @@
+# Snap cloud-routing declaration evidence
+
+## Scope
+
+Fixes the Snap `Build Snap (arm64)` failure observed on PR #12589 while building `@elizaos/core` declarations:
+
+- `packages/core/src/cloud-routing.ts(8,8): error TS2307: Cannot find module '@elizaos/cloud-routing' or its corresponding type declarations.`
+- `packages/core/src/cloud-routing.ts(15,8): error TS2307: Cannot find module '@elizaos/cloud-routing' or its corresponding type declarations.`
+
+The iOS plist PR did not touch core or Snap packaging. The failure comes from the Snap recipe's reduced workspace build reaching `@elizaos/core` declaration generation before `@elizaos/cloud-routing` has generated `dist` types, even though `packages/core/src/cloud-routing.ts` now imports it.
+
+## Verification
+
+- `bun run --cwd packages/cloud/routing build` before the filtered Turbo build - PASS.
+- `bunx turbo run build --filter=@elizaos/cloud-routing --filter=@elizaos/core` - PASS.
+- `bunx tsc --project packages/core/tsconfig.declarations.json --pretty false` - PASS after building `@elizaos/cloud-routing`.
+- `ruby -e 'require "yaml"; YAML.load_file("packages/app-core/packaging/snap/snapcraft.yaml")'` - PASS.
+- `git diff --check` against `origin/develop` - PASS.
+
+## Evidence matrix
+
+- Live model trajectories: N/A - no model, prompt, provider, action, or evaluator behavior changed.
+- Screenshots/video: N/A - no user-facing UI changed.
+- Backend logs: N/A - build configuration only.
+- Native/iOS capture: N/A - this is a Linux Snap declaration-build fix, not an app runtime change.

--- a/packages/app-core/packaging/snap/snapcraft.yaml
+++ b/packages/app-core/packaging/snap/snapcraft.yaml
@@ -476,12 +476,14 @@ parts:
       # `bun run build` also builds examples and release helpers, which are not
       # part of the snap payload and depend on workspaces intentionally removed
       # above.
-      # @elizaos/cloud-routing was migrated to packages/cloud/shared/src/routing
-      # in a62685d708 — the orphan packages/cloud/routing/ workspace stub
-      # (package.json only, no src, dist gitignored) can't build cleanly in
-      # fresh CI checkouts, and nothing currently imports it. Omit it from
-      # the snap closure until the source-of-truth migration is finished.
+      # Build this first because @elizaos/core's declaration pass imports the
+      # package via its generated dist types, while Turbo does not currently
+      # schedule @elizaos/cloud-routing before @elizaos/core in this filtered
+      # Snap closure.
+      bun run --cwd packages/cloud/routing build
+
       bunx turbo run build \
+        --filter=@elizaos/cloud-routing \
         --filter=@elizaos/core \
         --filter=@elizaos/shared \
         --filter=@elizaos/ui \


### PR DESCRIPTION
## Summary
- include `@elizaos/cloud-routing` in the reduced Snap runtime build closure
- remove the stale recipe comment that said the package was unused/orphaned
- add evidence for the `Build Snap (arm64)` failure observed on #12589

## Verification
- `bun install --ignore-scripts` in a clean `origin/develop` export
- `bunx turbo run build --filter=@elizaos/cloud-routing --filter=@elizaos/core`
- `bunx tsc --project packages/core/tsconfig.declarations.json --pretty false`
- `ruby -e 'require "yaml"; YAML.load_file("packages/app-core/packaging/snap/snapcraft.yaml")'`
- `git diff --check origin/develop..fix/snap-cloud-routing-build`

## Evidence
- `.github/issue-evidence/12589-snap-cloud-routing/README.md`

## Notes
- No UI, model, prompt, provider, action, evaluator, or native runtime behavior changed.
- This is a CI/package build closure fix for the Snap recipe. It should unblock the Snap check that failed on the iOS background-audio PR.
