### PR TITLE
fix(#12940): dedupe discord outbound message memories

### DIFF
--- a/.github/issue-evidence/12940-discord-outbound-memory-dedupe.md
+++ b/.github/issue-evidence/12940-discord-outbound-memory-dedupe.md
@@ -1,0 +1,72 @@
+# #12940 Discord outbound message memory dedupe
+
+Date: 2026-07-04
+Base: `origin/develop` at `1a5c37bc02`
+Branch: `fix/12940-discord-outbound-memory-dedupe`
+
+## Scope
+
+- `plugins/plugin-discord/messages.ts`
+- `plugins/plugin-discord/service.ts`
+- `plugins/plugin-discord/__tests__/messages-url.test.ts`
+
+This slice addresses #12940 finding 10's suspected duplicate bot-message rows by
+making Discord connector-side message-memory persistence idempotent. Discord
+already derives response memory ids from the platform message id via
+`createUniqueUuid(runtime, sentMessage.id)`. The new helper checks
+`runtime.getMemoryById(memory.id)` before writing and skips connector-side
+`createMemory` when core or another Discord send path already persisted that
+deterministic id.
+
+The guard is used for:
+
+- normal Discord response callbacks,
+- connector send/draft paths,
+- existing inbound persistence, preserving its previous no-id no-op behavior.
+
+## Validation
+
+Commands run from a fresh sparse worktree based on current `origin/develop`:
+
+```bash
+bunx @biomejs/biome check \
+  plugins/plugin-discord/messages.ts \
+  plugins/plugin-discord/service.ts \
+  plugins/plugin-discord/__tests__/messages-url.test.ts
+```
+
+Result: passed.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+Focused unit test added:
+
+```text
+plugins/plugin-discord/__tests__/messages-url.test.ts
+  createDiscordMessageMemoryOnce
+    - skips connector-side persistence when the deterministic memory id already exists
+    - creates the message memory when no existing id is found
+```
+
+Sparse-worktree blockers:
+
+- `bun run --cwd plugins/plugin-discord test -- __tests__/messages-url.test.ts`
+  initially failed before loading tests because `discord.js` was absent from the
+  sparse dependency graph.
+- After installing external Discord/Vitest packages in a temporary dependency
+  directory, the test then failed before loading tests because `@elizaos/core`
+  package exports require a built core entry.
+- Attempting `bun run --cwd packages/core build` in the sparse checkout reached
+  unresolved transitive dependencies such as `@elizaos/prompts`, `handlebars`,
+  `uuid`, `drizzle-orm`, and logger dependencies.
+- `bun run --cwd plugins/plugin-discord typecheck` failed before TypeScript
+  analysis because `tsgo` was absent from the sparse dependency graph.
+
+No live Discord run was captured for this narrow persistence guard. The live
+symptom in #12940 already identified duplicate bot rows with the same Discord
+platform message identity; this PR adds the deterministic-id guard and focused
+unit coverage for the duplicate-write path.

--- a/plugins/plugin-discord/__tests__/messages-url.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-url.test.ts
@@ -12,6 +12,7 @@ import {
 import type { Message as DiscordMessage } from "discord.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+	createDiscordMessageMemoryOnce,
 	hasActiveTaskAgentWorkForMessage,
 	MessageManager,
 	shouldSuppressTimeoutForInFlightDispatchForTests,
@@ -231,5 +232,69 @@ describe("shouldSuppressTimeoutForInFlightDispatchForTests", () => {
 				responseDispatchInFlight: false,
 			}),
 		).toBe(false);
+	});
+});
+
+describe("createDiscordMessageMemoryOnce", () => {
+	const message = {
+		id: "22222222-2222-4222-8222-222222222222",
+		entityId: "11111111-1111-1111-1111-111111111111",
+		agentId: "11111111-1111-1111-1111-111111111111",
+		roomId: "33333333-3333-4333-8333-333333333333",
+		content: { text: "already sent", source: "discord" },
+	} as Memory;
+
+	it("skips connector-side persistence when the deterministic memory id already exists", async () => {
+		const existing = { ...message, content: { text: "persisted" } };
+		const createMemory = vi.fn();
+		const testRuntime = {
+			agentId: message.agentId,
+			createMemory,
+			getMemoryById: vi.fn(async () => existing),
+			logger: {
+				debug: vi.fn(),
+				error: vi.fn(),
+				info: vi.fn(),
+				warn: vi.fn(),
+			},
+		} as unknown as IAgentRuntime;
+
+		const result = await createDiscordMessageMemoryOnce(testRuntime, message, {
+			operation: "test",
+			platformMessageId: "discord-message-1",
+		});
+
+		expect(result).toBe(existing);
+		expect(createMemory).not.toHaveBeenCalled();
+		expect(testRuntime.logger.debug).toHaveBeenCalledWith(
+			expect.objectContaining({
+				messageId: "discord-message-1",
+				memoryId: message.id,
+				operation: "test",
+			}),
+			"Skipping duplicate Discord message memory",
+		);
+	});
+
+	it("creates the message memory when no existing id is found", async () => {
+		const createMemory = vi.fn(async () => message.id);
+		const testRuntime = {
+			agentId: message.agentId,
+			createMemory,
+			getMemoryById: vi.fn(async () => null),
+			logger: {
+				debug: vi.fn(),
+				error: vi.fn(),
+				info: vi.fn(),
+				warn: vi.fn(),
+			},
+		} as unknown as IAgentRuntime;
+
+		const result = await createDiscordMessageMemoryOnce(testRuntime, message, {
+			operation: "test",
+		});
+
+		expect(result).toBe(message);
+		expect(createMemory).toHaveBeenCalledWith(message, "messages");
 	});
 });

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -243,6 +243,41 @@ export function shouldSuppressTimeoutForInFlightDispatchForTests({
 	return generationTimedOut && responseDispatchInFlight;
 }
 
+export async function createDiscordMessageMemoryOnce(
+	runtime: Pick<
+		IAgentRuntime,
+		"agentId" | "createMemory" | "getMemoryById" | "logger"
+	>,
+	memory: Memory,
+	context: {
+		operation: string;
+		platformMessageId?: string;
+	} = { operation: "discord-message-persist" },
+): Promise<Memory | null> {
+	if (!memory.id) {
+		const id = await runtime.createMemory(memory, "messages");
+		return { ...memory, id };
+	}
+
+	const existing = await runtime.getMemoryById(memory.id);
+	if (existing) {
+		runtime.logger.debug(
+			{
+				src: "plugin:discord",
+				agentId: runtime.agentId,
+				memoryId: memory.id,
+				messageId: context.platformMessageId,
+				operation: context.operation,
+			},
+			"Skipping duplicate Discord message memory",
+		);
+		return existing;
+	}
+
+	await runtime.createMemory(memory, "messages");
+	return memory;
+}
+
 /**
  * Class representing a Message Manager for handling Discord messages.
  */
@@ -422,12 +457,9 @@ export class MessageManager {
 			return;
 		}
 
-		const existing = await this.runtime.getMemoryById(memory.id);
-		if (existing) {
-			return;
-		}
-
-		await this.runtime.createMemory(memory, "messages");
+		await createDiscordMessageMemoryOnce(this.runtime, memory, {
+			operation: "discord-inbound",
+		});
 	}
 
 	private markMessageAsProcessing(messageId: string): boolean {
@@ -1179,6 +1211,7 @@ export class MessageManager {
 							metadata: {
 								type: MemoryType.MESSAGE,
 								accountId: this.accountId,
+								platformMessageId: m.id,
 							},
 							createdAt: m.createdTimestamp,
 						};
@@ -1186,7 +1219,13 @@ export class MessageManager {
 					}
 
 					for (const m of memories) {
-						await this.runtime.createMemory(m, "messages");
+						await createDiscordMessageMemoryOnce(this.runtime, m, {
+							operation: "discord-response-callback",
+							platformMessageId:
+								typeof m.metadata?.platformMessageId === "string"
+									? m.metadata.platformMessageId
+									: undefined,
+						});
 					}
 
 					if (memories.length > 0) {

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -141,7 +141,7 @@ import {
 	resolveDiscordRuntimeEntityId,
 	resolveElizaOwnerEntityId,
 } from "./identity";
-import { MessageManager } from "./messages";
+import { createDiscordMessageMemoryOnce, MessageManager } from "./messages";
 import type {
 	BuildMemoryFromMessageOptions,
 	ChannelHistoryOptions,
@@ -1815,7 +1815,10 @@ export class DiscordService extends Service implements IDiscordService {
 								createdAt: sentMsg.createdTimestamp || Date.now(),
 							};
 
-							await runtime.createMemory(memory, "messages");
+							await createDiscordMessageMemoryOnce(runtime, memory, {
+								operation: "discord-connector-send",
+								platformMessageId: sentMsg.id,
+							});
 							lastPersistedMemory = memory;
 							runtime.logger.debug(
 								{


### PR DESCRIPTION
## Summary

- add an idempotent Discord message-memory persistence helper keyed by deterministic memory id
- use it for Discord response callbacks and connector send/draft persistence so already-saved platform messages are not written again
- preserve inbound no-id behavior while routing inbound duplicate checks through the same helper
- add focused unit coverage for skip-vs-create behavior
- add evidence at `.github/issue-evidence/12940-discord-outbound-memory-dedupe.md`

## Evidence

- `bunx @biomejs/biome check plugins/plugin-discord/messages.ts plugins/plugin-discord/service.ts plugins/plugin-discord/__tests__/messages-url.test.ts`
- `git diff --check`

Sparse validation blockers documented in the evidence file:

- focused Discord test could not load in this sparse checkout because `discord.js` and then built `@elizaos/core` exports were unavailable
- core build in the sparse checkout then hit missing transitive dependencies (`@elizaos/prompts`, `handlebars`, `uuid`, `drizzle-orm`, logger deps, etc.)
- plugin-discord typecheck could not start because `tsgo` is absent from the sparse dependency graph

Fixes #12940 finding 10.
