### PR TITLE
docs(#12907): align WeChat plugin script guide

### DIFF
--- a/plugins/plugin-wechat/AGENTS.md
+++ b/plugins/plugin-wechat/AGENTS.md
@@ -53,9 +53,13 @@ plugins/plugin-wechat/
 
 ```bash
 bun run --cwd plugins/plugin-wechat build       # tsup + tsc declaration emit
-bun run --cwd plugins/plugin-wechat check       # tsc type-check (no emit)
+bun run --cwd plugins/plugin-wechat typecheck   # tsgo --noEmit -p tsconfig.json
 bun run --cwd plugins/plugin-wechat test        # vitest run
 bun run --cwd plugins/plugin-wechat test:watch  # vitest watch
+bun run --cwd plugins/plugin-wechat lint        # biome check --write --unsafe
+bun run --cwd plugins/plugin-wechat lint:check  # biome check (read-only)
+bun run --cwd plugins/plugin-wechat format      # biome format --write
+bun run --cwd plugins/plugin-wechat format:check # biome format (read-only)
 bun run --cwd plugins/plugin-wechat clean       # rm -rf dist
 ```
 

--- a/plugins/plugin-wechat/CLAUDE.md
+++ b/plugins/plugin-wechat/CLAUDE.md
@@ -53,9 +53,13 @@ plugins/plugin-wechat/
 
 ```bash
 bun run --cwd plugins/plugin-wechat build       # tsup + tsc declaration emit
-bun run --cwd plugins/plugin-wechat check       # tsc type-check (no emit)
+bun run --cwd plugins/plugin-wechat typecheck   # tsgo --noEmit -p tsconfig.json
 bun run --cwd plugins/plugin-wechat test        # vitest run
 bun run --cwd plugins/plugin-wechat test:watch  # vitest watch
+bun run --cwd plugins/plugin-wechat lint        # biome check --write --unsafe
+bun run --cwd plugins/plugin-wechat lint:check  # biome check (read-only)
+bun run --cwd plugins/plugin-wechat format      # biome format --write
+bun run --cwd plugins/plugin-wechat format:check # biome format (read-only)
 bun run --cwd plugins/plugin-wechat clean       # rm -rf dist
 ```
 


### PR DESCRIPTION
Follow-up to #12959 / #12907. The connector script normalization removed plugin-wechat's nonstandard `check` script and added standard `typecheck`, `lint`, `lint:check`, `format`, and `format:check` verbs. This updates the package-local CLAUDE.md and AGENTS.md so future agents do not follow a removed command.\n\nValidation:\n- cmp verified plugins/plugin-wechat/CLAUDE.md and plugins/plugin-wechat/AGENTS.md are identical.\n- rg verified the removed `bun run --cwd plugins/plugin-wechat check` command is absent.\n- git diff --check passed.\n- While reviewing #12959, `bun run --cwd plugins/plugin-wechat typecheck` passed and `bun run --cwd plugins/plugin-wechat test` passed: 2 files / 5 tests.\n\nN/A: runtime connector screenshots/trajectory; documentation-only follow-up with no code behavior change.