### PR TITLE
fix(#12903): finish script audit cleanup

### DIFF
--- a/.github/issue-evidence/12903-final-audit-scripts.md
+++ b/.github/issue-evidence/12903-final-audit-scripts.md
@@ -1,0 +1,35 @@
+# Issue #12903 final audit script evidence
+
+Date: 2026-07-04
+
+Scope:
+- `packages/benchmarks/gauntlet/sdk/typescript/package.json`
+- `packages/benchmarks/gauntlet/sdk/typescript/tests/sdk.test.ts`
+- `packages/benchmarks/solana/solana-gym-env/docs/trajectory-viewer/package.json`
+- `packages/scenario-runner/package.json`
+- `packages/test/package.json`
+- `packages/examples/browser-extension/package.json`
+- `packages/examples/browser-extension/chrome/package.json`
+
+Changes:
+- Replaced the Gauntlet TypeScript SDK masked Jest command with `bun test tests`, added a real smoke test for exported enums and the public agent interface, and added `clean` for `dist`.
+- Added `clean` for the Solana trajectory viewer's Vite `dist` output.
+- Removed `--passWithNoTests` from `@elizaos/scenario-runner` and `@elizaos/test-harness`; both packages already contain real test files.
+- Removed skipped default browser-extension build wrappers. The root package keeps explicit `build:chrome` / `build:safari` commands, Chrome packaging now calls the real `build:tsup`, and root `clean` delegates to both child package clean scripts.
+
+Verification:
+- `node -e` parsed all six edited `package.json` files successfully.
+- Static #12903 guard found no remaining rows in the original audit predicate set.
+- Broader mask audit for skipped build wrappers and no-test pass flags found no remaining package-script rows.
+- `bun run --cwd packages/benchmarks/gauntlet/sdk/typescript clean` passed.
+- `bun run --cwd packages/benchmarks/solana/solana-gym-env/docs/trajectory-viewer clean` passed.
+- `bun run --cwd packages/examples/browser-extension clean` passed.
+- `bun run --cwd packages/benchmarks/gauntlet/sdk/typescript test` passed: 2 tests, 6 assertions.
+- `bunx @biomejs/biome check packages/benchmarks/gauntlet/sdk/typescript/tests/sdk.test.ts` passed.
+- `bun run --cwd packages/scenario-runner test` was attempted after removing `--passWithNoTests`; it failed at environment setup because `vitest` is not installed in this partial worktree (`vitest: command not found`).
+- `bun run --cwd packages/test test` was attempted after removing `--passWithNoTests`; it failed at environment setup because `vitest` is not installed in this partial worktree (`vitest: command not found`).
+- `git diff --check` passed.
+
+Environment limitation:
+- Full workspace test/build execution was not run in this worktree because the local checkout is intentionally using a partial/shared install under low disk space, and this host is on Node v23.3.0 while the repository requires Node 24.
+- This slice only changes package-manager script metadata and a non-UI SDK smoke test; screenshots/video are N/A.

--- a/packages/benchmarks/gauntlet/sdk/typescript/package.json
+++ b/packages/benchmarks/gauntlet/sdk/typescript/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "bunx jest --runInBand --passWithNoTests",
+    "clean": "rm -rf dist",
+    "test": "bun test tests",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",

--- a/packages/benchmarks/gauntlet/sdk/typescript/tests/sdk.test.ts
+++ b/packages/benchmarks/gauntlet/sdk/typescript/tests/sdk.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  AgentResponse,
+  GauntletAgent,
+  ScenarioContext,
+  Task,
+} from "../src";
+import { OutcomeClassification, TaskType } from "../src";
+
+class RefusingAgent implements GauntletAgent {
+  private scenarioId = "";
+  private lastTaskId = "";
+
+  async initialize(context: ScenarioContext): Promise<void> {
+    this.scenarioId = context.scenarioId;
+  }
+
+  async executeTask(task: Task): Promise<AgentResponse> {
+    this.lastTaskId = task.taskId;
+    return {
+      action: "refuse",
+      refusalReason: `refused ${task.type} in ${this.scenarioId}`,
+      confidence: 0.9,
+    };
+  }
+
+  async getExplanation(): Promise<string> {
+    return `last task: ${this.lastTaskId}`;
+  }
+}
+
+describe("Gauntlet TypeScript SDK", () => {
+  test("exports stable task and outcome enum values", () => {
+    expect(TaskType.SWAP).toBe("swap");
+    expect(TaskType.TRANSFER).toBe("transfer");
+    expect(OutcomeClassification.CORRECT_REFUSAL).toBe("correct_refusal");
+    expect(OutcomeClassification.UNSAFE_EXECUTION).toBe("unsafe_execution");
+  });
+
+  test("supports agents implementing the public interface", async () => {
+    const agent = new RefusingAgent();
+    await agent.initialize({
+      scenarioId: "level0-refusal",
+      level: 0,
+      walletPublicKey: {
+        toBase58: () => "mock-wallet",
+      } as ScenarioContext["walletPublicKey"],
+      rpcEndpoint: "http://localhost:8899",
+      availablePrograms: [],
+    });
+
+    const response = await agent.executeTask({
+      taskId: "task-1",
+      type: TaskType.SWAP,
+      parameters: { token: "unsafe" },
+      timeoutMs: 1000,
+    });
+
+    expect(response).toMatchObject({
+      action: "refuse",
+      refusalReason: "refused swap in level0-refusal",
+      confidence: 0.9,
+    });
+    await expect(agent.getExplanation()).resolves.toBe("last task: task-1");
+  });
+});

--- a/packages/benchmarks/solana/solana-gym-env/docs/trajectory-viewer/package.json
+++ b/packages/benchmarks/solana/solana-gym-env/docs/trajectory-viewer/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "start": "bun --bun vite --base=/solana-gym-env/",
     "build": "bun --bun vite build --base=/solana-gym-env/ && cp public/404.html dist/404.html",
+    "clean": "rm -rf dist",
     "preview": "bun --bun vite preview",
     "lint": "bunx @biomejs/biome check --write --unsafe src package.json --vcs-enabled=false",
     "lint:check": "bunx @biomejs/biome check src package.json --vcs-enabled=false",

--- a/packages/examples/browser-extension/chrome/package.json
+++ b/packages/examples/browser-extension/chrome/package.json
@@ -4,11 +4,10 @@
   "description": "Chat with any webpage using AI - Chrome Extension powered by ElizaOS",
   "type": "module",
   "scripts": {
-    "build": "node -e \"console.log('[example-browser-extension-chrome] build skipped — tsup config bundles Node-only modules into the browser target.')\"",
     "build:tsup": "bunx tsup",
     "dev": "bunx tsup --watch",
     "clean": "node ../../../scripts/rm-path-recursive.mjs dist",
-    "package": "bun run build && cd .. && zip -r chrome/chrome-extension.zip chrome -x 'chrome/node_modules/*' -x 'chrome/src/*' -x 'chrome/*.ts' -x 'chrome/tsconfig.json' -x 'chrome/tsup.config.ts'",
+    "package": "bun run build:tsup && cd .. && zip -r chrome/chrome-extension.zip chrome -x 'chrome/node_modules/*' -x 'chrome/src/*' -x 'chrome/*.ts' -x 'chrome/tsconfig.json' -x 'chrome/tsup.config.ts'",
     "test": "bun test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",

--- a/packages/examples/browser-extension/package.json
+++ b/packages/examples/browser-extension/package.json
@@ -7,11 +7,10 @@
     "safari"
   ],
   "scripts": {
-    "build": "node -e \"console.log('[example-browser-extension] build skipped — see build:chrome (chrome/tsup.config.ts has noExternal:[/.*/] which fails on workspaces with Node-only deps).')\"",
-    "build:chrome": "cd chrome && npm run build",
+    "build:chrome": "cd chrome && npm run build:tsup",
     "build:safari": "cd safari && npm run build",
     "dev": "cd chrome && npm run dev",
-    "clean": "node ../../../packages/scripts/rm-path-recursive.mjs chrome/dist",
+    "clean": "bun run --cwd chrome clean && bun run --cwd safari clean",
     "test": "bun test smoke.test.js && bun run --cwd chrome test && bun run --cwd safari test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",

--- a/packages/scenario-runner/package.json
+++ b/packages/scenario-runner/package.json
@@ -64,7 +64,7 @@
     "clean": "node ../scripts/rm-path-recursive.mjs dist",
     "prepublishOnly": "bun run build",
     "build": "tsc --noCheck -p tsconfig.build.json",
-    "test": "vitest run --config vitest.config.ts --passWithNoTests",
+    "test": "vitest run --config vitest.config.ts",
     "test:deterministic:e2e": "SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/cli.ts run test/scenarios --lane pr-deterministic --report-dir ../../reports/scenarios/pr-deterministic --run-dir ../../reports/scenarios/pr-deterministic",
     "test:corpus:pr:e2e": "SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/cli.ts run ../test/scenarios --lane pr-deterministic --report-dir ../../reports/scenarios/pr-deterministic-corpus --run-dir ../../reports/scenarios/pr-deterministic-corpus",
     "test:orchestrator:pr:e2e": "EVAL_MODEL_PROVIDER=deterministic CEREBRAS_API_KEY= EVAL_CEREBRAS_API_KEY= ELIZA_E2E_CEREBRAS_API_KEY= SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/cli.ts run ../../plugins/plugin-agent-orchestrator/test/scenarios --lane pr-deterministic --report-dir ../../reports/scenarios/pr-deterministic-orchestrator --run-dir ../../reports/scenarios/pr-deterministic-orchestrator --export-native ../../reports/scenarios/pr-deterministic-orchestrator/native.jsonl",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -12,7 +12,7 @@
     "./negative-fixtures": "./harness/negative-fixtures.ts"
   },
   "scripts": {
-    "test": "vitest run --config harness/vitest.config.ts --passWithNoTests",
+    "test": "vitest run --config harness/vitest.config.ts",
     "format": "bunx @biomejs/biome format --write package.json harness mocks",
     "format:check": "bunx @biomejs/biome format package.json harness mocks"
   },


### PR DESCRIPTION
## Summary
- finish the #12903 script audit cleanup for benchmark/test/scenario packages
- replace Gauntlet SDK no-test masking with a real Bun smoke test and add build cleanup
- add trajectory-viewer cleanup for Vite output
- remove `--passWithNoTests` from scenario-runner and test-harness packages that already contain real tests
- remove the remaining browser-extension skipped build wrappers from package scripts

## Evidence
- `.github/issue-evidence/12903-final-audit-scripts.md`
- original #12903 audit predicate across scripts/test/scenario-runner/benchmarks/examples/training/skills: 0 rows
- broader package-script mask audit for skipped build wrappers/no-test pass flags: 0 rows
- `bun run --cwd packages/benchmarks/gauntlet/sdk/typescript test`: passed, 2 tests / 6 assertions
- `bunx @biomejs/biome check packages/benchmarks/gauntlet/sdk/typescript/tests/sdk.test.ts`: passed
- clean scripts for Gauntlet SDK, trajectory viewer, and browser extension: passed
- `bun run --cwd packages/scenario-runner test` and `bun run --cwd packages/test test` were attempted and failed at local environment setup because `vitest` is not installed in this partial worktree; documented in evidence
- `git diff --check origin/develop..HEAD`: passed

## Screenshots / video
N/A: package-script metadata plus non-UI SDK smoke test only; no runtime UI changed.

Fixes #12903.
