### PR TITLE
fix(#12259): route core tests through orchestrator

### DIFF
--- a/.github/issue-evidence/12259-test-core-orchestrator.md
+++ b/.github/issue-evidence/12259-test-core-orchestrator.md
@@ -1,0 +1,29 @@
+# Issue #12259 - test:core uses the test orchestrator
+
+## Change
+
+- Removed the root `turbo.json` `test` task so root test lanes are not routed through a generic Turbo package graph.
+- Rewired root `test:core` from `run-turbo.mjs run test --filter=./packages/core` to `run-all-tests.mjs --only=test --no-cloud --filter='@elizaos/core \\(packages/core\\)#test'`.
+
+## Verification
+
+Run on 2026-07-04:
+
+- `node -e "const fs=require('fs'); const t=JSON.parse(fs.readFileSync('turbo.json','utf8')).tasks; if ('test' in t) process.exit(1);"`
+- `node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('package.json','utf8')); if (!pkg.scripts['test:core'].includes('run-all-tests.mjs') || pkg.scripts['test:core'].includes('run-turbo.mjs')) process.exit(1);"`
+- `node packages/scripts/run-all-tests.mjs --only=test --no-cloud --filter='@elizaos/core \\(packages/core\\)#test' --plan=json`
+- `git diff --check origin/develop..HEAD`
+
+The plan output selected exactly one task:
+
+- `@elizaos/core (packages/core)#test`
+
+Attempted full runtime verification:
+
+- `bun run test:core`
+
+That command reached `@elizaos/core (packages/core)#test`, then failed because the auxiliary worktree did not have a local install and the temporary shared `node_modules` symlink did not contain `vitest/vitest.mjs`. A fresh monorepo install was not attempted because the machine had about 7.8 GiB free at the time of verification.
+
+## Evidence notes
+
+Screenshots and recordings are N/A: this is a root CLI/Turbo configuration change with no user interface.

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "test:cache-stability": "node packages/scripts/run-vitest.mjs run packages/core/src/runtime/__tests__/cache-key-stability.test.ts",
     "test:plugins": "bun run build:core && TEST_PACKAGE_FILTER='\\(plugins/' TEST_SCRIPT_FILTER='^test$' node packages/scripts/run-all-tests.mjs --only=test --no-cloud --concurrency=3",
     "test:client": "bun run build:core && bun run check:loadperf-bundle && TEST_PACKAGE_FILTER='\\((packages/app|packages/ui|plugins/plugin-personal-assistant|plugins/plugin-training)\\)' TEST_SCRIPT_FILTER='^test$' node packages/scripts/run-all-tests.mjs --no-cloud --concurrency=3",
-    "test:core": "node packages/scripts/with-test-runtime.mjs node packages/scripts/run-turbo.mjs run test --filter=./packages/core",
+    "test:core": "node packages/scripts/with-test-runtime.mjs node packages/scripts/run-all-tests.mjs --only=test --no-cloud --filter='@elizaos/core \\(packages/core\\)#test'",
     "test:server": "bun run build:core && TEST_PACKAGE_FILTER='\\((packages/agent|packages/app-core|packages/shared|packages/core|packages/tui|packages/vault|packages/elizaos|packages/skills|packages/scenario-runner|packages/test)\\)' TEST_SCRIPT_FILTER='^test$' node packages/scripts/run-all-tests.mjs --no-cloud --concurrency=3",
     "test:remote-capabilities": "bun run --cwd packages/agent test:remote-capabilities",
     "capability-router:fixture-server": "bun packages/scripts/capability-router-fixture-server.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -568,19 +568,6 @@
       "cache": false,
       "persistent": true
     },
-    "test": {
-      "dependsOn": ["^build"],
-      "outputs": ["coverage/**"],
-      "inputs": [
-        "src/**/*.ts",
-        "src/**/*.js",
-        "__tests__/**/*",
-        "*.test.*",
-        "package.json",
-        "tests/**/*"
-      ],
-      "cache": false
-    },
     "migrate": {
       "dependsOn": ["@elizaos/core#build"],
       "cache": false


### PR DESCRIPTION
## Summary
- remove the generic root Turbo `test` task
- route root `test:core` through `run-all-tests.mjs` with an exact core package filter
- add issue evidence for the CLI/Turbo routing change

## Verification
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('package.json','utf8')); JSON.parse(fs.readFileSync('turbo.json','utf8')); const t=JSON.parse(fs.readFileSync('turbo.json','utf8')).tasks; if ('test' in t) process.exit(1); const pkg=JSON.parse(fs.readFileSync('package.json','utf8')); if (!pkg.scripts['test:core'].includes('run-all-tests.mjs') || pkg.scripts['test:core'].includes('run-turbo.mjs')) process.exit(1); console.log('config assertions passed');"`
- `node packages/scripts/run-all-tests.mjs --only=test --no-cloud --filter='@elizaos/core \(packages/core\)#test' --plan=json`
- `git diff --check`
- `git diff --check origin/develop..HEAD`

## Evidence
- `.github/issue-evidence/12259-test-core-orchestrator.md`
- Screenshots/recordings: N/A, root CLI/Turbo config only.

Full `bun run test:core` was attempted and reached `@elizaos/core (packages/core)#test`, then failed because this auxiliary worktree had no local install and the shared temporary `node_modules` symlink did not contain `vitest/vitest.mjs`; a fresh monorepo install was not attempted with about 7.8 GiB free.