### PR TITLE
fix(#12626): clean up late native stream listeners

### DIFF
--- a/packages/ui/src/api/native-agent-stream.test.ts
+++ b/packages/ui/src/api/native-agent-stream.test.ts
@@ -15,13 +15,22 @@ import {
  * `agentStream*` events on demand — exactly how the native bridge will emit them
  * via Capacitor `notifyListeners`.
  */
-function makeFakeAgent(streamId = "s1", completion?: Promise<unknown>) {
+function makeFakeAgent(
+  streamId = "s1",
+  completion?: Promise<unknown>,
+  options: { addListenerDelayMs?: number } = {},
+) {
   const listeners = new Map<string, Array<(e: unknown) => void>>();
   const agent: NativeStreamingAgentPlugin = {
     async requestStream() {
       return { streamId, completion };
     },
     async addListener(eventName, listener) {
+      if (options.addListenerDelayMs) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, options.addListenerDelayMs),
+        );
+      }
       const arr = listeners.get(eventName) ?? [];
       arr.push(listener);
       listeners.set(eventName, arr);
@@ -151,6 +160,20 @@ describe("createNativeStreamingResponse", () => {
       path: "/x",
     });
     await expect(responsePromise).rejects.toThrow("native boot failed");
+  });
+
+  it("removes listener handles that resolve after an early native completion rejection", async () => {
+    const completion = Promise.reject(new Error("native boot failed"));
+    const { agent, listenerCount } = makeFakeAgent("s1", completion, {
+      addListenerDelayMs: 5,
+    });
+    const responsePromise = createNativeStreamingResponse(agent, {
+      path: "/x",
+    });
+    await expect(responsePromise).rejects.toThrow("native boot failed");
+    await flush();
+    await flush();
+    expect(listenerCount()).toBe(0);
   });
 
   it("errors the body when the native stream call rejects after the head", async () => {

--- a/packages/ui/src/api/native-agent-stream.ts
+++ b/packages/ui/src/api/native-agent-stream.ts
@@ -102,6 +102,13 @@ export async function createNativeStreamingResponse(
     detached = true;
     for (const handle of handles) void handle.remove();
   };
+  const trackHandle = (handle: NativeStreamListenerHandle): void => {
+    if (detached) {
+      void handle.remove();
+      return;
+    }
+    handles.push(handle);
+  };
 
   const body = new ReadableStream<Uint8Array>({
     start(c) {
@@ -193,9 +200,9 @@ export async function createNativeStreamingResponse(
     void stream.completion.catch(failStream);
   }
 
-  handles.push(await agent.addListener("agentStreamResponse", onResponse));
-  handles.push(await agent.addListener("agentStreamChunk", onChunk));
-  handles.push(await agent.addListener("agentStreamComplete", onComplete));
+  trackHandle(await agent.addListener("agentStreamResponse", onResponse));
+  trackHandle(await agent.addListener("agentStreamChunk", onChunk));
+  trackHandle(await agent.addListener("agentStreamComplete", onComplete));
 
   return head;
 }


### PR DESCRIPTION
## Summary

Ports the one remaining valid cleanup from draft PR #12791: if the native stream completion rejects while listener registration is still resolving, remove those late listener handles immediately instead of leaving them attached.

## Evidence

- `git diff --check origin/develop...HEAD`
- `bunx biome check packages/ui/src/api/native-agent-stream.ts packages/ui/src/api/native-agent-stream.test.ts`
- `bunx vitest run packages/ui/src/api/native-agent-stream.test.ts --pool forks --testTimeout 10000` (1 file, 9 tests passed)

## PR evidence notes

- App visual audit: N/A. This changes `packages/ui/src/api/native-agent-stream.ts`, a native streaming API helper, and its unit test only; there is no rendered UI surface to capture.
- iOS device/simulator capture: N/A for this replacement slice. The stale draft already contains broader native-stream work, but this PR is limited to deterministic listener cleanup covered by the regression test above.

Supersedes the residual useful change from #12791.
