### PR TITLE
docs(#12757): clean browser plugin prose headers

### DIFF
--- a/plugins/plugin-browser/auto-enable.ts
+++ b/plugins/plugin-browser/auto-enable.ts
@@ -1,9 +1,9 @@
-// Auto-enable check for @elizaos/plugin-browser.
-//
-// Plugin manifest entry-point — referenced by package.json's
-// `elizaos.plugin.autoEnableModule`. Keep this module light: env reads only,
-// no service init, no transitive imports of the full plugin runtime. The
-// auto-enable engine loads dozens of these per boot.
+/**
+ * Auto-enable gate for the browser automation plugin.
+ *
+ * The plugin manifest loads this module during boot, so it stays limited to
+ * feature-config inspection and avoids runtime imports.
+ */
 import type { PluginAutoEnableContext } from "@elizaos/core";
 
 function isFeatureEnabled(

--- a/plugins/plugin-browser/src/__tests__/browser-service.test.ts
+++ b/plugins/plugin-browser/src/__tests__/browser-service.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser target-routing tests for the pluggable browser service.
+ *
+ * They cover priority selection, fallback, pinned-target behavior, and mobile
+ * registration context without launching real browser backends.
+ */
 import { ElizaError } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BrowserService, type BrowserTarget } from "../browser-service.js";

--- a/plugins/plugin-browser/src/actions/browser.test.ts
+++ b/plugins/plugin-browser/src/actions/browser.test.ts
@@ -1,3 +1,9 @@
+/**
+ * BROWSER action tests for command normalization and service dispatch.
+ *
+ * They use an injected browser service to verify aliases, target overrides,
+ * progress callbacks, and error handling without a real browser target.
+ */
 import type { HandlerCallback } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { BROWSER_SERVICE_TYPE } from "../browser-service.js";

--- a/plugins/plugin-browser/src/actions/browser.ts
+++ b/plugins/plugin-browser/src/actions/browser.ts
@@ -1,3 +1,9 @@
+/**
+ * BROWSER action surface for workspace, bridge, and Stagehand targets.
+ *
+ * It normalizes user-facing subactions, delegates execution through
+ * BrowserService when available, and falls back to the in-process workspace.
+ */
 import type {
   Action,
   ActionExample,

--- a/plugins/plugin-browser/src/actions/wait-for-url-predicate.test.ts
+++ b/plugins/plugin-browser/src/actions/wait-for-url-predicate.test.ts
@@ -1,3 +1,9 @@
+/**
+ * URL wait-predicate tests for browser navigation workflows.
+ *
+ * They pin substring matching, regex literals, invalid-regex fallback, and
+ * empty-pattern behavior.
+ */
 import { describe, expect, it } from "vitest";
 import { buildWaitForUrlPredicate } from "./wait-for-url-predicate.js";
 

--- a/plugins/plugin-browser/src/actions/wait-for-url.test.ts
+++ b/plugins/plugin-browser/src/actions/wait-for-url.test.ts
@@ -1,10 +1,14 @@
+/**
+ * Deterministic wait-for-URL tests for browser navigation workflows.
+ *
+ * The fake clock keeps polling synchronous while covering match, timeout, and
+ * unreadable-current-URL paths.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { waitForUrl } from "./wait-for-url.js";
 
-/**
- * Deterministic fake clock: `now()` advances only when `sleep(ms)` is called,
- * so the poll loop runs synchronously with no real timers.
- */
+// `now()` advances only when `sleep(ms)` is called, so the poll loop runs
+// synchronously with no real timers.
 function fakeClock(start = 0) {
   let current = start;
   return {

--- a/plugins/plugin-browser/src/bridge-policy.test.ts
+++ b/plugins/plugin-browser/src/bridge-policy.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser bridge policy tests for pairing-token and domain helpers.
+ *
+ * They pin environment fallback order, expiry generation, and web-only domain
+ * normalization.
+ */
 import { describe, expect, it } from "vitest";
 import {
   browserBridgeDomainFromUrl,

--- a/plugins/plugin-browser/src/bridge-policy.ts
+++ b/plugins/plugin-browser/src/bridge-policy.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser bridge policy helpers for companion focus and pairing-token limits.
+ *
+ * These functions stay pure so routes and services can share the same TTL and
+ * domain-normalization behavior.
+ */
 export const MAX_BROWSER_FOCUS_WINDOW_MS = 2 * 60 * 1000;
 export const DEFAULT_BROWSER_COMPANION_PAIRING_TOKEN_TTL_MS =
   30 * 24 * 60 * 60 * 1000;

--- a/plugins/plugin-browser/src/bridge-readiness.test.ts
+++ b/plugins/plugin-browser/src/bridge-readiness.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Browser bridge readiness tests for settings, permissions, and companion age.
+ *
+ * They keep route-facing state names aligned with the bridge policy helpers.
+ */
 import { describe, expect, it } from "vitest";
 import {
   browserBridgeCompanionIsRecent,

--- a/plugins/plugin-browser/src/bridge-readiness.ts
+++ b/plugins/plugin-browser/src/bridge-readiness.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser bridge readiness resolver for companion-driven browser control.
+ *
+ * It folds settings, pause windows, companion recency, and permissions into a
+ * route-facing readiness state.
+ */
 import type {
   BrowserBridgeCompanionStatus,
   BrowserBridgePermissionState,

--- a/plugins/plugin-browser/src/bridge-records.test.ts
+++ b/plugins/plugin-browser/src/bridge-records.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Browser bridge record-factory tests for companion, tab, and page records.
+ *
+ * They pin generated ids, timestamp defaults, and pairing-token defaults.
+ */
 import { describe, expect, it } from "vitest";
 import {
   createBrowserBridgeCompanionStatus,

--- a/plugins/plugin-browser/src/bridge-records.ts
+++ b/plugins/plugin-browser/src/bridge-records.ts
@@ -1,3 +1,9 @@
+/**
+ * Record factories for browser bridge companion, tab, and page-context data.
+ *
+ * They centralize generated ids and timestamp defaults before records enter
+ * route-service storage.
+ */
 import crypto from "node:crypto";
 import type {
   BrowserBridgeCompanionStatus,

--- a/plugins/plugin-browser/src/browser-capture-hooks.ts
+++ b/plugins/plugin-browser/src/browser-capture-hooks.ts
@@ -1,3 +1,8 @@
+/**
+ * Global hook registry for browser capture operations supplied by host shells.
+ *
+ * The runtime plugin reads these hooks without importing desktop capture code.
+ */
 import type { BrowserCaptureConfig } from "./workspace/browser-capture.js";
 
 export interface BrowserCaptureHooks {

--- a/plugins/plugin-browser/src/browser-workspace-hooks.ts
+++ b/plugins/plugin-browser/src/browser-workspace-hooks.ts
@@ -1,3 +1,9 @@
+/**
+ * Global hook registry for browser workspace operations supplied by host shells.
+ *
+ * The runtime plugin calls through this boundary when desktop or app surfaces
+ * own the actual browser tabs.
+ */
 import type {
   BrowserWorkspaceTab,
   EvaluateBrowserWorkspaceTabRequest,

--- a/plugins/plugin-browser/src/companion-auth.test.ts
+++ b/plugins/plugin-browser/src/companion-auth.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Browser bridge companion bearer-auth tests.
+ *
+ * They cover active tokens, pending rotation tokens, expiry, and revocation.
+ */
 import { describe, expect, it } from "vitest";
 import { authenticateBrowserBridgeCompanionCredential } from "./companion-auth.js";
 

--- a/plugins/plugin-browser/src/companion-auth.ts
+++ b/plugins/plugin-browser/src/companion-auth.ts
@@ -1,3 +1,9 @@
+/**
+ * Companion pairing-token authentication for Browser Bridge routes.
+ *
+ * It accepts active or pending rotation tokens and returns typed failures for
+ * invalid, expired, or revoked credentials.
+ */
 export type BrowserBridgeCompanionCredentialLike = {
   companion: {
     pairingTokenExpiresAt?: string | null;

--- a/plugins/plugin-browser/src/lifeops-session-contracts.ts
+++ b/plugins/plugin-browser/src/lifeops-session-contracts.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared LifeOps browser-session contracts for browser bridge route services.
+ *
+ * The types describe session ownership, companion routing, action progress, and
+ * completion payloads without importing LifeOps internals.
+ */
 import type { BrowserBridgeAction, BrowserBridgeKind } from "./contracts.js";
 
 export type LifeOpsBrowserSessionStatus =

--- a/plugins/plugin-browser/src/message-adapter.test.ts
+++ b/plugins/plugin-browser/src/message-adapter.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser bridge message-adapter tests for triage integration.
+ *
+ * They verify availability without a route service and page-context projection
+ * into the shared message adapter shape.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { BrowserBridgeAdapter } from "./message-adapter.js";

--- a/plugins/plugin-browser/src/message-adapter.ts
+++ b/plugins/plugin-browser/src/message-adapter.ts
@@ -1,3 +1,9 @@
+/**
+ * Message adapter that exposes the current browser page to triage workflows.
+ *
+ * It reads page context through the route service and maps it into the shared
+ * MessageRef contract.
+ */
 import {
   BaseMessageAdapter,
   type IAgentRuntime,

--- a/plugins/plugin-browser/src/packaging.ts
+++ b/plugins/plugin-browser/src/packaging.ts
@@ -1,3 +1,9 @@
+/**
+ * Companion extension packaging helpers for Browser Bridge.
+ *
+ * They locate extension workspaces and artifacts, synthesize release manifests,
+ * and open or build local Chrome/Safari companion packages.
+ */
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";

--- a/plugins/plugin-browser/src/parity/browser-matrix.test.ts
+++ b/plugins/plugin-browser/src/parity/browser-matrix.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser parity-matrix tests for promoted actions and schema values.
+ *
+ * They compare the live plugin action surface with the declared capability
+ * matrix so browser command drift fails in CI.
+ */
 import { listSubactionsFromParameters } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { browserAction } from "../actions/browser.js";

--- a/plugins/plugin-browser/src/password-manager-bridge.test.ts
+++ b/plugins/plugin-browser/src/password-manager-bridge.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Password-manager bridge tests for fixture and explicit-none backends.
+ *
+ * They ensure test mode never writes real clipboard contents.
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import {
   clearPasswordManagerBackendCache,

--- a/plugins/plugin-browser/src/routes/__tests__/browser-bridge-companion-revoke.test.ts
+++ b/plugins/plugin-browser/src/routes/__tests__/browser-bridge-companion-revoke.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser Bridge route tests for companion revocation and request validation.
+ *
+ * They exercise route-level auth and malformed-input handling before service
+ * mutation.
+ */
 import type http from "node:http";
 import type { AgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-browser/src/routes/__tests__/workspace-account-gate.test.ts
+++ b/plugins/plugin-browser/src/routes/__tests__/workspace-account-gate.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser workspace route tests for connector-account privacy gates.
+ *
+ * They pin account role, status, privacy, and partition requirements before
+ * connector-backed browser sessions can run commands.
+ */
 import {
   getConnectorAccountManager,
   type IAgentRuntime,

--- a/plugins/plugin-browser/src/routes/workspace-account-gate.ts
+++ b/plugins/plugin-browser/src/routes/workspace-account-gate.ts
@@ -1,3 +1,9 @@
+/**
+ * Connector-account policy guard for browser workspace routes and commands.
+ *
+ * It validates account role, status, privacy, and partition ownership before a
+ * connector-backed browser session can expose browser state.
+ */
 import {
   type ConnectorAccount,
   type ConnectorAccountAccessGate,

--- a/plugins/plugin-browser/src/routes/workspace-routes.test.ts
+++ b/plugins/plugin-browser/src/routes/workspace-routes.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser workspace HTTP route tests for tab and command endpoints.
+ *
+ * They cover snapshot reads, malformed payloads, encoded tab ids, desktop
+ * bridge errors, and command routing responses.
+ */
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/plugins/plugin-browser/src/service.ts
+++ b/plugins/plugin-browser/src/service.ts
@@ -1,3 +1,9 @@
+/**
+ * Route-service contract for Browser Bridge and LifeOps browser sessions.
+ *
+ * Runtime hosts implement this service so plugin routes can manage settings,
+ * companions, page context, packages, and browser-session progress.
+ */
 import type { Service, UUID } from "@elizaos/core";
 import type {
   BrowserBridgeCompanionAutoPairResponse,

--- a/plugins/plugin-browser/src/targets/stagehand-target.test.ts
+++ b/plugins/plugin-browser/src/targets/stagehand-target.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Stagehand browser target tests for mobile platform gating.
+ *
+ * They verify the optional Playwright backend stays explicit on mobile and
+ * remains available for desktop routing.
+ */
 import { describe, expect, it } from "vitest";
 import { maybeCreateStagehandTarget } from "./stagehand-target.js";
 

--- a/plugins/plugin-browser/src/targets/stagehand-target.ts
+++ b/plugins/plugin-browser/src/targets/stagehand-target.ts
@@ -1,3 +1,9 @@
+/**
+ * Optional Stagehand target for BrowserService routing.
+ *
+ * It discovers a local or remote Stagehand command endpoint, gates mobile
+ * registration, and normalizes command responses into workspace results.
+ */
 import { execFileSync, execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";

--- a/plugins/plugin-browser/src/workspace.ts
+++ b/plugins/plugin-browser/src/workspace.ts
@@ -1,1 +1,4 @@
+/**
+ * Barrel export for browser workspace command and tab utilities.
+ */
 export * from "./workspace/index.js";

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-connector-auth.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-connector-auth.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser workspace connector-session tests for account partition isolation.
+ *
+ * They verify stable partition derivation, session reuse, and secret-export
+ * denial for connector-backed browser tabs.
+ */
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   __resetBrowserWorkspaceStateForTests,

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-errors.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-errors.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser workspace error tests for typed command failures.
+ *
+ * They pin error classification, idempotent tagging, and helper-created errors
+ * used by HTTP routes and command execution.
+ */
 import { describe, expect, it } from "vitest";
 import {
   type BrowserWorkspaceErrorCode,
@@ -16,7 +22,7 @@ import {
   resolveBrowserWorkspaceCommandElementRefs,
 } from "../browser-workspace-helpers.ts";
 
-/** Capture the Error thrown by a thunk. */
+// Capture the Error thrown by a thunk.
 function thrown(fn: () => unknown): unknown {
   try {
     fn();

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-script-policy.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-script-policy.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Browser workspace script-policy tests for web and desktop backends.
+ *
+ * They pin the default ban on user scripts and the explicit desktop opt-in.
+ */
 import { describe, expect, it } from "vitest";
 import { createDesktopBrowserWorkspaceCommandScript } from "../browser-workspace-desktop.js";
 import {

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-web-real-code.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-web-real-code.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Web-mode browser workspace tests for the real command router.
+ *
+ * They drive routed documents through navigation, forms, screenshots, DOM reads,
+ * and structured clicks without replacing the workspace command path.
+ */
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   __resetBrowserWorkspaceStateForTests,

--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-web-security.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-web-security.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Web-mode browser workspace security tests for user-script rejection.
+ *
+ * They prove eval and scripted waits fail before JSDOM can run arbitrary code.
+ */
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   __resetBrowserWorkspaceStateForTests,

--- a/plugins/plugin-browser/src/workspace/browser-workspace-desktop.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-desktop.ts
@@ -1,3 +1,9 @@
+/**
+ * Desktop bridge client for browser workspace commands.
+ *
+ * It resolves the local bridge configuration, forwards tab requests over HTTP,
+ * and generates in-page scripts for desktop-owned browser tabs.
+ */
 import { createBrowserWorkspaceError } from "./browser-workspace-errors.js";
 import {
   assertBrowserWorkspaceConnectorSecretsNotExported,

--- a/plugins/plugin-browser/src/workspace/browser-workspace-elements.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-elements.ts
@@ -1,3 +1,9 @@
+/**
+ * DOM element selection and inspection helpers for browser workspace commands.
+ *
+ * They build stable selectors, resolve semantic selectors, and summarize
+ * interactive elements for snapshots and agent actions.
+ */
 import type { JSDOM } from "jsdom";
 import {
   buildBrowserWorkspaceCssStringLiteral,

--- a/plugins/plugin-browser/src/workspace/browser-workspace-forms.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-forms.ts
@@ -1,3 +1,9 @@
+/**
+ * Web-mode form, control, and activation helpers for browser workspace tabs.
+ *
+ * They mutate JSDOM-backed documents the same command router uses for clicks,
+ * typing, scrolling, navigation, and form submission.
+ */
 import type { JSDOM } from "jsdom";
 import {
   buildBrowserWorkspaceElementSelector,

--- a/plugins/plugin-browser/src/workspace/browser-workspace-helpers.normalize-command.test.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-helpers.normalize-command.test.ts
@@ -1,15 +1,15 @@
+/**
+ * Browser workspace command-normalization tests for aliases and timeouts.
+ *
+ * They pin recursive step normalization so legacy command shapes route to the
+ * intended browser operation.
+ */
 import { describe, expect, it } from "vitest";
 import type { BrowserWorkspaceCommand } from "../actions/browser.ts";
 import { normalizeBrowserWorkspaceCommand } from "./browser-workspace-helpers.ts";
 
-/**
- * `normalizeBrowserWorkspaceCommand` canonicalizes a browser workspace command
- * before it is dispatched (#10333 — shipped untested). It resolves subaction
- * aliases (goto→navigate, read→get) case-insensitively, coalesces the
- * timeout from `timeoutMs` / `ms` / `milliseconds`, and recurses into nested
- * `steps`. A regression here silently routes a command to the wrong browser op
- * or drops a timeout, so each path is pinned.
- */
+// A regression here silently routes a command to the wrong browser operation or
+// drops a timeout, so each path is pinned.
 const cmd = (o: Record<string, unknown>): BrowserWorkspaceCommand =>
   o as unknown as BrowserWorkspaceCommand;
 

--- a/plugins/plugin-browser/src/workspace/browser-workspace-helpers.test.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-helpers.test.ts
@@ -1,14 +1,15 @@
+/**
+ * Browser workspace input-helper tests for untrusted command arguments.
+ *
+ * They pin numeric coercion and whitespace normalization used before browser
+ * bridge commands act on user-supplied values.
+ */
 import { describe, expect, it } from "vitest";
 import {
   normalizeBrowserWorkspaceText,
   parseBrowserWorkspaceNumberLike,
 } from "./browser-workspace-helpers";
 
-/**
- * Tests for the browser-workspace input helpers (#10333 / #8801). These coerce
- * untrusted command arguments (numbers, text) the browser bridge acts on, and
- * were untested.
- */
 describe("parseBrowserWorkspaceNumberLike", () => {
   it("passes a finite number through", () => {
     expect(parseBrowserWorkspaceNumberLike(42)).toBe(42);

--- a/plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared browser workspace helpers for command input, partitions, and errors.
+ *
+ * They normalize user-supplied values, protect connector-backed sessions from
+ * raw secret export, and enforce the user-script execution policy.
+ */
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { createBrowserWorkspaceError } from "./browser-workspace-errors.js";

--- a/plugins/plugin-browser/src/workspace/browser-workspace-jsdom.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-jsdom.ts
@@ -1,3 +1,9 @@
+/**
+ * JSDOM runtime setup for the web-mode browser workspace.
+ *
+ * It locates jsdom in Bun-hoisted installs, installs browser-like APIs, and
+ * wires runtime state into each tab document.
+ */
 import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";

--- a/plugins/plugin-browser/src/workspace/browser-workspace-network.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-network.ts
@@ -1,3 +1,9 @@
+/**
+ * Network routing and request recording for browser workspace tabs.
+ *
+ * It matches synthetic routes, applies workspace headers and credentials, and
+ * captures request metadata for HAR-like inspection.
+ */
 import {
   browserWorkspacePageFetch,
   DEFAULT_TIMEOUT_MS,

--- a/plugins/plugin-browser/src/workspace/browser-workspace-selector.test.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-selector.test.ts
@@ -1,18 +1,15 @@
+/**
+ * Browser workspace selector-parser tests for user-authored selectors.
+ *
+ * They pin quoted values, semantic selector kinds, role names, and clean
+ * failures for unsupported selector forms.
+ */
 import { describe, expect, it } from "vitest";
 import {
   normalizeBrowserWorkspaceSelectorSyntax,
   parseBrowserWorkspaceSemanticSelector,
   trimBrowserWorkspaceQuotedValue,
 } from "./browser-workspace-elements.js";
-
-/**
- * The semantic selector parser turns an LLM-/user-authored selector string
- * (e.g. `role=button[name="Submit"]`, `text=Hello`, `label: Email`) into a
- * structured find command. It must strip quotes / has-text() wrappers, accept
- * both `:` and `=` separators, route each kind to the right findBy, and return
- * null for unknown kinds or selectors with no value (so a bad selector fails
- * cleanly instead of silently matching the wrong element).
- */
 
 describe("trimBrowserWorkspaceQuotedValue", () => {
   it("unwraps single/double quotes and has-text()", () => {

--- a/plugins/plugin-browser/src/workspace/browser-workspace-snapshots.test.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-snapshots.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser workspace snapshot-helper tests for export and diff utilities.
+ *
+ * They pin PDF text escaping, snapshot-change detection, and DOM storage/cookie
+ * extraction.
+ */
 import { describe, expect, it } from "vitest";
 import {
   diffBrowserWorkspaceSnapshots,
@@ -6,13 +12,6 @@ import {
   readBrowserWorkspaceStorage,
 } from "./browser-workspace-snapshots.js";
 import type { BrowserWorkspaceSnapshotRecord } from "./browser-workspace-types.js";
-
-/**
- * Browser-workspace snapshot helpers. PDF-text escaping must neutralize the
- * `\ ( )` metacharacters (avoids malformed/injected PDF content streams),
- * snapshot diffing flags any title/url/body change, and storage/cookie parsing
- * must round-trip key/value pairs from the DOM surfaces.
- */
 
 describe("escapeBrowserWorkspacePdfText", () => {
   it("escapes backslash and parentheses", () => {

--- a/plugins/plugin-browser/src/workspace/browser-workspace-snapshots.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-snapshots.ts
@@ -1,3 +1,9 @@
+/**
+ * Snapshot and export helpers for browser workspace documents.
+ *
+ * They build synthetic screenshots, minimal PDFs, normalized text snapshots,
+ * and serializable storage/cookie state.
+ */
 import { normalizeBrowserWorkspaceText } from "./browser-workspace-helpers.js";
 import type { BrowserWorkspaceSnapshotRecord } from "./browser-workspace-types.js";
 

--- a/plugins/plugin-browser/src/workspace/browser-workspace-state.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-state.ts
@@ -1,3 +1,9 @@
+/**
+ * In-memory state for web-mode browser workspace tabs.
+ *
+ * It tracks tabs, runtime settings, element refs, clipboard text, traces, and a
+ * lock that serializes mutations across concurrent commands.
+ */
 import type { JSDOM } from "jsdom";
 import type {
   BrowserWorkspaceDomElementSummary,
@@ -28,10 +34,8 @@ export function setBrowserWorkspaceClipboardText(value: string): void {
   browserWorkspaceClipboardText = value;
 }
 
-/**
- * Simple async mutex to serialise mutations to webWorkspaceState.
- * Prevents concurrent requests from corrupting tab state or history.
- */
+// Serializes mutations to webWorkspaceState so concurrent requests do not
+// corrupt tab state or history.
 let webStateLock: Promise<void> = Promise.resolve();
 export function withWebStateLock<T>(fn: () => T | Promise<T>): Promise<T> {
   const next = webStateLock.then(fn, fn);

--- a/plugins/plugin-browser/src/workspace/browser-workspace-types.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-types.ts
@@ -1,10 +1,14 @@
+/**
+ * Browser workspace command, tab, result, and runtime-state types.
+ *
+ * These contracts are shared by in-process web mode, desktop bridge mode,
+ * Stagehand targets, route handlers, and benchmark executors.
+ */
 import type { JSDOM } from "jsdom";
 
-// "chromium" is emitted only by the real-Chromium benchmark executor
-// (src/benchmark/chromium-executor.ts, #10333) — never by
-// executeBrowserWorkspaceCommand, which stays "cloud" | "desktop" | "web". It
-// lets the benchmark's BrowserWorkspaceCommandResult carry an accurate engine
-// tag without a parallel result type.
+// "chromium" is emitted only by the real-Chromium benchmark executor; command
+// execution stays "cloud" | "desktop" | "web" so benchmark results do not need
+// a parallel result type.
 export type BrowserWorkspaceMode = "chromium" | "cloud" | "desktop" | "web";
 
 export type BrowserWorkspaceTabKind = "internal" | "standard";

--- a/plugins/plugin-browser/src/workspace/browser-workspace-web.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-web.ts
@@ -1,3 +1,9 @@
+/**
+ * Web-mode browser workspace command executor for JSDOM-backed tabs.
+ *
+ * It owns tab selection, utility commands, DOM interactions, storage/network
+ * state, and structured alternatives to arbitrary script execution.
+ */
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import {

--- a/plugins/plugin-browser/vitest.real.config.ts
+++ b/plugins/plugin-browser/vitest.real.config.ts
@@ -1,18 +1,12 @@
+/**
+ * Vitest config for real-engine browser workspace lanes.
+ *
+ * It opts `*.real.test.ts` files back into execution while keeping root
+ * workspace aliases and long timeouts for Chromium-backed runs.
+ */
 import { defineConfig } from "vitest/config";
 import baseConfig from "../../vitest.config.ts";
 
-/**
- * Dedicated config for the real-engine lanes (#10333). The root
- * `vitest.config.ts` excludes `**\/*.real.test.ts` so they stay out of the
- * default `vitest run`; this config opts them back in (without re-adding that
- * exclusion — `mergeConfig` would concatenate it back) while keeping the root's
- * `@elizaos/*` → source aliases so plugin-browser resolves its workspace deps.
- *
- * Run via: `bunx vitest run --config plugins/plugin-browser/vitest.real.config.ts`
- * (or the `test:real-chromium` package script). The lanes still self-skip when
- * no Chromium binary is installed, so this is only meaningful after
- * `bunx playwright install --with-deps chromium`.
- */
 export default defineConfig({
   resolve: baseConfig.resolve,
   test: {


### PR DESCRIPTION
## Summary
- Add top-of-file prose headers across plugin-browser files missing them.
- Convert a few header-like in-body blocks into durable implementation comments where appropriate.
- Keep this as a comment-only cleanup; no code tokens changed.

Closes #12757.

## Validation
- Scoped missing-header audit over `plugins/plugin-browser`: PASS (93 source/config files scanned, 0 missing headers).
- `bun run check:comment-only`: PASS (`50 source file(s) changed; every code token identical to origin/develop. Comments only.`)
- `git diff --check origin/develop...HEAD`: PASS.
- `git diff --name-only origin/develop...HEAD | xargs bunx @biomejs/biome check --config-path biome.json --files-ignore-unknown=true --no-errors-on-unmatched`: PASS exit 0; reports 3 existing optional-chain warnings in unchanged code tokens.

## Evidence N/A
- UI screenshots/video: N/A - comment-only cleanup outside `packages/app`.
- Live LLM trajectories: N/A - no agent/action/prompt/model behavior changed.
- Backend/frontend logs: N/A - no runtime behavior changed.
- Domain artifacts: N/A - no data-producing behavior changed.