### PR TITLE
docs(#12233): prose headers + churn cleanup — app-core + app + shared (B03)

### DIFF
--- a/packages/app-core/src/api/__tests__/ensure-min-role.test.ts
+++ b/packages/app-core/src/api/__tests__/ensure-min-role.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Pins the tokenless authorization branch of the compat sensitive-route helper
+ * (`ensureCompatSensitiveRouteAuthorized`): a trusted same-machine loopback
+ * caller is granted OWNER, while remote or local-auth-required callers fail
+ * closed with 403. Drives the real helper against hand-built Node
+ * `http.IncomingMessage`/`ServerResponse` objects — no live server.
+ */
 import http from "node:http";
 import { Socket } from "node:net";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";

--- a/packages/app-core/src/api/__tests__/ensure-route-min-role.test.ts
+++ b/packages/app-core/src/api/__tests__/ensure-route-min-role.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Exercises the DB-aware route role gates `ensureRouteMinRole` and
+ * `ensureRouteAuthorized`: an owner browser session reaches OWNER routes, a
+ * machine session is treated as USER (blocked from OWNER), CSRF rejection
+ * precedes any role check on cookie writes, and the Android static-token
+ * local-auth path still resolves as OWNER. Harness mocks core `roleRank`,
+ * shared token resolution, the session store, `isTrustedLocalRequest`, and the
+ * `AuthStore` identity lookup; requests/responses are synthetic Node http objects.
+ */
 import http from "node:http";
 import { Socket } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/app-core/src/api/__tests__/identity-role-mapper.test.ts
+++ b/packages/app-core/src/api/__tests__/identity-role-mapper.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit test for `roleForIdentityKind`, the single identity-kind → canonical-role
+ * mapper (owner→OWNER, machine→USER, absent→NONE). Pure function call; no mocks
+ * or harness.
+ */
 import { describe, expect, it } from "vitest";
 import { roleForIdentityKind } from "../auth.js";
 

--- a/packages/app-core/src/api/auth-pairing-routes.test.ts
+++ b/packages/app-core/src/api/auth-pairing-routes.test.ts
@@ -1,3 +1,14 @@
+/**
+ * Covers `handleAuthPairingCompatRoutes` — the device-pairing compat routes
+ * (`GET /api/auth/pair-code`, `POST /api/auth/pair`): the pair code is visible
+ * only to trusted-loopback callers, a successful remote pair mints a revocable
+ * machine session (returning the session id, never the static API token) and
+ * reuses an existing owner identity when present, and the flow stays dark when
+ * pairing is disabled. Harness mocks core logger/`stringToUuid`, the agent
+ * config loader, shared loopback/token helpers, the `auth` module overrides,
+ * the session and `AuthStore` layers, and first-run provisioning; drives
+ * synthetic Node http request/response objects.
+ */
 import crypto from "node:crypto";
 import * as http from "node:http";
 import { Socket } from "node:net";

--- a/packages/app-core/src/api/auth-pairing-routes.ts
+++ b/packages/app-core/src/api/auth-pairing-routes.ts
@@ -1,3 +1,14 @@
+/**
+ * Mounts the device-pairing and first-run/auth-status compat HTTP routes:
+ * `GET /api/first-run/status`, `GET /api/auth/status`, `GET /api/auth/pair-code`,
+ * and `POST /api/auth/pair`. The rotating short pair code lives in process
+ * memory with a TTL and is disclosed only to trusted-loopback callers;
+ * `POST /api/auth/pair` rate-limits by client IP, validates the code, and (when
+ * a runtime DB is available) mints a revocable machine session bound to the
+ * owner or a `paired-device` identity — returning the session id rather than the
+ * forever-valid static API token. `/api/auth/status` is a public, secret-free
+ * probe the dashboard uses to decide whether to show the pairing/login UI.
+ */
 import crypto from "node:crypto";
 import type http from "node:http";
 import { loadElizaConfig } from "@elizaos/agent";

--- a/packages/app-core/src/api/auth/audit.test.ts
+++ b/packages/app-core/src/api/auth/audit.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Tests the auth audit emitter (`appendAuditEvent` + `redactMetadata`): events
+ * are written to the JSONL audit log and the auth store with token-shaped
+ * metadata redacted and user-agents truncated, the JSONL write still happens
+ * (and the store error rethrows) when the store fails, the store write is still
+ * attempted when the log path can't be created, and the log rotates once it
+ * hits the size limit. Uses a real temp `ELIZA_STATE_DIR` and a fake in-memory
+ * auth store.
+ */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/packages/app-core/src/api/auth/discord-exchange.test.ts
+++ b/packages/app-core/src/api/auth/discord-exchange.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Tests `resolveDiscordExchange`, the server-side Discord Activity OAuth2 code →
+ * user-id exchange: it fails closed (undefined) when the client id/secret are
+ * unconfigured, round-trips a valid code through the two-step token+user fetch
+ * (bearering the minted access token, never the secret), returns null on every
+ * upstream failure/empty-payload/thrown path, and never logs the client secret.
+ * Uses a sequenced fetch stub and a settings-backed fake runtime.
+ */
 import { logger } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {

--- a/packages/app-core/src/api/auth/embed-handshake.test.ts
+++ b/packages/app-core/src/api/auth/embed-handshake.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Tests `verifyEmbedLaunch`, the shared connector-embed launch handshake:
+ * accepts a correctly HMAC-signed Telegram Mini App `initData` (and an injected
+ * Discord code exchange) for OWNER/ADMIN principals, and fails closed with 403
+ * on insufficient role, forged signature, stale `auth_date`, missing bot token,
+ * or a failed/empty Discord exchange — with role checks skipped once the payload
+ * is rejected. Builds real signed Telegram payloads and injects a stub
+ * `hasRoleAccess`/`discordExchange`; the clock is a fixed constant.
+ */
 import { createHmac } from "node:crypto";
 import type { IAgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/app-core/src/api/auth/embed-handshake.ts
+++ b/packages/app-core/src/api/auth/embed-handshake.ts
@@ -1,3 +1,8 @@
+/**
+ * Home of `verifyEmbedLaunch` — the shared, fail-closed launch handshake that
+ * every connector embed (Telegram Mini App, Discord Activity) passes through
+ * before a scoped session token is minted.
+ */
 import { createHmac, timingSafeEqual } from "node:crypto";
 import {
   hasRoleAccess as coreHasRoleAccess,

--- a/packages/app-core/src/api/auth/embed-session-token.test.ts
+++ b/packages/app-core/src/api/auth/embed-session-token.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests the embed session-token codec: HMAC-signed mint/verify round-trips,
+ * fail-closed rejection of wrong-secret / tampered / expired / malformed tokens,
+ * and the `isEmbedRole` / `EMBED_ELEVATED_ROLES` elevated-role gate. Pure
+ * functions exercised directly with a fixed secret — no server or clock harness.
+ */
 import { describe, expect, it } from "vitest";
 import {
   EMBED_ELEVATED_ROLES,

--- a/packages/app-core/src/api/auth/passwords.test.ts
+++ b/packages/app-core/src/api/auth/passwords.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests the password-strength guard enforced at the auth sign-up/reset boundary:
+ * `assertPasswordStrong` acceptance, and the too-short / missing-letter /
+ * missing-digit-or-symbol rejections plus the typed `WeakPasswordError.reason`.
+ * Pure-function assertions, no server harness.
+ */
 import { describe, expect, it } from "vitest";
 import {
   assertPasswordStrong,

--- a/packages/app-core/src/api/auth/sensitive-rate-limit.test.ts
+++ b/packages/app-core/src/api/auth/sensitive-rate-limit.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Tests the sensitive-auth rate limiters: per-IP attempt budgets
+ * (`SENSITIVE_RATE_LIMIT_MAX` over the window), isolation between named route
+ * buckets, rejection of empty limiter names, window-expiry reset, the shared
+ * null-IP "unknown" bucket, and the `_resetSensitiveLimiters` test hook (which
+ * also clears the shared `bootstrapExchangeLimiter`). Time is passed explicitly,
+ * so there is no fake clock.
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import {
   _resetSensitiveLimiters,

--- a/packages/app-core/src/api/auth/tokens.ts
+++ b/packages/app-core/src/api/auth/tokens.ts
@@ -1,3 +1,9 @@
+/**
+ * Constant-time token equality for API auth. `tokenMatches` compares an expected
+ * secret/bearer token against a provided one without leaking length or content
+ * through timing: it pads both buffers to equal length before a timing-safe
+ * compare and folds the true length check into the returned boolean.
+ */
 import crypto from "node:crypto";
 
 /** Timing-safe token comparison (constant-time regardless of input length). */

--- a/packages/app-core/src/api/automation-action-classifier.ts
+++ b/packages/app-core/src/api/automation-action-classifier.ts
@@ -1,3 +1,8 @@
+/**
+ * Classifies a loaded runtime action into an automation-node `class` from its
+ * declared tags: actions carrying the agent-orchestration + delegate capability
+ * tags surface as `"agent"` nodes, everything else as plain `"action"` nodes.
+ */
 import { type Action, hasActionTags } from "@elizaos/core";
 import type { AutomationNodeDescriptor } from "@elizaos/shared";
 

--- a/packages/app-core/src/api/automation-node-contributors.ts
+++ b/packages/app-core/src/api/automation-node-contributors.ts
@@ -1,3 +1,12 @@
+/**
+ * Registry and builder for automation-catalog node contributors. Plugins register
+ * a contributor keyed by id; `listAutomationNodeContributors` returns them so the
+ * automation-catalog route can collect each plugin's `AutomationNodeDescriptor`s,
+ * keeping catalog ownership with the owning plugin. `buildRuntimeCapabilityNodes`
+ * turns declarative `RuntimeCapabilityNodeSpec`s into descriptors, gating each
+ * node's availability on the runtime's loaded actions/plugins (marked disabled
+ * with a `disabledReason` when the backing capability is absent).
+ */
 import type { loadElizaConfig } from "@elizaos/agent";
 import type { AgentRuntime, UUID } from "@elizaos/core";
 import type { AutomationNodeDescriptor } from "@elizaos/shared";

--- a/packages/app-core/src/api/automations-compat-routes.test.ts
+++ b/packages/app-core/src/api/automations-compat-routes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Tests `classifyRuntimeActionNode`'s tag-based classification: an action carrying
+ * the agent-orchestration / delegate tags maps to the `"agent"` node class, while
+ * an ordinary tagged action stays in the `"action"` class.
+ */
 import { describe, expect, it } from "vitest";
 import { classifyRuntimeActionNode } from "./automation-action-classifier.ts";
 

--- a/packages/app-core/src/api/background-tasks-routes.test.ts
+++ b/packages/app-core/src/api/background-tasks-routes.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Tests `handleBackgroundTasksRoute`, the POST /api/background/run-due-tasks
+ * handler that routes native background wakes into the canonical core
+ * `TaskService.runDueTasks()`. Covers the happy run, the 503 when no task
+ * service is present, coalescing of concurrent wakes into one in-flight run, and
+ * pass-through of unrelated paths (with a stubbed `getService`/auth) — then an
+ * end-to-end pass against a real `AgentRuntime` + `TaskService` that seeds, runs,
+ * and deletes a real due one-shot task.
+ */
 import * as http from "node:http";
 import { Socket } from "node:net";
 import {

--- a/packages/app-core/src/api/background-tasks-routes.ts
+++ b/packages/app-core/src/api/background-tasks-routes.ts
@@ -1,3 +1,10 @@
+/**
+ * Mounts POST /api/background/run-due-tasks, the entry point for platform-native
+ * background wakes. It authorizes the request, resolves the canonical core
+ * `TaskService` off the current runtime, and drives `runDueTasks()` — coalescing
+ * concurrent wakes into a single in-flight run rather than standing up a second
+ * scheduler. Returns 503 when the runtime or task service is unavailable.
+ */
 import type http from "node:http";
 import { type Service, ServiceType } from "@elizaos/core";
 import { ensureRouteAuthorized } from "./auth.ts";

--- a/packages/app-core/src/api/catalog-routes.ts
+++ b/packages/app-core/src/api/catalog-routes.ts
@@ -1,13 +1,13 @@
-// Catalog routes — surfaces the registry SoT to the frontend.
-//
-// /api/catalog/apps  → static apps known to the registry (internal-tool apps,
-//                      curated apps, plugin-shipped apps). Lets AppsView stop
-//                      depending on the hardcoded internal-tool app table
-//                      and the ELIZA_CURATED_APP_DEFINITIONS list.
-//
-// Server-discovered apps (npm packages installed at runtime) and overlay
-// apps (runtime-registered) are still merged on the frontend; this endpoint
-// covers the static, declared catalog only.
+/**
+ * Catalog routes — surfaces the static app registry as JSON for the dashboard.
+ *
+ * Mounts `GET /api/catalog/apps`, returning the apps the registry declares
+ * (internal-tool, curated, and plugin-shipped apps) as `RegistryAppInfo` so the
+ * frontend's AppsView need not hardcode the internal-tool app table or the
+ * ELIZA_CURATED_APP_DEFINITIONS list. Server-discovered apps (npm packages
+ * installed at runtime) and runtime-registered overlay apps are merged in on the
+ * frontend; this endpoint covers only the static, declared catalog.
+ */
 
 import type http from "node:http";
 import { resolveAppHeroImage } from "@elizaos/agent";

--- a/packages/app-core/src/api/cloud-pair-route.test.ts
+++ b/packages/app-core/src/api/cloud-pair-route.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Exercises `handleCloudPairRoute` — the `/pair` HTTP handler that redeems a
+ * cloud pairing token against the cloud API and returns an HTML handoff page
+ * that stores the returned apiKey in sessionStorage. Drives real
+ * http.IncomingMessage/ServerResponse fakes and stubs `globalThis.fetch` to
+ * simulate the cloud API; covers the missing-token, expired, unreachable, no-key,
+ * XSS-escaping, origin-forwarding, and per-IP rate-limit branches.
+ */
 import * as http from "node:http";
 import { Socket } from "node:net";
 import {

--- a/packages/app-core/src/api/compat-route-shared-trust.test.ts
+++ b/packages/app-core/src/api/compat-route-shared-trust.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies that app-core's `isTrustedLocalRequest` wrapper wires the correct
+ * policy gates into the shared trust classifier, using real
+ * http.IncomingMessage fakes with spoofable Host / X-Forwarded-For headers.
+ */
 import http from "node:http";
 import { Socket } from "node:net";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";

--- a/packages/app-core/src/api/compat-route-shared.ts
+++ b/packages/app-core/src/api/compat-route-shared.ts
@@ -1,3 +1,14 @@
+/**
+ * Shared primitives for the app-core compat HTTP API (the `*-compat-routes`
+ * handlers). Holds the mutable `CompatRuntimeState` container (live runtime +
+ * pending restart reasons) and the helpers those routes lean on: a bounded
+ * restart-reason queue, same-machine trust (`isTrustedLocalRequest`, delegating
+ * to the canonical `@elizaos/shared` classifier with app-core's env gates), a
+ * size-capped JSON body reader that honours a pre-parsed `req.body`, first-run
+ * completion detection from persisted config, and a best-effort grab of the
+ * live Drizzle DB handle. `null` from the DB grab means "service unavailable",
+ * never authentication.
+ */
 import type http from "node:http";
 import { loadElizaConfig } from "@elizaos/agent/config/config";
 import type { AgentRuntime } from "@elizaos/core";

--- a/packages/app-core/src/api/credential-resolver.test.ts
+++ b/packages/app-core/src/api/credential-resolver.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises the credential resolver (`resolveProviderCredential`,
+ * `resolveProviderCredentialMulti`, `scanAllCredentials`) against the real
+ * core model-provider secret catalog and `SECRET_KEY_ALIASES`, driving actual
+ * `process.env` values (no mocks) and restoring them per test. Covers env-alias
+ * normalization, full-catalog scanning, and refusal of subscription selections.
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import {
   resolveProviderCredential,

--- a/packages/app-core/src/api/credential-tunnel-routes.test.ts
+++ b/packages/app-core/src/api/credential-tunnel-routes.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Exercises `handleCredentialTunnelRoute` — the POST `/api/credential-tunnel`
+ * (+ legacy `/submit` alias) handler that hands a credential from the owner
+ * runtime to a sub-agent session via the SubAgentCredentialBridge service.
+ * Drives both a vi-mocked bridge and the real bridge adapter (over a real
+ * credential-tunnel + dispatch registry) with fake http req/res; asserts the
+ * OWNER-auth gate, no-bridge 503, identifier validation, single-redemption, and
+ * the full CredentialScopeError-code → HTTP-status mapping.
+ */
 import * as http from "node:http";
 import { Socket } from "node:net";
 import { createSensitiveRequestDispatchRegistry } from "@elizaos/core";

--- a/packages/app-core/src/api/credential-tunnel-routes.ts
+++ b/packages/app-core/src/api/credential-tunnel-routes.ts
@@ -1,3 +1,12 @@
+/**
+ * Mounts POST `/api/credential-tunnel` (and the legacy `/submit` alias): the
+ * owner-only endpoint that tunnels a single secret to a sub-agent session.
+ * Requires the OWNER role, validates the child-session/scope identifiers and
+ * key against strict allow-lists, then delegates to the runtime's
+ * SubAgentCredentialBridge service. Translates each `CredentialScopeError.code`
+ * to its HTTP status (invalid→400, unknown→404, expired→410, mismatch/redeemed
+ * →403, no_ciphertext→409) and returns 503 when no bridge is registered.
+ */
 import type http from "node:http";
 import {
   CredentialScopeError,

--- a/packages/app-core/src/api/database-rows-compat-routes.test.ts
+++ b/packages/app-core/src/api/database-rows-compat-routes.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Exercises `handleDatabaseRowsCompatRoute` — the dashboard table-browser raw
+ * row read — with its OWNER-role gate as the focus. Drives the real
+ * `ensureRouteMinRole` through mocked session/identity primitives (and the
+ * injectable `ensureOwner` seam) so a USER-tier session is denied 403 before any
+ * SQL runs; mocks `@elizaos/shared` SQL helpers with canned introspection/count
+ * results to cover the OWNER read, malformed-count, and numeric-string paths.
+ */
 import http from "node:http";
 import { Socket } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -243,8 +251,8 @@ describe("handleDatabaseRowsCompatRoute", () => {
 describe("GET /api/database/tables/:name/rows OWNER gate", () => {
   it("rejects a USER-role machine session with 403 and never reads the table", async () => {
     // A machine identity resolves to the USER tier: an active session, but
-    // not OWNER. Before the fix this reached raw SELECT * FROM <table>; now
-    // it must be denied at the gate.
+    // not OWNER. A raw SELECT * FROM <table> must be denied at the gate before
+    // any SQL runs.
     mocks.findActiveSession.mockResolvedValue(
       makeSession({ id: "machine-session", kind: "machine" }),
     );

--- a/packages/app-core/src/api/database-rows-compat-routes.ts
+++ b/packages/app-core/src/api/database-rows-compat-routes.ts
@@ -1,3 +1,13 @@
+/**
+ * Mounts GET `/api/database/tables/:name/rows` — the dashboard table browser's
+ * raw-row read. Requires OWNER (raw reads can expose secrets/sessions/identity
+ * tables), then introspects the table's schema and column list (cached with a
+ * short TTL and bounded size), resolving an ambiguous unqualified name to
+ * `public` where possible. Returns a paginated, searchable (ILIKE across all
+ * columns), sortable page plus an exact `count(*)`; identifiers are sanitized
+ * and quoted and literals escaped for the raw SQL. A count that cannot be parsed
+ * raises a typed `DB_COUNT_UNAVAILABLE` rather than fabricating zero.
+ */
 import type http from "node:http";
 import { ElizaError } from "@elizaos/core";
 import {

--- a/packages/app-core/src/api/dev-boot-history.test.ts
+++ b/packages/app-core/src/api/dev-boot-history.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit test for buildBootHistoryPayload — the /api/dev/boot-history payload
+ * builder. Verifies plugin-load failures surface via the mocked
+ * getLastFailedPluginDetails() accessor from @elizaos/agent (and that an empty
+ * accessor yields no failures), exercised against a real temp state dir.
+ */
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/packages/app-core/src/api/dev-compat-routes.ts
+++ b/packages/app-core/src/api/dev-compat-routes.ts
@@ -1,3 +1,11 @@
+/**
+ * Loopback-only dev observability route surface mounted under /api/dev/*.
+ * handleDevCompatRoutes dispatches GET probes (stack, route-catalog,
+ * cursor-screenshot, console-log, voice/inference/device-resource metrics,
+ * boot-history, route-timings), gating each on a loopback origin plus route
+ * authorization and short-circuiting to 404 when NODE_ENV is production. Returns
+ * true once it owns a request, false to let the caller keep dispatching.
+ */
 import type http from "node:http";
 import { ensureRouteAuthorized } from "./auth.ts";
 import {

--- a/packages/app-core/src/api/dev-console-log.guard.test.ts
+++ b/packages/app-core/src/api/dev-console-log.guard.test.ts
@@ -1,15 +1,16 @@
+/**
+ * Tests for the dev-console-log path guard (#8801 / #9943): isAllowedDevConsole
+ * LogPath gates a file READ exposed over the dev API, so without it a traversal
+ * could read arbitrary files. Only `desktop-dev-console.log` UNDER the resolved
+ * state dir (incl. nested) is allowed; wrong basenames, paths outside the state
+ * dir, and `..` escapes are rejected.
+ */
 import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { isAllowedDevConsoleLogPath } from "./dev-console-log";
 
-/**
- * Tests for the dev-console-log path guard (#8801 / #9943). isAllowedDevConsole
- * LogPath gates a file READ exposed over the dev API; without it a traversal
- * could read arbitrary files. It must allow only `desktop-dev-console.log` UNDER
- * the state dir. It was untested.
- */
 describe("isAllowedDevConsoleLogPath", () => {
   let stateDir: string;
   const prev = process.env.ELIZA_STATE_DIR;

--- a/packages/app-core/src/api/dev-route-catalog.test.ts
+++ b/packages/app-core/src/api/dev-route-catalog.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit + route tests for buildRouteCatalog and GET /api/dev/route-catalog: the
+ * catalog covers every TAB_PATHS entry and mirrors SETTINGS_SECTION_META from
+ * @elizaos/ui exactly, and the route is loopback-only and disabled in
+ * production. Auth, config, and port resolution are mocked to true/fixed values.
+ */
 import * as http from "node:http";
 import { Socket } from "node:net";
 import { SETTINGS_SECTION_META } from "@elizaos/ui/components/settings/settings-section-meta";

--- a/packages/app-core/src/api/dev-voice-latency-route.test.ts
+++ b/packages/app-core/src/api/dev-voice-latency-route.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Route test for GET /api/dev/voice-latency via handleDevCompatRoutes, driving
+ * the real voiceLatencyTracer from @elizaos/plugin-local-inference: asserts the
+ * traces + histograms + metadata payload, ?limit= truncation (newest last),
+ * loopback-only rejection, and prod-disabled behavior.
+ */
 import { Socket } from "node:net";
 import {
   afterEach,

--- a/packages/app-core/src/api/drop-status-compat-route.test.ts
+++ b/packages/app-core/src/api/drop-status-compat-route.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit test for handleDropStatusCompatRoute: GET /api/drop/status is claimed
+ * (returns true) only when the sensitive-route auth gate rejects; authorized or
+ * non-matching requests fall through (returns false). The auth gate is mocked
+ * under both `./auth` and `./auth.ts` specifiers, with per-test module resets.
+ */
 import http from "node:http";
 import { Socket } from "node:net";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/app-core/src/api/drop-status-compat-route.ts
+++ b/packages/app-core/src/api/drop-status-compat-route.ts
@@ -1,3 +1,9 @@
+/**
+ * Compat guard for GET /api/drop/status. When the sensitive-route auth gate
+ * rejects, it logs and claims the request (returns true) so the caller stops;
+ * for authorized or non-matching requests it returns false to fall through to
+ * the real handler. It never serves drop status itself — only the auth gate.
+ */
 import type http from "node:http";
 import { logger } from "@elizaos/core";
 import { ensureCompatSensitiveRouteAuthorized } from "./auth.ts";

--- a/packages/app-core/src/api/embed-auth-routes.test.ts
+++ b/packages/app-core/src/api/embed-auth-routes.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Route tests for handleEmbedAuthRoutes (POST /api/embed/auth): a platform
+ * launch handshake (Telegram/Discord, dependency-injected verifyEmbedLaunch) is
+ * validated and, on success, minted into a scoped embed-session token that the
+ * compat API auth gate accepts through the same reader. Covers the 503/400/403
+ * fail-closed paths and env-only vs runtime-only signing-secret sources.
+ */
 import * as http from "node:http";
 import { Socket } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/app-core/src/api/first-run-persistence.restart.test.ts
+++ b/packages/app-core/src/api/first-run-persistence.restart.test.ts
@@ -1,18 +1,3 @@
-import * as fs from "node:fs";
-import * as os from "node:os";
-import * as path from "node:path";
-// Import from narrow subpaths, not the "@elizaos/agent" barrel: the barrel's
-// runtime/eliza.ts has dynamic plugin imports (e.g. @elizaos/plugin-birdclaw)
-// that the test bundler cannot resolve. These are the same production functions.
-import { applyCanonicalFirstRunConfig } from "@elizaos/agent/api/provider-switch-config";
-import { loadElizaConfig, saveElizaConfig } from "@elizaos/agent/config/config";
-import {
-  normalizeDeploymentTargetConfig,
-  normalizeServiceRoutingConfig,
-} from "@elizaos/shared";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { hasCompatPersistedFirstRunState } from "./compat-route-shared";
-
 /**
  * Regression guard for issue #11506 (symptom 2: "onboarding never persists").
  *
@@ -39,6 +24,20 @@ import { hasCompatPersistedFirstRunState } from "./compat-route-shared";
  * first-run filesystem (no config on disk), then simulates a restart by calling
  * `loadElizaConfig()` again against that same on-disk state.
  */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+// Import from narrow subpaths, not the "@elizaos/agent" barrel: the barrel's
+// runtime/eliza.ts has dynamic plugin imports (e.g. @elizaos/plugin-birdclaw)
+// that the test bundler cannot resolve. These are the same production functions.
+import { applyCanonicalFirstRunConfig } from "@elizaos/agent/api/provider-switch-config";
+import { loadElizaConfig, saveElizaConfig } from "@elizaos/agent/config/config";
+import {
+  normalizeDeploymentTargetConfig,
+  normalizeServiceRoutingConfig,
+} from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { hasCompatPersistedFirstRunState } from "./compat-route-shared";
 
 let stateDir: string;
 let priorStateDir: string | undefined;

--- a/packages/app-core/src/api/first-run-routes.ts
+++ b/packages/app-core/src/api/first-run-routes.ts
@@ -1,3 +1,16 @@
+/**
+ * Mounts `POST /api/first-run`, the onboarding submit endpoint. Parses the
+ * first-run payload, rejects deprecated field shapes, and persists the chosen
+ * deployment target / linked accounts / service routing into `ElizaConfig`
+ * (flipping `meta.firstRunComplete`). When the run is cloud-linked it resolves
+ * the Eliza Cloud API key from config, sealed secrets, or env and writes it
+ * back so the upstream config save keeps it, then mirrors the merged config to
+ * the live runtime through a loopback `PUT /api/config`.
+ *
+ * A defensive delayed resave (`scheduleCloudApiKeyResave`) re-writes
+ * `cloud.apiKey` if a concurrent config write clobbers it — a best-effort
+ * workaround for an unreproduced upstream race, logged at warn on failure.
+ */
 import type http from "node:http";
 import {
   applyCanonicalFirstRunConfig,

--- a/packages/app-core/src/api/i18n-locale-routes.test.ts
+++ b/packages/app-core/src/api/i18n-locale-routes.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `resolveSuggestedUiLanguage` and the `GET /api/i18n/locale`
+ * route handler, driving fake `http.IncomingMessage`/`ServerResponse` objects
+ * with a mocked `loadElizaConfig`. Covers configured-language preference,
+ * Accept-Language q-value fallback, and unrelated-route pass-through.
+ */
 import * as http from "node:http";
 import { Socket } from "node:net";
 import { describe, expect, it, vi } from "vitest";

--- a/packages/app-core/src/api/i18n-locale-routes.ts
+++ b/packages/app-core/src/api/i18n-locale-routes.ts
@@ -1,3 +1,10 @@
+/**
+ * Mounts the public `GET /api/i18n/locale` endpoint, which suggests a UI
+ * language for a fresh client. Prefers a configured non-English `ui.language`
+ * from `ElizaConfig`, otherwise selects the best-supported `Accept-Language`
+ * match in q-value order, and falls back to English. The selection logic lives
+ * in `resolveSuggestedUiLanguage` and is exercised directly by the unit tests.
+ */
 import type http from "node:http";
 import { loadElizaConfig } from "@elizaos/agent";
 import { normalizeLanguage } from "@elizaos/shared";

--- a/packages/app-core/src/api/internal-routes.test.ts
+++ b/packages/app-core/src/api/internal-routes.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the `POST /api/internal/wake` handler and `getDeviceSecret`,
+ * driving fake req/res objects. Covers device-secret bearer auth (401s), wake
+ * body validation, the happy path (runDueTasks fired, telemetry mirrored),
+ * runtime / task-service unavailability, error capture, deadline→maxWallTimeMs
+ * clamping, routing pass-through, and on-disk device-secret persistence + mode.
+ */
 import fs from "node:fs";
 import * as http from "node:http";
 import { Socket } from "node:net";

--- a/packages/app-core/src/api/internal-routes.ts
+++ b/packages/app-core/src/api/internal-routes.ts
@@ -1,3 +1,20 @@
+/**
+ * Mounts `POST /api/internal/wake`, the internal wake surface called by
+ * sandboxed background-runner JSContexts (Capacitor BackgroundRunner on iOS
+ * QuickJS / Android V8) and other host shims that cannot use cookie-based
+ * session auth. A wake POST fires the TaskService's `runDueTasks` once
+ * (coalescing concurrent calls) and records `WakeTelemetry` that /api/health
+ * reads to surface the last background tick.
+ *
+ * Auth model: a single device-secret bearer token. The runner JS is shipped
+ * with the secret as one of its event args at build/launch time, so the secret
+ * travels in-process and is not user input.
+ *
+ * The bearer secret is persisted under the Eliza state dir so background
+ * runners rebuilt independently of the host process can be seeded with a stable
+ * value across restarts. `ELIZA_DEVICE_SECRET` still wins when present and
+ * sufficiently long, which keeps managed deployments deterministic.
+ */
 import { randomBytes } from "node:crypto";
 import fs from "node:fs";
 import type http from "node:http";
@@ -6,21 +23,6 @@ import { resolveStateDir, type Service, ServiceType } from "@elizaos/core";
 import type { CompatRuntimeState } from "./compat-route-shared";
 import { readCompatJsonBody } from "./compat-route-shared";
 import { sendJson } from "./response";
-
-/**
- * Internal routes called by sandboxed background-runner JSContexts (Capacitor
- * BackgroundRunner on iOS QuickJS / Android V8) and by other host shims that
- * cannot use the cookie-based session auth.
- *
- * Auth model: a single device-secret bearer token. The runner JS is shipped
- * with the secret as one of its event args at build/launch time, so the
- * secret travels in-process and is not user input.
- *
- * The bearer secret is persisted under the Eliza state dir so background
- * runners rebuilt independently of the host process can be seeded with a
- * stable value across restarts. `ELIZA_DEVICE_SECRET` still wins when present
- * and sufficiently long, which keeps managed deployments deterministic.
- */
 
 /**
  * The runtime contract is `runDueTasks(): Promise<void>`. The optional

--- a/packages/app-core/src/api/ios-local-agent-transport.test.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Unit tests for the app-core iOS in-process local-agent transport bridge,
+ * driving `handleIosLocalAgentNativeRequest`, the fetch bridge, and the ITTP
+ * transport with hoisted Capacitor / build-variant / kernel mocks. Covers
+ * full-Bun native dispatch + start, the ITTP dev fallback, network-policy
+ * gating across local / cloud / store modes, watchdog restart handling, IPC
+ * path extraction (incl. Chromium custom-scheme URLs), and the #11030 hostile
+ * Capacitor-proxy deadlock guard.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const originalGlobalFetch = globalThis.fetch;

--- a/packages/app-core/src/api/ios-local-agent-transport.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.ts
@@ -1,3 +1,20 @@
+/**
+ * App-core copy of the iOS in-process local-agent transport. Bridges renderer
+ * HTTP — the global `fetch`, the `iosLocalAgentRequest` window-bridge
+ * capability, and the ITTP `AgentRequestTransport` — to the on-device agent
+ * instead of real network I/O, dispatching through either the full-Bun
+ * Capacitor runtime (`ElizaBunRuntime`, engine `"bun"`) or, in dev, the
+ * JSContext ITTP compatibility kernel.
+ *
+ * Enforces the iOS network policy: store/cloud builds block cleartext loopback
+ * and private-network hosts, and cloud mode only permits local-inference / TTS
+ * IPC. Chat token streams route through the streaming bridge (#12354), and
+ * watchdog restart requests re-run the full-Bun start path. Invariant: never
+ * await the raw Capacitor plugin proxy — its fabricated `then` trap resolves to
+ * a native method that never settles, so the runtime is always wrapped into a
+ * plain bound-method object first (#11030). A sibling copy lives in
+ * `@elizaos/ui`; both share one module-level boot-progress state.
+ */
 import { Capacitor, registerPlugin } from "@capacitor/core";
 import { getElizaApiBase } from "@elizaos/shared";
 import {

--- a/packages/app-core/src/api/response.ts
+++ b/packages/app-core/src/api/response.ts
@@ -1,3 +1,10 @@
+/**
+ * JSON response helpers for the app-core HTTP API. `sendJson` writes a status
+ * plus an `application/json` body (and is a no-op once headers are sent);
+ * `sendJsonError` wraps a message as `{ error }`. Every payload is serialized
+ * through a replacer that strips stack traces so error internals never leak to
+ * clients.
+ */
 import type http from "node:http";
 
 /**

--- a/packages/app-core/src/api/route-auth-policy.dispatch.test.ts
+++ b/packages/app-core/src/api/route-auth-policy.dispatch.test.ts
@@ -1,3 +1,13 @@
+/**
+ * H5 (#12228): the app-core compat dispatcher must be default-deny. The
+ * declarative policy table + `enforceCompatRouteAuthPolicy` landed in #12214;
+ * this test pins the behavior through the REAL dispatcher entrypoint
+ * (`handleElizaCompatRoute` → `handleCompatRoute` → `handleCompatRouteInner`),
+ * proving the gate short-circuits an un-gated (undeclared) compat route with a
+ * 401 BEFORE any `handle*` module runs — i.e. a future handler that forgets its
+ * own `ensureRoute*` call still cannot ship an unauthenticated compat route as
+ * long as its prefix is compat-managed.
+ */
 import http from "node:http";
 import { Socket } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -18,17 +28,6 @@ vi.mock(import("@elizaos/core"), async (importOriginal) => {
 
 import type { CompatRuntimeState } from "./compat-route-shared";
 import { handleElizaCompatRoute } from "./server";
-
-/**
- * H5 (#12228): the app-core compat dispatcher must be default-deny. The
- * declarative policy table + `enforceCompatRouteAuthPolicy` landed in #12214;
- * this test pins the behavior through the REAL dispatcher entrypoint
- * (`handleElizaCompatRoute` → `handleCompatRoute` → `handleCompatRouteInner`),
- * proving the gate short-circuits an un-gated (undeclared) compat route with a
- * 401 BEFORE any `handle*` module runs — i.e. a future handler that forgets its
- * own `ensureRoute*` call still cannot ship an unauthenticated compat route as
- * long as its prefix is compat-managed.
- */
 
 const STATE: CompatRuntimeState = {
   current: null,

--- a/packages/app-core/src/api/route-auth-policy.test.ts
+++ b/packages/app-core/src/api/route-auth-policy.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the compat route auth-policy table and its enforcement gate,
+ * driving real `http.IncomingMessage` / `ServerResponse` doubles through
+ * `enforceCompatRouteAuthPolicy` to assert tier resolution, prefix-bleed
+ * safety, fail-closed 401s for undeclared managed routes, and pass-through of
+ * unmanaged paths to the upstream server.
+ */
 import http from "node:http";
 import { Socket } from "node:net";
 import { describe, expect, it } from "vitest";

--- a/packages/app-core/src/api/route-auth-policy.ts
+++ b/packages/app-core/src/api/route-auth-policy.ts
@@ -1,3 +1,17 @@
+/**
+ * Auth-policy table plus enforcement gate for the app-core compat HTTP surface.
+ *
+ * Each declaration binds a route to a required tier — `public`, `session`, or
+ * `OWNER` — matched against method + pathname by exact path, path prefix, or
+ * regex. `resolveCompatRouteAuthPolicy` returns the first matching declaration;
+ * `isCompatManagedRoute` reports whether a path falls under an app-core-owned
+ * prefix. `enforceCompatRouteAuthPolicy` is the dispatcher gate: it allows
+ * public routes, runs session/OWNER checks via `ensureRouteAuthorized` /
+ * `ensureRouteMinRole`, fails closed with 401 for any managed-prefix path that
+ * has no explicit policy, and returns "unmanaged" so unrelated paths fall
+ * through to the upstream agent server. The policy list and the managed-prefix
+ * list must stay in sync — a managed prefix with no matching policy 401s.
+ */
 import type http from "node:http";
 import { ensureRouteAuthorized, ensureRouteMinRole } from "./auth.ts";
 import type { CompatRuntimeState } from "./compat-route-shared";

--- a/packages/app-core/src/api/secrets-manager-routes.ts
+++ b/packages/app-core/src/api/secrets-manager-routes.ts
@@ -1,3 +1,14 @@
+/**
+ * Mounts the Settings → Secrets Manager HTTP surface: `/api/secrets/manager/*`
+ * (backend detection, preferences, install-method discovery, SSE-streamed
+ * install jobs, and vendor sign-in/out) and `/api/secrets/logins/*` (in-app
+ * browser saved-login list/reveal/CRUD plus per-domain autofill toggles). Every
+ * route is OWNER-gated in the handler itself, not only by the dispatch prefix,
+ * and wraps `@elizaos/vault`'s SecretsManager, which routes sensitive writes to
+ * the user's chosen password manager with `in-house` as the always-available
+ * fallback. See the block above `getManager` for the per-process-singleton and
+ * shared-vault-mutex rationale.
+ */
 import type http from "node:http";
 import {
   type BackendId,

--- a/packages/app-core/src/api/secrets-routes-auth.test.ts
+++ b/packages/app-core/src/api/secrets-routes-auth.test.ts
@@ -1,16 +1,16 @@
+/**
+ * #12087 Item 4: the secrets handlers must reject non-OWNER callers on their own,
+ * not merely rely on the `/api/secrets/*` prefix gate in server.ts. These tests
+ * call each handler DIRECTLY (bypassing the dispatch prefix) with a remote,
+ * unauthenticated caller and assert a 401 before any secrets logic runs, plus a
+ * false return (no auth side effects) for paths outside the secrets prefix.
+ */
 import * as http from "node:http";
 import { Socket } from "node:net";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { CompatStateLike } from "./auth.ts";
 import { handleSecretsInventoryRoute } from "./secrets-inventory-routes";
 import { handleSecretsManagerRoute } from "./secrets-manager-routes";
-
-/**
- * #12087 Item 4: the secrets handlers must reject non-OWNER callers on their own,
- * not merely rely on the `/api/secrets/*` prefix gate in server.ts. These tests
- * call each handler DIRECTLY (bypassing the dispatch prefix) with a remote,
- * unauthenticated caller and assert a 401 before any secrets logic runs.
- */
 
 interface FakeRes {
   res: http.ServerResponse;

--- a/packages/app-core/src/api/sensitive-request-routes.test.ts
+++ b/packages/app-core/src/api/sensitive-request-routes.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for the local sensitive-request HTTP routes: the create → submit
+ * lifecycle over an in-memory `LocalSensitiveRequestStore` with an injected
+ * clock and fulfillment hooks. Covers the no-tunnel fallback (no public link
+ * issued), authenticated-tunnel delivery, the tunnel-auth-required 403,
+ * expired/replayed submit-token rejection, and that secret / private-info
+ * values and submit tokens never appear in any response body.
+ */
 import * as http from "node:http";
 import { Socket } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/app-core/src/api/sensitive-request-routes.ts
+++ b/packages/app-core/src/api/sensitive-request-routes.ts
@@ -1,3 +1,16 @@
+/**
+ * HTTP routes under `/api/sensitive-requests` for collecting secrets and
+ * private info out-of-band. POST creates a request — validating the secret or
+ * private_info target, forcing a private-delivery policy, and resolving a
+ * delivery plan (owner-app instruction, DM fallback, or authenticated tunnel
+ * link) from the current environment. `/:id` GET returns a redacted view;
+ * `/:id/submit` consumes a single-use, timing-safe submit token and fulfills
+ * via the vault (secrets) or a caller-supplied hook (private info); `/:id/cancel`
+ * cancels a pending request. Callers must pass the trusted-local / API-token /
+ * session gate; tunnel-delivered requests additionally require local
+ * sensitive-request auth to be configured, else 403. Responses are always
+ * redacted so raw values and submit tokens never leak.
+ */
 import type http from "node:http";
 import {
   defaultSensitiveRequestPolicy,

--- a/packages/app-core/src/api/sensitive-request-store.ts
+++ b/packages/app-core/src/api/sensitive-request-store.ts
@@ -1,3 +1,14 @@
+/**
+ * In-memory store backing the local sensitive-request routes. Holds
+ * `SensitiveRequest` records keyed by id, each carrying a SHA-256 hash of a
+ * single-use submit token (never the token itself), a TTL-derived expiry, and a
+ * bounded audit trail. Enforces the submit-token lifecycle — timing-safe hash
+ * comparison, lazy expiry, single-use (replay yields 409), pending-only — and
+ * transitions records through fulfilled/failed/canceled/expired. Metadata is
+ * redacted on every audit append, and `redactLocalSensitiveRequest` strips the
+ * token hash before a record is serialized to a client.
+ * `localSensitiveRequestStore` is the shared process singleton.
+ */
 import crypto from "node:crypto";
 import {
   type JsonObject,

--- a/packages/app-core/src/api/server-cors.test.ts
+++ b/packages/app-core/src/api/server-cors.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for the server CORS origin allowlist. Verifies the packaged
+ * Electrobun `views://` scheme and native mobile schemes are trusted only for
+ * local hosts, that localhost is allowed on every env-configured port
+ * (API / UI / single-process / gateway / home plus Electrobun dev ports), that
+ * explicit `ELIZA_ALLOWED_ORIGINS` remote origins normalize and gate correctly,
+ * and that the env-derived port cache recomputes after invalidation.
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import {
   buildCorsAllowedPorts,

--- a/packages/app-core/src/api/server-reset-hop.test.ts
+++ b/packages/app-core/src/api/server-reset-hop.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Regression tests for #7409: `_clearCompatPgliteDataDirForTests` must stop the
+ * runtime and delete the `.elizadb` PGlite data dir purely in-process, never
+ * issuing a loopback HTTP request (which would deadlock the reset hop). Also
+ * asserts the delete still runs when `runtime.stop()` never resolves (watchdog
+ * timeout via fake timers), the safety guard refusing any dir not named
+ * `.elizadb`, and tolerance of a missing data dir. `@elizaos/core` logger and
+ * `@elizaos/agent` path resolvers are mocked to keep the reset hermetic.
+ */
 import fs, { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/packages/app-core/src/api/server-wallet-trade.ts
+++ b/packages/app-core/src/api/server-wallet-trade.ts
@@ -1,3 +1,12 @@
+/**
+ * Hardens the compat wallet-export route on top of `@elizaos/agent`'s upstream
+ * rejection check. Adds per-IP rate limiting (one export per 10 minutes), a
+ * two-phase confirmation nonce with a forced delay before an export is allowed,
+ * audit logging of every outcome, and compat auth-context + header mirroring
+ * around each upstream call. `resolveWalletExportRejection` is the hardened
+ * entry point consumed by the API server; it returns a rejection (status +
+ * reason) or `null` when the export may proceed.
+ */
 import crypto from "node:crypto";
 import type http from "node:http";
 import { resolveWalletExportRejection as upstreamResolveWalletExportRejection } from "@elizaos/agent";

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -1,3 +1,16 @@
+/**
+ * app-core wrapper around `@elizaos/agent`'s dashboard HTTP API. Monkey-patches
+ * `http.createServer` so every request first runs the compat pipeline — CORS for
+ * local renderers (Vite/WKWebView), env-alias and config-file sync, header
+ * mirroring, and `/api/status` body rewriting — then dispatches app-core compat
+ * routes (auth/session/pairing, cloud proxy + billing, secrets, sensitive
+ * requests, first-run, plugins, catalog, local-inference, agent reset) before
+ * delegating to the upstream listener. `startApiServer` wraps upstream start,
+ * seeds the module-scoped shared compat runtime state so the early and late
+ * patch sites share one reference, hydrates wallet keys, and installs the
+ * hardened wallet-export guard. Route helpers are re-exported here so tests can
+ * import them from `./server`.
+ */
 import fs from "node:fs";
 import http from "node:http";
 import { createRequire } from "node:module";
@@ -216,12 +229,6 @@ const _PACKAGE_ROOT_NAMES = new Set(["eliza", "elizaai", "elizaos"]);
 // Internal helpers used by the monkey-patch handler (stay in server.ts)
 // ---------------------------------------------------------------------------
 
-// extractHeaderValue — now imported from ./auth
-// tokenMatches — now imported from ./auth
-// Pairing infrastructure — now in ./auth-pairing-routes
-// getProvidedApiToken, ensureCompatApiAuthorized, isDevEnvironment,
-// ensureCompatSensitiveRouteAuthorized — now imported from ./auth
-
 function hydrateWalletOsStoreFlagFromConfig(): void {
   if (process.env.ELIZA_WALLET_OS_STORE?.trim()) {
     return;
@@ -391,8 +398,6 @@ async function clearCompatPgliteDataDir(
 }
 
 export const _clearCompatPgliteDataDirForTests = clearCompatPgliteDataDir;
-
-// sendJsonResponse, sendJsonErrorResponse — now imported from ./response
 
 function resolveCompatStatusAgentName(
   state: CompatRuntimeState,

--- a/packages/app-core/src/browser.ts
+++ b/packages/app-core/src/browser.ts
@@ -1,3 +1,11 @@
+/**
+ * Browser-safe surface of `@elizaos/app-core`, aliased in by browser bundlers in
+ * place of the Node `index.ts`. Re-exports the dashboard React/UI components,
+ * registration contracts, and Electrobun desktop runtimes from `@elizaos/ui` and
+ * `@elizaos/shared`, and provides inert stubs for the server-only helpers
+ * (`sendJson`, `ensureRouteAuthorized`, `sharedVault`, …) so browser code links
+ * against the same names without pulling in Node server modules.
+ */
 // Registration-surface contracts live in @elizaos/shared (React-free canonical
 // home); import them from there rather than the React package.
 export {

--- a/packages/app-core/src/cli/argv.test.ts
+++ b/packages/app-core/src/cli/argv.test.ts
@@ -1,3 +1,8 @@
+/**
+ * CLI argv parsing. argv is [node, script, ...args]; the helpers must respect
+ * the `--` terminator, support `--flag value` and `--flag=value`, and the
+ * state-migration gate must skip read-only subcommands (health/status/agent).
+ */
 import { describe, expect, it } from "vitest";
 import {
   getCommandPath,
@@ -10,12 +15,6 @@ import {
   shouldMigrateState,
   shouldMigrateStateFromPath,
 } from "./argv.js";
-
-/**
- * CLI argv parsing. argv is [node, script, ...args]; the helpers must respect
- * the `--` terminator, support `--flag value` and `--flag=value`, and the
- * state-migration gate must skip read-only subcommands (health/status/agent).
- */
 
 const cli = (...args: string[]): string[] => ["node", "eliza", ...args];
 

--- a/packages/app-core/src/cli/argv.ts
+++ b/packages/app-core/src/cli/argv.ts
@@ -1,3 +1,12 @@
+/**
+ * Pre-Commander CLI argument parsing helpers that operate on the raw `argv`
+ * (`[node, script, ...args]`). Detects help/version flags, reads flag presence
+ * and `--flag value` / `--flag=value` values while honoring the `--` terminator,
+ * extracts the positional command path, and normalizes argv so a program name or
+ * a `node`/`bun` executable prefix is handled uniformly. `shouldMigrateState` is
+ * the gate that lets read-only subcommands (health, status, agent, memory
+ * status) run without triggering state migration.
+ */
 import { parsePositiveInteger } from "@elizaos/shared";
 
 const HELP_FLAGS = new Set(["-h", "--help"]);

--- a/packages/app-core/src/cli/banner.ts
+++ b/packages/app-core/src/cli/banner.ts
@@ -1,3 +1,10 @@
+/**
+ * Formats and emits the one-time CLI startup banner — title (from
+ * `APP_CLI_NAME`, default "eliza"), version, and short commit hash, themed when
+ * the TTY is rich. `emitCliBanner` is idempotent via a module-level guard and
+ * stays silent for non-TTY output and for `--json` / `--version` invocations so
+ * machine-readable output is never polluted.
+ */
 import { isRich, theme } from "@elizaos/shared";
 import { resolveCommitHash } from "./git-commit";
 

--- a/packages/app-core/src/cli/cli-name.ts
+++ b/packages/app-core/src/cli/cli-name.ts
@@ -1,3 +1,10 @@
+/**
+ * Resolves the CLI's display name (`APP_CLI_NAME`, default "eliza") and rewrites
+ * command strings so generated help and examples show the active binary name.
+ * `replaceCliName` swaps a leading `eliza`/`elizaos` token — with an optional
+ * `bun`/`npm`/`bunx`/`npx` runner prefix matched by `CLI_PREFIX_RE` — for the
+ * resolved name, leaving unrelated commands untouched.
+ */
 import path from "node:path";
 
 /** CLI name — reads from APP_CLI_NAME env var, defaults to "eliza". */

--- a/packages/app-core/src/cli/cli-utils.ts
+++ b/packages/app-core/src/cli/cli-utils.ts
@@ -1,3 +1,8 @@
+/**
+ * Wraps a CLI command action in error handling: runs the async action and, on
+ * failure, either delegates to the optional `onError` callback or reports
+ * through the runtime's `error` and exits with code 1.
+ */
 export async function runCommandWithRuntime(
   runtime: { error: (message: string) => void; exit: (code: number) => void },
   action: () => Promise<void>,

--- a/packages/app-core/src/cli/doctor/checks.host-config.test.ts
+++ b/packages/app-core/src/cli/doctor/checks.host-config.test.ts
@@ -1,6 +1,3 @@
-import { describe, expect, it } from "vitest";
-import { checkHostConfig } from "./checks.ts";
-
 /**
  * `checkHostConfig` is the doctor preflight that warns an operator when the
  * agent's HTTP API is bound somewhere reachable without a stable token (#8801 —
@@ -9,6 +6,9 @@ import { checkHostConfig } from "./checks.ts";
  * exposed-vs-safe branch is pinned. It reads only the injected env, so no global
  * state is touched.
  */
+import { describe, expect, it } from "vitest";
+import { checkHostConfig } from "./checks.ts";
+
 describe("checkHostConfig", () => {
   it("passes for the default loopback bind", () => {
     const r = checkHostConfig({});

--- a/packages/app-core/src/cli/git-commit.ts
+++ b/packages/app-core/src/cli/git-commit.ts
@@ -1,3 +1,11 @@
+/**
+ * Resolves the short (7-char) git commit hash of the running build, used to
+ * stamp version and diagnostics output. Probes sources in priority order:
+ * `GIT_COMMIT` / `GIT_SHA` env, a bundled `build-info.json`, the package's
+ * `gitHead` field, then a walk up to the enclosing `.git/HEAD` (following
+ * `gitdir:` worktree pointers and ref indirection). The first hit is memoized
+ * for the process; an unresolved hash yields null rather than throwing.
+ */
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";

--- a/packages/app-core/src/cli/plugins-cli.test.ts
+++ b/packages/app-core/src/cli/plugins-cli.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the `eliza plugins` CLI input helpers: `normalizePluginName`,
+ * `parsePluginSpec`, and the `validatePluginPath` boundary guard. Exercises
+ * shorthand expansion, version parsing, and rejection of path-escape and
+ * symlink-escape attempts against real temp-dir cwd/home fixtures.
+ */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/packages/app-core/src/cli/plugins-cli.ts
+++ b/packages/app-core/src/cli/plugins-cli.ts
@@ -1,3 +1,13 @@
+/**
+ * Registers the `eliza plugins` command group — browse, search, info, install,
+ * uninstall, list installed, refresh, test drop-ins, add-path, list paths,
+ * config, and open — backed by the agent's PluginManagerService and the
+ * `@elizaos/plugin-registry` installer. Also exports the input guards
+ * (`normalizePluginName`, `parsePluginSpec`, `validatePluginPath`) and the
+ * `findPluginExport` heuristic that locates a Plugin-shaped export in a loaded
+ * module. Plugin names and paths are validated before install to reject
+ * path-escape and shell-unsafe input.
+ */
 import fs from "node:fs";
 import os from "node:os";
 import nodePath from "node:path";

--- a/packages/app-core/src/cli/profile-utils.ts
+++ b/packages/app-core/src/cli/profile-utils.ts
@@ -1,3 +1,9 @@
+/**
+ * Profile-name validation for the CLI's `--profile` / `--dev` state
+ * namespacing: `isValidProfileName` enforces a path- and shell-safe charset,
+ * and `normalizeProfileName` trims and folds the reserved "default" name (and
+ * anything invalid) to null so callers fall back to the base state dir.
+ */
 const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/i;
 
 export function isValidProfileName(value: string): boolean {

--- a/packages/app-core/src/cli/profile.ts
+++ b/packages/app-core/src/cli/profile.ts
@@ -1,3 +1,12 @@
+/**
+ * Pre-Commander parsing and env wiring for the CLI's `--profile <name>` /
+ * `--dev` flags, which isolate an agent's state, config, and ports under a
+ * named XDG namespace. `parseCliProfileArgs` extracts and validates the profile
+ * (rejecting `--dev` combined with `--profile`) and strips the flag from argv
+ * ahead of the command word; `applyCliProfileEnv` fills ELIZA_PROFILE /
+ * ELIZA_NAMESPACE / ELIZA_STATE_DIR / ELIZA_CONFIG_PATH (and the dev gateway
+ * port) as defaults only, never overriding explicit env.
+ */
 import os from "node:os";
 import path from "node:path";
 import { isValidProfileName } from "./profile-utils";

--- a/packages/app-core/src/cli/program.ts
+++ b/packages/app-core/src/cli/program.ts
@@ -1,1 +1,4 @@
+/**
+ * Barrel re-export of `buildProgram` from the CLI program assembly module.
+ */
 export { buildProgram } from "./program/build-program";

--- a/packages/app-core/src/cli/program/build-program.ts
+++ b/packages/app-core/src/cli/program/build-program.ts
@@ -1,3 +1,9 @@
+/**
+ * Assembles the root Commander program for the `eliza` CLI: applies help and
+ * banner formatting, registers the pre-action hooks, and wires in every
+ * top-level command, returning the ready-to-parse program stamped with
+ * CLI_VERSION.
+ */
 import { Command } from "commander";
 import { CLI_VERSION } from "../version";
 import { registerProgramCommands } from "./command-registry";

--- a/packages/app-core/src/cli/program/command-registry.ts
+++ b/packages/app-core/src/cli/program/command-registry.ts
@@ -1,3 +1,10 @@
+/**
+ * Registers every top-level `eliza` CLI command onto the Commander program —
+ * start, benchmark, capability-router, setup, doctor, db, configure, config,
+ * dashboard, update, auth, and the delegated sub-CLIs — each defined in its own
+ * `register.<name>` module. Sub-CLI registration receives argv for lazy
+ * dispatch.
+ */
 import type { Command } from "commander";
 import { registerAuthCommand } from "./register.auth";
 import { registerBenchmarkCommand } from "./register.benchmark";

--- a/packages/app-core/src/cli/program/help.ts
+++ b/packages/app-core/src/cli/program/help.ts
@@ -1,3 +1,10 @@
+/**
+ * Configures the root CLI program's help presentation: the program name,
+ * version, and global flags (--verbose / --debug / --dev / --profile /
+ * --no-color), themed term and heading coloring, the one-shot startup banner,
+ * and the trailing Examples plus docs-link block. Rendering only — it defines
+ * no command behavior.
+ */
 import { formatDocsLink, isRich, theme } from "@elizaos/shared";
 import type { Command } from "commander";
 import { formatCliBannerLine, hasEmittedCliBanner } from "../banner";

--- a/packages/app-core/src/cli/program/preaction.ts
+++ b/packages/app-core/src/cli/program/preaction.ts
@@ -1,3 +1,11 @@
+/**
+ * Commander `preAction` hook wiring for the CLI program: before any command's
+ * action runs it sets the process title from the top-level command name, and —
+ * unless `--help`/`--version` or a banner-suppressing command (update,
+ * completion, or `ELIZA_HIDE_BANNER`) is in play — emits the CLI banner and
+ * schedules the update-notification check. It also resolves the verbose/debug
+ * flag and silences Node warnings when not verbose.
+ */
 import { isTruthyEnvValue } from "@elizaos/shared";
 import type { Command } from "commander";
 import { setVerbose } from "../../utils/globals";

--- a/packages/app-core/src/cli/program/register.auth.dev-login.test.ts
+++ b/packages/app-core/src/cli/program/register.auth.dev-login.test.ts
@@ -1,11 +1,12 @@
+/**
+ * Tests for the dev SIWE wallet login (`runDevWalletLogin`): generate an
+ * ephemeral Ethereum wallet, sign the SIWE challenge, and exchange it for a
+ * cloud API key with no browser/OAuth. A fixed private key plus a mocked fetch
+ * keep the suite offline and deterministic; covers the mint-without-save happy
+ * path, a transient nonce-failure retry, and a verify rejection.
+ */
 import { describe, expect, it } from "vitest";
 import { runDevWalletLogin } from "./register.auth";
-
-/**
- * Dev SIWE wallet login: generate an ephemeral Ethereum wallet, sign the SIWE
- * challenge, exchange it for a cloud API key — no browser/OAuth. These tests
- * use a fixed private key + a mocked fetch so they are offline + deterministic.
- */
 
 const FIXED_PK =
   "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";

--- a/packages/app-core/src/cli/program/register.benchmark.ts
+++ b/packages/app-core/src/cli/program/register.benchmark.ts
@@ -1,3 +1,9 @@
+/**
+ * Registers the `benchmark` CLI command: runs a benchmark task headlessly
+ * against the agent, delegating to `@elizaos/agent`'s `runBenchmark`. Supports a
+ * one-shot `--task <path>` JSON run or a long-lived `--server` mode that accepts
+ * line-delimited JSON tasks on stdin, with a per-task `--timeout`.
+ */
 import type { Command } from "commander";
 
 export function registerBenchmarkCommand(program: Command) {

--- a/packages/app-core/src/cli/program/register.capability-router.test.ts
+++ b/packages/app-core/src/cli/program/register.capability-router.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Tests for the `capability-router` CLI helpers: `buildCapabilityRouterConnectPayload`
+ * (shaping and validating direct/provider/cloud connect payloads) and
+ * `runCapabilityRouterConformance` (driving a remote endpoint through every
+ * plugin-protocol surface). Uses the shared `CAPABILITY_ROUTER_PROTOCOL_FIXTURE`
+ * and a mocked `fetch` to assert payload shape, method call ordering, and bearer
+ * auth without a live endpoint.
+ */
 import { CAPABILITY_ROUTER_PROTOCOL_FIXTURE } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {

--- a/packages/app-core/src/cli/program/register.capability-router.ts
+++ b/packages/app-core/src/cli/program/register.capability-router.ts
@@ -1,3 +1,15 @@
+/**
+ * Registers the `capability-router` CLI command group for wiring remote
+ * capability-router plugin endpoints into a running agent. `connect` POSTs a
+ * connect payload to the agent's `/api/capability-router/connect` route — for a
+ * direct/provider endpoint or an Eliza Cloud-provisioned one; the exported
+ * `buildCapabilityRouterConnectPayload` shapes and validates that body.
+ * `conformance` drives an endpoint through the plugin protocol (actions,
+ * providers, routes, view assets, models, lifecycle/event/service/app-bridge
+ * hooks, and the evaluator families) via `runCapabilityRouterConformance`,
+ * returning an exercised-surface report. Remaining helpers normalize/validate
+ * options and parse capability-invoke responses.
+ */
 import { theme } from "@elizaos/shared";
 import type { Command } from "commander";
 

--- a/packages/app-core/src/cli/program/register.config.ts
+++ b/packages/app-core/src/cli/program/register.config.ts
@@ -1,3 +1,10 @@
+/**
+ * Registers the `config` CLI command group: `get <key>` reads a dot-path value
+ * from the loaded Eliza config, `path` prints the resolved config file path, and
+ * `show` renders all values grouped by section (honoring UI hints for labels,
+ * grouping, sensitive-value masking, and advanced/hidden fields), with a
+ * `--json` raw dump. Helpers flatten the nested config and infer group names.
+ */
 import type { ElizaConfig } from "@elizaos/agent";
 import { getLogPrefix, theme } from "@elizaos/shared";
 import type { Command } from "commander";

--- a/packages/app-core/src/cli/program/register.configure.ts
+++ b/packages/app-core/src/cli/program/register.configure.ts
@@ -1,3 +1,8 @@
+/**
+ * Registers the `configure` CLI command: prints static configuration guidance —
+ * how to read/edit config values and the common provider API-key environment
+ * variables — plus a docs link. Guidance only; it does not mutate any config.
+ */
 import { formatDocsLink, theme } from "@elizaos/shared";
 import type { Command } from "commander";
 

--- a/packages/app-core/src/cli/program/register.dashboard.ts
+++ b/packages/app-core/src/cli/program/register.dashboard.ts
@@ -1,3 +1,11 @@
+/**
+ * Registers the `dashboard` CLI command, which opens the Control UI in the
+ * browser. It probes the given `--port` (then the default) for a listening
+ * server and opens that URL; failing that it locates the eliza package root,
+ * spawns the app's Vite dev server, and opens the dev URL once Vite reports
+ * "Local:" (or after a timeout). Cross-platform browser launch and dev-server
+ * teardown (including a Windows taskkill tree-kill) are handled here.
+ */
 import { theme } from "@elizaos/shared";
 import type { Command } from "commander";
 

--- a/packages/app-core/src/cli/program/register.db.ts
+++ b/packages/app-core/src/cli/program/register.db.ts
@@ -1,3 +1,9 @@
+/**
+ * Registers the `db` CLI command group. `db reset` deletes the local agent
+ * database directory (`<stateDir>/workspace/.elizadb`), which is re-created on
+ * the next start, after an interactive confirmation prompt unless `--yes` is
+ * passed. Runs inside `runCommandWithRuntime` for consistent error/exit handling.
+ */
 import fs from "node:fs";
 import path from "node:path";
 import { resolveStateDir } from "@elizaos/core";

--- a/packages/app-core/src/cli/program/register.doctor.ts
+++ b/packages/app-core/src/cli/program/register.doctor.ts
@@ -1,3 +1,13 @@
+/**
+ * Registers the `doctor` and `doctor:mtp` Commander CLI commands, which run
+ * environment health checks and render the results. `doctor` groups
+ * CheckResults by category (system/config/storage/network) for human output,
+ * emits a machine-readable summary under `--json`, and with `--fix` auto-runs
+ * remediation for autoFixable checks — but only when the fix string is an
+ * `eliza …` sub-command, since arbitrary shell fixes are printed, never
+ * executed. `doctor:mtp` probes MTP llama-server acceleration readiness. Both
+ * exit non-zero when any check fails.
+ */
 import { spawnSync } from "node:child_process";
 import { theme } from "@elizaos/shared";
 import type { Command } from "commander";

--- a/packages/app-core/src/cli/program/register.models.ts
+++ b/packages/app-core/src/cli/program/register.models.ts
@@ -1,3 +1,8 @@
+/**
+ * Registers the `models` CLI command, which reports which model providers are
+ * configured by probing a fixed list of provider API-key / base-URL env vars
+ * and printing each as "configured" or "not set". Read-only; sets nothing.
+ */
 import { getLogPrefix } from "@elizaos/shared";
 import type { Command } from "commander";
 

--- a/packages/app-core/src/cli/program/register.setup.ts
+++ b/packages/app-core/src/cli/program/register.setup.ts
@@ -1,3 +1,14 @@
+/**
+ * Registers the `setup` CLI command and the interactive model-provider wizard
+ * behind it. Bootstraps the XDG state-dir config and the agent workspace:
+ * sets a provider key non-interactively from --provider/--key/--key-stdin flags
+ * or walks the TTY wizard, persists it into the config's `env` section, ensures
+ * the workspace directory exists, then prints a doctor summary. Also exports the
+ * config read/write helpers (loadConfig/saveConfig/resolveConfigPath),
+ * hasModelKey provider detection, and runProviderWizard for reuse elsewhere.
+ * Secret entry suppresses terminal echo; --key-stdin is preferred over --key so
+ * keys never land in shell history or process lists.
+ */
 import fs from "node:fs";
 import path from "node:path";
 import { resolveConfigPath } from "@elizaos/agent";

--- a/packages/app-core/src/cli/program/register.start.ts
+++ b/packages/app-core/src/cli/program/register.start.ts
@@ -1,3 +1,12 @@
+/**
+ * Registers the `start` command (and its `run` alias), which boot the elizaOS
+ * agent runtime in server-only mode (API server, no interactive chat loop) via
+ * startEliza. Resolves the API connection key: an explicit --connection-key
+ * value is used verbatim, the bare flag or a network (non-loopback) bind with no
+ * existing token auto-generates one, and loopback access stays open. Once the
+ * server is ready, prints the local URL, the masked connection key, and any
+ * remote-access pairing code.
+ */
 import crypto from "node:crypto";
 import {
   formatDocsLink,

--- a/packages/app-core/src/cli/program/register.subclis.ts
+++ b/packages/app-core/src/cli/program/register.subclis.ts
@@ -1,3 +1,11 @@
+/**
+ * Lazy registration for nested sub-CLIs (`plugins`, `models`) on the Commander
+ * program. Each entry is registered as a placeholder command that, on first
+ * invocation, swaps itself out for the real sub-CLI module and re-parses argv so
+ * the intended sub-command runs — keeping their heavy imports off the startup
+ * path. `registerSubCliByName` force-loads one eagerly by name; setting
+ * ELIZA_DISABLE_LAZY_SUBCOMMANDS registers every sub-CLI up front.
+ */
 import { isTruthyEnvValue } from "@elizaos/shared";
 import type { Command } from "commander";
 import { buildParseArgv, getPrimaryCommand, hasHelpOrVersion } from "../argv";

--- a/packages/app-core/src/cli/run-main.ts
+++ b/packages/app-core/src/cli/run-main.ts
@@ -1,3 +1,13 @@
+/**
+ * `runCli()` — the CLI process entrypoint. Installs the restart handler, loads
+ * `.env`, normalizes provider key aliases (Z_AI_API_KEY→ZAI_API_KEY,
+ * KIMI_API_KEY→MOONSHOT_API_KEY), builds the Commander program, eagerly loads
+ * the primary sub-CLI when one is named, then parses argv. Also owns the global
+ * error handlers: long-running server commands (`start`/`serve`) install crash
+ * guards that keep the process alive on background rejections and hand uncaught
+ * exceptions to the supervisor for restart, while one-shot commands fail fast;
+ * tests opt out so a rejection still fails the test.
+ */
 import process from "node:process";
 import {
   getLogPrefix,

--- a/packages/app-core/src/cli/version.ts
+++ b/packages/app-core/src/cli/version.ts
@@ -1,3 +1,7 @@
+/**
+ * Resolves the elizaOS CLI version at load time from package metadata and
+ * exports it as CLI_VERSION for `--version` output and diagnostics.
+ */
 import { resolveElizaVersion } from "@elizaos/agent";
 
 export const CLI_VERSION = resolveElizaVersion(import.meta.url);

--- a/packages/app-core/src/config/app-config.test.ts
+++ b/packages/app-core/src/config/app-config.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies that app-core's config barrel re-exports the shared
+ * DEFAULT_APP_CONFIG intact (app name plus branding docs/app URLs).
+ */
 import { describe, expect, it } from "vitest";
 
 import { DEFAULT_APP_CONFIG } from "./app-config";

--- a/packages/app-core/src/config/app-config.ts
+++ b/packages/app-core/src/config/app-config.ts
@@ -1,3 +1,8 @@
+/**
+ * Config barrel: re-exports the AppConfig type family plus DEFAULT_APP_CONFIG
+ * and resolveAppBranding from @elizaos/shared, so app-core consumers import app
+ * configuration from one local path rather than reaching into shared directly.
+ */
 export {
   type AndroidUserAgentMarker,
   type AospVariantConfig,

--- a/packages/app-core/src/connectors/capacitor-jsc.ts
+++ b/packages/app-core/src/connectors/capacitor-jsc.ts
@@ -1,8 +1,13 @@
-// Native boundary contract for the `CapacitorJsc` Capacitor plugin. The Swift
-// class (target name: `CapacitorJscPlugin`, registered with
-// `@objc(CapacitorJscPlugin)`) must implement the methods declared on
-// `CapacitorJscPlugin` below. Use a host JSContext (JavaScriptCore), not a
-// WKWebView, so App Review treats the runtime as a sandboxed scripting engine.
+/**
+ * Native boundary contract for the `CapacitorJsc` Capacitor plugin: declares the
+ * marshalled-value wire format and the native method surface, then registers a
+ * `jsc-ios` factory with `@elizaos/agent`'s JS-runtime registry so the agent can
+ * evaluate/import untrusted JS on iOS. The Swift class (target name
+ * `CapacitorJscPlugin`, registered with `@objc(CapacitorJscPlugin)`) must
+ * implement the methods declared on `CapacitorJscPlugin` below. Uses a host
+ * JSContext (JavaScriptCore), not a WKWebView, so App Review treats the runtime
+ * as a sandboxed scripting engine.
+ */
 
 import { Capacitor, registerPlugin } from "@capacitor/core";
 

--- a/packages/app-core/src/connectors/capacitor-quickjs.ts
+++ b/packages/app-core/src/connectors/capacitor-quickjs.ts
@@ -1,8 +1,13 @@
-// Native boundary contract for the `CapacitorQuickJs` Capacitor plugin.
-// Android is the primary target: the Kotlin plugin must run QuickJS in a
-// service with `android:isolatedProcess="true"` so interpreter faults and
-// untrusted code stay outside the host process. iOS may register the same
-// plugin only as the fallback runtime when JavaScriptCore is unavailable.
+/**
+ * Native boundary contract for the `CapacitorQuickJs` Capacitor plugin: declares
+ * the marshalled-value wire format and the native method surface, then registers
+ * the `quickjs-android` and `quickjs-ios-fallback` factories with
+ * `@elizaos/agent`'s JS-runtime registry. Android is the primary target: the
+ * Kotlin plugin must run QuickJS in a service with
+ * `android:isolatedProcess="true"` so interpreter faults and untrusted code stay
+ * outside the host process. iOS registers the same plugin only as the fallback
+ * runtime when JavaScriptCore is unavailable.
+ */
 
 import { Capacitor, registerPlugin } from "@capacitor/core";
 

--- a/packages/app-core/src/connectors/capacitor-sqlite.ts
+++ b/packages/app-core/src/connectors/capacitor-sqlite.ts
@@ -1,6 +1,12 @@
-// Boundary facade for `@capacitor-community/sqlite`. The native side is the
-// published community plugin; this module keeps app code on a stable,
-// parameterized API instead of exposing the plugin's wider surface.
+/**
+ * Boundary facade over `@capacitor-community/sqlite`, exposing a small
+ * `SqliteDatabase` handle (`execute`/`query`/`close`), `openDatabase`, and an
+ * `isSqliteAvailable` probe. Keeps app code on a stable, parameterized API
+ * instead of the community plugin's wider surface, and refuses SQL containing a
+ * `${` template-interpolation marker so bound `values` stay the only path for
+ * dynamic data. Off-native (no registered plugin) `openDatabase` throws and
+ * `isSqliteAvailable` returns false.
+ */
 
 import { Capacitor } from "@capacitor/core";
 import {

--- a/packages/app-core/src/diagnostics/integration-observability.ts
+++ b/packages/app-core/src/diagnostics/integration-observability.ts
@@ -1,3 +1,13 @@
+/**
+ * Structured telemetry for outbound integration boundaries (cloud, wallet,
+ * marketplace, mcp). `createIntegrationTelemetrySpan` opens a span for one
+ * boundary operation and returns settle-once `success`/`failure` callbacks;
+ * whichever fires first computes `durationMs` and emits a single
+ * `integration_boundary_v1` JSON event prefixed `[integration]` — `info` on
+ * success, `warn` on failure — to the core logger (or an injected sink). Error
+ * kinds are inferred (AbortError/TimeoutError/"timeout" → `timeout`) and every
+ * token is lowercased/sanitized to `[a-z0-9_-]` and capped at 64 chars.
+ */
 import { logger } from "@elizaos/core";
 
 export type IntegrationBoundary = "cloud" | "wallet" | "marketplace" | "mcp";

--- a/packages/app-core/src/first-run/first-run-config.test.ts
+++ b/packages/app-core/src/first-run/first-run-config.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for `buildFirstRunRuntimeConfig`, the pure onboarding config
+ * builder: asserts a Cerebras first-run selection resolves to direct-transport
+ * Cerebras text inference under a local deployment target with no cloud linkage.
+ * Pure function, no mocks.
+ */
 import { describe, expect, it } from "vitest";
 import { buildFirstRunRuntimeConfig } from "./first-run-config";
 

--- a/packages/app-core/src/first-run/first-run-config.ts
+++ b/packages/app-core/src/first-run/first-run-config.ts
@@ -1,3 +1,14 @@
+/**
+ * Pure translator from first-run onboarding answers into the runtime config the
+ * app persists. `buildFirstRunRuntimeConfig` takes the collected selections
+ * (runtime target local/remote/elizacloud, provider + API key, primary and
+ * tiered model ids, remote-connect and cloud-key state, capability toggles) and
+ * derives: the `deploymentTarget` (local/remote/cloud), `linkedAccounts` flags,
+ * the `serviceRouting` llmText route plus cloud service-routing defaults,
+ * `credentialInputs`, a `featureSetup` describing selected connectors and
+ * capabilities, and `needsProviderSetup` (true only when a non-omitted target
+ * resolved no LLM route). Side-effect free; callers apply the result.
+ */
 import {
   buildDefaultElizaCloudServiceRouting,
   buildElizaCloudServiceRoute,

--- a/packages/app-core/src/first-run/runtime-target.ts
+++ b/packages/app-core/src/first-run/runtime-target.ts
@@ -1,3 +1,11 @@
+/**
+ * First-run runtime-target vocabulary shared by the onboarding flow. Defines the
+ * `FirstRunRuntimeTarget` union ("" | local | remote | elizacloud |
+ * elizacloud-hybrid), the `isElizaCloudFirstRunTarget` predicate (true for the
+ * two elizacloud variants), and `activeServerKindToFirstRunRuntimeTarget`, which
+ * maps the active server kind onto the persisted target — note the `cloud →
+ * elizacloud` rename. All pure and dependency-free.
+ */
 export type FirstRunRuntimeTarget =
   | ""
   | "local"

--- a/packages/app-core/src/index.ts
+++ b/packages/app-core/src/index.ts
@@ -1,5 +1,14 @@
-// Node/runtime barrel for @elizaos/app-core.
-// Frontend surfaces live in @elizaos/ui; pure contracts/utilities live in @elizaos/shared.
+/**
+ * Node/runtime barrel for `@elizaos/app-core` (the `.` export): re-exports the
+ * dashboard HTTP API plus auth/response helpers, the Eliza runtime loader and
+ * runtime-mode/desktop surfaces, the curated registry, security/vault/steward
+ * services, first-run config, and diagnostics. Frontend surfaces live in
+ * `@elizaos/ui`; pure contracts/utilities live in `@elizaos/shared`. Star
+ * re-exports are used except where a name collides with `@elizaos/ui`
+ * (`ConfigField`/`getPlugins`, re-exported explicitly); `./platform/empty-node-module`
+ * is deliberately excluded so its browser aliases can't shadow the real Node
+ * exports.
+ */
 
 export * from "./api/auth.ts";
 export * from "./api/automation-node-contributors";

--- a/packages/app-core/src/platform/elizaos-agent-browser-stub.ts
+++ b/packages/app-core/src/platform/elizaos-agent-browser-stub.ts
@@ -1,7 +1,11 @@
-// Browser-side inert alias for @elizaos/agent. Server-only runtime — every export
-// resolves to an inert/empty value so the renderer graph can statically
-// satisfy named imports from app-core dist files without pulling in any
-// Node-only code.
+/**
+ * Browser-side inert alias for the server-only `@elizaos/agent` package. Browser
+ * bundlers resolve `@elizaos/agent` to this module so the renderer's dependency
+ * graph can statically satisfy the named imports that app-core dist files pull
+ * from it, without dragging in any Node-only runtime code. Every named export is
+ * a noop or empty collection, and the default export is a Proxy that yields
+ * `noop` for any key/apply — nothing here executes.
+ */
 
 const noop = () => undefined;
 const noopProxyHandler: ProxyHandler<typeof noop> = {

--- a/packages/app-core/src/platform/elizaos-plugin-elizacloud-browser-stub.ts
+++ b/packages/app-core/src/platform/elizaos-plugin-elizacloud-browser-stub.ts
@@ -1,7 +1,11 @@
-// Browser-side inert alias for @elizaos/plugin-elizacloud. The plugin's runtime
-// surface (cloud secrets, TTS/billing/relay routes, wallet provisioning, the
-// cloud client) only runs server-side; the renderer just needs the named
-// imports to statically resolve. Every export here is inert.
+/**
+ * Browser-side inert alias for the server-only `@elizaos/plugin-elizacloud`
+ * package. The plugin's real surface (cloud secrets, TTS/billing/relay routes,
+ * wallet provisioning, the cloud client) runs only server-side; the renderer
+ * only needs the named imports to statically resolve. Sync resolvers are noops,
+ * async cloud-route handlers return `false` ("not handled here"), data fetchers
+ * return empty results, and `isCloudProvisionedContainer` is a hard `false`.
+ */
 
 const noop = () => undefined;
 const noopProxyHandler: ProxyHandler<typeof noop> = {

--- a/packages/app-core/src/platform/empty-node-module.ts
+++ b/packages/app-core/src/platform/empty-node-module.ts
@@ -1,3 +1,14 @@
+/**
+ * Universal empty-module alias target for browser builds. tsconfig-paths maps
+ * both a handful of Node built-ins (stream `pipeline`/`finished`, the WHATWG
+ * stream globals, `util/types` `isX` guards) and a large roster of server-only
+ * `@elizaos/agent` / `@elizaos/plugin-elizacloud` exports onto this file, so the
+ * renderer graph resolves every named import without pulling in Node-only code.
+ * Exports are noops / empty collections / typed-empty shapes; the default export
+ * is a catch-all Proxy. Intentionally NOT re-exported from `index.ts` — doing so
+ * would shadow the real Node `api/server` / `runtime/eliza` exports; Node imports
+ * the originals while bundlers alias in this stub.
+ */
 const noop = () => undefined;
 const asyncNoop = async () => undefined;
 const falseNoop = () => false;

--- a/packages/app-core/src/platform/ios-runtime-backends.test.ts
+++ b/packages/app-core/src/platform/ios-runtime-backends.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit coverage for the iOS local-runtime backend policy (`ios-runtime-backends`):
+ * backend selection precedence (full Bun engine vs. gated SwiftBun / ITTP
+ * compatibility fallbacks), the invariant that every backend stays
+ * TypeScript-owned + bridge-only, and the production/App-Store blocker list.
+ * Pure in-memory assertions, no simulator.
+ */
 import { describe, expect, it } from "vitest";
 import {
   getIosLocalRuntimeBackendDefinition,

--- a/packages/app-core/src/platform/ios-runtime-backends.ts
+++ b/packages/app-core/src/platform/ios-runtime-backends.ts
@@ -1,3 +1,13 @@
+/**
+ * Policy table plus selectors that decide which in-process runtime backs the
+ * local iOS agent. Enumerates the three candidate backends (`full-bun-engine`,
+ * `swift-bun-jscore`, `ittp-jscontext`) with their readiness/capability flags,
+ * then resolves a selection from availability plus opt-in flags. The invariant
+ * the table and the blocker checks enforce: the agent runtime always stays in
+ * the TypeScript bundle and native code is bridge-only, so only the full Bun
+ * engine is approved for production / App-Store local-runtime builds — the
+ * others are explicitly-enabled compatibility paths surfaced as warnings.
+ */
 export type IosLocalRuntimeBackendId =
   | "full-bun-engine"
   | "swift-bun-jscore"

--- a/packages/app-core/src/platform/ios-runtime-bridge.ts
+++ b/packages/app-core/src/platform/ios-runtime-bridge.ts
@@ -1,9 +1,13 @@
-// iOS full-Bun smoke harness: when the host build sets the smoke-request
-// flag in localStorage / Capacitor Preferences, this module boots the
-// in-process ElizaBunRuntime, drives a sequence of WebView-fetch and direct
-// bridge probes against the local agent, and persists the result back into
-// Preferences so the simulator host can read it. The probe runs once per
-// page load and stays inactive when the flag is absent.
+/**
+ * iOS full-Bun smoke harness. When the host build sets the smoke-request flag in
+ * localStorage / Capacitor Preferences, this module boots the in-process
+ * `ElizaBunRuntime`, drives a sequence of WebView-fetch and direct-bridge probes
+ * against the local agent (health, the local-inference hub/providers/device,
+ * model activation, then a real chat + streamed reply), and persists each step's
+ * result back into Preferences so the simulator host can poll it. The probe runs
+ * once per page load and stays inactive when the flag is absent or the runtime
+ * is in cloud / cloud-hybrid mode.
+ */
 import { Preferences } from "@capacitor/preferences";
 import { formatError } from "@elizaos/shared";
 import { primeIosFullBunRuntime } from "../api/ios-local-agent-transport";

--- a/packages/app-core/src/platform/native-library-policy.test.ts
+++ b/packages/app-core/src/platform/native-library-policy.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit coverage for `resolveNativeLibraryCandidate`: direct builds accept any
+ * existing dylib, store builds accept only the expected-basename library inside
+ * the signed `.app` bundle, and symlink / relative / out-of-bundle candidates
+ * are rejected (returning null, not throwing). Exercises real temp dirs and
+ * symlinks on the local filesystem.
+ */
 import { mkdirSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/packages/app-core/src/platform/native-library-policy.ts
+++ b/packages/app-core/src/platform/native-library-policy.ts
@@ -1,3 +1,13 @@
+/**
+ * Load-path allow policy for native libraries (e.g. macOS `.dylib` bridges).
+ * `resolveNativeLibraryCandidate` returns the realpath to load or null: direct
+ * (non-store) builds accept any existing file, while store builds
+ * (`ELIZA_BUILD_VARIANT=store`) are hardened — the candidate must carry an
+ * expected basename and, after symlink resolution, still resolve inside a
+ * trusted signed `.app` bundle (derived from `execPath` / `moduleDir`).
+ * Rejections warn and fall through rather than throw;
+ * `resolveFirstNativeLibraryCandidate` walks a list and returns the first pass.
+ */
 import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
 

--- a/packages/app-core/src/platform/native-plugin-entrypoints.ts
+++ b/packages/app-core/src/platform/native-plugin-entrypoints.ts
@@ -1,12 +1,12 @@
-// Side-effect barrel that registers every elizaOS Capacitor native plugin so
-// it's available on mobile boot. Each import pulls in the plugin's
-// `web.ts` / `native` registration code under the hood.
-//
-// The published `@elizaos/app-core` npm package contains this file as a
-// publish-time generated entrypoint; the source tree version exists so
-// `ELIZA_ELIZA_SOURCE=local` consumers can resolve the same import path
-// against linked workspace packages. Imports resolve through the
-// `@elizaos/capacitor-*` path mappings in tsconfig{,.build}.json.
+/**
+ * Side-effect barrel that registers every elizaOS Capacitor native plugin so it
+ * is available on mobile boot — each bare import pulls in that plugin's
+ * `web.ts` / native registration code. The published `@elizaos/app-core` npm
+ * package ships this as a publish-time-generated entrypoint; the source-tree
+ * copy exists so `ELIZA_ELIZA_SOURCE=local` consumers can resolve the same
+ * import path against linked workspace packages (imports resolve through the
+ * `@elizaos/capacitor-*` path mappings in tsconfig{,.build}.json).
+ */
 import "@elizaos/capacitor-camera";
 import "@elizaos/capacitor-canvas";
 import "@elizaos/capacitor-contacts";

--- a/packages/app-core/src/registry/index.ts
+++ b/packages/app-core/src/registry/index.ts
@@ -1,10 +1,12 @@
-// Backwards-compatibility shim.
-//
-// The first-party curated registry (schema, loader, entries, and the runtime
-// registration overlay) moved to `@elizaos/registry/first-party`. This re-export
-// keeps the `@elizaos/app-core/registry` subpath — and the `@elizaos/app-core`
-// barrel re-exports — stable for existing consumers (plugin-registry,
-// plugin-capacitor-bridge, app-core's own catalog/eliza/vault-bootstrap).
-//
-// New code should import directly from `@elizaos/registry/first-party`.
+/**
+ * Backwards-compatibility shim for the curated app/plugin/connector registry.
+ *
+ * The first-party curated registry (schema, loader, entries, and the runtime
+ * registration overlay) moved to `@elizaos/registry/first-party`. This re-export
+ * keeps the `@elizaos/app-core/registry` subpath — and the `@elizaos/app-core`
+ * barrel re-exports — stable for existing consumers (plugin-registry,
+ * plugin-capacitor-bridge, app-core's own catalog/eliza/vault-bootstrap).
+ *
+ * New code should import directly from `@elizaos/registry/first-party`.
+ */
 export * from "@elizaos/registry/first-party";

--- a/packages/app-core/src/runtime/android-avf-microdroid-bridge.test.ts
+++ b/packages/app-core/src/runtime/android-avf-microdroid-bridge.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises the Android AVF/Microdroid native bridge helpers against in-process
+ * fake `ElizaNative` bridges (no real Android): the feature probe's mapping of
+ * native virtualization JSON to availability flags/env, the ready vs
+ * payload-missing gating, and the request boundary's fail-closed and
+ * malformed-response paths.
+ */
 import { describe, expect, it } from "vitest";
 import {
   ANDROID_AVF_MICRODROID_REQUEST_CONTRACT_VERSION,

--- a/packages/app-core/src/runtime/android-avf-microdroid-bridge.ts
+++ b/packages/app-core/src/runtime/android-avf-microdroid-bridge.ts
@@ -1,3 +1,14 @@
+/**
+ * Maps the Android native virtualization bridge (AVF / Microdroid, exposed on
+ * `globalThis.ElizaNative`) into the mobile-safe runtime surface. Reads the
+ * native probe JSON to build a feature probe — capability state, availability
+ * flags, and the `ELIZA_ANDROID_*` env hints the runtime consumes — and, when a
+ * request bridge is present, wraps it as an `AndroidAvfMicrodroidBoundary` that
+ * forwards capability requests to native (stamping each with the contract
+ * version) and fails closed unless the probe reports a `ready` Microdroid
+ * payload. All native JSON is parsed defensively: malformed or mismatched
+ * responses become structured, non-retryable errors rather than throwing.
+ */
 import type {
   AndroidAvfMicrodroidBoundary,
   AndroidAvfMicrodroidCapabilityState,

--- a/packages/app-core/src/runtime/api-dev-settings-banner.ts
+++ b/packages/app-core/src/runtime/api-dev-settings-banner.ts
@@ -1,3 +1,12 @@
+/**
+ * Renders the "API — effective settings" developer banner printed after the API
+ * server binds its listen socket. Reads the post-start environment and the
+ * resolved API security config to summarize bind host/port, the API token and
+ * how it was sourced (user env vs auto-generated), CORS origins, allowed hosts,
+ * the auto-token disable flag, renderer/log paths, and the dev hook endpoints —
+ * giving each row its effective value, where it came from, and how to change it.
+ * Output is a figlet-headed table for console display only.
+ */
 import process from "node:process";
 import {
   type DevSettingsRow,

--- a/packages/app-core/src/runtime/app-route-plugin-registry.ts
+++ b/packages/app-core/src/runtime/app-route-plugin-registry.ts
@@ -1,3 +1,8 @@
+/**
+ * Re-exports the app-route-plugin loader registry from `@elizaos/core` so
+ * app-core consumers can register, list, and drain the deferred loaders that
+ * mount plugin-owned HTTP routes once the runtime is ready.
+ */
 export type {
   AppRoutePluginLoader,
   AppRoutePluginRegistryEntry,

--- a/packages/app-core/src/runtime/app-route-plugin-skip.test.ts
+++ b/packages/app-core/src/runtime/app-route-plugin-skip.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Covers the app-route-plugin skip/normalize/load helpers exported from
+ * `eliza.ts`: `getSkippedAppRoutePluginIds` (parsing the
+ * `ELIZA_SKIP_APP_ROUTE_PLUGINS` env list), `normalizeAppRoutePluginId` (id
+ * canonicalization), and `__loadAppRoutePluginFromSpecifierForTest` (loading a
+ * real first-party route plugin and surfacing missing transitive imports). One
+ * case writes a throwaway plugin package into `node_modules`; another asserts
+ * eliza.ts hardcodes no first-party route-loader fallbacks.
+ */
 import { readFileSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";

--- a/packages/app-core/src/runtime/autonomy-policy.test.ts
+++ b/packages/app-core/src/runtime/autonomy-policy.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit-tests `isRuntimeAutonomyEnabled` — the ENABLE_AUTONOMY env gate that
+ * defaults the autonomy loop off and enables it only for "true"/"1".
+ */
 import { describe, expect, it } from "vitest";
 import { isRuntimeAutonomyEnabled } from "./autonomy-policy";
 

--- a/packages/app-core/src/runtime/autonomy-policy.ts
+++ b/packages/app-core/src/runtime/autonomy-policy.ts
@@ -1,3 +1,8 @@
+/**
+ * Resolves whether the runtime autonomy loop is enabled from the ENABLE_AUTONOMY
+ * environment variable. Defaults off; only the literal "true" (any case) or "1"
+ * turns it on — every other value leaves autonomy disabled.
+ */
 export function isRuntimeAutonomyEnabled(
   env: Record<string, string | undefined> = process.env,
 ): boolean {

--- a/packages/app-core/src/runtime/build-character-from-config.ts
+++ b/packages/app-core/src/runtime/build-character-from-config.ts
@@ -1,3 +1,12 @@
+/**
+ * App-core wrapper around `@elizaos/agent`'s `buildCharacterFromConfig` that
+ * layers dashboard branding onto the built character. Syncs the Eliza/app env
+ * aliases before and after the upstream build, normalizes message examples, and
+ * fills style, adjectives, topics, and post/message examples from the matched
+ * bundled style preset (resolved by preset id, avatar index, then name) — but
+ * only where both the agent-list entry and the built character leave them unset,
+ * so explicit config always wins.
+ */
 import { buildCharacterFromConfig as upstreamBuildCharacterFromConfig } from "@elizaos/agent";
 import {
   getDefaultStylePreset,

--- a/packages/app-core/src/runtime/build-variant.test.ts
+++ b/packages/app-core/src/runtime/build-variant.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the build-variant resolver: verify that getBuildVariant /
+ * isStoreBuild / isDirectBuild read ELIZA_BUILD_VARIANT, honor "store" vs
+ * "direct", and fall back to the direct default when the env var is unset or
+ * unrecognized. Pure env-driven with no runtime harness — each case resets the
+ * memoized value via _resetBuildVariantForTests.
+ */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   _resetBuildVariantForTests,

--- a/packages/app-core/src/runtime/bundled-fused-lib.test.ts
+++ b/packages/app-core/src/runtime/bundled-fused-lib.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Unit tests for bundled fused-library discovery. findBundledFusedLibDir walks
+ * up from the runtime module URL to a sibling local-inference/lib that holds the
+ * platform fused binary, and ensureBundledFusedLibDir points
+ * ELIZA_INFERENCE_LIB_DIR at it while respecting explicit
+ * ELIZA_INFERENCE_LIB_DIR / ELIZA_INFERENCE_LIBRARY overrides. Runs against real
+ * temp dirs staged on disk (no mocks); both return null in dev/mobile layouts
+ * where nothing is bundled.
+ */
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/packages/app-core/src/runtime/channel-plugin-map.ts
+++ b/packages/app-core/src/runtime/channel-plugin-map.ts
@@ -1,9 +1,12 @@
-// The channel -> plugin-package map is derived at registry build time from each
-// connector entry's `channels` (see packages/registry/src/first-party). This was
-// previously a hand-maintained mirror of `@elizaos/agent`'s CHANNEL_PLUGIN_MAP
-// (kept in sync manually to avoid an `agent ↔ app-core` ESM cycle). Both now
-// statically import the same generated artifact, so the duplication and the
-// cycle are gone — neither package imports the other for this map.
+/**
+ * Exposes CHANNEL_PLUGIN_MAP: the channel-name → plugin-package lookup used to
+ * resolve which connector plugin owns a given channel. The map is derived at
+ * registry build time from each connector entry's `channels` (see
+ * packages/registry/src/first-party) and statically imported here as JSON, so
+ * `@elizaos/agent` and `@elizaos/app-core` share one generated artifact with no
+ * cross-import and no hand-maintained duplication — eliminating the former
+ * `agent ↔ app-core` ESM cycle.
+ */
 import channelPluginMap from "@elizaos/registry/first-party/channel-plugin-map.json" with {
   type: "json",
 };

--- a/packages/app-core/src/runtime/desktop/DesktopSurfaceNavigationRuntime.tsx
+++ b/packages/app-core/src/runtime/desktop/DesktopSurfaceNavigationRuntime.tsx
@@ -1,3 +1,10 @@
+/**
+ * Headless desktop runtime (renders null) that routes Electrobun tray/menu clicks
+ * into main-shell navigation. Subscribes to the desktopTrayMenuClick bridge event
+ * and, for "show-main:" / "navigate-" item ids in the allowed tab sets, switches
+ * to the desktop shell view and sets the active tab; the "open-notifications" item
+ * opens the notification center in place instead of navigating a tab.
+ */
 import { subscribeDesktopBridgeEvent } from "@elizaos/ui/bridge/electrobun-rpc";
 import { dispatchOpenNotificationCenter } from "@elizaos/ui/events";
 import { useApp } from "@elizaos/ui/state/useApp";

--- a/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
+++ b/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
@@ -1,3 +1,13 @@
+/**
+ * Headless desktop runtime (renders null) that binds the Electrobun tray/menu to
+ * app actions. Publishes the tray-popover launcher catalog from
+ * DESKTOP_VIEW_WINDOWS to the renderer store, subscribes to desktopTrayMenuClick
+ * to drive the App-menu "Reset App…" flow, and handles TRAY_ACTION_EVENT items:
+ * opening views in their own desktop windows, navigating chat/plugins/
+ * notifications, toggling agent lifecycle, firing a test notification, and window
+ * show/hide/quit — all through the electrobun-rpc bridge. Only active under
+ * isElectrobunRuntime(); polls with backoff until the RPC bridge attaches.
+ */
 import {
   getElectrobunRendererRpc,
   invokeDesktopBridgeRequest,

--- a/packages/app-core/src/runtime/desktop/DetachedShellRoot.tsx
+++ b/packages/app-core/src/runtime/desktop/DetachedShellRoot.tsx
@@ -1,3 +1,12 @@
+/**
+ * Renders the root of a detached desktop window — a single non-"main"
+ * WindowShellRoute (browser, chat, plugins, triggers, or a settings section)
+ * inside the shared app workspace chrome. Gates on app state first: startup
+ * failure, pairing, and a first-run-blocked notice each short-circuit before the
+ * routed content. Heavy page views are lazy-loaded behind Suspense so they stay
+ * off every window's first-paint graph; PluginsPageView is imported statically
+ * because App.tsx already eager-loads it, so a lazy edge here buys nothing.
+ */
 import type { PageScope } from "@elizaos/ui/components/pages/page-scoped-conversations";
 import { PairingView } from "@elizaos/ui/components/shell/PairingView";
 import { StartupFailureView } from "@elizaos/ui/components/shell/StartupFailureView";

--- a/packages/app-core/src/runtime/desktop/browser-entry-tray-exports.test.ts
+++ b/packages/app-core/src/runtime/desktop/browser-entry-tray-exports.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Guards the browser-safe barrel (src/browser.ts): asserts it re-exports
+ * DESKTOP_TRAY_MENU_ITEMS from the real ./runtime/desktop runtime rather than the
+ * Node index or @elizaos/ui, and never ships an empty stub menu. Source-text
+ * assertions over browser.ts plus a sanity check that the live menu carries a
+ * "quit" item.
+ */
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";

--- a/packages/app-core/src/runtime/desktop/desktop-view-windows.test.ts
+++ b/packages/app-core/src/runtime/desktop/desktop-view-windows.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Drift guard for the desktop view-window catalog. This lane can import the
+ * @elizaos/agent BUILTIN_VIEWS catalog that neither the renderer bundle nor the
+ * bun main process can, so it asserts that the renderer DESKTOP_VIEW_WINDOWS and
+ * the menu-bar VIEW_MENU_ENTRIES both match the desktop-eligible builtin views
+ * (id, label, path) and cover the same set, and that tray view-item ids
+ * round-trip through parse/build.
+ */
 import { BUILTIN_VIEWS } from "@elizaos/agent/api/builtin-views";
 import { describe, expect, it } from "vitest";
 import {

--- a/packages/app-core/src/runtime/desktop/index.ts
+++ b/packages/app-core/src/runtime/desktop/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Barrel for the Electrobun desktop runtime: re-exports the app-window renderer,
+ * the headless tray/menu and surface-navigation runtimes, the detached-window
+ * shell root, and the tray-menu catalog. This is the desktop surface pulled in by
+ * the browser-safe app-core entry.
+ */
 export * from "./AppWindowRenderer";
 export * from "./DesktopSurfaceNavigationRuntime";
 export * from "./DesktopTrayRuntime";

--- a/packages/app-core/src/runtime/desktop/tray-menu.test.ts
+++ b/packages/app-core/src/runtime/desktop/tray-menu.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit coverage for the desktop tray Notifications entry (#10706): asserts the
+ * static tray catalog and click-audit table in tray-menu.ts expose the
+ * `tray-open-notifications` item, and grep-guards DesktopTrayRuntime.tsx source
+ * so the tray id actually routes to dispatchOpenNotificationCenter(). Reads the
+ * real module + runtime source — no runtime boot.
+ */
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";

--- a/packages/app-core/src/runtime/desktop/tray-menu.ts
+++ b/packages/app-core/src/runtime/desktop/tray-menu.ts
@@ -1,3 +1,16 @@
+/**
+ * Static catalog + label localization for the desktop (Electrobun) system-tray
+ * menu. Declares the tray item tree (DESKTOP_TRAY_MENU_ITEMS), the
+ * desktop-eligible builtin views surfaced under the "Views" submenu
+ * (DESKTOP_VIEW_WINDOWS), the `tray-open-view-<id>` item-id codec, and the
+ * click-audit table (DESKTOP_TRAY_CLICK_AUDIT) that pins each tray id to its
+ * expected renderer action. `buildLocalizedTrayMenu()` resolves labelKeys
+ * through a translator at desktop boot. Everything here is pure so the tray
+ * shape stays unit-testable and out of the `@elizaos/agent` view-catalog import
+ * graph — the renderer bundle builds the tray synchronously, with no /api/views
+ * round-trip. DesktopTrayRuntime consumes these to build and dispatch the native
+ * tray.
+ */
 import type { DesktopClickAuditItem } from "@elizaos/ui/utils/desktop-workspace";
 
 interface DesktopTrayMenuItem {

--- a/packages/app-core/src/runtime/dev-server.ts
+++ b/packages/app-core/src/runtime/dev-server.ts
@@ -1,3 +1,15 @@
+/**
+ * Combined dev-server / desktop-agent process entry. Binds the app-core API
+ * server first (state "starting") so the dashboard can connect immediately,
+ * then bootstraps the AgentRuntime in the background with retry + PGlite
+ * corrupt-data auto-reset, hot-swaps the runtime on restart (RESTART_AGENT /
+ * POST /api/agent/restart via setRestartHandler), and owns SIGINT/SIGTERM
+ * graceful shutdown (startEliza runs headless and defers signal handling here).
+ * Emits startup-timing plus RSS/heap instrumentation; timing anchors to a
+ * parent-spawn env timestamp when present so logs include dependency import
+ * time. The heavy ./eliza runtime graph is imported lazily to keep it out of the
+ * eager import path before the API port binds.
+ */
 // Static ESM imports evaluate before this module body runs. Prefer a parent
 // spawn timestamp so startup logs include dependency import/evaluation time.
 const MODULE_BODY_START = Date.now();

--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -1,3 +1,23 @@
+/**
+ * App-core Eliza runtime loader: the single boot chokepoint every app-core agent
+ * process funnels through. Wraps `@elizaos/agent`'s startEliza / bootElizaRuntime
+ * with app-shell concerns — installs the agent host bridge (vault, account pool,
+ * wallet-key hydration, cloud-pair route), syncs brand env aliases, binds the
+ * API server (bind-first, then background runtime boot), and runs the post-ready
+ * boot tail: local-inference + TTS handler registration, autonomy service +
+ * bootstrap context, app-route plugins and registry runtime-hooks (drained
+ * concurrently with per-loader failure isolation), sensitive-request + sub-agent
+ * credential adapters, the trigger event bridge, connector-target catalog, and
+ * background embedding + voice model warmup.
+ *
+ * Also owns PGlite startup-error normalization + auto-reset (quarantine a
+ * corrupt `.elizadb` and retry once), the ELIZA_SKIP_APP_ROUTE_PLUGINS /
+ * ELIZA_DEFER_APP_ROUTES boot knobs (both default to byte-identical boot), the
+ * local-agent IPC port gate (#12180), and a direct-run CLI (help/version) when
+ * executed as a script. Mobile platforms take a trimmed boot path. Several seams
+ * (PostReadyBootSteps, __setLatestBootTailRuntimeForTest) exist only for focused
+ * unit tests.
+ */
 import "@elizaos/shared";
 import { existsSync } from "node:fs";
 import { rename } from "node:fs/promises";

--- a/packages/app-core/src/runtime/ensure-text-to-speech-handler.ts
+++ b/packages/app-core/src/runtime/ensure-text-to-speech-handler.ts
@@ -1,3 +1,12 @@
+/**
+ * Registers the runtime fallback TEXT_TO_SPEECH model handler so streaming and
+ * swarm voice paths always have a synthesizer even when no provider plugin
+ * claimed the slot. Reads eliza.json to honor a disabled TTS provider, resolves
+ * the default provider (Edge TTS), loads its handler, wraps it with the
+ * provider's first-sentence LRU cache when available, and registers it at the
+ * provider's priority — a no-op when a handler is already registered or the
+ * runtime lacks getModel/registerModel. Invoked from the post-ready boot tail.
+ */
 import { loadElizaConfig } from "@elizaos/agent";
 import { type AgentRuntime, logger, ModelType } from "@elizaos/core";
 import { formatError } from "@elizaos/shared";

--- a/packages/app-core/src/runtime/install-agent-host-bridge.test.ts
+++ b/packages/app-core/src/runtime/install-agent-host-bridge.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Verifies installAgentHostBridge() swaps the agent host-bridge seam from its
+ * no-op default to the app-core implementation, exposing real vault /
+ * account-pool / shared-vault / build-variant / cloud-pair-route capabilities.
+ * Drives the real host-bridge singleton (reset before and after) — no runtime
+ * boot.
+ */
 import {
   _resetAgentHostBridge,
   defaultAgentHostBridge,

--- a/packages/app-core/src/runtime/mobile-safe-runtime.test.ts
+++ b/packages/app-core/src/runtime/mobile-safe-runtime.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit coverage for mobile-safe-runtime.ts: feature detection across iOS
+ * (JavaScriptCore/QuickJS), Android (AVF/Microdroid + isolated-process), and web
+ * hosts, provider selection/fallback ordering, the in-memory virtual file system
+ * (paths, quotas, snapshots/diff/rollback), the capability broker response
+ * shape, and the unavailable-provider placeholders. Pure in-process assertions
+ * with synthetic probes — no native bridge attached.
+ */
 import { describe, expect, it } from "vitest";
 import {
   createAndroidAvfMicrodroidProvider,

--- a/packages/app-core/src/runtime/mobile-safe-runtime.ts
+++ b/packages/app-core/src/runtime/mobile-safe-runtime.ts
@@ -1,3 +1,17 @@
+/**
+ * Host-agnostic contracts + detection for running untrusted code on mobile app
+ * shells that have no Node/Bun runtime. Probes which sandbox boundaries the
+ * current shell actually exposes (detectMobileSafeRuntimeFeatures) — iOS
+ * JavaScriptCore / QuickJS, Android AVF-Microdroid and isolated-process,
+ * WebAssembly, and a dev-only in-process safe-JS applet — and never advertises a
+ * provider until its native boundary is attached. Provides provider factories +
+ * preference-ordered selection, a capability broker with a stable
+ * request/response envelope, a mobile-safe virtual file system (in-memory impl
+ * with quotas, snapshots, diff, and rollback, plus an adapter over the agent
+ * VFS), and the safe-JS applet compile/load/run pipeline whose sandbox denies
+ * imports, eval, shell, and other host escapes. Types-and-pure-functions only —
+ * no device APIs are called here.
+ */
 import { formatError } from "@elizaos/shared";
 
 export type MobileSafeRuntimePlatform = "ios" | "android" | "web" | "unknown";

--- a/packages/app-core/src/runtime/mode/remote-forwarder.test.ts
+++ b/packages/app-core/src/runtime/mode/remote-forwarder.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Unit coverage for the remote-mode request forwarder that a local controller
+ * uses to relay traffic to its private remote Eliza target.
+ * `shouldForwardToRemoteTarget` decides which cloud-auth mutations get forwarded
+ * (POST login/disconnect and billing/v1 writes — never GETs or unrelated paths),
+ * and `buildForwardHeaders` rewrites the outbound header set: preserving
+ * multi-valued `set-cookie`, stripping hop-by-hop headers, rewriting Host to the
+ * target, and injecting a Bearer token only when a remote access token is set.
+ */
 import { describe, expect, test } from "vitest";
 import {
   buildForwardHeaders,

--- a/packages/app-core/src/runtime/mode/route-mode-matrix.test.ts
+++ b/packages/app-core/src/runtime/mode/route-mode-matrix.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Unit coverage for runtime-mode resolution and the route-visibility matrix.
+ * `resolveRuntimeMode` maps deployment config to local / local-only / cloud /
+ * remote (accepting only private remote targets), and `isRouteVisible` /
+ * `findRouteModeRule` / `findRegisteredRouteModeRule` decide which API routes are
+ * exposed per mode: local-inference routes hidden off local runtimes, `/api/cloud`
+ * hidden in local-only, plugin-declared route modes honored, and un-matrixed
+ * routes default-allow.
+ */
 import { describe, expect, test } from "vitest";
 import { findRegisteredRouteModeRule } from "./route-mode-guard";
 import { findRouteModeRule, isRouteVisible } from "./route-mode-matrix";

--- a/packages/app-core/src/runtime/mode/runtime-mode.test.ts
+++ b/packages/app-core/src/runtime/mode/runtime-mode.test.ts
@@ -1,10 +1,3 @@
-import { describe, expect, it } from "vitest";
-import {
-  isLocalRemoteHost,
-  isLocalRuntime,
-  validateRemoteApiBase,
-} from "./runtime-mode.ts";
-
 /**
  * Remote mode is a thin controller for ANOTHER local/private Eliza instance —
  * never Eliza Cloud or a public model API. validateRemoteApiBase is the guard
@@ -13,6 +6,12 @@ import {
  * would let the controller drive an untrusted instance, so each rejection here
  * is a real safety boundary.
  */
+import { describe, expect, it } from "vitest";
+import {
+  isLocalRemoteHost,
+  isLocalRuntime,
+  validateRemoteApiBase,
+} from "./runtime-mode.ts";
 
 describe("isLocalRemoteHost", () => {
   it("accepts loopback, .local, link-local, and private ranges", () => {

--- a/packages/app-core/src/runtime/pglite-auto-reset.test.ts
+++ b/packages/app-core/src/runtime/pglite-auto-reset.test.ts
@@ -1,3 +1,11 @@
+/**
+ * The app-core DB auto-reset (invoked by attemptPgliteAutoReset when a corrupt
+ * `.elizadb` dir is detected) must recover the PGlite singleton through
+ * plugin-sql's PUBLIC closePgliteSingleton() API — not by hand-copying the
+ * plugin's private global-singletons Symbol. These tests seed and inspect the
+ * singleton exclusively via the exported getPgliteSingletonCache() accessor,
+ * proving the seam is real.
+ */
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import {
@@ -7,14 +15,6 @@ import {
 import { afterEach, describe, expect, it } from "vitest";
 import { resetPluginSqlPgliteSingleton } from "./pglite-auto-reset";
 
-/**
- * The app-core DB auto-reset (invoked by attemptPgliteAutoReset when a corrupt
- * `.elizadb` dir is detected) must recover the PGlite singleton through
- * plugin-sql's PUBLIC closePgliteSingleton() API — not by hand-copying the
- * plugin's private global-singletons Symbol. These tests
- * seed and inspect the singleton exclusively via the exported
- * getPgliteSingletonCache() accessor, proving the seam is real.
- */
 describe("resetPluginSqlPgliteSingleton (app-core DB auto-reset)", () => {
   const originalPgliteDataDir = process.env.PGLITE_DATA_DIR;
 

--- a/packages/app-core/src/runtime/pglite-auto-reset.ts
+++ b/packages/app-core/src/runtime/pglite-auto-reset.ts
@@ -1,3 +1,9 @@
+/**
+ * Runtime-side recovery seam for a corrupt or in-use PGlite data directory:
+ * exposes {@link resetPluginSqlPgliteSingleton}, which the eliza.ts auto-reset
+ * path calls (after quarantining the `.elizadb` dir) so the next
+ * `createDatabaseAdapter()` rebuilds a fresh PGlite manager from clean state.
+ */
 import { logger } from "@elizaos/core";
 import { closePgliteSingleton } from "@elizaos/plugin-sql";
 import { formatError } from "@elizaos/shared";

--- a/packages/app-core/src/runtime/platform-policy-docs.test.ts
+++ b/packages/app-core/src/runtime/platform-policy-docs.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Documentation-drift guard: reads the shipped mobile + sandbox docs and the
+ * `run-mobile-build.mjs` Android build script straight from the repo tree and
+ * asserts they stay in sync about what the Android "cloud" build strips (the
+ * in-process agent service, elevated permissions, bundled agent assets/native
+ * libs) and how the sandbox docs gate the shell / coding-tools /
+ * agent-orchestrator plugins. Fails if a doc claim and the build behavior diverge.
+ */
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/packages/app-core/src/runtime/repair-boot-phase.test.ts
+++ b/packages/app-core/src/runtime/repair-boot-phase.test.ts
@@ -1,3 +1,13 @@
+/**
+ * Unit coverage for the post-ready boot tail phase split in `eliza.ts`:
+ * `getDeferAppRoutesEnabled` (the ELIZA_DEFER_APP_ROUTES === "1" truth table) and
+ * `runPostReadyBootTail`, which runs the post-ready-safe boot steps — TTS, app
+ * routes, runtime hooks, sensitive-request adapters, credential bridge, trigger
+ * bridge, connector catalog, voice warmup — in declared order. Tests drive
+ * injected step stubs to assert step ordering, deferred-mode dispatch (the caller
+ * returns before a hung app-route load settles), the superseded-runtime teardown
+ * guard, and per-step error isolation.
+ */
 import type { AgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/app-core/src/runtime/runtime-bootstrap-policy.ts
+++ b/packages/app-core/src/runtime/runtime-bootstrap-policy.ts
@@ -1,3 +1,11 @@
+/**
+ * Pure decision helpers for runtime bootstrap failures — no I/O, no runtime
+ * dependency. Classifies a boot error as retryable or terminal: fatal PGlite
+ * conditions (data-dir in use, corrupt data, manual-reset-required) stop retries
+ * immediately, otherwise callers back off via `nextRuntimeBootRetryDelayMs`
+ * (exponential, capped at 30s) and flip to the terminal error state once the
+ * attempt-count or elapsed-duration threshold is crossed.
+ */
 const FATAL_PGLITE_CODES = new Set([
   "ELIZA_PGLITE_DATA_DIR_IN_USE",
   "ELIZA_PGLITE_CORRUPT_DATA",

--- a/packages/app-core/src/runtime/runtime-hook-channel.test.ts
+++ b/packages/app-core/src/runtime/runtime-hook-channel.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit coverage for `drainRuntimeHookContributors`, the generic runtime-hook
+ * channel the boot tail drains. It invokes each registry-declared contributor's
+ * `invoke(runtime)` in declared order, silently skips a contributor whose
+ * optional plugin is absent (OptionalAppRoutePluginUnavailableError), and
+ * rethrows any real failure — short-circuiting the remaining contributors.
+ */
 import type { AgentRuntime } from "@elizaos/core";
 import { OptionalAppRoutePluginUnavailableError } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";

--- a/packages/app-core/src/runtime/sub-agent-credential-bridge-wiring.test.ts
+++ b/packages/app-core/src/runtime/sub-agent-credential-bridge-wiring.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Tests `registerSubAgentCredentialBridge` against a minimal AgentRuntime fake:
+ * a parent runtime registers the bridge under both service names + the actions
+ * plugin and round-trips declareScope/tunnelCredential through the adapter
+ * (idempotently), while a sandboxed child with no ACP service registers nothing
+ * and degrades to the 503 path.
+ */
 import type {
   AgentRuntime,
   Service,

--- a/packages/app-core/src/runtime/tts-default-handler.ts
+++ b/packages/app-core/src/runtime/tts-default-handler.ts
@@ -1,3 +1,9 @@
+/**
+ * Fallback loader for the default (edge-tts) text-to-speech handler, used only
+ * on boot paths where the edge-tts plugin did not self-register its
+ * `ModelType.TEXT_TO_SPEECH` model, so streaming / swarm voice can still resolve
+ * a handler.
+ */
 import { ModelType } from "@elizaos/core";
 import type { TtsModelHandler } from "./tts-provider-registry.js";
 

--- a/packages/app-core/src/runtime/tts-provider-registry.test.ts
+++ b/packages/app-core/src/runtime/tts-provider-registry.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Tests the TTS provider registry: the default provider entry is metadata-only
+ * (no importable handler), config/env disable controls resolve through the
+ * provider config key, and the default is selected by the data-driven
+ * `defaultTextToSpeech` flag — asserted partly via source-grep guards against a
+ * hard-coded `edge-tts` id or a variable-specifier `import()`.
+ */
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/app-core/src/runtime/tts-provider-registry.ts
+++ b/packages/app-core/src/runtime/tts-provider-registry.ts
@@ -1,3 +1,13 @@
+/**
+ * Resolves the default text-to-speech provider from the first-party plugin
+ * registry. The default is data-driven: the owning voice plugin marks its
+ * registry entry `defaultTextToSpeech: true` (guarded by `subtype: "voice"`),
+ * and its `id`/`npmName` flow through as the provider name, config key, and
+ * disable-flag lookup — no plugin id is hard-coded in the resolution path.
+ * Entries are metadata-only (the concrete handler self-registers at plugin
+ * load); this module also exposes the config/env disable check for the resolved
+ * provider.
+ */
 import process from "node:process";
 import type { AgentRuntime } from "@elizaos/core";
 import firstPartyRegistry from "@elizaos/registry/first-party/generated.json" with {

--- a/packages/app-core/src/runtime/voice-warmup.test.ts
+++ b/packages/app-core/src/runtime/voice-warmup.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests voice-model warmup: `shouldWarmupVoice` gating (desktop-only, skipped on
+ * mobile / cloud-only / dev hot-reload respawns), the silent RIFF/WAVE warmup
+ * buffer, and `warmVoiceModels` loading TTS then STT in order without rejecting
+ * when a model load fails.
+ */
 import { describe, expect, it, vi } from "vitest";
 import {
   buildSilentWarmupWav,

--- a/packages/app-core/src/security/agent-vault-id.test.ts
+++ b/packages/app-core/src/security/agent-vault-id.test.ts
@@ -1,15 +1,15 @@
+/**
+ * Tests the agent vault id: a deterministic sha256 over the canonical state dir
+ * (base64url-truncated, stable `mldy1-` prefix) that namespaces an agent's
+ * secrets in the OS keychain, plus the `<vaultId>:<kind>` keychain-account
+ * derivation. The same install always resolves the same vault, and two
+ * different state dirs never collide onto one keychain namespace.
+ */
 import { describe, expect, it } from "vitest";
 import {
   deriveAgentVaultId,
   keychainAccountForSecretKind,
 } from "./agent-vault-id.ts";
-
-/**
- * The agent vault id namespaces an agent's secrets in the OS keychain. It is a
- * deterministic sha256 over the canonical state dir (base64url-truncated, with
- * a stable `mldy1-` prefix) so the same install always resolves the same vault,
- * and two different state dirs never collide onto one keychain namespace.
- */
 
 describe("deriveAgentVaultId", () => {
   it("is deterministic for a given state dir and prefixed", () => {

--- a/packages/app-core/src/security/agent-vault-id.ts
+++ b/packages/app-core/src/security/agent-vault-id.ts
@@ -1,3 +1,12 @@
+/**
+ * Derives the opaque, per-install vault id that namespaces an agent's secrets in
+ * the OS keychain. The id is a deterministic sha256 over the canonical state dir
+ * (XDG / `ELIZA_STATE_DIR` precedence, realpath-normalized), base64url-truncated
+ * behind a stable `mldy1-` prefix, so one install always resolves the same vault
+ * and two state dirs never collide. Kept dependency-light for the Electrobun
+ * bootstrap path (no `@elizaos/core` barrel import), and pairs the vault id with
+ * a secret kind to form the keychain account handle.
+ */
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import { homedir } from "node:os";

--- a/packages/app-core/src/security/hydrate-wallet-keys-from-platform-store.ts
+++ b/packages/app-core/src/security/hydrate-wallet-keys-from-platform-store.ts
@@ -1,3 +1,11 @@
+/**
+ * Boot-time hydration of wallet (and steward) secrets into `process.env`.
+ * Wallet keys are read from the shared vault (now the source of truth), with a
+ * one-shot migration of any legacy values still only in the OS keystore; steward
+ * env vars stay on the OS-keystore path because that backend's lifecycle is
+ * independent of the unified vault. Runs before upstream `startApiServer` merges
+ * `config.env`, so persisted config only fills gaps neither store supplies.
+ */
 import { logger } from "@elizaos/core";
 
 import { sharedVault } from "../services/vault-mirror";

--- a/packages/app-core/src/security/platform-secure-store-node.ts
+++ b/packages/app-core/src/security/platform-secure-store-node.ts
@@ -1,3 +1,10 @@
+/**
+ * Node-side OS secure-store backends for agent secrets: macOS Keychain (the
+ * `security` CLI, passwords passed via stdin to keep them out of argv / `ps`),
+ * Linux libsecret (`secret-tool`), and an explicit unavailable backend on
+ * platforms with no adapter. Exposes the platform factory plus availability and
+ * env-gated (`ELIZA_WALLET_OS_STORE`) enablement checks for the wallet key path.
+ */
 import { execFile, spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";

--- a/packages/app-core/src/services/account-pool.test.ts
+++ b/packages/app-core/src/services/account-pool.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Unit tests for AccountPool — provider-scoped linked-account selection and
+ * eligibility gating. Covers id-collision resolution across providers,
+ * priority/round-robin/session-affinity/usage-aware strategies, least-used
+ * burst spreading, and the eligibility guard (exclude set, enabled flag,
+ * accountIds allow-list, rate-limit re-admission). The pool is driven through
+ * injected readAccounts/writeAccount and a stubbed fetch, so no real credential
+ * store or provider API is touched.
+ */
 import type { LinkedAccountConfig } from "@elizaos/shared";
 import { describe, expect, it } from "vitest";
 import { AccountPool } from "./account-pool";

--- a/packages/app-core/src/services/ambient-audio/__tests__/ambient-audio.test.ts
+++ b/packages/app-core/src/services/ambient-audio/__tests__/ambient-audio.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the ambient-audio subsystem: consent expiry gating, the
+ * replay buffer's newest-samples-within-maxSeconds trimming and frame-format
+ * rejection, the response-gate decision thresholds, and the in-memory service's
+ * consent enforcement + audio clearing on stop. Runs fully in-memory against
+ * synthetic Int16 frames — no real capture device or transcription.
+ */
 import { describe, expect, it } from "vitest";
 import { AmbientAudioConsentState } from "../consent.ts";
 import { ReplayBuffer } from "../replay-buffer.ts";

--- a/packages/app-core/src/services/ambient-audio/consent.ts
+++ b/packages/app-core/src/services/ambient-audio/consent.ts
@@ -1,3 +1,10 @@
+/**
+ * In-memory store of ambient-audio capture consent, keyed by owner id. Tracks
+ * grant/revoke and honours per-record expiry: `get` returns null once a record
+ * has lapsed, and `require` throws when no active consent exists. This is the
+ * gate the capture service consults before it may start or resume listening —
+ * capture must never begin without a live (non-expired) consent record.
+ */
 import type { ConsentRecord } from "./types.ts";
 
 export class AmbientAudioConsentState {

--- a/packages/app-core/src/services/ambient-audio/index.ts
+++ b/packages/app-core/src/services/ambient-audio/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Barrel for the ambient-audio subsystem: re-exports the consent state, replay
+ * buffer, response gate, in-memory service, and the shared ambient-audio types.
+ */
 export { AmbientAudioConsentState } from "./consent.ts";
 export { ReplayBuffer } from "./replay-buffer.ts";
 export { decideResponse } from "./response-gate.ts";

--- a/packages/app-core/src/services/ambient-audio/replay-buffer.ts
+++ b/packages/app-core/src/services/ambient-audio/replay-buffer.ts
@@ -1,3 +1,10 @@
+/**
+ * Fixed-duration rolling buffer of the most recent ambient audio. Accepts only
+ * 16 kHz mono Int16 frames, copies their samples, and caps retained audio to
+ * `maxSeconds` (default 30) by trimming the oldest samples as new ones arrive.
+ * `readTail(seconds)` returns the newest N seconds as a contiguous Int16Array,
+ * letting the service replay the moment just before a response decision.
+ */
 import type { AudioFrame } from "./types.ts";
 
 interface StoredFrame {

--- a/packages/app-core/src/services/ambient-audio/response-gate.ts
+++ b/packages/app-core/src/services/ambient-audio/response-gate.ts
@@ -1,3 +1,10 @@
+/**
+ * Pure decision function that decides whether the agent should speak in
+ * response to ambient audio. Weighs the gate signals — direct address, wake
+ * intent, owner confidence, whether the context expects a reply, and VAD
+ * activity — and returns a `ResponseDecision` carrying the winning reason and a
+ * confidence score. Signal values are clamped to [0,1]; no side effects.
+ */
 import type { ResponseDecision, ResponseGateSignals } from "./types.ts";
 
 const clamp01 = (value: number): number =>

--- a/packages/app-core/src/services/ambient-audio/service.ts
+++ b/packages/app-core/src/services/ambient-audio/service.ts
@@ -1,3 +1,10 @@
+/**
+ * In-memory reference implementation of `AmbientAudioService`. Drives the
+ * capture mode state machine (stopped → listening ⇄ paused) and feeds incoming
+ * frames into a `ReplayBuffer`. `start`/`resume` require an active consent
+ * record via `AmbientAudioConsentState`, `pushFrame` is rejected unless
+ * listening, and `stop` clears both the owner binding and all retained audio.
+ */
 import type { AmbientAudioConsentState } from "./consent.ts";
 import { ReplayBuffer } from "./replay-buffer.ts";
 import type {

--- a/packages/app-core/src/services/ambient-audio/types.ts
+++ b/packages/app-core/src/services/ambient-audio/types.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared type definitions for the ambient-audio subsystem: capture modes, the
+ * owner consent record, the raw audio frame (fixed 16 kHz mono Int16), a
+ * transcribed segment, the response-gate signals/decision, and the
+ * `AmbientAudioService` interface that concrete capture backends implement.
+ */
 export type AmbientAudioMode = "stopped" | "listening" | "paused";
 
 export interface ConsentRecord {

--- a/packages/app-core/src/services/app-updates/update-policy.test.ts
+++ b/packages/app-core/src/services/app-updates/update-policy.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Unit tests for the app-update policy resolver. Asserts that
+ * `resolveAppUpdatePolicy` maps each platform/build-variant/elizaOS combination
+ * to the correct update channel, authority, and auto-update/manual-check
+ * capabilities (desktop direct vs store, App Store/Play, Android sideload vs
+ * AOSP, iOS sideload), and that `mapAgentUpdateStatusToSnapshot` renders the
+ * package-manager-constrained agent status snapshot, prioritising check errors.
+ * Both targets are pure functions, so these run without any I/O.
+ */
 import { describe, expect, it } from "vitest";
 import {
   mapAgentUpdateStatusToSnapshot,

--- a/packages/app-core/src/services/app-updates/update-policy.ts
+++ b/packages/app-core/src/services/app-updates/update-policy.ts
@@ -1,3 +1,19 @@
+/**
+ * Derives the update policy and snapshots that the dashboard's "Updates" surface
+ * renders, for both the app shell itself and the connected agent.
+ *
+ * `resolveAppUpdatePolicy` maps platform + native flag + build variant + elizaOS
+ * image to a distribution channel, update authority, and the set of allowed
+ * affordances (auto-update, manual check, release notes) plus display labels —
+ * encoding each channel's constraint: desktop-direct self-updates from GitHub;
+ * store / App Store / Google Play / AOSP builds are host-managed and cannot
+ * self-update; sideload builds are manual-only. `mapAgentUpdateStatusToSnapshot`
+ * turns a connected agent's AgentUpdateStatus into a UI snapshot keyed on its
+ * install method (npm/bun/homebrew/snap/apt/flatpak/local-dev).
+ * `getApplicationUpdateSnapshot` detects the current platform via Capacitor and
+ * combines native app info with the resolved policy. Pure derivation — clients
+ * render these DTO fields, they do not recompute them.
+ */
 import { Capacitor } from "@capacitor/core";
 import {
   type AgentUpdateAuthority,

--- a/packages/app-core/src/services/coding-account-bridge.test.ts
+++ b/packages/app-core/src/services/coding-account-bridge.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Exercises the coding-agent account selector bridge (getCodingAgentSelectorBridge)
+ * and its auth-failure triage (isAuthFailure): least-used vs priority vs config-
+ * vs env-driven selection, per-agent env patches (CLAUDE_CODE_OAUTH_TOKEN, a
+ * materialized CODEX_HOME/auth.json + config.toml with a TOML-injection guard,
+ * CEREBRAS_API_KEY), usage attribution, and rate-limit skipping. Runs against a
+ * real temp ELIZA_HOME / ELIZA_STATE_DIR and real account storage — no mocked pool.
+ */
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/packages/app-core/src/services/connector-target-catalog.test.ts
+++ b/packages/app-core/src/services/connector-target-catalog.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers createElizaConnectorTargetCatalog: aggregating registered connector
+ * target sources into groups, re-reading the source registry on every call,
+ * platform filtering without invoking non-matching sources, forwarding the
+ * getConfig/fetch/clock/logger seams into enumerate, and concatenating groups
+ * across multiple sources. Sources are in-test fakes / vi.fn stubs.
+ */
 import type { TargetSource } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/packages/app-core/src/services/credential-tunnel-service.test.ts
+++ b/packages/app-core/src/services/credential-tunnel-service.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Covers the credential tunnel service and its sub-agent credential bridge
+ * adapter: a one-shot tunnel where a parent declares a scope (64-hex scoped token
+ * + scope id + TTL), tunnels a ciphertext, and retrieves it exactly once — with
+ * guards for replay, expiry, session isolation, undeclared keys, and bad token
+ * shapes. Also asserts the bridge dispatches an owner-only sensitive request
+ * without leaking the scoped token or value, and that registration skips
+ * sandbox/child runtimes. Uses in-process services with an injected fake clock.
+ */
 import {
   createSensitiveRequestDispatchRegistry,
   SENSITIVE_REQUEST_DISPATCH_REGISTRY_SERVICE,

--- a/packages/app-core/src/services/persistence.test.ts
+++ b/packages/app-core/src/services/persistence.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers resolveIosPersistenceAdapter: it selects the iOS SQLite persistence
+ * adapter when the plugin is available and otherwise falls back to Capacitor
+ * Preferences. Deps are in-memory fake adapters + vi.fn availability probes.
+ */
 import { describe, expect, it, vi } from "vitest";
 
 import {

--- a/packages/app-core/src/services/sensitive-requests/cloud-link-adapter.test.ts
+++ b/packages/app-core/src/services/sensitive-requests/cloud-link-adapter.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Covers the cloud_authenticated_link sensitive-request delivery adapter: it
+ * builds the Eliza Cloud link the owner opens to satisfy a request
+ * (/sensitive-requests/<id> for secret/oauth/private_info,
+ * /payment/app-charge/<appId>/<id> for payment), returns "cloud not paired" when
+ * unpaired, a structured error for a payment request missing an appId, and
+ * URL-encodes the request id. The cloud base is injected via resolveCloudBase.
+ */
 import type {
   DispatchSensitiveRequest,
   SensitiveRequest,

--- a/packages/app-core/src/services/sensitive-requests/cloud-link-adapter.ts
+++ b/packages/app-core/src/services/sensitive-requests/cloud-link-adapter.ts
@@ -1,3 +1,14 @@
+/**
+ * Sensitive-request delivery adapter for the `cloud_authenticated_link` target:
+ * resolves the paired Eliza Cloud site base URL (from runtime settings or env,
+ * the default resolver gated on ELIZAOS_CLOUD_API_KEY) and builds the
+ * authenticated cloud link the owner opens to satisfy the request —
+ * `/sensitive-requests/<id>` for secret/oauth/private_info, and
+ * `/payment/app-charge/<appId>/<id>` for payment (appId from the target or the
+ * request callback). Returns a structured DeliveryResult: delivered with url +
+ * expiresAt, or delivered:false with a reason when cloud is not paired or a
+ * payment request is missing its appId.
+ */
 import type {
   DeliveryResult,
   DispatchSensitiveRequest as SensitiveRequest,

--- a/packages/app-core/src/services/sensitive-requests/instruct-dm-only-adapter.test.ts
+++ b/packages/app-core/src/services/sensitive-requests/instruct-dm-only-adapter.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers the instruct_dm_only sensitive-request delivery target: the last-resort
+ * adapter that, when no private or authenticated route exists, reports success
+ * with no url and formRendered=false (instructing the owner to move to a DM or
+ * the owner app), for every request kind including payment.
+ */
 import type { DispatchSensitiveRequest, SensitiveRequest } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { instructDmOnlySensitiveRequestAdapter } from "./instruct-dm-only-adapter";

--- a/packages/app-core/src/services/sensitive-requests/owner-app-inline-adapter.test.ts
+++ b/packages/app-core/src/services/sensitive-requests/owner-app-inline-adapter.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Covers the owner_app_inline sensitive-request delivery target: for an owner-app
+ * private secret request it sends an inline sensitive-request form envelope via
+ * runtime.sendMessageToTarget, and this suite asserts the envelope/form shape
+ * (fields, labels, sub-agent tunnel metadata without leaking the scoped token,
+ * image-field metadata per #8910) and the rejections (non-owner-app-private
+ * channel, non-secret kind, missing sendMessageToTarget, transport failure).
+ * Uses a vi.fn runtime capture plus core's real resolveSensitiveRequestDelivery.
+ */
 import {
   ChannelType,
   type Content,

--- a/packages/app-core/src/services/sensitive-requests/owner-app-inline-adapter.ts
+++ b/packages/app-core/src/services/sensitive-requests/owner-app-inline-adapter.ts
@@ -1,3 +1,15 @@
+/**
+ * SensitiveRequestDeliveryAdapter for `target === "owner_app_inline"`: delivers
+ * `kind: "secret"` sensitive-requests inline into the owner-app private DM chat.
+ * It builds a status-only `secretRequest` envelope (rendered by the UI's
+ * `SensitiveRequestBlock`) and dispatches it via the runtime's
+ * `sendMessageToTarget`. Delivery is gated on the request classifying as
+ * `owner_app_private` (`classifySensitiveRequestSource`), so secrets are only
+ * collected on the local owner surface. Supports multi-key tunnel requests
+ * (sub-agent credential scopes) and per-field image/file upload inputs. The
+ * runtime is type-narrowed at the boundary instead of importing `IAgentRuntime`,
+ * so the registry can pass `unknown`.
+ */
 import {
   ChannelType,
   type Content,

--- a/packages/app-core/src/services/sensitive-requests/owner-app-oauth-adapter.test.ts
+++ b/packages/app-core/src/services/sensitive-requests/owner-app-oauth-adapter.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `ownerAppOAuthSensitiveRequestAdapter`: verifies the OAuth
+ * envelope shape, owner-app-private channel gating, kind/target validation, and
+ * that the authorization URL never leaks into the chat `text`. Uses a `vi.fn`
+ * `sendMessageToTarget` mock that captures each dispatched message.
+ */
 import {
   ChannelType,
   type Content,

--- a/packages/app-core/src/services/sensitive-requests/owner-app-oauth-adapter.ts
+++ b/packages/app-core/src/services/sensitive-requests/owner-app-oauth-adapter.ts
@@ -1,3 +1,12 @@
+/**
+ * SensitiveRequestDeliveryAdapter for `target === "owner_app_oauth"`: the OAuth
+ * sibling of the inline-secret adapter. Delivers `kind: "oauth"` requests as an
+ * inline chat message whose `secretRequest.form.kind === "oauth"` envelope is
+ * rendered by the UI's `OAuthRequestPanel`. Delivery is gated on the request
+ * classifying as `owner_app_private`, and the authorization URL travels only
+ * inside the envelope's `form.authorizationUrl` — never in the chat `text` (see
+ * the security note on the runtime interface below).
+ */
 import {
   ChannelType,
   type Content,

--- a/packages/app-core/src/services/sensitive-requests/public-link-adapter.test.ts
+++ b/packages/app-core/src/services/sensitive-requests/public-link-adapter.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `publicLinkSensitiveRequestAdapter`: verifies it emits a public
+ * app-charge URL only for `any_payer` payment requests carrying an `appId`,
+ * resolves the cloud base from the runtime setting / env / default, URL-encodes
+ * path components, and refuses secrets, verified-payer payments, and missing appId.
+ */
 import type {
   SensitiveRequest,
   SensitiveRequestWithPaymentContext,

--- a/packages/app-core/src/services/sensitive-requests/tunnel-link-adapter.test.ts
+++ b/packages/app-core/src/services/sensitive-requests/tunnel-link-adapter.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `createTunnelLinkSensitiveRequestAdapter`: verifies the
+ * tunnel-served URL is built from the reported tunnel base (trailing slashes
+ * trimmed), the "no active tunnel" failure paths, payment kind without an appId,
+ * and the fallback to the runtime `tunnel` service when no status resolver is injected.
+ */
 import type {
   DispatchSensitiveRequest,
   SensitiveRequestKind,

--- a/packages/app-core/src/services/sensitive-requests/tunnel-link-adapter.ts
+++ b/packages/app-core/src/services/sensitive-requests/tunnel-link-adapter.ts
@@ -1,3 +1,11 @@
+/**
+ * SensitiveRequestDeliveryAdapter factory for
+ * `target === "tunnel_authenticated_link"`: routes a sensitive-request to the
+ * device's active tunnel by returning `${tunnelBase}/api/sensitive-requests/<id>`.
+ * The tunnel-status resolver is injectable (for tests) and defaults to the core
+ * `getTunnelService`; when no tunnel is active it fails with "no active tunnel".
+ * Also exports a ready-made singleton (`tunnelLinkSensitiveRequestAdapter`).
+ */
 import type {
   DeliveryResult,
   IAgentRuntime,

--- a/packages/app-core/src/services/steward-credentials.test.ts
+++ b/packages/app-core/src/services/steward-credentials.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for `saveStewardCredentials` / `loadStewardCredentials`: verifies
+ * steward secrets (apiKey, agentToken) land in the PlatformSecureStore rather
+ * than the plaintext metadata file, that legacy plaintext secrets are migrated
+ * and scrubbed on load, and that scrubbing still happens when the secure store
+ * is unavailable. Uses an in-memory secure store and a temp `ELIZA_STATE_DIR`.
+ */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/packages/app-core/src/services/steward-sidecar/process-management.ts
+++ b/packages/app-core/src/services/steward-sidecar/process-management.ts
@@ -1,3 +1,10 @@
+/**
+ * Process-management helpers for the Steward sidecar. `findStewardEntryPoint`
+ * locates the Steward API entry on disk (env override, then `@stwd/api`
+ * module resolution), and `pipeOutput` streams a spawned process's stdout/stderr
+ * line-by-line into the structured logger (warn for stderr, info for stdout),
+ * invoking an optional per-line callback.
+ */
 import * as fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { logger } from "@elizaos/core";

--- a/packages/app-core/src/services/tunnel-to-mobile/index.ts
+++ b/packages/app-core/src/services/tunnel-to-mobile/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Public barrel for the tunnel-to-mobile client: re-exports
+ * `TunnelToMobileClient` and its option/state/socket types from
+ * `./tunnel-to-mobile-client`.
+ */
 export {
   TunnelToMobileClient,
   type TunnelToMobileOptions,

--- a/packages/app-core/src/services/tunnel-to-mobile/tunnel-to-mobile-client.test.ts
+++ b/packages/app-core/src/services/tunnel-to-mobile/tunnel-to-mobile-client.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for the Mac-side TunnelToMobileClient relay dialer: URL
+ * construction (deviceId + pairing-token query params), state-machine
+ * transitions, the register frame emitted on socket open, frame delivery with
+ * malformed-JSON tolerance, and the guard that rejects construction when no
+ * WebSocket implementation is available. Drives a synchronous in-process
+ * FakeSocket double rather than a live relay connection.
+ */
 import { describe, expect, it, vi } from "vitest";
 import {
   TunnelToMobileClient,

--- a/packages/app-core/src/services/vault-bootstrap.test.ts
+++ b/packages/app-core/src/services/vault-bootstrap.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit test for runVaultBootstrap startup resilience: when only the
+ * process.env mirroring step cannot reach the vault, boot must not fail — the
+ * run resolves reporting the unreachable key as failed rather than throwing.
+ * @elizaos/agent, @elizaos/core, and the registry are mocked, and the vault is
+ * a hand-rolled stub whose set() always throws.
+ */
 import type { Vault } from "@elizaos/vault";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/app-core/src/services/vault-mirror.test.ts
+++ b/packages/app-core/src/services/vault-mirror.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the shared vault facade: sharedSecretsManager() memoizes a
+ * single process-wide SecretsManager and sharedVault() returns its vault,
+ * while _resetSharedVaultForTesting() swaps the cached facade for a fresh one.
+ * Exercises real createTestVault instances, disposed after each test.
+ */
 import { createTestVault, type TestVault } from "@elizaos/vault";
 import { afterEach, describe, expect, it } from "vitest";
 import {

--- a/packages/app-core/src/services/voice-profiles/__tests__/diarization-pipeline.test.ts
+++ b/packages/app-core/src/services/voice-profiles/__tests__/diarization-pipeline.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for MOCK_DIARIZATION_PIPELINE: an empty audioRef yields no
+ * segments, and a non-empty ref returns two deterministic mock speaker
+ * segments with ordered, non-degenerate time ranges.
+ */
 import { describe, expect, it } from "vitest";
 import { MOCK_DIARIZATION_PIPELINE } from "../diarization-pipeline.ts";
 

--- a/packages/app-core/src/services/voice-profiles/__tests__/nickname-evaluator.test.ts
+++ b/packages/app-core/src/services/voice-profiles/__tests__/nickname-evaluator.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for NAIVE_NICKNAME_EVALUATOR: pattern-based nickname extraction
+ * from transcript lines ("call me X", "my name is X", "I go by X"), the
+ * no-match and multi-transcript cases, and the capitalization filter that
+ * rejects lowercase candidates.
+ */
 import { describe, expect, it } from "vitest";
 import { NAIVE_NICKNAME_EVALUATOR } from "../nickname-evaluator.ts";
 

--- a/packages/app-core/src/services/voice-profiles/__tests__/owner-confidence.test.ts
+++ b/packages/app-core/src/services/voice-profiles/__tests__/owner-confidence.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for scoreOwnerConfidence: per-signal weighting (challenge,
+ * recent auth, the device-trust step, context expectation, and capped voice
+ * similarity), the reason strings attached to each contributing signal, and
+ * clamping of the final score to [0, 1].
+ */
 import { describe, expect, it } from "vitest";
 import {
   type OwnerConfidenceInput,

--- a/packages/app-core/src/services/voice-profiles/__tests__/private-challenge.test.ts
+++ b/packages/app-core/src/services/voice-profiles/__tests__/private-challenge.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for InMemoryChallengeService: issuing a challenge with a
+ * sha256-hashed expected answer, single-use correct verification, rejection of
+ * wrong/unknown/expired challenges, and the id+seed default-hash path used
+ * when no expected answer is configured. Uses an injectable clock for expiry.
+ */
 import { describe, expect, it } from "vitest";
 import { InMemoryChallengeService } from "../private-challenge.ts";
 

--- a/packages/app-core/src/services/voice-profiles/__tests__/store.test.ts
+++ b/packages/app-core/src/services/voice-profiles/__tests__/store.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for InMemoryVoiceProfileStore: upsert/get/list/delete roundtrips,
+ * cosine-similarity search sorted descending with the limit honored, and a
+ * 200-profile scale case asserting top-k results stay ordered by similarity.
+ */
 import { describe, expect, it } from "vitest";
 import { InMemoryVoiceProfileStore } from "../store.ts";
 import type { VoiceProfile } from "../types.ts";

--- a/packages/app-core/src/services/voice-profiles/diarization-pipeline.ts
+++ b/packages/app-core/src/services/voice-profiles/diarization-pipeline.ts
@@ -1,3 +1,10 @@
+/**
+ * Speaker-diarization contract for voice-profile audio: a DiarizationPipeline
+ * splits an audio reference into per-speaker DiarizationSegment time ranges.
+ * MOCK_DIARIZATION_PIPELINE is the deterministic placeholder implementation
+ * (empty for an empty ref, two fixed speaker segments otherwise) used until a
+ * real diarization backend is wired in.
+ */
 import type { DiarizationSegment } from "./types.ts";
 
 export interface DiarizationPipeline {

--- a/packages/app-core/src/services/voice-profiles/index.ts
+++ b/packages/app-core/src/services/voice-profiles/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Barrel for the voice-profiles service surface: re-exports the subsystem's
+ * public types and default implementations — the diarization pipeline, the
+ * naive (regex-only) nickname evaluator, the owner-confidence scorer, the
+ * in-memory owner challenge service, and the in-memory voice-profile store.
+ */
 export type { DiarizationPipeline } from "./diarization-pipeline.ts";
 export { MOCK_DIARIZATION_PIPELINE } from "./diarization-pipeline.ts";
 export type {

--- a/packages/app-core/src/services/voice-profiles/nickname-evaluator.ts
+++ b/packages/app-core/src/services/voice-profiles/nickname-evaluator.ts
@@ -1,3 +1,10 @@
+/**
+ * Deterministic nickname extraction over voice transcripts: scans each
+ * transcript entry for self-naming phrases ("call me …", "my name is …",
+ * "I go by …") and emits `NicknameProposal`s tagged owner/household with a
+ * fixed per-pattern confidence. `NAIVE_NICKNAME_EVALUATOR` is the default,
+ * regex-only implementation of the `NicknameEvaluator` contract — no model call.
+ */
 export interface NicknameProposal {
   nickname: string;
   subject: "owner" | "household";

--- a/packages/app-core/src/services/voice-profiles/owner-confidence.ts
+++ b/packages/app-core/src/services/voice-profiles/owner-confidence.ts
@@ -1,3 +1,10 @@
+/**
+ * Scores how confident the runtime is that the current speaker is the device
+ * owner. Combines weighted signals — a recently passed private challenge,
+ * recent authentication, voice similarity to the owner profile (capped),
+ * device trust level, and whether context expects the owner — into a clamped
+ * [0,1] `OwnerConfidence` score plus the reason tags that contributed to it.
+ */
 import type { OwnerConfidence } from "./types.ts";
 
 export interface OwnerConfidenceInput {

--- a/packages/app-core/src/services/voice-profiles/private-challenge.ts
+++ b/packages/app-core/src/services/voice-profiles/private-challenge.ts
@@ -1,3 +1,10 @@
+/**
+ * In-memory owner-verification challenge service. `issue()` mints an
+ * `OwnerChallenge` (uuid, prompt, sha256 hash of the expected answer, TTL);
+ * `verify()` hashes the submitted answer against the stored digest, rejecting
+ * expired challenges and consuming a challenge on success or expiry. Backs the
+ * private-phrase step of owner authentication; the default TTL is five minutes.
+ */
 import { createHash, randomUUID } from "node:crypto";
 import type { OwnerChallenge } from "./types.ts";
 

--- a/packages/app-core/src/services/voice-profiles/store.ts
+++ b/packages/app-core/src/services/voice-profiles/store.ts
@@ -1,3 +1,10 @@
+/**
+ * Voice-profile persistence contract plus an in-memory implementation. Stores
+ * `VoiceProfile` records keyed by id and answers similarity queries by cosine
+ * similarity against each profile's embedding previews — a profile's score is
+ * its best-matching embedding, and hits are returned sorted descending and
+ * capped at `limit`. `InMemoryVoiceProfileStore` is the default, non-durable store.
+ */
 import type { VoiceProfile } from "./types.ts";
 
 export interface VoiceProfileSearchHit {

--- a/packages/app-core/src/services/voice-profiles/types.ts
+++ b/packages/app-core/src/services/voice-profiles/types.ts
@@ -1,3 +1,10 @@
+/**
+ * Shared data contracts for the voice-profiles subsystem: an embedding summary,
+ * per-profile quality metrics, the `VoiceProfile` record (owner flag,
+ * embeddings, consent basis), a diarization segment, the owner-confidence
+ * result, and the owner-challenge record. Consumed across the store, nickname
+ * evaluator, confidence scorer, and challenge service.
+ */
 export interface VoiceEmbeddingSummary {
   vectorPreview: ReadonlyArray<number>;
   modelId: string;

--- a/packages/app-core/src/test-support/test-helpers.ts
+++ b/packages/app-core/src/test-support/test-helpers.ts
@@ -1,13 +1,16 @@
+/**
+ * Shared helpers for app-core unit tests: an environment-variable sandbox,
+ * plugin-shape predicates and export extractors, package/connector import
+ * resolvers (Telegram, Lens, Farcaster, Nostr, Matrix, Feishu), mock
+ * update-check payloads, lightweight mocked HTTP request/response objects, and
+ * optional-dynamic-import guards that swallow missing-module errors.
+ */
 import { EventEmitter } from "node:events";
 import { existsSync } from "node:fs";
 import type http from "node:http";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-
-/**
- * Test helper utilities shared across unit tests.
- */
 
 const OPTIONAL_IMPORT_ERROR_MARKERS = [
   "Cannot find module",

--- a/packages/app-core/src/ui-compat.ts
+++ b/packages/app-core/src/ui-compat.ts
@@ -1,6 +1,12 @@
-// Registration-surface contracts + registries (overlay apps, detail extensions)
-// are owned by @elizaos/shared — the React-free canonical home — so this
-// Node-reachable shim registers app surfaces without touching the React package.
+/**
+ * `./ui-compat` subpath export — a Node-reachable UI-compat shim that lets app
+ * plugins register dashboard surfaces and pull a curated slice of the UI kit
+ * without dragging the React component graph into the API process at boot.
+ *
+ * Registration-surface contracts + registries (overlay apps, detail extensions)
+ * are owned by @elizaos/shared — the React-free canonical home — so this shim
+ * registers app surfaces without touching the React package.
+ */
 export type {
   AppDetailExtensionProps,
   OverlayApp,

--- a/packages/app-core/src/utils/eliza-root.ts
+++ b/packages/app-core/src/utils/eliza-root.ts
@@ -1,3 +1,11 @@
+/**
+ * Locates the elizaOS core package root at runtime by walking ancestor
+ * directories until it finds a `package.json` whose name is `"eliza"`. Candidate
+ * start dirs are derived from a module URL, `argv[1]` (including
+ * `node_modules/.bin` shim resolution), and the cwd. Exposes async
+ * (`resolveElizaPackageRoot`) and sync (`resolveElizaPackageRootSync`) variants;
+ * both return null when no matching root is found.
+ */
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";

--- a/packages/app-core/src/utils/globals.ts
+++ b/packages/app-core/src/utils/globals.ts
@@ -1,3 +1,11 @@
+/**
+ * Process-global CLI flags and the gated verbose logger for the app-core CLI.
+ * Holds the one-shot `verbose` and non-interactive `yes` flags (set once from
+ * parsed command options), and `logVerbose`, which mirrors a message to the
+ * structured logger and — only when `--verbose` is on — echoes it to stdout in
+ * muted styling. `shouldLogVerbose` OR-combines the flag with the `LOG_LEVEL`
+ * threshold, so verbose output also follows an elevated log level.
+ */
 import { logger } from "@elizaos/core";
 import { theme } from "@elizaos/shared";
 

--- a/packages/app/src/__tests__/embed-csp.test.ts
+++ b/packages/app/src/__tests__/embed-csp.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for the Cloudflare Pages `functions/_middleware` embed CSP policy.
+ * Asserts `embedFrameAncestors` and the `/embed` `onRequest` handler emit
+ * per-platform `frame-ancestors` (telegram/discord only, stripping
+ * X-Frame-Options), deny unknown/missing platforms with `'none'`, and leave
+ * non-embed SPA paths and their inherited framing headers untouched. Requests
+ * run through the real handler with a stubbed SPA `next()`; no network.
+ */
 import { describe, expect, it } from "vitest";
 import {
   type EmbedPlatform,

--- a/packages/app/src/android-update-checker.test.ts
+++ b/packages/app/src/android-update-checker.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for `AndroidUpdateChecker.check()` — the Android sideload OTA
+ * flow. Covers platform/build-variant gating, versionCode comparison
+ * (update available vs. not), network- and HTTP-error tolerance, the 24h
+ * check-throttle backed by localStorage, and the per-channel manifest URL.
+ * Capacitor App/Device/Browser bridges and `fetch` are mocked; `localStorage`
+ * and `import.meta.env` are stubbed per test.
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock @capacitor/app, @capacitor/browser, @capacitor/device before importing the module under test.

--- a/packages/app/src/android-update-checker.ts
+++ b/packages/app/src/android-update-checker.ts
@@ -1,3 +1,12 @@
+/**
+ * Android sideload OTA update checker. Active only on Android sideload builds:
+ * `check()` fetches the GitHub release update manifest for the requested
+ * channel (stable/beta), compares its `versionCode` against the installed
+ * build, and reports whether an update is available — throttled to once per 24h
+ * via `localStorage`. `promptIfUpdateAvailable()` confirms with the user and
+ * opens the APK download page through the Capacitor Browser. Best-effort: any
+ * network/parse failure degrades to no-update this cycle and never blocks boot.
+ */
 import { App } from "@capacitor/app";
 import { Browser } from "@capacitor/browser";
 import { Device } from "@capacitor/device";

--- a/packages/app/src/app-config.ts
+++ b/packages/app/src/app-config.ts
@@ -1,3 +1,11 @@
+/**
+ * App-identity re-exports for the shell. Surfaces the package-root
+ * `app.config.ts` as `APP_CONFIG` and derives the values the rest of
+ * `packages/app` reads: the branding base (`APP_BRANDING_BASE`), log prefix,
+ * namespace, and desktop URL scheme. Namespace and URL scheme fall back to the
+ * CLI name when unset. This is the white-label seam — swap `app.config.ts` to
+ * rebrand.
+ */
 import { resolveAppBranding } from "@elizaos/app-core";
 import appConfig from "../app.config";
 

--- a/packages/app/src/brand-env.ts
+++ b/packages/app/src/brand-env.ts
@@ -1,3 +1,11 @@
+/**
+ * Brand env-var alias table. `buildBrandEnvAliases(prefix)` maps a white-label
+ * distribution's `<PREFIX>_*` environment variables (API/auth, cloud-service
+ * toggles, ports) onto their canonical `ELIZA_*` names, so a rebranded app can
+ * be configured under its own prefix while the runtime still reads `ELIZA_*`.
+ * `APP_ENV_ALIASES` is the concrete table resolved for this app's configured
+ * prefix (`APP_ENV_PREFIX`).
+ */
 import { APP_CONFIG } from "./app-config";
 import { normalizeEnvPrefix } from "./env-prefix.js";
 

--- a/packages/app/src/character-catalog.ts
+++ b/packages/app/src/character-catalog.ts
@@ -1,3 +1,8 @@
+/**
+ * Default character catalog for the app shell. `APP_CHARACTER_CATALOG` is the
+ * built-in preset list produced by `buildElizaCharacterCatalog()` from
+ * `@elizaos/shared`, typed as the UI's `CharacterCatalogData`.
+ */
 import { buildElizaCharacterCatalog } from "@elizaos/shared";
 import type { CharacterCatalogData } from "@elizaos/ui/config";
 

--- a/packages/app/src/deep-link-handler.test.ts
+++ b/packages/app/src/deep-link-handler.test.ts
@@ -1,5 +1,14 @@
 // @vitest-environment jsdom
 
+/**
+ * Unit tests for the app-shell deep-link dispatcher (`createDeepLinkHandler`)
+ * and its `isTrustedAppLink` host guard. Verifies custom-scheme and trusted
+ * `https://` universal links route top-level surfaces (wallet, connectors,
+ * apps/deploy) onto the navigation-intent bus rather than the hash, that
+ * notifications/keyboard-dictation fire their injected side effects, and that
+ * untrusted or unconfigured hosts are ignored. Runs under jsdom with `window`,
+ * `location.hash`, and event listeners; dispatch seams are `vi.fn()` spies.
+ */
 import { NAVIGATE_VIEW_EVENT } from "@elizaos/ui/events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {

--- a/packages/app/src/deep-link-handler.ts
+++ b/packages/app/src/deep-link-handler.ts
@@ -1,8 +1,14 @@
-// === Phase 5D: extracted from main.tsx ===
-// App-shell deep-link dispatcher. Recognizes the white-label `<scheme>://`
-// links emitted by the iOS/Android intents, the desktop share target, and
-// first-run redirects. Pure routing logic — share-target persistence and
-// CONNECT event dispatch are injected so the dispatcher stays test-friendly.
+/**
+ * App-shell deep-link dispatcher. Recognizes the white-label `<scheme>://`
+ * links — and trusted `https://` universal/App links — delivered by the
+ * iOS/Android intents, the desktop share target, and first-run redirects, then
+ * routes them: top-level surfaces (settings, wallet, browser, connectors,
+ * apps/deploy) onto the `eliza:navigate:view` bus; assistant-launch,
+ * messaging, and contacts paths onto hash routes; plus dedicated
+ * connect/share/notifications/keyboard-dictation handlers. Pure routing logic —
+ * navigation, share-target persistence, and CONNECT event dispatch are injected
+ * so the dispatcher stays test-friendly.
+ */
 
 import {
   CONNECT_EVENT,

--- a/packages/app/src/deep-link-routing.test.ts
+++ b/packages/app/src/deep-link-routing.test.ts
@@ -1,3 +1,13 @@
+/**
+ * Unit and property tests for the deep-link routing table
+ * (`buildAssistantLaunchHashRoute` / `resolveDeepLinkNavigationIntent`): asserts
+ * chat-launch paths fold into `#chat?…` with the trusted `assistant-entry`
+ * source and a stable launch id, top-level-surface paths resolve to the right
+ * tab/subview navigation intent, and unknown paths stay non-routable. The pure
+ * functions are called directly; fast-check fuzzes arbitrary query strings and
+ * unknown paths to prove no unsafe route (`javascript:`, CR/LF injection) or
+ * accidental chat fall-through ever escapes.
+ */
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import {

--- a/packages/app/src/deep-link-routing.ts
+++ b/packages/app/src/deep-link-routing.ts
@@ -1,3 +1,19 @@
+/**
+ * Deep-link routing table for the app shell: maps custom-URL-scheme
+ * (`eliza://…`) and universal-link paths onto the two in-app navigation
+ * primitives.
+ *
+ * `resolveDeepLinkNavigationIntent()` handles top-level surfaces (Settings,
+ * Wallet/Inventory, Browser, Cloud Apps, Settings → Connectors), returning a
+ * `DeepLinkNavigationIntent` the caller dispatches on the `eliza:navigate:view`
+ * event bus. `buildAssistantLaunchHashRoute()` handles chat-launch entries
+ * (ask / chat / voice / smart-reply / LifeOps briefs and tasks, plus Android
+ * feature-open aliases), folding them into a single `#chat?…` hash route that
+ * carries the trusted `assistant-entry` source and a stable launch id the
+ * always-mounted ContinuousChatOverlay claims. Both return `null` for
+ * unrecognized paths, so an unknown deep link is non-routable rather than
+ * silently opening chat.
+ */
 const ASSISTANT_ENTRY_SOURCE = "assistant-entry";
 const ASSISTANT_LAUNCH_TEXT_KEYS = ["text", "q", "query", "body"] as const;
 

--- a/packages/app/src/desktop-hotkey.test.ts
+++ b/packages/app/src/desktop-hotkey.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for `decideChatOverlayToggle`, the desktop global-hotkey decision
+ * that maps the chat overlay's {focused, visible} state to a `show`/`hide`
+ * action: dismiss only when focused AND visible, otherwise summon (including
+ * when the overlay is visible but backgrounded behind another app). Pure
+ * function, called directly.
+ */
 import { describe, expect, it } from "vitest";
 import { decideChatOverlayToggle } from "./desktop-hotkey";
 

--- a/packages/app/src/embed-bootstrap.test.ts
+++ b/packages/app/src/embed-bootstrap.test.ts
@@ -1,3 +1,14 @@
+/**
+ * Tests for the `/embed` bootstrap handshake (`isEmbedPath` + `runEmbedHandshake`)
+ * that authenticates Telegram Mini App / Discord Activity embeds: it detects the
+ * platform (explicit `?platform=` or auto-detected from injected Telegram
+ * initData or a Discord `?code=` redirect), POSTs the signed launch payload to
+ * `<base>/api/embed/auth`, and installs the returned token on the client. The
+ * client, fetch, and window are injected fakes; the suite drives the real
+ * handshake and asserts it fails closed (no token installed) on unknown
+ * platform, missing payload/OAuth state, non-2xx responses, token-less bodies,
+ * network errors, and timeouts.
+ */
 import { describe, expect, it, vi } from "vitest";
 import {
   type EmbedClient,

--- a/packages/app/src/env-prefix.js
+++ b/packages/app/src/env-prefix.js
@@ -1,3 +1,11 @@
+/**
+ * Normalizes an app's configured env-var prefix into a canonical uppercase
+ * identifier: collapses each run of non-alphanumeric characters to a single `_`,
+ * strips leading/trailing underscores, and uppercases the result; throws when
+ * the value reduces to an empty identifier. Authored as plain JS (with an
+ * `env-prefix.d.ts` sidecar) so the same rule can be shared by the Vite/build
+ * config, the build script, and the runtime brand-env code.
+ */
 export function normalizeEnvPrefix(value) {
   const normalized = value
     .trim()

--- a/packages/app/src/ios-attachment-smoke.ts
+++ b/packages/app/src/ios-attachment-smoke.ts
@@ -1,3 +1,16 @@
+/**
+ * On-device iOS attachment round-trip smoke, run inside the shipped app (not a
+ * unit test) when the CI/QA harness stages a request in localStorage/Preferences
+ * (`eliza:ios-attachment-smoke:request`). `runIosAttachmentSmokeIfRequested()`
+ * waits for any pending onboarding smoke, uploads a 1×1 PNG to
+ * `/api/device-e2e/upload-image`, asserts the returned content-addressed
+ * `/api/media/<sha256>.png` URL and the re-fetched served bytes match the source
+ * sha256, writes those bytes through the Capacitor Filesystem CACHE directory
+ * and reads them back (sha256 re-verified), then opens the native Share sheet
+ * with the file URI. Every phase and the final ok/failed verdict are persisted
+ * to Preferences (`…:result`) for the simulator harness to poll; runs at most
+ * once per app launch.
+ */
 import { Filesystem } from "@capacitor/filesystem";
 import { Share } from "@capacitor/share";
 

--- a/packages/app/src/ios-runtime.test.ts
+++ b/packages/app/src/ios-runtime.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for `resolveIosRuntimeConfig`, the iOS runtime-config resolver:
+ * asserts the env precedence (iOS-specific → mobile fallback → Android as a
+ * last resort), that a trailing-slash apiBase is normalized and the
+ * device-bridge WebSocket URL is derived from it, and that the App Store-safe
+ * full-Bun runtime is flagged available. Pure function, called directly.
+ */
 import { describe, expect, it } from "vitest";
 import { resolveIosRuntimeConfig } from "./ios-runtime";
 

--- a/packages/app/src/ios-runtime.ts
+++ b/packages/app/src/ios-runtime.ts
@@ -1,3 +1,10 @@
+/**
+ * App-local re-export barrel for the iOS runtime configuration helpers, which
+ * actually live in `@elizaos/ui` (`platform/ios-runtime`). Surfaces the
+ * `IosRuntimeConfig` / `IosRuntimeMode` types plus `resolveIosRuntimeConfig`,
+ * `apiBaseToDeviceBridgeUrl`, `resolveCloudApiBase`, and
+ * `DEFAULT_ELIZA_CLOUD_BASE` under a stable app-side import path.
+ */
 export type {
   IosRuntimeConfig,
   IosRuntimeMode,

--- a/packages/app/src/keyboard-dictation.test.ts
+++ b/packages/app/src/keyboard-dictation.test.ts
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 
-// App-side keyboard app-handoff dictation session (#12185): App-Group state
-// ordering, transcript publication, explicit error states, cancel semantics,
-// and the missing-bridge (non-iOS) path. Bridge + capture are injected fakes;
-// the state machine and DOM overlay under test are real.
+/**
+ * App-side keyboard app-handoff dictation session (#12185): covers App-Group
+ * state ordering, transcript publication, explicit error states, cancel
+ * semantics, and the missing-bridge (non-iOS) path. Bridge + capture are
+ * injected fakes; the state machine and DOM overlay under test are real.
+ */
 
 import type {
   VoiceCaptureFactoryOptions,

--- a/packages/app/src/main.network-fallback.test.ts
+++ b/packages/app/src/main.network-fallback.test.ts
@@ -1,11 +1,17 @@
+/**
+ * Verifies the window `online`/`offline` connectivity fallback in
+ * `createMobileLifecycle().initializeNetworkListener` — the path that drives
+ * NETWORK_STATUS_CHANGE_EVENT when the Capacitor Network plugin is absent from
+ * the Android WebView bridge (mocked to throw here), including transition
+ * de-duplication. jsdom harness.
+ */
 import { NETWORK_STATUS_CHANGE_EVENT } from "@elizaos/ui/events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createMobileLifecycle } from "./mobile-lifecycle";
 
 // The live Android/Capacitor entrypoint (main.tsx `getMobileLifecycle()`)
 // delegates its network listener to this helper's `initializeNetworkListener`,
-// so the #10472 window `online`/`offline` fallback runs in production. Before
-// that wiring the fallback lived only in this helper and had zero importers.
+// so the #10472 window `online`/`offline` fallback runs in production.
 //
 // Simulate the exact on-device failure that motivated the fallback: the
 // Capacitor `Network` plugin is absent from the Android WebView bridge, so

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1,3 +1,27 @@
+/**
+ * Renderer boot entry and composition root for the cross-platform Eliza app
+ * shell (web browser, Electrobun desktop, and Capacitor iOS/Android). Runs
+ * before React mounts: starts cold-start telemetry, registers host-external
+ * view importers, and resolves cloud-only branding from the injected API base
+ * / desktop runtime mode.
+ *
+ * `main()` drives the boot pipeline — embed-iframe session handshake, app-window
+ * and model-tester route shortcuts, managed cloud launch connection, the
+ * headless iOS full-Bun backend smoke gate, popout and detached/overlay window
+ * shells, then the per-platform bridge stack (storage + Capacitor bridges, iOS
+ * local-agent fetch/native-request bridges, Android native agent fetch bridge,
+ * screen-capture / OCR / voice harnesses) — before mounting the React tree
+ * (`@elizaos/ui` App, optionally wrapped by the web-only CloudRouterShell) and
+ * running `initializePlatform()` concurrently after paint.
+ *
+ * Also owns deep-link handling (custom `<scheme>://` + `eliza.app` universal
+ * links → hash routes, navigate-view events, or first-run remote connect), the
+ * trusted-apiBase / native-WebSocket URL policy (tightened for iOS store + cloud
+ * builds; a bearer token is never accepted from an OS deep link), the mobile
+ * device bridge + agent tunnel + background runner, and the desktop tray /
+ * global-shortcut / chat-overlay wiring. Modules not needed for first paint are
+ * deferred onto the idle path. Exports the resolved platform flags.
+ */
 import { ErrorBoundary } from "@elizaos/ui/components/ui/error-boundary";
 import "@elizaos/ui/styles";
 // Native-only (ios/android/desktop): register the Eliza Cloud Applications

--- a/packages/app/src/mobile-bridges.ts
+++ b/packages/app/src/mobile-bridges.ts
@@ -1,10 +1,14 @@
-// === Phase 5D: extracted from main.tsx ===
-// Mobile (iOS/Android) device bridge + agent tunnel + background runner
-// orchestration. The device bridge tunnels llama.cpp + native plugin calls
-// from the WebView to the on-device agent; the agent tunnel exposes the
-// local agent over a relay for tunnel-to-mobile pairings; the background
-// runner keeps the host informed of apiBase + auth token so it can serve
-// requests when the WebView is backgrounded.
+/**
+ * Mobile (iOS/Android) device bridge + agent tunnel + background runner
+ * orchestration as a standalone factory (`createMobileBridges`). The device
+ * bridge tunnels llama.cpp + native plugin calls from the WebView to the
+ * on-device agent; the agent tunnel exposes the local agent over a relay for
+ * tunnel-to-mobile pairings; the background runner keeps the native host
+ * informed of apiBase + auth token so it can serve requests while the WebView
+ * is backgrounded. Runtime-mode changes re-wire the active transport; AOSP
+ * Eliza-derived Android builds skip the redundant device bridge. No-op off
+ * native platforms.
+ */
 
 import { BackgroundRunner } from "@capacitor/background-runner";
 import type { PluginListenerHandle } from "@capacitor/core";

--- a/packages/app/src/mobile-lifecycle.keyboard-guard.test.ts
+++ b/packages/app/src/mobile-lifecycle.keyboard-guard.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Regression test (#12030 item 4): an iOS Keyboard-bridge throw inside
+ * `createMobileLifecycle().initializeKeyboard()` must be swallowed + logged and
+ * still resolve, so a pod/plugin skew cannot strand the awaited lifecycle
+ * bootstrap. jsdom harness; `@capacitor/keyboard` is mocked to throw on
+ * setResizeMode.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createMobileLifecycle } from "./mobile-lifecycle";
 

--- a/packages/app/src/mobile-lifecycle.ts
+++ b/packages/app/src/mobile-lifecycle.ts
@@ -1,9 +1,13 @@
-// === Phase 5D: extracted from main.tsx ===
-// Idempotent Capacitor lifecycle wiring for iOS/Android: status bar overlay
-// + dark style, keyboard accessory/resize, app foreground/background events,
-// back-button navigation, deep-link bootstrap (cold + warm), and the network
-// connectivity bridge that lets the WebSocket reconnect scheduler stop
-// burning backoff during airplane mode.
+/**
+ * Idempotent Capacitor lifecycle wiring for iOS/Android, built by
+ * `createMobileLifecycle` and driven from the app-shell boot: status-bar
+ * overlay + dark style, keyboard accessory/resize, app foreground/background
+ * events (with a `visibilitychange` fallback), hardware back-button navigation,
+ * deep-link bootstrap (cold + warm launch URLs), and the network connectivity
+ * bridge that lets the WebSocket reconnect scheduler stop burning backoff during
+ * airplane mode. Each Capacitor call is guarded so a missing or throwing plugin
+ * degrades to a log instead of stranding the rest of the wiring.
+ */
 
 import { App as CapacitorApp } from "@capacitor/app";
 import { Keyboard, KeyboardResize } from "@capacitor/keyboard";

--- a/packages/app/src/model-tester-entry.tsx
+++ b/packages/app/src/model-tester-entry.tsx
@@ -1,3 +1,13 @@
+/**
+ * Standalone Model Tester page entry, served from `model-tester.html`.
+ * Imperatively builds its own DOM — no React —
+ * rendering one probe card per model capability (text small/large, embedding,
+ * TTS, transcription, VAD, image description, image generation). Reads
+ * `/api/model-tester/status` for availability and POSTs each probe to
+ * `/api/model-tester/run`, rendering audio/image results inline. All
+ * provider-supplied output is HTML-escaped before it enters innerHTML (XSS
+ * guard mirrored from the app-model-tester routes).
+ */
 type TestStatus = {
   id: string;
   label: string;

--- a/packages/app/src/native/keyboard-dictation-bridge.ts
+++ b/packages/app/src/native/keyboard-dictation-bridge.ts
@@ -1,8 +1,10 @@
-// Thin JS wrapper over the native iOS `ElizaKeyboard` Capacitor plugin
-// (packages/app-core/platforms/ios/App/App/ElizaKeyboardBridge.swift). The
-// app-side dictation session publishes its state through these methods into
-// the shared App Group, where the ElizaKeyboard extension polls it and inserts
-// the transcript. Returns null off iOS — the handoff only exists there.
+/**
+ * Thin JS wrapper over the native iOS `ElizaKeyboard` Capacitor plugin
+ * (packages/app-core/platforms/ios/App/App/ElizaKeyboardBridge.swift). The
+ * app-side dictation session publishes its state through these methods into the
+ * shared App Group, where the ElizaKeyboard extension polls it and inserts the
+ * transcript. Returns null off iOS — the handoff only exists there.
+ */
 
 import { Capacitor } from "@capacitor/core";
 

--- a/packages/app/src/native/voice-capture.ts
+++ b/packages/app/src/native/voice-capture.ts
@@ -1,8 +1,10 @@
-// Thin JS wrapper over the native Android `VoiceCapture` Capacitor plugin
-// (packages/app-core/platforms/android/.../VoiceCapturePlugin.java). It
-// starts/stops `ElizaVoiceCaptureService` — the microphone foreground
-// service that keeps continuous-chat capture alive when the WebView is
-// backgrounded. No-ops on non-Android platforms.
+/**
+ * Thin JS wrapper over the native Android `VoiceCapture` Capacitor plugin
+ * (packages/app-core/platforms/android/.../VoiceCapturePlugin.java). It
+ * starts/stops `ElizaVoiceCaptureService` — the microphone foreground service
+ * that keeps continuous-chat capture alive when the WebView is backgrounded.
+ * No-ops on non-Android platforms.
+ */
 
 import { Capacitor } from "@capacitor/core";
 

--- a/packages/app/src/plugin-registrations.test.ts
+++ b/packages/app/src/plugin-registrations.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Pins `discoverSideEffectAppModules` against the real plugin/package tree:
+ * every plugin that self-declares `elizaos.appRegister` must be discovered in a
+ * stable order, resolve a real entry file, and be a `workspace:*` dependency of
+ * this app — and the first-render `/register` module must still be imported by
+ * main.tsx. Reads the live filesystem (no mocks).
+ */
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/packages/app/src/plugin-registrations.ts
+++ b/packages/app/src/plugin-registrations.ts
@@ -1,3 +1,9 @@
+/**
+ * Declares the side-effect app-module loader list the renderer runs at boot. The
+ * `SideEffectAppModuleLoader` type below pairs a stable key with a lazy
+ * `import()`; the exported array is a build-time seam populated by vite (see its
+ * own doc for the plugin-discovery mechanism).
+ */
 export type SideEffectAppModuleLoader = {
   key: string;
   load: () => Promise<unknown>;

--- a/packages/app/src/services/android-update-checker.ts
+++ b/packages/app/src/services/android-update-checker.ts
@@ -1,6 +1,12 @@
-// Checks for APK updates on Android sideload builds only.
-// Not used in Play Store builds (Play Store handles updates natively).
-// Detected via VITE_ANDROID_BUILD_VARIANT=sideload env var.
+/**
+ * Android OTA update checker for sideload builds. Polls a GitHub-hosted update
+ * manifest (stable or beta channel) at most once per day, compares its
+ * versionCode against the installed app's build, and — when newer — confirms
+ * with the user and opens the APK download page in the system browser. A no-op
+ * on Play Store builds (the Play Store handles updates natively); the sideload
+ * variant is detected via the `VITE_ANDROID_BUILD_VARIANT=sideload` build flag
+ * plus an Android platform check.
+ */
 
 import { App } from "@capacitor/app";
 import { Browser } from "@capacitor/browser";

--- a/packages/app/src/shims/cloud-shell-stub.tsx
+++ b/packages/app/src/shims/cloud-shell-stub.tsx
@@ -1,3 +1,8 @@
+/**
+ * Stub module that stands in for the real cloud router shell in builds that
+ * exclude the cloud/web dashboard surface. See the component doc below for the
+ * passthrough contract.
+ */
 import type { ReactNode } from "react";
 
 /**

--- a/packages/app/src/shims/cookie.ts
+++ b/packages/app/src/shims/cookie.ts
@@ -1,3 +1,14 @@
+/**
+ * Browser shim for the `cookie` package: a dependency-free implementation of
+ * HTTP cookie parsing and serialization for the app bundle. `parse` splits a
+ * `Cookie` header into a name→value map (first key wins, optional decode);
+ * `serialize` builds a `Set-Cookie` string from a name/value plus attribute
+ * options; `parseSetCookie` reads a single `Set-Cookie` line back into a
+ * structured record. Re-exported under the several names cookie's consumers
+ * expect (parseCookie / stringifyCookie / stringifySetCookie) plus a default
+ * aggregate, so it can be aliased in place of the real package in the browser
+ * build.
+ */
 type CookieOptions = {
   domain?: string;
   encode?: (value: string) => string;

--- a/packages/app/src/shims/cron-parser.ts
+++ b/packages/app/src/shims/cron-parser.ts
@@ -1,3 +1,12 @@
+/**
+ * Browser shim for the `cron-parser` package, mirroring the
+ * `CronExpressionParser.parse(expr).next().toDate()` surface the app consumes.
+ * `parse` validates a 5-field expression (rejecting malformed fields or
+ * out-of-range values), but the returned iterator is intentionally minimal: each
+ * `next()` advances the cursor by one minute from `currentDate` rather than
+ * resolving the true next matching instant — enough to satisfy validation and
+ * the API shape in the bundle without the full scheduler engine.
+ */
 type ParseOptions = {
   currentDate?: Date | string | number;
 };

--- a/packages/app/src/shims/debug.ts
+++ b/packages/app/src/shims/debug.ts
@@ -1,3 +1,12 @@
+/**
+ * Browser shim for the `debug` package: namespaced debug loggers gated by a
+ * namespace filter. `createDebug(namespace)` returns a logger that emits to
+ * `console.debug` only when its namespace is enabled; enablement is driven by
+ * `enable`/`disable` and persisted in `localStorage["debug"]`, matched against
+ * comma/space-separated namespaces with `*` wildcard and trailing-`*` prefix
+ * support. Exposes the same statics (enable/disable/enabled/coerce) and the
+ * default/named exports the real module provides.
+ */
 type DebugLogger = ((...args: unknown[]) => void) & {
   namespace: string;
   enabled: boolean;

--- a/packages/app/src/shims/decimal-js-light.ts
+++ b/packages/app/src/shims/decimal-js-light.ts
@@ -1,3 +1,11 @@
+/**
+ * Browser shim for the `decimal.js-light` package: a minimal `Decimal` class
+ * exposing the arithmetic and comparison surface (abs, add, sub, mul, div, mod,
+ * pow, log, lt, lte, isint) plus number/string coercion. Backed by a native JS
+ * `number` rather than true arbitrary-precision math, so it trades exactness for
+ * a tiny bundle — adequate for the app's display-side calculations, not for
+ * high-precision financial arithmetic.
+ */
 type DecimalInput = Decimal | number | string;
 
 export default class Decimal {

--- a/packages/app/src/shims/es-toolkit-compat-get.ts
+++ b/packages/app/src/shims/es-toolkit-compat-get.ts
@@ -1,1 +1,5 @@
+/**
+ * Re-exports `get` from the es-toolkit compat shim as both the named and default
+ * export, matching the import shapes callers use for lodash-style `get`.
+ */
 export { get, get as default } from "./es-toolkit-compat";

--- a/packages/app/src/shims/es-toolkit-compat-isPlainObject.ts
+++ b/packages/app/src/shims/es-toolkit-compat-isPlainObject.ts
@@ -1,1 +1,6 @@
+/**
+ * Re-exports `isPlainObject` from the es-toolkit compat shim as both the named
+ * and default export, matching the import shapes callers use for the
+ * lodash-style `isPlainObject`.
+ */
 export { isPlainObject, isPlainObject as default } from "./es-toolkit-compat";

--- a/packages/app/src/shims/es-toolkit-compat-last.ts
+++ b/packages/app/src/shims/es-toolkit-compat-last.ts
@@ -1,1 +1,8 @@
+/**
+ * Browser-bundle entry point for `es-toolkit/compat/last`, aliased from that
+ * subpath import by the app's Vite config. Re-exports `last` (named + default)
+ * from the local lodash-compatible reimplementation so the real es-toolkit
+ * package never enters the bundle. `last` returns the final element of an
+ * array-like value, or `undefined` when it is empty/nullish.
+ */
 export { last, last as default } from "./es-toolkit-compat";

--- a/packages/app/src/shims/es-toolkit-compat-maxBy.ts
+++ b/packages/app/src/shims/es-toolkit-compat-maxBy.ts
@@ -1,1 +1,8 @@
+/**
+ * Browser-bundle entry point for `es-toolkit/compat/maxBy`, aliased from that
+ * subpath import by the app's Vite config. Re-exports `maxBy` (named + default)
+ * from the local lodash-compatible reimplementation so the real es-toolkit
+ * package never enters the bundle. `maxBy` returns the collection element whose
+ * numeric iteratee value is greatest (NaN values skipped).
+ */
 export { maxBy, maxBy as default } from "./es-toolkit-compat";

--- a/packages/app/src/shims/es-toolkit-compat-minBy.ts
+++ b/packages/app/src/shims/es-toolkit-compat-minBy.ts
@@ -1,1 +1,8 @@
+/**
+ * Browser-bundle entry point for `es-toolkit/compat/minBy`, aliased from that
+ * subpath import by the app's Vite config. Re-exports `minBy` (named + default)
+ * from the local lodash-compatible reimplementation so the real es-toolkit
+ * package never enters the bundle. `minBy` returns the collection element whose
+ * numeric iteratee value is smallest (NaN values skipped).
+ */
 export { minBy, minBy as default } from "./es-toolkit-compat";

--- a/packages/app/src/shims/es-toolkit-compat-omit.ts
+++ b/packages/app/src/shims/es-toolkit-compat-omit.ts
@@ -1,1 +1,8 @@
+/**
+ * Browser-bundle entry point for `es-toolkit/compat/omit`, aliased from that
+ * subpath import by the app's Vite config. Re-exports `omit` (named + default)
+ * from the local lodash-compatible reimplementation so the real es-toolkit
+ * package never enters the bundle. `omit` returns a shallow copy of an object
+ * with the listed top-level keys removed.
+ */
 export { omit, omit as default } from "./es-toolkit-compat";

--- a/packages/app/src/shims/es-toolkit-compat-range.ts
+++ b/packages/app/src/shims/es-toolkit-compat-range.ts
@@ -1,1 +1,8 @@
+/**
+ * Browser-bundle entry point for `es-toolkit/compat/range`, aliased from that
+ * subpath import by the app's Vite config. Re-exports `range` (named + default)
+ * from the local lodash-compatible reimplementation so the real es-toolkit
+ * package never enters the bundle. `range` builds an array of numbers across a
+ * start/end/step interval, inferring direction when step is omitted.
+ */
 export { range, range as default } from "./es-toolkit-compat";

--- a/packages/app/src/shims/es-toolkit-compat-sortBy.ts
+++ b/packages/app/src/shims/es-toolkit-compat-sortBy.ts
@@ -1,1 +1,8 @@
+/**
+ * Browser-bundle entry point for `es-toolkit/compat/sortBy`, aliased from that
+ * subpath import by the app's Vite config. Re-exports `sortBy` (named +
+ * default) from the local lodash-compatible reimplementation so the real
+ * es-toolkit package never enters the bundle. `sortBy` returns a stable
+ * ascending sort of a collection keyed by one or more iteratees.
+ */
 export { sortBy, sortBy as default } from "./es-toolkit-compat";

--- a/packages/app/src/shims/es-toolkit-compat-sumBy.ts
+++ b/packages/app/src/shims/es-toolkit-compat-sumBy.ts
@@ -1,1 +1,8 @@
+/**
+ * Browser-bundle entry point for `es-toolkit/compat/sumBy`, aliased from that
+ * subpath import by the app's Vite config. Re-exports `sumBy` (named + default)
+ * from the local lodash-compatible reimplementation so the real es-toolkit
+ * package never enters the bundle. `sumBy` totals the numeric iteratee value of
+ * each collection element (NaN values counted as zero).
+ */
 export { sumBy, sumBy as default } from "./es-toolkit-compat";

--- a/packages/app/src/shims/es-toolkit-compat-throttle.ts
+++ b/packages/app/src/shims/es-toolkit-compat-throttle.ts
@@ -1,1 +1,8 @@
+/**
+ * Browser-bundle entry point for `es-toolkit/compat/throttle`, aliased from
+ * that subpath import by the app's Vite config. Re-exports `throttle` (named +
+ * default) from the local lodash-compatible reimplementation so the real
+ * es-toolkit package never enters the bundle. `throttle` rate-limits a function
+ * to at most one invocation per wait window, exposing `cancel` and `flush`.
+ */
 export { throttle, throttle as default } from "./es-toolkit-compat";

--- a/packages/app/src/shims/es-toolkit-compat-uniqBy.ts
+++ b/packages/app/src/shims/es-toolkit-compat-uniqBy.ts
@@ -1,1 +1,8 @@
+/**
+ * Browser-bundle entry point for `es-toolkit/compat/uniqBy`, aliased from that
+ * subpath import by the app's Vite config. Re-exports `uniqBy` (named +
+ * default) from the local lodash-compatible reimplementation so the real
+ * es-toolkit package never enters the bundle. `uniqBy` dedupes a collection by
+ * iteratee key, keeping the first occurrence of each key.
+ */
 export { uniqBy, uniqBy as default } from "./es-toolkit-compat";

--- a/packages/app/src/shims/es-toolkit-compat.ts
+++ b/packages/app/src/shims/es-toolkit-compat.ts
@@ -1,3 +1,12 @@
+/**
+ * Browser-bundle shim aliased in place of the lodash/es-toolkit helper set the
+ * dashboard's dependencies reach for, exposing only the subset actually used
+ * (get, isPlainObject, uniqBy, sortBy, throttle, last, maxBy/minBy, range,
+ * omit, sumBy) so no full utility library ships in the renderer. Path access
+ * and merges guard against prototype-pollution keys (__proto__, constructor,
+ * prototype). Iteratees may be a function, a property path, or a matcher
+ * object, mirroring the lodash calling convention callers expect.
+ */
 type PathSegment = string | number | symbol;
 type Iteratee<T> =
   | ((item: T) => unknown)

--- a/packages/app/src/shims/eventemitter3.ts
+++ b/packages/app/src/shims/eventemitter3.ts
@@ -1,3 +1,12 @@
+/**
+ * Browser-bundle shim aliased in place of the `eventemitter3` package, backing
+ * the classic Node EventEmitter surface (on/once/emit/off/removeListener/
+ * removeAllListeners plus the eventNames/listeners/listenerCount introspection
+ * helpers) with a single Map of event name to listener entries. Supports the
+ * optional per-listener `context` binding and once-semantics that eventemitter3
+ * consumers rely on, so dependencies keep working without pulling the real
+ * dependency into the renderer.
+ */
 type EventName = string | symbol;
 type Listener = (...args: unknown[]) => void;
 

--- a/packages/app/src/shims/extend.ts
+++ b/packages/app/src/shims/extend.ts
@@ -1,3 +1,10 @@
+/**
+ * Browser-bundle shim aliased in place of the `extend` npm module, replicating
+ * its jQuery-style deep/shallow merge: an optional leading boolean selects deep
+ * mode, then later sources are folded onto the target left-to-right. Deep mode
+ * recurses into plain objects and arrays; shallow mode assigns by reference.
+ * Prototype-pollution keys (__proto__, constructor, prototype) are skipped.
+ */
 type AnyRecord = Record<PropertyKey, unknown>;
 
 function isPlainObject(value: unknown): value is AnyRecord {

--- a/packages/app/src/shims/fast-redact.ts
+++ b/packages/app/src/shims/fast-redact.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser-bundle shim aliased in place of `fast-redact` (a pino transitive dep).
+ * Log redaction is a no-op in the renderer: the factory always returns an
+ * identity redactor with an identity `restore`, satisfying the call signature
+ * without shipping the real string-path compiler or mutating any payload.
+ */
 type FastRedactOptions = {
   paths?: string[];
   serialize?: false | ((value: unknown) => string);

--- a/packages/app/src/shims/handlebars.ts
+++ b/packages/app/src/shims/handlebars.ts
@@ -1,3 +1,11 @@
+/**
+ * Browser-bundle shim aliased in place of Handlebars, exposing just `compile`
+ * for the small templating dependencies use. It resolves dotted `{{path}}` /
+ * unescaped `{{{path}}}` interpolations against the render context, treating
+ * missing/nullish values as empty strings. Block helpers, partials, and
+ * comments are intentionally unsupported (tags starting with #/`/`>`/`!` are
+ * skipped), keeping the real Handlebars engine out of the renderer.
+ */
 type TemplateContext = Record<string, unknown>;
 type TemplateDelegate = (context: TemplateContext) => string;
 

--- a/packages/app/src/shims/mammoth.ts
+++ b/packages/app/src/shims/mammoth.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser-bundle shim aliased in place of `mammoth` (DOCX-to-text). The library
+ * depends on Node-only facilities, so the renderer stub keeps the `extractRawText`
+ * signature but always rejects, forcing document extraction onto the backend
+ * instead of failing at bundle time.
+ */
 export async function extractRawText(): Promise<{ value: string }> {
   throw new Error("DOCX extraction is unavailable in the browser renderer.");
 }

--- a/packages/app/src/shims/nprogress.ts
+++ b/packages/app/src/shims/nprogress.ts
@@ -1,3 +1,11 @@
+/**
+ * Browser-bundle shim aliased in place of the `nprogress` slim progress-bar
+ * library, reimplementing its singleton API (configure/set/start/done/inc/
+ * trickle plus status introspection) against a single `#nprogress` DOM node.
+ * Progress is clamped to [0,1]; reaching 1 resets status to null and removes
+ * the element. Both the default export and the named function exports mirror
+ * nprogress so existing imports resolve unchanged.
+ */
 type NProgressSettings = {
   minimum: number;
   easing: string;

--- a/packages/app/src/shims/picocolors.ts
+++ b/packages/app/src/shims/picocolors.ts
@@ -1,3 +1,10 @@
+/**
+ * Browser-bundle shim aliased in place of `picocolors`. Terminal ANSI styling
+ * is meaningless in the renderer, so every color/style function is a plain
+ * String() passthrough, `isColorSupported` is false, and `createColors`
+ * returns the same object. Preserves the picocolors call surface for
+ * dependencies without emitting escape codes.
+ */
 const passthrough = (value: unknown): string => String(value);
 
 const colors = {

--- a/packages/app/src/shims/react-is.ts
+++ b/packages/app/src/shims/react-is.ts
@@ -1,3 +1,11 @@
+/**
+ * Browser-bundle shim aliased in place of `react-is`, providing the element
+ * type-guards (isElement/isFragment/isForwardRef/isMemo/isPortal) plus `typeOf`
+ * that libraries use to introspect React nodes. It matches against the
+ * `$$typeof`/`type` symbols directly (covering both the transitional and legacy
+ * element tags) so it stays correct on the installed React without depending on
+ * react-is internals.
+ */
 import { Fragment, isValidElement } from "react";
 
 const REACT_ELEMENT_TYPE = Symbol.for("react.transitional.element");

--- a/packages/app/src/shims/set-cookie-parser.ts
+++ b/packages/app/src/shims/set-cookie-parser.ts
@@ -1,3 +1,12 @@
+/**
+ * Browser shim for the `set-cookie-parser` npm package, aliased into the app
+ * bundle in place of the Node-oriented original. Parses one or more raw
+ * Set-Cookie header strings (or a `Headers` / header-record input) into
+ * structured `{ name, value, ...attributes }` cookie objects, splitting a
+ * comma-joined header back into individual cookies and tolerating malformed
+ * percent-encoding the way a browser does. Exposes `parse`, `parseString`, and
+ * `splitCookiesString` matching the upstream surface.
+ */
 type ParseOptions = {
   decodeValues?: boolean;
   map?: boolean;

--- a/packages/app/src/shims/style-to-js.ts
+++ b/packages/app/src/shims/style-to-js.ts
@@ -1,3 +1,12 @@
+/**
+ * Browser shim for the `style-to-js` npm package used by the app bundle.
+ * Converts a raw CSS inline-style string into a React-compatible style object,
+ * camelCasing property names (honoring vendor prefixes and the `reactCompat`
+ * `-ms-` special case) and leaving CSS custom properties (`--foo`) untouched.
+ * Declaration and property/value splitting are quote- and paren-aware so
+ * `url(...)`, `calc(...)`, and quoted values survive `;`/`:` inside them.
+ * Exposes the callable `StyleToJS` as both named and default export.
+ */
 const CUSTOM_PROPERTY_REGEX = /^--[a-zA-Z0-9_-]+$/;
 const HYPHEN_REGEX = /-([a-z])/g;
 const NO_HYPHEN_REGEX = /^[^-]+$/;

--- a/packages/app/src/shims/unpdf.ts
+++ b/packages/app/src/shims/unpdf.ts
@@ -1,3 +1,8 @@
+/**
+ * Browser stub for the `unpdf` package: PDF text extraction and document-proxy
+ * access are Node-only, so the app bundle aliases the module to these throwing
+ * placeholders rather than pulling the PDF engine into the renderer.
+ */
 export async function extractText(): Promise<{ text: string }> {
   throw new Error(
     "PDF text extraction is unavailable in the browser renderer.",

--- a/packages/app/src/shims/use-sync-external-store-with-selector.ts
+++ b/packages/app/src/shims/use-sync-external-store-with-selector.ts
@@ -1,3 +1,11 @@
+/**
+ * Browser shim reimplementing `use-sync-external-store/shim/with-selector`.
+ * Wraps React's native `useSyncExternalStore` with a memoized selector so a
+ * store subscription only re-renders when the selected slice actually changes,
+ * comparing successive selections with the optional `isEqual` equality fn and
+ * caching the last committed value across snapshots. Lets the app depend on the
+ * selector-aware store hook without bundling the upstream package.
+ */
 import {
   useDebugValue,
   useEffect,

--- a/packages/app/src/shims/use-sync-external-store.ts
+++ b/packages/app/src/shims/use-sync-external-store.ts
@@ -1,1 +1,6 @@
+/**
+ * Browser shim for `use-sync-external-store/shim`: React 18+ ships
+ * `useSyncExternalStore` natively, so this re-exports it directly instead of
+ * bundling the standalone polyfill.
+ */
 export { useSyncExternalStore } from "react";

--- a/packages/app/src/shims/vercel-oidc.ts
+++ b/packages/app/src/shims/vercel-oidc.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser stub for `@vercel/oidc`: Vercel OIDC token exchange is a server-side
+ * concern with no meaning in the app renderer, so this aliases the module to
+ * empty-token getters and no-op error classes, keeping the server-only OIDC
+ * code out of the browser bundle.
+ */
 export class AccessTokenMissingError extends Error {}
 export class RefreshAccessTokenFailedError extends Error {}
 

--- a/packages/app/src/url-trust-policy.ts
+++ b/packages/app/src/url-trust-policy.ts
@@ -1,8 +1,13 @@
-// === Phase 5D: extracted from main.tsx ===
-// Host trust policy for the white-label app shell. Decides whether a given
-// apiBase / deep-link target / native WebSocket URL is safe to dial. The
-// strict iOS path (store builds, cloud-runtime modes) and the dev-friendly
-// loopback path live side by side so the boot orchestration stays in main.
+/**
+ * Host trust policy for the white-label app shell: decides whether a given
+ * apiBase, deep-link target, or native WebSocket URL is safe to dial, keeping
+ * that decision out of the boot orchestration in `main.tsx`. A strict iOS path
+ * (App Store / TestFlight builds and cloud-runtime modes, which App Review
+ * forbids from reaching non-HTTPS or private-network hosts) and a dev-friendly
+ * loopback/private-LAN path live side by side. `createUrlTrustPolicy` closes
+ * over a `UrlTrustPolicyContext` and returns the per-URL guards; URL parse
+ * failures fail closed (treated as untrusted).
+ */
 
 import {
   IOS_LOCAL_AGENT_IPC_BASE,

--- a/packages/shared/src/apps/registry.test.ts
+++ b/packages/shared/src/apps/registry.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Tests the shared overlay-app and detail-extension registries: the AOSP-gating
+ * rules that decide which `androidOnly` overlay apps are visible per platform +
+ * user-agent (real elizaOS AOSP, white-label AOSP, stock Android, iOS, desktop,
+ * and the legacy string-context API) and the panel-id roundtrip for detail
+ * extensions. Runs against the real registries with synthetic UA strings,
+ * resetting the UI registry host around each case.
+ */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { RegistryAppInfo } from "../contracts/apps.js";
 import { resetUiRegistryHostForTests } from "../registry-host.js";

--- a/packages/shared/src/character-language.test.ts
+++ b/packages/shared/src/character-language.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit test for `normalizeCharacterLanguage`: covers canonical pass-through,
+ * Chinese-variant collapsing, regional/script-tag normalization (incl.
+ * `fil`→`tl`), whitespace trimming, and the `en` fallback for unknown or
+ * non-string input. Pure string logic, no mocks.
+ */
 import { describe, expect, it } from "vitest";
 import { normalizeCharacterLanguage } from "./character-language";
 

--- a/packages/shared/src/character-presets.test.ts
+++ b/packages/shared/src/character-presets.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Verifies character-preset resolution when several personas share one VRM
+ * avatar art index (the default Eliza and Chen both render asset 1). Pins that
+ * id lookup, avatarIndex lookup, the default-preset accessor, and the catalog
+ * builder each resolve to the intended persona against the real bundled
+ * CHARACTER_DEFINITIONS — no mocks.
+ */
 import { describe, expect, it } from "vitest";
 
 import { CHARACTER_DEFINITIONS } from "./character-presets.characters.js";

--- a/packages/shared/src/chat-upload-limits.test.ts
+++ b/packages/shared/src/chat-upload-limits.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises the chat-upload size and MIME contracts: maxRawBytesForBase64
+ * derives a raw-byte cap whose base64 encoding stays under each base64 ceiling
+ * (checked against Node's real base64 encoder), and the image/upload MIME
+ * allowlists stay lowercase, mutually consistent, and free of the phone-photo
+ * formats (HEIC/HEIF/SVG) the client must re-encode before upload.
+ */
 import { describe, expect, it } from "vitest";
 import {
   CHAT_IMAGE_MIME_TYPE_SET,

--- a/packages/shared/src/cli/parse-duration.test.ts
+++ b/packages/shared/src/cli/parse-duration.test.ts
@@ -1,12 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { parseDurationMs } from "./parse-duration";
-
 /**
  * Duration string parser used by CLI/config knobs. Unit suffixes must convert
  * to the right millisecond count, the default unit applies only when no suffix
  * is given, and malformed/negative input must throw rather than silently
  * yielding a bogus timeout.
  */
+import { describe, expect, it } from "vitest";
+import { parseDurationMs } from "./parse-duration";
 
 describe("parseDurationMs", () => {
   it("converts each unit suffix to milliseconds", () => {

--- a/packages/shared/src/config/__tests__/app-manifest.test.ts
+++ b/packages/shared/src/config/__tests__/app-manifest.test.ts
@@ -1,5 +1,9 @@
-// Unit tests for app-level manifest helpers (elizaos.app block in
-// the host app's package.json).
+/**
+ * Unit tests for the app-level manifest helpers (readAppManifest,
+ * filterCandidatesByAppManifest, applyAppManifestDefaults) that read the
+ * `elizaos.app` block from a host app's package.json. Runs against real
+ * package.json files written to a temp dir — no fs mocks.
+ */
 
 import fs from "node:fs/promises";
 import os from "node:os";

--- a/packages/shared/src/config/__tests__/cloud-only.test.ts
+++ b/packages/shared/src/config/__tests__/cloud-only.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises shouldUseCloudOnlyBranding, the predicate that decides when a
+ * surface is locked to Eliza Cloud branding. Covers production web with no
+ * injected host backend, injected loopback backends, native shells and their
+ * runtime modes (cloud / cloud-hybrid / elizacloud alias), and the desktop
+ * runtime-mode override that forces cloud-only even in dev.
+ */
 import { describe, expect, it } from "vitest";
 import { shouldUseCloudOnlyBranding } from "../cloud-only.js";
 

--- a/packages/shared/src/config/__tests__/distribution-profile.test.ts
+++ b/packages/shared/src/config/__tests__/distribution-profile.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Exercises the distribution-profile resolver driven by
+ * ELIZA_DISTRIBUTION_PROFILE: resolveDistributionProfile defaults to
+ * "unrestricted" on unset/blank input, accepts known profiles
+ * case-insensitively, and throws on unknown values rather than silently
+ * defaulting; plus the isDistributionProfile guard and the canonical
+ * DISTRIBUTION_PROFILES list.
+ */
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/shared/src/config/__tests__/plugin-manifest.test.ts
+++ b/packages/shared/src/config/__tests__/plugin-manifest.test.ts
@@ -1,9 +1,11 @@
-// Unit tests for the plugin manifest auto-enable engine.
-//
-// These tests use a temp directory with fake plugin packages — each one has a
-// package.json declaring elizaos.plugin.autoEnableModule and a small check
-// module that exports shouldEnable / shouldForce. The engine reads them
-// without booting the actual plugin runtime.
+/**
+ * Unit tests for the plugin-manifest auto-enable engine (pluginShortId,
+ * evaluatePluginManifest, evaluatePluginManifests, applyPluginManifestVerdicts).
+ * Each test writes a fake plugin package to a temp dir — a package.json
+ * declaring `elizaos.plugin.autoEnableModule` plus a small check module that
+ * exports shouldEnable / shouldForce — and the engine loads them for real,
+ * without booting the plugin runtime.
+ */
 
 import fs from "node:fs/promises";
 import os from "node:os";

--- a/packages/shared/src/config/__tests__/runtime-mode.test.ts
+++ b/packages/shared/src/config/__tests__/runtime-mode.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises the runtime-execution-mode helpers: normalizing raw mode strings
+ * (cloud / local-safe / local-yolo, trimming and casing), the
+ * cloud/local/safe/yolo predicates, deriving a default mode from a deployment
+ * target, and reading the effective mode from config (explicit executionMode
+ * wins, else the deployment target, else local-safe).
+ */
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/shared/src/config/app-manifest.ts
+++ b/packages/shared/src/config/app-manifest.ts
@@ -1,41 +1,20 @@
-// App-level plugin manifest.
-//
-// Each host app (eliza, eliza, custom downstream apps) declares which
-// plugins it considers candidates and how they default in its own
-// `package.json` under `elizaos.app`:
-//
-//   {
-//     "elizaos": {
-//       "app": {
-//         "candidates": [
-//           "@elizaos/plugin-anthropic",
-//           "@elizaos/plugin-openai",
-//           "@elizaos/plugin-wallet"
-//         ],
-//         "defaults": {
-//           "@elizaos/plugin-cua": { "enabled": false },
-//           "wallet": { "enabled": true }
-//         },
-//         "capabilities": {
-//           "browser": "required",
-//           "wallet": "optional"
-//         }
-//       }
-//     }
-//   }
-//
-// The plugin auto-enable engine reads the host app's manifest at boot:
-//   - If `candidates` is set, restrict the discovered plugin list to that
-//     allow-list (apps that haven't explicitly listed a plugin won't
-//     load it even if its own auto-enable matches).
-//   - If `defaults` is set, prepopulate `config.plugins.entries` with the
-//     declared `{ enabled }` flags BEFORE the manifest evaluator runs, so
-//     the user's own config still overrides app defaults.
-//   - `capabilities` is informational today — surfaced via the verdict so
-//     UIs can show "this app requires X" / "this app needs you to wire up Y".
-//
-// Apps that don't declare `elizaos.app` are unrestricted (every discovered
-// plugin is a candidate, no defaults applied).
+/**
+ * App-level plugin manifest helpers. A host app declares which plugins it
+ * considers candidates and how they default in its own package.json under an
+ * `elizaos.app` block (AppManifestBlock below documents the exact shape).
+ *
+ * The plugin auto-enable engine consumes that block at boot:
+ *   - `candidates` restricts the discovered plugin list to an allow-list; an
+ *     app that doesn't list a plugin won't load it even if that plugin's own
+ *     auto-enable would match.
+ *   - `defaults` prepopulates `config.plugins.entries` with `{ enabled }` flags
+ *     before the manifest evaluator runs, so a user's saved config still wins.
+ *   - `capabilities` is informational — surfaced via the verdict so UIs can
+ *     warn when a required capability isn't satisfied by any enabled plugin.
+ *
+ * An app that declares no `elizaos.app` block is unrestricted: every discovered
+ * plugin is a candidate and no defaults are applied.
+ */
 
 import { promises as fs } from "node:fs";
 import path from "node:path";

--- a/packages/shared/src/config/config-catalog.test.ts
+++ b/packages/shared/src/config/config-catalog.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the config-catalog JSON Pointer path helpers (getByPath /
+ * setByPath): RFC 6901 escape handling (~0 / ~1), array-index coercion rules,
+ * and prototype-pollution guarding on write.
+ */
 import { describe, expect, it } from "vitest";
 import { getByPath, setByPath } from "./config-catalog.js";
 

--- a/packages/shared/src/config/config.ts
+++ b/packages/shared/src/config/config.ts
@@ -1,3 +1,11 @@
+/**
+ * Backward-compatibility shims for elizaOS cloud configuration: re-exports the
+ * `ElizaConfig` type and provides the legacy "cloud.enabled" → `providers[]`
+ * migration helpers. `migrateCloudEnabledToProviders` upgrades an old config
+ * that set `cloud.enabled` into the modern representation (an "elizacloud"
+ * entry in `providers`); `isCloudActiveFromProviders` reports whether that
+ * entry is present.
+ */
 // CYCLE BREAK: re-exporting from @elizaos/agent here created an
 // agent ↔ shared cycle that broke node ESM resolution at the bench
 // server boot. Consumers should import these directly from

--- a/packages/shared/src/config/env-vars.ts
+++ b/packages/shared/src/config/env-vars.ts
@@ -1,3 +1,6 @@
-// Kept as an empty module so older deep imports fail closed without creating
-// a shared -> agent runtime cycle.
+/**
+ * Intentionally-empty compatibility module. Kept so older deep imports of
+ * `@elizaos/shared/config/env-vars` fail closed (resolve to nothing) instead of
+ * reintroducing a shared → agent runtime cycle. Do not add exports here.
+ */
 export {};

--- a/packages/shared/src/config/plugin-auto-enable-engine.test.ts
+++ b/packages/shared/src/config/plugin-auto-enable-engine.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit test asserting CONNECTOR_PLUGINS is sourced from the generated
+ * first-party channel-plugin-map (e.g. wechat → @elizaos/plugin-wechat) rather
+ * than a stale hand-maintained value.
+ */
 import { describe, expect, it } from "vitest";
 
 import { CONNECTOR_PLUGINS } from "./plugin-auto-enable-engine";

--- a/packages/shared/src/config/plugin-auto-enable-engine.ts
+++ b/packages/shared/src/config/plugin-auto-enable-engine.ts
@@ -1,14 +1,16 @@
-// Connector / streaming reverse-lookup maps consumed by host-app code.
-//
-// The connector/streaming detection helpers (isConnectorConfigured,
-// isStreamingDestinationConfigured, isWechatConfigured) live in
-// @elizaos/core now — re-exported below for back-compat with callers that
-// still import from @elizaos/shared. The reverse-lookup maps stay here
-// since they're app-side data (consumed by plugins-routes.ts to
-// translate package names ↔ connector keys for UI config sync).
-//
-// Plugin auto-enable is in ./plugin-manifest.ts. Each plugin declares its
-// own enable conditions via package.json's `elizaos.plugin.autoEnableModule`.
+/**
+ * Connector / streaming package-name ↔ connector-key reverse-lookup maps
+ * consumed by host-app code (plugins-routes.ts uses them to sync UI config).
+ * `CONNECTOR_PLUGINS` is sourced from the generated first-party
+ * channel-plugin-map.json; `STREAMING_PLUGINS` is the streaming equivalent.
+ *
+ * The configured-detection helpers (isConnectorConfigured,
+ * isStreamingDestinationConfigured, isWechatConfigured) now live in
+ * @elizaos/core and are re-exported here for back-compat with callers that
+ * still import them from @elizaos/shared. Per-plugin auto-enable itself lives in
+ * ./plugin-manifest.ts (each plugin declares conditions via package.json's
+ * `elizaos.plugin.autoEnableModule`).
+ */
 import channelPluginMap from "@elizaos/registry/first-party/channel-plugin-map.json" with {
   type: "json",
 };

--- a/packages/shared/src/config/plugin-auto-enable.ts
+++ b/packages/shared/src/config/plugin-auto-enable.ts
@@ -1,9 +1,11 @@
-// Backward-compat surface for callers that imported from the old wrapper path.
-//
-// Auto-enable now lives in ./plugin-manifest.ts (per-plugin manifest pattern).
-// What's left here are the connector / streaming reverse-lookup maps and
-// the configured-detection helpers that several other packages still consume —
-// they're not auto-enable, just shared data.
+/**
+ * Backward-compat re-export surface for callers that imported from the old
+ * plugin-auto-enable wrapper path. Auto-enable itself now lives in
+ * ./plugin-manifest.ts (per-plugin manifest pattern); what this module
+ * forwards are the connector / streaming reverse-lookup maps and the
+ * configured-detection helpers several other packages still consume — shared
+ * data, not auto-enable logic.
+ */
 export {
   CONNECTOR_PLUGINS,
   isConnectorConfigured,

--- a/packages/shared/src/config/plugin-manifest.ts
+++ b/packages/shared/src/config/plugin-manifest.ts
@@ -1,37 +1,36 @@
-// Plugin manifest evaluation engine.
-//
-// Each plugin declares its auto-enable conditions in its package.json under
-// `elizaos.plugin`, optionally pointing at a small JS module that implements
-// the actual `shouldEnable(ctx)` check:
-//
-//   {
-//     "elizaos": {
-//       "plugin": {
-//         "autoEnableModule": "./dist/auto-enable.js",
-//         "force": false,
-//         "capabilities": ["text-large", "tool-use"]
-//       }
-//     }
-//   }
-//
-// The check module exports:
-//
-//   export function shouldEnable(ctx: PluginAutoEnableContext): boolean | Promise<boolean>;
-//   export function shouldForce?(ctx: PluginAutoEnableContext): boolean;  // optional override
-//
-// The engine here:
-//   1. Walks a list of candidate plugin packages.
-//   2. Reads each package.json for the elizaos.plugin block.
-//   3. Dynamic-imports the autoEnableModule (cheap if it stays small — convention,
-//      not enforced; consumers can lint via knip or import-graph if drift becomes a problem).
-//   4. Evaluates shouldEnable + shouldForce against the runtime context.
-//   5. Returns a verdict per plugin.
-//
-// This replaces the centralized maps in plugin-auto-enable-engine.ts. Both
-// engines coexist during the migration: the new one runs first, the old one
-// fills gaps for plugins that haven't migrated yet. When all plugins ship a
-// manifest, the central maps and the old engine can be deleted.
-
+/**
+ * Plugin manifest evaluation engine — decides which plugins auto-enable by
+ * reading each plugin's own manifest instead of a centralized map.
+ *
+ * Each plugin declares its auto-enable conditions in its package.json under
+ * `elizaos.plugin`, optionally pointing at a small JS module that implements
+ * the actual `shouldEnable(ctx)` check:
+ *
+ *   {
+ *     "elizaos": {
+ *       "plugin": {
+ *         "autoEnableModule": "./dist/auto-enable.js",
+ *         "force": false,
+ *         "capabilities": ["text-large", "tool-use"]
+ *       }
+ *     }
+ *   }
+ *
+ * The check module exports:
+ *
+ *   export function shouldEnable(ctx: PluginAutoEnableContext): boolean | Promise<boolean>;
+ *   export function shouldForce?(ctx: PluginAutoEnableContext): boolean;  // optional override
+ *
+ * The engine walks candidate plugin packages, reads each package.json for the
+ * elizaos.plugin block, dynamic-imports the autoEnableModule, evaluates
+ * shouldEnable + shouldForce against the runtime context, and returns a verdict
+ * per plugin (never throwing — failures surface in the verdict's `error`).
+ *
+ * This replaces the centralized maps in plugin-auto-enable-engine.ts. Both
+ * engines coexist during the migration: the new one runs first, the old one
+ * fills gaps for plugins that haven't migrated yet. When all plugins ship a
+ * manifest, the central maps and the old engine can be deleted.
+ */
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";

--- a/packages/shared/src/connectors.test.ts
+++ b/packages/shared/src/connectors.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the connector-source alias registry
+ * (normalizeConnectorSource plus the register/expand/metadata helpers): alias
+ * normalization, filter expansion, and passive-source metadata lookup against
+ * runtime-registered declarations.
+ */
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/shared/src/contracts/agent-routes.test.ts
+++ b/packages/shared/src/contracts/agent-routes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the /api/agents/* request Zod schemas (autonomy, export, and
+ * registry register / update-uri / sync): boolean and password validation,
+ * string trimming, whitespace absorption, and strict extra-field rejection.
+ */
 import { describe, expect, it } from "vitest";
 import {
   AGENT_TRANSFER_MIN_PASSWORD_LENGTH,

--- a/packages/shared/src/contracts/app-permissions-routes.test.ts
+++ b/packages/shared/src/contracts/app-permissions-routes.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Contract tests for the /api/apps permissions route Zod schemas: the granted-permissions view,
+ * its list response, and the PUT request that grants/revokes namespaces. Exercises the real
+ * schemas from app-permissions-routes.js — strict parsing, enum and namespace whitelists, and
+ * accept/reject cases; no server or transport is involved.
+ */
 import { describe, expect, it } from "vitest";
 import {
   AppPermissionsViewSchema,

--- a/packages/shared/src/contracts/app-permissions.test.ts
+++ b/packages/shared/src/contracts/app-permissions.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Contract tests for the app-permission manifest parser: parseAppIsolation (worker/none
+ * fallback) and parseAppPermissions, which validates the fs/net permission slices, enforces the
+ * MAX_PATTERN_LENGTH glob cap, and preserves unknown namespaces under `raw` for forward
+ * compatibility. Drives the real parser directly with accept/reject fixtures.
+ */
 import { describe, expect, it } from "vitest";
 import {
   MAX_PATTERN_LENGTH,

--- a/packages/shared/src/contracts/apps-favorites-routes.test.ts
+++ b/packages/shared/src/contracts/apps-favorites-routes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Contract tests for the app-favorites route Zod schemas: the toggle-one PUT, the replace-all
+ * POST, and the favorites list response. Verifies appName trimming, strict extra-field
+ * rejection, and element typing against the real schemas.
+ */
 import { describe, expect, it } from "vitest";
 import {
   FavoritesResponseSchema,

--- a/packages/shared/src/contracts/apps-lifecycle-routes.test.ts
+++ b/packages/shared/src/contracts/apps-lifecycle-routes.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Contract tests for the app-lifecycle route Zod schemas — launch, install, stop, relaunch,
+ * create, overlay-presence, refresh, install-progress events, and the install response's
+ * success/failure discriminated union. Exercises trimming, strict parsing, and each accept/reject
+ * branch directly against the schemas.
+ */
 import { describe, expect, it } from "vitest";
 import {
   InstallProgressEventSchema,

--- a/packages/shared/src/contracts/apps-loading-routes.test.ts
+++ b/packages/shared/src/contracts/apps-loading-routes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Contract tests for the load-apps-from-directory route Zod schemas: the request (absolute-path
+ * requirement) and the success response carrying registered items plus rejected-manifest
+ * diagnostics. Parses real fixtures for accept/reject cases.
+ */
 import { describe, expect, it } from "vitest";
 import {
   PostLoadFromDirectoryRequestSchema,

--- a/packages/shared/src/contracts/apps-runs-routes.test.ts
+++ b/packages/shared/src/contracts/apps-runs-routes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Contract tests for the app-run route Zod schemas: the run-message request (content field with
+ * a `message` alias and trimming) and the run-control action request (pause/resume). Drives the
+ * real schemas with accept/reject fixtures.
+ */
 import { describe, expect, it } from "vitest";
 import {
   PostRunControlRequestSchema,

--- a/packages/shared/src/contracts/apps.test.ts
+++ b/packages/shared/src/contracts/apps.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Contract tests for the core apps domain Zod schemas shared across the dashboard: JSON session
+ * values, viewer auth/config, session state and activity, run health facets/details, run events
+ * and summaries, and the launch/stop/verify/relaunch result shapes. Parses canonical fixtures for
+ * accept/reject cases against the real schemas.
+ */
 import { describe, expect, it } from "vitest";
 import {
   AppLaunchDiagnosticSchema,

--- a/packages/shared/src/contracts/auth-routes.test.ts
+++ b/packages/shared/src/contracts/auth-routes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Contract tests for the device-pairing auth route Zod schemas: the pair request (non-empty
+ * code) and the pair response (token). Exercises strict parsing and accept/reject cases against
+ * the real schemas.
+ */
 import { describe, expect, it } from "vitest";
 import {
   PostAuthPairRequestSchema,

--- a/packages/shared/src/contracts/character-routes.test.ts
+++ b/packages/shared/src/contracts/character-routes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Contract tests for the character-field generation route request schema: the target field enum
+ * (bio/system/style/chatExamples/postExamples), append/replace mode, and strict context parsing.
+ * Drives the real schema with accept/reject fixtures.
+ */
 import { describe, expect, it } from "vitest";
 import { PostCharacterGenerateRequestSchema } from "./character-routes.js";
 

--- a/packages/shared/src/contracts/cloud-coding-containers.test.ts
+++ b/packages/shared/src/contracts/cloud-coding-containers.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Contract tests for the cloud coding-container surface: the canonical
+ * CLOUD_CONTAINER runtime service-type slot and the schema that promotes a
+ * VFS snapshot into a cloud container. Confirms the promotion request stays
+ * strict — unrecognized keys (e.g. a legacy `legacyServiceType`) are rejected
+ * with the exact issue message. Pure in-process schema parsing, no server or
+ * mocks: it validates the same exported objects the live routes consume.
+ */
 import { describe, expect, it } from "vitest";
 import {
   CLOUD_CONTAINER_SERVICE_TYPE,

--- a/packages/shared/src/contracts/connector-routes.test.ts
+++ b/packages/shared/src/contracts/connector-routes.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Contract tests for the connector-management request schemas:
+ * PostConnectorRequestSchema (create/update a connector) and
+ * PostProviderSwitchRequestSchema (swap the model provider). Locks in name
+ * trimming, rejection of reserved/prototype-pollution keys, strict extra-field
+ * rejection, and the provider/apiKey/primaryModel trimming plus apiKey size
+ * cap. Pure in-process schema parsing — the exported schemas are exercised
+ * directly, with no HTTP server or mocks in the loop.
+ */
 import { describe, expect, it } from "vitest";
 import {
   PostConnectorRequestSchema,

--- a/packages/shared/src/contracts/conversation-routes.test.ts
+++ b/packages/shared/src/contracts/conversation-routes.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Contract tests for the conversation route request schemas: create
+ * (optional title/greeting/lang/metadata), truncate (trimmed messageId +
+ * optional inclusive flag), patch (title/generate/metadata, with `null`
+ * clearing metadata), and cleanup-empty (optional trimmed keepId). Asserts
+ * trimming, strict extra-field rejection, and nested-metadata strictness.
+ * Pure in-process schema parsing — no server or mocks.
+ */
 import { describe, expect, it } from "vitest";
 import {
   PatchConversationRequestSchema,

--- a/packages/shared/src/contracts/diagnostics-routes.test.ts
+++ b/packages/shared/src/contracts/diagnostics-routes.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Contract tests for the diagnostics log-export request schema: json/csv
+ * format selection plus optional source/level/tags/since/limit filters.
+ * Covers tags accepted as either an array or a single string, `since` as a
+ * number or ISO string, and strict rejection of unknown formats and extra
+ * fields. Pure in-process schema parsing — no server or mocks.
+ */
 import { describe, expect, it } from "vitest";
 import { PostLogExportRequestSchema } from "./diagnostics-routes.js";
 

--- a/packages/shared/src/contracts/first-run-cerebras.test.ts
+++ b/packages/shared/src/contracts/first-run-cerebras.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Contract tests pinning the Cerebras first-run provider and guarding the
+ * core/shared provider-catalog mirror against drift. Verifies Cerebras is
+ * registered as an OpenAI-compatible api-key provider (CEREBRAS_API_KEY,
+ * @elizaos/plugin-openai), that id/casing/alias normalization and the
+ * cerebras-api direct-account mapping resolve, and that the shared catalog +
+ * direct-account map deep-equal their canonical copies imported directly from
+ * `packages/core`. Pure in-process assertions over the real exported catalogs.
+ */
 import { describe, expect, it } from "vitest";
 // Core is the innermost package (`packages/shared` depends on `@elizaos/core`,
 // never the reverse), so the first-run provider catalog is duplicated in both:

--- a/packages/shared/src/contracts/first-run-routes.test.ts
+++ b/packages/shared/src/contracts/first-run-routes.test.ts
@@ -1,3 +1,13 @@
+/**
+ * Contract tests for PostFirstRunRequestSchema, the onboarding payload that
+ * seeds a new agent's character. Covers the required trimmed name, rejection
+ * of every deprecated field key with the canonical legacy message, the full
+ * character body (bio/systemPrompt/style/examples/theme/preset), both the
+ * current and legacy messageExamples shapes, strict style keys, structured
+ * sections (deployment/linked accounts/service routing/credentials/connectors/
+ * features/inventory providers), and voice-preset passthrough. Pure in-process
+ * schema parsing — no server or mocks.
+ */
 import { describe, expect, it } from "vitest";
 import {
   FIRST_RUN_DEPRECATED_FIELD_KEYS,

--- a/packages/shared/src/contracts/inbox-routes.test.ts
+++ b/packages/shared/src/contracts/inbox-routes.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Contract tests for PostInboxMessageRequestSchema, the schema for injecting
+ * an inbound message into a room. Locks in the required roomId/source/text
+ * shape, trimming and source lower-casing, required-field and empty-text
+ * rejection, treatment of blank replyToMessageId as absent, and strict
+ * extra-field rejection. Pure in-process schema parsing — no server or mocks.
+ */
 import { describe, expect, it } from "vitest";
 import { PostInboxMessageRequestSchema } from "./inbox-routes.js";
 

--- a/packages/shared/src/contracts/memory-routes.test.ts
+++ b/packages/shared/src/contracts/memory-routes.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Contract tests for the memory route request schemas: remember (create) and
+ * patch (edit). Both require a non-blank text field that is trimmed, reject
+ * whitespace-only text with the canonical message, and reject any extra field
+ * (e.g. source/embedding). Pure in-process schema parsing — no server or mocks.
+ */
 import { describe, expect, it } from "vitest";
 import {
   PatchMemoryRequestSchema,

--- a/packages/shared/src/contracts/misc-routes.test.ts
+++ b/packages/shared/src/contracts/misc-routes.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Contract tests for the assorted "misc" route request schemas: share ingest,
+ * agent-event injection, terminal command runs, and the custom-action
+ * lifecycle (create/update/generate/test). Covers trimming and defaulting
+ * (enabled/similes/parameters), the discriminated handler union
+ * (http/shell/code) with per-variant required fields, clientId/params
+ * passthrough, and strict extra-field rejection across every schema. Pure
+ * in-process schema parsing — no server or mocks.
+ */
 import { describe, expect, it } from "vitest";
 import {
   PostAgentEventRequestSchema,

--- a/packages/shared/src/contracts/page-scope.test.ts
+++ b/packages/shared/src/contracts/page-scope.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Contract tests for the `page-scope` guard: asserts `isPageScope` accepts every
+ * value in the declared `PAGE_SCOPES` set and rejects undeclared, malformed, and
+ * non-string inputs. Exercises the real guard synchronously — no mocks.
+ */
 import { describe, expect, it } from "vitest";
 
 import { isPageScope, PAGE_SCOPES } from "./page-scope.js";

--- a/packages/shared/src/contracts/permissions-routes.test.ts
+++ b/packages/shared/src/contracts/permissions-routes.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Contract tests for the native-permission route request schemas
+ * (`PutPermissionsShellRequestSchema`, `PutPermissionsStateRequestSchema`):
+ * verifies accepted shapes, boolean/enum enforcement, the permission-status map,
+ * and strict rejection of unknown fields. Parses through the real Zod schemas.
+ */
 import { describe, expect, it } from "vitest";
 import {
   PutPermissionsShellRequestSchema,

--- a/packages/shared/src/contracts/personal-assistant.test.ts
+++ b/packages/shared/src/contracts/personal-assistant.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Contract tests for the LifeOps shared connector definitions: `capabilitiesForSide`
+ * scoping (owner side stays read-only, agent side gets the full declared set) and the
+ * frozen provider / capability / degradation-axis id lists that persisted connector
+ * status records depend on. Asserts against the real exported constants.
+ */
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/shared/src/contracts/plugin-routes.test.ts
+++ b/packages/shared/src/contracts/plugin-routes.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Contract tests for the plugin-management route request schemas (install, update,
+ * uninstall, core-toggle, PUT plugin, secrets, curated skill source): covers name
+ * trimming, config/secret value typing, the release-stream enum, and strict
+ * extra-field rejection. Parses through the real Zod schemas.
+ */
 import { describe, expect, it } from "vitest";
 import {
   PostPluginCoreToggleRequestSchema,

--- a/packages/shared/src/contracts/relationships-routes.test.ts
+++ b/packages/shared/src/contracts/relationships-routes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Contract tests for `PostRelationshipLinkRequestSchema`: targetEntityId trimming,
+ * optional evidence passthrough, and strict rejection of blank/missing ids and
+ * unknown fields. Parses through the real Zod schema.
+ */
 import { describe, expect, it } from "vitest";
 import { PostRelationshipLinkRequestSchema } from "./relationships-routes.js";
 

--- a/packages/shared/src/contracts/skills-routes.test.ts
+++ b/packages/shared/src/contracts/skills-routes.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Contract tests for the skills + marketplace route request schemas (catalog
+ * install/uninstall, acknowledge, create, source PUT, marketplace install/uninstall):
+ * covers slug/name trimming, whitespace-as-absent version/description, the source
+ * enum, the at-least-one-of marketplace-install constraint, and strict extra-field
+ * rejection. Parses through the real Zod schemas.
+ */
 import { describe, expect, it } from "vitest";
 import {
   PostMarketplaceInstallRequestSchema,

--- a/packages/shared/src/contracts/subscription-routes.test.ts
+++ b/packages/shared/src/contracts/subscription-routes.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Contract tests for the LLM-subscription OAuth route schemas (Anthropic code
+ * exchange + setup token, OpenAI code exchange): covers code/token trimming, the
+ * required sk-ant-oat01 token prefix, waitForCallback handling, and strict
+ * extra-field rejection. Parses through the real Zod schemas.
+ */
 import { describe, expect, it } from "vitest";
 import {
   PostSubscriptionAnthropicExchangeRequestSchema,

--- a/packages/shared/src/contracts/tail-routes.test.ts
+++ b/packages/shared/src/contracts/tail-routes.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Contract tests for the tail bug-report and update-channel route schemas:
+ * `PostBugReportRequestSchema` required/optional fields including the nested startup
+ * diagnostics object and category enum, plus `PutUpdateChannelRequestSchema` channel
+ * enum validation. Both enforce strict extra-field rejection. Parses through the
+ * real Zod schemas.
+ */
 import { describe, expect, it } from "vitest";
 import {
   PostBugReportRequestSchema,

--- a/packages/shared/src/contracts/wallet-routes.test.ts
+++ b/packages/shared/src/contracts/wallet-routes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Contract tests for the wallet route request schemas (import, generate, set-primary):
+ * covers privateKey trimming, chain/source enums, optional-chain auto-detect on
+ * import, and strict extra-field rejection. Parses through the real Zod schemas.
+ */
 import { describe, expect, it } from "vitest";
 import {
   PostWalletGenerateRequestSchema,

--- a/packages/shared/src/contracts/wallet.test.ts
+++ b/packages/shared/src/contracts/wallet.test.ts
@@ -1,10 +1,3 @@
-import { describe, expect, it } from "vitest";
-import {
-  DEFAULT_WALLET_RPC_SELECTIONS,
-  normalizeWalletRpcProviderId,
-  normalizeWalletRpcSelections,
-} from "./wallet.ts";
-
 /**
  * Wallet RPC provider selection. Normalization resolves legacy aliases
  * (elizacloud → eliza-cloud, helius → helius-birdeye), is case/space-insensitive,
@@ -12,6 +5,12 @@ import {
  * rejected on a chain that doesn't offer it (solana). Unknown/blank values fall
  * back to the safe Eliza Cloud default rather than a broken provider id.
  */
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_WALLET_RPC_SELECTIONS,
+  normalizeWalletRpcProviderId,
+  normalizeWalletRpcSelections,
+} from "./wallet.ts";
 
 describe("normalizeWalletRpcProviderId", () => {
   it("accepts valid ids case/space-insensitively", () => {

--- a/packages/shared/src/contracts/workbench-routes.test.ts
+++ b/packages/shared/src/contracts/workbench-routes.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Zod request-schema contracts for the workbench API (todo CRUD plus the VFS
+ * project / file / snapshot / rollback endpoints). Pins the trimming, coercion
+ * (priority accepted as number, string, or null), and strict no-extra-fields
+ * behavior that every workbench route relies on. Exercises the real exported
+ * schemas directly, with no route or server harness.
+ */
 import { describe, expect, it } from "vitest";
 import {
   PostWorkbenchTodoCompleteRequestSchema,

--- a/packages/shared/src/elizacloud/base-url.test.ts
+++ b/packages/shared/src/elizacloud/base-url.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Eliza Cloud base-URL resolution. normalizeCloudSiteUrl collapses api/www host
+ * aliases to the apex origin, strips query and hash, preserves loopback origins
+ * but coerces other origins to https, and sanitizes malformed input rather than
+ * echoing it back; resolveCloudApiBaseUrl appends the canonical /api/v1 path.
+ * The ELIZAOS_CLOUD_BASE_URL env override takes precedence over the passed URL.
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import { normalizeCloudSiteUrl, resolveCloudApiBaseUrl } from "./base-url";
 

--- a/packages/shared/src/email-classification/email-classifier.test.ts
+++ b/packages/shared/src/email-classification/email-classifier.test.ts
@@ -1,3 +1,12 @@
+/**
+ * LifeOps email classifier: the deterministic rule fast-path
+ * (classifyEmailByRules — known-contact, list-unsubscribe, billing, and
+ * transactional signals), the enabled + configured-model settings resolvers,
+ * and classifyEmail's rule-first-then-LLM-fallback orchestration, plus the
+ * untrusted-content fencing helper. @elizaos/core and the runtime are stubbed
+ * (getSetting / useModel), so the LLM branch runs against a canned useModel
+ * rather than a live model.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@elizaos/core", () => ({

--- a/packages/shared/src/events/shell-navigate-view.test.ts
+++ b/packages/shared/src/events/shell-navigate-view.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Shell navigate-view event contract (from events/index): the
+ * eliza:navigate:view DOM CustomEvent factory and its name constant, payload
+ * normalization (valid fields kept, malformed optionals dropped, non-string
+ * view ids filtered out), and the websocket frame builder. Pure contract
+ * assertions, with no DOM or socket harness.
+ */
 import { describe, expect, it } from "vitest";
 import {
   createNavigateViewEvent,

--- a/packages/shared/src/i18n/keyword-matching.test.ts
+++ b/packages/shared/src/i18n/keyword-matching.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Keyword matching backs i18n action routing. Normalization (NFKC + lowercase +
+ * whitespace collapse), ASCII word-boundary matching (so "cat" doesn't match
+ * "category"), and longest-term-first selection must all hold — a loose match
+ * here fires the wrong action.
+ */
 import { describe, expect, it } from "vitest";
 import {
   collectKeywordTermMatches,
@@ -6,13 +12,6 @@ import {
   splitKeywordDoc,
   textIncludesKeywordTerm,
 } from "./keyword-matching";
-
-/**
- * Keyword matching backs i18n action routing. Normalization (NFKC + lowercase +
- * whitespace collapse), ASCII word-boundary matching (so "cat" doesn't match
- * "category"), and longest-term-first selection must all hold — a loose match
- * here fires the wrong action.
- */
 
 describe("normalizeKeywordMatchText", () => {
   it("lowercases, collapses whitespace, trims", () => {

--- a/packages/shared/src/knowledge-graph/merge.test.ts
+++ b/packages/shared/src/knowledge-graph/merge.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Identity-merge engine. Matching is case-insensitive on (platform, handle);
+ * the observe decision is create / merge (>= auto threshold) / conflict (low
+ * confidence or multiple candidates); and folding an identity must dedupe
+ * evidence and keep the higher-confidence claim — losing provenance here
+ * silently corrupts the knowledge graph.
+ */
 import { describe, expect, it } from "vitest";
 import type { Entity, EntityIdentity } from "./entity-types";
 import {
@@ -6,14 +13,6 @@ import {
   findIdentityMatches,
   foldIdentity,
 } from "./merge";
-
-/**
- * Identity-merge engine. Matching is case-insensitive on (platform, handle);
- * the observe decision is create / merge (>= auto threshold) / conflict (low
- * confidence or multiple candidates); and folding an identity must dedupe
- * evidence and keep the higher-confidence claim — losing provenance here
- * silently corrupts the knowledge graph.
- */
 
 const ident = (o: Partial<EntityIdentity>): EntityIdentity =>
   ({

--- a/packages/shared/src/lifeops-normalize/service-normalize.test.ts
+++ b/packages/shared/src/lifeops-normalize/service-normalize.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Shared LifeOps input normalizers (#8795). Phone numbers normalize to E.164,
+ * priority/integers clamp to valid ranges, and enum-like fields canonicalize or
+ * reject — these gate untrusted assistant input into the scheduling pipelines.
+ */
 import { describe, expect, it } from "vitest";
 import {
   normalizeOptionalFiniteNumber,
@@ -9,12 +14,6 @@ import {
   normalizeReminderUrgency,
   normalizeValidTimeZone,
 } from "./service-normalize.ts";
-
-/**
- * Shared LifeOps input normalizers (#8795). Phone numbers normalize to E.164,
- * priority/integers clamp to valid ranges, and enum-like fields canonicalize or
- * reject — these gate untrusted assistant input into the scheduling pipelines.
- */
 
 describe("normalizePhoneNumber", () => {
   it("normalizes US and international numbers to E.164", () => {

--- a/packages/shared/src/lifeops-normalize/time-zone.test.ts
+++ b/packages/shared/src/lifeops-normalize/time-zone.test.ts
@@ -1,10 +1,3 @@
-import { describe, expect, it } from "vitest";
-import {
-  isValidTimeZone,
-  normalizeTimeZone,
-  resolveDefaultTimeZone,
-} from "./time-zone";
-
 /**
  * IANA time-zone normalization (LifeOps normalize primitives). A scheduled
  * reminder fired in the wrong zone is a real user-facing bug, so the
@@ -13,6 +6,13 @@ import {
  * compare against `resolveDefaultTimeZone()` rather than a hardcoded string so
  * they hold on any CI machine.
  */
+import { describe, expect, it } from "vitest";
+import {
+  isValidTimeZone,
+  normalizeTimeZone,
+  resolveDefaultTimeZone,
+} from "./time-zone";
+
 describe("isValidTimeZone", () => {
   it("accepts real IANA zones and rejects nonsense", () => {
     expect(isValidTimeZone("UTC")).toBe(true);

--- a/packages/shared/src/local-inference/catalog.test.ts
+++ b/packages/shared/src/local-inference/catalog.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Asserts the Eliza-1 tier metadata baked into `catalog.ts`: the canonical tier
+ * id set (kept in three-file sync with the Python manifest + publish shell),
+ * size-cased display names, the 128k context floor, safe runtime/quant
+ * optimizations, hosted-MTP and voice/vision component paths, and the
+ * on-device-only mobile QAT/LiteRT bundle gating. Pure Vitest over the static
+ * MODEL_CATALOG; one case exercises the ELIZA_PUBLISH_STATUS_OVERRIDES env gate.
+ */
 import { describe, expect, it } from "vitest";
 import {
   ELIZA_1_HOSTED_MTP_TIER_IDS,

--- a/packages/shared/src/local-inference/device-fit.test.ts
+++ b/packages/shared/src/local-inference/device-fit.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Exercises `selectBestEliza1Fit` device-tier selection: the biggest tier that
+ * fits a given RAM budget, always at the QJL KV quant, targeting the 128k window
+ * — downscaling context near the floor and returning null (route to Cloud) when
+ * not even a minimal local window fits. Also checks monotonicity in RAM and that
+ * no sub-2B tier is ever picked. Pure Vitest over MODEL_CATALOG.
+ */
 import { describe, expect, it } from "vitest";
 import { MODEL_CATALOG } from "./catalog";
 import {

--- a/packages/shared/src/local-inference/hf-proxy.test.ts
+++ b/packages/shared/src/local-inference/hf-proxy.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers `resolveHfDownloadBase` / `resolveHfDownloadBases`, which decide where
+ * local-inference bundle `resolve` traffic goes: explicit mirror overrides, the
+ * Eliza Cloud HF proxy (when a cloud API key is set), then direct
+ * huggingface.co. The harness saves/restores the relevant env vars and resets
+ * the cloud-secrets cache around each case.
+ */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { _resetCloudSecretsForTesting } from "../elizacloud/cloud-secrets.js";
 import { resolveHfDownloadBase, resolveHfDownloadBases } from "./hf-proxy.js";

--- a/packages/shared/src/local-inference/hub-auth.test.ts
+++ b/packages/shared/src/local-inference/hub-auth.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers the HuggingFace hub-auth helpers: token resolution across the
+ * documented env aliases (in precedence order, trimmed, blank-as-unset), strict
+ * huggingface.co host recognition, and bearer-header attachment that fires only
+ * for HF hosts so a token is never leaked to mirrors. The harness saves/restores
+ * the HF_* token env vars around each case.
+ */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   hasHuggingFaceToken,

--- a/packages/shared/src/local-inference/manifest-signature.test.ts
+++ b/packages/shared/src/local-inference/manifest-signature.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers Ed25519 manifest signature verification
+ * (`verifyManifestSignature` / `verifyManifestSignatureText`): acceptance under
+ * the current key and during a two-key rotation, and rejection of wrong-key,
+ * tampered-body, empty-key-list, and malformed or wrong-length signature/key
+ * inputs. Signs bodies with real key pairs generated via Node webcrypto.
+ */
 import { webcrypto } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {

--- a/packages/shared/src/local-inference/network-policy.test.ts
+++ b/packages/shared/src/local-inference/network-policy.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Covers the network-aware model-update policy: classifyNetwork (the five
+ * canonical connection classes plus unknown), applyNetworkPolicy (auto/ask
+ * decisions per class, quiet-hours downgrade, headless explicit-only override),
+ * inQuietHours (same-day and across-midnight windows), the evaluateNetworkPolicy
+ * composition, and the shipped DEFAULT_NETWORK_POLICY_PREFERENCES. Pure Vitest
+ * with injected clocks.
+ */
 import { describe, expect, it } from "vitest";
 import {
   applyNetworkPolicy,

--- a/packages/shared/src/local-inference/routing-preferences.test.ts
+++ b/packages/shared/src/local-inference/routing-preferences.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers the local/cloud routing-policy union: that ROUTING_POLICIES exposes
+ * local-only, cloud-only, and auto with no duplicates, that
+ * DEFAULT_ROUTING_POLICY is a member, and that the isRoutingPolicy type guard
+ * accepts every member and rejects non-members. Pure Vitest over the exported
+ * constants.
+ */
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_ROUTING_POLICY,

--- a/packages/shared/src/local-inference/runtime-class.test.ts
+++ b/packages/shared/src/local-inference/runtime-class.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Covers the runtime-class helpers for the Eliza-1-only local stack:
+ * classifyCatalogModelRuntimeClass / classifyInstalledModelRuntimeClass both
+ * always return "fused-eliza1" (the generic-GGUF path was removed in #8808), and
+ * withRuntimeClass backfills that field on legacy rows while returning the same
+ * reference when it is already set. Pure Vitest over MODEL_CATALOG plus
+ * synthetic InstalledModel rows.
+ */
 import { describe, expect, it } from "vitest";
 
 import { MODEL_CATALOG } from "./catalog.js";

--- a/packages/shared/src/local-inference/throughput.test.ts
+++ b/packages/shared/src/local-inference/throughput.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers `computeGenerationThroughput` — splitting prefill vs decode tok/s from
+ * output counters and a measured TTFT, reporting null (never a fabricated zero)
+ * when a window is unmeasurable (absent/impossible TTFT, non-positive duration,
+ * nothing decoded, zero prompt tokens) — and the `isGenerationCounters` frame
+ * guard. Pure Vitest over synthetic counter frames.
+ */
 import { describe, expect, it } from "vitest";
 import {
   computeGenerationThroughput,

--- a/packages/shared/src/local-inference/voice-models.test.ts
+++ b/packages/shared/src/local-inference/voice-models.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit coverage for the voice-model version catalog (`voice-models.ts`): semver
+ * ordering, HuggingFace resolve-URL construction, and integrity bookkeeping over
+ * `VOICE_MODEL_VERSIONS` — every published version carries a valid semver, hf
+ * repo/revision, changelog, ISO publish timestamp, and pinned sha256 + byte size
+ * per GGUF asset. Pure data/URL assertions; no network or model download.
+ */
 import { describe, expect, it } from "vitest";
 import {
   compareVoiceModelSemver,

--- a/packages/shared/src/loopback-trust.test.ts
+++ b/packages/shared/src/loopback-trust.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Unit coverage for the shared local-trust gate (`loopback-trust.ts`) that both
+ * `@elizaos/app-core` and `@elizaos/agent` use to decide whether an inbound HTTP
+ * request may bypass auth. Exercises loopback peer detection, proxy-client-header
+ * spoofing rejection, Host/Origin/Referer classification, and the per-consumer env
+ * policy gates — running the shared host/origin cases under both option bundles to
+ * prove identical logic while the divergent cloud/dev-bypass gates are tested apart.
+ * Requests are synthesized via a stubbed `http.IncomingMessage`.
+ */
 import http from "node:http";
 import { Socket } from "node:net";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";

--- a/packages/shared/src/meetings.test.ts
+++ b/packages/shared/src/meetings.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for `parseMeetingUrl` (`meetings.ts`): platform detection and
+ * native-id canonicalization for Google Meet / Teams / Zoom links, plus the
+ * malformed percent-escape Teams id that must return null rather than throw a
+ * URIError (which previously crashed the Transcripts/Calendar views).
+ */
 import { describe, expect, it } from "vitest";
 import { parseMeetingUrl } from "./meetings.js";
 

--- a/packages/shared/src/process-guards.test.ts
+++ b/packages/shared/src/process-guards.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit coverage for `installProcessCrashGuards` (`process-guards.ts`) and the
+ * `shouldIgnoreUnhandledRejection` classifier: idempotent install, non-fatal
+ * handling of background unhandled rejections, credit-exhaustion downgrade to warn,
+ * and the uncaught-exception policies (default supervised restart / keep-alive /
+ * exit). Listeners are captured by stubbing `process.on` so a deliberately triggered
+ * rejection never escapes into the test runner.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { shouldIgnoreUnhandledRejection } from "./error-classification.js";

--- a/packages/shared/src/recent-messages-state.ts
+++ b/packages/shared/src/recent-messages-state.ts
@@ -1,6 +1,8 @@
-// `getRecentMessagesData` is owned by `@elizaos/core` (canonical accessor for
-// the `state.data.providers.RECENT_MESSAGES.data.recentMessages` array) and
-// re-exported here so agent/plugin consumers keep their `@elizaos/shared`
-// import path. The core symbol is exported from both the node and browser
-// barrels, so this re-export resolves in browser bundles too.
+/**
+ * Re-exports `getRecentMessagesData` — the canonical accessor for the
+ * `state.data.providers.RECENT_MESSAGES.data.recentMessages` array, owned by
+ * `@elizaos/core` — so agent/plugin consumers keep their `@elizaos/shared` import
+ * path. The core symbol ships from both the node and browser barrels, so this
+ * re-export resolves in browser bundles too.
+ */
 export { getRecentMessagesData } from "@elizaos/core";

--- a/packages/shared/src/runtime-env.expose-port.test.ts
+++ b/packages/shared/src/runtime-env.expose-port.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit coverage for `resolveApiExposePort` (`runtime-env.ts`): parses the single
+ * `ELIZA_API_EXPOSE_PORT` env key into a boolean, asserting the truthy/falsy value
+ * table (with surrounding-whitespace tolerance) and the unset default of false.
+ */
 import { describe, expect, it } from "vitest";
 import { API_EXPOSE_PORT_KEYS, resolveApiExposePort } from "./runtime-env";
 

--- a/packages/shared/src/runtime-env.test.ts
+++ b/packages/shared/src/runtime-env.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for the runtime-env host security helpers (`runtime-env.ts`):
+ * loopback/wildcard bind-host classification, URL/bracketed host stripping, and
+ * `resolveApiSecurityConfig` — proving malformed `127.*` binds are never promoted to
+ * loopback and that the origin/host allow-lists are trimmed into arrays.
+ */
 import { describe, expect, it } from "vitest";
 import {
   isLoopbackBindHost,

--- a/packages/shared/src/spoken-text.test.ts
+++ b/packages/shared/src/spoken-text.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for `sanitizeSpeechText` (`spoken-text.ts`): strips internal
+ * thinking/reasoning blocks (closed and unterminated), fenced code, and URLs (while
+ * keeping markdown link labels and inline-code words), then collapses stage
+ * directions and repeated punctuation before text is handed to TTS.
+ */
 import { describe, expect, it } from "vitest";
 
 import { sanitizeSpeechText } from "./spoken-text";

--- a/packages/shared/src/steward-session-client/steward-oauth-pkce.test.ts
+++ b/packages/shared/src/steward-session-client/steward-oauth-pkce.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for the Steward OAuth PKCE helpers (`steward-oauth-pkce.ts`):
+ * verifies the S256 code challenge derives from its verifier and that
+ * `buildStewardOAuthAuthorizeUrl` includes the PKCE query params (code_challenge +
+ * S256 method) when a challenge is supplied and omits them when it is not.
+ */
 import { describe, expect, it } from "vitest";
 import {
   buildStewardOAuthAuthorizeUrl,

--- a/packages/shared/src/terminal/palette.ts
+++ b/packages/shared/src/terminal/palette.ts
@@ -1,5 +1,10 @@
-// CLI palette tokens for CLI/UI theming.
-// Keep in sync with docs/cli/index.md (CLI palette section).
+/**
+ * Accent and status color tokens for CLI / terminal-adjacent UI theming.
+ *
+ * `CLI_PALETTE` is the single source of hex values for accent, info, success,
+ * warn, error, and muted terminal output. Keep in sync with the CLI palette
+ * section of `docs/cli/index.md`.
+ */
 export const CLI_PALETTE = {
   accent: "#FF5A2D",
   accentBright: "#FF7A3D",

--- a/packages/shared/src/test-env-config.test.ts
+++ b/packages/shared/src/test-env-config.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Covers the test-only env catalog in `test-env-config.ts`: the tracked
+ * TEST_ENV_FAMILIES/TEST_ENV_NAMES enumeration, the acme fixture credential
+ * accessors, phase2/phase3 smoke-flag normalization, and voice-E2E default
+ * merging. Runs over in-memory TestEnvRecord objects, never real process.env.
+ */
 import { describe, expect, it } from "vitest";
 import {
   listTestEnvFamilyNames,

--- a/packages/shared/src/transcripts.test.ts
+++ b/packages/shared/src/transcripts.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers the pure transcript helpers in `transcripts.ts`: speaker counting,
+ * duration, plain-text/preview rendering, word flattening, the active-word
+ * binary search, list-row summarization (including meeting-metadata
+ * projection), and ASR word-timing validation. All assertions run over
+ * in-memory transcript fixtures.
+ */
 import { describe, expect, it } from "vitest";
 import {
   activeWordIndex,

--- a/packages/shared/src/type-guards.test.ts
+++ b/packages/shared/src/type-guards.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Runtime type guards used to validate untrusted/unknown payloads at boundaries
+ * before they're treated as records. They must distinguish plain objects from
+ * arrays and null, and asNonEmptyString must reject whitespace-only strings so
+ * blank values don't pass as present.
+ */
 import { describe, expect, it } from "vitest";
 import {
   asNonEmptyString,
@@ -6,13 +12,6 @@ import {
   asRecordOrUndefined,
   isPlainObject,
 } from "./type-guards.ts";
-
-/**
- * Runtime type guards used to validate untrusted/unknown payloads at boundaries
- * before they're treated as records. They must distinguish plain objects from
- * arrays and null, and asNonEmptyString must reject whitespace-only strings so
- * blank values don't pass as present.
- */
 
 describe("isPlainObject", () => {
   it("accepts plain objects, rejects arrays / null / primitives", () => {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,3 +1,15 @@
+/**
+ * Runtime-agnostic type contracts shared across the bridge, dashboard, and
+ * host surfaces — a type-only module (no runtime values). Collects: Electrobun
+ * RPC install-detection types, per-connector status snapshots (WhatsApp,
+ * Telegram, Discord, Slack, Google Chat, Signal, iMessage, Nostr, MS Teams)
+ * and the generic channel snapshot shape, the plugin config-UI hint schema
+ * (`ConfigUiHint` with dynamic-value / visibility / validation / action-binding
+ * expressions and `PluginUiTheme` tokens), config snapshots, presence entries,
+ * gateway agent/session/file rows, cron job definitions, and skill status
+ * reports. Consumed by both Node and browser code, so it must stay import-free.
+ */
+
 // ── Shared Electrobun RPC types ─────────────────────────────────────────────
 // Defined here so both src/bridge/ and platforms/electrobun/ can import them
 // without crossing the build boundary.

--- a/packages/shared/src/utils/assistant-text.test.ts
+++ b/packages/shared/src/utils/assistant-text.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers `extractAssistantReplyText` and `stripAssistantStageDirections`:
+ * recovering user-facing reply text from leaked response-handler JSON and
+ * argument fragments, unwrapping bare {reply}/{response} objects (primitives
+ * only, guarded against unrelated payloads), stripping stage directions, and
+ * degrading safely on null/undefined input. Pure string assertions.
+ */
 import { describe, expect, it } from "vitest";
 import {
   extractAssistantReplyText,

--- a/packages/shared/src/utils/eliza-globals.test.ts
+++ b/packages/shared/src/utils/eliza-globals.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers the Eliza API base/token accessors in `eliza-globals.ts`: get/set/clear
+ * resolve through the boot-config store rather than mutable `window.__ELIZA*__`
+ * globals (which must be ignored even when forged), values are trimmed, and a
+ * blank write clears the current value. Harness stubs `window` via vitest and
+ * resets boot config after each test.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getBootConfig, setBootConfig } from "../config/boot-config-store.js";
 import {

--- a/packages/shared/src/utils/env.test.ts
+++ b/packages/shared/src/utils/env.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Env value normalization + the boolean-disabled check. Empty/whitespace must
+ * normalize to absent, and isEnvDisabled must treat only explicit falsy tokens
+ * as "off" (default-enabled) — a loose check here would flip feature defaults.
+ */
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_APP_ROUTE_PLUGIN_MODULES,
@@ -6,12 +11,6 @@ import {
   normalizeEnvValueOrNull,
   syncElizaEnvAliases,
 } from "./env";
-
-/**
- * Env value normalization + the boolean-disabled check. Empty/whitespace must
- * normalize to absent, and isEnvDisabled must treat only explicit falsy tokens
- * as "off" (default-enabled) — a loose check here would flip feature defaults.
- */
 
 describe("normalizeEnvValue / normalizeEnvValueOrNull", () => {
   it("trims, maps empty/non-string to absent", () => {

--- a/packages/shared/src/utils/exec-safety.test.ts
+++ b/packages/shared/src/utils/exec-safety.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers `isSafeExecutableValue`: it accepts bare executable names and explicit
+ * paths while rejecting shell-metacharacter, flag-leading, and quoted values so
+ * an executable string can never smuggle in a shell command. Uses fast-check to
+ * fuzz that any injected metacharacter is always unsafe and that accepted bare
+ * names match the documented `[A-Za-z0-9._+-]` (non-dash-leading) character set.
+ */
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import { isSafeExecutableValue } from "./exec-safety";

--- a/packages/shared/src/utils/format.test.ts
+++ b/packages/shared/src/utils/format.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Shared display formatters (uptime / byte size / USD). These render values in
+ * dashboard views; the unit thresholds, precision, and fallback handling are
+ * pinned so the displayed figures stay correct and stable.
+ */
 import { describe, expect, it } from "vitest";
 import {
   formatByteSize,
@@ -5,12 +10,6 @@ import {
   formatUptime,
   formatUsd,
 } from "./format";
-
-/**
- * Shared display formatters (uptime / byte size / USD). These render values in
- * dashboard views; the unit thresholds, precision, and fallback handling are
- * pinned so the displayed figures stay correct and stable.
- */
 
 describe("formatUptime", () => {
   it("renders compact units and handles invalid input", () => {

--- a/packages/shared/src/utils/host-capabilities.test.ts
+++ b/packages/shared/src/utils/host-capabilities.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Coverage for `detectHostCapabilities`, which classifies the runtime host
+ * (Cloudflare Worker, Capacitor foreground-only, Capacitor + BackgroundRunner,
+ * browser tab, full Node) from environment signals into a capability profile.
+ * Each case pins the exact flag set (fs/inbound/longRunning/childProcess/net/
+ * mobile/browser + label) a host kind exposes, which gates scheduling and
+ * feature availability across surfaces.
+ */
 import { describe, expect, it } from "vitest";
 import { detectHostCapabilities } from "./host-capabilities";
 

--- a/packages/shared/src/utils/labels.test.ts
+++ b/packages/shared/src/utils/labels.test.ts
@@ -1,6 +1,3 @@
-import { describe, expect, it } from "vitest";
-import { autoLabel } from "./labels";
-
 /**
  * `autoLabel` derives the human-readable label shown next to a plugin config
  * field from its env-key + plugin id — strip the plugin prefix, title-case the
@@ -8,6 +5,9 @@ import { autoLabel } from "./labels";
  * regression in prefix stripping or the acronym set would silently mangle every
  * generated settings label. Pure.
  */
+import { describe, expect, it } from "vitest";
+import { autoLabel } from "./labels";
+
 describe("autoLabel", () => {
   it("strips the underscored plugin prefix and preserves acronyms", () => {
     expect(autoLabel("PLUGIN_API_KEY", "plugin")).toBe("API Key");

--- a/packages/shared/src/utils/name-tokens.test.ts
+++ b/packages/shared/src/utils/name-tokens.test.ts
@@ -1,16 +1,15 @@
-import { describe, expect, it } from "vitest";
-import {
-  replaceIndexedNameTokens,
-  replaceNameTokens,
-  tokenizeNameOccurrences,
-} from "./name-tokens";
-
 /**
  * Character-name token helpers. `replaceNameTokens` expands `{{name}}` /
  * `{{agentName}}` into the literal name; `tokenizeNameOccurrences` reverses
  * it during rename so every text field keeps propagating. Both run on
  * user-entered names, so `$`-sequences and non-ASCII names must round-trip.
  */
+import { describe, expect, it } from "vitest";
+import {
+  replaceIndexedNameTokens,
+  replaceNameTokens,
+  tokenizeNameOccurrences,
+} from "./name-tokens";
 
 describe("replaceNameTokens", () => {
   it("replaces both token spellings with the name", () => {

--- a/packages/shared/src/utils/name-tokens.ts
+++ b/packages/shared/src/utils/name-tokens.ts
@@ -1,9 +1,15 @@
-// `replaceNameTokens` (`{{name}}` / `{{agentName}}`) and
-// `replaceIndexedNameTokens` (`{{name1}}` / `{{user1}}` example slots) are owned
-// by `@elizaos/core` — both whitespace-tolerant and `$`-sequence safe — and
-// re-exported here so existing `@elizaos/shared` / `@elizaos/ui` consumers keep
-// their import path. The core symbols are exported from both the node and
-// browser barrels, so this re-export resolves in browser bundles too.
+/**
+ * Character-name token helpers for the character / config surfaces.
+ *
+ * `replaceNameTokens` (`{{name}}` / `{{agentName}}`) and
+ * `replaceIndexedNameTokens` (`{{name1}}` / `{{user1}}` example slots) are owned
+ * by `@elizaos/core` — both whitespace-tolerant and `$`-sequence safe — and
+ * re-exported here so existing `@elizaos/shared` / `@elizaos/ui` consumers keep
+ * their import path (core exports them from both the node and browser barrels,
+ * so this re-export resolves in browser bundles too). `tokenizeNameOccurrences`
+ * below is the inverse: it rewrites literal name occurrences back into
+ * `{{name}}` tokens so a later rename keeps propagating.
+ */
 export { replaceIndexedNameTokens, replaceNameTokens } from "@elizaos/core";
 
 /**

--- a/packages/shared/src/utils/number-parsing.test.ts
+++ b/packages/shared/src/utils/number-parsing.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Coverage for the strict numeric parsers (`parsePositiveInteger`,
+ * `parsePositiveFloat`, `parseClampedFloat`, `parseClampedInteger`) used to
+ * sanitize config / env / form inputs. Pins the fallback behaviour and the
+ * rejection of partial, malformed, non-finite, and unsafe-integer strings
+ * rather than silently coercing them.
+ */
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/shared/src/utils/permission-deep-links.test.ts
+++ b/packages/shared/src/utils/permission-deep-links.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Coverage for the macOS permission deep-link helpers. `getMacPermissionDeepLink`
+ * maps each permission id to its System Settings privacy-pane URL (falling back
+ * to the root Privacy pane for unmapped ids), and `openPermissionSettings`
+ * invokes the opener with that URL on darwin while warning and skipping on
+ * win32/linux. The opener and console are injected, so no real System Settings
+ * launch occurs.
+ */
 import { describe, expect, it, vi } from "vitest";
 import {
   getMacPermissionDeepLink,

--- a/packages/shared/src/utils/streaming-text.test.ts
+++ b/packages/shared/src/utils/streaming-text.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Coverage for the streaming-text reconciler (`mergeStreamingText`,
+ * `computeStreamingDelta`, `resolveStreamingUpdate`) that folds incoming token
+ * snapshots into the already-displayed chat text. Combines named regressions
+ * (repeated single-char deltas, suffix/prefix overlap dedupe, cumulative
+ * snapshots, in-place revisions) with fast-check property fuzzing of the
+ * append / replace / unchanged classification.
+ */
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import {

--- a/packages/shared/src/view-hero-art.test.ts
+++ b/packages/shared/src/view-hero-art.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the deterministic view hero-art generator (view-hero-art.ts):
+ * SVG rendering, stable per-key hue derivation that avoids the blue band,
+ * keyword/tag/icon-name to glyph mapping, XML escaping, and per-slug element-id
+ * namespacing. Pure functions, no mocks.
+ */
 import { describe, expect, it } from "vitest";
 import {
   generateViewHeroSvgFor,

--- a/packages/shared/src/views/host-external-contract.test.ts
+++ b/packages/shared/src/views/host-external-contract.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Guards that the host-external URL query-param name contract stays in sync with
+ * the dependency-free agent runtime transform that mirrors the names as string
+ * literals. Reads the real `.mjs` off disk — the transform itself is not mocked.
+ */
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";

--- a/packages/shared/src/views/view-interact-protocol.test.ts
+++ b/packages/shared/src/views/view-interact-protocol.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Pins the frozen view-interact capability contract shared by the agent views
+ * route and the UI DynamicViewLoader: the standard capability values, the
+ * agent-surface capability ids handled by the shell registry, and that the two
+ * id sets stay disjoint.
+ */
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/shared/src/voice-eot.test.ts
+++ b/packages/shared/src/voice-eot.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests the canonical end-of-turn scoring heuristic (scoreEndOfTurnHeuristic):
+ * the ordered rule table (trail-off, sentence-final punctuation, question tags,
+ * conjunctions/prepositions, short utterances, neutral fallback), rule ordering,
+ * and that scores stay finite within [0,1] on adversarial input. Pure function.
+ */
 import { describe, expect, it } from "vitest";
 import { scoreEndOfTurnHeuristic as score } from "./voice-eot";
 

--- a/packages/shared/src/voice-wer.test.ts
+++ b/packages/shared/src/voice-wer.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests the word-error-rate metric (normalizeWerText, wordErrorRate): text
+ * normalization and Levenshtein-based scoring, plus that the voice self-test
+ * quality gate (0.34) genuinely discriminates good from degraded ASR rather than
+ * rubber-stamping a verbatim mock transcript. Pure functions, no mocks.
+ */
 import { describe, expect, it } from "vitest";
 
 import { normalizeWerText, wordErrorRate } from "./voice-wer";

--- a/packages/shared/src/voice/first-sentence-snip.test.ts
+++ b/packages/shared/src/voice/first-sentence-snip.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests first-sentence extraction for TTS opener caching (firstSentenceSnip,
+ * wordCount, normalizeForKey, and the version pin): sentence-boundary detection
+ * across abbreviations, decimals, quotes, and CJK; the word-count ceiling; and
+ * deterministic cache-key normalization. Pure functions, no mocks.
+ */
 import { describe, expect, it } from "vitest";
 import {
   FIRST_SENTENCE_MAX_WORDS,

--- a/packages/shared/src/voice/owner-inference.test.ts
+++ b/packages/shared/src/voice/owner-inference.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests speaker owner-candidate inference (resolveOwnerCandidate) over a stream
+ * of confidence-scored observations: dominance/share/margin thresholds, tie
+ * ambiguity, the confidence floor and unrecognized-speaker filtering, and the
+ * undecided path. Pure function.
+ */
 import { describe, expect, it } from "vitest";
 import { resolveOwnerCandidate } from "./owner-inference";
 

--- a/packages/shared/src/voice/respond-gate.test.ts
+++ b/packages/shared/src/voice/respond-gate.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests the voice respond-gate (shouldRespondToVoiceTurn, buildVoiceTurnSignal):
+ * disfluency/echo suppression, bystander vs enrolled-speaker gating, wake-word
+ * rescue, and acoustic self-voice rejection of the agent's own mis-transcribed
+ * output. Pure functions, no mocks.
+ */
 import { describe, expect, it } from "vitest";
 import {
   AGENT_SELF_VOICE_THRESHOLD,

--- a/packages/shared/src/voice/voice-cancellation-token.test.ts
+++ b/packages/shared/src/voice/voice-cancellation-token.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests the voice cancellation token and its per-room registry: abort
+ * idempotency (first reason wins), synchronous onAbort fan-out including late
+ * registration and listener-error isolation, AbortSignal linking, and registry
+ * arm/abort/abortAll/clear semantics. Uses vitest spies; no external I/O.
+ */
 import { describe, expect, it, vi } from "vitest";
 import {
   createAbortedVoiceCancellationToken,

--- a/packages/shared/src/wallet/market-overview.test.ts
+++ b/packages/shared/src/wallet/market-overview.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Unit tests for the wallet market-overview shared domain helpers in
+ * ./market-overview.ts: the stablecoin id/symbol filter sets, the
+ * CoinGecko/Polymarket provider metadata, the CoinGecko markets request URL,
+ * raw-row mapping/parsing (dropping incomplete records), mover ranking, and
+ * per-coin price snapshots. Assertions run entirely in-memory over fixture
+ * rows with no network or mocks, pinning the domain data so the Cloud
+ * market-preview service and the iOS agent kernel fallback cannot drift.
+ */
 import { describe, expect, it } from "vitest";
 import {
   buildCoinGeckoMarketsUrl,


### PR DESCRIPTION
## What

Batch **B03** of the repo-wide comment cleanup (#12233, parent #12181) — `packages/app-core`
(HTTP API + dashboard host), `packages/app` (web+desktop dashboard, Vite+React), and
`packages/shared` (cross-package utilities + brand assets). Every in-scope headerless file gets
an accurate prose header; churn comments removed/rewritten.

**Comments only — zero functional diff.** Machine-proven by `node scripts/assert-comment-only-diff.mjs`:
every changed file's TypeScript code-token stream is byte-identical to base. No JSX text,
className, or string literal is touched — this is **not a UI change**, so no visual review applies.

## Scope (358 files)

app-core route/host modules, app React components/hooks/utils, and shared utilities.

## Notes

- 2 files intentionally left as-is (already carry accurate headers).
- Heads-up surfaced while headering (out of scope for this comment-only pass): `packages/app/src/mobile-bridges.ts`
  exports `createMobileBridges` with **zero importers** — main.tsx keeps its own inline copies of the
  same device-bridge/agent-tunnel/background-runner functions, so this file is a parallel extraction that
  was never wired in. Worth a follow-up to either adopt it in main.tsx or delete it as dead code.

## Verification
```
node scripts/assert-comment-only-diff.mjs
# OK — 358 source file(s) changed; every code token identical to base. Comments only.
```
Closes #12233.