### PR TITLE
docs(#12901): align package guides with normalized script verbs

### DIFF
--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -93,9 +93,10 @@ bun run --cwd packages/agent start            # bun run src/bin.ts (defaults to 
 bun run --cwd packages/agent dev              # bun --hot src/bin.ts
 bun run --cwd packages/agent typecheck        # tsgo --noEmit -p tsconfig.json
 bun run --cwd packages/agent test             # vitest run --config vitest.config.ts
-bun run --cwd packages/agent lint             # biome check (curated src subdirs)
-bun run --cwd packages/agent lint:fix
-bun run --cwd packages/agent format
+bun run --cwd packages/agent lint             # biome check --write (curated src subdirs)
+bun run --cwd packages/agent lint:check       # biome check read-only
+bun run --cwd packages/agent format           # biome format --write
+bun run --cwd packages/agent format:check     # biome format read-only
 bun run --cwd packages/agent build            # build:dist (tsc --noCheck → prepare-package-dist → rewrite imports)
 bun run --cwd packages/agent build:mobile     # bun scripts/build-mobile-bundle.mjs
 bun run --cwd packages/agent build:ios-bun    # mobile bundle, --target=ios
@@ -143,7 +144,7 @@ supervisor relaunches) — never a silent `process.exit`.
 - `bin.ts` statically imports `node:fs` and pins AOSP/mobile bootstrap symbols onto `globalThis` to defeat tree-shaking in the mobile bundle — do not remove those guards.
 - `core-plugins.ts` splits plugins into blocking vs deferred boot phases; slow feature/provider plugins must stay in the deferred set or boot regresses.
 - Several barrel re-exports avoid duplicate-symbol (`TS2308`) collisions and lazy-load heavy plugins (wallet, app-manager, elizacloud) — read the inline comments in `index.ts`/`api/index.ts`/`services/index.ts` before adding broad `export *` lines.
-- `lint`/`lint:fix` only cover a curated subset of `src/` directories (see the script in `package.json`); `format` covers all of `src`.
+- `lint`/`lint:check` only cover a curated subset of `src/` directories (see the script in `package.json`); `format` covers all of `src`.
 - TEE work (dstack) is gated behind `services/tee-boot-gate*` and validated by `scripts/validate-tee-*.mjs` + `scripts/tee-*-smoke.ts`; see `docs/tee-agent-implementation-plan.md`.
 - **Files / media storage.** Attachment bytes live in one content-addressed store, `api/media-store.ts` (`${STATE_DIR}/media/<sha256>.<ext>`, served pre-auth at `/api/media/<sha256>` with `nosniff` + a download `Content-Disposition` for SVG/active types). `services/file-storage.ts` (`LocalFileStorageService`, fills `ServiceType.REMOTE_FILES`) is the contract the rest of the system resolves via `runtime.getService(ServiceType.REMOTE_FILES)` — `store`/`getUrl`/`list`/`delete`; the authenticated `api/files-routes.ts` (`GET`/`DELETE /api/files`) and the `actions/files.ts` `FILES` agent tool both go through it. `api/media-runtime.ts` rehosts inline `data:` and remote generated-media URLs into the store on the outgoing path (SSRF-guarded) and runs the reference-aware orphan GC (which also counts document `metadata.mediaUrl`). Do NOT add a second file store, a `files` DB table, or a refcount/GC engine — see issue #8876 and the root AGENTS.md anti-pattern clause.
 

--- a/packages/agent/CLAUDE.md
+++ b/packages/agent/CLAUDE.md
@@ -93,9 +93,10 @@ bun run --cwd packages/agent start            # bun run src/bin.ts (defaults to 
 bun run --cwd packages/agent dev              # bun --hot src/bin.ts
 bun run --cwd packages/agent typecheck        # tsgo --noEmit -p tsconfig.json
 bun run --cwd packages/agent test             # vitest run --config vitest.config.ts
-bun run --cwd packages/agent lint             # biome check (curated src subdirs)
-bun run --cwd packages/agent lint:fix
-bun run --cwd packages/agent format
+bun run --cwd packages/agent lint             # biome check --write (curated src subdirs)
+bun run --cwd packages/agent lint:check       # biome check read-only
+bun run --cwd packages/agent format           # biome format --write
+bun run --cwd packages/agent format:check     # biome format read-only
 bun run --cwd packages/agent build            # build:dist (tsc --noCheck → prepare-package-dist → rewrite imports)
 bun run --cwd packages/agent build:mobile     # bun scripts/build-mobile-bundle.mjs
 bun run --cwd packages/agent build:ios-bun    # mobile bundle, --target=ios
@@ -143,7 +144,7 @@ supervisor relaunches) — never a silent `process.exit`.
 - `bin.ts` statically imports `node:fs` and pins AOSP/mobile bootstrap symbols onto `globalThis` to defeat tree-shaking in the mobile bundle — do not remove those guards.
 - `core-plugins.ts` splits plugins into blocking vs deferred boot phases; slow feature/provider plugins must stay in the deferred set or boot regresses.
 - Several barrel re-exports avoid duplicate-symbol (`TS2308`) collisions and lazy-load heavy plugins (wallet, app-manager, elizacloud) — read the inline comments in `index.ts`/`api/index.ts`/`services/index.ts` before adding broad `export *` lines.
-- `lint`/`lint:fix` only cover a curated subset of `src/` directories (see the script in `package.json`); `format` covers all of `src`.
+- `lint`/`lint:check` only cover a curated subset of `src/` directories (see the script in `package.json`); `format` covers all of `src`.
 - TEE work (dstack) is gated behind `services/tee-boot-gate*` and validated by `scripts/validate-tee-*.mjs` + `scripts/tee-*-smoke.ts`; see `docs/tee-agent-implementation-plan.md`.
 - **Files / media storage.** Attachment bytes live in one content-addressed store, `api/media-store.ts` (`${STATE_DIR}/media/<sha256>.<ext>`, served pre-auth at `/api/media/<sha256>` with `nosniff` + a download `Content-Disposition` for SVG/active types). `services/file-storage.ts` (`LocalFileStorageService`, fills `ServiceType.REMOTE_FILES`) is the contract the rest of the system resolves via `runtime.getService(ServiceType.REMOTE_FILES)` — `store`/`getUrl`/`list`/`delete`; the authenticated `api/files-routes.ts` (`GET`/`DELETE /api/files`) and the `actions/files.ts` `FILES` agent tool both go through it. `api/media-runtime.ts` rehosts inline `data:` and remote generated-media URLs into the store on the outgoing path (SSRF-guarded) and runs the reference-aware orphan GC (which also counts document `metadata.mediaUrl`). Do NOT add a second file store, a `files` DB table, or a refcount/GC engine — see issue #8876 and the root AGENTS.md anti-pattern clause.
 

--- a/packages/app-core/AGENTS.md
+++ b/packages/app-core/AGENTS.md
@@ -64,7 +64,7 @@ Run from repo root with `--cwd packages/app-core`:
 - `bun run --cwd packages/app-core typecheck` — `tsgo --noEmit -p tsconfig.json`
 - `bun run --cwd packages/app-core test` — vitest (config `vitest.config.ts`)
 - `bun run --cwd packages/app-core test:auth` — auth/auth-bootstrap/auth-store suites, no file parallelism
-- `bun run --cwd packages/app-core lint` / `lint:fix` / `format` / `format:fix` — Biome
+- `bun run --cwd packages/app-core lint` / `lint:check` / `format` / `format:check` — Biome
 - `bun run --cwd packages/app-core benchmark:server` — action benchmark harness
 - SMS-gateway, flatpak, codesign, and voice scripts are namespaced (`sms-gateway:*`, `build:flatpak*`, `codesign:mas*`, `voice:*`) — see `package.json`.
 

--- a/packages/app-core/CLAUDE.md
+++ b/packages/app-core/CLAUDE.md
@@ -64,7 +64,7 @@ Run from repo root with `--cwd packages/app-core`:
 - `bun run --cwd packages/app-core typecheck` — `tsgo --noEmit -p tsconfig.json`
 - `bun run --cwd packages/app-core test` — vitest (config `vitest.config.ts`)
 - `bun run --cwd packages/app-core test:auth` — auth/auth-bootstrap/auth-store suites, no file parallelism
-- `bun run --cwd packages/app-core lint` / `lint:fix` / `format` / `format:fix` — Biome
+- `bun run --cwd packages/app-core lint` / `lint:check` / `format` / `format:check` — Biome
 - `bun run --cwd packages/app-core benchmark:server` — action benchmark harness
 - SMS-gateway, flatpak, codesign, and voice scripts are namespaced (`sms-gateway:*`, `build:flatpak*`, `codesign:mas*`, `voice:*`) — see `package.json`.
 

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -161,10 +161,10 @@ bun run --cwd packages/shared build:i18n     # regenerate src/i18n/generated/
 bun run --cwd packages/shared build:dist     # tsc only (does not regenerate i18n)
 bun run --cwd packages/shared typecheck      # tsgo --noEmit
 bun run --cwd packages/shared test           # vitest run
-bun run --cwd packages/shared lint           # biome check src
-bun run --cwd packages/shared lint:fix       # biome check --write src
-bun run --cwd packages/shared format         # biome format src (read-only check)
-bun run --cwd packages/shared format:fix     # biome format --write src
+bun run --cwd packages/shared lint           # biome check --write src
+bun run --cwd packages/shared lint:check     # biome check src (read-only)
+bun run --cwd packages/shared format         # biome format --write src
+bun run --cwd packages/shared format:check   # biome format src (read-only)
 bun run --cwd packages/shared clean          # rm -rf dist
 bun run --cwd packages/shared sync           # copy assets to consumer public/ dirs
 ```

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -161,10 +161,10 @@ bun run --cwd packages/shared build:i18n     # regenerate src/i18n/generated/
 bun run --cwd packages/shared build:dist     # tsc only (does not regenerate i18n)
 bun run --cwd packages/shared typecheck      # tsgo --noEmit
 bun run --cwd packages/shared test           # vitest run
-bun run --cwd packages/shared lint           # biome check src
-bun run --cwd packages/shared lint:fix       # biome check --write src
-bun run --cwd packages/shared format         # biome format src (read-only check)
-bun run --cwd packages/shared format:fix     # biome format --write src
+bun run --cwd packages/shared lint           # biome check --write src
+bun run --cwd packages/shared lint:check     # biome check src (read-only)
+bun run --cwd packages/shared format         # biome format --write src
+bun run --cwd packages/shared format:check   # biome format src (read-only)
 bun run --cwd packages/shared clean          # rm -rf dist
 bun run --cwd packages/shared sync           # copy assets to consumer public/ dirs
 ```

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -138,9 +138,9 @@ bun run --cwd packages/ui test:agent-surface-e2e   # agent-surface __e2e__ runne
 bun run --cwd packages/ui test:chat-sheet-e2e      # continuous-chat pull-sheet drag-gesture __e2e__ runner
 bun run --cwd packages/ui test:home-screen-e2e     # home-screen __e2e__ runner
 bun run --cwd packages/ui test:chat-ambient-e2e    # /chat ambient orange-pulse background screenshot __e2e__ runner
-bun run --cwd packages/ui lint                # biome check src
-bun run --cwd packages/ui lint:fix            # biome check --write src
-bun run --cwd packages/ui format / format:fix # biome format
+bun run --cwd packages/ui lint                # biome check --write src
+bun run --cwd packages/ui lint:check          # biome check src (read-only)
+bun run --cwd packages/ui format / format:check # biome format write / read-only
 bun run --cwd packages/ui stories:dev         # Vite stories (stories/vite.config.ts)
 bun run --cwd packages/ui storybook           # Storybook dev server (port 6006)
 bun run --cwd packages/ui build-storybook     # Storybook static build

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -138,9 +138,9 @@ bun run --cwd packages/ui test:agent-surface-e2e   # agent-surface __e2e__ runne
 bun run --cwd packages/ui test:chat-sheet-e2e      # continuous-chat pull-sheet drag-gesture __e2e__ runner
 bun run --cwd packages/ui test:home-screen-e2e     # home-screen __e2e__ runner
 bun run --cwd packages/ui test:chat-ambient-e2e    # /chat ambient orange-pulse background screenshot __e2e__ runner
-bun run --cwd packages/ui lint                # biome check src
-bun run --cwd packages/ui lint:fix            # biome check --write src
-bun run --cwd packages/ui format / format:fix # biome format
+bun run --cwd packages/ui lint                # biome check --write src
+bun run --cwd packages/ui lint:check          # biome check src (read-only)
+bun run --cwd packages/ui format / format:check # biome format write / read-only
 bun run --cwd packages/ui stories:dev         # Vite stories (stories/vite.config.ts)
 bun run --cwd packages/ui storybook           # Storybook dev server (port 6006)
 bun run --cwd packages/ui build-storybook     # Storybook static build


### PR DESCRIPTION
Follow-up to #12943 / #12901. The package.json script normalization removed lint:fix/format:fix aliases and made lint/format mutating with lint:check/format:check as read-only verbs. This updates the affected package-local CLAUDE.md and AGENTS.md command guides so future agents do not follow stale script names.\n\nValidation:\n- cmp verified CLAUDE.md and AGENTS.md remain identical for packages/agent, packages/app-core, packages/shared, and packages/ui.\n- rg verified lint:fix/format:fix are absent from those affected package guides.\n- git diff --check origin/develop...HEAD passed.\n\nN/A: source tests, app audit, screenshots/video; documentation-only follow-up with no runtime or rendered UI behavior.