### PR TITLE
fix(verify): close resolver gaps after baseline sweep

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3290,6 +3290,7 @@
       "version": "2.0.3-beta.7",
       "dependencies": {
         "@elizaos/core": "workspace:*",
+        "@elizaos/shared": "workspace:*",
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.2",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -150,6 +150,36 @@
       "default": "./dist/services/app-session-gate.js",
       "types": "./src/services/app-session-gate.d.ts"
     },
+    "./services/tee-evidence": {
+      "types": "./src/services/tee-evidence.ts",
+      "eliza-source": {
+        "types": "./src/services/tee-evidence.ts",
+        "import": "./src/services/tee-evidence.ts",
+        "default": "./src/services/tee-evidence.ts"
+      },
+      "bun": {
+        "types": "./src/services/tee-evidence.ts",
+        "import": "./src/services/tee-evidence.ts",
+        "default": "./src/services/tee-evidence.ts"
+      },
+      "import": "./dist/services/tee-evidence.js",
+      "default": "./dist/services/tee-evidence.js"
+    },
+    "./services/tee-evidence-provider": {
+      "types": "./src/services/tee-evidence-provider.ts",
+      "eliza-source": {
+        "types": "./src/services/tee-evidence-provider.ts",
+        "import": "./src/services/tee-evidence-provider.ts",
+        "default": "./src/services/tee-evidence-provider.ts"
+      },
+      "bun": {
+        "types": "./src/services/tee-evidence-provider.ts",
+        "import": "./src/services/tee-evidence-provider.ts",
+        "default": "./src/services/tee-evidence-provider.ts"
+      },
+      "import": "./dist/services/tee-evidence-provider.js",
+      "default": "./dist/services/tee-evidence-provider.js"
+    },
     "./services/permissions/probers/index": {
       "types": "./src/services/permissions/probers/index.d.ts",
       "eliza-source": {

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -57,10 +57,10 @@ import { remindersPlugin } from "@elizaos/plugin-reminders";
 import { remoteDesktopPlugin } from "@elizaos/plugin-remote-desktop";
 import { XDmAdapter } from "@elizaos/plugin-x/lifeops-message-adapter";
 import type {
-	IPermissionsRegistry,
-	PermissionState,
-	Platform,
-	Prober,
+  IPermissionsRegistry,
+  PermissionState,
+  Platform,
+  Prober,
 } from "@elizaos/shared";
 import { blockAction } from "./actions/block.js";
 import { briefAction } from "./actions/brief.js";
@@ -253,7 +253,8 @@ function toSharedPermissionState(state: {
 
 const websiteBlockingPermissionProber: Prober = {
   id: "website-blocking",
-  check: async () => toSharedPermissionState(await getSelfControlPermissionState()),
+  check: async () =>
+    toSharedPermissionState(await getSelfControlPermissionState()),
   request: async () =>
     toSharedPermissionState(await requestSelfControlPermission()),
   openSettings: openSelfControlPermissionLocation,


### PR DESCRIPTION
## Summary
- add explicit @elizaos/agent tee evidence service subpath exports used by plugin-tee confidential entrypoints
- sync bun.lock with plugin-commands' direct @elizaos/shared dependency
- keep the personal-assistant website-blocking prober hunk formatted after #12919

## Validation
- bun run --cwd plugins/plugin-tee typecheck
- bunx @biomejs/biome check packages/agent/package.json plugins/plugin-personal-assistant/src/plugin.ts
- git diff --check origin/develop...HEAD
