### PR TITLE
fix(#12273): fallback-slop sweep — app plugins A (fail-fast over fabricated defaults)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/terminal-capabilities.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/terminal-capabilities.ts
@@ -176,6 +176,8 @@ function canExecute(filePath: string): boolean {
     accessSync(filePath, constants.X_OK);
     return true;
   } catch {
+    // error-policy:J3 existence/permission probe; access failure means the path
+    // is absent or not executable — false is the expected-miss signal.
     return false;
   }
 }

--- a/plugins/plugin-coding-tools/src/actions/ls.ts
+++ b/plugins/plugin-coding-tools/src/actions/ls.ts
@@ -264,7 +264,11 @@ export async function lsHandler(
         type = "file";
         size = st.size;
       }
-    } catch {}
+    } catch {
+      // error-policy:J6 best-effort per-entry enrichment; a name that vanished
+      // between readdir and lstat (transient race) must not abort the whole
+      // listing. The entry name is still truthful; only its type/size default.
+    }
     enriched.push(size === undefined ? { name, type } : { name, type, size });
   }
 

--- a/plugins/plugin-coding-tools/src/services/session-cwd-service.ts
+++ b/plugins/plugin-coding-tools/src/services/session-cwd-service.ts
@@ -105,6 +105,8 @@ async function isDirectory(absPath: string): Promise<boolean> {
   try {
     return (await fs.stat(absPath)).isDirectory();
   } catch {
+    // error-policy:J3 existence/type probe; a stat failure (ENOENT) means the
+    // path is absent — false is the expected-miss signal.
     return false;
   }
 }

--- a/plugins/plugin-computeruse/src/platform/driver.ts
+++ b/plugins/plugin-computeruse/src/platform/driver.ts
@@ -11,6 +11,7 @@
  * and `screenshot.ts` modules remain importable for the legacy code path.
  */
 
+import { logger } from "@elizaos/core";
 import type { ScreenRegion } from "../types.js";
 import {
   desktopClick,
@@ -61,8 +62,7 @@ export function selectedDriver(): DriverName {
   if (requested === "legacy") return "legacy";
   if (requested !== "nutjs") {
     if (!warned) {
-      // eslint-disable-next-line no-console
-      console.warn(
+      logger.warn(
         `[computeruse] Unknown ELIZA_COMPUTERUSE_DRIVER=${requested}; falling back to legacy.`,
       );
       warned = true;
@@ -71,8 +71,7 @@ export function selectedDriver(): DriverName {
   }
   if (!nutAvailable()) {
     if (!warned) {
-      // eslint-disable-next-line no-console
-      console.warn(
+      logger.warn(
         `[computeruse] nutjs driver unavailable (${loadFailureReason()}); falling back to legacy shell drivers.`,
       );
       warned = true;

--- a/plugins/plugin-computeruse/src/scene/a11y-provider.error-policy.test.ts
+++ b/plugins/plugin-computeruse/src/scene/a11y-provider.error-policy.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Error-policy tests for the accessibility providers' snapshot failure path
+ * (#12273). The interface contract is that `snapshot()` returns `[]` for "no
+ * reachable nodes" so the scene-builder always produces a Scene — but a genuine
+ * failure (the platform a11y binary missing, or permission revoked) must not be
+ * silently indistinguishable from an empty desktop. These tests drive the real
+ * missing-binary path (osascript/powershell are absent on the Linux CI host) and
+ * assert the failure is surfaced via `logger.warn`, not swallowed.
+ */
+
+import { logger } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DarwinAccessibilityProvider,
+  WindowsAccessibilityProvider,
+} from "./a11y-provider.js";
+
+const onDarwin = process.platform === "darwin";
+const onWindows = process.platform === "win32";
+
+describe("accessibility provider snapshot failure surfacing", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.skipIf(onDarwin)(
+    "Darwin provider surfaces the osascript failure via logger.warn and still returns []",
+    async () => {
+      const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+
+      // osascript does not exist on a non-macOS host → execFileSync throws.
+      const nodes = await new DarwinAccessibilityProvider().snapshot();
+
+      expect(nodes).toEqual([]);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0])).toContain(
+        "[DarwinAccessibilityProvider]",
+      );
+    },
+  );
+
+  it.skipIf(onWindows)(
+    "Windows provider surfaces the PowerShell failure via logger.warn and still returns []",
+    async () => {
+      const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+
+      // powershell does not exist on a non-Windows host → execFileSync throws.
+      const nodes = await new WindowsAccessibilityProvider().snapshot();
+
+      expect(nodes).toEqual([]);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0])).toContain(
+        "[WindowsAccessibilityProvider]",
+      );
+    },
+  );
+});

--- a/plugins/plugin-computeruse/src/scene/a11y-provider.ts
+++ b/plugins/plugin-computeruse/src/scene/a11y-provider.ts
@@ -29,6 +29,7 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { logger } from "@elizaos/core";
 import { commandExists, currentPlatform } from "../platform/helpers.js";
 import type { SceneAxNode } from "./scene-types.js";
 
@@ -171,6 +172,8 @@ except Exception as e:
         .filter((n) => n && typeof n === "object")
         .map((n, i) => mapAtspiNode(n as Record<string, unknown>, i));
     } catch {
+      // error-policy:J4 AT-SPI probe; empty result advances the failover chain
+      // to the Wayland compositor tier (see snapshot()).
       return [];
     }
   }
@@ -197,6 +200,8 @@ except Exception as e:
       });
       return parseHyprlandClients(text);
     } catch {
+      // error-policy:J4 Hyprland IPC probe; empty result advances the failover
+      // chain to the Sway tier (see tryWaylandCompositor()).
       return [];
     }
   }
@@ -210,6 +215,8 @@ except Exception as e:
       });
       return parseSwayTree(text);
     } catch {
+      // error-policy:J4 Sway IPC probe; empty result is the last failover tier,
+      // leaving the Linux provider with no reachable a11y nodes.
       return [];
     }
   }
@@ -231,6 +238,8 @@ export function parseHyprlandClients(text: string): SceneAxNode[] {
   try {
     raw = JSON.parse(text);
   } catch {
+    // error-policy:J3 untrusted `hyprctl` output; unparseable JSON yields the
+    // explicit empty node list rather than a fabricated window.
     return [];
   }
   if (!Array.isArray(raw)) return [];
@@ -278,6 +287,8 @@ export function parseSwayTree(text: string): SceneAxNode[] {
   try {
     raw = JSON.parse(text) as SwayNode;
   } catch {
+    // error-policy:J3 untrusted `swaymsg` output; unparseable JSON yields the
+    // explicit empty node list rather than a fabricated window.
     return [];
   }
   if (!raw) return [];
@@ -398,7 +409,17 @@ export class DarwinAccessibilityProvider implements AccessibilityProvider {
           displayId: 0,
         } as SceneAxNode;
       });
-    } catch {
+    } catch (err) {
+      // error-policy:J4 the interface contract is [] = "no reachable nodes" so
+      // the scene-builder always produces a Scene; but osascript failing
+      // (a11y permission revoked, binary missing) is a failure, not an empty
+      // desktop — surface it so revocation is visible instead of silently
+      // shrinking the scene the agent trusts as complete.
+      logger.warn(
+        `[DarwinAccessibilityProvider] a11y snapshot failed; returning no nodes: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
       return [];
     }
   }
@@ -462,7 +483,16 @@ $out | ConvertTo-Json -Depth 4 -Compress
             displayId: 0,
           } as SceneAxNode;
         });
-    } catch {
+    } catch (err) {
+      // error-policy:J4 the interface contract is [] = "no reachable nodes" so
+      // the scene-builder always produces a Scene; but PowerShell/UIA failing
+      // is a failure, not an empty desktop — surface it so the shrunken scene
+      // is visible instead of silently trusted as complete.
+      logger.warn(
+        `[WindowsAccessibilityProvider] a11y snapshot failed; returning no nodes: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
       return [];
     }
   }

--- a/plugins/plugin-computeruse/src/services/desktop-control.ts
+++ b/plugins/plugin-computeruse/src/services/desktop-control.ts
@@ -59,6 +59,8 @@ export function commandExists(command: string): boolean {
     });
     return true;
   } catch {
+    // error-policy:J3 existence probe; a non-zero `which`/`where` exit means the
+    // command is absent — false is the expected-miss signal, not a swallowed bug.
     return false;
   }
 }

--- a/plugins/plugin-personal-assistant/src/automation-node-contributor.error-policy.test.ts
+++ b/plugins/plugin-personal-assistant/src/automation-node-contributor.error-policy.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Error-policy tests for the LifeOps automation-node contributor's native
+ * Calendar permission resolver (#12273). Asserts the fast-fail behavior: a live
+ * permission-check failure falls back to the cached read (a legitimate degraded
+ * value), while a *total* failure (both check and cached read broken) surfaces
+ * via `runtime.reportError` rather than silently collapsing into the same `null`
+ * a missing permission system returns. Deterministic: the permissions registry
+ * is a hand-built fake, no live OS permission bridge.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import type { PermissionState } from "@elizaos/shared";
+import { describe, expect, it, vi } from "vitest";
+
+// The module under test pulls a value import from app-core's registration seam;
+// stub it so this unit test does not require app-core to be built.
+vi.mock("@elizaos/app-core/api/automation-node-contributors", () => ({
+  registerAutomationNodeContributor: vi.fn(),
+}));
+
+import { resolveNativeCalendarPermission } from "./automation-node-contributor.js";
+
+function cachedState(): PermissionState {
+  return {
+    id: "calendar",
+    status: "granted",
+    lastChecked: Date.now(),
+    canRequest: false,
+    platform: "darwin",
+  };
+}
+
+function makeRuntime(registry: unknown): {
+  runtime: IAgentRuntime;
+  reportError: ReturnType<typeof vi.fn>;
+} {
+  const reportError = vi.fn();
+  const runtime = {
+    getService: (serviceType: string) =>
+      serviceType === "eliza_permissions_registry" ? registry : null,
+    reportError,
+  } as unknown as IAgentRuntime;
+  return { runtime, reportError };
+}
+
+describe("resolveNativeCalendarPermission error policy", () => {
+  it("returns the cached value when the live check fails but the cache is readable", async () => {
+    const cached = cachedState();
+    const registry = {
+      check: vi.fn().mockRejectedValue(new Error("live probe unavailable")),
+      get: vi.fn().mockReturnValue(cached),
+    };
+    const { runtime, reportError } = makeRuntime(registry);
+
+    const result = await resolveNativeCalendarPermission(runtime);
+
+    expect(result).toBe(cached);
+    expect(registry.get).toHaveBeenCalledWith("calendar");
+    // Falling back to a legitimate cached value is not a reportable failure.
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it("reports the error and returns null when both the live check and the cached read fail", async () => {
+    const checkError = new Error("live probe unavailable");
+    const getError = new Error("cache backend down");
+    const registry = {
+      check: vi.fn().mockRejectedValue(checkError),
+      get: vi.fn().mockImplementation(() => {
+        throw getError;
+      }),
+    };
+    const { runtime, reportError } = makeRuntime(registry);
+
+    const result = await resolveNativeCalendarPermission(runtime);
+
+    // Unknown, not fabricated-authorized/denied.
+    expect(result).toBeNull();
+    // The total failure is surfaced (drives ERROR_REPORTED + the recent-errors
+    // provider), not swallowed.
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError).toHaveBeenCalledWith(
+      "PersonalAssistant.calendarPermission",
+      getError,
+      { via: "check+get" },
+    );
+  });
+
+  it("returns null without reporting when no permissions registry is present", async () => {
+    const { runtime, reportError } = makeRuntime(undefined);
+
+    const result = await resolveNativeCalendarPermission(runtime);
+
+    // Absence of the permission system is a legitimate null, not a failure.
+    expect(result).toBeNull();
+    expect(reportError).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-personal-assistant/src/automation-node-contributor.ts
+++ b/plugins/plugin-personal-assistant/src/automation-node-contributor.ts
@@ -31,6 +31,8 @@ async function resolveGoogleStatus(
         error instanceof Error ? error.message : String(error)
       }`,
     );
+    // error-policy:J4 null renders the automation node as "not connected /
+    // requires setup" — a designed, distinguishable unavailable state.
     return null;
   }
 }
@@ -46,6 +48,8 @@ async function resolveTelegramStatus(
         error instanceof Error ? error.message : String(error)
       }`,
     );
+    // error-policy:J4 null renders the automation node as "not connected /
+    // requires setup" — a designed, distinguishable unavailable state.
     return null;
   }
 }
@@ -61,6 +65,8 @@ async function resolveSignalStatus(
         error instanceof Error ? error.message : String(error)
       }`,
     );
+    // error-policy:J4 null renders the automation node as "not connected /
+    // requires setup" — a designed, distinguishable unavailable state.
     return null;
   }
 }
@@ -76,6 +82,8 @@ async function resolveDiscordStatus(
         error instanceof Error ? error.message : String(error)
       }`,
     );
+    // error-policy:J4 null renders the automation node as "not connected /
+    // requires setup" — a designed, distinguishable unavailable state.
     return null;
   }
 }
@@ -89,7 +97,7 @@ function isPermissionsRegistry(value: unknown): value is IPermissionsRegistry {
   );
 }
 
-async function resolveNativeCalendarPermission(
+export async function resolveNativeCalendarPermission(
   runtime: AutomationNodeContributorContext["runtime"],
 ): Promise<PermissionState | null> {
   const service = runtime.getService(PERMISSIONS_REGISTRY_SERVICE);
@@ -100,13 +108,23 @@ async function resolveNativeCalendarPermission(
     return await service.check("calendar");
   } catch (error) {
     logger.warn(
-      `[lifeops] Failed to resolve native Calendar permission: ${
+      `[lifeops] Live native Calendar permission check failed; falling back to cached value: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
     try {
+      // error-policy:J4 cached permission state while the live check is
+      // unavailable — the cache is a legitimate degraded read, not a fabricated
+      // default.
       return service.get("calendar");
-    } catch {
+    } catch (getError) {
+      // Both live check and cached read failed: the permission state is truly
+      // unknown. Surface it (reportError → ERROR_REPORTED) rather than silently
+      // collapsing "unknown" into the same null a missing permission system
+      // returns; callers treat null as "unknown" and render it as such.
+      runtime.reportError("PersonalAssistant.calendarPermission", getError, {
+        via: "check+get",
+      });
       return null;
     }
   }


### PR DESCRIPTION
## Fallback-slop sweep — app plugins A (#12273, parent #12182)

Precision-focused slice of the app-plugins-A sweep (personal-assistant, health, agent-orchestrator, computeruse, coding-tools, shell). Behavior-changing work, so per the batch guidance I converted only high-confidence slop, annotated justified J-category handlers, and **left ambiguous absent-value / designed-degrade / large `?? <lit>` load-path candidates untouched** (counted in "left" below). A small precise PR over a large reckless one.

Uses the #12263 foundation: `runtime.reportError` → `ERROR_REPORTED`, the diff-scoped `audit:error-policy-ratchet`, and the `// error-policy:J<N>` grep convention.

### Re-derived suspect counts (slice @ develop `d8451f8133`)

| pattern | count |
|---|---|
| empty catch (incl. embedded-script literals) | 7 |
| promise swallow `.catch(()=>…)` | 50 |
| return-default catch | 204 |
| `?? <lit>` | 884 |
| `\|\| <lit>` | 28 |
| `console.*` (src, non-`scripts/`) | 3 |

### Site table (verdicts)

| site | pattern | verdict |
|---|---|---|
| `plugin-personal-assistant/src/automation-node-contributor.ts` `resolveNativeCalendarPermission` inner `catch { return null }` | fabricated default on total failure | **CONVERT** → `runtime.reportError` + return explicit null (unknown) |
| `…/automation-node-contributor.ts` `service.get("calendar")` cached read | fallback path | **KEEP** J4 (cached value while live check unavailable) |
| `…/automation-node-contributor.ts` `resolveGoogle/Telegram/Signal/Discord Status` `return null` | log-and-return-null | **KEEP** J4 (null → "not connected / requires setup" distinguishable state) |
| `plugin-computeruse/src/scene/a11y-provider.ts` Darwin `snapshot()` `catch { return [] }` | silent terminal swallow | **CONVERT** → `logger.warn` surfaces revocation, keeps documented `[]` contract |
| `…/a11y-provider.ts` Windows `snapshot()` `catch { return [] }` | silent terminal swallow | **CONVERT** → `logger.warn` (same) |
| `…/a11y-provider.ts` `tryAtspi` / `tryHyprland` / `trySway` `catch { return [] }` | provider failover | **KEEP** J4 (empty advances the failover chain) |
| `…/a11y-provider.ts` `parseHyprlandClients` / `parseSwayTree` JSON.parse catch | untrusted-input parse | **KEEP** J3 (explicit empty on unparseable subprocess output) |
| `…/a11y-provider.ts:379/381/454` `catch {}` | embedded JXA/PowerShell string literals | **EXEMPT** (grep hits, not TS handlers) |
| `plugin-computeruse/src/platform/driver.ts:65,75` `console.warn` | logger-only violation | **CONVERT** → `logger.warn` |
| `plugin-computeruse/src/services/desktop-control.ts` `commandExists` | `catch { return false }` probe | **KEEP** J3 (existence probe; false = absent) |
| `plugin-coding-tools/src/services/session-cwd-service.ts` `isDirectory` | `catch { return false }` probe | **KEEP** J3 (stat probe; false = absent) |
| `plugin-agent-orchestrator/src/services/terminal-capabilities.ts` `canExecute` | `catch { return false }` probe | **KEEP** J3 (access probe; false = absent/not-exec) |
| `plugin-coding-tools/src/actions/ls.ts:267` `catch {}` | per-entry lstat swallow | **KEEP** J6 (best-effort per-entry enrichment; readdir→lstat race) |
| `smithers-task-runner.ts:236` `console.error` | inside generated Node worker script | **EXEMPT** (embedded-script literal) |
| ~884 `?? <lit>` / 204 return-default / 50 promise-swallow across the slice | mixed | **LEFT** — legitimate absent-value / designed-degrade or needs deeper per-site analysis; precision over completeness |

### Per-category tally

- **Converted:** 4 sites (calendar permission double-catch; Darwin + Windows a11y snapshot; driver console→logger — 2 console calls).
- **Annotated (kept, justified):** 10 handlers — J3 ×5, J4 ×7 (across 5 resolvers + 3 failover tiers... counted as annotation sites), J6 ×1. `grep -c error-policy:J` across touched files = 16 annotation lines.
- **Left (sitesLeft):** ~1160 candidates (884 `??`, 204 return-default, 50 promise-swallow, 28 `||`) — deliberately untouched; mostly legitimate absent-value/optional-config defaults or designed degrade that cannot be distinguished from masking without deeper analysis.

### Exemplar before → after

`plugin-personal-assistant/src/automation-node-contributor.ts` — the batch's exemplar #1:

```ts
// BEFORE — total failure fabricates null; "unknown" collapses into the same
// value "no permission system" returns, and nobody is told.
    try {
      return service.get("calendar");
    } catch {
      return null;
    }

// AFTER — cached read is a legitimate J4 fallback; a total failure is reported.
    try {
      // error-policy:J4 cached permission state while the live check is unavailable
      return service.get("calendar");
    } catch (getError) {
      runtime.reportError("PersonalAssistant.calendarPermission", getError, {
        via: "check+get",
      });
      return null; // callers treat null as "unknown", rendered as such
    }
```

Test (`automation-node-contributor.error-policy.test.ts`): cached fallback returns the cached value with **no** `reportError`; a total failure reports **once** and returns null; a missing registry returns null without reporting.

### Evidence

- **Real-error-path tests (no mock-swallow):**
  - `a11y-provider.error-policy.test.ts` drives the **real missing-binary path** (osascript/powershell absent on the Linux host) and asserts the failure is surfaced via `logger.warn` (`[DarwinAccessibilityProvider]` / `[WindowsAccessibilityProvider]`) instead of being silently swallowed, while `snapshot()` still returns `[]` (documented contract). — 2 passed.
  - `automation-node-contributor.error-policy.test.ts` — 3 passed.
- **Ratchet proof (`bun run audit:error-policy-ratchet`):** `no new fallback-slop in touched files`; every touched file `emptyCatch`/`serverConsole` count unchanged or lower (no additions).
- **Touched-package tests green:** computeruse a11y-provider/scene-builder/driver (43 passed), coding-tools ls/session-cwd (14 passed), agent-orchestrator terminal-capabilities (10 passed), plus the 2 new suites.
- **Typecheck:** computeruse / coding-tools / agent-orchestrator typecheck clean. personal-assistant has pre-existing cross-package resolution errors (unbuilt `@elizaos/ui/*`, `@elizaos/plugin-calendar`, app-core `AutomationNodeContributor` type) on lines unrelated to this diff; my edits add none.
- Pre-existing failures observed and confirmed **not** caused by this diff (unbuilt-dep resolution or unrelated assertions): coding-tools `bash.test.ts` "mixed disk and RAM" (spawns real `df`/`free`, 90s timeout flake; `bash.ts` byte-identical to develop), computeruse `android-bridge.test.ts` manifest assertion + `routes-e2e.test.ts` (`@elizaos/plugin-x402` unbuilt).

N/A: real-LLM trajectory / screenshots — this slice touches OS-probe and permission-resolution error paths with no user-facing UI surface and no model-behavior change; the induced-failure behavior is proven by the missing-binary and reportError unit tests above.

Refs #12273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
