### PR TITLE
fix(#12259): remove lint build deps

### DIFF
--- a/.github/issue-evidence/12259-lint-no-build-deps.md
+++ b/.github/issue-evidence/12259-lint-no-build-deps.md
@@ -1,0 +1,31 @@
+# Issue #12259 - Lint tasks no longer force builds
+
+PR scope:
+
+- Removed generic `dependsOn` build prerequisites from the `lint` Turbo task.
+- Removed the same generic build prerequisites from the `lint:check` Turbo
+  task.
+- Left `typecheck` build prerequisites unchanged.
+
+Local verification on 2026-07-04:
+
+```bash
+node -e "const fs=require('fs'); const t=JSON.parse(fs.readFileSync('turbo.json','utf8')).tasks; if ('dependsOn' in t.lint || 'dependsOn' in t['lint:check']) process.exit(1); if (!Array.isArray(t.typecheck.dependsOn)) process.exit(1);"
+
+node -e "JSON.parse(require('fs').readFileSync('turbo.json','utf8'));"
+
+git diff --check origin/develop..HEAD
+```
+
+Turbo dry-run:
+
+```bash
+ln -s /Users/shawwalters/eliza/node_modules node_modules
+node packages/scripts/run-turbo.mjs run lint:check --dry=json --filter=./packages/core
+rm node_modules
+```
+
+The dry-run completed and emitted a `lint:check` plan without any build task
+dependency injected by the generic lint task.
+
+Screenshots/recordings: N/A, Turbo config only; no UI changed.

--- a/turbo.json
+++ b/turbo.json
@@ -318,21 +318,9 @@
       "outputs": ["dist/**"]
     },
     "lint": {
-      "dependsOn": [
-        "@elizaos/core#build",
-        "@elizaos/shared#build",
-        "@elizaos/plugin-agent-skills#build",
-        "@elizaos/plugin-app-manager#build"
-      ],
       "outputs": []
     },
     "lint:check": {
-      "dependsOn": [
-        "@elizaos/core#build",
-        "@elizaos/shared#build",
-        "@elizaos/plugin-agent-skills#build",
-        "@elizaos/plugin-app-manager#build"
-      ],
       "outputs": []
     },
     "typecheck": {


### PR DESCRIPTION
## Summary
- remove generic build `dependsOn` from the Turbo `lint` task
- remove generic build `dependsOn` from the Turbo `lint:check` task
- leave `typecheck` build prerequisites unchanged

## Evidence
- `.github/issue-evidence/12259-lint-no-build-deps.md`

## Verification
```bash
node -e "const fs=require('fs'); const t=JSON.parse(fs.readFileSync('turbo.json','utf8')).tasks; if ('dependsOn' in t.lint || 'dependsOn' in t['lint:check']) process.exit(1); if (!Array.isArray(t.typecheck.dependsOn)) process.exit(1);"
node -e "JSON.parse(require('fs').readFileSync('turbo.json','utf8'));"
git diff --check origin/develop..HEAD
```

Turbo dry-run evidence:
```bash
rm -f node_modules
ln -s /Users/shawwalters/eliza/node_modules node_modules
node packages/scripts/run-turbo.mjs run lint:check --dry=json --filter=./packages/core > /tmp/eliza-lint-dry.json
rm -f node_modules
node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('/tmp/eliza-lint-dry.json','utf8')); const tasks=p.tasks.map(t=>({taskId:t.taskId,dependencies:t.dependencies,dependsOn:t.resolvedTaskDefinition?.dependsOn})); console.log(JSON.stringify(tasks,null,2)); if (tasks.some(t => t.dependencies.length || t.dependsOn.length)) process.exit(1);"
```

Observed task summary:
```json
[
  {
    "taskId": "@elizaos/core#lint:check",
    "dependencies": [],
    "dependsOn": []
  }
]
```

Screenshots/recordings: N/A, Turbo config only; no UI changed.