### PR TITLE
fix(#12903): normalize vercel example scripts

### DIFF
--- a/.github/issue-evidence/12903-vercel-script-contract.md
+++ b/.github/issue-evidence/12903-vercel-script-contract.md
@@ -1,0 +1,74 @@
+# #12903 Vercel example script-contract evidence
+
+Branch slice: normalize the Vercel Edge example package scripts.
+
+## Package
+
+- `packages/examples/vercel`
+
+## Script contract changes
+
+- Removed `build: tsc --noEmit`; it emitted no build artifact and duplicated
+  the existing `typecheck` command.
+- Removed the `|| echo ... skipping` test wrapper. `test-client.ts` already
+  handles a missing local endpoint and exits 0 with instructions, so the wrapper
+  only hid real command failures.
+- Added `format` and read-only `format:check`.
+
+## Verification
+
+Current working tree: `origin/develop` at `9f93cee71f`.
+
+Static guard:
+
+```bash
+node - <<'NODE'
+const fs = require('fs');
+const p = 'packages/examples/vercel/package.json';
+const pkg = JSON.parse(fs.readFileSync(p,'utf8'));
+const scripts = pkg.scripts || {};
+const bad = [];
+if ('build' in scripts) bad.push(`build=${scripts.build}`);
+for (const [name, body] of Object.entries(scripts)) if (/\|\|\s*true|\|\|\s*echo|echo .*skipping|tsc\s+--noEmit/.test(body)) bad.push(`${name}=${body}`);
+for (const name of ['lint:check','format','format:check','typecheck','test']) if (!scripts[name]) bad.push(`missing ${name}`);
+if (bad.length) { console.error(bad.join('\n')); process.exit(1); }
+console.log('vercel scripts normalized');
+NODE
+```
+
+Result:
+
+```text
+vercel scripts normalized
+```
+
+Commands:
+
+```bash
+bun run --cwd packages/examples/vercel lint:check
+bun run --cwd packages/examples/vercel format:check
+bun run --cwd packages/examples/vercel test
+```
+
+Result:
+
+```text
+biome check passed for 6 files.
+biome format passed for 6 files.
+test-client.ts exited 0 through its built-in no-server path:
+  Server not available at http://localhost:3000
+  Tests skipped (no server running)
+```
+
+## Local blocker
+
+`typecheck` was attempted with a temporary
+`node_modules -> /Users/shawwalters/eliza/node_modules` symlink. Dependency
+resolution remains broken in this auxiliary worktree:
+
+```text
+bun run --cwd packages/examples/vercel typecheck
+  error TS2688: Cannot find type definition file for 'node'
+```
+
+This slice changes only package scripts; it does not change Vercel runtime code.

--- a/packages/examples/vercel/package.json
+++ b/packages/examples/vercel/package.json
@@ -5,13 +5,14 @@
   "description": "elizaOS Vercel Edge Function examples (TypeScript)",
   "scripts": {
     "dev": "vercel dev",
-    "build": "tsc --noEmit",
     "deploy": "vercel deploy",
     "deploy:prod": "vercel deploy --prod",
-    "test": "bun run test-client.ts || echo 'Vercel edge tests require running API endpoint - skipping'",
+    "test": "bun run test-client.ts",
     "clean": "node ../../scripts/rm-path-recursive.mjs dist .vercel",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Fixes a #12903 script-normalization slice for `packages/examples/vercel`:

- removes fake `build: tsc --noEmit` in favor of the existing `typecheck`
- removes the `|| echo ... skipping` wrapper from `test`; `test-client.ts` already exits 0 for the no-server case and should be allowed to fail for real command errors
- adds `format` and `format:check`
- records evidence in `.github/issue-evidence/12903-vercel-script-contract.md`

## Why

The #12903 contract reserves `build` for emitted artifacts and disallows fake-success wrappers. The Vercel test client already handles the optional live endpoint internally, so the package script does not need to mask failures.

## Verification

- `git diff --check origin/develop..HEAD`
- JSON parse check for `packages/examples/vercel/package.json`
- static guard confirming no fake build, no masked test wrapper, and required check verbs present
- `bun run --cwd packages/examples/vercel lint:check`
- `bun run --cwd packages/examples/vercel format:check`
- `bun run --cwd packages/examples/vercel test`

## Known local limitations

Full `bun install` / `bun run verify` were not run in this auxiliary worktree because the filesystem has about 4 GiB free. `typecheck` was attempted with a temporary shared `node_modules` symlink, but `tsgo` cannot find the `node` type library in that layout. Details are in the evidence file.
