### PR TITLE
fix(#12903): normalize benchmark library scripts

### DIFF
--- a/.github/issue-evidence/12903-benchmark-library-script-contract.md
+++ b/.github/issue-evidence/12903-benchmark-library-script-contract.md
@@ -1,0 +1,88 @@
+# Evidence: #12903 benchmark library script contract
+
+## Scope
+
+- `packages/benchmarks/framework/typescript/package.json`
+- `packages/benchmarks/lib/package.json`
+
+## Change
+
+- Removed artifact-free `build: bun run typecheck` scripts from the benchmark
+  framework package and shared benchmark library.
+- Kept `typecheck` as the real TypeScript validation command.
+- Added read-only `lint:check` and `format:check` verbs plus mutating
+  `format`.
+- Added package-local `check` scripts that run typecheck, lint check, and
+  format check.
+- Added the benchmark framework's missing workspace dependencies for the
+  `@elizaos/*` packages it imports during typecheck.
+
+## Verification
+
+Commands run on 2026-07-04 from a worktree rebased on current
+`origin/develop`:
+
+```bash
+git diff --check
+node - <<'NODE'
+const fs = require('fs');
+for (const p of [
+  'packages/benchmarks/framework/typescript/package.json',
+  'packages/benchmarks/lib/package.json',
+]) {
+  const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
+  const scripts = pkg.scripts || {};
+  const failures = [];
+  if ('build' in scripts) failures.push('build script should be absent');
+  for (const key of ['typecheck', 'lint', 'lint:check', 'format', 'format:check', 'check']) {
+    if (!scripts[key]) failures.push(`missing ${key}`);
+  }
+  for (const [name, value] of Object.entries(scripts)) {
+    if (/echo\s+|exit\s+0|\|\|\s*true/.test(String(value))) {
+      failures.push(`${name} masks success: ${value}`);
+    }
+  }
+  if (failures.length) {
+    console.error(`${p}: ${failures.join('; ')}`);
+    process.exitCode = 1;
+  } else {
+    console.log(`${p}: script contract ok`);
+  }
+}
+NODE
+bun run --cwd packages/benchmarks/framework/typescript check
+bun run --cwd packages/benchmarks/lib check
+bun run --cwd packages/benchmarks/lib test
+```
+
+Result:
+
+```text
+packages/benchmarks/framework/typescript/package.json: script contract ok
+packages/benchmarks/lib/package.json: script contract ok
+packages/benchmarks/framework/typescript lint:check: passed, 5 files
+packages/benchmarks/framework/typescript format:check: passed, 5 files
+packages/benchmarks/lib check: passed, 12 files lint/format checked
+packages/benchmarks/lib test: passed, 4 files / 44 tests
+```
+
+Local blocker:
+
+```text
+packages/benchmarks/framework/typescript check:
+  tsgo could not resolve @elizaos/plugin-openai or
+  @elizaos/plugin-cli-inference through this auxiliary worktree's inherited
+  node_modules symlink, even after adding the provider directories and building
+  them. This PR adds the missing workspace dependency declarations so a normal
+  workspace install can resolve those imports.
+```
+
+## Evidence Matrix
+
+- Real-LLM trajectories: N/A - package metadata script normalization only; no
+  benchmark scenario, model, prompt, or handler path changed.
+- Backend/frontend logs: N/A - no runtime server or UI behavior changed.
+- Screenshots/video/audio: N/A - no user-facing UI or audio behavior changed.
+- Domain artifacts: N/A - no benchmark result artifacts were produced by this
+  metadata-only change; package-local checks and tests exercise the changed
+  script surface.

--- a/packages/benchmarks/framework/typescript/package.json
+++ b/packages/benchmarks/framework/typescript/package.json
@@ -9,7 +9,15 @@
     "bench:real-llm": "LOG_LEVEL=${LOG_LEVEL:-fatal} bun run src/bench.ts --real-llm",
     "bench:real-llm:quick": "LOG_LEVEL=${LOG_LEVEL:-fatal} bun run src/bench.ts --real-llm --scenarios=single-message,conversation-10",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
     "typecheck": "tsgo --noEmit",
-    "build": "bun run typecheck"
+    "check": "bun run typecheck && bun run lint:check && bun run format:check"
+  },
+  "dependencies": {
+    "@elizaos/core": "workspace:*",
+    "@elizaos/plugin-cli-inference": "workspace:*",
+    "@elizaos/plugin-openai": "workspace:*"
   }
 }

--- a/packages/benchmarks/lib/package.json
+++ b/packages/benchmarks/lib/package.json
@@ -14,8 +14,12 @@
   },
   "scripts": {
     "test": "vitest run",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
     "typecheck": "tsgo --noEmit",
-    "build": "bun run typecheck"
+    "check": "bun run typecheck && bun run lint:check && bun run format:check"
   },
   "dependencies": {
     "zod": "^4.4.3"


### PR DESCRIPTION
## Summary

Refs #12903.

Normalizes script contracts for two benchmark support packages:

- `packages/benchmarks/framework/typescript`
- `packages/benchmarks/lib`

Changes:

- removes artifact-free `build: bun run typecheck`
- keeps `typecheck` as the real TypeScript validation command
- adds `lint:check`, `format`, `format:check`, and package-local `check`
- adds missing workspace dependencies to the TypeScript benchmark framework for the `@elizaos/*` packages it imports during typecheck
- records evidence in `.github/issue-evidence/12903-benchmark-library-script-contract.md`

## Validation

- Read `packages/benchmarks/CLAUDE.md`; no package-local guides exist under the two edited package directories.
- PASS: `git diff --check`
- PASS: static script contract guard for both edited package.json files
- PASS: `bun run --cwd packages/benchmarks/framework/typescript lint:check`
- PASS: `bun run --cwd packages/benchmarks/framework/typescript format:check`
- PASS: `bun run --cwd packages/benchmarks/lib check`
- PASS: `bun run --cwd packages/benchmarks/lib test` - 4 files / 44 tests

## Local blocker

- `bun run --cwd packages/benchmarks/framework/typescript check` is blocked in this auxiliary sparse worktree because its inherited `node_modules` symlink resolves workspace packages from another worktree. `tsgo` cannot resolve `@elizaos/plugin-openai` or `@elizaos/plugin-cli-inference` there, even after adding and building those provider directories locally. This PR adds those missing workspace dependency declarations so a normal workspace install can resolve the imports.

## Evidence

See `.github/issue-evidence/12903-benchmark-library-script-contract.md`.
