### PR TITLE
fix(#12262): remove lifeops root wrapper

### DIFF
--- a/.github/issue-evidence/12262-remove-lifeops-root-wrapper.md
+++ b/.github/issue-evidence/12262-remove-lifeops-root-wrapper.md
@@ -1,0 +1,39 @@
+# Evidence: #12262 remove LifeOps root wrapper
+
+Date: 2026-07-04
+
+## Change
+
+- Deleted root `test:lifeops`.
+- Documented the replacement as `bun run test:plugin 'plugin-personal-assistant'`.
+- Updated root `CLAUDE.md` / `AGENTS.md` script count and migration table.
+
+Screenshots/recordings: N/A. This is a root script/docs cleanup with no UI behavior change.
+
+## Verification
+
+```bash
+node -e "const p=require('./package.json'); if (Object.hasOwn(p.scripts,'test:lifeops')) throw new Error('test:lifeops still exists'); if (Object.keys(p.scripts).length !== 207) throw new Error('script count '+Object.keys(p.scripts).length); console.log('test:plugin body:', p.scripts['test:plugin']); console.log('lifeops wrapper deletion assertions passed')"
+# test:plugin body: node packages/scripts/run-all-tests.mjs --only=e2e --pattern
+# lifeops wrapper deletion assertions passed
+```
+
+```bash
+node scripts/assert-agents-claude-identical.mjs
+# [assert-agents-claude-identical] PASS: 301 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.
+```
+
+```bash
+node packages/scripts/audit-scripts.mjs
+# [audit-scripts] OK - no orphan/no-op/broken scripts.
+```
+
+```bash
+grep -RIn "test:lifeops" .github docs packages plugins scripts CLAUDE.md AGENTS.md package.json
+# Remaining hits are the root migration docs and historical #10200 evidence.
+```
+
+```bash
+git diff --check
+# no output
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ bun run cloud:mock     # boot the full local cloud stack with mocks
 ```
 
 Scope any command to one package with `--cwd`:
-`bun run --cwd packages/core test`. The repo has 208 root scripts; the list
+`bun run --cwd packages/core test`. The repo has 207 root scripts; the list
 above is the day-to-day set. Use `bun run` with no args to print them all.
 
 ### Removed Root Command Migrations
@@ -62,6 +62,7 @@ above is the day-to-day set. Use `bun run` with no args to print them all.
 | `bun run test:ci` | `bun run test` |
 | `bun run test:cloud:playwright` | `bun run --cwd packages/app test:e2e` |
 | `bun run test:ui:playwright` | `bun run --cwd packages/app test:e2e` |
+| `bun run test:lifeops` | `bun run test:plugin 'plugin-personal-assistant'` |
 | `bun run lint:all` | `bun run verify` |
 | `bun run build:typescript` | `node packages/scripts/run-turbo.mjs run build` |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ bun run cloud:mock     # boot the full local cloud stack with mocks
 ```
 
 Scope any command to one package with `--cwd`:
-`bun run --cwd packages/core test`. The repo has 208 root scripts; the list
+`bun run --cwd packages/core test`. The repo has 207 root scripts; the list
 above is the day-to-day set. Use `bun run` with no args to print them all.
 
 ### Removed Root Command Migrations
@@ -62,6 +62,7 @@ above is the day-to-day set. Use `bun run` with no args to print them all.
 | `bun run test:ci` | `bun run test` |
 | `bun run test:cloud:playwright` | `bun run --cwd packages/app test:e2e` |
 | `bun run test:ui:playwright` | `bun run --cwd packages/app test:e2e` |
+| `bun run test:lifeops` | `bun run test:plugin 'plugin-personal-assistant'` |
 | `bun run lint:all` | `bun run verify` |
 | `bun run build:typescript` | `node packages/scripts/run-turbo.mjs run build` |
 

--- a/package.json
+++ b/package.json
@@ -187,7 +187,6 @@
     "test:e2e": "TEST_LANE=pr node packages/scripts/run-all-tests.mjs --only=e2e --no-cloud --exclude eliza/packages/app-core/test/app/memory-relationships.real.e2e.test.ts --exclude eliza/packages/app-core/test/app/qa-checklist.real.e2e.test.ts",
     "test:e2e:heavy": "TEST_LANE=post-merge bunx vitest run --config packages/test/vitest/real.config.ts --passWithNoTests eliza/packages/app-core/test/app/memory-relationships.real.e2e.test.ts packages/app-core/test/app/memory-relationships.real.e2e.test.ts eliza/packages/app-core/test/app/qa-checklist.real.e2e.test.ts packages/app-core/test/app/qa-checklist.real.e2e.test.ts",
     "test:e2e:live": "TEST_LANE=post-merge node packages/scripts/run-all-tests.mjs --only=e2e --no-cloud",
-    "test:lifeops": "node packages/scripts/run-all-tests.mjs --filter=plugins/plugin-personal-assistant --only=e2e",
     "lifeops:verify-cerebras": "bun --bun plugins/plugin-personal-assistant/scripts/verify-cerebras-wiring.ts",
     "personality:judge": "bun --bun packages/benchmarks/personality-bench/src/runner.ts",
     "personality:bench:calibrate": "bun --filter @elizaos/personality-bench calibrate",


### PR DESCRIPTION
## Summary
- delete the package-specific root `test:lifeops` wrapper
- document the replacement `bun run test:plugin 'plugin-personal-assistant'`
- add issue evidence for the deletion

## Evidence
- `.github/issue-evidence/12262-remove-lifeops-root-wrapper.md`

## Verification
- `node -e "const p=require('./package.json'); if (Object.hasOwn(p.scripts,'test:lifeops')) throw new Error('test:lifeops still exists'); if (Object.keys(p.scripts).length !== 207) throw new Error('script count '+Object.keys(p.scripts).length); console.log('lifeops wrapper deletion assertions passed')"`
- `node scripts/assert-agents-claude-identical.mjs`
- `node packages/scripts/audit-scripts.mjs`
- `git diff --check origin/develop..HEAD`