### PR TITLE
fix(#12259): guard phantom turbo overrides

### DIFF
--- a/.github/issue-evidence/12259-phantom-turbo-overrides.md
+++ b/.github/issue-evidence/12259-phantom-turbo-overrides.md
@@ -1,0 +1,32 @@
+# Issue #12259 - phantom Turbo override guard
+
+## Change
+
+- Extended `packages/scripts/audit-turbo-build-deps.mjs` to fail on any `pkg#task` override whose owner package is missing or does not define that script.
+- Extended the dependency-edge audit to scan named `#build` dependencies from all `pkg#task` overrides, including `#typecheck` overrides.
+- Removed 22 dead named `#build` edges from typecheck overrides in `turbo.json`.
+- Added `packages/scripts/audit-turbo-build-deps.self-test.mjs` with a synthetic workspace that fails on missing owner scripts/packages and passes after fixing the fixture.
+
+## Verification
+
+Run on 2026-07-04:
+
+- `node --check packages/scripts/audit-turbo-build-deps.mjs`
+- `node --check packages/scripts/audit-turbo-build-deps.self-test.mjs`
+- `node packages/scripts/audit-turbo-build-deps.self-test.mjs`
+- `node packages/scripts/audit-turbo-build-deps.mjs`
+- `node -e "JSON.parse(require('fs').readFileSync('turbo.json','utf8'));"`
+- `git diff --check`
+- `git diff --check origin/develop..HEAD`
+
+Real audit result:
+
+- No phantom `#build` dependency edges.
+- No phantom `pkg#task` overrides.
+- Residual non-failing output:
+  - 3 undeclared dependency-edge warnings.
+  - 9 redundant override info entries.
+
+## Evidence notes
+
+Screenshots and recordings are N/A: this is a root CLI/Turbo auditor and config cleanup with no user interface.

--- a/packages/scripts/audit-turbo-build-deps.mjs
+++ b/packages/scripts/audit-turbo-build-deps.mjs
@@ -30,9 +30,8 @@ import { fileURLToPath } from "node:url";
 import { listPackages } from "./lib/workspaces.mjs";
 
 const repoRoot = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "..",
-  "..",
+  process.env.AUDIT_TURBO_REPO_ROOT ??
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "..", ".."),
 );
 
 function readJson(p) {
@@ -163,14 +162,39 @@ const ALLOW_OWNERS = new Set([
 const turbo = readJson(path.join(repoRoot, "turbo.json"));
 const tasks = turbo.tasks ?? {};
 
+const phantomTaskOverrides = [];
 const phantoms = [];
 const undeclared = [];
 const redundant = [];
 
 for (const [taskName, def] of Object.entries(tasks)) {
-  if (!taskName.endsWith("#build")) continue;
-  if (taskName === "build") continue; // the generic task, not an override
-  const owner = taskName.slice(0, -"#build".length);
+  const separator = taskName.lastIndexOf("#");
+  if (separator !== -1) {
+    const owner = taskName.slice(0, separator);
+    const scriptName = taskName.slice(separator + 1);
+    const ownerDir = resolvePackageDir(owner);
+    if (!ownerDir) {
+      phantomTaskOverrides.push(
+        `${taskName} — owner package is not a workspace member`,
+      );
+    } else {
+      try {
+        const pkg = readJson(path.join(ownerDir, "package.json"));
+        if (!Object.hasOwn(pkg.scripts ?? {}, scriptName)) {
+          phantomTaskOverrides.push(
+            `${taskName} — owner package does not define script "${scriptName}"`,
+          );
+        }
+      } catch {
+        phantomTaskOverrides.push(
+          `${taskName} — owner package.json could not be read`,
+        );
+      }
+    }
+  }
+
+  if (separator === -1) continue;
+  const owner = taskName.slice(0, separator);
   const deps = def.dependsOn ?? [];
   const named = deps.filter((d) => d.endsWith("#build") && !d.startsWith("^"));
   if (named.length === 0) continue;
@@ -240,4 +264,15 @@ if (phantoms.length) {
   );
   process.exit(1);
 }
+if (phantomTaskOverrides.length) {
+  console.error(
+    `[audit-turbo-build-deps] ${phantomTaskOverrides.length} phantom pkg#task override(s):\n`,
+  );
+  for (const p of phantomTaskOverrides) console.error(`  ✗ ${p}`);
+  console.error(
+    "\nA phantom override names a package task whose owner package does not provide that script.\nRemove the dead turbo.json override or restore the package script.",
+  );
+  process.exit(1);
+}
 console.log("[audit-turbo-build-deps] ✓ no phantom #build dependency edges");
+console.log("[audit-turbo-build-deps] ✓ no phantom pkg#task overrides");

--- a/packages/scripts/audit-turbo-build-deps.self-test.mjs
+++ b/packages/scripts/audit-turbo-build-deps.self-test.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "audit-turbo-build-deps.mjs",
+);
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "turbo-audit-"));
+
+try {
+  writeJson(path.join(tempRoot, "package.json"), {
+    name: "fixture-root",
+    private: true,
+    workspaces: ["packages/*"],
+  });
+  writeJson(path.join(tempRoot, "packages/foo/package.json"), {
+    name: "@fixture/foo",
+    scripts: { build: "echo build" },
+  });
+  writeJson(path.join(tempRoot, "turbo.json"), {
+    tasks: {
+      "@fixture/foo#build": {},
+      "@fixture/foo#typecheck": {},
+      "@fixture/missing#build": {},
+    },
+  });
+
+  const failResult = spawnSync(process.execPath, [scriptPath], {
+    cwd: tempRoot,
+    env: { ...process.env, AUDIT_TURBO_REPO_ROOT: tempRoot },
+    encoding: "utf8",
+  });
+  const failOutput = `${failResult.stdout}\n${failResult.stderr}`;
+  if (failResult.status === 0) {
+    console.error("expected phantom override audit to fail");
+    process.exit(1);
+  }
+  for (const expected of [
+    '@fixture/foo#typecheck — owner package does not define script "typecheck"',
+    "@fixture/missing#build — owner package is not a workspace member",
+  ]) {
+    if (!failOutput.includes(expected)) {
+      console.error(`missing expected audit output: ${expected}`);
+      console.error(failOutput);
+      process.exit(1);
+    }
+  }
+
+  writeJson(path.join(tempRoot, "packages/foo/package.json"), {
+    name: "@fixture/foo",
+    scripts: { build: "echo build", typecheck: "echo typecheck" },
+  });
+  writeJson(path.join(tempRoot, "packages/missing/package.json"), {
+    name: "@fixture/missing",
+    scripts: { build: "echo build" },
+  });
+
+  const passResult = spawnSync(process.execPath, [scriptPath], {
+    cwd: tempRoot,
+    env: { ...process.env, AUDIT_TURBO_REPO_ROOT: tempRoot },
+    encoding: "utf8",
+  });
+  if (passResult.status !== 0) {
+    process.stderr.write(passResult.stderr);
+    process.exit(passResult.status ?? 1);
+  }
+
+  console.log("audit-turbo-build-deps self-test passed");
+} finally {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/turbo.json
+++ b/turbo.json
@@ -339,8 +339,6 @@
       "dependsOn": [
         "@elizaos/core#build",
         "@elizaos/shared#build",
-        "@elizaos/plugin-agent-skills#build",
-        "@elizaos/plugin-app-manager#build",
         "@elizaos/agent#build",
         "^build"
       ],
@@ -350,13 +348,11 @@
       "dependsOn": [
         "@elizaos/plugin-browser#build",
         "@elizaos/plugin-personal-assistant#build",
-        "@elizaos/plugin-registry#build",
         "@elizaos/ui#build"
       ],
       "outputs": []
     },
     "@elizaos/cloud-api#typecheck": {
-      "dependsOn": ["@elizaos/plugin-cloud-apps#build"],
       "outputs": []
     },
     "@elizaos/cloud-shared#typecheck": {
@@ -364,7 +360,7 @@
       "outputs": []
     },
     "@elizaos/plugin-discord#typecheck": {
-      "dependsOn": ["@elizaos/plugin-sql#build", "^build"],
+      "dependsOn": ["^build"],
       "outputs": []
     },
     "@elizaos/plugin-tailscale#typecheck": {
@@ -372,15 +368,6 @@
       "outputs": []
     },
     "@elizaos/plugin-calendar#typecheck": {
-      "dependsOn": [
-        "@elizaos/plugin-app-manager#build",
-        "@elizaos/plugin-browser#build",
-        "@elizaos/plugin-capacitor-bridge#build",
-        "@elizaos/plugin-coding-tools#build",
-        "@elizaos/plugin-registry#build",
-        "@elizaos/plugin-remote-manifest#build",
-        "@elizaos/plugin-task-coordinator#build"
-      ],
       "outputs": []
     },
     "@elizaos/plugin-personal-assistant#typecheck": {
@@ -408,9 +395,6 @@
         "@elizaos/core#build",
         "@elizaos/shared#build",
         "@elizaos/ui#build",
-        "@elizaos/plugin-agent-skills#build",
-        "@elizaos/plugin-app-manager#build",
-        "@elizaos/plugin-task-coordinator#build",
         "^build"
       ],
       "outputs": []
@@ -419,19 +403,12 @@
       "dependsOn": [
         "@elizaos/core#build",
         "@elizaos/shared#build",
-        "@elizaos/plugin-agent-skills#build",
-        "@elizaos/plugin-app-manager#build",
-        "@elizaos/ui#build",
         "^build"
       ],
       "outputs": []
     },
     "@elizaos/example-autonomous#typecheck": {
-      "dependsOn": [
-        "@elizaos/app-core#build",
-        "@elizaos/agent#build",
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "outputs": []
     },
     "@elizaos/example-telegram#typecheck": {
@@ -515,19 +492,11 @@
       "outputs": []
     },
     "@elizaos/plugin-sub-agent-claude-code#typecheck": {
-      "dependsOn": [
-        "@elizaos/plugin-remote-manifest#build",
-        "@elizaos/plugin-worker-runtime#build",
-        "^build"
-      ],
+      "dependsOn": ["@elizaos/plugin-remote-manifest#build", "^build"],
       "outputs": []
     },
     "@elizaos/plugin-local-inference#typecheck": {
-      "dependsOn": [
-        "@elizaos/agent#build",
-        "@elizaos/plugin-task-coordinator#build",
-        "^build"
-      ],
+      "dependsOn": ["@elizaos/agent#build", "^build"],
       "outputs": []
     },
     "@elizaos/example-farcaster#build": {


### PR DESCRIPTION
## Summary
- extend `audit-turbo-build-deps.mjs` to fail on `pkg#task` overrides whose owner package is missing or lacks the script
- extend named `#build` dependency-edge auditing to all `pkg#task` overrides, including `#typecheck`
- remove 22 dead named `#build` edges from typecheck overrides in `turbo.json`
- add a synthetic self-test for the phantom override guard

## Verification
- `node --check packages/scripts/audit-turbo-build-deps.mjs`
- `node --check packages/scripts/audit-turbo-build-deps.self-test.mjs`
- `node packages/scripts/audit-turbo-build-deps.self-test.mjs`
- `node packages/scripts/audit-turbo-build-deps.mjs`
- `node -e "JSON.parse(require('fs').readFileSync('turbo.json','utf8'));"`
- `git diff --check origin/develop..HEAD`

Real audit exits 0 with:
- no phantom `#build` dependency edges
- no phantom `pkg#task` overrides
- residual non-failing output: 3 undeclared-edge warnings, 9 redundant override info entries

## Evidence
- `.github/issue-evidence/12259-phantom-turbo-overrides.md`
- Screenshots/recordings: N/A, CLI/Turbo auditor and config cleanup only.