### PR TITLE
fix(#12903): remove masked example script checks

### DIFF
--- a/.github/issue-evidence/12903-example-lint-masks.md
+++ b/.github/issue-evidence/12903-example-lint-masks.md
@@ -1,0 +1,120 @@
+# #12903 example lint-mask cleanup evidence
+
+Branch slice: normalize the script contracts for three `packages/examples/*`
+packages that were hiding read-only checks behind `|| true`.
+
+## Packages
+
+- `packages/examples/code`
+- `packages/examples/elizagotchi`
+- `packages/examples/moltbook`
+
+## Script contract changes
+
+- Removed `|| true` from `lint:check` in all three packages.
+- Removed `|| true` from `format:check` in `packages/examples/moltbook`.
+- Added `format` / `format:check` to `packages/examples/code` and
+  `packages/examples/elizagotchi`.
+- Added `clean: rm -rf dist` to `packages/examples/code` and
+  `packages/examples/elizagotchi`, which both have real builds that emit
+  `dist`.
+- Removed the fake `build: bun run typecheck` from
+  `packages/examples/moltbook`; it emits no artifact, so `typecheck` remains the
+  real command.
+
+## Verification
+
+Current working tree: `origin/develop` at `2b7ce1ede1`.
+
+Static script guard:
+
+```bash
+node - <<'NODE'
+const fs = require('fs');
+for (const p of ['packages/examples/code/package.json','packages/examples/elizagotchi/package.json','packages/examples/moltbook/package.json']) {
+  const pkg = JSON.parse(fs.readFileSync(p,'utf8'));
+  const bad = Object.entries(pkg.scripts || {}).filter(([,v]) => /\|\|\s*true|echo .*skipping|No build step|No TypeScript/.test(v));
+  if (bad.length) {
+    console.error(`${p}: ${bad.map(([k,v]) => `${k}=${v}`).join('; ')}`);
+    process.exitCode = 1;
+  } else {
+    console.log(`${p}: no masked/fake success scripts`);
+  }
+}
+NODE
+```
+
+Result:
+
+```text
+packages/examples/code/package.json: no masked/fake success scripts
+packages/examples/elizagotchi/package.json: no masked/fake success scripts
+packages/examples/moltbook/package.json: no masked/fake success scripts
+```
+
+Read-only lint and format checks:
+
+```bash
+bun run --cwd packages/examples/code lint:check
+bun run --cwd packages/examples/code format:check
+bun run --cwd packages/examples/elizagotchi lint:check
+bun run --cwd packages/examples/elizagotchi format:check
+bun run --cwd packages/examples/moltbook lint:check
+bun run --cwd packages/examples/moltbook format:check
+```
+
+Result:
+
+```text
+packages/examples/code: biome check passed for 52 files; biome format passed for 51 files.
+packages/examples/elizagotchi: biome check passed for 18 files; biome format passed for 17 files.
+packages/examples/moltbook: biome check passed for 9 files; biome format passed for 9 files.
+```
+
+`packages/examples/code` and `packages/examples/elizagotchi` also print a
+non-failing Biome info message because their package-local `biome.json` schema
+URL is `2.5.1` while the resolved CLI is `2.5.2`.
+
+Targeted tests:
+
+```bash
+bun run --cwd packages/examples/elizagotchi test
+```
+
+Result:
+
+```text
+2 pass, 0 fail
+```
+
+## Local blockers
+
+This auxiliary worktree does not have a valid local install. A temporary
+`node_modules -> /Users/shawwalters/eliza/node_modules` symlink was enough to
+start `tsgo`/`bun test`, but package resolution remains broken because the
+shared install's workspace symlinks point outside this worktree.
+
+Blocked commands and first failures:
+
+```text
+bun run --cwd packages/examples/code typecheck
+  error TS2688: Cannot find type definition file for 'bun'
+  error TS2688: Cannot find type definition file for 'node'
+
+bun run --cwd packages/examples/elizagotchi typecheck
+  error TS2688: Cannot find type definition file for 'node'
+
+bun run --cwd packages/examples/moltbook typecheck
+  error TS2688: Cannot find type definition file for 'node'
+
+bun run --cwd packages/examples/code test
+  ENOENT while resolving package '@elizaos/core'
+  Cannot find module '@elizaos/tui'
+
+bun run --cwd packages/examples/moltbook test
+  Cannot find module 'dotenv/config'
+  Cannot find module '@solana/web3.js'
+```
+
+The worktree was checked after these probes and remained clean except for this
+slice's package script edits and this evidence file.

--- a/packages/examples/code/package.json
+++ b/packages/examples/code/package.json
@@ -29,7 +29,10 @@
     "e2e:games": "bun src/e2e/game-generation.ts",
     "e2e:deterministic-replay": "bun --conditions eliza-source --tsconfig-override ../../../tsconfig.json tests/e2e/deterministic-app-build-replay.mjs",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "lint:check": "bunx @biomejs/biome check . || true",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "clean": "rm -rf dist",
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {

--- a/packages/examples/elizagotchi/package.json
+++ b/packages/examples/elizagotchi/package.json
@@ -8,7 +8,10 @@
     "preview": "bun --bun vite preview",
     "test": "bun test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "lint:check": "bunx @biomejs/biome check . || true",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "clean": "rm -rf dist",
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {

--- a/packages/examples/moltbook/package.json
+++ b/packages/examples/moltbook/package.json
@@ -10,11 +10,10 @@
     "bags:claim": "bun run bags-claimer.ts",
     "test": "bun test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "lint:check": "bunx @biomejs/biome check . || true",
+    "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",
-    "format:check": "bunx @biomejs/biome format . || true",
-    "typecheck": "tsgo --noEmit",
-    "build": "bun run typecheck"
+    "format:check": "bunx @biomejs/biome format .",
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",


### PR DESCRIPTION
## Summary

Fixes a #12903 script-normalization slice for three example packages:

- removes masked `|| true` read-only checks from `packages/examples/code`, `packages/examples/elizagotchi`, and `packages/examples/moltbook`
- adds missing `format` / `format:check` verbs to Code and Elizagotchi
- adds `clean` for Code and Elizagotchi because their builds emit `dist`
- removes Moltbook's fake `build: bun run typecheck` because it emits no artifact
- records evidence in `.github/issue-evidence/12903-example-lint-masks.md`

## Why

#12903 requires package scripts in this tooling/examples group to use real command outcomes: read-only checks must fail when they find problems, `build` should only exist for emitted artifacts, and `clean` should pair with real build outputs.

## Verification

- `git diff --check origin/develop..HEAD`
- static script guard: no `|| true`, fake skip echoes, or fake build/typecheck success scripts remain in the three edited packages
- `bun run --cwd packages/examples/code lint:check`
- `bun run --cwd packages/examples/code format:check`
- `bun run --cwd packages/examples/elizagotchi lint:check`
- `bun run --cwd packages/examples/elizagotchi format:check`
- `bun run --cwd packages/examples/elizagotchi test`
- `bun run --cwd packages/examples/moltbook lint:check`
- `bun run --cwd packages/examples/moltbook format:check`

## Known local limitations

Full `bun install` / `bun run verify` were not run in this auxiliary worktree because the filesystem has 6.5 GiB free and the repo install is already known to exceed that margin. Typecheck and some package tests were attempted with a temporary shared `node_modules` symlink, but package resolution is broken in that layout; details are captured in the evidence file.
