### PR TITLE
docs(#12803): clean health scheduling prose headers

### DIFF
--- a/plugins/plugin-health/src/components/health/HealthView.test.tsx
+++ b/plugins/plugin-health/src/components/health/HealthView.test.tsx
@@ -1,6 +1,6 @@
-// @vitest-environment jsdom
-
 /**
+ * @vitest-environment jsdom
+ *
  * Drives the unified HealthView (the single GUI/XR data wrapper) through the
  * rendered spatial DOM: the same component the bundle exports for both the
  * "gui" and "xr" modalities. It is a read-only sleep summary over the three
@@ -22,10 +22,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-// `@elizaos/ui` is the giant renderer barrel; HealthView only touches
-// `client.getBaseUrl()` (default fetcher seam, overridden in every test). The
-// spatial primitives come from the separate `@elizaos/ui/spatial` subpath,
-// which is not mocked.
+// HealthView only touches client.getBaseUrl; spatial primitives stay unmocked.
 vi.mock("@elizaos/ui", () => ({
   client: { getBaseUrl: () => "http://test.local" },
 }));

--- a/plugins/plugin-health/src/components/health/health-view-bundle.ts
+++ b/plugins/plugin-health/src/components/health/health-view-bundle.ts
@@ -1,5 +1,5 @@
-// Vite view-bundle entry. Re-exports the HealthView component so the built
-// bundle (dist/views/bundle.js) exposes the named export the view loader reads.
-// Kept separate from HealthView.tsx so that file exports only React components
-// and stays Fast-Refresh-compatible in dev.
+/**
+ * Health view-bundle entry exposes HealthView as the named export consumed by
+ * the app view loader.
+ */
 export { HealthView } from "./HealthView.tsx";

--- a/plugins/plugin-health/src/providers/index.ts
+++ b/plugins/plugin-health/src/providers/index.ts
@@ -1,4 +1,6 @@
-/** Barrel for the health provider factory and its result builders. */
+/**
+ * Barrel for the health provider factory and its result builders.
+ */
 export {
   buildHealthProviderResult,
   buildUnavailableHealthProviderResult,

--- a/plugins/plugin-health/src/routes/index.ts
+++ b/plugins/plugin-health/src/routes/index.ts
@@ -1,2 +1,4 @@
-/** Barrel re-exporting the health-owned sleep route factories. */
+/**
+ * Barrel re-exporting the health-owned sleep route factories.
+ */
 export * from "./sleep.js";

--- a/plugins/plugin-health/src/sleep/awake-probability.compute.test.ts
+++ b/plugins/plugin-health/src/sleep/awake-probability.compute.test.ts
@@ -1,11 +1,11 @@
+/**
+ * Awake-probability tests pin the directional invariants of the logistic model
+ * that gates health check-in timing.
+ */
 import { describe, expect, it } from "vitest";
 import { computeAwakeProbability } from "./awake-probability.js";
 
-// #8795 — computeAwakeProbability is the logistic awake/asleep model that gates
-// check-in timing; it was the other untested "heavy fixture" function. It mixes
-// 5+ interacting terms, so pin tuning-stable DIRECTIONAL invariants (not hand-
-// computed constants): strong-awake vs strong-asleep cross, low-evidence ->
-// pUnknown dominates, and the probabilities stay a normalized distribution.
+// Pin directional invariants rather than hand-computed tuning constants.
 const iso = (ms: number) => new Date(ms).toISOString();
 const args = (o: Record<string, unknown>) =>
   o as unknown as Parameters<typeof computeAwakeProbability>[0];

--- a/plugins/plugin-health/src/sleep/sleep-cycle.test.ts
+++ b/plugins/plugin-health/src/sleep/sleep-cycle.test.ts
@@ -1,16 +1,12 @@
+/**
+ * Sleep-cycle classification tests verify overnight, nap, and unknown labels
+ * used by day-boundary anchoring and wake inference.
+ */
 import { describe, expect, it } from "vitest";
 import { classifyLifeOpsSleepCycleType } from "./sleep-cycle.js";
 
-/**
- * Sleep-cycle classification (#8795 health). `classifyLifeOpsSleepCycleType`
- * decides whether an episode is an overnight sleep, a nap, or unknown — the
- * label that drives day-boundary anchoring and the awake/wake inference. It was
- * untested. Pure given its inputs (duration math + local-hour lookups); these
- * use UTC so the local-hour thresholds are deterministic.
- */
-
 const H = 3_600_000;
-// A UTC timestamp at the given local hour (UTC) on a fixed date.
+// UTC keeps local-hour thresholds deterministic.
 const at = (hour: number, day = 1): number => Date.UTC(2024, 0, day, hour);
 const UTC = "UTC";
 

--- a/plugins/plugin-health/src/sleep/sleep-regularity.compute.test.ts
+++ b/plugins/plugin-health/src/sleep/sleep-regularity.compute.test.ts
@@ -1,11 +1,11 @@
+/**
+ * Sleep-regularity tests pin episode filtering, classification floors, and the
+ * perfectly regular nightly schedule invariant.
+ */
 import { describe, expect, it } from "vitest";
 import type { SleepRegularityEpisodeLike } from "./sleep-regularity.js";
 import { computeSleepRegularity } from "./sleep-regularity.js";
 
-// #8795 — sleep-regularity gates circadian insights. computeSleepRegularity was
-// untested; pin the filter (non-nap, >=180min, ended before now), the 5-episode
-// classification floor, the perfectly-regular invariant (identical wall-clock
-// schedule -> very_regular, ~0 variance), and the insufficient-data fail-closed.
 const nowMs = Date.parse("2026-06-24T00:00:00Z");
 const ep = (
   startAt: string,
@@ -13,7 +13,7 @@ const ep = (
   cycleType: SleepRegularityEpisodeLike["cycleType"] = "overnight",
 ): SleepRegularityEpisodeLike => ({ startAt, endAt, cycleType });
 
-// Six nights, identical 23:00->07:00 UTC schedule (>=5 needed to classify).
+// Six nights are enough to cross the five-episode classification floor.
 const regularNights: SleepRegularityEpisodeLike[] = [
   ep("2026-06-17T23:00:00Z", "2026-06-18T07:00:00Z"),
   ep("2026-06-18T23:00:00Z", "2026-06-19T07:00:00Z"),

--- a/plugins/plugin-health/src/ui/index.ts
+++ b/plugins/plugin-health/src/ui/index.ts
@@ -1,4 +1,6 @@
-/** Barrel re-exporting the health/screen-time assistant command catalog. */
+/**
+ * Barrel re-exporting the health and screen-time assistant command catalog.
+ */
 export {
   HEALTH_ASSISTANT_COMMANDS,
   type HealthAssistantCommand,

--- a/plugins/plugin-health/test/fitbit-connector.contract.test.ts
+++ b/plugins/plugin-health/test/fitbit-connector.contract.test.ts
@@ -1,19 +1,7 @@
-// Keyless contract test: replays REAL-shaped recorded Fitbit Web API responses
-// (src/health-bridge/__fixtures__/fitbit.recorded.json — the per-date
-// profile / activities / sleep / heart / weight resources with the real
-// api.fitbit.com wire field names) through the actual syncFitbit normalizer
-// (via the exported syncHealthConnectorData) and asserts the produced
-// HealthConnectorSyncPayload is contract-shaped. This is what validates the
-// Fitbit connector against the real API shape: the raw->normalized transform
-// (summary.steps->steps, summary.distances[total].distance km->distance_meters m,
-// summary.{fairlyActive,veryActive}Minutes->active_minutes, summary.caloriesOut->
-// calories, activities-heart[].value.restingHeartRate->resting_heart_rate,
-// summary.totalMinutesAsleep min->sleep_hours h, sleep[].duration ms->durationSeconds,
-// sleep[].timeInBed min->timeInBedSeconds, sleep[].minutesToFallAsleep min->
-// latencySeconds, sleep[].minutesAwake min->awakeSeconds, sleep[].isMainSleep,
-// levels.data[]->stageSamples, body.log.weight[].weight kg->weight_kg) is
-// exercised against the real field names with no network.
-// fitbit-connector.real.test.ts re-fetches the live API to catch drift.
+/**
+ * Fitbit connector contract tests replay recorded Web API resources through the
+ * actual normalizer to pin real field-name mappings without network access.
+ */
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";

--- a/plugins/plugin-health/test/fitbit-connector.real.test.ts
+++ b/plugins/plugin-health/test/fitbit-connector.real.test.ts
@@ -1,13 +1,7 @@
-// Live drift check against the REAL Fitbit Web API (api.fitbit.com).
-//
-// Drives the actual syncFitbit normalizer (via syncHealthConnectorData) against
-// the live API with a real access token and asserts the produced
-// HealthConnectorSyncPayload is still contract-shaped — catching drift from the
-// recorded fixture replayed keyless in fitbit-connector.contract.test.ts.
-//
-// Gated: opt-in via FITBIT_LIVE_TEST=1 or the post-merge live lane
-// (TEST_LANE=post-merge) AND a token in FITBIT_ACCESS_TOKEN. Skips cleanly
-// otherwise, so a token-less run is a no-op rather than a failure.
+/**
+ * Fitbit live drift tests run the real Web API normalizer when an access token
+ * and live-test lane are explicitly enabled.
+ */
 
 import { describe, expect, it } from "vitest";
 import { syncHealthConnectorData } from "../src/health-bridge/health-connectors.js";

--- a/plugins/plugin-health/test/oura-connector.contract.test.ts
+++ b/plugins/plugin-health/test/oura-connector.contract.test.ts
@@ -1,15 +1,7 @@
-// Keyless contract test: replays REAL-shaped recorded Oura v2 collections
-// (src/health-bridge/__fixtures__/oura.recorded.json — the {data:[...]} envelopes
-// for sleep / daily_activity / daily_readiness / heartrate / workout, plus the
-// top-level personal_info resource, with the real Oura wire field names) through
-// the actual syncOura normalizer (via the exported syncHealthConnectorData) and
-// asserts the produced HealthConnectorSyncPayload is contract-shaped. This is
-// what validates the Oura connector against the real API shape: the raw->
-// normalized sleep transform (bedtime_start->startAt, bedtime_end->endAt,
-// total_sleep_duration->durationSeconds, *_sleep_duration->{light,deep,rem},
-// type long_sleep->isMainSleep, score->sleepScore, average_hrv->averageHrvMs)
-// is exercised against the real field names with no network.
-// oura-connector.real.test.ts re-fetches the live API to catch drift.
+/**
+ * Oura connector contract tests replay recorded v2 API collections through the
+ * actual normalizer to pin real field-name mappings without network access.
+ */
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";

--- a/plugins/plugin-health/test/oura-connector.real.test.ts
+++ b/plugins/plugin-health/test/oura-connector.real.test.ts
@@ -1,13 +1,7 @@
-// Live drift check against the REAL Oura API (api.ouraring.com/v2).
-//
-// Drives the actual syncOura normalizer (via syncHealthConnectorData) against
-// the live API with a real access token and asserts the produced
-// HealthConnectorSyncPayload is still contract-shaped — catching drift from the
-// recorded fixture replayed keyless in oura-connector.contract.test.ts.
-//
-// Gated: opt-in via OURA_LIVE_TEST=1 or the post-merge live lane
-// (TEST_LANE=post-merge) AND a token in OURA_ACCESS_TOKEN. Skips cleanly
-// otherwise, so a token-less run is a no-op rather than a failure.
+/**
+ * Oura live drift tests run the real v2 API normalizer when an access token and
+ * live-test lane are explicitly enabled.
+ */
 
 import { describe, expect, it } from "vitest";
 import { syncHealthConnectorData } from "../src/health-bridge/health-connectors.js";

--- a/plugins/plugin-health/test/scenarios/health-status-and-trend.scenario.ts
+++ b/plugins/plugin-health/test/scenarios/health-status-and-trend.scenario.ts
@@ -1,10 +1,8 @@
-import { scenario } from "@elizaos/scenario-runner/schema";
-
 /**
- * Health domain parity scenario (#8795 item 6). Exercises the owner asking for
- * a current health snapshot and a weekly trend — routing to the OWNER_HEALTH
- * surface (plugin-health factories behind the personal-assistant wrapper).
+ * Health parity scenario exercises owner health status and weekly trend routing
+ * through the live-only scenario runner lane.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
 export default scenario({
   lane: "live-only",
   id: "health-status-and-trend",

--- a/plugins/plugin-health/test/scenarios/screentime-weekly-recap.scenario.ts
+++ b/plugins/plugin-health/test/scenarios/screentime-weekly-recap.scenario.ts
@@ -1,10 +1,8 @@
-import { scenario } from "@elizaos/scenario-runner/schema";
-
 /**
- * Screen-time / focus parity scenario (#8795 item 6). Owner asks for a weekly
- * screen-time recap and a focus adjustment — routing to OWNER_SCREENTIME
- * (macOS-gated) and, optionally, a blocker/focus change.
+ * Screen-time parity scenario exercises weekly recap and focus adjustment
+ * routing through the live-only scenario runner lane.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
 export default scenario({
   lane: "live-only",
   id: "screentime-weekly-recap",

--- a/plugins/plugin-health/test/scenarios/sleep-recap-bedtime.scenario.ts
+++ b/plugins/plugin-health/test/scenarios/sleep-recap-bedtime.scenario.ts
@@ -1,10 +1,8 @@
-import { scenario } from "@elizaos/scenario-runner/schema";
-
 /**
- * Sleep + bedtime parity scenario (#8795 item 6). Covers the bedtime wind-down
- * prompt and the morning sleep recap — the default-pack behaviors in
- * `plugin-health/src/default-packs/{bedtime,sleep-recap}.ts`.
+ * Sleep parity scenario covers bedtime wind-down and morning recap behavior
+ * contributed by the health default packs.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
 export default scenario({
   lane: "live-only",
   id: "sleep-recap-bedtime",

--- a/plugins/plugin-health/test/scenarios/wake-up-routine.scenario.ts
+++ b/plugins/plugin-health/test/scenarios/wake-up-routine.scenario.ts
@@ -1,9 +1,8 @@
-import { scenario } from "@elizaos/scenario-runner/schema";
-
 /**
- * Wake-up routine parity scenario (#8795 item 6). Covers the morning check-in
- * behavior from `plugin-health/src/default-packs/wake-up.ts`.
+ * Wake-up parity scenario exercises the morning health check-in behavior from
+ * the wake-up default pack.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
 export default scenario({
   lane: "live-only",
   id: "wake-up-routine",

--- a/plugins/plugin-health/test/strava-connector.contract.test.ts
+++ b/plugins/plugin-health/test/strava-connector.contract.test.ts
@@ -1,14 +1,7 @@
-// Keyless contract test: replays a REAL-shaped recorded Strava response
-// (src/health-bridge/__fixtures__/strava.recorded.json — GET /athlete +
-// GET /athlete/activities with the real Strava v3 wire field names) through
-// the actual syncStrava normalizer (via the exported syncHealthConnectorData)
-// and asserts the produced HealthConnectorSyncPayload is contract-shaped.
-// This is what validates the Strava connector against the real API shape:
-// the raw->normalized transform (id->sourceExternalId, sport_type->workoutType,
-// start_date->startAt + computed endAt, moving_time->durationSeconds,
-// distance->distanceMeters, average_heartrate->averageHeartRate) is exercised
-// against the real field names with no network. strava-connector.real.test.ts
-// re-fetches the live API (with a token) to catch drift from this recording.
+/**
+ * Strava connector contract tests replay recorded v3 API responses through the
+ * actual normalizer to pin real field-name mappings without network access.
+ */
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";

--- a/plugins/plugin-health/test/strava-connector.real.test.ts
+++ b/plugins/plugin-health/test/strava-connector.real.test.ts
@@ -1,13 +1,7 @@
-// Live drift check against the REAL Strava API (www.strava.com/api/v3).
-//
-// Drives the actual syncStrava normalizer (via syncHealthConnectorData) against
-// the live API with a real access token and asserts the produced
-// HealthConnectorSyncPayload is still contract-shaped — catching drift from the
-// recorded fixture replayed keyless in strava-connector.contract.test.ts.
-//
-// Gated: opt-in via STRAVA_LIVE_TEST=1 or the post-merge live lane
-// (TEST_LANE=post-merge) AND a token in STRAVA_ACCESS_TOKEN. Skips cleanly
-// otherwise, so a token-less run is a no-op rather than a failure.
+/**
+ * Strava live drift tests run the real v3 API normalizer when an access token
+ * and live-test lane are explicitly enabled.
+ */
 
 import { describe, expect, it } from "vitest";
 import { syncHealthConnectorData } from "../src/health-bridge/health-connectors.js";

--- a/plugins/plugin-health/test/withings-connector.contract.test.ts
+++ b/plugins/plugin-health/test/withings-connector.contract.test.ts
@@ -1,19 +1,7 @@
-// Keyless contract test: replays REAL-shaped recorded Withings API responses
-// (src/health-bridge/__fixtures__/withings.recorded.json — the {status,body}
-// envelopes for getactivity / getsummary / getmeas with the real
-// wbsapi.withings.net wire field names) through the actual syncWithings
-// normalizer (via the exported syncHealthConnectorData) and asserts the
-// produced HealthConnectorSyncPayload is contract-shaped. This is what
-// validates the Withings connector against the real API shape: the raw->
-// normalized transform (activities[].steps->steps, .active->active_minutes,
-// .totalcalories->calories, .distance->distance_meters, .hr_average->heart_rate,
-// .hr_resting->resting_heart_rate; sleep series[].startdate/.enddate UNIX->
-// startAt/endAt ISO, .data.total_sleep_time->durationSeconds, .data.*duration->
-// {light,deep,rem}SleepSeconds; measuregrps[].measures value*10^unit by type
-// -> weight_kg/heart_rate/blood_oxygen_percent/body_temperature_celsius/
-// heart_rate_variability/blood_pressure_systolic/blood_pressure_diastolic) is
-// exercised against the real field names with no network.
-// withings-connector.real.test.ts re-fetches the live API to catch drift.
+/**
+ * Withings connector contract tests replay recorded API envelopes through the
+ * actual normalizer to pin real field-name mappings without network access.
+ */
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";

--- a/plugins/plugin-health/test/withings-connector.real.test.ts
+++ b/plugins/plugin-health/test/withings-connector.real.test.ts
@@ -1,13 +1,7 @@
-// Live drift check against the REAL Withings API (wbsapi.withings.net).
-//
-// Drives the actual syncWithings normalizer (via syncHealthConnectorData)
-// against the live API with a real access token and asserts the produced
-// HealthConnectorSyncPayload is still contract-shaped — catching drift from the
-// recorded fixture replayed keyless in withings-connector.contract.test.ts.
-//
-// Gated: opt-in via WITHINGS_LIVE_TEST=1 or the post-merge live lane
-// (TEST_LANE=post-merge) AND a token in WITHINGS_ACCESS_TOKEN. Skips cleanly
-// otherwise, so a token-less run is a no-op rather than a failure.
+/**
+ * Withings live drift tests run the real API normalizer when an access token
+ * and live-test lane are explicitly enabled.
+ */
 
 import { describe, expect, it } from "vitest";
 import { syncHealthConnectorData } from "../src/health-bridge/health-connectors.js";

--- a/plugins/plugin-health/vite.config.views.ts
+++ b/plugins/plugin-health/vite.config.views.ts
@@ -1,4 +1,6 @@
-/** Vite build config for the health view bundle (dist/views/bundle.js). */
+/**
+ * Vite build configuration for the health view bundle consumed by app hosts.
+ */
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
 export default createViewBundleConfig({

--- a/plugins/plugin-health/vitest.config.ts
+++ b/plugins/plugin-health/vitest.config.ts
@@ -1,4 +1,7 @@
-/** Vitest config for plugin-health, wiring the shared provider-SDK aliases. */
+/**
+ * Vitest configuration for plugin-health tests, provider SDK shims, and sibling
+ * scheduling source aliases.
+ */
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 import {
@@ -6,11 +9,7 @@ import {
   providerSdkShimPlugin,
 } from "../../packages/test/vitest/provider-sdk-aliases";
 
-// Resolve `@elizaos/plugin-scheduling` to its in-repo source so the
-// cross-plugin gate-coverage guard (default-packs/gate-coverage.test.ts)
-// exercises the sibling package's actual `registerBuiltInGates` — not a
-// stale prebuilt `dist` or a hoisted node_modules copy. Keyed on the package
-// root so subpath imports still resolve normally.
+// Cross-plugin gate coverage must exercise sibling source, not stale dist.
 const aliases = {
   ...providerSdkAliases,
   "@elizaos/tui": fileURLToPath(
@@ -28,8 +27,7 @@ export default defineConfig({
   },
   test: {
     alias: aliases,
-    // screen-time range helpers compute from the machine-local start of day;
-    // pin the zone so these assertions are deterministic across dev + CI.
+    // Pin local-day helpers so screen-time assertions match across dev and CI.
     env: { TZ: "America/Los_Angeles" },
     include: ["src/**/*.test.{ts,tsx}", "test/**/*.test.{ts,tsx}"],
     exclude: [

--- a/plugins/plugin-scheduling/src/index.ts
+++ b/plugins/plugin-scheduling/src/index.ts
@@ -1,6 +1,7 @@
-// The spine barrel (scheduled-task/index) already re-exports AnchorRegistry +
-// createAnchorRegistry from consolidation-policy, so surface only the
-// anchor-registry's own symbols here to avoid a duplicate-export collision.
+/**
+ * Scheduling package barrel exports the runner spine, routes, dispatch policy,
+ * plugin object, and anchor registry helpers for hosts.
+ */
 export {
   __resetAnchorRegistryForTests,
   APP_LIFEOPS_ANCHORS,

--- a/plugins/plugin-scheduling/src/plugin.ts
+++ b/plugins/plugin-scheduling/src/plugin.ts
@@ -1,3 +1,12 @@
+/**
+ * Scheduling plugin registration hosts the generic scheduled-task runner,
+ * routes, default-pack seeding, and fallback deps on every platform.
+ *
+ * Hosts inject production deps and domain packs via the runner deps and default
+ * pack registries; the built-in fallback pack only seeds when no host owns the
+ * runner. Each runtime keeps one runner service, one injected deps set, and one
+ * scheduled-task REST route.
+ */
 import { type IAgentRuntime, logger, type Plugin } from "@elizaos/core";
 import { buildSchedulingRoutes } from "./routes/plugin-routes.js";
 import { buildFallbackDefaultPack } from "./scheduled-task/default-pack.js";
@@ -12,38 +21,6 @@ import {
   seedRegisteredTaskPacks,
 } from "./scheduled-task/seed-registry.js";
 
-/**
- * `@elizaos/plugin-scheduling` — the scheduling spine, an always-loaded,
- * self-seeding runtime primitive.
- *
- * This plugin HOSTS the generic ScheduledTask runtime surface so scheduled
- * tasks run + serve their REST API + seed on ANY platform (including mobile)
- * from this plugin alone:
- *
- *  - the runner host `ScheduledTaskRunnerService` (built from the
- *    runtime-injected deps provider, or the built-in default deps),
- *  - the generic REST route at `/api/lifeops/scheduled-tasks`,
- *  - a boot seeder that materializes the generic default-task pack registry.
- *
- * Consumers (e.g. `@elizaos/plugin-personal-assistant`) inject production deps
- * via `registerScheduledTaskRunnerDeps` and register their domain packs via
- * `registerDefaultTaskPack`; when present, their deps win (first-wins). This
- * plugin imports neither `@elizaos/app-core`, `@elizaos/agent`, nor
- * `@elizaos/plugin-personal-assistant`.
- *
- * It ships ONE small, generic built-in fallback pack (`buildFallbackDefaultPack`
- * — a daily "Good morning" reminder + a paused "Weekly review" starter) that is
- * seeded ONLY when no consumer host is present. The consumer signal is the
- * injected deps provider: a host like PA calls `registerScheduledTaskRunnerDeps`
- * during its `init` (which completes before `runtime.initPromise` resolves), so
- * by seed time the spine knows whether a host owns the runner. When a host is
- * present its richer domain pack supersedes the fallback and the fallback is not
- * registered → no double-seed. On a stock mobile boot (no PA) the fallback seeds
- * so the home Tasks widget resolves.
- *
- * One runner/store invariant: a single runner service + a single injected deps
- * set + a single REST route per runtime (runtime first-wins dedup).
- */
 export const schedulingPlugin: Plugin = {
   name: "@elizaos/plugin-scheduling",
   description:

--- a/plugins/plugin-scheduling/src/scheduled-task/trigger-tz.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/trigger-tz.ts
@@ -1,10 +1,10 @@
+/**
+ * Trigger timezone helpers resolve owner-local cron triggers before they reach
+ * the core scheduler.
+ */
 import type { OwnerFactsView } from "./types.js";
 
-/**
- * Sentinel `tz` value on cron triggers meaning "the owner's timezone,
- * whatever it currently is". Default task packs use it so a pack authored
- * once fires at the owner's local hour everywhere.
- */
+/** Sentinel cron timezone that resolves to the owner's current timezone. */
 export const OWNER_LOCAL_TZ = "owner_local";
 
 /**

--- a/plugins/plugin-scheduling/vite.config.views.ts
+++ b/plugins/plugin-scheduling/vite.config.views.ts
@@ -1,5 +1,6 @@
-/** Vite build config for the `lifeops-live-test` view bundle (dist/views/bundle.js). */
-
+/**
+ * Vite build configuration for the scheduling live-test view bundle.
+ */
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
 export default createViewBundleConfig({

--- a/plugins/plugin-scheduling/vitest.config.ts
+++ b/plugins/plugin-scheduling/vitest.config.ts
@@ -1,5 +1,7 @@
-/** Vitest config for @elizaos/plugin-scheduling (node env + src/test globs). */
-
+/**
+ * Vitest configuration for scheduling runner and route tests in a Node
+ * environment.
+ */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Adds or repairs required top-of-file prose headers across the remaining `plugin-health` and `plugin-scheduling` files in #12803 scope.
- Rewrites long file-purpose/churn comments into durable present-tense headers and keeps only useful invariant notes in body comments.
- Leaves code tokens unchanged; this is a comment-only cleanup.

Closes #12803.

## Validation
- Read `plugins/plugin-health/CLAUDE.md` and `plugins/plugin-scheduling/CLAUDE.md`.
- PASS: scoped header audit
  - `plugins/plugin-health FILES=107 MISSING=0`
  - `plugins/plugin-scheduling FILES=48 MISSING=0`
- PASS: `bun run check:comment-only`
  - `[assert-comment-only-diff] OK — 27 source file(s) changed; every code token identical to origin/develop. Comments only.`
- PASS: `git diff --check -- plugins/plugin-health plugins/plugin-scheduling`
- PASS: `bun run --cwd plugins/plugin-health lint:check`
  - `Checked 116 files in 158ms. No fixes applied.`
- PASS: `bun run --cwd plugins/plugin-scheduling lint`
  - `Checked 46 files in 127ms. No fixes applied.`
- PASS: `bun run --cwd plugins/plugin-scheduling test`
  - `19 passed (19)`, `238 passed (238)`
- BLOCKED: `bun run verify`
  - Sparse checkout is missing `packages/auth/AGENTS.md`, so `check:agents-claude` fails before workspace verification starts.
- BLOCKED: `bun run --cwd plugins/plugin-scheduling typecheck`
  - Local dist-node dependency declaration resolution fails in shared logger/UI deps (`adze`, Capacitor packages, `lucide-react`, etc.).
- BLOCKED: `bun run --cwd plugins/plugin-health typecheck`
  - Local dist-node dependency declaration resolution fails in shared logger/TUI/UI deps, and the sparse workspace cannot resolve `@elizaos/plugin-scheduling` for one health gate-coverage test import.
- BLOCKED: `bun run --cwd plugins/plugin-health test`
  - After adding `packages/test` to the sparse checkout, 29 files pass and 4 are skipped, but 3 suites fail on local `@elizaos/ui` / `@elizaos/ui/spatial` package resolution.

## Evidence
- N/A - comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- N/A - no runtime, model, UI, audio, native, or domain behavior changed.

Refs #12803
