### PR TITLE
fix(app-core): import first-run helpers from core barrel

### DIFF
--- a/packages/app-core/src/api/credential-resolver.ts
+++ b/packages/app-core/src/api/credential-resolver.ts
@@ -23,16 +23,14 @@ import {
   isSubscriptionProvider,
 } from "@elizaos/auth/types";
 import {
-  logger,
-  MODEL_PROVIDER_SECRETS,
-  SECRET_KEY_ALIASES,
-} from "@elizaos/core";
-import {
   getDirectAccountProviderForFirstRunProvider,
   getFirstRunProviderOption,
   getStoredFirstRunProviderId,
+  logger,
+  MODEL_PROVIDER_SECRETS,
   normalizeFirstRunProviderId,
-} from "@elizaos/core/contracts/first-run-options";
+  SECRET_KEY_ALIASES,
+} from "@elizaos/core";
 import { getDefaultAccountPool } from "../account-pool.js";
 
 // ── Credential source registry ───────────────────────────────────────

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -50,8 +50,12 @@ export {
 } from "./constants";
 export { isElizaCloudServiceSelectedInConfig } from "./contracts/cloud-topology";
 export {
+	getDirectAccountProviderForFirstRunProvider,
+	getFirstRunProviderOption,
+	getStoredFirstRunProviderId,
 	isCloudInferenceSelectedInConfig,
 	migrateLegacyRuntimeConfig,
+	normalizeFirstRunProviderId,
 	type StylePreset,
 } from "./contracts/first-run-options";
 export {


### PR DESCRIPTION
## Summary
- re-export the first-run provider helper functions from the public @elizaos/core Node barrel
- update app-core's credential resolver to import those runtime values from @elizaos/core instead of the declaration-only contracts subpath
- keep the contracts subpath surface unchanged

Closes #12794.

## Validation
- PASS: `bun run --cwd packages/app-core test -- src/api/credential-resolver.test.ts src/api/credential-resolver.multi-account.test.ts` (2 files / 11 tests)
- PASS: `bunx @biomejs/biome check packages/core/src/index.node.ts packages/app-core/src/api/credential-resolver.ts`
- PASS: `git diff --check`
- PASS: direct runtime export check against built bundle: imported `packages/core/dist/node/index.node.js` and verified all four helper exports are functions
- PASS: `rg -n "@elizaos/core/contracts/first-run-options" packages/app-core/src/api/credential-resolver.ts packages/app-core/src` returned no app-core credential-resolver runtime imports from the broken subpath

## Known validation limitation
- `bun run --cwd packages/core build:node` bundles JS successfully after generating i18n keyword data, but declaration generation fails on the existing linked-dependency type-resolution baseline (drizzle-orm/yaml/fs-extra/mammoth/etc. resolving through `/home/shaw/milady/eliza/dist/node_modules`).
- `bun run --cwd packages/app-core typecheck` likewise fails on the same broad baseline declaration-resolution issues outside this patch.
