### PR TITLE
docs(#12903): correct script evidence

### DIFF
--- a/.github/issue-evidence/12903-benchmark-library-script-contract.md
+++ b/.github/issue-evidence/12903-benchmark-library-script-contract.md
@@ -60,22 +60,18 @@ Result:
 ```text
 packages/benchmarks/framework/typescript/package.json: script contract ok
 packages/benchmarks/lib/package.json: script contract ok
+packages/benchmarks/framework/typescript check: passed after building @elizaos/plugin-openai and @elizaos/plugin-cli-inference
 packages/benchmarks/framework/typescript lint:check: passed, 5 files
 packages/benchmarks/framework/typescript format:check: passed, 5 files
 packages/benchmarks/lib check: passed, 12 files lint/format checked
 packages/benchmarks/lib test: passed, 4 files / 44 tests
 ```
 
-Local blocker:
-
-```text
-packages/benchmarks/framework/typescript check:
-  tsgo could not resolve @elizaos/plugin-openai or
-  @elizaos/plugin-cli-inference through this auxiliary worktree's inherited
-  node_modules symlink, even after adding the provider directories and building
-  them. This PR adds the missing workspace dependency declarations so a normal
-  workspace install can resolve those imports.
-```
+`packages/benchmarks/framework/typescript check` initially needed the
+`@elizaos/plugin-openai` and `@elizaos/plugin-cli-inference` workspace packages
+prepared. After `bun run --cwd plugins/plugin-openai build` and
+`bun run --cwd plugins/plugin-cli-inference build`, the package-local `check`
+script passed.
 
 ## Evidence Matrix
 

--- a/.github/issue-evidence/12903-integration-examples-script-contract.md
+++ b/.github/issue-evidence/12903-integration-examples-script-contract.md
@@ -18,7 +18,7 @@ Branch slice: normalize script contracts for three integration examples.
 
 ## Verification
 
-Current working tree: `origin/develop` at `c1f211d534`.
+Current working tree: `github/develop` at `c1f211d534`.
 
 Static guard:
 
@@ -63,33 +63,34 @@ packages/examples/farcaster: biome check passed for 5 files; biome format passed
 packages/examples/twitter-xai: biome check passed for 5 files; biome format passed for 5 files.
 ```
 
-## Runtime/test probes
+Typecheck:
 
-```text
-packages/examples/cloudflare test:
-  Worker not available at http://localhost:8787
-  Skipping integration tests (worker must be running)
-
-packages/examples/farcaster test:
-  Cannot find module '@elizaos/core'
-
-packages/examples/twitter-xai test:
-  Cannot find module '@elizaos/core'
+```bash
+bun run --cwd plugins/plugin-xai build
+bun run --cwd plugins/plugin-x build
+for pkg in packages/examples/cloudflare packages/examples/farcaster packages/examples/twitter-xai; do
+  bun run --cwd "$pkg" typecheck
+done
 ```
 
-Typecheck with a temporary
-`node_modules -> /Users/shawwalters/eliza/node_modules` symlink:
-
 ```text
-packages/examples/cloudflare:
-  TS2688 cannot find type definition file for '@cloudflare/workers-types'
-
-packages/examples/farcaster:
-  TS2688 cannot find type definition file for 'node'
-
-packages/examples/twitter-xai:
-  TS2688 cannot find type definition file for 'node'
+packages/examples/cloudflare: passed
+packages/examples/farcaster: passed
+packages/examples/twitter-xai: passed after building @elizaos/plugin-xai and @elizaos/plugin-x
 ```
 
-This auxiliary worktree has about 4 GiB free and no valid local install, so full
-`bun install` / `bun run verify` were not run here.
+Tests:
+
+```bash
+for pkg in packages/examples/cloudflare packages/examples/farcaster packages/examples/twitter-xai; do
+  timeout 60s bun run --cwd "$pkg" test
+done
+```
+
+```text
+packages/examples/cloudflare: skipped cleanly because no worker was running at http://localhost:8787
+packages/examples/farcaster: 2 tests passed
+packages/examples/twitter-xai: 6 tests passed
+```
+
+Full `bun run verify` was not rerun for this package-metadata-only slice.


### PR DESCRIPTION
## Summary

Refs #12903 and follows up #13035 / #13037.

Two recently merged #12903 slices carried evidence from sparse auxiliary worktrees that listed dependency-resolution blockers. I reran the relevant checks in the full workspace and confirmed the package-local checks pass after preparing the needed workspace plugin packages.

This updates only evidence files:

- `.github/issue-evidence/12903-integration-examples-script-contract.md`
- `.github/issue-evidence/12903-benchmark-library-script-contract.md`

## Verification

Previously run against #13035 in `/tmp/eliza-pr-12935`:

- `git diff --check github/develop...HEAD`
- static script guard for Cloudflare, Farcaster, and Twitter/XAI example package scripts
- `bun run --cwd <pkg> lint:check` and `format:check` for those three packages
- `bun run --cwd plugins/plugin-xai build`
- `bun run --cwd plugins/plugin-x build`
- `bun run --cwd <pkg> typecheck` for all three packages
- `timeout 60s bun run --cwd <pkg> test` for all three packages

Previously run for #13037 evidence validation:

- `bun run --cwd plugins/plugin-openai build`
- `bun run --cwd plugins/plugin-cli-inference build`
- `bun run --cwd packages/benchmarks/framework/typescript check`
- `bun run --cwd packages/benchmarks/lib check`
- `bun run --cwd packages/benchmarks/lib test`

For this evidence-only follow-up:

- `git diff --check github/develop...HEAD`
- `git diff --check`
