### PR TITLE
docs(#12758): clean music component prose headers

### DIFF
--- a/plugins/plugin-music/src/components/analytics.ts
+++ b/plugins/plugin-music/src/components/analytics.ts
@@ -1,3 +1,9 @@
+/**
+ * DJ analytics persistence for guild-scoped music sessions.
+ *
+ * It stores play counts, listener snapshots, popular times, and session
+ * milestones in room-scoped components.
+ */
 import {
   type Component,
   createUniqueUuid,

--- a/plugins/plugin-music/src/components/componentData.ts
+++ b/plugins/plugin-music/src/components/componentData.ts
@@ -1,3 +1,9 @@
+/**
+ * Component data serialization helpers for music persistence.
+ *
+ * They keep component payloads JSON-safe before storing library, playlist,
+ * preference, and analytics state in runtime components.
+ */
 import type { Component, MetadataValue } from "@elizaos/core";
 
 type ComponentData = NonNullable<Component["data"]>;

--- a/plugins/plugin-music/src/components/djGuildSettings.ts
+++ b/plugins/plugin-music/src/components/djGuildSettings.ts
@@ -1,3 +1,9 @@
+/**
+ * Per-guild DJ behavior settings stored in room-scoped components.
+ *
+ * These settings control autonomy, auto-fill, commentary, events, station
+ * metadata, and audio behavior for a music room.
+ */
 import {
   createUniqueUuid,
   type IAgentRuntime,

--- a/plugins/plugin-music/src/components/djIntroOptions.ts
+++ b/plugins/plugin-music/src/components/djIntroOptions.ts
@@ -1,3 +1,9 @@
+/**
+ * DJ introduction and commentary configuration stored per music room.
+ *
+ * The options describe LLM/template behavior, tone, timing, and metadata usage
+ * for track introductions.
+ */
 import {
   createUniqueUuid,
   type IAgentRuntime,

--- a/plugins/plugin-music/src/components/djTips.ts
+++ b/plugins/plugin-music/src/components/djTips.ts
@@ -1,3 +1,9 @@
+/**
+ * Tip ledger and aggregate tip statistics for the music DJ surface.
+ *
+ * Records are stored at agent scope so tip totals and top supporters can span
+ * rooms while preserving room references on individual tips.
+ */
 import {
   createUniqueUuid,
   type IAgentRuntime,

--- a/plugins/plugin-music/src/components/musicLibrary.ts
+++ b/plugins/plugin-music/src/components/musicLibrary.ts
@@ -1,3 +1,9 @@
+/**
+ * Persistent music library helpers for global track history.
+ *
+ * They store songs as memories, track play counts and requesters, and expose
+ * library summaries used by providers and playlist operations.
+ */
 import {
   type IAgentRuntime,
   logger,

--- a/plugins/plugin-music/src/components/playlists.ts
+++ b/plugins/plugin-music/src/components/playlists.ts
@@ -1,3 +1,9 @@
+/**
+ * Playlist persistence helpers for user-owned music collections.
+ *
+ * Playlists are stored as entity components and reused by music actions for
+ * save, load, delete, and add operations.
+ */
 import { type IAgentRuntime, logger, type UUID } from "@elizaos/core";
 import { v4 } from "uuid";
 import {

--- a/plugins/plugin-music/src/components/preferences.ts
+++ b/plugins/plugin-music/src/components/preferences.ts
@@ -1,3 +1,9 @@
+/**
+ * User music preference persistence for recommendations and history.
+ *
+ * Preferences merge favorite and disliked music signals with request and
+ * listening-session history in entity components.
+ */
 import type { IAgentRuntime, UUID } from "@elizaos/core";
 import { v4 } from "uuid";
 import {

--- a/plugins/plugin-music/src/components/repetitionControl.ts
+++ b/plugins/plugin-music/src/components/repetitionControl.ts
@@ -1,3 +1,9 @@
+/**
+ * In-memory repetition guard for music playback queues.
+ *
+ * It tracks recent plays by guild and rejects tracks that replay inside the
+ * configured interval.
+ */
 import { logger } from "@elizaos/core";
 
 /**

--- a/plugins/plugin-music/src/components/songMemory.ts
+++ b/plugins/plugin-music/src/components/songMemory.ts
@@ -1,3 +1,9 @@
+/**
+ * Long-lived per-song memory for playback and request statistics.
+ *
+ * Song memory records identity, engagement, timing, requester, and room
+ * patterns across the music library.
+ */
 import { createUniqueUuid, type IAgentRuntime, type UUID } from "@elizaos/core";
 import { v4 } from "uuid";
 import {

--- a/plugins/plugin-music/src/components/storageContext.ts
+++ b/plugins/plugin-music/src/components/storageContext.ts
@@ -1,3 +1,9 @@
+/**
+ * Storage context helpers for music components that need room or agent scope.
+ *
+ * Room-scoped helpers require an existing world, while agent-scoped helpers
+ * create deterministic backing world and room records.
+ */
 import {
   createUniqueUuid,
   type IAgentRuntime,

--- a/plugins/plugin-music/src/core/broadcast.ts
+++ b/plugins/plugin-music/src/core/broadcast.ts
@@ -1,3 +1,9 @@
+/**
+ * Public audio broadcast facade for music stream consumers.
+ *
+ * It hides StreamCore and StreamMultiplexer internals behind the IAudioBroadcast
+ * contract used by Discord, web streaming, and other playback targets.
+ */
 import { EventEmitter } from "node:events";
 import type { Readable } from "node:stream";
 import { logger } from "@elizaos/core";

--- a/plugins/plugin-music/src/core/index.ts
+++ b/plugins/plugin-music/src/core/index.ts
@@ -1,3 +1,6 @@
+/**
+ * Barrel exports for the music broadcast core.
+ */
 export { Broadcast } from "./broadcast";
 export type { StreamCoreState, TrackMetadata } from "./streamCore";
 export { StreamCore } from "./streamCore";

--- a/plugins/plugin-music/src/core/streamCore.ts
+++ b/plugins/plugin-music/src/core/streamCore.ts
@@ -1,3 +1,9 @@
+/**
+ * Canonical audio stream engine for music broadcasts.
+ *
+ * It keeps one never-ending output stream alive, swaps track and silence
+ * sources, and emits state changes for broadcast consumers.
+ */
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { PassThrough, type Readable } from "node:stream";

--- a/plugins/plugin-music/src/core/streamMultiplexer.test.ts
+++ b/plugins/plugin-music/src/core/streamMultiplexer.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Stream multiplexer tests for backpressure behavior.
+ *
+ * They pin blocking policy pause/resume behavior and source recovery after slow
+ * consumers are removed.
+ */
 import { PassThrough } from "node:stream";
 import { describe, expect, it } from "vitest";
 import { StreamMultiplexer } from "./streamMultiplexer";

--- a/plugins/plugin-music/src/core/streamMultiplexer.ts
+++ b/plugins/plugin-music/src/core/streamMultiplexer.ts
@@ -1,3 +1,9 @@
+/**
+ * Fan-out stream multiplexer for live music broadcast consumers.
+ *
+ * It isolates slow subscribers with configurable backpressure policies so one
+ * listener cannot stall the shared audio source.
+ */
 import { PassThrough, type Readable } from "node:stream";
 import { logger } from "@elizaos/core";
 

--- a/plugins/plugin-music/src/router/audioRouter.ts
+++ b/plugins/plugin-music/src/router/audioRouter.ts
@@ -1,3 +1,9 @@
+/**
+ * Audio routing manager for sending music streams to registered voice targets.
+ *
+ * It supports simulcast and independent routes without depending directly on a
+ * Discord plugin type.
+ */
 import { PassThrough, type Readable } from "node:stream";
 import { logger } from "@elizaos/core";
 

--- a/plugins/plugin-music/src/router/index.ts
+++ b/plugins/plugin-music/src/router/index.ts
@@ -1,3 +1,6 @@
+/**
+ * Barrel exports for music routing, zones, and mix sessions.
+ */
 export {
   type AudioRouteConfig,
   AudioRouter,

--- a/plugins/plugin-music/src/router/mixSessionManager.ts
+++ b/plugins/plugin-music/src/router/mixSessionManager.ts
@@ -1,3 +1,9 @@
+/**
+ * Runtime mix-session manager for temporary music routing configurations.
+ *
+ * Sessions collect zone mappings, routing mode, metadata, and optional cleanup
+ * timers for multi-target playback setups.
+ */
 import { type IAgentRuntime, logger } from "@elizaos/core";
 import type { AudioRoutingMode } from "./audioRouter";
 

--- a/plugins/plugin-music/src/router/zoneManager.ts
+++ b/plugins/plugin-music/src/router/zoneManager.ts
@@ -1,3 +1,8 @@
+/**
+ * Zone registry for named groups of music voice targets.
+ *
+ * Zones provide a stable routing abstraction above raw target ids.
+ */
 import { logger } from "@elizaos/core";
 
 /**


### PR DESCRIPTION
## Summary
- Add top-of-file prose headers to the plugin-music components/core/router slice.
- Keep this PR comment-only; no code tokens changed.

Partial for #12758. This covers 20 music component/core/router files. The remaining open scope is primarily plugin-music root/src/service/utility files, so #12758 should stay open after this PR.

## Validation
- Read `plugins/plugin-music/CLAUDE.md`.
- Changed-file header audit: PASS (20/20 changed files begin with prose headers).
- `bun run check:comment-only`: PASS (`20 source file(s) changed; every code token identical to origin/develop. Comments only.`)
- `git diff --check origin/develop...HEAD`: PASS.
- `git diff --name-only origin/develop...HEAD | xargs bunx @biomejs/biome check --config-path biome.json --files-ignore-unknown=true --no-errors-on-unmatched`: PASS (20 files checked, no fixes).

## Evidence N/A
- UI screenshots/video: N/A - comment-only cleanup with zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- Live LLM trajectories: N/A - no agent/action/provider/prompt/model behavior changed.
- Backend/frontend logs: N/A - no runtime behavior changed.
- Audio/domain artifacts: N/A - no playback, generation, or artifact-producing behavior changed.