### PR TITLE
fix(#12903): normalize plugin example scripts

### DIFF
--- a/.github/issue-evidence/12903-plugin-example-script-contract.md
+++ b/.github/issue-evidence/12903-plugin-example-script-contract.md
@@ -1,0 +1,25 @@
+# Issue #12903 plugin/code example script contract evidence
+
+Date: 2026-07-04
+
+Scope:
+- `packages/examples/code/package.json`
+- `packages/examples/_plugin/package.json`
+- `packages/examples/plugin-echo/package.json`
+
+Changes:
+- Removed the remaining `--pass-with-no-tests` mask from the Code example test script. The package already contains real `src/*.test.ts` files, so the test command now fails if discovery unexpectedly finds no tests.
+- Added an explicit `clean` script to the plugin starter template, whose build emits `dist`.
+- Added an explicit `clean` script to the Echo plugin example, whose build emits `dist`.
+
+Verification:
+- `node -e` parsed all three edited `package.json` files successfully.
+- Static guard confirmed these three packages no longer match the #12903 masked-test/fake-build/missing-check/build-without-clean audit predicates.
+- `bun run --cwd packages/examples/_plugin lint:check` passed: Biome checked 9 files with no fixes applied.
+- `bun run --cwd packages/examples/plugin-echo lint:check` passed: Biome checked 3 files with no fixes applied.
+- `bun run --cwd packages/examples/code test` now discovers and runs the real test set, but failed in this partial-install worktree because workspace/local dependencies are unresolved (`@elizaos/core`, `@elizaos/tui`, `uuid`, `chalk`). The run reported 2 passing tests before dependency-resolution failures in the remaining files.
+- `git diff --check` passed.
+
+Environment limitation:
+- Full build execution was not run in this worktree because the local checkout is intentionally using a partial/shared install under low disk space, and this host is on Node v23.3.0 while the repository requires Node 24.
+- This slice only changes package-manager script metadata; no runtime code or UI files changed, so screenshots/video are N/A.

--- a/packages/examples/_plugin/package.json
+++ b/packages/examples/_plugin/package.json
@@ -61,6 +61,7 @@
   "scripts": {
     "dev": "bun run build:watch",
     "build": "bun run build.ts",
+    "clean": "rm -rf dist",
     "lint": "bunx @biomejs/biome check --write --unsafe ./src",
     "lint:check": "bunx @biomejs/biome check ./src",
     "typecheck": "tsgo --noEmit",

--- a/packages/examples/code/package.json
+++ b/packages/examples/code/package.json
@@ -24,7 +24,7 @@
     "start": "bun src/index.ts",
     "dev": "bun --watch src/index.ts",
     "build": "bun build src/index.ts --outdir dist --target bun --external @elizaos/core --external \"@elizaos/plugin-*\" && bun build src/acp.ts --outdir dist --target bun --external @elizaos/core --external \"@elizaos/plugin-*\" && node scripts/write-dist-tsconfig.mjs",
-    "test": "bun test --pass-with-no-tests src",
+    "test": "bun test src",
     "e2e:subagents": "bun src/e2e/subagents.ts",
     "e2e:games": "bun src/e2e/game-generation.ts",
     "e2e:deterministic-replay": "bun --conditions eliza-source --tsconfig-override ../../../tsconfig.json tests/e2e/deterministic-app-build-replay.mjs",

--- a/packages/examples/plugin-echo/package.json
+++ b/packages/examples/plugin-echo/package.json
@@ -31,6 +31,7 @@
   ],
   "scripts": {
     "build": "tsc --noCheck -p tsconfig.json",
+    "clean": "rm -rf dist",
     "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "node ../../scripts/run-vitest.mjs run --config ./vitest.config.ts",
     "lint": "bunx @biomejs/biome check --write --unsafe src",


### PR DESCRIPTION
## Summary
- remove the remaining `--pass-with-no-tests` mask from `packages/examples/code`
- add explicit `clean` scripts for the plugin starter and Echo plugin examples that emit `dist`
- add evidence for the script-contract verification slice

## Evidence
- `.github/issue-evidence/12903-plugin-example-script-contract.md`
- `node -e` JSON parse for edited package manifests: passed
- static #12903 script guard for edited packages: passed
- `bun run --cwd packages/examples/_plugin lint:check`: passed
- `bun run --cwd packages/examples/plugin-echo lint:check`: passed
- `bun run --cwd packages/examples/code test`: command now discovers real tests, but fails in this partial-install worktree because workspace/local dependencies are unresolved (`@elizaos/core`, `@elizaos/tui`, `uuid`, `chalk`)
- `git diff --check origin/develop..HEAD`: passed

## Screenshots / video
N/A: script metadata only; no runtime UI changed.

Fixes part of #12903.
