### PR TITLE
docs(#12241): add small example directory headers

### DIFF
--- a/packages/examples/autonomous/autonomous.test.ts
+++ b/packages/examples/autonomous/autonomous.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Deterministic coverage for the autonomous example decision parser, command
+ * allowlist, and prompt scaffolding.
+ */
 import { expect, test } from "bun:test";
 import { decisionPrompt, isCommandAllowed, parseDecision } from "./autonomous";
 

--- a/packages/examples/autonomous/autonomous.ts
+++ b/packages/examples/autonomous/autonomous.ts
@@ -1,3 +1,7 @@
+/**
+ * Runnable autonomous-agent example that lets an Eliza agent decide between
+ * bounded shell actions, sleeps, and stopping while recording each decision.
+ */
 import fs from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";

--- a/packages/examples/chat/chat.test.ts
+++ b/packages/examples/chat/chat.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Deterministic coverage for chat example provider priority and missing-key
+ * behavior before any live model plugin is imported.
+ */
 import { afterEach, expect, test } from "bun:test";
 import { detectLLMPlugin, hasValidApiKey, LLM_PROVIDERS } from "./chat";
 

--- a/packages/examples/chat/chat.ts
+++ b/packages/examples/chat/chat.ts
@@ -1,3 +1,7 @@
+/**
+ * Command-line chat example that boots an Eliza runtime with the first
+ * configured live model provider and routes stdin messages through it.
+ */
 import "dotenv/config";
 import * as readline from "node:readline";
 import {

--- a/packages/examples/lp-manager/src/character.ts
+++ b/packages/examples/lp-manager/src/character.ts
@@ -1,3 +1,6 @@
+/**
+ * Character definition for the liquidity-position manager example agent.
+ */
 import { createCharacter } from "@elizaos/core";
 
 export const character = createCharacter({

--- a/packages/examples/lp-manager/src/services/LpMonitoringService.ts
+++ b/packages/examples/lp-manager/src/services/LpMonitoringService.ts
@@ -1,8 +1,8 @@
+/**
+ * Monitoring service for the liquidity-position manager example, coordinating
+ * wallet, DEX, profile, and yield services around rebalance decisions.
+ */
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
-
-// =============================================================================
-// Type Definitions (mirrors @elizaos/plugin-wallet's LP types)
-// =============================================================================
 
 interface TokenBalance {
   address: string;
@@ -61,7 +61,6 @@ interface TransactionResult {
   tokensReceived?: TokenBalance[];
 }
 
-// Service interfaces
 interface DexInteractionService {
   getAllUserLpPositions(userId: string): Promise<LpPositionDetails[]>;
   addLiquidity(config: {
@@ -110,10 +109,6 @@ interface VaultService {
   getBalances(publicKey: string): Promise<TokenBalance[]>;
   getVaultKeypair(userId: string, encryptedSecretKey: string): Promise<unknown>;
 }
-
-// =============================================================================
-// Monitoring Types
-// =============================================================================
 
 interface MonitoredPosition {
   position: LpPositionDetails;
@@ -175,10 +170,6 @@ export interface LpMonitoringStatus {
   config: LpMonitoringConfig;
 }
 
-// =============================================================================
-// Constants
-// =============================================================================
-
 const SERVICE_NAMES = {
   DEX: "dex-interaction",
   PROFILE: "UserLpProfileService",
@@ -198,10 +189,6 @@ const DEFAULTS = {
   POSITION_AGE_MS: 3600000,
   MAX_RECENT_REBALANCES: 20,
 } as const;
-
-// =============================================================================
-// LpMonitoringService
-// =============================================================================
 
 export class LpMonitoringService extends Service {
   public static readonly serviceType = "LpMonitoringService";


### PR DESCRIPTION
## Summary
- Adds required top-of-file prose headers to the autonomous, chat, and lp-manager example source/test files.
- Removes separator-only section comments from the LP monitoring example service while preserving the code token stream.

Relates to #12241.

## Evidence
- `git fetch origin +refs/heads/develop:refs/remotes/origin/develop && git rebase origin/develop` before final verification: passed; branch rebased onto `fe9d42990a`.
- `bun run check:comment-only`: passed; 6 source files changed and every code token is identical to `origin/develop`.
- `bunx @biomejs/biome check packages/examples/autonomous/autonomous.ts packages/examples/autonomous/autonomous.test.ts packages/examples/chat/chat.ts packages/examples/chat/chat.test.ts packages/examples/lp-manager/src/character.ts packages/examples/lp-manager/src/services/LpMonitoringService.ts`: passed after final rebase.
- `bun --conditions=eliza-source test packages/examples/autonomous/autonomous.test.ts packages/examples/chat/chat.test.ts`: passed after final rebase; 7 tests, 22 assertions.
- `bun run --cwd packages/examples/lp-manager test`: passed; package has no test files.
- `git diff --check`: passed after final rebase.
- First-header audit over all 6 touched files: passed.

## Root verify
- `bun run verify`: failed outside this slice. The run passed `check:agents-claude`, `audit:type-safety-ratchet`, and `audit:error-policy-ratchet`, then failed during the repo-wide turbo lint/typecheck lane with unrelated formatting errors in:
  - `packages/shared/src/voice/aec/echo-alignment.ts`
  - `plugins/plugin-xr/src/services/vision-pipeline.ts`
- The command exited with code 139 after those unrelated lint failures. The worktree remained clean afterward.

## Evidence matrix
- Real LLM trajectory: N/A - comment-only source headers; no agent behavior, prompts, providers, or model routing changed.
- Backend logs: N/A - no runtime/API/service behavior changed.
- Frontend logs/screenshots/video: N/A - no UI changed.
- Domain artifacts: N/A - no generated runtime artifacts changed.