### PR TITLE
chore(#12906): normalize model/inference/embedding/TTS provider plugin scripts

### DIFF
--- a/plugins/plugin-anthropic-proxy/__tests__/auto-enable.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/auto-enable.test.ts
@@ -21,9 +21,7 @@ describe("plugin-anthropic-proxy auto-enable", () => {
   });
 
   it("is case-insensitive and trims whitespace", () => {
-    expect(shouldEnable(ctx({ CLAUDE_MAX_PROXY_MODE: "  INLINE  " }))).toBe(
-      true,
-    );
+    expect(shouldEnable(ctx({ CLAUDE_MAX_PROXY_MODE: "  INLINE  " }))).toBe(true);
     expect(shouldEnable(ctx({ CLAUDE_MAX_PROXY_MODE: "Shared" }))).toBe(true);
   });
 
@@ -47,14 +45,10 @@ describe("plugin-anthropic-proxy auto-enable", () => {
   });
 
   it("ignores ANTHROPIC_BASE_URL (the plugin SETS that, doesn't read it)", () => {
-    expect(
-      shouldEnable(ctx({ ANTHROPIC_BASE_URL: "http://127.0.0.1:18801/v1" })),
-    ).toBe(false);
+    expect(shouldEnable(ctx({ ANTHROPIC_BASE_URL: "http://127.0.0.1:18801/v1" }))).toBe(false);
   });
 
   it("ignores CLAUDE_MAX_CREDENTIALS_PATH alone", () => {
-    expect(
-      shouldEnable(ctx({ CLAUDE_MAX_CREDENTIALS_PATH: "/some/path.json" })),
-    ).toBe(false);
+    expect(shouldEnable(ctx({ CLAUDE_MAX_CREDENTIALS_PATH: "/some/path.json" }))).toBe(false);
   });
 });

--- a/plugins/plugin-anthropic-proxy/__tests__/eliza-fingerprint.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/eliza-fingerprint.test.ts
@@ -183,8 +183,6 @@ describe("eliza fingerprint — patterns", () => {
   });
 
   it("paraphrase preserves muting semantics keyword 'stay quiet'", () => {
-    expect(ELIZA_SYSTEM_CONFIG_PARAPHRASE.toLowerCase()).toContain(
-      "stay quiet",
-    );
+    expect(ELIZA_SYSTEM_CONFIG_PARAPHRASE.toLowerCase()).toContain("stay quiet");
   });
 });

--- a/plugins/plugin-anthropic-proxy/__tests__/entry-exports.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/entry-exports.test.ts
@@ -6,11 +6,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import {
-  DEFAULT_REVERSE_MAP,
-  DEFAULT_TOOL_RENAMES,
-  getStainlessHeaders,
-} from "../index.js";
+import { DEFAULT_REVERSE_MAP, DEFAULT_TOOL_RENAMES, getStainlessHeaders } from "../index.js";
 
 describe("package entry exports (#11496)", () => {
   it("exports getStainlessHeaders returning the CC identity header set", () => {

--- a/plugins/plugin-anthropic-proxy/__tests__/manifest-engine.integration.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/manifest-engine.integration.test.ts
@@ -30,7 +30,7 @@ describe("manifest engine integration: plugin-anthropic-proxy", () => {
   it("reads the manifest and reports enabled=true for CLAUDE_MAX_PROXY_MODE=inline", async () => {
     const verdict = await evaluatePluginManifest(
       candidate,
-      ctxFromEnv({ CLAUDE_MAX_PROXY_MODE: "inline" }),
+      ctxFromEnv({ CLAUDE_MAX_PROXY_MODE: "inline" })
     );
     expect(verdict).not.toBeNull();
     expect(verdict?.enabled).toBe(true);
@@ -40,7 +40,7 @@ describe("manifest engine integration: plugin-anthropic-proxy", () => {
   it("reads the manifest and reports enabled=true for CLAUDE_MAX_PROXY_MODE=shared", async () => {
     const verdict = await evaluatePluginManifest(
       candidate,
-      ctxFromEnv({ CLAUDE_MAX_PROXY_MODE: "shared" }),
+      ctxFromEnv({ CLAUDE_MAX_PROXY_MODE: "shared" })
     );
     expect(verdict?.enabled).toBe(true);
   });
@@ -48,7 +48,7 @@ describe("manifest engine integration: plugin-anthropic-proxy", () => {
   it("reads the manifest and reports enabled=false for CLAUDE_MAX_PROXY_MODE=off", async () => {
     const verdict = await evaluatePluginManifest(
       candidate,
-      ctxFromEnv({ CLAUDE_MAX_PROXY_MODE: "off" }),
+      ctxFromEnv({ CLAUDE_MAX_PROXY_MODE: "off" })
     );
     expect(verdict?.enabled).toBe(false);
     expect(verdict?.error).toBeNull();

--- a/plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts
@@ -5,10 +5,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import {
-  type ProcessBodyConfig,
-  processBody,
-} from "../src/proxy/process-body.js";
+import { type ProcessBodyConfig, processBody } from "../src/proxy/process-body.js";
 
 const baseConfig: ProcessBodyConfig = {
   replacements: [],
@@ -21,10 +18,7 @@ const baseConfig: ProcessBodyConfig = {
   sessionId: "session-test",
 };
 
-function parseProcessed(
-  body: unknown,
-  overrides: Partial<ProcessBodyConfig> = {},
-) {
+function parseProcessed(body: unknown, overrides: Partial<ProcessBodyConfig> = {}) {
   const result = processBody(JSON.stringify(body), {
     ...baseConfig,
     ...overrides,

--- a/plugins/plugin-anthropic-proxy/__tests__/proxy-server.routing.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/proxy-server.routing.test.ts
@@ -44,7 +44,7 @@ function installUpstream(statusCode = 200, body = "{}") {
         return upstream;
       }) as ClientRequest["end"];
       return upstream;
-    },
+    }
   );
 }
 

--- a/plugins/plugin-anthropic-proxy/__tests__/proxy.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/proxy.test.ts
@@ -21,10 +21,7 @@ import { reverseMap } from "../src/proxy/reverse-map.js";
 import { applyReplacements } from "../src/proxy/sanitize.js";
 import { ProxyServer } from "../src/proxy/server.js";
 import { applyQuotedRenames } from "../src/proxy/tool-rename.js";
-import {
-  AnthropicProxyService,
-  resolveConfig,
-} from "../src/services/proxy-service.js";
+import { AnthropicProxyService, resolveConfig } from "../src/services/proxy-service.js";
 import { loadCredentials } from "../src/utils/credentials-loader.js";
 
 // String literals chosen from the eliza-fingerprint dictionaries shipped
@@ -49,10 +46,7 @@ afterEach(async () => {
   }
 });
 
-function withEnv<T>(
-  overrides: Record<string, string | undefined>,
-  fn: () => T,
-): T {
+function withEnv<T>(overrides: Record<string, string | undefined>, fn: () => T): T {
   const prev: Record<string, string | undefined> = {};
   for (const [k, v] of Object.entries(overrides)) {
     prev[k] = process.env[k];
@@ -121,9 +115,7 @@ describe("billing fingerprint", () => {
     expect(a).toBe(b);
     expect(a).toHaveLength(3);
     expect(/^[0-9a-f]{3}$/.test(a)).toBe(true);
-    const c = computeBillingFingerprint(
-      "a completely different prompt body for hashing",
-    );
+    const c = computeBillingFingerprint("a completely different prompt body for hashing");
     expect(c).toHaveLength(3);
     expect([a, c].length).toBe(2);
   });
@@ -132,7 +124,7 @@ describe("billing fingerprint", () => {
 describe("AnthropicProxyService modes", () => {
   it("starts in off mode and does not listen", async () => {
     const service = await withEnv({ CLAUDE_MAX_PROXY_MODE: "off" }, () =>
-      AnthropicProxyService.start({} as unknown as never),
+      AnthropicProxyService.start({} as unknown as never)
     );
     cleanup.push(() => service.stop());
     expect(service.getEffectiveMode()).toBe("off");
@@ -149,20 +141,16 @@ describe("AnthropicProxyService modes", () => {
         res.end();
       }
     });
-    await new Promise<void>((resolve) =>
-      upstream.listen(0, "127.0.0.1", resolve),
-    );
+    await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", resolve));
     const port = (upstream.address() as { port: number }).port;
-    cleanup.push(
-      () => new Promise<void>((resolve) => upstream.close(() => resolve())),
-    );
+    cleanup.push(() => new Promise<void>((resolve) => upstream.close(() => resolve())));
 
     const service = await withEnv(
       {
         CLAUDE_MAX_PROXY_MODE: "shared",
         CLAUDE_MAX_PROXY_UPSTREAM: `http://127.0.0.1:${port}`,
       },
-      () => AnthropicProxyService.start({} as unknown as never),
+      () => AnthropicProxyService.start({} as unknown as never)
     );
     cleanup.push(() => service.stop());
     expect(service.getEffectiveMode()).toBe("shared");
@@ -179,7 +167,7 @@ describe("AnthropicProxyService modes", () => {
         CLAUDE_MAX_PROXY_PORT: "0",
         CLAUDE_CODE_OAUTH_TOKEN: "test-oauth-token-not-real",
       },
-      () => AnthropicProxyService.start({} as unknown as never),
+      () => AnthropicProxyService.start({} as unknown as never)
     );
     cleanup.push(() => service.stop());
 
@@ -198,7 +186,7 @@ describe("AnthropicProxyService modes", () => {
         CLAUDE_MAX_PROXY_AUTH_TOKEN: undefined,
         CLAUDE_CODE_OAUTH_TOKEN: "test-oauth-token-not-real",
       },
-      () => AnthropicProxyService.start({} as unknown as never),
+      () => AnthropicProxyService.start({} as unknown as never)
     );
     cleanup.push(() => service.stop());
     expect(service.getEffectiveMode()).toBe("off");
@@ -211,7 +199,7 @@ describe("AnthropicProxyService modes", () => {
         CLAUDE_MAX_PROXY_MODE: "shared",
         CLAUDE_MAX_PROXY_UPSTREAM: "http://example.com/proxy",
       },
-      () => AnthropicProxyService.start({} as unknown as never),
+      () => AnthropicProxyService.start({} as unknown as never)
     );
     cleanup.push(() => service.stop());
     expect(service.getEffectiveMode()).toBe("off");
@@ -224,7 +212,7 @@ describe("AnthropicProxyService modes", () => {
         CLAUDE_MAX_PROXY_MODE: "sharedd",
         CLAUDE_CODE_OAUTH_TOKEN: "test-oauth-token-not-real",
       },
-      () => AnthropicProxyService.start({} as unknown as never),
+      () => AnthropicProxyService.start({} as unknown as never)
     );
     cleanup.push(() => service.stop());
     expect(service.getEffectiveMode()).toBe("off");
@@ -238,13 +226,9 @@ describe("AnthropicProxyService modes", () => {
       res.writeHead(204);
       res.end();
     });
-    await new Promise<void>((resolve) =>
-      blocker.listen(0, "127.0.0.1", resolve),
-    );
+    await new Promise<void>((resolve) => blocker.listen(0, "127.0.0.1", resolve));
     const port = (blocker.address() as { port: number }).port;
-    cleanup.push(
-      () => new Promise<void>((resolve) => blocker.close(() => resolve())),
-    );
+    cleanup.push(() => new Promise<void>((resolve) => blocker.close(() => resolve())));
     try {
       const service = await withEnv(
         {
@@ -252,7 +236,7 @@ describe("AnthropicProxyService modes", () => {
           CLAUDE_MAX_PROXY_PORT: String(port),
           CLAUDE_CODE_OAUTH_TOKEN: "test-oauth-token-not-real",
         },
-        () => AnthropicProxyService.start({} as unknown as never),
+        () => AnthropicProxyService.start({} as unknown as never)
       );
       cleanup.push(() => service.stop());
       expect(service.getEffectiveMode()).toBe("off");
@@ -300,7 +284,7 @@ describe("ProxyServer auth and URL contracts", () => {
     await expect(
       fetch(`${url}/health`, {
         headers: { Authorization: "Bearer proxy-token" },
-      }),
+      })
     ).resolves.toMatchObject({
       status: 200,
     });
@@ -312,7 +296,7 @@ describe("credentials loader", () => {
     const result = withEnv({ CLAUDE_CODE_OAUTH_TOKEN: undefined }, () =>
       loadCredentials({
         credentialsPath: "/nonexistent/path/that/does/not/exist.json",
-      }),
+      })
     );
     if (result.creds === null) {
       expect(result.error).toBeDefined();
@@ -338,7 +322,7 @@ describe("config resolver", () => {
         CLAUDE_MAX_PROXY_PORT: undefined,
         CLAUDE_MAX_PROXY_BIND_HOST: undefined,
       },
-      () => resolveConfig(),
+      () => resolveConfig()
     );
     expect(cfg.mode).toBe("inline");
     expect(cfg.port).toBe(18801);
@@ -362,7 +346,7 @@ describe("config resolver", () => {
           paraphrase: '{"type":"text","text":"Short framework policy."}',
           minStripLen: 10,
         },
-      }),
+      })
     );
 
     const cfg = withEnv(
@@ -370,14 +354,12 @@ describe("config resolver", () => {
         CLAUDE_MAX_PROXY_CONFIG_PATH: configPath,
         CLAUDE_MAX_PROXY_MODE: "off",
       },
-      () => resolveConfig(),
+      () => resolveConfig()
     );
 
     expect(cfg.configError).toBeUndefined();
     expect(cfg.configPath).toBe(configPath);
-    expect(cfg.fingerprintConfig?.replacements).toEqual([
-      ["framework-A", "framework-B"],
-    ]);
+    expect(cfg.fingerprintConfig?.replacements).toEqual([["framework-A", "framework-B"]]);
     expect(cfg.fingerprintConfig?.systemPromptStrip).toMatchObject({
       start: "FRAMEWORK_START",
       end: "FRAMEWORK_END",
@@ -391,7 +373,7 @@ describe("config resolver", () => {
         CLAUDE_MAX_PROXY_CONFIG_PATH: "/missing/anthropic-proxy-config.json",
         CLAUDE_MAX_PROXY_MODE: "inline",
       },
-      () => resolveConfig(),
+      () => resolveConfig()
     );
     expect(cfg.mode).toBe("inline");
     expect(cfg.configError).toContain("CLAUDE_MAX_PROXY_CONFIG_PATH not found");

--- a/plugins/plugin-anthropic-proxy/__tests__/sse-rewrite.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/sse-rewrite.test.ts
@@ -16,10 +16,10 @@ describe("createSseStream", () => {
       (text) => emitted.push(text),
       () => {
         finished = true;
-      },
+      }
     );
 
-    stream.write(Buffer.from("x".repeat(70) + "ocp", "utf8"));
+    stream.write(Buffer.from(`${"x".repeat(70)}ocp`, "utf8"));
     stream.write(Buffer.from("latform", "utf8"));
     stream.end();
 
@@ -33,7 +33,7 @@ describe("createSseStream", () => {
     const stream = createSseStream(
       (text) => text,
       (text) => emitted.push(text),
-      () => undefined,
+      () => undefined
     );
     const payload = Buffer.from(`data: ${"x".repeat(70)} 中文 🚀\n\n`, "utf8");
     const splitInsideRocket = payload.indexOf(Buffer.from("🚀")) + 2;
@@ -55,7 +55,7 @@ describe("createSseStream", () => {
       (text) => emitted.push(text),
       () => {
         finished = true;
-      },
+      }
     );
 
     stream.end();

--- a/plugins/plugin-anthropic-proxy/biome.json
+++ b/plugins/plugin-anthropic-proxy/biome.json
@@ -1,0 +1,57 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+	"root": false,
+	"files": {
+		"includes": [
+			"auto-enable.ts",
+			"build.ts",
+			"index.ts",
+			"index.browser.ts",
+			"index.node.ts",
+			"vitest.config.ts",
+			"src/**/*.ts",
+			"__tests__/**/*.ts",
+			"!**/*.js",
+			"!**/*.d.ts",
+			"!dist",
+			"!node_modules"
+		]
+	},
+	"assist": {
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"preset": "recommended",
+			"correctness": {
+				"noUnusedVariables": "error"
+			},
+			"a11y": {
+				"useButtonType": "off"
+			},
+			"style": {},
+			"complexity": {
+				"noCommaOperator": "off",
+				"useLiteralKeys": "off"
+			}
+		}
+	},
+	"formatter": {
+		"enabled": true,
+		"indentWidth": 2,
+		"indentStyle": "space",
+		"lineWidth": 100
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double",
+			"trailingCommas": "es5",
+			"semicolons": "always"
+		}
+	}
+}

--- a/plugins/plugin-anthropic-proxy/build.ts
+++ b/plugins/plugin-anthropic-proxy/build.ts
@@ -5,8 +5,7 @@
  */
 import { buildPlugin } from "../plugin-build";
 
-const reexport = (from: string) =>
-  `export * from "${from}";\nexport { default } from "${from}";\n`;
+const reexport = (from: string) => `export * from "${from}";\nexport { default } from "${from}";\n`;
 
 await buildPlugin({
   name: "@elizaos/plugin-anthropic-proxy",

--- a/plugins/plugin-anthropic-proxy/index.browser.ts
+++ b/plugins/plugin-anthropic-proxy/index.browser.ts
@@ -11,8 +11,7 @@ import type { Plugin } from "@elizaos/core";
 
 const anthropicProxyPluginBrowserUnavailable: Plugin = {
   name: "anthropic-proxy",
-  description:
-    "Anthropic proxy (unavailable in browser; only functional in Node environments)",
+  description: "Anthropic proxy (unavailable in browser; only functional in Node environments)",
   services: [],
   actions: [],
   providers: [],

--- a/plugins/plugin-anthropic-proxy/index.ts
+++ b/plugins/plugin-anthropic-proxy/index.ts
@@ -15,11 +15,7 @@
 import { type IAgentRuntime, logger, type Plugin } from "@elizaos/core";
 import { proxyStatusAction } from "./src/actions/proxy-status.action.js";
 import { anthropicProxyRoutes } from "./src/routes/status-route.js";
-import {
-  ANTHROPIC_PROXY_SERVICE_NAME,
-  AnthropicProxyService,
-  resolveConfig,
-} from "./src/services/proxy-service.js";
+import { AnthropicProxyService, resolveConfig } from "./src/services/proxy-service.js";
 
 export { computeBillingFingerprint } from "./src/proxy/billing-fingerprint.js";
 export {
@@ -71,20 +67,15 @@ const anthropicProxyPlugin: Plugin = {
     },
   },
 
-  init: async (
-    _config: Record<string, string>,
-    _runtime: IAgentRuntime,
-  ): Promise<void> => {
+  init: async (_config: Record<string, string>, _runtime: IAgentRuntime): Promise<void> => {
     const cfg = resolveConfig();
     if (cfg.mode === "off") {
-      logger.info(
-        "[anthropic-proxy] init — mode=off (ANTHROPIC_BASE_URL unchanged)",
-      );
+      logger.info("[anthropic-proxy] init — mode=off (ANTHROPIC_BASE_URL unchanged)");
       return;
     }
 
     logger.info(
-      `[anthropic-proxy] init — mode=${cfg.mode}; service start will set ANTHROPIC_BASE_URL after validation`,
+      `[anthropic-proxy] init — mode=${cfg.mode}; service start will set ANTHROPIC_BASE_URL after validation`
     );
   },
 };

--- a/plugins/plugin-anthropic-proxy/package.json
+++ b/plugins/plugin-anthropic-proxy/package.json
@@ -60,6 +60,10 @@
   "scripts": {
     "dev": "bun run build.ts --watch",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo .turbo-tsconfig.json tsconfig.tsbuildinfo",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check . --no-errors-on-unmatched",
     "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "bunx vitest run --config vitest.config.ts",
     "build": "bun run build.ts",

--- a/plugins/plugin-anthropic-proxy/src/actions/proxy-status.action.ts
+++ b/plugins/plugin-anthropic-proxy/src/actions/proxy-status.action.ts
@@ -22,9 +22,7 @@ export const proxyStatusAction: Action = {
   contexts: ["debug", "operations"],
   validate: async () => true,
   handler: async (runtime: IAgentRuntime): Promise<ActionResult> => {
-    const service = runtime.getService<AnthropicProxyService>(
-      ANTHROPIC_PROXY_SERVICE_NAME,
-    );
+    const service = runtime.getService<AnthropicProxyService>(ANTHROPIC_PROXY_SERVICE_NAME);
     if (!service) {
       return {
         success: false,
@@ -43,9 +41,7 @@ export const proxyStatusAction: Action = {
       lines.push(`requests: ${status.stats.requestsServed}`);
       lines.push(`uptime: ${status.stats.uptimeSec}s`);
       if (status.stats.tokenExpiresInHours !== null) {
-        lines.push(
-          `tokenExpiresInHours: ${status.stats.tokenExpiresInHours.toFixed(1)}`,
-        );
+        lines.push(`tokenExpiresInHours: ${status.stats.tokenExpiresInHours.toFixed(1)}`);
       }
       lines.push(`subscription: ${status.stats.subscriptionType ?? "unknown"}`);
     }
@@ -53,7 +49,7 @@ export const proxyStatusAction: Action = {
       lines.push(
         `upstream: reachable=${status.upstream.reachable} ` +
           `status=${status.upstream.status ?? "n/a"}` +
-          (status.upstream.error ? ` error=${status.upstream.error}` : ""),
+          (status.upstream.error ? ` error=${status.upstream.error}` : "")
       );
     }
     return {

--- a/plugins/plugin-anthropic-proxy/src/proxy/billing-fingerprint.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/billing-fingerprint.ts
@@ -9,16 +9,10 @@
  */
 
 import { createHash } from "node:crypto";
-import {
-  BILLING_HASH_INDICES,
-  BILLING_HASH_SALT,
-  CC_VERSION,
-} from "./constants.js";
+import { BILLING_HASH_INDICES, BILLING_HASH_SALT, CC_VERSION } from "./constants.js";
 
 export function computeBillingFingerprint(firstUserText: string): string {
-  const chars = BILLING_HASH_INDICES.map((i) => firstUserText[i] ?? "0").join(
-    "",
-  );
+  const chars = BILLING_HASH_INDICES.map((i) => firstUserText[i] ?? "0").join("");
   const input = `${BILLING_HASH_SALT}${chars}${CC_VERSION}`;
   return createHash("sha256").update(input).digest("hex").slice(0, 3);
 }

--- a/plugins/plugin-anthropic-proxy/src/proxy/cc-tool-injection.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/cc-tool-injection.ts
@@ -44,7 +44,7 @@ export interface ToolSectionResult {
 export function processToolsSection(
   m: string,
   stripDescriptions: boolean,
-  injectSyntheticTools: boolean,
+  injectSyntheticTools: boolean
 ): ToolSectionResult {
   const toolsIdx = m.indexOf('"tools":[');
   if (toolsIdx === -1) {
@@ -80,10 +80,7 @@ export function processToolsSection(
     if (injectSyntheticTools) {
       const insertAt = '"tools":['.length;
       section =
-        section.slice(0, insertAt) +
-        CC_SYNTHETIC_TOOLS.join(",") +
-        "," +
-        section.slice(insertAt);
+        section.slice(0, insertAt) + CC_SYNTHETIC_TOOLS.join(",") + "," + section.slice(insertAt);
       syntheticToolsInjected = CC_SYNTHETIC_TOOLS.length;
     }
     return {
@@ -96,11 +93,7 @@ export function processToolsSection(
   if (injectSyntheticTools) {
     const insertAt = toolsIdx + '"tools":['.length;
     return {
-      body:
-        m.slice(0, insertAt) +
-        CC_SYNTHETIC_TOOLS.join(",") +
-        "," +
-        m.slice(insertAt),
+      body: m.slice(0, insertAt) + CC_SYNTHETIC_TOOLS.join(",") + "," + m.slice(insertAt),
       descriptionsStripped: 0,
       syntheticToolsInjected: CC_SYNTHETIC_TOOLS.length,
     };

--- a/plugins/plugin-anthropic-proxy/src/proxy/eliza-fingerprint.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/eliza-fingerprint.ts
@@ -185,6 +185,5 @@ export const ELIZA_SYSTEM_CONFIG_PARAPHRASE =
   "exception is if a different human in the channel addresses you directly.\\n";
 
 /** Anchor strings used by the Layer 4 strip to locate eliza's boundary. */
-export const ELIZA_IDENTITY_MARKER =
-  "HARD RULE: If a human in this channel told you to be quiet";
+export const ELIZA_IDENTITY_MARKER = "HARD RULE: If a human in this channel told you to be quiet";
 export const ELIZA_BOUNDARY_END = "Bots cannot mute or unmute you.";

--- a/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
@@ -88,10 +88,7 @@ function findMatchingObjectEnd(str: string, start: number): number {
   return -1;
 }
 
-export function processBody(
-  bodyStr: string,
-  config: ProcessBodyConfig,
-): ProcessBodyResult {
+export function processBody(bodyStr: string, config: ProcessBodyConfig): ProcessBodyResult {
   let m = bodyStr;
 
   // Layer 2: String trigger sanitization
@@ -115,7 +112,7 @@ export function processBody(
   const toolResult = processToolsSection(
     m,
     config.stripToolDescriptions !== false,
-    config.injectCCSyntheticTools !== false,
+    config.injectCCSyntheticTools !== false
   );
   m = toolResult.body;
 
@@ -219,8 +216,7 @@ export function processBody(
             stripFrom = i;
             break;
           }
-          if (m[i] !== " " && m[i] !== "\n" && m[i] !== "\r" && m[i] !== "\t")
-            break;
+          if (m[i] !== " " && m[i] !== "\n" && m[i] !== "\r" && m[i] !== "\t") break;
         }
         m = m.slice(0, stripFrom) + m.slice(last.end + 1);
         positions.pop();
@@ -241,10 +237,7 @@ export function processBody(
     }
     const msgsIdx2 = m.indexOf('"messages":[');
     if (msgsIdx2 !== -1) {
-      for (const marker of [
-        '{"type":"thinking"',
-        '{"type":"redacted_thinking"',
-      ]) {
+      for (const marker of ['{"type":"thinking"', '{"type":"redacted_thinking"']) {
         let searchFrom = msgsIdx2;
         while (true) {
           const idx = m.indexOf(marker, searchFrom);

--- a/plugins/plugin-anthropic-proxy/src/proxy/sanitize.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/sanitize.ts
@@ -7,10 +7,7 @@
 
 export type Pair = readonly [string, string];
 
-export function applyReplacements(
-  input: string,
-  pairs: ReadonlyArray<Pair>,
-): string {
+export function applyReplacements(input: string, pairs: ReadonlyArray<Pair>): string {
   let m = input;
   for (const [find, replace] of pairs) {
     // split/join is the algorithm used by proxy.js — preserves byte parity.

--- a/plugins/plugin-anthropic-proxy/src/proxy/server.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/server.ts
@@ -3,17 +3,9 @@
  * from proxy.js v2.2.3 in a controllable Service-friendly object.
  */
 
-import {
-  createServer,
-  type IncomingMessage,
-  type Server,
-  type ServerResponse,
-} from "node:http";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { request as httpsRequest } from "node:https";
-import {
-  type LoadResult,
-  loadCredentials,
-} from "../utils/credentials-loader.js";
+import { type LoadResult, loadCredentials } from "../utils/credentials-loader.js";
 import {
   CC_VERSION,
   DEFAULT_PORT,
@@ -165,7 +157,7 @@ export class ProxyServer {
         server.removeListener("error", reject);
         this.listening = true;
         this.logger.info(
-          `anthropic-proxy listening on http://${this.bindHost}:${this.port} (cc=${CC_VERSION})`,
+          `anthropic-proxy listening on http://${this.bindHost}:${this.port} (cc=${CC_VERSION})`
         );
         resolve();
       });
@@ -187,9 +179,7 @@ export class ProxyServer {
   getUrl(): string {
     const address = this.server?.address();
     const port =
-      address && typeof address === "object" && "port" in address
-        ? address.port
-        : this.port;
+      address && typeof address === "object" && "port" in address ? address.port : this.port;
     return `http://${this.bindHost}:${port}`;
   }
 
@@ -209,9 +199,7 @@ export class ProxyServer {
   private handleRequest(req: IncomingMessage, res: ServerResponse): void {
     if (this.proxyAuthToken && !this.isAuthorized(req)) {
       res.writeHead(401, { "Content-Type": "application/json" });
-      res.end(
-        JSON.stringify({ type: "error", error: { message: "unauthorized" } }),
-      );
+      res.end(JSON.stringify({ type: "error", error: { message: "unauthorized" } }));
       return;
     }
     if (req.url === "/health" && req.method === "GET") {
@@ -232,7 +220,7 @@ export class ProxyServer {
           JSON.stringify({
             type: "error",
             error: { message: credsResult.error ?? "no credentials" },
-          }),
+          })
         );
         return;
       }
@@ -272,11 +260,8 @@ export class ProxyServer {
         headers[k] = v;
       }
 
-      const existingBeta =
-        (headers["anthropic-beta"] as string | undefined) ?? "";
-      const betas = existingBeta
-        ? existingBeta.split(",").map((b) => b.trim())
-        : [];
+      const existingBeta = (headers["anthropic-beta"] as string | undefined) ?? "";
+      const betas = existingBeta ? existingBeta.split(",").map((b) => b.trim()) : [];
       for (const b of REQUIRED_BETAS) {
         if (!betas.includes(b)) betas.push(b);
       }
@@ -284,7 +269,7 @@ export class ProxyServer {
 
       if (this.verbose) {
         this.logger.info(
-          `#${reqNum} ${req.method} ${req.url} (${originalSize}b -> ${body.length}b)`,
+          `#${reqNum} ${req.method} ${req.url} (${originalSize}b -> ${body.length}b)`
         );
       }
 
@@ -330,7 +315,7 @@ export class ProxyServer {
                   reverseMap: this.reverseMapPairs,
                 }),
               (text) => res.write(text),
-              () => res.end(),
+              () => res.end()
             );
             upRes.on("data", (chunk: Buffer) => stream.write(chunk));
             upRes.on("end", () => stream.end());
@@ -351,7 +336,7 @@ export class ProxyServer {
               res.end(respBody);
             });
           }
-        },
+        }
       );
       upstream.on("error", (e) => {
         this.logger.error(`#${reqNum} upstream error: ${(e as Error).message}`);
@@ -361,7 +346,7 @@ export class ProxyServer {
             JSON.stringify({
               type: "error",
               error: { message: (e as Error).message },
-            }),
+            })
           );
         }
       });
@@ -393,12 +378,10 @@ export class ProxyServer {
           requestsServed: stats.requestsServed,
           uptime: `${stats.uptimeSec}s`,
           tokenExpiresInHours:
-            stats.tokenExpiresInHours === null
-              ? "n/a"
-              : stats.tokenExpiresInHours.toFixed(1),
+            stats.tokenExpiresInHours === null ? "n/a" : stats.tokenExpiresInHours.toFixed(1),
           subscriptionType: stats.subscriptionType ?? "unknown",
           layers: stats.layers,
-        }),
+        })
       );
     } catch (e) {
       res.writeHead(500, { "Content-Type": "application/json" });
@@ -406,7 +389,7 @@ export class ProxyServer {
         JSON.stringify({
           status: "error",
           message: (e as Error).message,
-        }),
+        })
       );
     }
   }

--- a/plugins/plugin-anthropic-proxy/src/proxy/sse-rewrite.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/sse-rewrite.ts
@@ -27,7 +27,7 @@ export interface SseStream {
 export function createSseStream(
   reverseFn: ReverseFn,
   emit: (text: string) => void,
-  finish: () => void,
+  finish: () => void
 ): SseStream {
   const decoder = new StringDecoder("utf8");
   let pending = "";

--- a/plugins/plugin-anthropic-proxy/src/proxy/stainless-headers.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/stainless-headers.ts
@@ -9,20 +9,8 @@ import { INSTANCE_SESSION_ID } from "./process-body.js";
 
 export function getStainlessHeaders(): Record<string, string> {
   const p = process.platform;
-  const osName =
-    p === "darwin"
-      ? "macOS"
-      : p === "win32"
-        ? "Windows"
-        : p === "linux"
-          ? "Linux"
-          : p;
-  const arch =
-    process.arch === "x64"
-      ? "x64"
-      : process.arch === "arm64"
-        ? "arm64"
-        : process.arch;
+  const osName = p === "darwin" ? "macOS" : p === "win32" ? "Windows" : p === "linux" ? "Linux" : p;
+  const arch = process.arch === "x64" ? "x64" : process.arch === "arm64" ? "arm64" : process.arch;
   return {
     "user-agent": `claude-cli/${CC_VERSION} (external, cli)`,
     "x-app": "cli",

--- a/plugins/plugin-anthropic-proxy/src/proxy/system-prompt.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/system-prompt.ts
@@ -21,10 +21,7 @@
  */
 
 import { SYSTEM_CONFIG_PARAPHRASE } from "./constants.js";
-import {
-  ELIZA_BOUNDARY_END,
-  ELIZA_IDENTITY_MARKER,
-} from "./eliza-fingerprint.js";
+import { ELIZA_BOUNDARY_END, ELIZA_IDENTITY_MARKER } from "./eliza-fingerprint.js";
 
 const MIN_STRIP_LEN = 200;
 
@@ -56,7 +53,7 @@ const DEFAULT_STRIP_CONFIG: SystemPromptStripConfig = {
 
 export function stripSystemConfig(
   m: string,
-  config: SystemPromptStripConfig = DEFAULT_STRIP_CONFIG,
+  config: SystemPromptStripConfig = DEFAULT_STRIP_CONFIG
 ): {
   body: string;
   stripped: number;

--- a/plugins/plugin-anthropic-proxy/src/proxy/tool-rename.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/tool-rename.ts
@@ -10,10 +10,7 @@
 
 import type { Pair } from "./sanitize.js";
 
-export function applyQuotedRenames(
-  input: string,
-  pairs: ReadonlyArray<Pair>,
-): string {
+export function applyQuotedRenames(input: string, pairs: ReadonlyArray<Pair>): string {
   let m = input;
   for (const [orig, renamed] of pairs) {
     m = m.split(`"${orig}"`).join(`"${renamed}"`);
@@ -25,10 +22,7 @@ export function applyQuotedRenames(
  * Reverse-direction: handles plain ("Name") AND escaped (\"Name\") forms.
  * pairs is the forward map; we reverse it (rename -> orig) on the wire.
  */
-export function applyQuotedRenamesReverse(
-  input: string,
-  pairs: ReadonlyArray<Pair>,
-): string {
+export function applyQuotedRenamesReverse(input: string, pairs: ReadonlyArray<Pair>): string {
   let r = input;
   for (const [orig, renamed] of pairs) {
     r = r.split(`"${renamed}"`).join(`"${orig}"`);

--- a/plugins/plugin-anthropic-proxy/src/routes/status-route.ts
+++ b/plugins/plugin-anthropic-proxy/src/routes/status-route.ts
@@ -4,12 +4,7 @@
  * External health/diagnostic surface for the Anthropic proxy.
  */
 
-import type {
-  IAgentRuntime,
-  Route,
-  RouteRequest,
-  RouteResponse,
-} from "@elizaos/core";
+import type { IAgentRuntime, Route, RouteRequest, RouteResponse } from "@elizaos/core";
 import {
   ANTHROPIC_PROXY_SERVICE_NAME,
   type AnthropicProxyService,
@@ -18,11 +13,9 @@ import {
 async function handleStatus(
   _req: RouteRequest,
   res: RouteResponse,
-  runtime: IAgentRuntime,
+  runtime: IAgentRuntime
 ): Promise<void> {
-  const service = runtime.getService<AnthropicProxyService>(
-    ANTHROPIC_PROXY_SERVICE_NAME,
-  );
+  const service = runtime.getService<AnthropicProxyService>(ANTHROPIC_PROXY_SERVICE_NAME);
   if (!service) {
     res.status(503).json({
       error: "AnthropicProxyService not loaded",

--- a/plugins/plugin-anthropic-proxy/src/services/proxy-service.ts
+++ b/plugins/plugin-anthropic-proxy/src/services/proxy-service.ts
@@ -57,8 +57,7 @@ function isLoopbackHost(host: string): boolean {
 function isPrivateHost(host: string): boolean {
   const normalized = host.trim().toLowerCase();
   if (isLoopbackHost(normalized)) return true;
-  if (normalized.endsWith(".local") || normalized.endsWith(".internal"))
-    return true;
+  if (normalized.endsWith(".local") || normalized.endsWith(".internal")) return true;
   if (/^10\./.test(normalized)) return true;
   if (/^192\.168\./.test(normalized)) return true;
   const match = normalized.match(/^172\.(\d+)\./);
@@ -72,7 +71,7 @@ function validateSharedUpstream(upstream: string): string {
     return upstream.replace(/\/$/, "");
   }
   throw new Error(
-    "CLAUDE_MAX_PROXY_UPSTREAM must use https unless it points to a loopback/private host",
+    "CLAUDE_MAX_PROXY_UPSTREAM must use https unless it points to a loopback/private host"
   );
 }
 
@@ -120,19 +119,11 @@ function readSystemPromptStrip(value: unknown): SystemPromptStripConfig {
     typeof record.paraphrase !== "string" ||
     record.paraphrase.length === 0
   ) {
-    throw new Error(
-      "systemPromptStrip requires non-empty start, end, and paraphrase strings",
-    );
+    throw new Error("systemPromptStrip requires non-empty start, end, and paraphrase strings");
   }
-  const minStripLen =
-    record.minStripLen === undefined ? undefined : Number(record.minStripLen);
-  if (
-    minStripLen !== undefined &&
-    (!Number.isFinite(minStripLen) || minStripLen < 0)
-  ) {
-    throw new Error(
-      "systemPromptStrip.minStripLen must be a non-negative number",
-    );
+  const minStripLen = record.minStripLen === undefined ? undefined : Number(record.minStripLen);
+  if (minStripLen !== undefined && (!Number.isFinite(minStripLen) || minStripLen < 0)) {
+    throw new Error("systemPromptStrip.minStripLen must be a non-negative number");
   }
   return {
     start: record.start,
@@ -200,8 +191,7 @@ function resolveFingerprintConfig(): {
 
 export function resolveConfig(): ProxyServiceConfig {
   const modeRaw = (readEnv("CLAUDE_MAX_PROXY_MODE") ?? "inline").toLowerCase();
-  const validMode =
-    modeRaw === "off" || modeRaw === "shared" || modeRaw === "inline";
+  const validMode = modeRaw === "off" || modeRaw === "shared" || modeRaw === "inline";
   const mode: ProxyMode = validMode ? modeRaw : "off";
 
   const portRaw = readEnv("CLAUDE_MAX_PROXY_PORT");
@@ -236,19 +226,13 @@ export class AnthropicProxyService extends Service {
   private effectiveUrl: string | null = null;
   private startError: string | null = null;
 
-  constructor(runtime?: IAgentRuntime) {
-    super(runtime);
-  }
-
   static async start(runtime: IAgentRuntime): Promise<AnthropicProxyService> {
     const service = new AnthropicProxyService(runtime);
     const config = resolveConfig();
     service.proxyConfig = config;
     if (config.configError) {
       service.startError = config.configError;
-      logger.warn(
-        `[anthropic-proxy] ${service.startError} — falling back to off`,
-      );
+      logger.warn(`[anthropic-proxy] ${service.startError} — falling back to off`);
       service.effectiveMode = "off";
       service.effectiveUrl = null;
       return service;
@@ -264,7 +248,7 @@ export class AnthropicProxyService extends Service {
     if (config.mode === "shared") {
       if (!config.upstream) {
         logger.warn(
-          "[anthropic-proxy] mode=shared but CLAUDE_MAX_PROXY_UPSTREAM not set — falling back to off",
+          "[anthropic-proxy] mode=shared but CLAUDE_MAX_PROXY_UPSTREAM not set — falling back to off"
         );
         service.effectiveMode = "off";
         return service;
@@ -274,16 +258,12 @@ export class AnthropicProxyService extends Service {
         service.effectiveUrl = validateSharedUpstream(config.upstream);
       } catch (e) {
         service.startError = (e as Error).message;
-        logger.warn(
-          `[anthropic-proxy] ${service.startError} — falling back to off`,
-        );
+        logger.warn(`[anthropic-proxy] ${service.startError} — falling back to off`);
         service.effectiveMode = "off";
         return service;
       }
       setAnthropicBaseUrl(service.effectiveUrl);
-      logger.info(
-        `[anthropic-proxy] mode=shared — using upstream ${service.effectiveUrl}`,
-      );
+      logger.info(`[anthropic-proxy] mode=shared — using upstream ${service.effectiveUrl}`);
       return service;
     }
 
@@ -291,9 +271,7 @@ export class AnthropicProxyService extends Service {
     if (!isLoopbackHost(config.bindHost) && !config.proxyAuthToken) {
       service.startError =
         "CLAUDE_MAX_PROXY_AUTH_TOKEN is required when CLAUDE_MAX_PROXY_BIND_HOST is not loopback";
-      logger.warn(
-        `[anthropic-proxy] ${service.startError} — falling back to off`,
-      );
+      logger.warn(`[anthropic-proxy] ${service.startError} — falling back to off`);
       service.effectiveMode = "off";
       return service;
     }
@@ -321,14 +299,12 @@ export class AnthropicProxyService extends Service {
       service.effectiveMode = "inline";
       service.effectiveUrl = server.getUrl();
       setAnthropicBaseUrl(service.effectiveUrl);
-      logger.info(
-        `[anthropic-proxy] mode=inline — listening on ${service.effectiveUrl}`,
-      );
+      logger.info(`[anthropic-proxy] mode=inline — listening on ${service.effectiveUrl}`);
     } catch (e) {
       service.startError = (e as Error).message;
       logger.warn(
         `[anthropic-proxy] failed to start inline proxy (${service.startError}). ` +
-          "Run 'claude auth login' to authenticate. Service will degrade to off mode.",
+          "Run 'claude auth login' to authenticate. Service will degrade to off mode."
       );
       service.effectiveMode = "off";
       service.effectiveUrl = null;
@@ -376,9 +352,7 @@ export class AnthropicProxyService extends Service {
     let stats: ReturnType<ProxyServer["getStats"]> | null = null;
     if (this.server) stats = this.server.getStats();
 
-    let upstream:
-      | { reachable: boolean; status?: number; error?: string }
-      | undefined;
+    let upstream: { reachable: boolean; status?: number; error?: string } | undefined;
     if (this.effectiveMode === "shared" && this.effectiveUrl) {
       try {
         const r = await fetch(`${this.effectiveUrl}/health`, {

--- a/plugins/plugin-anthropic-proxy/src/utils/credentials-loader.ts
+++ b/plugins/plugin-anthropic-proxy/src/utils/credentials-loader.ts
@@ -49,7 +49,7 @@ function jwtExpiresAt(token: string): number {
 }
 
 export function loadCredentials(
-  opts: { credentialsPath?: string; envToken?: string } = {},
+  opts: { credentialsPath?: string; envToken?: string } = {}
 ): LoadResult {
   if (opts.envToken) {
     return {
@@ -69,9 +69,7 @@ export function loadCredentials(
   candidates.push(join(home, ".claude", "credentials.json"));
 
   for (const candidate of candidates) {
-    const resolved = candidate.startsWith("~")
-      ? join(home, candidate.slice(1))
-      : candidate;
+    const resolved = candidate.startsWith("~") ? join(home, candidate.slice(1)) : candidate;
     try {
       if (existsSync(resolved) && statSync(resolved).size > 0) {
         let raw = readFileSync(resolved, "utf8");
@@ -84,7 +82,7 @@ export function loadCredentials(
           };
         };
         const oauth = parsed.claudeAiOauth;
-        if (!oauth || !oauth.accessToken) {
+        if (!oauth?.accessToken) {
           return {
             creds: null,
             error: `credentials file ${resolved} missing claudeAiOauth.accessToken`,

--- a/plugins/plugin-aosp-local-inference/package.json
+++ b/plugins/plugin-aosp-local-inference/package.json
@@ -39,8 +39,10 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc --noCheck -p tsconfig.json --noEmit",
-    "typecheck": "tsgo -p tsconfig.json --noEmit",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo node_modules",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
     "test": "bun test __tests__"

--- a/plugins/plugin-cli-inference/package.json
+++ b/plugins/plugin-cli-inference/package.json
@@ -71,7 +71,7 @@
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "vitest run --config ./vitest.config.ts",
     "test:ts": "vitest run --config ./vitest.config.ts",
     "build": "bun run build.ts"

--- a/plugins/plugin-edge-tts/package.json
+++ b/plugins/plugin-edge-tts/package.json
@@ -84,7 +84,7 @@
     "format:check": "bunx @biomejs/biome format .",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test:e2e": "node ../../packages/app-core/scripts/run-local-plugin-live-smoke.mjs",
     "test:live": "bun run test:e2e"
   },

--- a/plugins/plugin-local-inference/package.json
+++ b/plugins/plugin-local-inference/package.json
@@ -130,7 +130,7 @@
 		"lint:check": "bunx @biomejs/biome check .",
 		"format": "bunx @biomejs/biome format --write .",
 		"format:check": "bunx @biomejs/biome format .",
-		"typecheck": "tsgo --noEmit"
+		"typecheck": "tsgo --noEmit -p tsconfig.json"
 	},
 	"dependencies": {
 		"@elizaos/core": "workspace:*",

--- a/plugins/plugin-openai/package.json
+++ b/plugins/plugin-openai/package.json
@@ -81,7 +81,7 @@
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "vitest run --config ./vitest.config.ts",
     "test:ts": "vitest run --config ./vitest.config.ts",
     "test:harness": "bunx vitest run --config vitest.harness.config.ts",

--- a/plugins/plugin-xai/package.json
+++ b/plugins/plugin-xai/package.json
@@ -71,9 +71,9 @@
     "dev": "bun --hot build.ts",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo",
     "test": "vitest run",
-    "typecheck": "tsgo --noEmit",
-    "lint": "bunx @biomejs/biome check .",
-    "lint:check": "bun run lint",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format ."
   },


### PR DESCRIPTION
Closes #12906

Applies the #12261 verb contract to the model/inference/embedding/TTS provider plugin family only. Scope is limited to these plugins' `package.json` (plus one scoped `biome.json`); no `packages/*`, root `package.json`, or connector plugins were touched.

## Scope (14 plugins)

Model providers: `plugin-anthropic`, `plugin-anthropic-proxy`, `plugin-openai`, `plugin-groq`, `plugin-openrouter`, `plugin-google-genai`, `plugin-ollama`, `plugin-xai`. Local inference: `plugin-local-inference`, `plugin-aosp-local-inference`, `plugin-cli-inference`. Embeddings: `plugin-embeddings`. TTS: `plugin-edge-tts`, `plugin-elevenlabs`.

Deliberately excluded: `plugin-google` / `plugin-google-chat` (Gmail/Drive/Calendar/Meet **connectors**, no `ModelType` handlers), `plugin-native-llama` (owned by the #12261 native-plugin group).

## What changed (verb table)

| Plugin | Change |
|---|---|
| `plugin-anthropic-proxy` | **Added** `lint` / `lint:check` / `format` / `format:check` (had none — never linted). Added a scoped `biome.json` (mirrors `plugin-anthropic`) that lints authored `.ts` only, excluding committed compiled `.js`/`.d.ts` artifacts. |
| `plugin-aosp-local-inference` | **Added** `format` / `format:check`; normalized `typecheck` flag order to `tsgo --noEmit -p tsconfig.json`. |
| `plugin-xai` | **Fixed inverted lint pair**: `lint` now mutates (`check --write --unsafe .`), `lint:check` is read-only (`check .`) instead of `bun run lint`. Pinned `typecheck` to `-p tsconfig.json`. |
| `plugin-openai` | Pinned `typecheck` to `tsgo --noEmit -p tsconfig.json`. |
| `plugin-cli-inference` | Pinned `typecheck` to `tsgo --noEmit -p tsconfig.json`. |
| `plugin-edge-tts` | Pinned `typecheck` to `tsgo --noEmit -p tsconfig.json`. |
| `plugin-local-inference` | Pinned `typecheck` to `tsgo --noEmit -p tsconfig.json`. |
| `plugin-anthropic`, `plugin-groq`, `plugin-openrouter`, `plugin-google-genai`, `plugin-ollama`, `plugin-embeddings`, `plugin-elevenlabs` | Already contract-compliant — no change. |

Real-API lane names (`test:live` / `test:e2e` on `plugin-edge-tts`) preserved. No `\|\| true` / echo-only success bodies. No `@ts-ignore` carpet — **zero real type errors surfaced** once workspace deps were built (the family already typechecks clean).

Two commits: script normalization, then the first-lint biome format churn for `plugin-anthropic-proxy` (separate, per the contract).

## Verification (real runs)

Workspace deps built first (`run-turbo.mjs run build --filter=...`) so `@elizaos/core` etc. resolve; the initial `Cannot find module '@elizaos/core'` failures were purely unbuilt deps, not plugin type errors.

**typecheck + lint:check across all 14 (post-rebase):**
```
plugin-anthropic               typecheck=0  lint:check=0
plugin-anthropic-proxy         typecheck=0  lint:check=0
plugin-openai                  typecheck=0  lint:check=0
plugin-groq                    typecheck=0  lint:check=0
plugin-openrouter              typecheck=0  lint:check=0
plugin-google-genai            typecheck=0  lint:check=0
plugin-ollama                  typecheck=0  lint:check=0
plugin-xai                     typecheck=0  lint:check=0
plugin-local-inference         typecheck=0  lint:check=1  (pre-existing, see below)
plugin-aosp-local-inference    typecheck=0  lint:check=0
plugin-cli-inference           typecheck=0  lint:check=0
plugin-embeddings              typecheck=0  lint:check=0
plugin-edge-tts                typecheck=0  lint:check=0
plugin-elevenlabs              typecheck=0  lint:check=0
```

**`plugin-anthropic-proxy` after biome autofix:** `typecheck` exit 0, `lint:check` exit 0, `test` — 8 files / 54 tests passed.

**`node packages/scripts/ensure-plugin-test-conventions.mjs --check`** — none of the 14 in-scope plugins are flagged. (Guard exits 1 only for `plugin-native-eliza-tasks` and `plugin-social-alpha`, both out-of-scope and unchanged here.)

**`node packages/scripts/audit-build-typecheck.mjs`** — no in-scope plugin flagged. (Sole repo violation is pre-existing `@elizaos/lifeops-bench`, out of scope.)

## Pre-existing blocker (not addressed here)

`plugin-local-inference` `lint:check` exits 1 on a formatting issue in `src/services/voice/__fixtures__/voice-workbench-logic-baseline.json`. The `lint:check` command is byte-identical to `origin/develop` (this PR only changed that plugin's `typecheck` script), so the failure predates this PR and is a test-fixture formatting issue unrelated to script normalization. Fixing it belongs to a lint-churn pass for that plugin, not this verb-normalization PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)