### PR TITLE
fix(#12276): fallback-slop sweep (feed) — annotate justified handlers, no fabricated defaults

### DIFF
--- a/packages/feed/apps/web/src/utils/browser-storage.ts
+++ b/packages/feed/apps/web/src/utils/browser-storage.ts
@@ -8,6 +8,7 @@ function getStorage(type: BrowserStorageType): Storage | null {
   try {
     return window[type];
   } catch {
+    // error-policy:J4 storage access throws in private-mode / blocked-cookie browsers; feature degrades to no-storage
     return null;
   }
 }
@@ -22,6 +23,7 @@ export function readStorageItem(
   try {
     return storage.getItem(key);
   } catch {
+    // error-policy:J4 getItem can throw under storage pressure / privacy modes; feature degrades to absent value
     return null;
   }
 }
@@ -36,6 +38,7 @@ export function readStorageJson<T>(
   try {
     return JSON.parse(stored) as T;
   } catch {
+    // error-policy:J3 stored value is untrusted (may be stale/corrupt); unparseable JSON is invalid, null is the explicit "no usable value" signal
     return null;
   }
 }
@@ -52,6 +55,7 @@ export function writeStorageItem(
     storage.setItem(key, value);
     return true;
   } catch {
+    // error-policy:J4 setItem throws on quota-exceeded / private mode; false lets the caller degrade without crashing the UI
     return false;
   }
 }
@@ -67,6 +71,7 @@ export function removeStorageItem(
     storage.removeItem(key);
     return true;
   } catch {
+    // error-policy:J4 removeItem throws in private mode / blocked storage; false lets the caller degrade without crashing the UI
     return false;
   }
 }
@@ -83,6 +88,7 @@ export function listStorageKeys(type: BrowserStorageType): string[] {
     }
     return keys;
   } catch {
+    // error-policy:J4 storage enumeration throws in private mode / blocked storage; empty list degrades the feature without crashing the UI
     return [];
   }
 }

--- a/packages/feed/packages/agents/src/autonomous/track-agent-trade.ts
+++ b/packages/feed/packages/agents/src/autonomous/track-agent-trade.ts
@@ -41,6 +41,7 @@ function getClient(): PostHog | null {
       requestTimeout: 5000,
     });
   } catch {
+    // error-policy:J7 analytics side-channel init; failure disables tracking (same no-op as the no-key path above) and must never break agent trading
     return null;
   }
   return client;

--- a/packages/feed/packages/api/src/auth-middleware.ts
+++ b/packages/feed/packages/api/src/auth-middleware.ts
@@ -320,13 +320,14 @@ export async function optionalAuth(
       };
     }
   } catch {
-    // fall through
+    // error-policy:J3 not a valid agent session → fall through to Steward verification (untrusted-token discrimination)
   }
 
   try {
     const payload = await verifyStewardToken(token);
     return resolveUserFromStewardPayload(payload);
   } catch {
+    // error-policy:J3 token fails verification → treated as unauthenticated (fail-closed); null is the explicit "no valid identity" signal
     return null;
   }
 }
@@ -346,13 +347,14 @@ export async function optionalAuthFromHeaders(
       return { userId: agentSession.agentId, isAgent: true };
     }
   } catch {
-    // fall through
+    // error-policy:J3 not a valid agent session → fall through to Steward verification (untrusted-token discrimination)
   }
 
   try {
     const payload = await verifyStewardToken(token);
     return resolveUserFromStewardPayload(payload);
   } catch {
+    // error-policy:J3 token fails verification → treated as unauthenticated (fail-closed); null is the explicit "no valid identity" signal
     return null;
   }
 }

--- a/packages/feed/packages/api/src/services/notification-email-service.ts
+++ b/packages/feed/packages/api/src/services/notification-email-service.ts
@@ -120,6 +120,7 @@ export function verifyNotificationUnsubscribeToken(
       exp: payload.exp,
     };
   } catch {
+    // error-policy:J3 undecodable/malformed unsubscribe token is invalid input; null is the explicit "invalid token" signal
     return null;
   }
 }

--- a/packages/feed/packages/api/src/wallet-auth.ts
+++ b/packages/feed/packages/api/src/wallet-auth.ts
@@ -14,6 +14,7 @@ function safeDecodeJwtPayload(token: string): Record<string, number> | null {
     const padded = payload + "=".repeat((4 - (payload.length % 4)) % 4);
     return JSON.parse(atob(padded)) as Record<string, number>;
   } catch {
+    // error-policy:J3 malformed/undecodable JWT payload is invalid input; null is the explicit "not a readable token" signal
     return null;
   }
 }

--- a/packages/feed/packages/db/src/balance-transaction-classification.ts
+++ b/packages/feed/packages/db/src/balance-transaction-classification.ts
@@ -526,6 +526,7 @@ function extractRequestedBalanceUnits(
       }
     }
   } catch {
+    // error-policy:J3 parse of an untrusted description blob; malformed JSON means no requested-units field, null is the explicit "absent" signal (matches the non-`{` early return above)
     return null;
   }
 

--- a/packages/feed/packages/engine/src/llm/json-continuation-parser.ts
+++ b/packages/feed/packages/engine/src/llm/json-continuation-parser.ts
@@ -148,6 +148,7 @@ export function attemptJsonRepair(jsonStr: string): string | null {
     JSON.parse(repaired);
     return repaired;
   } catch {
+    // error-policy:J3 probe of untrusted model output; unparseable repair is invalid, null is the explicit "not valid JSON" signal
     return null;
   }
 }

--- a/packages/feed/packages/engine/src/services/shared-chat-context-service.ts
+++ b/packages/feed/packages/engine/src/services/shared-chat-context-service.ts
@@ -322,6 +322,7 @@ function parseStoredSnapshot(
           : new Date().toISOString(),
     };
   } catch {
+    // error-policy:J3 parse of a persisted snapshot blob; malformed/legacy shape is invalid, null re-derives from source
     return null;
   }
 }

--- a/packages/feed/packages/engine/src/utils/error-utils.ts
+++ b/packages/feed/packages/engine/src/utils/error-utils.ts
@@ -192,6 +192,7 @@ export async function handleNonCritical<T>(
   try {
     return await operation();
   } catch (error) {
+    // error-policy:J7 designed non-critical wrapper: the failure is surfaced via logger.error; null lets a supplementary step be skipped without killing the tick
     logger.error(context, { error: formatError(error) }, service);
     return null;
   }

--- a/packages/feed/packages/shared/src/utils/snowflake.ts
+++ b/packages/feed/packages/shared/src/utils/snowflake.ts
@@ -169,6 +169,7 @@ class SnowflakeGenerator {
       SnowflakeGenerator.parse(idBigInt);
       return true;
     } catch {
+      // error-policy:J3 validation predicate over untrusted input; unparseable id is invalid, false is the explicit result
       return false;
     }
   }

--- a/packages/feed/tools/chroma/global-setup.ts
+++ b/packages/feed/tools/chroma/global-setup.ts
@@ -17,7 +17,9 @@ async function ensureExtensionsDownloaded(): Promise<void> {
   try {
     await access(metamaskDir);
     return;
-  } catch {}
+  } catch {
+    // error-policy:J3 existence probe — absence (not failure) means the extension is not yet downloaded; fall through to download it
+  }
   await new Promise<void>((resolve, _reject) => {
     const child = spawn(
       "npx",


### PR DESCRIPTION
## Summary

Continues the `packages/feed` fallback-slop sweep (#12276, part of #12182). The two unambiguous domain-slop exemplars from the issue — the world-state snapshot reads (`world-state-snapshot-service.ts`) and `gameService.getQuestionOutcome()` — were already converted to fail loud by the earlier partial-chunk PR #12750 (merged). This pass **re-derives the suspect list at current `develop`, classifies each site against the binding J1–J7 rubric, and annotates the justified survivors** with grep-able `// error-policy:J<N> <reason>` comments so "every remaining handler carries a documented justification" becomes mechanically checkable.

**This is a precision pass, not a bulk conversion.** After #12750 extracted the two conflation exemplars, every remaining silent `return <default>` from a catch in the feed **domain layer** (engine / api / db / shared / agents) is — on inspection — a J3 untrusted-input parse/validation guard, and the logged degrades are designed content-generation / cache / tick-fault-isolation paths. There is no remaining unambiguous *fabricated-success-masking-a-primary-failure* slop that can be safely converted, so **no behavior was changed** here. Forcing conversions in the gray zone (auth fail-closed, decorative prompt context, LLM-content degrade, optional-Redis) is exactly the over-removal failure mode the sweep guards against, so those were left and counted.

## Re-derived suspect counts (feed, non-test src @ base)

| kind | count | notes |
|---|---|---|
| empty catch | 1 | `tools/chroma/global-setup.ts` — existence probe (annotated J3) |
| promise swallow `.catch(()=>…)` | 38 | mostly `request.json()` / `optionalAuth()` J3 + e2e/teardown J6 |
| return-default catch | 105 | domain layer is J3 parse-guards; content/cache degrades log |
| `?? <lit>` | 1785 | numeric config/display defaults — highest over-removal risk, left |
| `\|\| <lit>` | 953 | same |

## Site table — this PR (19 handlers annotated, 0 converted)

| file:line | verdict | reason |
|---|---|---|
| `packages/api/src/wallet-auth.ts:16` | **J3** | malformed/undecodable JWT payload → null "not a readable token" |
| `packages/api/src/auth-middleware.ts` (agent-session ×2) | **J3** | not-an-agent-session → fall through to Steward verification |
| `packages/api/src/auth-middleware.ts` (steward ×2) | **J3** | token fails verification → unauthenticated (fail-closed) |
| `packages/api/src/services/notification-email-service.ts:122` | **J3** | undecodable unsubscribe token → invalid |
| `packages/db/src/balance-transaction-classification.ts:528` | **J3** | malformed description JSON → no requested-units field (absent) |
| `packages/engine/src/llm/json-continuation-parser.ts:150` | **J3** | probe of untrusted model output → null "not valid JSON" |
| `packages/engine/src/services/shared-chat-context-service.ts:324` | **J3** | parse of persisted snapshot blob → null re-derives from source |
| `packages/shared/src/utils/snowflake.ts:171` | **J3** | validation predicate over untrusted id → false |
| `apps/web/src/utils/browser-storage.ts` (getStorage/getItem/setItem/removeItem/listKeys) | **J4** | storage throws in private-mode / quota; feature degrades (issue exemplar #3) |
| `apps/web/src/utils/browser-storage.ts:38` (readStorageJson) | **J3** | stale/corrupt stored value → null |
| `packages/engine/src/utils/error-utils.ts:194` | **J7** | documented non-critical wrapper: failure surfaced via `logger.error`; null skips a supplementary step without killing the tick |
| `packages/agents/src/autonomous/track-agent-trade.ts:43` | **J7** | analytics side-channel init; failure disables tracking (same no-op as no-key path), never breaks agent trading |
| `tools/chroma/global-setup.ts:20` | **J3** | existence probe — absence (not failure) → download the extension |

Per-category tally: **converted 0 · annotated 19 (12 J3 / 5 J4 / 2 J7) · left ~330**.

## Left (classified, deliberately not converted — over-removal guard)

- **`?? <lit>` / `|| <lit>` (2738 candidates)** — dominated by legitimate config/display/optional-field defaults; conflating "not loaded" with "zero" only applies where a *loaded* market/balance value is masked, which pure `packages/core` (pricing/CPMM) does **not** do (0 catch-slop there). Left rather than reclassified blind.
- **`game-tick.ts` step wrappers, `cache-service.ts`, `random-context.ts`, `QuestionManager`/`world-facts-generator` generation catches** — designed fault-isolation / cache degrade / decorative-prompt / LLM-content-degrade, all of which **log**. J-adjacent but ambiguous enough that conversion risks the tick's designed resilience and existing tests; left for a follow-up that can attach the sim-tick evidence.
- **optional-Redis handlers** (`event-cache-service`, `org-coordination-service`) — `if (!client) return <off>` establishes Redis as optional-by-design; no live callers found. Left.

## Verification

- `bun run audit:error-policy-ratchet` → **`no new fallback-slop in touched files`** (every touched file `emptyCatch 0→0` / `2→2`, `serverConsole 0→0`).
- `bun test packages/engine/src/llm/__tests__/json-continuation-parser.test.ts` → **33 pass / 0 fail** (a touched engine file; existing suite stays green).
- Changes are **comment-only additions** (`git diff` code-token stream unchanged), so they cannot alter behavior or typecheck outcome. Feed's workspace typecheck has pre-existing failures (missing built declaration outputs + implicit-any, documented in #12750) **unrelated to and unaffected by** this diff.

## Evidence matrix

- Backend logs of a real stopped-DB engine-tick failure: **N/A** — the behavior-changing conversion that warranted it (world-state fail-loud) shipped in #12750 with its own evidence (`.github/issue-evidence/12276-feed-world-state-errors.md`). This PR changes no behavior.
- Frontend screenshots/video: **N/A** — no rendered UI changed (comment-only annotations in a util).
- Real-LLM trajectories: **N/A** — no prompt/action/provider/model behavior changed.
- Domain artifacts: **N/A** — no data written or read differently.

Refs #12276

🤖 Generated with [Claude Code](https://claude.com/claude-code)
