### PR TITLE
docs(#12756): clean plugin-vision prose headers

### DIFF
--- a/plugins/plugin-vision/auto-enable.ts
+++ b/plugins/plugin-vision/auto-enable.ts
@@ -1,9 +1,10 @@
-// Auto-enable check for @elizaos/plugin-vision.
-//
-// Plugin manifest entry-point — referenced by package.json's
-// `elizaos.plugin.autoEnableModule`. Keep this module light: env reads only,
-// no service init, no transitive imports of the full plugin runtime. The
-// auto-enable engine loads dozens of these per boot.
+/**
+ * Auto-enable predicate for @elizaos/plugin-vision.
+ *
+ * This package-manifest entrypoint stays limited to config inspection so the
+ * auto-enable engine can load it without initializing vision services or native
+ * detector dependencies.
+ */
 import type { PluginAutoEnableContext } from "@elizaos/core";
 
 function isFeatureEnabled(

--- a/plugins/plugin-vision/index.browser.ts
+++ b/plugins/plugin-vision/index.browser.ts
@@ -1,3 +1,8 @@
+/**
+ * Browser boundary export for plugin-vision; direct browser use is unsupported
+ * and callers should route vision work through a server-side runtime.
+ */
+
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 

--- a/plugins/plugin-vision/src/action.capture-hardening.test.ts
+++ b/plugins/plugin-vision/src/action.capture-hardening.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Hardening coverage for VISION capture inputs and media payload bounds.
+ */
+
 import {
   ContentType,
   type HandlerCallback,

--- a/plugins/plugin-vision/src/action.structured.test.ts
+++ b/plugins/plugin-vision/src/action.structured.test.ts
@@ -1,13 +1,13 @@
+/**
+ * Structured-parameter tests for VISION action operation and mode normalization.
+ *
+ * These pin planner-provided params as the source of truth and prevent raw
+ * message substring matching from reappearing.
+ */
+
 import { describe, expect, it } from "vitest";
 import { normalizeOp, normalizeVisionMode } from "./action-params";
 import { VisionMode } from "./types";
-
-/**
- * #10471 — the VISION action resolves its operation and mode from the planner's
- * STRUCTURED params, never from English keyword-matching the raw message text.
- * These pin that the removed keyword banks / substring parsing stay gone (and
- * that the old `"coffee".includes("off")` → OFF substring bug cannot recur).
- */
 
 describe("normalizeOp (structured op only)", () => {
   it("accepts canonical ops", () => {

--- a/plugins/plugin-vision/src/action.ts
+++ b/plugins/plugin-vision/src/action.ts
@@ -1,3 +1,8 @@
+/**
+ * Vision action handler that routes structured sub-operations for capture,
+ * describe, mode changes, entity naming, and screen element grounding.
+ */
+
 import {
   type Action,
   type ActionExample,

--- a/plugins/plugin-vision/src/audio-capture-stream.ts
+++ b/plugins/plugin-vision/src/audio-capture-stream.ts
@@ -1,3 +1,8 @@
+/**
+ * Streaming microphone capture service that chunks audio, detects speech
+ * boundaries, and routes transcription through the runtime model layer.
+ */
+
 import { type ChildProcess, spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import {
@@ -210,7 +215,7 @@ export class StreamingAudioCaptureService extends EventEmitter {
       }
     }
 
-    // Clean up old chunks (keep last 30 seconds)
+    // Retain only the rolling audio window needed for interruption context.
     const cutoffTime = timestamp - 30000;
     this.audioBuffer = this.audioBuffer.filter((c) => c.timestamp > cutoffTime);
   }

--- a/plugins/plugin-vision/src/audio-capture.ts
+++ b/plugins/plugin-vision/src/audio-capture.ts
@@ -1,3 +1,8 @@
+/**
+ * File-based audio capture service that records short clips from the host
+ * microphone and sends them through the runtime transcription model.
+ */
+
 import { exec } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";

--- a/plugins/plugin-vision/src/config.ts
+++ b/plugins/plugin-vision/src/config.ts
@@ -1,3 +1,8 @@
+/**
+ * Vision plugin configuration schema and runtime-setting parser for camera,
+ * screen, OCR, detector, and VLM update behavior.
+ */
+
 import { logger } from "@elizaos/core";
 import { z } from "zod";
 import type { VisionConfig, VisionMode } from "./types";

--- a/plugins/plugin-vision/src/describe-backpressure.test.ts
+++ b/plugins/plugin-vision/src/describe-backpressure.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Deterministic clock tests for the describe-loop backpressure controller.
+ */
+
 import { describe, expect, it } from "vitest";
 import { DescribeBackpressureController } from "./describe-backpressure";
 

--- a/plugins/plugin-vision/src/describe-backpressure.ts
+++ b/plugins/plugin-vision/src/describe-backpressure.ts
@@ -1,27 +1,17 @@
-// DescribeBackpressureController — the owner of the "run the expensive VLM
-// describe this tick?" decision for VisionService's continuous loops
-// (#9105 milestone 8 / #9581). The DirtyTileDescriber / full-frame
-// `IMAGE_DESCRIPTION` call is the dominant token + RAM cost of the loop; the
-// cheap OCR/YOLO/dHash steps keep running while describing is paused. Two
-// independent pause signals:
-//
-//   1. **Arbiter memory-pressure** — the external WS1 signal cascaded from
-//      `@elizaos/plugin-local-inference`'s MemoryArbiter (`memory_pressure`
-//      events). The WS1 bridge only delivers *pressure* events, never the
-//      recovery (`nominal`) edge, so a pressure signal pauses describing for a
-//      cooldown window and auto-resumes after that window of silence. A direct
-//      arbiter that does report `nominal` clears the pause immediately.
-//   2. **Local RSS GROWTH over a captured baseline** — a self-contained
-//      low-RAM guard (`MAX_MEMORY_USAGE_MB`) so the loop throttles even when no
-//      arbiter is registered (standalone / on-device), the common case for a
-//      local agent on a memory-constrained machine. The cap measures
-//      *vision-attributable growth* over the RSS baseline captured on the first
-//      describe tick — NOT absolute process RSS. A local agent mmaps multi-GB
-//      GGUF text + vision models, so its steady-state RSS routinely exceeds any
-//      reasonable MB cap; comparing absolute RSS to the cap would pause
-//      describing forever. Measuring growth over the loop's starting footprint
-//      means a large-but-steady baseline never trips the guard, while a genuine
-//      runaway still does. This signal is always-on and self-recovering:
+/**
+ * Backpressure controller for deciding whether VisionService should run the
+ * expensive IMAGE_DESCRIPTION step on a continuous-loop tick.
+ *
+ * DirtyTileDescriber and full-frame VLM calls dominate token and RAM cost, while
+ * OCR, YOLO, and dHash steps can keep running during a describe pause. Pauses
+ * come from either external memory-pressure events or local RSS growth measured
+ * over the loop's first-describe baseline, so large-but-steady model RSS does
+ * not permanently suppress describing.
+ *
+ * External WS1 pressure events pause for a cooldown because that bridge may not
+ * deliver the nominal recovery edge; direct arbiters that report nominal clear
+ * the pause immediately.
+ */
 //      describing resumes the moment RSS drops back within `baseline + cap`.
 //
 // While paused the describe step is skipped (backpressure) and the skip is

--- a/plugins/plugin-vision/src/eliza1-bridge.test.ts
+++ b/plugins/plugin-vision/src/eliza1-bridge.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Bridge tests for routing scene descriptions through the eliza-1 image model slot.
+ */
+
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { VisionService } from "./service";

--- a/plugins/plugin-vision/src/entity-tracker.ts
+++ b/plugins/plugin-vision/src/entity-tracker.ts
@@ -1,3 +1,8 @@
+/**
+ * In-memory entity tracker that turns detections into stable visual-world
+ * entities with active and recently-left presence windows.
+ */
+
 import { createUniqueUuid, type IAgentRuntime, logger } from "@elizaos/core";
 import type {
   BoundingBox,
@@ -263,12 +268,12 @@ export class EntityTracker {
       }
     }
 
-    // Clean up old "recently left" entries
+    // Recently-left entries are short-lived presence signals, not history.
     this.worldState.recentlyLeft = this.worldState.recentlyLeft.filter(
       (entry) => timestamp - entry.leftAt < this.CLEANUP_THRESHOLD,
     );
 
-    // Clean up very old entities
+    // Entities with no recent observations are evicted from the active world.
     for (const [entityId, entity] of this.worldState.entities) {
       if (timestamp - entity.lastSeen > this.CLEANUP_THRESHOLD * 10) {
         this.worldState.entities.delete(entityId);

--- a/plugins/plugin-vision/src/face-detector-ggml.ts
+++ b/plugins/plugin-vision/src/face-detector-ggml.ts
@@ -1,20 +1,11 @@
-// face-detector-ggml.ts — ggml-backed BlazeFace binding.
-//
-// bun:ffi binding for the BlazeFace head exposed by the standalone
-// `packages/native/plugins/face-cpp/` library. This is the ggml-backed
-// replacement for the removed ONNX detector surface. It
-// exposes the same surface (`MediaPipeFaceConfig`, `MediaPipeFaceDetection`,
-// `BlazeFaceGgmlDetector` modeled on `MediaPipeFaceDetector`) so existing
-// callers can opt into the native backend without touching call sites.
-//
-// The C ABI is frozen but some native builds return `-ENOSYS` from
-// `face_detect_open` / `face_detect`. `BlazeFaceGgmlDetector.isAvailable()`
-// returns false until both the compiled `libface.<so|dylib|dll>` and the
-// BlazeFace GGUF artifact exist.
-// Until those land, every public method falls through to a clear error —
-// there is no silent fallback to a different backend.
-//
-// See `packages/native/plugins/face-cpp/AGENTS.md` for the port plan.
+/**
+ * ggml-backed BlazeFace binding for the native face-cpp detector surface.
+ *
+ * The C ABI is fixed, but native builds may report unsupported operations until
+ * both the compiled library and BlazeFace GGUF artifact are present. Availability
+ * checks return false until the full detector path can run, and public methods
+ * fail clearly rather than falling back to another backend.
+ */
 
 import { promises as fs } from "node:fs";
 import * as os from "node:os";

--- a/plugins/plugin-vision/src/face-detector-mediapipe.ts
+++ b/plugins/plugin-vision/src/face-detector-mediapipe.ts
@@ -1,12 +1,11 @@
-// face-detector-mediapipe.ts — DEPRECATED.
-//
-// The previous implementation used `onnxruntime-node` to run BlazeFace. That
-// backend is no longer shipped. This compatibility class reports unavailable
-// and the runtime uses the configured face-recognition backend instead.
-//
-// Kept as a migration shim so existing imports (test fixtures) continue to
-// compile without touching the test layout. The class is internal and not
-// wired into the production `VisionService`.
+/**
+ * Compatibility face-detector surface for callers that still import the
+ * MediaPipe-shaped BlazeFace types.
+ *
+ * The runtime uses the configured ggml face backend; this internal class reports
+ * unavailable so stale imports keep compiling without becoming a production
+ * detector path.
+ */
 
 import { logger } from "@elizaos/core";
 import type { BoundingBox } from "./types";

--- a/plugins/plugin-vision/src/face-recognition-ggml.distance.test.ts
+++ b/plugins/plugin-vision/src/face-recognition-ggml.distance.test.ts
@@ -1,10 +1,12 @@
+/**
+ * Geometry tests for face-embedding distance helpers used by identity matching.
+ */
+
 import { describe, expect, it } from "vitest";
 import { cosineDistance, l2Distance } from "./face-recognition-ggml.js";
 
 const f = (...v: number[]) => new Float32Array(v);
 
-// #9105 vision — face-embedding distance metrics gate identity matching, so
-// their geometry must be exact (and dimension mismatches must fail loud).
 describe("face-recognition distance metrics", () => {
   it("cosineDistance: 0 identical, 1 orthogonal, 2 opposite (unit vectors)", () => {
     expect(cosineDistance(f(1, 0), f(1, 0))).toBeCloseTo(0, 6);

--- a/plugins/plugin-vision/src/face-recognition-ggml.ts
+++ b/plugins/plugin-vision/src/face-recognition-ggml.ts
@@ -1,22 +1,12 @@
-// face-recognition-ggml.ts — native ggml face recognition.
-//
-// bun:ffi binding for the face-embed head exposed by the standalone
-// `packages/native/plugins/face-cpp/` library, plus the full
-// `FaceRecognition` surface (detect → embed → match → store) consumed by
-// `VisionService`. This is the only face-recognition backend; there is no
-// tfjs / face-api.js fallback.
-//
-// The native library produces a 128-d L2-normalized embedding from a
-// `face_detection` record (bbox + 6 BlazeFace landmarks). That detection
-// is what `BlazeFaceGgmlDetector` returns, so the pipeline is:
-//
-//   const det = await blazefaceDetector.detect(buffer);
-//   const emb = await embedder.embed(buffer, det[i]);
-//
-// `FaceEmbedGgmlRecognizer` owns only the embedding step; the matching,
-// storage, and persistence that make up the `FaceLibrary` surface live in
-// the `FaceRecognition` class below. Cosine + L2 distance helpers mirror
-// `face_embed_distance` / `face_embed_distance_l2`.
+/**
+ * Native ggml face-recognition pipeline for detection, embedding, matching,
+ * and in-memory identity storage.
+ *
+ * The native library produces 128-dimensional L2-normalized embeddings from
+ * BlazeFace detections. `FaceEmbedGgmlRecognizer` owns only embedding; matching
+ * and persistence live in `FaceRecognition`. There is no tfjs or face-api
+ * fallback path.
+ */
 
 import { promises as fs } from "node:fs";
 import * as os from "node:os";

--- a/plugins/plugin-vision/src/fusion-prompt.test.ts
+++ b/plugins/plugin-vision/src/fusion-prompt.test.ts
@@ -1,10 +1,9 @@
-// fusion-prompt.test.ts — buildSceneDescriptionPrompt detector fusion (#9105).
-//
-// The Gemma-4 VLM describe prompt must carry the detectors' output (OCR text,
-// YOLO objects, recognized faces) as additional context alongside the image.
-// These assert the pure prompt-builder injects each detector channel, caps and
-// dedupes them, and omits the keys entirely when a channel is empty so the
-// detection-off path is byte-for-byte unchanged.
+/**
+ * Prompt-fusion coverage for injecting detector output into VLM scene descriptions.
+ *
+ * OCR text, YOLO objects, and recognized faces are added as bounded context while
+ * the detection-off path remains byte-for-byte unchanged.
+ */
 
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-vision/src/get-screen-elements.test.ts
+++ b/plugins/plugin-vision/src/get-screen-elements.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Screen-element fusion tests for merging OCR, accessibility, and VLM boxes.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   type AxNodeLike,

--- a/plugins/plugin-vision/src/image-input.test.ts
+++ b/plugins/plugin-vision/src/image-input.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Image input validation tests for encoded buffers and model-safe data URLs.
+ */
+
 import sharp from "sharp";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-vision/src/image-input.ts
+++ b/plugins/plugin-vision/src/image-input.ts
@@ -1,3 +1,8 @@
+/**
+ * Image validation helpers for action inputs and captures before they are sent
+ * to vision models or returned as media attachments.
+ */
+
 import { getSharp, type SharpMetadata } from "./image/sharp-compat";
 
 export const MAX_VISION_IMAGE_BYTES = 25 * 1024 * 1024;

--- a/plugins/plugin-vision/src/image/sharp-compat.test.ts
+++ b/plugins/plugin-vision/src/image/sharp-compat.test.ts
@@ -1,9 +1,9 @@
-// sharp-compat.test.ts — diff the pure-JS shim against native sharp.
-//
-// Native sharp is available in this Linux worktree, so every op the shim
-// implements is compared directly against sharp's output on small generated
-// images. This proves the fallback is faithful for the operations the
-// codebase uses on the mobile path.
+/**
+ * Compatibility tests that diff the pure-JS image shim against native sharp.
+ *
+ * Native sharp is available in this Linux lane, so each supported shim operation
+ * is compared on small generated images for the mobile fallback path.
+ */
 
 import sharp from "sharp";
 import { describe, expect, it } from "vitest";

--- a/plugins/plugin-vision/src/image/sharp-compat.ts
+++ b/plugins/plugin-vision/src/image/sharp-compat.ts
@@ -1,18 +1,11 @@
-// sharp-compat.ts — lazy sharp resolver + pure-JS fallback.
-//
-// plugin-vision is loadable on mobile (Android bun-musl) only if its module
-// graph does not pull native code at module-eval. `sharp` loads the libvips
-// native addon the moment it is imported, so every runtime call site goes
-// through `getSharp()` here, which imports `sharp` *dynamically* (inside the
-// function) and caches the resolved factory. On a host where the native
-// binary loads (desktop glibc/musl), that is real `sharp` and performance is
-// unchanged. Where it cannot load, `getSharp()` returns a pure-JS shim backed
-// by `jimp` (no native deps) that is API-compatible for exactly the operations
-// the codebase uses: metadata, resize{fit:"fill"}, removeAlpha, ensureAlpha,
-// extract, extend, trim, clone, png, jpeg, raw, toBuffer.
-//
-// The shim is not a general sharp reimplementation — it implements the subset
-// in `sharp-compat.test.ts`, which diffs shim output against native sharp.
+/**
+ * Lazy image processing resolver that keeps plugin-vision loadable on mobile.
+ *
+ * Runtime call sites reach native sharp through dynamic import so Android
+ * bun-musl does not evaluate libvips at module load. Hosts without native sharp
+ * receive a Jimp-backed shim for the exact operations covered in
+ * `sharp-compat.test.ts`.
+ */
 
 import { deflateSync } from "node:zlib";
 import { Jimp, JimpMime } from "jimp";

--- a/plugins/plugin-vision/src/index.ts
+++ b/plugins/plugin-vision/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Runtime plugin registration for vision services, actions, providers, routes,
+ * OCR backends, and computeruse bridge providers.
+ */
+
 import type { Plugin } from "@elizaos/core";
 import {
   isAndroidMobile,

--- a/plugins/plugin-vision/src/lifecycle.integration.test.ts
+++ b/plugins/plugin-vision/src/lifecycle.integration.test.ts
@@ -1,5 +1,6 @@
-// Integration test: simulate a memory-pressure event on a fake arbiter and
-// verify that registered vision sub-services (YOLO + OCR) get released.
+/**
+ * Lifecycle integration test for releasing registered vision sub-services on pressure.
+ */
 
 import { describe, expect, it, vi } from "vitest";
 import { type IModelArbiter, VisionServiceLifecycleManager } from "./lifecycle";

--- a/plugins/plugin-vision/src/lifecycle.test.ts
+++ b/plugins/plugin-vision/src/lifecycle.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Deterministic lifecycle-manager tests for idle unloads and arbiter wiring.
+ */
+
 import { describe, expect, it, vi } from "vitest";
 import {
   type IModelArbiter,

--- a/plugins/plugin-vision/src/lifecycle.ts
+++ b/plugins/plugin-vision/src/lifecycle.ts
@@ -1,19 +1,12 @@
-// VisionServiceLifecycleManager
-//
-// Manages dynamic load/unload of vision sub-services (YOLO, RapidOCR,
-// MediaPipe face, MoveNet pose). Two ownership signals drive release:
-//
-//   1. **Idle watchdog** — if a sub-service hasn't been queried for
-//      `idleUnloadMs` (default 60s), it's released.
-//   2. **Memory-pressure listener** — when an external arbiter signals
-//      pressure, the coldest sub-services are released first.
-//
-// The arbiter is owned by WS1 (`@elizaos/plugin-local-inference`). Until that
-// service is registered on the runtime we operate in standalone mode: idle
-// watchdog still ticks, but no external pressure signal arrives.
-//
-// Acquisition is opt-in: a sub-service that registers an `acquire` callback
-// will be re-loaded on demand the next time it's used after a release.
+/**
+ * Lifecycle manager for dynamically loading and releasing vision sub-services
+ * such as YOLO, OCR, face detection, and pose backends.
+ *
+ * Releases are driven by idle time and optional external memory-pressure
+ * signals. When no arbiter is registered, the idle watchdog still runs in
+ * standalone mode. Services that provide an acquire callback are reloaded on
+ * demand after release.
+ */
 
 import { logger } from "@elizaos/core";
 

--- a/plugins/plugin-vision/src/mobile/capacitor-camera.test.ts
+++ b/plugins/plugin-vision/src/mobile/capacitor-camera.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Mobile camera registry and Capacitor bridge tests for native frame sources.
+ */
+
 import { afterEach, describe, expect, it } from "vitest";
 import type { MobileCameraSource } from "./capacitor-camera";
 import {

--- a/plugins/plugin-vision/src/mobile/capacitor-camera.ts
+++ b/plugins/plugin-vision/src/mobile/capacitor-camera.ts
@@ -1,13 +1,10 @@
-// MobileCameraSource — JS contract for native Capacitor / AOSP camera bridges.
-//
-// This file defines the JS contract and a small Capacitor bridge adapter. The
-// native sides (Android CameraX via plugin-aosp, iOS AVFoundation via
-// plugin-ios) expose matching methods through `Capacitor.Plugins.ElizaVision`.
-//
-// The JS surface stays stable while native camera plugins register concrete
-// sources. Anything in plugin-vision that needs a mobile camera goes through
-// `MobileCameraSource`, never directly through `imagesnap` / `fswebcam` /
-// `ffmpeg`.
+/**
+ * JavaScript contract and Capacitor adapter for native mobile camera sources.
+ *
+ * Android CameraX and iOS AVFoundation bridges expose matching methods through
+ * `Capacitor.Plugins.ElizaVision`. Runtime camera consumers go through
+ * `MobileCameraSource` instead of shelling out to desktop capture tools.
+ */
 
 import { logger } from "@elizaos/core";
 import type { CameraInfo, VisionFrame } from "../types";

--- a/plugins/plugin-vision/src/ocr-bridge.test.ts
+++ b/plugins/plugin-vision/src/ocr-bridge.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Queue and timeout tests for renderer-driven OCR bridge requests.
+ */
+
 import { describe, expect, it } from "vitest";
 import { OcrBridgeService, type OcrBridgeWord } from "./ocr-bridge.js";
 

--- a/plugins/plugin-vision/src/ocr-bridge.ts
+++ b/plugins/plugin-vision/src/ocr-bridge.ts
@@ -1,3 +1,8 @@
+/**
+ * Runtime service for renderer-provided OCR requests, used by mobile/native
+ * bridges that can read text from captured screen images.
+ */
+
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
 
 export const OCR_BRIDGE_SERVICE_TYPE = "vision-ocr-bridge";

--- a/plugins/plugin-vision/src/ocr-service-android-bridge.test.ts
+++ b/plugins/plugin-vision/src/ocr-service-android-bridge.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Mapping tests for native Android OCR words into shared OCR result records.
+ */
+
 import { describe, expect, it } from "vitest";
 import type { OcrBridgeWord } from "./ocr-bridge.js";
 import { mapOcrWordsToResult } from "./ocr-service-android-bridge.js";

--- a/plugins/plugin-vision/src/ocr-service-android-bridge.ts
+++ b/plugins/plugin-vision/src/ocr-service-android-bridge.ts
@@ -1,3 +1,8 @@
+/**
+ * Coordinate-aware OCR adapter that delegates screen-image recognition to the
+ * Android renderer bridge and maps returned words into vision OCR blocks.
+ */
+
 import { type IAgentRuntime, logger } from "@elizaos/core";
 import {
   OCR_BRIDGE_SERVICE_TYPE,

--- a/plugins/plugin-vision/src/ocr-service-doctr.ts
+++ b/plugins/plugin-vision/src/ocr-service-doctr.ts
@@ -1,20 +1,12 @@
-// doctr-based OCR backend — ggml runtime via `native/doctr.cpp/`.
-//
-// Replaces the previous PP-OCRv5 / onnxruntime-node path. Two-stage pipeline:
-//   1. Detection (db_mobilenet_v3_large + DBNet head) — produces a probability
-//      map at H/4 × W/4.
-//   2. Contour → bbox post-processing (this file).
-//   3. Recognition (crnn_mobilenet_v3_small + CTC) — per-crop logits.
-//   4. CTC greedy decode (this file).
-//
-// The C++ side runs only the forward passes. Post-processing is pure TS to
-// keep the native surface minimal and to share the same decode logic with
-// native OCR providers that return logits. Apple Vision returns text directly so its
-// recognition path skips steps 2-4).
-//
-// **No fallback** — if doctr.cpp + GGUFs aren't available the service throws
-// a clear error and the chain in `ocr-service.ts` falls through to the next
-// backend (apple-vision on darwin) or surfaces the error to the caller.
+/**
+ * doCTR OCR backend using the ggml runtime under `native/doctr.cpp`.
+ *
+ * The native side runs DBNet/CRNN forward passes; TypeScript owns contour
+ * post-processing and CTC greedy decode so the native ABI stays small and the
+ * decode logic can be shared. If libraries or GGUFs are unavailable, this
+ * backend throws clearly and the OCR chain decides whether another backend can
+ * handle the request.
+ */
 
 import { logger } from "@elizaos/core";
 import { getSharp } from "./image/sharp-compat";

--- a/plugins/plugin-vision/src/ocr-service-paddleocr.test.ts
+++ b/plugins/plugin-vision/src/ocr-service-paddleocr.test.ts
@@ -1,15 +1,16 @@
+/**
+ * Parser and mapper tests for the PaddleOCR Python wrapper JSON contract.
+ *
+ * CI exercises the pure conversion path without requiring a real PaddleOCR
+ * install while keeping the wrapper and parser shape anchored.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   mapPaddleOcrJsonToResult,
   parsePaddleOcrJson,
 } from "./ocr-service-paddleocr.js";
 
-/**
- * The PaddleOCR provider (#9581) drives a Python wrapper that emits a stable
- * JSON shape (`[{ box:[[x,y]x4], text, conf }, …]`). These tests pin the pure
- * parser + mapper against that contract so CI never needs a real PaddleOCR
- * install and the wrapper↔parser format has a single source of truth.
- */
 describe("parsePaddleOcrJson (#9581)", () => {
   it("parses well-formed detections", () => {
     const json = JSON.stringify([

--- a/plugins/plugin-vision/src/ocr-service.test.ts
+++ b/plugins/plugin-vision/src/ocr-service.test.ts
@@ -1,3 +1,7 @@
+/**
+ * OCR service tests for backend availability and structured text extraction.
+ */
+
 import { describe, expect, it } from "vitest";
 import { extractStructuredDataFromOCR, OCRService } from "./ocr-service";
 import { DoctrOCRService, shouldPreferAppleVision } from "./ocr-service-doctr";

--- a/plugins/plugin-vision/src/ocr-service.ts
+++ b/plugins/plugin-vision/src/ocr-service.ts
@@ -1,3 +1,8 @@
+/**
+ * OCR backend chain for plugin-vision, selecting Apple Vision or doCTR and
+ * adapting extracted text into the plugin's screen-tile result shape.
+ */
+
 import { logger } from "@elizaos/core";
 import { assertValidVisionImageBuffer } from "./image-input";
 import { DoctrOCRService, shouldPreferAppleVision } from "./ocr-service-doctr";
@@ -11,7 +16,7 @@ export interface OCRServiceConfig {
    *   1. Apple Vision (darwin only, when a provider has been registered)
    *   2. doCTR (ggml-backed CRNN+DBNet via native/doctr.cpp)
    *
-   * There is no tesseract / onnx fallback — the migration removed both.
+   * Tesseract and ONNX are intentionally outside this backend chain.
    * If neither backend can initialize, `initialize()` throws.
    */
   backend?: OCRBackendName;

--- a/plugins/plugin-vision/src/person-detector.ts
+++ b/plugins/plugin-vision/src/person-detector.ts
@@ -1,14 +1,10 @@
-// PersonDetector — dedicated person-detection model.
-//
-// Strategy:
-//   - Default to a class-filtered YOLOv8n run ("person"-only). This is fast,
-//     accurate, and reuses a single model file for both general object
-//     detection and person detection.
-//   - Pose data (keypoints) is not produced here; a ggml pose backend is
-//     pending, and the service falls back to heuristic person detection.
-//
-// Returning `PersonInfo` rather than a generic detection makes this a drop-in
-// replacement for the heuristic person detection in `service.ts`.
+/**
+ * Person detector that adapts class-filtered YOLO detections into `PersonInfo`
+ * records for the vision service.
+ *
+ * Pose keypoints are not produced here; callers combine this with heuristic or
+ * future pose backends when they need orientation data.
+ */
 
 import { logger } from "@elizaos/core";
 import type { PersonInfo } from "./types";

--- a/plugins/plugin-vision/src/provider.test.ts
+++ b/plugins/plugin-vision/src/provider.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Provider tests for composing fresh and stale vision context into agent state.
+ */
+
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { visionProvider } from "./provider";

--- a/plugins/plugin-vision/src/provider.ts
+++ b/plugins/plugin-vision/src/provider.ts
@@ -1,3 +1,8 @@
+/**
+ * Context provider that injects current visual perception state into media and
+ * browser turns without exposing unbounded detection lists to the prompt.
+ */
+
 import {
   type IAgentRuntime,
   logger,

--- a/plugins/plugin-vision/src/routes.ocr.test.ts
+++ b/plugins/plugin-vision/src/routes.ocr.test.ts
@@ -1,3 +1,7 @@
+/**
+ * HTTP route tests for draining OCR bridge requests and accepting native results.
+ */
+
 import { describe, expect, it } from "vitest";
 import { OcrBridgeService, type OcrBridgeWord } from "./ocr-bridge.js";
 import { ocrRequestsRoute, ocrResultRoute } from "./routes.js";

--- a/plugins/plugin-vision/src/routes.ts
+++ b/plugins/plugin-vision/src/routes.ts
@@ -1,9 +1,10 @@
-// Renderer-pull routes for the Android screen-capture bridge.
-//
-// The renderer interval-polls the GET route to drain queued capture requests,
-// captures each via the Capacitor ScreenCapture plugin, then POSTs the PNG
-// back to the POST route. Both mount at their exact paths (`rawPath: true`)
-// because the Android JNI loopback forwards by literal `/api/...` path.
+/**
+ * Renderer-pulled routes for Android screen capture and OCR bridge traffic.
+ *
+ * The renderer polls for queued capture/OCR requests, performs native
+ * Capacitor work, then posts results back to exact raw paths because the Android
+ * JNI loopback forwards literal `/api/...` paths.
+ */
 
 import type { Route } from "@elizaos/core";
 import {

--- a/plugins/plugin-vision/src/screen-capture-bridge.test.ts
+++ b/plugins/plugin-vision/src/screen-capture-bridge.test.ts
@@ -1,5 +1,9 @@
-// Pure correlation tests for the renderer-pulled screen-capture bridge.
-// No device, no Capacitor — exercises the request/queue/submit handshake only.
+/**
+ * Pure correlation tests for the renderer-pulled screen-capture bridge.
+ *
+ * These cover the request, queue, and submit handshake without a device or
+ * Capacitor host.
+ */
 
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-vision/src/screen-capture-bridge.ts
+++ b/plugins/plugin-vision/src/screen-capture-bridge.ts
@@ -1,13 +1,10 @@
-// Android agent-triggered screen-capture bridge (renderer-pulled).
-//
-// On Android the agent runs in a musl bun process with no Capacitor and no
-// agent->renderer push channel (the local-IPC base never opens a WebSocket).
-// So screen capture is renderer-PULLED: the agent enqueues a capture request
-// here; the renderer interval-polls `GET /api/vision/capture-requests`, takes a
-// frame via the Capacitor ScreenCapture plugin (MediaProjection), and POSTs the
-// PNG back to `POST /api/vision/screen-frame`, which calls `submitFrame` to
-// resolve the matching pending promise. The JNI loopback already forwards any
-// `/api/...` path, so no Java/Kotlin change is needed.
+/**
+ * Android screen-capture bridge for agent-triggered, renderer-pulled frames.
+ *
+ * The agent runs outside Capacitor and cannot push to the renderer, so it
+ * enqueues requests here. The renderer polls, captures via MediaProjection, and
+ * posts PNG frames back to resolve matching promises.
+ */
 
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
 

--- a/plugins/plugin-vision/src/screen-capture.ts
+++ b/plugins/plugin-vision/src/screen-capture.ts
@@ -1,3 +1,8 @@
+/**
+ * Host screen capture implementation for desktop platforms, including command
+ * selection, image decoding, and tiling for local vision model input.
+ */
+
 import { exec } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
@@ -206,7 +211,7 @@ export class ScreenCaptureService {
         activeTile.data = activeTilerTile.pngBytes;
       }
 
-      // Clean up temp file
+      // Command-line capture tools write through a temporary image file.
       await fs.unlink(tempFile).catch(() => {});
 
       // Create screen capture object
@@ -221,7 +226,7 @@ export class ScreenCaptureService {
       this.lastCapture = capture;
       return capture;
     } catch (error) {
-      // Clean up temp file on error
+      // Failed captures still need to release temporary image files.
       await fs.unlink(tempFile).catch(() => {});
       throw error;
     }

--- a/plugins/plugin-vision/src/screen-tiler.test.ts
+++ b/plugins/plugin-vision/src/screen-tiler.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Screenshot tiling tests for tile dimensions and absolute-coordinate recovery.
+ */
+
 import sharp from "sharp";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-vision/src/service-backpressure-wiring.test.ts
+++ b/plugins/plugin-vision/src/service-backpressure-wiring.test.ts
@@ -1,15 +1,14 @@
+/**
+ * Integration coverage for VisionService wiring into describe-loop backpressure.
+ *
+ * The pure controller is unit-tested separately; this file exercises runtime
+ * arbiter subscription, pressure propagation, manual resume, stats, and stop cleanup.
+ */
+
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import type { IModelArbiter } from "./lifecycle";
 import { VisionService } from "./service";
-
-// Integration coverage for the VisionService ↔ DescribeBackpressureController
-// wiring shipped in PR #9688 (#9581 / #9105 M8). The pure controller is unit-
-// tested in describe-backpressure.test.ts and the WS1 bridge in
-// ws1-arbiter-bridge.test.ts; this file exercises the service glue itself:
-// attachMemoryArbiter() resolving + subscribing the arbiter, the onPressure →
-// setPressure("critical") cascade, resumeDescribeLoop(), getBackpressureStats(),
-// idempotent re-attach, and unsubscribe on stop().
 
 type PressureCb = (holders: string[]) => void;
 

--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -1,4 +1,7 @@
-// Vision service for camera integration and scene analysis
+/**
+ * Long-running vision service for camera/screen capture, scene description,
+ * OCR, object/person detection, entity tracking, and audio transcription.
+ */
 
 import { exec } from "node:child_process";
 import * as fs from "node:fs/promises";
@@ -2241,12 +2244,12 @@ export class VisionService extends Service {
           // Read the captured image
           const imageBuffer = await fs.readFile(tempFile);
 
-          // Clean up temp file
+          // Command-line camera tools write through a temporary image file.
           await fs.unlink(tempFile).catch(() => {});
 
           return imageBuffer;
         } catch (error) {
-          // Clean up temp file on error
+          // Failed captures still need to release temporary image files.
           await fs.unlink(tempFile).catch(() => {});
           throw error;
         }

--- a/plugins/plugin-vision/src/tests/e2e/screen-vision.ts
+++ b/plugins/plugin-vision/src/tests/e2e/screen-vision.ts
@@ -1,3 +1,7 @@
+/**
+ * End-to-end screen-vision suite for OCR and image-description runtime behavior.
+ */
+
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { createUniqueUuid } from "@elizaos/core";
 import { visionAction } from "../../action";

--- a/plugins/plugin-vision/src/tests/e2e/vision-runtime.ts
+++ b/plugins/plugin-vision/src/tests/e2e/vision-runtime.ts
@@ -1,3 +1,7 @@
+/**
+ * Runtime smoke suite for plugin-vision service, provider, and action surfaces.
+ */
+
 import type { Action, Content, IAgentRuntime, Provider } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import type { VisionService } from "../../service";

--- a/plugins/plugin-vision/src/tests/e2e/vision-worker-tests.ts
+++ b/plugins/plugin-vision/src/tests/e2e/vision-worker-tests.ts
@@ -1,3 +1,7 @@
+/**
+ * End-to-end worker suite for screen capture, OCR, and threaded vision paths.
+ */
+
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import type { IAgentRuntime } from "@elizaos/core";

--- a/plugins/plugin-vision/src/tests/test-pattern-generator.ts
+++ b/plugins/plugin-vision/src/tests/test-pattern-generator.ts
@@ -1,3 +1,7 @@
+/**
+ * Generated image fixtures for exercising screen tiling and OCR geometry paths.
+ */
+
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { logger } from "@elizaos/core";

--- a/plugins/plugin-vision/src/toggle-actions.test.ts
+++ b/plugins/plugin-vision/src/toggle-actions.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Toggle-action tests for transitions between camera, screen, both, and off modes.
+ */
+
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { VisionService } from "./service";

--- a/plugins/plugin-vision/src/trajectory.test.ts
+++ b/plugins/plugin-vision/src/trajectory.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Trajectory logging tests for image-description calls made by VisionService.
+ */
+
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { VisionService } from "./service";

--- a/plugins/plugin-vision/src/types.ts
+++ b/plugins/plugin-vision/src/types.ts
@@ -1,3 +1,8 @@
+/**
+ * Shared contracts for plugin-vision services, detections, scene descriptions,
+ * screen tiles, OCR results, and tracked visual entities.
+ */
+
 import type { DescribePauseReason } from "./describe-backpressure";
 
 export const VisionServiceType = {

--- a/plugins/plugin-vision/src/vision-context-augmenter.test.ts
+++ b/plugins/plugin-vision/src/vision-context-augmenter.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Vision context augmenter tests for OCR, object, and face prompt enrichment.
+ */
+
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-vision/src/vision-worker-manager.ts
+++ b/plugins/plugin-vision/src/vision-worker-manager.ts
@@ -1,3 +1,8 @@
+/**
+ * Worker-thread manager for offloading screen capture and OCR processing from
+ * the main vision service loop.
+ */
+
 import * as path from "node:path";
 import { TextDecoder } from "node:util";
 import { Worker } from "node:worker_threads";

--- a/plugins/plugin-vision/src/workers/ocr-worker.ts
+++ b/plugins/plugin-vision/src/workers/ocr-worker.ts
@@ -1,3 +1,7 @@
+/**
+ * Worker-thread OCR loop that reads captured frames from shared buffers.
+ */
+
 import { parentPort, workerData } from "node:worker_threads";
 import { getSharp } from "../image/sharp-compat";
 import { OCRService } from "../ocr-service";

--- a/plugins/plugin-vision/src/workers/screen-capture-worker.ts
+++ b/plugins/plugin-vision/src/workers/screen-capture-worker.ts
@@ -1,3 +1,7 @@
+/**
+ * Worker-thread screen capture loop that writes frames into shared buffers.
+ */
+
 import { exec } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
@@ -315,10 +319,10 @@ class ScreenCaptureWorker {
         Atomics.store(this.atomicState, this.WRITE_LOCK_INDEX, 0);
       }
 
-      // Clean up temp file
+      // Each capture owns one temporary image file.
       await fs.unlink(tempFile).catch(() => {});
     } catch (error) {
-      // Clean up temp file on error
+      // Failed captures leave the same temporary file path behind.
       await fs.unlink(tempFile).catch(() => {});
       throw error;
     }

--- a/plugins/plugin-vision/src/workers/worker-logger.ts
+++ b/plugins/plugin-vision/src/workers/worker-logger.ts
@@ -1,8 +1,9 @@
+/**
+ * Worker-safe logger that forwards worker-thread log messages to the main thread.
+ */
+
 import { parentPort } from "node:worker_threads";
 
-/**
- * Worker-safe logger that sends log messages to the main thread
- */
 export const logger = {
   info: (message: string, ...args: unknown[]) => {
     const logMessage = {

--- a/plugins/plugin-vision/src/yolo-detector.test.ts
+++ b/plugins/plugin-vision/src/yolo-detector.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Detector lifecycle tests for YOLO, person, and MediaPipe face adapters.
+ */
+
 import { describe, expect, it } from "vitest";
 import { MediaPipeFaceDetector } from "./face-detector-mediapipe";
 import { PersonDetector } from "./person-detector";

--- a/plugins/plugin-vision/src/yolo-detector.ts
+++ b/plugins/plugin-vision/src/yolo-detector.ts
@@ -1,17 +1,11 @@
-// YOLO object detector — ggml runtime via `native/yolo.cpp/`.
-//
-// Replaces COCO-SSD (TensorFlow.js) and the prior onnxruntime-node YOLO
-// path. Default model is YOLOv8n COCO (80 classes). Weights are NOT bundled
-// in the npm package — they're fetched / built into a per-user state dir
-// (`<state-dir>/models/vision/yolov8n.gguf`).
-//
-// Pipeline:
-//   1. Letterbox + RGB CHW normalize to 640x640 (this file).
-//   2. Forward pass (yolo.cpp via bun:ffi).
-//   3. parseYoloV8 — decode (cx, cy, w, h, scores) per anchor.
-//   4. NMS.
-//
-// **No fallback.** If the native lib or GGUF is missing, init throws.
+/**
+ * ggml-backed YOLOv8 detector for object boxes produced by native/yolo.cpp.
+ *
+ * Weights are resolved from the per-user state directory rather than bundled in
+ * npm. This module owns letterboxing, tensor normalization, YOLOv8 output
+ * decoding, and NMS. If the native library or GGUF is missing, initialization
+ * throws instead of silently falling back.
+ */
 
 import { logger } from "@elizaos/core";
 import { getSharp } from "./image/sharp-compat";

--- a/plugins/plugin-vision/vitest.config.ts
+++ b/plugins/plugin-vision/vitest.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Vitest configuration for plugin-vision unit and integration suites.
+ */
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Add package-standard prose headers across plugin-vision source, test, worker, and config files missing them.
- Convert filename/change-history style top comments into durable system-purpose prose.
- Clean a few churn-style implementation comments while preserving code tokens.

## Verification
- `bun run check:comment-only`
- header audit: 99 files scanned, 0 missing top prose headers
- `git diff --check -- plugins/plugin-vision`
- `bun run --cwd plugins/plugin-vision lint:check`
- `bun run --cwd plugins/plugin-vision typecheck`
- `bun run --cwd plugins/plugin-vision test` (38 files, 240 passed, 4 skipped)
- `bun run verify` attempted; blocked before workspace checks by sparse checkout missing `packages/auth/AGENTS.md` in `check:agents-claude`

## Notes
- Added `packages/cloud/routing` to the local sparse checkout and built that dependency so plugin-vision tests could resolve `@elizaos/cloud-routing`; generated dist artifacts are ignored and not part of this PR.

Closes #12756