### PR TITLE
fix(#12903): add app example clean scripts

### DIFF
--- a/.github/issue-evidence/12903-app-example-clean-verbs.md
+++ b/.github/issue-evidence/12903-app-example-clean-verbs.md
@@ -1,0 +1,25 @@
+# Issue #12903 app example clean evidence
+
+Date: 2026-07-04
+
+Scope:
+- `packages/examples/app/capacitor/backend/package.json`
+- `packages/examples/app/capacitor/frontend/package.json`
+- `packages/examples/app/electron/backend/package.json`
+- `packages/examples/app/electron/frontend/package.json`
+
+Changes:
+- Added explicit `clean` scripts for remaining app example packages with real build artifacts.
+- Capacitor backend cleans `dist`.
+- Capacitor and Electron Vite frontends clean `dist`.
+- Electron backend cleans TypeScript output `dist` and copied renderer output `renderer`.
+
+Verification:
+- `node -e` parsed all four edited `package.json` files successfully.
+- Static #12903 guard confirmed all four edited packages no longer report `build without clean`.
+- Ran all four new clean scripts successfully.
+- `git diff --check` passed.
+
+Environment limitation:
+- Full build execution was not run in this worktree because the local checkout is intentionally using a partial/shared install under low disk space, and this host is on Node v23.3.0 while the repository requires Node 24.
+- This slice only changes package-manager script metadata; no runtime code or UI files changed, so screenshots/video are N/A.

--- a/packages/examples/app/capacitor/backend/package.json
+++ b/packages/examples/app/capacitor/backend/package.json
@@ -10,6 +10,7 @@
     "lint:check": "bunx @biomejs/biome check .",
     "typecheck": "tsc --noEmit",
     "build": "bun build src/server.ts --outdir=dist --target=bun --format=esm --packages=external",
+    "clean": "rm -rf dist",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format ."
   },

--- a/packages/examples/app/capacitor/frontend/package.json
+++ b/packages/examples/app/capacitor/frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "bun --bun vite",
     "build": "tsc && bun --bun vite build",
+    "clean": "rm -rf dist",
     "preview": "bun --bun vite preview",
     "test": "bun test",
     "typecheck": "tsc --noEmit",

--- a/packages/examples/app/electron/backend/package.json
+++ b/packages/examples/app/electron/backend/package.json
@@ -5,6 +5,7 @@
   "main": "dist/main.js",
   "scripts": {
     "build": "tsc --noCheck -p tsconfig.json",
+    "clean": "rm -rf dist renderer",
     "copy-renderer": "node -e \"import('node:fs/promises').then(async fs=>{const {cp,rm,mkdir}=fs;await rm('renderer',{recursive:true,force:true});await mkdir('renderer',{recursive:true});await cp('../frontend/dist','renderer',{recursive:true});})\"",
     "start": "bun run build && bun run copy-renderer && electron .",
     "dev": "bun run build && ELECTRON_RENDERER_URL=http://localhost:5177 electron .",

--- a/packages/examples/app/electron/frontend/package.json
+++ b/packages/examples/app/electron/frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "bun --bun vite",
     "build": "tsc && bun --bun vite build",
+    "clean": "rm -rf dist",
     "preview": "bun --bun vite preview",
     "test": "bun test",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- add explicit `clean` scripts for remaining app example build artifacts
- clean `dist` for Capacitor backend/frontend and Electron frontend
- clean `dist` plus copied `renderer` output for Electron backend
- add evidence for this #12903 slice

## Evidence
- `.github/issue-evidence/12903-app-example-clean-verbs.md`
- `node -e` JSON parse for edited package manifests: passed
- static #12903 guard for edited packages: passed
- all four new `clean` scripts: passed
- `git diff --check origin/develop..HEAD`: passed

## Screenshots / video
N/A: script metadata only; no runtime UI changed.

Fixes part of #12903.
