### PR TITLE
docs(#12241): add homepage UI headers

### DIFF
--- a/packages/homepage/src/components/BlobButton.tsx
+++ b/packages/homepage/src/components/BlobButton.tsx
@@ -1,3 +1,6 @@
+/**
+ * Animated homepage call-to-action button with an expanding QR panel.
+ */
 import { animated, useSpring } from "@react-spring/web";
 import type { ComponentType, HTMLAttributes } from "react";
 import { type ReactNode, useEffect, useRef, useState } from "react";

--- a/packages/homepage/src/components/ChatUI/renderChatToCanvas.ts
+++ b/packages/homepage/src/components/ChatUI/renderChatToCanvas.ts
@@ -1,3 +1,9 @@
+/**
+ * Canvas renderer for the chat transcript shown on the homepage device model.
+ *
+ * It measures and paints the iMessage and Telegram mock conversations at a
+ * fixed high-resolution scale so the texture stays crisp on the 3D surface.
+ */
 import { BRAND_COLORS } from "@elizaos/shared/brand";
 
 type Msg = { from: "bot" | "user"; text: string };

--- a/packages/homepage/src/components/DocumentMetaManager.tsx
+++ b/packages/homepage/src/components/DocumentMetaManager.tsx
@@ -1,12 +1,12 @@
+/**
+ * Metadata synchronizer for homepage title and social preview tags.
+ *
+ * Static markup in `index.html` provides pre-React fallback values; once React
+ * mounts, this component replaces them with active-language strings.
+ */
 import { useEffect } from "react";
 import { useT } from "@/providers/I18nProvider";
 
-/**
- * Keeps `<title>` and the Open Graph / Twitter meta tags in sync with the
- * active i18n language. The static markup in `index.html` provides the
- * pre-React fallback values; once React mounts this component swaps them in
- * for the translated strings on every language change.
- */
 export function DocumentMetaManager(): null {
   const t = useT();
 

--- a/packages/homepage/src/components/ModelViewers/ModelB.tsx
+++ b/packages/homepage/src/components/ModelViewers/ModelB.tsx
@@ -1,3 +1,9 @@
+/**
+ * Three.js phone model scene for the homepage onboarding demo.
+ *
+ * The component maps the canvas-rendered chat UI onto the model screen and
+ * exposes imperative controls used by the surrounding onboarding flow.
+ */
 import { animated, useSpring } from "@react-spring/three";
 import { Environment, useGLTF } from "@react-three/drei";
 import { Canvas, useFrame } from "@react-three/fiber";

--- a/packages/homepage/src/components/QRCode.tsx
+++ b/packages/homepage/src/components/QRCode.tsx
@@ -1,3 +1,6 @@
+/**
+ * Inline SVG QR code used by the homepage phone handoff CTA.
+ */
 import { useT } from "@/providers/I18nProvider";
 
 export default function QRCode({ className }: { className?: string }) {

--- a/packages/homepage/src/components/ShaderBackground/ShaderBackground.tsx
+++ b/packages/homepage/src/components/ShaderBackground/ShaderBackground.tsx
@@ -1,3 +1,6 @@
+/**
+ * Full-viewport WebGL shader background for the homepage onboarding flow.
+ */
 import { Canvas, useFrame } from "@react-three/fiber";
 import { useEffect, useRef } from "react";
 import * as THREE from "three";

--- a/packages/homepage/src/components/ShaderBackground/gradientWaveMaterial.ts
+++ b/packages/homepage/src/components/ShaderBackground/gradientWaveMaterial.ts
@@ -1,3 +1,6 @@
+/**
+ * Custom react-three/fiber material for the homepage gradient wave shader.
+ */
 import { shaderMaterial } from "@react-three/drei";
 import { extend, type ThreeElement } from "@react-three/fiber";
 import * as THREE from "three";

--- a/packages/homepage/src/components/VideoCall.tsx
+++ b/packages/homepage/src/components/VideoCall.tsx
@@ -1,3 +1,6 @@
+/**
+ * Animated webcam preview overlay for the homepage phone demo.
+ */
 import { animated, useSpring } from "@react-spring/web";
 import { X } from "lucide-react";
 import type { ComponentType, HTMLAttributes } from "react";

--- a/packages/homepage/src/components/brand/eliza-logo.tsx
+++ b/packages/homepage/src/components/brand/eliza-logo.tsx
@@ -1,3 +1,6 @@
+/**
+ * Brand logo image component for homepage navigation and onboarding surfaces.
+ */
 import { BRAND_PATHS, LOGO_FILES } from "@elizaos/shared/brand";
 import { useT } from "@/providers/I18nProvider";
 

--- a/packages/homepage/src/components/login/country-flag.tsx
+++ b/packages/homepage/src/components/login/country-flag.tsx
@@ -1,3 +1,6 @@
+/**
+ * Country flag renderer for the homepage phone-number picker.
+ */
 import { hasFlag } from "country-flag-icons";
 import * as FlagComponents from "country-flag-icons/react/3x2";
 import type * as React from "react";

--- a/packages/homepage/src/components/login/phone-number-input.tsx
+++ b/packages/homepage/src/components/login/phone-number-input.tsx
@@ -1,3 +1,6 @@
+/**
+ * Country-aware phone number input for homepage sign-in and linking forms.
+ */
 import { BRAND_COLORS } from "@elizaos/shared/brand";
 import { Input } from "@elizaos/ui/input";
 import { getCountries, getCountryCallingCode } from "libphonenumber-js";

--- a/packages/homepage/src/pages/connected.tsx
+++ b/packages/homepage/src/pages/connected.tsx
@@ -1,3 +1,7 @@
+/**
+ * Authenticated homepage dashboard for linked messaging platforms and account
+ * handoff actions.
+ */
 import { Button } from "@elizaos/ui/button";
 import {
   AppleMessagesIcon,

--- a/packages/homepage/src/pages/get-started.tsx
+++ b/packages/homepage/src/pages/get-started.tsx
@@ -1,3 +1,7 @@
+/**
+ * Homepage onboarding page for connecting messaging platforms and starting an
+ * Eliza Cloud session.
+ */
 import { BRAND_COLORS } from "@elizaos/shared/brand";
 import { Button } from "@elizaos/ui/button";
 import {

--- a/packages/homepage/src/pages/login.tsx
+++ b/packages/homepage/src/pages/login.tsx
@@ -1,3 +1,7 @@
+/**
+ * Compatibility login route that redirects visitors to the correct homepage
+ * onboarding or connected state.
+ */
 import { BRAND_PATHS, LOGO_FILES } from "@elizaos/shared/brand";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";

--- a/packages/homepage/src/pages/marketing.tsx
+++ b/packages/homepage/src/pages/marketing.tsx
@@ -1,3 +1,6 @@
+/**
+ * Public homepage download and launch surface for elizaOS apps.
+ */
 import { BRAND_PATHS, EXTERNAL_URLS, LOGO_FILES } from "@elizaos/shared/brand";
 import {
   ArrowRight,


### PR DESCRIPTION
## Summary
- Add required top-of-file prose headers to the remaining homepage component and page modules.
- Move the existing `DocumentMetaManager` prose block to the required top-of-file position.
- Comment-only cleanup for #12241; no code or string literal behavior changed.

## Verification
- `bun run check:comment-only` PASS: 15 source files changed; every code token identical to `origin/develop`.
- `bun run --cwd packages/homepage test` PASS: 2 tests.
- `bunx @biomejs/biome check <15 touched files>` PASS.
- `git diff --check` PASS.
- First-line header audit for touched files PASS.
- `bun run --cwd packages/homepage typecheck` FAILS outside this change: `packages/ui/src/i18n/index.ts` and `packages/ui/src/i18n/messages.ts` import `normalizeLanguage`, `DEFAULT_UI_LANGUAGE`, `UI_LANGUAGES`, and `UiLanguage` from `@elizaos/shared`, but the current local workspace resolution does not export those members.

## Evidence
- Screenshots/video: N/A - comment-only header cleanup; `check:comment-only` proves runtime tokens are unchanged.
- Backend/frontend logs: N/A - no executable behavior changed.
- Real-LLM trajectories: N/A - no agent, prompt, model, provider, or evaluator behavior changed.
