### PR TITLE
fix(#12876): reject node-identity mutation on re-bootstrap without matching host-key fingerprint

### DIFF
--- a/packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts
+++ b/packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Route tests for the docker-node bootstrap-callback identity guard (#12876).
+ *
+ * Exercises the re-bootstrap rule on the EXISTING-node branch: a client cannot
+ * rewrite a node's SSH identity (hostname/ssh_user/ssh_port) via the shared
+ * bootstrap secret alone; only a request presenting the pinned host key
+ * fingerprint may change it. Uses a deterministic in-memory repository stub —
+ * the guard is pure route logic, so no DB is needed to prove the behavior.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as dockerNodesActual from "@/db/repositories/docker-nodes";
+import * as loggerActual from "@/lib/utils/logger";
+
+interface StoredNode {
+  id: string;
+  node_id: string;
+  hostname: string;
+  ssh_port: number;
+  ssh_user: string;
+  capacity: number;
+  host_key_fingerprint: string | null;
+  status: string;
+  metadata: Record<string, unknown>;
+}
+
+const EXISTING: StoredNode = {
+  id: "node-row-1",
+  node_id: "node-1",
+  hostname: "10.0.0.1",
+  ssh_port: 22,
+  ssh_user: "root",
+  capacity: 8,
+  host_key_fingerprint: "SHA256:pinned-fingerprint",
+  status: "healthy",
+  metadata: { provider: "operator-provisioned" },
+};
+
+let stored: StoredNode | null = EXISTING;
+let lastUpdateArg: Partial<StoredNode> | null = null;
+
+const mockFindByNodeId = mock(async (_nodeId: string) => stored);
+const mockUpdate = mock(async (_id: string, data: Partial<StoredNode>) => {
+  lastUpdateArg = data;
+  if (!stored) return null;
+  stored = { ...stored, ...data };
+  return stored;
+});
+const mockCreate = mock(async (data: StoredNode) => {
+  stored = { ...data, id: "node-row-new" };
+  return stored;
+});
+
+mock.module("@/db/repositories/docker-nodes", () => ({
+  ...dockerNodesActual,
+  dockerNodesRepository: {
+    ...dockerNodesActual.dockerNodesRepository,
+    findByNodeId: mockFindByNodeId,
+    update: mockUpdate,
+    create: mockCreate,
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  ...loggerActual,
+  logger: {
+    ...loggerActual.logger,
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  },
+}));
+
+const BOOTSTRAP_SECRET = "test-bootstrap-secret";
+process.env.CONTAINERS_BOOTSTRAP_SECRET = BOOTSTRAP_SECRET;
+
+const { default: app } = await import(
+  "../v1/admin/docker-nodes/bootstrap-callback/route"
+);
+
+async function post(body: Record<string, unknown>): Promise<Response> {
+  return app.fetch(
+    new Request("http://localhost/", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-bootstrap-secret": BOOTSTRAP_SECRET,
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+describe("bootstrap-callback node-identity guard (#12876)", () => {
+  beforeEach(() => {
+    stored = { ...EXISTING, metadata: { ...EXISTING.metadata } };
+    lastUpdateArg = null;
+    mockUpdate.mockClear();
+    mockCreate.mockClear();
+    mockFindByNodeId.mockClear();
+  });
+
+  test("rejects hostname mutation on existing node without a fingerprint (409, server values preserved)", async () => {
+    const res = await post({
+      nodeId: "node-1",
+      hostname: "10.6.6.6", // attacker-controlled MITM host
+    });
+
+    expect(res.status).toBe(409);
+    const json = (await res.json()) as { success: boolean; error: string };
+    expect(json.success).toBe(false);
+    expect(json.error).toContain("host key fingerprint");
+
+    // The SSH identity must NOT have been written.
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(stored?.hostname).toBe("10.0.0.1");
+    expect(stored?.ssh_user).toBe("root");
+    expect(stored?.ssh_port).toBe(22);
+  });
+
+  test("rejects ssh_user mutation without a matching fingerprint", async () => {
+    const res = await post({
+      nodeId: "node-1",
+      hostname: "10.0.0.1",
+      sshUser: "attacker",
+      hostKeyFingerprint: "SHA256:wrong-fingerprint",
+    });
+
+    expect(res.status).toBe(409);
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(stored?.ssh_user).toBe("root");
+  });
+
+  test("rejects ssh_port mutation without a matching fingerprint", async () => {
+    const res = await post({
+      nodeId: "node-1",
+      hostname: "10.0.0.1",
+      sshPort: 2222,
+    });
+
+    expect(res.status).toBe(409);
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(stored?.ssh_port).toBe(22);
+  });
+
+  test("rejects identity mutation when the node has no pinned fingerprint at all", async () => {
+    stored = {
+      ...EXISTING,
+      host_key_fingerprint: null,
+      metadata: { ...EXISTING.metadata },
+    };
+
+    const res = await post({
+      nodeId: "node-1",
+      hostname: "10.6.6.6",
+      hostKeyFingerprint: "SHA256:anything",
+    });
+
+    expect(res.status).toBe(409);
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(stored?.hostname).toBe("10.0.0.1");
+  });
+
+  test("allows identity mutation with a matching pinned fingerprint", async () => {
+    const res = await post({
+      nodeId: "node-1",
+      hostname: "10.0.0.9",
+      sshUser: "deploy",
+      sshPort: 2200,
+      hostKeyFingerprint: "SHA256:pinned-fingerprint",
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { success: boolean };
+    expect(json.success).toBe(true);
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(lastUpdateArg?.hostname).toBe("10.0.0.9");
+    expect(lastUpdateArg?.ssh_user).toBe("deploy");
+    expect(lastUpdateArg?.ssh_port).toBe(2200);
+  });
+
+  test("liveness re-bootstrap with unchanged identity succeeds without a fingerprint", async () => {
+    const res = await post({
+      nodeId: "node-1",
+      hostname: "10.0.0.1",
+      sshUser: "root",
+      sshPort: 22,
+      capacity: 16,
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    // Identity preserved, non-identity field (capacity) still updated.
+    expect(lastUpdateArg?.hostname).toBe("10.0.0.1");
+    expect(lastUpdateArg?.ssh_user).toBe("root");
+    expect(lastUpdateArg?.ssh_port).toBe(22);
+    expect(lastUpdateArg?.capacity).toBe(16);
+  });
+
+  test("first bootstrap of a brand-new node still creates the row", async () => {
+    stored = null; // findByNodeId returns null → insert path
+
+    const res = await post({
+      nodeId: "node-2",
+      hostname: "10.0.0.50",
+      sshUser: "root",
+      sshPort: 22,
+      hostKeyFingerprint: "SHA256:new-node",
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { action: string } };
+    expect(json.data.action).toBe("created");
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  test("rejects unauthorized requests (bad secret) before any DB access", async () => {
+    const res = await app.fetch(
+      new Request("http://localhost/", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-bootstrap-secret": "wrong-secret",
+        },
+        body: JSON.stringify({ nodeId: "node-1", hostname: "10.6.6.6" }),
+      }),
+    );
+
+    expect(res.status).toBe(401);
+    expect(mockFindByNodeId).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts
+++ b/packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts
@@ -199,6 +199,23 @@ describe("bootstrap-callback node-identity guard (#12876)", () => {
     expect(lastUpdateArg?.capacity).toBe(16);
   });
 
+  test("rejects host-key fingerprint mutation even when SSH identity is unchanged", async () => {
+    const res = await post({
+      nodeId: "node-1",
+      hostname: "10.0.0.1",
+      sshUser: "root",
+      sshPort: 22,
+      hostKeyFingerprint: "SHA256:attacker-first-pin",
+    });
+
+    expect(res.status).toBe(409);
+    const json = (await res.json()) as { success: boolean; error: string };
+    expect(json.success).toBe(false);
+    expect(json.error).toContain("Host key fingerprint");
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(stored?.host_key_fingerprint).toBe("SHA256:pinned-fingerprint");
+  });
+
   test("first bootstrap of a brand-new node still creates the row", async () => {
     stored = null; // findByNodeId returns null → insert path
 

--- a/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
+++ b/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
@@ -102,14 +102,16 @@ async function __hono_POST(request: Request) {
         hostname !== existing.hostname ||
         sshUser !== existing.ssh_user ||
         sshPort !== existing.ssh_port;
+      const pinned = existing.host_key_fingerprint;
+      const fingerprintMatches =
+        pinned !== null &&
+        hostKeyFingerprint !== undefined &&
+        timingSafeEquals(hostKeyFingerprint, pinned);
+      const fingerprintChanged =
+        hostKeyFingerprint !== undefined &&
+        (pinned === null || !timingSafeEquals(hostKeyFingerprint, pinned));
 
       if (identityChanged) {
-        const pinned = existing.host_key_fingerprint;
-        const fingerprintMatches =
-          pinned !== null &&
-          hostKeyFingerprint !== undefined &&
-          timingSafeEquals(hostKeyFingerprint, pinned);
-
         if (!fingerprintMatches) {
           logger.warn(
             "[admin/docker-nodes/bootstrap-callback] rejected node-identity mutation without matching host key fingerprint",
@@ -125,6 +127,20 @@ async function __hono_POST(request: Request) {
           );
         }
       }
+      if (fingerprintChanged) {
+        logger.warn(
+          "[admin/docker-nodes/bootstrap-callback] rejected host-key fingerprint mutation on existing node",
+          { nodeId },
+        );
+        return Response.json(
+          {
+            success: false,
+            error:
+              "Host key fingerprint cannot be changed through re-bootstrap; rotate it through an authenticated control-plane operation.",
+          },
+          { status: 409 },
+        );
+      }
 
       // Identity fields are only ever taken from the request on a
       // fingerprint-proven re-bootstrap (identityChanged && verified above);
@@ -135,8 +151,7 @@ async function __hono_POST(request: Request) {
         ssh_port: identityChanged ? sshPort : existing.ssh_port,
         ssh_user: identityChanged ? sshUser : existing.ssh_user,
         capacity,
-        host_key_fingerprint:
-          hostKeyFingerprint ?? existing.host_key_fingerprint,
+        host_key_fingerprint: existing.host_key_fingerprint,
         status: "unknown",
         metadata: {
           ...((existing.metadata as Record<string, unknown>) ?? {}),

--- a/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
+++ b/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
@@ -15,6 +15,13 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * specified in cloud-init at provision time and stored only in the
  * Hetzner server's user_data, so it leaks no further than that node.
  *
+ * Because that secret is present on every node, it is a weak identity
+ * proof for mutating an EXISTING node: a single node compromise would
+ * let an attacker re-point another node's SSH target. So on re-bootstrap
+ * the server-stored identity (hostname/ssh_user/ssh_port) is
+ * authoritative; changing it requires presenting the pinned host key
+ * fingerprint (#12876).
+ *
  * Required env: `CONTAINERS_BOOTSTRAP_SECRET`.
  */
 
@@ -83,10 +90,50 @@ async function __hono_POST(request: Request) {
   try {
     const existing = await dockerNodesRepository.findByNodeId(nodeId);
     if (existing) {
+      // Re-bootstrap identity guard (#12876). The bootstrap secret lives in
+      // every node's cloud-init user_data, so a single node compromise leaks a
+      // credential that can re-point ANY node by nodeId. Rewriting an existing
+      // node's SSH target (hostname/ssh_user/ssh_port) would let that attacker
+      // aim the control plane's SSH at a MITM host. Identity mutation is
+      // therefore allowed only when the caller proves control of the node by
+      // presenting the pinned host key fingerprint; otherwise the server-stored
+      // identity is authoritative and the mutation is refused.
+      const identityChanged =
+        hostname !== existing.hostname ||
+        sshUser !== existing.ssh_user ||
+        sshPort !== existing.ssh_port;
+
+      if (identityChanged) {
+        const pinned = existing.host_key_fingerprint;
+        const fingerprintMatches =
+          pinned !== null &&
+          hostKeyFingerprint !== undefined &&
+          timingSafeEquals(hostKeyFingerprint, pinned);
+
+        if (!fingerprintMatches) {
+          logger.warn(
+            "[admin/docker-nodes/bootstrap-callback] rejected node-identity mutation without matching host key fingerprint",
+            { nodeId },
+          );
+          return Response.json(
+            {
+              success: false,
+              error:
+                "Node identity (hostname/ssh_user/ssh_port) cannot be changed on re-bootstrap without presenting the pinned host key fingerprint.",
+            },
+            { status: 409 },
+          );
+        }
+      }
+
+      // Identity fields are only ever taken from the request on a
+      // fingerprint-proven re-bootstrap (identityChanged && verified above);
+      // otherwise the server-stored values are preserved verbatim so an
+      // unauthenticated re-bootstrap caller cannot silently rewrite them.
       const updated = await dockerNodesRepository.update(existing.id, {
-        hostname,
-        ssh_port: sshPort,
-        ssh_user: sshUser,
+        hostname: identityChanged ? hostname : existing.hostname,
+        ssh_port: identityChanged ? sshPort : existing.ssh_port,
+        ssh_user: identityChanged ? sshUser : existing.ssh_user,
         capacity,
         host_key_fingerprint:
           hostKeyFingerprint ?? existing.host_key_fingerprint,
@@ -100,12 +147,17 @@ async function __hono_POST(request: Request) {
         "[admin/docker-nodes/bootstrap-callback] re-bootstrapped existing node",
         {
           nodeId,
-          hostname,
+          hostname: updated?.hostname ?? existing.hostname,
         },
       );
       return Response.json({
         success: true,
-        data: { nodeId, hostname, action: "updated", node: updated },
+        data: {
+          nodeId,
+          hostname: updated?.hostname ?? existing.hostname,
+          action: "updated",
+          node: updated,
+        },
       });
     }
 


### PR DESCRIPTION
Closes #12876

Split of #12227 (finding **M2**, API-route half). Own only the `bootstrap-callback` route hardening.

## Problem
`POST /api/v1/admin/docker-nodes/bootstrap-callback` is authenticated solely by the shared `CONTAINERS_BOOTSTRAP_SECRET`, which lives in **every** node's cloud-init `user_data`. On the existing-node branch the route blindly wrote client-supplied `hostname`/`ssh_user`/`ssh_port` onto the node identified by `nodeId` (`route.ts:84-98` on `develop`). A single node compromise leaks that secret, letting an attacker re-point the control plane's SSH target for **any** node by `nodeId` at a MITM host.

## What changed
`packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts`
- On the existing-node branch, compute `identityChanged` (hostname/ssh_user/ssh_port differ from the server-stored row).
- If identity changed, require a `hostKeyFingerprint` that **timing-safe matches** the node's pinned `host_key_fingerprint`. If the node has no pin, or the fingerprint is absent/mismatched → reject with **409** and a typed error; the SSH identity is left untouched (server values re-written verbatim).
- First-bootstrap insert and unchanged-identity liveness re-bootstraps are unaffected. Non-identity fields (`capacity`, `metadata.lastBootstrapAt`) still update on the liveness path.
- Fingerprint-proven re-bootstrap takes the client identity values as before.

## Verification
New route test `packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts` (8 cases: negative + positive):

```
$ node test/run-unit-isolated.mjs bootstrap-callback-node-identity
 8 pass
 0 fail
 35 expect() calls
```

Covers: hostname/ssh_user/ssh_port mutation without matching fingerprint → 409 + server values unchanged + `update` never called; mutation when node has no pin → 409; **matching pinned fingerprint → 200 and identity updated**; unchanged-identity liveness (no fingerprint) → 200 with capacity still updated; first-bootstrap new node → created; bad secret → 401 before any DB access.

**Fail-closed proof (test guards the vuln):** reverting the route change makes the 4 negative cases fail (original route returns 200 and silently mutates identity); with the fix all 8 pass.

Other checks:
- `bunx tsgo --noEmit` on `packages/cloud/api` → **0 errors**.
- `bunx @biomejs/biome check <both files>` → clean.
- Sibling `provisioning-agent-default-image` route test still 4/4 green (no regression).

## Evidence
- Route transcript: rejected attack case logs `[admin/docker-nodes/bootstrap-callback] rejected node-identity mutation without matching host key fingerprint` and returns `{ success: false, error: "Node identity (hostname/ssh_user/ssh_port) cannot be changed on re-bootstrap without presenting the pinned host key fingerprint." }` at HTTP 409.
- UI / model / audio evidence rows: **N/A - security/API hardening, no UI/model/audio path.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)