### PR TITLE
fix(#12903): add example build clean scripts

### DIFF
--- a/.github/issue-evidence/12903-example-build-clean-verbs.md
+++ b/.github/issue-evidence/12903-example-build-clean-verbs.md
@@ -1,0 +1,33 @@
+# Issue #12903 example build clean evidence
+
+Date: 2026-07-04
+
+Scope:
+- `packages/examples/cloud/clone-ur-crush/package.json`
+- `packages/examples/cloud/edad/package.json`
+- `packages/examples/cloud/x402-image-gen/package.json`
+- `packages/examples/farcaster-miniapp/package.json`
+- `packages/examples/react/package.json`
+- `packages/examples/trader/package.json`
+
+Changes:
+- Added explicit `clean` scripts for examples with real build artifacts.
+- Bun server examples clean `dist`.
+- Vite examples clean `dist`.
+- `clone-ur-crush` cleans the custom Next build output `.next`, temporary `.next-build-*` directories, and `tsconfig.tsbuildinfo`.
+
+Verification:
+- `node -e` parsed all six edited `package.json` files successfully.
+- Static #12903 guard confirmed all six edited packages no longer report `build without clean`.
+- Ran all six new clean scripts successfully:
+  - `bun run --cwd packages/examples/cloud/clone-ur-crush clean`
+  - `bun run --cwd packages/examples/cloud/edad clean`
+  - `bun run --cwd packages/examples/cloud/x402-image-gen clean`
+  - `bun run --cwd packages/examples/farcaster-miniapp clean`
+  - `bun run --cwd packages/examples/react clean`
+  - `bun run --cwd packages/examples/trader clean`
+- `git diff --check` passed.
+
+Environment limitation:
+- Full build execution was not run in this worktree because the local checkout is intentionally using a partial/shared install under low disk space, and this host is on Node v23.3.0 while the repository requires Node 24.
+- This slice only changes package-manager script metadata; no runtime code or UI files changed, so screenshots/video are N/A.

--- a/packages/examples/cloud/clone-ur-crush/package.json
+++ b/packages/examples/cloud/clone-ur-crush/package.json
@@ -8,6 +8,7 @@
     "typecheck": "tsgo --noEmit",
     "test": "bun run typecheck",
     "build": "node ../../../scripts/with-package-build-lock.mjs packages/examples/cloud/clone-ur-crush -- node scripts/build.mjs",
+    "clean": "rm -rf .next .next-build-* tsconfig.tsbuildinfo",
     "start": "next start --port 3012",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",

--- a/packages/examples/cloud/edad/package.json
+++ b/packages/examples/cloud/edad/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsgo --noEmit",
     "test": "bun run test.ts",
     "build": "bun build server.ts --outdir=dist --target=bun --format=esm",
+    "clean": "rm -rf dist",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format ."
   },

--- a/packages/examples/cloud/x402-image-gen/package.json
+++ b/packages/examples/cloud/x402-image-gen/package.json
@@ -8,6 +8,7 @@
     "typecheck": "tsgo --noEmit",
     "test": "bun run test.ts",
     "build": "bun build server.ts --outdir=dist --target=bun --format=esm",
+    "clean": "rm -rf dist",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format ."
   },

--- a/packages/examples/farcaster-miniapp/package.json
+++ b/packages/examples/farcaster-miniapp/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "bun --bun vite",
     "build": "tsc && bun --bun vite build",
+    "clean": "rm -rf dist",
     "preview": "bun --bun vite preview",
     "start": "node server.js",
     "test": "bun test",

--- a/packages/examples/react/package.json
+++ b/packages/examples/react/package.json
@@ -7,6 +7,7 @@
     "dev": "bun --bun vite",
     "prebuild": "node scripts/copy-pglite-assets.mjs",
     "build": "tsc && bun --bun vite build",
+    "clean": "rm -rf dist",
     "prepreview": "node scripts/copy-pglite-assets.mjs",
     "preview": "bun --bun vite preview",
     "test": "bun test",

--- a/packages/examples/trader/package.json
+++ b/packages/examples/trader/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "bun --bun vite",
     "build": "tsc && bun --bun vite build",
+    "clean": "rm -rf dist",
     "preview": "bun --bun vite preview",
     "test": "bun test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",


### PR DESCRIPTION
## Summary
- add explicit `clean` scripts for build-emitting cloud/Vite examples
- clean `dist` for Bun server and Vite examples
- clean `.next`, temp `.next-build-*`, and `tsconfig.tsbuildinfo` for the custom clone-ur-crush Next build
- add evidence for this #12903 slice

## Evidence
- `.github/issue-evidence/12903-example-build-clean-verbs.md`
- `node -e` JSON parse for edited package manifests: passed
- static #12903 guard for edited packages: passed
- all six new `clean` scripts: passed
- `git diff --check origin/develop..HEAD`: passed

## Screenshots / video
N/A: script metadata only; no runtime UI changed.

Fixes part of #12903.
