### PR TITLE
fix(#12903): normalize browser form echo example scripts

### DIFF
--- a/.github/issue-evidence/12903-browser-form-echo-scripts.md
+++ b/.github/issue-evidence/12903-browser-form-echo-scripts.md
@@ -1,0 +1,91 @@
+# #12903 browser/form/plugin-echo script normalization
+
+Date: 2026-07-04
+Base: `origin/develop` at `5dcd79eb2d`
+Branch: `fix/12903-browser-form-echo-scripts`
+
+## Scope
+
+- `packages/examples/browser-extension`
+- `packages/examples/browser-extension/chrome`
+- `packages/examples/browser-extension/safari`
+- `packages/examples/form`
+- `packages/examples/plugin-echo`
+
+This slice removes the fake browser-extension `typecheck` scripts, adds missing
+read-only `lint:check` and format verbs, and makes Plugin Echo's `lint` mutating
+while keeping `lint:check` read-only.
+
+The documented browser-extension aggregate `build` skip remains in place because
+the package documents target-specific build commands and the aggregate build is a
+known browser-bundling constraint rather than a hidden `typecheck` alias.
+
+## Validation
+
+Commands run from a fresh sparse worktree based on current `origin/develop`:
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+Inline Node audit over the edited `package.json` scripts.
+
+Result for edited packages:
+
+```text
+packages/examples/browser-extension/package.json: ok
+packages/examples/browser-extension/chrome/package.json: ok
+packages/examples/browser-extension/safari/package.json: ok
+packages/examples/form/package.json: ok
+packages/examples/plugin-echo/package.json: ok
+```
+
+Package-local checks:
+
+```bash
+bun run --cwd packages/examples/browser-extension lint:check
+bun run --cwd packages/examples/browser-extension format:check
+bun run --cwd packages/examples/browser-extension/chrome lint:check
+bun run --cwd packages/examples/browser-extension/chrome format:check
+bun run --cwd packages/examples/browser-extension/safari lint:check
+bun run --cwd packages/examples/browser-extension/safari format:check
+bun run --cwd packages/examples/form lint:check
+bun run --cwd packages/examples/form format:check
+bun run --cwd packages/examples/plugin-echo lint:check
+bun run --cwd packages/examples/plugin-echo format:check
+```
+
+Result: all passed.
+
+Smoke/unit tests:
+
+```bash
+bun run --cwd packages/examples/browser-extension test
+bun run --cwd packages/examples/plugin-echo test
+```
+
+Result:
+
+- Browser extension: 6 passing Bun tests across root, Chrome, and Safari smoke tests.
+- Plugin Echo: 1 passing Vitest file, 3 passing tests.
+
+Additional delegated test attempted:
+
+```bash
+bun run --cwd packages/examples/form test
+```
+
+Result: blocked in the sparse worktree after entering `packages/examples/chat`
+because dependencies for `dotenv/config` and `@elizaos/plugin-sql` were not
+available in the sparse dependency graph. The Form scripts changed only by adding
+check/format verbs; the delegated test command itself was not changed.
+
+Residual scoped audit after this slice:
+
+```text
+packages=47 issues=36
+```
+
+Remaining failures are other example packages outside this PR's scope.

--- a/packages/examples/browser-extension/chrome/package.json
+++ b/packages/examples/browser-extension/chrome/package.json
@@ -11,6 +11,9 @@
     "package": "bun run build && cd .. && zip -r chrome/chrome-extension.zip chrome -x 'chrome/node_modules/*' -x 'chrome/src/*' -x 'chrome/*.ts' -x 'chrome/tsconfig.json' -x 'chrome/tsup.config.ts'",
     "test": "bun test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {

--- a/packages/examples/browser-extension/package.json
+++ b/packages/examples/browser-extension/package.json
@@ -14,6 +14,8 @@
     "clean": "node ../../../packages/scripts/rm-path-recursive.mjs chrome/dist",
     "test": "bun test smoke.test.js && bun run --cwd chrome test && bun run --cwd safari test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "typecheck": "echo 'No TypeScript config; skipping typecheck'"
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   }
 }

--- a/packages/examples/browser-extension/safari/package.json
+++ b/packages/examples/browser-extension/safari/package.json
@@ -9,6 +9,8 @@
     "info": "echo 'See README.md for detailed Safari extension build instructions'",
     "test": "bun test",
     "lint": "node scripts/fix-generated-safari.mjs && bunx @biomejs/biome check --write --unsafe .",
-    "typecheck": "echo 'No TypeScript config; skipping typecheck'"
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   }
 }

--- a/packages/examples/form/package.json
+++ b/packages/examples/form/package.json
@@ -9,7 +9,10 @@
     "typecheck": "bun run --cwd ../chat typecheck",
     "test": "bun run --cwd ../chat typecheck",
     "build": "bun run --cwd ../chat build",
-    "lint": "bunx @biomejs/biome check --write --unsafe ."
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "engines": {
     "node": ">=24.0.0"

--- a/packages/examples/plugin-echo/package.json
+++ b/packages/examples/plugin-echo/package.json
@@ -33,8 +33,11 @@
     "build": "tsc --noCheck -p tsconfig.json",
     "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "node ../../scripts/run-vitest.mjs run --config ./vitest.config.ts",
-    "lint": "bunx @biomejs/biome check src",
-    "lint:fix": "bunx @biomejs/biome check --write src"
+    "lint": "bunx @biomejs/biome check --write --unsafe src",
+    "lint:check": "bunx @biomejs/biome check src",
+    "lint:fix": "bunx @biomejs/biome check --write src",
+    "format": "bunx @biomejs/biome format --write src",
+    "format:check": "bunx @biomejs/biome format src"
   },
   "dependencies": {
     "@elizaos/core": "workspace:*"


### PR DESCRIPTION
## Summary

- remove fake browser-extension root/Safari `typecheck` scripts
- add read-only `lint:check` plus `format` / `format:check` to browser-extension, Chrome, Safari, Form, and Plugin Echo examples
- make Plugin Echo `lint` mutating while keeping `lint:check` read-only
- add issue evidence at `.github/issue-evidence/12903-browser-form-echo-scripts.md`

## Evidence

- `git diff --check`
- static package-script audit over edited packages
- `bun run --cwd packages/examples/browser-extension lint:check`
- `bun run --cwd packages/examples/browser-extension format:check`
- `bun run --cwd packages/examples/browser-extension/chrome lint:check`
- `bun run --cwd packages/examples/browser-extension/chrome format:check`
- `bun run --cwd packages/examples/browser-extension/safari lint:check`
- `bun run --cwd packages/examples/browser-extension/safari format:check`
- `bun run --cwd packages/examples/form lint:check`
- `bun run --cwd packages/examples/form format:check`
- `bun run --cwd packages/examples/plugin-echo lint:check`
- `bun run --cwd packages/examples/plugin-echo format:check`
- `bun run --cwd packages/examples/browser-extension test` (6 passing Bun tests)
- `bun run --cwd packages/examples/plugin-echo test` (1 Vitest file, 3 passing tests)

Blocked in sparse worktree: `bun run --cwd packages/examples/form test` enters `packages/examples/chat` and cannot resolve `dotenv/config` / `@elizaos/plugin-sql` from the sparse dependency graph. The Form test command itself is unchanged; this PR only adds check/format verbs there.

Residual #12903 examples audit after this slice: `packages=47 issues=36`.

Fixes part of #12903.
