### PR TITLE
fix(#12283): require traveler persona local due time

### DIFF
--- a/packages/scenario-runner/schema/index.d.ts
+++ b/packages/scenario-runner/schema/index.d.ts
@@ -214,6 +214,11 @@ type DefinitionCountForbiddenDueLocalTime = {
   minute?: number;
   timeZone?: string;
 };
+type DefinitionCountExpectedDueLocalTime = {
+  hour: number;
+  minute?: number;
+  timeZone?: string;
+};
 type DefinitionCountWebsiteAccess = {
   groupKey?: string;
   websites?: string[];
@@ -424,6 +429,7 @@ export type ScenarioFinalCheck =
       requiredEveryMinutes?: number;
       requiredMaxOccurrencesPerDay?: number;
       expectedTimeZone?: string;
+      expectedDueLocalTimes?: DefinitionCountExpectedDueLocalTime[];
       forbiddenDueLocalTimes?: DefinitionCountForbiddenDueLocalTime[];
       requireReminderPlan?: boolean;
       websiteAccess?: DefinitionCountWebsiteAccess;

--- a/packages/scenario-runner/schema/index.js
+++ b/packages/scenario-runner/schema/index.js
@@ -105,6 +105,7 @@ export const FINAL_CHECK_KEYS = new Map(
       "requiredEveryMinutes",
       "requiredMaxOccurrencesPerDay",
       "expectedTimeZone",
+      "expectedDueLocalTimes",
       "forbiddenDueLocalTimes",
       "requireReminderPlan",
       "websiteAccess",

--- a/packages/scenario-runner/src/final-checks/definition-count-final-check.test.ts
+++ b/packages/scenario-runner/src/final-checks/definition-count-final-check.test.ts
@@ -156,6 +156,56 @@ describe("definitionCountDelta final check", () => {
     expect(result.detail).toContain("forbidden");
   });
 
+  it("fails when a once definition misses an expected local due time", async () => {
+    mockState.definitions = [
+      definitionRecord({
+        title: "US colleague sync",
+        timezone: "America/New_York",
+        cadence: {
+          kind: "once",
+          dueAt: "2026-07-05T13:00:00.000Z",
+        },
+      }),
+    ];
+
+    const result = await run({
+      type: "definitionCountDelta",
+      title: "sync",
+      titleAliases: ["US colleague sync"],
+      delta: 1,
+      cadenceKind: "once",
+      expectedDueLocalTimes: [{ hour: 3, minute: 0, timeZone: "Asia/Tokyo" }],
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.detail).toContain("expected 03:00 in Asia/Tokyo");
+    expect(result.detail).toContain("22:00 in Asia/Tokyo");
+  });
+
+  it("passes when a once definition matches an expected local due time", async () => {
+    mockState.definitions = [
+      definitionRecord({
+        title: "US colleague sync",
+        timezone: "America/New_York",
+        cadence: {
+          kind: "once",
+          dueAt: "2026-07-05T18:00:00.000Z",
+        },
+      }),
+    ];
+
+    const result = await run({
+      type: "definitionCountDelta",
+      title: "sync",
+      titleAliases: ["US colleague sync"],
+      delta: 1,
+      cadenceKind: "once",
+      expectedDueLocalTimes: [{ hour: 3, minute: 0, timeZone: "Asia/Tokyo" }],
+    });
+
+    expect(result.status).toBe("passed");
+  });
+
   it("lists the stored definition titles when no title matches (misroute diagnostic)", async () => {
     // The live gemma-4-31b brush-teeth misroute saved the habit under the
     // goals store / a different title; the "saw none" branch must name what

--- a/packages/scenario-runner/src/final-checks/index.ts
+++ b/packages/scenario-runner/src/final-checks/index.ts
@@ -468,6 +468,11 @@ type DefinitionCountCheck = {
   requiredEveryMinutes?: number;
   requiredMaxOccurrencesPerDay?: number;
   expectedTimeZone?: string;
+  expectedDueLocalTimes?: Array<{
+    hour?: number;
+    minute?: number;
+    timeZone?: string;
+  }>;
   forbiddenDueLocalTimes?: Array<{
     hour?: number;
     minute?: number;
@@ -653,6 +658,50 @@ function definitionMismatchReasons(
     reasons.push(
       `timezone expected ${check.expectedTimeZone}, saw ${String(record.definition.timezone ?? "missing")}`,
     );
+  }
+  if (
+    Array.isArray(check.expectedDueLocalTimes) &&
+    check.expectedDueLocalTimes.length > 0
+  ) {
+    const dueAt = cadence?.dueAt;
+    const expectedLocalTimes = check.expectedDueLocalTimes.filter(
+      (expected) => typeof expected.hour === "number",
+    );
+    const observedLocalTimes = expectedLocalTimes.map((expected) => {
+      const timeZone = expected.timeZone ?? record.definition.timezone;
+      return {
+        expected,
+        timeZone,
+        local: localHourMinuteForInstant(dueAt, timeZone),
+      };
+    });
+    if (observedLocalTimes.some(({ local }) => !local)) {
+      reasons.push(
+        `dueAt local time unavailable for ${String(dueAt ?? "missing")}`,
+      );
+    } else if (
+      !observedLocalTimes.some(({ expected, local }) => {
+        const minute = expected.minute ?? 0;
+        return local?.hour === expected.hour && local?.minute === minute;
+      })
+    ) {
+      const expectedText = expectedLocalTimes
+        .map((expected) => {
+          const timeZone = expected.timeZone ?? record.definition.timezone;
+          return `${String(expected.hour).padStart(2, "0")}:${String(expected.minute ?? 0).padStart(2, "0")} in ${String(timeZone)}`;
+        })
+        .join(" or ");
+      const observedText = observedLocalTimes
+        .map(({ local, timeZone }) =>
+          local
+            ? `${String(local.hour).padStart(2, "0")}:${String(local.minute).padStart(2, "0")} in ${String(timeZone)}`
+            : `unavailable in ${String(timeZone)}`,
+        )
+        .join(", ");
+      reasons.push(
+        `dueAt local time expected ${expectedText}, saw ${observedText}`,
+      );
+    }
   }
   if (Array.isArray(check.requiredSlots) && check.requiredSlots.length > 0) {
     const slots = Array.isArray(cadence?.slots) ? cadence.slots : [];

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/traveler-timezone-truth.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/traveler-timezone-truth.catalog.json
@@ -18,8 +18,8 @@
       "pack": "C1",
       "tier": "T2",
       "surface": "scenario-runner",
-      "status": "verified",
-      "notes": "Live Cerebras gpt-oss-120b passed (judge+delta): converted 2pm US Eastern to 3am JST, flagged the biological-night conflict, created the reminder."
+      "status": "authored",
+      "notes": "Original live report flagged the 3am JST conflict, but the persisted definition stored dueAt 2026-07-05T13:00:00.000Z (22:00 JST), so this awaits recapture with expectedDueLocalTimes passing."
     }
   ]
 }

--- a/plugins/plugin-personal-assistant/test/scenarios/traveler-biological-night-meeting-flag.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/traveler-biological-night-meeting-flag.scenario.ts
@@ -54,6 +54,8 @@ export default scenario({
         "reminder for the sync",
       ],
       delta: 1,
+      cadenceKind: "once",
+      expectedDueLocalTimes: [{ hour: 3, minute: 0, timeZone: "Asia/Tokyo" }],
     },
   ],
 });


### PR DESCRIPTION
## What & why

Follow-up to #12996. The C1 traveler report says the assistant created the 2pm US Eastern sync reminder as 3am Tokyo/JST, but the persisted scheduled definition in the attached report has:

- `timezone: "America/New_York"`
- `cadence.dueAt: "2026-07-05T13:00:00.000Z"`

That resolves to 09:00 America/New_York / 22:00 Asia/Tokyo, not the expected 2pm Eastern / 3am Tokyo instant. The old `definitionCountDelta` check only proved a matching definition existed, so the invalid artifact was marked verified.

This adds `expectedDueLocalTimes` to `definitionCountDelta`, uses it in the traveler scenario to require 03:00 in `Asia/Tokyo`, and demotes the C1 catalog entry to `authored` until a corrected live trajectory is recaptured. D1 remains verified.

## Validation

- PASS: `bunx vitest run packages/scenario-runner/src/final-checks/definition-count-final-check.test.ts` (9 tests, run in the #12996 review worktree after dependency install)
- PASS: schema smoke: `scenario({ finalChecks: [{ type: "definitionCountDelta", title: "sync", expectedDueLocalTimes: [{ hour: 3, minute: 0, timeZone: "Asia/Tokyo" }] }] })`
- PASS: `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --json` (C1 authored 1 / verified 0; no errors)
- PASS: `bunx @biomejs/biome check` on the 6 touched files
- PASS: `git diff --check HEAD~1..HEAD`

Attempted broader checks in the PR review worktree:

- `bunx vitest run packages/scenario-runner/src/schema-strict.test.ts` did not run because the fresh worktree lacked built workspace exports (`@elizaos/plugin-local-inference/voice-workbench`) after resolving earlier generated/core artifacts.
- `bun run --cwd packages/scenario-runner typecheck` failed on missing built workspace package exports (`@elizaos/plugin-blocker`, `@elizaos/plugin-personal-assistant`, `@elizaos/plugin-scheduling`, shared UI exports, etc.). The local nullable error introduced during development was fixed before this PR.

No UI surface changed.
