### PR TITLE
fix(#12903): normalize a2a example scripts

### DIFF
--- a/.github/issue-evidence/12903-a2a-script-contract.md
+++ b/.github/issue-evidence/12903-a2a-script-contract.md
@@ -1,0 +1,66 @@
+# #12903 A2A example script-contract evidence
+
+Branch slice: normalize `packages/examples/a2a` package scripts.
+
+## Script contract changes
+
+- Removed `build: bun run typecheck`; it emitted no build artifact.
+- Kept `typecheck` as the real TypeScript validation command.
+- Added read-only `lint:check`.
+- Added `format` and read-only `format:check`.
+
+## Verification
+
+Current working tree: `origin/develop` at `9f93cee71f`.
+
+Static guard:
+
+```bash
+node - <<'NODE'
+const fs = require('fs');
+const p = 'packages/examples/a2a/package.json';
+const pkg = JSON.parse(fs.readFileSync(p,'utf8'));
+const scripts = pkg.scripts || {};
+const bad = [];
+if ('build' in scripts) bad.push(`build=${scripts.build}`);
+if (!scripts.typecheck) bad.push('missing typecheck');
+for (const name of ['lint:check','format','format:check']) if (!scripts[name]) bad.push(`missing ${name}`);
+if (bad.length) { console.error(bad.join('\n')); process.exit(1); }
+console.log('a2a scripts normalized');
+NODE
+```
+
+Result:
+
+```text
+a2a scripts normalized
+```
+
+Commands:
+
+```bash
+bun run --cwd packages/examples/a2a lint:check
+bun run --cwd packages/examples/a2a format:check
+```
+
+Result:
+
+```text
+biome check passed for 5 files.
+biome format passed for 5 files.
+```
+
+## Local blockers
+
+This auxiliary worktree does not have a valid local workspace install.
+
+```text
+bun run --cwd packages/examples/a2a test
+  Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'express' imported from .../packages/examples/a2a/server.ts
+
+bun run --cwd packages/examples/a2a typecheck
+  error TS2688: Cannot find type definition file for 'node'
+```
+
+The test command was also attempted without leaving any lockfile or dependency
+churn in the worktree.

--- a/packages/examples/a2a/package.json
+++ b/packages/examples/a2a/package.json
@@ -7,8 +7,10 @@
     "start": "bun run server.ts",
     "test": "cd ../../.. && bunx tsx packages/examples/a2a/test-runner.ts",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "typecheck": "tsgo --noEmit",
-    "build": "bun run typecheck"
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",


### PR DESCRIPTION
## Summary

Fixes a #12903 script-normalization slice for `packages/examples/a2a`:

- removes fake `build: bun run typecheck` because it emits no artifacts
- keeps `typecheck` as the real TypeScript validation command
- adds `lint:check`, `format`, and `format:check`
- records evidence in `.github/issue-evidence/12903-a2a-script-contract.md`

## Why

The #12903 contract reserves `build` for emitted artifacts and requires real read-only check verbs. A2A already has a real `typecheck`, so `build` was only a duplicate validation alias.

## Verification

- `git diff --check origin/develop..HEAD`
- JSON parse check for `packages/examples/a2a/package.json`
- static guard confirming `build` is removed, `typecheck` remains, and check verbs exist
- `bun run --cwd packages/examples/a2a lint:check`
- `bun run --cwd packages/examples/a2a format:check`

## Known local limitations

Full `bun install` / `bun run verify` were not run in this auxiliary worktree because the filesystem has about 4 GiB free. A2A `test` and `typecheck` were attempted; tests cannot resolve `express` without a workspace install, and `tsgo` cannot find the `node` type library through the temporary shared `node_modules` symlink. Details are in the evidence file.
