### PR TITLE
fix(lifeops): recurring-trigger death on no-reply retry, negative-offset schedule fire-storm, contact-edit wipes edge interaction state

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/domains/relationships-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/relationships-service.ts
@@ -96,15 +96,27 @@ export class RelationshipsDomain {
         : (existing?.state ?? {}),
     });
 
+    // `RelationshipStore.upsert` is a full-replace write (`state_* =
+    // EXCLUDED.state_*`), so the edge's interaction-recency state must be
+    // carried forward explicitly: a contact edit that doesn't set
+    // `lastContactedAt` (notes/tags update, re-add via the dedup path) would
+    // otherwise wipe `lastInteractionAt` + `interactionCount` and make the
+    // cadence-overdue check nag about a contact the owner just talked to.
+    const existingEdge = await relationshipStore.get(
+      contactEdgeId(entity.entityId),
+    );
     const edge = await relationshipStore.upsert({
       relationshipId: contactEdgeId(entity.entityId),
       fromEntityId: SELF_ENTITY_ID,
       toEntityId: entity.entityId,
       type: input.relationshipType || "contact",
       metadata: { ...input.metadata },
-      state: input.lastContactedAt
-        ? { lastInteractionAt: input.lastContactedAt }
-        : {},
+      state: {
+        ...(existingEdge?.state ?? {}),
+        ...(input.lastContactedAt
+          ? { lastInteractionAt: input.lastContactedAt }
+          : {}),
+      },
       evidence: [LIFEOPS_CONTACT_TAG],
       confidence: 1,
       source: "import",

--- a/plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit coverage for the relative-schedule resolver's baseline-projection
+ * branch. Pins the invariant the workflow scheduler loop depends on: the
+ * resolved instant is strictly AFTER the cursor, including for negative-offset
+ * schedules (during_night / "before bedtime") whose fire instant precedes the
+ * projected anchor. Deterministic vitest, no runtime.
+ */
+import { describe, expect, it } from "vitest";
+import { resolveNextRelativeScheduleInstant } from "./relative-schedule-resolver.js";
+import type { LifeOpsScheduleMergedStateRecord } from "./repository.js";
+
+/**
+ * Minimal merged-state fixture: very_regular owner in UTC with a median
+ * bedtime of 23:00 and wake of 08:00, and no live sleep-cycle anchors — the
+ * resolver must project from the baseline.
+ */
+const mergedState = {
+  timezone: "UTC",
+  circadianState: "awake",
+  regularity: { regularityClass: "very_regular" },
+  baseline: { medianWakeLocalHour: 8, medianBedtimeLocalHour: 23 },
+  relativeTime: { bedtimeTargetAt: null },
+  wakeAt: null,
+} as unknown as LifeOpsScheduleMergedStateRecord;
+
+const duringNight = {
+  kind: "during_night",
+  timezone: "UTC",
+  windowMinutesBeforeSleepTarget: 120,
+} as Parameters<typeof resolveNextRelativeScheduleInstant>[0]["schedule"];
+
+describe("resolveNextRelativeScheduleInstant — negative-offset projection", () => {
+  // Bedtime target 23:00 − 120m = 21:00; at now=22:30 today's fire instant
+  // has already passed, so the next occurrence is tomorrow 21:00 — never a
+  // past instant that would be "due" immediately.
+  it("never resolves a during_night instant at or before now", () => {
+    const nowMs = Date.parse("2026-07-01T22:30:00.000Z");
+    const resolved = resolveNextRelativeScheduleInstant({
+      schedule: duringNight,
+      state: mergedState,
+      cursorIso: null,
+      nowMs,
+    });
+    expect(resolved).toBe("2026-07-02T21:00:00.000Z");
+  });
+
+  // The scheduler's run-due loop recomputes with cursorIso = the dueAt it just
+  // executed. If the resolver returns the same instant, the loop executes the
+  // workflow `limit` times per tick and never advances — the resolved instant
+  // must be strictly after the cursor.
+  it("advances past the cursor when re-resolved from the previous dueAt", () => {
+    const nowMs = Date.parse("2026-07-01T22:30:00.000Z");
+    const first = resolveNextRelativeScheduleInstant({
+      schedule: duringNight,
+      state: mergedState,
+      cursorIso: null,
+      nowMs,
+    });
+    expect(first).not.toBeNull();
+    const second = resolveNextRelativeScheduleInstant({
+      schedule: duringNight,
+      state: mergedState,
+      cursorIso: first,
+      nowMs,
+    });
+    expect(second).not.toBeNull();
+    expect(Date.parse(second as string)).toBeGreaterThan(
+      Date.parse(first as string),
+    );
+  });
+
+  // Positive-offset sanity: relative_to_wake +240m at now=10:00 with wake
+  // baseline 08:00 fires TODAY at 12:00 — the anchor already passed but the
+  // fire instant has not, so it must not be pushed to tomorrow.
+  it("keeps a still-future positive-offset fire on today's anchor", () => {
+    const nowMs = Date.parse("2026-07-01T10:00:00.000Z");
+    const resolved = resolveNextRelativeScheduleInstant({
+      schedule: {
+        kind: "relative_to_wake",
+        timezone: "UTC",
+        offsetMinutes: 240,
+      } as Parameters<typeof resolveNextRelativeScheduleInstant>[0]["schedule"],
+      state: mergedState,
+      cursorIso: null,
+      nowMs,
+    });
+    expect(resolved).toBe("2026-07-01T12:00:00.000Z");
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.ts
@@ -50,11 +50,22 @@ function nextProjectedLocalInstant(args: {
   timezone: string;
   cursorMs: number;
   localHour: number;
+  /**
+   * Offset applied to the anchor to get the actual fire instant. The advance
+   * condition must be evaluated on `anchor + offset`, not the anchor alone: a
+   * negative offset (during_night, "before bedtime" offsets) can place the
+   * fire instant behind the cursor even when the anchor is ahead of it, and
+   * re-resolving from that fire instant would then return the SAME past
+   * instant forever — the scheduler loop refires the workflow `limit` times
+   * per tick instead of advancing to the next occurrence.
+   */
+  offsetMinutes: number;
   allowedWeekdays?: number[];
 }): number | null {
   const parts = getZonedDateParts(new Date(args.cursorMs), args.timezone);
   const totalMinutes = Math.round(args.localHour * 60);
   const minuteOfDay = ((totalMinutes % (24 * 60)) + 24 * 60) % (24 * 60);
+  const offsetMs = args.offsetMinutes * 60_000;
   for (let dayOffset = 0; dayOffset < 14; dayOffset += 1) {
     const candidate = buildUtcDateFromLocalParts(args.timezone, {
       year: parts.year,
@@ -64,9 +75,11 @@ function nextProjectedLocalInstant(args: {
       minute: minuteOfDay % 60,
       second: 0,
     }).getTime();
-    if (candidate <= args.cursorMs) {
+    if (candidate + offsetMs <= args.cursorMs) {
       continue;
     }
+    // Weekday restrictions apply to the anchor's local day (the sleep-day the
+    // occurrence belongs to), not the offsetted fire instant.
     if (weekdayMatches(candidate, args.timezone, args.allowedWeekdays)) {
       return candidate;
     }
@@ -172,6 +185,7 @@ export function resolveNextRelativeScheduleInstant(args: {
     timezone: state.timezone,
     cursorMs,
     localHour: projectedHour,
+    offsetMinutes,
     allowedWeekdays: args.schedule.onDays,
   });
   if (projectedAnchorMs === null) {

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.no-reply-policy.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.no-reply-policy.test.ts
@@ -96,10 +96,15 @@ describe("processDueScheduledTasks — no-reply policy (#11793)", () => {
       runtime.agentId,
       reminder.taskId,
     );
+    // The retry rides on the snooze override (`state.firedAt` = nextRetryAt),
+    // NOT on a trigger rewrite — the original trigger must survive so
+    // recurring tasks keep their future occurrences.
     expect(retried?.trigger).toEqual({
       kind: "once",
-      atIso: "2026-05-09T12:31:00.000Z",
+      atIso: "2026-05-09T11:00:00.000Z",
     });
+    expect(retried?.state.status).toBe("scheduled");
+    expect(retried?.state.firedAt).toBe("2026-05-09T12:31:00.000Z");
     expect(retried?.metadata?.noReplyPolicy).toMatchObject({
       maxRetries: 1,
       retryCadenceMinutes: [60],
@@ -126,7 +131,7 @@ describe("processDueScheduledTasks — no-reply policy (#11793)", () => {
       {
         taskId: reminder.taskId,
         status: "fired",
-        reason: "once_due",
+        reason: "scheduled_override_due",
         occurrenceAtIso: "2026-05-09T12:31:00.000Z",
       },
     ]);

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.no-reply-recurrence.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.no-reply-recurrence.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression coverage: a RECURRING reminder must survive the no-reply
+ * retry/terminal path with its trigger intact. The retry mechanism is the
+ * snooze override (`state.firedAt` = nextRetryAt), not a trigger rewrite —
+ * rewriting the trigger to `once` used to kill the recurrence permanently
+ * after a single unanswered occurrence. Real repository-backed runtime.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createLifeOpsTestRuntime,
+  type RealTestRuntimeResult,
+} from "../../../test/helpers/runtime.ts";
+import { LifeOpsRepository } from "../repository.ts";
+import type { ScheduledTask } from "./index.ts";
+import {
+  type ProcessDueScheduledTasksResult,
+  processDueScheduledTasks,
+} from "./scheduler.ts";
+
+let runtimeResult: RealTestRuntimeResult | undefined;
+
+afterEach(async () => {
+  await runtimeResult?.cleanup?.();
+  runtimeResult = undefined;
+});
+
+function tick(
+  runtime: RealTestRuntimeResult["runtime"],
+  nowIso: string,
+): Promise<ProcessDueScheduledTasksResult> {
+  return processDueScheduledTasks({
+    runtime,
+    agentId: runtime.agentId,
+    now: new Date(nowIso),
+    limit: 10,
+  });
+}
+
+describe("processDueScheduledTasks — no-reply retry keeps recurring triggers alive", () => {
+  it("daily cron reminder: retry + terminal skip on day 1, fires AGAIN on day 2", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const repo = new LifeOpsRepository(runtime);
+
+    const cronTrigger = {
+      kind: "cron",
+      expression: "0 11 * * *",
+      tz: "UTC",
+    } as const;
+    const task: ScheduledTask = {
+      taskId: "st_recurring_no_reply",
+      kind: "reminder",
+      promptInstructions: "Take medication.",
+      trigger: cronTrigger,
+      priority: "high",
+      respectsGlobalPause: false,
+      source: "user_chat",
+      createdBy: runtime.agentId,
+      ownerVisible: true,
+      completionCheck: { kind: "user_acknowledged", followupAfterMinutes: 30 },
+      // Cron tasks never fire occurrences from before their creation; pin
+      // creation into the test's past-dated time frame.
+      metadata: { createdAtIso: "2026-05-08T00:00:00.000Z" },
+      state: {
+        status: "fired",
+        followupCount: 0,
+        firedAt: "2026-05-09T11:00:00.000Z",
+      },
+    };
+    await repo.upsertScheduledTask(runtime.agentId, task);
+
+    // Day 1, 11:31 — the unanswered fire times out into a no-reply retry.
+    const retryTick = await tick(runtime, "2026-05-09T11:31:00.000Z");
+    expect(retryTick.errors).toEqual([]);
+    expect(retryTick.completionTimeouts).toEqual([
+      {
+        taskId: task.taskId,
+        status: "scheduled",
+        reason: "no_reply_retry_1",
+        occurrenceAtIso: "2026-05-09T11:30:00.000Z",
+      },
+    ]);
+    const retried = await repo.getScheduledTask(runtime.agentId, task.taskId);
+    // THE regression assertion: the cron trigger must survive the retry.
+    expect(retried?.trigger).toEqual(cronTrigger);
+    // The retry is carried by the snooze override, not a trigger rewrite.
+    expect(retried?.state.status).toBe("scheduled");
+    expect(retried?.state.firedAt).toBe("2026-05-09T12:31:00.000Z");
+
+    // Day 1, 12:32 — the retry fires via the scheduled override.
+    const refireTick = await tick(runtime, "2026-05-09T12:32:00.000Z");
+    expect(refireTick.errors).toEqual([]);
+    expect(
+      refireTick.fires.find((fire) => fire.taskId === task.taskId)?.status,
+    ).toBe("fired");
+
+    // Day 1, 13:02 — still no reply: terminal skip for the day.
+    const terminalTick = await tick(runtime, "2026-05-09T13:02:00.000Z");
+    expect(terminalTick.errors).toEqual([]);
+    expect(terminalTick.completionTimeouts).toEqual([
+      {
+        taskId: task.taskId,
+        status: "skipped",
+        reason: "no_reply_reminder_expired",
+        occurrenceAtIso: "2026-05-09T13:02:00.000Z",
+      },
+    ]);
+    const skipped = await repo.getScheduledTask(runtime.agentId, task.taskId);
+    expect(skipped?.state.status).toBe("skipped");
+    expect(skipped?.trigger).toEqual(cronTrigger);
+
+    // Day 2, 11:01 — the daily recurrence must fire again. With the trigger
+    // rewritten to `once` this tick fired NOTHING and the reminder was dead
+    // forever.
+    const day2Tick = await tick(runtime, "2026-05-10T11:01:00.000Z");
+    expect(day2Tick.errors).toEqual([]);
+    const day2Fire = day2Tick.fires.find((fire) => fire.taskId === task.taskId);
+    expect(day2Fire?.status).toBe("fired");
+    expect(day2Fire?.reason).toBe("cron_due");
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
@@ -553,11 +553,17 @@ async function handleCompletionTimeout(args: {
       },
     };
     await args.repo.upsertScheduledTask(args.agentId, args.task);
+    // The snooze override (status back to `scheduled` + `state.firedAt` =
+    // untilIso) is the whole retry mechanism: `scheduledOverrideDue` fires the
+    // task AT the override instant for every trigger kind. The trigger itself
+    // must stay untouched — rewriting it to `once` here would permanently
+    // destroy a recurring trigger: once the retry settles (owner reply OR
+    // terminal no-reply), a `once` trigger with `firedAt` set resolves to a
+    // NULL next-fire, so a daily reminder would never fire again after a
+    // single unanswered occurrence.
     const snoozed = await args.runner.apply(args.task.taskId, "snooze", {
       untilIso: nextRetryAt,
     });
-    snoozed.trigger = { kind: "once", atIso: nextRetryAt };
-    delete snoozed.state.firedAt;
     snoozed.state.lastDecisionLog = `no_reply_retry_${state.retryCount + 1}: ${args.reason}`;
     await args.repo.upsertScheduledTask(args.agentId, snoozed);
     return {

--- a/plugins/plugin-personal-assistant/test/relationships-edge-state.test.ts
+++ b/plugins/plugin-personal-assistant/test/relationships-edge-state.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression coverage: a contact edit must not wipe the SELF→contact edge's
+ * interaction-recency state. `RelationshipStore.upsert` is a full-replace
+ * write, so `upsertRelationship` has to carry the existing edge state forward
+ * when the update carries no `lastContactedAt` — otherwise a notes/tags edit
+ * (or a re-add through the identity dedup path) resets `lastInteractionAt`
+ * and the cadence-overdue check nags about a freshly-contacted person.
+ * Real PGLite runtime, no mocks.
+ */
+
+import { KnowledgeGraphService, knowledgeGraphSchema } from "@elizaos/agent";
+import type { AgentRuntime, Plugin } from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  createRealTestRuntime,
+  type RealTestRuntimeResult,
+} from "../../../packages/test/helpers/real-runtime.ts";
+import { contactEdgeId } from "../src/lifeops/relationships/mapping.ts";
+import { LifeOpsRepository } from "../src/lifeops/repository.ts";
+import { LifeOpsService } from "../src/lifeops/service.ts";
+
+const AGENT_ID = "lifeops-relationships-edge-state-agent";
+
+/** Registers the knowledge-graph schema + service the contact graph needs. */
+const knowledgeGraphPlugin: Plugin = {
+  name: "eliza",
+  description: "Test-only knowledge-graph schema + service registration.",
+  schema: knowledgeGraphSchema,
+  services: [KnowledgeGraphService],
+};
+
+describe("upsertRelationship — edge interaction state survives contact edits", () => {
+  let runtime: AgentRuntime;
+  let service: LifeOpsService;
+  let repo: LifeOpsRepository;
+  let testResult: RealTestRuntimeResult;
+
+  beforeAll(async () => {
+    testResult = await createRealTestRuntime({
+      characterName: AGENT_ID,
+      plugins: [knowledgeGraphPlugin],
+    });
+    runtime = testResult.runtime;
+    await LifeOpsRepository.bootstrapSchema(runtime);
+    service = new LifeOpsService(runtime);
+    repo = new LifeOpsRepository(runtime);
+  }, 180_000);
+
+  afterAll(async () => {
+    await testResult?.cleanup();
+  });
+
+  it("keeps lastInteractionAt when the contact is edited without lastContactedAt", async () => {
+    const lastContactedAt = "2026-05-01T10:00:00.000Z";
+    const created = await service.upsertRelationship({
+      name: "Pat",
+      primaryChannel: "telegram",
+      primaryHandle: "@pat",
+      email: null,
+      phone: null,
+      notes: "old friend",
+      tags: [],
+      relationshipType: "friend",
+      lastContactedAt,
+      metadata: {},
+    });
+
+    const store = await repo.relationshipStore(runtime.agentId);
+    const edgeBefore = await store.get(contactEdgeId(created.id));
+    expect(edgeBefore?.state.lastInteractionAt).toBe(lastContactedAt);
+
+    // Edit the contact's notes without re-asserting lastContactedAt — the
+    // exact shape the ENTITY action's update/dedup paths produce.
+    await service.upsertRelationship({
+      id: created.id,
+      name: "Pat",
+      primaryChannel: "telegram",
+      primaryHandle: "@pat",
+      email: null,
+      phone: null,
+      notes: "old friend — met at the conference",
+      tags: ["conference"],
+      relationshipType: "friend",
+      lastContactedAt: null,
+      metadata: {},
+    });
+
+    const edgeAfter = await store.get(contactEdgeId(created.id));
+    expect(edgeAfter?.state.lastInteractionAt).toBe(lastContactedAt);
+  });
+
+  it("lets an explicit lastContactedAt overwrite the carried-forward state", async () => {
+    const first = "2026-05-01T10:00:00.000Z";
+    const second = "2026-06-01T09:00:00.000Z";
+    const created = await service.upsertRelationship({
+      name: "Sam",
+      primaryChannel: "email",
+      primaryHandle: "sam@example.com",
+      email: "sam@example.com",
+      phone: null,
+      notes: "",
+      tags: [],
+      relationshipType: "contact",
+      lastContactedAt: first,
+      metadata: {},
+    });
+
+    await service.upsertRelationship({
+      id: created.id,
+      name: "Sam",
+      primaryChannel: "email",
+      primaryHandle: "sam@example.com",
+      email: "sam@example.com",
+      phone: null,
+      notes: "",
+      tags: [],
+      relationshipType: "contact",
+      lastContactedAt: second,
+      metadata: {},
+    });
+
+    const store = await repo.relationshipStore(runtime.agentId);
+    const edge = await store.get(contactEdgeId(created.id));
+    expect(edge?.state.lastInteractionAt).toBe(second);
+  });
+});


### PR DESCRIPTION
## Summary

Three real, mutation-checked bugs in `plugin-personal-assistant` LifeOps pure logic, each proven with a concrete failing input before authoring the fix. No new scheduling mechanism, no promptInstructions-driven behavior, no DispatchResult changes — all fixes are inside the existing structural-field logic.

### 1. No-reply retry permanently destroys recurring triggers (`lifeops/scheduled-task/scheduler.ts`)

`handleCompletionTimeout`'s retry path rewrote `task.trigger` to `{kind:"once", atIso:nextRetryAt}` and deleted the snooze override.

**Concrete failure:** daily cron reminder (`0 11 * * *`, `user_acknowledged` + 30m followup) fires day 1 at 11:00; no reply by 11:31 → retry rewrites the trigger to `once`. Whichever way the retry settles — owner reply (completed) or terminal no-reply (skipped) — `computeNextFireAt` on a `once` trigger with `firedAt` set returns NULL. **Day 2 at 11:01 the reminder fires nothing, forever.** One missed day silently kills a daily medication reminder.

**Fix:** the snooze override (`status=scheduled` + `state.firedAt=nextRetryAt`) is already the retry mechanism — `scheduledOverrideDue` fires it at the override instant for every trigger kind — so the trigger now stays untouched. Verified end-to-end on the real PGlite runtime across the full 4-tick lifecycle (retry → override refire → terminal skip → day-2 `cron_due` refire).

- Test: `scheduler.no-reply-recurrence.test.ts` (new) + updated expectations in `scheduler.no-reply-policy.test.ts` (trigger survives the retry; refire reason is `scheduled_override_due`).
- Mutation check: reverting only the scheduler change → new test FAILS (trigger/status assertions + day-2 fire missing). ✅

### 2. Negative-offset schedule resolver never advances → workflow fire-storm (`lifeops/relative-schedule-resolver.ts`)

The baseline-projection branch required `anchor > cursor` but returned `anchor + offset`. With a negative offset (`during_night`, before-bedtime offsets) the fire instant lands BEFORE the cursor.

**Concrete failure (probe-executed):** `during_night` 120m before a 23:00 median bedtime, now = 22:30 UTC → resolver returned `21:00 TODAY` (past ⇒ immediately due); re-resolving from that dueAt returned the **same 21:00 again**. `runDueWorkflows`' while-loop therefore executed the same workflow `limit` times in a single tick and persisted the stuck `nextDueAt` — repeating every tick.

**Fix:** the advance condition now evaluates `anchor + offset` against the cursor (weekday restriction stays on the anchor's sleep-day). Post-fix probe: first resolve = tomorrow 21:00 (future), re-resolve = day-after 21:00 (strictly advancing). Symmetric win: `relative_to_wake +240m` at 10:00 now fires TODAY 12:00 instead of skipping to tomorrow.

- Test: `relative-schedule-resolver.test.ts` (new, pure/deterministic, 3 cases).
- Mutation check: reverting only the resolver change → all 3 cases FAIL. ✅

### 3. Contact edit wipes the edge's interaction-recency state (`lifeops/domains/relationships-service.ts`)

`RelationshipStore.upsert` is a full-replace write (`state_last_interaction_at = EXCLUDED…`, `state_interaction_count = EXCLUDED…`), and `upsertRelationship` passed `state: {}` whenever `input.lastContactedAt` was null — exactly what the ENTITY action's notes/tags edits and the re-add-via-identity-dedup path produce.

**Concrete failure:** create contact with `lastContactedAt=2026-05-01T10:00Z` (edge `lastInteractionAt` set) → edit the contact's notes (`lastContactedAt:null`) → edge `lastInteractionAt` becomes NULL and `interactionCount` resets to 0. `RelationshipStore.list({cadenceOverdueAsOf})` then reports the contact "overdue by definition" and the follow-up pipeline nags the owner about a person they just talked to; `subject_updated` completion checks on relationship subjects also lose their signal.

**Fix:** carry the existing edge state forward, letting an explicit `lastContactedAt` still overwrite it.

- Test: `test/relationships-edge-state.test.ts` (new; real PGlite runtime + real `KnowledgeGraphService` stores, no mocks; 2 cases incl. explicit-overwrite non-regression).
- Mutation check: reverting only the service change → carried-forward case FAILS. ✅

## Verification

- `bunx vitest run --no-cache` on all 4 test files after rebasing onto current `origin/develop`: **4 files / 14 tests passed** (includes the develop-side no-reply suite).
- Each fix mutation-checked individually (revert fix → its test reds → restore).
- `bunx biome check --write` clean on all touched files.
- `tsc` on the plugin: no NEW errors in touched files (remaining reports are pre-existing dist-less-workspace artifacts identical at the merge-base).

## Evidence checklist (PR_EVIDENCE.md)

- Real-LLM trajectories: **N/A** — pure structural scheduler/resolver/store logic; no model, prompt, action-routing, or provider behavior changed; deterministic tick/resolver math exercised directly.
- Screenshots / video / frontend logs: **N/A** — no UI surface; server-side pure logic only.
- Backend logs + domain artifacts: covered by the real-runtime tests — scheduled-task rows, state-log transitions, and knowledge-graph edge rows inspected via `LifeOpsRepository`/`RelationshipStore` assertions on a real PGlite DB.
- Concrete failure inputs: documented above and pinned in the tests (each was probe-executed red before the fix was authored).

[phone-ui]

---
**Authored end-to-end by a Fable-5 agent** (verified 100% claude-fable-5), committed + pushed on its own branch. Each fix probe-executed against the real function (concrete input → wrong output) BEFORE authoring; the agent honestly dropped ~11 candidates (incl. two shallower ones from a prior capped run) as not-provably-wrong. Main-loop re-verification: 7-file merge-base diff; the pure `relative-schedule-resolver.test.ts` passes 3/3 and mutation-reproduces (revert → 3 red); the scheduler.ts diff is exactly the described fix (stop rewriting a recurring trigger to `once`). NOTE: `scheduler.no-reply-recurrence.test.ts` + `relationships-edge-state.test.ts` fail to *collect* in a bare worktree (`Cannot find package '@elizaos/auth/atomic-json'` — an unbuilt transitive dep subpath in this checkout, NOT a test failure; the agent ran them green with deps built, and CI builds deps first). The 3 fixes' assertions themselves pass. — [phone-ui]