### PR TITLE
[codex] Fix build:core workspace symlink repair

### DIFF
--- a/packages/scripts/__tests__/build-core.test.ts
+++ b/packages/scripts/__tests__/build-core.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { buildCoreTurboArgs } from "../build-core.mjs";
+import {
+  BUILD_CORE_PREREQUISITE_SCRIPTS,
+  buildCoreTurboArgs,
+} from "../build-core.mjs";
 import { CORE_BUILD_PACKAGES } from "../build-core-packages.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -112,6 +115,12 @@ describe("build-core package set (issue #10200)", () => {
   test("buildCoreTurboArgs forwards extra turbo args after the filters", () => {
     const args = buildCoreTurboArgs(["--force"]);
     expect(args.at(-1)).toBe("--force");
+  });
+
+  test("build:core repairs workspace links before invoking turbo", () => {
+    expect(BUILD_CORE_PREREQUISITE_SCRIPTS).toContain(
+      "ensure-workspace-symlinks.mjs",
+    );
   });
 
   test("root build:core delegates to the driver (no re-inlined --filter list)", () => {

--- a/packages/scripts/build-core.mjs
+++ b/packages/scripts/build-core.mjs
@@ -2,8 +2,9 @@
 /**
  * Build the "core" package set (issue #10200).
  *
- * Drives `run-turbo.mjs run build` over the leaf packages declared in
- * `build-core-packages.mjs`. This replaces the hand-maintained
+ * Ensures workspace package symlinks exist, then drives `run-turbo.mjs run
+ * build` over the leaf packages declared in `build-core-packages.mjs`. This
+ * replaces the hand-maintained
  * `--filter=@elizaos/… (×27)` string that used to live inline in the root
  * `build:core` package.json script. The emitted Turbo invocation is identical to
  * the old inline list — same `run build --filter=…` args, same default Turbo
@@ -24,6 +25,7 @@ import { CORE_BUILD_PACKAGES } from "./build-core-packages.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const RUN_TURBO = path.join(SCRIPT_DIR, "run-turbo.mjs");
+export const BUILD_CORE_PREREQUISITE_SCRIPTS = ["ensure-workspace-symlinks.mjs"];
 
 /** The exact `run-turbo.mjs` argv for the core build, plus any forwarded args. */
 export function buildCoreTurboArgs(extra = []) {
@@ -37,6 +39,30 @@ export function buildCoreTurboArgs(extra = []) {
 
 function main() {
   const extra = process.argv.slice(2);
+  for (const script of BUILD_CORE_PREREQUISITE_SCRIPTS) {
+    console.log(`[build-core] running ${script}`);
+    const prerequisite = spawnSync(
+      process.execPath,
+      [path.join(SCRIPT_DIR, script)],
+      {
+        stdio: "inherit",
+      },
+    );
+    if (prerequisite.error) {
+      console.error(
+        `[build-core] could not run ${script}: ${prerequisite.error.message}\n` +
+          `[build-core] re-run after \`bun install\`: bun run build:core`,
+      );
+      process.exit(1);
+    }
+    if (prerequisite.status !== 0) {
+      console.error(
+        `[build-core] ${script} failed (exit ${prerequisite.status ?? "signal"}). ` +
+          `Re-run after \`bun install\`: bun run build:core`,
+      );
+      process.exit(prerequisite.status ?? 1);
+    }
+  }
   console.log(
     `[build-core] building ${CORE_BUILD_PACKAGES.length} core packages via turbo` +
       (extra.length ? ` (extra args: ${extra.join(" ")})` : ""),


### PR DESCRIPTION
## What changed

- `packages/scripts/build-core.mjs` now runs the existing `ensure-workspace-symlinks.mjs` prerequisite before invoking Turbo.
- `packages/scripts/__tests__/build-core.test.ts` now guards that `build:core` keeps the workspace-link repair prerequisite.

## Why

`cloud-cf-deploy.yml` installs with `bun install --no-save --ignore-scripts`, so the repository `postinstall` hook does not run `ensure-workspace-symlinks.mjs`. In a clean deploy-style checkout, Bun did not create `node_modules/@elizaos/cloud-routing`; then `@elizaos/core` declaration emit could not resolve `@elizaos/cloud-routing`, even though Turbo already knows `@elizaos/core#build` depends on `@elizaos/cloud-routing#build`.

Centralizing the repair in `build:core` fixes all workflow/test/deploy callers instead of duplicating the step in each deploy job.

Fixes #12872.

## Evidence

- Reproduced clean no-postinstall state: after `bun install --no-save --ignore-scripts --cache-dir "$HOME/.bun-install-cache-deploy"`, `node_modules/@elizaos/cloud-routing` and `packages/cloud/routing/dist` were absent.
- Reproduced core declaration failure: after existing logger/contracts prep, `bun run --cwd packages/core build` failed with `src/cloud-routing.ts(...): error TS2307: Cannot find module '@elizaos/cloud-routing' or its corresponding type declarations.`
- Verified fix from the rebased branch: removed `node_modules/@elizaos/cloud-routing` and `packages/cloud/routing/dist`, then ran `node packages/scripts/build-core.mjs --force --concurrency=1 --output-logs=errors-only`; output showed `[ensure-workspace-symlinks] created=1 ...` followed by `Tasks: 69 successful, 69 total`.
- Focused test: `bun test packages/scripts/__tests__/build-core.test.ts` passed, 8/8 tests.
- Diff hygiene: `git diff --check origin/develop..HEAD` passed.

## Evidence rows

- Real LLM trajectory: N/A - build tooling only; no agent/model behavior changed.
- Backend logs: N/A - no runtime/API/server path changed.
- Frontend logs/screenshots/video: N/A - no UI changed.
- Domain artifacts: N/A - no DB, memory, chain, scheduled task, generated user artifact, or file-store behavior changed.
