### PR TITLE
fix(#12259): fold electrobun into turbo build

### DIFF
--- a/.github/issue-evidence/12259-electrobun-build-graph.md
+++ b/.github/issue-evidence/12259-electrobun-build-graph.md
@@ -1,0 +1,30 @@
+# Issue #12259 - Electrobun builds inside the Turbo graph
+
+## Change
+
+- Removed the root build script's `!@elizaos/electrobun` Turbo filter.
+- Removed the appended `bun run --cwd packages/app-core/platforms/electrobun build` tail step.
+- Left `bun run check:view-bundles` as the root build tail gate.
+
+The existing `@elizaos/electrobun#build` Turbo task has `dependsOn: ["@elizaos/app#build", "^build"]`, `cache: false`, and `outputs: []`, so Electrobun keeps its build ordering while running inside the graph.
+
+## Verification
+
+Run on 2026-07-04:
+
+- Static root script assertion:
+  - root `build` no longer contains `!@elizaos/electrobun`
+  - root `build` no longer contains `--cwd packages/app-core/platforms/electrobun build`
+  - root `build` still contains `bun run check:view-bundles`
+- Turbo dry run:
+  - `node packages/scripts/run-turbo.mjs run build --concurrency=8 --filter='!./packages/examples/**' --filter='!./packages/benchmarks/**' --cache=local:rw,remote:r --output-logs=errors-only --dry=json`
+  - Confirmed the task set contains `@elizaos/electrobun#build`.
+  - Confirmed `@elizaos/electrobun#build` depends on `@elizaos/app#build`.
+- `git diff --check`
+- `git diff --check origin/develop..HEAD`
+
+The Turbo dry run used a temporary `node_modules` symlink to the main checkout because the auxiliary worktree does not have a local install.
+
+## Evidence notes
+
+Screenshots and recordings are N/A: this is a root CLI/Turbo build-graph change with no user interface.

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "dev:agent": "bun run --cwd packages/agent dev",
     "dev:core": "bun run --cwd packages/core dev",
     "start:debug": "NODE_NO_WARNINGS=1 LOG_LEVEL=debug bun run --cwd packages/agent start",
-    "build": "node packages/scripts/run-turbo.mjs run build --concurrency=8 --filter='!@elizaos/electrobun' --filter='!./packages/examples/**' --filter='!./packages/benchmarks/**' --cache=local:rw,remote:r --output-logs=errors-only && bun run --cwd packages/app-core/platforms/electrobun build && bun run check:view-bundles",
+    "build": "node packages/scripts/run-turbo.mjs run build --concurrency=8 --filter='!./packages/examples/**' --filter='!./packages/benchmarks/**' --cache=local:rw,remote:r --output-logs=errors-only && bun run check:view-bundles",
     "build:typescript": "node packages/scripts/run-turbo.mjs run build",
     "build:client": "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/app",
     "build:views": "node packages/scripts/build-views.mjs",


### PR DESCRIPTION
## Summary
- remove the root build script's `!@elizaos/electrobun` Turbo filter
- remove the appended `bun run --cwd packages/app-core/platforms/electrobun build` tail step
- keep `bun run check:view-bundles` as the root build tail gate

## Verification
- static root build assertion: no `!@elizaos/electrobun`, no Electrobun `--cwd` build tail, still contains `bun run check:view-bundles`
- Turbo dry run with temporary `node_modules` symlink:
  - `node packages/scripts/run-turbo.mjs run build --concurrency=8 --filter='!./packages/examples/**' --filter='!./packages/benchmarks/**' --cache=local:rw,remote:r --output-logs=errors-only --dry=json`
  - confirmed `@elizaos/electrobun#build` is in the task set
  - confirmed it depends on `@elizaos/app#build`
- `git diff --check origin/develop..HEAD`

## Evidence
- `.github/issue-evidence/12259-electrobun-build-graph.md`
- Screenshots/recordings: N/A, root CLI/Turbo build graph only.