### PR TITLE
fix(core): narrow tier-a sub-action expansion to turn-relevant children

### DIFF
--- a/packages/core/src/__tests__/tiered-action-surface.test.ts
+++ b/packages/core/src/__tests__/tiered-action-surface.test.ts
@@ -480,6 +480,80 @@ describe("v5 tiered action surface", () => {
 		expect(toolNames).not.toContain("SEND_EMAIL");
 	});
 
+	it("caps a hot parent's sub-action flood to the turn-relevant children", async () => {
+		// One hot tier-A parent must not expose its whole namespace (observed
+		// live: all 24 MESSAGE_* children on a two-intent turn). The per-parent
+		// child narrow keeps the Stage-1 candidate plus the best query-token
+		// matches under the default cap of 8; everything else stays reachable
+		// only through the MESSAGE umbrella, whose handler routes any subaction.
+		const reviewQueue = makeAction({
+			name: "MESSAGE_REVIEW_QUEUE",
+			description: "Review channel messages awaiting a response.",
+		});
+		const sendReply = makeAction({
+			name: "MESSAGE_SEND_REPLY",
+			description: "Reply to messages needing a response.",
+		});
+		const bulkOps = Array.from({ length: 10 }, (_, i) =>
+			makeAction({
+				name: `MESSAGE_OP_${i}`,
+				description: `Unrelated bulk operation number ${i}.`,
+			}),
+		);
+		const message = makeAction({
+			name: "MESSAGE",
+			description: "Message management parent action.",
+			subActions: [
+				"MESSAGE_REVIEW_QUEUE",
+				"MESSAGE_SEND_REPLY",
+				...bulkOps.map((action) => action.name),
+			],
+		});
+		const runtime = makeRuntime({
+			actions: [message, reviewQueue, sendReply, ...bulkOps],
+			responses: [
+				stage1Response({
+					contexts: ["general"],
+					intents: ["review channel messages", "reply to messages"],
+					candidateActionNames: ["MESSAGE_REVIEW_QUEUE"],
+				}),
+				plannerToolResponse("MESSAGE_REVIEW_QUEUE"),
+				finishEvaluatorResponse("Reviewed the queue."),
+			],
+		});
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("review the channel messages needing a response"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		const plannerCall = getCalls(runtime).find(
+			(call) => call.modelType === ModelType.ACTION_PLANNER,
+		);
+		const tools = (
+			plannerCall?.params as { tools?: Array<{ name?: string }> } | undefined
+		)?.tools;
+		const toolNames = tools?.map((tool) => tool.name).filter(Boolean) ?? [];
+		// Fires when relevant: the umbrella and the turn-relevant children are
+		// first-class tools.
+		expect(toolNames).toContain("MESSAGE");
+		expect(toolNames).toContain("MESSAGE_REVIEW_QUEUE");
+		expect(toolNames).toContain("MESSAGE_SEND_REPLY");
+		// Lean when not: the namespace is capped, not fully expanded.
+		const childTools = toolNames.filter((name) =>
+			String(name).startsWith("MESSAGE_"),
+		);
+		expect(childTools.length).toBeLessThanOrEqual(8);
+		expect(toolNames).not.toContain("MESSAGE_OP_9");
+		// Prompt footprint drops with the tool surface: the narrowed-out child
+		// no longer appears in the rendered action section either.
+		const prompt = availableActionsSection(runtime);
+		expect(prompt).toContain("MESSAGE_REVIEW_QUEUE");
+		expect(prompt).not.toContain("MESSAGE_OP_9");
+	});
+
 	it("omits planner tools that execution would reject for the selected context", async () => {
 		process.env.ACTION_ROLE_POLICY = JSON.stringify({ BASH: "GUEST" });
 		_resetActionRolePolicyCacheForTests();

--- a/packages/core/src/actions/__tests__/to-tool.test.ts
+++ b/packages/core/src/actions/__tests__/to-tool.test.ts
@@ -395,6 +395,93 @@ describe("buildPlannerToolsFromTieredActions", () => {
 		expect(tools.map((tool) => tool.name)).toEqual(["MUSIC", "PLAY_MUSIC"]);
 	});
 
+	it("expands only allow-listed children when tierAChildrenByParent has an entry", () => {
+		const playMusic = makeTieredAction({
+			name: "PLAY_MUSIC",
+			description: "Start playing a track.",
+		});
+		const pauseMusic = makeTieredAction({
+			name: "PAUSE_MUSIC",
+			description: "Pause the active track.",
+		});
+		const stopMusic = makeTieredAction({
+			name: "STOP_MUSIC",
+			description: "Stop playback.",
+		});
+		const music = makeTieredAction({
+			name: "MUSIC",
+			description: "Music control parent action.",
+			subActions: [playMusic, pauseMusic, stopMusic],
+		});
+
+		const tools = buildPlannerToolsFromTieredActions([music], {
+			tierAParents: new Set(["MUSIC"]),
+			tierAChildrenByParent: { MUSIC: ["PLAY_MUSIC"] },
+		});
+
+		// The parent umbrella stays — narrowed-out children remain dispatchable
+		// through it — but only the allow-listed child becomes a native tool.
+		expect(tools.map((tool) => tool.name)).toEqual(["MUSIC", "PLAY_MUSIC"]);
+	});
+
+	it("expands all children for tier-A parents without an allow-list entry", () => {
+		const playMusic = makeTieredAction({
+			name: "PLAY_MUSIC",
+			description: "Start playing a track.",
+		});
+		const music = makeTieredAction({
+			name: "MUSIC",
+			description: "Music control parent action.",
+			subActions: [playMusic],
+		});
+		const createTask = makeTieredAction({
+			name: "CREATE_TASK",
+			description: "Create a task.",
+		});
+		const lifeops = makeTieredAction({
+			name: "LIFEOPS",
+			description: "Life-ops umbrella parent.",
+			subActions: [createTask],
+		});
+
+		const tools = buildPlannerToolsFromTieredActions([music, lifeops], {
+			tierAParents: new Set(["MUSIC", "LIFEOPS"]),
+			// Only LIFEOPS is narrowed; MUSIC has no entry and expands fully.
+			tierAChildrenByParent: new Map([["LIFEOPS", []]]),
+		});
+
+		expect(tools.map((tool) => tool.name)).toEqual([
+			"MUSIC",
+			"PLAY_MUSIC",
+			"LIFEOPS",
+		]);
+	});
+
+	it("does not report narrowed-out string refs as unresolved", () => {
+		const onUnresolvedSubAction = vi.fn();
+		const music = makeTieredAction({
+			name: "MUSIC",
+			description: "Music control parent action.",
+			subActions: ["PLAY_MUSIC", "MISSING_CHILD"],
+		});
+		const playMusic = makeTieredAction({
+			name: "PLAY_MUSIC",
+			description: "Start playing a track.",
+		});
+
+		const tools = buildPlannerToolsFromTieredActions([music], {
+			tierAParents: new Set(["MUSIC"]),
+			actionLookup: new Map([["PLAY_MUSIC", playMusic]]),
+			// MISSING_CHILD is narrowed out — an intentional skip, not an
+			// unresolvable reference.
+			tierAChildrenByParent: { MUSIC: ["PLAY_MUSIC"] },
+			onUnresolvedSubAction,
+		});
+
+		expect(tools.map((tool) => tool.name)).toEqual(["MUSIC", "PLAY_MUSIC"]);
+		expect(onUnresolvedSubAction).not.toHaveBeenCalled();
+	});
+
 	it("emits parent terminals separately — does not implicitly append REPLY/IGNORE/STOP", () => {
 		// The tiered builder is a pure transform over input actions; callers are
 		// responsible for appending CORE_PLANNER_TERMINALS afterwards. This test

--- a/packages/core/src/actions/to-tool.ts
+++ b/packages/core/src/actions/to-tool.ts
@@ -360,6 +360,19 @@ export interface BuildPlannerToolsFromTieredActionsOptions {
 		parentName: string;
 		subActionName: string;
 	}) => void;
+	/**
+	 * Per-parent allow-list of sub-action names (case-insensitive) to expand
+	 * for tier-A parents. Produced by the tiering surface's per-parent child
+	 * narrowing (`maxTierAChildrenPerParent` in `tierActionResults`): when a
+	 * parent has an entry, only the listed children become first-class tools;
+	 * every other subaction stays reachable through the parent umbrella tool,
+	 * whose handler dispatches any subaction. Parents WITHOUT an entry expand
+	 * all sub-actions, so full-surface mode and callers that never narrow are
+	 * unaffected.
+	 */
+	tierAChildrenByParent?:
+		| ReadonlyMap<string, readonly string[]>
+		| Readonly<Record<string, readonly string[]>>;
 }
 
 function normalizeParentNameKey(name: string): string {
@@ -386,6 +399,32 @@ function buildParentNameSet(
 		}
 	}
 	return set;
+}
+
+function resolveTierAChildAllowlist(
+	value: BuildPlannerToolsFromTieredActionsOptions["tierAChildrenByParent"],
+): Map<string, Set<string>> {
+	const map = new Map<string, Set<string>>();
+	if (!value) {
+		return map;
+	}
+	const entries: Iterable<[string, readonly string[]]> =
+		value instanceof Map ? value : Object.entries(value);
+	for (const [parentName, childNames] of entries) {
+		const parentKey = normalizeParentNameKey(parentName);
+		if (!parentKey || !Array.isArray(childNames)) {
+			continue;
+		}
+		const childKeys = new Set<string>();
+		for (const childName of childNames) {
+			const childKey = normalizeParentNameKey(String(childName));
+			if (childKey) {
+				childKeys.add(childKey);
+			}
+		}
+		map.set(parentKey, childKeys);
+	}
+	return map;
 }
 
 function resolveActionLookup(
@@ -443,6 +482,9 @@ export function buildPlannerToolsFromTieredActions(
 ): ToolDefinition[] {
 	const tierAKeys = buildParentNameSet(options.tierAParents);
 	const actionLookup = resolveActionLookup(options.actionLookup);
+	const childAllowlistByParent = resolveTierAChildAllowlist(
+		options.tierAChildrenByParent,
+	);
 
 	// Top up the lookup with anything already in `actions` so children that
 	// appear inline elsewhere in the input remain resolvable from a string ref.
@@ -473,11 +515,27 @@ export function buildPlannerToolsFromTieredActions(
 		if (!tierAKeys.has(key)) {
 			continue;
 		}
+		const allowedChildren = childAllowlistByParent.get(key);
 		for (const subAction of action.subActions ?? []) {
 			let child: PlannerToolActionShape | undefined;
 			let subActionName = "";
 			if (typeof subAction === "string") {
 				subActionName = subAction;
+			} else if (subAction && typeof subAction === "object") {
+				subActionName = subAction.name;
+				child = subAction;
+			}
+			// The allow-list check runs before string-ref resolution: a
+			// narrowed-out child is an intentional skip (it stays dispatchable
+			// through the parent umbrella), not an unresolvable reference, so
+			// it must not fire onUnresolvedSubAction.
+			if (
+				allowedChildren &&
+				!allowedChildren.has(normalizeParentNameKey(subActionName))
+			) {
+				continue;
+			}
+			if (typeof subAction === "string") {
 				child = actionLookup.get(normalizeParentNameKey(subAction));
 				if (!child) {
 					onUnresolved({
@@ -486,9 +544,6 @@ export function buildPlannerToolsFromTieredActions(
 					});
 					continue;
 				}
-			} else if (subAction && typeof subAction === "object") {
-				subActionName = subAction.name;
-				child = subAction;
 			}
 			if (!child) {
 				continue;

--- a/packages/core/src/runtime/__tests__/action-tiering.test.ts
+++ b/packages/core/src/runtime/__tests__/action-tiering.test.ts
@@ -364,6 +364,150 @@ describe("action tiering", () => {
 		]);
 	});
 
+	describe("per-parent tier-A child narrowing", () => {
+		// A hot parent with a wide namespace: two children match the turn's
+		// wording, the other ten are unrelated operations.
+		const messageActions = [
+			{
+				name: "MESSAGE",
+				description: "Message management parent.",
+				subActions: [
+					"MESSAGE_REVIEW_QUEUE",
+					"MESSAGE_SEND_REPLY",
+					...Array.from({ length: 10 }, (_, i) => `MESSAGE_OP_${i}`),
+				],
+			},
+			{
+				name: "MESSAGE_REVIEW_QUEUE",
+				description: "Review channel messages awaiting a response.",
+			},
+			{
+				name: "MESSAGE_SEND_REPLY",
+				description: "Reply to messages needing a response.",
+			},
+			...Array.from({ length: 10 }, (_, i) => ({
+				name: `MESSAGE_OP_${i}`,
+				description: `Unrelated bulk operation number ${i}.`,
+			})),
+		];
+		const reviewTurnTokens = [
+			"review",
+			"channel",
+			"messages",
+			"needing",
+			"response",
+			"reply",
+		];
+
+		it("caps children per tier-A parent and keeps the query-relevant ones", () => {
+			const catalog = buildActionCatalog(messageActions);
+			const message = catalog.parentByName.get("MESSAGE");
+			if (!message) {
+				throw new Error("missing MESSAGE parent");
+			}
+
+			const surface = tierActionResults({
+				catalog,
+				results: [resultFor(message, 0.95)],
+				maxTierAChildrenPerParent: 4,
+				queryTokens: reviewTurnTokens,
+			});
+
+			const tierA = surface.tierAParents[0];
+			expect(tierA.name).toBe("MESSAGE");
+			expect(tierA.childNames).toHaveLength(4);
+			expect(tierA.childNames).toContain("MESSAGE_REVIEW_QUEUE");
+			expect(tierA.childNames).toContain("MESSAGE_SEND_REPLY");
+			// The parent umbrella stays exposed as the catch-all dispatcher.
+			expect(surface.exposedActionNames).toContain("MESSAGE");
+			// Narrowed-out children leave the exposed surface entirely.
+			expect(surface.exposedActionNames).not.toContain("MESSAGE_OP_9");
+		});
+
+		it("always keeps Stage-1 candidate children even when token ranking misses them", () => {
+			const catalog = buildActionCatalog(messageActions);
+			const message = catalog.parentByName.get("MESSAGE");
+			if (!message) {
+				throw new Error("missing MESSAGE parent");
+			}
+
+			const surface = tierActionResults({
+				catalog,
+				results: [resultFor(message, 0.95)],
+				narrowToCandidateActions: ["MESSAGE_OP_7"],
+				maxTierAChildrenPerParent: 2,
+				queryTokens: reviewTurnTokens,
+			});
+
+			const tierA = surface.tierAParents[0];
+			expect(tierA.childNames).toContain("MESSAGE_OP_7");
+			expect(tierA.childNames).toHaveLength(2);
+		});
+
+		it("applies the default cap of 8 when the knob is omitted", () => {
+			const catalog = buildActionCatalog(messageActions);
+			const message = catalog.parentByName.get("MESSAGE");
+			if (!message) {
+				throw new Error("missing MESSAGE parent");
+			}
+
+			const surface = tierActionResults({
+				catalog,
+				results: [resultFor(message, 0.95)],
+				queryTokens: reviewTurnTokens,
+			});
+
+			expect(surface.tierAParents[0].childNames).toHaveLength(8);
+			expect(surface.tierAParents[0].childNames).toContain(
+				"MESSAGE_REVIEW_QUEUE",
+			);
+		});
+
+		it("leaves parents whose children fit the cap untouched", () => {
+			const catalog = buildActionCatalog(actions);
+			const music = catalog.parentByName.get("MUSIC");
+			if (!music) {
+				throw new Error("missing MUSIC parent");
+			}
+
+			const surface = tierActionResults({
+				catalog,
+				results: [resultFor(music, 0.92)],
+				queryTokens: ["pause", "the", "song"],
+			});
+
+			expect(surface.tierAParents[0].childNames).toEqual([
+				"PAUSE_MUSIC",
+				"PLAY_TRACK",
+			]);
+		});
+
+		it("narrows deterministically without query tokens via catalog child order", () => {
+			const catalog = buildActionCatalog(messageActions);
+			const message = catalog.parentByName.get("MESSAGE");
+			if (!message) {
+				throw new Error("missing MESSAGE parent");
+			}
+
+			const first = tierActionResults({
+				catalog,
+				results: [resultFor(message, 0.95)],
+				maxTierAChildrenPerParent: 3,
+			});
+			const second = tierActionResults({
+				catalog,
+				results: [resultFor(message, 0.95)],
+				maxTierAChildrenPerParent: 3,
+			});
+
+			expect(first.tierAParents[0].childNames).toEqual(
+				second.tierAParents[0].childNames,
+			);
+			expect(first.tierAParents[0].childNames).toHaveLength(3);
+			expect(first.actionSurfaceHash).toBe(second.actionSurfaceHash);
+		});
+	});
+
 	it("creates deterministic hashes from sorted parent sets", () => {
 		const left = stableActionSurfaceHash({
 			protocolActions: ["REPLY", "IGNORE", "STOP", "CONTINUE"],

--- a/packages/core/src/runtime/action-tiering.ts
+++ b/packages/core/src/runtime/action-tiering.ts
@@ -1,5 +1,6 @@
 import {
 	type ActionCatalog,
+	type ActionCatalogChild,
 	type ActionCatalogParent,
 	normalizeActionName,
 } from "./action-catalog";
@@ -7,6 +8,7 @@ import {
 	type ActionRetrievalResult,
 	candidateNamespaceParentExists,
 	parentAliasesForCandidateAction,
+	tokenizeActionSearchText,
 } from "./action-retrieval";
 
 export const TIER0_PROTOCOL_ACTIONS = [
@@ -23,6 +25,14 @@ export type Tier0ProtocolAction = (typeof TIER0_PROTOCOL_ACTIONS)[number];
 // Set just below a perfect 1.0 so only an overwhelmingly dominant match (not a
 // merely good tier-A hit) overrides Stage-1's routing judgement.
 const RETRIEVAL_OVERRIDE_SCORE = 0.97;
+
+// Per-parent cap on children exposed as first-class planner tools. Symmetric
+// with the maxTierAParents default: without it a single hot parent floods the
+// surface with its whole namespace regardless of turn intent (observed live:
+// all 24 MESSAGE_* children on a two-intent turn, all 33 BROWSER_* children on
+// a browser turn). Narrowing never removes capability — the parent umbrella
+// tool stays exposed and its handler dispatches ANY subaction, exposed or not.
+const DEFAULT_MAX_TIER_A_CHILDREN_PER_PARENT = 8;
 
 export type ActionTier = "tier0" | "tierA" | "tierB" | "tierC";
 
@@ -55,6 +65,24 @@ export type TierActionResultsInput = {
 	 * outside the cap isn't silently displaced before the narrow runs.
 	 */
 	narrowToCandidateActions?: readonly string[];
+	/**
+	 * Cap on sub-actions exposed as first-class planner tools per tier-A
+	 * parent (parents themselves are capped by `maxTierAParents`). Children
+	 * are ranked against the turn's Stage-1 signals: candidate-named children
+	 * always survive (explicit routing decision), remaining slots go to the
+	 * best `queryTokens` overlap with each child's catalog search text.
+	 * Narrowed-out children remain reachable through the parent umbrella
+	 * tool, whose handler routes any subaction.
+	 */
+	maxTierAChildrenPerParent?: number;
+	/**
+	 * Turn query tokens (`ActionRetrievalResponse.query.tokens` — message
+	 * text plus Stage-1 candidate names) used to rank children within a
+	 * tier-A parent when `maxTierAChildrenPerParent` applies. Without tokens
+	 * the ranking degrades to candidate matches first, then catalog child
+	 * order — still deterministic, just intent-blind.
+	 */
+	queryTokens?: readonly string[];
 };
 
 export type TieredActionSurface = {
@@ -266,6 +294,17 @@ export function tierActionResults(
 		tierCParents.sort(compareTieredParents);
 	}
 
+	// Runs after the parent narrow + caps so it sees the final tier-A set
+	// (including candidate-promoted parents, whose children were restored on
+	// promotion) and narrows within each parent to the turn-relevant children.
+	narrowTierAChildrenPerParent(tierAParents, {
+		cap: normalizedLimit(
+			input.maxTierAChildrenPerParent ?? DEFAULT_MAX_TIER_A_CHILDREN_PER_PARENT,
+		),
+		candidateSet: narrowSet,
+		queryTokens: input.queryTokens,
+	});
+
 	const exposedParentNames = sortedUnique([
 		...tierAParents.map((parent) => parent.name),
 		...tierBParents.map((parent) => parent.name),
@@ -355,6 +394,100 @@ function emptyResult(parent: ActionCatalogParent): ActionRetrievalResult {
 		stageScores: {},
 		matchedBy: [],
 	};
+}
+
+// Children have no ActionRetrievalResult of their own (retrieval ranks
+// parents), so the per-parent narrow scores them with the same structural
+// signals the parent ranking used: Stage-1 candidate names and query-token
+// overlap against the child's catalog search text. Token sets are cached per
+// catalog child — the catalog itself is cached across turns, so the tokenize
+// cost is paid once per child, not once per message.
+const childScoringTokensCache = new WeakMap<ActionCatalogChild, Set<string>>();
+
+function getChildScoringTokens(child: ActionCatalogChild): Set<string> {
+	const cached = childScoringTokensCache.get(child);
+	if (cached) {
+		return cached;
+	}
+	const computed = new Set(tokenizeActionSearchText(child.searchText));
+	childScoringTokensCache.set(child, computed);
+	return computed;
+}
+
+function childMatchesCandidate(
+	child: ActionCatalogChild,
+	candidateSet: ReadonlySet<string>,
+): boolean {
+	if (candidateSet.size === 0) {
+		return false;
+	}
+	if (candidateSet.has(child.normalizedName)) {
+		return true;
+	}
+	for (const simile of child.similes) {
+		if (candidateSet.has(normalizeActionName(simile))) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function narrowTierAChildrenPerParent(
+	tierAParents: TieredParentAction[],
+	options: {
+		cap: number;
+		candidateSet: ReadonlySet<string>;
+		queryTokens?: readonly string[];
+	},
+): void {
+	const queryTokenSet = new Set(options.queryTokens ?? []);
+	for (let index = 0; index < tierAParents.length; index += 1) {
+		const entry = tierAParents[index];
+		if (!entry || entry.childNames.length <= options.cap) {
+			continue;
+		}
+		const scored = entry.result.parent.children.map((child, catalogIndex) => {
+			let overlap = 0;
+			if (queryTokenSet.size > 0) {
+				const childTokens = getChildScoringTokens(child);
+				for (const token of queryTokenSet) {
+					if (childTokens.has(token)) {
+						overlap += 1;
+					}
+				}
+			}
+			return {
+				child,
+				catalogIndex,
+				candidate: childMatchesCandidate(child, options.candidateSet),
+				overlap,
+			};
+		});
+		// Candidate-named children always survive — Stage-1's explicit routing
+		// decision, and the planner surface force-exposes registered candidates
+		// downstream, so dropping them here would only desynchronize the two.
+		// They may exceed the cap; the cap bounds the UNRANKED tail, not the
+		// explicit picks. Ties break on catalog child order (name-sorted at
+		// catalog build) so the narrow — and the surface hash derived from it —
+		// stays deterministic.
+		const candidates = scored.filter((child) => child.candidate);
+		const rest = scored
+			.filter((child) => !child.candidate)
+			.sort(
+				(left, right) =>
+					right.overlap - left.overlap ||
+					left.catalogIndex - right.catalogIndex,
+			)
+			.slice(0, Math.max(0, options.cap - candidates.length));
+		const kept = [...candidates, ...rest].sort(
+			(left, right) => left.catalogIndex - right.catalogIndex,
+		);
+		tierAParents[index] = {
+			...entry,
+			childNames: kept.map((child) => child.child.name),
+			childNormalizedNames: kept.map((child) => child.child.normalizedName),
+		};
+	}
 }
 
 function parentOnlyTieredParent(

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2213,6 +2213,14 @@ type V5PlannerActionSurfaceSummary = {
 	catalogParentCount: number;
 	exposedActionCount: number;
 	tierAParents: string[];
+	/**
+	 * Children exposed as first-class planner tools per tier-A parent, after
+	 * the per-parent child narrowing (`maxTierAChildrenPerParent`). Read back
+	 * by `collectPlannerTools` so the native-tool expansion matches the tiered
+	 * surface instead of re-expanding every subaction of a hot parent. Absent
+	 * in full-surface mode, where every subaction expands.
+	 */
+	tierAChildrenByParent?: Record<string, string[]>;
 	tierBParents: string[];
 	omittedParentCount: number;
 	omittedParentNamesPreview: string[];
@@ -2600,6 +2608,10 @@ function buildV5PlannerActionSurface(params: {
 		catalog,
 		results: retrieval.results,
 		narrowToCandidateActions: candidateActions,
+		// Message-text + candidate tokens rank children WITHIN each tier-A
+		// parent so a hot parent exposes its turn-relevant children instead of
+		// its whole namespace (maxTierAChildrenPerParent).
+		queryTokens: retrieval.query.tokens,
 	});
 	const toolSearchEndedAt = Date.now();
 	const exposedActionNames = new Set(
@@ -2710,6 +2722,12 @@ function buildV5PlannerActionSurface(params: {
 			catalogParentCount: catalog.parents.length,
 			exposedActionCount,
 			tierAParents: tieredSurface.sortedTierAParentNames,
+			tierAChildrenByParent: Object.fromEntries(
+				tieredSurface.tierAParents.map((parent) => [
+					parent.name,
+					[...parent.childNames],
+				]),
+			),
 			tierBParents: tieredSurface.sortedTierBParentNames,
 			omittedParentCount: tieredSurface.omittedParentNames.length,
 			omittedParentNamesPreview: tieredSurface.omittedParentNames.slice(0, 20),
@@ -5485,6 +5503,7 @@ function collectPlannerTools(
 			actionLookup: new Map(
 				actions.map((action) => [action.name, action] as const),
 			),
+			tierAChildrenByParent: readTierAChildrenByParentFromContext(context),
 		}),
 		...CORE_PLANNER_TERMINALS,
 	];
@@ -5514,6 +5533,38 @@ function readTierAParentsFromContext(context: ContextObject): Set<string> {
 		}
 	}
 	return set;
+}
+
+/**
+ * Read the per-parent tier-A child allow-list from the action surface
+ * metadata. Returns `undefined` when the surface carries no
+ * `tierAChildrenByParent` (full-surface mode, or contexts built outside the
+ * tiered pipeline), in which case the tiered tool builder expands every
+ * subaction of a tier-A parent as before.
+ */
+function readTierAChildrenByParentFromContext(
+	context: ContextObject,
+): Record<string, string[]> | undefined {
+	const surface = (context.metadata as { actionSurface?: unknown } | undefined)
+		?.actionSurface;
+	if (!surface || typeof surface !== "object") {
+		return undefined;
+	}
+	const raw = (surface as { tierAChildrenByParent?: unknown })
+		.tierAChildrenByParent;
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+		return undefined;
+	}
+	const record: Record<string, string[]> = {};
+	for (const [parentName, childNames] of Object.entries(raw)) {
+		if (!Array.isArray(childNames)) {
+			continue;
+		}
+		record[parentName] = childNames.filter(
+			(name): name is string => typeof name === "string",
+		);
+	}
+	return record;
 }
 
 /**


### PR DESCRIPTION
## Problem

Tier-A expansion has no per-child narrowing: one hot parent exposes ALL of its subaction virtuals regardless of turn intent.

- `packages/core/src/runtime/action-tiering.ts` caps tier-A **parents** at 8 (`maxTierAParents`) but every tier-A entry carries its full `childNames` list.
- `buildPlannerToolsFromTieredActions` (`packages/core/src/actions/to-tool.ts`) expands **every** entry of `parent.subActions` with no cap or ranking.
- `narrowToCandidateActions` narrows child-name hits back to *parents* but never narrows *within* a parent.

Observed live: Stage-1 emitted intents `['review channel messages','reply to messages needing response']` yet all 24 `MESSAGE_*` children were exposed (tj-1570c7975ef486); a browser turn exposed all 33 `BROWSER_*` children (tj-fd1f7b7cb55fbf). That is pure context flood — the planner prompt carries dozens of tool schemas irrelevant to the turn.

Repro on unmodified develop (24-child parent, review-intent tokens):

```
tier-A parent: MESSAGE  children exposed: 24
planner tools emitted: 25
```

## Fix (structural, inside the existing tiering mechanism)

- New `maxTierAChildrenPerParent` knob (default 8) next to `maxTierAParents` in `TierActionResultsInput`. Children are ranked per tier-A parent against the turn's Stage-1 signals:
  - **candidate-named children always survive** (Stage-1's explicit routing decision; the surface force-exposes registered candidates downstream, so dropping them here would desynchronize the two);
  - remaining slots go to the best **query-token overlap** (`ActionRetrievalResponse.query.tokens` — message text + candidate names, the same retrieval machinery that already scores parents) against each child's catalog `searchText`;
  - ties break on catalog child order, so the narrow — and the surface hash derived from it — stays deterministic.
- The narrowed per-parent child set flows through the action-surface summary (`tierAChildrenByParent`) into `collectPlannerTools`, and `buildPlannerToolsFromTieredActions` accepts it as a per-parent allow-list, so the native-tool expansion matches the tiered surface. Parents **without** an entry expand fully — full-surface mode (`ELIZA_PLANNER_FULL_ACTION_SURFACE=1`) and legacy callers are byte-identical.
- **No capability is removed**: the parent umbrella tool stays exposed as the catch-all dispatcher and its handler (sub-planner) routes ANY subaction, exposed or not. Narrowed-out string refs are intentional skips and do not fire `onUnresolvedSubAction`.

Same repro with the fix: `children exposed: 8`, `planner tools emitted: 9`, and the query-relevant child is among the kept 8.

## Tests

- `action-tiering.test.ts` — 5 new: cap + query-relevant keep, candidate children always kept, default cap of 8, parents under the cap untouched, deterministic narrow without query tokens.
- `to-tool.test.ts` — 3 new: allow-list filters expansion (parent stays), parents without an entry expand fully, narrowed-out string refs are not reported unresolved.
- `tiered-action-surface.test.ts` — 1 new integration test driving the real Stage-1 → planner pipeline: a 12-child hot parent with candidate `MESSAGE_REVIEW_QUEUE` exposes the umbrella + the turn-relevant children, caps `MESSAGE_*` child tools at 8, and the narrowed-out child (`MESSAGE_OP_9`) disappears from both the `tools` array and the rendered action section (prompt footprint drop asserted).

## Verification (real counts)

- `packages/core` vitest: **3043 passed | 7 failed | 11 skipped (3061)** — the 7 failures (`media/fetch.test.ts` ×4, `link-extraction` ×1, `action-handler-callsite-audit` ×1, `tiered-action-surface` "omits planner tools that execution would reject" ×1) fail **identically on unmodified develop** on the same box (verified via `git stash` baseline run) — zero regressions from this diff.
- `bun run --cwd packages/core typecheck` — exit 0.
- `bun run --cwd packages/core build` (Node + browser + edge + d.ts) — green.

## Evidence

- Live trajectories cited above (tj-1570c7975ef486, tj-fd1f7b7cb55fbf) are the originating flood observations.
- Deterministic repro before/after included in the description; integration test asserts the same end-to-end through `runV5MessageRuntimeStage1`.
- UI/video/screenshots: N/A — planner-surface change with no user-facing rendering; behavior is asserted on the planner `tools` array and rendered action section in tests.
