### PR TITLE
fix(#12894,#12896): settle orphaned speculative-match + firstWindow promises on voice cancel/finalize

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.ts
@@ -196,6 +196,17 @@ export interface RuntimeEventSink {
 	 * playback-frames ingest route. Absent on headless/core runtimes.
 	 */
 	voiceEchoReferenceProvider?: EchoReferenceProvider;
+	/**
+	 * `IAgentRuntime.reportError` when the sink is a real runtime (#12263 J7).
+	 * Threaded into the attribution pipeline so the detached speech-start
+	 * speculative match's failures surface into RECENT_ERRORS / owner-escalation
+	 * (#12894). Absent on headless/core sinks — the pipeline then logs instead.
+	 */
+	reportError?(
+		scope: string,
+		error: unknown,
+		context?: Record<string, unknown>,
+	): void;
 }
 
 /**
@@ -506,9 +517,10 @@ export class AudioFrameConsumer {
 		if (this.closed) return;
 		this.closed = true;
 		this.unsubscribeVad();
-		// A turn left open at close never reaches speech-end: cancel its
-		// speculative match so the encoder promise cannot dangle.
-		this.incrementalTurn?.speculativeMatch.cancel();
+		// A turn left open at close never reaches speech-end: abandon it so its
+		// speech-start speculative `embed()` unwinds (settles `firstWindow`) rather
+		// than hanging on an await that never resolves (#12896).
+		this.incrementalTurn?.cancel();
 		this.incrementalTurn = null;
 		await this.attributing;
 		this.turnListeners.clear();
@@ -576,8 +588,9 @@ export class AudioFrameConsumer {
 		this.incrementalTurn = null;
 		this.diarizedSamples = 0;
 		if (total === 0) {
-			// No buffered audio — release the speculative match so it can't dangle.
-			incrementalTurn?.speculativeMatch.cancel();
+			// No buffered audio — abandon the turn so its speculative `embed()`
+			// unwinds (settles `firstWindow`) instead of suspending forever (#12896).
+			incrementalTurn?.cancel();
 			return;
 		}
 		const pcm = concatFloat32(chunks, total);

--- a/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.windowed.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/audio-frame-consumer.windowed.test.ts
@@ -1,11 +1,17 @@
 /**
- * AudioFrameConsumer windowed long-turn integration (#12257). Drives the
- * consumer with a manual VAD and an incremental fake pipeline to prove that a
- * long turn decodes each 5 s window DURING capture and only the trailing
- * partial window at speech-end — so post-endpoint attribution work is bounded
- * to one window. A pipeline without `beginTurn` still takes the one-shot path.
+ * AudioFrameConsumer windowed long-turn integration (#12257) + the speculative-
+ * match promise-lifecycle cancel path (#12896). Drives the consumer with a
+ * manual VAD and an incremental fake pipeline to prove that a long turn decodes
+ * each 5 s window DURING capture and only the trailing partial window at
+ * speech-end. The lifecycle block wires the REAL `VoiceAttributionPipeline`
+ * (fake encoder/diarizer + real profile store) so `close()` and a zero-buffer
+ * speech-end exercise the real `IncrementalTurnAttributor.cancel()`, proving a
+ * turn abandoned before finalize unwinds its suspended speculative `embed()`.
  */
 
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	type AttributionPipelineLike,
@@ -13,10 +19,15 @@ import {
 	type RuntimeEventSink,
 	type VadSegmenter,
 } from "./audio-frame-consumer";
-import type {
-	IncrementalTurnAttributor,
-	VoiceAttributionOutput,
+import { VoiceProfileStore } from "./profile-store";
+import {
+	type IncrementalTurnAttributor,
+	type VoiceAttributionOutput,
+	VoiceAttributionPipeline,
 } from "./speaker/attribution-pipeline";
+import type { Diarizer } from "./speaker/diarizer";
+import { PYANNOTE_SEGMENTATION_3_INT8_MODEL_ID } from "./speaker/diarizer";
+import type { SpeakerEncoder } from "./speaker/encoder";
 import type { PcmFrame, VadEvent } from "./types";
 
 const SR = 16_000;
@@ -97,6 +108,9 @@ class IncrementalFakePipeline implements AttributionPipelineLike {
 				cancel: () => {
 					cancelled = true;
 				},
+			},
+			cancel: () => {
+				cancelled = true;
 			},
 			pushWindow: async (windowPcm, windowStartMs) => {
 				windowsDiarized += 1;
@@ -235,5 +249,178 @@ describe("AudioFrameConsumer windowed long-turn attribution (#12257)", () => {
 		expect(pipeline.attributeCalls).toBe(1);
 		expect(pipeline.lastPcmLength).toBe(12 * SR);
 		expect(turns).toHaveLength(1);
+	});
+});
+
+// ---- speculative-match cancel path (#12896) ------------------------------
+
+const MODEL = "wespeaker-resnet34-lm-int8";
+
+function fixedEmbedding(): Float32Array {
+	const v = new Float32Array(256);
+	for (let i = 0; i < v.length; i += 1) v[i] = Math.sin(i * 0.05);
+	return v;
+}
+
+function makeEncoder(): SpeakerEncoder {
+	return {
+		embeddingDim: 256,
+		sampleRate: SR,
+		modelId: MODEL,
+		async encode() {
+			return fixedEmbedding();
+		},
+		async dispose() {},
+	};
+}
+
+function makeDiarizer(): Diarizer {
+	return {
+		modelId: PYANNOTE_SEGMENTATION_3_INT8_MODEL_ID,
+		sampleRate: SR,
+		async diarizeWindow(pcm) {
+			const durationMs = Math.round((pcm.length / SR) * 1000);
+			return {
+				localSpeakerCount: 1,
+				speechMs: durationMs,
+				segments: [
+					{
+						startMs: 0,
+						endMs: durationMs,
+						localSpeakerId: 0,
+						confidence: 0.9,
+						hasOverlap: false,
+					},
+				],
+			};
+		},
+		async dispose() {},
+	};
+}
+
+async function freshStore(): Promise<VoiceProfileStore> {
+	const dir = mkdtempSync(path.join(tmpdir(), "vp-afc-"));
+	const store = new VoiceProfileStore({ rootDir: dir });
+	await store.init();
+	return store;
+}
+
+/**
+ * Real `VoiceAttributionPipeline` that also hands each created attributor to the
+ * test, so it can hold the live speculative handle after the consumer has nulled
+ * its private reference. The consumer's `close()` / zero-buffer speech-end still
+ * drive the REAL `cancel()` — nothing about the abandon path is faked.
+ */
+function buildRealPipeline(pipeline: VoiceAttributionPipeline): {
+	pipeline: AttributionPipelineLike;
+	attributors: IncrementalTurnAttributor[];
+} {
+	const attributors: IncrementalTurnAttributor[] = [];
+	const wrapped: AttributionPipelineLike = {
+		attribute: (req) => pipeline.attribute(req),
+		beginTurn: (init) => {
+			const attributor = pipeline.beginTurn(init);
+			attributors.push(attributor);
+			return attributor;
+		},
+	};
+	return { pipeline: wrapped, attributors };
+}
+
+async function withUnhandledRejectionCapture(
+	fn: () => Promise<void>,
+): Promise<unknown[]> {
+	const captured: unknown[] = [];
+	const onReject = (reason: unknown): void => {
+		captured.push(reason);
+	};
+	process.on("unhandledRejection", onReject);
+	try {
+		await fn();
+		await Promise.resolve();
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+	} finally {
+		process.off("unhandledRejection", onReject);
+	}
+	return captured;
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+	return Promise.race([
+		promise,
+		new Promise<T>((_resolve, reject) => {
+			setTimeout(
+				() => reject(new Error(`promise did not settle within ${ms}ms`)),
+				ms,
+			);
+		}),
+	]);
+}
+
+function buildRealConsumer(pipeline: AttributionPipelineLike) {
+	const vad = new ManualVad();
+	const runtime = new FakeRuntime();
+	const consumer = new AudioFrameConsumer(
+		{ vad, pipeline, runtime },
+		{ preRollSeconds: 0, maxTurnSeconds: 60 },
+	);
+	return { vad, consumer };
+}
+
+describe("AudioFrameConsumer speculative-match cancel path (#12896)", () => {
+	it("close() while a turn is open settles the suspended speculative embed()", async () => {
+		const { pipeline, attributors } = buildRealPipeline(
+			new VoiceAttributionPipeline({
+				encoder: makeEncoder(),
+				diarizer: makeDiarizer(),
+				profileStore: await freshStore(),
+			}),
+		);
+		const { vad, consumer } = buildRealConsumer(pipeline);
+
+		const captured = await withUnhandledRejectionCapture(async () => {
+			// Speech-start opens a turn; no window ever fills, so the speculative
+			// embed() is suspended awaiting the first window.
+			vad.emit({ type: "speech-start", timestampMs: 0, probability: 0.9 });
+			await consumer.pushDecodedFrame(new Float32Array(0.5 * SR), 0);
+			expect(attributors).toHaveLength(1);
+
+			// Close mid-turn: the REAL cancel() must settle firstWindow so embed()
+			// unwinds. A regression leaves it hanging → withTimeout rejects.
+			await consumer.close();
+			const result = await withTimeout(
+				attributors[0].speculativeMatch.result,
+				1_000,
+			);
+			expect(result).toBeNull();
+		});
+		expect(captured).toEqual([]);
+	});
+
+	it("a zero-buffer speech-end settles the suspended speculative embed()", async () => {
+		const { pipeline, attributors } = buildRealPipeline(
+			new VoiceAttributionPipeline({
+				encoder: makeEncoder(),
+				diarizer: makeDiarizer(),
+				profileStore: await freshStore(),
+			}),
+		);
+		const { vad, consumer } = buildRealConsumer(pipeline);
+
+		const captured = await withUnhandledRejectionCapture(async () => {
+			// Speech-start then an immediate speech-end with no buffered frames:
+			// finalizeTurn(total===0) takes the abandon branch.
+			vad.emit({ type: "speech-start", timestampMs: 0, probability: 0.9 });
+			expect(attributors).toHaveLength(1);
+			vad.emit({ type: "speech-end", timestampMs: 0, speechDurationMs: 0 });
+			await consumer.flush();
+
+			const result = await withTimeout(
+				attributors[0].speculativeMatch.result,
+				1_000,
+			);
+			expect(result).toBeNull();
+		});
+		expect(captured).toEqual([]);
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/engine-bridge.ts
+++ b/plugins/plugin-local-inference/src/services/voice/engine-bridge.ts
@@ -1312,6 +1312,11 @@ export class EngineVoiceBridge {
 					encoder: lazyEncoder,
 					...(lazyDiarizer ? { diarizer: lazyDiarizer } : {}),
 					profileStore: opts.profileStore,
+					// Surface the detached speech-start speculative match's failures into
+					// the runtime error stream when a full runtime is present (#12894 J7).
+					...(isEventRuntime(opts.runtime)
+						? { reportError: opts.runtime.reportError.bind(opts.runtime) }
+						: {}),
 				});
 			}
 		}

--- a/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
+++ b/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
@@ -423,6 +423,11 @@ export class LiveDiarizationSession {
 			encoder,
 			diarizer,
 			profileStore: store,
+			// Surface the detached speech-start speculative match's failures into the
+			// runtime's error stream when the sink is a real runtime (#12894 J7).
+			...(this.runtime.reportError
+				? { reportError: this.runtime.reportError.bind(this.runtime) }
+				: {}),
 		});
 		const residualSuppression = resolveResidualSuppression();
 		const config: AudioFrameConsumerConfig = {

--- a/plugins/plugin-local-inference/src/services/voice/speaker/attribution-pipeline.incremental.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/speaker/attribution-pipeline.incremental.test.ts
@@ -1,9 +1,11 @@
 /**
- * Windowed long-turn attribution tests (#12257). Real VoiceProfileStore on a
- * temp dir + a fake encoder/diarizer so the windowing, the shared-tail parity
- * with one-shot `attribute`, the post-endpoint decode bound, and the
- * speech-start speculative `beginMatch` are all exercised against the real
- * profile store — only the native GGUF forward passes are faked.
+ * Windowed long-turn attribution tests (#12257) plus the speculative-match
+ * promise-lifecycle regressions (#12894 orphaned result promise, #12896
+ * firstWindow never settling on cancel). Real VoiceProfileStore on a temp dir +
+ * a fake encoder/diarizer so the windowing, the shared-tail parity with one-shot
+ * `attribute`, the post-endpoint decode bound, and the speech-start speculative
+ * `beginMatch` are all exercised against the real profile store — only the
+ * native GGUF forward passes are faked.
  */
 
 import { mkdtempSync } from "node:fs";
@@ -11,7 +13,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { VoiceProfileStore } from "../profile-store";
-import { VoiceAttributionPipeline } from "./attribution-pipeline";
+import {
+	type AttributionDiagnosticSink,
+	VoiceAttributionPipeline,
+} from "./attribution-pipeline";
 import type { Diarizer } from "./diarizer";
 import { PYANNOTE_SEGMENTATION_3_INT8_MODEL_ID } from "./diarizer";
 import type { SpeakerEncoder } from "./encoder";
@@ -48,6 +53,46 @@ function makeEncoder(): SpeakerEncoder & { inputs: number[] } {
 		},
 		async dispose() {},
 	};
+}
+
+/** Encoder whose `encode()` always rejects — models a native GGUF forward-pass
+ *  failure so the speculative match's detached result promise rejects. */
+function makeRejectingEncoder(message: string): SpeakerEncoder {
+	return {
+		embeddingDim: 256,
+		sampleRate: SR,
+		modelId: MODEL,
+		async encode() {
+			throw new Error(message);
+		},
+		async dispose() {},
+	};
+}
+
+/** Run pending microtasks + one macrotask so a background promise (the detached
+ *  speculative `embed()`/`findBestMatch()`) settles and any unhandled rejection
+ *  is delivered to the process listener before we assert. */
+async function drainTasks(): Promise<void> {
+	await Promise.resolve();
+	await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+/** Capture unhandled promise rejections for the duration of `fn`. */
+async function withUnhandledRejectionCapture(
+	fn: () => Promise<void>,
+): Promise<unknown[]> {
+	const captured: unknown[] = [];
+	const onReject = (reason: unknown): void => {
+		captured.push(reason);
+	};
+	process.on("unhandledRejection", onReject);
+	try {
+		await fn();
+		await drainTasks();
+	} finally {
+		process.off("unhandledRejection", onReject);
+	}
+	return captured;
 }
 
 /** One full-window single-speaker segment per decode; records input lengths. */
@@ -223,3 +268,108 @@ describe("VoiceAttributionPipeline windowed long turns", () => {
 		expect(out.observation).not.toBeNull();
 	});
 });
+
+describe("VoiceAttributionPipeline speculative-match promise lifecycle", () => {
+	it("routes an encode failure to reportError, not an unhandled rejection (#12894)", async () => {
+		const reported: Array<{ scope: string; error: unknown }> = [];
+		const reportError: AttributionDiagnosticSink = (scope, error) => {
+			reported.push({ scope, error });
+		};
+		const pipeline = new VoiceAttributionPipeline({
+			encoder: makeRejectingEncoder("wespeaker forward pass failed"),
+			diarizer: makeDiarizer(),
+			profileStore: await freshStore(),
+			reportError,
+		});
+
+		const captured = await withUnhandledRejectionCapture(async () => {
+			const attributor = pipeline.beginTurn({
+				turnId: "t-reject",
+				startedAtMs: 0,
+			});
+			// Pushing a full window settles firstWindow with real PCM, so the
+			// speculative embed() proceeds to encode() — which rejects.
+			await attributor.pushWindow(new Float32Array(WINDOW_SAMPLES), 0);
+			// Abandon the turn (the real cancel path). The detached result promise
+			// must already be consumed by the pipeline, so cancelling adds no orphan.
+			attributor.cancel();
+		});
+
+		// The rejection surfaced through the diagnostic sink...
+		expect(reported).toHaveLength(1);
+		expect(reported[0]?.scope).toBe(
+			"VoiceAttributionPipeline.speculativeMatch",
+		);
+		expect((reported[0]?.error as Error).message).toBe(
+			"wespeaker forward pass failed",
+		);
+		// ...and NEVER as an unhandled rejection.
+		expect(captured).toEqual([]);
+	});
+
+	it("cancel() settles a suspended speculative embed() so it never hangs (#12896)", async () => {
+		// No reportError wired — a clean cancel resolves the result to null, so the
+		// diagnostic sink must not fire and no unhandled rejection may occur.
+		const pipeline = new VoiceAttributionPipeline({
+			encoder: makeEncoder(),
+			diarizer: makeDiarizer(),
+			profileStore: await freshStore(),
+		});
+
+		const captured = await withUnhandledRejectionCapture(async () => {
+			const attributor = pipeline.beginTurn({
+				turnId: "t-cancel",
+				startedAtMs: 0,
+			});
+			// No window ever pushed: embed() is suspended on `await firstWindow`.
+			expect(attributor.windowsDiarized).toBe(0);
+			attributor.cancel();
+			// The suspended embed() must now unwind and the result promise settle.
+			// A hung promise would time out here instead of resolving.
+			const result = await withTimeout(
+				attributor.speculativeMatch.result,
+				1_000,
+			);
+			expect(result).toBeNull();
+		});
+		expect(captured).toEqual([]);
+	});
+
+	it("cancel() is idempotent and safe after finalize (#12896)", async () => {
+		const pipeline = new VoiceAttributionPipeline({
+			encoder: makeEncoder(),
+			diarizer: makeDiarizer(),
+			profileStore: await freshStore(),
+		});
+		const captured = await withUnhandledRejectionCapture(async () => {
+			const attributor = pipeline.beginTurn({
+				turnId: "t-idem",
+				startedAtMs: 0,
+			});
+			await attributor.pushWindow(new Float32Array(WINDOW_SAMPLES), 0);
+			await attributor.finalize({
+				fullPcm: new Float32Array(WINDOW_SAMPLES),
+				endedAtMs: 5_000,
+			});
+			// Extra cancels after a normal finalize are no-ops, not re-settles.
+			attributor.cancel();
+			attributor.cancel();
+			await withTimeout(attributor.speculativeMatch.result, 1_000);
+		});
+		expect(captured).toEqual([]);
+	});
+});
+
+/** Reject if a promise has not settled within `ms`, so a regression that leaves
+ *  the speculative match hanging fails fast instead of timing out the suite. */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+	return Promise.race([
+		promise,
+		new Promise<T>((_resolve, reject) => {
+			setTimeout(
+				() => reject(new Error(`promise did not settle within ${ms}ms`)),
+				ms,
+			);
+		}),
+	]);
+}

--- a/plugins/plugin-local-inference/src/services/voice/speaker/attribution-pipeline.ts
+++ b/plugins/plugin-local-inference/src/services/voice/speaker/attribution-pipeline.ts
@@ -18,6 +18,7 @@
  * encoder / profile-store dependencies into the streaming-ASR contract.
  */
 
+import { logger } from "@elizaos/core";
 import type {
 	VoiceImprintMatchHandle,
 	VoiceProfileObservation,
@@ -34,10 +35,31 @@ import type { Diarizer, LocalSpeakerSegment } from "./diarizer";
 import type { SpeakerEncoder } from "./encoder";
 import { WESPEAKER_MIN_SAMPLES } from "./encoder";
 
+/**
+ * Diagnostic sink for a failure that has no return-value path back to a caller
+ * — matches `IAgentRuntime.reportError` so a wired live session forwards the
+ * failure into RECENT_ERRORS / owner-escalation (#12263 J7). Optional: a
+ * pipeline built without a runtime (tests, older callers) falls back to
+ * `logger.warn`, but the failure is always observed, never swallowed.
+ */
+export type AttributionDiagnosticSink = (
+	scope: string,
+	error: unknown,
+	context?: Record<string, unknown>,
+) => void;
+
 export interface VoiceAttributionPipelineDeps {
 	encoder: SpeakerEncoder;
 	diarizer?: Diarizer;
 	profileStore: VoiceProfileStore;
+	/**
+	 * Observability boundary for the speech-start speculative match's background
+	 * result promise. That encode runs detached from any caller (no code awaits
+	 * `speculativeMatch.result` — turn-taking that will read it is #12255), so an
+	 * `encode()`/`findBestMatch()` rejection has nowhere to surface and would
+	 * become an unhandled rejection (#12894). Routed here instead.
+	 */
+	reportError?: AttributionDiagnosticSink;
 }
 
 export interface VoiceAttributionRequest {
@@ -94,6 +116,13 @@ export interface IncrementalTurnFinalize {
 export interface IncrementalTurnAttributor {
 	pushWindow(windowPcm: Float32Array, windowStartMs: number): Promise<void>;
 	finalize(args: IncrementalTurnFinalize): Promise<VoiceAttributionOutput>;
+	/**
+	 * Abandon a turn that never reaches `finalize` (VAD close mid-turn,
+	 * zero-buffer speech-end). Settles the speech-start window promise so a
+	 * suspended speculative `embed()` unwinds instead of hanging forever
+	 * (#12896), and cancels the match handle. Idempotent; safe after `finalize`.
+	 */
+	cancel(): void;
 	readonly speculativeMatch: VoiceImprintMatchHandle;
 	/** Count of window decodes done DURING the turn (excludes the finalize window). */
 	readonly windowsDiarized: number;
@@ -265,6 +294,27 @@ export class VoiceAttributionPipeline {
 			},
 			...(init.signal ? { signal: init.signal } : {}),
 		});
+		// Nothing in this pipeline awaits the speculative result (turn-taking that
+		// will consume it is #12255), so its rejection has no caller to land on.
+		// Consume it here once so an `encode()`/`findBestMatch()` failure surfaces
+		// through the diagnostic sink instead of becoming an unhandled rejection
+		// (#12894). `cancel()` resolves the promise to `null` (never rejects), so
+		// this only fires on a genuine encode/match failure.
+		speculativeMatch.result.catch((error: unknown) => {
+			const context = { turnId: init.turnId };
+			if (this.deps.reportError) {
+				this.deps.reportError(
+					"VoiceAttributionPipeline.speculativeMatch",
+					error,
+					context,
+				);
+			} else {
+				logger.warn(
+					{ error, ...context },
+					"[VoiceAttributionPipeline] speculative match failed",
+				);
+			}
+		});
 
 		const diarizeInto = async (
 			pcm: Float32Array,
@@ -282,11 +332,21 @@ export class VoiceAttributionPipeline {
 			}
 		};
 
+		// Settle the speech-start window promise (to `null`) and cancel the match.
+		// A suspended `embed()` (still `await`-ing `firstWindow` because no window
+		// ever pushed) unwinds via the `!pcm` guard → `beginMatch` resolves its
+		// result to `null` rather than hanging forever (#12896). Idempotent.
+		const abandonSpeculativeMatch = (): void => {
+			settleFirstWindow(null);
+			speculativeMatch.cancel();
+		};
+
 		return {
 			get windowsDiarized() {
 				return windowsDiarized;
 			},
 			speculativeMatch,
+			cancel: abandonSpeculativeMatch,
 			pushWindow: async (windowPcm, windowStartMs) => {
 				settleFirstWindow(windowPcm);
 				windowsDiarized += 1;


### PR DESCRIPTION
Closes #12894
Closes #12896

Both are voice-lifecycle promise-settling leaks in the windowed long-turn attributor (`plugin-local-inference`), splits of #12625. Fixed together because they touch the same `beginTurn` handle and the same real cancel sites, so a single PR avoids self-conflict.

## What changed

`VoiceAttributionPipeline.beginTurn` (`speaker/attribution-pipeline.ts`) kicks off a speech-start speculative `beginMatch` whose background `embed()` runs detached from any caller. Two leaks:

**#12894 — orphaned speculative-match result promise.** No production code awaits `speculativeMatch.result` (the turn-taking consumer is the still-open #12255), so an `encode()` / `findBestMatch()` rejection had nowhere to land and became an **unhandled rejection**. Now the result promise is consumed once at handle creation and routed through `runtime.reportError` (J7 diagnostic → RECENT_ERRORS / owner-escalation), falling back to `logger.warn` when the pipeline is built without a runtime. The failure is always observed, never swallowed. `reportError` is threaded from the real runtime by `LiveDiarizationSession` and `EngineVoiceBridge`.

**#12896 — `firstWindow` never settles on cancel/zero-buffer finalize.** On VAD close mid-turn / zero-buffer speech-end the old code called `speculativeMatch.cancel()` (a flag flip only) but never settled the `firstWindow` promise, so a speculative `embed()` suspended on `await firstWindow` **hung forever**. `IncrementalTurnAttributor` now exposes `cancel()`, which settles `firstWindow(null)` (embed unwinds via its `!pcm` guard → `beginMatch` resolves the result to `null`) and cancels the match. The real consumer cancel sites — `AudioFrameConsumer.close()` and the `finalizeTurn(total === 0)` branch — call the new `cancel()` instead of the bare `speculativeMatch.cancel()`.

No downstream attribution behavior changes: the fixes only settle/consume promises that were previously leaked. The normal `finalize` path is untouched.

### Files
- `speaker/attribution-pipeline.ts` — consume `speculativeMatch.result` via `.catch` (reportError / logger); add `IncrementalTurnAttributor.cancel()` that settles `firstWindow(null)`; add optional `reportError` to pipeline deps.
- `audio-frame-consumer.ts` — call `incrementalTurn.cancel()` on `close()` and zero-buffer `finalizeTurn`; add optional `reportError` to `RuntimeEventSink`.
- `live-diarization-session.ts`, `engine-bridge.ts` — thread the real runtime's `reportError` into the pipeline.
- `speaker/attribution-pipeline.incremental.test.ts`, `audio-frame-consumer.windowed.test.ts` — new regression tests.

## Verification

Source-based lifecycle regressions (no audio hardware). Tests use the **real** `VoiceAttributionPipeline` (fake encoder/diarizer + real `VoiceProfileStore`) driven through the **real** consumer cancel path — no no-op fake.

Each new test **fails when its fix is reverted**: #12894 → unhandled rejection / reportError not called; #12896 → `promise did not settle within 1000ms` (the exact hang).

```
✓ speculative-match promise lifecycle > routes an encode failure to reportError, not an unhandled rejection (#12894)
✓ speculative-match promise lifecycle > cancel() settles a suspended speculative embed() so it never hangs (#12896)
✓ speculative-match promise lifecycle > cancel() is idempotent and safe after finalize (#12896)
✓ AudioFrameConsumer speculative-match cancel path (#12896) > close() while a turn is open settles the suspended speculative embed()
✓ AudioFrameConsumer speculative-match cancel path (#12896) > a zero-buffer speech-end settles the suspended speculative embed()

Test Files  2 passed (2)
     Tests  12 passed (12)     # 5 new + 7 pre-existing #12257, all green
```

Regression check (fix neutralized):
```
× cancel() settles a suspended speculative embed() so it never hangs (#12896)   Error: promise did not settle within 1000ms
× close() while a turn is open settles the suspended speculative embed()          Error: promise did not settle within 1000ms
× a zero-buffer speech-end settles the suspended speculative embed()              Error: promise did not settle within 1000ms
× routes an encode failure to reportError, not an unhandled rejection (#12894)    (reportError empty / unhandled rejection captured)
```

Also run on the touched files:
- `bunx vitest run` over `attribution-pipeline.incremental`, `audio-frame-consumer.windowed`, `audio-frame-consumer`, `attribution-pipeline` → **32 passed**.
- `bunx @elizaos/biome check <6 files>` → clean.
- `node packages/scripts/error-policy-ratchet.mjs` → no new fallback-slop (`emptyCatch 4->4`, `1->1`; `serverConsole 0->0`).
- `tsc --noEmit -p plugins/plugin-local-inference/tsconfig.json` → 0 errors.

**Frontend / device / real-LLM evidence: N/A** — these are pure background-promise lifecycle regressions with no UI, model, or device surface; assertions are on unhandled-rejection presence and `embed()` promise settlement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)