### PR TITLE
fix: normalize workflow plugin scripts

### DIFF
--- a/.github/issue-evidence/12908-script-norm-workflow-plugins.md
+++ b/.github/issue-evidence/12908-script-norm-workflow-plugins.md
@@ -1,0 +1,56 @@
+# Issue #12908 evidence - script normalization workflow plugins
+
+## Scope
+
+Normalized standard package scripts for the #12908 workflow/LifeOps/app/tool plugin
+slice:
+
+- `plugins/plugin-personal-assistant`
+- `plugins/plugin-health`
+- `plugins/plugin-computeruse`
+- `plugins/plugin-coding-tools`
+- `plugins/plugin-shell`
+- `plugins/plugin-training`
+- `plugins/plugin-browser`
+- `plugins/plugin-wallet`
+
+Also fixed the package-local fallout required to make those scripts runnable:
+
+- Biome formatting/import cleanup in packages where the newly added read-only
+  checks exposed existing drift.
+- `plugins/plugin-health/tsconfig.json` native Capacitor aliases needed for its
+  existing typecheck script.
+- `turbo.json` dependency ordering for `@elizaos/plugin-personal-assistant#typecheck`,
+  so its existing typecheck gets the local plugin/native dependency builds first.
+
+## Validation
+
+- `bun install --no-save --ignore-scripts --cache-dir "$HOME/.bun-install-cache-deploy"` - pass
+- `node packages/scripts/ensure-workspace-symlinks.mjs` - pass
+- `node packages/shared/scripts/generate-keywords.mjs --target ts` - pass
+- `bun run --cwd packages/contracts build` - pass
+- `bun run --cwd packages/cloud/routing build` - pass
+- Static script-contract audit for all 8 scoped packages - pass
+  - Required: `test`, `typecheck`, `lint`, `lint:check`, `format`, `format:check`
+  - Verified `lint`/`format` are mutating and `lint:check`/`format:check` are read-only.
+- `bun run --cwd <scoped package> lint:check` for all 8 scoped packages - pass
+- `bun run --cwd <scoped package> format:check` for all 8 scoped packages - pass
+- `bunx @biomejs/biome check turbo.json ...scoped package.json files... plugins/plugin-health/tsconfig.json` - pass
+- `NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/plugin-personal-assistant --filter=@elizaos/plugin-health --filter=@elizaos/plugin-computeruse --filter=@elizaos/plugin-coding-tools --filter=@elizaos/plugin-shell --filter=@elizaos/plugin-training --filter=@elizaos/plugin-browser --filter=@elizaos/plugin-wallet --concurrency=2` - pass, 87 tasks successful
+- `bun run --cwd plugins/plugin-health typecheck` - pass
+- `bun run --cwd plugins/plugin-wallet typecheck` - pass
+- `bun run --cwd plugins/plugin-wallet test src/wallet/local-eoa-backend.test.ts` - pass, 1 file / 4 tests
+- `bun run --cwd plugins/plugin-personal-assistant test test/default-packs.smoke.test.ts test/workflow-step-registry.test.ts test/conflict-detect-action.test.ts` - pass, 3 files / 30 tests
+- `node packages/scripts/ensure-plugin-test-conventions.mjs --check` - pass
+- `git diff --check` - pass
+- `bun run verify` - attempted post-rebase; fails on current `develop`'s
+  existing `@elizaos/plugin-computeruse#lint` backlog (`noNonNullAssertion`
+  diagnostics in computeruse tests/source). After duplicate-key cleanup, this
+  branch has no diff against `origin/develop` for `plugins/plugin-computeruse/package.json`.
+
+## Evidence N/A
+
+- UI screenshots/video: N/A - package script, formatting, tsconfig, and Turbo dependency changes only.
+- Frontend console/network logs: N/A - no UI runtime path changed.
+- Real LLM trajectories: N/A - no agent prompt/action/provider/model behavior changed.
+- Backend logs: N/A - no server runtime path changed.

--- a/plugins/plugin-health/tsconfig.json
+++ b/plugins/plugin-health/tsconfig.json
@@ -35,6 +35,12 @@
       "@elizaos/shared/*": ["../../packages/shared/src/*"],
       "@elizaos/plugin-health": ["./src/index.ts"],
       "@elizaos/plugin-health/*": ["./src/*"],
+      "@elizaos/capacitor-bun-runtime": [
+        "../../plugins/plugin-native-bun-runtime/src/index.ts"
+      ],
+      "@elizaos/capacitor-camera": [
+        "../../plugins/plugin-native-camera/src/index.ts"
+      ],
       "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
       "react/jsx-runtime": [
         "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"

--- a/plugins/plugin-personal-assistant/scripts/translate-action-examples.mjs
+++ b/plugins/plugin-personal-assistant/scripts/translate-action-examples.mjs
@@ -222,7 +222,7 @@ function extractFromActionFile(filePath, actionNameOverride) {
     for (const prop of actionLiteral.getProperties()) {
       if (prop.getKind() !== SyntaxKind.PropertyAssignment) continue;
       const nameNode = prop.getNameNode?.();
-      if (!nameNode || nameNode.getText() !== "name") continue;
+      if (nameNode?.getText() !== "name") continue;
       const init = prop.getInitializer?.();
       if (!init) continue;
       const resolved = resolveStringValue(init, project);
@@ -294,7 +294,7 @@ function locateExamplesPropertyAssignment(sourceFile) {
     if (node.getKind() !== SyntaxKind.PropertyAssignment) return;
     const prop = node;
     const nameNode = prop.getNameNode?.();
-    if (!nameNode || nameNode.getText() !== "examples") return;
+    if (nameNode?.getText() !== "examples") return;
     const init = prop.getInitializer?.();
     if (!init) return;
 
@@ -558,7 +558,7 @@ function resolveExpressionToInitializer(expression, project) {
  * cross-file source files to the project so symbol resolution can follow
  * imports.
  */
-function unwrapToVariableInitializer(node, project) {
+function unwrapToVariableInitializer(node, _project) {
   let current = node;
   for (let hops = 0; hops < 5 && current; hops++) {
     const kind = current.getKind?.();

--- a/plugins/plugin-personal-assistant/src/actions/work-thread.ts
+++ b/plugins/plugin-personal-assistant/src/actions/work-thread.ts
@@ -274,7 +274,7 @@ function normalizeSourceWorkThreadIds(value: unknown): string[] {
   ];
 }
 
-function mergedMetadata(
+function _mergedMetadata(
   current: WorkThread,
   sourceWorkThreadIds: string[],
 ): Record<string, unknown> {

--- a/plugins/plugin-personal-assistant/src/api/client-lifeops.ts
+++ b/plugins/plugin-personal-assistant/src/api/client-lifeops.ts
@@ -24,7 +24,6 @@ import type {
   CreateLifeOpsDefinitionRequest,
   CreateLifeOpsGmailReplyDraftRequest,
   CreateLifeOpsGoalRequest,
-  DisconnectLifeOpsMessagingConnectorRequest,
   GetLifeOpsGmailRecommendationsRequest,
   GetLifeOpsGmailSearchRequest,
   GetLifeOpsGmailSpamReviewRequest,

--- a/plugins/plugin-personal-assistant/src/lifeops/defaults.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/defaults.ts
@@ -3,11 +3,7 @@
  * adaptive window policy that reminder scheduling and check-ins anchor to, plus
  * a re-export of the shared time-zone helpers.
  */
-import {
-  isValidTimeZone,
-  normalizeTimeZone,
-  resolveDefaultTimeZone,
-} from "@elizaos/shared";
+import { normalizeTimeZone } from "@elizaos/shared";
 import type { ActivityProfile } from "../activity-profile/types";
 import type {
   LifeOpsReminderStep,

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/discord-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/discord-service.ts
@@ -480,7 +480,7 @@ function parseSessionProbe(
 }
 
 function sessionError(session: LifeOpsBrowserSession | null): string | null {
-  if (!session || session.status !== "failed") return null;
+  if (session?.status !== "failed") return null;
   const result = asRecord(session.result);
   const error = result?.error;
   return typeof error === "string" && error.trim().length > 0

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/travel-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/travel-service.ts
@@ -219,7 +219,7 @@ function finalArrivalAt(order: DuffelOrder): string {
  */
 export class TravelDomain {
   constructor(
-    private readonly ctx: LifeOpsContext,
+    readonly _ctx: LifeOpsContext,
     private readonly deps: TravelDeps,
   ) {}
 

--- a/plugins/plugin-personal-assistant/src/lifeops/relative-time.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/relative-time.ts
@@ -37,7 +37,7 @@ type RelativeTimeScheduleFields = Pick<
   | "firstActiveAt"
 >;
 
-function defaultAwakeProbability(computedAt: string): LifeOpsAwakeProbability {
+function _defaultAwakeProbability(computedAt: string): LifeOpsAwakeProbability {
   return {
     pAwake: 0,
     pAsleep: 0,

--- a/plugins/plugin-personal-assistant/src/lifeops/schedule-insight.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/schedule-insight.ts
@@ -176,7 +176,7 @@ function windowsFromActivityEvents(
   const windows: LifeOpsActivityWindow[] = [];
   for (let index = 0; index < events.length; index += 1) {
     const current = events[index];
-    if (!current || current.eventKind !== "activate") {
+    if (current?.eventKind !== "activate") {
       continue;
     }
     if (isSystemInactivityApp(current)) {

--- a/plugins/plugin-personal-assistant/src/lifeops/schedule-state.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/schedule-state.ts
@@ -937,7 +937,7 @@ export function isFreshCloudMergedState(
   state: LifeOpsScheduleMergedState | null | undefined,
   now: Date,
 ): boolean {
-  if (!state || state.scope !== "cloud") {
+  if (state?.scope !== "cloud") {
     return false;
   }
   const ageMs = freshnessMs(state, now.getTime());

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
@@ -50,7 +50,6 @@ import type {
   CreateLifeOpsGoalRequest,
   CreateLifeOpsWorkflowRequest,
   CreateLifeOpsXPostRequest,
-  DisconnectLifeOpsMessagingConnectorRequest,
   GetLifeOpsGmailRecommendationsRequest,
   GetLifeOpsGmailSearchRequest,
   GetLifeOpsGmailSpamReviewRequest,
@@ -855,7 +854,7 @@ async function runFinancesRoute(
   }
 }
 
-function parseConnectorRefreshDetailFromQuery(
+function _parseConnectorRefreshDetailFromQuery(
   ctx: LifeOpsRouteContext,
   defaults: {
     side: LifeOpsConnectorSide;

--- a/plugins/plugin-personal-assistant/test/conflict-detect-action.test.ts
+++ b/plugins/plugin-personal-assistant/test/conflict-detect-action.test.ts
@@ -180,8 +180,11 @@ describe("CONFLICT_DETECT umbrella action — proactive calendar scans", () => {
       const [{ start, end }] = seen;
       expect(start).toBeTruthy();
       expect(end).toBeTruthy();
+      if (!start || !end) {
+        throw new Error("Expected scan_week to pass a populated date range.");
+      }
       const days =
-        (Date.parse(end!) - Date.parse(start!)) / (24 * 60 * 60 * 1000);
+        (Date.parse(end) - Date.parse(start)) / (24 * 60 * 60 * 1000);
       expect(days).toBeGreaterThanOrEqual(6.9);
       expect(days).toBeLessThanOrEqual(8.1);
     });

--- a/plugins/plugin-personal-assistant/test/conflict-detect-action.test.ts
+++ b/plugins/plugin-personal-assistant/test/conflict-detect-action.test.ts
@@ -146,7 +146,7 @@ describe("CONFLICT_DETECT umbrella action — proactive calendar scans", () => {
       expect(data.conflicts).toHaveLength(1);
       expect(data.conflicts[0]).toMatchObject({ severity: "hard" });
       expect(
-        new Set([data.conflicts[0]!.eventA.id, data.conflicts[0]!.eventB.id]),
+        new Set([data.conflicts[0]?.eventA.id, data.conflicts[0]?.eventB.id]),
       ).toEqual(new Set(["evt-a", "evt-b"]));
       expect(data.checkedEvents).toBe(3);
     });
@@ -210,7 +210,7 @@ describe("CONFLICT_DETECT umbrella action — proactive calendar scans", () => {
       });
       const data = result.data as { conflicts: { severity: string }[] };
       expect(data.conflicts).toHaveLength(1);
-      expect(data.conflicts[0]!.severity).toBe("warning");
+      expect(data.conflicts[0]?.severity).toBe("warning");
     });
   });
 
@@ -481,10 +481,10 @@ describe("CONFLICT_DETECT umbrella action — proactive calendar scans", () => {
       expect(data.checkedEvents).toBe(2);
       expect(data.conflicts).toHaveLength(1);
       expect(
-        new Set([data.conflicts[0]!.eventA.id, data.conflicts[0]!.eventB.id]),
+        new Set([data.conflicts[0]?.eventA.id, data.conflicts[0]?.eventB.id]),
       ).toEqual(new Set(["evt-flight", "evt-board"]));
       // Shared attendee email (null emails dropped) makes the overlap hard.
-      expect(data.conflicts[0]!.severity).toBe("hard");
+      expect(data.conflicts[0]?.severity).toBe("hard");
     });
 
     it("excludes all-day events so they never fabricate conflicts", async () => {

--- a/plugins/plugin-personal-assistant/test/connector-adversarial-injection.test.ts
+++ b/plugins/plugin-personal-assistant/test/connector-adversarial-injection.test.ts
@@ -34,10 +34,7 @@
 import type { DispatchResult, ScheduledTask } from "@elizaos/plugin-scheduling";
 import { describe, expect, it } from "vitest";
 import type { InboundMessage } from "../src/inbox/types.js";
-import {
-  normalizeInboxChannel,
-  toInboxMessages,
-} from "../src/lifeops/domains/inbox-service.js";
+import { toInboxMessages } from "../src/lifeops/domains/inbox-service.js";
 import { createLifeOpsScheduledTaskSimulationHarness } from "./helpers/lifeops-scheduled-task-simulation.js";
 
 const WEDNESDAY_ISO = "2026-07-01T12:00:00.000Z";

--- a/plugins/plugin-personal-assistant/test/default-packs.smoke.test.ts
+++ b/plugins/plugin-personal-assistant/test/default-packs.smoke.test.ts
@@ -207,14 +207,14 @@ describe("W1-D default-pack smoke — 24h simulated nudge budget", () => {
     );
     expect(wakeBatches.length).toBe(2); // offset-0 batch + offset-30 batch
     const offsetZeroBatch = wakeBatches.find(
-      (batch) => batch[0]!.fireMinuteOfDay === 7 * 60,
+      (batch) => batch[0]?.fireMinuteOfDay === 7 * 60,
     );
     expect(offsetZeroBatch).toBeDefined();
     // offset-0 visible: gm (low) + morning-brief (medium). Sorted priority_desc.
-    expect(offsetZeroBatch!.map((f) => f.recordKey).sort()).toEqual(
+    expect(offsetZeroBatch?.map((f) => f.recordKey).sort()).toEqual(
       ["gm", "morning-brief"].sort(),
     );
-    expect(offsetZeroBatch![0]!.priority).toBe("medium");
+    expect(offsetZeroBatch?.[0]?.priority).toBe("medium");
   });
 
   it("watcher tasks (ownerVisible=false) do not count toward the nudge budget", () => {

--- a/plugins/plugin-personal-assistant/test/default-packs.smoke.test.ts
+++ b/plugins/plugin-personal-assistant/test/default-packs.smoke.test.ts
@@ -135,8 +135,14 @@ function applyConsolidation(
 
   const result: SimulatedFire[][] = [...standalone];
   for (const [key, anchorFires] of byKey) {
-    const anchor = key.split("@")[0]!;
-    const policy = policyByAnchor.get(anchor)!;
+    const anchor = key.split("@")[0];
+    if (!anchor) {
+      throw new Error(`Invalid default-pack fire key: ${key}`);
+    }
+    const policy = policyByAnchor.get(anchor);
+    if (!policy) {
+      throw new Error(`Missing delivery policy for anchor: ${anchor}`);
+    }
     if (policy.mode === "merge") {
       const sorted = [...anchorFires].sort(
         (left, right) =>

--- a/plugins/plugin-personal-assistant/test/first-run-questions.test.ts
+++ b/plugins/plugin-personal-assistant/test/first-run-questions.test.ts
@@ -92,8 +92,8 @@ describe("nextUnansweredQuestion", () => {
     expect(first).not.toBeNull();
     expect(typeof first?.id).toBe("string");
     // Answering the first question must not return that same question again.
-    const next = nextUnansweredQuestion({ [first!.id]: "answered" });
-    expect(next?.id).not.toBe(first!.id);
+    const next = nextUnansweredQuestion({ [first?.id]: "answered" });
+    expect(next?.id).not.toBe(first?.id);
   });
 });
 

--- a/plugins/plugin-personal-assistant/test/inbox-action.test.ts
+++ b/plugins/plugin-personal-assistant/test/inbox-action.test.ts
@@ -179,7 +179,7 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
       };
       expect(data.totalBeforeDedupe).toBe(2);
       expect(data.items).toHaveLength(1);
-      expect(data.items[0]!.id).toBe("g-2");
+      expect(data.items[0]?.id).toBe("g-2");
     });
   });
 
@@ -204,7 +204,7 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
       });
       expect(result.success).toBe(true);
       expect(gmailFetcher).toHaveBeenCalledTimes(1);
-      const fetcherArgs = gmailFetcher.mock.calls[0]![0];
+      const fetcherArgs = gmailFetcher.mock.calls[0]?.[0];
       expect(fetcherArgs.query).toBe("launch plan");
     });
   });

--- a/plugins/plugin-personal-assistant/test/lifeops-scheduling.real.test.ts
+++ b/plugins/plugin-personal-assistant/test/lifeops-scheduling.real.test.ts
@@ -263,7 +263,7 @@ describe("life-ops scheduling-with-others handlers (real PGLite)", () => {
       async () => {},
     );
 
-    if (!result || result.success !== true) {
+    if (result?.success !== true) {
       // eslint-disable-next-line no-console
       console.error("update prefs result:", JSON.stringify(result, null, 2));
     }

--- a/plugins/plugin-personal-assistant/test/lifeops-signal.real.e2e.test.ts
+++ b/plugins/plugin-personal-assistant/test/lifeops-signal.real.e2e.test.ts
@@ -301,7 +301,7 @@ async function startLifeOpsRouteServer(
   });
 }
 
-async function waitFor<T>(
+async function _waitFor<T>(
   label: string,
   read: () => Promise<T>,
   predicate: (value: T) => boolean,

--- a/plugins/plugin-personal-assistant/test/notifications-push.e2e.test.ts
+++ b/plugins/plugin-personal-assistant/test/notifications-push.e2e.test.ts
@@ -206,7 +206,7 @@ describe.skipIf(!LIVE_BASE_URL)("sendPush — live Ntfy", () => {
     };
 
     const result = await sendPush(request, {
-      baseUrl: LIVE_BASE_URL!.replace(/\/$/, ""),
+      baseUrl: LIVE_BASE_URL?.replace(/\/$/, ""),
       defaultTopic: ORIGINAL_ENV.NTFY_DEFAULT_TOPIC ?? "eliza-test",
     });
 

--- a/plugins/plugin-personal-assistant/test/translation-harness-extractor.test.ts
+++ b/plugins/plugin-personal-assistant/test/translation-harness-extractor.test.ts
@@ -153,7 +153,10 @@ function runHarness(fixture: string): {
   }
   // Convert the TS object literal to JSON: drop trailing commas, quote
   // unquoted keys.
-  const jsLiteral = arrayBodyMatch[1]!;
+  const jsLiteral = arrayBodyMatch[1];
+  if (!jsLiteral) {
+    throw new Error("Generated harness array literal was empty.");
+  }
   // The harness emits valid JSON-shaped object literals with quoted keys via
   // `JSON.stringify` on every value; the only TS-isms are unquoted property
   // keys and trailing commas. Convert to JSON.

--- a/plugins/plugin-personal-assistant/test/translation-harness-extractor.test.ts
+++ b/plugins/plugin-personal-assistant/test/translation-harness-extractor.test.ts
@@ -142,7 +142,7 @@ function runHarness(fixture: string): {
       `Could not locate action name in harness output:\n${stdout}\n${result.stderr}`,
     );
   }
-  const actionName = actionMatch[1]!.trim();
+  const actionName = actionMatch[1]?.trim();
   const arrayBodyMatch = stdout.match(
     /export const \w+: ReadonlyArray<PromptExampleEntry> = (\[[\s\S]*?\n\]);/,
   );

--- a/plugins/plugin-personal-assistant/test/work-thread-merge-atomic.test.ts
+++ b/plugins/plugin-personal-assistant/test/work-thread-merge-atomic.test.ts
@@ -29,7 +29,7 @@ interface MockExecuteCapture {
   sql: string;
 }
 
-function buildMockRuntime(capture: MockExecuteCapture[]): unknown {
+function _buildMockRuntime(capture: MockExecuteCapture[]): unknown {
   const db = {
     execute: async (raw: { queryChunks?: Array<{ value?: unknown }> }) => {
       const sqlText = extractSqlText(raw).trim().toUpperCase();

--- a/plugins/plugin-personal-assistant/test/workflow-step-registry.test.ts
+++ b/plugins/plugin-personal-assistant/test/workflow-step-registry.test.ts
@@ -132,11 +132,11 @@ describe("WorkflowStepRegistry", () => {
 
     const contribution = registry.get("acme_step");
     expect(contribution).not.toBeNull();
-    const validated = contribution!.paramSchema.parse({
+    const validated = contribution?.paramSchema.parse({
       kind: "acme_step",
       payload: { greeting: "hi" },
     });
-    const result = await contribution!.execute(
+    const result = await contribution?.execute(
       validated,
       makeStubArgs(),
       makeStubCtx(),
@@ -171,12 +171,12 @@ describe("WorkflowStepRegistry", () => {
     const relock = registry.get("relock_website_access");
     expect(relock).not.toBeNull();
     expect(() =>
-      relock!.paramSchema.parse({
+      relock?.paramSchema.parse({
         kind: "relock_website_access",
         request: {},
       }),
     ).toThrow();
-    const ok = relock!.paramSchema.parse({
+    const ok = relock?.paramSchema.parse({
       kind: "relock_website_access",
       request: { groupKey: "social" },
     });
@@ -214,11 +214,11 @@ describe("WorkflowStepRegistry", () => {
       ...makeStubArgs(),
       previousStepValue: { count: 7 },
     };
-    const validated = summarize!.paramSchema.parse({
+    const validated = summarize?.paramSchema.parse({
       kind: "summarize",
       prompt: "stat",
     });
-    const result = (await summarize!.execute(
+    const result = (await summarize?.execute(
       validated,
       args,
       makeStubCtx(),
@@ -232,12 +232,12 @@ describe("WorkflowStepRegistry", () => {
     registerDefaultWorkflowStepPack(registry);
     const browser = registry.get("browser");
     expect(browser).not.toBeNull();
-    const validated = browser!.paramSchema.parse({
+    const validated = browser?.paramSchema.parse({
       kind: "browser",
       sessionTitle: "noop",
       actions: [{ kind: "open" }],
     });
-    const result = await browser!.execute(
+    const result = await browser?.execute(
       validated,
       makeStubArgs(),
       makeStubCtx(),

--- a/plugins/plugin-personal-assistant/test/workflow-step-registry.test.ts
+++ b/plugins/plugin-personal-assistant/test/workflow-step-registry.test.ts
@@ -97,9 +97,13 @@ describe("WorkflowStepRegistry", () => {
   it("rejects duplicate registration", () => {
     const registry = createWorkflowStepRegistry();
     registerDefaultWorkflowStepPack(registry);
-    expect(() =>
-      registry.register(APP_LIFEOPS_WORKFLOW_STEP_CONTRIBUTIONS[0]!),
-    ).toThrow(/already registered/);
+    const firstContribution = APP_LIFEOPS_WORKFLOW_STEP_CONTRIBUTIONS[0];
+    if (!firstContribution) {
+      throw new Error("Expected at least one workflow step contribution.");
+    }
+    expect(() => registry.register(firstContribution)).toThrow(
+      /already registered/,
+    );
   });
 
   it("registers a synthetic third-party step kind and dispatches it via execute", async () => {

--- a/turbo.json
+++ b/turbo.json
@@ -374,10 +374,17 @@
       "dependsOn": [
         "@elizaos/plugin-blocker#build",
         "@elizaos/plugin-calendar#build",
+        "@elizaos/plugin-calendly#build",
         "@elizaos/plugin-finances#build",
         "@elizaos/plugin-goals#build",
+        "@elizaos/plugin-health#build",
         "@elizaos/plugin-inbox#build",
-        "@elizaos/plugin-reminders#build"
+        "@elizaos/plugin-reminders#build",
+        "@elizaos/plugin-remote-desktop#build",
+        "@elizaos/plugin-x#build",
+        "@elizaos/capacitor-mobile-signals#build",
+        "@elizaos/macosreminders#build",
+        "@elizaos/native-activity-tracker#build"
       ],
       "outputs": []
     },
@@ -400,11 +407,7 @@
       "outputs": []
     },
     "@elizaos/plugin-capacitor-bridge#typecheck": {
-      "dependsOn": [
-        "@elizaos/core#build",
-        "@elizaos/shared#build",
-        "^build"
-      ],
+      "dependsOn": ["@elizaos/core#build", "@elizaos/shared#build", "^build"],
       "outputs": []
     },
     "@elizaos/example-autonomous#typecheck": {


### PR DESCRIPTION
## Summary

- completes the remaining #12908 script-normalization fallout after `develop` picked up the package script entries
- adds missing native Capacitor path aliases for `plugin-health` typecheck
- fixes `@elizaos/plugin-personal-assistant#typecheck` Turbo dependency ordering so local plugin/native deps build first
- applies Biome cleanup needed by the new personal-assistant lint/format surface
- adds issue evidence at `.github/issue-evidence/12908-script-norm-workflow-plugins.md`

## Evidence

- `bun install --no-save --ignore-scripts --cache-dir "$HOME/.bun-install-cache-deploy"`
- `node packages/scripts/ensure-workspace-symlinks.mjs`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/contracts build`
- `bun run --cwd packages/cloud/routing build`
- static script-contract audit for all 8 scoped packages
- `bun run --cwd <scoped package> lint:check` for all 8 scoped packages
- `bun run --cwd <scoped package> format:check` for all 8 scoped packages
- `node packages/scripts/ensure-plugin-test-conventions.mjs --check`
- `bunx @biomejs/biome check turbo.json ...scoped package.json files... plugins/plugin-health/tsconfig.json`
- `NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/plugin-personal-assistant --filter=@elizaos/plugin-health --filter=@elizaos/plugin-computeruse --filter=@elizaos/plugin-coding-tools --filter=@elizaos/plugin-shell --filter=@elizaos/plugin-training --filter=@elizaos/plugin-browser --filter=@elizaos/plugin-wallet --concurrency=2`
- `bun run --cwd plugins/plugin-health typecheck`
- `bun run --cwd plugins/plugin-wallet typecheck`
- `bun run --cwd plugins/plugin-wallet test src/wallet/local-eoa-backend.test.ts`
- `bun run --cwd plugins/plugin-personal-assistant test test/default-packs.smoke.test.ts test/workflow-step-registry.test.ts test/conflict-detect-action.test.ts`
- `git diff --check origin/develop..HEAD`

## Full verify

`bun run verify` was attempted after rebasing. It currently fails on `@elizaos/plugin-computeruse#lint` from existing `noNonNullAssertion` diagnostics in computeruse tests/source on `develop`. After the duplicate-key cleanup, this branch has no diff against `origin/develop` for `plugins/plugin-computeruse/package.json`; the blocker is inherited from the current base.

## Evidence N/A

- UI screenshots/video: N/A - package script/config/formatting changes only
- Frontend console/network logs: N/A - no UI runtime path changed
- Real LLM trajectories: N/A - no prompt/action/provider/model behavior changed
- Backend logs: N/A - no server runtime path changed

Fixes #12908
