### PR TITLE
chore(plugin-anthropic-proxy): fix lint check after script normalization

### DIFF
--- a/plugins/plugin-anthropic-proxy/src/proxy/cc-tool-injection.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/cc-tool-injection.ts
@@ -79,8 +79,8 @@ export function processToolsSection(
     let syntheticToolsInjected = 0;
     if (injectSyntheticTools) {
       const insertAt = '"tools":['.length;
-      section =
-        section.slice(0, insertAt) + CC_SYNTHETIC_TOOLS.join(",") + "," + section.slice(insertAt);
+      const syntheticTools = CC_SYNTHETIC_TOOLS.join(",");
+      section = `${section.slice(0, insertAt)}${syntheticTools},${section.slice(insertAt)}`;
       syntheticToolsInjected = CC_SYNTHETIC_TOOLS.length;
     }
     return {
@@ -92,8 +92,9 @@ export function processToolsSection(
 
   if (injectSyntheticTools) {
     const insertAt = toolsIdx + '"tools":['.length;
+    const syntheticTools = CC_SYNTHETIC_TOOLS.join(",");
     return {
-      body: m.slice(0, insertAt) + CC_SYNTHETIC_TOOLS.join(",") + "," + m.slice(insertAt),
+      body: `${m.slice(0, insertAt)}${syntheticTools},${m.slice(insertAt)}`,
       descriptionsStripped: 0,
       syntheticToolsInjected: CC_SYNTHETIC_TOOLS.length,
     };

--- a/plugins/plugin-anthropic-proxy/src/utils/credentials-loader.ts
+++ b/plugins/plugin-anthropic-proxy/src/utils/credentials-loader.ts
@@ -36,7 +36,8 @@ function jwtExpiresAt(token: string): number {
   try {
     const parts = token.split(".");
     if (parts.length < 2) return 0;
-    const payload = parts[1]!;
+    const payload = parts[1];
+    if (!payload) return 0;
     // base64url -> base64
     const b64 = payload.replace(/-/g, "+").replace(/_/g, "/");
     const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);


### PR DESCRIPTION
## Summary
- fix the `plugin-anthropic-proxy lint:check` findings introduced after #12949 added the package Biome config
- replace synthetic-tool string concatenation with explicit template assembly
- replace a JWT payload non-null assertion with an explicit empty-payload guard

## Verification
- `bun run --cwd plugins/plugin-anthropic-proxy lint:check` — PASS
- `bun run --cwd plugins/plugin-anthropic-proxy typecheck` — PASS
- `bun run --cwd plugins/plugin-anthropic-proxy test` — PASS, 8 files / 54 tests
- `git diff --check origin/develop...HEAD` — PASS

## Evidence Matrix
- Real-LLM trajectories: N/A - package lint/type cleanup only; no model behavior changed
- Backend/frontend logs: N/A - no runtime server path exercised
- Screenshots/video: N/A - no UI changed
- Domain artifacts: N/A - no generated runtime artifacts changed
