### PR TITLE
chore(#12907): normalize connector plugin scripts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3397,6 +3397,7 @@
         "@biomejs/biome": "2.5.2",
         "@types/node": "^25.0.3",
         "typescript": "^6.0.3",
+        "vitest": "^4.1.4",
       },
       "peerDependencies": {
         "@elizaos/core": "workspace:*",

--- a/plugins/plugin-bluebubbles/package.json
+++ b/plugins/plugin-bluebubbles/package.json
@@ -47,7 +47,7 @@
     "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsgo --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/plugins/plugin-bluesky/package.json
+++ b/plugins/plugin-bluesky/package.json
@@ -49,7 +49,7 @@
     "dev": "bun --hot build.ts",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo",
     "test": "vitest run",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",

--- a/plugins/plugin-discord-local/package.json
+++ b/plugins/plugin-discord-local/package.json
@@ -60,7 +60,8 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.2",
     "@types/node": "^25.0.3",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.4"
   },
   "scripts": {
     "dev": "bun --hot build.ts",
@@ -70,6 +71,7 @@
     "lint:check": "bunx @biomejs/biome check --config-path ./biome.json .",
     "build": "bun run build.ts",
     "build:ts": "bun run build.ts",
+    "test": "vitest run",
     "format": "bunx @biomejs/biome format --write --config-path ./biome.json .",
     "format:check": "bunx @biomejs/biome format --config-path ./biome.json ."
   },

--- a/plugins/plugin-discord/package.json
+++ b/plugins/plugin-discord/package.json
@@ -49,7 +49,7 @@
 		"clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo && node ../../packages/scripts/clean-stray-dts.mjs",
 		"test": "vitest run",
 		"test:harness": "vitest run --config ./vitest.harness.config.ts",
-		"typecheck": "tsgo --noEmit",
+		"typecheck": "tsgo --noEmit -p tsconfig.json",
 		"lint": "bunx @biomejs/biome check --write --unsafe .",
 		"lint:check": "bunx @biomejs/biome check .",
 		"format": "bunx @biomejs/biome format --write .",

--- a/plugins/plugin-farcaster/package.json
+++ b/plugins/plugin-farcaster/package.json
@@ -73,7 +73,6 @@
     "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "npx -y vitest@4.0.18 run",
     "test:unit": "npx -y vitest@4.0.18 run __tests__",
-    "test:integration": "echo 'No integration tests'",
     "test:watch": "vitest",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",

--- a/plugins/plugin-feishu/package.json
+++ b/plugins/plugin-feishu/package.json
@@ -64,7 +64,7 @@
 		"format:check": "bunx @biomejs/biome format .",
 		"lint:check": "bunx @biomejs/biome check .",
 		"build:ts": "bun run build",
-		"typecheck": "tsgo --noEmit"
+		"typecheck": "tsgo --noEmit -p tsconfig.json"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/plugins/plugin-google-chat/package.json
+++ b/plugins/plugin-google-chat/package.json
@@ -53,7 +53,7 @@
     "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsgo --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/plugins/plugin-imessage/package.json
+++ b/plugins/plugin-imessage/package.json
@@ -48,7 +48,7 @@
     "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsgo --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/plugins/plugin-instagram/package.json
+++ b/plugins/plugin-instagram/package.json
@@ -54,7 +54,7 @@
     "format:check": "bunx @biomejs/biome format .",
     "lint:check": "bunx @biomejs/biome check .",
     "build:ts": "bun run build",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsgo --noEmit -p tsconfig.json"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/plugin-line/package.json
+++ b/plugins/plugin-line/package.json
@@ -39,7 +39,7 @@
     "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsgo --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/plugins/plugin-matrix/package.json
+++ b/plugins/plugin-matrix/package.json
@@ -47,7 +47,7 @@
     "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsgo --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "fake-indexeddb": "^6.2.5",

--- a/plugins/plugin-nostr/package.json
+++ b/plugins/plugin-nostr/package.json
@@ -52,7 +52,7 @@
     "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsgo --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/plugins/plugin-signal/package.json
+++ b/plugins/plugin-signal/package.json
@@ -64,7 +64,7 @@
     "dev": "bun --hot build.ts",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo",
     "test": "vitest run",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",

--- a/plugins/plugin-slack/package.json
+++ b/plugins/plugin-slack/package.json
@@ -63,7 +63,7 @@
     "dev": "bun --hot build.ts",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo",
     "test": "vitest run",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",

--- a/plugins/plugin-telegram-standalone/package.json
+++ b/plugins/plugin-telegram-standalone/package.json
@@ -71,6 +71,7 @@
     "build": "bun run build.ts",
     "build:ts": "bun run build.ts",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "vitest run",
     "lint": "bunx @biomejs/biome check --write --config-path ./biome.json .",
     "lint:check": "bunx @biomejs/biome check --config-path ./biome.json .",

--- a/plugins/plugin-telegram/package.json
+++ b/plugins/plugin-telegram/package.json
@@ -52,8 +52,9 @@
     "vitest": "^4.0.0"
   },
   "scripts": {
-    "build": "tsup && tsc --project tsconfig.build.json",
+    "build": "tsup && tsc --project tsconfig.build.json --noCheck",
     "dev": "tsup --watch",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "vitest run",
     "test:harness": "bunx vitest run --config vitest.harness.config.ts",
     "test:watch": "vitest",

--- a/plugins/plugin-twitch/package.json
+++ b/plugins/plugin-twitch/package.json
@@ -48,7 +48,7 @@
     "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsgo --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@twurple/auth": "^8.0.0",

--- a/plugins/plugin-wechat/package.json
+++ b/plugins/plugin-wechat/package.json
@@ -51,9 +51,13 @@
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck --outDir dist --rootDir src",
-    "check": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "vitest run --config ./vitest.config.ts",
     "test:watch": "vitest --config ./vitest.config.ts",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist"
   },
   "peerDependencies": {

--- a/plugins/plugin-wechat/src/index.ts
+++ b/plugins/plugin-wechat/src/index.ts
@@ -12,6 +12,7 @@ import {
   type IAgentRuntime,
   type Memory,
   type MessageConnectorTarget,
+  type Plugin,
   stringToUuid,
   type TargetInfo,
   type UUID,
@@ -47,28 +48,6 @@ export function isWechatConnectorConfigured(
   }
 
   return false;
-}
-
-export interface Plugin {
-  name: string;
-  description: string;
-  init?: (
-    config: Record<string, unknown>,
-    runtime: unknown,
-  ) => Promise<void | (() => Promise<void>)>;
-  dispose?: () => Promise<void> | void;
-  /**
-   * Declarative auto-enable conditions consumed by the runtime's
-   * plugin-auto-enable engine. Mirrors the shape on `@elizaos/core` Plugin.
-   */
-  autoEnable?: {
-    envKeys?: string[];
-    connectorKeys?: string[];
-    shouldEnable?: (
-      env: Record<string, string | undefined>,
-      config: Record<string, unknown>,
-    ) => boolean;
-  };
 }
 
 let channel: WechatChannel | null = null;
@@ -381,7 +360,7 @@ const wechatPlugin: Plugin = {
     connectorKeys: ["wechat"],
   },
 
-  async init(config: Record<string, unknown>, runtime: unknown) {
+  async init(config: Record<string, string>, runtime: IAgentRuntime) {
     try {
       const manager = getConnectorAccountManager(runtime as IAgentRuntime);
       manager.registerProvider(
@@ -426,15 +405,6 @@ const wechatPlugin: Plugin = {
     await channel.start();
     registerWechatMessageConnector(runtime, wechatConfig);
     console.log("[wechat] Plugin initialized");
-
-    // Return cleanup function
-    return async () => {
-      if (channel) {
-        await channel.stop();
-        channel = null;
-        console.log("[wechat] Plugin stopped");
-      }
-    };
   },
   async dispose() {
     if (channel) {

--- a/plugins/plugin-x/package.json
+++ b/plugins/plugin-x/package.json
@@ -66,7 +66,7 @@
     "prepack": "bun run build",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo .turbo-tsconfig.json tsconfig.tsbuildinfo",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format ."


### PR DESCRIPTION
Closes #12907

Applies the #12261 standard verb contract to the connector / social plugin family only. No `packages/*`, root, or model-plugin scripts touched.

## Verb contract applied
`test` (real, can fail), `typecheck` = `tsgo --noEmit -p tsconfig.json`, mutating `lint`, read-only `lint:check`, `format` / `format:check`, `build` where artifacts are emitted. Live smoke lanes (`test:e2e` / `test:live` / `test:harness`) preserved, never renamed to a generic no-op `test`. No `|| true` / echo-only success bodies.

## Per-plugin changes
| plugin | change |
|---|---|
| bluebubbles, bluesky, discord, feishu, google-chat, imessage, instagram, line, matrix, nostr, signal, slack, twitch, x (14) | `typecheck` normalized `tsgo --noEmit` → `tsgo --noEmit -p tsconfig.json` |
| plugin-wechat | replaced nonstandard `check: tsc --noEmit` with `typecheck: tsgo --noEmit -p tsconfig.json`; added `lint`/`lint:check`/`format`/`format:check`. Surfaced type error fixed by deleting a hand-rolled local `Plugin` interface (drifted from `@elizaos/core`, missing `connectorSources`) and using the canonical `@elizaos/core` `Plugin` type; dropped the redundant init-return cleanup (identical to `dispose()`, unused by the loader) |
| plugin-telegram | added `typecheck`; added `--noCheck` to the build's `tsc` declaration emit so it stops double-type-checking (tsgo checks, tsc emits) |
| plugin-telegram-standalone | added missing `typecheck` |
| plugin-discord-local | added a real `test` (`vitest run`) — it had a route-level e2e vitest suite but no test verb — plus the `vitest` dev dep |
| plugin-farcaster | removed the `test:integration` echo-noop (no integration tests; `test` runs the real suite) |
| plugin-whatsapp | already compliant — untouched |

## Coverage matrix (after)
All 20 connectors: `test` `typecheck` `lint` `lint:check` `format` `format:check` `build` = ✓. discord + telegram retain `test:e2e` / `test:live` / `test:harness`.

## Verification
Typecheck deps (`@elizaos/core` + turbo `typecheck` dependsOn set) built first, then:

- `typecheck` — green for all 20 connectors.
- `lint:check` — green for all 20 connectors (0 format churn → no separate format commit needed).
- `test` — verified real & passing on the modified/unit-testable plugins: wechat (5), discord-local (11), farcaster (48), telegram-standalone (6), bluebubbles (27), google-chat (11), instagram (4), line (98), matrix (35), signal (28), twitch (47).
- `packages/scripts/audit-build-typecheck.mjs` — no violation in any touched connector.
- `packages/scripts/ensure-plugin-test-conventions.mjs --check` — no would-change in any touched connector.
- `bun run audit:error-policy-ratchet` — green (wechat `src/index.ts`: emptyCatch 0→0, serverConsole 0→0).
- telegram `build` re-verified: emits `dist/index.d.ts` with `--noCheck`.

## Pre-existing blockers (out of scope, not introduced here)
- `plugin-imessage` `test` fails one suite (`__tests__/integration.test.ts`: `No "BaseMessageAdapter" export is defined on the "@elizaos/core" mock`) — a test-mock drift on `develop`; my change to imessage is only the one-line `typecheck` normalization.
- `audit-build-typecheck` flags `@elizaos/lifeops-bench` (a `packages/*` benchmark) and `ensure-plugin-test-conventions` flags `plugin-native-eliza-tasks` / `plugin-social-alpha` — all non-connectors owned by sibling #12261 splits; present at the merge base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)