### PR TITLE
docs(#12905): align native plugin script guides

### DIFF
--- a/plugins/plugin-native-activity-tracker/AGENTS.md
+++ b/plugins/plugin-native-activity-tracker/AGENTS.md
@@ -40,15 +40,17 @@ plugins/plugin-native-activity-tracker/
 
 ## Commands
 
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
+
 ```bash
-# Compile TypeScript (produces dist/)
-bun run --cwd plugins/plugin-native-activity-tracker build
-
-# Compile the Swift helper binary (Darwin only, requires Xcode command-line tools)
-bun run --cwd plugins/plugin-native-activity-tracker build:swift
-
-# Run unit tests
-bun run --cwd plugins/plugin-native-activity-tracker test
+bun run --cwd plugins/plugin-native-activity-tracker build         # build package artifacts
+bun run --cwd plugins/plugin-native-activity-tracker build:swift   # build Swift helper (Darwin only)
+bun run --cwd plugins/plugin-native-activity-tracker typecheck     # TypeScript typecheck
+bun run --cwd plugins/plugin-native-activity-tracker lint          # mutating Biome check
+bun run --cwd plugins/plugin-native-activity-tracker lint:check    # read-only Biome check
+bun run --cwd plugins/plugin-native-activity-tracker format        # write formatting
+bun run --cwd plugins/plugin-native-activity-tracker format:check  # read-only formatting check
+bun run --cwd plugins/plugin-native-activity-tracker test          # run package tests
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-activity-tracker/CLAUDE.md
+++ b/plugins/plugin-native-activity-tracker/CLAUDE.md
@@ -40,15 +40,17 @@ plugins/plugin-native-activity-tracker/
 
 ## Commands
 
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
+
 ```bash
-# Compile TypeScript (produces dist/)
-bun run --cwd plugins/plugin-native-activity-tracker build
-
-# Compile the Swift helper binary (Darwin only, requires Xcode command-line tools)
-bun run --cwd plugins/plugin-native-activity-tracker build:swift
-
-# Run unit tests
-bun run --cwd plugins/plugin-native-activity-tracker test
+bun run --cwd plugins/plugin-native-activity-tracker build         # build package artifacts
+bun run --cwd plugins/plugin-native-activity-tracker build:swift   # build Swift helper (Darwin only)
+bun run --cwd plugins/plugin-native-activity-tracker typecheck     # TypeScript typecheck
+bun run --cwd plugins/plugin-native-activity-tracker lint          # mutating Biome check
+bun run --cwd plugins/plugin-native-activity-tracker lint:check    # read-only Biome check
+bun run --cwd plugins/plugin-native-activity-tracker format        # write formatting
+bun run --cwd plugins/plugin-native-activity-tracker format:check  # read-only formatting check
+bun run --cwd plugins/plugin-native-activity-tracker test          # run package tests
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-agent/AGENTS.md
+++ b/plugins/plugin-native-agent/AGENTS.md
@@ -41,12 +41,20 @@ plugins/plugin-native-agent/
 
 ## Commands
 
-Only these scripts exist in `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-agent build   # clean → tsc → rollup → dist/
-bun run --cwd plugins/plugin-native-agent clean   # remove dist/
-bun run --cwd plugins/plugin-native-agent watch   # tsc --watch
+bun run --cwd plugins/plugin-native-agent clean           # remove build output
+bun run --cwd plugins/plugin-native-agent build           # build package artifacts
+bun run --cwd plugins/plugin-native-agent typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-agent lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-agent lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-agent format          # write formatting
+bun run --cwd plugins/plugin-native-agent format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-agent test            # run package tests
+bun run --cwd plugins/plugin-native-agent prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-agent watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-agent build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-agent/CLAUDE.md
+++ b/plugins/plugin-native-agent/CLAUDE.md
@@ -41,12 +41,20 @@ plugins/plugin-native-agent/
 
 ## Commands
 
-Only these scripts exist in `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-agent build   # clean → tsc → rollup → dist/
-bun run --cwd plugins/plugin-native-agent clean   # remove dist/
-bun run --cwd plugins/plugin-native-agent watch   # tsc --watch
+bun run --cwd plugins/plugin-native-agent clean           # remove build output
+bun run --cwd plugins/plugin-native-agent build           # build package artifacts
+bun run --cwd plugins/plugin-native-agent typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-agent lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-agent lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-agent format          # write formatting
+bun run --cwd plugins/plugin-native-agent format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-agent test            # run package tests
+bun run --cwd plugins/plugin-native-agent prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-agent watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-agent build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-appblocker/AGENTS.md
+++ b/plugins/plugin-native-appblocker/AGENTS.md
@@ -53,15 +53,20 @@ plugins/plugin-native-appblocker/
 
 ## Commands
 
-Only scripts that exist in `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-appblocker build         # tsc + rollup → dist/
-bun run --cwd plugins/plugin-native-appblocker test          # vitest web fallback contract
-bun run --cwd plugins/plugin-native-appblocker clean         # rm dist/
+bun run --cwd plugins/plugin-native-appblocker clean           # remove build output
+bun run --cwd plugins/plugin-native-appblocker build           # build package artifacts
+bun run --cwd plugins/plugin-native-appblocker typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-appblocker lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-appblocker lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-appblocker format          # write formatting
+bun run --cwd plugins/plugin-native-appblocker format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-appblocker test            # run package tests
+bun run --cwd plugins/plugin-native-appblocker prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-appblocker build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
-
-There is no lint script in this package.
 
 ## Config / env vars
 

--- a/plugins/plugin-native-appblocker/CLAUDE.md
+++ b/plugins/plugin-native-appblocker/CLAUDE.md
@@ -53,15 +53,20 @@ plugins/plugin-native-appblocker/
 
 ## Commands
 
-Only scripts that exist in `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-appblocker build         # tsc + rollup → dist/
-bun run --cwd plugins/plugin-native-appblocker test          # vitest web fallback contract
-bun run --cwd plugins/plugin-native-appblocker clean         # rm dist/
+bun run --cwd plugins/plugin-native-appblocker clean           # remove build output
+bun run --cwd plugins/plugin-native-appblocker build           # build package artifacts
+bun run --cwd plugins/plugin-native-appblocker typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-appblocker lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-appblocker lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-appblocker format          # write formatting
+bun run --cwd plugins/plugin-native-appblocker format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-appblocker test            # run package tests
+bun run --cwd plugins/plugin-native-appblocker prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-appblocker build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
-
-There is no lint script in this package.
 
 ## Config / env vars
 

--- a/plugins/plugin-native-bun-runtime/AGENTS.md
+++ b/plugins/plugin-native-bun-runtime/AGENTS.md
@@ -83,13 +83,20 @@ plugins/plugin-native-bun-runtime/
 
 ## Commands
 
-Scripts that exist in `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-bun-runtime build   # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-bun-runtime clean   # remove dist/
-bun run --cwd plugins/plugin-native-bun-runtime watch   # tsc --watch
-bun run --cwd plugins/plugin-native-bun-runtime test    # vitest run
+bun run --cwd plugins/plugin-native-bun-runtime clean           # remove build output
+bun run --cwd plugins/plugin-native-bun-runtime build           # build package artifacts
+bun run --cwd plugins/plugin-native-bun-runtime typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-bun-runtime lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-bun-runtime lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-bun-runtime format          # write formatting
+bun run --cwd plugins/plugin-native-bun-runtime format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-bun-runtime test            # run package tests
+bun run --cwd plugins/plugin-native-bun-runtime prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-bun-runtime watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-bun-runtime build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-bun-runtime/CLAUDE.md
+++ b/plugins/plugin-native-bun-runtime/CLAUDE.md
@@ -83,13 +83,20 @@ plugins/plugin-native-bun-runtime/
 
 ## Commands
 
-Scripts that exist in `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-bun-runtime build   # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-bun-runtime clean   # remove dist/
-bun run --cwd plugins/plugin-native-bun-runtime watch   # tsc --watch
-bun run --cwd plugins/plugin-native-bun-runtime test    # vitest run
+bun run --cwd plugins/plugin-native-bun-runtime clean           # remove build output
+bun run --cwd plugins/plugin-native-bun-runtime build           # build package artifacts
+bun run --cwd plugins/plugin-native-bun-runtime typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-bun-runtime lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-bun-runtime lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-bun-runtime format          # write formatting
+bun run --cwd plugins/plugin-native-bun-runtime format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-bun-runtime test            # run package tests
+bun run --cwd plugins/plugin-native-bun-runtime prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-bun-runtime watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-bun-runtime build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-calendar/AGENTS.md
+++ b/plugins/plugin-native-calendar/AGENTS.md
@@ -50,10 +50,19 @@ plugins/plugin-native-calendar/
 
 ## Commands
 
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
+
 ```bash
-bun run --cwd plugins/plugin-native-calendar build          # tsc + rollup → dist/
-bun run --cwd plugins/plugin-native-calendar clean          # remove dist/
-bun run --cwd plugins/plugin-native-calendar prepublishOnly # build before npm publish
+bun run --cwd plugins/plugin-native-calendar clean           # remove build output
+bun run --cwd plugins/plugin-native-calendar build           # build package artifacts
+bun run --cwd plugins/plugin-native-calendar typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-calendar lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-calendar lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-calendar format          # write formatting
+bun run --cwd plugins/plugin-native-calendar format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-calendar test            # run package tests
+bun run --cwd plugins/plugin-native-calendar prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-calendar build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / Env Vars

--- a/plugins/plugin-native-calendar/CLAUDE.md
+++ b/plugins/plugin-native-calendar/CLAUDE.md
@@ -50,10 +50,19 @@ plugins/plugin-native-calendar/
 
 ## Commands
 
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
+
 ```bash
-bun run --cwd plugins/plugin-native-calendar build          # tsc + rollup → dist/
-bun run --cwd plugins/plugin-native-calendar clean          # remove dist/
-bun run --cwd plugins/plugin-native-calendar prepublishOnly # build before npm publish
+bun run --cwd plugins/plugin-native-calendar clean           # remove build output
+bun run --cwd plugins/plugin-native-calendar build           # build package artifacts
+bun run --cwd plugins/plugin-native-calendar typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-calendar lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-calendar lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-calendar format          # write formatting
+bun run --cwd plugins/plugin-native-calendar format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-calendar test            # run package tests
+bun run --cwd plugins/plugin-native-calendar prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-calendar build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / Env Vars

--- a/plugins/plugin-native-camera/AGENTS.md
+++ b/plugins/plugin-native-camera/AGENTS.md
@@ -68,16 +68,21 @@ plugins/plugin-native-camera/
 
 ## Commands
 
-Only scripts defined in `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-camera build   # clean + tsc + rollup bundle
-bun run --cwd plugins/plugin-native-camera clean   # remove dist/
-bun run --cwd plugins/plugin-native-camera watch   # tsc --watch
-bun run --cwd plugins/plugin-native-camera test    # run vitest unit tests
+bun run --cwd plugins/plugin-native-camera clean           # remove build output
+bun run --cwd plugins/plugin-native-camera build           # build package artifacts
+bun run --cwd plugins/plugin-native-camera typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-camera lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-camera lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-camera format          # write formatting
+bun run --cwd plugins/plugin-native-camera format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-camera test            # run package tests
+bun run --cwd plugins/plugin-native-camera prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-camera watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-camera build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
-
-`prepublishOnly` runs `build` automatically before `npm publish`.
 
 ## Config / env vars
 

--- a/plugins/plugin-native-camera/CLAUDE.md
+++ b/plugins/plugin-native-camera/CLAUDE.md
@@ -68,16 +68,21 @@ plugins/plugin-native-camera/
 
 ## Commands
 
-Only scripts defined in `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-camera build   # clean + tsc + rollup bundle
-bun run --cwd plugins/plugin-native-camera clean   # remove dist/
-bun run --cwd plugins/plugin-native-camera watch   # tsc --watch
-bun run --cwd plugins/plugin-native-camera test    # run vitest unit tests
+bun run --cwd plugins/plugin-native-camera clean           # remove build output
+bun run --cwd plugins/plugin-native-camera build           # build package artifacts
+bun run --cwd plugins/plugin-native-camera typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-camera lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-camera lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-camera format          # write formatting
+bun run --cwd plugins/plugin-native-camera format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-camera test            # run package tests
+bun run --cwd plugins/plugin-native-camera prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-camera watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-camera build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
-
-`prepublishOnly` runs `build` automatically before `npm publish`.
 
 ## Config / env vars
 

--- a/plugins/plugin-native-canvas/AGENTS.md
+++ b/plugins/plugin-native-canvas/AGENTS.md
@@ -81,10 +81,20 @@ plugins/plugin-native-canvas/
 
 ## Commands
 
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
+
 ```bash
-bun run --cwd plugins/plugin-native-canvas build   # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-canvas watch   # tsc --watch (no rollup)
-bun run --cwd plugins/plugin-native-canvas clean   # remove dist/
+bun run --cwd plugins/plugin-native-canvas clean           # remove build output
+bun run --cwd plugins/plugin-native-canvas build           # build package artifacts
+bun run --cwd plugins/plugin-native-canvas typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-canvas lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-canvas lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-canvas format          # write formatting
+bun run --cwd plugins/plugin-native-canvas format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-canvas test            # run package tests
+bun run --cwd plugins/plugin-native-canvas prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-canvas watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-canvas build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-canvas/CLAUDE.md
+++ b/plugins/plugin-native-canvas/CLAUDE.md
@@ -81,10 +81,20 @@ plugins/plugin-native-canvas/
 
 ## Commands
 
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
+
 ```bash
-bun run --cwd plugins/plugin-native-canvas build   # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-canvas watch   # tsc --watch (no rollup)
-bun run --cwd plugins/plugin-native-canvas clean   # remove dist/
+bun run --cwd plugins/plugin-native-canvas clean           # remove build output
+bun run --cwd plugins/plugin-native-canvas build           # build package artifacts
+bun run --cwd plugins/plugin-native-canvas typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-canvas lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-canvas lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-canvas format          # write formatting
+bun run --cwd plugins/plugin-native-canvas format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-canvas test            # run package tests
+bun run --cwd plugins/plugin-native-canvas prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-canvas watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-canvas build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-contacts/AGENTS.md
+++ b/plugins/plugin-native-contacts/AGENTS.md
@@ -53,12 +53,20 @@ plugins/plugin-native-contacts/
 
 ## Commands
 
-```bash
-bun run --cwd plugins/plugin-native-contacts build    # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-contacts clean    # rm dist/
-```
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
-`prepublishOnly` runs `build` automatically on `bun publish`.
+```bash
+bun run --cwd plugins/plugin-native-contacts clean           # remove build output
+bun run --cwd plugins/plugin-native-contacts build           # build package artifacts
+bun run --cwd plugins/plugin-native-contacts typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-contacts lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-contacts lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-contacts format          # write formatting
+bun run --cwd plugins/plugin-native-contacts format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-contacts test            # run package tests
+bun run --cwd plugins/plugin-native-contacts prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-contacts build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
+```
 
 ## Config / env vars
 

--- a/plugins/plugin-native-contacts/CLAUDE.md
+++ b/plugins/plugin-native-contacts/CLAUDE.md
@@ -53,12 +53,20 @@ plugins/plugin-native-contacts/
 
 ## Commands
 
-```bash
-bun run --cwd plugins/plugin-native-contacts build    # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-contacts clean    # rm dist/
-```
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
-`prepublishOnly` runs `build` automatically on `bun publish`.
+```bash
+bun run --cwd plugins/plugin-native-contacts clean           # remove build output
+bun run --cwd plugins/plugin-native-contacts build           # build package artifacts
+bun run --cwd plugins/plugin-native-contacts typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-contacts lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-contacts lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-contacts format          # write formatting
+bun run --cwd plugins/plugin-native-contacts format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-contacts test            # run package tests
+bun run --cwd plugins/plugin-native-contacts prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-contacts build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
+```
 
 ## Config / env vars
 

--- a/plugins/plugin-native-desktop/AGENTS.md
+++ b/plugins/plugin-native-desktop/AGENTS.md
@@ -50,15 +50,20 @@ plugins/plugin-native-desktop/
 
 ## Commands
 
-Scripts in package.json:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-desktop build          # delegates to build:unlocked via with-package-build-lock.mjs
-bun run --cwd plugins/plugin-native-desktop build:unlocked # clean + tsc + rollup (actual build steps)
-bun run --cwd plugins/plugin-native-desktop clean          # delete dist/
-bun run --cwd plugins/plugin-native-desktop watch          # tsc --watch (no rollup)
-bun run --cwd plugins/plugin-native-desktop test           # vitest run
-# prepublishOnly runs build automatically before npm publish
+bun run --cwd plugins/plugin-native-desktop clean           # remove build output
+bun run --cwd plugins/plugin-native-desktop build           # build package artifacts
+bun run --cwd plugins/plugin-native-desktop typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-desktop lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-desktop lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-desktop format          # write formatting
+bun run --cwd plugins/plugin-native-desktop format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-desktop test            # run package tests
+bun run --cwd plugins/plugin-native-desktop prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-desktop watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-desktop build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-desktop/CLAUDE.md
+++ b/plugins/plugin-native-desktop/CLAUDE.md
@@ -50,15 +50,20 @@ plugins/plugin-native-desktop/
 
 ## Commands
 
-Scripts in package.json:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-desktop build          # delegates to build:unlocked via with-package-build-lock.mjs
-bun run --cwd plugins/plugin-native-desktop build:unlocked # clean + tsc + rollup (actual build steps)
-bun run --cwd plugins/plugin-native-desktop clean          # delete dist/
-bun run --cwd plugins/plugin-native-desktop watch          # tsc --watch (no rollup)
-bun run --cwd plugins/plugin-native-desktop test           # vitest run
-# prepublishOnly runs build automatically before npm publish
+bun run --cwd plugins/plugin-native-desktop clean           # remove build output
+bun run --cwd plugins/plugin-native-desktop build           # build package artifacts
+bun run --cwd plugins/plugin-native-desktop typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-desktop lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-desktop lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-desktop format          # write formatting
+bun run --cwd plugins/plugin-native-desktop format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-desktop test            # run package tests
+bun run --cwd plugins/plugin-native-desktop prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-desktop watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-desktop build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-eliza-tasks/AGENTS.md
+++ b/plugins/plugin-native-eliza-tasks/AGENTS.md
@@ -45,11 +45,20 @@ plugins/plugin-native-eliza-tasks/
 
 ## Commands
 
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
+
 ```bash
-bun run --cwd plugins/plugin-native-eliza-tasks build   # tsc + rollup
-bun run --cwd plugins/plugin-native-eliza-tasks clean   # rm dist/
-bun run --cwd plugins/plugin-native-eliza-tasks watch   # tsc --watch
-bun run --cwd plugins/plugin-native-eliza-tasks test    # vitest run --passWithNoTests
+bun run --cwd plugins/plugin-native-eliza-tasks clean           # remove build output
+bun run --cwd plugins/plugin-native-eliza-tasks build           # build package artifacts
+bun run --cwd plugins/plugin-native-eliza-tasks typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-eliza-tasks lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-eliza-tasks lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-eliza-tasks format          # write formatting
+bun run --cwd plugins/plugin-native-eliza-tasks format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-eliza-tasks test            # run package tests
+bun run --cwd plugins/plugin-native-eliza-tasks prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-eliza-tasks watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-eliza-tasks build:unlocked  # bun run clean && bunx tsc -p tsconfig.json && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-eliza-tasks/CLAUDE.md
+++ b/plugins/plugin-native-eliza-tasks/CLAUDE.md
@@ -45,11 +45,20 @@ plugins/plugin-native-eliza-tasks/
 
 ## Commands
 
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
+
 ```bash
-bun run --cwd plugins/plugin-native-eliza-tasks build   # tsc + rollup
-bun run --cwd plugins/plugin-native-eliza-tasks clean   # rm dist/
-bun run --cwd plugins/plugin-native-eliza-tasks watch   # tsc --watch
-bun run --cwd plugins/plugin-native-eliza-tasks test    # vitest run --passWithNoTests
+bun run --cwd plugins/plugin-native-eliza-tasks clean           # remove build output
+bun run --cwd plugins/plugin-native-eliza-tasks build           # build package artifacts
+bun run --cwd plugins/plugin-native-eliza-tasks typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-eliza-tasks lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-eliza-tasks lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-eliza-tasks format          # write formatting
+bun run --cwd plugins/plugin-native-eliza-tasks format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-eliza-tasks test            # run package tests
+bun run --cwd plugins/plugin-native-eliza-tasks prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-eliza-tasks watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-eliza-tasks build:unlocked  # bun run clean && bunx tsc -p tsconfig.json && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-gateway/AGENTS.md
+++ b/plugins/plugin-native-gateway/AGENTS.md
@@ -49,23 +49,28 @@ plugins/plugin-native-gateway/
 
 ## Commands
 
-Scripts defined in `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-gateway build           # tsc + rollup → dist/
-bun run --cwd plugins/plugin-native-gateway build:docs      # docgen → README.md, then build
-bun run --cwd plugins/plugin-native-gateway watch           # tsc --watch
-bun run --cwd plugins/plugin-native-gateway lint            # biome check (+ swiftlint if installed)
-bun run --cwd plugins/plugin-native-gateway lint:check      # biome check (read-only)
-bun run --cwd plugins/plugin-native-gateway fmt             # biome check --write --unsafe
-bun run --cwd plugins/plugin-native-gateway format          # biome format --write
-bun run --cwd plugins/plugin-native-gateway format:check    # biome format (dry-run)
-bun run --cwd plugins/plugin-native-gateway verify          # verify:ios + verify:android + verify:web
-bun run --cwd plugins/plugin-native-gateway verify:web      # bun run build only
-bun run --cwd plugins/plugin-native-gateway verify:ios      # pod install + xcodebuild
-bun run --cwd plugins/plugin-native-gateway verify:android  # ./gradlew clean build test
-bun run --cwd plugins/plugin-native-gateway docgen          # @capacitor/docgen → README.md + dist/docs.json
-bun run --cwd plugins/plugin-native-gateway clean           # delete dist/
+bun run --cwd plugins/plugin-native-gateway clean           # remove build output
+bun run --cwd plugins/plugin-native-gateway build           # build package artifacts
+bun run --cwd plugins/plugin-native-gateway build:docs      # generate docs and build artifacts
+bun run --cwd plugins/plugin-native-gateway typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-gateway lint            # mutating Biome check plus native lint tail
+bun run --cwd plugins/plugin-native-gateway lint:check      # read-only Biome check plus native lint tail
+bun run --cwd plugins/plugin-native-gateway format          # write formatting
+bun run --cwd plugins/plugin-native-gateway format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-gateway test            # run package tests
+bun run --cwd plugins/plugin-native-gateway prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-gateway watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-gateway build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
+bun run --cwd plugins/plugin-native-gateway docgen          # docgen --api GatewayPlugin --output-readme README.md --output-json dist/docs.json
+bun run --cwd plugins/plugin-native-gateway fmt             # bunx @biomejs/biome check --write --unsafe . && bash -c 'if command -v swiftlint >/dev/null 2>&1; then bun run swiftlint -- lint --fix; fi'
+bun run --cwd plugins/plugin-native-gateway swiftlint       # node-swiftlint
+bun run --cwd plugins/plugin-native-gateway verify          # bun run verify:ios && bun run verify:android && bun run verify:web
+bun run --cwd plugins/plugin-native-gateway verify:android  # cd android && ./gradlew clean build test && cd ..
+bun run --cwd plugins/plugin-native-gateway verify:ios      # cd ios && pod install && xcodebuild -workspace Plugin.xcworkspace -scheme Plugin -destination generic/platform=iOS && cd ..
+bun run --cwd plugins/plugin-native-gateway verify:web      # bun run build
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-gateway/CLAUDE.md
+++ b/plugins/plugin-native-gateway/CLAUDE.md
@@ -49,23 +49,28 @@ plugins/plugin-native-gateway/
 
 ## Commands
 
-Scripts defined in `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-gateway build           # tsc + rollup → dist/
-bun run --cwd plugins/plugin-native-gateway build:docs      # docgen → README.md, then build
-bun run --cwd plugins/plugin-native-gateway watch           # tsc --watch
-bun run --cwd plugins/plugin-native-gateway lint            # biome check (+ swiftlint if installed)
-bun run --cwd plugins/plugin-native-gateway lint:check      # biome check (read-only)
-bun run --cwd plugins/plugin-native-gateway fmt             # biome check --write --unsafe
-bun run --cwd plugins/plugin-native-gateway format          # biome format --write
-bun run --cwd plugins/plugin-native-gateway format:check    # biome format (dry-run)
-bun run --cwd plugins/plugin-native-gateway verify          # verify:ios + verify:android + verify:web
-bun run --cwd plugins/plugin-native-gateway verify:web      # bun run build only
-bun run --cwd plugins/plugin-native-gateway verify:ios      # pod install + xcodebuild
-bun run --cwd plugins/plugin-native-gateway verify:android  # ./gradlew clean build test
-bun run --cwd plugins/plugin-native-gateway docgen          # @capacitor/docgen → README.md + dist/docs.json
-bun run --cwd plugins/plugin-native-gateway clean           # delete dist/
+bun run --cwd plugins/plugin-native-gateway clean           # remove build output
+bun run --cwd plugins/plugin-native-gateway build           # build package artifacts
+bun run --cwd plugins/plugin-native-gateway build:docs      # generate docs and build artifacts
+bun run --cwd plugins/plugin-native-gateway typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-gateway lint            # mutating Biome check plus native lint tail
+bun run --cwd plugins/plugin-native-gateway lint:check      # read-only Biome check plus native lint tail
+bun run --cwd plugins/plugin-native-gateway format          # write formatting
+bun run --cwd plugins/plugin-native-gateway format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-gateway test            # run package tests
+bun run --cwd plugins/plugin-native-gateway prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-gateway watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-gateway build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
+bun run --cwd plugins/plugin-native-gateway docgen          # docgen --api GatewayPlugin --output-readme README.md --output-json dist/docs.json
+bun run --cwd plugins/plugin-native-gateway fmt             # bunx @biomejs/biome check --write --unsafe . && bash -c 'if command -v swiftlint >/dev/null 2>&1; then bun run swiftlint -- lint --fix; fi'
+bun run --cwd plugins/plugin-native-gateway swiftlint       # node-swiftlint
+bun run --cwd plugins/plugin-native-gateway verify          # bun run verify:ios && bun run verify:android && bun run verify:web
+bun run --cwd plugins/plugin-native-gateway verify:android  # cd android && ./gradlew clean build test && cd ..
+bun run --cwd plugins/plugin-native-gateway verify:ios      # cd ios && pod install && xcodebuild -workspace Plugin.xcworkspace -scheme Plugin -destination generic/platform=iOS && cd ..
+bun run --cwd plugins/plugin-native-gateway verify:web      # bun run build
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-llama/AGENTS.md
+++ b/plugins/plugin-native-llama/AGENTS.md
@@ -45,11 +45,20 @@ rollup.config.mjs           Rollup bundle config (IIFE + CJS outputs; ESM comes 
 
 ## Commands
 
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
+
 ```bash
-bun run --cwd plugins/plugin-native-llama build    # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-llama clean    # rm dist/
-bun run --cwd plugins/plugin-native-llama test     # vitest run
-bun run --cwd plugins/plugin-native-llama watch    # tsc --watch
+bun run --cwd plugins/plugin-native-llama clean           # remove build output
+bun run --cwd plugins/plugin-native-llama build           # build package artifacts
+bun run --cwd plugins/plugin-native-llama typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-llama lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-llama lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-llama format          # write formatting
+bun run --cwd plugins/plugin-native-llama format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-llama test            # run package tests
+bun run --cwd plugins/plugin-native-llama prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-llama watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-llama build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-llama/CLAUDE.md
+++ b/plugins/plugin-native-llama/CLAUDE.md
@@ -45,11 +45,20 @@ rollup.config.mjs           Rollup bundle config (IIFE + CJS outputs; ESM comes 
 
 ## Commands
 
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
+
 ```bash
-bun run --cwd plugins/plugin-native-llama build    # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-llama clean    # rm dist/
-bun run --cwd plugins/plugin-native-llama test     # vitest run
-bun run --cwd plugins/plugin-native-llama watch    # tsc --watch
+bun run --cwd plugins/plugin-native-llama clean           # remove build output
+bun run --cwd plugins/plugin-native-llama build           # build package artifacts
+bun run --cwd plugins/plugin-native-llama typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-llama lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-llama lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-llama format          # write formatting
+bun run --cwd plugins/plugin-native-llama format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-llama test            # run package tests
+bun run --cwd plugins/plugin-native-llama prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-llama watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-llama build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-location/AGENTS.md
+++ b/plugins/plugin-native-location/AGENTS.md
@@ -49,26 +49,21 @@ plugins/plugin-native-location/
 
 ## Commands
 
-Only scripts that exist in this package's `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-# Build TypeScript + rollup bundles
-bun run --cwd plugins/plugin-native-location build
-
-# Cleans dist/, then runs docgen → tsc → rollup bundles
-bun run --cwd plugins/plugin-native-location build:docs
-
-# Delete dist/
-bun run --cwd plugins/plugin-native-location clean
-
-# Generate README.md from JSDoc (requires @capacitor/docgen)
-bun run --cwd plugins/plugin-native-location docgen
-
-# Run unit tests (vitest)
-bun run --cwd plugins/plugin-native-location test
-
-# Android instrumented test for the native reader (from packages/app-core/platforms/android)
-./gradlew :elizaos-capacitor-location:connectedDebugAndroidTest
+bun run --cwd plugins/plugin-native-location clean           # remove build output
+bun run --cwd plugins/plugin-native-location build           # build package artifacts
+bun run --cwd plugins/plugin-native-location build:docs      # generate docs and build artifacts
+bun run --cwd plugins/plugin-native-location typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-location lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-location lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-location format          # write formatting
+bun run --cwd plugins/plugin-native-location format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-location test            # run package tests
+bun run --cwd plugins/plugin-native-location prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-location build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
+bun run --cwd plugins/plugin-native-location docgen          # docgen --api LocationPlugin --output-readme README.md --output-json dist/docs.json
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-location/CLAUDE.md
+++ b/plugins/plugin-native-location/CLAUDE.md
@@ -49,26 +49,21 @@ plugins/plugin-native-location/
 
 ## Commands
 
-Only scripts that exist in this package's `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-# Build TypeScript + rollup bundles
-bun run --cwd plugins/plugin-native-location build
-
-# Cleans dist/, then runs docgen → tsc → rollup bundles
-bun run --cwd plugins/plugin-native-location build:docs
-
-# Delete dist/
-bun run --cwd plugins/plugin-native-location clean
-
-# Generate README.md from JSDoc (requires @capacitor/docgen)
-bun run --cwd plugins/plugin-native-location docgen
-
-# Run unit tests (vitest)
-bun run --cwd plugins/plugin-native-location test
-
-# Android instrumented test for the native reader (from packages/app-core/platforms/android)
-./gradlew :elizaos-capacitor-location:connectedDebugAndroidTest
+bun run --cwd plugins/plugin-native-location clean           # remove build output
+bun run --cwd plugins/plugin-native-location build           # build package artifacts
+bun run --cwd plugins/plugin-native-location build:docs      # generate docs and build artifacts
+bun run --cwd plugins/plugin-native-location typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-location lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-location lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-location format          # write formatting
+bun run --cwd plugins/plugin-native-location format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-location test            # run package tests
+bun run --cwd plugins/plugin-native-location prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-location build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
+bun run --cwd plugins/plugin-native-location docgen          # docgen --api LocationPlugin --output-readme README.md --output-json dist/docs.json
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-macosalarm/AGENTS.md
+++ b/plugins/plugin-native-macosalarm/AGENTS.md
@@ -37,13 +37,20 @@ plugins/plugin-native-macosalarm/
 
 ## Commands
 
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
+
 ```bash
-bun run --cwd plugins/plugin-native-macosalarm build          # tsc + swiftc
-bun run --cwd plugins/plugin-native-macosalarm build:ts       # TypeScript only
-bun run --cwd plugins/plugin-native-macosalarm build:helper   # Swift binary only
-bun run --cwd plugins/plugin-native-macosalarm typecheck      # tsgo --noEmit
-bun run --cwd plugins/plugin-native-macosalarm test           # vitest run
-bun run --cwd plugins/plugin-native-macosalarm clean          # rm -rf dist bin
+bun run --cwd plugins/plugin-native-macosalarm clean           # remove build output
+bun run --cwd plugins/plugin-native-macosalarm build           # build package artifacts
+bun run --cwd plugins/plugin-native-macosalarm typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-macosalarm lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-macosalarm lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-macosalarm format          # write formatting
+bun run --cwd plugins/plugin-native-macosalarm format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-macosalarm test            # run package tests
+bun run --cwd plugins/plugin-native-macosalarm prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-macosalarm build:helper    # node scripts/build-helper.mjs
+bun run --cwd plugins/plugin-native-macosalarm build:ts        # tsc --noCheck -p tsconfig.json
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-macosalarm/CLAUDE.md
+++ b/plugins/plugin-native-macosalarm/CLAUDE.md
@@ -37,13 +37,20 @@ plugins/plugin-native-macosalarm/
 
 ## Commands
 
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
+
 ```bash
-bun run --cwd plugins/plugin-native-macosalarm build          # tsc + swiftc
-bun run --cwd plugins/plugin-native-macosalarm build:ts       # TypeScript only
-bun run --cwd plugins/plugin-native-macosalarm build:helper   # Swift binary only
-bun run --cwd plugins/plugin-native-macosalarm typecheck      # tsgo --noEmit
-bun run --cwd plugins/plugin-native-macosalarm test           # vitest run
-bun run --cwd plugins/plugin-native-macosalarm clean          # rm -rf dist bin
+bun run --cwd plugins/plugin-native-macosalarm clean           # remove build output
+bun run --cwd plugins/plugin-native-macosalarm build           # build package artifacts
+bun run --cwd plugins/plugin-native-macosalarm typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-macosalarm lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-macosalarm lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-macosalarm format          # write formatting
+bun run --cwd plugins/plugin-native-macosalarm format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-macosalarm test            # run package tests
+bun run --cwd plugins/plugin-native-macosalarm prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-macosalarm build:helper    # node scripts/build-helper.mjs
+bun run --cwd plugins/plugin-native-macosalarm build:ts        # tsc --noCheck -p tsconfig.json
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-messages/AGENTS.md
+++ b/plugins/plugin-native-messages/AGENTS.md
@@ -39,14 +39,19 @@ plugins/plugin-native-messages/
 
 ## Commands
 
-Scripts defined in this package.json:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-messages build           # lock-wrapped build; delegates to build:unlocked
-bun run --cwd plugins/plugin-native-messages build:unlocked  # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-messages clean           # node ../../packages/scripts/rm-path-recursive.mjs dist
-bun run --cwd plugins/plugin-native-messages test            # vitest run
-bun run --cwd plugins/plugin-native-messages prepublishOnly  # same as build
+bun run --cwd plugins/plugin-native-messages clean           # remove build output
+bun run --cwd plugins/plugin-native-messages build           # build package artifacts
+bun run --cwd plugins/plugin-native-messages typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-messages lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-messages lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-messages format          # write formatting
+bun run --cwd plugins/plugin-native-messages format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-messages test            # run package tests
+bun run --cwd plugins/plugin-native-messages prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-messages build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-messages/CLAUDE.md
+++ b/plugins/plugin-native-messages/CLAUDE.md
@@ -39,14 +39,19 @@ plugins/plugin-native-messages/
 
 ## Commands
 
-Scripts defined in this package.json:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-messages build           # lock-wrapped build; delegates to build:unlocked
-bun run --cwd plugins/plugin-native-messages build:unlocked  # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-messages clean           # node ../../packages/scripts/rm-path-recursive.mjs dist
-bun run --cwd plugins/plugin-native-messages test            # vitest run
-bun run --cwd plugins/plugin-native-messages prepublishOnly  # same as build
+bun run --cwd plugins/plugin-native-messages clean           # remove build output
+bun run --cwd plugins/plugin-native-messages build           # build package artifacts
+bun run --cwd plugins/plugin-native-messages typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-messages lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-messages lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-messages format          # write formatting
+bun run --cwd plugins/plugin-native-messages format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-messages test            # run package tests
+bun run --cwd plugins/plugin-native-messages prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-messages build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-mlkit-text/AGENTS.md
+++ b/plugins/plugin-native-mlkit-text/AGENTS.md
@@ -32,18 +32,20 @@ android/
 
 ## Commands
 
-Run from repo root:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-mlkit-text build
-bun run --cwd plugins/plugin-native-mlkit-text test
-```
-
-On-device instrumented test (from `packages/app-core/platforms/android`, with a
-device/emulator attached — pin one with `ANDROID_SERIAL=<serial>`):
-
-```bash
-./gradlew :elizaos-capacitor-mlkit-text:connectedDebugAndroidTest
+bun run --cwd plugins/plugin-native-mlkit-text clean           # remove build output
+bun run --cwd plugins/plugin-native-mlkit-text build           # build package artifacts
+bun run --cwd plugins/plugin-native-mlkit-text typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-mlkit-text lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-mlkit-text lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-mlkit-text format          # write formatting
+bun run --cwd plugins/plugin-native-mlkit-text format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-mlkit-text test            # run package tests
+bun run --cwd plugins/plugin-native-mlkit-text prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-mlkit-text watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-mlkit-text build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Gotchas

--- a/plugins/plugin-native-mlkit-text/CLAUDE.md
+++ b/plugins/plugin-native-mlkit-text/CLAUDE.md
@@ -32,18 +32,20 @@ android/
 
 ## Commands
 
-Run from repo root:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-mlkit-text build
-bun run --cwd plugins/plugin-native-mlkit-text test
-```
-
-On-device instrumented test (from `packages/app-core/platforms/android`, with a
-device/emulator attached — pin one with `ANDROID_SERIAL=<serial>`):
-
-```bash
-./gradlew :elizaos-capacitor-mlkit-text:connectedDebugAndroidTest
+bun run --cwd plugins/plugin-native-mlkit-text clean           # remove build output
+bun run --cwd plugins/plugin-native-mlkit-text build           # build package artifacts
+bun run --cwd plugins/plugin-native-mlkit-text typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-mlkit-text lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-mlkit-text lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-mlkit-text format          # write formatting
+bun run --cwd plugins/plugin-native-mlkit-text format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-mlkit-text test            # run package tests
+bun run --cwd plugins/plugin-native-mlkit-text prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-mlkit-text watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-mlkit-text build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Gotchas

--- a/plugins/plugin-native-mobile-agent-bridge/AGENTS.md
+++ b/plugins/plugin-native-mobile-agent-bridge/AGENTS.md
@@ -45,17 +45,21 @@ rollup.config.mjs                           Bundles CJS + ESM outputs.
 
 ## Commands
 
-Only scripts defined in `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-mobile-agent-bridge build         # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-mobile-agent-bridge clean         # remove dist/
-bun run --cwd plugins/plugin-native-mobile-agent-bridge watch         # tsc --watch
-bun run --cwd plugins/plugin-native-mobile-agent-bridge test          # vitest run
-bun run --cwd plugins/plugin-native-mobile-agent-bridge lint          # biome check
-bun run --cwd plugins/plugin-native-mobile-agent-bridge fmt           # biome check --write --unsafe
-bun run --cwd plugins/plugin-native-mobile-agent-bridge format        # biome format --write
-bun run --cwd plugins/plugin-native-mobile-agent-bridge format:check  # biome format (dry-run)
+bun run --cwd plugins/plugin-native-mobile-agent-bridge clean           # remove build output
+bun run --cwd plugins/plugin-native-mobile-agent-bridge build           # build package artifacts
+bun run --cwd plugins/plugin-native-mobile-agent-bridge typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-mobile-agent-bridge lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-mobile-agent-bridge lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-mobile-agent-bridge format          # write formatting
+bun run --cwd plugins/plugin-native-mobile-agent-bridge format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-mobile-agent-bridge test            # run package tests
+bun run --cwd plugins/plugin-native-mobile-agent-bridge prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-mobile-agent-bridge watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-mobile-agent-bridge build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
+bun run --cwd plugins/plugin-native-mobile-agent-bridge fmt             # bunx @biomejs/biome check --write --unsafe .
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-mobile-agent-bridge/CLAUDE.md
+++ b/plugins/plugin-native-mobile-agent-bridge/CLAUDE.md
@@ -45,17 +45,21 @@ rollup.config.mjs                           Bundles CJS + ESM outputs.
 
 ## Commands
 
-Only scripts defined in `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-mobile-agent-bridge build         # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-mobile-agent-bridge clean         # remove dist/
-bun run --cwd plugins/plugin-native-mobile-agent-bridge watch         # tsc --watch
-bun run --cwd plugins/plugin-native-mobile-agent-bridge test          # vitest run
-bun run --cwd plugins/plugin-native-mobile-agent-bridge lint          # biome check
-bun run --cwd plugins/plugin-native-mobile-agent-bridge fmt           # biome check --write --unsafe
-bun run --cwd plugins/plugin-native-mobile-agent-bridge format        # biome format --write
-bun run --cwd plugins/plugin-native-mobile-agent-bridge format:check  # biome format (dry-run)
+bun run --cwd plugins/plugin-native-mobile-agent-bridge clean           # remove build output
+bun run --cwd plugins/plugin-native-mobile-agent-bridge build           # build package artifacts
+bun run --cwd plugins/plugin-native-mobile-agent-bridge typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-mobile-agent-bridge lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-mobile-agent-bridge lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-mobile-agent-bridge format          # write formatting
+bun run --cwd plugins/plugin-native-mobile-agent-bridge format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-mobile-agent-bridge test            # run package tests
+bun run --cwd plugins/plugin-native-mobile-agent-bridge prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-mobile-agent-bridge watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-mobile-agent-bridge build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
+bun run --cwd plugins/plugin-native-mobile-agent-bridge fmt             # bunx @biomejs/biome check --write --unsafe .
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-mobile-signals/AGENTS.md
+++ b/plugins/plugin-native-mobile-signals/AGENTS.md
@@ -54,23 +54,21 @@ tsconfig.json                          TypeScript config (emits to dist/esm/)
 
 ## Commands
 
-Scripts that exist in this package's `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-# Build: tsc + rollup (outputs dist/esm/, dist/plugin.cjs.js, dist/plugin.js)
-bun run --cwd plugins/plugin-native-mobile-signals build
-
-# Clean dist/
-bun run --cwd plugins/plugin-native-mobile-signals clean
-
-# Run vitest tests
-bun run --cwd plugins/plugin-native-mobile-signals test
-
-# Validate iOS Screen Time build wiring against the host app's Xcode project
-bun run --cwd plugins/plugin-native-mobile-signals validate:ios-screen-time
-
-# Watch mode TypeScript compilation
-bun run --cwd plugins/plugin-native-mobile-signals watch
+bun run --cwd plugins/plugin-native-mobile-signals clean                     # remove build output
+bun run --cwd plugins/plugin-native-mobile-signals build                     # build package artifacts
+bun run --cwd plugins/plugin-native-mobile-signals typecheck                 # TypeScript typecheck
+bun run --cwd plugins/plugin-native-mobile-signals lint                      # mutating Biome check
+bun run --cwd plugins/plugin-native-mobile-signals lint:check                # read-only Biome check
+bun run --cwd plugins/plugin-native-mobile-signals format                    # write formatting
+bun run --cwd plugins/plugin-native-mobile-signals format:check              # read-only formatting check
+bun run --cwd plugins/plugin-native-mobile-signals test                      # run package tests
+bun run --cwd plugins/plugin-native-mobile-signals prepublishOnly            # publish-time build hook
+bun run --cwd plugins/plugin-native-mobile-signals watch                     # watch TypeScript sources
+bun run --cwd plugins/plugin-native-mobile-signals build:unlocked            # bun run clean && bunx tsc -p tsconfig.json && bunx rollup -c rollup.config.mjs
+bun run --cwd plugins/plugin-native-mobile-signals validate:ios-screen-time  # node scripts/validate-ios-screen-time.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-mobile-signals/CLAUDE.md
+++ b/plugins/plugin-native-mobile-signals/CLAUDE.md
@@ -54,23 +54,21 @@ tsconfig.json                          TypeScript config (emits to dist/esm/)
 
 ## Commands
 
-Scripts that exist in this package's `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-# Build: tsc + rollup (outputs dist/esm/, dist/plugin.cjs.js, dist/plugin.js)
-bun run --cwd plugins/plugin-native-mobile-signals build
-
-# Clean dist/
-bun run --cwd plugins/plugin-native-mobile-signals clean
-
-# Run vitest tests
-bun run --cwd plugins/plugin-native-mobile-signals test
-
-# Validate iOS Screen Time build wiring against the host app's Xcode project
-bun run --cwd plugins/plugin-native-mobile-signals validate:ios-screen-time
-
-# Watch mode TypeScript compilation
-bun run --cwd plugins/plugin-native-mobile-signals watch
+bun run --cwd plugins/plugin-native-mobile-signals clean                     # remove build output
+bun run --cwd plugins/plugin-native-mobile-signals build                     # build package artifacts
+bun run --cwd plugins/plugin-native-mobile-signals typecheck                 # TypeScript typecheck
+bun run --cwd plugins/plugin-native-mobile-signals lint                      # mutating Biome check
+bun run --cwd plugins/plugin-native-mobile-signals lint:check                # read-only Biome check
+bun run --cwd plugins/plugin-native-mobile-signals format                    # write formatting
+bun run --cwd plugins/plugin-native-mobile-signals format:check              # read-only formatting check
+bun run --cwd plugins/plugin-native-mobile-signals test                      # run package tests
+bun run --cwd plugins/plugin-native-mobile-signals prepublishOnly            # publish-time build hook
+bun run --cwd plugins/plugin-native-mobile-signals watch                     # watch TypeScript sources
+bun run --cwd plugins/plugin-native-mobile-signals build:unlocked            # bun run clean && bunx tsc -p tsconfig.json && bunx rollup -c rollup.config.mjs
+bun run --cwd plugins/plugin-native-mobile-signals validate:ios-screen-time  # node scripts/validate-ios-screen-time.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-network-policy/AGENTS.md
+++ b/plugins/plugin-native-network-policy/AGENTS.md
@@ -54,13 +54,20 @@ plugins/plugin-native-network-policy/
 
 ## Commands
 
-```bash
-bun run --cwd plugins/plugin-native-network-policy build    # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-network-policy clean    # remove dist/
-bun run --cwd plugins/plugin-native-network-policy test     # vitest run
-```
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
-No lint script is defined in this package's `package.json`; use repo-root tooling.
+```bash
+bun run --cwd plugins/plugin-native-network-policy clean           # remove build output
+bun run --cwd plugins/plugin-native-network-policy build           # build package artifacts
+bun run --cwd plugins/plugin-native-network-policy typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-network-policy lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-network-policy lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-network-policy format          # write formatting
+bun run --cwd plugins/plugin-native-network-policy format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-network-policy test            # run package tests
+bun run --cwd plugins/plugin-native-network-policy prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-network-policy build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
+```
 
 ## Config / env vars
 

--- a/plugins/plugin-native-network-policy/CLAUDE.md
+++ b/plugins/plugin-native-network-policy/CLAUDE.md
@@ -54,13 +54,20 @@ plugins/plugin-native-network-policy/
 
 ## Commands
 
-```bash
-bun run --cwd plugins/plugin-native-network-policy build    # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-network-policy clean    # remove dist/
-bun run --cwd plugins/plugin-native-network-policy test     # vitest run
-```
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
-No lint script is defined in this package's `package.json`; use repo-root tooling.
+```bash
+bun run --cwd plugins/plugin-native-network-policy clean           # remove build output
+bun run --cwd plugins/plugin-native-network-policy build           # build package artifacts
+bun run --cwd plugins/plugin-native-network-policy typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-network-policy lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-network-policy lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-network-policy format          # write formatting
+bun run --cwd plugins/plugin-native-network-policy format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-network-policy test            # run package tests
+bun run --cwd plugins/plugin-native-network-policy prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-network-policy build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
+```
 
 ## Config / env vars
 

--- a/plugins/plugin-native-phone/AGENTS.md
+++ b/plugins/plugin-native-phone/AGENTS.md
@@ -46,12 +46,19 @@ plugins/plugin-native-phone/
 
 ## Commands
 
-Only scripts defined in this package's `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-phone build     # tsc + rollup (produces dist/)
-bun run --cwd plugins/plugin-native-phone clean     # removes dist/
-bun run --cwd plugins/plugin-native-phone test      # vitest run
+bun run --cwd plugins/plugin-native-phone clean           # remove build output
+bun run --cwd plugins/plugin-native-phone build           # build package artifacts
+bun run --cwd plugins/plugin-native-phone typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-phone lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-phone lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-phone format          # write formatting
+bun run --cwd plugins/plugin-native-phone format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-phone test            # run package tests
+bun run --cwd plugins/plugin-native-phone prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-phone build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-phone/CLAUDE.md
+++ b/plugins/plugin-native-phone/CLAUDE.md
@@ -46,12 +46,19 @@ plugins/plugin-native-phone/
 
 ## Commands
 
-Only scripts defined in this package's `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-phone build     # tsc + rollup (produces dist/)
-bun run --cwd plugins/plugin-native-phone clean     # removes dist/
-bun run --cwd plugins/plugin-native-phone test      # vitest run
+bun run --cwd plugins/plugin-native-phone clean           # remove build output
+bun run --cwd plugins/plugin-native-phone build           # build package artifacts
+bun run --cwd plugins/plugin-native-phone typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-phone lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-phone lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-phone format          # write formatting
+bun run --cwd plugins/plugin-native-phone format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-phone test            # run package tests
+bun run --cwd plugins/plugin-native-phone prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-phone build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-reminders/AGENTS.md
+++ b/plugins/plugin-native-reminders/AGENTS.md
@@ -33,10 +33,18 @@ plugins/plugin-native-reminders/
 
 ## Commands
 
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
+
 ```bash
-bun run --cwd plugins/plugin-native-reminders test
-bun run --cwd plugins/plugin-native-reminders build
-bun run --cwd plugins/plugin-native-reminders clean
+bun run --cwd plugins/plugin-native-reminders clean           # remove build output
+bun run --cwd plugins/plugin-native-reminders build           # build package artifacts
+bun run --cwd plugins/plugin-native-reminders typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-reminders lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-reminders lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-reminders format          # write formatting
+bun run --cwd plugins/plugin-native-reminders format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-reminders test            # run package tests
+bun run --cwd plugins/plugin-native-reminders prepublishOnly  # publish-time build hook
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-reminders/CLAUDE.md
+++ b/plugins/plugin-native-reminders/CLAUDE.md
@@ -33,10 +33,18 @@ plugins/plugin-native-reminders/
 
 ## Commands
 
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
+
 ```bash
-bun run --cwd plugins/plugin-native-reminders test
-bun run --cwd plugins/plugin-native-reminders build
-bun run --cwd plugins/plugin-native-reminders clean
+bun run --cwd plugins/plugin-native-reminders clean           # remove build output
+bun run --cwd plugins/plugin-native-reminders build           # build package artifacts
+bun run --cwd plugins/plugin-native-reminders typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-reminders lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-reminders lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-reminders format          # write formatting
+bun run --cwd plugins/plugin-native-reminders format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-reminders test            # run package tests
+bun run --cwd plugins/plugin-native-reminders prepublishOnly  # publish-time build hook
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-screencapture/AGENTS.md
+++ b/plugins/plugin-native-screencapture/AGENTS.md
@@ -74,13 +74,20 @@ plugins/plugin-native-screencapture/
 
 ## Commands
 
-All scripts come from `package.json`. Run from repo root with `--cwd`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-screencapture build    # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-screencapture clean    # remove dist/
-bun run --cwd plugins/plugin-native-screencapture watch    # tsc --watch (no rollup)
-bun run --cwd plugins/plugin-native-screencapture test     # vitest run (src/web.test.ts)
+bun run --cwd plugins/plugin-native-screencapture clean           # remove build output
+bun run --cwd plugins/plugin-native-screencapture build           # build package artifacts
+bun run --cwd plugins/plugin-native-screencapture typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-screencapture lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-screencapture lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-screencapture format          # write formatting
+bun run --cwd plugins/plugin-native-screencapture format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-screencapture test            # run package tests
+bun run --cwd plugins/plugin-native-screencapture prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-screencapture watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-screencapture build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / Env Vars

--- a/plugins/plugin-native-screencapture/CLAUDE.md
+++ b/plugins/plugin-native-screencapture/CLAUDE.md
@@ -74,13 +74,20 @@ plugins/plugin-native-screencapture/
 
 ## Commands
 
-All scripts come from `package.json`. Run from repo root with `--cwd`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-screencapture build    # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-screencapture clean    # remove dist/
-bun run --cwd plugins/plugin-native-screencapture watch    # tsc --watch (no rollup)
-bun run --cwd plugins/plugin-native-screencapture test     # vitest run (src/web.test.ts)
+bun run --cwd plugins/plugin-native-screencapture clean           # remove build output
+bun run --cwd plugins/plugin-native-screencapture build           # build package artifacts
+bun run --cwd plugins/plugin-native-screencapture typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-screencapture lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-screencapture lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-screencapture format          # write formatting
+bun run --cwd plugins/plugin-native-screencapture format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-screencapture test            # run package tests
+bun run --cwd plugins/plugin-native-screencapture prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-screencapture watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-screencapture build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / Env Vars

--- a/plugins/plugin-native-settings/AGENTS.md
+++ b/plugins/plugin-native-settings/AGENTS.md
@@ -37,14 +37,19 @@ src/
 
 ## Commands
 
-Scripts defined in this package's `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-settings build       # tsup JS + tsc types
-bun run --cwd plugins/plugin-native-settings typecheck   # tsgo --noEmit
-bun run --cwd plugins/plugin-native-settings lint        # biome check src
-bun run --cwd plugins/plugin-native-settings test        # vitest run
-bun run --cwd plugins/plugin-native-settings clean       # rm -rf dist
+bun run --cwd plugins/plugin-native-settings clean         # remove build output
+bun run --cwd plugins/plugin-native-settings build         # build package artifacts
+bun run --cwd plugins/plugin-native-settings typecheck     # TypeScript typecheck
+bun run --cwd plugins/plugin-native-settings lint          # mutating Biome check
+bun run --cwd plugins/plugin-native-settings lint:check    # read-only Biome check
+bun run --cwd plugins/plugin-native-settings format        # write formatting
+bun run --cwd plugins/plugin-native-settings format:check  # read-only formatting check
+bun run --cwd plugins/plugin-native-settings test          # run package tests
+bun run --cwd plugins/plugin-native-settings build:js      # tsup --config ../tsup.plugin-packages.shared.ts
+bun run --cwd plugins/plugin-native-settings build:types   # tsc --noCheck -p tsconfig.build.json
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-settings/CLAUDE.md
+++ b/plugins/plugin-native-settings/CLAUDE.md
@@ -37,14 +37,19 @@ src/
 
 ## Commands
 
-Scripts defined in this package's `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-settings build       # tsup JS + tsc types
-bun run --cwd plugins/plugin-native-settings typecheck   # tsgo --noEmit
-bun run --cwd plugins/plugin-native-settings lint        # biome check src
-bun run --cwd plugins/plugin-native-settings test        # vitest run
-bun run --cwd plugins/plugin-native-settings clean       # rm -rf dist
+bun run --cwd plugins/plugin-native-settings clean         # remove build output
+bun run --cwd plugins/plugin-native-settings build         # build package artifacts
+bun run --cwd plugins/plugin-native-settings typecheck     # TypeScript typecheck
+bun run --cwd plugins/plugin-native-settings lint          # mutating Biome check
+bun run --cwd plugins/plugin-native-settings lint:check    # read-only Biome check
+bun run --cwd plugins/plugin-native-settings format        # write formatting
+bun run --cwd plugins/plugin-native-settings format:check  # read-only formatting check
+bun run --cwd plugins/plugin-native-settings test          # run package tests
+bun run --cwd plugins/plugin-native-settings build:js      # tsup --config ../tsup.plugin-packages.shared.ts
+bun run --cwd plugins/plugin-native-settings build:types   # tsc --noCheck -p tsconfig.build.json
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-shared-types/AGENTS.md
+++ b/plugins/plugin-native-shared-types/AGENTS.md
@@ -35,7 +35,16 @@ plugins/plugin-native-shared-types/
 
 ## Commands
 
-This package has no build, test, or lint scripts. There is nothing to run.
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
+
+```bash
+bun run --cwd plugins/plugin-native-shared-types typecheck     # TypeScript typecheck
+bun run --cwd plugins/plugin-native-shared-types lint          # mutating Biome check
+bun run --cwd plugins/plugin-native-shared-types lint:check    # read-only Biome check
+bun run --cwd plugins/plugin-native-shared-types format        # write formatting
+bun run --cwd plugins/plugin-native-shared-types format:check  # read-only formatting check
+bun run --cwd plugins/plugin-native-shared-types test          # run package tests
+```
 
 ## Config / env vars
 

--- a/plugins/plugin-native-shared-types/CLAUDE.md
+++ b/plugins/plugin-native-shared-types/CLAUDE.md
@@ -35,7 +35,16 @@ plugins/plugin-native-shared-types/
 
 ## Commands
 
-This package has no build, test, or lint scripts. There is nothing to run.
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
+
+```bash
+bun run --cwd plugins/plugin-native-shared-types typecheck     # TypeScript typecheck
+bun run --cwd plugins/plugin-native-shared-types lint          # mutating Biome check
+bun run --cwd plugins/plugin-native-shared-types lint:check    # read-only Biome check
+bun run --cwd plugins/plugin-native-shared-types format        # write formatting
+bun run --cwd plugins/plugin-native-shared-types format:check  # read-only formatting check
+bun run --cwd plugins/plugin-native-shared-types test          # run package tests
+```
 
 ## Config / env vars
 

--- a/plugins/plugin-native-swabble/AGENTS.md
+++ b/plugins/plugin-native-swabble/AGENTS.md
@@ -65,15 +65,21 @@ plugins/plugin-native-swabble/
 
 ## Commands
 
-Scripts that exist in `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-swabble build    # tsc → dist/esm, then rollup → dist/plugin.js + dist/plugin.cjs.js
-bun run --cwd plugins/plugin-native-swabble clean    # remove dist/
-bun run --cwd plugins/plugin-native-swabble watch    # tsc --watch (no rollup)
+bun run --cwd plugins/plugin-native-swabble clean           # remove build output
+bun run --cwd plugins/plugin-native-swabble build           # build package artifacts
+bun run --cwd plugins/plugin-native-swabble typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-swabble lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-swabble lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-swabble format          # write formatting
+bun run --cwd plugins/plugin-native-swabble format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-swabble test            # run package tests
+bun run --cwd plugins/plugin-native-swabble prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-swabble watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-swabble build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
-
-`build` requires `tsc` to complete before rollup reads `dist/esm/index.js`. Do not run rollup standalone.
 
 ## Config / env vars
 

--- a/plugins/plugin-native-swabble/CLAUDE.md
+++ b/plugins/plugin-native-swabble/CLAUDE.md
@@ -65,15 +65,21 @@ plugins/plugin-native-swabble/
 
 ## Commands
 
-Scripts that exist in `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-swabble build    # tsc → dist/esm, then rollup → dist/plugin.js + dist/plugin.cjs.js
-bun run --cwd plugins/plugin-native-swabble clean    # remove dist/
-bun run --cwd plugins/plugin-native-swabble watch    # tsc --watch (no rollup)
+bun run --cwd plugins/plugin-native-swabble clean           # remove build output
+bun run --cwd plugins/plugin-native-swabble build           # build package artifacts
+bun run --cwd plugins/plugin-native-swabble typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-swabble lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-swabble lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-swabble format          # write formatting
+bun run --cwd plugins/plugin-native-swabble format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-swabble test            # run package tests
+bun run --cwd plugins/plugin-native-swabble prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-swabble watch           # watch TypeScript sources
+bun run --cwd plugins/plugin-native-swabble build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
-
-`build` requires `tsc` to complete before rollup reads `dist/esm/index.js`. Do not run rollup standalone.
 
 ## Config / env vars
 

--- a/plugins/plugin-native-system/AGENTS.md
+++ b/plugins/plugin-native-system/AGENTS.md
@@ -62,12 +62,19 @@ plugins/plugin-native-system/
 
 ## Commands
 
-Only scripts from `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-system build          # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-system clean          # remove dist/
-bun run --cwd plugins/plugin-native-system test           # vitest run (web layer unit tests)
+bun run --cwd plugins/plugin-native-system clean           # remove build output
+bun run --cwd plugins/plugin-native-system build           # build package artifacts
+bun run --cwd plugins/plugin-native-system typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-system lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-system lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-system format          # write formatting
+bun run --cwd plugins/plugin-native-system format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-system test            # run package tests
+bun run --cwd plugins/plugin-native-system prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-system build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / Env Vars

--- a/plugins/plugin-native-system/CLAUDE.md
+++ b/plugins/plugin-native-system/CLAUDE.md
@@ -62,12 +62,19 @@ plugins/plugin-native-system/
 
 ## Commands
 
-Only scripts from `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-system build          # clean + tsc + rollup
-bun run --cwd plugins/plugin-native-system clean          # remove dist/
-bun run --cwd plugins/plugin-native-system test           # vitest run (web layer unit tests)
+bun run --cwd plugins/plugin-native-system clean           # remove build output
+bun run --cwd plugins/plugin-native-system build           # build package artifacts
+bun run --cwd plugins/plugin-native-system typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-system lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-system lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-system format          # write formatting
+bun run --cwd plugins/plugin-native-system format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-system test            # run package tests
+bun run --cwd plugins/plugin-native-system prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-system build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / Env Vars

--- a/plugins/plugin-native-talkmode/AGENTS.md
+++ b/plugins/plugin-native-talkmode/AGENTS.md
@@ -54,15 +54,22 @@ plugins/plugin-native-talkmode/
 
 ## Commands
 
-Only scripts defined in this package's `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-talkmode build         # clean + tsc + rollup (ESM + CJS + IIFE)
-bun run --cwd plugins/plugin-native-talkmode build:docs    # clean + docgen + tsc + rollup
-bun run --cwd plugins/plugin-native-talkmode clean         # remove dist/
+bun run --cwd plugins/plugin-native-talkmode clean           # remove build output
+bun run --cwd plugins/plugin-native-talkmode build           # build package artifacts
+bun run --cwd plugins/plugin-native-talkmode build:docs      # generate docs and build artifacts
+bun run --cwd plugins/plugin-native-talkmode typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-talkmode lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-talkmode lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-talkmode format          # write formatting
+bun run --cwd plugins/plugin-native-talkmode format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-talkmode test            # run package tests
+bun run --cwd plugins/plugin-native-talkmode prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-talkmode build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
+bun run --cwd plugins/plugin-native-talkmode docgen          # docgen --api TalkModePlugin --output-readme README.md --output-json dist/docs.json
 ```
-
-API reference generation (`build:docs`) uses `@capacitor/docgen` targeting `TalkModePlugin` and writes to `README.md` and `dist/docs.json`.
 
 ## Config / env vars
 

--- a/plugins/plugin-native-talkmode/CLAUDE.md
+++ b/plugins/plugin-native-talkmode/CLAUDE.md
@@ -54,15 +54,22 @@ plugins/plugin-native-talkmode/
 
 ## Commands
 
-Only scripts defined in this package's `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-talkmode build         # clean + tsc + rollup (ESM + CJS + IIFE)
-bun run --cwd plugins/plugin-native-talkmode build:docs    # clean + docgen + tsc + rollup
-bun run --cwd plugins/plugin-native-talkmode clean         # remove dist/
+bun run --cwd plugins/plugin-native-talkmode clean           # remove build output
+bun run --cwd plugins/plugin-native-talkmode build           # build package artifacts
+bun run --cwd plugins/plugin-native-talkmode build:docs      # generate docs and build artifacts
+bun run --cwd plugins/plugin-native-talkmode typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-talkmode lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-talkmode lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-talkmode format          # write formatting
+bun run --cwd plugins/plugin-native-talkmode format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-talkmode test            # run package tests
+bun run --cwd plugins/plugin-native-talkmode prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-talkmode build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
+bun run --cwd plugins/plugin-native-talkmode docgen          # docgen --api TalkModePlugin --output-readme README.md --output-json dist/docs.json
 ```
-
-API reference generation (`build:docs`) uses `@capacitor/docgen` targeting `TalkModePlugin` and writes to `README.md` and `dist/docs.json`.
 
 ## Config / env vars
 

--- a/plugins/plugin-native-websiteblocker/AGENTS.md
+++ b/plugins/plugin-native-websiteblocker/AGENTS.md
@@ -64,14 +64,21 @@ tsconfig.json                           TS build config
 
 ## Commands
 
-```bash
-bun run --cwd plugins/plugin-native-websiteblocker build        # tsc + rollup (outputs dist/)
-bun run --cwd plugins/plugin-native-websiteblocker clean        # remove dist/
-bun run --cwd plugins/plugin-native-websiteblocker test:android:manual  # Gradle unit tests
-packages/app-core/platforms/android/gradlew -p packages/app-core/platforms/android :elizaos-capacitor-websiteblocker:connectedDebugAndroidTest  # Android instrumented tests
-```
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
-`prepublishOnly` runs `build` automatically on `npm publish`.
+```bash
+bun run --cwd plugins/plugin-native-websiteblocker clean                # remove build output
+bun run --cwd plugins/plugin-native-websiteblocker build                # build package artifacts
+bun run --cwd plugins/plugin-native-websiteblocker typecheck            # TypeScript typecheck
+bun run --cwd plugins/plugin-native-websiteblocker lint                 # mutating Biome check
+bun run --cwd plugins/plugin-native-websiteblocker lint:check           # read-only Biome check
+bun run --cwd plugins/plugin-native-websiteblocker format               # write formatting
+bun run --cwd plugins/plugin-native-websiteblocker format:check         # read-only formatting check
+bun run --cwd plugins/plugin-native-websiteblocker test                 # run package tests
+bun run --cwd plugins/plugin-native-websiteblocker test:android:manual  # manual Android/Gradle test lane
+bun run --cwd plugins/plugin-native-websiteblocker prepublishOnly       # publish-time build hook
+bun run --cwd plugins/plugin-native-websiteblocker build:unlocked       # bun run clean && tsc && bunx rollup -c rollup.config.mjs
+```
 
 ## Config / env vars
 

--- a/plugins/plugin-native-websiteblocker/CLAUDE.md
+++ b/plugins/plugin-native-websiteblocker/CLAUDE.md
@@ -64,14 +64,21 @@ tsconfig.json                           TS build config
 
 ## Commands
 
-```bash
-bun run --cwd plugins/plugin-native-websiteblocker build        # tsc + rollup (outputs dist/)
-bun run --cwd plugins/plugin-native-websiteblocker clean        # remove dist/
-bun run --cwd plugins/plugin-native-websiteblocker test:android:manual  # Gradle unit tests
-packages/app-core/platforms/android/gradlew -p packages/app-core/platforms/android :elizaos-capacitor-websiteblocker:connectedDebugAndroidTest  # Android instrumented tests
-```
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
-`prepublishOnly` runs `build` automatically on `npm publish`.
+```bash
+bun run --cwd plugins/plugin-native-websiteblocker clean                # remove build output
+bun run --cwd plugins/plugin-native-websiteblocker build                # build package artifacts
+bun run --cwd plugins/plugin-native-websiteblocker typecheck            # TypeScript typecheck
+bun run --cwd plugins/plugin-native-websiteblocker lint                 # mutating Biome check
+bun run --cwd plugins/plugin-native-websiteblocker lint:check           # read-only Biome check
+bun run --cwd plugins/plugin-native-websiteblocker format               # write formatting
+bun run --cwd plugins/plugin-native-websiteblocker format:check         # read-only formatting check
+bun run --cwd plugins/plugin-native-websiteblocker test                 # run package tests
+bun run --cwd plugins/plugin-native-websiteblocker test:android:manual  # manual Android/Gradle test lane
+bun run --cwd plugins/plugin-native-websiteblocker prepublishOnly       # publish-time build hook
+bun run --cwd plugins/plugin-native-websiteblocker build:unlocked       # bun run clean && tsc && bunx rollup -c rollup.config.mjs
+```
 
 ## Config / env vars
 

--- a/plugins/plugin-native-wifi/AGENTS.md
+++ b/plugins/plugin-native-wifi/AGENTS.md
@@ -49,13 +49,19 @@ plugins/plugin-native-wifi/
 
 ## Commands
 
-Only scripts defined in this package's `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-wifi build          # tsc + rollup → dist/
-bun run --cwd plugins/plugin-native-wifi clean          # delete dist/
-bun run --cwd plugins/plugin-native-wifi test           # vitest run
-bun run --cwd plugins/plugin-native-wifi prepublishOnly # clean + build (runs automatically before npm publish)
+bun run --cwd plugins/plugin-native-wifi clean           # remove build output
+bun run --cwd plugins/plugin-native-wifi build           # build package artifacts
+bun run --cwd plugins/plugin-native-wifi typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-wifi lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-wifi lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-wifi format          # write formatting
+bun run --cwd plugins/plugin-native-wifi format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-wifi test            # run package tests
+bun run --cwd plugins/plugin-native-wifi prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-wifi build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars

--- a/plugins/plugin-native-wifi/CLAUDE.md
+++ b/plugins/plugin-native-wifi/CLAUDE.md
@@ -49,13 +49,19 @@ plugins/plugin-native-wifi/
 
 ## Commands
 
-Only scripts defined in this package's `package.json`:
+Scripts are defined in `package.json`; run them from the repo root with `bun run --cwd`:
 
 ```bash
-bun run --cwd plugins/plugin-native-wifi build          # tsc + rollup → dist/
-bun run --cwd plugins/plugin-native-wifi clean          # delete dist/
-bun run --cwd plugins/plugin-native-wifi test           # vitest run
-bun run --cwd plugins/plugin-native-wifi prepublishOnly # clean + build (runs automatically before npm publish)
+bun run --cwd plugins/plugin-native-wifi clean           # remove build output
+bun run --cwd plugins/plugin-native-wifi build           # build package artifacts
+bun run --cwd plugins/plugin-native-wifi typecheck       # TypeScript typecheck
+bun run --cwd plugins/plugin-native-wifi lint            # mutating Biome check
+bun run --cwd plugins/plugin-native-wifi lint:check      # read-only Biome check
+bun run --cwd plugins/plugin-native-wifi format          # write formatting
+bun run --cwd plugins/plugin-native-wifi format:check    # read-only formatting check
+bun run --cwd plugins/plugin-native-wifi test            # run package tests
+bun run --cwd plugins/plugin-native-wifi prepublishOnly  # publish-time build hook
+bun run --cwd plugins/plugin-native-wifi build:unlocked  # bun run clean && tsc && bunx rollup -c rollup.config.mjs
 ```
 
 ## Config / env vars


### PR DESCRIPTION
Follow-up to #12953 after the native plugin script normalization merged.

## Scope
- Updates `CLAUDE.md` and `AGENTS.md` command sections for the 29 native plugin packages whose `package.json` scripts changed in #12953.
- Keeps each `CLAUDE.md` / `AGENTS.md` pair identical.
- Removes stale guide claims such as no lint scripts / no package scripts / old `--passWithNoTests` wording.

## Validation
- `cmp` over every `plugins/plugin-native-*/CLAUDE.md` and `AGENTS.md` pair: PASS
- package-script coverage check: every changed native package command section includes every script from its `package.json`: PASS
- stale-text guard for `no lint script`, `There is no lint`, `has no build, test, or lint`, `passWithNoTests`: PASS (no matches)
- `node packages/scripts/ensure-plugin-test-conventions.mjs --check`: PASS
- `node packages/scripts/audit-build-typecheck.mjs`: PASS
- `git diff --check origin/develop...HEAD`: PASS

Evidence N/A: docs-only follow-up; no runtime, UI, native bridge, or script behavior changed.