### PR TITLE
fix(#12902): normalize plugin host registry scripts

### DIFF
--- a/.github/issue-evidence/12902-plugin-host-registry-scripts.md
+++ b/.github/issue-evidence/12902-plugin-host-registry-scripts.md
@@ -1,0 +1,31 @@
+# Issue #12902 plugin host/registry script evidence
+
+Date: 2026-07-04
+
+Scope:
+- `packages/plugin-remote-manifest/package.json`
+- `packages/plugin-worker-runtime/package.json`
+- `packages/plugin-worker-runtime/src/compat.test.ts`
+- `packages/plugin-sub-agent-claude-code/package.json`
+- `packages/plugin-sub-agent-claude-code/src/compat.test.ts`
+- `packages/plugin-sub-agent-claude-code/tsconfig.json`
+- `packages/registry/package.json`
+
+Changes:
+- Added read-only `lint:check` scripts and standard `format` / `format:check` verbs.
+- Aligned mutating lint scripts with the Biome write convention.
+- Removed `--pass-with-no-tests` from compatibility wrapper package tests and added real export smoke tests.
+- Added source path aliases to the sub-agent wrapper tsconfig so its compatibility re-exports resolve against `plugin-remote-manifest` source in a monorepo checkout.
+- Removed Registry's misleading `build` alias; Registry generation remains explicit via `generate` and `generate:first-party` because it rewrites tracked JSON rather than emitting a disposable build artifact.
+
+Verification:
+- `node -e` parsed all four edited `package.json` files successfully.
+- Static #12902 guard confirmed these packages no longer report no-test masks, missing check verbs, or build-without-clean rows.
+- Compatibility wrapper smoke tests passed.
+- Read-only `lint:check` scripts passed for `plugin-remote-manifest`, `plugin-worker-runtime`, `plugin-sub-agent-claude-code`, and `registry`.
+- Biome check passed for the two new smoke test files.
+- `git diff --check` passed.
+
+Environment limitation:
+- Full workspace test/build execution was not run in this worktree because the local checkout is intentionally using a partial/shared install under low disk space, and this host is on Node v23.3.0 while the repository requires Node 24.
+- This slice only changes package-manager script metadata plus non-UI smoke tests; screenshots/video are N/A.

--- a/packages/plugin-remote-manifest/package.json
+++ b/packages/plugin-remote-manifest/package.json
@@ -15,9 +15,11 @@
     "build": "node ../scripts/rm-path-recursive.mjs dist tsconfig.build.tsbuildinfo && tsc --noCheck -p tsconfig.build.json",
     "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "bun test src/",
-    "lint": "bunx @biomejs/biome check src",
-    "lint:fix": "bunx @biomejs/biome check --write src",
-    "format": "bunx @biomejs/biome format src",
+    "lint": "bunx @biomejs/biome check --write --unsafe src",
+    "lint:check": "bunx @biomejs/biome check src",
+    "lint:fix": "bunx @biomejs/biome check --write --unsafe src",
+    "format": "bunx @biomejs/biome format --write src",
+    "format:check": "bunx @biomejs/biome format src",
     "format:fix": "bunx @biomejs/biome format --write src"
   },
   "dependencies": {

--- a/packages/plugin-sub-agent-claude-code/package.json
+++ b/packages/plugin-sub-agent-claude-code/package.json
@@ -13,9 +13,12 @@
     "clean": "node ../scripts/rm-path-recursive.mjs dist",
     "build": "node ../scripts/rm-path-recursive.mjs dist tsconfig.build.tsbuildinfo && tsc --noCheck -p tsconfig.build.json",
     "typecheck": "tsgo --noEmit -p tsconfig.json",
-    "test": "bun test src/ --pass-with-no-tests",
-    "lint": "bunx @biomejs/biome check src",
-    "lint:fix": "bunx @biomejs/biome check --write src"
+    "test": "bun test src/",
+    "lint": "bunx @biomejs/biome check --write --unsafe src",
+    "lint:check": "bunx @biomejs/biome check src",
+    "lint:fix": "bunx @biomejs/biome check --write --unsafe src",
+    "format": "bunx @biomejs/biome format --write src",
+    "format:check": "bunx @biomejs/biome format src"
   },
   "dependencies": {
     "@elizaos/plugin-remote-manifest": "workspace:*"

--- a/packages/plugin-sub-agent-claude-code/src/compat.test.ts
+++ b/packages/plugin-sub-agent-claude-code/src/compat.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { plugin } from "./plugin";
+import { ClaudeCodeSubAgentService } from "./sub-agent-service";
+
+describe("plugin-sub-agent-claude-code compatibility exports", () => {
+  test("re-exports the remote sub-agent plugin descriptor", () => {
+    expect(plugin.name).toBe("@elizaos/plugin-sub-agent-claude-code");
+    expect(plugin.services?.[0]?.serviceType).toBe("sub-agent.claude-code");
+  });
+
+  test("re-exports the host-callable service class", () => {
+    expect(ClaudeCodeSubAgentService.serviceType).toBe("sub-agent.claude-code");
+    expect(ClaudeCodeSubAgentService.rpcMethods).toContain("createSession");
+    expect(ClaudeCodeSubAgentService.rpcMethods).toContain("terminate");
+  });
+});

--- a/packages/plugin-sub-agent-claude-code/tsconfig.json
+++ b/packages/plugin-sub-agent-claude-code/tsconfig.json
@@ -17,6 +17,17 @@
     "declarationMap": true,
     "sourceMap": true,
     "noEmit": true,
+    "paths": {
+      "@elizaos/plugin-remote-manifest": [
+        "../plugin-remote-manifest/src/types.ts"
+      ],
+      "@elizaos/plugin-remote-manifest/sub-agent-claude-code": [
+        "../plugin-remote-manifest/src/sub-agent-claude-code/plugin.ts"
+      ],
+      "@elizaos/plugin-remote-manifest/*": ["../plugin-remote-manifest/src/*"],
+      "@elizaos/security": ["../security/src/index.ts"],
+      "@elizaos/security/*": ["../security/src/*"]
+    },
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/plugin-worker-runtime/package.json
+++ b/packages/plugin-worker-runtime/package.json
@@ -13,10 +13,12 @@
     "clean": "node ../scripts/rm-path-recursive.mjs dist",
     "build": "node ../scripts/rm-path-recursive.mjs dist tsconfig.build.tsbuildinfo && tsc --noCheck -p tsconfig.build.json",
     "typecheck": "tsgo --noEmit -p tsconfig.json",
-    "test": "bun test src/ --pass-with-no-tests",
-    "lint": "bunx @biomejs/biome check src",
-    "lint:fix": "bunx @biomejs/biome check --write src",
-    "format": "bunx @biomejs/biome format src",
+    "test": "bun test src/",
+    "lint": "bunx @biomejs/biome check --write --unsafe src",
+    "lint:check": "bunx @biomejs/biome check src",
+    "lint:fix": "bunx @biomejs/biome check --write --unsafe src",
+    "format": "bunx @biomejs/biome format --write src",
+    "format:check": "bunx @biomejs/biome format src",
     "format:fix": "bunx @biomejs/biome format --write src"
   },
   "dependencies": {

--- a/packages/plugin-worker-runtime/src/compat.test.ts
+++ b/packages/plugin-worker-runtime/src/compat.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { toWireError } from "./error";
+import { SUPPORTED_RUNTIME_METHODS } from "./runtime-proxy";
+
+describe("plugin-worker-runtime compatibility exports", () => {
+  test("re-exports worker runtime helpers", () => {
+    const wireError = toWireError(new Error("boom"));
+
+    expect(wireError.message).toBe("boom");
+    expect(SUPPORTED_RUNTIME_METHODS).toContain("getService");
+  });
+});

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -41,12 +41,13 @@
     "generate": "bun run src/generate.ts",
     "generate:first-party": "bun run src/first-party/generate.ts",
     "generate:first-party:check": "bun run src/first-party/generate.ts --check",
-    "build": "bun run src/generate.ts && bun run src/first-party/generate.ts",
     "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "node ../scripts/run-vitest.mjs run --config ./vitest.config.ts",
-    "lint": "bunx @biomejs/biome check src",
-    "lint:fix": "bunx @biomejs/biome check --write src",
-    "format": "bunx @biomejs/biome format src",
+    "lint": "bunx @biomejs/biome check --write --unsafe src",
+    "lint:check": "bunx @biomejs/biome check src",
+    "lint:fix": "bunx @biomejs/biome check --write --unsafe src",
+    "format": "bunx @biomejs/biome format --write src",
+    "format:check": "bunx @biomejs/biome format src",
     "format:fix": "bunx @biomejs/biome format --write src"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- normalize script verbs for plugin-remote-manifest, worker-runtime, sub-agent wrapper, and registry
- replace wrapper no-test masks with real compatibility smoke tests
- add source aliases for sub-agent wrapper monorepo resolution
- remove Registry's misleading `build` alias; generation remains explicit via `generate` commands

## Evidence
- `.github/issue-evidence/12902-plugin-host-registry-scripts.md`
- manifest JSON parse for edited packages: passed
- static #12902 guard for edited packages: passed
- worker-runtime and sub-agent wrapper smoke tests: passed
- `lint:check` for plugin-remote-manifest, plugin-worker-runtime, plugin-sub-agent-claude-code, and registry: passed
- Biome check for new smoke test files: passed
- `git diff --check origin/develop..HEAD`: passed

## Screenshots / video
N/A: package-script metadata plus non-UI smoke tests only; no runtime UI changed.

Fixes part of #12902.
