### PR TITLE
docs(#12831): clean feed tools comments

### DIFF
--- a/packages/feed/tools/chroma/dev-server.ts
+++ b/packages/feed/tools/chroma/dev-server.ts
@@ -1,4 +1,10 @@
 #!/usr/bin/env bun
+/**
+ * Local Chroma e2e server bootstrap for Feed's web app and chain simulator.
+ *
+ * The runner prepares local services, deploys contracts once, and starts Next
+ * with the webpack dev pipeline that this workspace configures explicitly.
+ */
 
 import { type ChildProcess, spawn } from "node:child_process";
 import path from "node:path";

--- a/packages/feed/tools/chroma/playwright.config.ts
+++ b/packages/feed/tools/chroma/playwright.config.ts
@@ -1,3 +1,9 @@
+/**
+ * Playwright configuration for Feed's Chroma browser regression lane.
+ *
+ * It wires the local dev server, serialized Chromium execution, and retained
+ * failure artifacts for the tests under `tools/chroma/specs`.
+ */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig, devices } from "@playwright/test";

--- a/packages/feed/tools/chroma/scripts/ensure-dev-auth-session.ts
+++ b/packages/feed/tools/chroma/scripts/ensure-dev-auth-session.ts
@@ -1,3 +1,9 @@
+/**
+ * Dev-auth session seeder for Chroma browser tests.
+ *
+ * The script creates or updates the local Synpress trader account and prints
+ * the cookies and tokens that browser helpers install before navigation.
+ */
 import { createHash } from "node:crypto";
 import { db, eq, users } from "@feed/db";
 import { generateSnowflakeId } from "@feed/shared";

--- a/packages/feed/tools/chroma/specs/helpers/auth.ts
+++ b/packages/feed/tools/chroma/specs/helpers/auth.ts
@@ -1,3 +1,9 @@
+/**
+ * Wallet-auth compatibility helpers for Feed Chroma tests.
+ *
+ * Synpress-facing tests receive deterministic local wallet credentials while
+ * browser auth is installed through the Feed dev-auth session bridge.
+ */
 import type { Page } from "@playwright/test";
 import { installSynpressDevAuth } from "./dev-auth";
 

--- a/packages/feed/tools/chroma/specs/helpers/dev-auth.ts
+++ b/packages/feed/tools/chroma/specs/helpers/dev-auth.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser-side dev-auth installer for Feed Chroma specs.
+ *
+ * It shells through the local session seeder, then installs the Steward cookies
+ * and access-token local storage expected by the web app.
+ */
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/feed/tools/chroma/specs/helpers/page-helpers.health.test.ts
+++ b/packages/feed/tools/chroma/specs/helpers/page-helpers.health.test.ts
@@ -1,9 +1,9 @@
 /**
  * Health-probe semantics for the chroma e2e helpers (bun test).
  *
- * Regression guard for the "<500 means healthy" bug: the old probe hit `/`
- * and accepted ANY non-5xx response, so a 404-ing, half-booted, or entirely
- * wrong server counted as healthy and the suite ran against garbage.
+ * Regression guard for readiness probes that hit `/` and accept any non-5xx
+ * response: a 404-ing, half-booted, or entirely wrong server must not count as
+ * healthy.
  * Healthy means `/api/health` answers 2xx with `{ status: "ok" }`.
  *
  * Run: bun run test:unit (from tools/chroma)

--- a/packages/feed/tools/dag-visualizer/playwright.config.mjs
+++ b/packages/feed/tools/dag-visualizer/playwright.config.mjs
@@ -1,3 +1,9 @@
+/**
+ * Playwright configuration for the standalone Feed DAG visualizer.
+ *
+ * Recording mode redirects traces, screenshots, and videos into the shared
+ * evidence directory while normal local runs keep artifacts beside the tool.
+ */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig, devices } from "@playwright/test";

--- a/packages/feed/tools/e2e-gate.mjs
+++ b/packages/feed/tools/e2e-gate.mjs
@@ -2,8 +2,8 @@
 /**
  * Gate runner for the Feed browser e2e lanes (tools/e2e, tools/chroma).
  *
- * The old inline `sh -c ... exit 0` gate made a skipped lane
- * indistinguishable from a green run. This runner makes skipping VISIBLE:
+ * Inline `sh -c ... exit 0` gates can make a skipped lane indistinguishable
+ * from a green run. This runner makes skipping VISIBLE:
  *
  * - RUN_FEED_E2E=1  → run the wrapped Playwright command, propagate its exit.
  * - otherwise       → print a loud skip banner + a machine-readable


### PR DESCRIPTION
## Summary
- Add top-of-file prose headers for Feed Chroma and DAG visualizer tool files that were missing them.
- Rewrite residual churn/history comments in Feed tools to present-tense operational context.
- Keep the patch comment-only; code tokens are unchanged.

Fixes #12831

## Validation
- PASS `bun run check:comment-only`
- PASS in-scope header audit: 34 Feed tool source files, 0 missing headers
- PASS `bun run --cwd packages/feed/tools/chroma test:unit` (7 tests)
- PASS `bun run --cwd packages/feed/tools/dag-visualizer test` (136 Playwright tests)
- PASS `node packages/feed/tools/e2e-gate.mjs --suite smoke -- echo should-not-run` (expected local skip banner, exit 0)
- PASS `git diff --check origin/develop...HEAD`

## Verification notes
- `bunx @biomejs/biome check <changed Feed tool files>` does not process these paths because root Biome ignores the nested Feed workspace.
- `bun run --cwd packages/feed/tools/chroma typecheck` currently fails on pre-existing Chroma spec implicit-`any` diagnostics and missing `@avalix/chroma` types; this comment-only patch does not touch those code paths.
- `bun run verify` was attempted and failed in the known unrelated `@elizaos/cloud-shared:typecheck` lane: `drizzle-orm*` declarations resolve through `dist/node_modules`, which cascades into implicit-`any` diagnostics in `plugins/plugin-sql/src/schema/*`.

## Evidence
- UI/video/domain artifacts: N/A - comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
