### PR TITLE
fix(core): fact write dedupe + kind-stamped relationship echo (#12849)

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -48,6 +48,7 @@ import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "./runtime/builtin-fie
 import { ChatPreHandlerRegistry } from "./runtime/chat-pre-handler-registry";
 import { ContextRegistry } from "./runtime/context-registry";
 import { DEFAULT_CONTEXT_DEFINITIONS } from "./runtime/default-contexts";
+import { findEquivalentFactId } from "./runtime/fact-write-dedupe";
 import type { ResponseHandlerEvaluator } from "./runtime/response-handler-evaluators";
 import type { ResponseHandlerFieldEvaluator } from "./runtime/response-handler-field-evaluator";
 import { ResponseHandlerFieldRegistry } from "./runtime/response-handler-field-registry";
@@ -9716,6 +9717,17 @@ ${section_end}`;
 					}),
 				},
 			};
+		}
+
+		// Facts are structurally deduped at write time: when an equivalent row
+		// (same normalized text + room + entity) already exists, skip the insert
+		// and hand back the existing id. The adapter cannot do this — its
+		// similarity check needs an embedding (absent inline on fact writes) and
+		// is bypassed whenever callers pass `unique` — so without this guard the
+		// same claim lands as multiple rows (see runtime/fact-write-dedupe.ts).
+		if (tableName === "facts") {
+			const equivalentId = await findEquivalentFactId(this, memory);
+			if (equivalentId) return equivalentId;
 		}
 
 		const ids = await this.adapter.createMemories([

--- a/packages/core/src/runtime/__tests__/fact-write-dedupe.test.ts
+++ b/packages/core/src/runtime/__tests__/fact-write-dedupe.test.ts
@@ -129,9 +129,7 @@ describe("fact write-time dedupe (runtime.createMemory)", () => {
 describe("facts_and_relationships stage — no duplicate durable echo", () => {
 	const GUITAR_OUTPUT = JSON.stringify({
 		facts: ["nubs plays guitar"],
-		relationships: [
-			{ subject: "nubs", predicate: "plays", object: "guitar" },
-		],
+		relationships: [{ subject: "nubs", predicate: "plays", object: "guitar" }],
 		thought: "new fact",
 	});
 

--- a/packages/core/src/runtime/__tests__/fact-write-dedupe.test.ts
+++ b/packages/core/src/runtime/__tests__/fact-write-dedupe.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { factsProvider } from "../../features/advanced-capabilities/providers/facts";
+import { AgentRuntime } from "../../runtime";
+import { type Character, ModelType } from "../../types";
+import type { Memory } from "../../types/memory";
+import type { UUID } from "../../types/primitives";
+import type { State } from "../../types/state";
+import { runFactsAndRelationshipsStage } from "../facts-and-relationships";
+
+/**
+ * Structural write-time dedupe for the `facts` table, driven through a real
+ * AgentRuntime + InMemoryDatabaseAdapter (only the extraction model output is
+ * canned via registerModel). Regression-proves the live double-write: one
+ * extraction turn persisted the same claim twice — a fact row (kind=current)
+ * plus a relationship-echo row with no `kind`, which the FACTS reader then
+ * promoted to a durable fact ("nubs plays guitar" duplicated durable).
+ */
+
+const USER = "00000000-0000-0000-0000-000000000001" as UUID;
+const OTHER_USER = "00000000-0000-0000-0000-000000000009" as UUID;
+const ROOM = "00000000-0000-0000-0000-000000000003" as UUID;
+const JAKE = "00000000-0000-0000-0000-0000000000a1" as UUID;
+
+function makeRuntime(modelResponse?: string): AgentRuntime {
+	const runtime = new AgentRuntime({
+		character: { name: "Eliza", bio: "test", settings: {} } as Character,
+		adapter: new InMemoryDatabaseAdapter(),
+		logLevel: "fatal",
+	});
+	if (modelResponse !== undefined) {
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			async () => modelResponse,
+			"test",
+			0,
+		);
+	}
+	return runtime;
+}
+
+function makeMessage(runtime: AgentRuntime, text: string): Memory {
+	return {
+		id: crypto.randomUUID() as UUID,
+		entityId: USER,
+		agentId: runtime.agentId,
+		roomId: ROOM,
+		content: { text, source: "test" },
+		createdAt: Date.now(),
+	};
+}
+
+function makeState(): State {
+	return {
+		values: {},
+		data: {
+			providers: {
+				ENTITIES: {
+					data: {
+						entities: [
+							{ id: USER, names: ["nubs"] },
+							{ id: JAKE, names: ["Jake"] },
+						],
+					},
+				},
+			},
+		},
+		text: "",
+	};
+}
+
+function makeFact(text: string, entityId: UUID = USER): Memory {
+	return {
+		id: crypto.randomUUID() as UUID,
+		entityId,
+		agentId: undefined as unknown as UUID,
+		roomId: ROOM,
+		content: { text, type: "fact" },
+		createdAt: Date.now(),
+	};
+}
+
+async function readFactRows(runtime: AgentRuntime): Promise<Memory[]> {
+	return runtime.getMemories({
+		tableName: "facts",
+		roomId: ROOM,
+		count: 100,
+		unique: false,
+	});
+}
+
+describe("fact write-time dedupe (runtime.createMemory)", () => {
+	it("skips an equivalent fact insert even when unique:true is passed", async () => {
+		const runtime = makeRuntime();
+		const firstId = await runtime.createMemory(
+			makeFact("nubs plays guitar"),
+			"facts",
+			true,
+		);
+		const secondId = await runtime.createMemory(
+			makeFact("Nubs plays guitar."),
+			"facts",
+			true,
+		);
+		expect(secondId).toBe(firstId);
+		const rows = await readFactRows(runtime);
+		expect(rows).toHaveLength(1);
+	});
+
+	it("keeps same-text facts from different entities (scope preserved)", async () => {
+		const runtime = makeRuntime();
+		await runtime.createMemory(makeFact("plays guitar", USER), "facts", true);
+		await runtime.createMemory(
+			makeFact("plays guitar", OTHER_USER),
+			"facts",
+			true,
+		);
+		expect(await readFactRows(runtime)).toHaveLength(2);
+	});
+
+	it("never treats empty normalized text as equivalent", async () => {
+		const runtime = makeRuntime();
+		await runtime.createMemory(makeFact("!!!"), "facts", true);
+		await runtime.createMemory(makeFact("???"), "facts", true);
+		expect(await readFactRows(runtime)).toHaveLength(2);
+	});
+});
+
+describe("facts_and_relationships stage — no duplicate durable echo", () => {
+	const GUITAR_OUTPUT = JSON.stringify({
+		facts: ["nubs plays guitar"],
+		relationships: [
+			{ subject: "nubs", predicate: "plays", object: "guitar" },
+		],
+		thought: "new fact",
+	});
+
+	it("one turn emitting a fact plus its relationship echo lands ONE facts row", async () => {
+		// Live symptom: the fact row and the relationship-echo row landed 5ms
+		// apart with identical text — the echo must be structurally skipped.
+		const runtime = makeRuntime(GUITAR_OUTPUT);
+		await runFactsAndRelationshipsStage({
+			runtime,
+			message: makeMessage(runtime, "i play guitar btw"),
+			state: makeState(),
+			extract: {
+				facts: ["nubs plays guitar"],
+				relationships: [
+					{ subject: "nubs", predicate: "plays", object: "guitar" },
+				],
+			},
+		});
+		const rows = await readFactRows(runtime);
+		expect(rows.map((row) => row.content.text)).toEqual(["nubs plays guitar"]);
+	});
+
+	it("extracting the same fact in two turns yields ONE facts row", async () => {
+		// The per-turn LLM dedupe pool is advisory (the model can miss); the
+		// structural write guard must hold even when it does.
+		const runtime = makeRuntime(GUITAR_OUTPUT);
+		for (let turn = 0; turn < 2; turn += 1) {
+			await runFactsAndRelationshipsStage({
+				runtime,
+				message: makeMessage(runtime, "i play guitar btw"),
+				state: makeState(),
+				extract: { facts: ["nubs plays guitar"] },
+			});
+		}
+		expect(await readFactRows(runtime)).toHaveLength(1);
+	});
+
+	it("a relationship echo is stamped current and never read back as durable", async () => {
+		const runtime = makeRuntime(
+			JSON.stringify({
+				facts: [],
+				relationships: [
+					{ subject: "nubs", predicate: "has_sibling", object: "Jake" },
+				],
+				thought: "new rel",
+			}),
+		);
+		await runFactsAndRelationshipsStage({
+			runtime,
+			message: makeMessage(runtime, "Jake is my brother"),
+			state: makeState(),
+			extract: {
+				relationships: [
+					{ subject: "nubs", predicate: "has_sibling", object: "Jake" },
+				],
+			},
+		});
+
+		const rows = await readFactRows(runtime);
+		expect(rows).toHaveLength(1);
+		const meta = rows[0].metadata as Record<string, unknown>;
+		expect(meta.kind).toBe("current");
+		expect(meta.confidence).toBe(0.6);
+		expect(meta.verificationStatus).toBe("self_reported");
+
+		// Read back through the real FACTS provider: the echo must rank as a
+		// current fact, not get promoted to the durable section (the reader
+		// defaults missing `kind` to durable).
+		const result = await factsProvider.get(
+			runtime,
+			makeMessage(runtime, "does nubs have a sibling named Jake?"),
+			makeState(),
+		);
+		const data = result.data as {
+			durableFacts: Memory[];
+			currentFacts: Memory[];
+		};
+		expect(data.durableFacts).toHaveLength(0);
+		expect(data.currentFacts.map((row) => row.content.text)).toEqual([
+			"nubs has_sibling Jake",
+		]);
+	});
+});

--- a/packages/core/src/runtime/fact-write-dedupe.ts
+++ b/packages/core/src/runtime/fact-write-dedupe.ts
@@ -1,0 +1,70 @@
+/**
+ * Structural write-time dedupe for the `facts` table: before a fact insert,
+ * find an existing row with the same normalized text in the same
+ * room + entity scope so `runtime.createMemory` can skip the write and return
+ * the existing row's id.
+ *
+ * This guard exists because nothing else structurally prevents duplicate fact
+ * rows. The adapter-level similarity check requires an embedding (facts
+ * writers have none inline — embeddings are backfilled asynchronously) and is
+ * bypassed entirely when callers pass an explicit `unique` flag, and the
+ * per-turn LLM dedupe pool is advisory (the model can and does miss). The
+ * live failure this closes: one extraction turn persisted the same claim
+ * twice, milliseconds apart — a fact row plus a relationship-echo row — and
+ * the FACTS reader surfaced both.
+ *
+ * Equivalence is text + scope equality after canonicalization, not semantic
+ * similarity: paraphrase-level dedupe stays with the LLM pool and the
+ * reflection pass. The candidate pool is bounded to the same recent window
+ * the FACTS provider reads, so the check degrades to a plain insert (never an
+ * error) on rooms with very deep fact history.
+ */
+
+import type { Memory } from "../types/memory";
+import type { UUID } from "../types/primitives";
+import type { IAgentRuntime } from "../types/runtime";
+
+const DEDUPE_CANDIDATE_POOL = 120;
+
+/**
+ * Canonical form for fact-text equality: case-, punctuation-, and
+ * whitespace-insensitive, unicode-aware. An empty key never matches (so
+ * punctuation-only or empty texts are never deduped against each other).
+ */
+export function normalizeFactTextKey(value: string): string {
+	return value
+		.toLowerCase()
+		.replace(/[^\p{L}\p{N}]+/gu, " ")
+		.trim();
+}
+
+/**
+ * Returns the id of an existing `facts` row equivalent to `memory`
+ * (same normalized text, same room, same entity), or null when the write
+ * should proceed. Rows sharing `memory.id` are ignored — same-id idempotence
+ * is the adapter's contract, not a duplicate.
+ */
+export async function findEquivalentFactId(
+	runtime: Pick<IAgentRuntime, "getMemories">,
+	memory: Memory,
+): Promise<UUID | null> {
+	const text =
+		typeof memory.content?.text === "string" ? memory.content.text : "";
+	const key = normalizeFactTextKey(text);
+	if (!key || !memory.roomId) return null;
+
+	const existing = await runtime.getMemories({
+		tableName: "facts",
+		roomId: memory.roomId,
+		count: DEDUPE_CANDIDATE_POOL,
+		unique: false,
+	});
+	for (const candidate of existing) {
+		if (!candidate.id || candidate.id === memory.id) continue;
+		if ((candidate.entityId ?? null) !== (memory.entityId ?? null)) continue;
+		const candidateText =
+			typeof candidate.content?.text === "string" ? candidate.content.text : "";
+		if (normalizeFactTextKey(candidateText) === key) return candidate.id;
+	}
+	return null;
+}

--- a/packages/core/src/runtime/facts-and-relationships.ts
+++ b/packages/core/src/runtime/facts-and-relationships.ts
@@ -561,6 +561,7 @@ async function persistFactsAndRelationships(
 				runtime,
 				message,
 			);
+			const echoText = `${normalized.subject} ${normalized.predicate} ${normalized.object}`;
 			try {
 				await runtime.createMemory(
 					{
@@ -568,7 +569,7 @@ async function persistFactsAndRelationships(
 						agentId: runtime.agentId,
 						roomId: message.roomId,
 						content: {
-							text: `${normalized.subject} ${normalized.predicate} ${normalized.object}`,
+							text: echoText,
 							type: "relationship",
 							subject: normalized.subject,
 							predicate: normalized.predicate,
@@ -581,7 +582,18 @@ async function persistFactsAndRelationships(
 							sourceEntityId,
 							targetEntityId,
 							tags: ["relationship", "extracted", "stage1"],
+							keywords: buildFactKeywordsForStorage(echoText),
 							extractedAt: Date.now(),
+							// Same stage-1 classification as the fact branch above: this
+							// echo lands in the `facts` table, and the reader defaults a
+							// missing `kind` to `durable` — an unkinded echo therefore
+							// resurfaces as a permanent durable fact (live symptom: the
+							// same claim shown twice, once durable, once current).
+							kind: "current" as FactKind,
+							category: "relationship",
+							confidence: DEFAULT_STAGE_FACT_CONFIDENCE,
+							verificationStatus: "self_reported" as FactVerificationStatus,
+							validAt: new Date().toISOString(),
 						},
 					} as Memory,
 					"facts",


### PR DESCRIPTION
Closes #12849

## What

Two structural fixes for fact double-writes in the memory pipeline:

1. **Stamp the relationship echo** (`packages/core/src/runtime/facts-and-relationships.ts`): the stage-1 relationship echo row written into the `facts` table now carries the same classification as the sibling fact branch — `kind: "current"`, stage confidence (0.6), `verificationStatus: "self_reported"`, `validAt`, and retrieval `keywords`. Previously it carried **no `kind`**, and the FACTS reader defaults missing `kind` to `durable`, so every unverified single-message echo resurfaced as a permanent durable identity fact.
2. **Structural write-time dedupe for facts** (`packages/core/src/runtime/fact-write-dedupe.ts`, wired in `runtime.createMemory`): before a `facts` insert, skip the write and return the existing row's id when an equivalent row (same normalized text + room + entity) already exists. Text+scope equality after unicode-aware canonicalization — not an LLM call, not regex-on-content; paraphrase-level dedupe stays with the LLM pool and the reflection pass.

## Why

Live symptom (trajectory `tj-7c727fdb81eabd`): the prompt showed

```
Things remilio nubilio knows about the speaker:
[durable.uncategorized conf=0.60] nubs plays guitar
[durable.uncategorized conf=0.60] nubs has_sibling Jake
```

`conf=0.60` is the stage-1 default and the snake_case predicate is the echo shape — unverified single-message writes rendered as durable facts, with the fact row and its echo landing milliseconds apart (observed 5ms/26ms) as two rows of the same text.

Nothing prevented this structurally: the adapter's `createMemory` never skips an insert (its similarity check only sets the row's `unique` flag, needs an embedding that fact writers don't have inline, and is bypassed entirely when callers pass an explicit `unique` value — both fact writers pass `true`), and the per-turn LLM dedupe pool is advisory and room-scoped.

## Verification (real, counted)

New regression suite `packages/core/src/runtime/__tests__/fact-write-dedupe.test.ts` drives a **real `AgentRuntime` + `InMemoryDatabaseAdapter`** through the actual stage and the real FACTS provider (only the extraction model output is canned via `registerModel`).

**Before (develop c0c2ddf374) — reproduces the disease, 4/6 fail:**

- one turn emitting a fact + its relationship echo → 2 identical-text rows (`["nubs plays guitar", "nubs plays guitar"]`)
- same fact extracted in two turns → 4 rows
- `createMemory` twice with equivalent text + `unique:true` → 2 rows
- echo `metadata.kind` → `undefined` (reader promotes to durable)

**After — 6/6 pass:**

- one extraction turn → exactly ONE facts row
- two turns, same fact → ONE row
- echo stamped `kind: "current"` and read back by the real FACTS provider under `currentFacts` with `durableFacts` empty
- scope preserved: same text from a different entity still inserts; punctuation-only texts (empty normalized key) never dedupe against each other

**Suites:**

- `bun run --cwd packages/core test` → 3005 passed | 7 failed | 11 skipped (3023) — failure parity proven: with the branch changes stashed, unmodified develop fails the exact same 7 tests in this environment (`src/media/fetch.test.ts` ×4, `link-extraction.test.ts`, `action-handler-callsite-audit.test.ts`, `tiered-action-surface.test.ts` — network-fetch and live-model-quota dependent), none on facts/memory paths
- targeted: stage tests + `src/features/advanced-capabilities/` → 18 files, 139 passed
- `bun run --cwd packages/core typecheck` (tsgo) → clean

## Evidence

- Live-LLM trajectory: read by hand — `tj-7c727fdb81eabd` prompt segment quoted above shows the misclassified echo rows a real model was fed (the domain artifact this PR removes).
- Domain artifacts: facts rows inspected in-test via the real adapter (counts + metadata asserted above).
- Screenshots / video / frontend logs: N/A — no UI surface; runtime memory-write path only.

## Notes for review

- The guard lives in `runtime.createMemory` (not the adapters) so every adapter and every fact writer is covered by one bounded read (`count: 120`, the FACTS provider's own candidate window). On rooms with deeper fact history than the window it degrades to a plain insert — never an error.
- `add_durable` from the reflection pass on text that already exists as a `current` fact now returns the existing row's id instead of inserting a cross-kind duplicate; kind promotion is an explicit `updateMemory` concern, not a duplicate-insert side effect.
