### PR TITLE
fix(ios): terminate local agent streams on bridge errors

### DIFF
--- a/.github/issue-evidence/12626-ios-stream-hang/README.md
+++ b/.github/issue-evidence/12626-ios-stream-hang/README.md
@@ -1,0 +1,28 @@
+# iOS local-agent stream termination evidence
+
+## Scope
+
+Fixes #12626 stream lifecycle regressions:
+
+- Native-call rejection before the response head now rejects the shared streaming response head, allowing the iOS buffered fallback/error path to run instead of hanging forever.
+- Mid-stream WebView/native `stream_emit` rejection no longer poisons the serialized chunk queue before the terminal frame; the bridge attempts a final `complete` frame with the emit error.
+
+## Verification
+
+- `bun install --ignore-scripts` in a clean `origin/develop` export - PASS.
+- `bun run --cwd packages/cloud/routing build` - PASS, required for the bridge test import graph in the clean export.
+- `node packages/shared/scripts/generate-keywords.mjs --target ts` - PASS, required for core generated keyword data in the clean export.
+- `bunx vitest run packages/ui/src/api/native-agent-stream.test.ts packages/ui/src/api/ios-streaming-agent-plugin.test.ts plugins/plugin-capacitor-bridge/src/ios/bridge.stream.test.ts` - PASS, 3 files / 21 tests.
+- `bunx biome check packages/ui/src/api/native-agent-stream.ts packages/ui/src/api/native-agent-stream.test.ts packages/ui/src/api/ios-streaming-agent-plugin.ts packages/ui/src/api/ios-streaming-agent-plugin.test.ts plugins/plugin-capacitor-bridge/src/ios/bridge.ts plugins/plugin-capacitor-bridge/src/ios/bridge.stream.test.ts` - PASS.
+
+## Typecheck status
+
+- `bun run --cwd packages/ui typecheck` - BLOCKED by unrelated existing workspace errors, including unresolved `@elizaos/contracts` and pre-existing `AccountWithCredentialFlag` field errors in account UI files.
+- `bun run --cwd plugins/plugin-capacitor-bridge typecheck` - BLOCKED by unrelated existing workspace errors, including unresolved optional `@elizaos/auth`, plugin, contracts, security, and skills packages.
+
+## Evidence matrix
+
+- Live model trajectories: N/A - no prompt, provider, action, evaluator, or model selection behavior changed.
+- Screenshots/video: BLOCKED - this host has Command Line Tools only; no full Xcode/iOS simulator SDK is installed.
+- Native/iOS device logs: BLOCKED - no iOS simulator/device runtime is available on this host.
+- Backend/client logs: covered by focused in-process stream tests; no live app runtime was available for device capture.

--- a/packages/ui/src/api/ios-streaming-agent-plugin.test.ts
+++ b/packages/ui/src/api/ios-streaming-agent-plugin.test.ts
@@ -141,7 +141,7 @@ describe("createIosStreamingAgentPlugin", () => {
     expect(text).toBe("Hello world");
   });
 
-  it("surfaces a call rejection to onStreamError without throwing to the caller", async () => {
+  it("surfaces a call rejection to onStreamError and the stream completion", async () => {
     const onError = vi.fn();
     const runtime: IosStreamingRuntime = {
       async call(): Promise<{ result: unknown }> {
@@ -152,13 +152,32 @@ describe("createIosStreamingAgentPlugin", () => {
       },
     };
     const plugin = createIosStreamingAgentPlugin(runtime, onError);
-    const { streamId } = await plugin.requestStream({
+    const { streamId, completion } = await plugin.requestStream({
       method: "POST",
       path: "/api/conversations/c1/messages/stream",
     });
     expect(streamId).toMatch(/^ios-stream-/);
-    await new Promise((r) => setTimeout(r, 0));
+    await expect(completion).rejects.toThrow("bridge exploded");
     expect(onError).toHaveBeenCalledOnce();
     expect(String(onError.mock.calls[0][0])).toContain("bridge exploded");
+  });
+
+  it("rejects the response head when the native call rejects before emitting a head", async () => {
+    const runtime: IosStreamingRuntime = {
+      async call(): Promise<{ result: unknown }> {
+        throw new Error("backend failed before stream head");
+      },
+      async addListener() {
+        return { remove: () => {} };
+      },
+    };
+    const plugin = createIosStreamingAgentPlugin(runtime);
+
+    await expect(
+      createNativeStreamingResponse(plugin, {
+        method: "POST",
+        path: "/api/conversations/c1/messages/stream",
+      }),
+    ).rejects.toThrow("backend failed before stream head");
   });
 });

--- a/packages/ui/src/api/ios-streaming-agent-plugin.ts
+++ b/packages/ui/src/api/ios-streaming-agent-plugin.ts
@@ -77,6 +77,10 @@ export function createIosStreamingAgentPlugin(
           onStreamError?.(error);
           throw error;
         });
+      // `requestStream` intentionally returns before the native call settles.
+      // Mark the promise handled immediately; the shared stream helper still
+      // observes the original rejection through the returned promise.
+      void completion.catch(() => {});
       return Promise.resolve({ streamId, completion });
     },
     addListener(

--- a/packages/ui/src/api/ios-streaming-agent-plugin.ts
+++ b/packages/ui/src/api/ios-streaming-agent-plugin.ts
@@ -44,10 +44,10 @@ function newStreamId(): string {
 
 /**
  * Build a `NativeStreamingAgentPlugin` backed by the iOS runtime bridge. The
- * `onStreamError` hook (optional) observes a native call that rejects after the
- * stream head was already delivered — the response body is already terminated by
- * an `agentStreamComplete` event in the normal path, so this is purely for
- * diagnostics, never for control flow.
+ * `onStreamError` hook (optional) observes a native call rejection for
+ * diagnostics. The returned stream `completion` promise is load-bearing: if the
+ * native call rejects before a terminal `agentStreamComplete` event, the shared
+ * stream helper settles the head/body instead of leaving the reader pending.
  */
 export function createIosStreamingAgentPlugin(
   runtime: IosStreamingRuntime,
@@ -56,12 +56,12 @@ export function createIosStreamingAgentPlugin(
   return {
     requestStream(
       options: NativeStreamAgentRequestOptions,
-    ): Promise<{ streamId: string }> {
+    ): Promise<{ streamId: string; completion: Promise<unknown> }> {
       const streamId = newStreamId();
       // Fire-and-forget: the call blocks until the stream completes, but the
       // token events already reached the WebView through the listeners the
       // caller attached before awaiting this resolved streamId.
-      void runtime
+      const completion = runtime
         .call({
           method: "http_request_stream",
           args: {
@@ -75,8 +75,9 @@ export function createIosStreamingAgentPlugin(
         })
         .catch((error) => {
           onStreamError?.(error);
+          throw error;
         });
-      return Promise.resolve({ streamId });
+      return Promise.resolve({ streamId, completion });
     },
     addListener(
       eventName:

--- a/packages/ui/src/api/native-agent-stream.test.ts
+++ b/packages/ui/src/api/native-agent-stream.test.ts
@@ -15,11 +15,11 @@ import {
  * `agentStream*` events on demand — exactly how the native bridge will emit them
  * via Capacitor `notifyListeners`.
  */
-function makeFakeAgent(streamId = "s1") {
+function makeFakeAgent(streamId = "s1", completion?: Promise<unknown>) {
   const listeners = new Map<string, Array<(e: unknown) => void>>();
   const agent: NativeStreamingAgentPlugin = {
     async requestStream() {
-      return { streamId };
+      return { streamId, completion };
     },
     async addListener(eventName, listener) {
       const arr = listeners.get(eventName) ?? [];
@@ -142,6 +142,34 @@ describe("createNativeStreamingResponse", () => {
     await flush();
     emit("agentStreamComplete", { streamId: "s1", error: "connect refused" });
     await expect(responsePromise).rejects.toThrow("connect refused");
+  });
+
+  it("rejects the head when the native stream call rejects without a complete event", async () => {
+    const completion = Promise.reject(new Error("native boot failed"));
+    const { agent } = makeFakeAgent("s1", completion);
+    const responsePromise = createNativeStreamingResponse(agent, {
+      path: "/x",
+    });
+    await expect(responsePromise).rejects.toThrow("native boot failed");
+  });
+
+  it("errors the body when the native stream call rejects after the head", async () => {
+    let rejectCompletion: (error: Error) => void = () => {};
+    const completion = new Promise((_resolve, reject) => {
+      rejectCompletion = reject;
+    });
+    const { agent, emit } = makeFakeAgent("s1", completion);
+    const responsePromise = createNativeStreamingResponse(agent, {
+      path: "/x",
+    });
+    await flush();
+    emit("agentStreamResponse", { streamId: "s1", status: 200 });
+    const response = await responsePromise;
+    const reader = (response.body as ReadableStream<Uint8Array>).getReader();
+
+    rejectCompletion(new Error("native stream died"));
+
+    await expect(reader.read()).rejects.toThrow("native stream died");
   });
 
   it("detaches all listeners once the stream completes", async () => {

--- a/packages/ui/src/api/native-agent-stream.ts
+++ b/packages/ui/src/api/native-agent-stream.ts
@@ -125,6 +125,7 @@ export async function createNativeStreamingResponse(
     resolveHead = resolve;
     rejectHead = reject;
   });
+  void head.catch(() => {});
   let headSettled = false;
 
   const failStream = (reason: unknown): void => {
@@ -188,13 +189,13 @@ export async function createNativeStreamingResponse(
     }
   };
 
-  handles.push(await agent.addListener("agentStreamResponse", onResponse));
-  handles.push(await agent.addListener("agentStreamChunk", onChunk));
-  handles.push(await agent.addListener("agentStreamComplete", onComplete));
-
   if (stream.completion) {
     void stream.completion.catch(failStream);
   }
+
+  handles.push(await agent.addListener("agentStreamResponse", onResponse));
+  handles.push(await agent.addListener("agentStreamChunk", onChunk));
+  handles.push(await agent.addListener("agentStreamComplete", onComplete));
 
   return head;
 }

--- a/packages/ui/src/api/native-agent-stream.ts
+++ b/packages/ui/src/api/native-agent-stream.ts
@@ -45,7 +45,7 @@ export interface NativeStreamListenerHandle {
 export interface NativeStreamingAgentPlugin {
   requestStream: (
     options: NativeStreamAgentRequestOptions,
-  ) => Promise<{ streamId: string }>;
+  ) => Promise<{ streamId: string; completion?: Promise<unknown> }>;
   addListener: (
     eventName:
       | "agentStreamResponse"
@@ -86,7 +86,8 @@ export async function createNativeStreamingResponse(
   agent: NativeStreamingAgentPlugin,
   options: NativeStreamAgentRequestOptions,
 ): Promise<Response> {
-  const { streamId } = await agent.requestStream(options);
+  const stream = await agent.requestStream(options);
+  const { streamId } = stream;
 
   let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
   // Buffer events that land before `start()` runs (and the terminal state if it
@@ -125,6 +126,26 @@ export async function createNativeStreamingResponse(
     rejectHead = reject;
   });
   let headSettled = false;
+
+  const failStream = (reason: unknown): void => {
+    if (detached) return;
+    const error =
+      reason instanceof Error
+        ? reason
+        : new Error(String(reason ?? "Stream failed"));
+    if (!headSettled) {
+      headSettled = true;
+      rejectHead(error);
+      detach();
+      return;
+    }
+    if (controller) {
+      controller.error(error);
+      detach();
+    } else {
+      terminal = { error: error.message };
+    }
+  };
 
   const onResponse = (event: unknown): void => {
     const e = event as NativeStreamResponseEvent;
@@ -170,6 +191,10 @@ export async function createNativeStreamingResponse(
   handles.push(await agent.addListener("agentStreamResponse", onResponse));
   handles.push(await agent.addListener("agentStreamChunk", onChunk));
   handles.push(await agent.addListener("agentStreamComplete", onComplete));
+
+  if (stream.completion) {
+    void stream.completion.catch(failStream);
+  }
 
   return head;
 }

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.stream.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.stream.test.ts
@@ -160,6 +160,42 @@ describe("iOS bridge — streamConversationMessageResponse", () => {
 		expect(tokenChunks.length).toBeGreaterThan(1);
 	});
 
+	it("emits a terminal complete frame when a mid-stream chunk emit rejects", async () => {
+		const runtime = createStreamingRuntime(["a", "b", "c"]);
+		const backend = makeBackendWithConversation(runtime);
+		const frames: StreamEmitFrame[] = [];
+
+		await streamConversationMessageResponse(
+			backend,
+			CONVERSATION_ID,
+			{ text: "hi" },
+			"stream-reject",
+			async (frame) => {
+				frames.push(frame);
+				if (
+					frame.kind === "chunk" &&
+					decodeChunk(frame).type === "token" &&
+					decodeChunk(frame).text === "b"
+				) {
+					throw new Error("webview emit failed");
+				}
+			},
+		);
+
+		expect(frames[0]).toMatchObject({ kind: "response", status: 200 });
+		expect(frames.at(-1)).toEqual({
+			streamId: "stream-reject",
+			kind: "complete",
+			error: "Error: webview emit failed",
+		});
+		expect(
+			frames
+				.filter((f) => f.kind === "chunk")
+				.map(decodeChunk)
+				.some((p) => p.type === "done"),
+		).toBe(true);
+	});
+
 	it("emits a 404 stream for an unknown conversation without throwing", async () => {
 		const runtime = createStreamingRuntime(["ignored"]);
 		const backend = makeBackendWithConversation(runtime);

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -44,9 +44,9 @@ import {
 	toStoredModelPath,
 } from "../shared/local-inference-stored-path.ts";
 import {
-	createStdioBridge,
 	type StdioBridgeRequestFrame as BridgeRequest,
 	type StdioBridgeResponseFrame as BridgeResponse,
+	createStdioBridge,
 } from "../shared/stdio-bridge.ts";
 import { runModelGrind } from "./model-grind.ts";
 
@@ -3988,10 +3988,18 @@ export async function streamConversationMessageResponse(
 	// A serialized emit tail: keep `chunk` frames in generation order even though
 	// `emit` may be async, and let `complete` await every prior chunk.
 	let emitTail: Promise<void> = Promise.resolve();
+	let emitError: unknown = null;
+	const emitSafely = async (frame: StreamEmitFrame): Promise<void> => {
+		try {
+			await emit(frame);
+		} catch (error) {
+			emitError ??= error;
+		}
+	};
 	const enqueueChunk = (payload: Record<string, unknown>): void => {
 		const dataBase64 = sseChunkBase64(payload);
 		emitTail = emitTail.then(() =>
-			Promise.resolve(emit({ streamId, kind: "chunk", dataBase64 })),
+			emitSafely({ streamId, kind: "chunk", dataBase64 }),
 		);
 	};
 
@@ -4019,7 +4027,7 @@ export async function streamConversationMessageResponse(
 		}
 	} catch (error) {
 		await emitTail;
-		await emit({
+		await emitSafely({
 			streamId,
 			kind: "chunk",
 			dataBase64: sseChunkBase64({
@@ -4027,7 +4035,11 @@ export async function streamConversationMessageResponse(
 				error: error instanceof Error ? error.message : String(error),
 			}),
 		});
-		await emit({ streamId, kind: "complete", error: null });
+		await emit({
+			streamId,
+			kind: "complete",
+			error: emitError ? String(emitError) : null,
+		});
 		return;
 	}
 
@@ -4059,7 +4071,11 @@ export async function streamConversationMessageResponse(
 	});
 
 	await emitTail;
-	await emit({ streamId, kind: "complete", error: null });
+	await emit({
+		streamId,
+		kind: "complete",
+		error: emitError ? String(emitError) : null,
+	});
 }
 
 export async function handleDirectCoreRoute(


### PR DESCRIPTION
## Summary
- add an optional native stream `completion` promise so pre-head iOS bridge rejection settles the shared streaming response instead of hanging
- propagate iOS `http_request_stream` call rejection through that completion promise while preserving the diagnostic error hook
- keep the iOS bridge chunk queue alive after `stream_emit` rejection and emit a terminal `complete` frame with the emit error

Fixes #12626.

## Verification
- `bun install --ignore-scripts` in a clean `origin/develop` export
- `bun run --cwd packages/cloud/routing build`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bunx vitest run packages/ui/src/api/native-agent-stream.test.ts packages/ui/src/api/ios-streaming-agent-plugin.test.ts plugins/plugin-capacitor-bridge/src/ios/bridge.stream.test.ts`
- `bunx biome check packages/ui/src/api/native-agent-stream.ts packages/ui/src/api/native-agent-stream.test.ts packages/ui/src/api/ios-streaming-agent-plugin.ts packages/ui/src/api/ios-streaming-agent-plugin.test.ts plugins/plugin-capacitor-bridge/src/ios/bridge.ts plugins/plugin-capacitor-bridge/src/ios/bridge.stream.test.ts`

## Evidence
- `.github/issue-evidence/12626-ios-stream-hang/README.md`

## Typecheck status
- `bun run --cwd packages/ui typecheck` is blocked by unrelated existing workspace errors (`@elizaos/contracts` resolution and account UI `AccountWithCredentialFlag` field errors).
- `bun run --cwd plugins/plugin-capacitor-bridge typecheck` is blocked by unrelated existing workspace resolution errors for optional/auth/plugin packages.

## Device evidence
- iOS simulator/device screenshot, recording, and native logs are still blocked on this host because only Command Line Tools are installed; `xcrun --sdk iphonesimulator --show-sdk-path` cannot locate an iOS simulator SDK.
