### PR TITLE
fix(#12321): remove publish status override hatch

### DIFF
--- a/.github/issue-evidence/12216-stage4-remove-publish-status-overrides/README.md
+++ b/.github/issue-evidence/12216-stage4-remove-publish-status-overrides/README.md
@@ -1,0 +1,33 @@
+# Stage 4 Remove Publish Status Overrides Evidence
+
+Issue: #12321
+
+PR scope:
+
+- Remove the runtime `ELIZA_PUBLISH_STATUS_OVERRIDES` reader from the shared
+  Eliza-1 model catalog.
+- Keep the known qwen35 tiers (`eliza-1-9b`, `eliza-1-27b`,
+  `eliza-1-27b-256k`) statically `pending` until their published bytes pass
+  the Gemma text-architecture gate.
+- Add a regression test that sets the retired env var and verifies the pending
+  qwen tiers remain pending.
+
+Verification:
+
+```bash
+git grep -n "ELIZA_PUBLISH_STATUS_OVERRIDES\\|readPublishStatusOverride" -- packages/shared/src plugins/plugin-local-inference/src packages/ui/src/services | head -100
+# packages/shared/src/local-inference/catalog.test.ts only
+
+git diff --check origin/develop..HEAD
+# passed
+```
+
+Attempted focused Vitest:
+
+```bash
+bun run --cwd packages/shared test -- src/local-inference/catalog.test.ts
+```
+
+Result: failed before tests ran because this auxiliary worktree does not have a
+usable `node_modules/vitest/vitest.mjs` install. The PR keeps the regression in
+`packages/shared/src/local-inference/catalog.test.ts` for CI to execute.

--- a/packages/shared/src/local-inference/catalog.test.ts
+++ b/packages/shared/src/local-inference/catalog.test.ts
@@ -5,6 +5,7 @@ import {
   ELIZA_1_ON_DEVICE_TIER_IDS,
   ELIZA_1_TIER_IDS,
   ELIZA_1_VISION_TIER_IDS,
+  eliza1TierPublishStatus,
   isOnDeviceTier,
   MODEL_CATALOG,
 } from "./catalog.js";
@@ -51,6 +52,28 @@ describe("Eliza-1 runtime quant metadata", () => {
       expect(entry?.displayName).toBe(EXPECTED_DISPLAY_NAMES[id]);
       expect(entry?.params).toBe(EXPECTED_CHAT_PARAMS[id]);
       expect(entry?.ggufFile).toContain(id);
+    }
+  });
+
+  it("does not allow env overrides to publish pending qwen tiers", () => {
+    const previous = process.env.ELIZA_PUBLISH_STATUS_OVERRIDES;
+    process.env.ELIZA_PUBLISH_STATUS_OVERRIDES = JSON.stringify({
+      "eliza-1-9b": "published",
+      "eliza-1-27b": "published",
+      "eliza-1-27b-256k": "published",
+    });
+    try {
+      expect(eliza1TierPublishStatus("eliza-1-2b")).toBe("published");
+      expect(eliza1TierPublishStatus("eliza-1-4b")).toBe("published");
+      expect(eliza1TierPublishStatus("eliza-1-9b")).toBe("pending");
+      expect(eliza1TierPublishStatus("eliza-1-27b")).toBe("pending");
+      expect(eliza1TierPublishStatus("eliza-1-27b-256k")).toBe("pending");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.ELIZA_PUBLISH_STATUS_OVERRIDES;
+      } else {
+        process.env.ELIZA_PUBLISH_STATUS_OVERRIDES = previous;
+      }
     }
   });
 

--- a/packages/shared/src/local-inference/catalog.ts
+++ b/packages/shared/src/local-inference/catalog.ts
@@ -129,10 +129,8 @@ export function isDefaultEligibleId(id: string): boolean {
  * `CatalogModel`) before recommending a first-run default — see
  * `recommendForFirstRun` and elizaOS/eliza#7629.
  *
- * Set the override env var `ELIZA_PUBLISH_STATUS_OVERRIDES` to a JSON
- * object like `{"eliza-1-2b":"published","eliza-1-9b":"pending"}` to
- * override at runtime without changing the static map (useful for QA
- * and for installs that depend on a private HF mirror).
+ * This is intentionally not runtime-overridable: the qwen35 tiers below are
+ * blocked until the published bytes pass the Gemma text-architecture gate.
  *
  * W3-12 audit (2026-05-14): the following areas require publish attention:
  *   - 2B vision: enabled in the catalog and canonical vision tier set;
@@ -163,8 +161,6 @@ export const ELIZA_1_TIER_PUBLISH_STATUS: Readonly<
 export function eliza1TierPublishStatus(
   id: Eliza1TierId | string,
 ): "published" | "pending" {
-  const override = readPublishStatusOverride(id);
-  if (override) return override;
   const hint = (
     ELIZA_1_TIER_PUBLISH_STATUS as Record<
       string,
@@ -172,25 +168,6 @@ export function eliza1TierPublishStatus(
     >
   )[id];
   return hint ?? "published";
-}
-
-function readPublishStatusOverride(
-  id: string,
-): "published" | "pending" | undefined {
-  const raw =
-    typeof process !== "undefined"
-      ? process.env.ELIZA_PUBLISH_STATUS_OVERRIDES
-      : undefined;
-  if (!raw) return undefined;
-  try {
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    const value = parsed[id];
-    if (value === "published" || value === "pending") return value;
-  } catch {
-    // Malformed override JSON is non-fatal — fall back to the static
-    // publish-status hint and the catalog's own `publishStatus` field.
-  }
-  return undefined;
 }
 
 export const ELIZA_1_PLACEHOLDER_IDS: ReadonlySet<string> = new Set(


### PR DESCRIPTION
## Summary
- remove the runtime `ELIZA_PUBLISH_STATUS_OVERRIDES` reader from the shared Eliza-1 catalog
- keep known qwen35 tiers statically `pending` until their published bytes pass the Gemma architecture gate
- add a regression test proving the retired env var no longer publishes pending qwen tiers

## Evidence
- `.github/issue-evidence/12216-stage4-remove-publish-status-overrides/README.md`
- `git grep -n "ELIZA_PUBLISH_STATUS_OVERRIDES\|readPublishStatusOverride" -- packages/shared/src plugins/plugin-local-inference/src packages/ui/src/services | head -100` (only the regression test remains)
- `git diff --check origin/develop..HEAD`

## Not run
- `bun run --cwd packages/shared test -- src/local-inference/catalog.test.ts` could not start in this auxiliary worktree because `node_modules/vitest/vitest.mjs` is unavailable. CI should run the added Vitest regression.

Refs #12321