### PR TITLE
fix(#12259): mark persistent turbo tasks uncached

### DIFF
--- a/.github/issue-evidence/12259-turbo-persistent-cache.md
+++ b/.github/issue-evidence/12259-turbo-persistent-cache.md
@@ -1,0 +1,19 @@
+# Issue #12259 - Persistent Turbo tasks are uncached
+
+PR scope:
+
+- `turbo.json` now marks both persistent generic tasks, `dev` and `start`, with
+  `cache: false`.
+- No other Turbo pipeline behavior is changed in this slice.
+
+Local verification on 2026-07-04:
+
+```bash
+node -e "const fs=require('fs'); const t=JSON.parse(fs.readFileSync('turbo.json','utf8')).tasks; if (t.dev.cache !== false || t.start.cache !== false) process.exit(1);"
+
+node -e "JSON.parse(require('fs').readFileSync('turbo.json','utf8'));"
+
+git diff --check origin/develop..HEAD
+```
+
+Screenshots/recordings: N/A, Turbo config only; no UI changed.

--- a/turbo.json
+++ b/turbo.json
@@ -572,10 +572,12 @@
     "start": {
       "dependsOn": ["@elizaos/core#build"],
       "env": ["LOG_LEVEL"],
+      "cache": false,
       "persistent": true
     },
     "dev": {
       "dependsOn": ["@elizaos/core#build"],
+      "cache": false,
       "persistent": true
     },
     "test": {


### PR DESCRIPTION
## Summary
- set `cache: false` on the generic persistent Turbo `dev` task
- set `cache: false` on the generic persistent Turbo `start` task
- leave the rest of the #12259 pipeline rewrite untouched for separate PRs

## Evidence
- `.github/issue-evidence/12259-turbo-persistent-cache.md`

## Verification
```bash
node -e "const fs=require('fs'); const t=JSON.parse(fs.readFileSync('turbo.json','utf8')).tasks; if (t.dev.cache !== false || t.start.cache !== false) process.exit(1);"
node -e "JSON.parse(require('fs').readFileSync('turbo.json','utf8'));"
git diff --check origin/develop..HEAD
```

Screenshots/recordings: N/A, Turbo config only; no UI changed.