### PR TITLE
fix(#12265): annotate the last agent empty catches per error-policy rubric

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -4709,7 +4709,10 @@ export async function startApiServer(opts?: {
       );
       try {
         socket.destroy();
-      } catch {}
+      } catch {
+        // error-policy:J6 best-effort teardown — the socket may already be
+        // destroyed after the failed upgrade; nothing more to do.
+      }
     });
     try {
       const wsUrl = new URL(

--- a/packages/agent/src/api/wallet-capability.ts
+++ b/packages/agent/src/api/wallet-capability.ts
@@ -74,7 +74,10 @@ function hasRuntimeEvmService(runtime: AgentRuntime | null): boolean {
           ) {
             return true;
           }
-        } catch {}
+        } catch {
+          // error-policy:J3 service-registry probe — a lookup that throws means
+          // this provider isn't usable here; treated as absent, try the next.
+        }
       }
     }
     return false;
@@ -88,7 +91,10 @@ function hasRuntimeEvmService(runtime: AgentRuntime | null): boolean {
         if (getService(serviceName)) {
           return true;
         }
-      } catch {}
+      } catch {
+        // error-policy:J3 service-registry probe — a lookup that throws means
+        // this provider isn't usable here; treated as absent, try the next.
+      }
     }
     return false;
   } catch {


### PR DESCRIPTION
## Summary

Part of the fallback-slop sweep for `packages/agent` (#12265, parent #12182). The 3 remaining **unannotated empty catches** in the agent API layer are justified handlers; this adds the grep-able `// error-policy:J<N>` annotations the binding rubric requires, with **no behavior change** (comments added inside the catch blocks only).

- `api/server.ts` — the WS-upgrade `socket.destroy()` cleanup → **J6 best-effort teardown** (the socket may already be destroyed after a failed upgrade).
- `api/wallet-capability.ts` — the two EVM service-registry probes → **J3**: a service lookup that throws means that provider isn't usable here, so it is treated as absent and the next candidate is tried. The function returns an honest `false` (capability absent), never a fabricated success.

This clears the last truly-empty catch sites in `packages/agent/src` (3 → 0), so `noEmptyBlockStatements` holds for them.

> Scope note: this is a bounded, safe slice of #12265 — it does not close the batch, which still covers the broader `?? <literal>` / `.catch(()=>)` judgment calls across the agent runtime (best done as small, tested, evidence-backed slices per DoD).

## Validation

- `node packages/scripts/error-policy-ratchet.mjs` → **`no new fallback-slop in touched files`** (the enforced diff-scoped gate).
- `bunx @biomejs/biome check` on both touched files → clean, no fixes.
- Truly-empty catches in `packages/agent/src`: **3 on develop → 0 on this branch**.
- Annotations are grep-able: `git grep 'error-policy:J[36]'`.

## Evidence rows
- Real-LLM trajectory / logs / screenshots — **N/A**: comment-only annotations inside existing catch blocks; zero runtime behavior change (the caught paths and their outcomes are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)