### PR TITLE
fix(cloud): /v1/messages reasoning-model output floor — no bill-for-empty (#12864)

### DIFF
--- a/packages/cloud/api/__tests__/messages-reasoning-floor.test.ts
+++ b/packages/cloud/api/__tests__/messages-reasoning-floor.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure-helper test for v1/messages/route.ts's `messagesEffectiveMaxTokens`.
+ *
+ * /v1/messages (the anthropic-proxy / eliza-code path) previously set the output
+ * budget to `request.max_tokens` with no floor for cerebras reasoning models —
+ * so a small max_tokens was consumed entirely by hidden reasoning and the caller
+ * was billed for empty output. This mirrors the chat/completions reasoning floor
+ * so the two money paths agree. Pure, no I/O.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { messagesEffectiveMaxTokens } from "../v1/messages/route";
+
+const MIN = 4096; // mirror of MESSAGES_MIN_RESPONSE_TOKENS — fail loudly if it moves
+
+describe("messagesEffectiveMaxTokens", () => {
+  test("non-reasoning model: requested budget passes through unchanged", () => {
+    expect(messagesEffectiveMaxTokens(256, null, "openai/gpt-4o-mini")).toBe(
+      256,
+    );
+    expect(
+      messagesEffectiveMaxTokens(undefined, null, "openai/gpt-4o-mini"),
+    ).toBeUndefined();
+  });
+
+  test("cerebras reasoning model: a small or absent budget is floored to MIN (no bill-for-empty)", () => {
+    // Without the floor, 256 tokens are spent on hidden reasoning → empty but
+    // billed output. gpt-oss-120b / gemma-4-31b match REASONING_MODEL_PATTERNS.
+    expect(messagesEffectiveMaxTokens(256, null, "gpt-oss-120b")).toBe(MIN);
+    expect(messagesEffectiveMaxTokens(undefined, null, "gemma-4-31b")).toBe(
+      MIN,
+    );
+  });
+
+  test("cerebras reasoning model: a larger requested budget is honored", () => {
+    expect(messagesEffectiveMaxTokens(8000, null, "gpt-oss-120b")).toBe(8000);
+  });
+
+  test("Anthropic CoT: budget covers the thinking budget PLUS a response floor", () => {
+    expect(messagesEffectiveMaxTokens(1000, 10000, "anthropic/claude-x")).toBe(
+      10000 + MIN,
+    );
+  });
+});

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -35,6 +35,7 @@ import {
   estimateTokens,
   getProviderFromModel,
   getSafeModelParams,
+  modelUsesReasoningTokens,
   normalizeModelName,
 } from "@/lib/pricing";
 import {
@@ -150,6 +151,36 @@ function normalizeModelId(model: string): string {
   if (model.includes("/")) return model;
   if (model.startsWith("claude-")) return `anthropic/${model}`;
   return model;
+}
+
+const MESSAGES_MIN_RESPONSE_TOKENS = 4096;
+
+/**
+ * Response-token budget for a /v1/messages generation. Mirrors the
+ * chat/completions floor: Anthropic CoT needs headroom for thinking PLUS the
+ * answer, and non-Anthropic reasoning models (cerebras zai-glm-4.7 /
+ * gpt-oss-120b / gemma-4-31b) spend hidden reasoning tokens — without a floor a
+ * small `max_tokens` is consumed by reasoning alone and the caller is billed
+ * for empty output. Non-reasoning models pass their requested budget through.
+ */
+export function messagesEffectiveMaxTokens(
+  requestMaxTokens: number | undefined,
+  cotBudget: number | null,
+  model: string,
+): number | undefined {
+  if (cotBudget != null) {
+    return Math.max(
+      requestMaxTokens ?? MESSAGES_MIN_RESPONSE_TOKENS,
+      cotBudget + MESSAGES_MIN_RESPONSE_TOKENS,
+    );
+  }
+  if (modelUsesReasoningTokens(model)) {
+    return Math.max(
+      requestMaxTokens ?? MESSAGES_MIN_RESPONSE_TOKENS,
+      MESSAGES_MIN_RESPONSE_TOKENS,
+    );
+  }
+  return requestMaxTokens;
 }
 
 function inferImageMediaType(urlOrType: string): string {
@@ -795,14 +826,11 @@ async function handleNonStream(
     cotBudget != null
       ? mergeAnthropicCotProviderOptions(model, process.env, cotBudget)
       : {};
-  const MIN_RESPONSE_BUFFER = 4096;
-  const effectiveMaxTokens =
-    cotBudget != null
-      ? Math.max(
-          request.max_tokens ?? MIN_RESPONSE_BUFFER,
-          cotBudget + MIN_RESPONSE_BUFFER,
-        )
-      : request.max_tokens;
+  const effectiveMaxTokens = messagesEffectiveMaxTokens(
+    request.max_tokens,
+    cotBudget,
+    model,
+  );
 
   try {
     const result = await generateText({
@@ -1158,14 +1186,11 @@ async function handleStream(
     cotBudget != null
       ? mergeAnthropicCotProviderOptions(model, process.env, cotBudget)
       : {};
-  const MIN_RESPONSE_BUFFER = 4096;
-  const effectiveMaxTokens =
-    cotBudget != null
-      ? Math.max(
-          request.max_tokens ?? MIN_RESPONSE_BUFFER,
-          cotBudget + MIN_RESPONSE_BUFFER,
-        )
-      : request.max_tokens;
+  const effectiveMaxTokens = messagesEffectiveMaxTokens(
+    request.max_tokens,
+    cotBudget,
+    model,
+  );
 
   const result = streamText({
     model: getLanguageModel(model),


### PR DESCRIPTION
Closes #12864. `[cloud-money]`. Found by a demo-golden-path Fable-5 hunt.

**Bug (MED money):** `/v1/messages` had no MIN_RESPONSE floor for cerebras reasoning models → hidden reasoning eats a small `max_tokens` → empty-but-billed output. `chat/completions` has the floor; messages diverged.

**Fix:** `messagesEffectiveMaxTokens` mirrors the chat/completions floor at both message token sites. **4/4 green; red without the fix.** typecheck + biome clean. Money path — no self-merge.