### PR TITLE
docs(#12810): clean tool plugin comments

### DIFF
--- a/plugins/app-model-tester/src/ModelTesterAppView.interact.ts
+++ b/plugins/app-model-tester/src/ModelTesterAppView.interact.ts
@@ -1,7 +1,7 @@
-// View-bundle `interact` capability handler, split out of ModelTesterAppView.tsx
-// so that file exports only React components and stays Fast-Refresh-compatible
-// (Vite would full-reload a component file that also exports a plain function).
-// The view bundle re-exports `interact` via ./model-tester-view-bundle.ts.
+/**
+ * View-bundle capability handler for the Model Tester TUI surface.
+ * It stays separate from the React component file so Fast Refresh sees component-only exports while the built view bundle still exposes `interact`.
+ */
 
 const DEFAULT_PROMPT =
   "Say exactly one short sentence about the Eliza-1 model tester working.";
@@ -13,9 +13,6 @@ const MODEL_TESTER_COMMAND_TO_TEST: Record<string, string> = {
   "run-vad": "vad",
 };
 
-// The TUI capability ids this view registers (matches plugin.ts `capabilities`
-// and the interact() handler below). The view bundle re-exports `interact`, so
-// the terminal surface dispatches these capabilities through the same handler.
 export const MODEL_TESTER_TUI_CAPABILITIES: readonly string[] = [
   "get-status",
   ...Object.keys(MODEL_TESTER_COMMAND_TO_TEST),

--- a/plugins/app-model-tester/src/ModelTesterAppView.test.tsx
+++ b/plugins/app-model-tester/src/ModelTesterAppView.test.tsx
@@ -1,10 +1,10 @@
-// @vitest-environment jsdom
-
 /**
  * Drives the ModelTesterAppView overlay through the rendered DOM: status
  * population, ready-count math, prompt presets, per-probe and run-all dispatch,
  * result rendering (embedding/TTS/image/failure), and the asset pickers. The
  * @elizaos/ui surfaces and fetch are mocked, so the harness is deterministic.
+ *
+ * @vitest-environment jsdom
  */
 
 import {

--- a/plugins/app-model-tester/src/ModelTesterView.test.tsx
+++ b/plugins/app-model-tester/src/ModelTesterView.test.tsx
@@ -1,11 +1,9 @@
-// @vitest-environment jsdom
-
-// Drives the unified ModelTesterView (the single GUI/XR/TUI data wrapper) through
-// the rendered DOM: the same component the bundle exports for the "gui", "xr",
-// and "tui" modalities. Asserts the on-mount status fetch, the prompt-preset
-// switch, run-all sequencing, refresh, per-probe run dispatch, and the Back
-// navigation — functional parity with the legacy ModelTesterAppView surface,
-// expressed through the spatial action contract.
+/**
+ * Drives the unified ModelTesterView data wrapper through the rendered DOM.
+ * The harness covers the same component exported for GUI, XR, and TUI modalities, including status fetch, prompt presets, run-all sequencing, refresh, probe dispatch, and navigation through the spatial action contract.
+ *
+ * @vitest-environment jsdom
+ */
 
 import { NAVIGATE_VIEW_EVENT } from "@elizaos/ui/events";
 import {

--- a/plugins/app-model-tester/src/model-tester-probe.helpers.ts
+++ b/plugins/app-model-tester/src/model-tester-probe.helpers.ts
@@ -1,7 +1,7 @@
-// Browser-side asset helpers shared by the tri-modal data wrapper
-// (ModelTesterView) and the legacy overlay wrapper (ModelTesterAppView).
-// Kept in a plain .ts module (no React) so both component files import the same
-// decode logic instead of duplicating it.
+/**
+ * Browser-side asset helpers shared by the Model Tester view wrappers.
+ * The module stays React-free so both component surfaces use the same file and audio decode logic.
+ */
 
 declare global {
   interface Window {

--- a/plugins/app-model-tester/src/model-tester-view-bundle.ts
+++ b/plugins/app-model-tester/src/model-tester-view-bundle.ts
@@ -1,7 +1,6 @@
-// Vite view-bundle entry. Re-exports the unified spatial data wrapper plus the
-// `interact` capability handler so the built bundle (dist/views/bundle.js)
-// exposes the named exports the view loader reads (`ModelTesterView`,
-// `interact`). Kept separate from ModelTesterView.tsx so that file exports only
-// React components and stays Fast-Refresh-compatible in dev.
+/**
+ * Vite view-bundle entry for Model Tester.
+ * It re-exports the unified view wrapper and capability handler under the named exports the elizaOS view loader reads.
+ */
 export { interact } from "./ModelTesterAppView.interact";
 export { ModelTesterView } from "./ModelTesterView";

--- a/plugins/app-model-tester/src/tui-capabilities.test.ts
+++ b/plugins/app-model-tester/src/tui-capabilities.test.ts
@@ -1,9 +1,7 @@
-// Contract test: the Model Tester TUI capability set stays in sync across its
-// three sources — the exported capability list, plugin.ts `capabilities`, and
-// the interact() handler the view bundle re-exports. The terminal surface mounts
-// the unified ModelTesterSpatialView (see register-terminal-view.tsx) and the
-// view bundle exports `interact`, so these capabilities drive real terminal
-// dispatch; this test locks them against drift.
+/**
+ * Contract tests for Model Tester TUI capability wiring.
+ * They keep the exported capability list, plugin view declaration, and bundle `interact` handler aligned so terminal dispatch cannot drift silently.
+ */
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";

--- a/plugins/plugin-agent-skills/auto-enable.ts
+++ b/plugins/plugin-agent-skills/auto-enable.ts
@@ -1,9 +1,8 @@
-// Auto-enable check for @elizaos/plugin-agent-skills.
-//
-// Plugin manifest entry-point — referenced by package.json's
-// `elizaos.plugin.autoEnableModule`. Keep this module light: env reads only,
-// no service init, no transitive imports of the full plugin runtime. The
-// auto-enable engine loads dozens of these per boot.
+/**
+ * Auto-enable gate for the Agent Skills plugin.
+ * The manifest loads this module during boot, so it stays limited to config inspection and avoids service/runtime imports.
+ */
+
 import type { PluginAutoEnableContext } from "@elizaos/core";
 
 function isFeatureEnabled(

--- a/plugins/plugin-agent-skills/src/parser.validation.test.ts
+++ b/plugins/plugin-agent-skills/src/parser.validation.test.ts
@@ -1,14 +1,12 @@
+/**
+ * Skill-package validation tests for Agent Skills frontmatter.
+ * The parser gates SKILL.md loading, including slug constraints, directory/name alignment, and required fields.
+ */
+
 import { describe, expect, it } from "vitest";
 import { validateFrontmatter, validateSkillDirectory } from "./parser.ts";
 import type { SkillFrontmatter } from "./types.ts";
 
-/**
- * Skill-package validation (#8801 — shipped untested). `validateFrontmatter` /
- * `validateSkillDirectory` are the gate a SKILL.md passes before the agent will
- * load it; the name is used as a directory/registry key, so a name that is not
- * a constrained slug (uppercase, underscores, leading/consecutive hyphens, a
- * mismatch with its directory) must be REJECTED, and required fields enforced.
- */
 const fm = (over: Partial<SkillFrontmatter> = {}): SkillFrontmatter => ({
   name: "my-skill",
   description: "A clear description of what this skill does and when to use it.",

--- a/plugins/plugin-agent-skills/src/security/manifest-scanner.test.ts
+++ b/plugins/plugin-agent-skills/src/security/manifest-scanner.test.ts
@@ -1,12 +1,11 @@
+/**
+ * In-memory skill-manifest builder tests for the security scanner.
+ * The manifest records byte lengths for text and binary payloads so integrity checks do not confuse character count with UTF-8 size.
+ */
+
 import { describe, expect, it } from "vitest";
 import { buildManifestEntriesFromMemory } from "./manifest-scanner";
 
-/**
- * Tests for the in-memory skill-manifest builder (#8801 / #9943). The manifest
- * feeds the security scanner / integrity check, so the per-file size must be the
- * UTF-8 BYTE length (not the character count) — otherwise non-ASCII files report
- * a wrong size. It was untested.
- */
 describe("buildManifestEntriesFromMemory", () => {
   it("returns an empty manifest for no files", () => {
     expect(buildManifestEntriesFromMemory(new Map())).toEqual([]);

--- a/plugins/plugin-codex-cli/auto-enable.ts
+++ b/plugins/plugin-codex-cli/auto-enable.ts
@@ -1,9 +1,8 @@
-// Auto-enable check for @elizaos/plugin-codex-cli.
-//
-// Plugin manifest entry-point — referenced by package.json's
-// `elizaos.plugin.autoEnableModule`. Keep this module light: config reads
-// only, no service init, no transitive imports of the full plugin runtime.
-// The auto-enable engine loads dozens of these per boot.
+/**
+ * Auto-enable gate for the Codex CLI model-provider plugin.
+ * The manifest loads this module during boot, so it stays limited to config inspection and avoids backend/auth imports.
+ */
+
 import type { PluginAutoEnableContext } from "@elizaos/core";
 
 /**

--- a/plugins/plugin-gitpathologist/build.ts
+++ b/plugins/plugin-gitpathologist/build.ts
@@ -1,19 +1,12 @@
 #!/usr/bin/env bun
-import { buildPlugin } from "../plugin-build";
 
 /**
- * Build script for @elizaos/plugin-gitpathologist.
- *
- * Outputs:
- * - ESM (Node): dist/node/index.js
- * - CJS (Node): dist/cjs/index.cjs
- * - Types: dist/index.d.ts + dist/node/index.d.ts + dist/cjs/index.d.ts
- *
- * Runs on the shared `buildPlugin` driver. The CJS bundle's `index.js` is
- * renamed to `index.cjs`; its sibling `index.js.map` is intentionally left
- * unrenamed so the emitted `//# sourceMappingURL=index.js.map` reference stays
- * valid.
+ * Build entrypoint for the git-pathology plugin.
+ * It uses the shared plugin build driver to emit Node ESM/CJS bundles and declarations while preserving CJS sourcemap references.
  */
+
+import { buildPlugin } from "../plugin-build";
+
 const reexport = (from: string) => `export * from "${from}";\nexport { default } from "${from}";\n`;
 
 await buildPlugin({

--- a/plugins/plugin-mcp/__tests__/integration/mcp-server.test.ts
+++ b/plugins/plugin-mcp/__tests__/integration/mcp-server.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Opt-in integration tests for real MCP server connectivity.
+ * The npx-backed lane is gated by ELIZA_MCP_NPX_INTEGRATION because package-manager and registry delays can exceed the normal unit timeout.
+ */
+
 import { execSync } from "node:child_process";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
@@ -5,7 +10,6 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const runNpxMcpServerTests = process.env.ELIZA_MCP_NPX_INTEGRATION === "1";
 
-// Helper function to check if a command exists
 function commandExists(cmd: string): boolean {
   try {
     execSync(`which ${cmd}`, { stdio: "ignore" });
@@ -14,18 +18,6 @@ function commandExists(cmd: string): boolean {
     return false;
   }
 }
-
-/**
- * Integration tests for MCP server connectivity.
- * These tests require real MCP servers to be available.
- *
- * To run these tests, you need:
- * 1. Node.js installed
- * 2. npx available in PATH
- *
- * The external npx-backed tests are opt-in via ELIZA_MCP_NPX_INTEGRATION=1
- * because package-manager/network delays can exceed the unit test timeout.
- */
 
 describe("MCP Server Integration", () => {
   describe("StdioClientTransport", () => {

--- a/plugins/plugin-mcp/__tests__/validation.test.ts
+++ b/plugins/plugin-mcp/__tests__/validation.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Selection-validator tests for MCP tool and resource dispatch.
+ * They cover untrusted model output before a call reaches a connected server, including server state, tool/resource existence, and argument schema checks.
+ */
+
 import type { State } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
@@ -5,13 +10,6 @@ import {
   validateToolSelectionArgument,
   validateToolSelectionName,
 } from "../src/utils/validation.js";
-
-/**
- * The selection validators gate untrusted model output before it dispatches a
- * tool/resource call: a selection may only target a *connected* server and a
- * tool/resource that actually exists, and tool arguments must satisfy the
- * tool's own input schema.
- */
 
 const stateWith = (mcp: Record<string, unknown>): State =>
   ({ values: { mcp }, data: {}, text: "" }) as unknown as State;

--- a/plugins/plugin-mcp/src/utils/__tests__/json.test.ts
+++ b/plugins/plugin-mcp/src/utils/__tests__/json.test.ts
@@ -1,13 +1,11 @@
+/**
+ * JSON utility tests for MCP model-output parsing and argument validation.
+ * They cover fenced/prose-wrapped JSON extraction, JSON5 leniency, and schema checks for tool-call arguments.
+ */
+
 import { describe, expect, it } from "vitest";
 import { parseJSON, parseStructuredModelOutput, validateJsonSchema } from "../json";
 
-/**
- * Tests for the MCP JSON utilities (#8801 / #9943). `parseJSON` /
- * `parseStructuredModelOutput` extract a JSON object out of raw model output
- * (fences, surrounding prose, JSON5 leniency) and `validateJsonSchema` gates
- * tool-call arguments — both brittle, security/correctness-relevant, and
- * previously untested.
- */
 describe("parseJSON", () => {
   it("parses a plain JSON object", () => {
     expect(parseJSON('{"a":1}')).toEqual({ a: 1 });

--- a/plugins/plugin-pty/index.ts
+++ b/plugins/plugin-pty/index.ts
@@ -1,23 +1,12 @@
+/**
+ * PTY service plugin for elizaOS web terminal sessions.
+ * It registers the `PTY_SERVICE` bridge and authenticated spawn/list/stop routes that connect the existing xterm UI and WebSocket path to real interactive CLI processes.
+ */
+
 import type { Plugin } from "@elizaos/core";
 import { ptyRoutes } from "./routes/pty-routes";
 import { PtyService } from "./services/pty-service";
 
-/**
- * `@elizaos/plugin-pty` — registers `PTY_SERVICE`, the one piece the app's web
- * terminal needs to drive a real interactive CLI.
- *
- * The xterm UI, the WebSocket `pty-input`/`pty-output`/`pty-resize` handlers in
- * the agent server, and the interactive `eliza-code` CLI already exist. Without
- * a registered `PTY_SERVICE`, `getPtyConsoleBridge()` returns null and the
- * terminal is inert. This plugin supplies that service (a node-pty–backed
- * console bridge) plus routes to spawn/list/stop sessions — most importantly an
- * interactive `eliza-code` session pointed at Eliza Cloud/cerebras, giving a
- * real CLI with all slash commands on any device, with an agent we own (no TOS
- * exposure).
- *
- * Opt-in: add it to an agent's plugin list. Intended for the developer-gated
- * cockpit; disabled automatically on store builds.
- */
 export const ptyPlugin: Plugin = {
   name: "pty",
   description:

--- a/plugins/plugin-pty/lib/eliza-code-spec.ts
+++ b/plugins/plugin-pty/lib/eliza-code-spec.ts
@@ -1,27 +1,12 @@
+/**
+ * Spawn-spec builders for interactive eliza-code PTY sessions.
+ * The pure builders point the owned eliza-code CLI at Eliza Cloud with coding-only confinement so cockpit sessions run a real slash-command terminal without inheriting the server environment.
+ */
+
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { DEFAULT_CEREBRAS_TEXT_MODEL } from "@elizaos/core";
 import type { PtySpawnSpec } from "../services/pty-types";
-
-/**
- * Builds the {@link PtySpawnSpec} that launches the **interactive** `eliza-code`
- * CLI (the real slash-command TUI in `packages/examples/code`) inside a PTY,
- * pointed at Eliza Cloud so inference runs on cerebras (`gemma-4-31b` for both
- * fast and smart tiers).
- *
- * This is the load-bearing wiring for "a real CLI on my phone": eliza-code is an
- * agent we own (no TOS exposure), it already implements `/help`, `/clear`,
- * `/task`, etc., and it selects its provider purely from env — so pointing it at
- * cerebras is entirely an environment concern, captured here as a pure function.
- *
- * eliza-code's provider resolution (packages/examples/code/src/lib/model-provider.ts):
- *   ELIZA_CODE_PROVIDER=openai  →  plugin-openai, keyed by OPENAI_API_KEY, with
- *   OPENAI_BASE_URL / OPENAI_{SMALL,MEDIUM,LARGE}_MODEL overrides. Eliza Cloud
- *   exposes an OpenAI-compatible endpoint, so this routes straight to cerebras.
- *
- * Cockpit PTY sessions run eliza-code in coding-only mode so the terminal
- * cannot recursively spawn orchestrator sub-agents from inside the REPL.
- */
 
 export const ELIZA_CLOUD_DEFAULT_BASE_URL = "https://api.elizacloud.ai/v1";
 export const ELIZA_CLOUD_FAST_MODEL = DEFAULT_CEREBRAS_TEXT_MODEL;

--- a/plugins/plugin-pty/lib/vendor-cli-spec.ts
+++ b/plugins/plugin-pty/lib/vendor-cli-spec.ts
@@ -1,27 +1,11 @@
+/**
+ * Spawn-spec builders for the gated vendor-CLI PTY tier.
+ * They launch real interactive subscription CLIs only through explicit route gates, pass credential handles opaquely, and never parse or persist vendor tokens here.
+ */
+
 import { existsSync } from "node:fs";
 import path from "node:path";
 import type { PtySpawnSpec } from "../services/pty-types";
-
-/**
- * Spawn specs for the EXPERIMENTAL vendor-CLI tier (#10832 Phase 2): the real
- * interactive **Claude Code** / **Codex** CLIs in a PTY, authenticating with
- * the user's OWN subscription credentials. Running a vendor CLI on a
- * subscription is the TOS-unsafe tier, so the spawn route only reaches these
- * builders behind `PTY_VENDOR_CLI_ENABLED` (default OFF) — and never on store
- * builds.
- *
- * Credential paths reuse the conventions of the existing subscription plugins:
- *   • claude — `plugin-anthropic-proxy`'s loader order: `CLAUDE_CODE_OAUTH_TOKEN`
- *     env first, else the CLI reads `~/.claude/.credentials.json` itself (the
- *     PTY inherits HOME). The token is passed through opaquely, never parsed
- *     or logged.
- *   • codex — `plugin-codex-cli`'s auth cache `~/.codex/auth.json`; an explicit
- *     `CODEX_HOME` (the per-account dir convention used by
- *     coding-account-bridge) is passed through when configured.
- *
- * Both CLIs are launched PLAIN (no args): the interactive TUI, not the
- * `claude --print` / `codex exec` one-shot paths.
- */
 
 /** Session kinds served by the vendor-CLI tier. */
 export type PtyVendorCliKind = "claude" | "codex";

--- a/plugins/plugin-pty/services/bun-pty-spawn.ts
+++ b/plugins/plugin-pty/services/bun-pty-spawn.ts
@@ -1,12 +1,10 @@
+/**
+ * Bun native PTY adapter for interactive terminal sessions.
+ * It uses `Bun.spawn({ terminal })` under Bun because node-pty's write path is broken there, while preserving the same handle contract the Node adapter uses.
+ */
+
 import type { PtyHandle, PtySpawn } from "./pty-types";
 
-/**
- * True when running on the Bun runtime, which provides a native PTY
- * (`Bun.spawn({ terminal })`). We prefer it under Bun because `@lydell/node-pty`'s
- * write path is broken there (`this._socket.write is not a function`) — output
- * streams fine but keystrokes throw. Bun's own terminal handles both. Under
- * Node, node-pty works end to end, so we use it there.
- */
 export function isBunRuntime(): boolean {
   return typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
 }

--- a/plugins/plugin-pty/services/pty-service.ts
+++ b/plugins/plugin-pty/services/pty-service.ts
@@ -1,3 +1,8 @@
+/**
+ * Service registration for interactive PTY terminal sessions.
+ * It exposes the `PTY_SERVICE` console bridge that the agent server's WebSocket layer uses for output, keystrokes, resize events, and session lifecycle.
+ */
+
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
 import {
   PtyConsoleBridge,
@@ -6,10 +11,6 @@ import {
 } from "./pty-session-store";
 import type { PtySessionInfo, PtySpawnSpec } from "./pty-types";
 
-/**
- * Resolves the directory interactive PTY sessions are confined to:
- * `PTY_ALLOWED_DIRECTORY` (setting or env) → the process cwd.
- */
 function resolveAllowedRoot(runtime?: IAgentRuntime): string {
   const fromSetting = runtime?.getSetting?.("PTY_ALLOWED_DIRECTORY");
   const raw =
@@ -29,17 +30,6 @@ function resolveIdleTimeoutMs(runtime?: IAgentRuntime): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
-/**
- * `PTY_SERVICE`: the single service the agent server looks up
- * (`runtime.getService("PTY_SERVICE")`) to drive the web terminal. It exposes a
- * {@link PtyConsoleBridge} (`consoleBridge`) that the WS layer subscribes to for
- * output and forwards keystrokes/resizes into, plus session lifecycle methods
- * the plugin's routes call.
- *
- * Registering this service is the ONE missing piece: the xterm UI, the WS
- * `pty-input`/`pty-output`/`pty-resize` handlers, and the interactive
- * `eliza-code` CLI all already exist — this connects them.
- */
 export class PtyService extends Service {
   public static serviceType = "PTY_SERVICE";
 

--- a/plugins/plugin-pty/services/pty-session-store.ts
+++ b/plugins/plugin-pty/services/pty-session-store.ts
@@ -1,3 +1,8 @@
+/**
+ * PTY session store and console bridge for web-terminal sessions.
+ * It confines child process environment/cwd, buffers output for late subscribers, selects Bun or Node PTY backends, and emits the bridge events consumed by the agent server.
+ */
+
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import path from "node:path";
@@ -28,10 +33,6 @@ const EXITED_SESSION_TTL_MS = 15_000;
 /** Fallback reap for REPL sessions whose browser/socket disappeared. */
 const DEFAULT_IDLE_TIMEOUT_MS = 15 * 60_000;
 
-/**
- * Small, non-secret process env that a child terminal commonly needs to start
- * (path lookup, home directory, locale, color). Do not add account/API secrets.
- */
 const SAFE_INHERITED_ENV_KEYS = new Set([
   "PATH",
   "Path",
@@ -56,7 +57,6 @@ const SAFE_INHERITED_ENV_KEYS = new Set([
   "XDG_DATA_HOME",
 ]);
 
-/** Explicit spawn-spec env the interactive-CLI PTYs are allowed to receive. */
 const ALLOWED_SPEC_ENV_KEYS = new Set([
   "ELIZA_CODE_PROVIDER",
   "ELIZA_CODE_CODING_ONLY",

--- a/plugins/plugin-pty/test/fake-pty.ts
+++ b/plugins/plugin-pty/test/fake-pty.ts
@@ -1,11 +1,10 @@
+/**
+ * Controllable in-memory PTY test double for the PTY session store.
+ * Tests exercise the same handle callbacks and write/resize/kill methods as a native PTY while replacing only the operating-system terminal.
+ */
+
 import type { PtyHandle, PtySpawn } from "../services/pty-types";
 
-/**
- * A controllable in-memory stand-in for a node-pty `IPty`. Lets tests drive the
- * exact same code path the native module would (onData/onExit callbacks,
- * write/resize/kill recording) without a real terminal — so the store, bridge,
- * and routing logic are exercised for real, only the OS PTY is doubled.
- */
 export class FakePty implements PtyHandle {
   readonly pid: number;
   readonly written: string[] = [];

--- a/plugins/plugin-pty/test/pty.real.test.ts
+++ b/plugins/plugin-pty/test/pty.real.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Real PTY engine tests for the session store and console bridge.
+ * They spawn actual OS processes through the runtime-selected PTY backend and assert output, exit, and keystroke flow without the fake handle.
+ */
+
 import { describe, expect, it } from "vitest";
 import { isBunRuntime } from "../services/bun-pty-spawn";
 import type {
@@ -10,12 +15,6 @@ import {
   PtySessionStore,
 } from "../services/pty-session-store";
 
-/**
- * Real end-to-end test of the PTY engine: spawns an ACTUAL OS process through
- * the real store + bridge (no fakes) and asserts output/exit/keystroke flow.
- * Under Bun this exercises Bun.spawn({ terminal }) via bunTruePtySpawn; under
- * Node it gates on `@lydell/node-pty` actually loading (optional native dep).
- */
 let ptyAvailable = isBunRuntime();
 try {
   if (!ptyAvailable) {

--- a/plugins/plugin-shell/__tests__/isSafeBinUsage.test.ts
+++ b/plugins/plugin-shell/__tests__/isSafeBinUsage.test.ts
@@ -1,14 +1,12 @@
+/**
+ * Shell auto-approval guard tests for safe binary usage.
+ * They pin the security boundary that only allowlisted executables without path-like or existing-file arguments may be auto-approved.
+ */
+
 import { describe, expect, it } from "vitest";
 import { isSafeBinUsage, normalizeSafeBins } from "../approvals/analysis";
 import type { CommandResolution } from "../approvals/types";
 
-/**
- * Tests for the shell auto-approval guard (#8801 / #9943). isSafeBinUsage decides
- * whether a command may be auto-approved: only an allowlisted executable with NO
- * path-like / existing-file arguments (so it can't quietly read or mutate files).
- * It's a security boundary and was untested; `fileExists` is injected for
- * determinism.
- */
 const res = (
   executableName: string,
   resolvedPath: string | undefined = `/usr/bin/${executableName}`

--- a/plugins/plugin-shell/__tests__/isSafeCommand.test.ts
+++ b/plugins/plugin-shell/__tests__/isSafeCommand.test.ts
@@ -1,12 +1,11 @@
+/**
+ * Shell command-injection guard tests for executable command strings.
+ * They pin dangerous patterns that the shell plugin must reject before command execution reaches the service.
+ */
+
 import { describe, expect, it } from "vitest";
 import { isSafeCommand } from "../utils/pathUtils";
 
-/**
- * Tests for the shell command-injection guard (#8801 / #9943). isSafeCommand
- * gates what the shell plugin will run, so it is a security boundary — yet it
- * had no assertions. The dangerous-pattern set is pinned so a future edit that
- * weakens it fails loudly.
- */
 describe("isSafeCommand", () => {
   it("allows ordinary commands (including a single pipe)", () => {
     for (const c of ["ls -la", "echo hello world", "git status", "cat file.txt | grep needle"]) {

--- a/plugins/plugin-shell/auto-enable.ts
+++ b/plugins/plugin-shell/auto-enable.ts
@@ -1,9 +1,8 @@
-// Auto-enable check for @elizaos/plugin-shell.
-//
-// Plugin manifest entry-point — referenced by package.json's
-// `elizaos.plugin.autoEnableModule`. Keep this module light: env reads only,
-// no service init, no transitive imports of the full plugin runtime. The
-// auto-enable engine loads dozens of these per boot.
+/**
+ * Auto-enable gate for the shell execution plugin.
+ * The manifest loads this module during boot, so it stays limited to feature/env checks and avoids service imports.
+ */
+
 import type { PluginAutoEnableContext } from "@elizaos/core";
 
 function isFeatureEnabled(config: PluginAutoEnableContext["config"], key: string): boolean {

--- a/plugins/plugin-trajectory-logger/src/api-client.contract.test.ts
+++ b/plugins/plugin-trajectory-logger/src/api-client.contract.test.ts
@@ -1,19 +1,7 @@
-// External-API CONTRACT test.
-//
-// The api-client wire types (TrajectoryListResult / TrajectoryDetail / UILlmCall /
-// UIToolEvent / UIEvaluationEvent / UIProviderAccess) describe the subset of the
-// @elizaos/plugin-training trajectory routes this widget reads. This test feeds
-// the REAL parser (fetchTrajectoryList / fetchTrajectoryDetail / readJson) a
-// fixture whose shape is copied verbatim from the provider's response builders:
-//   - GET /api/trajectories  -> { trajectories: UITrajectoryRecord[], total, offset, limit }
-//     (plugin-training/src/routes/trajectory-routes.ts: handleGetTrajectories
-//      -> listItemToUIRecord)
-//   - GET /api/trajectories/:id -> UITrajectoryDetailResult
-//     (handleGetTrajectoryDetail -> trajectoryToUIDetail: trajectory + llmCalls
-//      with stepType/purpose/actionType/response, providerAccesses, toolEvents,
-//      evaluationEvents)
-// It then asserts the parsed DTOs are contract-valid AND that summarizePhases()
-// + extractShouldRespondDecision() classify the real payload end-to-end.
+/**
+ * External API contract tests for the trajectory logger client.
+ * The fixtures mirror plugin-training route responses so the real parser and phase summarizers are checked against the wire shape this widget reads.
+ */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -24,8 +12,6 @@ import {
 } from "./api-client.js";
 import { extractShouldRespondDecision, summarizePhases } from "./phases.js";
 
-// Verbatim from listItemToUIRecord(): a full UITrajectoryRecord. The widget reads
-// only id/status/llmCallCount, but the real route returns the whole record.
 const LIST_PAYLOAD = {
   trajectories: [
     {
@@ -72,8 +58,6 @@ const LIST_PAYLOAD = {
   limit: 10,
 };
 
-// Verbatim from trajectoryToUIDetail() + buildUIEventFields(): a complete
-// UITrajectoryDetailResult covering all four phases.
 const DETAIL_PAYLOAD = {
   trajectory: { ...LIST_PAYLOAD.trajectories[1], status: "completed" },
   llmCalls: [

--- a/plugins/plugin-trajectory-logger/src/api-client.ts
+++ b/plugins/plugin-trajectory-logger/src/api-client.ts
@@ -1,6 +1,7 @@
-// Wire shapes for /api/trajectories[?/...] (served by @elizaos/plugin-training).
-// Only the fields the widget reads are typed — extra fields the route returns
-// are tolerated, just untyped.
+/**
+ * Wire types and fetch wrappers for trajectory logger routes.
+ * The plugin-training API returns larger payloads, but this client types only the fields the widget reads and tolerates extra route fields.
+ */
 
 export interface TrajectoryListItem {
   id: string;

--- a/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.interact.ts
+++ b/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.interact.ts
@@ -1,7 +1,8 @@
-// View-bundle `interact` capability handler, split out of TrajectoryLoggerView.tsx
-// so that file exports only React components and stays Fast-Refresh-compatible
-// (Vite would full-reload a component file that also exports a plain function).
-// The view bundle re-exports `interact` via ./trajectory-logger-view-bundle.ts.
+/**
+ * View-bundle capability handler for the trajectory logger TUI surface.
+ * It stays separate from the React component file so Fast Refresh sees component-only exports while the built view bundle still exposes `interact`.
+ */
+
 import { fetchTrajectoryDetail, fetchTrajectoryList } from "../api-client";
 
 export async function interact(

--- a/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.test.tsx
+++ b/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.test.tsx
@@ -1,11 +1,9 @@
-// @vitest-environment jsdom
-
-// Drives the unified TrajectoryLoggerView (the single GUI/XR data wrapper) that
-// the bundle exports for the "gui" and "xr" modalities. Asserts it mounts the
-// one presentational TrajectoryLoggerSpatialView inside a SpatialSurface, polls
-// real-shape trajectory data into the snapshot, and routes the spatial action
-// ids (`back`, `select:<slot>:<phase>`, `refresh`) across the GUI and TUI
-// surfaces.
+/**
+ * Drives the unified TrajectoryLoggerView data wrapper through the rendered DOM.
+ * The harness mounts the spatial surface, feeds real-shape trajectory data, and routes spatial action ids across the GUI and TUI surfaces.
+ *
+ * @vitest-environment jsdom
+ */
 
 import { NAVIGATE_VIEW_EVENT } from "@elizaos/ui/events";
 import { SpatialSurface } from "@elizaos/ui/spatial";

--- a/plugins/plugin-trajectory-logger/src/components/trajectory-logger-view-bundle.ts
+++ b/plugins/plugin-trajectory-logger/src/components/trajectory-logger-view-bundle.ts
@@ -1,7 +1,7 @@
-// Vite view-bundle entry. Re-exports the unified spatial view component plus
-// the `interact` capability handler so the built bundle (dist/views/bundle.js)
-// exposes the named exports the view loader reads (`TrajectoryLoggerView`,
-// `interact`). Kept separate from TrajectoryLoggerView.tsx so that file exports
-// only React components and stays Fast-Refresh-compatible.
+/**
+ * Vite view-bundle entry for the trajectory logger.
+ * It re-exports the unified spatial view and capability handler under the named exports the elizaOS view loader reads.
+ */
+
 export { interact } from "./TrajectoryLoggerView.interact.ts";
 export { TrajectoryLoggerView } from "./TrajectoryLoggerView.tsx";

--- a/plugins/plugin-trajectory-logger/src/usePollingTrajectories.test.tsx
+++ b/plugins/plugin-trajectory-logger/src/usePollingTrajectories.test.tsx
@@ -1,9 +1,8 @@
-// @vitest-environment jsdom
-
 /**
- * Exercises the `usePollingTrajectories` hook against a stubbed `fetch` serving
- * real-shape list/detail envelopes, asserting it selects the active + last
- * trajectory, polls, and distinguishes the routes-unavailable state from errors.
+ * Polling-hook tests for trajectory logger route state.
+ * They serve real-shape list/detail envelopes through fetch and assert active/last selection, polling, and unavailable-route handling.
+ *
+ * @vitest-environment jsdom
  */
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";


### PR DESCRIPTION
## Summary
- converts missing or misplaced prose headers across the #12810 small tool plugin scope
- trims restatement/banner comments while preserving durable notes about service/test boundaries
- leaves executable code untouched; no package metadata or generated files changed

Closes #12810

## Validation
- `bun run check:comment-only`
  - PASS: 31 source files changed; every code token identical to `origin/develop`
- scoped missing-header audit over the #12810 plugin list
  - PASS: no missing headers
- `git diff --check origin/develop...HEAD`
  - PASS
- `git diff --name-only origin/develop...HEAD | xargs bunx @biomejs/biome check --config-path biome.json --files-ignore-unknown=true --no-errors-on-unmatched`
  - PASS: checked 29 files, no fixes applied

## Additional Test Attempt
- `bunx vitest run plugins/app-model-tester/src/ModelTesterAppView.test.tsx plugins/app-model-tester/src/ModelTesterView.test.tsx plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.test.tsx plugins/plugin-trajectory-logger/src/usePollingTrajectories.test.tsx`
  - FAIL in the symlinked temp worktree before exercising this comment change: duplicate React hook dispatcher (`dist/node_modules/react` vs root React) and missing `webxr-polyfill` resolution. The run did enter jsdom, confirming the moved `@vitest-environment` pragmas are still recognized.

## Evidence Notes
- Comment-only cleanup; no UI, runtime, model, DB, connector, shell, PTY, or prompt behavior changes.
- No screenshots/video/live model trajectories apply because the code token stream is unchanged.