### PR TITLE
fix(#12268): fallback-slop sweep — fail-fast reconciler annotation, annotate justified cloud handlers

### DIFF
--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -84,6 +84,8 @@ function normalizeOriginHost(value: string | undefined): string | null {
     }
     return normalizeHostname(origin.host);
   } catch {
+    // error-policy:J3 untrusted origin header parse; null = reject (unparseable
+    // origin is not a valid host and must not be matched against the allowlist).
     return null;
   }
 }

--- a/packages/cloud/api/src/steward/embedded.ts
+++ b/packages/cloud/api/src/steward/embedded.ts
@@ -141,7 +141,10 @@ function resolveStewardUpstream(
         continue;
       }
       return trimTrailingSlash(url.toString());
-    } catch {}
+    } catch {
+      // error-policy:J3 malformed configured upstream candidate; skip it and
+      // try the next. All-invalid falls through to null (no upstream).
+    }
   }
   return null;
 }

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -345,6 +345,9 @@ async function forwardWithRetry(
     if (targets.length === 0) {
       if (!woken) {
         woken = true;
+        // error-policy:J5 fire-and-forget wake; wakeServer catches and logs
+        // every real failure internally (server-router.ts:191-214), so this
+        // only suppresses a residual pre-guard rejection.
         wakeServer(serverName, serverUrl).catch(() => {});
       }
       lastError = new Error("No pods available (scaled to zero)");
@@ -363,6 +366,9 @@ async function forwardWithRetry(
     lastError = result.error;
     if (!woken && result.isConnectionError) {
       woken = true;
+      // error-policy:J5 fire-and-forget wake; wakeServer catches and logs
+      // every real failure internally (server-router.ts:191-214), so this
+      // only suppresses a residual pre-guard rejection.
       wakeServer(serverName, serverUrl).catch(() => {});
     }
   }

--- a/packages/cloud/services/operator/capabilities/__tests__/reconciler-previous-agents.test.ts
+++ b/packages/cloud/services/operator/capabilities/__tests__/reconciler-previous-agents.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Real-error-path coverage for `getPreviousAgentIds` (#12268): a corrupt or
+ * malformed `eliza.ai/previous-agents` annotation must throw so the reconcile
+ * loop's J1 boundary surfaces it, never fabricate an empty list that silently
+ * skips Redis cleanup of removed agents.
+ */
+import { describe, expect, test } from "bun:test";
+import type { Server } from "../crd/generated/server-v1alpha1";
+import { getPreviousAgentIds } from "../reconciler";
+
+function serverWithAnnotation(value: string | undefined): Server {
+  return {
+    metadata: {
+      name: "server-a",
+      annotations:
+        value === undefined ? {} : { "eliza.ai/previous-agents": value },
+    },
+  } as Server;
+}
+
+describe("getPreviousAgentIds", () => {
+  test("absent annotation is a legitimate empty list (first reconcile)", () => {
+    expect(getPreviousAgentIds(serverWithAnnotation(undefined))).toEqual([]);
+    expect(getPreviousAgentIds({ metadata: {} } as Server)).toEqual([]);
+  });
+
+  test("valid JSON string array round-trips", () => {
+    expect(
+      getPreviousAgentIds(serverWithAnnotation('["agent-1","agent-2"]')),
+    ).toEqual(["agent-1", "agent-2"]);
+    expect(getPreviousAgentIds(serverWithAnnotation("[]"))).toEqual([]);
+  });
+
+  test("corrupt JSON throws (does not fabricate empty)", () => {
+    expect(() =>
+      getPreviousAgentIds(serverWithAnnotation("{not json")),
+    ).toThrow(/corrupt eliza.ai\/previous-agents annotation/);
+  });
+
+  test("well-formed JSON that is not a string array throws", () => {
+    expect(() =>
+      getPreviousAgentIds(serverWithAnnotation('{"agent":1}')),
+    ).toThrow(/not a string array/);
+    expect(() => getPreviousAgentIds(serverWithAnnotation("[1,2,3]"))).toThrow(
+      /not a string array/,
+    );
+    expect(() =>
+      getPreviousAgentIds(serverWithAnnotation('"agent-1"')),
+    ).toThrow(/not a string array/);
+  });
+
+  test("corrupt annotation preserves the underlying parse error as cause", () => {
+    try {
+      getPreviousAgentIds(serverWithAnnotation("{not json"));
+      throw new Error("expected getPreviousAgentIds to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).cause).toBeInstanceOf(Error);
+    }
+  });
+});

--- a/packages/cloud/services/operator/capabilities/reconciler.ts
+++ b/packages/cloud/services/operator/capabilities/reconciler.ts
@@ -83,6 +83,9 @@ export async function reconciler(instance: Server) {
 
     Log.info(`Server ${name}: reconciliation complete`);
   } catch (err) {
+    // error-policy:J1 outermost handler for the Pepr reconcile callback; any
+    // failure below (apply, Redis routing, corrupt-annotation throw) surfaces
+    // as a structured operator error instead of a silent partial reconcile.
     Log.error(err, `Server ${name}: reconciliation failed`);
   }
 }
@@ -100,15 +103,31 @@ export async function finalizer(instance: Server) {
   Log.info(`Server ${name}: Redis cleanup complete`);
 }
 
-function getPreviousAgentIds(instance: Server): string[] {
+export function getPreviousAgentIds(instance: Server): string[] {
   const annotation =
     instance.metadata?.annotations?.["eliza.ai/previous-agents"];
+  // Absent annotation legitimately means "no prior agents" (first reconcile).
   if (!annotation) return [];
+  let parsed: unknown;
   try {
-    return JSON.parse(annotation);
-  } catch {
-    return [];
+    parsed = JSON.parse(annotation);
+  } catch (err) {
+    // A corrupt annotation must NOT read as "no previous agents": that would
+    // silently skip removeAgentServer() for agents dropped since the last
+    // reconcile, leaking stale Redis routing keys. Throw to the reconcile
+    // loop's J1 boundary (below) so the failure is logged and the annotation
+    // is not overwritten with a lie.
+    throw new Error(
+      `Server ${instance.metadata?.name ?? "<unknown>"}: corrupt eliza.ai/previous-agents annotation`,
+      { cause: err },
+    );
   }
+  if (!Array.isArray(parsed) || parsed.some((id) => typeof id !== "string")) {
+    throw new Error(
+      `Server ${instance.metadata?.name ?? "<unknown>"}: eliza.ai/previous-agents annotation is not a string array`,
+    );
+  }
+  return parsed;
 }
 
 async function updateStatus(instance: Server, status: Server["status"]) {


### PR DESCRIPTION
## Fallback-slop sweep: `packages/cloud/*` (#12268)

Part of the #12182 fable swarm. Behavior-changing work under a **high** risk profile (money / auth / webhook boundaries) — this is a **small, precise** slice: one real slop conversion + justified-handler annotations, not a wholesale rewrite of the 843 J1 Hono route handlers.

### Re-derived suspect inventory (develop @ `f126e75fb6`)

Ran the issue's rg patterns over `packages/cloud/**` (excluding tests/`.d.ts`/dist/generated):

| pattern | raw hits | real server-code sites after triage |
|---|---|---|
| strict empty catch | 5 | **1** (embedded.ts:144). The other 4 are inside browser `<script>` **string literals** (`app-frontend-hosting.ts:563`, `agent-github-return.ts:171/177/185`) — not code, exempt. |
| promise-swallow (`.catch(() => …)`) | 133 | overwhelmingly J3 body-parse (`c.req.json().catch(() => null)` → route returns 400) and J6 teardown (`disconnect()/del()/cancel().catch(() => {})`). Left for a follow-up pass; see below. |
| `?? <lit>` / `\|\| <lit>` | ~1036 | left (over-removal risk too high without per-site data-path proof). |

### Verdict table (this PR)

| site | verdict | action |
|---|---|---|
| `services/operator/capabilities/reconciler.ts` `getPreviousAgentIds` | **SLOP** | convert → throw |
| `services/operator/capabilities/reconciler.ts:85` reconcile catch | J1 | annotate |
| `services/gateway-webhook/src/server-router.ts:348,366` `wakeServer().catch(() => {})` | J5 | annotate |
| `api/src/steward/embedded.ts:144` upstream-candidate URL parse | J3 | annotate + de-empty |
| `api/src/index.ts:86` origin-header parse | J3 | annotate |

### The conversion (exemplar #1 in the issue)

`getPreviousAgentIds` returned `[]` from a `catch` on `JSON.parse`. A **corrupt** `eliza.ai/previous-agents` annotation therefore read as "no previous agents", silently skipping `removeAgentServer()` for agents dropped since the last reconcile — leaking stale Redis routing keys with zero trace.

Before → after:

```ts
// BEFORE — corrupt annotation silently skips Redis cleanup
if (!annotation) return [];
try { return JSON.parse(annotation); } catch { return []; }

// AFTER — absent is []; corrupt/malformed throws to the reconcile J1 boundary
if (!annotation) return [];                 // legitimate absence (first reconcile)
let parsed: unknown;
try { parsed = JSON.parse(annotation); }
catch (err) { throw new Error(`Server …: corrupt … annotation`, { cause: err }); }
if (!Array.isArray(parsed) || parsed.some((id) => typeof id !== "string"))
  throw new Error(`Server …: … annotation is not a string array`);
return parsed;
```

The operator package does not depend on `@elizaos/core`, so this throws a native `Error` with `cause` (not `ElizaError`); it surfaces at the reconcile loop's `catch (err) { Log.error(...) }` J1 boundary. The absent-annotation path still legitimately returns `[]` — that is not slop.

### Why `wakeServer` is J5, not slop (self-corrected from the issue's exemplar #2)

The issue lists `wakeServer(...).catch(() => {})` as slop to convert to a logging catch. On inspection, `wakeServer` (`server-router.ts:191-214`) **already** `logger.error`s both the non-OK k8s scale response and any fetch error internally. The call-site `.catch(() => {})` therefore suppresses only a residual pre-guard rejection whose real failures are already observed — textbook **J5**. Annotating (zero risk) is more accurate than adding a duplicate log, so both sites are annotated J5 with a pointer to where the rejection is observed.

### `cloud/api` route dirs as J1 boundaries

Per the issue, the ~843 `catch_other` sites in `packages/cloud/api/**/route.ts` are Hono route handlers translating exceptions to structured HTTP failures — a **J1 boundary** documented here rather than annotated per-handler. Body-parse `c.req.json().catch(() => null)` sites are J3 (the null path returns a 400) and are left for a focused follow-up; spot-checks confirmed the sampled ones return a failure, not a fabricated success body.

### Tests

New real error-path coverage `capabilities/__tests__/reconciler-previous-agents.test.ts` (bun:test) — absent → `[]`, valid array round-trip, corrupt JSON throws, non-array / non-string-element throws, `cause` preserved. No mock-swallow.

```
operator:         6 pass / 0 fail  (incl. 5 new)
gateway-webhook: 19 pass / 0 fail
```

### Verification

- `bun run --cwd packages/cloud/services/operator test` → 6 pass
- `bun run --cwd packages/cloud/services/gateway-webhook test` → 19 pass
- `typecheck` clean: operator, gateway-webhook; cloud-api touched files (comment-only) unaffected
- `biome check` clean on all touched files
- `bun run audit:error-policy-ratchet` → **`no new fallback-slop in touched files`** (3 changed prod files, empty-catch 0→0 / 1→1, serverConsole 0→0)
- strict empty-catch grep over the 4 touched source files → **0**

### Per-category tally

- **converted (slop → fast-fail):** 1 (reconciler `getPreviousAgentIds`)
- **annotated (justified keep):** 5 (J1×1, J5×2, J3×2)
- **left (sitesLeft):** ~133 promise-swallow + ~1036 `?? / ||` literal candidates — deferred; conversion needs per-site data-path proof and the money/auth/webhook risk profile makes reckless removal worse than none.

### Evidence

The induced-failure surfacing is proven by the new test: a genuinely corrupt annotation fixture now throws (`corrupt eliza.ai/previous-agents annotation`) with the parse error preserved on `.cause`, versus the old silent `[]`. No live cluster is required to observe the behavior change — it is a pure-function error-path assertion.

Refs #12268

🤖 Generated with [Claude Code](https://claude.com/claude-code)
