### PR TITLE
fix(embeddings): reject non-integer response indexes

### DIFF
--- a/plugins/plugin-embeddings/__tests__/embedding.test.ts
+++ b/plugins/plugin-embeddings/__tests__/embedding.test.ts
@@ -228,6 +228,31 @@ describe("plugin-embeddings handleBatchTextEmbedding", () => {
       /duplicate index 0/i
     );
   });
+
+  it("throws when the response index is not an integer", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: async () => ({
+            object: "list",
+            data: [
+              { object: "embedding", embedding: vectorOf(1536), index: 0.5 },
+              { object: "embedding", embedding: vectorOf(1536), index: 1 },
+            ],
+            model: "text-embedding-3-small",
+          }),
+          text: async () => "",
+        }) as unknown as Response
+    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock as unknown as typeof fetch);
+
+    await expect(handleBatchTextEmbedding(createRuntime(), ["one", "two"])).rejects.toThrow(
+      /out-of-range index 0.5/i
+    );
+  });
 });
 
 describe("plugin-embeddings input truncation", () => {

--- a/plugins/plugin-embeddings/src/models/embedding.ts
+++ b/plugins/plugin-embeddings/src/models/embedding.ts
@@ -144,7 +144,7 @@ async function requestEmbeddings(
   const vectors: number[][] = new Array(expectedCount);
   for (const item of data.data) {
     const idx = typeof item.index === "number" ? item.index : undefined;
-    if (idx === undefined || idx < 0 || idx >= expectedCount) {
+    if (idx === undefined || !Number.isInteger(idx) || idx < 0 || idx >= expectedCount) {
       throw new Error(
         `Embedding API returned out-of-range index ${String(item.index)} (expected 0..${expectedCount - 1})`
       );


### PR DESCRIPTION
## Summary

Follow-up to #13008. During review, the duplicate-index guard fixed repeated integer indexes but the response-shape validator still accepted numeric non-integer indexes such as `0.5`.

A response with `index: 0.5` can pass the old range check, write to an object property rather than a real array slot, and leave a vector hole in the returned batch. This violates the plugin-embeddings contract: throw on malformed provider output, never return sparse/fabricated vectors.

## Change

- Require `Number.isInteger(index)` before accepting an embedding response item index.
- Add a regression test for a `0.5` response index.

## Validation

- `bun run --cwd plugins/plugin-embeddings test` passed: 31 tests across 3 files.
- `bun run --cwd plugins/plugin-embeddings typecheck` passed.
- `bunx @biomejs/biome check plugins/plugin-embeddings/src/models/embedding.ts plugins/plugin-embeddings/__tests__/embedding.test.ts` passed.
- `git diff --check origin/develop...HEAD` passed.

No UI, persistence, or model behavior changed; this is provider response-shape validation.
