### PR TITLE
ci: retarget high-frequency metadata jobs to idle self-hosted fleet

### DIFF
--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -47,7 +47,7 @@ env:
 jobs:
   changes:
     name: Classify changed paths
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     outputs:
       dev_smoke: ${{ steps.filter.outputs.dev_smoke }}
     steps:

--- a/.github/workflows/docker-ci-smoke.yml
+++ b/.github/workflows/docker-ci-smoke.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   changes:
     name: Classify changed paths
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     outputs:
       docker: ${{ steps.filter.outputs.docker }}
     steps:

--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   changes:
     name: Classify changed paths
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     outputs:
       ios: ${{ steps.filter.outputs.ios }}
       android: ${{ steps.filter.outputs.android }}

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   changes:
     name: Classify changed paths
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     outputs:
       run_scenario_pr: ${{ steps.filter.outputs.run_scenario_pr }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ permissions:
 jobs:
   changes:
     name: Classify changed paths
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     outputs:
       server: ${{ steps.filter.outputs.server }}
       client: ${{ steps.filter.outputs.client }}

--- a/.github/workflows/windows-desktop-preload-smoke.yml
+++ b/.github/workflows/windows-desktop-preload-smoke.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   changes:
     name: Classify changed paths
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     outputs:
       desktop_preload: ${{ steps.filter.outputs.desktop_preload }}
     steps:

--- a/.github/workflows/windows-dev-smoke.yml
+++ b/.github/workflows/windows-dev-smoke.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   changes:
     name: Classify changed paths
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, hetzner-robot]
     outputs:
       windows_dev: ${{ steps.filter.outputs.windows_dev }}
     steps:


### PR DESCRIPTION
## What

Retarget the highest-frequency, cheapest CI job in the repo — the **"Classify changed paths"** path-gate job — from GitHub-hosted `ubuntu-24.04` onto the mostly-idle `[self-hosted, hetzner-robot]` fleet, across 7 workflows. One line changed per job; nothing else touched.

## Why — queue-saturation diagnosis

The self-hosted fleet is healthy and mostly idle while GitHub-hosted jobs queue:

- **Fleet:** `gh api repos/elizaos/eliza/actions/runners` → 26 online, 0 offline, ~4 busy → **~22 hetzner-robot runners idle**. Labels: `[self-hosted, Linux, X64, hetzner-robot]`.
- **Every queued job is GitHub-hosted:** inspecting the oldest queued runs, all had `labels=[ubuntu-24.04]`, `runner=none` (unassigned, waiting on GH-hosted concurrency — not on hetzner).
- **Queue is a rolling FIFO draining at ~2–3 min pickup**, not a wedge — but that latency is paid by *everyone* on ~400 pushes/day fanned across 153 workflow files. GitHub Actions had no incident.

Root cause is **GH-hosted demand fan-out**, not a broken fleet. The fastest no-admin lever is to move cheap, high-frequency jobs onto the idle self-hosted capacity. This PR does exactly that for the single most-run job class.

This **complements the demand-reduction thread**: the merge-queue `ci-ok` aggregate (#12718, now merged) and the CI dedupe work (#12338) reduce *how many* jobs run; this PR reduces *where the cheapest ones run* so the GH-hosted pool drains faster in the meantime.

## Selection criteria (all must hold)

1. **High frequency** — runs on every PR/push (top-of-workflow path classifier).
2. **Cheap + short** — `< 1 min`, no build matrix.
3. **Safe on self-hosted** — no untrusted fork code with secret exposure.
4. **No GH-hosted-only assumptions** — no apt/sudo/docker/preinstalled-toolchain reliance.
5. **Concurrency-safe** — no global installs, no port binding, no clean-machine assumption.

## Retargeted jobs (7)

All are the identical `changes:` / "Classify changed paths" job: `actions/checkout` + `node packages/scripts/ci-path-gate.mjs` (test.yml also runs two node self-test scripts). Pure Node, no install steps.

| Workflow | Trigger | What the job executes | Secrets in job env? | Why safe on self-hosted |
|---|---|---|---|---|
| `test.yml` | `pull_request` / `push` | checkout + `node ci-path-gate.mjs` (+ node self-tests) | No (top env is secret-free by design) | Repo-controlled node classifier; no fork secrets; node present on fleet |
| `scenario-pr.yml` | `pull_request` / `push` | checkout + `node ci-path-gate.mjs` | No (provider keys set to `""`) | same |
| `dev-smoke.yml` | `pull_request` / `push` | checkout + `node ci-path-gate.mjs` | Workflow-level keys inherited, but `pull_request` (not `_target`) → no secrets to forks; runs repo code only | same as GH-hosted today |
| `docker-ci-smoke.yml` | `pull_request` / `push` | checkout + `node ci-path-gate.mjs` | No | same |
| `mobile-build-smoke.yml` | `pull_request` | checkout + `node ci-path-gate.mjs` | No | same |
| `windows-dev-smoke.yml` | `pull_request` / schedule | checkout + `node ci-path-gate.mjs` | No | same |
| `windows-desktop-preload-smoke.yml` | `pull_request` | checkout + `node ci-path-gate.mjs` | No | same |

Only the classifier job moves — the downstream heavy jobs (dev-smoke, docker smoke, windows/macos builds) stay on their existing runners.

### Security notes
- **Zero `pull_request_target`** across all 7 workflows (verified) → no fork-secret exposure vector on the classifier.
- **Fork ratio ~0**: last 30 PRs (`gh pr list --json headRepositoryOwner`) were all same-repo `elizaOS/eliza` branches. Fork PRs are rare, and on `pull_request` they get a read-only token + no secrets regardless.
- **Fleet capability confirmed** from existing self-hosted workflows: `actions-zombie-janitor.yml` runs on `[self-hosted, Linux, X64, hetzner-robot]` and relies on `actions/github-script` (Node); `cloud-cf-deploy.yml` runs full bun/wrangler builds there. Node is known-good. These jobs need nothing more than checkout + node.

## Disqualified candidates (kept on GH-hosted)

| Candidate | Reason |
|---|---|
| `pr.yaml` (PR Title Check) | Uses `jq` + `gh pr comment` in shell steps. `gh` CLI is a GH-hosted preinstalled tool, not guaranteed on the fleet; failure-path reporting could break. No creative rewrite → disqualified. |
| `auto-label.yml` | `pull_request_target` with `pull-requests: write` / `issues: write` + `GITHUB_TOKEN`. Even though it doesn't check out PR head, a write-token `_target` job is exactly the class to keep off self-hosted. |
| `app-aesthetic-audit.yml` / `aesthetic-audit` | Heavy: `bun install` + `bunx playwright install --with-deps chromium` (needs apt), 45-min timeout. Not cheap, not toolchain-safe. |
| `feed-env-audit.yml` | Full workspace `bun install` — heavier, leaves store state on shared box. Held for conservatism. |
| Downstream jobs in the 7 workflows above | Real build/test/e2e matrices — out of scope, stay on GH-hosted / windows / macos. |

## Rollback

Revert one `runs-on` line per job (`[self-hosted, hetzner-robot]` → `ubuntu-24.04`). Each job is independent — partial rollback is trivial.

## Collision check
- `gh pr list --search "runner self-hosted ci"` and keyword searches (`self-hosted`, `hetzner`, `retarget runs-on`) → **no open PR** already retargeting jobs.
- **#12157** (cloud eliza-code runner cutover) is about the *coding sub-agent* runner image (opencode → eliza-code), **not** the general `hetzner-robot` Actions fleet — the fleet this PR targets is not being decommissioned.
- **#12338** (CI dedupe) may later consolidate classifier jobs; this PR is orthogonal (runner target only) and is a one-line-per-job revert if they collide.

— [sol-orch]
