### PR TITLE
docs(#12862): clean tui prose headers

### DIFF
--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -1,3 +1,7 @@
+/**
+ * Autocomplete providers for slash commands and filesystem path suggestions in
+ * terminal editors.
+ */
 import { spawnSync } from "node:child_process";
 import { readdirSync, statSync } from "fs";
 import { homedir } from "os";

--- a/packages/tui/src/components/box.ts
+++ b/packages/tui/src/components/box.ts
@@ -1,3 +1,7 @@
+/**
+ * Box component that applies padding and optional background styling around
+ * child terminal components.
+ */
 import type { Component } from "../tui.js";
 import { applyBackgroundToLine, visibleWidth } from "../utils.js";
 
@@ -8,9 +12,6 @@ type RenderCache = {
   lines: string[];
 };
 
-/**
- * Box component - a container that applies padding and background to all children
- */
 export class Box implements Component {
   children: Component[] = [];
   private paddingX: number;

--- a/packages/tui/src/components/cancellable-loader.ts
+++ b/packages/tui/src/components/cancellable-loader.ts
@@ -1,3 +1,7 @@
+/**
+ * Cancellable loader that turns the shared select-cancel keybinding into an
+ * AbortSignal for long-running terminal operations.
+ */
 import { getEditorKeybindings } from "../keybindings.js";
 import { Loader } from "./loader.js";
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1,3 +1,7 @@
+/**
+ * Multi-line terminal editor with history, undo, kill-ring, autocomplete, and
+ * Kitty keyboard protocol handling.
+ */
 import type {
   AutocompleteItem,
   AutocompleteProvider,
@@ -27,7 +31,6 @@ export {
   layoutText,
   wordWrapLine,
 } from "./editor/layout.js";
-// Re-export types and utilities from editor submodules
 export type {
   EditorOptions,
   EditorState,
@@ -38,7 +41,6 @@ export type {
 } from "./editor/types.js";
 export { restoreSnapshot, UndoManager } from "./editor/undo.js";
 
-// Import for internal use
 import { wordWrapLine as wordWrapLineInternal } from "./editor/layout.js";
 import type {
   EditorOptions,

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -1,3 +1,7 @@
+/**
+ * Inline image component for terminals with Kitty or iTerm2 image protocol
+ * support, with text fallback for unsupported hosts.
+ */
 import {
   getCapabilities,
   getImageDimensions,

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -1,3 +1,7 @@
+/**
+ * Single-line terminal text input with cursor movement, paste handling, and
+ * editor keybinding support.
+ */
 import { getEditorKeybindings } from "../keybindings.js";
 import { type Component, CURSOR_MARKER, type Focusable } from "../tui.js";
 import {
@@ -16,9 +20,6 @@ import { getSegmenter, visibleWidth } from "../utils.js";
 
 const segmenter = getSegmenter();
 
-/**
- * Input component - single-line text input with horizontal scrolling
- */
 export class Input implements Component, Focusable {
   private value: string = "";
   private cursor: number = 0; // Cursor position in the value

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -1,10 +1,11 @@
+/**
+ * Animated terminal loader that invalidates the host TUI while its spinner
+ * frame advances.
+ */
 import { LOADER_ANIMATION_INTERVAL_MS } from "../constants.js";
 import type { TUI } from "../tui.js";
 import { Text } from "./text.js";
 
-/**
- * Loader component with spinning animation.
- */
 export class Loader extends Text {
   private frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
   private currentFrame = 0;

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1,3 +1,7 @@
+/**
+ * Markdown renderer that converts marked tokens into width-bounded ANSI-styled
+ * terminal lines.
+ */
 import { marked, type Token } from "marked";
 import { isImageLine } from "../terminal-image.js";
 import type { Component } from "../tui.js";
@@ -8,7 +12,6 @@ import {
   wrapTextWithAnsi,
 } from "../utils.js";
 
-// Import types and utilities from submodules
 import type { InlineRenderContext } from "./markdown/inline-renderer.js";
 import { renderInlineTokens as renderInlineTokensUtil } from "./markdown/inline-renderer.js";
 import type { ListRenderContext } from "./markdown/list-renderer.js";
@@ -22,7 +25,6 @@ import type {
 } from "./markdown/types.js";
 import { getStylePrefix } from "./markdown/types.js";
 
-// Re-export types for backward compatibility
 export type {
   DefaultTextStyle,
   MarkdownTheme,

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -1,3 +1,7 @@
+/**
+ * Keyboard-navigable terminal selection list with filtering and bounded
+ * visible rows.
+ */
 import { getEditorKeybindings } from "../keybindings.js";
 import type { Component } from "../tui.js";
 import { truncateToWidth } from "../utils.js";

--- a/packages/tui/src/components/settings-list.ts
+++ b/packages/tui/src/components/settings-list.ts
@@ -1,3 +1,7 @@
+/**
+ * Terminal settings list with value cycling, search, and nested submenu
+ * support.
+ */
 import { fuzzyFilter } from "../fuzzy.js";
 import { getEditorKeybindings } from "../keybindings.js";
 import type { Component } from "../tui.js";

--- a/packages/tui/src/components/spacer.ts
+++ b/packages/tui/src/components/spacer.ts
@@ -1,3 +1,6 @@
+/**
+ * Spacer component that contributes a fixed number of blank terminal rows.
+ */
 import type { Component } from "../tui.js";
 
 /**

--- a/packages/tui/src/components/text.ts
+++ b/packages/tui/src/components/text.ts
@@ -1,3 +1,7 @@
+/**
+ * Text component that wraps ANSI-styled content into width-bounded terminal
+ * rows with optional padding and background styling.
+ */
 import type { Component } from "../tui.js";
 import {
   applyBackgroundToLine,
@@ -5,9 +9,6 @@ import {
   wrapTextWithAnsi,
 } from "../utils.js";
 
-/**
- * Text component - displays multi-line text with word wrapping
- */
 export class Text implements Component {
   private text: string;
   private paddingX: number; // Left/right padding

--- a/packages/tui/src/components/truncated-text.ts
+++ b/packages/tui/src/components/truncated-text.ts
@@ -1,3 +1,7 @@
+/**
+ * Single-line text component for terminal headers and status rows that must
+ * truncate rather than wrap.
+ */
 import type { Component } from "../tui.js";
 import { truncateToWidth, visibleWidth } from "../utils.js";
 

--- a/packages/tui/src/editor-component.ts
+++ b/packages/tui/src/editor-component.ts
@@ -1,3 +1,6 @@
+/**
+ * Shared editor component contract for pluggable terminal text editors.
+ */
 import type { AutocompleteProvider } from "./autocomplete.js";
 import type { Component } from "./tui.js";
 

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -1,4 +1,7 @@
-// Core TUI interfaces and classes
+/**
+ * Public API barrel for the terminal UI renderer, components, themes, input
+ * helpers, and testing utilities.
+ */
 
 // Autocomplete support
 export {

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -1,3 +1,6 @@
+/**
+ * Runtime-configurable editor action keybindings for terminal input widgets.
+ */
 import { type KeyId, matchesKey } from "./keys.js";
 
 /**
@@ -41,7 +44,6 @@ export type EditorAction =
   // Undo
   | "undo";
 
-// Re-export KeyId from keys.ts
 export type { KeyId };
 
 /**

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -41,7 +41,7 @@ function isCompleteSequence(
 
   // CSI sequences: ESC [
   if (afterEsc.startsWith("[")) {
-    // Check for old-style mouse sequence: ESC[M + 3 bytes
+    // Detect legacy mouse sequence framing: ESC[M + 3 bytes.
     if (afterEsc.startsWith("[M")) {
       // Old-style mouse needs ESC[M + 3 bytes = 6 total
       return data.length >= 6 ? "complete" : "incomplete";

--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -1,3 +1,7 @@
+/**
+ * Terminal image capability detection and Kitty/iTerm2 image protocol
+ * renderers.
+ */
 export type ImageProtocol = "kitty" | "iterm2" | null;
 
 export interface TerminalCapabilities {

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -1,3 +1,7 @@
+/**
+ * Terminal abstraction and process-backed implementation for raw-mode TUI
+ * rendering and input dispatch.
+ */
 import * as fs from "node:fs";
 import {
   DEFAULT_TERMINAL_HEIGHT,
@@ -8,9 +12,6 @@ import {
 import { setKittyProtocolActive } from "./keys.js";
 import { StdinBuffer } from "./stdin-buffer.js";
 
-/**
- * Minimal terminal interface for TUI
- */
 export interface Terminal {
   // Start the terminal with input and resize handlers
   start(onInput: (data: string) => void, onResize: () => void): void;
@@ -52,9 +53,6 @@ export interface Terminal {
   setTitle(title: string): void; // Set terminal window title
 }
 
-/**
- * Real terminal using process.stdin/stdout
- */
 export class ProcessTerminal implements Terminal {
   private wasRaw = false;
   private inputHandler?: (data: string) => void;

--- a/packages/tui/src/testing/virtual-terminal.ts
+++ b/packages/tui/src/testing/virtual-terminal.ts
@@ -1,3 +1,6 @@
+/**
+ * Headless xterm-backed terminal implementation for deterministic TUI tests.
+ */
 import type { Terminal as XtermTerminalType } from "@xterm/headless";
 import xterm from "@xterm/headless";
 import type { Terminal } from "../terminal.js";

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -121,7 +121,7 @@ export class TUI extends Container {
   }
 
   setFocus(component: Component | null): void {
-    // Clear focused flag on old component
+    // Clear focus on the previously focused component before assigning the new one.
     if (isFocusable(this.focusedComponent)) {
       this.focusedComponent.focused = false;
     }
@@ -742,7 +742,7 @@ export class TUI extends Container {
       return;
     }
 
-    // Check if firstChanged is above what was previously visible
+    // If the first changed row is above the visible region, redraw from the top.
     // Use previousLines.length (not maxLinesRendered) to avoid false positives after content shrinks
     const previousContentViewportTop = Math.max(
       0,

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -1,3 +1,7 @@
+/**
+ * ANSI-aware terminal text measurement, truncation, wrapping, and style-state
+ * helpers.
+ */
 import { eastAsianWidth } from "get-east-asian-width";
 
 // Grapheme segmenter (shared instance)

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Autocomplete tests cover slash command filtering and filesystem path
+ * suggestions against temporary directories.
+ */
 import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/packages/tui/test/box.test.ts
+++ b/packages/tui/test/box.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Box component tests verify child rendering, padding, background styling, and
+ * child removal behavior.
+ */
 import { describe, expect, test } from "vitest";
 import { Box } from "../src/components/box.js";
 import { Text } from "../src/components/text.js";

--- a/packages/tui/test/bug-regression-isimageline-startswith-bug.test.ts
+++ b/packages/tui/test/bug-regression-isimageline-startswith-bug.test.ts
@@ -14,7 +14,7 @@ describe("Bug regression: isImageLine() crash with image escape sequences", () =
   describe("Bug scenario: Terminal without image support", () => {
     it("old implementation would return false, causing crash", () => {
       /**
-       * OLD IMPLEMENTATION (buggy):
+       * StartsWith-only detector:
        * ```typescript
        * export function isImageLine(line: string): boolean {
        *   const prefix = getImageEscapePrefix();
@@ -29,7 +29,7 @@ describe("Bug regression: isImageLine() crash with image escape sequences", () =
        * - Crash: "Rendered line exceeds terminal width (304401 > 115)"
        */
 
-      // Simulate old implementation behavior
+      // This local detector models the startsWith-only failure mode.
       const oldIsImageLine = (
         line: string,
         imageEscapePrefix: string | null,
@@ -44,7 +44,7 @@ describe("Bug regression: isImageLine() crash with image escape sequences", () =
       const lineWithImageSequence =
         "Read image file [image/jpeg]\x1b]1337;File=size=800,600;inline=1:base64data...\x07";
 
-      // Old implementation would return false (BUG!)
+      // The startsWith-only detector returns false for the mid-line sequence.
       const oldResult = oldIsImageLine(
         lineWithImageSequence,
         terminalWithoutImageSupport,

--- a/packages/tui/test/cursor-movement.test.ts
+++ b/packages/tui/test/cursor-movement.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Cursor movement tests cover grapheme-aware terminal cursor math for editor
+ * navigation.
+ */
 import { describe, expect, test } from "vitest";
 import {
   deleteGraphemeBackward,

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Editor tests exercise terminal text editing, history, undo, autocomplete,
+ * paste handling, and keybinding behavior.
+ */
 import assert from "node:assert";
 import { stripVTControlCharacters } from "node:util";
 import { describe, it } from "vitest";

--- a/packages/tui/test/fuzzy.test.ts
+++ b/packages/tui/test/fuzzy.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Fuzzy matching tests lock list filtering and ranking behavior for terminal
+ * selection surfaces.
+ */
 import assert from "node:assert";
 import { describe, it } from "vitest";
 import { fuzzyFilter, fuzzyMatch } from "../src/fuzzy.js";

--- a/packages/tui/test/image-test.ts
+++ b/packages/tui/test/image-test.ts
@@ -1,3 +1,7 @@
+/**
+ * Manual image protocol smoke script for rendering fixture images in a real
+ * terminal.
+ */
 import { readFileSync } from "fs";
 import { Image } from "../src/components/image.js";
 import { Spacer } from "../src/components/spacer.js";

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Input component tests cover single-line editing, cursor movement, paste
+ * normalization, and submit/cancel handling.
+ */
 import assert from "node:assert";
 import { describe, it } from "vitest";
 import { Input } from "../src/components/input.js";

--- a/packages/tui/test/key-tester.ts
+++ b/packages/tui/test/key-tester.ts
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/**
+ * Interactive terminal key tester for inspecting raw input sequences against
+ * the key matcher.
+ */
 import { matchesKey } from "../src/keys.js";
 import { ProcessTerminal } from "../src/terminal.js";
 import { type Component, TUI } from "../src/tui.js";

--- a/packages/tui/test/keybindings.test.ts
+++ b/packages/tui/test/keybindings.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Keybinding tests verify the default editor action map and runtime remapping
+ * behavior.
+ */
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -1,11 +1,17 @@
+/**
+ * Loader component coverage for rendered spinner text, message updates, and
+ * interval cleanup using a minimal TUI requestRender boundary.
+ */
+
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { Loader } from "../src/components/loader.js";
 import type { TUI } from "../src/tui.js";
 
 /**
- * Minimal mock TUI for Loader tests.
- * Loader only uses requestRender(), so we mock just that method.
- * Uses Pick<TUI, 'requestRender'> to ensure type alignment with actual TUI.
+ * Minimal TUI boundary for Loader tests.
+ *
+ * Loader only calls requestRender, and Pick<TUI, "requestRender"> keeps the
+ * test double aligned with the public TUI shape.
  */
 type MockTUI = Pick<TUI, "requestRender"> & {
   requestRender: ReturnType<typeof mock>;
@@ -24,14 +30,13 @@ describe("Loader component", () => {
   });
 
   afterEach(() => {
-    // Stop the loader to clear any intervals
+    // Spinner intervals must not leak between tests.
     if (loader) {
       loader.stop();
     }
   });
 
-  // Cast helper - Loader only uses requestRender(), so partial mock is safe.
-  // We use 'as unknown as TUI' because MockTUI is intentionally a subset.
+  // Loader only reaches requestRender, so this partial TUI is a bounded test double.
   const asTUI = (m: MockTUI): TUI => m as unknown as TUI;
 
   describe("constructor", () => {
@@ -42,7 +47,6 @@ describe("Loader component", () => {
         (s) => s,
       );
       const lines = loader.render(40);
-      // Should render spinner + message
       expect(lines.some((l) => l.includes("Loading..."))).toBe(true);
     });
 
@@ -86,7 +90,6 @@ describe("Loader component", () => {
         (s) => s,
       );
       const lines = loader.render(40);
-      // First line should be empty (for spacing)
       expect(lines[0]).toBe("");
       expect(lines.length).toBeGreaterThan(1);
     });
@@ -112,7 +115,7 @@ describe("Loader component", () => {
         (s) => s,
         (s) => s,
       );
-      // Reset mock to clear constructor call
+      // Clear the constructor-triggered request before measuring setMessage.
       mockTUI.requestRender.mockClear();
       loader.setMessage("New message");
       expect(mockTUI.requestRender).toHaveBeenCalled();
@@ -127,9 +130,8 @@ describe("Loader component", () => {
         (s) => s,
       );
       loader.stop();
-      // Reset mock to clear previous calls
+      // Only render requests after stop matter for this assertion.
       mockTUI.requestRender.mockClear();
-      // Wait a bit and verify no more render requests
       await new Promise((resolve) => setTimeout(resolve, 200));
       expect(mockTUI.requestRender).not.toHaveBeenCalled();
     });

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Markdown component tests render formatted terminal output into a virtual
+ * terminal so ANSI styling and cell attributes can be asserted deterministically.
+ */
+
 import assert from "node:assert";
 import { Chalk } from "chalk";
 import { describe, it } from "vitest";
@@ -6,7 +11,7 @@ import { VirtualTerminal } from "../src/testing/virtual-terminal.js";
 import { type Component, TUI } from "../src/tui.js";
 import { defaultMarkdownTheme } from "./test-themes.js";
 
-// Force full color in CI so ANSI assertions are deterministic
+// Force full color in CI so ANSI assertions are deterministic.
 const chalk = new Chalk({ level: 3 });
 
 function getCellItalic(

--- a/packages/tui/test/overlay-options.test.ts
+++ b/packages/tui/test/overlay-options.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Overlay rendering tests verify size negotiation and placement against the
+ * virtual terminal renderer rather than a real terminal.
+ */
+
 import assert from "node:assert";
 import { describe, it } from "vitest";
 import { VirtualTerminal } from "../src/testing/virtual-terminal.js";
@@ -11,7 +16,7 @@ class StaticOverlay implements Component {
   ) {}
 
   render(width: number): string[] {
-    // Store the width we were asked to render at for verification
+    // Capture the negotiated width so placement tests can assert it later.
     this.requestedWidth = width;
     return this.lines;
   }

--- a/packages/tui/test/overlay-short-content.test.ts
+++ b/packages/tui/test/overlay-short-content.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Overlay tests for short base content verify that modal layers render without
+ * corrupting the underlying virtual terminal rows.
+ */
+
 import assert from "node:assert";
 import { describe, it } from "vitest";
 import { VirtualTerminal } from "../src/testing/virtual-terminal.js";

--- a/packages/tui/test/paste-handler.test.ts
+++ b/packages/tui/test/paste-handler.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Paste handler utility tests cover bracketed paste parsing for single-line and
+ * multiline editor input without involving a live terminal stream.
+ */
+
 import { describe, expect, test } from "vitest";
 import {
   cleanPasteForMultiLine,

--- a/packages/tui/test/progress-bar.test.ts
+++ b/packages/tui/test/progress-bar.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Progress bar tests verify width accounting for narrow terminals, ANSI
+ * styling, and message truncation.
+ */
+
 import { describe, expect, test } from "vitest";
 import { ProgressBar } from "../src/components/progress-bar.js";
 import { visibleWidth } from "../src/utils.js";

--- a/packages/tui/test/select-list.test.ts
+++ b/packages/tui/test/select-list.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Select list tests cover keyboard-facing list state, filtering, and rendered
+ * labels with a deterministic plain-text theme.
+ */
+
 import assert from "node:assert";
 import { describe, it } from "vitest";
 import { SelectList } from "../src/components/select-list.js";

--- a/packages/tui/test/spacer.test.ts
+++ b/packages/tui/test/spacer.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Spacer component tests verify deterministic blank-line output for terminal
+ * layouts that need fixed vertical gaps.
+ */
+
 import { describe, expect, test } from "vitest";
 import { Spacer } from "../src/components/spacer.js";
 

--- a/packages/tui/test/text.test.ts
+++ b/packages/tui/test/text.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Text component tests cover padding, truncation, and ANSI-aware wrapping for
+ * terminal text blocks.
+ */
+
 import { describe, expect, test } from "vitest";
 import { Text } from "../src/components/text.js";
 import { visibleWidth } from "../src/utils.js";
@@ -7,21 +12,18 @@ describe("Text component", () => {
     test("creates empty Text with default padding", () => {
       const text = new Text();
       const lines = text.render(40);
-      // Empty text returns empty array
       expect(lines).toEqual([]);
     });
 
     test("creates Text with content", () => {
       const text = new Text("Hello, World!");
       const lines = text.render(40);
-      // Should have vertical padding (1 empty line top + 1 content + 1 empty line bottom)
       expect(lines.length).toBe(3);
     });
 
     test("creates Text with custom padding", () => {
       const text = new Text("Hello", 2, 2);
       const lines = text.render(40);
-      // 2 empty top + 1 content + 2 empty bottom = 5
       expect(lines.length).toBe(5);
     });
   });
@@ -31,21 +33,18 @@ describe("Text component", () => {
       const text = new Text("Hello", 2, 0);
       const lines = text.render(20);
       expect(lines.length).toBe(1);
-      // Check padding on left side
       expect(lines[0].startsWith("  Hello")).toBe(true);
     });
 
     test("wraps long text", () => {
       const text = new Text("This is a long text that should wrap", 0, 0);
       const lines = text.render(20);
-      // Should wrap to multiple lines
       expect(lines.length).toBeGreaterThan(1);
     });
 
     test("handles tabs by converting to spaces", () => {
       const text = new Text("Hello\tWorld", 0, 0);
       const lines = text.render(80);
-      // Tab should be converted to 3 spaces
       expect(lines[0]).toContain("   ");
     });
 
@@ -65,7 +64,6 @@ describe("Text component", () => {
       const text = new Text("Hello");
       const lines1 = text.render(40);
       const lines2 = text.render(40);
-      // Should return same cached array
       expect(lines1).toBe(lines2);
     });
 
@@ -73,7 +71,6 @@ describe("Text component", () => {
       const text = new Text("Hello");
       const lines1 = text.render(40);
       const lines2 = text.render(30);
-      // Different width should produce different result
       expect(lines1).not.toBe(lines2);
     });
   });
@@ -98,7 +95,6 @@ describe("Text component", () => {
   describe("setCustomBgFn", () => {
     test("applies background function to lines", () => {
       const text = new Text("Hello", 0, 0);
-      // Simple mock function that wraps text
       text.setCustomBgFn((t) => `[BG]${t}[/BG]`);
       const lines = text.render(20);
       expect(lines[0].startsWith("[BG]")).toBe(true);
@@ -120,7 +116,6 @@ describe("Text component", () => {
       const lines1 = text.render(40);
       text.invalidate();
       const lines2 = text.render(40);
-      // After invalidate, should be a new array (not same reference)
       expect(lines1).not.toBe(lines2);
     });
   });

--- a/packages/tui/test/toast.test.ts
+++ b/packages/tui/test/toast.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Toast component tests verify compact notification rendering with wide
+ * characters, ANSI styling, and borders.
+ */
+
 import { describe, expect, test } from "vitest";
 import { Toast } from "../src/components/toast.js";
 import { visibleWidth } from "../src/utils.js";

--- a/packages/tui/test/truncated-text.test.ts
+++ b/packages/tui/test/truncated-text.test.ts
@@ -1,10 +1,15 @@
+/**
+ * Truncated text tests verify fixed-line rendering, padding, and ANSI width
+ * accounting for terminal rows.
+ */
+
 import assert from "node:assert";
 import { Chalk } from "chalk";
 import { describe, it } from "vitest";
 import { TruncatedText } from "../src/components/truncated-text.js";
 import { visibleWidth } from "../src/utils.js";
 
-// Force full color in CI so ANSI assertions are deterministic
+// Force full color in CI so ANSI assertions are deterministic.
 const chalk = new Chalk({ level: 3 });
 
 describe("TruncatedText component", () => {
@@ -12,10 +17,8 @@ describe("TruncatedText component", () => {
     const text = new TruncatedText("Hello world", 1, 0);
     const lines = text.render(50);
 
-    // Should have exactly one content line (no vertical padding)
     assert.strictEqual(lines.length, 1);
 
-    // Line should be exactly 50 visible characters
     const visibleLen = visibleWidth(lines[0]);
     assert.strictEqual(visibleLen, 50);
   });
@@ -24,10 +27,8 @@ describe("TruncatedText component", () => {
     const text = new TruncatedText("Hello", 0, 2);
     const lines = text.render(40);
 
-    // Should have 2 padding lines + 1 content line + 2 padding lines = 5 total
     assert.strictEqual(lines.length, 5);
 
-    // All lines should be exactly 40 characters
     for (const line of lines) {
       assert.strictEqual(visibleWidth(line), 40);
     }
@@ -41,10 +42,8 @@ describe("TruncatedText component", () => {
 
     assert.strictEqual(lines.length, 1);
 
-    // Should be exactly 30 characters
     assert.strictEqual(visibleWidth(lines[0]), 30);
 
-    // Should contain ellipsis
     const stripped = lines[0].replace(/\x1b\[[0-9;]*m/g, "");
     assert.ok(stripped.includes("..."));
   });
@@ -56,10 +55,8 @@ describe("TruncatedText component", () => {
 
     assert.strictEqual(lines.length, 1);
 
-    // Should be exactly 40 visible characters (ANSI codes don't count)
     assert.strictEqual(visibleWidth(lines[0]), 40);
 
-    // Should preserve the color codes
     assert.ok(lines[0].includes("\x1b["));
   });
 
@@ -72,23 +69,18 @@ describe("TruncatedText component", () => {
 
     assert.strictEqual(lines.length, 1);
 
-    // Should be exactly 20 visible characters
     assert.strictEqual(visibleWidth(lines[0]), 20);
 
-    // Should contain reset code before ellipsis
     assert.ok(lines[0].includes("\x1b[0m..."));
   });
 
   it("handles text that fits exactly", () => {
-    // With paddingX=1, available width is 30-2=28
-    // "Hello world" is 11 chars, fits comfortably
     const text = new TruncatedText("Hello world", 1, 0);
     const lines = text.render(30);
 
     assert.strictEqual(lines.length, 1);
     assert.strictEqual(visibleWidth(lines[0]), 30);
 
-    // Should NOT contain ellipsis
     const stripped = lines[0].replace(/\x1b\[[0-9;]*m/g, "");
     assert.ok(!stripped.includes("..."));
   });
@@ -109,7 +101,6 @@ describe("TruncatedText component", () => {
     assert.strictEqual(lines.length, 1);
     assert.strictEqual(visibleWidth(lines[0]), 40);
 
-    // Should only contain "First line"
     const stripped = lines[0].replace(/\x1b\[[0-9;]*m/g, "").trim();
     assert.ok(stripped.includes("First line"));
     assert.ok(!stripped.includes("Second line"));
@@ -125,7 +116,6 @@ describe("TruncatedText component", () => {
     assert.strictEqual(lines.length, 1);
     assert.strictEqual(visibleWidth(lines[0]), 25);
 
-    // Should contain ellipsis and not second line
     const stripped = lines[0].replace(/\x1b\[[0-9;]*m/g, "");
     assert.ok(stripped.includes("..."));
     assert.ok(!stripped.includes("Second line"));

--- a/packages/tui/test/tui-overlay-style-leak.test.ts
+++ b/packages/tui/test/tui-overlay-style-leak.test.ts
@@ -1,3 +1,8 @@
+/**
+ * TUI overlay regression tests verify that modal rendering restores ANSI style
+ * state before returning to base content.
+ */
+
 import assert from "node:assert";
 import { describe, it } from "vitest";
 import { VirtualTerminal } from "../src/testing/virtual-terminal.js";

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -1,3 +1,8 @@
+/**
+ * TUI render tests exercise the virtual terminal pipeline for cursor movement,
+ * style attributes, and incremental row updates.
+ */
+
 import assert from "node:assert";
 import { describe, it } from "vitest";
 import { VirtualTerminal } from "../src/testing/virtual-terminal.js";

--- a/packages/tui/test/wrap-ansi.test.ts
+++ b/packages/tui/test/wrap-ansi.test.ts
@@ -1,3 +1,8 @@
+/**
+ * ANSI wrapping tests verify that style open and reset sequences remain scoped
+ * to the wrapped text segments they decorate.
+ */
+
 import assert from "node:assert";
 import { describe, it } from "vitest";
 import { visibleWidth, wrapTextWithAnsi } from "../src/utils.js";
@@ -12,10 +17,8 @@ describe("wrapTextWithAnsi", () => {
 
       const wrapped = wrapTextWithAnsi(text, 40);
 
-      // First line should NOT contain underline code - it's just "read this thread"
       assert.strictEqual(wrapped[0], "read this thread");
 
-      // Second line should start with underline, have URL content
       assert.strictEqual(wrapped[1].startsWith(underlineOn), true);
       assert.ok(wrapped[1].includes("https://"));
     });
@@ -39,12 +42,9 @@ describe("wrapTextWithAnsi", () => {
 
       const wrapped = wrapTextWithAnsi(text, 30);
 
-      // Middle lines (with underlined content) should end with underline-off, not full reset
-      // Line 1 and 2 contain underlined URL parts
       for (let i = 1; i < wrapped.length - 1; i++) {
         const line = wrapped[i];
         if (line.includes(underlineOn)) {
-          // Should end with underline off, NOT full reset
           assert.strictEqual(line.endsWith(underlineOff), true);
           assert.strictEqual(line.endsWith("\x1b[0m"), false);
         }
@@ -60,12 +60,10 @@ describe("wrapTextWithAnsi", () => {
 
       const wrapped = wrapTextWithAnsi(text, 15);
 
-      // Each line should have background color
       for (const line of wrapped) {
         assert.ok(line.includes(bgBlue));
       }
 
-      // Middle lines should NOT end with full reset (kills background for padding)
       for (let i = 0; i < wrapped.length - 1; i++) {
         assert.strictEqual(wrapped[i].endsWith("\x1b[0m"), false);
       }
@@ -80,7 +78,6 @@ describe("wrapTextWithAnsi", () => {
 
       const wrapped = wrapTextWithAnsi(text, 20);
 
-      // All lines should have background color 41 (either as \x1b[41m or combined like \x1b[4;41m)
       for (const line of wrapped) {
         const hasBgColor =
           line.includes("[41m") ||
@@ -89,10 +86,8 @@ describe("wrapTextWithAnsi", () => {
         assert.ok(hasBgColor);
       }
 
-      // Lines with underlined content should use underline-off at end, not full reset
       for (let i = 0; i < wrapped.length - 1; i++) {
         const line = wrapped[i];
-        // If this line has underline on, it should end with underline off (not full reset)
         if (
           (line.includes("[4m") ||
             line.includes("[4;") ||
@@ -129,12 +124,10 @@ describe("wrapTextWithAnsi", () => {
 
       const wrapped = wrapTextWithAnsi(text, 10);
 
-      // Each continuation line should start with red code
       for (let i = 1; i < wrapped.length; i++) {
         assert.strictEqual(wrapped[i].startsWith(red), true);
       }
 
-      // Middle lines should not end with full reset
       for (let i = 0; i < wrapped.length - 1; i++) {
         assert.strictEqual(wrapped[i].endsWith("\x1b[0m"), false);
       }


### PR DESCRIPTION
## Summary
- Adds purpose prose headers across TUI source and test files that were missing the required top block.
- Rewrites/removes churn-style and assertion-restatement comments while preserving code behavior.
- Keeps the change comment-only for the B02-C cleanup scope.

Closes #12862

## Verification
- PASS: `bun run check:comment-only`
- PASS: `bunx biome format $(git diff --name-only origin/develop -- packages/tui)`
- PASS: `git diff --check origin/develop`
- PASS: `bun run --cwd packages/tui build`
- PASS: TUI source header audit: `MISSING_COUNT=0`
- FAIL (environment): `bun run --cwd packages/tui test` fails because sparse install cannot resolve `@xterm/headless` from `packages/tui/src/testing/virtual-terminal.ts`; 20 files / 276 tests passed before the import failures.
- FAIL (environment): `bun run --cwd packages/tui typecheck` fails on missing declarations/packages for `@xterm/headless`, `marked`, and `get-east-asian-width` in this sparse workspace.
- FAIL (environment): `bun run verify` fails immediately in `check:agents-claude` because sparse checkout is missing `packages/auth/AGENTS.md`.

## Evidence
- N/A - documentation/comment-only cleanup; no runtime UI, model, connector, native, or domain artifact behavior changed.
