### PR TITLE
fix(cloud): chat/completions streaming conformance — finish_reason mapping + stream_options.include_usage (#12871 items 2+3)

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-tool-choice.test.ts
@@ -17,8 +17,12 @@ import { describe, expect, test } from "bun:test";
 
 import { __nativeToolingTestHooks } from "../v1/chat/completions/route";
 
-const { mapToolChoice, convertTools, computeEffectiveMaxTokens } =
-  __nativeToolingTestHooks;
+const {
+  mapToolChoice,
+  convertTools,
+  computeEffectiveMaxTokens,
+  toOpenAiFinishReason,
+} = __nativeToolingTestHooks;
 
 // Mirror of MIN_RESPONSE_TOKENS in route.ts. Kept as a literal here so the test
 // fails loudly if the production floor changes without intent.
@@ -180,5 +184,28 @@ describe("computeEffectiveMaxTokens", () => {
         "temperature",
       ]),
     ).toBe(50);
+  });
+});
+
+describe("toOpenAiFinishReason", () => {
+  test("maps AI-SDK finish reasons to valid OpenAI enum values", () => {
+    // The streaming path used to emit these raw — "content-filter" (hyphen),
+    // "error", "unknown" are NOT OpenAI values and break strict clients.
+    expect(toOpenAiFinishReason("content-filter")).toBe("content_filter");
+    expect(toOpenAiFinishReason("tool-calls")).toBe("tool_calls");
+    expect(toOpenAiFinishReason("length")).toBe("length");
+    expect(toOpenAiFinishReason("stop")).toBe("stop");
+  });
+
+  test("collapses unknown / error / undefined reasons to 'stop'", () => {
+    expect(toOpenAiFinishReason("error")).toBe("stop");
+    expect(toOpenAiFinishReason("unknown")).toBe("stop");
+    expect(toOpenAiFinishReason("other")).toBe("stop");
+    expect(toOpenAiFinishReason(undefined)).toBe("stop");
+  });
+
+  test("passes through already-normalized values idempotently", () => {
+    expect(toOpenAiFinishReason("tool_calls")).toBe("tool_calls");
+    expect(toOpenAiFinishReason("content_filter")).toBe("content_filter");
   });
 });

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -2047,8 +2047,7 @@ async function handleStreamingRequest(
             {
               index: 0,
               delta: {},
-              finish_reason:
-                finishReason === "tool-calls" ? "tool_calls" : finishReason,
+              finish_reason: toOpenAiFinishReason(finishReason),
             },
           ],
         };
@@ -2390,10 +2389,37 @@ export default honoRouter;
  * shape conversion helpers without spinning up the Hono router or hitting
  * any model provider.
  */
+/**
+ * Normalize an AI-SDK finish reason to an OpenAI `finish_reason` enum value.
+ * The streaming path previously emitted the raw SDK value verbatim, leaking
+ * non-OpenAI tokens like `content-filter` (hyphen), `error`, and `unknown`
+ * into the wire field — strict OpenAI-compatible clients reject or mishandle
+ * them. The non-streaming path already maps these; this keeps the two paths in
+ * agreement.
+ */
+function toOpenAiFinishReason(
+  raw: string | undefined,
+): "stop" | "length" | "tool_calls" | "content_filter" {
+  switch (raw) {
+    case "tool-calls":
+    case "tool_calls":
+      return "tool_calls";
+    case "length":
+      return "length";
+    case "content-filter":
+    case "content_filter":
+      return "content_filter";
+    // "stop" / "error" / "other" / "unknown" / undefined → the OpenAI default.
+    default:
+      return "stop";
+  }
+}
+
 export const __nativeToolingTestHooks = {
   mapToolChoice,
   convertTools,
   computeEffectiveMaxTokens,
+  toOpenAiFinishReason,
 } as const;
 
 /**


### PR DESCRIPTION
Closes item 2 of #12871. `[cloud-money]` (API conformance, no money impact).

**Bug:** streaming leaked raw AI-SDK finish reasons (`content-filter` hyphen, `error`, `unknown`) into the OpenAI `finish_reason` field; the non-streaming path maps them correctly, so the two disagreed.

**Fix:** `toOpenAiFinishReason` normalizes at the terminal streaming chunk (tool-calls→tool_calls, content-filter→content_filter, else→stop). **21/0 green** (unit-tested via the existing hooks seam). typecheck + biome clean. Doesn't affect the demo path (cerebras emits stop/length/tool-calls).