### PR TITLE
docs(#12758): clean music action prose headers

### DIFF
--- a/plugins/plugin-music/src/__tests__/core-test-mock.ts
+++ b/plugins/plugin-music/src/__tests__/core-test-mock.ts
@@ -1,3 +1,7 @@
+/**
+ * Shared Vitest mock for music tests that need core services without loading
+ * the full runtime.
+ */
 import { vi } from "vitest";
 
 vi.mock("@elizaos/core", () => {

--- a/plugins/plugin-music/src/actions/confirmation.ts
+++ b/plugins/plugin-music/src/actions/confirmation.ts
@@ -1,3 +1,9 @@
+/**
+ * Confirmation helpers for destructive music actions.
+ *
+ * The action handlers share this wrapper so playlist, queue, transport, and
+ * download operations use the same pending-confirmation contract.
+ */
 import type {
   ActionResult,
   HandlerCallback,

--- a/plugins/plugin-music/src/actions/downloadMusic.test.ts
+++ b/plugins/plugin-music/src/actions/downloadMusic.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Download action tests for structured query routing.
+ *
+ * They pin media-context validation and prevent the handler from extracting
+ * download targets from free-form message text.
+ */
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { handleDownloadMusic, validateDownloadMusic } from "./downloadMusic";

--- a/plugins/plugin-music/src/actions/downloadMusic.ts
+++ b/plugins/plugin-music/src/actions/downloadMusic.ts
@@ -1,3 +1,9 @@
+/**
+ * Download subaction for fetching and caching music from search queries.
+ *
+ * It validates structured input or active media/file context, asks for
+ * confirmation, and streams fetch progress through the action callback.
+ */
 import {
   type ActionExample,
   type ActionResult,

--- a/plugins/plugin-music/src/actions/manageRouting.ts
+++ b/plugins/plugin-music/src/actions/manageRouting.ts
@@ -1,3 +1,9 @@
+/**
+ * Routing-management action for the music playback engine.
+ *
+ * It exposes structured commands for routing mode, broadcast routes, and status
+ * over the AudioRouter and ZoneManager boundary.
+ */
 import type {
   Action,
   ActionResult,

--- a/plugins/plugin-music/src/actions/manageRoutingZones.test.ts
+++ b/plugins/plugin-music/src/actions/manageRoutingZones.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Routing and zone action tests for structured command parameters.
+ *
+ * They verify routing and zone mutations come from action options rather than
+ * parsed prose.
+ */
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { ZoneManager } from "../router";

--- a/plugins/plugin-music/src/actions/manageZones.ts
+++ b/plugins/plugin-music/src/actions/manageZones.ts
@@ -1,3 +1,9 @@
+/**
+ * Zone-management action for grouped music playback targets.
+ *
+ * It creates, deletes, inspects, and edits ZoneManager groups through
+ * structured action parameters.
+ */
 import type {
   Action,
   ActionResult,

--- a/plugins/plugin-music/src/actions/music-player-action-docs.ts
+++ b/plugins/plugin-music/src/actions/music-player-action-docs.ts
@@ -1,3 +1,6 @@
+/**
+ * Compact action-surface summary injected into music action guidance.
+ */
 export const MUSIC_PLAYER_ACTION_DOCS = [
   "playback_sources: YouTube, SoundCloud, Spotify links via search, and yt-dlp supported media URLs",
   "transport_actions: PAUSE_MUSIC, RESUME_MUSIC, STOP_MUSIC, SKIP_TRACK",

--- a/plugins/plugin-music/src/actions/music.test.ts
+++ b/plugins/plugin-music/src/actions/music.test.ts
@@ -1,3 +1,9 @@
+/**
+ * MUSIC umbrella-action tests for structured dispatch and context routing.
+ *
+ * They pin validation from planner context, legacy aliases, and delegation to
+ * the underlying music handlers.
+ */
 import type { ActionResult, IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { manageRouting } from "./manageRouting";

--- a/plugins/plugin-music/src/actions/music.ts
+++ b/plugins/plugin-music/src/actions/music.ts
@@ -1,3 +1,10 @@
+/**
+ * Umbrella MUSIC action dispatcher for playback, queue, library, routing, and
+ * generation subactions.
+ *
+ * It normalizes legacy aliases and routes structured action parameters to the
+ * narrower handlers that own each music capability.
+ */
 import type {
   Action,
   ActionExample,

--- a/plugins/plugin-music/src/actions/musicLibrary.ts
+++ b/plugins/plugin-music/src/actions/musicLibrary.ts
@@ -1,3 +1,10 @@
+/**
+ * Music library action facade for playlist, query playback, YouTube search, and
+ * download subactions.
+ *
+ * It keeps library-oriented aliases and validation in one place before
+ * delegating to the specialized handlers.
+ */
 import type {
   Action,
   ActionExample,

--- a/plugins/plugin-music/src/actions/playAudio.ts
+++ b/plugins/plugin-music/src/actions/playAudio.ts
@@ -1,3 +1,10 @@
+/**
+ * Direct playback action for URLs, library tracks, Spotify links, and search
+ * results.
+ *
+ * It bridges MusicService, Discord voice state, library lookups, and
+ * progressive user feedback before queueing or starting audio.
+ */
 import {
   type Action,
   type ActionExample,

--- a/plugins/plugin-music/src/actions/playMusicQuery.test.ts
+++ b/plugins/plugin-music/src/actions/playMusicQuery.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Smart music-query validation tests for routing-context behavior.
+ *
+ * They prove structured queries and media context work across languages without
+ * English keyword extraction.
+ */
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { validatePlayMusicQuery } from "./playMusicQuery";

--- a/plugins/plugin-music/src/actions/playMusicQuery.ts
+++ b/plugins/plugin-music/src/actions/playMusicQuery.ts
@@ -1,3 +1,9 @@
+/**
+ * Smart query playback action for research-backed music requests.
+ *
+ * It turns structured or media-routed requests into library and web-search
+ * lookups before queueing the selected track.
+ */
 import {
   type ActionExample,
   type ActionResult,

--- a/plugins/plugin-music/src/actions/playbackOp.test.ts
+++ b/plugins/plugin-music/src/actions/playbackOp.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Playback transport tests for structured pause, resume, skip, stop, and queue
+ * operations.
+ *
+ * They keep transport validation independent from free-form message text.
+ */
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { playbackOp, validatePlaybackControl } from "./playbackOp";

--- a/plugins/plugin-music/src/actions/playbackOp.ts
+++ b/plugins/plugin-music/src/actions/playbackOp.ts
@@ -1,3 +1,9 @@
+/**
+ * Playback transport action for queue and current-track controls.
+ *
+ * It resolves the active guild, gates destructive transport operations, and
+ * coordinates MusicService and fetch progress feedback.
+ */
 import {
   type Action,
   type ActionExample,

--- a/plugins/plugin-music/src/actions/playlistOp.test.ts
+++ b/plugins/plugin-music/src/actions/playlistOp.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Playlist operation tests for structured names and destructive confirmation.
+ *
+ * They prevent playlist mutations from being inferred from prose alone.
+ */
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { handlePlaylistOp, validatePlaylistOp } from "./playlistOp";

--- a/plugins/plugin-music/src/actions/playlistOp.ts
+++ b/plugins/plugin-music/src/actions/playlistOp.ts
@@ -1,3 +1,9 @@
+/**
+ * Playlist subaction handler for save, load, delete, and add operations.
+ *
+ * It reads structured playlist names and coordinates MusicService queue state
+ * with MusicLibraryService persistence.
+ */
 import {
   type ActionExample,
   type ActionResult,

--- a/plugins/plugin-music/src/actions/searchYouTube.test.ts
+++ b/plugins/plugin-music/src/actions/searchYouTube.test.ts
@@ -1,3 +1,9 @@
+/**
+ * YouTube search action tests for structured query handling.
+ *
+ * They verify validation and search execution do not mine free-form message
+ * text for a target query.
+ */
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { handleSearchYouTube, validateSearchYouTube } from "./searchYouTube";

--- a/plugins/plugin-music/src/actions/searchYouTube.ts
+++ b/plugins/plugin-music/src/actions/searchYouTube.ts
@@ -1,3 +1,9 @@
+/**
+ * YouTube search subaction for music-library backed video lookup.
+ *
+ * It accepts structured search parameters, stores useful search memory, and
+ * returns playable YouTube candidates.
+ */
 import {
   type ActionExample,
   type ActionResult,

--- a/plugins/plugin-music/src/providers/musicInfoProvider.ts
+++ b/plugins/plugin-music/src/providers/musicInfoProvider.ts
@@ -1,3 +1,9 @@
+/**
+ * Music metadata provider for track, artist, and album context.
+ *
+ * It detects music entities in the current turn and asks MusicLibraryService for
+ * compact metadata that can inform DJ introductions or music conversations.
+ */
 import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import type { MusicLibraryService } from "../services/musicLibraryService";

--- a/plugins/plugin-music/src/providers/musicLibraryProvider.test.ts
+++ b/plugins/plugin-music/src/providers/musicLibraryProvider.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Music library provider tests for language-agnostic structured context.
+ *
+ * They verify the provider emits the same library payload regardless of request
+ * language.
+ */
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import musicLibraryProvider from "./musicLibraryProvider";

--- a/plugins/plugin-music/src/providers/musicLibraryProvider.ts
+++ b/plugins/plugin-music/src/providers/musicLibraryProvider.ts
@@ -1,3 +1,9 @@
+/**
+ * Music library provider for aggregate library stats and recent-track context.
+ *
+ * It injects play counts, top tracks, and recent tracks from the persisted music
+ * library into media and knowledge turns.
+ */
 import {
   type IAgentRuntime,
   logger,
@@ -69,9 +75,7 @@ export const musicLibraryProvider: Provider = {
   },
 };
 
-/**
- * Format milliseconds into a human-readable time ago string
- */
+// Formats a millisecond delta into compact provider text.
 function formatTimeAgo(ms: number): string {
   const seconds = Math.floor(ms / 1000);
   const minutes = Math.floor(seconds / 60);

--- a/plugins/plugin-music/src/providers/musicPlaylistsProvider.ts
+++ b/plugins/plugin-music/src/providers/musicPlaylistsProvider.ts
@@ -1,3 +1,9 @@
+/**
+ * Playlist provider for user-scoped saved music playlists.
+ *
+ * It reads MusicLibraryService playlists for the requesting entity and injects a
+ * compact JSON list into media and knowledge turns.
+ */
 import {
   type IAgentRuntime,
   logger,

--- a/plugins/plugin-music/src/providers/musicQueueProvider.ts
+++ b/plugins/plugin-music/src/providers/musicQueueProvider.ts
@@ -1,3 +1,9 @@
+/**
+ * Queue provider for now-playing and upcoming music context.
+ *
+ * It resolves the current room's server queue from MusicService and emits a
+ * bounded JSON summary for media and knowledge turns.
+ */
 import {
   type IAgentRuntime,
   logger,

--- a/plugins/plugin-music/src/providers/wikipediaProvider.test.ts
+++ b/plugins/plugin-music/src/providers/wikipediaProvider.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Wikipedia provider tests for request-context preservation.
+ *
+ * They verify extraction receives the user request across languages without
+ * English keyword purpose inference.
+ */
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { wikipediaProvider } from "./wikipediaProvider";

--- a/plugins/plugin-music/src/providers/wikipediaProvider.ts
+++ b/plugins/plugin-music/src/providers/wikipediaProvider.ts
@@ -1,3 +1,9 @@
+/**
+ * Wikipedia music provider for LLM-extracted artist and track context.
+ *
+ * It detects music entities, fetches Wikipedia material through
+ * MusicLibraryService, and injects extracted context into media turns.
+ */
 import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import type { DetectedMusicEntity } from "../services/musicEntityDetectionService";


### PR DESCRIPTION
## Summary
- Add top-of-file prose headers to the plugin-music action/provider/test slice.
- Convert one local helper comment into durable present-tense wording.
- Keep this PR comment-only; no code tokens changed.

Partial for #12758. This covers 27 music action/provider/test files. A live audit still shows remaining headerless plugin-music files outside this slice, so #12758 should stay open after this PR.

## Validation
- Read `plugins/plugin-music/CLAUDE.md`.
- Changed-file header audit: PASS (27/27 changed files begin with prose headers).
- `bun run check:comment-only`: PASS (`27 source file(s) changed; every code token identical to origin/develop. Comments only.`)
- `git diff --check origin/develop...HEAD`: PASS.
- `git diff --name-only origin/develop...HEAD | xargs bunx @biomejs/biome check --config-path biome.json --files-ignore-unknown=true --no-errors-on-unmatched`: PASS (27 files checked, no fixes).

## Evidence N/A
- UI screenshots/video: N/A - comment-only cleanup with zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- Live LLM trajectories: N/A - no agent/action/provider/prompt/model behavior changed.
- Backend/frontend logs: N/A - no runtime behavior changed.
- Audio/domain artifacts: N/A - no playback, generation, or artifact-producing behavior changed.