### PR TITLE
docs(#12755): clean facewear runtime prose headers

### DIFF
--- a/plugins/plugin-facewear/src/actions/display-text.ts
+++ b/plugins/plugin-facewear/src/actions/display-text.ts
@@ -1,3 +1,7 @@
+/**
+ * Smartglasses display action parses text requests and sends paginated content
+ * to Even Realities G1 lenses.
+ */
 import {
   type Action,
   type ActionResult,

--- a/plugins/plugin-facewear/src/actions/facewear-connect.ts
+++ b/plugins/plugin-facewear/src/actions/facewear-connect.ts
@@ -1,3 +1,7 @@
+/**
+ * Facewear connection action returns device-specific setup instructions for XR
+ * headsets and smartglasses.
+ */
 import type {
   Action,
   HandlerCallback,

--- a/plugins/plugin-facewear/src/actions/facewear-control.ts
+++ b/plugins/plugin-facewear/src/actions/facewear-control.ts
@@ -1,3 +1,7 @@
+/**
+ * Smartglasses control action dispatches Even Realities G1 operations from chat
+ * into the smartglasses service.
+ */
 import {
   type Action,
   type ActionResult,

--- a/plugins/plugin-facewear/src/actions/facewear-debug.ts
+++ b/plugins/plugin-facewear/src/actions/facewear-debug.ts
@@ -1,3 +1,7 @@
+/**
+ * Facewear debug action reports XR, smartglasses, and coordinator service
+ * diagnostics for connected wearable devices.
+ */
 import type {
   Action,
   HandlerCallback,

--- a/plugins/plugin-facewear/src/actions/facewear-status.ts
+++ b/plugins/plugin-facewear/src/actions/facewear-status.ts
@@ -1,3 +1,7 @@
+/**
+ * Smartglasses status action formats Even Realities connection, lens,
+ * microphone, Wi-Fi, and audio state for chat responses.
+ */
 import type { Action, ActionResult, IAgentRuntime } from "@elizaos/core";
 import { getSmartglassesService } from "../services/smartglasses-service.ts";
 import {

--- a/plugins/plugin-facewear/src/actions/microphone.ts
+++ b/plugins/plugin-facewear/src/actions/microphone.ts
@@ -1,3 +1,7 @@
+/**
+ * Smartglasses microphone action toggles the G1 microphone through parsed chat
+ * intent or explicit JSON parameters.
+ */
 import {
   type Action,
   type ActionResult,

--- a/plugins/plugin-facewear/src/actions/view-actions.ts
+++ b/plugins/plugin-facewear/src/actions/view-actions.ts
@@ -1,3 +1,7 @@
+/**
+ * XR view actions open, close, switch, list, and resize app views inside
+ * connected headset sessions.
+ */
 import { listViews } from "@elizaos/agent/api/views-registry";
 import type {
   Action,
@@ -11,8 +15,6 @@ import {
   type XRSessionService,
 } from "../services/xr-session-service.ts";
 
-// ── Helpers ────────────────────────────────────────────────────────────────
-
 function getService(runtime: IAgentRuntime): XRSessionService | null {
   return runtime.getService<XRSessionService>(XR_SERVICE_TYPE) ?? null;
 }
@@ -22,8 +24,7 @@ function firstConnectionId(svc: XRSessionService): string | null {
 }
 
 function agentBaseUrl(): string {
-  // The API port is orchestrator-assigned (never hardcoded) — read it from the
-  // environment, not a non-existent `runtime.port` field. Falls back to 31337.
+  // The API port is orchestrator-assigned, so view URLs read it from env.
   const port =
     process.env.ELIZA_API_PORT?.trim() ||
     process.env.ELIZA_PORT?.trim() ||

--- a/plugins/plugin-facewear/src/actions/vision-query.ts
+++ b/plugins/plugin-facewear/src/actions/vision-query.ts
@@ -1,3 +1,7 @@
+/**
+ * XR vision query action describes the latest camera frame captured from a
+ * connected headset session.
+ */
 import type {
   Action,
   ActionResult,
@@ -19,7 +23,7 @@ export const xrQueryVisionAction: Action = {
   validate: async (runtime: IAgentRuntime): Promise<boolean> => {
     const svc = runtime.getService<XRSessionService>(XR_SERVICE_TYPE);
     if (!svc?.hasActiveConnections()) return false;
-    // At least one connection must have a recent frame
+    // Vision queries need a non-stale frame from at least one headset.
     return svc
       .getConnections()
       .some((c) => svc.getVisionPipeline().hasRecentFrame(c.id));

--- a/plugins/plugin-facewear/src/actions/xr-runtime-setup.ts
+++ b/plugins/plugin-facewear/src/actions/xr-runtime-setup.ts
@@ -1,3 +1,7 @@
+/**
+ * OpenXR runtime setup action reports desktop runtime detection and install
+ * planning for XR headset support.
+ */
 import type {
   Action,
   HandlerCallback,
@@ -12,13 +16,6 @@ import {
   planOpenXrInstall,
 } from "../runtime/openxr-runtime.ts";
 
-/**
- * SETUP_XR_RUNTIME — report the desktop OpenXR runtime state and, when none is
- * active, the exact steps to install one (Monado / SteamVR on Linux, SteamVR /
- * WMR on Windows). This is the "is my VR/AR set up?" answer for the agent; the
- * actual install commands are surfaced for the user to run (privileged steps are
- * never executed silently).
- */
 export const facewearSetupRuntimeAction: Action = {
   name: "SETUP_XR_RUNTIME",
   description:

--- a/plugins/plugin-facewear/src/components/WearablesSettingsSection.tsx
+++ b/plugins/plugin-facewear/src/components/WearablesSettingsSection.tsx
@@ -1,3 +1,7 @@
+/**
+ * Wearables settings section hosts the facewear and smartglasses management
+ * panels under the app settings surface.
+ */
 import {
   Tabs,
   TabsContent,
@@ -8,9 +12,7 @@ import { lazy, Suspense, useEffect, useState } from "react";
 
 type WearablesTab = "facewear" | "smartglasses";
 
-// Lazy so the heavy XR/BLE view code stays code-split out of the host shell
-// bundle until the user actually opens Settings → Wearables. These are the same
-// component modules the native app-shell pages used to load.
+// Keep XR and BLE view code out of the host shell until Settings opens.
 const FacewearView = lazy(() =>
   import("./FacewearView").then((m) => ({ default: m.FacewearView })),
 );

--- a/plugins/plugin-facewear/src/components/facewear-profiles.ts
+++ b/plugins/plugin-facewear/src/components/facewear-profiles.ts
@@ -1,8 +1,7 @@
-// Pure facewear device-profile data + connected-state derivation, used by the
-// unified data wrapper (FacewearView.tsx). Split out so the .tsx files export
-// only React components
-// and stay Fast-Refresh-compatible (Vite full-reloads a component file that also
-// exports plain data/functions).
+/**
+ * Facewear profile helpers derive supported device rows and connected-state
+ * labels for the unified view wrapper.
+ */
 
 import type { FacewearDeviceType } from "../devices/registry.ts";
 

--- a/plugins/plugin-facewear/src/devices/apple-vision-pro.ts
+++ b/plugins/plugin-facewear/src/devices/apple-vision-pro.ts
@@ -1,3 +1,7 @@
+/**
+ * Apple Vision Pro device constants describe visionOS WebXR capabilities and
+ * native app compatibility.
+ */
 export { DEVICE_REGISTRY } from "./registry.ts";
 export const AVP_WEBXR_FEATURES = [
   "local-floor",
@@ -9,6 +13,5 @@ export const AVP_WEBXR_FEATURES = [
 export const VISIONOS_MIN_VERSION = "1.0";
 export const VISIONOS_RECOMMENDED_VERSION = "2.4";
 export const AVP_SAFARI_WEBXR_SUPPORT = "visionOS 1.1+";
-// visionOS WebXR is supported in Safari and WKWebView on visionOS 1.1+
-// The facewear PWA runs inside WKWebView in the ElizaFacewear native app
+// The ElizaFacewear native app hosts the PWA in WKWebView.
 export const AVP_WKWEBVIEW_WEBXR = true;

--- a/plugins/plugin-facewear/src/devices/even-realities.ts
+++ b/plugins/plugin-facewear/src/devices/even-realities.ts
@@ -1,3 +1,7 @@
+/**
+ * Even Realities device constants expose G1/G2 BLE UUIDs and supported profile
+ * identifiers.
+ */
 export { DEVICE_REGISTRY } from "./registry.ts";
 export const EVEN_G1_UART_SERVICE_UUID = "6e400001-b5a3-f393-e0a9-e50e24dcca9e";
 export const EVEN_G1_TX_CHAR_UUID = "6e400002-b5a3-f393-e0a9-e50e24dcca9e";

--- a/plugins/plugin-facewear/src/devices/meta-quest.ts
+++ b/plugins/plugin-facewear/src/devices/meta-quest.ts
@@ -1,3 +1,7 @@
+/**
+ * Meta Quest device constants describe supported headset identifiers and WebXR
+ * feature requirements.
+ */
 export { DEVICE_REGISTRY } from "./registry.ts";
 export const META_QUEST_WEBXR_FEATURES = [
   "hand-tracking",

--- a/plugins/plugin-facewear/src/devices/registry.ts
+++ b/plugins/plugin-facewear/src/devices/registry.ts
@@ -1,3 +1,7 @@
+/**
+ * Facewear device registry lists supported XR headsets, smartglasses, native
+ * app targets, and setup metadata.
+ */
 export type FacewearDeviceType =
   | "meta-quest"
   | "xreal"

--- a/plugins/plugin-facewear/src/devices/xreal.ts
+++ b/plugins/plugin-facewear/src/devices/xreal.ts
@@ -1,3 +1,7 @@
+/**
+ * XReal device constants describe supported glasses models and NRSDK camera
+ * integration metadata.
+ */
 export { DEVICE_REGISTRY } from "./registry.ts";
 export const XREAL_SDK_VERSION = "3.0.0";
 export const XREAL_WEBXR_FEATURES = ["local-floor", "hit-test", "dom-overlay"];
@@ -9,5 +13,5 @@ export const XREAL_DEVICE_TYPES = [
   "xreal-one",
 ] as const;
 export type XrealDeviceType = (typeof XREAL_DEVICE_TYPES)[number];
-// XREAL SDK 3.0.0: NRCameraRig replaces Camera2 for camera access
+// NRSDK 3.0.0 routes camera access through NRCameraRig.
 export const XREAL_CAMERA_RIG_CLASS = "com.xreal.nrsdk.NRCameraRig";

--- a/plugins/plugin-facewear/src/index.ts
+++ b/plugins/plugin-facewear/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Facewear plugin registration wires XR headset streaming, Even Realities
+ * smartglasses control, views, routes, providers, and services into elizaOS.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import { displayFacewearTextAction } from "./actions/display-text.ts";
 import { facewearConnectAction } from "./actions/facewear-connect.ts";

--- a/plugins/plugin-facewear/src/protocol/smartglasses.ts
+++ b/plugins/plugin-facewear/src/protocol/smartglasses.ts
@@ -1,3 +1,7 @@
+/**
+ * Even Realities G1 protocol definitions encode BLE commands, display payloads,
+ * notifications, and audio events exchanged with smartglasses.
+ */
 export type GlassSide = "left" | "right";
 export type G1ConnectionReadyMode = "lens-specific" | "official" | "android-f4";
 export type SmartglassesAudioEncoding = "pcm16" | "lc3" | "unknown";

--- a/plugins/plugin-facewear/src/protocol/xr.ts
+++ b/plugins/plugin-facewear/src/protocol/xr.ts
@@ -1,13 +1,13 @@
-// Binary frame layout:
-//   bytes 0–3  : big-endian uint32 — JSON header length
-//   bytes 4–N  : UTF-8 JSON header
-//   bytes N+1… : raw binary payload (audio PCM/Opus, JPEG, etc.)
-//
-// Text frames are JSON control messages (no binary payload).
+/**
+ * XR protocol definitions frame headset control messages, audio, camera images,
+ * pose metadata, and in-headset view state.
+ *
+ * Binary frames start with a big-endian uint32 JSON-header length, then UTF-8
+ * JSON header bytes, then the raw payload. Text frames are JSON control
+ * messages without a binary payload.
+ */
 
 export type XRDeviceType = "quest3" | "xreal" | "even-realities" | "simulator";
-
-// ── Client → Server (text frames) ──────────────────────────────────────────
 
 /** View panel state reported back from the XR device */
 export interface XRViewPanelState {

--- a/plugins/plugin-facewear/src/providers/facewear-context.ts
+++ b/plugins/plugin-facewear/src/providers/facewear-context.ts
@@ -1,3 +1,7 @@
+/**
+ * Facewear context provider injects connected XR headset and smartglasses state
+ * into the agent prompt.
+ */
 import type {
   IAgentRuntime,
   Memory,

--- a/plugins/plugin-facewear/src/providers/smartglasses-status.ts
+++ b/plugins/plugin-facewear/src/providers/smartglasses-status.ts
@@ -1,3 +1,7 @@
+/**
+ * Smartglasses status provider injects Even Realities connection, lens,
+ * microphone, event, and audio state into the agent prompt.
+ */
 import type { Provider } from "@elizaos/core";
 import { getSmartglassesService } from "../services/smartglasses-service.ts";
 import {

--- a/plugins/plugin-facewear/src/register.ts
+++ b/plugins/plugin-facewear/src/register.ts
@@ -1,11 +1,12 @@
+/**
+ * Facewear settings registration adds the wearables section to GUI hosts and
+ * terminal view renderers to Node hosts.
+ */
 import { registerSettingsSection } from "@elizaos/ui/components/settings/settings-section-registry";
 import { Glasses } from "lucide-react";
 import { WearablesSettingsSection } from "./components/WearablesSettingsSection.tsx";
 
-// Wearable hardware (XR headsets + Even Realities smartglasses) is configuration,
-// so it lives under Settings → Wearables instead of as two standalone launcher
-// views. One settings section hosts both as tabs. The agent's XR/TUI view
-// surfaces and FACEWEAR_*/SMARTGLASSES_*/XR_* actions are unaffected.
+// Wearable hardware is configuration, so it lives under Settings -> Wearables.
 registerSettingsSection({
   id: "wearables",
   label: "settings.section.wearables",
@@ -21,10 +22,7 @@ registerSettingsSection({
   Component: WearablesSettingsSection,
 });
 
-// In a terminal host (the Node agent, no DOM), register the facewear and
-// smartglasses views so they render inline in the terminal as the unified
-// FacewearSpatialView / SmartglassesSpatialView.
-// Lazy + DOM-guarded so the terminal engine stays out of browser/mobile bundles.
+// DOM-guarded dynamic imports keep terminal rendering out of browser bundles.
 if (typeof window === "undefined") {
   void import("./register-terminal-view.tsx")
     .then((m) => {

--- a/plugins/plugin-facewear/src/routes/connect.ts
+++ b/plugins/plugin-facewear/src/routes/connect.ts
@@ -1,3 +1,7 @@
+/**
+ * XR connect route serves the headset pairing page with the app URL encoded for
+ * local network or tunnel access.
+ */
 import { networkInterfaces } from "node:os";
 import type { Route } from "@elizaos/core";
 
@@ -12,7 +16,7 @@ function getLocalIp(): string {
 }
 
 function getAppUrl(): string {
-  // Set by the connect script when a tunnel is active
+  // Connect scripts set this when a tunnel is active.
   if (process.env.XR_APP_URL) return process.env.XR_APP_URL;
   const port = process.env.VITE_PORT ?? "5173";
   return `http://${getLocalIp()}:${port}`;

--- a/plugins/plugin-facewear/src/routes/device-config.ts
+++ b/plugins/plugin-facewear/src/routes/device-config.ts
@@ -1,3 +1,7 @@
+/**
+ * Facewear device routes expose supported device profiles and active connection
+ * status to the settings UI.
+ */
 import type { Route } from "@elizaos/core";
 import {
   getAllDeviceProfiles,

--- a/plugins/plugin-facewear/src/routes/simulator-route.ts
+++ b/plugins/plugin-facewear/src/routes/simulator-route.ts
@@ -1,3 +1,7 @@
+/**
+ * XR simulator route serves the built browser emulator bundle for Playwright
+ * and local headset simulation harnesses.
+ */
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -7,11 +11,6 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const pluginRoot = resolve(__dirname, "../../");
 const EMULATOR_BUNDLE = resolve(pluginRoot, "../../emulator/dist/emulator.js");
 
-/**
- * Serves the built WebXR emulator bundle at GET /api/xr/simulator.js
- * Only active when the bundle exists (i.e., after `bun run emulator:build`).
- * Used by Playwright tests that prefer HTTP-served scripts over filesystem paths.
- */
 export const simulatorRoute: Route = {
   type: "GET",
   path: "/xr/simulator.js",

--- a/plugins/plugin-facewear/src/routes/status.ts
+++ b/plugins/plugin-facewear/src/routes/status.ts
@@ -1,3 +1,7 @@
+/**
+ * XR status route reports active headset sessions and recent camera-frame
+ * availability.
+ */
 import type { Route } from "@elizaos/core";
 import {
   XR_SERVICE_TYPE,

--- a/plugins/plugin-facewear/src/routes/view-host.ts
+++ b/plugins/plugin-facewear/src/routes/view-host.ts
@@ -1,26 +1,12 @@
-import type { Route } from "@elizaos/core";
-
 /**
- * GET /api/xr/view-host/:id
+ * XR view-host route serves a self-contained HTML shell that mounts registered
+ * app view bundles inside headset panels.
  *
- * Serves a self-contained HTML page that loads and renders a registered
- * elizaOS view bundle inside an XR-optimised shell. App-xr opens this URL
- * in an iframe that is overlaid on the WebXR scene.
- *
- * The host page:
- *  1. Loads React + ReactDOM from the CDN (same versions as the view bundles).
- *  2. Dynamically imports the view bundle from the agent's /api/views/:id/bundle.js.
- *  3. Mounts the view component inside an XR-friendly dark-theme container.
- *  4. Provides a minimal elizaOS context (agentBaseUrl, viewId, postMessage bridge).
- *  5. Routes voice transcript text to the focused form input.
- *
- * Inter-frame communication (postMessage):
- *  Parent → host:  { type:"xr:transcript", text:"..." }  — fill focused input
- *                  { type:"xr:focus-next" }              — tab to next field
- *  Host → parent:  { type:"xr:view-ready", viewId:"..." }
- *                  { type:"xr:navigate", viewId:"..." }
- *                  { type:"xr:close" }
+ * The host page loads React and ReactDOM, imports `/api/views/:id/bundle.js`,
+ * mounts the component with minimal elizaOS context, and bridges transcript,
+ * navigation, readiness, and close events with the WebXR parent frame.
  */
+import type { Route } from "@elizaos/core";
 export const viewHostRoute: Route = {
   type: "GET",
   path: "/xr/view-host/:id",

--- a/plugins/plugin-facewear/src/routes/views.ts
+++ b/plugins/plugin-facewear/src/routes/views.ts
@@ -1,3 +1,7 @@
+/**
+ * XR views route lists registered XR-capable plugin views for the headset view
+ * launcher and pushes the catalog to active sessions.
+ */
 import { listViews } from "@elizaos/agent/api/views-registry";
 import type { Route } from "@elizaos/core";
 import {
@@ -5,11 +9,6 @@ import {
   type XRSessionService,
 } from "../services/xr-session-service.ts";
 
-/**
- * GET /api/xr/views
- * Returns all XR-typed views from registered plugins.
- * Used by app-xr to populate the view launcher.
- */
 export const viewsRoute: Route = {
   type: "GET",
   path: "/xr/views",

--- a/plugins/plugin-facewear/src/routes/xr-runtime.ts
+++ b/plugins/plugin-facewear/src/routes/xr-runtime.ts
@@ -1,12 +1,11 @@
+/**
+ * XR runtime route returns desktop OpenXR detection status and install planning
+ * for the facewear settings row.
+ */
 import type { Route } from "@elizaos/core";
 import { detectOpenXrRuntimeNow } from "../runtime/node-probe.ts";
 import { planOpenXrInstall } from "../runtime/openxr-runtime.ts";
 
-/**
- * `GET /api/facewear/xr-runtime` — the desktop OpenXR runtime status + an install
- * plan when none is active. The FacewearView "VR/AR runtime" row reads this; the
- * SETUP_XR_RUNTIME action formats the same data for chat.
- */
 export const facewearXrRuntimeRoute: Route = {
   path: "/api/facewear/xr-runtime",
   type: "GET",

--- a/plugins/plugin-facewear/src/services/audio-pipeline.ts
+++ b/plugins/plugin-facewear/src/services/audio-pipeline.ts
@@ -1,8 +1,12 @@
+/**
+ * XR audio pipeline buffers headset microphone chunks, converts PCM to WAV when
+ * needed, and routes speech through the runtime transcription model.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import type { XRAudioHeader } from "../protocol/xr.ts";
 
-// Prepend a RIFF/WAV header so Whisper can decode raw Float32 PCM.
+// Whisper expects raw Float32 PCM to arrive in a WAV container.
 function pcmF32ToWav(pcmData: Buffer, sampleRate: number): Buffer {
   const channels = 1; // ScriptProcessorNode fallback is always mono
   const dataSize = pcmData.length;
@@ -23,8 +27,7 @@ function pcmF32ToWav(pcmData: Buffer, sampleRate: number): Buffer {
   return Buffer.concat([header, pcmData]);
 }
 
-// Accumulate up to FLUSH_AFTER_MS of audio then transcribe.
-// Also flush if no chunk arrives within SILENCE_GAP_MS (end-of-utterance).
+// These windows balance latency against utterance completeness for headset mics.
 const FLUSH_AFTER_MS = 2000;
 const SILENCE_GAP_MS = 1500;
 

--- a/plugins/plugin-facewear/src/services/facewear-service.ts
+++ b/plugins/plugin-facewear/src/services/facewear-service.ts
@@ -1,3 +1,7 @@
+/**
+ * Facewear service coordinates active XR headset and smartglasses services for
+ * device discovery and shared capability reporting.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { Service } from "@elizaos/core";
 import type { SmartglassesService } from "./smartglasses-service.ts";

--- a/plugins/plugin-facewear/src/services/smartglasses-service.ts
+++ b/plugins/plugin-facewear/src/services/smartglasses-service.ts
@@ -1,3 +1,7 @@
+/**
+ * Smartglasses service manages Even Realities G1 transport selection, display
+ * packets, dashboard updates, microphone control, and status reporting.
+ */
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
 import {
   type DisplayPage,

--- a/plugins/plugin-facewear/src/services/vision-pipeline.ts
+++ b/plugins/plugin-facewear/src/services/vision-pipeline.ts
@@ -1,3 +1,7 @@
+/**
+ * XR vision pipeline stores recent headset camera frames and sends fresh images
+ * to the runtime vision model for scene descriptions.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import type { XRFrameHeader } from "../protocol/xr.ts";
@@ -8,7 +12,7 @@ export interface LatestFrame {
   receivedAt: number;
 }
 
-// A frame older than this is considered stale and won't be described
+// Avoid describing a view that is no longer representative of the wearer.
 const FRAME_MAX_AGE_MS = 10_000;
 
 export class VisionPipeline {

--- a/plugins/plugin-facewear/src/services/xr-session-service.ts
+++ b/plugins/plugin-facewear/src/services/xr-session-service.ts
@@ -1,3 +1,7 @@
+/**
+ * XR session service hosts the headset WebSocket server and bridges control,
+ * audio, camera, view, and smartglasses frames into the agent runtime.
+ */
 import type {
   Content,
   HandlerCallback,

--- a/plugins/plugin-facewear/src/status-format.ts
+++ b/plugins/plugin-facewear/src/status-format.ts
@@ -1,3 +1,7 @@
+/**
+ * Smartglasses status formatting derives operator-facing setup summaries,
+ * blocker reasons, and lens labels from service status.
+ */
 import type { SmartglassesStatus } from "./services/smartglasses-service.ts";
 import type { SmartglassesConnectedLenses } from "./transport/types.ts";
 

--- a/plugins/plugin-facewear/src/transport/even-bridge.ts
+++ b/plugins/plugin-facewear/src/transport/even-bridge.ts
@@ -1,3 +1,7 @@
+/**
+ * Even bridge transport adapts native Android, desktop, or Mentra bridge calls
+ * to the shared smartglasses transport interface.
+ */
 import {
   encodeMicCommand,
   G1Command,

--- a/plugins/plugin-facewear/src/transport/mock.ts
+++ b/plugins/plugin-facewear/src/transport/mock.ts
@@ -1,3 +1,7 @@
+/**
+ * Mock smartglasses transport provides deterministic G1 writes, events, audio,
+ * transcripts, and Wi-Fi responses for tests and local simulation.
+ */
 import {
   encodeMicCommand,
   type G1Event,

--- a/plugins/plugin-facewear/src/transport/noble.ts
+++ b/plugins/plugin-facewear/src/transport/noble.ts
@@ -1,3 +1,7 @@
+/**
+ * Noble transport connects to Even Realities G1 lenses over Node BLE and maps
+ * characteristics to smartglasses events.
+ */
 import type { EventEmitter } from "node:events";
 import {
   EVEN_G1_UART,

--- a/plugins/plugin-facewear/src/transport/types.ts
+++ b/plugins/plugin-facewear/src/transport/types.ts
@@ -1,3 +1,7 @@
+/**
+ * Smartglasses transport contracts define the BLE, native bridge, browser, and
+ * mock surfaces consumed by the service.
+ */
 import type {
   G1Event,
   GlassSide,

--- a/plugins/plugin-facewear/src/transport/web-bluetooth.ts
+++ b/plugins/plugin-facewear/src/transport/web-bluetooth.ts
@@ -1,3 +1,7 @@
+/**
+ * Web Bluetooth transport pairs Even Realities G1 lenses from browser hosts and
+ * maps GATT notifications to smartglasses events.
+ */
 import {
   EVEN_G1_UART,
   encodeMicCommand,

--- a/plugins/plugin-facewear/src/ui/SmartglassesView.helpers.ts
+++ b/plugins/plugin-facewear/src/ui/SmartglassesView.helpers.ts
@@ -1,7 +1,7 @@
-// Pure smartglasses report/diagnostics helpers split out of SmartglassesView.tsx
-// so that file exports only the React component and stays Fast-Refresh-compatible
-// (Vite full-reloads a component file that also exports plain functions/types).
-// SmartglassesView.tsx and the report test both import from here.
+/**
+ * Smartglasses view helpers derive diagnostics reports, Wi-Fi bridge output,
+ * display packets, and setup guidance outside the React component module.
+ */
 
 import {
   type DisplayPage,

--- a/plugins/plugin-facewear/src/ui/SmartglassesView.tsx
+++ b/plugins/plugin-facewear/src/ui/SmartglassesView.tsx
@@ -1,3 +1,7 @@
+/**
+ * Smartglasses dashboard view manages Even Realities pairing, display commands,
+ * microphone controls, Wi-Fi bridge operations, and hardware diagnostics.
+ */
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { Button } from "@elizaos/ui/components/ui/button";
 import { Input } from "@elizaos/ui/components/ui/input";

--- a/plugins/plugin-facewear/src/ui/facewear-view-bundle.ts
+++ b/plugins/plugin-facewear/src/ui/facewear-view-bundle.ts
@@ -1,11 +1,6 @@
-// Vite view-bundle entry. Re-exports the view components the facewear plugin
-// manifest declares (see the `views` array in src/index.ts) so the built bundle
-// (dist/views/bundle.js) exposes the named exports the view loader reads.
-//
-// The two own views collapse to one tri-modal declaration each:
-//   - `FacewearView`         → the gui/xr/tui Facewear data wrapper
-//   - `SmartglassesPanelView` → the gui/xr/tui Smartglasses operator panel
-// Both render the single spatial source (FacewearSpatialView /
-// SmartglassesSpatialView).
+/**
+ * Facewear view-bundle entry re-exports the GUI, XR, and TUI view components
+ * declared by the plugin manifest for the app view loader.
+ */
 export { FacewearView } from "../components/FacewearView.tsx";
 export { SmartglassesPanelView } from "../components/SmartglassesPanelView.tsx";


### PR DESCRIPTION
## Summary
- Add or repair top-of-file prose headers across the remaining facewear runtime/source files.
- Rewrite several file-purpose/churn comments into durable present-tense notes.
- Keep this PR comment-only; no code tokens changed.

Closes #12755. The earlier merged #13006 covered the test/config slice; this PR covers the remaining 43 runtime/source files, and the full `plugins/plugin-facewear` self-audit now reports 0 missing headers.

## Validation
- Read `plugins/plugin-facewear/CLAUDE.md`.
- Full scoped missing-header audit over `plugins/plugin-facewear`: PASS (0 missing headers).
- `bun run check:comment-only`: PASS (`43 source file(s) changed; every code token identical to origin/develop. Comments only.`)
- `git diff --check origin/develop...HEAD`: PASS.
- `git diff --name-only origin/develop...HEAD | xargs bunx @biomejs/biome check --config-path biome.json --files-ignore-unknown=true --no-errors-on-unmatched`: PASS (43 files checked, no fixes).

## Evidence N/A
- UI screenshots/video: N/A - comment-only cleanup with zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- Live LLM trajectories: N/A - no agent/action/provider/prompt/model behavior changed.
- Backend/frontend logs: N/A - no runtime behavior changed.
- Device/domain artifacts: N/A - no device, bridge, capture, or artifact-producing behavior changed.