### PR TITLE
fix(cloud): unblock the prod Worker deploy — add missing @elizaos/core stub exports (completes #12051 security promote)

### DIFF
--- a/packages/cloud/api/__tests__/elizaos-core-stub.test.ts
+++ b/packages/cloud/api/__tests__/elizaos-core-stub.test.ts
@@ -4,6 +4,9 @@ import {
   DEFAULT_CEREBRAS_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
+  fetchWithSsrfGuard,
+  runWithTrajectoryPurpose,
+  SsrfBlockedError,
 } from "../src/stubs/elizaos-core";
 
 describe("elizaos-core Worker stub", () => {
@@ -13,5 +16,113 @@ describe("elizaos-core Worker stub", () => {
     expect(DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL).toBe(
       DEFAULT_CEREBRAS_TEXT_MODEL,
     );
+  });
+
+  test("runWithTrajectoryPurpose runs the callback and returns its result", async () => {
+    await expect(
+      runWithTrajectoryPurpose("inbox_triage", async () => "ok"),
+    ).resolves.toBe("ok");
+  });
+
+  describe("fetchWithSsrfGuard", () => {
+    const noFetch = () => {
+      throw new Error("fetch must not be reached for a blocked URL");
+    };
+
+    test("blocks non-http(s) schemes, localhost, internal names, and private/reserved IPs", async () => {
+      const blocked = [
+        "file:///etc/passwd",
+        "ftp://example.com/x",
+        "http://localhost/x",
+        "http://sub.localhost/x",
+        "http://metadata.google.internal/computeMetadata/v1/",
+        "http://foo.internal/x",
+        "http://printer.local/x",
+        "http://127.0.0.1/x",
+        "http://10.1.2.3/x",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://172.16.0.1/x",
+        "http://192.168.1.1/x",
+        "http://100.64.0.1/x",
+        "http://0.0.0.0/x",
+        "http://[::1]/x",
+        "http://[fe80::1]/x",
+        "http://[fd00::1]/x",
+        "http://[::ffff:127.0.0.1]/x",
+      ];
+      for (const url of blocked) {
+        await expect(
+          fetchWithSsrfGuard({ url, fetchImpl: noFetch }),
+        ).rejects.toBeInstanceOf(SsrfBlockedError);
+      }
+    });
+
+    test("fetches an allowed URL and returns { response, finalUrl, release }", async () => {
+      const { response, finalUrl, release } = await fetchWithSsrfGuard({
+        url: "https://example.com/audio.mp3",
+        fetchImpl: async () => new Response("bytes", { status: 200 }),
+      });
+      expect(response.status).toBe(200);
+      expect(finalUrl).toBe("https://example.com/audio.mp3");
+      await expect(response.text()).resolves.toBe("bytes");
+      await release();
+    });
+
+    test("follows redirects manually, re-validates every hop, and strips credentials cross-origin", async () => {
+      const seen: Array<{ url: string; auth: string | null }> = [];
+      const fetchImpl = async (
+        input: RequestInfo | URL,
+        init?: RequestInit,
+      ) => {
+        const url = String(input);
+        seen.push({
+          url,
+          auth: new Headers(init?.headers).get("authorization"),
+        });
+        if (url === "https://a.example.com/start") {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://b.example.com/next" },
+          });
+        }
+        return new Response("done", { status: 200 });
+      };
+      const { response, finalUrl } = await fetchWithSsrfGuard({
+        url: "https://a.example.com/start",
+        init: { headers: { authorization: "Bearer secret" } },
+        fetchImpl,
+      });
+      expect(response.status).toBe(200);
+      expect(finalUrl).toBe("https://b.example.com/next");
+      expect(seen[0]?.auth).toBe("Bearer secret");
+      expect(seen[1]?.auth).toBeNull(); // stripped on the cross-origin hop
+    });
+
+    test("blocks a redirect that targets an internal address", async () => {
+      await expect(
+        fetchWithSsrfGuard({
+          url: "https://a.example.com/start",
+          fetchImpl: async () =>
+            new Response(null, {
+              status: 302,
+              headers: { location: "http://169.254.169.254/latest/meta-data/" },
+            }),
+        }),
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
+    });
+
+    test("gives up after maxRedirects hops", async () => {
+      await expect(
+        fetchWithSsrfGuard({
+          url: "https://a.example.com/loop",
+          maxRedirects: 2,
+          fetchImpl: async (input) =>
+            new Response(null, {
+              status: 302,
+              headers: { location: `${String(input)}x` },
+            }),
+        }),
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
+    });
   });
 });

--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -258,6 +258,251 @@ export function runWithTrajectoryContext<T>(
   return fn();
 }
 
+/**
+ * Worker-safe stand-in for `runWithTrajectoryPurpose` (same rationale as
+ * `runWithTrajectoryContext` above): with no trajectory manager in the Worker
+ * bundle there is no ambient context to preserve or purpose-tag, so just run
+ * the function. (Pulled in transitively via `@elizaos/shared`
+ * email-classification — not invoked on a Worker route.)
+ */
+export function runWithTrajectoryPurpose<T>(
+  _purpose: string,
+  fn: () => T | Promise<T>,
+): T | Promise<T> {
+  return fn();
+}
+
+// ---------------------------------------------------------------------------
+// fetchWithSsrfGuard — Worker-safe port of @elizaos/core/network/fetch-guard.
+//
+// Pulled into the bundle via plugin-elizacloud transcription (`audioUrl`
+// fetch). workerd has no `node:dns`, so the core guard's DNS pinning is not
+// portable; everything else is reproduced: http(s)-only, blocked-hostname +
+// private/loopback/link-local literal-IP rejection, manual redirect following
+// with re-validation on every hop, credential-header stripping on
+// cross-origin hops, spec-correct 301/302/303 GET rewrites, and timeout
+// wiring. Fail-closed: a URL this port cannot positively clear is rejected.
+// ---------------------------------------------------------------------------
+
+/** Mirrors core's `SsrfBlockedError` for callers that match on `name`. */
+export class SsrfBlockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SsrfBlockedError";
+  }
+}
+
+export type GuardedFetchOptions = {
+  url: string;
+  fetchImpl?: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Promise<Response>;
+  init?: RequestInit;
+  maxRedirects?: number;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+};
+
+export type GuardedFetchResult = {
+  response: Response;
+  finalUrl: string;
+  release: () => Promise<void>;
+};
+
+const SSRF_BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "metadata",
+  "metadata.google.internal",
+  "instance-data",
+]);
+const SSRF_BLOCKED_HOST_SUFFIXES = [
+  ".localhost",
+  ".local",
+  ".internal",
+  ".home.arpa",
+];
+
+function isPrivateIpv4(hostname: string): boolean {
+  const m = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) return false;
+  const octets = [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4])];
+  if (octets.some((o) => o > 255)) return true; // malformed literal — reject
+  const [a, b] = octets;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) || // CGNAT
+    (a === 169 && b === 254) || // link-local / cloud metadata
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 0) || // 192.0.0.0/24 special + 192.0.2.0/24 doc
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    a >= 224 // multicast + reserved + broadcast
+  );
+}
+
+function isBlockedIpLiteral(hostname: string): boolean {
+  if (isPrivateIpv4(hostname)) return true;
+  const h = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (!h.includes(":")) return false; // not an IPv6 literal
+  if (h === "::" || h === "::1") return true;
+  if (
+    h.startsWith("fe80:") ||
+    h.startsWith("fe9") ||
+    h.startsWith("fea") ||
+    h.startsWith("feb")
+  )
+    return true; // link-local fe80::/10
+  if (h.startsWith("fc") || h.startsWith("fd")) return true; // unique-local fc00::/7
+  if (h.startsWith("ff")) return true; // multicast
+  // v4-mapped: dotted form (::ffff:127.0.0.1) or the canonical hex form the
+  // WHATWG URL parser serializes it to (::ffff:7f00:1).
+  const v4MappedDotted = h.match(
+    /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/,
+  );
+  if (v4MappedDotted?.[1]) return isPrivateIpv4(v4MappedDotted[1]);
+  const v4MappedHex = h.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (v4MappedHex?.[1] && v4MappedHex[2]) {
+    const hi = Number.parseInt(v4MappedHex[1], 16);
+    const lo = Number.parseInt(v4MappedHex[2], 16);
+    return isPrivateIpv4(`${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`);
+  }
+  return false;
+}
+
+function assertSsrfAllowedUrl(url: URL): void {
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new SsrfBlockedError(
+      `Blocked non-http(s) URL scheme: ${url.protocol}`,
+    );
+  }
+  const host = url.hostname.toLowerCase().replace(/\.$/, "");
+  if (host.length === 0) {
+    throw new SsrfBlockedError("Blocked URL with empty hostname");
+  }
+  if (SSRF_BLOCKED_HOSTNAMES.has(host)) {
+    throw new SsrfBlockedError(`Blocked hostname: ${host}`);
+  }
+  if (SSRF_BLOCKED_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix))) {
+    throw new SsrfBlockedError(`Blocked internal hostname: ${host}`);
+  }
+  if (isBlockedIpLiteral(host)) {
+    throw new SsrfBlockedError(`Blocked private/reserved IP literal: ${host}`);
+  }
+}
+
+const SSRF_CROSS_ORIGIN_STRIPPED_HEADERS = [
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+];
+const SSRF_REDIRECT_BODY_STRIPPED_HEADERS = [
+  "content-encoding",
+  "content-language",
+  "content-location",
+  "content-type",
+  "content-length",
+];
+
+function stripHeaders(
+  headers: HeadersInit | undefined,
+  names: string[],
+): Headers {
+  const cleaned = new Headers(headers);
+  for (const name of names) cleaned.delete(name);
+  return cleaned;
+}
+
+function combineAbortSignals(
+  a?: AbortSignal,
+  b?: AbortSignal,
+): AbortSignal | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  const controller = new AbortController();
+  for (const signal of [a, b]) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      break;
+    }
+    signal.addEventListener("abort", () => controller.abort(signal.reason), {
+      once: true,
+    });
+  }
+  return controller.signal;
+}
+
+export async function fetchWithSsrfGuard(
+  options: GuardedFetchOptions,
+): Promise<GuardedFetchResult> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const maxRedirects = options.maxRedirects ?? 3;
+  const timeoutSignal =
+    options.timeoutMs !== undefined
+      ? AbortSignal.timeout(options.timeoutMs)
+      : undefined;
+  const signal = combineAbortSignals(options.signal, timeoutSignal);
+
+  let current = new URL(options.url);
+  let method = (options.init?.method ?? "GET").toUpperCase();
+  let body = options.init?.body;
+  let headers = new Headers(options.init?.headers);
+
+  for (let hop = 0; hop <= maxRedirects; hop++) {
+    assertSsrfAllowedUrl(current);
+    const response = await fetchImpl(current.toString(), {
+      ...options.init,
+      method,
+      body,
+      headers,
+      redirect: "manual",
+      signal,
+    });
+
+    const location = response.headers.get("location");
+    if (response.status >= 300 && response.status < 400 && location) {
+      const next = new URL(location, current);
+      try {
+        if (!response.bodyUsed) await response.body?.cancel();
+      } catch {
+        // redirect body already settled — nothing to release
+      }
+      // Spec redirect rewrite: 301/302 POST→GET, 303 anything-but-GET/HEAD→GET.
+      if (
+        ((response.status === 301 || response.status === 302) &&
+          method === "POST") ||
+        (response.status === 303 && method !== "GET" && method !== "HEAD")
+      ) {
+        method = "GET";
+        body = undefined;
+        headers = stripHeaders(headers, SSRF_REDIRECT_BODY_STRIPPED_HEADERS);
+      }
+      if (next.origin !== current.origin) {
+        headers = stripHeaders(headers, SSRF_CROSS_ORIGIN_STRIPPED_HEADERS);
+      }
+      current = next;
+      continue;
+    }
+
+    return {
+      response,
+      finalUrl: current.toString(),
+      release: async () => {
+        try {
+          if (!response.bodyUsed) await response.body?.cancel();
+        } catch {
+          // body already consumed/locked — nothing to release
+        }
+      },
+    };
+  }
+  throw new SsrfBlockedError(
+    `Exceeded ${maxRedirects} redirects fetching ${options.url}`,
+  );
+}
+
 type InferenceTimingMeta = Record<string, string | number | boolean>;
 
 /**

--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -1619,6 +1619,14 @@
           "help": "Discord channel ID used during test suite to locate the test channel for sending messages, voice interactions, and other test operations.",
           "advanced": false
         },
+        "DISCORD_VOICE_TRANSCRIPTS": {
+          "type": "string",
+          "required": false,
+          "sensitive": false,
+          "label": "Voice Transcripts",
+          "help": "Set to \"on\" to record live diarized meeting transcripts whenever the bot sits in a voice channel. Off by default; the /transcribe slash command can start/stop per channel.",
+          "advanced": false
+        },
         "DISCORD_VOICE_CHANNEL_ID": {
           "type": "string",
           "required": false,


### PR DESCRIPTION
## Unblock the prod Worker deploy (security promote #12051 is NOT live on the API Worker)

The #12051 develop→main promote merged cleanly, migrations ran, and Console Pages deployed — but the **Deploy API Worker** job of run [28680305905](https://github.com/elizaOS/eliza/actions/runs/28680305905) failed at `wrangler deploy`:

```
✘ No matching export in "src/stubs/elizaos-core.ts" for import "runWithTrajectoryPurpose"
    (via packages/shared/src/email-classification/email-classifier.ts)
✘ No matching export in "src/stubs/elizaos-core.ts" for import "fetchWithSsrfGuard"
    (via plugins/plugin-elizacloud/src/models/transcription.ts)
```

So the cross-org IDOR fixes (#11981) + app-key scope fixes (#11943/#11958) + money fixes are on `main` but **not yet running on api.elizacloud.ai**. The Worker aliases `@elizaos/core` → `src/stubs/elizaos-core.ts` at bundle time; code merged to develop started importing two core symbols the stub never gained. The deploy job's `Verify Worker` typecheck resolves the *real* core types, so this only surfaces at the wrangler bundling step.

### Fix

- **`runWithTrajectoryPurpose`** — passthrough stub, same rationale + comment pattern as the existing `runWithTrajectoryContext` stub (no trajectory manager in the Worker bundle; pulled in transitively, not invoked on a Worker route).
- **`fetchWithSsrfGuard`** — a real Worker-safe port of `core/src/network/fetch-guard.ts`, **not** a bare `fetch` passthrough, so the SSRF guarantee survives if the path ever executes on the Worker: http(s)-only, blocked-hostname (`localhost`/`*.local`/`*.internal`/metadata) + private/reserved IP-literal rejection (incl. v4-mapped IPv6 in both dotted and URL-canonical hex form), manual redirect following with per-hop re-validation, cross-origin credential-header stripping, spec-correct 301/302/303 GET rewrites, timeout wiring, `{ response, finalUrl, release }` contract. The one intentional delta from core: no DNS pinning (workerd has no `node:dns`).
- **Stub parity test extended** (`__tests__/elizaos-core-stub.test.ts`): imports + exercises both new exports — blocked-URL matrix, allowed fetch, cross-origin credential stripping, redirect-to-metadata block, redirect cap.

### Evidence

- `bun test __tests__/elizaos-core-stub.test.ts` → 7 pass / 0 fail (31 asserts).
- `bunx wrangler deploy --dry-run --env production` from this branch → bundle builds clean (the exact step that failed in CI). Output attached in PR comment thread.
- Develop carries the identical stub + importing files (its staging Worker deploy hits the same wall once its separate `build:core` break clears) — same patch will be PR'd to develop as a follow-up.

Merging this to `main` re-triggers `cloud-cf-deploy.yml`; I'll approve the migrate-db gate (migrations idempotent — 0171 already applied by run 28680305905) and watch the Worker deploy through, then verify `/api/health` + prod behavior.

— [cloud-frontdoor]
