### PR TITLE
docs(#12241): add API and social example headers

### DIFF
--- a/packages/examples/agent-console/action-scanner.test.ts
+++ b/packages/examples/agent-console/action-scanner.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Deterministic fixture coverage for agent-console action scanning and
+ * subaction inference.
+ */
 import { expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";

--- a/packages/examples/agent-console/action-scanner.ts
+++ b/packages/examples/agent-console/action-scanner.ts
@@ -1,3 +1,7 @@
+/**
+ * Static action scanner for the agent-console example, extracting action
+ * metadata and subaction relationships from elizaOS package sources.
+ */
 import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, normalize, relative, resolve, sep } from "node:path";

--- a/packages/examples/agent-console/server.ts
+++ b/packages/examples/agent-console/server.ts
@@ -1,7 +1,7 @@
-// Agent Console — observable elizaOS AgentRuntime with a live dashboard.
-// Spins up a real @elizaos/core AgentRuntime, wires plugin-openai (Cerebras-aware),
-// wraps useModel and subscribes to EventType.* so the UI sees every stage,
-// every prompt, every action, every evaluator, every model token.
+/**
+ * Observable AgentRuntime dashboard example that wraps model calls and runtime
+ * events so the browser can inspect prompts, actions, evaluators, and tokens.
+ */
 
 import { join, resolve } from "node:path";
 import {

--- a/packages/examples/farcaster/agent.test.js
+++ b/packages/examples/farcaster/agent.test.js
@@ -1,3 +1,6 @@
+/**
+ * Deterministic coverage for Farcaster example environment validation.
+ */
 import { afterEach, describe, expect, test } from "bun:test";
 import { requireEnv, validateEnvironment } from "./agent";
 

--- a/packages/examples/farcaster/agent.ts
+++ b/packages/examples/farcaster/agent.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env bun
 
+/**
+ * Farcaster example agent entrypoint that validates Neynar credentials, loads
+ * workspace plugins, and keeps the polling service alive.
+ */
 import { AgentRuntime, type Plugin } from "@elizaos/core";
 import { config as loadDotEnv } from "dotenv";
 

--- a/packages/examples/farcaster/character.ts
+++ b/packages/examples/farcaster/character.ts
@@ -1,3 +1,6 @@
+/**
+ * Character definition for the OpenAI-backed Farcaster example agent.
+ */
 import { createCharacter } from "@elizaos/core";
 
 export const character = createCharacter({

--- a/packages/examples/rest-api/elysia/server.test.ts
+++ b/packages/examples/rest-api/elysia/server.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Elysia REST API example smoke tests for CORS handling and request validation.
+ */
 import { expect, test } from "bun:test";
 import { app } from "./server";
 

--- a/packages/examples/rest-api/express/server.test.ts
+++ b/packages/examples/rest-api/express/server.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Express REST API example smoke tests against a bound local HTTP server.
+ */
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import type { Server } from "node:http";
 import { app } from "./server";

--- a/packages/examples/rest-api/hono/server.test.ts
+++ b/packages/examples/rest-api/hono/server.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Hono REST API example smoke tests for CORS handling and request validation.
+ */
 import { expect, test } from "bun:test";
 import { app } from "./server";
 

--- a/packages/examples/twitter-xai/agent.test.ts
+++ b/packages/examples/twitter-xai/agent.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Deterministic coverage for X/Grok example environment validation and runtime
+ * settings propagation.
+ */
 import { afterEach, expect, test } from "bun:test";
 import { AgentRuntime, getBasicCapabilitiesSettings } from "@elizaos/core";
 import { requireEnv, validateEnvironment } from "./agent";

--- a/packages/examples/twitter-xai/agent.ts
+++ b/packages/examples/twitter-xai/agent.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env bun
 
+/**
+ * X example agent entrypoint that validates Grok and X credentials, loads
+ * workspace plugins, and keeps the polling service alive.
+ */
 import { AgentRuntime, getBasicCapabilitiesSettings } from "@elizaos/core";
 import { config as loadDotEnv } from "dotenv";
 

--- a/packages/examples/twitter-xai/character.ts
+++ b/packages/examples/twitter-xai/character.ts
@@ -1,3 +1,6 @@
+/**
+ * Character definition for the Grok-backed X example agent.
+ */
 import { createCharacter } from "@elizaos/core";
 
 export const character = createCharacter({


### PR DESCRIPTION
## Summary
- Adds required top-of-file prose headers to agent-console, Farcaster, REST API, and X/Grok example source/test files.
- Converts the existing agent-console server line-comment file banner into the required prose block header.

Relates to #12241.

## Evidence
- `git fetch origin +refs/heads/develop:refs/remotes/origin/develop && git rebase origin/develop`: passed before final verification; branch rebased onto `f2c2377e06`.
- `bun run check:comment-only`: passed; 12 source files changed and every code token is identical to `origin/develop`.
- `bunx @biomejs/biome check packages/examples/agent-console/action-scanner.ts packages/examples/agent-console/action-scanner.test.ts packages/examples/agent-console/server.ts packages/examples/farcaster/agent.ts packages/examples/farcaster/agent.test.js packages/examples/farcaster/character.ts packages/examples/rest-api/elysia/server.test.ts packages/examples/rest-api/express/server.test.ts packages/examples/rest-api/hono/server.test.ts packages/examples/twitter-xai/agent.ts packages/examples/twitter-xai/agent.test.ts packages/examples/twitter-xai/character.ts`: exited 0 after final rebase; reports 13 pre-existing warnings in `packages/examples/agent-console/server.ts` for `any` and non-null assertions.
- `bun --conditions=eliza-source test packages/examples/agent-console/action-scanner.test.ts packages/examples/farcaster/agent.test.js packages/examples/rest-api/elysia/server.test.ts packages/examples/rest-api/express/server.test.ts packages/examples/rest-api/hono/server.test.ts packages/examples/twitter-xai/agent.test.ts`: passed after final rebase; 15 tests, 34 assertions.
- `git diff --check`: passed.
- First-header audit over all 12 touched files: passed.

## Root verify
- `bun run verify`: failed outside this slice. It passed `check:agents-claude`, `audit:type-safety-ratchet`, and `audit:error-policy-ratchet`, then failed in the repo-wide turbo lane on unrelated `plugins/plugin-xr/src/services/vision-pipeline.ts` formatting.
- During that verify run, `@elizaos/plugin-local-inference:lint` rewrote `plugins/plugin-local-inference/src/services/voice/__fixtures__/voice-workbench-logic-baseline.json`; I restored that unrelated formatter output and reran `bun run check:comment-only`, which passed.

## Evidence matrix
- Real LLM trajectory: N/A - comment-only source headers; no agent behavior, prompts, providers, or model routing changed.
- Backend logs: N/A - no runtime/API/service behavior changed.
- Frontend logs/screenshots/video: N/A - no UI changed.
- Domain artifacts: N/A - no generated runtime artifacts changed.