### PR TITLE
fix(main): cherry-pick #12936 — export Filesystem/Share from build:web native stubs (unbreaks prod Pages deploys)

### DIFF
--- a/packages/app/vite/native-module-stub-plugin.ts
+++ b/packages/app/vite/native-module-stub-plugin.ts
@@ -825,6 +825,24 @@ export function nativeModuleStubPlugin(
             "export default noopObj;",
           ].join("\n");
         }
+        if (capPkg === "@capacitor/filesystem") {
+          // Imported (with @capacitor/share) by src/ios-attachment-smoke.ts,
+          // which main.tsx pulls in statically but only runs behind an isIOS
+          // gate. A silent no-op here would fabricate a successful file write
+          // if a web/desktop path ever called it, so every method throws.
+          return [
+            "const mobileOnly = (prop) => () => { throw new Error('@capacitor/filesystem.' + String(prop) + ' is mobile-only; not available in this build.'); };",
+            "export const Filesystem = new Proxy({}, { get: (_, prop) => mobileOnly(prop) });",
+            "export default Filesystem;",
+          ].join("\n");
+        }
+        if (capPkg === "@capacitor/share") {
+          return [
+            "const mobileOnly = (prop) => () => { throw new Error('@capacitor/share.' + String(prop) + ' is mobile-only; not available in this build.'); };",
+            "export const Share = new Proxy({}, { get: (_, prop) => mobileOnly(prop) });",
+            "export default Share;",
+          ].join("\n");
+        }
         if (capPkg === "@capacitor/background-runner") {
           return [
             "const asyncNoop = async () => {};",


### PR DESCRIPTION
## What

Cherry-pick of a06ad2211b (#12936, already merged to develop) onto `main`.

## Why main needs it now

- Promote #12848 (merged 2026-07-04 04:46Z) carried #12065's `packages/app/src/ios-attachment-smoke.ts` onto `main`. That file top-level imports `{ Filesystem }` from `@capacitor/filesystem` and `{ Share }` from `@capacitor/share`.
- `build:web` routes all `@capacitor/*` (except core) through `vite/native-module-stub-plugin.ts`, whose generic stub did not emit those named exports, so rollup fails:
  `"Filesystem" is not exported by "^@native-stub:@capacitor/filesystem", imported by "src/ios-attachment-smoke.ts"`.
- Observed live: develop→staging Cloud CF Deploy run 28695298240 failed both Pages jobs (console + app) at their build steps with exactly this error at head d567622f22 (pre-fix). The fix #12936 landed on develop at 05:26Z, but `main` does not have it — so every prod Pages deploy from current `main` (db2b2a0929) will fail the same way (prod run 28695321227's App build is exposed to it).

## Scope

- Single file, +18 lines, identical to the develop commit (cherry-picked with `-x`).
- Stubs are fail-loud (every method throws "mobile-only"), no fabricated success — consistent with the fallback-slop policy.
- Migrations + API Worker jobs are unaffected (they already pass); this only unbreaks the two Pages builds.

The next develop→main promote would carry this anyway; this PR just closes the window where prod front-end deploys from `main` are build-broken.

[cloud-security]