### PR TITLE
fix(browser): preserve pinned target availability failures

### DIFF
--- a/.github/issue-evidence/12274-browser-target-availability.md
+++ b/.github/issue-evidence/12274-browser-target-availability.md
@@ -1,0 +1,66 @@
+# Issue #12274 - Browser pinned target availability failures
+
+## Scope
+
+This chunk fixes the browser-service slop called out in issue #12274: when a caller pins a browser target and that target's `available()` probe throws, the failure no longer collapses into an empty target list and a generic "not available" message. `BrowserService.resolveTargets()` now throws an `ElizaError` with:
+
+- `code`: `BROWSER_TARGET_UNAVAILABLE`
+- `context`: `{ "targetId": "<target>", "subaction": "<command subaction>" }`
+- `severity`: `ephemeral`
+- `cause`: the original availability/probe error
+
+Automatic unpinned target resolution still ignores unhealthy targets so the existing fallback behavior remains intact.
+
+## Verification
+
+Run on July 4, 2026 from branch `codex/fix-12274-browser-target-availability`.
+
+```bash
+bun run --cwd plugins/plugin-browser test -- src/__tests__/browser-service.test.ts
+```
+
+Result: passed, 1 file / 7 tests.
+
+```bash
+bun run --cwd plugins/plugin-browser test
+```
+
+Result: passed, 27 files / 147 tests.
+
+```bash
+bunx @biomejs/biome check \
+  plugins/plugin-browser/src/browser-service.ts \
+  plugins/plugin-browser/src/__tests__/browser-service.test.ts
+```
+
+Result: passed, 2 files checked.
+
+```bash
+bun run --cwd plugins/plugin-browser typecheck
+```
+
+Result: passed.
+
+```bash
+bun run --cwd plugins/plugin-browser build
+```
+
+Result: passed.
+
+```bash
+bun run audit:error-policy-ratchet
+```
+
+Result: passed with no new fallback slop.
+
+## Root Verify
+
+`bun run verify` was last run on this develop line during the preceding #12272 chunk and failed in unrelated `@elizaos/cloud-ui#lint` import/export ordering and formatting findings under `packages/cloud-ui/src/approvals/*` and `packages/cloud-ui/src/index.ts`. Those files are outside this branch's touched files.
+
+## Evidence Matrix
+
+- Backend logs: N/A - this is an in-process service target-resolution failure covered by the direct `BrowserService.execute({ subaction: "state" }, "bridge")` regression test.
+- Frontend screenshots/video: N/A - no UI surface changed.
+- Browser recording: N/A - the fixed path rejects a failing pinned target availability probe before any browser command reaches a real workspace or companion.
+- Real-LLM trajectories: N/A - no prompt/action/provider/model behavior changed.
+- Domain artifact: the injected `bridge health probe failed` error is preserved as the `cause` of `BROWSER_TARGET_UNAVAILABLE` in `plugins/plugin-browser/src/__tests__/browser-service.test.ts`.

--- a/plugins/plugin-browser/src/__tests__/browser-service.test.ts
+++ b/plugins/plugin-browser/src/__tests__/browser-service.test.ts
@@ -1,3 +1,4 @@
+import { ElizaError } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BrowserService, type BrowserTarget } from "../browser-service.js";
 
@@ -7,6 +8,7 @@ function createTarget(args: {
   id: string;
   priority: number;
   available?: boolean;
+  availableError?: Error;
   fail?: boolean;
   score?: BrowserTarget["score"];
 }): BrowserTarget {
@@ -16,7 +18,10 @@ function createTarget(args: {
     description: args.id,
     priority: args.priority,
     ...(args.score ? { score: args.score } : {}),
-    available: vi.fn(async () => args.available ?? true),
+    available: vi.fn(async () => {
+      if (args.availableError) throw args.availableError;
+      return args.available ?? true;
+    }),
     execute: vi.fn(async (command) => {
       if (args.fail) throw new Error(`${args.id} failed`);
       return {
@@ -71,6 +76,33 @@ describe("BrowserService target routing", () => {
     await expect(
       service.execute({ subaction: "state" }, "workspace"),
     ).rejects.toThrow("workspace failed");
+  });
+
+  it("preserves pinned target availability failures as typed errors", async () => {
+    const service = new BrowserService();
+    const availabilityError = new Error("bridge health probe failed");
+    service.registerTarget(
+      createTarget({
+        id: "bridge",
+        priority: 80,
+        availableError: availabilityError,
+      }),
+    );
+    service.registerTarget(createTarget({ id: "workspace", priority: 100 }));
+
+    try {
+      await service.execute({ subaction: "state" }, "bridge");
+      throw new Error("expected pinned target availability failure");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe("BROWSER_TARGET_UNAVAILABLE");
+      expect((error as ElizaError).context).toEqual({
+        targetId: "bridge",
+        subaction: "state",
+      });
+      expect((error as ElizaError).severity).toBe("ephemeral");
+      expect((error as Error).cause).toBe(availabilityError);
+    }
   });
 
   it("passes desktop context so companion targets can win when available", async () => {

--- a/plugins/plugin-browser/src/browser-service.ts
+++ b/plugins/plugin-browser/src/browser-service.ts
@@ -27,7 +27,7 @@
  * the whole point of the pattern. The BROWSER action stays one action.
  */
 
-import { type IAgentRuntime, logger, Service } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime, logger, Service } from "@elizaos/core";
 import {
   BROWSER_BRIDGE_ROUTE_SERVICE_TYPE,
   type BrowserBridgeRouteService,
@@ -191,8 +191,19 @@ export class BrowserService extends Service {
       if (!target) return [];
       try {
         return (await target.available()) ? [target] : [];
-      } catch {
-        return [];
+      } catch (error) {
+        throw new ElizaError(
+          `Browser target "${preferredId}" availability check failed.`,
+          {
+            code: "BROWSER_TARGET_UNAVAILABLE",
+            cause: error,
+            context: {
+              targetId: preferredId,
+              subaction: command.subaction,
+            },
+            severity: "ephemeral",
+          },
+        );
       }
     }
 


### PR DESCRIPTION
## Summary
- change pinned browser target availability probe failures from a silent empty target list into a typed `ElizaError`
- include `BROWSER_TARGET_UNAVAILABLE`, target id, command subaction, ephemeral severity, and the original probe error as `cause`
- add a `BrowserService.execute(..., "bridge")` regression test while preserving automatic unpinned fallback behavior

## Evidence
- `.github/issue-evidence/12274-browser-target-availability.md`

## Verification
- `bun run --cwd plugins/plugin-browser test -- src/__tests__/browser-service.test.ts`
- `bun run --cwd plugins/plugin-browser test`
- `bunx @biomejs/biome check plugins/plugin-browser/src/browser-service.ts plugins/plugin-browser/src/__tests__/browser-service.test.ts`
- `bun run --cwd plugins/plugin-browser typecheck`
- `bun run --cwd plugins/plugin-browser build`
- `bun run audit:error-policy-ratchet`

## Root Verify
- `bun run verify` was last run on this develop line during the preceding #12272 chunk and failed in unrelated `@elizaos/cloud-ui#lint` import/export ordering and formatting findings under `packages/cloud-ui/src/approvals/*` and `packages/cloud-ui/src/index.ts`. Those files are outside this PR.

## Evidence Matrix
- Backend logs: N/A - in-process service target-resolution failure covered by direct package test
- Frontend screenshots/video: N/A - no UI changed
- Browser recording: N/A - fixed path rejects before any browser workspace/companion command is sent
- Real-LLM trajectories: N/A - no prompt/action/provider/model behavior changed

Closes #12274 (partial app-plugins-B slice chunk).
