### PR TITLE
fix(#12895): release fused-EOT voice-budget reservation on failed arm

### DIFF
--- a/plugins/plugin-local-inference/src/services/engine.ts
+++ b/plugins/plugin-local-inference/src/services/engine.ts
@@ -1399,268 +1399,284 @@ export class LocalInferenceEngine {
 					});
 		const semanticEotActive = fusedEot !== null;
 
-		const vad =
-			opts.vad ??
-			(await vadMod.createSileroVadDetector({
-				bundleRoot: bridge.bundlePath(),
-				ffi: bridge.ffi,
-				ctx: bridge.ffi
-					? () => {
-							const ctx = bridge.ffiCtx;
-							if (ctx === null) {
-								throw new VoiceStartupError(
-									"missing-ffi",
-									"[voice] Cannot initialize native VAD: fused FFI context is not loaded.",
-								);
+		// The fused-EOT reservation (8 MB voice-budget) is only released via the
+		// `controller.stop` teardown wired at the end of this method. Any await
+		// between the build above and that wiring can throw (ASR-unavailable,
+		// turn-detector warm failure, wake-word/mic startup) — without this guard
+		// the reservation would leak against the process-wide budget on a failed
+		// arm (#12895). Dispose is idempotent, so the success path still owns it
+		// through `controller.stop`.
+		try {
+			const vad =
+				opts.vad ??
+				(await vadMod.createSileroVadDetector({
+					bundleRoot: bridge.bundlePath(),
+					ffi: bridge.ffi,
+					ctx: bridge.ffi
+						? () => {
+								const ctx = bridge.ffiCtx;
+								if (ctx === null) {
+									throw new VoiceStartupError(
+										"missing-ffi",
+										"[voice] Cannot initialize native VAD: fused FFI context is not loaded.",
+									);
+								}
+								return ctx;
 							}
-							return ctx;
-						}
-					: undefined,
-				config: { semanticEotActive },
-			}));
-		logger.info(
-			`[LocalInferenceEngine] voice endpoint: endHangoverMs=${vad.endHangoverMs} (${
-				semanticEotActive
-					? "fused semantic EOT active"
-					: "fixed-VAD floor — fused semantic EOT unavailable"
-			})`,
-		);
-
-		// ASR — throws `AsrUnavailableError` when the fused decoder is
-		// unavailable (the fused build is the sole on-device ASR runtime). Gated
-		// on the VAD so silent frames aren't decoded.
-		const transcriber = bridge.createStreamingTranscriber({ vad });
-		// Voice Wave 2 (2026-05-14): tier-aware turn-detector revision selection.
-		// `2b` (the entry tier) ships the ~66 MB EN-only SmolLM2-135M distill
-		// (`v1.2.2-en`); `4b`+ ship the ~396 MB multilingual pruned
-		// semantic detector (`v0.4.1-intl`). The on-disk layout is per-tier so the
-		// bundle dir already contains the matching ONNX — `revision` here is a
-		// telemetry label (the upstream tag the bundle was staged from). When no
-		// active bundle is resolvable we omit the hint and the resolver falls
-		// back to the upstream-default filename order.
-		const activeTier = this.activeEliza1Bundle?.tierId;
-		const tierRevision = activeTier
-			? eotMod.turnDetectorRevisionForTier(activeTier)
-			: undefined;
-		const eliza1EotSelected = resolveEliza1EotSelection(
-			opts.useEliza1Eot,
-			opts.eliza1EotLoraPath,
-		);
-		const eliza1EotClassifier =
-			eliza1EotSelected !== "off" && opts.turnDetector !== false
-				? this.tryBuildEliza1EotClassifier(
-						eliza1EotSelected,
-						opts.eliza1EotLoraPath,
-					)
-				: null;
-		if (eliza1EotSelected === "force" && !eliza1EotClassifier) {
-			throw new VoiceStartupError(
-				"missing-turn-detector",
-				"[voice] useEliza1Eot:true requested but the in-process Eliza-1 EOT scorer is unavailable on the FFI runtime — use the GGUF turn detector by setting useEliza1Eot:false.",
+						: undefined,
+					config: { semanticEotActive },
+				}));
+			logger.info(
+				`[LocalInferenceEngine] voice endpoint: endHangoverMs=${vad.endHangoverMs} (${
+					semanticEotActive
+						? "fused semantic EOT active"
+						: "fixed-VAD floor — fused semantic EOT unavailable"
+				})`,
 			);
-		}
-		// Resolver order: prefer the fused composite EOT (v11), then the legacy
-		// in-process Eliza-1 scorer + GGUF turn detector (both null on the FFI
-		// runtime — they needed node-llama controlledEvaluate), then the
-		// heuristic. The ONNX path was removed.
-		const ggmlTurnDetector =
-			opts.turnDetector === false || fusedEot
-				? undefined
-				: await eotGgmlMod
-						.createBundledLiveKitGgmlTurnDetector({
-							...(opts.turnDetectorModelDir
-								? { modelDir: opts.turnDetectorModelDir }
-								: {}),
-							...(tierRevision ? { revision: tierRevision } : {}),
-						})
-						.catch(() => null);
-		const turnDetector =
-			opts.turnDetector === false
-				? undefined
-				: (opts.turnDetector ??
-					fusedEot ??
-					eliza1EotClassifier ??
-					ggmlTurnDetector ??
-					new eotMod.HeuristicEotClassifier());
-		if (turnDetector) {
-			try {
-				// Warm one short pass while the session is arming, so the first
-				// real user pause does not pay model-load latency.
-				await turnDetector.score("yes");
-			} catch (err) {
+
+			// ASR — throws `AsrUnavailableError` when the fused decoder is
+			// unavailable (the fused build is the sole on-device ASR runtime). Gated
+			// on the VAD so silent frames aren't decoded.
+			const transcriber = bridge.createStreamingTranscriber({ vad });
+			// Voice Wave 2 (2026-05-14): tier-aware turn-detector revision selection.
+			// `2b` (the entry tier) ships the ~66 MB EN-only SmolLM2-135M distill
+			// (`v1.2.2-en`); `4b`+ ship the ~396 MB multilingual pruned
+			// semantic detector (`v0.4.1-intl`). The on-disk layout is per-tier so the
+			// bundle dir already contains the matching ONNX — `revision` here is a
+			// telemetry label (the upstream tag the bundle was staged from). When no
+			// active bundle is resolvable we omit the hint and the resolver falls
+			// back to the upstream-default filename order.
+			const activeTier = this.activeEliza1Bundle?.tierId;
+			const tierRevision = activeTier
+				? eotMod.turnDetectorRevisionForTier(activeTier)
+				: undefined;
+			const eliza1EotSelected = resolveEliza1EotSelection(
+				opts.useEliza1Eot,
+				opts.eliza1EotLoraPath,
+			);
+			const eliza1EotClassifier =
+				eliza1EotSelected !== "off" && opts.turnDetector !== false
+					? this.tryBuildEliza1EotClassifier(
+							eliza1EotSelected,
+							opts.eliza1EotLoraPath,
+						)
+					: null;
+			if (eliza1EotSelected === "force" && !eliza1EotClassifier) {
 				throw new VoiceStartupError(
 					"missing-turn-detector",
-					`[voice] Cannot initialize semantic turn detector: ${err instanceof Error ? err.message : String(err)}`,
+					"[voice] useEliza1Eot:true requested but the in-process Eliza-1 EOT scorer is unavailable on the FFI runtime — use the GGUF turn detector by setting useEliza1Eot:false.",
 				);
 			}
-		}
-
-		// G5.d (Gauntlet cleanup): delegate to the bridge's canonical
-		// VoiceCancellationCoordinator. The bridge is the single owner — it
-		// constructs the coordinator + policy at `EngineVoiceBridge.start()`
-		// when `runtime` is passed in `EngineVoiceBridgeOptions` (see
-		// `engine-bridge.ts buildCancellationWiring`). Earlier C0-F wiring
-		// built a separate coordinator here; that path is removed.
-		//
-		// Back-compat: when callers still pass `opts.runtime` to
-		// `startVoiceSession()` but did not pass `runtime` to `startVoice()`,
-		// the bridge has no coordinator. We log once and proceed — the
-		// caller-supplied runtime is ignored because the bridge owns the
-		// FFI context that the coordinator targets.
-		if (opts.runtime && !bridge.cancellationCoordinatorOrNull()) {
-			console.warn(
-				"[voice] startVoiceSession({ runtime }) supplied but the bridge has no canonical cancellation coordinator — pass `runtime` to startVoice() instead. Ignoring the session-level runtime.",
-			);
-		}
-
-		const controller = new VoiceTurnController(
-			{
-				vad,
-				transcriber,
-				scheduler: bridge.scheduler,
-				...(turnDetector ? { turnDetector } : {}),
-				prewarm:
-					opts.prewarm ??
-					((roomId: string) => {
-						void this.prewarmConversation(roomId, "");
-					}),
-				playFirstAudioFiller: () => this.playFirstAudioFiller(),
-				generate: opts.generate,
-			},
-			{
-				roomId: opts.roomId,
-				...(opts.speculatePauseMs !== undefined
-					? { speculatePauseMs: opts.speculatePauseMs }
-					: {}),
-			},
-			opts.events ?? {},
-		);
-
-		// Bind the bridge's BargeInController into the bridge's canonical
-		// coordinator (G5.d). No-op when the bridge was constructed without a
-		// runtime — returns a no-op unsubscribe so the teardown path stays
-		// branchless.
-		const unsubCoordinator = bridge.bindBargeInControllerForRoom(opts.roomId);
-
-		// Mic → ring buffer (the buffer the ASR / instrumentation can read from)
-		// + per-frame fan-out to the VAD and the streaming transcriber.
-		const { unsubscribe: stopMicRing } = pipeMicToRingBuffer(
-			micSource,
-			new InMemoryAudioSink(),
-		);
-		// Optional openWakeWord hotword gate (opt-in, local mode). Resolved
-		// against the active bundle; absent graphs → silently no wake word.
-		let wakeWord: import("./voice/wake-word").OpenWakeWordDetector | null =
-			null;
-		let feedWakeFrame: ((pcm: Float32Array) => void) | null = null;
-		if (opts.wakeWord?.enabled) {
-			const {
-				isPlaceholderWakeWordHead,
-				loadBundledWakeWordModel,
-				OPENWAKEWORD_DEFAULT_HEAD,
-				OpenWakeWordDetector,
-			} = await import("./voice/wake-word");
-			const { bridgeDetectorToFusedWake } = await import(
-				"./voice/fused-wake-bridge"
-			);
-			const headName = opts.wakeWord.head?.trim() || OPENWAKEWORD_DEFAULT_HEAD;
-			if (isPlaceholderWakeWordHead(headName)) {
-				console.warn(
-					`[voice] wake word head '${headName}' is a PLACEHOLDER (the upstream openWakeWord "hey jarvis" head, renamed) — it fires on "hey jarvis", not the Eliza-1 wake phrase. Experimental, opt-in only; see packages/inference/reports/porting/2026-05-11/wakeword-head-plan.md.`,
-				);
-			}
-			if (!bridge.ffi) {
-				throw new VoiceStartupError(
-					"missing-ffi",
-					"[voice] Cannot initialize wake-word detector: fused libelizainference FFI is not loaded. Wake-word detection requires the native GGUF runtime (eliza_inference_wakeword_* symbols).",
-				);
-			}
-			const ffiCtxResolver = () => {
-				const ctx = bridge.ffiCtx;
-				if (ctx === null) {
+			// Resolver order: prefer the fused composite EOT (v11), then the legacy
+			// in-process Eliza-1 scorer + GGUF turn detector (both null on the FFI
+			// runtime — they needed node-llama controlledEvaluate), then the
+			// heuristic. The ONNX path was removed.
+			const ggmlTurnDetector =
+				opts.turnDetector === false || fusedEot
+					? undefined
+					: await eotGgmlMod
+							.createBundledLiveKitGgmlTurnDetector({
+								...(opts.turnDetectorModelDir
+									? { modelDir: opts.turnDetectorModelDir }
+									: {}),
+								...(tierRevision ? { revision: tierRevision } : {}),
+							})
+							.catch(() => null);
+			const turnDetector =
+				opts.turnDetector === false
+					? undefined
+					: (opts.turnDetector ??
+						fusedEot ??
+						eliza1EotClassifier ??
+						ggmlTurnDetector ??
+						new eotMod.HeuristicEotClassifier());
+			if (turnDetector) {
+				try {
+					// Warm one short pass while the session is arming, so the first
+					// real user pause does not pay model-load latency.
+					await turnDetector.score("yes");
+				} catch (err) {
 					throw new VoiceStartupError(
-						"missing-ffi",
-						"[voice] Cannot initialize wake-word detector: fused FFI context is not loaded.",
+						"missing-turn-detector",
+						`[voice] Cannot initialize semantic turn detector: ${err instanceof Error ? err.message : String(err)}`,
 					);
 				}
-				return ctx;
-			};
-			const model = await loadBundledWakeWordModel({
-				ffi: bridge.ffi,
-				ctx: ffiCtxResolver,
-				bundleRoot: bridge.bundlePath(),
-				...(opts.wakeWord.head ? { head: opts.wakeWord.head } : {}),
-			});
-			if (model) {
-				const forwardFusedWake = opts.wakeWord.onFusedWake
-					? bridgeDetectorToFusedWake(opts.wakeWord.onFusedWake)
-					: null;
-				const detector = new OpenWakeWordDetector({
-					model,
-					...(opts.wakeWord.threshold !== undefined
-						? { config: { threshold: opts.wakeWord.threshold } }
-						: {}),
-					onWake: (info) => {
-						void this.prewarmConversation(opts.roomId, "");
-						opts.wakeWord?.onWake?.();
-						// Bridge the real native firing to the renderer (#10351):
-						// the bar activates and a turn starts via useWakeController.
-						forwardFusedWake?.(info);
-					},
-				});
-				wakeWord = detector;
-				// The mic frame size need not match the openWakeWord frame size
-				// (1280 samples = 80 ms @ 16 kHz); re-buffer into exact frames.
-				const need = model.frameSamples;
-				let acc = new Float32Array(0);
-				feedWakeFrame = (pcm: Float32Array) => {
-					const merged = new Float32Array(acc.length + pcm.length);
-					merged.set(acc);
-					merged.set(pcm, acc.length);
-					let off = 0;
-					while (merged.length - off >= need) {
-						const slice = merged.slice(off, off + need);
-						off += need;
-						void detector.pushFrame(slice);
-					}
-					acc = merged.slice(off);
-				};
-			} else {
-				console.info(
-					"[voice] wake word requested but no openWakeWord model in this bundle — running VAD-gated only",
+			}
+
+			// G5.d (Gauntlet cleanup): delegate to the bridge's canonical
+			// VoiceCancellationCoordinator. The bridge is the single owner — it
+			// constructs the coordinator + policy at `EngineVoiceBridge.start()`
+			// when `runtime` is passed in `EngineVoiceBridgeOptions` (see
+			// `engine-bridge.ts buildCancellationWiring`). Earlier C0-F wiring
+			// built a separate coordinator here; that path is removed.
+			//
+			// Back-compat: when callers still pass `opts.runtime` to
+			// `startVoiceSession()` but did not pass `runtime` to `startVoice()`,
+			// the bridge has no coordinator. We log once and proceed — the
+			// caller-supplied runtime is ignored because the bridge owns the
+			// FFI context that the coordinator targets.
+			if (opts.runtime && !bridge.cancellationCoordinatorOrNull()) {
+				console.warn(
+					"[voice] startVoiceSession({ runtime }) supplied but the bridge has no canonical cancellation coordinator — pass `runtime` to startVoice() instead. Ignoring the session-level runtime.",
 				);
 			}
-		}
 
-		const unsubFrame = micSource.onFrame((frame) => {
-			// The VAD forward pass is serialized internally; fire-and-forget so a
-			// slow frame doesn't backpressure the mic (the VAD records overruns).
-			void vad.pushFrame(frame);
-			transcriber.feed(frame);
-			feedWakeFrame?.(frame.pcm);
-		});
+			const controller = new VoiceTurnController(
+				{
+					vad,
+					transcriber,
+					scheduler: bridge.scheduler,
+					...(turnDetector ? { turnDetector } : {}),
+					prewarm:
+						opts.prewarm ??
+						((roomId: string) => {
+							void this.prewarmConversation(roomId, "");
+						}),
+					playFirstAudioFiller: () => this.playFirstAudioFiller(),
+					generate: opts.generate,
+				},
+				{
+					roomId: opts.roomId,
+					...(opts.speculatePauseMs !== undefined
+						? { speculatePauseMs: opts.speculatePauseMs }
+						: {}),
+				},
+				opts.events ?? {},
+			);
 
-		controller.start();
-		await micSource.start();
+			// Bind the bridge's BargeInController into the bridge's canonical
+			// coordinator (G5.d). No-op when the bridge was constructed without a
+			// runtime — returns a no-op unsubscribe so the teardown path stays
+			// branchless.
+			const unsubCoordinator = bridge.bindBargeInControllerForRoom(opts.roomId);
 
-		// Single teardown knob: stopping the controller stops the mic chain too.
-		const origStop = controller.stop.bind(controller);
-		controller.stop = () => {
-			origStop();
-			unsubFrame();
-			stopMicRing();
-			void micSource.stop();
-			transcriber.dispose();
-			// Release the fused EOT scorer's voice-budget reservation.
+			// Mic → ring buffer (the buffer the ASR / instrumentation can read from)
+			// + per-frame fan-out to the VAD and the streaming transcriber.
+			const { unsubscribe: stopMicRing } = pipeMicToRingBuffer(
+				micSource,
+				new InMemoryAudioSink(),
+			);
+			// Optional openWakeWord hotword gate (opt-in, local mode). Resolved
+			// against the active bundle; absent graphs → silently no wake word.
+			let wakeWord: import("./voice/wake-word").OpenWakeWordDetector | null =
+				null;
+			let feedWakeFrame: ((pcm: Float32Array) => void) | null = null;
+			if (opts.wakeWord?.enabled) {
+				const {
+					isPlaceholderWakeWordHead,
+					loadBundledWakeWordModel,
+					OPENWAKEWORD_DEFAULT_HEAD,
+					OpenWakeWordDetector,
+				} = await import("./voice/wake-word");
+				const { bridgeDetectorToFusedWake } = await import(
+					"./voice/fused-wake-bridge"
+				);
+				const headName =
+					opts.wakeWord.head?.trim() || OPENWAKEWORD_DEFAULT_HEAD;
+				if (isPlaceholderWakeWordHead(headName)) {
+					console.warn(
+						`[voice] wake word head '${headName}' is a PLACEHOLDER (the upstream openWakeWord "hey jarvis" head, renamed) — it fires on "hey jarvis", not the Eliza-1 wake phrase. Experimental, opt-in only; see packages/inference/reports/porting/2026-05-11/wakeword-head-plan.md.`,
+					);
+				}
+				if (!bridge.ffi) {
+					throw new VoiceStartupError(
+						"missing-ffi",
+						"[voice] Cannot initialize wake-word detector: fused libelizainference FFI is not loaded. Wake-word detection requires the native GGUF runtime (eliza_inference_wakeword_* symbols).",
+					);
+				}
+				const ffiCtxResolver = () => {
+					const ctx = bridge.ffiCtx;
+					if (ctx === null) {
+						throw new VoiceStartupError(
+							"missing-ffi",
+							"[voice] Cannot initialize wake-word detector: fused FFI context is not loaded.",
+						);
+					}
+					return ctx;
+				};
+				const model = await loadBundledWakeWordModel({
+					ffi: bridge.ffi,
+					ctx: ffiCtxResolver,
+					bundleRoot: bridge.bundlePath(),
+					...(opts.wakeWord.head ? { head: opts.wakeWord.head } : {}),
+				});
+				if (model) {
+					const forwardFusedWake = opts.wakeWord.onFusedWake
+						? bridgeDetectorToFusedWake(opts.wakeWord.onFusedWake)
+						: null;
+					const detector = new OpenWakeWordDetector({
+						model,
+						...(opts.wakeWord.threshold !== undefined
+							? { config: { threshold: opts.wakeWord.threshold } }
+							: {}),
+						onWake: (info) => {
+							void this.prewarmConversation(opts.roomId, "");
+							opts.wakeWord?.onWake?.();
+							// Bridge the real native firing to the renderer (#10351):
+							// the bar activates and a turn starts via useWakeController.
+							forwardFusedWake?.(info);
+						},
+					});
+					wakeWord = detector;
+					// The mic frame size need not match the openWakeWord frame size
+					// (1280 samples = 80 ms @ 16 kHz); re-buffer into exact frames.
+					const need = model.frameSamples;
+					let acc = new Float32Array(0);
+					feedWakeFrame = (pcm: Float32Array) => {
+						const merged = new Float32Array(acc.length + pcm.length);
+						merged.set(acc);
+						merged.set(pcm, acc.length);
+						let off = 0;
+						while (merged.length - off >= need) {
+							const slice = merged.slice(off, off + need);
+							off += need;
+							void detector.pushFrame(slice);
+						}
+						acc = merged.slice(off);
+					};
+				} else {
+					console.info(
+						"[voice] wake word requested but no openWakeWord model in this bundle — running VAD-gated only",
+					);
+				}
+			}
+
+			const unsubFrame = micSource.onFrame((frame) => {
+				// The VAD forward pass is serialized internally; fire-and-forget so a
+				// slow frame doesn't backpressure the mic (the VAD records overruns).
+				void vad.pushFrame(frame);
+				transcriber.feed(frame);
+				feedWakeFrame?.(frame.pcm);
+			});
+
+			controller.start();
+			await micSource.start();
+
+			// Single teardown knob: stopping the controller stops the mic chain too.
+			const origStop = controller.stop.bind(controller);
+			controller.stop = () => {
+				origStop();
+				unsubFrame();
+				stopMicRing();
+				void micSource.stop();
+				transcriber.dispose();
+				// Release the fused EOT scorer's voice-budget reservation.
+				fusedEot?.dispose();
+				wakeWord?.reset();
+				// G5.d: tear down only the per-room barge-in binding. The bridge
+				// owns the coordinator lifecycle and disposes it in
+				// `EngineVoiceBridge.dispose()` — we must not dispose it here or
+				// we would cancel armed tokens for other concurrent rooms.
+				unsubCoordinator();
+			};
+			return controller;
+		} catch (err) {
+			// error-policy:J6 best-effort teardown — release the fused-EOT
+			// reservation before rethrowing so a failed arm does not leak its 8 MB
+			// voice-budget slot (#12895). The original error propagates unchanged.
 			fusedEot?.dispose();
-			wakeWord?.reset();
-			// G5.d: tear down only the per-room barge-in binding. The bridge
-			// owns the coordinator lifecycle and disposes it in
-			// `EngineVoiceBridge.dispose()` — we must not dispose it here or
-			// we would cancel armed tokens for other concurrent rooms.
-			unsubCoordinator();
-		};
-		return controller;
+			throw err;
+		}
 	}
 
 	/**

--- a/plugins/plugin-local-inference/src/services/voice/fused-eot-arm-leak.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/fused-eot-arm-leak.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Regression test for the fused-EOT voice-budget leak on a failed voice arm
+ * (#12895). `LocalInferenceEngine.startVoiceSession()` reserves the 8 MB
+ * fused-EOT scoring context via `tryBuildFusedEotClassifier`, but only wires
+ * its release into `controller.stop` at the very end of the arm. Any await in
+ * between (ASR-unavailable, turn-detector warm, wake/mic startup) that throws
+ * would leak the reservation against the process-wide budget. This drives the
+ * REAL `startVoiceSession` arm path with a minimal fake bridge + injected test
+ * budget, forces `createStreamingTranscriber` to throw after the reservation is
+ * taken, and asserts the budget returns to baseline. Deterministic — no native
+ * library, no mic, no audio.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { classifyDeviceTier } from "../device-tier";
+import { LocalInferenceEngine } from "../engine";
+import type { HardwareProbe } from "../types";
+import type { ElizaInferenceFfi } from "./ffi-bindings";
+import { AsrUnavailableError } from "./transcriber";
+import type { MicSource } from "./types";
+import type { VadDetector } from "./vad";
+import {
+	createVoiceBudgetForTest,
+	setSharedVoiceBudgetForTest,
+	type VoiceBudget,
+} from "./voice-budget";
+
+const MB = 1024 * 1024;
+
+const maxProbe: HardwareProbe = {
+	totalRamGb: 64,
+	freeRamGb: 48,
+	gpu: { backend: "cuda", totalVramGb: 24, freeVramGb: 22 },
+	cpuCores: 16,
+	platform: "linux",
+	arch: "x64",
+	appleSilicon: false,
+	recommendedBucket: "xl",
+	source: "capacitor-llama",
+};
+
+/** Fused FFI stub that advertises the v11 EOT symbol so the fused-EOT
+ *  classifier builds and takes its reservation. */
+function eotCapableFfi(): ElizaInferenceFfi {
+	return {
+		libraryPath: "/tmp/fake",
+		libraryAbiVersion: "11",
+		create: () => 1n,
+		destroy: () => {},
+		mmapAcquire: () => {},
+		mmapEvict: () => {},
+		ttsSynthesize: () => {
+			throw new Error("not used");
+		},
+		asrTranscribe: () => {
+			throw new Error("not used");
+		},
+		ttsStreamSupported: () => false,
+		ttsSynthesizeStream: () => {
+			throw new Error("not used");
+		},
+		cancelTts: () => {},
+		setVerifierCallback: () => ({ close: () => {} }),
+		vadSupported: () => true,
+		vadOpen: () => 7n,
+		vadProcess: () => 0.1,
+		vadReset: () => {},
+		vadClose: () => {},
+		asrStreamSupported: () => false,
+		asrStreamOpen: () => {
+			throw new Error("not used");
+		},
+		asrStreamFeed: () => {},
+		asrStreamPartial: () => ({ partial: "" }),
+		asrStreamFinish: () => ({ partial: "" }),
+		asrStreamClose: () => {},
+		eotSupported: () => true,
+		eotScore: () => ({ targetProb: 0.5 }),
+		tokenize: () => new Int32Array([1]),
+		close: () => {},
+	} as unknown as ElizaInferenceFfi;
+}
+
+/** A do-nothing VAD passed via `opts.vad` so the arm skips the native VAD
+ *  loader — the fused-EOT reservation still happens before it. */
+function fakeVad(): VadDetector {
+	return {
+		endHangoverMs: 500,
+		pushFrame: async () => {},
+	} as unknown as VadDetector;
+}
+
+/** A mic source that never starts frames — the arm throws (in ASR) before it
+ *  is ever used. */
+function fakeMicSource(): MicSource {
+	return {
+		sampleRate: 16_000,
+		frameSamples: 512,
+		running: false,
+		start: async () => {},
+		stop: async () => {},
+		onFrame: () => () => {},
+		onError: () => () => {},
+	};
+}
+
+/**
+ * Minimal structural bridge exposing only the members `startVoiceSession`
+ * reads before ASR throws: `lifecycle.current()`, `backend`, `ffi`, and
+ * `createStreamingTranscriber()`. `asrThrows` forces the ASR path — the sole
+ * failure injected after the fused-EOT reservation is taken.
+ */
+function fakeBridge(ffi: ElizaInferenceFfi): object {
+	return {
+		lifecycle: { current: () => ({ kind: "voice-on" }) },
+		backend: { id: "ffi" },
+		ffi,
+		ffiCtx: 1n,
+		scheduler: {},
+		bundlePath: () => "/tmp/fake-bundle",
+		createStreamingTranscriber: () => {
+			throw new AsrUnavailableError(
+				"[voice] Fused ASR decoder unavailable in this build.",
+			);
+		},
+		bindBargeInControllerForRoom: () => () => {},
+		cancellationCoordinatorOrNull: () => null,
+	};
+}
+
+/** Inject a fake voice bridge into the engine's private field (test seam). */
+function injectBridge(engine: LocalInferenceEngine, bridge: object): void {
+	(engine as unknown as { voiceBridge: object }).voiceBridge = bridge;
+}
+
+describe("startVoiceSession fused-EOT reservation on a failed arm (#12895)", () => {
+	afterEach(() => {
+		setSharedVoiceBudgetForTest(null);
+	});
+
+	function pinBudget(): VoiceBudget {
+		const budget = createVoiceBudgetForTest({
+			totalBytes: 64 * MB,
+			assessment: classifyDeviceTier(maxProbe),
+		});
+		setSharedVoiceBudgetForTest(budget);
+		return budget;
+	}
+
+	it("releases the fused-EOT reservation when ASR is unavailable mid-arm", async () => {
+		const budget = pinBudget();
+		expect(budget.snapshot()).toHaveLength(0);
+
+		const engine = new LocalInferenceEngine();
+		injectBridge(engine, fakeBridge(eotCapableFfi()));
+
+		await expect(
+			engine.startVoiceSession({
+				roomId: "room-1",
+				vad: fakeVad(),
+				micSource: fakeMicSource(),
+				generate: async () => ({ replyText: "" }) as never,
+			}),
+		).rejects.toBeInstanceOf(AsrUnavailableError);
+
+		// The 8 MB fused-EOT reservation must be released on the throwing path —
+		// the budget returns to baseline, no leak.
+		expect(budget.snapshot()).toHaveLength(0);
+		expect(budget.freeBytes()).toBe(budget.totalBytes());
+	});
+
+	it("takes no reservation and leaves the budget clean when EOT is disabled", async () => {
+		const budget = pinBudget();
+
+		const engine = new LocalInferenceEngine();
+		injectBridge(engine, fakeBridge(eotCapableFfi()));
+
+		await expect(
+			engine.startVoiceSession({
+				roomId: "room-2",
+				vad: fakeVad(),
+				micSource: fakeMicSource(),
+				turnDetector: false,
+				generate: async () => ({ replyText: "" }) as never,
+			}),
+		).rejects.toBeInstanceOf(AsrUnavailableError);
+
+		expect(budget.snapshot()).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
Closes #12895

## What changed

`LocalInferenceEngine.startVoiceSession()` (`plugins/plugin-local-inference/src/services/engine.ts`) builds the fused end-of-turn classifier via `tryBuildFusedEotClassifier`, which reserves `FUSED_EOT_SCORER_RESERVE_BYTES` (8 MB) against the process-wide voice budget. The reservation's `dispose()` was **only** wired into `controller.stop`, installed at the very end of the arm.

Every await between the fused-EOT build and that stop-wiring can throw:
- `bridge.createStreamingTranscriber({ vad })` → `AsrUnavailableError` when the fused ASR decoder is missing
- `turnDetector.score("yes")` warm pass
- `loadBundledWakeWordModel(...)` / `micSource.start()` (wake/mic startup)

On any of these throws, `startVoiceSession` returned before reassigning `controller.stop`, so `fusedEot.dispose()` never ran and the 8 MB reservation leaked permanently against the shared budget (a re-arm after a transient failure would leak another 8 MB each time, eventually mapping to `VoiceLifecycleError("ram-pressure")`).

The fix wraps the arm body from just after the fused-EOT build through the stop-wiring in a `try/catch` that disposes the reservation before rethrowing. `dispose()` is idempotent (backed by the reservation's idempotent `release`), so the **success path is unchanged** — it still releases through `controller.stop`; only the throwing path now cleans up. The catch is annotated `// error-policy:J6 best-effort teardown` and rethrows the original error unchanged.

Diff is minimal: the body is re-indented one level under `try {` (the bulk of the line count is pure indentation) plus the catch block. `git diff -w` shows only the try/catch wrapper added.

## Files changed
- `plugins/plugin-local-inference/src/services/engine.ts` — try/catch around the fused-EOT arm body releasing the reservation on failure
- `plugins/plugin-local-inference/src/services/voice/fused-eot-arm-leak.test.ts` — new regression test

## Verification

**Regression test drives the real arm path** — a minimal fake bridge advertising the v11 EOT symbol (so `tryBuildFusedEotClassifier` genuinely reserves) with the shared budget pinned via `setSharedVoiceBudgetForTest`, then forces `createStreamingTranscriber` to throw `AsrUnavailableError` after the reservation is taken. Asserts `budget.snapshot()` returns to length 0 and `freeBytes() === totalBytes()`.

Green (fix in place):
```
$ bunx vitest run .../voice/fused-eot-arm-leak.test.ts .../voice/voice-budget-loaders.test.ts .../voice/composite-eot-classifier.test.ts
 Test Files  3 passed (3)
      Tests  21 passed (21)
```

Red proof (temporarily removed the `fusedEot?.dispose()` from the catch) — the test detects the leak:
```
AssertionError: expected [ { …(5) } ] to have a length of +0 but got 1
- 0
+ 1
  at .../fused-eot-arm-leak.test.ts:168  expect(budget.snapshot()).toHaveLength(0)
```
stdout confirmed the real path ran: `[LocalInferenceEngine] voice endpoint: endHangoverMs=500 (fused semantic EOT active)`.

**error-policy ratchet** (touched files clean):
```
$ node packages/scripts/error-policy-ratchet.mjs
  plugins/plugin-local-inference/src/services/engine.ts: emptyCatch 1->1, serverConsole 0->0
[error-policy-ratchet] no new fallback-slop in touched files
```

**biome:**
```
$ bunx biome check plugins/plugin-local-inference/src/services/engine.ts .../voice/fused-eot-arm-leak.test.ts
Checked 2 files in 65ms. No fixes applied.
```

**typecheck** (`bun run --cwd plugins/plugin-local-inference typecheck`): clean after building the `@elizaos/contracts` artifact (the only errors before that were pre-existing `@elizaos/contracts` module-not-found in `packages/core`/`packages/shared`, unrelated to this change).

## Evidence not applicable
- Real-LLM trajectories: N/A — no agent/prompt/model behavior changed; this is a memory-reservation lifecycle fix on the voice arm path.
- Screenshots/video/native capture: N/A — no UI or renderer surface; the leak is server-side voice-budget accounting, proven by the deterministic budget-snapshot test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)