### PR TITLE
fix(cloud): export runWithTrajectoryPurpose + fetchWithSsrfGuard from Worker core-stub — unblock prod deploy

### DIFF
--- a/packages/cloud/api/__tests__/elizaos-core-stub.test.ts
+++ b/packages/cloud/api/__tests__/elizaos-core-stub.test.ts
@@ -4,6 +4,9 @@ import {
   DEFAULT_CEREBRAS_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
+  fetchWithSsrfGuard,
+  runWithTrajectoryPurpose,
+  SsrfBlockedError,
 } from "../src/stubs/elizaos-core";
 
 describe("elizaos-core Worker stub", () => {
@@ -13,5 +16,126 @@ describe("elizaos-core Worker stub", () => {
     expect(DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL).toBe(
       DEFAULT_CEREBRAS_TEXT_MODEL,
     );
+  });
+
+  test("runWithTrajectoryPurpose runs the fn and returns its result (sync + async)", async () => {
+    expect(runWithTrajectoryPurpose("worker-test", () => 41 + 1)).toBe(42);
+    await expect(
+      runWithTrajectoryPurpose("worker-test", async () => "async-ok"),
+    ).resolves.toBe("async-ok");
+    expect(() =>
+      runWithTrajectoryPurpose("worker-test", () => {
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+  });
+
+  describe("fetchWithSsrfGuard", () => {
+    const neverFetch = () => {
+      throw new Error("fetchImpl must not be reached for a blocked target");
+    };
+
+    test("blocks literal private/metadata targets before any fetch", async () => {
+      for (const url of [
+        "http://169.254.169.254/latest/meta-data/",
+        "http://127.0.0.1:8080/",
+        "http://10.0.0.5/internal",
+        "http://localhost/admin",
+        "http://metadata.google.internal/computeMetadata/v1/",
+      ]) {
+        await expect(
+          fetchWithSsrfGuard({ url, fetchImpl: neverFetch }),
+        ).rejects.toBeInstanceOf(SsrfBlockedError);
+      }
+    });
+
+    test("rejects non-http(s) URLs", async () => {
+      await expect(
+        fetchWithSsrfGuard({
+          url: "file:///etc/passwd",
+          fetchImpl: neverFetch,
+        }),
+      ).rejects.toThrow("Invalid URL: must be http or https");
+    });
+
+    test("fails CLOSED when a lookupFn is provided without a pinnedFetchImpl", async () => {
+      await expect(
+        fetchWithSsrfGuard({
+          url: "https://example.com/",
+          lookupFn: async () => [{ address: "93.184.216.34", family: 4 }],
+          fetchImpl: neverFetch,
+        }),
+      ).rejects.toThrow(/lookupFn was provided without a pinnedFetchImpl/);
+    });
+
+    test("returns the response for an allowed target via the injected fetchImpl", async () => {
+      const { response, finalUrl, release } = await fetchWithSsrfGuard({
+        url: "https://example.com/audio.mp3",
+        fetchImpl: async () => new Response("ok", { status: 200 }),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("ok");
+      expect(finalUrl).toBe("https://example.com/audio.mp3");
+      await release();
+    });
+
+    test("re-validates every redirect hop — redirect to a private IP is blocked", async () => {
+      let calls = 0;
+      const fetchImpl = async () => {
+        calls += 1;
+        return new Response(null, {
+          status: 302,
+          headers: { location: "http://169.254.169.254/latest/meta-data/" },
+        });
+      };
+      await expect(
+        fetchWithSsrfGuard({ url: "https://example.com/start", fetchImpl }),
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
+      expect(calls).toBe(1);
+    });
+
+    test("strips credential headers on a cross-origin redirect", async () => {
+      const seenAuth: Array<string | null> = [];
+      const fetchImpl = async (
+        input: RequestInfo | URL,
+        init?: RequestInit,
+      ) => {
+        const headers = new Headers(init?.headers);
+        seenAuth.push(headers.get("authorization"));
+        if (String(input).startsWith("https://example.com/")) {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://evil.example.net/capture" },
+          });
+        }
+        return new Response("done", { status: 200 });
+      };
+      const { response, release } = await fetchWithSsrfGuard({
+        url: "https://example.com/start",
+        init: { headers: { authorization: "Bearer secret" } },
+        fetchImpl,
+      });
+      expect(response.status).toBe(200);
+      expect(seenAuth).toEqual(["Bearer secret", null]);
+      await release();
+    });
+
+    test("caps redirects", async () => {
+      let hop = 0;
+      const fetchImpl = async () => {
+        hop += 1;
+        return new Response(null, {
+          status: 302,
+          headers: { location: `https://example.com/hop-${hop}` },
+        });
+      };
+      await expect(
+        fetchWithSsrfGuard({
+          url: "https://example.com/start",
+          maxRedirects: 2,
+          fetchImpl,
+        }),
+      ).rejects.toThrow("Too many redirects (limit: 2)");
+    });
   });
 });

--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -7,6 +7,54 @@
  * Worker-side path reaches them.
  */
 
+// The stub may bundle real core source ONLY when the module is pure — zero
+// imports (or type-only), zero top-level I/O, zero node built-ins. Reusing
+// the real module beats a drift-prone copy for anything security-relevant
+// (SSRF blocklists, log redaction). Anything heavier gets a Worker-safe
+// stand-in below instead.
+import {
+  isBlockedHostname,
+  isPrivateIpAddress,
+  type LookupFn,
+  type PinnedHostname,
+  type PinnedLookup,
+  resolvePinnedHostname,
+  resolvePinnedHostnameWithPolicy,
+  SsrfBlockedError,
+  type SsrfPolicy,
+} from "../../../../core/src/network/ssrf";
+
+// `globalThis` Symbol.for account-selection bridges (pure). app-core service
+// modules bundled into the Worker call the setters at module scope.
+export {
+  ANTHROPIC_ACCOUNT_POOL_BRIDGE_SYMBOL,
+  CODING_AGENT_SELECTOR_BRIDGE_SYMBOL,
+  getAnthropicAccountPoolBridge,
+  getCodingAgentSelectorBridge,
+  setAnthropicAccountPoolBridge,
+  setCodingAgentSelectorBridge,
+} from "../../../../core/src/account-pool-bridge";
+// Subscription-auth provider registry (pure Map). packages/auth registers and
+// reads providers through @elizaos/core; every bundled import resolves to this
+// stub, so re-exporting the real module keeps one shared registry instance.
+export {
+  getSubscriptionAuthProvider,
+  hasSubscriptionAuthProvider,
+  listSubscriptionAuthProviders,
+  registerSubscriptionAuthProvider,
+  resetSubscriptionAuthProviders,
+} from "../../../../core/src/features/subscription-auth/registry.ts";
+
+// Log-redaction helpers used by cloud-shared's logger. These MUST stay the
+// real implementations — a pass-through here would leak API keys/tokens into
+// Worker logs. Pure string/regex logic, safe to bundle.
+export {
+  isSensitiveKeyName,
+  redactLogArgs,
+} from "../../../../core/src/security/redact";
+export type { SsrfPolicy };
+export { SsrfBlockedError };
+
 const NOT_AVAILABLE =
   "@elizaos/core runtime APIs are not available in the Cloudflare Workers API bundle. Route agent runtime work through the agent-server sidecar.";
 
@@ -258,6 +306,22 @@ export function runWithTrajectoryContext<T>(
   return fn();
 }
 
+/**
+ * Worker-safe stand-in for `runWithTrajectoryPurpose`. In core this tags the
+ * active trajectory context with a pipeline purpose before running `fn`; the
+ * trajectory context manager lives on the agent sidecar and no trajectory is
+ * ever recorded in the Worker bundle, so just run the function. (Pulled into
+ * the bundle transitively via `@elizaos/shared` email-classification — not
+ * invoked on a Worker route. Deleting this export breaks the Worker build:
+ * #11845/#11875.)
+ */
+export function runWithTrajectoryPurpose<T>(
+  _purpose: string,
+  fn: () => T | Promise<T>,
+): T | Promise<T> {
+  return fn();
+}
+
 type InferenceTimingMeta = Record<string, string | number | boolean>;
 
 /**
@@ -357,6 +421,337 @@ export function sendJsonError(
   status = 400,
 ): Response {
   return Response.json({ error: message }, { status });
+}
+
+// ---------------------------------------------------------------------------
+// SSRF-guarded fetch — Worker port of core `network/fetch-guard.ts`. Pulled
+// into the bundle via plugin-elizacloud's transcription model (audioUrl
+// fetches are attachment fetches and MUST stay SSRF-guarded). Mirrors core's
+// edge branch exactly: workerd has no `node:dns`, so core itself documents
+// this same no-pin literal-host mode for Workers (see EDGE-SSRF in core).
+// The ONLY delta from core is dropping the Node-autoloaded pinned transport
+// (`node-pinned-fetch`), which cannot run on workerd; callers may still
+// inject `lookupFn` + `pinnedFetchImpl`, and a lookupFn WITHOUT a pinned
+// transport fails CLOSED, same as core. Do not weaken these checks.
+// ---------------------------------------------------------------------------
+
+type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export type PinnedLookupFetchParams = {
+  url: URL;
+  init: RequestInit;
+  lookup: PinnedLookup;
+  addresses: string[];
+};
+
+export type PinnedLookupFetchLike = (
+  params: PinnedLookupFetchParams,
+) => Promise<Response>;
+
+export type GuardedFetchOptions = {
+  url: string;
+  fetchImpl?: FetchLike;
+  pinnedFetchImpl?: PinnedLookupFetchLike;
+  init?: RequestInit;
+  maxRedirects?: number;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  policy?: SsrfPolicy;
+  lookupFn?: LookupFn;
+};
+
+export type GuardedFetchResult = {
+  response: Response;
+  finalUrl: string;
+  release: () => Promise<void>;
+};
+
+const DEFAULT_MAX_REDIRECTS = 3;
+
+// Credential-bearing headers that must never follow a redirect to a different
+// origin (this guard follows redirects manually with `redirect: "manual"`, so
+// it must reproduce the stripping standard fetch does).
+const CROSS_ORIGIN_STRIPPED_HEADERS = [
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+] as const;
+
+// Entity/body headers dropped when a redirect rewrites the request to a
+// bodyless GET (301/302 POST, any 303), per the WHATWG redirect rules.
+const REDIRECT_BODY_STRIPPED_HEADERS = [
+  "content-encoding",
+  "content-language",
+  "content-location",
+  "content-type",
+  "content-length",
+] as const;
+
+function stripCredentialHeaders(
+  headers: HeadersInit | undefined,
+): HeadersInit | undefined {
+  if (!headers) {
+    return headers;
+  }
+  const cleaned = new Headers(headers);
+  for (const name of CROSS_ORIGIN_STRIPPED_HEADERS) {
+    cleaned.delete(name);
+  }
+  return cleaned;
+}
+
+function stripBodyHeaders(
+  headers: HeadersInit | undefined,
+): HeadersInit | undefined {
+  if (!headers) {
+    return headers;
+  }
+  const cleaned = new Headers(headers);
+  for (const name of REDIRECT_BODY_STRIPPED_HEADERS) {
+    cleaned.delete(name);
+  }
+  return cleaned;
+}
+
+function shouldRewriteToGet(status: number, method: string): boolean {
+  const upper = method.toUpperCase();
+  if ((status === 301 || status === 302) && upper === "POST") {
+    return true;
+  }
+  if (status === 303 && upper !== "GET" && upper !== "HEAD") {
+    return true;
+  }
+  return false;
+}
+
+function isRedirectStatus(status: number): boolean {
+  return (
+    status === 301 ||
+    status === 302 ||
+    status === 303 ||
+    status === 307 ||
+    status === 308
+  );
+}
+
+function buildAbortSignal(params: {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}): {
+  signal?: AbortSignal;
+  cleanup: () => void;
+} {
+  const { timeoutMs, signal } = params;
+  if (!timeoutMs && !signal) {
+    return { signal: undefined, cleanup: () => {} };
+  }
+
+  if (!timeoutMs) {
+    return { signal, cleanup: () => {} };
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const onAbort = () => controller.abort();
+  if (signal) {
+    if (signal.aborted) {
+      controller.abort();
+    } else {
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+  }
+
+  const cleanup = () => {
+    clearTimeout(timeoutId);
+    if (signal) {
+      signal.removeEventListener("abort", onAbort);
+    }
+  };
+
+  return { signal: controller.signal, cleanup };
+}
+
+/**
+ * Fetch with SSRF protection — Worker-safe mirror of core's
+ * `fetchWithSsrfGuard` contract:
+ *
+ * - Validates URL protocol (http/https only) on EVERY hop
+ * - Blocks literal private/loopback/link-local IPs and internal hostnames via
+ *   the real core validators (honoring `policy.allowPrivateNetwork` /
+ *   `policy.allowedHostnames`)
+ * - With an injected `lookupFn` + `pinnedFetchImpl`: resolves and pins DNS to
+ *   also defend against rebinding; a `lookupFn` without a pinned transport
+ *   throws (fail closed) — never downgrades to unpinned fetch
+ * - Follows redirects manually, re-validating every hop, rewriting to a
+ *   bodyless GET where the WHATWG rules require it, and stripping credential
+ *   headers on cross-origin hops
+ * - Supports timeout and abort signals
+ */
+export async function fetchWithSsrfGuard(
+  params: GuardedFetchOptions,
+): Promise<GuardedFetchResult> {
+  const fetcher: FetchLike | undefined = params.fetchImpl ?? globalThis.fetch;
+  if (!fetcher) {
+    throw new Error("fetch is not available");
+  }
+  const lookupFn = params.lookupFn;
+  const pinnedFetchImpl = params.pinnedFetchImpl;
+
+  // Same fail-closed footgun guard as core (#11147): a lookupFn computes a DNS
+  // pin, but without a pinnedFetchImpl to connect to that pinned IP the pin
+  // would be silently discarded, re-opening the rebinding race.
+  if (lookupFn && !pinnedFetchImpl) {
+    throw new Error(
+      "SSRF guard: a DNS lookupFn was provided without a pinnedFetchImpl. " +
+        "Refusing to fall back to the unpinned fetcher — the computed DNS pin " +
+        "would be discarded, re-introducing a DNS-rebinding race. Provide a " +
+        "pinnedFetchImpl alongside the lookupFn.",
+    );
+  }
+
+  const maxRedirects =
+    typeof params.maxRedirects === "number" &&
+    Number.isFinite(params.maxRedirects)
+      ? Math.max(0, Math.floor(params.maxRedirects))
+      : DEFAULT_MAX_REDIRECTS;
+
+  const { signal, cleanup } = buildAbortSignal({
+    timeoutMs: params.timeoutMs,
+    signal: params.signal,
+  });
+
+  let released = false;
+  const release = async () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    cleanup();
+  };
+
+  const visited = new Set<string>();
+  let currentUrl = params.url;
+  let redirectCount = 0;
+  let hopHeaders = params.init?.headers;
+  let hopMethod = params.init?.method;
+  let hopBodyDropped = false;
+
+  while (true) {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(currentUrl);
+    } catch {
+      await release();
+      throw new Error("Invalid URL: must be http or https");
+    }
+    if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+      await release();
+      throw new Error("Invalid URL: must be http or https");
+    }
+    try {
+      let pinned: PinnedHostname | undefined;
+      if (lookupFn) {
+        const usePolicy = Boolean(
+          params.policy?.allowPrivateNetwork ||
+            params.policy?.allowedHostnames?.length,
+        );
+        pinned = usePolicy
+          ? await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
+              lookupFn,
+              policy: params.policy,
+            })
+          : await resolvePinnedHostname(parsedUrl.hostname, lookupFn);
+      } else {
+        // EDGE-SSRF (matches core): no `node:dns` on workerd, so no socket
+        // pinning — block literal internal targets on every hop; the residual
+        // rebinding exposure is closed operationally by Cloudflare egress
+        // policy (see core network/fetch-guard.ts EDGE-SSRF note).
+        const allowPrivate = Boolean(params.policy?.allowPrivateNetwork);
+        const host = parsedUrl.hostname.trim().toLowerCase().replace(/\.$/, "");
+        const allowed = new Set(
+          (params.policy?.allowedHostnames ?? []).map((value) =>
+            value.trim().toLowerCase().replace(/\.$/, ""),
+          ),
+        );
+        if (!allowPrivate && !allowed.has(host)) {
+          if (isBlockedHostname(parsedUrl.hostname)) {
+            await release();
+            throw new SsrfBlockedError(
+              `Blocked hostname: ${parsedUrl.hostname}`,
+            );
+          }
+          if (isPrivateIpAddress(parsedUrl.hostname)) {
+            await release();
+            throw new SsrfBlockedError("Blocked: private/internal IP address");
+          }
+        }
+      }
+
+      const init: RequestInit = {
+        ...(params.init ? { ...params.init } : {}),
+        ...(hopHeaders ? { headers: hopHeaders } : {}),
+        ...(hopMethod !== undefined ? { method: hopMethod } : {}),
+        ...(hopBodyDropped ? { body: undefined } : {}),
+        redirect: "manual",
+        ...(signal ? { signal } : {}),
+      };
+
+      const response =
+        pinned && pinnedFetchImpl
+          ? await pinnedFetchImpl({
+              url: parsedUrl,
+              init,
+              lookup: pinned.lookup,
+              addresses: pinned.addresses,
+            })
+          : await fetcher(parsedUrl.toString(), init);
+
+      if (isRedirectStatus(response.status)) {
+        const location = response.headers.get("location");
+        if (!location) {
+          await release();
+          throw new Error(
+            `Redirect missing location header (${response.status})`,
+          );
+        }
+        redirectCount += 1;
+        if (redirectCount > maxRedirects) {
+          await release();
+          throw new Error(`Too many redirects (limit: ${maxRedirects})`);
+        }
+        const nextParsedUrl = new URL(location, parsedUrl);
+        const nextUrl = nextParsedUrl.toString();
+        if (visited.has(nextUrl)) {
+          await release();
+          throw new Error("Redirect loop detected");
+        }
+        visited.add(nextUrl);
+        if (shouldRewriteToGet(response.status, hopMethod ?? "GET")) {
+          hopMethod = "GET";
+          hopBodyDropped = true;
+          hopHeaders = stripBodyHeaders(hopHeaders);
+        }
+        if (parsedUrl.origin !== nextParsedUrl.origin) {
+          hopHeaders = stripCredentialHeaders(hopHeaders);
+        }
+        void response.body?.cancel();
+        currentUrl = nextUrl;
+        continue;
+      }
+
+      return {
+        response,
+        finalUrl: currentUrl,
+        release,
+      };
+    } catch (err) {
+      await release();
+      throw err;
+    }
+  }
 }
 
 const CONNECTOR_SOURCE_ALIASES: Record<string, readonly string[]> = {
@@ -604,7 +999,13 @@ export const ServiceType = {
   PDF: "PDF",
   REMOTE_FILES: "REMOTE_FILES",
   MEDIA_GENERATION: "MEDIA_GENERATION",
+  CLOUD_AUTH: "CLOUD_AUTH",
 } as const;
+
+// Mirrors core's `cloud-auth-service.ts` (`ServiceType.CLOUD_AUTH`). Pulled in
+// via plugin-elizacloud's cloud-auth service, which the Worker bundle reaches
+// transitively — the service itself runs on the agent sidecar.
+export const CLOUD_AUTH_SERVICE_TYPE = ServiceType.CLOUD_AUTH;
 
 export const VECTOR_DIMS = {
   SMALL: 384,


### PR DESCRIPTION
## URGENT — prod deploy blocker (maintainer review requested, do not let it sit)

Unblocks the promote **#12051** prod deploy carrying the money fixes (#12047 embeddings affiliate, #11976/#11989, #11785). **Please review + merge via maintainer lane — I am not self-merging.**

### The break (deploy run [28680305905](https://github.com/elizaOS/eliza/actions/runs/28680305905), job 85062716654, re-run failed identically 2026-07-04T04:2x)

`Deploy to Cloudflare Workers` / wrangler esbuild fails on `main` (and would fail on develop once its `build:core` blocker is cleared):

```
✘ [ERROR] No matching export in "src/stubs/elizaos-core.ts" for import "runWithTrajectoryPurpose"
      ../../shared/src/email-classification/email-classifier.ts:20:2
✘ [ERROR] No matching export in "src/stubs/elizaos-core.ts" for import "fetchWithSsrfGuard"
      ../../../plugins/plugin-elizacloud/src/models/transcription.ts:2:9
```

Worker-stub-drift, same class as #11845/#11857/#11865/#11875/#11902. Root cause of the first: commit `c7b4c1d332` ("fix: clear monetization branch blockers" — a stale branch merged **after** the hotfixes) deleted the `runWithTrajectoryPurpose` export that #11845/#11875 had added. The second: plugin-elizacloud's transcription `audioUrl` fetch was routed through the SSRF guard (correctly), but the guard was never stubbed for the Worker bundle.

A local **production dry-run** surfaced **8 more** missing stub exports that accumulated while the wrangler step was masked by the develop lane's earlier `build:core` failure — all fixed here too: `registerSubscriptionAuthProvider`/`getSubscriptionAuthProvider`/`hasSubscriptionAuthProvider` (packages/auth), `isSensitiveKeyName`/`redactLogArgs` (cloud-shared logger), `CLOUD_AUTH_SERVICE_TYPE` (plugin-elizacloud cloud-auth), `setAnthropicAccountPoolBridge`/`setCodingAgentSelectorBridge` (app-core services).

### What was added (matches the stub's existing patterns)

- **`runWithTrajectoryPurpose`** — pass-through beside the existing `runWithTrajectoryContext` stand-in. The trajectory context manager lives on the agent sidecar; purpose-tagging is observability, nothing billing/security-bearing runs through it in the Worker.
- **`fetchWithSsrfGuard`** — Worker-safe port of core's guard that **reuses the real, pure `core/src/network/ssrf.ts` validators** (zero imports, zero I/O) so the blocklist (exotic IPv4 encodings, IPv6 prefixes, metadata hostnames) cannot drift. Full contract preserved: http/https-only per hop, private/loopback/link-local + internal-hostname blocking honoring `policy`, manual redirects re-validated every hop, WHATWG 301/302-POST/303 GET-rewrite + body-header strip, cross-origin credential stripping, timeout/abort, and **fail-closed** on `lookupFn` without `pinnedFetchImpl`. The only delta from core is omitting the Node-autoloaded pinned-DNS transport — workerd has no `node:dns`; this is exactly core's own documented **EDGE-SSRF** mode. **SSRF protection is not weakened.** (Bonus: bundling core's real guard would have been *wrong* on workerd — `nodejs_compat` defines `process.versions.node`, so core would try the Node pinned transport and fail closed at runtime.)
- **`isSensitiveKeyName` / `redactLogArgs`** — re-exported from core's pure `security/redact.ts`. These must stay real: a no-op here would leak API keys/tokens into Worker logs.
- **subscription-auth registry + account-pool bridges** — re-exported from their pure core modules (every bundled `@elizaos/core` import resolves to this stub, so the bundle shares one registry instance).
- **`CLOUD_AUTH_SERVICE_TYPE`** — mirrored (`ServiceType.CLOUD_AUTH`, same value as core).

### Build proof (real output, local dry-run of the exact wrangler build the deploy runs)

```
$ cd packages/cloud/api && bunx wrangler deploy --env production --dry-run --outdir /tmp/wrangler-dryrun-check
 ⛅️ wrangler 4.100.0
Total Upload: 15967.15 KiB / gzip: 3544.10 KiB
--dry-run: exiting now.
EXIT=0   (grep -c 'ERROR|No matching export' → 0)
```

Before the fix, the identical local harness reproduced the missing-export failures (the 2 from CI + the 8 newly-exposed ones), so the harness demonstrably catches this error class.

Also verified:
- `bun run --cwd packages/cloud/api typecheck` → clean
- `bunx biome check` on both files → clean
- `bun test __tests__/elizaos-core-stub.test.ts` → **9 pass** — new tests cover the SSRF guard for real: private-IP/metadata/localhost blocking before any fetch, non-http(s) rejection, fail-closed lookupFn-without-pinned-transport, redirect-hop re-validation (redirect→169.254.169.254 blocked), cross-origin credential stripping, redirect cap, plus trajectory-purpose pass-through (sync/async/throw).

### ⚠️ Second, independent deploy blocker (NOT fixed here)

Every current develop deploy run dies **earlier**, at `Build linked elizaOS workspaces` (`bun run build:core`):

```
@elizaos/core:build: src/cloud-routing.ts(8,8): error TS2307: Cannot find module '@elizaos/cloud-routing'
```

(e.g. runs 28694656324, 28694875576 — all 3 deploy jobs, deterministic). `@elizaos/cloud-routing` IS in `CORE_BUILD_PACKAGES` and in core's `dependencies`, so this looks like an install/turbo-graph issue in the deploy job, from the #12092 item-28 cloud-routing single-sourcing. #12650 fixed only the snap variant. **Both** blockers must be clear before the next develop→main promote deploys; filing separately.

urgent: unblocks promote #12051 money-fix deploy

[cloud-security]