### PR TITLE
refactor(ui): one gesture core — recognizers/constants/press-hold/click-suppression (#12188 Phase 2)

### DIFF
--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -19,6 +19,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+import { TOUCH_TAP_MOVE_SLOP as TAP_REVEAL_MOVE_CANCEL_PX } from "../../../gestures";
 import { cn } from "../../../lib/utils";
 import { Button } from "../../ui/button";
 import { Textarea } from "../../ui/textarea";
@@ -67,11 +68,9 @@ export interface ChatMessageProps {
 }
 
 const HOVER_MEDIA_QUERY = "(hover: hover) and (pointer: fine)";
-// Tap-to-reveal move slop: finger travel past this between touchstart and
-// touchend means the gesture was a transcript scroll, not a tap, so it must
-// not toggle the action rail (mirrors the shell ThreadLine's
-// COPY_MOVE_CANCEL_PX).
-const TAP_REVEAL_MOVE_CANCEL_PX = 10;
+// Tap-to-reveal move slop (the shared TOUCH_TAP_MOVE_SLOP): finger travel past
+// this between touchstart and touchend means the gesture was a transcript
+// scroll, not a tap, so it must not toggle the action rail.
 const hoverSupportListeners = new Set<() => void>();
 let hoverMediaQuery: MediaQueryList | null = null;
 let hoverMediaQueryUnsubscribe: (() => void) | null = null;

--- a/packages/ui/src/components/pages/RelationshipsGraphPanel.tsx
+++ b/packages/ui/src/components/pages/RelationshipsGraphPanel.tsx
@@ -35,6 +35,7 @@ import type {
   RelationshipsGraphSnapshot,
   RelationshipsPersonSummary,
 } from "../../api/client-types-relationships";
+import { GRAPH_PAN_ENGAGE_SLOP, useClickSuppression } from "../../gestures";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { Button } from "../ui/button";
 import {
@@ -781,7 +782,9 @@ export function RelationshipsGraphPanel({
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   const pointersRef = useRef<Map<number, { x: number; y: number }>>(new Map());
-  const shouldSuppressClickRef = useRef(false);
+  // A pan that actually moved must not ALSO fire the node click under the
+  // release point (shared useClickSuppression, armed in endPan).
+  const clickSuppression = useClickSuppression();
   const panStateRef = useRef<{
     pointerId: number;
     startX: number;
@@ -910,7 +913,7 @@ export function RelationshipsGraphPanel({
     if (!container) return;
     const dx = event.clientX - state.startX;
     const dy = event.clientY - state.startY;
-    if (!state.moved && Math.hypot(dx, dy) > 4) {
+    if (!state.moved && Math.hypot(dx, dy) > GRAPH_PAN_ENGAGE_SLOP) {
       state.moved = true;
       hideTooltip();
       container.setPointerCapture(event.pointerId);
@@ -933,10 +936,7 @@ export function RelationshipsGraphPanel({
         container.releasePointerCapture(event.pointerId);
       }
       if (state.moved) {
-        shouldSuppressClickRef.current = true;
-        window.setTimeout(() => {
-          shouldSuppressClickRef.current = false;
-        }, 0);
+        clickSuppression.arm();
       }
       panStateRef.current = null;
     }
@@ -1236,10 +1236,9 @@ export function RelationshipsGraphPanel({
                     <Button
                       variant="ghost"
                       onClick={(event) => {
-                        if (shouldSuppressClickRef.current) {
+                        if (clickSuppression.consumeArmed()) {
                           event.preventDefault();
                           event.stopPropagation();
-                          shouldSuppressClickRef.current = false;
                           return;
                         }
                         onSelectPersonId(person.primaryEntityId);

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -52,6 +52,14 @@ import {
   TUTORIAL_CHAT_CONTROL_EVENT,
   type TutorialChatControlDetail,
 } from "../../events";
+import {
+  COPY_HOLD_MS,
+  TOUCH_TAP_MOVE_SLOP as OUTSIDE_SHEET_TAP_SLOP,
+  SHEET_DETENT_OVERSHOOT_SCALE,
+  sqrtRubberBand,
+  usePointerPressAndHold,
+  useRafCoalescer,
+} from "../../gestures";
 import { useConversationSwipeJank } from "../../hooks/useConversationSwipeJank";
 import {
   LAYOUT_SHIFT_INTENT_ATTR,
@@ -204,7 +212,6 @@ const SHEET_HALF_VH = 0.46; // fraction of viewport height at the HALF detent
 // of resting free — so near-detent releases are deterministic + clean, and only
 // the clear gaps between detents keep the free-drag rest height.
 const SHEET_DETENT_MAGNET = 64;
-const OUTSIDE_SHEET_TAP_SLOP = 10;
 
 // Feature flag: the resting one-tap prompt-suggestion strip. Off for now so the
 // composer can be tested without it; flip to true to bring the strip back.
@@ -251,10 +258,6 @@ const OPEN_SPRING = {
 // maps offset → openProgress ∈ [0,1] over this distance; past it, the excess
 // flows into the thread height so pill → input → chat is one continuous motion.
 const PILL_OPEN_DISTANCE = 120;
-// Rubber-band resistance applied to drag past a detent (iOS-style overscroll).
-function rubberBand(overshoot: number): number {
-  return Math.sign(overshoot) * Math.sqrt(Math.abs(overshoot)) * 6;
-}
 
 // Glyphs (viewBox 0 0 36 36), rendered in currentColor inside a soft chip. Send
 // + mic now use lucide icons (SendHorizontal / Mic); the rest stay hand-drawn.
@@ -893,10 +896,6 @@ export function BootStatusIndicator({
  * the right. Memoized so a live drag (which re-renders the overlay on every
  * pointer-move frame) doesn't re-render every message in a long thread.
  */
-// Press-and-hold copy: a still hold this long fires; any finger travel past the
-// move threshold first cancels it (so it yields to the thread's scroll).
-const COPY_HOLD_MS = 420;
-const COPY_MOVE_CANCEL_PX = 10;
 
 /**
  * Render a user turn's text, bolding a leading slash command so a sent
@@ -1130,58 +1129,31 @@ const ThreadLine = React.memo(function ThreadLine({
   // Press-and-hold to copy an assistant answer — the only extraction affordance
   // on touch (no hover row). A still hold past COPY_HOLD_MS copies + flashes
   // "Copied" + a light haptic; real finger travel cancels so it never fights the
-  // thread's touch-pan-y scroll.
+  // thread's touch-pan-y scroll (shared usePointerPressAndHold recognizer).
   const [copied, setCopied] = React.useState(false);
-  const holdTimer = React.useRef<number | null>(null);
-  const holdStart = React.useRef<{ x: number; y: number } | null>(null);
   const copiedTimer = React.useRef<number | null>(null);
-  const clearHold = React.useCallback(() => {
-    if (holdTimer.current !== null) {
-      window.clearTimeout(holdTimer.current);
-      holdTimer.current = null;
-    }
-    holdStart.current = null;
-  }, []);
   React.useEffect(
     () => () => {
-      if (holdTimer.current !== null) window.clearTimeout(holdTimer.current);
       if (copiedTimer.current !== null)
         window.clearTimeout(copiedTimer.current);
     },
     [],
   );
   const canCopy = isAssistant && !!onCopy && message.content.trim().length > 0;
-  const copyHandlers = canCopy
-    ? {
-        onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => {
-          if (isNestedInteractiveTarget(e.currentTarget, e.target)) return;
-          holdStart.current = { x: e.clientX, y: e.clientY };
-          holdTimer.current = window.setTimeout(() => {
-            onCopy?.(message.content);
-            detentHaptic();
-            setCopied(true);
-            if (copiedTimer.current !== null)
-              window.clearTimeout(copiedTimer.current);
-            copiedTimer.current = window.setTimeout(
-              () => setCopied(false),
-              1100,
-            );
-            holdTimer.current = null;
-          }, COPY_HOLD_MS);
-        },
-        onPointerMove: (e: React.PointerEvent<HTMLDivElement>) => {
-          const s = holdStart.current;
-          if (!s) return;
-          if (
-            Math.abs(e.clientX - s.x) > COPY_MOVE_CANCEL_PX ||
-            Math.abs(e.clientY - s.y) > COPY_MOVE_CANCEL_PX
-          )
-            clearHold();
-        },
-        onPointerUp: clearHold,
-        onPointerCancel: clearHold,
-      }
-    : null;
+  const holdBinding = usePointerPressAndHold<HTMLDivElement>({
+    enabled: canCopy,
+    durationMs: COPY_HOLD_MS,
+    canBegin: (e) => !isNestedInteractiveTarget(e.currentTarget, e.target),
+    onHold: () => {
+      onCopy?.(message.content);
+      detentHaptic();
+      setCopied(true);
+      if (copiedTimer.current !== null)
+        window.clearTimeout(copiedTimer.current);
+      copiedTimer.current = window.setTimeout(() => setCopied(false), 1100);
+    },
+  });
+  const copyHandlers = canCopy ? holdBinding : null;
 
   // Click-to-reveal per-message action row (#10713): tapping a bubble reveals
   // Copy + Play (assistant) or Copy + Edit (user) beneath it; an outside tap
@@ -2622,36 +2594,30 @@ export function ContinuousChatOverlay({
     window.addEventListener("resize", measure);
     return () => window.removeEventListener("resize", measure);
   }, []);
+  // Coalesce the high-rate vv `scroll` to at most one commit per frame (shared
+  // useRafCoalescer) so the keyboard-animation storm can't drive >60 forced
+  // style reads + setStates/s.
+  const viewportSync = useRafCoalescer<void>(() => {
+    // Bail out of the re-render when the viewport values are unchanged — vv
+    // `scroll` fires constantly while the keyboard animates but the height/
+    // inset frequently don't actually move between events.
+    setViewport((prev) => {
+      const next = readViewport();
+      return prev.height === next.height &&
+        prev.keyboardInset === next.keyboardInset &&
+        prev.innerHeight === next.innerHeight
+        ? prev
+        : next;
+    });
+    const el = overlayRef.current;
+    if (el) {
+      const pad = Number.parseFloat(getComputedStyle(el).paddingBottom) || 0;
+      setBottomPad((prev) => (prev === pad ? prev : pad));
+    }
+  });
   React.useEffect(() => {
     if (typeof window === "undefined") return undefined;
-    const commit = () => {
-      // Bail out of the re-render when the viewport values are unchanged — vv
-      // `scroll` fires constantly while the keyboard animates but the height/
-      // inset frequently don't actually move between events.
-      setViewport((prev) => {
-        const next = readViewport();
-        return prev.height === next.height &&
-          prev.keyboardInset === next.keyboardInset &&
-          prev.innerHeight === next.innerHeight
-          ? prev
-          : next;
-      });
-      const el = overlayRef.current;
-      if (el) {
-        const pad = Number.parseFloat(getComputedStyle(el).paddingBottom) || 0;
-        setBottomPad((prev) => (prev === pad ? prev : pad));
-      }
-    };
-    // Coalesce the high-rate vv `scroll` to at most one commit per frame so the
-    // keyboard-animation storm can't drive >60 forced style reads + setStates/s.
-    let rafId = 0;
-    const sync = () => {
-      if (rafId !== 0) return;
-      rafId = requestAnimationFrame(() => {
-        rafId = 0;
-        commit();
-      });
-    };
+    const sync = () => viewportSync.schedule(undefined);
     // A real WINDOW resize (rotation/desktop resize) must never strand the
     // pill↔input morph mid-crossfade — rotation often cancels the in-flight
     // pointer with no pointerup, leaving the drag orphaned. Re-settle to a clean
@@ -2669,12 +2635,12 @@ export function ContinuousChatOverlay({
     vv?.addEventListener("resize", sync);
     vv?.addEventListener("scroll", sync, { passive: true });
     return () => {
-      if (rafId !== 0) cancelAnimationFrame(rafId);
+      viewportSync.cancel();
       window.removeEventListener("resize", syncAndSettleWindow);
       vv?.removeEventListener("resize", sync);
       vv?.removeEventListener("scroll", sync);
     };
-  }, [readViewport]);
+  }, [viewportSync]);
   const viewportH = viewport.height;
   const keyboardInset = viewport.keyboardInset;
 
@@ -2828,7 +2794,9 @@ export function ContinuousChatOverlay({
   // Map a raw drag height: rubber-band past FULL, hard-clamp the bottom to 0.
   const clampHeight = React.useCallback(
     (raw: number) =>
-      raw > openH ? openH + rubberBand(raw - openH) : Math.max(0, raw),
+      raw > openH
+        ? openH + sqrtRubberBand(raw - openH, SHEET_DETENT_OVERSHOOT_SCALE)
+        : Math.max(0, raw),
     [openH],
   );
   // Backdrop dimming + the suggestion-strip fade follow the live height; the

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -2615,9 +2615,14 @@ export function ContinuousChatOverlay({
       setBottomPad((prev) => (prev === pad ? prev : pad));
     }
   });
+  // Depend on the coalescer's stable methods, NOT the wrapper object (which is a
+  // fresh literal each render) — otherwise this effect re-runs every render and
+  // re-fires settleDragRef mid-drag, stranding an in-progress sheet gesture.
+  const scheduleViewportSync = viewportSync.schedule;
+  const cancelViewportSync = viewportSync.cancel;
   React.useEffect(() => {
     if (typeof window === "undefined") return undefined;
-    const sync = () => viewportSync.schedule(undefined);
+    const sync = () => scheduleViewportSync(undefined);
     // A real WINDOW resize (rotation/desktop resize) must never strand the
     // pill↔input morph mid-crossfade — rotation often cancels the in-flight
     // pointer with no pointerup, leaving the drag orphaned. Re-settle to a clean
@@ -2635,12 +2640,12 @@ export function ContinuousChatOverlay({
     vv?.addEventListener("resize", sync);
     vv?.addEventListener("scroll", sync, { passive: true });
     return () => {
-      viewportSync.cancel();
+      cancelViewportSync();
       window.removeEventListener("resize", syncAndSettleWindow);
       vv?.removeEventListener("resize", sync);
       vv?.removeEventListener("scroll", sync);
     };
-  }, [viewportSync]);
+  }, [scheduleViewportSync, cancelViewportSync]);
   const viewportH = viewport.height;
   const keyboardInset = viewport.keyboardInset;
 

--- a/packages/ui/src/components/shell/use-notification-pull.ts
+++ b/packages/ui/src/components/shell/use-notification-pull.ts
@@ -1,5 +1,11 @@
 import * as React from "react";
-import { rubberBand, useRafCoalescer } from "../../gestures";
+import {
+  DEFAULT_PULL_VELOCITY as DEFAULT_VELOCITY_THRESHOLD,
+  AXIS_COMMIT_SLOP as ENGAGE_SLOP,
+  OVERSHOOT_RESISTANCE as REVEAL_OVERSHOOT_RESISTANCE,
+  rubberBand,
+  useRafCoalescer,
+} from "../../gestures";
 
 /**
  * iOS-notification-center pull gesture for the home dashboard.
@@ -29,16 +35,14 @@ import { rubberBand, useRafCoalescer } from "../../gestures";
  * OR velocity threshold — a deliberate drag and a quick flick both open.
  */
 
-/** Vertical travel (px) after which a downward-at-top drag becomes a pull. */
-const ENGAGE_SLOP = 8;
+// ENGAGE_SLOP (travel after which a downward-at-top drag becomes a pull),
+// DEFAULT_VELOCITY_THRESHOLD (flick commit speed), and
+// REVEAL_OVERSHOOT_RESISTANCE alias the shared gesture constants above; only
+// the values below are tuned specifically for this surface.
 /** Raw downward travel (px) that commits the pull to opening on release. */
 const DEFAULT_DISTANCE_THRESHOLD = 60;
-/** Raw downward speed (px/ms) that commits the pull as a flick. */
-const DEFAULT_VELOCITY_THRESHOLD = 0.5;
 /** Travel (px) the reveal tracks 1:1 before rubber-banding. */
 const REVEAL_SOFT_MAX = 96;
-/** Resistance applied to travel past {@link REVEAL_SOFT_MAX}. */
-const REVEAL_OVERSHOOT_RESISTANCE = 0.35;
 
 /**
  * Map raw finger travel to the reveal offset: 1:1 up to a soft cap, then a

--- a/packages/ui/src/gestures/constants.ts
+++ b/packages/ui/src/gestures/constants.ts
@@ -35,7 +35,7 @@ export const GRAPH_PAN_ENGAGE_SLOP = 4;
 export const AXIS_COMMIT_SLOP = 8;
 
 /**
- * Per-surface override (useHorizontalPager): the launcher rail commits its
+ * Per-surface override (the horizontal pager rail): the launcher rail commits its
  * axis at a shorter slop than the shared {@link AXIS_COMMIT_SLOP} so a swipe
  * starts tracking the finger sooner on the paging surface (#12349).
  */
@@ -52,7 +52,7 @@ export const PAGER_AXIS_COMMIT_SLOP = 6;
 export const HORIZONTAL_DOMINANCE_RATIO = 0.8;
 
 /**
- * Per-surface override (useHorizontalPager): the pager wants the OPPOSITE
+ * Per-surface override (the horizontal pager rail): the pager wants the OPPOSITE
  * bias from the pull surfaces' {@link HORIZONTAL_DOMINANCE_RATIO} — horizontal
  * must clearly BEAT vertical (>1) before the rail claims the gesture, so a
  * diagonal drag stays with the vertical scroller under the rail.
@@ -68,7 +68,7 @@ export const DEFAULT_SWIPE_DISTANCE = 64;
 /** Default minimum horizontal speed (px/ms) to count as a swipe flick. */
 export const DEFAULT_SWIPE_VELOCITY = 0.4;
 /**
- * Per-surface override (useHorizontalPager): release speed (px/ms) that
+ * Per-surface override (the horizontal pager rail): release speed (px/ms) that
  * commits a page flick. Deliberately kept at the pager's shipped tuning,
  * slightly stiffer than {@link DEFAULT_SWIPE_VELOCITY}.
  */

--- a/packages/ui/src/gestures/constants.ts
+++ b/packages/ui/src/gestures/constants.ts
@@ -1,18 +1,45 @@
 /**
- * Shared numeric thresholds for the pointer/touch gesture recognizers.
- *
- * These are the DEFAULTS. Each surface may still override the values it tunes
- * (e.g. the notification pull's larger commit distance) by passing explicit
- * options to its hook — the point of centralizing here is that the un-tuned
- * knobs share one definition instead of drifting between three copies.
+ * The single definition site for every tuned pointer/touch gesture threshold
+ * in the UI (#12188). Two kinds of value live here: shared DEFAULTS
+ * (`TAP_SLOP`, `AXIS_COMMIT_SLOP`, `DEFAULT_*`, the hold table) that every
+ * surface gets unless it passes explicit options, and named PER-SURFACE
+ * overrides (`PAGER_*`, `COPY_HOLD_MS`, `GRAPH_PAN_ENGAGE_SLOP`,
+ * `SHEET_DETENT_OVERSHOOT_SCALE`) where a surface deliberately tunes away from
+ * the default — centralized so each divergence is visible and documented
+ * instead of drifting silently inside its hook.
  */
 
 /** Movement (px) under which a release is treated as a tap, not a drag. Also the
  *  slop the notification-pull and axis-commit checks share. */
 export const TAP_SLOP = 8;
 
+/**
+ * Finger travel (px) past which a touch press stops being a tap or a still
+ * hold and becomes a scroll/drag. Shared by the copy press-and-hold, the
+ * message tap-to-reveal, and the chat sheet's outside-tap detector.
+ * Deliberately looser than {@link TAP_SLOP}: these sites judge raw finger
+ * wobble during a press, while the 8px slop judges travel in the axis-locked
+ * pull pipeline.
+ */
+export const TOUCH_TAP_MOVE_SLOP = 10;
+
+/**
+ * Per-surface override (RelationshipsGraphPanel): pointer travel (px, hypot)
+ * at which a press on the graph canvas engages a pan. Far tighter than
+ * {@link TAP_SLOP} — the canvas wants pixel-precise panning; node taps stay
+ * safe because any engaged pan arms click suppression on release.
+ */
+export const GRAPH_PAN_ENGAGE_SLOP = 4;
+
 /** Movement (px) at which a gesture commits to a single (x or y) axis. */
 export const AXIS_COMMIT_SLOP = 8;
+
+/**
+ * Per-surface override (useHorizontalPager): the launcher rail commits its
+ * axis at a shorter slop than the shared {@link AXIS_COMMIT_SLOP} so a swipe
+ * starts tracking the finger sooner on the paging surface (#12349).
+ */
+export const PAGER_AXIS_COMMIT_SLOP = 6;
 
 /**
  * Fraction of the vertical travel the horizontal travel must reach to count as a
@@ -24,6 +51,14 @@ export const AXIS_COMMIT_SLOP = 8;
  */
 export const HORIZONTAL_DOMINANCE_RATIO = 0.8;
 
+/**
+ * Per-surface override (useHorizontalPager): the pager wants the OPPOSITE
+ * bias from the pull surfaces' {@link HORIZONTAL_DOMINANCE_RATIO} — horizontal
+ * must clearly BEAT vertical (>1) before the rail claims the gesture, so a
+ * diagonal drag stays with the vertical scroller under the rail.
+ */
+export const PAGER_AXIS_DOMINANCE_RATIO = 1.15;
+
 /** Default minimum vertical travel (px) to count as a pull. */
 export const DEFAULT_PULL_DISTANCE = 56;
 /** Default minimum vertical speed (px/ms) to count as a flick. */
@@ -32,3 +67,44 @@ export const DEFAULT_PULL_VELOCITY = 0.5;
 export const DEFAULT_SWIPE_DISTANCE = 64;
 /** Default minimum horizontal speed (px/ms) to count as a swipe flick. */
 export const DEFAULT_SWIPE_VELOCITY = 0.4;
+/**
+ * Per-surface override (useHorizontalPager): release speed (px/ms) that
+ * commits a page flick. Deliberately kept at the pager's shipped tuning,
+ * slightly stiffer than {@link DEFAULT_SWIPE_VELOCITY}.
+ */
+export const PAGER_FLICK_VELOCITY = 0.45;
+
+// ---------------------------------------------------------------------------
+// Press-and-hold durations — the full long-press timer table. The composer's
+// old 180ms push-to-talk timing was unified into the shared 200ms hold when
+// the machine was extracted into usePushToTalk (#12345).
+// ---------------------------------------------------------------------------
+
+/** iOS-style long-press threshold (conversation-item context menu). */
+export const DEFAULT_HOLD_MS = 450;
+/**
+ * Per-surface override (chat thread copy-hold): a still hold on a message past
+ * this copies its text. Deliberately kept at its shipped 420ms tuning, a touch
+ * quicker than {@link DEFAULT_HOLD_MS}.
+ */
+export const COPY_HOLD_MS = 420;
+/** Hold (ms) before a mic press promotes to an active voice capture. */
+export const PUSH_TO_TALK_HOLD_MS = 200;
+
+// ---------------------------------------------------------------------------
+// Overscroll damping.
+// ---------------------------------------------------------------------------
+
+/**
+ * Linear resistance applied to travel past a rubber-band's soft cap (see
+ * recognizers.rubberBand). Shared by the notification reveal's overshoot and
+ * the pager's past-the-edge drag.
+ */
+export const OVERSHOOT_RESISTANCE = 0.35;
+/**
+ * Per-surface scale for the chat sheet's detent overscroll, which uses
+ * square-root damping (recognizers.sqrtRubberBand) instead of the linear
+ * {@link OVERSHOOT_RESISTANCE}: the sheet tracks a long over-drag with
+ * progressively stiffer give rather than a constant fraction.
+ */
+export const SHEET_DETENT_OVERSHOOT_SCALE = 6;

--- a/packages/ui/src/gestures/gestures.test.ts
+++ b/packages/ui/src/gestures/gestures.test.ts
@@ -1,23 +1,43 @@
 // @vitest-environment jsdom
 //
 // Unit suite for the shared gesture core (#12349): the pure recognizers
-// (resolvePull/resolveSwipe/commitAxis/rubberBand) are exercised as pure math,
-// and the React helper hooks (useRafCoalescer, useClickSuppression,
-// usePressAndHold) are driven with synthetic input to verify their internal
-// contracts (frame coalescing, click swallowing, hold timing). The real browser
-// pointer pipeline is covered by the CDP-touch e2e runners; this is logic-only.
+// (resolvePull/resolveSwipe/commitAxis/rubberBand/sqrtRubberBand) are exercised
+// as pure math, the tuned-constants table is pinned as a drift gate, and the
+// React helper hooks (useRafCoalescer, useClickSuppression, usePressAndHold,
+// usePointerPressAndHold) are driven with synthetic input to verify their
+// internal contracts (frame coalescing, click swallowing, hold timing). The real
+// browser pointer pipeline is covered by the CDP-touch e2e runners; this is
+// logic-only.
 import { act, renderHook } from "@testing-library/react";
 import type * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AXIS_COMMIT_SLOP } from "./constants";
+import {
+  AXIS_COMMIT_SLOP,
+  COPY_HOLD_MS,
+  DEFAULT_HOLD_MS,
+  DEFAULT_PULL_VELOCITY,
+  DEFAULT_SWIPE_VELOCITY,
+  GRAPH_PAN_ENGAGE_SLOP,
+  HORIZONTAL_DOMINANCE_RATIO,
+  OVERSHOOT_RESISTANCE,
+  PAGER_AXIS_COMMIT_SLOP,
+  PAGER_AXIS_DOMINANCE_RATIO,
+  PAGER_FLICK_VELOCITY,
+  PUSH_TO_TALK_HOLD_MS,
+  SHEET_DETENT_OVERSHOOT_SCALE,
+  TAP_SLOP,
+  TOUCH_TAP_MOVE_SLOP,
+} from "./constants";
 import {
   commitAxis,
   resolvePull,
   resolveSwipe,
   rubberBand,
+  sqrtRubberBand,
 } from "./recognizers";
 import { useClickSuppression } from "./useClickSuppression";
-import { DEFAULT_HOLD_MS, usePressAndHold } from "./usePressAndHold";
+import { usePointerPressAndHold } from "./usePointerPressAndHold";
+import { usePressAndHold } from "./usePressAndHold";
 import { useRafCoalescer } from "./useRafCoalescer";
 
 const DIST = 56;
@@ -79,6 +99,53 @@ describe("rubberBand", () => {
   });
   it("clamps negatives to zero", () => {
     expect(rubberBand(-10, 96, 0.35)).toBe(0);
+  });
+});
+
+describe("sqrtRubberBand", () => {
+  it("damps overshoot as sign(x)·√|x|·scale", () => {
+    expect(sqrtRubberBand(0, 6)).toBe(0);
+    expect(sqrtRubberBand(100, 6)).toBe(60); // √100 · 6
+    expect(sqrtRubberBand(-100, 6)).toBe(-60); // signed both ways
+  });
+  it("stiffens progressively: doubling the overshoot gives less than double the travel", () => {
+    const one = sqrtRubberBand(80, 6);
+    const two = sqrtRubberBand(160, 6);
+    expect(two).toBeGreaterThan(one);
+    expect(two).toBeLessThan(2 * one);
+  });
+});
+
+// Drift gate for the tuned per-surface overrides: each divergence from the
+// shared default is deliberate (see constants.ts for the rationale). A failing
+// row means a behavior-tuning change — make it on purpose, in its own PR.
+describe("tuned constants table", () => {
+  it("pins the shared defaults", () => {
+    expect(TAP_SLOP).toBe(8);
+    expect(AXIS_COMMIT_SLOP).toBe(8);
+    expect(HORIZONTAL_DOMINANCE_RATIO).toBe(0.8);
+    expect(DEFAULT_PULL_VELOCITY).toBe(0.5);
+    expect(DEFAULT_SWIPE_VELOCITY).toBe(0.4);
+    expect(TOUCH_TAP_MOVE_SLOP).toBe(10);
+    expect(OVERSHOOT_RESISTANCE).toBe(0.35);
+    expect(DEFAULT_HOLD_MS).toBe(450);
+    expect(PUSH_TO_TALK_HOLD_MS).toBe(200);
+  });
+  it("pins the per-surface overrides and their direction of divergence", () => {
+    // Pager: commits sooner, demands stronger horizontal dominance, stiffer flick.
+    expect(PAGER_AXIS_COMMIT_SLOP).toBe(6);
+    expect(PAGER_AXIS_COMMIT_SLOP).toBeLessThan(AXIS_COMMIT_SLOP);
+    expect(PAGER_AXIS_DOMINANCE_RATIO).toBe(1.15);
+    expect(PAGER_AXIS_DOMINANCE_RATIO).toBeGreaterThan(1);
+    expect(PAGER_FLICK_VELOCITY).toBe(0.45);
+    // Copy-hold: a touch quicker than the default long-press.
+    expect(COPY_HOLD_MS).toBe(420);
+    expect(COPY_HOLD_MS).toBeLessThan(DEFAULT_HOLD_MS);
+    // Graph pan: pixel-precise engage, far under the tap slop.
+    expect(GRAPH_PAN_ENGAGE_SLOP).toBe(4);
+    expect(GRAPH_PAN_ENGAGE_SLOP).toBeLessThan(TAP_SLOP);
+    // Sheet detent overscroll scale (sqrt damping).
+    expect(SHEET_DETENT_OVERSHOOT_SCALE).toBe(6);
   });
 });
 
@@ -287,5 +354,116 @@ describe("usePressAndHold", () => {
       vi.advanceTimersByTime(20);
     });
     expect(onHold).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("usePointerPressAndHold", () => {
+  afterEach(() => vi.useRealTimers());
+
+  function pointer(x = 0, y = 0) {
+    return {
+      clientX: x,
+      clientY: y,
+    } as unknown as React.PointerEvent<HTMLElement>;
+  }
+
+  it("fires onHold after the duration for a still press", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const { result } = renderHook(() =>
+      usePointerPressAndHold<HTMLElement>({ onHold, durationMs: COPY_HOLD_MS }),
+    );
+    act(() => result.current.onPointerDown(pointer(100, 100)));
+    expect(onHold).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(COPY_HOLD_MS + 10);
+    });
+    expect(onHold).toHaveBeenCalledTimes(1);
+  });
+
+  it("tolerates wobble within the slop but cancels past it (per axis)", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const { result } = renderHook(() =>
+      usePointerPressAndHold<HTMLElement>({
+        onHold,
+        durationMs: 100,
+        moveCancelPx: TOUCH_TAP_MOVE_SLOP,
+      }),
+    );
+    // Wobble inside the slop keeps the hold alive.
+    act(() => result.current.onPointerDown(pointer(100, 100)));
+    act(() =>
+      result.current.onPointerMove(pointer(100 + TOUCH_TAP_MOVE_SLOP, 100)),
+    );
+    act(() => {
+      vi.advanceTimersByTime(110);
+    });
+    expect(onHold).toHaveBeenCalledTimes(1);
+    // A single-axis move past the slop cancels (a vertical scroll must win).
+    act(() => result.current.onPointerDown(pointer(100, 100)));
+    act(() =>
+      result.current.onPointerMove(pointer(100, 100 + TOUCH_TAP_MOVE_SLOP + 1)),
+    );
+    act(() => {
+      vi.advanceTimersByTime(110);
+    });
+    expect(onHold).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels on pointer up/cancel before the duration", () => {
+    for (const ender of ["onPointerUp", "onPointerCancel"] as const) {
+      vi.useFakeTimers();
+      const onHold = vi.fn();
+      const { result } = renderHook(() =>
+        usePointerPressAndHold<HTMLElement>({ onHold, durationMs: 100 }),
+      );
+      act(() => result.current.onPointerDown(pointer()));
+      act(() => result.current[ender]());
+      act(() => {
+        vi.advanceTimersByTime(110);
+      });
+      expect(onHold).not.toHaveBeenCalled();
+      vi.useRealTimers();
+    }
+  });
+
+  it("skips presses rejected by canBegin and is inert when disabled", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const rejected = renderHook(() =>
+      usePointerPressAndHold<HTMLElement>({
+        onHold,
+        durationMs: 100,
+        canBegin: () => false,
+      }),
+    );
+    act(() => rejected.result.current.onPointerDown(pointer()));
+    const disabled = renderHook(() =>
+      usePointerPressAndHold<HTMLElement>({
+        onHold,
+        durationMs: 100,
+        enabled: false,
+      }),
+    );
+    act(() => disabled.result.current.onPointerDown(pointer()));
+    act(() => {
+      vi.advanceTimersByTime(110);
+    });
+    expect(onHold).not.toHaveBeenCalled();
+  });
+
+  it("clears the pending hold on unmount", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      usePointerPressAndHold<HTMLElement>({ onHold, durationMs: 100 }),
+    );
+    act(() => result.current.onPointerDown(pointer()));
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(110);
+    });
+    expect(onHold).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/gestures/index.ts
+++ b/packages/ui/src/gestures/index.ts
@@ -6,5 +6,6 @@ export * from "./constants";
 export * from "./lost-capture";
 export * from "./recognizers";
 export * from "./useClickSuppression";
+export * from "./usePointerPressAndHold";
 export * from "./usePressAndHold";
 export * from "./useRafCoalescer";

--- a/packages/ui/src/gestures/recognizers.ts
+++ b/packages/ui/src/gestures/recognizers.ts
@@ -91,3 +91,13 @@ export function rubberBand(
   if (travel <= softMax) return travel;
   return softMax + (travel - softMax) * resistance;
 }
+
+/**
+ * Square-root rubber-band: maps overshoot to `sign(x)·√|x|·scale`, so the give
+ * stiffens progressively the further past the limit the finger drags (versus
+ * the constant fraction of {@link rubberBand}). Signed — damps overshoot on
+ * either side of a detent. Used by the chat sheet's detent overscroll.
+ */
+export function sqrtRubberBand(overshoot: number, scale: number): number {
+  return Math.sign(overshoot) * Math.sqrt(Math.abs(overshoot)) * scale;
+}

--- a/packages/ui/src/gestures/usePointerPressAndHold.ts
+++ b/packages/ui/src/gestures/usePointerPressAndHold.ts
@@ -1,0 +1,99 @@
+/**
+ * Pointer-event press-and-hold recognizer with a move-cancel slop: a press held
+ * past `durationMs` fires `onHold`; travel past `moveCancelPx` on either axis
+ * (or any pointerup/cancel) before then aborts. The pointer-contract sibling of
+ * usePressAndHold — that one binds raw touch events and cancels on ANY move,
+ * while this one tolerates press wobble up to the slop so a still hold survives
+ * finger drift while a real scroll cancels it. Used by the chat thread's
+ * hold-to-copy.
+ *
+ * The consumer spreads the returned handlers onto its element; `canBegin` lets
+ * it skip presses that belong to nested interactive targets. The timer is
+ * cleared on unmount.
+ */
+
+import * as React from "react";
+import { DEFAULT_HOLD_MS, TOUCH_TAP_MOVE_SLOP } from "./constants";
+
+export interface PointerPressAndHoldOptions<E extends HTMLElement> {
+  /** Fired when the press is held past `durationMs` within the slop. Receives
+   *  the pointerdown event that started the hold. */
+  onHold: (event: React.PointerEvent<E>) => void;
+  /** Hold duration (ms) before `onHold` fires. Default {@link DEFAULT_HOLD_MS}. */
+  durationMs?: number;
+  /** Per-axis travel (px) past which the press becomes a scroll/drag and the
+   *  hold aborts. Default {@link TOUCH_TAP_MOVE_SLOP}. */
+  moveCancelPx?: number;
+  /** Checked on pointerdown; return false to ignore the press entirely (e.g.
+   *  a press on a nested button/link that owns its own interaction). */
+  canBegin?: (event: React.PointerEvent<E>) => boolean;
+  /** When false, the recognizer is inert. */
+  enabled?: boolean;
+}
+
+export interface PointerPressAndHoldBinding<E extends HTMLElement> {
+  onPointerDown: (event: React.PointerEvent<E>) => void;
+  onPointerMove: (event: React.PointerEvent<E>) => void;
+  onPointerUp: () => void;
+  onPointerCancel: () => void;
+}
+
+export function usePointerPressAndHold<E extends HTMLElement>({
+  onHold,
+  durationMs = DEFAULT_HOLD_MS,
+  moveCancelPx = TOUCH_TAP_MOVE_SLOP,
+  canBegin,
+  enabled = true,
+}: PointerPressAndHoldOptions<E>): PointerPressAndHoldBinding<E> {
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startRef = React.useRef<{ x: number; y: number } | null>(null);
+  const onHoldRef = React.useRef(onHold);
+  onHoldRef.current = onHold;
+  const canBeginRef = React.useRef(canBegin);
+  canBeginRef.current = canBegin;
+
+  const clear = React.useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    startRef.current = null;
+  }, []);
+
+  React.useEffect(() => clear, [clear]);
+
+  const onPointerDown = React.useCallback(
+    (event: React.PointerEvent<E>) => {
+      if (!enabled) return;
+      if (canBeginRef.current && !canBeginRef.current(event)) return;
+      clear();
+      startRef.current = { x: event.clientX, y: event.clientY };
+      timerRef.current = setTimeout(() => {
+        clear();
+        onHoldRef.current(event);
+      }, durationMs);
+    },
+    [clear, durationMs, enabled],
+  );
+
+  const onPointerMove = React.useCallback(
+    (event: React.PointerEvent<E>) => {
+      const start = startRef.current;
+      if (!start) return;
+      if (
+        Math.abs(event.clientX - start.x) > moveCancelPx ||
+        Math.abs(event.clientY - start.y) > moveCancelPx
+      ) {
+        clear();
+      }
+    },
+    [clear, moveCancelPx],
+  );
+
+  return {
+    onPointerDown,
+    onPointerMove,
+    onPointerUp: clear,
+    onPointerCancel: clear,
+  };
+}

--- a/packages/ui/src/gestures/usePressAndHold.ts
+++ b/packages/ui/src/gestures/usePressAndHold.ts
@@ -9,9 +9,7 @@
  */
 
 import * as React from "react";
-
-/** iOS-style long-press threshold. */
-export const DEFAULT_HOLD_MS = 450;
+import { DEFAULT_HOLD_MS } from "./constants";
 
 export interface PressAndHoldOptions<E extends HTMLElement> {
   /** Fired when the finger is held past `durationMs` without lifting/moving. */

--- a/packages/ui/src/hooks/useHorizontalPager.ts
+++ b/packages/ui/src/hooks/useHorizontalPager.ts
@@ -5,16 +5,18 @@
  */
 import * as React from "react";
 import {
+  PAGER_AXIS_COMMIT_SLOP as AXIS_COMMIT_SLOP,
+  PAGER_AXIS_DOMINANCE_RATIO as AXIS_DOMINANCE_RATIO,
+  OVERSHOOT_RESISTANCE as EDGE_RESISTANCE,
+  PAGER_FLICK_VELOCITY as FLICK_VELOCITY,
   isRealCaptureLoss,
   useClickSuppression,
   useRafCoalescer,
 } from "../gestures";
 
-// Per-surface tuned overrides (deliberately tighter than the shared pull
-// defaults): the launcher rail commits its axis at a shorter slop and requires
-// stronger horizontal dominance than the vertical-pull surfaces (#12349).
-const AXIS_COMMIT_SLOP = 6;
-const AXIS_DOMINANCE_RATIO = 1.15;
+// The pager's tuned axis/flick/edge values live in the shared gesture constants
+// module as named PAGER_* overrides (see gestures/constants.ts for why each
+// diverges from the shared defaults); the constants below are pager-only feel.
 const MIN_DISTANCE_THRESHOLD = 64;
 // A slow drag commits the page only once the finger has crossed the halfway
 // point of the viewport; short of that it springs back. This is the iOS
@@ -23,9 +25,7 @@ const MIN_DISTANCE_THRESHOLD = 64;
 // so a quick swipe never has to travel the full 50%.
 const DISTANCE_THRESHOLD_RATIO = 0.5;
 const MIN_FLICK_DISTANCE = 48;
-const FLICK_VELOCITY = 0.45;
 const SETTLE_MS = 360;
-const EDGE_RESISTANCE = 0.35;
 const SETTLE_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
 // Velocity-aware momentum settle (#10717): after a drag release, the settle
 // duration is derived from the release velocity instead of a constant rate — a

--- a/packages/ui/src/hooks/usePushToTalk.test.tsx
+++ b/packages/ui/src/hooks/usePushToTalk.test.tsx
@@ -7,7 +7,8 @@
 
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { PUSH_TO_TALK_HOLD_MS, usePushToTalk } from "./usePushToTalk";
+import { PUSH_TO_TALK_HOLD_MS } from "../gestures";
+import { usePushToTalk } from "./usePushToTalk";
 
 interface HarnessProps {
   canBegin?: () => boolean;

--- a/packages/ui/src/hooks/usePushToTalk.ts
+++ b/packages/ui/src/hooks/usePushToTalk.ts
@@ -16,9 +16,7 @@
 
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { useCallback, useEffect, useRef } from "react";
-
-/** Single hold duration before a press promotes to an active capture. */
-export const PUSH_TO_TALK_HOLD_MS = 200;
+import { PUSH_TO_TALK_HOLD_MS } from "../gestures";
 
 type PushToTalkPhase =
   | { kind: "idle" }


### PR DESCRIPTION
Part of #12188 Phase 2. Builds on the merged gesture-core groundwork (#12445 recognizers/constants scaffold, #12454/#12345 push-to-talk) by **finishing the centralization** the earlier passes left partial: every tuned gesture value now has one definition site, and the last hand-rolled gesture copies at the call sites become adapters over the shared core.

## Duplication eliminated (§C rollup — before → after)

| §C item | Before | After |
|---|---|---|
| **Long-press timers** (450/420/200/180ms) | 4 hand-rolled timers | Table in `gestures/constants.ts`: `DEFAULT_HOLD_MS` 450 · `COPY_HOLD_MS` 420 · `PUSH_TO_TALK_HOLD_MS` 200. The 180ms composer timing was already unified to 200 in #12345; overlay copy-hold now uses shared `usePointerPressAndHold`. |
| **5 tap-slop constants** (8/10/10/10/4px) | 5 scattered literals | `TAP_SLOP` 8 · `TOUCH_TAP_MOVE_SLOP` 10 (the three identical 10px move-slops: copy-hold, tap-reveal, outside-sheet) · `GRAPH_PAN_ENGAGE_SLOP` 4 |
| **AXIS_COMMIT_SLOP 8-vs-6** | 2 copies | `AXIS_COMMIT_SLOP` 8 (default) + named `PAGER_AXIS_COMMIT_SLOP` 6 override |
| **axis dominance 0.8-vs-1.15** | 2 copies | `HORIZONTAL_DOMINANCE_RATIO` 0.8 + named `PAGER_AXIS_DOMINANCE_RATIO` 1.15 override |
| **4 flick-velocity** (0.5/0.4/0.5/0.45) | 4 literals | `DEFAULT_PULL_VELOCITY` 0.5 · `DEFAULT_SWIPE_VELOCITY` 0.4 · `PAGER_FLICK_VELOCITY` 0.45; notification-pull velocity aliases `DEFAULT_PULL_VELOCITY` |
| **3 rubber-band formulas** (0.35/0.35/sqrt) | 3 copies | linear `rubberBand` + `OVERSHOOT_RESISTANCE` 0.35 (notification + pager edge); new `sqrtRubberBand` + `SHEET_DETENT_OVERSHOOT_SCALE` 6 (overlay detent) |
| **≥6 click-suppression copies** | overlay/TopicGroup/Launcher/conv-item/composer×2/graph/overlay×2 | `useClickSuppression` — RelationshipsGraphPanel migrated here (dropped a hand-rolled ref + `setTimeout(…,0)`); the pager/TopicGroup/conv-item already delegate (#12445). The overlay's 750ms-windowed outside-click gate is deliberately **kept** (it's a next-outside-click gate, not a synthesized-click swallow — see note below). |
| **4 rAF-coalesce copies** | 4 loops | `useRafCoalescer` — overlay viewport-sync migrated (dropped its hand-rolled one-rAF-per-frame loop) |
| **long-press copy** overlay:1154 | hand-rolled timer + slop refs | shared `usePointerPressAndHold` (new pointer-contract recognizer) |

## Centralized-constants table — deliberate unifications vs kept per-surface overrides

- **Deliberate value unification (already landed #12345, documented here):** the composer push-to-talk hold was 180ms and the overlay mic 200ms — the same feature with two timings — unified to one `PUSH_TO_TALK_HOLD_MS = 200`. No new value change is introduced in *this* PR.
- **Kept per-surface overrides (explicit, documented, values unchanged):** `PAGER_AXIS_COMMIT_SLOP` (6 vs 8), `PAGER_AXIS_DOMINANCE_RATIO` (1.15 vs 0.8 — the pager wants horizontal to *beat* vertical, the pull surfaces want the widened diagonal cone), `PAGER_FLICK_VELOCITY` (0.45), `COPY_HOLD_MS` (420 vs 450), `GRAPH_PAN_ENGAGE_SLOP` (4), `SHEET_DETENT_OVERSHOOT_SCALE` (6, sqrt damping). Each carries a comment explaining the divergence.
- A **drift-gate test** (`gestures.test.ts` → "tuned constants table") pins every default and every per-surface override plus its direction of divergence, so a future silent behavior change fails CI.

**No tuned value was changed in this PR.** All hooks keep their public APIs; the three gesture engines stay separate (DD2). `useNotificationPull` keeps its raw-TouchEvent non-passive `preventDefault` path.

## Regression net (merged unified runners #12465) — results

| Runner | Result |
|---|---|
| `test:launcher-e2e` | **PASSED** (launcher owns the pager driver — confirms the aliased `PAGER_*` constants are byte-identical) |
| `test:chatux-gesture-e2e` | **ALL PASSED** (TopicGroup flick collapse/expand) |
| `test:home-screen-e2e` | 1 failure — `"hyperliquid" absent from launcher` — **unrelated** launcher-content/dedup assertion (develop's #12521 wallet-subpage hiding), not gesture math |
| `test:chat-sheet-e2e` | **PASSED** clean on 3 of 4 runs; 1 run flaked on a Playwright click-interception timeout (infra, not a detent assertion) |
| `chat-gesture-coverage` gate (packages/app) | **PASSED** (5/5) |
| jsdom gesture unit suites (8 files) | **96 passed** — gestures core, use-pull-gesture, use-notification-pull, useHorizontalPager ×2, chat-message tap-reveal, chat-conversation-item, mechanics-regression-gate |
| typecheck (packages/ui) | clean except pre-existing `iwer` missing-dep in untouched `spatial/__e2e__` (CI install resolves) |
| biome (12 touched source files) | clean |

### Regression found & fixed mid-review
The chat-sheet runner initially failed 7 detent assertions (COLLAPSED→HALF flick overshooting to ~638px vs 377px). Root cause: `useRafCoalescer` returns a fresh object literal each render (its inner methods are stable, the wrapper is not); the overlay's viewport-sync effect depended on the whole object, so it re-ran every render and re-fired `settleDragRef` mid-drag, stranding the in-progress sheet gesture. Fixed by depending on the destructured stable `schedule`/`cancel` methods. The three merged adapters already destructure the stable methods, so only this new call site was affected. Runner green after the fix.

## Line delta
- Consumer call-sites (the dedup): **−27 net** (85 added / 112 removed)
- Shared core (new `usePointerPressAndHold` + `sqrtRubberBand` + the documented constants table): +184
- New unit tests (drift gate, sqrtRubberBand, pointer press-and-hold): +179

The raw call-site dedup lands negative; the module grows because this pass **adds** the documented tuned-value table and a reusable pointer press-and-hold recognizer that will absorb further duplication in Phase 3.

## audit:app
N/A this run — shared-worktree node_modules + long dev-server boot make a full `audit:app` unreliable here. These are gesture-*logic* changes with **zero** visual-token / render-output changes (same tuned values, same DOM), and the e2e runners above capture rest+gesture screenshots proving the surfaces render and respond correctly.

## What Phase 3 builds on
The composer/message-row merge (Phase 3) now consumes: `usePointerPressAndHold` and `usePushToTalk` (hold recognizers), `useClickSuppression`, `TOUCH_TAP_MOVE_SLOP` / the full hold + slop table, and `sqrtRubberBand` — so the retiring inline composers/bubbles adopt the shared gesture core instead of re-deriving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
