### PR TITLE
fix(google-chat): fail closed on invalid accounts json

### DIFF
--- a/.github/issue-evidence/12272-google-chat-invalid-accounts-json.md
+++ b/.github/issue-evidence/12272-google-chat-invalid-accounts-json.md
@@ -1,0 +1,69 @@
+# Issue #12272 - Google Chat invalid accounts JSON
+
+## Scope
+
+This chunk fixes the Google Chat connector account-config slop called out in issue #12272: malformed `GOOGLE_CHAT_ACCOUNTS` no longer resolves to `{}` and silently boots the connector as if no accounts were configured. The parser now throws an `ElizaError` with:
+
+- `code`: `GOOGLE_CHAT_CONFIG_INVALID`
+- `context`: `{ "setting": "GOOGLE_CHAT_ACCOUNTS" }`
+- `severity`: `fatal`
+- `cause`: the original `SyntaxError`
+
+The Google Chat Vitest shim for `@elizaos/core` now also exports the real structured-error symbols so connector unit tests exercise the same error type used by production imports.
+
+## Verification
+
+Run on July 3, 2026 from branch `codex/fix-12272-google-chat-invalid-accounts`.
+
+```bash
+bun run --cwd plugins/plugin-google-chat test -- src/accounts.test.ts
+```
+
+Result: passed, 1 file / 6 tests.
+
+```bash
+bun run --cwd plugins/plugin-google-chat test
+```
+
+Result: passed, 2 files / 11 tests.
+
+```bash
+bunx @biomejs/biome check \
+  plugins/plugin-google-chat/src/accounts.ts \
+  plugins/plugin-google-chat/src/accounts.test.ts \
+  packages/test/vitest/shims/elizaos-core-connector.ts
+```
+
+Result: passed, 3 files checked.
+
+```bash
+bun run --cwd plugins/plugin-google-chat typecheck
+```
+
+Result: passed.
+
+```bash
+bun run --cwd plugins/plugin-google-chat build
+```
+
+Result: passed.
+
+```bash
+bun run audit:error-policy-ratchet
+```
+
+Result: passed. The ratchet reported 1 changed production source file and no new fallback slop.
+
+```bash
+bun run verify
+```
+
+Result: failed on an unrelated existing lint issue in `@elizaos/cloud-ui#lint` after 104 successful tasks. The reported files were `packages/cloud-ui/src/approvals/ApprovalsRoute.tsx`, `packages/cloud-ui/src/approvals/components/approvals-tab.tsx`, `packages/cloud-ui/src/approvals/components/ballots-tab.tsx`, `packages/cloud-ui/src/approvals/components/sensitive-tab.tsx`, `packages/cloud-ui/src/approvals/index.ts`, `packages/cloud-ui/src/approvals/lib/approvals.ts`, and `packages/cloud-ui/src/index.ts`, all import/export ordering or formatting findings outside this branch's touched files.
+
+## Evidence Matrix
+
+- Backend logs: N/A - this is a startup/config parsing failure covered by a direct package regression test before any Google Chat API client or route runs.
+- Frontend screenshots/video: N/A - no UI surface changed.
+- Live Google Chat round-trip: N/A - the fixed path rejects malformed local configuration before a connector account can be constructed or a platform request can be made.
+- Real-LLM trajectories: N/A - no agent action, provider, prompt, model, or message-turn behavior changed.
+- Domain artifact: the failing config input `{not json` now produces the typed fatal error asserted in `plugins/plugin-google-chat/src/accounts.test.ts`.

--- a/packages/test/vitest/shims/elizaos-core-connector.ts
+++ b/packages/test/vitest/shims/elizaos-core-connector.ts
@@ -23,7 +23,10 @@ export { readRequestedConnectorRole } from "../../../core/src/connectors/oauth-r
 // assertions in error-path tests exercise the real type, not a stub.
 export {
   ElizaError,
+  type ElizaErrorOptions,
+  type ElizaErrorSeverity,
   isElizaError,
+  type ReportedError,
   toElizaError,
 } from "../../../core/src/errors.ts";
 export {

--- a/plugins/plugin-google-chat/src/accounts.test.ts
+++ b/plugins/plugin-google-chat/src/accounts.test.ts
@@ -3,7 +3,7 @@
  * provider, and the workflow credential provider, against an in-memory
  * `getSetting` stub — no Google API calls.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {
   listGoogleChatAccountIds,
@@ -25,13 +25,22 @@ function runtime(
 }
 
 describe("Google Chat account config", () => {
-  it("ignores malformed GOOGLE_CHAT_ACCOUNTS and falls back to default discovery", () => {
+  it("fails closed for malformed GOOGLE_CHAT_ACCOUNTS", () => {
     const rt = runtime({
       GOOGLE_CHAT_ACCOUNTS: "{not json",
     });
 
-    expect(listGoogleChatAccountIds(rt)).toEqual(["default"]);
-    expect(resolveDefaultGoogleChatAccountId(rt)).toBe("default");
+    expect(() => listGoogleChatAccountIds(rt)).toThrow(ElizaError);
+    try {
+      resolveDefaultGoogleChatAccountId(rt);
+      throw new Error("expected malformed GOOGLE_CHAT_ACCOUNTS to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe("GOOGLE_CHAT_CONFIG_INVALID");
+      expect((error as ElizaError).context).toEqual({ setting: "GOOGLE_CHAT_ACCOUNTS" });
+      expect((error as ElizaError).severity).toBe("fatal");
+      expect((error as Error).cause).toBeInstanceOf(SyntaxError);
+    }
   });
 
   it("does not leak default env credentials into explicitly requested named accounts", () => {

--- a/plugins/plugin-google-chat/src/accounts.ts
+++ b/plugins/plugin-google-chat/src/accounts.ts
@@ -5,7 +5,7 @@
  * `google-chat` alias), merging per field. Supplies the service the space list
  * and service-account credentials for each configured account.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import type { GoogleChatAudienceType, GoogleChatSettings } from "./types.js";
 
 export const DEFAULT_GOOGLE_CHAT_ACCOUNT_ID = "default";
@@ -55,8 +55,13 @@ function parseAccountsJson(runtime: IAgentRuntime): Record<string, GoogleChatAcc
     return parsed && typeof parsed === "object"
       ? (parsed as Record<string, GoogleChatAccountConfig>)
       : {};
-  } catch {
-    return {};
+  } catch (error) {
+    throw new ElizaError("Google Chat accounts config is not valid JSON.", {
+      code: "GOOGLE_CHAT_CONFIG_INVALID",
+      cause: error,
+      context: { setting: "GOOGLE_CHAT_ACCOUNTS" },
+      severity: "fatal",
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- change malformed `GOOGLE_CHAT_ACCOUNTS` parsing from silent `{}` fallback to a fatal `ElizaError` with `GOOGLE_CHAT_CONFIG_INVALID`
- update the account resolution regression test to assert the typed error, preserved `SyntaxError` cause, severity, and config setting context
- keep the connector Vitest shim aligned with the real core structured-error export path for this error-path test

## Evidence
- `.github/issue-evidence/12272-google-chat-invalid-accounts-json.md`

## Verification
- `bun run --cwd plugins/plugin-google-chat test -- src/accounts.test.ts`
- `bun run --cwd plugins/plugin-google-chat test`
- `bunx @biomejs/biome check plugins/plugin-google-chat/src/accounts.ts plugins/plugin-google-chat/src/accounts.test.ts packages/test/vitest/shims/elizaos-core-connector.ts`
- `bun run --cwd plugins/plugin-google-chat typecheck`
- `bun run --cwd plugins/plugin-google-chat build`
- `bun run audit:error-policy-ratchet`

## Root Verify
- `bun run verify` was run after rebasing onto `origin/develop` and failed in unrelated `@elizaos/cloud-ui#lint` import/export ordering and formatting findings under `packages/cloud-ui/src/approvals/*` and `packages/cloud-ui/src/index.ts`. Those files are outside this PR.

## Evidence Matrix
- Backend logs: N/A - local startup/config parse failure before Google Chat API/client construction
- Frontend screenshots/video: N/A - no UI changed
- Live Google Chat round-trip: N/A - malformed local config rejects before platform I/O
- Real-LLM trajectories: N/A - no prompt/action/provider/model behavior changed

Closes #12272 (partial connector-slice chunk).
