### PR TITLE
docs(#12755): clean facewear source prose headers

### DIFF
--- a/plugins/plugin-facewear/src/actions/display-text.ts
+++ b/plugins/plugin-facewear/src/actions/display-text.ts
@@ -1,3 +1,6 @@
+/**
+ * Agent action for sending paginated text to Even Realities smartglasses.
+ */
 import {
   type Action,
   type ActionResult,

--- a/plugins/plugin-facewear/src/actions/facewear-connect.ts
+++ b/plugins/plugin-facewear/src/actions/facewear-connect.ts
@@ -1,3 +1,6 @@
+/**
+ * Agent action that returns pairing instructions for supported facewear devices.
+ */
 import type {
   Action,
   HandlerCallback,

--- a/plugins/plugin-facewear/src/actions/facewear-control.ts
+++ b/plugins/plugin-facewear/src/actions/facewear-control.ts
@@ -1,3 +1,6 @@
+/**
+ * Agent control surface for Even Realities smartglasses operations.
+ */
 import {
   type Action,
   type ActionResult,

--- a/plugins/plugin-facewear/src/actions/facewear-debug.ts
+++ b/plugins/plugin-facewear/src/actions/facewear-debug.ts
@@ -1,3 +1,6 @@
+/**
+ * Agent diagnostics action for the facewear coordinator, XR session, and smartglasses services.
+ */
 import type {
   Action,
   HandlerCallback,

--- a/plugins/plugin-facewear/src/actions/facewear-status.ts
+++ b/plugins/plugin-facewear/src/actions/facewear-status.ts
@@ -1,3 +1,6 @@
+/**
+ * Agent action that summarizes the current smartglasses connection and setup state.
+ */
 import type { Action, ActionResult, IAgentRuntime } from "@elizaos/core";
 import { getSmartglassesService } from "../services/smartglasses-service.ts";
 import {

--- a/plugins/plugin-facewear/src/actions/microphone.ts
+++ b/plugins/plugin-facewear/src/actions/microphone.ts
@@ -1,3 +1,6 @@
+/**
+ * Agent action for toggling the Even Realities microphone transport.
+ */
 import {
   type Action,
   type ActionResult,

--- a/plugins/plugin-facewear/src/actions/view-actions.ts
+++ b/plugins/plugin-facewear/src/actions/view-actions.ts
@@ -1,3 +1,6 @@
+/**
+ * Agent actions for opening, closing, listing, switching, and resizing XR view panels.
+ */
 import { listViews } from "@elizaos/agent/api/views-registry";
 import type {
   Action,

--- a/plugins/plugin-facewear/src/actions/vision-query.ts
+++ b/plugins/plugin-facewear/src/actions/vision-query.ts
@@ -1,3 +1,6 @@
+/**
+ * Agent action that asks the active XR headset camera frame for visual context.
+ */
 import type {
   Action,
   ActionResult,

--- a/plugins/plugin-facewear/src/actions/xr-runtime-setup.ts
+++ b/plugins/plugin-facewear/src/actions/xr-runtime-setup.ts
@@ -1,3 +1,6 @@
+/**
+ * Agent action that reports desktop OpenXR runtime readiness and install guidance.
+ */
 import type {
   Action,
   HandlerCallback,

--- a/plugins/plugin-facewear/src/components/WearablesSettingsSection.tsx
+++ b/plugins/plugin-facewear/src/components/WearablesSettingsSection.tsx
@@ -1,3 +1,6 @@
+/**
+ * Settings section that hosts the XR headset and smartglasses configuration tabs.
+ */
 import {
   Tabs,
   TabsContent,
@@ -8,9 +11,8 @@ import { lazy, Suspense, useEffect, useState } from "react";
 
 type WearablesTab = "facewear" | "smartglasses";
 
-// Lazy so the heavy XR/BLE view code stays code-split out of the host shell
-// bundle until the user actually opens Settings → Wearables. These are the same
-// component modules the native app-shell pages used to load.
+// Lazy so heavy XR/BLE view code stays out of the host shell bundle until the
+// user opens Settings -> Wearables.
 const FacewearView = lazy(() =>
   import("./FacewearView").then((m) => ({ default: m.FacewearView })),
 );

--- a/plugins/plugin-facewear/src/components/facewear-profiles.ts
+++ b/plugins/plugin-facewear/src/components/facewear-profiles.ts
@@ -1,8 +1,10 @@
-// Pure facewear device-profile data + connected-state derivation, used by the
-// unified data wrapper (FacewearView.tsx). Split out so the .tsx files export
-// only React components
-// and stay Fast-Refresh-compatible (Vite full-reloads a component file that also
-// exports plain data/functions).
+/**
+ * Device-profile rows and connected-state derivation for the facewear data
+ * wrapper.
+ *
+ * Keeping the plain data outside React component files lets Vite preserve fast
+ * refresh for the component modules that consume these helpers.
+ */
 
 import type { FacewearDeviceType } from "../devices/registry.ts";
 

--- a/plugins/plugin-facewear/src/devices/apple-vision-pro.ts
+++ b/plugins/plugin-facewear/src/devices/apple-vision-pro.ts
@@ -1,3 +1,6 @@
+/**
+ * Apple Vision Pro capability constants for the facewear device registry.
+ */
 export { DEVICE_REGISTRY } from "./registry.ts";
 export const AVP_WEBXR_FEATURES = [
   "local-floor",
@@ -9,6 +12,5 @@ export const AVP_WEBXR_FEATURES = [
 export const VISIONOS_MIN_VERSION = "1.0";
 export const VISIONOS_RECOMMENDED_VERSION = "2.4";
 export const AVP_SAFARI_WEBXR_SUPPORT = "visionOS 1.1+";
-// visionOS WebXR is supported in Safari and WKWebView on visionOS 1.1+
-// The facewear PWA runs inside WKWebView in the ElizaFacewear native app
+// The facewear PWA runs in WKWebView, which supports WebXR on visionOS 1.1+.
 export const AVP_WKWEBVIEW_WEBXR = true;

--- a/plugins/plugin-facewear/src/devices/even-realities.ts
+++ b/plugins/plugin-facewear/src/devices/even-realities.ts
@@ -1,3 +1,6 @@
+/**
+ * Even Realities G1/G2 BLE constants for smartglasses transports.
+ */
 export { DEVICE_REGISTRY } from "./registry.ts";
 export const EVEN_G1_UART_SERVICE_UUID = "6e400001-b5a3-f393-e0a9-e50e24dcca9e";
 export const EVEN_G1_TX_CHAR_UUID = "6e400002-b5a3-f393-e0a9-e50e24dcca9e";

--- a/plugins/plugin-facewear/src/devices/meta-quest.ts
+++ b/plugins/plugin-facewear/src/devices/meta-quest.ts
@@ -1,3 +1,6 @@
+/**
+ * Meta Quest WebXR capability constants for the facewear device registry.
+ */
 export { DEVICE_REGISTRY } from "./registry.ts";
 export const META_QUEST_WEBXR_FEATURES = [
   "hand-tracking",

--- a/plugins/plugin-facewear/src/devices/registry.ts
+++ b/plugins/plugin-facewear/src/devices/registry.ts
@@ -1,3 +1,6 @@
+/**
+ * Canonical facewear device profiles shared by routes, actions, and setup views.
+ */
 export type FacewearDeviceType =
   | "meta-quest"
   | "xreal"

--- a/plugins/plugin-facewear/src/devices/xreal.ts
+++ b/plugins/plugin-facewear/src/devices/xreal.ts
@@ -1,3 +1,6 @@
+/**
+ * XREAL device and SDK constants for the facewear device registry.
+ */
 export { DEVICE_REGISTRY } from "./registry.ts";
 export const XREAL_SDK_VERSION = "3.0.0";
 export const XREAL_WEBXR_FEATURES = ["local-floor", "hit-test", "dom-overlay"];
@@ -9,5 +12,5 @@ export const XREAL_DEVICE_TYPES = [
   "xreal-one",
 ] as const;
 export type XrealDeviceType = (typeof XREAL_DEVICE_TYPES)[number];
-// XREAL SDK 3.0.0: NRCameraRig replaces Camera2 for camera access
+// XREAL SDK 3.0.0 exposes camera access through NRCameraRig.
 export const XREAL_CAMERA_RIG_CLASS = "com.xreal.nrsdk.NRCameraRig";

--- a/plugins/plugin-facewear/src/index.ts
+++ b/plugins/plugin-facewear/src/index.ts
@@ -1,3 +1,6 @@
+/**
+ * Plugin entry point that registers facewear actions, providers, services, routes, and views.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import { displayFacewearTextAction } from "./actions/display-text.ts";
 import { facewearConnectAction } from "./actions/facewear-connect.ts";

--- a/plugins/plugin-facewear/src/protocol/smartglasses.ts
+++ b/plugins/plugin-facewear/src/protocol/smartglasses.ts
@@ -1,3 +1,6 @@
+/**
+ * Even Realities G1 binary protocol types, encoders, decoders, and display layout helpers.
+ */
 export type GlassSide = "left" | "right";
 export type G1ConnectionReadyMode = "lens-specific" | "official" | "android-f4";
 export type SmartglassesAudioEncoding = "pcm16" | "lc3" | "unknown";

--- a/plugins/plugin-facewear/src/protocol/xr.ts
+++ b/plugins/plugin-facewear/src/protocol/xr.ts
@@ -1,13 +1,15 @@
-// Binary frame layout:
-//   bytes 0–3  : big-endian uint32 — JSON header length
-//   bytes 4–N  : UTF-8 JSON header
-//   bytes N+1… : raw binary payload (audio PCM/Opus, JPEG, etc.)
-//
-// Text frames are JSON control messages (no binary payload).
+/**
+ * XR websocket protocol shapes shared by the facewear runtime, routes, and
+ * browser panels.
+ *
+ * Binary frames start with a big-endian uint32 JSON header length, followed by
+ * the UTF-8 header and raw audio or image payload bytes. Text frames carry JSON
+ * control messages with no binary payload.
+ */
 
 export type XRDeviceType = "quest3" | "xreal" | "even-realities" | "simulator";
 
-// ── Client → Server (text frames) ──────────────────────────────────────────
+// Client -> server text frames.
 
 /** View panel state reported back from the XR device */
 export interface XRViewPanelState {
@@ -39,7 +41,7 @@ export type XRClientControl =
   | { type: "view_closed"; viewId: string }
   | { type: "view_event"; viewId: string; event: string; payload?: unknown };
 
-// ── Client → Server (binary frames) ────────────────────────────────────────
+// Client -> server binary frames.
 
 export interface XRAudioHeader {
   type: "audio";
@@ -63,7 +65,7 @@ export interface XRFrameHeader {
 
 export type XRBinaryHeader = XRAudioHeader | XRFrameHeader;
 
-// ── Server → Client (text frames) ──────────────────────────────────────────
+// Server -> client text frames.
 
 /** XR panel sizing options */
 export interface XRPanelConfig {

--- a/plugins/plugin-facewear/src/providers/facewear-context.ts
+++ b/plugins/plugin-facewear/src/providers/facewear-context.ts
@@ -1,3 +1,6 @@
+/**
+ * Prompt provider for connected XR headset and smartglasses context.
+ */
 import type {
   IAgentRuntime,
   Memory,

--- a/plugins/plugin-facewear/src/providers/smartglasses-status.ts
+++ b/plugins/plugin-facewear/src/providers/smartglasses-status.ts
@@ -1,3 +1,6 @@
+/**
+ * Prompt provider that exposes Even Realities connection, microphone, Wi-Fi, and event status.
+ */
 import type { Provider } from "@elizaos/core";
 import { getSmartglassesService } from "../services/smartglasses-service.ts";
 import {

--- a/plugins/plugin-facewear/src/register.ts
+++ b/plugins/plugin-facewear/src/register.ts
@@ -1,3 +1,6 @@
+/**
+ * UI registration module for the Wearables settings section.
+ */
 import { registerSettingsSection } from "@elizaos/ui/components/settings/settings-section-registry";
 import { Glasses } from "lucide-react";
 import { WearablesSettingsSection } from "./components/WearablesSettingsSection.tsx";

--- a/plugins/plugin-facewear/src/routes/connect.ts
+++ b/plugins/plugin-facewear/src/routes/connect.ts
@@ -1,3 +1,6 @@
+/**
+ * Pairing page route for opening the headset WebXR app from a local network URL.
+ */
 import { networkInterfaces } from "node:os";
 import type { Route } from "@elizaos/core";
 

--- a/plugins/plugin-facewear/src/routes/device-config.ts
+++ b/plugins/plugin-facewear/src/routes/device-config.ts
@@ -1,3 +1,6 @@
+/**
+ * JSON routes for facewear device profiles and connected-device status.
+ */
 import type { Route } from "@elizaos/core";
 import {
   getAllDeviceProfiles,

--- a/plugins/plugin-facewear/src/routes/simulator-route.ts
+++ b/plugins/plugin-facewear/src/routes/simulator-route.ts
@@ -1,3 +1,6 @@
+/**
+ * Route that serves the built XR emulator bundle to browser-based harnesses.
+ */
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -7,11 +10,6 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const pluginRoot = resolve(__dirname, "../../");
 const EMULATOR_BUNDLE = resolve(pluginRoot, "../../emulator/dist/emulator.js");
 
-/**
- * Serves the built WebXR emulator bundle at GET /api/xr/simulator.js
- * Only active when the bundle exists (i.e., after `bun run emulator:build`).
- * Used by Playwright tests that prefer HTTP-served scripts over filesystem paths.
- */
 export const simulatorRoute: Route = {
   type: "GET",
   path: "/xr/simulator.js",

--- a/plugins/plugin-facewear/src/routes/status.ts
+++ b/plugins/plugin-facewear/src/routes/status.ts
@@ -1,3 +1,6 @@
+/**
+ * XR status route for active headset connections and session state.
+ */
 import type { Route } from "@elizaos/core";
 import {
   XR_SERVICE_TYPE,

--- a/plugins/plugin-facewear/src/routes/view-host.ts
+++ b/plugins/plugin-facewear/src/routes/view-host.ts
@@ -1,3 +1,6 @@
+/**
+ * XR view host route for rendering registered elizaOS views inside headset panels.
+ */
 import type { Route } from "@elizaos/core";
 
 /**

--- a/plugins/plugin-facewear/src/routes/views.ts
+++ b/plugins/plugin-facewear/src/routes/views.ts
@@ -1,3 +1,6 @@
+/**
+ * View catalog route for XR-capable plugin views.
+ */
 import { listViews } from "@elizaos/agent/api/views-registry";
 import type { Route } from "@elizaos/core";
 import {

--- a/plugins/plugin-facewear/src/routes/xr-runtime.ts
+++ b/plugins/plugin-facewear/src/routes/xr-runtime.ts
@@ -1,3 +1,6 @@
+/**
+ * Runtime route for desktop OpenXR detection and install planning.
+ */
 import type { Route } from "@elizaos/core";
 import { detectOpenXrRuntimeNow } from "../runtime/node-probe.ts";
 import { planOpenXrInstall } from "../runtime/openxr-runtime.ts";

--- a/plugins/plugin-facewear/src/services/audio-pipeline.ts
+++ b/plugins/plugin-facewear/src/services/audio-pipeline.ts
@@ -1,3 +1,6 @@
+/**
+ * Audio pipeline that transcribes PCM frames streamed from XR headset clients.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import type { XRAudioHeader } from "../protocol/xr.ts";

--- a/plugins/plugin-facewear/src/services/facewear-service.ts
+++ b/plugins/plugin-facewear/src/services/facewear-service.ts
@@ -1,3 +1,6 @@
+/**
+ * Coordinator service that reports active XR and smartglasses devices as one facewear surface.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { Service } from "@elizaos/core";
 import type { SmartglassesService } from "./smartglasses-service.ts";

--- a/plugins/plugin-facewear/src/services/smartglasses-service.ts
+++ b/plugins/plugin-facewear/src/services/smartglasses-service.ts
@@ -1,3 +1,6 @@
+/**
+ * Smartglasses service that owns Even Realities transport selection, protocol writes, and status.
+ */
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
 import {
   type DisplayPage,

--- a/plugins/plugin-facewear/src/services/vision-pipeline.ts
+++ b/plugins/plugin-facewear/src/services/vision-pipeline.ts
@@ -1,3 +1,6 @@
+/**
+ * Vision pipeline that stores headset camera frames and sends the freshest frame to a VLM.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import type { XRFrameHeader } from "../protocol/xr.ts";
@@ -8,7 +11,7 @@ export interface LatestFrame {
   receivedAt: number;
 }
 
-// A frame older than this is considered stale and won't be described
+// Stale headset frames are ignored rather than described out of context.
 const FRAME_MAX_AGE_MS = 10_000;
 
 export class VisionPipeline {

--- a/plugins/plugin-facewear/src/services/xr-session-service.ts
+++ b/plugins/plugin-facewear/src/services/xr-session-service.ts
@@ -1,3 +1,6 @@
+/**
+ * WebSocket service for XR headset sessions, frame ingestion, voice events, and view control.
+ */
 import type {
   Content,
   HandlerCallback,

--- a/plugins/plugin-facewear/src/status-format.ts
+++ b/plugins/plugin-facewear/src/status-format.ts
@@ -1,3 +1,6 @@
+/**
+ * Formatting helpers for smartglasses setup and connection status across actions and providers.
+ */
 import type { SmartglassesStatus } from "./services/smartglasses-service.ts";
 import type { SmartglassesConnectedLenses } from "./transport/types.ts";
 

--- a/plugins/plugin-facewear/src/transport/even-bridge.ts
+++ b/plugins/plugin-facewear/src/transport/even-bridge.ts
@@ -1,3 +1,6 @@
+/**
+ * Smartglasses transport adapter for the native Even bridge surface.
+ */
 import {
   encodeMicCommand,
   G1Command,

--- a/plugins/plugin-facewear/src/transport/mock.ts
+++ b/plugins/plugin-facewear/src/transport/mock.ts
@@ -1,3 +1,6 @@
+/**
+ * Deterministic smartglasses transport used by tests and local UI harnesses.
+ */
 import {
   encodeMicCommand,
   type G1Event,

--- a/plugins/plugin-facewear/src/transport/noble.ts
+++ b/plugins/plugin-facewear/src/transport/noble.ts
@@ -1,3 +1,6 @@
+/**
+ * Node BLE transport for Even Realities smartglasses using Noble-compatible adapters.
+ */
 import type { EventEmitter } from "node:events";
 import {
   EVEN_G1_UART,

--- a/plugins/plugin-facewear/src/transport/types.ts
+++ b/plugins/plugin-facewear/src/transport/types.ts
@@ -1,3 +1,6 @@
+/**
+ * Transport contract shared by native bridge, Web Bluetooth, Noble, and mock smartglasses drivers.
+ */
 import type {
   G1Event,
   GlassSide,

--- a/plugins/plugin-facewear/src/transport/web-bluetooth.ts
+++ b/plugins/plugin-facewear/src/transport/web-bluetooth.ts
@@ -1,3 +1,6 @@
+/**
+ * Browser Web Bluetooth transport for Even Realities smartglasses.
+ */
 import {
   EVEN_G1_UART,
   encodeMicCommand,

--- a/plugins/plugin-facewear/src/ui/SmartglassesView.helpers.ts
+++ b/plugins/plugin-facewear/src/ui/SmartglassesView.helpers.ts
@@ -1,7 +1,10 @@
-// Pure smartglasses report/diagnostics helpers split out of SmartglassesView.tsx
-// so that file exports only the React component and stays Fast-Refresh-compatible
-// (Vite full-reloads a component file that also exports plain functions/types).
-// SmartglassesView.tsx and the report test both import from here.
+/**
+ * Smartglasses report and diagnostics helpers shared by the panel component and
+ * its report tests.
+ *
+ * Keeping the plain functions outside the React component module lets Vite
+ * preserve fast refresh for SmartglassesView.
+ */
 
 import {
   type DisplayPage,

--- a/plugins/plugin-facewear/src/ui/SmartglassesView.tsx
+++ b/plugins/plugin-facewear/src/ui/SmartglassesView.tsx
@@ -1,3 +1,6 @@
+/**
+ * Smartglasses settings panel for pairing, diagnostics, display tests, Wi-Fi setup, and events.
+ */
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { Button } from "@elizaos/ui/components/ui/button";
 import { Input } from "@elizaos/ui/components/ui/input";

--- a/plugins/plugin-facewear/src/ui/facewear-view-bundle.ts
+++ b/plugins/plugin-facewear/src/ui/facewear-view-bundle.ts
@@ -1,11 +1,9 @@
-// Vite view-bundle entry. Re-exports the view components the facewear plugin
-// manifest declares (see the `views` array in src/index.ts) so the built bundle
-// (dist/views/bundle.js) exposes the named exports the view loader reads.
-//
-// The two own views collapse to one tri-modal declaration each:
-//   - `FacewearView`         → the gui/xr/tui Facewear data wrapper
-//   - `SmartglassesPanelView` → the gui/xr/tui Smartglasses operator panel
-// Both render the single spatial source (FacewearSpatialView /
-// SmartglassesSpatialView).
+/**
+ * Vite view-bundle entry for the named exports declared in the facewear plugin
+ * manifest.
+ *
+ * The built view bundle exposes the data wrapper and smartglasses operator panel
+ * views so the runtime view loader can mount the shared spatial components.
+ */
 export { FacewearView } from "../components/FacewearView.tsx";
 export { SmartglassesPanelView } from "../components/SmartglassesPanelView.tsx";


### PR DESCRIPTION
## Summary
- Adds required top prose headers to the remaining in-scope `plugins/plugin-facewear/src` source files.
- Rewrites the existing file-leading/churn comments in present tense while preserving code tokens.
- Completes the current facewear source header audit after the test cleanup PR.

## Evidence
- Header audit: `source=104 missing=0`
- `bun run check:comment-only` — PASS, 43 source files changed and every code token identical to `origin/develop`
- `git diff --check origin/develop...HEAD` — PASS
- `git diff --name-only origin/develop...HEAD | xargs bunx @biomejs/biome check --config-path biome.json --files-ignore-unknown=true --no-errors-on-unmatched` — PASS, checked 43 files
- `bun run verify` — attempted; failed outside this branch in `@elizaos/tui:lint` on existing lint diagnostics such as `src/keys.ts` control-character regex and non-null assertions. The command also briefly wrote an unrelated Biome fix in `packages/core/src/utils/prompt-batcher/batcher.ts`; that generated write was restored and is not part of this PR.

## Evidence N/A
- UI screenshots/video, frontend/backend logs, model trajectories, and domain artifacts: N/A — comment-only change with token-identical source verified by `check:comment-only`.
