### PR TITLE
fix(model-plugins): groq core tool/toolChoice normalization + Go-duration 429 parsing; xai system-prompt wiring

### DIFF
--- a/plugins/plugin-groq/__tests__/tool-normalization.shape.test.ts
+++ b/plugins/plugin-groq/__tests__/tool-normalization.shape.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Wire-shape tests for Groq tool plumbing and 429 cooldown parsing.
+ *
+ * The runtime hands plugins core `ToolDefinition[]` arrays and core
+ * `ToolChoice` objects ({ type: "tool", name }); the AI SDK needs a ToolSet
+ * keyed by tool name (with `inputSchema`) and { type: "tool", toolName }.
+ * Passing the raw shapes through gives Groq function names like "0" with an
+ * empty schema. Deterministic harness: the `ai` SDK entry is mocked; no live
+ * API.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function createRuntime() {
+  return Object.assign(Object.create(null) as IAgentRuntime, {
+    character: { system: "system prompt" },
+    emitEvent: vi.fn(async () => undefined),
+    getSetting: vi.fn((key: string) => {
+      const settings: Record<string, string> = {
+        GROQ_API_KEY: "test-key",
+        GROQ_SMALL_MODEL: "groq-small",
+      };
+      return settings[key] ?? null;
+    }),
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.doUnmock("ai");
+  vi.doUnmock("@ai-sdk/groq");
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+describe("Groq core ToolDefinition[] normalization", () => {
+  it("converts core ToolDefinition arrays and core toolChoice to the AI SDK shapes", async () => {
+    const generateText = vi.fn(async (_options: Record<string, unknown>) => ({
+      text: "",
+      toolCalls: [{ toolName: "lookup", input: { q: "x" } }],
+      finishReason: "tool-calls",
+      usage: { inputTokens: 5, outputTokens: 2, totalTokens: 7 },
+    }));
+    vi.doMock("ai", async () => {
+      const actual = await vi.importActual<typeof import("ai")>("ai");
+      return { ...actual, generateText };
+    });
+    vi.doMock("@ai-sdk/groq", () => ({
+      createGroq: () => ({
+        languageModel: (modelName: string) => ({ modelName }),
+      }),
+    }));
+
+    const { groqPlugin } = await import("../index");
+    const handler = groqPlugin.models?.TEXT_SMALL as (
+      runtime: IAgentRuntime,
+      params: unknown
+    ) => Promise<unknown>;
+    const parameters = {
+      type: "object",
+      properties: { q: { type: "string" } },
+      required: ["q"],
+    };
+    await handler(createRuntime(), {
+      prompt: "use the tool",
+      // Core runtime shape: ordered ToolDefinition[] + { type: "tool", name }.
+      tools: [{ name: "lookup", description: "Lookup a thing", parameters }],
+      toolChoice: { type: "tool", name: "lookup" },
+    });
+
+    const call = generateText.mock.calls[0]?.[0] as {
+      tools?: Record<string, { description?: string; inputSchema?: { jsonSchema?: unknown } }>;
+      toolChoice?: unknown;
+    };
+    if (!call) {
+      throw new Error("Expected generateText to be called");
+    }
+    expect(call.tools).not.toHaveProperty("0");
+    expect(call.tools?.lookup?.description).toBe("Lookup a thing");
+    expect(call.tools?.lookup?.inputSchema?.jsonSchema).toEqual(parameters);
+    expect(call.toolChoice).toEqual({ type: "tool", toolName: "lookup" });
+  });
+});
+
+describe("Groq 429 cooldown parsing (extractRetryDelay)", () => {
+  it("parses Go-style compound durations from Groq rate-limit messages", async () => {
+    const { extractRetryDelay } = await import("../index");
+    expect(extractRetryDelay("Rate limit reached. Please try again in 7m30s.")).toBe(451_000);
+    expect(extractRetryDelay("Rate limit reached. Please try again in 2m59.56s.")).toBe(180_560);
+    expect(extractRetryDelay("Please try again in 30s.")).toBe(31_000);
+    expect(extractRetryDelay("Please try again in 859ms.")).toBe(1_859);
+    expect(extractRetryDelay("no hint at all")).toBe(10_000);
+  });
+
+  it("waits out a minute-format server cooldown before retrying a 429", async () => {
+    const delays: number[] = [];
+    vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      callback: TimerHandler,
+      delay?: number
+    ) => {
+      delays.push(delay ?? 0);
+      if (typeof callback === "function") {
+        callback();
+      }
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+    const generateText = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("Rate limit reached for model. Please try again in 2m59.56s.")
+      )
+      .mockResolvedValueOnce({
+        text: "after cooldown",
+        finishReason: "stop",
+        usage: { inputTokens: 4, outputTokens: 2, totalTokens: 6 },
+      });
+    vi.doMock("ai", async () => {
+      const actual = await vi.importActual<typeof import("ai")>("ai");
+      return { ...actual, generateText };
+    });
+    vi.doMock("@ai-sdk/groq", () => ({
+      createGroq: () => ({
+        languageModel: (modelName: string) => ({ modelName }),
+      }),
+    }));
+
+    const { groqPlugin } = await import("../index");
+    const handler = groqPlugin.models?.TEXT_SMALL as (
+      runtime: IAgentRuntime,
+      params: unknown
+    ) => Promise<unknown>;
+    await expect(handler(createRuntime(), { prompt: "retry me" })).resolves.toBe("after cooldown");
+
+    // hinted 180 560 ms (2m59.56s + 1s) + first-attempt jitter backoff 500 ms.
+    expect(delays[0]).toBe(181_060);
+  });
+});

--- a/plugins/plugin-groq/index.ts
+++ b/plugins/plugin-groq/index.ts
@@ -323,12 +323,27 @@ function createGroqClient(runtime: IAgentRuntime) {
   });
 }
 
-function extractRetryDelay(message: string): number {
-  const match = message.match(/try again in (\d+\.?\d*)s/i);
-  if (match?.[1]) {
-    return Math.ceil(Number.parseFloat(match[1]) * 1000) + 1000;
+// Groq 429s phrase the cooldown as a Go-style duration: "7m30s", "2m59.56s",
+// "859ms", or plain "30s". Sum every component; a seconds-only regex reads
+// "7m30s" as no match (10s default) and re-collides with the same window.
+export function extractRetryDelay(message: string): number {
+  const match = message.match(/try again in ((?:\d+(?:\.\d+)?(?:ms|[smhd]))+)/i);
+  if (!match?.[1]) {
+    return 10000;
   }
-  return 10000;
+  const unitMs: Record<string, number> = {
+    ms: 1,
+    s: 1_000,
+    m: 60_000,
+    h: 3_600_000,
+    d: 86_400_000,
+  };
+  let totalMs = 0;
+  for (const part of match[1].matchAll(/(\d+(?:\.\d+)?)(ms|[smhd])/gi)) {
+    totalMs +=
+      Number.parseFloat(part[1] ?? "0") * (unitMs[(part[2] ?? "s").toLowerCase()] ?? 1_000);
+  }
+  return Math.ceil(totalMs) + 1000;
 }
 
 /**
@@ -401,6 +416,97 @@ function buildGroqStructuredOutput(responseSchema: unknown): NativeOutput {
     ...(schemaOptions.name ? { name: schemaOptions.name } : {}),
     ...(schemaOptions.description ? { description: schemaOptions.description } : {}),
   }) as NativeOutput;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+// The runtime exposes tools as ordered core `ToolDefinition[]` ({ name,
+// description, parameters }). The AI SDK expects a `ToolSet` keyed by
+// provider-visible tool names with `inputSchema`; passing the array through
+// gives Groq function names like "0" with an empty schema. Pre-built ToolSet
+// objects (no `name` field on values) pass through unchanged.
+function readGroqToolSet(value: unknown): ToolSet | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const isArr = Array.isArray(value);
+  if (!isArr && !isRecord(value)) {
+    return undefined;
+  }
+  const entries: Array<[string, unknown]> = isArr
+    ? (value as unknown[]).map((v, i) => [String(i), v] as [string, unknown])
+    : Object.entries(value as Record<string, unknown>);
+
+  const tools: Record<string, unknown> = {};
+  let sawNamedTool = false;
+  for (const [origKey, rawTool] of entries) {
+    if (!isRecord(rawTool)) {
+      continue;
+    }
+    const functionTool = isRecord(rawTool.function) ? rawTool.function : undefined;
+    const name =
+      typeof rawTool.name === "string" && rawTool.name
+        ? rawTool.name
+        : typeof functionTool?.name === "string" && functionTool.name
+          ? functionTool.name
+          : undefined;
+    if (name) {
+      sawNamedTool = true;
+      const schema = isRecord(rawTool.parameters)
+        ? (rawTool.parameters as JSONSchema7)
+        : isRecord(functionTool?.parameters)
+          ? (functionTool.parameters as JSONSchema7)
+          : isRecord(rawTool.input_schema)
+            ? (rawTool.input_schema as JSONSchema7)
+            : ({ type: "object" } satisfies JSONSchema7);
+      const description =
+        typeof rawTool.description === "string"
+          ? rawTool.description
+          : typeof functionTool?.description === "string"
+            ? functionTool.description
+            : undefined;
+      tools[name] = {
+        ...(description ? { description } : {}),
+        inputSchema: jsonSchema(schema),
+      };
+    } else if (!isArr) {
+      tools[origKey] = rawTool;
+    }
+  }
+
+  if (sawNamedTool) {
+    return Object.keys(tools).length > 0 ? (tools as ToolSet) : undefined;
+  }
+  return !isArr && isRecord(value) ? (value as ToolSet) : undefined;
+}
+
+// Core `ToolChoice` uses `{ type: "tool", name }` / `{ type: "function",
+// function: { name } }`; the AI SDK only understands `{ type: "tool",
+// toolName }` and the string enums.
+function readGroqToolChoice(value: unknown): ToolChoice<ToolSet> | undefined {
+  if (!value) {
+    return undefined;
+  }
+  if (typeof value === "string" && (value === "auto" || value === "none" || value === "required")) {
+    return value;
+  }
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  if (value.type === "tool" && typeof value.toolName === "string") {
+    return value as ToolChoice<ToolSet>;
+  }
+  if (value.type === "tool" && typeof value.name === "string") {
+    return { type: "tool", toolName: value.name };
+  }
+  if (value.type === "function" && isRecord(value.function)) {
+    const name = value.function.name;
+    return typeof name === "string" ? { type: "tool", toolName: name } : undefined;
+  }
+  return typeof value.name === "string" ? { type: "tool", toolName: value.name } : undefined;
 }
 
 type GroqUsage = {
@@ -580,8 +686,8 @@ function buildGroqGenerateParams(
 } {
   const paramsWithNative = params as GenerateTextParams & {
     messages?: ModelMessage[];
-    tools?: ToolSet;
-    toolChoice?: ToolChoice<ToolSet>;
+    tools?: unknown;
+    toolChoice?: unknown;
     responseSchema?: unknown;
   };
   const returnNative = Boolean(
@@ -590,6 +696,8 @@ function buildGroqGenerateParams(
       paramsWithNative.toolChoice ||
       paramsWithNative.responseSchema
   );
+  const normalizedTools = readGroqToolSet(paramsWithNative.tools);
+  const normalizedToolChoice = readGroqToolChoice(paramsWithNative.toolChoice);
   return {
     prompt: promptText,
     system: systemPrompt,
@@ -602,8 +710,8 @@ function buildGroqGenerateParams(
     presencePenalty: boundedNumber(params.presencePenalty, 0.7, -2, 2),
     stopSequences: stringArray(params.stopSequences),
     ...(paramsWithNative.messages ? { messages: paramsWithNative.messages } : {}),
-    ...(paramsWithNative.tools ? { tools: paramsWithNative.tools } : {}),
-    ...(paramsWithNative.toolChoice ? { toolChoice: paramsWithNative.toolChoice } : {}),
+    ...(normalizedTools ? { tools: normalizedTools } : {}),
+    ...(normalizedToolChoice ? { toolChoice: normalizedToolChoice } : {}),
     ...(paramsWithNative.responseSchema ? { responseSchema: paramsWithNative.responseSchema } : {}),
     ...(returnNative ? { returnNative } : {}),
   };

--- a/plugins/plugin-xai/__tests__/system-prompt.shape.test.ts
+++ b/plugins/plugin-xai/__tests__/system-prompt.shape.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Wire-shape tests for the xAI system-prompt plumbing: the request body sent
+ * to /chat/completions must carry the resolved system instruction as a leading
+ * system message (caller `params.system` first, character identity fallback),
+ * without duplicating a system message the caller already provided.
+ * Deterministic harness: fetch is mocked; no live API.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleTextSmall } from "../models/grok";
+
+function createRuntime(character?: Record<string, unknown>) {
+  return {
+    character: character ?? {
+      name: "Grokky",
+      system: "character system prompt",
+    },
+    emitEvent: vi.fn(async () => undefined),
+    getSetting: vi.fn((key: string) => {
+      const settings: Record<string, string> = {
+        XAI_API_KEY: "test-key",
+        XAI_SMALL_MODEL: "grok-test-small",
+      };
+      return settings[key] ?? null;
+    }),
+  } as IAgentRuntime;
+}
+
+function mockChatCompletion(text = "ok") {
+  const fetchMock = vi.fn(
+    async () =>
+      new Response(
+        JSON.stringify({
+          id: "x",
+          object: "chat.completion",
+          created: 0,
+          model: "grok-test-small",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: text },
+              finish_reason: "stop",
+            },
+          ],
+          usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+  );
+  vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as typeof fetch);
+  return fetchMock;
+}
+
+function requestMessages(fetchMock: ReturnType<typeof vi.fn>) {
+  const body = fetchMock.mock.calls[0]?.[1]?.body;
+  return (
+    JSON.parse(String(body)) as {
+      messages: Array<{ role: string; content: string }>;
+    }
+  ).messages;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("xAI system prompt plumbing", () => {
+  it("sends caller params.system as a leading system message", async () => {
+    const fetchMock = mockChatCompletion();
+    await handleTextSmall(createRuntime(), {
+      prompt: "hi",
+      system: "You are a precise test agent.",
+    });
+
+    const messages = requestMessages(fetchMock);
+    expect(messages).toEqual([
+      { role: "system", content: "You are a precise test agent." },
+      { role: "user", content: "hi" },
+    ]);
+  });
+
+  it("falls back to the character identity when params.system is absent", async () => {
+    const fetchMock = mockChatCompletion();
+    await handleTextSmall(createRuntime(), { prompt: "hi" });
+
+    const messages = requestMessages(fetchMock);
+    expect(messages[0]?.role).toBe("system");
+    expect(messages[0]?.content).toContain("character system prompt");
+    expect(messages[1]).toEqual({ role: "user", content: "hi" });
+  });
+
+  it("does not duplicate a system message the caller already leads with", async () => {
+    const fetchMock = mockChatCompletion();
+    await handleTextSmall(createRuntime(), {
+      messages: [
+        { role: "system", content: "already here" },
+        { role: "user", content: "hi" },
+      ],
+    } as never);
+
+    const messages = requestMessages(fetchMock);
+    expect(
+      messages.filter((message) => message.role === "system"),
+    ).toHaveLength(1);
+    expect(messages[0]).toEqual({ role: "system", content: "already here" });
+    expect(messages[1]).toEqual({ role: "user", content: "hi" });
+  });
+});

--- a/plugins/plugin-xai/models/grok.ts
+++ b/plugins/plugin-xai/models/grok.ts
@@ -6,6 +6,8 @@
  * ../index.ts.
  */
 import {
+  buildCanonicalSystemPrompt,
+  dropDuplicateLeadingSystemMessage,
   type EventPayload,
   EventType,
   type GenerateTextParams,
@@ -14,6 +16,7 @@ import {
   ModelType,
   type ModelTypeName,
   recordLlmCall,
+  resolveEffectiveSystemPrompt,
   type TextEmbeddingParams,
   type TextStreamResult,
 } from "@elizaos/core";
@@ -488,9 +491,24 @@ async function generateText(
       paramsWithNative.responseSchema,
   );
 
-  const messages: ChatMessage[] = paramsWithNative.messages?.length
+  // xAI's chat API carries the system instruction as a leading system message;
+  // dropping it here would strip both caller-provided `params.system` and the
+  // character identity from every request.
+  const systemPrompt = resolveEffectiveSystemPrompt({
+    params: paramsWithNative,
+    fallback: buildCanonicalSystemPrompt({ character: runtime.character }),
+  });
+  const rawMessages: ChatMessage[] = paramsWithNative.messages?.length
     ? (paramsWithNative.messages as ChatMessage[])
     : [{ role: "user", content: promptText }];
+  const wireMessages = systemPrompt
+    ? (dropDuplicateLeadingSystemMessage(rawMessages, systemPrompt) ??
+      rawMessages)
+    : rawMessages;
+  const messages: ChatMessage[] =
+    systemPrompt && wireMessages[0]?.role !== "system"
+      ? [{ role: "system", content: systemPrompt }, ...wireMessages]
+      : wireMessages;
 
   const body: Record<string, unknown> = {
     model,
@@ -549,7 +567,7 @@ async function generateText(
     runtime,
     {
       model,
-      systemPrompt: "",
+      systemPrompt: systemPrompt ?? "",
       userPrompt: promptText,
       temperature: params.temperature ?? 0,
       maxTokens: params.maxTokens ?? 0,


### PR DESCRIPTION
## What

Three provider-plugin request/response bugs, each probe-verified against the real code path before fixing, each covered by a deterministic (no-live-API) wire-shape unit test, each mutation-checked.

### 1. plugin-groq — core `ToolDefinition[]` / `ToolChoice` passed raw to the AI SDK (tool calling broken)

The runtime hands plugins `tools` as ordered core `ToolDefinition[]` (`{name, description, parameters}`) and `toolChoice` as core `{ type: "tool", name }`. Groq forwarded both untouched into `generateText`.

**Concrete failure (probe-executed against the real `ai` SDK with a recording stub model):** the provider received

```json
tools: [{ "type": "function", "name": "0", "inputSchema": { "properties": {}, "additionalProperties": false } }]
toolChoice: { "type": "tool" }
```

— tool named **"0"**, parameters schema **dropped entirely**, toolChoice with **no toolName**. Every core tool-calling request through Groq was broken. openrouter/ollama/anthropic all carry normalizers for exactly this; Groq was the odd one out.

**Fix:** `readGroqToolSet` / `readGroqToolChoice` (mirrors openrouter): named ToolSet with `inputSchema: jsonSchema(parameters)`; `{type:"tool",name}` / `{type:"function",function:{name}}` / `{name}` → `{type:"tool",toolName}`. Pre-built ToolSet objects still pass through by identity (existing `native-plumbing.shape.test.ts` identity assertion stays green).

### 2. plugin-groq — 429 cooldown parser can't read Groq's real duration format

Groq 429s phrase the cooldown Go-style: `"Please try again in 7m30s"`, `"2m59.56s"`, `"859ms"`. The old regex `/try again in (\d+\.?\d*)s/` only matched pure seconds → **`extractRetryDelay("…try again in 7m30s.") returned 10000 instead of 451000`**, so the retry fired ~7 minutes early into the same window and burned all 5 rate-limit retries before throwing.

**Fix:** parse and sum ms/s/m/h/d components (+1s cushion, unchanged); seconds-only messages behave identically to before.

### 3. plugin-xai — system prompt silently dropped from every request

`generateText()` built `messages = [{role:"user",content:prompt}]` with no system handling at all — unlike every other provider plugin (groq/openrouter/ollama/google-genai/anthropic all run `resolveEffectiveSystemPrompt`). **Concrete failure:** `handleTextSmall(runtime, { prompt: "hi", system: "You are a precise test agent." })` produced a wire body with **no system message** — caller `params.system` (a first-class core `GenerateTextParams` field) and the agent's character identity never reached Grok.

**Fix:** resolve via `resolveEffectiveSystemPrompt` (fallback `buildCanonicalSystemPrompt({character})`), prepend as the leading system message, dedupe a caller-provided leading system message via `dropDuplicateLeadingSystemMessage`. Non-stream telemetry now records the real systemPrompt.

## Tests & mutation evidence

| Fix | Test | Green | Mutation check |
|---|---|---|---|
| groq tool normalization | `plugins/plugin-groq/__tests__/tool-normalization.shape.test.ts` — asserts the `generateText` call carries `tools.lookup` (not `"0"`) with the real schema + `{type:"tool",toolName:"lookup"}` | ✅ | revert wiring to raw passthrough → **1 failed** ✅ |
| groq 429 cooldown | same file — direct asserts (`7m30s`→451000, `2m59.56s`→180560, `30s`→31000, `859ms`→1859, no-hint→10000) + end-to-end retry-loop test asserting `setTimeout` delay of exactly **181060 ms** | ✅ | restore old regex → **2 failed** ✅ |
| xai system prompt | `plugins/plugin-xai/__tests__/system-prompt.shape.test.ts` — parses the mocked-fetch request body: leading system message for `params.system`, character fallback, no duplication | ✅ | stash grok.ts fix → **2 failed** ✅ |

- Full suites green post-rebase: plugin-groq **31 passed | 1 skipped**, plugin-xai **27 passed | 1 skipped** (`bunx vitest run --no-cache`).
- `tsgo --noEmit` clean on both plugins; biome clean.
- Reviewed clean (no fix warranted): plugin-openrouter, plugin-ollama, plugin-google-genai, plugin-anthropic — they already normalize tools/system correctly; google-genai's chars/4 usage heuristic is documented-by-design telemetry.

## Evidence N/A rows
- **Live-model trajectory:** N/A — no GROQ/XAI API key in this environment; all three bugs are pure request-shaping defects fully provable at the wire boundary (mocked `ai` SDK / mocked `fetch` capture the exact request the provider would receive). The groq tools bug was additionally probe-executed through the **real** `ai` SDK (unmocked) with a recording stub model.
- **Screenshots / video / frontend logs:** N/A — no UI surface; model-provider request/response logic only.
- **Domain artifacts:** the failing wire bodies (tool name "0", empty schema, missing system message) are reproduced verbatim by the committed tests.

[phone-ui]

---
**Authored end-to-end by a Fable-5 agent** (verified 100% claude-fable-5), committed + pushed on its own branch. Each fix probe-executed against the real code path (recording-stub model / real ai SDK) BEFORE authoring. Independently re-verified: 4-file merge-base diff, the 2 new test files 6/6 green (--no-cache), and the groq tool-normalization mutation reproduced (revert → 3 red; restore → green). NOTE: `plugin-groq/__tests__/keyless-harness.harness.test.ts` shows 2 failures, but these are **PRE-EXISTING on clean origin/develop** (verified: they fail identically with this branch's groq change reverted) — a flaky/broken heavy integration harness unrelated to this diff, not a regression from these fixes. Agent honestly DROPPED 4 candidates (openrouter substring match, xai stream usage, google-genai heuristic usage = documented design, anthropic/ollama/openrouter = clean). — [phone-ui]