### PR TITLE
fix(#12321): gate HF audit text architecture

### DIFF
--- a/.github/issue-evidence/12216-stage4-hf-audit-architecture/README.md
+++ b/.github/issue-evidence/12216-stage4-hf-audit-architecture/README.md
@@ -1,0 +1,20 @@
+# Stage 4: HF audit text architecture gate
+
+Issue: #12321
+
+This slice makes the metadata-only Hugging Face release audit enforce the text
+architecture recorded in each bundle manifest. Every `files.text` entry must
+carry a non-empty `architecture` value and it must be Gemma-family
+(`gemma*`). A qwen35 text artifact recorded in the manifest now fails the HF
+release audit instead of passing through as a Gemma bundle.
+
+Verification commands:
+
+```bash
+python3 -m pytest packages/training/scripts/manifest/test_audit_hf_eliza1_release.py -q -k 'complete_hf_release_audit_passes or non_gemma_manifest_text_architecture or missing_manifest_text_context_variant or wrong_manifest_text_context_value or requires_quantization_sidecars'
+python3 -m py_compile packages/training/scripts/manifest/audit_hf_eliza1_release.py packages/training/scripts/manifest/test_audit_hf_eliza1_release.py
+git diff --check origin/develop..HEAD
+```
+
+UI/screenshots/video: N/A. This change only affects release-audit metadata
+checks and tests.

--- a/packages/training/scripts/manifest/audit_hf_eliza1_release.py
+++ b/packages/training/scripts/manifest/audit_hf_eliza1_release.py
@@ -571,6 +571,28 @@ def _manifest_text_context_blockers(manifest: Mapping[str, Any], tier: str) -> l
     return blockers
 
 
+def _manifest_text_architecture_blockers(manifest: Mapping[str, Any]) -> list[str]:
+    files = manifest.get("files")
+    if not isinstance(files, Mapping):
+        return ["missing manifest files block"]
+    text_entries = files.get("text")
+    if not isinstance(text_entries, list) or not text_entries:
+        return ["missing files.text block"]
+    blockers: list[str] = []
+    for entry in text_entries:
+        if not isinstance(entry, Mapping):
+            blockers.append("files.text entry: not an object")
+            continue
+        path = entry.get("path")
+        label = path if isinstance(path, str) else "files.text entry"
+        architecture = entry.get("architecture")
+        if not isinstance(architecture, str) or not architecture:
+            blockers.append(f"{label}: architecture missing")
+        elif not architecture.lower().startswith("gemma"):
+            blockers.append(f"{label}: architecture={architecture!r}")
+    return blockers
+
+
 def _manifest_required_file_blockers(
     manifest: Mapping[str, Any],
     *,
@@ -1639,6 +1661,13 @@ def audit_hf_release(
             f"{tier} manifest records native and half context text variants",
             not text_context_blockers,
             ", ".join(text_context_blockers[:8]) + (f" (+{len(text_context_blockers) - 8} more)" if len(text_context_blockers) > 8 else ""),
+        )
+        text_architecture_blockers = _manifest_text_architecture_blockers(manifest)
+        report.check(
+            f"{tier} manifest text architectures are Gemma",
+            not text_architecture_blockers,
+            ", ".join(text_architecture_blockers[:8])
+            + (f" (+{len(text_architecture_blockers) - 8} more)" if len(text_architecture_blockers) > 8 else ""),
         )
         manifest_required_file_blockers = _manifest_required_file_blockers(
             manifest,

--- a/packages/training/scripts/manifest/test_audit_hf_eliza1_release.py
+++ b/packages/training/scripts/manifest/test_audit_hf_eliza1_release.py
@@ -69,6 +69,7 @@ def _complete_model_paths() -> list[str]:
     for tier, tier_plan in build_plan().items():
         paths.append(f"bundles/{tier}/eliza-1.manifest.json")
         paths.extend(f"bundles/{tier}/{rel}" for rel in tier_plan.required_files)
+        paths.extend(f"bundles/{tier}/{rel}" for rel in QUANTIZATION_SIDECARS)
         paths.extend(
             f"bundles/{tier}/{target.evidence_path}"
             for target in tier_plan.required_platform_evidence
@@ -771,10 +772,12 @@ def _passing_model_manifest(tier: str) -> str:
     for rel in build_plan()[tier].required_files:
         root = rel.split("/", 1)[0]
         entry: dict[str, object] = {"path": rel, "sha256": "a" * 64}
-        if root == "text" and "-128k" in rel:
-            entry["ctx"] = 131072
-        elif root == "text" and "-256k" in rel:
-            entry["ctx"] = 262144
+        if root == "text":
+            entry["architecture"] = "gemma4"
+            if "-128k" in rel:
+                entry["ctx"] = 131072
+            elif "-256k" in rel:
+                entry["ctx"] = 262144
         files_by_dir.setdefault(root, []).append(entry)
     return __import__("json").dumps(
         {
@@ -1009,6 +1012,26 @@ def test_hf_release_audit_blocks_missing_manifest_text_context_variant() -> None
     assert any(
         check["name"] == "2b manifest records native and half context text variants"
         and "text/eliza-1-2b-256k.gguf" in check["detail"]
+        for check in failed
+    )
+
+
+def test_hf_release_audit_blocks_non_gemma_manifest_text_architecture() -> None:
+    bad_manifest = __import__("json").loads(_passing_model_manifest("9b"))
+    bad_manifest["files"]["text"][0]["architecture"] = "qwen35"
+
+    report = audit_hf_release(
+        fetch_json=_fetcher(),
+        fetch_text=_text_fetcher(
+            model_manifests={"9b": __import__("json").dumps(bad_manifest)}
+        ),
+    )
+
+    assert not report.ok
+    failed = [check for check in report.checks if not check["ok"]]
+    assert any(
+        check["name"] == "9b manifest text architectures are Gemma"
+        and "architecture='qwen35'" in check["detail"]
         for check in failed
     )
 


### PR DESCRIPTION
## Summary
- make `audit_hf_eliza1_release.py` require every manifest `files.text` entry to carry a Gemma-family architecture
- fail the HF audit when a manifest records qwen35 or missing text architecture
- update the release-audit happy-path fixture to include text architecture and complete quant sidecar sibling paths
- add a regression test proving qwen35 text architecture blocks the audit

## Evidence
- `python3 -m pytest packages/training/scripts/manifest/test_audit_hf_eliza1_release.py -q -k 'complete_hf_release_audit_passes or non_gemma_manifest_text_architecture or missing_manifest_text_context_variant or wrong_manifest_text_context_value or requires_quantization_sidecars'`\n- `python3 -m py_compile packages/training/scripts/manifest/audit_hf_eliza1_release.py packages/training/scripts/manifest/test_audit_hf_eliza1_release.py`\n- `git diff --check origin/develop..HEAD`\n\nIssue evidence: `.github/issue-evidence/12216-stage4-hf-audit-architecture/README.md`\n\nScreenshots/video: N/A, release-audit metadata gate only.\n\nRefs #12321