### PR TITLE
feat(#12284): no-reply loop respects owner reminderIntensity (item 6)

### DIFF
--- a/.github/issue-evidence/12284-reminder-intensity-noreply.md
+++ b/.github/issue-evidence/12284-reminder-intensity-noreply.md
@@ -1,0 +1,72 @@
+# Evidence — #12284 item 6: the spine reads `reminderIntensity`
+
+Advances #12284 (parent #12186). One of the eight items left after #12406: the
+owner's `reminderIntensity` fact (`minimal | normal | persistent |
+high_priority_only`) was stored but **never read by the scheduling spine** — it
+only shaped the legacy `LifeOpsReminderPlan` path (`applyReminderIntensityToPlan`).
+
+## What changed
+
+The tick-driven no-reply follow-up loop now respects owner intensity. The
+correct seam is PA's **no-reply policy** (`defaultNoReplyPolicyFor` /
+`resolveNoReplyPolicy` in `scheduled-task/scheduler.ts`) — *not* the spine's
+escalation ladder, which drives **dispatch-failure** channel advance
+(`applyDispatchPolicy`), a different concern that intensity must not touch.
+
+- New pure module `scheduled-task/no-reply-intensity.ts`:
+  `applyReminderIntensityToNoReplyPolicy(policy, intensity, priority)` mirrors
+  the documented legacy semantics of `applyReminderIntensityToPlan`:
+  - `minimal` → fire once, drop all retries.
+  - `persistent` → one extra nudge at the trailing cadence.
+  - `high_priority_only` → only high-priority tasks keep nudges; others fire once.
+  - `normal` / unset → unchanged.
+- `resolveNoReplyPolicy` applies it to the **default** per-kind policy; an
+  explicit per-task `metadata.noReplyPolicy` override still wins field-by-field.
+- `processDueScheduledTasks` reads `ownerFacts.reminderIntensity` (already loaded
+  each tick) and threads it into `handleCompletionTimeout`.
+
+Grep of `plugin-scheduling`/PA for `reminderIntensity` was previously empty on the
+tick path; it now flows into the no-reply loop.
+
+## Verification
+
+- **Pure unit test** (`no-reply-intensity.test.ts`) — ran locally: **6 passed**.
+  Covers every intensity × priority branch, empty-ladder fallback, and
+  field-preservation.
+
+  ```
+  bun run --cwd plugins/plugin-personal-assistant test src/lifeops/scheduled-task/no-reply-intensity.test.ts
+  → Test Files 1 passed, Tests 6 passed
+  ```
+
+- **Integration test** (`scheduler.no-reply-policy.test.ts`, 4 new cases) — drives
+  the **real** `processDueScheduledTasks` against a real `AgentRuntime` + DB
+  (`createLifeOpsTestRuntime`), sets the owner fact via
+  `OwnerFactStore.setReminderIntensity`, and asserts the real domain artifacts:
+  - `minimal`: a fired reminder times out straight to terminal **skip** (no
+    `no_reply_retry_1`), `noReplyPolicy.maxRetries === 0`.
+  - `persistent`: still retries, `noReplyPolicy.maxRetries === 2`,
+    `retryCadenceMinutes === [60, 60]`.
+  - `high_priority_only` + medium: suppressed to fire-once (`maxRetries 0`).
+  - `high_priority_only` + high: keeps default nudge (`maxRetries 1`).
+
+- **Typecheck**: `bun run --cwd plugins/plugin-personal-assistant typecheck` → exit 0 (clean).
+
+### Local-run note for the integration test
+
+The integration cases exercise the full PA plugin graph, which cannot boot under
+vitest **in this git worktree** — a pre-existing, worktree-wide resolution gap
+(vite can't resolve bare deps like `react/jsx-dev-runtime`, `adze` that live only
+in the parent checkout's `node_modules`; the 4 untouched #11793 cases in the same
+file fail identically). CI's full install runs them. Local proof of the core
+logic is the pure-module test above; the integration test is real code that
+compiles clean and asserts real domain artifacts.
+
+## Evidence rows
+
+| Evidence | Status |
+| --- | --- |
+| Real-LLM trajectory | N/A — this is scheduler-tick task-processing logic, not model/prompt/action behavior. The domain artifacts (no-reply state transitions) are the evidence, asserted in the integration test. |
+| Domain artifacts | ScheduledTask `noReplyPolicy` / `noReplyState` / terminal status transitions — asserted in the integration test. |
+| Backend logs | `[lifeops-scheduled-task]` no-reply retry/terminal paths (integration-driven). |
+| Frontend / screenshots / video | N/A — no UI surface changed. |

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/no-reply-intensity.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/no-reply-intensity.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure-transform coverage for reminder-intensity → no-reply ladder (#12284 D3).
+ * No runtime graph: exercises `applyReminderIntensityToNoReplyPolicy` directly.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  applyReminderIntensityToNoReplyPolicy,
+  type NoReplyLadder,
+} from "./no-reply-intensity.ts";
+
+const base: NoReplyLadder = { maxRetries: 1, retryCadenceMinutes: [60] };
+
+describe("applyReminderIntensityToNoReplyPolicy", () => {
+  it("normal / unset leaves the ladder unchanged", () => {
+    expect(applyReminderIntensityToNoReplyPolicy(base, undefined, "high")).toEqual(
+      base,
+    );
+    expect(applyReminderIntensityToNoReplyPolicy(base, "normal", "high")).toEqual(
+      base,
+    );
+  });
+
+  it("minimal drops every retry (fire once)", () => {
+    expect(applyReminderIntensityToNoReplyPolicy(base, "minimal", "high")).toEqual(
+      { maxRetries: 0, retryCadenceMinutes: [] },
+    );
+  });
+
+  it("persistent appends one nudge at the trailing cadence", () => {
+    expect(
+      applyReminderIntensityToNoReplyPolicy(base, "persistent", "high"),
+    ).toEqual({ maxRetries: 2, retryCadenceMinutes: [60, 60] });
+    // Two-step base → three steps, trailing cadence reused.
+    expect(
+      applyReminderIntensityToNoReplyPolicy(
+        { maxRetries: 2, retryCadenceMinutes: [30, 120] },
+        "persistent",
+        "medium",
+      ),
+    ).toEqual({ maxRetries: 3, retryCadenceMinutes: [30, 120, 120] });
+  });
+
+  it("persistent on an empty ladder falls back to a 60m nudge", () => {
+    expect(
+      applyReminderIntensityToNoReplyPolicy(
+        { maxRetries: 0, retryCadenceMinutes: [] },
+        "persistent",
+        "high",
+      ),
+    ).toEqual({ maxRetries: 1, retryCadenceMinutes: [60] });
+  });
+
+  it("high_priority_only suppresses non-high tasks but keeps high ones", () => {
+    expect(
+      applyReminderIntensityToNoReplyPolicy(base, "high_priority_only", "medium"),
+    ).toEqual({ maxRetries: 0, retryCadenceMinutes: [] });
+    expect(
+      applyReminderIntensityToNoReplyPolicy(base, "high_priority_only", "low"),
+    ).toEqual({ maxRetries: 0, retryCadenceMinutes: [] });
+    expect(
+      applyReminderIntensityToNoReplyPolicy(base, "high_priority_only", "high"),
+    ).toEqual(base);
+  });
+
+  it("preserves the other policy fields it does not own", () => {
+    const rich = {
+      maxRetries: 1,
+      retryCadenceMinutes: [60],
+      terminalStatus: "skipped" as const,
+      sensitive: true,
+    };
+    expect(
+      applyReminderIntensityToNoReplyPolicy(rich, "minimal", "high"),
+    ).toMatchObject({ terminalStatus: "skipped", sensitive: true });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/no-reply-intensity.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/no-reply-intensity.test.ts
@@ -12,18 +12,18 @@ const base: NoReplyLadder = { maxRetries: 1, retryCadenceMinutes: [60] };
 
 describe("applyReminderIntensityToNoReplyPolicy", () => {
   it("normal / unset leaves the ladder unchanged", () => {
-    expect(applyReminderIntensityToNoReplyPolicy(base, undefined, "high")).toEqual(
-      base,
-    );
-    expect(applyReminderIntensityToNoReplyPolicy(base, "normal", "high")).toEqual(
-      base,
-    );
+    expect(
+      applyReminderIntensityToNoReplyPolicy(base, undefined, "high"),
+    ).toEqual(base);
+    expect(
+      applyReminderIntensityToNoReplyPolicy(base, "normal", "high"),
+    ).toEqual(base);
   });
 
   it("minimal drops every retry (fire once)", () => {
-    expect(applyReminderIntensityToNoReplyPolicy(base, "minimal", "high")).toEqual(
-      { maxRetries: 0, retryCadenceMinutes: [] },
-    );
+    expect(
+      applyReminderIntensityToNoReplyPolicy(base, "minimal", "high"),
+    ).toEqual({ maxRetries: 0, retryCadenceMinutes: [] });
   });
 
   it("persistent appends one nudge at the trailing cadence", () => {
@@ -52,7 +52,11 @@ describe("applyReminderIntensityToNoReplyPolicy", () => {
 
   it("high_priority_only suppresses non-high tasks but keeps high ones", () => {
     expect(
-      applyReminderIntensityToNoReplyPolicy(base, "high_priority_only", "medium"),
+      applyReminderIntensityToNoReplyPolicy(
+        base,
+        "high_priority_only",
+        "medium",
+      ),
     ).toEqual({ maxRetries: 0, retryCadenceMinutes: [] });
     expect(
       applyReminderIntensityToNoReplyPolicy(base, "high_priority_only", "low"),

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/no-reply-intensity.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/no-reply-intensity.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure reminder-intensity → no-reply-policy transform (#12284 D3).
+ *
+ * The owner's `reminderIntensity` fact shapes how persistently the tick-driven
+ * no-reply loop re-nudges when the owner does not reply. This is the structural
+ * equivalent, on the ScheduledTask spine, of `applyReminderIntensityToPlan`
+ * (which shapes the legacy reminder-plan steps): the initial fire always
+ * happens; intensity only reshapes the *follow-up* ladder.
+ *
+ * Kept as a standalone pure function so it is unit-testable without booting the
+ * scheduler's runtime graph. `scheduler.ts` calls it against the default
+ * per-kind policy before merging any explicit per-task `metadata.noReplyPolicy`
+ * override (which still wins).
+ */
+import type { ReminderIntensity } from "../owner/fact-store.js";
+
+/** The subset of a no-reply policy that reminder intensity reshapes. */
+export interface NoReplyLadder {
+  maxRetries: number;
+  retryCadenceMinutes: number[];
+}
+
+type TaskPriority = "low" | "medium" | "high";
+
+/**
+ * Reshape a no-reply follow-up ladder by the owner's reminder intensity.
+ *
+ *  - `minimal`: fire once, never re-nudge (drop all retries).
+ *  - `persistent`: one extra nudge at the same trailing cadence (mirrors the
+ *    legacy plan's appended in-app follow-up).
+ *  - `high_priority_only`: only high-priority tasks keep their nudges;
+ *    everything else fires once.
+ *  - `normal` / unset: unchanged.
+ */
+export function applyReminderIntensityToNoReplyPolicy<T extends NoReplyLadder>(
+  policy: T,
+  intensity: ReminderIntensity | undefined,
+  priority: TaskPriority,
+): T {
+  switch (intensity) {
+    case "minimal":
+      return { ...policy, maxRetries: 0, retryCadenceMinutes: [] };
+    case "high_priority_only":
+      return priority === "high"
+        ? policy
+        : { ...policy, maxRetries: 0, retryCadenceMinutes: [] };
+    case "persistent": {
+      const cadence = policy.retryCadenceMinutes;
+      const trailing = cadence.length > 0 ? cadence[cadence.length - 1] : 60;
+      return {
+        ...policy,
+        maxRetries: policy.maxRetries + 1,
+        retryCadenceMinutes: [...cadence, trailing],
+      };
+    }
+    default:
+      return policy;
+  }
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.no-reply-policy.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.no-reply-policy.test.ts
@@ -7,6 +7,7 @@ import {
   createLifeOpsTestRuntime,
   type RealTestRuntimeResult,
 } from "../../../test/helpers/runtime.ts";
+import { resolveOwnerFactStore } from "../owner/fact-store.ts";
 import { LifeOpsRepository } from "../repository.ts";
 import type { ScheduledTask } from "./index.ts";
 import { processDueScheduledTasks } from "./scheduler.ts";
@@ -346,5 +347,145 @@ describe("processDueScheduledTasks — no-reply policy (#11793)", () => {
     const skipped = await repo.getScheduledTask(runtime.agentId, task.taskId);
     expect(skipped?.state.status).toBe("skipped");
     expect(skipped?.metadata?.noReplyPolicy).toBeUndefined();
+  });
+});
+
+describe("processDueScheduledTasks — reminder intensity modulates the no-reply loop (#12284)", () => {
+  const provenance = {
+    source: "policy_action" as const,
+    recordedAt: "2026-05-09T10:00:00.000Z",
+  };
+
+  async function seedFiredReminder(
+    runtime: RealTestRuntimeResult["runtime"],
+    priority: ScheduledTask["priority"],
+  ): Promise<ScheduledTask> {
+    return seedScheduledTask(runtime, {
+      taskId: `st_intensity_${Math.random().toString(36).slice(2, 8)}`,
+      kind: "reminder",
+      promptInstructions: "Take medication.",
+      trigger: { kind: "once", atIso: "2026-05-09T11:00:00.000Z" },
+      priority,
+      respectsGlobalPause: false,
+      source: "user_chat",
+      ownerVisible: true,
+      completionCheck: { kind: "user_acknowledged", followupAfterMinutes: 30 },
+      state: {
+        status: "fired",
+        followupCount: 0,
+        firedAt: "2026-05-09T11:00:00.000Z",
+      },
+    });
+  }
+
+  const timeoutTick = (runtime: RealTestRuntimeResult["runtime"]) =>
+    processDueScheduledTasks({
+      runtime,
+      agentId: runtime.agentId,
+      now: new Date("2026-05-09T11:31:00.000Z"),
+      limit: 5,
+    });
+
+  it("minimal: a fired reminder times out straight to terminal skip, no retry", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const repo = new LifeOpsRepository(runtime);
+    await resolveOwnerFactStore(runtime).setReminderIntensity(
+      { intensity: "minimal" },
+      provenance,
+    );
+    const reminder = await seedFiredReminder(runtime, "high");
+
+    const result = await timeoutTick(runtime);
+
+    expect(result.errors).toEqual([]);
+    // No retry ("no_reply_retry_1"): the first timeout is terminal.
+    expect(result.completionTimeouts).toHaveLength(1);
+    expect(result.completionTimeouts[0]).toMatchObject({
+      taskId: reminder.taskId,
+      status: "skipped",
+    });
+    const skipped = await repo.getScheduledTask(
+      runtime.agentId,
+      reminder.taskId,
+    );
+    expect(skipped?.state.status).toBe("skipped");
+    expect(skipped?.metadata?.noReplyPolicy).toMatchObject({
+      maxRetries: 0,
+      retryCadenceMinutes: [],
+    });
+  });
+
+  it("persistent: a fired reminder earns an extra nudge before terminal (maxRetries 2)", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const repo = new LifeOpsRepository(runtime);
+    await resolveOwnerFactStore(runtime).setReminderIntensity(
+      { intensity: "persistent" },
+      provenance,
+    );
+    const reminder = await seedFiredReminder(runtime, "high");
+
+    const result = await timeoutTick(runtime);
+
+    expect(result.errors).toEqual([]);
+    // Still retries (not terminal), but the policy now carries an extra step.
+    expect(result.completionTimeouts).toHaveLength(1);
+    expect(result.completionTimeouts[0]).toMatchObject({
+      taskId: reminder.taskId,
+      status: "scheduled",
+      reason: "no_reply_retry_1",
+    });
+    const retried = await repo.getScheduledTask(
+      runtime.agentId,
+      reminder.taskId,
+    );
+    expect(retried?.metadata?.noReplyPolicy).toMatchObject({
+      maxRetries: 2,
+      retryCadenceMinutes: [60, 60],
+    });
+  });
+
+  it("high_priority_only: a medium-priority reminder is suppressed to fire-once", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const repo = new LifeOpsRepository(runtime);
+    await resolveOwnerFactStore(runtime).setReminderIntensity(
+      { intensity: "high_priority_only" },
+      provenance,
+    );
+    const reminder = await seedFiredReminder(runtime, "medium");
+
+    const result = await timeoutTick(runtime);
+
+    expect(result.errors).toEqual([]);
+    expect(result.completionTimeouts[0]?.status).toBe("skipped");
+    const skipped = await repo.getScheduledTask(
+      runtime.agentId,
+      reminder.taskId,
+    );
+    expect(skipped?.state.status).toBe("skipped");
+    expect(skipped?.metadata?.noReplyPolicy).toMatchObject({ maxRetries: 0 });
+  });
+
+  it("high_priority_only: a high-priority reminder keeps its default nudge", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const repo = new LifeOpsRepository(runtime);
+    await resolveOwnerFactStore(runtime).setReminderIntensity(
+      { intensity: "high_priority_only" },
+      provenance,
+    );
+    const reminder = await seedFiredReminder(runtime, "high");
+
+    const result = await timeoutTick(runtime);
+
+    expect(result.errors).toEqual([]);
+    expect(result.completionTimeouts[0]?.status).toBe("scheduled");
+    const retried = await repo.getScheduledTask(
+      runtime.agentId,
+      reminder.taskId,
+    );
+    expect(retried?.metadata?.noReplyPolicy).toMatchObject({ maxRetries: 1 });
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
@@ -28,6 +28,7 @@ import {
 } from "@elizaos/plugin-scheduling";
 import {
   ownerFactsToView,
+  type ReminderIntensity,
   resolveOwnerFactStore,
 } from "../owner/fact-store.js";
 import {
@@ -35,6 +36,7 @@ import {
   resolvePendingPromptsStore,
 } from "../pending-prompts/store.js";
 import { LifeOpsRepository } from "../repository.js";
+import { applyReminderIntensityToNoReplyPolicy } from "./no-reply-intensity.js";
 import { getScheduledTaskRunner } from "./service.js";
 
 type NoReplyTerminalStatus = "skipped" | "expired" | "failed";
@@ -244,8 +246,16 @@ function defaultNoReplyPolicyFor(task: ScheduledTask): NoReplyPolicy | null {
   }
 }
 
-function resolveNoReplyPolicy(task: ScheduledTask): NoReplyPolicy | null {
-  const base = defaultNoReplyPolicyFor(task);
+function resolveNoReplyPolicy(
+  task: ScheduledTask,
+  intensity?: ReminderIntensity,
+): NoReplyPolicy | null {
+  const defaultPolicy = defaultNoReplyPolicyFor(task);
+  // Owner intensity shapes the DEFAULT ladder; an explicit per-task
+  // `metadata.noReplyPolicy` override (merged below) still wins field-by-field.
+  const base = defaultPolicy
+    ? applyReminderIntensityToNoReplyPolicy(defaultPolicy, intensity, task.priority)
+    : null;
   const raw = readRecord(
     task.metadata?.noReplyPolicy,
   ) as StoredNoReplyPolicy | null;
@@ -340,9 +350,11 @@ export async function processDueScheduledTasks(
     agentId: request.agentId,
     now: () => request.now,
   });
-  const ownerFacts = ownerFactsToView(
-    await resolveOwnerFactStore(request.runtime).read(),
-  );
+  const ownerFactsRaw = await resolveOwnerFactStore(request.runtime).read();
+  const ownerFacts = ownerFactsToView(ownerFactsRaw);
+  // Owner-wide reminder intensity shapes how persistently the no-reply loop
+  // re-nudges (see `applyReminderIntensityToNoReplyPolicy`).
+  const reminderIntensity = ownerFactsRaw.reminderIntensity?.value;
   const dueContext = {
     now: request.now,
     ownerFacts,
@@ -433,6 +445,7 @@ export async function processDueScheduledTasks(
           runner,
           agentId: request.agentId,
           task,
+          reminderIntensity,
           now: request.now,
           reason: timeout.reason,
         });
@@ -497,8 +510,9 @@ async function handleCompletionTimeout(args: {
   task: ScheduledTask;
   now: Date;
   reason: string;
+  reminderIntensity?: ReminderIntensity;
 }): Promise<{ task: ScheduledTask; reason: string }> {
-  const policy = resolveNoReplyPolicy(args.task);
+  const policy = resolveNoReplyPolicy(args.task, args.reminderIntensity);
   if (!policy) {
     const skipped = await args.runner.apply(args.task.taskId, "skip", {
       reason: args.reason,

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
@@ -254,7 +254,11 @@ function resolveNoReplyPolicy(
   // Owner intensity shapes the DEFAULT ladder; an explicit per-task
   // `metadata.noReplyPolicy` override (merged below) still wins field-by-field.
   const base = defaultPolicy
-    ? applyReminderIntensityToNoReplyPolicy(defaultPolicy, intensity, task.priority)
+    ? applyReminderIntensityToNoReplyPolicy(
+        defaultPolicy,
+        intensity,
+        task.priority,
+      )
     : null;
   const raw = readRecord(
     task.metadata?.noReplyPolicy,


### PR DESCRIPTION
## What & why

Advances #12284 (parent #12186). After #12406 landed the foundational items,
eight remained. This PR closes **item 6**: the owner's `reminderIntensity` fact
(`minimal | normal | persistent | high_priority_only`) was stored but **never
read by the scheduling spine** — it only shaped the legacy `LifeOpsReminderPlan`
path (`applyReminderIntensityToPlan`). A grep of the tick path for
`reminderIntensity` was empty.

## The change

Intensity now shapes the tick-driven **no-reply follow-up loop** — the correct
seam for reminder *persistence*. (Deliberately **not** the spine escalation
ladder: that drives dispatch-**failure** channel advance via
`applyDispatchPolicy`, a delivery concern intensity must not touch.)

- New pure module `scheduled-task/no-reply-intensity.ts` —
  `applyReminderIntensityToNoReplyPolicy(policy, intensity, priority)` mirrors
  the documented legacy semantics of `applyReminderIntensityToPlan`:
  `minimal` drops retries; `persistent` adds one trailing nudge;
  `high_priority_only` suppresses non-high tasks; `normal`/unset unchanged.
- `resolveNoReplyPolicy` applies it to the **default** per-kind policy; an
  explicit per-task `metadata.noReplyPolicy` override still wins field-by-field.
- `processDueScheduledTasks` threads `ownerFacts.reminderIntensity` (already
  loaded each tick) into `handleCompletionTimeout`.

## Verification

- `no-reply-intensity.test.ts` — pure, **6 passed locally** (every intensity ×
  priority branch, empty-ladder fallback, field-preservation).
- `scheduler.no-reply-policy.test.ts` — **4 new integration cases** driving the
  real `processDueScheduledTasks` + real DB (`createLifeOpsTestRuntime`), setting
  the owner fact via `OwnerFactStore.setReminderIntensity`, asserting real
  `noReplyPolicy`/state/terminal artifacts (minimal→skip, persistent→maxRetries 2
  cadence [60,60], high_priority_only→suppress non-high / keep high).
- `bun run --cwd plugins/plugin-personal-assistant typecheck` → exit 0.

Evidence + a note on the worktree-local integration-run limitation:
`.github/issue-evidence/12284-reminder-intensity-noreply.md`.

| Evidence | Status |
| --- | --- |
| Real-LLM trajectory | N/A — scheduler-tick task-processing logic, not model/prompt/action behavior. Domain artifacts are the evidence. |
| Domain artifacts | ScheduledTask `noReplyPolicy`/`noReplyState`/terminal transitions — asserted in the integration test. |
| Frontend / screenshots | N/A — no UI surface changed. |

Relates to #12284, #12186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)