### PR TITLE
refactor(#12797): fail-fast on audio/embedding errors, drop fabricated zero/empty outputs

### DIFF
--- a/plugins/plugin-elevenlabs/__tests__/streaming.test.ts
+++ b/plugins/plugin-elevenlabs/__tests__/streaming.test.ts
@@ -224,6 +224,27 @@ describe("plugin-elevenlabs TTS streaming", () => {
     ).rejects.toThrow(/upstream 503/);
   });
 
+  // Malformed provider response: the SDK resolves with no stream. The handler
+  // must throw rather than fabricate an empty audio buffer (issue #12797).
+  it.each([
+    null,
+    undefined,
+  ])("throws on an empty TTS stream body (%s) instead of returning fake audio", async (emptyBody) => {
+    streamMock.mockReset();
+    streamMock.mockResolvedValueOnce(emptyBody);
+
+    const { elevenLabsPlugin } = await import("../src/index.js");
+    const ttsHandler = elevenLabsPlugin.models?.TEXT_TO_SPEECH;
+    const runtime = createTestRuntime();
+
+    await expect(
+      ttsHandler?.(
+        runtime as unknown as Parameters<NonNullable<typeof ttsHandler>>[0],
+        "no stream",
+      ),
+    ).rejects.toThrow("Empty response body from ElevenLabs SDK");
+  });
+
   it.each([
     "",
     " \n\t ",
@@ -477,6 +498,49 @@ describe("plugin-elevenlabs STT transcription", () => {
       "ELEVENLABS_STT_NUM_SPEAKERS must be an integer between 1 and 32",
     );
     expect(convertMock).not.toHaveBeenCalled();
+  });
+
+  // Provider rejection: the SDK throws. The handler must surface the failure to
+  // the caller rather than returning a fabricated/empty transcript (#12797).
+  it("propagates STT SDK errors instead of returning an empty transcript", async () => {
+    convertMock.mockReset();
+    convertMock.mockRejectedValueOnce(new Error("stt upstream 500"));
+
+    const { elevenLabsPlugin } = await import("../src/index.js");
+    const transcriptionHandler = elevenLabsPlugin.models?.TRANSCRIPTION;
+    const runtime = createTestRuntime();
+
+    await expect(
+      transcriptionHandler?.(
+        runtime as unknown as Parameters<
+          NonNullable<typeof transcriptionHandler>
+        >[0],
+        Buffer.from([1, 2, 3]),
+      ),
+    ).rejects.toThrow(/stt upstream 500/);
+  });
+
+  // Malformed provider response: the SDK resolves with no payload. The handler
+  // must throw rather than return an empty-string transcript (#12797).
+  it.each([
+    null,
+    undefined,
+  ])("throws on an empty STT response (%s) instead of returning fake text", async (emptyResponse) => {
+    convertMock.mockReset();
+    convertMock.mockResolvedValueOnce(emptyResponse);
+
+    const { elevenLabsPlugin } = await import("../src/index.js");
+    const transcriptionHandler = elevenLabsPlugin.models?.TRANSCRIPTION;
+    const runtime = createTestRuntime();
+
+    await expect(
+      transcriptionHandler?.(
+        runtime as unknown as Parameters<
+          NonNullable<typeof transcriptionHandler>
+        >[0],
+        Buffer.from([1, 2, 3]),
+      ),
+    ).rejects.toThrow("Empty response from ElevenLabs STT API");
   });
 
   it("supports browser object URL input without a global Buffer", async () => {

--- a/plugins/plugin-elevenlabs/src/index.ts
+++ b/plugins/plugin-elevenlabs/src/index.ts
@@ -121,6 +121,8 @@ function validateAudioUrl(value: unknown): string {
   try {
     parsed = new URL(url);
   } catch {
+    // error-policy:J3 untrusted-input sanitizing — an unparseable caller-supplied
+    // URL is an explicit validation failure, not a swallowed error.
     throw new Error("ElevenLabs transcription audioUrl must be a valid URL");
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
@@ -133,7 +135,11 @@ function validateAudioUrl(value: unknown): string {
  * Voice settings configuration for ElevenLabs API
  */
 interface VoiceSettings {
-  apiKey: string;
+  // `undefined` when no key is configured — never a fabricated "" that would
+  // read as "a key is present". The real API call resolves the key separately
+  // via getElevenLabsClientConfig (which throws when it is required and absent);
+  // this field only drives the inline test suite's presence checks.
+  apiKey: string | undefined;
   voiceId: string;
   model: string;
   stability: string;
@@ -145,7 +151,8 @@ interface VoiceSettings {
 }
 
 interface TranscriptionSettings {
-  apiKey: string;
+  // See VoiceSettings.apiKey — `undefined` when unset, never a fabricated "".
+  apiKey: string | undefined;
   modelId: string;
   languageCode?: string;
   timestampsGranularity: string;
@@ -214,7 +221,7 @@ function getElevenLabsClientConfig(runtime: IAgentRuntime): {
  */
 function getVoiceSettings(runtime: IAgentRuntime): VoiceSettings {
   return {
-    apiKey: getApiKey(runtime) || "",
+    apiKey: getApiKey(runtime),
     voiceId: getSetting(runtime, "ELEVENLABS_VOICE_ID", "EXAVITQu4vr4xnSDxMaL"),
     model: getSetting(runtime, "ELEVENLABS_MODEL_ID", "eleven_monolingual_v1"),
     stability: getSetting(runtime, "ELEVENLABS_VOICE_STABILITY", "0.5"),
@@ -232,7 +239,7 @@ function getVoiceSettings(runtime: IAgentRuntime): VoiceSettings {
     ),
     style: getSetting(runtime, "ELEVENLABS_VOICE_STYLE", "0"),
     speakerBoost: parseBooleanFromText(
-      `${getSetting(runtime, "ELEVENLABS_VOICE_USE_SPEAKER_BOOST", "true") ?? "true"}`,
+      getSetting(runtime, "ELEVENLABS_VOICE_USE_SPEAKER_BOOST", "true"),
     ),
   };
 }
@@ -253,7 +260,7 @@ function getTranscriptionSettings(
   }
 
   return {
-    apiKey: getApiKey(runtime) || "",
+    apiKey: getApiKey(runtime),
     modelId: getSetting(runtime, "ELEVENLABS_STT_MODEL_ID", "scribe_v1"),
     languageCode: languageCode || undefined,
     timestampsGranularity: getSetting(
@@ -262,11 +269,11 @@ function getTranscriptionSettings(
       "word",
     ),
     diarize: parseBooleanFromText(
-      `${getSetting(runtime, "ELEVENLABS_STT_DIARIZE", "false") ?? "false"}`,
+      getSetting(runtime, "ELEVENLABS_STT_DIARIZE", "false"),
     ),
     numSpeakers,
     tagAudioEvents: parseBooleanFromText(
-      `${getSetting(runtime, "ELEVENLABS_STT_TAG_AUDIO_EVENTS", "false") ?? "false"}`,
+      getSetting(runtime, "ELEVENLABS_STT_TAG_AUDIO_EVENTS", "false"),
     ),
   };
 }
@@ -339,32 +346,26 @@ async function fetchSpeech(
     latency: string;
   },
 ): Promise<Uint8Array> {
-  try {
-    const client = new ElevenLabsClient(getElevenLabsClientConfig(runtime));
+  const client = new ElevenLabsClient(getElevenLabsClientConfig(runtime));
 
-    const stream = await client.textToSpeech.stream(params.voiceId, {
-      text: params.text,
-      modelId: params.modelId,
-      outputFormat: parseTtsOutputFormat(params.outputFormat),
-      optimizeStreamingLatency: Number(params.latency) || 0,
-      voiceSettings: {
-        stability: Number(params.stability) || 0,
-        similarityBoost: Number(params.similarity) || 0,
-        style: Number(params.style) || 0,
-        useSpeakerBoost: !!params.speakerBoost,
-      },
-    });
+  const stream = await client.textToSpeech.stream(params.voiceId, {
+    text: params.text,
+    modelId: params.modelId,
+    outputFormat: parseTtsOutputFormat(params.outputFormat),
+    optimizeStreamingLatency: Number(params.latency) || 0,
+    voiceSettings: {
+      stability: Number(params.stability) || 0,
+      similarityBoost: Number(params.similarity) || 0,
+      style: Number(params.style) || 0,
+      useSpeakerBoost: !!params.speakerBoost,
+    },
+  });
 
-    if (!stream) {
-      throw new Error("Empty response body from ElevenLabs SDK");
-    }
-
-    return readStreamToUint8Array(stream);
-  } catch (error: unknown) {
-    const msg = error instanceof Error ? error.message : String(error);
-    logger.error(`ElevenLabs fetchSpeech error: ${msg}`);
-    throw error instanceof Error ? error : new Error(msg);
+  if (!stream) {
+    throw new Error("Empty response body from ElevenLabs SDK");
   }
+
+  return readStreamToUint8Array(stream);
 }
 
 async function fetchTranscription(
@@ -379,45 +380,39 @@ async function fetchTranscription(
     tagAudioEvents: boolean;
   },
 ): Promise<string> {
-  try {
-    const client = new ElevenLabsClient(getElevenLabsClientConfig(runtime));
+  const client = new ElevenLabsClient(getElevenLabsClientConfig(runtime));
 
-    const body: BodySpeechToTextV1SpeechToTextPost = {
-      modelId: parseSttModelId(params.modelId),
-      file: params.audioFile,
-    };
+  const body: BodySpeechToTextV1SpeechToTextPost = {
+    modelId: parseSttModelId(params.modelId),
+    file: params.audioFile,
+  };
 
-    if (params.languageCode) {
-      body.languageCode = params.languageCode;
-    }
-
-    body.timestampsGranularity = parseSttTimestampsGranularity(
-      params.timestampsGranularity,
-    );
-
-    if (params.diarize) {
-      body.diarize = true;
-      if (params.numSpeakers !== undefined) {
-        body.numSpeakers = params.numSpeakers;
-      }
-    }
-
-    if (params.tagAudioEvents) {
-      body.tagAudioEvents = true;
-    }
-
-    const response = await client.speechToText.convert(body);
-
-    if (!response) {
-      throw new Error("Empty response from ElevenLabs STT API");
-    }
-
-    return extractTranscript(response);
-  } catch (error: unknown) {
-    const msg = error instanceof Error ? error.message : String(error);
-    logger.error(`ElevenLabs fetchTranscription error: ${msg}`);
-    throw error instanceof Error ? error : new Error(msg);
+  if (params.languageCode) {
+    body.languageCode = params.languageCode;
   }
+
+  body.timestampsGranularity = parseSttTimestampsGranularity(
+    params.timestampsGranularity,
+  );
+
+  if (params.diarize) {
+    body.diarize = true;
+    if (params.numSpeakers !== undefined) {
+      body.numSpeakers = params.numSpeakers;
+    }
+  }
+
+  if (params.tagAudioEvents) {
+    body.tagAudioEvents = true;
+  }
+
+  const response = await client.speechToText.convert(body);
+
+  if (!response) {
+    throw new Error("Empty response from ElevenLabs STT API");
+  }
+
+  return extractTranscript(response);
 }
 
 // Note: WAV header utilities removed to ensure browser safety. Prefer mp3 output.
@@ -505,9 +500,13 @@ export const elevenLabsPlugin: Plugin = {
         });
         return stream;
       } catch (error: unknown) {
-        const msg = error instanceof Error ? error.message : String(error);
-        logger.error(`ElevenLabs model error: ${msg}`);
-        throw error instanceof Error ? error : new Error(msg);
+        // error-policy:J1 model-slot boundary — log once at the TTS handler edge,
+        // then rethrow so the runtime planner loop surfaces the failure to the
+        // model. Never returns a fabricated/empty audio buffer.
+        logger.error(
+          `[ElevenLabs] TEXT_TO_SPEECH failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        throw error;
       }
     },
     [ModelType.TRANSCRIPTION]: async (
@@ -553,9 +552,13 @@ export const elevenLabsPlugin: Plugin = {
 
         return transcript;
       } catch (error: unknown) {
-        const msg = error instanceof Error ? error.message : String(error);
-        logger.error(`ElevenLabs transcription error: ${msg}`);
-        throw error instanceof Error ? error : new Error(msg);
+        // error-policy:J1 model-slot boundary — log once at the TRANSCRIPTION
+        // handler edge, then rethrow so the runtime planner loop surfaces the
+        // failure to the model. Never returns a fabricated/empty transcript.
+        logger.error(
+          `[ElevenLabs] TRANSCRIPTION failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        throw error;
       }
     },
   },

--- a/plugins/plugin-embeddings/src/models/embedding.ts
+++ b/plugins/plugin-embeddings/src/models/embedding.ts
@@ -114,6 +114,9 @@ async function requestEmbeddings(
   });
 
   if (!response.ok) {
+    // error-policy:J2 context-adding — the request already failed (non-2xx); a
+    // body that is itself unreadable must not mask the HTTP error we are about to
+    // throw, so fall back to a placeholder for the message only.
     const errorText = await response.text().catch(() => "Unknown error");
     throw new Error(
       `Embedding API error: ${response.status} ${response.statusText} - ${errorText}`


### PR DESCRIPTION
Closes #12797

## Premise

#12797 (split from #12271) asks the embeddings/TTS provider group — `plugin-embeddings`, `plugin-elevenlabs`, `plugin-edge-tts` — to throw or return an explicit failure instead of fabricating zero/marker vectors, fake/empty audio, or success-shaped defaults (extends #9324).

**Premise partly pre-resolved:** the parent sweep #12793 (commit `e970e56135`) already converted the fake-audio / zero-vector error paths in these three plugins — `plugin-edge-tts` teardown was annotated J6, `plugin-embeddings` was already fail-fast from #9324, and the `plugin-elevenlabs` streaming test suite ("propagates SDK errors instead of returning empty bytes") was added. This PR closes out the **residual** unannotated fallback literals and double-log-and-rethrow sludge, adds the missing failure-path tests, and annotates the justified keeps.

## Inventory (fixed vs justified)

### plugin-elevenlabs/src/index.ts — fixed
- **Fabricated empty-string API key** (`getApiKey(runtime) || ""`, 2 sites) → `apiKey: string | undefined`. Honest "absent" instead of a `""` that reads as "a key is present". The real call resolves the key via `getElevenLabsClientConfig` (which throws when required and absent); the settings field only drives the inline test presence checks, where both `""` and `undefined` are falsy — behavior-preserving.
- **Dead `?? "true"/"false"`** on the three boolean settings → removed. The 3-arg `getSetting(runtime, key, fallback)` overload delegates to `resolveSetting(..., { defaultValue })`, which always returns a string, so the coalescing operand was unreachable.
- **Double log-and-rethrow** — `fetchSpeech` / `fetchTranscription` caught, reduced to message, re-logged, and rethrew the *same* error, then the model handlers logged it *again*. Removed the inner-helper catches so failures propagate to the single model-slot boundary handler, which logs once and rethrows the **original** error (preserving stack/type). Never fabricates empty audio/text.

### plugin-elevenlabs/src/index.ts — justified (annotated)
- `validateAudioUrl` `new URL()` parse catch → `// error-policy:J3` (untrusted-input sanitizing → explicit typed validation throw).
- The two model-slot boundary handlers → `// error-policy:J1` (log once at the model edge, rethrow so the runtime planner loop surfaces the failure).

### plugin-embeddings/src/models/embedding.ts — justified (annotated)
- Non-2xx error-body read `.text().catch(() => "Unknown error")` → `// error-policy:J2` (context-adding; an unreadable body must not mask the HTTP error being thrown). All real error paths already throw; the only synthetic return is the documented boot dimension-probe marker for `null` input — legitimate, unchanged.

### plugin-edge-tts — no change
Already fail-fast; both teardown catches carry `// error-policy:J6` (landed in #12793). No fabricated audio.

## Verification

All commands run in the worktree against `origin/develop`.

**Tests (real failure-path assertions, local SDK stubs):**
```
$ bun run --cwd plugins/plugin-elevenlabs test   → 32 pass / 0 fail (was 27; +5 new)
$ bun run --cwd plugins/plugin-edge-tts   test   → 8 pass / 0 fail
$ bun run --cwd plugins/plugin-embeddings test   → 27 pass / 0 fail
```
New elevenlabs cases assert the throw (never a fabricated empty result) on: TTS SDK rejection, empty TTS stream body (`null`/`undefined`), STT SDK rejection, empty STT response (`null`/`undefined`). Logs confirm the J1 boundary fires and the error propagates, e.g. `[ElevenLabs] TRANSCRIPTION failed: Empty response from ElevenLabs STT API`.

**Ratchet — no new slop, net neutral (two try/catch blocks removed):**
```
$ node packages/scripts/error-policy-ratchet.mjs
[error-policy-ratchet] base origin/develop (13b7ae2369); 2 changed production source file(s)
[error-policy-ratchet]   plugins/plugin-elevenlabs/src/index.ts: emptyCatch 0->0, serverConsole 0->0
[error-policy-ratchet]   plugins/plugin-embeddings/src/models/embedding.ts: emptyCatch 0->0, serverConsole 0->0
[error-policy-ratchet] no new fallback-slop in touched files
```

**Typecheck + lint (all touched plugins clean):**
```
$ bun run --cwd plugins/plugin-elevenlabs typecheck   → clean
$ bun run --cwd plugins/plugin-embeddings typecheck    → clean
$ bun run --cwd plugins/plugin-edge-tts  typecheck     → clean
$ biome check <changed files>                          → No fixes applied
```

## Evidence

- **Real-LLM / provider trajectories: N/A** — this is a deterministic error-path code change. The added tests assert a **throw / propagated failure** on provider rejection and malformed provider response using local SDK stubs; no real audio hardware or live provider call is needed to prove a thrown error. The success paths (real streaming, real transcription) are unchanged from `develop` and remain covered by the existing suite.
- **Backend logs:** the new J1 boundary log lines appear in the test output above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)