### PR TITLE
fix(cloud): gate embeddings OPTIMISTIC billing off affiliate-marked requests — close the residual #12017 mint

### DIFF
--- a/packages/cloud/api/__tests__/embeddings-affiliate-reserve.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-affiliate-reserve.test.ts
@@ -111,15 +111,23 @@ mock.module("@/db/repositories/affiliates", () => ({
 
 // --- Credits ledger: reserve stub reproducing the REAL hold arithmetic
 // (credits.ts reserve(): estimatedCost × estimatedCostMultiplier, buffered by
-// COST_BUFFER) so reservedAmount is faithful to what prod would hold. ---------
+// COST_BUFFER, thrown InsufficientCreditsError when the org balance can't
+// cover the hold) so reservedAmount AND the 402 gate are faithful to prod. ----
+let orgBalanceUsd = Number.POSITIVE_INFINITY;
 const reconcile = mock(async (_actualCost: number) => undefined);
 const reserve = mock(
   async (
     params: { estimatedCostMultiplier?: number } & Record<string, unknown>,
   ) => {
     const multiplier = params.estimatedCostMultiplier ?? 1;
+    const hold = BASE_COST * multiplier * COST_BUFFER;
+    if (hold > orgBalanceUsd) {
+      // The REAL class the route's instanceof checks against (credits.ts,
+      // re-exported by ai-billing) — mirrors credits.ts reserve() fail-closed.
+      throw new creditsActual.InsufficientCreditsError(hold, orgBalanceUsd);
+    }
     return {
-      reservedAmount: BASE_COST * multiplier * COST_BUFFER,
+      reservedAmount: hold,
       reservationTransactionId: "reservation-1",
       reconcile,
     };
@@ -229,6 +237,7 @@ function post(body: unknown, ctx: ExecutionContext, affiliateCode?: string) {
 beforeEach(() => {
   affiliateUserId = AFFILIATE_USER;
   affiliateActive = true;
+  orgBalanceUsd = Number.POSITIVE_INFINITY;
   requireUserOrApiKeyWithOrg.mockClear();
   resolveInferenceAuthContext.mockClear();
   enforceOrgRateLimit.mockClear();
@@ -348,6 +357,47 @@ describe("POST /api/v1/embeddings — affiliate markup is reserved upfront (#120
     };
     expect(reserveArg.estimatedCostMultiplier).toBeUndefined();
     expect(reconcile.mock.calls[0][0]).toBeCloseTo(BASE_COST, 6);
+    expect(addEarnings).not.toHaveBeenCalled();
+  });
+
+  test("caller who can afford base but NOT base+markup is 402'd upfront — no embedding, no settle, no mint", async () => {
+    // $0.20 covers the base hold ($0.10 × 1.5 = $0.15) but NOT the marked-up
+    // hold ($0.10 × 11 × 1.5 = $1.65). Pre-#12017 this request sailed through
+    // (the reserve never saw the affiliate) and settled a $1.10 charge against
+    // a $0.15 hold while minting $1.00 of cashable earnings.
+    orgBalanceUsd = 0.2;
+
+    // Positive control: WITHOUT the affiliate header the same balance passes.
+    const control = makeExecutionCtx();
+    const controlRes = await post(
+      { model: "text-embedding-3-small", input: "hi" },
+      control.ctx,
+    );
+    expect(controlRes.status).toBe(200);
+    await Promise.all(control.scheduled);
+    expect(reserve).toHaveBeenCalledTimes(1);
+
+    reserve.mockClear();
+    reconcile.mockClear();
+    addEarnings.mockClear();
+    embed.mockClear();
+
+    // The attack request: base affordable, base+markup not → fail-closed 402
+    // BEFORE the embedder runs, so nothing settles and nothing is minted.
+    const { ctx, scheduled } = makeExecutionCtx();
+    const res = await post(
+      { model: "text-embedding-3-small", input: "hi" },
+      ctx,
+      "PARTNER1000",
+    );
+    expect(res.status).toBe(402);
+    const body = (await res.json()) as { error: { type: string } };
+    expect(body.error.type).toBe("insufficient_quota");
+    await Promise.all(scheduled);
+
+    expect(reserve).toHaveBeenCalledTimes(1); // the marked-up reserve attempt
+    expect(embed).not.toHaveBeenCalled();
+    expect(reconcile).not.toHaveBeenCalled();
     expect(addEarnings).not.toHaveBeenCalled();
   });
 

--- a/packages/cloud/api/__tests__/embeddings-optimistic-billing.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-optimistic-billing.test.ts
@@ -35,6 +35,7 @@ import * as languageModelActual from "@/lib/providers/language-model";
 import * as aiBillingActual from "@/lib/services/ai-billing";
 import * as inferenceAuthActual from "@/lib/services/inference-auth-context";
 import * as fastPathActual from "@/lib/services/inference-billing-fast-path";
+import * as ledgerActual from "@/lib/services/inference-billing-ledger";
 import * as usageActual from "@/lib/services/usage";
 
 const aiActual = require("ai") as Record<string, unknown>;
@@ -56,6 +57,7 @@ let backstopAvailable = true;
 let gateBalanceUsd = 100;
 let thresholdUsd = 5;
 let backstopPersists = true;
+let billingLedger = "kv"; // anything but "db" → the KV backstop branch
 
 // --- spies on the two terminal billing paths --------------------------------
 const writePendingInferenceCharge = mock(
@@ -118,6 +120,19 @@ mock.module("@/lib/services/inference-billing-fast-path", () => ({
   createOptimisticDebitSettler,
 }));
 
+// DB-ledger optimistic branch (#12017): the ledger selector is a knob and the
+// admission/settler are spied so the tests can prove which branch admitted.
+const admitInferenceChargeViaLedger = mock(
+  async () => ({ admitted: true }) as never,
+);
+const createLedgerDebitSettler = mock(() => async () => undefined);
+mock.module("@/lib/services/inference-billing-ledger", () => ({
+  ...ledgerActual,
+  resolveInferenceBillingLedger: () => billingLedger,
+  admitInferenceChargeViaLedger,
+  createLedgerDebitSettler,
+}));
+
 // Synchronous reserve path — spied so we can prove it is the fallback. billUsage
 // is a no-op return (the settle is not the observation point here).
 mock.module("@/lib/services/ai-billing", () => ({
@@ -158,6 +173,14 @@ mock.module("ai", () => ({
 const embeddingsRoute = (await import("../v1/embeddings/route")).default;
 
 afterAll(() => {
+  // Leave the knobs fail-safe BEFORE restoring the modules: bun's mock.module
+  // can leave already-evaluated importers (the route, first loaded by an
+  // earlier test file) bound to the mocked functions even after the registry
+  // restore below, and those closures read these knobs by reference. A leaked
+  // `billingEnabled=true` (or a "db" ledger) would silently flip LATER test
+  // files' requests onto an optimistic path their suites never account for.
+  billingEnabled = false;
+  billingLedger = "kv";
   mock.module(
     "@/lib/services/inference-auth-context",
     () => inferenceAuthActual,
@@ -169,6 +192,7 @@ afterAll(() => {
     "@/lib/services/inference-billing-fast-path",
     () => fastPathActual,
   );
+  mock.module("@/lib/services/inference-billing-ledger", () => ledgerActual);
   mock.module("@/lib/services/ai-billing", () => aiBillingActual);
   mock.module("@/lib/services/usage", () => usageActual);
   mock.module("ai", () => aiActual);
@@ -187,7 +211,7 @@ function makeExecutionCtx() {
   };
 }
 
-function post(body: unknown, ctx?: ExecutionContext) {
+function post(body: unknown, ctx?: ExecutionContext, affiliateCode?: string) {
   return embeddingsRoute.request(
     "/",
     {
@@ -196,6 +220,7 @@ function post(body: unknown, ctx?: ExecutionContext) {
         Authorization: "Bearer eliza_test_key",
         "Content-Type": "application/json",
         "x-request-id": CLIENT_REQUEST_ID,
+        ...(affiliateCode ? { "X-Affiliate-Code": affiliateCode } : {}),
       },
       body: JSON.stringify(body),
     },
@@ -211,9 +236,12 @@ describe("POST /api/v1/embeddings optimistic-billing route decision (#9899/#1010
     gateBalanceUsd = 100;
     thresholdUsd = 5;
     backstopPersists = true;
+    billingLedger = "kv";
     writePendingInferenceCharge.mockClear();
     reserveCredits.mockClear();
     createOptimisticDebitSettler.mockClear();
+    admitInferenceChargeViaLedger.mockClear();
+    createLedgerDebitSettler.mockClear();
   });
 
   test("eligible org takes the optimistic path: writes backstop, skips the synchronous reserve", async () => {
@@ -327,5 +355,73 @@ describe("POST /api/v1/embeddings optimistic-billing route decision (#9899/#1010
     // ...but a non-durable write must fall through to the synchronous reserve.
     expect(reserveCredits).toHaveBeenCalledTimes(1);
     expect(createOptimisticDebitSettler).not.toHaveBeenCalled();
+  });
+
+  // #12017: the optimistic branches admit on a BASE-cost estimate and this
+  // route's billUsage runs without the reservation (#10557), so an affiliate
+  // markup (attacker-set, up to 1000%) would be minted as cashable earnings
+  // against money the admission gate never accounted for. A request carrying
+  // X-Affiliate-Code must therefore take the SYNCHRONOUS reserve, whose hold
+  // folds the markup (reserveCredits → resolveBillableAffiliate →
+  // estimatedCostMultiplier — the markup arithmetic itself is pinned by
+  // embeddings-affiliate-reserve.test.ts).
+  test("X-Affiliate-Code forces the synchronous reserve even when the KV optimistic path is eligible (#12017)", async () => {
+    const { ctx, scheduled } = makeExecutionCtx();
+    const res = await post(
+      { model: "text-embedding-3-small", input: "hi" },
+      ctx,
+      "PARTNER1000",
+    );
+    await Promise.all(scheduled);
+    expect(res.status).toBe(200);
+
+    // Neither optimistic admission may see a marked-up request…
+    expect(writePendingInferenceCharge).not.toHaveBeenCalled();
+    expect(createOptimisticDebitSettler).not.toHaveBeenCalled();
+    // …the synchronous reserve runs and CARRIES the affiliate, so the hold
+    // covers base + markup and an uncollectable settle can't mint earnings.
+    expect(reserveCredits).toHaveBeenCalledTimes(1);
+    const reserveCalls = reserveCredits.mock.calls as unknown as Array<
+      [{ affiliateCode?: string | null }]
+    >;
+    expect(reserveCalls[0]?.[0]?.affiliateCode).toBe("PARTNER1000");
+  });
+
+  test("X-Affiliate-Code also bypasses the DB-ledger optimistic branch (#12017)", async () => {
+    billingLedger = "db";
+
+    // Positive control: WITHOUT the header the ledger branch admits and the
+    // synchronous reserve is skipped — proving the gate below is affiliate-
+    // specific, not a broken ledger branch.
+    const control = makeExecutionCtx();
+    const controlRes = await post(
+      { model: "text-embedding-3-small", input: "hi" },
+      control.ctx,
+    );
+    await Promise.all(control.scheduled);
+    expect(controlRes.status).toBe(200);
+    expect(admitInferenceChargeViaLedger).toHaveBeenCalledTimes(1);
+    expect(reserveCredits).not.toHaveBeenCalled();
+
+    admitInferenceChargeViaLedger.mockClear();
+    createLedgerDebitSettler.mockClear();
+    reserveCredits.mockClear();
+
+    const { ctx, scheduled } = makeExecutionCtx();
+    const res = await post(
+      { model: "text-embedding-3-small", input: "hi" },
+      ctx,
+      "PARTNER1000",
+    );
+    await Promise.all(scheduled);
+    expect(res.status).toBe(200);
+
+    expect(admitInferenceChargeViaLedger).not.toHaveBeenCalled();
+    expect(createLedgerDebitSettler).not.toHaveBeenCalled();
+    expect(reserveCredits).toHaveBeenCalledTimes(1);
+    const reserveCalls = reserveCredits.mock.calls as unknown as Array<
+      [{ affiliateCode?: string | null }]
+    >;
+    expect(reserveCalls[0]?.[0]?.affiliateCode).toBe("PARTNER1000");
   });
 });

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -228,9 +228,26 @@ app.post("/", async (c) => {
     // Durable backstop selected by INFERENCE_BILLING_LEDGER (see chat route). The
     // DB ledger's atomic admission is itself the gate and needs no writable cache.
     const optimisticBillingEnabled = isOptimisticBillingEnabled();
+    // #12017 (part 2): a request carrying an affiliate code must take the
+    // SYNCHRONOUS reserve. Both optimistic fast paths below admit on a
+    // BASE-cost estimate (calculateCost only) — the affiliate markup
+    // (attacker-set, up to 1000%) is invisible to them because
+    // resolveBillableAffiliate lives inside reserveCredits, and on this route
+    // billUsage runs WITHOUT the reservation (#10557), so nothing clamps the
+    // affiliate credit to collected money on those paths. An optimistically
+    // admitted marked-up request could therefore settle far past the admission
+    // gate's headroom while still minting the full cashable affiliate cut —
+    // the same uncollectable-overage mint this issue fixes on the synchronous
+    // path, one env flag away. Falling through folds the markup into the
+    // upfront hold (estimatedCostMultiplier) and 402s upfront when the balance
+    // can't cover base+markup (fail-closed). This costs the fast path nothing
+    // where it matters: the optimistic paths exist for the internal
+    // agent-recall embed hot path, which never sends X-Affiliate-Code.
+    const optimisticAllowedForRequest =
+      optimisticBillingEnabled && affiliateCode === null;
     const useDbLedger =
       !!orgId &&
-      optimisticBillingEnabled &&
+      optimisticAllowedForRequest &&
       resolveInferenceBillingLedger() === "db";
 
     if (useDbLedger) {
@@ -278,7 +295,7 @@ app.post("/", async (c) => {
     if (
       !optimisticReady &&
       orgId &&
-      optimisticBillingEnabled &&
+      optimisticAllowedForRequest &&
       !useDbLedger &&
       isOptimisticBackstopAvailable()
     ) {


### PR DESCRIPTION
## Residual of #12017 (part 1 = #12047, sync path). #12017 was closed on part 1, but the **optimistic** paths were still exposed — reopening the concern here.

## Bug (MED, CASHABLE mint — behind `INFERENCE_OPTIMISTIC_BILLING=true`)
#12047 threaded `affiliateCode` into the /v1/embeddings **synchronous** `reserveCredits` so the hold covers the markup. But both **optimistic** fast paths — the DB-ledger admission (`admitInferenceChargeViaLedger`) and the KV pending-charge backstop (`writePendingInferenceCharge`) — still admit on a **base-cost estimate only**. The affiliate markup (attacker-set up to 1000%) is invisible to them because `resolveBillableAffiliate` lives inside `reserveCredits`; and on this route `billUsage` runs **without** the reservation (#10557), so `collectedAffiliateEarnings` has no reconciliation to clamp against. With optimistic billing on, a marked-up request settles past the admission headroom while minting the full affiliate cut as redeemable earnings — the same uncollectable-overage mint, one env flag away.

## Fix (fail-safe fall-through)
A request carrying `X-Affiliate-Code` now **skips both optimistic branches** and takes the synchronous reserve (whose hold folds the markup via `estimatedCostMultiplier = 1 + markup` and 402s upfront when balance can't cover base+markup). Chosen over duplicating the affiliate-eligibility math into the route gate so those rules stay single-sourced in `ai-billing`. The optimistic paths exist for the internal agent-recall embed hot path, which **never sends `X-Affiliate-Code`** — the fast path loses nothing. No double-charge: exactly one reservation on affiliate requests; #10557 single-settle untouched.

## Tests (mutation-verified)
- `embeddings-optimistic-billing.test.ts`: affiliate header bypasses the KV backstop AND the DB-ledger branch (each with a no-header positive control proving the branch still admits). **Mutation:** revert the gate → `2 fail`.
- `embeddings-affiliate-reserve.test.ts`: a caller who can afford base ($0.15) but NOT base+markup ($1.65) is 402'd before the embedder runs. **Mutation:** remove `affiliateCode` from the sync reserve → `2 fail`.
- Also fixed a latent bun `mock.module` cross-file leak the new tests exposed (optimistic suite now resets knobs in `afterAll`).
- **All 4 embeddings suites: 29 pass / 0 fail** (both file orders); biome + typecheck clean.

Authored by Fable-5 to my spec; independent Fable review posted below. **Follow-up flagged:** /v1/chat/completions may have the same optimistic-branch gap post-#11976 (verifying separately). Money lane → @lalalune; not self-merged.