### PR TITLE
test(#12362): make the live WORKFLOW-action scenario actually pass (Cerebras trajectory)

### DIFF
--- a/.github/issue-evidence/12362-lifeops-live/live-workflow-action-executions.report.json
+++ b/.github/issue-evidence/12362-lifeops-live/live-workflow-action-executions.report.json
@@ -1,0 +1,445 @@
+{
+  "runId": "0ec8e98f-ae83-46d9-a69b-afe103688c47",
+  "startedAtIso": "2026-07-04T05:12:28.605Z",
+  "completedAtIso": "2026-07-04T05:12:38.956Z",
+  "providerName": "openai",
+  "scenarios": [
+    {
+      "id": "live-workflow-action-executions",
+      "title": "Live model routes a request to the WORKFLOW executions op",
+      "domain": "scenario-runner",
+      "tags": [
+        "live",
+        "workflow",
+        "action-routing",
+        "12362"
+      ],
+      "status": "passed",
+      "durationMs": 5008,
+      "turns": [
+        {
+          "name": "user asks for the workflow's recent runs",
+          "kind": "message",
+          "text": "Can you check my \"Morning digest\" workflow and tell me its most recent runs?",
+          "responseText": "The “Morning digest” workflow (ID `live-workflow-action-executions`) has one recent execution:\n\n- **Run ID:** 7b40b8f0‑7c04‑456e‑9225‑9d44dd79e4d3  \n- **Start time:** 2026‑07‑04 05:12:33.694 UTC  \n- **Finish time:** 2026‑07‑04 05:12:34.744 UTC  \n- **Status:** `success` (run completed)  \n- **Mode:** `manual`  \n- **Result details:** The workflow set a “digest” value to `sent` at 2026‑07‑04T05:12:34.691 UTC (triggered manually).",
+          "actionsCalled": [
+            {
+              "actionName": "WORKFLOW",
+              "parameters": {
+                "parameters": {
+                  "action": "executions",
+                  "workflowId": "live-workflow-action-executions",
+                  "limit": 5
+                },
+                "actionContext": {
+                  "previousResults": []
+                }
+              },
+              "result": {
+                "success": true,
+                "data": {
+                  "executions": [
+                    {
+                      "id": "7b40b8f0-7c04-456e-9225-9d44dd79e4d3",
+                      "data": {
+                        "resultData": {
+                          "engine": {
+                            "nodes": 2,
+                            "failed": 0,
+                            "levels": 2,
+                            "retries": 0,
+                            "skipped": 0,
+                            "started": 2,
+                            "finished": 2,
+                            "provider": "smithers",
+                            "maxConcurrency": 1
+                          },
+                          "runData": {
+                            "Set": [
+                              {
+                                "data": {
+                                  "main": [
+                                    [
+                                      {
+                                        "json": {
+                                          "digest": "sent",
+                                          "firedAt": "2026-07-04T05:12:34.691Z",
+                                          "trigger": "manual"
+                                        },
+                                        "pairedItem": {
+                                          "item": 0
+                                        }
+                                      }
+                                    ]
+                                  ]
+                                },
+                                "source": [
+                                  {
+                                    "previousNode": "Manual Trigger",
+                                    "previousNodeRun": 0,
+                                    "previousNodeOutput": 0
+                                  }
+                                ],
+                                "startTime": 1783141954719,
+                                "executionTime": 1
+                              }
+                            ],
+                            "Manual Trigger": [
+                              {
+                                "data": {
+                                  "main": [
+                                    [
+                                      {
+                                        "json": {
+                                          "firedAt": "2026-07-04T05:12:34.691Z",
+                                          "trigger": "manual"
+                                        }
+                                      }
+                                    ]
+                                  ]
+                                },
+                                "source": [],
+                                "startTime": 1783141954690,
+                                "executionTime": 1
+                              }
+                            ]
+                          },
+                          "lastNodeExecuted": "Set"
+                        }
+                      },
+                      "mode": "manual",
+                      "status": "success",
+                      "finished": true,
+                      "startedAt": "2026-07-04T05:12:33.694Z",
+                      "stoppedAt": "2026-07-04T05:12:34.744Z",
+                      "workflowId": "live-workflow-action-executions"
+                    }
+                  ]
+                },
+                "values": {
+                  "workflowId": "live-workflow-action-executions",
+                  "count": 1
+                },
+                "text": "Fetched 1 executions for workflow live-workflow-action-executions.",
+                "raw": {
+                  "success": true,
+                  "text": "Fetched 1 executions for workflow live-workflow-action-executions.",
+                  "values": {
+                    "workflowId": "live-workflow-action-executions",
+                    "count": 1
+                  },
+                  "data": {
+                    "executions": [
+                      {
+                        "id": "7b40b8f0-7c04-456e-9225-9d44dd79e4d3",
+                        "data": {
+                          "resultData": {
+                            "engine": {
+                              "nodes": 2,
+                              "failed": 0,
+                              "levels": 2,
+                              "retries": 0,
+                              "skipped": 0,
+                              "started": 2,
+                              "finished": 2,
+                              "provider": "smithers",
+                              "maxConcurrency": 1
+                            },
+                            "runData": {
+                              "Set": [
+                                {
+                                  "data": {
+                                    "main": [
+                                      [
+                                        {
+                                          "json": {
+                                            "digest": "sent",
+                                            "firedAt": "2026-07-04T05:12:34.691Z",
+                                            "trigger": "manual"
+                                          },
+                                          "pairedItem": {
+                                            "item": 0
+                                          }
+                                        }
+                                      ]
+                                    ]
+                                  },
+                                  "source": [
+                                    {
+                                      "previousNode": "Manual Trigger",
+                                      "previousNodeRun": 0,
+                                      "previousNodeOutput": 0
+                                    }
+                                  ],
+                                  "startTime": 1783141954719,
+                                  "executionTime": 1
+                                }
+                              ],
+                              "Manual Trigger": [
+                                {
+                                  "data": {
+                                    "main": [
+                                      [
+                                        {
+                                          "json": {
+                                            "firedAt": "2026-07-04T05:12:34.691Z",
+                                            "trigger": "manual"
+                                          }
+                                        }
+                                      ]
+                                    ]
+                                  },
+                                  "source": [],
+                                  "startTime": 1783141954690,
+                                  "executionTime": 1
+                                }
+                              ]
+                            },
+                            "lastNodeExecuted": "Set"
+                          }
+                        },
+                        "mode": "manual",
+                        "status": "success",
+                        "finished": true,
+                        "startedAt": "2026-07-04T05:12:33.694Z",
+                        "stoppedAt": "2026-07-04T05:12:34.744Z",
+                        "workflowId": "live-workflow-action-executions"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "durationMs": 3850,
+          "failedAssertions": []
+        }
+      ],
+      "finalChecks": [
+        {
+          "label": "actionCalled",
+          "type": "actionCalled",
+          "status": "passed",
+          "detail": "WORKFLOW succeeded 1x (1 total call(s))"
+        },
+        {
+          "label": "the seeded execution is retained and readable through the real service",
+          "type": "custom",
+          "status": "passed",
+          "detail": "predicate returned undefined"
+        }
+      ],
+      "actionsCalled": [
+        {
+          "actionName": "WORKFLOW",
+          "parameters": {
+            "parameters": {
+              "action": "executions",
+              "workflowId": "live-workflow-action-executions",
+              "limit": 5
+            },
+            "actionContext": {
+              "previousResults": []
+            }
+          },
+          "result": {
+            "success": true,
+            "data": {
+              "executions": [
+                {
+                  "id": "7b40b8f0-7c04-456e-9225-9d44dd79e4d3",
+                  "data": {
+                    "resultData": {
+                      "engine": {
+                        "nodes": 2,
+                        "failed": 0,
+                        "levels": 2,
+                        "retries": 0,
+                        "skipped": 0,
+                        "started": 2,
+                        "finished": 2,
+                        "provider": "smithers",
+                        "maxConcurrency": 1
+                      },
+                      "runData": {
+                        "Set": [
+                          {
+                            "data": {
+                              "main": [
+                                [
+                                  {
+                                    "json": {
+                                      "digest": "sent",
+                                      "firedAt": "2026-07-04T05:12:34.691Z",
+                                      "trigger": "manual"
+                                    },
+                                    "pairedItem": {
+                                      "item": 0
+                                    }
+                                  }
+                                ]
+                              ]
+                            },
+                            "source": [
+                              {
+                                "previousNode": "Manual Trigger",
+                                "previousNodeRun": 0,
+                                "previousNodeOutput": 0
+                              }
+                            ],
+                            "startTime": 1783141954719,
+                            "executionTime": 1
+                          }
+                        ],
+                        "Manual Trigger": [
+                          {
+                            "data": {
+                              "main": [
+                                [
+                                  {
+                                    "json": {
+                                      "firedAt": "2026-07-04T05:12:34.691Z",
+                                      "trigger": "manual"
+                                    }
+                                  }
+                                ]
+                              ]
+                            },
+                            "source": [],
+                            "startTime": 1783141954690,
+                            "executionTime": 1
+                          }
+                        ]
+                      },
+                      "lastNodeExecuted": "Set"
+                    }
+                  },
+                  "mode": "manual",
+                  "status": "success",
+                  "finished": true,
+                  "startedAt": "2026-07-04T05:12:33.694Z",
+                  "stoppedAt": "2026-07-04T05:12:34.744Z",
+                  "workflowId": "live-workflow-action-executions"
+                }
+              ]
+            },
+            "values": {
+              "workflowId": "live-workflow-action-executions",
+              "count": 1
+            },
+            "text": "Fetched 1 executions for workflow live-workflow-action-executions.",
+            "raw": {
+              "success": true,
+              "text": "Fetched 1 executions for workflow live-workflow-action-executions.",
+              "values": {
+                "workflowId": "live-workflow-action-executions",
+                "count": 1
+              },
+              "data": {
+                "executions": [
+                  {
+                    "id": "7b40b8f0-7c04-456e-9225-9d44dd79e4d3",
+                    "data": {
+                      "resultData": {
+                        "engine": {
+                          "nodes": 2,
+                          "failed": 0,
+                          "levels": 2,
+                          "retries": 0,
+                          "skipped": 0,
+                          "started": 2,
+                          "finished": 2,
+                          "provider": "smithers",
+                          "maxConcurrency": 1
+                        },
+                        "runData": {
+                          "Set": [
+                            {
+                              "data": {
+                                "main": [
+                                  [
+                                    {
+                                      "json": {
+                                        "digest": "sent",
+                                        "firedAt": "2026-07-04T05:12:34.691Z",
+                                        "trigger": "manual"
+                                      },
+                                      "pairedItem": {
+                                        "item": 0
+                                      }
+                                    }
+                                  ]
+                                ]
+                              },
+                              "source": [
+                                {
+                                  "previousNode": "Manual Trigger",
+                                  "previousNodeRun": 0,
+                                  "previousNodeOutput": 0
+                                }
+                              ],
+                              "startTime": 1783141954719,
+                              "executionTime": 1
+                            }
+                          ],
+                          "Manual Trigger": [
+                            {
+                              "data": {
+                                "main": [
+                                  [
+                                    {
+                                      "json": {
+                                        "firedAt": "2026-07-04T05:12:34.691Z",
+                                        "trigger": "manual"
+                                      }
+                                    }
+                                  ]
+                                ]
+                              },
+                              "source": [],
+                              "startTime": 1783141954690,
+                              "executionTime": 1
+                            }
+                          ]
+                        },
+                        "lastNodeExecuted": "Set"
+                      }
+                    },
+                    "mode": "manual",
+                    "status": "success",
+                    "finished": true,
+                    "startedAt": "2026-07-04T05:12:33.694Z",
+                    "stoppedAt": "2026-07-04T05:12:34.744Z",
+                    "workflowId": "live-workflow-action-executions"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "failedAssertions": [],
+      "providerName": "openai"
+    }
+  ],
+  "totals": {
+    "passed": 1,
+    "failed": 0,
+    "skipped": 0,
+    "flakyPassed": 0,
+    "costUsd": 0,
+    "finalChecksSkipped": 0
+  },
+  "totalCount": 1,
+  "passedCount": 1,
+  "failedCount": 0,
+  "skippedCount": 0,
+  "flakyPassedCount": 0,
+  "totalCostUsd": 0,
+  "artifactPaths": {
+    "runDir": "/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/vigilant-moser-707cf0/reports/scenarios/live-12362",
+    "matrixJson": "/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/vigilant-moser-707cf0/reports/scenarios/live-12362/matrix.json",
+    "viewerIndex": "/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/vigilant-moser-707cf0/reports/scenarios/live-12362/viewer/index.html",
+    "viewerData": "/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/vigilant-moser-707cf0/reports/scenarios/live-12362/viewer/data.js"
+  }
+}

--- a/.github/issue-evidence/12362-workflow-lifeops-integration.md
+++ b/.github/issue-evidence/12362-workflow-lifeops-integration.md
@@ -74,33 +74,51 @@ bun run --cwd packages/scenario-runner test src/corpus-assertion-guard.test.ts
   → 9 pass  (the new live-only scenario does not trip the pr-deterministic ratchet)
 ```
 
-## Live-model WORKFLOW-action trajectory
+## Live-model WORKFLOW-action trajectory — PASSED (Cerebras gpt-oss-120b)
 
-Authored: `packages/scenario-runner/test/scenarios/live-workflow-action-executions.scenario.ts`
-(`lane: "live-only"`). It seeds + executes a real embedded workflow, then a
-live user turn ("check my '<name>' workflow and tell me its most recent runs")
-must route to the `WORKFLOW` action's `executions` op; `finalChecks` assert
-`actionCalled WORKFLOW status:success` and that the seeded execution is readable
-through the real service. The file loads and lists cleanly
-(`eliza-scenarios list … --scenario live-workflow-action-executions`).
+`packages/scenario-runner/test/scenarios/live-workflow-action-executions.scenario.ts`
+(`lane: "live-only"`) seeds a real embedded workflow, tags it for the scenario
+owner (so the user-scoped `ACTIVE_WORKFLOWS` provider surfaces it), executes it
+once, then a live user turn ("check my 'Morning digest' workflow and tell me its
+most recent runs") must route to the `WORKFLOW` action's `executions` op.
 
-**Live run status in this dev environment: BLOCKED (environmental, not a code
-defect).** Booting the full scenario `AgentRuntime` dynamically imports the
-optional `@elizaos/plugin-vision`, whose `sharp-compat.ts` hard-imports `jimp`
-(`"jimp": "^1.6.0"`, declared in `plugins/plugin-vision/package.json`). `jimp`
-is not present in the shared workspace `node_modules` — a full-`bun install`
-gap that affects the parent checkout too (`install:light` / artifact-sync skips
-it), not something this branch introduced. CI with a full install runs it. The
-existing deterministic sibling
-(`deterministic-workflow-actions-routes.scenario.ts`) already proves the same
-WORKFLOW action + routes end to end under the LLM proxy, and cases (a)–(f)
-above prove the scheduling/dispatch path with real services and artifacts.
+Ran against a live model (Cerebras `gpt-oss-120b` via the OpenAI-compatible
+provider):
+
+```
+eliza-scenarios run test/scenarios --scenario live-workflow-action-executions
+| live-workflow-action-executions | passed | 5008ms |
+Totals: 1 passed, 0 failed
+```
+
+**Trajectory, reviewed by hand** (report:
+`.github/issue-evidence/12362-lifeops-live/live-workflow-action-executions.report.json`):
+
+- `actionsCalled: [("WORKFLOW", success=true)]` — the model genuinely selected
+  the WORKFLOW action (not forced by a fixture) and its `executions` op succeeded.
+- The agent's reply reported the **real** execution the seed produced:
+  > The "Morning digest" workflow (ID `live-workflow-action-executions`) has one
+  > recent execution: Run ID `7b40b8f0-7c04-…`, Start/Finish times …
+- `finalChecks`: `actionCalled WORKFLOW status:success` → passed; the `custom`
+  check (seeded execution still readable through the real `EmbeddedWorkflowService`)
+  → passed.
+
+(First runs failed for real, documented reasons — the workflow wasn't
+user-tag-scoped so the provider hid it, and the assertion read the wrong
+`ScenarioTurnExecution` field; both fixed. The passing report above is the
+final artifact.)
+
+Environment note: the full scenario `AgentRuntime` dynamically imports the
+optional `@elizaos/plugin-vision` (→ `jimp`). `jimp@1.6.1` is present in the
+`.bun` store but its top-level `node_modules/jimp` symlink was missing in this
+workspace; restoring the symlink (a linking gap, no lockfile change) let the
+runtime boot. CI's full install has it.
 
 ## Evidence rows
 
 | Evidence | Status |
 | --- | --- |
-| Real-LLM trajectory | Authored + schema-valid; live run blocked by the `jimp`/plugin-vision install gap (documented above); deterministic proxy sibling covers the WORKFLOW action path. |
+| Real-LLM trajectory | **Attached + reviewed** — live Cerebras `gpt-oss-120b` run, WORKFLOW action selected + succeeded, real execution reported; report JSON in `.github/issue-evidence/12362-lifeops-live/`. |
 | Backend logs | Attached (Smithers `workflow executed` + embedded-service registration). |
 | Domain artifacts | `embedded_executions`, `TriggerRunRecord`, ScheduledTask `fired` state-log — asserted in-test and listed above. |
 | Frontend logs / screenshots / video | N/A — no UI surface changed (test-only). |

--- a/packages/scenario-runner/test/scenarios/live-workflow-action-executions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-workflow-action-executions.scenario.ts
@@ -22,6 +22,7 @@ import {
   type EmbeddedWorkflowService,
 } from "../../../../plugins/plugin-workflow/src/services/index.ts";
 import type { WorkflowDefinition } from "../../../../plugins/plugin-workflow/src/types/index.ts";
+import { getUserTagName } from "../../../../plugins/plugin-workflow/src/utils/context.ts";
 
 const WORKFLOW_ID = "live-workflow-action-executions";
 const WORKFLOW_NAME = "Morning digest";
@@ -100,9 +101,25 @@ async function seedWorkflow(ctx: ScenarioContext): Promise<string | undefined> {
     runtime.routes.push({ ...route, __scenarioWorkflowRoute: true });
   }
 
+  // The ACTIVE_WORKFLOWS provider scopes by a per-user tag
+  // (`WorkflowService.listWorkflows(userId)` filters by `getUserTagName`), so a
+  // workflow created straight on the embedded engine is invisible to the model.
+  // Create it (keeps our stable id + a real execution), then tag it for the
+  // scenario's owner entity (the executor exposes it as ELIZA_ADMIN_ENTITY_ID)
+  // so the provider surfaces it and the live model can route to it.
+  const ownerId = runtime.getSetting?.("ELIZA_ADMIN_ENTITY_ID") as
+    | string
+    | undefined;
+  if (!ownerId) return "scenario owner entity id was not available";
+
   const embedded = await embeddedService(runtime);
   await embedded.deleteWorkflow(WORKFLOW_ID).catch(() => undefined);
   await embedded.createWorkflow(workflowDefinition);
+
+  const tagName = await getUserTagName(runtime, ownerId);
+  const userTag = await embedded.getOrCreateTag(tagName);
+  await embedded.updateWorkflowTags(WORKFLOW_ID, [userTag.id]);
+
   const execution = await embedded.executeWorkflow(WORKFLOW_ID);
   seededExecutionId = execution.id;
   return undefined;
@@ -112,15 +129,23 @@ async function seedWorkflow(ctx: ScenarioContext): Promise<string | undefined> {
 function expectWorkflowExecutionsAction(
   execution: ScenarioTurnExecution,
 ): string | undefined {
-  const action = execution.actions?.find((a) => a.name === "WORKFLOW");
-  if (!action) return "expected the WORKFLOW action to be selected";
-  if (action.result?.success !== true) {
-    return `expected WORKFLOW result.success=true, saw ${JSON.stringify(action.result)}`;
+  const action = execution.actionsCalled.find(
+    (candidate) => candidate.actionName === "WORKFLOW",
+  );
+  if (!action) {
+    return `expected the WORKFLOW action to be selected, saw ${
+      execution.actionsCalled.map((c) => c.actionName).join(", ") || "none"
+    }`;
   }
-  const executions = (action.result as { data?: { executions?: unknown[] } })
-    ?.data?.executions;
+  const result = action.result as
+    | { success?: boolean; data?: { executions?: unknown[] } }
+    | undefined;
+  if (result?.success !== true) {
+    return `expected WORKFLOW result.success=true, saw ${JSON.stringify(result)}`;
+  }
+  const executions = result.data?.executions;
   if (!Array.isArray(executions) || executions.length < 1) {
-    return `expected at least one execution in the action result, saw ${JSON.stringify(action.result)}`;
+    return `expected at least one execution in the action result, saw ${JSON.stringify(result)}`;
   }
   return undefined;
 }


### PR DESCRIPTION
## What & why

Follow-up to #12913 (merged). That PR added the `live-workflow-action-executions`
scenario, but in a form that would **fail** if run live: the seeded workflow was
not user-tag-scoped (so the user-scoped `ACTIVE_WORKFLOWS` provider hid it), and
the turn assertion read a non-existent `ScenarioTurnExecution.actions`/`name`
field. Live-only scenarios don't run on PR CI, so nothing was red — but the
scenario was not a real, passing trajectory.

This PR makes it pass for real against a live model:

- **User-scope the seed**: tag the seeded workflow for the scenario owner entity
  (`getUserTagName` → `getOrCreateTag` → `updateWorkflowTags`) so the provider
  surfaces it and the model can route to it. Keeps the stable id + a real execution.
- **Fix the assertion**: read `execution.actionsCalled` / `actionName` (the real
  `ScenarioTurnExecution` shape).

## Verification — live run (Cerebras `gpt-oss-120b`)

```
eliza-scenarios run test/scenarios --scenario live-workflow-action-executions
| live-workflow-action-executions | passed | 5008ms |
Totals: 1 passed, 0 failed
```

Trajectory reviewed by hand: `actionsCalled: [("WORKFLOW", success=true)]`; the
agent reported the **real** seeded execution ("The 'Morning digest' workflow …
has one recent execution: Run ID `7b40b8f0-…`"); both finalChecks passed. Report
+ write-up under `.github/issue-evidence/12362-lifeops-live/`.

`bun run --cwd packages/scenario-runner test src/corpus-assertion-guard.test.ts` → 9 pass.

Relates to #12362, #12177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)