### PR TITLE
test(ui): format thread autoscroll regression

### DIFF
--- a/packages/ui/src/hooks/useThreadAutoScroll.test.tsx
+++ b/packages/ui/src/hooks/useThreadAutoScroll.test.tsx
@@ -208,7 +208,9 @@ describe("useThreadAutoScroll", () => {
     // scrollTop stays at 600. A live re-measure reads 1300-600-400=300 > 80 and
     // wrongly stops following; the pre-growth measure (1000-600-400=0) follows.
     height = 1300;
-    rerender(<Harness growthKey={2} scroller={scroller} onState={cap.onState} />);
+    rerender(
+      <Harness growthKey={2} scroller={scroller} onState={cap.onState} />,
+    );
     flushRaf();
     // Followed to the new clamped bottom (1300 - 400); reader stays pinned.
     expect(scroller.scrollTop).toBe(900);


### PR DESCRIPTION
## Summary
- Wrap the new useThreadAutoScroll regression test rerender call so Biome accepts the file after #12624 merged.
- No runtime code changes.

## Verification
- PASS: bunx @biomejs/biome check packages/ui/src/hooks/useThreadAutoScroll.ts packages/ui/src/hooks/useThreadAutoScroll.test.tsx
- PASS: git diff --check origin/develop...HEAD
- NOTE: bun run --cwd packages/ui test -- src/hooks/useThreadAutoScroll.test.tsx was attempted in the temp worktree and fails before assertions with duplicate React resolution caused by the local symlinked dependency setup: React is loaded from dist/node_modules and node_modules. This PR only fixes formatting.

## Evidence Matrix
- Screenshots/video: N/A - formatting-only test change, no UI/runtime behavior changed.
- Real-LLM trajectories: N/A - no model/prompt/provider/action behavior changed.
- Domain artifacts: N/A - no domain data changes.