### PR TITLE
fix(ci): add merge queue ci-ok aggregate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [develop]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
+  merge_group:
+    branches: [develop]
+    types: [checks_requested]
   push:
     branches: [develop]
   workflow_dispatch:
@@ -64,13 +67,33 @@ jobs:
         shell: bash
         env:
           PR_LABELS: ${{ github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name, ',') || '' }}
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
         run: |
           set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME}" = "merge_group" ]; then
+            {
+              echo "server=true"
+              echo "client=true"
+              echo "plugins=true"
+              echo "desktop=true"
+              echo "zero_key=true"
+              echo "cloud=true"
+            } >> "$GITHUB_OUTPUT"
+            {
+              echo "### Tests path gate"
+              echo
+              echo "Merge queue runs validate the synthesized queue SHA, so path"
+              echo "diffs are deliberately not used. Running the full required"
+              echo "test suite for the \`ci-ok\` aggregate check."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           node packages/scripts/ci-path-gate.mjs \
             --config test \
             --event "${{ github.event_name }}" \
-            --base "${{ github.event.pull_request.base.sha }}" \
-            --head "${{ github.event.pull_request.head.sha }}" \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
             --labels "$PR_LABELS" \
             --output "$GITHUB_OUTPUT" \
             --summary "$GITHUB_STEP_SUMMARY"
@@ -1228,8 +1251,8 @@ jobs:
         if: needs.provider-live-e2e.result == 'success' && needs.provider-live-e2e.outputs.skip != 'true'
         run: bun run test:remote-capabilities:validate-live-reports --kind provider --expect-count 3..4 --max-age-minutes 120 --max-future-minutes 5 --allowed-providers e2b,home-machine,mobile-companion,desktop-companion --require-providers e2b,home-machine,mobile-companion --require-ci --require-file-identity reports/remote-capabilities/providers
 
-  test-status:
-    name: All Tests Passed
+  ci-ok:
+    name: ci-ok
     if: ${{ !cancelled() && always() }}
     needs:
       - changes
@@ -1262,7 +1285,7 @@ jobs:
           echo "provider-live-e2e:${{ needs.provider-live-e2e.result }}"
           echo "github-live-artifact-validate:${{ needs.github-live-artifact-validate.result }}"
           echo "==================================="
-          strict_results="${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}"
+          strict_results="${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}"
           bad=0
           for pair in \
             "changes:${{ needs.changes.result }}" \
@@ -1278,6 +1301,10 @@ jobs:
             "github-live-artifact-validate:${{ needs.github-live-artifact-validate.result }}"; do
             name="${pair%%:*}"
             result="${pair##*:}"
+            if [ "$name" = "github-live-artifact-validate" ] && [ "$result" = "skipped" ] && [ "${{ github.event_name }}" != "workflow_dispatch" ] && [ "${{ github.event_name }}" != "schedule" ]; then
+              echo "::notice title=Test gate::Live artifact validation is observed only on workflow_dispatch/schedule, so its skip is allowed for ${{ github.event_name }}."
+              continue
+            fi
             if [ "$name" = "github-live-artifact-validate" ] && [ "$result" = "skipped" ] && [ "${{ needs.cloud-live-e2e.outputs.capability_skip }}" = "true" ] && [ "${{ needs.provider-live-e2e.outputs.skip }}" = "true" ]; then
               echo "::notice title=Test gate::Live artifact validation skipped because no live report producers were configured."
               continue
@@ -1294,4 +1321,4 @@ jobs:
           if [ "$bad" -ne 0 ]; then
             exit 1
           fi
-          echo "All required test jobs passed."
+          echo "All required test jobs passed. Required develop ruleset check: ci-ok."

--- a/docs/CI_MERGE_QUEUE.md
+++ b/docs/CI_MERGE_QUEUE.md
@@ -1,0 +1,85 @@
+# Develop Merge Queue
+
+This document defines the agent-owned workflow contract for enabling GitHub
+merge queue on `develop`. Repository administrators still own the branch ruleset
+and queue enablement; see the `needs-human` admin issue linked from #12339.
+
+## Required Status Check
+
+Require exactly this aggregate check in the `develop` ruleset:
+
+- `ci-ok`
+
+`ci-ok` is the final job in `.github/workflows/test.yml`. It depends on every
+required job in the Tests workflow and fails when any required job result is not
+`success`, except for explicitly allowed PR-only path-gated skips.
+
+## Merge-Group Suite
+
+`merge_group` runs validate the synthesized queue SHA, not an individual PR
+diff. For that reason the Tests workflow deliberately ignores PR path-gating on
+`merge_group` and runs the full required suite:
+
+- Server Tests
+- Client Tests
+- XR harness e2e
+- Plugin Tests
+- Integration Lane (personal-assistant)
+- Electrobun Desktop Contract
+- Zero-Key deterministic E2E aggregate
+- Cloud Live E2E, when its configured secrets are present
+- Remote Capability Provider Live E2E, when its configured secrets are present
+
+Pull requests still use `packages/scripts/ci-path-gate.mjs` so small PRs can
+skip unrelated lanes, but queue entries do not.
+
+The Remote Capability GitHub Live Artifact Validator is deliberately observed
+only on `workflow_dispatch` and `schedule`, where the report-producing live
+smokes run. `ci-ok` allows that validator to be skipped on `pull_request`,
+`push`, and `merge_group` events.
+
+## Runtime Budget
+
+Initial queue target:
+
+- p95 `merge_group` runtime for `ci-ok`: 90 minutes or less
+- measurement window: 10 consecutive merge-group runs
+- if p95 exceeds the target, file follow-up issues for the longest jobs before
+  tightening the ruleset further
+
+The admin closeout evidence should include the 10-run timing report and any
+long-pole follow-ups.
+
+## Flake Policy
+
+Do not bypass `ci-ok` for a flaky job without preserving a public trail.
+
+When a merge-group run fails:
+
+1. Re-run only failed jobs once if the failure is infrastructure-shaped
+   (network reset, runner loss, package registry outage, or clearly unrelated
+   service timeout).
+2. If the rerun passes, comment on the PR or queue evidence with the failed run,
+   rerun link, and suspected external cause.
+3. If the same job flakes twice in a 24-hour window, open a focused flake issue
+   with logs and mark the job owner.
+4. If the failure is product/test logic, fix it in a PR. Do not quarantine it as
+   a flake.
+
+Temporary quarantines must include:
+
+- the tracking issue
+- the exact skipped assertion/job/lane
+- the removal condition
+- a due date or run-count limit
+
+## Admin Ruleset Checklist
+
+After the workflow PR lands, a repository admin should:
+
+1. Enable merge queue for `develop`.
+2. Require the `ci-ok` status check.
+3. Keep required-up-to-date disabled if merge queue owns the queue SHA.
+4. Use queue settings from the admin issue unless updated by measured evidence.
+5. Attach ruleset JSON, a queue-merged canary PR, a blocked red PR, and the
+   10-run timing report to the admin issue.

--- a/packages/scripts/ci-workflow-dedup-contract.mjs
+++ b/packages/scripts/ci-workflow-dedup-contract.mjs
@@ -78,6 +78,21 @@ assertDeepEqual(
   ["develop"],
   "test.yml PR branches",
 );
+assertDeepEqual(
+  parseInlineBranches(tests, "merge_group", ".github/workflows/test.yml"),
+  ["develop"],
+  "test.yml merge queue branches",
+);
+assertIncludes(
+  tests,
+  "name: ci-ok",
+  "test.yml required aggregate status",
+);
+assertIncludes(
+  tests,
+  'if [ "${GITHUB_EVENT_NAME}" = "merge_group" ]; then',
+  "test.yml merge queue path-gate bypass",
+);
 
 const scenarioPr = read(".github/workflows/scenario-pr.yml");
 assertDeepEqual(


### PR DESCRIPTION
## Summary

Fixes #12718.

Adds the agent-owned merge-queue workflow support split out of #12339:

- adds a `merge_group` trigger for `develop` to `.github/workflows/test.yml`
- makes merge-group runs bypass PR path diffs and run the full required Tests suite for the queue SHA
- exposes the single aggregate required status check as `ci-ok`
- preserves intentional live-artifact validator skips outside `workflow_dispatch` / `schedule`
- guards the trigger/check contract in `ci-workflow-dedup-contract.mjs`
- documents the admin-required check name, merge-group suite, p95 budget, and flake policy in `docs/CI_MERGE_QUEUE.md`

Repository admins should require status check: `ci-ok`.

## Validation

- `node packages/scripts/ci-workflow-dedup-contract.mjs`
- `node packages/scripts/ci-path-gate.self-test.mjs`
- `actionlint .github/workflows/test.yml`
- `git diff --check`

## Evidence / N/A

- UI screenshots/video: N/A - workflow and documentation only.
- Model trajectories: N/A - no agent/model behavior changed.
- Runtime domain artifacts: N/A - merge queue ruleset enablement remains in #12719.
