### PR TITLE
fix(scripts): refresh dist path aliases after walker migration

### DIFF
--- a/tsconfig.dist-paths.json
+++ b/tsconfig.dist-paths.json
@@ -21,6 +21,9 @@
       "@elizaos/app-model-tester": [
         "./plugins/app-model-tester/dist/index.d.ts"
       ],
+      "@elizaos/auth": [
+        "./packages/auth/dist/index.d.ts"
+      ],
       "@elizaos/bench-eliza-1": [
         "./packages/benchmarks/eliza-1/src/index.ts"
       ],
@@ -110,6 +113,9 @@
       ],
       "@elizaos/cloud-services-common": [
         "./packages/cloud/services/_common/src/index.ts"
+      ],
+      "@elizaos/cloud-ui": [
+        "./packages/cloud-ui/dist/index.d.ts"
       ],
       "@elizaos/configbench": [
         "./packages/benchmarks/configbench/dist/index.d.ts"
@@ -233,6 +239,9 @@
       ],
       "@elizaos/plugin-documents": [
         "./plugins/plugin-documents/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-e2b-sandbox": [
+        "./plugins/plugin-e2b-sandbox/dist/index.d.ts"
       ],
       "@elizaos/plugin-edge-tts": [
         "./plugins/plugin-edge-tts/dist/index.d.ts"
@@ -458,6 +467,9 @@
       ],
       "@elizaos/plugin-telegram": [
         "./plugins/plugin-telegram/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-telegram-standalone": [
+        "./plugins/plugin-telegram-standalone/dist/src/index.d.ts"
       ],
       "@elizaos/plugin-todos": [
         "./plugins/plugin-todos/dist/index.d.ts"


### PR DESCRIPTION
## Summary
- Refresh `tsconfig.dist-paths.json` after the workspace-walker migration in #12631.
- Adds the four aliases emitted by the migrated `generate-dist-paths-config.mjs` seam on current `develop`.

## Evidence
- `node packages/scripts/generate-dist-paths-config.mjs --check` -> passed (204 path aliases current).
- `git diff --check origin/develop...HEAD` -> passed.

## Context
#12631 merged before this generated-file follow-up could attach to its head. Without this PR, `node packages/scripts/generate-dist-paths-config.mjs --check` fails on current `develop` because `tsconfig.dist-paths.json` is stale.

## N/A
- UI screenshots/video: generated TypeScript path-alias config only.
- Real-LLM trajectories: no model, prompt, provider, action, or evaluator behavior changed.
- Backend logs/domain artifacts: no runtime service path changed.