### PR TITLE
fix(#12903): normalize game example scripts

### DIFF
--- a/.github/issue-evidence/12903-game-examples-script-contract.md
+++ b/.github/issue-evidence/12903-game-examples-script-contract.md
@@ -1,0 +1,86 @@
+# #12903 game examples script-contract evidence
+
+Branch slice: normalize script contracts for three simple runnable examples.
+
+## Packages
+
+- `packages/examples/game-of-life`
+- `packages/examples/text-adventure`
+- `packages/examples/tic-tac-toe`
+
+## Script contract changes
+
+- Removed `build: bun run typecheck`; these packages do not emit build
+  artifacts.
+- Kept `typecheck` as the real TypeScript validation command.
+- Added read-only `lint:check`.
+- Added `format` and read-only `format:check`.
+
+## Verification
+
+Current working tree: `origin/develop` at `8572de50ec`.
+
+Static guard:
+
+```bash
+node - <<'NODE'
+const fs = require('fs');
+for (const p of ['packages/examples/game-of-life/package.json','packages/examples/text-adventure/package.json','packages/examples/tic-tac-toe/package.json']) {
+  const pkg = JSON.parse(fs.readFileSync(p,'utf8'));
+  const scripts = pkg.scripts || {};
+  const bad = [];
+  if ('build' in scripts) bad.push(`build=${scripts.build}`);
+  if (!scripts.typecheck) bad.push('missing typecheck');
+  for (const name of ['lint:check','format','format:check']) if (!scripts[name]) bad.push(`missing ${name}`);
+  if (bad.length) { console.error(`${p}: ${bad.join('; ')}`); process.exitCode = 1; }
+  else console.log(`${p}: fake build removed; check verbs present`);
+}
+NODE
+```
+
+Result:
+
+```text
+packages/examples/game-of-life/package.json: fake build removed; check verbs present
+packages/examples/text-adventure/package.json: fake build removed; check verbs present
+packages/examples/tic-tac-toe/package.json: fake build removed; check verbs present
+```
+
+Read-only lint and format:
+
+```bash
+bun run --cwd packages/examples/game-of-life lint:check
+bun run --cwd packages/examples/game-of-life format:check
+bun run --cwd packages/examples/text-adventure lint:check
+bun run --cwd packages/examples/text-adventure format:check
+bun run --cwd packages/examples/tic-tac-toe lint:check
+bun run --cwd packages/examples/tic-tac-toe format:check
+```
+
+Result:
+
+```text
+packages/examples/game-of-life: biome check passed for 3 files; biome format passed for 3 files.
+packages/examples/text-adventure: biome check passed for 4 files; biome format passed for 4 files.
+packages/examples/tic-tac-toe: biome check passed for 3 files; biome format passed for 3 files.
+```
+
+## Local blockers
+
+This auxiliary worktree does not have a valid workspace install.
+
+```text
+bun run --cwd packages/examples/game-of-life test
+  ENOENT while resolving package '@elizaos/core'
+
+bun run --cwd packages/examples/text-adventure test
+  Cannot find module '@clack/prompts'
+
+bun run --cwd packages/examples/tic-tac-toe test
+  ENOENT while resolving package '@elizaos/core'
+
+bun run --cwd <each package> typecheck
+  error TS2688: Cannot find type definition file for 'node'
+```
+
+This slice changes only package scripts; it does not change runtime or test code.

--- a/packages/examples/game-of-life/package.json
+++ b/packages/examples/game-of-life/package.json
@@ -10,8 +10,10 @@
     "stats": "bun run game.ts --stats",
     "test": "bun run game.ts --fast --agents=2 --ticks=3",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "typecheck": "tsgo --noEmit",
-    "build": "bun run typecheck"
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/packages/examples/text-adventure/package.json
+++ b/packages/examples/text-adventure/package.json
@@ -8,8 +8,10 @@
     "dev": "bun --watch run game.ts",
     "test": "bun test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "typecheck": "tsgo --noEmit",
-    "build": "bun run typecheck"
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/packages/examples/tic-tac-toe/package.json
+++ b/packages/examples/tic-tac-toe/package.json
@@ -11,8 +11,10 @@
     "bench": "bun run game.ts --bench",
     "test": "bun run game.ts --bench --no-prompt --iterations=5",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "typecheck": "tsgo --noEmit",
-    "build": "bun run typecheck"
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",


### PR DESCRIPTION
## Summary

Fixes a #12903 script-normalization slice for simple game examples:

- removes fake `build: bun run typecheck` from Game of Life, Text Adventure, and Tic Tac Toe examples
- keeps `typecheck` as the real TypeScript validation command
- adds `lint:check`, `format`, and `format:check`
- records evidence in `.github/issue-evidence/12903-game-examples-script-contract.md`

## Why

The #12903 contract reserves `build` for emitted artifacts and requires real read-only check verbs. These examples are runnable TypeScript programs and tests, but they do not produce package-level build output.

## Verification

- `git diff --check origin/develop..HEAD`
- JSON parse check for the edited `package.json` files
- static guard confirming `build` is removed, `typecheck` remains, and check verbs exist
- `bun run --cwd packages/examples/game-of-life lint:check`
- `bun run --cwd packages/examples/game-of-life format:check`
- `bun run --cwd packages/examples/text-adventure lint:check`
- `bun run --cwd packages/examples/text-adventure format:check`
- `bun run --cwd packages/examples/tic-tac-toe lint:check`
- `bun run --cwd packages/examples/tic-tac-toe format:check`

## Known local limitations

Full `bun install` / `bun run verify` were not run in this auxiliary worktree because the filesystem has about 4 GiB free. Tests and typechecks were attempted and are blocked by missing workspace-installed runtime/type dependencies in this worktree. Details are in the evidence file.
