### PR TITLE
fix(#12272): fallback-slop sweep — connector plugins (fail-fast over fabricated defaults + annotate justified handlers)

### DIFF
--- a/plugins/plugin-bluesky/utils/config.ts
+++ b/plugins/plugin-bluesky/utils/config.ts
@@ -85,6 +85,9 @@ function parseAccountsJson(
 			? (parsed as Record<string, RawBlueSkyAccountConfig>)
 			: {};
 	} catch {
+		// error-policy:J3 malformed BLUESKY_ACCOUNTS JSON is untrusted config input; the
+		// multi-account blob contributes no entries while single-account env settings
+		// still govern — a corrupt blob must not crash account discovery (accounts.test.ts).
 		return {};
 	}
 }

--- a/plugins/plugin-discord/discord-avatar-cache.ts
+++ b/plugins/plugin-discord/discord-avatar-cache.ts
@@ -124,7 +124,10 @@ export async function cacheDiscordAvatarUrl(
 		if (stat.isFile()) {
 			return getDiscordAvatarPublicPath(requestedFileName);
 		}
-	} catch {}
+	} catch {
+		// error-policy:J3 stat probe for a cache hit; a miss (ENOENT and peers) is the
+		// expected path and falls through to the download below.
+	}
 
 	const existing = inflightDiscordAvatarDownloads.get(requestedFileName);
 	if (existing) {
@@ -162,7 +165,10 @@ export async function cacheDiscordAvatarUrl(
 			if (stat.isFile()) {
 				return getDiscordAvatarPublicPath(finalFileName);
 			}
-		} catch {}
+		} catch {
+			// error-policy:J3 stat probe for a concurrently-materialized cache entry; a
+			// miss is expected and falls through to the atomic write below.
+		}
 
 		const tempFilePath = `${finalFilePath}.${process.pid}.${Date.now()}.tmp`;
 		await fs.writeFile(tempFilePath, bytes, { mode: 0o600 });

--- a/plugins/plugin-discord/profileSync.ts
+++ b/plugins/plugin-discord/profileSync.ts
@@ -194,7 +194,11 @@ async function loadDiscordProfileAvatarBytes(
 			if (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:") {
 				remoteUrl = parsedUrl;
 			}
-		} catch {}
+		} catch {
+			// error-policy:J3 the avatar source is untrusted input that may be a data URI,
+			// URL, or local path; a URL parse failure just means "not a remote URL" and
+			// falls through to the local-candidate reader below — not an error.
+		}
 
 		if (remoteUrl) {
 			const fetchImpl = runtime.fetch ?? globalThis.fetch;

--- a/plugins/plugin-farcaster/utils/config.ts
+++ b/plugins/plugin-farcaster/utils/config.ts
@@ -73,6 +73,9 @@ function parseAccountsJson(runtime: IAgentRuntime): Record<string, RawFarcasterA
       ? (parsed as Record<string, RawFarcasterAccountConfig>)
       : {};
   } catch {
+    // error-policy:J3 malformed FARCASTER_ACCOUNTS JSON is untrusted config input; the
+    // multi-account blob contributes no entries while single-account env settings
+    // still govern — a corrupt blob must not crash account discovery (accounts.test.ts).
     return {};
   }
 }

--- a/plugins/plugin-feishu/src/messageManager.test.ts
+++ b/plugins/plugin-feishu/src/messageManager.test.ts
@@ -17,6 +17,7 @@ function createRuntime() {
 		agentId,
 		ensureConnection: vi.fn().mockResolvedValue(undefined),
 		emitEvent: vi.fn(),
+		reportError: vi.fn(),
 	});
 }
 
@@ -90,7 +91,7 @@ describe("MessageManager inbound event handling", () => {
 		expect(runtime.emitEvent).not.toHaveBeenCalled();
 	});
 
-	it("emits hostile malformed JSON text with a finite timestamp", async () => {
+	it("surfaces hostile malformed JSON as an explicit invalid marker, not fake-empty text", async () => {
 		const runtime = createRuntime();
 		const manager = createManager(runtime);
 
@@ -105,11 +106,20 @@ describe("MessageManager inbound event handling", () => {
 				userId: "ou_sender",
 			}),
 		);
+		// Unparseable content must not silently become "" (the agent would answer to
+		// nothing); it surfaces as an explicit marker and a reported error.
+		expect(runtime.reportError).toHaveBeenCalledWith(
+			"Feishu.parseMessageContent",
+			expect.any(Error),
+			expect.objectContaining({ msgType: "text" }),
+		);
 		expect(runtime.emitEvent).toHaveBeenCalledWith(
 			FeishuEventTypes.MESSAGE_RECEIVED,
 			expect.objectContaining({
 				message: expect.objectContaining({
-					content: expect.objectContaining({ text: "" }),
+					content: expect.objectContaining({
+						text: "[unparseable text message]",
+					}),
 					createdAt: expect.any(Number),
 				}),
 			}),

--- a/plugins/plugin-feishu/src/messageManager.ts
+++ b/plugins/plugin-feishu/src/messageManager.ts
@@ -352,8 +352,15 @@ export class MessageManager {
 				default:
 					return content.text || "";
 			}
-		} catch {
-			return "";
+		} catch (err) {
+			// error-policy:J3 unparseable platform message content → explicit invalid
+			// marker (never fabricate empty text the agent would answer to nothing), and
+			// report so repeated malformed payloads from Feishu become observable.
+			this.runtime.reportError("Feishu.parseMessageContent", err, {
+				msgType: message.msgType,
+				messageId: message.messageId,
+			});
+			return `[unparseable ${message.msgType} message]`;
 		}
 	}
 

--- a/plugins/plugin-imessage/src/rpc.ts
+++ b/plugins/plugin-imessage/src/rpc.ts
@@ -414,6 +414,8 @@ export async function probeIMessageRpc(params: {
     await client.stop();
     return { ok: true };
   } catch (err) {
+    // error-policy:J6 best-effort teardown after a failed probe; the real failure is
+    // returned as the structured result below, so a stop() error here is irrelevant.
     await client.stop().catch(() => {});
     return {
       ok: false,

--- a/plugins/plugin-matrix/src/accounts.ts
+++ b/plugins/plugin-matrix/src/accounts.ts
@@ -47,6 +47,9 @@ function parseAccountsJson(runtime: IAgentRuntime): Record<string, MatrixAccount
       ? (parsed as Record<string, MatrixAccountConfig>)
       : {};
   } catch {
+    // error-policy:J3 malformed MATRIX_ACCOUNTS JSON is untrusted config input; the
+    // multi-account blob contributes no entries while single-account env settings
+    // still govern — a corrupt blob must not crash account discovery (accounts.test.ts).
     return {};
   }
 }

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -1155,6 +1155,8 @@ export class MatrixService extends Service implements IMatrixService {
     const other = request.otherUserId;
     if (!state.settings.verifyAllowlist.includes(other)) {
       logger.warn(`Matrix rejecting verification request from non-allowlisted ${other}`);
+      // error-policy:J6 best-effort teardown of a rejected verification request; the
+      // rejection is already logged and the request is being abandoned.
       await request.cancel().catch(() => {});
       return;
     }
@@ -1165,6 +1167,8 @@ export class MatrixService extends Service implements IMatrixService {
       }
       const verifier = request.verifier ?? (await this.awaitVerifier(request));
       if (!verifier) {
+        // error-policy:J6 best-effort teardown when no verifier materialized; the
+        // request is being abandoned either way.
         await request.cancel().catch(() => {});
         return;
       }

--- a/plugins/plugin-nostr/src/accounts.ts
+++ b/plugins/plugin-nostr/src/accounts.ts
@@ -53,6 +53,9 @@ function parseAccountsJson(runtime: IAgentRuntime): Record<string, NostrAccountC
       ? (parsed as Record<string, NostrAccountConfig>)
       : {};
   } catch {
+    // error-policy:J3 malformed NOSTR_ACCOUNTS JSON is untrusted config input; the
+    // multi-account blob contributes no entries while single-account env settings
+    // still govern — a corrupt blob must not crash account discovery (accounts.test.ts).
     return {};
   }
 }

--- a/plugins/plugin-telegram/src/account-auth-service.ts
+++ b/plugins/plugin-telegram/src/account-auth-service.ts
@@ -821,6 +821,8 @@ export class TelegramAccountAuthSession
       return;
     }
     this.persistSession();
+    // error-policy:J6 best-effort teardown; the client is being discarded regardless,
+    // so a disconnect error must not block cleanup.
     await this.client.disconnect().catch(() => undefined);
     this.client = null;
   }

--- a/plugins/plugin-whatsapp/src/webhook-auth.ts
+++ b/plugins/plugin-whatsapp/src/webhook-auth.ts
@@ -44,6 +44,9 @@ export function verifyWhatsAppWebhookSignature(
     }
     return crypto.timingSafeEqual(expectedBuffer, computedBuffer);
   } catch {
+    // error-policy:J3 untrusted webhook signature; a malformed/non-hex header cannot
+    // pass verification, so any decode failure is an explicit "signature invalid" (false),
+    // not a swallowed error.
     return false;
   }
 }


### PR DESCRIPTION
## Fallback-slop sweep (#12182): connector plugins — precise first pass

Part of the #12182 fast-fail error-policy rollout. This slice covers the 15 messaging/social
connector plugins. It is a **precision-first** pass: convert only unambiguous fabricated-success
slop, annotate the confidently-justified handlers (J-categories), and leave everything ambiguous
(legitimate absence / designed degrade) untouched rather than risk masking real behavior. Uses the
foundation from #12263 (`ElizaError`, `runtime.reportError`, `ERROR_REPORTED`, the diff-scoped
`audit:error-policy-ratchet`).

### Re-derived suspect list (develop @ merge-base)

The connector tree has already been cleaned substantially since the 8a2b993282 calibration snapshot:
only **5** empty catches remain (vs 72 calibrated), and the real profile-sync swallow the issue
exemplar-4 pointed at (`profileSync.ts:192`) is already gone on develop. Sweep buckets surveyed:
empty catch (5), promise-swallow `.catch(()=>…)` (~30), return-default catch (~45). The ~470
`?? <lit>` / `|| <lit>` payload/config candidates were **not** swept in this pass (deferred —
they need per-field "is this a legitimately-absent value" judgement and belong in a follow-up).

### What changed — per-site verdict table

| Site | Bucket | Verdict | Action |
|---|---|---|---|
| `plugin-feishu/src/messageManager.ts:355` `parseMessageContent` catch → `return ""` | return-default | **SLOP → fail-fast** | Convert: unparseable platform message content now returns an explicit `[unparseable <type> message]` marker + `runtime.reportError("Feishu.parseMessageContent", …)` instead of fabricating empty text the agent answers to nothing (J3 explicit-invalid). Test updated to assert the marker + reportError, not `text:""`. |
| `plugin-nostr/src/accounts.ts:55` `parseAccountsJson` catch → `{}` | return-default | KEEP (J3) | Annotate: malformed `NOSTR_ACCOUNTS` is untrusted config; the multi-account blob contributes nothing while single-account env still governs — tested designed fallback (`accounts.test.ts`). |
| `plugin-matrix/src/accounts.ts:49` `parseAccountsJson` catch → `{}` | return-default | KEEP (J3) | Annotate (same shape; `accounts.test.ts` "ignores malformed MATRIX_ACCOUNTS JSON and falls back"). |
| `plugin-bluesky/utils/config.ts:87` `parseAccountsJson` catch → `{}` | return-default | KEEP (J3) | Annotate (`accounts.test.ts` "ignores malformed BLUESKY_ACCOUNTS", "…disabled instead of throwing"). |
| `plugin-farcaster/utils/config.ts:75` `parseAccountsJson` catch → `{}` | return-default | KEEP (J3) | Annotate (`accounts.test.ts` "ignores malformed FARCASTER_ACCOUNTS JSON instead of crashing account discovery"). |
| `plugin-whatsapp/src/webhook-auth.ts:46` `verifyWebhookSignature` catch → `false` | return-default | KEEP (J3) | Annotate: untrusted `X-Hub-Signature-256`; a malformed/non-hex header cannot pass verification, so a decode failure IS "signature invalid", not a swallow. |
| `plugin-discord/profileSync.ts:197` URL-parse `catch {}` | empty | KEEP (J3) | Annotate: avatar source may be data-URI / URL / local path; a URL parse failure means "not a remote URL" and falls through to the local-candidate reader. |
| `plugin-discord/discord-avatar-cache.ts:127` `fs.stat` cache-hit probe `catch {}` | empty | KEEP (J3) | Annotate: a miss (ENOENT and peers) is the expected path → download. |
| `plugin-discord/discord-avatar-cache.ts:165` `fs.stat` cache-hit probe `catch {}` | empty | KEEP (J3) | Annotate (concurrently-materialized entry probe). |
| `plugin-imessage/src/rpc.ts:417` `client.stop().catch(() => {})` | promise-swallow | KEEP (J6) | Annotate: best-effort teardown after a failed probe; the real failure is returned as the structured `{ ok:false, error }` result. |
| `plugin-telegram/src/account-auth-service.ts:824` `disconnect().catch(() => undefined)` | promise-swallow | KEEP (J6) | Annotate: teardown; client discarded regardless. |
| `plugin-matrix/src/service.ts:1158` `request.cancel().catch(() => {})` | promise-swallow | KEEP (J6) | Annotate: best-effort teardown of a rejected verification request (rejection already logged). |
| `plugin-matrix/src/service.ts:1168` `request.cancel().catch(() => {})` | promise-swallow | KEEP (J6) | Annotate: teardown when no verifier materialized. |

### Left untouched (counted in `sitesLeft`) — deliberate precision calls

Not slop, or cannot be distinguished from legitimate absence/designed-degrade without behavior-changing
risk (this tree is high-risk: reconnect/backoff + designed degrade dominate):

- **Config-parse `{}` fallbacks** are tested designed-degrade (see the 4 KEEP rows) — converting them to
  throw would red existing `accounts.test.ts` "ignores malformed …" cases. Left as-is + annotated.
- **`.catch(() => null)` profile/user/group/room lookups** (`plugin-line/src/service.ts`,
  `plugin-signal`, `plugin-discord/discord-profiles.ts`, `plugin-feishu/src/service.ts`, …) — "enrichment
  lookup miss → null" reads as legitimate absence, not a masked failure; needs per-caller review.
- **`return null`/`return false` from credential providers** (`workflow-credential-provider.ts` across
  line/feishu/farcaster, `plugin-slack/connector-credential-refs.ts`) — `null` is the provider's
  "no credential available" signal; ambiguous, left.
- **`plugin-discord/user-account-scraper/*` `return false`** probe results — CDP/browser probe misses.
- The **~470 `?? <lit>` / `|| <lit>`** payload/config candidates — out of scope for this pass.

`sitesLeft` counts the surveyed catch-bucket suspects left untouched; the literal-default sweep is a
separate follow-up.

### Per-category tally

- **Converted (slop → fail-fast):** 1 — feishu fabricated-empty-message-text → explicit invalid marker + `reportError`.
- **Annotated (kept, justified):** 12 — 8× J3 (untrusted-input parse: 4 config-JSON, 1 webhook signature, 1 URL-parse, 2 fs.stat cache probe) + 4× J6 (best-effort teardown).
- **Left (ambiguous absence / designed degrade / out-of-scope):** ~68 surveyed catch-suspects + ~470 literal-default candidates.

### Exemplar before → after (feishu, exemplar 1 in #12272)

```ts
// BEFORE — any parse hiccup turns a real user message into ""; the agent answers to nothing
} catch {
  return "";
}
// AFTER — unparseable content is an explicit outcome and is reported
} catch (err) {
  // error-policy:J3 unparseable platform message content → explicit invalid marker …
  this.runtime.reportError("Feishu.parseMessageContent", err, { msgType: message.msgType, messageId: message.messageId });
  return `[unparseable ${message.msgType} message]`;
}
```

Its test (`messageManager.test.ts`) was updated from asserting the old fabricated `text: ""` to asserting
the explicit marker **and** that `reportError` fired with the stable scope `"Feishu.parseMessageContent"` —
no test asserts the old fabricated default.

### Verification

- `plugins/plugin-feishu` full suite: **15/15 pass** (incl. the rewritten malformed-JSON test).
- Account-config suites green with annotations: nostr 3/3, matrix 4/4, bluesky 10/10, farcaster 6/6.
- `bun run audit:error-policy-ratchet`: **passes** — "no new fallback-slop in touched files" (every touched
  file `emptyCatch 0->0, serverConsole 0->0`).
- `tsc --noEmit` on `plugin-feishu`: clean.
- 13 grep-able `// error-policy:J<N>` annotations added; 0 `console.*` introduced; no `bun.lock` drift; path-specific adds only.

### Evidence (`PR_EVIDENCE.md`)

- Backend log of `reportError` firing on a real induced failure: **N/A in this PR** — exercised via the unit
  test which asserts `runtime.reportError` is called with the stable scope on malformed inbound content
  (the real `AgentRuntime.reportError` → `ERROR_REPORTED` wiring is covered by the #12263 foundation tests).
  A live connector round-trip against a 401-ing endpoint is deferred with the send/receive-path conversions
  a future pass will make once the ambiguous lookups above are individually reviewed.
- Real-LLM trajectory / screenshots / audio: **N/A** — no agent-prompt, UI, or voice surface changed; this
  is a connector error-handling correctness change with a deterministic unit test.

Refs #12272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
