### PR TITLE
fix(#12903): remove fake example build scripts

### DIFF
--- a/.github/issue-evidence/12903-example-fake-build-typecheck.md
+++ b/.github/issue-evidence/12903-example-fake-build-typecheck.md
@@ -1,0 +1,88 @@
+# #12903 example fake build/typecheck cleanup evidence
+
+Branch slice: remove package-level fake `typecheck` / `build` scripts from
+example packages that do not have package-level TypeScript or build artifacts.
+
+## Packages
+
+- `packages/examples/app/capacitor`
+- `packages/examples/app/electron`
+- `packages/examples/html`
+- `packages/examples/moltbook/bags-claimer`
+
+## Script contract changes
+
+- Removed `typecheck: echo 'No TypeScript config; skipping typecheck'`.
+- Removed `build: echo 'No build step configured; skipping build'`.
+- Added real read-only `lint:check` and `format:check` scripts.
+- Added mutating `format` scripts to pair with the existing mutating `lint`.
+
+The app workspace packages keep their explicit delegated commands such as
+`build:frontend` / `build:renderer`; only the fake package-level `build` was
+removed.
+
+## Verification
+
+Current working tree: `origin/develop` at `ed24761896`.
+
+Read-only lint, format, and smoke tests:
+
+```bash
+bun run --cwd packages/examples/app/capacitor lint:check
+bun run --cwd packages/examples/app/capacitor format:check
+bun run --cwd packages/examples/app/capacitor test
+
+bun run --cwd packages/examples/app/electron lint:check
+bun run --cwd packages/examples/app/electron format:check
+bun run --cwd packages/examples/app/electron test
+
+bun run --cwd packages/examples/html lint:check
+bun run --cwd packages/examples/html format:check
+bun run --cwd packages/examples/html test
+
+bun run --cwd packages/examples/moltbook/bags-claimer lint:check
+bun run --cwd packages/examples/moltbook/bags-claimer format:check
+```
+
+Results:
+
+```text
+packages/examples/app/capacitor:
+  biome check passed for 20 files
+  biome format passed for 19 files
+  test passed: 4 pass, 0 fail
+
+packages/examples/app/electron:
+  biome check passed for 22 files
+  biome format passed for 21 files
+  test passed: 4 pass, 0 fail
+
+packages/examples/html:
+  biome check passed for 3 files
+  biome format passed for 2 files
+  test passed: 3 pass, 0 fail
+
+packages/examples/moltbook/bags-claimer:
+  biome check passed for 3 files
+  biome format passed for 3 files
+```
+
+## Local blocker
+
+`packages/examples/moltbook/bags-claimer` test requires dependencies from a
+workspace install. This clean auxiliary worktree has no local `node_modules`,
+and a temporary `node_modules -> /Users/shawwalters/eliza/node_modules` symlink
+still does not resolve the package dependency:
+
+```bash
+bun run --cwd packages/examples/moltbook/bags-claimer test
+```
+
+Result:
+
+```text
+error: Cannot find module '@solana/web3.js' from '.../packages/examples/moltbook/bags-claimer/claimer.ts'
+```
+
+This slice changes only scripts; it does not change Bags Claimer runtime or test
+code.

--- a/packages/examples/app/capacitor/package.json
+++ b/packages/examples/app/capacitor/package.json
@@ -9,8 +9,9 @@
     "cap:sync": "bunx cap sync",
     "test": "bun test smoke.test.js && bun run --cwd frontend test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "typecheck": "echo 'No TypeScript config; skipping typecheck'",
-    "build": "echo 'No build step configured; skipping build'"
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "devDependencies": {
     "@capacitor/cli": "^8.3.4",

--- a/packages/examples/app/electron/package.json
+++ b/packages/examples/app/electron/package.json
@@ -9,7 +9,8 @@
     "start": "bun run --cwd backend start",
     "test": "bun test smoke.test.js && bun run --cwd frontend test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "typecheck": "echo 'No TypeScript config; skipping typecheck'",
-    "build": "echo 'No build step configured; skipping build'"
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   }
 }

--- a/packages/examples/html/package.json
+++ b/packages/examples/html/package.json
@@ -6,8 +6,9 @@
     "start": "python3 -m http.server 3000 --directory ../../..",
     "test": "bun test html.test.js",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "typecheck": "echo 'No TypeScript config; skipping typecheck'",
-    "build": "echo 'No build step configured; skipping build'"
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@elizaos/plugin-anthropic": "workspace:*",

--- a/packages/examples/moltbook/bags-claimer/package.json
+++ b/packages/examples/moltbook/bags-claimer/package.json
@@ -6,8 +6,9 @@
     "claim": "bun run claimer.ts --once",
     "test": "bun test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "typecheck": "echo 'No TypeScript config; skipping typecheck'",
-    "build": "echo 'No build step configured; skipping build'"
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@solana/web3.js": "1.98.4",


### PR DESCRIPTION
## Summary

Fixes another #12903 script-normalization slice for examples with fake package-level scripts:

- removes placeholder `typecheck` scripts that only echoed "No TypeScript config"
- removes placeholder `build` scripts that only echoed "No build step configured"
- adds real `lint:check`, `format`, and `format:check` scripts
- keeps explicit delegated app commands such as `build:frontend` / `build:renderer`
- records evidence in `.github/issue-evidence/12903-example-fake-build-typecheck.md`

## Why

#12903 requires package scripts to reflect real package capabilities. These four example packages do not have package-level TypeScript or build artifacts, so a fake green `typecheck` or `build` hides that fact from Turbo/script audits.

## Verification

- `git diff --check origin/develop..HEAD`
- JSON parse check for the edited `package.json` files
- static guard confirming the edited packages no longer have fake `build` / `typecheck` scripts and do have read-only check verbs
- `bun run --cwd packages/examples/app/capacitor lint:check`
- `bun run --cwd packages/examples/app/capacitor format:check`
- `bun run --cwd packages/examples/app/capacitor test`
- `bun run --cwd packages/examples/app/electron lint:check`
- `bun run --cwd packages/examples/app/electron format:check`
- `bun run --cwd packages/examples/app/electron test`
- `bun run --cwd packages/examples/html lint:check`
- `bun run --cwd packages/examples/html format:check`
- `bun run --cwd packages/examples/html test`
- `bun run --cwd packages/examples/moltbook/bags-claimer lint:check`
- `bun run --cwd packages/examples/moltbook/bags-claimer format:check`

## Known local limitations

Full `bun install` / `bun run verify` were not run in this auxiliary worktree because the filesystem has 4.3 GiB free. `packages/examples/moltbook/bags-claimer test` was attempted and is blocked by missing workspace-installed `@solana/web3.js`; a temporary shared `node_modules` symlink did not resolve it. Details are in the evidence file.
