### PR TITLE
docs(#12804): clean finances prose headers

### DIFF
--- a/plugins/plugin-finances/src/components/finances/FinancesView.test.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesView.test.tsx
@@ -1,6 +1,6 @@
-// @vitest-environment jsdom
-
 /**
+ * @vitest-environment jsdom
+ *
  * Drives the unified FinancesView (the single GUI/XR data wrapper) through the
  * rendered DOM: the same component the bundle exports for both the "gui" and
  * "xr" modalities. It reads the four read-only money endpoints PA serves:
@@ -17,10 +17,7 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-// `@elizaos/ui` is the giant renderer barrel; FinancesView only touches
-// `client.getBaseUrl()` (default fetcher seam, overridden in every test) and
-// `client.sendChatMessage()` (connect + drill-down affordances). The spatial
-// primitives come from the separate `@elizaos/ui/spatial` subpath, not mocked.
+// FinancesView only touches base URL and chat affordances from the UI client.
 const { sendChatMessage } = vi.hoisted(() => ({ sendChatMessage: vi.fn() }));
 vi.mock("@elizaos/ui", () => ({
   client: {

--- a/plugins/plugin-finances/src/components/finances/format-minor.test.ts
+++ b/plugins/plugin-finances/src/components/finances/format-minor.test.ts
@@ -1,12 +1,7 @@
-// Unit tests for the load-bearing minor-units -> currency render helper.
-//
-// The CLAUDE.md contract: "Currency amounts are stored as minor units (cents)
-// in amountMinor ... convert at the render boundary." `formatMinor` IS that
-// boundary, so its conversion (cents -> major units via Intl.NumberFormat) and
-// its invalid-ISO-code catch fallback are asserted here independent of the DOM.
-//
-// Expected formatted strings were verified against Node's full-ICU
-// Intl.NumberFormat output (the same engine the test runner uses).
+/**
+ * Currency formatting tests pin the finance view boundary that converts stored
+ * minor units into user-facing Intl currency strings.
+ */
 
 import { describe, expect, it } from "vitest";
 import { formatMinor } from "./FinancesView.tsx";

--- a/plugins/plugin-finances/src/db/index.ts
+++ b/plugins/plugin-finances/src/db/index.ts
@@ -1,3 +1,5 @@
-/** Barrel: re-exports the finances Drizzle schema (`app_finances` tables). */
+/**
+ * Barrel re-exporting the finances Drizzle schema for app_finances tables.
+ */
 export * from "./schema.ts";
 export { financesDbSchema as default } from "./schema.ts";

--- a/plugins/plugin-finances/src/payment-types.ts
+++ b/plugins/plugin-finances/src/payment-types.ts
@@ -1,4 +1,7 @@
-/** Payment-source / transaction / recurring-charge types for the finance back-end. */
+/**
+ * Finance payment types describe payment sources, transactions, spending
+ * summaries, and recurring charges.
+ */
 export type LifeOpsPaymentSourceKind =
   | "csv"
   | "plaid"

--- a/plugins/plugin-finances/src/plugin.test.ts
+++ b/plugins/plugin-finances/src/plugin.test.ts
@@ -1,7 +1,7 @@
-// Guards the `finances` view registration against the view loader silently
-// failing to resolve the component. The view loader matches the registered
-// `componentExport` name against a named export in the bundle, so the export
-// name and the registration must agree.
+/**
+ * Finances plugin contract tests pin the view registration and named component
+ * export consumed by the app view loader.
+ */
 
 import { describe, expect, it } from "vitest";
 import { FinancesView } from "./components/finances/FinancesView.tsx";
@@ -21,10 +21,8 @@ describe("financesPlugin view registration", () => {
 
   it("resolves the registered componentExport to the exported component function", () => {
     const view = financesPlugin.views?.[0];
-    // The named export the loader looks up must exist and be a component.
+    // The loader resolves this named export from the built view bundle.
     expect(typeof FinancesView).toBe("function");
-    // ...and its function name must match the registered componentExport so the
-    // bundle's named export resolves.
     expect(FinancesView.name).toBe(view?.componentExport);
     expect(FinancesView.name).toBe("FinancesView");
   });

--- a/plugins/plugin-finances/src/subscriptions-types.ts
+++ b/plugins/plugin-finances/src/subscriptions-types.ts
@@ -1,4 +1,7 @@
-/** Subscription audit / candidate / cancellation types for the subscriptions back-end. */
+/**
+ * Finance subscription types describe audit results, detected candidates, and
+ * cancellation workflow state.
+ */
 export type LifeOpsSubscriptionAuditStatus = "completed" | "failed";
 
 export type LifeOpsSubscriptionSource = "gmail" | "manual";

--- a/plugins/plugin-finances/vite.config.views.ts
+++ b/plugins/plugin-finances/vite.config.views.ts
@@ -1,5 +1,6 @@
-/** Vite build config for the `finances` view bundle (dist/views/bundle.js). */
-
+/**
+ * Vite build configuration for the finances dashboard view bundle.
+ */
 import path from "node:path";
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
@@ -9,8 +10,7 @@ export default createViewBundleConfig({
   entry: "./src/components/finances/finances-view-bundle.ts",
   outDir: "dist/views",
   componentExport: "FinancesView",
-  // The finances plugin owns the Plaid link flow; bundle its own stub for the
-  // (renderer-unshipped) react-plaid-link widget instead of leaving it external.
+  // Bundle the local Plaid link shim because the renderer does not ship it.
   aliases: {
     "react-plaid-link": path.resolve(
       process.cwd(),

--- a/plugins/plugin-finances/vitest.config.ts
+++ b/plugins/plugin-finances/vitest.config.ts
@@ -1,5 +1,7 @@
-/** Vitest config for @elizaos/plugin-finances (module aliases + test globs). */
-
+/**
+ * Vitest configuration for finances unit and React view tests with local module
+ * aliases.
+ */
 import { createRequire } from "node:module";
 import path from "node:path";
 import { defineConfig } from "vitest/config";
@@ -8,9 +10,7 @@ const require = createRequire(import.meta.url);
 
 export default defineConfig({
   resolve: {
-    // Pin a single React copy so jsdom view tests do not mix the workspace and
-    // hoisted React peers (which breaks hooks / rendering). Mirrors
-    // plugin-facewear / plugin-documents.
+    // Pin one React copy so jsdom view tests do not mix workspace and hoisted peers.
     alias: [
       {
         find: /^react$/,


### PR DESCRIPTION
## Summary
- Cleans the `plugin-finances` slice of #12804 by converting file-purpose comments to required prose headers.
- Removes churn/restatement wording in the finances view/config tests while keeping durable boundary notes.
- Leaves code tokens unchanged; this is a comment-only partial for #12804 and does not close the full five-plugin issue.

Refs #12804

## Validation
- Read `plugins/plugin-finances/CLAUDE.md`.
- PASS: scoped header audit for `plugins/plugin-finances` TypeScript/TSX sources: `MISSING=0`.
- PASS: `bun run check:comment-only`
  - `[assert-comment-only-diff] OK — 8 source file(s) changed; every code token identical to origin/develop. Comments only.`
- PASS: `git diff --check origin/develop...HEAD`
- PASS: changed-file Biome check
  - `Checked 8 files in 32ms. No fixes applied.`
- BLOCKED: `bun run verify`
  - Sparse checkout is missing `packages/auth/AGENTS.md`, so `check:agents-claude` fails before workspace verification starts.

## Evidence
- N/A - comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- N/A - no runtime, model, UI, audio, native, wallet/chain, or domain behavior changed.
