### PR TITLE
docs(#12805): clean small assistant plugin prose headers

### DIFF
--- a/plugins/plugin-commands/__tests__/model-switch-command.test.ts
+++ b/plugins/plugin-commands/__tests__/model-switch-command.test.ts
@@ -1,7 +1,7 @@
-// Coverage for `/model local|cloud [id]` routing through the shared
-// runtime-switch loopback route (#12178). The route HTTP is stubbed via a
-// mocked global fetch; a bare `/model <name>` must NOT hit the route (it stays
-// a per-room preference).
+/**
+ * Model command tests cover local/cloud runtime switching through a stubbed
+ * loopback route while preserving per-room model preference behavior.
+ */
 
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-commands/auto-enable.ts
+++ b/plugins/plugin-commands/auto-enable.ts
@@ -1,9 +1,7 @@
-// Auto-enable check for @elizaos/plugin-commands.
-//
-// Plugin manifest entry-point — referenced by package.json's
-// `elizaos.plugin.autoEnableModule`. Keep this module light: env reads only,
-// no service init, no transitive imports of the full plugin runtime. The
-// auto-enable engine loads dozens of these per boot.
+/**
+ * Commands auto-enable probe reads character feature config without importing
+ * the full plugin runtime.
+ */
 import type { PluginAutoEnableContext } from "@elizaos/core";
 
 function isFeatureEnabled(
@@ -18,7 +16,7 @@ function isFeatureEnabled(
 	return false;
 }
 
-/** Enable when `config.features.commands` is truthy / not explicitly disabled. */
+/** Enable when `config.features.commands` is truthy or not explicitly disabled. */
 export function shouldEnable(ctx: PluginAutoEnableContext): boolean {
 	return isFeatureEnabled(ctx.config, "commands");
 }

--- a/plugins/plugin-commands/index.ts
+++ b/plugins/plugin-commands/index.ts
@@ -1,3 +1,5 @@
-/** Package entry barrel: re-exports the plugin surface from `src/index`. */
+/**
+ * Package entry barrel re-exports the commands plugin surface.
+ */
 export * from "./src/index";
 export { default } from "./src/index";

--- a/plugins/plugin-commands/vitest.config.ts
+++ b/plugins/plugin-commands/vitest.config.ts
@@ -1,4 +1,6 @@
-/** Vitest config for @elizaos/plugin-commands: runs the node-environment unit suite. */
+/**
+ * Vitest configuration for command parser and action tests in Node.
+ */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-form/auto-enable.ts
+++ b/plugins/plugin-form/auto-enable.ts
@@ -1,9 +1,7 @@
-// Auto-enable check for @elizaos/plugin-form.
-//
-// Plugin manifest entry-point — referenced by package.json's
-// `elizaos.plugin.autoEnableModule`. Keep this module light: env reads only,
-// no service init, no transitive imports of the full plugin runtime. The
-// auto-enable engine loads dozens of these per boot.
+/**
+ * Form auto-enable probe reads character feature config without importing the
+ * full plugin runtime.
+ */
 import type { PluginAutoEnableContext } from "@elizaos/core";
 
 function isFeatureEnabled(
@@ -18,7 +16,7 @@ function isFeatureEnabled(
   return false;
 }
 
-/** Enable when `config.features.form` is truthy / not explicitly disabled. */
+/** Enable when `config.features.form` is truthy or not explicitly disabled. */
 export function shouldEnable(ctx: PluginAutoEnableContext): boolean {
   return isFeatureEnabled(ctx.config, "form");
 }

--- a/plugins/plugin-form/vitest.config.ts
+++ b/plugins/plugin-form/vitest.config.ts
@@ -1,4 +1,7 @@
-/** Vitest config for @elizaos/plugin-form: runs the node unit suite, gating the live extraction tests to the post-merge lane. */
+/**
+ * Vitest configuration for form unit tests and post-merge-gated live extraction
+ * suites.
+ */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -8,9 +11,7 @@ export default defineConfig({
     exclude: [
       "dist/**",
       "node_modules/**",
-      // #9310 §E: the guarded *.live.test.ts suite (self-skips keyless) is
-      // invocable only in the post-merge lane, where run-all-tests.mjs
-      // prints a named skip accounting.
+      // Live extraction tests self-skip keyless and only run in post-merge.
       ...(process.env.VITEST_LANE === "post-merge"
         ? []
         : ["src/**/*.live.test.ts", "test/**/*.live.test.ts"]),

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.test.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.test.tsx
@@ -1,4 +1,7 @@
-/** Render tests for the relationships spatial view over the TUI surface (deterministic static markup, no live runtime). */
+/**
+ * Relationships spatial view tests render deterministic HTML and TUI markup
+ * without a live runtime.
+ */
 import { visibleWidth } from "@elizaos/tui";
 import { SpatialSurface } from "@elizaos/ui/spatial";
 import {

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsView.test.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsView.test.tsx
@@ -1,6 +1,6 @@
-// @vitest-environment jsdom
-
 /**
+ * @vitest-environment jsdom
+ *
  * Drives the unified RelationshipsView (the single GUI/XR data wrapper) through
  * the rendered DOM: the same component the bundle exports for both the "gui" and
  * "xr" modalities. It is a read-only entity/relationship graph viewer over the
@@ -24,8 +24,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-// `@elizaos/ui` is the giant renderer barrel; RelationshipsView only touches
-// `client.getBaseUrl()` (default fetcher seam, overridden in every test) and
+// RelationshipsView only touches client.getBaseUrl and sendChatMessage here.
 // `client.sendChatMessage()` (add-someone + open-entity affordances). The
 // spatial primitives come from the separate `@elizaos/ui/spatial` subpath, which
 // is not mocked.

--- a/plugins/plugin-relationships/src/components/relationships/relationships-view-bundle.ts
+++ b/plugins/plugin-relationships/src/components/relationships/relationships-view-bundle.ts
@@ -1,5 +1,5 @@
-// Vite view-bundle entry. The built bundle (dist/views/bundle.js) exposes the
-// named export `RelationshipsView` the view loader reads via
-// __ELIZA_VIEW_EXPORT__. Kept separate from RelationshipsView.tsx so that file
-// exports only React components and stays Fast-Refresh-compatible in dev.
+/**
+ * Relationships view-bundle entry exposes RelationshipsView for the app view
+ * loader while keeping the component module React-only.
+ */
 export { RelationshipsView } from "./RelationshipsView.tsx";

--- a/plugins/plugin-relationships/src/db/index.ts
+++ b/plugins/plugin-relationships/src/db/index.ts
@@ -1,2 +1,4 @@
-/** Barrel for the relationships knowledge-graph drizzle schema. */
+/**
+ * Barrel for the relationships knowledge-graph drizzle schema.
+ */
 export * from "./schema.js";

--- a/plugins/plugin-relationships/src/db/schema.ts
+++ b/plugins/plugin-relationships/src/db/schema.ts
@@ -1,3 +1,7 @@
+/**
+ * Relationships drizzle schema defines the minimal entity and relationship graph
+ * tables registered by the plugin runtime.
+ */
 import { sql } from "drizzle-orm";
 import {
   index,
@@ -8,22 +12,6 @@ import {
   uuid,
 } from "drizzle-orm/pg-core";
 
-/**
- * Drizzle schema for the relationships knowledge graph.
- *
- * Backs the `@elizaos/plugin-relationships` plugin. The runtime registers
- * migrations from this schema via the plugin object's `schema` field.
- *
- * Tables:
- *   - `entities`      — nodes (person/org/place/project/concept)
- *   - `relationships` — typed edges between entities
- *
- * NOTE: This is a minimal scaffold. The full LifeOps EntityStore and
- * RelationshipStore (see `plugins/plugin-personal-assistant/src/lifeops/entities/store.ts`
- * and `plugins/plugin-personal-assistant/src/lifeops/relationships/store.ts`) carry
- * richer per-row state (identities array, attributes map, retired status,
- * sentiment trend, …). Migration of those columns lands in a follow-up.
- */
 export const relationshipsSchema = pgSchema("app_relationships");
 
 export const entitiesTable = relationshipsSchema.table(

--- a/plugins/plugin-relationships/src/plugin.test.ts
+++ b/plugins/plugin-relationships/src/plugin.test.ts
@@ -1,4 +1,7 @@
-/** Contract tests asserting @elizaos/plugin-relationships registers its action, provider, and schema. */
+/**
+ * Relationships plugin contract tests assert action, provider, schema, and view
+ * registration without a live database.
+ */
 import { describe, expect, it } from "vitest";
 
 import { entityAction } from "./actions/entity.js";
@@ -25,7 +28,7 @@ describe("@elizaos/plugin-relationships contract", () => {
   });
 
   it("registers the graph-CRUD action as KNOWLEDGE_GRAPH, not ENTITY", () => {
-    // PA owns the ENTITY action; this plugin must not collide with it.
+    // Personal Assistant owns ENTITY, so this plugin must not collide with it.
     expect(entityAction.name).toBe(RELATIONSHIPS_ACTION_NAME);
     expect(entityAction.name).toBe("KNOWLEDGE_GRAPH");
     expect(entityAction.name).not.toBe("ENTITY");

--- a/plugins/plugin-relationships/src/plugin.ts
+++ b/plugins/plugin-relationships/src/plugin.ts
@@ -1,28 +1,13 @@
+/**
+ * Relationships plugin registration adds graph CRUD, planner context, schema,
+ * and the dashboard viewer over the runtime knowledge graph service.
+ */
 import type { Plugin } from "@elizaos/core";
 
 import { entityAction } from "./actions/entity.js";
 import * as dbSchema from "./db/index.js";
 import { entityGraphProvider } from "./providers/entity-graph.js";
 
-/**
- * `@elizaos/plugin-relationships`
- *
- * The relationships viewer + "extras" over the runtime knowledge graph. The
- * graph itself (`EntityStore` / `RelationshipStore`) is owned by the runtime:
- * `@elizaos/agent`'s `KnowledgeGraphService`. This plugin consumes it via
- * `resolveKnowledgeGraphService(runtime)` and adds:
- *   - the `KNOWLEDGE_GRAPH` graph-CRUD action,
- *   - the `ENTITY_GRAPH` planner-context provider,
- *   - the `/relationships` viewer.
- *
- * It does NOT register an `ENTITY` action — `@elizaos/plugin-personal-assistant`
- * owns that (rich Rolodex orchestration with an LLM planner). Keeping a
- * distinct action name avoids a duplicate `ENTITY` registration when both
- * plugins load together.
- *
- * Hard-depends on `@elizaos/plugin-sql` — the runtime registers migrations
- * from `schema` (this module's drizzle pgSchema('app_relationships')).
- */
 export const relationshipsPlugin: Plugin = {
   name: "relationships",
   description:

--- a/plugins/plugin-relationships/vite.config.views.ts
+++ b/plugins/plugin-relationships/vite.config.views.ts
@@ -1,4 +1,6 @@
-/** Vite bundle config for the relationships dashboard view (emits to dist/views). */
+/**
+ * Vite build configuration for the relationships dashboard view bundle.
+ */
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
 export default createViewBundleConfig({

--- a/plugins/plugin-relationships/vitest.config.ts
+++ b/plugins/plugin-relationships/vitest.config.ts
@@ -1,4 +1,7 @@
-/** Vitest config for @elizaos/plugin-relationships: extends the shared base config with the package's local aliases. */
+/**
+ * Vitest configuration for relationships contract and React view tests with
+ * shared workspace aliases.
+ */
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -11,12 +14,7 @@ const baseAliases = Array.isArray(baseConfig.resolve?.alias)
   ? baseConfig.resolve.alias
   : [];
 
-// The unit suite covers the RelationshipsView render + kind-filter + refresh +
-// retry interaction (src/components/relationships/RelationshipsView.test.tsx,
-// jsdom via per-file directive) and the existing scaffold contract guard
-// (src/plugin.test.ts, node env). The base config supplies the @elizaos/* source
-// aliases that plugin.ts needs; the React aliases below pin a single React copy
-// so jsdom does not mix the workspace and hoisted peers (mirrors plugin-inbox).
+// Pin one React copy so jsdom tests do not mix workspace and hoisted peers.
 const liveOnlyExcludes = [
   "dist/**",
   "**/node_modules/**",

--- a/plugins/plugin-todos/build.ts
+++ b/plugins/plugin-todos/build.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env bun
-/** Build entry for @elizaos/plugin-todos: bundles the Node plugin and the browser view through the shared buildPlugin helper. */
+/**
+ * Build entry for plugin-todos bundles the Node plugin and browser view through
+ * the shared plugin build helper.
+ */
 import { buildPlugin } from "../plugin-build";
 
 await buildPlugin({

--- a/plugins/plugin-todos/src/actions/todo.test.ts
+++ b/plugins/plugin-todos/src/actions/todo.test.ts
@@ -1,4 +1,7 @@
-/** Unit tests for the TODO umbrella action and CURRENT_TODOS provider, driven against a deterministic in-memory FakeTodosService (no live database). */
+/**
+ * Todo action tests cover the TODO umbrella action and CURRENT_TODOS provider
+ * against a deterministic in-memory service with no live database.
+ */
 import type {
   ActionResult,
   HandlerOptions,

--- a/plugins/plugin-todos/src/components/todos/TodosSpatialView.test.tsx
+++ b/plugins/plugin-todos/src/components/todos/TodosSpatialView.test.tsx
@@ -1,4 +1,7 @@
-/** Render tests for the todos spatial view over the TUI surface (deterministic static markup). */
+/**
+ * Todos spatial view tests render deterministic HTML and TUI markup without a
+ * live runtime.
+ */
 import { visibleWidth } from "@elizaos/tui";
 import { SpatialSurface } from "@elizaos/ui/spatial";
 import {

--- a/plugins/plugin-todos/src/components/todos/TodosView.test.tsx
+++ b/plugins/plugin-todos/src/components/todos/TodosView.test.tsx
@@ -1,6 +1,6 @@
-// @vitest-environment jsdom
-
 /**
+ * @vitest-environment jsdom
+ *
  * Drives the unified TodosView (the single GUI/XR data wrapper) through the
  * rendered DOM: the same component the bundle exports for both the "gui" and
  * "xr" modalities. It is a read-only three-lane board (Today / Upcoming /

--- a/plugins/plugin-todos/src/components/todos/todos-view-bundle.ts
+++ b/plugins/plugin-todos/src/components/todos/todos-view-bundle.ts
@@ -1,5 +1,5 @@
-// Vite view-bundle entry. Re-exports the TodosView component so the built
-// bundle (dist/views/bundle.js) exposes the named export the view loader reads.
-// Kept separate from TodosView.tsx so that file exports only React components
-// and stays Fast-Refresh-compatible in dev.
+/**
+ * Todos view-bundle entry exposes TodosView for the app view loader while
+ * keeping the component module React-only.
+ */
 export { TodosView } from "./TodosView.js";

--- a/plugins/plugin-todos/src/db/index.ts
+++ b/plugins/plugin-todos/src/db/index.ts
@@ -1,2 +1,4 @@
-/** Barrel for the plugin-todos drizzle schema. */
+/**
+ * Barrel for the plugin-todos drizzle schema.
+ */
 export * from "./schema.js";

--- a/plugins/plugin-todos/src/providers/current-todos.ts
+++ b/plugins/plugin-todos/src/providers/current-todos.ts
@@ -1,4 +1,7 @@
-/** CURRENT_TODOS provider (position -5): injects the user's pending + in-progress todos as a markdown checklist into the planner context each turn in the tasks/todos/automation contexts. */
+/**
+ * CURRENT_TODOS provider injects active todos into task planning context each
+ * turn for tasks, todos, and automation conversations.
+ */
 import type {
   IAgentRuntime,
   Memory,
@@ -25,7 +28,6 @@ function checkboxFor(status: Todo["status"]): string {
 
 /**
  * Surface the user's current todo list to the planner each turn.
- * Mirrors how Claude Code keeps the TodoWrite list in the model's context.
  * Returns empty text when the user has no active todos.
  *
  * Scoping: by `entityId` (user) — todos persist across rooms for the same user.

--- a/plugins/plugin-todos/src/types.ts
+++ b/plugins/plugin-todos/src/types.ts
@@ -1,4 +1,7 @@
-/** Shared constants and types for @elizaos/plugin-todos: the service type + log prefix, the todo status enum, and the provider context tags. */
+/**
+ * Shared todo constants and types define service identity, statuses, actions,
+ * and planner context tags.
+ */
 export const TODOS_LOG_PREFIX = "[Todos]";
 export const TODOS_SERVICE_TYPE = "todos";
 

--- a/plugins/plugin-todos/vite.config.views.ts
+++ b/plugins/plugin-todos/vite.config.views.ts
@@ -1,4 +1,6 @@
-/** Vite bundle config for the todos dashboard view (emits to dist/views). */
+/**
+ * Vite build configuration for the todos dashboard view bundle.
+ */
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
 export default createViewBundleConfig({

--- a/plugins/plugin-todos/vitest.config.ts
+++ b/plugins/plugin-todos/vitest.config.ts
@@ -1,4 +1,7 @@
-/** Vitest config for @elizaos/plugin-todos: pins node resolution conditions for the SQL-backed suite. */
+/**
+ * Vitest configuration for todos action, provider, and view tests with Node
+ * resolution conditions.
+ */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Adds or repairs required top-of-file prose headers across `plugin-todos`, `plugin-relationships`, `plugin-form`, and `plugin-commands`.
- Converts one-line file comments and churn-style file-purpose comments into durable prose headers.
- Leaves code tokens unchanged; this is comment-only cleanup.

Closes #12805.

## Validation
- Read package-local guides for `plugin-todos`, `plugin-relationships`, `plugin-form`, and `plugin-commands`.
- PASS: scoped header audit
  - `plugins/plugin-todos FILES=20 MISSING=0`
  - `plugins/plugin-relationships FILES=20 MISSING=0`
  - `plugins/plugin-form FILES=21 MISSING=0`
  - `plugins/plugin-commands FILES=28 MISSING=0`
- PASS: `bun run check:comment-only`
  - `[assert-comment-only-diff] OK — 25 source file(s) changed; every code token identical to origin/develop. Comments only.`
- PASS: `git diff --check -- plugins/plugin-todos plugins/plugin-relationships plugins/plugin-form plugins/plugin-commands`
- PASS: changed-file Biome check
  - `Checked 25 files in 71ms. No fixes applied.`
- PASS: `bun run --cwd plugins/plugin-commands test`
  - `8 passed (8)`, `84 passed (84)`
- PASS: `bun run --cwd plugins/plugin-form test`
  - `3 passed (3)`, `22 passed (22)`
- BLOCKED: `bun run verify`
  - Sparse checkout is missing `packages/auth/AGENTS.md`, so `check:agents-claude` fails before workspace verification starts.
- BLOCKED: `bun run --cwd plugins/plugin-todos test`
  - 2 files pass / 34 tests pass, but 3 suites fail on local sparse dependency resolution: `@elizaos/vault`, `@elizaos/ui`, and `@elizaos/ui/spatial`.
- BLOCKED: `bun run --cwd plugins/plugin-relationships test`
  - 3 files pass / 28 tests pass, but 3 suites fail on local sparse dependency resolution: `@elizaos/auth` and `webxr-polyfill` via the shared UI spatial runtime.

## Evidence
- N/A - comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- N/A - no runtime, model, UI, audio, native, or domain behavior changed.

Refs #12805
