### PR TITLE
docs(#12241): add more example headers

### DIFF
--- a/packages/examples/convex/convex/agent.ts
+++ b/packages/examples/convex/convex/agent.ts
@@ -1,5 +1,9 @@
 "use node";
 
+/**
+ * Convex action host for the chat example, caching an Eliza runtime and
+ * routing messages through the first configured live model provider.
+ */
 import {
   AgentRuntime,
   ChannelType,

--- a/packages/examples/convex/convex/http.ts
+++ b/packages/examples/convex/convex/http.ts
@@ -1,3 +1,7 @@
+/**
+ * HTTP routes for the Convex chat example, exposing CORS-aware chat and
+ * health endpoints backed by the internal agent action.
+ */
 import { httpRouter } from "convex/server";
 import { api, internal } from "./_generated/api";
 import { httpAction } from "./_generated/server";

--- a/packages/examples/convex/convex/messages.ts
+++ b/packages/examples/convex/convex/messages.ts
@@ -1,3 +1,6 @@
+/**
+ * Convex message and conversation mutations/queries for the chat example.
+ */
 import { v } from "convex/values";
 import { internalMutation, mutation, query } from "./_generated/server";
 

--- a/packages/examples/convex/convex/schema.ts
+++ b/packages/examples/convex/convex/schema.ts
@@ -1,3 +1,6 @@
+/**
+ * Convex schema for persisted chat messages and conversation metadata.
+ */
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 

--- a/packages/examples/moltbook/autonomous.test.ts
+++ b/packages/examples/moltbook/autonomous.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Deterministic coverage for Moltbook autonomous-agent configuration parsing.
+ */
 import { afterEach, describe, expect, test } from "bun:test";
 import { type Config, getConfig, validateConfig } from "./autonomous";
 

--- a/packages/examples/moltbook/autonomous.ts
+++ b/packages/examples/moltbook/autonomous.ts
@@ -1,3 +1,7 @@
+/**
+ * Autonomous Moltbook example agent with a themed character, environment
+ * validation, and bounded posting loop configuration.
+ */
 import "dotenv/config";
 import process from "node:process";
 

--- a/packages/examples/moltbook/bags-claimer.test.ts
+++ b/packages/examples/moltbook/bags-claimer.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Deterministic coverage for top-level Bags fee formatting helpers.
+ */
 import { describe, expect, test } from "bun:test";
 import { formatSol } from "./bags-claimer";
 

--- a/packages/examples/moltbook/bags-claimer/claimer.test.ts
+++ b/packages/examples/moltbook/bags-claimer/claimer.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Deterministic coverage for nested Bags fee formatting helpers.
+ */
 import { describe, expect, test } from "bun:test";
 import { formatSol } from "./claimer";
 

--- a/packages/examples/plugin-echo/src/actions/echo.test.ts
+++ b/packages/examples/plugin-echo/src/actions/echo.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Unit coverage for the echo example action validator and callback result.
+ */
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { echoAction } from "./echo.ts";

--- a/packages/examples/plugin-echo/src/actions/echo.ts
+++ b/packages/examples/plugin-echo/src/actions/echo.ts
@@ -1,3 +1,6 @@
+/**
+ * Echo action implementation for the reference plugin example.
+ */
 import type {
   Action,
   ActionResult,

--- a/packages/examples/plugin-echo/src/index.ts
+++ b/packages/examples/plugin-echo/src/index.ts
@@ -1,3 +1,6 @@
+/**
+ * Reference echo plugin export used by the plugin example and registry docs.
+ */
 import type { Plugin } from "@elizaos/core";
 import { echoAction } from "./actions/echo.ts";
 

--- a/packages/examples/plugin-echo/vitest.config.ts
+++ b/packages/examples/plugin-echo/vitest.config.ts
@@ -1,3 +1,6 @@
+/**
+ * Vitest configuration for the echo plugin example unit tests.
+ */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- add required prose headers to Convex, Moltbook, and plugin-echo example files
- keep the change comment-only; no runtime code tokens changed

## Evidence
- `bun run check:comment-only` — PASS, 12 source files changed and every code token identical to `origin/develop`
- `bunx @biomejs/biome check packages/examples/convex/convex/agent.ts packages/examples/convex/convex/http.ts packages/examples/convex/convex/messages.ts packages/examples/convex/convex/schema.ts packages/examples/moltbook/autonomous.test.ts packages/examples/moltbook/autonomous.ts packages/examples/moltbook/bags-claimer.test.ts packages/examples/moltbook/bags-claimer/claimer.test.ts packages/examples/plugin-echo/src/actions/echo.test.ts packages/examples/plugin-echo/src/actions/echo.ts packages/examples/plugin-echo/src/index.ts packages/examples/plugin-echo/vitest.config.ts` — PASS
- `bun --conditions=eliza-source test packages/examples/moltbook/autonomous.test.ts packages/examples/moltbook/bags-claimer.test.ts packages/examples/moltbook/bags-claimer/claimer.test.ts` — PASS, 4 tests
- `bun run --cwd packages/examples/plugin-echo test` — PASS, 1 file / 3 tests
- `git diff --check origin/develop...HEAD` — PASS

## Root Verify
- `bun run verify` — FAILS outside this change in the Turbo lint lane: `@elizaos/electrobun:lint` reports pre-existing formatting needed in `src/voice/voice-service.test.ts`; command exits 139 after the lint failure. A separate formatter side effect in `packages/core/src/utils/prompt-batcher/batcher.ts` was restored, and `bun run check:comment-only` was rerun successfully afterward.

## Evidence Matrix
- Real-LLM trajectories: N/A - comment-only headers, no agent/action/prompt/model behavior changed
- Backend/frontend logs: N/A - no runtime path changed
- Screenshots/video: N/A - no UI changed
- Domain artifacts: N/A - no generated runtime artifacts changed
