### PR TITLE
docs(#12231): prose headers + churn cleanup — core services + utils (B01 part 4, final)

### DIFF
--- a/packages/core/src/services/__tests__/action-callback-voice.test.ts
+++ b/packages/core/src/services/__tests__/action-callback-voice.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Exercises `wrapSingleTurnVisibleCallback` (services/message): action-callback
+ * text is rewritten through TEXT_SMALL into natural language, while passive REPLY
+ * callbacks pass through untouched. Runs against a mock runtime with a stubbed model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { createMockRuntime } from "../../testing/mock-runtime";
 import type { HandlerCallback, Memory } from "../../types";

--- a/packages/core/src/services/__tests__/channel-topics.test.ts
+++ b/packages/core/src/services/__tests__/channel-topics.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises `ChannelTopicsService`: the per-room LRU of recent channel topics —
+ * dedup with move-to-most-recent, FIFO eviction at capacity, persistence to
+ * room.metadata, hydration on restart, and defensive handling when rooms or the
+ * DB are missing. Backed by a mock runtime over an in-memory room map.
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockRuntime } from "../../testing/mock-runtime";
 import type { Room, UUID } from "../../types/index";

--- a/packages/core/src/services/__tests__/failure-reply-prompt.test.ts
+++ b/packages/core/src/services/__tests__/failure-reply-prompt.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Pins `buildFailureReplyPrompt` and the `isRateLimitError` /
+ * `isModelProviderFallbackError` classifiers (services/message) against the live
+ * hallucination and 429-cascade regressions detailed below. Pure-function checks,
+ * no runtime.
+ */
 import { APICallError, RetryError } from "ai";
 import { describe, expect, it } from "vitest";
 import {

--- a/packages/core/src/services/agent-event-bridge.test.ts
+++ b/packages/core/src/services/agent-event-bridge.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises the `agent-event-bridge` functions that fan runtime lifecycle,
+ * action, evaluator, and connector-message events into `AgentEventService`
+ * streams and guarded inbox notifications, including the no-service no-op path.
+ * Runs against a mock runtime backed by a real AgentEventService.
+ */
 import { describe, expect, it } from "vitest";
 import { createMockRuntime } from "../testing/mock-runtime";
 import type { AgentEventPayload } from "../types/agentEvent.ts";

--- a/packages/core/src/services/approval.test.ts
+++ b/packages/core/src/services/approval.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Exercises `ApprovalService.listPendingUserActions`: in-flight async approvals
+ * map to canonical `PendingUserAction` records with options, weight, and the
+ * self-expiry deadline for timed requests. Runs against a minimal stub runtime.
+ */
 import { describe, expect, it } from "vitest";
 import type { IAgentRuntime, UUID } from "../types/index.ts";
 import { PENDING_USER_ACTION_WEIGHT } from "../types/index.ts";

--- a/packages/core/src/services/channel-topics.search.test.ts
+++ b/packages/core/src/services/channel-topics.search.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises `matchTopicRooms` (channel-topics): cross-channel topic search that
+ * ranks rooms by matching-topic count, matches whitespace tokens
+ * case-insensitively, and honors the empty-query / limit / no-match edge cases.
+ * Pure-function checks.
+ */
 import { describe, expect, it } from "vitest";
 import { matchTopicRooms } from "./channel-topics.ts";
 

--- a/packages/core/src/services/embedding.test.ts
+++ b/packages/core/src/services/embedding.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises `EmbeddingGenerationService`: drain configuration (batch vs per-item,
+ * fast-shutdown) and the `processBatch` path — one batch call with per-id
+ * write-back, empty-vector and count-mismatch failure handling, and isolated
+ * per-item fallback. Runs against a mock runtime with stubbed embedding models.
+ */
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { ModelType } from "../types/model";
 import type { IAgentRuntime } from "../types/runtime";

--- a/packages/core/src/services/embedding.ts
+++ b/packages/core/src/services/embedding.ts
@@ -1,3 +1,13 @@
+/**
+ * Long-lived singleton that owns asynchronous embedding generation for memories.
+ * Registered by the basic-capabilities bundle; it listens for
+ * EMBEDDING_GENERATION_REQUESTED events and drains a priority `BatchQueue` on the
+ * task scheduler, embedding each memory's text and writing the vector back via
+ * `updateMemory`. When a TEXT_EMBEDDING_BATCH model is registered it collapses a
+ * per-turn embed burst into one round-trip, falling back per-item on any batch
+ * failure; when no TEXT_EMBEDDING model exists it starts disabled so text-only
+ * deployments still run.
+ */
 import type { EmbeddingGenerationPayload } from "../types/events";
 import { EventType } from "../types/events";
 import type { Memory } from "../types/memory";

--- a/packages/core/src/services/evaluator.test.ts
+++ b/packages/core/src/services/evaluator.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises `EvaluatorService.run`: active evaluator sections merge into one
+ * structured model call in priority order, invalid sections and processor
+ * failures stay isolated, and the schema -> json_object -> plain-JSON fallback
+ * ladder (with schema-skip arming) degrades gracefully. Runs against a real
+ * AgentRuntime + InMemoryDatabaseAdapter with a stubbed useModel.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter";
 import { AgentRuntime } from "../runtime";

--- a/packages/core/src/services/evaluator.ts
+++ b/packages/core/src/services/evaluator.ts
@@ -1,3 +1,12 @@
+/**
+ * `EvaluatorService`: the runtime singleton that runs every registered post-turn
+ * evaluator in a single merged, schema-constrained SMALL-model call, then routes
+ * each evaluator's slice of the output through its processors. Exposes the
+ * `runPostTurnEvaluators` helper the message loop invokes after a turn (skipped on
+ * mobile, where reflection would serialize on the on-device engine). Remembers,
+ * per runtime, when a provider rejects schema-constrained output and falls back to
+ * a json_object request so a doomed schema round-trip is not repaid every turn.
+ */
 import { v4 as uuidv4 } from "uuid";
 import { logger } from "../logger.ts";
 import { isMobilePlatform } from "../runtime-env.ts";

--- a/packages/core/src/services/followUp.ts
+++ b/packages/core/src/services/followUp.ts
@@ -1,3 +1,11 @@
+/**
+ * `FollowUpService`: the runtime singleton that schedules and manages contact
+ * follow-ups as queue tasks (one-shot `dueAt` rows the task scheduler runs then
+ * deletes) and surfaces smart follow-up suggestions derived from relationship
+ * analytics. Depends on `RelationshipsService` for contact data and mirrors the
+ * next follow-up into each contact's custom fields; its registered `follow_up`
+ * task worker writes a reminder memory and emits `follow_up:due` when a task fires.
+ */
 import { createUniqueUuid } from "../entities";
 import { logger } from "../logger";
 import type { Memory } from "../types/memory";

--- a/packages/core/src/services/hook.event-enumeration.test.ts
+++ b/packages/core/src/services/hook.event-enumeration.test.ts
@@ -1,14 +1,13 @@
+/**
+ * Verifies HookService.start registers exactly the HOOK_* members of the
+ * statically-imported EventType enum — every HOOK_* event, and only those.
+ * Drives the real service against a minimal fake runtime that records each
+ * registerEvent call.
+ */
 import { describe, expect, it } from "vitest";
 import { EventType } from "../types/events";
 import type { IAgentRuntime } from "../types/runtime";
 import { HookService } from "./hook";
-
-/**
- * Item #36 (Refs #12091): HookService enumerates HOOK_* event types via a
- * static `import { EventType }` instead of an inline `require("../types/events")`.
- * This proves the statically-imported enum is the source the interceptor setup
- * registers, and that every HOOK_* member (and only those) gets wired.
- */
 
 function makeRuntime(registered: string[]): IAgentRuntime {
 	return {

--- a/packages/core/src/services/message.processAttachments.test.ts
+++ b/packages/core/src/services/message.processAttachments.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers `DefaultMessageService.processAttachments`: remote fetches route through
+ * the mocked SSRF-guarded fetcher (zero real network), a failing attachment is
+ * isolated as ephemeral without throwing, and local text/csv/markdown/pdf docs
+ * extract real text through the un-mocked extractor.
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ContentType, type Media } from "../types/primitives";
 import type { IAgentRuntime } from "../types/runtime";

--- a/packages/core/src/services/message.shortcut-gate.test.ts
+++ b/packages/core/src/services/message.shortcut-gate.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Integration tests for runShortcutGate, the pre-LLM shortcut gate: confident
+ * slash-command and natural-language matches dispatch straight to the target
+ * action with zero model calls, honoring role gates, validate() failures, and
+ * the disable env flag. The fake runtime's useModel throws, so any inference
+ * attempt fails the test.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ShortcutRegistry } from "../runtime/shortcut-registry";
 import type { Action } from "../types/components";
@@ -5,11 +12,6 @@ import { EventType } from "../types/events";
 import type { Memory, State, UUID } from "../types/index";
 import { runShortcutGate } from "./message";
 
-/**
- * Integration test for the pre-LLM shortcut gate (#8791): a confident match
- * runs the target action and returns its reply with ZERO model calls. The fake
- * runtime's useModel throws, so any inference attempt fails the test.
- */
 function echoAction(
 	opts: {
 		validate?: () => Promise<boolean>;
@@ -242,10 +244,9 @@ describe("runShortcutGate (#8791 pre-LLM gate)", () => {
 		expect(shortcutEvents).toHaveLength(1);
 	});
 
-	// #12087 Item 3: the shortcut path must enforce the target action's declared
-	// roleGate before running its handler. Previously it called validate()/handler()
-	// directly, so a shortcut targeting an OWNER-gated action was reachable by any
-	// USER whose shortcut lacked `requiresElevated`.
+	// #12087 Item 3: the shortcut path enforces the target action's declared
+	// roleGate before running its handler, so a shortcut targeting an OWNER-gated
+	// action is unreachable by a USER whose shortcut lacks `requiresElevated`.
 	function ownerGatedEcho(handler: Action["handler"]): Action {
 		return {
 			name: "ECHO_COMMAND",

--- a/packages/core/src/services/message.stage1-retry.test.ts
+++ b/packages/core/src/services/message.stage1-retry.test.ts
@@ -1,16 +1,17 @@
+/**
+ * Exercises the Stage-1 retry policy (shouldRetryStage1Generation and
+ * getStage1RetryReason). A "malformed HANDLE_RESPONSE tool call" caused by a
+ * completion-cap truncation must NOT be retried — regenerating at the same token
+ * cap truncates again, burning full Stage-1 turns for the same result (a +12-16s
+ * tail-latency spike on direct/DM chat); truncation is routed to the dedicated
+ * recovery path instead. Empty or garbled output that did not hit the cap is
+ * still worth one retry.
+ */
 import { describe, expect, it } from "vitest";
 import { HANDLE_RESPONSE_TOOL_NAME } from "../actions/to-tool";
 import type { GenerateTextResult } from "../types/index";
 import { getStage1RetryReason, shouldRetryStage1Generation } from "./message";
 
-/**
- * Stage-1 retry policy (latency fix): a "malformed HANDLE_RESPONSE tool call"
- * caused by a completion-limit truncation must NOT be retried — regenerating at
- * the same token cap truncates again, burning full Stage-1 turns for the same
- * result (the measured +12-16s tail-latency spike on direct/DM chat). Truncation
- * is routed to the dedicated recovery path instead. Empty/garbled output that did
- * not hit the cap is still worth one retry.
- */
 function rawWith(opts: {
 	finishReason?: string;
 	completionTokens?: number;

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1,3 +1,13 @@
+/**
+ * Built-in `DefaultMessageService` (the runtime's `IMessageService` singleton) and
+ * the helpers it composes, implementing the full inbound-message pipeline: memory
+ * creation, should-respond gating, the pre-LLM shortcut gate, Stage-1 response
+ * generation with its retry/truncation policy, the planner loop over tiered
+ * actions, attachment enrichment, voice-turn arbitration, and post-turn evaluation
+ * — turning a received `Memory` into a response plus any executed actions. The
+ * runtime message loop drives it; a host may swap in an alternate `IMessageService`
+ * to replace it wholesale.
+ */
 import { v4 } from "uuid";
 import z from "zod";
 import { formatActionNames, formatActions } from "../actions";
@@ -2237,16 +2247,14 @@ async function collectV5PlannerCandidateActions(args: {
 	candidateActions?: readonly string[];
 	userRoles?: readonly RoleGateRole[];
 }): Promise<Action[]> {
-	// We used to filter the candidate set by `action.contexts` against the
-	// messageHandler-picked `selectedContexts`. That filter excluded owner
-	// actions, CALENDAR, SCHEDULED_TASKS, etc. whenever the messageHandler routed to
-	// "general" — even when the user clearly asked for a habit/event/etc.
-	// (See the 2026-05-09 candidate-surface root-cause audit.)
-	//
-	// Now: the surface starts from every action, then applies only the same
-	// execution gates the planner executor will enforce. That keeps role-policy
-	// overrides working for deployments that intentionally expose an action
-	// outside its declared context, while avoiding dead tools that the planner
+	// The candidate surface starts from every runtime action and applies only the
+	// same execution gates the planner executor will enforce — it deliberately does
+	// NOT pre-filter by `action.contexts` against the messageHandler-picked
+	// `selectedContexts`. Context pre-filtering excludes owner actions, CALENDAR,
+	// SCHEDULED_TASKS, etc. whenever the messageHandler routes to "general", even
+	// when the user clearly asked for a habit/event/etc. Starting from every action
+	// keeps role-policy overrides working for deployments that intentionally expose
+	// an action outside its declared context, while avoiding dead tools the planner
 	// could select but execution would immediately reject.
 	const allRuntimeActions = args.runtime.actions;
 	const actionLookup = buildRuntimeActionLookup(args.runtime);
@@ -4162,12 +4170,12 @@ export function applyDirectCurrentCandidateBackstopToMessageHandler(
 	// to force-plan over a finished answer whose only planning signals are weak,
 	// injectable ones (a simple/general context + search/shell-class candidates)
 	// via shouldPreferCompleteDirectReply. The plain-text fallback lands here
-	// instead and previously skipped that valve, so a COMPLETE plain-text answer
+	// too and must apply the same valve: without it, a COMPLETE plain-text answer
 	// ("Your lucky number is 4291." / a solved logic puzzle) that this backstop
-	// happened to tag with an inferred WEB_SEARCH candidate got promoted to
+	// happened to tag with an inferred WEB_SEARCH candidate would be promoted to
 	// requiresTool=true — forcing a pointless web search + a slow extra planner
 	// round, even though the identical answer in JSON form (contexts=[simple])
-	// went direct. Apply the same structural valve here so the two Stage-1 shapes
+	// goes direct. Apply the same structural valve here so the two Stage-1 shapes
 	// route identically. Live-info stays correct: its Stage-1 reply is an ack
 	// ("Checking the price now."), not a complete answer, so it fails
 	// looksLikeCompleteDirectReply and still forces the fetch. Coding/spawn stays
@@ -10547,7 +10555,6 @@ export class DefaultMessageService implements IMessageService {
 
 	/**
 	 * Deletes a message from the agent's memory.
-	 * This method handles the actual deletion logic that was previously in event handlers.
 	 *
 	 * @param runtime - The agent runtime instance
 	 * @param message - The message memory to delete

--- a/packages/core/src/services/message.voice-gate.test.ts
+++ b/packages/core/src/services/message.voice-gate.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the message service's voice-turn helpers: dual-path parsing of the
+ * turn-signal and speaker id from either content top-level or content.metadata,
+ * and the server-side suppress/confirm truth table over the client's signal (#9147).
+ */
 import { describe, expect, it } from "vitest";
 import {
 	getVoiceSpeakerEntityId,

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Tests the direct-action heuristics — shell / web-search intent detection and
+ * action-name resolution by canonical name, simile, or delegation tag. They must
+ * fire on clear intent yet respect explicit negations ("don't run commands",
+ * "don't browse the web"), since a false positive runs an unwanted
+ * side-effecting action.
+ */
 import { describe, expect, it } from "vitest";
 import type { Action } from "../../types/components";
 import {
@@ -7,13 +14,6 @@ import {
 	looksLikeLocalShellRequest,
 	looksLikeWebSearchRequest,
 } from "./direct-action-heuristics.ts";
-
-/**
- * Direct-action heuristics decide whether a message should directly trigger a
- * shell / web-search action. They must fire on clear intent but respect
- * explicit negations ("don't run commands", "don't browse the web") — a false
- * positive runs an unwanted side-effecting action.
- */
 
 describe("looksLikeLocalShellRequest", () => {
 	it("fires on local inspect-the-repo intent, not on unrelated text", () => {

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -1,3 +1,12 @@
+/**
+ * Pre-model heuristics that decide which registered actions a raw message should
+ * directly trigger: local-shell inspection, web/live-info lookup, coding-task
+ * delegation, and views/app navigation. Each detector fires on clear intent,
+ * honors explicit negations ("don't run commands", "don't browse the web"), and
+ * resolves action names structurally by canonical name, simile, or tag — so a
+ * runtime missing a given backend action simply yields no candidate. Also derives
+ * a concrete shell command or web-search query from the message text.
+ */
 import type { Action } from "../../types/components";
 
 export interface DirectActionInferenceHooks {
@@ -149,9 +158,7 @@ export function findAvailableActionName(
 ): string | undefined {
 	// Resolve in `names` PRIORITY order, not action-registration order: for each
 	// wanted name in turn, return the first action whose name or simile matches.
-	// The leading preference wins — the first name in `names` that matches any
-	// registered action (by name or simile) is returned, regardless of
-	// registration order.
+	// The leading preference wins regardless of registration order.
 	for (const want of names) {
 		const wanted = normalizeActionIdentifier(want);
 		const match = actions.find((action) => {
@@ -228,9 +235,9 @@ export function inferDirectCurrentRequestCandidateActions(
 		// apps", "list running apps", "launch the shopify app") is ambiguous
 		// between the views/apps *page* (VIEWS) and the applications themselves
 		// (the APP control action). Surface BOTH candidates and let the planner
-		// arbitrate from the exposed routing hints — previously only VIEWS was
-		// hinted, so every installed-apps ask was answered with the UI view
-		// catalog (#9950). Structurally anchored to a registered app-control
+		// arbitrate from the exposed routing hints; hinting only VIEWS answers
+		// every installed-apps ask with the UI view catalog instead of the app
+		// itself (#9950). Structurally anchored to a registered app-control
 		// action, so runtimes without one are unaffected.
 		const appControlAction = findAppControlActionNameForAppRequest(
 			actions,

--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -1,3 +1,12 @@
+/**
+ * Classifies model-call failures — rate-limit/429, auth 401/403, and transient
+ * provider errors worth failing over to another provider — and assembles the
+ * user-facing fallback reply when a turn's grounding trajectory fails.
+ * Classification unwraps the AI SDK retry envelope and reads the structured HTTP
+ * status first, falling back to a message-substring scan for status-less errors.
+ * buildFailureReplyPrompt shapes the in-character apology (never answering on the
+ * merits), and stripReasoningBlocks removes <think> spans from the raw reply.
+ */
 import { ModelType } from "../../types/model";
 
 type ErrorWithStatus = {

--- a/packages/core/src/services/message/generate-text-result.test.ts
+++ b/packages/core/src/services/message/generate-text-result.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Pins getV5ModelText and extractGenerateTextContentText normalization across the
+ * provider-boundary shapes real adapters return — raw string, text field, string
+ * or part-array content, and response-only payload — so typed access to
+ * GenerateTextResult's content/response fields keeps working without unsafe casts.
+ */
 import { describe, expect, it } from "vitest";
 import type { GenerateTextResult } from "../../types/model";
 import {
@@ -5,12 +11,6 @@ import {
 	getV5ModelText,
 } from "./generate-text-result";
 
-/**
- * #9155: `GenerateTextResult` now declares the real provider-boundary fields
- * (`content`, `response`) that the normalizer reads. These tests pin the
- * normalization of the three shapes real adapters return so the typed access
- * (no `as unknown as Record<string, unknown>` casts) keeps working.
- */
 describe("getV5ModelText (#9155 boundary normalization)", () => {
 	it("returns a raw string passthrough", () => {
 		expect(getV5ModelText("hello")).toBe("hello");

--- a/packages/core/src/services/message/generate-text-result.ts
+++ b/packages/core/src/services/message/generate-text-result.ts
@@ -1,3 +1,10 @@
+/**
+ * Normalizes an AI-SDK v5 `GenerateTextResult` (or a bare string) into the plain
+ * assistant text the runtime persists and renders. Prefers a non-empty top-level
+ * `text`, then the concatenation of `text`/`output_text` content parts, then the
+ * `response` field, and finally falls back to the raw `text` or a JSON dump so a
+ * caller never receives `undefined` even when no readable text is present.
+ */
 import type { GenerateTextResult } from "../../types/model";
 
 export function getV5ModelText(raw: string | GenerateTextResult): string {

--- a/packages/core/src/services/message/provider-error-hygiene.test.ts
+++ b/packages/core/src/services/message/provider-error-hygiene.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit coverage for the provider-error hygiene helpers: model-provider
+ * failover/rate-limit classification (including the TEXT_TO_SPEECH fail-closed
+ * carve-out) and the transient-failure response-memory skip rule.
+ */
 import { describe, expect, it } from "vitest";
 import { type Memory, ModelType } from "../../types";
 import { shouldSkipResponseMemoryPersistence } from "../message";

--- a/packages/core/src/services/notification.test.ts
+++ b/packages/core/src/services/notification.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit coverage for NotificationService over a mock runtime with an in-memory
+ * cache and event bus: creation/validation, listing filters, read state,
+ * groupKey collapse, expiry, retention-cap eviction, and cache rehydration.
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockRuntime } from "../testing/mock-runtime";
 import type { AgentNotification } from "../types/notification.ts";

--- a/packages/core/src/services/relationships-graph-builder.ts
+++ b/packages/core/src/services/relationships-graph-builder.ts
@@ -1,3 +1,13 @@
+/**
+ * Builds the relationships graph model backing RelationshipsService: unions
+ * entities into identity clusters ("people"), derives weighted, sentiment-tagged
+ * edges from explicit relationship rows and from conversation adjacency/reply
+ * signals, and assembles per-person detail (facts, recent conversations,
+ * relevant memories, personality preferences). Exposes a TTL-cached
+ * RelationshipsGraphService (snapshot / person-detail / merge propose+accept+
+ * reject) plus cluster-aware getMemories/searchMemories helpers that fan a
+ * lookup across every member of a person's identity cluster.
+ */
 import { getCloudAuthService } from "../cloud-auth-service";
 import type {
 	Entity,

--- a/packages/core/src/services/relationships.ts
+++ b/packages/core/src/services/relationships.ts
@@ -1,3 +1,13 @@
+/**
+ * RelationshipsService: the runtime's long-lived contact and relationship store.
+ * Owns per-agent contacts (CRUD, platform handles, interaction history,
+ * relationship goals and followup cadence, cross-platform import), relationship
+ * analytics and strength scoring, strengthened identity records
+ * (`entity_identities`) with confidence-based auto-merge candidates
+ * (`entity_merge_candidates`), and identity-cluster resolution via union-find.
+ * Graph snapshot and person-detail assembly are delegated to the graph builder.
+ * Consumed by relationships providers/actions, LifeOps, and the dashboard.
+ */
 import { sql } from "drizzle-orm";
 import { logger } from "../logger";
 import type { Component, Entity, Relationship } from "../types/environment";
@@ -43,7 +53,6 @@ function isConfirmedIdentityLinkLike(relationship: Relationship): boolean {
 	return typeof status === "string" && status === "confirmed";
 }
 
-// Extended Relationship interface with new fields
 interface ExtendedRelationship extends Relationship {
 	relationshipType?: string;
 	strength?: number;
@@ -727,7 +736,6 @@ export class RelationshipsService extends Service {
 		// Load existing contact info from components
 		await this.loadContactInfoFromComponents();
 
-		// Service initialized
 		logger.info("[RelationshipsService] Initialized successfully");
 	}
 
@@ -736,7 +744,6 @@ export class RelationshipsService extends Service {
 		this.contactInfoCache.clear();
 		this.analyticsCache.clear();
 		this.categoriesCache = [];
-		// Service stopped
 		logger.info("[RelationshipsService] Stopped successfully");
 	}
 
@@ -2286,7 +2293,7 @@ export class RelationshipsService extends Service {
 	}
 
 	// ───────────────────────────────────────────────────────────────────────
-	// Graph snapshot / person detail (merged from former RelationshipsGraphService)
+	// Graph snapshot / person detail
 	// ───────────────────────────────────────────────────────────────────────
 
 	/**

--- a/packages/core/src/services/task-scheduler.test.ts
+++ b/packages/core/src/services/task-scheduler.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit coverage for the shared task-scheduler tick loop under fake timers:
+ * error resilience when getTasks rejects, dirty-agent re-arm/quiet semantics,
+ * and not re-arming an agent that unregisters mid-tick.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { logger } from "../logger";
 import type { IDatabaseAdapter } from "../types/database";

--- a/packages/core/src/services/task.test.ts
+++ b/packages/core/src/services/task.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Tests for TaskService tick re-arm, repeat-task backoff/auto-pause, and
+ * self-queue suppression, driven by fake timers over an in-memory task store,
+ * plus the AgentRuntime task mutations that mark the local service dirty.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentRuntime } from "../runtime";
 import type { UUID } from "../types/primitives";

--- a/packages/core/src/services/task.ts
+++ b/packages/core/src/services/task.ts
@@ -1,4 +1,11 @@
-// registered to runtime through plugin
+/**
+ * TaskService: the runtime singleton that polls `queue`-tagged tasks and runs
+ * their registered worker when due. Owns the tick loop — a local `setInterval`,
+ * a shared task-scheduler daemon, or serverless `runDueTasks()` — plus
+ * repeat-task cadence, failure backoff and auto-pause, and overlap suppression
+ * for blocking runs. Registered by the basic-capabilities plugin and reached
+ * via `runtime.getService(ServiceType.TASK)`.
+ */
 
 import { promptRunnerTaskWorker } from "../features/basic-capabilities/prompt-runner-task";
 import type { JsonValue } from "../types";
@@ -28,26 +35,9 @@ function resolveDueTime(task: Task): number | null {
 }
 
 /**
- * TaskService class representing a service that schedules and executes tasks.
- * @extends Service
- * @property {NodeJS.Timeout|null} timer - Timer for executing tasks
- * @property {number} TICK_INTERVAL - Interval in milliseconds to check for tasks
- * @property {ServiceTypeName} serviceType - Service type of TASK
- * @property {string} capabilityDescription - Description of the service's capability
- * @static
- * @method start - Static method to start the TaskService
- * @method createTestTasks - Method to create test tasks
- * @method startTimer - Public method to start the timer for checking tasks
- * @method validateTasks - Private method to validate tasks
- * @method checkTasks - Private method to check tasks and execute them
- * @method executeTask - Private method to execute a task
- * @static
- * @method stop - Static method to stop the TaskService
- * @method stop - Method to stop the TaskService
- */
-/**
- * Start the TaskService with the given runtime.
- * @param {IAgentRuntime} runtime - The runtime for the TaskService.
+ * Each tick validates due `queue` tasks against their worker's `shouldRun`,
+ * then runs `worker.execute`. Repeat tasks reschedule on their interval (with
+ * failure backoff); one-shot tasks are deleted after running.
  */
 export class TaskService extends Service {
 	private timer: NodeJS.Timeout | null = null;

--- a/packages/core/src/services/trajectories.ts
+++ b/packages/core/src/services/trajectories.ts
@@ -1,3 +1,10 @@
+/**
+ * Services-layer barrel for the trajectory subsystem: re-exports the
+ * TrajectoriesService, its read routes, and the export/type modules, and
+ * defines the public `TrajectoryProviderAccess`/`TrajectoryLlmCall` shapes —
+ * the recorder records widened with their resolved step/run identifiers — that
+ * external consumers depend on instead of reaching into runtime/.
+ */
 export { tryHandleTrajectoryReadRoutes } from "../features/trajectories/read-routes";
 export { TrajectoriesService } from "../features/trajectories/TrajectoriesService";
 export * from "./trajectory-export";

--- a/packages/core/src/services/trajectory-export.test.ts
+++ b/packages/core/src/services/trajectory-export.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Tests for the trajectory export helpers: usage/cache summaries, flattened
+ * LLM-call iteration, and JSON/JSONL/ART serialization over a sample trajectory
+ * built from both persisted `stepsJson` and inline `steps`.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	iterateTrajectoryLlmCalls,

--- a/packages/core/src/services/trajectory-export.ts
+++ b/packages/core/src/services/trajectory-export.ts
@@ -1,3 +1,11 @@
+/**
+ * Trajectory export helpers: flatten persisted trajectory steps into per-LLM-call
+ * records, summarize token and cache usage, and serialize a batch of
+ * trajectories to eliza-native JSON/JSONL rows, CSV, or ART message rows. Reads
+ * either the in-memory `steps` array or the persisted `stepsJson` string, and
+ * tolerates missing or malformed fields by coercing to finite numbers and
+ * skipping unparseable rows.
+ */
 import { textFromChatMessageContent } from "../runtime/system-prompt";
 
 export {

--- a/packages/core/src/services/trajectory-types.ts
+++ b/packages/core/src/services/trajectory-types.ts
@@ -1,10 +1,14 @@
+/**
+ * Canonical type definitions for the trajectory subsystem: recorded LLM-call,
+ * provider-access, skill-invocation, and step records; per-trajectory summary,
+ * usage-totals, and cache-stats shapes; and the eliza-native export row and
+ * format tag that the export helpers and training pipelines consume.
+ */
 import type { JsonValue } from "../types/primitives.ts";
 
 // Re-export the canonical retrieval-funnel shapes from `trajectory-recorder`
-// so external consumers can depend on the services-layer surface instead of
-// reaching into runtime/. Closes the Wave 2-C funnel-instrumentation
-// contract: per-stage retrieval entries + fused top-K + selected/correct
-// action lists.
+// so external consumers depend on the services-layer surface instead of
+// reaching into runtime/.
 export type {
 	RecordedRetrievalPerStageScores,
 	RecordedRetrievalStageEntry,
@@ -144,7 +148,7 @@ export type TrajectoryStepId = string;
 
 /**
  * Structured truncation marker shape persisted alongside per-skill
- * invocation records. Mirrors the W1-T4 action-step marker emitted by
+ * invocation records. Mirrors the action-step marker emitted by
  * `applyTrajectoryFieldCap` so downstream consumers can apply identical
  * handling regardless of which seam produced the cap.
  */
@@ -155,12 +159,11 @@ export interface TrajectorySkillInvocationTruncationMarker {
 }
 
 /**
- * One captured skill invocation. Closes M13 (W1-T5): every USE_SKILL
- * execution emits one of these against the active trajectory step so the
- * trajectory viewer and training pipelines can replay the skill seam in
- * full detail.
+ * One captured skill invocation. Every USE_SKILL execution emits one of
+ * these against the active trajectory step so the trajectory viewer and
+ * training pipelines can replay the skill seam in full detail.
  *
- * Shape mirrors the W1-T4 tool-stage capture: encoded JSON strings for
+ * Shape mirrors the tool-stage capture: encoded JSON strings for
  * structured fields, per-field 64KB cap with a structured marker on
  * overflow. `args` and `result` are stored pre-encoded so reads do not
  * need to re-parse; consumers can `JSON.parse` when they need the
@@ -206,7 +209,7 @@ export interface TrajectoryStepRecord {
 	scriptHash?: string;
 	usedSkills?: string[];
 	/**
-	 * Per-skill invocation records. Closes M13 (W1-T5). Each record carries
+	 * Per-skill invocation records. Each record carries
 	 * `(skillSlug, args, result, durationMs, parentStepId)` plus mode/script
 	 * metadata so the trajectory viewer can render the skill seam without
 	 * re-running the action.
@@ -214,9 +217,9 @@ export interface TrajectoryStepRecord {
 	skillInvocations?: TrajectorySkillInvocationRecord[];
 	/**
 	 * Name of the evaluator that produced this step. Only set when
-	 * `kind === "evaluator"`. Closes M14: every evaluator turn emits an
-	 * EVALUATOR step wrapping its model call as a child so reviewers and
-	 * training pipelines can isolate the evaluator seam.
+	 * `kind === "evaluator"`. Every evaluator turn emits an EVALUATOR step
+	 * wrapping its model call as a child so reviewers and training pipelines
+	 * can isolate the evaluator seam.
 	 */
 	evaluatorName?: string;
 }

--- a/packages/core/src/services/triggerScheduling.test.ts
+++ b/packages/core/src/services/triggerScheduling.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Tests for the trigger cron parser and next-run computation: `N/step`
+ * expansion, the Sunday-as-7 alias, DST fall-back dedupe, POSIX dom/dow OR
+ * semantics, and the non-representable-base guard.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	computeNextCronRunAtMs,
@@ -47,8 +52,8 @@ describe("parseCronExpression - minute field", () => {
 
 describe("parseCronExpression - day-of-week Sunday alias (7 == 0)", () => {
 	// POSIX/Vixie cron accepts BOTH 0 and 7 for Sunday, and LLMs commonly emit
-	// `7`. Previously the dayOfWeek range was capped at 6, so `7` (and any range
-	// or step touching it) hard-failed trigger creation.
+	// `7`; the parser accepts `7` (single, range end, or step) and folds it onto
+	// Sunday (0) rather than hard-failing trigger creation.
 	it("accepts a bare `7` and folds it onto Sunday (0)", () => {
 		expect(daysOfWeek("0 0 * * 7")).toEqual([0]);
 	});

--- a/packages/core/src/services/triggerScheduling.ts
+++ b/packages/core/src/services/triggerScheduling.ts
@@ -1,3 +1,11 @@
+/**
+ * Trigger scheduling math: parses 5-field cron expressions (with `N/step`,
+ * range, list, and the Sunday-as-7 alias), computes the next matching run time
+ * in a given timezone (honoring POSIX day-of-month/day-of-week OR-semantics and
+ * DST fall-back dedupe), and resolves interval/once/cron/event triggers to
+ * their next-run timing. Cron parsing returns null on malformed input; interval
+ * values are clamped to [MIN, MAX]_TRIGGER_INTERVAL_MS.
+ */
 import type { TriggerConfig, TriggerType } from "../types/trigger";
 
 export const MIN_TRIGGER_INTERVAL_MS = 60_000;
@@ -264,9 +272,9 @@ export function computeNextCronRunAtMs(
 	// Cap the window at the max representable Date so a base near the ceiling
 	// scans only the representable remainder, not ~527k Invalid-Date candidates.
 	const cutoff = Math.min(start + CRON_SCAN_WINDOW_MS, MAX_REPRESENTABLE_MS);
-	// Hoist ONE formatter for the entire scan. Previously getTimezoneOffsetMs
-	// allocated a fresh Intl.DateTimeFormat per candidate minute — up to ~527k
-	// allocations across the 366-day window.
+	// Hoist ONE formatter for the entire scan: a per-candidate-minute
+	// Intl.DateTimeFormat would allocate up to ~527k times across the 366-day
+	// window.
 	const formatter =
 		timezone && timezone !== "UTC" ? buildTzFormatter(timezone) : null;
 

--- a/packages/core/src/utils/__tests__/streaming-field-events.test.ts
+++ b/packages/core/src/utils/__tests__/streaming-field-events.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Streaming field extractors (StructuredFieldStreamExtractor,
+ * ResponseSkeletonStreamExtractor): per-field start/done/chunk events, clean
+ * text-only streaming, JSON-skeleton field selection, think-tag hiding, and
+ * abort handling, fed in small slices to exercise chunk boundaries.
+ */
 import { describe, expect, it } from "vitest";
 import type { SchemaRow } from "../../types/state";
 import {
@@ -220,9 +226,9 @@ describe("ResponseSkeletonStreamExtractor", () => {
 	it("streams non-envelope prose straight through as the reply (passthrough)", () => {
 		// A local model that was not grammar-constrained (e.g. the FFI backend,
 		// which cannot apply GBNF) emits the reply as raw prose with no JSON
-		// envelope. Previously the extractor matched no spans and emitted nothing,
-		// so chat-routes collapsed the whole reply into one trailing chunk. Now it
-		// streams the prose token-by-token.
+		// envelope. The extractor still streams that prose token-by-token rather
+		// than matching no spans and collapsing the whole reply into one trailing
+		// chunk.
 		const chunks: string[] = [];
 		const accumulated: string[] = [];
 		const extractor = new ResponseSkeletonStreamExtractor({

--- a/packages/core/src/utils/action-results.test.ts
+++ b/packages/core/src/utils/action-results.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Action-result helpers bound how much of a (potentially huge) tool output
+ * lands in prompt state. Token estimation, middle-truncation with a full-output
+ * reference, and oversize warnings keep a verbose action from blowing the
+ * context budget.
+ */
+
 import { describe, expect, it } from "vitest";
 import type { ActionResult } from "../types/components";
 import {
@@ -8,13 +15,6 @@ import {
 	stringifyActionResultError,
 	truncateMiddle,
 } from "./action-results.ts";
-
-/**
- * Action-result helpers bound how much of a (potentially huge) tool output
- * lands in prompt state. Token estimation, middle-truncation with a full-output
- * reference, and oversize warnings keep a verbose action from blowing the
- * context budget.
- */
 
 const result = (r: Partial<ActionResult>): ActionResult => r as ActionResult;
 

--- a/packages/core/src/utils/action-results.ts
+++ b/packages/core/src/utils/action-results.ts
@@ -1,3 +1,12 @@
+/**
+ * Bounds how much of a (potentially huge) action/tool result reaches prompt
+ * state. Estimates token cost from character length, truncates the text and
+ * error fields in the middle while preserving head and tail, and surfaces a
+ * filesystem reference (e.g. `fullOutputPath`) to the complete output when one
+ * is present in the result data. `collectActionResultSizeWarnings` flags fields
+ * over a token threshold, and `formatActionResultsForPrompt` renders the most
+ * recent results (capped at `MAX_PROMPTED_ACTION_RESULTS`) into the prompt block.
+ */
 import type { ActionResult, ProviderDataRecord } from "../types/components";
 
 export const MAX_PROMPTED_ACTION_RESULTS = 8;

--- a/packages/core/src/utils/action-validation.ts
+++ b/packages/core/src/utils/action-validation.ts
@@ -1,3 +1,9 @@
+/**
+ * Decides whether an action is eligible this turn by testing that the action's
+ * declared routing contexts overlap the routing contexts active for the current
+ * message and state. Eligibility depends only on active routing contexts, not on
+ * natural-language keyword matching.
+ */
 import type { AgentContext, Memory, State } from "../types/index.ts";
 import {
 	getActiveRoutingContextsForTurn,

--- a/packages/core/src/utils/batch-queue/priority-queue.ts
+++ b/packages/core/src/utils/batch-queue/priority-queue.ts
@@ -1,5 +1,3 @@
-import { logger } from "../../logger.js";
-
 /**
  * In-memory priority queue: **high** items dequeue before **normal**, before **low**.
  *
@@ -10,6 +8,8 @@ import { logger } from "../../logger.js";
  * **Why `onPressure` returns boolean:** The caller decides whether to evict, reject the new
  * item, or take other action — we do not silently drop work here.
  */
+
+import { logger } from "../../logger.js";
 
 export type QueuePriority = "high" | "normal" | "low";
 
@@ -91,7 +91,6 @@ export class PriorityQueue<T> {
 			}
 			this.normalItems.push(item);
 		}
-		// Note: separates items by priority for efficient batch processing and avoids linear scans.
 	}
 
 	/** Remove up to `n` items from the front (highest priority first). */

--- a/packages/core/src/utils/batch-queue/process-batch.test.ts
+++ b/packages/core/src/utils/batch-queue/process-batch.test.ts
@@ -1,12 +1,13 @@
+/**
+ * Exercises the opt-in `processBatch` path on BatchQueue that lets the
+ * embedding-drain embed N texts in one request. Per-item callers (no
+ * `processBatch`) are unaffected; with it set, a drain calls it ONCE and only
+ * falls back to the per-item `process` if the batched call throws.
+ */
+
 import { describe, expect, test } from "vitest";
 import { BatchQueue } from "./index";
 
-/**
- * Tests for the opt-in `processBatch` path on BatchQueue (added for the
- * embedding-drain so N texts embed in one request). Existing per-item callers
- * (no `processBatch`) are unaffected; with it set, a drain calls it ONCE and
- * only falls back to the per-item `process` if the batched call throws.
- */
 describe("BatchQueue processBatch", () => {
 	function makeQueue(opts: {
 		process: (item: number) => Promise<void>;

--- a/packages/core/src/utils/batch-queue/task-drain.test.ts
+++ b/packages/core/src/utils/batch-queue/task-drain.test.ts
@@ -1,3 +1,9 @@
+/**
+ * TaskDrain startup reconciliation: dedupes persisted repeat tasks that share a
+ * managed drain, reusing and re-intervalling one while deleting the rest instead
+ * of creating a new task. Driven against a mock runtime backed by an in-memory
+ * task list.
+ */
 import { describe, expect, test, vi } from "vitest";
 import { createMockRuntime } from "../../testing/mock-runtime";
 import type { Task } from "../../types/task";

--- a/packages/core/src/utils/buffer.test.ts
+++ b/packages/core/src/utils/buffer.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Cross-platform buffer abstraction (Node Buffer / browser Uint8Array). The
+ * encoding round-trips and byte ops must agree across representations, since
+ * crypto/secret code depends on these for hex/base64 conversions.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
 	alloc,
@@ -13,12 +19,6 @@ import {
 	slice,
 	toHex,
 } from "./buffer.ts";
-
-/**
- * Cross-platform buffer abstraction (Node Buffer / browser Uint8Array). The
- * encoding round-trips and byte ops must agree across representations, since
- * crypto/secret code depends on these for hex/base64 conversions.
- */
 
 describe("hex / string round-trips", () => {
 	it("utf8 ⇄ hex ⇄ string", () => {

--- a/packages/core/src/utils/channel-utils.test.ts
+++ b/packages/core/src/utils/channel-utils.test.ts
@@ -1,11 +1,3 @@
-import { describe, expect, it } from "vitest";
-import {
-	normalizeChatType,
-	resolveMentionGating,
-	resolveMentionGatingWithBypass,
-	shouldAckReaction,
-} from "./channel-utils.ts";
-
 /**
  * Channel decision gates. resolveMentionGating decides whether the agent even
  * processes a message: it must SKIP only when a mention is required, detectable,
@@ -13,6 +5,14 @@ import {
  * counts as mentioned. Getting this wrong makes the bot either ignore people who
  * @-mentioned it or spam every message in a group.
  */
+
+import { describe, expect, it } from "vitest";
+import {
+	normalizeChatType,
+	resolveMentionGating,
+	resolveMentionGatingWithBypass,
+	shouldAckReaction,
+} from "./channel-utils.ts";
 
 describe("normalizeChatType", () => {
 	it("folds platform synonyms into direct/group/channel", () => {

--- a/packages/core/src/utils/context-catalog.test.ts
+++ b/packages/core/src/utils/context-catalog.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies resolveProviderContexts (context-catalog) surfaces the ACTION_STATE
+ * provider in every first-party context. Vitest, direct function calls.
+ */
+
 import { describe, expect, it } from "vitest";
 import { actionStateProvider } from "../features/basic-capabilities/providers/actionState";
 import { FIRST_PARTY_CONTEXT_IDS } from "../runtime/context-normalization";

--- a/packages/core/src/utils/context-catalog.ts
+++ b/packages/core/src/utils/context-catalog.ts
@@ -1,3 +1,11 @@
+/**
+ * Static catalog mapping built-in action and provider names to the agent
+ * contexts they belong to, and the resolvers that pick a component's contexts —
+ * its own declared `contexts` when present, otherwise this catalog's entry,
+ * defaulting to "general". The source of routing context for components that do
+ * not declare their own.
+ */
+
 import { FIRST_PARTY_CONTEXT_IDS } from "../runtime/context-normalization";
 import type { Action, AgentContext, Provider } from "../types/components";
 
@@ -12,9 +20,8 @@ export const ACTION_CONTEXT_MAP: Record<string, AgentContext[]> = {
 	CONFIGURE: ["general", "settings"],
 	APP: ["connectors"],
 	PLUGIN: ["connectors", "admin"],
-	// PAGE_DELEGATE replaces the eight retired per-page <NAME>_ACTIONS parents.
-	// Its contexts array is declared on the action itself; this fallback entry
-	// covers any code paths that still resolve via this catalog.
+	// PAGE_DELEGATE's contexts array is declared on the action itself; this
+	// fallback entry covers any code paths that still resolve via this catalog.
 	PAGE_DELEGATE: ["general"],
 	WALLET: ["wallet"],
 	PREDICTION_MARKET: ["wallet"],

--- a/packages/core/src/utils/context-routing.test.ts
+++ b/packages/core/src/utils/context-routing.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Core context routing gates which actions/providers are surfaced each turn.
+ * shouldIncludeByContext is permissive by design (no declared or no active
+ * contexts → include) but otherwise requires an overlap, so a context-scoped
+ * action only appears in its context. inferContextRoutingFromText scores the
+ * message text into a primary context (general when nothing matches).
+ */
+
 import { describe, expect, it } from "vitest";
 import type { Action, Provider } from "../types/components";
 import {
@@ -7,14 +15,6 @@ import {
 	routingContextsOverlap,
 	shouldIncludeByContext,
 } from "./context-routing.ts";
-
-/**
- * Core context routing gates which actions/providers are surfaced each turn.
- * shouldIncludeByContext is permissive by design (no declared or no active
- * contexts → include) but otherwise requires an overlap, so a context-scoped
- * action only appears in its context. inferContextRoutingFromText scores the
- * message text into a primary context (general when nothing matches).
- */
 
 const action = (name: string, contexts?: string[]): Action =>
 	({ name, ...(contexts ? { contexts } : {}) }) as unknown as Action;

--- a/packages/core/src/utils/context-routing.ts
+++ b/packages/core/src/utils/context-routing.ts
@@ -1,3 +1,12 @@
+/**
+ * Turn-level context routing: derives the active agent contexts for a turn —
+ * from routing metadata carried on state/message, or by scoring the message
+ * text against keyword signals — and gates which actions/providers surface by
+ * testing whether a component's declared contexts overlap the active set.
+ * Gating is permissive: a component with no declared contexts, or an empty
+ * active set, is always included.
+ */
+
 import type { Action, AgentContext, Provider } from "../types/components";
 import type { Memory } from "../types/memory";
 import type { Content, ContentValue } from "../types/primitives";

--- a/packages/core/src/utils/crypto-compat.aes-gcm.test.ts
+++ b/packages/core/src/utils/crypto-compat.aes-gcm.test.ts
@@ -1,14 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { decryptAes256Gcm, encryptAes256Gcm } from "./crypto-compat.ts";
-
 /**
  * AES-256-GCM authenticated encryption (#8801 — the crypto primitive that
- * protects stored secrets/character keys, shipped untested). The properties that
- * matter for security are pinned: an exact round-trip, AAD binding, and that any
+ * protects stored secrets/character keys). The properties that matter for
+ * security are pinned: an exact round-trip, AAD binding, and that any
  * tamper / wrong key / wrong AAD is REJECTED (GCM's authentication), plus the
  * key/IV/tag length guards. A regression that silently returned plaintext on a
  * bad tag would be a critical confidentiality+integrity break.
  */
+
+import { describe, expect, it } from "vitest";
+import { decryptAes256Gcm, encryptAes256Gcm } from "./crypto-compat.ts";
 
 const KEY = new Uint8Array(32).map((_, i) => i + 1); // 32 bytes → AES-256
 const KEY2 = new Uint8Array(32).map((_, i) => 255 - i); // a different key

--- a/packages/core/src/utils/deterministic.test.ts
+++ b/packages/core/src/utils/deterministic.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Deterministic helpers must be reproducible: the same seed always yields the
+ * same RNG stream / shuffle / sample, and stableStringify must be key-order
+ * independent. Reproducibility is what makes seeded tests and stable IDs work.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
 	buildDeterministicSeed,
@@ -9,12 +15,6 @@ import {
 	hashStringToUint32,
 	stableStringify,
 } from "./deterministic.ts";
-
-/**
- * Deterministic helpers must be reproducible: the same seed always yields the
- * same RNG stream / shuffle / sample, and stableStringify must be key-order
- * independent. Reproducibility is what makes seeded tests and stable IDs work.
- */
 
 describe("hashStringToUint32", () => {
 	it("is a stable uint32 hash, input-sensitive", () => {

--- a/packages/core/src/utils/deterministic.ts
+++ b/packages/core/src/utils/deterministic.ts
@@ -1,3 +1,10 @@
+/**
+ * Seeded deterministic helpers: an FNV-1a string hash, a reproducible PRNG, and
+ * seed-driven shuffle/sample/pick plus example-name generation, all keyed by a
+ * string or number seed so the same seed always yields the same result. Also
+ * provides stableStringify — key-order-independent JSON for stable hashing/IDs.
+ */
+
 import { EXAMPLE_NAMES } from "./example-names";
 
 const UINT32_MAX = 0x100000000;

--- a/packages/core/src/utils/environment.ts
+++ b/packages/core/src/utils/environment.ts
@@ -1,10 +1,11 @@
-import { parseBooleanValue } from "./boolean.js";
-
 /**
- * Browser and Node.js compatible environment variable abstraction
- * This module provides a cross-platform interface for accessing environment variables
- * that works in both browser and Node.js environments.
+ * Browser- and Node-compatible environment-variable abstraction — a
+ * cross-platform interface for reading and setting env vars in both browser and
+ * Node runtimes (via a cached singleton and typed convenience getters), plus
+ * Node-only upward .env discovery and dotenv loading.
  */
+
+import { parseBooleanValue } from "./boolean.js";
 
 /**
  * Type representing the runtime environment

--- a/packages/core/src/utils/example-names.ts
+++ b/packages/core/src/utils/example-names.ts
@@ -1,3 +1,10 @@
+/**
+ * Fixed roster of gender-neutral placeholder display names for seeding examples
+ * and synthetic entities, plus pickRandomExampleName for a random pick (with a
+ * `user<n>` fallback). The ordered `as const` list keeps seeded consumers
+ * (deterministic.ts) reproducible across runs.
+ */
+
 export const EXAMPLE_NAMES = [
 	"Avery",
 	"Blake",

--- a/packages/core/src/utils/format-error.test.ts
+++ b/packages/core/src/utils/format-error.test.ts
@@ -1,6 +1,3 @@
-import { describe, expect, it } from "vitest";
-import { formatError } from "./format-error.ts";
-
 /**
  * `formatError` is the canonical error-message extractor and runs on failure
  * paths across the runtime, so it must never itself throw and mask the original
@@ -9,6 +6,10 @@ import { formatError } from "./format-error.ts";
  * `toString` / `Symbol.toPrimitive`; a pathological `Error` subclass can expose
  * a throwing `message` getter. Every one of these must resolve to a string.
  */
+
+import { describe, expect, it } from "vitest";
+import { formatError } from "./format-error.ts";
+
 describe("formatError", () => {
 	it("returns an Error's message", () => {
 		expect(formatError(new Error("socket hang up"))).toBe("socket hang up");

--- a/packages/core/src/utils/json-llm.test.ts
+++ b/packages/core/src/utils/json-llm.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import { extractAndParseJSONObjectFromText } from "./json-llm";
 
 /**
- * Tests for the core LLM-output JSON parser (#8801 / #9943). This is used across
- * the runtime to turn a model's text into a structured object; a regression
- * breaks every structured output. It was untested.
+ * Tests for `extractAndParseJSONObjectFromText`, the core LLM-output JSON parser
+ * (#8801 / #9943): it turns a model's text into a structured object, so a
+ * regression here breaks every structured model output.
  */
 describe("extractAndParseJSONObjectFromText", () => {
 	it("parses a plain JSON object", () => {

--- a/packages/core/src/utils/message-text.test.ts
+++ b/packages/core/src/utils/message-text.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests for `getUserMessageText`, covering that a connector's current-turn text
+ * wins over the rendered channel envelope stored on the message content.
+ */
 import { describe, expect, it } from "vitest";
 import type { Memory } from "../types/memory";
 import { getUserMessageText } from "./message-text";

--- a/packages/core/src/utils/message-text.ts
+++ b/packages/core/src/utils/message-text.ts
@@ -1,3 +1,10 @@
+/**
+ * Extracts the user's actual request text from a message `Memory`. Unwraps the
+ * document-augmentation `<user_request>` envelope, strips a trailing
+ * `[language instruction: ...]` suffix, and caps oversized input. Prefers a
+ * connector's `currentMessageText` over the rendered `text`, and offers a
+ * lowercased, whitespace-collapsed variant for matching.
+ */
 import type { Memory } from "../types/memory";
 
 const DOCUMENT_AUGMENTATION_PREFIX =

--- a/packages/core/src/utils/model-errors.ts
+++ b/packages/core/src/utils/model-errors.ts
@@ -1,3 +1,9 @@
+/**
+ * Classifies model-call errors as transient (worth retrying) by scanning the
+ * error message for known rate-limit, overload, timeout, and 5xx signatures.
+ * Retry logic around model invocations consumes this to decide whether to back
+ * off and try again versus surface the failure.
+ */
 const TRANSIENT_MODEL_ERROR_PATTERNS = [
 	"service temporarily unavailable",
 	"temporarily unavailable",

--- a/packages/core/src/utils/model-lookup-caller.test.ts
+++ b/packages/core/src/utils/model-lookup-caller.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests for `captureModelLookupCaller` / `captureModelLookupCallerFromStack`,
+ * covering plugin/package attribution across live stacks, installed
+ * `node_modules` and pnpm virtual-store layouts, and rejection of third-party
+ * frames.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	captureModelLookupCaller,

--- a/packages/core/src/utils/model-lookup-caller.ts
+++ b/packages/core/src/utils/model-lookup-caller.ts
@@ -1,3 +1,10 @@
+/**
+ * Attributes a `runtime.useModel()` call to the plugin or package that triggered
+ * it by parsing the captured stack trace down to package names, skipping internal
+ * runtime frames and unrelated third-party `node_modules` dependencies while
+ * still crediting installed `@elizaos/*` packages. Feeds model-lookup debug
+ * diagnostics.
+ */
 export type ModelLookupCallerTrace = {
 	/** Outermost plugin or package that triggered the lookup. */
 	caller?: string;

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -1,3 +1,10 @@
+/**
+ * Resolves and caches the filesystem directories elizaOS reads and writes — data,
+ * database, characters, generated, and upload folders. Each is overridable by a
+ * dedicated env var and otherwise derived from the resolved state dir. Exposes a
+ * process-wide cached singleton, per-directory accessors, and a reset used by
+ * tests.
+ */
 import { join } from "node:path";
 import { resolveStateDir } from "./state-dir";
 

--- a/packages/core/src/utils/prompt-batcher.ts
+++ b/packages/core/src/utils/prompt-batcher.ts
@@ -1,3 +1,8 @@
+/**
+ * Public entry point for the prompt batcher: re-exports the batcher and
+ * dispatcher classes, shared helpers, and types that coalesce many per-section
+ * prompt requests into batched model calls.
+ */
 export {
 	BatcherDisposedError,
 	type BatcherStats,

--- a/packages/core/src/utils/prompt-batcher/batcher.test.ts
+++ b/packages/core/src/utils/prompt-batcher/batcher.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Exercises PromptBatcher's recurring drain loop, minCycleMs throttling, and
+ * once-section cache reuse / stale-while-revalidate against an in-memory runtime
+ * and a fake dispatcher (no real model calls).
+ */
 import { describe, expect, test } from "vitest";
 import type {
 	BatcherResult,

--- a/packages/core/src/utils/prompt-batcher/batcher.ts
+++ b/packages/core/src/utils/prompt-batcher/batcher.ts
@@ -1,3 +1,12 @@
+/**
+ * Batches many independent structured prompt "sections" into a small number of
+ * pooled LLM calls, keyed by affinity group, to cut per-turn model traffic.
+ * Owns the section registry, per-message buffers, the in-memory + persisted
+ * result cache, and one repeating drain task per affinity; consumers register
+ * sections through askOnce / askNow / onDrain / think and await the resolved
+ * fields (or receive them via onResult). The runtime constructs one
+ * PromptBatcher singleton and feeds it messages via tick().
+ */
 import type { Memory } from "../../types/memory";
 import type { GenerateTextParams } from "../../types/model";
 import {
@@ -290,7 +299,7 @@ export class PromptBatcher {
 		this.inMemoryCache.delete(cacheKey);
 		// error-policy:J7 best-effort DB cache invalidation — the in-memory entry is
 		// already cleared above and a stale DB cache row is harmless, so a delete
-		// failure (deleteCache now throws on DB error, #12269) must NOT become an
+		// failure (deleteCache throws on DB error, #12269) must NOT become an
 		// unhandled rejection that terminates one-shot CLI / embedded hosts. Surface
 		// via reportError, never rethrow.
 		void this.runtime

--- a/packages/core/src/utils/prompt-batcher/dispatcher.test.ts
+++ b/packages/core/src/utils/prompt-batcher/dispatcher.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies PromptDispatcher threads each section's retry budget into structured
+ * model calls and tags call-plan priority (background vs interactive, #11914),
+ * against a mock runtime whose dynamicPromptExecFromState is stubbed.
+ */
 import { describe, expect, test } from "vitest";
 import { createMockRuntime } from "../../testing/mock-runtime";
 import type { ResolvedSection } from "../../types/prompt-batcher";

--- a/packages/core/src/utils/prompt-batcher/dispatcher.ts
+++ b/packages/core/src/utils/prompt-batcher/dispatcher.ts
@@ -1,3 +1,12 @@
+/**
+ * Packs resolved prompt sections into batched model call plans and executes
+ * them: groups by affinity, then priority, then model preference; bin-packs
+ * packable sections under a per-call token budget while isolated sections go
+ * alone; runs the plans through a concurrency-limited semaphore; then
+ * de-namespaces the pooled response back into per-section field maps. Returns
+ * the per-section results plus per-call metadata for the batcher's stats and
+ * drain log. Consumed by PromptBatcher.
+ */
 import type { GenerateTextParams } from "../../types/model";
 import type { ResolvedSection } from "../../types/prompt-batcher";
 import type { IAgentRuntime } from "../../types/runtime";

--- a/packages/core/src/utils/prompt-batcher/shared.ts
+++ b/packages/core/src/utils/prompt-batcher/shared.ts
@@ -1,3 +1,12 @@
+/**
+ * Shared types and pure helpers for the prompt-batcher (batcher + dispatcher):
+ * the deferred, cache-entry, call-meta, and settings shapes, plus identifier
+ * sanitizing, retry-count clamping (0..2, floored), minimal-State construction,
+ * character-context assembly, per-platform source-message id derivation for
+ * dedup, schema field picking, section-drift comparison, and an incremental
+ * rolling average. Re-exports the single Semaphore implementation for the
+ * dispatcher.
+ */
 import type { Memory } from "../../types/memory";
 import type {
 	BatcherResult,

--- a/packages/core/src/utils/prompt-compression.ts
+++ b/packages/core/src/utils/prompt-compression.ts
@@ -1,1 +1,2 @@
+/** Re-exports the prompt-description compressor from `@elizaos/prompts` on the core utils surface. */
 export { compressPromptDescription } from "@elizaos/prompts";

--- a/packages/core/src/utils/read-env.test.ts
+++ b/packages/core/src/utils/read-env.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers readEnv / readEnvBool: canonical-key lookup, default fallback,
+ * whitespace-only treated as unset, and truthy/falsy string parsing (against an
+ * injected env map, not process.env).
+ */
 import { describe, expect, it } from "vitest";
 import { readEnv, readEnvBool } from "./read-env.ts";
 

--- a/packages/core/src/utils/recursive-character-text-splitter.ts
+++ b/packages/core/src/utils/recursive-character-text-splitter.ts
@@ -1,3 +1,11 @@
+/**
+ * Character-count text chunker: recursively splits text on separators from
+ * coarsest to finest (paragraph, line, space, character) and re-merges adjacent
+ * pieces up to chunkSize, carrying chunkOverlap between successive chunks. The
+ * length function may be async; chunkOverlap must be < chunkSize or the
+ * constructor throws. Pieces that still exceed chunkSize are emitted and logged
+ * as a warning.
+ */
 import logger from "../logger";
 
 /** Parameters for {@link RecursiveCharacterTextSplitter}. */

--- a/packages/core/src/utils/resolve-setting.test.ts
+++ b/packages/core/src/utils/resolve-setting.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests for resolveSetting: runtime-setting-wins-over-env precedence, non-string
+ * coercion, the readEnv-based env fallback (whitespace treated as unset), and
+ * default handling, driven through an in-memory SettingReader stub rather than a
+ * live runtime.
+ */
 import { describe, expect, it } from "vitest";
 import { resolveSetting, type SettingReader } from "./resolve-setting.ts";
 

--- a/packages/core/src/utils/retry.backoff.test.ts
+++ b/packages/core/src/utils/retry.backoff.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import { type BackoffPolicy, computeBackoff } from "./retry";
 
 /**
- * Tests for the restart/retry backoff math (#10203 / #10197 stability, #8801).
- * computeBackoff drives crash-recovery and retry delays; the exponential growth,
- * the attempt clamp, the maxMs cap, and the jitter bounds were untested.
+ * Tests for the restart/retry backoff math. computeBackoff drives crash-recovery
+ * and retry delays; these cover the exponential growth, the attempt clamp, the
+ * maxMs cap, and the jitter bounds.
  */
 const noJitter: BackoffPolicy = {
 	initialMs: 100,

--- a/packages/core/src/utils/state-dir.test.ts
+++ b/packages/core/src/utils/state-dir.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests for the state-directory resolvers (`resolveStateDir`,
+ * `getElizaNamespace`, `resolveOAuthDir`, `resolveUserPath`, `migrateStateDir`):
+ * env/XDG precedence and `~` expansion are checked against a platform-portable
+ * fake homedir, and `migrateStateDir` runs against real temp directories.
+ */
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, resolve, sep } from "node:path";

--- a/packages/core/src/utils/synthetic-conversation-artifact.ts
+++ b/packages/core/src/utils/synthetic-conversation-artifact.ts
@@ -1,3 +1,10 @@
+/**
+ * Detects whether a piece of text or a memory is a synthetic conversation
+ * artifact — a compaction/summary/hybrid-ledger record the runtime generated —
+ * rather than a genuine turn. The text form matches summary markers and
+ * phrasing; the memory form also inspects `metadata.source` and `tags`. Used to
+ * keep synthesized state out of paths that should only see real messages.
+ */
 import type { Memory } from "../types/memory.ts";
 
 const SYNTHETIC_SOURCE_RE = /\b(?:compaction|compactor|synthetic|summary)\b/i;

--- a/packages/core/src/utils/text-splitting.test.ts
+++ b/packages/core/src/utils/text-splitting.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests for `extractFirstSentence`, the sentence-boundary splitter behind
+ * reply/TTS early-emit: the cases pin abbreviation handling (e.g./i.e./Mr./Dr.,
+ * including quoted/parenthesized/emphasized forms) so it never chops a reply
+ * mid-abbreviation.
+ */
 import { describe, expect, it } from "vitest";
 import { extractFirstSentence } from "./text-splitting.ts";
 

--- a/packages/core/src/utils/type-guards.ts
+++ b/packages/core/src/utils/type-guards.ts
@@ -1,3 +1,10 @@
+/**
+ * Runtime type guards that narrow `unknown` to record-shaped values.
+ * `isPlainObject` accepts only object-literal / null-prototype objects,
+ * rejecting built-ins (Date, Map, typed arrays, Error, Promise, …) and class
+ * instances; `isObjectRecord` is the looser any-non-null-non-array-object check;
+ * `asRecord` / `asRecordOrUndefined` narrow-or-nullify for safe property access.
+ */
 const NON_PLAIN_CONSTRUCTORS = new Set([
 	Array,
 	Date,

--- a/packages/core/src/utils/workspace-folder-config.test.ts
+++ b/packages/core/src/utils/workspace-folder-config.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests for the workspace-folder config store (`read`/`write`/`clear` +
+ * `workspaceFolderConfigPath`): round-trips path + bookmark, tolerates null
+ * bookmarks and malformed JSON, and honors `ELIZA_STATE_DIR`, all against a real
+ * temp state directory.
+ */
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";


### PR DESCRIPTION
## What

Batch **B01 part 4 (final)** of the repo-wide comment cleanup (#12231, parent #12181) —
`packages/core/src/services` (long-lived runtime singletons) and `packages/core/src/utils`
(shared helpers). Completes the packages/core header sweep for B01.

**Comments only — zero functional diff.** Machine-proven by `node scripts/assert-comment-only-diff.mjs`:
every changed file's TypeScript code-token stream is byte-identical to base.

## Scope (77 files)

`services/` + `utils/` — service headers name what each singleton owns and who consumes it;
util headers state what each helper computes and its contract/edge cases.

Completes B01 across #12824 (p1: boundary/data/schema subsystems), #12874 (p2: root + types
load-bearing modules incl. runtime.ts), #12926 (p3: features subsystems), and this PR.

## Verification
```
node scripts/assert-comment-only-diff.mjs
# OK — 77 source file(s) changed; every code token identical to base. Comments only.
```
Part of #12231.