### PR TITLE
fix(#12903): finish app example script normalization

### DIFF
--- a/.github/issue-evidence/12903-app-example-scripts.md
+++ b/.github/issue-evidence/12903-app-example-scripts.md
@@ -1,0 +1,89 @@
+# #12903 app example script normalization
+
+Date: 2026-07-04
+Base: `origin/develop` at `6ada4e6185`
+Branch: `fix/12903-app-example-scripts`
+
+## Scope
+
+- `packages/examples/app/capacitor/backend`
+- `packages/examples/app/capacitor/frontend`
+- `packages/examples/app/electron/backend`
+- `packages/examples/app/electron/frontend`
+
+This final examples slice removes empty backend test passes, replaces the
+Capacitor backend's `build: bun run typecheck` alias with a real Bun build, adds
+backend smoke tests, and adds missing `lint:check`, `format`, and read-only
+`format:check` scripts to the app subpackages.
+
+No app UI source was changed.
+
+## Validation
+
+Commands run from a fresh sparse worktree based on current `origin/develop`:
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+Inline script-contract audit over the edited package manifests:
+
+```text
+packages/examples/app/capacitor/backend/package.json: ok
+packages/examples/app/capacitor/frontend/package.json: ok
+packages/examples/app/electron/backend/package.json: ok
+packages/examples/app/electron/frontend/package.json: ok
+```
+
+Package-local checks and tests:
+
+```bash
+bun run --cwd packages/examples/app/capacitor/backend lint:check
+bun run --cwd packages/examples/app/capacitor/backend format:check
+bun run --cwd packages/examples/app/capacitor/backend test
+bun run --cwd packages/examples/app/capacitor/frontend lint:check
+bun run --cwd packages/examples/app/capacitor/frontend format:check
+bun run --cwd packages/examples/app/capacitor/frontend test
+bun run --cwd packages/examples/app/electron/backend lint:check
+bun run --cwd packages/examples/app/electron/backend format:check
+bun run --cwd packages/examples/app/electron/backend test
+bun run --cwd packages/examples/app/electron/frontend lint:check
+bun run --cwd packages/examples/app/electron/frontend format:check
+bun run --cwd packages/examples/app/electron/frontend test
+```
+
+Result: all passed.
+
+Build check:
+
+```bash
+bun run --cwd packages/examples/app/capacitor/backend build
+```
+
+Result: passed; Bun bundled `src/server.ts` and emitted `server.js`.
+
+Parent workspace smoke tests:
+
+```bash
+bun run --cwd packages/examples/app/capacitor test
+bun run --cwd packages/examples/app/electron test
+```
+
+Result:
+
+- Capacitor app workspace: 6 passing Bun tests across parent, backend, and frontend smoke files.
+- Electron app workspace: 6 passing Bun tests across parent, backend, and frontend smoke files.
+
+Full examples audit after this slice:
+
+```text
+packages=47 issues=0
+```
+
+Full #12903 scoped audit after this slice:
+
+```text
+packages=68 issues=0
+```

--- a/packages/examples/app/capacitor/backend/package.json
+++ b/packages/examples/app/capacitor/backend/package.json
@@ -5,10 +5,13 @@
   "scripts": {
     "dev": "bun --watch run src/server.ts",
     "start": "bun run src/server.ts",
-    "test": "vitest run --passWithNoTests",
+    "test": "bun test smoke.test.js",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
     "typecheck": "tsc --noEmit",
-    "build": "bun run typecheck"
+    "build": "bun build src/server.ts --outdir=dist --target=bun --format=esm --packages=external",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/packages/examples/app/capacitor/backend/smoke.test.js
+++ b/packages/examples/app/capacitor/backend/smoke.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = import.meta.dir;
+const read = (path) => readFileSync(join(root, path), "utf8");
+
+describe("Capacitor backend package", () => {
+  test("declares real package scripts without empty test or typecheck build aliases", () => {
+    const pkg = JSON.parse(read("package.json"));
+
+    expect(pkg.scripts.test).toBe("bun test smoke.test.js");
+    expect(pkg.scripts.test).not.toContain("--passWithNoTests");
+    expect(pkg.scripts.build).toContain("bun build src/server.ts");
+    expect(pkg.scripts.build).not.toContain("typecheck");
+    expect(pkg.scripts["lint:check"]).toContain("biome check");
+    expect(pkg.scripts["format:check"]).toContain("biome format");
+  });
+
+  test("exposes the HTTP chat endpoints used by the Capacitor frontend", () => {
+    const server = read("src/server.ts");
+
+    expect(server).toContain('url === "/health"');
+    expect(server).toContain('url === "/greeting"');
+    expect(server).toContain('url === "/history"');
+    expect(server).toContain('url === "/reset"');
+    expect(server).toContain('url === "/chat"');
+    expect(server).toContain("Missing 'text' in request body");
+    expect(server).toContain("Access-Control-Allow-Origin");
+  });
+});

--- a/packages/examples/app/capacitor/frontend/package.json
+++ b/packages/examples/app/capacitor/frontend/package.json
@@ -8,7 +8,10 @@
     "preview": "bun --bun vite preview",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
-    "lint": "bunx @biomejs/biome check --write --unsafe ."
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "react": "19.2.3",

--- a/packages/examples/app/electron/backend/package.json
+++ b/packages/examples/app/electron/backend/package.json
@@ -8,9 +8,12 @@
     "copy-renderer": "node -e \"import('node:fs/promises').then(async fs=>{const {cp,rm,mkdir}=fs;await rm('renderer',{recursive:true,force:true});await mkdir('renderer',{recursive:true});await cp('../frontend/dist','renderer',{recursive:true});})\"",
     "start": "bun run build && bun run copy-renderer && electron .",
     "dev": "bun run build && ELECTRON_RENDERER_URL=http://localhost:5177 electron .",
-    "test": "vitest run --passWithNoTests",
+    "test": "bun test smoke.test.js",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "typecheck": "tsc --noEmit"
+    "lint:check": "bunx @biomejs/biome check .",
+    "typecheck": "tsc --noEmit",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",

--- a/packages/examples/app/electron/backend/smoke.test.js
+++ b/packages/examples/app/electron/backend/smoke.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = import.meta.dir;
+const read = (path) => readFileSync(join(root, path), "utf8");
+
+describe("Electron backend package", () => {
+  test("declares real package scripts without empty test passes", () => {
+    const pkg = JSON.parse(read("package.json"));
+
+    expect(pkg.scripts.test).toBe("bun test smoke.test.js");
+    expect(pkg.scripts.test).not.toContain("--passWithNoTests");
+    expect(pkg.scripts.build).toContain("tsc --noCheck");
+    expect(pkg.scripts["lint:check"]).toContain("biome check");
+    expect(pkg.scripts["format:check"]).toContain("biome format");
+  });
+
+  test("keeps the main process wired through a narrow preload IPC bridge", () => {
+    const main = read("src/main.ts");
+    const preload = read("src/preload.ts");
+    const ipc = read("src/ipc.ts");
+
+    expect(main).toContain("registerChatIpc()");
+    expect(main).toContain("contextIsolation: true");
+    expect(main).toContain("nodeIntegration: false");
+    expect(preload).toContain('exposeInMainWorld("elizaChat"');
+    expect(ipc).toContain('ipcMain.handle("chat:getGreeting"');
+    expect(ipc).toContain('"chat:sendMessage"');
+    expect(ipc).toContain('throw new Error("Missing text")');
+  });
+});

--- a/packages/examples/app/electron/frontend/package.json
+++ b/packages/examples/app/electron/frontend/package.json
@@ -8,7 +8,10 @@
     "preview": "bun --bun vite preview",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
-    "lint": "bunx @biomejs/biome check --write --unsafe ."
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
     "react": "19.2.3",


### PR DESCRIPTION
## Summary

- replace app backend `vitest --passWithNoTests` scripts with real Bun smoke tests
- replace Capacitor backend `build: bun run typecheck` with a real Bun build
- add missing `lint:check`, `format`, and `format:check` scripts to the app subexample packages
- add evidence at `.github/issue-evidence/12903-app-example-scripts.md`

## Evidence

- `git diff --check`
- static package-script audit over edited app subpackages
- `lint:check`, `format:check`, and `test` for all four edited subpackages
- `bun run --cwd packages/examples/app/capacitor/backend build`
- `bun run --cwd packages/examples/app/capacitor test` (6 passing Bun tests)
- `bun run --cwd packages/examples/app/electron test` (6 passing Bun tests)
- full examples audit: `packages=47 issues=0`
- full #12903 scoped audit: `packages=68 issues=0`

Fixes #12903.
