### PR TITLE
fix(calendar): report route service load failures

### DIFF
--- a/.github/issue-evidence/12275-calendar-route-service-load.md
+++ b/.github/issue-evidence/12275-calendar-route-service-load.md
@@ -1,0 +1,75 @@
+# #12275 calendar route service-load evidence
+
+## Scope
+
+- Chunk for issue #12275.
+- Calendar routes no longer treat a rejected `getServiceLoadPromise("calendar")` as an absent service.
+- Actual service-load failures now call `runtime.reportError("CalendarRoutes.serviceLoad", ...)` and throw `ElizaError` code `CALENDAR_SERVICE_LOAD_FAILED`.
+- A genuinely absent calendar service still returns the designed route-level `503` JSON response.
+
+## Verification
+
+```bash
+bun run --cwd plugins/plugin-calendar test -- src/routes/plugin-routes.test.ts
+```
+
+Result: passed, 1 file / 2 tests.
+
+```bash
+bunx @biomejs/biome check plugins/plugin-calendar/src/routes/plugin-routes.ts plugins/plugin-calendar/src/routes/plugin-routes.test.ts
+```
+
+Result: passed.
+
+```bash
+bun run --cwd plugins/plugin-calendar build
+```
+
+Result: passed.
+
+```bash
+bun run audit:error-policy-ratchet
+```
+
+Result: passed on the committed diff. The audit reported one changed production source file and no new fallback slop in `plugins/plugin-calendar/src/routes/plugin-routes.ts`.
+
+```bash
+bun run --cwd plugins/plugin-calendar typecheck
+```
+
+Result: failed on unrelated workspace/package issues:
+
+```text
+../../packages/agent/src/runtime/optional-plugin-imports.generated.ts(13,14): Cannot find module '@elizaos/plugin-task-coordinator'
+src/meetings/auto-join.ts(37,8): Cannot find module '@elizaos/plugin-scheduling'
+src/meetings/meeting-join-dispatch.ts(20,37): Cannot find module '@elizaos/plugin-scheduling'
+../plugin-local-inference/src/services/downloader.ts(963,6): Argument of type '{ error: unknown; }' is not assignable to parameter of type 'string'.
+../plugin-local-inference/src/services/downloader.ts(1052,6): Argument of type '{ error: unknown; }' is not assignable to parameter of type 'string'.
+```
+
+```bash
+bun run verify
+```
+
+Result: failed in unrelated `@elizaos/cloud-shared#lint` formatting after 141 successful Turbo tasks:
+
+```text
+packages/cloud/shared/src/lib/types/cloud-api.ts:451
+Formatter would print:
+return value === "super_admin" || value === "moderator" || value === "viewer";
+```
+
+## Route Failure Evidence
+
+The focused route test drives the real `calendarRouteHandler()` with fake HTTP
+request/response objects:
+
+- absent service: returns `503` with `{ "error": "Calendar service is not available." }`
+- rejected service-load promise: calls `runtime.reportError(...)`, throws `CALENDAR_SERVICE_LOAD_FAILED`, and does not send the absent-service response
+
+## Evidence Matrix
+
+- Backend logs: route test asserts the runtime error-reporting call for the service-load failure path.
+- Frontend screenshots/video: N/A - no UI rendering changed.
+- Real-LLM trajectories: N/A - no model, prompt, provider, action, or evaluator behavior changed.
+- Domain artifacts: N/A - no calendar events, external accounts, database rows, scheduled tasks, generated files, or connector artifacts changed.

--- a/plugins/plugin-calendar/src/routes/plugin-routes.test.ts
+++ b/plugins/plugin-calendar/src/routes/plugin-routes.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Calendar HTTP route adapter tests cover service-resolution failure policy at
+ * the runtime boundary.
+ */
+
+import type http from "node:http";
+import type { ElizaError, IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { calendarRouteHandler } from "./plugin-routes.js";
+
+function createRequest(path = "/api/lifeops/calendar/feed") {
+  return {
+    method: "GET",
+    url: path,
+    headers: { host: "localhost" },
+  } as http.IncomingMessage;
+}
+
+function createResponse() {
+  const response = {
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    body: "",
+    headersSent: false,
+    setHeader(name: string, value: number | string | readonly string[]) {
+      response.headers[name.toLowerCase()] = Array.isArray(value)
+        ? value.join(", ")
+        : String(value);
+    },
+    end(chunk?: unknown) {
+      response.headersSent = true;
+      response.body = chunk === undefined ? "" : String(chunk);
+      return response;
+    },
+  };
+  return response as unknown as http.ServerResponse & typeof response;
+}
+
+function createRuntime(overrides: {
+  serviceLoad?: Promise<unknown>;
+  reportError?: ReturnType<typeof vi.fn>;
+}): IAgentRuntime {
+  return {
+    agentId: "calendar-agent",
+    getService: vi.fn(() => null),
+    getServiceLoadPromise: vi.fn(() => overrides.serviceLoad ?? null),
+    reportError: overrides.reportError ?? vi.fn(),
+  } as unknown as IAgentRuntime;
+}
+
+describe("calendarRouteHandler", () => {
+  it("returns unavailable when the calendar service is absent", async () => {
+    const handler = calendarRouteHandler();
+    const req = createRequest();
+    const res = createResponse();
+    const runtime = createRuntime({});
+
+    await handler(req, res, runtime);
+
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body)).toEqual({
+      error: "Calendar service is not available.",
+    });
+    expect(runtime.reportError).not.toHaveBeenCalled();
+  });
+
+  it("reports and throws when the calendar service load fails", async () => {
+    const handler = calendarRouteHandler();
+    const req = createRequest();
+    const res = createResponse();
+    const loadError = new Error("migration failed");
+    const reportError = vi.fn();
+    const runtime = createRuntime({
+      serviceLoad: Promise.reject(loadError),
+      reportError,
+    });
+
+    await expect(handler(req, res, runtime)).rejects.toMatchObject({
+      code: "CALENDAR_SERVICE_LOAD_FAILED",
+    } satisfies Partial<ElizaError>);
+    expect(reportError).toHaveBeenCalledWith(
+      "CalendarRoutes.serviceLoad",
+      loadError,
+      { serviceType: "calendar" },
+    );
+    expect(res.headersSent).toBe(false);
+  });
+});

--- a/plugins/plugin-calendar/src/routes/plugin-routes.ts
+++ b/plugins/plugin-calendar/src/routes/plugin-routes.ts
@@ -1,5 +1,6 @@
 import type http from "node:http";
 import {
+  ElizaError,
   type IAgentRuntime,
   type LegacyRouteHandler,
   logger,
@@ -117,8 +118,14 @@ async function resolveCalendarService(
   try {
     const loaded = await runtime.getServiceLoadPromise(CALENDAR_SERVICE_TYPE);
     return isCalendarRouteService(loaded) ? loaded : null;
-  } catch {
-    return null;
+  } catch (error) {
+    runtime.reportError?.("CalendarRoutes.serviceLoad", error, {
+      serviceType: CALENDAR_SERVICE_TYPE,
+    });
+    throw new ElizaError("Calendar service failed to load.", {
+      code: "CALENDAR_SERVICE_LOAD_FAILED",
+      cause: error,
+    });
   }
 }
 


### PR DESCRIPTION
Part of #12275.

## Summary

- Keep genuinely absent CalendarService behavior as the designed route-level `503` unavailable response.
- Stop treating a rejected `getServiceLoadPromise("calendar")` as service absence.
- Report service-load failures with `runtime.reportError("CalendarRoutes.serviceLoad", ...)` and throw `ElizaError` code `CALENDAR_SERVICE_LOAD_FAILED`.
- Add focused route-handler regression tests for absent service vs failed service load.

## Evidence

- `bun run --cwd plugins/plugin-calendar test -- src/routes/plugin-routes.test.ts` passed, 1 file / 2 tests.
- `bunx @biomejs/biome check plugins/plugin-calendar/src/routes/plugin-routes.ts plugins/plugin-calendar/src/routes/plugin-routes.test.ts` passed.
- `bun run --cwd plugins/plugin-calendar build` passed.
- `bun run audit:error-policy-ratchet` passed on the committed diff.

## Known Unrelated Verification Blockers

`bun run --cwd plugins/plugin-calendar typecheck` failed on existing workspace/package issues outside this change:

```text
../../packages/agent/src/runtime/optional-plugin-imports.generated.ts(13,14): Cannot find module '@elizaos/plugin-task-coordinator'
src/meetings/auto-join.ts(37,8): Cannot find module '@elizaos/plugin-scheduling'
src/meetings/meeting-join-dispatch.ts(20,37): Cannot find module '@elizaos/plugin-scheduling'
../plugin-local-inference/src/services/downloader.ts(963,6): Argument of type '{ error: unknown; }' is not assignable to parameter of type 'string'.
../plugin-local-inference/src/services/downloader.ts(1052,6): Argument of type '{ error: unknown; }' is not assignable to parameter of type 'string'.
```

`bun run verify` was attempted and failed in unrelated `@elizaos/cloud-shared#lint` formatting after 141 successful Turbo tasks:

```text
packages/cloud/shared/src/lib/types/cloud-api.ts:451
Formatter would print:
return value === "super_admin" || value === "moderator" || value === "viewer";
```

## Evidence Matrix

- Backend logs: route test asserts runtime error-reporting for the service-load failure path.
- Frontend screenshots/video: N/A - no UI rendering changed.
- Real-LLM trajectories: N/A - no model, prompt, provider, action, or evaluator behavior changed.
- Domain artifacts: N/A - no calendar events, external accounts, database rows, scheduled tasks, generated files, or connector artifacts changed.
