### PR TITLE
docs(#12808): clean computeruse residual comments

### DIFF
--- a/plugins/plugin-computeruse/build.ts
+++ b/plugins/plugin-computeruse/build.ts
@@ -6,8 +6,8 @@
  * Three Node/ESM entrypoints are bundled with linked sourcemaps and flat
  * `[name].[ext]` naming (index + register-routes at the dist root, the mobile
  * OCR provider under dist/mobile). Declarations are emitted declaration-only
- * from tsconfig.build.json. The emitted `dist/` is byte-identical to the
- * previous hand-rolled build.
+ * from tsconfig.build.json, preserving the package's established `dist/`
+ * layout for downstream imports.
  */
 import { buildPlugin } from "../plugin-build";
 

--- a/plugins/plugin-computeruse/src/__tests__/security-hardening.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/security-hardening.test.ts
@@ -1,9 +1,13 @@
+/**
+ * Security hardening tests cover file-path credential blocklists and child
+ * process environment sanitization across POSIX and Windows path semantics.
+ */
 import os from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ComputerUseApprovalManager } from "../approval-manager.js";
 import { sanitizeChildEnv, validateFilePath } from "../platform/security.js";
 
-// Captured at module load, BEFORE any test fakes `process.platform`. POSIX
+// Captured at module load before any test fakes `process.platform`. POSIX
 // absolute paths (`/etc/shadow`, `/home/<user>/…`) are only meaningful when
 // `node:path` resolves with POSIX semantics; on a Windows host `path.win32`
 // rewrites `/etc/shadow` → `C:\etc\shadow`, so the POSIX assertions cannot be

--- a/plugins/plugin-computeruse/src/approval-manager.guard.test.ts
+++ b/plugins/plugin-computeruse/src/approval-manager.guard.test.ts
@@ -1,9 +1,10 @@
+/**
+ * Approval-mode guard tests validate untrusted strings received from disk or
+ * the route layer before they can affect the computer-use safety gate.
+ */
 import { describe, expect, it } from "vitest";
 import { isApprovalMode } from "./approval-manager.js";
 
-// #9105 computer-use — the approval mode persisted to disk / received over the
-// API is an untrusted string; the guard is what keeps an invalid mode from
-// silently disabling the safety gate. Pin every accepted + rejected value.
 describe("isApprovalMode", () => {
   it("accepts exactly the four real approval modes", () => {
     for (const m of ["full_control", "smart_approve", "approve_all", "off"]) {

--- a/plugins/plugin-computeruse/src/platform/coords.test.ts
+++ b/plugins/plugin-computeruse/src/platform/coords.test.ts
@@ -1,12 +1,12 @@
+/**
+ * Multi-monitor coordinate translation tests cover local display pixels,
+ * OS-global pixels, macOS backing-store scaling, and display hit-testing.
+ *
+ * The input driver targets global coordinates, so this math is the boundary
+ * between model/display-local actions and platform-level mouse dispatch.
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DisplayInfo } from "./displays.js";
-
-/**
- * Multi-monitor coordinate translation (#9105/#9170). Each display has a local
- * top-left origin; the driver needs OS-global pixels. The math must offset by
- * the display origin, divide backing-store coords by scaleFactor on macOS only,
- * and map a global point back to the display that contains it.
- */
 
 const DISPLAYS: DisplayInfo[] = [
   {

--- a/plugins/plugin-computeruse/src/platform/normalized-coords.ts
+++ b/plugins/plugin-computeruse/src/platform/normalized-coords.ts
@@ -1,18 +1,16 @@
-// Normalized 0–1000 coordinate space for Computer Use × Vision (issue #9105, M2).
-//
-// Every grounder/OCR backend reports element positions in its own device-pixel
-// space, which is DPI- and resolution-dependent: the same on-screen button is
-// (1280, 720) on a 2560×1440 panel and (640, 360) on a 1280×720 one. The GET_SCREEN
-// envelope needs ONE canonical, DPI-stable coordinate space so a model's chosen
-// target maps back to a click identically regardless of capture resolution.
-//
-// Following the Unlimited-OCR prior art cited in the EPIC, that canonical space is
-// a 0–1000 normalized grid: positions are a fraction of the display, quantized to
-// 1000 buckets per axis. Convert to normalized at the grounding boundary, reason
-// in normalized space, then `fromNormalized()` back to logical pixels (which
-// `coords.ts:localToGlobal` then maps to the input driver's global space).
-//
-// Pure + deterministic; no DOM, no platform calls.
+/**
+ * Normalized coordinate conversion for Computer Use and Vision grounding.
+ *
+ * Grounders and OCR backends report positions in device-pixel spaces that vary
+ * by DPI and capture resolution. The GET_SCREEN envelope uses one 0-1000
+ * display-relative grid so a model's chosen target maps back to a click
+ * consistently across screen sizes.
+ *
+ * Conversion happens at the grounding boundary: positions enter normalized
+ * space for reasoning, then return to logical pixels before `coords.ts` maps
+ * them into the input driver's global coordinate space. The module is pure and
+ * deterministic, with no DOM or platform calls.
+ */
 
 import type { ScreenRegion } from "../types.js";
 

--- a/plugins/plugin-computeruse/src/platform/screenshot-quality.test.ts
+++ b/plugins/plugin-computeruse/src/platform/screenshot-quality.test.ts
@@ -1,17 +1,15 @@
+/**
+ * Screenshot quality tests pin the pure classifier that guards real-driver
+ * screenshot evidence lanes from empty or visually blank PNG captures.
+ *
+ * Synthetic metrics lock the empty floor, single-color rule, and dominant-color
+ * threshold without depending on live display capture.
+ */
 import { describe, expect, it } from "vitest";
 import {
   type ScreenshotQuality,
   screenshotQualityIssues,
 } from "./screenshot-quality";
-
-/**
- * Screenshot blank/one-color detection (#9105). `screenshotQualityIssues` is the
- * pure classifier that turns decoded PNG metrics into human-readable quality
- * problems — it gates the real-driver screenshot lanes, but the classifier
- * itself (the empty floor, the one-color rule, and the `>0.995` "effectively
- * one color" boundary) was only ever exercised through live PNG decoding. These
- * pin the thresholds against synthetic metrics.
- */
 
 const quality = (o: Partial<ScreenshotQuality>): ScreenshotQuality => ({
   width: 100,

--- a/plugins/plugin-computeruse/src/routes/sandbox-routes.ts
+++ b/plugins/plugin-computeruse/src/routes/sandbox-routes.ts
@@ -1361,7 +1361,7 @@ function getPlatformInfo(): Record<string, string | boolean> {
     arch: require("node:os").arch(),
     dockerInstalled,
     dockerRunning,
-    // Legacy compat: dockerAvailable = running (old clients check this)
+    // Compatibility field: dockerAvailable mirrors the running daemon state.
     dockerAvailable: dockerRunning,
     appleContainerAvailable,
     wsl2: os === "win32" ? isWsl2Available() : false,

--- a/plugins/plugin-computeruse/src/scene/a11y-provider.parsers.test.ts
+++ b/plugins/plugin-computeruse/src/scene/a11y-provider.parsers.test.ts
@@ -1,9 +1,12 @@
+/**
+ * Linux accessibility parser tests cover Hyprland and Sway window enumeration
+ * for the scene grounding tier.
+ *
+ * Both parsers are pure adapters over `hyprctl clients -j` and
+ * `swaymsg -t get_tree`, so fixture assertions can run on any CI host.
+ */
 import { describe, expect, it } from "vitest";
 import { parseHyprlandClients, parseSwayTree } from "./a11y-provider.js";
-
-// #9105 — Linux window enumeration for the a11y grounding tier reads `hyprctl
-// clients -j` (Hyprland) and `swaymsg -t get_tree` (Sway). Both parsers are pure
-// and Linux-specific, so lock them here (the right host to test them on).
 
 describe("parseHyprlandClients", () => {
   it("maps each client to a window node with display-absolute bbox", () => {

--- a/plugins/plugin-computeruse/src/scene/serialize.test.ts
+++ b/plugins/plugin-computeruse/src/scene/serialize.test.ts
@@ -1,15 +1,14 @@
+/**
+ * Scene serialization tests pin the token-budgeted JSON fence that the scene
+ * provider injects into prompts.
+ *
+ * The serializer caps per-display OCR, prefers the focused-display AX subtree,
+ * and clips background apps so high-resolution multi-monitor sessions stay
+ * prompt-sized while preserving actionable structure.
+ */
 import { describe, expect, it } from "vitest";
 import type { Scene, SceneApp, SceneOcrBox } from "./scene-types.js";
 import { serializeSceneForPrompt } from "./serialize.js";
-
-/**
- * Token-budget Scene serialization (#9105 M3 / WS6). `serializeSceneForPrompt`
- * caps the per-display OCR list, prefers the focused-display AX subtree, and
- * clips background apps so a 4k multi-monitor session doesn't blow the prompt
- * to thousands of tokens. `scene-provider.test.ts` only asserts a few
- * substrings of the output; none of the cap/sort/trim branches were pinned.
- * This does that, parsing the fenced JSON to assert structure.
- */
 
 const baseScene = (o: Partial<Scene> = {}): Scene => ({
   timestamp: 1000,

--- a/plugins/plugin-computeruse/src/services/desktop-control.detect.test.ts
+++ b/plugins/plugin-computeruse/src/services/desktop-control.detect.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Capability detection tests pin the desktop-control report consumed before
+ * computer-use capture or input dispatch attempts real platform work.
+ *
+ * The detector must degrade gracefully on headless CI hosts while staying
+ * internally consistent across Linux, macOS, and Windows capability fields.
+ */
 import { describe, expect, it } from "vitest";
 import {
   type DesktopControlCapability,
@@ -5,10 +12,6 @@ import {
   isHeadfulGuiAvailable,
 } from "./desktop-control.js";
 
-// #9105 — the Linux/macOS/Windows capability detector is what the CUA loop reads
-// before attempting capture/control. It must degrade gracefully (never throw)
-// and stay internally consistent across headful + headless hosts, so this test
-// is safe in CI either way.
 const isCap = (c: DesktopControlCapability) => {
   expect(typeof c.available).toBe("boolean");
   expect(typeof c.tool).toBe("string");


### PR DESCRIPTION
## Summary
- Add/repair top prose headers for the remaining `plugins/plugin-computeruse` files found by the residual audit.
- Move durable test rationale before imports and rewrite churn/history comments into present-tense behavior notes.
- Keep the patch comment-only; code tokens are unchanged.

Fixes #12808

## Validation
- `bun run check:comment-only`
- `bun run --cwd plugins/plugin-computeruse typecheck`
- `bunx @biomejs/biome check plugins/plugin-computeruse/build.ts plugins/plugin-computeruse/src/__tests__/security-hardening.test.ts plugins/plugin-computeruse/src/approval-manager.guard.test.ts plugins/plugin-computeruse/src/platform/coords.test.ts plugins/plugin-computeruse/src/platform/normalized-coords.ts plugins/plugin-computeruse/src/platform/screenshot-quality.test.ts plugins/plugin-computeruse/src/routes/sandbox-routes.ts plugins/plugin-computeruse/src/scene/a11y-provider.parsers.test.ts plugins/plugin-computeruse/src/scene/serialize.test.ts plugins/plugin-computeruse/src/services/desktop-control.detect.test.ts`
- `git diff --check origin/develop -- plugins/plugin-computeruse`

## Notes
- This local checkout is sparse (`git` reports 11% of tracked files present), so full package runtime tests are blocked by missing unrelated workspace paths.
- `bun run --cwd plugins/plugin-computeruse test` currently fails outside this patch because `src/__tests__/routes-e2e.test.ts` imports missing `packages/agent/src/api/runtime-plugin-routes.ts`, and `src/__tests__/android-bridge.test.ts` expects absent Android manifest/shortcut files under `packages/app-core/platforms/android/...`.
- `bun run --cwd plugins/plugin-computeruse build` currently fails before compiling this package because `packages/scripts/rm-path-recursive.mjs` is absent in the sparse checkout.
- `bun run --cwd plugins/plugin-computeruse lint` resolves to the Android/Java `lint` binary in this environment and exits with usage code 2; Biome was run directly on changed files instead.
