### PR TITLE
docs(#12231): prose headers + churn cleanup — core root + types load-bearing modules (B01 part 2)

### DIFF
--- a/packages/core/src/access-context.test.ts
+++ b/packages/core/src/access-context.test.ts
@@ -1,16 +1,15 @@
+/**
+ * Unit tests for buildAccessContext against a deterministic fake runtime (no live
+ * model or DB): it must resolve the requester's identity, world, and role by
+ * running role resolution against the SAME world resolveWorldForMessage picks, so
+ * worldId, role, and isOwner always agree on one world. Outside a world (no
+ * resolvable worldId) role/owner are undefined — callers must read that as "no
+ * elevated access", never "unrestricted".
+ */
 import { describe, expect, it } from "vitest";
 import { buildAccessContext } from "./access-context";
 import { createUniqueUuid } from "./entities";
 import type { IAgentRuntime, Memory, UUID } from "./types";
-
-/**
- * buildAccessContext resolves the requester's identity, world, and role from a
- * message by running role resolution against the SAME world that
- * resolveWorldForMessage picks. worldId, role, and isOwner therefore always
- * agree on one world. Outside a world (no resolvable worldId) role/owner are
- * undefined — callers must read that as "no elevated access", never
- * "unrestricted".
- */
 
 const AGENT = "00000000-0000-0000-0000-0000000000a9" as UUID;
 const USER = "00000000-0000-0000-0000-0000000000u5" as UUID;

--- a/packages/core/src/access-context.ts
+++ b/packages/core/src/access-context.ts
@@ -1,3 +1,10 @@
+/**
+ * Assembles the {@link AccessContext} DTO — requester entity, world scope, role,
+ * and owner flag — that authorization checks read for a message-driven request.
+ * A thin composition over `roles.ts`: it runs role resolution against the single
+ * world `resolveWorldForMessage` selects, so `worldId`, `role`, and `isOwner`
+ * are always derived together and can never disagree on which world they scope.
+ */
 import {
 	getLiveEntityMetadataFromMessage,
 	resolveEntityRole,

--- a/packages/core/src/action-docs.ts
+++ b/packages/core/src/action-docs.ts
@@ -1,3 +1,14 @@
+/**
+ * Merges canonical, spec-generated capability docs (`generated/action-docs.ts`)
+ * into runtime `Action` / `Provider` definitions so the prompt-facing docs are
+ * complete for every registered capability. The merge is additive and
+ * conservative: it never overwrites an existing description, similes, or
+ * parameters, and it always fills `descriptionCompressed` (and the
+ * parameter-level compressed descriptions) via `compressPromptDescription` —
+ * matching Python's `compress_prompt_description` — so prompt compression is on
+ * even for plugins that ship no canonical spec row.
+ */
+
 import { allActionDocs, allProviderDocs } from "./generated/action-docs.ts";
 import type {
 	Action,

--- a/packages/core/src/action-names.test.ts
+++ b/packages/core/src/action-names.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Deterministic test pinning the reserved action-name constants and the
+ * canonical ordering of `NON_EXECUTABLE_RESPONSE_ACTION_NAMES`.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
 	IGNORE_ACTION_NAME,

--- a/packages/core/src/action-names.ts
+++ b/packages/core/src/action-names.ts
@@ -1,3 +1,9 @@
+/**
+ * Reserved action-name constants and the canonically ordered
+ * `NON_EXECUTABLE_RESPONSE_ACTION_NAMES` set — the response actions
+ * (REPLY / NONE / IGNORE) that carry no side-effecting handler.
+ */
+
 export const REPLY_ACTION_NAME = "REPLY";
 export const NONE_ACTION_NAME = "NONE";
 export const IGNORE_ACTION_NAME = "IGNORE";

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -1,3 +1,19 @@
+/**
+ * Formats the agent's registered actions into prompt text and parses the action
+ * calls the model returns back into validated parameters. On the render side it
+ * composes deterministic (seeded-RNG) action examples, compressed
+ * name/description/parameter listings, and canonical JSON call examples, so a
+ * given action set always yields the same prompt. On the parse side it turns the
+ * model's `{ actions, params }` payload into a per-action
+ * `Map<string, ActionParameters>`, coercing loose scalars/arrays and validating
+ * each value against the action's parameter schema (type, enum, pattern,
+ * min/max).
+ *
+ * Sits between the action catalog and the message loop's model call, and also
+ * acts as the barrel re-exporting the action sub-modules (extractor pipeline,
+ * JSON model output, subaction promotion/dispatch, recent-context,
+ * resolve-action-args).
+ */
 import { testSchemaPattern } from "./actions/validate-tool-args.ts";
 import { allActionDocs } from "./generated/action-docs.ts";
 import type {

--- a/packages/core/src/activity-plaintext.ts
+++ b/packages/core/src/activity-plaintext.ts
@@ -1,3 +1,17 @@
+/**
+ * Renders agent/PTY activity events and trajectory records into short,
+ * human-readable plaintext summaries for surfaces that show an activity feed.
+ * Pure formatting over loosely-typed event payloads — every field access is
+ * guarded (`isRecord` / `readString` / `readFiniteNumber`), so malformed input
+ * yields `null` rather than throwing; there is no runtime or IO dependency.
+ *
+ * `activityEventToPlaintext` dispatches on the event's `stream` for agent
+ * events (assistant, lifecycle, action, tool, evaluator, provider, message,
+ * memory, error, notification) and falls back to PTY task events.
+ * `trajectoryToPlaintext` summarizes a trajectory summary/detail record with
+ * its LLM calls, provider accesses, and events.
+ */
+
 import type {
 	TrajectoryDetailRecord,
 	TrajectoryLlmCallRecord,

--- a/packages/core/src/ambient-context.test.ts
+++ b/packages/core/src/ambient-context.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit coverage for the ambient-context singleton: `getAmbientSingleton` builds
+ * a value once and caches it on a shared `globalThis` slot keyed by symbol so
+ * duplicate module copies agree, `setAmbientSingleton` overrides it everywhere,
+ * and `peekAmbientSingleton` reads without creating. Pure deterministic test —
+ * no model or database.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/packages/core/src/app-registry.ts
+++ b/packages/core/src/app-registry.ts
@@ -1,3 +1,9 @@
+/**
+ * Symbol-keyed global registry of curated Eliza app definitions (slug, canonical
+ * name, aliases). Shared through the ambient singleton so core, shared,
+ * app-core, and plugin consumers read and extend the same list regardless of
+ * which copy of the package they import.
+ */
 import { getAmbientSingleton } from "./ambient-context";
 
 export interface ElizaCuratedAppDefinition {

--- a/packages/core/src/app-route-plugin-registry.ts
+++ b/packages/core/src/app-route-plugin-registry.ts
@@ -1,3 +1,14 @@
+/**
+ * Registry and drain logic for app-route plugins — plugins that expose HTTP
+ * routes but register a loader here (keyed by id) instead of via `Plugin.routes`
+ * so a bundler cannot tree-shake them away. {@link drainAppRoutePluginLoaders}
+ * pulls the loaded plugins' routes onto a runtime's route table idempotently
+ * (keyed by `${type}:${path}`), tolerating both the `@elizaos/agent` and
+ * `@elizaos/app-core` boots draining against the same table. Also owns the
+ * optional-unavailable error contract (matched by `Error.name`, not
+ * `instanceof`) so an intentionally-absent optional plugin is a graceful skip
+ * even across duplicate `@elizaos/core` bundles.
+ */
 import { getAmbientSingleton } from "./ambient-context";
 import { logger } from "./logger";
 import {

--- a/packages/core/src/boot-env.test.ts
+++ b/packages/core/src/boot-env.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers boot-env's env-alias mirroring (branded ↔ ELIZA_ keys with stale-target
+ * clearing) and the write-once boot-config store: a late window mirror cannot
+ * replace an established store, and the singleton is held through the
+ * ambient-context accessor. Deterministic; mutates and restores process.env and
+ * globalThis around each case.
+ */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { peekAmbientSingleton } from "./ambient-context";
 import {

--- a/packages/core/src/boot-env.ts
+++ b/packages/core/src/boot-env.ts
@@ -1,3 +1,16 @@
+/**
+ * App boot configuration plus env-alias mirroring, shared across every bundled
+ * copy of `@elizaos/core`. The boot-config store is a write-once singleton kept
+ * on the shared global slot through core's ambient-context accessor so
+ * core/shared/ui bundles observe one instance; an established store always wins
+ * over the pre-boot `__ELIZAOS_APP_BOOT_CONFIG__` window mirror that the HTML
+ * bootstrap / Electrobun preload seeds before any bundle loads.
+ *
+ * syncBrandEnvToEliza / syncElizaEnvToBrand copy values between branded and
+ * ELIZA_ env-key aliases and remember which targets they wrote, so a source key
+ * that disappears clears only its own mirrored target and never a value set by
+ * hand. The sync* wrappers pull the alias list from the boot config.
+ */
 import {
 	peekAmbientSingleton,
 	setAmbientSingleton,

--- a/packages/core/src/bundle-safety.test.ts
+++ b/packages/core/src/bundle-safety.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers anchorBundleSafety — stashing values under the exact
+ * `__bundle_safety_<name>__` global key, with a distinct key per name — plus the
+ * repo invariant that every feature barrel routes through the shared helper
+ * instead of hand-rolling the `globalThis` assignment. Deterministic; the
+ * invariant check walks the real `features/` tree on disk.
+ */
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/core/src/character.test.ts
+++ b/packages/core/src/character.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers normalizeCharacterInput's document/knowledge merge and asserts
+ * character.ts owns no provider-plugin auto-enable rules (no `buildCharacterPlugins`
+ * export, no hardcoded `@elizaos/plugin-` names). Pure in-process assertions, no
+ * runtime or model.
+ */
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/packages/core/src/character.ts
+++ b/packages/core/src/character.ts
@@ -1,3 +1,16 @@
+/**
+ * Character-config normalization and validation. Turns a loose `CharacterInput`
+ * (the shapes accepted from JSON, the CLI, and callers) into a canonical
+ * `Character`: coerces `bio` to an array, folds legacy `knowledge` entries into
+ * `documents`, normalizes message examples to `MessageExampleGroup[]`, and maps
+ * document entries onto the `DocumentSourceItem` oneof shape. `parseCharacter`
+ * and `validateCharacterConfig` run the result through `validateCharacter`
+ * (schemas/character) and surface issue paths as readable errors.
+ *
+ * Deliberately owns no plugin auto-enable rules — it hardcodes no concrete
+ * plugin package names (enforced by character.test.ts); provider/plugin
+ * resolution lives elsewhere.
+ */
 import { validateCharacter } from "./schemas/character";
 import type {
 	Character,

--- a/packages/core/src/cloud-auth-service.test.ts
+++ b/packages/core/src/cloud-auth-service.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers `getCloudAuthService` resolving (and rejecting) a cloud-auth service
+ * through a hand-built runtime whose `getService` returns an in-memory stub — no
+ * live runtime or plugin, exercising only the duck-typing guard.
+ */
 import { describe, expect, test } from "vitest";
 import {
 	CLOUD_AUTH_SERVICE_TYPE,

--- a/packages/core/src/cloud-auth-service.ts
+++ b/packages/core/src/cloud-auth-service.ts
@@ -1,3 +1,11 @@
+/**
+ * Contract and safe accessor for the cloud-auth service that a plugin registers
+ * in the runtime's `ServiceType.CLOUD_AUTH` slot. `getCloudAuthService` resolves
+ * that slot and duck-types the result, so core-side callers can read the current
+ * API key / user / organization without importing the plugin that provides it.
+ * A slot holding a service that does not implement the interface resolves to
+ * null rather than throwing.
+ */
 import type { IAgentRuntime } from "./types/runtime";
 import type { Service } from "./types/service";
 import { ServiceType } from "./types/service";

--- a/packages/core/src/cloud-routing.test.ts
+++ b/packages/core/src/cloud-routing.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers `isCloudConnected` and `resolveCloudRoute` — the gate and resolver
+ * behind the three inference deployment modes documented below — over a
+ * synthetic `getSetting` map rather than a live runtime.
+ */
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/core/src/cloud-routing.ts
+++ b/packages/core/src/cloud-routing.ts
@@ -1,6 +1,10 @@
-// Single-sourced from @elizaos/cloud-routing (#12092 item 28). Core previously
-// duplicated this module; the copies drifted. `RuntimeSettings` is re-exported
-// under core's historical `CloudRuntimeSettings` name to preserve the surface.
+/**
+ * Re-exports the cloud inference routing surface — route resolution plus the
+ * cloud-connection gate — from `@elizaos/cloud-routing`, keeping core a thin
+ * pass-through over a single source of truth. `RuntimeSettings` is re-exported
+ * under core's historical `CloudRuntimeSettings` name to preserve the public
+ * surface. (#12092 item 28)
+ */
 export type {
 	CloudRoute,
 	CloudRouteSource,

--- a/packages/core/src/connectors.ts
+++ b/packages/core/src/connectors.ts
@@ -1,3 +1,15 @@
+/**
+ * Connector source registry: canonicalizes and classifies the `source` tag
+ * carried on inbound messages (discord, telegram, farcaster, ...). Owners
+ * register a canonical source with aliases and metadata (`sourceKind`
+ * active/passive, `isPassive`); lookups normalize a raw source to its canonical
+ * form, expand a source filter across all known aliases, and report whether a
+ * source is passive.
+ *
+ * State is process-global and owner-scoped: registrations accumulate per owner
+ * and merge on read, so plugins can contribute aliases without clobbering each
+ * other, and an owner's contributions can be unregistered wholesale.
+ */
 export type ConnectorSourceKind = "passive" | "active";
 
 export interface ConnectorSourceMetadata {

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -1,3 +1,15 @@
+/**
+ * `DatabaseAdapter` — the abstract base every concrete persistence adapter
+ * (plugin-sql's Drizzle adapters, `InMemoryDatabaseAdapter`, …) extends to
+ * satisfy the {@link IDatabaseAdapter} contract declared in `types/database.ts`.
+ * It carries no storage logic: it re-declares the batch-first CRUD surface
+ * (arrays in, arrays out) as `abstract` methods, so a missing override is a
+ * compile-time error, and centralizes the JSDoc adapter authors see in their
+ * IDE. Optional domains an adapter need not support (connector-account and
+ * OAuth-flow storage) default here to throwing a clear adapter-level error
+ * rather than silently succeeding.
+ */
+
 import type {
 	AccessContext,
 	Agent,
@@ -75,11 +87,6 @@ export abstract class DatabaseAdapter<DB extends object = object>
 	abstract initialize(
 		config?: Record<string, string | number | boolean | null>,
 	): Promise<void>;
-
-	/**
-	 * Initialize the database adapter.
-	 * @returns A Promise that resolves when initialization is complete.
-	 */
 
 	/**
 	 * Run plugin schema migrations for all registered plugins

--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -1,3 +1,19 @@
+/**
+ * Entity resolution, identity formatting, and component-visibility trust for the
+ * agent runtime. `findEntityByName` combines a TEXT_SMALL model call with
+ * recent-interaction and relationship signals to map a natural-language
+ * reference in a message ("me", a name, an `@handle`) onto a known `Entity`;
+ * `getEntityDetails` and `formatEntities` merge and render a room's entities for
+ * prompt context; `createUniqueUuid` derives a stable per-agent UUID from a base
+ * id.
+ *
+ * `resolveTrustedComponentSourceIds` gates which entity components are visible:
+ * a component's data is trusted only when its source is the message sender, the
+ * agent itself, or a source whose RESOLVED role (see roles.ts) is
+ * ADMIN-or-higher — never a raw stored role grant. Sits on the runtime boundary
+ * (getRoom / getWorld / getEntitiesForRoom / getRelationships / useModel) and
+ * imports roles.ts lazily to avoid a cycle with createUniqueUuid.
+ */
 import { logger } from "./logger";
 // Type-only (erased at runtime, so no cycle with roles.ts, which imports
 // createUniqueUuid from this module). The role-resolution values are pulled via a
@@ -23,15 +39,15 @@ type EntityDetailsRecord = Pick<Entity, "id" | "names"> & {
 };
 
 /**
- * #12087 Item 16: component-visibility filtering used to trust the raw
- * `world.metadata.roles[sourceEntityId]` literal (OWNER/ADMIN → visible). That
- * bypassed resolveEntityRole's demotion rules — a stored OWNER grant is demoted
- * to GUEST under a configured canonical owner, and connector-admin roles can be
- * revoked — so a stale OWNER grant kept another entity's components trusted.
- * Batch-resolve each source entity's effective role once (resolveEntityRole is
- * async) before the synchronous component filter, and trust only resolved
- * ADMIN-or-higher. Returns the set of source entity ids whose components are
- * trusted for this world.
+ * Component-visibility filtering decides trust from each source entity's
+ * RESOLVED effective role, not the raw `world.metadata.roles[sourceEntityId]`
+ * literal. `resolveEntityRole` demotes a stored OWNER grant to GUEST under a
+ * configured canonical owner and honors connector-admin revocation, so keying
+ * off the literal would keep a stale OWNER grant trusted and leak another
+ * entity's components. Because `resolveEntityRole` is async, each source
+ * entity's role is batch-resolved once before the synchronous component filter;
+ * only resolved ADMIN-or-higher is trusted. Returns the set of source entity ids
+ * whose components are trusted for this world. (#12087 Item 16)
  */
 export async function resolveTrustedComponentSourceIds(
 	runtime: IAgentRuntime,

--- a/packages/core/src/identity-clusters.ts
+++ b/packages/core/src/identity-clusters.ts
@@ -1,3 +1,10 @@
+/**
+ * Optional-capability bridge to the "relationships" service for identity-cluster
+ * resolution: `getRelatedEntityIds` expands an entity id to its cluster members
+ * and `resolvePrimaryEntityId` collapses an alias to its canonical primary id.
+ * Degrades to the identity function when the service, or the relevant method, is
+ * absent, so callers can treat clustering as best-effort.
+ */
 import type { IAgentRuntime, Service, UUID } from "./types/index.ts";
 
 type IdentityClusterResolver = Service & {

--- a/packages/core/src/lifeops-passive-connectors.ts
+++ b/packages/core/src/lifeops-passive-connectors.ts
@@ -1,3 +1,9 @@
+/**
+ * Resolves whether LifeOps passive connectors are enabled, reading the
+ * `ELIZA_LIFEOPS_PASSIVE_CONNECTORS` / `LIFEOPS_PASSIVE_CONNECTORS` setting from
+ * a runtime (`getSetting`) first, then the process env. Defaults to enabled;
+ * only an explicit falsey value (`0`/`false`/`off`/`no`/`disabled`) disables it.
+ */
 type SettingsReader = {
 	getSetting?: (key: string) => unknown;
 };

--- a/packages/core/src/memory.test.ts
+++ b/packages/core/src/memory.test.ts
@@ -1,3 +1,13 @@
+/**
+ * Exercises the {@link Memory} helpers in ./memory — `createMessageMemory`
+ * scoping, the per-`MemoryType` metadata/memory guards, and `getMemoryText` —
+ * against hand-built records with no live model or database (pure vitest). The
+ * guards drive how each record is stored, embedded, and retrieved, so they must
+ * discriminate strictly on the `MemoryType` tag (a document fragment must never
+ * be mistaken for a top-level document) and `isCustomMetadata` must stay the
+ * catch-all for any type outside the four known kinds.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
 	createMessageMemory,
@@ -16,13 +26,6 @@ import {
 	MemoryType,
 	type UUID,
 } from "./types";
-
-/**
- * Memory metadata type guards drive how each record is stored, embedded, and
- * retrieved. They must discriminate strictly on the MemoryType tag (a document
- * fragment must never be mistaken for a top-level document), and isCustomMetadata
- * must be the catch-all for any type outside the four known kinds.
- */
 
 const id = (s: string) => s as UUID;
 

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -1,3 +1,13 @@
+/**
+ * Factory and type guards for {@link Memory} records: `createMessageMemory`
+ * stamps a MESSAGE-metadata memory (scope derived from whether an `agentId` is
+ * present), and the `is*Metadata` / `is*Memory` guards discriminate a record's
+ * kind by its `MemoryType` tag so storage, embedding, and retrieval can branch
+ * on it. `isCustomMetadata` is the catch-all for any type outside the four known
+ * kinds. The types come from `./types` (`types/memory.ts`); this module holds
+ * only the runtime helpers over them.
+ */
+
 import {
 	type Content,
 	type CustomMetadata,

--- a/packages/core/src/mobile-device-bridge-service.ts
+++ b/packages/core/src/mobile-device-bridge-service.ts
@@ -1,3 +1,12 @@
+/**
+ * Service contract for the mobile-device inference bridge — the host that
+ * relays on-device GPU inference (llama.cpp over Metal / Vulkan / GPU-delegate)
+ * to a paired phone. Defines the status DTO and the abstract
+ * {@link MobileDeviceBridgeService} that a mobile-host plugin subclasses and
+ * registers through the normal service registry, keyed by
+ * {@link ServiceType.MOBILE_DEVICE_BRIDGE}; consumers resolve it via
+ * `runtime.getService`.
+ */
 import { Service, ServiceType } from "./types/service";
 
 /**

--- a/packages/core/src/model-gateway.test.ts
+++ b/packages/core/src/model-gateway.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers the model-gateway resolution layer — `resolveModelGateway` /
+ * `applyModelGateway`, the canonical `ELIZA_MODEL_GATEWAY_*` env var names, the
+ * credential scrubber, and strict fail-closed mode — over a synthetic getSetting
+ * record, so no process.env or live provider is touched.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	applyModelGateway,

--- a/packages/core/src/name-tokens.test.ts
+++ b/packages/core/src/name-tokens.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Deterministic tests for the canonical `{{name}}` / `{{nameN}}` token helpers
+ * (`name-tokens.ts`) and the `getRecentMessagesData` state accessor. Pure
+ * string/object functions — no model or database in the loop.
+ */
+
 import { describe, expect, it } from "vitest";
 import { replaceIndexedNameTokens, replaceNameTokens } from "./name-tokens";
 import { getRecentMessagesData } from "./recent-messages-state";

--- a/packages/core/src/optimization-root-dir.ts
+++ b/packages/core/src/optimization-root-dir.ts
@@ -1,3 +1,7 @@
+/**
+ * Single source of truth for the default optimization artifacts directory,
+ * shared so the runtime and plugins resolve the same location.
+ */
 import { join } from "node:path";
 import { resolveStateDir } from "./utils/state-dir";
 

--- a/packages/core/src/plugin-lifecycle.context-role-gate.test.ts
+++ b/packages/core/src/plugin-lifecycle.context-role-gate.test.ts
@@ -1,3 +1,13 @@
+/**
+ * Regression test (#12089): an action's effective role gate must resolve
+ * plugin-registered contexts through the PER-RUNTIME context registry, so a
+ * context registered at runtime via `runtime.contexts.register(...)` with
+ * `roleGate.minRole = OWNER` participates in the gate. Deriving from a
+ * module-level snapshot of only the first-party defaults would leave the plugin
+ * context invisible and collapse the effective gate to USER — a permission
+ * bypass. Deterministic: a hand-built lifecycle runtime driven through the
+ * planned-tool-call gate, no live model or database.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { installRuntimePluginLifecycle } from "./plugin-lifecycle";
 import { ContextRegistry } from "./runtime/context-registry";
@@ -6,15 +16,6 @@ import {
 	executePlannedToolCall,
 } from "./runtime/execute-planned-tool-call";
 import type { Action, IAgentRuntime, Memory, UUID } from "./types";
-
-/**
- * FIX 2 (#12089): an action's effective roleGate must be derived through the
- * PER-RUNTIME context registry so a context registered at runtime by a plugin
- * (via `runtime.contexts.register(...)`) with `roleGate.minRole = OWNER`
- * participates in the gate. Previously the derivation read a module-level
- * snapshot of only the first-party defaults, so a plugin context was invisible
- * and the effective gate silently collapsed to USER — a permission bypass.
- */
 
 const noop = () => undefined;
 

--- a/packages/core/src/plugin-lifecycle.ts
+++ b/packages/core/src/plugin-lifecycle.ts
@@ -1,3 +1,29 @@
+/**
+ * Installs per-plugin ownership tracking and hot lifecycle (unload / reload /
+ * reconfigure) onto an {@link IAgentRuntime}. {@link installRuntimePluginLifecycle}
+ * wraps the runtime's `register*` methods so that, during a `registerPlugin`
+ * call, every action, provider, evaluator, route, event, model, service,
+ * shortcut, send-handler, and database adapter the plugin contributes is
+ * attributed to it — captured through async-context storage
+ * (`AsyncLocalStorage` on Node, a stack fallback elsewhere) rather than by name.
+ * The resulting {@link PluginOwnership} record is the reverse index that makes
+ * teardown possible.
+ *
+ * It then adds `unloadPlugin`, `reloadPlugin`, `applyPluginConfig`,
+ * `getPluginOwnership`, and `getAllPluginOwnership` to the runtime. Teardown
+ * removes exactly the tracked references by identity, stops owned service
+ * instances and classes, and runs each plugin's optional `dispose` hook; a
+ * failed `registerPlugin` rolls its partial registration back through the same
+ * path.
+ *
+ * Invariants: install is idempotent (guarded by
+ * `__elizaPluginLifecycleInstalled`); a plugin that registers a database adapter
+ * cannot be hot-unloaded and forces a full runtime reload; and an action's
+ * effective role gate is derived through the PER-RUNTIME context registry so
+ * contexts registered at runtime by plugins participate in access control (a
+ * module-level snapshot would silently collapse a stricter gate to USER — a
+ * permission bypass, #12089).
+ */
 import { unregisterConnectorSourceMetadataOwner } from "./connectors";
 import { roleRank } from "./runtime/context-gates";
 import type { ContextRegistry } from "./runtime/context-registry";
@@ -285,11 +311,11 @@ function applyEffectiveActionContexts(
 /**
  * Derive an action's effective role gate from the role gates declared by the
  * contexts it is tagged with. Resolution goes through the PER-RUNTIME context
- * registry so contexts registered at runtime by plugins
- * via `runtime.contexts.register(...)` participate — not just the first-party
- * defaults. (Previously this read a module-level snapshot of the default
- * contexts, so a plugin-registered context declaring `minRole: OWNER` was
- * invisible and the gate silently collapsed to USER — a permission bypass.)
+ * registry so contexts registered at runtime by plugins via
+ * `runtime.contexts.register(...)` participate — not just the first-party
+ * defaults. Reading a module-level snapshot of only the defaults would leave a
+ * plugin-registered context declaring `minRole: OWNER` invisible and collapse
+ * the gate to USER — a permission bypass (#12089).
  */
 function roleGateForActionContexts(
 	contexts: readonly AgentContext[] | undefined,

--- a/packages/core/src/plugin.test.ts
+++ b/packages/core/src/plugin.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the plugin loader/resolver surface ({@link loadPlugin},
+ * {@link resolvePlugins}): object plugins pass through, string references route
+ * through an injected {@link PluginResolver} and fail closed (skip, never
+ * install) when none is present, and the supply-chain entry points stay absent.
+ * Deterministic — stub plugin objects, no live resolver.
+ */
 import { describe, expect, it, vi } from "vitest";
 import * as pluginModule from "./plugin";
 import { loadPlugin, type PluginResolver, resolvePlugins } from "./plugin";
@@ -10,8 +17,8 @@ const makePlugin = (name: string): Plugin => ({
 
 describe("core plugin loader — no runtime install / no name imports", () => {
 	it("exposes no auto-install or module-import entry points", () => {
-		// The supply-chain surface (bun add / variable-specifier import) is gone:
-		// core no longer exports tryInstallPlugin or loadAndPreparePlugin.
+		// Core exposes no supply-chain surface (bun add / variable-specifier
+		// import): tryInstallPlugin and loadAndPreparePlugin are not exported.
 		expect(
 			(pluginModule as Record<string, unknown>).tryInstallPlugin,
 		).toBeUndefined();

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -1,3 +1,20 @@
+/**
+ * Plugin load, validation, and dependency resolution for the runtime.
+ *
+ * Turns the `(string | Plugin)[]` list from character config into an ordered,
+ * validated `Plugin[]`: {@link validatePlugin}/{@link isValidPluginShape} enforce
+ * the shape, {@link resolvePluginDependencies} topologically sorts by
+ * `dependencies` (plus `testDependencies` in test mode) with cycle detection, and
+ * {@link normalizePluginName} reconciles scoped (`@elizaos/plugin-x`) and short
+ * (`x`) name forms so aliases dedupe to one entry.
+ *
+ * Core deliberately never imports plugin modules by name and never installs
+ * packages — both are supply-chain concerns owned by the host (the `elizaos` CLI
+ * / `@elizaos/agent`). A {@link PluginResolver} is injected to turn string
+ * references into `Plugin` objects; with no resolver, string references are
+ * skipped (fail closed), never dynamically imported. Browser/edge builds have no
+ * loader and drop string references outright.
+ */
 import { logger } from "./logger";
 
 import type { Plugin } from "./types";

--- a/packages/core/src/recent-messages-state.ts
+++ b/packages/core/src/recent-messages-state.ts
@@ -1,3 +1,5 @@
+/** Canonical reader for the memory array `recentMessagesProvider` publishes on runtime state; `@elizaos/shared` re-exports it so every caller shares one accessor rather than re-deriving the provider path. */
+
 import type { Memory, State } from "./types";
 
 /**

--- a/packages/core/src/roles.test.ts
+++ b/packages/core/src/roles.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Unit tests for the role + permission helpers, driven as pure functions over
+ * hand-built world metadata and a deterministic fake runtime (no live model or
+ * DB). canModifyRole is the privilege-escalation gate: OWNER may change anyone,
+ * ADMIN may only manage strictly-lower ranks and may never grant OWNER, and
+ * USER/GUEST may change no one. normalizeRole must fold unknown input to GUEST
+ * (never silently grant a higher role), and the connector-admin whitelist
+ * matches an entity only on its stable platform id.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	CANONICAL_ROLE_RANK,
@@ -18,14 +27,6 @@ import {
 	satisfiesRoleGate,
 } from "./runtime/context-gates.ts";
 import type { IAgentRuntime, Memory } from "./types";
-
-/**
- * Role + permission helpers. canModifyRole is the privilege-escalation gate:
- * OWNER may change anyone, ADMIN may only manage strictly-lower ranks and may
- * never grant OWNER, and USER/GUEST may change no one. normalizeRole must fold
- * unknown input to GUEST (never silently grant a higher role), and the
- * connector-admin whitelist matches an entity only on its stable platform id.
- */
 
 describe("normalizeRole", () => {
 	it("recognizes the three named roles, else GUEST", () => {

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -1,3 +1,25 @@
+/**
+ * The agent's role/permission authorization system: the OWNER > ADMIN > USER >
+ * GUEST tier vocabulary, the canonical rank table every gate compares against,
+ * and the resolution that turns a sender + world into an effective role. A role
+ * is merged here from four sources — an explicit grant stored on world metadata
+ * (`roles`/`roleSources`), the configured or world-recorded canonical owner, a
+ * connector-admin whitelist match on a stable platform id, and confirmed
+ * identity links that let a linked entity inherit the owner/grant. `canModifyRole`
+ * is the privilege-escalation gate (OWNER may change anyone; ADMIN only
+ * strictly-lower ranks and never grants OWNER); `hasRoleAccess` is the read-time
+ * gate callers use to admit or deny an action.
+ *
+ * Consumed by access-context.ts, the runtime context-gates, and plugin-manager
+ * security wrappers. Load-bearing invariants an editor must preserve: rank lives
+ * only in CANONICAL_ROLE_RANK, shared with runtime/context-gates.ts so the two
+ * never drift (#9948); MEMBER is an alias of USER, not a demotion to GUEST, so
+ * both resolution paths agree (#12087 Item 6); resolution trusts ONLY connector
+ * identity stamped into the Memory, never client-supplied content.metadata; and
+ * every access check fails CLOSED — an unknown role ranks below GUEST and an
+ * unresolvable sender is treated as USER, never a higher tier. Owner and role
+ * grants are recorded explicitly with their source so they stay auditable.
+ */
 import { createUniqueUuid } from "./entities";
 import { logger } from "./logger";
 import type { IAgentRuntime, Memory, UUID, World } from "./types";
@@ -14,10 +36,9 @@ export type RoleGrantSource = "owner" | "manual" | "connector_admin";
  * disagreed: the `NONE` floor and the `MEMBER` alias (`environment.ts` `Role`)
  * plus `USER`/`GUEST` (`RoleName`). `USER` and `MEMBER` are the same tier.
  *
- * Previously `roles.ts` and `runtime/context-gates.ts` each defined their own
- * rank literal with different absolute values — two tables that could silently
- * drift apart was the authz hazard called out in #9948. Both now derive from
- * this constant.
+ * `roles.ts` and `runtime/context-gates.ts` both derive their ranking from this
+ * constant rather than each keeping a private rank literal — two rank tables
+ * that could silently drift apart is the authz hazard #9948 calls out.
  */
 export const CANONICAL_ROLE_RANK = {
 	NONE: 0,

--- a/packages/core/src/runtime-env.ts
+++ b/packages/core/src/runtime-env.ts
@@ -1,3 +1,16 @@
+/**
+ * Resolves the HTTP API server's environment configuration from a
+ * `RuntimeEnvRecord` (defaulting to `process.env`): bind host, auth token,
+ * allowed origins/hosts, null-origin policy, and the desktop / single-process /
+ * UI port precedence. The API host and boot helpers read through these resolvers
+ * rather than touching `process.env` directly, so one set of precedence and
+ * alias rules (e.g. `ELIZA_API_PORT` then `ELIZA_PORT`) applies everywhere.
+ *
+ * Also classifies a bind host as loopback vs wildcard — the signal for whether
+ * an auth token must be present before binding to a public interface — and
+ * detects mobile (`ELIZA_PLATFORM=android|ios`) embeddings where host
+ * capabilities that shell out are unavailable.
+ */
 import { isTruthyEnvValue } from "./env-utils.js";
 
 const DEFAULT_API_BIND_HOST = "127.0.0.1";

--- a/packages/core/src/runtime-route-context.ts
+++ b/packages/core/src/runtime-route-context.ts
@@ -1,3 +1,11 @@
+/**
+ * Per-runtime "host context" for plugin route handlers: the config load/save,
+ * runtime-restart, and telemetry-span hooks the host process exposes to routes
+ * without those routes importing the host. The context is stashed on the runtime
+ * object under a non-enumerable, `Symbol.for`-keyed holder so it survives across
+ * module instances. `setRuntimeRouteHostContext` returns a restore closure, so a
+ * caller can install a context for the span of a request and roll it back after.
+ */
 export interface RuntimeRouteTelemetrySpan {
 	success: (meta?: Record<string, unknown>) => void;
 	failure: (meta?: Record<string, unknown>) => void;

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1,3 +1,30 @@
+/**
+ * The `AgentRuntime` — the central orchestrator every Eliza agent runs on, and
+ * the concrete `implements IAgentRuntime`. One instance owns a single agent's
+ * whole world: its actions, providers, evaluators, and services; the
+ * model-handler registry and the `useModel` dispatch/routing/fallback layer; the
+ * plugin set and its lifecycle (register / unload / reload / config); memory and
+ * state (database adapter, embeddings, `stateCache`, working memory); and the
+ * message loop that runs provider -> model -> action -> evaluator. Plugins
+ * contribute capabilities; the runtime wires and runs them, and nearly all of
+ * `@elizaos/core` and every plugin ultimately talks to this class.
+ *
+ * The file is ~10k lines — navigate by symbol, never top-to-bottom. Alongside the
+ * class it exports typed boot errors (`NoModelProviderConfiguredError`,
+ * `EmbeddingDimensionProbeError`) that `initialize()` treats specially.
+ *
+ * Invariants to preserve when editing:
+ * - `getSetting()` resolves per-agent config and DELIBERATELY never reads
+ *   `process.env` — in a multi-tenant process that would leak a host secret into
+ *   every agent; hosts fold dotenv into the constructor `settings` map instead.
+ * - Embedding width is pinned to whichever TEXT_EMBEDDING provider answered the
+ *   boot dimension probe; a later embedding from a different provider can emit a
+ *   width the SQL adapter silently drops (#8769). If every provider fails the
+ *   probe, `initialize()` catches `EmbeddingDimensionProbeError` non-fatally and
+ *   disables embedding generation instead of crashing boot.
+ * - Without a database adapter, `initialize()` falls back to the in-memory
+ *   adapter only when `ALLOW_NO_DATABASE` is set.
+ */
 import Handlebars from "handlebars";
 import { v4 as uuidv4 } from "uuid";
 import {

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -47,6 +47,16 @@
 // SOFTWARE.
 
 /**
+ * In-memory keyword search for `@elizaos/core`: a vendored Porter2 (Snowball
+ * English) stemmer, a Unicode-aware {@link Tokenizer}, an Okapi {@link BM25}
+ * ranker, and the hybrid-search utilities (`buildFtsQuery`, `bm25RankToScore`,
+ * `mergeHybridResults`) that fuse BM25 keyword hits with vector-similarity hits.
+ * The stemmer helpers work on raw char codes for speed and stay faithful to the
+ * upstream Snowball spec — treat that section as vendored, not hand-tunable. The
+ * porter2.js / fast-bm25 MIT license above governs this file; keep it intact.
+ */
+
+/**
  * Checks if the character code represents a vowel (a, e, i, o, u, y).
  * @param char - The character code.
  * @returns True if the character is a vowel, false otherwise.

--- a/packages/core/src/sensitive-request-policy.test.ts
+++ b/packages/core/src/sensitive-request-policy.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the sensitive-request delivery policy — pure, deterministic, no
+ * IO. Exercises resolveSensitiveRequestDelivery across the security-critical
+ * branches (secrets refused in public rooms, owner-app inline entry, private DM,
+ * authenticated cloud/tunnel links, and an unauthenticated tunnel rejected) plus
+ * sensitiveRequestEnvironmentFromSettings' cloud-availability gating.
+ */
 import { describe, expect, test } from "vitest";
 import {
 	resolveSensitiveRequestDelivery,

--- a/packages/core/src/sensitive-request-policy.ts
+++ b/packages/core/src/sensitive-request-policy.ts
@@ -1,3 +1,17 @@
+/**
+ * Type vocabulary and pure decision logic for "sensitive requests" — collecting
+ * a secret, payment, OAuth grant, or private-info field from a user without
+ * leaking it. `resolveSensitiveRequestDelivery` maps a request kind + channel +
+ * environment (cloud / tunnel / DM / owner-app availability) to a delivery plan:
+ * an inline owner-app form, a private DM, an authenticated cloud/tunnel link, or
+ * a refusal that keeps the value out of public rooms.
+ *
+ * Security invariants callers depend on: secrets and private info never resolve
+ * to a public link; a tunnel counts only when explicitly authenticated (tunnel
+ * reachability is not an auth boundary); and redactSensitiveRequestMetadata masks
+ * any secret-looking key before metadata is logged or persisted. Everything here
+ * is pure and environment-driven — no runtime, IO, or side effects.
+ */
 import { ChannelType } from "./types/primitives";
 
 export type SensitiveRequestKind =

--- a/packages/core/src/services.ts
+++ b/packages/core/src/services.ts
@@ -1,3 +1,12 @@
+/**
+ * Fluent, type-safe builder for defining `Service` subclasses at runtime.
+ * `createService(type)` / `defineService(spec)` turn a start/stop/description
+ * spec into a `TypedServiceBuilder` — a constructor carrying the static
+ * `serviceType` and `start(runtime)` members the plugin loader expects — so a
+ * plugin can register a service without hand-authoring a class. Static members
+ * are pinned via `Object.defineProperty` to match the base `ServiceClass` shape
+ * from `types/plugin.ts`, which stays the canonical definition.
+ */
 import type { IAgentRuntime, ServiceTypeName } from "./types";
 import { Service } from "./types";
 

--- a/packages/core/src/settings.encryption.test.ts
+++ b/packages/core/src/settings.encryption.test.ts
@@ -1,11 +1,3 @@
-import { describe, expect, it } from "vitest";
-import {
-	decryptObjectValues,
-	decryptStringValue,
-	encryptObjectValues,
-	encryptStringValue,
-} from "./settings.ts";
-
 /**
  * Settings secret encryption (#8801 — the at-rest protection for secret settings
  * like API keys, shipped untested). It is AES-256-GCM keyed by SHA-256(salt) with
@@ -15,6 +7,14 @@ import {
  * critically — that a WRONG salt fails *safe* (returns the ciphertext, never a
  * garbled/partial plaintext).
  */
+import { describe, expect, it } from "vitest";
+import {
+	decryptObjectValues,
+	decryptStringValue,
+	encryptObjectValues,
+	encryptStringValue,
+} from "./settings.ts";
+
 const SALT = "salt-alpha";
 const SECRET = "sk-api-key-do-not-leak-1234567890";
 

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -1,3 +1,19 @@
+/**
+ * At-rest encryption for secret settings and the SECRET_SALT lifecycle. Secret
+ * values (API keys and the like) are encrypted with AES-256-GCM keyed by
+ * SHA-256(SECRET_SALT) under an "elizaos:settings:v2" AAD; legacy AES-256-CBC
+ * ciphertext still decrypts. getSalt() reads the salt once and caches it with a
+ * short TTL because it runs on every getSetting string-decrypt — the hot path
+ * avoids re-clearing the env cache, and clearSaltCache() is the test seam. In
+ * production a non-default SECRET_SALT is required unless
+ * ELIZA_ALLOW_DEFAULT_SECRET_SALT overrides the check.
+ *
+ * Consumed by the runtime's getSetting/setSetting path and by world/character
+ * setup: saltWorldSettings/unsaltWorldSettings (gated on each setting's `secret`
+ * flag) and encryptedCharacter/decryptedCharacter walk their string values,
+ * round-tripping non-strings untouched. Decryption fails SAFE — a wrong salt
+ * returns the original ciphertext, never a partial plaintext.
+ */
 import { createUniqueUuid } from "./entities";
 import { logger } from "./logger";
 import type {
@@ -80,10 +96,10 @@ export function getSalt(): string {
 
 	// Fast path: within the TTL, trust the cached salt WITHOUT re-clearing the
 	// whole environment cache. getSalt runs on every getSetting string-decrypt,
-	// and the old unconditional `getEnvironment().clearCache()` made each of
-	// those force a full env re-read. SECRET_SALT is a boot-time constant; a
-	// runtime change is picked up at the next cache refresh (<= TTL) or via the
-	// explicit clearSaltCache() seam tests use.
+	// and unconditionally clearing the env cache here (`getEnvironment().clearCache()`)
+	// would force a full env re-read on each of those. SECRET_SALT is a boot-time
+	// constant; a runtime change is picked up at the next cache refresh (<= TTL)
+	// or via the explicit clearSaltCache() seam tests use.
 	if (saltCache !== null && now - saltCache.timestamp < SALT_CACHE_TTL_MS) {
 		return saltCache.value;
 	}
@@ -112,7 +128,6 @@ export function getSalt(): string {
 		saltErrorLogged = true;
 	}
 
-	// Update cache with latest env-derived salt
 	saltCache = {
 		value: currentEnvSalt,
 		timestamp: now,
@@ -136,9 +151,8 @@ export function clearSaltCache(): void {
  * @returns {string} - The encrypted value in 'iv:encrypted' format
  */
 export function encryptStringValue(value: string, salt: string): string {
-	// Check if value is undefined or null
 	if (value === undefined || value === null) {
-		return value; // Return the value as is (undefined or null)
+		return value;
 	}
 
 	if (typeof value === "boolean" || typeof value === "number") {

--- a/packages/core/src/spoken-text.ts
+++ b/packages/core/src/spoken-text.ts
@@ -1,3 +1,11 @@
+/**
+ * Reduces a model's written-form output to speakable prose for TTS.
+ * `sanitizeSpeechText` NFKC-normalizes the input, then strips thinking /
+ * analysis / tool tags, code fences and inline code, markdown links, raw HTML,
+ * and URLs, removes parenthetical and bracketed stage directions, normalizes
+ * punctuation and unusual glyphs, and collapses whitespace.
+ */
+
 function collapseWhitespace(input: string): string {
 	return input.replace(/\s+/g, " ").trim();
 }

--- a/packages/core/src/trajectory-utils.ts
+++ b/packages/core/src/trajectory-utils.ts
@@ -1,3 +1,24 @@
+/**
+ * Runtime-side utilities for recording model trajectories: the glue between raw
+ * LLM/provider call sites and whichever trajectory-logger service is registered
+ * (`services/trajectories`). Owns the LLM-call detail/purpose taxonomy, the
+ * strict-mode guards that fail fast when a generative call happens outside a
+ * trajectory step, and the wrappers that open child steps around actions,
+ * providers, evaluators, and spawned sub-agents.
+ *
+ * `recordLlmCall` is the canonical entry point for raw SDK/fetch generation: it
+ * times `fn`, derives the response text, and emits an llm-call entry against the
+ * active step. `withStandaloneTrajectory` / `withActionStep` / `withProviderStep`
+ * / `withEvaluatorStep` establish the trajectory context those calls attach to;
+ * `resolveTrajectoryLogger` picks the best-scoring logger service by capability
+ * so this module never depends directly on `@elizaos/agent`.
+ *
+ * Also builds the context-object trajectory export (JSON-sanitized, cycle-safe)
+ * and holds the process-global registry of trajectory `source` tags excluded
+ * from training/optimization datasets. Strict enforcement is gated on
+ * `ELIZA_TRAJECTORY_STRICT`; embeddings, tokenizers, and speech/media models are
+ * exempt from the generative-call guards.
+ */
 import { getAmbientSingleton } from "./ambient-context.js";
 import { isTruthyEnvValue } from "./env-utils.js";
 import {

--- a/packages/core/src/tunnel-service.ts
+++ b/packages/core/src/tunnel-service.ts
@@ -1,3 +1,12 @@
+/**
+ * Service contract and accessors for the network tunnel that exposes a local
+ * agent port over the public internet (tailscale / headscale / ngrok). Defines
+ * {@link ITunnelService} plus its status and provider types, and resolver
+ * helpers that fetch the registered {@link ServiceType.TUNNEL} service off a
+ * runtime (validating it exposes the expected shape) or report whether the
+ * tunnel slot is still unclaimed. Concrete implementations live in a tunnel
+ * plugin.
+ */
 import type { IAgentRuntime } from "./types/runtime";
 import type { Service } from "./types/service";
 import { ServiceType } from "./types/service";

--- a/packages/core/src/types/connector-setup.test.ts
+++ b/packages/core/src/types/connector-setup.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises the connector-setup contract — the `SetupState` lifecycle union,
+ * `SETUP_ERROR_CODES`, `buildSetupError`, `setupPath`, and `SetupStatusResponse`
+ * that connector plugins and the app-core API host share. Deterministic
+ * assertions with no model or database in the loop.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	buildSetupError,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,4 +1,12 @@
-// Core types
+/**
+ * Canonical barrel for the core type system: re-exports every `types/*` module
+ * plus the public prompt/util helpers, forming the `@elizaos/core` type surface
+ * that `@elizaos/agent`, `@elizaos/app-core`, and every plugin import.
+ *
+ * Most modules are re-exported via `export *`, but a few whose runtime values
+ * must survive tree-shaking (e.g. view-kind) are re-exported explicitly — see
+ * the inline note before converting one back to a star export.
+ */
 
 export { logger } from "../logger";
 // Utilities that are part of the public API.

--- a/packages/core/src/types/message-source.test.ts
+++ b/packages/core/src/types/message-source.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Pins the canonical `content.source` sentinel strings and the `MESSAGE_SOURCES`
+ * map. Deterministic assertions with no model or database in the loop.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	MESSAGE_SOURCE_AGENT_GREETING,

--- a/packages/core/src/types/model.test.ts
+++ b/packages/core/src/types/model.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the text-generation model-type predicate — `isTextGenerationModelType`
+ * over `TEXT_GENERATION_MODEL_TYPES` and `ModelType`, including case and
+ * whitespace normalization. Pure predicate assertions; no live model is invoked.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	isTextGenerationModelType,

--- a/packages/core/src/types/swarm-coordinator.test.ts
+++ b/packages/core/src/types/swarm-coordinator.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Verifies the swarm-coordinator service slot — `SWARM_COORDINATOR_SERVICE_TYPE`,
+ * its `ServiceType` registration, and `getSwarmCoordinatorService` resolving
+ * through a runtime. Uses a hand-built stub runtime and coordinator; no real
+ * service is instantiated.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	getSwarmCoordinatorService,

--- a/packages/core/src/types/tools.test.ts
+++ b/packages/core/src/types/tools.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the tool-group registry — legacy `TOOL_GROUPS` expansion via
+ * `expandToolGroups` plus the `TOOL_GROUP_DEFINITIONS` risk-tag metadata read by
+ * policy/audit callers. Deterministic assertions over the static definitions.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	expandToolGroups,

--- a/packages/core/src/types/view-kind.test.ts
+++ b/packages/core/src/types/view-kind.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises view-kind resolution and gating — `resolveViewKind` (including the
+ * legacy `developerOnly` mapping), `isViewKindEnabled`, `isViewVisible`, and the
+ * `VIEW_KIND_META` table over the closed `VIEW_KINDS` set. Deterministic
+ * assertions with no model or database in the loop.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	type EnabledViewKinds,

--- a/packages/core/src/utils.parsing.test.ts
+++ b/packages/core/src/utils.parsing.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Foundational parsing/identity utilities used throughout the runtime.
+ * stringToUuid must be deterministic (same input → same id, so an external id
+ * always maps to the same entity) and idempotent on an already-valid UUID;
+ * parseJSONObjectFromText must recover an object from chatty model text or
+ * return null; and the boolean/truncation helpers must degrade safely.
+ * Pure deterministic unit test — no model or database.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	parseBooleanFromText,
@@ -6,14 +14,6 @@ import {
 	truncateToCompleteSentence,
 	validateUuid,
 } from "./utils.ts";
-
-/**
- * Foundational parsing/identity utilities used throughout the runtime.
- * stringToUuid must be deterministic (same input → same id, so an external id
- * always maps to the same entity) and idempotent on an already-valid UUID;
- * parseJSONObjectFromText must recover an object from chatty model text or
- * return null; and the boolean/truncation helpers must degrade safely.
- */
 
 const UUID_RE =
 	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,3 +1,24 @@
+/**
+ * Shared runtime helpers re-exported from `@elizaos/core`: prompt composition,
+ * message/post formatting, structured-response parsing, and deterministic
+ * identity.
+ *
+ * `composePrompt` / `composePromptFromState` render `{{binding}}` templates via
+ * Handlebars — double-brace bindings are rewritten to triple-brace so values are
+ * not HTML-escaped — and fall back to an eval-free replacer under a restricted
+ * CSP (browser-extension) environment. `formatMessages` / `formatPosts` turn
+ * `Memory[]` into the transcript the model reads. `parseKeyValueXml` (legacy
+ * `<response>` XML), `parseToonKeyValue`, and `parseJSONObjectFromText` recover
+ * structured fields from chatty model output, tolerating malformed input by
+ * returning null rather than throwing.
+ *
+ * `stringToUuid` derives a deterministic, RFC-4122-shaped UUID from an arbitrary
+ * string via an in-tree pure-JS SHA-1 (with a WebCrypto-backed cache), so the
+ * same external id always maps to the same entity across Node and browser; it is
+ * idempotent on an already-valid UUID. This module is also the barrel that
+ * `export * from "./utils"` resolves to, so helpers under `utils/` that must be
+ * reachable from the package are re-exported at the bottom.
+ */
 import Handlebars from "handlebars";
 import z from "zod";
 


### PR DESCRIPTION
## What

Batch **B01 part 2** of the repo-wide comment cleanup (#12231, parent #12181) — the
load-bearing files at `packages/core/src` root + `types/`. Every in-scope file gets an
accurate purpose-explaining prose header; churn comments are removed/rewritten to present-tense
durable fact.

**Comments only — zero functional diff.** Machine-proven by `node scripts/assert-comment-only-diff.mjs`:
every changed file's TypeScript code-token stream is byte-identical to base.

## Scope (58 files)

The framework's highest-dividend modules: `runtime.ts` (the 10k-line `AgentRuntime`, headered with
its `getSetting`/embedding-width invariants), plugin lifecycle, entities/character, roles/access,
memory/db/search, cloud auth+routing, action naming/docs, settings/boot, connectors/services,
utils, and the core type barrels (`types/`).

Follows #12824 (B01 part 1, core boundary/data/schema subsystems — merged). Remaining B01:
`features/`, `services/`, `utils/` in follow-up per-subtree PRs.

## Verification

```
node scripts/assert-comment-only-diff.mjs
# OK — 58 source file(s) changed; every code token identical to base. Comments only.
```

Part of #12231.