### PR TITLE
fix(#12321): harden publish integrity gates

### DIFF
--- a/.github/issue-evidence/12321-publish-integrity-gates.md
+++ b/.github/issue-evidence/12321-publish-integrity-gates.md
@@ -1,0 +1,38 @@
+# Release Verification Queue Integrity Evidence
+
+Issue: #12321
+
+## Scope Exercised
+
+- Removed saved-summary input from the verification queue CLI so queue
+  generation uses the live HF release audit instead of an operator-supplied
+  stale or forged audit summary.
+- The per-tier `--allow-missing` and `--skip-hash-verify` bypass removals
+  landed separately in #12768; this branch was rebased over that work.
+
+## Commands Run
+
+```bash
+python3 -m py_compile \
+  packages/training/scripts/manifest/release_verification_queue.py \
+  packages/training/scripts/publish/publish_eliza1_model_repo.py
+node --check packages/training/scripts/publish/eliza1-hf-stage.mjs
+bash -n packages/training/scripts/publish/eliza1-hf-push.sh
+git diff --check origin/develop..HEAD
+```
+
+Result: passed.
+
+```bash
+uv run --project packages/training --with pytest -- python -m pytest \
+  packages/training/scripts/publish/test_publish_eliza1_model_repo.py \
+  packages/training/scripts/manifest/test_release_verification_queue.py -q
+```
+
+Result after rebase over #12768: `32 passed`.
+
+## N/A Evidence
+
+- Screenshots, recordings, audio, and live-LLM trajectories are not applicable;
+  this change only affects CLI publish gate behavior.
+- No live Hugging Face upload was performed.

--- a/packages/training/scripts/manifest/release_verification_queue.py
+++ b/packages/training/scripts/manifest/release_verification_queue.py
@@ -616,7 +616,6 @@ def render_markdown(items: list[QueueItem]) -> str:
 
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
-    ap.add_argument("--summary-json", type=Path, help="Use a saved audit --summary JSON file.")
     ap.add_argument("--bundle-root", default="/tmp/eliza-1-bundles")
     ap.add_argument(
         "--verify-dir",
@@ -656,10 +655,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.local_only and args.hardware_only:
         ap.error("--local-only and --hardware-only are mutually exclusive")
 
-    if args.summary_json:
-        summary = json.loads(args.summary_json.read_text(encoding="utf-8"))
-    else:
-        summary = audit_hf_release().summary()
+    summary = audit_hf_release().summary()
     limit = 1 if args.next else args.limit
     all_items = build_queue(
         summary,


### PR DESCRIPTION
## Summary
- remove the saved-summary input from the release verification queue CLI
- force queue generation to use the live HF release audit instead of a stale or operator-supplied summary JSON
- keep the per-tier publish bypass removals on the already-merged #12768 branch; this PR is rebased over that work

## Evidence
- Added `.github/issue-evidence/12321-publish-integrity-gates.md`
- `python3 -m pytest packages/training/scripts/manifest/test_release_verification_queue.py -q` — 15 passed
- `python3 -m pytest packages/training/scripts/publish/test_publish_eliza1_model_repo.py -q` — 17 passed
- `python3 -m py_compile packages/training/scripts/manifest/release_verification_queue.py packages/training/scripts/publish/publish_eliza1_model_repo.py`
- `node --check packages/training/scripts/publish/eliza1-hf-stage.mjs`
- `bash -n packages/training/scripts/publish/eliza1-hf-push.sh`
- `git diff --check origin/develop..HEAD`

## N/A
- No live Hugging Face upload was performed.
- Screenshots, recordings, audio, and live-LLM trajectories do not apply to this CLI publish-gate change.

Replaces stale conflicting PR #12737.
Refs #12321
