### PR TITLE
docs(#12758): clean music service prose headers

### DIFF
--- a/plugins/plugin-music/src/contracts.ts
+++ b/plugins/plugin-music/src/contracts.ts
@@ -1,3 +1,10 @@
+/**
+ * Audio broadcast contracts shared between the music playback engine and
+ * downstream consumers such as Discord voice or web stream listeners.
+ *
+ * The contracts keep playback fan-out independent of any connector plugin so
+ * slow or disconnected consumers cannot block the source broadcast.
+ */
 import type { EventEmitter } from "node:events";
 import type { Readable } from "node:stream";
 

--- a/plugins/plugin-music/src/discordVoice.ts
+++ b/plugins/plugin-music/src/discordVoice.ts
@@ -1,3 +1,7 @@
+/**
+ * Structural Discord voice types used by music playback without importing the
+ * Discord plugin at module load time.
+ */
 import type { VoiceManagerLike } from "./queue";
 
 /**

--- a/plugins/plugin-music/src/index.ts
+++ b/plugins/plugin-music/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Music plugin registration and public export surface for playback, library,
+ * metadata, routing, and streaming capabilities.
+ */
 import { type IAgentRuntime, logger, type Plugin } from "@elizaos/core";
 import { musicAction } from "./actions/music";
 import { musicInfoProvider } from "./providers/musicInfoProvider";

--- a/plugins/plugin-music/src/plugin-compression.test.ts
+++ b/plugins/plugin-music/src/plugin-compression.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Compression-shape tests for the music plugin's public action and provider
+ * surface using a deterministic in-memory runtime harness.
+ */
 import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import musicPlugin from "./index";

--- a/plugins/plugin-music/src/queue.ts
+++ b/plugins/plugin-music/src/queue.ts
@@ -1,3 +1,7 @@
+/**
+ * Per-guild playback queue and voice-manager bridge for music tracks, crossfade
+ * options, and broadcast handoff.
+ */
 import { EventEmitter } from "node:events";
 import { PassThrough, type Readable } from "node:stream";
 import { type IAgentRuntime, logger } from "@elizaos/core";

--- a/plugins/plugin-music/src/route-fallback.ts
+++ b/plugins/plugin-music/src/route-fallback.ts
@@ -1,3 +1,7 @@
+/**
+ * Compatibility response for legacy music-player status polling when the full
+ * music route plugin is absent.
+ */
 import type { ServerResponse } from "node:http";
 import type { AgentRuntime } from "@elizaos/core";
 

--- a/plugins/plugin-music/src/routes.ts
+++ b/plugins/plugin-music/src/routes.ts
@@ -1,3 +1,10 @@
+/**
+ * HTTP route handlers for music playback streams, queue inspection, now-playing
+ * metadata, and control commands.
+ *
+ * Streaming routes support both direct web clients and Shoutcast/Icecast-style
+ * metadata injection for players that expect interleaved track titles.
+ */
 import { Transform, type TransformCallback } from "node:stream";
 import type {
   IAgentRuntime,

--- a/plugins/plugin-music/src/search-category.test.ts
+++ b/plugins/plugin-music/src/search-category.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Deterministic registration tests for the music search category metadata that
+ * the runtime search surface consumes.
+ */
 import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-music/src/search-category.ts
+++ b/plugins/plugin-music/src/search-category.ts
@@ -1,3 +1,7 @@
+/**
+ * Runtime search category registrations for YouTube video search and Wikipedia
+ * music metadata lookup.
+ */
 import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
 
 export const YOUTUBE_SEARCH_CATEGORY: SearchCategoryRegistration = {

--- a/plugins/plugin-music/src/service.ts
+++ b/plugins/plugin-music/src/service.ts
@@ -1,3 +1,7 @@
+/**
+ * Music playback service that owns queues, broadcast streams, Discord voice
+ * wiring, audio routing, and optional library analytics hooks.
+ */
 import { type IAgentRuntime, logger, Service, type UUID } from "@elizaos/core";
 import type { BroadcastTrackMetadata, IAudioBroadcast } from "./contracts";
 import { Broadcast } from "./core";

--- a/plugins/plugin-music/src/services/audioCache.ts
+++ b/plugins/plugin-music/src/services/audioCache.ts
@@ -1,3 +1,10 @@
+/**
+ * Transient audio cache for yt-dlp downloads and Discord/web playback
+ * transcodes.
+ *
+ * The cache resolves ffmpeg and yt-dlp at runtime, stores reusable files under
+ * the configured cache directory, and keeps archive storage separate.
+ */
 import { exec, execFile } from "node:child_process";
 import {
   createReadStream,

--- a/plugins/plugin-music/src/services/geniusClient.ts
+++ b/plugins/plugin-music/src/services/geniusClient.ts
@@ -1,3 +1,7 @@
+/**
+ * Genius API client for resolving track pages and lyric metadata links used by
+ * music information enrichment.
+ */
 import { logger } from "@elizaos/core";
 import { type RetryableError, retryWithBackoff } from "../utils/retry";
 

--- a/plugins/plugin-music/src/services/lastFmClient.ts
+++ b/plugins/plugin-music/src/services/lastFmClient.ts
@@ -1,3 +1,7 @@
+/**
+ * Last.fm metadata client for optional artist, album, and track enrichment when
+ * a Last.fm API key is configured.
+ */
 import { logger } from "@elizaos/core";
 import type { AlbumInfo, ArtistInfo, TrackInfo } from "../types";
 import { type RetryableError, retryWithBackoff } from "../utils/retry";

--- a/plugins/plugin-music/src/services/musicBrainzClient.ts
+++ b/plugins/plugin-music/src/services/musicBrainzClient.ts
@@ -1,3 +1,7 @@
+/**
+ * MusicBrainz metadata client for zero-key artist, album, and recording lookup
+ * with retry behavior around the public API.
+ */
 import { logger } from "@elizaos/core";
 import type { AlbumInfo, ArtistInfo, TrackInfo } from "../types";
 import { retryWithBackoff } from "../utils/retry";

--- a/plugins/plugin-music/src/services/musicEntityDetectionService.ts
+++ b/plugins/plugin-music/src/services/musicEntityDetectionService.ts
@@ -1,3 +1,7 @@
+/**
+ * LLM-assisted music entity detection service for extracting artists, albums,
+ * and songs from conversation text.
+ */
 import { type IAgentRuntime, logger, ModelType } from "@elizaos/core";
 import { parseJsonObjectResponse } from "../utils/json";
 

--- a/plugins/plugin-music/src/services/musicInfoService.ts
+++ b/plugins/plugin-music/src/services/musicInfoService.ts
@@ -1,3 +1,7 @@
+/**
+ * Aggregated music metadata service that coordinates MusicBrainz and optional
+ * external enrichment providers.
+ */
 import { type IAgentRuntime, logger } from "@elizaos/core";
 import type {
   AlbumInfo,

--- a/plugins/plugin-music/src/services/musicLibraryService.ts
+++ b/plugins/plugin-music/src/services/musicLibraryService.ts
@@ -1,3 +1,7 @@
+/**
+ * Music library service that aggregates playlists, preferences, analytics,
+ * entity detection, metadata lookup, and recommendation helpers.
+ */
 import { type IAgentRuntime, logger, Service, type UUID } from "@elizaos/core";
 import {
   type DJAnalytics,

--- a/plugins/plugin-music/src/services/musicStorage.ts
+++ b/plugins/plugin-music/src/services/musicStorage.ts
@@ -1,3 +1,7 @@
+/**
+ * Permanent high-quality music archive storage for callers that want retained
+ * source files instead of the transient playback cache.
+ */
 import { exec } from "node:child_process";
 import {
   createReadStream,

--- a/plugins/plugin-music/src/services/smartMusicFetch.ts
+++ b/plugins/plugin-music/src/services/smartMusicFetch.ts
@@ -1,3 +1,7 @@
+/**
+ * Smart music fetch service that prefers library matches and can fall back to
+ * yt-dlp or optional torrent-provider services.
+ */
 import { type IAgentRuntime, logger, Service, type UUID } from "@elizaos/core";
 
 // Local contracts for the optional torrent peer plugins. They aren't always

--- a/plugins/plugin-music/src/services/spotifyClient.test.ts
+++ b/plugins/plugin-music/src/services/spotifyClient.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Deterministic Spotify recommendation tests for seed truncation and outbound
+ * request construction using a stubbed fetch implementation.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SpotifyClient, testExports } from "./spotifyClient";
 

--- a/plugins/plugin-music/src/services/spotifyClient.ts
+++ b/plugins/plugin-music/src/services/spotifyClient.ts
@@ -1,3 +1,7 @@
+/**
+ * Spotify Web API client for client-credentials authentication, track lookup,
+ * audio features, and recommendation requests.
+ */
 import { logger } from "@elizaos/core";
 import { Buffer } from "buffer";
 import type {

--- a/plugins/plugin-music/src/services/theAudioDbClient.ts
+++ b/plugins/plugin-music/src/services/theAudioDbClient.ts
@@ -1,3 +1,6 @@
+/**
+ * TheAudioDB metadata client for optional artist and album artwork enrichment.
+ */
 import { logger } from "@elizaos/core";
 import { type RetryableError, retryWithBackoff } from "../utils/retry";
 

--- a/plugins/plugin-music/src/services/wikipediaClient.ts
+++ b/plugins/plugin-music/src/services/wikipediaClient.ts
@@ -1,3 +1,7 @@
+/**
+ * Wikipedia music metadata client with shared conservative rate limiting for
+ * artist, album, and track background lookups.
+ */
 import { logger } from "@elizaos/core";
 import type { AlbumInfo, ArtistInfo, TrackInfo } from "../types";
 

--- a/plugins/plugin-music/src/services/wikipediaExtractionService.test.ts
+++ b/plugins/plugin-music/src/services/wikipediaExtractionService.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Deterministic Wikipedia extraction tests for prompt context and cache-key
+ * behavior using a stubbed text model.
+ */
 import { type IAgentRuntime, ModelType } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import type { WikipediaClient } from "./wikipediaClient";

--- a/plugins/plugin-music/src/services/wikipediaExtractionService.ts
+++ b/plugins/plugin-music/src/services/wikipediaExtractionService.ts
@@ -1,3 +1,7 @@
+/**
+ * LLM extraction helper that turns Wikipedia source data into structured music
+ * facts for provider and recommendation context.
+ */
 import { type IAgentRuntime, logger, ModelType } from "@elizaos/core";
 import type { AlbumInfo, ArtistInfo, TrackInfo } from "../types";
 import { parseJsonObjectResponse } from "../utils/json";

--- a/plugins/plugin-music/src/services/youtubeSearch.ts
+++ b/plugins/plugin-music/src/services/youtubeSearch.ts
@@ -1,3 +1,7 @@
+/**
+ * YouTube search service for video and music result metadata with cached
+ * play-dl lookups.
+ */
 import { logger } from "@elizaos/core";
 
 const YOUTUBE_SEARCH_SERVICE_NAME = "youtubeSearch";

--- a/plugins/plugin-music/src/utils/ffmpegEnv.ts
+++ b/plugins/plugin-music/src/utils/ffmpegEnv.ts
@@ -1,3 +1,7 @@
+/**
+ * FFmpeg and ffprobe binary resolution helpers for playback caching and stream
+ * normalization subprocesses.
+ */
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { delimiter, dirname } from "node:path";

--- a/plugins/plugin-music/src/utils/json.ts
+++ b/plugins/plugin-music/src/utils/json.ts
@@ -1,3 +1,7 @@
+/**
+ * JSON parsing helpers for model responses that may be wrapped in prose or
+ * fenced code blocks.
+ */
 export function parseJsonObjectResponse<T = Record<string, unknown>>(
   response: string,
 ): T | null {

--- a/plugins/plugin-music/src/utils/musicDebug.ts
+++ b/plugins/plugin-music/src/utils/musicDebug.ts
@@ -1,3 +1,7 @@
+/**
+ * Debug logging helpers for music subprocesses, stream setup, and cache
+ * diagnostics.
+ */
 import { logger } from "@elizaos/core";
 
 /** Set `ELIZA_MUSIC_DEBUG=1` for verbose music-player / cache / stream logs. */

--- a/plugins/plugin-music/src/utils/opusBroadcastNormalize.ts
+++ b/plugins/plugin-music/src/utils/opusBroadcastNormalize.ts
@@ -1,3 +1,7 @@
+/**
+ * Optional ffmpeg normalization pipeline for keeping broadcast Opus streams
+ * paced and playable for long-running consumers.
+ */
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { PassThrough, type Readable } from "node:stream";
 import { logger } from "@elizaos/core";

--- a/plugins/plugin-music/src/utils/progressiveMessage.ts
+++ b/plugins/plugin-music/src/utils/progressiveMessage.ts
@@ -1,3 +1,7 @@
+/**
+ * Progress-message adapter that provides Discord-style in-place status updates
+ * through the generic action callback contract.
+ */
 import type { HandlerCallback } from "@elizaos/core";
 
 /**

--- a/plugins/plugin-music/src/utils/resolveMusicGuildId.ts
+++ b/plugins/plugin-music/src/utils/resolveMusicGuildId.ts
@@ -1,3 +1,7 @@
+/**
+ * Guild-id resolution shared by playback control actions so web and Discord
+ * queues target the same active playback entry.
+ */
 import type { Memory } from "@elizaos/core";
 import type { MusicService } from "../service";
 

--- a/plugins/plugin-music/src/utils/smartFetchService.ts
+++ b/plugins/plugin-music/src/utils/smartFetchService.ts
@@ -1,3 +1,7 @@
+/**
+ * Structural accessors for the optional smart music fetch service used by
+ * download and play-query flows.
+ */
 import type { IAgentRuntime, UUID } from "@elizaos/core";
 
 export type MusicFetchProgress = {

--- a/plugins/plugin-music/src/utils/streamFallback.ts
+++ b/plugins/plugin-music/src/utils/streamFallback.ts
@@ -1,3 +1,6 @@
+/**
+ * Canonical yt-dlp-backed stream creation for music playback URLs.
+ */
 import type { Readable } from "node:stream";
 import { logger } from "@elizaos/core";
 import { createYtdlpStream } from "./ytdlpFallback";

--- a/plugins/plugin-music/src/utils/ytdlpCheck.ts
+++ b/plugins/plugin-music/src/utils/ytdlpCheck.ts
@@ -1,3 +1,7 @@
+/**
+ * yt-dlp executable discovery and installation diagnostics for playback and
+ * cache subprocesses.
+ */
 import { execSync } from "node:child_process";
 import { accessSync, constants, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";

--- a/plugins/plugin-music/src/utils/ytdlpCli.ts
+++ b/plugins/plugin-music/src/utils/ytdlpCli.ts
@@ -1,3 +1,7 @@
+/**
+ * yt-dlp command-line helpers for JavaScript runtime detection and shell-safe
+ * argument emission.
+ */
 import { basename, dirname } from "node:path";
 
 /**

--- a/plugins/plugin-music/src/utils/ytdlpFallback.ts
+++ b/plugins/plugin-music/src/utils/ytdlpFallback.ts
@@ -1,3 +1,7 @@
+/**
+ * yt-dlp streaming fallback that spawns the downloader, annotates failures, and
+ * exposes a readable stream for playback.
+ */
 import { spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { createReadStream, existsSync, unlinkSync } from "node:fs";

--- a/plugins/plugin-music/tsup.config.ts
+++ b/plugins/plugin-music/tsup.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Build configuration for publishing the music plugin as an ESM package with
+ * declaration output.
+ */
 import { defineConfig } from "tsup";
 
 export default defineConfig({

--- a/plugins/plugin-music/vitest.config.ts
+++ b/plugins/plugin-music/vitest.config.ts
@@ -1,3 +1,6 @@
+/**
+ * Vitest configuration for deterministic node-based music plugin tests.
+ */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Adds required top prose headers to the remaining 39 in-scope `plugins/plugin-music` source/config files.
- Covers service, route, queue, utility, config, and deterministic test files after the previously merged action/component slices.
- Keeps the change comment-only; no code tokens, exports, strings, or formatting semantics changed.

## Evidence
- Header audit: `source=93 missing=0`
- `bun run check:comment-only` — PASS, 39 source files changed and every code token identical to `origin/develop`
- `git diff --check origin/develop...HEAD` — PASS
- `git diff --name-only origin/develop...HEAD | xargs bunx @biomejs/biome check --config-path biome.json --files-ignore-unknown=true --no-errors-on-unmatched` — PASS, checked 39 files
- `bun run verify` — attempted; failed outside this branch in `@elizaos/plugin-xr:lint` because `plugins/plugin-xr/src/services/vision-pipeline.ts` needs Biome formatting around `runtime.reportError("VisionPipeline.describeFrame", err, { connectionId })`. Several repo-wide write-mode lint tasks also produced unrelated formatter writes; those generated writes were restored and are not part of this PR.

## Evidence N/A
- UI screenshots/video, frontend/backend logs, model trajectories, audio, and domain artifacts: N/A — comments-only change with zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
