### PR TITLE
fix(#12903): add connector example smoke tests

### DIFF
--- a/.github/issue-evidence/12903-connector-example-tests.md
+++ b/.github/issue-evidence/12903-connector-example-tests.md
@@ -1,0 +1,108 @@
+# #12903 connector example script/test evidence
+
+Branch slice: normalize script contracts for connector-style examples that had
+fake builds or empty-test pass flags.
+
+## Packages
+
+- `packages/examples/bluesky`
+- `packages/examples/discord`
+- `packages/examples/lp-manager`
+
+## Script contract changes
+
+- `packages/examples/bluesky`
+  - Removed `--passWithNoTests` from `test`.
+  - Removed artifact-free `build: bun run typecheck`.
+  - Added `format` and read-only `format:check`.
+- `packages/examples/discord`
+  - Replaced `vitest run --passWithNoTests` with a real `bun test smoke.test.js`.
+  - Added `smoke.test.js` covering package scripts and Discord agent wiring.
+  - Removed artifact-free `build: bun run typecheck`.
+  - Added `format` and read-only `format:check`.
+- `packages/examples/lp-manager`
+  - Replaced `bun test --pass-with-no-tests` with a real
+    `bun test smoke.test.js`.
+  - Added `smoke.test.js` covering package scripts and LP monitoring wiring.
+  - Removed artifact-free `build: bun run typecheck`.
+  - Added `lint:check`, `format`, and read-only `format:check`.
+
+## Verification
+
+Current working tree: `origin/develop` at `222307ddb8`.
+
+Static guard:
+
+```bash
+node - <<'NODE'
+const fs = require('fs');
+for (const p of ['packages/examples/bluesky/package.json','packages/examples/discord/package.json','packages/examples/lp-manager/package.json']) {
+  const pkg = JSON.parse(fs.readFileSync(p,'utf8'));
+  const scripts = pkg.scripts || {};
+  const text = JSON.stringify(scripts);
+  const bad = [];
+  if ('build' in scripts) bad.push(`build=${scripts.build}`);
+  if (!scripts.typecheck) bad.push('missing typecheck');
+  for (const name of ['lint:check','format','format:check','test']) if (!scripts[name]) bad.push(`missing ${name}`);
+  if (/passWithNoTests|pass-with-no-tests|bun run typecheck/.test(text)) bad.push(`masked/fake script remains: ${text}`);
+  if (bad.length) { console.error(`${p}: ${bad.join('; ')}`); process.exitCode = 1; }
+  else console.log(`${p}: connector example scripts normalized`);
+}
+NODE
+```
+
+Result:
+
+```text
+packages/examples/bluesky/package.json: connector example scripts normalized
+packages/examples/discord/package.json: connector example scripts normalized
+packages/examples/lp-manager/package.json: connector example scripts normalized
+```
+
+Read-only lint and format:
+
+```bash
+for pkg in packages/examples/bluesky packages/examples/discord packages/examples/lp-manager; do
+  bun run --cwd "$pkg" lint:check
+  bun run --cwd "$pkg" format:check
+done
+```
+
+Result:
+
+```text
+packages/examples/bluesky: biome check passed for 6 files; biome format passed for 6 files.
+packages/examples/discord: biome check passed for 6 files; biome format passed for 6 files.
+packages/examples/lp-manager: biome check passed for 9 files; biome format passed for 9 files.
+```
+
+Smoke tests:
+
+```bash
+bun run --cwd packages/examples/discord test
+bun run --cwd packages/examples/lp-manager test
+```
+
+Result:
+
+```text
+packages/examples/discord: 2 pass, 0 fail
+packages/examples/lp-manager: 2 pass, 0 fail
+```
+
+## Local blockers
+
+This auxiliary worktree has no valid local install.
+
+```text
+packages/examples/bluesky test:
+  vitest: command not found
+
+packages/examples/bluesky typecheck:
+packages/examples/discord typecheck:
+packages/examples/lp-manager typecheck:
+  error TS2688: Cannot find type definition file for 'node'
+```
+
+Full `bun install` / `bun run verify` were not run here because the filesystem
+has only a few GiB free.

--- a/packages/examples/bluesky/package.json
+++ b/packages/examples/bluesky/package.json
@@ -6,13 +6,14 @@
   "scripts": {
     "start": "bun run agent.ts",
     "dev": "bun --watch run agent.ts",
-    "test": "vitest run __tests__ --passWithNoTests",
+    "test": "vitest run __tests__",
     "test:watch": "vitest",
     "test:live": "LIVE_TEST=true vitest run",
     "typecheck": "tsgo --noEmit",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
-    "build": "bun run typecheck"
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/packages/examples/discord/package.json
+++ b/packages/examples/discord/package.json
@@ -6,12 +6,13 @@
   "scripts": {
     "start": "bun run agent.ts",
     "dev": "bun --watch run agent.ts",
-    "test": "vitest run --passWithNoTests",
-    "test:watch": "vitest",
+    "test": "bun test smoke.test.js",
+    "test:watch": "bun test --watch",
     "typecheck": "tsgo --noEmit",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
-    "build": "bun run typecheck"
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/packages/examples/discord/smoke.test.js
+++ b/packages/examples/discord/smoke.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = import.meta.dir;
+const read = (path) => readFileSync(join(root, path), "utf8");
+
+describe("Discord example package", () => {
+  test("declares real package scripts without fake build or empty-test passes", () => {
+    const pkg = JSON.parse(read("package.json"));
+
+    expect(pkg.scripts.test).toBe("bun test smoke.test.js");
+    expect(pkg.scripts.build).toBeUndefined();
+    expect(pkg.scripts["lint:check"]).toBe("bunx @biomejs/biome check .");
+    expect(pkg.scripts["format:check"]).toBe("bunx @biomejs/biome format .");
+    expect(JSON.stringify(pkg.scripts)).not.toContain("passWithNoTests");
+  });
+
+  test("keeps the runnable agent wired to Discord handlers and plugins", () => {
+    const agent = read("agent.ts");
+    const handlers = read("handlers.ts");
+    const character = read("character.ts");
+
+    expect(agent).toContain("registerDiscordHandlers(runtime)");
+    expect(agent).toContain("registerSlashCommands(runtime)");
+    expect(agent).toContain("@elizaos/plugin-discord");
+    expect(handlers).toContain("DISCORD_SLASH_COMMAND");
+    expect(handlers).toContain("DISCORD_REGISTER_COMMANDS");
+    expect(character).toContain("DiscordEliza");
+  });
+});

--- a/packages/examples/lp-manager/package.json
+++ b/packages/examples/lp-manager/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "start": "bun run src/agent.ts",
     "dev": "bun --watch run src/agent.ts",
-    "test": "bun test --pass-with-no-tests",
+    "test": "bun test smoke.test.js",
     "test:watch": "bun test --watch",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "typecheck": "tsgo --noEmit",
-    "build": "bun run typecheck"
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/packages/examples/lp-manager/smoke.test.js
+++ b/packages/examples/lp-manager/smoke.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = import.meta.dir;
+const read = (path) => readFileSync(join(root, path), "utf8");
+
+describe("LP Manager example package", () => {
+  test("declares real package scripts without fake build or empty-test passes", () => {
+    const pkg = JSON.parse(read("package.json"));
+
+    expect(pkg.scripts.test).toBe("bun test smoke.test.js");
+    expect(pkg.scripts.build).toBeUndefined();
+    expect(pkg.scripts["lint:check"]).toBe("bunx @biomejs/biome check .");
+    expect(pkg.scripts["format:check"]).toBe("bunx @biomejs/biome format .");
+    expect(JSON.stringify(pkg.scripts)).not.toContain("pass-with-no-tests");
+  });
+
+  test("keeps the agent entrypoint wired to monitoring and wallet services", () => {
+    const agent = read("src/agent.ts");
+    const service = read("src/services/LpMonitoringService.ts");
+    const entrypoint = read("src/index.ts");
+
+    expect(agent).toContain("class LpManagerAgent");
+    expect(agent).toContain("LpMonitoringService.start");
+    expect(agent).toContain("@elizaos/plugin-wallet");
+    expect(service).toContain("class LpMonitoringService extends Service");
+    expect(entrypoint).toContain(
+      "export { LpManagerAgent, loadConfigFromEnv }",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a #12903 script-normalization slice for connector examples:

- removes Bluesky's `--passWithNoTests` and fake `build: bun run typecheck`
- replaces Discord's empty-test pass with a real `bun test smoke.test.js`
- replaces LP Manager's empty-test pass with a real `bun test smoke.test.js`
- removes artifact-free build aliases and adds missing check/format verbs
- records evidence in `.github/issue-evidence/12903-connector-example-tests.md`

## Why

#12903 explicitly disallows fake-success/no-op scripts. Discord and LP Manager had no test files, so this adds smoke tests that validate their package scripts and source wiring without importing external elizaOS plugins.

## Verification

- `git diff --check origin/develop..HEAD`
- JSON parse check for edited `package.json` files
- static guard confirming no fake build, no pass-with-no-tests, and required check verbs present
- `bun run --cwd packages/examples/bluesky lint:check`
- `bun run --cwd packages/examples/bluesky format:check`
- `bun run --cwd packages/examples/discord lint:check`
- `bun run --cwd packages/examples/discord format:check`
- `bun run --cwd packages/examples/discord test`
- `bun run --cwd packages/examples/lp-manager lint:check`
- `bun run --cwd packages/examples/lp-manager format:check`
- `bun run --cwd packages/examples/lp-manager test`

## Known local limitations

Full `bun install` / `bun run verify` were not run in this auxiliary worktree because the filesystem has under 2 GiB free. Bluesky's Vitest command and all three package typechecks were attempted but are blocked by missing local install dependencies/type libraries. Details are in the evidence file.
