### PR TITLE
fix(#12321): gate publish on HF release audit

### DIFF
--- a/.github/issue-evidence/12216-stage4-publish-hf-audit-gate/README.md
+++ b/.github/issue-evidence/12216-stage4-publish-hf-audit-gate/README.md
@@ -1,0 +1,22 @@
+# Stage 4 Publish HF Audit Gate Evidence
+
+Issue: #12321
+
+PR scope:
+
+- Wire the metadata-only HF release audit into the non-dry-run publish orchestrator after final release evidence upload and before local release tagging.
+- Block a real publish with `EXIT_HF_AUDIT_FAIL` if the published Hub surface is not green.
+- Keep `--dry-run` deterministic and local-only because no Hub upload exists for the audit to inspect.
+
+Verification:
+
+```bash
+python3 -m pytest packages/training/scripts/publish/test_orchestrator.py -q -k 'real_publish_finalizes_and_uploads_hf_evidence or real_publish_blocks_when_hf_release_audit_fails or real_base_v1_publish_rejects_retired_qwen_asr_provenance'
+# ... [100%] 3 passed
+
+python3 -m pytest packages/training/scripts/publish/test_orchestrator.py -q
+# ..................................................... [100%] 53 passed
+
+python3 -m py_compile packages/training/scripts/publish/orchestrator.py packages/training/scripts/publish/test_orchestrator.py
+# passed
+```

--- a/packages/training/scripts/publish/orchestrator.py
+++ b/packages/training/scripts/publish/orchestrator.py
@@ -98,6 +98,10 @@ from scripts.manifest.eliza1_platform_plan import (  # noqa: E402
 from scripts.manifest.eliza1_licenses import (  # noqa: E402
     verify_bundle_licenses,
 )
+from scripts.manifest.audit_hf_eliza1_release import (  # noqa: E402
+    DEFAULT_DATASET_REPO,
+    audit_hf_release,
+)
 
 # ---------------------------------------------------------------------------
 # Exit codes
@@ -112,6 +116,7 @@ EXIT_EVAL_GATE_FAIL = 13
 EXIT_MANIFEST_INVALID = 14
 EXIT_HF_PUSH_FAIL = 15
 EXIT_RELEASE_EVIDENCE_FAIL = 16
+EXIT_HF_AUDIT_FAIL = 17
 
 ELIZA_1_HF_ORG = "elizaos"
 
@@ -2735,6 +2740,28 @@ def push_final_release_evidence(
     )
 
 
+def run_hf_release_audit(ctx: PublishContext) -> None:
+    """Block completed publishes unless the public HF release surface is green."""
+
+    if ctx.dry_run:
+        log.info("[hf-audit] dry-run: skipped because no Hub upload occurred")
+        return
+    report = audit_hf_release(model_repo=ctx.repo_id, dataset_repo=DEFAULT_DATASET_REPO)
+    if report.ok:
+        log.info(
+            "[hf-audit] passed: model=%s dataset=%s checks=%d",
+            report.model_repo,
+            report.dataset_repo,
+            len(report.checks),
+        )
+        return
+    log.error("[hf-audit] failed after upload:\n%s", report.render())
+    raise OrchestratorError(
+        "HF release audit failed after upload; refusing to tag this publish.",
+        EXIT_HF_AUDIT_FAIL,
+    )
+
+
 def tag_training_repo(ctx: PublishContext, version: str, dry_run: bool) -> str | None:
     """Apply ``eliza-1-<tier>-v<version>`` to HEAD of the training repo.
 
@@ -2860,6 +2887,9 @@ def run(ctx: PublishContext) -> int:
                 upload_evidence,
             )
             push_final_release_evidence(ctx, release_path, checksum_path)
+
+        log.info("[stage 7/7] audit published HF release surface")
+        run_hf_release_audit(ctx)
 
         tag_name = tag_training_repo(ctx, version, ctx.dry_run)
         log.info("done. tag=%s", tag_name)

--- a/packages/training/scripts/publish/test_orchestrator.py
+++ b/packages/training/scripts/publish/test_orchestrator.py
@@ -34,6 +34,7 @@ from scripts.publish.orchestrator import (  # noqa: E402
     EXIT_KERNEL_VERIFY_FAIL,
     EXIT_MISSING_FILE,
     EXIT_OK,
+    EXIT_HF_AUDIT_FAIL,
     EXIT_RELEASE_EVIDENCE_FAIL,
     EXIT_USAGE,
     OrchestratorError,
@@ -1290,6 +1291,7 @@ def test_real_publish_finalizes_and_uploads_hf_evidence(
     bundle = _build_fixture_bundle(tmp_path)
     metal = _metal_report(tmp_path)
     final_uploads: list[tuple[str, str]] = []
+    audit_calls: list[str] = []
 
     def fake_push_to_hf(
         ctx: PublishContext,
@@ -1326,12 +1328,18 @@ def test_real_publish_finalizes_and_uploads_hf_evidence(
         "push_final_release_evidence",
         fake_push_final_release_evidence,
     )
+    monkeypatch.setattr(
+        orchestrator,
+        "run_hf_release_audit",
+        lambda ctx: audit_calls.append(ctx.repo_id),
+    )
     monkeypatch.setattr(orchestrator, "tag_training_repo", lambda *args: "tagged")
 
     rc = run(_ctx("4b", bundle, metal=metal, dry_run=False))
 
     assert rc == EXIT_OK
     assert final_uploads == [("evidence/release.json", "checksums/SHA256SUMS")]
+    assert audit_calls == [ELIZA_1_HF_REPO]
     release = json.loads((bundle / "evidence" / "release.json").read_text())
     assert release["releaseState"] == "final"
     assert release["hf"]["status"] == "uploaded"
@@ -1414,11 +1422,60 @@ def test_real_base_v1_publish_rejects_retired_qwen_asr_provenance(
         "push_final_release_evidence",
         lambda *args: None,
     )
+    monkeypatch.setattr(orchestrator, "run_hf_release_audit", lambda *args: None)
     monkeypatch.setattr(orchestrator, "tag_training_repo", lambda *args: "tagged")
 
     rc = run(_ctx("4b", bundle, metal=metal, dry_run=False))
 
     assert rc == EXIT_RELEASE_EVIDENCE_FAIL
+
+
+def test_real_publish_blocks_when_hf_release_audit_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import scripts.publish.orchestrator as orchestrator  # noqa: PLC0415
+
+    bundle = _build_fixture_bundle(tmp_path)
+    metal = _metal_report(tmp_path)
+    tag_calls: list[str] = []
+
+    def fake_push_to_hf(
+        ctx: PublishContext,
+        manifest_path: Path,
+        readme_path: Path,
+        upload_pairs: list[tuple[Path, str]],
+    ) -> dict[str, Any]:
+        return {
+            "repoId": ctx.repo_id,
+            "status": "uploaded",
+            "commit": "payload123",
+            "url": f"https://huggingface.co/{ctx.repo_id}/commit/payload123",
+            "uploadedPaths": [
+                "bundles/4b/eliza-1.manifest.json",
+                "bundles/4b/README.md",
+                *(target for _, target in upload_pairs),
+            ],
+        }
+
+    def failing_audit(ctx: PublishContext) -> None:
+        raise orchestrator.OrchestratorError(
+            "HF release audit failed after upload; refusing to tag this publish.",
+            EXIT_HF_AUDIT_FAIL,
+        )
+
+    monkeypatch.setattr(orchestrator, "push_to_hf", fake_push_to_hf)
+    monkeypatch.setattr(orchestrator, "push_final_release_evidence", lambda *args: None)
+    monkeypatch.setattr(orchestrator, "run_hf_release_audit", failing_audit)
+    monkeypatch.setattr(
+        orchestrator,
+        "tag_training_repo",
+        lambda *args: tag_calls.append("tagged") or "tagged",
+    )
+
+    rc = run(_ctx("4b", bundle, metal=metal, dry_run=False))
+
+    assert rc == EXIT_HF_AUDIT_FAIL
+    assert tag_calls == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- run the metadata-only HF release audit during real publish after final release evidence upload
- fail with `EXIT_HF_AUDIT_FAIL` before local release tagging when the published HF surface is red
- keep dry-run deterministic/local because no Hub upload exists to audit

## Evidence
- `.github/issue-evidence/12216-stage4-publish-hf-audit-gate/README.md`
- `python3 -m pytest packages/training/scripts/publish/test_orchestrator.py -q`
- `python3 -m py_compile packages/training/scripts/publish/orchestrator.py packages/training/scripts/publish/test_orchestrator.py`
- `git diff --check origin/develop..HEAD`

Refs #12321