### PR TITLE
fix(cloud): unblock Cloud CF Deploy — core#build waits for cloud-routing + restore 10 missing Worker stub exports

### DIFF
--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -258,6 +258,20 @@ export function runWithTrajectoryContext<T>(
   return fn();
 }
 
+/**
+ * Worker-safe pass-through for core's `runWithTrajectoryPurpose`. The Worker
+ * build has no AsyncLocalStorage trajectory-context manager (node-only), so
+ * trajectory-purpose tracking is a no-op here. Pulled into the bundle via
+ * `@elizaos/shared` email-classification (#11580) — not invoked on a Worker
+ * route, but the export must exist for the bundle to link.
+ */
+export function runWithTrajectoryPurpose<T>(
+  _purpose: string,
+  fn: () => T | Promise<T>,
+): T | Promise<T> {
+  return fn();
+}
+
 type InferenceTimingMeta = Record<string, string | number | boolean>;
 
 /**
@@ -579,6 +593,15 @@ export function redactSensitiveRequestMetadata(value: unknown): unknown {
   return redacted;
 }
 
+// Log-redaction helpers consumed by the cloud-shared Worker logger on every
+// log call. Re-exported from the REAL core module — `security/redact.ts` is a
+// zero-import pure leaf, so it is Worker-safe, and single-sourcing it here
+// keeps Worker-side secret masking from drifting behind core's.
+export {
+  isSensitiveKeyName,
+  redactLogArgs,
+} from "../../../../core/src/security/redact";
+
 export const ModelType = {
   TEXT_SMALL: "TEXT_SMALL",
   TEXT_LARGE: "TEXT_LARGE",
@@ -604,7 +627,13 @@ export const ServiceType = {
   PDF: "PDF",
   REMOTE_FILES: "REMOTE_FILES",
   MEDIA_GENERATION: "MEDIA_GENERATION",
+  CLOUD_AUTH: "CLOUD_AUTH",
 } as const;
+
+// Mirrors core's `CLOUD_AUTH_SERVICE_TYPE = ServiceType.CLOUD_AUTH`. Imported
+// by plugin-elizacloud's cloud-auth service, which the Worker bundles for its
+// shared constants; the sidecar owns the actual service registration.
+export const CLOUD_AUTH_SERVICE_TYPE = ServiceType.CLOUD_AUTH;
 
 export const VECTOR_DIMS = {
   SMALL: 384,
@@ -660,6 +689,46 @@ export const getEntityDetails = throwingExport("getEntityDetails");
 export const splitChunks = throwingExport("splitChunks");
 export const createMessageMemory = throwingExport("createMessageMemory");
 export const executePlannedToolCall = throwingExport("executePlannedToolCall");
+
+// SSRF-guarded fetch is runtime network machinery (pinned-DNS lookups are
+// node-only). It reaches the bundle via plugin-elizacloud's transcription
+// model helper, which only runs on the agent sidecar. Fail closed: if a
+// Worker path ever invokes it, throw rather than fetch unguarded.
+export const fetchWithSsrfGuard = throwingExport("fetchWithSsrfGuard");
+
+/**
+ * Host-bridge setters (core `account-pool-bridge.ts`). The real
+ * implementations write to a host-app global slot that nothing in the Worker
+ * ever reads, and they already no-op when the slot is absent — so faithful
+ * Worker stand-ins are no-ops, not throws (app-core service modules install
+ * these bridges at import time).
+ */
+export function setAnthropicAccountPoolBridge(_bridge: unknown): void {}
+export function setCodingAgentSelectorBridge(_bridge: unknown): void {}
+
+/**
+ * Subscription-auth provider registry (core `features/subscription-auth`).
+ * `@elizaos/auth` registers built-in descriptors at module init, so the
+ * Worker needs a real (tiny) registry, not a throwing stand-in. Semantics
+ * mirror core: last registration per id wins.
+ */
+const subscriptionAuthProviders = new Map<string, { id: string }>();
+
+export function registerSubscriptionAuthProvider(provider: {
+  id: string;
+}): void {
+  subscriptionAuthProviders.set(provider.id, provider);
+}
+
+export function getSubscriptionAuthProvider(
+  id: string,
+): { id: string } | undefined {
+  return subscriptionAuthProviders.get(id);
+}
+
+export function hasSubscriptionAuthProvider(id: string): boolean {
+  return subscriptionAuthProviders.has(id);
+}
 
 function renderSystemPromptBio(value: unknown): string {
   if (typeof value === "string") return value.trim();

--- a/turbo.json
+++ b/turbo.json
@@ -244,7 +244,11 @@
       "outputs": ["chrome/dist/**", "safari/Chat with Webpage/**"]
     },
     "@elizaos/core#build": {
-      "dependsOn": ["@elizaos/contracts#build", "@elizaos/logger#build"],
+      "dependsOn": [
+        "@elizaos/contracts#build",
+        "@elizaos/logger#build",
+        "@elizaos/cloud-routing#build"
+      ],
       "env": ["LOG_LEVEL"],
       "outputs": ["dist/**", "src/i18n/generated/**"],
       "inputs": [
@@ -256,6 +260,10 @@
       ]
     },
     "@elizaos/contracts#build": {
+      "dependsOn": [],
+      "outputs": ["dist/**"]
+    },
+    "@elizaos/cloud-routing#build": {
       "dependsOn": [],
       "outputs": ["dist/**"]
     },


### PR DESCRIPTION
## Summary

Every Cloud CF Deploy is currently red, on both branches, from two independent regressions. This PR fixes both; it is the gate for the pending develop->main promote (~380 commits of overnight work).

**Regression 1 — turbo graph (breaks all 3 deploy jobs on develop).** #12171 single-sourced `packages/core/src/cloud-routing.ts` from `@elizaos/cloud-routing`, but the pinned `@elizaos/core#build` override in `turbo.json` only waited on contracts+logger. A fresh CI checkout builds core before cloud-routing's dist exists → `TS2307 Cannot find module '@elizaos/cloud-routing'` in the *Build linked elizaOS core workspace* step (e.g. run [28694322598](https://github.com/elizaOS/eliza/actions/runs/28694322598)). Every develop staging deploy since ~07-03 17:41 failed this way. Fix: leaf override for `@elizaos/cloud-routing#build` (zero runtime deps, mirrors contracts/logger, avoids the global task's `@elizaos/core#build` edge becoming a cycle) + add it to core#build's `dependsOn`. Note: PR #12650 fixes the same root cause for the Snap recipe only; this fixes the deploy/CI lane.

**Regression 2 — Worker core stub (broke the main prod deploy).** The #11993 merge resolution dropped the `runWithTrajectoryPurpose` pass-through from `src/stubs/elizaos-core.ts` (the exact 0-export promote break #11902 defused), and newer develop work (#12169 host bridges, #12218 subscription-auth registry, #12229/#12572 redaction convergence, plugin-elizacloud cloud-auth/transcription) added 8 more `@elizaos/core` imports the stub never exported. The main push run [28680305905](https://github.com/elizaOS/eliza/actions/runs/28680305905) (5b7b4c2651) failed the API Worker esbuild on 2 of these — **prod Worker is stale at 554eed43f8**. `wrangler deploy --dry-run` enumerates all 10 missing exports on develop.

Per-symbol Worker semantics (stub doctrine: runtime-only helpers throw; import-time surfaces must be functional):
- `runWithTrajectoryPurpose` — pass-through (same as `runWithTrajectoryContext`; bundled via email-classifier, not invoked on a Worker route)
- `fetchWithSsrfGuard` — fail-closed `throwingExport` (never fetch unguarded in the Worker)
- `setAnthropicAccountPoolBridge` / `setCodingAgentSelectorBridge` — no-ops (faithful: core no-ops when the host slot is absent; app-core installs these at import time)
- `register/get/hasSubscriptionAuthProvider` — real Map registry (`@elizaos/auth` registers built-ins at module init)
- `isSensitiveKeyName` / `redactLogArgs` — re-export of the REAL `core/src/security/redact.ts` (zero-import pure leaf; the cloud-shared Worker logger calls these on every log line — a stub copy would let Worker-side secret masking drift)
- `CLOUD_AUTH_SERVICE_TYPE` + `ServiceType.CLOUD_AUTH` — constant mirror

## Verification (at develop tip cadfdecdba)

- `bunx wrangler deploy --dry-run` in `packages/cloud/api`: **was 10 link errors → builds clean** (bundle 15.9 MiB)
- turbo repro: `rm -rf packages/cloud/routing/dist && bunx turbo run build --filter=@elizaos/core --force` → 4/4 tasks green, cloud-routing dist rebuilt before core (previously reproduced the exact CI TS2307)
- `bunx turbo run build --filter=@elizaos/core --dry-run` → `@elizaos/cloud-routing#build` in core's Dependencies, no cycle
- `bun run typecheck` clean in `packages/cloud/shared` and `packages/cloud/api` (tsgo)
- `bun test __tests__/elizaos-core-stub.test.ts` green; biome clean on both files

Evidence is CI-shaped (deploy-pipeline fix, no UI/agent surface): the failing runs above are the before, the post-merge develop staging deploy run is the after.

Promote escort context: once this lands and the develop staging deploy goes green, the develop->main promote follows (merge commit), which also un-breaks the prod Worker deploy.

Signed: [cloud-frontdoor] (promote-escort subagent)