### PR TITLE
fix(app-core): import first-run provider helpers from the @elizaos/core barrel (dev-boot blocker #12794)

### DIFF
--- a/packages/app-core/src/api/credential-resolver.ts
+++ b/packages/app-core/src/api/credential-resolver.ts
@@ -23,16 +23,14 @@ import {
   isSubscriptionProvider,
 } from "@elizaos/auth/types";
 import {
-  logger,
-  MODEL_PROVIDER_SECRETS,
-  SECRET_KEY_ALIASES,
-} from "@elizaos/core";
-import {
   getDirectAccountProviderForFirstRunProvider,
   getFirstRunProviderOption,
   getStoredFirstRunProviderId,
+  logger,
+  MODEL_PROVIDER_SECRETS,
   normalizeFirstRunProviderId,
-} from "@elizaos/core/contracts/first-run-options";
+  SECRET_KEY_ALIASES,
+} from "@elizaos/core";
 import { getDefaultAccountPool } from "../account-pool.js";
 
 // ── Credential source registry ───────────────────────────────────────

--- a/packages/core/src/__tests__/runtime-barrel.test.ts
+++ b/packages/core/src/__tests__/runtime-barrel.test.ts
@@ -15,6 +15,27 @@ describe("@elizaos/core runtime barrel", () => {
 		}
 	});
 
+	it("re-exports first-run provider helpers consumed as runtime values (#12794)", () => {
+		// dist/contracts/ ships .d.ts only (contracts are not build entrypoints),
+		// so runtime consumers (e.g. app-core's credential-resolver) must import
+		// these VALUES from the barrel; the "@elizaos/core/contracts/*" subpath
+		// resolves to a non-existent .js and breaks `bun run dev` boot.
+		const barrel = readFileSync(resolve(sourceRoot, "index.node.ts"), "utf8");
+		const firstRunExport = barrel.match(
+			/export\s*\{([^}]*)\}\s*from\s*["']\.\/contracts\/first-run-options["']/,
+		);
+
+		expect(firstRunExport).not.toBeNull();
+		for (const name of [
+			"getDirectAccountProviderForFirstRunProvider",
+			"getFirstRunProviderOption",
+			"getStoredFirstRunProviderId",
+			"normalizeFirstRunProviderId",
+		]) {
+			expect(firstRunExport?.[1]).toContain(name);
+		}
+	});
+
 	it("does not ship the filesystem-probing plugin-loader (workspace probing is host/CLI concern)", () => {
 		// The loader that probed sibling packages' unbuilt src/ trees and imported
 		// them by variable specifier is gone; core resolves plugins only through

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -50,8 +50,12 @@ export {
 } from "./constants";
 export { isElizaCloudServiceSelectedInConfig } from "./contracts/cloud-topology";
 export {
+	getDirectAccountProviderForFirstRunProvider,
+	getFirstRunProviderOption,
+	getStoredFirstRunProviderId,
 	isCloudInferenceSelectedInConfig,
 	migrateLegacyRuntimeConfig,
+	normalizeFirstRunProviderId,
 	type StylePreset,
 } from "./contracts/first-run-options";
 export {


### PR DESCRIPTION
Fixes #12794

[phone-ui]

## Before

`bun run dev` boot died with `Cannot find module '@elizaos/core/contracts/first-run-options'`.

Root cause: `packages/app-core/src/api/credential-resolver.ts` imported 4 runtime VALUES (`getDirectAccountProviderForFirstRunProvider`, `getFirstRunProviderOption`, `getStoredFirstRunProviderId`, `normalizeFirstRunProviderId`) from the `@elizaos/core/contracts/first-run-options` subpath. `@elizaos/core`'s build emits per-file `.js` only for explicit entrypoints — `dist/contracts/` is `.d.ts`-only (contracts have always been types-first; cloud-topology/service-routing/wallet/first-run-options all lack `.js`). The `package.json` `exports` `"./*" -> "./dist/*.js"` wildcard therefore resolved to a non-existent `dist/contracts/first-run-options.js`, and none of the 4 functions were re-exported from the `@elizaos/core` barrel.

## After (Option 1 — contracts stay types-only)

- `packages/core/src/index.node.ts`: the 4 helpers are added to the existing `export { ... } from "./contracts/first-run-options"` re-export (same style, alphabetized). No new build entrypoint; `index.browser.ts`/`index.edge.ts` untouched (neither references first-run-options; the consumer is node-target).
- `packages/app-core/src/api/credential-resolver.ts`: the 4 value imports move into the existing `from "@elizaos/core"` import; the dead subpath import is removed. Grep confirms no other `@elizaos/core/contracts/*` imports remain in app-core/app.
- `packages/core/src/__tests__/runtime-barrel.test.ts`: new regression guard asserting the barrel keeps re-exporting the 4 helpers (mutation-verified: fails when the barrel change is reverted).

## Resolution proof

After `bun run --cwd packages/core build`:

```
$ bun -e "import('@elizaos/core').then(m => console.log([...4 names].map(n => typeof m[n])))"
[ "function", "function", "function", "function" ]

$ bun -e "import('.../packages/app-core/src/api/credential-resolver.ts').then(...)"
credential-resolver loaded OK: [ "resolveProviderCredential", "resolveProviderCredentialMulti", "scanAllCredentials" ]
```

That second import is the exact module whose load failed on `bun run dev`.

## Tests / checks

- `packages/core/src/__tests__/runtime-barrel.test.ts`: 3/3 pass (new guard fails 1/3 with the barrel fix stashed — mutation check).
- `packages/app-core` `credential-resolver.test.ts` + `credential-resolver.multi-account.test.ts`: 11/11 pass.
- Typecheck: `packages/core` clean; `packages/app-core` reports 7 errors that are byte-identical with the fix stashed vs applied (pre-existing on develop, in plugin-elizacloud/plugin-discord/plugin-local-inference — untouched by this PR).
- Biome clean on all 3 touched files; branch rebased onto latest `origin/develop` and everything re-verified post-rebase.

## Evidence matrix

- Real-LLM trajectories: N/A — module-resolution fix; no agent/action/provider/prompt/model behavior change.
- Video walkthrough / before-after screenshots (desktop + mobile): N/A — no UI change; the user-visible effect is "dev boot no longer crashes", proven by the module-resolution transcript above.
- Frontend console/network logs: N/A — no frontend change.
- Backend logs / domain artifacts: the resolution proof above is the domain artifact — the previously-unresolvable module now imports and exports its API under bun (the dev-boot runtime).

Signed: [phone-ui]

---
**Root-caused by [phone-ui] on `bun run dev` boot; fix authored by a Fable-5 agent** (verified 100% claude-fable-5), committed + pushed. Independently re-verified by the main loop: 3-file diff, core rebuilt, `import('@elizaos/core')` → the 4 helpers all resolve as `function`, barrel-guard test mutation-checked (revert → 1/3 red). This unblocks local `bun run dev` on a fresh current-develop checkout — I hit it live while rebuilding the app for the hands-on session. — [phone-ui]