### PR TITLE
fix(#12283): reject night-owl persona 9am due-time verification

### DIFF
--- a/.github/issue-evidence/12283-lifeops-personas.md
+++ b/.github/issue-evidence/12283-lifeops-personas.md
@@ -1,8 +1,10 @@
 # Evidence — #12283 LifeOps persona-journey scenarios
 
 Issue #12283 asks for 72 persona-journey scenarios across 8 packs. This is the
-first increment: four live-only scenarios (packs B1 and A1) driven against a
-**live** model and hand-reviewed.
+current increment: three verified A1 live-only scenarios plus one authored B1
+live-only scenario. The original B1 live report is retained below, but a
+follow-up review found its persisted local due time invalid for the premise; the
+B1 scenario now awaits a corrected live verification run.
 
 ## Scenarios 2-4 — A1 adhd-capture-and-start (tier T1)
 
@@ -47,9 +49,10 @@ the turn text, never in `promptInstructions`). Premise from the issue's B1 table
 habit and NOT default to a 9am/morning slot.
 
 `finalChecks`: `definitionCountDelta` (effect-reading — a scheduled-task
-definition was created) + `judgeRubric` (flexibility respected, no fixed slot).
+definition was created, with a forbidden 09:00 local due-time guard) +
+`judgeRubric` (flexibility respected, no fixed slot).
 
-## Verification — live run (Cerebras `gpt-oss-120b`), passed twice
+## Verification — live run correction
 
 ```
 eliza-scenarios run .../test/scenarios --scenario night-owl-flexible-habit-any-time-today
@@ -57,23 +60,30 @@ eliza-scenarios run .../test/scenarios --scenario night-owl-flexible-habit-any-t
 Totals: 1 passed, 0 failed
 ```
 
-**Trajectory, reviewed by hand** (report:
+**Original trajectory from #12972** (report:
 `.github/issue-evidence/12283-lifeops-personas/night-owl-flexible-habit-any-time-today.report.json`):
 
 - `actionsCalled: ["OWNER_REMINDERS"]` — the model routed to reminder creation.
 - Reply: *"Sure thing—I've set a reminder for you to drink a glass of water today
   around 1 pm. If you'd prefer a different time, just let me know!"* — chose 1pm
   (not a 9am/morning default) and offered flexibility.
-- `definitionCountDelta` → passed: 1 matching definition for "drink water".
+- `definitionCountDelta` → originally passed: 1 matching definition for "drink water".
 - `judgeRubric` → passed, score **1.00** ≥ 0.6.
 
-Passed on two independent runs (6.3s / 6.8s) — reliable, not a fluke.
+Follow-up correction (#12972 review): the attached JSON report stores
+`cadence.dueAt: "2026-07-04T13:00:00.000Z"` with
+`timezone: "America/New_York"`, which resolves to 09:00 local time on July 4,
+2026. The scenario now includes a structural `forbiddenDueLocalTimes` assertion
+so that artifact would fail instead of being counted as verified. The catalog is
+therefore demoted to `authored` until a new live trajectory is captured with the
+structural check passing.
 
 ## Catalog + gates
 
 - `_catalogs/night-owl-anchored-day.catalog.json` records the scenario as
-  `verified`. `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs`
-  → B1 1/24 authored, 1/1 verified; the entry resolves to the real file.
+  `authored`, not `verified`, until a recaptured trajectory passes the structural
+  local-time assertion. `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs`
+  resolves the entry to the real file.
 - `_catalogs/adhd-capture-and-start.catalog.json` records three A1 scenarios as
   `verified`. The same catalog coverage command reports A1 3/28 authored, 3/3
   verified; each entry resolves to the real scenario file.
@@ -84,17 +94,19 @@ Passed on two independent runs (6.3s / 6.8s) — reliable, not a fluke.
 
 ## Scope note (honest)
 
-This is 1 of 72. A second B1 premise (`night-owl-end-of-her-evening-nudge`,
-recurring 2am wind-down) was authored and run live: the model behaved correctly
-(scheduled the nudge toward her ~2am night window, judge 1.00) **but no
-scheduled-task definition persisted** — a real recurring-reminder persistence
-gap in the `OWNER_REMINDERS` path worth a separate investigation, so it is not
-shipped here. The remaining packs/premises are enumerated in the issue's tables.
+This file currently covers three verified A1 scenarios plus one authored B1
+scenario awaiting recapture. A second B1 premise
+(`night-owl-end-of-her-evening-nudge`, recurring 2am wind-down) was authored and
+run live: the model behaved correctly (scheduled the nudge toward her ~2am night
+window, judge 1.00) **but no scheduled-task definition persisted** — a real
+recurring-reminder persistence gap in the `OWNER_REMINDERS` path worth a
+separate investigation, so it is not shipped here. The remaining packs/premises
+are enumerated in the issue's tables.
 
 ## Evidence rows
 
 | Evidence | Status |
 | --- | --- |
-| Real-LLM trajectory | **Attached + reviewed** — live Cerebras `gpt-oss-120b`; `OWNER_REMINDERS` created the B1 habit plus three A1 reminders, each judge 1.00; report JSON in `.github/issue-evidence/12283-lifeops-personas/`. |
-| Domain artifacts | `life_scheduled_definitions` rows — asserted via `definitionCountDelta`, including delta 0 for the superseded Sarah task. |
+| Real-LLM trajectory | A1 trajectories are **attached + reviewed** — live Cerebras `gpt-oss-120b`, each judge 1.00. B1 trajectory is attached but **invalid as verification** because the persisted `dueAt` resolves to 09:00 America/New_York; a new B1 live trajectory is required. |
+| Domain artifacts | A1 `life_scheduled_definitions` rows are asserted via `definitionCountDelta`, including delta 0 for the superseded Sarah task. The B1 row is now rejected by `forbiddenDueLocalTimes` until recaptured with a non-9am local due time. |
 | Frontend / screenshots | N/A — no UI surface changed (scenario authoring). |

--- a/packages/scenario-runner/schema/index.d.ts
+++ b/packages/scenario-runner/schema/index.d.ts
@@ -209,6 +209,11 @@ type DefinitionCountRequiredSlot = {
   label?: string;
   minuteOfDay?: number;
 };
+type DefinitionCountForbiddenDueLocalTime = {
+  hour: number;
+  minute?: number;
+  timeZone?: string;
+};
 type DefinitionCountWebsiteAccess = {
   groupKey?: string;
   websites?: string[];
@@ -419,6 +424,7 @@ export type ScenarioFinalCheck =
       requiredEveryMinutes?: number;
       requiredMaxOccurrencesPerDay?: number;
       expectedTimeZone?: string;
+      forbiddenDueLocalTimes?: DefinitionCountForbiddenDueLocalTime[];
       requireReminderPlan?: boolean;
       websiteAccess?: DefinitionCountWebsiteAccess;
     })

--- a/packages/scenario-runner/schema/index.js
+++ b/packages/scenario-runner/schema/index.js
@@ -105,6 +105,7 @@ export const FINAL_CHECK_KEYS = new Map(
       "requiredEveryMinutes",
       "requiredMaxOccurrencesPerDay",
       "expectedTimeZone",
+      "forbiddenDueLocalTimes",
       "requireReminderPlan",
       "websiteAccess",
     ],

--- a/packages/scenario-runner/src/final-checks/definition-count-final-check.test.ts
+++ b/packages/scenario-runner/src/final-checks/definition-count-final-check.test.ts
@@ -131,6 +131,31 @@ describe("definitionCountDelta final check", () => {
     expect(result.detail).toContain("1260");
   });
 
+  it("fails when a once definition lands on a forbidden local due time", async () => {
+    mockState.definitions = [
+      definitionRecord({
+        title: "Drink water",
+        timezone: "America/New_York",
+        cadence: {
+          kind: "once",
+          dueAt: "2026-07-04T13:00:00.000Z",
+        },
+      }),
+    ];
+
+    const result = await run({
+      type: "definitionCountDelta",
+      title: "Drink water",
+      delta: 1,
+      cadenceKind: "once",
+      forbiddenDueLocalTimes: [{ hour: 9, minute: 0 }],
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.detail).toContain("09:00");
+    expect(result.detail).toContain("forbidden");
+  });
+
   it("lists the stored definition titles when no title matches (misroute diagnostic)", async () => {
     // The live gemma-4-31b brush-teeth misroute saved the habit under the
     // goals store / a different title; the "saw none" branch must name what

--- a/packages/scenario-runner/src/final-checks/index.ts
+++ b/packages/scenario-runner/src/final-checks/index.ts
@@ -468,6 +468,11 @@ type DefinitionCountCheck = {
   requiredEveryMinutes?: number;
   requiredMaxOccurrencesPerDay?: number;
   expectedTimeZone?: string;
+  forbiddenDueLocalTimes?: Array<{
+    hour?: number;
+    minute?: number;
+    timeZone?: string;
+  }>;
   requireReminderPlan?: boolean;
   websiteAccess?: Record<string, unknown>;
 };
@@ -593,6 +598,40 @@ function looselyMatchesValue(actual: unknown, expected: unknown): boolean {
   return actual === expected;
 }
 
+function localHourMinuteForInstant(
+  dueAt: unknown,
+  timeZone: unknown,
+): { hour: number; minute: number } | null {
+  if (typeof dueAt !== "string" || typeof timeZone !== "string") {
+    return null;
+  }
+  const date = new Date(dueAt);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: false,
+    }).formatToParts(date);
+    const hourPart = parts.find((part) => part.type === "hour")?.value;
+    const minutePart = parts.find((part) => part.type === "minute")?.value;
+    if (hourPart === undefined || minutePart === undefined) {
+      return null;
+    }
+    const parsedHour = Number(hourPart);
+    const parsedMinute = Number(minutePart);
+    if (Number.isNaN(parsedHour) || Number.isNaN(parsedMinute)) {
+      return null;
+    }
+    return { hour: parsedHour % 24, minute: parsedMinute };
+  } catch {
+    return null;
+  }
+}
+
 function definitionMismatchReasons(
   record: DefinitionRecordLike,
   check: DefinitionCountCheck,
@@ -652,6 +691,31 @@ function definitionMismatchReasons(
     reasons.push(
       `maxOccurrencesPerDay expected ${check.requiredMaxOccurrencesPerDay}, saw ${String(cadence?.maxOccurrencesPerDay ?? "missing")}`,
     );
+  }
+  if (
+    Array.isArray(check.forbiddenDueLocalTimes) &&
+    check.forbiddenDueLocalTimes.length > 0
+  ) {
+    const dueAt = cadence?.dueAt;
+    for (const forbidden of check.forbiddenDueLocalTimes) {
+      if (typeof forbidden.hour !== "number") {
+        continue;
+      }
+      const timeZone = forbidden.timeZone ?? record.definition.timezone;
+      const local = localHourMinuteForInstant(dueAt, timeZone);
+      if (!local) {
+        reasons.push(
+          `dueAt local time unavailable for ${String(dueAt ?? "missing")} in ${String(timeZone ?? "missing timezone")}`,
+        );
+        continue;
+      }
+      const minute = forbidden.minute ?? 0;
+      if (local.hour === forbidden.hour && local.minute === minute) {
+        reasons.push(
+          `dueAt local time ${String(local.hour).padStart(2, "0")}:${String(local.minute).padStart(2, "0")} in ${String(timeZone)} is forbidden`,
+        );
+      }
+    }
   }
   if (typeof check.requireReminderPlan === "boolean") {
     const hasReminderPlan =

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/night-owl-anchored-day.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/night-owl-anchored-day.catalog.json
@@ -18,8 +18,8 @@
       "pack": "B1",
       "tier": "T1",
       "surface": "scenario-runner",
-      "status": "verified",
-      "notes": "Live Cerebras gpt-oss-120b run passed (judge 1.00): a flexible 'any time today' water habit; the model chose 1pm rather than a 9am/morning default."
+      "status": "authored",
+      "notes": "Follow-up to #12972: the first live report resolved 2026-07-04T13:00:00Z to 09:00 America/New_York, so it is not verified until recaptured with the structural forbiddenDueLocalTimes check passing."
     }
   ]
 }

--- a/plugins/plugin-personal-assistant/test/scenarios/night-owl-flexible-habit-any-time-today.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/night-owl-flexible-habit-any-time-today.scenario.ts
@@ -45,6 +45,8 @@ export default scenario({
         "stay hydrated",
       ],
       delta: 1,
+      cadenceKind: "once",
+      forbiddenDueLocalTimes: [{ hour: 9, minute: 0 }],
     },
     {
       type: "judgeRubric",


### PR DESCRIPTION
## What

Follow-up to #12972. The merged night-owl persona scenario claimed the live run avoided a 9am/morning default, but the attached domain artifact stored `cadence.dueAt: 2026-07-04T13:00:00.000Z` with `timezone: America/New_York`, which is 09:00 local on July 4, 2026.

This PR:
- adds `definitionCountDelta.forbiddenDueLocalTimes` so scenario final checks can reject a persisted `cadence.dueAt` that resolves to a forbidden local wall-clock time;
- wires the night-owl scenario to forbid 09:00 local;
- demotes the B1 catalog entry from `verified` to `authored`;
- updates the evidence note to mark the original report invalid as verification until recaptured.

## Verification

Passed:
- `bunx vitest run packages/scenario-runner/src/final-checks/definition-count-final-check.test.ts packages/scenario-runner/src/schema-strict.test.ts` — 17 passed
- `bun run --cwd packages/scenario-runner typecheck`
- `bunx @biomejs/biome check <touched files>`
- `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --json` — B1 authored 1, verified 0, no errors
- `git diff --check`

Also ran `bun run --cwd packages/scenario-runner test`; it still has unrelated existing failures in `scenario-pr-workflow.test.ts` (`test-status:` workflow assertion) and `deterministic-action-coverage.test.ts` (app-control action manifest drift plus two unclassified live scenario ids). The targeted final-check/schema tests above pass.

## Evidence

No UI/model behavior changed. This is a structural scenario-runner assertion and evidence correction. The new unit test encodes the exact bad artifact from #12972: `2026-07-04T13:00:00.000Z` in `America/New_York` must fail as forbidden `09:00` local.