### PR TITLE
fix(#12320): gate stock kquant load smoke

### DIFF
--- a/.github/issue-evidence/12216-stage3-kquant-load-gate/README.md
+++ b/.github/issue-evidence/12216-stage3-kquant-load-gate/README.md
@@ -1,0 +1,22 @@
+# Stage 3: stock K-quant artifact load gate
+
+Issue: #12320
+
+This slice makes the stock GGUF K-quant wrappers fail closed when their
+post-quantization `llama-cli` load-smoke fails. The shipped Gemma path uses
+stock llama.cpp K-quants (`Q4_K_M` today), so the apply step now treats the
+real produced GGUF load test as publish-blocking instead of warning and still
+writing success metadata. The explicit `--no-smoke-load` escape hatch remains
+for local debugging but records `releaseEligible: false` in the sidecar.
+
+Verification commands:
+
+```bash
+python3 -m pytest packages/training/scripts/quantization/test_recipes_smoke.py -q -k 'kquant_sibling_fails_when_artifact_load_smoke_fails or kquant_sibling_no_smoke_marks_artifact_not_release_eligible'
+python3 -m pytest packages/training/scripts/quantization/test_recipes_smoke.py -q -k 'kquant_sibling_exports_constant or kquant_sibling_dry_run_prints_quant_level or gguf_wrappers_default_to_runtime_llama_cpp_submodule'
+python3 -m py_compile packages/training/scripts/quantization/_common.py packages/training/scripts/quantization/gguf-q3_k_m_apply.py packages/training/scripts/quantization/gguf-q4_k_m_apply.py packages/training/scripts/quantization/gguf-q5_k_m_apply.py packages/training/scripts/quantization/gguf-q6_k_apply.py packages/training/scripts/quantization/test_recipes_smoke.py
+git diff --check origin/develop..HEAD
+```
+
+UI/screenshots/video: N/A. This change only affects training quantization
+scripts and their tests.

--- a/packages/training/scripts/quantization/_common.py
+++ b/packages/training/scripts/quantization/_common.py
@@ -17,8 +17,6 @@ from typing import TYPE_CHECKING, Mapping
 
 import torch
 import torch.nn as nn
-from transformers import AutoModelForCausalLM, AutoTokenizer
-from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 if TYPE_CHECKING:
     # Static-only import. ``PretrainedConfig`` is the upstream type for
@@ -27,6 +25,7 @@ if TYPE_CHECKING:
     # want the helpers below. Behind ``TYPE_CHECKING`` mypy/pyright still
     # see the strong type and reject helpers that misuse the config.
     from transformers import PretrainedConfig
+    from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 log = logging.getLogger(__name__)
 
@@ -57,6 +56,8 @@ def load_model_and_tokenizer(
     dtype: torch.dtype = torch.bfloat16,
 ) -> tuple[nn.Module, PreTrainedTokenizerBase]:
     """Load a HF causal-LM checkpoint, merging a LoRA adapter if present."""
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
     p = Path(model_path)
     if p.exists() and is_lora_dir(p):
         base = resolve_base_for_lora(p)
@@ -85,7 +86,7 @@ def load_model_and_tokenizer(
 
 
 def save_model(
-    model: nn.Module, tokenizer: PreTrainedTokenizerBase, output_dir: Path
+    model: nn.Module, tokenizer: "PreTrainedTokenizerBase", output_dir: Path
 ) -> None:
     """Persist model + tokenizer to ``output_dir`` via safetensors."""
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/packages/training/scripts/quantization/gguf-q3_k_m_apply.py
+++ b/packages/training/scripts/quantization/gguf-q3_k_m_apply.py
@@ -206,9 +206,9 @@ def main(argv: list[str] | None = None) -> int:
         "--no-smoke-load",
         dest="smoke_load",
         action="store_false",
-        help="Skip the post-quantize llama-cli load-smoke (default: run it — "
-             "load the produced GGUF and generate a few tokens to confirm the "
-             "quantized weights are valid).",
+        help="Skip the post-quantize llama-cli load-smoke. This is a local "
+             "debug escape hatch; release/publish runs must keep the default "
+             "artifact load test enabled.",
     )
     ap.set_defaults(smoke_load=True)
     ap.add_argument("--dry-run", action="store_true")
@@ -256,7 +256,15 @@ def main(argv: list[str] | None = None) -> int:
         if smoke.get("ok"):
             log.info("load-smoke OK: %r", smoke.get("output", "")[:80])
         else:
-            log.warning("load-smoke FAILED: %s", smoke.get("error"))
+            log.error("load-smoke FAILED: %s", smoke.get("error"))
+            return 2
+    else:
+        smoke = {
+            "ok": False,
+            "skipped": True,
+            "releaseEligible": False,
+            "reason": "--no-smoke-load was passed",
+        }
 
     sidecar = {
         "method": f"gguf_{QUANT_LEVEL.lower()}",

--- a/packages/training/scripts/quantization/gguf-q4_k_m_apply.py
+++ b/packages/training/scripts/quantization/gguf-q4_k_m_apply.py
@@ -201,9 +201,9 @@ def main(argv: list[str] | None = None) -> int:
         "--no-smoke-load",
         dest="smoke_load",
         action="store_false",
-        help="Skip the post-quantize llama-cli load-smoke (default: run it — "
-             "load the produced GGUF and generate a few tokens to confirm the "
-             "quantized weights are valid).",
+        help="Skip the post-quantize llama-cli load-smoke. This is a local "
+             "debug escape hatch; release/publish runs must keep the default "
+             "artifact load test enabled.",
     )
     ap.set_defaults(smoke_load=True)
     ap.add_argument("--dry-run", action="store_true")
@@ -251,7 +251,15 @@ def main(argv: list[str] | None = None) -> int:
         if smoke.get("ok"):
             log.info("load-smoke OK: %r", smoke.get("output", "")[:80])
         else:
-            log.warning("load-smoke FAILED: %s", smoke.get("error"))
+            log.error("load-smoke FAILED: %s", smoke.get("error"))
+            return 2
+    else:
+        smoke = {
+            "ok": False,
+            "skipped": True,
+            "releaseEligible": False,
+            "reason": "--no-smoke-load was passed",
+        }
 
     sidecar = {
         "method": f"gguf_{QUANT_LEVEL.lower()}",

--- a/packages/training/scripts/quantization/gguf-q5_k_m_apply.py
+++ b/packages/training/scripts/quantization/gguf-q5_k_m_apply.py
@@ -184,9 +184,9 @@ def main(argv: list[str] | None = None) -> int:
         "--no-smoke-load",
         dest="smoke_load",
         action="store_false",
-        help="Skip the post-quantize llama-cli load-smoke (default: run it — "
-             "load the produced GGUF and generate a few tokens to confirm the "
-             "quantized weights are valid).",
+        help="Skip the post-quantize llama-cli load-smoke. This is a local "
+             "debug escape hatch; release/publish runs must keep the default "
+             "artifact load test enabled.",
     )
     ap.set_defaults(smoke_load=True)
     ap.add_argument("--dry-run", action="store_true")
@@ -234,7 +234,15 @@ def main(argv: list[str] | None = None) -> int:
         if smoke.get("ok"):
             log.info("load-smoke OK: %r", smoke.get("output", "")[:80])
         else:
-            log.warning("load-smoke FAILED: %s", smoke.get("error"))
+            log.error("load-smoke FAILED: %s", smoke.get("error"))
+            return 2
+    else:
+        smoke = {
+            "ok": False,
+            "skipped": True,
+            "releaseEligible": False,
+            "reason": "--no-smoke-load was passed",
+        }
 
     sidecar = {
         "method": f"gguf_{QUANT_LEVEL.lower()}",

--- a/packages/training/scripts/quantization/gguf-q6_k_apply.py
+++ b/packages/training/scripts/quantization/gguf-q6_k_apply.py
@@ -187,9 +187,9 @@ def main(argv: list[str] | None = None) -> int:
         "--no-smoke-load",
         dest="smoke_load",
         action="store_false",
-        help="Skip the post-quantize llama-cli load-smoke (default: run it — "
-             "load the produced GGUF and generate a few tokens to confirm the "
-             "quantized weights are valid).",
+        help="Skip the post-quantize llama-cli load-smoke. This is a local "
+             "debug escape hatch; release/publish runs must keep the default "
+             "artifact load test enabled.",
     )
     ap.set_defaults(smoke_load=True)
     ap.add_argument("--dry-run", action="store_true")
@@ -237,7 +237,15 @@ def main(argv: list[str] | None = None) -> int:
         if smoke.get("ok"):
             log.info("load-smoke OK: %r", smoke.get("output", "")[:80])
         else:
-            log.warning("load-smoke FAILED: %s", smoke.get("error"))
+            log.error("load-smoke FAILED: %s", smoke.get("error"))
+            return 2
+    else:
+        smoke = {
+            "ok": False,
+            "skipped": True,
+            "releaseEligible": False,
+            "reason": "--no-smoke-load was passed",
+        }
 
     sidecar = {
         "method": f"gguf_{QUANT_LEVEL.lower()}",

--- a/packages/training/scripts/quantization/test_recipes_smoke.py
+++ b/packages/training/scripts/quantization/test_recipes_smoke.py
@@ -887,6 +887,85 @@ def test_kquant_sibling_dry_run_prints_quant_level(
     assert payload["dry_run"] is True
 
 
+@pytest.mark.parametrize("module_basename,expected_level", _KQUANT_SIBLINGS)
+def test_kquant_sibling_fails_when_artifact_load_smoke_fails(
+    module_basename: str, expected_level: str, monkeypatch, tmp_path
+):
+    mod = _load_module_from_quantization_file(module_basename)
+    fake_llama = tmp_path / "llama.cpp"
+    fake_llama.mkdir()
+    fake_convert = fake_llama / "convert_hf_to_gguf.py"
+    fake_convert.write_text("# fake\n", encoding="utf-8")
+    fake_quantize = fake_llama / "llama-quantize"
+    fake_quantize.write_text("# fake\n", encoding="utf-8")
+    fake_quantize.chmod(0o755)
+
+    def fake_run(cmd):
+        cmd = [str(part) for part in cmd]
+        if "--outfile" in cmd:
+            Path(cmd[cmd.index("--outfile") + 1]).write_bytes(b"f16")
+        elif cmd[-1] == expected_level:
+            Path(cmd[-2]).write_bytes(b"quantized")
+
+    monkeypatch.setattr(mod, "_find_convert_script", lambda _dir: fake_convert)
+    monkeypatch.setattr(mod, "_find_quantize_binary", lambda _dir: fake_quantize)
+    monkeypatch.setattr(mod, "_run", fake_run)
+    monkeypatch.setattr(
+        mod,
+        "_smoke_load_gguf",
+        lambda _gguf, _quantize: {"ok": False, "error": "synthetic load failure"},
+    )
+
+    rc = mod.main([
+        "--model", "google/gemma-4-E2B",
+        "--output", str(tmp_path / "out"),
+    ])
+
+    assert rc == 2
+    assert not list((tmp_path / "out").glob("gguf_*.json"))
+
+
+@pytest.mark.parametrize("module_basename,_expected_level", _KQUANT_SIBLINGS)
+def test_kquant_sibling_no_smoke_marks_artifact_not_release_eligible(
+    module_basename: str, _expected_level: str, monkeypatch, tmp_path
+):
+    mod = _load_module_from_quantization_file(module_basename)
+    fake_llama = tmp_path / "llama.cpp"
+    fake_llama.mkdir()
+    fake_convert = fake_llama / "convert_hf_to_gguf.py"
+    fake_convert.write_text("# fake\n", encoding="utf-8")
+    fake_quantize = fake_llama / "llama-quantize"
+    fake_quantize.write_text("# fake\n", encoding="utf-8")
+    fake_quantize.chmod(0o755)
+
+    def fake_run(cmd):
+        cmd = [str(part) for part in cmd]
+        if "--outfile" in cmd:
+            Path(cmd[cmd.index("--outfile") + 1]).write_bytes(b"f16")
+        else:
+            Path(cmd[-2]).write_bytes(b"quantized")
+
+    monkeypatch.setattr(mod, "_find_convert_script", lambda _dir: fake_convert)
+    monkeypatch.setattr(mod, "_find_quantize_binary", lambda _dir: fake_quantize)
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    out_dir = tmp_path / "out"
+    rc = mod.main([
+        "--model", "google/gemma-4-E2B",
+        "--output", str(out_dir),
+        "--no-smoke-load",
+    ])
+
+    assert rc == 0
+    sidecar = json.loads(next(out_dir.glob("gguf_*.json")).read_text())
+    assert sidecar["smoke_load"] == {
+        "ok": False,
+        "skipped": True,
+        "releaseEligible": False,
+        "reason": "--no-smoke-load was passed",
+    }
+
+
 @pytest.mark.parametrize(
     "module_basename",
     (


### PR DESCRIPTION
## Summary
- make stock GGUF K-quant wrappers fail closed when the default llama-cli load-smoke fails
- mark `--no-smoke-load` output as `releaseEligible: false` in quant sidecars
- make `_common` avoid eager `transformers` imports so GGUF wrappers can be tested/imported without ML dependency version collisions
- add focused regression tests for all stock K-quant siblings

## Evidence
- `python3 -m pytest packages/training/scripts/quantization/test_recipes_smoke.py -q -k 'kquant_sibling_fails_when_artifact_load_smoke_fails or kquant_sibling_no_smoke_marks_artifact_not_release_eligible'`\n- `python3 -m pytest packages/training/scripts/quantization/test_recipes_smoke.py -q -k 'kquant_sibling_exports_constant or kquant_sibling_dry_run_prints_quant_level or gguf_wrappers_default_to_runtime_llama_cpp_submodule'`\n- `python3 -m py_compile packages/training/scripts/quantization/_common.py packages/training/scripts/quantization/gguf-q3_k_m_apply.py packages/training/scripts/quantization/gguf-q4_k_m_apply.py packages/training/scripts/quantization/gguf-q5_k_m_apply.py packages/training/scripts/quantization/gguf-q6_k_apply.py packages/training/scripts/quantization/test_recipes_smoke.py`\n- `git diff --check origin/develop..HEAD`\n\nIssue evidence: `.github/issue-evidence/12216-stage3-kquant-load-gate/README.md`\n\nScreenshots/video: N/A, training quantization script change only.\n\nRefs #12320