### PR TITLE
chore: clear residual script convention audits

### DIFF
--- a/packages/lifeops-bench/package.json
+++ b/packages/lifeops-bench/package.json
@@ -9,7 +9,7 @@
     "benchmark:server": "node --import tsx src/server.ts",
     "normalize-capture": "node --import tsx scripts/normalize-eliza-capture.ts",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
     "build": "bun run typecheck"
   },
   "dependencies": {

--- a/plugins/plugin-social-alpha/package.json
+++ b/plugins/plugin-social-alpha/package.json
@@ -25,7 +25,7 @@
 	],
 	"scripts": {
 		"build": "bun run build:js && bun run build:views && bun run build:types",
-		"test": "vitest run --passWithNoTests",
+		"test": "vitest run",
 		"clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo node_modules",
 		"lint": "bunx @biomejs/biome check src",
 		"lint:check": "bun run lint",


### PR DESCRIPTION
## Summary
- switch `@elizaos/lifeops-bench` typecheck from `tsc --noEmit` to the repo-standard `tsgo --noEmit -p tsconfig.json`
- remove `--passWithNoTests` from `@elizaos/plugin-social-alpha` test script so plugin test conventions are clean

## Validation
- `node packages/scripts/audit-build-typecheck.mjs` PASS
- `node packages/scripts/ensure-plugin-test-conventions.mjs --check` PASS
- `bunx @biomejs/biome check packages/lifeops-bench/package.json plugins/plugin-social-alpha/package.json` PASS
- `git diff --check` PASS
- `bun run --cwd plugins/plugin-social-alpha lint` PASS
- `bun run --cwd plugins/plugin-social-alpha typecheck` PASS

Attempted but blocked by this sparse temp worktree's install/symlink graph:
- `bun run --cwd packages/lifeops-bench typecheck` now invokes `tsgo --noEmit -p tsconfig.json`, but fails before package-local checking on unresolved workspace packages (`@elizaos/auth/*`, `@elizaos/vault`, `@elizaos/agent`, provider plugins, shared subpaths) from the borrowed node_modules graph.
- `bun run --cwd plugins/plugin-social-alpha test` runs 6/7 test files with 21 passing tests, but the spatial view test cannot resolve `@elizaos/tui` because this temp worktree's `node_modules` is a symlink to another worktree and its generated `@elizaos/*` symlinks resolve under that old node_modules path.

## Evidence Notes
- Script-only cleanup; no runtime, UI, model, connector, wallet, or native behavior changed.
