### PR TITLE
fix(ios): harden local agent stream completion cleanup

### DIFF
--- a/packages/ui/src/api/native-agent-stream.test.ts
+++ b/packages/ui/src/api/native-agent-stream.test.ts
@@ -15,13 +15,22 @@ import {
  * `agentStream*` events on demand — exactly how the native bridge will emit them
  * via Capacitor `notifyListeners`.
  */
-function makeFakeAgent(streamId = "s1", completion?: Promise<unknown>) {
+function makeFakeAgent(
+  streamId = "s1",
+  completion?: Promise<unknown>,
+  options: { addListenerDelayMs?: number } = {},
+) {
   const listeners = new Map<string, Array<(e: unknown) => void>>();
   const agent: NativeStreamingAgentPlugin = {
     async requestStream() {
       return { streamId, completion };
     },
     async addListener(eventName, listener) {
+      if (options.addListenerDelayMs) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, options.addListenerDelayMs),
+        );
+      }
       const arr = listeners.get(eventName) ?? [];
       arr.push(listener);
       listeners.set(eventName, arr);
@@ -151,6 +160,20 @@ describe("createNativeStreamingResponse", () => {
       path: "/x",
     });
     await expect(responsePromise).rejects.toThrow("native boot failed");
+  });
+
+  it("removes listener handles that resolve after an early native completion rejection", async () => {
+    const completion = Promise.reject(new Error("native boot failed"));
+    const { agent, listenerCount } = makeFakeAgent("s1", completion, {
+      addListenerDelayMs: 5,
+    });
+    const responsePromise = createNativeStreamingResponse(agent, {
+      path: "/x",
+    });
+    await expect(responsePromise).rejects.toThrow("native boot failed");
+    await flush();
+    await flush();
+    expect(listenerCount()).toBe(0);
   });
 
   it("errors the body when the native stream call rejects after the head", async () => {

--- a/packages/ui/src/api/native-agent-stream.ts
+++ b/packages/ui/src/api/native-agent-stream.ts
@@ -102,6 +102,13 @@ export async function createNativeStreamingResponse(
     detached = true;
     for (const handle of handles) void handle.remove();
   };
+  const trackHandle = (handle: NativeStreamListenerHandle): void => {
+    if (detached) {
+      void handle.remove();
+      return;
+    }
+    handles.push(handle);
+  };
 
   const body = new ReadableStream<Uint8Array>({
     start(c) {
@@ -193,9 +200,9 @@ export async function createNativeStreamingResponse(
     void stream.completion.catch(failStream);
   }
 
-  handles.push(await agent.addListener("agentStreamResponse", onResponse));
-  handles.push(await agent.addListener("agentStreamChunk", onChunk));
-  handles.push(await agent.addListener("agentStreamComplete", onComplete));
+  trackHandle(await agent.addListener("agentStreamResponse", onResponse));
+  trackHandle(await agent.addListener("agentStreamChunk", onChunk));
+  trackHandle(await agent.addListener("agentStreamComplete", onComplete));
 
   return head;
 }


### PR DESCRIPTION
## Summary

Restores and hardens the iOS local-agent streaming termination fix against current `develop`.

Current `origin/develop` still lacks the native stream completion path even though the earlier PR was marked merged, so this branch carries the stream fix stack and adds one more cleanup guard:

- `NativeStreamingAgentPlugin.requestStream()` can return a background `completion` promise.
- Early native completion rejection rejects the response head instead of leaving chat turns pending.
- Mid-stream native completion rejection errors the response body and detaches listeners.
- iOS bridge chunk-dispatch failures now emit terminal completion instead of skipping the complete frame.
- New follow-up: listener handles that resolve after an early completion rejection are removed immediately, preventing late listener leaks.

## Validation

Run in `/tmp/eliza-ios-stream-current` on rebased commit `c89679ec11`:

- PASS: `node packages/shared/scripts/generate-keywords.mjs --target ts`
- PASS: `bun run --cwd packages/cloud/routing build`
- PASS: `bunx vitest run packages/ui/src/api/native-agent-stream.test.ts --pool forks --testTimeout 10000` (1 file, 9 tests)
- PASS: `bunx vitest run packages/ui/src/api/ios-streaming-agent-plugin.test.ts --pool forks --testTimeout 10000` (1 file, 5 tests)
- PASS: `bunx vitest run plugins/plugin-capacitor-bridge/src/ios/bridge.stream.test.ts --pool forks --testTimeout 10000` (1 file, 8 tests)
- PASS: `bunx biome check packages/ui/src/api/native-agent-stream.ts packages/ui/src/api/native-agent-stream.test.ts packages/ui/src/api/ios-streaming-agent-plugin.ts packages/ui/src/api/ios-streaming-agent-plugin.test.ts plugins/plugin-capacitor-bridge/src/ios/bridge.ts plugins/plugin-capacitor-bridge/src/ios/bridge.stream.test.ts`

## Evidence limits

Native iOS simulator/device screenshot, recording, and logs remain blocked on this host: active developer directory is Command Line Tools, and `iphonesimulator` SDK / `simctl` are unavailable.
