### PR TITLE
refactor(#12790): typed failures over fallback slop in cloud sdk/routing

### DIFF
--- a/packages/cloud/routing/src/resolve.test.ts
+++ b/packages/cloud/routing/src/resolve.test.ts
@@ -203,6 +203,8 @@ describe("cloud routing helpers", () => {
     "//evil.test/api/v1",
     "https://cloud.example.com/api/v1?x=1",
     "https://cloud.example.com/api/v1#frag",
+    "not a url",
+    "http://",
   ])("rejects unsafe cloud base URLs: %s", (baseUrl) => {
     expect(
       cloudServiceApisBaseUrl(

--- a/packages/cloud/routing/src/resolve.ts
+++ b/packages/cloud/routing/src/resolve.ts
@@ -58,6 +58,9 @@ function normalizeCloudBaseUrl(rawUrl: string): string | null {
   try {
     parsed = new URL(rawUrl);
   } catch {
+    // error-policy:J3 rawUrl is a caller/config-provided string; an unparseable
+    // value is an explicit "no valid cloud base" signal (null), which
+    // buildCloudProxyRoute keeps distinct from a resolved route.
     return null;
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {

--- a/packages/cloud/sdk/src/client.ts
+++ b/packages/cloud/sdk/src/client.ts
@@ -173,8 +173,10 @@ function normalizeCloudApiBaseUrl(
   let url: URL;
   try {
     url = new URL(baseUrl);
-  } catch {
-    throw new Error(`Invalid Eliza Cloud API base URL: ${baseUrl}`);
+  } catch (cause) {
+    // error-policy:J2 translate an opaque URL parse failure into a named,
+    // actionable config error at the SDK construction boundary.
+    throw new Error(`Invalid Eliza Cloud API base URL: ${baseUrl}`, { cause });
   }
   if (url.protocol !== "http:" && url.protocol !== "https:") {
     throw new Error(`Invalid Eliza Cloud API base URL protocol: ${baseUrl}`);
@@ -205,7 +207,9 @@ function browserBaseUrlForCliLogin(baseUrl: string): string {
       return DEFAULT_ELIZA_CLOUD_BASE_URL;
     }
   } catch {
-    // Fall through to the configured base URL.
+    // error-policy:J3 baseUrl is a configured string, not guaranteed parseable;
+    // this is an opportunistic host swap, so an unparseable input yields the
+    // identity result (the configured URL) rather than failing the login start.
   }
   return baseUrl;
 }

--- a/packages/cloud/sdk/src/http.test.ts
+++ b/packages/cloud/sdk/src/http.test.ts
@@ -225,4 +225,67 @@ describe("ElizaCloudHttpClient errors", () => {
       },
     });
   });
+
+  it("throws instead of fabricating success on a 2xx with malformed JSON", async () => {
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: asFetch(
+        async () =>
+          new Response("{not-json", {
+            status: 200,
+            statusText: "OK",
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    });
+
+    await expect(client.request("GET", "/api/test")).rejects.toMatchObject({
+      name: "CloudApiError",
+      statusCode: 200,
+      errorBody: {
+        success: false,
+        error: "HTTP 200: malformed JSON response body: {not-json",
+      },
+    });
+  });
+
+  it("keeps not-found, auth, and server failures as distinct statuses", async () => {
+    const respondWith = (status: number, statusText: string) =>
+      new ElizaCloudHttpClient({
+        baseUrl: "https://cloud.test",
+        fetchImpl: asFetch(async () =>
+          Response.json(
+            { success: false, error: statusText },
+            { status, statusText },
+          ),
+        ),
+      });
+
+    await expect(
+      respondWith(404, "Not Found").request("GET", "/api/x"),
+    ).rejects.toMatchObject({ name: "CloudApiError", statusCode: 404 });
+    await expect(
+      respondWith(401, "Unauthorized").request("GET", "/api/x"),
+    ).rejects.toMatchObject({ name: "CloudApiError", statusCode: 401 });
+    await expect(
+      respondWith(500, "Internal Server Error").request("GET", "/api/x"),
+    ).rejects.toMatchObject({ name: "CloudApiError", statusCode: 500 });
+  });
+
+  it("accepts a 2xx text/plain body as a success without JSON parsing", async () => {
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: asFetch(
+        async () =>
+          new Response("pong", {
+            status: 200,
+            headers: { "content-type": "text/plain" },
+          }),
+      ),
+    });
+
+    await expect(client.request("GET", "/api/ping")).resolves.toEqual({
+      success: true,
+    });
+  });
 });

--- a/packages/cloud/sdk/src/http.test.ts
+++ b/packages/cloud/sdk/src/http.test.ts
@@ -249,6 +249,25 @@ describe("ElizaCloudHttpClient errors", () => {
     });
   });
 
+  it("does not confuse valid JSON fields with the internal malformed-json marker", async () => {
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: asFetch(async () =>
+        Response.json({
+          success: true,
+          kind: "malformed-json",
+          text: "this is valid application JSON",
+        }),
+      ),
+    });
+
+    await expect(client.request("GET", "/api/test")).resolves.toEqual({
+      success: true,
+      kind: "malformed-json",
+      text: "this is valid application JSON",
+    });
+  });
+
   it("keeps not-found, auth, and server failures as distinct statuses", async () => {
     const respondWith = (status: number, statusText: string) =>
       new ElizaCloudHttpClient({

--- a/packages/cloud/sdk/src/http.ts
+++ b/packages/cloud/sdk/src/http.ts
@@ -84,14 +84,20 @@ function resolveUrl(
  * on a 2xx response `request()` promotes this to a thrown failure rather than
  * fabricating a success — a malformed JSON body is a broken response, not data.
  */
+const malformedJsonBodyBrand = Symbol("MalformedJsonBody");
+
 interface MalformedJsonBody {
+  readonly [malformedJsonBodyBrand]: true;
   readonly kind: "malformed-json";
   readonly text: string;
 }
 
 function isMalformedJsonBody(value: unknown): value is MalformedJsonBody {
   return (
-    isRecord(value) && (value as { kind?: unknown }).kind === "malformed-json"
+    isRecord(value) &&
+    (value as { [malformedJsonBodyBrand]?: unknown })[
+      malformedJsonBodyBrand
+    ] === true
   );
 }
 
@@ -109,7 +115,11 @@ async function parseResponseBody(response: Response): Promise<unknown> {
   } catch {
     // error-policy:J3 declared-JSON parse failure returns a typed marker; the
     // caller surfaces it (error path) or throws (2xx), never a fake success.
-    return { kind: "malformed-json", text } satisfies MalformedJsonBody;
+    return {
+      [malformedJsonBodyBrand]: true,
+      kind: "malformed-json",
+      text,
+    } satisfies MalformedJsonBody;
   }
 }
 

--- a/packages/cloud/sdk/src/http.ts
+++ b/packages/cloud/sdk/src/http.ts
@@ -78,6 +78,23 @@ function resolveUrl(
   return appendQuery(url, query).toString();
 }
 
+/**
+ * A body the server labelled `application/json` but that failed to parse. The
+ * raw text is retained so error responses can still surface it in their message;
+ * on a 2xx response `request()` promotes this to a thrown failure rather than
+ * fabricating a success — a malformed JSON body is a broken response, not data.
+ */
+interface MalformedJsonBody {
+  readonly kind: "malformed-json";
+  readonly text: string;
+}
+
+function isMalformedJsonBody(value: unknown): value is MalformedJsonBody {
+  return (
+    isRecord(value) && (value as { kind?: unknown }).kind === "malformed-json"
+  );
+}
+
 async function parseResponseBody(response: Response): Promise<unknown> {
   const text = await response.text();
   if (!text) return undefined;
@@ -90,7 +107,9 @@ async function parseResponseBody(response: Response): Promise<unknown> {
   try {
     return JSON.parse(text);
   } catch {
-    return text;
+    // error-policy:J3 declared-JSON parse failure returns a typed marker; the
+    // caller surfaces it (error path) or throws (2xx), never a fake success.
+    return { kind: "malformed-json", text } satisfies MalformedJsonBody;
   }
 }
 
@@ -99,6 +118,12 @@ function normalizeErrorBody(
   statusText: string,
   body: unknown,
 ): CloudApiErrorBody {
+  if (isMalformedJsonBody(body)) {
+    return {
+      success: false,
+      error: `HTTP ${status}: ${body.text}`,
+    };
+  }
   if (isRecord(body)) {
     const rawError = body.error;
     const errorObject = isRecord(rawError) ? rawError : null;
@@ -288,6 +313,15 @@ export class ElizaCloudHttpClient {
       throw response.status === 402
         ? new InsufficientCreditsError(errorBody)
         : new CloudApiError(response.status, errorBody);
+    }
+
+    // A 2xx that promised JSON but delivered unparseable bytes is a broken
+    // response, not a success — surface it instead of fabricating one.
+    if (isMalformedJsonBody(body)) {
+      throw new CloudApiError(response.status, {
+        success: false,
+        error: `HTTP ${response.status}: malformed JSON response body: ${body.text}`,
+      });
     }
 
     if (body === undefined || typeof body === "string") {


### PR DESCRIPTION
Closes #12790

## Scope re-derivation (`packages/cloud/{sdk,routing,infra,docs-redirect}`, non-test)
Re-ran the inventory grep against `origin/develop`. Actual hits:

- **`sdk`**: 3 `new URL()` catches (`http.ts`, `client.ts` ×2), plus a `{ success: true }` fabrication on the success path.
- **`routing`**: 1 `new URL()` catch (`resolve.ts`).
- **`infra`**: **no `.ts`/`.tsx` source** — IaC only (terraform, docker-compose, charts, shell). Nothing to change.
- **`docs-redirect`**: `worker.ts` is a pure 301 redirect — no catch/console/fallback. Nothing to change.
- **console sites**: 0. **`.catch()` sites**: 0. (Already clean.)

## Fixed (real slop → typed failure)
| Path | Line | Was | Now |
|---|---|---|---|
| `packages/cloud/sdk/src/http.ts` | `parseResponseBody` / `request` | a **2xx** response that declared `application/json` but delivered unparseable bytes fell through to `return { success: true }` — a broken upstream read as a healthy success | `parseResponseBody` returns a typed `malformed-json` marker; error path still surfaces the raw text, **2xx path throws `CloudApiError`** instead of fabricating success |

## Justified keeps (annotated `// error-policy:J<N>`)
| Path | Line | Category | Reason |
|---|---|---|---|
| `packages/cloud/sdk/src/http.ts` | `parseResponseBody` catch | **J3** | declared-JSON parse failure yields a typed marker the caller surfaces/throws on — never a fake-valid default |
| `packages/cloud/sdk/src/client.ts` | `normalizeCloudApiBaseUrl` catch | **J2** | translates an opaque `new URL()` failure into a named config error at the SDK construction boundary; now attaches `cause` |
| `packages/cloud/sdk/src/client.ts` | `browserBaseUrlForCliLogin` catch | **J3** | `baseUrl` is a configured string, not guaranteed parseable; an opportunistic host swap returns the identity result on parse failure rather than failing login start |
| `packages/cloud/routing/src/resolve.ts` | `normalizeCloudBaseUrl` catch | **J3** | unparseable config URL → explicit `null` "no valid cloud base" signal, kept distinct from a resolved route |

Nullish-literal sites reviewed and left: `features.ts:66` (`?? null` = typed lookup-miss), `http.ts:208` (`requiredCredits ?? 0` = display mirror; authoritative `undefined` preserved in `errorBody`), `mock-service.ts:137` (mock counter init). None conflate a broken pipeline with empty/zero data.

## Tests (added, error-path, kinds kept distinct)
- **2xx + malformed JSON → throws** `CloudApiError` (not fabricated success).
- **2xx `text/plain` → still succeeds** (`{ success: true }`).
- **404 / 401 / 500 stay distinct** `statusCode`s (not-found/auth vs server failure).
- **unparseable cloud base URL** (`"not a url"`, `"http://"`) → disabled/`null` route.

## Verification
```
$ bunx vitest run packages/cloud/sdk/src/http.test.ts packages/cloud/routing/src/resolve.test.ts
  Test Files  2 passed (2)   Tests  75 passed (75)

$ cd packages/cloud/sdk && bun test src        # bun test runner (package default)
  69 pass, 19 skip, 0 fail  (Ran 88 tests across 9 files)

$ bun run --cwd packages/cloud/sdk typecheck   # tsgo --noEmit → exit 0
$ bun run --cwd packages/cloud/routing typecheck && test   # 63 passed, exit 0
$ bun run --cwd packages/cloud/sdk lint && --cwd packages/cloud/routing lint   # biome clean

$ node packages/scripts/error-policy-ratchet.mjs
  base origin/develop (13b7ae2369); 3 changed production source file(s)
  resolve.ts: emptyCatch 0->0   client.ts: emptyCatch 1->1   http.ts: emptyCatch 0->0
  no new fallback-slop in touched files
```

`client.ts` shows `emptyCatch 1->1`: the `browserBaseUrlForCliLogin` catch body is comment-only (the J3 annotation), counted by the AST heuristic; the count is unchanged (net-neutral), which is the policy-approved way to keep an annotated justified handler.

### Evidence rows
- Real-cloud LLM trajectory: **N/A** — no live-credential path exercised; the SDK/routing changes are pure request/response shaping, covered by injected-fetch unit tests.
- UI screenshots: **N/A** — no `packages/app/` or cloud-frontend surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)