### PR TITLE
docs(#12804): finish lifeops connector prose headers

### DIFF
--- a/plugins/plugin-calendar/src/actions/calendar.ts
+++ b/plugins/plugin-calendar/src/actions/calendar.ts
@@ -1,3 +1,9 @@
+/**
+ * Registers the scaffolded owner-facing CALENDAR umbrella action. The moved
+ * calendar handler lives in `calendar-handler.ts`; this action preserves the
+ * planner-facing sub-op vocabulary while each op still reports a scaffold
+ * failure until routed through the full calendar runner.
+ */
 import type {
   Action,
   ActionResult,
@@ -6,14 +12,6 @@ import type {
   Memory,
   State,
 } from "@elizaos/core";
-
-/**
- * Scaffold stub for the owner-facing `CALENDAR` umbrella action. Registers the
- * action contract and its sub-op vocabulary (read feed, create/update/delete
- * events, find slots, travel buffers, conflict-on-create); every sub-op returns
- * a `scaffold_stub` failure. The lower-level `createCalendarActionRunner`
- * (`./calendar-handler.ts`) is the runner `plugin-lifeops` drives today.
- */
 
 const CALENDAR_OPS = [
   "read_feed",

--- a/plugins/plugin-calendar/src/actions/conflict-detect.ts
+++ b/plugins/plugin-calendar/src/actions/conflict-detect.ts
@@ -1,3 +1,9 @@
+/**
+ * Registers the scaffolded CONFLICT_DETECT action and its calendar-conflict
+ * sub-op vocabulary. The action is intentionally non-mutating until the full
+ * conflict scanner is migrated; each recognized op returns a scaffold failure
+ * instead of pretending to inspect the owner's feed.
+ */
 import type {
   Action,
   ActionResult,
@@ -6,14 +12,6 @@ import type {
   Memory,
   State,
 } from "@elizaos/core";
-
-/**
- * Scaffold stub for the `CONFLICT_DETECT` calendar-conflict scanner action.
- * Registers the subaction vocabulary — `scan_today` (overlapping events today),
- * `scan_week` (overlaps across the rolling week), and `scan_event_proposal`
- * (a proposed window vs the owner feed) — each returning a `scaffold_stub`
- * failure naming the subaction.
- */
 
 const CONFLICT_DETECT_OPS = [
   "scan_today",

--- a/plugins/plugin-calendar/src/actions/deps.ts
+++ b/plugins/plugin-calendar/src/actions/deps.ts
@@ -1,3 +1,9 @@
+/**
+ * Defines the host seams used by the moved calendar action runner. LifeOps
+ * still owns model execution, recent-conversation grounding, and optional
+ * travel-buffer computation, so the calendar handler receives those capabilities
+ * through this typed dependency object instead of importing LifeOps internals.
+ */
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import type { LifeOpsCalendarEvent } from "@elizaos/shared";
 

--- a/plugins/plugin-calendar/src/internal/detail.ts
+++ b/plugins/plugin-calendar/src/internal/detail.ts
@@ -1,11 +1,11 @@
+/**
+ * Normalizes loose action-detail records into typed primitives and parses model
+ * JSON responses after removing common wrapper formats. Calendar action handlers
+ * use these helpers at the LLM/runtime boundary so malformed details fail to
+ * resolve instead of leaking weak casts through the event service.
+ */
 import type { Memory, ProviderDataRecord } from "@elizaos/core";
 
-/**
- * Internal request URL passed as the `requestUrl` argument to
- * `CalendarService` methods. The calendar service only uses this to read the
- * connector mode/side from query params for remote requests; for in-process
- * action handlers a fixed loopback URL is correct.
- */
 export const INTERNAL_URL = new URL("http://127.0.0.1/");
 
 export function toActionData<T extends object>(data: T): ProviderDataRecord {

--- a/plugins/plugin-calendar/src/meetings/auto-join-settings.ts
+++ b/plugins/plugin-calendar/src/meetings/auto-join-settings.ts
@@ -1,3 +1,9 @@
+/**
+ * Persists the per-agent policy for automatically joining meetings discovered
+ * from calendar events. The policy is stored in runtime cache, keeping the
+ * calendar package independent from LifeOps scheduler state while preserving
+ * the owner-visible off/ask/all behavior.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 
 /**

--- a/plugins/plugin-calendar/src/service/feed-preferences.ts
+++ b/plugins/plugin-calendar/src/service/feed-preferences.ts
@@ -1,3 +1,8 @@
+/**
+ * Stores calendar feed-inclusion preferences in the runtime cache. Keys combine
+ * connector grant id and calendar id so multi-account Google users can include
+ * or hide each calendar without depending on LifeOps scheduler metadata.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 
 /**

--- a/plugins/plugin-calendar/src/service/gate.ts
+++ b/plugins/plugin-calendar/src/service/gate.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines the cross-domain host gate used by CalendarService. Calendar owns
+ * event/sync persistence, while Google grant lookup, reminder plans, and audit
+ * rows are supplied by the host or LifeOps through this seam.
+ */
 import crypto from "node:crypto";
 import {
   getConnectorAccountManager,
@@ -20,18 +25,6 @@ import {
   resolveGoogleConnectorAccount,
 } from "../internal/google-delegates.js";
 
-/**
- * Cross-domain seam for the calendar service. Calendar owns the calendar event
- * and sync-state tables; the work below belongs to other domains:
- *
- * - **Google connector grants/accounts** are owned by the host's connector
- *   layer (LifeOps' Google service mixin). The default gate resolves them
- *   directly through `@elizaos/plugin-google` connector accounts.
- * - **Reminder plans** and **audit events** are owned by LifeOps' repository.
- *   The default gate no-ops them; LifeOps injects a real implementation via
- *   `CalendarService.setGate(...)` so calendar events keep firing reminders
- *   and writing audit rows.
- */
 export interface CalendarHostGate {
   getGoogleConnectorAccounts(
     requestUrl: URL,

--- a/plugins/plugin-calendar/test/parse-explicit-local-date.test.ts
+++ b/plugins/plugin-calendar/test/parse-explicit-local-date.test.ts
@@ -1,15 +1,13 @@
+/**
+ * Covers relative-date phrasing for the deterministic CALENDAR date resolver.
+ * The assertions compute expected local dates through the same timezone helpers
+ * the resolver uses, so they stay clock-independent while guarding everyday
+ * phrases like "tomorrow" and "in ten days."
+ */
 import { describe, expect, it } from "vitest";
 import { parseExplicitLocalDate } from "../src/actions/calendar-handler.js";
 import { addDaysToLocalDate, getZonedDateParts } from "../src/internal/time.js";
 
-/**
- * Relative-date phrasing coverage (#8795). The deterministic date resolver used
- * by the CALENDAR action previously returned null for "today"/"tomorrow"/"in N
- * days" — the exact everyday phrasing in the action's own examples ("Schedule a
- * meeting with Alex at 3pm tomorrow") — forcing an avoidable LLM round-trip.
- * These assert the offsets relative to "today" in a fixed timezone, computed
- * with the same time helpers the resolver uses so the test is clock-independent.
- */
 const TZ = "America/New_York";
 
 function expectedFromToday(offset: number) {

--- a/plugins/plugin-inbox/src/db/schema.ts
+++ b/plugins/plugin-inbox/src/db/schema.ts
@@ -1,19 +1,11 @@
+/**
+ * Defines the plugin-inbox Drizzle schema for triage entries, examples, and
+ * email-unsubscribe history. The table and column names mirror their original
+ * `app_lifeops` forms so InboxMigrationService can copy existing data into the
+ * plugin-owned `app_inbox` namespace without destructive rewrites.
+ */
 import { boolean, integer, pgSchema, real, text } from "drizzle-orm/pg-core";
 
-/**
- * Drizzle schema for plugin-inbox.
- *
- * The inbox-triage tables (`life_inbox_triage_entries`,
- * `life_inbox_triage_examples`, `life_email_unsubscribes`) were carved out of
- * `@elizaos/plugin-personal-assistant`'s `app_lifeops` schema into `app_inbox`,
- * owned by this plugin. Table + column names (and column order) are preserved
- * verbatim so the non-destructive `InboxMigrationService` can copy existing
- * `app_lifeops` rows across on first boot. The runtime registers this schema
- * through `@elizaos/plugin-sql`.
- *
- * Gmail sync/projection tables (`life_gmail_*`, `life_inbox_messages`) are NOT
- * part of the inbox-triage domain — they stay owned by PA in `app_lifeops`.
- */
 export const inboxSchema = pgSchema("app_inbox");
 
 export const lifeInboxTriageEntries = inboxSchema.table(

--- a/plugins/plugin-inbox/src/db/sql.ts
+++ b/plugins/plugin-inbox/src/db/sql.ts
@@ -1,11 +1,10 @@
-import type { IAgentRuntime } from "@elizaos/core";
-
 /**
- * Self-contained raw-SQL helpers for the inbox back-end. Copied verbatim from
- * the PA LifeOps sql helpers (renamed error prefixes) so this plugin carries no
- * dependency on `@elizaos/plugin-personal-assistant`. Keep in sync only when a
- * correctness fix applies to both; do not add inbox-specific logic here.
+ * Provides the raw-SQL value encoders and row coercion helpers used by the
+ * inbox repositories. This is a self-contained copy of the LifeOps SQL helper
+ * surface so plugin-inbox can own `app_inbox` persistence without importing
+ * `@elizaos/plugin-personal-assistant`.
  */
+import type { IAgentRuntime } from "@elizaos/core";
 
 export type RawSqlQuery = {
   queryChunks: Array<{ value?: unknown }>;

--- a/plugins/plugin-inbox/src/inbox/channel-deep-links.test.ts
+++ b/plugins/plugin-inbox/src/inbox/channel-deep-links.test.ts
@@ -1,7 +1,11 @@
+/**
+ * Exercises pure per-channel deep-link URL construction for cross-channel
+ * inbox triage. The cases pin platform-specific identifiers so queue entries
+ * can link back to Discord, Telegram, Signal, iMessage, WhatsApp, Slack, Gmail,
+ * and other source threads without dispatching connector calls.
+ */
 import { describe, expect, it } from "vitest";
 import { buildDeepLink, resolveChannelName } from "./channel-deep-links.js";
-
-/** Pure per-channel deep-link URL construction for cross-channel inbox triage. */
 
 describe("buildDeepLink — Discord", () => {
   it("builds a guild channel link, with optional message", () => {

--- a/plugins/plugin-inbox/src/inbox/config.ts
+++ b/plugins/plugin-inbox/src/inbox/config.ts
@@ -1,10 +1,11 @@
+/**
+ * Loads inbox triage defaults plus optional owner/agent overrides from the
+ * agent config. Nested settings are deep-merged so partial auto-reply or rule
+ * overrides do not erase the plugin's default safety thresholds.
+ */
 import { loadElizaConfig } from "@elizaos/agent/config/config";
 import type { InboxTriageConfig } from "./types.js";
 
-/**
- * Load inbox triage configuration from the agent config file.
- * Falls back to sensible defaults when not configured.
- */
 export function loadInboxTriageConfig(): InboxTriageConfig {
   try {
     const cfg = loadElizaConfig();
@@ -15,7 +16,7 @@ export function loadInboxTriageConfig(): InboxTriageConfig {
       return deepMergeConfig(DEFAULT_CONFIG, raw);
     }
   } catch {
-    // Config loading failed; use defaults
+    // Startup can run before a config file exists; defaults keep triage inert.
   }
   return { ...DEFAULT_CONFIG };
 }

--- a/plugins/plugin-inbox/src/inbox/gmail-normalize.test.ts
+++ b/plugins/plugin-inbox/src/inbox/gmail-normalize.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers Gmail input normalization for owner and LLM-supplied query values.
+ * These tests pin address extraction, mailbox-list splitting, duration parsing,
+ * and label/message id validation before values reach Gmail API calls.
+ */
 import { describe, expect, it } from "vitest";
 import {
   extractNormalizedEmailAddress,
@@ -7,15 +12,6 @@ import {
   parseGmailRelativeDuration,
   splitMailboxLikeList,
 } from "./gmail-normalize.ts";
-
-/**
- * Gmail input normalization. These run on owner-/LLM-supplied query params and
- * raw RFC5322-ish header strings: email extraction must pull the address out of
- * "Name <addr>" / mailto: forms and lowercase it, the mailbox splitter must not
- * break on commas inside quotes or angle brackets, and the label-id validator
- * must reject anything outside Gmail's id charset (so a crafted label id can't
- * smuggle characters into a Gmail API call).
- */
 
 describe("extractNormalizedEmailAddress", () => {
   it("pulls + lowercases the address from common forms", () => {

--- a/plugins/plugin-inbox/src/inbox/migration.test.ts
+++ b/plugins/plugin-inbox/src/inbox/migration.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers the non-destructive `app_lifeops` to `app_inbox` table-copy migration
+ * through an injected in-memory SQL executor. The suite guards source-missing
+ * and target-non-empty skips, snooze-column repair, and the invariant that the
+ * source schema is never dropped or altered.
+ */
 import { describe, expect, it } from "vitest";
 import {
   MIGRATED_INBOX_TABLES,
@@ -5,13 +11,6 @@ import {
   migrateInboxTables,
   type SqlExecutor,
 } from "./migration.ts";
-
-/**
- * Covers the non-destructive `app_lifeops` -> `app_inbox` triage-table copy
- * against an injected in-memory `SqlExecutor` (no real DB): skip when the source
- * is missing or the target is non-empty, never drop the source, and map old rows
- * with `NULL AS snoozed_until`.
- */
 
 /** A scripted executor: each statement is matched by substring → response. */
 function fakeExec(

--- a/plugins/plugin-inbox/src/inbox/unsubscribe-repository.ts
+++ b/plugins/plugin-inbox/src/inbox/unsubscribe-repository.ts
@@ -1,3 +1,9 @@
+/**
+ * Implements the raw-SQL repository for email-unsubscribe history in
+ * `app_inbox.life_email_unsubscribes`. It mirrors the inbox repository pattern:
+ * thin runtime-DB access, explicit value encoding, and no dependency on
+ * `@elizaos/plugin-personal-assistant`.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import {
   executeRawSql,
@@ -17,15 +23,6 @@ import type {
   EmailUnsubscribeStatus,
 } from "./email-unsubscribe-types.ts";
 
-/**
- * Raw-SQL repository for the email-unsubscribe history.
- *
- * Reads/writes `app_inbox.life_email_unsubscribes`, the table PA still
- * registers + migrates (no data migration — the table name is preserved). Same
- * pattern as {@link InboxRepository}: a thin raw-SQL wrapper over the runtime DB
- * handle so this plugin carries no `@elizaos/plugin-personal-assistant`
- * dependency.
- */
 function parseEmailUnsubscribe(
   row: Record<string, unknown>,
 ): EmailUnsubscribeRecord {

--- a/plugins/plugin-inbox/test/gmail-normalize.test.ts
+++ b/plugins/plugin-inbox/test/gmail-normalize.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Guards the public Gmail normalization helpers used by inbox tests and
+ * integration callers. These cases cover delimiter handling, address
+ * canonicalization, and range checks for search and unresponded-age filters.
+ */
 import { describe, expect, it } from "vitest";
 import {
   extractNormalizedEmailAddress,
@@ -7,13 +12,6 @@ import {
   parseGmailRelativeDuration,
   splitMailboxLikeList,
 } from "../src/inbox/gmail-normalize.js";
-
-/**
- * Pure parsers over untrusted Gmail input — recipient lists, addresses, and
- * search/duration filters. They must split on the right delimiters while
- * respecting quotes/angle brackets, canonicalize addresses, and reject
- * out-of-range or malformed values rather than silently coercing them.
- */
 
 describe("splitMailboxLikeList", () => {
   it("splits on , ; newline and || but not inside quotes or angle brackets", () => {

--- a/plugins/plugin-inbox/test/plugin-views.test.ts
+++ b/plugins/plugin-inbox/test/plugin-views.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Pins the plugin-inbox view and route registration contract in a Node test
+ * environment. The UI barrels are mocked so this can assert descriptor drift,
+ * view aliases, and HTTP route metadata without evaluating browser-only code.
+ */
 import { describe, expect, it, vi } from "vitest";
 
 // This node-env guard imports the real InboxView (to assert its function name
@@ -13,11 +18,6 @@ vi.mock("@elizaos/ui/agent-surface", () => ({
 
 import { InboxView } from "../src/components/inbox/InboxView.tsx";
 import { inboxPlugin } from "../src/plugin.ts";
-
-// Regression guard pinning the view-registration descriptor in src/plugin.ts to
-// the actually-exported component. If the componentExport name, route path, or
-// the email/mail aliases drift, view loading silently breaks at runtime; this
-// test fails loudly instead. Lives in the node env (no DOM needed).
 
 describe("inboxPlugin view registration", () => {
   it("registers exactly one view with the inbox descriptor", () => {


### PR DESCRIPTION
## Summary
- Completes the remaining #12804 prose-header cleanup across `plugin-calendar` and `plugin-inbox`.
- Confirms the full in-scope set now has top-of-file headers: calendar, inbox, meetings, contacts, and finances all audit at `MISSING=0`.
- Removes/moves stale lower file-purpose comments while keeping durable boundary notes; code tokens are unchanged.

Closes #12804

## Validation
- Read package guides for `plugin-calendar`, `plugin-inbox`, `plugin-meetings`, `plugin-contacts`, and `plugin-finances`.
- PASS: scoped header audit:
  - `plugins/plugin-calendar FILES=78 MISSING=0`
  - `plugins/plugin-inbox FILES=53 MISSING=0`
  - `plugins/plugin-meetings FILES=86 MISSING=0`
  - `plugins/plugin-contacts FILES=23 MISSING=0`
  - `plugins/plugin-finances FILES=39 MISSING=0`
- PASS: `bun run check:comment-only`
  - `[assert-comment-only-diff] OK — 17 source file(s) changed; every code token identical to origin/develop. Comments only.`
- PASS: `git diff --check`
- PASS: changed-file Biome check
  - `Checked 17 files in 27ms. No fixes applied.`

## Local blockers
- `bun run --cwd plugins/plugin-calendar test` is blocked in this auxiliary worktree by incomplete dependency/generated-artifact resolution (`@elizaos/shared`, `packages/core/src/i18n/generated/validation-keyword-data.ts`, `drizzle-orm`, React runtime imports). 5 files did execute and pass before suite startup failures; no failures reached changed code behavior.
- `bun run --cwd plugins/plugin-inbox test` is blocked in this auxiliary worktree by missing React package resolution in `vitest.config.ts`.
- `bun run verify` was not run because this branch is comments-only and the available worktree install is incomplete; the zero-code-token guard above is the authoritative behavior check for this slice.

## Evidence
- N/A - comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- N/A - no runtime, model, UI, audio, native, wallet/chain, or connector behavior changed.
