### PR TITLE
fix(embeddings,documents): reject duplicate-index batch holes + never split surrogate pairs at truncation cuts

### DIFF
--- a/plugins/plugin-documents/src/document-presenter.test.ts
+++ b/plugins/plugin-documents/src/document-presenter.test.ts
@@ -1,7 +1,10 @@
 /** Unit tests for presentDocument: deterministic mapping of document Memory metadata to display cards (no runtime). */
 import type { Memory, UUID } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import { presentDocument } from "./document-presenter";
+import {
+  getDocumentTitleFromMetadata,
+  presentDocument,
+} from "./document-presenter";
 
 function docMemory(metadata: Record<string, unknown>): Memory {
   return {
@@ -38,5 +41,25 @@ describe("presentDocument — transcript link passthrough", () => {
     );
     expect(dto.transcriptId).toBeUndefined();
     expect(dto.transcriptAudioUrl).toBeUndefined();
+  });
+});
+
+describe("getDocumentTitleFromMetadata — derived-title truncation", () => {
+  it("never splits a surrogate pair at the truncation cut", () => {
+    // The 😀 spans code units 78..79 of the first line, exactly where the
+    // 80-char label cut lands; a blind slice would leave a lone high surrogate
+    // that renders as U+FFFD in the documents view.
+    const line = `${"x".repeat(78)}😀${"y".repeat(20)}`;
+    const title = getDocumentTitleFromMetadata(undefined, line);
+    expect(title.isWellFormed()).toBe(true);
+    expect(title).toBe(`${"x".repeat(78)}...`);
+  });
+
+  it("keeps an astral char that falls fully inside the kept prefix", () => {
+    const line = `😀${"x".repeat(100)}`;
+    const title = getDocumentTitleFromMetadata(undefined, line);
+    expect(title.isWellFormed()).toBe(true);
+    expect(title.startsWith("😀")).toBe(true);
+    expect(title.endsWith("...")).toBe(true);
   });
 });

--- a/plugins/plugin-documents/src/document-presenter.ts
+++ b/plugins/plugin-documents/src/document-presenter.ts
@@ -115,9 +115,14 @@ function asNumber(value: unknown): number | undefined {
 }
 
 function truncateLabel(value: string, maxLength = 80): string {
-  return value.length > maxLength
-    ? `${value.slice(0, maxLength - 1).trimEnd()}...`
-    : value;
+  if (value.length <= maxLength) return value;
+  // Back off one code unit when the cut would land between the halves of a
+  // surrogate pair — otherwise the label ends in a lone high surrogate that
+  // renders as U+FFFD in the documents view.
+  let end = maxLength - 1;
+  const lastKept = value.charCodeAt(end - 1);
+  if (lastKept >= 0xd800 && lastKept <= 0xdbff) end -= 1;
+  return `${value.slice(0, end).trimEnd()}...`;
 }
 
 function stripMarkdownPrefix(line: string): string {

--- a/plugins/plugin-embeddings/__tests__/embedding.test.ts
+++ b/plugins/plugin-embeddings/__tests__/embedding.test.ts
@@ -201,4 +201,66 @@ describe("plugin-embeddings handleBatchTextEmbedding", () => {
     );
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("throws when the response repeats an index (a hole must never be returned)", async () => {
+    // Count check alone passes (2 items for 2 inputs) but slot 1 stays unfilled;
+    // returning [B, undefined] would silently persist a corrupt vector.
+    const fetchMock = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: async () => ({
+            object: "list",
+            data: [
+              { object: "embedding", embedding: vectorOf(1536), index: 0 },
+              { object: "embedding", embedding: vectorOf(1536), index: 0 },
+            ],
+            model: "text-embedding-3-small",
+          }),
+          text: async () => "",
+        }) as unknown as Response
+    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as unknown as typeof fetch);
+
+    await expect(handleBatchTextEmbedding(createRuntime(), ["one", "two"])).rejects.toThrow(
+      /duplicate index 0/i
+    );
+  });
+});
+
+describe("plugin-embeddings input truncation", () => {
+  const MAX_EMBEDDING_CHARS = 8_000 * 4;
+
+  it("never splits a surrogate pair at the truncation boundary", async () => {
+    // The 😀 spans code units MAX-1..MAX, so a blind slice(0, MAX) would keep a
+    // lone high surrogate — mojibake (U+FFFD) or a reject at the endpoint.
+    const text = `${"a".repeat(MAX_EMBEDDING_CHARS - 1)}😀tail`;
+    const fetchMock = vi.fn(async () => mockEmbeddingsResponse([vectorOf(1536)]));
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as unknown as typeof fetch);
+
+    await handleTextEmbedding(createRuntime(), text);
+
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const sent = body.input as string;
+    expect(sent.isWellFormed()).toBe(true);
+    expect(sent.length).toBeLessThanOrEqual(MAX_EMBEDDING_CHARS);
+    expect(sent).toBe("a".repeat(MAX_EMBEDDING_CHARS - 1));
+  });
+
+  it("keeps an astral char that fits entirely under the cap", async () => {
+    // Here the pair ends exactly at the boundary — no back-off should occur.
+    const text = `${"a".repeat(MAX_EMBEDDING_CHARS - 2)}😀tail`;
+    const fetchMock = vi.fn(async () => mockEmbeddingsResponse([vectorOf(1536)]));
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as unknown as typeof fetch);
+
+    await handleTextEmbedding(createRuntime(), text);
+
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const sent = body.input as string;
+    expect(sent.isWellFormed()).toBe(true);
+    expect(sent).toBe(`${"a".repeat(MAX_EMBEDDING_CHARS - 2)}😀`);
+    expect(sent.length).toBe(MAX_EMBEDDING_CHARS);
+  });
 });

--- a/plugins/plugin-embeddings/src/models/embedding.ts
+++ b/plugins/plugin-embeddings/src/models/embedding.ts
@@ -78,7 +78,13 @@ function truncate(text: string): string {
   logger.warn(
     `[Embeddings] Input too long (~${Math.ceil(text.length / 4)} tokens), truncating to ~8000 tokens`
   );
-  return text.slice(0, MAX_EMBEDDING_CHARS);
+  // Never cut between the halves of a surrogate pair: a trailing lone high
+  // surrogate is not valid Unicode, so it reaches the endpoint as U+FFFD (or a
+  // hard reject on strict JSON parsers) and corrupts the embedded text.
+  const lastKept = text.charCodeAt(MAX_EMBEDDING_CHARS - 1);
+  const end =
+    lastKept >= 0xd800 && lastKept <= 0xdbff ? MAX_EMBEDDING_CHARS - 1 : MAX_EMBEDDING_CHARS;
+  return text.slice(0, end);
 }
 
 /**
@@ -141,6 +147,14 @@ async function requestEmbeddings(
     if (idx === undefined || idx < 0 || idx >= expectedCount) {
       throw new Error(
         `Embedding API returned out-of-range index ${String(item.index)} (expected 0..${expectedCount - 1})`
+      );
+    }
+    // A repeated index passes the count check above yet leaves another slot as
+    // a hole, which the batch path would otherwise silently return (Commandment
+    // 8: throw, never hand back a fabricated/undefined vector).
+    if (vectors[idx] !== undefined) {
+      throw new Error(
+        `Embedding API returned duplicate index ${idx}; a vector slot would be left unfilled`
       );
     }
     if (!Array.isArray(item.embedding) || item.embedding.length !== embeddingDimension) {


### PR DESCRIPTION
## What

Three real, probe-confirmed pure-logic bugs in `@elizaos/plugin-embeddings` and `@elizaos/plugin-documents`, each fixed minimally with a mutation-checked unit test. All were verified against current `develop` (59f1ec419a) by executing the real functions with the wrong-output inputs BEFORE authoring fixes.

## Bug 1 — batch embedding response with a repeated `index` returns a silent `undefined` hole

`requestEmbeddings` (`plugins/plugin-embeddings/src/models/embedding.ts`) checks `data.data.length === expectedCount` and that each item's `index` is in range, but a response that **repeats** an index passes both checks and leaves another vector slot unfilled. `handleTextEmbedding` guards its single slot; `handleBatchTextEmbedding` returned the sparse array as-is.

**Concrete failure (probe-executed on develop):** inputs `["one","two"]`, mocked wire response `[{index:0,embedding:A},{index:0,embedding:B}]` → returned `[B, undefined]`. That violates the package contract ("THROW, never fabricate", AGENTS.md / #9324) and hands an `undefined` "vector" to the embedding store.

**Fix:** throw `duplicate index N` when a response item addresses an already-filled slot. With the existing length + range checks, no-duplicates pigeonholes every slot as filled — no hole can survive.

## Bug 2 — embedding input truncation splits a surrogate pair on the wire

`truncate()` sliced at `MAX_EMBEDDING_CHARS` (32 000) raw UTF-16 code units.

**Concrete failure (probe-executed on develop):** input `"a".repeat(31999) + "😀tail"` → the JSON body's `input` ended in lone high surrogate `0xD83D`, `String.prototype.isWellFormed() === false`. The endpoint receives U+FFFD mojibake (or strict JSON parsers reject the request outright).

**Fix:** back off one code unit when the unit at the cut is a high surrogate (0xD800–0xDBFF). A pair ending exactly at the cap is kept (covered by a second test).

## Bug 3 — derived document titles end in a lone surrogate

`truncateLabel` in `plugins/plugin-documents/src/document-presenter.ts` had the same blind `slice(0, maxLength - 1)`.

**Concrete failure (probe-executed on develop):** `getDocumentTitleFromMetadata(undefined, "x".repeat(78) + "😀" + "y".repeat(20))` → title's last kept char is a lone high surrogate (`isWellFormed() === false`), rendered as � in the documents view card. Fixed with the same one-unit back-off before `slice + trimEnd + "..."`.

## Evidence

| Check | Result |
|---|---|
| Probe on unmodified develop | 3/3 wrong-output assertions passed (bugs confirmed live) |
| New tests with fixes | `bunx vitest run --no-cache plugins/plugin-embeddings/__tests__/embedding.test.ts plugins/plugin-documents/src/document-presenter.test.ts` → **21/21 green** |
| Full plugin-embeddings unit suite | 30/30 green (embedding + config + auto-enable) |
| Mutation check, fix 1 | Guard removed → `throws when the response repeats an index` FAILED (16/17); restored → green |
| Mutation check, fix 2 | Blind slice restored → `never splits a surrogate pair at the truncation boundary` FAILED (16/17); restored → green |
| Mutation check, fix 3 | Old truncateLabel restored → `never splits a surrogate pair at the truncation cut` FAILED (3/4); restored → green |
| biome | clean on all 4 touched files |
| Live-LLM trajectories | N/A — pure response-shape/string-boundary logic; both handlers are exercised through the package's established wire-mocked-fetch harness (no model behavior changed) |
| Screenshots / video | N/A — no UI code changed; the presenter fix is a pure string function covered by unit tests |
| DB/domain artifacts | N/A — no persistence code touched; the batch fix *prevents* a corrupt store write |

Scope: 4 files, +109/−5 — `plugin-embeddings/src/models/embedding.ts`, `plugin-embeddings/__tests__/embedding.test.ts`, `plugin-documents/src/document-presenter.ts`, `plugin-documents/src/document-presenter.test.ts`.

[phone-ui]

---
**Authored end-to-end by a Fable-5 agent** (verified 100% claude-fable-5), committed + pushed on its own branch. Each fix probe-executed against the real function on develop (concrete input → wrong output) BEFORE authoring — 3/3 probe assertions confirmed the bugs live. Independently re-verified: 4-file merge-base diff, 21/21 green (--no-cache), embedding.ts mutation reproduced (revert → tests red; restore → green). The two surrogate-pair bugs were surfaced by the explicit multibyte-testing instruction (CI uses ASCII assumptions). Agent dropped 4 speculative candidates. — [phone-ui]