### PR TITLE
fix: add echo reference AEC for local ASR

### DIFF
--- a/.github/issue-evidence/12256-echo-aec-evidence.md
+++ b/.github/issue-evidence/12256-echo-aec-evidence.md
@@ -1,0 +1,52 @@
+# Issue 12256 Echo AEC Evidence
+
+Branch: `fix/12256-echo-aec`
+
+## Implemented in this chunk
+
+- Local ASR uploads now carry monotonic capture timing so desktop mic WAVs can
+  align with playback-frame timestamps.
+- `/api/voice/playback-frames` feeds a process-local far-end reference even
+  when live diarization is not active, so batch local ASR can consume the same
+  TTS reference stream.
+- `POST /api/asr/local-inference` applies NLMS echo cancellation to timed JSON
+  uploads before transcription and exposes AEC counters on the status endpoint.
+- Browser local-ASR capture and Electrobun `VoiceService` both hold low-RMS ASR
+  starts during active TTS/post-TTS cooldown while allowing loud barge-in.
+- Small typecheck blockers fixed in `downloader.ts`, Electrobun proxy API-base
+  nullability, and the UI fixture Tailwind/PostCSS typing boundary.
+
+## Verification run locally
+
+- `bunx @biomejs/biome check ...touched files` passed.
+- Final post-rebase focused tests:
+  - `bun run --cwd plugins/plugin-local-inference test -- src/services/voice/far-end-echo-reference.test.ts src/routes/local-inference-asr-route.test.ts` passed: 2 files, 8 tests.
+  - `bun run --cwd packages/ui test -- src/hooks/useVoiceChat.local-asr.test.tsx src/voice/voice-capture-factory.test.ts src/voice/local-asr-capture.test.ts` passed: 3 files, 17 tests.
+  - `bun run --cwd packages/app-core/platforms/electrobun test src/voice/voice-service.test.ts` passed: 1 file, 18 tests.
+- `bun run --cwd plugins/plugin-local-inference typecheck` passed.
+- Before the root verify cleanup removed generated package artifacts,
+  `bun run --cwd packages/ui typecheck` passed and
+  `bun run --cwd packages/app-core/platforms/electrobun typecheck` passed.
+- `git diff --check` passed.
+- `bun install` passed after syncing with `origin/develop`.
+- `bun run verify` was attempted. It failed outside this change on
+  `@elizaos/cloud-ui#lint` import ordering in `packages/cloud-ui/src/approvals/*`
+  and also surfaced an unrelated `@elizaos/cloud-shared#lint` formatting error
+  in `packages/cloud/shared/src/lib/types/cloud-api.ts`. The run generated enough
+  build output to fill the local disk; generated artifacts were cleaned and the
+  focused tests above were rerun afterward.
+
+## Evidence status
+
+- Deterministic ERLE evidence: covered by `far-end-echo-reference.test.ts`,
+  which pushes synthetic playback frames, uploads a timestamp-aligned echo WAV,
+  asserts NLMS is applied, and verifies ERLE is greater than 3 dB.
+- Screenshots: N/A for this chunk; no visual layout or pixel surface changed.
+- Screen recording: pending real desktop voice loop capture.
+- Audio artifact: pending real TTS-to-mic loopback capture with before/after ASR
+  transcript and ERLE telemetry.
+- Real-LLM trajectories: N/A for this chunk; no prompt/model behavior changed.
+- Backend/frontend logs: pending real desktop run.
+
+This evidence file supports a draft PR. The issue is not ready to close until
+real audio/device evidence is captured and manually reviewed.

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -844,7 +844,8 @@ async function startRendererServer(): Promise<string> {
       // on same-origin /api fetches whether it's loaded via Vite (watch mode)
       // or this static server (non-watch dev:desktop). Without this, every
       // /api/* call returned SPA HTML and Settings sat on "Loading…" forever.
-      const apiBase = apiBaseOwner.getCurrent().base ?? initialApiBase;
+      const apiBase =
+        apiBaseOwner.getCurrent().base ?? initialApiBase ?? undefined;
       if (shouldProxyToApiBase(apiBase) && isRendererApiProxyPath(pathname)) {
         const target = new URL(pathname + url.search, apiBase);
         try {

--- a/packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts
@@ -544,6 +544,51 @@ describe("VoiceService", () => {
     ]);
   });
 
+  it("holds low-RMS ASR starts during the post-TTS cooldown but allows loud barge-in", async () => {
+    const { voice, adapter } = harness({
+      ELIZA_VOICE_LIVE_RUNTIME: "1",
+      ELIZA_VOICE_LIVE_TTS: "1",
+    });
+
+    await voice.start({ mode: "local-runtime" });
+    await voice.synthesizeSpeech({ text: "assistant reply" });
+    adapter.emitAsrFinal({
+      text: "assistant reply echo",
+      metadata: { rms: 0.01 },
+    });
+    await flushVoiceEvents();
+
+    expect(adapter.runtimeHandoffCount).toBe(0);
+
+    adapter.emitAsrFinal({
+      text: "stop talking please",
+      metadata: { rms: 0.04 },
+    });
+    await flushVoiceEvents();
+
+    expect(adapter.runtimeHandoffCount).toBe(1);
+    expect(adapter.lastHandoffParams?.text).toBe("stop talking please");
+  });
+
+  it("honors ELIZA_VOICE_POST_TTS_COOLDOWN_MS=0", async () => {
+    const { voice, adapter } = harness({
+      ELIZA_VOICE_LIVE_RUNTIME: "1",
+      ELIZA_VOICE_LIVE_TTS: "1",
+      ELIZA_VOICE_POST_TTS_COOLDOWN_MS: "0",
+    });
+
+    await voice.start({ mode: "local-runtime" });
+    await voice.synthesizeSpeech({ text: "assistant reply" });
+    adapter.emitAsrFinal({
+      text: "quiet immediate follow up",
+      metadata: { rms: 0.01 },
+    });
+    await flushVoiceEvents();
+
+    expect(adapter.runtimeHandoffCount).toBe(1);
+    expect(adapter.lastHandoffParams?.text).toBe("quiet immediate follow up");
+  });
+
   it("returns structured errors for missing ASR, TTS, and playback", async () => {
     const { voice, adapter } = harness({
       ELIZA_VOICE_LIVE_RUNTIME: "1",

--- a/packages/app-core/platforms/electrobun/src/voice/voice-service.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-service.ts
@@ -76,6 +76,19 @@ function isTruthy(value: string | undefined): boolean {
   );
 }
 
+const DEFAULT_POST_TTS_COOLDOWN_MS = 1500;
+const TTS_BARGE_IN_RMS_THRESHOLD = 0.025;
+
+function parseNonNegativeMs(
+  value: string | undefined,
+  fallback: number,
+): number {
+  if (value === undefined) return fallback;
+  const parsed = Number(value.trim());
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return Math.round(parsed);
+}
+
 function requireNonEmpty(value: string, field: string): string {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -93,6 +106,18 @@ function mergeMetadata(
 ): Record<string, JsonValue> | undefined {
   if (!left && !right) return undefined;
   return { ...(left ?? {}), ...(right ?? {}) };
+}
+
+function metadataNumber(
+  metadata: Record<string, JsonValue> | undefined,
+  fields: readonly string[],
+): number | undefined {
+  if (!metadata) return undefined;
+  for (const field of fields) {
+    const value = metadata[field];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return undefined;
 }
 
 function latencySummaryJson(
@@ -156,6 +181,7 @@ export class VoiceService {
   private readonly runtimeAdapter: VoiceRuntimeAdapter;
   private readonly pipelineId: VoicePipelineId;
   private readonly latencyBudget: VoiceLatencyBudget;
+  private readonly postTtsCooldownMs: number;
   private statusValue: VoicePipelineStatus = "idle";
   private mode: VoiceTestMode = "mock";
   private activeTurn: VoiceTurn | null = null;
@@ -170,6 +196,8 @@ export class VoiceService {
   /** Agent's most recent spoken reply + when it landed — feeds the echo guard. */
   private lastAgentReply: string | undefined;
   private lastAgentReplyAtMs: number | undefined;
+  private ttsPlaybackActive = false;
+  private lastTtsPlaybackEndedAtMs: number | undefined;
 
   constructor(options: VoiceServiceOptions = {}) {
     this.traceService = options.traceService ?? null;
@@ -196,6 +224,10 @@ export class VoiceService {
       });
     this.pipelineId = this.pipelineIdFactory();
     this.latencyBudget = getVoiceLatencyBudgetFromEnv(this.env);
+    this.postTtsCooldownMs = parseNonNegativeMs(
+      this.env.ELIZA_VOICE_POST_TTS_COOLDOWN_MS,
+      DEFAULT_POST_TTS_COOLDOWN_MS,
+    );
   }
 
   async status(): Promise<VoicePipelineSnapshot> {
@@ -300,6 +332,7 @@ export class VoiceService {
     });
     turn.responseText = text;
     this.statusValue = "speaking";
+    this.markTtsPlaybackActive();
     await this.updateTurn("tts_started");
     const started = await this.mark("tts", "started", {
       text,
@@ -327,6 +360,7 @@ export class VoiceService {
       text,
       voiceId: params.voiceId ?? null,
     });
+    this.markTtsPlaybackEnded();
     await this.finishTurn("completed");
     this.statusValue = "listening";
     return cloneVoiceTurn(turn);
@@ -477,6 +511,14 @@ export class VoiceService {
     turn.status = status;
     turn.updatedAt = this.timestamp();
     turn.completedAt = turn.updatedAt;
+    if (
+      this.ttsPlaybackActive &&
+      turn.marks.some(
+        (mark) => mark.stage === "tts" || mark.stage === "playback",
+      )
+    ) {
+      this.markTtsPlaybackEnded();
+    }
     if (message) turn.error = message;
     if (status === "error") {
       await this.trace(
@@ -687,6 +729,7 @@ export class VoiceService {
     metadata?: Record<string, JsonValue>;
   }): Promise<void> {
     const text = requireNonEmpty(event.text, "text");
+    if (this.shouldHoldAsrStartForTts(event.metadata)) return;
     const turn = await this.ensureTurn({
       trace: this.traceEnabled,
       metadata: event.metadata,
@@ -735,6 +778,7 @@ export class VoiceService {
     trace: boolean,
   ): Promise<void> {
     const text = requireNonEmpty(event.text, "text");
+    if (this.shouldHoldAsrStartForTts(event.metadata)) return;
     const turn = await this.ensureTurn({
       trace,
       metadata: event.metadata,
@@ -890,6 +934,45 @@ export class VoiceService {
     this.lastAgentReplyAtMs = this.now().getTime();
   }
 
+  private markTtsPlaybackActive(): void {
+    this.ttsPlaybackActive = true;
+  }
+
+  private markTtsPlaybackEnded(): void {
+    if (!this.ttsPlaybackActive) return;
+    this.ttsPlaybackActive = false;
+    this.lastTtsPlaybackEndedAtMs = this.now().getTime();
+  }
+
+  private ttsCaptureGateState():
+    | { phase: "speaking"; elapsedMs: 0 }
+    | { phase: "post-tts-cooldown"; elapsedMs: number }
+    | null {
+    if (this.ttsPlaybackActive || this.statusValue === "speaking") {
+      return { phase: "speaking", elapsedMs: 0 };
+    }
+    if (this.lastTtsPlaybackEndedAtMs === undefined) return null;
+    const elapsedMs = this.now().getTime() - this.lastTtsPlaybackEndedAtMs;
+    if (elapsedMs < 0 || elapsedMs >= this.postTtsCooldownMs) return null;
+    return { phase: "post-tts-cooldown", elapsedMs };
+  }
+
+  private shouldHoldAsrStartForTts(
+    metadata: Record<string, JsonValue> | undefined,
+  ): boolean {
+    if (
+      this.activeTurn?.transcriptPartial ||
+      this.activeTurn?.transcriptFinal
+    ) {
+      return false;
+    }
+    const gate = this.ttsCaptureGateState();
+    if (!gate) return false;
+    const rms = metadataNumber(metadata, ["rms", "audioRms", "inputRms"]);
+    if (rms === undefined) return false;
+    return rms < TTS_BARGE_IN_RMS_THRESHOLD;
+  }
+
   private async handleTtsResult(
     params: VoiceSynthesizeSpeechParams,
     result: VoiceSynthesisResult,
@@ -903,6 +986,7 @@ export class VoiceService {
     });
     turn.responseText = params.text;
     this.statusValue = "speaking";
+    this.markTtsPlaybackActive();
     await this.updateTurn("tts_started");
     const started = await this.mark("tts", "started", {
       text: params.text,
@@ -930,6 +1014,7 @@ export class VoiceService {
       },
     );
     if (!this.runtimeAdapter.playAudio) {
+      this.markTtsPlaybackEnded();
       await this.finishTurn("error", "Voice playback is unavailable.");
       throw new VoiceError(
         "VOICE_AUDIO_OUTPUT_UNAVAILABLE",
@@ -947,6 +1032,7 @@ export class VoiceService {
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Voice playback failed.";
+      this.markTtsPlaybackEnded();
       await this.finishTurn("error", message);
       throw error;
     }
@@ -982,6 +1068,7 @@ export class VoiceService {
       playback,
       event.metadata ?? {},
     );
+    this.markTtsPlaybackEnded();
     await this.finishTurn("completed");
     this.statusValue = "listening";
   }

--- a/packages/ui/src/hooks/useVoiceChat.local-asr.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.local-asr.test.tsx
@@ -52,6 +52,10 @@ describe("useVoiceChat local ASR", () => {
       stop,
       cancel: vi.fn(),
       analyser: null,
+      captureTiming: {
+        captureStartedAtMs: 100,
+        captureEndedAtMs: 350,
+      },
     });
     const onTranscript = vi.fn();
     const onTranscriptPreview = vi.fn();
@@ -93,7 +97,11 @@ describe("useVoiceChat local ASR", () => {
           "Content-Type": "application/json",
           Accept: "application/json",
         }),
-        body: JSON.stringify({ audioBase64: "AQIDBA==" }),
+        body: JSON.stringify({
+          audioBase64: "AQIDBA==",
+          captureStartedAtMs: 100,
+          captureEndedAtMs: 350,
+        }),
       }),
     );
     expect(onTranscriptPreview).toHaveBeenCalledWith(

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -47,6 +47,7 @@ import {
 } from "../voice/local-asr-capture";
 import {
   isLocalInferenceAsrReady,
+  type TranscribeWavOptions,
   transcribeLocalInferenceWav,
 } from "../voice/local-asr-transcribe";
 import {
@@ -777,8 +778,20 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
   }, [applyTranscriptUpdate, resetListeningState]);
 
   const transcribeLocalInferenceAudio = useCallback(
-    async (audio: Uint8Array, signal?: AbortSignal): Promise<string> => {
-      const { text } = await transcribeLocalInferenceWav(audio, { signal });
+    async (
+      audio: Uint8Array,
+      signal?: AbortSignal,
+      timing?: LocalAsrRecorder["captureTiming"],
+    ): Promise<string> => {
+      const options: TranscribeWavOptions = {};
+      if (signal) options.signal = signal;
+      if (timing?.captureStartedAtMs !== undefined) {
+        options.captureStartedAtMs = timing.captureStartedAtMs;
+      }
+      if (timing?.captureEndedAtMs !== undefined) {
+        options.captureEndedAtMs = timing.captureEndedAtMs;
+      }
+      const { text } = await transcribeLocalInferenceWav(audio, options);
       return text;
     },
     [],
@@ -1042,7 +1055,11 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         if (recorder) {
           try {
             const audio = await recorder.stop();
-            const transcript = await transcribeLocalInferenceAudio(audio);
+            const transcript = await transcribeLocalInferenceAudio(
+              audio,
+              undefined,
+              recorder.captureTiming,
+            );
             applyTranscriptUpdate(transcript, true, {
               mode:
                 normalizeActiveVoiceSessionMode(mode) ??

--- a/packages/ui/src/testing/e2e-runner/fixture-bundle.ts
+++ b/packages/ui/src/testing/e2e-runner/fixture-bundle.ts
@@ -11,7 +11,7 @@ import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import tailwind from "@tailwindcss/postcss";
 import { build, type Plugin } from "esbuild";
-import postcss from "postcss";
+import postcss, { type AcceptedPlugin } from "postcss";
 
 export interface BundleFixtureOptions {
   /** Absolute path to the fixture entry (`.tsx`). */
@@ -140,7 +140,7 @@ export async function compileTailwindTheme({
 @import "${toUrl(join(stylesDir, "tailwind-theme.css"))}";
 ${sourceImports}
 `;
-  const result = await postcss([tailwind()]).process(input, {
+  const result = await postcss([tailwind() as AcceptedPlugin]).process(input, {
     from: toUrl(join(stylesDir, "styles.css")),
   });
   return result.css;

--- a/packages/ui/src/voice/local-asr-capture.test.ts
+++ b/packages/ui/src/voice/local-asr-capture.test.ts
@@ -6,8 +6,10 @@ import { describe, expect, it } from "vitest";
 import {
   createLocalAsrAutoStopDetector,
   encodeMonoPcm16Wav,
+  isLocalAsrTtsCooldownStartAllowed,
   isSilentPcmAudio,
   measurePcmAudio,
+  resolveLocalAsrTtsCooldownGateConfig,
 } from "./local-asr-capture";
 
 describe("local ASR capture", () => {
@@ -67,6 +69,72 @@ describe("local ASR capture", () => {
     expect(detect(silence, 520)).toEqual({
       shouldBuffer: false,
       shouldStop: true,
+    });
+  });
+
+  it("parses the post-TTS cooldown with the conservative default", () => {
+    expect(resolveLocalAsrTtsCooldownGateConfig().postTtsCooldownMs).toBe(1500);
+    expect(
+      resolveLocalAsrTtsCooldownGateConfig({ postTtsCooldownMs: 250 })
+        .postTtsCooldownMs,
+    ).toBe(250);
+    expect(
+      resolveLocalAsrTtsCooldownGateConfig({ postTtsCooldownMs: -1 })
+        .postTtsCooldownMs,
+    ).toBe(1500);
+  });
+
+  it("raises the capture start gate during TTS cooldown but allows loud barge-in", () => {
+    const quietEcho = measurePcmAudio(new Float32Array([0.01, -0.01, 0.008]));
+    const loudBargeIn = measurePcmAudio(new Float32Array([0.04, -0.04, 0.035]));
+    const gate = {
+      lastPlaybackEndedAtMs: () => 1_000,
+      postTtsCooldownMs: 1_500,
+    };
+
+    expect(isLocalAsrTtsCooldownStartAllowed(quietEcho, gate, 1_400)).toBe(
+      false,
+    );
+    expect(isLocalAsrTtsCooldownStartAllowed(loudBargeIn, gate, 1_400)).toBe(
+      true,
+    );
+    expect(isLocalAsrTtsCooldownStartAllowed(quietEcho, gate, 2_600)).toBe(
+      true,
+    );
+  });
+
+  it("applies the TTS start gate only before speech begins", () => {
+    const detect = createLocalAsrAutoStopDetector(
+      {
+        startGraceMs: 0,
+        minSpeechMs: 100,
+        silenceMs: 200,
+        speechRmsThreshold: 0.003,
+        speechPeakThreshold: 0.012,
+        ttsCooldownGate: {
+          isPlaybackActive: () => true,
+          bargeInRmsThreshold: 0.025,
+          bargeInPeakThreshold: 0.08,
+        },
+      },
+      0,
+    );
+    if (!detect) throw new Error("auto-stop detector was not created");
+
+    const quietEcho = new Float32Array([0.01, -0.01, 0.008]);
+    const loudBargeIn = new Float32Array([0.04, -0.04, 0.035]);
+
+    expect(detect(quietEcho, 10)).toEqual({
+      shouldBuffer: false,
+      shouldStop: false,
+    });
+    expect(detect(loudBargeIn, 20)).toEqual({
+      shouldBuffer: true,
+      shouldStop: false,
+    });
+    expect(detect(quietEcho, 30)).toEqual({
+      shouldBuffer: true,
+      shouldStop: false,
     });
   });
 });

--- a/packages/ui/src/voice/local-asr-capture.ts
+++ b/packages/ui/src/voice/local-asr-capture.ts
@@ -5,11 +5,18 @@
 export interface LocalAsrRecorder {
   stop(): Promise<Uint8Array>;
   cancel(): void;
+  /** Monotonic capture timing, in the same clock used by playback-frame taps. */
+  readonly captureTiming?: LocalAsrCaptureTiming;
   /**
    * Live analyser tapped off the same mic stream, for amplitude visualization.
    * `null` once the recorder has been stopped / cancelled (the context closes).
    */
   analyser: AnalyserNode | null;
+}
+
+export interface LocalAsrCaptureTiming {
+  captureStartedAtMs: number;
+  captureEndedAtMs?: number;
 }
 
 export interface LocalAsrAutoStopOptions {
@@ -19,14 +26,16 @@ export interface LocalAsrAutoStopOptions {
   maxSpeechMs?: number;
   speechRmsThreshold?: number;
   speechPeakThreshold?: number;
+  ttsCooldownGate?: LocalAsrTtsCooldownGateOptions;
 }
 
 export interface LocalAsrRecorderOptions {
   autoStop?: LocalAsrAutoStopOptions;
+  ttsCooldownGate?: LocalAsrTtsCooldownGateOptions;
   onAutoStop?: () => void;
 }
 
-/** Fully-resolved auto-stop config (every {@link LocalAsrAutoStopOptions} field set). */
+/** Fully-resolved numeric auto-stop config. */
 export interface LocalAsrAutoStopConfig {
   startGraceMs: number;
   minSpeechMs: number;
@@ -41,11 +50,36 @@ export interface LocalAsrAutoStopUpdate {
   shouldStop: boolean;
 }
 
+export interface LocalAsrTtsCooldownGateOptions {
+  postTtsCooldownMs?: number;
+  bargeInRmsThreshold?: number;
+  bargeInPeakThreshold?: number;
+  isPlaybackActive?: () => boolean;
+  lastPlaybackEndedAtMs?: () => number | null | undefined;
+}
+
+export interface LocalAsrTtsCooldownGateConfig {
+  postTtsCooldownMs: number;
+  bargeInRmsThreshold: number;
+  bargeInPeakThreshold: number;
+}
+
 type AudioContextConstructor = typeof AudioContext;
 
 type WindowWithAudioContext = Window & {
   AudioContext?: AudioContextConstructor;
   webkitAudioContext?: AudioContextConstructor;
+};
+
+type WindowWithTtsPlaybackState = Window & {
+  __elizaVoiceTtsPlayback?: {
+    active?: boolean;
+    lastEndedAtMs?: number;
+  };
+};
+
+type ProcessWithEnv = {
+  env?: Record<string, string | undefined>;
 };
 
 function getAudioContextCtor(): AudioContextConstructor | undefined {
@@ -125,6 +159,114 @@ export const DEFAULT_LOCAL_ASR_AUTO_STOP: LocalAsrAutoStopConfig = {
   speechPeakThreshold: 0.012,
 };
 
+export const DEFAULT_LOCAL_ASR_POST_TTS_COOLDOWN_MS = 1500;
+export const DEFAULT_LOCAL_ASR_TTS_BARGE_IN_RMS_THRESHOLD = 0.025;
+export const DEFAULT_LOCAL_ASR_TTS_BARGE_IN_PEAK_THRESHOLD = 0.08;
+
+function readRuntimeEnvValue(key: string): string | undefined {
+  if (typeof process === "undefined") return undefined;
+  const env = (process as ProcessWithEnv).env;
+  if (!env) return undefined;
+  return env[key];
+}
+
+function parseNonNegativeMs(
+  value: string | number | undefined,
+  fallback: number,
+): number {
+  if (value === undefined) return fallback;
+  const parsed = typeof value === "number" ? value : Number(value.trim());
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return Math.round(parsed);
+}
+
+function finitePositive(value: number | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  if (!Number.isFinite(value) || value <= 0) return fallback;
+  return value;
+}
+
+export function resolveLocalAsrTtsCooldownGateConfig(
+  options: LocalAsrTtsCooldownGateOptions = {},
+): LocalAsrTtsCooldownGateConfig {
+  return {
+    postTtsCooldownMs: parseNonNegativeMs(
+      options.postTtsCooldownMs ??
+        readRuntimeEnvValue("ELIZA_VOICE_POST_TTS_COOLDOWN_MS"),
+      DEFAULT_LOCAL_ASR_POST_TTS_COOLDOWN_MS,
+    ),
+    bargeInRmsThreshold: finitePositive(
+      options.bargeInRmsThreshold,
+      DEFAULT_LOCAL_ASR_TTS_BARGE_IN_RMS_THRESHOLD,
+    ),
+    bargeInPeakThreshold: finitePositive(
+      options.bargeInPeakThreshold,
+      DEFAULT_LOCAL_ASR_TTS_BARGE_IN_PEAK_THRESHOLD,
+    ),
+  };
+}
+
+function getWindowTtsPlaybackState():
+  | WindowWithTtsPlaybackState["__elizaVoiceTtsPlayback"]
+  | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as WindowWithTtsPlaybackState).__elizaVoiceTtsPlayback;
+}
+
+function isDefaultPlaybackActive(): boolean {
+  if (typeof window === "undefined") return false;
+  const sidecar = getWindowTtsPlaybackState();
+  if (sidecar?.active === true) return true;
+  const synth = window.speechSynthesis;
+  return synth?.speaking === true || synth?.pending === true;
+}
+
+function defaultLastPlaybackEndedAtMs(): number | null | undefined {
+  return getWindowTtsPlaybackState()?.lastEndedAtMs;
+}
+
+export function markLocalAsrTtsPlaybackStarted(atMs = nowMs()): void {
+  if (typeof window === "undefined") return;
+  (window as WindowWithTtsPlaybackState).__elizaVoiceTtsPlayback = {
+    active: true,
+    lastEndedAtMs: atMs,
+  };
+}
+
+export function markLocalAsrTtsPlaybackEnded(atMs = nowMs()): void {
+  if (typeof window === "undefined") return;
+  (window as WindowWithTtsPlaybackState).__elizaVoiceTtsPlayback = {
+    active: false,
+    lastEndedAtMs: atMs,
+  };
+}
+
+export function isLocalAsrTtsCooldownStartAllowed(
+  stats: PcmAudioStats,
+  options: LocalAsrTtsCooldownGateOptions = {},
+  sampleTimeMs = nowMs(),
+): boolean {
+  const config = resolveLocalAsrTtsCooldownGateConfig(options);
+  const playbackActive =
+    options.isPlaybackActive?.() ?? isDefaultPlaybackActive();
+  const lastEndedAtMs =
+    options.lastPlaybackEndedAtMs?.() ?? defaultLastPlaybackEndedAtMs();
+  const elapsedSincePlaybackEndMs =
+    typeof lastEndedAtMs === "number" && Number.isFinite(lastEndedAtMs)
+      ? sampleTimeMs - lastEndedAtMs
+      : Number.POSITIVE_INFINITY;
+  const inCooldown =
+    elapsedSincePlaybackEndMs >= 0 &&
+    elapsedSincePlaybackEndMs < config.postTtsCooldownMs;
+
+  if (!playbackActive && !inCooldown) return true;
+
+  return (
+    stats.rms >= config.bargeInRmsThreshold ||
+    stats.peak >= config.bargeInPeakThreshold
+  );
+}
+
 export function createLocalAsrAutoStopDetector(
   options: LocalAsrAutoStopOptions | undefined,
   startedAtMs = nowMs(),
@@ -137,6 +279,7 @@ export function createLocalAsrAutoStopDetector(
     ...DEFAULT_LOCAL_ASR_AUTO_STOP,
     ...options,
   };
+  const ttsCooldownGate = options.ttsCooldownGate;
   let firstSpeechAtMs: number | null = null;
   let lastSpeechAtMs: number | null = null;
   let stopped = false;
@@ -150,9 +293,17 @@ export function createLocalAsrAutoStopDetector(
     }
 
     const stats = measurePcmAudio(pcm);
-    const speechDetected =
+    const normalSpeechDetected =
       stats.rms >= config.speechRmsThreshold ||
       stats.peak >= config.speechPeakThreshold;
+    const speechDetected =
+      normalSpeechDetected &&
+      (firstSpeechAtMs !== null ||
+        isLocalAsrTtsCooldownStartAllowed(
+          stats,
+          ttsCooldownGate,
+          sampleTimeMs,
+        ));
 
     if (speechDetected) {
       if (firstSpeechAtMs === null) firstSpeechAtMs = sampleTimeMs;
@@ -253,7 +404,13 @@ export async function startLocalAsrRecorder(
   const chunks: Float32Array[] = [];
   let stopped = false;
   let autoStopRequested = false;
+  const captureStartedAtMs = nowMs();
+  let captureEndedAtMs: number | undefined;
   const autoStopDetector = createLocalAsrAutoStopDetector(options.autoStop);
+  const ttsCooldownGate = options.autoStop?.ttsCooldownGate
+    ? undefined
+    : options.ttsCooldownGate;
+  let captureStartAccepted = false;
 
   processor.onaudioprocess = (event) => {
     if (stopped) return;
@@ -269,10 +426,20 @@ export async function startLocalAsrRecorder(
       }
     }
 
-    const autoStopUpdate = autoStopDetector?.(mono) ?? {
-      shouldBuffer: true,
-      shouldStop: false,
-    };
+    const autoStopUpdate =
+      autoStopDetector?.(mono) ??
+      (() => {
+        if (captureStartAccepted) {
+          return { shouldBuffer: true, shouldStop: false };
+        }
+        const stats = measurePcmAudio(mono);
+        const shouldBuffer = isLocalAsrTtsCooldownStartAllowed(
+          stats,
+          ttsCooldownGate,
+        );
+        if (shouldBuffer) captureStartAccepted = true;
+        return { shouldBuffer, shouldStop: false };
+      })();
     if (autoStopUpdate.shouldBuffer) {
       chunks.push(mono);
     }
@@ -314,8 +481,16 @@ export async function startLocalAsrRecorder(
     get analyser() {
       return analyser;
     },
+    get captureTiming() {
+      const timing: LocalAsrCaptureTiming = { captureStartedAtMs };
+      if (captureEndedAtMs !== undefined) {
+        timing.captureEndedAtMs = captureEndedAtMs;
+      }
+      return timing;
+    },
     async stop() {
       const sampleRate = context.sampleRate;
+      captureEndedAtMs = nowMs();
       await cleanup();
       const pcm = concatPcm(chunks);
       if (pcm.length === 0) {

--- a/packages/ui/src/voice/local-asr-capture.ts
+++ b/packages/ui/src/voice/local-asr-capture.ts
@@ -404,7 +404,7 @@ export async function startLocalAsrRecorder(
   const chunks: Float32Array[] = [];
   let stopped = false;
   let autoStopRequested = false;
-  const captureStartedAtMs = nowMs();
+  let captureStartedAtMs: number | undefined;
   let captureEndedAtMs: number | undefined;
   const autoStopDetector = createLocalAsrAutoStopDetector(options.autoStop);
   const ttsCooldownGate = options.autoStop?.ttsCooldownGate
@@ -441,6 +441,8 @@ export async function startLocalAsrRecorder(
         return { shouldBuffer, shouldStop: false };
       })();
     if (autoStopUpdate.shouldBuffer) {
+      captureStartedAtMs ??=
+        nowMs() - (mono.length / Math.max(1, context.sampleRate)) * 1000;
       chunks.push(mono);
     }
     if (autoStopUpdate.shouldStop && !autoStopRequested && options.onAutoStop) {
@@ -482,7 +484,9 @@ export async function startLocalAsrRecorder(
       return analyser;
     },
     get captureTiming() {
-      const timing: LocalAsrCaptureTiming = { captureStartedAtMs };
+      const timing: LocalAsrCaptureTiming = {
+        captureStartedAtMs: captureStartedAtMs ?? captureEndedAtMs ?? nowMs(),
+      };
       if (captureEndedAtMs !== undefined) {
         timing.captureEndedAtMs = captureEndedAtMs;
       }

--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -18,6 +18,10 @@ import { resolveApiUrl } from "../utils";
 export interface TranscribeWavOptions {
   /** Forwarded to `fetch` so callers can cancel an in-flight transcription. */
   signal?: AbortSignal;
+  /** Monotonic mic-capture start time, aligned with playback-frame timestamps. */
+  captureStartedAtMs?: number;
+  /** Monotonic mic-capture end time, aligned with playback-frame timestamps. */
+  captureEndedAtMs?: number;
 }
 
 export interface TranscribeWavResult {
@@ -92,6 +96,12 @@ function bytesToBase64(bytes: Uint8Array): string {
   return btoa(binary);
 }
 
+function finiteOptional(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
 export async function transcribeLocalInferenceWav(
   audio: Uint8Array,
   options?: TranscribeWavOptions,
@@ -100,13 +110,27 @@ export async function transcribeLocalInferenceWav(
   // Android local-agent IPC only forwards string request bodies, so a binary
   // POST 503s with "only supports string request bodies". The ASR route accepts
   // `{ audioBase64 }` on every platform (web/desktop decode it identically).
+  const body: {
+    audioBase64: string;
+    captureStartedAtMs?: number;
+    captureEndedAtMs?: number;
+  } = { audioBase64: bytesToBase64(audio) };
+  const captureStartedAtMs = finiteOptional(options?.captureStartedAtMs);
+  const captureEndedAtMs = finiteOptional(options?.captureEndedAtMs);
+  if (captureStartedAtMs !== undefined) {
+    body.captureStartedAtMs = captureStartedAtMs;
+  }
+  if (captureEndedAtMs !== undefined) {
+    body.captureEndedAtMs = captureEndedAtMs;
+  }
+
   const res = await fetchWithCsrf(resolveApiUrl("/api/asr/local-inference"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json",
     },
-    body: JSON.stringify({ audioBase64: bytesToBase64(audio) }),
+    body: JSON.stringify(body),
     signal: options?.signal,
   });
   if (!res.ok) {

--- a/packages/ui/src/voice/voice-capture-factory.test.ts
+++ b/packages/ui/src/voice/voice-capture-factory.test.ts
@@ -90,6 +90,10 @@ describe("createVoiceCapture", () => {
           stop,
           cancel: vi.fn(),
           analyser: null,
+          captureTiming: {
+            captureStartedAtMs: 200,
+            captureEndedAtMs: 700,
+          },
         };
       },
     );
@@ -117,6 +121,13 @@ describe("createVoiceCapture", () => {
         backend: "local-inference",
         words: [],
       }),
+    );
+    expect(transcribeLocalInferenceWavMock).toHaveBeenCalledWith(
+      new Uint8Array([1, 2, 3]),
+      {
+        captureStartedAtMs: 200,
+        captureEndedAtMs: 700,
+      },
     );
     expect(onStateChange).toHaveBeenLastCalledWith("stopped", undefined);
   });

--- a/packages/ui/src/voice/voice-capture-factory.ts
+++ b/packages/ui/src/voice/voice-capture-factory.ts
@@ -409,7 +409,10 @@ export function createVoiceCapture(
       }
       try {
         const wav = await current.stop();
-        const { text, words } = await transcribeLocalInferenceWav(wav);
+        const { text, words } = await transcribeLocalInferenceWav(
+          wav,
+          current.captureTiming,
+        );
         onTranscript({
           text,
           final: true,

--- a/plugins/plugin-local-inference/src/routes/live-diarization-route.ts
+++ b/plugins/plugin-local-inference/src/routes/live-diarization-route.ts
@@ -41,6 +41,7 @@ import type {
 	AudioFrameEvent,
 	EchoReferenceProvider,
 } from "../services/voice/audio-frame-consumer.js";
+import { getSharedFarEndEchoReference } from "../services/voice/far-end-echo-reference.js";
 import {
 	LiveDiarizationSession,
 	type RuntimeEventSink,
@@ -245,13 +246,13 @@ export async function handleLiveDiarizationRoute(
 	if (url.pathname === "/api/voice/playback-frames" && method === "POST") {
 		if (!ensureCompatApiAuthorized(req, res)) return true;
 		const current = getSession(state);
-		if (!current) {
-			sendJsonError(res, 503, "Runtime not ready");
-			return true;
-		}
 		const body = await readCompatJsonBody(req, res);
 		if (!body) return true;
-		if (body.reset === true) current.resetPlayback();
+		const sharedReference = getSharedFarEndEchoReference();
+		if (body.reset === true) {
+			current?.resetPlayback();
+			sharedReference.resetPlayback();
+		}
 		const rawFrames = body.frames;
 		if (rawFrames !== undefined && !Array.isArray(rawFrames)) {
 			sendJsonError(
@@ -272,7 +273,8 @@ export async function handleLiveDiarizationRoute(
 			);
 			return true;
 		}
-		current.pushPlayback(frames);
+		current?.pushPlayback(frames);
+		sharedReference.pushPlayback(frames);
 		sendJson(res, 200, { ok: true, framesPushed: frames.length });
 		return true;
 	}

--- a/plugins/plugin-local-inference/src/routes/local-inference-asr-route.test.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-asr-route.test.ts
@@ -8,6 +8,13 @@ import * as http from "node:http";
 import { Socket } from "node:net";
 import { ModelType } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AudioFrameEvent } from "../services/voice/audio-frame-consumer";
+import { AUDIO_FRAME_PIPELINE_SAMPLE_RATE } from "../services/voice/audio-frame-consumer";
+import {
+	getSharedFarEndEchoReference,
+	resetSharedFarEndEchoReferenceForTesting,
+} from "../services/voice/far-end-echo-reference";
+import { encodeMonoPcm16Wav } from "../services/voice/wav-codec";
 import type { CompatRuntimeState } from "./compat-helpers";
 import { handleLocalInferenceAsrRoute } from "./local-inference-asr-route";
 import { transcribeWavWithWords } from "./local-inference-asr-transcribe";
@@ -28,6 +35,7 @@ const transcribeWavWithWordsMock = vi.mocked(transcribeWavWithWords);
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	resetSharedFarEndEchoReferenceForTesting();
 	engineMock.canTranscribeLocally.mockResolvedValue(true);
 });
 
@@ -57,6 +65,59 @@ function wavBytes(): Uint8Array {
 		view.setInt16(44 + index * 2, pcm[index] ?? 0, true);
 	}
 	return new Uint8Array(buffer);
+}
+
+function syntheticSpeech(samples: number): Float32Array {
+	const out = new Float32Array(samples);
+	let seed = 0x9e3779b9;
+	for (let index = 0; index < samples; index += 1) {
+		seed = (seed * 1664525 + 1013904223) >>> 0;
+		out[index] =
+			Math.sin((2 * Math.PI * 180 * index) / AUDIO_FRAME_PIPELINE_SAMPLE_RATE) *
+				0.18 +
+			(seed / 0xffffffff - 0.5) * 0.06;
+	}
+	return out;
+}
+
+function encodeFramePcm16(pcm: Float32Array): string {
+	const bytes = Buffer.alloc(pcm.length * 2);
+	for (let index = 0; index < pcm.length; index += 1) {
+		const sample = Math.max(-1, Math.min(1, pcm[index] ?? 0));
+		bytes.writeInt16LE(Math.round(sample * 32767), index * 2);
+	}
+	return bytes.toString("base64");
+}
+
+function rms(pcm: Float32Array): number {
+	let sum = 0;
+	for (const sample of pcm) sum += sample * sample;
+	return Math.sqrt(sum / Math.max(1, pcm.length));
+}
+
+function playbackFrames(
+	pcm: Float32Array,
+	startedAtMs: number,
+): AudioFrameEvent[] {
+	const frames: AudioFrameEvent[] = [];
+	const frameSamples = 320;
+	for (let offset = 0; offset < pcm.length; offset += frameSamples) {
+		const chunk = pcm.subarray(
+			offset,
+			Math.min(pcm.length, offset + frameSamples),
+		);
+		frames.push({
+			pcm16: encodeFramePcm16(chunk),
+			sampleRate: AUDIO_FRAME_PIPELINE_SAMPLE_RATE,
+			channels: 1,
+			samples: chunk.length,
+			rms: rms(chunk),
+			timestamp:
+				startedAtMs + (offset / AUDIO_FRAME_PIPELINE_SAMPLE_RATE) * 1000,
+			frameIndex: frames.length,
+		});
+	}
+	return frames;
 }
 
 function fakeReq(
@@ -137,6 +198,12 @@ describe("local inference ASR route", () => {
 		expect(out.bodyJson()).toEqual({
 			ready: true,
 			provider: "local-inference",
+			aec: expect.objectContaining({
+				echoReferenceWired: false,
+				playbackFramesReceived: 0,
+				playbackSamplesReceived: 0,
+				asrFramesCancelled: 0,
+			}),
 		});
 		expect(getModel).toHaveBeenCalledWith(ModelType.TRANSCRIPTION);
 		expect(engineMock.canTranscribeLocally).toHaveBeenCalledTimes(1);
@@ -164,7 +231,14 @@ describe("local inference ASR route", () => {
 
 		expect(handled).toBe(true);
 		expect(out.status()).toBe(200);
-		expect(out.bodyJson()).toEqual({ ready: false, provider: null });
+		expect(out.bodyJson()).toEqual({
+			ready: false,
+			provider: null,
+			aec: expect.objectContaining({
+				echoReferenceWired: false,
+				asrFramesCancelled: 0,
+			}),
+		});
 		expect(engineMock.canTranscribeLocally).toHaveBeenCalledTimes(1);
 	});
 
@@ -188,7 +262,14 @@ describe("local inference ASR route", () => {
 
 		expect(handled).toBe(true);
 		expect(out.status()).toBe(200);
-		expect(out.bodyJson()).toEqual({ ready: false, provider: null });
+		expect(out.bodyJson()).toEqual({
+			ready: false,
+			provider: null,
+			aec: expect.objectContaining({
+				echoReferenceWired: false,
+				asrFramesCancelled: 0,
+			}),
+		});
 		expect(engineMock.canTranscribeLocally).not.toHaveBeenCalled();
 	});
 
@@ -248,5 +329,41 @@ describe("local inference ASR route", () => {
 			Array.from(transcribeWavWithWordsMock.mock.calls[0]?.[1] as Uint8Array),
 		).toEqual(Array.from(wavBytes()));
 		expect(out.bodyJson()).toEqual({ text: "hello from json", words: [] });
+	});
+
+	it("applies the shared playback reference to timed JSON audio before transcription", async () => {
+		transcribeWavWithWordsMock.mockResolvedValue({
+			text: "cleaned local voice",
+			words: [],
+		});
+		const startedAtMs = 1_500;
+		const far = syntheticSpeech(AUDIO_FRAME_PIPELINE_SAMPLE_RATE * 2);
+		const wav = encodeMonoPcm16Wav(far, AUDIO_FRAME_PIPELINE_SAMPLE_RATE);
+		getSharedFarEndEchoReference().pushPlayback(
+			playbackFrames(far, startedAtMs),
+		);
+		const state: CompatRuntimeState = {
+			current: {} as unknown as CompatRuntimeState["current"],
+		};
+		const req = fakeReq({
+			audioBase64: Buffer.from(wav).toString("base64"),
+			captureStartedAtMs: startedAtMs,
+			captureEndedAtMs: startedAtMs + 2_000,
+		});
+		req.headers["content-type"] = "application/json";
+		const out = fakeRes();
+
+		await handleLocalInferenceAsrRoute(req, out.res, state);
+
+		const forwarded = transcribeWavWithWordsMock.mock
+			.calls[0]?.[1] as Uint8Array;
+		expect(Array.from(forwarded)).not.toEqual(Array.from(wav));
+		expect(
+			getSharedFarEndEchoReference().status().asrFramesCancelled,
+		).toBeGreaterThan(0);
+		expect(out.bodyJson()).toEqual({
+			text: "cleaned local voice",
+			words: [],
+		});
 	});
 });

--- a/plugins/plugin-local-inference/src/routes/local-inference-asr-route.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-asr-route.ts
@@ -14,6 +14,10 @@ import type http from "node:http";
 import { ModelType } from "@elizaos/core";
 import { localInferenceEngine } from "../services/engine";
 import {
+	type AsrEchoCancellationOptions,
+	getSharedFarEndEchoReference,
+} from "../services/voice/far-end-echo-reference";
+import {
 	type CompatRuntimeState,
 	ensureRouteAuthorized,
 	readCompatJsonBody,
@@ -23,8 +27,20 @@ import { transcribeWavWithWords } from "./local-inference-asr-transcribe";
 
 const MAX_LOCAL_ASR_AUDIO_BYTES = 16 * 1024 * 1024;
 
+interface LocalInferenceAsrAudio {
+	audio: Uint8Array;
+	captureStartedAtMs?: number;
+	captureEndedAtMs?: number;
+}
+
 function toUint8Array(value: Uint8Array | ArrayBuffer): Uint8Array {
 	return value instanceof Uint8Array ? value : new Uint8Array(value);
+}
+
+function finiteOptional(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value)
+		? value
+		: undefined;
 }
 
 function coercePreParsedAudio(value: unknown): Uint8Array | null {
@@ -39,9 +55,9 @@ function coercePreParsedAudio(value: unknown): Uint8Array | null {
 async function readRawAudioBody(
 	req: http.IncomingMessage,
 	res: http.ServerResponse,
-): Promise<Uint8Array | null> {
+): Promise<LocalInferenceAsrAudio | null> {
 	const preParsed = coercePreParsedAudio((req as { body?: unknown }).body);
-	if (preParsed) return preParsed;
+	if (preParsed) return { audio: preParsed };
 
 	const chunks: Buffer[] = [];
 	let totalBytes = 0;
@@ -61,7 +77,7 @@ async function readRawAudioBody(
 		return null;
 	}
 
-	return new Uint8Array(Buffer.concat(chunks));
+	return { audio: new Uint8Array(Buffer.concat(chunks)) };
 }
 
 function firstHeaderValue(value: string | string[] | undefined): string {
@@ -71,7 +87,7 @@ function firstHeaderValue(value: string | string[] | undefined): string {
 async function readLocalInferenceAsrAudio(
 	req: http.IncomingMessage,
 	res: http.ServerResponse,
-): Promise<Uint8Array | null> {
+): Promise<LocalInferenceAsrAudio | null> {
 	const contentType = firstHeaderValue(req.headers["content-type"])
 		.toLowerCase()
 		.split(";", 1)[0]
@@ -81,7 +97,18 @@ async function readLocalInferenceAsrAudio(
 		const body = await readCompatJsonBody(req, res);
 		if (!body) return null;
 		if (typeof body.audioBase64 === "string") {
-			return new Uint8Array(Buffer.from(body.audioBase64, "base64"));
+			const input: LocalInferenceAsrAudio = {
+				audio: new Uint8Array(Buffer.from(body.audioBase64, "base64")),
+			};
+			const captureStartedAtMs = finiteOptional(body.captureStartedAtMs);
+			const captureEndedAtMs = finiteOptional(body.captureEndedAtMs);
+			if (captureStartedAtMs !== undefined) {
+				input.captureStartedAtMs = captureStartedAtMs;
+			}
+			if (captureEndedAtMs !== undefined) {
+				input.captureEndedAtMs = captureEndedAtMs;
+			}
+			return input;
 		}
 		sendJson(res, 400, { error: "Missing audioBase64" });
 		return null;
@@ -115,6 +142,7 @@ export async function handleLocalInferenceAsrRoute(
 		sendJson(res, 200, {
 			ready,
 			provider: ready ? "local-inference" : null,
+			aec: getSharedFarEndEchoReference().status(),
 		});
 		return true;
 	}
@@ -125,9 +153,9 @@ export async function handleLocalInferenceAsrRoute(
 
 	if (!(await ensureRouteAuthorized(req, res, state))) return true;
 
-	const audio = await readLocalInferenceAsrAudio(req, res);
-	if (!audio) return true;
-	if (audio.byteLength === 0) {
+	const input = await readLocalInferenceAsrAudio(req, res);
+	if (!input) return true;
+	if (input.audio.byteLength === 0) {
 		sendJson(res, 400, { error: "Missing audio" });
 		return true;
 	}
@@ -153,9 +181,20 @@ export async function handleLocalInferenceAsrRoute(
 			});
 			return true;
 		}
+		const aecOptions: AsrEchoCancellationOptions = {};
+		if (input.captureStartedAtMs !== undefined) {
+			aecOptions.captureStartedAtMs = input.captureStartedAtMs;
+		}
+		if (input.captureEndedAtMs !== undefined) {
+			aecOptions.captureEndedAtMs = input.captureEndedAtMs;
+		}
+		const aec = getSharedFarEndEchoReference().cancelAsrWav(
+			input.audio,
+			aecOptions,
+		);
 		const { text, words } = await transcribeWavWithWords(
 			runtime,
-			audio,
+			aec.audio,
 			abortController.signal,
 		);
 		completed = true;

--- a/plugins/plugin-local-inference/src/services/downloader.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.ts
@@ -959,8 +959,8 @@ export class Downloader {
 					throw error;
 				}
 				logger.warn(
-					`[Downloader] model hub request failed via ${candidate.label ?? candidate.base}; trying next base`,
 					{ error },
+					`[Downloader] model hub request failed via ${candidate.label ?? candidate.base}; trying next base`,
 				);
 				await sleep(failoverBackoffMs(index));
 				continue;
@@ -1048,8 +1048,8 @@ export class Downloader {
 					throw error;
 				}
 				logger.warn(
-					`[Downloader] background model hub request failed via ${candidate.label ?? candidate.base}; trying next base`,
 					{ error },
+					`[Downloader] background model hub request failed via ${candidate.label ?? candidate.base}; trying next base`,
 				);
 				await sleep(failoverBackoffMs(index));
 			}

--- a/plugins/plugin-local-inference/src/services/voice/far-end-echo-reference.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/far-end-echo-reference.test.ts
@@ -119,4 +119,30 @@ describe("FarEndEchoReference", () => {
 		if (!firstPlaybackFrame) throw new Error("missing playback frame");
 		expect(decodeAudioFramePcm(firstPlaybackFrame).length).toBe(FRAME_SAMPLES);
 	});
+
+	it("clears playback and ASR telemetry on reset", () => {
+		const reference = new FarEndEchoReference();
+		const startedAtMs = 3_000;
+		const far = syntheticSpeech(AUDIO_FRAME_PIPELINE_SAMPLE_RATE);
+		const wav = encodeMonoPcm16Wav(far, AUDIO_FRAME_PIPELINE_SAMPLE_RATE);
+
+		reference.pushPlayback(playbackFrames(far, startedAtMs));
+		const result = reference.cancelAsrWav(wav, {
+			captureStartedAtMs: startedAtMs,
+		});
+		expect(result.framesCancelled).toBeGreaterThan(0);
+
+		reference.resetPlayback();
+
+		expect(reference.status()).toMatchObject({
+			echoReferenceWired: false,
+			playbackFramesReceived: 0,
+			playbackSamplesReceived: 0,
+			lastPlaybackFrameAt: null,
+			echoDelayConfidence: 0,
+			echoDelayCalibrated: false,
+			asrFramesCancelled: 0,
+			lastAsrErleDb: null,
+		});
+	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/far-end-echo-reference.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/far-end-echo-reference.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Deterministic coverage for the process-local far-end reference used by
+ * desktop local ASR. The fixtures synthesize the exact playback-frame wire
+ * format so the test exercises timestamp alignment, WAV decoding, NLMS, and
+ * ERLE telemetry without loading native inference libraries.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import type { AudioFrameEvent } from "./audio-frame-consumer.js";
+import {
+	AUDIO_FRAME_PIPELINE_SAMPLE_RATE,
+	decodeAudioFramePcm,
+} from "./audio-frame-consumer.js";
+import { computeErle } from "./echo-metrics.js";
+import { FarEndEchoReference } from "./far-end-echo-reference.js";
+import { decodeMonoPcm16Wav, encodeMonoPcm16Wav } from "./wav-codec.js";
+
+const FRAME_SAMPLES = 320;
+
+const previousResidualSuppression =
+	process.env.ELIZA_VOICE_RESIDUAL_SUPPRESSION;
+
+afterEach(() => {
+	if (previousResidualSuppression === undefined) {
+		delete process.env.ELIZA_VOICE_RESIDUAL_SUPPRESSION;
+	} else {
+		process.env.ELIZA_VOICE_RESIDUAL_SUPPRESSION = previousResidualSuppression;
+	}
+});
+
+function syntheticSpeech(samples: number): Float32Array {
+	const out = new Float32Array(samples);
+	let seed = 0x12345678;
+	for (let index = 0; index < samples; index += 1) {
+		seed = (seed * 1664525 + 1013904223) >>> 0;
+		const noise = (seed / 0xffffffff - 0.5) * 0.08;
+		const voiced =
+			Math.sin((2 * Math.PI * 220 * index) / AUDIO_FRAME_PIPELINE_SAMPLE_RATE) *
+			0.18;
+		out[index] = voiced + noise;
+	}
+	return out;
+}
+
+function rms(pcm: Float32Array): number {
+	let sum = 0;
+	for (const sample of pcm) sum += sample * sample;
+	return Math.sqrt(sum / Math.max(1, pcm.length));
+}
+
+function encodeFramePcm16(pcm: Float32Array): string {
+	const bytes = Buffer.alloc(pcm.length * 2);
+	for (let index = 0; index < pcm.length; index += 1) {
+		const sample = Math.max(-1, Math.min(1, pcm[index] ?? 0));
+		bytes.writeInt16LE(Math.round(sample * 32767), index * 2);
+	}
+	return bytes.toString("base64");
+}
+
+function playbackFrames(
+	pcm: Float32Array,
+	startedAtMs: number,
+): AudioFrameEvent[] {
+	const frames: AudioFrameEvent[] = [];
+	for (let offset = 0; offset < pcm.length; offset += FRAME_SAMPLES) {
+		const chunk = pcm.subarray(offset, offset + FRAME_SAMPLES);
+		frames.push({
+			pcm16: encodeFramePcm16(chunk),
+			sampleRate: AUDIO_FRAME_PIPELINE_SAMPLE_RATE,
+			channels: 1,
+			samples: chunk.length,
+			rms: rms(chunk),
+			timestamp:
+				startedAtMs + (offset / AUDIO_FRAME_PIPELINE_SAMPLE_RATE) * 1000,
+			frameIndex: frames.length,
+		});
+	}
+	return frames;
+}
+
+describe("FarEndEchoReference", () => {
+	it("leaves local-ASR WAV bytes untouched when capture timing is absent", () => {
+		const reference = new FarEndEchoReference();
+		const startedAtMs = 1_000;
+		const far = syntheticSpeech(AUDIO_FRAME_PIPELINE_SAMPLE_RATE);
+		const wav = encodeMonoPcm16Wav(far, AUDIO_FRAME_PIPELINE_SAMPLE_RATE);
+
+		reference.pushPlayback(playbackFrames(far, startedAtMs));
+		const result = reference.cancelAsrWav(wav);
+
+		expect(result.applied).toBe(false);
+		expect(result.framesCancelled).toBe(0);
+		expect(Array.from(result.audio)).toEqual(Array.from(wav));
+	});
+
+	it("applies NLMS cancellation and exposes ERLE when timing aligns with playback", () => {
+		process.env.ELIZA_VOICE_RESIDUAL_SUPPRESSION = "0.1";
+		const reference = new FarEndEchoReference();
+		const startedAtMs = 2_000;
+		const far = syntheticSpeech(AUDIO_FRAME_PIPELINE_SAMPLE_RATE * 2);
+		const nearEcho = far.slice();
+		const wav = encodeMonoPcm16Wav(nearEcho, AUDIO_FRAME_PIPELINE_SAMPLE_RATE);
+
+		reference.pushPlayback(playbackFrames(far, startedAtMs));
+		const result = reference.cancelAsrWav(wav, {
+			captureStartedAtMs: startedAtMs,
+			captureEndedAtMs: startedAtMs + 2_000,
+		});
+		const cleaned = decodeMonoPcm16Wav(result.audio).pcm;
+
+		expect(result.applied).toBe(true);
+		expect(result.framesCancelled).toBeGreaterThan(0);
+		expect(Array.from(result.audio)).not.toEqual(Array.from(wav));
+		expect(computeErle(nearEcho, cleaned)).toBeGreaterThan(3);
+		expect(reference.status().asrFramesCancelled).toBe(result.framesCancelled);
+		expect(reference.status().lastAsrErleDb).toBeGreaterThan(3);
+		const firstPlaybackFrame = playbackFrames(far, startedAtMs)[0];
+		expect(firstPlaybackFrame).toBeDefined();
+		if (!firstPlaybackFrame) throw new Error("missing playback frame");
+		expect(decodeAudioFramePcm(firstPlaybackFrame).length).toBe(FRAME_SAMPLES);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/far-end-echo-reference.ts
+++ b/plugins/plugin-local-inference/src/services/voice/far-end-echo-reference.ts
@@ -1,0 +1,307 @@
+/**
+ * Process-local far-end playback reference for desktop local-ASR echo
+ * cancellation. The WebView streams rendered TTS frames here through the
+ * playback-frame route, and batch ASR uploads consume the aligned reference so
+ * the agent does not transcribe its own speaker output.
+ */
+
+import type { AudioFrameEvent } from "./audio-frame-consumer.js";
+import {
+	AUDIO_FRAME_PIPELINE_SAMPLE_RATE,
+	decodeAudioFramePcm,
+} from "./audio-frame-consumer.js";
+import {
+	estimateEchoDelaySamples,
+	platformPlaybackDelaySamples,
+} from "./echo-delay.js";
+import { computeErle } from "./echo-metrics.js";
+import { EchoReferenceBuffer } from "./echo-reference-buffer.js";
+import { NlmsEchoCanceller } from "./nlms-echo-canceller.js";
+import { decodeMonoPcm16Wav, encodeMonoPcm16Wav } from "./wav-codec.js";
+
+const ASR_AEC_FRAME_SAMPLES = 320;
+const ECHO_CAL_TARGET_SAMPLES = 16_000;
+const ECHO_CAL_MAX_SAMPLES = 24_000;
+const ECHO_CAL_MIN_CONFIDENCE = 0.3;
+const ECHO_CAL_MAX_LAG_SAMPLES = 8_000;
+const ECHO_CAL_CAP_EDGE_SAMPLES = 320;
+const ECHO_CAL_FAR_ENERGY_FLOOR = 1e-7;
+
+export interface AsrEchoCancellationOptions {
+	captureStartedAtMs?: number;
+	captureEndedAtMs?: number;
+}
+
+export interface AsrEchoCancellationResult {
+	audio: Uint8Array;
+	applied: boolean;
+	framesCancelled: number;
+	lastErleDb: number | null;
+}
+
+export interface FarEndEchoReferenceStatus {
+	echoReferenceWired: boolean;
+	playbackFramesReceived: number;
+	playbackSamplesReceived: number;
+	lastPlaybackFrameAt: number | null;
+	echoDelaySamples: number;
+	echoDelayConfidence: number;
+	echoDelayCalibrated: boolean;
+	asrFramesCancelled: number;
+	lastAsrErleDb: number | null;
+}
+
+function concatFloat32(chunks: Float32Array[]): Float32Array {
+	let total = 0;
+	for (const chunk of chunks) total += chunk.length;
+	const out = new Float32Array(total);
+	let offset = 0;
+	for (const chunk of chunks) {
+		out.set(chunk, offset);
+		offset += chunk.length;
+	}
+	return out;
+}
+
+function meanSquare(pcm: Float32Array): number {
+	if (pcm.length === 0) return 0;
+	let energy = 0;
+	for (let index = 0; index < pcm.length; index += 1) {
+		const sample = pcm[index] ?? 0;
+		energy += sample * sample;
+	}
+	return energy / pcm.length;
+}
+
+function finiteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+function resolveEchoDelaySamples(): number {
+	const raw = process.env.ELIZA_VOICE_ECHO_DELAY_MS;
+	if (raw && raw.trim().toLowerCase() === "auto") {
+		const platformId =
+			process.env.ELIZA_PLATFORM === "ios"
+				? "ios"
+				: process.env.ELIZA_PLATFORM === "android"
+					? "android"
+					: process.platform;
+		return platformPlaybackDelaySamples(
+			platformId,
+			AUDIO_FRAME_PIPELINE_SAMPLE_RATE,
+		);
+	}
+	const ms = Number(raw);
+	if (!Number.isFinite(ms) || ms <= 0) return 0;
+	return Math.round((ms / 1000) * AUDIO_FRAME_PIPELINE_SAMPLE_RATE);
+}
+
+function resolveResidualSuppression(): boolean | { gain: number } | undefined {
+	const raw =
+		process.env.ELIZA_VOICE_RESIDUAL_SUPPRESSION?.trim().toLowerCase();
+	if (!raw) return undefined;
+	if (raw === "1" || raw === "true" || raw === "on") return true;
+	const gain = Number(raw);
+	if (Number.isFinite(gain) && gain > 0 && gain <= 1) return { gain };
+	return undefined;
+}
+
+function createAsrEchoCanceller(): NlmsEchoCanceller {
+	const residualSuppression = resolveResidualSuppression();
+	return new NlmsEchoCanceller(
+		residualSuppression ? { residualSuppression } : {},
+	);
+}
+
+export class FarEndEchoReference {
+	private readonly echoBuffer = new EchoReferenceBuffer({
+		sampleRateHz: AUDIO_FRAME_PIPELINE_SAMPLE_RATE,
+	});
+	private readonly canceller = createAsrEchoCanceller();
+	private echoDelaySamples = resolveEchoDelaySamples();
+	private echoDelayConfidence = 0;
+	private echoDelayCalibrated = false;
+	private playbackFramesReceived = 0;
+	private playbackSamplesReceived = 0;
+	private lastPlaybackFrameAt: number | null = null;
+	private calNear: Float32Array[] = [];
+	private calFar: Float32Array[] = [];
+	private calSampleCount = 0;
+	private asrFramesCancelled = 0;
+	private lastAsrErleDb: number | null = null;
+
+	pushPlayback(frames: AudioFrameEvent[]): void {
+		for (const frame of frames) {
+			const pcm = decodeAudioFramePcm(frame);
+			this.echoBuffer.pushAt(frame.timestamp, pcm);
+			this.playbackFramesReceived += 1;
+			this.playbackSamplesReceived += pcm.length;
+			this.lastPlaybackFrameAt = Date.now();
+		}
+	}
+
+	resetPlayback(): void {
+		this.echoBuffer.reset();
+		this.canceller.reset();
+		this.calNear = [];
+		this.calFar = [];
+		this.calSampleCount = 0;
+		this.lastAsrErleDb = null;
+	}
+
+	status(): FarEndEchoReferenceStatus {
+		return {
+			echoReferenceWired: this.playbackSamplesReceived > 0,
+			playbackFramesReceived: this.playbackFramesReceived,
+			playbackSamplesReceived: this.playbackSamplesReceived,
+			lastPlaybackFrameAt: this.lastPlaybackFrameAt,
+			echoDelaySamples: this.echoDelaySamples,
+			echoDelayConfidence: this.echoDelayConfidence,
+			echoDelayCalibrated: this.echoDelayCalibrated,
+			asrFramesCancelled: this.asrFramesCancelled,
+			lastAsrErleDb: this.lastAsrErleDb,
+		};
+	}
+
+	cancelAsrWav(
+		audio: Uint8Array,
+		options: AsrEchoCancellationOptions = {},
+	): AsrEchoCancellationResult {
+		const decoded = decodeMonoPcm16Wav(audio);
+		if (decoded.sampleRate !== AUDIO_FRAME_PIPELINE_SAMPLE_RATE) {
+			return {
+				audio,
+				applied: false,
+				framesCancelled: 0,
+				lastErleDb: this.lastAsrErleDb,
+			};
+		}
+		const captureStartedAtMs = this.resolveCaptureStartMs(
+			decoded.pcm.length,
+			options,
+		);
+		if (!finiteNumber(captureStartedAtMs)) {
+			this.canceller.observeFarEndSilence(decoded.pcm);
+			return {
+				audio,
+				applied: false,
+				framesCancelled: 0,
+				lastErleDb: this.lastAsrErleDb,
+			};
+		}
+
+		const out = new Float32Array(decoded.pcm.length);
+		let framesCancelled = 0;
+		let lastErleDb: number | null = null;
+		for (
+			let offset = 0;
+			offset < decoded.pcm.length;
+			offset += ASR_AEC_FRAME_SAMPLES
+		) {
+			const near = decoded.pcm.subarray(
+				offset,
+				Math.min(decoded.pcm.length, offset + ASR_AEC_FRAME_SAMPLES),
+			);
+			const timestampMs =
+				captureStartedAtMs + (offset / AUDIO_FRAME_PIPELINE_SAMPLE_RATE) * 1000;
+			this.observeForDelayCalibration(near, timestampMs);
+			const far = this.echoBuffer.referenceAt(
+				timestampMs,
+				near.length,
+				this.echoDelaySamples,
+			);
+			if (meanSquare(far) < ECHO_CAL_FAR_ENERGY_FLOOR) {
+				this.canceller.observeFarEndSilence(near);
+				out.set(near, offset);
+				continue;
+			}
+			const cleaned = this.canceller.process(near, far);
+			out.set(cleaned, offset);
+			framesCancelled += 1;
+			lastErleDb = computeErle(near, cleaned);
+		}
+
+		if (framesCancelled === 0) {
+			return {
+				audio,
+				applied: false,
+				framesCancelled: 0,
+				lastErleDb: this.lastAsrErleDb,
+			};
+		}
+
+		this.asrFramesCancelled += framesCancelled;
+		this.lastAsrErleDb = lastErleDb;
+		return {
+			audio: encodeMonoPcm16Wav(out, decoded.sampleRate),
+			applied: true,
+			framesCancelled,
+			lastErleDb,
+		};
+	}
+
+	private resolveCaptureStartMs(
+		samples: number,
+		options: AsrEchoCancellationOptions,
+	): number | null {
+		if (finiteNumber(options.captureStartedAtMs)) {
+			return options.captureStartedAtMs;
+		}
+		if (finiteNumber(options.captureEndedAtMs)) {
+			return (
+				options.captureEndedAtMs -
+				(samples / AUDIO_FRAME_PIPELINE_SAMPLE_RATE) * 1000
+			);
+		}
+		return null;
+	}
+
+	private observeForDelayCalibration(
+		nearPcm: Float32Array,
+		timestampMs: number,
+	): void {
+		if (this.echoDelayCalibrated || nearPcm.length === 0) return;
+		const far = this.echoBuffer.referenceAt(timestampMs, nearPcm.length, 0);
+		if (meanSquare(far) < ECHO_CAL_FAR_ENERGY_FLOOR) return;
+
+		this.calNear.push(nearPcm.slice());
+		this.calFar.push(far);
+		this.calSampleCount += nearPcm.length;
+		while (
+			this.calSampleCount > ECHO_CAL_MAX_SAMPLES &&
+			this.calNear.length > 1
+		) {
+			this.calSampleCount -= (this.calNear.shift() as Float32Array).length;
+			this.calFar.shift();
+		}
+		if (this.calSampleCount < ECHO_CAL_TARGET_SAMPLES) return;
+
+		const est = estimateEchoDelaySamples(
+			concatFloat32(this.calNear),
+			concatFloat32(this.calFar),
+			{ maxLagSamples: ECHO_CAL_MAX_LAG_SAMPLES },
+		);
+		if (
+			est.confidence >= ECHO_CAL_MIN_CONFIDENCE &&
+			est.lagSamples < ECHO_CAL_MAX_LAG_SAMPLES - ECHO_CAL_CAP_EDGE_SAMPLES
+		) {
+			this.echoDelaySamples = est.lagSamples;
+			this.echoDelayConfidence = est.confidence;
+			this.echoDelayCalibrated = true;
+		}
+		this.calNear = [];
+		this.calFar = [];
+		this.calSampleCount = 0;
+	}
+}
+
+let sharedFarEndEchoReference: FarEndEchoReference | null = null;
+
+export function getSharedFarEndEchoReference(): FarEndEchoReference {
+	sharedFarEndEchoReference ??= new FarEndEchoReference();
+	return sharedFarEndEchoReference;
+}
+
+export function resetSharedFarEndEchoReferenceForTesting(): void {
+	sharedFarEndEchoReference = new FarEndEchoReference();
+}

--- a/plugins/plugin-local-inference/src/services/voice/far-end-echo-reference.ts
+++ b/plugins/plugin-local-inference/src/services/voice/far-end-echo-reference.ts
@@ -143,9 +143,16 @@ export class FarEndEchoReference {
 	resetPlayback(): void {
 		this.echoBuffer.reset();
 		this.canceller.reset();
+		this.echoDelaySamples = resolveEchoDelaySamples();
+		this.echoDelayConfidence = 0;
+		this.echoDelayCalibrated = false;
+		this.playbackFramesReceived = 0;
+		this.playbackSamplesReceived = 0;
+		this.lastPlaybackFrameAt = null;
 		this.calNear = [];
 		this.calFar = [];
 		this.calSampleCount = 0;
+		this.asrFramesCancelled = 0;
 		this.lastAsrErleDb = null;
 	}
 


### PR DESCRIPTION
## Summary
- feed playback frames into a process-local far-end reference for timed local-ASR uploads
- send monotonic capture timing from browser local ASR so NLMS can align mic WAVs with TTS playback
- add TTS/post-TTS low-RMS capture gates in browser local ASR and Electrobun voice service while preserving loud barge-in
- fix small typecheck blockers in downloader logging, Electrobun proxy nullability, and UI fixture PostCSS typing

## Evidence
- Evidence note: `.github/issue-evidence/12256-echo-aec-evidence.md`
- Focused post-rebase tests passed:
  - `bun run --cwd plugins/plugin-local-inference test -- src/services/voice/far-end-echo-reference.test.ts src/routes/local-inference-asr-route.test.ts`
  - `bun run --cwd packages/ui test -- src/hooks/useVoiceChat.local-asr.test.tsx src/voice/voice-capture-factory.test.ts src/voice/local-asr-capture.test.ts`
  - `bun run --cwd packages/app-core/platforms/electrobun test src/voice/voice-service.test.ts`
  - `bun run --cwd plugins/plugin-local-inference typecheck`

## Root Verify
- `bun install` passed.
- `bun run verify` was attempted and failed outside this change on `@elizaos/cloud-ui#lint` import ordering in `packages/cloud-ui/src/approvals/*`, with an additional unrelated `@elizaos/cloud-shared#lint` formatting error in `packages/cloud/shared/src/lib/types/cloud-api.ts`.
- The verify run generated enough build output to fill local disk; generated artifacts were cleaned, then the focused tests above were rerun successfully.

## Remaining Evidence Before Ready
- real desktop TTS-to-mic loopback audio artifact
- frontend/backend logs from that real run
- screen recording of the desktop voice loop

Relates #12256