### PR TITLE
fix(#12321): remove publish gate alias bypass

### DIFF
--- a/.github/issue-evidence/12216-stage4-remove-gate-alias/README.md
+++ b/.github/issue-evidence/12216-stage4-remove-gate-alias/README.md
@@ -1,0 +1,22 @@
+# Stage 4 Remove Gate Alias Evidence
+
+Issue: #12321
+
+PR scope:
+
+- Remove the `ELIZA_PUBLISH_ALLOW_GATE_ALIAS` publish bypass from the Eliza-1 orchestrator.
+- Require `evals/aggregate.json` to carry independent `e2e_loop_ok` and `thirty_turn_ok` booleans.
+- Keep a regression test showing the retired env var no longer lets a missing `e2e_loop_ok` publish.
+
+Verification:
+
+```bash
+python3 -m pytest packages/training/scripts/publish/test_orchestrator.py -q -k 'missing_e2e_loop_ok_blocks_publish or dry_run_succeeds_on_fixture'
+# .. [100%] 2 passed
+
+python3 -m pytest packages/training/scripts/publish/test_orchestrator.py -q
+# .................................................... [100%] 52 passed
+
+python3 -m py_compile packages/training/scripts/publish/orchestrator.py packages/training/scripts/publish/test_orchestrator.py
+# passed
+```

--- a/packages/training/scripts/publish/orchestrator.py
+++ b/packages/training/scripts/publish/orchestrator.py
@@ -1846,34 +1846,7 @@ def run_eval_gates(ctx: PublishContext) -> tuple[GateReport, dict[str, Any]]:
             EXIT_EVAL_GATE_FAIL,
         )
 
-    # ``e2e_loop_ok`` and ``thirty_turn_ok`` are independent contract booleans
-    # (manifest ``evals.e2eLoopOk`` / ``evals.thirtyTurnOk``) and both are
-    # ``required: true`` gates. When the eval blob is missing ``e2e_loop_ok``
-    # the operator can opt in to a lower-fidelity publish that aliases it onto
-    # ``thirty_turn_ok`` (ELIZA_PUBLISH_ALLOW_GATE_ALIAS=1) — manifest
-    # assembly already does this via ``_read_independent_bool``; do the same
-    # for the gate report so the report and the manifest stay consistent.
     results = eval_blob.get("results")
-    if (
-        isinstance(results, dict)
-        and "e2e_loop_ok" not in results
-        and "thirty_turn_ok" in results
-        and os.environ.get(PUBLISH_ALLOW_GATE_ALIAS_ENV) == "1"
-        and isinstance(results["thirty_turn_ok"], bool)
-    ):
-        log.warning(
-            "[evals] aliasing results.%s ← results.%s "
-            "(opt-in via %s=1). Two independent manifest contract gates are "
-            "being sourced from one measurement; this is a lower-fidelity "
-            "publish.",
-            "e2e_loop_ok",
-            "thirty_turn_ok",
-            PUBLISH_ALLOW_GATE_ALIAS_ENV,
-        )
-        results = dict(results)
-        results["e2e_loop_ok"] = results["thirty_turn_ok"]
-        eval_blob = dict(eval_blob)
-        eval_blob["results"] = results
     if isinstance(results, dict):
         mtp_report = _mtp_report_eval(ctx)
         enriched_results = dict(results)
@@ -2178,11 +2151,7 @@ def assemble_manifest(
     # alias (e2e_loop_ok ← thirty_turn_ok gate result) hid the fact that
     # one of the two gates had no measurement.
     thirty_turn_ok = _read_independent_bool(results, "thirty_turn_ok")
-    e2e_loop_ok = _read_independent_bool(
-        results,
-        "e2e_loop_ok",
-        opt_in_alias_for="thirty_turn_ok",
-    )
+    e2e_loop_ok = _read_independent_bool(results, "e2e_loop_ok")
     mtp_report = _mtp_report_eval(ctx)
     mtp_acceptance_rate = _optional_float(results.get("mtp_acceptance"))
     if mtp_acceptance_rate is None:
@@ -2274,30 +2243,15 @@ def _gate_passed(report: GateReport, name: str) -> bool:
     return True
 
 
-# Operator opt-in for collapsing two independent contract booleans onto
-# a single observed measurement. Set to "1" to allow the orchestrator
-# to source ``e2e_loop_ok`` from the ``thirty_turn_ok`` measurement when
-# the eval blob doesn't carry an ``e2e_loop_ok`` key. Without the opt-in,
-# a missing key is publish-blocking.
-PUBLISH_ALLOW_GATE_ALIAS_ENV = "ELIZA_PUBLISH_ALLOW_GATE_ALIAS"
-
-
 def _read_independent_bool(
     results: Mapping[str, Any],
     key: str,
-    *,
-    opt_in_alias_for: str | None = None,
 ) -> bool:
     """Read an independent contract boolean from the eval results blob.
 
-    When ``key`` is missing AND ``opt_in_alias_for`` is provided, the
-    orchestrator falls back to the alias key only if the operator has
-    set ``ELIZA_PUBLISH_ALLOW_GATE_ALIAS=1`` — and logs a clear warning
-    that two independent manifest fields are being sourced from one
-    measurement. Without the opt-in, the missing key raises
-    ``OrchestratorError`` so the publish surfaces the contract gap
-    instead of silently emitting a manifest with one half of the gate
-    inferred.
+    Missing keys raise ``OrchestratorError`` so the publish surfaces
+    the contract gap instead of emitting a manifest with one gate
+    inferred from a different measurement.
     """
     if key in results:
         value = results[key]
@@ -2309,46 +2263,10 @@ def _read_independent_bool(
             )
         return value
 
-    if opt_in_alias_for is None:
-        raise OrchestratorError(
-            f"evals/aggregate.json missing required boolean results.{key!r}",
-            EXIT_EVAL_GATE_FAIL,
-        )
-
-    if os.environ.get(PUBLISH_ALLOW_GATE_ALIAS_ENV) != "1":
-        raise OrchestratorError(
-            f"evals/aggregate.json missing results.{key!r}; the manifest "
-            f"contract requires it as an independent measurement from "
-            f"{opt_in_alias_for!r}. To temporarily alias it to "
-            f"{opt_in_alias_for!r} (lower-fidelity publish), re-run with "
-            f"{PUBLISH_ALLOW_GATE_ALIAS_ENV}=1.",
-            EXIT_EVAL_GATE_FAIL,
-        )
-
-    if opt_in_alias_for not in results:
-        raise OrchestratorError(
-            f"evals/aggregate.json missing both results.{key!r} and the "
-            f"alias source results.{opt_in_alias_for!r}; nothing to alias.",
-            EXIT_EVAL_GATE_FAIL,
-        )
-
-    aliased = results[opt_in_alias_for]
-    if not isinstance(aliased, bool):
-        raise OrchestratorError(
-            f"evals/aggregate.json results.{opt_in_alias_for!r} must be "
-            f"a bool to be aliased to {key!r}, got {type(aliased).__name__}",
-            EXIT_EVAL_GATE_FAIL,
-        )
-    log.warning(
-        "[evals] aliasing results.%s ← results.%s "
-        "(opt-in via %s=1). Two independent manifest contract gates are "
-        "being sourced from one measurement; this is a lower-fidelity "
-        "publish.",
-        key,
-        opt_in_alias_for,
-        PUBLISH_ALLOW_GATE_ALIAS_ENV,
+    raise OrchestratorError(
+        f"evals/aggregate.json missing required boolean results.{key!r}",
+        EXIT_EVAL_GATE_FAIL,
     )
-    return aliased
 
 
 # ---------------------------------------------------------------------------

--- a/packages/training/scripts/publish/test_orchestrator.py
+++ b/packages/training/scripts/publish/test_orchestrator.py
@@ -1613,44 +1613,22 @@ def test_dry_run_tag_is_printed_not_executed(tmp_path: Path, caplog) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_missing_e2e_loop_ok_blocks_publish_without_opt_in(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_missing_e2e_loop_ok_blocks_publish(tmp_path: Path, monkeypatch) -> None:
     """The orchestrator refuses to silently alias e2e_loop_ok ← thirty_turn_ok.
 
     AGENTS.md §6 declares the two manifest fields as independent
-    contract gates; without the explicit ``ELIZA_PUBLISH_ALLOW_GATE_ALIAS``
-    opt-in, a missing ``e2e_loop_ok`` is publish-blocking.
+    contract gates; a missing ``e2e_loop_ok`` is publish-blocking even
+    if the retired alias env var is set.
     """
-    blob = _passing_eval_blob()
-    blob["results"].pop("e2e_loop_ok")
-    bundle = _build_fixture_bundle(tmp_path, eval_blob=blob)
-    metal = _metal_report(tmp_path)
-    monkeypatch.delenv("ELIZA_PUBLISH_ALLOW_GATE_ALIAS", raising=False)
-
-    rc = run(_ctx("4b", bundle, metal=metal, dry_run=True))
-    assert rc == EXIT_EVAL_GATE_FAIL
-    assert not (bundle / "eliza-1.manifest.json").is_file()
-
-
-def test_alias_opt_in_allows_publish_with_warning(
-    tmp_path: Path, monkeypatch, caplog
-) -> None:
-    """With the opt-in env var, e2e_loop_ok aliases thirty_turn_ok and warns."""
     blob = _passing_eval_blob()
     blob["results"].pop("e2e_loop_ok")
     bundle = _build_fixture_bundle(tmp_path, eval_blob=blob)
     metal = _metal_report(tmp_path)
     monkeypatch.setenv("ELIZA_PUBLISH_ALLOW_GATE_ALIAS", "1")
 
-    with caplog.at_level(logging.WARNING, logger="publish.orchestrator"):
-        rc = run(_ctx("4b", bundle, metal=metal, dry_run=True))
-
-    assert rc == EXIT_OK
-    assert "aliasing results.e2e_loop_ok" in caplog.text
-    manifest = json.loads((bundle / "eliza-1.manifest.json").read_text())
-    assert manifest["evals"]["e2eLoopOk"] is True
-    assert manifest["evals"]["thirtyTurnOk"] is True
+    rc = run(_ctx("4b", bundle, metal=metal, dry_run=True))
+    assert rc == EXIT_EVAL_GATE_FAIL
+    assert not (bundle / "eliza-1.manifest.json").is_file()
 
 
 def test_cli_help(monkeypatch, capsys) -> None:


### PR DESCRIPTION
## Summary
- remove the `ELIZA_PUBLISH_ALLOW_GATE_ALIAS` bypass from the publish orchestrator
- require independent `e2e_loop_ok` and `thirty_turn_ok` measurements in `evals/aggregate.json`
- keep a regression test proving the retired env var no longer allows a missing `e2e_loop_ok`

## Evidence
- `.github/issue-evidence/12216-stage4-remove-gate-alias/README.md`
- `python3 -m pytest packages/training/scripts/publish/test_orchestrator.py -q`
- `python3 -m py_compile packages/training/scripts/publish/orchestrator.py packages/training/scripts/publish/test_orchestrator.py`
- `git diff --check origin/develop..HEAD`

Refs #12321