### PR TITLE
fix(#12321): remove HF stage publish bypasses

### DIFF
--- a/.github/issue-evidence/12216-stage4-remove-hf-stage-bypasses/README.md
+++ b/.github/issue-evidence/12216-stage4-remove-hf-stage-bypasses/README.md
@@ -1,0 +1,28 @@
+# Stage 4 Remove HF Stage Bypasses Evidence
+
+Issue: #12321
+
+PR scope:
+
+- Remove `--allow-missing` from the per-tier HF model repo publisher so blocked bundle plans always exit non-zero.
+- Remove `--skip-hash-verify` so publish planning always hashes and verifies staged artifacts.
+- Remove the same bypass options from the Node staging wrapper and update the shell helper text.
+
+Verification:
+
+```bash
+grep -R "allow-missing\\|skip-hash-verify\\|allowMissing\\|skipHashVerify" -n packages/training/scripts/publish packages/training/scripts/test_hf_publish.py | head -100
+# no output
+
+python3 -m pytest packages/training/scripts/publish/test_publish_eliza1_model_repo.py -q -k 'dry_run_blocks_missing_with_report or checksum_mismatch or harness_eval_missing'
+# .. [100%] 2 passed
+
+python3 -m pytest packages/training/scripts/publish/test_publish_eliza1_model_repo.py -q
+# ................. [100%] 17 passed
+
+python3 -m py_compile packages/training/scripts/publish/publish_eliza1_model_repo.py packages/training/scripts/publish/test_publish_eliza1_model_repo.py
+# passed
+
+node --check packages/training/scripts/publish/eliza1-hf-stage.mjs
+# passed
+```

--- a/packages/training/scripts/publish/eliza1-hf-push.sh
+++ b/packages/training/scripts/publish/eliza1-hf-push.sh
@@ -78,7 +78,7 @@ To dry-run via the underlying CLI:
   cd packages/training && \
     python3 -m scripts.publish.publish_eliza1_model_repo \
       --bundles-root ~/.eliza/local-inference/models \
-      --dry-run --allow-missing --report /tmp/eliza1-hf-plan.json
+      --dry-run --report /tmp/eliza1-hf-plan.json
 
 See packages/training/reports/eliza1-hf-readiness-2026-05-14.md for the
 per-tier blocker ledger before paying for an upload.

--- a/packages/training/scripts/publish/eliza1-hf-stage.mjs
+++ b/packages/training/scripts/publish/eliza1-hf-stage.mjs
@@ -16,8 +16,8 @@
  *   node packages/training/scripts/publish/eliza1-hf-stage.mjs --tier 2b --tier 4b
  *
  * Exit codes mirror the Python publisher:
- *   0 - every tier uploadable (or --allow-missing was passed)
- *   2 - at least one tier has unresolved blockers (default behaviour)
+ *   0 - every tier uploadable
+ *   2 - at least one tier has unresolved blockers
  *   other - Python launch / interpreter failure
  */
 
@@ -42,9 +42,7 @@ function parseArgs(argv) {
     bundlesRoot: DEFAULT_BUNDLES_ROOT,
     tiers: [],
     report: null,
-    allowMissing: true,
     strictVoicePolicy: false,
-    skipHashVerify: false,
     extra: [],
   };
   for (let i = 0; i < argv.length; i++) {
@@ -59,17 +57,12 @@ function parseArgs(argv) {
       out.tiers.push(argv[++i]);
     } else if (arg === "--report") {
       out.report = argv[++i];
-    } else if (arg === "--no-allow-missing") {
-      out.allowMissing = false;
     } else if (arg === "--strict-voice-policy") {
       out.strictVoicePolicy = true;
-    } else if (arg === "--skip-hash-verify") {
-      out.skipHashVerify = true;
     } else if (arg === "--help" || arg === "-h") {
       process.stdout.write(
         `Usage: node eliza1-hf-stage.mjs [--dry-run] [--bundles-root DIR] ` +
-          `[--tier TIER]... [--report PATH] [--strict-voice-policy] ` +
-          `[--skip-hash-verify] [--no-allow-missing]\n`,
+          `[--tier TIER]... [--report PATH] [--strict-voice-policy]\n`,
       );
       process.exit(0);
     } else {
@@ -113,9 +106,7 @@ function main() {
     args.push("--tier", tier);
   }
   if (opts.dryRun) args.push("--dry-run");
-  if (opts.allowMissing) args.push("--allow-missing");
   if (opts.strictVoicePolicy) args.push("--strict-voice-policy");
-  if (opts.skipHashVerify) args.push("--skip-hash-verify");
   if (opts.report) args.push("--report", opts.report);
   for (const extra of opts.extra) args.push(extra);
 

--- a/packages/training/scripts/publish/publish_eliza1_model_repo.py
+++ b/packages/training/scripts/publish/publish_eliza1_model_repo.py
@@ -882,13 +882,7 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--bundles-root", type=Path, default=DEFAULT_BUNDLES_ROOT)
     ap.add_argument("--tier", choices=TIERS, action="append", dest="tiers")
     ap.add_argument("--dry-run", action="store_true")
-    ap.add_argument("--allow-missing", action="store_true")
     ap.add_argument("--strict-voice-policy", action="store_true")
-    ap.add_argument(
-        "--skip-hash-verify",
-        action="store_true",
-        help="Only check manifest file presence; do not hash large GGUF files.",
-    )
     ap.add_argument(
         "--large-folder-upload",
         action="store_true",
@@ -903,7 +897,7 @@ def main(argv: list[str] | None = None) -> int:
         args.bundles_root,
         tiers,
         strict_voice_policy=args.strict_voice_policy,
-        verify_hashes=not args.skip_hash_verify,
+        verify_hashes=True,
     )
     _print_summary(plans, repo_id=args.repo_id, dry_run=args.dry_run)
 
@@ -922,7 +916,7 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     blockers = [p for p in plans if not p.uploadable]
-    if blockers and not args.allow_missing:
+    if blockers:
         return 2
     if not args.dry_run:
         token = _token()

--- a/packages/training/scripts/publish/test_publish_eliza1_model_repo.py
+++ b/packages/training/scripts/publish/test_publish_eliza1_model_repo.py
@@ -387,7 +387,7 @@ def test_plan_bundle_accepts_mtp_weight_claim_for_mtp_tier(tmp_path: Path):
     assert not any("weights lists MTP path" in e for e in plan.errors)
 
 
-def test_dry_run_allows_missing_with_report(tmp_path: Path, capsys):
+def test_dry_run_blocks_missing_with_report(tmp_path: Path, capsys):
     report = tmp_path / "report.json"
 
     rc = P.main(
@@ -397,12 +397,11 @@ def test_dry_run_allows_missing_with_report(tmp_path: Path, capsys):
             "--tier",
             "2b",
             "--dry-run",
-            "--allow-missing",
             "--report",
             str(report),
         ]
     )
 
-    assert rc == 0
+    assert rc == 2
     assert "Eliza-1 model repo publish plan" in capsys.readouterr().out
     assert json.loads(report.read_text())["plans"][0]["tier"] == "2b"


### PR DESCRIPTION
## Summary
- remove `--allow-missing` from the per-tier HF model repo publisher so blocked plans always exit non-zero
- remove `--skip-hash-verify` so staged artifacts are always hashed and verified
- remove both bypasses from the Node staging wrapper and update shell helper text

## Evidence
- `.github/issue-evidence/12216-stage4-remove-hf-stage-bypasses/README.md`
- `python3 -m pytest packages/training/scripts/publish/test_publish_eliza1_model_repo.py -q`
- `python3 -m py_compile packages/training/scripts/publish/publish_eliza1_model_repo.py packages/training/scripts/publish/test_publish_eliza1_model_repo.py`
- `node --check packages/training/scripts/publish/eliza1-hf-stage.mjs`
- `git diff --check origin/develop..HEAD`

Refs #12321