### PR TITLE
docs(#12830): clean Feed script comments

### DIFF
--- a/packages/feed/scripts/bootstrap-alpha-groups.ts
+++ b/packages/feed/scripts/bootstrap-alpha-groups.ts
@@ -88,8 +88,7 @@ async function main() {
     try {
       const tiers = await TieredGroupService.ensureAllTiersExist(npc.id);
 
-      // Count new vs existing
-      const newTiers = tiers.filter((t) => t.memberCount === 1); // Only NPC owner = new
+      const newTiers = tiers.filter((t) => t.memberCount === 1);
 
       if (newTiers.length > 0) {
         logger.info(

--- a/packages/feed/scripts/build-workspace.ts
+++ b/packages/feed/scripts/build-workspace.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 
+/**
+ * Workspace build orchestrator for Feed packages and apps.
+ * It runs package builds in dependency order so local checks exercise the same artifacts used by integration lanes.
+ */
+
 import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 

--- a/packages/feed/scripts/collect-complete-production-trajectories.ts
+++ b/packages/feed/scripts/collect-complete-production-trajectories.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 
+/**
+ * Production trajectory collector for validated Feed runs.
+ * It samples recent agents, verifies minimum trajectory and model-call coverage, and writes the reviewed corpus manifest.
+ */
+
 import { existsSync, promises as fs, mkdirSync } from "node:fs";
 import path from "node:path";
 import { config as loadEnvFile } from "dotenv";

--- a/packages/feed/scripts/collect-trust-experiment-corpus.ts
+++ b/packages/feed/scripts/collect-trust-experiment-corpus.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 
+/**
+ * Trust-experiment corpus collector for Feed trajectory outputs.
+ * It runs matrix/export cycles until configured corpus targets are met and records the aggregate collection manifest.
+ */
+
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parseArgs } from "node:util";

--- a/packages/feed/scripts/docs/pull_elysia_docs.ts
+++ b/packages/feed/scripts/docs/pull_elysia_docs.ts
@@ -1,18 +1,11 @@
 #!/usr/bin/env bun
-import { mkdir } from "node:fs/promises";
 
 /**
- * Fetch Elysia documentation into local markdown files using Bun/TypeScript.
- *
- * Strategy:
- * - Read the public VitePress hashmap at https://elysiajs.com/hashmap.json to discover pages.
- * - Skip blog/playground/4koma.
- * - Try to download the `.md` source for each page.
- * - If `.md` is missing, fall back to HTML and do a lightweight HTML -> markdown pass.
- *
- * Usage:
- *   bun run scripts/pull_elysia_docs.ts [--base-url https://elysiajs.com] [--output elysia] [--workers 16]
+ * Elysia documentation mirror for Feed's local vendor references.
+ * It discovers public VitePress pages, skips non-reference areas, and writes markdown snapshots for offline use.
  */
+
+import { mkdir } from "node:fs/promises";
 
 const BASE_URL = "https://elysiajs.com";
 const HASHMAP_PATH = "/hashmap.json";

--- a/packages/feed/scripts/env-audit.ts
+++ b/packages/feed/scripts/env-audit.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 
+/**
+ * Environment-variable audit for Feed workspaces.
+ * It compares declared, referenced, and platform-provided keys so runtime env contract drift is visible.
+ */
+
 import {
   existsSync,
   readdirSync,

--- a/packages/feed/scripts/export-local-character-trajectories.ts
+++ b/packages/feed/scripts/export-local-character-trajectories.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 
+/**
+ * Local character trajectory exporter for Feed development databases.
+ * It matches canonical roster agents to recent trajectory rows and writes review artifacts for simulation tuning.
+ */
+
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parseArgs } from "node:util";

--- a/packages/feed/scripts/export-production-trajectories.ts
+++ b/packages/feed/scripts/export-production-trajectories.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 
+/**
+ * Production trajectory batch exporter for Feed training data.
+ * It pages through Postgres trajectory rows, writes JSONL batches, and records cursor metadata for resumable exports.
+ */
+
 import {
   createWriteStream,
   existsSync,

--- a/packages/feed/scripts/feed-health.ts
+++ b/packages/feed/scripts/feed-health.ts
@@ -33,9 +33,6 @@ const { values: args } = parseArgs({
 const outputJson = args.json ?? false;
 const windowHours = Math.max(1, Number.parseInt(args.hours ?? "24", 10));
 
-// ---------------------------------------------------------------------------
-// Thresholds
-// ---------------------------------------------------------------------------
 const STALE_NPC_POST_MIN = 30; // no NPC post in this many minutes → STALE
 const STALE_ORG_POST_MIN = 15; // no org post in this many minutes → STALE
 const ARTICLES_PER_HOUR_WARN = 6; // more than this per hour → flood
@@ -48,9 +45,6 @@ const FIRST_WORDS_DUPE_WINDOW_MIN = 30; // look for first-N-word dupes
 const FIRST_WORDS_N = 8; // words to compare for near-dupe check
 const SAME_AUTHOR_DUPE_WINDOW_MIN = 30; // same author near-dupe window
 
-// ---------------------------------------------------------------------------
-// Color helpers
-// ---------------------------------------------------------------------------
 const reset = "\x1b[0m";
 const bold = "\x1b[1m";
 const red = "\x1b[31m";
@@ -349,9 +343,6 @@ async function run(): Promise<FeedHealthReport> {
     });
   }
 
-  // -------------------------------------------------------------------------
-  // 5. Group chat quality
-  // -------------------------------------------------------------------------
   const chatWindowStart = new Date(now.getTime() - 60 * 60 * 1000); // last 1h
   const groupChatIds = await db
     .select({ id: chats.id })

--- a/packages/feed/scripts/generate-avatar-pfps.ts
+++ b/packages/feed/scripts/generate-avatar-pfps.ts
@@ -1,9 +1,13 @@
+/**
+ * Avatar profile-picture generator for Feed actor assets.
+ * It combines visual subject, place, and style prompts before sending image jobs to the configured generation service.
+ */
+
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fal } from "@fal-ai/client";
 
-// ── Cute Animals ──────────────────────────────────────────────────────
 const ANIMALS = [
   "dragon",
   "red panda",
@@ -57,7 +61,6 @@ const ANIMALS = [
   "ember cat",
 ];
 
-// ── San Francisco Landmarks ──────────────────────────────────────────
 const SF_LANDMARKS = [
   "the Golden Gate Bridge",
   "Alcatraz Island",
@@ -91,7 +94,6 @@ const SF_LANDMARKS = [
   "the San Francisco City Hall dome",
 ];
 
-// ── Occupations / Archetypes (from the hat matrix) ──────────────────
 const OCCUPATIONS = [
   // Black Hat
   "evil scammer",
@@ -125,7 +127,6 @@ const OCCUPATIONS = [
   "relationship builder",
 ];
 
-// ── Prompt builder ───────────────────────────────────────────────────
 interface AvatarSpec {
   index: number;
   animal: string;
@@ -142,7 +143,6 @@ function buildPrompt(
   return `a close-up portrait profile picture of a cute little ${animal} who is a ${occupation}, waist-up shot focused on their face, with ${landmark} in the background, drawn in a 3D pixar style, centered composition`;
 }
 
-// ── Deterministic shuffle (Fisher-Yates with seeded PRNG) ───────────
 function seededRandom(seed: number) {
   let s = seed;
   return () => {
@@ -160,13 +160,11 @@ function shuffle<T>(arr: T[], rand: () => number): T[] {
   return a;
 }
 
-// ── Generate 150 unique combos ──────────────────────────────────────
 function generateSpecs(): AvatarSpec[] {
   const rand = seededRandom(42);
   const specs: AvatarSpec[] = [];
   const seen = new Set<string>();
 
-  // Shuffle each list independently
   const animals = shuffle(ANIMALS, rand);
   const landmarks = shuffle(SF_LANDMARKS, rand);
   const occupations = shuffle(OCCUPATIONS, rand);
@@ -201,7 +199,6 @@ function generateSpecs(): AvatarSpec[] {
   return specs;
 }
 
-// ── Main ─────────────────────────────────────────────────────────────
 const CONCURRENCY = 20;
 const TIMEOUT_MS = 120_000; // 2 min per image max
 const OUTPUT_DIR = join(import.meta.dir, "..", "output", "avatar-pfps");

--- a/packages/feed/scripts/generate-local-character-sheets.ts
+++ b/packages/feed/scripts/generate-local-character-sheets.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 
+/**
+ * Local character-sheet generator for Feed roster data.
+ * It materializes canonical character sheets and prints a concise roster summary for simulation setup.
+ */
+
 import path from "node:path";
 import { config } from "dotenv";
 import {

--- a/packages/feed/scripts/generate-skills-md.test.ts
+++ b/packages/feed/scripts/generate-skills-md.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Deterministic tests for Feed skill documentation generation.
+ * They exercise parser and markdown grouping behavior without network or runtime services.
+ */
+
 import { describe, expect, test } from "bun:test";
 import {
   generateSkillsMarkdown,

--- a/packages/feed/scripts/generate-user-pfps.ts
+++ b/packages/feed/scripts/generate-user-pfps.ts
@@ -1,10 +1,13 @@
+/**
+ * User profile-picture generator for Feed seed users.
+ * It creates deterministic prompt combinations and writes generated image metadata for manual selection.
+ */
+
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-// ── Subjects (animals, mythical creatures, characters) ───────────────
 export const SUBJECTS = [
-  // Animals — dignified and striking
   "a cat",
   "a wolf",
   "a fox",
@@ -21,7 +24,6 @@ export const SUBJECTS = [
   "a snow leopard",
   "an eagle",
   "a red panda",
-  // Mythical
   "a dragon",
   "a phoenix",
   "a griffin",
@@ -30,7 +32,6 @@ export const SUBJECTS = [
   "a celestial kirin",
   "a sea serpent",
   "a nine-tailed fox",
-  // Characters & archetypes — polished versions
   "a robot head",
   "an astronaut helmet",
   "a samurai helmet",
@@ -39,7 +40,6 @@ export const SUBJECTS = [
   "a space explorer",
   "a scholar with books",
   "a captain at the helm",
-  // Symbols & objects — elegant
   "a diamond",
   "a crown",
   "an hourglass",
@@ -50,7 +50,6 @@ export const SUBJECTS = [
   "a glowing lantern",
   "a golden coin",
   "a key",
-  // Abstract
   "a fractal flower",
   "a DNA helix",
   "a geometric eye",
@@ -58,16 +57,13 @@ export const SUBJECTS = [
   "a lotus flower",
 ];
 
-// ── Backgrounds ──────────────────────────────────────────────────────
 const BACKGROUNDS = [
-  // Abstract & pattern
   "a soft geometric gradient",
   "concentric circles in muted tones",
   "a mandala pattern",
   "liquid marble in deep blue and gold",
   "a topographic map in sepia",
   "a clean studio gradient",
-  // Color fields
   "a deep midnight blue",
   "a rich forest green",
   "a warm amber and gold gradient",
@@ -77,7 +73,6 @@ const BACKGROUNDS = [
   "an iridescent sheen",
   "a stark white minimalist backdrop",
   "a deep navy with stars",
-  // Environments
   "a dense jungle canopy",
   "an underwater coral reef",
   "a mountain range at dusk",
@@ -90,7 +85,6 @@ const BACKGROUNDS = [
   "a bamboo forest in mist",
 ];
 
-// ── Themes / moods — polished and appealing ──────────────────────────
 const THEMES = [
   "elegant and regal",
   "ethereal and dreamlike",
@@ -114,7 +108,6 @@ const THEMES = [
   "sophisticated and refined",
 ];
 
-// ── Art styles — polished, not meme-y ────────────────────────────────
 export const STYLES = [
   "3D Pixar render",
   "hand-drawn ink illustration",
@@ -143,7 +136,6 @@ export const STYLES = [
   "soft pastel illustration",
 ];
 
-// ── Prompt builder ───────────────────────────────────────────────────
 interface PfpSpec {
   index: number;
   subject: string;
@@ -162,7 +154,6 @@ export function buildPrompt(
   return `A polished profile picture avatar: ${subject}, ${theme} mood, rendered in ${style} style. Background: ${background}. Centered composition, close-up portrait framing, square crop. High quality, clean edges, no text, no watermarks, no logos.`;
 }
 
-// ── Deterministic shuffle ────────────────────────────────────────────
 function seededRandom(seed: number) {
   let s = seed;
   return () => {
@@ -180,7 +171,6 @@ function shuffle<T>(arr: T[], rand: () => number): T[] {
   return a;
 }
 
-// ── Generate 150 unique combos ──────────────────────────────────────
 function generateSpecs(): PfpSpec[] {
   const rand = seededRandom(777);
   const specs: PfpSpec[] = [];
@@ -224,7 +214,6 @@ function generateSpecs(): PfpSpec[] {
   return specs;
 }
 
-// ── Main ─────────────────────────────────────────────────────────────
 const CONCURRENCY = 20;
 const TIMEOUT_MS = 120_000;
 const OUTPUT_DIR = join(import.meta.dir, "..", "output", "user-pfps");

--- a/packages/feed/scripts/market-health.ts
+++ b/packages/feed/scripts/market-health.ts
@@ -37,9 +37,6 @@ const outputJson = args.json ?? false;
 const watchMode = args.watch ?? false;
 const intervalSec = Math.max(5, Number.parseInt(args.interval ?? "30", 10));
 
-// ---------------------------------------------------------------------------
-// Thresholds (named so they're easy to tune)
-// ---------------------------------------------------------------------------
 const PRED_EXTREME_LOW = 0.05; // odds below this → EXTREME
 const PRED_EXTREME_HIGH = 0.95; // odds above this → EXTREME
 const PRED_THIN_LIQUIDITY = 5_000; // USD below this → THIN
@@ -50,9 +47,6 @@ const PERP_STALE_INDEX_PCT = 0.1; // |current - index| / index → STALE_INDEX
 const PERP_HIGH_FUNDING_APR = 0.3; // annual funding rate magnitude → HIGH_FUNDING
 const PERP_STALE_QUOTE_MIN = 30; // minutes since quoteUpdatedAt → STALE_QUOTE
 
-// ---------------------------------------------------------------------------
-// Color helpers
-// ---------------------------------------------------------------------------
 const reset = "\x1b[0m";
 const bold = "\x1b[1m";
 const red = "\x1b[31m";

--- a/packages/feed/scripts/market-realism-report.ts
+++ b/packages/feed/scripts/market-realism-report.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 
+/**
+ * Market realism report for Feed prediction and perpetual markets.
+ * It reads recent market history, computes realism metrics, and emits either text diagnostics or JSON.
+ */
+
 import { parseArgs } from "node:util";
 import { db } from "@feed/db";
 import {

--- a/packages/feed/scripts/pre-dev/pre-dev-local.ts
+++ b/packages/feed/scripts/pre-dev/pre-dev-local.ts
@@ -228,7 +228,6 @@ if (minioRunning.trim() !== MINIO_CONTAINER) {
   console.info("✅ MinIO is running");
 }
 
-// 8. Run database migrations and seed
 const LOCAL_DATABASE_URL =
   "postgresql://feed:feed_dev_password@localhost:5433/feed";
 process.env.DATABASE_URL = LOCAL_DATABASE_URL;

--- a/packages/feed/scripts/pre-dev/pre-dev-testnet.ts
+++ b/packages/feed/scripts/pre-dev/pre-dev-testnet.ts
@@ -170,7 +170,6 @@ if (redisRunning.trim() !== "feed-redis") {
   console.info("✅ Redis is running", undefined, "Script");
 }
 
-// Run database migrations
 import {
   actorState,
   checkDatabaseHealth,

--- a/packages/feed/scripts/prune-next-server-sourcemaps.ts
+++ b/packages/feed/scripts/prune-next-server-sourcemaps.ts
@@ -1,3 +1,8 @@
+/**
+ * Next.js server sourcemap pruning script for Feed deployments.
+ * It strips server sourcemap references from standalone output while leaving client assets intact.
+ */
+
 import { readdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 

--- a/packages/feed/scripts/run-local-character-simulation.ts
+++ b/packages/feed/scripts/run-local-character-simulation.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 
+/**
+ * Local character simulation runner for Feed.
+ * It creates roster-backed agents, executes world and agent ticks, and writes trajectory artifacts for behavior review.
+ */
+
 import path from "node:path";
 import { parseArgs } from "node:util";
 import type { IAgentRuntime } from "@elizaos/core";

--- a/packages/feed/scripts/run-trust-experiment-matrix.ts
+++ b/packages/feed/scripts/run-trust-experiment-matrix.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 
+/**
+ * Trust-experiment matrix runner for Feed agents.
+ * It builds seeded agent cohorts, runs optional simulations, and writes comparative trust artifacts for training review.
+ */
+
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parseArgs } from "node:util";

--- a/packages/feed/scripts/scambench/eliza_bridge.ts
+++ b/packages/feed/scripts/scambench/eliza_bridge.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 
+/**
+ * ScamBench bridge for running benchmark prompts through a Feed/elizaOS agent.
+ * It adapts stdin bridge messages into runtime memories and returns model responses for the benchmark harness.
+ */
+
 import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline";
 import {

--- a/packages/feed/scripts/seed-nft-collection.ts
+++ b/packages/feed/scripts/seed-nft-collection.ts
@@ -342,12 +342,10 @@ async function takeLeaderboardSnapshot(): Promise<void> {
     }
   }
 
-  // Insert new snapshots
   for (let i = 0; i < topUsers.length; i++) {
     const user = topUsers[i]!;
     const rank = i + 1;
 
-    // Skip if user has already minted
     if (mintedUserIds.has(user.id)) {
       continue;
     }

--- a/packages/feed/scripts/test-integration-with-server.ts
+++ b/packages/feed/scripts/test-integration-with-server.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 
+/**
+ * Integration-test launcher for Feed against a running web server.
+ * It manages server readiness, isolated workspaces, and optional test discovery for the app integration lane.
+ */
+
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import {
   cpSync,

--- a/packages/feed/scripts/testing-skip-inventory.mjs
+++ b/packages/feed/scripts/testing-skip-inventory.mjs
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 
+/**
+ * Testing skip inventory auditor for Feed.
+ * It scans source files for skipped tests and reports undocumented unconditional skips as tracked test debt.
+ */
+
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/feed/scripts/typecheck-workspace.ts
+++ b/packages/feed/scripts/typecheck-workspace.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 
+/**
+ * Typecheck orchestrator for Feed workspace packages.
+ * It runs package-specific TypeScript projects in dependency order and builds declarations needed by downstream apps.
+ */
+
 import { spawn } from "node:child_process";
 import { resolve } from "node:path";
 

--- a/packages/feed/scripts/validate-env.ts
+++ b/packages/feed/scripts/validate-env.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 
+/**
+ * Environment validation entrypoint for Feed deployments.
+ * It checks required service, database, cache, and game variables before local or deployed startup.
+ */
+
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 


### PR DESCRIPTION
## Summary
- adds required prose headers to Feed script/config source files in the #12830 scope
- trims decorative/restatement comments in Feed scripts without changing executable code
- leaves packages/feed/packages/** untouched per the split issue

Closes #12830

## Validation
- `bun run check:comment-only`
  - PASS: 26 source files changed; every code token identical to `origin/develop`
- scoped missing-header audit over `packages/feed/scripts` plus Feed root source/config files
  - PASS: no missing headers
- `git diff --check origin/develop...HEAD`
  - PASS
- `git diff --name-only origin/develop...HEAD | sed s#^packages/feed/## | xargs bunx @biomejs/biome check --config-path ../../biome.json --files-ignore-unknown=true --no-errors-on-unmatched`
  - PASS with existing `noUndeclaredEnvVars` warnings in touched scripts; no errors, no fixes applied
- `bun run --cwd packages/feed lint`
  - PASS; checked the package-defined lint subset

## Evidence Notes
- Comment-only cleanup; no UI, runtime, model, DB, connector, or prompt behavior changes.
- No screenshots/video/live model trajectories apply because the code token stream is unchanged.