### PR TITLE
docs(#12757): clean plugin-browser prose headers

### DIFF
--- a/plugins/plugin-browser/auto-enable.ts
+++ b/plugins/plugin-browser/auto-enable.ts
@@ -1,9 +1,9 @@
-// Auto-enable check for @elizaos/plugin-browser.
-//
-// Plugin manifest entry-point — referenced by package.json's
-// `elizaos.plugin.autoEnableModule`. Keep this module light: env reads only,
-// no service init, no transitive imports of the full plugin runtime. The
-// auto-enable engine loads dozens of these per boot.
+/**
+ * Import-free auto-enable predicate for the browser automation plugin.
+ *
+ * The plugin manifest references this module directly, so it only reads config
+ * and avoids transitive imports of the full browser runtime.
+ */
 import type { PluginAutoEnableContext } from "@elizaos/core";
 
 function isFeatureEnabled(

--- a/plugins/plugin-browser/src/__tests__/browser-service.test.ts
+++ b/plugins/plugin-browser/src/__tests__/browser-service.test.ts
@@ -1,3 +1,7 @@
+/**
+ * BrowserService tests for target registration, resolution, and dispatch behavior.
+ */
+
 import { ElizaError } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BrowserService, type BrowserTarget } from "../browser-service.js";

--- a/plugins/plugin-browser/src/actions/browser.test.ts
+++ b/plugins/plugin-browser/src/actions/browser.test.ts
@@ -1,3 +1,7 @@
+/**
+ * BROWSER action tests for command normalization and target dispatch.
+ */
+
 import type { HandlerCallback } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { BROWSER_SERVICE_TYPE } from "../browser-service.js";

--- a/plugins/plugin-browser/src/actions/browser.ts
+++ b/plugins/plugin-browser/src/actions/browser.ts
@@ -1,3 +1,7 @@
+/**
+ * BROWSER action dispatcher for workspace, bridge, and external browser targets.
+ */
+
 import type {
   Action,
   ActionExample,

--- a/plugins/plugin-browser/src/actions/wait-for-url-predicate.test.ts
+++ b/plugins/plugin-browser/src/actions/wait-for-url-predicate.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Predicate tests for BROWSER wait_for_url substring and regex matching.
+ */
+
 import { describe, expect, it } from "vitest";
 import { buildWaitForUrlPredicate } from "./wait-for-url-predicate.js";
 

--- a/plugins/plugin-browser/src/actions/wait-for-url.test.ts
+++ b/plugins/plugin-browser/src/actions/wait-for-url.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Deterministic tests for the BROWSER wait_for_url polling loop.
+ */
+
 import { describe, expect, it, vi } from "vitest";
 import { waitForUrl } from "./wait-for-url.js";
 

--- a/plugins/plugin-browser/src/bridge-policy.test.ts
+++ b/plugins/plugin-browser/src/bridge-policy.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser bridge policy tests for token expiry and URL focus helpers.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   browserBridgeDomainFromUrl,

--- a/plugins/plugin-browser/src/bridge-policy.ts
+++ b/plugins/plugin-browser/src/bridge-policy.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser bridge token, expiry, focus-window, and domain policy helpers.
+ */
+
 export const MAX_BROWSER_FOCUS_WINDOW_MS = 2 * 60 * 1000;
 export const DEFAULT_BROWSER_COMPANION_PAIRING_TOKEN_TTL_MS =
   30 * 24 * 60 * 60 * 1000;

--- a/plugins/plugin-browser/src/bridge-readiness.test.ts
+++ b/plugins/plugin-browser/src/bridge-readiness.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser bridge readiness tests for companion recency, permissions, and pause state.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   browserBridgeCompanionIsRecent,

--- a/plugins/plugin-browser/src/bridge-readiness.ts
+++ b/plugins/plugin-browser/src/bridge-readiness.ts
@@ -1,3 +1,7 @@
+/**
+ * Readiness policy for summarizing browser bridge setup and companion health.
+ */
+
 import type {
   BrowserBridgeCompanionStatus,
   BrowserBridgePermissionState,

--- a/plugins/plugin-browser/src/bridge-records.test.ts
+++ b/plugins/plugin-browser/src/bridge-records.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser bridge record constructor tests for companion, tab, and page-context defaults.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   createBrowserBridgeCompanionStatus,

--- a/plugins/plugin-browser/src/bridge-records.ts
+++ b/plugins/plugin-browser/src/bridge-records.ts
@@ -1,3 +1,7 @@
+/**
+ * Constructors for normalized browser bridge companion, tab, and page-context records.
+ */
+
 import crypto from "node:crypto";
 import type {
   BrowserBridgeCompanionStatus,

--- a/plugins/plugin-browser/src/browser-capture-hooks.ts
+++ b/plugins/plugin-browser/src/browser-capture-hooks.ts
@@ -1,3 +1,7 @@
+/**
+ * Global browser capture hook registry shared by runtime and capture surfaces.
+ */
+
 import type { BrowserCaptureConfig } from "./workspace/browser-capture.js";
 
 export interface BrowserCaptureHooks {

--- a/plugins/plugin-browser/src/browser-workspace-hooks.ts
+++ b/plugins/plugin-browser/src/browser-workspace-hooks.ts
@@ -1,3 +1,7 @@
+/**
+ * Global browser workspace hook registry for desktop and web command execution.
+ */
+
 import type {
   BrowserWorkspaceTab,
   EvaluateBrowserWorkspaceTabRequest,

--- a/plugins/plugin-browser/src/companion-auth.test.ts
+++ b/plugins/plugin-browser/src/companion-auth.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Companion authentication tests for browser bridge token validation.
+ */
+
 import { describe, expect, it } from "vitest";
 import { authenticateBrowserBridgeCompanionCredential } from "./companion-auth.js";
 

--- a/plugins/plugin-browser/src/companion-auth.ts
+++ b/plugins/plugin-browser/src/companion-auth.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser bridge companion authentication types and bearer-token validators.
+ */
+
 export type BrowserBridgeCompanionCredentialLike = {
   companion: {
     pairingTokenExpiresAt?: string | null;

--- a/plugins/plugin-browser/src/lifeops-session-contracts.ts
+++ b/plugins/plugin-browser/src/lifeops-session-contracts.ts
@@ -1,3 +1,7 @@
+/**
+ * LifeOps browser-session contracts shared by the browser bridge route surface.
+ */
+
 import type { BrowserBridgeAction, BrowserBridgeKind } from "./contracts.js";
 
 export type LifeOpsBrowserSessionStatus =

--- a/plugins/plugin-browser/src/message-adapter.test.ts
+++ b/plugins/plugin-browser/src/message-adapter.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Message adapter tests for reading browser bridge page contexts as messages.
+ */
+
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { BrowserBridgeAdapter } from "./message-adapter.js";

--- a/plugins/plugin-browser/src/message-adapter.ts
+++ b/plugins/plugin-browser/src/message-adapter.ts
@@ -1,3 +1,7 @@
+/**
+ * MessageAdapter implementation backed by browser bridge page-context records.
+ */
+
 import {
   BaseMessageAdapter,
   type IAgentRuntime,

--- a/plugins/plugin-browser/src/packaging.ts
+++ b/plugins/plugin-browser/src/packaging.ts
@@ -1,3 +1,7 @@
+/**
+ * Companion browser-extension packaging helpers for build, reveal, and download flows.
+ */
+
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";

--- a/plugins/plugin-browser/src/parity/browser-matrix.test.ts
+++ b/plugins/plugin-browser/src/parity/browser-matrix.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser parity matrix tests against the live BROWSER action schema.
+ */
+
 import { listSubactionsFromParameters } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { browserAction } from "../actions/browser.js";

--- a/plugins/plugin-browser/src/password-manager-bridge.test.ts
+++ b/plugins/plugin-browser/src/password-manager-bridge.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Password manager bridge tests for backend selection and secret-safe clipboard injection.
+ */
+
 import { afterEach, describe, expect, it } from "vitest";
 import {
   clearPasswordManagerBackendCache,

--- a/plugins/plugin-browser/src/routes/__tests__/browser-bridge-companion-revoke.test.ts
+++ b/plugins/plugin-browser/src/routes/__tests__/browser-bridge-companion-revoke.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser bridge route tests for companion revoke authorization and state changes.
+ */
+
 import type http from "node:http";
 import type { AgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-browser/src/routes/__tests__/workspace-account-gate.test.ts
+++ b/plugins/plugin-browser/src/routes/__tests__/workspace-account-gate.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Workspace account-gate route tests for authentication and authorization decisions.
+ */
+
 import {
   getConnectorAccountManager,
   type IAgentRuntime,

--- a/plugins/plugin-browser/src/routes/workspace-account-gate.ts
+++ b/plugins/plugin-browser/src/routes/workspace-account-gate.ts
@@ -1,3 +1,7 @@
+/**
+ * Account gate middleware for browser workspace HTTP routes.
+ */
+
 import {
   type ConnectorAccount,
   type ConnectorAccountAccessGate,

--- a/plugins/plugin-browser/src/routes/workspace-routes.test.ts
+++ b/plugins/plugin-browser/src/routes/workspace-routes.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser workspace route tests for command dispatch and HTTP response mapping.
+ */
+
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/plugins/plugin-browser/src/service.ts
+++ b/plugins/plugin-browser/src/service.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser bridge route service interface implemented by host plugins.
+ */
+
 import type { Service, UUID } from "@elizaos/core";
 import type {
   BrowserBridgeCompanionAutoPairResponse,

--- a/plugins/plugin-browser/src/targets/stagehand-target.test.ts
+++ b/plugins/plugin-browser/src/targets/stagehand-target.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Stagehand browser target tests for environment detection and command forwarding.
+ */
+
 import { describe, expect, it } from "vitest";
 import { maybeCreateStagehandTarget } from "./stagehand-target.js";
 

--- a/plugins/plugin-browser/src/targets/stagehand-target.ts
+++ b/plugins/plugin-browser/src/targets/stagehand-target.ts
@@ -1,3 +1,7 @@
+/**
+ * Stagehand BrowserTarget implementation for remote Playwright command servers.
+ */
+
 import { execFileSync, execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";

--- a/plugins/plugin-browser/src/workspace.ts
+++ b/plugins/plugin-browser/src/workspace.ts
@@ -1,1 +1,5 @@
+/**
+ * Browser workspace public re-export surface for package subpath consumers.
+ */
+
 export * from "./workspace/index.js";

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-connector-auth.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-connector-auth.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser workspace connector-auth tests for blocking secret export paths.
+ */
+
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   __resetBrowserWorkspaceStateForTests,

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-errors.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-errors.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser workspace error-contract tests for typed classification and tagging.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   type BrowserWorkspaceErrorCode,

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-script-policy.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-script-policy.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser workspace script policy tests for allowed and blocked execution paths.
+ */
+
 import { describe, expect, it } from "vitest";
 import { createDesktopBrowserWorkspaceCommandScript } from "../browser-workspace-desktop.js";
 import {

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-web-real-code.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-web-real-code.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Real-code web workspace tests for command execution against JSDOM pages.
+ */
+
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   __resetBrowserWorkspaceStateForTests,

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-web-security.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-web-security.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Web workspace security tests for script, connector, and network restrictions.
+ */
+
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   __resetBrowserWorkspaceStateForTests,

--- a/plugins/plugin-browser/src/workspace/browser-workspace-desktop.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-desktop.ts
@@ -1,3 +1,7 @@
+/**
+ * Desktop browser workspace client for forwarding commands to the embedded BrowserView.
+ */
+
 import { createBrowserWorkspaceError } from "./browser-workspace-errors.js";
 import {
   assertBrowserWorkspaceConnectorSecretsNotExported,

--- a/plugins/plugin-browser/src/workspace/browser-workspace-elements.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-elements.ts
@@ -1,3 +1,7 @@
+/**
+ * Element lookup, selector parsing, and DOM inspection helpers for browser workspace.
+ */
+
 import type { JSDOM } from "jsdom";
 import {
   buildBrowserWorkspaceCssStringLiteral,

--- a/plugins/plugin-browser/src/workspace/browser-workspace-forms.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-forms.ts
@@ -1,3 +1,7 @@
+/**
+ * Form interaction helpers for browser workspace click, fill, type, and key commands.
+ */
+
 import type { JSDOM } from "jsdom";
 import {
   buildBrowserWorkspaceElementSelector,

--- a/plugins/plugin-browser/src/workspace/browser-workspace-helpers.normalize-command.test.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-helpers.normalize-command.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Command-normalization tests for browser workspace aliases and defaults.
+ */
+
 import { describe, expect, it } from "vitest";
 import type { BrowserWorkspaceCommand } from "../actions/browser.ts";
 import { normalizeBrowserWorkspaceCommand } from "./browser-workspace-helpers.ts";

--- a/plugins/plugin-browser/src/workspace/browser-workspace-helpers.test.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-helpers.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser workspace helper tests for URL, tab, and command utility behavior.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   normalizeBrowserWorkspaceText,

--- a/plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts
@@ -1,3 +1,7 @@
+/**
+ * Shared browser workspace utilities for command normalization, tabs, and URLs.
+ */
+
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { createBrowserWorkspaceError } from "./browser-workspace-errors.js";

--- a/plugins/plugin-browser/src/workspace/browser-workspace-jsdom.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-jsdom.ts
@@ -1,3 +1,7 @@
+/**
+ * JSDOM browser workspace backend for web and mobile fallback command execution.
+ */
+
 import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";

--- a/plugins/plugin-browser/src/workspace/browser-workspace-network.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-network.ts
@@ -1,3 +1,7 @@
+/**
+ * Network interception and HAR helpers for browser workspace page loading.
+ */
+
 import {
   browserWorkspacePageFetch,
   DEFAULT_TIMEOUT_MS,

--- a/plugins/plugin-browser/src/workspace/browser-workspace-selector.test.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-selector.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Selector parsing tests for browser workspace element targeting.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   normalizeBrowserWorkspaceSelectorSyntax,

--- a/plugins/plugin-browser/src/workspace/browser-workspace-snapshots.test.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-snapshots.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Browser workspace snapshot tests for HTML, text, and screenshot outputs.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   diffBrowserWorkspaceSnapshots,

--- a/plugins/plugin-browser/src/workspace/browser-workspace-snapshots.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-snapshots.ts
@@ -1,3 +1,7 @@
+/**
+ * Snapshot, diff, screenshot, and PDF helpers for browser workspace documents.
+ */
+
 import { normalizeBrowserWorkspaceText } from "./browser-workspace-helpers.js";
 import type { BrowserWorkspaceSnapshotRecord } from "./browser-workspace-types.js";
 

--- a/plugins/plugin-browser/src/workspace/browser-workspace-state.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-state.ts
@@ -1,3 +1,7 @@
+/**
+ * Mutable tab and session state for browser workspace command execution.
+ */
+
 import type { JSDOM } from "jsdom";
 import type {
   BrowserWorkspaceDomElementSummary,

--- a/plugins/plugin-browser/src/workspace/browser-workspace-types.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-types.ts
@@ -1,3 +1,7 @@
+/**
+ * Shared command, tab, session, and result types for browser workspace.
+ */
+
 import type { JSDOM } from "jsdom";
 
 // "chromium" is emitted only by the real-Chromium benchmark executor

--- a/plugins/plugin-browser/src/workspace/browser-workspace-web.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-web.ts
@@ -1,3 +1,7 @@
+/**
+ * Web-mode browser workspace command executor backed by JSDOM documents.
+ */
+
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import {

--- a/plugins/plugin-browser/vitest.real.config.ts
+++ b/plugins/plugin-browser/vitest.real.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Vitest configuration for browser plugin real-Chromium lanes.
+ */
+
 import { defineConfig } from "vitest/config";
 import baseConfig from "../../vitest.config.ts";
 


### PR DESCRIPTION
## Summary
- Add required top prose headers to plugin-browser source and test files missing them.
- Convert the auto-enable entry comment into the standard top prose header.
- Preserve behavior: comment-only diff, no code token changes.

## Verification
- Header audit: 93 files scanned, 0 missing top prose headers
- `git diff --check -- plugins/plugin-browser`
- `bun run check:comment-only`
- `bun run --cwd plugins/plugin-browser lint:check` (exits 0; existing optional-chain warnings only)
- `bun run --cwd plugins/plugin-browser test` (27 files, 147 tests passed)

## Verification attempted
- `bun run --cwd packages/contracts build` succeeded to repair local `@elizaos/contracts` dist.
- `bun run --cwd plugins/plugin-browser typecheck` still blocked by this checkout dependency graph resolving declarations through `dist/node_modules` (`adze`, `fast-redact`, `drizzle-orm/pg-core`), plus resulting schema callback implicit-any diagnostics. No code tokens changed in this PR.

Closes #12757