### PR TITLE
test(ui): home-screen e2e stub registers hyperliquid with group:"wallet" (fixture drift from #12521)

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.views-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.views-stub.ts
@@ -116,7 +116,14 @@ export function useRoutableViews() {
       builtinView("chat", "Chat", "/chat"),
       builtinView("views", "Views", "/views"),
       builtinView("shopify", "Shopify", "/shopify", "ShoppingBag", true),
-      builtinView("hyperliquid", "Hyperliquid", "/hyperliquid", "TrendingUp", true),
+      // Wallet sub-page: the real plugin-hyperliquid registration carries
+      // `group: "wallet"`, which is what launcher curation keys on to fold it
+      // under the single Wallet tile (#12521) — mirror it here so the e2e
+      // exercises the real group-based hide, not the removed id blocklist.
+      {
+        ...builtinView("hyperliquid", "Hyperliquid", "/hyperliquid", "TrendingUp", true),
+        group: "wallet",
+      },
       // Page 1 — everyday apps (curated order is enforced by launcher-curation).
       builtinView("wallet", "Wallet", "/wallet", "Wallet", true, heroDataUri(28, "wallet")),
       // Duplicate wallet registration — must collapse to the single Wallet tile.


### PR DESCRIPTION
## Problem

On the develop tip, the home-screen e2e lane fails:

```
✗ "hyperliquid" is absent from the launcher (removed/hidden/deduped)
```

## Root cause — stale fixture, not a product bug

PR #12521 (64fd033a3b) replaced the launcher curation's `hyperliquid`/`polymarket` id blocklist with the group-based wallet sub-page hide: `isGroupedLauncherSubPage` in `packages/ui/src/components/pages/launcher-curation.ts` drops entries with `group: "wallet"` whose canonical id isn't `wallet`. The real registration carries that group (`plugins/plugin-hyperliquid/src/plugin.ts:148`), so the shipped launcher correctly folds Hyperliquid under the Wallet tile.

The home-screen e2e views stub (`home-screen-fixture.views-stub.ts`) still registered hyperliquid **without** the group, so curation no longer dropped the fixture entry and the absence assertion failed. Product behavior verified correct; only the fixture drifted.

## Fix

Register the stub's hyperliquid entry with `group: "wallet"`, mirroring the real plugin registration, so the e2e exercises the actual group-based hide instead of the removed blocklist. One file, fixture-only.

## Evidence

Before (develop tip 8d988af151):
```
✗ "hyperliquid" is absent from the launcher (removed/hidden/deduped)
HOME-SCREEN E2E FAILED (2)
```

After (this branch):
```
✓ "hyperliquid" is absent from the launcher (removed/hidden/deduped)
✓ duplicate wallet registrations collapse to one tile
```

- `bun run --cwd packages/ui typecheck` → exit 0.
- The one remaining red in the lane is the pre-existing rail-swipe frame-budget perf gate, load-sensitive and unrelated to this fixture — filed as #12914 rather than silently loosening a perf budget.
- Screenshots/video/trajectories: N/A — test-fixture-only change, no product code or rendered surface touched (the lane's own screenshots regenerate byte-identical launcher content minus nothing; product launcher behavior unchanged and already covered by `launcher-curation.test.ts` from #12521).

— nubs-cloud [cloud-frontdoor]