### PR TITLE
fix(#12894): observe speculative speaker match rejections

### DIFF
--- a/.github/issue-evidence/12894-speaker-attribution-rejection.md
+++ b/.github/issue-evidence/12894-speaker-attribution-rejection.md
@@ -1,0 +1,37 @@
+# Issue #12894 - Speculative Speaker Attribution Rejection
+
+## Change
+
+- `VoiceProfileStore.beginMatch()` now observes the eager `result` promise immediately while returning the same promise unchanged.
+- `VoiceAttributionPipeline.beginTurn()` regression coverage uses a fake speaker encoder whose `encode()` rejects after the first speculative window is pushed.
+
+## Manual Review
+
+- Reviewed the `beginMatch()` promise path by hand: the added `catch` is side-effect-only, so abandoned handles no longer emit `unhandledRejection`, while explicit `await handle.result` still receives the original rejection.
+- Reviewed the new regression assertion: it records `process.on("unhandledRejection")`, abandons the speculative handle through the pipeline path, flushes the event loop, asserts no unhandled rejection, then verifies `speculativeMatch.result` still rejects with the encoder failure.
+
+## Verification
+
+```bash
+bun install --no-save --ignore-scripts --cache-dir "$HOME/.bun-install-cache-deploy"
+node packages/scripts/ensure-workspace-symlinks.mjs
+node packages/shared/scripts/generate-keywords.mjs --target ts
+bun run --cwd packages/contracts build
+bun run --cwd packages/cloud/routing build
+bun run --cwd plugins/plugin-local-inference test src/services/voice/speaker/attribution-pipeline.incremental.test.ts __tests__/voice-profile-store.test.ts
+bun run --cwd plugins/plugin-local-inference typecheck
+git diff --check
+```
+
+Results:
+
+- Focused Vitest: 2 files passed, 28 tests passed.
+- `plugins/plugin-local-inference` typecheck: passed.
+- `git diff --check`: passed.
+
+## Evidence N/A
+
+- Real audio capture: N/A - no audio device, native encoder, diarizer, or capture path changed.
+- Hardware/mobile/desktop capture: N/A - no platform bridge or UI surface changed.
+- Screenshots/video/frontend logs: N/A - non-UI runtime regression.
+- Real-LLM trajectories: N/A - no model prompt/action/provider behavior changed.

--- a/plugins/plugin-local-inference/src/services/voice/profile-store.ts
+++ b/plugins/plugin-local-inference/src/services/voice/profile-store.ts
@@ -469,6 +469,9 @@ export class VoiceProfileStore {
 				if (args.signal) args.signal.removeEventListener("abort", onAbort);
 			}
 		})();
+		// `result` is returned unchanged; this only observes abandoned speculative
+		// handles so their encoder/store failures do not hit process-level handlers.
+		void result.catch(() => undefined);
 		return {
 			result,
 			current: () => current,

--- a/plugins/plugin-local-inference/src/services/voice/speaker/attribution-pipeline.incremental.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/speaker/attribution-pipeline.incremental.test.ts
@@ -77,6 +77,10 @@ function makeDiarizer(): Diarizer & { inputs: number[] } {
 	};
 }
 
+async function flushPromises(): Promise<void> {
+	await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
 afterEach(() => {
 	stores.length = 0;
 });
@@ -221,5 +225,44 @@ describe("VoiceAttributionPipeline windowed long turns", () => {
 		// Exactly one diarizer decode — the whole (sub-window) turn.
 		expect(diarizer.inputs).toEqual([shortPcm.length]);
 		expect(out.observation).not.toBeNull();
+	});
+
+	it("observes abandoned speculative encoder failures without changing result rejection", async () => {
+		const unhandled: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			unhandled.push(reason);
+		};
+		const encoder: SpeakerEncoder = {
+			embeddingDim: 256,
+			sampleRate: SR,
+			modelId: MODEL,
+			async encode() {
+				throw new Error("speculative encoder failed");
+			},
+			async dispose() {},
+		};
+		const pipeline = new VoiceAttributionPipeline({
+			encoder,
+			diarizer: makeDiarizer(),
+			profileStore: await freshStore(),
+		});
+
+		process.on("unhandledRejection", onUnhandledRejection);
+		try {
+			const attributor = pipeline.beginTurn({
+				turnId: "t-spec-reject",
+				startedAtMs: 0,
+			});
+			await attributor.pushWindow(new Float32Array(WINDOW_SAMPLES), 0);
+			await flushPromises();
+			await flushPromises();
+
+			expect(unhandled).toEqual([]);
+			await expect(attributor.speculativeMatch.result).rejects.toThrow(
+				"speculative encoder failed",
+			);
+		} finally {
+			process.off("unhandledRejection", onUnhandledRejection);
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- Observe `VoiceProfileStore.beginMatch()` eager result promises immediately, while returning the same promise unchanged for downstream awaiters.
- Add a `VoiceAttributionPipeline.beginTurn()` regression with a rejecting fake speaker encoder that asserts no `unhandledRejection` is emitted for an abandoned speculative handle.
- Add issue evidence under `.github/issue-evidence/12894-speaker-attribution-rejection.md`.

## Verification
- `bun install --no-save --ignore-scripts --cache-dir "$HOME/.bun-install-cache-deploy"`
- `node packages/scripts/ensure-workspace-symlinks.mjs`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/contracts build`
- `bun run --cwd packages/cloud/routing build`
- `bun run --cwd plugins/plugin-local-inference test src/services/voice/speaker/attribution-pipeline.incremental.test.ts __tests__/voice-profile-store.test.ts`
- `bun run --cwd plugins/plugin-local-inference typecheck`
- `git diff --check origin/develop..HEAD`

## Evidence
- `.github/issue-evidence/12894-speaker-attribution-rejection.md`
- Real audio capture: N/A - no audio device, native encoder, diarizer, or capture path changed.
- Hardware/mobile/desktop capture: N/A - no platform bridge or UI surface changed.
- Screenshots/video/frontend logs: N/A - non-UI runtime regression.
- Real-LLM trajectories: N/A - no model prompt/action/provider behavior changed.

Fixes #12894