### PR TITLE
docs(#12755): clean facewear test prose headers

### DIFF
--- a/plugins/plugin-facewear/app-xr/playwright.config.ts
+++ b/plugins/plugin-facewear/app-xr/playwright.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright coverage for the headset WebXR client served through the facewear
+ * view-host route.
+ */
 import path from "node:path";
 import { defineConfig, devices } from "@playwright/test";
 

--- a/plugins/plugin-facewear/emulator/src/cli.ts
+++ b/plugins/plugin-facewear/emulator/src/cli.ts
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/**
+ * Command-line WebSocket device emulator for exercising facewear XR sessions
+ * without a physical headset.
+ */
 // Usage: bun run src/cli.ts -- --device meta-quest --url ws://localhost:31338
 // Or:    node dist/cli.js --device simulator --url ws://localhost:31338
 

--- a/plugins/plugin-facewear/emulator/src/device-emulator.ts
+++ b/plugins/plugin-facewear/emulator/src/device-emulator.ts
@@ -1,3 +1,7 @@
+/**
+ * WebSocket client that speaks the facewear XR hello and frame protocol for
+ * local headset simulation.
+ */
 import { WebSocket } from "ws";
 
 export type FacewearDeviceType =
@@ -7,7 +11,7 @@ export type FacewearDeviceType =
   | "apple-vision-pro"
   | "simulator";
 
-// Maps FacewearDeviceType to the XR protocol deviceType field
+// XR sessions expect the protocol deviceType field, not the package profile id.
 const DEVICE_TYPE_MAP: Record<FacewearDeviceType, string> = {
   "meta-quest": "quest3",
   xreal: "xreal",

--- a/plugins/plugin-facewear/emulator/src/node.ts
+++ b/plugins/plugin-facewear/emulator/src/node.ts
@@ -1,5 +1,7 @@
-// Node-side entry point — exports the Playwright fixture and mock server.
-// Do not import this from browser code.
+/**
+ * Node-side test entry point for the XR Playwright fixture and mock agent
+ * server.
+ */
 export {
   expect,
   MockAgentServer,

--- a/plugins/plugin-facewear/emulator/vite.config.ts
+++ b/plugins/plugin-facewear/emulator/vite.config.ts
@@ -1,8 +1,10 @@
+/**
+ * Vite build configuration for the browser-side XR emulator injected by
+ * Playwright.
+ */
 import { resolve } from "node:path";
 import { defineConfig } from "vite";
 
-// Builds the browser-side emulator as a self-contained IIFE.
-// Output: dist/emulator.js — injected into pages by Playwright via addInitScript.
 export default defineConfig({
   build: {
     lib: {
@@ -15,7 +17,7 @@ export default defineConfig({
     rollupOptions: {
       output: {
         inlineDynamicImports: true,
-        // Force the output filename to emulator.js (not emulator.iife.js)
+        // Playwright fixtures load this exact filename with addInitScript.
         entryFileNames: "[name].js",
       },
     },

--- a/plugins/plugin-facewear/src/__tests__/device-registry.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/device-registry.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Device registry tests pin every supported facewear profile and the public
+ * lookup helpers used by setup and status views.
+ */
 import { describe, expect, it } from "vitest";
 import {
   DEVICE_REGISTRY,

--- a/plugins/plugin-facewear/src/__tests__/even-bridge.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/even-bridge.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Even native bridge tests cover lens write ordering, event normalization, and
+ * Wi-Fi result shapes without loading a platform bridge.
+ */
 import { describe, expect, it } from "vitest";
 import { G1Command } from "../protocol/smartglasses.ts";
 import { EvenBridgeTransport } from "../transport/even-bridge.ts";

--- a/plugins/plugin-facewear/src/__tests__/facewear-service.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/facewear-service.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Facewear service tests cover the coordinator behavior when XR and
+ * smartglasses services are absent or available through the runtime.
+ */
 import { describe, expect, it, vi } from "vitest";
 import {
   FACEWEAR_SERVICE_TYPE,

--- a/plugins/plugin-facewear/src/__tests__/facewear-status-route-contract.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/facewear-status-route-contract.test.ts
@@ -1,10 +1,8 @@
-// End-to-end contract test for the FacewearView data source: the REAL
-// facewearStatusRoute handler runs over a REAL FacewearService (whose runtime
-// returns realistically-shaped XR + smartglasses services), and the JSON body is
-// asserted to match the exact { connected, devices:[{id,kind,deviceType}] } DTO
-// that the FacewearView wrapper parses from
-// fetch("/api/facewear/status"). This pins the producer (route) and the consumer
-// (view parser) to one shape.
+/**
+ * End-to-end route contract for the FacewearView data source. The route handler
+ * runs over FacewearService with realistically shaped XR and smartglasses
+ * services, then pins the status DTO consumed by the view wrapper.
+ */
 
 import type { Route } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-facewear/src/__tests__/facewear-visual-copy.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/facewear-visual-copy.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Visual-copy tests keep the facewear surfaces on shared spatial vocabulary and
+ * shell theme tokens instead of bespoke color literals.
+ */
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -8,9 +12,7 @@ function readSource(relativePath: string): string {
   return readFileSync(resolve(root, relativePath), "utf8");
 }
 
-// Glyphs the spatial / shell surfaces must not hardcode (custom palettes,
-// raw color literals, emoji). The collapsed facewear views render through the
-// shared spatial vocabulary + shell theme tokens, never a bespoke palette.
+// The collapsed facewear views render through shared spatial and shell tokens.
 const FORBIDDEN = ["#0a0a0c", "#6366f1", "#a1a1aa", "rgba("];
 
 describe("facewear visual copy", () => {
@@ -26,9 +28,7 @@ describe("facewear visual copy", () => {
         );
       }
     }
-    // FacewearView is a thin GUI/XR wrapper that delegates to FacewearSpatialView;
-    // the spatial primitives (and thus the @elizaos/ui/spatial import) live in
-    // the spatial view, never in raw HTML the wrapper would have to style itself.
+    // Spatial primitives stay in the spatial view, where the shell can theme them.
     expect(
       readSource("components/FacewearSpatialView.tsx"),
       "FacewearSpatialView renders via spatial primitives",

--- a/plugins/plugin-facewear/src/__tests__/native-build-infra.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/native-build-infra.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Native build infrastructure tests verify that each facewear platform scaffold
+ * and emulator workspace can be found and parsed.
+ */
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/plugins/plugin-facewear/src/__tests__/noble.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/noble.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Noble transport tests exercise BLE discovery, lens routing, and notification
+ * handling through in-memory peripherals.
+ */
 import { EventEmitter } from "node:events";
 import { describe, expect, it } from "vitest";
 import { G1Command } from "../protocol/smartglasses.ts";

--- a/plugins/plugin-facewear/src/__tests__/protocol-smartglasses.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/protocol-smartglasses.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Smartglasses protocol tests pin Even Realities G1 command encoders and parser
+ * behavior at the byte level.
+ */
 import { describe, expect, it } from "vitest";
 import {
   encodeAppWhitelist,

--- a/plugins/plugin-facewear/src/__tests__/protocol-xr.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/protocol-xr.test.ts
@@ -1,3 +1,7 @@
+/**
+ * XR protocol tests verify binary frame encoding for audio, images, and pose
+ * metadata exchanged with headset clients.
+ */
 import { describe, expect, it } from "vitest";
 import { decodeBinaryFrame, encodeBinaryFrame } from "../protocol/xr.ts";
 

--- a/plugins/plugin-facewear/src/__tests__/smartglasses-basic-actions.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/smartglasses-basic-actions.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Smartglasses basic action tests cover display and microphone command behavior
+ * against the service boundary.
+ */
 import { describe, expect, it } from "vitest";
 import { displaySmartglassesTextAction } from "../actions/display-text.ts";
 import { smartglassesMicrophoneAction } from "../actions/microphone.ts";

--- a/plugins/plugin-facewear/src/__tests__/smartglasses-bridge-contract.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/smartglasses-bridge-contract.test.ts
@@ -1,13 +1,7 @@
-// Contract test for the SmartglassesView Wi-Fi bridge parser against real-shaped
-// native-bridge responses. The field-name variants below are the contract the
-// plugin actually handles at runtime: they mirror the Even Realities / Mentra
-// native bridge shapes normalized in src/transport/even-bridge.ts
-// (normalizeBridgeWifiEvent / normalizeWifiResult) and the request `op` payloads
-// documented in docs/smartglasses.md ({op:"wifi_scan"|"wifi_status"|
-// "wifi_configure"|"wifi_setup"}). Each fixture's shape is verified against those
-// in-repo sources, not invented. This is the SmartglassesView (gui+xr) view's
-// external-data contract: SmartglassesView calls these exact parser helpers on
-// the bridge response when the user clicks Scan / Status / Configure / Setup.
+/**
+ * SmartglassesView Wi-Fi bridge contract tests cover real-shaped Even Realities
+ * and Mentra native bridge responses normalized by the UI parser helpers.
+ */
 
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-facewear/src/__tests__/smartglasses-control-action.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/smartglasses-control-action.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Smartglasses control action tests exercise G1 command dispatch, validation
+ * errors, and mock transport state updates.
+ */
 import { describe, expect, it } from "vitest";
 import { smartglassesControlAction } from "../actions/facewear-control.ts";
 import { G1Command } from "../protocol/smartglasses.ts";

--- a/plugins/plugin-facewear/src/__tests__/smartglasses-view-report.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/smartglasses-view-report.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Smartglasses view report tests pin the diagnostic summary, bridge helpers,
+ * and display packet construction used by the wearable dashboard.
+ */
 import { describe, expect, it } from "vitest";
 import {
   G1AiStatus,

--- a/plugins/plugin-facewear/src/__tests__/smartglasses-view.test.tsx
+++ b/plugins/plugin-facewear/src/__tests__/smartglasses-view.test.tsx
@@ -1,12 +1,10 @@
-// @vitest-environment jsdom
-//
-// Renders the real SmartglassesView component driven by a fake native bridge
-// (window.__evenBridge) so connectHeadset uses EvenBridgeTransport. Asserts the
-// populated data (lens pills, report rows, checklist, events, wifi chips) and
-// every interactive control's effect (connect, platform tabs, display presets,
-// Display/Clear/Mic/Run-Check handlers + disabled gating, Wi-Fi scan/status/
-// configure handlers + !bridge disabling, Report Copy/Download, tap-driven mic
-// auto-enable/disable, Events empty-state vs populated reversed list + overflow).
+/**
+ * @vitest-environment jsdom
+ *
+ * SmartglassesView tests render the dashboard against a fake native bridge so
+ * the EvenBridgeTransport path, report rows, Wi-Fi controls, and mic flows are
+ * exercised through the real component.
+ */
 
 import {
   act,
@@ -19,11 +17,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SmartglassesView } from "../ui/SmartglassesView.tsx";
 
-// A fake Even/Mentra native bridge. Only the methods SmartglassesView's
-// EvenBridgeTransport path actually calls are implemented:
-// - onEvent registers the event pump; pushEvent() feeds the component's onEvent.
-// - write/setMicState capture outbound writes (display, init, mic).
-// - the wifi methods return realistic native-bridge response shapes.
+// The fake bridge implements only the native operations the component invokes.
 function makeFakeBridge() {
   let eventCb: ((event: unknown) => void) | null = null;
   const writes: Array<{ side: string; first: number; bytes: number }> = [];

--- a/plugins/plugin-facewear/src/__tests__/status-format.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/status-format.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Smartglasses status formatting tests pin setup hints and physical blocker
+ * summaries shown to wearable users.
+ */
 import { describe, expect, it } from "vitest";
 import { setupHintForStatus, setupSummaryForStatus } from "../status-format.ts";
 

--- a/plugins/plugin-facewear/src/__tests__/web-bluetooth.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/web-bluetooth.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Web Bluetooth transport tests exercise G1 lens discovery, writes, and
+ * notification parsing with browser-shaped fakes.
+ */
 import { describe, expect, it } from "vitest";
 import { G1Command } from "../protocol/smartglasses.ts";
 import { WebBluetoothG1Transport } from "../transport/web-bluetooth.ts";

--- a/plugins/plugin-facewear/src/__tests__/xr-smartglasses-bridge.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/xr-smartglasses-bridge.test.ts
@@ -1,3 +1,7 @@
+/**
+ * XR smartglasses bridge tests verify headset WebSocket messages are routed
+ * into SmartglassesService for native G1 frames and microphone audio.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 import WebSocket from "ws";

--- a/plugins/plugin-facewear/src/components/FacewearSpatialView.test.tsx
+++ b/plugins/plugin-facewear/src/components/FacewearSpatialView.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * Facewear spatial view tests verify HTML and terminal rendering for connected
+ * XR and smartglasses profile snapshots.
+ */
 import { visibleWidth } from "@elizaos/tui";
 import { SpatialSurface } from "@elizaos/ui/spatial";
 import {

--- a/plugins/plugin-facewear/src/components/FacewearView.test.tsx
+++ b/plugins/plugin-facewear/src/components/FacewearView.test.tsx
@@ -1,11 +1,9 @@
-// @vitest-environment jsdom
-//
-// Drives the unified FacewearView (the single GUI/XR data wrapper) through the
-// rendered DOM: the same component the bundle exports for both the "gui" and
-// "xr" modalities. Asserts the device rows, the connected header pill, the
-// even-realities -> /apps/smartglasses routing, the WebXR -> /api/xr/connect
-// routing, the XR connect/status quick-actions, and the Refresh re-fetch all
-// reach the native bridge with the exact arguments.
+/**
+ * @vitest-environment jsdom
+ *
+ * FacewearView tests drive the unified GUI/XR wrapper through device rows,
+ * routing actions, connect/status controls, and refresh fetches.
+ */
 
 import {
   act,

--- a/plugins/plugin-facewear/src/components/SmartglassesPanelView.test.tsx
+++ b/plugins/plugin-facewear/src/components/SmartglassesPanelView.test.tsx
@@ -1,10 +1,9 @@
-// @vitest-environment jsdom
-//
-// Drives the unified SmartglassesPanelView (the single GUI/XR data wrapper) -
-// the same component the bundle exports for both the "gui" and "xr" modalities.
-// Asserts it mirrors the live report the full dashboard publishes on
-// window.facewearSmartglassesReport, toggles mic locally, and forwards the
-// Wi-Fi controls to the same native bridge the dashboard drives.
+/**
+ * @vitest-environment jsdom
+ *
+ * SmartglassesPanelView tests cover the compact GUI/XR panel, live report
+ * mirroring, local mic toggles, and native bridge Wi-Fi controls.
+ */
 
 import {
   act,

--- a/plugins/plugin-facewear/src/components/SmartglassesSpatialView.test.tsx
+++ b/plugins/plugin-facewear/src/components/SmartglassesSpatialView.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * Smartglasses spatial view tests verify HTML and terminal rendering for G1
+ * diagnostic report snapshots.
+ */
 import { visibleWidth } from "@elizaos/tui";
 import { SpatialSurface } from "@elizaos/ui/spatial";
 import {

--- a/plugins/plugin-facewear/src/protocol/smartglasses.encoders.test.ts
+++ b/plugins/plugin-facewear/src/protocol/smartglasses.encoders.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Even Realities G1 encoder tests pin fixed command opcodes and sequence byte
+ * wrapping for BLE packets.
+ */
 import { describe, expect, it } from "vitest";
 import {
   encodeBatteryStatusRequest,
@@ -9,13 +13,6 @@ import {
   encodeMicCommand,
   encodeSilentMode,
 } from "./smartglasses.js";
-
-/**
- * Even Realities G1 BLE command encoders. A wrong opcode byte sends the glasses
- * the wrong instruction, so the exact wire bytes are pinned. Command opcodes:
- * Brightness 0x01, SilentMode 0x03, OpenMic 0x0e, ExitFunction 0x18,
- * Heartbeat 0x25, Battery 0x2c, Init 0x4d, RightInit 0xf4, StartAi 0xf5.
- */
 
 const bytes = (u: Uint8Array): number[] => Array.from(u);
 

--- a/plugins/plugin-facewear/src/protocol/smartglasses.layout.test.ts
+++ b/plugins/plugin-facewear/src/protocol/smartglasses.layout.test.ts
@@ -1,15 +1,13 @@
+/**
+ * G1 display layout tests pin glyph measurement, line wrapping, and pagination
+ * for text shown on the lenses.
+ */
 import { describe, expect, it } from "vitest";
 import {
   formatDisplayLines,
   measureG1DisplayText,
   paginateDisplayText,
 } from "./smartglasses.js";
-
-/**
- * G1 display text layout: width measurement (per-script glyph widths), line
- * wrapping, and pagination with centered padding. These drive what the wearer
- * actually sees, so wrap points + page shape are pinned.
- */
 
 describe("measureG1DisplayText", () => {
   it("measures by script: empty=0, CJK=18, Korean=24, monotonic in length", () => {

--- a/plugins/plugin-facewear/src/runtime/openxr-runtime.test.ts
+++ b/plugins/plugin-facewear/src/runtime/openxr-runtime.test.ts
@@ -1,3 +1,7 @@
+/**
+ * OpenXR runtime tests exercise detection and install planning through an
+ * in-memory platform probe.
+ */
 import { describe, expect, it } from "vitest";
 import {
   detectOpenXrRuntime,
@@ -7,7 +11,7 @@ import {
   type RuntimeProbe,
 } from "./openxr-runtime.ts";
 
-/** A probe backed by an in-memory filesystem + a fixed platform. */
+/** In-memory filesystem and platform probe for deterministic runtime detection. */
 function fakeProbe(opts: {
   platform: string;
   files?: Record<string, string>;

--- a/plugins/plugin-facewear/vite.config.views.ts
+++ b/plugins/plugin-facewear/vite.config.views.ts
@@ -1,3 +1,7 @@
+/**
+ * View bundle configuration for the facewear settings panel served by the app
+ * plugin host.
+ */
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
 export default createViewBundleConfig({

--- a/plugins/plugin-facewear/vitest.config.ts
+++ b/plugins/plugin-facewear/vitest.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Vitest configuration for facewear unit, transport, and React view coverage
+ * against source aliases in this sparse workspace.
+ */
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";


### PR DESCRIPTION
## Summary
- Add or repair top-of-file prose headers across the facewear test/config/emulator slice.
- Convert a few long churn-style test comments into durable present-tense rationale.
- Keep this PR comment-only; no code tokens changed.

Partial for #12755. This covers 31 facewear test/config files. A live audit still shows remaining headerless facewear runtime/action/source files outside this slice, so #12755 should stay open after this PR.

## Validation
- Read `plugins/plugin-facewear/CLAUDE.md`.
- PASS: changed-file header audit: all changed source files begin with required prose headers.
- PASS: strict facewear audit improved from `FACEWEAR_MISSING=74` to `FACEWEAR_MISSING=43` out of 104 source files.
- PASS: `bun run check:comment-only`
  - `[assert-comment-only-diff] OK — 31 source file(s) changed; every code token identical to origin/develop. Comments only.`
- PASS: `git diff --check -- plugins/plugin-facewear`
- PASS: `bun run --cwd plugins/plugin-facewear lint`
  - `Checked 83 files in 121ms. No fixes applied.`
- BLOCKED: `bun run verify`
  - Sparse checkout is missing `packages/auth/AGENTS.md`, so `check:agents-claude` fails before workspace verification starts.
- BLOCKED: `bun run --cwd plugins/plugin-facewear typecheck`
  - Local sparse/dependency state cannot resolve `@elizaos/plugin-x402`, several dist-node dependency declarations (`adze`, `fast-redact`, `marked`, `get-east-asian-width`, `lucide-react`), and UI spatial/agent-surface exports; it also reports the existing `Button` `unstyled` prop mismatch in `src/ui/SmartglassesView.tsx`.
- BLOCKED: `bun run --cwd plugins/plugin-facewear test`
  - View bundle build succeeds, then emulator build fails when the re-exported `plugin-xr` simulator cannot resolve `iwer` from this sparse checkout's package root.

## Evidence
- N/A - comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- N/A - no runtime, model, UI, audio, native, or domain behavior changed.

Refs #12755
