### PR TITLE
fix(app-core): type fs remote symlink stats

### DIFF
--- a/packages/app-core/platforms/electrobun/remotes/fs/src/bun/fs-service.ts
+++ b/packages/app-core/platforms/electrobun/remotes/fs/src/bun/fs-service.ts
@@ -1,3 +1,4 @@
+import type { Stats } from "node:fs";
 import {
   lstat,
   mkdir,
@@ -15,9 +16,9 @@ import type {
   FileListFailure,
   FileListParams,
   FileListResult,
-  FileRemoteErrorCode,
   FileReadTextParams,
   FileReadTextResult,
+  FileRemoteErrorCode,
   FileRoot,
   FileSearchMatch,
   FileSearchParams,
@@ -294,7 +295,7 @@ export class FileRemoteService {
       return;
     }
 
-    let stats;
+    let stats: Stats;
     try {
       const linkStats = await lstat(guarded.absolutePath);
       if (linkStats.isSymbolicLink()) return;


### PR DESCRIPTION
## Summary

Follow-up to #12832. The fs remote symlink guard introduced `let stats` without an explicit type in a Biome-checked file, and the added protocol import order was not sorted. This keeps the behavior from #12832 unchanged while making the touched file pass lint/type validation.

## Validation

- `bunx @biomejs/biome check packages/app-core/platforms/electrobun/remotes/fs/src/bun/fs-service.ts`
- `bun run --cwd packages/app-core/platforms/electrobun/remotes/fs smoke`
- `bun run --cwd packages/app-core/platforms/electrobun/remotes/fs typecheck`
- `git diff --check`

Smoke output included the expected partial listing proof:

```json
"failedEntries": [
  {
    "path": "/tmp/eliza-fs-OcaKRY/broken-link",
    "error": "Path does not exist."
  }
]
```

## Evidence matrix

- Real-LLM trajectories: N/A - no agent/model/prompt path changed.
- UI screenshots/video: N/A - no UI change.
- Backend/domain artifacts: fs smoke output above shows the real temp-dir listing still surfaces the dangling symlink in `failedEntries`.
