### PR TITLE
fix(cloud): gate /v1/chat/completions optimistic billing off affiliate-marked requests — close the #12749 cashable mint on the main route

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-affiliate-reserve.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-affiliate-reserve.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Guard tests for #12749 — /v1/chat/completions must fail closed (402) when a
+ * caller can afford the base cost but NOT base + affiliate markup.
+ *
+ * #11976 threaded `affiliateCode` into the synchronous reserveCredits
+ * (`estimatedCostMultiplier = 1 + markup`), so the upfront hold covers the
+ * attacker-set markup (up to 1000%) and the later cashable affiliate credit is
+ * always backed by money the platform actually collected. #12749 routes every
+ * affiliate-marked request onto that synchronous reserve (the optimistic
+ * fast paths are gated off by `affiliateCode === null`); these tests pin the
+ * money invariant of that fallback on THIS route: the marked-up hold is
+ * attempted and, when the balance can't cover it, the request is 402'd before
+ * the model call — no settle, no mint.
+ *
+ * They drive the REAL `handleChatCompletionsPOST` + the REAL reserveCredits
+ * from ai-billing (affiliate resolution and multiplier math run for real).
+ * Only the deep boundaries are stubbed: auth, provider config, pricing's
+ * calculateCost (deterministic $0.10 base), the affiliate lookup, the credits
+ * ledger reserve (reproducing credits.ts's hold arithmetic + fail-closed
+ * InsufficientCreditsError), the earnings writer, and the model call (which
+ * throws, because the 402 gate — not the settle — is the observation point).
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as affiliatesActual from "@/db/repositories/affiliates";
+import * as pricingActual from "@/lib/pricing";
+import * as languageModelActual from "@/lib/providers/language-model";
+import * as contentModerationActual from "@/lib/services/content-moderation";
+import * as creditsActual from "@/lib/services/credits";
+import * as inferenceAuthContextActual from "@/lib/services/inference-auth-context";
+import * as modelCatalogActual from "@/lib/services/model-catalog";
+import * as redeemableEarningsActual from "@/lib/services/redeemable-earnings";
+import * as teamPoolActual from "@/lib/services/team-credential-pool";
+import * as creditReservationActual from "@/lib/utils/credit-reservation";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+// Force the synchronous-reserve path (the one #12749 falls back to): optimistic
+// billing off, no DB ledger.
+process.env.INFERENCE_OPTIMISTIC_BILLING = "";
+process.env.INFERENCE_BILLING_LEDGER = "";
+delete process.env.CREDIT_COST_BUFFER; // default 1.5, mirrored by the stub
+
+const aiActual = require("ai") as Record<string, unknown>;
+
+const ORG = "00000000-0000-4000-8000-0000000000aa";
+const USER = "00000000-0000-4000-8000-0000000000bb";
+const API_KEY_ID = "00000000-0000-4000-8000-0000000000cc";
+const AFFILIATE_USER = "00000000-0000-4000-8000-00000000aff1";
+
+const BASE_COST = 0.1; // deterministic base+platform cost from calculateCost
+const COST_BUFFER = 1.5; // credits.ts default (CREDIT_COST_BUFFER unset)
+
+// NOTE: this file needs the REAL ai-billing (reserveCredits →
+// resolveBillableAffiliate → multiplier math) — it is the code under test
+// together with the route's reserve context. It therefore must run in its own
+// process (the canonical `test/run-unit-isolated.mjs` lane does this): bun's
+// top-level mock.module is process-global with no working per-file restore, so
+// a sibling suite that mocks reserveCredits (chat-completions-optimistic-
+// billing.test.ts) would leak its stub into this file if both shared a process.
+
+// Auth: resolve straight to an authorized org user via the hot-path resolver so
+// the org-credits branch (not app-credits) is taken and moderation is skipped.
+mock.module("@/lib/services/inference-auth-context", () => ({
+  ...inferenceAuthContextActual,
+  isInferenceHotPathCacheEnabled: () => true,
+  resolveInferenceAuthContext: async () => ({
+    kind: "authorized",
+    ctx: { userId: USER, orgId: ORG, apiKeyId: API_KEY_ID },
+  }),
+}));
+
+// Provider config: pretend a provider is configured; the model object is unused
+// because the model call is stubbed.
+mock.module("@/lib/providers/language-model", () => ({
+  ...languageModelActual,
+  hasLanguageModelProviderConfigured: () => true,
+  getLanguageModel: () => ({}) as never,
+}));
+
+// Deterministic pricing so the affiliate math is exact.
+mock.module("@/lib/pricing", () => ({
+  ...pricingActual,
+  calculateCost: async () => ({
+    totalCost: BASE_COST,
+    inputCost: BASE_COST,
+    outputCost: 0,
+  }),
+}));
+
+// Pooled-credential selection is not under test — and it is the ONLY real DB
+// query on this path. Stubbing it keeps PGlite from ever booting: under bun
+// test, PGlite's Emscripten runtime sets process.exitCode = 99 as a side
+// effect of initializing, which makes the file's process exit non-zero even
+// with every test green (the isolated runner then reports it FAILED).
+mock.module("@/lib/services/team-credential-pool", () => ({
+  ...teamPoolActual,
+  getTeamPoolRegistry: () => ({
+    selectCredential: async () => null,
+    recordUse: async () => undefined,
+    recordProviderFailure: async () => undefined,
+  }),
+}));
+
+// Reasoning-detection catalog read is best-effort; make it a no-op miss.
+mock.module("@/lib/services/model-catalog", () => ({
+  ...modelCatalogActual,
+  getCachedGatewayModelById: async () => null,
+}));
+
+// Moderation: not under test.
+mock.module("@/lib/services/content-moderation", () => ({
+  ...contentModerationActual,
+  contentModerationService: {
+    ...contentModerationActual.contentModerationService,
+    shouldBlockUser: async () => false,
+    moderateInBackground: () => {},
+  },
+}));
+
+// Affiliate lookup: attacker-set 1000% markup owned by AFFILIATE_USER.
+const getAffiliateCodeByCode = mock(async () => ({
+  id: "aff-code-1",
+  user_id: AFFILIATE_USER,
+  markup_percent: "1000",
+  is_active: true,
+}));
+mock.module("@/db/repositories/affiliates", () => ({
+  ...affiliatesActual,
+  affiliatesRepository: new Proxy(affiliatesActual.affiliatesRepository, {
+    get: (target, prop, receiver) =>
+      prop === "getAffiliateCodeByCode"
+        ? getAffiliateCodeByCode
+        : Reflect.get(target, prop, receiver),
+  }),
+}));
+
+// Credits ledger: reserve stub reproducing the REAL hold arithmetic
+// (credits.ts reserve(): estimatedCost × estimatedCostMultiplier, buffered by
+// COST_BUFFER, thrown InsufficientCreditsError when the org balance can't
+// cover the hold) so the hold AND the 402 gate are faithful to prod.
+let orgBalanceUsd = Number.POSITIVE_INFINITY;
+const reconcile = mock(async (_actualCost: number) => undefined);
+const reserve = mock(
+  async (
+    params: { estimatedCostMultiplier?: number } & Record<string, unknown>,
+  ) => {
+    const multiplier = params.estimatedCostMultiplier ?? 1;
+    const hold = BASE_COST * multiplier * COST_BUFFER;
+    if (hold > orgBalanceUsd) {
+      // The REAL class the route's instanceof checks against (credits.ts,
+      // re-exported by ai-billing) — mirrors credits.ts reserve() fail-closed.
+      throw new creditsActual.InsufficientCreditsError(hold, orgBalanceUsd);
+    }
+    return {
+      reservedAmount: hold,
+      reservationTransactionId: "reservation-1",
+      reconcile,
+    };
+  },
+);
+mock.module("@/lib/services/credits", () => ({
+  ...creditsActual,
+  creditsService: new Proxy(creditsActual.creditsService, {
+    get: (target, prop, receiver) =>
+      prop === "reserve" ? reserve : Reflect.get(target, prop, receiver),
+  }),
+}));
+
+// The cashable write that must never happen on a 402'd request.
+const addEarnings = mock(async (_params: Record<string, unknown>) => ({
+  ledgerId: "ledger-1",
+}));
+mock.module("@/lib/services/redeemable-earnings", () => ({
+  ...redeemableEarningsActual,
+  redeemableEarningsService: new Proxy(
+    redeemableEarningsActual.redeemableEarningsService,
+    {
+      get: (target, prop, receiver) =>
+        prop === "addEarnings"
+          ? addEarnings
+          : Reflect.get(target, prop, receiver),
+    },
+  ),
+}));
+
+// Settler factory for the reserve path — stub to a no-op so the post-response
+// settle in the catch block needs no ledger (the 402 gate is the observation
+// point, not the settle).
+const createCreditReservationSettler = mock(() => async () => null);
+mock.module("@/lib/utils/credit-reservation", () => ({
+  ...creditReservationActual,
+  createCreditReservationSettler,
+}));
+
+// Stub the model call so the positive control returns right after the billing
+// decision; the attack request must 402 BEFORE ever reaching it.
+const generateText = mock(() => {
+  throw new Error("model-call-stub");
+});
+mock.module("ai", () => ({
+  ...aiActual,
+  generateText,
+  streamText: () => {
+    throw new Error("model-call-stub");
+  },
+}));
+
+// Import the route AFTER the mocks. ai-billing (reserveCredits,
+// resolveBillableAffiliate, the multiplier math) is REAL — it is the code under
+// test together with the route's reserve context.
+const { handleChatCompletionsPOST } = await import(
+  "../v1/chat/completions/route"
+);
+
+afterAll(() => {
+  // Leave the knob fail-safe BEFORE restoring the modules: bun's mock.module
+  // can leave already-evaluated importers bound to these closures, which read
+  // the knob by reference (see embeddings-optimistic-billing.test.ts).
+  orgBalanceUsd = Number.POSITIVE_INFINITY;
+  mock.module(
+    "@/lib/services/inference-auth-context",
+    () => inferenceAuthContextActual,
+  );
+  mock.module("@/lib/providers/language-model", () => languageModelActual);
+  mock.module("@/lib/pricing", () => pricingActual);
+  mock.module("@/lib/services/model-catalog", () => modelCatalogActual);
+  mock.module(
+    "@/lib/services/content-moderation",
+    () => contentModerationActual,
+  );
+  mock.module("@/db/repositories/affiliates", () => affiliatesActual);
+  mock.module("@/lib/services/credits", () => creditsActual);
+  mock.module(
+    "@/lib/services/redeemable-earnings",
+    () => redeemableEarningsActual,
+  );
+  mock.module("@/lib/services/team-credential-pool", () => teamPoolActual);
+  mock.module("@/lib/utils/credit-reservation", () => creditReservationActual);
+  mock.module("ai", () => aiActual);
+});
+
+function makeRequest(affiliateCode?: string): Request {
+  return new Request("https://api.test/api/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(affiliateCode ? { "X-Affiliate-Code": affiliateCode } : {}),
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      messages: [{ role: "user", content: "hello" }],
+      stream: false,
+    }),
+  });
+}
+
+beforeEach(() => {
+  orgBalanceUsd = Number.POSITIVE_INFINITY;
+  getAffiliateCodeByCode.mockClear();
+  reserve.mockClear();
+  reconcile.mockClear();
+  addEarnings.mockClear();
+  createCreditReservationSettler.mockClear();
+  generateText.mockClear();
+});
+
+// The first request through the handler pays a multi-second one-off init cost
+// (PGlite boot via the TeamPoolRegistry lookup), so both tests get a generous
+// timeout — a timed-out first test would leak its in-flight request into the
+// second one's spy counts.
+const TEST_TIMEOUT_MS = 30_000;
+
+describe("POST /api/v1/chat/completions — affiliate markup is reserved upfront (#12749)", () => {
+  test(
+    "X-Affiliate-Code folds the 1000% markup into the synchronous hold",
+    async () => {
+      const res = await handleChatCompletionsPOST(makeRequest("PARTNER1000"), {
+        skipOrgRateLimit: true,
+      });
+      // The stubbed model call makes this an error response — the reserve args
+      // are the observation point, not the status.
+      expect(res.status).not.toBe(402);
+
+      expect(reserve).toHaveBeenCalledTimes(1);
+      const reserveArg = reserve.mock.calls[0][0] as {
+        organizationId: string;
+        estimatedCostMultiplier?: number;
+      };
+      expect(reserveArg.organizationId).toBe(ORG);
+      expect(reserveArg.estimatedCostMultiplier).toBeCloseTo(11, 6); // 1 + 1000%
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  test(
+    "caller who can afford base but NOT base+markup is 402'd upfront — no model call, no settle, no mint",
+    async () => {
+      // $0.20 covers the base hold ($0.10 × 1.5 = $0.15) but NOT the marked-up
+      // hold ($0.10 × 11 × 1.5 = $1.65). Pre-#11976/#12749 this request would
+      // proceed and settle a marked-up charge against a base-only hold while
+      // minting the uncollectable delta as cashable earnings.
+      orgBalanceUsd = 0.2;
+
+      // Positive control: WITHOUT the affiliate header the same balance passes
+      // the reserve gate (no multiplier on the hold).
+      const controlRes = await handleChatCompletionsPOST(makeRequest(), {
+        skipOrgRateLimit: true,
+      });
+      expect(controlRes.status).not.toBe(402);
+      expect(reserve).toHaveBeenCalledTimes(1);
+      const controlArg = reserve.mock.calls[0][0] as {
+        estimatedCostMultiplier?: number;
+      };
+      expect(controlArg.estimatedCostMultiplier).toBeUndefined();
+
+      reserve.mockClear();
+      reconcile.mockClear();
+      addEarnings.mockClear();
+      generateText.mockClear();
+
+      // The attack request: base affordable, base+markup not → fail-closed 402
+      // BEFORE the model call, so nothing settles and nothing is minted.
+      const res = await handleChatCompletionsPOST(makeRequest("PARTNER1000"), {
+        skipOrgRateLimit: true,
+      });
+      expect(res.status).toBe(402);
+      const body = (await res.json()) as { error: { type: string } };
+      expect(body.error.type).toBe("insufficient_quota");
+
+      expect(reserve).toHaveBeenCalledTimes(1); // the marked-up reserve attempt
+      expect(generateText).not.toHaveBeenCalled();
+      expect(reconcile).not.toHaveBeenCalled();
+      expect(addEarnings).not.toHaveBeenCalled();
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
@@ -30,6 +30,10 @@
  *   4. Flag OFF → synchronous reserve (default-safe).
  *   5. Non-durable backstop write → fall back to synchronous reserve (backstop
  *      attempted, optimistic settler NOT wired).
+ *   6. X-Affiliate-Code bypasses BOTH optimistic branches (KV backstop and
+ *      DB-ledger admission) and takes the synchronous reserve carrying the
+ *      code, so the hold folds the affiliate markup (#12749) — each with a
+ *      no-header positive control proving the branch still admits without it.
  */
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -42,6 +46,7 @@ import * as aiBillingActual from "@/lib/services/ai-billing";
 import * as contentModerationActual from "@/lib/services/content-moderation";
 import * as inferenceAuthContextActual from "@/lib/services/inference-auth-context";
 import * as fastPathActual from "@/lib/services/inference-billing-fast-path";
+import * as ledgerActual from "@/lib/services/inference-billing-ledger";
 import * as modelCatalogActual from "@/lib/services/model-catalog";
 import * as creditReservationActual from "@/lib/utils/credit-reservation";
 
@@ -60,6 +65,7 @@ let backstopAvailable = true;
 let gateBalanceUsd = 100;
 let thresholdUsd = 5;
 let backstopPersists = true;
+let billingLedger = "kv"; // anything but "db" → the KV backstop branch
 
 // --- spies on the two terminal billing paths --------------------------------
 const writePendingInferenceCharge = mock(async () => backstopPersists);
@@ -131,6 +137,19 @@ mock.module("@/lib/services/inference-billing-fast-path", () => ({
   createOptimisticDebitSettler,
 }));
 
+// DB-ledger optimistic branch (#12749): the ledger selector is a knob and the
+// admission/settler are spied so the tests can prove which branch admitted.
+const admitInferenceChargeViaLedger = mock(
+  async () => ({ admitted: true }) as never,
+);
+const createLedgerDebitSettler = mock(() => async () => null);
+mock.module("@/lib/services/inference-billing-ledger", () => ({
+  ...ledgerActual,
+  resolveInferenceBillingLedger: () => billingLedger,
+  admitInferenceChargeViaLedger,
+  createLedgerDebitSettler,
+}));
+
 // Synchronous reserve path — spied so we can prove it is the fallback.
 mock.module("@/lib/services/ai-billing", () => ({
   ...aiBillingActual,
@@ -161,6 +180,14 @@ const { handleChatCompletionsPOST } = await import(
 );
 
 afterAll(() => {
+  // Leave the knobs fail-safe BEFORE restoring the modules: bun's mock.module
+  // can leave already-evaluated importers (the route, first loaded by an
+  // earlier test file) bound to the mocked functions even after the registry
+  // restore below, and those closures read these knobs by reference. A leaked
+  // `billingEnabled=true` (or a "db" ledger) would silently flip LATER test
+  // files' requests onto an optimistic path their suites never account for.
+  billingEnabled = false;
+  billingLedger = "kv";
   mock.module("ai", () => aiActual);
   mock.module(
     "@/lib/services/inference-auth-context",
@@ -177,16 +204,18 @@ afterAll(() => {
     "@/lib/services/inference-billing-fast-path",
     () => fastPathActual,
   );
+  mock.module("@/lib/services/inference-billing-ledger", () => ledgerActual);
   mock.module("@/lib/services/ai-billing", () => aiBillingActual);
   mock.module("@/lib/utils/credit-reservation", () => creditReservationActual);
 });
 
-function makeRequest(): Request {
+function makeRequest(affiliateCode?: string): Request {
   return new Request("https://api.test/api/v1/chat/completions", {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "x-request-id": CLIENT_REQUEST_ID,
+      ...(affiliateCode ? { "X-Affiliate-Code": affiliateCode } : {}),
     },
     body: JSON.stringify({
       model: "gpt-4o-mini",
@@ -196,10 +225,12 @@ function makeRequest(): Request {
   });
 }
 
-async function drive(): Promise<void> {
+async function drive(affiliateCode?: string): Promise<void> {
   // The handler owns its try/catch and always returns a Response (the stubbed
   // model call makes it an error response); we only read the spies.
-  await handleChatCompletionsPOST(makeRequest(), { skipOrgRateLimit: true });
+  await handleChatCompletionsPOST(makeRequest(affiliateCode), {
+    skipOrgRateLimit: true,
+  });
 }
 
 describe("chat/completions optimistic-billing route decision (#9899/#10066)", () => {
@@ -209,10 +240,13 @@ describe("chat/completions optimistic-billing route decision (#9899/#10066)", ()
     gateBalanceUsd = 100;
     thresholdUsd = 5;
     backstopPersists = true;
+    billingLedger = "kv";
     writePendingInferenceCharge.mockClear();
     reserveCredits.mockClear();
     createOptimisticDebitSettler.mockClear();
     createCreditReservationSettler.mockClear();
+    admitInferenceChargeViaLedger.mockClear();
+    createLedgerDebitSettler.mockClear();
   });
 
   test("eligible org takes the optimistic path: writes backstop, skips the synchronous reserve", async () => {
@@ -272,5 +306,62 @@ describe("chat/completions optimistic-billing route decision (#9899/#10066)", ()
     // ...but a non-durable write must fall through to the synchronous reserve.
     expect(reserveCredits).toHaveBeenCalledTimes(1);
     expect(createOptimisticDebitSettler).not.toHaveBeenCalled();
+  });
+
+  // #12749: the optimistic branches admit on a BASE-cost estimate and chat's
+  // billUsage runs without the reservation (#10557), so an affiliate markup
+  // (attacker-set, up to 1000%) would be minted as cashable earnings against
+  // money the admission gate never accounted for. A request carrying
+  // X-Affiliate-Code must therefore take the SYNCHRONOUS reserve, whose hold
+  // folds the markup (reserveCredits → resolveBillableAffiliate →
+  // estimatedCostMultiplier, threaded by #11976 — the markup arithmetic itself
+  // is pinned by chat-completions-affiliate-reserve.test.ts).
+  test("X-Affiliate-Code forces the synchronous reserve even when the KV optimistic path is eligible (#12749)", async () => {
+    // Positive control: WITHOUT the header the KV backstop admits and the
+    // synchronous reserve is skipped — proving the gate below is affiliate-
+    // specific, not a broken KV branch.
+    await drive();
+    expect(writePendingInferenceCharge).toHaveBeenCalledTimes(1);
+    expect(reserveCredits).not.toHaveBeenCalled();
+
+    writePendingInferenceCharge.mockClear();
+    createOptimisticDebitSettler.mockClear();
+    reserveCredits.mockClear();
+
+    await drive("PARTNER1000");
+    // Neither optimistic admission may see a marked-up request…
+    expect(writePendingInferenceCharge).not.toHaveBeenCalled();
+    expect(createOptimisticDebitSettler).not.toHaveBeenCalled();
+    // …the synchronous reserve runs and CARRIES the affiliate, so the hold
+    // covers base + markup and an uncollectable settle can't mint earnings.
+    expect(reserveCredits).toHaveBeenCalledTimes(1);
+    const reserveCalls = reserveCredits.mock.calls as unknown as Array<
+      [{ affiliateCode?: string | null }]
+    >;
+    expect(reserveCalls[0]?.[0]?.affiliateCode).toBe("PARTNER1000");
+  });
+
+  test("X-Affiliate-Code also bypasses the DB-ledger optimistic branch (#12749)", async () => {
+    billingLedger = "db";
+
+    // Positive control: WITHOUT the header the ledger branch admits and the
+    // synchronous reserve is skipped.
+    await drive();
+    expect(admitInferenceChargeViaLedger).toHaveBeenCalledTimes(1);
+    expect(createLedgerDebitSettler).toHaveBeenCalledTimes(1);
+    expect(reserveCredits).not.toHaveBeenCalled();
+
+    admitInferenceChargeViaLedger.mockClear();
+    createLedgerDebitSettler.mockClear();
+    reserveCredits.mockClear();
+
+    await drive("PARTNER1000");
+    expect(admitInferenceChargeViaLedger).not.toHaveBeenCalled();
+    expect(createLedgerDebitSettler).not.toHaveBeenCalled();
+    expect(reserveCredits).toHaveBeenCalledTimes(1);
+    const reserveCalls = reserveCredits.mock.calls as unknown as Array<
+      [{ affiliateCode?: string | null }]
+    >;
+    expect(reserveCalls[0]?.[0]?.affiliateCode).toBe("PARTNER1000");
   });
 });

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -1206,8 +1206,23 @@ export async function handleChatCompletionsPOST(
       // so it does not need the KV org-balance hint or a writable cache.
       let optimisticReady = false;
       const optimisticBillingEnabled = isOptimisticBillingEnabled();
+      // #12749: a request carrying an affiliate code must take the SYNCHRONOUS
+      // reserve. Both optimistic fast paths below admit on a BASE-cost estimate
+      // (calculateCost only) — the affiliate markup (attacker-set, up to 1000%)
+      // is invisible to them because resolveBillableAffiliate lives inside
+      // reserveCredits, and on this route billUsage runs WITHOUT the
+      // reservation (#10557), so nothing clamps the affiliate credit to
+      // collected money on those paths. An optimistically admitted marked-up
+      // request could therefore settle far past the admission gate's headroom
+      // while still minting the full cashable affiliate cut — an uncollectable-
+      // overage mint, one env flag away. Falling through folds the markup into
+      // the upfront hold (#11976 threaded affiliateCode → estimatedCostMultiplier)
+      // and 402s upfront when the balance can't cover base+markup (fail-closed).
+      // Affiliate-marked traffic is rare, so the hot path loses nothing.
+      const optimisticAllowedForRequest =
+        optimisticBillingEnabled && affiliateCode === null;
       const useDbLedger =
-        optimisticBillingEnabled && resolveInferenceBillingLedger() === "db";
+        optimisticAllowedForRequest && resolveInferenceBillingLedger() === "db";
 
       if (useDbLedger) {
         const { totalCost } = await calculateCost(
@@ -1253,7 +1268,7 @@ export async function handleChatCompletionsPOST(
       let estimatedCostUsd = 0;
       if (
         !optimisticReady &&
-        optimisticBillingEnabled &&
+        optimisticAllowedForRequest &&
         !useDbLedger &&
         isOptimisticBackstopAvailable()
       ) {


### PR DESCRIPTION
Fixes #12749. Mirrors the approved embeddings fix (#12731 / #12017) on the highest-volume inference route.

## Bug (MED, CASHABLE mint — behind `INFERENCE_OPTIMISTIC_BILLING=true`)
Both OPTIMISTIC billing branches in `POST /api/v1/chat/completions` — DB-ledger admission (`admitInferenceChargeViaLedger`) and the KV backstop (`writePendingInferenceCharge`) — admitted on a **base-only** `calculateCost` estimate with no affiliate markup and no affiliate gate. Chat's `billUsage` runs with **no reservation** (streaming + non-streaming), so `collectedAffiliateEarnings` has no reconciliation to clamp: an attacker-set markup (up to 1000%) was minted to `redeemableEarnings` **unconditionally at billUsage-time** while the optimistic debit collected only what balance covered — a cashable mint on the uncollectable overage.

## Fix (mirror #12731)
```ts
const optimisticAllowedForRequest = optimisticBillingEnabled && affiliateCode === null;
```
Both optimistic branches gate on it → any `X-Affiliate-Code` request falls through to the synchronous `reserveCredits`, which #11976 already made safe (folds the markup into the hold via `estimatedCostMultiplier`, 402s upfront, fail-closed). No-affiliate hot path is behaviorally unchanged (gate ≡ `optimisticBillingEnabled`). `billUsage` / #10557 single-settle / sync reserve untouched — no double-charge.

## Tests (mutation-verified)
- `chat-completions-optimistic-billing.test.ts`: X-Affiliate-Code bypasses **both** the KV backstop and the DB-ledger branch (each with a no-header positive control proving the branch still admits); sync reserve carries the code.
- `chat-completions-affiliate-reserve.test.ts` (new, mirrors embeddings): drives the **real** `reserveCredits` — 1000% markup lands on the hold (`estimatedCostMultiplier ≈ 11`); a caller who can afford base ($0.15) but NOT base+markup ($1.65) is **402'd before the model call** (no settle, no mint), with a no-header positive control.
- **Mutations:** revert the gate → the 2 bypass tests fail; drop affiliateCode from the sync reserve → all 4 affiliate tests fail. Both restored.
- `node test/run-unit-isolated.mjs chat-completions`: all 4 files pass isolated. Biome clean.

**Independent Fable review: correct — closes_mint ✅, both_branches_gated ✅ (enumerated every optimistic site), no_double_charge ✅, no_perf_regression ✅, defects: none.** This completes the optimistic-mint class across both metered routes (embeddings #12731 + chat here). Money lane → @lalalune; not self-merged.