### PR TITLE
docs(#12863): add remote manifest residual headers

### DIFF
--- a/packages/plugin-remote-manifest/examples/hello-remote-plugin/install.test.ts
+++ b/packages/plugin-remote-manifest/examples/hello-remote-plugin/install.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Hello remote plugin install tests prove the sample plugin can be installed,
+ * bootstrapped, and loaded from a temporary store.
+ */
 import { describe, expect, it } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/packages/plugin-remote-manifest/examples/hello-remote-plugin/worker.mjs
+++ b/packages/plugin-remote-manifest/examples/hello-remote-plugin/worker.mjs
@@ -1,3 +1,7 @@
+/**
+ * Hello remote plugin worker exposes a minimal action, provider, and service
+ * through the bootstrap contract used by remote plugin install tests.
+ */
 import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 

--- a/packages/plugin-remote-manifest/examples/remote-plugin-clock/install.test.ts
+++ b/packages/plugin-remote-manifest/examples/remote-plugin-clock/install.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Clock example install tests prove the sample remote plugin can be installed
+ * into the content-addressed store and loaded back from disk.
+ */
 import { describe, expect, it } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/packages/plugin-remote-manifest/examples/remote-plugin-clock/worker.mjs
+++ b/packages/plugin-remote-manifest/examples/remote-plugin-clock/worker.mjs
@@ -1,3 +1,7 @@
+/**
+ * Clock example worker publishes a time provider through the remote plugin
+ * bootstrap and appends invocation evidence for install smoke tests.
+ */
 import { appendFileSync } from "node:fs";
 
 const bootstrap = globalThis.__remotePluginBootstrap;

--- a/packages/plugin-remote-manifest/src/host-shim/android/index.test.ts
+++ b/packages/plugin-remote-manifest/src/host-shim/android/index.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Android host shim tests exercise JSON bridge request dispatch, response
+ * delivery, event fanout, and reset behavior with a fake native bridge.
+ */
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import { getHostShim, resetHostShim } from "../index.js";
 import { installAndroidShim, resetAndroidShimForTests } from "./index.js";

--- a/packages/plugin-remote-manifest/src/host-shim/electrobun/index.test.ts
+++ b/packages/plugin-remote-manifest/src/host-shim/electrobun/index.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Electrobun host shim tests verify desktop bridge request forwarding,
+ * response correlation, event delivery, and listener cleanup.
+ */
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import { getHostShim, resetHostShim } from "../index.js";
 import { installElectrobunShim, resetElectrobunShimForTests } from "./index.js";

--- a/packages/plugin-remote-manifest/src/host-shim/index.test.ts
+++ b/packages/plugin-remote-manifest/src/host-shim/index.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Host shim registry tests verify install, lookup, overwrite, and reset
+ * behavior shared by platform-specific remote plugin bridges.
+ */
 import { describe, expect, it } from "bun:test";
 import {
   getHostShim,

--- a/packages/plugin-remote-manifest/src/host-shim/ios/index.test.ts
+++ b/packages/plugin-remote-manifest/src/host-shim/ios/index.test.ts
@@ -1,3 +1,7 @@
+/**
+ * iOS host shim tests cover WebKit message-handler dispatch, native response
+ * delivery, event fanout, and bridge reset behavior.
+ */
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import { getHostShim, resetHostShim } from "../index.js";
 import { installIosShim, resetIosShimForTests } from "./index.js";

--- a/packages/plugin-remote-manifest/src/host-shim/web.test.ts
+++ b/packages/plugin-remote-manifest/src/host-shim/web.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Web host shim tests exercise browser postMessage request routing, event
+ * fanout, listener cleanup, and failure handling with a fake window object.
+ */
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import { getHostShim, resetHostShim } from "./index.js";
 import { installWebShim, resetWebShimForTests } from "./web.js";

--- a/packages/plugin-remote-manifest/src/index.test.ts
+++ b/packages/plugin-remote-manifest/src/index.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Barrel tests lock the default package export surface used by remote plugin
+ * hosts, workers, and compatibility wrapper packages.
+ */
 import { describe, expect, it } from "bun:test";
 import * as manifestBarrel from "./index.js";
 

--- a/packages/plugin-remote-manifest/src/manifest.test.ts
+++ b/packages/plugin-remote-manifest/src/manifest.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Manifest helper tests cover permission consent requests, manifest tag
+ * extraction, and permission diffs for remote plugin install review.
+ */
 import { describe, expect, it } from "bun:test";
 import {
   buildRemotePluginPermissionConsentRequest,

--- a/packages/plugin-remote-manifest/src/permissions.test.ts
+++ b/packages/plugin-remote-manifest/src/permissions.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Permission helper tests cover normalization, flattening, merging, and tag
+ * parsing across current grants and legacy compatibility shapes.
+ */
 import { describe, expect, it } from "bun:test";
 import {
   flattenRemotePluginPermissions,

--- a/packages/plugin-remote-manifest/src/rpc-mac.test.ts
+++ b/packages/plugin-remote-manifest/src/rpc-mac.test.ts
@@ -1,3 +1,7 @@
+/**
+ * RPC MAC tests verify canonical byte encoding, key-id derivation, and hex
+ * codec behavior used by host-to-worker message integrity checks.
+ */
 import { describe, expect, it } from "bun:test";
 import {
   canonicalRpcBytes,

--- a/packages/plugin-remote-manifest/src/signature.test.ts
+++ b/packages/plugin-remote-manifest/src/signature.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Artifact signature tests verify local Ed25519 signing and validation paths
+ * against temporary plugin tarballs and in-memory KMS keys.
+ */
 import { describe, expect, it } from "bun:test";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/packages/plugin-remote-manifest/src/store.test.ts
+++ b/packages/plugin-remote-manifest/src/store.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Install-store tests exercise registry IO, path containment, bootstrap writes,
+ * and source-folder installation against real temporary directories.
+ */
 import { describe, expect, it } from "bun:test";
 import {
   mkdirSync,

--- a/packages/plugin-remote-manifest/src/sub-agent-claude-code/plugin.test.ts
+++ b/packages/plugin-remote-manifest/src/sub-agent-claude-code/plugin.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Claude Code plugin tests lock the remote sub-agent descriptor, permissions,
+ * and service registration exposed to the plugin loader.
+ */
 import { describe, expect, it } from "bun:test";
 import { plugin } from "./plugin.js";
 import { ClaudeCodeSubAgentService } from "./sub-agent-service.js";

--- a/packages/plugin-remote-manifest/src/sub-agent-claude-code/sandbox.test.ts
+++ b/packages/plugin-remote-manifest/src/sub-agent-claude-code/sandbox.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Claude Code sandbox tests validate filesystem policy rendering and path
+ * handling for the reference remote sub-agent sandbox assets.
+ */
 import { describe, expect, it } from "bun:test";
 import {
   chmodSync,

--- a/packages/plugin-remote-manifest/src/sub-agent-claude-code/session-recorder.test.ts
+++ b/packages/plugin-remote-manifest/src/sub-agent-claude-code/session-recorder.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Session recorder tests verify transcript persistence, retention pruning, and
+ * symlink-safe cleanup for Claude Code remote sub-agent sessions.
+ */
 import { describe, expect, it } from "bun:test";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";

--- a/packages/plugin-remote-manifest/src/sub-agent-claude-code/sub-agent-service.test.ts
+++ b/packages/plugin-remote-manifest/src/sub-agent-claude-code/sub-agent-service.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Claude Code service tests exercise subprocess launch, request routing,
+ * audit emission, and shutdown behavior with mocked Bun process handles.
+ */
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { mkdtempSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/packages/plugin-remote-manifest/src/validation.test.ts
+++ b/packages/plugin-remote-manifest/src/validation.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Manifest validation tests exercise JSON-like input parsing and issue
+ * reporting for remote plugin manifests received at install boundaries.
+ */
 import { describe, expect, it } from "bun:test";
 import { validateRemotePluginManifest } from "./validation.js";
 

--- a/packages/plugin-remote-manifest/src/worker-runtime/bootstrap.test.ts
+++ b/packages/plugin-remote-manifest/src/worker-runtime/bootstrap.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Worker bootstrap tests verify that plugin descriptors and lifecycle hooks
+ * wire into the remote runtime channel with deterministic in-memory fixtures.
+ */
 import { describe, expect, it } from "bun:test";
 import type { RemotePluginWorkerMessage } from "../index.js";
 import { bootstrap } from "./bootstrap.js";

--- a/packages/plugin-remote-manifest/src/worker-runtime/descriptor.test.ts
+++ b/packages/plugin-remote-manifest/src/worker-runtime/descriptor.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Descriptor tests cover worker announce payload construction from plugin
+ * actions, providers, services, routes, events, models, evaluators, and tests.
+ */
 import { describe, expect, it } from "bun:test";
 import {
   buildAnnounceDescriptor,

--- a/packages/plugin-remote-manifest/src/worker-runtime/dispatch.test.ts
+++ b/packages/plugin-remote-manifest/src/worker-runtime/dispatch.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Worker dispatch tests verify handler registration, MAC enforcement, and
+ * audited surface invocation for remote plugin RPC messages.
+ */
 import { describe, expect, it } from "bun:test";
 import {
   AuditDispatcher,

--- a/packages/plugin-remote-manifest/src/worker-runtime/envelope.test.ts
+++ b/packages/plugin-remote-manifest/src/worker-runtime/envelope.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Worker envelope tests cover request-id allocation and subprocess channel
+ * message framing without launching the full remote plugin runtime.
+ */
 import { afterEach, describe, expect, it } from "bun:test";
 import {
   createRequestIdAllocator,

--- a/packages/plugin-remote-manifest/src/worker-runtime/runtime-proxy.test.ts
+++ b/packages/plugin-remote-manifest/src/worker-runtime/runtime-proxy.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Runtime proxy tests drive the worker-side API facade over an in-memory
+ * channel, including request correlation and event delivery behavior.
+ */
 import { describe, expect, it } from "bun:test";
 import type { RemotePluginWorkerMessage } from "../index.js";
 import type { WorkerChannel } from "./envelope.js";


### PR DESCRIPTION
## Summary
- Add purpose headers to residual plugin-remote-manifest test files and example workers.
- Cover host shim, worker runtime, sub-agent, store/signature/permission tests, and install examples.
- Keep the patch comment-only; code tokens are unchanged.

Fixes #12863

## Validation
- PASS `bun run check:comment-only`
- PASS `bun run --cwd packages/plugin-remote-manifest test` (139 tests)
- PASS `bun run --cwd packages/plugin-remote-manifest typecheck`
- PASS `bun run --cwd packages/plugin-remote-manifest lint`
- PASS `git diff --check origin/develop...HEAD`

## Verification notes
- `bun run verify` was attempted after #12919 landed. In this local sparse checkout, `packages/scripts` is not materialized (`git sparse-checkout list` only includes packages/core, packages/scenario-runner, packages/shared, plugins/plugin-computeruse, plugins/plugin-vision), so multiple package builds failed to resolve `packages/scripts/rm-path-recursive.mjs` and `packages/scripts/with-package-build-lock.mjs`; verify then exited 139. This is a workspace checkout limitation, not a code-token change in this PR.

## Evidence
- UI/video/domain artifacts: N/A - comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
