### PR TITLE
docs(#12759): clean cloud bridge tail comments

### DIFF
--- a/plugins/plugin-capacitor-bridge/scripts/check-android-manifest.mjs
+++ b/plugins/plugin-capacitor-bridge/scripts/check-android-manifest.mjs
@@ -1,3 +1,10 @@
+/**
+ * Android manifest guard for the Capacitor bridge native fragment.
+ *
+ * The package build runs this before bundling so a stray `tools:*` attribute
+ * cannot reach Capacitor sync without the namespace declaration Android needs.
+ */
+
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-capacitor-bridge/src/android/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/bridge.ts
@@ -130,7 +130,7 @@ function setupAndroidBridgeEnvironment(): string {
 		canonicalHome = rawHome;
 	}
 
-	// Remap any env var that starts with the old (symlink) prefix to the
+	// Remap any env var that starts with the symlinked prefix to the
 	// canonical (real) prefix so downstream code resolves paths consistently.
 	if (canonicalHome !== rawHome) {
 		if (process.env.HOME) process.env.HOME = canonicalHome;

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for the Android in-process route dispatch path.
+ *
+ * They drive `dispatchBufferedRequest` and `dispatchStreamingRequest` against a
+ * fake route kernel, proving the loopback buffered envelope and incremental
+ * streaming sink lifecycle without booting a runtime or device.
+ */
+
 import type { IAgentRuntime, RouteHandlerResult } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import type { StdioBridgeStreamSink } from "../shared/stdio-bridge.ts";
@@ -6,14 +14,6 @@ import {
 	dispatchBufferedRequest,
 	dispatchStreamingRequest,
 } from "./dispatch.ts";
-
-/**
- * Unit tests for the Android in-process route dispatch (#12352). They drive
- * `dispatchBufferedRequest` / `dispatchStreamingRequest` against a fake
- * `dispatchRoute` standing in for the real in-process kernel — no runtime boot,
- * no device — asserting the loopback-shaped buffered envelope and the
- * incremental streaming sink lifecycle the WebView contract depends on.
- */
 
 const runtime = {} as IAgentRuntime;
 

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
@@ -175,8 +175,8 @@ function notFound(method: string, pathname: string): AndroidBufferedResponse {
 /**
  * Dispatch one buffered request in-process and return the loopback-shaped
  * envelope. Throws on an invalid path/method (the caller surfaces it as an
- * error frame). A body arrives already-buffered because the handler ran to
- * `res.end()` before this resolves.
+ * error frame). A body arrives already-buffered because this resolves only after
+ * the handler runs to `res.end()`.
  */
 export async function dispatchBufferedRequest(
 	runtime: IAgentRuntime,

--- a/plugins/plugin-capacitor-bridge/src/index.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/index.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Import-safety coverage for the Capacitor bridge public barrel.
+ *
+ * Desktop consumers must be able to import helper exports without implicitly
+ * booting Android bridge state or mutating mobile platform environment vars.
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const SAVED_ENV = {

--- a/plugins/plugin-capacitor-bridge/src/index.ts
+++ b/plugins/plugin-capacitor-bridge/src/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Public entry point for the Capacitor mobile device bridge package.
+ *
+ * The package exports lazy Android/iOS CLI bootstraps, the runtime service
+ * plugin, and filesystem sandbox utilities without starting mobile bridge
+ * state during ordinary desktop imports.
+ */
+
 export async function runAndroidBridgeCli(): Promise<void> {
 	const { runAndroidBridgeCli } = await import("./android/bridge.js");
 	await runAndroidBridgeCli();

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -1,3 +1,11 @@
+/**
+ * iOS Bun-host bridge for the Capacitor local-agent runtime.
+ *
+ * The native shell starts this module over stdio, then exchanges JSON-RPC
+ * frames for in-process API routes, local model loading, downloads, voice
+ * calls, and transcript surfaces while all filesystem access stays sandboxed.
+ */
+
 import { Buffer } from "node:buffer";
 import crypto from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
@@ -50,10 +58,6 @@ import {
 } from "../shared/stdio-bridge.ts";
 import { runModelGrind } from "./model-grind.ts";
 
-// `BridgeRequest` / `BridgeResponse` are the shared stdio frame types
-// (imported above as aliases) — the single source of truth for the NDJSON
-// request/response envelope this bridge speaks.
-
 interface HostCallFrame {
 	type: "host_call";
 	id: string;
@@ -103,7 +107,7 @@ interface HttpRequestPayload {
 interface HttpStreamRequestPayload extends HttpRequestPayload {
 	/**
 	 * The stream identity the caller pre-allocated so it can attach
-	 * `agentStream*` listeners before this request runs (the native `call`
+	 * `agentStream*` listeners ahead of this request (the native `call`
 	 * blocks until the stream finishes, so listeners must be live first).
 	 */
 	streamId?: unknown;
@@ -4433,8 +4437,7 @@ async function dispatchBridgeRequest(
 			// Each frame reaches the WebView as a `stream_emit` host-call, which the
 			// native host translates into an `agentStream*` Capacitor event. The
 			// call blocks until the stream finishes; tokens are already delivered by
-			// then, so the caller's listeners (attached before this ran) saw them
-			// live.
+			// then, so the caller's pre-attached listeners saw them live.
 			return fetchBackendStream(
 				backendForStream,
 				streamPayload,

--- a/plugins/plugin-capacitor-bridge/src/ios/model-grind.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/model-grind.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Deterministic coverage for the iOS local model grind helpers.
+ *
+ * The tests exercise WAV decoding, PCM resampling, WER scoring, and injected
+ * model-grind dependencies without invoking native llama, TTS, or ASR engines.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
 	decodeWavToPcm,

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.gating.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.gating.test.ts
@@ -1,9 +1,11 @@
-// Regression: the capacitor-llama TEXT handlers must NOT be registered while
-// nothing can serve them. On Android the WebView-side llama-cpp-capacitor
-// plugin is retired (#9560 one-bionic-path cutover), so the WS device bridge
-// can never attach; if the handlers register anyway they win `useModel`
-// routing at priority 0 and every chat turn dies with
-// "DEVICE_DISCONNECTED: no Capacitor llama device bridge attached" (#11277).
+/**
+ * Regression coverage for dead mobile bridge handler registration.
+ *
+ * Android text handlers must stay unregistered unless the bionic host or a real
+ * device bridge can serve them, otherwise they capture model routing and every
+ * chat turn fails with a disconnected-device error.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // SERVICE_ENABLED is read at module load, so enable the bridge before importing.

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.mtp.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.mtp.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Tests for Gemma mobile speculative-decoding bundle resolution.
+ *
+ * The suite builds temporary local model bundles and verifies that bootstrap
+ * load arguments enable MTP only when the staged drafter GGUF is actually
+ * present beside or inside the shipped text model bundle.
+ */
+
 import {
 	existsSync,
 	mkdirSync,

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.registry-paths.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.registry-paths.test.ts
@@ -1,10 +1,11 @@
-// Regression for #11669: the bootstrap's registry-backed model resolution
-// must survive an app-container migration. Rows are stored relative to the
-// local-inference root; legacy rows hold absolute paths from a container
-// UUID that no longer exists after an iOS reinstall/update. Before this fix
-// `resolveFromRegistry` did a verbatim existsSync on the stored string, so
-// both formats failed and the loader fell through to re-downloading a model
-// that was already fully present on disk.
+/**
+ * Regression coverage for registry-backed local model path resolution.
+ *
+ * The bootstrap must survive iOS app-container migration: relative rows resolve
+ * against the current local-inference root, while legacy absolute rows are
+ * re-anchored by their stored suffix only when the artifact exists.
+ */
+
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.serving-status.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.serving-status.test.ts
@@ -1,9 +1,11 @@
-// #11498: getMobileDeviceBridgeServingStatus must report the in-process
-// bionic host as serving ONLY when the capacitor-llama handlers were actually
-// bound via the bionic-host trigger AND the host's abstract UDS accepts a
-// connection right now — never from env configuration or plugin presence
-// alone. This is the signal the mobile-local-chat-smoke readiness gate and
-// GET /api/local-inference/providers (servingVia) rely on.
+/**
+ * Serving-status coverage for the mobile bionic host path.
+ *
+ * `getMobileDeviceBridgeServingStatus` reports the host as serving only after
+ * handler registration and a live abstract-UDS probe, which is the readiness
+ * signal consumed by smoke tests and local-inference provider status.
+ */
+
 import net from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.stream-step.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.stream-step.test.ts
@@ -1,7 +1,11 @@
-// #11913: the bionic host decodes `streamStep` tokens per native call before
-// flushing a token frame. The agent side threads the shared streaming knob
-// (ELIZA_LOCAL_STREAM_TOKENS_PER_STEP) into the op="generateStream" request;
-// unset/invalid values are omitted so the host applies its own default (8).
+/**
+ * Unit coverage for the bionic streaming step-size environment knob.
+ *
+ * The agent side forwards `ELIZA_LOCAL_STREAM_TOKENS_PER_STEP` only when it is
+ * a positive integer; unset or invalid values let the native host apply its
+ * decode-step default.
+ */
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resolveBionicStreamStep } from "./mobile-device-bridge-bootstrap";
 

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -1208,10 +1208,10 @@ function flattenChatParamsForPrompt(params: GenerateTextParams): string {
 // The bionic host does a SINGLE blocking generate per call (no streaming), so
 // the whole decode must finish inside this window. On a CPU-only build (the
 // Vulkan lib isn't staged) a small model runs at only a few tok/s, so a longer
-// reply (~200+ tokens) blew past the old 120s cap → "bionic host timed out", the
-// turn fell back to an empty/failed reply, and an empty trajectory was recorded.
-// Default to 300s (the other native device-bridge ops already use 600s) and let
-// it be tuned via env for slower devices.
+// reply (~200+ tokens) can exceed a 120s window and surface as a bionic-host
+// timeout with an empty/failed turn. Default to 300s (the other native
+// device-bridge ops already use 600s) and let it be tuned via env for slower
+// devices.
 const BIONIC_REQUEST_TIMEOUT_MS = readTimeoutMs(
 	"ELIZA_BIONIC_REQUEST_TIMEOUT_MS",
 	300_000,

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-service.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-service.test.ts
@@ -1,6 +1,10 @@
-// Item 35 (#12091): the mobile device bridge is modeled as a runtime Service
-// (ServiceType.MOBILE_DEVICE_BRIDGE) registered by the mobile-host plugin and
-// consumed via runtime.getService — NOT via the deleted core Symbol.for slot.
+/**
+ * Runtime service coverage for the Capacitor mobile device bridge.
+ *
+ * The bridge is registered through the mobile-host plugin under
+ * `ServiceType.MOBILE_DEVICE_BRIDGE` and consumed via the runtime service API.
+ */
+
 import { AgentRuntime, ServiceType } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-capacitor-bridge/src/shared/fs-promises-proxy.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/fs-promises-proxy.ts
@@ -1,3 +1,11 @@
+/**
+ * Sandboxed `node:fs/promises` facade for the iOS bridge runtime.
+ *
+ * Every path-taking promise API is wrapped through the mobile filesystem
+ * resolver so bridge code can import familiar fs helpers without escaping the
+ * native workspace root.
+ */
+
 import * as realPromises from "node:fs/promises";
 import type { AnyFn, FsAccessMode } from "./fs-sandbox.ts";
 import {

--- a/plugins/plugin-capacitor-bridge/src/shared/fs-proxy.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/fs-proxy.ts
@@ -1,3 +1,11 @@
+/**
+ * Sandboxed `node:fs` facade for the iOS bridge runtime.
+ *
+ * The proxy mirrors sync, callback, stream, and promise APIs while routing
+ * path-taking operations through the mobile filesystem resolver installed by
+ * `installMobileFsShim`.
+ */
+
 import * as realFs from "node:fs";
 
 import * as sandboxedPromises from "./fs-promises-proxy.ts";

--- a/plugins/plugin-capacitor-bridge/src/shared/fs-sandbox.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/fs-sandbox.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for the mobile filesystem sandbox wrappers.
+ *
+ * The suite exercises resolver installation, path-like normalization, open-mode
+ * detection, multi-path wrapping, and native-binary write blocking without
+ * patching the real `node:fs` module.
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	guardMobileFsWritePath,

--- a/plugins/plugin-capacitor-bridge/src/shared/fs-sandbox.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/fs-sandbox.ts
@@ -1,3 +1,11 @@
+/**
+ * Shared path-guard primitives for the mobile filesystem shim.
+ *
+ * These helpers normalize Node path-like inputs, derive read/write intent, and
+ * route filesystem calls through the workspace resolver that blocks traversal
+ * and native-binary writes.
+ */
+
 import * as realFs from "node:fs";
 import * as nodePath from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-capacitor-bridge/src/shared/local-inference-stored-path.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/local-inference-stored-path.test.ts
@@ -1,7 +1,11 @@
-// Regression for #11669: registry.json rows must survive an iOS app-container
-// migration. Stored rows are container-relative; legacy absolute rows from a
-// dead container UUID are re-anchored by their `/local-inference/` suffix and
-// only accepted when the artifact really exists at the re-anchored location.
+/**
+ * Regression coverage for persisted local-inference model paths.
+ *
+ * Registry rows survive iOS app-container migration by storing relative paths;
+ * legacy absolute rows are re-anchored by their `/local-inference/` suffix only
+ * when the artifact exists under the current state directory.
+ */
+
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-capacitor-bridge/src/shared/stdio-bridge.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/stdio-bridge.test.ts
@@ -1,17 +1,17 @@
+/**
+ * Unit tests for the platform-neutral NDJSON stdio bridge.
+ *
+ * They drive the framing and dispatch loop with fake buffered and streaming
+ * handlers, while the full iOS CLI wiring remains covered by the bridge route
+ * tests.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
 	createStdioBridge,
 	type StdioBridgeResponseFrame,
 	type StdioBridgeStreamHandler,
 } from "./stdio-bridge.ts";
-
-/**
- * Unit tests for the platform-neutral NDJSON stdio kernel (#12180). These drive
- * the framing/dispatch loop directly with a fake buffered request handler
- * standing in for the in-process `dispatchRoute` kernel, so they run with no
- * runtime boot and no device. The full iOS CLI wiring is exercised by
- * `../ios/bridge.routes.test.ts` (which must stay green after this extraction).
- */
 
 /** Collect written frames and feed NDJSON input in one shot. */
 function harness(

--- a/plugins/plugin-capacitor-bridge/src/type-shims/agent-api.ts
+++ b/plugins/plugin-capacitor-bridge/src/type-shims/agent-api.ts
@@ -1,3 +1,11 @@
+/**
+ * Type-only shim for agent API imports used by the Capacitor bridge package.
+ *
+ * The real `dispatchRoute` implementation is loaded dynamically at runtime;
+ * this file lets package-local typechecking avoid depending on built agent
+ * output.
+ */
+
 import type { IncomingMessage, ServerResponse } from "node:http";
 
 export function dispatchRoute(

--- a/plugins/plugin-capacitor-bridge/src/type-shims/agent-root.ts
+++ b/plugins/plugin-capacitor-bridge/src/type-shims/agent-root.ts
@@ -1,3 +1,10 @@
+/**
+ * Type-only shim for the agent root bootstrap imported by Android bridge code.
+ *
+ * Runtime code loads the real package dynamically; this stand-in exists only so
+ * the bridge package can typecheck without a built agent distribution.
+ */
+
 export function startEliza(_options: { serverOnly: true }): Promise<unknown> {
 	throw new Error("Type shim only");
 }

--- a/plugins/plugin-capacitor-bridge/src/type-shims/agent-runtime.ts
+++ b/plugins/plugin-capacitor-bridge/src/type-shims/agent-runtime.ts
@@ -1,3 +1,11 @@
+/**
+ * Type-only shim for the agent runtime bootstrap used by the iOS bridge.
+ *
+ * The actual `bootElizaRuntime` implementation is resolved dynamically in the
+ * bundled mobile host; this shim keeps local typechecking independent of agent
+ * build artifacts.
+ */
+
 import type { IAgentRuntime } from "@elizaos/core";
 
 export function bootElizaRuntime(): Promise<IAgentRuntime> {

--- a/plugins/plugin-capacitor-bridge/src/type-shims/app-core-root.ts
+++ b/plugins/plugin-capacitor-bridge/src/type-shims/app-core-root.ts
@@ -1,5 +1,9 @@
-// Typecheck-only stand-in for dynamic `@elizaos/app-core` imports pulled in
-// through source path mappings. The dynamic import sites cast the module shape
-// explicitly and should not depend on generated app-core dist during this
-// package's typecheck.
+/**
+ * Type-only stand-in for dynamic `@elizaos/app-core` imports.
+ *
+ * Source path mappings can pull this package into local typecheck; dynamic
+ * import sites cast the module shape explicitly and do not require generated
+ * app-core dist output.
+ */
+
 export {};

--- a/plugins/plugin-capacitor-bridge/src/type-shims/plugin-local-inference-runtime.ts
+++ b/plugins/plugin-capacitor-bridge/src/type-shims/plugin-local-inference-runtime.ts
@@ -1,3 +1,11 @@
+/**
+ * Type-only shim for optional plugin-local-inference runtime wiring.
+ *
+ * Mobile bridge code imports the real router handler dynamically when present;
+ * this file keeps the bridge package typecheck from requiring that plugin's
+ * built runtime output.
+ */
+
 export function installRouterHandler(
 	_runtime: unknown,
 	_options: unknown,

--- a/plugins/plugin-capacitor-bridge/tsup.config.ts
+++ b/plugins/plugin-capacitor-bridge/tsup.config.ts
@@ -1,3 +1,10 @@
+/**
+ * Build configuration for the Capacitor bridge package.
+ *
+ * The bundle publishes lazy CLI entries and shared fs-shim utilities while
+ * keeping elizaOS workspace packages and native llama bindings external.
+ */
+
 import { defineConfig } from "tsup";
 
 export default defineConfig({

--- a/plugins/plugin-capacitor-bridge/vitest.config.ts
+++ b/plugins/plugin-capacitor-bridge/vitest.config.ts
@@ -1,3 +1,10 @@
+/**
+ * Vitest configuration for the Capacitor bridge package.
+ *
+ * Bridge tests run serially in Node because several suites mutate process env,
+ * module caches, abstract sockets, or singleton bridge state.
+ */
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-cloud-apps/__tests__/reference-resolution.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/reference-resolution.test.ts
@@ -26,8 +26,8 @@ describe("matchAppByReference / findAppByReference — ambiguity-safe resolution
   });
 
   it("REGRESSION: a sentence naming the longer app resolves to it, not its prefix sibling", () => {
-    // The old raw-substring find() returned the first (prefix) match, so a
-    // single "delete Prod API Backup — yes" tore down the wrong "Prod API".
+    // Prefix siblings are dangerous for destructive confirms: the sentence must
+    // bind to the full named app, not the first shorter substring match.
     const apps = [app("Prod API"), app("Prod API Backup")]; // "Prod API" is first
     expect(
       matchAppByReference(apps, "delete Prod API Backup — yes").app?.name,
@@ -81,7 +81,7 @@ describe("extractAppReference — planner options (nested `parameters` first)", 
 
   it("REGRESSION: reads the real planner shape — args nested under options.parameters", () => {
     // execute-planned-tool-call.ts puts validated args at options.parameters;
-    // the old top-level-only read missed them and fell back to the raw text.
+    // falling back to raw text can lose the planner's resolved app reference.
     expect(
       extractAppReference(msg, { parameters: { appName: "Acme Bot" } }),
     ).toBe("Acme Bot");

--- a/plugins/plugin-cloud-apps/__tests__/withdraw-app-earnings.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/withdraw-app-earnings.test.ts
@@ -308,9 +308,8 @@ describe("WITHDRAW_APP_EARNINGS", () => {
 
   it("MONEY REGRESSION: planner-nested amount stages $50, NOT the full balance", async () => {
     // Real planner path (execute-planned-tool-call.ts): validated args arrive
-    // under options.parameters and the text carries no digits. The old
-    // top-level-only read missed the amount → requested=null → the FULL $100
-    // balance was staged and a confirm withdrew all of it.
+    // under options.parameters and the text carries no digits. Losing that
+    // nested amount would stage the full withdrawable balance.
     const withdrawals = trackWithdrawals();
     const runtime = keyedRuntime();
     const cb = captureCallback();
@@ -339,9 +338,8 @@ describe("WITHDRAW_APP_EARNINGS", () => {
   });
 
   it("REGRESSION: a digit inside the app name never reads as an amount", async () => {
-    // "withdraw my Acme2 earnings" — the old bare-number regex captured the
-    // "2" of "Acme2" as $2.00 (here: a below-threshold refusal; elsewhere a
-    // wrong staged amount). It must stage the full balance instead.
+    // App-name digits are not standalone money amounts; "Acme2" must resolve as
+    // an app reference and stage the full balance unless the user names an amount.
     const acme2 = makeApp({
       id: "id-acme2",
       name: "Acme2",
@@ -552,7 +550,7 @@ describe("parseWithdrawAmount — planner options (nested `parameters` first) + 
   });
 
   it("REGRESSION: a digit glued into an app name is NOT an amount", () => {
-    // The old bare-number regex captured the "2" of "Acme2" → $2.00.
+    // Only standalone numeric tokens count as requested payout amounts.
     expect(parseWithdrawAmount("withdraw my Acme2 earnings")).toBeNull();
     expect(parseWithdrawAmount("cash out App2000")).toBeNull();
     expect(parseWithdrawAmount("payout for my a1b2 app")).toBeNull();

--- a/plugins/plugin-cloud-apps/src/actions/deploy-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/deploy-app.ts
@@ -11,9 +11,9 @@
  * On a verified-live deploy we also write the idempotent facts cache so the
  * agent recalls the app later (convenience, not the gate).
  *
- * NOTE: a real end-to-end deploy cannot be verified until the staging deploy
- * backend is armed (#9853 / Phase 4). The unit tests drive the gate with a
- * mocked status progression + reachability — that is the proof for now.
+ * The completion gate is injectable, so tests pin the status progression and
+ * reachability decisions here while live staging deploy coverage remains owned
+ * by the cloud API e2e lane.
  */
 
 import type { AppDto } from "@elizaos/cloud-sdk";

--- a/plugins/plugin-cloud-apps/src/actions/regenerate-app-api-key.ts
+++ b/plugins/plugin-cloud-apps/src/actions/regenerate-app-api-key.ts
@@ -4,7 +4,7 @@
  * Rotating invalidates the current key IMMEDIATELY — anything using it stops
  * working until updated — so this action never rotates on the first ask:
  *   1. First turn ("rotate my Acme key"): resolve the app, return a confirmation
- *      prompt spelling out that the old key dies right away. No rotate call.
+ *      prompt spelling out that the previous key dies right away. No rotate call.
  *   2. Follow-up with structured `confirm: true` for the pending prompt:
  *      `client.regenerateAppApiKey(id)` runs exactly once.
  *

--- a/plugins/plugin-cloud-apps/src/client.ts
+++ b/plugins/plugin-cloud-apps/src/client.ts
@@ -235,11 +235,11 @@ export interface ReferenceMatch<T> {
  *      shorter prefix. When two or more items tie for the top score the result
  *      is AMBIGUOUS: `item` is null and `candidates` holds the tied items.
  *
- * Never silently returns the first of several equally-good matches — the old
- * raw-substring `find()` let a one-message "delete Prod API Backup" resolve to
- * (and tear down) the wrong "Prod API" app, "delete my chatbot helper" match
- * an app named "Bot" via the "bot" inside "chatbot", and an adversarially
- * named influencer profile capture someone else's booking.
+ * Never silently returns the first of several equally-good matches: destructive
+ * references such as "delete Prod API Backup" must not resolve to the shorter
+ * "Prod API" prefix, "delete my chatbot helper" must not match an app named
+ * "Bot", and adversarial influencer names must not capture someone else's
+ * booking.
  */
 export function matchByReference<T>(
   items: T[],

--- a/plugins/plugin-cloud-apps/src/deploy-gate.ts
+++ b/plugins/plugin-cloud-apps/src/deploy-gate.ts
@@ -22,10 +22,9 @@
  * receives an AbortSignal to tear down the stalled connection, and the gate
  * additionally races the call so even a signal-ignoring dep can never wedge it.
  *
- * The gate is pure and fully injectable (status fetch, app fetch, probe, sleep)
- * so it can be unit-tested against a mocked status progression + reachability —
- * which is the proof for now: a real end-to-end deploy cannot be verified until
- * the staging deploy backend is armed (#9853 / Phase 4).
+ * The gate is pure and fully injectable (status fetch, app fetch, probe, sleep),
+ * so unit tests can pin status progression, timeout, and reachability behavior
+ * without coupling this helper to a live staging deploy backend.
  */
 
 import type { AppDeployStatusResponse, AppResponse } from "@elizaos/cloud-sdk";

--- a/plugins/plugin-cloud-apps/src/index.ts
+++ b/plugins/plugin-cloud-apps/src/index.ts
@@ -1,10 +1,9 @@
 /**
- * @elizaos/plugin-cloud-apps
+ * Cloud Apps lifecycle plugin for connector-driven app management.
  *
- * Lets an Eliza agent manage the user's Eliza Cloud Apps — list them, describe
- * one, and run the create → deploy → live loop — from a single plugin
- * registration that reaches every connector (in-app, Discord, Telegram, and
- * cloud-hosted) through the shared AgentRuntime pipeline.
+ * The registration lets an Eliza agent list, inspect, create, deploy, monetize,
+ * back up, and safely mutate the user's Eliza Cloud Apps from every connector
+ * surface through the shared AgentRuntime pipeline.
  *
  * Read-core (non-mutating):
  *   - Action  LIST_CLOUD_APPS       — list the user's apps (name / url / status).
@@ -36,14 +35,9 @@
  *                                     to honest replies; money never transits the connector.
  *   - Action  LIST_APP_DOMAINS      — READ-ONLY: registrar/status/SSL/verification per domain.
  *
- * Auth: reads `ELIZAOS_CLOUD_API_KEY` (+ optional `ELIZAOS_CLOUD_BASE_URL`) via
- * runtime settings — the same credentials plugin-elizacloud uses. With no key
- * the actions degrade gracefully and the provider stays EMPTY.
- *
- * NOTE: a real end-to-end deploy can't be verified until the staging deploy
- * backend is armed (#9853 / Phase 4). DEPLOY_APP's tests drive the completion
- * gate with a mocked status progression + reachability — that is the proof for now.
- * ───────────────────────────────────────────────────────────────────────────
+ * Auth uses `ELIZAOS_CLOUD_API_KEY` plus optional `ELIZAOS_CLOUD_BASE_URL` from
+ * runtime settings, matching plugin-elizacloud credentials. Without a key,
+ * actions decline gracefully and the provider stays empty.
  */
 
 import type { Plugin } from "@elizaos/core";

--- a/plugins/plugin-e2b-sandbox/index.ts
+++ b/plugins/plugin-e2b-sandbox/index.ts
@@ -1,20 +1,13 @@
+/**
+ * Plugin registration for the E2B remote sandbox backend.
+ *
+ * The host capability router owns provider selection; this package contributes
+ * only the E2B factory service so agents can opt into e2b.dev filesystem,
+ * terminal, and git sandboxes.
+ */
+
 import type { Plugin } from "@elizaos/core";
 import { E2BSandboxFactoryService } from "./services/e2b-sandbox-factory-service";
-
-/**
- * `@elizaos/plugin-e2b-sandbox` — the `e2b.dev` vendor backend for the host
- * remote capability router.
- *
- * The router lives in the host (`@elizaos/agent`) and owns the provider-neutral
- * selection logic plus the eliza-cloud / home HTTP runners. The E2B SDK path
- * (and the `e2b` npm dependency) lives here: this plugin registers
- * {@link E2BSandboxFactoryService} under `E2B_SANDBOX_FACTORY_SERVICE_TYPE`, and
- * the router selects the `e2b` provider only when that service is present.
- *
- * Opt-in: enabled when the agent is configured for the `e2b` remote runner
- * (`ELIZA_CODING_REMOTE_RUNNER=e2b` / `ELIZA_E2B_REMOTE_RUNNER`), or by listing
- * the plugin in a character's plugin list.
- */
 export const e2bSandboxPlugin: Plugin = {
   name: "e2b-sandbox",
   description:

--- a/plugins/plugin-e2b-sandbox/services/e2b-sandbox-factory-service.ts
+++ b/plugins/plugin-e2b-sandbox/services/e2b-sandbox-factory-service.ts
@@ -1,3 +1,11 @@
+/**
+ * E2B SDK-backed sandbox factory for the host remote capability router.
+ *
+ * The service is registered under the shared E2B factory service type; the host
+ * router selects this provider only when the plugin is installed and configured.
+ * SDK entry metadata is normalized into the core sandbox contract here.
+ */
+
 import {
   E2B_SANDBOX_FACTORY_SERVICE_TYPE,
   type E2BSandboxClient,
@@ -13,14 +21,6 @@ import {
 import type { SandboxConnectOpts, SandboxOpts } from "e2b";
 
 const LOG_CONTEXT = { src: "service:e2b_sandbox_factory" } as const;
-
-/**
- * `@elizaos/plugin-e2b-sandbox` — the `e2b.dev` SDK backend for the host remote
- * capability router. Registering this service under
- * {@link E2B_SANDBOX_FACTORY_SERVICE_TYPE} is the single thing that lets the
- * router select the `e2b` provider; without the plugin the router routes only
- * eliza-cloud / home runners and reports E2B as unavailable.
- */
 export class E2BSandboxFactoryService
   extends Service
   implements E2BSandboxFactoryServiceContract
@@ -98,8 +98,7 @@ type E2BSdkSandbox = {
       error?: string;
     }>;
   };
-  // The e2b SDK's Sandbox.kill() resolves to a boolean (was void in older SDK
-  // versions); match it so the SDK Sandbox stays structurally assignable here.
+  // Match the SDK's boolean kill result so Sandbox stays structurally assignable.
   kill(opts?: { requestTimeoutMs?: number }): Promise<boolean>;
 };
 

--- a/plugins/plugin-e2b-sandbox/test/e2b-sandbox-factory-service.test.ts
+++ b/plugins/plugin-e2b-sandbox/test/e2b-sandbox-factory-service.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for the E2B sandbox factory service contract.
+ *
+ * The E2B SDK boundary is faked while service registration, entry-type
+ * normalization, delegated file operations, command execution, and sandbox
+ * teardown behavior run through the real adapter code.
+ */
+
 import {
   E2B_SANDBOX_FACTORY_SERVICE_TYPE,
   type SandboxCommandRunOptions,


### PR DESCRIPTION
## Summary
- Add or repair top-of-file prose headers for the remaining plugin-capacitor-bridge and plugin-e2b-sandbox source files in the B17-G scope.
- Rewrite churn-phrased comments in plugin-cloud-apps, plugin-capacitor-bridge, and plugin-e2b-sandbox into durable present-tense rationale.
- Leave code tokens unchanged; this is a comment-only cleanup for #12759.

## Verification
- bun run check:comment-only -> passed: 38 source files changed, every code token identical to origin/develop.
- Header scan for plugins/plugin-cloud-apps, plugins/plugin-capacitor-bridge, plugins/plugin-e2b-sandbox -> 0 missing of 104 in-scope source files.
- git diff --check origin/develop -> passed.
- bunx @biomejs/biome check on the 38 touched files -> passed.
- bun run --cwd plugins/plugin-capacitor-bridge lint:check -> passed.
- bun run --cwd plugins/plugin-capacitor-bridge test -> passed: 14 files, 99 tests.
- bun run --cwd plugins/plugin-e2b-sandbox lint:check -> passed.
- bun run --cwd plugins/plugin-e2b-sandbox test -> passed: 1 file, 4 tests.
- bun run --cwd plugins/plugin-e2b-sandbox typecheck -> passed.
- bun run --cwd plugins/plugin-cloud-apps lint -> passed, no fixes applied.

Attempted:
- bun run verify -> failed outside this comment-only diff. Root verify reached workspace typecheck and failed in @elizaos/cloud-shared:typecheck due existing declaration resolution errors through dist/node_modules/drizzle-orm/*, then exited 139. It also reported unrelated pre-existing package-local failures when running plugins/plugin-capacitor-bridge typecheck: @elizaos/plugin-coding-tools declaration missing, plugin-local-inference logger typing, and plugin-wallet automation-node exports/types. The changed files are machine-proven comment-only by check:comment-only.

## Evidence Notes
- Trajectory/screenshots/video/audio/domain artifacts: N/A - comments-only change, zero functional diff machine-checked by scripts/assert-comment-only-diff.mjs.

Refs #12759
