### PR TITLE
fix(#12274): fallback-slop sweep — app plugins B (wallet/vision/music/agent-skills/browser/workflow/training)

### DIFF
--- a/plugins/plugin-browser/src/bridge-policy.ts
+++ b/plugins/plugin-browser/src/bridge-policy.ts
@@ -39,6 +39,10 @@ export function browserBridgeDomainFromUrl(url: string): string | null {
     const hostname = parsed.hostname.trim().toLowerCase().replace(/\.+$/, "");
     return hostname.length > 0 ? hostname : null;
   } catch {
+    // error-policy:J3 untrusted-input sanitizing — `new URL()` throws on a
+    // malformed URL; null is the explicit "not a valid http(s) URL" signal
+    // callers fail-closed on (no domain → no focus/policy match), never a
+    // fabricated-valid domain.
     return null;
   }
 }

--- a/plugins/plugin-browser/src/routes/workspace.ts
+++ b/plugins/plugin-browser/src/routes/workspace.ts
@@ -174,6 +174,9 @@ function decodeBrowserWorkspaceTabId(raw: string | undefined): string | null {
     const decoded = decodeURIComponent(raw).trim();
     return decoded ? decoded : null;
   } catch {
+    // error-policy:J3 untrusted-input sanitizing — decodeURIComponent throws on
+    // a malformed percent-encoding in a path param; null is the explicit
+    // "invalid tab id" signal (the route then 404s), never a fabricated id.
     return null;
   }
 }

--- a/plugins/plugin-browser/src/workspace/browser-capture.ts
+++ b/plugins/plugin-browser/src/workspace/browser-capture.ts
@@ -241,13 +241,30 @@ export async function stopBrowserCapture() {
   if (activeCaptureLoop) {
     try {
       await activeCaptureLoop;
-    } catch {}
+    } catch (err) {
+      // error-policy:J6 best-effort teardown — the capture loop is being torn
+      // down; a late frame-capture rejection is already surfaced inside the loop
+      // (see logger.warn above) and must not block shutdown.
+      logger.debug(
+        `[browser-capture] capture loop settled with error during stop: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
     activeCaptureLoop = null;
   }
   if (activeBrowser) {
     try {
       await activeBrowser.close();
-    } catch {}
+    } catch (err) {
+      // error-policy:J6 best-effort teardown — a browser that fails to close
+      // cleanly during shutdown cannot be recovered here; drop the reference.
+      logger.debug(
+        `[browser-capture] browser close failed during stop: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
     activeBrowser = null;
   }
   logger.info("[browser-capture] Stopped");

--- a/plugins/plugin-wallet/src/wallet/local-eoa-backend.test.ts
+++ b/plugins/plugin-wallet/src/wallet/local-eoa-backend.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for `LocalEoaBackend.create` key resolution. Exercises the real
+ * key-derivation path (no mocked signer): a valid base58 Solana secret yields a
+ * usable signer, and — critically — a configured-but-malformed key surfaces the
+ * typed `SolanaPrivateKeyInvalidError` instead of being swallowed into a null
+ * that reads identically to "no wallet configured".
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { Keypair } from "@solana/web3.js";
+import bs58 from "bs58";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LocalEoaBackend } from "./local-eoa-backend";
+import {
+  SolanaPrivateKeyInvalidError,
+  WalletBackendNotConfiguredError,
+} from "./errors";
+
+const KEY_ENV_VARS = [
+  "EVM_PRIVATE_KEY",
+  "SOLANA_PRIVATE_KEY",
+  "WALLET_PRIVATE_KEY",
+];
+
+function runtimeWith(settings: Record<string, string | undefined>): IAgentRuntime {
+  return {
+    getSetting: vi.fn((key: string) => settings[key]),
+  } as unknown as IAgentRuntime;
+}
+
+describe("LocalEoaBackend.create — Solana key resolution", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    // The resolver falls back to process.env; clear the wallet keys so the
+    // test's runtime.getSetting is the sole source of truth.
+    for (const name of KEY_ENV_VARS) {
+      savedEnv[name] = process.env[name];
+      delete process.env[name];
+    }
+  });
+
+  afterEach(() => {
+    for (const name of KEY_ENV_VARS) {
+      if (savedEnv[name] === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = savedEnv[name];
+      }
+    }
+  });
+
+  it("derives a Solana signer from a valid base58 secret", async () => {
+    const kp = Keypair.generate();
+    const secret = bs58.encode(kp.secretKey);
+    const backend = await LocalEoaBackend.create(
+      runtimeWith({ SOLANA_PRIVATE_KEY: secret }),
+    );
+    expect(String(backend.getAddresses().solana)).toBe(kp.publicKey.toBase58());
+    expect(backend.canSign("solana")).toBe(true);
+  });
+
+  it("surfaces a malformed configured key instead of masking it as 'no wallet'", async () => {
+    // A configured key that decodes to the wrong length is a misconfiguration:
+    // it must throw the typed invalid-key error, never fall through to
+    // WalletBackendNotConfiguredError (which means "no key was configured").
+    const wrongLength = bs58.encode(new Uint8Array(48));
+    await expect(
+      LocalEoaBackend.create(runtimeWith({ SOLANA_PRIVATE_KEY: wrongLength })),
+    ).rejects.toBeInstanceOf(SolanaPrivateKeyInvalidError);
+  });
+
+  it("surfaces a non-base58 configured key as a typed invalid-key error", async () => {
+    await expect(
+      LocalEoaBackend.create(runtimeWith({ SOLANA_PRIVATE_KEY: "not valid base58 !!!" })),
+    ).rejects.toBeInstanceOf(SolanaPrivateKeyInvalidError);
+  });
+
+  it("still reports NO_WALLET_CONFIGURED when genuinely no key is set", async () => {
+    await expect(LocalEoaBackend.create(runtimeWith({}))).rejects.toBeInstanceOf(
+      WalletBackendNotConfiguredError,
+    );
+  });
+});

--- a/plugins/plugin-wallet/src/wallet/local-eoa-backend.ts
+++ b/plugins/plugin-wallet/src/wallet/local-eoa-backend.ts
@@ -77,14 +77,14 @@ function resolveSolanaKeypair(runtime: IAgentRuntime): Keypair | null {
     process.env.SOLANA_PRIVATE_KEY ??
     readSetting(runtime, "WALLET_PRIVATE_KEY") ??
     process.env.WALLET_PRIVATE_KEY;
+  // Absence (no key configured) is a legitimate null; a configured-but-malformed
+  // key is a misconfiguration that must surface. keypairFromSolanaSecret throws
+  // the typed SolanaPrivateKeyInvalidError — let it propagate rather than
+  // swallowing it into a null that reads identically to "no wallet configured".
   if (!raw) {
     return null;
   }
-  try {
-    return keypairFromSolanaSecret(raw);
-  } catch {
-    return null;
-  }
+  return keypairFromSolanaSecret(raw);
 }
 
 class LocalSolanaSigner implements SolanaSigner {


### PR DESCRIPTION
## Fallback-slop sweep (#12182): app plugins B — wallet / vision / music / agent-skills / browser / workflow / training

Executes the #12182 rubric against the app-plugins-B slice. This is behavior-changing
work, so it is deliberately a **small, precise** PR: high-confidence slop converted to
fast-fail, plausibly-justified handlers annotated, everything ambiguous left untouched
and counted. Precision over completeness — a reckless large sweep here would fake wallet
success or drop a designed browser/workflow degrade.

Foundation (#12263) is used as-is: `ElizaError` code/context/cause, and the diff-scoped
`bun run audit:error-policy-ratchet`.

### Re-derived suspect counts (this slice @ base `36be3c8655`)

| pattern | count |
|---|---|
| empty catch (non-test, TS) | 4 (2 real; 2 inside a PowerShell string — exempt per issue) |
| promise swallow `.catch(()=>…)` | 33 |
| return-default catch | 133 |
| `?? <lit>` | 699 |
| `\|\| <lit>` | 316 |
| try blocks | 968 |

### Site table (verdict per touched site)

| site | pattern | verdict | action |
|---|---|---|---|
| `plugin-wallet/src/wallet/local-eoa-backend.ts:83-87` | catch → `return null` | **SLOP** | convert → let typed `SolanaPrivateKeyInvalidError` propagate |
| `plugin-browser/src/workspace/browser-capture.ts:244` | empty catch (teardown) | **J6** | keep + `logger.debug` + annotate |
| `plugin-browser/src/workspace/browser-capture.ts:250` | empty catch (teardown) | **J6** | keep + `logger.debug` + annotate |
| `plugin-browser/src/bridge-policy.ts:41` | `new URL()` catch → null | **J3** | keep + annotate (typed-invalid, callers fail-closed) |
| `plugin-browser/src/routes/workspace.ts:176` | `decodeURIComponent` catch → null | **J3** | keep + annotate (typed-invalid tab id → 404) |

### Per-category tally

- **Converted (slop → fast-fail): 1** — `local-eoa-backend.ts` (money path).
- **Annotated (justified J-category): 4** — 2× J6 (browser teardown), 2× J3 (browser URL/tab-id parse).
- **Left (ambiguous / designed degrade / legitimate absence): ~large** — e.g. the kamino
  APY service (`Math.random()`-fabricated data — a larp rewrite, out of a fallback sweep's
  scope), workflow-service generation/deploy degrades (`getRuntimeContext`/`fixWorkflowErrors`/
  `activateWorkflow` log-and-continue — nuanced product-degrade judgment, not money paths),
  agent-skills load paths (already `logger.warn` per failure — not silent), and the wallet
  `?? "0"` transaction/LP defaults (ERC20 `value=0`, optional second LP token — legitimate
  defaults, not catch-swallow). Precision beats completeness; these are candidates for a
  follow-up with the product owner, not high-confidence one-shot conversions.

### Exemplar before → after (the money-path conversion)

`resolveSolanaKeypair` swallowed a carefully-typed error, conflating "invalid configured key"
with "no key configured":

```ts
// BEFORE — a malformed SOLANA_PRIVATE_KEY reads as WalletBackendNotConfiguredError("NO_WALLET_CONFIGURED")
if (!raw) return null;
try {
  return keypairFromSolanaSecret(raw);   // throws typed SolanaPrivateKeyInvalidError
} catch {
  return null;                            // swallowed
}

// AFTER — absence stays null; a configured-but-malformed key surfaces the typed error
if (!raw) return null;                    // legitimate absence
return keypairFromSolanaSecret(raw);      // invalid key propagates
```

### Test (real error path, no mocked dependency)

`plugin-wallet/src/wallet/local-eoa-backend.test.ts` drives the real key-derivation path
(real `@solana/web3.js` `Keypair`, real base58):

- valid base58 secret → usable signer (`getAddresses().solana` matches, `canSign('solana')`);
- **wrong-length** configured key → `rejects.toBeInstanceOf(SolanaPrivateKeyInvalidError)`;
- **non-base58** configured key → `SolanaPrivateKeyInvalidError`;
- genuinely no key set → still `WalletBackendNotConfiguredError` (absence path preserved).

### Verification

- `bun run --cwd plugins/plugin-wallet test` → **126 passed, 1 skipped** (incl. the 4 new tests).
- `bun run --cwd plugins/plugin-browser test` → **147 passed**.
- `bun run --cwd plugins/plugin-wallet check` → clean; `bun run --cwd plugins/plugin-browser typecheck` → clean.
- `bun run audit:error-policy-ratchet` → **pass**; browser-capture `emptyCatch 2→0`, no new slop in any touched file.

Refs #12274 · parent #12182 · foundation #12263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
