### PR TITLE
fix(anthropic): honor explicit Claude config path

### DIFF
--- a/plugins/plugin-anthropic/utils/credential-store.ts
+++ b/plugins/plugin-anthropic/utils/credential-store.ts
@@ -270,12 +270,14 @@ function readFromCredentialStore(): ClaudeCredentials | null {
   const { join } = require("node:path") as typeof import("node:path");
   const { homedir } = require("node:os") as typeof import("node:os");
 
-  if (process.platform === "darwin") {
+  const configDirOverride = getEnvVar("CLAUDE_CONFIG_DIR")?.trim();
+  const configDir = configDirOverride || join(homedir(), ".claude");
+
+  if (!configDirOverride && process.platform === "darwin") {
     const fromKeychain = readFromMacKeychain();
     if (fromKeychain) return fromKeychain;
   }
 
-  const configDir = getEnvVar("CLAUDE_CONFIG_DIR") ?? join(homedir(), ".claude");
   const credPath = join(configDir, ".credentials.json");
   const { readFileSync } = require("node:fs") as typeof import("node:fs");
 

--- a/plugins/plugin-edge-tts/AGENTS.md
+++ b/plugins/plugin-edge-tts/AGENTS.md
@@ -93,7 +93,7 @@ This plugin has a single responsibility (TTS model handler). The typical extensi
 ## Conventions / gotchas
 
 - **Node-only.** The browser build (`src/index.browser.ts`) exports a browser-unavailable plugin shape and warning log. Do not add Node.js file system or WebSocket code to the browser entry point.
-- **Temp file I/O.** `node-edge-tts` writes audio to a temp file (via `mkdtempSync`); the plugin reads it back and cleans up in a `finally` block. If cleanup fails, the error is silently ignored to avoid masking the audio result.
+- **Temp file I/O.** `node-edge-tts` writes audio to a temp file (via `mkdtempSync`); the plugin reads it back and cleans up in a `finally` block. Cleanup failure is logged at warn/debug level but must not mask the audio result.
 - **5000-character limit.** Enforced explicitly before calling the TTS service. The upstream service has its own practical limit near this value; errors above it are opaque network failures.
 - **Type declarations.** `node-edge-tts` ships its own TypeScript declarations in its `dist/` folder (`edge-tts.d.ts`, `drm.d.ts`). No hand-written type declarations are needed for this package.
 - **`synthesizeEdgeSpeech`** passes `null` as the runtime to `getEdgeTTSSettings`, so it reads only from `process.env`. Do not call it inside an agent handler where a runtime is available — use `runtime.useModel(ModelType.TEXT_TO_SPEECH, ...)` instead.

--- a/plugins/plugin-edge-tts/CLAUDE.md
+++ b/plugins/plugin-edge-tts/CLAUDE.md
@@ -93,7 +93,7 @@ This plugin has a single responsibility (TTS model handler). The typical extensi
 ## Conventions / gotchas
 
 - **Node-only.** The browser build (`src/index.browser.ts`) exports a browser-unavailable plugin shape and warning log. Do not add Node.js file system or WebSocket code to the browser entry point.
-- **Temp file I/O.** `node-edge-tts` writes audio to a temp file (via `mkdtempSync`); the plugin reads it back and cleans up in a `finally` block. If cleanup fails, the error is silently ignored to avoid masking the audio result.
+- **Temp file I/O.** `node-edge-tts` writes audio to a temp file (via `mkdtempSync`); the plugin reads it back and cleans up in a `finally` block. Cleanup failure is logged at warn/debug level but must not mask the audio result.
 - **5000-character limit.** Enforced explicitly before calling the TTS service. The upstream service has its own practical limit near this value; errors above it are opaque network failures.
 - **Type declarations.** `node-edge-tts` ships its own TypeScript declarations in its `dist/` folder (`edge-tts.d.ts`, `drm.d.ts`). No hand-written type declarations are needed for this package.
 - **`synthesizeEdgeSpeech`** passes `null` as the runtime to `getEdgeTTSSettings`, so it reads only from `process.env`. Do not call it inside an agent handler where a runtime is available — use `runtime.useModel(ModelType.TEXT_TO_SPEECH, ...)` instead.


### PR DESCRIPTION
## Summary
- make `CLAUDE_CONFIG_DIR` authoritative in the Anthropic credential-store file reader, so macOS keychain credentials cannot mask an explicitly selected corrupt or absent Claude credential file
- update Edge TTS package guidance to match #12793 cleanup logging behavior

## Verification
- `bun run --cwd plugins/plugin-anthropic test`
- `bun run --cwd plugins/plugin-anthropic typecheck`
- `cmp -s plugins/plugin-edge-tts/CLAUDE.md plugins/plugin-edge-tts/AGENTS.md`
- `git diff --check origin/develop..HEAD`

Follow-up to #12793 / refs #12271.
