### PR TITLE
fix(#12893): add phone channel mute controls

### DIFF
--- a/.github/issue-evidence/12893-phone-ui-mute-toggle.md
+++ b/.github/issue-evidence/12893-phone-ui-mute-toggle.md
@@ -1,0 +1,20 @@
+# Issue 12893 — phone UI mute toggle
+
+## Summary
+
+- Added `muted` / `mutedScope` to `/api/inbox/chats` rows by resolving the same effective room/server mute state used by inbound message gating.
+- Added `POST /api/inbox/chats/mute` for deterministic UI writes to room mute, server mute, and timed mute state.
+- Added channel and server mute controls to the shared conversations sidebar used by the phone/mobile chat drawer.
+- Preserved mute state in the conversations sidebar model and added a focused model test.
+
+## Validation
+
+- `bunx @biomejs/biome check packages/agent/src/api/inbox-routes.ts packages/ui/src/api/client-chat.ts packages/ui/src/components/conversations/ConversationsSidebar.tsx packages/ui/src/components/conversations/conversation-sidebar-model.ts packages/ui/src/components/conversations/conversation-sidebar-model.test.ts` — passed.
+- `git diff --check` — passed.
+
+## Blocked Validation
+
+- `bun test packages/ui/src/components/conversations/conversation-sidebar-model.test.ts` — blocked in the sparse worktree because `lucide-react` is missing from the symlinked `node_modules`.
+- `bun run --cwd packages/ui typecheck` — blocked by sparse dependency resolution; failures are missing packages such as `lucide-react`, `uuid`, `drizzle-orm`, Capacitor packages, and generated validation data.
+- `bun run --cwd packages/agent typecheck` — blocked by sparse dependency resolution; the local duplicate-core type error was resolved, but remaining failures are missing packages such as `@elizaos/plugin-discord/*`, auth/vault/plugin-sql packages, and unrelated plugin-local-inference type errors from the shared dependency tree.
+- `bun run --cwd packages/app audit:app` — attempted twice. First failed because `plugins/` was absent from sparse checkout. After adding `plugins`, `packages/native`, and `packages/tui`, the audit still failed before Playwright screenshots because view builds could not resolve `@elizaos/capacitor-phone`, `@elizaos/capacitor-messages`, and `@xterm/xterm` from the shared sparse dependency tree.

--- a/packages/agent/src/api/inbox-routes.ts
+++ b/packages/agent/src/api/inbox-routes.ts
@@ -50,6 +50,12 @@ import {
   normalizeConnectorSource,
   PostInboxMessageRequestSchema,
 } from "@elizaos/shared";
+import { z } from "zod";
+import {
+  resolveEffectiveMuteState,
+  setRoomMuteUntil,
+  setWorldMuteState,
+} from "../../../core/src/services/message/mute-state.ts";
 
 let discordModulePromise: Promise<{
   cacheDiscordAvatarUrl: (
@@ -420,6 +426,30 @@ function readRoomChannelId(room: Room | undefined): string | undefined {
     readLooseStringValue(asLooseRecord(room), ["channelId", "channel_id"]) ??
     undefined
   );
+}
+
+function muteUntilIsoFromDuration(
+  durationMinutes: number | undefined,
+): string | undefined {
+  return durationMinutes && durationMinutes > 0
+    ? new Date(Date.now() + durationMinutes * 60_000).toISOString()
+    : undefined;
+}
+
+async function resolveInboxRoomMuteState(
+  runtime: AgentRuntime,
+  room: Room | undefined,
+  roomId: UUID,
+): Promise<Pick<InboxChat, "muted" | "mutedScope">> {
+  const worldId = readRoomWorldId(room);
+  const effective = await resolveEffectiveMuteState(runtime, {
+    roomIds: [roomId],
+    ...(worldId ? { worldId: worldId as UUID } : {}),
+  });
+  if (!effective.muted) {
+    return { muted: false };
+  }
+  return { muted: true, mutedScope: effective.scope };
 }
 
 function readRoomCreatedAt(room: Room | undefined): number | undefined {
@@ -1697,6 +1727,10 @@ interface InboxChat {
    * connector tags rooms.
    */
   roomType?: string;
+  /** Whether the agent is muted in this room, including inherited server mute. */
+  muted: boolean;
+  /** Source of the effective mute when muted. */
+  mutedScope?: "room" | "server";
   /** Display title — contact name for 1:1 chats, group name otherwise. */
   title: string;
   /** Best-effort avatar URL for direct chats when the connector exposes one. */
@@ -1711,6 +1745,18 @@ interface InboxChat {
 
 /** Cap on how many characters of last-message text we return per chat. */
 const INBOX_CHAT_PREVIEW_LENGTH = 140;
+
+const PostInboxChatMuteRequestSchema = z.object({
+  roomId: z.string().trim().min(1),
+  action: z.enum(["mute", "unmute"]),
+  scope: z.enum(["room", "server"]).optional().default("room"),
+  durationMinutes: z
+    .number()
+    .int()
+    .positive()
+    .max(60 * 24 * 30)
+    .optional(),
+});
 
 type DiscordRoomProfile = {
   avatarUrl?: string;
@@ -1859,6 +1905,11 @@ async function loadInboxChats(
     const room = roomById.get(roomIdKey as UUID);
     const worldId = readRoomWorldId(room);
     const world = worldId ? worldsById.get(worldId as UUID) : undefined;
+    const muteState = await resolveInboxRoomMuteState(
+      runtime,
+      room,
+      roomIdKey as UUID,
+    );
     const liveDiscordProfile = isDiscordConnectorSource(entry.source)
       ? await resolveDiscordRoomProfile(
           runtime,
@@ -1965,6 +2016,7 @@ async function loadInboxChats(
       ...(worldId ? { worldId } : {}),
       worldLabel: resolveInboxWorldLabel(room, world),
       ...(roomType ? { roomType } : {}),
+      ...muteState,
       title,
       avatarUrl: isDiscordConnectorSource(entry.source)
         ? await cacheInboxDiscordAvatar(
@@ -2145,6 +2197,98 @@ export async function handleInboxRoute(
       helpers.error(
         res,
         `failed to send inbox reply: ${err instanceof Error ? err.message : String(err)}`,
+        500,
+      );
+    }
+    return true;
+  }
+
+  // ── POST /api/inbox/chats/mute ───────────────────────────────────
+  // Direct UI affordance for the same room/server mute state the ROOM
+  // action writes. Keeps the sidebar toggle deterministic instead of
+  // sending synthetic chat prompts through the planner.
+  if (method === "POST" && pathname === "/api/inbox/chats/mute") {
+    const runtime = state.runtime;
+    if (!runtime) {
+      helpers.error(res, "runtime not ready", 503);
+      return true;
+    }
+
+    const rawBody = await helpers.readJsonBody<Record<string, unknown>>(
+      req,
+      res,
+      { maxBytes: 16 * 1024 },
+    );
+    if (rawBody === null) {
+      return true;
+    }
+    const parsed = PostInboxChatMuteRequestSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      const issuePath = issue?.path.join(".");
+      helpers.error(
+        res,
+        `Invalid request body at ${issuePath}: ${issue?.message}`,
+        400,
+      );
+      return true;
+    }
+
+    const { action, durationMinutes, roomId, scope } = parsed.data;
+    const targetRoomId = roomId as UUID;
+    const room = await runtime.getRoom(targetRoomId);
+    if (!room) {
+      helpers.error(res, "inbox room not found", 404);
+      return true;
+    }
+
+    try {
+      if (scope === "server") {
+        const worldId = readRoomWorldId(room);
+        if (!worldId) {
+          helpers.error(res, "inbox room has no server/world", 400);
+          return true;
+        }
+        const untilIso = muteUntilIsoFromDuration(durationMinutes);
+        await setWorldMuteState(
+          runtime,
+          worldId as UUID,
+          action === "mute" ? { ...(untilIso ? { untilIso } : {}) } : null,
+        );
+      } else {
+        await runtime.updateParticipantUserState(
+          targetRoomId,
+          runtime.agentId,
+          action === "mute" ? "MUTED" : null,
+        );
+        await setRoomMuteUntil(
+          runtime,
+          targetRoomId,
+          action === "mute"
+            ? (muteUntilIsoFromDuration(durationMinutes) ?? null)
+            : null,
+        );
+      }
+
+      const latestRoom = (await runtime.getRoom(targetRoomId)) ?? room;
+      const muteState = await resolveInboxRoomMuteState(
+        runtime,
+        latestRoom,
+        targetRoomId,
+      );
+      helpers.json(res, {
+        ok: true,
+        roomId: targetRoomId,
+        scope,
+        action,
+        ...muteState,
+      });
+    } catch (err) {
+      helpers.error(
+        res,
+        `failed to update inbox mute state: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
         500,
       );
     }

--- a/packages/ui/src/api/client-chat.ts
+++ b/packages/ui/src/api/client-chat.ts
@@ -385,6 +385,8 @@ declare module "./client-base" {
          * because not every connector tags rooms.
          */
         roomType?: string;
+        muted?: boolean;
+        mutedScope?: "room" | "server";
         title: string;
         avatarUrl?: string;
         lastMessageText: string;
@@ -392,6 +394,19 @@ declare module "./client-base" {
         messageCount: number;
       }>;
       count: number;
+    }>;
+    setInboxChatMute(data: {
+      action: "mute" | "unmute";
+      durationMinutes?: number;
+      roomId: string;
+      scope?: "room" | "server";
+    }): Promise<{
+      ok: boolean;
+      roomId: string;
+      action: "mute" | "unmute";
+      scope: "room" | "server";
+      muted?: boolean;
+      mutedScope?: "room" | "server";
     }>;
     sendInboxMessage(data: {
       accountId?: string;
@@ -1071,6 +1086,9 @@ ElizaClient.prototype.getInboxChats = async function (
         transportSource?: string;
         worldId?: string;
         worldLabel: string;
+        roomType?: string;
+        muted?: boolean;
+        mutedScope?: "room" | "server";
         title: string;
         avatarUrl?: string;
         lastMessageText: string;
@@ -1097,6 +1115,8 @@ ElizaClient.prototype.getInboxChats = async function (
       worldId?: string;
       /** User-facing server/world label for selectors and section headers. */
       worldLabel: string;
+      muted?: boolean;
+      mutedScope?: "room" | "server";
       title: string;
       avatarUrl?: string;
       lastMessageText: string;
@@ -1105,6 +1125,23 @@ ElizaClient.prototype.getInboxChats = async function (
     }>;
     count: number;
   }>(path);
+};
+
+ElizaClient.prototype.setInboxChatMute = async function (
+  this: ElizaClient,
+  data,
+) {
+  return this.fetch<{
+    ok: boolean;
+    roomId: string;
+    action: "mute" | "unmute";
+    scope: "room" | "server";
+    muted?: boolean;
+    mutedScope?: "room" | "server";
+  }>("/api/inbox/chats/mute", {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
 };
 
 ElizaClient.prototype.sendInboxMessage = async function (

--- a/packages/ui/src/components/conversations/ConversationsSidebar.tsx
+++ b/packages/ui/src/components/conversations/ConversationsSidebar.tsx
@@ -15,6 +15,8 @@
  */
 
 import {
+  Bell,
+  BellOff,
   MessagesSquare,
   Plus,
   Search,
@@ -84,6 +86,8 @@ interface InboxChatRow {
   canSend?: boolean;
   id: string;
   lastMessageAt: number;
+  muted?: boolean;
+  mutedScope?: "room" | "server";
   roomType?: string;
   source: string;
   transportSource?: string;
@@ -190,6 +194,7 @@ export function ConversationsSidebar({
     title: string;
   } | null>(null);
   const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 });
+  const [muteBusyIds, setMuteBusyIds] = useState<Set<string>>(() => new Set());
   const menuAnchorRef = useRef<HTMLDivElement>(null);
   // Each section (messages, terminal, per-connector) is independently
   // collapsible. Sections default to expanded — users only care that
@@ -253,6 +258,8 @@ export function ConversationsSidebar({
           canSend: chat.canSend,
           id: chat.id,
           lastMessageAt: chat.lastMessageAt,
+          muted: chat.muted,
+          mutedScope: chat.mutedScope,
           roomType: chat.roomType,
           source: chat.source,
           transportSource: chat.transportSource,
@@ -584,6 +591,64 @@ export function ConversationsSidebar({
     onClose?.();
   };
 
+  const updateInboxChatMute = useCallback(
+    async (
+      row: ConversationsSidebarRow,
+      action: "mute" | "unmute",
+      options?: { durationMinutes?: number; scope?: "room" | "server" },
+    ) => {
+      if (row.kind !== "inbox" || muteBusyIds.has(row.id)) return;
+      setMuteBusyIds((prev) => new Set(prev).add(row.id));
+      try {
+        const result = await client.setInboxChatMute({
+          action,
+          roomId: row.id,
+          scope: options?.scope ?? "room",
+          ...(options?.durationMinutes
+            ? { durationMinutes: options.durationMinutes }
+            : {}),
+        });
+        setInboxChats((prev) =>
+          prev.map((chat) => {
+            if (options?.scope === "server" && chat.worldId === row.worldId) {
+              if (result.mutedScope === "server") {
+                return { ...chat, muted: true, mutedScope: "server" };
+              }
+              if (chat.mutedScope !== "server") {
+                return chat;
+              }
+              const { mutedScope: _mutedScope, ...rest } = chat;
+              return { ...rest, muted: false };
+            }
+            return chat.id === row.id
+              ? {
+                  ...chat,
+                  muted: result.muted,
+                  mutedScope: result.mutedScope,
+                }
+              : chat;
+          }),
+        );
+      } catch (err) {
+        setActionNotice(
+          t("conversations.muteFailed", {
+            defaultValue: "Failed to update mute state: {{message}}",
+            message: errorMessage(err),
+          }),
+          "error",
+          4800,
+        );
+      } finally {
+        setMuteBusyIds((prev) => {
+          const next = new Set(prev);
+          next.delete(row.id);
+          return next;
+        });
+      }
+    },
+    [muteBusyIds, setActionNotice, t],
+  );
+
   const isGameModal = variant === "game-modal";
 
   // Plugins supply the scope-chip icons, so load them eagerly so the
@@ -713,6 +778,10 @@ export function ConversationsSidebar({
           rows: [...group.rows].sort(
             (left, right) => right.sortKey - left.sortKey,
           ),
+          serverMuted: group.rows.some(
+            (row) => row.muted && row.mutedScope === "server",
+          ),
+          serverMutable: group.rows.some((row) => Boolean(row.worldId)),
         };
       })
       .sort((left, right) => {
@@ -997,6 +1066,21 @@ export function ConversationsSidebar({
                   emptyLabel={t("conversations.none", {
                     defaultValue: "No chats in this view",
                   })}
+                  serverMuted={section.serverMuted}
+                  onToggleSectionMute={
+                    section.serverMutable
+                      ? (action, durationMinutes) => {
+                          const row = section.rows.find(
+                            (candidate) => candidate.worldId,
+                          );
+                          if (!row) return;
+                          void updateInboxChatMute(row, action, {
+                            durationMinutes,
+                            scope: "server",
+                          });
+                        }
+                      : undefined
+                  }
                   activeListId={activeListId}
                   rowListId={rowListId}
                   isTerminalRow={isTerminalRow}
@@ -1018,6 +1102,7 @@ export function ConversationsSidebar({
                     openRenameDialog({ id: row.id, title: row.title })
                   }
                   onSelectRow={handleRowSelect}
+                  onToggleInboxMute={updateInboxChatMute}
                 />
               ))}
             </div>
@@ -1042,6 +1127,11 @@ interface CollapsibleChannelSectionProps {
   onAdd?: () => void;
   addLabel?: string;
   emptyLabel?: string;
+  serverMuted?: boolean;
+  onToggleSectionMute?: (
+    action: "mute" | "unmute",
+    durationMinutes?: number,
+  ) => void;
   activeListId: string | null;
   rowListId: (row: ConversationsSidebarRow) => string;
   isTerminalRow: (row: ConversationsSidebarRow) => boolean;
@@ -1060,6 +1150,11 @@ interface CollapsibleChannelSectionProps {
   onRequestDeleteConfirm: (row: ConversationsSidebarRow) => void;
   onRequestRename: (row: ConversationsSidebarRow) => void;
   onSelectRow: (row: ConversationsSidebarRow) => void;
+  onToggleInboxMute?: (
+    row: ConversationsSidebarRow,
+    action: "mute" | "unmute",
+    options?: { durationMinutes?: number; scope?: "room" | "server" },
+  ) => void | Promise<void>;
 }
 
 function CollapsibleChannelSection({
@@ -1073,6 +1168,8 @@ function CollapsibleChannelSection({
   onAdd,
   addLabel,
   emptyLabel,
+  serverMuted = false,
+  onToggleSectionMute,
   activeListId,
   rowListId,
   isTerminalRow,
@@ -1088,7 +1185,11 @@ function CollapsibleChannelSection({
   onRequestDeleteConfirm,
   onRequestRename,
   onSelectRow,
+  onToggleInboxMute,
 }: CollapsibleChannelSectionProps) {
+  const sectionMuteLabel = serverMuted
+    ? t("conversations.unmuteServer", { defaultValue: "Unmute server" })
+    : t("conversations.muteServer", { defaultValue: "Mute server" });
   return (
     <CollapsibleSidebarSection
       sectionKey={sectionKey}
@@ -1105,64 +1206,210 @@ function CollapsibleChannelSection({
       hoverActionsOnDesktop={!mobile}
       testIdPrefix="channel-section"
     >
+      {onToggleSectionMute ? (
+        <div className="mb-1 flex items-center gap-1 pl-1 pr-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-6 min-w-0 flex-1 justify-start gap-1.5 rounded-sm px-2 text-2xs text-muted hover:text-txt"
+            onClick={() => onToggleSectionMute(serverMuted ? "unmute" : "mute")}
+            title={sectionMuteLabel}
+            aria-label={sectionMuteLabel}
+          >
+            {serverMuted ? (
+              <BellOff className="h-3.5 w-3.5 shrink-0" aria-hidden />
+            ) : (
+              <Bell className="h-3.5 w-3.5 shrink-0" aria-hidden />
+            )}
+            <span className="truncate">{sectionMuteLabel}</span>
+          </Button>
+          {!serverMuted ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="h-6 w-6 shrink-0 rounded-sm text-muted hover:text-txt"
+                  aria-label={t("conversations.muteServerDuration", {
+                    defaultValue: "Mute server duration",
+                  })}
+                  title={t("conversations.muteServerDuration", {
+                    defaultValue: "Mute server duration",
+                  })}
+                >
+                  <BellOff className="h-3.5 w-3.5" aria-hidden />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-36">
+                <DropdownMenuItem
+                  onClick={() => onToggleSectionMute("mute", 60)}
+                >
+                  {t("conversations.muteForHour", {
+                    defaultValue: "Mute 1 hour",
+                  })}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => onToggleSectionMute("mute", 60 * 8)}
+                >
+                  {t("conversations.muteForDay", {
+                    defaultValue: "Mute 8 hours",
+                  })}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
+        </div>
+      ) : null}
       {rows.map((row) => {
         const conversationId = rowListId(row);
         return (
-          <ChatConversationItem
-            key={conversationId}
-            conversation={{
-              id: conversationId,
-              ...(row.source ? { source: row.source } : {}),
-              title: row.title,
-              updatedAtLabel: row.updatedAtLabel,
-            }}
-            deleting={deletingId === row.id}
-            isActive={conversationId === activeListId}
-            isConfirmingDelete={
-              row.kind === "conversation" &&
-              !isTerminalRow(row) &&
-              confirmDeleteId === row.id
-            }
-            isUnread={
-              row.kind === "conversation" &&
-              !isTerminalRow(row) &&
-              unreadConversations.has(row.id)
-            }
-            labels={{
-              actions: t("conversations.actions", {
-                defaultValue: "More actions",
-              }),
-              delete: t("conversations.delete"),
-              deleteConfirm: t("conversations.deleteConfirm"),
-              deleteNo: t("common.no"),
-              deleteYes: t("common.yes"),
-              rename: t("conversations.rename"),
-            }}
-            mobile={mobile}
-            onCancelDelete={onCancelDelete}
-            onConfirmDelete={() => {
-              if (row.kind === "inbox" || isTerminalRow(row)) return;
-              void onConfirmDelete(row.id);
-            }}
-            onOpenActions={(event) => {
-              if (row.kind === "inbox" || isTerminalRow(row)) {
-                event.preventDefault();
-                event.stopPropagation();
-                return;
-              }
-              onOpenActions(event, { id: row.id, title: row.title });
-            }}
-            onRequestDeleteConfirm={() => {
-              if (row.kind === "inbox" || isTerminalRow(row)) return;
-              onRequestDeleteConfirm(row);
-            }}
-            onRequestRename={() => {
-              if (row.kind === "inbox" || isTerminalRow(row)) return;
-              onRequestRename(row);
-            }}
-            onSelect={() => onSelectRow(row)}
-            variant={variant}
-          />
+          <div key={conversationId} className="flex min-w-0 items-center gap-1">
+            <div className="min-w-0 flex-1">
+              <ChatConversationItem
+                conversation={{
+                  id: conversationId,
+                  ...(row.source ? { source: row.source } : {}),
+                  title: row.title,
+                  updatedAtLabel: row.muted
+                    ? row.mutedScope === "server"
+                      ? t("conversations.serverMuted", {
+                          defaultValue: "Server muted",
+                        })
+                      : t("conversations.channelMuted", {
+                          defaultValue: "Channel muted",
+                        })
+                    : row.updatedAtLabel,
+                }}
+                deleting={deletingId === row.id}
+                isActive={conversationId === activeListId}
+                isConfirmingDelete={
+                  row.kind === "conversation" &&
+                  !isTerminalRow(row) &&
+                  confirmDeleteId === row.id
+                }
+                isUnread={
+                  row.kind === "conversation" &&
+                  !isTerminalRow(row) &&
+                  unreadConversations.has(row.id)
+                }
+                labels={{
+                  actions: t("conversations.actions", {
+                    defaultValue: "More actions",
+                  }),
+                  delete: t("conversations.delete"),
+                  deleteConfirm: t("conversations.deleteConfirm"),
+                  deleteNo: t("common.no"),
+                  deleteYes: t("common.yes"),
+                  rename: t("conversations.rename"),
+                }}
+                mobile={mobile}
+                onCancelDelete={onCancelDelete}
+                onConfirmDelete={() => {
+                  if (row.kind === "inbox" || isTerminalRow(row)) return;
+                  void onConfirmDelete(row.id);
+                }}
+                onOpenActions={(event) => {
+                  if (row.kind === "inbox" || isTerminalRow(row)) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    return;
+                  }
+                  onOpenActions(event, { id: row.id, title: row.title });
+                }}
+                onRequestDeleteConfirm={() => {
+                  if (row.kind === "inbox" || isTerminalRow(row)) return;
+                  onRequestDeleteConfirm(row);
+                }}
+                onRequestRename={() => {
+                  if (row.kind === "inbox" || isTerminalRow(row)) return;
+                  onRequestRename(row);
+                }}
+                onSelect={() => onSelectRow(row)}
+                variant={variant}
+              />
+            </div>
+            {row.kind === "inbox" && onToggleInboxMute ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    className="h-7 w-7 shrink-0 rounded-sm text-muted hover:text-txt"
+                    aria-label={
+                      row.muted
+                        ? t("conversations.unmuteChannel", {
+                            defaultValue: "Unmute channel",
+                          })
+                        : t("conversations.muteChannel", {
+                            defaultValue: "Mute channel",
+                          })
+                    }
+                    title={
+                      row.muted
+                        ? t("conversations.unmuteChannel", {
+                            defaultValue: "Unmute channel",
+                          })
+                        : t("conversations.muteChannel", {
+                            defaultValue: "Mute channel",
+                          })
+                    }
+                  >
+                    {row.muted ? (
+                      <BellOff className="h-3.5 w-3.5" aria-hidden />
+                    ) : (
+                      <Bell className="h-3.5 w-3.5" aria-hidden />
+                    )}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-40">
+                  {row.muted ? (
+                    <DropdownMenuItem
+                      onClick={() => void onToggleInboxMute(row, "unmute")}
+                    >
+                      {t("conversations.unmuteChannel", {
+                        defaultValue: "Unmute channel",
+                      })}
+                    </DropdownMenuItem>
+                  ) : (
+                    <>
+                      <DropdownMenuItem
+                        onClick={() => void onToggleInboxMute(row, "mute")}
+                      >
+                        {t("conversations.muteChannel", {
+                          defaultValue: "Mute channel",
+                        })}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() =>
+                          void onToggleInboxMute(row, "mute", {
+                            durationMinutes: 60,
+                          })
+                        }
+                      >
+                        {t("conversations.muteForHour", {
+                          defaultValue: "Mute 1 hour",
+                        })}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() =>
+                          void onToggleInboxMute(row, "mute", {
+                            durationMinutes: 60 * 8,
+                          })
+                        }
+                      >
+                        {t("conversations.muteForDay", {
+                          defaultValue: "Mute 8 hours",
+                        })}
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : null}
+          </div>
         );
       })}
     </CollapsibleSidebarSection>

--- a/packages/ui/src/components/conversations/conversation-sidebar-model.test.ts
+++ b/packages/ui/src/components/conversations/conversation-sidebar-model.test.ts
@@ -204,4 +204,30 @@ describe("buildConversationsSidebarModel — connector scope", () => {
     const dmRow = model.rows.find((r) => r.id === "dm1");
     expect(dmRow?.worldLabel).toBe("DMs");
   });
+
+  it("preserves connector mute state on sidebar rows", () => {
+    const model = buildConversationsSidebarModel({
+      conversations: [],
+      inboxChats: [
+        inbox({
+          id: "muted-channel",
+          source: "discord",
+          muted: true,
+          mutedScope: "server",
+          worldId: "guild-1",
+          worldLabel: "Acme Guild",
+        }),
+      ],
+      searchQuery: "",
+      sourceScope: ALL_CONNECTORS_SOURCE_SCOPE,
+      t,
+      worldScope: ALL_WORLDS_SCOPE,
+    });
+
+    expect(model.rows[0]).toMatchObject({
+      id: "muted-channel",
+      muted: true,
+      mutedScope: "server",
+    });
+  });
 });

--- a/packages/ui/src/components/conversations/conversation-sidebar-model.ts
+++ b/packages/ui/src/components/conversations/conversation-sidebar-model.ts
@@ -41,6 +41,8 @@ export interface InboxChatSidebarRow {
   id: string;
   lastMessageAt: number;
   roomType?: string;
+  muted?: boolean;
+  mutedScope?: "room" | "server";
   source: string;
   transportSource?: string;
   title: string;
@@ -57,6 +59,8 @@ export interface ConversationsSidebarRow {
   source?: string;
   sourceKey: string;
   transportSource?: string;
+  muted?: boolean;
+  mutedScope?: "room" | "server";
   title: string;
   updatedAtLabel: string;
   worldId?: string;
@@ -177,6 +181,8 @@ function buildInboxRows(
         source: normalizedSource,
         sourceKey: normalizedSource,
         transportSource: chat.transportSource ?? chat.source,
+        muted: chat.muted === true,
+        mutedScope: chat.mutedScope,
         title: chat.title,
         updatedAtLabel: formatRelativeTime(isoDate, t),
         ...(chat.worldId ? { worldId: chat.worldId } : {}),


### PR DESCRIPTION
## Summary

- Adds effective mute state to `/api/inbox/chats` rows (`muted`, `mutedScope`) using the same room/server mute resolver as inbound message gating.
- Adds `POST /api/inbox/chats/mute` for deterministic room/server mute, unmute, and timed mute writes from UI controls.
- Adds mobile/shared conversations sidebar controls for channel mute/unmute, timed mute presets, and server mute/unmute where a connector world is available.
- Adds sidebar model coverage for preserving connector mute state.

Fixes #12893.

## Evidence

See `.github/issue-evidence/12893-phone-ui-mute-toggle.md`.

Passed:

- `bunx @biomejs/biome check packages/agent/src/api/inbox-routes.ts packages/ui/src/api/client-chat.ts packages/ui/src/components/conversations/ConversationsSidebar.tsx packages/ui/src/components/conversations/conversation-sidebar-model.ts packages/ui/src/components/conversations/conversation-sidebar-model.test.ts`
- `git diff --check origin/develop..HEAD`

Blocked in this sparse worktree:

- `bun test packages/ui/src/components/conversations/conversation-sidebar-model.test.ts` — missing `lucide-react` from the symlinked sparse `node_modules`.
- `bun run --cwd packages/ui typecheck` and `bun run --cwd packages/agent typecheck` — missing sparse dependencies; agent duplicate-core type issue from the first attempt was resolved.
- `bun run --cwd packages/app audit:app` — after expanding sparse checkout to include `plugins`, `packages/native`, and `packages/tui`, the audit still failed before screenshots because view builds could not resolve `@elizaos/capacitor-phone`, `@elizaos/capacitor-messages`, and `@xterm/xterm` from the shared sparse dependency tree.
