### PR TITLE
fix(#12749): gate chat affiliate requests off optimistic billing

### DIFF
--- a/.github/issue-evidence/12749-chat-affiliate-optimistic-gate.md
+++ b/.github/issue-evidence/12749-chat-affiliate-optimistic-gate.md
@@ -1,0 +1,36 @@
+# Issue #12749 — chat affiliate optimistic billing gate
+
+## Change
+
+- `/v1/chat/completions` now disables both optimistic billing branches when
+  `X-Affiliate-Code` is present.
+- Affiliate-marked requests fall through to the synchronous `reserveCredits`
+  path, where affiliate markup is included in the upfront hold.
+- Added route-decision regression coverage for both optimistic backends:
+  - KV pending-charge path bypassed when `X-Affiliate-Code` is present.
+  - DB ledger path bypassed when `X-Affiliate-Code` is present, with a no-header
+    positive control proving the DB optimistic branch still admits normal calls.
+
+## Local Verification
+
+- PASS: `bunx @biomejs/biome check packages/cloud/api/v1/chat/completions/route.ts packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts`
+
+## Attempted / Blocked
+
+- `bun run --cwd packages/cloud/api test -- __tests__/chat-completions-optimistic-billing.test.ts`
+  - blocked before assertions by current workspace build artifact resolution:
+    `SyntaxError: Export named 'ElizaError' not found in module 'packages/core/dist/index.d.ts'`.
+- `NODE_OPTIONS='--conditions=eliza-source' bun run --cwd packages/cloud/api test -- __tests__/chat-completions-optimistic-billing.test.ts`
+  - same blocker.
+- `bun run --cwd packages/cloud/api typecheck`
+  - blocked by existing workspace dependency declaration resolution for
+    `@elizaos/auth/*` imports from `packages/app-core/src/services/*`.
+
+## Evidence N/A
+
+- Screenshots/video: N/A — backend billing route guard, no UI.
+- Real LLM trajectories: N/A — no model, prompt, provider, action, or evaluator
+  behavior changed.
+- Runtime cloud stack trace: not captured locally because the focused unit test
+  and package typecheck are blocked by unrelated workspace build/declaration
+  issues before reaching this route.

--- a/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
@@ -42,6 +42,7 @@ import * as aiBillingActual from "@/lib/services/ai-billing";
 import * as contentModerationActual from "@/lib/services/content-moderation";
 import * as inferenceAuthContextActual from "@/lib/services/inference-auth-context";
 import * as fastPathActual from "@/lib/services/inference-billing-fast-path";
+import * as billingLedgerActual from "@/lib/services/inference-billing-ledger";
 import * as modelCatalogActual from "@/lib/services/model-catalog";
 import * as creditReservationActual from "@/lib/utils/credit-reservation";
 
@@ -60,6 +61,7 @@ let backstopAvailable = true;
 let gateBalanceUsd = 100;
 let thresholdUsd = 5;
 let backstopPersists = true;
+let billingLedger: "kv" | "db" = "kv";
 
 // --- spies on the two terminal billing paths --------------------------------
 const writePendingInferenceCharge = mock(async () => backstopPersists);
@@ -69,6 +71,8 @@ const reserveCredits = mock(async () => ({
   reconcile: async () => null,
 }));
 const createOptimisticDebitSettler = mock(() => async () => null);
+const admitInferenceChargeViaLedger = mock(async () => ({ admitted: true }));
+const createLedgerDebitSettler = mock(() => async () => null);
 const createCreditReservationSettler = mock(() => async () => null);
 
 // Auth: resolve straight to an authorized org user via the hot-path resolver so
@@ -131,6 +135,13 @@ mock.module("@/lib/services/inference-billing-fast-path", () => ({
   createOptimisticDebitSettler,
 }));
 
+mock.module("@/lib/services/inference-billing-ledger", () => ({
+  ...billingLedgerActual,
+  resolveInferenceBillingLedger: () => billingLedger,
+  admitInferenceChargeViaLedger,
+  createLedgerDebitSettler,
+}));
+
 // Synchronous reserve path — spied so we can prove it is the fallback.
 mock.module("@/lib/services/ai-billing", () => ({
   ...aiBillingActual,
@@ -177,16 +188,21 @@ afterAll(() => {
     "@/lib/services/inference-billing-fast-path",
     () => fastPathActual,
   );
+  mock.module(
+    "@/lib/services/inference-billing-ledger",
+    () => billingLedgerActual,
+  );
   mock.module("@/lib/services/ai-billing", () => aiBillingActual);
   mock.module("@/lib/utils/credit-reservation", () => creditReservationActual);
 });
 
-function makeRequest(): Request {
+function makeRequest(affiliateCode?: string): Request {
   return new Request("https://api.test/api/v1/chat/completions", {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "x-request-id": CLIENT_REQUEST_ID,
+      ...(affiliateCode ? { "X-Affiliate-Code": affiliateCode } : {}),
     },
     body: JSON.stringify({
       model: "gpt-4o-mini",
@@ -196,10 +212,12 @@ function makeRequest(): Request {
   });
 }
 
-async function drive(): Promise<void> {
+async function drive(affiliateCode?: string): Promise<void> {
   // The handler owns its try/catch and always returns a Response (the stubbed
   // model call makes it an error response); we only read the spies.
-  await handleChatCompletionsPOST(makeRequest(), { skipOrgRateLimit: true });
+  await handleChatCompletionsPOST(makeRequest(affiliateCode), {
+    skipOrgRateLimit: true,
+  });
 }
 
 describe("chat/completions optimistic-billing route decision (#9899/#10066)", () => {
@@ -209,9 +227,12 @@ describe("chat/completions optimistic-billing route decision (#9899/#10066)", ()
     gateBalanceUsd = 100;
     thresholdUsd = 5;
     backstopPersists = true;
+    billingLedger = "kv";
     writePendingInferenceCharge.mockClear();
     reserveCredits.mockClear();
     createOptimisticDebitSettler.mockClear();
+    admitInferenceChargeViaLedger.mockClear();
+    createLedgerDebitSettler.mockClear();
     createCreditReservationSettler.mockClear();
   });
 
@@ -272,5 +293,40 @@ describe("chat/completions optimistic-billing route decision (#9899/#10066)", ()
     // ...but a non-durable write must fall through to the synchronous reserve.
     expect(reserveCredits).toHaveBeenCalledTimes(1);
     expect(createOptimisticDebitSettler).not.toHaveBeenCalled();
+  });
+
+  test("X-Affiliate-Code forces the synchronous reserve even when the KV optimistic path is eligible (#12749)", async () => {
+    await drive("PARTNER1000");
+
+    expect(writePendingInferenceCharge).not.toHaveBeenCalled();
+    expect(createOptimisticDebitSettler).not.toHaveBeenCalled();
+    expect(reserveCredits).toHaveBeenCalledTimes(1);
+    const reserveCalls = reserveCredits.mock.calls as unknown as Array<
+      [{ affiliateCode?: string | null }]
+    >;
+    expect(reserveCalls[0]?.[0]?.affiliateCode).toBe("PARTNER1000");
+  });
+
+  test("X-Affiliate-Code also bypasses the DB-ledger optimistic branch (#12749)", async () => {
+    billingLedger = "db";
+
+    await drive();
+    expect(admitInferenceChargeViaLedger).toHaveBeenCalledTimes(1);
+    expect(createLedgerDebitSettler).toHaveBeenCalledTimes(1);
+    expect(reserveCredits).not.toHaveBeenCalled();
+
+    admitInferenceChargeViaLedger.mockClear();
+    createLedgerDebitSettler.mockClear();
+    reserveCredits.mockClear();
+
+    await drive("PARTNER1000");
+
+    expect(admitInferenceChargeViaLedger).not.toHaveBeenCalled();
+    expect(createLedgerDebitSettler).not.toHaveBeenCalled();
+    expect(reserveCredits).toHaveBeenCalledTimes(1);
+    const reserveCalls = reserveCredits.mock.calls as unknown as Array<
+      [{ affiliateCode?: string | null }]
+    >;
+    expect(reserveCalls[0]?.[0]?.affiliateCode).toBe("PARTNER1000");
   });
 });

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -1206,8 +1206,17 @@ export async function handleChatCompletionsPOST(
       // so it does not need the KV org-balance hint or a writable cache.
       let optimisticReady = false;
       const optimisticBillingEnabled = isOptimisticBillingEnabled();
+      // #12749: affiliate-marked requests must take the synchronous reserve.
+      // Both optimistic branches admit on the base/platform estimate only, while
+      // affiliate markup is resolved inside reserveCredits. The later billUsage
+      // call does not receive a reservation, so the collected-earnings clamp is
+      // inert on an optimistic path. Falling through keeps the affiliate math
+      // single-sourced in reserveCredits and 402s upfront when base+markup is
+      // not covered.
+      const optimisticAllowedForRequest =
+        optimisticBillingEnabled && affiliateCode === null;
       const useDbLedger =
-        optimisticBillingEnabled && resolveInferenceBillingLedger() === "db";
+        optimisticAllowedForRequest && resolveInferenceBillingLedger() === "db";
 
       if (useDbLedger) {
         const { totalCost } = await calculateCost(
@@ -1253,7 +1262,7 @@ export async function handleChatCompletionsPOST(
       let estimatedCostUsd = 0;
       if (
         !optimisticReady &&
-        optimisticBillingEnabled &&
+        optimisticAllowedForRequest &&
         !useDbLedger &&
         isOptimisticBackstopAvailable()
       ) {


### PR DESCRIPTION
## Summary

Fixes #12749.

- Disables both `/v1/chat/completions` optimistic billing branches when `X-Affiliate-Code` is present.
- Affiliate-marked requests now fall through to synchronous `reserveCredits`, where affiliate markup is included in the upfront hold and can 402 fail-closed.
- Adds route-decision regression coverage for both optimistic backends:
  - KV pending-charge path bypassed when `X-Affiliate-Code` is present.
  - DB ledger path bypassed when `X-Affiliate-Code` is present, with a no-header positive control proving normal DB optimistic admission still works.

## Verification

- `bunx @biomejs/biome check packages/cloud/api/v1/chat/completions/route.ts packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts`
  - pass

Attempted:

- `bun run --cwd packages/cloud/api test -- __tests__/chat-completions-optimistic-billing.test.ts`
  - blocked before assertions by current workspace build artifact resolution: `SyntaxError: Export named 'ElizaError' not found in module 'packages/core/dist/index.d.ts'`.
- `NODE_OPTIONS='--conditions=eliza-source' bun run --cwd packages/cloud/api test -- __tests__/chat-completions-optimistic-billing.test.ts`
  - same blocker.
- `bun run --cwd packages/cloud/api typecheck`
  - blocked by existing workspace dependency declaration resolution for `@elizaos/auth/*` imports from `packages/app-core/src/services/*`.

## Evidence

See `.github/issue-evidence/12749-chat-affiliate-optimistic-gate.md`.

Screenshots/video: N/A - backend billing route guard only.
Real LLM trajectories: N/A - no model/prompt/provider/action/evaluator behavior changed.
