### PR TITLE
refactor(#12739): explicit TUI degrade/error states over silent fallbacks

### DIFF
--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -575,7 +575,9 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
             const fullPath = join(searchDir, entry.name);
             isDirectory = statSync(fullPath).isDirectory();
           } catch {
-            // Broken symlink or permission error - treat as file
+            // error-policy:J4 a broken symlink or unreadable target cannot be a
+            // navigable directory; it stays a file entry (no trailing slash) so
+            // the completion is offered, just not as a directory to descend into.
           }
         }
 
@@ -635,8 +637,12 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
       });
 
       return suggestions;
-    } catch (_e) {
-      // Directory doesn't exist or not accessible
+    } catch {
+      // error-policy:J4 path-completion is a best-effort convenience over a live
+      // filesystem: a partial/nonexistent path or an unreadable dir (deleted
+      // mid-keystroke, permission-denied) yields no candidates, which the caller
+      // renders as no popup. Empty here means "nothing to complete", never masked
+      // data — completion has no valid non-empty result for an unreadable path.
       return [];
     }
   }
@@ -724,6 +730,9 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
       return suggestions;
     } catch {
+      // error-policy:J4 fuzzy `@`-file search is a best-effort convenience: an fd
+      // spawn/parse failure yields no candidates, which the caller renders as no
+      // popup. Empty means "nothing to complete", never masked data.
       return [];
     }
   }

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -22,7 +22,12 @@ export interface ImageOptions {
 export class Image implements Component {
   private base64Data: string;
   private mimeType: string;
-  private dimensions: ImageDimensions;
+  // undefined = pixel dimensions could not be determined (unsupported format or
+  // corrupt/truncated data). Kept undefined rather than a fabricated default so
+  // render() degrades to a distinguishable text placeholder instead of drawing
+  // the image at a fake size — which would corrupt the differential renderer's
+  // height accounting (#12739).
+  private dimensions: ImageDimensions | undefined;
   private theme: ImageTheme;
   private options: ImageOptions;
   private imageId?: number;
@@ -41,11 +46,8 @@ export class Image implements Component {
     this.mimeType = mimeType;
     this.theme = theme;
     this.options = options;
-    this.dimensions = dimensions ||
-      getImageDimensions(base64Data, mimeType) || {
-        widthPx: 800,
-        heightPx: 600,
-      };
+    this.dimensions =
+      dimensions ?? getImageDimensions(base64Data, mimeType) ?? undefined;
     this.imageId = options.imageId;
   }
 
@@ -69,7 +71,11 @@ export class Image implements Component {
     const caps = getCapabilities();
     let lines: string[];
 
-    if (caps.images) {
+    // error-policy:J4 unknown dimensions is a distinguishable degrade, not a
+    // fabricated size — the graphical protocols need real pixel dimensions to
+    // compute row height, so fall through to the text placeholder (which omits
+    // the size), never draw a fake-sized image.
+    if (caps.images && this.dimensions) {
       const result = renderImage(this.base64Data, this.dimensions, {
         maxWidthCells: maxWidth,
         imageId: this.imageId,

--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -225,6 +225,8 @@ export function getPngDimensions(base64Data: string): ImageDimensions | null {
 
     return { widthPx: width, heightPx: height };
   } catch {
+    // error-policy:J3 untrusted base64/binary — a decode/read overrun means the
+    // PNG header is unparseable; null is the explicit "unknown dimensions" signal.
     return null;
   }
 }
@@ -268,6 +270,8 @@ export function getJpegDimensions(base64Data: string): ImageDimensions | null {
 
     return null;
   } catch {
+    // error-policy:J3 untrusted base64/binary — a decode/read overrun means the
+    // JPEG markers are unparseable; null is the explicit "unknown dimensions" signal.
     return null;
   }
 }
@@ -290,6 +294,8 @@ export function getGifDimensions(base64Data: string): ImageDimensions | null {
 
     return { widthPx: width, heightPx: height };
   } catch {
+    // error-policy:J3 untrusted base64/binary — a decode/read overrun means the
+    // GIF header is unparseable; null is the explicit "unknown dimensions" signal.
     return null;
   }
 }
@@ -329,6 +335,8 @@ export function getWebpDimensions(base64Data: string): ImageDimensions | null {
 
     return null;
   } catch {
+    // error-policy:J3 untrusted base64/binary — a decode/read overrun means the
+    // WebP header is unparseable; null is the explicit "unknown dimensions" signal.
     return null;
   }
 }

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -249,6 +249,9 @@ export class ProcessTerminal implements Terminal {
       try {
         fs.appendFileSync(this.writeLogPath, data, { encoding: "utf8" });
       } catch (err) {
+        // error-policy:J6 best-effort diagnostic — TUI_WRITE_LOG is an opt-in
+        // debug capture, not the render path. Surface the failure to stderr and
+        // disable the log so a bad path never stalls every subsequent write.
         const path = this.writeLogPath;
         this.writeLogPath = null;
         process.stderr.write(

--- a/packages/tui/test/image-component.test.ts
+++ b/packages/tui/test/image-component.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Exercises the Image component's degrade path over the real render pipeline —
+ * no mocks: capability detection is driven by env vars and the actual PNG header
+ * parser decides whether dimensions are known. Guards #12739: undeterminable
+ * dimensions must render a distinguishable text placeholder, never a
+ * fabricated-size graphic that corrupts differential-render height accounting.
+ */
+
+import assert from "node:assert";
+import { afterEach, beforeEach, describe, it } from "vitest";
+import { Image } from "../src/components/image.js";
+import { resetCapabilitiesCache } from "../src/terminal-image.js";
+
+const KITTY_ENV_KEYS = ["KITTY_WINDOW_ID", "TERM_PROGRAM"] as const;
+
+// A minimal PNG whose IHDR reports 120x80 — enough bytes for getPngDimensions.
+const VALID_PNG_B64 = "iVBORwAAAAAAAAAAAAAAAAAAAHgAAABQ";
+// 24 zero bytes: long enough to pass the length guard, wrong signature -> null.
+const CORRUPT_B64 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+const theme = { fallbackColor: (s: string) => s };
+
+function forceKittyCapabilities(): void {
+  process.env.KITTY_WINDOW_ID = "1";
+  resetCapabilitiesCache();
+}
+
+describe("Image degrade states (#12739)", () => {
+  const saved = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const key of KITTY_ENV_KEYS) {
+      saved.set(key, process.env[key]);
+      delete process.env[key];
+    }
+    resetCapabilitiesCache();
+  });
+
+  afterEach(() => {
+    for (const key of KITTY_ENV_KEYS) {
+      const prev = saved.get(key);
+      if (prev === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = prev;
+      }
+    }
+    resetCapabilitiesCache();
+  });
+
+  it("renders a distinguishable text placeholder when dimensions are unknown, even on an image-capable terminal", () => {
+    forceKittyCapabilities();
+
+    const image = new Image(CORRUPT_B64, "image/png", theme, {
+      filename: "broken.png",
+    });
+    const lines = image.render(80);
+
+    // Degrade must be a single text line, not a multi-row graphical sequence.
+    assert.strictEqual(lines.length, 1);
+    assert.ok(
+      lines[0].includes("[Image:") && lines[0].includes("broken.png"),
+      `expected text placeholder, got: ${JSON.stringify(lines[0])}`,
+    );
+    // The Kitty/iTerm2 graphical escape must NOT be emitted for unknown dims.
+    assert.ok(
+      !lines[0].includes("\x1b_G") && !lines[0].includes("\x1b]1337;File="),
+      "unknown-dimension image must not emit a graphical protocol sequence",
+    );
+  });
+
+  it("never fabricates a size (no 800x600) in the placeholder for unknown dimensions", () => {
+    forceKittyCapabilities();
+
+    const image = new Image(CORRUPT_B64, "image/jpeg", theme, {
+      filename: "corrupt.jpg",
+    });
+    const [line] = image.render(80);
+
+    // imageFallback omits the size when dimensions are undefined; the old code
+    // substituted a fabricated { widthPx: 800, heightPx: 600 } here.
+    assert.ok(
+      !/\d+x\d+/.test(line),
+      `placeholder must not contain a fabricated pixel size, got: ${JSON.stringify(line)}`,
+    );
+  });
+
+  it("renders the graphical protocol path when dimensions are known", () => {
+    forceKittyCapabilities();
+
+    const image = new Image(VALID_PNG_B64, "image/png", theme, {
+      maxWidthCells: 40,
+    });
+    const lines = image.render(80);
+
+    // Known dimensions on a Kitty terminal produce a real image sequence, and
+    // the component pads with (rows-1) empty lines for height accounting.
+    const joined = lines.join("");
+    assert.ok(
+      joined.includes("\x1b_G"),
+      "known-dimension image on a Kitty terminal must emit a Kitty sequence",
+    );
+    assert.ok(
+      !joined.includes("[Image:"),
+      "known-dimension image must not degrade to the text placeholder",
+    );
+  });
+
+  it("degrades to the text placeholder on a non-image terminal regardless of dimensions", () => {
+    // No image env keys set -> detectCapabilities() reports images: null.
+    resetCapabilitiesCache();
+
+    const image = new Image(VALID_PNG_B64, "image/png", theme, {
+      filename: "photo.png",
+    });
+    const lines = image.render(80);
+
+    assert.strictEqual(lines.length, 1);
+    assert.ok(lines[0].includes("[Image:") && lines[0].includes("photo.png"));
+  });
+});

--- a/packages/tui/test/terminal-write-log.test.ts
+++ b/packages/tui/test/terminal-write-log.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Exercises ProcessTerminal.write's TUI_WRITE_LOG capture over the real fs path
+ * — no mocked fs: the log target is a real unwritable path so appendFileSync
+ * genuinely throws. Guards #12739's J6 keep: a diagnostic-write failure must
+ * surface (to stderr) and disable further attempts, never be silently swallowed.
+ */
+
+import assert from "node:assert";
+import { afterEach, beforeEach, describe, it } from "vitest";
+import { ProcessTerminal } from "../src/terminal.js";
+
+describe("ProcessTerminal TUI_WRITE_LOG failure surfacing (#12739)", () => {
+  let savedEnv: string | undefined;
+  let stdoutWrite: typeof process.stdout.write;
+  let stderrWrite: typeof process.stderr.write;
+  let stderrCapture: string;
+
+  beforeEach(() => {
+    savedEnv = process.env.TUI_WRITE_LOG;
+    // A path whose parent does not exist -> appendFileSync throws ENOENT.
+    process.env.TUI_WRITE_LOG = "/nonexistent-dir-12739/does/not/exist.log";
+
+    stdoutWrite = process.stdout.write.bind(process.stdout);
+    stderrWrite = process.stderr.write.bind(process.stderr);
+    stderrCapture = "";
+    // Swallow stdout (the terminal writes ANSI to it) and capture stderr.
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderrCapture += String(chunk);
+      return true;
+    }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    process.stdout.write = stdoutWrite;
+    process.stderr.write = stderrWrite;
+    if (savedEnv === undefined) {
+      delete process.env.TUI_WRITE_LOG;
+    } else {
+      process.env.TUI_WRITE_LOG = savedEnv;
+    }
+  });
+
+  it("surfaces the log-write failure to stderr and disables further attempts", () => {
+    const terminal = new ProcessTerminal();
+
+    // First write triggers the failing appendFileSync; the error must surface.
+    terminal.write("hello");
+    assert.ok(
+      stderrCapture.includes("TUI_WRITE_LOG: failed to write to"),
+      `expected the diagnostic failure on stderr, got: ${JSON.stringify(stderrCapture)}`,
+    );
+
+    // Log path is now disabled: a second write must NOT re-attempt (no second
+    // stderr line), proving the failure is not swallowed-and-retried forever.
+    const afterFirst = stderrCapture;
+    terminal.write("world");
+    assert.strictEqual(
+      stderrCapture,
+      afterFirst,
+      "a disabled write-log must not re-attempt on subsequent writes",
+    );
+  });
+});


### PR DESCRIPTION
Closes #12739

Part of the #12182 error-policy family (long-tail slice split from #12275). Scope: non-test TypeScript in `packages/tui`.

## Premise check
`packages/tui` is a **pure synchronous rendering library** — no `Plugin`, no actions/providers, and **no `runtime` handle** (confirmed in `packages/tui/CLAUDE.md`). So `runtime.reportError` does not apply here; the "background/async failure with a runtime handle" clause has no in-scope target. The genuine slop is one fabricated-data fallback on the render path; the rest of the flagged sites are legitimate best-effort/untrusted-input handlers, now annotated.

## Site inventory (fixed vs justified-annotated)

| File:line | Pattern | Verdict | Action |
|---|---|---|---|
| `components/image.ts:44` | `getImageDimensions(...) \|\| { widthPx: 800, heightPx: 600 }` | **slop — fixed** | Undeterminable dims fabricated a fake 800×600, drawing an unparseable image at a wrong size and corrupting the differential renderer's height accounting. Now `dimensions` is kept `undefined` and `render()` degrades to the existing text placeholder (`[Image: file [mime]]`, size omitted) — a distinguishable J4 state, never a fake-sized graphic. |
| `terminal-image.ts:227/270/292/331` | `catch { return null }` in PNG/JPEG/GIF/WebP header parsers | justified **J3** | Untrusted base64/binary; `null` is the explicit "unknown dimensions" signal (the value the fix above now honors). Annotated. |
| `terminal.ts:251` | `catch` around `TUI_WRITE_LOG` `appendFileSync` | justified **J6** | Opt-in debug capture, not the render path; surfaces to stderr and disables itself. Annotated. |
| `autocomplete.ts:577` | `catch {}` on symlink `statSync` | justified **J4** | Broken/unreadable symlink target can't be a navigable dir; stays a file entry. Annotated. |
| `autocomplete.ts:638` | `catch { return [] }` on `readdirSync` path completion | justified **J4** | Best-effort completion over a live FS; empty ⇒ caller renders no popup (`getSuggestions` returns `null` on `length===0`), never masked data. Annotated. |
| `autocomplete.ts:726` | `catch { return [] }` on fd fuzzy search | justified **J4** | Same: no candidates ⇒ no popup. Annotated. |

The ~29 `\|\| <literal>` / ~13 `?? <literal>` sites from the issue's rough sizing were reviewed and are **legitimate, not slop**: option-defaults in constructors (`?? true`, `?? 0`), optional marked-parser token arrays (`token.tokens || []`), out-of-bounds array-index defaults (`lines[i] || ""`), and env-var-absence (`process.env.X || ""`). None substitute for failed/missing data that should have loaded, so none were touched (minimal diff).

## Verification (real, no mocks)

**New TUI error-path tests** — drive the real render pipeline + real fs:

\`\`\`
$ bunx vitest run packages/tui/test/image-component.test.ts packages/tui/test/terminal-write-log.test.ts
 Test Files  2 passed (2)
      Tests  5 passed (5)
\`\`\`

- `image-component.test.ts` — corrupt/undeterminable input on an **image-capable** (Kitty) terminal renders a single distinguishable text placeholder, emits **no** graphical escape, and contains **no** fabricated `NxN` size; valid dims still render the Kitty graphical path (positive control); non-image terminal degrades too.
- `terminal-write-log.test.ts` — a real failing diagnostic write (`TUI_WRITE_LOG` → nonexistent dir) **surfaces to stderr** and **disables** further attempts, proving the J6 handler is not a silent swallow.

**Full package suite** (no regression from the `ImageDimensions | undefined` type change):
\`\`\`
$ bun run --cwd packages/tui test
 Test Files  28 passed (28)
      Tests  490 passed | 11 skipped (501)
\`\`\`

**Typecheck:**
\`\`\`
$ bun run --cwd packages/tui typecheck   # tsgo --noEmit -p tsconfig.build.json — clean
\`\`\`

**Error-policy ratchet** (diff-scoped, base `origin/develop`):
\`\`\`
$ node packages/scripts/error-policy-ratchet.mjs
[error-policy-ratchet] base origin/develop; 4 changed production source file(s)
  packages/tui/src/autocomplete.ts: emptyCatch 1->1, serverConsole 0->0
  packages/tui/src/components/image.ts: emptyCatch 0->0, serverConsole 0->0
  packages/tui/src/terminal-image.ts: emptyCatch 0->0, serverConsole 0->0
  packages/tui/src/terminal.ts: emptyCatch 0->0, serverConsole 0->0
[error-policy-ratchet] no new fallback-slop in touched files
\`\`\`

**Biome** on my changed/new files (`components/image.ts` + both test files): clean. The two biome findings elsewhere in `autocomplete.ts`/`terminal.ts` (`node:path` import, control-char regex) are **pre-existing on `origin/develop`**, not in this diff.

## Terminal transcript evidence (after fix)
Undeterminable dimensions on an image-capable (Kitty) terminal:
\`\`\`
lines.length = 1
line[0] = "[Image: broken.png [image/png]]"
emits graphical escape?  false
contains fabricated size (NxN)?  false
\`\`\`
Before: dims were fabricated as `800x600` and the component attempted to draw a wrongly-sized Kitty graphic (height accounting off by the fake row count).

- **Real-LLM trajectories:** N/A — `packages/tui` is a rendering library with no model/agent/prompt path.
- **UI screenshots/video:** N/A — terminal rendering library, not a `packages/app` web/desktop surface; transcript evidence above is the rendered artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)