### PR TITLE
fix(cloud-api): reject path-traversal suffixes in eliza-app webhook forwarder (#12878, L3)

### DIFF
--- a/packages/cloud/api/__tests__/eliza-app-webhook-suffix.test.ts
+++ b/packages/cloud/api/__tests__/eliza-app-webhook-suffix.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Path-traversal guard for the eliza-app webhook forwarder (finding L3, #12878).
+ *
+ * `_forward.ts` appends the request's trailing path onto the internal gateway
+ * URL. These tests pin that only empty/benign safe-char suffixes survive, and
+ * that any dot-segment or percent-encoded separator (which the URL parser leaves
+ * intact) is rejected before it can escape `/webhook/<project>/<platform>`.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+// Mock the logger before importing so loading the forwarder never pulls the
+// real logger chain (core → @elizaos/cloud-routing).
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(), info: mock(), warn: mock(), debug: mock() },
+}));
+
+const { safeWebhookSuffix } = (await import(
+  "../eliza-app/webhook/_forward"
+)) as typeof import("../eliza-app/webhook/_forward");
+
+const P = "telegram";
+const base = `/api/eliza-app/webhook/${P}`;
+
+describe("safeWebhookSuffix", () => {
+  test("an exact-match path has an empty suffix", () => {
+    expect(safeWebhookSuffix(base, P)).toBe("");
+  });
+
+  test("a bare trailing slash is normalized to empty", () => {
+    expect(safeWebhookSuffix(`${base}/`, P)).toBe("");
+  });
+
+  test("a benign safe-char sub-path is preserved", () => {
+    expect(safeWebhookSuffix(`${base}/inbound/v2`, P)).toBe("/inbound/v2");
+  });
+
+  test("a non-matching prefix yields empty (nothing to forward)", () => {
+    expect(safeWebhookSuffix("/api/other/telegram", P)).toBe("");
+  });
+
+  test.each([
+    `${base}/..`,
+    `${base}/../admin`,
+    `${base}/..%2fadmin`,
+    `${base}/%2e%2e%2fadmin`,
+    `${base}/foo%2f..%2fbar`,
+    `${base}/foo/../bar`,
+    `${base}/foo\\bar`,
+    `${base}/foo.bar`,
+    `${base}/foo%00`,
+  ])("rejects a traversal/encoded suffix: %s", (pathname) => {
+    expect(safeWebhookSuffix(pathname, P)).toBeNull();
+  });
+});

--- a/packages/cloud/api/eliza-app/webhook/_forward.ts
+++ b/packages/cloud/api/eliza-app/webhook/_forward.ts
@@ -19,12 +19,32 @@ function readStringEnv(c: AppContext, keys: readonly string[]): string | null {
   return null;
 }
 
-function requestSuffix(c: AppContext, platform: string): string {
-  const pathname = new URL(c.req.url).pathname;
+// The forwarder appends the request's trailing path onto the internal gateway
+// URL, so a traversal suffix (`..%2f…`, `%2e%2e…`, backslashes) would let a
+// caller escape `/webhook/<project>/<platform>` and hit arbitrary gateway paths.
+// The URL parser only collapses *literal* dot-segments, so percent-encoded
+// separators survive to here. Webhook routes are fixed paths, so a legitimate
+// suffix is only ever empty or benign safe-char segments — reject anything else
+// rather than forward it. (finding L3, #12878 / #12227)
+const SAFE_WEBHOOK_SUFFIX = /^(?:\/[A-Za-z0-9_-]+)*\/?$/;
+
+/**
+ * Extract the trailing path to forward from `pathname`, or `null` if it is a
+ * traversal attempt. Pure so the allowlist can be exercised directly.
+ */
+export function safeWebhookSuffix(
+  pathname: string,
+  platform: string,
+): string | null {
   const prefix = `/api/eliza-app/webhook/${platform}`;
   if (!pathname.startsWith(prefix)) return "";
   const suffix = pathname.slice(prefix.length);
-  return suffix === "/" ? "" : suffix;
+  if (suffix === "/" || suffix === "") return "";
+  return SAFE_WEBHOOK_SUFFIX.test(suffix) ? suffix : null;
+}
+
+function requestSuffix(c: AppContext, platform: string): string | null {
+  return safeWebhookSuffix(new URL(c.req.url).pathname, platform);
 }
 
 interface ForwardOptions {
@@ -94,14 +114,24 @@ export async function forwardToWebhookGateway(
     );
   }
 
+  const suffix = requestSuffix(c, platform);
+  if (suffix === null) {
+    logger.warn("[ElizaAppWebhook] rejected traversal suffix", { platform });
+    return c.json(
+      {
+        success: false,
+        code: "WEBHOOK_INVALID_PATH",
+        error: "Invalid webhook path",
+      },
+      400,
+    );
+  }
+
   const project =
     readStringEnv(c, ["ELIZA_APP_WEBHOOK_PROJECT"]) ?? "eliza-app";
   const target = new URL(baseUrl);
   const sourceUrl = new URL(c.req.url);
-  target.pathname = `/webhook/${encodeURIComponent(project)}/${platform}${requestSuffix(
-    c,
-    platform,
-  )}`;
+  target.pathname = `/webhook/${encodeURIComponent(project)}/${platform}${suffix}`;
   target.search = sourceUrl.search;
 
   return proxyRequest(c, target, "webhook gateway", options);


### PR DESCRIPTION
Part of #12878 (finding **L3** of the #12227 Cloud API security review) — the **suffix-sanitization** half.

## The vulnerability
`eliza-app/webhook/_forward.ts` appends the request's trailing path onto the
internal gateway URL:

```ts
target.pathname = `/webhook/${project}/${platform}${requestSuffix(c, platform)}`;
```

`requestSuffix` returned `pathname.slice(prefix.length)` unsanitized. The URL
parser only collapses **literal** dot-segments, so a percent-encoded separator —
`/api/eliza-app/webhook/telegram/..%2fadmin` or `…/%2e%2e%2fadmin` — survives to
the forwarder and escapes the `/webhook/<project>/<platform>` prefix, letting an
attacker reach arbitrary internal-gateway paths.

## The fix
- Extract a pure `safeWebhookSuffix(pathname, platform)` allowlist: only an empty
  suffix or benign `/[A-Za-z0-9_-]+` segments are forwarded; any dot-segment,
  encoded separator, backslash, or control char returns `null`.
- `forwardToWebhookGateway` returns `400 WEBHOOK_INVALID_PATH` on a rejected
  suffix instead of forwarding. Webhook routes are fixed paths, so no legitimate
  caller sends a non-empty suffix.

## Scope
This addresses the **path-traversal / suffix-sanitization** portion of L3. The
gateway-authentication half (edge signature verification or a shared forward
secret — it depends on the internal gateway validating it) and the L4/L5 replay
dedupe remain open under #12878.

## Verification
`node test/run-unit-isolated.mjs eliza-app-webhook-suffix`:

```
13 pass
0 fail
```

Covers empty/benign suffixes plus a table of traversal/encoded attack strings
(`..`, `../admin`, `..%2fadmin`, `%2e%2e%2fadmin`, `foo%2f..%2fbar`, backslash,
`%00`). `biome check` clean; `tsc --noEmit` clean for the changed files; rebased
on `origin/develop`.

## Evidence
| Type | Status |
|---|---|
| Adversarial tests | ✅ 13 tests, above |
| Backend logs | forwarder logs + returns 400 on rejected suffix |
| UI / frontend | N/A — security/API hardening, no UI path |
| Real-LLM trajectories | N/A — no model/agent path |
| Audio / voice | N/A — no audio path |