### PR TITLE
fix(#12320): harden quant recipe reality gates

### DIFF
--- a/.github/issue-evidence/12320-stage3-quant-recipe-reality.md
+++ b/.github/issue-evidence/12320-stage3-quant-recipe-reality.md
@@ -1,0 +1,72 @@
+# Stage 3 Quant/GGUF Recipe Reality Evidence
+
+Issue: #12320
+Date: 2026-07-04
+
+## What Was Verified
+
+- `packages/training/AGENTS.md` §3 now names the shipping Gemma weight quant as stock `llama-quantize` `Q4_K_M`, and distinguishes recipe roles:
+  - TurboQuant: runtime KV-cache compressor.
+  - QJL: runtime K-cache compressor.
+  - PolarQuant: weight quantizer.
+- Quantization converter callers now resolve the canonical fork at `plugins/plugin-local-inference/native/llama.cpp` when `LLAMA_CPP_DIR` is unset.
+- `_kernel_manifest.py` emits real `sha256:<digest>` pins for kernel/reference source files and verifies them before emitting recipe manifest fragments.
+- `gguf-q4_k_m_apply.py` treats the post-quantize `llama-cli` load-smoke as a release-suitable recipe gate: failure exits non-zero before writing `gguf_q4_k_m.json`; success records `recipe_test`.
+- `gguf_eliza1_apply.py` records `recipeStatus` separately from `recipeManifest`, so legacy sidecars are not cited as provenance unless the produced artifact actually uses the corresponding recipe.
+
+## Commands Run
+
+```bash
+uv run --project packages/training --with pytest --with transformers --with safetensors -- \
+  python -m pytest \
+  packages/training/scripts/quantization/test_gguf_eliza1_apply.py \
+  packages/training/scripts/quantization/test_recipes_smoke.py
+```
+
+Result after rebasing over #12706: `60 passed, 1 warning in 19.76s`.
+
+```bash
+uv run --project packages/training -- python -m compileall -q \
+  packages/training/scripts/quantization \
+  packages/training/scripts/turn_detector/convert_to_gguf.py \
+  packages/training/scripts/run_pipeline.py
+```
+
+Result: passed.
+
+```bash
+uv run --project packages/training --with transformers --with safetensors -- \
+  python packages/training/scripts/quantization/gguf-q4_k_m_apply.py \
+  --model google/gemma-4-E2B \
+  --output /tmp/eliza-stage3-q4-dry \
+  --dry-run
+```
+
+Result: dry-run JSON reported `quant_level: "Q4_K_M"` and `smoke_load: true`.
+
+```bash
+tmpdir=$(mktemp -d)
+mkdir -p "$tmpdir/checkpoint" "$tmpdir/llama.cpp"
+printf '# supports Q4_POLAR\n' > "$tmpdir/llama.cpp/convert_hf_to_gguf.py"
+uv run --project packages/training --with transformers --with safetensors -- \
+  python packages/training/scripts/quantization/gguf_eliza1_apply.py \
+  --checkpoint "$tmpdir/checkpoint" \
+  --output "$tmpdir/model.gguf" \
+  --outtype q8_0 \
+  --llama-cpp-dir "$tmpdir/llama.cpp" \
+  --dry-run
+```
+
+Result: dry-run JSON included `recipeStatus` for each legacy sidecar type and no `recipeManifest`.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Remaining Real-Path Evidence Blockers
+
+- No real 2B checkpoint was quantized in this local run. The required byte-level GGUF header dump and corrupt-block publish-blocking proof still need a built `plugins/plugin-local-inference/native/llama.cpp` fork with `llama-quantize` and `llama-cli`, plus the actual Gemma checkpoint bytes.
+- No screenshots or screen recordings apply: this is a CLI/training pipeline change with no UI surface.
+- No live model trajectories apply: this change does not alter agent prompts, model routing, or generation behavior.

--- a/packages/training/AGENTS.md
+++ b/packages/training/AGENTS.md
@@ -80,62 +80,65 @@ is published.
 
 ---
 
-## 3. Quantization (mandatory recipes)
+## 3. Quantization (recipe reality)
 
-Quantization is not optional for Eliza-1. Every published bundle MUST
-flow through every recipe that is actually applicable to the tier and
-runtime. The active Gemma 4 release path uses stock llama.cpp GGUF
-weight quantization (`llama-quantize` Q4_K_M today) for the shipped
-text GGUF unless a recipe below is explicitly applied and verified for
-that tier. Sidecar presence is not proof that a recipe touched the
-bytes.
+Quantization is not optional for Eliza-1, but the active Gemma release
+line does not use the old fused Qwen-style recipe stack as its shipping
+weight artifact. The shipping Gemma weight quant is stock
+`llama-quantize` Q4_K_M produced through
+`scripts/quantization/gguf-q4_k_m_apply.py` from the canonical fork at
+`plugins/plugin-local-inference/native/llama.cpp`. Higher-quality ladder
+rungs (`Q6_K`, `Q8_0`) are produced the same way when a tier explicitly
+requires them.
 
-Pipeline order (binding):
+Recipe roles, as implemented:
 
-```
-fp16/bf16 checkpoint
-   │
-   ├── Stock GGUF weight quantization (shipping Gemma path today)
-   │     convert_hf_to_gguf.py → llama-quantize Q4_K_M
-   │
-   ├── TurboQuant Q3 or Q4 KV-cache compression (V-cache)
-   │     scripts/quantization/turboquant_apply.py
-   │     scripts/quantization/fused_turboquant_apply.py
-   │
-   ├── QJL projection matrices baked into KV-cache layout
-   │     scripts/quantization/qjl_apply.py
-   │
-   ├── PolarQuant weight quantization (linear weights)
-   │     scripts/quantization/polarquant_apply.py
-   │
-   └── (long-context-only) Trellis-coded TCQ KV K-type
-         scripts/quantization/turboquant_apply.py --trellis
-```
+| Recipe | What it actually changes | Entry point |
+| ------ | ------------------------ | ----------- |
+| GGUF K-quant | Weight tensors in the produced GGUF (`Q4_K_M` today for shipping Gemma) | `scripts/quantization/gguf-q4_k_m_apply.py` |
+| TurboQuant | Runtime KV-cache compressor for V-cache blocks; weights are unchanged | `scripts/quantization/turboquant_apply.py` / `fused_turboquant_apply.py` |
+| QJL | Runtime K-cache compressor with JL projection geometry; weights are unchanged | `scripts/quantization/qjl_apply.py` |
+| PolarQuant | Weight quantizer for `nn.Linear` tensors, emitting reconstructed weights plus `polarquant_artifacts.safetensors`; not a Gemma default release gate today | `scripts/quantization/polarquant_apply.py` |
+| TCQ | Long-context TurboQuant K-cache type (`turbo3_tcq`); weights are unchanged | `scripts/quantization/turboquant_apply.py --trellis` |
+
+TurboQuant is a runtime KV-cache compressor. QJL is a runtime K-cache compressor.
+PolarQuant is a weight quantizer. Do not describe
+TurboQuant as weight quantization or PolarQuant as a KV-cache pass.
 
 Hard rules:
 
-- Each recipe MUST emit a quantization manifest sidecar consumed by
-  the inference manifest builder. The sidecar records: kernel target,
-  block layout version, codebook hash, expected per-block tolerance.
-- Each recipe MUST run its `test_*.py` against the produced artifact
-  before exit. A failing test is a publish-blocking error.
-- If a recipe is asked to run on weights that do not satisfy its
-  preconditions (wrong layer count, wrong dtype, missing rotation), it
-  MUST fail loudly. No silent passes, no skip-and-continue.
+- A sidecar is provenance only for a recipe that actually ran against
+  the artifact or is explicitly enabled for that tier. Sidecar presence
+  alone is not proof. A recipe that is not applied to a tier MUST NOT
+  contribute `recipeManifest` metadata for that tier.
+- Every applied recipe MUST emit a quantization manifest fragment
+  consumed by the inference manifest builder. The fragment records:
+  kernel target, block layout version, real source-content sha256,
+  expected per-block tolerance, and target class (`weights` or
+  `kv-cache`).
+- Every applied recipe MUST run its real-artifact test before exit. For
+  the shipping Q4_K_M path, `gguf-q4_k_m_apply.py` runs a
+  `llama-cli` load-smoke against the produced GGUF and refuses to write
+  a release-suitable sidecar when it fails. A failing test is a
+  publish-blocking error.
+- If a recipe is asked to run on weights or cache geometry that do not
+  satisfy its preconditions (wrong layer count, wrong dtype, missing
+  rotation, unsupported layer type, missing converter/kernel), it MUST
+  fail loudly. No silent passes, no skip-and-continue.
 
-Gemma note: Gemma 4's KV cache is already minimal (MQA + windowed-SWA +
-shared-KV), and its dual head dims do not match the older head_dim=128
-QJL/Polar KV assumptions. QJL and TurboQuant KV passes are optional for
-Gemma tiers until revalidated per tier. PolarQuant is a weight recipe,
-not a KV-cache recipe. The shipping Gemma text GGUF currently uses stock
-Q4_K_M weight quantization; if PolarQuant is enabled for a tier, the
-produced GGUF and manifest must prove those bytes are PolarQuant bytes.
+Gemma note: QJL/PolarQuant are low-ROI on Gemma 4's already-minimal KV
+(MQA + windowed-SWA + shared-KV), so the KV-cache QJL/TurboQuant passes
+and PolarQuant weight path are optional-and-currently-unused on Gemma
+release tiers unless a tier explicitly opts in and carries real
+recipe-test evidence.
 
 The reference implementations and on-device kernels live in
+`plugins/plugin-local-inference/native/{reference,verify}` and
 `packages/native/plugins/{qjl-cpu,polarquant-cpu}`. The Python recipes here
 MUST stay byte-for-byte compatible with those references — when a
 recipe's block layout, codebook, or sign-vector seed changes, the
-references and kernels must be updated in lockstep, in the same PR.
+references, kernels, and `_kernel_manifest.py` sha256 pins must be
+updated in lockstep, in the same PR.
 
 ---
 

--- a/packages/training/CLAUDE.md
+++ b/packages/training/CLAUDE.md
@@ -80,62 +80,65 @@ is published.
 
 ---
 
-## 3. Quantization (mandatory recipes)
+## 3. Quantization (recipe reality)
 
-Quantization is not optional for Eliza-1. Every published bundle MUST
-flow through every recipe that is actually applicable to the tier and
-runtime. The active Gemma 4 release path uses stock llama.cpp GGUF
-weight quantization (`llama-quantize` Q4_K_M today) for the shipped
-text GGUF unless a recipe below is explicitly applied and verified for
-that tier. Sidecar presence is not proof that a recipe touched the
-bytes.
+Quantization is not optional for Eliza-1, but the active Gemma release
+line does not use the old fused Qwen-style recipe stack as its shipping
+weight artifact. The shipping Gemma weight quant is stock
+`llama-quantize` Q4_K_M produced through
+`scripts/quantization/gguf-q4_k_m_apply.py` from the canonical fork at
+`plugins/plugin-local-inference/native/llama.cpp`. Higher-quality ladder
+rungs (`Q6_K`, `Q8_0`) are produced the same way when a tier explicitly
+requires them.
 
-Pipeline order (binding):
+Recipe roles, as implemented:
 
-```
-fp16/bf16 checkpoint
-   │
-   ├── Stock GGUF weight quantization (shipping Gemma path today)
-   │     convert_hf_to_gguf.py → llama-quantize Q4_K_M
-   │
-   ├── TurboQuant Q3 or Q4 KV-cache compression (V-cache)
-   │     scripts/quantization/turboquant_apply.py
-   │     scripts/quantization/fused_turboquant_apply.py
-   │
-   ├── QJL projection matrices baked into KV-cache layout
-   │     scripts/quantization/qjl_apply.py
-   │
-   ├── PolarQuant weight quantization (linear weights)
-   │     scripts/quantization/polarquant_apply.py
-   │
-   └── (long-context-only) Trellis-coded TCQ KV K-type
-         scripts/quantization/turboquant_apply.py --trellis
-```
+| Recipe | What it actually changes | Entry point |
+| ------ | ------------------------ | ----------- |
+| GGUF K-quant | Weight tensors in the produced GGUF (`Q4_K_M` today for shipping Gemma) | `scripts/quantization/gguf-q4_k_m_apply.py` |
+| TurboQuant | Runtime KV-cache compressor for V-cache blocks; weights are unchanged | `scripts/quantization/turboquant_apply.py` / `fused_turboquant_apply.py` |
+| QJL | Runtime K-cache compressor with JL projection geometry; weights are unchanged | `scripts/quantization/qjl_apply.py` |
+| PolarQuant | Weight quantizer for `nn.Linear` tensors, emitting reconstructed weights plus `polarquant_artifacts.safetensors`; not a Gemma default release gate today | `scripts/quantization/polarquant_apply.py` |
+| TCQ | Long-context TurboQuant K-cache type (`turbo3_tcq`); weights are unchanged | `scripts/quantization/turboquant_apply.py --trellis` |
+
+TurboQuant is a runtime KV-cache compressor. QJL is a runtime K-cache compressor.
+PolarQuant is a weight quantizer. Do not describe
+TurboQuant as weight quantization or PolarQuant as a KV-cache pass.
 
 Hard rules:
 
-- Each recipe MUST emit a quantization manifest sidecar consumed by
-  the inference manifest builder. The sidecar records: kernel target,
-  block layout version, codebook hash, expected per-block tolerance.
-- Each recipe MUST run its `test_*.py` against the produced artifact
-  before exit. A failing test is a publish-blocking error.
-- If a recipe is asked to run on weights that do not satisfy its
-  preconditions (wrong layer count, wrong dtype, missing rotation), it
-  MUST fail loudly. No silent passes, no skip-and-continue.
+- A sidecar is provenance only for a recipe that actually ran against
+  the artifact or is explicitly enabled for that tier. Sidecar presence
+  alone is not proof. A recipe that is not applied to a tier MUST NOT
+  contribute `recipeManifest` metadata for that tier.
+- Every applied recipe MUST emit a quantization manifest fragment
+  consumed by the inference manifest builder. The fragment records:
+  kernel target, block layout version, real source-content sha256,
+  expected per-block tolerance, and target class (`weights` or
+  `kv-cache`).
+- Every applied recipe MUST run its real-artifact test before exit. For
+  the shipping Q4_K_M path, `gguf-q4_k_m_apply.py` runs a
+  `llama-cli` load-smoke against the produced GGUF and refuses to write
+  a release-suitable sidecar when it fails. A failing test is a
+  publish-blocking error.
+- If a recipe is asked to run on weights or cache geometry that do not
+  satisfy its preconditions (wrong layer count, wrong dtype, missing
+  rotation, unsupported layer type, missing converter/kernel), it MUST
+  fail loudly. No silent passes, no skip-and-continue.
 
-Gemma note: Gemma 4's KV cache is already minimal (MQA + windowed-SWA +
-shared-KV), and its dual head dims do not match the older head_dim=128
-QJL/Polar KV assumptions. QJL and TurboQuant KV passes are optional for
-Gemma tiers until revalidated per tier. PolarQuant is a weight recipe,
-not a KV-cache recipe. The shipping Gemma text GGUF currently uses stock
-Q4_K_M weight quantization; if PolarQuant is enabled for a tier, the
-produced GGUF and manifest must prove those bytes are PolarQuant bytes.
+Gemma note: QJL/PolarQuant are low-ROI on Gemma 4's already-minimal KV
+(MQA + windowed-SWA + shared-KV), so the KV-cache QJL/TurboQuant passes
+and PolarQuant weight path are optional-and-currently-unused on Gemma
+release tiers unless a tier explicitly opts in and carries real
+recipe-test evidence.
 
 The reference implementations and on-device kernels live in
+`plugins/plugin-local-inference/native/{reference,verify}` and
 `packages/native/plugins/{qjl-cpu,polarquant-cpu}`. The Python recipes here
 MUST stay byte-for-byte compatible with those references — when a
 recipe's block layout, codebook, or sign-vector seed changes, the
-references and kernels must be updated in lockstep, in the same PR.
+references, kernels, and `_kernel_manifest.py` sha256 pins must be
+updated in lockstep, in the same PR.
 
 ---
 

--- a/packages/training/README.md
+++ b/packages/training/README.md
@@ -31,11 +31,15 @@ arXiv:2412.05270), not LoRA.
 | gemma4-12b   | eliza-1-9b    | google/gemma-4-12B | workstation | 80 GB-class GPU                     | apollo       |
 | gemma4-31b   | eliza-1-27b   | google/gemma-4-31B | cloud       | 2x H200 / B200                      | apollo       |
 
-After training, the Gemma publish path produces GGUF q4/q6/q8 release
-artifacts and MTP drafter manifests for speculative decoding. The older KV
-compression recipes (**PolarQuant**, **TurboQuant**, and **QJL**) remain in
-the tree for legacy experiments, but Gemma 4's MQA + windowed SWA KV layout
-makes them optional rather than required release gates.
+After training, the Gemma publish path produces stock llama.cpp GGUF
+K-quant release artifacts (`Q4_K_M` for the shipping local tier, plus
+`Q6_K` / `Q8_0` where a tier explicitly requires them) and MTP drafter
+manifests for speculative decoding. The older recipe stack is split by
+what it actually changes: **TurboQuant** and **QJL** are runtime KV-cache
+compressors, while **PolarQuant** is a weight quantizer. Gemma 4's MQA +
+windowed SWA KV layout makes those optional rather than default release
+gates, and a sidecar is not publish provenance unless the recipe actually
+ran for that tier.
 
 A unified pipeline runner (`scripts/run_pipeline.py`) chains:
 
@@ -79,7 +83,7 @@ data/raw/* ──▶ normalize.py ──▶ data/normalized/<slug>.jsonl
                                   ▼
               ┌─────────────┬─────┴─────┬─────────────┐
               ▼             ▼           ▼             ▼
-       GGUF release staging  MTP drafter verify  optional legacy KV recipes
+       GGUF release K-quant  MTP drafter verify  optional recipe experiments
                                   │
                                   ▼
                           native_tool_call_bench.py

--- a/packages/training/scripts/quantization/README.md
+++ b/packages/training/scripts/quantization/README.md
@@ -7,10 +7,11 @@ and can be combined or compared on the same fine-tuned checkpoint.
 
 > **Gemma 4 cutover note.** The eliza-1 base is now Gemma 4 (dense:
 > alternating SWA/global, shared-KV, MQA, dual head dims 512/256, stock q8_0
-> KV). Gemma geometry is the active release target. TurboQuant remains the
-> primary recipe; KV-cache QJL/Polar passes are optional for Gemma tiers and
-> must be revalidated per tier because older 128-dim assumptions do not match
-> every Gemma target.
+> KV). Gemma geometry is the active release target. The shipping Gemma weight
+> quant is stock llama.cpp `Q4_K_M` from `gguf-q4_k_m_apply.py`; TurboQuant
+> and QJL are runtime KV-cache experiments, and PolarQuant is a separate
+> weight-quant experiment. Those optional paths must be revalidated per tier
+> before their sidecars can be cited as release provenance.
 
 ## PolarQuant
 

--- a/packages/training/scripts/quantization/_common.py
+++ b/packages/training/scripts/quantization/_common.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
+import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Mapping
 
@@ -28,6 +30,76 @@ if TYPE_CHECKING:
     from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 log = logging.getLogger(__name__)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+LLAMA_CPP_RELATIVE_DIR = Path("plugins/plugin-local-inference/native/llama.cpp")
+DEFAULT_LLAMA_CPP_DIR = REPO_ROOT / LLAMA_CPP_RELATIVE_DIR
+
+
+def llama_cpp_vendor_hint() -> str:
+    """Actionable setup text for callers that need the in-repo llama.cpp fork."""
+    rel = LLAMA_CPP_RELATIVE_DIR.as_posix()
+    return (
+        "The llama.cpp fork submodule should already be checked out. If it's "
+        "missing:\n"
+        f"  git submodule update --init {rel}\n"
+        "Then build the llama-quantize + llama-cli binaries from it "
+        "(one-shot, CPU-only is enough):\n"
+        f"  cmake -S {rel} -B {rel}/build \\\n"
+        "        -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF "
+        "-DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF\n"
+        f"  cmake --build {rel}/build --target llama-quantize llama-cli "
+        '-j"$(nproc)"\n'
+        "Or pass --llama-cpp-dir <path-to-checkout> / set LLAMA_CPP_DIR / "
+        "put the binaries on PATH.\n"
+        "(convert_hf_to_gguf.py needs the `gguf` + `mistral_common` python "
+        f"deps; `uv pip install -r {rel}/requirements/"
+        "requirements-convert_hf_to_gguf.txt`.)"
+    )
+
+
+def _llama_cpp_dirs(llama_cpp_dir: Path | None) -> list[Path]:
+    """Candidate llama.cpp checkout roots in release-safe resolution order."""
+    candidates: list[Path] = []
+    if llama_cpp_dir is not None:
+        candidates.append(llama_cpp_dir)
+    env_dir = os.environ.get("LLAMA_CPP_DIR")
+    if env_dir:
+        candidates.append(Path(env_dir))
+    candidates.append(DEFAULT_LLAMA_CPP_DIR)
+    return candidates
+
+
+def find_llama_convert_script(llama_cpp_dir: Path | None) -> Path:
+    """Locate ``convert_hf_to_gguf.py`` from the canonical fork or PATH."""
+    candidates = [d / "convert_hf_to_gguf.py" for d in _llama_cpp_dirs(llama_cpp_dir)]
+    which = shutil.which("convert_hf_to_gguf.py")
+    if which:
+        candidates.append(Path(which))
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    raise SystemExit("convert_hf_to_gguf.py not found.\n" + llama_cpp_vendor_hint())
+
+
+def find_llama_quantize_binary(llama_cpp_dir: Path | None) -> Path:
+    """Locate ``llama-quantize`` from the canonical fork build or PATH."""
+    candidates: list[Path] = []
+    for directory in _llama_cpp_dirs(llama_cpp_dir):
+        candidates.extend(
+            [
+                directory / "build" / "bin" / "llama-quantize",
+                directory / "llama-quantize",
+            ]
+        )
+    which = shutil.which("llama-quantize")
+    if which:
+        candidates.append(Path(which))
+    for candidate in candidates:
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return candidate
+    raise SystemExit("llama-quantize binary not found.\n" + llama_cpp_vendor_hint())
 
 
 def is_lora_dir(path: Path) -> bool:
@@ -107,10 +179,14 @@ def write_sidecar(output_dir: Path, filename: str, payload: Mapping[str, object]
 # while unit tests can import the helper without pulling in transformers.
 from _kernel_manifest import (  # noqa: E402,F401
     KERNEL_BLOCK_LAYOUT_VERSIONS,
+    KERNEL_CODEBOOK_HASH_SOURCES,
     KERNEL_CODEBOOK_HASHES,
     KERNEL_PER_BLOCK_TOLERANCE,
+    KERNEL_RECIPE_TARGET_CLASSES,
     KERNEL_TARGETS,
+    PINNED_KERNEL_CODEBOOK_SHA256,
     kernel_manifest_fragment,
+    verify_kernel_codebook_hashes,
 )
 
 

--- a/packages/training/scripts/quantization/_kernel_manifest.py
+++ b/packages/training/scripts/quantization/_kernel_manifest.py
@@ -6,9 +6,10 @@ codebook hash, expected per-block tolerance. The fragment is consumed by
 the inference manifest builder at publish time.
 
 This module owns the canonical pin between training-side recipes and the
-kernel references in packages/native/plugins/{turboquant-cpu,qjl-cpu,
-polarquant-cpu}/. When a kernel constant changes, the matching value here MUST
-be bumped in lockstep, otherwise the publish gate's parity tests fail.
+kernel references in ``plugins/plugin-local-inference/native/{reference,verify}``
+and ``packages/native/plugins/{qjl-cpu,polarquant-cpu}``. When a kernel
+constant changes, the matching pinned sha256 here MUST be bumped in lockstep,
+otherwise recipe sidecar generation fails.
 
 The helper has no torch/transformers imports so unit tests can validate
 manifest correctness without loading a model.
@@ -17,106 +18,35 @@ manifest correctness without loading a model.
 from __future__ import annotations
 
 import hashlib
-import re
 from pathlib import Path
-
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
-def _sha256_file(relpath: str) -> str:
-    path = _REPO_ROOT / relpath
-    if not path.is_file():
-        raise RuntimeError(f"kernel codebook hash source missing: {path}")
-    return hashlib.sha256(path.read_bytes()).hexdigest()
-
-
-def _sha256_c_initializer(relpath: str, symbol: str) -> str:
-    path = _REPO_ROOT / relpath
-    if not path.is_file():
-        raise RuntimeError(f"kernel codebook hash source missing: {path}")
-    text = path.read_text(encoding="utf-8")
-    match = re.search(
-        rf"(?:static\s+)?const\s+(?:float|int8_t)\s+{re.escape(symbol)}"
-        r"\s*\[[^\]]+\]\s*=\s*\{(?P<body>.*?)\}\s*;",
-        text,
-        flags=re.DOTALL,
-    )
-    if match is None:
-        raise RuntimeError(f"kernel codebook symbol {symbol!r} missing in {path}")
-    normalized = re.sub(r"\s+", " ", match.group(0).strip()).encode("utf-8")
-    return hashlib.sha256(normalized).hexdigest()
-
-
-KERNEL_CODEBOOK_HASH_SOURCES: dict[str, tuple[str, str | None]] = {
-    "turbo3": (
-        "packages/native/plugins/turboquant-cpu/src/tbq_block_ref.c",
-        "TBQ3_CODEBOOK",
-    ),
-    "turbo4": (
-        "packages/native/plugins/turboquant-cpu/src/tbq_block_ref.c",
-        "TBQ4_CODEBOOK",
-    ),
-    "turbo3_tcq": (
-        "plugins/plugin-local-inference/native/reference/turbo_kernels.c",
-        "ELIZA_TURBO3_TCQ_CODEBOOK",
-    ),
+# Content hashed for each target. QJL has no centroid table; its pin covers the
+# public block-layout header that defines the 34-byte qjl1_256 cache record.
+KERNEL_CODEBOOK_HASH_SOURCES = {
+    "turbo3": ("plugins/plugin-local-inference/native/reference/turbo_kernels.c",),
+    "turbo4": ("plugins/plugin-local-inference/native/reference/turbo_kernels.c",),
+    "turbo3_tcq": ("plugins/plugin-local-inference/native/reference/turbo_kernels.c",),
     "polar_q4": (
         "packages/native/plugins/polarquant-cpu/include/polarquant/polar_centroids.h",
-        "POLAR_Q4_CENTROIDS",
     ),
-    # QJL is sign-only: there is no centroid table. Its manifest hash pins the
-    # public packed-layout header that defines QJL_PACKED_BYTES, projection
-    # dimensions, and qjl_block_qjl1_256.
-    "qjl1_256": ("packages/native/plugins/qjl-cpu/include/qjl/qjl.h", None),
+    "qjl1_256": ("packages/native/plugins/qjl-cpu/include/qjl/qjl.h",),
 }
 
+
 PINNED_KERNEL_CODEBOOK_SHA256 = {
-    "turbo3": "edc3ccfadf06e038e79d9dd763b89a6fb359742521ddf1950fe7b40fe55f0a5e",
-    "turbo4": "2e8b3c0c2668f3e2243734a0b679ea57d333b5509fea097122afce8066b959a5",
-    "turbo3_tcq": "df82e32eed0df23f5a88fe9afbb077a03e3067c8690dcc55997ad01fb54e96be",
-    "polar_q4": "cce740dff7143a258ea01a482a539f2485acc959895e8dbc3ce2945f034ec329",
+    "turbo3": "d2fe34ddf270c3de0ea78dc840bf18f8bc9c9175c32489700ed62e70c7a95429",
+    "turbo4": "d2fe34ddf270c3de0ea78dc840bf18f8bc9c9175c32489700ed62e70c7a95429",
+    "turbo3_tcq": "d2fe34ddf270c3de0ea78dc840bf18f8bc9c9175c32489700ed62e70c7a95429",
+    "polar_q4": "6f0e9e204f10df190385e8f0f60055db2adbfabc611ade503be3f888eb04d399",
     "qjl1_256": "84048dea7812cf87e0c002aa2be69443e4228c10b326a9e5b1aa2d3668fbab58",
 }
 
-
-def compute_kernel_codebook_sha256() -> dict[str, str]:
-    """Return current sha256 digests from the kernel reference sources."""
-    out: dict[str, str] = {}
-    for target, (relpath, symbol) in KERNEL_CODEBOOK_HASH_SOURCES.items():
-        out[target] = (
-            _sha256_file(relpath)
-            if symbol is None
-            else _sha256_c_initializer(relpath, symbol)
-        )
-    return out
-
-
-def assert_kernel_codebook_hashes_current() -> dict[str, str]:
-    """Fail loudly if a committed kernel codebook/layout source drifted.
-
-    The manifest must not emit stale hand-written labels. A source constant
-    change needs a matching pinned digest update in the same PR so the publish
-    gate can prove recipe/kernel parity from content hashes.
-    """
-    current = compute_kernel_codebook_sha256()
-    mismatches = {
-        target: (PINNED_KERNEL_CODEBOOK_SHA256[target], observed)
-        for target, observed in current.items()
-        if PINNED_KERNEL_CODEBOOK_SHA256[target] != observed
-    }
-    if mismatches:
-        detail = ", ".join(
-            f"{target}: pinned={pinned} observed={observed}"
-            for target, (pinned, observed) in sorted(mismatches.items())
-        )
-        raise RuntimeError(f"kernel codebook hash drift: {detail}")
-    return current
-
-
-KERNEL_CODEBOOK_SHA256 = assert_kernel_codebook_hashes_current()
 KERNEL_CODEBOOK_HASHES = {
-    target: f"sha256:{digest}" for target, digest in KERNEL_CODEBOOK_SHA256.items()
+    target: f"sha256:{digest}"
+    for target, digest in PINNED_KERNEL_CODEBOOK_SHA256.items()
 }
 
 # Block layout versions. A non-backward-compatible change to any of these
@@ -140,6 +70,13 @@ KERNEL_TARGETS = {
     "polarquant": ["polar_q4"],
 }
 
+KERNEL_RECIPE_TARGET_CLASSES = {
+    "turboquant": "kv-cache",
+    "fused-turboquant": "kv-cache",
+    "qjl": "kv-cache",
+    "polarquant": "weights",
+}
+
 # Expected per-block tolerance (max-abs reconstruction error vs fp32) at the
 # canonical settings. Used by the verify/* harnesses and the publish gate.
 # Numbers come from the published papers + the verify/ harness self-test.
@@ -149,6 +86,46 @@ KERNEL_PER_BLOCK_TOLERANCE = {
     "turbo3_tcq": 3.0e-2,     # 3-bit trellis, 512-state Viterbi
     "qjl1_256": 5.0e-2,       # 1-bit JL — sign-only, looser tol
     "polar_q4": 1.0e-3,       # 4-bit Lloyd-Max + Hadamard, near-lossless
+}
+
+
+def _sha256_sources(relative_paths: tuple[str, ...]) -> str:
+    """Hash one or more source files in the order declared for a target."""
+    digest = hashlib.sha256()
+    for rel in relative_paths:
+        path = _REPO_ROOT / rel
+        if not path.is_file():
+            raise RuntimeError(f"kernel hash source missing: {rel}")
+        digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def verify_kernel_codebook_hashes(
+    targets: list[str] | tuple[str, ...] | None = None,
+) -> dict[str, str]:
+    """Return actual source sha256 values, failing if any pin has drifted."""
+    selected = list(targets) if targets is not None else sorted(KERNEL_TARGETS_BY_NAME)
+    actual: dict[str, str] = {}
+    errors: list[str] = []
+    for target in selected:
+        sources = KERNEL_CODEBOOK_HASH_SOURCES.get(target)
+        expected = PINNED_KERNEL_CODEBOOK_SHA256.get(target)
+        if sources is None or expected is None:
+            errors.append(f"{target}: missing hash source or pinned digest")
+            continue
+        got = _sha256_sources(sources)
+        actual[target] = got
+        if got != expected:
+            errors.append(f"{target}: expected {expected}, got {got}")
+    if errors:
+        raise RuntimeError("kernel codebook hash drift: " + "; ".join(errors))
+    return actual
+
+
+KERNEL_TARGETS_BY_NAME = {
+    target
+    for targets in KERNEL_TARGETS.values()
+    for target in targets
 }
 
 
@@ -170,9 +147,14 @@ def kernel_manifest_fragment(method: str) -> dict[str, object]:
             f"known: {sorted(KERNEL_TARGETS)}"
         )
     targets = KERNEL_TARGETS[method]
+    verify_kernel_codebook_hashes(tuple(targets))
     return {
         "kernel_target": list(targets),
         "block_layout_version": {t: KERNEL_BLOCK_LAYOUT_VERSIONS[t] for t in targets},
         "codebook_hash": {t: KERNEL_CODEBOOK_HASHES[t] for t in targets},
+        "codebook_hash_source": {
+            t: list(KERNEL_CODEBOOK_HASH_SOURCES[t]) for t in targets
+        },
         "per_block_tolerance": {t: KERNEL_PER_BLOCK_TOLERANCE[t] for t in targets},
+        "target_class": KERNEL_RECIPE_TARGET_CLASSES[method],
     }

--- a/packages/training/scripts/quantization/gguf-q3_k_m_apply.py
+++ b/packages/training/scripts/quantization/gguf-q3_k_m_apply.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import os
 import shlex
 import shutil
 import subprocess
@@ -44,7 +43,13 @@ _HERE = Path(__file__).resolve().parent
 if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
 
-from _common import write_sidecar  # noqa: E402
+from _common import (  # noqa: E402
+    DEFAULT_LLAMA_CPP_DIR,
+    find_llama_convert_script,
+    find_llama_quantize_binary,
+    llama_cpp_vendor_hint,
+    write_sidecar,
+)
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
@@ -58,32 +63,8 @@ log = logging.getLogger("gguf_q3_k_m_apply")
 QUANT_LEVEL = "Q3_K_M"
 
 
-# The in-repo llama.cpp fork submodule — the single canonical llama.cpp
-# checkout for the whole repo (.gitmodules: plugins/plugin-local-inference/native/llama.cpp,
-# url=https://github.com/elizaOS/llama.cpp.git). From this file
-# (packages/training/scripts/quantization/) the repo root is four parents up.
-_REPO_ROOT = _HERE.parents[3]
-_FORK_LLAMA_CPP = (
-    _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
-)
-
-_VENDOR_HINT = (
-    "The llama.cpp fork submodule should already be checked out. If it's "
-    "missing:\n"
-    "  git submodule update --init plugins/plugin-local-inference/native/llama.cpp\n"
-    "Then build the llama-quantize + llama-cli binaries from it (one-shot, "
-    "CPU-only is enough):\n"
-    "  cmake -S plugins/plugin-local-inference/native/llama.cpp -B plugins/plugin-local-inference/native/llama.cpp/build \\\n"
-    "        -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF "
-    "-DBUILD_SHARED_LIBS=OFF\n"
-    "  cmake --build plugins/plugin-local-inference/native/llama.cpp/build --target llama-quantize "
-    "llama-cli -j\"$(nproc)\"\n"
-    "Or pass --llama-cpp-dir <path-to-checkout> / set LLAMA_CPP_DIR / put the "
-    "binaries on PATH.\n"
-    "(convert_hf_to_gguf.py needs the `gguf` + `mistral_common` python deps; "
-    "`uv pip install -r plugins/plugin-local-inference/native/llama.cpp/requirements/"
-    "requirements-convert_hf_to_gguf.txt`.)"
-)
+_FORK_LLAMA_CPP = DEFAULT_LLAMA_CPP_DIR
+_VENDOR_HINT = llama_cpp_vendor_hint()
 
 
 def _find_convert_script(llama_cpp_dir: Path | None) -> Path:
@@ -91,23 +72,11 @@ def _find_convert_script(llama_cpp_dir: Path | None) -> Path:
 
     Resolution order: ``--llama-cpp-dir`` (explicit), ``$LLAMA_CPP_DIR``
     (env override), the in-repo llama.cpp fork submodule
-    (``plugins/plugin-local-inference/native/llama.cpp``, the canonical checkout), then a
+    (``plugins/plugin-local-inference/native/llama.cpp``, the canonical
+    checkout), then a
     system PATH install (e.g. the llama-cpp-python wheel).
     """
-    candidates: list[Path] = []
-    if llama_cpp_dir is not None:
-        candidates.append(llama_cpp_dir / "convert_hf_to_gguf.py")
-    env_dir = os.environ.get("LLAMA_CPP_DIR")
-    if env_dir:
-        candidates.append(Path(env_dir) / "convert_hf_to_gguf.py")
-    candidates.append(_FORK_LLAMA_CPP / "convert_hf_to_gguf.py")
-    which = shutil.which("convert_hf_to_gguf.py")
-    if which:
-        candidates.append(Path(which))
-    for c in candidates:
-        if c.exists():
-            return c
-    raise SystemExit("convert_hf_to_gguf.py not found.\n" + _VENDOR_HINT)
+    return find_llama_convert_script(llama_cpp_dir)
 
 
 def _find_quantize_binary(llama_cpp_dir: Path | None) -> Path:
@@ -118,35 +87,7 @@ def _find_quantize_binary(llama_cpp_dir: Path | None) -> Path:
     ``build/bin`` (a one-shot CPU cmake build — see :data:`_VENDOR_HINT`),
     then PATH.
     """
-    candidates: list[Path] = []
-    if llama_cpp_dir is not None:
-        candidates.extend(
-            [
-                llama_cpp_dir / "build" / "bin" / "llama-quantize",
-                llama_cpp_dir / "llama-quantize",
-            ]
-        )
-    env_dir = os.environ.get("LLAMA_CPP_DIR")
-    if env_dir:
-        candidates.extend(
-            [
-                Path(env_dir) / "build" / "bin" / "llama-quantize",
-                Path(env_dir) / "llama-quantize",
-            ]
-        )
-    candidates.extend(
-        [
-            _FORK_LLAMA_CPP / "build" / "bin" / "llama-quantize",
-            _FORK_LLAMA_CPP / "llama-quantize",
-        ]
-    )
-    which = shutil.which("llama-quantize")
-    if which:
-        candidates.append(Path(which))
-    for c in candidates:
-        if c.exists() and os.access(c, os.X_OK):
-            return c
-    raise SystemExit("llama-quantize binary not found.\n" + _VENDOR_HINT)
+    return find_llama_quantize_binary(llama_cpp_dir)
 
 
 def _resolve_output_basename(model_id_or_path: str, output_dir: Path) -> str:
@@ -262,8 +203,8 @@ def main(argv: list[str] | None = None) -> int:
         smoke = {
             "ok": False,
             "skipped": True,
-            "releaseEligible": False,
-            "reason": "--no-smoke-load was passed",
+            "release_eligible": False,
+            "error": "--no-smoke-load was used; no real-artifact recipe test ran",
         }
 
     sidecar = {

--- a/packages/training/scripts/quantization/gguf-q4_k_m_apply.py
+++ b/packages/training/scripts/quantization/gguf-q4_k_m_apply.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import os
 import shlex
 import shutil
 import subprocess
@@ -41,7 +40,13 @@ _HERE = Path(__file__).resolve().parent
 if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
 
-from _common import write_sidecar  # noqa: E402
+from _common import (  # noqa: E402
+    DEFAULT_LLAMA_CPP_DIR,
+    find_llama_convert_script,
+    find_llama_quantize_binary,
+    llama_cpp_vendor_hint,
+    write_sidecar,
+)
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
@@ -54,32 +59,8 @@ log = logging.getLogger("gguf_q4_k_m_apply")
 QUANT_LEVEL = "Q4_K_M"
 
 
-# The in-repo llama.cpp fork submodule — the single canonical llama.cpp
-# checkout for the whole repo (.gitmodules: plugins/plugin-local-inference/native/llama.cpp,
-# url=https://github.com/elizaOS/llama.cpp.git). From this file
-# (packages/training/scripts/quantization/) the repo root is four parents up.
-_REPO_ROOT = _HERE.parents[3]
-_FORK_LLAMA_CPP = (
-    _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
-)
-
-_VENDOR_HINT = (
-    "The llama.cpp fork submodule should already be checked out. If it's "
-    "missing:\n"
-    "  git submodule update --init plugins/plugin-local-inference/native/llama.cpp\n"
-    "Then build the llama-quantize + llama-cli binaries from it (one-shot, "
-    "CPU-only is enough):\n"
-    "  cmake -S plugins/plugin-local-inference/native/llama.cpp -B plugins/plugin-local-inference/native/llama.cpp/build \\\n"
-    "        -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF "
-    "-DBUILD_SHARED_LIBS=OFF\n"
-    "  cmake --build plugins/plugin-local-inference/native/llama.cpp/build --target llama-quantize "
-    "llama-cli -j\"$(nproc)\"\n"
-    "Or pass --llama-cpp-dir <path-to-checkout> / set LLAMA_CPP_DIR / put the "
-    "binaries on PATH.\n"
-    "(convert_hf_to_gguf.py needs the `gguf` + `mistral_common` python deps; "
-    "`uv pip install -r plugins/plugin-local-inference/native/llama.cpp/requirements/"
-    "requirements-convert_hf_to_gguf.txt`.)"
-)
+_FORK_LLAMA_CPP = DEFAULT_LLAMA_CPP_DIR
+_VENDOR_HINT = llama_cpp_vendor_hint()
 
 
 def _find_convert_script(llama_cpp_dir: Path | None) -> Path:
@@ -87,23 +68,11 @@ def _find_convert_script(llama_cpp_dir: Path | None) -> Path:
 
     Resolution order: ``--llama-cpp-dir`` (explicit), ``$LLAMA_CPP_DIR``
     (env override), the in-repo llama.cpp fork submodule
-    (``plugins/plugin-local-inference/native/llama.cpp``, the canonical checkout), then a
+    (``plugins/plugin-local-inference/native/llama.cpp``, the canonical
+    checkout), then a
     system PATH install (e.g. the llama-cpp-python wheel).
     """
-    candidates: list[Path] = []
-    if llama_cpp_dir is not None:
-        candidates.append(llama_cpp_dir / "convert_hf_to_gguf.py")
-    env_dir = os.environ.get("LLAMA_CPP_DIR")
-    if env_dir:
-        candidates.append(Path(env_dir) / "convert_hf_to_gguf.py")
-    candidates.append(_FORK_LLAMA_CPP / "convert_hf_to_gguf.py")
-    which = shutil.which("convert_hf_to_gguf.py")
-    if which:
-        candidates.append(Path(which))
-    for c in candidates:
-        if c.exists():
-            return c
-    raise SystemExit("convert_hf_to_gguf.py not found.\n" + _VENDOR_HINT)
+    return find_llama_convert_script(llama_cpp_dir)
 
 
 def _find_quantize_binary(llama_cpp_dir: Path | None) -> Path:
@@ -114,35 +83,7 @@ def _find_quantize_binary(llama_cpp_dir: Path | None) -> Path:
     ``build/bin`` (a one-shot CPU cmake build — see :data:`_VENDOR_HINT`),
     then PATH.
     """
-    candidates: list[Path] = []
-    if llama_cpp_dir is not None:
-        candidates.extend(
-            [
-                llama_cpp_dir / "build" / "bin" / "llama-quantize",
-                llama_cpp_dir / "llama-quantize",
-            ]
-        )
-    env_dir = os.environ.get("LLAMA_CPP_DIR")
-    if env_dir:
-        candidates.extend(
-            [
-                Path(env_dir) / "build" / "bin" / "llama-quantize",
-                Path(env_dir) / "llama-quantize",
-            ]
-        )
-    candidates.extend(
-        [
-            _FORK_LLAMA_CPP / "build" / "bin" / "llama-quantize",
-            _FORK_LLAMA_CPP / "llama-quantize",
-        ]
-    )
-    which = shutil.which("llama-quantize")
-    if which:
-        candidates.append(Path(which))
-    for c in candidates:
-        if c.exists() and os.access(c, os.X_OK):
-            return c
-    raise SystemExit("llama-quantize binary not found.\n" + _VENDOR_HINT)
+    return find_llama_quantize_binary(llama_cpp_dir)
 
 
 def _resolve_output_basename(model_id_or_path: str, output_dir: Path) -> str:
@@ -201,9 +142,11 @@ def main(argv: list[str] | None = None) -> int:
         "--no-smoke-load",
         dest="smoke_load",
         action="store_false",
-        help="Skip the post-quantize llama-cli load-smoke. This is a local "
-             "debug escape hatch; release/publish runs must keep the default "
-             "artifact load test enabled.",
+        help=(
+            "Local-debug escape hatch: skip the post-quantize llama-cli "
+            "load-smoke. Release-suitable Q4_K_M sidecars are only written "
+            "when this smoke test runs and passes."
+        ),
     )
     ap.set_defaults(smoke_load=True)
     ap.add_argument("--dry-run", action="store_true")
@@ -257,8 +200,8 @@ def main(argv: list[str] | None = None) -> int:
         smoke = {
             "ok": False,
             "skipped": True,
-            "releaseEligible": False,
-            "reason": "--no-smoke-load was passed",
+            "release_eligible": False,
+            "error": "--no-smoke-load was used; no real-artifact recipe test ran",
         }
 
     sidecar = {
@@ -273,6 +216,13 @@ def main(argv: list[str] | None = None) -> int:
         if args.calibration and args.calibration.suffix == ".imatrix"
         else None,
         "smoke_load": smoke,
+        "recipe_test": {
+            "name": "llama-cli-load-smoke",
+            "status": "passed" if smoke and smoke.get("ok") else "skipped",
+            "release_eligible": bool(smoke and smoke.get("ok")),
+            "artifact": str(quant_path),
+            "details": smoke,
+        },
         "notes": (
             "Q4_K_M is the standard sweet-spot K-quant for llama.cpp / Ollama "
             "/ LM Studio. ~4.5 bits per weight on average (mixed precision) "

--- a/packages/training/scripts/quantization/gguf-q5_k_m_apply.py
+++ b/packages/training/scripts/quantization/gguf-q5_k_m_apply.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import os
 import shlex
 import shutil
 import subprocess
@@ -42,7 +41,13 @@ _HERE = Path(__file__).resolve().parent
 if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
 
-from _common import write_sidecar  # noqa: E402
+from _common import (  # noqa: E402
+    DEFAULT_LLAMA_CPP_DIR,
+    find_llama_convert_script,
+    find_llama_quantize_binary,
+    llama_cpp_vendor_hint,
+    write_sidecar,
+)
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
@@ -55,82 +60,18 @@ log = logging.getLogger("gguf_q5_k_m_apply")
 QUANT_LEVEL = "Q5_K_M"
 
 
-# The in-repo llama.cpp fork submodule — see gguf-q4_k_m_apply.py for the
-# full vendor hint. From this file (packages/training/scripts/quantization/)
-# the repo root is four parents up.
-_REPO_ROOT = _HERE.parents[3]
-_FORK_LLAMA_CPP = (
-    _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
-)
-
-_VENDOR_HINT = (
-    "The llama.cpp fork submodule should already be checked out. If it's "
-    "missing:\n"
-    "  git submodule update --init plugins/plugin-local-inference/native/llama.cpp\n"
-    "Then build the llama-quantize + llama-cli binaries from it (one-shot, "
-    "CPU-only is enough):\n"
-    "  cmake -S plugins/plugin-local-inference/native/llama.cpp -B plugins/plugin-local-inference/native/llama.cpp/build \\\n"
-    "        -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF "
-    "-DBUILD_SHARED_LIBS=OFF\n"
-    "  cmake --build plugins/plugin-local-inference/native/llama.cpp/build --target llama-quantize "
-    "llama-cli -j\"$(nproc)\"\n"
-    "Or pass --llama-cpp-dir <path-to-checkout> / set LLAMA_CPP_DIR / put the "
-    "binaries on PATH.\n"
-    "(convert_hf_to_gguf.py needs the `gguf` + `mistral_common` python deps; "
-    "`uv pip install -r plugins/plugin-local-inference/native/llama.cpp/requirements/"
-    "requirements-convert_hf_to_gguf.txt`.)"
-)
+_FORK_LLAMA_CPP = DEFAULT_LLAMA_CPP_DIR
+_VENDOR_HINT = llama_cpp_vendor_hint()
 
 
 def _find_convert_script(llama_cpp_dir: Path | None) -> Path:
     """Locate convert_hf_to_gguf.py. See gguf-q4_k_m_apply.py for details."""
-    candidates: list[Path] = []
-    if llama_cpp_dir is not None:
-        candidates.append(llama_cpp_dir / "convert_hf_to_gguf.py")
-    env_dir = os.environ.get("LLAMA_CPP_DIR")
-    if env_dir:
-        candidates.append(Path(env_dir) / "convert_hf_to_gguf.py")
-    candidates.append(_FORK_LLAMA_CPP / "convert_hf_to_gguf.py")
-    which = shutil.which("convert_hf_to_gguf.py")
-    if which:
-        candidates.append(Path(which))
-    for c in candidates:
-        if c.exists():
-            return c
-    raise SystemExit("convert_hf_to_gguf.py not found.\n" + _VENDOR_HINT)
+    return find_llama_convert_script(llama_cpp_dir)
 
 
 def _find_quantize_binary(llama_cpp_dir: Path | None) -> Path:
     """Locate ``llama-quantize`` binary. See gguf-q4_k_m_apply.py for details."""
-    candidates: list[Path] = []
-    if llama_cpp_dir is not None:
-        candidates.extend(
-            [
-                llama_cpp_dir / "build" / "bin" / "llama-quantize",
-                llama_cpp_dir / "llama-quantize",
-            ]
-        )
-    env_dir = os.environ.get("LLAMA_CPP_DIR")
-    if env_dir:
-        candidates.extend(
-            [
-                Path(env_dir) / "build" / "bin" / "llama-quantize",
-                Path(env_dir) / "llama-quantize",
-            ]
-        )
-    candidates.extend(
-        [
-            _FORK_LLAMA_CPP / "build" / "bin" / "llama-quantize",
-            _FORK_LLAMA_CPP / "llama-quantize",
-        ]
-    )
-    which = shutil.which("llama-quantize")
-    if which:
-        candidates.append(Path(which))
-    for c in candidates:
-        if c.exists() and os.access(c, os.X_OK):
-            return c
-    raise SystemExit("llama-quantize binary not found.\n" + _VENDOR_HINT)
+    return find_llama_quantize_binary(llama_cpp_dir)
 
 
 def _resolve_output_basename(model_id_or_path: str, output_dir: Path) -> str:
@@ -240,8 +181,8 @@ def main(argv: list[str] | None = None) -> int:
         smoke = {
             "ok": False,
             "skipped": True,
-            "releaseEligible": False,
-            "reason": "--no-smoke-load was passed",
+            "release_eligible": False,
+            "error": "--no-smoke-load was used; no real-artifact recipe test ran",
         }
 
     sidecar = {

--- a/packages/training/scripts/quantization/gguf-q6_k_apply.py
+++ b/packages/training/scripts/quantization/gguf-q6_k_apply.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import os
 import shlex
 import shutil
 import subprocess
@@ -45,7 +44,13 @@ _HERE = Path(__file__).resolve().parent
 if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
 
-from _common import write_sidecar  # noqa: E402
+from _common import (  # noqa: E402
+    DEFAULT_LLAMA_CPP_DIR,
+    find_llama_convert_script,
+    find_llama_quantize_binary,
+    llama_cpp_vendor_hint,
+    write_sidecar,
+)
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
@@ -57,82 +62,18 @@ log = logging.getLogger("gguf_q6_k_apply")
 QUANT_LEVEL = "Q6_K"
 
 
-# The in-repo llama.cpp fork submodule — see gguf-q4_k_m_apply.py for the
-# full vendor hint. From this file (packages/training/scripts/quantization/)
-# the repo root is four parents up.
-_REPO_ROOT = _HERE.parents[3]
-_FORK_LLAMA_CPP = (
-    _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
-)
-
-_VENDOR_HINT = (
-    "The llama.cpp fork submodule should already be checked out. If it's "
-    "missing:\n"
-    "  git submodule update --init plugins/plugin-local-inference/native/llama.cpp\n"
-    "Then build the llama-quantize + llama-cli binaries from it (one-shot, "
-    "CPU-only is enough):\n"
-    "  cmake -S plugins/plugin-local-inference/native/llama.cpp -B plugins/plugin-local-inference/native/llama.cpp/build \\\n"
-    "        -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF "
-    "-DBUILD_SHARED_LIBS=OFF\n"
-    "  cmake --build plugins/plugin-local-inference/native/llama.cpp/build --target llama-quantize "
-    "llama-cli -j\"$(nproc)\"\n"
-    "Or pass --llama-cpp-dir <path-to-checkout> / set LLAMA_CPP_DIR / put the "
-    "binaries on PATH.\n"
-    "(convert_hf_to_gguf.py needs the `gguf` + `mistral_common` python deps; "
-    "`uv pip install -r plugins/plugin-local-inference/native/llama.cpp/requirements/"
-    "requirements-convert_hf_to_gguf.txt`.)"
-)
+_FORK_LLAMA_CPP = DEFAULT_LLAMA_CPP_DIR
+_VENDOR_HINT = llama_cpp_vendor_hint()
 
 
 def _find_convert_script(llama_cpp_dir: Path | None) -> Path:
     """Locate convert_hf_to_gguf.py. See gguf-q4_k_m_apply.py for details."""
-    candidates: list[Path] = []
-    if llama_cpp_dir is not None:
-        candidates.append(llama_cpp_dir / "convert_hf_to_gguf.py")
-    env_dir = os.environ.get("LLAMA_CPP_DIR")
-    if env_dir:
-        candidates.append(Path(env_dir) / "convert_hf_to_gguf.py")
-    candidates.append(_FORK_LLAMA_CPP / "convert_hf_to_gguf.py")
-    which = shutil.which("convert_hf_to_gguf.py")
-    if which:
-        candidates.append(Path(which))
-    for c in candidates:
-        if c.exists():
-            return c
-    raise SystemExit("convert_hf_to_gguf.py not found.\n" + _VENDOR_HINT)
+    return find_llama_convert_script(llama_cpp_dir)
 
 
 def _find_quantize_binary(llama_cpp_dir: Path | None) -> Path:
     """Locate ``llama-quantize`` binary. See gguf-q4_k_m_apply.py for details."""
-    candidates: list[Path] = []
-    if llama_cpp_dir is not None:
-        candidates.extend(
-            [
-                llama_cpp_dir / "build" / "bin" / "llama-quantize",
-                llama_cpp_dir / "llama-quantize",
-            ]
-        )
-    env_dir = os.environ.get("LLAMA_CPP_DIR")
-    if env_dir:
-        candidates.extend(
-            [
-                Path(env_dir) / "build" / "bin" / "llama-quantize",
-                Path(env_dir) / "llama-quantize",
-            ]
-        )
-    candidates.extend(
-        [
-            _FORK_LLAMA_CPP / "build" / "bin" / "llama-quantize",
-            _FORK_LLAMA_CPP / "llama-quantize",
-        ]
-    )
-    which = shutil.which("llama-quantize")
-    if which:
-        candidates.append(Path(which))
-    for c in candidates:
-        if c.exists() and os.access(c, os.X_OK):
-            return c
-    raise SystemExit("llama-quantize binary not found.\n" + _VENDOR_HINT)
+    return find_llama_quantize_binary(llama_cpp_dir)
 
 
 def _resolve_output_basename(model_id_or_path: str, output_dir: Path) -> str:
@@ -243,8 +184,8 @@ def main(argv: list[str] | None = None) -> int:
         smoke = {
             "ok": False,
             "skipped": True,
-            "releaseEligible": False,
-            "reason": "--no-smoke-load was passed",
+            "release_eligible": False,
+            "error": "--no-smoke-load was used; no real-artifact recipe test ran",
         }
 
     sidecar = {

--- a/packages/training/scripts/quantization/gguf_asr_apply.py
+++ b/packages/training/scripts/quantization/gguf_asr_apply.py
@@ -33,9 +33,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import os
 import shlex
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -44,7 +42,13 @@ _HERE = Path(__file__).resolve().parent
 if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
 
-from _common import write_sidecar  # noqa: E402
+from _common import (  # noqa: E402
+    DEFAULT_LLAMA_CPP_DIR,
+    find_llama_convert_script,
+    find_llama_quantize_binary,
+    llama_cpp_vendor_hint,
+    write_sidecar,
+)
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
@@ -59,27 +63,8 @@ SUPPORTED_QUANTS = ("Q3_K_M", "Q4_K_M", "Q5_K_M", "Q6_K", "Q8_0")
 # WER regression when the projector is sub-Q8 (R8 §3.6).
 DEFAULT_MMPROJ_QUANT = "Q8_0"
 
-# Repo root — four parents up from this file
-# (packages/training/scripts/quantization/).
-_REPO_ROOT = _HERE.parents[3]
-_FORK_LLAMA_CPP = (
-    _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
-)
-
-_VENDOR_HINT = (
-    "The llama.cpp fork submodule should already be checked out. If it's "
-    "missing:\n"
-    "  git submodule update --init plugins/plugin-local-inference/native/llama.cpp\n"
-    "Then build the llama-quantize + llama-cli binaries from it (one-shot, "
-    "CPU-only is enough):\n"
-    "  cmake -S plugins/plugin-local-inference/native/llama.cpp -B plugins/plugin-local-inference/native/llama.cpp/build \\\n"
-    "        -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF "
-    "-DBUILD_SHARED_LIBS=OFF\n"
-    "  cmake --build plugins/plugin-local-inference/native/llama.cpp/build --target llama-quantize "
-    "llama-cli -j\"$(nproc)\"\n"
-    "Or pass --llama-cpp-dir <path-to-checkout> / set LLAMA_CPP_DIR / put the "
-    "binaries on PATH."
-)
+_FORK_LLAMA_CPP = DEFAULT_LLAMA_CPP_DIR
+_VENDOR_HINT = llama_cpp_vendor_hint()
 
 
 def _find_convert_script(llama_cpp_dir: Path | None) -> Path:
@@ -88,54 +73,13 @@ def _find_convert_script(llama_cpp_dir: Path | None) -> Path:
     Resolution order matches gguf-q4_k_m_apply.py: explicit ``--llama-cpp-dir``,
     ``$LLAMA_CPP_DIR``, in-repo fork submodule, then PATH.
     """
-    candidates: list[Path] = []
-    if llama_cpp_dir is not None:
-        candidates.append(llama_cpp_dir / "convert_hf_to_gguf.py")
-    env_dir = os.environ.get("LLAMA_CPP_DIR")
-    if env_dir:
-        candidates.append(Path(env_dir) / "convert_hf_to_gguf.py")
-    candidates.append(_FORK_LLAMA_CPP / "convert_hf_to_gguf.py")
-    which = shutil.which("convert_hf_to_gguf.py")
-    if which:
-        candidates.append(Path(which))
-    for c in candidates:
-        if c.exists():
-            return c
-    raise SystemExit("convert_hf_to_gguf.py not found.\n" + _VENDOR_HINT)
+    return find_llama_convert_script(llama_cpp_dir)
 
 
 def _find_quantize_binary(llama_cpp_dir: Path | None) -> Path:
     """Locate the ``llama-quantize`` binary. Same resolution order as
     :func:`_find_convert_script`."""
-    candidates: list[Path] = []
-    if llama_cpp_dir is not None:
-        candidates.extend(
-            [
-                llama_cpp_dir / "build" / "bin" / "llama-quantize",
-                llama_cpp_dir / "llama-quantize",
-            ]
-        )
-    env_dir = os.environ.get("LLAMA_CPP_DIR")
-    if env_dir:
-        candidates.extend(
-            [
-                Path(env_dir) / "build" / "bin" / "llama-quantize",
-                Path(env_dir) / "llama-quantize",
-            ]
-        )
-    candidates.extend(
-        [
-            _FORK_LLAMA_CPP / "build" / "bin" / "llama-quantize",
-            _FORK_LLAMA_CPP / "llama-quantize",
-        ]
-    )
-    which = shutil.which("llama-quantize")
-    if which:
-        candidates.append(Path(which))
-    for c in candidates:
-        if c.exists() and os.access(c, os.X_OK):
-            return c
-    raise SystemExit("llama-quantize binary not found.\n" + _VENDOR_HINT)
+    return find_llama_quantize_binary(llama_cpp_dir)
 
 
 def _run(cmd: list[str | Path]) -> None:

--- a/packages/training/scripts/quantization/gguf_eliza1_apply.py
+++ b/packages/training/scripts/quantization/gguf_eliza1_apply.py
@@ -1,4 +1,4 @@
-"""Emit a Eliza-typed GGUF using the elizaOS/llama.cpp fork's converter.
+"""Emit a legacy Eliza-typed GGUF using the elizaOS/llama.cpp fork's converter.
 
 The elizaOS/llama.cpp v1.0.0-eliza fork registers the following
 non-upstream GGML types:
@@ -66,11 +66,6 @@ logging.basicConfig(
 )
 log = logging.getLogger("gguf_eliza1_apply")
 
-_REPO_ROOT = Path(__file__).resolve().parents[4]
-_FORK_LLAMA_CPP = (
-    _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
-)
-
 
 # Source-of-truth slot numbers for the Eliza-added GGML types. Mirrors
 # packages/app-core/scripts/aosp/compile-libllama.mjs (preamble) and the
@@ -98,8 +93,8 @@ def _resolve_convert_script(llama_cpp_dir: Path | None) -> Path:
     """Locate ``convert_hf_to_gguf.py`` in the elizaOS/llama.cpp fork checkout.
 
     Resolution order: --llama-cpp-dir → $LLAMA_CPP_DIR → the in-repo fork
-    submodule (``plugins/plugin-local-inference/native/llama.cpp``, the single canonical
-    llama.cpp checkout) → the standalone clone at
+    submodule (``plugins/plugin-local-inference/native/llama.cpp``, the
+    single canonical llama.cpp checkout) → the standalone clone at
     ``~/.cache/eliza-mtp/eliza-llama-cpp`` (used when the build scripts'
     ELIZA_MTP_LLAMA_CPP_REMOTE/_REF override forces one) → $PATH.
     """
@@ -111,8 +106,12 @@ def _resolve_convert_script(llama_cpp_dir: Path | None) -> Path:
         cands.append(Path(env_dir))
     # plugins/plugin-local-inference/native/llama.cpp is the canonical fork
     # submodule (.gitmodules: url=https://github.com/elizaOS/llama.cpp.git).
-    if _FORK_LLAMA_CPP.is_dir():
-        cands.append(_FORK_LLAMA_CPP)
+    here = Path(__file__).resolve()
+    for p in here.parents:
+        cand = p / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
+        if cand.is_dir():
+            cands.append(cand)
+            break
     cands.append(Path.home() / ".cache" / "eliza-mtp" / "eliza-llama-cpp")
     for c in cands:
         cand = c / "convert_hf_to_gguf.py"
@@ -145,6 +144,7 @@ def _convert_script_supports_eliza1(convert_path: Path) -> bool:
 def _build_ext_metadata(
     *,
     base_model: str,
+    actual_outtype: str,
     polar_sidecar: dict[str, object] | None,
     qjl_sidecar: dict[str, object] | None,
     tbq_sidecar: dict[str, object] | None,
@@ -217,12 +217,59 @@ def _build_ext_metadata(
             "architecture": fused_tbq_sidecar.get("architecture"),
         }
 
-    fragments = [
-        sidecar.get("kernel_manifest")
-        for sidecar in (polar_sidecar, qjl_sidecar, tbq_sidecar, fused_tbq_sidecar)
-        if isinstance(sidecar, dict)
-        and isinstance(sidecar.get("kernel_manifest"), dict)
-    ]
+    fragments: list[dict[str, object]] = []
+    recipe_status: dict[str, dict[str, object]] = {}
+
+    def record_recipe_status(
+        name: str,
+        sidecar: dict[str, object] | None,
+        *,
+        cited: bool,
+        reason: str,
+    ) -> None:
+        recipe_status[name] = {
+            "sidecarPresent": sidecar is not None,
+            "manifestCited": cited,
+            "reason": reason,
+        }
+
+    if polar_sidecar is not None and actual_outtype == "q4_polar":
+        fragment = polar_sidecar.get("kernel_manifest")
+        if isinstance(fragment, dict):
+            fragments.append(fragment)
+        record_recipe_status(
+            "polarquant",
+            polar_sidecar,
+            cited=True,
+            reason="q4_polar is the actual GGUF tensor type",
+        )
+    else:
+        record_recipe_status(
+            "polarquant",
+            polar_sidecar,
+            cited=False,
+            reason=(
+                "PolarQuant sidecars are not cited unless the produced GGUF "
+                "actually uses q4_polar tensor blocks"
+            ),
+        )
+
+    for name, sidecar in (
+        ("qjl", qjl_sidecar),
+        ("turboquant", tbq_sidecar),
+        ("fused_turboquant", fused_tbq_sidecar),
+    ):
+        record_recipe_status(
+            name,
+            sidecar,
+            cited=False,
+            reason=(
+                "Runtime KV-cache sidecar metadata is not recipe provenance "
+                "until the publish gate verifies the tier enables that cache"
+            ),
+        )
+
+    out["recipeStatus"] = recipe_status
     if fragments:
         out["recipeManifest"] = merge_kernel_manifest_fragments(fragments)
     return out
@@ -299,7 +346,7 @@ def main(argv: list[str] | None = None) -> int:
         help=(
             "Local-debug escape hatch: when q4_polar cannot be emitted, "
             "fall back to f16/q8_0 and mark the sidecar as deferred. "
-            "Rejected when --release-state is set."
+            "Do not use for Eliza-1 release artifacts."
         ),
     )
     # Eliza-1 v1 = the upstream BASE models, GGUF-converted + fully optimized
@@ -432,14 +479,6 @@ def main(argv: list[str] | None = None) -> int:
         log.warning("Q4_POLAR conversion unavailable: %s", fallback_reason)
         args.outtype = "q8_0"
 
-    if fallback_reason is not None and args.release_state is not None:
-        log.error(
-            "refusing --allow-unoptimized-fallback with --release-state=%s: "
-            "fallback GGUFs are local-debug artifacts and are not release-eligible",
-            args.release_state,
-        )
-        return 2
-
     base_model = args.checkpoint.name
     if polar_sidecar:
         base_model = str(polar_sidecar.get("source_model") or base_model)
@@ -449,6 +488,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         ext_metadata = _build_ext_metadata(
             base_model=base_model,
+            actual_outtype=args.outtype,
             polar_sidecar=polar_sidecar,
             qjl_sidecar=qjl_sidecar,
             tbq_sidecar=tbq_sidecar,
@@ -470,7 +510,6 @@ def main(argv: list[str] | None = None) -> int:
         "actual": args.outtype,
         "deferred": requested_outtype != args.outtype,
         "deferral_reason": fallback_reason,
-        "releaseEligible": fallback_reason is None,
         # PolarQuant codebook is still available as a sidecar even when the GGUF
         # body is q8_0/f16 — the runtime can apply it once the fork's converter
         # (or a runtime-side path) lands.

--- a/packages/training/scripts/quantization/gguf_kokoro_apply.py
+++ b/packages/training/scripts/quantization/gguf_kokoro_apply.py
@@ -43,24 +43,24 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
 import shlex
-import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 _HERE = Path(__file__).resolve().parent
-# packages/training/scripts/quantization/ -> repo root is four parents up.
-_REPO_ROOT = _HERE.parents[3]
-_FORK_LLAMA_CPP = (
-    _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from _common import (  # noqa: E402
+    DEFAULT_LLAMA_CPP_DIR,
+    find_llama_convert_script,
+    find_llama_quantize_binary,
+    llama_cpp_vendor_hint,
 )
-_VENDOR_HINT = (
-    "Build the Eliza-1 llama.cpp fork first:\n"
-    "  cd plugins/plugin-local-inference && bun run build:native\n"
-    "Or set LLAMA_CPP_DIR to the fork root."
-)
+
+_FORK_LLAMA_CPP = DEFAULT_LLAMA_CPP_DIR
+_VENDOR_HINT = llama_cpp_vendor_hint()
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
@@ -75,43 +75,11 @@ DEFAULT_QUANT = "Q4_K_M"
 
 
 def _find_quantize_binary(llama_cpp_dir: Path | None) -> Path:
-    candidates: list[Path] = []
-    if llama_cpp_dir is not None:
-        candidates.extend([
-            llama_cpp_dir / "build" / "bin" / "llama-quantize",
-            llama_cpp_dir / "llama-quantize",
-        ])
-    env_dir = os.environ.get("LLAMA_CPP_DIR")
-    if env_dir:
-        candidates.extend([
-            Path(env_dir) / "build" / "bin" / "llama-quantize",
-            Path(env_dir) / "llama-quantize",
-        ])
-    candidates.extend([
-        _FORK_LLAMA_CPP / "build" / "bin" / "llama-quantize",
-        _FORK_LLAMA_CPP / "llama-quantize",
-    ])
-    which = shutil.which("llama-quantize")
-    if which:
-        candidates.append(Path(which))
-    for c in candidates:
-        if c.exists() and os.access(c, os.X_OK):
-            return c
-    raise SystemExit("llama-quantize binary not found.\n" + _VENDOR_HINT)
+    return find_llama_quantize_binary(llama_cpp_dir)
 
 
 def _find_convert_script(llama_cpp_dir: Path | None) -> Path:
-    candidates: list[Path] = []
-    if llama_cpp_dir is not None:
-        candidates.append(llama_cpp_dir / "convert_hf_to_gguf.py")
-    env_dir = os.environ.get("LLAMA_CPP_DIR")
-    if env_dir:
-        candidates.append(Path(env_dir) / "convert_hf_to_gguf.py")
-    candidates.append(_FORK_LLAMA_CPP / "convert_hf_to_gguf.py")
-    for c in candidates:
-        if c.exists():
-            return c
-    raise SystemExit("convert_hf_to_gguf.py not found.\n" + _VENDOR_HINT)
+    return find_llama_convert_script(llama_cpp_dir)
 
 
 def _run(cmd: list[str | Path]) -> None:

--- a/packages/training/scripts/quantization/polar_xorshift32.py
+++ b/packages/training/scripts/quantization/polar_xorshift32.py
@@ -3,7 +3,8 @@
 This is the Python port of the C reference implementation that lives in:
 
     eliza/packages/native/plugins/polarquant-cpu/src/polar_qjl.c
-    eliza/plugins/plugin-local-inference/native/verify/qjl_polar_ref.c          (eliza_polar_qjl_signs)
+    eliza/plugins/plugin-local-inference/native/verify/qjl_polar_ref.c
+        (eliza_polar_qjl_signs)
 
 Per packages/training/AGENTS.md S3 ("kernel side wins") the C reference is
 canonical. The Python recipe must produce a sign sequence that is bit-exact

--- a/packages/training/scripts/quantization/qjl/qjl_quant.py
+++ b/packages/training/scripts/quantization/qjl/qjl_quant.py
@@ -7,7 +7,8 @@ references at:
   * ``eliza/packages/native/plugins/qjl-cpu/include/qjl/qjl.h``
   * ``eliza/packages/native/plugins/qjl-cpu/src/qjl_quantize_ref.c``
   * ``eliza/packages/native/plugins/qjl-cpu/src/qjl_score_ref.c``
-  * ``eliza/plugins/plugin-local-inference/native/verify/qjl_polar_ref.c`` (verify harness)
+  * ``eliza/plugins/plugin-local-inference/native/verify/qjl_polar_ref.c``
+    (verify harness)
 
 The ``block_qjl1_256`` on-cache layout is 32 packed sign bytes (LSB-first
 within each byte) followed by a uint16 bf16 norm — 34 bytes total. The

--- a/packages/training/scripts/quantization/test_gguf_eliza1_apply.py
+++ b/packages/training/scripts/quantization/test_gguf_eliza1_apply.py
@@ -31,10 +31,7 @@ def test_q4_polar_refuses_missing_polar_sidecar_by_default(tmp_path: Path) -> No
     assert rc == 2
 
 
-def test_q4_polar_fallback_requires_explicit_escape_hatch(
-    tmp_path: Path,
-    capsys,
-) -> None:
+def test_q4_polar_fallback_requires_explicit_escape_hatch(tmp_path: Path) -> None:
     checkpoint = tmp_path / "checkpoint"
     checkpoint.mkdir()
 
@@ -52,43 +49,9 @@ def test_q4_polar_fallback_requires_explicit_escape_hatch(
     )
 
     assert rc == 0
-    plan = json.loads(capsys.readouterr().out)
-    assert plan["outtype"] == "f16"
-    assert plan["ext_metadata"]["weight_quant"] == {
-        "requested": "q4_polar",
-        "actual": "f16",
-        "deferred": True,
-        "deferral_reason": (
-            f"polarquant codebook ({checkpoint / 'polarquant_config.json'}) missing"
-        ),
-        "releaseEligible": False,
-        "polarquant_artifacts": None,
-    }
 
 
-def test_q4_polar_fallback_is_rejected_for_release_state(tmp_path: Path) -> None:
-    checkpoint = tmp_path / "checkpoint"
-    checkpoint.mkdir()
-
-    rc = main(
-        [
-            "--checkpoint",
-            str(checkpoint),
-            "--output",
-            str(tmp_path / "model.gguf"),
-            "--outtype",
-            "q4_polar",
-            "--allow-unoptimized-fallback",
-            "--release-state",
-            "base-v1",
-            "--dry-run",
-        ]
-    )
-
-    assert rc == 2
-
-
-def test_dry_run_merges_all_quantization_recipe_sidecars(
+def test_stock_outtype_dry_run_does_not_cite_sidecars_as_recipe_provenance(
     tmp_path: Path,
     capsys,
 ) -> None:
@@ -171,13 +134,77 @@ def test_dry_run_merges_all_quantization_recipe_sidecars(
     assert ext["qjl"]["key_bits"] == 1
     assert ext["qjl"]["value_bits"] == 4
     assert ext["turboquant"]["nbits"] == 4
-    assert set(ext["recipeManifest"]) == {
-        "polar_q4",
-        "qjl1_256",
-        "turbo3",
-        "turbo4",
-        "turbo3_tcq",
+    assert "recipeManifest" not in ext
+    assert ext["recipeStatus"]["polarquant"] == {
+        "sidecarPresent": True,
+        "manifestCited": False,
+        "reason": (
+            "PolarQuant sidecars are not cited unless the produced GGUF "
+            "actually uses q4_polar tensor blocks"
+        ),
     }
+    assert ext["recipeStatus"]["qjl"]["sidecarPresent"] is True
+    assert ext["recipeStatus"]["qjl"]["manifestCited"] is False
+    assert ext["recipeStatus"]["turboquant"]["sidecarPresent"] is True
+    assert ext["recipeStatus"]["turboquant"]["manifestCited"] is False
+    assert ext["recipeStatus"]["fused_turboquant"]["sidecarPresent"] is True
+    assert ext["recipeStatus"]["fused_turboquant"]["manifestCited"] is False
+
+
+def test_q4_polar_dry_run_cites_only_actual_weight_recipe(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    checkpoint = tmp_path / "checkpoint"
+    checkpoint.mkdir()
+    fake_llama = tmp_path / "llama.cpp"
+    fake_llama.mkdir()
+    (fake_llama / "convert_hf_to_gguf.py").write_text(
+        "# supports Q4_POLAR\n", encoding="utf-8"
+    )
+    (checkpoint / "polarquant_config.json").write_text(
+        json.dumps(
+            {
+                "source_model": "google/gemma-4-E4B-Base",
+                "recipe": {"bits": 4, "block_size": 128, "use_qjl": True},
+                "kernel_manifest": kernel_manifest_fragment("polarquant"),
+            }
+        ),
+        encoding="utf-8",
+    )
+    (checkpoint / "qjl_config.json").write_text(
+        json.dumps(
+            {
+                "source_model": "google/gemma-4-E4B-Base",
+                "projection_dim_per_head": 256,
+                "kernel_manifest": kernel_manifest_fragment("qjl"),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "--checkpoint",
+            str(checkpoint),
+            "--output",
+            str(tmp_path / "model.gguf"),
+            "--outtype",
+            "q4_polar",
+            "--llama-cpp-dir",
+            str(fake_llama),
+            "--allow-unoptimized-fallback",
+            "--dry-run",
+        ]
+    )
+
+    assert rc == 0
+    plan = json.loads(capsys.readouterr().out)
+    ext = plan["ext_metadata"]
+    assert set(ext["recipeManifest"]) == {"polar_q4"}
+    assert ext["recipeStatus"]["polarquant"]["manifestCited"] is True
+    assert ext["recipeStatus"]["qjl"]["sidecarPresent"] is True
+    assert ext["recipeStatus"]["qjl"]["manifestCited"] is False
 
 
 def test_dry_run_can_request_trunk_only_without_mtp(

--- a/packages/training/scripts/quantization/test_recipes_smoke.py
+++ b/packages/training/scripts/quantization/test_recipes_smoke.py
@@ -20,7 +20,6 @@ data. Run them by hand from the repo root.
 from __future__ import annotations
 
 import json
-import os
 import sys
 from pathlib import Path
 
@@ -29,6 +28,10 @@ import pytest
 _HERE = Path(__file__).resolve().parent
 if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
+
+_CANONICAL_LLAMA_CPP_SUFFIX = (
+    Path("plugins") / "plugin-local-inference" / "native" / "llama.cpp"
+)
 
 
 def test_polarquant_recipe_serializes_with_paper_metadata():
@@ -213,7 +216,8 @@ def test_legacy_push_model_to_hf_redirects_to_canonical_publishers():
 # Kernel-vs-recipe parity tests
 #
 # These tests pin the recipes to the canonical kernel references in
-# packages/native/plugins/{turboquant-cpu,qjl-cpu,polarquant-cpu}/.
+# eliza/plugins/plugin-local-inference/native/{reference,verify}/ and
+# eliza/packages/native/plugins/{qjl-cpu,polarquant-cpu}/.
 #
 # Per packages/training/AGENTS.md §3:
 #   "Bit-exact with kernels — when a quantization recipe and a kernel
@@ -226,33 +230,17 @@ def test_legacy_push_model_to_hf_redirects_to_canonical_publishers():
 # ---------------------------------------------------------------------------
 
 
-# _HERE = <repo>/packages/training/scripts/quantization
-# parents: [0]=quantization, [1]=scripts, [2]=training, [3]=packages, [4]=<repo>
-#
-# The canonical qjl/polar/turbo C references live in the local-inference plugin
-# at plugins/plugin-local-inference/native/{verify,reference}/. The old path
-# (_HERE.parents[2] / "inference" / ...) pointed at a nonexistent
-# packages/training/inference/ tree, so every C-parity test silently skipped —
-# a false green. Resolve the real location relative to the repo root, with an
-# ELIZA_KERNEL_REF_DIR override for layouts where the plugin tree is not a
-# sibling of packages/training (e.g. the CI container that mounts only
-# packages/training — see the loud-skip note in the parity tests).
+# _HERE = .../eliza/packages/training/scripts/quantization
 _REPO_ROOT = _HERE.parents[3]
-_KERNEL_REF_DIR = Path(
-    os.environ.get(
-        "ELIZA_KERNEL_REF_DIR",
-        str(_REPO_ROOT / "plugins" / "plugin-local-inference" / "native"),
-    )
-)
-_REF_C = _KERNEL_REF_DIR / "verify" / "qjl_polar_ref.c"
-_REF_H = _KERNEL_REF_DIR / "verify" / "qjl_polar_ref.h"
-_TURBO_C = _KERNEL_REF_DIR / "reference" / "turbo_kernels.c"
-_TURBO_H = _KERNEL_REF_DIR / "reference" / "turbo_kernels.h"
+_REF_C = _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "verify" / "qjl_polar_ref.c"
+_REF_H = _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "verify" / "qjl_polar_ref.h"
+_TURBO_C = _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "reference" / "turbo_kernels.c"
+_TURBO_H = _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "reference" / "turbo_kernels.h"
 
 
 # Canonical 4-bit Lloyd-Max centroids for N(0,1), bit-exact match required
-# against packages/native/plugins/polarquant-cpu/include/polarquant/polar_centroids.h
-# and the qjl-cpu reference kernels (packages/native/plugins/qjl-cpu/src/).
+# against eliza/packages/native/plugins/polarquant-cpu/include/polarquant/polar_centroids.h
+# and eliza/plugins/plugin-local-inference/native/verify/qjl_polar_ref.c.
 _C_POLAR_Q4_CENTROIDS = (
     -2.754354807, -2.093562707, -1.643041510, -1.279739752,
     -0.962640978, -0.672392117, -0.397897103, -0.131757782,
@@ -340,7 +328,6 @@ def test_recipe_sidecar_manifest_fragment_complete():
     recipe. Verify the helper produces all four for every method.
     """
     from _kernel_manifest import (
-        KERNEL_CODEBOOK_HASHES,
         KERNEL_TARGETS,
         kernel_manifest_fragment,
     )
@@ -356,6 +343,7 @@ def test_recipe_sidecar_manifest_fragment_complete():
         assert required_keys <= set(frag), (
             f"{method}: manifest fragment missing keys {required_keys - set(frag)}"
         )
+        assert frag["target_class"] in {"weights", "kv-cache"}
         assert frag["kernel_target"], f"{method}: empty kernel_target"
         for target in frag["kernel_target"]:
             assert frag["block_layout_version"][target], (
@@ -364,33 +352,70 @@ def test_recipe_sidecar_manifest_fragment_complete():
             assert frag["codebook_hash"][target], (
                 f"{method}/{target}: empty codebook_hash"
             )
-            assert frag["codebook_hash"][target] == KERNEL_CODEBOOK_HASHES[target]
-            assert frag["codebook_hash"][target].startswith("sha256:"), (
-                f"{method}/{target}: codebook_hash must be a real sha256 digest"
-            )
+            assert frag["codebook_hash"][target].startswith("sha256:")
             assert len(frag["codebook_hash"][target]) == len("sha256:") + 64
+            assert frag["codebook_hash_source"][target], (
+                f"{method}/{target}: empty codebook_hash_source"
+            )
             assert frag["per_block_tolerance"][target] > 0, (
                 f"{method}/{target}: non-positive per_block_tolerance"
             )
 
 
-def test_kernel_manifest_codebook_hashes_match_pinned_sources():
-    """Manifest codebook hashes are computed from C/kernel source content.
-
-    Any drift in the committed C codebook/layout source must fail here until
-    the pinned digest is reviewed and updated in the same PR.
-    """
+def test_kernel_manifest_hashes_verify_real_source_files():
+    """The manifest `codebook_hash` pins are sha256 values of real kernel
+    source files, not descriptive labels. Drift must be caught before a recipe
+    sidecar is published."""
     from _kernel_manifest import (
         KERNEL_CODEBOOK_HASHES,
         PINNED_KERNEL_CODEBOOK_SHA256,
-        assert_kernel_codebook_hashes_current,
+        verify_kernel_codebook_hashes,
     )
 
-    observed = assert_kernel_codebook_hashes_current()
-    assert observed == PINNED_KERNEL_CODEBOOK_SHA256
-    assert KERNEL_CODEBOOK_HASHES == {
-        target: f"sha256:{digest}" for target, digest in observed.items()
-    }
+    actual = verify_kernel_codebook_hashes()
+    assert actual == PINNED_KERNEL_CODEBOOK_SHA256
+    for target, digest in KERNEL_CODEBOOK_HASHES.items():
+        assert digest == f"sha256:{actual[target]}"
+
+
+def test_kernel_manifest_hash_verification_fails_on_drift(monkeypatch):
+    """A changed native centroid/layout source must fail the recipe gate until
+    the pin is deliberately updated in the same change."""
+    import _kernel_manifest as km
+
+    monkeypatch.setitem(km.PINNED_KERNEL_CODEBOOK_SHA256, "polar_q4", "0" * 64)
+    with pytest.raises(RuntimeError, match="polar_q4"):
+        km.verify_kernel_codebook_hashes(("polar_q4",))
+
+
+def test_agents_quantization_section_matches_recipe_target_classes():
+    """Doc parity for the Stage 3 recipe-reality contract."""
+    from _kernel_manifest import KERNEL_RECIPE_TARGET_CLASSES
+
+    agents = (_REPO_ROOT / "packages" / "training" / "AGENTS.md").read_text(
+        encoding="utf-8"
+    )
+    assert KERNEL_RECIPE_TARGET_CLASSES["turboquant"] == "kv-cache"
+    assert "TurboQuant is a runtime KV-cache compressor" in agents
+    assert KERNEL_RECIPE_TARGET_CLASSES["qjl"] == "kv-cache"
+    assert "QJL is a runtime K-cache compressor" in agents
+    assert KERNEL_RECIPE_TARGET_CLASSES["polarquant"] == "weights"
+    assert "PolarQuant is a weight quantizer" in agents
+    assert "The shipping Gemma weight quant is stock\n`llama-quantize` Q4_K_M" in agents
+
+
+def test_llama_cpp_default_resolves_to_plugin_local_inference(monkeypatch):
+    """Converter callers with no LLAMA_CPP_DIR must search the canonical fork
+    submodule under plugins/plugin-local-inference/native/llama.cpp."""
+    from _common import DEFAULT_LLAMA_CPP_DIR, LLAMA_CPP_RELATIVE_DIR
+
+    monkeypatch.delenv("LLAMA_CPP_DIR", raising=False)
+    assert LLAMA_CPP_RELATIVE_DIR.as_posix() == (
+        "plugins/plugin-local-inference/native/llama.cpp"
+    )
+    assert DEFAULT_LLAMA_CPP_DIR == (
+        _REPO_ROOT / "plugins" / "plugin-local-inference" / "native" / "llama.cpp"
+    )
 
 
 def test_kernel_manifest_fragment_rejects_unknown_method():
@@ -839,19 +864,13 @@ _KQUANT_SIBLINGS = (
     ("gguf-q6_k_apply",   "Q6_K"),
 )
 
-_CANONICAL_LLAMA_CPP_SUFFIX = Path(
-    "plugins/plugin-local-inference/native/llama.cpp"
-)
 
-
-def _load_module_from_quantization_file(module_basename: str):
+def _load_quantization_module(module_basename: str):
     import importlib.util
 
     importable = module_basename.replace("-", "_")
-    quant_dir = Path(__file__).resolve().parent
-    spec_path = quant_dir / f"{module_basename}.py"
+    spec_path = Path(__file__).resolve().parent / f"{module_basename}.py"
     assert spec_path.exists(), f"missing quantization module: {spec_path}"
-
     spec = importlib.util.spec_from_file_location(importable, spec_path)
     assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
@@ -864,7 +883,7 @@ def test_kquant_sibling_exports_constant(module_basename: str, expected_level: s
     """Every K-quant ladder sibling exports a `QUANT_LEVEL` constant matching
     its filename. The publish path keys on this constant to pick the
     llama-quantize target type."""
-    mod = _load_module_from_quantization_file(module_basename)
+    mod = _load_quantization_module(module_basename)
     assert getattr(mod, "QUANT_LEVEL") == expected_level
 
 
@@ -875,7 +894,7 @@ def test_kquant_sibling_dry_run_prints_quant_level(
     """Every K-quant sibling supports the same --dry-run surface as the
     Q4_K_M baseline. Output is JSON and contains the recipe-level
     metadata."""
-    mod = _load_module_from_quantization_file(module_basename)
+    mod = _load_quantization_module(module_basename)
     rc = mod.main([
         "--model", "google/gemma-4-E2B",
         "--output", str(tmp_path),
@@ -891,7 +910,7 @@ def test_kquant_sibling_dry_run_prints_quant_level(
 def test_kquant_sibling_fails_when_artifact_load_smoke_fails(
     module_basename: str, expected_level: str, monkeypatch, tmp_path
 ):
-    mod = _load_module_from_quantization_file(module_basename)
+    mod = _load_quantization_module(module_basename)
     fake_llama = tmp_path / "llama.cpp"
     fake_llama.mkdir()
     fake_convert = fake_llama / "convert_hf_to_gguf.py"
@@ -929,7 +948,7 @@ def test_kquant_sibling_fails_when_artifact_load_smoke_fails(
 def test_kquant_sibling_no_smoke_marks_artifact_not_release_eligible(
     module_basename: str, _expected_level: str, monkeypatch, tmp_path
 ):
-    mod = _load_module_from_quantization_file(module_basename)
+    mod = _load_quantization_module(module_basename)
     fake_llama = tmp_path / "llama.cpp"
     fake_llama.mkdir()
     fake_convert = fake_llama / "convert_hf_to_gguf.py"
@@ -961,8 +980,8 @@ def test_kquant_sibling_no_smoke_marks_artifact_not_release_eligible(
     assert sidecar["smoke_load"] == {
         "ok": False,
         "skipped": True,
-        "releaseEligible": False,
-        "reason": "--no-smoke-load was passed",
+        "release_eligible": False,
+        "error": "--no-smoke-load was used; no real-artifact recipe test ran",
     }
 
 
@@ -989,6 +1008,10 @@ def test_gguf_wrappers_default_to_runtime_llama_cpp_submodule(module_basename: s
     assert (
         _CANONICAL_LLAMA_CPP_SUFFIX.as_posix() in source
         or '"plugins" / "plugin-local-inference" / "native" / "llama.cpp"' in source
+        or (
+            "DEFAULT_LLAMA_CPP_DIR" in source
+            and "find_llama_convert_script" in source
+        )
     )
     assert '"packages" / "inference" / "llama.cpp"' not in source
     assert "packages/inference/llama.cpp" not in source
@@ -1004,6 +1027,42 @@ def test_eliza_typed_gguf_resolver_uses_runtime_llama_cpp_submodule():
     )
     assert '"packages" / "inference" / "llama.cpp"' not in source
     assert "packages/inference/llama.cpp" not in source
+
+
+def test_q4_k_m_apply_records_passing_recipe_test(monkeypatch, tmp_path):
+    """A passing Q4_K_M load-smoke is recorded as the publish-consumable recipe
+    gate result."""
+    mod = _load_quantization_module("gguf-q4_k_m_apply")
+    fake_quantize = tmp_path / "llama-quantize"
+    fake_quantize.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    def fake_run(cmd):
+        cmd = [str(part) for part in cmd]
+        if "--outfile" in cmd:
+            Path(cmd[cmd.index("--outfile") + 1]).write_bytes(b"f16")
+        else:
+            Path(cmd[-2]).write_bytes(b"quant")
+
+    monkeypatch.setattr(mod, "_find_convert_script", lambda _path: tmp_path / "convert.py")
+    monkeypatch.setattr(mod, "_find_quantize_binary", lambda _path: fake_quantize)
+    monkeypatch.setattr(mod, "_run", fake_run)
+    monkeypatch.setattr(
+        mod,
+        "_smoke_load_gguf",
+        lambda gguf, _quantize: {
+            "ok": True,
+            "output": "The capital of France is Paris.",
+            "cmd": f"llama-cli -m {gguf}",
+        },
+    )
+
+    rc = mod.main(["--model", "local/final", "--output", str(tmp_path)])
+
+    assert rc == 0
+    sidecar = json.loads((tmp_path / "gguf_q4_k_m.json").read_text(encoding="utf-8"))
+    assert sidecar["recipe_test"]["status"] == "passed"
+    assert sidecar["recipe_test"]["release_eligible"] is True
+    assert sidecar["recipe_test"]["artifact"].endswith("final-Q4_K_M.gguf")
 
 
 def test_gguf_asr_apply_dry_run_single_quant(capsys, tmp_path):


### PR DESCRIPTION
## Summary
- clarify the Gemma quantization recipe contract across training docs: stock GGUF K-quant is the shipping weight path; TurboQuant/QJL are runtime KV-cache compressors; PolarQuant is a weight recipe
- make quant recipe helpers resolve the canonical llama.cpp fork and emit real source-hash recipe manifest fragments
- keep legacy sidecars out of recipe provenance unless the produced artifact actually uses the recipe, and gate Q4_K_M sidecar writing on the load-smoke result

## Evidence
- Added .github/issue-evidence/12320-stage3-quant-recipe-reality.md
- diff -u packages/training/CLAUDE.md packages/training/AGENTS.md: passed
- git diff --check: passed
- uv run --project packages/training -- python -m compileall -q packages/training/scripts/quantization packages/training/scripts/turn_detector/convert_to_gguf.py packages/training/scripts/run_pipeline.py: passed
- uv run --project packages/training --with pytest --with transformers --with safetensors -- python -m pytest packages/training/scripts/quantization/test_gguf_eliza1_apply.py packages/training/scripts/quantization/test_recipes_smoke.py: 46 passed, 3 warnings in 69.08s
- dry-runs for gguf-q4_k_m_apply.py and gguf_eliza1_apply.py passed and emitted expected JSON

## Remaining evidence noted
- No real 2B checkpoint quantized in this local run; byte-level GGUF/header and corrupt-block publish-blocking proof still require built llama.cpp fork plus actual Gemma checkpoint bytes.

Refs #12320