### PR TITLE
docs(#12754): clean app-control prose headers

### DIFF
--- a/plugins/plugin-app-control/src/actions/agent-switch.test.ts
+++ b/plugins/plugin-app-control/src/actions/agent-switch.test.ts
@@ -1,7 +1,9 @@
-// Unit coverage for the AGENT_SWITCH action: profile-query parsing, the OWNER
-// role gate, and the handler driving a mocked loopback switch client. The
-// client-side trust gate + real switch live in packages/ui; the route
-// round-trip lives in packages/agent.
+/**
+ * Unit coverage for AGENT_SWITCH profile parsing, owner gating, and loopback dispatch.
+ *
+ * The client-side trust gate lives in packages/ui; the route round trip lives in
+ * packages/agent.
+ */
 
 import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-app-control/src/actions/app.test.ts
+++ b/plugins/plugin-app-control/src/actions/app.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Role-policy tests for the APP action owner-only gate.
+ */
+
 import { describe, expect, it } from "vitest";
 import { createAppAction } from "./app.js";
 

--- a/plugins/plugin-app-control/src/actions/background.test.ts
+++ b/plugins/plugin-app-control/src/actions/background.test.ts
@@ -1,3 +1,7 @@
+/**
+ * BACKGROUND action tests for plan inference and renderer broadcast payloads.
+ */
+
 import type { IAgentRuntime, Media, Memory } from "@elizaos/core";
 import { BACKGROUND_APPLY_EVENT as SHARED_BACKGROUND_APPLY_EVENT } from "@elizaos/shared/events";
 import { describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-app-control/src/actions/model-switch.test.ts
+++ b/plugins/plugin-app-control/src/actions/model-switch.test.ts
@@ -1,6 +1,8 @@
-// Unit coverage for the MODEL_SWITCH action: intent parsing, sanctioned-model
-// enforcement, and the handler driving a mocked loopback switch client (no
-// network). The route's real HTTP behavior is covered in packages/agent.
+/**
+ * Unit coverage for MODEL_SWITCH intent parsing, sanctioned models, and loopback dispatch.
+ *
+ * The route's real HTTP behavior is covered in packages/agent.
+ */
 
 import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
 import { DEFAULT_ELIZA_CLOUD_TEXT_MODEL } from "@elizaos/shared";

--- a/plugins/plugin-app-control/src/actions/scaffold-env.test.ts
+++ b/plugins/plugin-app-control/src/actions/scaffold-env.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Scaffold environment tests for template discovery and coding-dispatch preflight.
+ */
+
 import {
 	chmodSync,
 	existsSync,

--- a/plugins/plugin-app-control/src/actions/view-command-matcher.test.ts
+++ b/plugins/plugin-app-control/src/actions/view-command-matcher.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Deterministic view-command matcher tests for explicit navigation phrases.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
 	__matcherData,

--- a/plugins/plugin-app-control/src/actions/views-client.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-client.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Views client tests for loopback API normalization and request construction.
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createViewsClient } from "./views-client.js";
 

--- a/plugins/plugin-app-control/src/actions/views-create.viewkind.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-create.viewkind.test.ts
@@ -1,10 +1,10 @@
+/**
+ * Prompt contract tests for assigning ViewKind on created plugin views.
+ */
+
 import { describe, expect, it } from "vitest";
 import { buildCreatePrompt } from "./views-create";
 
-/**
- * #8917: the view-create prompt must instruct the sub-agent to set a ViewKind on
- * the Plugin.views entry (release by default, developer for tooling, never system).
- */
 describe("buildCreatePrompt viewKind contract (#8917)", () => {
 	const prompt = buildCreatePrompt(
 		"a dashboard for X",

--- a/plugins/plugin-app-control/src/actions/views-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-management.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Views management tests for create, edit, delete, and follow-up routing flows.
+ */
+
 import {
 	mkdirSync,
 	mkdtempSync,

--- a/plugins/plugin-app-control/src/components/ViewManagerSpatialView.test.tsx
+++ b/plugins/plugin-app-control/src/components/ViewManagerSpatialView.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * Spatial view-manager render tests for TUI and XR surface output.
+ */
+
 import { visibleWidth } from "@elizaos/tui";
 import { SpatialSurface } from "@elizaos/ui/spatial";
 import {

--- a/plugins/plugin-app-control/src/evaluators/view-command-routing.ts
+++ b/plugins/plugin-app-control/src/evaluators/view-command-routing.ts
@@ -1,3 +1,7 @@
+/**
+ * Pre-LLM view-command routing helper for explicit navigation utterances.
+ */
+
 import { matchViewCommand } from "../actions/view-command-matcher.js";
 
 export const VIEWS_ACTION_NAME = "VIEWS";

--- a/plugins/plugin-app-control/src/evaluators/view-command-shortcut.test.ts
+++ b/plugins/plugin-app-control/src/evaluators/view-command-shortcut.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Shortcut evaluator tests for routing explicit view commands before tool planning.
+ */
+
 import type { ResponseHandlerEvaluatorContext } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { viewCommandShortcutEvaluator } from "./view-command-shortcut.ts";

--- a/plugins/plugin-app-control/src/evaluators/view-context.test.ts
+++ b/plugins/plugin-app-control/src/evaluators/view-context.test.ts
@@ -1,3 +1,7 @@
+/**
+ * View context evaluator tests for model-guided navigation from situational cues.
+ */
+
 import type {
 	EvaluatorPromptContext,
 	EvaluatorRunContext,

--- a/plugins/plugin-app-control/src/evaluators/view-context.ts
+++ b/plugins/plugin-app-control/src/evaluators/view-context.ts
@@ -1,3 +1,7 @@
+/**
+ * Evaluator that maps user context to registered views and dispatches navigation.
+ */
+
 import type { Evaluator, EvaluatorProcessor } from "@elizaos/core";
 import {
 	logger,

--- a/plugins/plugin-app-control/src/evaluators/view-followup-routing.test.ts
+++ b/plugins/plugin-app-control/src/evaluators/view-followup-routing.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Follow-up routing tests for view capability create, delete, and update intents.
+ */
+
 import type { ResponseHandlerEvaluatorContext } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { viewFollowupRoutingEvaluator } from "./view-followup-routing.js";

--- a/plugins/plugin-app-control/src/evaluators/view-followup-routing.ts
+++ b/plugins/plugin-app-control/src/evaluators/view-followup-routing.ts
@@ -1,3 +1,7 @@
+/**
+ * Response-handler evaluator that routes follow-up intent to focused view capabilities.
+ */
+
 import type {
 	ResponseHandlerEvaluator,
 	ResponseHandlerEvaluatorContext,

--- a/plugins/plugin-app-control/src/params.test.ts
+++ b/plugins/plugin-app-control/src/params.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Parameter normalization tests for app launch and close target extraction.
+ */
+
 import type { Memory } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
@@ -6,12 +10,6 @@ import {
 	normalizeActionOptions,
 	readStringOption,
 } from "./params.js";
-
-/**
- * Target extraction is the input boundary for launch/close — options take
- * precedence over free-text, and filler-word peeling must not let an empty or
- * filler-only phrase resolve to a bogus app name.
- */
 
 const msg = (text: string): Memory =>
 	({ content: { text } }) as unknown as Memory;

--- a/plugins/plugin-app-control/src/protected-apps.test.ts
+++ b/plugins/plugin-app-control/src/protected-apps.test.ts
@@ -1,11 +1,9 @@
+/**
+ * Protected-app resolution tests for first-party slug spoofing boundaries.
+ */
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { isProtected, resolveProtectedApps } from "./protected-apps.js";
-
-/**
- * Protected-apps resolution stops a foreign package from registering under a
- * first-party slug (e.g. spoofing knowledge) — a security boundary, so the
- * name-form matching (full / basename / app-stripped, case-insensitive) is pinned.
- */
 
 let savedEnv: string | undefined;
 beforeEach(() => {

--- a/plugins/plugin-app-control/src/providers/current-view.test.ts
+++ b/plugins/plugin-app-control/src/providers/current-view.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Current-view provider tests for exposing active renderer state to agent context.
+ */
+
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -138,3 +142,6 @@ describe("current_view acknowledgement provider (#8788)", () => {
 		expect(r.values?.currentViewSubview).toBe("voice");
 	});
 });
+/**
+ * Current-view provider tests for exposing active renderer state to agent context.
+ */

--- a/plugins/plugin-app-control/src/resolve.test.ts
+++ b/plugins/plugin-app-control/src/resolve.test.ts
@@ -1,3 +1,7 @@
+/**
+ * App and run-name resolution tests for exact, fuzzy, and ambiguous targets.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
 	formatAppCandidates,
@@ -94,3 +98,6 @@ describe("candidate formatting", () => {
 		).toBe("- Calculator [runId: r-1, status: running]");
 	});
 });
+/**
+ * App and run-name resolution tests for exact, fuzzy, and ambiguous targets.
+ */

--- a/plugins/plugin-app-control/src/runtime/current-view-hook.test.ts
+++ b/plugins/plugin-app-control/src/runtime/current-view-hook.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Runtime hook tests for capturing and clearing current-view state.
+ */
+
 import type { PipelineHookContextForPhase } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 import { applyCurrentViewComposeHook } from "./current-view-hook.js";
@@ -77,3 +81,6 @@ describe("applyCurrentViewComposeHook (#8788)", () => {
 		).toHaveLength(1);
 	});
 });
+/**
+ * Runtime hook tests for capturing and clearing current-view state.
+ */

--- a/plugins/plugin-app-control/src/runtime/view-switch-signal.test.ts
+++ b/plugins/plugin-app-control/src/runtime/view-switch-signal.test.ts
@@ -1,3 +1,7 @@
+/**
+ * View-switch signal tests for tracking recent navigation events.
+ */
+
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	__resetViewSwitchSignal,
@@ -39,3 +43,6 @@ describe("view-switch-signal", () => {
 		expect(hasFreshViewSwitch("room-1", 1_000)).toBe(false);
 	});
 });
+/**
+ * View-switch signal tests for tracking recent navigation events.
+ */

--- a/plugins/plugin-app-control/src/services/__tests__/verification-room-bridge.test.ts
+++ b/plugins/plugin-app-control/src/services/__tests__/verification-room-bridge.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verification-room bridge tests for relaying verification outcomes into chat rooms.
+ */
+
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VerificationRoomBridgeService } from "../verification-room-bridge.ts";
@@ -430,3 +434,6 @@ describe("VerificationRoomBridgeService — verdict posting", () => {
 		await service.stop();
 	});
 });
+/**
+ * Verification-room bridge tests for relaying verification outcomes into chat rooms.
+ */

--- a/plugins/plugin-app-control/src/shortcuts.test.ts
+++ b/plugins/plugin-app-control/src/shortcuts.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Natural-language shortcut tests for direct view navigation commands.
+ */
+
 import { matchShortcut } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { appControlPlugin } from "./index.ts";
@@ -68,3 +72,6 @@ describe("viewNavigationShortcuts (#8791)", () => {
 		).toBeNull();
 	});
 });
+/**
+ * Natural-language shortcut tests for direct view navigation commands.
+ */

--- a/plugins/plugin-app-control/src/views/ViewManagerView.manifest.test.ts
+++ b/plugins/plugin-app-control/src/views/ViewManagerView.manifest.test.ts
@@ -1,15 +1,9 @@
-// Manifest + source-shape contract for the collapsed views-manager declaration.
-//
-// The catalog ("the views view") collapsed its three gui/xr/tui declarations to
-// ONE entry that draws every surface from the single ViewManagerView source
-// (modalities ["gui","xr","tui"], componentExport "ViewManagerView"); the
-// terminal surface renders ViewManagerSpatialView via the spatial registry.
-//
-// This pins: exactly one views-manager declaration, the collapsed `modalities`
-// literal, no `viewType` (the duplicate-per-surface escape hatch is gone), the
-// componentExport, and that ViewManagerView.tsx is the thin data wrapper that
-// renders the single ViewManagerSpatialView inside a SpatialSurface (no
-// hand-rolled rich-DOM chrome).
+/**
+ * Manifest contract tests for the collapsed views-manager declaration.
+ *
+ * One manifest entry draws gui, xr, and tui surfaces from ViewManagerView while
+ * terminal rendering is delegated through the spatial registry.
+ */
 
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -74,3 +68,6 @@ describe("views-manager manifest (collapsed tri-modal declaration)", () => {
 		expect(viewSource).not.toContain("rgba(");
 	});
 });
+/**
+ * View manager manifest tests for exported view registrations and metadata.
+ */

--- a/plugins/plugin-app-control/src/views/ViewManagerView.render.test.tsx
+++ b/plugins/plugin-app-control/src/views/ViewManagerView.render.test.tsx
@@ -1,11 +1,11 @@
-// @vitest-environment jsdom
-//
-// Behavior tests for the consolidated ViewManagerView wrapper. It owns the live
-// GET /api/views fetch and the open→navigate handoff, and renders the single
-// presentational ViewManagerSpatialView inside a <SpatialSurface> (the SAME
-// export drives gui and xr — see src/index.ts views[]). These drive the real
-// wrapper against a stubbed `fetch` and assert the populated list renders and
-// that each control fires the correct loopback request.
+/**
+ * Behavior tests for the consolidated ViewManagerView wrapper.
+ *
+ * The wrapper owns GET /api/views fetching and open-to-navigate handoff while
+ * rendering the shared ViewManagerSpatialView inside a SpatialSurface.
+ *
+ * @vitest-environment jsdom
+ */
 
 import { emitViewEvent, VIEW_EVENTS } from "@elizaos/ui/events";
 import {
@@ -278,3 +278,6 @@ describe("ViewManagerView (gui/xr) wrapper", () => {
 		expect(calls[0].url).not.toContain("?viewType");
 	});
 });
+/**
+ * View manager render tests for populated, empty, and interaction states.
+ */

--- a/plugins/plugin-app-control/src/views/viewManagerData.contract.test.ts
+++ b/plugins/plugin-app-control/src/views/viewManagerData.contract.test.ts
@@ -1,14 +1,9 @@
-// Contract test: runs the plugin's REAL parser (fetchViewEntries) over a
-// response shaped exactly like the live GET /api/views payload.
-//
-// The canonical entry shape is ViewRegistryEntry in
-// packages/ui/src/hooks/useAvailableViews.ts (the type the /api/views endpoint
-// serves). The fixture below mirrors every field of that interface so the
-// parser is exercised against the real DTO contract, not a trimmed stub. If the
-// /api/views contract changes, update useAvailableViews.ts AND this fixture
-// together. fetchViewEntries must tolerate the full shape and surface the
-// fields the ViewManager UI reads (id/label/viewType/path/available/pluginName/
-// heroImageUrl).
+/**
+ * Contract tests for parsing the live GET /api/views payload shape.
+ *
+ * The fixture mirrors ViewRegistryEntry from packages/ui so fetchViewEntries is
+ * exercised against the real DTO contract, not a trimmed stub.
+ */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-app-control/src/views/viewManagerData.interact.test.ts
+++ b/plugins/plugin-app-control/src/views/viewManagerData.interact.test.ts
@@ -1,8 +1,8 @@
-// Coverage for the TUI interact() capability layer (the data layer exported from
-// viewManagerData.ts and surfaced as the plugin's terminal-open-view /
-// terminal-list-views capabilities in src/index.ts). Pins both the happy paths
-// (list + open) and the failure paths: missing viewId, unknown viewId, and an
-// unsupported capability.
+/**
+ * TUI interact capability tests for listing and opening terminal views.
+ *
+ * These cover happy paths plus missing, unknown, and unsupported capability inputs.
+ */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { interact } from "./viewManagerData";

--- a/plugins/plugin-app-control/test/scenarios/app-create-cancel.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/app-create-cancel.scenario.ts
@@ -1,12 +1,9 @@
+/**
+ * Live-only scenario for the app-create picker cancellation path.
+ */
+
 import { scenario } from "@elizaos/scenario-runner/schema";
 
-/**
- * Multi-turn create-then-cancel flow.
- *   Turn 1 — "build a calculator app" → picker shown with new/edit-N/cancel.
- *   Turn 2 — "cancel" → APP action validates the choice reply against the
- *            pending intent, deletes the intent task, replies with a cancel
- *            confirmation. No scaffold should occur.
- */
 export default scenario({
   lane: "live-only",
 	id: "app-create-cancel",

--- a/plugins/plugin-app-control/test/scenarios/app-create-no-existing.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/app-create-no-existing.scenario.ts
@@ -1,12 +1,9 @@
+/**
+ * Live-only scenario for APP create when no installed app fuzzy-matches the intent.
+ */
+
 import { scenario } from "@elizaos/scenario-runner/schema";
 
-/**
- * Single-turn create when no installed app fuzzy-matches the intent. The
- * APP action skips the picker and goes straight to the scaffold + dispatch
- * path. The orchestrator is not actually exercised in this scenario — we
- * only assert the action selection and that the assistant's response makes
- * sense.
- */
 export default scenario({
   lane: "live-only",
 	id: "app-create-no-existing",

--- a/plugins/plugin-app-control/test/scenarios/app-create-with-existing-picker.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/app-create-with-existing-picker.scenario.ts
@@ -1,14 +1,9 @@
+/**
+ * Live-only scenario for APP create picker selection of an existing app.
+ */
+
 import { scenario } from "@elizaos/scenario-runner/schema";
 
-/**
- * Multi-turn create flow:
- *   Turn 1 — user asks to "create a 3D scene viewer app". The APP action
- *            should fire in `mode=create` and respond with a [CHOICE:app-create
- *            ...] block listing existing scene/viewer apps for editing.
- *   Turn 2 — user replies "edit-1". The action validates again because the
- *            choice reply matches a pending intent task; mode is still
- *            `create` and the choice is resolved to an edit dispatch.
- */
 export default scenario({
   lane: "live-only",
 	id: "app-create-with-existing-picker",

--- a/plugins/plugin-app-control/test/scenarios/app-launch-basic.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/app-launch-basic.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Live-only scenario for APP launch sub-mode selection.
+ */
+
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({

--- a/plugins/plugin-app-control/test/scenarios/app-list.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/app-list.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Live-only scenario for APP list sub-mode selection and response content.
+ */
+
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({

--- a/plugins/plugin-app-control/test/scenarios/app-load-from-directory.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/app-load-from-directory.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Live-only scenario for APP load_from_directory sub-mode selection.
+ */
+
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({

--- a/plugins/plugin-app-control/test/scenarios/app-relaunch.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/app-relaunch.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Live-only scenario for APP relaunch sub-mode targeting.
+ */
+
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({

--- a/plugins/plugin-app-control/test/scenarios/background-set-color.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/background-set-color.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Live-model BACKGROUND scenario for broadcasting a named color payload.
+ */
+
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {
 	jsonResponse,
@@ -5,14 +9,6 @@ import {
 	registerAppControlHttpHandler,
 	resetAppControlHttpLoopback,
 } from "../../../../packages/scenario-runner/test/scenarios/_helpers/app-control-http-loopback";
-
-/**
- * Live-model BACKGROUND coverage (#10694): the model must choose the
- * BACKGROUND action from natural phrasing, and the handler must broadcast the
- * exact `background:apply` payload the renderer consumes ("teal" resolves to
- * the curated #0891b2 hex). The loopback handler stands in for the dashboard
- * broadcast route only — routing and payload both come from the real pipeline.
- */
 
 function normalizedBackgroundBroadcasts() {
 	return readAppControlHttpRequests(

--- a/plugins/plugin-app-control/test/scenarios/background-shader-undo-redo.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/background-shader-undo-redo.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Live-model BACKGROUND scenario for shader set, undo, redo, and reset routing.
+ */
+
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {
 	jsonResponse,
@@ -5,15 +9,6 @@ import {
 	registerAppControlHttpHandler,
 	resetAppControlHttpLoopback,
 } from "../../../../packages/scenario-runner/test/scenarios/_helpers/app-control-http-loopback";
-
-/**
- * Live-model BACKGROUND round trip (#10694): a natural-language ask for a
- * lava-lamp style animated background must land on the programmable GLSL
- * shader path (lava preset), then undo, redo, and reset must each be routed
- * back through BACKGROUND. The exact ordered `background:apply` broadcast
- * ledger proves the emitted op sequence the renderer's undo/redo history
- * consumes — not just that the action ran four times.
- */
 
 function normalizedBackgroundBroadcasts() {
 	return readAppControlHttpRequests(

--- a/plugins/plugin-app-control/test/scenarios/views-crud-lifecycle-i18n.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/views-crud-lifecycle-i18n.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Live-only scenario for localized VIEWS create, show, search, and delete lifecycle.
+ */
+
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-app-control/test/scenarios/views-crud-lifecycle.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/views-crud-lifecycle.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Live-only scenario for VIEWS create, show, search, and delete lifecycle.
+ */
+
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-app-control/test/scenarios/views-list.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/views-list.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Live-only scenario for VIEWS list sub-mode selection.
+ */
+
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({

--- a/plugins/plugin-app-control/test/scenarios/views-search.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/views-search.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Live-only scenario for VIEWS search sub-mode selection.
+ */
+
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({

--- a/plugins/plugin-app-control/test/scenarios/views-show.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/views-show.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Live-only scenario for dashboard-visible VIEWS show navigation.
+ */
+
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({

--- a/plugins/plugin-app-control/test/scenarios/views-voice-navigate.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/views-voice-navigate.scenario.ts
@@ -1,3 +1,7 @@
+/**
+ * Live-only scenario for single-word voice navigation through VIEWS show mode.
+ */
+
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({

--- a/plugins/plugin-app-control/vitest.config.ts
+++ b/plugins/plugin-app-control/vitest.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Vitest configuration for app-control unit, jsdom, and source-alias test lanes.
+ */
+
 import { createRequire } from "node:module";
 import path from "node:path";
 import { defineConfig } from "vitest/config";


### PR DESCRIPTION
## Summary
- Add required top prose headers to plugin-app-control tests, evaluators, scenarios, and config files missing them.
- Convert filename/change-history-style comments into durable package-purpose prose.
- Preserve behavior: comment-only diff, no code token changes.

## Verification
- Header audit: 112 files scanned, 0 missing top prose headers
- `git diff --check -- plugins/plugin-app-control`
- `bun run check:comment-only`
- `bun run --cwd plugins/plugin-app-control lint:check`

## Verification attempted
- `bun run --cwd plugins/plugin-app-control typecheck` blocked by sparse/local dependency state: unresolved `@elizaos/contracts` dist plus unrelated declaration resolution for adze/marked/lucide-react via local `dist/node_modules`.
- `bun run --cwd plugins/plugin-app-control test` ran 34/38 files successfully after expanding sparse deps; remaining failures are local dependency/build state issues (`@elizaos/ui` export/dist resolution, React duplicate instance, packaged elizaos template resolution), not code changes.
- `bun run install:light` blocked by sparse checkout missing many root workspaces from package.json.

Closes #12754