### PR TITLE
test(#12979): cover legacy A2A paid skill dispatch

### DIFF
--- a/.github/issue-evidence/12979-a2a-skill-money-guards.md
+++ b/.github/issue-evidence/12979-a2a-skill-money-guards.md
@@ -1,0 +1,38 @@
+# 12979 - A2A Skill Money Guards
+
+## Change Proven
+
+- `chat_with_agent` fails closed before agent dispatch or room creation.
+- `video_generation` / `generate_video` fail closed before credit reservation or generation-row creation.
+- Legacy A2A discovery no longer advertises the two disabled paid skills.
+- Legacy `message/send` dispatch reaches the same fail-closed guards for `chat_with_agent`, `video_generation`, and `generate_video`.
+
+## Commands Run
+
+```bash
+bun install --no-save --ignore-scripts --cache-dir "$HOME/.bun-install-cache-deploy"
+node packages/scripts/ensure-workspace-symlinks.mjs
+node packages/shared/scripts/generate-keywords.mjs --target ts
+bun run --cwd packages/contracts build
+bun run --cwd packages/cloud/routing build
+bun run build:core
+bun test --isolate --coverage-reporter=lcov packages/cloud/shared/src/lib/api/a2a/skills.money-guard.test.ts
+bunx @biomejs/biome check packages/cloud/shared/src/lib/api/a2a/skills.ts packages/cloud/shared/src/lib/api/a2a/handlers.ts packages/cloud/shared/src/lib/api/a2a/skills.money-guard.test.ts .github/issue-evidence/12979-a2a-skill-money-guards.md
+bun run --cwd packages/cloud/shared typecheck
+bun run --cwd packages/cloud/shared lint
+git diff --check
+```
+
+## Manual Review Notes
+
+- Reviewed `packages/cloud/shared/src/lib/api/a2a/skills.ts`: both exported unsafe skills call `rejectUnwiredPaidSkill(...)` before reading payload fields, reserving credits, creating generation rows, or dispatching to an agent.
+- Reviewed `packages/cloud/shared/src/lib/api/a2a/handlers.ts`: legacy discovery omits `chat_with_agent` and `video_generation`; direct legacy dispatch still calls the exported fail-closed guards if callers send those skill ids.
+- Reviewed `packages/cloud/shared/src/lib/api/a2a/skills.money-guard.test.ts`: tests use throwing dependency mocks for paid/model/provider paths, prove direct exports fail before context access, cover all three legacy dispatch ids, and assert discovery removal.
+- The focused test exited 0 with `4 pass`, `0 fail`, and `13 expect()` calls.
+
+## Evidence N/A
+
+- Real LLM trajectories: N/A - this change disables latent dead-code skill paths and does not invoke a model.
+- UI screenshots/video/front-end logs: N/A - no UI or frontend route changed.
+- Backend live request logs / cloud stack: N/A - the affected legacy skills are intentionally fail-closed before live paid service dispatch; the regression test proves no paid/model/provider side effects occur.
+- DB rows / billing records: N/A - successful behavior is absence of credit reservations, generation rows, and agent dispatch.

--- a/packages/cloud/shared/src/lib/api/a2a/skills.money-guard.test.ts
+++ b/packages/cloud/shared/src/lib/api/a2a/skills.money-guard.test.ts
@@ -6,12 +6,17 @@
  * branch runs first.
  */
 
-import { describe, expect, mock, test } from "bun:test";
-import type { A2AContext } from "./types";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { A2AContext, MessageSendParams } from "./types";
 
 function unexpectedDependencyCall(name: string): never {
   throw new Error(`${name} should not run in A2A money guard tests`);
 }
+
+const storeTask = mock(async () => undefined);
+const addMessageToHistory = mock(async () => undefined);
+const shouldBlockUser = mock(async () => false);
+const moderateInBackground = mock(() => undefined);
 
 mock.module("ai", () => ({
   APICallError: class APICallError extends Error {},
@@ -166,18 +171,17 @@ mock.module("../../services/usage", () => ({
 mock.module("../../services/a2a-task-store", () => ({
   a2aTaskStoreService: {
     addArtifact: () => unexpectedDependencyCall("a2aTaskStoreService.addArtifact"),
-    addMessageToHistory: () => unexpectedDependencyCall("a2aTaskStoreService.addMessageToHistory"),
+    addMessageToHistory,
     get: () => unexpectedDependencyCall("a2aTaskStoreService.get"),
-    set: () => unexpectedDependencyCall("a2aTaskStoreService.set"),
+    set: storeTask,
     updateTaskState: () => unexpectedDependencyCall("a2aTaskStoreService.updateTaskState"),
   },
 }));
 
 mock.module("../../services/content-moderation", () => ({
   contentModerationService: {
-    moderateInBackground: () =>
-      unexpectedDependencyCall("contentModerationService.moderateInBackground"),
-    shouldBlockUser: () => unexpectedDependencyCall("contentModerationService.shouldBlockUser"),
+    moderateInBackground,
+    shouldBlockUser,
   },
 }));
 
@@ -188,6 +192,32 @@ mock.module("../../utils/logger", () => ({
 }));
 
 const unusableContext = undefined as unknown as A2AContext;
+const handlerContext = {
+  apiKeyId: "api-key-1",
+  agentIdentifier: "a2a-test-agent",
+  user: {
+    id: "user-1",
+    email: "test@example.com",
+    name: "Test User",
+    organization_id: "org-1",
+    organization: {
+      id: "org-1",
+      name: "Test Org",
+      credit_balance: "100",
+    },
+  },
+} as A2AContext;
+
+function resetAllowedMocks() {
+  storeTask.mockClear();
+  addMessageToHistory.mockClear();
+  shouldBlockUser.mockClear();
+  moderateInBackground.mockClear();
+}
+
+beforeEach(() => {
+  resetAllowedMocks();
+});
 
 describe("A2A latent paid skill guards", () => {
   test("chat_with_agent fails closed before agent dispatch", async () => {
@@ -208,6 +238,34 @@ describe("A2A latent paid skill guards", () => {
     ).rejects.toThrow(
       "A2A skill 'video_generation' is disabled until it is wired through the billed delivery path",
     );
+  });
+
+  test("legacy message/send dispatch reaches disabled paid skill guards", async () => {
+    const { handleMessageSend } = await import("./handlers");
+
+    for (const skillId of ["chat_with_agent", "video_generation", "generate_video"]) {
+      resetAllowedMocks();
+      const params: MessageSendParams = {
+        message: {
+          role: "user",
+          parts: [
+            { type: "text", text: "make a video" },
+            { type: "data", data: { skill: skillId, prompt: "make a video" } },
+          ],
+        },
+        metadata: {
+          taskId: `task-${skillId}`,
+          contextId: `context-${skillId}`,
+        },
+      };
+
+      await expect(handleMessageSend(params, handlerContext)).rejects.toThrow(
+        "disabled until it is wired through the billed delivery path",
+      );
+
+      expect(storeTask).toHaveBeenCalledTimes(1);
+      expect(addMessageToHistory).toHaveBeenCalledTimes(1);
+    }
   });
 
   test("disabled money skills are not advertised for A2A discovery", async () => {


### PR DESCRIPTION
## Summary
- Add legacy `message/send` coverage for the disabled paid A2A skill ids: `chat_with_agent`, `video_generation`, and `generate_video`.
- Add the required issue evidence artifact for #12979 after #13020 merged the fail-closed guard.

Follow-up to #13020 / #12979.

## Evidence
- `.github/issue-evidence/12979-a2a-skill-money-guards.md`
- `bun test --isolate --coverage-reporter=lcov packages/cloud/shared/src/lib/api/a2a/skills.money-guard.test.ts` — PASS, 4 tests, 13 assertions
- `bun run --cwd packages/cloud/shared typecheck` — PASS
- `bun run --cwd packages/cloud/shared lint` — PASS
- `git diff --check origin/develop..HEAD` — PASS

## Evidence N/A
- UI screenshots/video/frontend logs: N/A — backend-only fail-closed guard test/evidence follow-up.
- Real LLM trajectories: N/A — no model path is invoked; the tests prove disabled paths do not reach model/provider services.
- DB/billing artifacts: N/A — expected behavior is absence of credit reservations, generation rows, and agent dispatch.
