### PR TITLE
fix(#12271): fallback-slop sweep — model/inference plugins (high-confidence slice)

### DIFF
--- a/plugins/plugin-anthropic/__tests__/credential-store.test.ts
+++ b/plugins/plugin-anthropic/__tests__/credential-store.test.ts
@@ -1,4 +1,5 @@
 /** Unit tests for OAuth token resolution in the credential store; uses real temp dirs and env-var manipulation, no live API. */
+import { ElizaError } from "@elizaos/core";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -11,6 +12,7 @@ describe("Anthropic credential store", () => {
   const originalNamespace = process.env.ELIZA_NAMESPACE;
   const originalEnvToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
   const originalAnthropicEnvToken = process.env.ANTHROPIC_OAUTH_TOKEN;
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
 
   beforeEach(() => {
     stateDir = join(tmpdir(), `anthropic-credentials-${Date.now()}`);
@@ -43,6 +45,11 @@ describe("Anthropic credential store", () => {
     } else {
       process.env.ANTHROPIC_OAUTH_TOKEN = originalAnthropicEnvToken;
     }
+    if (originalConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    }
     rmSync(stateDir, { recursive: true, force: true });
   });
 
@@ -61,5 +68,47 @@ describe("Anthropic credential store", () => {
     );
 
     expect(getClaudeOAuthToken().accessToken).toBe("fresh-app-token");
+  });
+
+  it("throws CREDENTIALS_CORRUPT when ~/.claude/.credentials.json is unparseable, not a silent null", () => {
+    // No env token and no app-managed creds: resolution reaches the file store.
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    delete process.env.ANTHROPIC_OAUTH_TOKEN;
+    const configDir = join(stateDir, "claude-config");
+    mkdirSync(configDir, { recursive: true });
+    // A file that EXISTS but is corrupt must surface — never downgrade to "no
+    // credentials", which would look identical to an absent file.
+    writeFileSync(join(configDir, ".credentials.json"), "{ this is not valid json ");
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    clearTokenCache();
+
+    try {
+      getClaudeOAuthToken();
+      expect.unreachable("a corrupt credential file must throw, not return null");
+    } catch (thrown) {
+      expect(thrown).toBeInstanceOf(ElizaError);
+      expect((thrown as ElizaError).code).toBe("CREDENTIALS_CORRUPT");
+    }
+  });
+
+  it("returns the honest 'not authenticated' error when the credential file is simply absent", () => {
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    delete process.env.ANTHROPIC_OAUTH_TOKEN;
+    const configDir = join(stateDir, "claude-config-absent");
+    mkdirSync(configDir, { recursive: true });
+    process.env.CLAUDE_CONFIG_DIR = configDir; // dir exists, .credentials.json does not
+    clearTokenCache();
+
+    // Absent (ENOENT) is not corrupt: the file reader returns null, and the
+    // caller raises the standard "could not read OAuth token" guidance error
+    // (a plain Error), NOT a CREDENTIALS_CORRUPT ElizaError.
+    try {
+      getClaudeOAuthToken();
+      expect.unreachable("no credentials means the caller must throw its guidance error");
+    } catch (thrown) {
+      expect(thrown).toBeInstanceOf(Error);
+      expect((thrown as ElizaError).code).not.toBe("CREDENTIALS_CORRUPT");
+      expect((thrown as Error).message).toContain("OAuth token");
+    }
   });
 });

--- a/plugins/plugin-anthropic/utils/credential-store.ts
+++ b/plugins/plugin-anthropic/utils/credential-store.ts
@@ -11,7 +11,7 @@
  * (env var → keychain → ~/.claude/.credentials.json).
  */
 
-import type { AnthropicAccountPoolBridge } from "@elizaos/core";
+import { type AnthropicAccountPoolBridge, ElizaError } from "@elizaos/core";
 
 interface OAuthToken {
   accessToken: string;
@@ -253,7 +253,10 @@ function readAppManagedAnthropicToken(): OAuthToken | null {
         return token;
       }
     } catch {
-      // Try the next known app-managed credential location.
+      // error-policy:J3 untrusted-input sanitizing — this probes a fixed list of
+      // known app-managed credential locations of which at most one exists;
+      // a read/parse miss at one location is the expected "not here" signal and
+      // moves to the next. Exhausting all yields the honest null below.
     }
   }
 
@@ -274,24 +277,61 @@ function readFromCredentialStore(): ClaudeCredentials | null {
 
   const configDir = getEnvVar("CLAUDE_CONFIG_DIR") ?? join(homedir(), ".claude");
   const credPath = join(configDir, ".credentials.json");
+  const { readFileSync } = require("node:fs") as typeof import("node:fs");
+
+  let raw: string;
   try {
-    const { readFileSync } = require("node:fs") as typeof import("node:fs");
-    const raw = readFileSync(credPath, "utf-8");
+    raw = readFileSync(credPath, "utf-8");
+  } catch (error) {
+    // error-policy:J3 untrusted-input sanitizing — a missing credential file is
+    // the expected "not authenticated this way" signal (null). Any other read
+    // failure (permissions, I/O) is a real problem the caller must not read as
+    // "no credentials", so it surfaces as a typed error.
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") return null;
+    throw new ElizaError("Failed to read Claude credential file", {
+      code: "CREDENTIALS_UNREADABLE",
+      cause: error,
+      context: { credPath },
+    });
+  }
+
+  // A file that exists but does not parse is corrupt, not absent — surfacing it
+  // prevents a silent downgrade of auth that would look identical to "no creds".
+  try {
     return JSON.parse(raw);
-  } catch {
-    return null;
+  } catch (error) {
+    throw new ElizaError("Claude credential file is corrupt (invalid JSON)", {
+      code: "CREDENTIALS_CORRUPT",
+      cause: error,
+      context: { credPath },
+    });
   }
 }
 
 function readFromMacKeychain(): ClaudeCredentials | null {
+  const { execSync } = require("node:child_process") as typeof import("node:child_process");
+
+  let raw: string;
   try {
-    const { execSync } = require("node:child_process") as typeof import("node:child_process");
-    const raw = execSync('security find-generic-password -s "Claude Code-credentials" -w', {
+    raw = execSync('security find-generic-password -s "Claude Code-credentials" -w', {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
     }).trim();
-    return JSON.parse(raw);
   } catch {
+    // error-policy:J3 untrusted-input sanitizing — a non-zero `security` exit
+    // means no matching keychain entry (absent → null), the expected "not stored
+    // here" outcome. The file-based reader is the next source tried by the caller.
     return null;
+  }
+
+  // The entry exists; if its payload does not parse it is corrupt, not absent.
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new ElizaError("Claude keychain credential is corrupt (invalid JSON)", {
+      code: "CREDENTIALS_CORRUPT",
+      cause: error,
+      context: { source: "macos-keychain" },
+    });
   }
 }

--- a/plugins/plugin-edge-tts/src/index.ts
+++ b/plugins/plugin-edge-tts/src/index.ts
@@ -213,11 +213,24 @@ function removeEdgeTempDir(tempDir: string, tempRoot = tmpdir()): boolean {
   try {
     rootRealPath = realpathSync(tempRoot);
     tempRealPath = realpathSync(tempDir);
-  } catch {
+  } catch (error) {
+    // error-policy:J6 best-effort teardown — resolving the temp dir failed
+    // (already gone, or unreadable); we cannot safely delete it. Surface a warn
+    // so a repeatedly-leaking temp dir is observable instead of vanishing.
+    logger.warn(
+      { tempDir, error: error instanceof Error ? error.message : String(error) },
+      "[EdgeTTS] Could not resolve temp dir for cleanup; leaving it in place"
+    );
     return false;
   }
 
   if (!isSubpath(tempRealPath, rootRealPath)) {
+    // error-policy:J6 best-effort teardown — refuse to rmSync a path that
+    // resolved outside the temp root (symlink-escape guard); warn on the leak.
+    logger.warn(
+      { tempDir: tempRealPath, tempRoot: rootRealPath },
+      "[EdgeTTS] Refusing to remove temp dir resolved outside the temp root"
+    );
     return false;
   }
 
@@ -262,11 +275,17 @@ async function generateSpeech(settings: EdgeTTSSettings, params: EdgeTTSParams):
     const audioBuffer = readFileSync(outputPath);
     return audioBuffer;
   } finally {
-    // Cleanup temp directory
     try {
       removeEdgeTempDir(tempDir);
-    } catch {
-      // Ignore cleanup errors
+    } catch (error) {
+      // error-policy:J6 best-effort teardown — cleanup runs in `finally` and must
+      // not mask the synthesized audio result (or the real failure) from the try
+      // body. removeEdgeTempDir already warns on the paths it declines; this
+      // catches only an unexpected rmSync throw and records it at debug.
+      logger.debug(
+        { tempDir, error: error instanceof Error ? error.message : String(error) },
+        "[EdgeTTS] Temp dir cleanup threw; ignoring to preserve the result"
+      );
     }
   }
 }

--- a/plugins/plugin-lmstudio/plugin.ts
+++ b/plugins/plugin-lmstudio/plugin.ts
@@ -53,6 +53,9 @@ export const lmStudioPlugin: Plugin = {
     // Auto-enable when LM Studio is reachable at the default localhost endpoint, even
     // without an env var. Mirrors how plugin-ollama auto-detects.
     shouldEnable: async () => {
+      // error-policy:J4 explicit degrade — this is a reachability probe run at
+      // load time; a connection/timeout failure to the local endpoint IS the
+      // "not available, don't auto-enable" answer (false), not a swallowed error.
       try {
         const result = await detectLMStudio({ timeoutMs: 750 });
         return result.available;

--- a/plugins/plugin-openrouter/__tests__/helpers.test.ts
+++ b/plugins/plugin-openrouter/__tests__/helpers.test.ts
@@ -1,12 +1,14 @@
+import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { extractJsonFromText, handleObjectGenerationError } from "../utils/helpers";
 
 /**
- * extractJsonFromText is the fallback chain that recovers a JSON object from a
- * model's text completion: raw JSON → ```json fenced block → generic fenced
- * block (only if it looks like an object) → first {...} span. A miss returns {}
- * rather than throwing, so structured-output handlers degrade gracefully on
- * chatty model responses.
+ * extractJsonFromText recovers a JSON object from a model's text completion (raw
+ * JSON → ```json fenced block → generic fenced block that looks like an object →
+ * first {...} span) and returns `null` on a total miss so an unparseable
+ * completion is distinguishable from a legitimately empty `{}`. Deterministic
+ * string fixtures — no model call. handleObjectGenerationError must rethrow a
+ * typed ElizaError, never fabricate a success-shaped `{ error }`.
  */
 
 describe("extractJsonFromText", () => {
@@ -27,14 +29,31 @@ describe("extractJsonFromText", () => {
     expect(extractJsonFromText('the result is {"value": 42} ok')).toEqual({ value: 42 });
   });
 
-  it("returns {} when no JSON can be recovered", () => {
-    expect(extractJsonFromText("no json here at all")).toEqual({});
+  it("returns null (not a fabricated {}) when no JSON can be recovered", () => {
+    expect(extractJsonFromText("no json here at all")).toBeNull();
+  });
+
+  it("returns null when a brace span is present but unparseable", () => {
+    expect(extractJsonFromText("almost {not: valid json,} really")).toBeNull();
   });
 });
 
 describe("handleObjectGenerationError", () => {
-  it("wraps the error message under an error key", () => {
-    expect(handleObjectGenerationError(new Error("boom"))).toEqual({ error: "boom" });
-    expect(handleObjectGenerationError("plain")).toEqual({ error: "plain" });
+  it("rethrows a typed ElizaError preserving the cause, never a fake success", () => {
+    const cause = new Error("boom");
+    try {
+      handleObjectGenerationError(cause);
+      expect.unreachable("handleObjectGenerationError must throw");
+    } catch (thrown) {
+      expect(thrown).toBeInstanceOf(ElizaError);
+      const err = thrown as ElizaError;
+      expect(err.code).toBe("MODEL_OBJECT_GENERATION_FAILED");
+      expect(err.message).toContain("boom");
+      expect(err.cause).toBe(cause);
+    }
+  });
+
+  it("wraps a non-Error thrown value", () => {
+    expect(() => handleObjectGenerationError("plain")).toThrow(ElizaError);
   });
 });

--- a/plugins/plugin-openrouter/utils/helpers.ts
+++ b/plugins/plugin-openrouter/utils/helpers.ts
@@ -1,55 +1,79 @@
 /**
- * Structured-output recovery helpers: `extractJsonFromText` walks a fallback
- * chain (raw JSON, fenced blocks, first `{...}` span) to salvage an object from a
- * chatty model completion, and `handleObjectGenerationError` turns a failure into
- * an `{ error }` object. `getJsonRepairFunction` optionally loads `jsonrepair`
- * when installed.
+ * Structured-output recovery helpers. `extractJsonFromText` walks a candidate
+ * chain (raw JSON, fenced blocks, first `{...}` span) to salvage an object from
+ * a chatty model completion, returning `null` when nothing parses so callers can
+ * branch on "unparseable" rather than mistake a fabricated `{}` for a valid empty
+ * object. `handleObjectGenerationError` rethrows a generation failure as a typed
+ * `ElizaError` (context-adding rethrow) instead of masking it as `{ error }`.
+ * `getJsonRepairFunction` optionally loads `jsonrepair` when installed.
  */
-import { type JsonValue, logger } from "@elizaos/core";
+import { ElizaError, type JsonValue, logger } from "@elizaos/core";
 
 export function getJsonRepairFunction(): ((text: string) => string) | undefined {
+  // error-policy:J3 optional-dependency probe — `jsonrepair` is not a declared
+  // dependency; its absence (module-not-found) is the expected "unavailable"
+  // signal, distinct from a real failure. Returning undefined is the typed
+  // "no repairer" result, not a fabricated success.
   try {
     const { jsonrepair } = require("jsonrepair");
     return jsonrepair;
-  } catch {
+  } catch (error) {
+    logger.debug(
+      { error: error instanceof Error ? error.message : String(error) },
+      "[openrouter] jsonrepair not installed; skipping JSON repair"
+    );
     return undefined;
   }
 }
 
-export function handleObjectGenerationError(error: unknown): Record<string, JsonValue> {
+/**
+ * Rethrow an object-generation failure as a typed {@link ElizaError}. Never
+ * returns — the previous `{ error: message }` shape was indistinguishable from a
+ * model that legitimately produced `{ error: ... }`, so a failed generation read
+ * as a successful one downstream.
+ */
+export function handleObjectGenerationError(error: unknown): never {
   const message = error instanceof Error ? error.message : String(error);
-  logger.error(`Error generating object: ${message}`);
-  return { error: message };
+  throw new ElizaError(`Object generation failed: ${message}`, {
+    code: "MODEL_OBJECT_GENERATION_FAILED",
+    cause: error,
+  });
 }
 
-export function extractJsonFromText(text: string): Record<string, JsonValue> {
-  try {
-    return JSON.parse(text) as Record<string, JsonValue>;
-  } catch {}
+/**
+ * Parse a JSON object out of a model completion, trying raw text then fenced and
+ * inline `{...}` spans. Returns `null` when no candidate parses — an explicit
+ * "unparseable" signal callers must branch on; it never fabricates a valid `{}`.
+ */
+export function extractJsonFromText(text: string): Record<string, JsonValue> | null {
+  const candidates: string[] = [text];
 
   const jsonBlockMatch = text.match(/```json\s*([\s\S]*?)\s*```/);
   if (jsonBlockMatch?.[1]) {
-    try {
-      return JSON.parse(jsonBlockMatch[1].trim()) as Record<string, JsonValue>;
-    } catch {}
+    candidates.push(jsonBlockMatch[1].trim());
   }
 
   const codeBlockMatch = text.match(/```\w*\s*([\s\S]*?)\s*```/);
   if (codeBlockMatch?.[1]) {
     const content = codeBlockMatch[1].trim();
     if (content.startsWith("{") && content.endsWith("}")) {
-      try {
-        return JSON.parse(content) as Record<string, JsonValue>;
-      } catch {}
+      candidates.push(content);
     }
   }
 
   const jsonMatch = text.match(/\{[\s\S]*\}/);
   if (jsonMatch?.[0]) {
+    candidates.push(jsonMatch[0]);
+  }
+
+  for (const candidate of candidates) {
+    // error-policy:J3 untrusted-input sanitizing — probing each candidate for
+    // parseability is expected; a non-parsing candidate falls through to the
+    // next, and exhausting all of them yields the typed `null` invalid signal.
     try {
-      return JSON.parse(jsonMatch[0]) as Record<string, JsonValue>;
+      return JSON.parse(candidate) as Record<string, JsonValue>;
     } catch {}
   }
 
-  return {};
+  return null;
 }


### PR DESCRIPTION
## Fallback-slop sweep (#12182): model/inference plugins — high-confidence slice

Precision-first slice of the #12271 sweep against the model/inference plugins. This tree is
**high-risk** for over-removal — provider failover chains and retry are legitimate (J1/J4) — so
this PR converts only the issue's **named high-confidence slop exemplars** and annotates the
justified handlers touched alongside them. It deliberately leaves a large `sitesLeft` (the
local-inference / aosp-bootstrap teardown `.catch` surface, the `?? <lit>` config defaults, and
the other provider object-parse helpers) for follow-up passes rather than risk reddening
existing tests. Base: `origin/develop` @ `b2dae906e1`. Foundation #12263 (`ElizaError`,
`runtime.reportError`, the diff-scoped ratchet) is on develop and used here.

### Re-derived site table (verdict per site)

| Site | Before | Verdict | After |
|---|---|---|---|
| `plugin-openrouter/utils/helpers.ts` `extractJsonFromText` (final `return {}`) | fabricates a valid empty object for unparseable model output | **slop → convert** | returns typed `null` (`Record \| null`); callers branch on "unparseable" |
| `plugin-openrouter/utils/helpers.ts` `handleObjectGenerationError` (`return { error }`) | converts an exception into a success-shaped object | **slop → convert** | rethrows `ElizaError("MODEL_OBJECT_GENERATION_FAILED", { cause })` |
| `plugin-openrouter/utils/helpers.ts` candidate-probe `try/catch` ×4 | probes JSON candidates | **justified J3** | collapsed to one annotated loop; parse miss falls through to typed `null` |
| `plugin-openrouter/utils/helpers.ts` `getJsonRepairFunction` optional-dep `catch` | swallows module-not-found | **justified J3** | annotated + `logger.debug`; absence is the typed "no repairer" |
| `plugin-anthropic/utils/credential-store.ts` `readFromCredentialStore` `catch { return null }` | ENOENT and corrupt both → `null` (silent auth downgrade) | **slop → convert** | ENOENT → `null` (J3); read error / corrupt JSON → `throw ElizaError("CREDENTIALS_UNREADABLE" / "CREDENTIALS_CORRUPT")` |
| `plugin-anthropic/utils/credential-store.ts` `readFromMacKeychain` `catch { return null }` | no-entry and corrupt both → `null` | **slop → convert** | non-zero `security` exit → `null` (J3); unparseable payload → `throw CREDENTIALS_CORRUPT` |
| `plugin-anthropic/utils/credential-store.ts` app-managed multi-location `catch` | probes 3 known paths | **justified J3** | annotated (absence at one location moves to next; exhaust → honest `null`) |
| `plugin-edge-tts/src/index.ts` `removeEdgeTempDir` realpath `catch { return false }` | silent teardown failure | **justified J6 (+observability)** | annotated + `logger.warn` so a repeatedly-leaking temp dir is observable |
| `plugin-edge-tts/src/index.ts` `removeEdgeTempDir` symlink-escape guard `return false` | silent refuse | **justified J6 (+observability)** | annotated + `logger.warn` on the leak |
| `plugin-edge-tts/src/index.ts` finally-block cleanup `catch {}` (empty) | swallows cleanup error | **justified J6** | annotated + `logger.debug`; empty catch removed (1→0 per ratchet) |
| `plugin-lmstudio/plugin.ts` `shouldEnable` `catch { return false }` | reachability probe | **justified J4** | annotated (connect/timeout failure IS "not available") |

### Per-category tally

- **Converted to fail-fast (behavior-changing):** 4 sites — openrouter `extractJsonFromText` (→ `null`) and `handleObjectGenerationError` (→ throw); anthropic `readFromCredentialStore` and `readFromMacKeychain` (corrupt → throw, absent still → `null`).
- **Annotated justified keeps:** 7 handlers — openrouter J3 ×2, anthropic J3 ×1, edge-tts J6 ×3 (two gained a `logger.warn`, one a `logger.debug` + empty-catch removal), lmstudio J4 ×1.
- **Left untouched (`sitesLeft`, counted, not converted):** the remainder of the ~278-candidate slice — local-inference / aosp-local-inference bootstrap teardown `.catch(() => {})` chains (J6-shaped best-effort teardown), ollama/cli-inference stream-usage `.catch(() => undefined)`, the `?? <lit>` / `|| <lit>` provider config defaults (base-URL / model-name defaults are legitimate), lmstudio's documented zero-vector-on-**unset**-embedding-model (config absence, not failure — needs a product decision + CLAUDE.md update), anthropic-proxy `jwtExpiresAt` diagnostic `return 0`, and the copy-paste object-parse helpers in google-genai/groq/xai/zai. Left because distinguishing "masking a failure" from "designed degrade / legitimate absent value" was not high-confidence, or because a conversion would red an existing test / documented behavior. Precision over completeness.

### Exemplar before → after + test

`plugin-openrouter/utils/helpers.ts`:

```ts
// BEFORE — unparseable model output is indistinguishable from the model returning {}
export function extractJsonFromText(text: string): Record<string, JsonValue> { ...; return {}; }
export function handleObjectGenerationError(error: unknown): Record<string, JsonValue> {
  return { error: message };   // a failed generation reads as a successful { error: ... }
}

// AFTER
export function extractJsonFromText(text: string): Record<string, JsonValue> | null { ...; return null; }
export function handleObjectGenerationError(error: unknown): never {
  throw new ElizaError(`Object generation failed: ${message}`, { code: "MODEL_OBJECT_GENERATION_FAILED", cause: error });
}
```

Test (`__tests__/helpers.test.ts`) rewritten to assert `extractJsonFromText` returns `null` on a
total miss and on a present-but-unparseable brace span, and that `handleObjectGenerationError`
throws an `ElizaError` with code `MODEL_OBJECT_GENERATION_FAILED` and the preserved `cause` — no
test asserts a fabricated `{}`.

New real-error-path tests in `plugin-anthropic/__tests__/credential-store.test.ts` write a
**real** corrupt `~/.claude/.credentials.json` to a temp `CLAUDE_CONFIG_DIR` and assert
`getClaudeOAuthToken()` throws `CREDENTIALS_CORRUPT` (not `null`), and that a genuinely absent
file still yields the honest "could not read OAuth token" guidance error — no mock of the file
reader.

### Ratchet proof

```
$ bun run audit:error-policy-ratchet
[error-policy-ratchet] base origin/develop (b2dae906e1); 1 changed production source file(s)
[error-policy-ratchet]   plugins/plugin-edge-tts/src/index.ts: emptyCatch 1->0, serverConsole 0->0
[error-policy-ratchet] no new fallback-slop in touched files
```

Slop reduced (edge-tts empty catch 1→0; openrouter `utils/helpers.ts` empty catches 4→1, both
remaining annotated J3 — that file is outside the ratchet's `src/`-scoped production set so it
is not counted, but the reduction is real), none added.

### Test results

- `plugin-openrouter test` — **5 files, 31 passed** (incl. rewritten helpers tests).
- `plugin-anthropic test` — **29 passed / 2 skipped** (incl. 3 credential-store tests: existing + 2 new corrupt/absent).
- `plugin-edge-tts test` — **8 passed**.
- `plugin-lmstudio test` — **49 passed**.
- `typecheck` clean for all four plugins.

### Evidence (`PR_EVIDENCE.md`)

- **Real-error-path test (no mock):** the anthropic corrupt-credential test drives a real temp
  file through the real reader and asserts the typed `ElizaError` — the fabricated-`null` path is
  gone. N/A for a live-provider unroutable-URL trajectory in this slice: the converted sites are
  the JSON-extract / credential / teardown helpers, not the HTTP request path (the request path
  already throws into the runtime's transient/fatal classifier — see `plugin-lmstudio` embedding
  handler which already throws per #9324 and is left intact).
- **Backend logs / real-LLM trajectory:** `N/A - <no HTTP request-path site was converted in this
  slice; the model-call layer already surfaces transient/fatal failures>`.
- **Screenshots / video:** `N/A - no UI surface touched (model/inference plugins register handlers only)`.

Refs #12271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
