### PR TITLE
fix(#12903): add format scripts to remaining examples

### DIFF
--- a/.github/issue-evidence/12903-format-only-examples.md
+++ b/.github/issue-evidence/12903-format-only-examples.md
@@ -1,0 +1,113 @@
+# #12903 format-only example script normalization
+
+Date: 2026-07-04
+Base: `origin/develop` at `f5d7680d77`
+Branch: `fix/12903-format-only-examples`
+
+## Scope
+
+- `packages/examples/agent-console`
+- `packages/examples/aws`
+- `packages/examples/gcp`
+- `packages/examples/next`
+- `packages/examples/react`
+- `packages/examples/cloud/edad`
+- `packages/examples/cloud/x402-image-gen`
+
+This slice adds missing `format` and read-only `format:check` scripts to
+example packages that already had real test/build/typecheck behavior and only
+needed formatter command parity for #12903.
+
+No runtime behavior, builds, tests, or deployment commands were changed.
+
+## Validation
+
+Commands run from a fresh sparse worktree based on current `origin/develop`:
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+Inline script-contract audit over the edited package manifests:
+
+```text
+packages/examples/agent-console/package.json: ok
+packages/examples/aws/package.json: ok
+packages/examples/gcp/package.json: ok
+packages/examples/next/package.json: ok
+packages/examples/react/package.json: ok
+packages/examples/cloud/edad/package.json: ok
+packages/examples/cloud/x402-image-gen/package.json: ok
+```
+
+Package-local format checks:
+
+```bash
+bun run --cwd packages/examples/agent-console format:check
+bun run --cwd packages/examples/aws format:check
+bun run --cwd packages/examples/gcp format:check
+bun run --cwd packages/examples/next format:check
+bun run --cwd packages/examples/react format:check
+bun run --cwd packages/examples/cloud/edad format:check
+bun run --cwd packages/examples/cloud/x402-image-gen format:check
+```
+
+Result: all passed.
+
+Existing lint checks where present:
+
+```bash
+bun run --cwd packages/examples/aws lint:check
+bun run --cwd packages/examples/gcp lint:check
+bun run --cwd packages/examples/next lint:check
+bun run --cwd packages/examples/react lint:check
+```
+
+Result: all passed.
+
+Smoke/tests:
+
+```bash
+bun run --cwd packages/examples/agent-console test
+bun run --cwd packages/examples/next test
+bun run --cwd packages/examples/react test
+bun run --cwd packages/examples/aws test
+bun run --cwd packages/examples/gcp test
+bun run --cwd packages/examples/cloud/x402-image-gen test
+```
+
+Result:
+
+- Agent Console: 1 passing Bun test.
+- Next: 2 passing Bun tests.
+- React: 3 passing Bun tests.
+- AWS: local handler smoke passed health, validation, and 404 checks; live chat skipped because `OPENAI_API_KEY` was not set.
+- GCP: command exited successfully and skipped integration because no local worker was running at `http://localhost:8080`.
+- x402 image gen: local flow test passed.
+
+Additional test attempted:
+
+```bash
+bun run --cwd packages/examples/cloud/edad test
+```
+
+Result: blocked in the sparse worktree because `@elizaos/cloud-sdk` could not be
+resolved through the sparse dependency graph when the eDad server process
+started. The eDad package's test command itself was not changed in this PR.
+
+Scoped audit after this slice:
+
+```text
+packages=7 issues=0
+```
+
+Full examples audit after this slice:
+
+```text
+packages=47 issues=22
+```
+
+Remaining failures are `packages/examples/app/*`, `packages/examples/farcaster-miniapp`,
+`packages/examples/smartglasses`, and `packages/examples/trader`.

--- a/packages/examples/agent-console/package.json
+++ b/packages/examples/agent-console/package.json
@@ -8,7 +8,9 @@
     "start": "bun run server.ts",
     "dev": "bun --hot run server.ts",
     "test": "bun test action-scanner.test.ts",
-    "typecheck": "tsgo --noEmit -p tsconfig.json"
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/packages/examples/aws/package.json
+++ b/packages/examples/aws/package.json
@@ -19,7 +19,9 @@
     "delete": "sam delete",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsgo --noEmit",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/packages/examples/cloud/edad/package.json
+++ b/packages/examples/cloud/edad/package.json
@@ -8,7 +8,9 @@
     "dev": "bun --hot run server.ts",
     "typecheck": "tsgo --noEmit",
     "test": "bun run test.ts",
-    "build": "bun build server.ts --outdir=dist --target=bun --format=esm"
+    "build": "bun build server.ts --outdir=dist --target=bun --format=esm",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@elizaos/cloud-sdk": "workspace:*"

--- a/packages/examples/cloud/x402-image-gen/package.json
+++ b/packages/examples/cloud/x402-image-gen/package.json
@@ -7,7 +7,9 @@
     "dev": "bun --hot run server.ts",
     "typecheck": "tsgo --noEmit",
     "test": "bun run test.ts",
-    "build": "bun build server.ts --outdir=dist --target=bun --format=esm"
+    "build": "bun build server.ts --outdir=dist --target=bun --format=esm",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@elizaos/cloud-sdk": "workspace:*"

--- a/packages/examples/gcp/package.json
+++ b/packages/examples/gcp/package.json
@@ -17,7 +17,9 @@
     "docker:build": "docker build -t eliza-worker-ts .",
     "docker:run": "docker run -p 8080:8080 -e OPENAI_API_KEY=$OPENAI_API_KEY eliza-worker-ts",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "lint:check": "bunx @biomejs/biome check ."
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/packages/examples/next/package.json
+++ b/packages/examples/next/package.json
@@ -10,7 +10,9 @@
     "test": "bun test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsgo --noEmit",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/packages/examples/react/package.json
+++ b/packages/examples/react/package.json
@@ -12,7 +12,9 @@
     "test": "bun test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsgo --noEmit",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.4.0",


### PR DESCRIPTION
## Summary

- add `format` / `format:check` scripts to seven example packages that only lacked formatter parity
- leave existing runtime/build/test/typecheck behavior unchanged
- add evidence at `.github/issue-evidence/12903-format-only-examples.md`

## Evidence

- `git diff --check`
- static package-script audit over edited packages
- `format:check` for agent-console, AWS, GCP, Next, React, eDad, and x402 image gen
- existing `lint:check` for AWS, GCP, Next, and React
- `bun run --cwd packages/examples/agent-console test` (1 passing Bun test)
- `bun run --cwd packages/examples/next test` (2 passing Bun tests)
- `bun run --cwd packages/examples/react test` (3 passing Bun tests)
- `bun run --cwd packages/examples/aws test` (local handler checks passed; live chat skipped without `OPENAI_API_KEY`)
- `bun run --cwd packages/examples/gcp test` (command exited successfully; integration skipped because no local worker was running)
- `bun run --cwd packages/examples/cloud/x402-image-gen test` (local flow passed)

Blocked in sparse worktree: `bun run --cwd packages/examples/cloud/edad test` cannot resolve `@elizaos/cloud-sdk` when starting the server through the sparse dependency graph. The eDad test command itself is unchanged.

Full examples residual audit after this slice: `packages=47 issues=22`.

Fixes part of #12903.
