### PR TITLE
fix(#12269): handle now-throwing cache methods at their best-effort callers (crash-regression fix)

### DIFF
--- a/packages/core/src/features/autonomy/service.ts
+++ b/packages/core/src/features/autonomy/service.ts
@@ -285,8 +285,19 @@ export class AutonomyService extends Service {
 		].join(":");
 
 		if (typeof this.runtime.getCache === "function") {
-			const cached =
-				await this.runtime.getCache<AutonomyCompactionCacheEntry>(cacheKey);
+			let cached: AutonomyCompactionCacheEntry | undefined;
+			try {
+				cached =
+					await this.runtime.getCache<AutonomyCompactionCacheEntry>(cacheKey);
+			} catch (err) {
+				// error-policy:J7 best-effort read of an optional cache — getCache now
+				// throws on a DB error (#12269); degrade to a cache miss and recompute
+				// below instead of aborting the deterministic compaction.
+				this.runtime.reportError("AutonomyCompaction", err, {
+					cacheKey,
+					step: "getCache",
+				});
+			}
 			if (cached?.summary) {
 				this.autonomyCompactionStats.cacheHits += 1;
 				this.autonomyCompactionStats.lastSourceCount = cached.sourceCount;
@@ -308,9 +319,17 @@ export class AutonomyService extends Service {
 		this.autonomyCompactionStats.lastSummaryChars = summary.length;
 
 		if (typeof this.runtime.setCache === "function") {
-			const stored = await this.runtime.setCache(cacheKey, entry);
-			if (stored !== false) {
+			try {
+				await this.runtime.setCache(cacheKey, entry);
 				this.autonomyCompactionStats.cacheWrites += 1;
+			} catch (err) {
+				// error-policy:J7 best-effort cache write — setCache now throws on a DB
+				// error (#12269); the entry is already computed, so surface the failure
+				// and still return it rather than losing the compaction.
+				this.runtime.reportError("AutonomyCompaction", err, {
+					cacheKey,
+					step: "setCache",
+				});
 			}
 		}
 

--- a/packages/core/src/utils/prompt-batcher/batcher.ts
+++ b/packages/core/src/utils/prompt-batcher/batcher.ts
@@ -288,7 +288,14 @@ export class PromptBatcher {
 	invalidateCache(sectionId: string): void {
 		const cacheKey = this._cacheKey(sectionId);
 		this.inMemoryCache.delete(cacheKey);
-		void this.runtime.deleteCache(cacheKey);
+		// error-policy:J7 best-effort DB cache invalidation — the in-memory entry is
+		// already cleared above and a stale DB cache row is harmless, so a delete
+		// failure (deleteCache now throws on DB error, #12269) must NOT become an
+		// unhandled rejection that terminates one-shot CLI / embedded hosts. Surface
+		// via reportError, never rethrow.
+		void this.runtime
+			.deleteCache(cacheKey)
+			.catch((err) => this.runtime.reportError("PromptBatcher", err, { cacheKey }));
 	}
 
 	invalidateAllCaches(): void {


### PR DESCRIPTION
## Fix a crash regression from the merged DB-adapter slop sweep (#12602 / #12269)

Found by an **adversarial correctness audit** of the merged fallback-slop fail-fast sweeps. The DB-adapter sweep correctly made the cache methods fail-fast — `getCache`/`setCache`/`deleteCache` now **throw** `ElizaError` on a DB error (annotated `// error-policy:J2`) instead of returning `undefined`/`false`. But two **best-effort callers** still assumed the old return-a-default contract, and the throw now weaponizes them.

### 1. `PromptBatcher.invalidateCache` — unhandled rejection → process crash (confirmed)
`batcher.ts` did:
```ts
this.inMemoryCache.delete(cacheKey);
void this.runtime.deleteCache(cacheKey);   // fire-and-forget, no .catch
```
`runtime.deleteCache → adapter.deleteCaches([key]) → base.ts deleteCache` (`plugin-sql/base.ts:3489`, now throws `DB_DELETE_FAILED`). A transient DB error during **normal cache invalidation** (this runs on the drain path + `invalidateAllCaches`) becomes an **unhandled promise rejection**:
- long-running agents: downgraded to a non-fatal log by `installProcessCrashGuards` (but now noisy on every DB blip — was silent);
- **one-shot CLI** (`run-main.ts` `unhandledRejection` → `process.exit(1)`) and **hosts embedding `@elizaos/core`** without those guards (Node 24 default = terminate): **process termination**, where it previously degraded silently.

The in-memory entry is already cleared and a stale DB cache row is harmless → this is a genuine **J7** best-effort boundary. Now `.catch(err => runtime.reportError(...))` — surfaced, never crashes.

### 2. `AutonomyService.getCompactedAutonomyThoughts` — best-effort cache aborts a deterministic recompute
The method wraps a **deterministic** compaction (no LLM cost, always succeeds) in best-effort `getCache`/`setCache`. Post-sweep both throw on a DB blip and **abort the successful compaction** instead of degrading. The `if (stored !== false)` guard was written for the old false-on-error contract. Both cache ops are now `try/catch`'d (**J7**) → `reportError` + continue; the computed entry is always returned.

### Correctness
- `reportError(scope, error: unknown, ctx?): void` is on `IAgentRuntime` and is itself self-safe (never throws) — so the `.catch` handler resolves the rejection cleanly.
- No behavior change on the success path; only the DB-error path degrades gracefully instead of throwing at a best-effort boundary.
- Scoped 2-file diff; these are the only fire-and-forget / `!== false` cache callers repo-wide (grep-verified).

Refs #12602 · #12269 · #12182
