### PR TITLE
docs(#12231): prose headers + churn cleanup — core features subsystems (B01 part 3)

### DIFF
--- a/packages/core/src/features/advanced-capabilities/actions/connectorActionUtils.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/connectorActionUtils.ts
@@ -1,3 +1,14 @@
+/**
+ * Shared helpers for the connector-backed messaging actions (MESSAGE and POST).
+ * Provides loose param coercion for planner-supplied input (textParam,
+ * boolParam, numberParam, limitParam — which clamps to 1..100 to bound query
+ * cost), connector selection and scoping by source + account
+ * (selectConnector / connectorSelectionFailure), target resolution from params,
+ * and the refresh* helpers that rewrite an action's description /
+ * descriptionCompressed to advertise the currently registered
+ * MessageConnector / PostConnector instances.
+ */
+
 import { logger } from "../../../logger.ts";
 import type {
 	Action,

--- a/packages/core/src/features/advanced-capabilities/actions/generateMedia.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/generateMedia.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers the GENERATE_MEDIA action's validate/handler: provider gating (media
+ * service vs IMAGE-model fallback), missing-URL failure, attachment delivery,
+ * and i18n-safe media-kind routing (#10471). Runs against a deterministic mock
+ * runtime (vi.fn media service, no live model).
+ */
+
 import { describe, expect, it, vi } from "vitest";
 import { ModelType, ServiceType } from "../../../types/index.ts";
 import { generateMediaAction } from "./generateMedia.ts";
@@ -164,8 +171,8 @@ describe("generateMediaAction media-kind routing is i18n-safe (#10471)", () => {
 			url: "https://cdn.example.com/i.png",
 			mimeType: "image/png",
 		}));
-		// English "video"/"music" words in the prompt must no longer steer the
-		// media kind — only the structured enum does. Absent enum ⇒ image.
+		// English "video"/"music" words in the prompt must not steer the media
+		// kind — only the structured enum does. Absent enum ⇒ image.
 		const englishyMessage = {
 			id: "msg",
 			roomId: "room",

--- a/packages/core/src/features/advanced-capabilities/actions/generateMedia.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/generateMedia.ts
@@ -1,3 +1,14 @@
+/**
+ * GENERATE_MEDIA action: turns a prompt into an image, video, or audio (music,
+ * sfx, or tts) attachment. Routes the request through the runtime's
+ * MEDIA_GENERATION service, falling back to the IMAGE model when only image
+ * generation is available and no service is configured. The result is delivered
+ * as an attachment-only callback (the planner/evaluator composes the
+ * user-facing text). Media kind comes from the structured `mediaType` /
+ * `audioKind` enums the planner emits, never from natural-language keywords
+ * (#10471).
+ */
+
 import { v4 } from "uuid";
 import type { ActionDoc } from "../../../generated/action-docs.ts";
 import { getActionSpec } from "../../../generated/spec-helpers.ts";

--- a/packages/core/src/features/advanced-capabilities/actions/message.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers the MESSAGE action: the list_connections cross-connector roster, the
+ * op=send owner-binding gate, and i18n-safe op inference (#10471). Uses
+ * createMockRuntime with deterministic mock connectors — no live model, no DB.
+ */
+
 import { describe, expect, it } from "vitest";
 import { createMockRuntime } from "../../../testing/mock-runtime";
 import type {
@@ -359,10 +365,10 @@ describe("inferOp is i18n-safe (#10471)", () => {
 	});
 
 	it("does NOT infer the op from natural-language text in any language", () => {
-		// Previously English regexes (e.g. /\b(delete|remove|unsend)\b/) picked the
-		// op from message text — invisible to non-English users and now removed.
-		// With no structured signal the op defaults to the safe `send`; the real
-		// op comes from the planner's `action` enum, which it emits in any language.
+		// Routing never infers the op from natural-language message text (any
+		// language): with no structured signal the op defaults to the safe `send`,
+		// and the real op comes from the planner's `action` enum, which it emits in
+		// any language.
 		expect(inferOp({})).toBe("send");
 		// A `text`-like field is not a recognized structured param and must be
 		// ignored by routing.

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -1,13 +1,15 @@
-// MESSAGE — single polymorphic action surface for the messaging domain.
-//
-// Dispatches to a switch over MESSAGE_OPS. Connector-backed ops (read_channel,
-// search, list_channels, list_servers, react, edit, delete, pin, join, leave,
-// get_user) call MessageConnector hooks directly. read_with_contact resolves a
-// person via the relationships graph and views their conversations across
-// every connected platform. Triage / inbox / draft ops delegate to the
-// existing triage actions in features/messaging/triage.
-//
-// Former leaf message actions are gone — MESSAGE is the only registration.
+/**
+ * MESSAGE — single polymorphic action surface for the messaging domain, and the
+ * only messaging action the runtime registers (there are no per-op leaf
+ * actions).
+ *
+ * Dispatches on a switch over MESSAGE_OPS. Connector-backed ops (read_channel,
+ * search, list_channels, list_servers, react, edit, delete, pin, join, leave,
+ * get_user) call MessageConnector hooks directly. read_with_contact resolves a
+ * person via the relationships graph and views their conversations across every
+ * connected platform. Triage / inbox / draft ops delegate to the triage actions
+ * in features/messaging/triage.
+ */
 
 import { getConnectorAccountManager } from "../../../connectors/account-manager.ts";
 import { findEntityByName } from "../../../entities.ts";
@@ -737,7 +739,7 @@ function opErrorWrap(op: MessageOperation, error: unknown): ActionResult {
 }
 
 // ---------------------------------------------------------------------------
-// op=send (folded from sendMessage.ts)
+// op=send
 // ---------------------------------------------------------------------------
 
 const ADMIN_TARGETS = new Set(["admin", "owner"]);
@@ -2323,7 +2325,7 @@ async function handleReadChannel(
 		);
 	}
 
-	// Local-room fallback (replaces former read-channel leaf behavior on agent runtime).
+	// Local-room fallback: read the channel from the agent runtime's own rooms.
 	if (!channel) {
 		return opFailure(
 			"read_channel",

--- a/packages/core/src/features/advanced-capabilities/actions/post.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/post.test.ts
@@ -4,8 +4,8 @@ import { postAction, resolveOp } from "./post.ts";
 /**
  * #10471 — POST op routing must come from the planner-emitted `action` enum
  * (or structured query/feed params), never from English keywords in the user
- * text. These cases previously routed via `/\b(search|find)\b/` etc., which
- * silently failed for every non-English request.
+ * text. Keyword routing (e.g. `/\b(search|find)\b/`) silently fails for every
+ * non-English request, so op selection stays structured-only.
  */
 describe("post resolveOp is i18n-safe (#10471)", () => {
 	it("routes by the planner action enum", () => {
@@ -29,8 +29,8 @@ describe("post resolveOp is i18n-safe (#10471)", () => {
 
 	it("does NOT infer the op from natural-language text", () => {
 		// No structured params: defaults to send regardless of what the text
-		// says, in any language. The old English regex would have returned
-		// "search"/"read" here; that English-only behavior is gone.
+		// says, in any language. The op never comes from natural-language
+		// keywords.
 		expect(resolveOp({ parameters: {} })).toBe("send");
 		expect(resolveOp(undefined)).toBe("send");
 	});

--- a/packages/core/src/features/advanced-capabilities/actions/post.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/post.ts
@@ -1,3 +1,14 @@
+/**
+ * POST action: the public feed/timeline surface (send publishes, read fetches a
+ * feed, search queries posts) across social PostConnectors — x, bluesky,
+ * farcaster, nostr, instagram. The counterpart to MESSAGE, which owns
+ * addressed/private messaging; the routingHint keeps the planner from confusing
+ * the two (public feed -> POST, DM/group/channel -> MESSAGE). Op selection comes
+ * from the structured `action` enum, never from natural-language keywords
+ * (#10471); shared connector selection and param coercion live in
+ * connectorActionUtils.
+ */
+
 import type {
 	Action,
 	ActionExample,

--- a/packages/core/src/features/advanced-capabilities/actions/room.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/room.ts
@@ -629,9 +629,8 @@ export const roomOpAction: Action = {
 		const chatName = normalizeString(params.chatName);
 		const durationMinutes = normalizeDurationMinutes(params.durationMinutes);
 
-		// Connector-targeted path (replaces CHAT_THREAD).
-		// Skip the model gate and act directly on the named room; preserves
-		// the previous CHAT_THREAD shape.
+		// Connector-targeted path: skip the model gate and act directly on the
+		// named room resolved by platform + roomId/chatName.
 		if (platform && (explicitRoomId || chatName)) {
 			const targetRoom = await resolveTargetRoom({
 				runtime: runtime as RuntimeLike,
@@ -701,9 +700,7 @@ export const roomOpAction: Action = {
 			return result;
 		}
 
-		// Default path: operate on the current room with model-decision gating
-		// (matches previous MUTE_ROOM / UNMUTE_ROOM / FOLLOW_ROOM / UNFOLLOW_ROOM
-		// behavior).
+		// Default path: operate on the current room with model-decision gating.
 		if (!state) {
 			return {
 				text: "State is required for ROOM",

--- a/packages/core/src/features/advanced-capabilities/evaluators/index.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Barrel for the advanced-capabilities evaluators: re-exports the reflection
+ * evaluators (fact / identity / relationship / success) and the skill
+ * evaluators (proposal / refinement) plus their `*Items` groupings for the
+ * runtime evaluator registry. The anchorBundleSafety call below is load-bearing
+ * — see the inline note for why the barrel must not be tree-shaken away.
+ */
+
 export {
 	factMemoryEvaluator,
 	identityEvaluator,

--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Deterministic unit tests for the reflection evaluators (reflection-items.ts):
+ * fact keyword dedupe / strengthen without embeddings, the strict-structured-output
+ * schema invariant across every reflection schema, and the tolerant per-op
+ * factExtractor parse. Runtime and model are vi.fn stubs — no live model, no DB.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { logger } from "../../../logger.ts";
 import type {

--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
@@ -1,3 +1,24 @@
+/**
+ * The post-response reflection evaluator bundle for the advanced-capabilities
+ * feature: `factMemory`, `relationships`, `identities`, and `success`, exported
+ * together as `reflectionItems`. Each runs after the agent replies, extracts
+ * structured output from the recent conversation via a strict-JSON-schema model
+ * call, and writes it back into runtime memory — durable/current fact-store ops,
+ * relationship edges between known room participants, platform-identity claims,
+ * and a task-completion assessment respectively.
+ *
+ * The evaluators share a single reflection-context prepare step (recent messages,
+ * entities in room, existing relationships) and gate on `canEvaluateMessage`.
+ * Fact dedupe is purely lexical (keyword / search-text similarity), so the
+ * factMemory path never issues an embedding call.
+ *
+ * Every response `schema` here is hand-written to survive strict
+ * structured-output mode (Groq / Cerebras / OpenAI strict): every object node
+ * declares `properties` and `additionalProperties: false`, and no value-constraint
+ * keyword (maxItems, pattern, …) appears — those caps are enforced in code
+ * instead. Violating that invariant 400s the whole extraction call and silently
+ * drops the turn's memories, which reflection-items.test.ts guards against.
+ */
 import { v4 } from "uuid";
 import z from "zod";
 import { getEntityDetails } from "../../../entities.ts";

--- a/packages/core/src/features/advanced-capabilities/evaluators/skill-items.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/skill-items.ts
@@ -1,3 +1,17 @@
+/**
+ * The skill-learning evaluator bundle for advanced-capabilities: `skillProposal`
+ * and `skillRefinement`, exported as `skillItems`. Both read the latest recorded
+ * trajectory from the trajectories service and, via a strict-JSON-schema model
+ * call, curate on-disk SKILL.md files under the runtime state dir. `skillProposal`
+ * drafts a new proposed skill when a completed, multi-step trajectory that used no
+ * curated skill contains a reusable procedure; `skillRefinement` rewrites (or, past
+ * MAX_AUTO_REFINEMENTS, re-stages under proposed/) the active skills a failed or
+ * retried trajectory exercised, tracking provenance in each file's frontmatter.
+ *
+ * Both evaluators go through `getLatestTrajectory`, which memoizes the latest-
+ * trajectory lookup per message id so their parallel shouldRun/prepare hooks don't
+ * repeat the store round-trip.
+ */
 import {
 	existsSync,
 	mkdirSync,

--- a/packages/core/src/features/advanced-capabilities/evaluators/task-completion.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/task-completion.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared task-completion contract for the reflection `success` evaluator: the
+ * `TaskCompletionAssessment` shape, its cache-key builder, and the provider-facing
+ * status formatter. reflection-items.ts writes an assessment here and caches it by
+ * message id; downstream providers render it via `formatTaskCompletionStatus`.
+ */
 import type { UUID } from "../../../types/index.ts";
 
 export interface TaskCompletionAssessment {

--- a/packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.ts
@@ -1,3 +1,11 @@
+/**
+ * Shared trajectory types and helpers for the skill-learning evaluators
+ * (skill-items.ts): the trajectory / step / service shapes, a defensive
+ * `getTrajectoryService` lookup that returns null unless the "trajectories" service
+ * exposes both list and detail, a tolerant JSON-object parser, and
+ * `formatTrajectoryForPrompt`, which renders a trajectory (step by step, prompts
+ * truncated) into the digest fed to the extraction model.
+ */
 import type { IAgentRuntime } from "../../../types/index.ts";
 
 export interface SkillTrajectoryLlmCall {

--- a/packages/core/src/features/advanced-capabilities/experience/actions/search-experiences.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/actions/search-experiences.ts
@@ -1,3 +1,11 @@
+/**
+ * The SEARCH_EXPERIENCES action for the experience capability: queries the agent's
+ * experience graph through the EXPERIENCE service and returns compact, ranked
+ * learnings plus a small related graph, with a copy-to-clipboard follow-up action
+ * for chaining. Validates on a structured `query`/`q` param, on experience/search
+ * intent in free text, or on an in-scope action context, and derives a query from
+ * the message when none is supplied.
+ */
 import { logger } from "../../../../logger.ts";
 import type {
 	Action,

--- a/packages/core/src/features/advanced-capabilities/experience/evaluators/experience-items.test.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/evaluators/experience-items.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Deterministic unit tests for `experiencePatternEvaluator` (experience-items.ts):
+ * signal-gated shouldRun (idle chat vs explicit lesson vs fallback interval),
+ * secret redaction + synthetic-summary filtering in prepare, and cross-batch dedupe
+ * on record. Runtime and EXPERIENCE service are vi.fn stubs — no live model, no DB.
+ */
 import { describe, expect, it, vi } from "vitest";
 import type { EvaluatorProcessorContext } from "../../../../types/evaluator";
 import type { Memory } from "../../../../types/memory";

--- a/packages/core/src/features/advanced-capabilities/experience/evaluators/experience-items.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/evaluators/experience-items.ts
@@ -1,3 +1,17 @@
+/**
+ * The `experiencePatterns` evaluator for the experience capability: after a turn,
+ * extracts reusable operational lessons (successes, failures, corrections,
+ * discoveries, validations) from the recent conversation and records them through
+ * the EXPERIENCE service. Gating is signal-driven — an explicit "remember this" or
+ * a scored signal (correction / failure / validated-outcome / …) runs it subject to
+ * a per-room min-gap counter, otherwise it falls back to a fixed message interval
+ * and only runs if the recent window still carries a signal.
+ *
+ * Conversation text is secret-redacted and synthetic summaries filtered before it
+ * reaches the model; extracted learnings are deduped (lexically normalized) against
+ * existing similar experiences and against each other, and dropped below the
+ * auto-record confidence threshold.
+ */
 import { logger } from "../../../../logger.ts";
 import { EvaluatorPriority } from "../../../../services/evaluator-priorities.ts";
 import type {

--- a/packages/core/src/features/advanced-capabilities/experience/providers/experienceProvider.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/providers/experienceProvider.ts
@@ -1,3 +1,11 @@
+/**
+ * The experience provider for the experience capability: injects the most relevant
+ * past learnings into turn context. Merges semantically matched experiences
+ * (queried by the current message text) with the highest-quality top experiences,
+ * dedupes by id, caps the set at MAX_RELEVANT_EXPERIENCES, and renders them into a
+ * `[RELEVANT EXPERIENCES]` block. No EXPERIENCE service, a too-short message, or no
+ * matches yields empty output; errors fail soft to empty text.
+ */
 import { logger } from "../../../../logger.ts";
 import type { Provider, ProviderResult } from "../../../../types/components.ts";
 import type { Memory } from "../../../../types/memory.ts";

--- a/packages/core/src/features/advanced-capabilities/experience/service.findSimilar.test.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/service.findSimilar.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for `ExperienceService.findSimilarExperiences` and its shared
+ * recall-embedder wiring: a mocked `embedRecallQuery` verifies that a null embed
+ * (timeout/error) fails open to the recency/quality fallback set, and that ranking
+ * always routes through the shared embedder rather than a direct useModel call.
+ * Uses the in-memory mock runtime — no live model, no real DB.
+ */
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { createMockRuntime } from "../../../testing/mock-runtime";
 import type { Memory } from "../../../types/memory.ts";

--- a/packages/core/src/features/advanced-capabilities/experience/service.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/service.ts
@@ -1,3 +1,23 @@
+/**
+ * Runs the ExperienceService, the long-lived singleton behind the experience
+ * advanced-capability: it records what the agent tried, the outcome, and the
+ * lesson learned, then makes those experiences retrievable to inform future
+ * decisions. Registers under the EXPERIENCE service type.
+ *
+ * Experiences live in an in-memory Map hydrated on start from the `experiences`
+ * memory table (the same table writes go back to), with secondary indexes by
+ * domain and type. Access counts accrue in memory and batch-persist on a 60s
+ * timer; a daily maintenance timer runs learning-text dedupe. Retrieval is
+ * semantic — a shared per-turn recall-query embedding plus cosine similarity —
+ * reranked so vector relevance dominates (70%) and quality signals (decayed
+ * confidence, importance, recency, access frequency) only tiebreak (30%), with a
+ * similarity floor and a recency-sort fallback when embeddings are unavailable.
+ *
+ * Confidence decay and inter-experience relationships/graph links are delegated
+ * to ConfidenceDecayManager and ExperienceRelationshipManager; on record,
+ * same-action / opposite-outcome experiences in one domain are cross-linked as
+ * `contradicts`.
+ */
 import { v4 as uuidv4 } from "uuid";
 import { logger } from "../../../logger.ts";
 import type { Memory } from "../../../types/memory.ts";

--- a/packages/core/src/features/advanced-capabilities/experience/types.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/types.ts
@@ -1,3 +1,12 @@
+/**
+ * Type contracts and the service-type registration for the experience
+ * advanced-capability. Declares the `Experience` record (context/action/result/
+ * learning plus categorization, confidence/importance, temporal, correction, and
+ * provenance fields), the `ExperienceType`/`OutcomeType` enums, and the query,
+ * analysis, dedupe, graph, and event shapes consumed by ExperienceService and
+ * its formatting/relationship utilities. The `declare module` augmentation adds
+ * `EXPERIENCE` to the core ServiceTypeRegistry so the service can register under it.
+ */
 import type { Memory } from "../../../types/memory.ts";
 import type {
 	JsonObject,
@@ -15,7 +24,6 @@ declare module "../../../types/service.ts" {
 	}
 }
 
-// Export service type constant
 export const ExperienceServiceType = {
 	EXPERIENCE: "EXPERIENCE" as const,
 } satisfies Partial<ServiceTypeRegistry>;

--- a/packages/core/src/features/advanced-capabilities/experience/utils/confidenceDecay.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/utils/confidenceDecay.ts
@@ -1,3 +1,12 @@
+/**
+ * Confidence-decay model for the experience capability: `ConfidenceDecayManager`
+ * ages an experience's stored confidence toward a floor along a configurable
+ * half-life after a grace period, with per-type and per-domain tuning (facts and
+ * safety/security lessons decay slower; performance and user-preference insights
+ * decay faster). ExperienceService uses the decayed confidence as the dominant
+ * quality signal when ranking and filtering recall; the manager also exposes
+ * reinforcement boosts and confidence-over-time trends.
+ */
 import type { Experience } from "../types";
 import { ExperienceType } from "../types";
 

--- a/packages/core/src/features/advanced-capabilities/experience/utils/experienceFormatter.test.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/utils/experienceFormatter.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the experience formatter/aggregation helpers (deterministic, no
+ * runtime or model). Stats drive what the agent believes about its own track
+ * record (success rate, averages), so the counting and averaging must be exact;
+ * keyword extraction feeds retrieval recall.
+ */
 import { describe, expect, it } from "vitest";
 import type { Experience } from "../types";
 import { ExperienceType, OutcomeType } from "../types";
@@ -7,12 +13,6 @@ import {
 	getExperienceStats,
 	groupExperiencesByDomain,
 } from "./experienceFormatter.ts";
-
-/**
- * Experience aggregation + keyword extraction. Stats drive what the agent
- * believes about its own track record (success rate, averages), so the counting
- * and averaging must be exact; keyword extraction feeds retrieval recall.
- */
 
 const exp = (o: Partial<Experience>): Experience =>
 	({

--- a/packages/core/src/features/advanced-capabilities/experience/utils/experienceFormatter.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/utils/experienceFormatter.ts
@@ -1,3 +1,12 @@
+/**
+ * Pure formatting and aggregation helpers for the experience capability. Renders
+ * an `Experience` for display, prompt injection, list, and RAG-storage text
+ * (with per-type emoji), groups experiences by domain, and computes aggregate
+ * stats (counts by type/outcome/domain, average confidence/importance, and
+ * success rate). Keyword extraction falls back to deriving terms from
+ * tags/learning/action/type/outcome/domain when none are stored. Consumed by the
+ * experience providers/prompts and pinned by experienceFormatter.test.ts.
+ */
 import type { Experience } from "../types";
 import { ExperienceType, OutcomeType } from "../types";
 

--- a/packages/core/src/features/advanced-capabilities/experience/utils/experienceRelationships.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/utils/experienceRelationships.ts
@@ -1,3 +1,12 @@
+/**
+ * Relationship graph for the experience capability: `ExperienceRelationshipManager`
+ * holds directed links between experiences (causes/contradicts/supports/
+ * supersedes/related) keyed by source id, and derives higher-order structure —
+ * causal chains from hypothesis to validation, contradictions (same action +
+ * opposite outcome in one domain, or an explicit `contradicts` link), and an
+ * impact score. ExperienceService owns an instance and consults it when
+ * recording experiences and when building the experience graph snapshot.
+ */
 import type { UUID } from "../../../../types/primitives.ts";
 import type { Experience, JsonObject } from "../types";
 import { ExperienceType, OutcomeType } from "../types";
@@ -123,7 +132,7 @@ export class ExperienceRelationshipManager {
 	}
 
 	private contentSimilarity(exp1: Experience, exp2: Experience): number {
-		// Simple keyword overlap for now
+		// Jaccard overlap of lowercased learning words
 		const words1 = new Set(exp1.learning.toLowerCase().split(/\s+/));
 		const words2 = new Set(exp2.learning.toLowerCase().split(/\s+/));
 

--- a/packages/core/src/features/advanced-capabilities/experience/utils/experienceText.test.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/utils/experienceText.test.ts
@@ -1,12 +1,13 @@
+/**
+ * Unit tests (deterministic, no runtime) for `sanitizeExperienceText`, which
+ * redacts PII/secrets out of experience text before it is persisted into agent
+ * memory (#8801 — it shipped untested). A regression here leaks emails, IPs,
+ * home-dir usernames, or API tokens into stored experiences, so each redaction
+ * class + the fail-safe truncation are pinned.
+ */
 import { describe, expect, it } from "vitest";
 import { sanitizeExperienceText } from "./experienceText";
 
-/**
- * `sanitizeExperienceText` redacts PII/secrets out of experience text before it
- * is persisted into agent memory (#8801 — it shipped untested). A regression
- * here leaks emails, IPs, home-dir usernames, or API tokens into stored
- * experiences, so each redaction class + the fail-safe truncation are pinned.
- */
 describe("sanitizeExperienceText", () => {
 	it("returns a placeholder for empty input", () => {
 		expect(sanitizeExperienceText("")).toBe("Unknown context");

--- a/packages/core/src/features/advanced-capabilities/experience/utils/experienceText.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/utils/experienceText.ts
@@ -1,3 +1,13 @@
+/**
+ * Text utilities for the experience capability: `sanitizeExperienceText` redacts
+ * PII/secrets (emails, IPs, home-dir usernames, prefixed/opaque tokens) and caps
+ * length before an experience is persisted; `detectExperienceDomain` maps free
+ * text to a coarse domain; `extractExperienceKeywords` tokenizes, stems, and
+ * frequency-ranks searchable terms; and `isDuplicateLearning` /
+ * `findDuplicateExperienceByLearning` decide near-duplicate learnings via
+ * normalized-substring, Jaccard, and containment thresholds. Consumed by
+ * ExperienceService for keyword derivation and dedupe maintenance.
+ */
 import type { Experience } from "../types.ts";
 
 /** Minimal interface of ExperienceService used by this module. */

--- a/packages/core/src/features/advanced-capabilities/fact-keywords.test.ts
+++ b/packages/core/src/features/advanced-capabilities/fact-keywords.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests (deterministic, no runtime) for the fact keyword tooling behind
+ * lexical fact retrieval. Tokenization strips punctuation/stopwords, splits
+ * hyphens, and applies length floors; extraction dedupes + ranks by frequency;
+ * lexical similarity blends coverage + jaccard (1.0 for identical keyword sets,
+ * 0 for disjoint).
+ */
 import { describe, expect, it } from "vitest";
 import {
 	buildFactQueryText,
@@ -5,13 +12,6 @@ import {
 	factLexicalSimilarity,
 	tokenizeFactText,
 } from "./fact-keywords.ts";
-
-/**
- * Fact keyword extraction backs lexical fact retrieval. Tokenization strips
- * punctuation/stopwords, splits hyphens, and applies length floors; extraction
- * dedupes + ranks by frequency; lexical similarity blends coverage + jaccard
- * (1.0 for identical keyword sets, 0 for disjoint).
- */
 
 describe("tokenizeFactText", () => {
 	it("lowercases, strips punctuation/stopwords, splits hyphens, floors length", () => {

--- a/packages/core/src/features/advanced-capabilities/fact-keywords.ts
+++ b/packages/core/src/features/advanced-capabilities/fact-keywords.ts
@@ -1,3 +1,12 @@
+/**
+ * Lexical keyword tooling behind fact retrieval in the advanced-capabilities
+ * bundle. Tokenizes fact text (lowercase, strip punctuation/stopwords, split
+ * hyphens, length floors), extracts and frequency-ranks keywords, and builds the
+ * per-fact search text and query text used for recall. `scoreFactKeywordRelevance`
+ * ranks candidate fact memories with BM25 over that search text, while
+ * `factLexicalSimilarity` blends coverage (0.7) and Jaccard (0.3) into a
+ * keyword-set similarity (1.0 identical, 0 disjoint) for dedupe/matching.
+ */
 import type { FactMetadata, Memory } from "../../types/index.ts";
 import { bm25Scores, normalizeBm25Scores } from "../documents/bm25.ts";
 

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers the PERSONALITY action handler against the in-memory FakeRuntime and a
+ * real PersonalityStore (no live model): scope-clarification for ambiguous
+ * requests, trait/reply-gate/directive mutations, named-profile load/save, and
+ * the audit-memory trail. Admin-only paths run on an owner-seeded runtime so
+ * hasRoleAccess grants access.
+ */
 import { beforeEach, describe, expect, test } from "vitest";
 import type { ActionResult, HandlerOptions } from "../../../../types/index.ts";
 import { personalityAction } from "../actions/personality.ts";

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-provider.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-provider.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers userPersonalityProvider.get against the in-memory FakeRuntime and a
+ * real PersonalityStore: rendering of user and global slots, suppression for
+ * agent self-messages and default (`always`) reply gates, and backward-
+ * compatible display of legacy free-text preference memories. Deterministic —
+ * no live model.
+ */
 import { beforeEach, describe, expect, test } from "vitest";
 import type { State, UUID } from "../../../../types/index.ts";
 import { userPersonalityProvider } from "../providers/user-personality.ts";

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-reply-gate.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-reply-gate.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit-tests the pure reply-gate helpers (resolveEffectiveReplyGate,
+ * decideReplyGate, messageContainsLiftSignal): user-over-global precedence, the
+ * never_until_lift / on_mention / always modes, and lift-signal detection. Pure
+ * functions over plain slot objects — no runtime, model, or store.
+ */
 import { describe, expect, test } from "vitest";
 import {
 	decideReplyGate,

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-store.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-store.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit-tests the PersonalityStore service (built on the in-memory FakeRuntime):
+ * per-user vs global slot isolation, trait writes and their audit entries, FIFO
+ * directive eviction at the cap, profile load/save, and the seeded default
+ * profiles. Deterministic — no live model.
+ */
 import { describe, expect, test } from "vitest";
 import { defaultProfiles } from "../profiles/index.ts";
 import {

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-verbosity.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-verbosity.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit-tests the verbosity enforcer (enforceVerbosity, approximateTokenCount):
+ * pass-through for normal/verbose/null, and terse truncation at the sentence
+ * boundary or via ellipsis once a reply exceeds the terse token cap. Pure
+ * functions, no runtime.
+ */
 import { describe, expect, test } from "vitest";
 import { MAX_TERSE_TOKENS } from "../types.ts";
 import {

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/test-helpers.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/test-helpers.ts
@@ -1,3 +1,11 @@
+/**
+ * Shared harness for the personality capability's unit tests: builds a minimal
+ * in-memory IAgentRuntime stub (Map-backed memory store, role resolution driven
+ * by an optional owner/admin set) wired to a real PersonalityStore, plus helpers
+ * to seed default profiles, craft messages, and capture handler callbacks. The
+ * store and the reply-gate/verbosity logic under test are real; only the runtime
+ * around them is faked — no live model and no database.
+ */
 import type {
 	Character,
 	Content,
@@ -104,12 +112,10 @@ export function makeFakeRuntime(options: FakeRuntimeOptions = {}): FakeRuntime {
 		async getParticipantUserState(): Promise<null> {
 			return null;
 		},
-		// hasRoleAccess uses these
 		// hasRoleAccess reads the canonical-owner config here: when `owner` is set
 		// it is exposed as ELIZA_ADMIN_ENTITY_ID so a message from that entity
-		// resolves to OWNER (>= ADMIN). Correct way to grant admin now that
-		// hasRoleAccess fails CLOSED on an unresolved role (no longer treats
-		// "no world context" as admin).
+		// resolves to OWNER (>= ADMIN). hasRoleAccess fails CLOSED on an
+		// unresolved role, so this is how these tests grant admin.
 		getSetting: (key: string) =>
 			key === "ELIZA_ADMIN_ENTITY_ID" && owner ? owner : undefined,
 		_test_owner: owner,

--- a/packages/core/src/features/advanced-capabilities/personality/actions/character.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/actions/character.test.ts
@@ -9,10 +9,10 @@ import type {
 /**
  * #12087 Item 17: CHARACTER declares a coarse `roleGate: { minRole: "ADMIN" }`
  * (the floor enforced by canActionRun) but `update_identity` (rename agent /
- * replace system prompt) requires OWNER. That per-op requirement used to be
- * three scattered inline `hasRoleAccess` checks — invisible in the metadata and
- * contradicting the declared gate. It now lives in the single, exported
- * CHARACTER_OP_ACCESS map that the handler enforces uniformly.
+ * replace system prompt) requires OWNER. That finer per-op requirement lives in
+ * the single, exported CHARACTER_OP_ACCESS map the handler enforces uniformly,
+ * not in scattered inline `hasRoleAccess` checks invisible in the metadata.
+ * Deterministic: `hasRoleAccess` is mocked; no live model or DB.
  */
 const rolesMock = vi.hoisted(() => ({ hasRoleAccess: vi.fn() }));
 vi.mock("../../../../roles.ts", () => rolesMock);

--- a/packages/core/src/features/advanced-capabilities/personality/actions/character.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/actions/character.ts
@@ -1,3 +1,22 @@
+/**
+ * Implements the CHARACTER action, the agent's self-editing entry point for its
+ * own character definition. Three operations dispatch from one handler: `modify`
+ * (LLM-driven edits to personality, tone, style, bio, topics, name, or system
+ * prompt, with a model-based safety filter and a per-user interaction-preference
+ * path), `persist` (flush the in-memory runtime.character to the persistence
+ * service), and `update_identity` (rename the agent or replace its system
+ * prompt).
+ *
+ * Access is layered: the declared `roleGate` is the coarse ADMIN floor, while
+ * CHARACTER_OP_ACCESS holds the finer per-op minimum the handler enforces
+ * (`update_identity` requires OWNER). `modify` first classifies intent with a
+ * rule heuristic, falling back to a TEXT_SMALL model call only when the
+ * heuristic is inconclusive; admins editing global scope go through
+ * CharacterFileManager, while non-admins (or an explicit user scope) store a
+ * per-user preference memory instead. `persist` flows through the shared
+ * persistCharacterPatch helper, and both global paths land in the
+ * character-persistence service.
+ */
 import { logger } from "../../../../logger.ts";
 import { hasRoleAccess } from "../../../../roles.ts";
 import type { Character } from "../../../../types/agent.ts";
@@ -32,8 +51,8 @@ type CharacterOp = (typeof CHARACTER_OPS)[number];
  * canActionRun before the handler runs; this map is the single, visible source
  * of truth for the finer per-op requirement the handler enforces (renaming the
  * agent / replacing its system prompt via `update_identity` requires OWNER, not
- * just ADMIN). Previously these were three scattered inline `hasRoleAccess`
- * checks, so the OWNER requirement was invisible in the action metadata.
+ * just ADMIN), instead of scattering inline `hasRoleAccess` checks that leave
+ * the OWNER requirement invisible in the action metadata.
  */
 export const CHARACTER_OP_ACCESS: Record<
 	CharacterOp,

--- a/packages/core/src/features/advanced-capabilities/personality/actions/personality.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/actions/personality.ts
@@ -1,3 +1,19 @@
+/**
+ * Implements the PERSONALITY action, the single dispatcher for structured
+ * personality-preference operations: setting or clearing the verbosity, tone,
+ * and formality traits, arming or lifting the reply gate, adding or clearing
+ * free-text directives, loading/saving named profiles, and showing current
+ * state. Each mutation runs through the PersonalityStore service and records an
+ * audit memory in the personality_audit_log table.
+ *
+ * Every trait/gate/directive op requires an explicit scope — "user" (the
+ * requesting entity's slot) or "global" (the agent-wide slot) — with no
+ * auto-inference: an ambiguous request returns a clarification rather than
+ * guessing. Global mutations and profile load/save are admin/owner-gated via
+ * hasRoleAccess. The slots written here are injected back into prompts by the
+ * user-personality provider and enforced by the reply-gate and verbosity
+ * helpers of the same capability.
+ */
 import { logger } from "../../../../logger.ts";
 import { hasRoleAccess } from "../../../../roles.ts";
 import type {
@@ -322,8 +338,8 @@ export const personalityAction: Action = {
 			? params.scope
 			: null;
 
-		// Ops that need scope: enforce explicit scope (NO auto-inference). This
-		// is the "non-ambiguity" the user explicitly asked for.
+		// Ops that need scope: enforce explicit scope (NO auto-inference) — an
+		// ambiguous request is clarified, never silently resolved to a default.
 		const needsScope: ReadonlySet<PersonalityOp> = new Set<PersonalityOp>([
 			"set_trait",
 			"clear_trait",

--- a/packages/core/src/features/advanced-capabilities/personality/character-persistence.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/character-persistence.ts
@@ -1,3 +1,12 @@
+/**
+ * Service-locator contract for the character-persistence service used by the
+ * personality capability. Exports the service-type token, the
+ * `CharacterPersistenceServiceLike` structural interface, a runtime type-guard,
+ * and `getCharacterPersistenceService` so callers (notably `CharacterFileManager`)
+ * can durably persist agent-driven or restored character changes without
+ * importing a concrete implementation. The persistence service itself lives
+ * outside core; core defines only the shape it must satisfy.
+ */
 import type { IAgentRuntime } from "../../../types/index.ts";
 
 export const CHARACTER_PERSISTENCE_SERVICE = "eliza_character_persistence";

--- a/packages/core/src/features/advanced-capabilities/personality/profiles/index.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/profiles/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Data module for the personality capability: the built-in named profiles that
+ * `PersonalityStore` registers on startup and that admins can load into the
+ * global slot via the PERSONALITY action.
+ */
 import type { PersonalityProfile } from "../types.ts";
 
 /**

--- a/packages/core/src/features/advanced-capabilities/personality/providers/user-personality.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/providers/user-personality.ts
@@ -1,3 +1,11 @@
+/**
+ * Provider in the personality capability that injects a user's structured
+ * personality slot (verbosity, tone, formality, reply-gate, custom directives),
+ * the global slot, and any legacy free-text preferences into the prompt, so the
+ * agent adapts its style per-user without editing the character definition.
+ * Reads slots from `PersonalityStore`; the export doc below covers the
+ * global-then-user prompt-precedence rule.
+ */
 import { logger } from "../../../../logger.ts";
 import type {
 	IAgentRuntime,

--- a/packages/core/src/features/advanced-capabilities/personality/reply-gate.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/reply-gate.ts
@@ -1,3 +1,11 @@
+/**
+ * Pure reply-gate decision logic for the personality capability. Given a user's
+ * and the global slot's `reply_gate` setting, decides whether the agent may
+ * respond at all before the model call — supporting the `on_mention` and
+ * `never_until_lift` mute modes and an explicit, testable list of lift phrases
+ * that unmute the agent. Consumed by the message runtime to short-circuit muted
+ * conversations without spending a model call.
+ */
 import type { PersonalitySlot, ReplyGateMode } from "./types.ts";
 
 /**

--- a/packages/core/src/features/advanced-capabilities/personality/services/character-file-manager.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/services/character-file-manager.ts
@@ -1,3 +1,13 @@
+/**
+ * Service in the personality capability that lets the agent safely self-modify
+ * its own character file. It validates proposed changes (a Zod schema plus
+ * name/system/bio/topic safety rules including prompt-injection and XSS guards),
+ * writes timestamped backups capped at `maxBackups`, merges the changes
+ * additively into the runtime character, and routes the durable write through
+ * the character-persistence service — updating `runtime.character` in place only
+ * after persistence succeeds. Also exposes backup/history listing and restore
+ * (from a backup file or a modification-history entry).
+ */
 import path from "node:path";
 import fs from "fs-extra";
 import { z } from "zod";

--- a/packages/core/src/features/advanced-capabilities/personality/services/personality-store.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/services/personality-store.ts
@@ -1,3 +1,13 @@
+/**
+ * Service in the personality capability that owns the structured personality
+ * slots (per-user and global) and the named profiles, plus an in-memory audit
+ * log of every mutation. Bundled profiles are registered on startup; slot
+ * mutations (`applyTrait`, `applyReplyGate`, add/clear directives,
+ * `loadProfileIntoGlobal`) return before/after pairs and record an audit entry.
+ * Slots are kept in-memory (mirrored as agent memories so state survives a
+ * reload). `getPersonalityStore` is the runtime accessor; the store backs the
+ * personality provider and the PERSONALITY action.
+ */
 import { logger } from "../../../../logger.ts";
 import type { IAgentRuntime } from "../../../../types/index.ts";
 import type { UUID } from "../../../../types/primitives.ts";

--- a/packages/core/src/features/advanced-capabilities/personality/types.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/types.ts
@@ -1,3 +1,11 @@
+/**
+ * Type system and constants for the personality capability: the
+ * `PersonalitySlot`, `PersonalityProfile`, and `PersonalityAuditEntry` shapes;
+ * the verbosity/tone/formality/reply-gate/trait/scope enums and their canonical
+ * value lists; memory-table names; the global-scope token; slot/directive
+ * limits; and the `ServiceTypeRegistry` augmentation for this capability's
+ * services. Shared by the store, providers, actions, and enforcer here.
+ */
 import type { UUID } from "../../../types/primitives.ts";
 import type { ServiceTypeRegistry } from "../../../types/service.ts";
 

--- a/packages/core/src/features/advanced-capabilities/personality/verbosity-enforcer.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/verbosity-enforcer.ts
@@ -1,3 +1,11 @@
+/**
+ * Deterministic post-generation verbosity enforcement for the personality
+ * capability. Approximates a token count via whitespace/punctuation splitting
+ * and hard-caps `terse` responses at `MAX_TERSE_TOKENS`, truncating at the
+ * nearest sentence boundary (`normal` and `verbose` pass through unchanged).
+ * Runs after the model returns so the truncation is observable in the
+ * trajectory.
+ */
 import { MAX_TERSE_TOKENS, type VerbosityLevel } from "./types.ts";
 
 /**

--- a/packages/core/src/features/advanced-capabilities/providers/contacts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/contacts.ts
@@ -1,3 +1,10 @@
+/**
+ * Provider in advanced-capabilities that injects the agent's saved contacts,
+ * grouped by category, into the prompt. Reads from `RelationshipsService`,
+ * caps the list at `MAX_CONTACTS`, resolves display names from entities, and
+ * emits per-category counts as provider values. Returns empty context when the
+ * relationships service is unavailable or on error.
+ */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import type { RelationshipsService } from "../../../services/relationships.ts";
 import type {

--- a/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for `factsProvider` (advanced-capabilities): asserts BM25 keyword
+ * retrieval surfaces the relevant durable/current facts (including a direct-recall
+ * fallback and current-fact time weighting) and that the provider never requests
+ * embeddings. Uses a hand-built deterministic runtime mock — no live model, no
+ * DB — whose `useModel` throws to enforce the no-embeddings invariant.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { IAgentRuntime, Memory, UUID } from "../../../types/index.ts";
 import { factsProvider } from "./facts.ts";

--- a/packages/core/src/features/advanced-capabilities/providers/facts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.ts
@@ -1,3 +1,16 @@
+/**
+ * FACTS provider: injects the durable and current facts the agent knows about
+ * the speaker into the prompt context. Pulls bounded recent candidate pools
+ * from the `facts` memory table (one room-scoped, one per related entity in the
+ * speaker's identity cluster), partitions them into durable (identity-level,
+ * never decays) and current (time-decayed) kinds, then ranks each kind locally
+ * with BM25 keyword scoring weighted by a per-kind confidence × recency prior.
+ * Retrieval deliberately avoids vector search so relevance is computed from the
+ * fact's own words and extracted keywords; a keyword-miss on durable facts
+ * falls back to the highest-prior candidates so direct recall still works. The
+ * ranking curves and two-store model are documented in
+ * docs/architecture/fact-memory.md.
+ */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { getRelatedEntityIds } from "../../../identity-clusters.ts";
 import type {

--- a/packages/core/src/features/advanced-capabilities/providers/followUps.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/followUps.ts
@@ -1,3 +1,11 @@
+/**
+ * FOLLOW_UPS provider: surfaces the agent's scheduled contact follow-ups into
+ * the prompt context. Reads upcoming follow-ups for the next 7 days plus
+ * relationship-lapse suggestions from the FollowUpService, resolves each
+ * contact's entity name, and renders a text summary split into overdue and
+ * upcoming groups (with days-overdue / days-until labels and reasons). Emits
+ * zero-count values and stays silent when the FollowUpService is unavailable.
+ */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import type { FollowUpService } from "../../../services/followUp.ts";
 import type {

--- a/packages/core/src/features/advanced-capabilities/providers/relationships.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/relationships.ts
@@ -1,3 +1,12 @@
+/**
+ * RELATIONSHIPS provider: injects the people the current speaker interacts with
+ * into the prompt context, sorted by interaction strength. Resolves the
+ * speaker's related-entity cluster, loads their relationship edges, keeps the
+ * strongest 30, and formats each counterpart as names + tags + a bounded slice
+ * of that entity's metadata. Output is hard-capped both per entity and in total
+ * because raw entity metadata can accumulate arbitrarily large blobs and would
+ * otherwise push the planner prompt past small-context model limits.
+ */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { getRelatedEntityIds } from "../../../identity-clusters.ts";
 import type {
@@ -24,17 +33,10 @@ const MAX_METADATA_CHARS_PER_ENTITY = 240;
 const MAX_RELATIONSHIPS_OUTPUT_CHARS = 4000;
 
 /**
- * Formats the provided relationships based on interaction strength and returns a string.
- * @param {IAgentRuntime} runtime - The runtime object to interact with the agent.
- * @param {Relationship[]} relationships - The relationships to format.
- * @returns {string} The formatted relationships as a string.
- */
-/**
- * Asynchronously formats relationships based on their interaction strength.
- *
- * @param {IAgentRuntime} runtime The runtime instance.
- * @param {Relationship[]} relationships The relationships to be formatted.
- * @returns {Promise<string>} A formatted string of the relationships.
+ * Sorts relationships by interaction strength, resolves each counterpart entity
+ * relative to the speaker's own ids, and renders the bounded names/tags/metadata
+ * block. `currentEntityIds` are the speaker's clustered ids, used to pick which
+ * side of each edge is the counterpart.
  */
 async function formatRelationships(
 	runtime: IAgentRuntime,

--- a/packages/core/src/features/advanced-capabilities/providers/roles.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/roles.ts
@@ -1,3 +1,12 @@
+/**
+ * ROLES provider: injects the server's role hierarchy (owners, administrators,
+ * members) into the prompt context for group channels. Reads role assignments
+ * from the room's world metadata ownership block, resolves each entity's display
+ * identity (falling back across per-platform metadata sources), dedupes by
+ * username, and renders a grouped Markdown hierarchy. Gated to GROUP rooms and
+ * callers with at least ADMIN role; returns an explanatory notice in DMs or when
+ * no ownership/role data exists for the world.
+ */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { logger } from "../../../logger.ts";
 import type {
@@ -80,19 +89,8 @@ function getRoleUser(entity: Entity | null | undefined): RoleUser | null {
 }
 
 /**
- * Role provider that retrieves roles in the server based on the provided runtime, message, and state.
- * * @type { Provider }
- * @property { string } name - The name of the role provider.
- * @property { string } description - A brief description of the role provider.
- * @property { Function } get - Asynchronous function that retrieves and processes roles in the server.
- * @param { IAgentRuntime } runtime - The agent runtime object.
- * @param { Memory } message - The message memory object.
- * @param { State } state - The state object.
- * @returns {Promise<ProviderResult>} The result containing roles data, values, and text.
- */
-/**
- * A provider for retrieving and formatting the role hierarchy in a server.
- * @type {Provider}
+ * Retrieves and formats the server role hierarchy from world ownership
+ * metadata; only meaningful in group scenarios (see the file header).
  */
 export const roleProvider: Provider = {
 	name: spec.name,

--- a/packages/core/src/features/advanced-capabilities/providers/settings.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/settings.ts
@@ -1,3 +1,13 @@
+/**
+ * SETTINGS provider: injects a world/server's configuration state into the
+ * prompt context and drives the onboarding / UPDATE_SETTINGS flow. Resolves the
+ * room's world (or, in a DM setup context, the owner's world — creating an empty
+ * settings block if none exists), decrypts stored secret values via
+ * unsaltWorldSettings, and renders either a setup checklist (required settings
+ * first, with explicit UPDATE_SETTINGS action instructions) or a read-only
+ * configuration summary. Secret values are masked outside setup, and total
+ * output is truncated at MAX_SETTINGS_OUTPUT_LENGTH.
+ */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { logger } from "../../../logger.ts";
 import { findWorldsForOwner } from "../../../roles.ts";
@@ -146,8 +156,8 @@ function generateStatusMessage(
 }
 
 /**
- * Creates an settings provider with the given configuration
- * Updated to use world metadata instead of cache
+ * Reads world settings from world metadata (secrets decrypted at read time) and
+ * formats them for setup or read-only display; see the file header.
  */
 export const settingsProvider: Provider = {
 	name: spec.name,

--- a/packages/core/src/features/advanced-memory/evaluators/index.ts
+++ b/packages/core/src/features/advanced-memory/evaluators/index.ts
@@ -1,8 +1,14 @@
-// Direct import + re-export (instead of `export { … } from`) so Bun.build's
-// tree-shaker can't elide the value bindings. The pure re-export form here
-// produced an empty module init in the mobile agent bundle and the runtime
-// crashed with `ReferenceError: memoryItems is not defined` when
-// `createAdvancedMemoryPlugin` referenced the binding.
+/**
+ * Barrel for the advanced-memory evaluators — `summaryEvaluator`,
+ * `longTermMemoryEvaluator`, and the `memoryItems` bundle — consumed by
+ * `createAdvancedMemoryPlugin`.
+ *
+ * Uses direct import + re-export rather than `export { … } from` so Bun.build's
+ * tree-shaker cannot elide the value bindings: the pure re-export form produced
+ * an empty module init in the mobile agent bundle, crashing the runtime with
+ * `ReferenceError: memoryItems is not defined` when the plugin referenced the
+ * binding.
+ */
 import {
 	longTermMemoryEvaluator as _longTermMemoryEvaluator,
 	memoryItems as _memoryItems,

--- a/packages/core/src/features/advanced-memory/evaluators/memory-items.test.ts
+++ b/packages/core/src/features/advanced-memory/evaluators/memory-items.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Deterministic regression tests for `summaryEvaluator`: the bounded
+ * first-summary prompt window, the first-store `lastMessageOffset` advancing by
+ * the summarized slice (not the full backlog), and `shouldRun` dialogue counting
+ * matching canonical `MemoryType.MESSAGE`. Uses an in-memory `createMockRuntime`
+ * and a stub `MemoryService` — no live model or database.
+ */
 import { describe, expect, it } from "vitest";
 import { createMockRuntime } from "../../../testing/mock-runtime";
 import type { EvaluatorRunOptions, Memory, State } from "../../../types";

--- a/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
+++ b/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
@@ -1,3 +1,20 @@
+/**
+ * The two evaluators of the advanced-memory capability. `summaryEvaluator` rolls
+ * the room's compact conversation summary forward; `longTermMemoryEvaluator`
+ * extracts high-confidence, durable facts about the user from recent dialogue.
+ * Both are bundled as `memoryItems` and registered by
+ * `createAdvancedMemoryPlugin`; each resolves `MemoryService` via
+ * `runtime.getService("memory")` and persists through it (summaries as session
+ * summaries, facts as long-term memories).
+ *
+ * Dialogue counting keys off the canonical `MemoryType.MESSAGE` (plus two legacy
+ * metadata strings for back-compat) and excludes synthetic-compaction and
+ * action_result rows, so summarization thresholds reflect real turns. Both the
+ * summary prompt and its store operate on a bounded slice of new dialogue
+ * (`summaryMaxNewMessages`) and advance `lastMessageOffset` by exactly that
+ * slice, so busy rooms never over-send and the rolling summary catches up across
+ * runs.
+ */
 import { logger } from "../../../logger.ts";
 import { EvaluatorPriority } from "../../../services/evaluator-priorities.ts";
 import type {

--- a/packages/core/src/features/advanced-memory/index.ts
+++ b/packages/core/src/features/advanced-memory/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Entry point for the advanced-memory capability. `createAdvancedMemoryPlugin`
+ * assembles the `memory` plugin from the summary + long-term evaluators, the
+ * summarized-context + long-term-recall providers, and `MemoryService`. The
+ * file also re-exports the capability's public surface — those
+ * evaluators/providers, the backend-agnostic schema definitions, the service,
+ * and its types.
+ */
 import type { IAgentRuntime, Plugin } from "../../types/index.ts";
 import { memoryItems } from "./evaluators/index.ts";
 import {

--- a/packages/core/src/features/advanced-memory/providers/context-summary.ts
+++ b/packages/core/src/features/advanced-memory/providers/context-summary.ts
@@ -1,3 +1,10 @@
+/**
+ * The `SUMMARIZED_CONTEXT` provider of the advanced-memory capability: injects
+ * the room's current rolling session summary (text, message range, date, and
+ * topics) into prompt context. Reads the summary from `MemoryService` via
+ * `runtime.getService("memory")`, trimming the body and topic list to bounded
+ * lengths; contributes nothing when no service or summary exists.
+ */
 import { logger } from "../../../logger.ts";
 import type {
 	IAgentRuntime,

--- a/packages/core/src/features/advanced-memory/providers/index.ts
+++ b/packages/core/src/features/advanced-memory/providers/index.ts
@@ -1,8 +1,13 @@
-// Direct import + re-export so Bun.build's tree-shaker can't elide these
-// value bindings the way it did for the pure `export { … } from` form
-// (see `../evaluators/index.ts` for the same workaround). The mobile
-// agent bundle was emitting an empty `init_providers` and the runtime
-// crashed with `ReferenceError: longTermMemoryProvider is not defined`.
+/**
+ * Barrel for the advanced-memory providers — `contextSummaryProvider` and
+ * `longTermMemoryProvider` — consumed by `createAdvancedMemoryPlugin`.
+ *
+ * Uses direct import + re-export rather than `export { … } from` so Bun.build's
+ * tree-shaker cannot elide the value bindings (same workaround as
+ * `../evaluators/index.ts`): the pure re-export form emitted an empty
+ * `init_providers` in the mobile agent bundle, crashing the runtime with
+ * `ReferenceError: longTermMemoryProvider is not defined`.
+ */
 import { contextSummaryProvider as _contextSummaryProvider } from "./context-summary.ts";
 import { longTermMemoryProvider as _longTermMemoryProvider } from "./long-term-memory.ts";
 

--- a/packages/core/src/features/advanced-memory/providers/long-term-memory.ts
+++ b/packages/core/src/features/advanced-memory/providers/long-term-memory.ts
@@ -1,3 +1,12 @@
+/**
+ * The `LONG_TERM_MEMORY` provider of the advanced-memory capability: injects the
+ * persistent facts and preferences stored about the current user into prompt
+ * context, rendered as "What I Know About You" with a per-category count. Reads
+ * the memories from `MemoryService` via `runtime.getService("memory")`, formats
+ * the already-fetched rows (rather than re-querying, to keep the count and text
+ * in agreement), and bounds the rendered text length; contributes nothing for
+ * the agent's own entity or when no service/memories exist.
+ */
 import { logger } from "../../../logger.ts";
 import type {
 	IAgentRuntime,

--- a/packages/core/src/features/advanced-memory/schemas/index.ts
+++ b/packages/core/src/features/advanced-memory/schemas/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Barrel for the advanced-memory capability's abstract table schemas: re-exports
+ * the backend-agnostic `SchemaTable` types plus the long-term-memories,
+ * memory-access-logs, and session-summaries table definitions that database
+ * plugins materialize. Also anchors the re-exported bindings against
+ * tree-shake collapse (see the bundle-safety note below).
+ */
+
 // Re-export the abstract schema types for convenience
 export type {
 	IndexColumn,

--- a/packages/core/src/features/advanced-memory/schemas/long-term-memories.ts
+++ b/packages/core/src/features/advanced-memory/schemas/long-term-memories.ts
@@ -1,3 +1,12 @@
+/**
+ * Backend-agnostic table schema for the advanced-memory capability's long-term
+ * store: durable per-entity facts categorized as episodic / semantic /
+ * procedural, each carrying a confidence score, optional source, optional
+ * embedding for vector recall, and access bookkeeping (count + last-accessed).
+ * MemoryService reads and writes these rows through a registered
+ * MemoryStorageProvider.
+ */
+
 import type { SchemaTable } from "../../../types/schema.ts";
 
 /**

--- a/packages/core/src/features/advanced-memory/schemas/memory-access-logs.ts
+++ b/packages/core/src/features/advanced-memory/schemas/memory-access-logs.ts
@@ -1,3 +1,10 @@
+/**
+ * Backend-agnostic table schema for the advanced-memory capability's access log:
+ * one row per read of a long-term memory or session summary, recording which
+ * memory (id + type), which agent, the access type, and when. Feeds usage
+ * bookkeeping for stored memories independent of the memory rows themselves.
+ */
+
 import type { SchemaTable } from "../../../types/schema.ts";
 
 /**

--- a/packages/core/src/features/advanced-memory/schemas/session-summaries.ts
+++ b/packages/core/src/features/advanced-memory/schemas/session-summaries.ts
@@ -1,3 +1,12 @@
+/**
+ * Backend-agnostic table schema for the advanced-memory capability's short-term
+ * rollups: one row per room-scoped (optionally entity-scoped) conversation
+ * summary, holding the summary text, message count and last-processed offset,
+ * the covered time window, extracted topics, and an optional embedding.
+ * MemoryService writes these as conversations grow so the context-summary
+ * provider can inject recent history.
+ */
+
 import type { SchemaTable } from "../../../types/schema.ts";
 
 /**

--- a/packages/core/src/features/advanced-memory/services/memory-service.ts
+++ b/packages/core/src/features/advanced-memory/services/memory-service.ts
@@ -1,3 +1,26 @@
+/**
+ * Runs the advanced-memory capability's `memory` service: short-term
+ * conversation summarization plus extraction and retrieval of long-term
+ * persistent facts. Registered by createAdvancedMemoryPlugin and consumed by
+ * the capability's providers (long-term-memory, context-summary) and evaluators
+ * (summary, long-term-memory).
+ *
+ * Persistence is delegated to a MemoryStorageProvider discovered at runtime via
+ * getService("memoryStorage") — supplied by a database plugin. When none is
+ * registered the service degrades gracefully: reads return empty, writes throw a
+ * descriptive error, and storage-backed features stay disabled. Thresholds and
+ * cadences come from runtime.getSetting (MEMORY_* keys) at initialize().
+ *
+ * Long-term reads are identity-cluster aware — they fan out across related
+ * entity IDs and dedupe by memory id so a cluster of N members yields distinct
+ * results rather than N copies. Vector search uses a native provider override
+ * when available and otherwise falls back to an in-process cosine scan (or to
+ * recent memories when vector search is disabled). The per-room session and
+ * per-(entity,room) extraction-checkpoint maps are capped FIFO to bound memory
+ * over long-lived processes. Also exports formatLongTermMemories, a pure helper
+ * that renders memories as a category-grouped markdown block.
+ */
+
 import {
 	getRelatedEntityIds,
 	resolvePrimaryEntityId,

--- a/packages/core/src/features/advanced-memory/trajectory.ts
+++ b/packages/core/src/features/advanced-memory/trajectory.ts
@@ -1,3 +1,12 @@
+/**
+ * Bridges the advanced-memory providers to the trajectory recorder: forwards a
+ * provider-access telemetry record (name, purpose, data, query) to the
+ * "trajectories" service so a captured run shows what context each memory
+ * provider injected. Resolves the trajectory step id from the message metadata
+ * or the ambient trajectory context, no-ops when neither is present, and
+ * swallows every error so telemetry never interrupts the message path.
+ */
+
 import { getTrajectoryContext } from "../../trajectory-context.ts";
 import type { TrajectoryProviderAccessLogger } from "../../trajectory-utils.ts";
 import type { IAgentRuntime, Memory } from "../../types/index.ts";

--- a/packages/core/src/features/advanced-memory/types.ts
+++ b/packages/core/src/features/advanced-memory/types.ts
@@ -1,3 +1,12 @@
+/**
+ * Type contracts for the advanced-memory capability: the LongTermMemoryCategory
+ * enum and the LongTermMemory / SessionSummary record shapes, the MemoryConfig
+ * knobs that drive summarization and extraction cadence, and the
+ * MemoryExtraction / SummaryResult model-output shapes. Shared by MemoryService,
+ * the memory providers and evaluators, and the MemoryStorageProvider contract in
+ * types/memory-storage.ts, which re-imports these as its persistence boundary.
+ */
+
 import type { TextGenerationModelType } from "../../types/model.ts";
 import type { JsonPrimitive, JsonValue, UUID } from "../../types/primitives.ts";
 

--- a/packages/core/src/features/advanced-planning/actions/plan.test.ts
+++ b/packages/core/src/features/advanced-planning/actions/plan.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the PLAN action's create/update/review/finalize subactions.
+ * Deterministic — the handler runs against a stub runtime with no model call;
+ * assertions cover the returned plan body and persistence metadata.
+ */
 import { describe, expect, test } from "vitest";
 import { CANONICAL_SUBACTION_KEY } from "../../../actions/subaction-dispatch.ts";
 import { planAction } from "./plan.ts";

--- a/packages/core/src/features/advanced-planning/actions/plan.ts
+++ b/packages/core/src/features/advanced-planning/actions/plan.ts
@@ -1,3 +1,12 @@
+/**
+ * Implements the PLAN action for the advanced-planning capability: a subaction
+ * router (create | update | finalize | review) that builds and edits multi-phase
+ * project plans. `create` synthesizes a phased plan from parameters; the other
+ * subactions operate on a supplied plan object, or return persistence-ready
+ * patches (`requiresPersistence: true`) when only a planId is given. Plans are
+ * constructed deterministically from parameters with no model call — distinct
+ * from PlanningService's LLM-driven planning. ADMIN role-gated.
+ */
 import { v4 as uuidv4 } from "uuid";
 import {
 	CANONICAL_SUBACTION_KEY,

--- a/packages/core/src/features/advanced-planning/index.ts
+++ b/packages/core/src/features/advanced-planning/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Barrel and plugin factory for the advanced-planning capability:
+ * `createAdvancedPlanningPlugin` registers the PLAN action and PlanningService,
+ * and disposes the service on unload. Also re-exports the capability's public
+ * types.
+ */
 import type { IAgentRuntime, Plugin } from "../../types/index.ts";
 import { planAction } from "./actions/plan.ts";
 import { PlanningService } from "./services/planning-service.ts";

--- a/packages/core/src/features/advanced-planning/services/planning-service.test.ts
+++ b/packages/core/src/features/advanced-planning/services/planning-service.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for PlanningService.createSimplePlan: verifies action selection
+ * follows the model's `<response>` actions decision, not keyword-matching on
+ * user text. Deterministic — the service runs against stub runtime/state with no
+ * live model.
+ */
 import { describe, expect, it } from "vitest";
 
 import type {

--- a/packages/core/src/features/advanced-planning/services/planning-service.ts
+++ b/packages/core/src/features/advanced-planning/services/planning-service.ts
@@ -1,3 +1,18 @@
+/**
+ * Runs the PlanningService for the advanced-planning capability: the long-lived
+ * service that turns goals into action plans and executes them. `createSimplePlan`
+ * wraps a model's chosen actions into a sequential plan; `createComprehensivePlan`
+ * prompts a TEXT_LARGE model to decompose a goal, then parses and enhances the
+ * result (unknown actions fall back to REPLY, missing retry policies are filled in).
+ * `executePlan` runs a plan's steps in sequential, parallel, or DAG order
+ * (topological, via a min-heap ready queue) with per-step retry/backoff, an
+ * in-memory PlanWorkingMemory, and abort-based cancellation tracked in
+ * `planExecutions`.
+ *
+ * `validatePlan` checks structure and, for DAG plans, circular dependencies;
+ * `adaptPlan` re-prompts the model to revise a plan mid-execution. Registered and
+ * disposed by createAdvancedPlanningPlugin.
+ */
 import { v4 as uuidv4 } from "uuid";
 import { logger } from "../../../logger.ts";
 import { runWithActionRoutingContext } from "../../../runtime/action-routing-context.ts";
@@ -189,13 +204,13 @@ export class PlanningService extends Service {
 		responseContent?: Content,
 	): Promise<ActionPlan | null> {
 		try {
-			// The model chooses which actions to run (the `<response>` actions
-			// field). When it chose none, the documented model-output contract
-			// treats the turn as a plain REPLY — so reply naturally instead of
-			// guessing intent by matching English keywords in the user's text
-			// (`text.includes("email"|"search"|"analyze"|…)`), which was brittle,
-			// English-only, and routed actions the model never decided to run
-			// (#10470, and the over-narration class in #10424).
+			// Action selection comes from the model's decision (the `<response>`
+			// actions field), never from keyword-matching the user's text. When
+			// the model chose no actions, the documented model-output contract
+			// treats the turn as a plain REPLY. Keyword routing (e.g.
+			// `text.includes("email"|"search"|"analyze")`) is avoided because it
+			// is brittle, English-only, and runs actions the model never decided
+			// to run (#10470, #10424).
 			const actions =
 				responseContent?.actions && responseContent.actions.length > 0
 					? responseContent.actions

--- a/packages/core/src/features/advanced-planning/types.ts
+++ b/packages/core/src/features/advanced-planning/types.ts
@@ -1,3 +1,10 @@
+/**
+ * Type contracts for the advanced-planning capability: the planning context,
+ * plan/step/execution-result shapes, retry policy, plan status, and the
+ * IPlanningService interface implemented by PlanningService and consumed by the
+ * PLAN action. Re-exports the shared JsonPrimitive/JsonValue helpers used across
+ * planning parameters.
+ */
 import type {
 	ActionParameters,
 	ActionResult,

--- a/packages/core/src/features/autonomy/action.test.ts
+++ b/packages/core/src/features/autonomy/action.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit test for the autonomy capability's ESCALATE action, covering the
+ * escalation targets it does not implement. Drives `escalateAction.handler`
+ * directly with cast-empty runtime/memory (no model, no service), asserting that
+ * `owner` and `third_party` targets fail with the `unsupported_escalation_target`
+ * error code rather than silently succeeding.
+ */
 import { describe, expect, it } from "vitest";
 import type { IAgentRuntime, Memory } from "../../types";
 import { escalateAction } from "./action";

--- a/packages/core/src/features/autonomy/service.test.ts
+++ b/packages/core/src/features/autonomy/service.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Unit tests for AutonomyService internals: filling the GEPA-optimized autonomy
+ * prompt when an OptimizedPromptService artifact is loaded, compacting older
+ * autonomous thoughts into a cached summary section, and gating target-room
+ * context so it never enumerates participant rooms without an explicit
+ * AUTONOMY_TARGET_ROOM_ID opt-in. Deterministic: uses `createMockRuntime` with an
+ * in-memory cache Map and an injected optimized-prompt service, no live model;
+ * private methods are reached through `unknown` casts.
+ */
 import { describe, expect, test, vi } from "vitest";
 import {
 	OPTIMIZED_PROMPT_SERVICE,

--- a/packages/core/src/features/basic-capabilities/actions/choice.test.ts
+++ b/packages/core/src/features/basic-capabilities/actions/choice.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Deterministic unit tests for the CHOOSE_OPTION action (`choiceAction`). The
+ * runtime is a vi.fn stub (getTasks/getTaskWorker/getRoom) — no live model, no
+ * DB — covering full-UUID and short-id task lookup, the #12087 Item 17
+ * authorization contract (validate checks only a pending choice, never a stored
+ * world role), and unknown-id rejection.
+ */
 import { describe, expect, it, vi } from "vitest";
 import type {
 	HandlerOptions,

--- a/packages/core/src/features/basic-capabilities/actions/choice.ts
+++ b/packages/core/src/features/basic-capabilities/actions/choice.ts
@@ -1,3 +1,13 @@
+/**
+ * Implements the CHOOSE_OPTION action of the basic-capabilities bundle: the
+ * agent's way to resolve a pending choice task (tasks tagged AWAITING_CHOICE
+ * whose metadata carries `options`). validate() gates on the declared
+ * `roleGate: { minRole: "ADMIN" }` plus the existence of such a task — it never
+ * re-derives the role itself. handler() matches the caller's taskId (short
+ * 8-char prefix or full UUID) and selectedOption, then runs the matching task
+ * worker (or deletes the task on the "ABORT" option); with no valid selection it
+ * replies with the formatted menu of tasks and their options.
+ */
 import { requireActionSpec } from "../../../generated/spec-helpers.ts";
 import { logger } from "../../../logger.ts";
 import type {

--- a/packages/core/src/features/basic-capabilities/actions/ignore.ts
+++ b/packages/core/src/features/basic-capabilities/actions/ignore.ts
@@ -1,3 +1,9 @@
+/**
+ * Implements the IGNORE action of the basic-capabilities bundle: the agent's way
+ * to intentionally stop responding — spam, hostility, or a thread it was asked
+ * to leave. handler() re-emits the pre-composed response content (if any) via the
+ * callback and returns a success result flagged `ignored`.
+ */
 import { requireActionSpec } from "../../../generated/spec-helpers.ts";
 import type {
 	Action,

--- a/packages/core/src/features/basic-capabilities/actions/none.ts
+++ b/packages/core/src/features/basic-capabilities/actions/none.ts
@@ -1,3 +1,8 @@
+/**
+ * Implements the NONE action of the basic-capabilities bundle: the no-op the
+ * planner selects when a turn needs a response but no further action. handler()
+ * performs no side effects and returns a success ActionResult.
+ */
 import { requireActionSpec } from "../../../generated/spec-helpers.ts";
 import type {
 	Action,

--- a/packages/core/src/features/basic-capabilities/actions/reply.test.ts
+++ b/packages/core/src/features/basic-capabilities/actions/reply.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Deterministic unit tests for the REPLY action's free-text branch. The runtime
+ * and useModel are vi.fn stubs (no live model), covering the fallback to
+ * planner-supplied text when the model returns empty structured text, and the
+ * fallback to raw non-JSON model text.
+ */
 import { describe, expect, it, vi } from "vitest";
 import type { IAgentRuntime, Memory, State } from "../../../index";
 import { ModelType } from "../../../index";

--- a/packages/core/src/features/basic-capabilities/actions/reply.ts
+++ b/packages/core/src/features/basic-capabilities/actions/reply.ts
@@ -1,3 +1,17 @@
+/**
+ * Implements the REPLY action of the basic-capabilities bundle — the agent's
+ * primary way to speak to the user. It extends the centralized REPLY spec with
+ * `ASK`/`CLARIFY` similes and a compressed description, and exposes two handler
+ * branches.
+ *
+ * The structured-question branch fires when a `questions` param is supplied: it
+ * validates 1-4 `ReplyQuestion` items (each with a header/question and optional
+ * multi-select options), renders them to text, and returns
+ * `requiresUserInteraction: true`. The free-text branch composes state and asks
+ * TEXT_LARGE for a reply — or echoes caller-provided `text` verbatim — parsing
+ * the model's JSON `{ thought, text }` and falling back to planner-supplied text
+ * when the model yields nothing usable.
+ */
 import { requireActionSpec } from "../../../generated/spec-helpers.ts";
 import { logger } from "../../../logger.ts";
 import { replyTemplate } from "../../../prompts.ts";
@@ -306,7 +320,7 @@ export const replyAction = {
 			};
 		}
 
-		// Free-text branch (the original REPLY behavior).
+		// Free-text branch: compose a reply from state, or echo caller text.
 		const actionContext = _options?.actionContext;
 		const previousResults = actionContext?.previousResults || [];
 

--- a/packages/core/src/features/basic-capabilities/channel-topic-search.test.ts
+++ b/packages/core/src/features/basic-capabilities/channel-topic-search.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Deterministic unit tests for the channel-topics search capability (#8927): the
+ * SEARCH_CHANNEL_TOPICS action and the GET /api/channel-topics/search route. The
+ * `channel_topics` service is a vi.fn stub, covering validate gating on service
+ * presence, param-vs-message-text query resolution, and the route's 200/400/503
+ * status contract.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { channelTopicSearchAction } from "./actions/channel-topic-search.ts";
 import { CHANNEL_TOPICS_SEARCH_ROUTE } from "./channel-topics-routes.ts";

--- a/packages/core/src/features/basic-capabilities/control-transport.test.ts
+++ b/packages/core/src/features/basic-capabilities/control-transport.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Integration tests for basic-capabilities control-message delivery. Each test
+ * boots a real AgentRuntime (allowNoDatabase, migrations skipped) with the
+ * basic-capabilities plugin plus a stub transport service, asserting that
+ * sendControlMessage routes through the typed CONTROL_TRANSPORT service and does
+ * NOT fall back to a substring-name-matched socket service.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { AgentRuntime } from "../../runtime.ts";
 import type { IAgentRuntime } from "../../types/runtime.ts";

--- a/packages/core/src/features/basic-capabilities/evaluators/__tests__/link-extraction.test.ts
+++ b/packages/core/src/features/basic-capabilities/evaluators/__tests__/link-extraction.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit coverage for the link-extraction evaluator (`linkExtractionEvaluator`):
+ * URL gating, preview fetch/summarize, dedupe and trailing-punctuation
+ * stripping, platform stamping, and output parsing. The harness is fully
+ * deterministic — a hand-mocked runtime with a `vi.fn` `useModel`, a stubbed
+ * `globalThis.fetch`, and no real network, model, or database.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
 	EvaluatorRunContext,

--- a/packages/core/src/features/basic-capabilities/evaluators/index.ts
+++ b/packages/core/src/features/basic-capabilities/evaluators/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Barrel for the basic-capabilities inbound auto-capture evaluators, collected
+ * into `basicCapabilitiesEvaluators` for the runtime's evaluator registry.
+ */
 import type { RegisteredEvaluator } from "../../../types/index.ts";
 import { linkExtractionEvaluator } from "./link-extraction.ts";
 
@@ -10,9 +14,9 @@ export { linkExtractionEvaluator } from "./link-extraction.ts";
  * records to memory as a side effect. Never modifies the agent's response and
  * never blocks the planner — failures are logged and swallowed.
  *
- * Image attachments are no longer analyzed here: inbound images are described
- * during message processing via the shared image-description cache, so a
- * post-response evaluator would only duplicate that vision call.
+ * Image attachments are not analyzed here: inbound images are described during
+ * message processing via the shared image-description cache, so a post-response
+ * evaluator would only duplicate that vision call.
  */
 export const basicCapabilitiesEvaluators: RegisteredEvaluator[] = [
 	linkExtractionEvaluator,

--- a/packages/core/src/features/basic-capabilities/evaluators/link-extraction.ts
+++ b/packages/core/src/features/basic-capabilities/evaluators/link-extraction.ts
@@ -1,3 +1,17 @@
+/**
+ * The link-extraction evaluator (`linkExtractionEvaluator`) for the
+ * basic-capabilities bundle: an inbound auto-capture evaluator that scans
+ * incoming message text for http(s) URLs, fetches a title/summary preview for
+ * each, and persists them as `link` memories in the `links` table.
+ *
+ * Registered through `evaluators/index.ts`. URLs are attacker-controlled, so
+ * every preview fetch is routed through the SSRF guard (`fetchWithSsrfGuard`),
+ * and the summary is produced by a `TEXT_SMALL` model call over the fetched
+ * page body. Capture is best-effort: the raw URL is still persisted when the
+ * preview fetch or summarization fails, per-message URLs are deduped and capped
+ * at `MAX_LINKS_PER_MESSAGE`, and per-URL errors are logged and swallowed so
+ * the evaluator never blocks the planner.
+ */
 import { v4 } from "uuid";
 import { fetchWithSsrfGuard } from "../../../network/index.ts";
 import { EvaluatorPriority } from "../../../services/evaluator-priorities.ts";
@@ -137,7 +151,7 @@ async function fetchLinkPreview(
 	// URLs come straight from inbound message text, so this fetch is attacker-
 	// controlled — route it through the SSRF guard (DNS-pinned, private/internal
 	// targets blocked, redirects validated per hop). Any failure (blocked,
-	// invalid, timeout, network) → no preview, exactly as before.
+	// invalid, timeout, network) → no preview.
 	let release: (() => Promise<void>) | undefined;
 	try {
 		const guarded = await fetchWithSsrfGuard({

--- a/packages/core/src/features/basic-capabilities/prompt-runner-task.test.ts
+++ b/packages/core/src/features/basic-capabilities/prompt-runner-task.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit coverage for the prompt-runner `TaskWorker` (`promptRunnerTaskWorker`):
+ * it wraps a scheduled task's `metadata.prompt` in the system prompt, calls
+ * `TEXT_LARGE` with `background` priority, and rejects a missing or empty
+ * prompt. Deterministic harness — a stub runtime whose `useModel` is a `vi.fn`,
+ * no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { ModelType } from "../../types/model";
 import type { IAgentRuntime } from "../../types/runtime";

--- a/packages/core/src/features/basic-capabilities/providers/actionState.ts
+++ b/packages/core/src/features/basic-capabilities/providers/actionState.ts
@@ -1,3 +1,16 @@
+/**
+ * The ACTION_STATE provider for the basic-capabilities bundle: it injects what
+ * has already happened in the current action chain into the planner prompt so
+ * later actions can build on earlier ones.
+ *
+ * It assembles up to four sections — the active action plan (steps, progress,
+ * per-step status/errors/results), the current chain's action results, working
+ * memory (top recent entries by timestamp), and recent action history
+ * reconstructed from `action_result` memories in the `messages` table (grouped
+ * by run and trimmed to a character budget). Results are context-agnostic, so
+ * the provider is not cache-stable across a turn; any failure degrades to
+ * "No action state available" rather than throwing.
+ */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import type {
 	ActionResult,
@@ -35,10 +48,6 @@ function formatDataForPrompt(data: unknown): string {
 	}
 }
 
-/**
- * Provider for sharing action execution state and plan between actions
- * Makes previous action results and execution plan available to subsequent actions
- */
 export const actionStateProvider: Provider = {
 	name: spec.name,
 	description: spec.description,

--- a/packages/core/src/features/basic-capabilities/providers/actions.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/actions.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit coverage for the ACTIONS provider's `isFollowUpCapableAction` helper:
+ * follow-up capability is recognized only via the `FOLLOW_UP_CAPABLE_ACTION_TAG`
+ * tag, never inferred from an action's name. Pure and deterministic — no runtime.
+ */
 import { describe, expect, it } from "vitest";
 import { FOLLOW_UP_CAPABLE_ACTION_TAG } from "../../../types/index.ts";
 import { isFollowUpCapableAction } from "./actions.ts";

--- a/packages/core/src/features/basic-capabilities/providers/actions.ts
+++ b/packages/core/src/features/basic-capabilities/providers/actions.ts
@@ -1,3 +1,21 @@
+/**
+ * The ACTIONS provider for the basic-capabilities bundle: it injects the
+ * catalog of response actions available for the current turn into the prompt.
+ *
+ * For each registered action it runs the action's `validate` against the
+ * message plus the connector account-policy check, then keeps only survivors
+ * whose contexts match the turn's active routing contexts. Non-actionable
+ * chatter and relationship follow-up reminders narrow the visible set down to
+ * generic chat actions (or follow-up-capable ones); grouped actions are
+ * collapsed for main chat and re-expanded — with their subactions and dynamic
+ * providers — when their context is engaged.
+ *
+ * The result surfaces `actionNames`, `actionsWithDescriptions`, and a
+ * `# Context Capabilities` block, and stashes the capability metadata under
+ * `CONTEXT_CAPABILITIES_STATE_KEY` for downstream context routing. Name/order
+ * randomization is seeded deterministically per (agent, room) so the catalog is
+ * stable within a conversation.
+ */
 import { formatActionNames, formatActions } from "../../../actions.ts";
 import { evaluateConnectorAccountPolicies } from "../../../connectors/account-manager.ts";
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
@@ -317,38 +335,6 @@ function formatContextCapabilities(
 	return lines.join("\n");
 }
 
-/**
- * A provider object that fetches possible response actions based on the provided runtime, message, and state.
- * @type {Provider}
- * @property {string} name - The name of the provider ("ACTIONS").
- * @property {string} description - The description of the provider ("Possible response actions").
- * @property {number} position - The position of the provider (-1).
- * @property {Function} get - Asynchronous function that retrieves actions that validate for the given message.
- * @param {IAgentRuntime} runtime - The runtime object.
- * @param {Memory} message - The message memory.
- * @param {State} state - The state object.
- * @returns {Object} An object containing the actions data, values, and combined text sections.
- */
-/**
- * Provider for ACTIONS
- *
- * @typedef {import('./Provider').Provider} Provider
- * @typedef {import('./Runtime').IAgentRuntime} IAgentRuntime
- * @typedef {import('./Memory').Memory} Memory
- * @typedef {import('./State').State} State
- * @typedef {import('./Action').Action} Action
- *
- * @type {Provider}
- * @property {string} name - The name of the provider
- * @property {string} description - Description of the provider
- * @property {number} position - The position of the provider
- * @property {Function} get - Asynchronous function to get actions that validate for a given message
- *
- * @param {IAgentRuntime} runtime - The agent runtime
- * @param {Memory} message - The message memory
- * @param {State} state - The state of the agent
- * @returns {Object} Object containing data, values, and text related to actions
- */
 export const actionsProvider: Provider = {
 	name: spec.name,
 	description: spec.description,
@@ -437,7 +423,7 @@ export const actionsProvider: Provider = {
 			[CONTEXT_CAPABILITIES_STATE_KEY]: contextCapabilitiesText,
 		};
 
-		// Combine all text sections - now including actionsWithDescriptions
+		// Combine all text sections: action names, descriptions, and context capabilities
 		const text = [actionNames, actionsWithDescriptions, contextCapabilitiesText]
 			.filter(Boolean)
 			.join("\n\n");

--- a/packages/core/src/features/basic-capabilities/providers/attachments.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/attachments.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit coverage for the ATTACHMENTS provider (`attachmentsProvider`): stale
+ * room attachments stay out of unrelated prompt text and out of sub-agent
+ * result turns, relevance is judged from the current/reply message text, and
+ * an `ATTACHMENT action=read` is advertised only when readable text is stored —
+ * with images the exception when a vision (`IMAGE_DESCRIPTION`) model is
+ * registered. Deterministic harness: a hand-stubbed runtime, no live model or DB.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	type IAgentRuntime,

--- a/packages/core/src/features/basic-capabilities/providers/attachments.ts
+++ b/packages/core/src/features/basic-capabilities/providers/attachments.ts
@@ -1,3 +1,18 @@
+/**
+ * The ATTACHMENTS provider for the basic-capabilities bundle: it injects the
+ * conversation's attachments into the prompt. Attachments from the current
+ * message and recent room messages are merged by id (newest wins), sorted
+ * most-recent-first, and capped at `MAX_VISIBLE_ATTACHMENTS`.
+ *
+ * Prompt text is gated: it renders only when the current message carries its
+ * own attachments, or when the current/reply message text both references and
+ * asks to inspect an attachment — stale room attachments never leak into
+ * unrelated turns, and sub-agent result turns are excluded outright. For each
+ * visible attachment it advertises whether the content is readable via
+ * `ATTACHMENT action=read`, keyed on stored `text`; images are the exception,
+ * since the read action re-describes them at read time whenever an
+ * `IMAGE_DESCRIPTION` model is registered.
+ */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import {
 	ContentType,
@@ -101,23 +116,6 @@ function shouldRenderAttachmentPromptText(
 	);
 }
 
-/**
- * Provides a list of attachments in the current conversation.
- * @param {IAgentRuntime} runtime - The agent runtime object.
- * @param {Memory} message - The message memory object.
- * @returns {Object} The attachments values, data, and text.
- */
-/**
- * Provides a list of attachments sent during the current conversation, including names, descriptions, and summaries.
- * @type {Provider}
- * @property {string} name - The name of the provider (ATTACHMENTS).
- * @property {string} description - Description of the provider.
- * @property {boolean} dynamic - Indicates if the provider is dynamic.
- * @property {function} get - Asynchronous function that retrieves attachments based on the runtime and message provided.
- * @param {IAgentRuntime} runtime - The runtime environment for the agent.
- * @param {Memory} message - The message object containing content and attachments.
- * @returns {Object} An object containing values, data, and text about the attachments retrieved.
- */
 export const attachmentsProvider: Provider = {
 	name: spec.name,
 	description: spec.description,

--- a/packages/core/src/features/basic-capabilities/providers/channelTopics.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/channelTopics.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Tests for the CHANNEL_TOPICS provider — asserts it renders the room's topic
+ * LRU most-recent-first, no-ops when the room has no topics or the service is
+ * unregistered, and reflects topics hydrated from persisted room metadata after
+ * a restart. Deterministic: a real ChannelTopicsService over an in-memory mock
+ * runtime, no live model.
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChannelTopicsService } from "../../../services/channel-topics";
 import { createMockRuntime } from "../../../testing/mock-runtime";

--- a/packages/core/src/features/basic-capabilities/providers/character.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/character.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests the CHARACTER provider's topics-sentence formatting — the
+ * "is also interested in" clause is omitted when the picked topic is the only
+ * topic, and rendered (excluding the picked topic) when other topics exist.
+ * Deterministic: a hand-built runtime stub, no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import type { IAgentRuntime, Memory, State } from "../../../types/index.ts";
 import { ChannelType } from "../../../types/index.ts";

--- a/packages/core/src/features/basic-capabilities/providers/character.ts
+++ b/packages/core/src/features/basic-capabilities/providers/character.ts
@@ -1,3 +1,13 @@
+/**
+ * The CHARACTER provider: injects the agent's identity into the prompt — the
+ * canonical system prompt, a bio sample, a deterministically picked current
+ * topic plus an "also interested in" list, an adjective, message/post examples,
+ * and chat-vs-post style directions chosen by room type (FEED/THREAD render the
+ * post variant). Every random-looking selection is seeded per agent+room via
+ * buildDeterministicSeed so a turn renders stably, and name placeholders are
+ * expanded through the name-token helpers. Text content (name/description) comes
+ * from the centralized CHARACTER provider spec.
+ */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import {
 	replaceIndexedNameTokens,
@@ -111,9 +121,6 @@ export const characterProvider: Provider = {
 					)
 				: null;
 
-		// postCreationTemplate in core prompts.ts
-		// Write a post that is {{adjective}} about {{topic}} (without mentioning {{topic}} directly), from the perspective of {{agentName}}. Do not add commentary or acknowledge this request, just write the post.
-		// Write a post that is {{Spartan is dirty}} about {{Spartan is currently}}
 		const topic = topicString || "";
 
 		// Format topics list. Sample the OTHER topics first — when the picked

--- a/packages/core/src/features/basic-capabilities/providers/choice.ts
+++ b/packages/core/src/features/basic-capabilities/providers/choice.ts
@@ -1,3 +1,9 @@
+/**
+ * The CHOICE provider: surfaces the room's pending tasks tagged AWAITING_CHOICE
+ * that carry selectable options, rendered as a numbered list the user can answer
+ * by naming an option. Returns a "no pending choices" placeholder when none are
+ * awaiting selection. Text content comes from the centralized CHOICE provider spec.
+ */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import type {
 	IAgentRuntime,
@@ -10,13 +16,6 @@ import type {
 // Get text content from centralized specs
 const spec = requireProviderSpec("CHOICE");
 
-// Define an interface for option objects
-/**
- * Interface for an object representing an option.
- * @typedef {Object} OptionObject
- * @property {string} name - The name of the option.
- * @property {string} [description] - The description of the option (optional).
- */
 /**
  * Interface for an object representing an option.
  * @typedef {Object} OptionObject

--- a/packages/core/src/features/basic-capabilities/providers/contextBench.ts
+++ b/packages/core/src/features/basic-capabilities/providers/contextBench.ts
@@ -1,3 +1,11 @@
+/**
+ * The CONTEXT_BENCH provider: bridges a benchmark harness into the message loop.
+ * When the inbound message carries a `benchmarkContext` metadata string it
+ * surfaces that text to the model and flags `benchmark_has_context` in state, so
+ * the message service forces REPLY/action execution and the full provider ->
+ * model -> action -> evaluator loop runs during benchmarks. See the provider doc
+ * below for the harness contract.
+ */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import type {
 	IAgentRuntime,

--- a/packages/core/src/features/basic-capabilities/providers/currentTime.ts
+++ b/packages/core/src/features/basic-capabilities/providers/currentTime.ts
@@ -1,3 +1,10 @@
+/**
+ * The CURRENT_TIME provider: injects the current date and time into the prompt
+ * in several formats (ISO, unix, date-only, time-only, day-of-week, and a human
+ * readable full form), resolved against the agent's TIMEZONE setting (default
+ * UTC) so the agent can reason about "now". Text content comes from the
+ * centralized CURRENT_TIME provider spec.
+ */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import type {
 	IAgentRuntime,

--- a/packages/core/src/features/basic-capabilities/providers/entities.ts
+++ b/packages/core/src/features/basic-capabilities/providers/entities.ts
@@ -1,3 +1,9 @@
+/**
+ * The ENTITIES provider: injects the people present in the current room —
+ * formatted entity details under a "People in the Room" header plus the sender's
+ * resolved name — so the agent knows who it is talking to. Text content comes
+ * from the centralized ENTITIES provider spec.
+ */
 import { formatEntities, getEntityDetails } from "../../../entities.ts";
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import type {

--- a/packages/core/src/features/basic-capabilities/providers/non-actionable-chatter.ts
+++ b/packages/core/src/features/basic-capabilities/providers/non-actionable-chatter.ts
@@ -1,3 +1,12 @@
+/**
+ * Text heuristics that classify an inbound user message as non-actionable
+ * chatter (idle small talk, venting, open-ended advice-seeking) or as a one-off
+ * relationship follow-up reminder. The PROVIDERS and ACTIONS providers consume
+ * these to suppress the full provider/action catalog for such messages — only
+ * GENERIC_CHAT_ACTIONS survive (plus follow-up-capable actions for reminders) —
+ * so the model isn't prompted to act on pure chatter. Matching runs over
+ * normalized user message text.
+ */
 import type { Memory } from "../../../types/index.ts";
 import { normalizeUserMessageText } from "../../../utils/message-text.ts";
 

--- a/packages/core/src/features/basic-capabilities/providers/platformContext.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/platformContext.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Tests for the PLATFORM_CHAT_CONTEXT and PLATFORM_USER_CONTEXT providers —
+ * covers connector selection (current-source match vs explicit routing context),
+ * per-platform output guidance, omission of recent messages from prompt text,
+ * and entity-scoped user resolution. Deterministic: connectors are vi.fn stubs,
+ * no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import type {
 	IAgentRuntime,

--- a/packages/core/src/features/basic-capabilities/providers/platformContext.ts
+++ b/packages/core/src/features/basic-capabilities/providers/platformContext.ts
@@ -1,3 +1,15 @@
+/**
+ * The PLATFORM_CHAT_CONTEXT and PLATFORM_USER_CONTEXT providers: inject
+ * connector-specific metadata for the current platform target. Chat context
+ * carries per-connector room metadata (source, channel/thread ids, summaries,
+ * output guidance) — deliberately NOT the canonical transcript, which the
+ * RECENT_MESSAGES provider owns; user context carries sender identity (handles,
+ * aliases, account labels). Connectors are selected by matching the message
+ * source, or by overlapping explicit routing contexts when no source is set, and
+ * each connector hook's result is normalized to JSON-safe ProviderValues. Recent
+ * messages are stripped from the emitted prompt text but kept in `data` for
+ * diagnostics.
+ */
 import type {
 	AgentContext,
 	IAgentRuntime,
@@ -45,9 +57,9 @@ const MAX_CONNECTOR_CONTEXTS = 8;
 // adds a per-connector view of the same conversation (so the model can
 // see e.g. that the same room is bridged across Discord and Telegram).
 // Five messages is enough to disambiguate the connector source without
-// re-shipping the full history twice. Was 10, lowered because two-connector
-// rooms (e.g. Discord default account + Discord stealth account) were
-// double-counting and pushing ~130K extra characters into the prompt.
+// re-shipping the full history twice. Kept low because two-connector rooms
+// (e.g. Discord default account + Discord stealth account) double-count and
+// would otherwise push ~130K extra characters into the prompt.
 const MAX_RECENT_MESSAGES = 5;
 const PLATFORM_OUTPUT_GUIDANCE: Record<string, string[]> = {
 	discord: [

--- a/packages/core/src/features/basic-capabilities/providers/provider-descriptions.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/provider-descriptions.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Guards that the conversation-history providers keep distinct, non-overlapping
+ * descriptions — RECENT_MESSAGES (the transcript), PLATFORM_CHAT_CONTEXT and
+ * PLATFORM_USER_CONTEXT (connector metadata), ADMIN_CHAT_HISTORY (autonomy
+ * control room) — so the planner never conflates them. Deterministic: asserts on
+ * the imported provider objects' static `description` strings; no runtime or model.
+ */
+
 import { describe, expect, it, vi } from "vitest";
 import { adminChatProvider } from "../../autonomy/providers.ts";
 import {

--- a/packages/core/src/features/basic-capabilities/providers/providers.ts
+++ b/packages/core/src/features/basic-capabilities/providers/providers.ts
@@ -1,3 +1,13 @@
+/**
+ * PROVIDERS provider — injects the catalog of available data providers into the
+ * planner prompt so the model can pick which context sources to pull on the next
+ * turn. Renders each provider's (compressed) description alongside a set of
+ * selection hints that map request kinds to provider names, and filters the list
+ * to providers whose declared contexts match the turn's active routing contexts.
+ * Suppresses the list entirely when the message looks like non-actionable
+ * chatter. Part of the basic-capabilities bundle.
+ */
+
 import {
 	getProviderSpec,
 	requireProviderSpec,
@@ -19,21 +29,6 @@ import { looksLikeNonActionableChatter } from "./non-actionable-chatter.ts";
 // Get text content from centralized specs
 const spec = requireProviderSpec("PROVIDERS");
 
-/**
- * Provider for retrieving list of all data providers available for the agent to use.
- * @type { Provider }
- */
-/**
- * Object representing the providersProvider, which contains information about data providers available for the agent.
- *
- * @type {Provider}
- * @property {string} name - The name of the provider ("PROVIDERS").
- * @property {string} description - Description of the provider.
- * @property {Function} get - Async function that filters dynamic providers, creates formatted text for each provider, and provides data for potential use.
- * @param {IAgentRuntime} runtime - The runtime of the agent.
- * @param {Memory} _message - The memory message.
- * @returns {Object} An object containing the formatted text and data for potential programmatic use.
- */
 export const providersProvider: Provider = {
 	name: spec.name,
 	description: spec.description,

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Behavioral tests for the RECENT_MESSAGES provider's transcript hygiene:
+ * dropping internal bridge / sub-agent / tool / path-dump / synthetic-failure /
+ * transient rows, deduping, compaction-ledger inclusion, and the conversation-
+ * window cap. Deterministic — drives `recentMessagesProvider.get` against a
+ * hand-built in-memory runtime of `vi.fn` stubs; no live model or database.
+ */
+
 import { describe, expect, it, vi } from "vitest";
 import {
 	ChannelType,

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
@@ -1,3 +1,27 @@
+/**
+ * RECENT_MESSAGES provider — builds the canonical bounded conversation
+ * transcript injected into the planner prompt for the current room. Fetches room
+ * memories (honoring the compaction start point), then filters, dedupes, and
+ * formats them into `# Conversation Messages` / `# Posts in Thread` blocks plus a
+ * `# Received Message` / `# Focus your response` framing for the incoming turn.
+ * Part of the basic-capabilities bundle and the single source of dialogue
+ * history — PLATFORM_CHAT_CONTEXT carries connector metadata, not the transcript.
+ *
+ * The filtering is load-bearing for prompt hygiene: internal bridge rows
+ * (sub-agent-router / swarm-synthesis), synthetic provider-failure replies,
+ * transient orchestrator status posts, leaked tool transcripts and local-path
+ * dumps, and consecutive- or assistant-run duplicates are all stripped so the
+ * model never re-reads its own machinery or paraphrases it as fact on a later
+ * turn. Rendered history is hard-capped to the runtime conversation length
+ * regardless of how many rows the adapter returns, and a persisted compaction
+ * ledger is prepended when present. On any error the provider degrades to an
+ * empty, safe result rather than throwing — a throw here would drop the entire
+ * turn's history.
+ *
+ * Also surfaces cross-room `recentInteractions` between the sender's identity
+ * cluster and the agent, rendered as message or post interactions by room type.
+ */
+
 import { getEntityDetails } from "../../../entities.ts";
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { getRelatedEntityIds } from "../../../identity-clusters.ts";
@@ -303,24 +327,8 @@ async function ensureFormattingEntities(
 	return Array.from(entitiesById.values());
 }
 
-// Move getRecentInteractions outside the provider
-/**
- * Retrieves the recent interactions between two entities in a specific context.
- *
- * @param {IAgentRuntime} runtime - The agent runtime object.
- * @param {UUID} sourceEntityId - The UUID of the source entity.
- * @param {UUID} targetEntityId - The UUID of the target entity.
- * @param {UUID} excludeRoomId - The UUID of the room to exclude from the search.
- * @returns {Promise<Memory[]>} A promise that resolves to an array of Memory objects representing recent interactions.
- */
-/**
- * Retrieves the recent interactions between two entities in different rooms excluding a specific room.
- * @param {IAgentRuntime} runtime - The agent runtime object.
- * @param {UUID} sourceEntityId - The UUID of the source entity.
- * @param {UUID} targetEntityId - The UUID of the target entity.
- * @param {UUID} excludeRoomId - The UUID of the room to exclude from the search.
- * @returns {Promise<Memory[]>} An array of Memory objects representing recent interactions between the two entities.
- */
+// Cross-room history between the sender's identity cluster and the target
+// entity, excluding the current room, capped to the most recent 20 rows.
 const getRecentInteractions = async (
 	runtime: IAgentRuntime,
 	sourceEntityId: UUID,
@@ -347,17 +355,6 @@ const getRecentInteractions = async (
 	});
 };
 
-/**
- * A provider object that retrieves recent messages, interactions, and memories based on a given message.
- * @typedef {object} Provider
- * @property {string} name - The name of the provider ("RECENT_MESSAGES").
- * @property {string} description - A description of the provider's purpose ("Recent messages, interactions and other memories").
- * @property {number} position - The position of the provider (100).
- * @property {Function} get - Asynchronous function that retrieves recent messages, interactions, and memories.
- * @param {IAgentRuntime} runtime - The runtime context for the agent.
- * @param {Memory} message - The message to retrieve data from.
- * @returns {object} An object containing data, values, and text sections.
- */
 export const recentMessagesProvider: Provider = {
 	name: spec.name,
 	description: spec.description,

--- a/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Tests the RUNTIME_MODEL_CONTEXT provider's slot resolution and gating: reading
+ * configured model slots, using the runtime resolver, provider-declared display
+ * settings, omitting unresolvable slots, and staying silent for non-model or
+ * sub-agent turns. Deterministic — a fake runtime (settings map + `models` map),
+ * toggling `process.env.CODEX_MODEL` to exercise the env fallback; no live model.
+ */
+
 import { describe, expect, it } from "vitest";
 import type { Memory } from "../../../types/memory.ts";
 import { ModelType } from "../../../types/model.ts";

--- a/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.ts
+++ b/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.ts
@@ -1,3 +1,19 @@
+/**
+ * RUNTIME_MODEL_CONTEXT provider — injects the agent's live model/provider
+ * configuration into the prompt so it can answer "what model are you using?"
+ * from real runtime facts instead of training-data guesses. Resolves each model
+ * slot (response handler, action planner, large/small text) via the runtime
+ * resolver, provider-declared display-model metadata, or the configured
+ * `*_MODEL` settings/env keys, and reports the provider adapter name, endpoint
+ * host, and the default coding sub-agent's model. Part of the basic-capabilities
+ * bundle.
+ *
+ * Gated: `shouldRenderRuntimeModelContext` only fires for self-directed
+ * model/provider/coding-agent questions and stays silent for sub-agent
+ * transcripts and unrelated turns. A slot that stays unresolvable is OMITTED
+ * rather than rendering its raw slot name (e.g. "RESPONSE_HANDLER") to the user.
+ */
+
 import type {
 	IAgentRuntime,
 	Memory,

--- a/packages/core/src/features/basic-capabilities/providers/uiContext.ts
+++ b/packages/core/src/features/basic-capabilities/providers/uiContext.ts
@@ -1,3 +1,11 @@
+/**
+ * UI_CONTEXT provider — surfaces which Eliza UI surface (view and tab) sent the
+ * current message and the capability contexts forced active for this turn, so
+ * the planner prefers actions and providers matching that context first. Stays
+ * silent when there is neither a UI view nor an active routing context. Part of
+ * the basic-capabilities bundle.
+ */
+
 import type { Memory, Provider, State } from "../../../types/index.ts";
 import {
 	CONTEXT_ROUTING_METADATA_KEY,

--- a/packages/core/src/features/basic-capabilities/providers/userEmotionSignal.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/userEmotionSignal.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Tests the USER_EMOTION_SIGNAL provider: emitting the `USER_SIGNAL` line for
+ * above-threshold voice emotion and non-none text emotion, staying silent below
+ * threshold / with no signal / when opted out, and its planner-contract position
+ * and contextGate. Deterministic — a fake runtime whose `getSetting` returns the
+ * opt-out flag; no live model.
+ */
+
 import { describe, expect, it } from "vitest";
 import type { IAgentRuntime, Memory, State } from "../../../types/index.ts";
 import type { UUID } from "../../../types/primitives.ts";

--- a/packages/core/src/features/basic-capabilities/providers/world.ts
+++ b/packages/core/src/features/basic-capabilities/providers/world.ts
@@ -1,3 +1,11 @@
+/**
+ * WORLD provider — injects world/environment context for the current room: the
+ * world name, the current channel, participant count, and a per-type channel
+ * breakdown (text/voice/dm/feed/thread/other) across every room in the world.
+ * Degrades to an explanatory message when the room, its world id, or the world
+ * record cannot be resolved. Part of the basic-capabilities bundle.
+ */
+
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { logger } from "../../../logger.ts";
 import type {
@@ -13,10 +21,6 @@ import { addHeader } from "../../../utils.ts";
 // Get text content from centralized specs
 const spec = requireProviderSpec("WORLD");
 
-/**
- * Provider that exposes relevant world/environment information to agents.
- * Includes details like channel list, world name, and other world metadata.
- */
 export const worldProvider: Provider = {
 	name: spec.name,
 	description: spec.description,

--- a/packages/core/src/features/credential-proxy/client.test.ts
+++ b/packages/core/src/features/credential-proxy/client.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests the credential-proxy client — request signing (canonical string + versioned
+ * HMAC) and forwarding a target URL to the broker origin, plus the fail-closed per-host
+ * route allowlist. Deterministic: real node:crypto, a stub `fetch` that records calls
+ * instead of hitting the network, and a fixed clock.
+ */
 import { createHash, createHmac } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {

--- a/packages/core/src/features/credential-proxy/config.test.ts
+++ b/packages/core/src/features/credential-proxy/config.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Tests `resolveCredentialProxyConfig` — env-map resolution (off unless both URL and
+ * token are set), defaults, strict mode, fail-closed routes-override parsing/validation,
+ * and the raw VCS PAT deny-list. Deterministic; drives a fake env lookup, no real env.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	CREDENTIAL_PROXY_RAW_PAT_VARS,

--- a/packages/core/src/features/documents/__tests__/actions-routing.test.ts
+++ b/packages/core/src/features/documents/__tests__/actions-routing.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Tests the DOCUMENT action's `validate` and structured-routing `handler` — that
+ * the subaction comes from the planner's structured `action` param (via
+ * resolveActionArgs), not natural-language keywords, and that missing NL values
+ * are supplied by the extractor rather than stripped from message text. Fully
+ * deterministic: the runtime, DocumentService, and useModel are vi.fn stubs (the
+ * planner-trust path asserts useModel is never called); no live model or DB.
+ */
 import { describe, expect, it, vi } from "vitest";
 import type {
 	HandlerOptions,

--- a/packages/core/src/features/documents/__tests__/search.test.ts
+++ b/packages/core/src/features/documents/__tests__/search.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Tests the BM25 scoring helpers (tokenize / bm25Scores / normalizeBm25Scores)
+ * and DocumentService.searchDocuments across vector, keyword, and hybrid modes,
+ * including the fail-open-to-keyword path when the recall embed is slow or errors
+ * (issue #47). Deterministic: a real DocumentService and real BM25 run over an
+ * in-memory fragment list while the runtime's embedding model and memory reads
+ * are vi.fn stubs (fake embedding vectors); no live model or database.
+ */
 import { describe, expect, it, vi } from "vitest";
 import type { Memory, UUID } from "../../../types";
 import { MemoryType, ModelType } from "../../../types";

--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -1,3 +1,14 @@
+/**
+ * Implements the DOCUMENT umbrella action for the documents capability. One
+ * planner-routed action whose structured `action`/`subaction` enum dispatches to
+ * a per-subaction handler (list / search / read / write / edit / delete /
+ * import_file / import_url), each backed by {@link DocumentService}. Routing
+ * goes through {@link resolveActionArgs} on the structured params, never
+ * natural-language keyword matching. Enforces the four visibility scopes
+ * (global / owner-private / user-private / agent-private) and role-gated
+ * write/mutation access, and registers the `documents` search category as a
+ * side effect of validate/handler.
+ */
 import * as fs from "node:fs";
 import * as path from "node:path";
 import {

--- a/packages/core/src/features/documents/config.ts
+++ b/packages/core/src/features/documents/config.ts
@@ -1,3 +1,14 @@
+/**
+ * Resolves and validates the model configuration for the documents (RAG)
+ * pipeline. `validateModelConfig` reads embedding- and text-provider settings
+ * from `runtime.getSetting` (falling back to `process.env`), infers local-vs-
+ * OpenAI embedding defaults, folds in the vendor-neutral model gateway, and
+ * parses the result through `ModelConfigSchema`, raising a descriptive error
+ * when a required provider key is absent. `getProviderRateLimits` derives the
+ * concurrency / requests-per-minute / tokens-per-minute envelope the ingestion
+ * pipeline's rate limiter enforces. Consumed by document-processor.ts and
+ * llm.ts.
+ */
 import z from "zod";
 import { applyModelGateway, resolveModelGateway } from "../../model-gateway.ts";
 import type { IAgentRuntime } from "../../types";

--- a/packages/core/src/features/documents/ctx-embeddings.ts
+++ b/packages/core/src/features/documents/ctx-embeddings.ts
@@ -1,3 +1,12 @@
+/**
+ * Builds the contextual-chunk-enrichment prompts for document ingestion — the
+ * "contextual retrieval" step that situates each chunk within its document
+ * before embedding. Exposes content-type-aware system and user prompt builders
+ * (default / code / pdf / math / technical), MIME-type→template selection,
+ * token-target sizing, and the heuristics (`containsMathematicalContent`,
+ * `isTechnicalDocumentation`) that choose a template. Consumed by
+ * document-processor.ts when CTX_DOCUMENTS_ENABLED is set.
+ */
 export const DEFAULT_CHUNK_TOKEN_SIZE = 500;
 export const DEFAULT_CHUNK_OVERLAP_TOKENS = 100;
 export const DEFAULT_CHARS_PER_TOKEN = 3.5;

--- a/packages/core/src/features/documents/docs-loader.ts
+++ b/packages/core/src/features/documents/docs-loader.ts
@@ -1,3 +1,14 @@
+/**
+ * Filesystem loader that ingests on-disk files into the documents capability.
+ * `getDocumentsPath` resolves the documents directory (runtime setting →
+ * `DOCUMENTS_PATH` → `./docs`), `loadDocumentsFromPath` recursively walks it
+ * (skipping VCS/build dirs and dotfiles), and `addDocumentFromFilePath` maps a
+ * file extension to a content type, reads the file as UTF-8 or base64 depending
+ * on whether it is text-backed, and forwards it to
+ * `DocumentService.addDocument`. Used for startup ingestion and by the DOCUMENT
+ * import_file subaction; it talks to the service through a minimal local
+ * interface to avoid a circular import with service.ts.
+ */
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { logger } from "../../logger";

--- a/packages/core/src/features/documents/document-processor.ts
+++ b/packages/core/src/features/documents/document-processor.ts
@@ -1,3 +1,15 @@
+/**
+ * Core ingestion pipeline for the documents capability: turns raw document text
+ * into stored, embedded FRAGMENT memories. `processFragmentsSynchronously`
+ * splits text into overlapping token-sized chunks, optionally contextualizes
+ * each chunk through an LLM (the contextual-retrieval step, gated by
+ * CTX_DOCUMENTS_ENABLED), generates embeddings (batched or one-at-a-time via the
+ * runtime's TEXT_EMBEDDING model), and persists each fragment with
+ * `runtime.createMemory`. A token/request rate limiter derived from
+ * {@link getProviderRateLimits} throttles the calls, and 429s are retried. Also
+ * exposes `extractTextFromDocument` (PDF and text extraction) and
+ * `createDocumentMemory` (the parent DOCUMENT memory record).
+ */
 import type { Buffer } from "node:buffer";
 import { v4 as uuidv4 } from "uuid";
 import { logger } from "../../logger";
@@ -125,7 +137,6 @@ export async function processFragmentsSynchronously({
 		providerLimits.rateLimitEnabled,
 	);
 
-	// Process and save fragments
 	const { savedCount, failedCount } = await processAndSaveFragments({
 		runtime,
 		documentId,

--- a/packages/core/src/features/documents/index.ts
+++ b/packages/core/src/features/documents/index.ts
@@ -1,3 +1,13 @@
+/**
+ * Barrel and plugin factory for the documents capability — elizaOS's native RAG
+ * (document ingestion + retrieval). `createDocumentsPlugin` assembles the
+ * `Plugin` that registers {@link DocumentService}, {@link documentsProvider},
+ * and the DOCUMENT action, and disposes the service on unload. The
+ * `documentsPlugin` / `documentsPluginCore` (provider-only) /
+ * `documentsPluginHeadless` presets toggle the action and provider surfaces.
+ * The module also re-exports the feature's public API: BM25 scoring, URL
+ * ingestion, recall embedding, and the shared types.
+ */
 import type { IAgentRuntime, Plugin } from "../../types";
 import { documentActions } from "./actions";
 import { documentsProvider } from "./provider";

--- a/packages/core/src/features/documents/llm.ts
+++ b/packages/core/src/features/documents/llm.ts
@@ -1,3 +1,14 @@
+/**
+ * Provider-agnostic text-generation and embedding helpers for the documents
+ * (RAG) pipeline. `generateText` dispatches to Anthropic / OpenAI / OpenRouter /
+ * Google (with ephemeral prompt-caching paths for Claude and Gemini on
+ * OpenRouter), and `generateTextEmbedding` / `generateTextEmbeddingsBatch`
+ * produce embeddings via those providers or the runtime's local model. Every
+ * call resolves provider/model/key config from {@link validateModelConfig} and
+ * is wrapped in trajectory logging. The Vercel `ai` SDK and provider packages
+ * are imported lazily so this module — reachable from `@elizaos/core`'s browser
+ * entry — never pulls the SDK into the frontend bundle.
+ */
 import type { EmbeddingModel, ModelMessage } from "ai";
 import { logger } from "../../logger";
 import {

--- a/packages/core/src/features/documents/provider.ts
+++ b/packages/core/src/features/documents/provider.ts
@@ -1,3 +1,12 @@
+/**
+ * The `DOCUMENTS` dynamic provider: injects the agent's relevant and recent
+ * documents into the prompt for the `documents` context. It pulls the top
+ * relevant fragments (via `DocumentService.searchDocuments`) plus a bounded list
+ * of available/recent documents (via `listDocuments`), rendering snippets and
+ * document IDs the agent can cite or follow up to read. Returns an
+ * empty/unavailable payload when no `DocumentService` is registered. Gated to the
+ * `documents` context and a minimum `USER` role, with per-turn cache scope.
+ */
 import {
 	type IAgentRuntime,
 	type Memory,

--- a/packages/core/src/features/documents/recall-embed.test.ts
+++ b/packages/core/src/features/documents/recall-embed.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for `embedRecallQuery`: it returns the embedding on success, fails
+ * open to `null` on an embed error (never throwing onto the reply path), and
+ * caches/dedupes identical normalized recall queries within a turn (including
+ * across providers). Runs against `createMockRuntime` with a synchronous fake
+ * embed model — deterministic, no live LLM.
+ */
 import { describe, expect, test } from "vitest";
 import { createMockRuntime } from "../../testing/mock-runtime";
 import type { IAgentRuntime } from "../../types";

--- a/packages/core/src/features/documents/service-batch-embed.test.ts
+++ b/packages/core/src/features/documents/service-batch-embed.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for `DocumentService`'s batched fragment-embedding path
+ * (`TEXT_EMBEDDING_BATCH`): one batch call embeds every fragment in order, and an
+ * absent batch model or a wrong-shaped batch result falls back to the serial
+ * per-fragment embed with no fragment left unembedded. Drives `createMockRuntime`
+ * with a deterministic text-derived fake embedding (a vector traces back to the
+ * exact fragment text) — no live model or DB.
+ */
 import { describe, expect, test } from "vitest";
 import { createMockRuntime } from "../../testing/mock-runtime";
 import type { Memory, UUID } from "../../types";

--- a/packages/core/src/features/documents/service-character-ingest.test.ts
+++ b/packages/core/src/features/documents/service-character-ingest.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for `DocumentService` character-document ingestion under boot races:
+ * it waits for a late `TEXT_EMBEDDING` registration before ingesting (rather than
+ * writing empty-fragment stubs), and reprocesses an existing zero-fragment
+ * document stub. Drives `createMockRuntime` with Vitest fake timers —
+ * deterministic, no live model or DB.
+ */
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { createMockRuntime, MOCK_AGENT_ID } from "../../testing/mock-runtime";
 import type { Memory, UUID } from "../../types";

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -1,3 +1,21 @@
+/**
+ * `DocumentService`: the documents capability's runtime service and the core of
+ * the RAG subsystem. It ingests documents from uploads, URLs, files, and
+ * character config; extracts text, splits it into fragments, embeds them (batched
+ * when a `TEXT_EMBEDDING_BATCH` model is registered, else serial per-fragment),
+ * and persists documents + fragments into their own memory partitions. It answers
+ * recall queries via `searchDocuments` in vector, keyword (BM25), or hybrid mode,
+ * degrading to keyword when no embedding model is available.
+ *
+ * Registered under service type `documents` and consumed by `documentsProvider`
+ * and the document actions; recall queries are embedded through `embedRecallQuery`
+ * (per-turn cached, fail-open). It enforces per-document visibility scopes
+ * (global / owner-private / user-private / agent-private) via `canAccessDocument`,
+ * plus an optional `AccessContext` gate that is strictly subtractive — a requester
+ * can never widen their view by routing through it. On start it also migrates the
+ * legacy `knowledge` partition into the document partitions and backfills missing
+ * scopes.
+ */
 import { existsSync, statSync } from "node:fs";
 import { filterByAccessContext } from "../../access-control/filter";
 import { createUniqueUuid } from "../../entities";
@@ -52,7 +70,7 @@ import {
  * - "hybrid"  — (default) vector cosine + BM25, weighted 0.6/0.4.
  *               Falls back to "keyword" automatically when no TEXT_EMBEDDING
  *               model is registered (e.g. the cerebras runner).
- * - "vector"  — Pure vector / cosine-similarity search (original behaviour).
+ * - "vector"  — Pure vector / cosine-similarity search.
  * - "keyword" — Pure BM25 keyword search; does not require an embedding model.
  */
 export type SearchMode = "hybrid" | "vector" | "keyword";
@@ -957,7 +975,7 @@ export class DocumentService extends Service {
 		return this._hybridSearch(queryText, filterScope, message, accessContext);
 	}
 
-	/** Pure vector (cosine-similarity) search — original behaviour. */
+	/** Pure vector (cosine-similarity) search. */
 	private async _vectorSearch(
 		queryText: string,
 		filterScope: { roomId?: UUID; worldId?: UUID; entityId?: UUID },

--- a/packages/core/src/features/documents/types.ts
+++ b/packages/core/src/features/documents/types.ts
@@ -1,3 +1,12 @@
+/**
+ * Type and schema definitions for the documents capability: the stored-document
+ * shape, document/fragment memory metadata, visibility scopes, added-by role and
+ * source enums, load results, and the `ModelConfigSchema` zod schema (embedding /
+ * text-provider selection, rate-limit knobs, and startup-load config). Also
+ * registers the `DOCUMENTS: "documents"` entry into the runtime
+ * `ServiceTypeRegistry`. Shared across `service.ts`, `provider.ts`, and the
+ * document processors.
+ */
 import z from "zod";
 import type {
 	Content,

--- a/packages/core/src/features/documents/url-ingest.ts
+++ b/packages/core/src/features/documents/url-ingest.ts
@@ -1,3 +1,15 @@
+/**
+ * SSRF-guarded remote-URL ingestion for the documents capability. Fetches a URL
+ * with DNS pinning and a private/link-local address blocklist (the pinned lookup
+ * prevents DNS rebinding between the safety check and the socket connect),
+ * rejects redirects, and caps the response body size. Classifies the payload and
+ * returns document-ready content: YouTube transcripts, HTML flattened to plain
+ * text, plain text, or binary document types as base64.
+ *
+ * `__setDocumentUrlFetchImplForTests` swaps the pinned-socket fetch for a
+ * deterministic stub so the safety and parsing logic can be tested without real
+ * sockets.
+ */
 import { Buffer } from "node:buffer";
 import { lookup as dnsLookup } from "node:dns/promises";
 import {

--- a/packages/core/src/features/documents/utils.ts
+++ b/packages/core/src/features/documents/utils.ts
@@ -1,3 +1,11 @@
+/**
+ * Pure helpers for the documents capability: extracting text from file buffers
+ * (DOCX via mammoth, PDF via unpdf, plain text plus a UTF-8 fallback),
+ * classifying content types as binary vs text, deriving document titles and safe
+ * ASCII note filenames, normalizing source labels and S3 URLs, detecting base64
+ * payloads, and computing a stable content-based UUID used as the document
+ * dedupe key. Consumed by `service.ts` and the document processors.
+ */
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import * as mammoth from "mammoth";

--- a/packages/core/src/features/messaging/triage/__tests__/adapter-registration.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/adapter-registration.test.ts
@@ -15,8 +15,8 @@ import { createFakeRuntime } from "./fake-runtime.ts";
 
 /**
  * Mirrors what a connector plugin does at init: define an adapter for its own
- * source and register it into the shared TriageService. Core no longer ships
- * any connector-named adapters — they live in their owning plugins and register
+ * source and register it into the shared TriageService. Core ships no
+ * connector-named adapters — they live in their owning plugins and register
  * themselves. These tests pin that contract.
  */
 class TestConnectorAdapter extends BaseMessageAdapter {

--- a/packages/core/src/features/messaging/triage/__tests__/list-inbox-action.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/list-inbox-action.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises listInboxAction against a fake runtime and the in-process default
+ * message-ref store: seeds cached refs of mixed sources, then asserts the
+ * handler filters unread messages down to the requested sources. Deterministic
+ * — no live model, no connector, no real DB.
+ */
+
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { listInboxAction } from "../actions/listInbox.ts";

--- a/packages/core/src/features/messaging/triage/__tests__/message-action-params.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/message-action-params.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for reply-body parsing in `_shared.ts`. `parseDraftReplyParams`
+ * accepts common body aliases and rejects placeholder text (returning a
+ * `body is required` error), while `parseRespondToMessageParams` tolerates the
+ * same placeholder by leaving `body` undefined for MESSAGE to synthesize later.
+ * Pure and deterministic — no runtime.
+ */
+
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/core/src/features/messaging/triage/actions/draftFollowup.ts
+++ b/packages/core/src/features/messaging/triage/actions/draftFollowup.ts
@@ -1,3 +1,12 @@
+/**
+ * Triage action that composes a follow-up / check-in draft to one or more
+ * contacts on a chosen message source. Registered under the shared `MESSAGE`
+ * action name; parameters are parsed and validated by `parseDraftFollowupParams`
+ * before the handler delegates to the default TriageService's `draftFollowup`,
+ * which only produces a preview draft — it never sends. Sending is a separate,
+ * confirmed step. ADMIN-gated.
+ */
+
 import { logger } from "../../../../logger.ts";
 import type {
 	Action,

--- a/packages/core/src/features/messaging/triage/actions/draftReply.ts
+++ b/packages/core/src/features/messaging/triage/actions/draftReply.ts
@@ -1,3 +1,12 @@
+/**
+ * Triage action that composes a draft reply to an existing message. Registered
+ * under the shared `MESSAGE` action name; resolves the target from an explicit
+ * `messageId` or, failing that, by searching the TriageService for the best
+ * match to sender/content lookup hints (`resolveTargetMessageId`), then
+ * delegates to `draftReply` to build a preview. Never sends — sending is a
+ * separate, confirmed step. ADMIN-gated.
+ */
+
 import { logger } from "../../../../logger.ts";
 import type {
 	Action,

--- a/packages/core/src/features/messaging/triage/actions/listInbox.ts
+++ b/packages/core/src/features/messaging/triage/actions/listInbox.ts
@@ -1,3 +1,12 @@
+/**
+ * Read-only triage action that returns unread messages across every connected
+ * platform as one priority-sorted feed. Registered under the shared `MESSAGE`
+ * action name; serves cached refs from the TriageService store when present
+ * (re-ranked via `rankScored`) and otherwise triggers a live `triage()` pull,
+ * then filters to unread and trims to the requested limit. ADMIN-gated and
+ * side-effect free — it never drafts or mutates.
+ */
+
 import { logger } from "../../../../logger.ts";
 import type {
 	Action,

--- a/packages/core/src/features/messaging/triage/actions/manageMessage.ts
+++ b/packages/core/src/features/messaging/triage/actions/manageMessage.ts
@@ -1,3 +1,13 @@
+/**
+ * Triage action that mutates a single message or sender — archive, trash, spam,
+ * mark read/unread, add/remove a label or tag, mute thread, unsubscribe, or
+ * block. Registered under the shared `MESSAGE` action name; resolves the target
+ * by explicit `messageId` or by searching sender/content hints, then applies the
+ * parsed operation through the TriageService's `manage`. The `unsubscribe`
+ * operation first gates on user confirmation (`requireConfirmation`) before it
+ * runs. ADMIN-gated.
+ */
+
 import { logger } from "../../../../logger.ts";
 import type {
 	Action,

--- a/packages/core/src/features/messaging/triage/actions/respondToMessage.ts
+++ b/packages/core/src/features/messaging/triage/actions/respondToMessage.ts
@@ -1,3 +1,12 @@
+/**
+ * The one-shot reply action for the messaging-triage capability, registered
+ * under the shared `MESSAGE` action name. It resolves a target message (by
+ * explicit messageId or a natural-language lookup through the TriageService),
+ * drafts a reply, and then either sends immediately or, when a SendPolicy is
+ * registered, hands the draft off for owner approval. When the request omits a
+ * concrete body it synthesizes a conservative, approval-gated acknowledgment
+ * from the original message's subject/snippet rather than guessing content.
+ */
 import { logger } from "../../../../logger.ts";
 import type {
 	Action,

--- a/packages/core/src/features/messaging/triage/actions/scheduleDraftSend.ts
+++ b/packages/core/src/features/messaging/triage/actions/scheduleDraftSend.ts
@@ -1,3 +1,11 @@
+/**
+ * The deferred-send action for the messaging-triage capability, registered
+ * under the shared `MESSAGE` action name. Given an existing draft id and a
+ * target time, it schedules the draft to send later through the TriageService,
+ * preferring the adapter's native scheduling and falling back to a
+ * process-local timer. It verifies the draft exists before scheduling and
+ * reports the resolved send time.
+ */
 import { logger } from "../../../../logger.ts";
 import type {
 	Action,

--- a/packages/core/src/features/messaging/triage/actions/searchMessages.ts
+++ b/packages/core/src/features/messaging/triage/actions/searchMessages.ts
@@ -1,3 +1,12 @@
+/**
+ * The read-only cross-channel search action for the messaging-triage
+ * capability, registered under the shared `MESSAGE` action name. It runs
+ * combinable filters (source/connector, world/account, channel, sender,
+ * content keyword, tags, time range) through the TriageService and returns
+ * merged, cited hits with priority annotations. Strictly non-mutating —
+ * drafting, replying, sending, and other message mutations are handled by the
+ * sibling triage actions.
+ */
 import { logger } from "../../../../logger.ts";
 import type {
 	Action,

--- a/packages/core/src/features/messaging/triage/actions/sendDraft.test.ts
+++ b/packages/core/src/features/messaging/triage/actions/sendDraft.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Deterministic unit coverage for `outboundDraftOptionsFromMessage`, the MESSAGE
+ * action's outbound-field extraction. Stubs `runtime.useModel` (no live model)
+ * to prove the model is consulted only when structured params are incomplete,
+ * its XML is parsed into the draft, and a model failure degrades to no guessed
+ * fields.
+ */
 import { describe, expect, it, vi } from "vitest";
 
 import type {

--- a/packages/core/src/features/messaging/triage/actions/sendDraft.ts
+++ b/packages/core/src/features/messaging/triage/actions/sendDraft.ts
@@ -1,3 +1,20 @@
+/**
+ * The outbound compose-and-send action for the messaging-triage capability,
+ * registered under the shared `MESSAGE` action name. When no draft id is
+ * supplied it extracts the target platform, recipient, and body from the user's
+ * request (via `outboundDraftOptionsFromMessage`, which is model-driven so it
+ * works in any language) and persists a draft; when a draft id is supplied it
+ * sends that draft. If the TriageService adapter cannot create a draft it falls
+ * back to a locally stored draft so the confirmation flow still works.
+ *
+ * Two independent gates guard every send. The user-confirmation gate refuses to
+ * send without an explicit `confirmed: true`, returning a preview instead; the
+ * owner SendPolicy gate (when a policy is registered) can defer any send for
+ * owner approval, enqueuing the sendDraft executor for later replay.
+ *
+ * `outboundDraftOptionsFromMessage` is exported for the unit tests in
+ * `sendDraft.test.ts`.
+ */
 import crypto from "node:crypto";
 import { logger } from "../../../../logger.ts";
 import type {

--- a/packages/core/src/features/messaging/triage/actions/triageMessages.ts
+++ b/packages/core/src/features/messaging/triage/actions/triageMessages.ts
@@ -1,3 +1,11 @@
+/**
+ * The inbox-triage action for the messaging-triage capability, registered under
+ * the shared `MESSAGE` action name. It fetches unread/recent messages across
+ * connected platforms via the TriageService, scores each with deterministic
+ * contact + urgency heuristics, and returns a priority-ranked summary plus a
+ * per-message list (priority + suggested action). Read-only scan; it never
+ * drafts or sends.
+ */
 import { logger } from "../../../../logger.ts";
 import type {
 	Action,

--- a/packages/core/src/features/messaging/triage/index.ts
+++ b/packages/core/src/features/messaging/triage/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Barrel for the messaging-triage capability: re-exports the individual triage
+ * actions, the message adapters, the message-ref/send-policy/triage-engine/
+ * triage-service singletons and their types, and `messagingTriageActions` — the
+ * action list the runtime registers, which is the unified `messageAction` from
+ * advanced-capabilities.
+ */
 export { draftFollowupAction } from "./actions/draftFollowup.ts";
 export { draftReplyAction } from "./actions/draftReply.ts";
 export { listInboxAction } from "./actions/listInbox.ts";

--- a/packages/core/src/features/oauth/actions/create-oauth-intent.test.ts
+++ b/packages/core/src/features/oauth/actions/create-oauth-intent.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the CREATE_OAUTH_INTENT action, which mints an OAuth intent
+ * envelope and reports the eligible delivery targets for its hosted link.
+ * Deterministic harness: the runtime and the OAuthIntentsClient service are
+ * hand-rolled vi.fn mocks — no live model, network, or database. Covers the
+ * happy path plus provider/scope/state-token validation guards.
+ */
 import { describe, expect, test, vi } from "vitest";
 import {
 	OAUTH_INTENTS_CLIENT_SERVICE,

--- a/packages/core/src/features/oauth/actions/deliver-oauth-link.test.ts
+++ b/packages/core/src/features/oauth/actions/deliver-oauth-link.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the DELIVER_OAUTH_LINK action, which routes a pending OAuth
+ * intent's hosted link to an eligible target through the sensitive-request
+ * dispatch registry. Deterministic harness: the runtime, OAuthIntentsClient,
+ * and dispatch registry are vi.fn mocks — no real delivery adapter. Covers
+ * successful dispatch, missing-intent, and ineligible-target rejection.
+ */
 import { describe, expect, test, vi } from "vitest";
 import type { SensitiveRequestDispatchRegistry } from "../../../sensitive-requests/dispatch-registry";
 import {

--- a/packages/core/src/features/oauth/local-callback-bus.test.ts
+++ b/packages/core/src/features/oauth/local-callback-bus.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for LocalOAuthCallbackBus and the oauthLocalCallbackRoute HTTP
+ * handler — the in-process rendezvous that lets an awaiting agent turn resolve
+ * when a local OAuth callback lands (publish/waitFor, timeout expiry, supersede,
+ * stop, and the route's 200/400/404/503 status contract). Deterministic
+ * harness with fake timers and a stub response object; no real HTTP server.
+ */
 import { describe, expect, test, vi } from "vitest";
 import type { IAgentRuntime } from "../../types/index.ts";
 import { LocalOAuthCallbackBus } from "./local-callback-bus.ts";

--- a/packages/core/src/features/oauth/plugin.test.ts
+++ b/packages/core/src/features/oauth/plugin.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Structural tests for oauthPlugin: asserts it registers exactly the five
+ * atomic OAuth actions and contributes no services, providers, or evaluators.
+ * Pure in-memory inspection of the exported Plugin object — no runtime.
+ */
 import { describe, expect, test } from "vitest";
 import { oauthPlugin } from "./plugin";
 

--- a/packages/core/src/features/payments/actions/payment.test.ts
+++ b/packages/core/src/features/payments/actions/payment.test.ts
@@ -1,3 +1,13 @@
+/**
+ * Exercises the PAYMENT umbrella action's handler and validate across all six
+ * structural subactions (create_request, deliver_link, verify_payload, settle,
+ * await_callback, cancel_request), including legacy discriminator aliases,
+ * delivery-target eligibility gating, and proof/raw-settlement sanitization.
+ * Deterministic: service clients (PaymentRequestsClient, PaymentBusClient,
+ * PaymentSettler) and the dispatch registry are vi.fn() mocks over a stub
+ * runtime — no live model, DB, or real payment provider.
+ */
+
 import { describe, expect, test, vi } from "vitest";
 import type { SensitiveRequestDispatchRegistry } from "../../../sensitive-requests/dispatch-registry";
 import {

--- a/packages/core/src/features/payments/plugin.test.ts
+++ b/packages/core/src/features/payments/plugin.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Static shape check of the payments plugin: it registers PAYMENT as its only
+ * canonical action (with the six-value subaction discriminator enum) and
+ * contributes no services, providers, or evaluators. No runtime.
+ */
+
 import { describe, expect, test } from "vitest";
 import { paymentsPlugin } from "./plugin";
 

--- a/packages/core/src/features/plugin-config/actions/activate-plugin-if-ready.test.ts
+++ b/packages/core/src/features/plugin-config/actions/activate-plugin-if-ready.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit coverage for the ACTIVATE_PLUGIN_IF_READY action of the plugin-config
+ * capability: it activates a plugin and emits PluginActivated once every
+ * required secret is present, and stays a no-op (reason "not_ready") while keys
+ * are still missing. Runs against a hand-built stub runtime and an in-memory
+ * PluginConfigClient — no live model or database.
+ */
 import { describe, expect, test } from "vitest";
 import { ChannelType } from "../../../types/primitives";
 import { activatePluginIfReadyAction } from "./activate-plugin-if-ready";

--- a/packages/core/src/features/plugin-config/actions/deliver-plugin-config-form.test.ts
+++ b/packages/core/src/features/plugin-config/actions/deliver-plugin-config-form.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit coverage for the DELIVER_PLUGIN_CONFIG_FORM action: it dispatches one
+ * sensitive-request per missing required key through the
+ * SensitiveRequestDispatchRegistry, and fails when no delivery adapter is
+ * registered for the target. Uses a deterministic stub runtime, client, and
+ * dispatch registry — no live model or database.
+ */
 import { describe, expect, test } from "vitest";
 import { ChannelType } from "../../../types/primitives";
 import { deliverPluginConfigFormAction } from "./deliver-plugin-config-form";

--- a/packages/core/src/features/plugin-config/actions/poll-plugin-config-status.test.ts
+++ b/packages/core/src/features/plugin-config/actions/poll-plugin-config-status.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for the POLL_PLUGIN_CONFIG_STATUS action: it surfaces the
+ * client's ready/missing report and fails cleanly when the PluginConfigClient
+ * service is absent. Runs against an in-memory stub runtime and client — no
+ * live model or database.
+ */
 import { describe, expect, test } from "vitest";
 import { ChannelType } from "../../../types/primitives";
 import { pollPluginConfigStatusAction } from "./poll-plugin-config-status";

--- a/packages/core/src/features/plugin-config/actions/probe-plugin-config-requirements.test.ts
+++ b/packages/core/src/features/plugin-config/actions/probe-plugin-config-requirements.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for the PROBE_PLUGIN_CONFIG_REQUIREMENTS action: it returns the
+ * required/optional/present/missing key breakdown from the client and fails
+ * cleanly when no manifest is registered for the plugin. Runs against a
+ * deterministic stub runtime and client — no live model or database.
+ */
 import { describe, expect, test } from "vitest";
 import { ChannelType } from "../../../types/primitives";
 import { probePluginConfigRequirementsAction } from "./probe-plugin-config-requirements";

--- a/packages/core/src/features/plugin-config/plugin.test.ts
+++ b/packages/core/src/features/plugin-config/plugin.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Structural coverage for the pluginConfigPlugin barrel: asserts it registers
+ * exactly the four atomic plugin-config actions in order (PROBE, DELIVER, POLL,
+ * ACTIVATE) and contributes no services, providers, or evaluators. No runtime.
+ */
 import { describe, expect, test } from "vitest";
 import { pluginConfigPlugin } from "./plugin";
 

--- a/packages/core/src/features/plugin-manager/actions/plugin-handlers/create.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin-handlers/create.ts
@@ -1,3 +1,17 @@
+/**
+ * Implements the `create` (and `edit`) subaction of the plugin-manager umbrella
+ * action (MANAGE_PLUGINS): scaffolds a new Eliza plugin from the `min-plugin`
+ * template or edits an existing ejected plugin, then dispatches a
+ * coding-delegation task (the START_CODING_TASK-style action) to actually
+ * implement it. The delegated agent signals completion with a single
+ * `PLUGIN_CREATE_DONE` line that downstream verification keys on.
+ *
+ * When a free-form intent matches existing local plugins, `runCreate` emits an
+ * interstitial `[CHOICE:plugin-create]` block and persists the pending intent as
+ * a task tagged `PLUGIN_CREATE_INTENT_TAG`, so a follow-up new/edit-N/cancel
+ * reply resolves against it. Name derivation, template copying, and free-directory
+ * resolution are local filesystem work rooted at the caller-supplied repoRoot.
+ */
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { logger } from "../../../../logger.ts";

--- a/packages/core/src/features/plugin-manager/coreExtensions.ts
+++ b/packages/core/src/features/plugin-manager/coreExtensions.ts
@@ -5,7 +5,7 @@ import type { ServiceTypeName } from "../../types/service.ts";
  * Core Runtime Extensions
  *
  * This module provides extensions to the core runtime for plugin management.
- * `unregisterEvent` is now a first-class method on `AgentRuntime` / `IAgentRuntime`,
+ * `unregisterEvent` is a first-class method on `AgentRuntime` / `IAgentRuntime`,
  * so this file only retains component unregistration helpers (action/provider/
  * service) that live outside the runtime contract.
  */

--- a/packages/core/src/features/plugin-manager/index.ts
+++ b/packages/core/src/features/plugin-manager/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Barrel for the plugin-manager feature: defines `pluginManagerPlugin` — the
+ * MANAGE_PLUGINS umbrella action, the configuration-status/state/registry
+ * providers, and the PluginManagerService/CoreManagerService — and re-exports
+ * the feature's public surface (services, providers, relevance helpers, types,
+ * and path utilities) for other packages such as plugin-app-control.
+ */
 import type { IAgentRuntime } from "../../types/index.ts";
 import type { Plugin } from "../../types/plugin.ts";
 import { pluginAction } from "./actions/plugin.ts";

--- a/packages/core/src/features/plugin-manager/plugin-manager-umbrella.test.ts
+++ b/packages/core/src/features/plugin-manager/plugin-manager-umbrella.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Deterministic import-level tests for the plugin-manager barrel: asserts the
+ * plugin exposes only the MANAGE_PLUGINS umbrella action, that legacy standalone
+ * action names are folded into subactions and kept off the planner-facing action
+ * surface, and that the old per-operation actions are no longer re-exported.
+ */
 import { describe, expect, it } from "vitest";
 import { listSubactionsFromParameters } from "../../actions/promote-subactions.ts";
 import * as pluginManagerExports from "./index.ts";

--- a/packages/core/src/features/plugin-manager/providers/pluginConfigurationStatus.ts
+++ b/packages/core/src/features/plugin-manager/providers/pluginConfigurationStatus.ts
@@ -1,3 +1,10 @@
+/**
+ * The `pluginConfigurationStatus` provider: injects per-plugin configuration
+ * readiness into the prompt — which registered plugins are configured versus
+ * missing required env keys/secrets — derived from each plugin's config schema
+ * via PluginConfigurationService. Owner-gated and relevance-gated to the
+ * connectors/settings contexts, so it only fires on plugin-configuration talk.
+ */
 import type { Provider, ProviderResult } from "../../../types/components.ts";
 import type { Memory } from "../../../types/memory.ts";
 import type { IAgentRuntime } from "../../../types/runtime.ts";

--- a/packages/core/src/features/plugin-manager/providers/pluginStateProvider.ts
+++ b/packages/core/src/features/plugin-manager/providers/pluginStateProvider.ts
@@ -1,3 +1,9 @@
+/**
+ * The `pluginState` provider: injects the current lifecycle state of every
+ * plugin known to PluginManagerService into the prompt — loaded/ready/error/
+ * unloaded status, load errors, plus ejected, protected, and startup-original
+ * plugins. Owner-gated and relevance-gated to the connectors/settings contexts.
+ */
 import type { Provider, ProviderResult } from "../../../types/components.ts";
 import type { Memory } from "../../../types/memory.ts";
 import type { IAgentRuntime } from "../../../types/runtime.ts";

--- a/packages/core/src/features/plugin-manager/providers/registryPluginsProvider.ts
+++ b/packages/core/src/features/plugin-manager/providers/registryPluginsProvider.ts
@@ -1,3 +1,11 @@
+/**
+ * The `registryPlugins` provider: injects the elizaOS plugin registry catalog
+ * plus local install status into the prompt so the agent can discover and
+ * install plugins. Reads the registry via pluginRegistryService.getAllPlugins()
+ * (degrading to a warning line when the fetch fails) and installed plugins via
+ * PluginManagerService. Owner-gated, agent-scoped cache, relevance-gated to the
+ * connectors/settings contexts.
+ */
 import { logger } from "../../../logger.ts";
 import type { Provider, ProviderResult } from "../../../types/components.ts";
 import type { Memory } from "../../../types/memory.ts";

--- a/packages/core/src/features/plugin-manager/providers/relevance.ts
+++ b/packages/core/src/features/plugin-manager/providers/relevance.ts
@@ -1,3 +1,11 @@
+/**
+ * Shared relevance-gating helpers for the plugin-manager providers: base and
+ * common-connector keyword vocabularies, plus builders that fold in per-plugin
+ * name keywords and compile them into a word-boundary regex. `isProviderRelevant`
+ * combines keyword and regex matching over the current message and recent history
+ * to decide whether a plugin-manager provider should inject context, keeping
+ * these dynamic providers quiet on unrelated turns.
+ */
 import { getRecentMessagesData } from "../../../recent-messages-state.ts";
 import type { Memory } from "../../../types/memory.ts";
 import type { State } from "../../../types/state.ts";

--- a/packages/core/src/features/plugin-manager/security.test.ts
+++ b/packages/core/src/features/plugin-manager/security.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the plugin-manager owner/admin access wrappers
+ * (`hasOwnerAccess` / `hasAdminAccess`). Fully deterministic: role resolution
+ * is supplied through injected `SecurityDeps` fakes, so there is no runtime,
+ * database, or live model in play.
+ */
 import { describe, expect, it } from "vitest";
 import type { RoleCheckResult, RoleName } from "../../roles.ts";
 import type { IAgentRuntime, Memory } from "../../types/index.ts";

--- a/packages/core/src/features/plugin-manager/services/coreManagerService.ts
+++ b/packages/core/src/features/plugin-manager/services/coreManagerService.ts
@@ -1,3 +1,16 @@
+/**
+ * The `core_manager` service (`CoreManagerService`) of the plugin-manager
+ * capability: ejects, syncs, and reinjects the `@elizaos/core` package itself.
+ * Ejecting clones the elizaOS monorepo into `<stateDir>/core`, installs and
+ * builds it, then rewrites `tsconfig.json` `paths` so `@elizaos/core` resolves
+ * to the ejected `dist`; sync merges upstream and rebuilds; reinject removes
+ * the checkout and restores the default resolution.
+ *
+ * All git/build operations run behind a single serialized lock (`serialise`),
+ * git URLs/branches are validated against strict allowlists, and every
+ * write/remove is confined to the core base dir via `isWithinEjectedCoreDir`
+ * to prevent path escape. Upstream provenance is tracked in `.upstream.json`.
+ */
 import { exec, execFile } from "node:child_process";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -298,7 +311,7 @@ export class CoreManagerService extends Service {
 		return { ok: true };
 	}
 
-	// Public API methods matching original functionality
+	// Public API methods
 
 	async ejectCore(): Promise<CoreEjectResult> {
 		return this.serialise(async () => {

--- a/packages/core/src/features/plugin-manager/services/pluginManagerService.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginManagerService.ts
@@ -1,3 +1,20 @@
+/**
+ * The `plugin_manager` service (`PluginManagerService`), the heart of the
+ * plugin-manager capability: dynamically loads and unloads plugins into a live
+ * runtime — registering and unregistering their actions, providers, services,
+ * and event handlers — and installs, uninstalls, and updates plugins from the
+ * registry (npm, git, or local clone), plus eject/sync/reinject of the
+ * checked-out plugin source.
+ *
+ * It implements `PluginRegistry` over an in-memory `plugins` map keyed by
+ * `createUniqueUuid`. A `PROTECTED_PLUGINS` set plus the startup
+ * `originalPlugins` snapshot guard core plugins from being registered over or
+ * unloaded. Install and eject flows are each serialized behind their own lock,
+ * and every shell argument (package name, version, git URL/branch, registry
+ * subdirectory) is validated against a strict regex allowlist to prevent
+ * command injection; filesystem writes are confined to the state dir via
+ * `isWithinDir` / `sanitisePackageName`.
+ */
 import { exec } from "node:child_process";
 import path from "node:path";
 import { promisify } from "node:util";

--- a/packages/core/src/features/plugin-manager/services/pluginRegistryService.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginRegistryService.ts
@@ -1,3 +1,13 @@
+/**
+ * Registry data layer for the plugin-manager capability: fetches and normalizes
+ * the elizaOS plugin registry. Pulls `generated-registry.json` (falling back to
+ * the leaner `index.json`) from plugins.elizacloud.ai, scans the local
+ * `plugins/` directory for `elizaos.plugin.json` manifests that override remote
+ * entries, and caches the merged `Map<name, RegistryPlugin>` in memory for one
+ * hour. Exposes the lookup (`getRegistryEntry`, with fuzzy `@elizaos/`-prefix
+ * resolution), content-scored search, metadata conversion, and clone helpers
+ * that `PluginManagerService` builds its install/eject flows on top of.
+ */
 import { execFile } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/packages/core/src/features/plugin-manager/types.ts
+++ b/packages/core/src/features/plugin-manager/types.ts
@@ -1,3 +1,11 @@
+/**
+ * Shared type surface for the plugin-manager capability: the `ServiceTypeRegistry`
+ * augmentation and `PluginManagerServiceType` constants for its four services,
+ * the `PluginStatus` lifecycle enum, the in-runtime plugin/component tracking
+ * shapes (`PluginState`, `PluginComponents`, `PluginRegistry`,
+ * `ComponentRegistration`), and the result/progress DTOs for install, uninstall,
+ * eject, sync, and reinject operations plus registry metadata.
+ */
 import type { EventPayload, EventPayloadMap } from "../../types/events.ts";
 import type { Plugin as ElizaPlugin } from "../../types/plugin.ts";
 import type { ServiceTypeName } from "../../types/service.ts";

--- a/packages/core/src/features/plugin-manager/utils/paths.ts
+++ b/packages/core/src/features/plugin-manager/utils/paths.ts
@@ -1,3 +1,9 @@
+/**
+ * Path helpers for the plugin-manager capability: resolves the `eliza.json`
+ * config path under the state dir (honoring the `ELIZA_CONFIG_PATH` override)
+ * and re-exports the shared `resolveStateDir` / `resolveUserPath` state-dir
+ * utilities the manager's services depend on.
+ */
 import path from "node:path";
 import { resolveStateDir, resolveUserPath } from "../../../utils/state-dir.ts";
 

--- a/packages/core/src/features/secrets/actions/check-secret.test.ts
+++ b/packages/core/src/features/secrets/actions/check-secret.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Exercises `checkSecretHandler`, the SECRETS umbrella's `action=check` path,
+ * which reports per-key presence and a missing list without ever returning
+ * values, and fails when no keys are supplied. The runtime is a deterministic
+ * stub whose `SECRETS` service returns canned `exists()` answers — no live
+ * model or database.
+ */
+
 import { describe, expect, test } from "vitest";
 import { ChannelType } from "../../../types/primitives";
 import { checkSecretHandler } from "./check-secret";

--- a/packages/core/src/features/secrets/actions/delete-secret.test.ts
+++ b/packages/core/src/features/secrets/actions/delete-secret.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises `deleteSecretHandler`, the SECRETS umbrella's `action=delete` path,
+ * confirming it deletes in a DM channel but refuses in non-DM channels. The
+ * runtime is a deterministic stub whose `SECRETS` service returns a canned
+ * `delete()` result — no live model or database.
+ */
+
 import { describe, expect, test } from "vitest";
 import { ChannelType } from "../../../types/primitives";
 import { deleteSecretHandler } from "./delete-secret";

--- a/packages/core/src/features/secrets/actions/get-secret.test.ts
+++ b/packages/core/src/features/secrets/actions/get-secret.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Exercises `getSecretHandler`, the SECRETS umbrella's `action=get` path:
+ * returns the masked value by default, reports a null value (unmasked) when the
+ * secret is missing, and fails when the key parameter is absent. The runtime is
+ * a deterministic stub whose `SECRETS` service returns a canned `get()` value —
+ * no live model or database.
+ */
+
 import { describe, expect, test } from "vitest";
 import { ChannelType } from "../../../types/primitives";
 import { getSecretHandler } from "./get-secret";

--- a/packages/core/src/features/secrets/actions/list-secrets.test.ts
+++ b/packages/core/src/features/secrets/actions/list-secrets.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises `listSecretsHandler`, the SECRETS umbrella's `action=list` path,
+ * which returns sorted keys plus per-key metadata (setAt/ttl) but never the
+ * values, and supports prefix filtering. The runtime is a deterministic stub
+ * whose `SECRETS` service returns canned metadata — no live model or database.
+ */
+
 import { describe, expect, test } from "vitest";
 import { ChannelType } from "../../../types/primitives";
 import { listSecretsHandler } from "./list-secrets";

--- a/packages/core/src/features/secrets/actions/mirror-secret-to-vault.test.ts
+++ b/packages/core/src/features/secrets/actions/mirror-secret-to-vault.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Exercises `mirrorSecretToVaultHandler`, the SECRETS umbrella's `action=mirror`
+ * path, which copies a stored secret into a named external vault service and
+ * returns `mirrored=false` when that service is not registered. The runtime is a
+ * deterministic stub: the `SECRETS` service returns a canned value and the vault
+ * is an in-memory stub recording its `setSecret` writes — no live model or DB.
+ */
+
 import { describe, expect, test } from "vitest";
 import { ChannelType } from "../../../types/primitives";
 import { mirrorSecretToVaultHandler } from "./mirror-secret-to-vault";

--- a/packages/core/src/features/secrets/actions/request-secret.test.ts
+++ b/packages/core/src/features/secrets/actions/request-secret.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Exercises the SECRETS umbrella's `action=request` path: `secretsAction.validate`
+ * accepts public channels (so it can route the user elsewhere), while
+ * `requestSecretHandler` refuses to collect secret values in public chat and
+ * instead emits a DM/owner-app instruction. The runtime is a deterministic stub
+ * whose `SECRETS` service reports the key absent — no live model or database.
+ */
+
 import { describe, expect, test } from "vitest";
 import { ChannelType } from "../../../types/primitives";
 import { secretsAction } from "./manage-secret";

--- a/packages/core/src/features/secrets/providers/secrets-status.test.ts
+++ b/packages/core/src/features/secrets/providers/secrets-status.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Deterministic unit test for the SECRETS_INFO provider (features/secrets):
+ * asserts it injects a type-grouped summary of configured secrets, stays
+ * language-agnostic rather than gating its context on English secret keywords,
+ * and returns empty text when the secrets service is unavailable. Runs against
+ * a hand-built mock runtime — no live model or database.
+ */
 import { describe, expect, test } from "vitest";
 import type { IAgentRuntime, Memory } from "../../../types/index.ts";
 import {

--- a/packages/core/src/features/secrets/services/secrets-broker-wiring.test.ts
+++ b/packages/core/src/features/secrets/services/secrets-broker-wiring.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Deterministic unit test for SecretsService's broker wiring (features/secrets):
+ * the local composite store stays the default until both broker env vars are set
+ * and a client is supplied, broker-held keys return serialized handles (never
+ * plaintext) with fall-through to local for unheld keys, and strict mode fails
+ * closed on an unreachable broker while non-strict degrades to local. Runs
+ * against createMockRuntime with vi-mocked broker clients — no network.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { createMockRuntime } from "../../../testing/mock-runtime.ts";
 import type { IAgentRuntime } from "../../../types/index.ts";

--- a/packages/core/src/features/secrets/setup/service.test.ts
+++ b/packages/core/src/features/secrets/setup/service.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Deterministic unit test for SetupService (features/secrets/setup): the
+ * {{settingName}} substitution and updatedKey reporting in processMessage's
+ * settingUpdated path, plus startTelegramSetup dispatching the owner deep link
+ * through the runtime send registry (and staying silent without ownership
+ * metadata). Uses createMockRuntime with a seeded in-memory session — no live
+ * Telegram.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { createMockRuntime } from "../../../testing/mock-runtime.ts";
 import type { Memory, TargetInfo, UUID } from "../../../types/index.ts";
@@ -53,8 +61,8 @@ describe("SetupService.processMessage — settingUpdated message", () => {
 			content: { text: "sk-test-value" },
 		} as Memory);
 
-		// Before the fix, `.replace` bound only to the DEFAULT, so a custom
-		// message shipped the raw placeholder.
+		// The substitution must bind to the resolved (custom or default) message;
+		// a custom message must not ship the raw placeholder.
 		expect(result.response).toContain("Saved your OpenAI Key securely.");
 		expect(result.response).not.toContain("{{settingName}}");
 	});

--- a/packages/core/src/features/secrets/storage/access-control.test.ts
+++ b/packages/core/src/features/secrets/storage/access-control.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Deterministic unit test for permission enforcement across the secret storage
+ * backends (features/secrets/storage): ComponentSecretStorage (user-scoped),
+ * WorldMetadataStorage (world-scoped), and CharacterSettingsStorage (global).
+ * Verifies each fails closed on a missing or unentitled requester and enforces
+ * the read/write roles for its level. Uses createMockRuntime backed by
+ * in-memory component/world maps and a real KeyManager.
+ */
 import { describe, expect, it } from "vitest";
 import { createMockRuntime } from "../../../testing/mock-runtime.ts";
 import {

--- a/packages/core/src/features/secrets/storage/broker-config.test.ts
+++ b/packages/core/src/features/secrets/storage/broker-config.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Deterministic unit test for resolveSecretsBrokerConfig (features/secrets/
+ * storage): the both-or-nothing gate that activates the broker only when url and
+ * token are both non-blank, whitespace trimming, strict-flag parsing, and the
+ * SecretsBrokerUnavailableError shape. Pure-function test — no runtime.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	resolveSecretsBrokerConfig,

--- a/packages/core/src/features/secrets/storage/broker-store.test.ts
+++ b/packages/core/src/features/secrets/storage/broker-store.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Deterministic unit test for BrokerSecretStorage (features/secrets/storage):
+ * the non-decrypting invariant (get() returns serialized handles, refuses to
+ * pass through smuggled plaintext, and the source imports no decrypt path),
+ * read-only vs write-capable set(), and fail-closed-vs-soft error handling under
+ * strict/non-strict config. Uses vi-mocked broker clients and reads its own
+ * backend source for the structural guard.
+ */
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";

--- a/packages/core/src/features/secrets/validation.test.ts
+++ b/packages/core/src/features/secrets/validation.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Deterministic unit test for the custom validator strategy in secret validation
+ * (features/secrets): validateSecret fails closed when no custom validator is
+ * registered, prefers a key-specific validator, and falls back to the shared
+ * "custom" validator, exercised via registerValidator/unregisterValidator. No
+ * live model or network.
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	registerValidator,

--- a/packages/core/src/features/sub-agent-credentials/actions/await-child-agent-decision.test.ts
+++ b/packages/core/src/features/sub-agent-credentials/actions/await-child-agent-decision.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers the AWAIT_CHILD_AGENT_DECISION action, which blocks until the spawned
+ * child session emits a decision via the SubAgentChildDecisionBus service. The
+ * harness is deterministic: the bus is a `vi.fn` mock, so the tests assert the
+ * default 600s timeout, a caller-supplied `timeoutMs`, and validation failure
+ * when `childSessionId` is absent — no real bus or child process is involved.
+ */
 import { describe, expect, test, vi } from "vitest";
 import {
 	SUB_AGENT_CHILD_DECISION_BUS_SERVICE,

--- a/packages/core/src/features/sub-agent-credentials/actions/declare-sub-agent-credential-scope.test.ts
+++ b/packages/core/src/features/sub-agent-credentials/actions/declare-sub-agent-credential-scope.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Covers the DECLARE_SUB_AGENT_CREDENTIAL_SCOPE action, which asks the
+ * SubAgentCredentialBridge to open a credential scope for a child session. The
+ * harness is deterministic: the bridge is a `vi.fn` mock. Tests assert the
+ * owner-only actor/delivery defaults, that the scoped token never leaks through
+ * the user-facing callback, and both validation and handler degradation when
+ * the bridge service is missing or `credentialKeys` is empty.
+ */
 import { describe, expect, test, vi } from "vitest";
 import {
 	SUB_AGENT_CREDENTIAL_BRIDGE_SERVICE,

--- a/packages/core/src/features/sub-agent-credentials/actions/retrieve-child-agent-results.test.ts
+++ b/packages/core/src/features/sub-agent-credentials/actions/retrieve-child-agent-results.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers the RETRIEVE_CHILD_AGENT_RESULTS action, which fetches a finished
+ * child session's transcript/artifact bundle via the SubAgentChildResultsClient
+ * service. The harness is deterministic: the client is a `vi.fn` mock, so the
+ * tests assert the resolved bundle is passed through and that both validate and
+ * handler degrade cleanly when the results client is unavailable.
+ */
 import { describe, expect, test, vi } from "vitest";
 import {
 	SUB_AGENT_CHILD_RESULTS_CLIENT_SERVICE,

--- a/packages/core/src/features/sub-agent-credentials/actions/tunnel-credential-to-child-session.test.ts
+++ b/packages/core/src/features/sub-agent-credentials/actions/tunnel-credential-to-child-session.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers the TUNNEL_CREDENTIAL_TO_CHILD_SESSION action, which hands a single
+ * credential value to a child session through the SubAgentCredentialBridge. The
+ * harness is deterministic: the bridge is a `vi.fn` mock. Tests assert the
+ * params are forwarded verbatim, that the plaintext value never appears in the
+ * returned data, and that missing params or an absent bridge service fail.
+ */
 import { describe, expect, test, vi } from "vitest";
 import {
 	SUB_AGENT_CREDENTIAL_BRIDGE_SERVICE,

--- a/packages/core/src/features/sub-agent-credentials/plugin.test.ts
+++ b/packages/core/src/features/sub-agent-credentials/plugin.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the shape of `subAgentCredentialsPlugin`: it registers exactly the
+ * four atomic credential-bridge actions in declared order and contributes no
+ * services, providers, or evaluators. Pure object inspection — no runtime.
+ */
 import { describe, expect, test } from "vitest";
 import { subAgentCredentialsPlugin } from "./plugin";
 

--- a/packages/core/src/features/subscription-auth/index.ts
+++ b/packages/core/src/features/subscription-auth/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Public barrel for the subscription-auth capability: re-exports the
+ * registry accessors and the `SubscriptionAuthProvider` /
+ * `DiscoveredSubscriptionCredential` types that model-provider plugins use to
+ * describe a vendor's subscription product to the generic host `auth/` layer.
+ */
 export {
 	getSubscriptionAuthProvider,
 	hasSubscriptionAuthProvider,

--- a/packages/core/src/features/subscription-auth/registry.test.ts
+++ b/packages/core/src/features/subscription-auth/registry.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises the in-memory subscription-auth registry: register/lookup by id,
+ * listing, last-registration-wins override (plugin over built-in), and verbatim
+ * pass-through of discovered credentials. Deterministic — no model or DB, the
+ * registry Map is the whole system under test.
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	getSubscriptionAuthProvider,

--- a/packages/core/src/features/trajectories/TrajectoriesService.test.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Unit coverage for `TrajectoriesService`: it disables capture when the runtime
+ * adapter exposes no SQL executor, bounds and JSON-sanitizes LLM-call payloads
+ * (truncation, circular refs, functions) before persisting, keeps queued step
+ * writes parseable, skips internal embedding calls, and surfaces persisted
+ * metadata on list rows. The runtime and its SQL executor are stubbed
+ * (`executeRawSql` overridden against an in-memory row) — deterministic, no real
+ * database.
+ */
 import { describe, expect, it } from "vitest";
 import type { IAgentRuntime } from "../../types";
 import { TrajectoriesService } from "./TrajectoriesService";

--- a/packages/core/src/features/trajectories/index.ts
+++ b/packages/core/src/features/trajectories/index.ts
@@ -1,3 +1,20 @@
+/**
+ * Public barrel and plugin entry for the trajectories capability: exports the
+ * native `trajectoriesPlugin`, the `TrajectoriesService`, and the feature's
+ * type/format/pricing/export surface (ART conversion, reward services, action
+ * interceptor, per-provider price table).
+ *
+ * The plugin owns the trajectory lifecycle by listening to runtime events: it
+ * opens a trajectory + first step on `MESSAGE_RECEIVED` (enriching metadata from
+ * room state / web-conversation context) and closes it on `MESSAGE_SENT`,
+ * `RUN_ENDED`, or `RUN_TIMEOUT`. Because event ordering is not guaranteed, the
+ * module-level maps (`pendingTrajectoryStepBy*`) correlate a message/reply id to
+ * its open step so whichever terminal event fires first can end it exactly once;
+ * `cleanupPendingTrajectory` tears down every index entry to avoid leaks.
+ * Trajectory capture is best-effort — every failure is logged and swallowed so
+ * it never blocks the message loop, and the whole subsystem no-ops when
+ * `TrajectoriesService` is not resolvable (e.g. `@elizaos/plugin-sql` absent).
+ */
 import crypto from "node:crypto";
 import { createUniqueUuid } from "../../entities";
 import type { TrajectoryFinalStatus } from "../../trajectory-utils";
@@ -268,10 +285,9 @@ export const trajectoriesPlugin: Plugin = {
 							await logger.flushWriteQueue(normalizedTrajectoryId);
 						}
 					} else {
-						// Fallback if startTrajectory returns empty/null
-						// This path uses the stepId as the trajectoryId which matches legacy behavior
-						// provided the logger supports it, but here we are using the new service.
-						// If new service returns null, something is wrong, but we proceed best effort.
+						// startTrajectory returned empty/null: no trajectory id to record
+						// steps against, so proceed best-effort with the local stepId as the
+						// only correlation handle for the terminal events below.
 					}
 
 					if (message.id) {

--- a/packages/core/src/features/trajectories/pricing.test.ts
+++ b/packages/core/src/features/trajectories/pricing.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit coverage for the trajectories cost/pricing table: asserts the static
+ * per-provider rate card and context-window entries, the longest-family-key
+ * substring fallback for versioned model ids, the local-provider zero-cost rule,
+ * cache read/write accounting, and the MODEL_PRICES_JSON / MODEL_CONTEXT_WINDOWS_JSON
+ * env overrides. Fully deterministic — no live model; env is stubbed via
+ * vi.stubEnv.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	computeCallCostUsd,

--- a/packages/core/src/features/trajectories/read-routes.test.ts
+++ b/packages/core/src/features/trajectories/read-routes.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit coverage for the owner-side trajectory viewer read routes
+ * (`tryHandleTrajectoryReadRoutes`): path/method gating, the list/detail/stats
+ * UI wire shapes (including the timeout→error status collapse and step→phase
+ * flattening), search-param forwarding, opt-in room-context resolution, and the
+ * service-absent empty-200 fallback. The `ServerResponse` and runtime/service
+ * are hand-rolled fakes — deterministic, no HTTP server or database.
+ */
 import type { ServerResponse } from "node:http";
 import { describe, expect, it } from "vitest";
 import type { IAgentRuntime } from "../../types";

--- a/packages/core/src/features/trajectories/trajectory-json-export.test.ts
+++ b/packages/core/src/features/trajectories/trajectory-json-export.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit coverage for the v5 context-object trajectory export
+ * (`buildContextObjectTrajectoryExport` / `serializeContextObjectTrajectoryExport`):
+ * v5 context events serialize straight to JSON with no legacy conversion, and
+ * undefined metadata values are dropped. Deterministic — plain in-memory objects,
+ * no runtime or database.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	buildContextObjectTrajectoryExport,

--- a/packages/core/src/features/trajectories/types.ts
+++ b/packages/core/src/features/trajectories/types.ts
@@ -1,3 +1,22 @@
+/**
+ * The trajectory subsystem's canonical type system: the rich in-memory shapes a
+ * recorded agent episode is captured in and the derived shapes it is exported
+ * or persisted as.
+ *
+ * `Trajectory` is the top-level episode — an ordered list of `TrajectoryStep`s,
+ * each pairing an `EnvironmentState` observation with the agent's cognition
+ * (`LLMCall[]`, `ProviderAccess[]`) and the `ActionAttempt` it took, plus reward
+ * signals. `TrajectoryRecord` is the flattened database row (JSON columns +
+ * indexed scalars) that `TrajectoriesService` reads and writes. `ARTTrajectory`
+ * / `ChatMessage` / `TrajectoryGroup` / `TrainingBatch` are the RL-training
+ * (RULER/OpenPipe ART) projection produced by `art-format`, and the
+ * `Reward*`/`ContextObjectTrajectoryExport` types describe the AI-judge scoring
+ * request/response and the v5 context-object export envelope.
+ *
+ * These interfaces are the shared vocabulary across the whole feature (service,
+ * exporters, read routes, rewards); widen additively so on-disk rows and the
+ * viewer wire shapes stay backward-compatible.
+ */
 import type { JsonObject, JsonPrimitive, JsonValue, UUID } from "../../types";
 import type { ContextEvent } from "../../types/context-object";
 

--- a/packages/core/src/features/trust/__tests__/should-respond-risk-gate.test.ts
+++ b/packages/core/src/features/trust/__tests__/should-respond-risk-gate.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for the role-keyed should-respond injection gate
+ * (`should-respond-risk-gate.ts`): risk-factor scoring, role-keyed bypass, the
+ * pipeline-hook stamping, and the fail-closed model adjudication. Fully
+ * deterministic — the runtime and its `useModel` are `vi.fn` stubs (no live
+ * model, no DB); the live-model path is covered separately in the `.real` suite.
+ */
+
 import { describe, expect, it, vi } from "vitest";
 import type { Memory } from "../../../types/memory.ts";
 import type { IAgentRuntime } from "../../../types/runtime.ts";

--- a/packages/core/src/features/trust/actions/evaluateTrust.ts
+++ b/packages/core/src/features/trust/actions/evaluateTrust.ts
@@ -1,3 +1,13 @@
+/**
+ * Handler for the TRUST umbrella's `evaluate` subaction: reads a target entity's
+ * `TrustProfile` from the `trust-engine` service and renders it as either a
+ * one-line trust level or a detailed dimension/trend breakdown (`detailed`).
+ * Requires an explicit `entityId` — name-based lookups are rejected — and
+ * defaults to the message sender when no target is supplied. Fails soft with a
+ * structured `ActionResult` when the service is unavailable or the evaluation
+ * throws.
+ */
+
 import { logger } from "../../../logger.ts";
 import type {
 	ActionResult,

--- a/packages/core/src/features/trust/actions/hasTrustEngine.ts
+++ b/packages/core/src/features/trust/actions/hasTrustEngine.ts
@@ -1,3 +1,5 @@
+/** Availability guard for the TRUST action: true when the `trust-engine` service is registered on the runtime. */
+
 import type { IAgentRuntime } from "../../../types/index.ts";
 
 export function hasTrustEngine(runtime: IAgentRuntime): boolean {

--- a/packages/core/src/features/trust/actions/index.ts
+++ b/packages/core/src/features/trust/actions/index.ts
@@ -1,3 +1,5 @@
+/** Barrel for the TRUST action: the umbrella `trustAction`, its per-subaction handlers, and the `hasTrustEngine` availability guard. */
+
 export { evaluateTrustHandler } from "./evaluateTrust.ts";
 export { hasTrustEngine } from "./hasTrustEngine.ts";
 export { recordTrustInteractionHandler } from "./recordTrustInteraction.ts";

--- a/packages/core/src/features/trust/actions/recordTrustInteraction.ts
+++ b/packages/core/src/features/trust/actions/recordTrustInteraction.ts
@@ -1,3 +1,14 @@
+/**
+ * Handler for the TRUST umbrella's `record_interaction` subaction: parses a
+ * trust-affecting interaction (evidence type, target entity, impact,
+ * description) from the message JSON or action parameters, validates the type
+ * against `TrustEvidenceType`, and records it through the `trust-engine`
+ * service. The target defaults to the agent itself when none is given; the
+ * source is always the message sender. Fails soft with a structured
+ * `ActionResult` when the service is absent, the type is missing, or the type is
+ * invalid.
+ */
+
 import { logger } from "../../../logger.ts";
 import type {
 	ActionResult,

--- a/packages/core/src/features/trust/actions/requestElevation.ts
+++ b/packages/core/src/features/trust/actions/requestElevation.ts
@@ -1,3 +1,13 @@
+/**
+ * Handler for the TRUST umbrella's `request_elevation` subaction: asks the
+ * `contextual-permissions` service to grant the sender temporary elevated
+ * permission for a named action, using their `trust-engine` profile as context.
+ * Renders either the grant (with expiry) or the denial (with current trust score
+ * and remediation suggestions). Requires both the permission and trust services;
+ * fails soft with a structured `ActionResult` when either is missing or the
+ * request throws.
+ */
+
 import { logger } from "../../../logger.ts";
 import type {
 	ActionResult,

--- a/packages/core/src/features/trust/actions/roles.ts
+++ b/packages/core/src/features/trust/actions/roles.ts
@@ -1,3 +1,14 @@
+/**
+ * Handler for the TRUST umbrella's `update_role` subaction: assigns
+ * OWNER/ADMIN/NONE roles to entities within a group or world channel. A
+ * `TEXT_LARGE` extraction resolves who-gets-what from the request (explicit
+ * action parameters take precedence over the model output), the OWNER-only rule
+ * in `canModifyRole` is enforced per assignment, and results are persisted into
+ * `world.metadata.roles`. Requires `state`, a GROUP/WORLD channel, a `serverId`,
+ * and a resolvable world; each rejection path replies via the callback and
+ * returns a structured `ActionResult`.
+ */
+
 import dedent from "dedent";
 import { logger } from "../../../logger.ts";
 import {

--- a/packages/core/src/features/trust/evaluators/index.ts
+++ b/packages/core/src/features/trust/evaluators/index.ts
@@ -1,1 +1,3 @@
+/** Barrel for the trust feature's evaluators; re-exports the `securityEvaluator` pre-message security gate. */
+
 export * from "./securityEvaluator.ts";

--- a/packages/core/src/features/trust/evaluators/securityEvaluator.ts
+++ b/packages/core/src/features/trust/evaluators/securityEvaluator.ts
@@ -1,3 +1,15 @@
+/**
+ * Pre-message security gate for the trust feature, implemented as an
+ * `ALWAYS_BEFORE` action (despite the `evaluators/` location) so it runs ahead
+ * of the planner. Blocks messages carrying invisible-character obfuscation
+ * (zero-width / bidi / other control chars) or structural chat-template-token
+ * injection (`<|im_start|>`, `[INST]`, `"role":"system"`, END/NEW SYSTEM PROMPT,
+ * …) via pure heuristics — no keyword matching and no model call. Skips the
+ * agent's own messages and OWNER/ADMIN senders; on a hit returns a failing
+ * `ActionResult` naming the detected signals, otherwise passes through
+ * (`undefined`).
+ */
+
 import { logger } from "../../../logger.ts";
 import type {
 	Action,

--- a/packages/core/src/features/trust/index.ts
+++ b/packages/core/src/features/trust/index.ts
@@ -1,3 +1,14 @@
+/**
+ * Barrel and plugin factory for the trust capability. Assembles the trust
+ * `Plugin` from the trust action, the security pre-gate hook, the
+ * trust/security/admin providers, the four service wrappers (TrustEngine,
+ * SecurityModule, CredentialProtector, ContextualPermissionSystem), and the
+ * `trust` Drizzle schema, and re-exports the capability's public types,
+ * services, actions, and providers. `createTrustPlugin` builds the plugin with
+ * evaluators opt-in via `enableEvaluators`; on init it bootstraps the
+ * configured owner (OWNER_ENTITY_ID) to ADMIN in the WORLD_ID world's metadata
+ * roles.
+ */
 import { promoteSubactionsToActions } from "../../actions/promote-subactions.ts";
 import { logger } from "../../logger.ts";
 import {
@@ -33,11 +44,9 @@ export type {
 	PermissionContext,
 	PermissionDecision,
 } from "./types/permissions.ts";
-// Export types
 export * from "./types/security.ts";
-// Export types (avoid duplicate exports)
+// `*` re-export (not re-listed above) to avoid duplicate-export collisions with security.ts.
 export * from "./types/trust.ts";
-// Export services
 export {
 	ContextualPermissionSystem,
 	CredentialProtector,
@@ -45,7 +54,6 @@ export {
 	TrustEngine,
 };
 
-// Re-export service type for convenience
 export type TrustEngineService = InstanceType<typeof TrustEngine>;
 export type SecurityModuleService = InstanceType<typeof SecurityModule>;
 export type ContextualPermissionSystemService = InstanceType<
@@ -55,7 +63,6 @@ export type CredentialProtectorService = InstanceType<
 	typeof CredentialProtector
 >;
 
-// Export actions and providers
 export * from "./actions/index.ts";
 export * from "./evaluators/index.ts";
 export * from "./providers/index.ts";

--- a/packages/core/src/features/trust/providers/adminTrust.ts
+++ b/packages/core/src/features/trust/providers/adminTrust.ts
@@ -1,3 +1,10 @@
+/**
+ * Provider for the trust capability that marks the current speaker as a trusted
+ * admin when they are the world OWNER, injecting a directive that their
+ * contact/identity claims may be treated as trusted absent contradictory
+ * evidence. Resolves the owner from the room's world `metadata.ownership`/`roles`
+ * and is gated to admin/settings contexts and a minimum ADMIN role.
+ */
 import type {
 	IAgentRuntime,
 	Memory,

--- a/packages/core/src/features/trust/providers/index.ts
+++ b/packages/core/src/features/trust/providers/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the trust capability's providers: adminTrust, securityStatus, trustProfile. */
 export * from "./adminTrust.ts";
 export * from "./securityStatus.ts";
 export * from "./trustProfile.ts";

--- a/packages/core/src/features/trust/providers/securityStatus.ts
+++ b/packages/core/src/features/trust/providers/securityStatus.ts
@@ -1,3 +1,13 @@
+/**
+ * Provider for the trust capability that injects a security assessment of the
+ * incoming message during state composition: it runs the SecurityModule's
+ * prompt-injection analysis, recent-incident count, and threat-level scoring,
+ * and emits explicit refusal directives when the current message is flagged.
+ * Skips the agent's own messages and short-circuits to an admin_request signal
+ * when the sender resolves as admin context (see resolveAdminContext), so
+ * legitimate admins are not gated as adversarial input. Restricted to
+ * admin/settings contexts and a minimum ADMIN role.
+ */
 import { logger } from "../../../logger.ts";
 import type {
 	IAgentRuntime,

--- a/packages/core/src/features/trust/providers/trustProfile.ts
+++ b/packages/core/src/features/trust/providers/trustProfile.ts
@@ -1,3 +1,10 @@
+/**
+ * Provider for the trust capability that injects the sender's trust profile —
+ * overall score, per-dimension breakdown (reliability/competence/integrity/
+ * benevolence/transparency), trend direction, and recent positive/negative
+ * interaction counts — by evaluating the TrustEngine for the message sender.
+ * Gated to admin/settings contexts and a minimum ADMIN role.
+ */
 import { logger } from "../../../logger.ts";
 import type {
 	IAgentRuntime,

--- a/packages/core/src/features/trust/schema.ts
+++ b/packages/core/src/features/trust/schema.ts
@@ -1,3 +1,11 @@
+/**
+ * Drizzle table definitions for the trust capability, all under the `trust`
+ * Postgres schema: multi-dimensional trust profiles and the evidence feeding
+ * them, contextual role assignments, permission delegations, behavioral
+ * profiles (anomaly / multi-account detection), security incidents,
+ * cross-platform identity links, and anonymous whistleblower reports. Wired into
+ * the trust plugin's `schema` and materialized by the SQL adapters.
+ */
 import { sql } from "drizzle-orm";
 import {
 	boolean,

--- a/packages/core/src/features/trust/services/ContextualPermissionSystem.test.ts
+++ b/packages/core/src/features/trust/services/ContextualPermissionSystem.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Deterministic unit tests for ContextualPermissionSystem's role→permission
+ * mapping (#12087 Item 5) and world-scoped role resolution (#12087 Item 8). No
+ * runtime or DB: resolveEntityRole is mocked and getWorld is a stub, while the
+ * real CANONICAL_ROLE_RANK drives the rank-tier assertions.
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { IAgentRuntime, UUID } from "../../../types/index.ts";
 

--- a/packages/core/src/features/trust/services/ContextualPermissionSystem.ts
+++ b/packages/core/src/features/trust/services/ContextualPermissionSystem.ts
@@ -1,3 +1,12 @@
+/**
+ * Service for the trust capability that adjudicates access requests. `checkAccess`
+ * runs a request through an ordered pipeline — prompt-injection block
+ * (SecurityModule), role-based grants (cumulative canonical-rank tiers),
+ * trust-threshold grants (TrustEngine, read-only actions only), active temporary
+ * elevations, then delegated permissions — and caches allow decisions in a
+ * TTL-bounded LRU. Also mints time-boxed elevations (trust-gated, never for
+ * admin-only actions) and tracks inter-entity permission delegations.
+ */
 import { logger } from "../../../logger.ts";
 import {
 	CANONICAL_ROLE_RANK,
@@ -43,15 +52,13 @@ export class ContextualPermissionSystem {
 	private delegations = new Map<UUID, PermissionDelegation[]>();
 
 	/**
-	 * Role→action grants as cumulative rank tiers (#12087 Item 5). The prior map
-	 * was keyed per-role and non-cumulative, so it had two bugs: GUEST/USER/MEMBER
-	 * had no row at all (roleHasPermission returned false — FEWER grants than the
-	 * unauthenticated NONE tier), and the ADMIN row omitted the base grants
-	 * (send_message/view_content), so an admin could not even send a message.
-	 * Grants now accumulate by canonical rank: everyone at NONE and above gets
-	 * BASE_PERMISSIONS; ADMIN and above additionally get ADMIN_PERMISSIONS; OWNER
-	 * gets everything. (Full target: derive each requirement from the capability it
-	 * protects; the tier sets remain the interim source of truth.)
+	 * Role→action grants as cumulative rank tiers (#12087 Item 5). Grants
+	 * accumulate by canonical rank so no tier ever holds fewer grants than the
+	 * unauthenticated NONE floor: everyone at NONE and above gets BASE_PERMISSIONS
+	 * (including send_message/view_content); ADMIN and above additionally get
+	 * ADMIN_PERMISSIONS; OWNER gets everything. (Full target: derive each
+	 * requirement from the capability it protects; the tier sets remain the interim
+	 * source of truth.)
 	 */
 	private static readonly BASE_PERMISSIONS = new Set([
 		"send_message",
@@ -451,10 +458,10 @@ export class ContextualPermissionSystem {
 		context: PermissionContext,
 	): Promise<string[]> {
 		if (context.worldId) {
-			// #12087 Item 8: context.worldId is ALREADY a hashed world id. The prior
-			// getUserServerRole(runtime, entityId, context.worldId) re-hashed it as a
-			// serverId, found no world, and returned NONE for everyone. resolveEntityRole
-			// reads the world directly and applies canonical-owner/demotion rules.
+			// #12087 Item 8: context.worldId is ALREADY a hashed world id, so it must
+			// not be re-hashed as a serverId (doing so finds no world and yields NONE
+			// for everyone). resolveEntityRole reads the world directly and applies
+			// canonical-owner/demotion rules.
 			const world = await this.runtime.getWorld(context.worldId as UUID);
 			const role = await resolveEntityRole(
 				this.runtime,

--- a/packages/core/src/features/trust/services/CredentialProtector.ts
+++ b/packages/core/src/features/trust/services/CredentialProtector.ts
@@ -1,3 +1,18 @@
+/**
+ * Runs the `CredentialProtector` service of the trust capability: scans inbound
+ * messages for credential-theft attempts using regex plus obfuscation-aware
+ * keyword matching over sensitive-data mentions, exfiltration-request phrasing,
+ * phishing cues, and prompt-injection markers, while suppressing known
+ * legitimate contexts (password-reset help and the like) to limit false
+ * positives.
+ *
+ * Beyond detection it redacts sensitive data (`protectSensitiveData`), warns
+ * likely victims (`alertPotentialVictims`), and scores whole conversations.
+ * Confirmed threats are logged through the {@link SecurityModule} injected at
+ * `initialize`, which persists them as security incidents and trust evidence.
+ * The runtime-facing wrapper is `CredentialProtectorServiceWrapper`.
+ */
+
 import { logger } from "../../../logger.ts";
 import {
 	type IAgentRuntime,

--- a/packages/core/src/features/trust/services/SecurityModule.ts
+++ b/packages/core/src/features/trust/services/SecurityModule.ts
@@ -1,3 +1,22 @@
+/**
+ * Runs the `SecurityModule` service — the threat-detection core of the trust
+ * capability. Analyzes messages for prompt injection, social-engineering
+ * pressure (urgency, authority, intimidation, liking, reciprocity, and so on),
+ * and credential theft, and detects account-level abuse: multi-account linkage,
+ * phishing campaigns, username impersonation, and coordinated activity. Scoring
+ * is deterministic — regex banks (shared via `../injection-primitives`),
+ * obfuscation-aware keyword matching, behavioral-profile similarity, and
+ * Levenshtein/visual-similarity comparisons — with no model calls.
+ *
+ * Confirmed events are logged to the runtime log and best-effort persisted to
+ * the `securityIncidents` table (`SecurityStore`), then mapped to trust evidence
+ * fed back into the {@link TrustEngine}. Per-entity message/action history and
+ * behavioral profiles are held in memory, bounded by an LRU cap
+ * ({@link MAX_TRACKED_ENTITIES}) so a long-lived agent that talks to many users
+ * cannot grow without limit. The runtime-facing wrapper is
+ * `SecurityModuleServiceWrapper`.
+ */
+
 import { logger } from "../../../logger.ts";
 import type { IAgentRuntime, UUID } from "../../../types/index.ts";
 import {
@@ -84,8 +103,8 @@ export class SecurityModule {
 	}
 
 	// INJECTION_PATTERNS / INJECTION_KEYWORDS and the URGENCY/AUTHORITY/
-	// INTIMIDATION social-engineering banks now live in `../injection-primitives`
-	// (the single source shared with the should-respond risk gate, issue #9949).
+	// INTIMIDATION social-engineering banks live in `../injection-primitives`,
+	// the single source shared with the should-respond risk gate (issue #9949).
 
 	// Additional patterns for credential theft
 	private readonly CREDENTIAL_PATTERNS = [
@@ -445,7 +464,7 @@ export class SecurityModule {
 	}
 
 	/**
-	 * Log security event (now public)
+	 * Log security event
 	 */
 	async logSecurityEvent(
 		event: Omit<SecurityEvent, "id" | "timestamp" | "handled">,

--- a/packages/core/src/features/trust/services/TrustEngine.ts
+++ b/packages/core/src/features/trust/services/TrustEngine.ts
@@ -1,3 +1,18 @@
+/**
+ * Runs the `TrustEngine` service — the scoring core of the trust capability.
+ * Computes multi-dimensional trust profiles (reliability, competence, integrity,
+ * benevolence, transparency) by aggregating decayed, verification-weighted
+ * evidence, derives an overall score under context-specific dimension weights,
+ * and gates actions via `evaluateTrustDecision` against `TrustRequirements`.
+ *
+ * `recordInteraction` ingests evidence with per-entity hourly rate limiting and
+ * diminishing-returns weighting. Profiles are cached (FIFO-capped) and persisted
+ * as entity `trust_profile` components; evidence is read from both components
+ * and the `trustEvidence` table (`SecurityStore`) and merged. Consumed by the
+ * SecurityModule, ContextualPermissionSystem, trust providers/actions, and the
+ * `TrustEngineServiceWrapper` that registers it with the runtime.
+ */
+
 import { logger } from "../../../logger.ts";
 import {
 	type Component,

--- a/packages/core/src/features/trust/services/adminContext.ts
+++ b/packages/core/src/features/trust/services/adminContext.ts
@@ -1,3 +1,10 @@
+/**
+ * Shared helper for the trust capability that decides whether a message sender
+ * should be treated as trusted-admin context: true when they match the
+ * configured OWNER_ENTITY_ID, when the room is a direct agent<->user DM, or when
+ * they hold ADMIN/OWNER role in the resolved world. Consumed by the
+ * securityStatus provider to bypass adversarial-input gating for admins.
+ */
 import { createUniqueUuid } from "../../../entities.ts";
 import {
 	ChannelType,

--- a/packages/core/src/features/trust/services/db.ts
+++ b/packages/core/src/features/trust/services/db.ts
@@ -1,3 +1,10 @@
+/**
+ * Resolves the runtime's Drizzle database handle for the trust capability's
+ * data-access layer and defines the minimal chainable `DrizzleDB` shape those
+ * queries use. `getDb` throws when no adapter is attached; consumed by
+ * SecurityStore, TrustEngine, and SecurityModule.
+ */
+
 import type { IAgentRuntime } from "../../../types/index.ts";
 
 /**

--- a/packages/core/src/features/trust/services/wrappers.ts
+++ b/packages/core/src/features/trust/services/wrappers.ts
@@ -1,3 +1,16 @@
+/**
+ * Runtime `Service` wrappers that adapt the trust capability's plain engine
+ * classes — TrustEngine, SecurityModule, CredentialProtector, and
+ * ContextualPermissionSystem — into services the trust plugin registers. Each
+ * wrapper owns construction and startup ordering, awaiting its dependencies via
+ * `getServiceLoadPromise` (SecurityModule needs the trust engine;
+ * CredentialProtector needs the security module; ContextualPermissionSystem
+ * needs both), then exposes thin proxy methods onto the underlying instance.
+ *
+ * Kept in their own module to break the circular dependency between the engines
+ * and the evaluators/providers that consume them.
+ */
+
 import {
 	type IAgentRuntime,
 	Service,
@@ -122,7 +135,7 @@ export class SecurityModuleServiceWrapper extends Service {
 		return this.securityModule.logTrustImpact(entityId, event, impact, context);
 	}
 
-	// Add missing methods for tests
+	// Methods exposed for tests
 	storeMessage(message: SecurityMessage): Promise<void> {
 		return this.securityModule.storeMessage(message);
 	}

--- a/packages/core/src/features/trust/types/permissions.ts
+++ b/packages/core/src/features/trust/types/permissions.ts
@@ -1,3 +1,14 @@
+/**
+ * Type and helper definitions for the trust capability's permission and
+ * access-control subsystem: permission contexts, contextual (time-bounded,
+ * trust-gated) role assignments, permissions with constraints, decision and
+ * audit shapes, and elevation/delegation requests and results. Also defines a
+ * Unix-style octal permission model (`UnixPermission`, `ActionPermission`) and
+ * the `PermissionUtils` helpers that evaluate owner/group/other read/write/exec
+ * bits against a caller. Consumed by `ContextualPermissionSystem` and the
+ * service wrappers.
+ */
+
 import type { Role, UUID } from "../../../types/index.ts";
 import type { TrustRequirements } from "./trust.ts";
 

--- a/packages/core/src/features/trust/types/security.ts
+++ b/packages/core/src/features/trust/types/security.ts
@@ -1,3 +1,12 @@
+/**
+ * Type and enum definitions for the trust capability's security subsystem: the
+ * `SecurityContext` a check runs in, the `SecurityCheck`/`ThreatAssessment`
+ * verdicts, the `SecurityEvent` record and its `SecurityEventType` enum, and the
+ * pattern-detection result shapes (multi-account, phishing, impersonation,
+ * coordination, credential theft). Also defines the in-memory `BehavioralProfile`
+ * plus the `Message`/`Action` records the SecurityModule tracks per entity.
+ */
+
 import type { UUID } from "../../../types/index.ts";
 import type { PermissionContext } from "./permissions.ts";
 

--- a/packages/core/src/features/trust/types/trust.ts
+++ b/packages/core/src/features/trust/types/trust.ts
@@ -1,3 +1,12 @@
+/**
+ * Type and enum definitions for the trust capability's scoring model: the five
+ * `TrustDimensions`, the `TrustEvidenceType` enum and `TrustEvidence` records
+ * that move each dimension, the computed `TrustProfile` (dimensions, overall
+ * score, confidence, trend), the `TrustContext` evaluations run in, and the
+ * `TrustDecision`/`TrustRequirements`/`TrustInteraction`/`TrustCalculationConfig`
+ * shapes. Consumed by the TrustEngine and, via evidence mapping, the SecurityModule.
+ */
+
 import type { UUID } from "../../../types/index.ts";
 
 /**

--- a/packages/core/src/features/working-memory/attachmentContext.ts
+++ b/packages/core/src/features/working-memory/attachmentContext.ts
@@ -1,3 +1,14 @@
+/**
+ * Attachment-reading helpers behind the ATTACHMENT action of the working-memory
+ * capability. Gathers the attachments visible in the current conversation window
+ * (the current message plus the recent-message history, deduped by id and ordered
+ * newest-first), decides which one an untargeted request refers to (explicit
+ * id/locator match, or the sole attachment), and materializes readable content
+ * for each — stored extracted text or description, falling back to an on-demand
+ * vision description that reuses the shared content-addressed image cache.
+ * Consumed by readAttachmentAction.ts; the `_data`/`_mimeType`/`_createdAt` fields
+ * are inline-transport and ordering extensions carried alongside `Media`.
+ */
 import { describeImageCached } from "../../media/index.ts";
 import {
 	ContentType,

--- a/packages/core/src/features/working-memory/readAttachmentAction.i18n.test.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.i18n.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit coverage for readAttachmentActionKind — the ATTACHMENT action's routing of
+ * the planner-emitted `action`/`subaction` enum (plus dash/space aliases) to read
+ * vs save_as_document. Pure-function assertions, no runtime or model.
+ */
 import { describe, expect, it } from "vitest";
 import { readAttachmentActionKind } from "./readAttachmentAction.ts";
 

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -1,3 +1,18 @@
+/**
+ * Implements the ATTACHMENT action of the working-memory capability: an
+ * ADMIN-gated action that reads or persists attachments, link previews, and media
+ * already present in the current conversation (it never fetches new URLs — that
+ * routes to WEB_FETCH). action=read gathers the readable content and, per the
+ * request, answers the user's question via a TEXT_SMALL call, returns an
+ * attachment metadata record, or stashes the content into the bounded task
+ * clipboard; action=save_as_document writes the content to the DocumentService.
+ *
+ * Attachment gathering and selection are delegated to attachmentContext.ts,
+ * clipboard persistence to taskClipboardPersistence.ts, and document storage to
+ * features/documents. readAttachmentActionKind resolves the operation purely from
+ * the planner-emitted enum, deliberately doing no natural-language keyword
+ * inference so routing stays language-agnostic (#10471).
+ */
 import {
 	type Action,
 	type ActionResult,

--- a/packages/core/src/features/working-memory/taskClipboardPersistence.ts
+++ b/packages/core/src/features/working-memory/taskClipboardPersistence.ts
@@ -1,3 +1,12 @@
+/**
+ * Bridges the ATTACHMENT action to the task clipboard service of the
+ * working-memory capability. Decides whether a message requested clipboard
+ * persistence via the addToClipboard/persistToClipboard/saveToClipboard flags,
+ * resolves a display title, and stores one item through createTaskClipboardService
+ * — returning a discriminated result describing whether persistence was requested
+ * and whether it succeeded. Empty content and service errors surface as
+ * stored:false with a reason rather than throwing.
+ */
 import type { IAgentRuntime, Memory } from "../../types/index.ts";
 import type {
 	AddTaskClipboardItemInput,


### PR DESCRIPTION
## What

Batch **B01 part 3** of the repo-wide comment cleanup (#12231, parent #12181) — the core
capability subsystems under `packages/core/src/features`. Every in-scope file gets an accurate
prose header naming the capability it belongs to and its role (action / provider / service /
schema); churn comments removed/rewritten to present-tense fact.

**Comments only — zero functional diff.** Machine-proven by `node scripts/assert-comment-only-diff.mjs`:
every changed file's TypeScript code-token stream is byte-identical to base.

## Scope (225 files)

advanced-capabilities, basic-capabilities, trust, documents, messaging, plugin-manager,
secrets, advanced-memory, working-memory, trajectories, advanced-planning, plugin-config,
sub-agent-credentials, oauth, credential-proxy, payments, subscription-auth, autonomy.

Follows #12824 (p1) and #12874 (p2). Remaining B01: `services/` + `utils/` (final part).

## Verification
```
node scripts/assert-comment-only-diff.mjs
# OK — 225 source file(s) changed; every code token identical to base. Comments only.
```
Part of #12231.