### PR TITLE
fix(agent): memory read + delete correctness — cluster-expanded search, uuid validation, delete-by-query

### DIFF
--- a/packages/agent/src/actions/memories.test.ts
+++ b/packages/agent/src/actions/memories.test.ts
@@ -1,18 +1,48 @@
+/**
+ * MEMORY action handler tests against a deterministic in-memory runtime that
+ * mimics the SQL adapter's contract: uuid params are type-checked like a
+ * postgres uuid column (bad ids throw a drizzle-style error carrying the raw
+ * SQL) and the relationships service exposes identity-cluster membership.
+ */
 import type { ActionResult, IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import { normalizeActionIdentifier } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { memoryAction } from "./memories";
 
 const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
 const USER_ID = "00000000-0000-0000-0000-0000000000bb" as UUID;
 const ROOM_ID = "00000000-0000-0000-0000-0000000000cc" as UUID;
+const SIBLING_ID = "00000000-0000-0000-0000-0000000000dd" as UUID;
 
 type StoredRow = { memory: Memory; tableName: string; unique?: boolean };
 
-function makeRuntime(): { runtime: IAgentRuntime; rows: StoredRow[] } {
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function assertUuidOrThrowLikeDrizzle(value: unknown, column: string): void {
+  if (value == null) return;
+  if (typeof value === "string" && UUID_RE.test(value)) return;
+  throw new Error(
+    `Failed query: select "id", "content" from "memories" where "${column}" = $1 -- params: ["${String(value)}"]; invalid input syntax for type uuid`,
+  );
+}
+
+function makeRuntime(options?: {
+  clusters?: Partial<Record<string, UUID[]>>;
+}): { runtime: IAgentRuntime; rows: StoredRow[] } {
   const rows: StoredRow[] = [];
   const runtime = {
     agentId: AGENT_ID,
     character: { name: "Eliza" },
+    getService: (name: string) => {
+      if (name === "relationships" && options?.clusters) {
+        return {
+          getMemberEntityIds: async (entityId: UUID) =>
+            options.clusters?.[entityId] ?? [],
+        };
+      }
+      return null;
+    },
     createMemory: async (
       memory: Memory,
       tableName: string,
@@ -25,16 +55,47 @@ function makeRuntime(): { runtime: IAgentRuntime; rows: StoredRow[] } {
       tableName: string;
       roomId?: UUID;
       entityId?: UUID;
-    }) =>
-      rows
+    }) => {
+      assertUuidOrThrowLikeDrizzle(params.roomId, "roomId");
+      assertUuidOrThrowLikeDrizzle(params.entityId, "entityId");
+      return rows
         .filter((row) => row.tableName === params.tableName)
         .filter((row) => !params.roomId || row.memory.roomId === params.roomId)
         .filter(
           (row) => !params.entityId || row.memory.entityId === params.entityId,
         )
-        .map((row) => row.memory),
+        .map((row) => row.memory);
+    },
+    getMemoryById: async (memoryId: UUID) => {
+      assertUuidOrThrowLikeDrizzle(memoryId, "id");
+      return rows.find((row) => row.memory.id === memoryId)?.memory ?? null;
+    },
+    deleteMemory: async (memoryId: UUID) => {
+      assertUuidOrThrowLikeDrizzle(memoryId, "id");
+      const index = rows.findIndex((row) => row.memory.id === memoryId);
+      if (index >= 0) rows.splice(index, 1);
+    },
   } as unknown as IAgentRuntime;
   return { runtime, rows };
+}
+
+function seedFact(
+  rows: StoredRow[],
+  fields: { text: string; entityId: UUID; roomId?: UUID },
+): UUID {
+  const id = crypto.randomUUID() as UUID;
+  rows.push({
+    memory: {
+      id,
+      entityId: fields.entityId,
+      agentId: AGENT_ID,
+      roomId: fields.roomId ?? ROOM_ID,
+      content: { text: fields.text },
+      createdAt: Date.now(),
+    } as Memory,
+    tableName: "facts",
+  });
+  return id;
 }
 
 function makeMessage(): Memory {
@@ -48,10 +109,12 @@ function makeMessage(): Memory {
   } as Memory;
 }
 
+type TestParams = Record<string, string | string[] | number | boolean>;
+
 async function runAction(
   runtime: IAgentRuntime,
   message: Memory,
-  parameters: Record<string, string | string[]>,
+  parameters: TestParams,
 ): Promise<ActionResult> {
   const result = await memoryAction.handler(runtime, message, undefined, {
     parameters,
@@ -63,7 +126,7 @@ async function runAction(
 async function runCreate(
   runtime: IAgentRuntime,
   message: Memory,
-  parameters: Record<string, string | string[]>,
+  parameters: TestParams,
 ): Promise<ActionResult> {
   return runAction(runtime, message, { action: "create", ...parameters });
 }
@@ -154,5 +217,212 @@ describe("MEMORY op:create", () => {
     const result = await runCreate(runtime, makeMessage(), { text: "   " });
     expect(result.success).toBe(false);
     expect(rows).toHaveLength(0);
+  });
+});
+
+describe("MEMORY op:search identity-cluster expansion", () => {
+  it("finds a fact stored under a cluster sibling of the requested entityId", async () => {
+    // Live failure shape: the FACTS provider surfaced "nubs plays guitar"
+    // (stored under sibling entity ids) while MEMORY search on the primary
+    // entityId reported "Found 0 (total 0)". Search must read through the
+    // same identity-cluster expansion the provider uses.
+    const { runtime, rows } = makeRuntime({
+      clusters: { [USER_ID]: [SIBLING_ID] },
+    });
+    seedFact(rows, { text: "nubs plays guitar", entityId: SIBLING_ID });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      entityId: USER_ID,
+      query: "guitar",
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { memories: Array<{ text: string }> };
+    expect(data.memories).toHaveLength(1);
+    expect(data.memories[0].text).toBe("nubs plays guitar");
+  });
+
+  it("still filters to the entity's own rows when no cluster resolver exists", async () => {
+    const { runtime, rows } = makeRuntime();
+    seedFact(rows, { text: "nubs plays guitar", entityId: USER_ID });
+    seedFact(rows, { text: "someone else surfs", entityId: SIBLING_ID });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      entityId: USER_ID,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { memories: Array<{ text: string }> };
+    expect(data.memories).toHaveLength(1);
+    expect(data.memories[0].text).toBe("nubs plays guitar");
+  });
+});
+
+describe("MEMORY uuid validation", () => {
+  it('handles roomId "general" without running the query or leaking SQL', async () => {
+    // The mock getMemories throws a drizzle-style error (raw SQL included)
+    // for any non-uuid id, so a passing test proves the query never ran.
+    const { runtime, rows } = makeRuntime();
+    seedFact(rows, { text: "nubs plays guitar", entityId: USER_ID });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      roomId: "general",
+    });
+
+    expect(result.success).toBe(false);
+    expect((result.data as { error: string }).error).toBe(
+      "MEMORY_INVALID_UUID",
+    );
+    expect(result.text).toContain('roomId "general"');
+    expect(result.text?.toLowerCase()).not.toContain("failed query");
+    expect(result.text?.toLowerCase()).not.toContain("select");
+  });
+
+  it("handles a partial-uuid entityId on search cleanly", async () => {
+    const { runtime } = makeRuntime();
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      entityId: "0b8db237",
+    });
+    expect(result.success).toBe(false);
+    expect((result.data as { error: string }).error).toBe(
+      "MEMORY_INVALID_UUID",
+    );
+    expect(result.text?.toLowerCase()).not.toContain("failed query");
+  });
+
+  it("handles a partial-uuid memoryId on delete cleanly", async () => {
+    const { runtime, rows } = makeRuntime();
+    seedFact(rows, { text: "nubs plays guitar", entityId: USER_ID });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "delete",
+      memoryId: "82bdd9bb",
+      confirm: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect((result.data as { error: string }).error).toBe(
+      "MEMORY_INVALID_UUID",
+    );
+    expect(result.text?.toLowerCase()).not.toContain("failed query");
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe("MEMORY op:delete by query", () => {
+  it("resolves the fact by text and deletes every duplicate row of it", async () => {
+    // Reflection dedup failures store the same fact several times (live: six
+    // copies of "nubs plays guitar" across two sibling entity ids). One
+    // logical fact -> all rows removed.
+    const { runtime, rows } = makeRuntime({
+      clusters: { [USER_ID]: [SIBLING_ID] },
+    });
+    seedFact(rows, { text: "nubs plays guitar", entityId: SIBLING_ID });
+    seedFact(rows, { text: "nubs plays guitar", entityId: SIBLING_ID });
+    seedFact(rows, { text: "nubs plays guitar", entityId: USER_ID });
+    seedFact(rows, { text: "nubs lives on a boat", entityId: USER_ID });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "delete",
+      query: "nubs plays guitar",
+      entityId: USER_ID,
+      confirm: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect((result.values as { deletedCount: number }).deletedCount).toBe(3);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].memory.content.text).toBe("nubs lives on a boat");
+  });
+
+  it("refuses an ambiguous query matching distinct memories and lists ids", async () => {
+    const { runtime, rows } = makeRuntime();
+    const idA = seedFact(rows, {
+      text: "nubs plays guitar",
+      entityId: USER_ID,
+    });
+    const idB = seedFact(rows, {
+      text: "nubs plays guitar hero on fridays",
+      entityId: USER_ID,
+    });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "delete",
+      query: "plays guitar",
+      confirm: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect((result.data as { error: string }).error).toBe(
+      "MEMORY_AMBIGUOUS_QUERY",
+    );
+    expect(result.text).toContain(idA);
+    expect(result.text).toContain(idB);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("returns a clean not-found when no stored memory matches", async () => {
+    const { runtime, rows } = makeRuntime();
+    seedFact(rows, { text: "nubs plays guitar", entityId: USER_ID });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "delete",
+      query: "rides a unicycle",
+      confirm: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect((result.data as { error: string }).error).toBe("MEMORY_NOT_FOUND");
+    expect(rows).toHaveLength(1);
+  });
+
+  it("still requires confirm:true before deleting by query", async () => {
+    const { runtime, rows } = makeRuntime();
+    seedFact(rows, { text: "nubs plays guitar", entityId: USER_ID });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "delete",
+      query: "nubs plays guitar",
+    });
+
+    expect(result.success).toBe(false);
+    expect((result.data as { error: string }).error).toBe(
+      "MEMORY_CONFIRMATION_REQUIRED",
+    );
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe("MEMORY routing aliases", () => {
+  it("resolves planner-generated LIST_MEMORIES / SEARCH_MEMORY to MEMORY", () => {
+    // Mirrors buildRuntimeActionLookup (core services/message.ts): canonical
+    // action names claim their normalized identifier first, then similes fill
+    // the remaining slots. Without these aliases a listing intent fell
+    // through to VIEWS and errored.
+    const lookup = new Map<string, string>();
+    const actions = [memoryAction];
+    for (const action of actions) {
+      const normalized = normalizeActionIdentifier(action.name);
+      if (normalized && !lookup.has(normalized))
+        lookup.set(normalized, action.name);
+    }
+    for (const action of actions) {
+      for (const simile of action.similes ?? []) {
+        const normalized = normalizeActionIdentifier(simile);
+        if (normalized && !lookup.has(normalized))
+          lookup.set(normalized, action.name);
+      }
+    }
+
+    expect(lookup.get(normalizeActionIdentifier("LIST_MEMORIES"))).toBe(
+      "MEMORY",
+    );
+    expect(lookup.get(normalizeActionIdentifier("SEARCH_MEMORY"))).toBe(
+      "MEMORY",
+    );
   });
 });

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -1,3 +1,11 @@
+/**
+ * MEMORY action: model-driven create/search/update/delete over the agent's
+ * stored memories. Reads MUST match the scope the FACTS provider uses —
+ * identity-cluster-expanded entity ids — or a fact the provider surfaces
+ * reads back as "0 stored items" here, and deletion becomes unreachable.
+ * All model-supplied ids are parsed before touching the database so a bad
+ * id becomes a clean handled result, never a raw SQL error in model context.
+ */
 import type {
   Action,
   ActionResult,
@@ -6,7 +14,13 @@ import type {
   Memory,
   UUID,
 } from "@elizaos/core";
-import { MemoryType as CoreMemoryType, logger, ModelType } from "@elizaos/core";
+import {
+  MemoryType as CoreMemoryType,
+  getRelatedEntityIds,
+  logger,
+  ModelType,
+  validateUuid,
+} from "@elizaos/core";
 
 const MEMORY_OPS = ["create", "search", "update", "delete"] as const;
 type MemoryOp = (typeof MEMORY_OPS)[number];
@@ -42,6 +56,34 @@ interface MemoryListItem {
 
 function fail(text: string, error: string): ActionResult {
   return { success: false, text, data: { error } };
+}
+
+type UuidParamName = "entityId" | "roomId" | "memoryId";
+
+type ParsedUuidParam =
+  | { ok: true; id: UUID | undefined }
+  | { ok: false; result: ActionResult };
+
+// error-policy:J3 model-supplied ids arrive as free text ("general", partial
+// uuids); parsing before any query keeps drizzle from throwing — and from
+// echoing the failed SQL statement back into model context.
+function parseUuidParam(
+  value: string | undefined,
+  name: UuidParamName,
+): ParsedUuidParam {
+  const trimmed = value?.trim();
+  if (!trimmed) return { ok: true, id: undefined };
+  const id = validateUuid(trimmed);
+  if (!id) {
+    return {
+      ok: false,
+      result: fail(
+        `${name} "${trimmed}" is not a valid UUID. Omit it or use an id from a previous search result.`,
+        "MEMORY_INVALID_UUID",
+      ),
+    };
+  }
+  return { ok: true, id };
 }
 
 function normalizeMemoryOp(params: MemoryParams): MemoryOp | undefined {
@@ -156,25 +198,38 @@ async function doCreate(
   };
 }
 
-async function doSearch(
-  runtime: IAgentRuntime,
-  params: MemoryParams,
-): Promise<ActionResult> {
-  const type =
-    params.type && MEMORY_TYPES.includes(params.type) ? params.type : undefined;
-  const entityId = params.entityId?.trim() as UUID | undefined;
-  const roomId = params.roomId?.trim() as UUID | undefined;
-  const query = params.query?.trim();
-  const limit = clampLimit(params.limit, 50);
+interface MemoryCandidate {
+  memory: Memory;
+  type: MemoryType;
+}
 
-  const tables: readonly MemoryType[] = type ? [type] : MEMORY_TYPES;
-  const perTable = Math.max(limit * 2, 200);
-  const collected: { memory: Memory; type: MemoryType }[] = [];
+/**
+ * Shared read scope for search and delete-by-query. The entity filter is
+ * identity-cluster expanded via getRelatedEntityIds — the same expansion the
+ * FACTS provider applies — so a fact stored under a cluster sibling of the
+ * requested entityId is in scope. A strict-equality filter here made the same
+ * fact the provider had just surfaced report as "0 stored items".
+ */
+async function collectCandidates(
+  runtime: IAgentRuntime,
+  scope: {
+    type?: MemoryType;
+    entityId?: UUID;
+    roomId?: UUID;
+    query?: string;
+    limit: number;
+  },
+): Promise<MemoryCandidate[]> {
+  const tables: readonly MemoryType[] = scope.type
+    ? [scope.type]
+    : MEMORY_TYPES;
+  const perTable = Math.max(scope.limit * 2, 200);
+  const collected: MemoryCandidate[] = [];
 
   for (const tableName of tables) {
     const memories = await runtime.getMemories({
       agentId: runtime.agentId as UUID,
-      roomId,
+      roomId: scope.roomId,
       tableName,
       limit: perTable,
     });
@@ -186,10 +241,17 @@ async function doSearch(
     return typeof text === "string" && text.trim().length > 0;
   });
 
-  if (entityId)
-    filtered = filtered.filter((c) => c.memory.entityId === entityId);
+  if (scope.entityId) {
+    const clusterIds = new Set<string>(
+      await getRelatedEntityIds(runtime, scope.entityId),
+    );
+    filtered = filtered.filter(
+      (c) => c.memory.entityId != null && clusterIds.has(c.memory.entityId),
+    );
+  }
 
-  if (query) {
+  if (scope.query) {
+    const query = scope.query;
     filtered = filtered.filter((c) => {
       const text =
         (c.memory.content as { text?: string } | undefined)?.text ?? "";
@@ -200,6 +262,29 @@ async function doSearch(
   filtered.sort(
     (a, b) => (b.memory.createdAt ?? 0) - (a.memory.createdAt ?? 0),
   );
+  return filtered;
+}
+
+async function doSearch(
+  runtime: IAgentRuntime,
+  params: MemoryParams,
+): Promise<ActionResult> {
+  const type =
+    params.type && MEMORY_TYPES.includes(params.type) ? params.type : undefined;
+  const entityParam = parseUuidParam(params.entityId, "entityId");
+  if (!entityParam.ok) return entityParam.result;
+  const roomParam = parseUuidParam(params.roomId, "roomId");
+  if (!roomParam.ok) return roomParam.result;
+  const query = params.query?.trim();
+  const limit = clampLimit(params.limit, 50);
+
+  const filtered = await collectCandidates(runtime, {
+    type,
+    entityId: entityParam.id,
+    roomId: roomParam.id,
+    query,
+    limit,
+  });
 
   const total = filtered.length;
   const items = filtered
@@ -230,7 +315,9 @@ async function doUpdate(
   runtime: IAgentRuntime,
   params: MemoryParams,
 ): Promise<ActionResult> {
-  const memoryId = params.memoryId?.trim() as UUID | undefined;
+  const memoryParam = parseUuidParam(params.memoryId, "memoryId");
+  if (!memoryParam.ok) return memoryParam.result;
+  const memoryId = memoryParam.id;
   const text = typeof params.text === "string" ? params.text.trim() : "";
   if (!memoryId) return fail("memoryId is required.", "MEMORY_MISSING_ID");
   if (!text) return fail("text is required.", "MEMORY_MISSING_TEXT");
@@ -282,8 +369,13 @@ async function doDelete(
   runtime: IAgentRuntime,
   params: MemoryParams,
 ): Promise<ActionResult> {
-  const memoryId = params.memoryId?.trim() as UUID | undefined;
-  if (!memoryId) return fail("memoryId is required.", "MEMORY_MISSING_ID");
+  const memoryParam = parseUuidParam(params.memoryId, "memoryId");
+  if (!memoryParam.ok) return memoryParam.result;
+  const memoryId = memoryParam.id;
+  const query = params.query?.trim();
+  if (!memoryId && !query) {
+    return fail("memoryId or query is required.", "MEMORY_MISSING_ID");
+  }
   if (params.confirm !== true) {
     return fail(
       "Refusing to delete: pass confirm:true to acknowledge this destructive action.",
@@ -291,17 +383,108 @@ async function doDelete(
     );
   }
 
-  const existing = await runtime.getMemoryById(memoryId);
-  if (!existing) {
-    return fail(`Memory ${memoryId} was not found.`, "MEMORY_NOT_FOUND");
+  if (memoryId) {
+    const existing = await runtime.getMemoryById(memoryId);
+    if (!existing) {
+      return fail(`Memory ${memoryId} was not found.`, "MEMORY_NOT_FOUND");
+    }
+
+    await runtime.deleteMemory(memoryId);
+    return {
+      success: true,
+      text: `Forgot memory ${memoryId}.`,
+      values: { memoryId },
+      data: { actionName: "MEMORY", op: "delete" as const, memoryId },
+    };
   }
 
-  await runtime.deleteMemory(memoryId);
+  if (!query) {
+    return fail("memoryId or query is required.", "MEMORY_MISSING_ID");
+  }
+  return doDeleteByQuery(runtime, params, query);
+}
+
+/**
+ * Delete-by-query: "remove that fact" carries no memoryId, so resolve the
+ * memory through the same cluster-expanded read scope search uses, then
+ * delete. Reflection dedup failures leave several rows with identical text —
+ * one logical fact — so all rows of the single matched text are removed.
+ * A query that strongly matches more than one distinct text is ambiguous:
+ * refuse and list the candidates so the model can delete by exact id.
+ */
+async function doDeleteByQuery(
+  runtime: IAgentRuntime,
+  params: MemoryParams,
+  query: string,
+): Promise<ActionResult> {
+  const type =
+    params.type && MEMORY_TYPES.includes(params.type) ? params.type : undefined;
+  const entityParam = parseUuidParam(params.entityId, "entityId");
+  if (!entityParam.ok) return entityParam.result;
+  const roomParam = parseUuidParam(params.roomId, "roomId");
+  if (!roomParam.ok) return roomParam.result;
+
+  const limit = clampLimit(params.limit, 50);
+  const candidates = await collectCandidates(runtime, {
+    type,
+    entityId: entityParam.id,
+    roomId: roomParam.id,
+    query,
+    limit,
+  });
+
+  // Deletion needs a stronger bar than search ranking: scoreText >= 1 means
+  // the whole phrase matched or every query term matched.
+  const matched = candidates.filter((c) => {
+    const text =
+      (c.memory.content as { text?: string } | undefined)?.text ?? "";
+    return scoreText(text, query) >= 1;
+  });
+
+  if (matched.length === 0) {
+    return fail(`No stored memory matches "${query}".`, "MEMORY_NOT_FOUND");
+  }
+
+  const normalize = (c: MemoryCandidate) =>
+    ((c.memory.content as { text?: string } | undefined)?.text ?? "")
+      .trim()
+      .toLowerCase();
+  const distinctTexts = new Set(matched.map(normalize));
+  if (distinctTexts.size > 1) {
+    const lines = matched
+      .slice(0, 10)
+      .map((c) => toListItem(c.memory, c.type))
+      .map((m) => `- [${m.type}] ${m.id}: ${m.text.slice(0, 120)}`);
+    return {
+      success: false,
+      text: [
+        `Query "${query}" matches ${distinctTexts.size} distinct memories. Delete by memoryId instead:`,
+        ...lines,
+      ].join("\n"),
+      data: { error: "MEMORY_AMBIGUOUS_QUERY" },
+    };
+  }
+
+  const deleted: MemoryListItem[] = [];
+  for (const c of matched) {
+    const id = c.memory.id;
+    if (!id) continue;
+    await runtime.deleteMemory(id);
+    deleted.push(toListItem(c.memory, c.type));
+  }
+
   return {
     success: true,
-    text: `Forgot memory ${memoryId}.`,
-    values: { memoryId },
-    data: { actionName: "MEMORY", op: "delete" as const, memoryId },
+    text: `Forgot ${deleted.length} memory record(s) matching "${query}": ${
+      deleted[0]?.text.slice(0, 120) ?? ""
+    }`,
+    values: { deletedCount: deleted.length },
+    data: {
+      actionName: "MEMORY",
+      op: "delete" as const,
+      query,
+      deleted,
+    },
   };
 }
 
@@ -327,13 +510,15 @@ export const memoryAction: Action = {
     "BROWSE_MEMORIES",
     "FILTER_MEMORIES",
     "FIND_MEMORIES",
+    "LIST_MEMORIES",
+    "SEARCH_MEMORY",
     "REMOVE_MEMORY",
     "MODIFY_MEMORY",
   ],
   description:
-    "Manage agent memory records. op:create stores a new memory; op:search filters by type/entityId/roomId/query; op:update edits text and re-embeds (requires confirm:true); op:delete removes a memory (requires confirm:true).",
+    "Manage agent memory records. op:create stores a new memory; op:search filters by type/entityId/roomId/query; op:update edits text and re-embeds (requires confirm:true); op:delete removes a memory by memoryId or by query text match (requires confirm:true).",
   descriptionCompressed:
-    "manage agent memory create search update delete; update/delete require confirm:true",
+    "manage agent memory create search update delete; delete by memoryId or query; update/delete require confirm:true",
   routingHint:
     "store/search/edit the agent's OWN memory records about the user or conversation -> MEMORY; do NOT use for open-web lookups -> WEB_SEARCH, for reading messages already in a channel -> MESSAGE (action=search), or for the skill catalog -> SKILL",
   validate: async () => true,
@@ -422,7 +607,7 @@ export const memoryAction: Action = {
     {
       name: "query",
       description:
-        "search: case-insensitive text match against memory content.",
+        "search/delete: case-insensitive text match against memory content. delete: resolves the memory to remove when memoryId is unknown.",
       required: false,
       schema: { type: "string" as const },
     },
@@ -434,7 +619,8 @@ export const memoryAction: Action = {
     },
     {
       name: "memoryId",
-      description: "update/delete: id of the memory to mutate.",
+      description:
+        "update/delete: id of the memory to mutate. delete: optional when query is provided.",
       required: false,
       schema: { type: "string" as const },
     },

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -152,6 +152,7 @@ export * from "./features/subscription-auth/index.ts";
 // Export generated action/provider/evaluator specs from centralized prompts
 export * from "./generated/action-docs";
 export * from "./generated/spec-helpers";
+export * from "./identity-clusters";
 export * from "./inference-timing";
 export * from "./lifeops-passive-connectors";
 export * from "./logger";


### PR DESCRIPTION
## Problem

Live trace (Jul 3, room `82bdd9bb`): the `facts` table held six copies of "nubs plays guitar" under two identity-cluster sibling entity ids, and the FACTS provider surfaced the fact in conversation — but `MEMORY op:search` on the primary entityId truthfully replied **"Found 0 memory item(s) (total: 0)"**. Same store, two different read scopes. Because delete required an exact `memoryId` from that same broken search, user-requested fact deletion was structurally unreachable.

Four defects in `packages/agent/src/actions/memories.ts`:

1. **Search used strict `entityId` equality**, blind to identity-cluster siblings — while the FACTS provider reads through `getRelatedEntityIds`. Inconsistent read.
2. **Model-supplied `roomId`/`entityId`/`memoryId` were blind-cast into SQL uuid params** (`as UUID`). Free-text ids (`"general"`, partial uuids — both seen in June trajectories) made drizzle throw, and the handler's catch echoed the raw failed SELECT back into model context.
3. **No delete-by-query existed** — "remove that fact" had no path from fact text to deletion.
4. **Listing intents mis-routed**: the planner generates `LIST_MEMORIES`/`SEARCH_MEMORY`, neither of which was a MEMORY simile, so listing fell through to VIEWS and errored.

## Fix (structural, reuse-not-fork)

- **Cluster-expanded search**: the entity filter expands through `getRelatedEntityIds` — the exact helper the FACTS provider uses — so the search scope matches the reader. Core exports the existing `identity-clusters` module from the node barrel (one line; module is already type-only-imports).
- **Uuid validation at the boundary** (`parseUuidParam`, error-policy:J3): every model-supplied id is `validateUuid`-parsed before any query; a bad id returns `MEMORY_INVALID_UUID` with guidance, never a SQL leak.
- **Delete-by-query**: `op:delete` with `query` resolves candidates through the same cluster-expanded scope, requires a strong text match, deletes **all duplicate rows of the single matched text** (reflection-dedup failures store one logical fact many times), and refuses ambiguous queries with a candidate id list. `confirm:true` still required.
- **Routing similes**: added `LIST_MEMORIES` + `SEARCH_MEMORY` (verified unclaimed by any other runtime action; the stale `SEARCH_MEMORY` entry in generated action-docs never applies because SEARCH_EXPERIENCES has its own similes).

## Tests (`memories.test.ts`, 15 pass)

Mock runtime mimics the SQL adapter contract: non-uuid params **throw a drizzle-style error carrying the raw SQL**, so a passing validation test proves the query never ran; relationships service exposes cluster membership.

- cluster-expanded search finds a fact stored under a sibling entity (live failure shape)
- search without a cluster resolver still scopes to the entity's own rows
- `roomId "general"`, partial-uuid `entityId`/`memoryId` → clean handled errors, no `failed query`/`select` text leaked, rows untouched
- delete-by-query removes every duplicate row of the matched fact and leaves others
- ambiguous query → `MEMORY_AMBIGUOUS_QUERY` with candidate ids, nothing deleted
- no match → clean `MEMORY_NOT_FOUND`; missing `confirm` → refusal
- `LIST_MEMORIES`/`SEARCH_MEMORY` resolve to MEMORY via the normalized name+simile lookup contract

## Verification

- `vitest run src/actions/memories.test.ts`: **15/15 pass**
- `vitest run src/actions/` (whole dir): **63/63 pass, 10 files**
- `packages/core` typecheck: clean. `packages/agent` typecheck: no errors in touched files (remaining errors are pre-existing unbuilt-workspace-dist noise in ui/shared/plugins, present on clean develop)
- biome check on touched agent files: clean (`index.node.ts` format failure is pre-existing on develop, verified via stash)
- `bun run audit:error-policy-ratchet`: no new fallback-slop

Evidence: N/A screenshots/video — headless action-handler change, no UI surface. Live-LLM trajectory: the defect was captured from live Jul 3 trajectories (room `82bdd9bb`, entity `0b8db237` vs siblings `e8f33ce1`/`68675e32`); deterministic tests reproduce that exact shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)