### PR TITLE
fix(#12259): guard unsupported bun lockfile versions

### DIFF
--- a/.github/issue-evidence/12259-bun-lockfile-guard.md
+++ b/.github/issue-evidence/12259-bun-lockfile-guard.md
@@ -1,0 +1,40 @@
+# Issue #12259 - Bun lockfile version guard
+
+PR scope:
+
+- `packages/scripts/run-turbo.mjs` now parses `bun.lock` before spawning
+  Turbo and fails loudly when `lockfileVersion` exceeds the version supported by
+  the pinned Turbo parser.
+- The old Bun lockfile warning filter was removed; Turbo output now passes
+  through directly instead of hiding lockfile parser warnings.
+- `packages/scripts/run-turbo.self-test.mjs` proves a synthetic
+  `lockfileVersion: 1` passes and `lockfileVersion: 2` fails with the Turbo/Bun
+  compatibility pointer.
+
+Local verification on 2026-07-04:
+
+```bash
+node --check packages/scripts/run-turbo.mjs
+node --check packages/scripts/run-turbo.self-test.mjs
+node packages/scripts/run-turbo.self-test.mjs
+# run-turbo self-test passed
+
+RUN_TURBO_LOCKFILE_CHECK_ONLY=1 \
+  node packages/scripts/run-turbo.mjs run build --dry=json
+
+git diff --check
+```
+
+Attempted full Turbo dry run:
+
+```bash
+node packages/scripts/run-turbo.mjs run build --dry=json \
+  --filter=__run_turbo_lockfile_no_match__
+```
+
+Result: not run in this auxiliary worktree because no ancestor
+`node_modules/turbo` exists. The wrapper failed before Turbo spawn with the
+expected "Unable to find turbo" message. The lockfile guard path itself was
+verified with `RUN_TURBO_LOCKFILE_CHECK_ONLY=1`.
+
+Screenshots/recordings: N/A, CLI guard only; no UI changed.

--- a/packages/scripts/run-turbo.mjs
+++ b/packages/scripts/run-turbo.mjs
@@ -9,6 +9,52 @@ const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../..",
 );
+const maxSupportedBunLockfileVersion = 1;
+
+function bunLockfilePath() {
+  return process.env.RUN_TURBO_BUN_LOCKFILE
+    ? path.resolve(process.env.RUN_TURBO_BUN_LOCKFILE)
+    : path.join(repoRoot, "bun.lock");
+}
+
+function readBunLockfileVersion(lockfile) {
+  if (!fs.existsSync(lockfile)) return null;
+  const source = fs.readFileSync(lockfile, "utf8");
+  const match = source.match(/"lockfileVersion"\s*:\s*(\d+)/);
+  if (!match) {
+    throw new Error(
+      `${lockfile} does not contain a parseable "lockfileVersion" field.`,
+    );
+  }
+  return Number.parseInt(match[1], 10);
+}
+
+function assertSupportedBunLockfile() {
+  const lockfile = bunLockfilePath();
+  const version = readBunLockfileVersion(lockfile);
+  if (version === null) return;
+  if (version <= maxSupportedBunLockfileVersion) return;
+
+  throw new Error(
+    [
+      `Unsupported bun.lock lockfileVersion ${version} in ${lockfile}.`,
+      `This repo currently allows lockfileVersion <= ${maxSupportedBunLockfileVersion} because the pinned Turbo cannot parse newer Bun lockfiles for per-package dependency hashing.`,
+      "Regenerate bun.lock with a supported Bun version or update Turbo plus this guard together.",
+      "Context: https://github.com/vercel/turborepo/discussions/13126",
+    ].join("\n"),
+  );
+}
+
+try {
+  assertSupportedBunLockfile();
+} catch (error) {
+  console.error(`[run-turbo] ${error.message}`);
+  process.exit(1);
+}
+
+if (process.env.RUN_TURBO_LOCKFILE_CHECK_ONLY === "1") {
+  process.exit(0);
+}
 
 // Every `node_modules` from repoRoot up to the filesystem root. A git worktree
 // (e.g. `.claude/worktrees/<name>`) has no `node_modules` of its own and shares
@@ -74,46 +120,12 @@ try {
   child = spawn(turboCommand, turboCommandArgs, {
     cwd: process.cwd(),
     env: process.env,
-    stdio: ["inherit", "pipe", "pipe"],
+    stdio: "inherit",
   });
 } catch (error) {
   console.error(`Failed to start turbo: ${error.message}`);
   process.exit(1);
 }
-
-const warningStart = "An issue occurred while attempting to parse";
-
-function filterKnownBunLockWarning(stream, output) {
-  let pending = "";
-  let skipping = 0;
-
-  stream.on("data", (chunk) => {
-    pending += chunk.toString();
-    const lines = pending.split(/\r?\n/);
-    pending = lines.pop() ?? "";
-
-    for (const line of lines) {
-      if (line.includes(warningStart) && line.includes("bun.lock")) {
-        skipping = 3;
-        continue;
-      }
-      if (skipping > 0) {
-        skipping -= 1;
-        continue;
-      }
-      output.write(`${line}\n`);
-    }
-  });
-
-  stream.on("end", () => {
-    if (pending && skipping === 0 && !pending.includes(warningStart)) {
-      output.write(pending);
-    }
-  });
-}
-
-filterKnownBunLockWarning(child.stdout, process.stdout);
-filterKnownBunLockWarning(child.stderr, process.stderr);
 
 child.on("exit", (code, signal) => {
   if (signal) {

--- a/packages/scripts/run-turbo.self-test.mjs
+++ b/packages/scripts/run-turbo.self-test.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Self-test for run-turbo.mjs lockfile-version preflight.
+ *
+ * Turbo's Bun lock parser is part of cache correctness: unsupported lockfile
+ * versions must fail before a Turbo run can silently fall back to coarse
+ * invalidation.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const script = fileURLToPath(new URL("./run-turbo.mjs", import.meta.url));
+
+function makeLockfile(version) {
+  const dir = mkdtempSync(join(tmpdir(), "run-turbo-lock-"));
+  const lockfile = join(dir, "bun.lock");
+  writeFileSync(
+    lockfile,
+    JSON.stringify({ lockfileVersion: version, workspaces: {} }, null, 2),
+  );
+  return { dir, lockfile };
+}
+
+function runWithLockfile(version) {
+  const { dir, lockfile } = makeLockfile(version);
+  try {
+    return spawnSync(process.execPath, [script, "run", "build", "--dry=json"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        RUN_TURBO_BUN_LOCKFILE: lockfile,
+        RUN_TURBO_LOCKFILE_CHECK_ONLY: "1",
+      },
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`assertion failed: ${message}`);
+}
+
+{
+  const result = runWithLockfile(1);
+  assert(
+    result.status === 0,
+    `lockfileVersion 1 should pass, got ${result.status}: ${result.stderr}`,
+  );
+}
+
+{
+  const result = runWithLockfile(2);
+  assert(result.status === 1, "lockfileVersion 2 should fail");
+  assert(
+    result.stderr.includes("Unsupported bun.lock lockfileVersion 2"),
+    `expected unsupported-version error, got ${result.stderr}`,
+  );
+  assert(
+    result.stderr.includes("turborepo/discussions/13126"),
+    "error should point to the Turbo/Bun lockfile compatibility discussion",
+  );
+}
+
+console.log("run-turbo self-test passed");


### PR DESCRIPTION
## Summary
- add a preflight in `run-turbo.mjs` that rejects unsupported `bun.lock` `lockfileVersion` values before Turbo starts
- remove the old Bun-lock warning filter so Turbo parser warnings are no longer hidden
- add `run-turbo.self-test.mjs` covering synthetic v1 pass and v2 fail cases

## Evidence
- `.github/issue-evidence/12259-bun-lockfile-guard.md`

## Verification
```bash
node --check packages/scripts/run-turbo.mjs
node --check packages/scripts/run-turbo.self-test.mjs
node packages/scripts/run-turbo.self-test.mjs
RUN_TURBO_LOCKFILE_CHECK_ONLY=1 node packages/scripts/run-turbo.mjs run build --dry=json
git diff --check origin/develop..HEAD
```

Full Turbo dry-run note: not available in the auxiliary worktree because no ancestor `node_modules/turbo` exists; the guard path is verified with `RUN_TURBO_LOCKFILE_CHECK_ONLY=1` and CI will exercise the wrapper with installed dependencies.

Screenshots/recordings: N/A, CLI guard only; no UI changed.