### PR TITLE
fix(#12902): finish cloud deploy script normalization

### DIFF
--- a/.github/issue-evidence/12902-cloud-deploy-tail-scripts.md
+++ b/.github/issue-evidence/12902-cloud-deploy-tail-scripts.md
@@ -1,0 +1,74 @@
+# Issue #12902: cloud/deploy package script normalization tail
+
+## Scope
+
+Final tail slice for the #12902 package group:
+
+- `packages/cloud/infra`
+- `packages/cloud/docs-redirect`
+- `packages/cloud/api`
+- `packages/cloud/services/coding-remote-runner`
+- `packages/cloud/services/agent-server`
+- `packages/cloud/services/_smoke-mcp`
+
+`packages/deploy` was reviewed and contains systemd deploy assets, not a package manifest.
+
+## Changes
+
+- Added standard mutating `lint`, read-only `lint:check`, and format verbs where missing.
+- Removed the type-only `build` script from `packages/cloud/api`; `typecheck` remains the no-emit type command.
+- Removed the fake `agent-server` `test:integration` wrapper that targeted a nonexistent directory with `--pass-with-no-tests`.
+- Added real `build`/`clean` and standard check verbs for the temporary `_smoke-mcp` Worker harness.
+- Updated matching package-local `CLAUDE.md` and `AGENTS.md` command lists; verified each touched pair remains identical.
+
+## Verification
+
+Passed:
+
+```bash
+find packages/cloud packages/registry packages/plugin-remote-manifest packages/plugin-worker-runtime packages/plugin-sub-agent-claude-code -name package.json -maxdepth 4 -print0 | xargs -0 jq -e '.name and (.scripts|type=="object")' >/dev/null
+git diff --check
+node <static #12902 manifest guard>
+# packages=18 issues=0
+
+bun run --cwd packages/cloud/infra lint:check
+bun run --cwd packages/cloud/docs-redirect lint:check
+bun run --cwd packages/cloud/api lint:check
+bun run --cwd packages/cloud/services/coding-remote-runner lint:check
+bun run --cwd packages/cloud/services/agent-server lint:check
+bun run --cwd packages/cloud/services/_smoke-mcp lint:check
+
+for p in packages/cloud/infra packages/cloud/docs-redirect packages/cloud/api packages/cloud/services/coding-remote-runner packages/cloud/services/agent-server packages/cloud/services/_smoke-mcp; do bun run --cwd "$p" format:check || exit $?; done
+
+bun run --cwd packages/cloud/services/coding-remote-runner test
+
+for d in packages/cloud/infra packages/cloud/docs-redirect packages/cloud/api packages/cloud/services/coding-remote-runner packages/cloud/services/agent-server; do cmp -s "$d/CLAUDE.md" "$d/AGENTS.md" || exit 1; done
+```
+
+Notes:
+
+- `packages/cloud/infra lint:check` exited successfully with an existing Biome warning in `tests/terraform-static.test.ts` for a Terraform interpolation string literal.
+
+Blocked by the temp worktree's incomplete dependency install:
+
+```bash
+bun run --cwd packages/cloud/infra test
+# Cannot find package 'yaml'
+
+bun run --cwd packages/cloud/docs-redirect test
+# vitest: command not found
+
+bun run --cwd packages/cloud/services/agent-server test:unit
+# Cannot resolve @elizaos/core / @elizaos/cloud-services-common / ioredis
+
+bun run --cwd packages/cloud/services/coding-remote-runner typecheck
+bun run --cwd packages/cloud/api typecheck
+bun run --cwd packages/cloud/services/agent-server typecheck
+bun run --cwd packages/cloud/services/_smoke-mcp typecheck
+# Missing @types/node and/or @cloudflare/workers-types
+
+bun run --cwd packages/cloud/services/_smoke-mcp build
+# Wrangler reached bundling, then failed to resolve mcp-handler from the incomplete install.
+```
+
+The available `/Users/shawwalters/eliza/node_modules` was linked into the worktree before retrying, but it also lacks the dependencies above.

--- a/packages/cloud/api/AGENTS.md
+++ b/packages/cloud/api/AGENTS.md
@@ -67,10 +67,11 @@ Path-alias note: `@/lib/*`, `@/db/*`, `@/types/*`, `@/billing/*` resolve into `.
 bun run --cwd packages/cloud/api dev            # wrangler dev (local Worker)
 bun run --cwd packages/cloud/api dev:full       # dev + local control plane
 bun run --cwd packages/cloud/api codegen        # regen src/_router.generated.ts
-bun run --cwd packages/cloud/api build          # tsc --noEmit (type-only)
 bun run --cwd packages/cloud/api typecheck      # tsgo --noEmit
-bun run --cwd packages/cloud/api lint           # biome check .
-bun run --cwd packages/cloud/api lint:fix       # biome check --write .
+bun run --cwd packages/cloud/api lint           # biome check --write --unsafe .
+bun run --cwd packages/cloud/api lint:check     # biome check .
+bun run --cwd packages/cloud/api format         # biome format --write .
+bun run --cwd packages/cloud/api format:check   # biome format .
 bun run --cwd packages/cloud/api test           # bun test __tests__
 bun run --cwd packages/cloud/api test:audit     # route coverage audit
 bun run --cwd packages/cloud/api test:e2e       # batched e2e (test/e2e/)

--- a/packages/cloud/api/CLAUDE.md
+++ b/packages/cloud/api/CLAUDE.md
@@ -67,10 +67,11 @@ Path-alias note: `@/lib/*`, `@/db/*`, `@/types/*`, `@/billing/*` resolve into `.
 bun run --cwd packages/cloud/api dev            # wrangler dev (local Worker)
 bun run --cwd packages/cloud/api dev:full       # dev + local control plane
 bun run --cwd packages/cloud/api codegen        # regen src/_router.generated.ts
-bun run --cwd packages/cloud/api build          # tsc --noEmit (type-only)
 bun run --cwd packages/cloud/api typecheck      # tsgo --noEmit
-bun run --cwd packages/cloud/api lint           # biome check .
-bun run --cwd packages/cloud/api lint:fix       # biome check --write .
+bun run --cwd packages/cloud/api lint           # biome check --write --unsafe .
+bun run --cwd packages/cloud/api lint:check     # biome check .
+bun run --cwd packages/cloud/api format         # biome format --write .
+bun run --cwd packages/cloud/api format:check   # biome format .
 bun run --cwd packages/cloud/api test           # bun test __tests__
 bun run --cwd packages/cloud/api test:audit     # route coverage audit
 bun run --cwd packages/cloud/api test:e2e       # batched e2e (test/e2e/)

--- a/packages/cloud/docs-redirect/AGENTS.md
+++ b/packages/cloud/docs-redirect/AGENTS.md
@@ -9,10 +9,10 @@ This is a standalone infrastructure package — not an elizaOS plugin and not im
 ## Layout
 
 ```
-packages/docs-elizacloud-redirect/
+packages/cloud/docs-redirect/
   src/worker.ts        Entry point — the entire Worker (one fetch handler, ~25 lines)
   wrangler.toml        Cloudflare Worker config: route binding for docs.elizacloud.ai/*
-  package.json         Three scripts: test + dev + deploy
+  package.json         Scripts: test, lint/format, dev, deploy
 ```
 
 ## Key logic (`src/worker.ts`)
@@ -29,9 +29,11 @@ packages/docs-elizacloud-redirect/
 ## Commands
 
 ```bash
-bun run --cwd packages/docs-elizacloud-redirect dev     # wrangler local dev server
-bun run --cwd packages/docs-elizacloud-redirect deploy  # deploy to Cloudflare (production env)
-bun run --cwd packages/docs-elizacloud-redirect test    # vitest run
+bun run --cwd packages/cloud/docs-redirect dev     # wrangler local dev server
+bun run --cwd packages/cloud/docs-redirect deploy  # deploy to Cloudflare (production env)
+bun run --cwd packages/cloud/docs-redirect test    # vitest run
+bun run --cwd packages/cloud/docs-redirect lint:check # biome check .
+bun run --cwd packages/cloud/docs-redirect format:check # biome format .
 ```
 
 `deploy` targets `[env.production]` in `wrangler.toml`, which binds the route `docs.elizacloud.ai/*` on the `elizacloud.ai` zone automatically — no Cloudflare dashboard step beyond the one-time DNS record pointing `docs.elizacloud.ai` at the Cloudflare proxy.
@@ -62,7 +64,7 @@ The worker is intentionally trivial. If redirect rules change:
 - `private: true` — never published to npm; deploy-only via Wrangler.
 - No TypeScript compilation step; Wrangler bundles `src/worker.ts` directly via esbuild.
 - `workers_dev = false` means `wrangler deploy` without `--env production` deploys nothing to a `*.workers.dev` URL. Always pass `--env production` (the `deploy` script does this).
-- No tests. The logic is two conditionals; verify correctness by reading `src/worker.ts` or running `bun run dev` and inspecting redirects locally with `curl -I`.
+- Redirect behavior is covered by deterministic Vitest tests in `src/worker.test.ts`; use Wrangler locally for manual redirect checks when changing deployment config.
 
 <!-- BEGIN: evidence-and-e2e-mandate (managed; canonical standard = repo-root PR_EVIDENCE.md) -->
 ## ⛔ NON-NEGOTIABLE — evidence, trajectories & real end-to-end tests

--- a/packages/cloud/docs-redirect/CLAUDE.md
+++ b/packages/cloud/docs-redirect/CLAUDE.md
@@ -9,10 +9,10 @@ This is a standalone infrastructure package — not an elizaOS plugin and not im
 ## Layout
 
 ```
-packages/docs-elizacloud-redirect/
+packages/cloud/docs-redirect/
   src/worker.ts        Entry point — the entire Worker (one fetch handler, ~25 lines)
   wrangler.toml        Cloudflare Worker config: route binding for docs.elizacloud.ai/*
-  package.json         Three scripts: test + dev + deploy
+  package.json         Scripts: test, lint/format, dev, deploy
 ```
 
 ## Key logic (`src/worker.ts`)
@@ -29,9 +29,11 @@ packages/docs-elizacloud-redirect/
 ## Commands
 
 ```bash
-bun run --cwd packages/docs-elizacloud-redirect dev     # wrangler local dev server
-bun run --cwd packages/docs-elizacloud-redirect deploy  # deploy to Cloudflare (production env)
-bun run --cwd packages/docs-elizacloud-redirect test    # vitest run
+bun run --cwd packages/cloud/docs-redirect dev     # wrangler local dev server
+bun run --cwd packages/cloud/docs-redirect deploy  # deploy to Cloudflare (production env)
+bun run --cwd packages/cloud/docs-redirect test    # vitest run
+bun run --cwd packages/cloud/docs-redirect lint:check # biome check .
+bun run --cwd packages/cloud/docs-redirect format:check # biome format .
 ```
 
 `deploy` targets `[env.production]` in `wrangler.toml`, which binds the route `docs.elizacloud.ai/*` on the `elizacloud.ai` zone automatically — no Cloudflare dashboard step beyond the one-time DNS record pointing `docs.elizacloud.ai` at the Cloudflare proxy.
@@ -62,7 +64,7 @@ The worker is intentionally trivial. If redirect rules change:
 - `private: true` — never published to npm; deploy-only via Wrangler.
 - No TypeScript compilation step; Wrangler bundles `src/worker.ts` directly via esbuild.
 - `workers_dev = false` means `wrangler deploy` without `--env production` deploys nothing to a `*.workers.dev` URL. Always pass `--env production` (the `deploy` script does this).
-- No tests. The logic is two conditionals; verify correctness by reading `src/worker.ts` or running `bun run dev` and inspecting redirects locally with `curl -I`.
+- Redirect behavior is covered by deterministic Vitest tests in `src/worker.test.ts`; use Wrangler locally for manual redirect checks when changing deployment config.
 
 <!-- BEGIN: evidence-and-e2e-mandate (managed; canonical standard = repo-root PR_EVIDENCE.md) -->
 ## ⛔ NON-NEGOTIABLE — evidence, trajectories & real end-to-end tests

--- a/packages/cloud/docs-redirect/package.json
+++ b/packages/cloud/docs-redirect/package.json
@@ -5,6 +5,11 @@
   "type": "module",
   "description": "Cloudflare Worker that 301-redirects docs.elizacloud.ai/* to docs.elizaos.ai/cloud/*",
   "scripts": {
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "lint:fix": "bunx @biomejs/biome check --write --unsafe .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
     "test": "vitest run",
     "deploy": "wrangler deploy --env production",
     "dev": "wrangler dev"

--- a/packages/cloud/infra/AGENTS.md
+++ b/packages/cloud/infra/AGENTS.md
@@ -126,6 +126,10 @@ Numbered [Chainsaw](https://kyverno.github.io/chainsaw/) suites (`cloud/tests/0*
 
 ```bash
 bun run --cwd packages/cloud/infra test       # Run YAML/manifest smoke tests (Bun test)
+bun run --cwd packages/cloud/infra lint       # biome check --write --unsafe .
+bun run --cwd packages/cloud/infra lint:check # biome check .
+bun run --cwd packages/cloud/infra format     # biome format --write .
+bun run --cwd packages/cloud/infra format:check # biome format .
 ```
 
 Local cluster scripts (run directly, not via bun):

--- a/packages/cloud/infra/CLAUDE.md
+++ b/packages/cloud/infra/CLAUDE.md
@@ -126,6 +126,10 @@ Numbered [Chainsaw](https://kyverno.github.io/chainsaw/) suites (`cloud/tests/0*
 
 ```bash
 bun run --cwd packages/cloud/infra test       # Run YAML/manifest smoke tests (Bun test)
+bun run --cwd packages/cloud/infra lint       # biome check --write --unsafe .
+bun run --cwd packages/cloud/infra lint:check # biome check .
+bun run --cwd packages/cloud/infra format     # biome format --write .
+bun run --cwd packages/cloud/infra format:check # biome format .
 ```
 
 Local cluster scripts (run directly, not via bun):

--- a/packages/cloud/infra/package.json
+++ b/packages/cloud/infra/package.json
@@ -5,6 +5,11 @@
   "type": "module",
   "description": "Cloud infrastructure: local-dev values files, Kubernetes manifests, and Terraform for the elizaOS cloud stack.",
   "scripts": {
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "lint:fix": "bunx @biomejs/biome check --write --unsafe .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
     "test": "bun test tests"
   },
   "devDependencies": {

--- a/packages/cloud/services/_smoke-mcp/package.json
+++ b/packages/cloud/services/_smoke-mcp/package.json
@@ -4,6 +4,14 @@
   "private": true,
   "description": "Temporary build/dry-deploy harness to verify mcp-handler on Cloudflare Workers (workerd + nodejs_compat). NOT production. Delete once MCP_WORKERS_VERIFICATION.md is written.",
   "scripts": {
+    "build": "wrangler deploy --dry-run --outdir=dist",
+    "clean": "rm -rf dist",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "lint:fix": "bunx @biomejs/biome check --write --unsafe .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
     "dry-deploy": "wrangler deploy --dry-run --outdir=dist",
     "dev": "wrangler dev --port 8788"
   },

--- a/packages/cloud/services/agent-server/AGENTS.md
+++ b/packages/cloud/services/agent-server/AGENTS.md
@@ -43,10 +43,12 @@ Scope with `--cwd packages/cloud/services/agent-server`:
 bun run --cwd packages/cloud/services/agent-server start            # bun run src/index.ts
 bun run --cwd packages/cloud/services/agent-server dev              # bun --watch run src/index.ts
 bun run --cwd packages/cloud/services/agent-server typecheck        # tsgo --noEmit
-bun run --cwd packages/cloud/services/agent-server lint             # biome check .
+bun run --cwd packages/cloud/services/agent-server lint             # biome check --write --unsafe .
+bun run --cwd packages/cloud/services/agent-server lint:check       # biome check .
+bun run --cwd packages/cloud/services/agent-server format           # biome format --write .
+bun run --cwd packages/cloud/services/agent-server format:check     # biome format .
 bun run --cwd packages/cloud/services/agent-server test             # bun test
 bun run --cwd packages/cloud/services/agent-server test:unit        # bun test __tests__/unit/
-bun run --cwd packages/cloud/services/agent-server test:integration # __tests__/integration/ (pass-with-no-tests)
 ```
 
 ## Environment variables

--- a/packages/cloud/services/agent-server/CLAUDE.md
+++ b/packages/cloud/services/agent-server/CLAUDE.md
@@ -43,10 +43,12 @@ Scope with `--cwd packages/cloud/services/agent-server`:
 bun run --cwd packages/cloud/services/agent-server start            # bun run src/index.ts
 bun run --cwd packages/cloud/services/agent-server dev              # bun --watch run src/index.ts
 bun run --cwd packages/cloud/services/agent-server typecheck        # tsgo --noEmit
-bun run --cwd packages/cloud/services/agent-server lint             # biome check .
+bun run --cwd packages/cloud/services/agent-server lint             # biome check --write --unsafe .
+bun run --cwd packages/cloud/services/agent-server lint:check       # biome check .
+bun run --cwd packages/cloud/services/agent-server format           # biome format --write .
+bun run --cwd packages/cloud/services/agent-server format:check     # biome format .
 bun run --cwd packages/cloud/services/agent-server test             # bun test
 bun run --cwd packages/cloud/services/agent-server test:unit        # bun test __tests__/unit/
-bun run --cwd packages/cloud/services/agent-server test:integration # __tests__/integration/ (pass-with-no-tests)
 ```
 
 ## Environment variables

--- a/packages/cloud/services/coding-remote-runner/AGENTS.md
+++ b/packages/cloud/services/coding-remote-runner/AGENTS.md
@@ -41,6 +41,8 @@ bun run --cwd packages/cloud/services/coding-remote-runner start        # boot t
 bun run --cwd packages/cloud/services/coding-remote-runner dev          # boot with --watch
 bun run --cwd packages/cloud/services/coding-remote-runner test         # bun test
 bun run --cwd packages/cloud/services/coding-remote-runner typecheck    # tsgo --noEmit
+bun run --cwd packages/cloud/services/coding-remote-runner lint:check   # biome check .
+bun run --cwd packages/cloud/services/coding-remote-runner format:check # biome format .
 bun run --cwd packages/cloud/services/coding-remote-runner docker:build # build the local image
 ```
 

--- a/packages/cloud/services/coding-remote-runner/CLAUDE.md
+++ b/packages/cloud/services/coding-remote-runner/CLAUDE.md
@@ -41,6 +41,8 @@ bun run --cwd packages/cloud/services/coding-remote-runner start        # boot t
 bun run --cwd packages/cloud/services/coding-remote-runner dev          # boot with --watch
 bun run --cwd packages/cloud/services/coding-remote-runner test         # bun test
 bun run --cwd packages/cloud/services/coding-remote-runner typecheck    # tsgo --noEmit
+bun run --cwd packages/cloud/services/coding-remote-runner lint:check   # biome check .
+bun run --cwd packages/cloud/services/coding-remote-runner format:check # biome format .
 bun run --cwd packages/cloud/services/coding-remote-runner docker:build # build the local image
 ```
 

--- a/packages/cloud/services/coding-remote-runner/package.json
+++ b/packages/cloud/services/coding-remote-runner/package.json
@@ -7,6 +7,11 @@
   "scripts": {
     "start": "bun run src/index.ts",
     "dev": "bun --watch run src/index.ts",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "lint:fix": "bunx @biomejs/biome check --write --unsafe .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format .",
     "typecheck": "tsgo --noEmit",
     "test": "bun test",
     "docker:build": "docker build -t eliza-coding-remote-runner:local ."


### PR DESCRIPTION
## Summary

Final #12902 tail slice for cloud/deploy package script normalization.

- adds standard mutating/read-only lint and format verbs to remaining cloud package manifests
- removes the type-only `build` script from `packages/cloud/api`; `typecheck` remains the no-emit command
- removes the fake `agent-server` `test:integration` script that pointed at a nonexistent directory with `--pass-with-no-tests`
- gives the temporary `_smoke-mcp` harness real `build`/`clean` and standard check verbs
- updates matching package-local `CLAUDE.md`/`AGENTS.md` command docs and verifies parity

Evidence: `.github/issue-evidence/12902-cloud-deploy-tail-scripts.md`

## Verification

Passed:

```bash
find packages/cloud packages/registry packages/plugin-remote-manifest packages/plugin-worker-runtime packages/plugin-sub-agent-claude-code -name package.json -maxdepth 4 -print0 | xargs -0 jq -e '.name and (.scripts|type=="object")' >/dev/null
git diff --check
node <static #12902 manifest guard>
# packages=18 issues=0

bun run --cwd packages/cloud/infra lint:check
bun run --cwd packages/cloud/docs-redirect lint:check
bun run --cwd packages/cloud/api lint:check
bun run --cwd packages/cloud/services/coding-remote-runner lint:check
bun run --cwd packages/cloud/services/agent-server lint:check
bun run --cwd packages/cloud/services/_smoke-mcp lint:check

for p in packages/cloud/infra packages/cloud/docs-redirect packages/cloud/api packages/cloud/services/coding-remote-runner packages/cloud/services/agent-server packages/cloud/services/_smoke-mcp; do bun run --cwd "$p" format:check || exit $?; done

bun run --cwd packages/cloud/services/coding-remote-runner test

for d in packages/cloud/infra packages/cloud/docs-redirect packages/cloud/api packages/cloud/services/coding-remote-runner packages/cloud/services/agent-server; do cmp -s "$d/CLAUDE.md" "$d/AGENTS.md" || exit 1; done
```

Blocked by the temp worktree's incomplete dependency install, even after linking `/Users/shawwalters/eliza/node_modules`:

```bash
bun run --cwd packages/cloud/infra test
# Cannot find package 'yaml'

bun run --cwd packages/cloud/docs-redirect test
# vitest: command not found

bun run --cwd packages/cloud/services/agent-server test:unit
# Cannot resolve @elizaos/core / @elizaos/cloud-services-common / ioredis

bun run --cwd packages/cloud/services/coding-remote-runner typecheck
bun run --cwd packages/cloud/api typecheck
bun run --cwd packages/cloud/services/agent-server typecheck
bun run --cwd packages/cloud/services/_smoke-mcp typecheck
# Missing @types/node and/or @cloudflare/workers-types

bun run --cwd packages/cloud/services/_smoke-mcp build
# Wrangler reached bundling, then failed to resolve mcp-handler from the incomplete install.
```

Note: `packages/cloud/infra lint:check` exits successfully with one existing Biome warning in a Terraform interpolation string assertion.

Closes #12902.
