### PR TITLE
docs(#12844): add cloud routing tail headers

### DIFF
--- a/packages/cloud/docs-redirect/src/worker.test.ts
+++ b/packages/cloud/docs-redirect/src/worker.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Deterministic redirect tests for the legacy Eliza Cloud docs Worker.
+ *
+ * The harness calls the Worker fetch handler directly with synthetic Requests;
+ * no Cloudflare account, DNS, or network access is required.
+ */
+
 import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import worker from "./worker";

--- a/packages/cloud/docs-redirect/src/worker.ts
+++ b/packages/cloud/docs-redirect/src/worker.ts
@@ -1,13 +1,10 @@
-// Permanent redirect from the legacy Eliza Cloud docs hostname
-// (docs.elizacloud.ai) to the unified docs site at docs.elizaos.ai/cloud.
-//
-// Path and query are preserved:
-//   docs.elizacloud.ai/quickstart        -> docs.elizaos.ai/cloud/quickstart
-//   docs.elizacloud.ai/api/agents?x=1    -> docs.elizaos.ai/cloud/api/agents?x=1
-//   docs.elizacloud.ai/                  -> docs.elizaos.ai/cloud
-//
-// The /docs prefix that old elizacloud.ai/docs/* URLs carried is stripped if
-// present, since the new hostname does not use that prefix.
+/**
+ * Permanent redirect Worker from the legacy Eliza Cloud docs hostname to the
+ * unified docs site at docs.elizaos.ai/cloud.
+ *
+ * Path and query are preserved. A legacy `/docs` prefix is stripped because the
+ * canonical cloud docs hostname does not use that path segment.
+ */
 
 const TARGET_ORIGIN = "https://docs.elizaos.ai";
 const TARGET_PREFIX = "/cloud";

--- a/packages/cloud/routing/src/features.ts
+++ b/packages/cloud/routing/src/features.ts
@@ -1,3 +1,10 @@
+/**
+ * Feature registry for cloud-routing policy decisions.
+ *
+ * Each entry maps a routable capability to its per-agent setting key. Resolver
+ * helpers derive the public feature union and policy map from this table.
+ */
+
 export const FEATURE_POLICIES = ["local", "cloud", "auto"] as const;
 export type FeaturePolicy = (typeof FEATURE_POLICIES)[number];
 

--- a/packages/cloud/routing/src/index.ts
+++ b/packages/cloud/routing/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Public surface for cloud-routing feature metadata and route resolution.
+ */
+
 export {
   DEFAULT_FEATURE_POLICY,
   FEATURE_IDS,

--- a/packages/cloud/routing/src/resolve.test.ts
+++ b/packages/cloud/routing/src/resolve.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Deterministic unit and property tests for cloud-routing policy resolution.
+ *
+ * The harness uses in-memory runtime settings only; no network, cloud account,
+ * or live provider is required.
+ */
+
 import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import {

--- a/packages/cloud/routing/src/resolve.ts
+++ b/packages/cloud/routing/src/resolve.ts
@@ -1,3 +1,10 @@
+/**
+ * Cloud route resolver for local-key, cloud-proxy, and disabled service access.
+ *
+ * The resolver reads settings at call time, validates caller-provided service
+ * names and base URLs, and never performs network I/O.
+ */
+
 import {
   DEFAULT_FEATURE_POLICY,
   FEATURE_IDS,

--- a/packages/cloud/routing/src/types.ts
+++ b/packages/cloud/routing/src/types.ts
@@ -1,3 +1,7 @@
+/**
+ * Route result contracts shared by cloud-routing consumers.
+ */
+
 import type { FeaturePolicy } from "./features.js";
 
 export type CloudRouteSource = "local-key" | "cloud-proxy" | "disabled";


### PR DESCRIPTION
## Summary
- add required prose headers to the five `packages/cloud/routing/src` TypeScript source files called out by the B07-D tail audit
- convert the docs redirect Worker's line-comment opener to the required top `/** ... */` prose header
- add the missing deterministic harness header to the docs redirect Worker test

Refs #12844.

## Verification
- PASS: `bun run check:comment-only` (`7 source file(s) changed; every code token identical to origin/develop`)
- PASS: `bunx @biomejs/biome check packages/cloud/routing/src/features.ts packages/cloud/routing/src/index.ts packages/cloud/routing/src/resolve.test.ts packages/cloud/routing/src/resolve.ts packages/cloud/routing/src/types.ts packages/cloud/docs-redirect/src/worker.test.ts packages/cloud/docs-redirect/src/worker.ts`
- PASS: `bun run --cwd packages/cloud/routing test` (1 file / 61 tests)
- PASS: `bun run --cwd packages/cloud/docs-redirect test` (1 file / 6 tests)
- PASS: `git diff --check origin/develop...HEAD`

## Verify limitation
- `bun run verify` was attempted twice during the surrounding comment-only sweep and failed outside this change at `@elizaos/cloud-shared:typecheck`: missing declarations for `drizzle-orm*` resolved through `dist/node_modules`, followed by implicit-any errors in `plugins/plugin-sql/src/schema/*`. This branch is comment-only and the scoped verifier proves zero functional token changes.

## Evidence
- N/A - trajectories/screenshots/video/audio/domain artifacts: comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
