### PR TITLE
docs(#12246): prose file headers + churn cleanup — orchestrator/coding/training plugins (B16)

### DIFF
--- a/plugins/app-model-tester/scripts/model-tester-e2e.mjs
+++ b/plugins/app-model-tester/scripts/model-tester-e2e.mjs
@@ -1,5 +1,13 @@
 #!/usr/bin/env node
 
+/**
+ * End-to-end probe runner for the Model Tester routes: against a live agent server
+ * it asserts the static shell renders (and carries no Vite/HMR code), the status
+ * endpoint lists every probe, and each probe runs — treating a known-unavailable
+ * backend as a skip while requiring text-small, text-large, embedding, and vad to
+ * pass. Configured via MODEL_TESTER_BASE_URL / MODEL_TESTER_REQUIRE_ALL.
+ */
+
 const baseUrl = process.env.MODEL_TESTER_BASE_URL ?? "http://127.0.0.1:31337";
 const requireAll = process.env.MODEL_TESTER_REQUIRE_ALL === "1";
 

--- a/plugins/app-model-tester/src/ModelTesterAppView.interact.test.ts
+++ b/plugins/app-model-tester/src/ModelTesterAppView.interact.test.ts
@@ -1,3 +1,5 @@
+/** Covers the TUI `interact()` capability handler — status fetch, run-* capability-to-test mapping, param coercion, and error propagation — against a stubbed fetch (no live server). */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { interact } from "./ModelTesterAppView.interact.js";
 

--- a/plugins/app-model-tester/src/ModelTesterAppView.test.tsx
+++ b/plugins/app-model-tester/src/ModelTesterAppView.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
 
+/**
+ * Drives the ModelTesterAppView overlay through the rendered DOM: status
+ * population, ready-count math, prompt presets, per-probe and run-all dispatch,
+ * result rendering (embedding/TTS/image/failure), and the asset pickers. The
+ * @elizaos/ui surfaces and fetch are mocked, so the harness is deterministic.
+ */
+
 import {
   cleanup,
   fireEvent,

--- a/plugins/app-model-tester/src/ModelTesterAppView.tsx
+++ b/plugins/app-model-tester/src/ModelTesterAppView.tsx
@@ -1,3 +1,11 @@
+/**
+ * Overlay React view for the Model Tester: fetches per-probe status, dispatches
+ * individual and run-all probe requests against `/api/model-tester/*`, and renders
+ * results (text, embedding preview, generated images, TTS audio) with image/audio
+ * asset pickers and prompt presets. Each control is wired to the agent-surface
+ * registry so an Eliza agent can address it.
+ */
+
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import type { OverlayAppContext } from "@elizaos/ui/components/apps/overlay-app-api";
 import { Button } from "@elizaos/ui/components/ui/button";

--- a/plugins/app-model-tester/src/ModelTesterVisualCopy.test.ts
+++ b/plugins/app-model-tester/src/ModelTesterVisualCopy.test.ts
@@ -1,3 +1,5 @@
+/** Guards ModelTesterAppView.tsx against redundant header copy and paragraph metadata by scanning its source text (deterministic filesystem read, no render). */
+
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/app-model-tester/src/components/ModelTesterSpatialView.test.tsx
+++ b/plugins/app-model-tester/src/components/ModelTesterSpatialView.test.tsx
@@ -1,3 +1,5 @@
+/** Renders the one ModelTesterSpatialView across all three modalities — TUI terminal lines under the width contract, GUI/XR DOM via react-dom/server, and the terminal registry — from a fixed snapshot (deterministic, no live models). */
+
 import { visibleWidth } from "@elizaos/tui";
 import { SpatialSurface } from "@elizaos/ui/spatial";
 import {

--- a/plugins/app-model-tester/src/components/ModelTesterSpatialView.tsx
+++ b/plugins/app-model-tester/src/components/ModelTesterSpatialView.tsx
@@ -9,8 +9,8 @@
  * It is purely presentational (a snapshot + an action callback in, primitives
  * out) and imports only the cross-modality primitives, so it is safe to render
  * in the Node agent process where the terminal lives (no browser/Capacitor
- * runtime import). The rich `ModelTesterAppView` React view is untouched; this
- * is an additive sibling that mirrors the same probe data.
+ * runtime import). It mirrors the same probe data as the rich
+ * `ModelTesterAppView` React view.
  */
 
 import {

--- a/plugins/app-model-tester/src/index.ts
+++ b/plugins/app-model-tester/src/index.ts
@@ -1,3 +1,4 @@
+/** Package entry: re-exports the plugin, overlay app, routes, and views, and imports the app module for its registration side effects. */
 export * from "./ModelTesterAppView.js";
 export { ModelTesterView } from "./ModelTesterView.js";
 export { MODEL_TESTER_APP_NAME, modelTesterApp } from "./model-tester-app.js";

--- a/plugins/app-model-tester/src/model-tester-app.test.ts
+++ b/plugins/app-model-tester/src/model-tester-app.test.ts
@@ -1,3 +1,5 @@
+/** Verifies model-tester-app.ts registers the overlay app and shell page on import; the UI registries are mocked, so this is a deterministic registration check. */
+
 import { describe, expect, it, vi } from "vitest";
 
 const registerAppShellPage = vi.hoisted(() => vi.fn());

--- a/plugins/app-model-tester/src/model-tester-app.ts
+++ b/plugins/app-model-tester/src/model-tester-app.ts
@@ -1,3 +1,11 @@
+/**
+ * Registers the Model Tester with the app-shell and overlay-app registries at
+ * import time: the overlay app (`@elizaos/app-model-tester`) and the `/model-tester`
+ * shell page, both lazy-loading `ModelTesterAppView`. In a terminal host (no DOM) it
+ * also registers the unified spatial terminal view. Importing this module for its
+ * side effects is intentional; do not tree-shake it.
+ */
+
 import { registerAppShellPage } from "@elizaos/ui/app-shell-registry";
 import type { OverlayApp } from "@elizaos/ui/components/apps/overlay-app-api";
 import { registerOverlayApp } from "@elizaos/ui/components/apps/overlay-app-registry";

--- a/plugins/app-model-tester/src/plugin.ts
+++ b/plugins/app-model-tester/src/plugin.ts
@@ -1,3 +1,9 @@
+/**
+ * Defines `modelTesterPlugin` — the `Plugin` object that mounts the Model Tester
+ * dashboard surface: the three probe routes (delegated to `handleModelTesterRoute`)
+ * and a single view declaration spanning the GUI, XR, and TUI modalities.
+ */
+
 import type http from "node:http";
 import type { Plugin, Route, RouteRequest, RouteResponse } from "@elizaos/core";
 import { handleModelTesterRoute } from "./routes.js";

--- a/plugins/app-model-tester/src/routes.ts
+++ b/plugins/app-model-tester/src/routes.ts
@@ -1,3 +1,18 @@
+/**
+ * Request handler and probe logic behind the Model Tester HTTP surface: serves the
+ * standalone static tester shell at `GET /model-tester`, reports per-probe readiness
+ * at `GET /api/model-tester/status`, and runs one live model probe per
+ * `POST /api/model-tester/run` (text, embedding, image, image-description,
+ * transcription, text-to-speech, and pure-JS voice-activity detection).
+ *
+ * Every probe follows the same fallthrough: try the direct local-inference engine
+ * first (via `@elizaos/plugin-local-inference/services`, activated lazily and once
+ * through `ensureLocalEngineActive`), then registered cloud providers, collecting
+ * each failure into an `attempts` array rather than throwing on the first miss.
+ * `runModelTest` returns plain serialisable objects; the outermost handler wraps
+ * them in `{ ok, test, durationMs, output }`.
+ */
+
 import type http from "node:http";
 import { readCompatJsonBody } from "@elizaos/app-core/api/compat-route-shared";
 import { sendJson, sendJsonError } from "@elizaos/app-core/api/response";

--- a/plugins/app-model-tester/src/ui.ts
+++ b/plugins/app-model-tester/src/ui.ts
@@ -1,3 +1,4 @@
+/** Consumer-facing re-exports of the Model Tester React view and overlay app. */
 export { ModelTesterAppView } from "./ModelTesterAppView.js";
 export { ModelTesterView } from "./ModelTesterView.js";
 export { MODEL_TESTER_APP_NAME, modelTesterApp } from "./model-tester-app.js";

--- a/plugins/app-model-tester/vite.config.views.ts
+++ b/plugins/app-model-tester/vite.config.views.ts
@@ -1,3 +1,4 @@
+/** Vite build config for the Model Tester view bundle (dist/views/bundle.js), via the shared view-bundle preset. */
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
 export default createViewBundleConfig({

--- a/plugins/app-model-tester/vitest.config.ts
+++ b/plugins/app-model-tester/vitest.config.ts
@@ -1,3 +1,9 @@
+/**
+ * Vitest config for app-model-tester: pins a single react/react-dom copy from the
+ * workspace UI package (the plugin declares neither directly) and aliases a
+ * statically-imported plugin-health subpath to source for the keyless test lane.
+ */
+
 import { createRequire } from "node:module";
 import path from "node:path";
 import { defineConfig } from "vitest/config";

--- a/plugins/plugin-agent-orchestrator/__tests__/live/native-acp-smoke.live.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/live/native-acp-smoke.live.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Live smoke test that drives a real native ACP adapter subprocess through a tiny
+ * prompt end to end. Gated behind `RUN_LIVE_NATIVE_ACP=1`; skipped in keyless CI.
+ */
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.mcp.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.mcp.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies parseAcpMcpServersEnv — opt-in sub-agent MCP forwarding.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   type AcpMcpServerConfig,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies NativeAcpClient JSON-RPC lifecycle.
+ * Runs against a real temporary filesystem with a stubbed runtime; no live model.
+ */
 import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies AcpService.
+ * Drives a real ACP subprocess; deterministic harness (no live model).
+ */
 import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import path from "node:path";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/action-examples-cache.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/action-examples-cache.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies codingAgentExamplesProvider cache config.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { codingAgentExamplesProvider } from "../../src/providers/action-examples.js";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/active-sub-agents.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/active-sub-agents.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies activeSubAgentsProvider.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { activeSubAgentsProvider } from "../../src/providers/active-sub-agents.js";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/agent-routes-goal-wrapper.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/agent-routes-goal-wrapper.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies agent-routes goal wrapper.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { EventEmitter } from "node:events";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/app-deploy-guidance.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/app-deploy-guidance.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies app-deploy-guidance.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   augmentTaskWithDeployGuidance,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/archive-reopen-lifecycle.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/archive-reopen-lifecycle.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies TASKS archive/reopen lifecycle (#11028).
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import {
   archiveCodingTaskAction,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies availableAgentsProvider.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { availableAgentsProvider } from "../../src/providers/available-agents.js";
 import {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/bootstrap-diagnosis.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/bootstrap-diagnosis.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies diagnoseWorkspaceBootstrapFailure.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { diagnoseWorkspaceBootstrapFailure } from "../../src/services/repo-input.js";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/bridge-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/bridge-routes.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies bridge-routes — credential bridge.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
 import {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/cancel-task.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/cancel-task.test.ts
@@ -1,5 +1,9 @@
+/**
+ * Verifies TASKS:cancel.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
-// Post-consolidation: CANCEL_TASK is `TASKS { action: "cancel" }`.
+// CANCEL_TASK is `TASKS { action: "cancel" }`.
 import { cancelTaskAction } from "../../src/actions/tasks.js";
 import {
   callback,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/changeset-render.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/changeset-render.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies renderChangeSetBody.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { renderChangeSetBody } from "../../src/services/completion-evidence.js";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/claude-oauth-token.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/claude-oauth-token.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies isClaudeOAuthSubscriptionToken.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { isClaudeOAuthSubscriptionToken } from "../../src/services/acp-service.js";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/codex-sandbox.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/codex-sandbox.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies codex ACP sandbox helpers.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   appendCodexAcpSandboxConfig,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/coding-account-selection.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/coding-account-selection.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies isMultiAccountAgentType.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL as BRIDGE_SYMBOL } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/coding-session-changes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/coding-session-changes.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies codingSessionChangesProvider — staleness guard.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 
 import { codingSessionChangesProvider } from "../../src/providers/coding-session-changes.js";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-envelope.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-envelope.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies parseCompletionEnvelope (#8895).
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   COMPLETION_ENVELOPE_INSTRUCTION,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-failure-marker.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-failure-marker.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies completionHasFailureMarkerWithoutPositiveEvidence.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { completionHasFailureMarkerWithoutPositiveEvidence } from "../../src/evaluators/sub-agent-completion.js";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/create-task.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/create-task.test.ts
@@ -1,6 +1,10 @@
+/**
+ * Verifies TASKS:create.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import * as os from "node:os";
 import { describe, expect, it, vi } from "vitest";
-// Post-consolidation: CREATE_AGENT_TASK is `TASKS { action: "create" }` (default action).
+// CREATE_AGENT_TASK is `TASKS { action: "create" }` (the default action).
 import { createTaskAction } from "../../src/actions/tasks.js";
 import { codingAgentExamplesProvider } from "../../src/providers/action-examples.js";
 import {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/credential-prompt.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/credential-prompt.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies emitCredentialPrompt (#8907).
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import {
   emitCredentialPrompt,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/extract-completion-summary.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/extract-completion-summary.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies extractCompletionSummary.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { extractCompletionSummary } from "../../src/index.js";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/extract-dev-server-url.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/extract-dev-server-url.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies extractDevServerUrl.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { extractDevServerUrl } from "../../src/services/ansi-utils.js";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/extract-usage-update.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/extract-usage-update.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies extractUsageUpdate.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { extractUsageUpdate } from "../../src/services/acp-service.js";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/git-remote-safety.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/git-remote-safety.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies assertSafeGitRemote.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   assertSafeGitRef,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/goal-prompt.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/goal-prompt.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies buildGoalPrompt.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   buildGoalFollowUp,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/independent-verifier.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/independent-verifier.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies verdictFromEnvelope.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   shouldRunIndependentVerify,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/interruption-decider.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/interruption-decider.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies decideInterruption.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/json-model-output.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/json-model-output.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies parseJsonObjectResponse.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { parseJsonObjectResponse } from "../../src/services/json-model-output.js";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/list-agents.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/list-agents.test.ts
@@ -1,5 +1,9 @@
+/**
+ * Verifies TASKS:list_agents.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
-// Post-consolidation: LIST_AGENTS is `TASKS { action: "list_agents" }`.
+// LIST_AGENTS is `TASKS { action: "list_agents" }`.
 import { listAgentsAction } from "../../src/actions/tasks.js";
 import {
   callback,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies buildOpencodeSpawnConfig.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildOpencodeSpawnConfig } from "../../src/services/opencode-config.js";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies OrchestratorTaskStore backend selection.
+ * Runs against a real temporary filesystem; deterministic.
+ */
 import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/originating-request-routing.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/originating-request-routing.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies resolveOriginatingRequestText.
+ * Runs against a real temporary filesystem with a stubbed runtime; no live model.
+ */
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/provision-workspace-injection.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/provision-workspace-injection.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies provisionWorkspace command-injection gate (#10980 follow-up).
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/provision-workspace.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/provision-workspace.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies TASKS:provision_workspace.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { provisionWorkspaceAction } from "../../src/actions/tasks.js";
 import { CodingWorkspaceService } from "../../src/services/workspace-service.js";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/register-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/register-routes.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies register-routes — bundler-safe sentinel export.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 
 // Force the registration branch to run: by default `isLocalCodeExecutionAllowed`

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/repo-parsing.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/repo-parsing.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies parseOwnerRepo.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { stripAnsi } from "../../src/services/ansi-utils.js";
 import { normalizeRepositoryInput } from "../../src/services/repo-input.js";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/resolve-default-branch.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/resolve-default-branch.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies resolveDefaultBranch.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 // #9146 — resolveDefaultBranch runs `git ls-remote --symref` to find a repo's

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/resolve-spawn-workdir.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/resolve-spawn-workdir.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies resolveSpawnWorkdir — explicit workdir fallback.
+ * Runs against a real temporary filesystem with a stubbed runtime; no live model.
+ */
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/route-input-validation.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/route-input-validation.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies route input validation helpers.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   asBoolean,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sanitize-planner-text.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sanitize-planner-text.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies sanitizePlannerText.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { sanitizePlannerText } from "../../src/index.js";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/scan-and-unlink-older-than.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/scan-and-unlink-older-than.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies scanAndUnlinkOlderThan.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { mkdir, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/screenshot-delivery.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/screenshot-delivery.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies collectScreenshotPaths (#8904).
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { logger } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/send-to-agent.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/send-to-agent.test.ts
@@ -1,6 +1,10 @@
+/**
+ * Verifies TASKS:send.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
-// Post-consolidation: SEND_TO_AGENT is `TASKS { action: "send" }`. The action
-// variable still imports as `sendToAgentAction` (alias on the parent).
+// SEND_TO_AGENT is `TASKS { action: "send" }`; the action variable imports as
+// `sendToAgentAction` (an alias on the parent).
 import { sendToAgentAction } from "../../src/actions/tasks.js";
 import {
   callback,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/session-resume.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/session-resume.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies AcpService.updateSessionMetadata.
+ * Runs against a real temporary filesystem with a stubbed runtime; no live model.
+ */
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/session-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/session-store.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies InMemorySessionStore.
+ * Runs against a real temporary filesystem with a stubbed runtime; no live model.
+ */
 import { mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/setup-routes-credential-paths.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/setup-routes-credential-paths.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies setup-routes — credential bridge path templates are registered.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { codingAgentRoutePlugin } from "../../src/setup-routes.ts";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/setup-routes-task-detail-paths.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/setup-routes-task-detail-paths.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies setup-routes — task detail + control path templates are registered.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { codingAgentRoutePlugin } from "../../src/setup-routes.ts";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies shouldForwardEnv.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   canonicalForwardedEnvKey,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-executor.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-executor.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies detectTurnDone.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   type AcpLike,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-integration.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-integration.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies shouldUseSmithersTaskRunner.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import {
   type AcpTaskService,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-runner.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-runner.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies runTaskWithSmithers (durable Smithers-backed coding task).
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { runTaskWithSmithers } from "../../src/services/smithers-task-runner";
 import type {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
@@ -1,5 +1,9 @@
+/**
+ * Verifies TASKS:spawn_agent.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
-// Post-consolidation: SPAWN_AGENT is `TASKS { action: "spawn_agent" }`.
+// SPAWN_AGENT is `TASKS { action: "spawn_agent" }`.
 import { spawnAgentAction } from "../../src/actions/tasks.js";
 import {
   callback,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-trajectory-link.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-trajectory-link.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies buildLinkedSpawnMetadata.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import type { SpawnTrajectoryHandle } from "../../src/services/spawn-trajectory.js";
 import {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/stop-agent.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/stop-agent.test.ts
@@ -1,5 +1,9 @@
+/**
+ * Verifies TASKS:stop_agent.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
-// Post-consolidation: STOP_AGENT is `TASKS { action: "stop_agent" }`.
+// STOP_AGENT is `TASKS { action: "stop_agent" }`.
 import { stopAgentAction } from "../../src/actions/tasks.js";
 import {
   callback,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/strip-progress-label-prefix.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/strip-progress-label-prefix.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies stripProgressLabelPrefix.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-completion-evaluator.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-completion-evaluator.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies subAgentCompletionResponseEvaluator.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import type {
   Memory,
   MessageHandlerResult,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-env-deny.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-env-deny.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies isDeniedSubAgentEnvKey (customCredentials deny-list).
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { isDeniedSubAgentEnvKey } from "../../src/services/acp-service.ts";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-failure-evaluator.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-failure-evaluator.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies subAgentFailureResponseEvaluator.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import type {
   Memory,
   MessageHandlerResult,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-identity.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-identity.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies writeWorkspaceIdentity.
+ * Runs against a real temporary filesystem; deterministic.
+ */
 import {
   existsSync,
   mkdtempSync,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-inbox.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-inbox.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies SubAgentInbox.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { SubAgentInbox } from "../../src/services/sub-agent-inbox.js";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router-memory-bounds.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router-memory-bounds.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies pruneOldestTracked.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { pruneOldestTracked } from "../../src/services/sub-agent-router.js";
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router-roundtrip-getters.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router-roundtrip-getters.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies SubAgentRouter round-trip getters (#8901).
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import type { Content, Memory } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_ROUND_TRIP_CAP } from "../../src/services/router-loop-guard.js";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies SubAgentRouter.
+ * Drives a real subprocess against a temporary git workspace; deterministic (no live model).
+ */
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies getTaskAgentFrameworkState.
+ * Runs against a real temporary filesystem with a stubbed runtime; no live model.
+ */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-control-structural.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-control-structural.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies TASKS:control structural action.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { taskControlAction } from "../../src/actions/tasks.js";
 import {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-history.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-history.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies TASKS:history.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { taskHistoryAction } from "../../src/actions/tasks.js";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-response-capture.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-response-capture.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies captureTaskResponse / peekTaskResponse.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   captureTaskResponse,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-supervisor.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-supervisor.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies composeRoomDigest (#8900).
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import {
   composeRoomDigest,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-watchdog.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-watchdog.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies detectStalledSessions (#8901).
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   addSessionSpendUsd,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/tasks-action-aliases.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/tasks-action-aliases.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies TASKS action aliases.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { tasksSandboxStubAction } from "../../src/actions/sandbox-stub.js";
 import { tasksAction } from "../../src/actions/tasks.js";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/terminal-capabilities.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/terminal-capabilities.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies detectOrchestratorCapabilities.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   detectOrchestratorCapabilities,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/view-plugin-deploy-guidance.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/view-plugin-deploy-guidance.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies isViewPluginTask (#8918).
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   augmentTaskWithDeployGuidance,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/workspace-diff.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/workspace-diff.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies workspace-diff — real git capture.
+ * Drives a real subprocess against a temporary git workspace; deterministic (no live model).
+ */
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/plugins/plugin-agent-orchestrator/index.node.ts
+++ b/plugins/plugin-agent-orchestrator/index.node.ts
@@ -1,3 +1,6 @@
+/**
+ * Node build entry: re-exports the plugin surface with an explicit default binding for Node bundlers.
+ */
 export * from "./src/index.js";
 
 import _defaultExport from "./src/index.js";

--- a/plugins/plugin-agent-orchestrator/index.ts
+++ b/plugins/plugin-agent-orchestrator/index.ts
@@ -1,2 +1,5 @@
+/**
+ * Package entry: re-exports the plugin factory and default export from `src/index`.
+ */
 export * from "./src/index.js";
 export { default } from "./src/index.js";

--- a/plugins/plugin-agent-orchestrator/scripts/codex-exec-adapters.cjs
+++ b/plugins/plugin-agent-orchestrator/scripts/codex-exec-adapters.cjs
@@ -1,3 +1,8 @@
+/**
+ * Codex ACP exec adapter tables consumed when spawning Codex coding sub-agents.
+ * Maps each approval preset to Codex CLI sandbox flags and web-search settings,
+ * enumerates the valid sandbox modes, and pins the task-agent reasoning effort.
+ */
 "use strict";
 
 const adapters = require("coding-agent-adapters");

--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-native-transport.mcp.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-native-transport.mcp.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies parseAcpMcpServersEnv — opt-in sub-agent MCP forwarding.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   type AcpMcpServerConfig,

--- a/plugins/plugin-agent-orchestrator/src/__tests__/ansi-utils.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/ansi-utils.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies extractCompletionSummary.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   closeUnbalancedMarkdownFences,

--- a/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies shouldAutoVerifyGoal.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AcpService } from "../services/acp-service.js";
 import {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/coding-backend-routing.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/coding-backend-routing.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies readCodingRouting.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/extract-short-tool-deliverable.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/extract-short-tool-deliverable.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies extractShortToolDeliverable.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { extractShortToolDeliverable } from "../services/sub-agent-router";
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/goal-contract.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/goal-contract.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies buildDefaultAcceptanceCriteria (#8896).
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import {
   buildDefaultAcceptanceCriteria,

--- a/plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies resolveGoalCapabilities.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   buildGoalPrompt,

--- a/plugins/plugin-agent-orchestrator/src/__tests__/initial-task-timeout.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/initial-task-timeout.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies background initial task prompt timeout.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { resolveInitialTaskPromptTimeoutMs } from "../services/acp-service.ts";
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-device-support-matrix.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-device-support-matrix.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies orchestrator device support matrix (#9146).
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   buildOrchestratorDeviceSupportMatrix,

--- a/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies runParentAgentBroker.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runParentAgentBroker } from "../services/parent-agent-broker.js";

--- a/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-dispatch.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-dispatch.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies extractParentAgentDirective.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/route-utils.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/route-utils.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies sendServiceUnavailable.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import type { ServerResponse } from "node:http";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/skill-manifest.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/skill-manifest.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies buildSkillsManifest.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/skill-recommender.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/skill-recommender.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies recommendSkillsForTask.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { recommendSkillsForTask } from "../services/skill-recommender.js";

--- a/plugins/plugin-agent-orchestrator/src/__tests__/spawn-trajectory.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/spawn-trajectory.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies spawn trajectory linkage.
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import { type IAgentRuntime, runWithTrajectoryContext } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/spend-allowance.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/spend-allowance.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies estimateSelfSpendCostUsd.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   addSessionSpendUsd,

--- a/plugins/plugin-agent-orchestrator/src/__tests__/sub-agent-completion-finish-reason.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/sub-agent-completion-finish-reason.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies sub-agent completion: degenerate finish-reason relay (issue #8875).
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import type { Memory, MessageHandlerResult, UUID } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { subAgentCompletionResponseEvaluator } from "../evaluators/sub-agent-completion.js";

--- a/plugins/plugin-agent-orchestrator/src/__tests__/sub-agent-discord-routing.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/sub-agent-discord-routing.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies sub-agent Discord reply routing.
+ * Deterministic unit test of pure helpers; no runtime, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
   readOrigin,

--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-supervisor.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-supervisor.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies TaskSupervisorService digest sinks (#8902 AC2).
+ * Deterministic unit test with a stubbed runtime; no live model.
+ */
 import type { Content, IAgentRuntime, UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { TaskSupervisorService } from "../services/task-supervisor-service.ts";

--- a/plugins/plugin-agent-orchestrator/src/__tests__/terminal-capabilities.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/terminal-capabilities.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies orchestrator terminal capability detection.
+ * Runs against a real temporary filesystem; deterministic.
+ */
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-agent-orchestrator/src/__tests__/workdir-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/workdir-routes.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies task-agent adapter defaults.
+ * Runs against a real temporary filesystem; deterministic.
+ */
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/plugins/plugin-agent-orchestrator/src/actions/common.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/common.ts
@@ -1,3 +1,10 @@
+/**
+ * Shared helpers for the TASKS sub-action runners: the ACP service accessor,
+ * message/parameter extraction, originating-request text resolution, session
+ * lookup and selection, spawn-slot gating, approval-preset parsing, and
+ * error/result formatting. Keeps the per-action runners in `tasks.ts` thin.
+ */
+
 import type {
   ActionResult,
   HandlerCallback,

--- a/plugins/plugin-agent-orchestrator/src/actions/elizaos-capability.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/elizaos-capability.ts
@@ -1,3 +1,11 @@
+/**
+ * Action that shells out to the elizaOS device capability runner
+ * (`/usr/local/lib/elizaos/capability-runner`, overridable via
+ * `ELIZAOS_CAPABILITY_RUNNER`) to report or toggle host state: capability
+ * status, privacy mode, root status, and opening persistent storage. Only
+ * meaningful on elizaOS-provisioned OS builds where that runner is installed.
+ */
+
 import { execFile } from "node:child_process";
 import { constants } from "node:fs";
 import { access } from "node:fs/promises";

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -3,8 +3,8 @@
  * task-agent lifecycle, workspace lifecycle, GitHub issue management, and
  * coding-task archive/reopen surface.
  *
- * Old leaf actions live as similes; their handlers were folded into per-action
- * runners on this file.
+ * Each sub-action is exposed as a simile of the parent and dispatched to a
+ * per-action runner in this file.
  *
  * Actions:
  *   create               — CREATE_AGENT_TASK / START_CODING_TASK
@@ -332,9 +332,9 @@ function connectorMessageIdFromMemory(
  * On the FIRST spawn it is the connector message id (Discord/connectors) or,
  * when none exists (dashboard/web), the user message id. SubAgentRouter stamps
  * this id back onto every synthetic re-spawn inbound as `spawnRootMessageId`,
- * so a request that re-spawns resolves the SAME id on EVERY transport — the
- * connector-less dashboard/web path previously produced no key at all, so the
- * cap silently never fired there. Kept as a pure exported fn so the record
+ * so a request that re-spawns resolves the SAME id on EVERY transport. The
+ * connector-less dashboard/web path falls back to the user message id, so the
+ * per-origin cap fires there too. Kept as a pure exported fn so the record
  * (SubAgentRouter) and enforce (this action) sides can be proven to agree.
  */
 export function spawnRootIdFor(
@@ -1072,9 +1072,9 @@ async function runSpawnAgent(
     // Backend routing (see resolveCodingBackend): an explicit user ask wins,
     // then declared `character.routing.coding` policy, then the operator pin
     // (ELIZA_ACP_DEFAULT_AGENT), then the planner's heuristic `agentType` guess.
-    // The pin no longer unconditionally overrides — declaring character routing
-    // or naming a backend now takes effect, while a bare planner guess still
-    // sits below the pin (it routinely guesses from context tokens).
+    // The pin does not unconditionally override: declared character routing or
+    // an explicitly named backend takes precedence over it, while a bare
+    // planner guess sits below the pin (it routinely guesses from context tokens).
     const routed = resolveCodingBackendLogged({
       runtime,
       explicit: pickString(params, content, "requestedBackend"),
@@ -2172,8 +2172,7 @@ async function runControl(
 
   // Archive / reopen / pause are durable task-lifecycle operations, not ACP
   // session controls — route them to the durable task service (see
-  // runTaskLifecycleControl). Previously this branch hard-failed with
-  // UNSUPPORTED_OPERATION even though the service supports all three.
+  // runTaskLifecycleControl), which supports all three.
   if (action === "archive" || action === "reopen" || action === "pause") {
     return runTaskLifecycleControl(runtime, params, content, callback, action);
   }

--- a/plugins/plugin-agent-orchestrator/src/api/route-utils.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/route-utils.ts
@@ -1,3 +1,10 @@
+/**
+ * Shared HTTP plumbing for the orchestrator route modules: the `RouteContext`
+ * bundle (runtime plus the ACP and workspace services), request-body parsing,
+ * typed value coercers for untrusted JSON fields, and the JSON / error /
+ * service-unavailable response senders.
+ */
+
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { IAgentRuntime } from "@elizaos/core";
 import type { AcpActionService } from "../actions/common.js";

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
@@ -1,3 +1,17 @@
+/**
+ * Response-handler evaluator that decides what the planner does with a verified
+ * sub-agent `task_complete` synthetic memory: relay the sub-agent's answer
+ * directly to the user, or step aside for a concrete planner follow-up.
+ *
+ * Most of this file is the heuristics that separate a real deliverable from
+ * router/tool-transcript noise — captured `[tool output: …]` envelopes, raw
+ * path/transcript leaks, loopback-vs-user-facing URLs, empty-completion
+ * placeholders, and failure markers reported without positive evidence. A short
+ * clean answer, or a degenerate (`length` / `content_filter`) completion, is
+ * relayed once instead of re-spawned; that is the guard against the weak-model
+ * re-spawn loop (elizaOS/eliza#8875). Its failure-side twin is
+ * `sub-agent-failure.ts`.
+ */
 import {
   type AgentContext,
   MESSAGE_SOURCE_SUB_AGENT,

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts
@@ -1,3 +1,13 @@
+/**
+ * Response-handler evaluator that fires when a coding sub-agent dies without
+ * delivering — a hard ACP error, an exhausted state-recovery budget, or a
+ * force-stopped ping-pong loop — as stamped onto a synthetic inbound memory by
+ * the SubAgentRouter. It synthesizes a planner-ready failure turn so the parent
+ * agent replies with the outcome instead of leaving the user staring at the
+ * spawn acknowledgement in silence. The success counterpart is the
+ * `task_complete` completion evaluator; this covers the terminal-failure events
+ * that otherwise had no response handler.
+ */
 import {
   MESSAGE_SOURCE_SUB_AGENT,
   type Memory,

--- a/plugins/plugin-agent-orchestrator/src/providers/action-examples.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/action-examples.ts
@@ -5,8 +5,6 @@
  * which doesn't include custom plugin actions. This provider bridges the gap
  * by formatting our task-agent action examples in the same compact plain-text
  * style the model sees for core actions.
- *
- * @module providers/action-examples
  */
 
 import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";

--- a/plugins/plugin-agent-orchestrator/src/providers/active-workspace-context.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-workspace-context.ts
@@ -5,8 +5,6 @@
  * their current status. This provider reads from the workspace service and ACP
  * service to build a live context summary that's always
  * available in the prompt.
- *
- * @module providers/active-workspace-context
  */
 
 import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";

--- a/plugins/plugin-agent-orchestrator/src/providers/available-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/available-agents.ts
@@ -1,3 +1,10 @@
+/**
+ * `AVAILABLE_AGENTS` provider: the adapter inventory (which ACP coding backends
+ * are installed and authenticated) plus a bounded list of recent/active
+ * sessions, rendered into the planner context. Merges the `checkAvailableAgents`
+ * inventory with framework state so shell-adapter backends like opencode — which
+ * the adapter registry misses — still appear when installed and auth-ready.
+ */
 import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";
 import {
   getAcpService,

--- a/plugins/plugin-agent-orchestrator/src/providers/coding-session-changes.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/coding-session-changes.ts
@@ -9,8 +9,6 @@
  * workspace-diff) and persisted on session.metadata.lastChangeSet. This
  * provider reads the freshest one within a recency window so a stale build
  * from days ago doesn't bleed into an unrelated conversation.
- *
- * @module providers/coding-session-changes
  */
 
 import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -1,3 +1,11 @@
+/**
+ * Native ACP client: speaks the Agent Client Protocol as JSON-RPC over a
+ * spawned agent subprocess's stdio — the default transport for `AcpService`
+ * (the alternative is the legacy `acpx` CLI wrapper). Owns the child-process
+ * lifecycle, the `initialize` / `session/new` / `session/prompt` handshake, MCP
+ * server forwarding so a sub-agent inherits the parent's tools, and permission
+ * prompts resolved against the session's approval preset.
+ */
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { lstat, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -1,3 +1,19 @@
+/**
+ * `AcpService` (serviceType `ACP_SUBPROCESS_SERVICE`) owns the lifecycle of
+ * coding-agent subprocesses driven over the Agent Client Protocol (ACP). It
+ * spawns a chosen backend CLI (elizaos, pi-agent, claude, codex, opencode),
+ * speaks ACP over the native transport, tracks per-session state and emits the
+ * session events the SubAgentRouter and task store consume, and cancels or tears
+ * sessions down on stop or process shutdown.
+ *
+ * Spawns are configured for the runtime environment: a per-spawn model-gateway
+ * lease routes the sub-agent's inference through the parent (revoked when the
+ * session ends), credential-proxy and model-gateway env is injected while
+ * denied environment keys are stripped, and Codex runs get sandbox/approval
+ * configuration with a Landlock-availability fallback. A single process-wide
+ * SIGTERM/SIGINT handler fans out to every live instance so multi-tenant hosts,
+ * test runners, and hot-reload cycles don't leak per-instance listeners.
+ */
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";

--- a/plugins/plugin-agent-orchestrator/src/services/audit.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/audit.ts
@@ -1,3 +1,9 @@
+/**
+ * Append-only NDJSON audit log for orchestrator spawn / send / stop / cancel
+ * decisions, emitted as `TASK_AUDIT` runtime events and persisted to disk. The
+ * log self-rotates once it crosses a byte cap so a long-lived runtime cannot
+ * grow it unbounded.
+ */
 import { appendFile, mkdir, rename, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";

--- a/plugins/plugin-agent-orchestrator/src/services/codex-sandbox.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/codex-sandbox.ts
@@ -1,3 +1,9 @@
+/**
+ * Codex ACP sandbox configuration: normalizes `sandbox_mode` / `approval_policy`
+ * overrides and probes Linux Landlock availability so the orchestrator can hand
+ * a spawned Codex agent a safe-but-workable filesystem sandbox, falling back to
+ * `danger-full-access` where Landlock is unavailable.
+ */
 import { existsSync, readFileSync } from "node:fs";
 import { platform } from "node:os";
 

--- a/plugins/plugin-agent-orchestrator/src/services/json-model-output.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/json-model-output.ts
@@ -1,3 +1,7 @@
+/**
+ * Extracts a single JSON object from a model's text reply, tolerating code
+ * fences and surrounding prose; returns null when no object parses.
+ */
 export function parseJsonObjectResponse<T = Record<string, unknown>>(
   raw: string,
 ): T | null {

--- a/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
@@ -1,3 +1,10 @@
+/**
+ * Builds the OpenCode-specific ACP spawn configuration and environment: the
+ * provider/model wiring (Eliza Cloud OpenAI-compatible endpoint or Cerebras),
+ * the vendored OpenCode shim path, and the read-only web-fetch/web-search
+ * permission grant a spawned sub-agent needs to reach the network under the
+ * non-interactive approval preset.
+ */
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -865,7 +865,7 @@ export class RuntimeDbTaskStore {
     const searchText = buildSearchText(doc);
     // Portable upsert. Postgres/pglite need ON CONFLICT DO UPDATE; sqlite
     // ≥3.24 accepts the same syntax. Named-column DO UPDATE avoids the
-    // sqlite-only INSERT OR REPLACE form we used to emit.
+    // sqlite-only INSERT OR REPLACE form.
     await this.exec().run(
       `INSERT INTO orchestrator_tasks
        (id, status, archived, priority, title, search_text, updated_at, last_activity_at, document)

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -1,3 +1,14 @@
+/**
+ * Broker that lets a spawned coding sub-agent ask the running parent Eliza
+ * agent to use its own loaded capabilities — actions, providers, connectors,
+ * the confirmation flow, and Eliza Cloud commands — via `USE_SKILL parent-agent`.
+ * Exposes the skill manifest entry and the request runner.
+ *
+ * Mutating, paid, or destructive Cloud commands require an explicit human "yes"
+ * on a follow-up turn; fixed-cost self-spend commands may auto-authorize within
+ * the configured spend cap (see spend-allowance.ts), while variable-cost ones
+ * always demand confirmation because a child-declared price cannot be trusted.
+ */
 import type {
   HandlerCallback,
   IAgentRuntime,

--- a/plugins/plugin-agent-orchestrator/src/services/session-event-queue.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/session-event-queue.ts
@@ -1,3 +1,8 @@
+/**
+ * Per-session FIFO queue that serializes `blocked` / `turn_complete` ACP events
+ * so a single session's handlers run one at a time in arrival order, while
+ * distinct sessions drain concurrently.
+ */
 import { logger } from "@elizaos/core";
 
 export interface QueuedEvent {

--- a/plugins/plugin-agent-orchestrator/src/services/session-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/session-store.ts
@@ -1,3 +1,13 @@
+/**
+ * Tiered persistence for ACP sub-agent session records. Three backends share
+ * one `SessionStore` contract and are selected in order: a runtime SQL adapter
+ * (`RuntimeDbSessionStore`) when the runtime exposes one, else a lock-guarded
+ * JSON file (`FileSessionStore`), else process memory (`InMemorySessionStore`).
+ *
+ * The file backend extends the in-memory one, adding a cross-process file lock
+ * and atomic rename-based writes; the DB backend tolerates both a raw SQL
+ * adapter shape and the drizzle-based `@elizaos/plugin-sql` adapter.
+ */
 import {
   mkdir,
   open,
@@ -799,7 +809,7 @@ export class RuntimeDbSessionStore implements SessionStore {
   private async upsert(session: SessionInfo): Promise<void> {
     // Portable upsert. Postgres/pglite need ON CONFLICT DO UPDATE; sqlite
     // ≥3.24 accepts the same syntax. Named-column DO UPDATE avoids the
-    // sqlite-only INSERT OR REPLACE form we used to emit.
+    // sqlite-only INSERT OR REPLACE form.
     await this.exec().run(
       `INSERT INTO acp_sessions (
         id, name, agent_type, workdir, status, acpx_record_id, acpx_session_id, agent_session_id,

--- a/plugins/plugin-agent-orchestrator/src/services/skill-lifeops-context-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/skill-lifeops-context-broker.ts
@@ -1,3 +1,9 @@
+/**
+ * Task-scoped bridge that runs LifeOps skill actions on behalf of a spawned
+ * sub-agent and rewrites their raw results into readable prose via a small
+ * model call. Exposes the `lifeops-context` skill manifest entry and its
+ * request runner — the LifeOps sibling of the general parent-agent broker.
+ */
 import type {
   Action,
   ActionParameters,

--- a/plugins/plugin-agent-orchestrator/src/services/smithers-task-runner.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/smithers-task-runner.ts
@@ -1,3 +1,14 @@
+/**
+ * Runs a durable multi-turn coding task by spawning a Bun subprocess that hosts
+ * the Smithers workflow engine, and bridging its provision/turn/approval/submit
+ * steps back to the parent over stdio. Each step the subprocess needs executed
+ * is sent as a `StepRequest`, dispatched to the in-process `TaskStepExecutor`,
+ * and answered with a `StepResponse`; turns are bounded by `DEFAULT_MAX_TURNS`.
+ *
+ * The run executes under Bun (Smithers imports `bun:sqlite`), and the task's
+ * storage backend — sqlite, postgres, or PGlite — is resolved from environment
+ * and threaded into the subprocess payload.
+ */
 import { spawn } from "node:child_process";
 import { mkdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";

--- a/plugins/plugin-agent-orchestrator/src/services/spawn-trajectory.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/spawn-trajectory.ts
@@ -1,3 +1,9 @@
+/**
+ * Links a spawned sub-agent's trajectory to the parent orchestrator step. Wraps
+ * `spawnWithTrajectoryLink` to stamp parent/child trajectory step ids onto
+ * session metadata and child-process env, so a sub-agent's recorded decisions
+ * attach to the parent turn that spawned it.
+ */
 import {
   type IAgentRuntime,
   type SpawnTrajectoryHandle,

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -1,3 +1,17 @@
+/**
+ * SubAgentRouter service: subscribes to `AcpService` session events and routes a
+ * sub-agent's terminal output back into the elizaOS runtime as synthetic inbound
+ * memories, so the planner reacts to sub-agent progress and completion as if it
+ * were a normal inbound message. Owns completion synthesis — diff capture,
+ * screenshot delivery, built-app registration, and SSRF-guarded URL
+ * verification — and the loop backstops that stop runaway ping-pong and respawn
+ * cascades (see router-loop-guard.ts).
+ *
+ * On a lost or crashed session it recovers inside the router (respawn,
+ * verify-retry, or account failover) and suppresses the dead session's
+ * narration, so one task yields one user-facing completion rather than one per
+ * lineage generation.
+ */
 import { createHash, randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
@@ -1,3 +1,8 @@
+/**
+ * Resolves how a spawn is routed: normalizes a caller's backend/adapter name to
+ * a known adapter type and picks the working directory for a new coding session
+ * from the configured workspace-root env keys and per-label routing rules.
+ */
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/plugins/plugin-agent-orchestrator/src/services/task-policy.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-policy.ts
@@ -1,3 +1,9 @@
+/**
+ * Role-based access control for the TASKS surface. `requireTaskAgentAccess`
+ * gates create/interact abilities per connector against the caller's role,
+ * reading operator-declared policy over a conservative default that only lets
+ * admins spawn or drive agents from third-party connectors.
+ */
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";

--- a/plugins/plugin-agent-orchestrator/src/services/terminal-capabilities.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/terminal-capabilities.ts
@@ -1,3 +1,10 @@
+/**
+ * Detects whether a runtime can host local coding-agent orchestration and which
+ * shell/CLI tools are reachable. `detectOrchestratorTerminalSupport` /
+ * `classifyTerminalSupport` are the single gate the plugin and the checked-in
+ * device support matrix both consult, so a change here moves both together
+ * (see orchestrator-device-support-matrix.ts, issue #9146).
+ */
 import { accessSync, constants } from "node:fs";
 import path from "node:path";
 

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -1,3 +1,8 @@
+/**
+ * Shared type vocabulary for the ACP session layer: agent/backend kinds,
+ * approval presets, session status and lifecycle events, spawn options, and the
+ * `SessionStore` contract the persistence tiers implement.
+ */
 export type AgentType =
   | "elizaos"
   | "pi-agent"

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
@@ -1,3 +1,11 @@
+/**
+ * Computes the real git changeset for a coding session's workspace: captures a
+ * baseline SHA and dirty state at spawn, then renders the bounded diff and
+ * changed-file list that back the `CODING_SESSION_CHANGES` provider's answers to
+ * "show me the diff" queries. Output is capped by file count and character
+ * budget, and an unborn HEAD (a fresh repo with zero commits) is diffed against
+ * the canonical empty-tree hash so the whole working tree reads as added.
+ */
 import { spawnSync } from "node:child_process";
 import {
   existsSync,

--- a/plugins/plugin-agent-orchestrator/src/test-utils/action-test-utils.ts
+++ b/plugins/plugin-agent-orchestrator/src/test-utils/action-test-utils.ts
@@ -1,3 +1,8 @@
+/**
+ * Test fixtures for the TASKS action suite.
+ * Builders for fake `SessionInfo` records and a stubbed ACP service/runtime so
+ * action handlers can be driven without spawning a real subprocess.
+ */
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { vi } from "vitest";
 import type { SessionInfo } from "../services/types.js";

--- a/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/device-modality-scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/device-modality-scenario.ts
@@ -1,3 +1,8 @@
+/**
+ * Scenario helper that builds device-support evidence from the checked-in
+ * orchestrator device-support matrix and asserts every unsupported device profile
+ * exposes only the sandbox stub action with the matrix's expected refusal reason.
+ */
 import {
   createTerminalUnsupportedTasksAction,
   tasksSandboxStubAction,

--- a/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/orchestrator-scenario-harness.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/orchestrator-scenario-harness.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared harness for the orchestrator scenario suite.
+ * Installs a plugin exposing synthetic orchestrator actions backed by a real
+ * AcpService and OrchestratorTaskService/store over a temp workspace, and
+ * registers the verifier/judge fixtures the deterministic and live scenarios share.
+ */
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-device-modality-reach.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-device-modality-reach.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Scenario-runner scenario asserting which device modalities can spawn a local
+ * coding agent versus receiving the sandbox stub, read from the device-support matrix.
+ */
 import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-evidence-bundle.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-evidence-bundle.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Scenario-runner scenario asserting a completed coding task emits the full
+ * completion evidence bundle (changeset, logs, verification verdict).
+ */
 import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-grilling-happy-path.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-grilling-happy-path.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Scenario-runner (pr-deterministic) twin of the live grilling scenario: a
+ * no-evidence 'done' is grilled, then verified once passing test output is pasted.
+ */
 import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-multi-task-supervisor.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-multi-task-supervisor.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Scenario-runner (pr-deterministic) scenario asserting the task supervisor's
+ * cross-task digest surfaces the state of several concurrent orchestrator tasks.
+ */
 import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-reflexion-respawn.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-reflexion-respawn.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Scenario-runner scenario asserting a failed verification re-spawns the task with
+ * the prior failure's reflection injected into the next sub-agent's goal prompt.
+ */
 import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-view-cloud-deploy.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-view-cloud-deploy.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Scenario-runner scenario asserting a view-plugin coding task surfaces the cloud
+ * deploy guidance and mock cloud-deploy result the planner needs.
+ */
 import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator.grilling-happy-path.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator.grilling-happy-path.scenario.ts
@@ -1,3 +1,10 @@
+/**
+ * Live-model scenario for the OrchestratorTaskService grilling loop (#8932): a
+ * sub-agent's evidence-free "done" is grilled and rejected, then verified once
+ * it re-reports with pasted passing test output. The verifier judgement runs
+ * against the scenario's live model, so this is the `live-only` lane; the same
+ * loop is asserted deterministically in `orchestrator-scenario-logic` for CI.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { runGrillingHappyPathCheck } from "./_helpers/grilling-scenario";

--- a/plugins/plugin-agent-orchestrator/vitest.config.ts
+++ b/plugins/plugin-agent-orchestrator/vitest.config.ts
@@ -1,3 +1,6 @@
+/**
+ * Vitest configuration for the orchestrator package: Node environment, shared setup file, and the unit + `src` test globs.
+ */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-agent-skills/src/__tests__/core-test-mock.ts
+++ b/plugins/plugin-agent-skills/src/__tests__/core-test-mock.ts
@@ -1,3 +1,9 @@
+/**
+ * Vitest setup file that stubs @elizaos/core with a deterministic in-memory
+ * double — no-op trajectory hooks, a byte-capped `captureSkillInvocationIO`,
+ * and a minimal Service base class — so unit tests run without the full runtime.
+ */
+
 import { vi } from "vitest";
 
 vi.mock("@elizaos/core", () => {

--- a/plugins/plugin-agent-skills/src/actions/use-skill.test.ts
+++ b/plugins/plugin-agent-skills/src/actions/use-skill.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the USE_SKILL action. Mocks only the @elizaos/core trajectory
+ * hooks; drives real script execution against temp SKILL dirs on disk, with the
+ * shell-shebang cases skipped on Windows.
+ */
+
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/plugins/plugin-agent-skills/src/actions/use-skill.ts
+++ b/plugins/plugin-agent-skills/src/actions/use-skill.ts
@@ -6,9 +6,8 @@
  * eligibility, dispatches to script execution or guidance retrieval, and
  * annotates the active trajectory step with the skill that ran.
  *
- * The older fragmented actions (RUN_SKILL_SCRIPT, GET_SKILL_GUIDANCE) have
- * been removed. RUN_SKILL and INVOKE_SKILL are listed as similes so callers
- * still emitting those legacy names continue to resolve to USE_SKILL.
+ * RUN_SKILL and INVOKE_SKILL are registered as similes so callers emitting
+ * those names resolve to USE_SKILL.
  */
 
 import { spawn } from "node:child_process";

--- a/plugins/plugin-agent-skills/src/actions/validators.ts
+++ b/plugins/plugin-agent-skills/src/actions/validators.ts
@@ -1,3 +1,8 @@
+/**
+ * Shared `validate` factory for the skill catalog actions — gates each action
+ * on the AGENT_SKILLS_SERVICE being registered on the runtime.
+ */
+
 import type { Action, IAgentRuntime } from "@elizaos/core";
 import type { AgentSkillsService } from "../services/skills";
 

--- a/plugins/plugin-agent-skills/src/agent-runtime-shim.ts
+++ b/plugins/plugin-agent-skills/src/agent-runtime-shim.ts
@@ -1,3 +1,12 @@
+/**
+ * Inert integration-telemetry span factory plus the default agent-workspace
+ * directory resolver, shimmed here so route/service code can depend on them
+ * without pulling @elizaos/agent into the bundle. The telemetry spans are
+ * no-ops; `resolveDefaultAgentWorkspaceDir` honours ELIZA_WORKSPACE_DIR /
+ * ELIZA_STATE_DIR / ELIZA_PROFILE and otherwise falls back to a
+ * project-marker check on the runtime cwd.
+ */
+
 import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-agent-skills/src/api/skill-discovery-helpers.ts
+++ b/plugins/plugin-agent-skills/src/api/skill-discovery-helpers.ts
@@ -1,9 +1,8 @@
 /**
  * Skill discovery and preference persistence helpers.
  *
- * Extracted from server.ts. Handles loading/saving skill preferences,
- * discovering skills from filesystem and AgentSkillsService, and
- * Binance skill exposure filtering.
+ * Handles loading/saving skill preferences, discovering skills from the
+ * filesystem and AgentSkillsService, and Binance skill exposure filtering.
  */
 
 import fs from "node:fs";

--- a/plugins/plugin-agent-skills/src/api/skills-routes.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.ts
@@ -1,3 +1,14 @@
+/**
+ * HTTP route handlers for the skill-management surface mounted under
+ * /api/skills/*: workspace/marketplace skill CRUD, catalog install/uninstall,
+ * security-scan acknowledgement, and enable/disable persistence. The agent's
+ * HTTP server dispatches to these via `handleSkillsRoutes`.
+ *
+ * Enable/disable state persists in the agent database under a cache key;
+ * workspace discovery resolves the agent workspace dir from ELIZA_WORKSPACE_DIR,
+ * persisted folder config, cwd project markers, then the state dir.
+ */
+
 import fs from "node:fs";
 import type http from "node:http";
 import os from "node:os";

--- a/plugins/plugin-agent-skills/src/binance/direct-dispatch.test.ts
+++ b/plugins/plugin-agent-skills/src/binance/direct-dispatch.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the Binance direct-skill dispatch fast path and its chat
+ * pre-handler wrapper; restores the real @elizaos/core module over the global
+ * test stub so ModelType and friends resolve.
+ */
+
 import type { Action, IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { runDirectBinanceSkillDispatch } from "./direct-dispatch";

--- a/plugins/plugin-agent-skills/src/index.ts
+++ b/plugins/plugin-agent-skills/src/index.ts
@@ -12,10 +12,8 @@
  */
 
 export { USE_SKILL_ACTION_NAME, useSkillAction } from "./actions/use-skill";
-// Consolidated skill code from packages/agent.
-// HTTP route handlers + supporting services moved from packages/agent/src/api/
-// and packages/agent/src/services/. The agent's server.ts now imports them
-// from this barrel instead of co-locating them with the runtime.
+// HTTP route handlers and their supporting services live under ./api and
+// ./services; the agent's server imports them from this barrel.
 export { handleCuratedSkillsRoutes } from "./api/curated-skills-routes";
 export {
 	discoverSkills,

--- a/plugins/plugin-agent-skills/src/providers/skills.test.ts
+++ b/plugins/plugin-agent-skills/src/providers/skills.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the skill summary, instructions, and catalog-awareness
+ * providers, driven against a hand-built runtime stub (no live model).
+ */
+
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import type { SkillCatalogEntry } from "../types";

--- a/plugins/plugin-agent-skills/src/security/skill-scanner.test.ts
+++ b/plugins/plugin-agent-skills/src/security/skill-scanner.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the JS/TS code scanner — asserts it flags code-execution and
+ * exfiltration patterns in skill source. Deterministic, no live model.
+ */
+
 import { describe, expect, it } from "vitest";
 import { scanSkillPackage } from ".";
 import { isScannableCode, scanCodeSource } from "./skill-scanner";

--- a/plugins/plugin-agent-skills/src/services/install.test.ts
+++ b/plugins/plugin-agent-skills/src/services/install.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for `installSkillDependency` command-injection safety — asserts
+ * malicious package names are rejected before reaching the package manager.
+ */
+
 import { describe, expect, it } from "vitest";
 import { installSkillDependency } from "./install";
 

--- a/plugins/plugin-agent-skills/src/services/skill-marketplace.ts
+++ b/plugins/plugin-agent-skills/src/services/skill-marketplace.ts
@@ -1,3 +1,12 @@
+/**
+ * Skill marketplace client: installs, uninstalls, lists, and searches skills
+ * sourced from the ClawHub registry via shallow, sparse git checkouts.
+ *
+ * Skill names and git refs are validated against strict allow-patterns and all
+ * git/dependency work runs through `execFile` (never a shell), keeping
+ * untrusted registry input from escaping into command execution.
+ */
+
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";

--- a/plugins/plugin-agent-skills/src/services/skills.contract.test.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.contract.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Contract test pinning AgentSkillsService.serviceType to the exported
+ * AGENT_SKILLS_SERVICE_TYPE constant so registration and lookup stay in sync.
+ */
+
 import { describe, expect, it } from "vitest";
 import { AGENT_SKILLS_SERVICE_TYPE, AgentSkillsService } from "./skills";
 

--- a/plugins/plugin-agent-skills/tsup.config.ts
+++ b/plugins/plugin-agent-skills/tsup.config.ts
@@ -1,3 +1,5 @@
+/** tsup build config: bundles the barrel entry to ESM, keeping runtime-provided @elizaos/* and node deps external. */
+
 import { defineConfig } from "tsup";
 
 export default defineConfig({

--- a/plugins/plugin-agent-skills/vitest.config.ts
+++ b/plugins/plugin-agent-skills/vitest.config.ts
@@ -1,3 +1,5 @@
+/** Vitest config: runs the plugin's test files under Node with the core-mock setup file. */
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-benchmarks/__tests__/plugin.test.ts
+++ b/plugins/plugin-benchmarks/__tests__/plugin.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Deterministic vitest suite over the assembled `benchmarksPlugin`: asserts the
+ * default/named export identity, the total action count (umbrellas plus
+ * promoted virtuals), and the expected umbrella names. No runtime or model.
+ */
 import { describe, expect, it } from "vitest";
 
 import benchmarksPlugin, {

--- a/plugins/plugin-benchmarks/build.ts
+++ b/plugins/plugin-benchmarks/build.ts
@@ -5,8 +5,7 @@
  *
  * The single `index.ts` entry is bundled for Node with an external sourcemap.
  * Declarations are emitted via tsconfig.build.json (tolerated on failure), and
- * the root `index.d.ts` alias is written as a hand-rolled re-export. The emitted
- * `dist/` is byte-identical to the previous hand-rolled build.
+ * the root `index.d.ts` alias is written as a hand-rolled re-export.
  */
 import { buildPlugin } from "../plugin-build";
 

--- a/plugins/plugin-benchmarks/index.ts
+++ b/plugins/plugin-benchmarks/index.ts
@@ -1,2 +1,3 @@
+/** Package entry re-exporting the benchmarks plugin and its action surface from src/index. */
 export * from "./src/index";
 export { default } from "./src/index";

--- a/plugins/plugin-benchmarks/src/actions/osworld.ts
+++ b/plugins/plugin-benchmarks/src/actions/osworld.ts
@@ -1,3 +1,12 @@
+/**
+ * The OSWORLD umbrella action mirroring the OSWorld desktop-control benchmark's
+ * GUI operation vocabulary (click, double_click, right_click, type, key,
+ * scroll, drag, screenshot, wait, done, fail). Each operation is captured as a
+ * typed subaction so fine-tuning traces carry stable `OSWORLD_<op>` names after
+ * promotion via `promoteSubactionsToActions` in src/index.ts. The handler is a
+ * vocabulary shim: it validates and echoes structured parameters rather than
+ * driving a real desktop.
+ */
 import type {
   Action,
   ActionResult,

--- a/plugins/plugin-benchmarks/src/actions/tau-bench.ts
+++ b/plugins/plugin-benchmarks/src/actions/tau-bench.ts
@@ -1,3 +1,10 @@
+/**
+ * The TAU_BENCH_TOOL umbrella action mirroring the tau-bench retail/airline
+ * tool-calling benchmark. Its `tool_name` is free-text rather than a fixed
+ * enum, so no per-tool virtual subactions are promoted — a single umbrella
+ * action carries the tool name plus its arguments. The handler validates and
+ * echoes the structured call rather than executing a real tool.
+ */
 import type {
   Action,
   ActionResult,

--- a/plugins/plugin-benchmarks/src/actions/vending-machine.ts
+++ b/plugins/plugin-benchmarks/src/actions/vending-machine.ts
@@ -1,3 +1,12 @@
+/**
+ * The VENDING_MACHINE umbrella action mirroring the vending-bench benchmark's
+ * operating vocabulary (view_state, view_suppliers, place_order, restock_slot,
+ * set_price, collect_cash, update_notes, check_deliveries, advance_day). Each
+ * operation is captured as a typed subaction promoted to a stable
+ * `VENDING_MACHINE_<op>` virtual via `promoteSubactionsToActions` in
+ * src/index.ts. The handler is a vocabulary shim that validates and echoes
+ * structured parameters rather than running a real vending simulation.
+ */
 import type {
   Action,
   ActionResult,

--- a/plugins/plugin-benchmarks/src/actions/visualwebbench.ts
+++ b/plugins/plugin-benchmarks/src/actions/visualwebbench.ts
@@ -1,3 +1,12 @@
+/**
+ * The VISUALWEBBENCH_TASK umbrella action mirroring the VisualWebBench vision
+ * task vocabulary (web_caption, webqa, heading_ocr, element_ocr, element_ground,
+ * action_prediction, action_ground). Each task type is captured as a typed
+ * subaction promoted to a stable `VISUALWEBBENCH_TASK_<task>` virtual via
+ * `promoteSubactionsToActions` in src/index.ts. The handler is a vocabulary
+ * shim that validates and echoes structured parameters rather than performing
+ * real vision inference.
+ */
 import type {
   Action,
   ActionResult,

--- a/plugins/plugin-benchmarks/src/actions/webshop.ts
+++ b/plugins/plugin-benchmarks/src/actions/webshop.ts
@@ -1,3 +1,11 @@
+/**
+ * The WEBSHOP umbrella action mirroring the WebShop benchmark's navigation
+ * vocabulary (search, click, select_option, back, buy). Each operation is
+ * captured as a typed subaction promoted to a stable `WEBSHOP_<op>` virtual via
+ * `promoteSubactionsToActions` in src/index.ts. The handler is a vocabulary
+ * shim that validates and echoes structured parameters rather than driving a
+ * real storefront.
+ */
 import type {
   Action,
   ActionResult,

--- a/plugins/plugin-benchmarks/vitest.config.ts
+++ b/plugins/plugin-benchmarks/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for this package: Node environment, globals on, test files under __tests__. */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-cli/__tests__/core-test-mock.ts
+++ b/plugins/plugin-cli/__tests__/core-test-mock.ts
@@ -1,3 +1,8 @@
+/**
+ * Vitest setup file that stubs the @elizaos/core logger so registry and plugin
+ * suites can assert on log calls without pulling in the full core module.
+ */
+
 import { vi } from "vitest";
 
 vi.mock("@elizaos/core", () => ({

--- a/plugins/plugin-cli/src/index.test.ts
+++ b/plugins/plugin-cli/src/index.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises the plugin's public program surface — buildProgram, runCli, and
+ * command registration through the Commander root. Deterministic: commands and
+ * runtime are stubbed with vitest, no live model or process spawning.
+ */
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	buildProgram,

--- a/plugins/plugin-cli/src/registry.test.ts
+++ b/plugins/plugin-cli/src/registry.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers the module-level command registry: register/unregister/lookup,
+ * priority-sorted listing, duplicate-name replacement, and bulk registration
+ * against a real Commander instance. Deterministic; the core logger is mocked.
+ */
+
 import { logger } from "@elizaos/core";
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-cli/src/utils.test.ts
+++ b/plugins/plugin-cli/src/utils.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests the CLI utility helpers — duration/timeout parsing, byte and duration
+ * formatting, command formatting, CLI-name resolution, and the progress
+ * wrapper. Deterministic, with fast-check property tests over the parsers.
+ */
+
 import fc from "fast-check";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-cli/vitest.config.ts
+++ b/plugins/plugin-cli/vitest.config.ts
@@ -1,3 +1,9 @@
+/**
+ * Vitest configuration for the CLI plugin: node environment, serial execution
+ * (single worker, no file parallelism) so the module-level command registry
+ * stays isolated between suites, with the core logger mock loaded as a setup file.
+ */
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-codex-cli/__tests__/codex-backend.test.ts
+++ b/plugins/plugin-codex-cli/__tests__/codex-backend.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit coverage for the Codex provider: plugin model metadata, JWT expiry, the
+ * SSE parser, tool-schema translation, and CodexBackend request/stream handling
+ * driven by a fake fetch (no live model or network).
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import { __INTERNAL_buildCodexGenerateParams, codexCliPlugin } from "../index";
 import {

--- a/plugins/plugin-codex-cli/build.ts
+++ b/plugins/plugin-codex-cli/build.ts
@@ -2,8 +2,7 @@
 /**
  * Build script for @elizaos/plugin-codex-cli (Node + Browser).
  * Orchestration lives in the shared driver (plugins/plugin-build.ts); this lists
- * only what differs. The emitted `dist/` is byte-identical to the previous
- * hand-rolled build.
+ * only what differs.
  */
 import { buildPlugin } from "../plugin-build";
 

--- a/plugins/plugin-codex-cli/index.browser.ts
+++ b/plugins/plugin-codex-cli/index.browser.ts
@@ -1,3 +1,8 @@
+/**
+ * Browser build stub for the node-only Codex provider. Its model handlers throw
+ * because authentication reads ~/.codex/auth.json; the working implementation
+ * lives in index.ts and is only reachable in a node runtime.
+ */
 import type { Plugin } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 

--- a/plugins/plugin-codex-cli/index.node.ts
+++ b/plugins/plugin-codex-cli/index.node.ts
@@ -1,3 +1,4 @@
+/** Node build entry: re-exports the plugin from index.ts as the node bundle's default. */
 import pluginDefault from "./index";
 
 export * from "./index";

--- a/plugins/plugin-codex-cli/index.ts
+++ b/plugins/plugin-codex-cli/index.ts
@@ -1,3 +1,15 @@
+/**
+ * Plugin entry for the ChatGPT Codex model provider: registers the TEXT_*,
+ * RESPONSE_HANDLER, and ACTION_PLANNER model handlers that route generation
+ * through a user's ChatGPT subscription via the codex CLI OAuth cache. Every
+ * handler delegates to a single per-runtime CodexBackend (held in a WeakMap so
+ * calls on one runtime serialize through the backend's FIFO queue).
+ *
+ * Auto-enables only when an auth profile selects provider "codex-cli"; there is
+ * no env-key trigger. Tool- or message-bearing calls return native tool calls
+ * rather than a plain string, and streaming calls attach toolCalls so the
+ * planner still sees tool-only responses.
+ */
 import type { GenerateTextParams, IAgentRuntime, Plugin, TextStreamResult } from "@elizaos/core";
 import { logger, ModelType } from "@elizaos/core";
 import {

--- a/plugins/plugin-codex-cli/src/codex-backend.ts
+++ b/plugins/plugin-codex-cli/src/codex-backend.ts
@@ -1,3 +1,15 @@
+/**
+ * HTTP client for the ChatGPT Codex `/responses` SSE endpoint, plus the
+ * provider-neutral message/tool translation it needs. CodexBackend loads the
+ * codex CLI OAuth token, posts a Responses-API request, and consumes the event
+ * stream into text, native tool calls, finish reason, and token usage.
+ *
+ * Calls on one instance serialize through a FIFO tail promise with optional
+ * pre-request jitter. A 401 triggers exactly one OAuth refresh-and-retry. The
+ * base URL is restricted to chatgpt.com or localhost to prevent token
+ * exfiltration, and temperature/max_output_tokens are never sent because the
+ * gpt-5.x reasoning models reject them with a 400.
+ */
 import { logger, type ChatMessage, type JsonValue, type ToolCall, type ToolDefinition } from "@elizaos/core";
 import { parseSSE } from "./sse-parser";
 import { toOpenAITool, type OpenAITool } from "./tool-format-openai";

--- a/plugins/plugin-codex-cli/src/tool-format-openai.ts
+++ b/plugins/plugin-codex-cli/src/tool-format-openai.ts
@@ -1,3 +1,8 @@
+/**
+ * Maps elizaOS ToolDefinition objects to the OpenAI Responses function-tool
+ * shape. Strict tools are normalized to satisfy the codex backend's schema
+ * rules (see makeStrictSchema below); loose tools pass through verbatim.
+ */
 import type { ToolDefinition } from "@elizaos/core";
 
 export interface OpenAITool {

--- a/plugins/plugin-codex-cli/vitest.config.ts
+++ b/plugins/plugin-codex-cli/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config: aliases @elizaos/core to its built node dist and skips the live/real-model suites. */
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 

--- a/plugins/plugin-computeruse/scripts/capture-macos-desktop-evidence.mjs
+++ b/plugins/plugin-computeruse/scripts/capture-macos-desktop-evidence.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env bun
+/**
+ * Captures real macOS desktop-control evidence — probes platform capabilities,
+ * screenshot capture, clipboard, and browser availability against a live headful
+ * session, then writes a structured evidence manifest. Accessibility/TCC blockers
+ * are classified as requires-device-evidence rather than failures. Produces the
+ * macOS validation artifacts consumed by validate-platform-evidence.
+ */
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";

--- a/plugins/plugin-computeruse/scripts/capture-windows-desktop-evidence.mjs
+++ b/plugins/plugin-computeruse/scripts/capture-windows-desktop-evidence.mjs
@@ -1,4 +1,10 @@
 #!/usr/bin/env bun
+/**
+ * Captures real Windows desktop-control evidence in validator-contract order —
+ * capability probe, screenshot capture, clipboard, input, and window ops against
+ * a live session — and emits the structured manifest consumed by
+ * validate-platform-evidence. Check ids mirror docs/windows-desktop-validation.json.
+ */
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";

--- a/plugins/plugin-computeruse/scripts/validate-ios-device-evidence.mjs
+++ b/plugins/plugin-computeruse/scripts/validate-ios-device-evidence.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+/**
+ * Validates an iOS device-evidence manifest against the required check-id
+ * contract (ReplayKit foreground start, broadcast-extension handshake, Vision
+ * OCR, app-intent invocations, Foundation-model generation, memory-pressure
+ * probe). Fails when a required check is missing or carries a status outside
+ * the allowed set.
+ */
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-computeruse/scripts/validate-platform-evidence.mjs
+++ b/plugins/plugin-computeruse/scripts/validate-platform-evidence.mjs
@@ -1,4 +1,10 @@
 #!/usr/bin/env node
+/**
+ * Validates a desktop/mobile platform evidence manifest against its per-platform
+ * contract (required target keys and complete-evidence keys), enforcing that
+ * every check reports an allowed status and that passed platforms carry the
+ * device metadata the contract demands.
+ */
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-computeruse/src/__tests__/browser-auto-open.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/browser-auto-open.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Auto-open browser behavior of the computer-use flow, driven against a mocked
+ * platform/browser module (deterministic, no real CDP).
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-computeruse/src/__tests__/browser-execute-security.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/browser-execute-security.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Guards that executeBrowser refuses arbitrary agent-supplied script and never
+ * opens a page (GHSA-rcvr-766c-4phv). Deterministic unit test.
+ */
 import { describe, expect, it } from "vitest";
 import { executeBrowser } from "../platform/browser.js";
 import { BrowserExecuteDisabledError } from "../security/browser-script-policy.js";

--- a/plugins/plugin-computeruse/src/__tests__/browser-script-policy.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/browser-script-policy.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Pins the browser-script policy: arbitrary page.evaluate is never allowed.
+ * Deterministic unit test over the policy predicate.
+ */
 import { describe, expect, it } from "vitest";
 import {
   assertBrowserExecuteAllowed,

--- a/plugins/plugin-computeruse/src/__tests__/computer-interface.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/computer-interface.test.ts
@@ -249,7 +249,7 @@ describe("DefaultComputerInterface — driver delegation", () => {
         ],
       ],
     ]);
-    // The old start→end collapse no longer fires.
+    // A multi-point path does not collapse into a single start→end driver.drag.
     expect(calls.drag).toHaveLength(0);
   });
 

--- a/plugins/plugin-computeruse/src/__tests__/computer-use-approval-relay.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/computer-use-approval-relay.test.ts
@@ -1,3 +1,7 @@
+/**
+ * COMPUTER_USE action's approval-relay wiring — pending-approval snapshots reach
+ * the message callback. Deterministic; no real desktop.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { useComputerAction } from "../actions/use-computer.js";
 import type { ApprovalSnapshot } from "../types.js";

--- a/plugins/plugin-computeruse/src/__tests__/computeruse.real.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/computeruse.real.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Real computer-use lane: drives useComputerAction/windowAction through a live
+ * ComputerUseService and the real platform driver, asserting non-blank
+ * screenshots. Skips where no headful display is available.
+ */
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-computeruse/src/__tests__/macos-desktop-evidence-capture.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/macos-desktop-evidence-capture.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Classifier that maps macOS Accessibility/TCC blocker messages to
+ * requires-device-evidence in the capture harness. Deterministic unit test.
+ */
 import { describe, expect, it } from "vitest";
 import { isMacosAccessibilityEvidenceBlocker } from "../../scripts/capture-macos-desktop-evidence.mjs";
 

--- a/plugins/plugin-computeruse/src/__tests__/osworld-action-converter.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/osworld-action-converter.test.ts
@@ -1,3 +1,7 @@
+/**
+ * OSWorld action conversion + adapter, with the screenshot platform mocked.
+ * Deterministic unit test of the OSWorld to ComputerInterface translation.
+ */
 import { describe, expect, it, vi } from "vitest";
 import {
   fromOSWorldAction,

--- a/plugins/plugin-computeruse/src/__tests__/platform-capabilities.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/platform-capabilities.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Desktop platform-capability detection and the parity matrix it exposes.
+ * Deterministic unit test across simulated host OSes.
+ */
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-computeruse/src/__tests__/platform-evidence-validator.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/platform-evidence-validator.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Exercises the validate-platform-evidence CLI over temp manifests via spawnSync,
+ * asserting accept/reject on the platform-contract rules.
+ */
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -204,7 +208,7 @@ describe("platform evidence validator", () => {
     );
     // windows-desktop is intentionally NOT asserted here: it is fully
     // device-verified (#9581, 9/9 passed) and its release manifest is promoted to
-    // `passed`, so it no longer trips the complete gate. The gate still fails
+    // `passed`, so it does not trip the complete gate. The gate still fails
     // overall on iOS/Android/macOS/Linux below.
     expect(result.stderr).toContain(
       "--require-complete: check mediaProjectionCapture is requires_device_evidence",

--- a/plugins/plugin-computeruse/src/__tests__/runtime.live.e2e.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/runtime.live.e2e.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Live end-to-end: spawns a real runtime child process with the plugin loaded and
+ * drives it over HTTP. Real process + real routes, no mocks.
+ */
 import { spawn } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import net from "node:net";

--- a/plugins/plugin-computeruse/src/__tests__/security-file-target.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/security-file-target.test.ts
@@ -1,3 +1,7 @@
+/**
+ * resolveSafeFileTarget path-security checks against real temp directories and
+ * symlinks. Deterministic; exercises the real fs.
+ */
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-computeruse/src/__tests__/trajectory.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/trajectory.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Trajectory recording for the computer-use agent loop, with the screenshot and
+ * a11y platform modules mocked. Deterministic unit test.
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../platform/screenshot.js", () => ({

--- a/plugins/plugin-computeruse/src/__tests__/use-computer-action.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/use-computer-action.test.ts
@@ -1,3 +1,7 @@
+/**
+ * COMPUTER_USE action handler over a mocked ComputerUseService: param resolution,
+ * approval snapshots, and result shaping. Deterministic.
+ */
 import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { useComputerAction } from "../actions/use-computer.js";

--- a/plugins/plugin-computeruse/src/__tests__/vision-context-provider.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/vision-context-provider.test.ts
@@ -1,3 +1,7 @@
+/**
+ * VisionContextProvider snapshot + task-goal cache, with the process-list and
+ * window-list platform modules mocked. Deterministic unit test.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import type { Scene } from "../scene/scene-types.js";

--- a/plugins/plugin-computeruse/src/__tests__/windows-timeouts.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/windows-timeouts.test.ts
@@ -1,3 +1,7 @@
+/**
+ * psSpawnTimeoutMs env-override and floor behavior for Windows PowerShell spawns.
+ * Deterministic unit test.
+ */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   PS_SPAWN_TIMEOUT_ENV,

--- a/plugins/plugin-computeruse/src/actions/helpers.ts
+++ b/plugins/plugin-computeruse/src/actions/helpers.ts
@@ -1,3 +1,7 @@
+/**
+ * Shared helpers for the computer-use actions: normalizes handler parameters,
+ * shapes native results into ActionResult, and builds screenshot attachments.
+ */
 import type { ActionResult, HandlerOptions, Memory } from "@elizaos/core";
 
 export interface NativeComputerUseResult {

--- a/plugins/plugin-computeruse/src/actions/progress.ts
+++ b/plugins/plugin-computeruse/src/actions/progress.ts
@@ -1,3 +1,8 @@
+/**
+ * Per-step progress and approval-relay plumbing for computer-use actions. Wraps a
+ * handler so each dispatched sub-action emits structured progress content and
+ * pending-approval snapshots to the message callback.
+ */
 import {
   type Content,
   type HandlerCallback,

--- a/plugins/plugin-computeruse/src/actions/use-computer.ts
+++ b/plugins/plugin-computeruse/src/actions/use-computer.ts
@@ -1,3 +1,10 @@
+/**
+ * COMPUTER_USE parent action — the umbrella desktop verb (screenshot, click, type,
+ * key, scroll, drag, open, launch, …). Resolves params, enforces the OWNER role
+ * and approval gate, dispatches through ComputerUseService, and returns a
+ * screenshot-bearing result. Subactions are promoted to virtual top-level actions
+ * (COMPUTER_USE_CLICK, …) at registration.
+ */
 import type {
   Action,
   ActionResult,

--- a/plugins/plugin-computeruse/src/approval-manager.ts
+++ b/plugins/plugin-computeruse/src/approval-manager.ts
@@ -1,3 +1,11 @@
+/**
+ * ComputerUseApprovalManager — queues pending desktop actions and gates them by
+ * the active approval mode (full_control / smart_approve / approve_all / off),
+ * auto-allowing read-only safe commands and persisting the mode to disk.
+ *
+ * The approval mode read back from disk or the API is untrusted input; isApprovalMode
+ * validates it before it can relax the safety gate.
+ */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-computeruse/src/mobile/ocr-provider.test.ts
+++ b/plugins/plugin-computeruse/src/mobile/ocr-provider.test.ts
@@ -1,3 +1,7 @@
+/**
+ * OCR-provider registry (register/select/list/unregister) and the iOS Vision
+ * provider factory. Deterministic unit test over the provider seam.
+ */
 import { beforeEach, describe, expect, it } from "vitest";
 import type { IosComputerUseBridge } from "./ios-bridge.js";
 import {

--- a/plugins/plugin-computeruse/src/osworld/action-converter.test.ts
+++ b/plugins/plugin-computeruse/src/osworld/action-converter.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Round-trips OSWorld / PyAutoGUI actions through the converter to and from
+ * DesktopActionParams. Deterministic unit test.
+ */
 import { describe, expect, it } from "vitest";
 import type { DesktopActionParams } from "../types.js";
 import {

--- a/plugins/plugin-computeruse/src/platform/capabilities.ts
+++ b/plugins/plugin-computeruse/src/platform/capabilities.ts
@@ -1,3 +1,8 @@
+/**
+ * Desktop platform-capability detection — resolves which computer-use surfaces
+ * (screenshot, input, window control, browser, clipboard) are available on the
+ * host OS and their parity classification. iOS/Android live in mobile/, not here.
+ */
 import type { PlatformCapabilities } from "../types.js";
 import type { PlatformOS } from "./helpers.js";
 

--- a/plugins/plugin-computeruse/src/platform/file-ops.ts
+++ b/plugins/plugin-computeruse/src/platform/file-ops.ts
@@ -1,3 +1,8 @@
+/**
+ * Internal file primitives (read/write/list) behind path-security checks. Not
+ * exposed as an agent action — the FILE action owns user-facing file access;
+ * these back internal computer-use flows only.
+ */
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { FileActionResult, FileEntry } from "../types.js";

--- a/plugins/plugin-computeruse/src/platform/normalized-coords.test.ts
+++ b/plugins/plugin-computeruse/src/platform/normalized-coords.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Normalized 0-1000 coordinate-space conversions (point + box, clamp, center) for
+ * Computer Use x Vision. Deterministic unit test.
+ */
 import { describe, expect, it } from "vitest";
 import {
   boxFromNormalized,

--- a/plugins/plugin-computeruse/src/platform/permissions.ts
+++ b/plugins/plugin-computeruse/src/platform/permissions.ts
@@ -1,3 +1,8 @@
+/**
+ * Classifies OS permission-denied failures (Screen Recording, Accessibility, Input
+ * Monitoring) into a typed PermissionDeniedError so callers can surface the exact
+ * grant the user must enable rather than a generic failure.
+ */
 import { execFileSync } from "node:child_process";
 import type { PermissionType } from "../types.js";
 

--- a/plugins/plugin-computeruse/src/platform/screenshot-quality.ts
+++ b/plugins/plugin-computeruse/src/platform/screenshot-quality.ts
@@ -1,3 +1,8 @@
+/**
+ * Pure PNG screenshot-quality classifier: decodes width/height and samples pixel
+ * color distribution to detect blank or single-color captures. Gates the
+ * real-driver screenshot lanes without needing a live display.
+ */
 import { inflateSync } from "node:zlib";
 
 type PngColorType = 0 | 2 | 6;

--- a/plugins/plugin-computeruse/src/platform/security.ts
+++ b/plugins/plugin-computeruse/src/platform/security.ts
@@ -1,3 +1,8 @@
+/**
+ * Path and command security checks for computer-use: validates file targets
+ * against allowed roots (resolving symlinks), flags dangerous shell commands, and
+ * sanitizes the child-process environment before any spawn.
+ */
 import fs from "node:fs";
 import { lstat, realpath } from "node:fs/promises";
 import os from "node:os";

--- a/plugins/plugin-computeruse/src/platform/terminal.ts
+++ b/plugins/plugin-computeruse/src/platform/terminal.ts
@@ -1,3 +1,8 @@
+/**
+ * Internal terminal-session management (spawn shell, run command, buffer output)
+ * behind the dangerous-command guard. Not exposed as an agent action — the SHELL
+ * action owns user-facing terminal access.
+ */
 import { execFile } from "node:child_process";
 import os from "node:os";
 import type { TerminalActionResult } from "../types.js";

--- a/plugins/plugin-computeruse/src/platform/wayland-portal.test.ts
+++ b/plugins/plugin-computeruse/src/platform/wayland-portal.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Wayland screenshot-portal helpers: session detection and parsing of portal
+ * request handles and screenshot responses. Deterministic unit test.
+ */
 import { describe, expect, it } from "vitest";
 import {
   isWaylandSession,

--- a/plugins/plugin-computeruse/src/platform/wayland-portal.ts
+++ b/plugins/plugin-computeruse/src/platform/wayland-portal.ts
@@ -1,3 +1,9 @@
+/**
+ * xdg-desktop-portal screenshot sidecar for Wayland sessions, where direct
+ * framebuffer capture is blocked. Drives the org.freedesktop.portal.Screenshot
+ * D-Bus method via an embedded Python helper and returns the captured file,
+ * raising a typed permission error when the portal denies the request.
+ */
 import { execFileSync } from "node:child_process";
 import { copyFileSync } from "node:fs";
 import { commandExists } from "./helpers.js";

--- a/plugins/plugin-computeruse/src/register-routes.ts
+++ b/plugins/plugin-computeruse/src/register-routes.ts
@@ -1,3 +1,7 @@
+/**
+ * Registers the plugin's HTTP routes with app-core's lazy route loader, importing
+ * the plugin only when a computer-use route is first hit.
+ */
 import { registerAppRoutePluginLoader } from "@elizaos/core";
 
 registerAppRoutePluginLoader("@elizaos/plugin-computeruse", async () => {

--- a/plugins/plugin-computeruse/src/routes/computer-use-routes.ts
+++ b/plugins/plugin-computeruse/src/routes/computer-use-routes.ts
@@ -1,3 +1,9 @@
+/**
+ * Full HTTP route table for computer-use: approval listing, the SSE approval
+ * stream, approval-mode changes, and approve/deny of pending actions. Node http
+ * handlers; the compat wrapper in computer-use-compat-routes wires these into the
+ * plugin entry.
+ */
 import type http from "node:http";
 
 const EMPTY_APPROVAL_SNAPSHOT = {

--- a/plugins/plugin-computeruse/src/services/computer-use-service.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-service.ts
@@ -1,3 +1,13 @@
+/**
+ * ComputerUseService (serviceType "computeruse") — the plugin's central service.
+ * Owns input dispatch, screenshot capture, the browser CDP session, window
+ * operations, approval-manager wiring, and the SceneBuilder lifecycle, exposing
+ * them to the actions and providers.
+ *
+ * This is the single seam between the agent-facing action surface and the platform
+ * drivers: it resolves the active driver, enforces the approval gate before
+ * executing input, and caches per-turn scene state.
+ */
 import os from "node:os";
 import path from "node:path";
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";

--- a/plugins/plugin-computeruse/src/services/desktop-control.ts
+++ b/plugins/plugin-computeruse/src/services/desktop-control.ts
@@ -1,3 +1,8 @@
+/**
+ * Low-level desktop-control primitives (screenshot, pointer, key input) plus
+ * capability detection shared by the service and the sandbox backends. Detects
+ * whether a headful GUI is reachable and degrades without throwing.
+ */
 import { execFileSync } from "node:child_process";
 import { readFileSync, unlinkSync } from "node:fs";
 import { platform, tmpdir } from "node:os";

--- a/plugins/plugin-computeruse/src/services/vision-context-provider.ts
+++ b/plugins/plugin-computeruse/src/services/vision-context-provider.ts
@@ -1,3 +1,8 @@
+/**
+ * VisionContextProvider (serviceType "vision-context") — surfaces a VisionContext
+ * snapshot (open apps, focused window, recent actions, current task goal) for
+ * downstream consumers such as plugin-vision.
+ */
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
 import { listProcesses } from "../platform/process-list.js";
 import { listWindows } from "../platform/windows-list.js";

--- a/plugins/plugin-computeruse/test/helpers/screenshot-quality.test.ts
+++ b/plugins/plugin-computeruse/test/helpers/screenshot-quality.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Screenshot-quality helper: analyzePngScreenshot + assertScreenshotBase64NotBlank
+ * over deflate-built PNGs. Deterministic unit test.
+ */
 import { deflateSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-computeruse/test/helpers/screenshot-quality.ts
+++ b/plugins/plugin-computeruse/test/helpers/screenshot-quality.ts
@@ -1,3 +1,8 @@
+/**
+ * Test helper re-exporting the screenshot-quality classifier plus
+ * assertScreenshotBase64NotBlank, so real-driver screenshot lanes can assert a
+ * capture is not blank.
+ */
 import { expect } from "vitest";
 
 export {

--- a/plugins/plugin-computeruse/vitest.config.ts
+++ b/plugins/plugin-computeruse/vitest.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Vitest configuration for plugin-computeruse: aliases core/logger to source and
+ * excludes the live/real/e2e lanes from the default run.
+ */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";

--- a/plugins/plugin-gitpathologist/__tests__/action.test.ts
+++ b/plugins/plugin-gitpathologist/__tests__/action.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers gitPathologyAction.validate: it claims code-history prompts and
+ * explicit surface/action params but declines generic "when did" questions.
+ * Uses a stub runtime object; no real service, git, or model.
+ */
+
 import { describe, expect, it } from "vitest";
 import { gitPathologyAction } from "../src/actions/git-pathology.ts";
 

--- a/plugins/plugin-gitpathologist/__tests__/cache.test.ts
+++ b/plugins/plugin-gitpathologist/__tests__/cache.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises the on-disk report cache and makeCacheKey against a real temp
+ * directory: round-trip read/write, atomic-write cleanup, malformed-file
+ * tolerance, newest-first listing, and HEAD-sha freshness.
+ */
+
 import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-gitpathologist/__tests__/classify.test.ts
+++ b/plugins/plugin-gitpathologist/__tests__/classify.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers the rule-based commit classifier: conventional-prefix mapping,
+ * WIP/revert/merge detection, and risk flags (large-churn, wide-blast,
+ * breaking). Pure functions, no git or model.
+ */
+
 import { describe, expect, it } from "vitest";
 import { classify, classifyOne } from "../src/pipeline/classify.ts";
 import type { RawCommit } from "../src/types.ts";

--- a/plugins/plugin-gitpathologist/__tests__/inflect.test.ts
+++ b/plugins/plugin-gitpathologist/__tests__/inflect.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers peak and drift detection in findInflections over hand-built health
+ * timelines: peak selection with a minimum threshold and sustained-drop drift
+ * onset. Pure, deterministic.
+ */
+
 import { describe, expect, it } from "vitest";
 import { findInflections } from "../src/pipeline/inflect.ts";
 import type { CommitHealthPoint } from "../src/types.ts";

--- a/plugins/plugin-gitpathologist/__tests__/narrate.test.ts
+++ b/plugins/plugin-gitpathologist/__tests__/narrate.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers the narrate phase: deterministic rot-cause fallback when no model is
+ * present, and budget-capped model narration that falls back for drifts beyond
+ * budget. The model is a vi.fn stub, not a live LLM.
+ */
+
 import { describe, expect, it, vi } from "vitest";
 import { narrate } from "../src/pipeline/narrate.ts";
 import type { CommitHealthPoint, InflectionPoint } from "../src/types.ts";

--- a/plugins/plugin-gitpathologist/__tests__/scan.test.ts
+++ b/plugins/plugin-gitpathologist/__tests__/scan.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers normalizeSince window translation and scan against a real toy git
+ * repository (built with the git binary): commit ordering, file-touch line
+ * counts, parents, headSha, and the empty-surface case.
+ */
+
 import { rmSync } from "node:fs";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { headSha, normalizeSince, scan } from "../src/pipeline/scan.ts";

--- a/plugins/plugin-gitpathologist/__tests__/score.test.ts
+++ b/plugins/plugin-gitpathologist/__tests__/score.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers the deterministic EMA scorer: clean features outscore WIP dumps, test
+ * touches earn a bonus, the running average stays bounded, and a revert of a
+ * recent commit back-penalizes its target. Pure, no git or model.
+ */
+
 import { describe, expect, it } from "vitest";
 import { classify } from "../src/pipeline/classify.ts";
 import { score } from "../src/pipeline/score.ts";

--- a/plugins/plugin-gitpathologist/__tests__/secret-scrubber.test.ts
+++ b/plugins/plugin-gitpathologist/__tests__/secret-scrubber.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers the secret scrubber: redaction of Anthropic, OpenAI, GitHub, AWS, and
+ * Bearer tokens plus env-name=value patterns, benign-text passthrough, and the
+ * deep object and array walk. Pure string transforms.
+ */
+
 import { describe, expect, it } from "vitest";
 import { scrubSecrets, scrubSecretsDeep } from "../src/secret-scrubber.ts";
 

--- a/plugins/plugin-gitpathologist/build.ts
+++ b/plugins/plugin-gitpathologist/build.ts
@@ -9,11 +9,10 @@ import { buildPlugin } from "../plugin-build";
  * - CJS (Node): dist/cjs/index.cjs
  * - Types: dist/index.d.ts + dist/node/index.d.ts + dist/cjs/index.d.ts
  *
- * Migrated onto the shared `buildPlugin` driver (issue #10078). The CJS bundle
- * is renamed `index.js` -> `index.cjs` with a plain rename (its sibling
- * `index.js.map` is intentionally left unrenamed so the emitted
- * `//# sourceMappingURL=index.js.map` reference stays valid), byte-identical to
- * the prior hand-rolled build.
+ * Runs on the shared `buildPlugin` driver. The CJS bundle's `index.js` is
+ * renamed to `index.cjs`; its sibling `index.js.map` is intentionally left
+ * unrenamed so the emitted `//# sourceMappingURL=index.js.map` reference stays
+ * valid.
  */
 const reexport = (from: string) => `export * from "${from}";\nexport { default } from "${from}";\n`;
 

--- a/plugins/plugin-gitpathologist/src/render.ts
+++ b/plugins/plugin-gitpathologist/src/render.ts
@@ -1,3 +1,8 @@
+/**
+ * Renders a PathologyReport into the Markdown the GIT_PATHOLOGY action returns:
+ * a header block, the peak and drift inflection lists, and the rot post-mortem.
+ */
+
 import type { InflectionPoint, PathologyReport, RotCause } from "./types.ts";
 
 function short(sha: string): string {

--- a/plugins/plugin-gitpathologist/vitest.config.ts
+++ b/plugins/plugin-gitpathologist/vitest.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Configures the gitpathologist Vitest suite; aliases @elizaos/core and
+ * @elizaos/logger to their TypeScript sources so tests run without a built dist.
+ */
+
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 

--- a/plugins/plugin-mcp/__tests__/mcp-config-security.test.ts
+++ b/plugins/plugin-mcp/__tests__/mcp-config-security.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies the MCP plugin re-runs config security validation at its own boundary:
+ * drives the real validateMcpServerConfig from @elizaos/security to confirm unsafe
+ * stdio env channels (npm/uv config injection) are rejected before spawn.
+ */
 import { validateMcpServerConfig } from "@elizaos/security/mcp-server-config";
 import { describe, expect, it } from "vitest";
 

--- a/plugins/plugin-mcp/__tests__/routes-mcp.test.ts
+++ b/plugins/plugin-mcp/__tests__/routes-mcp.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Exercises handleMcpRoutes against a synthetic McpRouteContext (marketplace
+ * module mocked): asserts config CRUD, prototype-pollution key blocking, and
+ * marketplace routing. Route logic is real; the registry client is stubbed.
+ */
 import type http from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getMcpServerDetails, searchMcpMarketplace } from "../src/mcp-marketplace.js";

--- a/plugins/plugin-mcp/__tests__/service-lifecycle.test.ts
+++ b/plugins/plugin-mcp/__tests__/service-lifecycle.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests McpService teardown: connections and connection state are cleaned up even
+ * when a transport/client close rejects. Uses stubbed transport/client doubles.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { McpService } from "../src/service";
 

--- a/plugins/plugin-mcp/build.ts
+++ b/plugins/plugin-mcp/build.ts
@@ -7,11 +7,10 @@
  * - CJS (Node): dist/cjs/index.cjs
  * - Types: dist/index.d.ts + dist/node/index.d.ts + dist/cjs/index.d.ts
  *
- * Migrated onto the shared `buildPlugin` driver (issue #10078). The CJS bundle
- * is renamed `index.js` -> `index.cjs` with a plain rename (its sibling
- * `index.js.map` is intentionally left unrenamed so the emitted
- * `//# sourceMappingURL=index.js.map` reference stays valid), byte-identical to
- * the prior hand-rolled build.
+ * Runs on the shared `buildPlugin` driver. The CJS bundle is renamed
+ * `index.js` -> `index.cjs` with a plain rename; its sibling `index.js.map` is
+ * intentionally left unrenamed so the emitted `//# sourceMappingURL=index.js.map`
+ * reference stays valid.
  */
 import { buildPlugin } from "../plugin-build";
 
@@ -24,7 +23,7 @@ await buildPlugin({
   clean: true,
   externals: "auto",
   externalsOptions: {
-    // Transitive workspace + native deps the hand-list relied on.
+    // Transitive workspace + native deps that must stay external.
     extra: ["@elizaos/shared", "@elizaos/agent", "@node-llama-cpp", "node-llama-cpp"],
   },
   targets: [
@@ -49,8 +48,8 @@ await buildPlugin({
       renames: [["index.js", "index.cjs"]],
     },
   ],
-  // --noCheck because plugin-mcp transitively imports @elizaos/agent which has
-  // pre-existing migration debt outside our scope.
+  // Type-emit uses a dedicated project because plugin-mcp transitively imports
+  // @elizaos/agent, whose type errors are outside this package's control.
   dtsProject: "tsconfig.build.json",
   dtsShims: [
     { path: "index.d.ts", content: reexport("./node/index") },

--- a/plugins/plugin-mcp/index.browser.ts
+++ b/plugins/plugin-mcp/index.browser.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser build entry: MCP clients need Node stdio/SSE transports, so this warns
+ * and registers a no-op plugin. Use a server-side proxy to reach MCP servers.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 

--- a/plugins/plugin-mcp/src/actions/mcp.ts
+++ b/plugins/plugin-mcp/src/actions/mcp.ts
@@ -1,3 +1,12 @@
+/**
+ * The unified MCP action: a single entry point that routes an agent request to
+ * call_tool or read_resource (search_actions / list_connections are cloud-only
+ * and rejected here). The op is taken from structured parameters when present,
+ * else inferred from message text. Tool and resource selection are model-driven
+ * with retry/feedback; results are synthesized back to the user and persisted as
+ * memories. validate() gates the action on there being at least one connected
+ * server that exposes a tool or resource.
+ */
 import {
   type Action,
   type ActionResult,

--- a/plugins/plugin-mcp/src/index.ts
+++ b/plugins/plugin-mcp/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Plugin entry for @elizaos/plugin-mcp: registers McpService, the unified MCP
+ * action (widened with the connector/automation/knowledge contexts), and the MCP
+ * provider. Also re-exports handleMcpRoutes for host servers wiring /api/mcp/*.
+ */
 import {
   type Action,
   type IAgentRuntime,

--- a/plugins/plugin-mcp/src/mcp-marketplace.ts
+++ b/plugins/plugin-mcp/src/mcp-marketplace.ts
@@ -1,3 +1,9 @@
+/**
+ * Read-only client for the public MCP registry (registry.modelcontextprotocol.io):
+ * lists/searches published servers (latest versions only, classified as remote or
+ * stdio) and fetches a single server's details. Browse/discovery only — it does
+ * not install anything. Consumed by the marketplace routes in routes-mcp.ts.
+ */
 const MCP_REGISTRY_BASE_URL = "https://registry.modelcontextprotocol.io";
 
 export interface McpRegistryServer {

--- a/plugins/plugin-mcp/src/provider.ts
+++ b/plugins/plugin-mcp/src/provider.ts
@@ -1,3 +1,8 @@
+/**
+ * MCP provider: injects a compact summary of connected servers, their status,
+ * tools, and resources into agent context each turn. Reads McpService provider
+ * data and caps servers/tools/resources per turn to bound prompt size.
+ */
 import type { IAgentRuntime, Memory, Provider, ProviderResult, State } from "@elizaos/core";
 import type { McpService } from "./service";
 import type { McpProviderData } from "./types";

--- a/plugins/plugin-mcp/src/routes-mcp.ts
+++ b/plugins/plugin-mcp/src/routes-mcp.ts
@@ -1,3 +1,11 @@
+/**
+ * HTTP handler for /api/mcp/* on the host server: marketplace search/details
+ * (proxying registry.modelcontextprotocol.io), config CRUD over
+ * settings.mcp.servers, and runtime connection status. The host injects a
+ * McpRouteContext supplying request/response helpers plus config-security guards
+ * (prototype-pollution key blocking, stdio terminal authorization, per-server
+ * validation); stdio config changes require terminal authorization and a restart.
+ */
 import type http from "node:http";
 import { logger, type ReadJsonBodyOptions } from "@elizaos/core";
 import { getMcpServerDetails, searchMcpMarketplace } from "./mcp-marketplace.js";

--- a/plugins/plugin-mcp/src/service.ts
+++ b/plugins/plugin-mcp/src/service.ts
@@ -1,3 +1,15 @@
+/**
+ * McpService — owns the lifecycle of every MCP server connection: validates each
+ * config through @elizaos/security, builds the stdio or HTTP-SSE transport,
+ * connects the SDK client, and discovers its tools, resources, and resource
+ * templates.
+ *
+ * Stdio connections are health-checked with a periodic ping and reconnected with
+ * exponential backoff; HTTP/SSE connections rely on transport error/close events
+ * instead. Exposes callTool / readResource / getServers / getProviderData /
+ * restartConnection to the action and route layers. Tool input schemas are
+ * rewritten per model provider via the tool-compatibility layer.
+ */
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
 import { validateMcpServerConfig } from "@elizaos/security/mcp-server-config";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";

--- a/plugins/plugin-mcp/src/templates/errorAnalysisPrompt.ts
+++ b/plugins/plugin-mcp/src/templates/errorAnalysisPrompt.ts
@@ -1,3 +1,4 @@
+/** Re-export shim: the error-analysis prompt template, sourced from prompts.ts. */
 import { errorAnalysisTemplate } from "../prompts.js";
 
 export const errorAnalysisPrompt = errorAnalysisTemplate;

--- a/plugins/plugin-mcp/src/templates/feedbackTemplate.ts
+++ b/plugins/plugin-mcp/src/templates/feedbackTemplate.ts
@@ -1,3 +1,4 @@
+/** Re-export shim: the selection-retry feedback prompt template from prompts.ts. */
 import { feedbackTemplate } from "../prompts.js";
 
 export { feedbackTemplate };

--- a/plugins/plugin-mcp/src/templates/resourceAnalysisTemplate.ts
+++ b/plugins/plugin-mcp/src/templates/resourceAnalysisTemplate.ts
@@ -1,3 +1,4 @@
+/** Re-export shim: the resource-analysis prompt template from prompts.ts. */
 import { resourceAnalysisTemplate } from "../prompts.js";
 
 export { resourceAnalysisTemplate };

--- a/plugins/plugin-mcp/src/templates/resourceSelectionTemplate.ts
+++ b/plugins/plugin-mcp/src/templates/resourceSelectionTemplate.ts
@@ -1,3 +1,4 @@
+/** Re-export shim: the resource-selection prompt template from prompts.ts. */
 import { resourceSelectionTemplate } from "../prompts.js";
 
 export { resourceSelectionTemplate };

--- a/plugins/plugin-mcp/src/templates/toolReasoningTemplate.ts
+++ b/plugins/plugin-mcp/src/templates/toolReasoningTemplate.ts
@@ -1,3 +1,4 @@
+/** Re-export shim: the tool-result reasoning prompt template from prompts.ts. */
 import { toolReasoningTemplate } from "../prompts.js";
 
 export { toolReasoningTemplate };

--- a/plugins/plugin-mcp/src/templates/toolSelectionTemplate.ts
+++ b/plugins/plugin-mcp/src/templates/toolSelectionTemplate.ts
@@ -1,3 +1,4 @@
+/** Re-export shim: the tool selection-name and argument prompt templates from prompts.ts. */
 import { toolSelectionArgumentTemplate, toolSelectionNameTemplate } from "../prompts.js";
 
 export { toolSelectionArgumentTemplate, toolSelectionNameTemplate };

--- a/plugins/plugin-mcp/src/tool-compatibility/base.ts
+++ b/plugins/plugin-mcp/src/tool-compatibility/base.ts
@@ -1,3 +1,11 @@
+/**
+ * Base class for per-model-provider MCP tool-schema fixup, plus provider
+ * detection. transformToolSchema walks a JSON Schema and, per node type, drops
+ * the provider's unsupported keywords (subclasses declare which) and folds the
+ * dropped constraints into the description so the model still sees them.
+ * detectModelProvider infers the provider (openai/anthropic/google/openrouter)
+ * and capability flags from the runtime's model id.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import type { JSONSchema7 } from "json-schema";
 

--- a/plugins/plugin-mcp/src/tool-compatibility/index.ts
+++ b/plugins/plugin-mcp/src/tool-compatibility/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Factory that selects the MCP tool-compatibility implementation for the
+ * runtime's model provider. createMcpToolCompatibilitySync uses require() so it
+ * can run inside the synchronous tool-listing path; the async variant uses
+ * dynamic import. Returns null for providers needing no schema fixup.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { detectModelProvider, type McpToolCompatibility } from "./base";
 

--- a/plugins/plugin-mcp/src/tool-compatibility/providers/anthropic.ts
+++ b/plugins/plugin-mcp/src/tool-compatibility/providers/anthropic.ts
@@ -1,3 +1,9 @@
+/**
+ * Anthropic MCP tool-schema fixup: Claude accepts most JSON Schema keywords, so
+ * only `additionalProperties` is stripped from objects; dropped constraints
+ * (additionalProperties, format=date-time, pattern) are restated as natural-
+ * language hints appended to the property description.
+ */
 import { McpToolCompatibility, type SchemaConstraints } from "../base";
 
 interface AnthropicConstraints {

--- a/plugins/plugin-mcp/src/tool-compatibility/providers/google.ts
+++ b/plugins/plugin-mcp/src/tool-compatibility/providers/google.ts
@@ -1,3 +1,9 @@
+/**
+ * Google (Gemini) MCP tool-schema fixup: Gemini ignores most validation
+ * keywords, so string/number/array/object constraints are stripped from the
+ * schema and re-expressed as explicit natural-language rules appended to each
+ * property description.
+ */
 import { McpToolCompatibility, type SchemaConstraints } from "../base";
 
 interface GoogleConstraints {

--- a/plugins/plugin-mcp/src/tool-compatibility/providers/openai.ts
+++ b/plugins/plugin-mcp/src/tool-compatibility/providers/openai.ts
@@ -1,3 +1,10 @@
+/**
+ * OpenAI MCP tool-schema fixup: strips keywords older or reasoning OpenAI models
+ * reject (format, and more for reasoning models), applied only when the model
+ * lacks structured-output support or is a reasoning model. The reasoning-model
+ * variant additionally folds the dropped constraints into an IMPORTANT note in
+ * the description.
+ */
 import { McpToolCompatibility, type SchemaConstraints } from "../base";
 
 interface OpenAIConstraints {

--- a/plugins/plugin-mcp/src/tool-compatibility/test-example.ts
+++ b/plugins/plugin-mcp/src/tool-compatibility/test-example.ts
@@ -1,3 +1,9 @@
+/**
+ * Manual demonstration of the tool-compatibility layer: builds mock runtimes for
+ * each model provider, runs a deliberately constraint-heavy JSON Schema through
+ * transformToolSchema, and logs what each provider strips or rewrites. A runnable
+ * example, not part of the vitest suite.
+ */
 import { createCharacter, type IAgentRuntime } from "@elizaos/core";
 import type { JSONSchema7 } from "json-schema";
 import { createMcpToolCompatibility, detectModelProvider } from "./index";

--- a/plugins/plugin-mcp/src/types.ts
+++ b/plugins/plugin-mcp/src/types.ts
@@ -1,3 +1,11 @@
+/**
+ * Shared type definitions and runtime config guards for the MCP plugin:
+ * transport config shapes (stdio / HTTP-SSE) and their `isMcpSettings` guard,
+ * connection/server/provider models, tool-and-resource result shapes, JSON
+ * Schema types, and the tool/resource selection schemas the model must satisfy.
+ * Also holds ping/backoff constants and small assertion helpers. Consumed across
+ * the service, provider, action handler, and selection/validation utils.
+ */
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import type { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";

--- a/plugins/plugin-mcp/src/utils/error.ts
+++ b/plugins/plugin-mcp/src/utils/error.ts
@@ -1,3 +1,9 @@
+/**
+ * MCP error handling: handleMcpError logs the failure, optionally asks the model
+ * for a user-friendly explanation via the error-analysis prompt, and returns a
+ * failed ActionResult. McpError is a coded error type with named constructors for
+ * the common MCP failure modes.
+ */
 import type { State } from "@elizaos/core";
 import {
   type ActionResult,

--- a/plugins/plugin-mcp/src/utils/handler.ts
+++ b/plugins/plugin-mcp/src/utils/handler.ts
@@ -1,3 +1,7 @@
+/**
+ * Builds the ActionResult for the "no suitable tool" outcome: replies to the user
+ * that no MCP tool matched and falls back to direct assistance.
+ */
 import type { ActionResult, HandlerCallback } from "@elizaos/core";
 
 interface ToolSelectionResult {

--- a/plugins/plugin-mcp/src/utils/json.ts
+++ b/plugins/plugin-mcp/src/utils/json.ts
@@ -1,3 +1,9 @@
+/**
+ * JSON helpers for parsing and validating model-produced tool/resource
+ * selections: parseJSON strips code fences and surrounding prose then parses with
+ * JSON5 leniency, and validateJsonSchema gates a value against a JSON Schema via
+ * Ajv. Used on the untrusted-model-output boundary in the selection flow.
+ */
 import Ajv from "ajv";
 import JSON5 from "json5";
 

--- a/plugins/plugin-mcp/src/utils/mcp.ts
+++ b/plugins/plugin-mcp/src/utils/mcp.ts
@@ -1,3 +1,9 @@
+/**
+ * Provider-data assembly and memory persistence for MCP: buildMcpProviderData
+ * turns the connected-server list into the provider's structured data plus a
+ * markdown summary, and createMcpMemory records tool/resource use as an embedded
+ * agent memory.
+ */
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import type {
   McpProvider,

--- a/plugins/plugin-mcp/src/utils/processing.ts
+++ b/plugins/plugin-mcp/src/utils/processing.ts
@@ -1,3 +1,9 @@
+/**
+ * Post-call processing for MCP results: flattens tool output (text, base64 image
+ * attachments, embedded resources) and resource contents into text, then drives
+ * the model to synthesize a user-facing reply, persists the exchange as memory,
+ * and invokes the callback. Also sends the initial acknowledgement.
+ */
 import {
   type Content,
   ContentType,

--- a/plugins/plugin-mcp/src/utils/schemas.ts
+++ b/plugins/plugin-mcp/src/utils/schemas.ts
@@ -1,3 +1,8 @@
+/**
+ * JSON Schema objects and matching TypeScript types plus type guards for the
+ * three model-produced selection shapes: tool selection-name, tool-arguments, and
+ * resource selection. Shared by the selection prompts and validators.
+ */
 export const toolSelectionNameSchema = {
   type: "object",
   required: ["serverName", "toolName"],

--- a/plugins/plugin-mcp/src/utils/selection.ts
+++ b/plugins/plugin-mcp/src/utils/selection.ts
@@ -1,3 +1,9 @@
+/**
+ * Two-step model-driven tool selection: createToolSelectionName picks a server
+ * and tool, then createToolSelectionArgument fills arguments against that tool's
+ * input schema. Both run through withModelRetry, re-prompting with feedback until
+ * the output validates or retries are exhausted.
+ */
 import {
   composePromptFromState,
   type HandlerCallback,

--- a/plugins/plugin-mcp/src/utils/validation.ts
+++ b/plugins/plugin-mcp/src/utils/validation.ts
@@ -1,3 +1,9 @@
+/**
+ * Validators for model-produced tool/resource selections and the feedback prompts
+ * used to re-prompt on failure. A selection must target a connected server and an
+ * existing tool/resource, and tool arguments must satisfy the tool's own input
+ * schema; an explicit noTool/noResourceAvailable signal is accepted as valid.
+ */
 import type { State } from "@elizaos/core";
 import {
   type McpProviderData,

--- a/plugins/plugin-mcp/src/utils/wrapper.ts
+++ b/plugins/plugin-mcp/src/utils/wrapper.ts
@@ -1,3 +1,8 @@
+/**
+ * withModelRetry: parse-and-validate a model response, and on failure re-prompt
+ * the model with a caller-built feedback prompt up to the configured retry limit
+ * (settings.mcp.maxRetries, default 2), returning null once exhausted.
+ */
 import {
   type HandlerCallback,
   type IAgentRuntime,

--- a/plugins/plugin-mcp/vitest.config.ts
+++ b/plugins/plugin-mcp/vitest.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Vitest config for plugin-mcp: aliases @elizaos/* to workspace source so tests
+ * run against live package code, discovers the root and colocated test suites,
+ * and runs them in a Node environment.
+ */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";

--- a/plugins/plugin-pty/routes/pty-routes.ts
+++ b/plugins/plugin-pty/routes/pty-routes.ts
@@ -1,3 +1,14 @@
+/**
+ * HTTP route handlers for the PTY plugin: spawn / list / buffered-output / stop
+ * for interactive terminal sessions, mounted at `/api/pty/*` via `rawPath`.
+ *
+ * Spawning is gated three ways: HTTP callers must present the terminal step-up
+ * token (`ELIZA_TERMINAL_RUN_TOKEN`) while trusted in-process/loopback cockpit
+ * calls pass without it; `PTY_INTERACTIVE_ENABLED` (and store builds) gate all
+ * spawning; and the vendor `claude`/`codex` tier requires the separate
+ * `PTY_VENDOR_CLI_ENABLED` gate on top. The spawn handler never logs the
+ * request body — it can carry an Eliza Cloud API key.
+ */
 import { timingSafeEqual } from "node:crypto";
 import {
   type IAgentRuntime,

--- a/plugins/plugin-pty/test/eliza-code-spec.test.ts
+++ b/plugins/plugin-pty/test/eliza-code-spec.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for the pure eliza-code cerebras spawn-spec builder and bin
+ * resolver (`lib/eliza-code-spec.ts`): env/model/tier wiring, base-URL defaults,
+ * and resolver override + workspace walk-up, driven with an injected `exists`
+ * predicate — no real PTY or process spawn.
+ */
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-pty/test/pty-routes.test.ts
+++ b/plugins/plugin-pty/test/pty-routes.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Route-handler coverage for the PTY spawn/list/buffered-output/stop endpoints,
+ * driven against a real `PtyService` backed by an injected fake spawn
+ * (`makeFakeSpawn`) — no OS PTY. Exercises the terminal-token gate, the
+ * interactive/vendor enable flags, session-kind validation, and error responses.
+ */
 import { fileURLToPath } from "node:url";
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";

--- a/plugins/plugin-pty/test/pty-service.test.ts
+++ b/plugins/plugin-pty/test/pty-service.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Wiring coverage for `PtyService` (the `PTY_SERVICE` registration):
+ * start/stop/list/hasSession lifecycle and cwd confinement, driven with an
+ * injected fake spawn — no real PTY.
+ */
 import os from "node:os";
 import { describe, expect, it } from "vitest";
 import { PtyService } from "../services/pty-service";

--- a/plugins/plugin-pty/test/pty-session-store.test.ts
+++ b/plugins/plugin-pty/test/pty-session-store.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Coverage for `PtySessionStore` + `PtyConsoleBridge`: bridge output/exit
+ * routing, keystroke/resize forwarding, scrollback buffering, the session cap,
+ * cwd confinement, and idle/exit reaping — driven with an injected fake PTY
+ * (`makeFakeSpawn`), no OS process.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionOutputEvent } from "../services/pty-contract";
 import {

--- a/plugins/plugin-pty/test/vendor-cli-spec.test.ts
+++ b/plugins/plugin-pty/test/vendor-cli-spec.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for the pure claude/codex vendor-CLI spawn-spec builders and
+ * PATH-based bin resolvers (`lib/vendor-cli-spec.ts`): plain interactive launch,
+ * credential-passthrough env, and override/PATH resolution via an injected
+ * `exists` predicate — no real CLI spawned.
+ */
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-shell/__tests__/shell.real.test.ts
+++ b/plugins/plugin-shell/__tests__/shell.real.test.ts
@@ -1,3 +1,8 @@
+/**
+ * End-to-end tests for ShellService and shellHistoryProvider driving a real
+ * spawned shell in a temp directory (no mocks) — command execution, session
+ * tracking, and history-provider context injection.
+ */
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-shell/__tests__/terminal-capabilities.test.ts
+++ b/plugins/plugin-shell/__tests__/terminal-capabilities.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Tests for terminal-capability detection — detectTerminalSupport,
+ * resolveTerminalShell/resolveExecutable, and missingTerminalToolForCommand —
+ * using real files on disk (temp executables, chmod) rather than mocks.
+ */
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-shell/index.browser.ts
+++ b/plugins/plugin-shell/index.browser.ts
@@ -1,3 +1,8 @@
+/**
+ * Browser build stub for plugin-shell: exports a no-op Plugin whose init() warns
+ * that shell execution is unsupported in browsers. Selected in place of index.ts
+ * for the browser bundle target.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 

--- a/plugins/plugin-shell/index.ts
+++ b/plugins/plugin-shell/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Plugin object export for @elizaos/plugin-shell: registers ShellService and
+ * ExecApprovalService plus the SHELL_HISTORY provider, and gates auto-enable by
+ * platform (never on iOS or store builds; Android only under local-yolo mode).
+ * Registers no actions — the agent-facing SHELL action lives in
+ * @elizaos/plugin-coding-tools and consumes ShellService.
+ */
 import type { Plugin } from "@elizaos/core";
 import { ExecApprovalService } from "./approvals";
 import { shellHistoryProvider } from "./providers";

--- a/plugins/plugin-shell/providers/index.ts
+++ b/plugins/plugin-shell/providers/index.ts
@@ -1,1 +1,2 @@
+/** Barrel re-export for the SHELL_HISTORY provider. */
 export { default, shellHistoryProvider } from "./shellHistoryProvider";

--- a/plugins/plugin-shell/providers/shellHistoryProvider.ts
+++ b/plugins/plugin-shell/providers/shellHistoryProvider.ts
@@ -1,3 +1,9 @@
+/**
+ * SHELL_HISTORY provider — injects recent shell activity into agent context: the
+ * last commands with stdout/stderr/exit codes, the current and allowed working
+ * directories, and recent file operations. Fires only in terminal/code contexts
+ * and reads its state from ShellService.
+ */
 import {
   addHeader,
   type IAgentRuntime,

--- a/plugins/plugin-shell/services/index.ts
+++ b/plugins/plugin-shell/services/index.ts
@@ -1,3 +1,4 @@
+/** Barrel re-export of the module-level process-registry session API. */
 export {
   addSession,
   appendOutput,

--- a/plugins/plugin-shell/services/processRegistry.ts
+++ b/plugins/plugin-shell/services/processRegistry.ts
@@ -1,6 +1,8 @@
 /**
- * Process Registry - Manages running and finished shell sessions
- * Ported from otto bash-process-registry.ts
+ * Module-level registry of shell process sessions — both running and finished —
+ * backing ShellService's session tracking. State lives in module-scope Maps, so
+ * tests reset it via resetProcessRegistryForTests(). Enforces per-session output
+ * caps and a TTL sweep that evicts finished-session records.
  */
 
 import type { FinishedSession, ProcessSession, ProcessStatus } from "../types";

--- a/plugins/plugin-shell/services/shellService.ts
+++ b/plugins/plugin-shell/services/shellService.ts
@@ -1,6 +1,11 @@
 /**
- * Enhanced Shell Service with PTY, background execution, and session management
- * Migrated from otto bash-tools.exec.ts, bash-tools.process.ts
+ * ShellService — the shell plugin's core command executor. Runs commands via
+ * executeCommand() (simple, timeout-bounded) or exec() (PTY, background/yield,
+ * session tracking), and manages live sessions through processAction().
+ *
+ * Short-circuits in cloud mode and routes through SandboxManager under sandbox
+ * mode; PTY spawn (@lydell/node-pty) is optional and degrades to cross-spawn
+ * when the native module is unavailable.
  */
 
 import type { ChildProcessWithoutNullStreams } from "node:child_process";

--- a/plugins/plugin-shell/types/index.ts
+++ b/plugins/plugin-shell/types/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Shared type definitions for plugin-shell: command results and history entries,
+ * running/finished session shapes, exec options and results, and the shell
+ * config contract used across the services, providers, and utils.
+ */
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 
 export interface CommandResult {

--- a/plugins/plugin-shell/utils/config.ts
+++ b/plugins/plugin-shell/utils/config.ts
@@ -1,3 +1,8 @@
+/**
+ * Loads and zod-validates the shell configuration from environment variables
+ * into a ShellConfig, applying defaults and merging DEFAULT_FORBIDDEN_COMMANDS.
+ * Throws when SHELL_ALLOWED_DIRECTORY is missing or does not exist on disk.
+ */
 import fs from "node:fs";
 import path from "node:path";
 import { logger } from "@elizaos/core";

--- a/plugins/plugin-shell/utils/index.ts
+++ b/plugins/plugin-shell/utils/index.ts
@@ -1,3 +1,4 @@
+/** Barrel re-export of the shell plugin's utility surface. */
 export { DEFAULT_FORBIDDEN_COMMANDS, loadShellConfig } from "./config";
 export {
   extractBaseCommand,

--- a/plugins/plugin-shell/utils/pathUtils.ts
+++ b/plugins/plugin-shell/utils/pathUtils.ts
@@ -1,3 +1,8 @@
+/**
+ * Path and command-safety guards: validatePath() confines a resolved path to the
+ * allowed directory, while isForbiddenCommand/isSafeCommand/extractBaseCommand
+ * gate which commands the shell will run (the command-injection boundary).
+ */
 import path from "node:path";
 import { logger } from "@elizaos/core";
 

--- a/plugins/plugin-shell/utils/ptyKeys.ts
+++ b/plugins/plugin-shell/utils/ptyKeys.ts
@@ -1,6 +1,8 @@
 /**
- * PTY Key Encoding - Terminal key sequence encoding utilities
- * Ported from otto pty-keys.ts and pty-dsr.ts
+ * Encodes keyboard input into the escape sequences a PTY expects — bracketed
+ * paste, control keys, and named key sequences — and strips terminal DSR
+ * (device-status-report) requests from output. Used when driving interactive
+ * PTY sessions.
  */
 
 const ESC = "\x1b";

--- a/plugins/plugin-shell/utils/shellUtils.ts
+++ b/plugins/plugin-shell/utils/shellUtils.ts
@@ -1,6 +1,7 @@
 /**
- * Shell Utilities - Platform-specific shell configuration and helpers
- * Ported from otto shell-utils.ts and bash-tools.shared.ts
+ * Platform-specific shell helpers shared across the plugin: resolving the shell
+ * config, spawning with a PTY-to-cross-spawn fallback, killing sessions,
+ * sanitizing binary output, and slicing captured log lines.
  */
 
 import type {

--- a/plugins/plugin-shell/utils/terminalCapabilities.ts
+++ b/plugins/plugin-shell/utils/terminalCapabilities.ts
@@ -1,3 +1,8 @@
+/**
+ * Terminal-capability detection: enumerates known terminal tool names, detects
+ * whether a usable terminal/shell exists in the environment, resolves the shell
+ * and executables to run, and reports the missing tool for a given command.
+ */
 import fs from "node:fs";
 import path from "node:path";
 

--- a/plugins/plugin-shell/vitest.config.ts
+++ b/plugins/plugin-shell/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for plugin-shell: aliases @elizaos/* imports to workspace source. */
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 

--- a/plugins/plugin-task-coordinator/__tests__/unit/CodingAgentTasksPanel.test.tsx
+++ b/plugins/plugin-task-coordinator/__tests__/unit/CodingAgentTasksPanel.test.tsx
@@ -1,9 +1,8 @@
 // @vitest-environment jsdom
 //
 // Behavioral + data-display tests for CodingAgentTasksPanel (the task-coordinator
-// gui/xr view, src/CodingAgentTasksPanel.tsx). Previously this view had ZERO
-// in-plugin coverage — only an out-of-plugin Playwright spec. Here we render it
-// with realistic CodingAgentTaskThread / CodingAgentTaskThreadDetail fixtures and
+// gui/xr view, src/CodingAgentTasksPanel.tsx). Renders it with realistic
+// CodingAgentTaskThread / CodingAgentTaskThreadDetail fixtures and
 // assert: (a) the populated list shows specific titles/subtitles + total/active/
 // done count chips + session/decision chips; (b) typing in search re-fetches
 // with that search; (c) the show-archived toggle re-fetches with includeArchived

--- a/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-capability-parity.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-capability-parity.test.ts
@@ -1,3 +1,6 @@
+// Guards that the orchestrator view's declared capability manifest in
+// src/index.ts stays in exact lockstep with the ids runOrchestratorCapability
+// actually dispatches. Deterministic: reads and parses source text, no runtime.
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { ViewCapability } from "@elizaos/core";

--- a/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-command.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-command.test.ts
@@ -1,3 +1,6 @@
+// Covers the `/orchestrator-status` slash command: view-scoped/agent-target
+// registration, slash-only validate(), the deterministic callback reply with no
+// LLM call, and the gui/tui wire serialization. Deterministic, no live model.
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import {
   commandVisibleForSurface,

--- a/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-diff.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-diff.test.ts
@@ -1,3 +1,5 @@
+// Coverage for the pure LCS `lineDiff` behind the tool-call file-change cards:
+// context/add/remove classification and independent old/new line numbering.
 import { describe, expect, it } from "vitest";
 import { lineDiff } from "../../src/orchestrator-diff.helpers";
 

--- a/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-inspector-terminal-task.test.tsx
+++ b/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-inspector-terminal-task.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 //
 // Behavioral tests for the terminal-task action-bar guards in
-// `TaskInspector` (src/OrchestratorWorkbench.tsx). The inspector is mature
-// (4142 LOC); we test it directly via the exported `TaskInspector` symbol with
-// a hand-built detail fixture so the test is fast and does not need the
+// `TaskInspector` (src/OrchestratorWorkbench.tsx). We test it directly via the
+// exported `TaskInspector` symbol with a hand-built detail fixture so the test
+// is fast and does not need the
 // surrounding workbench, network mocks, or the conversation timeline.
 //
 // What's locked here (see

--- a/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-stream.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-stream.test.ts
@@ -1,3 +1,7 @@
+// Coverage for `buildConversation` — the pure transform turning polled message +
+// event records into the ordered conversation blocks the room renders (turn
+// separation, chunk merging, identity preservation) — plus the markdown
+// renderer. Deterministic: static React render, no live model.
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";

--- a/plugins/plugin-task-coordinator/src/AgentTabsSection.tsx
+++ b/plugins/plugin-task-coordinator/src/AgentTabsSection.tsx
@@ -1,3 +1,8 @@
+/**
+ * Framework tab row inside the coding-agent settings panel — a segmented group
+ * of the available agent frameworks, each tab carrying its install/auth state
+ * (preflight result → status icon).
+ */
 import {
   type AgentPreflightResult,
   Button,

--- a/plugins/plugin-task-coordinator/src/CockpitSessionPane.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitSessionPane.tsx
@@ -1,11 +1,9 @@
 /**
- * CockpitSessionPane — the coding cockpit's drill-in surface (Step 2 of the
- * gap-fill plan).
+ * CockpitSessionPane — the coding cockpit's drill-in surface.
  *
  * Tapping a room on the deck drills into THIS single-room detail view. It is a
  * pure composition of pieces that already exist in the orchestrator workbench,
- * lifted out of the 3.9k-line monolith so the cockpit can embed one room without
- * the list+filter chrome:
+ * reused so the cockpit can embed one room without the list+filter chrome:
  *
  *   • {@link useOrchestratorData} — the live data layer (detail + timeline,
  *     fast-poll while active, SSE near-live, loud-failure mutations).
@@ -16,8 +14,8 @@
  *     restart/validate/add-agent/stop-agent/…), wired to the same client calls
  *     the workbench uses, with `setSelectedId(null)` swapped for `onBack()`.
  *
- * It also unifies the drill-in with the floating-composer bubble binding (Step
- * 1): while this pane is open it registers a {@link useRegisterViewChatBinding}
+ * It also unifies the drill-in with the floating-composer bubble binding: while
+ * this pane is open it registers a {@link useRegisterViewChatBinding}
  * `onSubmit` that routes the composer's text to THIS task's room via
  * `postOrchestratorTaskMessage`, so the one bubble drives the focused room.
  *

--- a/plugins/plugin-task-coordinator/src/CodingAgentControlChip.tsx
+++ b/plugins/plugin-task-coordinator/src/CodingAgentControlChip.tsx
@@ -1,3 +1,7 @@
+/**
+ * App-shell header chip showing the live coding-agent session count with a
+ * stop-all control. Fills the `@elizaos/ui` control-chip slot.
+ */
 import {
   Button,
   type CodingAgentSession,

--- a/plugins/plugin-task-coordinator/src/CodingAgentSettingsSection.tsx
+++ b/plugins/plugin-task-coordinator/src/CodingAgentSettingsSection.tsx
@@ -1,3 +1,12 @@
+/**
+ * Per-framework coding-agent settings panel — the tabbed configuration surface
+ * (elizaOS, Pi Agent, OpenCode, Claude, Codex) for auth, model, and
+ * approval-preset settings. Fills the `@elizaos/ui` settings-section slot and
+ * composes AgentTabsSection, GlobalPrefsSection, LlmProviderSection,
+ * ModelConfigSection, and GitHubConnectionCard. Preferences persist through the
+ * agent prefs API, keyed by the env-prefix constants in
+ * coding-agent-settings-shared.
+ */
 import { type AgentPreflightResult, client, useAppSelector } from "@elizaos/ui";
 import { ExternalLink, Terminal } from "lucide-react";
 import {
@@ -229,9 +238,8 @@ export function CodingAgentSettingsSection() {
   // path that bypasses the `cloud.apiKey` contract.
   //
   // `.catch()` surfaces failed saves in an inline error banner so a
-  // failed POST no longer silently drops the user's typed API key on
-  // restart. (SaveFooter used to own this surface; we replaced it with
-  // debounced auto-save and lost the error-feedback path until now.)
+  // failed POST does not silently drop the user's typed API key on
+  // restart.
   const [autoSaveError, setAutoSaveError] = useState<string | null>(null);
   const autoSaveArmedRef = useRef(false);
   useEffect(() => {

--- a/plugins/plugin-task-coordinator/src/GlobalPrefsSection.tsx
+++ b/plugins/plugin-task-coordinator/src/GlobalPrefsSection.tsx
@@ -1,3 +1,8 @@
+/**
+ * Global coding-agent preference controls in the settings panel: the default
+ * coding directory, the agent selection strategy, the approval preset, and the
+ * multi-account strategy.
+ */
 import {
   Select,
   SelectContent,

--- a/plugins/plugin-task-coordinator/src/LlmProviderSection.tsx
+++ b/plugins/plugin-task-coordinator/src/LlmProviderSection.tsx
@@ -1,3 +1,8 @@
+/**
+ * LLM-provider selector sub-section of the coding-agent settings panel — chooses
+ * between subscription, API-keys, and Eliza Cloud provider modes and renders the
+ * matching credential inputs.
+ */
 import { Button, SettingsControls, useAppSelector } from "@elizaos/ui";
 import {
   AlertTriangle,

--- a/plugins/plugin-task-coordinator/src/ModelConfigSection.tsx
+++ b/plugins/plugin-task-coordinator/src/ModelConfigSection.tsx
@@ -1,3 +1,8 @@
+/**
+ * Model-selection controls for the active framework tab in the coding-agent
+ * settings panel — picks the model per provider, offering the fallback model
+ * lists when the provider exposes none.
+ */
 import {
   Select,
   SelectContent,

--- a/plugins/plugin-task-coordinator/src/OrchestratorAccountHealthPanel.test.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorAccountHealthPanel.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 //
 // The account-health panel (#9960) surfaces the multi-account pool's per-account
-// health + the server readiness verdict inside the orchestrator workbench (it
-// previously lived only in the chat sidebar). These tests pin: it fetches the
+// health + the server readiness verdict inside the orchestrator workbench (the
+// same accounts view the chat sidebar reuses). These tests pin: it fetches the
 // four sources, renders the reused accounts view, and renders the readiness
 // banner verbatim from the server DTO (ready vs degraded-with-problems).
 

--- a/plugins/plugin-task-coordinator/src/PtyConsoleBase.tsx
+++ b/plugins/plugin-task-coordinator/src/PtyConsoleBase.tsx
@@ -1,3 +1,13 @@
+/**
+ * PTY output streamer for a coding-agent session, rendered in drawer,
+ * side-panel, or full variant. Subscribes to `pty-output` WS events and shows
+ * the buffered + streamed scrollback with a single-line input and
+ * interrupt/stop controls.
+ *
+ * Scrollback is capped at `MAX_BUFFER_CHARS` (200,000) — older output is
+ * silently trimmed from the head. Backs the PtyConsoleDrawer /
+ * PtyConsoleSidePanel wrappers and fills the `@elizaos/ui` PtyConsoleBase slot.
+ */
 import { Button, type CodingAgentSession, client } from "@elizaos/ui";
 import { Input } from "@elizaos/ui/components/ui/input";
 import { Send, Square, Terminal, X } from "lucide-react";

--- a/plugins/plugin-task-coordinator/src/PtyConsoleDrawer.tsx
+++ b/plugins/plugin-task-coordinator/src/PtyConsoleDrawer.tsx
@@ -1,3 +1,7 @@
+/**
+ * Drawer variant of PtyConsoleBase — wraps the PTY console with a session
+ * switcher and a new-session control for the bottom-drawer surface.
+ */
 import { Button, type CodingAgentSession } from "@elizaos/ui";
 import { Plus, Terminal } from "lucide-react";
 import { PtyConsoleBase } from "./PtyConsoleBase";

--- a/plugins/plugin-task-coordinator/src/PtyConsoleSidePanel.tsx
+++ b/plugins/plugin-task-coordinator/src/PtyConsoleSidePanel.tsx
@@ -1,3 +1,4 @@
+/** Side-panel variant wrapper around PtyConsoleBase. */
 import type { CodingAgentSession } from "@elizaos/ui";
 import { PtyConsoleBase } from "./PtyConsoleBase";
 

--- a/plugins/plugin-task-coordinator/src/api/coding-agents-auth-sanitize.test.ts
+++ b/plugins/plugin-task-coordinator/src/api/coding-agents-auth-sanitize.test.ts
@@ -1,3 +1,5 @@
+// Coverage for `sanitizeAuthResult`: the field whitelist and URL-scheme check
+// applied to an adapter `triggerAuth()` response before it reaches the browser.
 import { describe, expect, it } from "vitest";
 import { sanitizeAuthResult } from "./coding-agents-auth-sanitize.js";
 

--- a/plugins/plugin-task-coordinator/src/api/coding-agents-auth-sanitize.ts
+++ b/plugins/plugin-task-coordinator/src/api/coding-agents-auth-sanitize.ts
@@ -10,8 +10,8 @@
  * compromised adapter from smuggling a `javascript:` / `data:` /
  * `file:` URL into an `<a href>`.
  *
- * Extracted into its own module so the sanitizer is unit-testable
- * without spinning up the whole HTTP server.
+ * A standalone module so the sanitizer is unit-testable without
+ * spinning up the whole HTTP server.
  */
 
 export interface SanitizedAuthResult {

--- a/plugins/plugin-task-coordinator/src/api/coding-agents-preflight-normalize.test.ts
+++ b/plugins/plugin-task-coordinator/src/api/coding-agents-preflight-normalize.test.ts
@@ -1,3 +1,5 @@
+// Coverage for `normalizePreflightAuth`: status normalization, the display-field
+// whitelist, and the undefined result for absent or malformed auth rows.
 import { describe, expect, it } from "vitest";
 import { normalizePreflightAuth } from "./coding-agents-preflight-normalize.js";
 

--- a/plugins/plugin-task-coordinator/src/api/coding-agents-preflight-normalize.ts
+++ b/plugins/plugin-task-coordinator/src/api/coding-agents-preflight-normalize.ts
@@ -11,12 +11,11 @@
  *     };
  *
  * The upstream `coding-agent-adapters` package types the auth field
- * as `unknown`. Before this normalizer, the route handlers just cast
- * the raw value to `Record<string, unknown>` and forwarded it, which
- * meant a shape drift in the adapter would silently break the UI's
- * `needsAuth` check (`preflightByAgent[agent]?.auth?.status === "unauthenticated"`).
- * TypeScript would still compile, but the Authenticate button would
- * never render. Normalizing at the boundary pins the contract.
+ * as `unknown`. Normalizing at the boundary pins the contract, so a
+ * shape drift in the adapter cannot silently break the UI's `needsAuth`
+ * check (`preflightByAgent[agent]?.auth?.status === "unauthenticated"`):
+ * a raw cast-and-forward would still compile yet leave the Authenticate
+ * button unrendered.
  */
 
 export type PreflightAuthStatus =

--- a/plugins/plugin-task-coordinator/src/components/OrchestratorSpatialView.test.tsx
+++ b/plugins/plugin-task-coordinator/src/components/OrchestratorSpatialView.test.tsx
@@ -1,3 +1,7 @@
+// Pins the one-source/three-modality contract of OrchestratorSpatialView: the
+// TUI render honors the terminal width budget (via renderViewToLines), and the
+// GUI/XR DOM render exposes the enriched action bar with XR scaled up.
+// Deterministic — typed snapshot in, rendered primitives out, no live model.
 import { visibleWidth } from "@elizaos/tui";
 import { SpatialSurface } from "@elizaos/ui/spatial";
 import {

--- a/plugins/plugin-task-coordinator/src/components/TaskCoordinatorSpatialView.test.tsx
+++ b/plugins/plugin-task-coordinator/src/components/TaskCoordinatorSpatialView.test.tsx
@@ -1,3 +1,7 @@
+// Pins the one-source/three-modality contract of TaskCoordinatorSpatialView: the
+// TUI render honors the terminal width budget (via renderViewToLines), the
+// GUI/XR DOM render mounts with agent hooks (XR scaled up), and the view
+// registers into the terminal registry the agent terminal mounts. Deterministic.
 import { visibleWidth } from "@elizaos/tui";
 import { SpatialSurface } from "@elizaos/ui/spatial";
 import {

--- a/plugins/plugin-task-coordinator/src/index.ts
+++ b/plugins/plugin-task-coordinator/src/index.ts
@@ -1,3 +1,15 @@
+/**
+ * Plugin definition for the coding-agent task coordinator: the view manifest,
+ * the orchestrator view's typed capability descriptors, and `init()`.
+ *
+ * Declares three views (`task-coordinator`, `orchestrator`, `cockpit`) with
+ * their bundle path + component exports, and the capability list the TUI layer
+ * uses to drive the orchestrator workbench. `init()` registers the
+ * view-scoped `/orchestrator-status` slash command into the per-runtime
+ * command registry; the deterministic handler action is the only server-side
+ * runtime contribution. All task/session state is owned by
+ * `@elizaos/plugin-agent-orchestrator` — this plugin is display + control only.
+ */
 import type { Plugin, ViewCapability } from "@elizaos/core";
 import {
   orchestratorStatusCommandAction,

--- a/plugins/plugin-task-coordinator/src/orchestrator-workbench-glyphs.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-workbench-glyphs.tsx
@@ -1,10 +1,9 @@
 /**
  * Pure presentational vocabulary for the orchestrator workbench (#9960):
  * status/session/verification/plan-step icon + tone maps, the label helpers,
- * and the small glyph components. Extracted from OrchestratorWorkbench.tsx (the
- * 3,931-line monolith) — these are stateless, runtime-free, and shared across
- * the header, task cards, inspector, and timeline, so they live here on their
- * own and are imported back. No data-layer, no `client`, no hooks.
+ * and the small glyph components. Stateless, runtime-free, and shared across the
+ * header, task cards, inspector, and timeline of OrchestratorWorkbench.tsx, so
+ * they live here on their own. No data-layer, no `client`, no hooks.
  */
 
 import type {

--- a/plugins/plugin-task-coordinator/src/pty-status-dots.ts
+++ b/plugins/plugin-task-coordinator/src/pty-status-dots.ts
@@ -1,1 +1,2 @@
+/** Re-exports the PTY status-dot glyph and the set of statuses that pulse, owned by @elizaos/ui. */
 export { PULSE_STATUSES, STATUS_DOT } from "@elizaos/ui";

--- a/plugins/plugin-task-coordinator/src/register.ts
+++ b/plugins/plugin-task-coordinator/src/register.ts
@@ -1,3 +1,10 @@
+/**
+ * Registration side-effect module — imported for effect, not exports. Activates
+ * the slot-registry fills (`register-slots`) that give the `@elizaos/ui`
+ * empty-slot defaults their real components, and, when running without a DOM
+ * (the Node agent / terminal host), lazily registers the two tri-modal views
+ * into the terminal registry so they render inline in the terminal.
+ */
 import "./register-slots.js";
 
 // In a terminal host (the Node agent, no DOM), register the unified

--- a/plugins/plugin-task-coordinator/src/session-hydration.ts
+++ b/plugins/plugin-task-coordinator/src/session-hydration.ts
@@ -1,3 +1,4 @@
+/** Re-exports the server-task-to-session mapping helper and terminal-status set owned by @elizaos/ui. */
 export {
   mapServerTasksToSessions,
   type ServerTask,

--- a/plugins/plugin-task-coordinator/src/ui.ts
+++ b/plugins/plugin-task-coordinator/src/ui.ts
@@ -1,3 +1,4 @@
+/** Re-exports the slot-filled coding-agent components from the slot-registry side-effect module for direct import. */
 export {
   CodingAgentControlChip,
   CodingAgentSettingsSection,

--- a/plugins/plugin-task-coordinator/src/use-orchestrator-data.test.ts
+++ b/plugins/plugin-task-coordinator/src/use-orchestrator-data.test.ts
@@ -1,9 +1,8 @@
 // @vitest-environment jsdom
 //
-// Wrapper test for the orchestrator workbench's extracted live-data layer
-// (#9960). The stateful data flow previously lived inline in the 3.9k-line
-// OrchestratorWorkbench with no test; this exercises useOrchestratorData in
-// isolation against a mocked client: list+status on mount, detail+timeline on
+// Wrapper test for the orchestrator workbench's live-data layer (#9960).
+// Exercises useOrchestratorData in isolation against a mocked client:
+// list+status on mount, detail+timeline on
 // selection, the loud-failure (actionError) path of runMutation, and timeline
 // paging.
 

--- a/plugins/plugin-task-coordinator/src/use-orchestrator-data.ts
+++ b/plugins/plugin-task-coordinator/src/use-orchestrator-data.ts
@@ -1,12 +1,12 @@
 /**
  * useOrchestratorData — the orchestrator workbench's live-data layer (#9960).
  *
- * Extracted from the OrchestratorWorkbench monolith: owns all task/session DATA
- * state (status, tasks, the selected task's detail + timeline) and the fetch /
- * poll / SSE-stream / mutation logic that keeps it live. The component keeps the
- * UI state (selection, filters, drawers) and feeds it in; everything that talks
- * to `client` and holds server data lives here, so the data flow is testable in
- * isolation (use-orchestrator-data.test.ts) without rendering the 3.6k-line view.
+ * Owns all task/session DATA state (status, tasks, the selected task's detail +
+ * timeline) and the fetch / poll / SSE-stream / mutation logic that keeps it
+ * live. OrchestratorWorkbench keeps the UI state (selection, filters, drawers)
+ * and feeds it in; everything that talks to `client` and holds server data lives
+ * here, so the data flow is testable in isolation (use-orchestrator-data.test.ts)
+ * without rendering the full workbench view.
  */
 
 import {

--- a/plugins/plugin-task-coordinator/test/coding-agent-codex-artifact.live.e2e.test.ts
+++ b/plugins/plugin-task-coordinator/test/coding-agent-codex-artifact.live.e2e.test.ts
@@ -1,3 +1,7 @@
+// Live end-to-end test that drives the real `codex` CLI to generate an artifact
+// (game.js/index.html/styles.css) and asserts the files land on disk. Gated on
+// the `codex` binary being in PATH and `~/.codex/auth.json` existing, so it
+// skips cleanly otherwise — run via `test:e2e:manual`.
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";

--- a/plugins/plugin-task-coordinator/vite.config.views.ts
+++ b/plugins/plugin-task-coordinator/vite.config.views.ts
@@ -1,3 +1,4 @@
+/** Vite config for the `build:views` step: bundles the view entry into dist/views/bundle.js served to the app shell. */
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
 export default createViewBundleConfig({

--- a/plugins/plugin-task-coordinator/vitest.config.ts
+++ b/plugins/plugin-task-coordinator/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the unit suite — aliases sibling plugin and package `src` dirs so tests resolve them from source. */
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";

--- a/plugins/plugin-task-coordinator/vitest.live.config.ts
+++ b/plugins/plugin-task-coordinator/vitest.live.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the live e2e suite under test/ — long timeouts for the real dev-stack/CLI runs it drives. */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-training/scripts/verify-view-switching.grid.test.ts
+++ b/plugins/plugin-training/scripts/verify-view-switching.grid.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Grid-builder + accuracy-gate coverage for the view-switching verification
+ * harness, over a hand-built fixture that deliberately omits one
+ * view×language×modality combination so the grid must report an "absent" cell
+ * rather than inventing a status. Pure and deterministic — no model, no server.
+ */
 import { describe, expect, it } from "vitest";
 import {
   buildResultGrid,

--- a/plugins/plugin-training/src/core/action-benchmark-runner.test.ts
+++ b/plugins/plugin-training/src/core/action-benchmark-runner.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the action-benchmark runner's command/env assembly and report parsing
+ * on a temp filesystem — deterministic, no model is spawned.
+ */
+
 import { existsSync } from "node:fs";
 import { readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";

--- a/plugins/plugin-training/src/core/action-benchmark-runner.ts
+++ b/plugins/plugin-training/src/core/action-benchmark-runner.ts
@@ -1,3 +1,10 @@
+/**
+ * Runs the Eliza-1 action-selection benchmark by spawning the app-core
+ * `action-selection.real.test.ts` vitest against a real model, then reads the
+ * emitted text/JSON reports back into a structured result. Consumed by the
+ * training-collection pipeline and the model-benchmark route.
+ */
+
 import { spawn } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";

--- a/plugins/plugin-training/src/core/benchmark-matrix-artifact.test.ts
+++ b/plugins/plugin-training/src/core/benchmark-matrix-artifact.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies the benchmark-matrix artifact builder and its schema against fixed
+ * per-tier inputs on a temp filesystem (deterministic).
+ */
+
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-training/src/core/benchmark-matrix-artifact.ts
+++ b/plugins/plugin-training/src/core/benchmark-matrix-artifact.ts
@@ -1,3 +1,8 @@
+/**
+ * Builds the benchmark-matrix artifact: aggregates per-tier Eliza-1 results
+ * (2b/4b/9b/27b, base vs trained) into a single schema-tagged JSON artifact.
+ */
+
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {

--- a/plugins/plugin-training/src/core/benchmark-vs-cerebras-runner.test.ts
+++ b/plugins/plugin-training/src/core/benchmark-vs-cerebras-runner.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the Eliza-1-vs-Cerebras runner's tier list and subprocess-arg
+ * assembly — pure, no subprocess is spawned.
+ */
+
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-training/src/core/benchmark-vs-cerebras-runner.ts
+++ b/plugins/plugin-training/src/core/benchmark-vs-cerebras-runner.ts
@@ -1,3 +1,9 @@
+/**
+ * Spawns the Eliza-1-vs-Cerebras comparison benchmark, assembling the tier
+ * list and subprocess args that pit each local tier against the Cerebras eval
+ * model.
+ */
+
 import { spawn } from "node:child_process";
 import { mkdir } from "node:fs/promises";
 import { join, resolve } from "node:path";

--- a/plugins/plugin-training/src/core/cli.test.ts
+++ b/plugins/plugin-training/src/core/cli.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the training CLI: parsing run-collection options from argv and
+ * formatting the preflight/run/list summaries (pure string logic).
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   buildRunCollectionOptionsFromCliArgs,

--- a/plugins/plugin-training/src/core/context-audit.ts
+++ b/plugins/plugin-training/src/core/context-audit.ts
@@ -1,3 +1,9 @@
+/**
+ * Audits how each registered action/provider resolves to `AgentContext`
+ * categories, cross-checking the live runtime plugin set against the static
+ * context catalog to surface unmapped or stale entries.
+ */
+
 import type { AgentRuntime, Plugin } from "@elizaos/core";
 import {
   ALL_CONTEXTS,

--- a/plugins/plugin-training/src/core/context-types.ts
+++ b/plugins/plugin-training/src/core/context-types.ts
@@ -1,3 +1,5 @@
+/** Canonical `AgentContext` category union shared by the context catalog, audit, and roleplay dataset builders. */
+
 export const AGENT_CONTEXTS = [
   "general",
   "finance",

--- a/plugins/plugin-training/src/core/eliza1-benchmark-recipe.test.ts
+++ b/plugins/plugin-training/src/core/eliza1-benchmark-recipe.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the Eliza-1 benchmark tier/variant vocabulary and the canonical
+ * tier-sort and action-pair helpers (pure).
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   canonicalElizaOneTierSort,

--- a/plugins/plugin-training/src/core/eliza1-benchmark-recipe.ts
+++ b/plugins/plugin-training/src/core/eliza1-benchmark-recipe.ts
@@ -1,3 +1,9 @@
+/**
+ * Tier and variant vocabulary for Eliza-1 benchmarks (2b/4b/9b/27b ×
+ * base/trained), plus the canonical tier-sort and action-pair helpers the
+ * runners and artifact builders share.
+ */
+
 export const ELIZA_ONE_BENCHMARK_TIERS = ["2b", "4b", "9b", "27b"] as const;
 
 export type ElizaOneBenchmarkTier = (typeof ELIZA_ONE_BENCHMARK_TIERS)[number];

--- a/plugins/plugin-training/src/core/eliza1-bundle-stager.test.ts
+++ b/plugins/plugin-training/src/core/eliza1-bundle-stager.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the Eliza-1 bundle stager's manifest and subprocess-arg assembly and
+ * its schema — deterministic, no shell-out.
+ */
+
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-training/src/core/eliza1-bundle-stager.ts
+++ b/plugins/plugin-training/src/core/eliza1-bundle-stager.ts
@@ -1,3 +1,9 @@
+/**
+ * Stages a model bundle for an Eliza-1 benchmark run: builds the stage
+ * manifest and subprocess args, then shells out to place the checkpoint and
+ * tokenizer files where the benchmark harness expects them.
+ */
+
 import { spawn } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";

--- a/plugins/plugin-training/src/core/ensure-cron-job.ts
+++ b/plugins/plugin-training/src/core/ensure-cron-job.ts
@@ -1,3 +1,10 @@
+/**
+ * Idempotent cron-job registration on the runtime TaskService: `ensureNamedCronJob`
+ * creates a repeat task once and skips if one with the same name already exists,
+ * and `registerRuntimeEventOnce` guards a runtime event subscription against
+ * duplicate registration across boots.
+ */
+
 interface MinimalLogger {
   info: (message: string) => void;
   warn: (message: string) => void;

--- a/plugins/plugin-training/src/core/eval-comparison-artifact.test.ts
+++ b/plugins/plugin-training/src/core/eval-comparison-artifact.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies the eval-comparison artifact payload builder against fixed
+ * base/candidate inputs on a temp filesystem (deterministic).
+ */
+
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-training/src/core/eval-comparison-artifact.ts
+++ b/plugins/plugin-training/src/core/eval-comparison-artifact.ts
@@ -1,3 +1,9 @@
+/**
+ * Builds the eval-comparison artifact: runs a base-vs-candidate eval subprocess
+ * and folds the two result sets into one schema-tagged JSON artifact used to
+ * decide prompt/model promotion.
+ */
+
 import { spawn } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";

--- a/plugins/plugin-training/src/core/feed-generation-runner.test.ts
+++ b/plugins/plugin-training/src/core/feed-generation-runner.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the feed-generation runner's arg assembly and artifact recording with
+ * a stub feed generator on a temp filesystem.
+ */
+
 import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-training/src/core/feed-generation-runner.ts
+++ b/plugins/plugin-training/src/core/feed-generation-runner.ts
@@ -1,3 +1,9 @@
+/**
+ * Runs the feed-generation stage of the training-collection pipeline: spawns
+ * the feed generator, collects the emitted feed files, and records a
+ * schema-tagged artifact summarizing what was produced.
+ */
+
 import { spawn } from "node:child_process";
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";

--- a/plugins/plugin-training/src/core/huggingface-dataset-ingest.test.ts
+++ b/plugins/plugin-training/src/core/huggingface-dataset-ingest.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the HuggingFace dataset ingest manifest and per-file receipts with
+ * mocked downloads on a temp filesystem (no network).
+ */
+
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-training/src/core/huggingface-dataset-ingest.ts
+++ b/plugins/plugin-training/src/core/huggingface-dataset-ingest.ts
@@ -1,3 +1,9 @@
+/**
+ * Ingests the Eliza-1 HuggingFace training dataset: downloads the configured
+ * dataset files into the training state dir, hashes each for a receipt, and
+ * writes a schema-tagged ingest manifest the collection pipeline consumes.
+ */
+
 import { createHash } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";

--- a/plugins/plugin-training/src/core/index.ts
+++ b/plugins/plugin-training/src/core/index.ts
@@ -1,3 +1,5 @@
+/** Barrel re-exporting the training-core runners, artifact builders, and config helpers. */
+
 export {
   type ActionBenchmarkRunOptions,
   type ActionBenchmarkRunResult,

--- a/plugins/plugin-training/src/core/lifeops-optimized-prompt-consumers.test.ts
+++ b/plugins/plugin-training/src/core/lifeops-optimized-prompt-consumers.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Guards that each `LIFEOPS_OPTIMIZED_PROMPT_TASKS` entry declared in core has a
+ * real consumer referenced in the source tree (static source scan), catching
+ * orphaned optimization tasks.
+ */
+
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-training/src/core/plugin-app-metadata.test.ts
+++ b/plugins/plugin-training/src/core/plugin-app-metadata.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Asserts the plugin's package.json publishes the fine-tuning dashboard app
+ * metadata used for local app discovery (reads the manifest, deterministic).
+ */
+
 import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 

--- a/plugins/plugin-training/src/core/prompt-compare.test.ts
+++ b/plugins/plugin-training/src/core/prompt-compare.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the prompt A/B comparison harness (`comparePrompts` +
+ * `formatComparisonSummary`) with a deterministic in-memory LM adapter.
+ */
+
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-training/src/core/roleplay-executor.ts
+++ b/plugins/plugin-training/src/core/roleplay-executor.ts
@@ -1,3 +1,9 @@
+/**
+ * Executes roleplay episodes turn-by-turn against the runtime model, capturing
+ * each turn as a trajectory and bucketizing the episodes into a report plus
+ * exported trajectory files for downstream optimization.
+ */
+
 import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";

--- a/plugins/plugin-training/src/core/roleplay-trajectories.ts
+++ b/plugins/plugin-training/src/core/roleplay-trajectories.ts
@@ -1,3 +1,9 @@
+/**
+ * Turns training samples into roleplay episodes and serializes them to the
+ * on-disk manifest/export shape the roleplay executor and dataset builders
+ * consume.
+ */
+
 import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";

--- a/plugins/plugin-training/src/core/scenario-runner.test.ts
+++ b/plugins/plugin-training/src/core/scenario-runner.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the scenario-runner wrapper's command assembly and workspace-root
+ * discovery on a temp filesystem — deterministic, no agent is spawned.
+ */
+
 import { existsSync } from "node:fs";
 import { readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";

--- a/plugins/plugin-training/src/core/scenario-runner.ts
+++ b/plugins/plugin-training/src/core/scenario-runner.ts
@@ -1,3 +1,9 @@
+/**
+ * Wraps the scenario-runner harness: builds the subprocess command that runs
+ * scenario blueprints through the real agent and collects the resulting
+ * trajectories for the training-collection pipeline.
+ */
+
 import { spawn } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";

--- a/plugins/plugin-training/src/core/test-trajectory-collector.test.ts
+++ b/plugins/plugin-training/src/core/test-trajectory-collector.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the test-trajectory collector's dedupe and manifest writing on a temp
+ * filesystem (deterministic).
+ */
+
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";

--- a/plugins/plugin-training/src/core/test-trajectory-collector.ts
+++ b/plugins/plugin-training/src/core/test-trajectory-collector.ts
@@ -1,3 +1,9 @@
+/**
+ * Collects trajectories emitted by test runs into the training state dir,
+ * deduping by content hash and writing a schema-tagged collection manifest the
+ * analysis index consumes.
+ */
+
 import { existsSync } from "node:fs";
 import {
   copyFile,

--- a/plugins/plugin-training/src/core/training-analysis-index.test.ts
+++ b/plugins/plugin-training/src/core/training-analysis-index.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the training-analysis index builder over synthesized artifact trees on
+ * a temp filesystem, including the HTML report rendering (deterministic).
+ */
+
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
@@ -856,10 +861,10 @@ describe("training analysis index", () => {
 
     // The embedded report <script> must be syntactically valid. A broken regex
     // in hrefForPath (`:///i`, parsed by the browser as a regex literal + a `//`
-    // line comment) previously left an unclosed `if (` and turned the ENTIRE
-    // <script> into a SyntaxError, disabling all report interactivity (filters,
-    // sorting, clickable source-file links). new Function() compiles without
-    // executing, so it surfaces a SyntaxError without needing a DOM.
+    // line comment) can leave an unclosed `if (` and turn the ENTIRE <script>
+    // into a SyntaxError, disabling all report interactivity (filters, sorting,
+    // clickable source-file links). new Function() compiles without executing,
+    // so it surfaces a SyntaxError without needing a DOM.
     const clientScript = html.match(/<script>([\s\S]*?)<\/script>/)?.[1];
     expect(clientScript, "report client <script> not found").toBeTruthy();
     expect(() => new Function(clientScript as string)).not.toThrow();

--- a/plugins/plugin-training/src/core/training-analysis-index.ts
+++ b/plugins/plugin-training/src/core/training-analysis-index.ts
@@ -1,3 +1,9 @@
+/**
+ * Scans the training state dir for collection/benchmark/dataset artifacts and
+ * builds a single schema-tagged index over them — the manifest that the
+ * readiness report and dashboard read to understand what training data exists.
+ */
+
 import { createReadStream, existsSync } from "node:fs";
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import {

--- a/plugins/plugin-training/src/core/training-collection-runner.test.ts
+++ b/plugins/plugin-training/src/core/training-collection-runner.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the full collection pipeline runner with stubbed stage subprocesses
+ * and a local HTTP fixture on a temp filesystem — deterministic, no live model.
+ */
+
 import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";

--- a/plugins/plugin-training/src/core/training-collection-runner.ts
+++ b/plugins/plugin-training/src/core/training-collection-runner.ts
@@ -1,3 +1,11 @@
+/**
+ * Orchestrates the full training-data collection pipeline end to end:
+ * HuggingFace dataset ingest, feed generation, scenario runs, and action
+ * benchmarks, writing each stage's artifact plus a schema-tagged run summary
+ * and collection index. This is the top-level entry the CLI and auto-train
+ * trigger call to assemble a training corpus.
+ */
+
 import { existsSync } from "node:fs";
 import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";

--- a/plugins/plugin-training/src/core/training-orchestrator.test.ts
+++ b/plugins/plugin-training/src/core/training-orchestrator.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the training orchestrator's per-task baseline loading against the
+ * declared training-task set (pure).
+ */
+
 import { describe, expect, it } from "vitest";
 import { ALL_TRAINING_TASKS } from "./training-config.js";
 import { loadBaselineForTask } from "./training-orchestrator.js";

--- a/plugins/plugin-training/src/core/training-readiness-report.test.ts
+++ b/plugins/plugin-training/src/core/training-readiness-report.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the training-readiness report builder over synthetic analysis-index
+ * inputs (pure).
+ */
+
 import { describe, expect, it } from "vitest";
 import type { TrainingAnalysisIndex } from "./training-analysis-index.js";
 import {

--- a/plugins/plugin-training/src/core/training-readiness-report.ts
+++ b/plugins/plugin-training/src/core/training-readiness-report.ts
@@ -1,3 +1,9 @@
+/**
+ * Derives a training-readiness report from the analysis index: which tiers have
+ * datasets, benchmarks, and eval coverage, and what action a caller must take
+ * to close each gap. Emitted as a schema-tagged artifact for the dashboard.
+ */
+
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {

--- a/plugins/plugin-training/src/core/trajectory-consumer.ts
+++ b/plugins/plugin-training/src/core/trajectory-consumer.ts
@@ -1,3 +1,8 @@
+/**
+ * Parses trajectory export payloads and extracts the per-call entries and
+ * `eliza_native_v1` rows that the optimizers and dataset builders consume.
+ */
+
 import type {
   Trajectory,
   TrajectoryLlmCall,

--- a/plugins/plugin-training/src/core/trajectory-export-bundle.test.ts
+++ b/plugins/plugin-training/src/core/trajectory-export-bundle.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers the privacy-filtered export bundle builder end to end on a temp
+ * filesystem, asserting PII is stripped and per-task JSONL is emitted; the HTTP
+ * upload path is stubbed (deterministic).
+ */
+
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import type http from "node:http";
 import { tmpdir } from "node:os";

--- a/plugins/plugin-training/src/core/trajectory-export-bundle.ts
+++ b/plugins/plugin-training/src/core/trajectory-export-bundle.ts
@@ -1,3 +1,11 @@
+/**
+ * Builds the privacy-filtered trajectory export bundle: runs recorded
+ * trajectories through the mandatory privacy filter, buckets them into per-task
+ * JSONL plus an HTML preview, and records privacy stats and optional cloud
+ * upload metadata. This is the single sanitized-write path — no code writes raw
+ * trajectories to disk or upload.
+ */
+
 import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Trajectory } from "@elizaos/agent";

--- a/plugins/plugin-training/src/core/trajectory-export-cron.test.ts
+++ b/plugins/plugin-training/src/core/trajectory-export-cron.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the nightly trajectory-export cron's paging and per-task bucketization
+ * with a stub trajectory service on a temp filesystem (deterministic).
+ */
+
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-training/src/core/trajectory-task-datasets.test.ts
+++ b/plugins/plugin-training/src/core/trajectory-task-datasets.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers per-task `eliza_native_v1` extraction and JSONL writing from recorded
+ * trajectories on a temp filesystem (deterministic).
+ */
+
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-training/src/core/trajectory-task-datasets.ts
+++ b/plugins/plugin-training/src/core/trajectory-task-datasets.ts
@@ -1,3 +1,10 @@
+/**
+ * Extracts per-task training examples from recorded trajectories and writes
+ * them as `eliza_native_v1` JSONL, one file per training task. Reward/quality
+ * signals (scenario status, judge score) ride along so failed scenarios are not
+ * cloned as gold supervision. Shared by the export bundle and the nightly cron.
+ */
+
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Trajectory, TrajectoryLlmCall } from "@elizaos/agent";

--- a/plugins/plugin-training/src/core/workspace-runtime.ts
+++ b/plugins/plugin-training/src/core/workspace-runtime.ts
@@ -1,3 +1,9 @@
+/**
+ * Workspace-root discovery and the default bun command used when the training
+ * runners shell out to sibling packages, resolving the monorepo root by walking
+ * up for workspace markers.
+ */
+
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 

--- a/plugins/plugin-training/src/dspy/optimizers/index.ts
+++ b/plugins/plugin-training/src/dspy/optimizers/index.ts
@@ -1,3 +1,5 @@
+/** Barrel re-exporting the DSPy-style optimizers (BootstrapFewshot, COPRO, MIPROv2). */
+
 export {
   type DspyBootstrapFewshotOptions,
   runDspyBootstrapFewshot,

--- a/plugins/plugin-training/src/index.ts
+++ b/plugins/plugin-training/src/index.ts
@@ -1,3 +1,4 @@
+/** Public entry point: re-exports the plugin's backends, CLI, optimizers, routes, services, and views. */
 export * from "./backends/native.js";
 export * from "./cli/train.js";
 export * from "./core/cli.js";

--- a/plugins/plugin-training/src/optimizers/index.ts
+++ b/plugins/plugin-training/src/optimizers/index.ts
@@ -1,3 +1,5 @@
+/** Barrel re-exporting the native optimizers, scorers, and shared optimizer types. */
+
 export {
   type BootstrapFewshotInput,
   type BootstrapFewshotOptions,

--- a/plugins/plugin-training/src/optimizers/scoring.test.ts
+++ b/plugins/plugin-training/src/optimizers/scoring.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the native scorers: planner action/view extraction and the view-aware
+ * agreement score (pure).
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   extractPlannerAction,

--- a/plugins/plugin-training/src/optimizers/view-context-dataset.test.ts
+++ b/plugins/plugin-training/src/optimizers/view-context-dataset.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Validates the view-context fixture rows are well-formed eliza_native_v1
+ * planner examples and that the view-selection scorer reads them
+ * (fixture-driven).
+ */
+
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-training/src/optimizers/view-switching-dataset.test.ts
+++ b/plugins/plugin-training/src/optimizers/view-switching-dataset.test.ts
@@ -8,9 +8,9 @@ import {
   scorePlannerAction,
 } from "./scoring.js";
 
-// Wires the view-switching action_planner eval dataset (previously an orphan
-// fixture referenced nowhere) into the test graph: every row must be a valid
-// eliza_native_v1 planner example, and the view-aware scorer must read it.
+// Wires the view-switching action_planner eval dataset into the test graph:
+// every row must be a valid eliza_native_v1 planner example, and the view-aware
+// scorer must read it.
 
 const DATASET_PATH = join(
   dirname(fileURLToPath(import.meta.url)),

--- a/plugins/plugin-training/src/register-runtime.ts
+++ b/plugins/plugin-training/src/register-runtime.ts
@@ -1,3 +1,10 @@
+/**
+ * Runtime wiring entry point (`registerTrainingRuntimeHooks`): registers the
+ * OptimizedPromptService, the training-config and training-trigger services, and
+ * the nightly trajectory-export and skill-scoring crons on an AgentRuntime. The
+ * host must call this at agent boot — the plugin does not auto-enable. Cron
+ * registration is skipped when `ELIZA_DISABLE_TRAINING_CRONS` is set.
+ */
 import type { AgentRuntime, Service } from "@elizaos/core";
 import { logger, OptimizedPromptService } from "@elizaos/core";
 import { registerSkillScoringCron } from "./core/skill-scoring-cron.js";

--- a/plugins/plugin-training/src/routes/experience-routes.ts
+++ b/plugins/plugin-training/src/routes/experience-routes.ts
@@ -1,8 +1,6 @@
 /**
- * Experience HTTP routes.
- *
- * Migrated from `packages/agent/src/api/experience-routes.ts` so the experience
- * service surface lives next to the rest of the training/trajectory plumbing.
+ * Experience HTTP routes — the experience-service surface, colocated with the
+ * rest of the training/trajectory plumbing.
  *
  * The runtime mounts these routes through the plugin route registry; see
  * `setup-routes.ts` for the registered Plugin and the `rawPath: true` paths.

--- a/plugins/plugin-training/src/routes/index.ts
+++ b/plugins/plugin-training/src/routes/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the plugin's HTTP route handlers: training, Vast.ai, trajectory, and experience. */
 export {
   EXPERIENCE_ROUTE_PATHS,
   type ExperienceRouteContext,

--- a/plugins/plugin-training/src/routes/training-routes.test.ts
+++ b/plugins/plugin-training/src/routes/training-routes.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Coverage for the `/api/training/*` route handler (`handleTrainingRoutes`),
+ * driving it against an in-memory fake TrainingService — no live backend.
+ */
 import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import type http from "node:http";
 import { tmpdir } from "node:os";

--- a/plugins/plugin-training/src/routes/training-routes.ts
+++ b/plugins/plugin-training/src/routes/training-routes.ts
@@ -1,3 +1,10 @@
+/**
+ * `/api/training/*` HTTP route handler for the fine-tuning dashboard: trajectory
+ * listing and export, dataset build, backend/job/model management, benchmark
+ * runs, and dataset/roleplay generation. `handleTrainingRoutes(ctx)` returns
+ * `true` once it has matched and responded, `false` otherwise, and reads the
+ * live TrainingService from the in-process registry.
+ */
 import type { Trajectory } from "@elizaos/agent";
 import type {
   AgentRuntime,

--- a/plugins/plugin-training/src/routes/trajectory-routes.test.ts
+++ b/plugins/plugin-training/src/routes/trajectory-routes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Coverage for the `/api/trajectories/*` route handler (`handleTrajectoryRoute`),
+ * with `@elizaos/agent`'s storage and zip helpers mocked so the routing, export,
+ * and streaming branches are exercised without a real trajectory store.
+ */
 import type http from "node:http";
 import { Readable } from "node:stream";
 import type { Trajectory } from "@elizaos/agent";

--- a/plugins/plugin-training/src/scripts/lifeops-gepa-seed.test.ts
+++ b/plugins/plugin-training/src/scripts/lifeops-gepa-seed.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit coverage for the LifeOps GEPA seed script's pure helpers — argument
+ * bounds parsing, the seed-task table, and the persist gate that only promotes an
+ * optimized prompt when it beats the baseline. No model calls.
+ */
 import { describe, expect, it } from "vitest";
 import {
   parseBoundedIntegerArg,

--- a/plugins/plugin-training/src/services/index.ts
+++ b/plugins/plugin-training/src/services/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the plugin's runtime services: backend detection, training config, trigger, TrainingService, Vast orchestration, and the active-service registry. */
 export {
   type BackendAvailability,
   clearBackendCache,

--- a/plugins/plugin-training/src/services/training-backend-check.ts
+++ b/plugins/plugin-training/src/services/training-backend-check.ts
@@ -1,3 +1,9 @@
+/**
+ * Detects which local fine-tuning backends are usable (`mlx`, `cuda`, `cpu`) by
+ * probing for the relevant toolchains with short-timeout subprocesses, caching
+ * the result for a minute so route handlers can report backend availability
+ * cheaply.
+ */
 import { execFile } from "node:child_process";
 
 export interface BackendAvailability {

--- a/plugins/plugin-training/src/services/training-config-service.test.ts
+++ b/plugins/plugin-training/src/services/training-config-service.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Coverage for TrainingConfigService and its registration helper — the settings
+ * extension the host SETTINGS action dispatches `toggle_training` to — using an
+ * in-memory config, no disk or host runtime.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-training/src/services/training-config-service.ts
+++ b/plugins/plugin-training/src/services/training-config-service.ts
@@ -2,12 +2,10 @@
  * TrainingConfigService — the plugin-training-owned settings extension the host
  * SETTINGS action dispatches `toggle_training` to.
  *
- * Previously the host action (`@elizaos/agent`) reached into this plugin via a
- * computed-specifier `import("@elizaos/plugin-training")` to call
- * `loadTrainingConfig`/`saveTrainingConfig` — a reverse dependency edge (host →
- * plugin) that the agent package did not even declare. That business logic now
- * lives here, behind a runtime service the host looks up by name: the plugin
- * contributes the capability, the host stays a dispatcher.
+ * The training-config business logic (`loadTrainingConfig` / `saveTrainingConfig`)
+ * lives here, behind a runtime service the host looks up by name, so the host
+ * stays a dispatcher and does not depend on this plugin: the plugin contributes
+ * the capability, the host resolves it without a reverse dependency edge.
  *
  * Service identifier: `TRAINING_CONFIG_SERVICE` (`"training_config_service"`).
  */

--- a/plugins/plugin-training/src/services/training-service-like.ts
+++ b/plugins/plugin-training/src/services/training-service-like.ts
@@ -1,3 +1,4 @@
+/** Structural interface the route layer depends on for a training service, decoupling the `/api/training/*` handlers from the concrete TrainingService implementation. */
 import type { Trajectory, TrajectoryListResult } from "@elizaos/agent";
 
 export interface TrainingServiceLike {

--- a/plugins/plugin-training/src/services/training-service-registry.ts
+++ b/plugins/plugin-training/src/services/training-service-registry.ts
@@ -1,3 +1,4 @@
+/** Process-global holder for the active TrainingService, so route handlers can reach the service the host builds at startup without threading it through every call. */
 import type { TrainingServiceWithRuntime } from "./training-service-like.js";
 
 let activeTrainingService: TrainingServiceWithRuntime | null = null;

--- a/plugins/plugin-training/src/services/training-service.test.ts
+++ b/plugins/plugin-training/src/services/training-service.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Coverage for TrainingService — asserts it reads trajectories from the runtime
+ * and hands the right set plus metadata to the export-bundle builder, with the
+ * bundle builder mocked so nothing is written to disk.
+ */
 import type { Trajectory } from "@elizaos/agent";
 import type { AgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-training/src/services/training-trigger.test.ts
+++ b/plugins/plugin-training/src/services/training-trigger.test.ts
@@ -1,13 +1,11 @@
 /**
- * TrainingTriggerService LifeOps coverage (#8795).
- *
- * Before the fix, `tasksForTrajectory` only recognized the six generic
- * runtime tasks, so a LifeOps-tagged trajectory (purpose calendar_extract,
- * inbox_triage, …) fell through to the default `response` bucket and the
- * per-task LifeOps thresholds could never fire. These tests prove:
+ * TrainingTriggerService LifeOps coverage (#8795). Asserts that
+ * `tasksForTrajectory` routes a LifeOps-tagged trajectory (purpose
+ * calendar_extract, inbox_triage, …) to its own per-task bucket rather than the
+ * generic `response` bucket, so per-task thresholds can fire:
  *
  *   - a LifeOps-purpose trajectory increments its own per-task counter,
- *   - a LifeOps per-task threshold actually fires `triggerTraining`,
+ *   - a LifeOps per-task threshold fires `triggerTraining`,
  *   - the bootstrap task set includes the LifeOps capabilities from
  *     `LIFEOPS_OPTIMIZED_PROMPT_TASKS` in `@elizaos/core`.
  */

--- a/plugins/plugin-training/src/setup-routes.ts
+++ b/plugins/plugin-training/src/setup-routes.ts
@@ -1,9 +1,7 @@
 /**
- * Training and trajectory HTTP routes for the app-training plugin.
- *
- * These routes were previously dispatched from
- * `packages/agent/src/api/server.ts`. They are now registered through the
- * plugin route registry with `rawPath: true`.
+ * `trainingPlugin` definition — registers the training and trajectory HTTP
+ * routes (with `rawPath: true`) and the fine-tuning views through the plugin
+ * route registry.
  *
  * The handlers read the live TrainingService from the in-process registry
  * (`getActiveTrainingService`), which server.ts startup populates after it

--- a/plugins/plugin-training/src/ui/FineTuningTuiView.test.tsx
+++ b/plugins/plugin-training/src/ui/FineTuningTuiView.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Integration coverage for the fine-tuning dashboard driven through its TUI
+ * `interact()` path: renders the real FineTuningView with the panels stubbed and
+ * exercises multi-step flows against a mocked UI client (no live training
+ * backend). Async utility timeouts are widened for saturated CI runners.
+ */
 import { openExternalUrl } from "@elizaos/ui/utils";
 import {
   cleanup,

--- a/plugins/plugin-training/src/ui/FineTuningView.tsx
+++ b/plugins/plugin-training/src/ui/FineTuningView.tsx
@@ -1,3 +1,12 @@
+/**
+ * FineTuningView — the fine-tuning dashboard's rich GUI/XR React component: the
+ * status, trajectories, datasets, backends, jobs, models, benchmark, and
+ * analysis-coverage panels wired to the `/api/training/*` endpoints through the
+ * shared UI client. Pure formatting/parsing helpers live in
+ * `FineTuningView.helpers.ts` and the `interact` capability handler in
+ * `FineTuningView.interact.ts`, so this file exports only React components and
+ * stays Fast-Refresh-compatible.
+ */
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import type {
   HuggingFaceDatasetIngestResponse,

--- a/plugins/plugin-training/src/ui/fine-tuning-panels.tsx
+++ b/plugins/plugin-training/src/ui/fine-tuning-panels.tsx
@@ -1,3 +1,9 @@
+/**
+ * Presentational panel components for the fine-tuning dashboard (status,
+ * datasets, jobs, models, backends, and controls), consumed by FineTuningView.
+ * Non-component constants and the streamed-event parser live in
+ * `fine-tuning-panels.helpers.ts` to keep this file Fast-Refresh-compatible.
+ */
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import type {
   TrainingDatasetRecord,

--- a/plugins/plugin-training/src/ui/index.ts
+++ b/plugins/plugin-training/src/ui/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the fine-tuning dashboard UI: the view, panels, and their pure helpers. */
 export * from "./FineTuningView.helpers.ts";
 export * from "./FineTuningView.js";
 export * from "./fine-tuning-panels.helpers.ts";

--- a/plugins/plugin-training/test/plugin-discord.stub.ts
+++ b/plugins/plugin-training/test/plugin-discord.stub.ts
@@ -1,3 +1,4 @@
+/** Test stub for `@elizaos/plugin-discord`'s avatar-cache and profile helpers, keeping the training suite free of a real Discord dependency. */
 import os from "node:os";
 import path from "node:path";
 

--- a/plugins/plugin-training/test/privacy-filter.test.ts
+++ b/plugins/plugin-training/test/privacy-filter.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Coverage for the mandatory trajectory privacy filter — asserts
+ * `applyPrivacyFilter` strips PII/credentials and `createHashAnonymizer` stably
+ * pseudonymizes identifiers before any export. Pure, no I/O.
+ */
 import { describe, expect, it } from "vitest";
 import {
   applyPrivacyFilter,

--- a/plugins/plugin-training/test/syntax-highlighter-language.stub.ts
+++ b/plugins/plugin-training/test/syntax-highlighter-language.stub.ts
@@ -1,1 +1,2 @@
+/** Empty test stub standing in for react-syntax-highlighter's language registration module. */
 export default {};

--- a/plugins/plugin-training/test/syntax-highlighter-prism-light.stub.tsx
+++ b/plugins/plugin-training/test/syntax-highlighter-prism-light.stub.tsx
@@ -1,3 +1,4 @@
+/** Test stub for react-syntax-highlighter's Prism light build — renders children in a plain <pre>, no highlighting. */
 import React from "react";
 
 function SyntaxHighlighter({ children }: { children?: React.ReactNode }) {

--- a/plugins/plugin-training/test/syntax-highlighter-style.stub.ts
+++ b/plugins/plugin-training/test/syntax-highlighter-style.stub.ts
@@ -1,3 +1,4 @@
+/** Empty test stub standing in for react-syntax-highlighter's style modules (e.g. `vscDarkPlus`). */
 export default {};
 
 export const vscDarkPlus = {};

--- a/plugins/plugin-training/vite.config.views.ts
+++ b/plugins/plugin-training/vite.config.views.ts
@@ -1,3 +1,4 @@
+/** Vite config for the `training` view bundle, delegating to the shared view-bundle builder. */
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
 export default createViewBundleConfig({

--- a/plugins/plugin-training/vitest.config.ts
+++ b/plugins/plugin-training/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the training plugin, extending the workspace default and wiring source aliases for the local workspace plugin/package dependencies. */
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerSpatialView.test.tsx
+++ b/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerSpatialView.test.tsx
@@ -1,3 +1,8 @@
+/**
+ * Renders the presentational `TrajectoryLoggerSpatialView` to both static DOM
+ * markup and real terminal lines (via the spatial TUI registry), asserting the
+ * one source produces sane output across GUI and TUI surfaces.
+ */
 import { visibleWidth } from "@elizaos/tui";
 import { SpatialSurface } from "@elizaos/ui/spatial";
 import {

--- a/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.interact.test.ts
+++ b/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.interact.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Tests the view-bundle `interact` capability handler against a stubbed `fetch`,
+ * asserting each TUI capability (list-trajectories, open-latest, filter-phase,
+ * refresh) issues the right trajectory route request.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { interact } from "./TrajectoryLoggerView.interact.js";
 

--- a/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.test.tsx
+++ b/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.test.tsx
@@ -4,8 +4,8 @@
 // the bundle exports for the "gui" and "xr" modalities. Asserts it mounts the
 // one presentational TrajectoryLoggerSpatialView inside a SpatialSurface, polls
 // real-shape trajectory data into the snapshot, and routes the spatial action
-// ids (`back`, `select:<slot>:<phase>`, `refresh`) — functional parity with the
-// retired hand-written GUI/TUI surfaces.
+// ids (`back`, `select:<slot>:<phase>`, `refresh`) across the GUI and TUI
+// surfaces.
 
 import { NAVIGATE_VIEW_EVENT } from "@elizaos/ui/events";
 import { SpatialSurface } from "@elizaos/ui/spatial";

--- a/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.visual-copy.test.ts
+++ b/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.visual-copy.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Source-level regression guard: reads the view file's text and asserts its
+ * visible copy carries no raw glyphs that break terminal width or read poorly
+ * across surfaces. No render — a static read of the component source.
+ */
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-trajectory-logger/src/phases.ts
+++ b/plugins/plugin-trajectory-logger/src/phases.ts
@@ -1,3 +1,15 @@
+/**
+ * Phase classification for a trajectory's LLM calls, tool events, and provider
+ * accesses. `phaseOf()` maps each call's `stepType`/`purpose` onto one of the
+ * four canonical phases (HANDLE / PLAN / ACTION / EVALUATE); `summarizePhases()`
+ * folds a `TrajectoryDetail` into an ordered per-phase status summary the view
+ * and TUI render, and `extractShouldRespondDecision()` pulls the respond/ignore
+ * verdict out of the HANDLE step.
+ *
+ * Consumed by the polling hook and the spatial view. Classification is a
+ * hard-coded heuristic: a call matching no phase set is silently omitted from
+ * every summary, so new step types must be registered here to appear.
+ */
 import type {
   TrajectoryDetail,
   UIEvaluationEvent,

--- a/plugins/plugin-trajectory-logger/src/ui.ts
+++ b/plugins/plugin-trajectory-logger/src/ui.ts
@@ -1,1 +1,2 @@
+/** Browser UI entry: re-exports the React `TrajectoryLoggerView` for view-bundle and app consumers, kept out of the Node plugin barrel so React never loads in the agent process. */
 export { TrajectoryLoggerView } from "./components/TrajectoryLoggerView";

--- a/plugins/plugin-trajectory-logger/src/usePollingTrajectories.test.tsx
+++ b/plugins/plugin-trajectory-logger/src/usePollingTrajectories.test.tsx
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * Exercises the `usePollingTrajectories` hook against a stubbed `fetch` serving
+ * real-shape list/detail envelopes, asserting it selects the active + last
+ * trajectory, polls, and distinguishes the routes-unavailable state from errors.
+ */
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { usePollingTrajectories } from "./usePollingTrajectories.js";

--- a/plugins/plugin-trajectory-logger/src/usePollingTrajectories.ts
+++ b/plugins/plugin-trajectory-logger/src/usePollingTrajectories.ts
@@ -1,3 +1,11 @@
+/**
+ * React hook that polls `/api/trajectories` (and the per-id detail route) every
+ * 700 ms and returns the active and most-recently-completed trajectory plus
+ * their details. Uses an `AbortController` to cancel in-flight requests on
+ * unmount. Distinguishes a genuine fetch error from the routes being absent
+ * (404/503 when `@elizaos/plugin-training` is not mounted) via a separate
+ * `unavailable` flag, so the view can degrade instead of showing an error.
+ */
 import { useEffect, useState } from "react";
 import {
   fetchTrajectoryDetail,

--- a/plugins/plugin-trajectory-logger/test/phases.test.ts
+++ b/plugins/plugin-trajectory-logger/test/phases.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the phase classifier (`summarizePhases` /
+ * `extractShouldRespondDecision`) over hand-built trajectory fixtures — pure
+ * functions, no runtime or network.
+ */
 import { describe, expect, it } from "vitest";
 import type {
   TrajectoryDetail,

--- a/plugins/plugin-trajectory-logger/vite.config.views.ts
+++ b/plugins/plugin-trajectory-logger/vite.config.views.ts
@@ -1,3 +1,4 @@
+/** Vite config that builds the standalone view bundle (dist/views/bundle.js) from the view-bundle entry, exposing `TrajectoryLoggerView` for the overlay view loader. */
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
 export default createViewBundleConfig({

--- a/plugins/plugin-trajectory-logger/vitest.config.ts
+++ b/plugins/plugin-trajectory-logger/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the trajectory-logger plugin: aliases React and testing-library to the workspace UI package's copies so the peer-dep-only components and jsdom render tests resolve without a per-package dependency. */
 import { createRequire } from "node:module";
 import path from "node:path";
 import { defineConfig } from "vitest/config";

--- a/plugins/plugin-workflow/__tests__/fixtures/smithers-runtime-case.ts
+++ b/plugins/plugin-workflow/__tests__/fixtures/smithers-runtime-case.ts
@@ -1,3 +1,8 @@
+/**
+ * Test fixture run as a child process by the smithers-runtime suite: executes a
+ * workflow through `runWorkflowWithSmithers` and prints a prefixed result line the
+ * parent parses. Exercises the real Smithers execution adapter.
+ */
 import { writeFile } from 'node:fs/promises';
 import {
   runWorkflowWithSmithers,

--- a/plugins/plugin-workflow/__tests__/fixtures/workflows.ts
+++ b/plugins/plugin-workflow/__tests__/fixtures/workflows.ts
@@ -1,3 +1,4 @@
+/** Builders for workflow definitions, nodes, executions, and match results used across the plugin's tests. */
 import type {
   WorkflowCredential,
   WorkflowDefinition,

--- a/plugins/plugin-workflow/__tests__/helpers/mockRuntime.ts
+++ b/plugins/plugin-workflow/__tests__/helpers/mockRuntime.ts
@@ -1,3 +1,4 @@
+/** Deterministic mock `IAgentRuntime` plus message/state builders for unit tests — services, settings, and `useModel` are stubbed. */
 import { mock } from 'bun:test';
 import type { IAgentRuntime, Memory, State } from '@elizaos/core';
 

--- a/plugins/plugin-workflow/__tests__/helpers/mockService.ts
+++ b/plugins/plugin-workflow/__tests__/helpers/mockService.ts
@@ -1,3 +1,4 @@
+/** Builds a mock `WorkflowService` with stubbed generation/CRUD methods for route and provider tests. */
 import { mock } from 'bun:test';
 import type { WorkflowService } from '../../src/services/workflow-service';
 import { createExecution, createWorkflowResponse } from '../fixtures/workflows';

--- a/plugins/plugin-workflow/__tests__/integration/providers/providers.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/providers/providers.test.ts
@@ -1,3 +1,4 @@
+/** Integration coverage for the three workflow providers against a mocked WorkflowService (deterministic, no live model). */
 import { describe, expect, mock, test } from 'bun:test';
 import { activeWorkflowsProvider } from '../../../src/providers/activeWorkflows';
 import { pendingDraftProvider } from '../../../src/providers/pendingDraft';

--- a/plugins/plugin-workflow/__tests__/unit/catalog.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/catalog.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the node-catalog search/lookup helpers over the bundled catalog (deterministic). */
 import { describe, expect, test } from 'bun:test';
 import {
   filterNodesByIntegrationSupport,

--- a/plugins/plugin-workflow/__tests__/unit/clarification.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/clarification.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for clarification coercion and catalog-clarification detection helpers (deterministic). */
 import { describe, expect, test } from 'bun:test';
 import type { ClarificationRequest } from '../../src/types';
 import {

--- a/plugins/plugin-workflow/__tests__/unit/context.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/context.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `buildConversationContext` message flattening (deterministic). */
 import { describe, expect, test } from 'bun:test';
 import { buildConversationContext } from '../../src/utils/context';
 import { createMockMessage, createMockState } from '../helpers/mockRuntime';

--- a/plugins/plugin-workflow/__tests__/unit/credentialResolver.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/credentialResolver.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `resolveCredentials` matching required node credentials against stored mappings (deterministic, mocked store). */
 import { describe, expect, mock, test } from 'bun:test';
 import type {
   CredentialProvider,

--- a/plugins/plugin-workflow/__tests__/unit/embeddedWorkflowService.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/embeddedWorkflowService.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for EmbeddedWorkflowService CRUD and persistence against a real PGlite-backed Drizzle store. */
 import { describe, expect, test } from 'bun:test';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';

--- a/plugins/plugin-workflow/__tests__/unit/evaluation-samples.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/evaluation-samples.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `buildWorkflowEvaluationSuite` JSONL sampling from executions (deterministic). */
 import { describe, expect, test } from 'bun:test';
 import { buildWorkflowEvaluationSuite } from '../../src/utils/evaluation-samples';
 import { createExecution, createWorkflowResponse } from '../fixtures/workflows';

--- a/plugins/plugin-workflow/__tests__/unit/generation.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/generation.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the RAG generation helpers (keyword extraction, intent, field/parameter correction) with a mocked model. */
 import { describe, expect, mock, test } from 'bun:test';
 import type {
   NodeDefinition,

--- a/plugins/plugin-workflow/__tests__/unit/outputSchema.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/outputSchema.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for node output-schema loading and field-path/operation lookups (deterministic). */
 import { describe, expect, test } from 'bun:test';
 import type { SchemaContent } from '../../src/types/index';
 import {

--- a/plugins/plugin-workflow/__tests__/unit/register-routes.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/register-routes.test.ts
@@ -1,3 +1,4 @@
+/** Unit test that importing `register-routes` registers the plugin's app route loader (mocked core registry). */
 import { describe, expect, it, mock } from 'bun:test';
 
 const registerAppRoutePluginLoader = mock(() => {});

--- a/plugins/plugin-workflow/__tests__/unit/respond-to-event.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/respond-to-event.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for EmbeddedWorkflowService event-triggered runs against a real PGlite-backed store, capturing emitted memories. */
 import { describe, expect, mock, test } from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';

--- a/plugins/plugin-workflow/__tests__/unit/routes/automations.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/routes/automations.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the `/api/automations` combined-view builder over an in-memory task/room runtime (deterministic). */
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { ServerResponse } from 'node:http';
 import type { AgentRuntime, Room, Task, UUID } from '@elizaos/core';

--- a/plugins/plugin-workflow/__tests__/unit/routes/executions.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/routes/executions.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the execution query route handlers against a mocked WorkflowService (deterministic). */
 import { describe, expect, mock, test } from 'bun:test';
 import type { RouteRequest, RouteResponse } from '@elizaos/core';
 import { executionRoutes } from '../../../src/routes/executions';

--- a/plugins/plugin-workflow/__tests__/unit/routes/nodes.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/routes/nodes.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the node-catalog route handlers over the bundled catalog (deterministic). */
 import { describe, expect, test } from 'bun:test';
 import type { RouteRequest, RouteResponse } from '@elizaos/core';
 import { nodeRoutes } from '../../../src/routes/nodes';

--- a/plugins/plugin-workflow/__tests__/unit/routes/validation.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/routes/validation.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the workflow-validation route handler over fixture workflows (deterministic). */
 import { describe, expect, test } from 'bun:test';
 import type { RouteRequest, RouteResponse } from '@elizaos/core';
 import { validationRoutes } from '../../../src/routes/validation';

--- a/plugins/plugin-workflow/__tests__/unit/routes/workbench-todos.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/routes/workbench-todos.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the workbench-todos route handler against an in-memory task-backed runtime (deterministic). */
 import { beforeEach, describe, expect, test } from 'bun:test';
 import type { AgentRuntime, Task, UUID } from '@elizaos/core';
 import { handleWorkbenchTodosRoutes } from '../../../src/routes/workbench-todos';

--- a/plugins/plugin-workflow/__tests__/unit/smithers-runtime.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/smithers-runtime.test.ts
@@ -1,3 +1,4 @@
+/** Integration test that spawns the smithers-runtime fixture as a child process and asserts on its real Smithers execution output. */
 import { describe, expect, it } from 'bun:test';
 import { spawn } from 'node:child_process';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';

--- a/plugins/plugin-workflow/__tests__/unit/validateAndRepair.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/validateAndRepair.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `validateAndRepair` node and output validation over fixture node definitions (deterministic). */
 import { describe, expect, test } from 'bun:test';
 import type { NodeDefinition, RuntimeContext, WorkflowDefinition } from '../../src/types/index';
 import { validateAndRepair } from '../../src/utils/validateAndRepair';

--- a/plugins/plugin-workflow/__tests__/unit/workflow-action.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-action.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the WORKFLOW action's op dispatch against a mocked WorkflowService (deterministic). */
 import { describe, expect, mock, test } from 'bun:test';
 import type { HandlerCallback, HandlerOptions, IAgentRuntime, Memory } from '@elizaos/core';
 import { workflowAction } from '../../src/actions/workflow';

--- a/plugins/plugin-workflow/__tests__/unit/workflow-clarification.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-clarification.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for clarification coercion, resolution application, and dot-path set helpers (deterministic). */
 import { describe, expect, test } from 'bun:test';
 import {
   applyResolutions,

--- a/plugins/plugin-workflow/__tests__/unit/workflow-dispatch.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-dispatch.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for WORKFLOW_DISPATCH service creation, registration, and dispatch (deterministic, mocked core). */
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import * as actualCore from '@elizaos/core';
 import { logger } from '@elizaos/core';

--- a/plugins/plugin-workflow/__tests__/unit/workflow-task-worker.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-task-worker.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the workflow trigger task worker firing scheduled runs against a real PGlite-backed EmbeddedWorkflowService. */
 import { describe, expect, setDefaultTimeout, test } from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';

--- a/plugins/plugin-workflow/__tests__/unit/workflow.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the workflow validation and repair helpers (node inputs, parameters, output refs, positioning) — deterministic. */
 import { describe, expect, test } from 'bun:test';
 import type { WorkflowDefinition, WorkflowNode } from '../../src/types/index';
 import {

--- a/plugins/plugin-workflow/__tests__/unit/workflowGenerationPrompt.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflowGenerationPrompt.test.ts
@@ -1,3 +1,4 @@
+/** Assertions locking in the name-to-id resolution rules embedded in the WORKFLOW_GENERATION_SYSTEM_PROMPT string (deterministic). */
 import { describe, expect, test } from 'bun:test';
 import { WORKFLOW_GENERATION_SYSTEM_PROMPT } from '../../src/utils/workflow-prompts/workflowGeneration';
 

--- a/plugins/plugin-workflow/src/actions/index.ts
+++ b/plugins/plugin-workflow/src/actions/index.ts
@@ -1,2 +1,3 @@
+/** Barrel for the plugin's actions: EVAL_CODE and the umbrella WORKFLOW action. */
 export { evalCodeAction } from './eval-code';
 export { workflowAction } from './workflow';

--- a/plugins/plugin-workflow/src/db/index.ts
+++ b/plugins/plugin-workflow/src/db/index.ts
@@ -1,3 +1,4 @@
+/** Re-exports the Drizzle workflow schema tables and `workflowSchema` from ./schema. */
 export {
   credentialMappings,
   embeddedCredentials,

--- a/plugins/plugin-workflow/src/db/schema.ts
+++ b/plugins/plugin-workflow/src/db/schema.ts
@@ -1,3 +1,13 @@
+/**
+ * Drizzle schema for the plugin's Postgres tables, grouped under the `workflow`
+ * pgSchema: credential mappings, workflows, workflow revisions, executions,
+ * embedded credentials, and tags.
+ *
+ * Registered on the plugin's `schema` field so the runtime provisions and
+ * migrates these tables. EmbeddedWorkflowService reads and writes them directly
+ * as both the CRUD store and the execution log; WorkflowCredentialStore owns the
+ * (userId, credType) → credential-id mappings table.
+ */
 import { sql } from 'drizzle-orm';
 import {
   boolean,

--- a/plugins/plugin-workflow/src/index.ts
+++ b/plugins/plugin-workflow/src/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Plugin definition and init for the in-process workflow engine. Wires the
+ * WORKFLOW/EVAL_CODE actions, the workflow providers, the Drizzle schema, and the
+ * services (WorkflowService, EmbeddedWorkflowService, credential store,
+ * WORKFLOW_DISPATCH). init registers the dispatch service so trigger tasks can
+ * fire workflows without the agent action layer; dispose stops long-lived
+ * services. Default-enabled (opt out with `workflow.enabled: false`).
+ */
 import { type IAgentRuntime, logger, type Plugin } from '@elizaos/core';
 import { evalCodeAction, workflowAction } from './actions/index';
 import * as dbSchema from './db/index';

--- a/plugins/plugin-workflow/src/providers/index.ts
+++ b/plugins/plugin-workflow/src/providers/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the workflow providers surfaced to the agent's prompt. */
 export { activeWorkflowsProvider } from './activeWorkflows';
 export { pendingDraftProvider } from './pendingDraft';
 export { workflowStatusProvider } from './workflowStatus';

--- a/plugins/plugin-workflow/src/providers/workflowStatus.ts
+++ b/plugins/plugin-workflow/src/providers/workflowStatus.ts
@@ -1,3 +1,7 @@
+/**
+ * `workflow_status` provider: lists each user's workflows with their last
+ * execution status for the automation/connectors contexts (ADMIN-gated).
+ */
 import { type IAgentRuntime, logger, type Memory, type Provider, type State } from '@elizaos/core';
 import { WORKFLOW_SERVICE_TYPE, type WorkflowService } from '../services/index';
 

--- a/plugins/plugin-workflow/src/register-routes.ts
+++ b/plugins/plugin-workflow/src/register-routes.ts
@@ -1,3 +1,9 @@
+/**
+ * Side-effect module that registers the plugin's rawPath route plugin
+ * (`@elizaos/plugin-workflow:routes`) with the app-route-plugin-registry, so the
+ * host mounts the `/api/workflow/*` and `/api/automations` endpoints. `index.ts`
+ * imports the exported flag to keep bundlers from dropping this registration.
+ */
 import { registerAppRoutePluginLoader } from '@elizaos/core';
 
 registerAppRoutePluginLoader('@elizaos/plugin-workflow:routes', async () => {

--- a/plugins/plugin-workflow/src/routes/embedded-webhooks.ts
+++ b/plugins/plugin-workflow/src/routes/embedded-webhooks.ts
@@ -1,3 +1,9 @@
+/**
+ * Plugin-relative route handlers for trigger-node webhooks, mounted under
+ * `/workflow/webhooks/:path` for every HTTP method. Inbound requests are handed
+ * to the EmbeddedWorkflowService, which matches the path against active webhook
+ * trigger nodes and starts the corresponding execution.
+ */
 import type { IAgentRuntime, Route, RouteRequest, RouteResponse } from '@elizaos/core';
 import {
   EMBEDDED_WORKFLOW_SERVICE_TYPE,

--- a/plugins/plugin-workflow/src/routes/executions.ts
+++ b/plugins/plugin-workflow/src/routes/executions.ts
@@ -1,3 +1,8 @@
+/**
+ * Plugin-relative route handlers for querying workflow executions, mounted under
+ * `/workflow/executions`. Reads the execution log through WorkflowService; the
+ * runtime prefixes these non-rawPath routes with the plugin name.
+ */
 import type { IAgentRuntime, Route, RouteRequest, RouteResponse } from '@elizaos/core';
 import { getService, validateLimit } from './_helpers';
 

--- a/plugins/plugin-workflow/src/routes/index.ts
+++ b/plugins/plugin-workflow/src/routes/index.ts
@@ -1,3 +1,4 @@
+/** Assembles the plugin-relative workflow route table (validation, nodes, executions, webhooks) mounted under `/workflow/*`. */
 import type { Route } from '@elizaos/core';
 import { embeddedWebhookRoutes } from './embedded-webhooks';
 import { executionRoutes } from './executions';
@@ -7,9 +8,8 @@ import { validationRoutes } from './validation';
 export { type AutomationsRouteContext, handleAutomationsRoutes } from './automations';
 
 // Workflow CRUD is served canonically by the rawPath `/api/workflow/*` surface
-// (plugin-routes.ts -> routes/workflow-routes.ts). The former plugin-relative
-// `/workflows*` CRUD duplicate (routes/workflows.ts) was removed in #12177.
-// The relative routes below have no rawPath twin, so they stay here.
+// (plugin-routes.ts -> routes/workflow-routes.ts). The relative routes below
+// have no rawPath twin, so they stay here.
 export const workflowRoutes: Route[] = [
   ...validationRoutes,
   ...nodeRoutes,

--- a/plugins/plugin-workflow/src/routes/nodes.ts
+++ b/plugins/plugin-workflow/src/routes/nodes.ts
@@ -1,3 +1,9 @@
+/**
+ * Plugin-relative route handlers for the node catalog, mounted under
+ * `/workflow/nodes`. Serves the bundled catalog (search, list, per-type lookup)
+ * filtered by integration support, augmented with the node types the
+ * EmbeddedWorkflowService has registered at runtime.
+ */
 import type { IAgentRuntime, Route, RouteRequest, RouteResponse } from '@elizaos/core';
 import {
   EMBEDDED_WORKFLOW_SERVICE_TYPE,

--- a/plugins/plugin-workflow/src/routes/validation.ts
+++ b/plugins/plugin-workflow/src/routes/validation.ts
@@ -1,3 +1,8 @@
+/**
+ * Plugin-relative route handler for `POST /workflow/workflows/validate`, which
+ * validates a workflow definition (nodes, connections, parameters, inputs)
+ * without deploying it and returns the collected errors.
+ */
 import type { IAgentRuntime, Route, RouteRequest, RouteResponse } from '@elizaos/core';
 import type { WorkflowDefinition } from '../types/index';
 import { validateNodeInputs, validateNodeParameters, validateWorkflow } from '../utils/workflow';

--- a/plugins/plugin-workflow/src/routes/workflow-routes.ts
+++ b/plugins/plugin-workflow/src/routes/workflow-routes.ts
@@ -1,3 +1,14 @@
+/**
+ * Central dispatcher for the rawPath `/api/workflow/*` surface: workflow CRUD,
+ * draft generation, clarification resolution, activate/deactivate, executions,
+ * and engine status. `handleWorkflowRoutes` inspects method + pathname and
+ * delegates to WorkflowService, building responses directly in-process with no
+ * proxy or HTTP sidecar.
+ *
+ * These routes are registered verbatim (no plugin-name prefix) via
+ * plugin-routes.ts and the app-route-plugin-registry; clarification handling
+ * threads pending catalog snapshots through the workflow-clarification lib.
+ */
 import type http from 'node:http';
 import type { AgentRuntime } from '@elizaos/core';
 import {

--- a/plugins/plugin-workflow/src/schemas/feasibility.ts
+++ b/plugins/plugin-workflow/src/schemas/feasibility.ts
@@ -1,3 +1,4 @@
+/** JSON schema for the feasibility-check LLM call: `{ feasible, reason }`. */
 export const feasibilitySchema = {
   type: 'object',
   properties: {

--- a/plugins/plugin-workflow/src/schemas/index.ts
+++ b/plugins/plugin-workflow/src/schemas/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the LLM structured-output JSON schemas used by the generation pipeline. */
 export { draftIntentSchema } from './draftIntent';
 export { feasibilitySchema } from './feasibility';
 export { keywordExtractionSchema } from './keywordExtraction';

--- a/plugins/plugin-workflow/src/schemas/keywordExtraction.ts
+++ b/plugins/plugin-workflow/src/schemas/keywordExtraction.ts
@@ -1,3 +1,4 @@
+/** JSON schema for the keyword-extraction LLM call: up to five node-search keywords. */
 export const keywordExtractionSchema = {
   type: 'object',
   properties: {

--- a/plugins/plugin-workflow/src/schemas/workflowMatching.ts
+++ b/plugins/plugin-workflow/src/schemas/workflowMatching.ts
@@ -1,3 +1,4 @@
+/** JSON schema for the workflow-matching LLM call: matched workflow id, confidence, and scored candidates. */
 export const workflowMatchingSchema = {
   type: 'object',
   properties: {

--- a/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
+++ b/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
@@ -1,3 +1,17 @@
+/**
+ * In-process workflow execution engine and persistence layer. A single
+ * `Service` (type `embedded_workflow_service`) is simultaneously the CRUD store
+ * for workflow definitions, credentials, tags, and revisions, and the runtime
+ * that executes node graphs — there is no external sidecar or HTTP boundary.
+ *
+ * Node execution delegates to the Smithers orchestrator (see smithers-runtime);
+ * sandboxed JS steps run through QuickJS via `evalQuickJsCode`. The service owns
+ * the scheduler for cron/interval triggers (scheduling idempotency keys guard
+ * against duplicate concurrent runs) and the webhook matcher that route handlers
+ * dispatch inbound requests to. Persistence is Drizzle-over-Postgres against the
+ * tables in ../db/schema; the trigger task-name/tag contract is mirrored from
+ * `packages/agent` to avoid a dependency cycle.
+ */
 import { createHash, randomUUID } from 'node:crypto';
 import {
   type IAgentRuntime,

--- a/plugins/plugin-workflow/src/services/index.ts
+++ b/plugins/plugin-workflow/src/services/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the plugin's services: embedded execution engine, credential store, dispatch, and the WorkflowService facade. */
 export {
   EMBEDDED_WORKFLOW_SERVICE_TYPE,
   EmbeddedWorkflowService,

--- a/plugins/plugin-workflow/src/services/smithers-runtime.ts
+++ b/plugins/plugin-workflow/src/services/smithers-runtime.ts
@@ -1,3 +1,14 @@
+/**
+ * Adapter that runs a workflow's node graph through the Smithers orchestrator.
+ * Translates the plugin's WorkflowDefinition into the Smithers execution plan,
+ * spawns a Bun worker (Smithers needs `bun:sqlite`) to run it, and maps the
+ * result back to a WorkflowExecution with engine metrics.
+ *
+ * Consumed by EmbeddedWorkflowService as the node-execution backend. Reads
+ * optional `SMITHERS_DB_*`, `ELIZA_SMITHERS_RUN_PAYLOAD`, and `BUN_BIN` env
+ * vars. Failed delegated nodes are echoed before Smithers' wrapper error so
+ * execution diagnostics retain the original node error.
+ */
 import { spawn } from 'node:child_process';
 import { mkdir, readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';

--- a/plugins/plugin-workflow/src/services/workflow-service.ts
+++ b/plugins/plugin-workflow/src/services/workflow-service.ts
@@ -1,3 +1,17 @@
+/**
+ * Public-facing WorkflowService (type `workflow`): the RAG generation pipeline
+ * and CRUD facade the `WORKFLOW` action and rawPath routes call into. Turns a
+ * natural-language prompt into a runnable workflow via keyword extraction →
+ * catalog search → LLM generation → validate/repair → deploy, then persists and
+ * activates it.
+ *
+ * Generation and modification both run up to three LLM-retry passes through
+ * `validateAndRepair` + `fixWorkflowErrors` to correct typeVersion
+ * hallucinations, missing credential blocks, and invalid output references
+ * before deploy. Deployment and execution are delegated to the
+ * EmbeddedWorkflowService; credential resolution goes through the registered
+ * WorkflowCredentialStore.
+ */
 import { type IAgentRuntime, logger, Service } from '@elizaos/core';
 import type {
   NodeDefinition,

--- a/plugins/plugin-workflow/src/trigger-routes.ts
+++ b/plugins/plugin-workflow/src/trigger-routes.ts
@@ -1,3 +1,9 @@
+/**
+ * Trigger route helpers and shared types for the trigger surface (cron/schedule
+ * triggers and task-to-workflow promotion). Exposes `handleTriggerRoutes`, which
+ * the route dispatcher consults, plus the metadata/summary shapes describing a
+ * trigger task's persisted state and its list view.
+ */
 import crypto from 'node:crypto';
 import {
   type TriggerRunRecord as CoreTriggerRunRecord,

--- a/plugins/plugin-workflow/src/types/index.ts
+++ b/plugins/plugin-workflow/src/types/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Core workflow domain and transport types (WorkflowDefinition, WorkflowNode,
+ * WorkflowExecution, drafts, credential-resolution shapes), the error classes,
+ * and the service-type and event-name constants shared across the plugin.
+ */
 import type { EventPayload } from '@elizaos/core';
 import type {
   INode,

--- a/plugins/plugin-workflow/src/types/workflow-contracts.ts
+++ b/plugins/plugin-workflow/src/types/workflow-contracts.ts
@@ -1,3 +1,8 @@
+/**
+ * n8n-style node contract types (INode, INodeProperties, INodeTypeDescription,
+ * INodeCredentials, IWorkflowSettings) describing the shape of catalog nodes and
+ * their parameters, mirroring the vendor node schema the generator targets.
+ */
 export type GenericValue = string | object | number | boolean | undefined | null;
 
 export type NodeParameterValue = string | number | boolean | undefined | null;

--- a/plugins/plugin-workflow/src/utils/context.ts
+++ b/plugins/plugin-workflow/src/utils/context.ts
@@ -1,3 +1,4 @@
+/** Conversation-context helpers for workflow actions: flattens recent messages into a prompt string and resolves a user's tag name. */
 import type { IAgentRuntime, Memory, State, UUID } from '@elizaos/core';
 
 export function buildConversationContext(message: Memory, state: State | undefined): string {

--- a/plugins/plugin-workflow/src/utils/credentialResolver.ts
+++ b/plugins/plugin-workflow/src/utils/credentialResolver.ts
@@ -1,3 +1,8 @@
+/**
+ * Resolves the credentials a generated workflow's nodes need — matching each
+ * required credential type against the user's stored mappings and reporting the
+ * connections still missing so the action can prompt the user to connect them.
+ */
 import { logger } from '@elizaos/core';
 import type {
   CredentialProvider,

--- a/plugins/plugin-workflow/src/utils/evaluation-samples.ts
+++ b/plugins/plugin-workflow/src/utils/evaluation-samples.ts
@@ -1,3 +1,8 @@
+/**
+ * Builds compact evaluation suites from a workflow's past executions — sampling
+ * node inputs/outputs into bounded JSONL cases for the Smithers eval / GEPA
+ * optimize flows. Preview and depth/size limits keep each case small.
+ */
 import type {
   WorkflowDefinitionResponse,
   WorkflowEvaluationSample,

--- a/plugins/plugin-workflow/src/utils/execution-diagnostics.ts
+++ b/plugins/plugin-workflow/src/utils/execution-diagnostics.ts
@@ -1,3 +1,8 @@
+/**
+ * Formats a workflow execution into the fields the run UI renders — per-node run
+ * rows, a status label with tone, duration in the right unit, and the first
+ * surfaced node error.
+ */
 import type { WorkflowExecution } from '../types/index';
 
 export type WorkflowExecutionTone = 'success' | 'danger' | 'warning' | 'muted';

--- a/plugins/plugin-workflow/src/utils/generation.ts
+++ b/plugins/plugin-workflow/src/utils/generation.ts
@@ -1,3 +1,9 @@
+/**
+ * LLM steps of the workflow RAG pipeline: keyword extraction, feasibility check,
+ * draft-intent classification, workflow generation, and the field/parameter
+ * correction passes. Each call pairs a prompt template with its structured-output
+ * schema and runs through `runtime.useModel`.
+ */
 import type { GenerateTextParams } from '@elizaos/core';
 import { type IAgentRuntime, logger, ModelType } from '@elizaos/core';
 import {

--- a/plugins/plugin-workflow/src/utils/workflow-prompts/actionResponse.ts
+++ b/plugins/plugin-workflow/src/utils/workflow-prompts/actionResponse.ts
@@ -1,3 +1,4 @@
+/** System prompt that formats the workflow assistant's user-facing replies (preview, clarification, deploy-success, auth-required). */
 export const ACTION_RESPONSE_SYSTEM_PROMPT = `You format responses for a workflow assistant.
 
 Rules:

--- a/plugins/plugin-workflow/src/utils/workflow-prompts/draftIntent.ts
+++ b/plugins/plugin-workflow/src/utils/workflow-prompts/draftIntent.ts
@@ -1,3 +1,4 @@
+/** System prompt that classifies a user's reply to a workflow draft as confirm / cancel / modify / new. */
 export const DRAFT_INTENT_SYSTEM_PROMPT = `Determine what the user wants to do with this workflow draft. A draft has been generated and shown to the user as a preview.
 
 Your job: determine what the user wants to do based on their message. The user may write in ANY language — interpret the meaning, not specific keywords.

--- a/plugins/plugin-workflow/src/utils/workflow-prompts/feasibilityCheck.ts
+++ b/plugins/plugin-workflow/src/utils/workflow-prompts/feasibilityCheck.ts
@@ -1,3 +1,4 @@
+/** Prompt that judges whether a workflow request is fulfillable given the restricted set of available integrations. */
 export const FEASIBILITY_CHECK_PROMPT = `You are evaluating whether a user's workflow request can be fulfilled with a restricted set of integrations.
 
 Some integrations the user might need are NOT available on this platform. You must decide if the request is still feasible with what IS available.

--- a/plugins/plugin-workflow/src/utils/workflow-prompts/fieldCorrection.ts
+++ b/plugins/plugin-workflow/src/utils/workflow-prompts/fieldCorrection.ts
@@ -1,3 +1,4 @@
+/** System and user prompts that repair an invalid `$json` field reference to a valid path from the source node's output schema. */
 export const FIELD_CORRECTION_SYSTEM_PROMPT = `Fix the workflows field reference to use a valid field path.
 
 You will receive:

--- a/plugins/plugin-workflow/src/utils/workflow-prompts/index.ts
+++ b/plugins/plugin-workflow/src/utils/workflow-prompts/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the workflow LLM prompt templates. */
 export { ACTION_RESPONSE_SYSTEM_PROMPT } from './actionResponse';
 export { DRAFT_INTENT_SYSTEM_PROMPT } from './draftIntent';
 export { FEASIBILITY_CHECK_PROMPT } from './feasibilityCheck';

--- a/plugins/plugin-workflow/src/utils/workflow-prompts/keywordExtraction.ts
+++ b/plugins/plugin-workflow/src/utils/workflow-prompts/keywordExtraction.ts
@@ -1,3 +1,4 @@
+/** System prompt that extracts up to five node-search keywords from a workflow request. */
 export const KEYWORD_EXTRACTION_SYSTEM_PROMPT = `Extract relevant search terms for finding workflow nodes.
 
 Given a user prompt describing an workflow, extract up to 5 concise keywords or phrases that best represent the core actions, services, or data transformations involved.

--- a/plugins/plugin-workflow/src/utils/workflow-prompts/parameterCorrection.ts
+++ b/plugins/plugin-workflow/src/utils/workflow-prompts/parameterCorrection.ts
@@ -1,3 +1,4 @@
+/** System and user prompts that remap generated node parameters onto the node's valid property names and structure. */
 export const PARAM_CORRECTION_SYSTEM_PROMPT = `Fix workflows node parameters to match the node's property definition.
 
 You receive:

--- a/plugins/plugin-workflow/src/utils/workflow-prompts/workflowGeneration.ts
+++ b/plugins/plugin-workflow/src/utils/workflow-prompts/workflowGeneration.ts
@@ -1,3 +1,4 @@
+/** System prompt defining the workflow JSON schema and generation rules the model follows to produce a runnable workflow. */
 export const WORKFLOW_GENERATION_SYSTEM_PROMPT = `## Workflow AI Definition: Core Concepts
 
 ### 1. **Workflow**

--- a/plugins/plugin-workflow/src/utils/workflow-prompts/workflowMatching.ts
+++ b/plugins/plugin-workflow/src/utils/workflow-prompts/workflowMatching.ts
@@ -1,3 +1,4 @@
+/** System prompt that matches a user request to the best of their existing workflows with a confidence grade. */
 export const WORKFLOW_MATCHING_SYSTEM_PROMPT = `Match the user's request to the most appropriate workflow from their available workflows.
 
 Consider:

--- a/plugins/plugin-workflow/src/utils/workflow.ts
+++ b/plugins/plugin-workflow/src/utils/workflow.ts
@@ -1,3 +1,9 @@
+/**
+ * Workflow validation and repair helpers: validates node inputs, parameters, and
+ * output references against the node catalog, corrects option parameters and
+ * expression prefixes, and lays out node positions. Consumed by the generation
+ * pipeline's validate/repair loop and the validation route.
+ */
 import { logger } from '@elizaos/core';
 import type {
   NodeDefinition,


### PR DESCRIPTION
## Summary

Comment-cleanup batch **B16** (parent #12181, sub-issue #12246): purpose-explaining prose file headers on previously header-less files + churn/change-narration removal across the agent-orchestration, coding, and training plugins.

**Comments and whitespace only — zero functional diff.** No code token changes, no file adds/deletes/renames, no license-block edits.

### Scope covered
`plugin-agent-orchestrator`, `plugin-computeruse`, `plugin-coding-tools`, `plugin-codex-cli`, `plugin-mcp`, `plugin-agent-skills`, `plugin-gitpathologist`, `plugin-trajectory-logger`, `plugin-task-coordinator`, `plugin-workflow`, `plugin-training`, `plugin-benchmarks`, `app-model-tester`, `plugin-shell`, `plugin-pty`, `plugin-cli`.

### What changed per file
- Header-less files now open with one accurate `/** … */` block phrased in each plugin's architecture terms (sub-agent/PTY/coding-task lifecycle, embedded workflow engine, APOLLO/DSPy training backends, OSWorld/mobile/sandbox actors, MCP client/server, multi-agent task coordination), guided by each plugin's `CLAUDE.md`. Placement: after any `#!` shebang, below any license block, before imports. Files whose first export already carried an accurate JSDoc-after-import were left as-is.
- Churn removed/rewritten: change-narration, next-line restatement, commented-out code, migration stories → present-tense fact where useful, else deleted.

## Validation

- **`bun run check:comment-only` → PASS**: `494 source file(s) changed; every code token identical to origin/develop. Comments only.` (TS-parser code-token equality — machine proof of zero functional diff, per parent #12181 WI-2).
- Rebased onto current `develop`, clean.

## Evidence rows
- Real-LLM trajectory / backend logs / screenshots — **N/A** (no runtime/UI/prompt behavior changed; comments only, machine-proven).

Closes #12246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)