### PR TITLE
fix(#12262): remove browser bridge root wrappers

### DIFF
--- a/.github/issue-evidence/12262-remove-browser-bridge-root-wrappers.md
+++ b/.github/issue-evidence/12262-remove-browser-bridge-root-wrappers.md
@@ -1,0 +1,76 @@
+# Evidence: #12262 remove browser-bridge root wrappers
+
+Date: 2026-07-04
+
+## Change
+
+- Deleted root `test:browser-bridge`.
+- Deleted root `test:browser-bridge:safari`.
+- Renamed package-local `packages/browser-extension` CI-style test surface:
+  - `test:unit` now runs the Vitest unit suite.
+  - `test` now runs `test:unit && test:smoke`.
+  - `test:ci` was removed.
+- Documented direct replacements in root `CLAUDE.md` / `AGENTS.md`.
+- Updated `packages/browser-extension/CLAUDE.md` / `AGENTS.md` command docs.
+
+Screenshots/recordings: N/A. This is a root/package script and docs cleanup with no UI behavior change.
+
+## Verification
+
+```bash
+node <<'NODE'
+const root = require('./package.json').scripts;
+for (const n of ['test:browser-bridge','test:browser-bridge:safari']) if (Object.hasOwn(root,n)) throw new Error(`${n} still exists`);
+if (Object.keys(root).length !== 203) throw new Error(`root script count ${Object.keys(root).length}`);
+const browser = require('./packages/browser-extension/package.json').scripts;
+if (browser.test !== 'bun run test:unit && bun run test:smoke') throw new Error(`browser test body: ${browser.test}`);
+if (!browser['test:unit']) throw new Error('missing test:unit');
+if (Object.hasOwn(browser,'test:ci')) throw new Error('browser test:ci still exists');
+console.log('browser bridge wrapper deletion assertions passed');
+NODE
+# browser bridge wrapper deletion assertions passed
+```
+
+```bash
+node scripts/assert-agents-claude-identical.mjs
+# [assert-agents-claude-identical] PASS: 301 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.
+```
+
+```bash
+node packages/scripts/audit-scripts.mjs
+# [audit-scripts] OK - no orphan/no-op/broken scripts.
+```
+
+```bash
+grep -RIn "test:browser-bridge\(:safari\)\?\|test:ci" packages/browser-extension .github docs packages plugins scripts CLAUDE.md AGENTS.md package.json
+# Remaining root-name hits are root migration docs and historical #10200 evidence.
+# Other `test:ci` hits are unrelated package-local or renamed-root migration references.
+```
+
+```bash
+bun run --cwd packages/browser-extension test:smoke
+# run with a temporary node_modules symlink to /Users/shawwalters/eliza/node_modules
+# Built Agent Browser Bridge extension 2.0.0-beta.2 (2.0.0.40002) to .../packages/browser-extension/dist/chrome
+# Agent Browser Bridge extension smoke checks passed.
+```
+
+```bash
+bun run --cwd packages/browser-extension test:smoke:safari
+# run with a temporary node_modules symlink to /Users/shawwalters/eliza/node_modules
+# exited 0
+```
+
+Unit-test limitation:
+
+```bash
+bun run --cwd packages/browser-extension test:unit
+# failed to load config from .../packages/browser-extension/vitest.extension.config.ts
+# Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'vitest' imported from /Users/shawwalters/eliza/node_modules/.vite-temp/...
+```
+
+The auxiliary worktree relies on the main checkout's shared dependency install, whose Vitest package/shim is incomplete. The package-local unit command should run in CI with a fresh install.
+
+```bash
+git diff --check
+# no output
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ bun run cloud:mock     # boot the full local cloud stack with mocks
 ```
 
 Scope any command to one package with `--cwd`:
-`bun run --cwd packages/core test`. The repo has 205 root scripts; the list
+`bun run --cwd packages/core test`. The repo has 203 root scripts; the list
 above is the day-to-day set. Use `bun run` with no args to print them all.
 
 ### Removed Root Command Migrations
@@ -65,6 +65,8 @@ above is the day-to-day set. Use `bun run` with no args to print them all.
 | `bun run test:lifeops` | `bun run test:plugin 'plugin-personal-assistant'` |
 | `bun run trajectory:inspect:test` | `bun test packages/scripts/__tests__/trajectory-validate.test.ts` |
 | `bun run audit:e2e-coverage:test` | `bun test packages/scripts/e2e-coverage/check-e2e-coverage.test.ts` |
+| `bun run test:browser-bridge` | `bun run --cwd packages/browser-extension test` |
+| `bun run test:browser-bridge:safari` | `bun run --cwd packages/browser-extension test:smoke:safari` |
 | `bun run lint:all` | `bun run verify` |
 | `bun run build:typescript` | `node packages/scripts/run-turbo.mjs run build` |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ bun run cloud:mock     # boot the full local cloud stack with mocks
 ```
 
 Scope any command to one package with `--cwd`:
-`bun run --cwd packages/core test`. The repo has 205 root scripts; the list
+`bun run --cwd packages/core test`. The repo has 203 root scripts; the list
 above is the day-to-day set. Use `bun run` with no args to print them all.
 
 ### Removed Root Command Migrations
@@ -65,6 +65,8 @@ above is the day-to-day set. Use `bun run` with no args to print them all.
 | `bun run test:lifeops` | `bun run test:plugin 'plugin-personal-assistant'` |
 | `bun run trajectory:inspect:test` | `bun test packages/scripts/__tests__/trajectory-validate.test.ts` |
 | `bun run audit:e2e-coverage:test` | `bun test packages/scripts/e2e-coverage/check-e2e-coverage.test.ts` |
+| `bun run test:browser-bridge` | `bun run --cwd packages/browser-extension test` |
+| `bun run test:browser-bridge:safari` | `bun run --cwd packages/browser-extension test:smoke:safari` |
 | `bun run lint:all` | `bun run verify` |
 | `bun run build:typescript` | `node packages/scripts/run-turbo.mjs run build` |
 

--- a/package.json
+++ b/package.json
@@ -166,8 +166,6 @@
     "test:remote-capabilities:source-build": "bun run --cwd packages/agent test:remote-capabilities:source-build",
     "test:remote-capabilities:docker": "bun run --cwd packages/agent test:remote-capabilities:docker",
     "browser-bridge:package:release": "cd packages/browser-extension && bun run package:release",
-    "test:browser-bridge": "cd packages/browser-extension && bun run test:ci",
-    "test:browser-bridge:safari": "cd packages/browser-extension && bun run test:smoke:safari",
     "dev:cloud": "concurrently -n api,web -c blue,magenta \"bun run dev:cloud:api\" \"bun run dev:cloud:web\"",
     "dev:cloud:api": "bun run --cwd packages/cloud/api dev",
     "dev:cloud:web": "bun run --cwd packages/app dev",

--- a/packages/browser-extension/AGENTS.md
+++ b/packages/browser-extension/AGENTS.md
@@ -87,10 +87,10 @@ bun run --cwd packages/browser-extension package:chrome          # .zip for Chro
 bun run --cwd packages/browser-extension package:safari
 bun run --cwd packages/browser-extension package:stores
 bun run --cwd packages/browser-extension package:release
-bun run --cwd packages/browser-extension test                    # vitest unit tests (src/)
+bun run --cwd packages/browser-extension test                    # unit tests + Chrome dist smoke
+bun run --cwd packages/browser-extension test:unit               # vitest unit tests (src/)
 bun run --cwd packages/browser-extension test:smoke              # smoke-checks Chrome dist artifacts
 bun run --cwd packages/browser-extension test:smoke:safari
-bun run --cwd packages/browser-extension test:ci                 # test + test:smoke
 ```
 
 Output lands in `dist/chrome/` or `dist/safari/`. Load `dist/chrome/` as an unpacked extension in Chrome DevTools for local dev.

--- a/packages/browser-extension/CLAUDE.md
+++ b/packages/browser-extension/CLAUDE.md
@@ -87,10 +87,10 @@ bun run --cwd packages/browser-extension package:chrome          # .zip for Chro
 bun run --cwd packages/browser-extension package:safari
 bun run --cwd packages/browser-extension package:stores
 bun run --cwd packages/browser-extension package:release
-bun run --cwd packages/browser-extension test                    # vitest unit tests (src/)
+bun run --cwd packages/browser-extension test                    # unit tests + Chrome dist smoke
+bun run --cwd packages/browser-extension test:unit               # vitest unit tests (src/)
 bun run --cwd packages/browser-extension test:smoke              # smoke-checks Chrome dist artifacts
 bun run --cwd packages/browser-extension test:smoke:safari
-bun run --cwd packages/browser-extension test:ci                 # test + test:smoke
 ```
 
 Output lands in `dist/chrome/` or `dist/safari/`. Load `dist/chrome/` as an unpacked extension in Chrome DevTools for local dev.

--- a/packages/browser-extension/package.json
+++ b/packages/browser-extension/package.json
@@ -10,10 +10,10 @@
     "package:safari": "bun scripts/package-safari.mjs",
     "package:stores": "bun scripts/package-store-assets.mjs",
     "package:release": "bun scripts/package-release.mjs",
-    "test": "bunx vitest run --config ./vitest.extension.config.ts",
+    "test": "bun run test:unit && bun run test:smoke",
+    "test:unit": "bunx vitest run --config ./vitest.extension.config.ts",
     "test:smoke": "node scripts/extension-smoke.mjs",
-    "test:smoke:safari": "node scripts/extension-smoke-safari.mjs",
-    "test:ci": "bun run test && bun run test:smoke"
+    "test:smoke:safari": "node scripts/extension-smoke-safari.mjs"
   },
   "dependencies": {
     "@elizaos/shared": "workspace:*"


### PR DESCRIPTION
## Summary
- delete root `test:browser-bridge` and `test:browser-bridge:safari`
- make browser-extension `test` the canonical unit+Chrome-smoke command and split unit tests to `test:unit`
- remove package-local `test:ci` and update root/package docs plus evidence

## Evidence
- `.github/issue-evidence/12262-remove-browser-bridge-root-wrappers.md`

## Verification
- static root/package script assertions for removed wrappers, script count 203, and browser-extension test bodies
- `node scripts/assert-agents-claude-identical.mjs`
- `node packages/scripts/audit-scripts.mjs`
- `bun run --cwd packages/browser-extension test:smoke` with temporary dependency symlink
- `bun run --cwd packages/browser-extension test:smoke:safari` with temporary dependency symlink
- `git diff --check origin/develop..HEAD`

`bun run --cwd packages/browser-extension test:unit` could not run in this auxiliary worktree because the shared dependency install cannot load `vitest/config`; the evidence file records the exact failure.