### PR TITLE
docs: foreground design-rationale (why-not-what) in the comment convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,8 +216,14 @@ the #12182 sweeps drive down. Logger only, never `console`, in server code.
 ## Slop and Comment Cleanup
 
 Every file is legible on its own: a purpose-explaining prose header at the top,
-in-body comments that carry only what the code cannot, and no change-narration.
-The rules below are binding for new code and for the repo-wide cleanup (#12181).
+then in-body comments that explain **why the code is the way it is** — the
+design rationale, the constraint that forced the approach, what consumes it —
+never a restatement of *what* it does. The reader can read the code; a comment
+earns its place only by adding what the code cannot show. No change-narration.
+Write for the next engineer opening this file cold in a **greenfield** codebase:
+there is no legacy to apologize for and no diff history to narrate — these
+comments are the codified, durable explanation of the system. The rules below
+are binding for new code and for the repo-wide cleanup (#12181).
 
 1. **Header form — one `/** … */` prose block at the very top** (after a `#!`
    shebang; after a third-party license block in the few files that carry one;
@@ -225,22 +231,27 @@ The rules below are binding for new code and for the repo-wide cleanup (#12181).
    `@author`/`@date`/`@version`. Position is the signal.
 2. **First sentence states what the file does in system terms; never repeat the
    filename** ("Local content-addressed media store for chat attachments.").
-   Then, only as warranted: relationships (consumers, dependencies, which
-   boundary it sits on), invariants/constraints, gotchas. Issue refs like
-   `(#9948)` are welcome when they anchor non-obvious rationale — never as a
-   substitute for stating it.
+   Then, only as warranted, give the reader a sense of the file's place in the
+   system: **who consumes it and what it consumes** (the boundary it sits on),
+   the invariants/constraints it must uphold, why it is shaped the way it is, and
+   gotchas to know before editing. Issue refs like `(#9948)` are welcome when
+   they anchor non-obvious rationale — never as a substitute for stating it.
 3. **Length scales with weight, hard ceiling ~25 lines.** Barrel `index.ts` /
    tiny type files: 1 line. Typical modules: 2–6 lines. Load-bearing modules:
    2–3 short paragraphs. Longer than that belongs in the package
    `CLAUDE.md`/`README.md` — reference it instead. Test files: 1–3 lines — what
    surface is under test and how real the harness is (live model vs
    deterministic proxy, real DB vs in-memory).
-4. **In-body comments carry only what the code cannot say**: intent, invariants,
-   units, boundary conditions, why-this-not-that, protocol quirks, ordering
-   constraints. Keep the two-tier split — `/** JSDoc */` on exported symbols (for
-   callers), `//` for implementation notes. Delete restatement, change-narration,
-   status updates, migration stories, and commented-out code. Do not
-   blanket-comment: a file whose code is clear needs a header and nothing else.
+4. **In-body comments explain the *why*, never the *what*.** The reader can see
+   what the code does; a comment earns its place only by adding what the code
+   cannot show — the design rationale (why this approach and not the obvious
+   alternative), the invariant or constraint that forced it, units and boundary
+   conditions, protocol quirks, ordering constraints, and non-obvious
+   consequences for callers. Keep the two-tier split — `/** JSDoc */` on exported
+   symbols (for callers), `//` for implementation notes. Delete restatement,
+   change-narration, status updates, migration stories, and commented-out code.
+   Do not blanket-comment: a file whose code is clear needs a header and nothing
+   else.
 5. **Churn test = durability test.** Would the comment be true and useful to
    someone who never saw the previous version? If it only makes sense as a diff
    annotation, delete it; if the fact is durable but churn-phrased, rewrite it to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,8 +216,14 @@ the #12182 sweeps drive down. Logger only, never `console`, in server code.
 ## Slop and Comment Cleanup
 
 Every file is legible on its own: a purpose-explaining prose header at the top,
-in-body comments that carry only what the code cannot, and no change-narration.
-The rules below are binding for new code and for the repo-wide cleanup (#12181).
+then in-body comments that explain **why the code is the way it is** — the
+design rationale, the constraint that forced the approach, what consumes it —
+never a restatement of *what* it does. The reader can read the code; a comment
+earns its place only by adding what the code cannot show. No change-narration.
+Write for the next engineer opening this file cold in a **greenfield** codebase:
+there is no legacy to apologize for and no diff history to narrate — these
+comments are the codified, durable explanation of the system. The rules below
+are binding for new code and for the repo-wide cleanup (#12181).
 
 1. **Header form — one `/** … */` prose block at the very top** (after a `#!`
    shebang; after a third-party license block in the few files that carry one;
@@ -225,22 +231,27 @@ The rules below are binding for new code and for the repo-wide cleanup (#12181).
    `@author`/`@date`/`@version`. Position is the signal.
 2. **First sentence states what the file does in system terms; never repeat the
    filename** ("Local content-addressed media store for chat attachments.").
-   Then, only as warranted: relationships (consumers, dependencies, which
-   boundary it sits on), invariants/constraints, gotchas. Issue refs like
-   `(#9948)` are welcome when they anchor non-obvious rationale — never as a
-   substitute for stating it.
+   Then, only as warranted, give the reader a sense of the file's place in the
+   system: **who consumes it and what it consumes** (the boundary it sits on),
+   the invariants/constraints it must uphold, why it is shaped the way it is, and
+   gotchas to know before editing. Issue refs like `(#9948)` are welcome when
+   they anchor non-obvious rationale — never as a substitute for stating it.
 3. **Length scales with weight, hard ceiling ~25 lines.** Barrel `index.ts` /
    tiny type files: 1 line. Typical modules: 2–6 lines. Load-bearing modules:
    2–3 short paragraphs. Longer than that belongs in the package
    `CLAUDE.md`/`README.md` — reference it instead. Test files: 1–3 lines — what
    surface is under test and how real the harness is (live model vs
    deterministic proxy, real DB vs in-memory).
-4. **In-body comments carry only what the code cannot say**: intent, invariants,
-   units, boundary conditions, why-this-not-that, protocol quirks, ordering
-   constraints. Keep the two-tier split — `/** JSDoc */` on exported symbols (for
-   callers), `//` for implementation notes. Delete restatement, change-narration,
-   status updates, migration stories, and commented-out code. Do not
-   blanket-comment: a file whose code is clear needs a header and nothing else.
+4. **In-body comments explain the *why*, never the *what*.** The reader can see
+   what the code does; a comment earns its place only by adding what the code
+   cannot show — the design rationale (why this approach and not the obvious
+   alternative), the invariant or constraint that forced it, units and boundary
+   conditions, protocol quirks, ordering constraints, and non-obvious
+   consequences for callers. Keep the two-tier split — `/** JSDoc */` on exported
+   symbols (for callers), `//` for implementation notes. Delete restatement,
+   change-narration, status updates, migration stories, and commented-out code.
+   Do not blanket-comment: a file whose code is clear needs a header and nothing
+   else.
 5. **Churn test = durability test.** Would the comment be true and useful to
    someone who never saw the previous version? If it only makes sense as a diff
    annotation, delete it; if the fact is durable but churn-phrased, rewrite it to


### PR DESCRIPTION
## What

Sharpens the root `## Slop and Comment Cleanup` convention (part of the #12181 comment-cleanup effort) per owner direction. The convention already existed; this foregrounds the emphasis that had been buried:

- **Intro** now leads with the principle: in-body comments explain **why the code is the way it is** (design rationale, the constraint that forced the approach, what consumes it), never a restatement of *what* it does — the reader can read the code. Framed as a **greenfield** codebase whose comments are the codified, durable explanation, with no legacy to apologize for and no diff history to narrate.
- **Rule 2 (header)** now foregrounds the file's place in the system — *who consumes it and what it consumes* (the boundary it sits on) and why it is shaped the way it is.
- **Rule 4 (in-body)** now leads with *"explain the why, never the what"* and the design-rationale-not-the-obvious-alternative test.

## Why

Keeps the guidance the same in substance but makes the load-bearing idea (why-not-what, design rationale, consumers, durable/greenfield) the first thing a reader takes away, so new code and the ongoing cleanup batches optimize for it.

## Notes

- `CLAUDE.md` and `AGENTS.md` kept byte-identical per repo convention (author CLAUDE.md, copy to AGENTS.md).
- Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)