### PR TITLE
fix(app-core): reject missing database row counts

### DIFF
--- a/.github/issue-evidence/12266-appcore-db-count-fallback.md
+++ b/.github/issue-evidence/12266-appcore-db-count-fallback.md
@@ -1,0 +1,64 @@
+# Issue #12266 - app-core database row count fallback
+
+## Scope
+
+This chunk fixes the `packages/app-core` database rows route count fallback called out in issue #12266. The route no longer treats a missing or malformed `count(*)` result as `0`; it throws an `ElizaError` with:
+
+- `code`: `DB_COUNT_UNAVAILABLE`
+- `context`: `{ "table": "\"schema\".\"table\"" }`
+- `severity`: `ephemeral`
+
+The row query is not executed after a malformed count result. Numeric string counts such as `"7"` still parse to `7`.
+
+## Verification
+
+Run on July 4, 2026 from branch `codex/fix-12266-appcore-db-count`.
+
+```bash
+bun run --cwd packages/app-core test -- src/api/database-rows-compat-routes.test.ts
+```
+
+Result: passed, 1 file / 6 tests.
+
+```bash
+bunx @biomejs/biome check \
+  packages/app-core/src/api/database-rows-compat-routes.ts \
+  packages/app-core/src/api/database-rows-compat-routes.test.ts
+```
+
+Result: passed, 2 files checked.
+
+```bash
+bun run --cwd packages/app-core build
+```
+
+Result: passed.
+
+```bash
+bun run audit:error-policy-ratchet
+```
+
+Result: passed with no new fallback slop.
+
+```bash
+bun run --cwd packages/app-core typecheck
+```
+
+Result: failed on unrelated existing `plugin-local-inference` downloader type errors:
+
+- `plugins/plugin-local-inference/src/services/downloader.ts:963`
+- `plugins/plugin-local-inference/src/services/downloader.ts:1052`
+
+Both report `Argument of type '{ error: unknown; }' is not assignable to parameter of type 'string'.`
+
+## Root Verify
+
+`bun run verify` was last run on this develop line during the preceding #12272 chunk and failed in unrelated `@elizaos/cloud-ui#lint` import/export ordering and formatting findings under `packages/cloud-ui/src/approvals/*` and `packages/cloud-ui/src/index.ts`. Those files are outside this branch's touched files.
+
+## Evidence Matrix
+
+- Backend logs: N/A - this is a direct API route error-path unit test with the SQL adapter seam stubbed at the route dependency boundary.
+- Frontend screenshots/video: N/A - no UI surface changed.
+- Real database artifact: N/A for this small chunk - the regression drives the route's real count parsing and confirms malformed count results stop before row reads; no schema/data migration changed.
+- Real-LLM trajectories: N/A - no prompt/action/provider/model behavior changed.
+- Domain artifact: `packages/app-core/src/api/database-rows-compat-routes.test.ts` asserts a malformed count row throws `DB_COUNT_UNAVAILABLE` and never runs `SELECT *`.

--- a/packages/app-core/src/api/database-rows-compat-routes.test.ts
+++ b/packages/app-core/src/api/database-rows-compat-routes.test.ts
@@ -18,6 +18,26 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@elizaos/core", () => ({
+  ElizaError: class ElizaError extends Error {
+    readonly code: string;
+    readonly context?: Record<string, unknown>;
+    readonly severity?: string;
+
+    constructor(
+      message: string,
+      options: {
+        code: string;
+        context?: Record<string, unknown>;
+        severity?: string;
+      },
+    ) {
+      super(message);
+      this.name = "ElizaError";
+      this.code = options.code;
+      this.context = options.context;
+      this.severity = options.severity;
+    }
+  },
   roleRank: (role: string | undefined) =>
     (
       ({
@@ -272,5 +292,76 @@ describe("GET /api/database/tables/:name/rows OWNER gate", () => {
       total: 2,
     });
     expect(mocks.executeRawSql).toHaveBeenCalled();
+  });
+
+  it("throws a typed error when the count query does not return a usable total", async () => {
+    const req = makeReq(
+      {},
+      "/api/database/tables/count_failures/rows?schema=public",
+    );
+    const res = fakeRes();
+    const ensureOwner = vi.fn(async () => true);
+
+    mocks.executeRawSql.mockImplementation(async (_runtime, sql: string) => {
+      if (sql.includes("information_schema.columns")) {
+        return { rows: [{ column_name: "id" }] };
+      }
+      if (sql.includes("count(*)")) {
+        return { rows: [{}] };
+      }
+      throw new Error("rows query should not run when count is malformed");
+    });
+
+    try {
+      await handleDatabaseRowsCompatRoute(req, res.res, STATE_WITH_DB, {
+        ensureOwner,
+      });
+      throw new Error("expected DB count failure");
+    } catch (error) {
+      expect(error).toMatchObject({
+        name: "ElizaError",
+        code: "DB_COUNT_UNAVAILABLE",
+        context: { table: '"public"."count_failures"' },
+        severity: "ephemeral",
+      });
+    }
+
+    expect(mocks.executeRawSql).toHaveBeenCalledTimes(2);
+    expect(
+      mocks.executeRawSql.mock.calls.some(([, sql]) =>
+        String(sql).includes("SELECT *"),
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts numeric string count values without fabricating zero", async () => {
+    const req = makeReq(
+      {},
+      "/api/database/tables/count_strings/rows?schema=public",
+    );
+    const res = fakeRes();
+    const ensureOwner = vi.fn(async () => true);
+
+    mocks.executeRawSql.mockImplementation(async (_runtime, sql: string) => {
+      if (sql.includes("information_schema.columns")) {
+        return { rows: [{ column_name: "id" }] };
+      }
+      if (sql.includes("count(*)")) {
+        return { rows: [{ total: "7" }] };
+      }
+      return { rows: [{ id: 1 }] };
+    });
+
+    await expect(
+      handleDatabaseRowsCompatRoute(req, res.res, STATE_WITH_DB, {
+        ensureOwner,
+      }),
+    ).resolves.toBe(true);
+
+    expect(res.status()).toBe(200);
+    expect(res.json()).toMatchObject({
+      table: "count_strings",
+      total: 7,
+    });
   });
 });

--- a/packages/app-core/src/api/database-rows-compat-routes.ts
+++ b/packages/app-core/src/api/database-rows-compat-routes.ts
@@ -1,4 +1,5 @@
 import type http from "node:http";
+import { ElizaError } from "@elizaos/core";
 import {
   executeRawSql,
   quoteIdent,
@@ -214,10 +215,15 @@ export async function handleDatabaseRowsCompatRoute(
     runtime,
     `SELECT count(*)::int AS total FROM ${qualifiedTable} ${whereClause}`,
   );
-  const total =
-    typeof countResult.rows[0]?.total === "number"
-      ? countResult.rows[0].total
-      : Number(countResult.rows[0]?.total ?? 0);
+  const rawTotal = countResult.rows[0]?.total;
+  const total = typeof rawTotal === "number" ? rawTotal : Number(rawTotal);
+  if (!Number.isFinite(total)) {
+    throw new ElizaError("Database row count is unavailable.", {
+      code: "DB_COUNT_UNAVAILABLE",
+      context: { table: qualifiedTable },
+      severity: "ephemeral",
+    });
+  }
 
   const rowsResult = await executeRawSql(
     runtime,


### PR DESCRIPTION
## Summary
- replace the database rows route `count(*) ?? 0` fallback with a typed `DB_COUNT_UNAVAILABLE` `ElizaError`
- stop the row query when the count result is missing or malformed
- add regression coverage for malformed count rows and numeric string counts

## Evidence
- `.github/issue-evidence/12266-appcore-db-count-fallback.md`

## Verification
- `bun run --cwd packages/app-core test -- src/api/database-rows-compat-routes.test.ts`
- `bunx @biomejs/biome check packages/app-core/src/api/database-rows-compat-routes.ts packages/app-core/src/api/database-rows-compat-routes.test.ts`
- `bun run --cwd packages/app-core build`
- `bun run audit:error-policy-ratchet`

## Known Unrelated Blockers
- `bun run --cwd packages/app-core typecheck` fails outside this PR in `plugins/plugin-local-inference/src/services/downloader.ts:963` and `:1052` (`{ error: unknown }` passed where `string` is expected).
- `bun run verify` was last run during the preceding chunk and failed in unrelated `@elizaos/cloud-ui#lint` import/export ordering and formatting findings under `packages/cloud-ui/src/approvals/*` and `packages/cloud-ui/src/index.ts`.

## Evidence Matrix
- Backend logs: N/A - direct API route error-path test at the SQL adapter seam
- Frontend screenshots/video: N/A - no UI changed
- Real database artifact: N/A for this small chunk - no schema/data migration changed; test proves malformed count stops before row read
- Real-LLM trajectories: N/A - no prompt/action/provider/model behavior changed

Closes #12266 (partial app-core/shared/logger/prompts slice chunk).
