### PR TITLE
docs(#12241): add straggler package headers

### DIFF
--- a/packages/browser-extension/src/test-dom-setup.ts
+++ b/packages/browser-extension/src/test-dom-setup.ts
@@ -1,5 +1,6 @@
-// Preload for bun test: install a minimal jsdom DOM on globalThis.
-// Loaded via `bun test --preload ./src/test-dom-setup.ts`.
+/**
+ * Bun test preload that installs a minimal jsdom browser surface on globalThis.
+ */
 import { JSDOM } from "jsdom";
 
 const dom = new JSDOM(

--- a/packages/contracts/vitest.config.ts
+++ b/packages/contracts/vitest.config.ts
@@ -1,3 +1,6 @@
+/**
+ * Vitest configuration for the declaration-only contracts package.
+ */
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({

--- a/packages/research/chip/scripts/tee/verify_cove_quote_roundtrip.mjs
+++ b/packages/research/chip/scripts/tee/verify_cove_quote_roundtrip.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-/*
+/**
  * Cross-language round-trip proof for the E1 CoVE attestation-quote firmware.
  *
  * Builds the host KAT (fw/dice/test_cove_quote), captures the canonical

--- a/packages/research/robot/eliza_robot/perception/tracking_visualizer/ar_overlay.js
+++ b/packages/research/robot/eliza_robot/perception/tracking_visualizer/ar_overlay.js
@@ -1,6 +1,10 @@
-// ---- Three.js AR overlay: trees, character, sphere on camera feed ----
-// Loaded as ES module. Uses inverse homography + solvePnP camera pose
-// to align 3D objects with the real camera view.
+/**
+ * Three.js AR overlay for aligning virtual scene objects with the robot camera
+ * feed.
+ *
+ * The module consumes inverse homography and solvePnP pose estimates from the
+ * tracking visualizer so rendered objects share the real camera projection.
+ */
 
 import * as THREE from "three";
 import { OrbitControls } from "three/addons/controls/OrbitControls.js";

--- a/packages/training/scripts/publish/eliza1-hf-stage.mjs
+++ b/packages/training/scripts/publish/eliza1-hf-stage.mjs
@@ -1,24 +1,25 @@
 #!/usr/bin/env node
-// eliza1-hf-stage.mjs — Node entry around the Eliza-1 per-tier HF publisher.
-//
-// Walks every tier in `ELIZA_1_TIERS` (resolved by the Python publisher),
-// asks `scripts.publish.publish_eliza1_model_repo` to plan each
-// `<bundles-root>/eliza-1-<tier>.bundle/` directory, and prints the
-// resulting plan + JSON report. **Dry-run by default** — this script
-// never invokes the actual HF upload path. To push, run
-// `eliza1-hf-push.sh` with `HF_TOKEN` set AND `--yes-i-will-pay`.
-//
-// Usage:
-//   node packages/training/scripts/publish/eliza1-hf-stage.mjs
-//   node packages/training/scripts/publish/eliza1-hf-stage.mjs --dry-run
-//   node packages/training/scripts/publish/eliza1-hf-stage.mjs --bundles-root ~/staging
-//   node packages/training/scripts/publish/eliza1-hf-stage.mjs --report /tmp/plan.json
-//   node packages/training/scripts/publish/eliza1-hf-stage.mjs --tier 2b --tier 4b
-//
-// Exit codes mirror the Python publisher:
-//   0 — every tier uploadable (or --allow-missing was passed)
-//   2 — at least one tier has unresolved blockers (default behaviour)
-//   other — Python launch / interpreter failure
+/**
+ * Node entrypoint around the Eliza-1 per-tier HuggingFace staging publisher.
+ *
+ * Walks every tier in `ELIZA_1_TIERS` (resolved by the Python publisher), asks
+ * `scripts.publish.publish_eliza1_model_repo` to plan each
+ * `<bundles-root>/eliza-1-<tier>.bundle/` directory, and prints the resulting
+ * plan plus JSON report. Dry-run is the default; actual uploads remain behind
+ * `eliza1-hf-push.sh` with `HF_TOKEN` and `--yes-i-will-pay`.
+ *
+ * Usage:
+ *   node packages/training/scripts/publish/eliza1-hf-stage.mjs
+ *   node packages/training/scripts/publish/eliza1-hf-stage.mjs --dry-run
+ *   node packages/training/scripts/publish/eliza1-hf-stage.mjs --bundles-root ~/staging
+ *   node packages/training/scripts/publish/eliza1-hf-stage.mjs --report /tmp/plan.json
+ *   node packages/training/scripts/publish/eliza1-hf-stage.mjs --tier 2b --tier 4b
+ *
+ * Exit codes mirror the Python publisher:
+ *   0 - every tier uploadable (or --allow-missing was passed)
+ *   2 - at least one tier has unresolved blockers (default behaviour)
+ *   other - Python launch / interpreter failure
+ */
 
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";


### PR DESCRIPTION
## Summary
- Add or normalize required top-of-file prose headers for five remaining B11 straggler files across research, contracts, browser-extension, and training.
- Convert existing useful top comments in the CoVE quote round-trip proof, robot AR overlay, browser extension jsdom preload, and Eliza-1 HF staging script into the required prose block form.
- Comment-only cleanup for #12241; no code or string literal behavior changed.

## Verification
- `bun run check:comment-only` PASS: 5 source files changed; every code token identical to `origin/develop`.
- `bunx @biomejs/biome check <5 touched files>` PASS with pre-existing warnings in `packages/research/robot/eliza_robot/perception/tracking_visualizer/ar_overlay.js` for unused imports/locals.
- `node --check packages/research/chip/scripts/tee/verify_cove_quote_roundtrip.mjs && node --check packages/research/robot/eliza_robot/perception/tracking_visualizer/ar_overlay.js && node --check packages/training/scripts/publish/eliza1-hf-stage.mjs` PASS.
- `bun run --cwd packages/contracts typecheck` PASS.
- `git diff --check` PASS.
- First-line header audit for touched files PASS.
- `bun run verify` FAILS outside this change in `@elizaos/cloud-shared#typecheck`: TypeScript resolves `drizzle-orm` from `dist/node_modules/drizzle-orm` without declaration files, causing TS7016 plus implicit-any fallout in `plugins/plugin-sql/src/schema/*`.

## Evidence
- Screenshots/video: N/A - comment-only header cleanup; `check:comment-only` proves runtime tokens are unchanged.
- Backend/frontend logs: N/A - no executable behavior changed.
- Real-LLM trajectories: N/A - no agent, prompt, model, provider, or evaluator behavior changed.
- Domain artifacts: N/A - no model, chain, hardware, or generated artifact behavior changed.
