### PR TITLE
docs(#12806): clean agent orchestrator prose headers

### DIFF
--- a/.github/issue-evidence/12806-agent-orchestrator-comment-cleanup.md
+++ b/.github/issue-evidence/12806-agent-orchestrator-comment-cleanup.md
@@ -1,0 +1,42 @@
+# Issue #12806 Evidence: plugin-agent-orchestrator comment cleanup
+
+Branch: `docs/12806-agent-orchestrator`
+Base: `origin/develop` at `df54daf798`
+
+## Scope
+
+Comment-only cleanup for `plugins/plugin-agent-orchestrator`, excluding generated,
+vendored, dependency, build, coverage, and cache paths. The branch adds or moves
+top-of-file prose headers in 31 source files and keeps executable tokens
+unchanged.
+
+## Validation
+
+```text
+$ bun run check:comment-only
+[assert-comment-only-diff] OK — 31 source file(s) changed; every code token identical to origin/develop. Comments only.
+```
+
+```text
+$ git diff --name-only origin/develop...HEAD | xargs bunx biome check --no-errors-on-unmatched
+Checked 31 files in 74ms. No fixes applied.
+```
+
+```text
+$ bun run --cwd plugins/plugin-agent-orchestrator test:unit
+Test Files  121 passed (121)
+Tests  1323 passed (1323)
+```
+
+```text
+$ git diff --check origin/develop...HEAD
+PASS
+```
+
+Header audit after the rebase returned no missing in-scope source files.
+
+## Non-applicable Evidence
+
+Live trajectories, screenshots, video, audio, server/client logs, and domain
+artifacts: N/A - comments-only change, zero functional diff machine-checked by
+`scripts/assert-comment-only-diff.mjs`.

--- a/plugins/plugin-agent-orchestrator/__tests__/setup.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/setup.ts
@@ -1,7 +1,9 @@
-// Default the durable Smithers task path OFF for unit tests so create-task tests
-// exercise the fast direct-prompt path (no per-task bun subprocess). The durable
-// runner, executor, and integration glue are tested directly in
-// smithers-task-*.test.ts. Production defaults ON (see shouldUseSmithersTaskRunner).
+/**
+ * Unit-test bootstrap keeps the durable Smithers task path off so create-task
+ * coverage exercises the fast direct-prompt path. The durable runner, executor,
+ * and integration glue are tested directly in smithers-task suites, while
+ * production defaults remain enabled through shouldUseSmithersTaskRunner.
+ */
 if (process.env.ELIZA_ORCHESTRATOR_SMITHERS === undefined) {
   process.env.ELIZA_ORCHESTRATOR_SMITHERS = "0";
 }

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/account-failover-respawn.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/account-failover-respawn.test.ts
@@ -1,4 +1,3 @@
-import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL } from "@elizaos/core";
 /**
  * Mid-session account failover: a running sub-agent that dies on a pooled
  * account's rate-limit / auth failure must not fail the task. The router marks
@@ -9,6 +8,8 @@ import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL } from "@elizaos/core";
  * shared state_lost lineage cap.
  */
 
+// biome-ignore assist/source/organizeImports: comment-only cleanup preserves import token order.
+import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL } from "@elizaos/core";
 import type { Content, HandlerCallback, Memory } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SubAgentRouter } from "../../src/services/sub-agent-router.js";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/account-failure-propagation.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/account-failure-propagation.test.ts
@@ -1,4 +1,3 @@
-import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL } from "@elizaos/core";
 /**
  * Account-failure propagation (#9960 error-handling audit): a spawned account's
  * auth / rate-limit failure must feed back to the pool (markNeedsReauth /
@@ -7,6 +6,8 @@ import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL } from "@elizaos/core";
  * conservative classifier and the router wiring that drives the pool bridge.
  */
 
+// biome-ignore assist/source/organizeImports: comment-only cleanup preserves import token order.
+import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL } from "@elizaos/core";
 import type { Content, HandlerCallback, Memory } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/account-readiness.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/account-readiness.test.ts
@@ -1,4 +1,3 @@
-import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL } from "@elizaos/core";
 /**
  * Account-readiness harness (#9960): the loud gate that asserts the pool has
  * ≥1 healthy Codex AND ≥1 healthy Claude (≥2 each for local rotation), instead
@@ -7,6 +6,8 @@ import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL } from "@elizaos/core";
  * returns 503 (loud) when the pool is not ready.
  */
 
+// biome-ignore assist/source/organizeImports: comment-only cleanup preserves import token order.
+import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL } from "@elizaos/core";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, expect, it, vi } from "vitest";
 import { handleOrchestratorRoutes } from "../../src/api/orchestrator-routes.js";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/active-workspace-context.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/active-workspace-context.test.ts
@@ -1,7 +1,3 @@
-import type { Memory, State } from "@elizaos/core";
-import { describe, expect, it } from "vitest";
-import { activeWorkspaceContextProvider } from "../../src/providers/active-workspace-context.js";
-
 /**
  * The provider used to compute "reusable" sessions by comparing against an
  * always-empty task list, so it advertised EVERY session — including busy,
@@ -9,6 +5,11 @@ import { activeWorkspaceContextProvider } from "../../src/providers/active-works
  * It also reported a phantom taskCount:0 + dead task/pending blocks. These
  * assert the corrected behavior: only idle ("ready") sessions are reusable.
  */
+
+import type { Memory, State } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { activeWorkspaceContextProvider } from "../../src/providers/active-workspace-context.js";
+
 function mkSession(id: string, name: string, status: string) {
   return {
     id,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/agent-name-assignment.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/agent-name-assignment.test.ts
@@ -1,15 +1,15 @@
-import { describe, expect, it } from "vitest";
-import {
-  assignAgentName,
-  pickSubAgentName,
-} from "../../src/services/agent-name-assignment.js";
-
 /**
  * Sub-agent naming guarantees an operator can tell workers apart: an explicit
  * label is always kept, and an auto-assigned name never collides with a live
  * sibling or with the parent agent. These invariants hold for every RNG
  * outcome, so iterating many times can't flake.
  */
+
+import { describe, expect, it } from "vitest";
+import {
+  assignAgentName,
+  pickSubAgentName,
+} from "../../src/services/agent-name-assignment.js";
 
 const RUNS = 100;
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/get-acp-service-order.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/get-acp-service-order.test.ts
@@ -1,9 +1,10 @@
+/** Pins the ACP-only resolution order used by TASKS after the acpx cleanup. */
+
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 
 import { getAcpService } from "../../src/actions/common.ts";
 
-/** Pins the ACP-only resolution order used by TASKS after the acpx cleanup. */
 describe("getAcpService resolution order", () => {
   function buildRuntime(services: Record<string, unknown>): IAgentRuntime {
     return {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/model-chooser-contract.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/model-chooser-contract.test.ts
@@ -1,4 +1,3 @@
-import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL } from "@elizaos/core";
 /**
  * Gap (J): sub-agent model + auth selection is dispersed across `buildEnv`
  * (private, in acp-service.ts) and `buildOpencodeAcpEnv` / `buildOpencodeSpawnConfig`
@@ -30,6 +29,7 @@ import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL } from "@elizaos/core";
  * to which model/auth a backend resolves to fails loudly.
  */
 
+import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AcpJsonRpcMessage,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/multi-account-spawn.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/multi-account-spawn.test.ts
@@ -1,9 +1,10 @@
-import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL } from "@elizaos/core";
 /**
  * Keystone test: the coding-account selector bridge is consulted on spawn and
  * its env patch is injected into the sub-agent subprocess (per agent type),
  * with single-account fallback when the bridge is absent.
  */
+
+import { CODING_AGENT_SELECTOR_BRIDGE_SYMBOL } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AcpJsonRpcMessage,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/session-store-filelock.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/session-store-filelock.test.ts
@@ -1,21 +1,9 @@
-// Gap (L): no cross-instance file-lock contention test for FileSessionStore.
-//
-// FileSessionStore persists its full in-memory session map to a single JSON
-// file under an OS-level advisory lock (`<file>.lock`, created with open(...,"wx")).
-// session-store.test.ts only exercises a SINGLE instance: concurrent writes
-// through one store's WriteQueue, plus stale-lock recovery for one store. It
-// never proves the lock actually arbitrates between TWO independent
-// FileSessionStore instances pointed at the SAME file.
-//
-// This file closes that gap. It spins up two real FileSessionStore instances
-// on the same temp file (os.tmpdir + mkdtemp, real fs) and asserts the
-// load-bearing cross-instance guarantees:
-//   1. No torn / corrupt writes: while both instances race concurrent
-//      create/update calls, the on-disk file is ALWAYS valid, fully-parseable
-//      JSON (never a half-written blob), and after settle a freshly-loaded
-//      third instance reads back a complete, internally-consistent record set.
-//   2. Each instance's own writes are never lost from its own view (the lock
-//      serializes writers; it does not silently drop an acquired write).
+/**
+ * Cross-instance FileSessionStore contention tests run two real store instances
+ * against the same temporary JSON file and OS-level advisory lock. They assert
+ * that concurrent writes never leave torn JSON on disk and that a fresh store
+ * can read a complete, internally consistent record set after the race settles.
+ */
 //   3. Correct stale-lock takeover: a fresh instance acquires the lock when a
 //      pre-existing lock file is older than the staleness threshold, and a
 //      NON-stale lock held by "another process" blocks the writer until it is

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/ssrf-guard.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/ssrf-guard.test.ts
@@ -1,3 +1,11 @@
+/**
+ * The verifier GET-probes URLs extracted from untrusted sub-agent narration, so
+ * the guard is a security boundary: loopback is the one allowed non-public
+ * range; every other off-public address (private, link-local incl. the
+ * 169.254.169.254 cloud-metadata IP, CGNAT, ULA, multicast) must be blocked,
+ * and neither DNS rebinding nor a redirect may slip past it.
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   assertHostAllowed,
@@ -8,14 +16,6 @@ import {
   setHostResolver,
   setPinnedTransport,
 } from "../../src/services/ssrf-guard.js";
-
-/**
- * The verifier GET-probes URLs extracted from untrusted sub-agent narration, so
- * the guard is a security boundary: loopback is the one allowed non-public
- * range; every other off-public address (private, link-local incl. the
- * 169.254.169.254 cloud-metadata IP, CGNAT, ULA, multicast) must be blocked,
- * and neither DNS rebinding nor a redirect may slip past it.
- */
 
 afterEach(() => {
   setHostResolver(); // reset to system resolver

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router-notification.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router-notification.test.ts
@@ -1,21 +1,9 @@
-// Gap (K): no test asserted that a completed coding task emits an
-// AgentNotification. SubAgentRouter.handleEvent fires a runtime notification
-// ONLY for a terminal `task_complete` event — it resolves the NOTIFICATION
-// service via getService(ServiceType.NOTIFICATION) ("notification") and calls
-// notify({ category: "agent", source: "orchestrator", deepLink: "/orchestrator",
-// groupKey: `orchestrator:${sessionId}`, ... }). The emit is fire-and-forget
-// (`void ...notify(...)`) so a regression that dropped it, mis-routed the
-// category/source/deepLink, or fired it for non-terminal events (error /
-// blocked / QUESTION_FOR_TASK_CREATOR / AGENT_COORDINATION / streaming chunks)
-// would go silently uncaught.
-//
-// This file drives real session events through the router's bound AcpService
-// event handler (the smallest seam that triggers notification) with a mocked
-// NOTIFICATION service, and asserts:
-//   - notify is called exactly once on task_complete
-//   - with category "agent", source "orchestrator", deepLink "/orchestrator"
-//   - groupKey includes the session id (`orchestrator:<sessionId>`)
-//   - data carries the session id + label + origin source
+/**
+ * SubAgentRouter notification tests drive real session events through the bound
+ * AcpService handler with a mocked notification service. They assert that a
+ * terminal task_complete event emits exactly one agent notification with the
+ * orchestrator source, deep link, session group key, and session metadata.
+ */
 //   - notify is NOT called for error / blocked / QUESTION_FOR_TASK_CREATOR /
 //     AGENT_COORDINATION / streaming (agent_message_chunk / tool_running) events
 //

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-policy.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-policy.test.ts
@@ -1,13 +1,14 @@
-import type { IAgentRuntime, Memory } from "@elizaos/core";
-import { describe, expect, it } from "vitest";
-import { requireTaskAgentAccess } from "../../src/services/task-policy.js";
-
 /**
  * A partial TASK_AGENT_ROLE_POLICY override (e.g. only tightening slack) must
  * MERGE over the built-in defaults, not replace them — otherwise the built-in
  * Discord ADMIN gate is silently dropped and Discord falls through to the GUEST
  * default, opening task-agent create/interact to anyone.
  */
+
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { requireTaskAgentAccess } from "../../src/services/task-policy.js";
+
 function runtimeWith(policy: unknown): IAgentRuntime {
   return {
     agentId: "00000000-0000-4000-8000-00000000pol1",

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/trajectory-feedback-insight-cap.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/trajectory-feedback-insight-cap.test.ts
@@ -1,6 +1,3 @@
-import { describe, expect, it } from "vitest";
-import { queryPastExperience } from "../../src/services/trajectory-feedback";
-
 /**
  * Per-trajectory insight budget regression (audit-2 #7).
  *
@@ -11,6 +8,9 @@ import { queryPastExperience } from "../../src/services/trajectory-feedback";
  * intermediate `experiences` array before the final dedup + `maxEntries` cap.
  * These tests pin BOTH paths to the same 50/trajectory budget.
  */
+
+import { describe, expect, it } from "vitest";
+import { queryPastExperience } from "../../src/services/trajectory-feedback";
 
 const MAX = 50;
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/wait-for-spawn-slot.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/wait-for-spawn-slot.test.ts
@@ -1,21 +1,9 @@
-// Unit tests for waitForSpawnSlot (src/actions/common.ts).
-//
-// Gap (L): waitForSpawnSlot — the concurrency gate that serialises sub-agent
-// spawns past a small ceiling so concurrent coding agents don't stampede the
-// model provider — had no unit coverage. This file pins its four load-bearing
-// behaviors deterministically (vitest fake timers, no real sleeping, mocked
-// service):
-//
-//   1. DISABLED when the limit is <= 0 (or non-finite): returns immediately
-//      and never reads session state.
-//   2. BLOCKS then PROCEEDS as active sessions terminate: it polls real
-//      session state and only returns once the active count drops below the
-//      ceiling.
-//   3. GIVES UP after maxWaitMs with a warn-and-proceed (never deadlocks).
-//   4. Counts ONLY non-terminal sessions toward the cap (completed / stopped /
-//      errored / cancelled don't occupy a slot; anything else — including
-//      transient statuses — does).
-//
+/**
+ * waitForSpawnSlot unit tests pin the concurrency gate that serializes coding
+ * sub-agent spawns past a configurable ceiling. Vitest fake timers and a mocked
+ * ACP service cover disabled limits, polling until capacity returns, warn-and-
+ * proceed timeout behavior, and terminal-status filtering without real sleeps.
+ */
 // Determinism: every wait is driven by vi.advanceTimersByTimeAsync; the
 // service's session list is a mutable array we flip between polls, so the gate
 // observes real state changes without any wall-clock sleeping or network.

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/workdir-validation.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/workdir-validation.test.ts
@@ -1,3 +1,10 @@
+/**
+ * resolveAllowedWorkdir is a sandbox boundary: an auto-spawned coding agent may
+ * only run inside `~/.eliza/workspaces` or the process cwd. A caller-supplied
+ * workdir pointing anywhere else (or one that doesn't exist) must be rejected,
+ * so a task can't escape the workspace sandbox.
+ */
+
 import { mkdir, rm } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -6,13 +13,6 @@ import {
   ensureTaskWorkdir,
   resolveAllowedWorkdir,
 } from "../../src/services/workdir-validation.js";
-
-/**
- * resolveAllowedWorkdir is a sandbox boundary: an auto-spawned coding agent may
- * only run inside `~/.eliza/workspaces` or the process cwd. A caller-supplied
- * workdir pointing anywhere else (or one that doesn't exist) must be rejected,
- * so a task can't escape the workspace sandbox.
- */
 
 const created: string[] = [];
 afterAll(async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-native-transport.verifier.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-native-transport.verifier.test.ts
@@ -1,7 +1,3 @@
-import { describe, expect, it } from "vitest";
-import { NativeAcpClient } from "../services/acp-native-transport";
-import type { ApprovalPreset } from "../services/types";
-
 /**
  * AC4 (#8898): the independent verifier's read-only-but-executable capability is
  * enforced at the native transport, not by prompt text.
@@ -15,6 +11,11 @@ import type { ApprovalPreset } from "../services/types";
  * (the verifier can run `bun test`, `git diff`, and read files) while edit/write/delete
  * are denied (any write physically throws off the same gate).
  */
+
+import { describe, expect, it } from "vitest";
+import { NativeAcpClient } from "../services/acp-native-transport";
+import type { ApprovalPreset } from "../services/types";
+
 function makeClient(approvalPreset: ApprovalPreset): NativeAcpClient {
   return new NativeAcpClient({
     command: "true",

--- a/plugins/plugin-agent-orchestrator/src/__tests__/config-mcp-servers.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/config-mcp-servers.test.ts
@@ -1,15 +1,15 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { readConfigMcpServers } from "../services/config-env";
-
 /**
  * Real integration test for MCP auto-inherit: write a config file, point
  * ELIZA_CONFIG_PATH at it, and assert readConfigMcpServers converts the
  * dashboard-persisted `mcp.servers` object into the ACP `session/new.mcpServers`
  * array shape. No mocks — it exercises the real file read + conversion.
  */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readConfigMcpServers } from "../services/config-env";
 
 let dir: string;
 let prevPath: string | undefined;

--- a/plugins/plugin-agent-orchestrator/src/__tests__/keyless-app-creation.e2e.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/keyless-app-creation.e2e.test.ts
@@ -1,12 +1,3 @@
-import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import type { IAgentRuntime } from "@elizaos/core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { AcpService } from "../services/acp-service.js";
-
 /**
  * KEYLESS end-to-end of app-creation-through-orchestration — NO LLM.
  *
@@ -19,6 +10,16 @@ import { AcpService } from "../services/acp-service.js";
  * spawn → prompt → tool → file-write → task_complete pipeline deterministically,
  * so app-creation orchestration is CI-testable without a live model.
  */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AcpService } from "../services/acp-service.js";
+
 const FAKE_AGENT = join(
   dirname(fileURLToPath(import.meta.url)),
   "..",

--- a/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-grilling-live-gemma.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-grilling-live-gemma.test.ts
@@ -1,9 +1,3 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  runGrillingEvidenceBundleCheck,
-  runGrillingHappyPathCheck,
-} from "../../test/scenarios/_helpers/grilling-scenario.ts";
-
 /**
  * LIVE end-to-end validation of the orchestrator grilling/verification loop
  * against a REAL model (Cerebras `gemma-4-31b`). Unlike the deterministic twin
@@ -15,6 +9,13 @@ import {
  *
  * Run: CEREBRAS_API_KEY=csk-... bunx vitest run orchestrator-grilling-live-gemma
  */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  runGrillingEvidenceBundleCheck,
+  runGrillingHappyPathCheck,
+} from "../../test/scenarios/_helpers/grilling-scenario.ts";
+
 const CEREBRAS_KEY = process.env.CEREBRAS_API_KEY?.trim() ?? "";
 const MODEL = process.env.GEMMA_MODEL?.trim() || "gemma-4-31b";
 const BASE_URL =

--- a/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-scenario-logic.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/orchestrator-scenario-logic.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Verifies the assertion LOGIC behind the three orchestrator scenarios in
+ * `test/scenarios/` (#8932) using deterministic models, so the grilling +
+ * multi-task loops have runnable, keyless coverage independent of the scenario
+ * CLI (which the live lane drives against a real model + ACP sub-agents). The
+ * scenario files import the exact same helpers.
+ */
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { buildDeviceSupportScenarioEvidence } from "../../test/scenarios/_helpers/device-modality-scenario.ts";
 import {
@@ -11,13 +19,6 @@ import {
 } from "../../test/scenarios/_helpers/reflexion-scenario.ts";
 import { runMultiTaskSupervisorCheck } from "../../test/scenarios/_helpers/supervisor-scenario.ts";
 
-/**
- * Verifies the assertion LOGIC behind the three orchestrator scenarios in
- * `test/scenarios/` (#8932) using deterministic models, so the grilling +
- * multi-task loops have runnable, keyless coverage independent of the scenario
- * CLI (which the live lane drives against a real model + ACP sub-agents). The
- * scenario files import the exact same helpers.
- */
 function makeBaseRuntime() {
   return {
     agentId: "00000000-0000-4000-8000-000000000001",

--- a/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker-spawn.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker-spawn.test.ts
@@ -1,6 +1,3 @@
-import { describe, expect, it, vi } from "vitest";
-import { runParentAgentBroker } from "../services/parent-agent-broker";
-
 /**
  * Real tests for sub-agent NESTING via the parent-agent broker's new
  * `spawn-sub-agent` mode: a running sub-agent spawns its own child on the same
@@ -8,6 +5,9 @@ import { runParentAgentBroker } from "../services/parent-agent-broker";
  * the required-field guards, and that a spawn error (e.g. the depth cap) is
  * surfaced back to the child as text rather than thrown.
  */
+
+import { describe, expect, it, vi } from "vitest";
+import { runParentAgentBroker } from "../services/parent-agent-broker";
 
 type SpawnFn = (
   taskId: string,

--- a/plugins/plugin-agent-orchestrator/src/__tests__/reflexion-respawn.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/reflexion-respawn.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Service-level proof for #8899 AC#3 (inject prior failure into the re-spawn
+ * prompt): drive the REAL `spawnAgentForTask` read-at-spawn path
+ * (orchestrator-task-service.ts ~L2242) — not the pure render leaf — so a
+ * failed verification's reflection provably reaches the SECOND sub-agent's goal
+ * prompt, including coercion of malformed persisted entries.
+ */
+
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
@@ -14,13 +22,6 @@ import {
 } from "../../test/scenarios/_helpers/reflexion-scenario.ts";
 import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
 
-/**
- * Service-level proof for #8899 AC#3 (inject prior failure into the re-spawn
- * prompt): drive the REAL `spawnAgentForTask` read-at-spawn path
- * (orchestrator-task-service.ts ~L2242) — not the pure render leaf — so a
- * failed verification's reflection provably reaches the SECOND sub-agent's goal
- * prompt, including coercion of malformed persisted entries.
- */
 function makeBaseRuntime(): IAgentRuntime {
   return {
     agentId: "00000000-0000-4000-8000-000000000001",

--- a/plugins/plugin-agent-orchestrator/src/__tests__/swarm-coordinator-acp-bind.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/swarm-coordinator-acp-bind.test.ts
@@ -1,8 +1,3 @@
-import type { IAgentRuntime } from "@elizaos/core";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AcpService } from "../services/acp-service.js";
-import { SwarmCoordinatorService } from "../services/swarm-coordinator-service.js";
-
 /**
  * Regression coverage for the coordinator "silent bind give-up" bug.
  *
@@ -19,6 +14,11 @@ import { SwarmCoordinatorService } from "../services/swarm-coordinator-service.j
  *   - ACP load-promise rejection marks the coordinator UNBOUND loudly.
  *   - never-registers keeps retrying (unbounded) instead of going silent.
  */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AcpService } from "../services/acp-service.js";
+import { SwarmCoordinatorService } from "../services/swarm-coordinator-service.js";
 
 /** Minimal fake ACP service exposing just the `onSessionEvent` surface. */
 function makeFakeAcp(): {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-change-set-mirror.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-change-set-mirror.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Proves the change set the sub-agent produced (captured onto the LIVE ACP
+ * session metadata at `task_complete`) is mirrored into the durable task-store
+ * session record so the existing `/api/orchestrator/tasks/:id` detail route
+ * serves it via `TaskSessionDto.metadata.lastChangeSet` — no new HTTP route.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AcpService } from "../services/acp-service.js";
 import { toTaskThreadDetail } from "../services/orchestrator-task-mapper.js";
@@ -5,12 +12,6 @@ import { OrchestratorTaskService } from "../services/orchestrator-task-service.j
 import { OrchestratorTaskStore } from "../services/orchestrator-task-store.js";
 import type { WorkspaceChangeSet } from "../services/workspace-diff.js";
 
-/**
- * Proves the change set the sub-agent produced (captured onto the LIVE ACP
- * session metadata at `task_complete`) is mirrored into the durable task-store
- * session record so the existing `/api/orchestrator/tasks/:id` detail route
- * serves it via `TaskSessionDto.metadata.lastChangeSet` — no new HTTP route.
- */
 type EventHandler = (sessionId: string, event: string, data: unknown) => void;
 
 const CHANGE_SET: WorkspaceChangeSet = {

--- a/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
@@ -1,3 +1,10 @@
+/**
+ * Provider context for active coding sub-agents, their readiness, and cap
+ * pressure. The planner consumes this structural snapshot to decide whether a
+ * turn should start a new session, reuse an idle worker, or wait for a stalled,
+ * spend-capped, or round-trip-capped session to resolve.
+ */
+
 import type {
   IAgentRuntime,
   Memory,

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-device-support-matrix.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-device-support-matrix.ts
@@ -1,9 +1,3 @@
-import {
-  classifyTerminalSupport,
-  type OrchestratorTerminalSupport,
-  type TerminalSupportEnv,
-} from "./terminal-capabilities.js";
-
 /**
  * Static device × backend × auth-mode support matrix for multi-subscription
  * coding-agent orchestration. Single checked-in source of truth that mirrors
@@ -20,6 +14,12 @@ import {
  * selector over a globalThis bridge). When a device supports coding agents,
  * every backend below is reachable on it; when unsupported, none are.
  */
+
+import {
+  classifyTerminalSupport,
+  type OrchestratorTerminalSupport,
+  type TerminalSupportEnv,
+} from "./terminal-capabilities.js";
 
 /** Coding backends with a first-party spawnable CLI (post #9167 cleanup). */
 export const ORCHESTRATOR_BACKENDS = [

--- a/plugins/plugin-agent-orchestrator/src/services/smithers-task-executor.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/smithers-task-executor.ts
@@ -1,3 +1,10 @@
+/**
+ * Smithers task executor adapts the orchestrator ACP service to the structured
+ * provision, turn, approval, and submit steps expected by the durable task
+ * runner. The interface stays narrow so tests can substitute an AcpLike without
+ * coupling the runner to AcpService internals.
+ */
+
 import type {
   TaskApprovalResult,
   TaskProvisionResult,

--- a/plugins/plugin-agent-orchestrator/src/services/smithers-task-integration.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/smithers-task-integration.ts
@@ -1,3 +1,10 @@
+/**
+ * Integration boundary between TASKS and the durable Smithers runner. It gates
+ * the structured task path behind runtime settings, normalizes AcpService's
+ * optional methods into the executor shape, and falls back to the direct prompt
+ * path when Smithers is disabled.
+ */
+
 import type { AcpLike } from "./smithers-task-executor";
 import { SmithersTaskExecutor } from "./smithers-task-executor";
 import { runTaskWithSmithers } from "./smithers-task-runner";

--- a/plugins/plugin-agent-orchestrator/src/services/workdir-validation.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workdir-validation.ts
@@ -1,3 +1,10 @@
+/**
+ * Workdir validation keeps auto-spawned coding agents inside the configured
+ * workspace sandbox. It expands the default per-task workspace under
+ * `~/.eliza/workspaces`, resolves symlinks before comparison, and rejects
+ * caller-supplied directories outside the allowed roots.
+ */
+
 import { mkdir, realpath } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-lifecycle.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-lifecycle.ts
@@ -1,3 +1,9 @@
+/**
+ * Scratch workspace lifecycle helpers remove temporary coding-agent directories
+ * only after path resolution proves they sit under the configured workspace
+ * base or an explicitly allowed root.
+ */
+
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";


### PR DESCRIPTION
## Summary
- Adds or moves top-of-file prose headers across the in-scope `plugins/plugin-agent-orchestrator` source/test files for #12806.
- Converts several churn-style file comments into durable present-tense test/module descriptions.
- Adds validation evidence at `.github/issue-evidence/12806-agent-orchestrator-comment-cleanup.md`.

## Validation
- `bun run check:comment-only` -> OK, 31 source files changed, every code token identical to `origin/develop`.
- `git diff --name-only origin/develop...HEAD | xargs bunx biome check --no-errors-on-unmatched` -> Checked 31 files, no fixes applied.
- in-scope header audit -> no missing source headers.
- `git diff --check origin/develop...HEAD` -> PASS.
- `bun run --cwd plugins/plugin-agent-orchestrator test:unit` -> 121 files / 1323 tests passed.

## Evidence N/A
Live trajectories, screenshots, video, audio, server/client logs, and domain artifacts: N/A - comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
