### PR TITLE
docs(#12847): clean cloud shared cache churn comments

### DIFF
--- a/packages/cloud/shared/src/lib/cache/__tests__/redis-factory-mock.test.ts
+++ b/packages/cloud/shared/src/lib/cache/__tests__/redis-factory-mock.test.ts
@@ -71,7 +71,7 @@ describe("hasRedisConfig", () => {
     const { hasRedisConfig } = await import("../redis-factory");
     // no config -> false
     expect(hasRedisConfig({})).toBe(false);
-    // TCP REDIS_URL (Railway) -> true  [the B1 fix: was previously Upstash-only]
+    // TCP REDIS_URL (Railway) -> true
     expect(hasRedisConfig({ REDIS_URL: "redis://default:pw@host:6379" })).toBe(true);
     // legacy Upstash REST creds -> true
     expect(

--- a/packages/cloud/shared/src/lib/cache/adapters/memory-cache-adapter.ts
+++ b/packages/cloud/shared/src/lib/cache/adapters/memory-cache-adapter.ts
@@ -147,13 +147,11 @@ export class MemoryCacheAdapter implements CacheRedisClient {
     const keys = [...new Set([...this.values.keys(), ...this.lists.keys()])]
       .filter((key) => pattern.test(key))
       .sort();
-    // Real pagination (the old impl returned only the first `count` keys and
-    // claimed completion — silently dropping the rest). Key-based opaque cursor
-    // ("mem:<lastKey>"): return the next `count` keys that sort strictly AFTER the
-    // cursor key. This is stable under deletion of already-returned keys (the
-    // delPattern case) — an offset cursor would skip keys as the set shrinks. The
-    // token is deliberately NON-numeric so callers can't parseInt it (mirrors
-    // Redis/KV opaque cursors and catches a parse-the-cursor regression).
+    // Real pagination uses a key-based opaque cursor ("mem:<lastKey>"): return
+    // the next `count` keys that sort strictly after the cursor key. This is
+    // stable under deletion of already-returned keys (the delPattern case), where
+    // an offset cursor would skip keys as the set shrinks. The token is
+    // deliberately non-numeric so callers must treat it like Redis/KV cursors.
     const after = cursor === "0" || cursor === 0 ? "" : String(cursor).slice("mem:".length);
     const startIdx = after === "" ? 0 : keys.findIndex((key) => key > after);
     const begin = startIdx < 0 ? keys.length : startIdx;

--- a/packages/cloud/shared/src/lib/cache/cache-scan-pagination.test.ts
+++ b/packages/cloud/shared/src/lib/cache/cache-scan-pagination.test.ts
@@ -2,10 +2,10 @@
  * SCAN pagination — opaque-cursor threading regression guard.
  *
  * scanByPrefix + delPattern must thread the backend's continuation cursor
- * VERBATIM. The old code did `Number.parseInt(cursor)`, which corrupts Cloudflare
- * KV's base64-ish token (and is only accidentally fine on Redis numeric cursors),
- * so KV pagination stopped after the first ~100-key page — the inference-charge
- * sweep leaked stragglers (uncharged) and delPattern left keys behind.
+ * VERBATIM. Cloudflare KV returns a base64-ish token that is not parseable as a
+ * number, while Redis numeric cursors are only one backend shape. Cursor
+ * corruption stops KV pagination after the first ~100-key page, leaking
+ * inference-charge stragglers and leaving delPattern keys behind.
  *
  * The MemoryCacheAdapter now emits a deliberately NON-numeric ("mem:<offset>")
  * cursor, so a memory-backed CacheClient exercises the multi-page path and any

--- a/packages/cloud/shared/src/lib/cache/client.ts
+++ b/packages/cloud/shared/src/lib/cache/client.ts
@@ -778,9 +778,9 @@ export class CacheClient {
 
     const start = Date.now();
     // Thread the cursor as an opaque string. Cloudflare KV returns a base64-ish
-    // continuation token (and "0" when complete); parsing it as a number (the old
-    // behavior) corrupted it, so KV pagination stopped after the first page and
-    // pattern deletes silently left every key beyond the first batch behind.
+    // continuation token (and "0" when complete); numeric parsing corrupts that
+    // token, stops KV pagination after the first page, and leaves every key
+    // beyond the first pattern-delete batch behind.
     let cursor: string | number = "0";
     let totalDeleted = 0;
     let iterations = 0;

--- a/packages/cloud/shared/src/lib/cache/keys.ts
+++ b/packages/cloud/shared/src/lib/cache/keys.ts
@@ -225,26 +225,26 @@ export const CacheKeys = {
  */
 export const CacheTTL = {
   org: {
-    data: 300, // 5 minutes (was 60s)
-    credits: 60, // 1 minute (was 15s)
-    dashboard: 300, // 5 minutes (was 90s) - stale after 180s
+    data: 300, // 5 minutes
+    credits: 60, // 1 minute
+    dashboard: 300, // 5 minutes - stale after 180s
   },
   analytics: {
     overview: {
-      daily: 300, // 5 minutes (was 120s)
-      weekly: 600, // 10 minutes (was 180s)
-      monthly: 1800, // 30 minutes (was 300s)
+      daily: 300, // 5 minutes
+      weekly: 600, // 10 minutes
+      monthly: 1800, // 30 minutes
     },
-    breakdown: 600, // 10 minutes (was 180s)
-    stats: 600, // 10 minutes (was 300s)
-    userBreakdown: 1800, // 30 minutes (was 600s)
-    projections: 600, // 10 minutes (was 300s)
-    timeSeries: 600, // 10 minutes (was 180s)
-    providerBreakdown: 600, // 10 minutes (was 180s)
-    modelBreakdown: 600, // 10 minutes (was 180s)
+    breakdown: 600, // 10 minutes
+    stats: 600, // 10 minutes
+    userBreakdown: 1800, // 30 minutes
+    projections: 600, // 10 minutes
+    timeSeries: 600, // 10 minutes
+    providerBreakdown: 600, // 10 minutes
+    modelBreakdown: 600, // 10 minutes
   },
   apiKey: {
-    validation: 600, // 10 minutes (was 300s)
+    validation: 600, // 10 minutes
     appMapping: 600, // 10 minutes - app-to-API-key mapping rarely changes
   },
   /**
@@ -277,7 +277,7 @@ export const CacheTTL = {
   },
   user: {
     byId: 600, // 10 minutes
-    byEmail: 600, // 10 minutes (was 300s)
+    byEmail: 600, // 10 minutes
     byStewardId: 600,
     withOrg: 600,
     byEmailWithOrg: 600,
@@ -289,7 +289,7 @@ export const CacheTTL = {
     resolve: 300, // 5 minutes
   },
   memory: {
-    item: 1440, // 24 minutes (unchanged - memory is critical)
+    item: 1440, // 24 minutes - memory is critical
     roomRecent: 300, // 5 minutes
     roomContext: 300, // 5 minutes
     conversationContext: 300, // 5 minutes
@@ -307,8 +307,8 @@ export const CacheTTL = {
     agentStats: 300, // 5 minutes
   },
   container: {
-    list: 60, // 1 minute (was 30s)
-    logs: 60, // 1 minute (was 30s)
+    list: 60, // 1 minute
+    logs: 60, // 1 minute
     metrics: 300, // 5 minutes
   },
   eliza: {

--- a/packages/cloud/shared/src/lib/cache/socket-redis-resilience.test.ts
+++ b/packages/cloud/shared/src/lib/cache/socket-redis-resilience.test.ts
@@ -55,8 +55,8 @@ describe("SocketRedis connection resilience", () => {
     const server = createServer((socket: NetSocket) => {
       connections += 1;
       if (connections === 1) {
-        // First connection dies as soon as the client speaks — a socket
-        // error, NOT a timeout (the path that previously never closed).
+        // First connection dies as soon as the client speaks: this is a socket
+        // error, not a timeout, and must close the poisoned connection.
         socket.once("data", () => socket.destroy());
         return;
       }

--- a/packages/cloud/shared/src/lib/cache/socket-redis.ts
+++ b/packages/cloud/shared/src/lib/cache/socket-redis.ts
@@ -310,7 +310,7 @@ class Connection {
         // context. Drop the connection so the next call reconnects instead of
         // reusing a poisoned socket for the isolate's lifetime. Guard on the
         // generation: if a queued caller already reconnected, this failure
-        // belongs to the OLD socket and must not tear down the new one.
+        // belongs to the previous socket and must not tear down the current one.
         if (opGeneration === -1 || opGeneration === this.generation) {
           await this.close().catch(() => {});
         }


### PR DESCRIPTION
Fixes #12847.

## Summary

Churn-only comment cleanup in `packages/cloud/shared/src/lib/cache`. Rewrites stale diff-history phrasing into present-tense rationale and removes obsolete "was before" annotations without changing code, string/template literals, exports, or behavior.

## Validation

- `bun run check:comment-only`
  - `[assert-comment-only-diff] OK — 7 source file(s) changed; every code token identical to origin/develop. Comments only.`
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/cache/__tests__/redis-factory-mock.test.ts packages/cloud/shared/src/lib/cache/adapters/memory-cache-adapter.ts packages/cloud/shared/src/lib/cache/cache-scan-pagination.test.ts packages/cloud/shared/src/lib/cache/client.ts packages/cloud/shared/src/lib/cache/keys.ts packages/cloud/shared/src/lib/cache/socket-redis-resilience.test.ts packages/cloud/shared/src/lib/cache/socket-redis.ts`
  - `Checked 7 files ... No fixes applied.`
- `git diff --check origin/develop...HEAD`
- `git diff --stat origin/develop...HEAD`
  - 7 files changed, 34 insertions(+), 36 deletions(-)

## Evidence matrix

- Real-LLM trajectories: N/A - comments-only change, no agent/model/prompt behavior.
- UI screenshots/video: N/A - comments-only change, no rendered UI.
- Backend logs/domain artifacts: N/A - comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
