### PR TITLE
chore(#12905): normalize native bridge plugin scripts (typecheck/lint/format)

### DIFF
--- a/plugins/plugin-native-activity-tracker/package.json
+++ b/plugins/plugin-native-activity-tracker/package.json
@@ -25,7 +25,11 @@
     "build": "node ../../packages/scripts/rm-path-recursive.mjs dist && tsc -p tsconfig.json --noCheck",
     "typecheck": "tsgo --noEmit -p tsconfig.json",
     "build:swift": "swiftc -O native/macos/activity-collector.swift -o native/macos/activity-collector",
-    "test": "vitest run"
+    "test": "vitest run",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@elizaos/core": "workspace:*"

--- a/plugins/plugin-native-agent/package.json
+++ b/plugins/plugin-native-agent/package.json
@@ -43,7 +43,12 @@
     "test": "vitest run",
     "prepublishOnly": "bun run build",
     "watch": "tsc --watch",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "devDependencies": {
     "@capacitor/core": "^8.3.1",

--- a/plugins/plugin-native-appblocker/package.json
+++ b/plugins/plugin-native-appblocker/package.json
@@ -35,7 +35,12 @@
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
     "test": "vitest run",
     "prepublishOnly": "bun run build",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "author": "elizaOS",
   "license": "MIT",

--- a/plugins/plugin-native-bun-runtime/package.json
+++ b/plugins/plugin-native-bun-runtime/package.json
@@ -44,7 +44,12 @@
     "test": "vitest run",
     "prepublishOnly": "bun run build",
     "watch": "tsc --watch",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "devDependencies": {
     "@capacitor/core": "^8.3.1",

--- a/plugins/plugin-native-calendar/package.json
+++ b/plugins/plugin-native-calendar/package.json
@@ -48,7 +48,12 @@
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
     "test": "vitest run",
     "prepublishOnly": "bun run build",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "capacitor": {
     "ios": {

--- a/plugins/plugin-native-camera/package.json
+++ b/plugins/plugin-native-camera/package.json
@@ -43,7 +43,12 @@
     "prepublishOnly": "bun run build",
     "test": "vitest run --config vitest.config.ts",
     "watch": "tsc --watch",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "devDependencies": {
     "@capacitor/core": "^8.3.1",

--- a/plugins/plugin-native-canvas/package.json
+++ b/plugins/plugin-native-canvas/package.json
@@ -43,7 +43,12 @@
     "test": "vitest run",
     "prepublishOnly": "bun run build",
     "watch": "tsc --watch",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "devDependencies": {
     "@capacitor/core": "^8.3.1",

--- a/plugins/plugin-native-contacts/package.json
+++ b/plugins/plugin-native-contacts/package.json
@@ -26,7 +26,12 @@
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
     "test": "vitest run",
     "prepublishOnly": "bun run build",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "license": "MIT",
   "capacitor": {

--- a/plugins/plugin-native-desktop/package.json
+++ b/plugins/plugin-native-desktop/package.json
@@ -38,7 +38,12 @@
     "test": "vitest run",
     "prepublishOnly": "bun run build",
     "watch": "tsc --watch",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "devDependencies": {
     "@capacitor/core": "^8.3.1",

--- a/plugins/plugin-native-eliza-tasks/package.json
+++ b/plugins/plugin-native-eliza-tasks/package.json
@@ -41,9 +41,14 @@
     "build": "node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-eliza-tasks -- bun run build:unlocked",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
     "prepublishOnly": "bun run build",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "watch": "tsc --watch",
-    "build:unlocked": "bun run clean && bunx tsc -p tsconfig.json && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && bunx tsc -p tsconfig.json && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "devDependencies": {
     "@capacitor/core": "^8.3.1",

--- a/plugins/plugin-native-gateway/package.json
+++ b/plugins/plugin-native-gateway/package.json
@@ -42,8 +42,8 @@
     "verify:ios": "cd ios && pod install && xcodebuild -workspace Plugin.xcworkspace -scheme Plugin -destination generic/platform=iOS && cd ..",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
     "verify:web": "bun run build",
-    "lint": "bunx @biomejs/biome check . && bash -c 'if command -v swiftlint >/dev/null 2>&1; then bun run swiftlint -- lint; fi'",
-    "lint:check": "bunx @biomejs/biome check .",
+    "lint": "bunx @biomejs/biome check --write --unsafe . && bash -c 'if command -v swiftlint >/dev/null 2>&1; then bun run swiftlint -- lint --fix; fi'",
+    "lint:check": "bunx @biomejs/biome check . && bash -c 'if command -v swiftlint >/dev/null 2>&1; then bun run swiftlint -- lint; fi'",
     "fmt": "bunx @biomejs/biome check --write --unsafe . && bash -c 'if command -v swiftlint >/dev/null 2>&1; then bun run swiftlint -- lint --fix; fi'",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
@@ -55,7 +55,8 @@
     "test": "vitest run",
     "watch": "tsc --watch",
     "prepublishOnly": "bun run build",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.2",

--- a/plugins/plugin-native-llama/package.json
+++ b/plugins/plugin-native-llama/package.json
@@ -36,7 +36,12 @@
     "test": "vitest run --config vitest.config.ts",
     "prepublishOnly": "bun run build",
     "watch": "tsc --watch",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "llama-cpp-capacitor": "^0.1.5"

--- a/plugins/plugin-native-llama/src/capacitor-llama-adapter.ts
+++ b/plugins/plugin-native-llama/src/capacitor-llama-adapter.ts
@@ -1040,7 +1040,9 @@ export class CapacitorLlamaAdapter implements LlamaAdapter {
           "[capacitor-llama] failed to unload after generation error",
           {
             error:
-              unloadErr instanceof Error ? unloadErr.message : String(unloadErr),
+              unloadErr instanceof Error
+                ? unloadErr.message
+                : String(unloadErr),
           },
         );
       }

--- a/plugins/plugin-native-location/package.json
+++ b/plugins/plugin-native-location/package.json
@@ -37,7 +37,12 @@
     "prepublishOnly": "bun run build",
     "test": "vitest run",
     "docgen": "docgen --api LocationPlugin --output-readme README.md --output-json dist/docs.json",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "author": "elizaOS",
   "license": "MIT",

--- a/plugins/plugin-native-macosalarm/package.json
+++ b/plugins/plugin-native-macosalarm/package.json
@@ -47,7 +47,11 @@
     "build:helper": "node scripts/build-helper.mjs",
     "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "vitest run --config vitest.config.ts",
-    "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist bin"
+    "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist bin",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@elizaos/core": "workspace:*"

--- a/plugins/plugin-native-messages/package.json
+++ b/plugins/plugin-native-messages/package.json
@@ -26,7 +26,12 @@
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
     "test": "vitest run",
     "prepublishOnly": "bun run build",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "license": "MIT",
   "capacitor": {

--- a/plugins/plugin-native-mlkit-text/package.json
+++ b/plugins/plugin-native-mlkit-text/package.json
@@ -39,7 +39,12 @@
     "test": "vitest run",
     "prepublishOnly": "bun run build",
     "watch": "tsc --watch",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "devDependencies": {
     "@capacitor/core": "^8.3.1",

--- a/plugins/plugin-native-mobile-agent-bridge/package.json
+++ b/plugins/plugin-native-mobile-agent-bridge/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/elizaOS/eliza"
   },
   "scripts": {
-    "lint": "bunx @biomejs/biome check .",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
     "fmt": "bunx @biomejs/biome check --write --unsafe .",
     "format": "bunx @biomejs/biome format --write .",
@@ -49,7 +49,8 @@
     "test": "vitest run",
     "watch": "tsc --watch",
     "prepublishOnly": "bun run build",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.2",

--- a/plugins/plugin-native-mobile-signals/package.json
+++ b/plugins/plugin-native-mobile-signals/package.json
@@ -46,7 +46,12 @@
     "test": "vitest run",
     "validate:ios-screen-time": "node scripts/validate-ios-screen-time.mjs",
     "watch": "tsc --watch",
-    "build:unlocked": "bun run clean && bunx tsc -p tsconfig.json && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && bunx tsc -p tsconfig.json && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "devDependencies": {
     "@capacitor/core": "^8.3.1",

--- a/plugins/plugin-native-network-policy/package.json
+++ b/plugins/plugin-native-network-policy/package.json
@@ -29,7 +29,12 @@
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
     "test": "vitest run",
     "prepublishOnly": "bun run build",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "license": "MIT",
   "capacitor": {

--- a/plugins/plugin-native-phone/package.json
+++ b/plugins/plugin-native-phone/package.json
@@ -26,7 +26,12 @@
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
     "test": "vitest run",
     "prepublishOnly": "bun run build",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "license": "MIT",
   "capacitor": {

--- a/plugins/plugin-native-reminders/package.json
+++ b/plugins/plugin-native-reminders/package.json
@@ -40,7 +40,11 @@
     "test": "vitest run",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
     "prepublishOnly": "bun run build",
-    "typecheck": "tsgo --noEmit -p tsconfig.json"
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/plugins/plugin-native-screencapture/package.json
+++ b/plugins/plugin-native-screencapture/package.json
@@ -44,7 +44,12 @@
     "test": "vitest run",
     "prepublishOnly": "bun run build",
     "watch": "tsc --watch",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "devDependencies": {
     "@capacitor/core": "^8.3.1",

--- a/plugins/plugin-native-settings/package.json
+++ b/plugins/plugin-native-settings/package.json
@@ -25,12 +25,15 @@
   },
   "scripts": {
     "typecheck": "tsgo --noEmit -p tsconfig.json",
-    "lint": "bunx @biomejs/biome check src",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
     "test": "bunx vitest run --config ./vitest.config.ts",
     "build": "bun run build:js && bun run build:types",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",
-    "build:types": "tsc --noCheck -p tsconfig.build.json"
+    "build:types": "tsc --noCheck -p tsconfig.build.json",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@elizaos/app-core": "workspace:*",

--- a/plugins/plugin-native-settings/tsconfig.json
+++ b/plugins/plugin-native-settings/tsconfig.json
@@ -1,32 +1,25 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "composite": false,
-    "jsx": "react-jsx",
+    "target": "ES2022",
+    "module": "ESNext",
     "moduleResolution": "bundler",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
     "strict": true,
     "strictNullChecks": true,
-    "skipLibCheck": true,
-    "types": ["node", "bun"],
-    "allowImportingTsExtensions": true,
     "noEmit": true,
     "declaration": false,
-    "declarationMap": false,
-    "sourceMap": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": true,
+    "types": ["node", "bun"],
     "paths": {
-      "@elizaos/app-core": ["../../packages/app-core/src/index.ts"],
-      "@elizaos/app-core/*": ["../../packages/app-core/src/*"],
-      "@elizaos/core": ["../../packages/core/src/index.node.ts"],
-      "@elizaos/logger": ["../../packages/logger/src/index.ts"],
-      "@elizaos/logger/*": ["../../packages/logger/src/*"],
-      "@elizaos/plugin-sql": ["../../plugins/plugin-sql/src/index.node.ts"],
-      "@elizaos/ui": ["../../packages/ui/src/index.ts"],
-      "@elizaos/ui/*": ["../../packages/ui/src/*"],
-      "@elizaos/shared": ["../../packages/shared/src/index.ts"],
-      "@elizaos/shared/*": ["../../packages/shared/src/*"],
-      "@elizaos/capacitor-system": [
-        "../../plugins/plugin-native-system/src/index.ts"
-      ],
+      "@elizaos/core": ["../../packages/core/dist/index.d.ts"],
+      "@elizaos/ui": ["../../packages/ui/dist/index.d.ts"],
+      "@elizaos/capacitor-system": ["../plugin-native-system/src/index.ts"],
       "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
       "react/jsx-runtime": [
         "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"
@@ -36,6 +29,14 @@
       ]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts"],
-  "exclude": ["src/**/*.stories.ts", "src/**/*.stories.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.stories.ts",
+    "src/**/*.stories.tsx",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/__tests__/**"
+  ]
 }

--- a/plugins/plugin-native-shared-types/package.json
+++ b/plugins/plugin-native-shared-types/package.json
@@ -8,7 +8,12 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "bun test"
+    "test": "bun test",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "files": [
     "src"

--- a/plugins/plugin-native-shared-types/tsconfig.json
+++ b/plugins/plugin-native-shared-types/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/plugins/plugin-native-swabble/package.json
+++ b/plugins/plugin-native-swabble/package.json
@@ -44,7 +44,12 @@
     "test": "vitest run",
     "prepublishOnly": "bun run build",
     "watch": "tsc --watch",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "devDependencies": {
     "@capacitor/core": "^8.3.1",

--- a/plugins/plugin-native-system/package.json
+++ b/plugins/plugin-native-system/package.json
@@ -26,7 +26,12 @@
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
     "test": "vitest run",
     "prepublishOnly": "bun run build",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "license": "MIT",
   "capacitor": {

--- a/plugins/plugin-native-talkmode/package.json
+++ b/plugins/plugin-native-talkmode/package.json
@@ -37,7 +37,12 @@
     "test": "vitest run",
     "prepublishOnly": "bun run build",
     "docgen": "docgen --api TalkModePlugin --output-readme README.md --output-json dist/docs.json",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "author": "elizaOS",
   "license": "MIT",

--- a/plugins/plugin-native-websiteblocker/package.json
+++ b/plugins/plugin-native-websiteblocker/package.json
@@ -36,7 +36,12 @@
     "test": "vitest run",
     "test:android:manual": "cd android && gradle test",
     "prepublishOnly": "bun run build",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "author": "elizaOS",
   "license": "MIT",

--- a/plugins/plugin-native-wifi/package.json
+++ b/plugins/plugin-native-wifi/package.json
@@ -26,7 +26,12 @@
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
     "test": "vitest run",
     "prepublishOnly": "bun run build",
-    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "license": "MIT",
   "capacitor": {


### PR DESCRIPTION
Closes #12905

Split from #12261. Normalizes the `plugins/plugin-native-*` family (30 plugins) to the settled verb contract so Turbo fan-out runs a **real (non-transit)** `typecheck` / `lint:check` / `format` task per plugin instead of silently skipping it.

## Verb contract applied
- `typecheck` = `tsgo --noEmit -p tsconfig.json` (repo model: tsgo checks, tsc emits)
- `lint` = biome mutating (`check --write --unsafe .`); `lint:check` = read-only (`check .`) — no `|| true`
- `format` / `format:check` = biome format write / read-only
- `test` stays real (no `--passWithNoTests` where real tests exist)

Every native plugin has real TS in `src/`, so **no N/A** — all 30 get a real `typecheck`.

## Per-plugin verb table

| Plugin | verbs added | verbs normalized | other |
|---|---|---|---|
| `plugin-native-activity-tracker` | `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-agent` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-appblocker` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-bun-runtime` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-calendar` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-camera` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-canvas` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-contacts` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-desktop` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-eliza-tasks` | `typecheck` `lint` `lint:check` `format` `format:check` | — | `test`: dropped `--passWithNoTests` (has real tests) |
| `plugin-native-filesystem` | — (already conformant) | — | — |
| `plugin-native-gateway` | `typecheck` | `lint` `lint:check` | biome split fixed; swiftlint tail preserved |
| `plugin-native-llama` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-location` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-macosalarm` | `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-messages` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-mlkit-text` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-mobile-agent-bridge` | `typecheck` | `lint` | biome `lint` made mutating |
| `plugin-native-mobile-signals` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-network-policy` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-phone` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-reminders` | `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-screencapture` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-settings` | `lint:check` `format` `format:check` | `lint` | **tsconfig.json rewritten** (see below) |
| `plugin-native-shared-types` | `typecheck` `lint` `lint:check` `format` `format:check` | — | **new tsconfig.json** (typechecks exported source types) |
| `plugin-native-swabble` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-system` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-talkmode` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-websiteblocker` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |
| `plugin-native-wifi` | `typecheck` `lint` `lint:check` `format` `format:check` | — | — |

**N/A:** none. `plugin-native-filesystem` already had the full standard set and is unchanged.

## tsconfig fixes (real type-error work)
- **`plugin-native-shared-types`** had no tsconfig despite exporting real TS (`main: ./src/index.ts`). Added a minimal `tsconfig.json` so its type contracts are actually checked.
- **`plugin-native-settings`** typecheck tsconfig mapped every `@elizaos/*` dep to **source** (via `extends ../../tsconfig.json`), dragging the entire `@elizaos/ui` + `@elizaos/core` source graph into the check and surfacing 40+ errors that belong to *other, unbuilt* packages (`@elizaos/tui`, `@elizaos/capacitor-*`, `@elizaos/cloud-routing`, a `packages/ui` `AccountWithCredentialFlag` issue). Replaced it with a self-contained config that resolves its three real deps (`@elizaos/core`, `@elizaos/ui` via built dist `.d.ts`; `@elizaos/capacitor-system` via native-system source). Its own `src/` now typechecks clean. Build config (`tsconfig.build.json`) untouched.

The cascade errors seen when running a plugin's `typecheck` standalone against an unbuilt workspace (`Cannot find module '@elizaos/core'`) are resolved once its declared prerequisites build — which is exactly what turbo's `typecheck` task depends on (`@elizaos/core#build`, `@elizaos/ui#build`, …). Verified by building those deps.

## Format churn
Landed as a **separate commit** (`style(#12905): biome format churn`). Only one file needed reformatting (`plugin-native-llama/src/capacitor-llama-adapter.ts`) — format-only, no code-token change, `format --write` (safe) only, no unsafe biome fixes applied.

## Verification
- **typecheck 30/30 green**, **lint:check 30/30 green** across all native plugins (after building `@elizaos/core` + `@elizaos/ui` deps, per the turbo task's declared dependencies).
- `biome lint` (rule-only): **0 errors** across all 30.
- `node packages/scripts/ensure-plugin-test-conventions.mjs --check` — **no native plugin flagged**.
- `node packages/scripts/audit-build-typecheck.mjs` — **no native plugin flagged**.
- `node packages/scripts/audit-turbo-build-deps.mjs` — passes (no phantom edges).
- Turbo dry-run: native plugins now show **35/35 real typecheck tasks** and **30/30 real lint:check tasks** (previously transit nodes).
- Sample `test` runs real: shared-types 4✓, camera 15✓, llama 39✓, eliza-tasks 7✓.

## Pre-existing, out-of-scope (not touched here)
- `packages/lifeops-bench` (`typecheck: tsc --noEmit`) is flagged by `audit-build-typecheck` on `develop` — it's a package, not a native plugin; belongs to the `packages/*` split.
- `plugins/plugin-social-alpha` still carries `--passWithNoTests` on `develop` — connector plugin, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)