### PR TITLE
fix(cloud-api): bootstrap-callback SSH-target mutation guard (#12876, M2)

### DIFF
--- a/packages/cloud/api/__tests__/docker-node-bootstrap-callback.test.ts
+++ b/packages/cloud/api/__tests__/docker-node-bootstrap-callback.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Bootstrap-callback SSH-target immutability (finding M2, #12876 / #12227).
+ *
+ * The bootstrap secret sits in every node's cloud-init user_data, so any single
+ * node compromise leaks it. These tests pin the invariant that a caller holding
+ * only that secret can NOT re-point an existing node's SSH target (hostname /
+ * ssh_user / ssh_port) nor swap its pinned host key — which would let them MITM
+ * the control plane's SSH. The pure `evaluateBootstrap` guard is exercised
+ * directly; the route tests drive the real Hono handler with a mocked repository
+ * to prove the persisted SSH params are never rewritten on a re-bootstrap.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+// Mock the DB/logger before importing the route so loading it never pulls the
+// real repository chain (cloud-shared → core → @elizaos/cloud-routing).
+const BOOTSTRAP_SECRET = "test-bootstrap-secret";
+process.env.CONTAINERS_BOOTSTRAP_SECRET = BOOTSTRAP_SECRET;
+
+const findByNodeId = mock();
+const update = mock();
+const create = mock();
+mock.module("@/db/repositories/docker-nodes", () => ({
+  dockerNodesRepository: { findByNodeId, update, create },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(), info: mock(), warn: mock(), debug: mock() },
+}));
+
+const { default: bootstrapRoute, evaluateBootstrap } = (await import(
+  "../v1/admin/docker-nodes/bootstrap-callback/route"
+)) as typeof import("../v1/admin/docker-nodes/bootstrap-callback/route");
+type BootstrapIdentity = Parameters<typeof evaluateBootstrap>[1];
+
+const EXISTING = {
+  hostname: "node-1.hetzner.example",
+  ssh_port: 22,
+  ssh_user: "root",
+  host_key_fingerprint: "SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+};
+
+const MATCHING_INPUT: BootstrapIdentity = {
+  hostname: EXISTING.hostname,
+  sshPort: EXISTING.ssh_port,
+  sshUser: EXISTING.ssh_user,
+  hostKeyFingerprint: EXISTING.host_key_fingerprint,
+};
+
+describe("evaluateBootstrap", () => {
+  test("fresh node (no existing row) is a create", () => {
+    expect(evaluateBootstrap(null, MATCHING_INPUT)).toEqual({
+      action: "create",
+    });
+  });
+
+  test("identical re-bootstrap of an existing node is a liveness update", () => {
+    expect(evaluateBootstrap(EXISTING, MATCHING_INPUT)).toEqual({
+      action: "update",
+    });
+  });
+
+  test("changing hostname of an existing node is rejected 409", () => {
+    const res = evaluateBootstrap(EXISTING, {
+      ...MATCHING_INPUT,
+      hostname: "attacker.mitm.example",
+    });
+    expect(res).toMatchObject({ action: "reject", status: 409 });
+  });
+
+  test("changing ssh_user of an existing node is rejected 409", () => {
+    const res = evaluateBootstrap(EXISTING, {
+      ...MATCHING_INPUT,
+      sshUser: "mallory",
+    });
+    expect(res).toMatchObject({ action: "reject", status: 409 });
+  });
+
+  test("changing ssh_port of an existing node is rejected 409", () => {
+    const res = evaluateBootstrap(EXISTING, {
+      ...MATCHING_INPUT,
+      sshPort: 2222,
+    });
+    expect(res).toMatchObject({ action: "reject", status: 409 });
+  });
+
+  test("a missing host_key_fingerprint is rejected 400", () => {
+    const res = evaluateBootstrap(null, {
+      ...MATCHING_INPUT,
+      hostKeyFingerprint: "",
+    });
+    expect(res).toMatchObject({ action: "reject", status: 400 });
+  });
+
+  test("swapping an already-pinned host key is rejected 409", () => {
+    const res = evaluateBootstrap(EXISTING, {
+      ...MATCHING_INPUT,
+      hostKeyFingerprint: "SHA256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    });
+    expect(res).toMatchObject({ action: "reject", status: 409 });
+  });
+
+  test("a never-pinned node may set its fingerprint when the SSH target is unchanged", () => {
+    const neverPinned = { ...EXISTING, host_key_fingerprint: null };
+    expect(evaluateBootstrap(neverPinned, MATCHING_INPUT)).toEqual({
+      action: "update",
+    });
+  });
+});
+
+const app = new Hono();
+app.route("/", bootstrapRoute);
+
+function post(body: unknown, secret: string | null = BOOTSTRAP_SECRET) {
+  return app.request("/", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(secret ? { "x-bootstrap-secret": secret } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_BODY = {
+  nodeId: "node-1",
+  hostname: EXISTING.hostname,
+  sshPort: EXISTING.ssh_port,
+  sshUser: EXISTING.ssh_user,
+  hostKeyFingerprint: EXISTING.host_key_fingerprint,
+};
+
+describe("POST /v1/admin/docker-nodes/bootstrap-callback", () => {
+  beforeEach(() => {
+    findByNodeId.mockReset();
+    update.mockReset();
+    create.mockReset();
+  });
+
+  test("rejects a bad secret with 401 and never touches the DB", async () => {
+    const res = await post(VALID_BODY, "wrong-secret");
+    expect(res.status).toBe(401);
+    expect(findByNodeId).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("rejects a fingerprint-less body with 400", async () => {
+    const { hostKeyFingerprint: _drop, ...noFingerprint } = VALID_BODY;
+    const res = await post(noFingerprint);
+    expect(res.status).toBe(400);
+    expect(update).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  test("refuses to re-point an existing node's hostname (409) and does not write", async () => {
+    findByNodeId.mockResolvedValue({ id: "row-1", metadata: {}, ...EXISTING });
+
+    const res = await post({
+      ...VALID_BODY,
+      hostname: "attacker.mitm.example",
+    });
+    const body = (await res.json()) as { success: boolean; error: string };
+
+    expect(res.status).toBe(409);
+    expect(body.success).toBe(false);
+    expect(update).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  test("an allowed re-bootstrap updates liveness WITHOUT rewriting the SSH target", async () => {
+    findByNodeId.mockResolvedValue({ id: "row-1", metadata: {}, ...EXISTING });
+    update.mockResolvedValue({ id: "row-1", ...EXISTING });
+
+    const res = await post(VALID_BODY);
+    expect(res.status).toBe(200);
+
+    expect(update).toHaveBeenCalledTimes(1);
+    const [, patch] = update.mock.calls[0] as [string, Record<string, unknown>];
+    expect(patch).not.toHaveProperty("hostname");
+    expect(patch).not.toHaveProperty("ssh_user");
+    expect(patch).not.toHaveProperty("ssh_port");
+  });
+
+  test("a brand-new node is inserted with its declared SSH target", async () => {
+    findByNodeId.mockResolvedValue(null);
+    create.mockResolvedValue({ id: "row-2", ...EXISTING });
+
+    const res = await post({ ...VALID_BODY, nodeId: "node-2" });
+    expect(res.status).toBe(200);
+
+    expect(create).toHaveBeenCalledTimes(1);
+    const [payload] = create.mock.calls[0] as [Record<string, unknown>];
+    expect(payload).toMatchObject({
+      node_id: "node-2",
+      hostname: EXISTING.hostname,
+      ssh_user: EXISTING.ssh_user,
+      ssh_port: EXISTING.ssh_port,
+    });
+  });
+});

--- a/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
+++ b/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
@@ -15,11 +15,24 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * specified in cloud-init at provision time and stored only in the
  * Hetzner server's user_data, so it leaks no further than that node.
  *
+ * Because that secret sits in every node's user_data, any single node
+ * compromise leaks it — so possession of the secret alone must not let a
+ * caller re-point an existing node's SSH target (that would MITM the control
+ * plane's SSH). The SSH identity (hostname/ssh_user/ssh_port) is therefore
+ * immutable once a node is registered: only a fresh insert may set it, a
+ * host_key_fingerprint is required on every call, and an already-pinned
+ * fingerprint may not be swapped. That decision lives in the pure
+ * `evaluateBootstrap` guard so it is unit-testable without a DB. (finding M2,
+ * #12876 / #12227).
+ *
  * Required env: `CONTAINERS_BOOTSTRAP_SECRET`.
  */
 
 import { z } from "zod";
-import { dockerNodesRepository } from "@/db/repositories/docker-nodes";
+import {
+  type DockerNode,
+  dockerNodesRepository,
+} from "@/db/repositories/docker-nodes";
 import { logger } from "@/lib/utils/logger";
 
 const callbackSchema = z.object({
@@ -28,8 +41,78 @@ const callbackSchema = z.object({
   capacity: z.number().int().min(1).max(64).optional().default(8),
   sshPort: z.number().int().min(1).max(65535).optional().default(22),
   sshUser: z.string().min(1).max(32).optional().default("root"),
-  hostKeyFingerprint: z.string().min(1).max(128).optional(),
+  hostKeyFingerprint: z.string().min(1).max(128),
 });
+
+/** The client-supplied SSH identity a bootstrap call asserts for a node. */
+export type BootstrapIdentity = {
+  hostname: string;
+  sshPort: number;
+  sshUser: string;
+  hostKeyFingerprint: string;
+};
+
+/** The subset of an existing node row the guard compares against. */
+type ExistingNodeIdentity = Pick<
+  DockerNode,
+  "hostname" | "ssh_port" | "ssh_user" | "host_key_fingerprint"
+>;
+
+export type BootstrapDecision =
+  | { action: "reject"; status: 400 | 409; error: string }
+  | { action: "create" }
+  | { action: "update" };
+
+/**
+ * Decide whether a bootstrap-callback POST may register a new node, refresh an
+ * existing node's liveness, or must be rejected — the security core of the
+ * route (finding M2). Pure so the SSH-target-immutability invariant can be
+ * exercised without a live Worker or Postgres.
+ *
+ * Rejections: a missing fingerprint (400); any change to an existing node's
+ * hostname/ssh_user/ssh_port (409); or a fingerprint that differs from an
+ * already-pinned one (409). A never-pinned node (null fingerprint) may set it
+ * on the next call as long as the SSH target is unchanged.
+ */
+export function evaluateBootstrap(
+  existing: ExistingNodeIdentity | null,
+  input: BootstrapIdentity,
+): BootstrapDecision {
+  if (!input.hostKeyFingerprint) {
+    return {
+      action: "reject",
+      status: 400,
+      error: "host_key_fingerprint is required",
+    };
+  }
+  if (!existing) {
+    return { action: "create" };
+  }
+  if (
+    input.hostname !== existing.hostname ||
+    input.sshUser !== existing.ssh_user ||
+    input.sshPort !== existing.ssh_port
+  ) {
+    return {
+      action: "reject",
+      status: 409,
+      error:
+        "SSH target (hostname/ssh_user/ssh_port) of an existing node cannot be changed via bootstrap-callback",
+    };
+  }
+  if (
+    existing.host_key_fingerprint &&
+    existing.host_key_fingerprint !== input.hostKeyFingerprint
+  ) {
+    return {
+      action: "reject",
+      status: 409,
+      error:
+        "host key fingerprint mismatch; refusing to re-pin an existing node",
+    };
+  }
+  return { action: "update" };
+}
 
 async function __hono_POST(request: Request) {
   const expected = process.env.CONTAINERS_BOOTSTRAP_SECRET;
@@ -82,26 +165,40 @@ async function __hono_POST(request: Request) {
 
   try {
     const existing = await dockerNodesRepository.findByNodeId(nodeId);
+    const decision = evaluateBootstrap(existing, {
+      hostname,
+      sshPort,
+      sshUser,
+      hostKeyFingerprint,
+    });
+
+    if (decision.action === "reject") {
+      logger.warn(
+        "[admin/docker-nodes/bootstrap-callback] rejected node mutation",
+        { nodeId, reason: decision.error },
+      );
+      return Response.json(
+        { success: false, error: decision.error },
+        { status: decision.status },
+      );
+    }
+
     if (existing) {
+      // decision.action === "update": the guard proved the SSH target is
+      // unchanged, so we refresh only liveness/capacity and never re-write
+      // hostname/ssh_user/ssh_port.
       const updated = await dockerNodesRepository.update(existing.id, {
-        hostname,
-        ssh_port: sshPort,
-        ssh_user: sshUser,
         capacity,
-        host_key_fingerprint:
-          hostKeyFingerprint ?? existing.host_key_fingerprint,
+        host_key_fingerprint: hostKeyFingerprint,
         status: "unknown",
         metadata: {
-          ...((existing.metadata as Record<string, unknown>) ?? {}),
+          ...(existing.metadata ?? {}),
           lastBootstrapAt: new Date().toISOString(),
         },
       });
       logger.info(
         "[admin/docker-nodes/bootstrap-callback] re-bootstrapped existing node",
-        {
-          nodeId,
-          hostname,
-        },
+        { nodeId },
       );
       return Response.json({
         success: true,


### PR DESCRIPTION
Closes #12876 (finding **M2** of the #12227 Cloud API security review).

## The vulnerability
`POST /api/v1/admin/docker-nodes/bootstrap-callback` authenticates with a shared
`X-Bootstrap-Secret` that lives in **every** node's cloud-init `user_data`, so any
single node compromise leaks it. The route then updated an existing node's
`hostname` / `ssh_port` / `ssh_user` from client-supplied values keyed by
`nodeId`:

```ts
const existing = await dockerNodesRepository.findByNodeId(nodeId);
if (existing) {
  await dockerNodesRepository.update(existing.id, {
    hostname, ssh_port: sshPort, ssh_user: sshUser, ...   // ← attacker-controlled
  });
}
```

A holder of the leaked secret could re-point any node's SSH target to a MITM host
that the control plane then SSHes into.

## The fix (API-route half)
- Extract a **pure `evaluateBootstrap` guard** (unit-testable without a DB) that
  makes an existing node's SSH identity immutable: only a fresh insert may set
  `hostname`/`ssh_user`/`ssh_port`; any change on re-bootstrap is rejected `409`.
- The `host_key_fingerprint` is now **required**, and once pinned it may not be
  swapped (`409`) — trust-on-first-use pinning of the node's host key.
- Re-bootstrap updates **liveness/capacity only** and never rewrites the SSH
  target.

## ⚠️ Deploy-ordering dependency
This is the **API-route half** the issue scopes. The cloud-init
node-registration side (`node-bootstrap.ts`) currently POSTs only
`{nodeId, hostname, capacity}` and does **not** yet send a fingerprint. Teaching
it to report the host key fingerprint is the node-registration concern tracked
under the #12230 hosted-agents sub-issue and must land in tandem so live
bootstraps keep succeeding. Left deliberately out of scope here per the issue's
"own the API-route half" boundary.

## Verification
`node test/run-unit-isolated.mjs docker-node-bootstrap-callback` (process-isolated
`bun test`):

```
13 pass
0 fail
26 expect() calls
```

Coverage (adversarial): SSH-target change on an existing node → `409` with **no**
DB write; fingerprint-less body → `400`; already-pinned fingerprint swap → `409`;
bad secret → `401` with no DB touch; allowed re-bootstrap asserts the update patch
contains **no** `hostname`/`ssh_user`/`ssh_port`; fresh insert persists the
declared SSH target.

`bunx biome check` clean; `tsc --noEmit` clean for the changed files; rebased on
`origin/develop`.

## Evidence
| Type | Status |
|---|---|
| Backend structured logs / route transcripts | test asserts 401/400/409 + no-DB-write on denied paths |
| Adversarial tests | ✅ 13 tests, above |
| UI / frontend | N/A — security/API hardening, no UI path |
| Real-LLM trajectories | N/A — no model/agent/prompt path |
| Audio / voice | N/A — no audio path |