### PR TITLE
fix(feed): fail world-state reads loudly

### DIFF
--- a/.github/issue-evidence/12276-feed-world-state-errors.md
+++ b/.github/issue-evidence/12276-feed-world-state-errors.md
@@ -1,0 +1,63 @@
+# Issue #12276 - Feed world-state read failures
+
+## Scope
+
+This chunk fixes the feed engine slop called out in issue #12276:
+
+- `WorldStateSnapshotService` no longer returns `[]` when prediction-market, perp-market, world-event, insider-assignment, or organization-state reads fail. It throws `DatabaseError` with the failing operation and original error message.
+- `gameService.getQuestionOutcome()` still returns `null` for a reachable unresolved/missing question, but throws `DatabaseError` when the query itself fails.
+- `getNpcGameContext()` no longer fabricates `true` when a question outcome lookup is missing or broken. Missing outcome skips that market intuition; query failures propagate.
+
+## Verification
+
+Run on July 4, 2026 from branch `codex/fix-12276-feed-world-state-errors`.
+
+```bash
+bun test ./packages/engine/src/__tests__/world-state-errors.test.ts
+```
+
+Result: passed, 1 file / 3 tests.
+
+```bash
+bunx @biomejs/biome check --config-path ../../biome.json \
+  --files-ignore-unknown=true \
+  --no-errors-on-unmatched \
+  packages/engine/src/services/world-state-snapshot-service.ts \
+  packages/engine/src/game-service.ts \
+  packages/engine/src/__tests__/world-state-errors.test.ts \
+  packages/agents/src/plugins/feed/providers/npc-game-context.ts
+```
+
+Result: passed with one pre-existing warning: `packages/engine/src/services/world-state-snapshot-service.ts` is a static-only class.
+
+```bash
+bun run audit:error-policy-ratchet
+```
+
+Result: passed with no new fallback slop.
+
+## Known Typecheck Blockers
+
+```bash
+bun run --cwd packages/feed/packages/engine typecheck
+```
+
+Result: failed on existing feed workspace type/build-output issues, including missing built declaration outputs for `@feed/db`, `@feed/shared`, `@feed/core`, and `@feed/pack-default`, plus pre-existing implicit `any`/strictness errors across engine files.
+
+```bash
+bun run --cwd packages/feed/packages/agents typecheck
+```
+
+Result: failed on existing missing built declaration outputs for `@feed/db`, `@feed/engine`, `@feed/api`, `@feed/shared`, and `@feed/a2a`, plus pre-existing implicit `any`/strictness errors across agents files.
+
+## Root Verify
+
+`bun run verify` was last run during the preceding #12272 chunk and failed in unrelated `@elizaos/cloud-ui#lint` import/export ordering and formatting findings under `packages/cloud-ui/src/approvals/*` and `packages/cloud-ui/src/index.ts`. Those files are outside this branch's touched files.
+
+## Evidence Matrix
+
+- Backend logs: N/A - this chunk is covered by direct feed engine tests that force DB read failures at the package boundary and assert typed `DatabaseError`.
+- Frontend screenshots/video: N/A - no UI surface changed.
+- Real stopped-DB run: N/A for this small chunk - the test proves the engine no longer fabricates empty world state from failed DB reads; no DB schema or runtime tick wiring changed.
+- Real-LLM trajectories: N/A - no prompt/action/provider/model behavior changed.
+- Domain artifact: `packages/feed/packages/engine/src/__tests__/world-state-errors.test.ts` asserts failed `questions` reads throw `DatabaseError`, snapshot insert is not called, reachable unresolved outcomes stay `null`, and failed outcome reads throw.

--- a/packages/feed/packages/agents/src/plugins/feed/providers/npc-game-context.ts
+++ b/packages/feed/packages/agents/src/plugins/feed/providers/npc-game-context.ts
@@ -169,17 +169,10 @@ You are ${npcActor.name}. Just be yourself — talk about what interests you, re
 
     const phase = getArcPhaseForDay(currentDay, arcPlan);
 
-    // Fetch the actual predetermined outcome from the question
-    // This ensures insiders get correct signals (not always YES)
-    let outcome = true; // fallback
-    try {
-      const questionData = await gameService.getQuestionOutcome(market.id);
-      if (questionData != null) {
-        outcome = questionData;
-      }
-    } catch {
-      // Fallback to true if lookup fails
-    }
+    // Fetch the actual predetermined outcome from the question.
+    // Without a real outcome, skip this intuition instead of fabricating YES.
+    const outcome = await gameService.getQuestionOutcome(market.id);
+    if (outcome == null) continue;
 
     const signal = getSignalDirection(arcPlan, phase, agentId, outcome);
 

--- a/packages/feed/packages/engine/src/__tests__/world-state-errors.test.ts
+++ b/packages/feed/packages/engine/src/__tests__/world-state-errors.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Error-path coverage for feed world-state reads and question outcomes.
+ *
+ * The DB module is replaced at the package boundary so these tests can force
+ * query failures while still driving the real engine services.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type MockTable = Record<string, unknown> & { __name: string };
+
+const tableResults = new Map<string, unknown[]>();
+const failingTables = new Set<string>();
+const insertValues = mock(async () => undefined);
+
+function table(name: string): MockTable {
+  return {
+    __name: name,
+    id: `${name}.id`,
+    text: `${name}.text`,
+    outcome: `${name}.outcome`,
+    basePrice: `${name}.basePrice`,
+    currentPrice: `${name}.currentPrice`,
+    eventType: `${name}.eventType`,
+    description: `${name}.description`,
+    insiderActorIds: `${name}.insiderActorIds`,
+    deceiverActorIds: `${name}.deceiverActorIds`,
+    windowId: `${name}.windowId`,
+  };
+}
+
+function rowsFor(tableName: string): unknown[] {
+  if (failingTables.has(tableName)) {
+    throw new Error(`${tableName} read failed`);
+  }
+  return tableResults.get(tableName) ?? [];
+}
+
+function selectBuilder() {
+  return {
+    from(source: MockTable) {
+      const tableName = source.__name;
+      const terminal = {
+        limit: mock(async () => rowsFor(tableName)),
+      };
+      return {
+        limit: terminal.limit,
+        orderBy: mock(() => terminal),
+        where: mock(() => terminal),
+      };
+    },
+  };
+}
+
+const questions = table("questions");
+const organizationState = table("organizationState");
+const worldEvents = table("worldEvents");
+const questionArcPlans = table("questionArcPlans");
+const worldStateSnapshots = table("worldStateSnapshots");
+
+mock.module("@feed/db", () => ({
+  db: {
+    insert: mock(() => ({ values: insertValues })),
+    select: mock(() => selectBuilder()),
+  },
+  desc: mock((value: unknown) => value),
+  eq: mock((left: unknown, right: unknown) => ({ left, right })),
+  games: table("games"),
+  generateSnowflakeId: mock(async () => "snapshot-1"),
+  getDbInstance: mock(() => ({})),
+  markets: table("markets"),
+  questions,
+  worldStateSnapshots,
+}));
+
+mock.module("@feed/db/schema", () => ({
+  organizationState,
+  questionArcPlans,
+  questions,
+  worldEvents,
+}));
+
+const { DatabaseError } = await import("@feed/shared");
+const { gameService } = await import("../game-service");
+const { WorldStateSnapshotService } = await import(
+  "../services/world-state-snapshot-service"
+);
+
+beforeEach(() => {
+  failingTables.clear();
+  tableResults.clear();
+  insertValues.mockClear();
+});
+
+describe("feed world-state database failures", () => {
+  test("captureSnapshot throws instead of writing an empty world when a state query fails", async () => {
+    failingTables.add("questions");
+
+    await expect(
+      WorldStateSnapshotService.captureSnapshot("window-1"),
+    ).rejects.toBeInstanceOf(DatabaseError);
+    await expect(
+      WorldStateSnapshotService.captureSnapshot("window-1"),
+    ).rejects.toMatchObject({
+      code: "DATABASE_ERROR",
+      context: {
+        operation: "WorldStateSnapshotService.getPredictionMarketState",
+        originalError: "questions read failed",
+      },
+    });
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  test("getQuestionOutcome preserves null for a reachable unresolved question", async () => {
+    tableResults.set("questions", [{ outcome: null }]);
+
+    await expect(
+      gameService.getQuestionOutcome("market-1"),
+    ).resolves.toBeNull();
+  });
+
+  test("getQuestionOutcome throws when the question query fails", async () => {
+    failingTables.add("questions");
+
+    await expect(
+      gameService.getQuestionOutcome("market-1"),
+    ).rejects.toMatchObject({
+      code: "DATABASE_ERROR",
+      context: {
+        operation: "GameService.getQuestionOutcome",
+        originalError: "questions read failed",
+      },
+    });
+  });
+});

--- a/packages/feed/packages/engine/src/game-service.ts
+++ b/packages/feed/packages/engine/src/game-service.ts
@@ -18,9 +18,13 @@ import {
   markets,
   questions,
 } from "@feed/db";
-import { logger } from "@feed/shared";
+import { DatabaseError, logger } from "@feed/shared";
 import { StaticDataRegistry } from "./services/static-data-registry";
 import { getGameDayNumber } from "./utils/date-utils";
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
 
 /**
  * Active market summary for NPC context (lightweight)
@@ -195,8 +199,12 @@ class GameService {
         .limit(1);
 
       return question?.outcome ?? null;
-    } catch {
-      return null;
+    } catch (error) {
+      throw new DatabaseError(
+        "Question outcome query failed",
+        "GameService.getQuestionOutcome",
+        toError(error),
+      );
     }
   }
 }

--- a/packages/feed/packages/engine/src/services/world-state-snapshot-service.ts
+++ b/packages/feed/packages/engine/src/services/world-state-snapshot-service.ts
@@ -1,4 +1,9 @@
 import { db, eq, generateSnowflakeId, worldStateSnapshots } from "@feed/db";
+import { DatabaseError } from "@feed/shared";
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
 
 export class WorldStateSnapshotService {
   /**
@@ -72,8 +77,12 @@ export class WorldStateSnapshotService {
         question: m.text,
         resolvedOutcome: m.outcome,
       }));
-    } catch {
-      return [];
+    } catch (error) {
+      throw new DatabaseError(
+        "Prediction market state query failed",
+        "WorldStateSnapshotService.getPredictionMarketState",
+        toError(error),
+      );
     }
   }
 
@@ -92,8 +101,12 @@ export class WorldStateSnapshotService {
         ticker: o.id,
         price: Number(o.basePrice),
       }));
-    } catch {
-      return [];
+    } catch (error) {
+      throw new DatabaseError(
+        "Perp market state query failed",
+        "WorldStateSnapshotService.getPerpMarketState",
+        toError(error),
+      );
     }
   }
 
@@ -109,8 +122,12 @@ export class WorldStateSnapshotService {
         .from(worldEvents)
         .limit(50);
       return events;
-    } catch {
-      return [];
+    } catch (error) {
+      throw new DatabaseError(
+        "World events query failed",
+        "WorldStateSnapshotService.getWorldEvents",
+        toError(error),
+      );
     }
   }
 
@@ -126,8 +143,12 @@ export class WorldStateSnapshotService {
         .from(questionArcPlans)
         .limit(50);
       return plans;
-    } catch {
-      return [];
+    } catch (error) {
+      throw new DatabaseError(
+        "Insider assignments query failed",
+        "WorldStateSnapshotService.getInsiderAssignments",
+        toError(error),
+      );
     }
   }
 
@@ -141,8 +162,12 @@ export class WorldStateSnapshotService {
       const { organizationState } = await import("@feed/db/schema");
       const orgs = await db.select().from(organizationState).limit(100);
       return orgs;
-    } catch {
-      return [];
+    } catch (error) {
+      throw new DatabaseError(
+        "Organization state query failed",
+        "WorldStateSnapshotService.getOrgStates",
+        toError(error),
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary
- make feed world-state snapshot reads throw `DatabaseError` instead of returning fabricated empty arrays on DB failures
- make `gameService.getQuestionOutcome()` preserve `null` for reachable unresolved questions but throw on query failures
- remove the NPC game-context hardcoded `true` fallback so market intuitions require a real outcome

## Evidence
- `.github/issue-evidence/12276-feed-world-state-errors.md`

## Verification
- `bun test ./packages/engine/src/__tests__/world-state-errors.test.ts`
- `bunx @biomejs/biome check --config-path ../../biome.json --files-ignore-unknown=true --no-errors-on-unmatched packages/engine/src/services/world-state-snapshot-service.ts packages/engine/src/game-service.ts packages/engine/src/__tests__/world-state-errors.test.ts packages/agents/src/plugins/feed/providers/npc-game-context.ts` (passes with one pre-existing static-only-class warning)
- `bun run audit:error-policy-ratchet`

## Known Typecheck Blockers
- `bun run --cwd packages/feed/packages/engine typecheck` fails on existing feed workspace issues: missing built declaration outputs for feed packages plus pre-existing implicit-any/strictness errors.
- `bun run --cwd packages/feed/packages/agents typecheck` fails on existing feed workspace issues: missing built declaration outputs for feed packages plus pre-existing implicit-any/strictness errors.

## Evidence Matrix
- Backend logs: N/A - direct feed engine test forces DB read failure at package boundary and asserts typed `DatabaseError`
- Frontend screenshots/video: N/A - no UI changed
- Real stopped-DB run: N/A for this small chunk - no DB schema/tick wiring changed; regression verifies failed DB reads no longer become empty state
- Real-LLM trajectories: N/A - no prompt/action/provider/model behavior changed

Closes #12276 (partial feed slice chunk).
