### PR TITLE
fix(cloud): server-generate /v1/messages billing requestId (close #12938's changes-requested, #11588 class)

### DIFF
--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -721,11 +721,18 @@ app.post("/", async (c) => {
     // valid `tools` array); keep it inside the settle-refunding try so a
     // conversion throw refunds the reservation instead of stranding the debit
     // the caller was just charged (refund-gap class, #11795).
-    // Request-stable id for the affiliate-earnings dedupe sourceId in billUsage
-    // (getRequestIdempotencyKey is header-based, so a client retry of the SAME
-    // request dedupes the cashable creator/affiliate legs; a fresh uuid is the
-    // no-header fallback). Threaded into handleStream / handleNonStream.
-    const requestId = getRequestIdempotencyKey() ?? crypto.randomUUID();
+    // #11588: the billing requestId feeds the affiliate-earnings dedupe
+    // sourceId (getAffiliateEarningsSourceId → `ai_billing:<op>:<requestId>`,
+    // deduped on addEarnings) while the org charge is unconditional. It MUST
+    // NOT be client-controllable, or a caller pinning `x-request-id`/an
+    // idempotency key across two real billed requests could suppress the
+    // second affiliate/creator credit while still paying the org charge
+    // (mirrors chat/completions). Server-generate it once per request — it
+    // stays stable across this request's stream-finish/abort/non-stream
+    // settle contexts, so the single-flight billing dedupe is preserved. The
+    // client retry key remains ONLY the reservation idempotencyKey (#10423).
+    // Threaded into handleStream / handleNonStream.
+    const requestId = crypto.randomUUID();
     const messages = anthropicMessagesToModelMessages(request.messages);
     const tools = convertTools(request.tools);
     const toolChoice = mapToolChoice(request.tool_choice);


### PR DESCRIPTION
## What

Follow-up to **#12938**, which merged with @lalalune's CHANGES_REQUESTED review unaddressed: `billUsage`'s `requestId` on `/v1/messages` was still

```ts
const requestId = getRequestIdempotencyKey() ?? crypto.randomUUID(); // header/client-derived
```

This PR applies exactly what that review asked for — mirror `chat/completions` (`route.ts:877-887`, the #11588 fix):

```ts
const requestId = crypto.randomUUID(); // server-generated, once per request
```

## Why (money path)

The billing `requestId` feeds the affiliate-earnings dedupe sourceId (`getAffiliateEarningsSourceId` → `ai_billing:<op>:<requestId>`, deduped on `addEarnings`) while the **org charge is unconditional**. Client-controllable ⇒ a caller pinning `x-request-id`/`Idempotency-Key` across two real billed requests suppresses the second affiliate/creator credit while still paying the org charge — the exact #11588 class. Known-pattern rule from #11512: never key an earnings/idempotency dedupe on a client-controlled value.

## What is preserved

- `requestId` is generated once per request, so it stays **request-stable across the stream-finish / abort / non-stream settle contexts** — the single-flight billing dedupe #12938 added is untouched (its test only asserts a stable truthy string, still green by construction).
- The client retry key remains **only** the reservation `idempotencyKey` (#10423 semantics, unchanged at `route.ts:660`).

## Scope

One hunk, comment + 1 line of code in `packages/cloud/api/v1/messages/route.ts`. No UI/model/prompt changes.

Flagging honestly: authored from a deps-less checkout — proven by diff inspection + parity with the chat/completions reference implementation; relying on Cloud Tests CI for the suite run (the touched behavior is covered by `messages-abort-partial-settle.test.ts`'s requestId assertions).

— [cloud-security]