### PR TITLE
fix(#12462): teach the docs checker .mdx (stop false-flagging Mintlify pages)

### DIFF
--- a/packages/scripts/launch-qa/check-docs.mjs
+++ b/packages/scripts/launch-qa/check-docs.mjs
@@ -240,11 +240,16 @@ function normalizeLinkTarget(rawTarget) {
 function candidatePaths(basePath) {
   const candidates = [basePath];
   if (!path.extname(basePath)) {
-    candidates.push(`${basePath}.md`);
+    // packages/docs is a Mintlify site whose pages are `.mdx`; links omit the
+    // extension, so `.mdx` must be tried alongside `.md` or every link to an
+    // `.mdx` page (e.g. `/config-schema`, `/user/change-character`) is a false
+    // "missing file".
+    candidates.push(`${basePath}.md`, `${basePath}.mdx`);
   }
   candidates.push(
     path.join(basePath, "README.md"),
     path.join(basePath, "index.md"),
+    path.join(basePath, "index.mdx"),
   );
   return candidates;
 }


### PR DESCRIPTION
## What

Part of **#12462** (docs-site accuracy) — the mechanical checker deliverable.

`packages/docs` is a Mintlify site of `.mdx` pages, and internal links omit the extension
(`/config-schema`, `/user/change-character`). `check-docs.mjs` resolved extensionless link
targets against `.md` / `README.md` / `index.md` only — never `.mdx` — so **every link to an
`.mdx` page was reported as a missing file** (261 false positives at full docs scope). That made
the checker's full-scope output untrustworthy, blocking the #12462 goal of catching command/link
drift mechanically.

## Fix

Add `.mdx` + `index.mdx` to `candidatePaths`.

| scope | before | after |
|---|---|---|
| `--scope=docs` reported issues | 715 | **454** |
| existing `.mdx` pages wrongly flagged | 261 | **0** |
| `--scope=launchdocs` gate | PASS | PASS (no regression) |

Verified: `config-schema.mdx`, `user/change-character.mdx`, `agents/runtime-and-lifecycle.mdx`
and the rest of the real pages are no longer flagged.

## What remains (scope note, not this PR)

The remaining **454** are *genuine* breakage the corrected checker now surfaces honestly —
dominated by a removed `/guides/*` page family that docs still link to:

```
46 /guides/connectors    20 /guides/cloud       17 /guides/wallet
15 /guides/coding-swarms 10 /guides/beginners-user-guide  7 /guides/documents  …
```

Reconciling these (recreate vs repoint vs remove ~150 links, plus changelog.mdx's 136) is the
page-by-page content pass of #12462 and needs content decisions — deliberately **not** done here
to avoid introducing *wrong* repoints. This PR makes that follow-up tractable by giving a
trustworthy broken-link list.

## Verification
```
node --check packages/scripts/launch-qa/check-docs.mjs        # ok
node packages/scripts/launch-qa/check-docs.mjs --scope=launchdocs   # PASS
node packages/scripts/launch-qa/check-docs.mjs --scope=docs   # 715 -> 454
```
Part of #12462.