### PR TITLE
test(groq): mock sdk for cooldown parser import

### DIFF
--- a/plugins/plugin-groq/__tests__/tool-normalization.shape.test.ts
+++ b/plugins/plugin-groq/__tests__/tool-normalization.shape.test.ts
@@ -84,6 +84,11 @@ describe("Groq core ToolDefinition[] normalization", () => {
 
 describe("Groq 429 cooldown parsing (extractRetryDelay)", () => {
   it("parses Go-style compound durations from Groq rate-limit messages", async () => {
+    vi.doMock("@ai-sdk/groq", () => ({
+      createGroq: () => ({
+        languageModel: (modelName: string) => ({ modelName }),
+      }),
+    }));
     const { extractRetryDelay } = await import("../index");
     expect(extractRetryDelay("Rate limit reached. Please try again in 7m30s.")).toBe(451_000);
     expect(extractRetryDelay("Rate limit reached. Please try again in 2m59.56s.")).toBe(180_560);


### PR DESCRIPTION
## Summary\n\nFollow-up to #12752. The new Groq cooldown parser test imports `../index` only to reach `extractRetryDelay`, but importing that module also loads `@ai-sdk/groq`. In a linked local install where the declared dependency exists in Bun's store but is not linked at `node_modules/@ai-sdk/groq`, the parser-only test failed before the assertion.\n\nThis makes the parser test hermetic by mocking `@ai-sdk/groq` before importing the plugin, matching the other tests in the same file. No production code changes.\n\n## Verification\n\n- `bun run --cwd plugins/plugin-groq test -- __tests__/tool-normalization.shape.test.ts`\n  - pass: 1 test file, 3 tests\n- `bunx @biomejs/biome check plugins/plugin-groq/__tests__/tool-normalization.shape.test.ts`\n  - pass\n- `git diff --check`\n  - pass\n\nUI / live-model evidence: N/A - test-only hermeticity patch; no provider behavior changed.