### PR TITLE
fix(#12903): normalize integration example scripts

### DIFF
--- a/.github/issue-evidence/12903-integration-examples-script-contract.md
+++ b/.github/issue-evidence/12903-integration-examples-script-contract.md
@@ -1,0 +1,95 @@
+# #12903 integration examples script-contract evidence
+
+Branch slice: normalize script contracts for three integration examples.
+
+## Packages
+
+- `packages/examples/cloudflare`
+- `packages/examples/farcaster`
+- `packages/examples/twitter-xai`
+
+## Script contract changes
+
+- Removed `build: bun run typecheck`; these packages do not emit build
+  artifacts.
+- Kept `typecheck` as the real TypeScript validation command.
+- Added `format` and read-only `format:check`.
+- Kept existing read-only `lint:check`.
+
+## Verification
+
+Current working tree: `origin/develop` at `c1f211d534`.
+
+Static guard:
+
+```bash
+node - <<'NODE'
+const fs = require('fs');
+for (const p of ['packages/examples/cloudflare/package.json','packages/examples/farcaster/package.json','packages/examples/twitter-xai/package.json']) {
+  const pkg = JSON.parse(fs.readFileSync(p,'utf8'));
+  const scripts = pkg.scripts || {};
+  const bad = [];
+  if ('build' in scripts) bad.push(`build=${scripts.build}`);
+  if (!scripts.typecheck) bad.push('missing typecheck');
+  for (const name of ['lint:check','format','format:check']) if (!scripts[name]) bad.push(`missing ${name}`);
+  if (bad.length) { console.error(`${p}: ${bad.join('; ')}`); process.exitCode = 1; }
+  else console.log(`${p}: fake build removed; check verbs present`);
+}
+NODE
+```
+
+Result:
+
+```text
+packages/examples/cloudflare/package.json: fake build removed; check verbs present
+packages/examples/farcaster/package.json: fake build removed; check verbs present
+packages/examples/twitter-xai/package.json: fake build removed; check verbs present
+```
+
+Read-only lint and format:
+
+```bash
+for pkg in packages/examples/cloudflare packages/examples/farcaster packages/examples/twitter-xai; do
+  bun run --cwd "$pkg" lint:check
+  bun run --cwd "$pkg" format:check
+done
+```
+
+Result:
+
+```text
+packages/examples/cloudflare: biome check passed for 4 files; biome format passed for 4 files.
+packages/examples/farcaster: biome check passed for 5 files; biome format passed for 5 files.
+packages/examples/twitter-xai: biome check passed for 5 files; biome format passed for 5 files.
+```
+
+## Runtime/test probes
+
+```text
+packages/examples/cloudflare test:
+  Worker not available at http://localhost:8787
+  Skipping integration tests (worker must be running)
+
+packages/examples/farcaster test:
+  Cannot find module '@elizaos/core'
+
+packages/examples/twitter-xai test:
+  Cannot find module '@elizaos/core'
+```
+
+Typecheck with a temporary
+`node_modules -> /Users/shawwalters/eliza/node_modules` symlink:
+
+```text
+packages/examples/cloudflare:
+  TS2688 cannot find type definition file for '@cloudflare/workers-types'
+
+packages/examples/farcaster:
+  TS2688 cannot find type definition file for 'node'
+
+packages/examples/twitter-xai:
+  TS2688 cannot find type definition file for 'node'
+```
+
+This auxiliary worktree has about 4 GiB free and no valid local install, so full
+`bun install` / `bun run verify` were not run here.

--- a/packages/examples/cloudflare/package.json
+++ b/packages/examples/cloudflare/package.json
@@ -14,8 +14,9 @@
     "secret": "wrangler secret put OPENAI_API_KEY",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
-    "typecheck": "tsgo --noEmit -p tsconfig.json",
-    "build": "bun run typecheck"
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "typecheck": "tsgo --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/packages/examples/farcaster/package.json
+++ b/packages/examples/farcaster/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsgo --noEmit",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
-    "build": "bun run typecheck"
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/packages/examples/twitter-xai/package.json
+++ b/packages/examples/twitter-xai/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsgo --noEmit",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
-    "build": "bun run typecheck"
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",


### PR DESCRIPTION
## Summary

Fixes a #12903 script-normalization slice for integration examples:

- removes fake `build: bun run typecheck` from Cloudflare, Farcaster, and xAI/X examples
- keeps `typecheck` as the real TypeScript validation command
- adds `format` and `format:check`
- records evidence in `.github/issue-evidence/12903-integration-examples-script-contract.md`

## Why

The #12903 contract reserves `build` for emitted artifacts and requires real read-only check verbs. These examples validate through `typecheck` and runtime tests, but they do not emit package-level build output.

## Verification

- `git diff --check origin/develop..HEAD`
- JSON parse check for edited `package.json` files
- static guard confirming `build` is removed, `typecheck` remains, and check verbs exist
- `bun run --cwd packages/examples/cloudflare lint:check`
- `bun run --cwd packages/examples/cloudflare format:check`
- `bun run --cwd packages/examples/farcaster lint:check`
- `bun run --cwd packages/examples/farcaster format:check`
- `bun run --cwd packages/examples/twitter-xai lint:check`
- `bun run --cwd packages/examples/twitter-xai format:check`

## Known local limitations

Full `bun install` / `bun run verify` were not run in this auxiliary worktree because the filesystem has about 4 GiB free. Tests and typechecks were attempted: Cloudflare test skips cleanly without a local worker, and Farcaster/xAI plus typechecks are blocked by missing workspace-installed runtime/type dependencies. Details are in the evidence file.
