### PR TITLE
test(#12283): A1 adhd-buried-commitment persona scenario (live, verified)

### DIFF
--- a/.github/issue-evidence/12283-lifeops-personas.md
+++ b/.github/issue-evidence/12283-lifeops-personas.md
@@ -1,10 +1,25 @@
 # Evidence — #12283 LifeOps persona-journey scenarios (first B1 increment)
 
 Issue #12283 asks for 72 persona-journey scenarios across 8 packs. This is the
-first increment: the B1 (night-owl-anchored-day) pack, live-only surface, driven
-against a **live** model and hand-reviewed.
+first increment: two live-only scenarios (packs B1 and A1) driven against a
+**live** model and hand-reviewed.
 
-## Scenario
+## Scenario 2 — A1 adhd-capture-and-start (tier T1)
+
+`plugins/plugin-personal-assistant/test/scenarios/adhd-buried-commitment-ramble.scenario.ts`.
+Premise (issue A1 table): *one load-bearing task buried in a rambling multi-topic
+message*. casey_adhd sends a tangent-filled message (barking dog, unwatched
+documentary, weird coffee, mercury retrograde) with one real commitment buried
+in it — call the pharmacy before 5pm about a refill.
+
+Live run (Cerebras `gpt-oss-120b`): **passed, 7857ms**. Trajectory reviewed:
+`actionsCalled: ["OWNER_REMINDERS"]`; reply *"The reminder has been set: call the
+pharmacy before 5 PM today about your prescription refill…"* — captured the one
+buried task **with** its deadline and created **no** distractor tasks.
+`definitionCountDelta` matched "call the pharmacy"; `judgeRubric` **1.00**. Report:
+`.github/issue-evidence/12283-lifeops-personas/adhd-buried-commitment-ramble.report.json`.
+
+## Scenario 1 — B1 night-owl-anchored-day (tier T1)
 
 `plugins/plugin-personal-assistant/test/scenarios/night-owl-flexible-habit-any-time-today.scenario.ts`
 (`lane: "live-only"`, pack B1, tier T1). Persona-as-data (night-owl framing in

--- a/.github/issue-evidence/12283-lifeops-personas.md
+++ b/.github/issue-evidence/12283-lifeops-personas.md
@@ -1,10 +1,10 @@
-# Evidence — #12283 LifeOps persona-journey scenarios (first B1 increment)
+# Evidence — #12283 LifeOps persona-journey scenarios
 
 Issue #12283 asks for 72 persona-journey scenarios across 8 packs. This is the
-first increment: two live-only scenarios (packs B1 and A1) driven against a
+first increment: four live-only scenarios (packs B1 and A1) driven against a
 **live** model and hand-reviewed.
 
-## Scenario 2 — A1 adhd-capture-and-start (tier T1)
+## Scenarios 2-4 — A1 adhd-capture-and-start (tier T1)
 
 `plugins/plugin-personal-assistant/test/scenarios/adhd-buried-commitment-ramble.scenario.ts`.
 Premise (issue A1 table): *one load-bearing task buried in a rambling multi-topic
@@ -18,6 +18,25 @@ pharmacy before 5 PM today about your prescription refill…"* — captured the 
 buried task **with** its deadline and created **no** distractor tasks.
 `definitionCountDelta` matched "call the pharmacy"; `judgeRubric` **1.00**. Report:
 `.github/issue-evidence/12283-lifeops-personas/adhd-buried-commitment-ramble.report.json`.
+
+`plugins/plugin-personal-assistant/test/scenarios/adhd-medication-refill-fuzzy-date-capture.scenario.ts`.
+Premise: a fuzzy-date medication refill reminder ("early next week") should be
+captured as a concrete dated reminder instead of being dropped for ambiguity.
+
+Live run (Cerebras `gpt-oss-120b`): **passed, 6386ms**. Trajectory reviewed:
+`actionsCalled: ["OWNER_REMINDERS"]`; reply set the Adderall refill reminder for
+Wednesday morning. `definitionCountDelta` matched "refill"; `judgeRubric`
+**1.00**. Report:
+`.github/issue-evidence/12283-lifeops-personas/adhd-medication-refill-fuzzy-date-capture.report.json`.
+
+`plugins/plugin-personal-assistant/test/scenarios/adhd-wait-no-correction-supersedes.scenario.ts`.
+Premise: a mid-message "wait no" correction should supersede the first task.
+
+Live run (Cerebras `gpt-oss-120b`): **passed, 6562ms**. Trajectory reviewed:
+`actionsCalled: ["OWNER_REMINDERS"]`; reply saved the corrected Tom reminder.
+`definitionCountDelta` matched "email Tom" with delta 1 and "email Sarah" with
+delta 0; `judgeRubric` **1.00**. Report:
+`.github/issue-evidence/12283-lifeops-personas/adhd-wait-no-correction-supersedes.report.json`.
 
 ## Scenario 1 — B1 night-owl-anchored-day (tier T1)
 
@@ -55,10 +74,13 @@ Passed on two independent runs (6.3s / 6.8s) — reliable, not a fluke.
 - `_catalogs/night-owl-anchored-day.catalog.json` records the scenario as
   `verified`. `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs`
   → B1 1/24 authored, 1/1 verified; the entry resolves to the real file.
+- `_catalogs/adhd-capture-and-start.catalog.json` records three A1 scenarios as
+  `verified`. The same catalog coverage command reports A1 3/28 authored, 3/3
+  verified; each entry resolves to the real scenario file.
 - All four scenario-runner corpus ratchets stay green (14 tests): the live-only
-  scenario does not touch the `pr-deterministic` id list, its `responseIncludes`
-  are absent (no echo), and its `finalChecks` include an effect-reading check
-  (`definitionCountDelta`) plus a non-skippable one.
+  scenarios do not touch the `pr-deterministic` id list, their `responseIncludes`
+  are absent (no echo), and their `finalChecks` include effect-reading checks
+  (`definitionCountDelta`) plus non-skippable ones.
 
 ## Scope note (honest)
 
@@ -73,6 +95,6 @@ shipped here. The remaining packs/premises are enumerated in the issue's tables.
 
 | Evidence | Status |
 | --- | --- |
-| Real-LLM trajectory | **Attached + reviewed** — live Cerebras `gpt-oss-120b`; `OWNER_REMINDERS` created the flexible habit, judge 1.00; report JSON in `.github/issue-evidence/12283-lifeops-personas/`. |
-| Domain artifacts | `life_scheduled_definitions` row (the created habit) — asserted via `definitionCountDelta`. |
+| Real-LLM trajectory | **Attached + reviewed** — live Cerebras `gpt-oss-120b`; `OWNER_REMINDERS` created the B1 habit plus three A1 reminders, each judge 1.00; report JSON in `.github/issue-evidence/12283-lifeops-personas/`. |
+| Domain artifacts | `life_scheduled_definitions` rows — asserted via `definitionCountDelta`, including delta 0 for the superseded Sarah task. |
 | Frontend / screenshots | N/A — no UI surface changed (scenario authoring). |

--- a/.github/issue-evidence/12283-lifeops-personas/adhd-buried-commitment-ramble.report.json
+++ b/.github/issue-evidence/12283-lifeops-personas/adhd-buried-commitment-ramble.report.json
@@ -1,0 +1,585 @@
+{
+  "runId": "4ccfb3b4-b677-4b9e-9555-e65713cd5da0",
+  "startedAtIso": "2026-07-04T05:49:53.433Z",
+  "completedAtIso": "2026-07-04T05:50:04.922Z",
+  "providerName": "openai",
+  "scenarios": [
+    {
+      "id": "adhd-buried-commitment-ramble",
+      "title": "ADHD: one load-bearing task buried in a rambling message",
+      "domain": "lifeops.reminders",
+      "tags": [
+        "lifeops",
+        "adhd",
+        "personas",
+        "12283"
+      ],
+      "status": "passed",
+      "durationMs": 7857,
+      "turns": [
+        {
+          "name": "casey rambles with one buried commitment",
+          "kind": "message",
+          "text": "ok so brain is everywhere today — the neighbor's dog was barking, i still haven't watched that documentary everyone keeps talking about, coffee tasted weird, oh and i think mercury is retrograde again lol. anyway the thing i actually can't forget: i HAVE to call the pharmacy before 5pm today about my prescription refill or they close the request. that's the one.",
+          "responseText": "The reminder has been set: call the pharmacy before 5 PM today about your prescription refill. Let me know if you’d like to adjust the time or add any details.",
+          "actionsCalled": [
+            {
+              "actionName": "OWNER_REMINDERS",
+              "parameters": {
+                "parameters": {
+                  "action": "create",
+                  "kind": "definition",
+                  "intent": "Call the pharmacy before 5pm today about prescription refill",
+                  "title": "Call pharmacy",
+                  "confirmed": false,
+                  "details": {}
+                },
+                "actionContext": {
+                  "previousResults": []
+                }
+              },
+              "result": {
+                "success": true,
+                "data": {
+                  "definition": {
+                    "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                    "domain": "user_lifeops",
+                    "subjectType": "owner",
+                    "subjectId": "71da199c-ba36-0996-a5eb-0236efbcbf0b",
+                    "visibilityScope": "owner_only",
+                    "contextPolicy": "explicit_only",
+                    "kind": "habit",
+                    "title": "Call pharmacy",
+                    "description": "Call the pharmacy about prescription refill",
+                    "originalIntent": "Call the pharmacy before 5pm today about prescription refill",
+                    "timezone": "America/New_York",
+                    "status": "active",
+                    "priority": 1,
+                    "cadence": {
+                      "kind": "once",
+                      "dueAt": "2026-07-04T21:04:59.688Z"
+                    },
+                    "windowPolicy": {
+                      "timezone": "America/New_York",
+                      "windows": [
+                        {
+                          "name": "morning",
+                          "label": "Morning",
+                          "startMinute": 300,
+                          "endMinute": 720
+                        },
+                        {
+                          "name": "afternoon",
+                          "label": "Afternoon",
+                          "startMinute": 720,
+                          "endMinute": 1020
+                        },
+                        {
+                          "name": "evening",
+                          "label": "Evening",
+                          "startMinute": 1020,
+                          "endMinute": 1320
+                        },
+                        {
+                          "name": "night",
+                          "label": "Night",
+                          "startMinute": 1320,
+                          "endMinute": 1680
+                        }
+                      ]
+                    },
+                    "progressionRule": {
+                      "kind": "none"
+                    },
+                    "websiteAccess": null,
+                    "reminderPlanId": "a830d823-fdb5-4c5d-95f9-08c51e9fa058",
+                    "goalId": null,
+                    "source": "chat",
+                    "metadata": {
+                      "nativeAppleReminder": {
+                        "kind": "reminder",
+                        "provider": "apple_reminders",
+                        "reminderId": "594D11AA-0CB3-47EF-97FC-6F1896885278",
+                        "source": "llm"
+                      },
+                      "privacyClass": "private",
+                      "publicContextBlocked": true
+                    },
+                    "id": "87be5112-7f20-4061-9aec-27a4857e16e7",
+                    "createdAt": "2026-07-04T05:49:59.689Z",
+                    "updatedAt": "2026-07-04T05:50:00.020Z"
+                  },
+                  "reminderPlan": {
+                    "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                    "ownerType": "definition",
+                    "ownerId": "87be5112-7f20-4061-9aec-27a4857e16e7",
+                    "steps": [
+                      {
+                        "channel": "in_app",
+                        "offsetMinutes": 0,
+                        "label": "Call pharmacy reminder"
+                      }
+                    ],
+                    "mutePolicy": {},
+                    "quietHours": {},
+                    "id": "a830d823-fdb5-4c5d-95f9-08c51e9fa058",
+                    "createdAt": "2026-07-04T05:49:59.702Z",
+                    "updatedAt": "2026-07-04T05:49:59.702Z"
+                  },
+                  "performance": {
+                    "lastCompletedAt": null,
+                    "lastSkippedAt": null,
+                    "lastActivityAt": null,
+                    "totalScheduledCount": 0,
+                    "totalCompletedCount": 0,
+                    "totalSkippedCount": 0,
+                    "totalPendingCount": 0,
+                    "currentOccurrenceStreak": 0,
+                    "bestOccurrenceStreak": 0,
+                    "currentPerfectDayStreak": 0,
+                    "bestPerfectDayStreak": 0,
+                    "last7Days": {
+                      "scheduledCount": 0,
+                      "completedCount": 0,
+                      "skippedCount": 0,
+                      "pendingCount": 0,
+                      "completionRate": 0,
+                      "perfectDayCount": 0
+                    },
+                    "last30Days": {
+                      "scheduledCount": 0,
+                      "completedCount": 0,
+                      "skippedCount": 0,
+                      "pendingCount": 0,
+                      "completionRate": 0,
+                      "perfectDayCount": 0
+                    }
+                  }
+                },
+                "text": "Got it—I’ve saved a reminder to call the pharmacy before 5 PM today about your prescription refill. Let me know if you’d like to adjust the time or add any details.",
+                "raw": {
+                  "success": true,
+                  "text": "Got it—I’ve saved a reminder to call the pharmacy before 5 PM today about your prescription refill. Let me know if you’d like to adjust the time or add any details.",
+                  "data": {
+                    "definition": {
+                      "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                      "domain": "user_lifeops",
+                      "subjectType": "owner",
+                      "subjectId": "71da199c-ba36-0996-a5eb-0236efbcbf0b",
+                      "visibilityScope": "owner_only",
+                      "contextPolicy": "explicit_only",
+                      "kind": "habit",
+                      "title": "Call pharmacy",
+                      "description": "Call the pharmacy about prescription refill",
+                      "originalIntent": "Call the pharmacy before 5pm today about prescription refill",
+                      "timezone": "America/New_York",
+                      "status": "active",
+                      "priority": 1,
+                      "cadence": {
+                        "kind": "once",
+                        "dueAt": "2026-07-04T21:04:59.688Z"
+                      },
+                      "windowPolicy": {
+                        "timezone": "America/New_York",
+                        "windows": [
+                          {
+                            "name": "morning",
+                            "label": "Morning",
+                            "startMinute": 300,
+                            "endMinute": 720
+                          },
+                          {
+                            "name": "afternoon",
+                            "label": "Afternoon",
+                            "startMinute": 720,
+                            "endMinute": 1020
+                          },
+                          {
+                            "name": "evening",
+                            "label": "Evening",
+                            "startMinute": 1020,
+                            "endMinute": 1320
+                          },
+                          {
+                            "name": "night",
+                            "label": "Night",
+                            "startMinute": 1320,
+                            "endMinute": 1680
+                          }
+                        ]
+                      },
+                      "progressionRule": {
+                        "kind": "none"
+                      },
+                      "websiteAccess": null,
+                      "reminderPlanId": "a830d823-fdb5-4c5d-95f9-08c51e9fa058",
+                      "goalId": null,
+                      "source": "chat",
+                      "metadata": {
+                        "nativeAppleReminder": {
+                          "kind": "reminder",
+                          "provider": "apple_reminders",
+                          "reminderId": "594D11AA-0CB3-47EF-97FC-6F1896885278",
+                          "source": "llm"
+                        },
+                        "privacyClass": "private",
+                        "publicContextBlocked": true
+                      },
+                      "id": "87be5112-7f20-4061-9aec-27a4857e16e7",
+                      "createdAt": "2026-07-04T05:49:59.689Z",
+                      "updatedAt": "2026-07-04T05:50:00.020Z"
+                    },
+                    "reminderPlan": {
+                      "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                      "ownerType": "definition",
+                      "ownerId": "87be5112-7f20-4061-9aec-27a4857e16e7",
+                      "steps": [
+                        {
+                          "channel": "in_app",
+                          "offsetMinutes": 0,
+                          "label": "Call pharmacy reminder"
+                        }
+                      ],
+                      "mutePolicy": {},
+                      "quietHours": {},
+                      "id": "a830d823-fdb5-4c5d-95f9-08c51e9fa058",
+                      "createdAt": "2026-07-04T05:49:59.702Z",
+                      "updatedAt": "2026-07-04T05:49:59.702Z"
+                    },
+                    "performance": {
+                      "lastCompletedAt": null,
+                      "lastSkippedAt": null,
+                      "lastActivityAt": null,
+                      "totalScheduledCount": 0,
+                      "totalCompletedCount": 0,
+                      "totalSkippedCount": 0,
+                      "totalPendingCount": 0,
+                      "currentOccurrenceStreak": 0,
+                      "bestOccurrenceStreak": 0,
+                      "currentPerfectDayStreak": 0,
+                      "bestPerfectDayStreak": 0,
+                      "last7Days": {
+                        "scheduledCount": 0,
+                        "completedCount": 0,
+                        "skippedCount": 0,
+                        "pendingCount": 0,
+                        "completionRate": 0,
+                        "perfectDayCount": 0
+                      },
+                      "last30Days": {
+                        "scheduledCount": 0,
+                        "completedCount": 0,
+                        "skippedCount": 0,
+                        "pendingCount": 0,
+                        "completionRate": 0,
+                        "perfectDayCount": 0
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "durationMs": 7620,
+          "failedAssertions": []
+        }
+      ],
+      "finalChecks": [
+        {
+          "label": "definitionCountDelta",
+          "type": "definitionCountDelta",
+          "status": "passed",
+          "detail": "1 matching definition(s) for \"call the pharmacy\""
+        },
+        {
+          "label": "captured-the-buried-task-not-the-tangents",
+          "type": "judgeRubric",
+          "status": "passed",
+          "detail": "score 1.00 ≥ 0.6",
+          "score": 1
+        }
+      ],
+      "actionsCalled": [
+        {
+          "actionName": "OWNER_REMINDERS",
+          "parameters": {
+            "parameters": {
+              "action": "create",
+              "kind": "definition",
+              "intent": "Call the pharmacy before 5pm today about prescription refill",
+              "title": "Call pharmacy",
+              "confirmed": false,
+              "details": {}
+            },
+            "actionContext": {
+              "previousResults": []
+            }
+          },
+          "result": {
+            "success": true,
+            "data": {
+              "definition": {
+                "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                "domain": "user_lifeops",
+                "subjectType": "owner",
+                "subjectId": "71da199c-ba36-0996-a5eb-0236efbcbf0b",
+                "visibilityScope": "owner_only",
+                "contextPolicy": "explicit_only",
+                "kind": "habit",
+                "title": "Call pharmacy",
+                "description": "Call the pharmacy about prescription refill",
+                "originalIntent": "Call the pharmacy before 5pm today about prescription refill",
+                "timezone": "America/New_York",
+                "status": "active",
+                "priority": 1,
+                "cadence": {
+                  "kind": "once",
+                  "dueAt": "2026-07-04T21:04:59.688Z"
+                },
+                "windowPolicy": {
+                  "timezone": "America/New_York",
+                  "windows": [
+                    {
+                      "name": "morning",
+                      "label": "Morning",
+                      "startMinute": 300,
+                      "endMinute": 720
+                    },
+                    {
+                      "name": "afternoon",
+                      "label": "Afternoon",
+                      "startMinute": 720,
+                      "endMinute": 1020
+                    },
+                    {
+                      "name": "evening",
+                      "label": "Evening",
+                      "startMinute": 1020,
+                      "endMinute": 1320
+                    },
+                    {
+                      "name": "night",
+                      "label": "Night",
+                      "startMinute": 1320,
+                      "endMinute": 1680
+                    }
+                  ]
+                },
+                "progressionRule": {
+                  "kind": "none"
+                },
+                "websiteAccess": null,
+                "reminderPlanId": "a830d823-fdb5-4c5d-95f9-08c51e9fa058",
+                "goalId": null,
+                "source": "chat",
+                "metadata": {
+                  "nativeAppleReminder": {
+                    "kind": "reminder",
+                    "provider": "apple_reminders",
+                    "reminderId": "594D11AA-0CB3-47EF-97FC-6F1896885278",
+                    "source": "llm"
+                  },
+                  "privacyClass": "private",
+                  "publicContextBlocked": true
+                },
+                "id": "87be5112-7f20-4061-9aec-27a4857e16e7",
+                "createdAt": "2026-07-04T05:49:59.689Z",
+                "updatedAt": "2026-07-04T05:50:00.020Z"
+              },
+              "reminderPlan": {
+                "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                "ownerType": "definition",
+                "ownerId": "87be5112-7f20-4061-9aec-27a4857e16e7",
+                "steps": [
+                  {
+                    "channel": "in_app",
+                    "offsetMinutes": 0,
+                    "label": "Call pharmacy reminder"
+                  }
+                ],
+                "mutePolicy": {},
+                "quietHours": {},
+                "id": "a830d823-fdb5-4c5d-95f9-08c51e9fa058",
+                "createdAt": "2026-07-04T05:49:59.702Z",
+                "updatedAt": "2026-07-04T05:49:59.702Z"
+              },
+              "performance": {
+                "lastCompletedAt": null,
+                "lastSkippedAt": null,
+                "lastActivityAt": null,
+                "totalScheduledCount": 0,
+                "totalCompletedCount": 0,
+                "totalSkippedCount": 0,
+                "totalPendingCount": 0,
+                "currentOccurrenceStreak": 0,
+                "bestOccurrenceStreak": 0,
+                "currentPerfectDayStreak": 0,
+                "bestPerfectDayStreak": 0,
+                "last7Days": {
+                  "scheduledCount": 0,
+                  "completedCount": 0,
+                  "skippedCount": 0,
+                  "pendingCount": 0,
+                  "completionRate": 0,
+                  "perfectDayCount": 0
+                },
+                "last30Days": {
+                  "scheduledCount": 0,
+                  "completedCount": 0,
+                  "skippedCount": 0,
+                  "pendingCount": 0,
+                  "completionRate": 0,
+                  "perfectDayCount": 0
+                }
+              }
+            },
+            "text": "Got it—I’ve saved a reminder to call the pharmacy before 5 PM today about your prescription refill. Let me know if you’d like to adjust the time or add any details.",
+            "raw": {
+              "success": true,
+              "text": "Got it—I’ve saved a reminder to call the pharmacy before 5 PM today about your prescription refill. Let me know if you’d like to adjust the time or add any details.",
+              "data": {
+                "definition": {
+                  "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                  "domain": "user_lifeops",
+                  "subjectType": "owner",
+                  "subjectId": "71da199c-ba36-0996-a5eb-0236efbcbf0b",
+                  "visibilityScope": "owner_only",
+                  "contextPolicy": "explicit_only",
+                  "kind": "habit",
+                  "title": "Call pharmacy",
+                  "description": "Call the pharmacy about prescription refill",
+                  "originalIntent": "Call the pharmacy before 5pm today about prescription refill",
+                  "timezone": "America/New_York",
+                  "status": "active",
+                  "priority": 1,
+                  "cadence": {
+                    "kind": "once",
+                    "dueAt": "2026-07-04T21:04:59.688Z"
+                  },
+                  "windowPolicy": {
+                    "timezone": "America/New_York",
+                    "windows": [
+                      {
+                        "name": "morning",
+                        "label": "Morning",
+                        "startMinute": 300,
+                        "endMinute": 720
+                      },
+                      {
+                        "name": "afternoon",
+                        "label": "Afternoon",
+                        "startMinute": 720,
+                        "endMinute": 1020
+                      },
+                      {
+                        "name": "evening",
+                        "label": "Evening",
+                        "startMinute": 1020,
+                        "endMinute": 1320
+                      },
+                      {
+                        "name": "night",
+                        "label": "Night",
+                        "startMinute": 1320,
+                        "endMinute": 1680
+                      }
+                    ]
+                  },
+                  "progressionRule": {
+                    "kind": "none"
+                  },
+                  "websiteAccess": null,
+                  "reminderPlanId": "a830d823-fdb5-4c5d-95f9-08c51e9fa058",
+                  "goalId": null,
+                  "source": "chat",
+                  "metadata": {
+                    "nativeAppleReminder": {
+                      "kind": "reminder",
+                      "provider": "apple_reminders",
+                      "reminderId": "594D11AA-0CB3-47EF-97FC-6F1896885278",
+                      "source": "llm"
+                    },
+                    "privacyClass": "private",
+                    "publicContextBlocked": true
+                  },
+                  "id": "87be5112-7f20-4061-9aec-27a4857e16e7",
+                  "createdAt": "2026-07-04T05:49:59.689Z",
+                  "updatedAt": "2026-07-04T05:50:00.020Z"
+                },
+                "reminderPlan": {
+                  "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                  "ownerType": "definition",
+                  "ownerId": "87be5112-7f20-4061-9aec-27a4857e16e7",
+                  "steps": [
+                    {
+                      "channel": "in_app",
+                      "offsetMinutes": 0,
+                      "label": "Call pharmacy reminder"
+                    }
+                  ],
+                  "mutePolicy": {},
+                  "quietHours": {},
+                  "id": "a830d823-fdb5-4c5d-95f9-08c51e9fa058",
+                  "createdAt": "2026-07-04T05:49:59.702Z",
+                  "updatedAt": "2026-07-04T05:49:59.702Z"
+                },
+                "performance": {
+                  "lastCompletedAt": null,
+                  "lastSkippedAt": null,
+                  "lastActivityAt": null,
+                  "totalScheduledCount": 0,
+                  "totalCompletedCount": 0,
+                  "totalSkippedCount": 0,
+                  "totalPendingCount": 0,
+                  "currentOccurrenceStreak": 0,
+                  "bestOccurrenceStreak": 0,
+                  "currentPerfectDayStreak": 0,
+                  "bestPerfectDayStreak": 0,
+                  "last7Days": {
+                    "scheduledCount": 0,
+                    "completedCount": 0,
+                    "skippedCount": 0,
+                    "pendingCount": 0,
+                    "completionRate": 0,
+                    "perfectDayCount": 0
+                  },
+                  "last30Days": {
+                    "scheduledCount": 0,
+                    "completedCount": 0,
+                    "skippedCount": 0,
+                    "pendingCount": 0,
+                    "completionRate": 0,
+                    "perfectDayCount": 0
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "failedAssertions": [],
+      "providerName": "openai",
+      "judgeScore": 1
+    }
+  ],
+  "totals": {
+    "passed": 1,
+    "failed": 0,
+    "skipped": 0,
+    "flakyPassed": 0,
+    "costUsd": 0,
+    "finalChecksSkipped": 0
+  },
+  "totalCount": 1,
+  "passedCount": 1,
+  "failedCount": 0,
+  "skippedCount": 0,
+  "flakyPassedCount": 0,
+  "totalCostUsd": 0,
+  "artifactPaths": {
+    "runDir": "/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/vigilant-moser-707cf0/reports/scenarios/live-12283",
+    "matrixJson": "/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/vigilant-moser-707cf0/reports/scenarios/live-12283/matrix.json",
+    "viewerIndex": "/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/vigilant-moser-707cf0/reports/scenarios/live-12283/viewer/index.html",
+    "viewerData": "/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/vigilant-moser-707cf0/reports/scenarios/live-12283/viewer/data.js"
+  }
+}

--- a/.github/issue-evidence/12283-lifeops-personas/adhd-medication-refill-fuzzy-date-capture.report.json
+++ b/.github/issue-evidence/12283-lifeops-personas/adhd-medication-refill-fuzzy-date-capture.report.json
@@ -1,0 +1,583 @@
+{
+  "runId": "efc7da2e-fd8c-4e03-ace2-239973d79027",
+  "startedAtIso": "2026-07-04T05:52:48.644Z",
+  "completedAtIso": "2026-07-04T05:52:57.763Z",
+  "providerName": "openai",
+  "scenarios": [
+    {
+      "id": "adhd-medication-refill-fuzzy-date-capture",
+      "title": "ADHD: a fuzzy-dated refill captured as a dated reminder",
+      "domain": "lifeops.reminders",
+      "tags": [
+        "lifeops",
+        "adhd",
+        "personas",
+        "12283"
+      ],
+      "status": "passed",
+      "durationMs": 6386,
+      "turns": [
+        {
+          "name": "casey asks for a fuzzy-dated refill reminder",
+          "kind": "message",
+          "text": "i always forget this — can you remind me to refill my adderall prescription early next week? whatever day makes sense, i just can't let it lapse.",
+          "responseText": "Sure thing—I’ve set a reminder to refill your Adderall prescription early next week (Wednesday morning). Let me know if you’d like to tweak the day or time!",
+          "actionsCalled": [
+            {
+              "actionName": "OWNER_REMINDERS",
+              "parameters": {
+                "parameters": {
+                  "action": "create",
+                  "kind": "definition",
+                  "intent": "remind me to refill my Adderall prescription early next week",
+                  "title": "Refill Adderall prescription",
+                  "details": {}
+                },
+                "actionContext": {
+                  "previousResults": []
+                }
+              },
+              "result": {
+                "success": true,
+                "data": {
+                  "definition": {
+                    "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                    "domain": "user_lifeops",
+                    "subjectType": "owner",
+                    "subjectId": "71da199c-ba36-0996-a5eb-0236efbcbf0b",
+                    "visibilityScope": "owner_only",
+                    "contextPolicy": "explicit_only",
+                    "kind": "habit",
+                    "title": "Refill Adderall prescription",
+                    "description": "Refill my Adderall prescription early next week to avoid lapse",
+                    "originalIntent": "remind me to refill my Adderall prescription early next week",
+                    "timezone": "America/New_York",
+                    "status": "active",
+                    "priority": 2,
+                    "cadence": {
+                      "kind": "once",
+                      "dueAt": "2026-07-06T13:00:00.000Z"
+                    },
+                    "windowPolicy": {
+                      "timezone": "America/New_York",
+                      "windows": [
+                        {
+                          "name": "morning",
+                          "label": "Morning",
+                          "startMinute": 300,
+                          "endMinute": 720
+                        },
+                        {
+                          "name": "afternoon",
+                          "label": "Afternoon",
+                          "startMinute": 720,
+                          "endMinute": 1020
+                        },
+                        {
+                          "name": "evening",
+                          "label": "Evening",
+                          "startMinute": 1020,
+                          "endMinute": 1320
+                        },
+                        {
+                          "name": "night",
+                          "label": "Night",
+                          "startMinute": 1320,
+                          "endMinute": 1680
+                        }
+                      ]
+                    },
+                    "progressionRule": {
+                      "kind": "none"
+                    },
+                    "websiteAccess": null,
+                    "reminderPlanId": "a5262e2c-238c-498a-890f-1c0771a52c97",
+                    "goalId": null,
+                    "source": "chat",
+                    "metadata": {
+                      "nativeAppleReminder": {
+                        "kind": "reminder",
+                        "provider": "apple_reminders",
+                        "reminderId": "279FCB2C-CA3A-4D55-81E0-C0DB2FE0FEC4",
+                        "source": "llm"
+                      },
+                      "privacyClass": "private",
+                      "publicContextBlocked": true
+                    },
+                    "id": "819b13e1-d991-4311-8b16-4ba58633fab3",
+                    "createdAt": "2026-07-04T05:52:53.966Z",
+                    "updatedAt": "2026-07-04T05:52:54.221Z"
+                  },
+                  "reminderPlan": {
+                    "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                    "ownerType": "definition",
+                    "ownerId": "819b13e1-d991-4311-8b16-4ba58633fab3",
+                    "steps": [
+                      {
+                        "channel": "in_app",
+                        "offsetMinutes": 0,
+                        "label": "Refill Adderall prescription reminder"
+                      }
+                    ],
+                    "mutePolicy": {},
+                    "quietHours": {},
+                    "id": "a5262e2c-238c-498a-890f-1c0771a52c97",
+                    "createdAt": "2026-07-04T05:52:53.982Z",
+                    "updatedAt": "2026-07-04T05:52:53.982Z"
+                  },
+                  "performance": {
+                    "lastCompletedAt": null,
+                    "lastSkippedAt": null,
+                    "lastActivityAt": null,
+                    "totalScheduledCount": 0,
+                    "totalCompletedCount": 0,
+                    "totalSkippedCount": 0,
+                    "totalPendingCount": 0,
+                    "currentOccurrenceStreak": 0,
+                    "bestOccurrenceStreak": 0,
+                    "currentPerfectDayStreak": 0,
+                    "bestPerfectDayStreak": 0,
+                    "last7Days": {
+                      "scheduledCount": 0,
+                      "completedCount": 0,
+                      "skippedCount": 0,
+                      "pendingCount": 0,
+                      "completionRate": 0,
+                      "perfectDayCount": 0
+                    },
+                    "last30Days": {
+                      "scheduledCount": 0,
+                      "completedCount": 0,
+                      "skippedCount": 0,
+                      "pendingCount": 0,
+                      "completionRate": 0,
+                      "perfectDayCount": 0
+                    }
+                  }
+                },
+                "text": "Sure thing—I’ve set a reminder to refill your Adderall prescription early next week (Wednesday morning). Let me know if you’d like to tweak the day or time!",
+                "raw": {
+                  "success": true,
+                  "text": "Sure thing—I’ve set a reminder to refill your Adderall prescription early next week (Wednesday morning). Let me know if you’d like to tweak the day or time!",
+                  "data": {
+                    "definition": {
+                      "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                      "domain": "user_lifeops",
+                      "subjectType": "owner",
+                      "subjectId": "71da199c-ba36-0996-a5eb-0236efbcbf0b",
+                      "visibilityScope": "owner_only",
+                      "contextPolicy": "explicit_only",
+                      "kind": "habit",
+                      "title": "Refill Adderall prescription",
+                      "description": "Refill my Adderall prescription early next week to avoid lapse",
+                      "originalIntent": "remind me to refill my Adderall prescription early next week",
+                      "timezone": "America/New_York",
+                      "status": "active",
+                      "priority": 2,
+                      "cadence": {
+                        "kind": "once",
+                        "dueAt": "2026-07-06T13:00:00.000Z"
+                      },
+                      "windowPolicy": {
+                        "timezone": "America/New_York",
+                        "windows": [
+                          {
+                            "name": "morning",
+                            "label": "Morning",
+                            "startMinute": 300,
+                            "endMinute": 720
+                          },
+                          {
+                            "name": "afternoon",
+                            "label": "Afternoon",
+                            "startMinute": 720,
+                            "endMinute": 1020
+                          },
+                          {
+                            "name": "evening",
+                            "label": "Evening",
+                            "startMinute": 1020,
+                            "endMinute": 1320
+                          },
+                          {
+                            "name": "night",
+                            "label": "Night",
+                            "startMinute": 1320,
+                            "endMinute": 1680
+                          }
+                        ]
+                      },
+                      "progressionRule": {
+                        "kind": "none"
+                      },
+                      "websiteAccess": null,
+                      "reminderPlanId": "a5262e2c-238c-498a-890f-1c0771a52c97",
+                      "goalId": null,
+                      "source": "chat",
+                      "metadata": {
+                        "nativeAppleReminder": {
+                          "kind": "reminder",
+                          "provider": "apple_reminders",
+                          "reminderId": "279FCB2C-CA3A-4D55-81E0-C0DB2FE0FEC4",
+                          "source": "llm"
+                        },
+                        "privacyClass": "private",
+                        "publicContextBlocked": true
+                      },
+                      "id": "819b13e1-d991-4311-8b16-4ba58633fab3",
+                      "createdAt": "2026-07-04T05:52:53.966Z",
+                      "updatedAt": "2026-07-04T05:52:54.221Z"
+                    },
+                    "reminderPlan": {
+                      "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                      "ownerType": "definition",
+                      "ownerId": "819b13e1-d991-4311-8b16-4ba58633fab3",
+                      "steps": [
+                        {
+                          "channel": "in_app",
+                          "offsetMinutes": 0,
+                          "label": "Refill Adderall prescription reminder"
+                        }
+                      ],
+                      "mutePolicy": {},
+                      "quietHours": {},
+                      "id": "a5262e2c-238c-498a-890f-1c0771a52c97",
+                      "createdAt": "2026-07-04T05:52:53.982Z",
+                      "updatedAt": "2026-07-04T05:52:53.982Z"
+                    },
+                    "performance": {
+                      "lastCompletedAt": null,
+                      "lastSkippedAt": null,
+                      "lastActivityAt": null,
+                      "totalScheduledCount": 0,
+                      "totalCompletedCount": 0,
+                      "totalSkippedCount": 0,
+                      "totalPendingCount": 0,
+                      "currentOccurrenceStreak": 0,
+                      "bestOccurrenceStreak": 0,
+                      "currentPerfectDayStreak": 0,
+                      "bestPerfectDayStreak": 0,
+                      "last7Days": {
+                        "scheduledCount": 0,
+                        "completedCount": 0,
+                        "skippedCount": 0,
+                        "pendingCount": 0,
+                        "completionRate": 0,
+                        "perfectDayCount": 0
+                      },
+                      "last30Days": {
+                        "scheduledCount": 0,
+                        "completedCount": 0,
+                        "skippedCount": 0,
+                        "pendingCount": 0,
+                        "completionRate": 0,
+                        "perfectDayCount": 0
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "durationMs": 6098,
+          "failedAssertions": []
+        }
+      ],
+      "finalChecks": [
+        {
+          "label": "definitionCountDelta",
+          "type": "definitionCountDelta",
+          "status": "passed",
+          "detail": "1 matching definition(s) for \"refill\""
+        },
+        {
+          "label": "fuzzy-date-captured-as-dated-reminder",
+          "type": "judgeRubric",
+          "status": "passed",
+          "detail": "score 1.00 ≥ 0.6",
+          "score": 1
+        }
+      ],
+      "actionsCalled": [
+        {
+          "actionName": "OWNER_REMINDERS",
+          "parameters": {
+            "parameters": {
+              "action": "create",
+              "kind": "definition",
+              "intent": "remind me to refill my Adderall prescription early next week",
+              "title": "Refill Adderall prescription",
+              "details": {}
+            },
+            "actionContext": {
+              "previousResults": []
+            }
+          },
+          "result": {
+            "success": true,
+            "data": {
+              "definition": {
+                "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                "domain": "user_lifeops",
+                "subjectType": "owner",
+                "subjectId": "71da199c-ba36-0996-a5eb-0236efbcbf0b",
+                "visibilityScope": "owner_only",
+                "contextPolicy": "explicit_only",
+                "kind": "habit",
+                "title": "Refill Adderall prescription",
+                "description": "Refill my Adderall prescription early next week to avoid lapse",
+                "originalIntent": "remind me to refill my Adderall prescription early next week",
+                "timezone": "America/New_York",
+                "status": "active",
+                "priority": 2,
+                "cadence": {
+                  "kind": "once",
+                  "dueAt": "2026-07-06T13:00:00.000Z"
+                },
+                "windowPolicy": {
+                  "timezone": "America/New_York",
+                  "windows": [
+                    {
+                      "name": "morning",
+                      "label": "Morning",
+                      "startMinute": 300,
+                      "endMinute": 720
+                    },
+                    {
+                      "name": "afternoon",
+                      "label": "Afternoon",
+                      "startMinute": 720,
+                      "endMinute": 1020
+                    },
+                    {
+                      "name": "evening",
+                      "label": "Evening",
+                      "startMinute": 1020,
+                      "endMinute": 1320
+                    },
+                    {
+                      "name": "night",
+                      "label": "Night",
+                      "startMinute": 1320,
+                      "endMinute": 1680
+                    }
+                  ]
+                },
+                "progressionRule": {
+                  "kind": "none"
+                },
+                "websiteAccess": null,
+                "reminderPlanId": "a5262e2c-238c-498a-890f-1c0771a52c97",
+                "goalId": null,
+                "source": "chat",
+                "metadata": {
+                  "nativeAppleReminder": {
+                    "kind": "reminder",
+                    "provider": "apple_reminders",
+                    "reminderId": "279FCB2C-CA3A-4D55-81E0-C0DB2FE0FEC4",
+                    "source": "llm"
+                  },
+                  "privacyClass": "private",
+                  "publicContextBlocked": true
+                },
+                "id": "819b13e1-d991-4311-8b16-4ba58633fab3",
+                "createdAt": "2026-07-04T05:52:53.966Z",
+                "updatedAt": "2026-07-04T05:52:54.221Z"
+              },
+              "reminderPlan": {
+                "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                "ownerType": "definition",
+                "ownerId": "819b13e1-d991-4311-8b16-4ba58633fab3",
+                "steps": [
+                  {
+                    "channel": "in_app",
+                    "offsetMinutes": 0,
+                    "label": "Refill Adderall prescription reminder"
+                  }
+                ],
+                "mutePolicy": {},
+                "quietHours": {},
+                "id": "a5262e2c-238c-498a-890f-1c0771a52c97",
+                "createdAt": "2026-07-04T05:52:53.982Z",
+                "updatedAt": "2026-07-04T05:52:53.982Z"
+              },
+              "performance": {
+                "lastCompletedAt": null,
+                "lastSkippedAt": null,
+                "lastActivityAt": null,
+                "totalScheduledCount": 0,
+                "totalCompletedCount": 0,
+                "totalSkippedCount": 0,
+                "totalPendingCount": 0,
+                "currentOccurrenceStreak": 0,
+                "bestOccurrenceStreak": 0,
+                "currentPerfectDayStreak": 0,
+                "bestPerfectDayStreak": 0,
+                "last7Days": {
+                  "scheduledCount": 0,
+                  "completedCount": 0,
+                  "skippedCount": 0,
+                  "pendingCount": 0,
+                  "completionRate": 0,
+                  "perfectDayCount": 0
+                },
+                "last30Days": {
+                  "scheduledCount": 0,
+                  "completedCount": 0,
+                  "skippedCount": 0,
+                  "pendingCount": 0,
+                  "completionRate": 0,
+                  "perfectDayCount": 0
+                }
+              }
+            },
+            "text": "Sure thing—I’ve set a reminder to refill your Adderall prescription early next week (Wednesday morning). Let me know if you’d like to tweak the day or time!",
+            "raw": {
+              "success": true,
+              "text": "Sure thing—I’ve set a reminder to refill your Adderall prescription early next week (Wednesday morning). Let me know if you’d like to tweak the day or time!",
+              "data": {
+                "definition": {
+                  "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                  "domain": "user_lifeops",
+                  "subjectType": "owner",
+                  "subjectId": "71da199c-ba36-0996-a5eb-0236efbcbf0b",
+                  "visibilityScope": "owner_only",
+                  "contextPolicy": "explicit_only",
+                  "kind": "habit",
+                  "title": "Refill Adderall prescription",
+                  "description": "Refill my Adderall prescription early next week to avoid lapse",
+                  "originalIntent": "remind me to refill my Adderall prescription early next week",
+                  "timezone": "America/New_York",
+                  "status": "active",
+                  "priority": 2,
+                  "cadence": {
+                    "kind": "once",
+                    "dueAt": "2026-07-06T13:00:00.000Z"
+                  },
+                  "windowPolicy": {
+                    "timezone": "America/New_York",
+                    "windows": [
+                      {
+                        "name": "morning",
+                        "label": "Morning",
+                        "startMinute": 300,
+                        "endMinute": 720
+                      },
+                      {
+                        "name": "afternoon",
+                        "label": "Afternoon",
+                        "startMinute": 720,
+                        "endMinute": 1020
+                      },
+                      {
+                        "name": "evening",
+                        "label": "Evening",
+                        "startMinute": 1020,
+                        "endMinute": 1320
+                      },
+                      {
+                        "name": "night",
+                        "label": "Night",
+                        "startMinute": 1320,
+                        "endMinute": 1680
+                      }
+                    ]
+                  },
+                  "progressionRule": {
+                    "kind": "none"
+                  },
+                  "websiteAccess": null,
+                  "reminderPlanId": "a5262e2c-238c-498a-890f-1c0771a52c97",
+                  "goalId": null,
+                  "source": "chat",
+                  "metadata": {
+                    "nativeAppleReminder": {
+                      "kind": "reminder",
+                      "provider": "apple_reminders",
+                      "reminderId": "279FCB2C-CA3A-4D55-81E0-C0DB2FE0FEC4",
+                      "source": "llm"
+                    },
+                    "privacyClass": "private",
+                    "publicContextBlocked": true
+                  },
+                  "id": "819b13e1-d991-4311-8b16-4ba58633fab3",
+                  "createdAt": "2026-07-04T05:52:53.966Z",
+                  "updatedAt": "2026-07-04T05:52:54.221Z"
+                },
+                "reminderPlan": {
+                  "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                  "ownerType": "definition",
+                  "ownerId": "819b13e1-d991-4311-8b16-4ba58633fab3",
+                  "steps": [
+                    {
+                      "channel": "in_app",
+                      "offsetMinutes": 0,
+                      "label": "Refill Adderall prescription reminder"
+                    }
+                  ],
+                  "mutePolicy": {},
+                  "quietHours": {},
+                  "id": "a5262e2c-238c-498a-890f-1c0771a52c97",
+                  "createdAt": "2026-07-04T05:52:53.982Z",
+                  "updatedAt": "2026-07-04T05:52:53.982Z"
+                },
+                "performance": {
+                  "lastCompletedAt": null,
+                  "lastSkippedAt": null,
+                  "lastActivityAt": null,
+                  "totalScheduledCount": 0,
+                  "totalCompletedCount": 0,
+                  "totalSkippedCount": 0,
+                  "totalPendingCount": 0,
+                  "currentOccurrenceStreak": 0,
+                  "bestOccurrenceStreak": 0,
+                  "currentPerfectDayStreak": 0,
+                  "bestPerfectDayStreak": 0,
+                  "last7Days": {
+                    "scheduledCount": 0,
+                    "completedCount": 0,
+                    "skippedCount": 0,
+                    "pendingCount": 0,
+                    "completionRate": 0,
+                    "perfectDayCount": 0
+                  },
+                  "last30Days": {
+                    "scheduledCount": 0,
+                    "completedCount": 0,
+                    "skippedCount": 0,
+                    "pendingCount": 0,
+                    "completionRate": 0,
+                    "perfectDayCount": 0
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "failedAssertions": [],
+      "providerName": "openai",
+      "judgeScore": 1
+    }
+  ],
+  "totals": {
+    "passed": 1,
+    "failed": 0,
+    "skipped": 0,
+    "flakyPassed": 0,
+    "costUsd": 0,
+    "finalChecksSkipped": 0
+  },
+  "totalCount": 1,
+  "passedCount": 1,
+  "failedCount": 0,
+  "skippedCount": 0,
+  "flakyPassedCount": 0,
+  "totalCostUsd": 0,
+  "artifactPaths": {
+    "runDir": "/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/vigilant-moser-707cf0/reports/scenarios/live-12283-adhd-medication-refill-fuzzy-date-capture",
+    "matrixJson": "/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/vigilant-moser-707cf0/reports/scenarios/live-12283-adhd-medication-refill-fuzzy-date-capture/matrix.json",
+    "viewerIndex": "/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/vigilant-moser-707cf0/reports/scenarios/live-12283-adhd-medication-refill-fuzzy-date-capture/viewer/index.html",
+    "viewerData": "/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/vigilant-moser-707cf0/reports/scenarios/live-12283-adhd-medication-refill-fuzzy-date-capture/viewer/data.js"
+  }
+}

--- a/.github/issue-evidence/12283-lifeops-personas/adhd-wait-no-correction-supersedes.report.json
+++ b/.github/issue-evidence/12283-lifeops-personas/adhd-wait-no-correction-supersedes.report.json
@@ -1,0 +1,587 @@
+{
+  "runId": "07aa3751-0342-48a7-bb57-1103e69bddc7",
+  "startedAtIso": "2026-07-04T05:52:59.036Z",
+  "completedAtIso": "2026-07-04T05:53:08.318Z",
+  "providerName": "openai",
+  "scenarios": [
+    {
+      "id": "adhd-wait-no-correction-supersedes",
+      "title": "ADHD: a mid-message self-correction supersedes the first task",
+      "domain": "lifeops.reminders",
+      "tags": [
+        "lifeops",
+        "adhd",
+        "personas",
+        "12283"
+      ],
+      "status": "passed",
+      "durationMs": 6562,
+      "turns": [
+        {
+          "name": "casey self-corrects mid-message",
+          "kind": "message",
+          "text": "remind me to email Sarah about the venue deposit tomorrow — wait no, not Sarah, it's Tom who handles the venue. remind me to email Tom about the venue deposit tomorrow.",
+          "responseText": "I’ve saved a reminder to email Tom about the venue deposit tomorrow. Let me know if you’d like to adjust the time or add any details.",
+          "actionsCalled": [
+            {
+              "actionName": "OWNER_REMINDERS",
+              "parameters": {
+                "parameters": {
+                  "action": "create",
+                  "kind": "definition",
+                  "intent": "remind me to email Tom about the venue deposit tomorrow",
+                  "title": "Email Tom about venue deposit"
+                },
+                "actionContext": {
+                  "previousResults": []
+                }
+              },
+              "result": {
+                "success": true,
+                "data": {
+                  "definition": {
+                    "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                    "domain": "user_lifeops",
+                    "subjectType": "owner",
+                    "subjectId": "71da199c-ba36-0996-a5eb-0236efbcbf0b",
+                    "visibilityScope": "owner_only",
+                    "contextPolicy": "explicit_only",
+                    "kind": "habit",
+                    "title": "Email Tom about venue deposit",
+                    "description": "Email Tom about the venue deposit",
+                    "originalIntent": "remind me to email Tom about the venue deposit tomorrow",
+                    "timezone": "America/New_York",
+                    "status": "active",
+                    "priority": 3,
+                    "cadence": {
+                      "kind": "once",
+                      "dueAt": "2026-07-05T13:00:00.000Z"
+                    },
+                    "windowPolicy": {
+                      "timezone": "America/New_York",
+                      "windows": [
+                        {
+                          "name": "morning",
+                          "label": "Morning",
+                          "startMinute": 300,
+                          "endMinute": 720
+                        },
+                        {
+                          "name": "afternoon",
+                          "label": "Afternoon",
+                          "startMinute": 720,
+                          "endMinute": 1020
+                        },
+                        {
+                          "name": "evening",
+                          "label": "Evening",
+                          "startMinute": 1020,
+                          "endMinute": 1320
+                        },
+                        {
+                          "name": "night",
+                          "label": "Night",
+                          "startMinute": 1320,
+                          "endMinute": 1680
+                        }
+                      ]
+                    },
+                    "progressionRule": {
+                      "kind": "none"
+                    },
+                    "websiteAccess": null,
+                    "reminderPlanId": "31e694cf-08be-46a1-b5fa-e7111bb54927",
+                    "goalId": null,
+                    "source": "chat",
+                    "metadata": {
+                      "nativeAppleReminder": {
+                        "kind": "reminder",
+                        "provider": "apple_reminders",
+                        "reminderId": "4599D0D8-15F3-4FB4-8787-9DE0EDF1E598",
+                        "source": "llm"
+                      },
+                      "privacyClass": "private",
+                      "publicContextBlocked": true
+                    },
+                    "id": "6c9db581-fc0a-4e98-93eb-753e0641093d",
+                    "createdAt": "2026-07-04T05:53:05.242Z",
+                    "updatedAt": "2026-07-04T05:53:05.575Z"
+                  },
+                  "reminderPlan": {
+                    "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                    "ownerType": "definition",
+                    "ownerId": "6c9db581-fc0a-4e98-93eb-753e0641093d",
+                    "steps": [
+                      {
+                        "channel": "in_app",
+                        "offsetMinutes": 0,
+                        "label": "Email Tom about venue deposit reminder"
+                      }
+                    ],
+                    "mutePolicy": {},
+                    "quietHours": {},
+                    "id": "31e694cf-08be-46a1-b5fa-e7111bb54927",
+                    "createdAt": "2026-07-04T05:53:05.267Z",
+                    "updatedAt": "2026-07-04T05:53:05.267Z"
+                  },
+                  "performance": {
+                    "lastCompletedAt": null,
+                    "lastSkippedAt": null,
+                    "lastActivityAt": null,
+                    "totalScheduledCount": 0,
+                    "totalCompletedCount": 0,
+                    "totalSkippedCount": 0,
+                    "totalPendingCount": 0,
+                    "currentOccurrenceStreak": 0,
+                    "bestOccurrenceStreak": 0,
+                    "currentPerfectDayStreak": 0,
+                    "bestPerfectDayStreak": 0,
+                    "last7Days": {
+                      "scheduledCount": 0,
+                      "completedCount": 0,
+                      "skippedCount": 0,
+                      "pendingCount": 0,
+                      "completionRate": 0,
+                      "perfectDayCount": 0
+                    },
+                    "last30Days": {
+                      "scheduledCount": 0,
+                      "completedCount": 0,
+                      "skippedCount": 0,
+                      "pendingCount": 0,
+                      "completionRate": 0,
+                      "perfectDayCount": 0
+                    }
+                  }
+                },
+                "text": "I’ve saved a reminder to email Tom about the venue deposit tomorrow. Let me know if you’d like to adjust the time or add any details.",
+                "raw": {
+                  "success": true,
+                  "text": "I’ve saved a reminder to email Tom about the venue deposit tomorrow. Let me know if you’d like to adjust the time or add any details.",
+                  "data": {
+                    "definition": {
+                      "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                      "domain": "user_lifeops",
+                      "subjectType": "owner",
+                      "subjectId": "71da199c-ba36-0996-a5eb-0236efbcbf0b",
+                      "visibilityScope": "owner_only",
+                      "contextPolicy": "explicit_only",
+                      "kind": "habit",
+                      "title": "Email Tom about venue deposit",
+                      "description": "Email Tom about the venue deposit",
+                      "originalIntent": "remind me to email Tom about the venue deposit tomorrow",
+                      "timezone": "America/New_York",
+                      "status": "active",
+                      "priority": 3,
+                      "cadence": {
+                        "kind": "once",
+                        "dueAt": "2026-07-05T13:00:00.000Z"
+                      },
+                      "windowPolicy": {
+                        "timezone": "America/New_York",
+                        "windows": [
+                          {
+                            "name": "morning",
+                            "label": "Morning",
+                            "startMinute": 300,
+                            "endMinute": 720
+                          },
+                          {
+                            "name": "afternoon",
+                            "label": "Afternoon",
+                            "startMinute": 720,
+                            "endMinute": 1020
+                          },
+                          {
+                            "name": "evening",
+                            "label": "Evening",
+                            "startMinute": 1020,
+                            "endMinute": 1320
+                          },
+                          {
+                            "name": "night",
+                            "label": "Night",
+                            "startMinute": 1320,
+                            "endMinute": 1680
+                          }
+                        ]
+                      },
+                      "progressionRule": {
+                        "kind": "none"
+                      },
+                      "websiteAccess": null,
+                      "reminderPlanId": "31e694cf-08be-46a1-b5fa-e7111bb54927",
+                      "goalId": null,
+                      "source": "chat",
+                      "metadata": {
+                        "nativeAppleReminder": {
+                          "kind": "reminder",
+                          "provider": "apple_reminders",
+                          "reminderId": "4599D0D8-15F3-4FB4-8787-9DE0EDF1E598",
+                          "source": "llm"
+                        },
+                        "privacyClass": "private",
+                        "publicContextBlocked": true
+                      },
+                      "id": "6c9db581-fc0a-4e98-93eb-753e0641093d",
+                      "createdAt": "2026-07-04T05:53:05.242Z",
+                      "updatedAt": "2026-07-04T05:53:05.575Z"
+                    },
+                    "reminderPlan": {
+                      "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                      "ownerType": "definition",
+                      "ownerId": "6c9db581-fc0a-4e98-93eb-753e0641093d",
+                      "steps": [
+                        {
+                          "channel": "in_app",
+                          "offsetMinutes": 0,
+                          "label": "Email Tom about venue deposit reminder"
+                        }
+                      ],
+                      "mutePolicy": {},
+                      "quietHours": {},
+                      "id": "31e694cf-08be-46a1-b5fa-e7111bb54927",
+                      "createdAt": "2026-07-04T05:53:05.267Z",
+                      "updatedAt": "2026-07-04T05:53:05.267Z"
+                    },
+                    "performance": {
+                      "lastCompletedAt": null,
+                      "lastSkippedAt": null,
+                      "lastActivityAt": null,
+                      "totalScheduledCount": 0,
+                      "totalCompletedCount": 0,
+                      "totalSkippedCount": 0,
+                      "totalPendingCount": 0,
+                      "currentOccurrenceStreak": 0,
+                      "bestOccurrenceStreak": 0,
+                      "currentPerfectDayStreak": 0,
+                      "bestPerfectDayStreak": 0,
+                      "last7Days": {
+                        "scheduledCount": 0,
+                        "completedCount": 0,
+                        "skippedCount": 0,
+                        "pendingCount": 0,
+                        "completionRate": 0,
+                        "perfectDayCount": 0
+                      },
+                      "last30Days": {
+                        "scheduledCount": 0,
+                        "completedCount": 0,
+                        "skippedCount": 0,
+                        "pendingCount": 0,
+                        "completionRate": 0,
+                        "perfectDayCount": 0
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "durationMs": 6362,
+          "failedAssertions": []
+        }
+      ],
+      "finalChecks": [
+        {
+          "label": "definitionCountDelta",
+          "type": "definitionCountDelta",
+          "status": "passed",
+          "detail": "1 matching definition(s) for \"email Tom\""
+        },
+        {
+          "label": "definitionCountDelta",
+          "type": "definitionCountDelta",
+          "status": "passed",
+          "detail": "no matching definition for \"email Sarah\""
+        },
+        {
+          "label": "correction-supersedes-first-task",
+          "type": "judgeRubric",
+          "status": "passed",
+          "detail": "score 1.00 ≥ 0.6",
+          "score": 1
+        }
+      ],
+      "actionsCalled": [
+        {
+          "actionName": "OWNER_REMINDERS",
+          "parameters": {
+            "parameters": {
+              "action": "create",
+              "kind": "definition",
+              "intent": "remind me to email Tom about the venue deposit tomorrow",
+              "title": "Email Tom about venue deposit"
+            },
+            "actionContext": {
+              "previousResults": []
+            }
+          },
+          "result": {
+            "success": true,
+            "data": {
+              "definition": {
+                "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                "domain": "user_lifeops",
+                "subjectType": "owner",
+                "subjectId": "71da199c-ba36-0996-a5eb-0236efbcbf0b",
+                "visibilityScope": "owner_only",
+                "contextPolicy": "explicit_only",
+                "kind": "habit",
+                "title": "Email Tom about venue deposit",
+                "description": "Email Tom about the venue deposit",
+                "originalIntent": "remind me to email Tom about the venue deposit tomorrow",
+                "timezone": "America/New_York",
+                "status": "active",
+                "priority": 3,
+                "cadence": {
+                  "kind": "once",
+                  "dueAt": "2026-07-05T13:00:00.000Z"
+                },
+                "windowPolicy": {
+                  "timezone": "America/New_York",
+                  "windows": [
+                    {
+                      "name": "morning",
+                      "label": "Morning",
+                      "startMinute": 300,
+                      "endMinute": 720
+                    },
+                    {
+                      "name": "afternoon",
+                      "label": "Afternoon",
+                      "startMinute": 720,
+                      "endMinute": 1020
+                    },
+                    {
+                      "name": "evening",
+                      "label": "Evening",
+                      "startMinute": 1020,
+                      "endMinute": 1320
+                    },
+                    {
+                      "name": "night",
+                      "label": "Night",
+                      "startMinute": 1320,
+                      "endMinute": 1680
+                    }
+                  ]
+                },
+                "progressionRule": {
+                  "kind": "none"
+                },
+                "websiteAccess": null,
+                "reminderPlanId": "31e694cf-08be-46a1-b5fa-e7111bb54927",
+                "goalId": null,
+                "source": "chat",
+                "metadata": {
+                  "nativeAppleReminder": {
+                    "kind": "reminder",
+                    "provider": "apple_reminders",
+                    "reminderId": "4599D0D8-15F3-4FB4-8787-9DE0EDF1E598",
+                    "source": "llm"
+                  },
+                  "privacyClass": "private",
+                  "publicContextBlocked": true
+                },
+                "id": "6c9db581-fc0a-4e98-93eb-753e0641093d",
+                "createdAt": "2026-07-04T05:53:05.242Z",
+                "updatedAt": "2026-07-04T05:53:05.575Z"
+              },
+              "reminderPlan": {
+                "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                "ownerType": "definition",
+                "ownerId": "6c9db581-fc0a-4e98-93eb-753e0641093d",
+                "steps": [
+                  {
+                    "channel": "in_app",
+                    "offsetMinutes": 0,
+                    "label": "Email Tom about venue deposit reminder"
+                  }
+                ],
+                "mutePolicy": {},
+                "quietHours": {},
+                "id": "31e694cf-08be-46a1-b5fa-e7111bb54927",
+                "createdAt": "2026-07-04T05:53:05.267Z",
+                "updatedAt": "2026-07-04T05:53:05.267Z"
+              },
+              "performance": {
+                "lastCompletedAt": null,
+                "lastSkippedAt": null,
+                "lastActivityAt": null,
+                "totalScheduledCount": 0,
+                "totalCompletedCount": 0,
+                "totalSkippedCount": 0,
+                "totalPendingCount": 0,
+                "currentOccurrenceStreak": 0,
+                "bestOccurrenceStreak": 0,
+                "currentPerfectDayStreak": 0,
+                "bestPerfectDayStreak": 0,
+                "last7Days": {
+                  "scheduledCount": 0,
+                  "completedCount": 0,
+                  "skippedCount": 0,
+                  "pendingCount": 0,
+                  "completionRate": 0,
+                  "perfectDayCount": 0
+                },
+                "last30Days": {
+                  "scheduledCount": 0,
+                  "completedCount": 0,
+                  "skippedCount": 0,
+                  "pendingCount": 0,
+                  "completionRate": 0,
+                  "perfectDayCount": 0
+                }
+              }
+            },
+            "text": "I’ve saved a reminder to email Tom about the venue deposit tomorrow. Let me know if you’d like to adjust the time or add any details.",
+            "raw": {
+              "success": true,
+              "text": "I’ve saved a reminder to email Tom about the venue deposit tomorrow. Let me know if you’d like to adjust the time or add any details.",
+              "data": {
+                "definition": {
+                  "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                  "domain": "user_lifeops",
+                  "subjectType": "owner",
+                  "subjectId": "71da199c-ba36-0996-a5eb-0236efbcbf0b",
+                  "visibilityScope": "owner_only",
+                  "contextPolicy": "explicit_only",
+                  "kind": "habit",
+                  "title": "Email Tom about venue deposit",
+                  "description": "Email Tom about the venue deposit",
+                  "originalIntent": "remind me to email Tom about the venue deposit tomorrow",
+                  "timezone": "America/New_York",
+                  "status": "active",
+                  "priority": 3,
+                  "cadence": {
+                    "kind": "once",
+                    "dueAt": "2026-07-05T13:00:00.000Z"
+                  },
+                  "windowPolicy": {
+                    "timezone": "America/New_York",
+                    "windows": [
+                      {
+                        "name": "morning",
+                        "label": "Morning",
+                        "startMinute": 300,
+                        "endMinute": 720
+                      },
+                      {
+                        "name": "afternoon",
+                        "label": "Afternoon",
+                        "startMinute": 720,
+                        "endMinute": 1020
+                      },
+                      {
+                        "name": "evening",
+                        "label": "Evening",
+                        "startMinute": 1020,
+                        "endMinute": 1320
+                      },
+                      {
+                        "name": "night",
+                        "label": "Night",
+                        "startMinute": 1320,
+                        "endMinute": 1680
+                      }
+                    ]
+                  },
+                  "progressionRule": {
+                    "kind": "none"
+                  },
+                  "websiteAccess": null,
+                  "reminderPlanId": "31e694cf-08be-46a1-b5fa-e7111bb54927",
+                  "goalId": null,
+                  "source": "chat",
+                  "metadata": {
+                    "nativeAppleReminder": {
+                      "kind": "reminder",
+                      "provider": "apple_reminders",
+                      "reminderId": "4599D0D8-15F3-4FB4-8787-9DE0EDF1E598",
+                      "source": "llm"
+                    },
+                    "privacyClass": "private",
+                    "publicContextBlocked": true
+                  },
+                  "id": "6c9db581-fc0a-4e98-93eb-753e0641093d",
+                  "createdAt": "2026-07-04T05:53:05.242Z",
+                  "updatedAt": "2026-07-04T05:53:05.575Z"
+                },
+                "reminderPlan": {
+                  "agentId": "546ac3ab-0468-01a2-9d5b-52dfa34bf9cc",
+                  "ownerType": "definition",
+                  "ownerId": "6c9db581-fc0a-4e98-93eb-753e0641093d",
+                  "steps": [
+                    {
+                      "channel": "in_app",
+                      "offsetMinutes": 0,
+                      "label": "Email Tom about venue deposit reminder"
+                    }
+                  ],
+                  "mutePolicy": {},
+                  "quietHours": {},
+                  "id": "31e694cf-08be-46a1-b5fa-e7111bb54927",
+                  "createdAt": "2026-07-04T05:53:05.267Z",
+                  "updatedAt": "2026-07-04T05:53:05.267Z"
+                },
+                "performance": {
+                  "lastCompletedAt": null,
+                  "lastSkippedAt": null,
+                  "lastActivityAt": null,
+                  "totalScheduledCount": 0,
+                  "totalCompletedCount": 0,
+                  "totalSkippedCount": 0,
+                  "totalPendingCount": 0,
+                  "currentOccurrenceStreak": 0,
+                  "bestOccurrenceStreak": 0,
+                  "currentPerfectDayStreak": 0,
+                  "bestPerfectDayStreak": 0,
+                  "last7Days": {
+                    "scheduledCount": 0,
+                    "completedCount": 0,
+                    "skippedCount": 0,
+                    "pendingCount": 0,
+                    "completionRate": 0,
+                    "perfectDayCount": 0
+                  },
+                  "last30Days": {
+                    "scheduledCount": 0,
+                    "completedCount": 0,
+                    "skippedCount": 0,
+                    "pendingCount": 0,
+                    "completionRate": 0,
+                    "perfectDayCount": 0
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "failedAssertions": [],
+      "providerName": "openai",
+      "judgeScore": 1
+    }
+  ],
+  "totals": {
+    "passed": 1,
+    "failed": 0,
+    "skipped": 0,
+    "flakyPassed": 0,
+    "costUsd": 0,
+    "finalChecksSkipped": 0
+  },
+  "totalCount": 1,
+  "passedCount": 1,
+  "failedCount": 0,
+  "skippedCount": 0,
+  "flakyPassedCount": 0,
+  "totalCostUsd": 0,
+  "artifactPaths": {
+    "runDir": "/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/vigilant-moser-707cf0/reports/scenarios/live-12283-adhd-wait-no-correction-supersedes",
+    "matrixJson": "/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/vigilant-moser-707cf0/reports/scenarios/live-12283-adhd-wait-no-correction-supersedes/matrix.json",
+    "viewerIndex": "/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/vigilant-moser-707cf0/reports/scenarios/live-12283-adhd-wait-no-correction-supersedes/viewer/index.html",
+    "viewerData": "/Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/vigilant-moser-707cf0/reports/scenarios/live-12283-adhd-wait-no-correction-supersedes/viewer/data.js"
+  }
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/adhd-capture-and-start.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/adhd-capture-and-start.catalog.json
@@ -12,5 +12,14 @@
       "status flips planned -> authored once the scenario file/literal exists; -> verified once a real-LLM run has been captured and hand-reviewed per PR_EVIDENCE.md."
     ]
   },
-  "scenarios": []
+  "scenarios": [
+    {
+      "id": "adhd-buried-commitment-ramble",
+      "pack": "A1",
+      "tier": "T1",
+      "surface": "scenario-runner",
+      "status": "verified",
+      "notes": "Live Cerebras gpt-oss-120b run passed (judge 1.00): extracted the one buried pharmacy-callback commitment (before 5pm) from a rambling multi-topic message, ignored the tangents."
+    }
+  ]
 }

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/adhd-capture-and-start.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/adhd-capture-and-start.catalog.json
@@ -20,6 +20,22 @@
       "surface": "scenario-runner",
       "status": "verified",
       "notes": "Live Cerebras gpt-oss-120b run passed (judge 1.00): extracted the one buried pharmacy-callback commitment (before 5pm) from a rambling multi-topic message, ignored the tangents."
+    },
+    {
+      "id": "adhd-medication-refill-fuzzy-date-capture",
+      "pack": "A1",
+      "tier": "T1",
+      "surface": "scenario-runner",
+      "status": "verified",
+      "notes": "Live Cerebras gpt-oss-120b passed (judge 1.00): fuzzy 'early next week' resolved to a concrete dated refill reminder (Wednesday morning)."
+    },
+    {
+      "id": "adhd-wait-no-correction-supersedes",
+      "pack": "A1",
+      "tier": "T1",
+      "surface": "scenario-runner",
+      "status": "verified",
+      "notes": "Live Cerebras gpt-oss-120b passed (judge 1.00): captured the corrected task (email Tom), created NO reminder for the superseded Sarah task (email-Sarah delta:0)."
     }
   ]
 }

--- a/plugins/plugin-personal-assistant/test/scenarios/adhd-buried-commitment-ramble.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/adhd-buried-commitment-ramble.scenario.ts
@@ -1,0 +1,58 @@
+/**
+ * A1 adhd-capture-and-start (live). casey_adhd sends a rambling, multi-topic
+ * message with exactly one load-bearing commitment buried inside it (a
+ * time-boxed pharmacy callback). The assistant must capture that one real task
+ * and not spawn a task for every tangent. Exercises existing capture/creation
+ * on the personas pack (#12283).
+ *
+ * Personas-as-data: the ADHD ramble lives in the turn text, never in
+ * `promptInstructions` (root AGENTS.md — one scheduler, structural fields only).
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "adhd-buried-commitment-ramble",
+  title: "ADHD: one load-bearing task buried in a rambling message",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "adhd", "personas", "12283"],
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "ADHD capture",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "casey rambles with one buried commitment",
+      text: "ok so brain is everywhere today — the neighbor's dog was barking, i still haven't watched that documentary everyone keeps talking about, coffee tasted weird, oh and i think mercury is retrograde again lol. anyway the thing i actually can't forget: i HAVE to call the pharmacy before 5pm today about my prescription refill or they close the request. that's the one.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "call the pharmacy",
+      titleAliases: [
+        "pharmacy",
+        "call pharmacy",
+        "prescription refill",
+        "refill",
+        "pharmacy about refill",
+      ],
+      delta: 1,
+    },
+    {
+      type: "judgeRubric",
+      name: "captured-the-buried-task-not-the-tangents",
+      minimumScore: 0.6,
+      rubric:
+        "The owner (ADHD) sent a rambling message full of tangents (barking dog, an unwatched documentary, weird coffee, mercury retrograde) with exactly ONE load-bearing commitment buried in it: call the pharmacy before 5pm today about a prescription refill. Grade PASS only if the assistant captured/scheduled the pharmacy-callback task (ideally with the before-5pm-today deadline) AND did NOT create tasks/reminders for the tangents (dog, documentary, coffee, retrograde). Deduct heavily if it spawned distractor tasks or missed the pharmacy commitment.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/adhd-medication-refill-fuzzy-date-capture.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/adhd-medication-refill-fuzzy-date-capture.scenario.ts
@@ -1,0 +1,57 @@
+/**
+ * A1 adhd-capture-and-start (live). casey_adhd asks to be reminded about a
+ * prescription refill with a fuzzy date ("early next week"). The assistant must
+ * capture it as a concrete dated reminder rather than dropping the timing.
+ * Exercises existing fuzzy-date capture on the personas pack (#12283).
+ *
+ * Personas-as-data: the framing lives in the turn text, never in
+ * `promptInstructions` (root AGENTS.md — one scheduler, structural fields only).
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "adhd-medication-refill-fuzzy-date-capture",
+  title: "ADHD: a fuzzy-dated refill captured as a dated reminder",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "adhd", "personas", "12283"],
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "ADHD capture",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "casey asks for a fuzzy-dated refill reminder",
+      text: "i always forget this — can you remind me to refill my adderall prescription early next week? whatever day makes sense, i just can't let it lapse.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "refill",
+      titleAliases: [
+        "refill adderall",
+        "refill prescription",
+        "adderall refill",
+        "prescription refill",
+        "refill medication",
+      ],
+      delta: 1,
+    },
+    {
+      type: "judgeRubric",
+      name: "fuzzy-date-captured-as-dated-reminder",
+      minimumScore: 0.6,
+      rubric:
+        "The owner asked to be reminded to refill an Adderall prescription 'early next week', giving a fuzzy timeframe rather than an exact date. Grade PASS only if the assistant captured/scheduled the refill reminder AND resolved the fuzzy timing into a concrete day/time early next week (rather than dropping the timing or refusing for lack of an exact date). Deduct if it created no reminder or ignored the 'early next week' timing entirely.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/adhd-wait-no-correction-supersedes.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/adhd-wait-no-correction-supersedes.scenario.ts
@@ -1,0 +1,62 @@
+/**
+ * A1 adhd-capture-and-start (live). casey_adhd starts a request, then
+ * self-corrects mid-message ("wait, no…"). The assistant must capture the
+ * CORRECTED task only, not the superseded one. Exercises existing in-message
+ * self-correction handling on the personas pack (#12283).
+ *
+ * Personas-as-data: the correction lives in the turn text, never in
+ * `promptInstructions` (root AGENTS.md — one scheduler, structural fields only).
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "adhd-wait-no-correction-supersedes",
+  title: "ADHD: a mid-message self-correction supersedes the first task",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "adhd", "personas", "12283"],
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "ADHD capture",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "casey self-corrects mid-message",
+      text: "remind me to email Sarah about the venue deposit tomorrow — wait no, not Sarah, it's Tom who handles the venue. remind me to email Tom about the venue deposit tomorrow.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "email Tom",
+      titleAliases: [
+        "email Tom about the venue",
+        "email Tom venue deposit",
+        "Tom venue deposit",
+        "venue deposit Tom",
+      ],
+      delta: 1,
+    },
+    {
+      type: "definitionCountDelta",
+      title: "email Sarah",
+      titleAliases: ["email Sarah about the venue", "Sarah venue deposit"],
+      delta: 0,
+    },
+    {
+      type: "judgeRubric",
+      name: "correction-supersedes-first-task",
+      minimumScore: 0.6,
+      rubric:
+        "The owner started to ask for a reminder to email Sarah, then self-corrected mid-message: 'wait no, not Sarah, it's Tom'. Grade PASS only if the assistant captured a reminder to email TOM about the venue deposit and did NOT also create a separate reminder to email Sarah. Deduct heavily if it created a Sarah reminder or captured both.",
+    },
+  ],
+});


### PR DESCRIPTION
## What & why

Follow-up to #12972 (merged, which landed the first B1 scenario). Adds the second
verified persona scenario for #12283, pack **A1 adhd-capture-and-start** (tier T1).

`plugins/plugin-personal-assistant/test/scenarios/adhd-buried-commitment-ramble.scenario.ts`
(`lane: "live-only"`). Premise from the issue's A1 table: *one load-bearing task
buried in a rambling multi-topic message*. casey_adhd sends a tangent-filled
message (barking dog, unwatched documentary, weird coffee, mercury retrograde)
with one real commitment inside — call the pharmacy before 5pm about a refill.
The assistant must capture that one task and not spawn tasks for the tangents.
Persona-as-data (ramble in the turn text, never `promptInstructions`).

## Verification — live run (Cerebras `gpt-oss-120b`), passed

```
| adhd-buried-commitment-ramble | passed | 7857ms |
```

Trajectory reviewed by hand: `actionsCalled: ["OWNER_REMINDERS"]`; reply *"The
reminder has been set: call the pharmacy before 5 PM today about your
prescription refill…"* — captured the one buried task **with** its deadline and
created **no** distractor tasks. `definitionCountDelta` matched "call the
pharmacy"; `judgeRubric` **1.00**. Report under
`.github/issue-evidence/12283-lifeops-personas/`.

Gates:
- `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs` → A1 1/28
  authored, **1/1 verified**.
- All four scenario-runner corpus ratchets green (14 tests) — live-only.

Relates to #12283, #12186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)