### PR TITLE
fix(#12321): bind kernel verify reports to artifacts

### DIFF
--- a/.github/issue-evidence/12321-kernel-verify-report-binding.md
+++ b/.github/issue-evidence/12321-kernel-verify-report-binding.md
@@ -1,0 +1,26 @@
+# Issue #12321 - Stage 4 kernel verification report binding
+
+PR scope:
+
+- Stage 2 publish hardware verification reports now require a pass report to be
+  bound to the current training repo commit.
+- Pass reports must also carry `modelSha256`, `ggufSha256`, or
+  `artifactSha256`, and that digest must match a shipped text GGUF in the
+  staged bundle.
+- Regression coverage blocks stale-commit reports and swapped-model reports
+  before `eliza-1.manifest.json` can be emitted.
+
+Local verification on 2026-07-04:
+
+```bash
+python3 -m pytest packages/training/scripts/publish/test_orchestrator.py -q
+# 54 passed
+
+python3 -m py_compile \
+  packages/training/scripts/publish/orchestrator.py \
+  packages/training/scripts/publish/test_orchestrator.py
+
+git diff --check
+```
+
+Screenshots/recordings: N/A, publisher gate behavior only; no UI changed.

--- a/packages/training/scripts/publish/orchestrator.py
+++ b/packages/training/scripts/publish/orchestrator.py
@@ -867,7 +867,7 @@ def _validate_mtp_disabled_metadata(
 
 
 def validate_bundle_layout(ctx: PublishContext) -> dict[str, list[Path]]:
-    """Enforce the §2 layout. Populates ``ctx.layout_files`` and returns it.
+    """Enforce the §2 layout and return the files selected for publishing.
 
     A missing required subdir/file is publish-blocking. ``vision/`` and
     ``asr/`` are tier-conditional but, when present, must contain at
@@ -1676,7 +1676,21 @@ def _verify_dir(ctx: PublishContext) -> Path:
     return ctx.training_repo_root.parent / "inference" / "verify"
 
 
-def _read_recorded_report(path: Path, expected_backend: str) -> KernelVerification:
+def _is_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(c in "0123456789abcdef" for c in value)
+    )
+
+
+def _read_recorded_report(
+    path: Path,
+    expected_backend: str,
+    *,
+    expected_at_commit: str,
+    model_sha256s: set[str],
+) -> KernelVerification:
     if not path.is_file():
         raise OrchestratorError(
             f"verification report not found: {path}",
@@ -1702,6 +1716,29 @@ def _read_recorded_report(path: Path, expected_backend: str) -> KernelVerificati
     if not at_commit:
         raise OrchestratorError(
             f"verification report at {path} missing atCommit",
+            EXIT_KERNEL_VERIFY_FAIL,
+        )
+    if at_commit != expected_at_commit:
+        raise OrchestratorError(
+            f"verification report at {path} was recorded at commit "
+            f"{at_commit!r}, expected {expected_at_commit!r}",
+            EXIT_KERNEL_VERIFY_FAIL,
+        )
+    model_sha = (
+        data.get("modelSha256")
+        or data.get("ggufSha256")
+        or data.get("artifactSha256")
+    )
+    if not _is_sha256(model_sha):
+        raise OrchestratorError(
+            f"verification report at {path} missing modelSha256/ggufSha256/"
+            "artifactSha256",
+            EXIT_KERNEL_VERIFY_FAIL,
+        )
+    if model_sha not in model_sha256s:
+        raise OrchestratorError(
+            f"verification report at {path} model sha256 {model_sha!r} does "
+            "not match a shipped text GGUF",
             EXIT_KERNEL_VERIFY_FAIL,
         )
     return KernelVerification(status="pass", at_commit=at_commit, report=report)
@@ -1750,6 +1787,7 @@ def _git_short_sha(repo_root: Path) -> str:
 
 def run_kernel_verification(
     ctx: PublishContext,
+    layout: Mapping[str, Sequence[Path]],
 ) -> dict[str, KernelVerification]:
     """Produce a backend → verification map per ``ELIZA_1_BACKENDS``.
 
@@ -1772,6 +1810,7 @@ def run_kernel_verification(
 
     supported = set(SUPPORTED_BACKENDS_BY_TIER[ctx.tier])
     sha = _git_short_sha(ctx.training_repo_root)
+    model_sha256s = _text_model_sha256s(ctx, layout)
 
     out: dict[str, KernelVerification] = {}
 
@@ -1786,7 +1825,12 @@ def run_kernel_verification(
     # Vulkan — recorded report from the bundle if tier includes it.
     if "vulkan" in supported:
         recorded = ctx.bundle_dir / "evals" / "vulkan_verify.json"
-        out["vulkan"] = _read_recorded_report(recorded, "vulkan")
+        out["vulkan"] = _read_recorded_report(
+            recorded,
+            "vulkan",
+            expected_at_commit=sha,
+            model_sha256s=model_sha256s,
+        )
 
     # Metal — hardware-only.
     if "metal" in supported:
@@ -1797,17 +1841,32 @@ def run_kernel_verification(
                 "on a verified host and pass --metal-verification PATH.",
                 EXIT_KERNEL_VERIFY_FAIL,
             )
-        out["metal"] = _read_recorded_report(ctx.metal_verification, "metal")
+        out["metal"] = _read_recorded_report(
+            ctx.metal_verification,
+            "metal",
+            expected_at_commit=sha,
+            model_sha256s=model_sha256s,
+        )
 
     # CUDA — recorded report.
     if "cuda" in supported:
         recorded = ctx.bundle_dir / "evals" / "cuda_verify.json"
-        out["cuda"] = _read_recorded_report(recorded, "cuda")
+        out["cuda"] = _read_recorded_report(
+            recorded,
+            "cuda",
+            expected_at_commit=sha,
+            model_sha256s=model_sha256s,
+        )
 
     # ROCm — recorded report.
     if "rocm" in supported:
         recorded = ctx.bundle_dir / "evals" / "rocm_verify.json"
-        out["rocm"] = _read_recorded_report(recorded, "rocm")
+        out["rocm"] = _read_recorded_report(
+            recorded,
+            "rocm",
+            expected_at_commit=sha,
+            model_sha256s=model_sha256s,
+        )
 
     # Backends not supported by this tier are recorded as skipped, with
     # a stable report name. The manifest validator only enforces "pass"
@@ -2755,7 +2814,7 @@ def run(ctx: PublishContext) -> int:
         release_evidence = validate_release_evidence(ctx, layout)
 
         log.info("[stage 3/7] kernel verification for tier %s", ctx.tier)
-        backends = run_kernel_verification(ctx)
+        backends = run_kernel_verification(ctx, layout)
         for b in SUPPORTED_BACKENDS_BY_TIER[ctx.tier]:
             log.info("  %s: %s (%s)", b, backends[b].status, backends[b].report)
 

--- a/packages/training/scripts/publish/test_orchestrator.py
+++ b/packages/training/scripts/publish/test_orchestrator.py
@@ -40,6 +40,7 @@ from scripts.publish.orchestrator import (  # noqa: E402
     OrchestratorError,
     PublishContext,
     TIER_TAGLINES,
+    _git_short_sha,
     run,
     validate_bundle_layout,
 )
@@ -63,6 +64,19 @@ def _sha256(path: Path) -> str:
     h = hashlib.sha256()
     h.update(path.read_bytes())
     return h.hexdigest()
+
+
+def _test_commit() -> str:
+    return _git_short_sha(_TRAINING_ROOT)
+
+
+def _fixture_text_sha(root: Path) -> str:
+    candidates = sorted(root.rglob("text/eliza-1-*-256k.gguf"))
+    if not candidates:
+        candidates = sorted(root.rglob("text/eliza-1-*-128k.gguf"))
+    if not candidates:
+        raise AssertionError(f"no fixture text GGUF under {root}")
+    return _sha256(candidates[0])
 
 
 def _passing_eval_blob(tier: str = "4b") -> dict[str, Any]:
@@ -212,6 +226,7 @@ def _build_fixture_bundle(
 
     # Evals — aggregate.json (gates input) + per-backend verify reports.
     blob = eval_blob if eval_blob is not None else _passing_eval_blob(tier)
+    commit = _test_commit()
     _write(
         bundle / "evals" / "aggregate.json",
         json.dumps(blob, indent=2),
@@ -330,7 +345,8 @@ def _build_fixture_bundle(
             {
                 "backend": "metal",
                 "status": "pass",
-                "atCommit": "deadbee",
+                "atCommit": commit,
+                "modelSha256": text_sha,
                 "report": "metal_verify.txt",
             }
         ),
@@ -341,7 +357,8 @@ def _build_fixture_bundle(
             {
                 "backend": "cpu",
                 "status": "pass",
-                "atCommit": "deadbee",
+                "atCommit": commit,
+                "modelSha256": text_sha,
                 "report": "cpu_reference.txt",
             }
         ),
@@ -352,7 +369,8 @@ def _build_fixture_bundle(
             {
                 "backend": "vulkan",
                 "status": "pass",
-                "atCommit": "deadbee",
+                "atCommit": commit,
+                "modelSha256": text_sha,
                 "report": "vulkan_verify.txt",
             }
         ),
@@ -363,7 +381,8 @@ def _build_fixture_bundle(
             {
                 "backend": "cuda",
                 "status": "pass",
-                "atCommit": "deadbee",
+                "atCommit": commit,
+                "modelSha256": text_sha,
                 "report": "cuda_verify.txt",
             }
         ),
@@ -374,7 +393,8 @@ def _build_fixture_bundle(
             {
                 "backend": "rocm",
                 "status": "pass",
-                "atCommit": "deadbee",
+                "atCommit": commit,
+                "modelSha256": text_sha,
                 "report": "rocm_verify.txt",
             }
         ),
@@ -593,14 +613,21 @@ def _rewrite_mtp_target_meta(bundle: Path, **updates: Any) -> None:
     path.write_text(json.dumps(data, indent=2) + "\n")
 
 
-def _metal_report(tmp_path: Path, status: str = "pass") -> Path:
+def _metal_report(
+    tmp_path: Path,
+    status: str = "pass",
+    *,
+    at_commit: str | None = None,
+    model_sha256: str | None = None,
+) -> Path:
     p = tmp_path / "metal_verify.json"
     p.write_text(
         json.dumps(
             {
                 "backend": "metal",
                 "status": status,
-                "atCommit": "cafef00",
+                "atCommit": at_commit or _test_commit(),
+                "modelSha256": model_sha256 or _fixture_text_sha(tmp_path),
                 "report": "metal_verify.txt",
             }
         )
@@ -1520,6 +1547,50 @@ def test_failing_kernel_verification_blocks_publish(tmp_path: Path) -> None:
 
     rc = run(_ctx("4b", bundle, metal=metal, dry_run=True))
     assert rc == EXIT_KERNEL_VERIFY_FAIL
+
+
+def test_kernel_verification_rejects_stale_commit_report(tmp_path: Path) -> None:
+    bundle = _build_fixture_bundle(tmp_path)
+    (bundle / "evals" / "vulkan_verify.json").write_text(
+        json.dumps(
+            {
+                "backend": "vulkan",
+                "status": "pass",
+                "atCommit": "0000000",
+                "modelSha256": _fixture_text_sha(bundle),
+                "report": "vulkan_verify.txt",
+            }
+        )
+    )
+    _write_checksums(bundle)
+    metal = _metal_report(tmp_path)
+
+    rc = run(_ctx("4b", bundle, metal=metal, dry_run=True))
+
+    assert rc == EXIT_KERNEL_VERIFY_FAIL
+    assert not (bundle / "eliza-1.manifest.json").is_file()
+
+
+def test_kernel_verification_rejects_swapped_model_report(tmp_path: Path) -> None:
+    bundle = _build_fixture_bundle(tmp_path)
+    (bundle / "evals" / "vulkan_verify.json").write_text(
+        json.dumps(
+            {
+                "backend": "vulkan",
+                "status": "pass",
+                "atCommit": _test_commit(),
+                "modelSha256": "f" * 64,
+                "report": "vulkan_verify.txt",
+            }
+        )
+    )
+    _write_checksums(bundle)
+    metal = _metal_report(tmp_path)
+
+    rc = run(_ctx("4b", bundle, metal=metal, dry_run=True))
+
+    assert rc == EXIT_KERNEL_VERIFY_FAIL
+    assert not (bundle / "eliza-1.manifest.json").is_file()
 
 
 def test_metal_required_but_missing_fails(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- require Stage 2 hardware verification pass reports to match the current training repo commit
- require pass reports to carry a shipped text-GGUF digest via `modelSha256`, `ggufSha256`, or `artifactSha256`
- add regressions for stale-commit and swapped-model verification reports blocking manifest emission

## Evidence
- `.github/issue-evidence/12321-kernel-verify-report-binding.md`

## Verification
```bash
python3 -m pytest packages/training/scripts/publish/test_orchestrator.py -q
python3 -m py_compile packages/training/scripts/publish/orchestrator.py packages/training/scripts/publish/test_orchestrator.py
git diff --check origin/develop..HEAD
```

Screenshots/recordings: N/A, publisher gate only; no UI changed.