### PR TITLE
docs(#12231): prose headers + churn cleanup — core runtime internals + __tests__ + residual (B01 part 5, complete)

### DIFF
--- a/packages/core/src/__tests__/action-catalog-cache.test.ts
+++ b/packages/core/src/__tests__/action-catalog-cache.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Verifies the memoized action-catalog builder (`getCachedActionCatalog`)
+ * returns a stable instance for an unchanged action set and self-invalidates
+ * when actions are registered, unregistered, or a localized-example resolver is
+ * supplied. Deterministic: synthetic Action stubs, no model or database.
+ */
 import { describe, expect, it } from "vitest";
 import { getCachedActionCatalog } from "../services/message";
 import type { Action } from "../types/components";

--- a/packages/core/src/__tests__/action-handler-callsite-audit.test.ts
+++ b/packages/core/src/__tests__/action-handler-callsite-audit.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Static source-tree audit that greps the real repo for direct
+ * `action.handler(...)` callsites and asserts every one is classified in the
+ * allowlist — so voiced-response handling stays intentional — with no stale
+ * entries left behind. Reads files from disk; no model or database.
+ */
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/core/src/__tests__/action-structure-audit.test.ts
+++ b/packages/core/src/__tests__/action-structure-audit.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Structural guards over the generated canonical action-docs aggregate: retired
+ * action names stay out, core-owned owner surfaces stay in while plugin-owned
+ * ones stay out, umbrella actions expose the `action` discriminator, and the
+ * fallback overlay preserves a plugin Action's own docs. Deterministic: imports
+ * the generated aggregate and concrete Action objects, no model or database.
+ */
 import { describe, expect, it } from "vitest";
 import { withCanonicalActionDocs } from "../action-docs.ts";
 import { secretsAction } from "../features/secrets/actions/manage-secret.ts";

--- a/packages/core/src/__tests__/activity-plaintext.test.ts
+++ b/packages/core/src/__tests__/activity-plaintext.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers the plaintext serializers that flatten PTY task lifecycle events,
+ * typed agent-event streams, and trajectory summaries into bounded
+ * human-readable lines. Deterministic: pure functions over synthetic event
+ * objects, no model or database.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	activityEventToPlaintext,

--- a/packages/core/src/__tests__/callback-templates.test.ts
+++ b/packages/core/src/__tests__/callback-templates.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises `composePromptFromState` with both string and function (callback)
+ * templates, and confirms `characterSchema` accepts function template values
+ * while rejecting non-string/non-function ones. Deterministic: pure prompt
+ * composition, no model.
+ */
 import { describe, expect, it } from "vitest";
 import { characterSchema } from "../schemas/character";
 import type { Character } from "../types/agent";

--- a/packages/core/src/__tests__/compose-state-provider-hook.test.ts
+++ b/packages/core/src/__tests__/compose-state-provider-hook.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises the `compose_state_providers` pipeline hook on
+ * `AgentRuntime.composeState`: a hook may filter and add providers, pass through
+ * unchanged, and a corrupted or thrown hook falls back to the pre-hook
+ * selection. Uses a real in-memory AgentRuntime with synthetic providers; no
+ * database or model.
+ */
 import { describe, expect, it } from "vitest";
 import { AgentRuntime } from "../runtime";
 import type { Character, Memory, Provider, UUID } from "../types";

--- a/packages/core/src/__tests__/compose-state-refresh-providers.test.ts
+++ b/packages/core/src/__tests__/compose-state-refresh-providers.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises the `refreshProviders` argument to `AgentRuntime.composeState`:
+ * cached providers are reused while only the named ones re-run, an omitted set
+ * re-runs everything, and an uncached provider runs even when unnamed. Uses a
+ * real in-memory AgentRuntime with call-counting providers; no database or
+ * model.
+ */
 import { describe, expect, it } from "vitest";
 import { AgentRuntime } from "../runtime";
 import type { Character, Memory, Provider, UUID } from "../types";

--- a/packages/core/src/__tests__/confirmation.test.ts
+++ b/packages/core/src/__tests__/confirmation.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers `requireConfirmation`: it confirms a pending action only when the
+ * follow-up text is a metadata-marked wrapped external payload, and treats
+ * marker-shaped user text lacking that metadata as a cancellation. Deterministic:
+ * Map-backed runtime cache stub, no model or database.
+ */
 import { describe, expect, it } from "vitest";
 import { wrapExternalContent } from "../security/external-content";
 import type { IAgentRuntime, Memory, UUID } from "../types";

--- a/packages/core/src/__tests__/description-compressed-lint.test.ts
+++ b/packages/core/src/__tests__/description-compressed-lint.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers `lintDescriptionCompressed`, the compressed action-description linter:
+ * empty/whitespace rejection, absence of a length cap, banned filler phrases and
+ * long-form words (with abbreviation hints), and non-imperative leading verbs.
+ * Deterministic: pure linter, no model.
+ */
 import { describe, expect, it } from "vitest";
 import { lintDescriptionCompressed } from "../utils/description-compressed-lint";
 

--- a/packages/core/src/__tests__/dynamic-prompt-json-mode.test.ts
+++ b/packages/core/src/__tests__/dynamic-prompt-json-mode.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Exercises AgentRuntime.dynamicPromptExecFromState: structured model calls
+ * request JSON-object response format, a validation failure feeds a corrective
+ * [REPAIR] context into the reroll, and exhausted retries return null while an
+ * explicit caller response format is preserved. Runs against a bare
+ * AgentRuntime (no DB adapter, logModelCall stubbed) with a registered vi.fn()
+ * model handler — fully deterministic, no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { AgentRuntime } from "../runtime";
 import { type Character, ModelType } from "../types";

--- a/packages/core/src/__tests__/entities-format.test.ts
+++ b/packages/core/src/__tests__/entities-format.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies formatEntities enforces prompt-hygiene caps: alias and long-metadata
+ * truncation plus a ceiling on the number of rendered entities. Pure
+ * deterministic function test.
+ */
 import { describe, expect, it } from "vitest";
 import { formatEntities } from "../entities.ts";
 import type { Entity } from "../types/index.ts";

--- a/packages/core/src/__tests__/env-truthy-parity.test.ts
+++ b/packages/core/src/__tests__/env-truthy-parity.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
+/**
+ * Pins the canonical env-truthiness contract (isTruthyEnvValue) and checks the
+ * boolean-parser wrappers (parseBooleanValue, parseBooleanText, readEnvBool)
+ * each keep their documented truthy/falsy token sets. Pure deterministic parser
+ * test.
+ */
 import { isTruthyEnvValue } from "../env-utils.js";
 import { parseBooleanText, parseBooleanValue } from "../utils/boolean.js";
 import { readEnvBool } from "../utils/read-env.js";
-
-// Pins the canonical env-truthiness contract after consolidating four
-// previously-duplicated copies onto core's `isTruthyEnvValue`, and verifies the
-// boolean parser wrappers preserve their documented (pre-consolidation) sets.
 
 const CANONICAL_TRUTHY = ["1", "true", "yes", "y", "on", "enabled"] as const;
 

--- a/packages/core/src/__tests__/inference-timing.test.ts
+++ b/packages/core/src/__tests__/inference-timing.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers InferenceTurnTimer and the inference-timing AsyncLocalStorage helpers:
+ * span roll-up by name, mark-derived timeToReply / timeToFirstToken,
+ * duplicate-mark anomaly detection, ALS attribution across async boundaries,
+ * and the emit / format / dev-payload registry. Deterministic — no live model.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	buildInferenceTimingDevPayload,

--- a/packages/core/src/__tests__/media-reply-sanitize.test.ts
+++ b/packages/core/src/__tests__/media-reply-sanitize.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies sanitizeReplyTextAfterMediaDelivery strips a delivered media URL (and
+ * its echo) from the reply while leaving non-echo prose, code indentation, and
+ * newlines untouched. Pure deterministic function test.
+ */
 import { describe, expect, it } from "vitest";
 import { sanitizeReplyTextAfterMediaDelivery } from "../services/message.ts";
 

--- a/packages/core/src/__tests__/message-action-dedupe.test.ts
+++ b/packages/core/src/__tests__/message-action-dedupe.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Exercises the message service's planner-action de-duplication
+ * (stripReplyWhenActionOwnsTurn) and sub-planner result collapse
+ * (subPlannerResultToPlannerToolResult): REPLY/alias dedupe, continueChain
+ * propagation from a terminal sub-action, and multi-step aggregation into the
+ * umbrella result. Runs against a stub runtime (actions + logger) — fully
+ * deterministic.
+ */
 import { describe, expect, it, vi } from "vitest";
 import {
 	stripReplyWhenActionOwnsTurn,

--- a/packages/core/src/__tests__/message-benchmark-integration.contract.test.ts
+++ b/packages/core/src/__tests__/message-benchmark-integration.contract.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Source-text contract test: reads services/message.ts and asserts benchmark-mode
+ * detection stays centralized in hasInboundBenchmarkContext /
+ * isBenchmarkForcingToolCall (no inline benchmark-flag inspection at call sites),
+ * that benchmark context forces CONTEXT_BENCH into the provider list, and that
+ * the planner requires a tool call only when both the env opt-in and an inbound
+ * benchmark signal are present. Static assertions over the file — no runtime.
+ */
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";

--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Regression suite over the message-routing helpers exported from
+ * services/message and runtime/message-handler: sub-agent completion relays are
+ * never promoted to tooling, raw field-transcript leaks are recovered to their
+ * replyText, the complete-direct-reply valve, planner action/param extraction,
+ * web-lookup routing, and VIEWS/APP candidate inference. Deterministic — each
+ * case drives the pure helpers directly, not a live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { parseActionParams } from "../actions";
 import type { Action, ActionResult, IAgentRuntime, Memory } from "../index";
@@ -369,14 +377,11 @@ describe("live routing regressions", () => {
 		).toEqual(["RESPOND"]);
 	});
 
-	// Removed: tests for compound-name splitting (`LIFE.add_goal` →
-	// `LIFE`), invented-action-name alias resolution (`TASKS_ADD_TODO` →
-	// `OWNER_TODOS`), and runtime-alias repair. With actions exposed as
-	// first-class tools + `toolChoice: "required"`, the model picks the
-	// canonical action name from the per-turn tool array directly — no
-	// compound-name decoding or alias repair is needed in the dispatch
-	// path. `PLANNER_ACTION_ALIASES` and `splitPlannerCompoundActionName`
-	// were deleted.
+	// No compound-name-splitting / invented-alias / runtime-alias-repair
+	// coverage here: with actions exposed as first-class tools under
+	// `toolChoice: "required"`, the model picks the canonical action name
+	// from the per-turn tool array directly, so the dispatch path does no
+	// compound-name decoding or alias repair.
 
 	it("infers safe params for explicit local shell checks", () => {
 		expect(

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Exercises Stage 1 of the message runtime (runV5MessageRuntimeStage1): native
+ * HANDLE_RESPONSE tool request/parse, direct-vs-planned routing, PII surrogate
+ * restoration at the reply boundary, truncation and junk-reply handling, the
+ * empty-completion retry budget, and planner fallback. Runs against a fabricated
+ * runtime whose useModel returns queued responses (deterministic — no live
+ * model, no DB); a few cases assert directly over the services/message.ts source.
+ */
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -22,7 +30,7 @@ import type { IAgentRuntime } from "../types/runtime";
 import type { State } from "../types/state";
 
 // Mirrors the scheduled-task backstop rule that plugin-personal-assistant
-// registers via `registerCandidateActionBackstopRule`. Core no longer hardcodes
+// registers via `registerCandidateActionBackstopRule`. Core does not hardcode
 // these action names / heuristic; the coding-delegation backstop consults
 // whatever rules a plugin registers, threaded in via `candidateBackstopRules`.
 const SCHEDULING_BACKSTOP_RULE: CandidateActionBackstopRule = {
@@ -561,7 +569,7 @@ describe("runV5MessageRuntimeStage1", () => {
 
 	it("keeps a valid-but-terse numeric Stage 1 reply without a second model call", async () => {
 		// A correct-but-terse numeric answer ("4") trips the low-quality heuristic
-		// but is worth keeping. The direct-reply regeneration path is gone, so the
+		// but is worth keeping. There is no direct-reply regeneration path, so the
 		// uncapped Stage-1 reply is the single source of truth: it is kept verbatim
 		// with no second TEXT_SMALL call.
 		const runtime = makeRuntime([

--- a/packages/core/src/__tests__/message-stable-prefix.test.ts
+++ b/packages/core/src/__tests__/message-stable-prefix.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Coverage for `renderMessageHandlerStablePrefix` — the cacheable system +
+ * tool-schema segment shared across a room's turns. Runs against a hand-built
+ * `vi`-mocked runtime with a stubbed `composeState`; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { renderMessageHandlerStablePrefix } from "../services/message";
 import type { UUID } from "../types/primitives";

--- a/packages/core/src/__tests__/message-stage1-context-catalog.test.ts
+++ b/packages/core/src/__tests__/message-stage1-context-catalog.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Coverage for the Stage 1 available-contexts catalog: `formatAvailableContextsForPrompt`
+ * rendering (compact and role-gated) and the role-scoped context list injected
+ * into the `runV5MessageRuntimeStage1` system prompt. Deterministic `vi`-mocked
+ * runtime with a canned tool-call response; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { HANDLE_RESPONSE_TOOL_NAME } from "../actions/to-tool";
 import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";

--- a/packages/core/src/__tests__/messages-format.test.ts
+++ b/packages/core/src/__tests__/messages-format.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Coverage for `formatMessages` conversation-history rendering: attachment
+ * read-advertisement gating, reacted-to message restoration, and bot-sender
+ * tagging. Pure formatter test — no runtime or model.
+ */
 import { describe, expect, it } from "vitest";
 import type { Media, Memory, UUID } from "../types/index.ts";
 import { formatMessages } from "../utils.ts";

--- a/packages/core/src/__tests__/mockCharacter.ts
+++ b/packages/core/src/__tests__/mockCharacter.ts
@@ -1,21 +1,9 @@
 import type { Character } from "@elizaos/core";
 
 /**
- * Mock character object representing a character in the system.
- *
- * @type {Character}
- */
-/**
- * Mock character object for testing purposes.
- *
- * @type {Character}
- * @property {string} name - The name of the character.
- * @property {string} username - The username of the character.
- * @property {Array} plugins - An array of plugins associated with the character.
- * @property {object} settings - Object containing character settings.
- * @property {object} settings.secrets - Object containing any secret settings.
- * @property {object} settings.voice - Object containing voice settings.
- * @property {string} settings.voice.model - The voice model used for the character.
+ * Shared Eliza `Character` fixture for core tests: a fully populated persona
+ * (bio, message and post examples, style, topics, voice settings) used to
+ * exercise prompt composition and character-dependent runtime paths.
  */
 export const mockCharacter: Character = {
 	name: "Eliza",

--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -1,3 +1,10 @@
+/**
+ * End-to-end coverage for the v5 message pipeline —
+ * messageHandler → planner → executor → evaluator — driven through
+ * `runV5MessageRuntimeStage1`. Uses a queued canned-response `vi` mock for the
+ * model, real action handlers, and real trajectory recording to a temp dir; no
+ * live model.
+ */
 import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/packages/core/src/__tests__/provisioning.test.ts
+++ b/packages/core/src/__tests__/provisioning.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Coverage for `ensureEmbeddingDimension` (core/provisioning.ts) — the daemon
+ * composition-path probe that snaps the embedding storage column to the
+ * configured width. Deterministic `createMockRuntime` with a mocked logger and
+ * adapter; no live model or DB.
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockRuntime } from "../testing/mock-runtime";
 import type { IAgentRuntime } from "../types/runtime";
@@ -25,9 +31,9 @@ beforeEach(() => {
  * setting probe used by the daemon-composition path (createRuntimes({ provision:
  * true }) → provisionAgent). It has two silent early-returns — no TEXT_EMBEDDING
  * model, and an unset/invalid EMBEDDING_DIMENSION — plus the happy path that
- * snaps the storage column to the configured width. None were covered; a
- * regression dropping the model-or-dim guard would call
- * adapter.ensureEmbeddingDimension with a wrong/default width and ship silently.
+ * snaps the storage column to the configured width. A regression dropping the
+ * model-or-dim guard would call adapter.ensureEmbeddingDimension with a
+ * wrong/default width and ship silently.
  *
  * NOTE: managed cloud agents do NOT take this path — they boot
  * `new AgentRuntime(...)` + `runtime.initialize()` and snap the column via

--- a/packages/core/src/__tests__/runtime-barrel.test.ts
+++ b/packages/core/src/__tests__/runtime-barrel.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Guards the `@elizaos/core` public barrel: keeps test helpers out of the
+ * package root, ensures first-run provider value re-exports stay present, and
+ * asserts the filesystem-probing plugin-loader is absent. Reads the source
+ * files as text and asserts on their contents.
+ */
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/core/src/__tests__/runtime-register-provider.test.ts
+++ b/packages/core/src/__tests__/runtime-register-provider.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Coverage for `AgentRuntime.registerProvider` — name-based deduplication and
+ * the `registerByDefault: false` opt-out across plugin and direct registration.
+ * Drives a real `AgentRuntime`; no model.
+ */
 import { describe, expect, it } from "vitest";
 import { AgentRuntime } from "../runtime";
 import type { Character, Provider } from "../types";

--- a/packages/core/src/__tests__/runtime-rerank-memories.test.ts
+++ b/packages/core/src/__tests__/runtime-rerank-memories.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Coverage for `AgentRuntime.rerankMemories` — merging BM25 keyword ranking with
+ * zero-overlap vector hits so semantic-only and attachment-only memories survive
+ * reranking. Drives a real `AgentRuntime`; no model.
+ */
 import { describe, expect, it } from "vitest";
 import { AgentRuntime } from "../runtime";
 import type { Character, Memory } from "../types";

--- a/packages/core/src/__tests__/runtime-settings.test.ts
+++ b/packages/core/src/__tests__/runtime-settings.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises `AgentRuntime.getSetting` resolution precedence (character env vs
+ * settings vs constructor settings vs DB-persisted values on restart) and
+ * prompt-batcher construction. Deterministic: real runtime over the in-memory
+ * adapter, no model calls.
+ */
 import { describe, expect, it } from "vitest";
 import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter";
 import { AgentRuntime } from "../runtime";

--- a/packages/core/src/__tests__/runtime-stop.test.ts
+++ b/packages/core/src/__tests__/runtime-stop.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Exercises `AgentRuntime.stop` fast-shutdown paths: not hanging on an
+ * unresolved service start, capping already-started stop waits, and surviving a
+ * synchronously-throwing stop. Deterministic: real runtime, no database.
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import { AgentRuntime } from "../runtime";
 import type { IAgentRuntime } from "../types/runtime";

--- a/packages/core/src/__tests__/service-type-collisions.test.ts
+++ b/packages/core/src/__tests__/service-type-collisions.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Guards serviceType uniqueness two ways: runtime warnings when duplicate
+ * serviceTypes register (real AgentRuntime) and a repo-wide TypeScript-AST scan
+ * of core, agent, and plugins that flags unallowlisted duplicate
+ * `static serviceType` declarations.
+ */
 import { readdirSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/core/src/__tests__/should-respond.live.test.ts
+++ b/packages/core/src/__tests__/should-respond.live.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Validates the shouldRespond classifier prompt against a live Ollama model
+ * (skipped unless ELIZA_RUN_LIVE_TESTS=1): reply/ignore/stop decisions over real
+ * TEXT_LARGE completions through a real AgentRuntime.
+ */
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter";
 import { shouldRespondTemplate } from "../prompts";

--- a/packages/core/src/__tests__/streaming-context-events.test.ts
+++ b/packages/core/src/__tests__/streaming-context-events.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers `emitStreamingHook` on the streaming context: no-op when a hook is
+ * absent, payload forwarding for tool/result/evaluation/context-event
+ * observers, and caller isolation from a throwing hook. Deterministic vitest
+ * spies, no runtime.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { emitStreamingHook, type StreamingContext } from "../streaming-context";
 import type { EvaluationResult } from "../types/components";

--- a/packages/core/src/__tests__/streaming-runtime-hooks.test.ts
+++ b/packages/core/src/__tests__/streaming-runtime-hooks.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers the streaming observer hooks fired through the planner loop and
+ * sub-planner (tool call, tool result, evaluation, context event): execution
+ * ordering, caller isolation from throwing hooks, failed-tool-result emission,
+ * and sub-planner context events. Deterministic: a stub runtime with queued
+ * model responses, no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { executePlannedToolCall } from "../runtime/execute-planned-tool-call";
 import {

--- a/packages/core/src/__tests__/stress-compaction.test.ts
+++ b/packages/core/src/__tests__/stress-compaction.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Drives `runV5MessageRuntimeStage1` through a many-step website-build
+ * simulation to exercise planner compaction, quality-gate failure recovery, and
+ * trajectory export/metrics. Deterministic: a canned-response stub runtime with
+ * real trajectory recording written to a temp dir, no live model.
+ */
 import {
 	mkdirSync,
 	mkdtempSync,

--- a/packages/core/src/__tests__/structured-parser.test.ts
+++ b/packages/core/src/__tests__/structured-parser.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for `parseKeyValueXml`: `<response>` block parsing and the
+ * prefix-extended-tag regression where a nested `<textarea>` inside `<text>`
+ * must not inflate close-tag matching. Deterministic parser test.
+ */
 import { describe, expect, it } from "vitest";
 import { parseKeyValueXml } from "../utils";
 

--- a/packages/core/src/__tests__/tiered-action-surface.test.ts
+++ b/packages/core/src/__tests__/tiered-action-surface.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises the v5 tiered action surface through `runV5MessageRuntimeStage1`:
+ * Stage-1 hints promoting a parent to Tier A, sub-actions surfaced as
+ * first-class planner tools, hot-parent child capping, role-gated tool omission,
+ * and Tier-B sub-planner execution. Deterministic: a canned-response stub
+ * runtime, no live model.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { _resetActionRolePolicyCacheForTests } from "../runtime/action-role-policy";
 import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
@@ -227,10 +234,10 @@ function plannerUserContent(runtime: IAgentRuntime): string {
 }
 
 function availableActionsSection(runtime: IAgentRuntime): string {
-	// Post-PLAN_ACTIONS-wrapper refactor: actions are exposed as native tools
-	// on the planner call, not in an `available_actions` text block. Synthesize
-	// a section-like view from the tool definitions so the tier-A vs tier-B
-	// assertions in this file can still inspect action name presence and order.
+	// Actions are exposed as native tools on the planner call, not in an
+	// `available_actions` text block. Synthesize a section-like view from the
+	// tool definitions so the tier-A vs tier-B assertions in this file can still
+	// inspect action name presence and order.
 	const plannerCall = getCalls(runtime).find(
 		(call) => call.modelType === ModelType.ACTION_PLANNER,
 	);

--- a/packages/core/src/__tests__/trajectory-context.test.ts
+++ b/packages/core/src/__tests__/trajectory-context.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Async-scoped trajectory-context helpers: runWithTrajectoryPurpose overrides
+ * only the purpose tag while preserving the enclosing trajectory / step / run /
+ * room ids, and the suite pins the bare-context shape that would otherwise
+ * clobber the step id. Deterministic — drives the context manager directly, no
+ * model.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	getTrajectoryContext,

--- a/packages/core/src/__tests__/transcription-mode-evaluator.test.ts
+++ b/packages/core/src/__tests__/transcription-mode-evaluator.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Transcription-mode reply suppression: the transcriptionModeActive flag reader
+ * (client-transport metadata path and in-process top-level path) and the
+ * `core.transcription_mode` builtin response-handler evaluator that turns a
+ * flagged turn into IGNORE + clearReply. Deterministic — the evaluator runs
+ * against hand-built Memory, no model.
+ */
 import { describe, expect, it } from "vitest";
 import type { ResponseHandlerEvaluatorContext } from "../runtime/response-handler-evaluators";
 import {

--- a/packages/core/src/__tests__/voice-turn-signal-confirm.test.ts
+++ b/packages/core/src/__tests__/voice-turn-signal-confirm.test.ts
@@ -1,3 +1,10 @@
+/**
+ * The `core.voice_turn_signal_confirm` builtin response-handler evaluator: the
+ * positive-decision path that promotes a Stage-1 IGNORE to RESPOND on an explicit
+ * server agentShouldSpeak signal, while never overriding a STOP, an existing
+ * RESPOND, or a user-next turn. Deterministic — driven with hand-built voice
+ * Memory + handler-decision contexts, no model.
+ */
 import { describe, expect, it } from "vitest";
 import type { ResponseHandlerEvaluatorContext } from "../runtime/response-handler-evaluators";
 import { BUILTIN_RESPONSE_HANDLER_EVALUATORS } from "../services/message";

--- a/packages/core/src/__tests__/voice-turn-signal-suppress.test.ts
+++ b/packages/core/src/__tests__/voice-turn-signal-suppress.test.ts
@@ -1,13 +1,17 @@
+/**
+ * The `core.voice_turn_signal` suppression gate (#8786): the server veto that
+ * blocks a voice reply when semantic turn-taking says the next speaker is not the
+ * agent (agentShouldSpeak false, next speaker user, or end-of-turn probability
+ * below 0.4), and only on voice channels carrying the signal. Deterministic — the
+ * builtin evaluator runs against hand-built Memory + handler-decision contexts,
+ * no model.
+ */
 import { describe, expect, it } from "vitest";
 import type { ResponseHandlerEvaluatorContext } from "../runtime/response-handler-evaluators";
 import { BUILTIN_RESPONSE_HANDLER_EVALUATORS } from "../services/message";
 import type { Memory } from "../types/memory";
 import { ChannelType, type UUID } from "../types/primitives";
 
-// core.voice_turn_signal is the ORIGINAL #8786 mechanism — the suppression-only
-// server gate that vetoes a voice reply when semantic turn-taking says the next
-// speaker is not the agent. The positive confirm path has a test
-// (voice-turn-signal-confirm.test.ts) but the suppress path had none.
 const ROOM = "11111111-1111-1111-1111-111111111111" as UUID;
 const ENTITY = "22222222-2222-2222-2222-222222222222" as UUID;
 

--- a/packages/core/src/features/basic-capabilities/dm-owner-grant.test.ts
+++ b/packages/core/src/features/basic-capabilities/dm-owner-grant.test.ts
@@ -6,12 +6,12 @@ import { ChannelType } from "../../types/primitives.ts";
 import { createBasicCapabilitiesPlugin } from "./index.ts";
 
 /**
- * P0 regression: the DM-world setup in `syncSingleUser` used to hardcode
- * `ownership.ownerId = <sender>` + `roles[<sender>] = OWNER` for ANY DM world.
- * With no canonical owner configured (ELIZA_ADMIN_ENTITY_ID unset — the
- * DEFAULT), roles.ts then promoted EVERY DM sender to OWNER, clearing every
- * `minRole: OWNER` gate (including SECRETS). Ownership must be granted ONLY to a
- * configured owner, via roles.ts's `recordOwnerGrant`.
+ * P0 permission-bypass guard for the DM-world setup in `syncSingleUser`: a DM
+ * world must NOT hardcode `ownership.ownerId = <sender>` + `roles[<sender>] =
+ * OWNER` for ANY DM world. With no canonical owner configured
+ * (ELIZA_ADMIN_ENTITY_ID unset — the DEFAULT) that promotes EVERY DM sender to
+ * OWNER, clearing every `minRole: OWNER` gate (including SECRETS). Ownership is
+ * granted ONLY to a configured owner, via roles.ts's `recordOwnerGrant`.
  */
 
 const AGENT_ID = "00000000-0000-0000-0000-0000000000aa";

--- a/packages/core/src/features/basic-capabilities/dm-world-metadata.test.ts
+++ b/packages/core/src/features/basic-capabilities/dm-world-metadata.test.ts
@@ -4,9 +4,9 @@ import { buildDmWorldMetadata } from "./index.ts";
 
 /**
  * #12087 Item 2: a DM world grants OWNER only to a configured canonical owner.
- * Previously every DM sender was written as OWNER of their own DM world, so with
- * no canonical owner configured (the default) anyone who could DM the agent
- * cleared every minRole:OWNER gate (SECRETS, SHELL, …).
+ * Without this guard every DM sender is written as OWNER of their own DM world,
+ * so with no canonical owner configured (the default) anyone who could DM the
+ * agent clears every minRole:OWNER gate (SECRETS, SHELL, …).
  */
 
 function runtimeWith(settings: Record<string, string>): IAgentRuntime {

--- a/packages/core/src/features/documents/recall-embed.ts
+++ b/packages/core/src/features/documents/recall-embed.ts
@@ -10,8 +10,8 @@ import { ModelType } from "../../types";
  * (`DocumentService._vectorSearch`/`_hybridSearch`), experience recall
  * (`ExperienceService.findSimilarExperiences`), and the relevant-conversations
  * provider. Because they all call this one function with the same runtime +
- * `runId` + (normalized) query text, the per-turn dedupe below collapses what
- * used to be 3 independent embed round-trips per turn into a single one.
+ * `runId` + (normalized) query text, the per-turn dedupe below collapses the
+ * 3 independent embed round-trips per turn into a single one.
  *
  * **Per-turn cache + in-flight dedupe.** The same query text is embedded more
  * than once per turn (vector + hybrid document search, experience recall,
@@ -27,12 +27,12 @@ import { ModelType } from "../../types";
  * blocked on an *error*, and recall is never silently dropped (we log it).
  *
  * There is deliberately NO app-level latency timeout here. A short, arbitrary
- * race (the former `RECALL_EMBED_TIMEOUT_MS`) fired on every healthy-but-slow
- * embed and silently degraded vector recall to keyword-only every turn — a
- * feature-kill switch, not a circuit breaker. Bounding a *hung* request is the
- * embedding model handler's job (it owns a real, cancelable request timeout);
- * keeping that bound at the request layer means a slow embed either completes
- * (rich recall) or genuinely errors (fail-open), with no silent middle ground.
+ * race on every healthy-but-slow embed would silently degrade vector recall to
+ * keyword-only every turn — a feature-kill switch, not a circuit breaker.
+ * Bounding a *hung* request is the embedding model handler's job (it owns a
+ * real, cancelable request timeout); keeping that bound at the request layer
+ * means a slow embed either completes (rich recall) or genuinely errors
+ * (fail-open), with no silent middle ground.
  */
 
 /** Normalize query text so trivially-different strings share one cache slot. */

--- a/packages/core/src/features/secrets/actions/mask.test.ts
+++ b/packages/core/src/features/secrets/actions/mask.test.ts
@@ -4,10 +4,10 @@ import { maskSecretValue } from "./mask";
 /**
  * Tests for the secret-display mask (#10317 credential bridge / #8801, #9943).
  * `maskSecretValue` decides exactly how much of a secret is shown when a value
- * is surfaced (logs, UI, the credential bridge). It had no assertions, yet a
- * bug here leaks the secret — so the invariants are pinned: short secrets are
- * fully hidden, only the first/last 4 chars of a long secret show, the middle
- * is never exposed, and the mask is capped so the length isn't revealed.
+ * is surfaced (logs, UI, the credential bridge). A bug here leaks the secret,
+ * so the invariants are pinned: short secrets are fully hidden, only the
+ * first/last 4 chars of a long secret show, the middle is never exposed, and
+ * the mask is capped so the length isn't revealed.
  */
 describe("maskSecretValue", () => {
 	it("fully masks secrets of 8 characters or fewer", () => {

--- a/packages/core/src/runtime/__tests__/action-catalog-i18n.test.ts
+++ b/packages/core/src/runtime/__tests__/action-catalog-i18n.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Locale-aware action-catalog example resolution: buildActionCatalog swaps
+ * English example pairs for registered localized [user, agent] translations via
+ * a resolver, falls back to English per-example when a locale entry is missing,
+ * passes non-pair example shapes through untouched, and localizes sub-action
+ * examples through the same resolver. Deterministic — an in-memory registry
+ * stands in for the multilingual prompt store; no model or I/O.
+ */
 import { describe, expect, it } from "vitest";
 import type { ActionExample } from "../../types/components";
 import {

--- a/packages/core/src/runtime/__tests__/action-retrieval-measurement.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval-measurement.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Instrumentation surface of retrieveActions: measurement mode exposes
+ * per-stage scores (exact/regex/keyword/bm25/embedding/contextMatch), the fused
+ * reciprocal-rank-fusion topK, and honors tierOverrides (topK cap, per-stage
+ * weights) without altering the primary results returned when it is off. Runs
+ * against a deterministic in-memory action catalog — no model or embeddings.
+ */
 import { describe, expect, it } from "vitest";
 import { buildActionCatalog } from "../action-catalog";
 import { retrieveActions } from "../action-retrieval";

--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Deterministic action catalogue assembly and multi-stage retrieval:
+ * buildActionCatalog's parent/child grouping (with non-fatal duplicate/missing
+ * sub-action warnings and virtual-subaction promotion) and retrieveActions'
+ * scoring stages — exact parent hints, regex over candidate namespaces/child
+ * names, BM25, the external i18n keyword signal, RRF fusion with optional
+ * embeddings, and recent-conversation gating for continuation-shaped turns.
+ * No model or embeddings; scores are computed from the in-memory catalog.
+ */
 import { describe, expect, it } from "vitest";
 import { promoteSubactionsToActions } from "../../actions/promote-subactions";
 import { searchMessagesAction } from "../../features/messaging/triage/actions/searchMessages";

--- a/packages/core/src/runtime/__tests__/action-schema-coverage.test.ts
+++ b/packages/core/src/runtime/__tests__/action-schema-coverage.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Enum coverage over first-party action parameter schemas: asserts that
+ * targetKind, manageOperation, payment-context kind/scope, and character
+ * fieldsToSave are constrained to their canonical kind sets — both on the raw
+ * ActionParameter schema and on the JSON Schema derived via actionToJsonSchema.
+ * Deterministic; exercises the real action definitions and schema builder.
+ */
 import { describe, expect, it } from "vitest";
 import { actionToJsonSchema } from "../../actions/action-schema";
 import {

--- a/packages/core/src/runtime/__tests__/action-tiering.test.ts
+++ b/packages/core/src/runtime/__tests__/action-tiering.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Tier assignment for the planner's exposed action surface: tierActionResults
+ * pins Tier-0 protocol controls, expands Tier-A parents with their children,
+ * keeps Tier-B parent-only, omits Tier-C, and applies Stage-1 candidate
+ * narrowing (promotion/demotion, simile-vs-canonical collision resolution,
+ * per-parent tier-A child capping) plus a deterministic surface hash.
+ * In-memory catalog; no model.
+ */
 import { describe, expect, it } from "vitest";
 import { buildActionCatalog } from "../action-catalog";
 import type { ActionRetrievalResult } from "../action-retrieval";

--- a/packages/core/src/runtime/__tests__/addressed-to.test.ts
+++ b/packages/core/src/runtime/__tests__/addressed-to.test.ts
@@ -1,3 +1,11 @@
+/**
+ * The uniform addressing gate messageAddressedToOtherParticipant (#9874):
+ * returns true only when a turn is directed at a resolvable OTHER room
+ * participant — bot or human alike — resolving @-names to ids via room
+ * entities, treating platform-alias self-addresses as self, failing safe on
+ * unresolvable names, and never consulting sender bot-ness. Runtime and its
+ * entity lookup are vi-mocked; no model or database.
+ */
 import { describe, expect, it, vi } from "vitest";
 import type { Entity, IAgentRuntime, Memory, UUID } from "../../types/index.ts";
 import { messageAddressedToOtherParticipant } from "../addressed-to.ts";

--- a/packages/core/src/runtime/__tests__/brain-provider-override.test.ts
+++ b/packages/core/src/runtime/__tests__/brain-provider-override.test.ts
@@ -4,7 +4,7 @@ import { AgentRuntime } from "../../runtime";
 import { type Character, ModelType } from "../../types";
 
 /**
- * Phase 5 — request-time chat-brain provider override.
+ * Request-time chat-brain provider override.
  *
  * `useModel(TEXT_LARGE)` with no pinned provider normally returns the
  * highest-priority registered handler. The `ELIZA_BRAIN_PROVIDER` setting lets

--- a/packages/core/src/runtime/__tests__/cache-control-universal.test.ts
+++ b/packages/core/src/runtime/__tests__/cache-control-universal.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Verifies `cacheProviderOptions` emits per-provider prompt-cache directives
+ * (eliza, cerebras, openai, anthropic, openrouter, gateway) derived from a
+ * prefix hash, with a deterministic, length-bounded cache key. Pure synchronous
+ * assertions — no model or network.
+ */
 import { describe, expect, it } from "vitest";
 import { cacheProviderOptions } from "../planner-loop";
 

--- a/packages/core/src/runtime/__tests__/cache-key-stability.test.ts
+++ b/packages/core/src/runtime/__tests__/cache-key-stability.test.ts
@@ -1,3 +1,20 @@
+/**
+ * Guards the determinism of the Anthropic prompt-cache prefix hash as a CI gate.
+ *
+ * The stable prompt prefix (the canonical Stage 1 / Stage 2 envelope and the
+ * planner-tool schemas) must hash the same every run: if its hash drifts, the
+ * Anthropic cached prefix is busted and every subsequent turn pays ~80% extra
+ * input tokens. These tests pin the invariants that keep it stable — the
+ * stable-prefix hash is a well-formed sha256, appending a dynamic (unstable)
+ * suffix never churns it, and mutating a stable segment always does.
+ *
+ * A hash change caused by editing a stable segment, the planner tool schema, or
+ * the cache-key construction is an intentional cache bust — expect and account
+ * for it. Any other churn (a stray whitespace edit in a prompt template, a
+ * reordered action list, an environment-dependent string, or a new segment that
+ * should have been marked `stable: false`) is a source bug to fix, not to rebase
+ * around.
+ */
 import { describe, expect, it } from "vitest";
 
 import {
@@ -12,25 +29,6 @@ import {
 	normalizePromptSegments,
 } from "../context-renderer";
 import { buildProviderCachePlan } from "../provider-cache-plan";
-
-/**
- * Cache-key stability CI gate.
- *
- * These hashes are snapshots of the Anthropic prompt-cache key inputs for a
- * fixed canonical Stage 1 / Stage 2 / planner-tool envelope. If any of these
- * hashes drift, the Anthropic cached prefix is busted and every subsequent PR
- * pays ~80% extra tokens until someone notices.
- *
- * When a hash change is INTENTIONAL (you genuinely meant to alter a stable
- * prompt segment, the planner tool schema, or the cache-key construction),
- * update the literal hash baked in below and document the change in
- * `docs/audits/lifeops-2026-05-11/cache-key-stability.md`.
- *
- * When the change is UNINTENTIONAL — typically a whitespace edit in a
- * prompt template, a reordered action list, an environment-dependent string,
- * or a new prompt segment that should have been marked `stable: false` — fix
- * the source, do NOT just rebase the snapshot.
- */
 
 // -- Canonical Stage 1 prefix ------------------------------------------------
 //
@@ -91,8 +89,6 @@ function stableSegmentPrefixHash(segments: PromptSegment[]): string {
 describe("cache-key stability — Anthropic prompt-cache invariants", () => {
 	it("Stage 1 stable-prefix hash is byte-stable for canonical input", () => {
 		const prefixHash = stableSegmentPrefixHash(STAGE_1_CANONICAL_SEGMENTS);
-		// Snapshot captured when Stage 1 protocol text was updated for the
-		// per-action native-tools refactor (removed "PLAN_ACTIONS" wording).
 		expect(prefixHash).toMatch(/^[0-9a-f]{64}$/);
 	});
 
@@ -103,9 +99,9 @@ describe("cache-key stability — Anthropic prompt-cache invariants", () => {
 
 	it("terminal-sentinel tool envelope (CORE_PLANNER_TERMINALS) is byte-stable", () => {
 		const toolEnvelopeHash = hashStableJson(CORE_PLANNER_TERMINALS);
-		// CORE_PLANNER_TERMINALS replaces the prior STABLE_PLANNER_TOOLS pair —
-		// the hash is a snapshot of REPLY / IGNORE / STOP exposed as their own
-		// native tools and changes only when one of those shapes is edited.
+		// CORE_PLANNER_TERMINALS is REPLY / IGNORE / STOP exposed as their own
+		// native tools; its hash changes only when one of those tool shapes is
+		// edited.
 		expect(toolEnvelopeHash).toMatch(/^[0-9a-f]{64}$/);
 	});
 

--- a/packages/core/src/runtime/__tests__/candidate-action-backstop.test.ts
+++ b/packages/core/src/runtime/__tests__/candidate-action-backstop.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises the per-runtime candidate-action backstop rule registry and its
+ * effect on planner candidate selection: a genuine scheduled-task candidate is
+ * protected while one that only accidentally surfaced on a coding turn is
+ * stripped in favor of the coding-delegation action. Deterministic, synthetic
+ * runtime — no model.
+ */
 import { describe, expect, it } from "vitest";
 import { messageHandlerFromFieldResult } from "../../services/message";
 import type { IAgentRuntime } from "../../types/runtime";

--- a/packages/core/src/runtime/__tests__/cleanup-scope.test.ts
+++ b/packages/core/src/runtime/__tests__/cleanup-scope.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers `withCleanup`: the cleanup callback runs only when the parent signal is
+ * aborted, fn results and errors propagate unchanged, and cleanup itself is
+ * time-bounded, aborting via `CleanupTimeoutError`. Deterministic timers, no
+ * runtime.
+ */
 import { describe, expect, it } from "vitest";
 import { CleanupTimeoutError, withCleanup } from "../cleanup-scope";
 

--- a/packages/core/src/runtime/__tests__/compress-mode.test.ts
+++ b/packages/core/src/runtime/__tests__/compress-mode.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises `ELIZA_PROMPT_COMPRESS` token-budget mode: the optimized-prompt
+ * resolver drops few-shot demonstrations and the planner-loop routing-hints
+ * block is skipped when the env flag is set. Deterministic — toggles the env var
+ * directly, no model.
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import type { OptimizedPromptService } from "../../services/optimized-prompt";
 import { resolveOptimizedPrompt } from "../../services/optimized-prompt-resolver";

--- a/packages/core/src/runtime/__tests__/context-hash.test.ts
+++ b/packages/core/src/runtime/__tests__/context-hash.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Checks the context-hash helpers: deterministic key-ordered JSON
+ * serialization, order-independent segment hashing, and cumulative
+ * order-sensitive prefix hashes that back the prompt-cache prefix keys. Pure
+ * functions, no model.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	computePrefixHashes,

--- a/packages/core/src/runtime/__tests__/context-registry.test.ts
+++ b/packages/core/src/runtime/__tests__/context-registry.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the context registry and gate helpers: id normalization, first-party
+ * context registration, finance-alias expansion, context/role-gate candidate
+ * filtering, and parent/subcontext cycle detection. Pure, no model.
+ */
 import { describe, expect, it } from "vitest";
 import type { ContextDefinition } from "../../types/contexts";
 import {

--- a/packages/core/src/runtime/__tests__/context-renderer.test.ts
+++ b/packages/core/src/runtime/__tests__/context-renderer.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers the context renderer: `renderContextObject` orders provider and tool
+ * prefixes ahead of append-only events without duplicating native tools as text
+ * segments, `buildStageChatMessages` splits a stage call into one cacheable
+ * system prefix plus a dynamic user block, and `cachePrefixSegments` keeps only
+ * the longest leading stable-prefix run for cache keys. Pure, no model.
+ */
 import { describe, expect, it } from "vitest";
 import type { ContextObject } from "../../types/context-object";
 import {
@@ -81,11 +88,10 @@ describe("context renderer", () => {
 	});
 
 	it("does not emit synthetic tool-text segments alongside native tools", () => {
-		// Regression: `renderPrefixTool` previously emitted both the native
-		// tool definition AND a `tool: NAME\ndescription: ...` text segment in
-		// the system prompt. Native tools are sent on the wire; the text
-		// duplicate inflated prompt tokens and confused models that saw the
-		// same surface area twice.
+		// Native tools are sent on the wire, so `renderPrefixTool` must not also
+		// emit a `tool: NAME\ndescription: ...` text segment in the system
+		// prompt: a text duplicate inflates prompt tokens and gives the model two
+		// representations of the same surface to reconcile.
 		const context: ContextObject = {
 			id: "ctx-no-text",
 			version: "v5",
@@ -103,7 +109,8 @@ describe("context renderer", () => {
 		const rendered = renderContextObject(context);
 		expect(rendered.tools.map((tool) => tool.name)).toEqual(["X", "Y", "Z"]);
 		expect(rendered.promptSegments).toHaveLength(0);
-		// And no segment whose content begins with `tool: ` (the old shape).
+		// And no segment whose content begins with `tool: ` (the forbidden
+		// text-tool shape).
 		for (const segment of rendered.promptSegments) {
 			expect(segment.content).not.toMatch(/^tool:\s*[A-Z_]/);
 		}

--- a/packages/core/src/runtime/__tests__/default-contexts.test.ts
+++ b/packages/core/src/runtime/__tests__/default-contexts.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Validates `DEFAULT_CONTEXT_DEFINITIONS`: unique ids and required fields, clean
+ * idempotent registration into a `ContextRegistry`, and role-scoped
+ * `listAvailable` filtering (OWNER-only vs USER vs GUEST contexts). Pure, no
+ * model.
+ */
 import { describe, expect, it } from "vitest";
 import { ContextRegistry } from "../context-registry";
 import { DEFAULT_CONTEXT_DEFINITIONS } from "../default-contexts";

--- a/packages/core/src/runtime/__tests__/direct-message-hook.test.ts
+++ b/packages/core/src/runtime/__tests__/direct-message-hook.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers the pre-LLM direct-message hook registry: per-runtime registration,
+ * first-hook-that-returns-a-result-wins ordering, unregistration, and isolation
+ * between runtimes. Pure in-memory — the runtime is a bare stub, no model or DB.
+ */
 import { describe, expect, it } from "vitest";
 import type { ActionResult } from "../../types/components";
 import type { Memory } from "../../types/memory";

--- a/packages/core/src/runtime/__tests__/embedding-dimension.test.ts
+++ b/packages/core/src/runtime/__tests__/embedding-dimension.test.ts
@@ -1,14 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
-import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
-import {
-	AgentRuntime,
-	EmbeddingDimensionProbeError,
-	NoModelProviderConfiguredError,
-} from "../../runtime";
-import { type Character, type Memory, ModelType, type UUID } from "../../types";
-
 /**
- * Boot-time TEXT_EMBEDDING dimension-probe semantics (#10702 / #8769):
+ * Boot-time TEXT_EMBEDDING dimension-probe semantics (#10702 / #8769), driven
+ * against a real AgentRuntime + InMemoryDatabaseAdapter with canned/broken
+ * embedding handlers registered via registerModel (no live model):
  *
  * 1. The probe fails over across ALL registered TEXT_EMBEDDING providers in
  *    priority order — any probe error advances, first success wins, sizes the
@@ -23,6 +16,14 @@ import { type Character, type Memory, ModelType, type UUID } from "../../types";
  * 4. runtime.initialize() survives a total probe failure — boot stays alive in
  *    the degraded mode instead of crashing (#10702's original symptom).
  */
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import {
+	AgentRuntime,
+	EmbeddingDimensionProbeError,
+	NoModelProviderConfiguredError,
+} from "../../runtime";
+import { type Character, type Memory, ModelType, type UUID } from "../../types";
 
 const ROOM_ID = "00000000-0000-0000-0000-000000000001" as UUID;
 

--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises the evaluator stage: parseEvaluatorOutput's JSON/prose recovery and
+ * runEvaluator's FINISH/CONTINUE decisions, messageToUser sanitization, and the
+ * injected clipboard/message effects. Deterministic — runtime.useModel returns
+ * canned strings, no live model or DB.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { ModelType } from "../../types/model";
 import { parseEvaluatorOutput, runEvaluator } from "../evaluator";
@@ -143,7 +149,7 @@ df -h / /home
 		expect(evaluatorParams.messages[0].content).toContain("evaluator_stage:");
 		expect(evaluatorParams.messages[0].content).toContain("agent_name: Eliza");
 		// Provider events render as `provider:NAME:\n<text>` (label + content);
-		// the old shape baked `provider: <name>` into the body, duplicating it.
+		// the label must not also be duplicated into the body.
 		expect(evaluatorParams.messages[1].content).toContain(
 			"provider:RECENT_MESSAGES:",
 		);
@@ -151,8 +157,8 @@ df -h / /home
 		expect(evaluatorParams.messages[1].content).not.toMatch(
 			/provider:RECENT_MESSAGES:\nprovider: RECENT_MESSAGES/,
 		);
-		// After the stacking fix, trajectory steps are conveyed as assistant/tool
-		// message pairs, NOT as a JSON dump in the user message.
+		// Trajectory steps are conveyed as assistant/tool message pairs, NOT as a
+		// JSON dump in the user message.
 		expect(evaluatorParams.messages[1].content).not.toMatch(/^trajectory:\n\[/);
 		expect(
 			evaluatorParams.providerOptions.eliza.modelInputBudget,

--- a/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
+++ b/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Drives executePlannedToolCall end to end: exact action-name matching, strict
+ * argument validation and planner-wrapper canonicalization, role/context/
+ * connector/private gating (including the ACTION_ROLE_POLICY override),
+ * ACTION_STARTED/ACTION_COMPLETED emission with sensitive-result suppression, and
+ * trajectory-step wiring; also unit-tests dropEmptyOptionalArgs. Deterministic —
+ * stub runtime with vi.fn handlers and in-memory connector storage, no live model.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	getConnectorAccountManager,

--- a/packages/core/src/runtime/__tests__/fact-write-dedupe.test.ts
+++ b/packages/core/src/runtime/__tests__/fact-write-dedupe.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Structural write-time dedupe for the `facts` table, driven through a real
+ * AgentRuntime + InMemoryDatabaseAdapter (only the extraction model output is
+ * canned via registerModel). Regression-proves the live double-write: one
+ * extraction turn persisted the same claim twice — a fact row (kind=current)
+ * plus a relationship-echo row with no `kind`, which the FACTS reader then
+ * promoted to a durable fact ("nubs plays guitar" duplicated durable).
+ */
 import { describe, expect, it } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import { factsProvider } from "../../features/advanced-capabilities/providers/facts";
@@ -7,15 +15,6 @@ import type { Memory } from "../../types/memory";
 import type { UUID } from "../../types/primitives";
 import type { State } from "../../types/state";
 import { runFactsAndRelationshipsStage } from "../facts-and-relationships";
-
-/**
- * Structural write-time dedupe for the `facts` table, driven through a real
- * AgentRuntime + InMemoryDatabaseAdapter (only the extraction model output is
- * canned via registerModel). Regression-proves the live double-write: one
- * extraction turn persisted the same claim twice — a fact row (kind=current)
- * plus a relationship-echo row with no `kind`, which the FACTS reader then
- * promoted to a durable fact ("nubs plays guitar" duplicated durable).
- */
 
 const USER = "00000000-0000-0000-0000-000000000001" as UUID;
 const OTHER_USER = "00000000-0000-0000-0000-000000000009" as UUID;

--- a/packages/core/src/runtime/__tests__/facts-and-relationships.test.ts
+++ b/packages/core/src/runtime/__tests__/facts-and-relationships.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers the Stage-1 facts/relationships extraction: parseFactsAndRelationshipsOutput
+ * across the text and tool-call (arguments/input/args/params) response shapes, and
+ * runFactsAndRelationshipsStage's candidate filtering, secret-like redaction,
+ * persistence, and voice/text extraction parity. Deterministic — a mock runtime
+ * whose useModel/getMemories/createMemory are vi.fn, no live model or DB.
+ */
 import { describe, expect, it, vi } from "vitest";
 import type { Memory } from "../../types/memory";
 import { ModelType } from "../../types/model";

--- a/packages/core/src/runtime/__tests__/json-output.test.ts
+++ b/packages/core/src/runtime/__tests__/json-output.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers the model-output JSON salvage helpers — parseJsonObject,
+ * extractJsonObjects, and repairJsonStringEscapes — over trailing garbage, raw
+ * control chars, invalid backslash escapes, and prose-embedded objects. Pure
+ * functions, no runtime.
+ */
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/core/src/runtime/__tests__/message-handler-output.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-output.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers Stage-1 response parsing: the replyText field evaluator (structural-
+ * punctuation and leaked tool-call-markup stripping), parseMessageHandlerOutput's
+ * candidate-action hint trim/dedupe/cap, and alignment of HANDLE_RESPONSE_SCHEMA
+ * with the composed field-registry schema. Deterministic — parses fixed JSON
+ * envelopes, no model.
+ */
 import { describe, expect, it } from "vitest";
 import { HANDLE_RESPONSE_SCHEMA } from "../../actions/to-tool";
 import {

--- a/packages/core/src/runtime/__tests__/message-handler.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers Stage-1 routing: routeMessageHandlerOutput's simple-reply vs planning vs
+ * ignore/stop decisions (including requiresTool / candidateActions promotion and
+ * its suppression), and parseMessageHandlerOutput's flat-envelope plus extract
+ * parsing. Deterministic — routes fixed output objects, no model.
+ */
 import { describe, expect, it } from "vitest";
 import { HANDLE_RESPONSE_SCHEMA } from "../../actions/to-tool";
 import {
@@ -353,11 +359,10 @@ describe("v5 message handler routing", () => {
 		]);
 	});
 
-	// Removed: "refusal suppression on planning path (elizaOS/eliza#7620)"
-	// describe block. The refusal-sanitization fallback was deleted along with
-	// the `refusal-detector` module. Under `toolChoice: "required"` + per-turn
-	// action tools, the model picks the right tool directly — there is no
-	// "model contradicts its own routing decision" case to repair.
+	// No refusal-sanitization repair runs on the planning path: under
+	// `toolChoice: "required"` + per-turn action tools the model picks the right
+	// tool directly, so there is no "model contradicts its own routing decision"
+	// case to repair.
 
 	it("maps shouldRespond IGNORE/STOP through routing", () => {
 		const ignore = parseMessageHandlerOutput(

--- a/packages/core/src/runtime/__tests__/message-post-connectors.test.ts
+++ b/packages/core/src/runtime/__tests__/message-post-connectors.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises the runtime message/post connector registries and the connector
+ * progress-UX dispatch (send / edit / typing / thread): registration,
+ * account-scoped send routing, read-time clone isolation, and capability
+ * gating. A real AgentRuntime over the in-memory adapter drives stub connector
+ * handlers — no live model or network.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import {

--- a/packages/core/src/runtime/__tests__/model-input-budget.test.ts
+++ b/packages/core/src/runtime/__tests__/model-input-budget.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for `buildModelInputBudget`: per-model context-window
+ * resolution, reserve-token scaling by the window fraction, compaction-
+ * threshold derivation, and the `MODEL_CONTEXT_WINDOWS_JSON` env override.
+ * Pure deterministic assertions — no live model, no database.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ChatMessage, ToolDefinition } from "../../types/model";
 import {
@@ -43,7 +49,7 @@ describe("buildModelInputBudget", () => {
 
 		it("preserves the legacy default reserve (10k) when no modelName provided", () => {
 			// This is the back-compat guarantee — callers that don't opt into
-			// the per-model lookup must see exactly the pre-PR threshold.
+			// the per-model lookup must see exactly the legacy threshold.
 			const budget = buildModelInputBudget({
 				messages: [userMessageOfChars(100)],
 			});

--- a/packages/core/src/runtime/__tests__/model-provider-failover.test.ts
+++ b/packages/core/src/runtime/__tests__/model-provider-failover.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Exercises `AgentRuntime.useModel` provider failover: an exhausted
+ * (rate-limited) provider falls through to the next registration, an
+ * `ELIZA_BRAIN_PROVIDER` pin is preferred yet still failed past when limited,
+ * and neither ordinary errors nor an explicitly requested provider trigger
+ * failover. A real runtime over the in-memory adapter drives stub handlers that
+ * throw the live subscription-limit envelope — no network model call.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import { AgentRuntime } from "../../runtime";

--- a/packages/core/src/runtime/__tests__/model-registrations.test.ts
+++ b/packages/core/src/runtime/__tests__/model-registrations.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises AgentRuntime model-registration observability: the
+ * `MODEL_REGISTERED` event payload, `getModelRegistrations()` returning
+ * handler-free metadata, plugin `modelMetadata` application, and failover
+ * surviving alongside the registry API. A real runtime over the in-memory
+ * adapter registers noop handlers — no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import { AgentRuntime } from "../../runtime";

--- a/packages/core/src/runtime/__tests__/pii-swap-reply-egress.test.ts
+++ b/packages/core/src/runtime/__tests__/pii-swap-reply-egress.test.ts
@@ -9,9 +9,9 @@ import { runWithTrajectoryContext } from "../../trajectory-context";
 /**
  * Reply-boundary egress test for the PII pseudonymization layer (#10827).
  *
- * The tool-call boundary (`execute-planned-tool-call.ts`) already restores real
- * PII into handler args, but a direct/terminal reply that does NOT go through a
- * tool call was shipping the surrogate to the user. `restorePiiInUserReplyText`
+ * The tool-call boundary (`execute-planned-tool-call.ts`) restores real PII into
+ * handler args, but a direct/terminal reply that does NOT go through a tool call
+ * would otherwise ship the surrogate to the user. `restorePiiInUserReplyText`
  * is the restore wired into `createV5ReplyStrategyResult` — the single chokepoint
  * every user-facing reply (direct `final_reply`, terminal `messageToUser`,
  * terminal planner `REPLY`, LifeOps direct) is built through. This proves the

--- a/packages/core/src/runtime/__tests__/planner-loop-8007-multistep.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-8007-multistep.test.ts
@@ -12,7 +12,7 @@ import { runPlannerLoop } from "../planner-loop";
  * 8 successive `ACTION_STARTED actionName=TASKS op=provision_workspace` events,
  * until the trajectory limit fired and Discord showed the 120s timeout.
  *
- * Two framework mechanisms now bound and unblock this loop; these tests pin
+ * Two framework mechanisms bound and unblock this loop; these tests pin
  * both against the exact orchestrator shape from the issue:
  *
  *  1. Prior successful tool results ARE surfaced into the next planner turn's

--- a/packages/core/src/runtime/__tests__/planner-loop-cerebras-recorded.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-cerebras-recorded.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Confirms the planner loop extracts a native tool call (name, args, id) from a
+ * recorded Cerebras / AI SDK v6 response shape (`toolName`/`input`,
+ * `finishReason: "tool-calls"`). Deterministic: `useModel` is a vitest mock
+ * replaying a captured fixture — no live provider call.
+ */
 import { describe, expect, it, vi } from "vitest";
 import type { GenerateTextResult, ToolDefinition } from "../../types/model";
 import { runPlannerLoop } from "../planner-loop";
@@ -15,8 +21,8 @@ type CerebrasRecordedToolCall = NonNullable<
  * toolCalls[].name, toolCalls[].input) and assert the planner correctly
  * extracts the tool call name and args.
  *
- * The fixture matches the shape returned by the Cerebras provider via the
- * AI SDK v6 adapter used in this branch.
+ * The fixture matches the shape returned by the Cerebras provider via its
+ * AI SDK v6 adapter.
  */
 
 /**

--- a/packages/core/src/runtime/__tests__/planner-loop-message-stacking.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-message-stacking.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Pins the planner's chat-message wire shape across loop iterations: an
+ * append-only array with a stable system+user prefix and one assistant+tool
+ * pair per completed step (prefix-cache-safe, no JSON trajectory dump).
+ * Deterministic — `useModel` is a vitest mock that captures each `messages`
+ * array; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import type {
 	ChatMessage,
@@ -138,15 +145,14 @@ describe("planner-loop message stacking regression", () => {
 	});
 
 	it("planner never appends a standalone trajectory JSON dump as the LAST message", async () => {
-		// The old bug: renderPlannerModelInput appended a role:"user" message at
-		// the END of the array as the LAST message containing `trajectory:\n[...]`.
-		// The fix: trajectory steps are now rendered as assistant/tool pairs, not
-		// as a standalone user message appended at the end.
+		// Regression guard: the LAST appended planner message must NOT be a
+		// role:"user" message whose content starts `trajectory:\n[` — trajectory
+		// steps render as assistant/tool pairs, never as a standalone user JSON
+		// dump appended at the end.
 		//
 		// Note: the context renderer (renderContextObject) legitimately includes
-		// trajectory state as part of messages[1] (the rendered context). That is
-		// expected. The regression guard is that the LAST appended planner message
-		// must NOT be a role:"user" message with content starting `trajectory:\n[`.
+		// trajectory state as part of messages[1] (the rendered context); that is
+		// expected and not what this guard checks.
 
 		const capturedMessages: ChatMessage[][] = [];
 		let callCount = 0;
@@ -187,9 +193,8 @@ describe("planner-loop message stacking regression", () => {
 		});
 
 		// For each planner call, the LAST message in the array must NOT be a
-		// role:"user" message with content starting `trajectory:\n[` (the old dump).
-		// After the fix, the last messages should be the assistant/tool pairs from
-		// trajectory steps.
+		// role:"user" message with content starting `trajectory:\n[`. The last
+		// messages are the assistant/tool pairs from trajectory steps.
 		for (const messages of capturedMessages) {
 			const lastMsg = messages[messages.length - 1];
 			const isJsonDump =
@@ -201,7 +206,7 @@ describe("planner-loop message stacking regression", () => {
 		}
 
 		// After the first tool executes, the second planner call must end with
-		// a role:"tool" message (the new append-only pattern).
+		// a role:"tool" message (append-only suffix).
 		if (capturedMessages.length >= 2) {
 			const secondPlannerMsgs = capturedMessages[1];
 			const lastMsg = secondPlannerMsgs?.[secondPlannerMsgs.length - 1];

--- a/packages/core/src/runtime/__tests__/planner-loop-multistep-advance.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-multistep-advance.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Regression coverage (#8007) for planner multi-step advance: each succeeded
+ * intermediate tool result is surfaced to the next turn so the loop advances
+ * (provision → spawn → submit) instead of re-dispatching the first step, and a
+ * weak model that re-emits an identical call is bounded. Deterministic —
+ * scripted `useModel` + tool executor shaped like the orchestrator's real
+ * returns; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import type { GenerateTextResult, ToolDefinition } from "../../types/model";
 import { runPlannerLoop } from "../planner-loop";

--- a/packages/core/src/runtime/__tests__/planner-loop-terminal-finish-without-message.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-terminal-finish-without-message.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Guards that a terminal-only FINISH verdict is honored even when the evaluator
+ * omits `messageToUser`: the loop falls back to the planner's terminal text
+ * instead of coercing FINISH→CONTINUE and burning the terminal-continuation cap.
+ * Deterministic — vitest-mocked `useModel`; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { runPlannerLoop } from "../planner-loop";
 

--- a/packages/core/src/runtime/__tests__/planner-loop-tools-vs-schema.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-tools-vs-schema.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Pins the planner's `useModel` wire contract: native tool-calling and
+ * `responseSchema` are mutually exclusive (tools set ⇒ no schema, empty ⇒
+ * schema), plus `toolChoice` forcing and the required-tool-miss cap that
+ * surfaces a captured refusal. Deterministic — vitest mock captures each
+ * `useModel` param set; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import type { ToolDefinition } from "../../types/model";
 import { runPlannerLoop } from "../planner-loop";

--- a/packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers the planner's user-facing-text isolation: only a tool's explicit
+ * `userFacingText` (never its log-shaped `text`) reaches the reply, the
+ * single-verified-result filter ignores failed steps, and the spawn-arg-leak
+ * detector suppresses leaked TASKS envelopes. Deterministic — vitest-mocked
+ * `useModel` plus pure helper assertions; no live model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import {
 	looksLikeSpawnEnvelopeJson,
@@ -8,28 +15,23 @@ import type { PlannerTrajectory } from "../planner-types";
 import type { TrajectoryRecorder } from "../trajectory-recorder";
 
 /**
- * Regression coverage for the structural fix that stops tool-diagnostic
- * `text` (shell prompts, `[exit 0]`, `--- stdout ---` wrappers, cwd
- * markers, byte counts) from being shown to users verbatim.
+ * Guards the `userFacingText` contract that keeps tool-diagnostic `text`
+ * (shell prompts, `[exit 0]`, `--- stdout ---` wrappers, cwd markers, byte
+ * counts) out of user replies.
  *
- * Before this PR, `latestToolResultText` returned `step.result.text` —
- * the tool's log-shaped projection. Tools like BASH emit:
+ * `PlannerToolResult` carries an explicit `userFacingText` field, and the
+ * terminal-FINISH fallback (used when the evaluator supplies no
+ * `messageToUser`) displays only that — never the tool's log-shaped `text`.
+ * A log-only tool like BASH emits a wrapper such as:
  *
  *   $ find /home/eliza/.eliza/trajectories -type f
  *   [exit 0] (cwd=/home/eliza/iqlabs/eliza/eliza, took=37ms)
  *   --- stdout ---
  *   443
  *
- * That entire wrapper string was leaking into Discord replies because
- * the planner-loop's terminal-FINISH fallback chain used it when the
- * evaluator didn't supply a `messageToUser`.
- *
- * The fix is structural: `PlannerToolResult` now carries an explicit
- * `userFacingText` field. The framework only uses that for direct user
- * display. Tools that emit logs leave it undefined → the framework
- * falls through to a synthesized response message instead of leaking
- * the wrapper. This avoids regex-based wrapper detection and gives
- * every tool a clear contract.
+ * and leaves `userFacingText` undefined, so the loop synthesizes a response
+ * instead of leaking the wrapper. This is a structural contract, not
+ * regex-based wrapper detection.
  */
 
 describe("planner-loop — user-facing tool text isolation", () => {

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Core planner-loop suite: `parsePlannerOutput` shape/recovery parsing and
+ * end-to-end `runPlannerLoop` behavior — tool dispatch, the evaluator FINISH
+ * gate, trajectory limits, coding/full-surface token caps, required-tool
+ * handling, suffix compaction, and `plannerTemplate` policy text. Deterministic
+ * — `useModel`, `executeToolCall`, and `evaluate` are vitest mocks; no live
+ * model.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { plannerTemplate } from "../../prompts/planner";
 import { type ChatMessage, ModelType } from "../../types/model";
@@ -371,9 +379,8 @@ describe("v5 planner loop skeleton", () => {
 		]);
 		expect(plannerParams.messages[0].content).toContain("planner_stage:");
 		expect(plannerParams.messages[0].content).toContain("agent_name: Eliza");
-		// Provider events render as `provider:NAME:\n<text>` (label + content).
-		// The previous shape baked an extra `provider: <name>` line into the
-		// content body, doubling up with the label. The new render drops that.
+		// Provider events render as `provider:NAME:\n<text>` (label + content),
+		// with no duplicate `provider: <name>` line baked into the content body.
 		expect(plannerParams.messages[1].content).toContain(
 			"provider:RECENT_MESSAGES:",
 		);
@@ -381,9 +388,9 @@ describe("v5 planner loop skeleton", () => {
 		expect(plannerParams.messages[1].content).not.toMatch(
 			/provider:RECENT_MESSAGES:\nprovider: RECENT_MESSAGES/,
 		);
-		// After the stacking fix, trajectory steps are conveyed as assistant/tool
-		// message pairs, NOT as a JSON dump in the user message. The user message
-		// (messages[1]) should no longer contain "trajectory:\n[".
+		// Trajectory steps are conveyed as assistant/tool message pairs, NOT as a
+		// JSON dump in the user message, so messages[1] never starts with
+		// "trajectory:\n[".
 		expect(plannerParams.messages[1].content).not.toMatch(/^trajectory:\n\[/);
 		expect(plannerParams.providerOptions.eliza.modelInputBudget).toMatchObject({
 			reserveTokens: 10_000,

--- a/packages/core/src/runtime/__tests__/planner-output-safety.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-output-safety.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Guards `parsePlannerOutput` user-visible safety: evaluator/control envelope
+ * JSON emitted in the native text channel is consumed as control data (never
+ * shown as a reply), while a genuine user-requested JSON object round-trips to a
+ * visible message. Pure unit tests — no model or runtime.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	looksLikeEvaluatorEnvelopeJson,

--- a/packages/core/src/runtime/__tests__/planner-rendering.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-rendering.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises planner render helpers: `truncateToolResultText` head/marker/tail
+ * clamping and `trajectoryStepsToMessages` per-step tool-result truncation
+ * (rendered-only, leaving `PlannerStep.result.text` pristine). Pure unit tests —
+ * no model or runtime.
+ */
 import { describe, expect, it } from "vitest";
 import type { ChatMessage } from "../../types/model";
 import {

--- a/packages/core/src/runtime/__tests__/private-action-gate.test.ts
+++ b/packages/core/src/runtime/__tests__/private-action-gate.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for the private-action turn gate — `isAutonomousTurn` and
+ * `privateActionAllowedOnTurn` — asserting that actions marked `private` are
+ * exposed only on autonomous turns and always-allowed otherwise. Pure
+ * predicates over an in-memory `Memory`; no runtime or model.
+ */
 import { describe, expect, it } from "vitest";
 import type { Memory } from "../../types/memory";
 import {

--- a/packages/core/src/runtime/__tests__/provider-cache-plan.test.ts
+++ b/packages/core/src/runtime/__tests__/provider-cache-plan.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit coverage for prompt-cache planning — `buildProviderCachePlan` and
+ * `buildPromptCacheKey` — verifying the per-provider `providerOptions` (OpenAI
+ * retention, Anthropic breakpoints, Cerebras/OpenRouter, Gemini, Gateway, and
+ * the eliza sidecar) and the 1024-char cache-key cap. Deterministic; no live
+ * provider call.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	buildPromptCacheKey,

--- a/packages/core/src/runtime/__tests__/response-field-transcript.test.ts
+++ b/packages/core/src/runtime/__tests__/response-field-transcript.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit coverage for the text-mode response-field transcript parser
+ * (`parseFieldTranscript`, `extractReplyTextFromTranscript`,
+ * `looksLikeRawFieldTranscript`, `splitTranscriptList`) and the message-handler
+ * fallback that recovers a clean reply from a leaked `shouldRespond:/replyText:`
+ * envelope. Driven by deterministic string fixtures (the exact #11712 leak,
+ * plus quoting/fenced counter-examples); no model.
+ */
 import { describe, expect, it } from "vitest";
 import { parseMessageHandlerOutput } from "../message-handler";
 import {
@@ -135,9 +143,9 @@ describe("response field transcript — looksLikeRawFieldTranscript (send-bounda
 // A reply that QUOTES a transcript is content, not a leak. This repo's own
 // daily workflow: a user pastes a leaked `shouldRespond:/replyText:` transcript
 // into chat and asks the bot to diagnose it. The diagnosis legitimately carries
-// quoted field lines; the guard must not rewrite it (previously the send
-// boundary replaced the whole diagnosis with the QUOTED replyText value,
-// silently dropping the actual answer).
+// quoted field lines; the guard must not rewrite it — otherwise the send
+// boundary would replace the whole diagnosis with the QUOTED replyText value,
+// silently dropping the actual answer.
 const QUOTING_DIAGNOSIS = `the bug is in your parser — when the model emits:
 
 shouldRespond: RESPOND

--- a/packages/core/src/runtime/__tests__/response-grammar.test.ts
+++ b/packages/core/src/runtime/__tests__/response-grammar.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit coverage for guided-decode grammar assembly: the Stage-1 response
+ * envelope grammar/skeleton, the Stage-2 per-action grammars (loose and strict
+ * single-call union), per-action parameter skeletons, bounded-number rules, the
+ * per-span argmax sampler plan, and the guided-decode provider-option merge.
+ * Pure grammar construction over synthetic actions and field evaluators — no
+ * model, no runtime.
+ */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { normalizeActionJsonSchema } from "../../actions/action-schema";
 import type { Action } from "../../types";
@@ -958,9 +966,9 @@ describe("buildPlannerActionGrammarStrict — single-call per-action union gramm
 });
 
 describe("buildPlannerActionGrammarStrict — realistic action set (P2-4 production shape)", () => {
-	// Mirror the kind of schemas Phase A declared on real actions. The test
-	// catches regressions where the grammar generator silently drops a
-	// constraint someone added downstream.
+	// Mirror the kind of schemas real actions declare. The test catches
+	// regressions where the grammar generator silently drops a constraint
+	// someone added downstream.
 	const messageAction = makeAction("MESSAGE", {
 		parameters: [
 			{
@@ -1696,7 +1704,7 @@ describe("buildBoundedNumberRule — boundary, single-value, and degenerate rang
 		const result = buildPlannerActionGrammarStrict([action]);
 		expect(result).not.toBeNull();
 		if (!result) return;
-		// Inverted range fix landed: min > max is unsatisfiable, so the impl
+		// An inverted range (min > max) is unsatisfiable, so the impl
 		// falls back to the shared `jsonnumber` rule (same shape as the large-
 		// range and float cases) instead of emitting an empty rule body that
 		// would produce malformed GBNF.

--- a/packages/core/src/runtime/__tests__/response-handler-evaluators.test.ts
+++ b/packages/core/src/runtime/__tests__/response-handler-evaluators.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit coverage for `runResponseHandlerEvaluators`, the deterministic
+ * post-Stage-1 patch pass that rewrites the parsed plan (contexts, candidate
+ * actions, parent-action hints, reply, deterministic tool call) in priority
+ * order, isolates individual evaluator failures, and reports applied patches.
+ * Synthetic evaluators over a stub runtime; no model.
+ */
 import { describe, expect, it } from "vitest";
 import type { MessageHandlerResult } from "../../types/components";
 import type { Memory } from "../../types/memory";

--- a/packages/core/src/runtime/__tests__/response-handler-field-registry.test.ts
+++ b/packages/core/src/runtime/__tests__/response-handler-field-registry.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit coverage for `ResponseHandlerFieldRegistry`: registration/dedup and
+ * validation, priority ordering, composed-schema stability and field subsetting,
+ * prompt-slice rendering (active vs gated-off, compact vs full), and field
+ * dispatch (parse/handle outcomes, defaulting, preempt, and abort-signal
+ * short-circuit). Synthetic field evaluators over a stub runtime; no model.
+ */
 import { describe, expect, it } from "vitest";
 import type { Memory } from "../../types/memory";
 import type { IAgentRuntime } from "../../types/runtime";

--- a/packages/core/src/runtime/__tests__/room-handler-queue.test.ts
+++ b/packages/core/src/runtime/__tests__/room-handler-queue.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for `RoomHandlerQueue`: per-room serialization, cross-room
+ * concurrency, queue-depth accounting (`pendingFor`), drain (`quiesce` /
+ * `quiesceAll`), empty-queue garbage collection, and lifecycle events. Exercises
+ * the real queue with real timers; no model or runtime.
+ */
 import { describe, expect, it } from "vitest";
 import { RoomHandlerQueue, type RoomQueueEvent } from "../room-handler-queue";
 

--- a/packages/core/src/runtime/__tests__/run-actions-by-mode.test.ts
+++ b/packages/core/src/runtime/__tests__/run-actions-by-mode.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises `AgentRuntime.runActionsByMode` (the hook-mode action runner):
+ * mode filtering, `modePriority` ordering, parallel DURING execution, context
+ * gating, error isolation, and callback attribution. Real runtime over the
+ * in-memory adapter with a stubbed `composeState` — deterministic, no model.
+ */
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import { AgentRuntime } from "../../runtime";

--- a/packages/core/src/runtime/__tests__/schema-compat.test.ts
+++ b/packages/core/src/runtime/__tests__/schema-compat.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for the Cerebras schema/function-name compatibility shims
+ * (`normalizeSchemaForCerebras`, `sanitizeFunctionNameForCerebras`): stripping
+ * empty object schemas, recursion into nested properties and array items, and
+ * identifier rewriting. Pure functions, deterministic.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	normalizeSchemaForCerebras,

--- a/packages/core/src/runtime/__tests__/secret-swap-egress.test.ts
+++ b/packages/core/src/runtime/__tests__/secret-swap-egress.test.ts
@@ -1,9 +1,3 @@
-import { describe, expect, it, vi } from "vitest";
-import { SecretSwapSession } from "../../security/secret-swap";
-import { runWithTrajectoryContext } from "../../trajectory-context";
-import type { Action, IAgentRuntime, Memory } from "../../types";
-import { executePlannedToolCall } from "../execute-planned-tool-call";
-
 /**
  * End-to-end egress test for the secret-swap layer (#10469).
  *
@@ -14,6 +8,11 @@ import { executePlannedToolCall } from "../execute-planned-tool-call";
  * instead of reaching the handler. The session is carried on the turn-scoped
  * trajectory context exactly as `useModel` stores it on ingress.
  */
+import { describe, expect, it, vi } from "vitest";
+import { SecretSwapSession } from "../../security/secret-swap";
+import { runWithTrajectoryContext } from "../../trajectory-context";
+import type { Action, IAgentRuntime, Memory } from "../../types";
+import { executePlannedToolCall } from "../execute-planned-tool-call";
 
 function makeRuntime(actions: Action[]): IAgentRuntime {
 	return {

--- a/packages/core/src/runtime/__tests__/secret-swap-use-model.test.ts
+++ b/packages/core/src/runtime/__tests__/secret-swap-use-model.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises the secret-swap ingress path in `AgentRuntime.useModel`: known
+ * secrets become per-session nonce placeholders before the model handler sees
+ * the prompt — including secrets added by pre_model hooks and secrets split
+ * across stream chunks — and never leak in the output. Real runtime over the
+ * in-memory adapter with a registered fake model handler; deterministic.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import { AgentRuntime } from "../../runtime";

--- a/packages/core/src/runtime/__tests__/serialization-memo.test.ts
+++ b/packages/core/src/runtime/__tests__/serialization-memo.test.ts
@@ -1,14 +1,14 @@
+/**
+ * Memoization of the planner-loop routing-hints prompt block. Exercises
+ * `__renderRoutingHintsBlockForTests`: output is memoized on `context.events`
+ * identity via a WeakMap, so repeated within-turn renders return the same bytes
+ * for free (and drop when the context is GC'd), and the compress-mode env flag
+ * suppresses rendering. Deterministic, no model.
+ */
 import { afterEach, describe, expect, it } from "vitest";
 
 import { __renderRoutingHintsBlockForTests } from "../planner-loop";
 import type { ContextObject } from "../planner-types";
-
-// Wave 2-D: after the per-action-native-tools refactor, the
-// "available_actions" prompt block is gone (action info now rides on the
-// tools array). The only remaining memoized renderer covered here is the
-// routing-hints block, which is keyed on `context.events` identity so
-// within-turn recomputation is free. WeakMap; no leak when the context
-// object is GC'd.
 
 interface ToolEvent {
 	id: string;

--- a/packages/core/src/runtime/__tests__/streaming-use-model.test.ts
+++ b/packages/core/src/runtime/__tests__/streaming-use-model.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises structured/plain streaming through `AgentRuntime.useModel` and
+ * `isLocalProvider` routing: local-handler stream callbacks, non-local
+ * textStream fan-out, tool-call/usage passthrough, mid-stream abort, and
+ * suppression of hidden image-description calls from ambient chat streams. Real
+ * runtime over the in-memory adapter with registered fake handlers; deterministic.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import { AgentRuntime } from "../../runtime";

--- a/packages/core/src/runtime/__tests__/sub-planner.test.ts
+++ b/packages/core/src/runtime/__tests__/sub-planner.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises the sub-planner helpers (`actionHasSubActions`,
+ * `detectSubActionCycles`, `resolveSubActions`, `runSubPlanner`): child-action
+ * resolution and simile matching, native-tool exposure, context propagation,
+ * and role/context gating. Mocked runtime with stubbed useModel/execute/evaluate;
+ * deterministic.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Action, IAgentRuntime, Memory } from "../../types";
 import { _resetActionRolePolicyCacheForTests } from "../action-role-policy";

--- a/packages/core/src/runtime/__tests__/system-prompt.test.ts
+++ b/packages/core/src/runtime/__tests__/system-prompt.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit coverage for the canonical system-prompt builder and helpers
+ * (`buildCanonicalSystemPrompt`, `resolveEffectiveSystemPrompt`,
+ * `dropDuplicateLeadingSystemMessage`): character/bio/role rendering,
+ * `{{name}}`/`{{agentName}}` substitution, and source precedence. Pure,
+ * deterministic.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	buildCanonicalSystemPrompt,

--- a/packages/core/src/runtime/__tests__/topics-field-evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/topics-field-evaluator.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit coverage for the topics field evaluator and `normalizeTopics`
+ * (lowercasing, dedupe, length/count caps, scalar coercion) plus topics
+ * threading through `parseMessageHandlerOutput`. Pure, deterministic.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	MAX_MESSAGE_TOPICS,

--- a/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the JSON-file trajectory recorder: stage recording, metrics
+ * roll-up, field capping/sanitization, price-table cost annotation, redacted
+ * markdown review artifacts, and finalize leak-guarding. Runs against real
+ * temp-dir filesystem writes with an in-process recorder — no live model;
+ * token/usage and cost inputs are hand-fed.
+ */
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/packages/core/src/runtime/__tests__/turn-controller.test.ts
+++ b/packages/core/src/runtime/__tests__/turn-controller.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for TurnControllerRegistry: per-room turn registration and
+ * cleanup, abort signalling, lifecycle events, and cross-room isolation. Fully
+ * in-process and deterministic (real timers, no model or DB).
+ */
 import { describe, expect, it } from "vitest";
 import {
 	TurnAbortedError,

--- a/packages/core/src/runtime/__tests__/use-model-provider-fallback.test.ts
+++ b/packages/core/src/runtime/__tests__/use-model-provider-fallback.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for AgentRuntime.useModel provider fallback: rotation to a
+ * lower-priority provider on retryable (429 / 5xx / 529 / fetch-failed) errors,
+ * failing closed for non-retryable errors and TTS slots, and honoring a pinned
+ * provider. Drives a real AgentRuntime + InMemoryDatabaseAdapter with vi.fn
+ * model handlers — no live model calls.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import { AgentRuntime } from "../../runtime";

--- a/packages/core/src/runtime/action-catalog.ts
+++ b/packages/core/src/runtime/action-catalog.ts
@@ -1,3 +1,9 @@
+/**
+ * Assembles the planner's action catalog: normalizes runtime actions into
+ * sorted parent/child entries with deduped keyword and search text, resolves
+ * declared sub-actions, applies locale-aware example swapping, and collects
+ * structural warnings (duplicate, missing, or invalid sub-actions).
+ */
 import {
 	type ActionSearchKeywordSource,
 	getActionSearchKeywordSources,

--- a/packages/core/src/runtime/action-gate.test.ts
+++ b/packages/core/src/runtime/action-gate.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Deterministic unit tests for the unified action gate (`canActionRun` /
+ * `actionGateFailure`) — synthetic in-process actions, no live model or DB.
+ */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Action } from "../types/components";
 import type { AgentContext, RoleGateRole } from "../types/contexts";

--- a/packages/core/src/runtime/action-gate.ts
+++ b/packages/core/src/runtime/action-gate.ts
@@ -1,3 +1,9 @@
+/**
+ * The single role/context/policy gate every action exposure and execution path
+ * consults before an action may be surfaced to the planner or run — composing
+ * the private-action gate, the operator role policy, the context gate, and the
+ * top-level role gate in a fixed precedence.
+ */
 import type { Action } from "../types/components";
 import type { AgentContext, RoleGate, RoleGateRole } from "../types/contexts";
 import type { Memory } from "../types/memory";
@@ -49,10 +55,7 @@ export interface ActionGateContext {
  * Returns a human-readable failure reason, or `undefined` when the action is
  * allowed. Every exposure and execution path — planner selection, sub-planner
  * child filtering, the tool-call executor, and the shortcut gate — routes
- * through this one function so their outcomes cannot drift apart. This is the
- * chokepoint the previous three near-duplicate implementations
- * (`getGateFailure`, `actionPassesPlannerExecutionGates`, the sub-planner
- * OR-filter) collapsed into.
+ * through this one function so their outcomes cannot drift apart.
  */
 export function actionGateFailure(
 	action: GateableAction,

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -1,3 +1,9 @@
+/**
+ * Multi-stage action retrieval for the planner: scores catalog parents by
+ * exact-hint, candidate-regex, keyword, BM25, embedding tie-breaker, and
+ * context-match signals, then fuses the per-stage rankings with reciprocal-rank
+ * fusion into a tier-sized candidate set.
+ */
 import { countActionSearchKeywordMatches } from "../i18n/action-search-keywords";
 import type { ActionCatalog, ActionCatalogParent } from "./action-catalog";
 import { normalizeActionName } from "./action-catalog";
@@ -583,11 +589,10 @@ interface ParentScoringTokens {
 
 // Per-catalog-parent scoring tokens, memoized by the parent object. The parent's
 // searchText is static, so tokenization + the term-frequency map are pure
-// functions of it; previously scoreBm25 recomputed both on every message. Keyed
-// by object identity in a WeakMap so it's recomputed only when the catalog
-// rebuilds (new parent objects) and auto-collected when the catalog is dropped.
-// The returned termFrequency map is read-only at the call sites, so sharing it
-// across calls is safe.
+// functions of it. Keyed by object identity in a WeakMap so it's recomputed only
+// when the catalog rebuilds (new parent objects) and auto-collected when the
+// catalog is dropped. The returned termFrequency map is read-only at the call
+// sites, so sharing it across calls is safe.
 const parentScoringCache = new WeakMap<
 	ActionCatalogParent,
 	ParentScoringTokens

--- a/packages/core/src/runtime/action-role-policy.test.ts
+++ b/packages/core/src/runtime/action-role-policy.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Deterministic unit tests for the `ACTION_ROLE_POLICY` operator override —
+ * env-var parse/cache and pure role authorization; no model or DB.
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	_resetActionRolePolicyCacheForTests,

--- a/packages/core/src/runtime/action-role-policy.ts
+++ b/packages/core/src/runtime/action-role-policy.ts
@@ -1,3 +1,9 @@
+/**
+ * Reads, caches, and applies the operator `ACTION_ROLE_POLICY` override:
+ * per-action minimum-role resolution, role-based authorization checks, and
+ * startup warnings for policy keys that loosen a declared gate or match no
+ * registered action.
+ */
 import { logger } from "../logger";
 import type { RoleGateRole } from "../types/contexts";
 import {

--- a/packages/core/src/runtime/action-tiering.ts
+++ b/packages/core/src/runtime/action-tiering.ts
@@ -1,3 +1,10 @@
+/**
+ * Tier-aware action catalog assembly for the planner. Partitions
+ * retrieval-ranked catalog parents into protocol (tier 0), first-class (tier A),
+ * umbrella-only (tier B), and omitted (tier C) bands, narrows tier A to the
+ * Stage-1 candidate actions, caps parents and per-parent children, and emits the
+ * exposed action surface plus a stable hash for cache and trajectory keying.
+ */
 import {
 	type ActionCatalog,
 	type ActionCatalogChild,

--- a/packages/core/src/runtime/addressed-to.ts
+++ b/packages/core/src/runtime/addressed-to.ts
@@ -1,3 +1,10 @@
+/**
+ * Resolves and persists the message handler's `addressedTo` targets. Upserts
+ * "addressed" relationship edges from the speaker to each resolved participant,
+ * and decides whether an inbound turn is directed at another participant (so the
+ * agent is merely overhearing and should not act on it). All name/id resolution
+ * runs against the room's entity list, without an LLM call.
+ */
 import type { Entity, UUID } from "../types/index";
 import type { Memory } from "../types/memory";
 import type { IAgentRuntime } from "../types/runtime";

--- a/packages/core/src/runtime/context-gates.test.ts
+++ b/packages/core/src/runtime/context-gates.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the role and context gate filters (`filterByContextGate`,
+ * `normalizeGateRole`). Deterministic in-line literal fixtures — no runtime,
+ * model, or database.
+ */
 import { describe, expect, it } from "vitest";
 import type { AgentContext } from "../types/contexts";
 import type { RoleGateRole } from "./context-gates";

--- a/packages/core/src/runtime/context-gates.ts
+++ b/packages/core/src/runtime/context-gates.ts
@@ -1,3 +1,10 @@
+/**
+ * Role and context gate predicates for provider and action visibility. Decides
+ * whether a caller's roles satisfy a `RoleGate` (min-rank plus anyOf/allOf/noneOf)
+ * and whether the active agent contexts satisfy a `ContextGate`, and filters a
+ * candidate list by both. Role and context names are normalized before every
+ * comparison.
+ */
 import { CANONICAL_ROLE_RANK } from "../roles";
 import type {
 	AgentContext,
@@ -7,7 +14,7 @@ import type {
 } from "../types/contexts";
 import { normalizeContextList } from "./context-normalization";
 
-// #9948: single source of truth for role ranking (was a duplicate literal here).
+// #9948: single source of truth for role ranking — delegates to CANONICAL_ROLE_RANK.
 const ROLE_RANK: Record<string, number> = CANONICAL_ROLE_RANK;
 
 export function normalizeGateRole(role: RoleGateRole): RoleGateRole {

--- a/packages/core/src/runtime/context-hash.ts
+++ b/packages/core/src/runtime/context-hash.ts
@@ -1,3 +1,9 @@
+/**
+ * Deterministic hashing for prompt segments and their cumulative prefixes.
+ * Provides a key-sorted, undefined-dropping stable JSON serializer plus sha256
+ * helpers so identical context prefixes hash identically across runs — the basis
+ * for prompt-cache reuse and trajectory prefix matching.
+ */
 import { createHash } from "../utils/crypto-compat";
 
 export type StableJsonValue =

--- a/packages/core/src/runtime/context-normalization.ts
+++ b/packages/core/src/runtime/context-normalization.ts
@@ -1,3 +1,9 @@
+/**
+ * Canonical first-party context ids and their normalization helpers. Lower-cases
+ * and underscores raw context ids, expands the narrow finance/crypto aliases to
+ * their canonical set, and de-duplicates a context list — the shared normal form
+ * every gate and registry comparison runs against.
+ */
 import type { AgentContext, FirstPartyAgentContext } from "../types/contexts";
 
 export const FIRST_PARTY_CONTEXT_IDS = [

--- a/packages/core/src/runtime/context-object.ts
+++ b/packages/core/src/runtime/context-object.ts
@@ -1,3 +1,9 @@
+/**
+ * Constructors for the per-turn `ContextObject` — the accumulator holding the
+ * static and trajectory prefixes plus the append-only event log the renderer
+ * replays into a stage's messages. `createContextObject` seeds one at schema
+ * version "v5"; `appendContextEvent` returns a copy with one event added.
+ */
 import type { ContextEvent, ContextObject } from "../types/context-object";
 
 export interface CreateContextObjectOptions {

--- a/packages/core/src/runtime/context-registry.ts
+++ b/packages/core/src/runtime/context-registry.ts
@@ -1,3 +1,10 @@
+/**
+ * Registry of the agent's context taxonomy. Stores normalized `ContextDefinition`
+ * records, validates on every mutation that parent and subcontext edges reference
+ * known contexts and form no cycles, and supports idempotent registration plus
+ * role-gated listing for prompt rendering. Exports a default registry seeded with
+ * the first-party context definitions.
+ */
 import type {
 	AgentContext,
 	ContextDefinition,

--- a/packages/core/src/runtime/context-renderer.ts
+++ b/packages/core/src/runtime/context-renderer.ts
@@ -1,3 +1,11 @@
+/**
+ * Replays a `ContextObject` into the wire shape a model stage consumes: chat
+ * messages, native tool specs, and labeled prompt segments. Formats each context
+ * event (message, memory, provider, tool, instruction, segment, and compacted
+ * runtime events) into its prompt representation and assembles the single-system
+ * plus single-user plus assistant/tool-suffix message array each planner stage
+ * sends.
+ */
 import type {
 	ContextEvent,
 	ContextInstructionEvent,
@@ -39,17 +47,6 @@ export function segmentBlock(segment: PromptSegment): string {
 }
 
 /**
- * Build the wire-shape `messages` array for a stage call: ONE system message
- * (Tier 1: stable context segments + the stage's task instructions), ONE user
- * message (Tier 2: dynamic context segments + caller-supplied dynamic blocks),
- * and the trajectory's append-only assistant/tool suffix.
- *
- * Why: stacking many `system` messages fragments the cache prefix, confuses
- * turn boundaries, and triggers strict provider validation. The native chat
- * protocol expects a single system + user prefix followed by assistant/tool
- * turns for each iteration of the planner loop.
- */
-/**
  * Drop segments with empty content. Used by `normalizePromptSegments` and as a
  * post-step in renderers that build segment lists incrementally.
  */
@@ -90,6 +87,17 @@ export function cachePrefixSegments(
 	return prefix.length > 0 ? prefix : segments.slice(0, 1);
 }
 
+/**
+ * Build the wire-shape `messages` array for a stage call: ONE system message
+ * (Tier 1: stable context segments + the stage's task instructions), ONE user
+ * message (Tier 2: dynamic context segments + caller-supplied dynamic blocks),
+ * and the trajectory's append-only assistant/tool suffix.
+ *
+ * Why: stacking many `system` messages fragments the cache prefix, confuses
+ * turn boundaries, and triggers strict provider validation. The native chat
+ * protocol expects a single system + user prefix followed by assistant/tool
+ * turns for each iteration of the planner loop.
+ */
 export function buildStageChatMessages(args: {
 	contextSegments: PromptSegment[];
 	stageLabel: string;

--- a/packages/core/src/runtime/conversation-compaction-hook.ts
+++ b/packages/core/src/runtime/conversation-compaction-hook.ts
@@ -1,3 +1,10 @@
+/**
+ * Registration slot and typed contract for the message-history compaction hook
+ * a plugin attaches to the runtime. The hook rewrites conversation history
+ * inside `State` before a response/continuation stage renders and reports what
+ * it did through the telemetry shape defined here; register/get store it on the
+ * runtime under a well-known symbol.
+ */
 import type { Memory } from "../types/memory";
 import type { IAgentRuntime } from "../types/runtime";
 import type { State } from "../types/state";

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -1,3 +1,9 @@
+/**
+ * Evaluator stage of the planner loop: renders the evaluator model input, runs
+ * the evaluator model call, and parses/repairs/sanitizes its structured
+ * decision (FINISH / CONTINUE / NEXT_RECOMMENDED) before the loop acts on it.
+ * Also records each evaluation as a trajectory stage for offline review.
+ */
 import { computeCallCostUsd } from "../features/trajectories/pricing";
 import { evaluatorSchema, evaluatorTemplate } from "../prompts/evaluator";
 import {

--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -1,3 +1,10 @@
+/**
+ * Executes one planner-selected tool call against its Action: resolves the
+ * action, applies role and connector-account gates, normalizes and validates
+ * the args, restores real secrets/PII at the egress boundary, runs the handler
+ * inside the trajectory / action-routing context, and emits ACTION_STARTED /
+ * ACTION_COMPLETED around a normalized ActionResult.
+ */
 import { validateToolArgs } from "../actions/validate-tool-args";
 import { evaluateConnectorAccountPolicies } from "../connectors/account-manager";
 import { checkSenderRole } from "../roles";

--- a/packages/core/src/runtime/facts-and-relationships.ts
+++ b/packages/core/src/runtime/facts-and-relationships.ts
@@ -1,3 +1,23 @@
+/**
+ * Stage that runs in parallel with the planner whenever Stage 1
+ * (messageHandler) extracts candidate facts or relationships from the user
+ * message. It does NOT block the user reply: planner + facts run concurrently.
+ *
+ * Responsibilities:
+ *   1. Keyword/BM25-search the `facts` table for memories similar to each
+ *      candidate so the model can see what's already known.
+ *   2. Pull existing relationships for the user/agent so duplicates can be
+ *      filtered.
+ *   3. Surface room entities so the model can ground subject/object names.
+ *   4. Ask the model which candidates are NEW + WORTH WRITING. The model emits
+ *      cleaned text and drops anything that's a near-duplicate of existing
+ *      facts/relationships.
+ *   5. Persist the kept entries via `runtime.createMemory` (facts table) and
+ *      `runtime.createRelationship` (relationships table).
+ *
+ * The trajectory recorder logs this as a `facts_and_relationships` stage so
+ * extraction quality can be reviewed offline.
+ */
 import {
 	buildFactKeywordsForStorage,
 	scoreFactKeywordRelevance,
@@ -22,27 +42,6 @@ import type { State } from "../types/state";
 import { isSyntheticConversationArtifactMemory } from "../utils/synthetic-conversation-artifact";
 import { parseJsonObject } from "./json-output";
 import { buildCanonicalSystemPrompt } from "./system-prompt";
-
-/**
- * Stage that runs in parallel with the planner whenever Stage 1
- * (messageHandler) extracts candidate facts or relationships from the user
- * message. It does NOT block the user reply: planner + facts run concurrently.
- *
- * Responsibilities:
- *   1. Keyword/BM25-search the `facts` table for memories similar to each
- *      candidate so the model can see what's already known.
- *   2. Pull existing relationships for the user/agent so duplicates can be
- *      filtered.
- *   3. Surface room entities so the model can ground subject/object names.
- *   4. Ask the model which candidates are NEW + WORTH WRITING. The model emits
- *      cleaned text and drops anything that's a near-duplicate of existing
- *      facts/relationships.
- *   5. Persist the kept entries via `runtime.createMemory` (facts table) and
- *      `runtime.createRelationship` (relationships table).
- *
- * The trajectory recorder logs this as a `facts_and_relationships` stage so
- * extraction quality can be reviewed offline.
- */
 
 export const FACTS_AND_RELATIONSHIPS_TOOL_NAME =
 	"FACTS_AND_RELATIONSHIPS_VALIDATE";

--- a/packages/core/src/runtime/json-output.ts
+++ b/packages/core/src/runtime/json-output.ts
@@ -1,3 +1,9 @@
+/**
+ * Tolerant parsers for raw model output: unwrap code fences, extract every
+ * top-level `{...}` object from noisy text, repair invalid JSON string escapes,
+ * and strip leaked tool-call markup / punctuation-only replies. Used wherever
+ * the runtime must salvage structure from a weak model's not-quite-valid JSON.
+ */
 export function parseJsonObject<T extends object>(raw: string): T | null {
 	const trimmed = raw.trim();
 	if (!trimmed) {

--- a/packages/core/src/runtime/limits.test.ts
+++ b/packages/core/src/runtime/limits.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit coverage for the planner runaway-loop guards (#8801 — these bound
+ * worst-case cost/looping but shipped untested): what stops a model that
+ * re-issues the same failing tool forever, or grows a trajectory past its token
+ * budget, from burning the turn. Pure deterministic tests — the
+ * threshold/signature/dedup helpers are exercised directly with synthetic
+ * failures and configs; no live model, no DB.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	assertRepeatedFailureLimit,
@@ -9,13 +17,6 @@ import {
 	mergeChainingLoopConfig,
 	TrajectoryLimitExceeded,
 } from "./limits.ts";
-
-/**
- * Planner runaway-loop guards (#8801 — these bound worst-case cost/looping but
- * shipped untested). They are what stops a model that re-issues the same failing
- * tool forever, or grows a trajectory past its token budget, from burning the
- * turn. The threshold/signature/dedup logic is pinned here.
- */
 
 describe("mergeChainingLoopConfig", () => {
 	it("returns the defaults (with reserve marked non-explicit) when given nothing", () => {

--- a/packages/core/src/runtime/limits.ts
+++ b/packages/core/src/runtime/limits.ts
@@ -1,3 +1,10 @@
+/**
+ * Bounds and guard functions for the planner chaining loop: the
+ * `ChainingLoopConfig` limit contract (max tool calls, repeated-failure and
+ * cumulative-token budgets, compaction thresholds), the typed
+ * `TrajectoryLimitExceeded` error, and the assert/count helpers that stop a
+ * runaway or stuck planner from burning a turn.
+ */
 export interface ChainingLoopConfig {
 	/** Maximum tool calls executed during one planner loop. */
 	maxToolCalls: number;
@@ -86,7 +93,7 @@ export interface ChainingLoopConfig {
 	 * single-step pathology without touching the trajectory's
 	 * archival/replay fidelity.
 	 *
-	 * Default: undefined (no cap — exact pre-PR behavior). Recommended
+	 * Default: undefined (no cap). Recommended
 	 * for tight-context models: ~8000 (one tool result still gets
 	 * roughly two pages of head + a half page of tail context).
 	 */

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -1,3 +1,9 @@
+/**
+ * Stage 1 of the message loop: parses the response-handler model output (the
+ * canonical JSON envelope or a plain-text keyed transcript) into a
+ * `MessageHandlerResult`, then routes the turn — direct reply, ignore/stop, or
+ * hand off to the planner — based on the selected contexts and tool hints.
+ */
 import type {
 	MessageHandlerAction,
 	MessageHandlerExtract,
@@ -44,9 +50,8 @@ export const SIMPLE_CONTEXT_ID = "simple";
  *
  * Expects the canonical response-handler field-registry envelope:
  * `{ shouldRespond, contexts, intents, replyText, candidateActionNames, facts,
- * relationships, addressedTo, emotion }`. The internal result still carries
- * the `plan` sub-object because the downstream runtime contract has not been
- * renamed.
+ * relationships, addressedTo, emotion }`. The internal result carries the
+ * `plan` sub-object to match the downstream runtime contract.
  */
 export function parseMessageHandlerOutput(
 	raw: string,

--- a/packages/core/src/runtime/model-input-budget.ts
+++ b/packages/core/src/runtime/model-input-budget.ts
@@ -1,3 +1,9 @@
+/**
+ * Estimates a planner stage's model-input token count and derives its
+ * compaction budget: resolves the context window (per-model lookup > explicit
+ * arg > default), computes the reserve and compaction threshold, and reports
+ * whether the input should be compacted before the call.
+ */
 import { lookupModelContextWindow } from "../features/trajectories/pricing";
 import type {
 	ChatMessage,
@@ -123,16 +129,15 @@ export function buildModelInputBudget(args: {
 	//      authoritative because it reflects the actual hard limit you'd
 	//      hit on the wire.
 	//   2. `contextWindowTokens` passed by the caller — usually the
-	//      generic 128k default carried on `ChainingLoopConfig` from when
-	//      the loop assumed a single context size. Used when no lookup.
+	//      generic 128k default carried on `ChainingLoopConfig`. Used
+	//      when no lookup resolves.
 	//   3. `DEFAULT_CONTEXT_WINDOW_TOKENS` — last-resort fallback.
 	//
 	// This ordering means a caller can opt into the per-model ceiling
 	// just by setting `modelName`, without having to also unset the
 	// generic default. Callers who *need* an exact override (e.g. a
 	// custom long-context tier) can still pin a number explicitly by
-	// omitting `modelName` and passing `contextWindowTokens` — that path
-	// is unchanged from the pre-lookup behavior.
+	// omitting `modelName` and passing `contextWindowTokens`.
 	const lookup = lookupModelContextWindow(args.modelName);
 
 	const contextWindowTokens =

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -1,3 +1,12 @@
+/**
+ * The planner's tool-calling agent loop: iteratively calls the planner model,
+ * dispatches queued tool calls, and either gates or runs the trajectory
+ * evaluator until a terminal signal, then synthesizes the final user-facing
+ * message under trajectory / repeated-failure / prompt-token limits. Also owns
+ * planner-output parsing (native plus text-recovered tool calls) and the
+ * user-safe-message projection that keeps tool/control JSON and pre-tool
+ * thoughts out of the reply.
+ */
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { computeCallCostUsd } from "../features/trajectories/pricing";
@@ -935,10 +944,9 @@ function normalizePlannerToolName(name: string): string {
 
 /**
  * Build a "Routing hints" block from each available action's
- * {@link Action.routingHint}. Replaces the hand-written domain-routing prose
- * that used to live inline in `plannerTemplate` — each action now carries
- * its own one-line hint as metadata, and the planner sees them only when the
- * action is actually exposed for this turn.
+ * {@link Action.routingHint}. Each action carries its own one-line hint as
+ * metadata, and the planner sees them only when the action is actually exposed
+ * for this turn.
  *
  * Returns `null` when no exposed action has a `routingHint` set, so the
  * planner prompt simply omits the section.
@@ -1300,8 +1308,8 @@ async function callPlanner(params: {
 	};
 	if (hasTools) {
 		modelParams.tools = params.tools;
-		// Force a native tool call. With actions exposed directly as tools
-		// (post-PLAN_ACTIONS-wrapper refactor), every viable planner outcome —
+		// Force a native tool call. With actions exposed directly as tools,
+		// every viable planner outcome —
 		// invoking an action, calling REPLY for a final message, or terminating
 		// via IGNORE / STOP — corresponds to a tool. There is no "the model
 		// shouldn't tool-call" case left, so `"required"` is the contract.
@@ -2374,12 +2382,11 @@ function normalizeBarePlannerAction(
 
 /**
  * Normalize a single raw planner tool call to a `PlannerToolCall`. With actions
- * exposed directly as native tools (post-PLAN_ACTIONS-wrapper refactor) the
- * tool name IS the action name; the universal terminal sentinels REPLY /
- * IGNORE / STOP arrive under their own names. We accept several legacy
- * adjacent fields (`toolName`, `tool`, `action`, `actionName`, `function`) so
- * provider quirks don't surface as parse failures, but no envelope unwrap or
- * compound-name decoding happens here anymore.
+ * exposed directly as native tools the tool name IS the action name; the
+ * universal terminal sentinels REPLY / IGNORE / STOP arrive under their own
+ * names. We accept several legacy adjacent fields (`toolName`, `tool`,
+ * `action`, `actionName`, `function`) so provider quirks don't surface as parse
+ * failures, but no envelope unwrap or compound-name decoding happens here.
  */
 
 function normalizeToolCall(entry: unknown): PlannerToolCall | null {
@@ -2708,13 +2715,9 @@ function terminalMessageFromToolCalls(
  * REPLY) must opt in by setting `userFacingText`. Tools that emit logs
  * (BASH, SHELL, fetchers, file readers) leave it unset; this function
  * then returns undefined and the caller falls through to the evaluator's
- * synthesized reply instead of dumping the log into the channel.
- *
- * Pre-PR, this function returned `step.result.text` directly — that's
- * how `$ find … [exit 0] (cwd=…) --- stdout --- 443` ever ended up as
- * a literal Discord reply. The fix is structural: tools tell the
- * framework what's safe, the framework doesn't guess by parsing
- * wrapper text.
+ * synthesized reply instead of dumping the log into the channel. The
+ * contract is structural: tools declare what is safe to show, the
+ * framework never guesses by parsing wrapper text.
  */
 function latestToolResultText(
 	trajectory: PlannerTrajectory,

--- a/packages/core/src/runtime/planner-rendering.ts
+++ b/packages/core/src/runtime/planner-rendering.ts
@@ -1,3 +1,9 @@
+/**
+ * Renders completed planner trajectory steps into native assistant/tool chat
+ * message pairs and projects a tool result to plain text for the next planner
+ * call, shaping everything append-only so the prompt prefix stays byte-stable
+ * for provider prompt caching. Also re-exports the provider cache-plan helpers.
+ */
 import type { ChatMessage, ChatMessageContentPart } from "../types/model";
 import type { JsonValue } from "../types/primitives.ts";
 import { stringifyForModel } from "./json-output";
@@ -29,7 +35,7 @@ export interface TrajectoryStepsToMessagesOptions {
 	 * any downstream consumer that wants the unredacted output. Only the
 	 * wire-shape message that goes to the next planner call is truncated.
 	 *
-	 * Default: undefined (no cap — exact pre-PR behavior).
+	 * Default: undefined (no cap).
 	 */
 	maxToolResultChars?: number;
 }

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared type contracts for the planner subsystem: the planner/evaluator runtime
+ * shapes, a single tool call and its result, a trajectory step, and the loop's
+ * parameter and result envelopes. Consumed by planner-loop, the evaluator, and
+ * the message handler that drives them.
+ */
 import type { EvaluationResult } from "../types/components";
 import type { ContextObject } from "../types/context-object";
 import type {

--- a/packages/core/src/runtime/plugin-action-context-lifecycle.test.ts
+++ b/packages/core/src/runtime/plugin-action-context-lifecycle.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Verifies plugin-registered contexts propagate their role gate onto actions,
+ * and that `executePlannedToolCall` enforces it — USER denied, OWNER allowed.
+ * Drives a real in-process `AgentRuntime` with a stubbed action handler; no
+ * model call.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { AgentRuntime } from "../runtime";
 import type { Memory, Plugin } from "../types";

--- a/packages/core/src/runtime/plugin-connector-source-lifecycle.test.ts
+++ b/packages/core/src/runtime/plugin-connector-source-lifecycle.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Checks that a plugin's `connectorSources` declarations register their aliases
+ * and passive flag on plugin load and are fully removed on unload. Drives a real
+ * in-process `AgentRuntime`; no model or database.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	getConnectorSourceAliases,

--- a/packages/core/src/runtime/plugin-shortcut-lifecycle.test.ts
+++ b/packages/core/src/runtime/plugin-shortcut-lifecycle.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Checks that plugin-owned shortcuts register into the shortcut registry, are
+ * tracked under plugin ownership, and are unregistered on unload. Drives a real
+ * in-process `AgentRuntime`; no model or database.
+ */
 import { describe, expect, it } from "vitest";
 import { AgentRuntime } from "../runtime";
 import type { Plugin } from "../types/plugin";

--- a/packages/core/src/runtime/private-action-gate.ts
+++ b/packages/core/src/runtime/private-action-gate.ts
@@ -1,3 +1,8 @@
+/**
+ * Gate that keeps `private` actions off any non-autonomous turn — exposing and
+ * executing them only when the triggering message is one of the autonomy
+ * service's own self-prompts.
+ */
 import type { Action } from "../types/components";
 import type { Memory } from "../types/memory";
 

--- a/packages/core/src/runtime/provider-cache-plan.ts
+++ b/packages/core/src/runtime/provider-cache-plan.ts
@@ -1,3 +1,9 @@
+/**
+ * Builds the per-provider prompt-cache plan from a rendered prompt's stable-
+ * prefix hash and segments: the OpenAI/Cerebras/OpenRouter cache keys, the
+ * Anthropic cache breakpoints under its four-block cap, and the eliza-local
+ * conversation-pinning options, for a single model generation.
+ */
 import type { PromptSegment } from "../types/model";
 import type { JsonValue } from "../types/primitives.ts";
 

--- a/packages/core/src/runtime/response-handler-evaluators.ts
+++ b/packages/core/src/runtime/response-handler-evaluators.ts
@@ -1,3 +1,9 @@
+/**
+ * Runs the registered response-handler evaluators over a Stage-1 message-handler
+ * result, applying each evaluator's patch to the plan — contexts, candidate
+ * actions, parent-action hints, deterministic tool call, reply — in priority
+ * order and collecting a per-evaluator trace of what changed.
+ */
 import type {
 	MessageHandlerAction,
 	MessageHandlerDeterministicToolCall,

--- a/packages/core/src/runtime/rlm.ts
+++ b/packages/core/src/runtime/rlm.ts
@@ -1,3 +1,12 @@
+/**
+ * Type contracts and the routing policy for the recursive-language-model (RLM)
+ * path — an iterative peek / grep / partition / map-subcall / summarize / stitch
+ * loop that reasons over context too large for a single model call. `decideRLMUse`
+ * is the gate: it decides whether a task engages the RLM instead of a direct
+ * one-shot model call, based on task kind, context token/character size, whether
+ * the context is external, and an explicit-request override.
+ */
+
 import type { JsonObject, JsonValue } from "../types/primitives";
 
 export type RLMOperation =

--- a/packages/core/src/runtime/shortcut-registry.test.ts
+++ b/packages/core/src/runtime/shortcut-registry.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for the voice/text shortcut matcher (`normalizeForMatch`,
+ * `compileTemplate`, `matchShortcut`, `ShortcutRegistry`): the always-on explicit
+ * slash-command tier, the caller-enabled natural-language tier with slot
+ * extraction and a confidence floor, and action/context/auth gating. Pure
+ * deterministic functions — no model, no DB.
+ */
+
 import { describe, expect, it } from "vitest";
 import type { ShortcutDefinition } from "../types/shortcut";
 import {

--- a/packages/core/src/runtime/sub-planner.ts
+++ b/packages/core/src/runtime/sub-planner.ts
@@ -1,3 +1,11 @@
+/**
+ * Nested planner descent for a parent action's declared sub-actions: resolves and
+ * gates the child actions (context + role policy, cycle detection), exposes each
+ * admissible child as its own native tool alongside the REPLY/IGNORE/STOP
+ * terminals, and runs a `runPlannerLoop` pass over them — recording a `subPlanner`
+ * trajectory stage so consumers can render the call tree.
+ */
+
 import { actionToJsonSchema } from "../actions/action-schema";
 import {
 	buildPlannerToolsFromActions,
@@ -185,13 +193,12 @@ export async function runSubPlanner(
 		params.action.contexts,
 		...declaredChildActions.map((child) => child.contexts),
 	);
-	// One gate for every path (#12087 Item 9). The prior `contextGated.has(child)
-	// || isActionAllowedByRolePolicy(child)` OR-filter admitted a child that passed
-	// its contextGate even when an ACTION_ROLE_POLICY entry the caller FAILS applied
-	// to it — policy is meant to REPLACE the declared gate, not be an alternative to
-	// it. canActionRun applies the same policy-or-gate precedence the executor uses.
-	// skipPrivateGate: child execution still runs through the executor, which
-	// enforces the private-action gate.
+	// One gate for every path (#12087 Item 9): canActionRun applies the same
+	// policy-or-gate precedence the executor uses. An ACTION_ROLE_POLICY entry
+	// REPLACES a child's declared contextGate rather than being an OR alternative to
+	// it, so a child the caller fails on policy is filtered even when its contextGate
+	// would admit it. skipPrivateGate: child execution still runs through the
+	// executor, which enforces the private-action gate.
 	const childActions = declaredChildActions.filter((child) =>
 		canActionRun(child, {
 			message: params.ctx.message,

--- a/packages/core/src/runtime/system-prompt.ts
+++ b/packages/core/src/runtime/system-prompt.ts
@@ -1,3 +1,11 @@
+/**
+ * System-prompt assembly for a model call: builds the canonical prompt from a
+ * character's `system` + `bio` (name-token expanded) plus the caller's role, and
+ * resolves the effective system prompt from explicit params, a leading `system`
+ * chat message, or a fallback — de-duplicating that leading system message when it
+ * already matches the resolved prompt.
+ */
+
 import { replaceNameTokens } from "../name-tokens";
 import type { Character } from "../types/agent";
 import type { RoleGateRole } from "../types/contexts";

--- a/packages/core/src/sessions/session-key.test.ts
+++ b/packages/core/src/sessions/session-key.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Session keys (`agent:{agentId}:{rest}`) identify sessions, threads, and peer
+ * connections. Build/parse must round-trip, IDs must be normalized path-safe,
+ * and thread/ACP/subagent discriminators must be parsed correctly — a wrong key
+ * routes a message to the wrong session.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	buildAcpSessionKey,
@@ -13,13 +19,6 @@ import {
 	resolveThreadParentSessionKey,
 	sanitizeAgentId,
 } from "./session-key.ts";
-
-/**
- * Session keys (`agent:{agentId}:{rest}`) identify sessions, threads, and peer
- * connections. Build/parse must round-trip, IDs must be normalized path-safe,
- * and thread/ACP/subagent discriminators must be parsed correctly — a wrong key
- * routes a message to the wrong session.
- */
 
 describe("build + parse round-trip", () => {
 	it("builds lowercased keys and parses them back", () => {

--- a/packages/core/src/utils/json-llm.test.ts
+++ b/packages/core/src/utils/json-llm.test.ts
@@ -1,11 +1,12 @@
+/**
+ * Tests for `extractAndParseJSONObjectFromText`, the core LLM-output JSON parser:
+ * it turns a model's text into a structured object, so a regression here breaks
+ * every structured model output. Deterministic — exercises the parser on fixed
+ * strings, no live model.
+ */
 import { describe, expect, it } from "vitest";
 import { extractAndParseJSONObjectFromText } from "./json-llm";
 
-/**
- * Tests for `extractAndParseJSONObjectFromText`, the core LLM-output JSON parser
- * (#8801 / #9943): it turns a model's text into a structured object, so a
- * regression here breaks every structured model output.
- */
 describe("extractAndParseJSONObjectFromText", () => {
 	it("parses a plain JSON object", () => {
 		expect(extractAndParseJSONObjectFromText('{"a":1,"b":"two"}')).toEqual({

--- a/packages/core/src/utils/prompt-batcher/shared.test.ts
+++ b/packages/core/src/utils/prompt-batcher/shared.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Prompt-batcher shared helpers. sanitizeIdentifier must yield a valid
+ * identifier (prefix when it can't start with a letter/underscore); retry count
+ * is clamped to 0..2; getSourceMessageId derives a stable per-platform dedup key
+ * (so the same inbound message isn't batched twice); and rollingAverage folds a
+ * new sample into a running mean.
+ */
 import { describe, expect, it } from "vitest";
 import type { Memory } from "../../types/memory";
 import {
@@ -8,14 +15,6 @@ import {
 	rollingAverage,
 	sanitizeIdentifier,
 } from "./shared.ts";
-
-/**
- * Prompt-batcher shared helpers. sanitizeIdentifier must yield a valid
- * identifier (prefix when it can't start with a letter/underscore); retry count
- * is clamped to 0..2; getSourceMessageId derives a stable per-platform dedup key
- * (so the same inbound message isn't batched twice); and rollingAverage folds a
- * new sample into a running mean.
- */
 
 describe("sanitizeIdentifier", () => {
 	it("replaces non-identifier chars and guarantees a valid leading char", () => {

--- a/packages/core/src/utils/retry.backoff.test.ts
+++ b/packages/core/src/utils/retry.backoff.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { type BackoffPolicy, computeBackoff } from "./retry";
-
 /**
  * Tests for the restart/retry backoff math. computeBackoff drives crash-recovery
  * and retry delays; these cover the exponential growth, the attempt clamp, the
  * maxMs cap, and the jitter bounds.
  */
+import { describe, expect, it } from "vitest";
+import { type BackoffPolicy, computeBackoff } from "./retry";
+
 const noJitter: BackoffPolicy = {
 	initialMs: 100,
 	maxMs: 10_000,

--- a/packages/core/src/validation/secrets.test.ts
+++ b/packages/core/src/validation/secrets.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Secret validation catches misconfigured API keys before they reach a provider
+ * (a wrong-shaped key fails the call at runtime, often after billing). Known
+ * keys are checked against a provider-specific pattern; unknown keys get basic
+ * checks that reject empty values and obvious placeholders ("your_api_key_here").
+ * inferValidationPatternKey maps prefixed/variant names back to the canonical key.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	checkRequiredSecrets,
@@ -7,14 +14,6 @@ import {
 	validateSecretKey,
 	validateSecrets,
 } from "./secrets.ts";
-
-/**
- * Secret validation catches misconfigured API keys before they reach a provider
- * (a wrong-shaped key fails the call at runtime, often after billing). Known
- * keys are checked against a provider-specific pattern; unknown keys get basic
- * checks that reject empty values and obvious placeholders ("your_api_key_here").
- * inferValidationPatternKey maps prefixed/variant names back to the canonical key.
- */
 
 describe("validateSecretKey — known patterns", () => {
 	it("accepts a well-formed OpenAI key, rejects a malformed one", () => {


### PR DESCRIPTION
## What

Batch **B01 part 5 (final)** of the repo-wide comment cleanup (#12231, parent #12181) — the
last headerless files in `packages/core`: the `runtime/` agent-loop internals (planner loop,
action catalog/tiering/gating, context registry/renderer, message handler, evaluators) + their
`__tests__`, the top-level `packages/core/src/__tests__` suite, and scattered stragglers
(`search.ts` header placed below its MIT porter2/fast-bm25 license block; secret-swap
bench/fuzz/redteam; feature test files).

**This completes the packages/core header sweep for B01** — every in-scope source file now
carries a purpose-explaining prose header.

**Comments only — zero functional diff.** Machine-proven by `node scripts/assert-comment-only-diff.mjs`:
every changed file's TypeScript code-token stream is byte-identical to base.

## Scope (145 files)

runtime/ internals + runtime/__tests__ + top-level __tests__ + residual stragglers.

Completes B01 across #12824 (p1: boundary/data/schema), #12874 (p2: root+types load-bearing),
#12926 (p3: features), #13030 (p4: services+utils), and this PR.

## Verification
```
node scripts/assert-comment-only-diff.mjs
# OK — 145 source file(s) changed; every code token identical to base. Comments only.
```
Closes #12231.