### PR TITLE
fix(#12259): add examples benchmark list mode

### DIFF
--- a/.github/issue-evidence/12259-examples-benchmarks-list-mode.md
+++ b/.github/issue-evidence/12259-examples-benchmarks-list-mode.md
@@ -1,0 +1,33 @@
+# Issue #12259 - examples/benchmarks side-runner list mode
+
+## Change
+
+- Added `--list` and `--list=json` to `packages/scripts/run-examples-benchmarks.mjs`.
+- Added `packages/scripts/run-examples-benchmarks.self-test.mjs` to prove list mode honors workspace membership, examples/benchmarks scope, workspace negations, and target script presence without running package scripts.
+
+## Verification
+
+Run on 2026-07-04:
+
+- `node --check packages/scripts/run-examples-benchmarks.mjs`
+- `node --check packages/scripts/run-examples-benchmarks.self-test.mjs`
+- `node packages/scripts/run-examples-benchmarks.self-test.mjs`
+- `node packages/scripts/run-examples-benchmarks.mjs lint --list=json`
+- `node packages/scripts/run-examples-benchmarks.mjs typecheck --list=json`
+
+Real repo list counts:
+
+- `lint`: 47 examples/benchmarks packages
+- `typecheck`: 53 examples/benchmarks packages
+
+Dry-run comparison using `node packages/scripts/run-turbo.mjs ... --dry=json` with a temporary `node_modules` symlink:
+
+- `lint`: side-runner 47, Turbo 254, missing from Turbo 0
+- `typecheck`: side-runner 53, Turbo 253, missing from Turbo 1
+- Missing typecheck package: `@elizaos/example-code`
+
+That missing typecheck package is caused by the current root `typecheck` body excluding `@elizaos/example-code` from the Turbo run while the side-runner still includes it. The follow-up side-runner deletion must handle this package before removing the side-runner.
+
+## Evidence notes
+
+Screenshots and recordings are N/A: this is a root CLI/script introspection change with no user interface.

--- a/packages/scripts/run-examples-benchmarks.mjs
+++ b/packages/scripts/run-examples-benchmarks.mjs
@@ -7,7 +7,18 @@ import { listPackages } from "./lib/workspaces.mjs";
 const scriptName = process.argv[2];
 if (!scriptName) {
   console.error(
-    "Usage: node packages/scripts/run-examples-benchmarks.mjs <script>",
+    "Usage: node packages/scripts/run-examples-benchmarks.mjs <script> [--list[=text|json]]",
+  );
+  process.exit(1);
+}
+const listArg = process.argv
+  .slice(3)
+  .find((arg) => arg === "--list" || arg.startsWith("--list="));
+const listFormat = listArg?.includes("=") ? listArg.split("=", 2)[1] : "text";
+
+if (listArg && !["text", "json"].includes(listFormat)) {
+  console.error(
+    `[${scriptName}] unsupported --list format "${listFormat}" (expected text or json)`,
   );
   process.exit(1);
 }
@@ -34,6 +45,27 @@ const packages = listPackages({ repoRoot: root })
     scripts: pkg.packageJson.scripts ?? {},
   }))
   .filter((pkg) => Object.hasOwn(pkg.scripts, scriptName));
+
+if (listArg) {
+  if (listFormat === "json") {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          script: scriptName,
+          roots,
+          packages: packages.map(({ name, dir }) => ({ name, dir })),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  } else {
+    for (const pkg of packages) {
+      console.log(`${pkg.name}\t${pkg.dir}`);
+    }
+  }
+  process.exit(0);
+}
 
 let failed = false;
 for (const pkg of packages) {

--- a/packages/scripts/run-examples-benchmarks.self-test.mjs
+++ b/packages/scripts/run-examples-benchmarks.self-test.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "run-examples-benchmarks.mjs",
+);
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(`${filePath}`, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+const tempRoot = fs.mkdtempSync(
+  path.join(os.tmpdir(), "run-examples-benchmarks-"),
+);
+
+try {
+  writeJson(path.join(tempRoot, "package.json"), {
+    name: "fixture-root",
+    private: true,
+    workspaces: [
+      "packages/examples/*",
+      "packages/benchmarks/*",
+      "packages/other/*",
+      "!packages/examples/excluded",
+    ],
+  });
+  writeJson(path.join(tempRoot, "packages/examples/with-lint/package.json"), {
+    name: "with-lint",
+    scripts: { lint: "echo lint" },
+  });
+  writeJson(path.join(tempRoot, "packages/examples/no-lint/package.json"), {
+    name: "no-lint",
+    scripts: { typecheck: "echo typecheck" },
+  });
+  writeJson(path.join(tempRoot, "packages/examples/excluded/package.json"), {
+    name: "excluded",
+    scripts: { lint: "echo lint" },
+  });
+  writeJson(path.join(tempRoot, "packages/benchmarks/bench/package.json"), {
+    name: "bench",
+    scripts: { lint: "echo lint" },
+  });
+  writeJson(path.join(tempRoot, "packages/other/not-in-scope/package.json"), {
+    name: "not-in-scope",
+    scripts: { lint: "echo lint" },
+  });
+
+  const result = spawnSync(
+    process.execPath,
+    [scriptPath, "lint", "--list=json"],
+    {
+      cwd: tempRoot,
+      encoding: "utf8",
+    },
+  );
+
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr);
+    process.exit(result.status ?? 1);
+  }
+
+  const listed = JSON.parse(result.stdout);
+  const dirs = listed.packages.map((pkg) => pkg.dir).sort();
+  const expected = [
+    "packages/benchmarks/bench",
+    "packages/examples/with-lint",
+  ];
+  if (JSON.stringify(dirs) !== JSON.stringify(expected)) {
+    console.error(
+      `unexpected package list:\nexpected ${JSON.stringify(
+        expected,
+      )}\nactual   ${JSON.stringify(dirs)}`,
+    );
+    process.exit(1);
+  }
+
+  const textResult = spawnSync(process.execPath, [scriptPath, "lint", "--list"], {
+    cwd: tempRoot,
+    encoding: "utf8",
+  });
+  if (textResult.status !== 0) {
+    process.stderr.write(textResult.stderr);
+    process.exit(textResult.status ?? 1);
+  }
+  if (!textResult.stdout.includes("with-lint\tpackages/examples/with-lint")) {
+    console.error("text list output did not include the expected package");
+    process.exit(1);
+  }
+
+  console.log("run-examples-benchmarks self-test passed");
+} finally {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- add `--list` / `--list=json` to `packages/scripts/run-examples-benchmarks.mjs`
- add a self-test covering workspace membership, scope roots, negations, and target script filtering
- capture package-set evidence for the follow-up side-runner deletion

## Verification
- `node --check packages/scripts/run-examples-benchmarks.mjs`
- `node --check packages/scripts/run-examples-benchmarks.self-test.mjs`
- `node packages/scripts/run-examples-benchmarks.self-test.mjs`
- `node packages/scripts/run-examples-benchmarks.mjs lint --list=json`
- `node packages/scripts/run-examples-benchmarks.mjs typecheck --list=json`
- `node packages/scripts/run-examples-benchmarks.mjs lint --list=xml` exits non-zero with the expected unsupported-format error
- `git diff --check origin/develop..HEAD`

## Evidence
- `.github/issue-evidence/12259-examples-benchmarks-list-mode.md`
- Screenshots/recordings: N/A, CLI/script introspection only.

## Follow-up finding
Using Turbo dry runs with a temporary `node_modules` symlink:
- `lint`: side-runner 47, Turbo 254, missing 0
- `typecheck`: side-runner 53, Turbo 253, missing 1 (`@elizaos/example-code`)

The follow-up deletion PR needs to handle `@elizaos/example-code`, because root `typecheck` currently excludes it from the Turbo run while the side-runner still includes it.