### PR TITLE
docs(#12241): add small example headers

### DIFF
--- a/packages/examples/bluesky/character.ts
+++ b/packages/examples/bluesky/character.ts
@@ -1,3 +1,6 @@
+/**
+ * Character definition for the Bluesky runnable example agent.
+ */
 import { createCharacter } from "@elizaos/core";
 
 /**

--- a/packages/examples/html/html.test.js
+++ b/packages/examples/html/html.test.js
@@ -1,3 +1,6 @@
+/**
+ * Bun smoke tests for the static browser-runtime HTML example.
+ */
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";

--- a/packages/examples/scripts/verify-examples.mjs
+++ b/packages/examples/scripts/verify-examples.mjs
@@ -1,4 +1,10 @@
 #!/usr/bin/env node
+/**
+ * Verification runner for the first-party examples workspace.
+ *
+ * It discovers example package scripts, checks documentation coverage, and can
+ * run typecheck, test, and build commands with a JSON report for CI.
+ */
 import { spawn } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";

--- a/packages/examples/telegram/telegram-agent.test.ts
+++ b/packages/examples/telegram/telegram-agent.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Bun tests for the Telegram example's environment validation and character
+ * factory.
+ */
 import { expect, test } from "bun:test";
 import { createTelegramCharacter, readRequiredEnv } from "./telegram-agent";
 

--- a/packages/examples/text-adventure/game.test.ts
+++ b/packages/examples/text-adventure/game.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Bun tests for the deterministic text-adventure game engine.
+ */
 import { expect, test } from "bun:test";
 import { AdventureGame, playScriptedAdventure } from "./game";
 


### PR DESCRIPTION
## Summary
- Add required top-of-file prose headers to five small first-party example files.
- Covers the one-file remaining slices in Bluesky, HTML, examples verification script, Telegram, and text-adventure.
- Comment-only cleanup for #12241; no code or string literal behavior changed.

## Verification
- `bun run check:comment-only` PASS: 5 source files changed; every code token identical to `origin/develop`.
- `bunx @biomejs/biome check <5 touched files>` PASS.
- `node --check packages/examples/html/html.test.js && node --check packages/examples/scripts/verify-examples.mjs` PASS.
- `bun test packages/examples/html/html.test.js packages/examples/telegram/telegram-agent.test.ts packages/examples/text-adventure/game.test.ts` PASS: 7 tests.
- `git diff --check` PASS.
- First-line header audit for touched files PASS.
- `bun run verify` not rerun for this examples-only slice after the immediately preceding B11 straggler run failed outside comment changes in `@elizaos/cloud-shared#typecheck`: TypeScript resolves `drizzle-orm` from `dist/node_modules/drizzle-orm` without declaration files, causing TS7016 plus implicit-any fallout in `plugins/plugin-sql/src/schema/*`.

## Evidence
- Screenshots/video: N/A - comment-only header cleanup; `check:comment-only` proves runtime tokens are unchanged.
- Backend/frontend logs: N/A - no executable behavior changed.
- Real-LLM trajectories: N/A - no agent, prompt, model, provider, or evaluator behavior changed.
- Domain artifacts: N/A - no model, chain, hardware, or generated artifact behavior changed.
