### PR TITLE
fix(#12903): normalize rest api example scripts

### DIFF
--- a/.github/issue-evidence/12903-rest-api-script-contract.md
+++ b/.github/issue-evidence/12903-rest-api-script-contract.md
@@ -1,0 +1,89 @@
+# #12903 REST API example script-contract evidence
+
+Branch slice: normalize script contracts for the three REST API examples.
+
+## Packages
+
+- `packages/examples/rest-api/elysia`
+- `packages/examples/rest-api/express`
+- `packages/examples/rest-api/hono`
+
+## Script contract changes
+
+- Removed `build: bun run typecheck` from all three packages. These packages do
+  not emit build artifacts; `typecheck` remains the real TypeScript validation
+  command.
+- Added read-only `lint:check`.
+- Added `format` and read-only `format:check`.
+
+## Verification
+
+Current working tree: `origin/develop` at `75bb9c3411`.
+
+Static guard:
+
+```bash
+node - <<'NODE'
+const fs = require('fs');
+for (const p of ['packages/examples/rest-api/elysia/package.json','packages/examples/rest-api/express/package.json','packages/examples/rest-api/hono/package.json']) {
+  const pkg = JSON.parse(fs.readFileSync(p,'utf8'));
+  const scripts = pkg.scripts || {};
+  const bad = [];
+  if ('build' in scripts) bad.push(`build=${scripts.build}`);
+  if (!scripts.typecheck) bad.push('missing typecheck');
+  for (const name of ['lint:check','format','format:check']) if (!scripts[name]) bad.push(`missing ${name}`);
+  if (bad.length) { console.error(`${p}: ${bad.join('; ')}`); process.exitCode = 1; }
+  else console.log(`${p}: fake build removed; check verbs present`);
+}
+NODE
+```
+
+Result:
+
+```text
+packages/examples/rest-api/elysia/package.json: fake build removed; check verbs present
+packages/examples/rest-api/express/package.json: fake build removed; check verbs present
+packages/examples/rest-api/hono/package.json: fake build removed; check verbs present
+```
+
+Read-only lint and format:
+
+```bash
+bun run --cwd packages/examples/rest-api/elysia lint:check
+bun run --cwd packages/examples/rest-api/elysia format:check
+bun run --cwd packages/examples/rest-api/express lint:check
+bun run --cwd packages/examples/rest-api/express format:check
+bun run --cwd packages/examples/rest-api/hono lint:check
+bun run --cwd packages/examples/rest-api/hono format:check
+```
+
+Result:
+
+```text
+packages/examples/rest-api/elysia: biome check passed for 4 files; biome format passed for 4 files.
+packages/examples/rest-api/express: biome check passed for 4 files; biome format passed for 4 files.
+packages/examples/rest-api/hono: biome check passed for 4 files; biome format passed for 4 files.
+```
+
+## Local blockers
+
+This clean auxiliary worktree does not have a local workspace install. A
+temporary `node_modules -> /Users/shawwalters/eliza/node_modules` symlink starts
+the commands, but dependency resolution remains broken.
+
+Blocked commands and first failures:
+
+```text
+bun run --cwd packages/examples/rest-api/elysia typecheck
+bun run --cwd packages/examples/rest-api/express typecheck
+bun run --cwd packages/examples/rest-api/hono typecheck
+  error TS2688: Cannot find type definition file for 'node'
+
+bun run --cwd packages/examples/rest-api/elysia test
+bun run --cwd packages/examples/rest-api/express test
+bun run --cwd packages/examples/rest-api/hono test
+  ENOENT while resolving package '@elizaos/core'
+```
+
+This slice changes only package scripts; it does not change REST API runtime or
+test code.

--- a/packages/examples/rest-api/elysia/package.json
+++ b/packages/examples/rest-api/elysia/package.json
@@ -8,8 +8,10 @@
     "dev": "bun --watch run server.ts",
     "test": "bun test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "typecheck": "tsgo --noEmit",
-    "build": "bun run typecheck"
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/packages/examples/rest-api/express/package.json
+++ b/packages/examples/rest-api/express/package.json
@@ -8,8 +8,10 @@
     "dev": "bun --watch run server.ts",
     "test": "bun test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "typecheck": "tsgo --noEmit",
-    "build": "bun run typecheck"
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/packages/examples/rest-api/hono/package.json
+++ b/packages/examples/rest-api/hono/package.json
@@ -8,8 +8,10 @@
     "dev": "bun --watch run server.ts",
     "test": "bun test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "typecheck": "tsgo --noEmit",
-    "build": "bun run typecheck"
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",


### PR DESCRIPTION
## Summary

Fixes a #12903 script-normalization slice for the REST API examples:

- removes fake `build: bun run typecheck` scripts that emitted no artifacts
- keeps `typecheck` as the real TypeScript validation command
- adds `lint:check`, `format`, and `format:check`
- records evidence in `.github/issue-evidence/12903-rest-api-script-contract.md`

## Why

The #12903 package-script contract reserves `build` for scripts that emit artifacts. These examples are runnable TypeScript examples with tests and typechecks, but they do not produce package-level build output.

## Verification

- `git diff --check origin/develop..HEAD`
- JSON parse check for the edited `package.json` files
- static guard confirming `build` is removed, `typecheck` remains, and check verbs exist
- `bun run --cwd packages/examples/rest-api/elysia lint:check`
- `bun run --cwd packages/examples/rest-api/elysia format:check`
- `bun run --cwd packages/examples/rest-api/express lint:check`
- `bun run --cwd packages/examples/rest-api/express format:check`
- `bun run --cwd packages/examples/rest-api/hono lint:check`
- `bun run --cwd packages/examples/rest-api/hono format:check`

## Known local limitations

Full `bun install` / `bun run verify` were not run in this auxiliary worktree because the filesystem has about 4 GiB free. REST API `typecheck` and tests were attempted with a temporary shared `node_modules` symlink, but dependency resolution remains broken in that layout: `tsgo` cannot find `node` types and tests cannot resolve `@elizaos/core`. Details are in the evidence file.
