### PR TITLE
docs(#12758): clean music service prose headers

### DIFF
--- a/plugins/plugin-music/src/contracts.ts
+++ b/plugins/plugin-music/src/contracts.ts
@@ -1,3 +1,6 @@
+/**
+ * Shared broadcast contracts for music playback and streaming surfaces.
+ */
 import type { EventEmitter } from "node:events";
 import type { Readable } from "node:stream";
 

--- a/plugins/plugin-music/src/discordVoice.ts
+++ b/plugins/plugin-music/src/discordVoice.ts
@@ -1,3 +1,9 @@
+/**
+ * Discord voice compatibility bridge for the music plugin.
+ *
+ * The shapes stay local so music can integrate with Discord voice services
+ * without a hard runtime dependency on the Discord plugin.
+ */
 import type { VoiceManagerLike } from "./queue";
 
 /**

--- a/plugins/plugin-music/src/index.ts
+++ b/plugins/plugin-music/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Plugin entrypoint for music playback, library, providers, routes, and search.
+ *
+ * It registers the umbrella MUSIC action, services, providers, HTTP routes, and
+ * search categories used by Eliza agents.
+ */
 import { type IAgentRuntime, logger, type Plugin } from "@elizaos/core";
 import { musicAction } from "./actions/music";
 import { musicInfoProvider } from "./providers/musicInfoProvider";

--- a/plugins/plugin-music/src/plugin-compression.test.ts
+++ b/plugins/plugin-music/src/plugin-compression.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Plugin compression tests for music action registration.
+ *
+ * They verify promoted subactions stay discoverable after the plugin object is
+ * built.
+ */
 import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import musicPlugin from "./index";

--- a/plugins/plugin-music/src/queue.ts
+++ b/plugins/plugin-music/src/queue.ts
@@ -1,3 +1,9 @@
+/**
+ * Per-guild music queue and voice playback model for direct audio streaming.
+ *
+ * It tracks queued tracks, current playback handles, and the voice manager used
+ * by MusicService.
+ */
 import { EventEmitter } from "node:events";
 import { PassThrough, type Readable } from "node:stream";
 import { type IAgentRuntime, logger } from "@elizaos/core";
@@ -41,6 +47,9 @@ interface DiscordServiceLike {
 
 /**
  * Represents a track in the music queue
+ */
+/**
+ * Per-guild music queue model for playback order and now-playing state.
  */
 export interface QueuedTrack {
   id: string;

--- a/plugins/plugin-music/src/route-fallback.ts
+++ b/plugins/plugin-music/src/route-fallback.ts
@@ -1,3 +1,9 @@
+/**
+ * Fallback music-player status route for hosts that mount plugin routes late.
+ *
+ * It answers status-like requests directly from MusicService when the normal
+ * plugin route table did not handle the request.
+ */
 import type { ServerResponse } from "node:http";
 import type { AgentRuntime } from "@elizaos/core";
 

--- a/plugins/plugin-music/src/routes.ts
+++ b/plugins/plugin-music/src/routes.ts
@@ -1,3 +1,9 @@
+/**
+ * HTTP streaming and control routes for the music player surface.
+ *
+ * Routes expose live audio streams, queue/status JSON, and authenticated
+ * transport controls under the plugin mount path.
+ */
 import { Transform, type TransformCallback } from "node:stream";
 import type {
   IAgentRuntime,

--- a/plugins/plugin-music/src/search-category.test.ts
+++ b/plugins/plugin-music/src/search-category.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Search category tests for the music library integrations.
+ */
 import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-music/src/search-category.ts
+++ b/plugins/plugin-music/src/search-category.ts
@@ -1,3 +1,9 @@
+/**
+ * Search category registration for YouTube and Wikipedia music lookups.
+ *
+ * These categories let the shared search registry delegate music-specific
+ * queries to MusicLibraryService.
+ */
 import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
 
 export const YOUTUBE_SEARCH_CATEGORY: SearchCategoryRegistration = {

--- a/plugins/plugin-music/src/service.ts
+++ b/plugins/plugin-music/src/service.ts
@@ -1,3 +1,10 @@
+/**
+ * Core music playback service for queues, broadcasts, routing, and Discord
+ * voice wiring.
+ *
+ * The service owns per-guild playback state and bridges cached audio into
+ * stream consumers and voice targets.
+ */
 import { type IAgentRuntime, logger, Service, type UUID } from "@elizaos/core";
 import type { BroadcastTrackMetadata, IAudioBroadcast } from "./contracts";
 import { Broadcast } from "./core";

--- a/plugins/plugin-music/src/services/audioCache.ts
+++ b/plugins/plugin-music/src/services/audioCache.ts
@@ -1,3 +1,9 @@
+/**
+ * Audio cache service for yt-dlp downloads and ffmpeg transcoding.
+ *
+ * It stores reusable audio artifacts and returns playable cached paths for the
+ * playback service.
+ */
 import { exec, execFile } from "node:child_process";
 import {
   createReadStream,

--- a/plugins/plugin-music/src/services/geniusClient.ts
+++ b/plugins/plugin-music/src/services/geniusClient.ts
@@ -1,3 +1,6 @@
+/**
+ * Genius API client for lyric-page metadata used by music context providers.
+ */
 import { logger } from "@elizaos/core";
 import { type RetryableError, retryWithBackoff } from "../utils/retry";
 

--- a/plugins/plugin-music/src/services/lastFmClient.ts
+++ b/plugins/plugin-music/src/services/lastFmClient.ts
@@ -1,3 +1,6 @@
+/**
+ * Last.fm API client for artist, track, and album metadata enrichment.
+ */
 import { logger } from "@elizaos/core";
 import type { AlbumInfo, ArtistInfo, TrackInfo } from "../types";
 import { type RetryableError, retryWithBackoff } from "../utils/retry";

--- a/plugins/plugin-music/src/services/musicBrainzClient.ts
+++ b/plugins/plugin-music/src/services/musicBrainzClient.ts
@@ -1,3 +1,9 @@
+/**
+ * MusicBrainz API client for zero-config music metadata lookup.
+ *
+ * It uses the configured user agent and rate-friendly requests for artist,
+ * release, and recording data.
+ */
 import { logger } from "@elizaos/core";
 import type { AlbumInfo, ArtistInfo, TrackInfo } from "../types";
 import { retryWithBackoff } from "../utils/retry";

--- a/plugins/plugin-music/src/services/musicEntityDetectionService.ts
+++ b/plugins/plugin-music/src/services/musicEntityDetectionService.ts
@@ -1,3 +1,9 @@
+/**
+ * LLM-backed music entity detector for songs, artists, and albums.
+ *
+ * It turns conversational text into structured entities consumed by metadata
+ * and Wikipedia providers.
+ */
 import { type IAgentRuntime, logger, ModelType } from "@elizaos/core";
 import { parseJsonObjectResponse } from "../utils/json";
 

--- a/plugins/plugin-music/src/services/musicInfoService.ts
+++ b/plugins/plugin-music/src/services/musicInfoService.ts
@@ -1,3 +1,9 @@
+/**
+ * Music information service that aggregates metadata sources.
+ *
+ * It combines MusicBrainz, Last.fm, Genius, TheAudioDB, and Wikipedia clients
+ * behind track, artist, and album lookup helpers.
+ */
 import { type IAgentRuntime, logger } from "@elizaos/core";
 import type {
   AlbumInfo,

--- a/plugins/plugin-music/src/services/musicLibraryService.ts
+++ b/plugins/plugin-music/src/services/musicLibraryService.ts
@@ -1,3 +1,9 @@
+/**
+ * Aggregated music library service for persistence, discovery, and metadata.
+ *
+ * It wraps component stores, playlist helpers, metadata clients, Spotify, and
+ * YouTube search behind the plugin's library service boundary.
+ */
 import { type IAgentRuntime, logger, Service, type UUID } from "@elizaos/core";
 import {
   type DJAnalytics,

--- a/plugins/plugin-music/src/services/musicStorage.ts
+++ b/plugins/plugin-music/src/services/musicStorage.ts
@@ -1,3 +1,9 @@
+/**
+ * Permanent music archive utility for high-quality downloaded tracks.
+ *
+ * This standalone service is exported for callers that want durable storage
+ * outside the playback cache.
+ */
 import { exec } from "node:child_process";
 import {
   createReadStream,

--- a/plugins/plugin-music/src/services/smartMusicFetch.ts
+++ b/plugins/plugin-music/src/services/smartMusicFetch.ts
@@ -1,3 +1,9 @@
+/**
+ * Smart fetch pipeline for resolving, downloading, and preparing music tracks.
+ *
+ * It combines YouTube search, yt-dlp, audio caching, and progress reporting for
+ * action handlers.
+ */
 import { type IAgentRuntime, logger, Service, type UUID } from "@elizaos/core";
 
 // Local contracts for the optional torrent peer plugins. They aren't always

--- a/plugins/plugin-music/src/services/spotifyClient.test.ts
+++ b/plugins/plugin-music/src/services/spotifyClient.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Spotify client tests for recommendation request shaping.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SpotifyClient, testExports } from "./spotifyClient";
 

--- a/plugins/plugin-music/src/services/spotifyClient.ts
+++ b/plugins/plugin-music/src/services/spotifyClient.ts
@@ -1,3 +1,9 @@
+/**
+ * Spotify Web API client for track lookup and recommendations.
+ *
+ * It manages client-credentials auth and translates plugin recommendation
+ * inputs into Spotify seed and audio-feature parameters.
+ */
 import { logger } from "@elizaos/core";
 import { Buffer } from "buffer";
 import type {

--- a/plugins/plugin-music/src/services/theAudioDbClient.ts
+++ b/plugins/plugin-music/src/services/theAudioDbClient.ts
@@ -1,3 +1,6 @@
+/**
+ * TheAudioDB client for artist and album artwork metadata.
+ */
 import { logger } from "@elizaos/core";
 import { type RetryableError, retryWithBackoff } from "../utils/retry";
 

--- a/plugins/plugin-music/src/services/wikipediaClient.ts
+++ b/plugins/plugin-music/src/services/wikipediaClient.ts
@@ -1,3 +1,9 @@
+/**
+ * Wikipedia API client for raw music encyclopedia extracts.
+ *
+ * Extracted text is later reduced by the Wikipedia extraction service before it
+ * enters provider context.
+ */
 import { logger } from "@elizaos/core";
 import type { AlbumInfo, ArtistInfo, TrackInfo } from "../types";
 

--- a/plugins/plugin-music/src/services/wikipediaExtractionService.test.ts
+++ b/plugins/plugin-music/src/services/wikipediaExtractionService.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Wikipedia extraction tests for LLM response parsing and fallback behavior.
+ */
 import { type IAgentRuntime, ModelType } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import type { WikipediaClient } from "./wikipediaClient";

--- a/plugins/plugin-music/src/services/wikipediaExtractionService.ts
+++ b/plugins/plugin-music/src/services/wikipediaExtractionService.ts
@@ -1,3 +1,9 @@
+/**
+ * LLM extraction service for turning Wikipedia text into music metadata.
+ *
+ * It prompts the runtime model with entity context and parses structured
+ * extraction results for providers.
+ */
 import { type IAgentRuntime, logger, ModelType } from "@elizaos/core";
 import type { AlbumInfo, ArtistInfo, TrackInfo } from "../types";
 import { parseJsonObjectResponse } from "../utils/json";

--- a/plugins/plugin-music/src/services/youtubeSearch.ts
+++ b/plugins/plugin-music/src/services/youtubeSearch.ts
@@ -1,3 +1,9 @@
+/**
+ * YouTube search helper backed by yt-dlp metadata extraction.
+ *
+ * It produces playable video candidates for library search and smart music
+ * fetch flows.
+ */
 import { logger } from "@elizaos/core";
 
 const YOUTUBE_SEARCH_SERVICE_NAME = "youtubeSearch";

--- a/plugins/plugin-music/src/utils/ffmpegEnv.ts
+++ b/plugins/plugin-music/src/utils/ffmpegEnv.ts
@@ -1,3 +1,6 @@
+/**
+ * FFmpeg and ffprobe path resolution for music transcoding.
+ */
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { delimiter, dirname } from "node:path";

--- a/plugins/plugin-music/src/utils/json.ts
+++ b/plugins/plugin-music/src/utils/json.ts
@@ -1,3 +1,6 @@
+/**
+ * JSON parsing helpers for model and service responses.
+ */
 export function parseJsonObjectResponse<T = Record<string, unknown>>(
   response: string,
 ): T | null {

--- a/plugins/plugin-music/src/utils/musicDebug.ts
+++ b/plugins/plugin-music/src/utils/musicDebug.ts
@@ -1,3 +1,6 @@
+/**
+ * Debug logging helpers gated by the music debug environment flag.
+ */
 import { logger } from "@elizaos/core";
 
 /** Set `ELIZA_MUSIC_DEBUG=1` for verbose music-player / cache / stream logs. */

--- a/plugins/plugin-music/src/utils/opusBroadcastNormalize.ts
+++ b/plugins/plugin-music/src/utils/opusBroadcastNormalize.ts
@@ -1,3 +1,6 @@
+/**
+ * Opus stream normalization helpers for broadcast-compatible audio output.
+ */
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { PassThrough, type Readable } from "node:stream";
 import { logger } from "@elizaos/core";

--- a/plugins/plugin-music/src/utils/progressiveMessage.ts
+++ b/plugins/plugin-music/src/utils/progressiveMessage.ts
@@ -1,3 +1,9 @@
+/**
+ * Progressive callback helper for long-running music actions.
+ *
+ * It coalesces user-visible status updates while downloads, searches, or
+ * playback preparation continue.
+ */
 import type { HandlerCallback } from "@elizaos/core";
 
 /**

--- a/plugins/plugin-music/src/utils/resolveMusicGuildId.ts
+++ b/plugins/plugin-music/src/utils/resolveMusicGuildId.ts
@@ -1,3 +1,6 @@
+/**
+ * Guild/server id resolution helpers for music playback operations.
+ */
 import type { Memory } from "@elizaos/core";
 import type { MusicService } from "../service";
 

--- a/plugins/plugin-music/src/utils/smartFetchService.ts
+++ b/plugins/plugin-music/src/utils/smartFetchService.ts
@@ -1,3 +1,6 @@
+/**
+ * Shared smart music fetch service accessors for action handlers.
+ */
 import type { IAgentRuntime, UUID } from "@elizaos/core";
 
 export type MusicFetchProgress = {

--- a/plugins/plugin-music/src/utils/streamFallback.ts
+++ b/plugins/plugin-music/src/utils/streamFallback.ts
@@ -1,3 +1,6 @@
+/**
+ * Stream fallback helpers for readable audio sources.
+ */
 import type { Readable } from "node:stream";
 import { logger } from "@elizaos/core";
 import { createYtdlpStream } from "./ytdlpFallback";

--- a/plugins/plugin-music/src/utils/ytdlpCheck.ts
+++ b/plugins/plugin-music/src/utils/ytdlpCheck.ts
@@ -1,3 +1,6 @@
+/**
+ * yt-dlp discovery helpers for the music download pipeline.
+ */
 import { execSync } from "node:child_process";
 import { accessSync, constants, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";

--- a/plugins/plugin-music/src/utils/ytdlpCli.ts
+++ b/plugins/plugin-music/src/utils/ytdlpCli.ts
@@ -1,3 +1,6 @@
+/**
+ * yt-dlp command helpers for metadata and media extraction.
+ */
 import { basename, dirname } from "node:path";
 
 /**

--- a/plugins/plugin-music/src/utils/ytdlpFallback.ts
+++ b/plugins/plugin-music/src/utils/ytdlpFallback.ts
@@ -1,3 +1,6 @@
+/**
+ * Fallback download helpers when direct yt-dlp extraction needs recovery.
+ */
 import { spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { createReadStream, existsSync, unlinkSync } from "node:fs";

--- a/plugins/plugin-music/tsup.config.ts
+++ b/plugins/plugin-music/tsup.config.ts
@@ -1,3 +1,6 @@
+/**
+ * tsup build config for the music plugin runtime bundle.
+ */
 import { defineConfig } from "tsup";
 
 export default defineConfig({

--- a/plugins/plugin-music/vitest.config.ts
+++ b/plugins/plugin-music/vitest.config.ts
@@ -1,3 +1,6 @@
+/**
+ * Vitest config for the music plugin unit test suite.
+ */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Add top-of-file prose headers to the remaining plugin-music root, service, route, utility, and config files.
- Keep this PR comment-only; no code tokens changed.

Closes #12758. Earlier merged PRs covered the action/provider/test slice and component/core/router slice; this PR covers the remaining 39 files, and the full `plugins/plugin-music` self-audit now reports 0 missing headers.

## Validation
- Read `plugins/plugin-music/CLAUDE.md`.
- Full scoped missing-header audit over `plugins/plugin-music`: PASS (0 missing headers).
- `bun run check:comment-only`: PASS (`39 source file(s) changed; every code token identical to origin/develop. Comments only.`)
- `git diff --check origin/develop...HEAD`: PASS.
- `git diff --name-only origin/develop...HEAD | xargs bunx @biomejs/biome check --config-path biome.json --files-ignore-unknown=true --no-errors-on-unmatched`: PASS (39 files checked, no fixes).

## Evidence N/A
- UI screenshots/video: N/A - comment-only cleanup with zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- Live LLM trajectories: N/A - no agent/action/provider/prompt/model behavior changed.
- Backend/frontend logs: N/A - no runtime behavior changed.
- Audio/domain artifacts: N/A - no playback, generation, or artifact-producing behavior changed.