### PR TITLE
docs(#12231): prose headers — final straggler pass, core + logger + registry (B01 complete)

### DIFF
--- a/packages/core/src/__tests__/env-truthy-parity.test.ts
+++ b/packages/core/src/__tests__/env-truthy-parity.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "vitest";
 /**
  * Pins the canonical env-truthiness contract (isTruthyEnvValue) and checks the
  * boolean-parser wrappers (parseBooleanValue, parseBooleanText, readEnvBool)
  * each keep their documented truthy/falsy token sets. Pure deterministic parser
  * test.
  */
+import { describe, expect, it } from "vitest";
 import { isTruthyEnvValue } from "../env-utils.js";
 import { parseBooleanText, parseBooleanValue } from "../utils/boolean.js";
 import { readEnvBool } from "../utils/read-env.js";

--- a/packages/core/src/__tests__/mockCharacter.ts
+++ b/packages/core/src/__tests__/mockCharacter.ts
@@ -1,10 +1,10 @@
-import type { Character } from "@elizaos/core";
-
 /**
  * Shared Eliza `Character` fixture for core tests: a fully populated persona
  * (bio, message and post examples, style, topics, voice settings) used to
  * exercise prompt composition and character-dependent runtime paths.
  */
+import type { Character } from "@elizaos/core";
+
 export const mockCharacter: Character = {
 	name: "Eliza",
 	username: "eliza",

--- a/packages/core/src/character-utils.test.ts
+++ b/packages/core/src/character-utils.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Character secret/plugin helpers are documented as IMMUTABLE — every mutator
+ * returns a NEW character and must not mutate the input (callers rely on this to
+ * avoid leaking secrets across agent configs). mergeCharacterSecrets must keep
+ * EXISTING values (never let an incoming map overwrite a configured secret), and
+ * model-provider detection keys off the known provider→secret map.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	addCharacterPlugin,
@@ -14,14 +21,6 @@ import {
 	setCharacterSecret,
 } from "./character-utils.ts";
 import type { Character } from "./types";
-
-/**
- * Character secret/plugin helpers are documented as IMMUTABLE — every mutator
- * returns a NEW character and must not mutate the input (callers rely on this to
- * avoid leaking secrets across agent configs). mergeCharacterSecrets must keep
- * EXISTING values (never let an incoming map overwrite a configured secret), and
- * model-provider detection keys off the known provider→secret map.
- */
 
 const base = (): Character =>
 	({

--- a/packages/core/src/entities.trusted-components.test.ts
+++ b/packages/core/src/entities.trusted-components.test.ts
@@ -1,6 +1,3 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Entity, IAgentRuntime, UUID, World } from "./types";
-
 /**
  * #12087 Item 16: component-visibility filtering must decide trust from the
  * RESOLVED role (resolveEntityRole, which demotes a stale stored OWNER grant to
@@ -8,6 +5,9 @@ import type { Entity, IAgentRuntime, UUID, World } from "./types";
  * revocation), not the raw world.metadata.roles literal. resolveEntityRole is
  * stubbed here; the real isAdminRank is kept so the rank threshold is exercised.
  */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Entity, IAgentRuntime, UUID, World } from "./types";
+
 const { resolveEntityRoleMock } = vi.hoisted(() => ({
 	resolveEntityRoleMock: vi.fn(),
 }));

--- a/packages/core/src/features/advanced-capabilities/actions/connectorActionUtils.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/connectorActionUtils.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Connector action param helpers coerce loose agent input. limitParam clamps to
+ * 1..100 (DoS-bounding a query), isUuidLike gates id-shaped inputs, and the
+ * scalar readers reject non-coercible values rather than passing them through.
+ */
 import { describe, expect, it } from "vitest";
 import type { HandlerOptions } from "../../../types/components";
 import {
@@ -9,12 +14,6 @@ import {
 	sourceParam,
 	textParam,
 } from "./connectorActionUtils.ts";
-
-/**
- * Connector action param helpers coerce loose agent input. limitParam clamps to
- * 1..100 (DoS-bounding a query), isUuidLike gates id-shaped inputs, and the
- * scalar readers reject non-coercible values rather than passing them through.
- */
 
 describe("paramsFromOptions / textParam", () => {
 	it("reads the parameters bag and trims non-empty strings", () => {

--- a/packages/core/src/features/advanced-capabilities/actions/post.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/post.test.ts
@@ -1,12 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { postAction, resolveOp } from "./post.ts";
-
 /**
  * #10471 — POST op routing must come from the planner-emitted `action` enum
  * (or structured query/feed params), never from English keywords in the user
  * text. Keyword routing (e.g. `/\b(search|find)\b/`) silently fails for every
  * non-English request, so op selection stays structured-only.
  */
+import { describe, expect, it } from "vitest";
+import { postAction, resolveOp } from "./post.ts";
+
 describe("post resolveOp is i18n-safe (#10471)", () => {
 	it("routes by the planner action enum", () => {
 		expect(resolveOp({ parameters: { action: "search" } })).toBe("search");

--- a/packages/core/src/features/advanced-capabilities/actions/room.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/room.ts
@@ -1,3 +1,15 @@
+/**
+ * ROOM_OP — unified room subscription / chat-thread state action.
+ *
+ * Replaces MUTE_ROOM / UNMUTE_ROOM / FOLLOW_ROOM / UNFOLLOW_ROOM (core) and
+ * the connector-targeted CHAT_THREAD action (app-lifeops). Defaults to the
+ * current room when `roomId` / `chatName` are omitted; supports cross-room
+ * targeting by `platform` + `chatName` lookup, `scope=server` mute/unmute of
+ * the whole guild the target room belongs to (world.metadata, consulted by
+ * the same inbound mute gate), and an optional `durationMinutes` mute window
+ * persisted as `agentMuteUntilIso` — services/message/mute-state.ts unmutes
+ * on the first inbound message at/after that ISO time.
+ */
 import {
 	findKeywordTermMatch,
 	getValidationKeywordTerms,
@@ -30,19 +42,6 @@ import {
 	composePromptFromState,
 	parseBooleanFromText,
 } from "../../../utils.ts";
-
-/**
- * ROOM_OP — unified room subscription / chat-thread state action.
- *
- * Replaces MUTE_ROOM / UNMUTE_ROOM / FOLLOW_ROOM / UNFOLLOW_ROOM (core) and
- * the connector-targeted CHAT_THREAD action (app-lifeops). Defaults to the
- * current room when `roomId` / `chatName` are omitted; supports cross-room
- * targeting by `platform` + `chatName` lookup, `scope=server` mute/unmute of
- * the whole guild the target room belongs to (world.metadata, consulted by
- * the same inbound mute gate), and an optional `durationMinutes` mute window
- * persisted as `agentMuteUntilIso` — services/message/mute-state.ts unmutes
- * on the first inbound message at/after that ISO time.
- */
 
 const ROOM_OPS = ["follow", "unfollow", "mute", "unmute"] as const;
 type RoomOp = (typeof ROOM_OPS)[number];

--- a/packages/core/src/features/advanced-capabilities/personality/actions/character.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/actions/character.test.ts
@@ -1,11 +1,3 @@
-import { describe, expect, it, vi } from "vitest";
-import type {
-	HandlerCallback,
-	IAgentRuntime,
-	Memory,
-	State,
-} from "../../../../types/index.ts";
-
 /**
  * #12087 Item 17: CHARACTER declares a coarse `roleGate: { minRole: "ADMIN" }`
  * (the floor enforced by canActionRun) but `update_identity` (rename agent /
@@ -14,6 +6,14 @@ import type {
  * not in scattered inline `hasRoleAccess` checks invisible in the metadata.
  * Deterministic: `hasRoleAccess` is mocked; no live model or DB.
  */
+import { describe, expect, it, vi } from "vitest";
+import type {
+	HandlerCallback,
+	IAgentRuntime,
+	Memory,
+	State,
+} from "../../../../types/index.ts";
+
 const rolesMock = vi.hoisted(() => ({ hasRoleAccess: vi.fn() }));
 vi.mock("../../../../roles.ts", () => rolesMock);
 

--- a/packages/core/src/features/advanced-capabilities/personality/actions/shared/persist-character-patch.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/actions/shared/persist-character-patch.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared write path for the personality character-editing actions: applies a
+ * partial character patch to the live runtime character and persists it through
+ * the runtime's character-persistence service, so remove/edit/reorder flows all
+ * commit through one durable, auditable path rather than mutating in memory.
+ */
 import { logger } from "../../../../../logger.ts";
 import type { Character, IAgentRuntime } from "../../../../../types/index.ts";
 import { getCharacterPersistenceService } from "../../character-persistence.ts";

--- a/packages/core/src/features/basic-capabilities/dm-owner-grant.test.ts
+++ b/packages/core/src/features/basic-capabilities/dm-owner-grant.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Drives the real ENTITY_JOINED handler from createBasicCapabilitiesPlugin plus
+ * the real roles.ts hasRoleAccess resolution against the exact world metadata the
+ * handler writes, so DM-world owner grants are checked end to end with nothing mocked.
+ */
 import { describe, expect, it } from "vitest";
 import { hasRoleAccess } from "../../roles.ts";
 import type { IAgentRuntime, Memory } from "../../types";

--- a/packages/core/src/features/basic-capabilities/dm-world-metadata.test.ts
+++ b/packages/core/src/features/basic-capabilities/dm-world-metadata.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit-tests buildDmWorldMetadata directly, feeding it fabricated runtime
+ * settings to assert which DM senders receive an owner grant and which get none.
+ */
 import { describe, expect, it } from "vitest";
 import type { IAgentRuntime } from "../../types";
 import { buildDmWorldMetadata } from "./index.ts";

--- a/packages/core/src/features/basic-capabilities/process-attachments-documents.test.ts
+++ b/packages/core/src/features/basic-capabilities/process-attachments-documents.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Drives the real processAttachments path over a stubbed fetch and hand-built,
+ * spec-valid PDF bytes, so document extraction (including real unpdf parsing)
+ * runs unmocked for every allow-listed upload type.
+ */
 import { Buffer } from "node:buffer";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {

--- a/packages/core/src/features/documents/ctx-embeddings.test.ts
+++ b/packages/core/src/features/documents/ctx-embeddings.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Pure-function unit tests for the contextual-chunk prompt builders in
+ * ctx-embeddings.ts — template interpolation, mime-type template selection, and
+ * fail-safe fallbacks, asserted with no runtime or model in the loop.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	getCachingContextualizationPrompt,

--- a/packages/core/src/features/documents/recall-embed.ts
+++ b/packages/core/src/features/documents/recall-embed.ts
@@ -1,7 +1,3 @@
-import { logger } from "../../logger";
-import type { IAgentRuntime } from "../../types";
-import { ModelType } from "../../types";
-
 /**
  * THE shared recall-query embedder on the reply hot path.
  *
@@ -34,6 +30,9 @@ import { ModelType } from "../../types";
  * means a slow embed either completes (rich recall) or genuinely errors
  * (fail-open), with no silent middle ground.
  */
+import { logger } from "../../logger";
+import type { IAgentRuntime } from "../../types";
+import { ModelType } from "../../types";
 
 /** Normalize query text so trivially-different strings share one cache slot. */
 function normalizeQuery(text: string): string {

--- a/packages/core/src/features/documents/utils.test.ts
+++ b/packages/core/src/features/documents/utils.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Pure-function unit tests for the document helpers in utils.ts — content-hash
+ * id generation, filename/title derivation from untrusted text, and
+ * source/base64 classification, all asserted directly with no runtime.
+ */
 import { describe, expect, it } from "vitest";
 import {
 	createDocumentNoteFilename,

--- a/packages/core/src/features/messaging/triage/__tests__/adapter-registration.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/adapter-registration.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Exercises the TriageService registration contract: a connector-style adapter
+ * registered the way a plugin registers one resolves and drives the real
+ * triage() dispatch, and unknown sources are skipped rather than throwing.
+ */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { IAgentRuntime } from "../../../../types/index.ts";
 import { BaseMessageAdapter } from "../adapters/base.ts";

--- a/packages/core/src/features/messaging/triage/actions/_shared.test.ts
+++ b/packages/core/src/features/messaging/triage/actions/_shared.test.ts
@@ -1,13 +1,13 @@
-import { describe, expect, it } from "vitest";
-import type { HandlerOptions } from "../../../../types/components";
-import { parseListInboxParams, parseTriageParams } from "./_shared.ts";
-
 /**
  * Triage param parsers turn loose agent-supplied options into typed inputs.
  * Sources are filtered to the known set, list fields accept comma-strings or
  * arrays, and numbers coerce from strings — malformed values drop to undefined
  * rather than reaching the inbox query as garbage.
  */
+
+import { describe, expect, it } from "vitest";
+import type { HandlerOptions } from "../../../../types/components";
+import { parseListInboxParams, parseTriageParams } from "./_shared.ts";
 
 const opts = (parameters: Record<string, unknown>): HandlerOptions =>
 	({ parameters }) as unknown as HandlerOptions;

--- a/packages/core/src/features/plugin-manager/coreExtensions.ts
+++ b/packages/core/src/features/plugin-manager/coreExtensions.ts
@@ -1,6 +1,3 @@
-import type { IAgentRuntime } from "../../types/runtime.ts";
-import type { ServiceTypeName } from "../../types/service.ts";
-
 /**
  * Core Runtime Extensions
  *
@@ -9,6 +6,9 @@ import type { ServiceTypeName } from "../../types/service.ts";
  * so this file only retains component unregistration helpers (action/provider/
  * service) that live outside the runtime contract.
  */
+
+import type { IAgentRuntime } from "../../types/runtime.ts";
+import type { ServiceTypeName } from "../../types/service.ts";
 
 /**
  * Extended runtime interface with optional component unregistration helpers.

--- a/packages/core/src/features/plugin-manager/services/pluginConfigurationService.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginConfigurationService.ts
@@ -1,3 +1,11 @@
+/**
+ * Backs the plugin-manager's readiness checks for a registered plugin: given a
+ * plugin, it reports which required config keys are still unset by reading the
+ * plugin's own declared `config` schema and testing each key against
+ * `process.env`. Works from real registered-plugin data, never by scanning
+ * source files on disk.
+ */
+
 import { logger } from "../../../logger.ts";
 import type { Plugin as ElizaPlugin } from "../../../types/plugin.ts";
 import type { IAgentRuntime } from "../../../types/runtime.ts";

--- a/packages/core/src/features/secrets/actions/mask.test.ts
+++ b/packages/core/src/features/secrets/actions/mask.test.ts
@@ -1,6 +1,3 @@
-import { describe, expect, it } from "vitest";
-import { maskSecretValue } from "./mask";
-
 /**
  * Tests for the secret-display mask (#10317 credential bridge / #8801, #9943).
  * `maskSecretValue` decides exactly how much of a secret is shown when a value
@@ -9,6 +6,10 @@ import { maskSecretValue } from "./mask";
  * first/last 4 chars of a long secret show, the middle is never exposed, and
  * the mask is capped so the length isn't revealed.
  */
+
+import { describe, expect, it } from "vitest";
+import { maskSecretValue } from "./mask";
+
 describe("maskSecretValue", () => {
 	it("fully masks secrets of 8 characters or fewer", () => {
 		expect(maskSecretValue("")).toBe("****");

--- a/packages/core/src/features/secrets/crypto/encryption.test.ts
+++ b/packages/core/src/features/secrets/crypto/encryption.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Core secrets encryption (AES-256-GCM). The security guarantees pinned here:
+ * a correct round-trip, authenticated decryption that rejects a wrong key or
+ * tampered ciphertext/algorithm, deterministic password-based key derivation,
+ * and a length-checked constant-time string comparison.
+ */
+
 import { describe, expect, it } from "vitest";
 import type { EncryptedSecret } from "../types.ts";
 import { EncryptionError } from "../types.ts";
@@ -15,13 +22,6 @@ import {
 	isEncryptedSecret,
 	secureCompare,
 } from "./encryption.ts";
-
-/**
- * Core secrets encryption (AES-256-GCM). The security guarantees pinned here:
- * a correct round-trip, authenticated decryption that rejects a wrong key or
- * tampered ciphertext/algorithm, deterministic password-based key derivation,
- * and a length-checked constant-time string comparison.
- */
 
 const KEY = generateKey();
 

--- a/packages/core/src/features/trajectories/art-format.test.ts
+++ b/packages/core/src/features/trajectories/art-format.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Core trajectory → ART (RL training) conversion. toARTMessages must emit the
+ * system/user/assistant message array; validateARTCompatibility rejects
+ * trajectories with no steps or no reward; groupTrajectories buckets by scenario.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
 	groupTrajectories,
@@ -5,12 +11,6 @@ import {
 	validateARTCompatibility,
 } from "./art-format.ts";
 import type { Trajectory } from "./types.ts";
-
-/**
- * Core trajectory → ART (RL training) conversion. toARTMessages must emit the
- * system/user/assistant message array; validateARTCompatibility rejects
- * trajectories with no steps or no reward; groupTrajectories buckets by scenario.
- */
 
 const step = () => ({
 	llmCalls: [

--- a/packages/core/src/features/trajectories/read-routes.ts
+++ b/packages/core/src/features/trajectories/read-routes.ts
@@ -1,6 +1,3 @@
-import type { ServerResponse } from "node:http";
-import type { IAgentRuntime, UUID } from "../../types";
-
 /**
  * Owner-side read routes for the realtime trajectory viewer
  * (`GET /api/trajectories`, `/api/trajectories/:id`, `/api/trajectories/stats`).
@@ -20,6 +17,9 @@ import type { IAgentRuntime, UUID } from "../../types";
  * IS loaded its richer route wins and this handler is never reached — no
  * shadowing, no regression.
  */
+
+import type { ServerResponse } from "node:http";
+import type { IAgentRuntime, UUID } from "../../types";
 
 interface ServiceTrajectoryListItem {
 	id: string;

--- a/packages/core/src/markdown/chunk.chunkMarkdownText.test.ts
+++ b/packages/core/src/markdown/chunk.chunkMarkdownText.test.ts
@@ -1,7 +1,3 @@
-import * as fc from "fast-check";
-import { describe, expect, it } from "vitest";
-import { chunkMarkdownText } from "./chunk.ts";
-
 /**
  * `chunkMarkdownText` feeds connectors with HARD length caps (Discord 2000,
  * SMS 160, …): a single chunk over `limit` gets the whole message rejected by
@@ -10,6 +6,11 @@ import { chunkMarkdownText } from "./chunk.ts";
  * not fit next to the forced minimum-progress break. The limit is a hard cap;
  * closing/reopening fences is best-effort within it.
  */
+
+import * as fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { chunkMarkdownText } from "./chunk.ts";
+
 describe("chunkMarkdownText", () => {
 	it("never exceeds the limit even when the fence close line cannot fit", () => {
 		const text = "```\nAAAAAAAAAAAAAAAAAAAA\n```\n";

--- a/packages/core/src/markdown/chunk.chunkText.test.ts
+++ b/packages/core/src/markdown/chunk.chunkText.test.ts
@@ -1,6 +1,3 @@
-import { describe, expect, it } from "vitest";
-import { chunkText } from "./chunk.ts";
-
 /**
  * `chunkText` splits an over-long message into delivery-sized chunks for
  * connectors with hard length limits (Discord 2000, SMS 160, …) (#8801). The
@@ -8,6 +5,9 @@ import { chunkText } from "./chunk.ts";
  * content is lost or corrupted across the split. A regression here
  * silently drops or mangles the user's outbound text, so these are pinned.
  */
+import { describe, expect, it } from "vitest";
+import { chunkText } from "./chunk.ts";
+
 describe("chunkText", () => {
 	it("returns [] for empty and a single chunk within-limit / non-positive limit", () => {
 		expect(chunkText("", 10)).toEqual([]);

--- a/packages/core/src/network/fetch-guard.a2a-card.test.ts
+++ b/packages/core/src/network/fetch-guard.a2a-card.test.ts
@@ -1,8 +1,3 @@
-import { describe, expect, it, vi } from "vitest";
-import { fetchWithSsrfGuard } from "./fetch-guard.ts";
-import { nodePinnedFetch } from "./node-pinned-fetch.ts";
-import { SsrfBlockedError } from "./ssrf.ts";
-
 /**
  * Regression guard for #12229 L9: the Feed A2A agent-card fetch routes through
  * fetchWithSsrfGuard, so an operator/agent-supplied card URL cannot reach a
@@ -10,6 +5,11 @@ import { SsrfBlockedError } from "./ssrf.ts";
  * so no real resolution/egress happens; asserts the guard refuses (throws) and
  * never calls the pinned transport for a private-resolving host.
  */
+import { describe, expect, it, vi } from "vitest";
+import { fetchWithSsrfGuard } from "./fetch-guard.ts";
+import { nodePinnedFetch } from "./node-pinned-fetch.ts";
+import { SsrfBlockedError } from "./ssrf.ts";
+
 describe("fetchWithSsrfGuard for the A2A agent-card URL (#12229 L9)", () => {
 	it.each([
 		"http://169.254.169.254/.well-known/agent-card.json",

--- a/packages/core/src/network/pinned-fetch.integration.test.ts
+++ b/packages/core/src/network/pinned-fetch.integration.test.ts
@@ -1,10 +1,3 @@
-import { createServer, type Server } from "node:http";
-import type { AddressInfo } from "node:net";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { fetchWithSsrfGuard } from "./fetch-guard.ts";
-import { nodePinnedFetch } from "./node-pinned-fetch.ts";
-import { type LookupFn, SsrfBlockedError } from "./ssrf.ts";
-
 /**
  * Socket-level integration tests for the pinned SSRF transport.
  *
@@ -13,6 +6,13 @@ import { type LookupFn, SsrfBlockedError } from "./ssrf.ts";
  * exist in any resolver, so a successful request proves the connection was
  * routed through the pinned lookup to 127.0.0.1 at the socket level.
  */
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { fetchWithSsrfGuard } from "./fetch-guard.ts";
+import { nodePinnedFetch } from "./node-pinned-fetch.ts";
+import { type LookupFn, SsrfBlockedError } from "./ssrf.ts";
+
 describe("pinned fetch through a real local HTTP server", () => {
 	let server: Server;
 	let port: number;

--- a/packages/core/src/runtime/__tests__/brain-provider-override.test.ts
+++ b/packages/core/src/runtime/__tests__/brain-provider-override.test.ts
@@ -1,8 +1,3 @@
-import { describe, expect, it } from "vitest";
-import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
-import { AgentRuntime } from "../../runtime";
-import { type Character, ModelType } from "../../types";
-
 /**
  * Request-time chat-brain provider override.
  *
@@ -15,6 +10,11 @@ import { type Character, ModelType } from "../../types";
  *    (a stale/typo'd value must never strand the brain),
  *  - never override an explicitly-pinned provider.
  */
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../runtime";
+import { type Character, ModelType } from "../../types";
+
 function makeRuntime(settings: Record<string, string> = {}): AgentRuntime {
 	return new AgentRuntime({
 		character: {

--- a/packages/core/src/runtime/__tests__/pii-swap-egress.test.ts
+++ b/packages/core/src/runtime/__tests__/pii-swap-egress.test.ts
@@ -1,12 +1,3 @@
-import { describe, expect, it, vi } from "vitest";
-import {
-	GazetteerEntityRecognizer,
-	PseudonymSession,
-} from "../../security/index.js";
-import { runWithTrajectoryContext } from "../../trajectory-context";
-import type { Action, IAgentRuntime, Memory } from "../../types";
-import { executePlannedToolCall } from "../execute-planned-tool-call";
-
 /**
  * Egress test for the PII pseudonymization layer (#10469 / #7007).
  *
@@ -17,6 +8,15 @@ import { executePlannedToolCall } from "../execute-planned-tool-call";
  * shown to the user) carries the real recipient while the model/trajectory kept
  * the surrogate.
  */
+import { describe, expect, it, vi } from "vitest";
+import {
+	GazetteerEntityRecognizer,
+	PseudonymSession,
+} from "../../security/index.js";
+import { runWithTrajectoryContext } from "../../trajectory-context";
+import type { Action, IAgentRuntime, Memory } from "../../types";
+import { executePlannedToolCall } from "../execute-planned-tool-call";
+
 
 function makeRuntime(actions: Action[]): IAgentRuntime {
 	return {

--- a/packages/core/src/runtime/__tests__/pii-swap-live-cerebras.real.test.ts
+++ b/packages/core/src/runtime/__tests__/pii-swap-live-cerebras.real.test.ts
@@ -1,3 +1,17 @@
+/**
+ * LIVE end-to-end proof for the PII pseudonymization layer (#10469 / #7007)
+ * against a REAL model provider (Cerebras `gpt-oss-120b`) — not a mock.
+ *
+ * It boots a runtime with `ELIZA_PII_SWAP_ENABLED`, sends a prompt containing a
+ * real person, org, and street address, and captures the EXACT text the provider
+ * received. It asserts the provider saw only realistic surrogates (zero real
+ * PII) and that the live model's own response references the surrogate — then
+ * runs the execution boundary and asserts the real values are restored into the
+ * tool-call args. Every artifact is written to
+ * `.github/issue-evidence/10469-pii-ner/` for manual review.
+ *
+ * Gated on CEREBRAS_API_KEY (post-merge / manual lane); skips cleanly otherwise.
+ */
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -19,20 +33,6 @@ import {
 } from "../../types";
 import { executePlannedToolCall } from "../execute-planned-tool-call";
 
-/**
- * LIVE end-to-end proof for the PII pseudonymization layer (#10469 / #7007)
- * against a REAL model provider (Cerebras `gpt-oss-120b`) — not a mock.
- *
- * It boots a runtime with `ELIZA_PII_SWAP_ENABLED`, sends a prompt containing a
- * real person, org, and street address, and captures the EXACT text the provider
- * received. It asserts the provider saw only realistic surrogates (zero real
- * PII) and that the live model's own response references the surrogate — then
- * runs the execution boundary and asserts the real values are restored into the
- * tool-call args. Every artifact is written to
- * `.github/issue-evidence/10469-pii-ner/` for manual review.
- *
- * Gated on CEREBRAS_API_KEY (post-merge / manual lane); skips cleanly otherwise.
- */
 
 const CEREBRAS_KEY = process.env.CEREBRAS_API_KEY;
 const EVIDENCE_DIR = join(

--- a/packages/core/src/runtime/__tests__/pii-swap-reply-egress.test.ts
+++ b/packages/core/src/runtime/__tests__/pii-swap-reply-egress.test.ts
@@ -1,11 +1,3 @@
-import { describe, expect, it } from "vitest";
-import {
-	GazetteerEntityRecognizer,
-	PseudonymSession,
-} from "../../security/index.js";
-import { restorePiiInUserReplyText } from "../../services/message";
-import { runWithTrajectoryContext } from "../../trajectory-context";
-
 /**
  * Reply-boundary egress test for the PII pseudonymization layer (#10827).
  *
@@ -18,6 +10,14 @@ import { runWithTrajectoryContext } from "../../trajectory-context";
  * user sees the REAL value while the surrogate is what the model produced
  * (i.e. what the trajectory/providers kept).
  */
+import { describe, expect, it } from "vitest";
+import {
+	GazetteerEntityRecognizer,
+	PseudonymSession,
+} from "../../security/index.js";
+import { restorePiiInUserReplyText } from "../../services/message";
+import { runWithTrajectoryContext } from "../../trajectory-context";
+
 
 /** A turn session over a known contact roster, exactly as the ingress mints one. */
 function sessionWithContacts(): PseudonymSession {

--- a/packages/core/src/runtime/__tests__/pii-swap-use-model.test.ts
+++ b/packages/core/src/runtime/__tests__/pii-swap-use-model.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Ingress test for the PII pseudonymization layer (#10469 / #7007).
+ *
+ * Proves that with `ELIZA_PII_SWAP_ENABLED` the model provider receives a fluent
+ * prompt containing *realistic surrogates* and ZERO real named-entity PII, that
+ * the response/trajectory keep surrogates (never real values), and that the
+ * layer is a pure no-op when disabled.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import { AgentRuntime } from "../../runtime";
@@ -10,14 +18,6 @@ import {
 import { runWithTrajectoryContext } from "../../trajectory-context";
 import { type Character, ModelType } from "../../types";
 
-/**
- * Ingress test for the PII pseudonymization layer (#10469 / #7007).
- *
- * Proves that with `ELIZA_PII_SWAP_ENABLED` the model provider receives a fluent
- * prompt containing *realistic surrogates* and ZERO real named-entity PII, that
- * the response/trajectory keep surrogates (never real values), and that the
- * layer is a pure no-op when disabled.
- */
 
 function makeRuntime(enabled: boolean): AgentRuntime {
 	return new AgentRuntime({

--- a/packages/core/src/runtime/__tests__/planner-loop-8007-multistep.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-8007-multistep.test.ts
@@ -1,6 +1,3 @@
-import { describe, expect, it, vi } from "vitest";
-import { runPlannerLoop } from "../planner-loop";
-
 /**
  * Regression coverage for issue elizaOS/eliza#8007:
  * "v5 planner loops on `decision: CONTINUE` without advancing past the first
@@ -23,6 +20,9 @@ import { runPlannerLoop } from "../planner-loop";
  *     past `maxRepeatedToolCalls` forces one terminal synthesis instead of
  *     running the turn to the trajectory/token limit.
  */
+import { describe, expect, it, vi } from "vitest";
+import { runPlannerLoop } from "../planner-loop";
+
 describe("v5 planner #8007 - multi-step orchestrator advance", () => {
 	const REPO = "acme/hello-world";
 

--- a/packages/core/src/runtime/__tests__/planner-streaming-suppression.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-streaming-suppression.test.ts
@@ -1,10 +1,3 @@
-import { describe, expect, it, vi } from "vitest";
-import {
-	getStreamingContext,
-	runWithStreamingContext,
-} from "../../streaming-context";
-import { runPlannerLoop } from "../planner-loop";
-
 /**
  * The planner pass must NOT stream its internals (raw reasoning, the forced
  * PLAN_ACTIONS envelope) to the chat SSE callback — only the structured
@@ -16,6 +9,13 @@ import { runPlannerLoop } from "../planner-loop";
  * token stream AND pass every other test — so this guards it directly. The
  * positive control proves the negative assertion is not vacuous.
  */
+import { describe, expect, it, vi } from "vitest";
+import {
+	getStreamingContext,
+	runWithStreamingContext,
+} from "../../streaming-context";
+import { runPlannerLoop } from "../planner-loop";
+
 describe("planner streaming suppression", () => {
 	it("swallows the planner model's stream chunks so they never reach the chat SSE sink", async () => {
 		const chatSseSink = vi.fn();

--- a/packages/core/src/runtime/__tests__/resolve-stream-fields.test.ts
+++ b/packages/core/src/runtime/__tests__/resolve-stream-fields.test.ts
@@ -1,12 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { resolveDynamicPromptStreamFields } from "../../runtime";
-import type { SchemaRow } from "../../types/state";
-
 /**
  * Locks the default token-stream contract for #9174: the line-oriented
  * dynamic-prompt path streams the clean reply `text` by default, honours
  * explicit `streamField` opt-in/opt-out, and never streams control fields.
  */
+import { describe, expect, it } from "vitest";
+import { resolveDynamicPromptStreamFields } from "../../runtime";
+import type { SchemaRow } from "../../types/state";
+
 describe("resolveDynamicPromptStreamFields (#9174)", () => {
 	it("streams the `text` field by default when no preference is expressed", () => {
 		const schema: SchemaRow[] = [

--- a/packages/core/src/schemas/character.test.ts
+++ b/packages/core/src/schemas/character.test.ts
@@ -1,6 +1,3 @@
-import { describe, expect, it } from "vitest";
-import { isValidCharacter, parseAndValidateCharacter } from "./character";
-
 /**
  * Unit tests for the character-config validators (`parseAndValidateCharacter`,
  * `isValidCharacter`, over the underlying `validateCharacter`) that gate whether
@@ -8,6 +5,9 @@ import { isValidCharacter, parseAndValidateCharacter } from "./character";
  * DB. Covers a valid character passing, malformed JSON reported distinctly from
  * schema errors, and non-object / missing-name rejection. (#8801 / #9943)
  */
+import { describe, expect, it } from "vitest";
+import { isValidCharacter, parseAndValidateCharacter } from "./character";
+
 describe("parseAndValidateCharacter", () => {
 	it("accepts a minimal valid character", () => {
 		expect(parseAndValidateCharacter('{"name":"Aria"}').success).toBe(true);

--- a/packages/core/src/security/secret-swap.bench.ts
+++ b/packages/core/src/security/secret-swap.bench.ts
@@ -1,13 +1,12 @@
-import { bench, describe } from "vitest";
-import { detectPii } from "./pii-detectors";
-import { SecretSwapSession } from "./secret-swap";
-
 /**
  * Throughput benchmarks for the secret-swap layer (#10469). Run with
  * `bunx vitest bench src/security/secret-swap.bench.ts`. These measure the
  * ingress (detect + substitute) and egress (restore) cost on realistic prompt
  * payloads so a future regex change that tanks performance is caught.
  */
+import { bench, describe } from "vitest";
+import { detectPii } from "./pii-detectors";
+import { SecretSwapSession } from "./secret-swap";
 
 const SECRETS = [
 	"4242424242424242", // card

--- a/packages/core/src/security/secret-swap.fuzz.test.ts
+++ b/packages/core/src/security/secret-swap.fuzz.test.ts
@@ -1,7 +1,3 @@
-import { describe, expect, it } from "vitest";
-import { luhnValid } from "./pii-detectors";
-import { SecretSwapSession } from "./secret-swap";
-
 /**
  * Property-based fuzz over the secret-swap layer (#10469). No external fuzz
  * library (fast-check v4 is unstable under Bun) — a seeded mulberry32 PRNG makes
@@ -15,6 +11,9 @@ import { SecretSwapSession } from "./secret-swap";
  *   (P4) idempotent placeholders: substitute(substitute(doc)) re-runs cleanly and
  *                               never swaps an already-emitted placeholder
  */
+import { describe, expect, it } from "vitest";
+import { luhnValid } from "./pii-detectors";
+import { SecretSwapSession } from "./secret-swap";
 
 function mulberry32(seed: number): () => number {
 	let a = seed >>> 0;

--- a/packages/core/src/security/secret-swap.redteam.test.ts
+++ b/packages/core/src/security/secret-swap.redteam.test.ts
@@ -1,15 +1,15 @@
-import { describe, expect, it } from "vitest";
-import {
-	SecretSwapSession,
-	SecretSwapUnresolvedPlaceholderError,
-} from "./secret-swap";
-
 /**
  * Adversarial / red-team suite for the secret-swap layer (#10469). These are the
  * cases an attacker (or a confused model) would use to either leak a real secret
  * or hijack the restore step. The layer's job is to FAIL LOUD or keep the
  * placeholder, never to silently leak.
  */
+import { describe, expect, it } from "vitest";
+import {
+	SecretSwapSession,
+	SecretSwapUnresolvedPlaceholderError,
+} from "./secret-swap";
+
 describe("secret-swap red-team", () => {
 	const PLACEHOLDER_RE = /__ELIZA_SECRET_[0-9a-f]{8,}_\d+__/;
 	const secret = "sk-live_redteam_AbC123dEf456GhI789";

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -1,3 +1,13 @@
+/**
+ * elizaOS's standard structured logger, built on Adze. Exposes the `Logger`
+ * interface and the `createLogger` factory (plus the default `logger` /
+ * `elizaLogger` singletons) as a Pino-shaped API extended with custom
+ * `success`/`progress` levels. Redacts sensitive fields via fast-redact, keeps
+ * an in-memory ring buffer with real-time listeners for WebSocket streaming,
+ * and lazily opens optional file sinks (`output.log`, `prompts.log`,
+ * `chat.log`) with prompt/response/chat instrumentation helpers. Adapts between
+ * node and a console-based browser path.
+ */
 // Test hook to clear env cache in logger tests (kept internal)
 export const __loggerTestHooks = {
   clearEnvCacheForTests: () => {},

--- a/packages/registry/src/first-party/connector-accounts.test.ts
+++ b/packages/registry/src/first-party/connector-accounts.test.ts
@@ -1,7 +1,9 @@
-// Tests for the OWNER+AGENT connector schema extension and the
-// `normalizeConnectorAuth` legacy-auto-map. Backwards compat: existing
-// manifests that only declare `auth` must keep loading and end up with a
-// populated `accounts.agent`.
+/**
+ * Exercises the OWNER+AGENT connector schema extension and the
+ * `normalizeConnectorAuth` legacy auto-map against the real Zod schema and
+ * loader (no I/O). Backwards compat: manifests that only declare `auth` must
+ * keep parsing and end up with a populated `accounts.agent`.
+ */
 
 import { describe, expect, it } from "vitest";
 import { loadRegistryFromRawEntries, normalizeConnectorAuth } from "./loader";

--- a/packages/registry/src/first-party/generate.ts
+++ b/packages/registry/src/first-party/generate.ts
@@ -1,16 +1,20 @@
-// First-party registry aggregator.
-//
-// Registration is plugin-side: each in-repo plugin/package owns its registry
-// entry as a `registry-entry.json` in its own directory (a single entry object,
-// or an array of entries). Curated entries with no vendored package — built-in
-// app-viewers and entries for plugins not checked out in this repo — live under
-// `curated/`. This script gathers all of them, validates each fail-loud against
-// the Zod schema, dedupes by id, and writes the aggregated `generated.json` that
-// the runtime loader reads (a single committed artifact, trivial to stage
-// alongside an on-device bundle).
-//
-//   bun run --cwd packages/registry generate:first-party   # rewrite generated.json
-//   bun run --cwd packages/registry generate:first-party --check   # CI drift gate
+/**
+ * First-party registry aggregator — the build-time generator behind the
+ * `generate:first-party` script.
+ *
+ * Registration is plugin-side: each in-repo plugin/package owns its registry
+ * entry as a `registry-entry.json` in its own directory (a single entry object,
+ * or an array of entries). Curated entries with no vendored package — built-in
+ * app-viewers and entries for plugins not checked out in this repo — live under
+ * `curated/`. This script gathers all of them, validates each fail-loud against
+ * the Zod schema, dedupes by id, and writes the aggregated `generated.json` that
+ * the runtime loader reads (a single committed artifact, trivial to stage
+ * alongside an on-device bundle), plus the derived curated-app / channel /
+ * provider maps. `--check` re-runs the generator and fails on drift for CI.
+ *
+ *   bun run --cwd packages/registry generate:first-party           # rewrite generated.json
+ *   bun run --cwd packages/registry generate:first-party --check   # CI drift gate
+ */
 
 import { execFileSync } from "node:child_process";
 import {

--- a/packages/registry/src/first-party/index.ts
+++ b/packages/registry/src/first-party/index.ts
@@ -1,13 +1,17 @@
-// First-party curated registry — runtime entry point.
-//
-// Reads JSON entries from `entries/`, validates, caches, and exposes typed
-// accessors. This is the single import path the rest of the codebase consumes
-// (`@elizaos/registry/first-party`, re-exported by `@elizaos/app-core/registry`
-// for backwards compatibility).
-//
-// Registration is plugin-side: bundled JSON under `entries/` is the default,
-// and any plugin can contribute or override an entry at runtime via
-// `registerRegistryEntry()` (deduped by `id`; runtime entries win).
+/**
+ * First-party curated registry — runtime entry point.
+ *
+ * Reads the aggregated `generated.json`, validates, caches, and exposes typed
+ * accessors. This is the single import path the rest of the codebase consumes
+ * (`@elizaos/registry/first-party`, re-exported by `@elizaos/app-core/registry`
+ * for backwards compatibility).
+ *
+ * Registration is plugin-side: bundled JSON is the default, and any plugin can
+ * contribute or override an entry at runtime via `registerRegistryEntry()`
+ * (deduped by `id`; runtime entries win). Resolving the generated file and the
+ * cache slot are both hardened against on-device bundling and circular-import
+ * re-entry (see `resolveGeneratedPath` and `cacheSlot`).
+ */
 
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";

--- a/packages/registry/src/first-party/loader.ts
+++ b/packages/registry/src/first-party/loader.ts
@@ -1,11 +1,15 @@
-// Registry loader. Reads, validates, and indexes the registry.
-//
-// Static data only. Runtime overlay (enabled, configured, isActive) is merged
-// in at the API layer via mergeWithRuntime() — the loader never touches it.
-//
-// Validation is fail-loud at boot: bad entries throw with a precise zod
-// message naming the offending file, so a malformed entry can't slip into a
-// running process.
+/**
+ * Registry loader. Validates raw entries and indexes them by id, kind, group,
+ * and npm name, and provides the kind-narrowed accessors plus the legacy
+ * `auth` → `accounts.agent` normalization.
+ *
+ * Static data only. Runtime overlay (enabled, configured, isActive) is merged
+ * in at the API layer via `mergeWithRuntime()` — the loader never touches it.
+ *
+ * Validation is fail-loud at boot: bad entries throw with a precise zod
+ * message naming the offending file, so a malformed entry can't slip into a
+ * running process.
+ */
 
 import {
   type AccountAuthKind,

--- a/packages/registry/src/first-party/schema.ts
+++ b/packages/registry/src/first-party/schema.ts
@@ -1,17 +1,21 @@
-// Registry SoT for apps, plugins, and connectors.
-//
-// Replaces the fragmented surface of:
-//   - plugins.json (97 entries, 5 categories)
-//   - PluginInfo (api/client-types-config.ts)
-//   - ConfigUiHint (types/index.ts)
-//   - RegistryAppInfo (shared/contracts/apps.ts)
-//   - VISIBLE_CONNECTOR_IDS / DEFAULT_ICONS / FEATURE_SUBGROUP / SUBGROUP_DISPLAY_ORDER
-//     (components/pages/plugin-list-utils.ts)
-//   - paramsToSchema() heuristics (PORT/TIMEOUT/MODEL guessing)
-//
-// Static registry only. Runtime overlay (enabled, configured, isActive,
-// validationErrors) lives in RegistryRuntimeOverlay and is merged at API read
-// time — never in the registry files themselves.
+/**
+ * Registry source-of-truth Zod schemas and inferred types for apps, plugins,
+ * and connectors — config fields, render hints, per-account auth, the
+ * discriminated `registryEntrySchema` union, and the runtime overlay/view.
+ *
+ * Replaces the fragmented surface of:
+ *   - plugins.json (97 entries, 5 categories)
+ *   - PluginInfo (api/client-types-config.ts)
+ *   - ConfigUiHint (types/index.ts)
+ *   - RegistryAppInfo (shared/contracts/apps.ts)
+ *   - VISIBLE_CONNECTOR_IDS / DEFAULT_ICONS / FEATURE_SUBGROUP / SUBGROUP_DISPLAY_ORDER
+ *     (components/pages/plugin-list-utils.ts)
+ *   - paramsToSchema() heuristics (PORT/TIMEOUT/MODEL guessing)
+ *
+ * Static registry only. Runtime overlay (enabled, configured, isActive,
+ * validationErrors) lives in RegistryRuntimeOverlay and is merged at API read
+ * time — never in the registry files themselves.
+ */
 
 import * as zod from "zod";
 


### PR DESCRIPTION
## What

Final straggler pass completing **B01** of the repo-wide comment cleanup (#12231, parent #12181).
Adds top-of-file prose headers to the ~45 files that prior automated passes skipped — bare test
files and modules that carried export-level JSDoc but no *file-level* header: packages/core
stragglers (character-utils.test, room action, recall-embed, feature test files, __tests__
residual), `packages/logger/src/logger.ts`, and `packages/registry/src/first-party/*`.

With this, **every in-scope source file in the B01 batch carries a purpose-explaining header.**

**Comments only — zero functional diff.** `node scripts/assert-comment-only-diff.mjs` → every
changed file's TypeScript code-token stream byte-identical to base.

## B01 completion

| part | scope | PR |
|---|---|---|
| p1 | core boundary/data/schema subsystems | #12824 |
| p2 | core root + types load-bearing (incl. runtime.ts) | #12874 |
| p3 | core features subsystems | #12926 |
| p4 | core services + utils | #13030 |
| p5 | core runtime internals + __tests__ + residual | #13039 |
| p6 | stragglers + logger + registry (this PR) | — |

Closes #12231.