### PR TITLE
fix(#12896): settle speculative attribution cancel

### DIFF
--- a/.github/issue-evidence/12896-attribution-cancel-settles.md
+++ b/.github/issue-evidence/12896-attribution-cancel-settles.md
@@ -1,0 +1,40 @@
+# Issue #12896 - Attribution Cancel Settles First Window
+
+## Change
+
+- `VoiceAttributionPipeline.beginTurn()` now wraps the speculative match handle so `cancel()` first settles the pending first-window promise with `null`, then delegates to the profile-store cancellation.
+- Abort signals passed to `beginTurn()` use the same cancellation path, so an aborted speculative lookup cannot leave the first-window embed continuation suspended.
+- `AudioFrameConsumer` regression coverage now drives the public `close()` path and the zero-buffer `speech-end` path with a real `VoiceAttributionPipeline` and real `VoiceProfileStore`.
+
+## Manual Review
+
+- Reviewed the wrapped cancel path by hand: normal `pushWindow()` and `finalize()` still settle the first window with audio, while close/cancel/abort settle it with `null`.
+- Reviewed the new tests: they wrap `VoiceProfileStore.beginMatch()` only to observe when the real embed continuation exits, then assert both the embed continuation and speculative `result` settle through the consumer's real cancellation paths.
+
+## Verification
+
+```bash
+bun install --no-save --ignore-scripts --cache-dir "$HOME/.bun-install-cache-deploy"
+node packages/scripts/ensure-workspace-symlinks.mjs
+node packages/shared/scripts/generate-keywords.mjs --target ts
+bun run --cwd packages/contracts build
+bun run --cwd packages/cloud/routing build
+bun run --cwd plugins/plugin-local-inference test src/services/voice/audio-frame-consumer.windowed.test.ts
+bunx @biomejs/biome check plugins/plugin-local-inference/src/services/voice/speaker/attribution-pipeline.ts plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.windowed.test.ts
+bun run --cwd plugins/plugin-local-inference typecheck
+git diff --check
+```
+
+Results:
+
+- Focused Vitest: 1 file passed, 5 tests passed.
+- Biome touched-file check: passed.
+- `plugins/plugin-local-inference` typecheck: passed.
+- `git diff --check`: passed.
+
+## Evidence N/A
+
+- Real audio capture: N/A - no native audio device, FFI model, or capture transport changed.
+- Hardware/mobile/desktop capture: N/A - unit-level lifecycle regression only.
+- Screenshots/video/frontend logs: N/A - non-UI runtime change.
+- Real-LLM trajectories: N/A - no prompt/action/provider/model behavior changed.

--- a/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.windowed.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.windowed.test.ts
@@ -6,21 +6,38 @@
  * to one window. A pipeline without `beginTurn` still takes the one-shot path.
  */
 
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import {
 	type AttributionPipelineLike,
 	AudioFrameConsumer,
 	type RuntimeEventSink,
 	type VadSegmenter,
 } from "./audio-frame-consumer";
+import {
+	type VoiceImprintMatchHandle,
+	VoiceProfileStore,
+} from "./profile-store";
 import type {
 	IncrementalTurnAttributor,
 	VoiceAttributionOutput,
 } from "./speaker/attribution-pipeline";
+import { VoiceAttributionPipeline } from "./speaker/attribution-pipeline";
+import type { SpeakerEncoder } from "./speaker/encoder";
 import type { PcmFrame, VadEvent } from "./types";
 
 const SR = 16_000;
 const WINDOW_SAMPLES = 5 * SR;
+const MODEL = "wespeaker-resnet34-lm-int8";
+const tempRoots: string[] = [];
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
 
 /** VAD the test drives directly — no Silero, no scripted probabilities. */
 class ManualVad implements VadSegmenter {
@@ -150,6 +167,85 @@ function buildConsumer(pipeline: AttributionPipelineLike) {
 	return { vad, consumer, turns };
 }
 
+function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timeout = setTimeout(
+			() => reject(new Error(`${label} did not settle`)),
+			100,
+		);
+		promise.then(
+			(value) => {
+				clearTimeout(timeout);
+				resolve(value);
+			},
+			(error) => {
+				clearTimeout(timeout);
+				reject(error);
+			},
+		);
+	});
+}
+
+async function buildRealAttributionConsumer(): Promise<{
+	vad: ManualVad;
+	consumer: AudioFrameConsumer;
+	encoder: SpeakerEncoder & { calls: number };
+	getSpeculativeHandle: () => VoiceImprintMatchHandle;
+	embedSettled: Promise<void>;
+}> {
+	const dir = mkdtempSync(path.join(tmpdir(), "aframe-cancel-"));
+	tempRoots.push(dir);
+	const store = new VoiceProfileStore({ rootDir: dir });
+	await store.init();
+
+	let handle: VoiceImprintMatchHandle | null = null;
+	let resolveEmbedSettled: () => void = () => {};
+	const embedSettled = new Promise<void>((resolve) => {
+		resolveEmbedSettled = resolve;
+	});
+	const beginMatch = store.beginMatch.bind(store);
+	store.beginMatch = ((args) => {
+		handle = beginMatch({
+			...args,
+			embed: async () => {
+				try {
+					return await args.embed();
+				} finally {
+					resolveEmbedSettled();
+				}
+			},
+		});
+		return handle;
+	}) as VoiceProfileStore["beginMatch"];
+
+	const encoder: SpeakerEncoder & { calls: number } = {
+		embeddingDim: 256,
+		sampleRate: SR,
+		modelId: MODEL,
+		calls: 0,
+		async encode() {
+			this.calls += 1;
+			return new Float32Array(256);
+		},
+		async dispose() {},
+	};
+	const pipeline = new VoiceAttributionPipeline({
+		encoder,
+		profileStore: store,
+	});
+	const { vad, consumer } = buildConsumer(pipeline);
+	return {
+		vad,
+		consumer,
+		encoder,
+		getSpeculativeHandle: () => {
+			if (!handle) throw new Error("speculative handle was not created");
+			return handle;
+		},
+		embedSettled,
+	};
+}
+
 /** Push `seconds` of turn audio as 0.5 s decoded frames from `startMs`. */
 async function pushSpeech(
 	consumer: AudioFrameConsumer,
@@ -235,5 +331,44 @@ describe("AudioFrameConsumer windowed long-turn attribution (#12257)", () => {
 		expect(pipeline.attributeCalls).toBe(1);
 		expect(pipeline.lastPcmLength).toBe(12 * SR);
 		expect(turns).toHaveLength(1);
+	});
+
+	it("close settles an open turn's suspended speculative first-window embed", async () => {
+		const { vad, consumer, encoder, getSpeculativeHandle, embedSettled } =
+			await buildRealAttributionConsumer();
+
+		vad.emit({ type: "speech-start", timestampMs: 0, probability: 0.9 });
+		const speculative = getSpeculativeHandle();
+		await consumer.close();
+
+		await expect(
+			withTimeout(embedSettled, "close speculative embed"),
+		).resolves.toBeUndefined();
+		await expect(
+			withTimeout(speculative.result, "close speculative result"),
+		).resolves.toBeNull();
+		expect(encoder.calls).toBe(0);
+	});
+
+	it("zero-buffer finalize settles the suspended speculative first-window embed", async () => {
+		const { vad, consumer, encoder, getSpeculativeHandle, embedSettled } =
+			await buildRealAttributionConsumer();
+
+		vad.emit({ type: "speech-start", timestampMs: 0, probability: 0.9 });
+		const speculative = getSpeculativeHandle();
+		vad.emit({
+			type: "speech-end",
+			timestampMs: 0,
+			speechDurationMs: 0,
+		});
+		await consumer.flush();
+
+		await expect(
+			withTimeout(embedSettled, "zero-buffer speculative embed"),
+		).resolves.toBeUndefined();
+		await expect(
+			withTimeout(speculative.result, "zero-buffer speculative result"),
+		).resolves.toBeNull();
+		expect(encoder.calls).toBe(0);
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/speaker/attribution-pipeline.ts
+++ b/plugins/plugin-local-inference/src/services/voice/speaker/attribution-pipeline.ts
@@ -246,14 +246,16 @@ export class VoiceAttributionPipeline {
 		const firstWindow = new Promise<Float32Array | null>((resolve) => {
 			resolveFirstWindow = resolve;
 		});
+		let removeCancelSignalListener: () => void = () => {};
 		let firstWindowSettled = false;
 		const settleFirstWindow = (pcm: Float32Array | null): void => {
 			if (firstWindowSettled) return;
 			firstWindowSettled = true;
+			removeCancelSignalListener();
 			resolveFirstWindow(pcm);
 		};
 
-		const speculativeMatch = this.deps.profileStore.beginMatch({
+		const storeSpeculativeMatch = this.deps.profileStore.beginMatch({
 			embed: async () => {
 				const pcm = await firstWindow;
 				if (!pcm || pcm.length < WESPEAKER_MIN_SAMPLES) return null;
@@ -265,6 +267,28 @@ export class VoiceAttributionPipeline {
 			},
 			...(init.signal ? { signal: init.signal } : {}),
 		});
+		const cancelSpeculativeMatch = (): void => {
+			settleFirstWindow(null);
+			storeSpeculativeMatch.cancel();
+		};
+		if (init.signal) {
+			if (init.signal.aborted) {
+				cancelSpeculativeMatch();
+			} else {
+				init.signal.addEventListener("abort", cancelSpeculativeMatch, {
+					once: true,
+				});
+				removeCancelSignalListener = () => {
+					init.signal?.removeEventListener("abort", cancelSpeculativeMatch);
+					removeCancelSignalListener = () => {};
+				};
+			}
+		}
+		const speculativeMatch: VoiceImprintMatchHandle = {
+			result: storeSpeculativeMatch.result,
+			current: () => storeSpeculativeMatch.current(),
+			cancel: cancelSpeculativeMatch,
+		};
 
 		const diarizeInto = async (
 			pcm: Float32Array,


### PR DESCRIPTION
## Summary
- Wrap `VoiceAttributionPipeline.beginTurn()` speculative match cancellation so it settles the pending first-window promise with `null` before delegating to the profile-store handle.
- Route `beginTurn()` abort signals through the same cancel path.
- Add `AudioFrameConsumer` regressions for both public cancellation paths from the issue: `close()` while a turn is open, and zero-buffer `speech-end`/finalize.

## Verification
- `bun install --no-save --ignore-scripts --cache-dir "$HOME/.bun-install-cache-deploy"`
- `node packages/scripts/ensure-workspace-symlinks.mjs`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/contracts build`
- `bun run --cwd packages/cloud/routing build`
- `bun run --cwd plugins/plugin-local-inference test src/services/voice/audio-frame-consumer.windowed.test.ts`
- `bunx @biomejs/biome check plugins/plugin-local-inference/src/services/voice/speaker/attribution-pipeline.ts plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.windowed.test.ts`
- `bun run --cwd plugins/plugin-local-inference typecheck`
- `git diff --check origin/develop..HEAD`

## Evidence
- `.github/issue-evidence/12896-attribution-cancel-settles.md`
- Real audio capture: N/A - no native audio device, FFI model, or capture transport changed.
- Hardware/mobile/desktop capture: N/A - unit-level lifecycle regression only.
- Screenshots/video/frontend logs: N/A - non-UI runtime change.
- Real-LLM trajectories: N/A - no prompt/action/provider/model behavior changed.

Fixes #12896