### PR TITLE
fix(plugin-health): 3 timezone/DST pure-logic bugs — UTC-keyed history days, DST fall-back day collapse, baseline-prior convention mismatch

### DIFF
--- a/plugins/plugin-health/src/screen-time/ranges.localdate.test.ts
+++ b/plugins/plugin-health/src/screen-time/ranges.localdate.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression test: `enumerateScreenTimeHistoryDays` must key each history
+ * bucket by the LOCAL calendar date. In any UTC+ timezone, local midnight maps
+ * to the previous UTC date, so a `toISOString()`-derived key labels every day
+ * with the day before (Tokyo local 2026-06-01T00:00 is 2026-05-31T15:00Z).
+ * Pure, deterministic; overrides the suite's pinned TZ per-test and restores it.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { enumerateScreenTimeHistoryDays } from "./ranges.js";
+
+const ORIGINAL_TZ = process.env.TZ;
+
+afterEach(() => {
+  process.env.TZ = ORIGINAL_TZ;
+});
+
+describe("enumerateScreenTimeHistoryDays local date key", () => {
+  it("keys days by the local calendar date in a UTC+ timezone (Tokyo)", () => {
+    process.env.TZ = "Asia/Tokyo";
+    const days = enumerateScreenTimeHistoryDays({
+      since: "2026-06-01T01:30:00.000Z", // 10:30 JST June 1
+      until: "2026-06-02T06:45:00.000Z", // 15:45 JST June 2
+    });
+
+    expect(days.map((day) => day.date)).toEqual(["2026-06-01", "2026-06-02"]);
+    // The day key must agree with the local (label) day, not the UTC day of
+    // the bucket's start instant.
+    expect(days[0]?.since).toBe("2026-05-31T15:00:00.000Z");
+  });
+
+  it("keys days by the local calendar date in a UTC- timezone (Los Angeles)", () => {
+    process.env.TZ = "America/Los_Angeles";
+    const days = enumerateScreenTimeHistoryDays({
+      since: "2026-06-01T10:30:00.000Z", // 03:30 PDT June 1
+      until: "2026-06-02T15:45:00.000Z", // 08:45 PDT June 2
+    });
+
+    expect(days.map((day) => day.date)).toEqual(["2026-06-01", "2026-06-02"]);
+  });
+});

--- a/plugins/plugin-health/src/screen-time/ranges.ts
+++ b/plugins/plugin-health/src/screen-time/ranges.ts
@@ -26,6 +26,18 @@ function addDays(date: Date, days: number): Date {
   return next;
 }
 
+// The day key must come from the LOCAL calendar date, not toISOString():
+// local midnight in any UTC+ timezone maps to the previous UTC date, which
+// would shift every history bucket back a day (e.g. Tokyo 2026-06-01T00:00
+// local is 2026-05-31T15:00Z).
+function localDateKey(date: Date): string {
+  return `${date.getFullYear().toString().padStart(4, "0")}-${(
+    date.getMonth() + 1
+  )
+    .toString()
+    .padStart(2, "0")}-${date.getDate().toString().padStart(2, "0")}`;
+}
+
 export function screenTimeRangeLabel(range: LifeOpsScreenTimeRangeKey): string {
   switch (range) {
     case "today":
@@ -84,7 +96,7 @@ export function enumerateScreenTimeHistoryDays(
     const dayStart = cursor;
     const dayEnd = addDays(dayStart, 1);
     days.push({
-      date: dayStart.toISOString().slice(0, 10),
+      date: localDateKey(dayStart),
       since: dayStart.toISOString(),
       until: new Date(Math.min(dayEnd.getTime(), endMs)).toISOString(),
       label: new Intl.DateTimeFormat(undefined, {

--- a/plugins/plugin-health/src/sleep/circadian-rules.baseline-prior.test.ts
+++ b/plugins/plugin-health/src/sleep/circadian-rules.baseline-prior.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression test for the `baselinePrior` circadian rule. The baseline stores
+ * bedtime in the 12..36 "hours past prior noon" convention and wake in 0..24;
+ * comparing the two conventions directly made the rule fire
+ * `currentHourLikelyAsleep` all afternoon AND during the post-wake morning,
+ * while the `currentHourLikelyAwake` branch was unreachable for any wake
+ * hour before ~08:00. Pure and timezone-parameterized.
+ */
+import { describe, expect, it } from "vitest";
+import type { LifeOpsPersonalBaseline } from "../contracts/health.js";
+import { scoreCircadianRules } from "./circadian-rules.js";
+
+const TYPICAL_BASELINE: LifeOpsPersonalBaseline = {
+  medianWakeLocalHour: 7,
+  medianBedtimeLocalHour: 23,
+  medianSleepDurationMin: 480,
+  bedtimeStddevMin: 20,
+  wakeStddevMin: 20,
+  sampleCount: 10,
+  windowDays: 28,
+};
+
+// Score with no signals/windows so the only possible firing is baselinePrior.
+function baselineFirings(
+  isoInstant: string,
+  baseline: LifeOpsPersonalBaseline,
+): string[] {
+  const result = scoreCircadianRules({
+    nowMs: Date.parse(isoInstant),
+    timezone: "America/Los_Angeles",
+    signals: [],
+    windows: [],
+    baseline,
+    regularityClass: "very_regular",
+    hasCurrentSleepEpisode: false,
+    currentSleepStartedAtMs: null,
+    lastSleepEndedAtMs: null,
+    currentEpisodeLikelyNap: false,
+  });
+  return result.firings.map(
+    (firing) => `${firing.name}->${firing.contributes}`,
+  );
+}
+
+describe("baselinePrior rule (bedtime 23:00, wake 07:00)", () => {
+  it("does not fire mid-afternoon", () => {
+    // 14:00 PDT — squarely inside the awake day, outside both windows.
+    expect(baselineFirings("2026-06-02T21:00:00Z", TYPICAL_BASELINE)).toEqual(
+      [],
+    );
+  });
+
+  it("fires the awake prior in the post-wake morning window", () => {
+    // 08:00 PDT — one hour after the baseline wake.
+    expect(baselineFirings("2026-06-02T15:00:00Z", TYPICAL_BASELINE)).toEqual([
+      "baseline.currentHourLikelyAwake->awake",
+    ]);
+  });
+
+  it("fires the asleep prior after bedtime and across midnight", () => {
+    // 23:30 PDT
+    expect(baselineFirings("2026-06-03T06:30:00Z", TYPICAL_BASELINE)).toEqual([
+      "baseline.currentHourLikelyAsleep->sleeping",
+    ]);
+    // 03:00 PDT
+    expect(baselineFirings("2026-06-02T10:00:00Z", TYPICAL_BASELINE)).toEqual([
+      "baseline.currentHourLikelyAsleep->sleeping",
+    ]);
+  });
+
+  it("handles a past-midnight bedtime (01:30, stored as 25.5)", () => {
+    const lateBaseline: LifeOpsPersonalBaseline = {
+      ...TYPICAL_BASELINE,
+      medianBedtimeLocalHour: 25.5,
+      medianWakeLocalHour: 9,
+    };
+    // 00:30 PDT — after midnight but before the 01:30 bedtime: no prior.
+    expect(baselineFirings("2026-06-02T07:30:00Z", lateBaseline)).toEqual([]);
+    // 02:00 PDT — inside the sleep window.
+    expect(baselineFirings("2026-06-02T09:00:00Z", lateBaseline)).toEqual([
+      "baseline.currentHourLikelyAsleep->sleeping",
+    ]);
+  });
+});

--- a/plugins/plugin-health/src/sleep/circadian-rules.ts
+++ b/plugins/plugin-health/src/sleep/circadian-rules.ts
@@ -252,8 +252,22 @@ const RULES: readonly Rule[] = [
     const hour = localHour(inputs.nowMs, inputs.timezone);
     const { medianBedtimeLocalHour: bedtime, medianWakeLocalHour: wake } =
       inputs.baseline;
-    const normalized = hour < 12 ? hour + 24 : hour;
-    if (normalized >= bedtime || normalized < wake + 12) {
+    // Compare on the plain 24h clock. `medianBedtimeLocalHour` uses the
+    // baseline's 12..36 "hours past prior noon" convention while the current
+    // hour and `medianWakeLocalHour` are 0..24, so both windows are reduced
+    // mod 24 and evaluated circularly (a window may span midnight).
+    const hourOfDay = ((hour % 24) + 24) % 24;
+    const bedtimeHour = ((bedtime % 24) + 24) % 24;
+    const wakeHour = ((wake % 24) + 24) % 24;
+    const inCircularWindow = (
+      value: number,
+      start: number,
+      end: number,
+    ): boolean =>
+      start <= end
+        ? value >= start && value < end
+        : value >= start || value < end;
+    if (inCircularWindow(hourOfDay, bedtimeHour, wakeHour)) {
       return {
         name: "baseline.currentHourLikelyAsleep",
         contributes: "sleeping",
@@ -262,7 +276,7 @@ const RULES: readonly Rule[] = [
         reason: `within baseline bedtime window (${bedtime.toFixed(1)}h-${wake.toFixed(1)}h)`,
       };
     }
-    if (normalized >= wake && normalized < wake + 4) {
+    if (inCircularWindow(hourOfDay, wakeHour, (wakeHour + 4) % 24)) {
       return {
         name: "baseline.currentHourLikelyAwake",
         contributes: "awake",

--- a/plugins/plugin-health/src/sleep/sleep-cycle.day-boundary.test.ts
+++ b/plugins/plugin-health/src/sleep/sleep-cycle.day-boundary.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression test: `resolveLifeOpsDayBoundary` must span the full LOCAL
+ * calendar day across DST transitions. Advancing local midnight by 24 elapsed
+ * hours lands on 23:00 of the SAME local day on a fall-back day (25 local
+ * hours), collapsing the boundary to endOfDay === startOfDay. Pure and
+ * timezone-parameterized — no dependence on the machine TZ.
+ */
+import { describe, expect, it } from "vitest";
+import { resolveLifeOpsDayBoundary } from "./sleep-cycle.js";
+
+const NO_SLEEP_CYCLE = {
+  cycleType: "unknown" as const,
+  sleepConfidence: 0.5,
+  currentSleepStartedAt: null,
+  lastSleepStartedAt: null,
+  lastSleepEndedAt: null,
+};
+
+describe("resolveLifeOpsDayBoundary DST handling", () => {
+  it("spans the full 25h local day on the US DST fall-back day", () => {
+    const boundary = resolveLifeOpsDayBoundary({
+      nowMs: Date.parse("2026-11-01T12:00:00-05:00"), // noon EST, fall-back day
+      timezone: "America/New_York",
+      sleepCycle: NO_SLEEP_CYCLE,
+    });
+
+    expect(boundary.startOfDayAt).toBe("2026-11-01T04:00:00.000Z"); // 00:00 EDT
+    expect(boundary.endOfDayAt).toBe("2026-11-02T05:00:00.000Z"); // 00:00 EST next day
+    expect(
+      Date.parse(boundary.endOfDayAt) - Date.parse(boundary.startOfDayAt),
+    ).toBe(25 * 3_600_000);
+  });
+
+  it("spans the 23h local day on the US DST spring-forward day", () => {
+    const boundary = resolveLifeOpsDayBoundary({
+      nowMs: Date.parse("2026-03-08T12:00:00-04:00"), // noon EDT, spring-forward day
+      timezone: "America/New_York",
+      sleepCycle: NO_SLEEP_CYCLE,
+    });
+
+    expect(boundary.startOfDayAt).toBe("2026-03-08T05:00:00.000Z"); // 00:00 EST
+    expect(boundary.endOfDayAt).toBe("2026-03-09T04:00:00.000Z"); // 00:00 EDT next day
+    expect(
+      Date.parse(boundary.endOfDayAt) - Date.parse(boundary.startOfDayAt),
+    ).toBe(23 * 3_600_000);
+  });
+
+  it("spans exactly 24h on a plain day", () => {
+    const boundary = resolveLifeOpsDayBoundary({
+      nowMs: Date.parse("2026-06-15T12:00:00-04:00"),
+      timezone: "America/New_York",
+      sleepCycle: NO_SLEEP_CYCLE,
+    });
+
+    expect(boundary.startOfDayAt).toBe("2026-06-15T04:00:00.000Z");
+    expect(boundary.endOfDayAt).toBe("2026-06-16T04:00:00.000Z");
+  });
+});

--- a/plugins/plugin-health/src/sleep/sleep-cycle.ts
+++ b/plugins/plugin-health/src/sleep/sleep-cycle.ts
@@ -15,6 +15,7 @@ import type {
 } from "../contracts/health.js";
 import { LIFEOPS_HEALTH_SIGNAL_SOURCES } from "../contracts/health.js";
 import {
+  addDaysToLocalDate,
   buildUtcDateFromLocalParts,
   getLocalDateKey,
   getZonedDateParts,
@@ -671,10 +672,10 @@ export function resolveLifeOpsDayBoundary(args: {
     minute: 0,
     second: 0,
   });
-  const nextDateParts = getZonedDateParts(
-    new Date(startOfDay.getTime() + 24 * 60 * 60 * 1_000),
-    args.timezone,
-  );
+  // Advance by calendar day, not by 24 elapsed hours: on a DST fall-back day
+  // (25 local hours) local-midnight + 24h is still 23:00 of the SAME local
+  // day, which would collapse the boundary to endOfDay === startOfDay.
+  const nextDateParts = addDaysToLocalDate(localDateParts, 1);
   const endOfDay = buildUtcDateFromLocalParts(args.timezone, {
     year: nextDateParts.year,
     month: nextDateParts.month,


### PR DESCRIPTION
## Summary

Three real, probe-confirmed pure-logic bugs in `plugins/plugin-health/src`, each fixed minimally with a mutation-checked unit test. No scheduler changes, no promptInstructions-driven behavior, no money/cloud surfaces touched.

## Bug 1 — screen-time history days keyed by the UTC date, not the local day

`enumerateScreenTimeHistoryDays` (`src/screen-time/ranges.ts`) built each bucket's `date` from `dayStart.toISOString().slice(0, 10)`. `dayStart` is **local** midnight, so in any UTC+ timezone the UTC date string is the *previous* day.

**Concrete failure (probe-executed pre-fix):** `TZ=Asia/Tokyo`, window covering local June 1–2 2026 →
`[{ date: "2026-05-31", label: "6/1" }, { date: "2026-06-01", label: "6/2" }]` — every history point's day key disagrees with the local day it represents. Consumed by `plugin-personal-assistant` `getScreenTimeHistory`, which spreads `...day` into user-facing history points. The existing `ranges.test.ts` only stayed green because the suite pins `TZ=America/Los_Angeles`, where local-midnight's UTC date coincides with the local date.

**Fix:** derive the key from the local calendar parts (`getFullYear`/`getMonth`/`getDate`).
**Test:** `src/screen-time/ranges.localdate.test.ts` (Tokyo + LA control). Mutation check: revert fix → Tokyo case fails (`2026-05-31` vs `2026-06-01`) → restore → green.

## Bug 2 — `resolveLifeOpsDayBoundary` collapses to a zero-width day on DST fall-back

`src/sleep/sleep-cycle.ts` found "next local midnight" by adding **24 elapsed hours** to local midnight and re-projecting. On a 25-hour fall-back day that lands at 23:00 of the *same* local day, so the rebuilt "next day" midnight is the same instant as the start.

**Concrete failure (probe-executed pre-fix):** `timezone: "America/New_York"`, `now = 2026-11-01T12:00-05:00` → `startOfDayAt === endOfDayAt === "2026-11-01T04:00:00.000Z"` — a zero-width `LifeOpsDayBoundary` on every US DST fall-back day, feeding schedule-insight day anchoring.

**Fix:** advance one **calendar** day via the existing `addDaysToLocalDate` before rebuilding local midnight. After the fix the fall-back day spans 25h (`end = 2026-11-02T05:00Z`), spring-forward spans 23h, plain days 24h — all asserted.
**Test:** `src/sleep/sleep-cycle.day-boundary.test.ts` (timezone-parameterized, no machine-TZ dependence). Mutation check: revert fix → fall-back case fails → restore → green.

## Bug 3 — circadian `baselinePrior` rule mixes hour conventions; "likely asleep" fires all afternoon, awake branch unreachable

`medianBedtimeLocalHour` uses the documented **12..36 "hours past prior noon"** convention (`contracts/lifeops.ts:1665`); `medianWakeLocalHour` and the current hour are **0..24**. `src/sleep/circadian-rules.ts` compared them directly (`normalized >= bedtime || normalized < wake + 12`; awake branch `normalized >= wake && normalized < wake + 4`).

**Concrete failure (probe-executed pre-fix, bedtime 23:00 / wake 07:00, very_regular, no other signals):**
- 14:00 local → fired `baseline.currentHourLikelyAsleep` (mid-afternoon!) via `14 < 7 + 12`.
- 08:00 local (post-wake morning) → fired `currentHourLikelyAsleep` instead of `currentHourLikelyAwake` via `32 >= 23`.
- The `currentHourLikelyAwake` branch is **unreachable** for any wake hour before ~08:00 (`normalized` is always ≥ 12 but the window tops out at `wake + 4`).

Net effect: a standing wrong `sleeping` weight biases `scoreCircadianRules` toward sleep during the day for every regular sleeper, and the intended morning-awake prior never contributes.

**Fix:** reduce both windows mod 24 and evaluate them as circular `[start, end)` windows (sleep = `[bedtime, wake)`, awake = `[wake, wake+4)`), handling past-midnight bedtimes (25.5 → 1:30) and midnight-spanning windows.
**Test:** `src/sleep/circadian-rules.baseline-prior.test.ts` (afternoon no-fire, morning awake, post-bedtime + mid-night asleep, past-midnight bedtime). Mutation check: revert fix → afternoon + morning cases fail → restore → green.

## Evidence

| Item | Result |
|---|---|
| Probe-execution of each bug pre-fix (real function, concrete input → wrong output) | ✅ all three reproduced (outputs quoted above) |
| New unit tests | ✅ 3 files / 9 tests green (`bunx vitest run --no-cache`) |
| Mutation checks (revert each fix alone → its test fails → restore) | ✅ all three |
| Neighboring suites (ranges, sleep-cycle, sleep-regularity ×2, awake-probability, sleep-service, routes/sleep) | ✅ 10 files / 37 tests green |
| Full plugin suite | ✅ 133 tests green; 3 pre-existing **collection** failures from unbuilt `@elizaos/ui` workspace dep (`Cannot find package '@elizaos/ui/spatial'`) verified identical on clean `origin/develop` via stash — unrelated |
| Typecheck (`tsgo`) + biome on touched files | ✅ clean |
| Live-LLM trajectory / screenshots / video | N/A — pure deterministic domain math (no agent/action/prompt/model or UI change); behavior fully proven by concrete-input unit tests above |

[phone-ui]

---
**Authored end-to-end by a Fable-5 agent** (verified 100% claude-fable-5), committed + pushed on its own branch. Each fix probe-executed against the real function (concrete TZ input → wrong output) BEFORE authoring. Independently re-verified: 6-file merge-base diff, 9/9 green (--no-cache), DST fall-back mutation reproduced (revert → test red; restore → green). These bugs were INVISIBLE in CI because the suite pins TZ=America/Los_Angeles — the agent tested Tokyo (UTC+) + America/New_York DST to surface them. Agent dropped 3 speculative candidates. The 3 pre-existing plugin-health COLLECTION failures (smoke/HealthSpatialView/HealthView) are an unbuilt @elizaos/ui workspace dep, verified identical on clean develop — unrelated. — [phone-ui]