### PR TITLE
feat(ui): chat surfaces + notification mechanics — tokens, physics, a11y

### DIFF
--- a/packages/ui/src/components/chat/MessageAttachments.tsx
+++ b/packages/ui/src/components/chat/MessageAttachments.tsx
@@ -313,8 +313,8 @@ function TileButton({
 }): React.JSX.Element {
   const cls = cn(
     "inline-flex h-7 w-7 items-center justify-center rounded-full",
-    "bg-black/70 text-white/90 transition-colors",
-    "hover:bg-black/85   ",
+    "bg-scrim text-white transition-colors",
+    "hover:bg-brand-black active:scale-[0.96] motion-reduce:active:scale-100",
   );
   if (href) {
     return (
@@ -363,11 +363,11 @@ function ImageTile({
 }): React.JSX.Element {
   const label = attachmentLabel(att);
   return (
-    <div className="group relative inline-block max-w-[min(20rem,100%)] overflow-hidden rounded-xl border border-white/12">
+    <div className="group relative inline-block max-w-[min(20rem,100%)] overflow-hidden rounded-lg border border-border bg-card">
       <Button
         variant="ghost"
         onClick={onExpand}
-        className="block h-auto w-full cursor-zoom-in rounded-none bg-transparent p-0 hover:bg-transparent   "
+        className="block h-auto w-full cursor-zoom-in rounded-none bg-transparent p-0 hover:bg-transparent"
         aria-label={`Expand image ${label}`}
       >
         <img
@@ -379,7 +379,7 @@ function ImageTile({
           // The type carries no intrinsic dimensions, so a 4:3 default is used.
           // `object-contain` letterboxes the full image inside that reserved box
           // (mirrors the video branch + lightbox) so non-4:3 content isn't cropped.
-          className="block aspect-[4/3] max-h-80 w-full object-contain"
+          className="block aspect-[4/3] max-h-80 w-full object-contain transition-transform duration-200 group-hover:scale-[1.01] motion-reduce:transition-none motion-reduce:group-hover:scale-100"
         />
       </Button>
       <div className="pointer-events-none absolute right-1.5 top-1.5 flex gap-1.5 opacity-0 transition-opacity group-hover:opacity-100">
@@ -418,8 +418,8 @@ function FileTile({
       asChild
       variant="ghost"
       className={cn(
-        "h-auto max-w-[min(20rem,100%)] justify-start gap-2.5 whitespace-normal rounded-xl border border-white/12 bg-white/[0.06] px-3 py-2.5",
-        "text-white/90 transition-colors hover:bg-white/[0.12]   ",
+        "h-auto min-h-touch max-w-[min(20rem,100%)] justify-start gap-2.5 whitespace-normal rounded-lg border border-border bg-card px-3 py-2.5",
+        "text-txt transition-colors hover:bg-bg-hover hover:border-border-strong active:scale-[0.99] motion-reduce:active:scale-100",
       )}
     >
       <a
@@ -428,25 +428,25 @@ function FileTile({
         rel="noreferrer"
         download={kind === "link" ? undefined : downloadName(att, kind)}
       >
-        <Icon className="h-5 w-5 shrink-0 text-white/70" />
+        <Icon className="h-5 w-5 shrink-0 text-muted" strokeWidth={1.5} />
         <span className="min-w-0 flex-1">
-          <span className="block truncate text-[13px] font-medium">
+          <span className="block truncate text-xs-tight font-medium">
             {label}
           </span>
           {att.description?.trim() ? (
-            <span className="block truncate text-[11px] text-white/55">
+            <span className="block truncate text-2xs text-muted">
               {att.description.trim()}
             </span>
           ) : (
-            <span className="block text-[11px] uppercase tracking-wide text-white/45">
+            <span className="block text-2xs uppercase tracking-wide text-muted">
               {kind === "link" ? "link" : kind}
             </span>
           )}
         </span>
         {kind === "link" ? (
-          <LinkIcon className="h-4 w-4 shrink-0 text-white/55" />
+          <LinkIcon className="h-4 w-4 shrink-0 text-muted" strokeWidth={1.5} />
         ) : (
-          <Download className="h-4 w-4 shrink-0 text-white/55" />
+          <Download className="h-4 w-4 shrink-0 text-muted" strokeWidth={1.5} />
         )}
       </a>
     </Button>
@@ -494,8 +494,8 @@ function PdfTile({
         asChild
         variant="ghost"
         className={cn(
-          "h-auto max-w-[min(20rem,100%)] justify-start gap-2.5 whitespace-normal rounded-xl border border-white/12 bg-white/[0.06] px-3 py-2.5",
-          "text-white/90 transition-colors hover:bg-white/[0.12]   ",
+          "h-auto min-h-touch max-w-[min(20rem,100%)] justify-start gap-2.5 whitespace-normal rounded-lg border border-border bg-card px-3 py-2.5",
+          "text-txt transition-colors hover:bg-bg-hover hover:border-border-strong active:scale-[0.99] motion-reduce:active:scale-100",
         )}
       >
         <a
@@ -505,16 +505,16 @@ function PdfTile({
           download={downloadName(att, "pdf")}
           data-testid="pdf-attachment-fallback"
         >
-          <FileText className="h-5 w-5 shrink-0 text-white/70" />
+          <FileText className="h-5 w-5 shrink-0 text-muted" strokeWidth={1.5} />
           <span className="min-w-0 flex-1">
-            <span className="block truncate text-[13px] font-medium">
+            <span className="block truncate text-xs-tight font-medium">
               {label}
             </span>
-            <span className="block text-[11px] uppercase tracking-wide text-white/45">
+            <span className="block text-2xs uppercase tracking-wide text-muted">
               {t("messageattachments.pdfLabel")}
             </span>
           </span>
-          <Download className="h-4 w-4 shrink-0 text-white/55" />
+          <Download className="h-4 w-4 shrink-0 text-muted" strokeWidth={1.5} />
         </a>
       </Button>
     );
@@ -524,11 +524,11 @@ function PdfTile({
     <figure
       data-testid="pdf-attachment"
       aria-label={frameTitle}
-      className="m-0 w-full max-w-[min(36rem,100%)] overflow-hidden rounded-xl border border-white/12 bg-white/[0.04]"
+      className="m-0 w-full max-w-[min(36rem,100%)] overflow-hidden rounded-lg border border-border bg-card"
     >
-      <figcaption className="flex items-center gap-2 border-b border-white/10 px-3 py-2">
-        <FileText className="h-4 w-4 shrink-0 text-white/70" />
-        <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-white/90">
+      <figcaption className="flex items-center gap-2 border-b border-border px-3 py-2">
+        <FileText className="h-4 w-4 shrink-0 text-muted" strokeWidth={1.5} />
+        <span className="min-w-0 flex-1 truncate text-xs-tight font-medium text-txt">
           {label}
         </span>
         <span className="flex shrink-0 gap-1.5">
@@ -550,7 +550,7 @@ function PdfTile({
         // Sandbox the embedded document: allow it to be treated as same-origin
         // so the native viewer's resources load, but grant no script/forms/etc.
         sandbox="allow-same-origin"
-        className="block h-[28rem] w-full border-0 bg-white"
+        className="block h-[28rem] w-full border-0 bg-brand-white"
       />
     </figure>
   );
@@ -694,11 +694,11 @@ function Model3dTile({
     <figure
       data-testid="model3d-attachment"
       aria-label={label}
-      className="m-0 w-full max-w-[min(28rem,100%)] overflow-hidden rounded-xl border border-white/12 bg-white/[0.04]"
+      className="m-0 w-full max-w-[min(28rem,100%)] overflow-hidden rounded-lg border border-border bg-card"
     >
-      <figcaption className="flex items-center gap-2 border-b border-white/10 px-3 py-2">
-        <Box className="h-4 w-4 shrink-0 text-white/70" />
-        <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-white/90">
+      <figcaption className="flex items-center gap-2 border-b border-border px-3 py-2">
+        <Box className="h-4 w-4 shrink-0 text-muted" strokeWidth={1.5} />
+        <span className="min-w-0 flex-1 truncate text-xs-tight font-medium text-txt">
           {label}
         </span>
         <span className="flex shrink-0 gap-1.5">
@@ -715,7 +715,7 @@ function Model3dTile({
         <Button
           asChild
           variant="ghost"
-          className="h-auto w-full justify-start gap-2.5 rounded-none px-3 py-3 text-white/85 transition-colors hover:bg-white/[0.08]"
+          className="h-auto min-h-touch w-full justify-start gap-2.5 rounded-none px-3 py-3 text-txt transition-colors hover:bg-bg-hover"
         >
           <a
             href={src}
@@ -724,21 +724,21 @@ function Model3dTile({
             download={downloadName(att, "model3d")}
             data-testid="model3d-attachment-fallback"
           >
-            <Box className="h-5 w-5 shrink-0 text-white/60" />
-            <span className="min-w-0 flex-1 text-[12px] text-white/60">
+            <Box className="h-5 w-5 shrink-0 text-muted" strokeWidth={1.5} />
+            <span className="min-w-0 flex-1 text-2xs text-muted">
               {t("messageattachments.model3dDownloadToView")}
             </span>
-            <Download className="h-4 w-4 shrink-0 text-white/55" />
+            <Download className="h-4 w-4 shrink-0 text-muted" strokeWidth={1.5} />
           </a>
         </Button>
       ) : (
         <div
           ref={mountRef}
           data-testid="model3d-canvas"
-          className="relative h-72 w-full bg-black/40"
+          className="relative h-72 w-full bg-bg-elevated"
         >
           {status === "loading" ? (
-            <span className="absolute inset-0 flex items-center justify-center text-[12px] text-white/60">
+            <span className="absolute inset-0 flex items-center justify-center text-2xs text-muted">
               {t("messageattachments.model3dLoading")}
             </span>
           ) : null}
@@ -773,8 +773,8 @@ function CodeTile({
         asChild
         variant="ghost"
         className={cn(
-          "h-auto max-w-[min(20rem,100%)] justify-start gap-2.5 whitespace-normal rounded-xl border border-white/12 bg-white/[0.06] px-3 py-2.5",
-          "text-white/90 transition-colors hover:bg-white/[0.12]   ",
+          "h-auto min-h-touch max-w-[min(20rem,100%)] justify-start gap-2.5 whitespace-normal rounded-lg border border-border bg-card px-3 py-2.5",
+          "text-txt transition-colors hover:bg-bg-hover hover:border-border-strong active:scale-[0.99] motion-reduce:active:scale-100",
         )}
       >
         <a
@@ -784,16 +784,16 @@ function CodeTile({
           download={downloadName(att, "code")}
           data-testid="code-attachment-fallback"
         >
-          <Code2 className="h-5 w-5 shrink-0 text-white/70" />
+          <Code2 className="h-5 w-5 shrink-0 text-muted" strokeWidth={1.5} />
           <span className="min-w-0 flex-1">
-            <span className="block truncate text-[13px] font-medium">
+            <span className="block truncate text-xs-tight font-medium">
               {label}
             </span>
-            <span className="block text-[11px] uppercase tracking-wide text-white/45">
+            <span className="block text-2xs uppercase tracking-wide text-muted">
               {t("messageattachments.textLabel")}
             </span>
           </span>
-          <Download className="h-4 w-4 shrink-0 text-white/55" />
+          <Download className="h-4 w-4 shrink-0 text-muted" strokeWidth={1.5} />
         </a>
       </Button>
     );
@@ -804,14 +804,14 @@ function CodeTile({
     <figure
       data-testid="code-attachment"
       aria-label={t("messageattachments.codePreviewTitle", { name: label })}
-      className="m-0 w-full max-w-[min(36rem,100%)] overflow-hidden rounded-xl border border-white/12 bg-white/[0.04]"
+      className="m-0 w-full max-w-[min(36rem,100%)] overflow-hidden rounded-lg border border-border bg-card"
     >
-      <figcaption className="flex items-center gap-2 border-b border-white/10 px-3 py-2">
-        <Code2 className="h-4 w-4 shrink-0 text-white/70" />
-        <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-white/90">
+      <figcaption className="flex items-center gap-2 border-b border-border px-3 py-2">
+        <Code2 className="h-4 w-4 shrink-0 text-muted" strokeWidth={1.5} />
+        <span className="min-w-0 flex-1 truncate text-xs-tight font-medium text-txt">
           {label}
         </span>
-        <span className="shrink-0 text-[11px] uppercase tracking-wide text-white/45">
+        <span className="shrink-0 text-2xs uppercase tracking-wide text-muted">
           {language}
         </span>
         <TileButton
@@ -849,14 +849,14 @@ function UnsafeAttachmentTile({
     <div
       data-testid="unsafe-attachment"
       className={cn(
-        "flex max-w-[min(20rem,100%)] items-center gap-2.5 rounded-xl border border-white/12 bg-white/[0.06] px-3 py-2.5",
-        "text-white/90",
+        "flex max-w-[min(20rem,100%)] items-center gap-2.5 rounded-lg border border-border bg-card px-3 py-2.5",
+        "text-txt",
       )}
     >
-      <FileText className="h-5 w-5 shrink-0 text-white/70" />
+      <FileText className="h-5 w-5 shrink-0 text-muted" strokeWidth={1.5} />
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-[13px] font-medium">{label}</span>
-        <span className="block text-[11px] uppercase tracking-wide text-white/45">
+        <span className="block truncate text-xs-tight font-medium">{label}</span>
+        <span className="block text-2xs uppercase tracking-wide text-muted">
           unsupported attachment
         </span>
       </span>
@@ -879,18 +879,18 @@ function TranscriptTile({
       onClick={onOpen}
       data-testid="transcript-attachment"
       className={cn(
-        "group h-auto max-w-[min(20rem,100%)] justify-start gap-2.5 whitespace-normal rounded-xl border border-white/12 bg-white/[0.06] px-3 py-2.5 text-left",
-        "text-white/90 transition-colors hover:bg-white/[0.12]   ",
+        "group h-auto min-h-touch max-w-[min(20rem,100%)] justify-start gap-2.5 whitespace-normal rounded-lg border border-border bg-card px-3 py-2.5 text-left",
+        "text-txt transition-colors hover:bg-bg-hover hover:border-border-strong active:scale-[0.99] motion-reduce:active:scale-100",
       )}
     >
-      <ScrollText className="h-5 w-5 shrink-0 text-white/70" />
+      <ScrollText className="h-5 w-5 shrink-0 text-muted" strokeWidth={1.5} />
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-[13px] font-medium">{label}</span>
-        <span className="block text-[11px] uppercase tracking-wide text-white/45">
+        <span className="block truncate text-xs-tight font-medium">{label}</span>
+        <span className="block text-2xs uppercase tracking-wide text-muted">
           Transcript · tap to open
         </span>
       </span>
-      <Maximize2 className="h-4 w-4 shrink-0 text-white/55 transition-colors group-hover:text-white/80" />
+      <Maximize2 className="h-4 w-4 shrink-0 text-muted transition-colors group-hover:text-txt" strokeWidth={1.5} />
     </Button>
   );
 }
@@ -931,7 +931,7 @@ function Lightbox({
         variant="ghost"
         aria-label="Close preview"
         onClick={onClose}
-        className="absolute inset-0 h-auto w-auto cursor-zoom-out rounded-none bg-black/85 p-0 hover:bg-black/85"
+        className="absolute inset-0 h-auto w-auto cursor-zoom-out rounded-none bg-scrim p-0 hover:bg-scrim"
       />
       <img
         src={src}
@@ -1044,10 +1044,10 @@ export function MessageAttachments({
               <div
                 key={att.id}
                 data-testid="audio-attachment"
-                className="max-w-[min(22rem,100%)] rounded-xl border border-white/12 bg-white/[0.06] px-3 py-2.5"
+                className="max-w-[min(22rem,100%)] rounded-lg border border-border bg-card px-3 py-2.5"
               >
                 {att.title?.trim() ? (
-                  <div className="mb-1.5 truncate text-[12px] font-medium text-white/80">
+                  <div className="mb-1.5 truncate text-2xs font-medium text-txt">
                     {att.title.trim()}
                   </div>
                 ) : null}
@@ -1071,7 +1071,7 @@ export function MessageAttachments({
                 preload="metadata"
                 // Reserve a stable 16:9 box so the row height is fixed before
                 // the video metadata loads — avoids layout shift on load.
-                className="aspect-video max-h-80 w-full max-w-[min(22rem,100%)] rounded-xl border border-white/12 object-contain"
+                className="aspect-video max-h-80 w-full max-w-[min(22rem,100%)] rounded-lg border border-border bg-card object-contain"
               >
                 <track kind="captions" />
               </video>

--- a/packages/ui/src/components/chat/TranscriptViewerOverlay.tsx
+++ b/packages/ui/src/components/chat/TranscriptViewerOverlay.tsx
@@ -442,17 +442,17 @@ export function TranscriptViewerOverlay({
         aria-label="Close transcript"
         onClick={onClose}
         variant="ghost"
-        className="absolute inset-0 h-auto w-auto cursor-default rounded-none bg-black/85 hover:bg-black/85"
+        className="absolute inset-0 h-auto w-auto cursor-default rounded-none bg-scrim hover:bg-scrim"
       />
       <div
         className={cn(
           "relative flex max-h-full w-full max-w-2xl flex-col overflow-hidden",
-          "rounded-2xl border border-white/15 bg-[rgb(22,22,28)] text-white",
+          "rounded-lg border border-border bg-card text-txt",
         )}
       >
         {/* Header: title + close */}
-        <div className="flex items-center gap-2 border-b border-white/10 px-4 py-3">
-          <h2 className="min-w-0 flex-1 truncate text-sm font-semibold">
+        <div className="flex items-center gap-2 border-b border-border px-4 py-3">
+          <h2 className="min-w-0 flex-1 truncate text-sm font-semibold text-txt-strong">
             {title}
           </h2>
           <Button
@@ -460,9 +460,9 @@ export function TranscriptViewerOverlay({
             onClick={onClose}
             variant="ghost"
             size="icon-sm"
-            className="h-7 w-7 rounded-full bg-white/10 text-white/80 transition-colors hover:bg-white/20"
+            className="h-7 w-7 rounded-full bg-bg-hover text-muted transition-colors hover:bg-surface hover:text-txt active:scale-[0.96] motion-reduce:active:scale-100"
           >
-            <X className="h-4 w-4" />
+            <X className="h-4 w-4" strokeWidth={1.5} />
           </Button>
         </div>
 
@@ -483,15 +483,15 @@ export function TranscriptViewerOverlay({
               >
                 <track kind="captions" />
               </audio>
-              <div className="flex items-center gap-1 text-xs text-white/50">
-                <FileAudio className="h-3.5 w-3.5 shrink-0" aria-hidden />
+              <div className="flex items-center gap-1 text-xs text-muted">
+                <FileAudio className="h-3.5 w-3.5 shrink-0" strokeWidth={1.5} aria-hidden />
                 <span className="mr-1">Recording</span>
                 <Button
                   onClick={handleDownloadAudio}
                   data-testid="transcript-save-audio"
                   variant="ghost"
                   size="sm"
-                  className="h-auto rounded px-1.5 py-0.5 text-xs font-normal text-white/70 transition-colors hover:bg-white/10 hover:text-white"
+                  className="h-auto rounded-sm px-1.5 py-0.5 text-xs font-normal text-muted transition-colors hover:bg-bg-hover hover:text-txt"
                 >
                   Download
                 </Button>
@@ -500,7 +500,7 @@ export function TranscriptViewerOverlay({
                   data-testid="transcript-share-audio"
                   variant="ghost"
                   size="sm"
-                  className="h-auto rounded px-1.5 py-0.5 text-xs font-normal text-white/70 transition-colors hover:bg-white/10 hover:text-white"
+                  className="h-auto rounded-sm px-1.5 py-0.5 text-xs font-normal text-muted transition-colors hover:bg-bg-hover hover:text-txt"
                 >
                   Share
                 </Button>
@@ -508,7 +508,7 @@ export function TranscriptViewerOverlay({
             </div>
           ) : null}
           {load.status === "loading" ? (
-            <div className="flex items-center gap-2 py-8 text-sm text-white/60">
+            <div className="flex items-center gap-2 py-8 text-sm text-muted">
               <Spinner size={16} /> Loading transcript…
             </div>
           ) : editing ? (
@@ -517,20 +517,20 @@ export function TranscriptViewerOverlay({
               onChange={(e) => setValue(e.target.value)}
               aria-label="Edit transcript"
               data-testid="transcript-editor"
-              className="min-h-[40vh] w-full resize-none border-white/15 bg-black/30 text-[13px] leading-relaxed text-white"
+              className="min-h-[40vh] w-full resize-none border-border bg-bg text-xs-tight leading-relaxed text-txt"
               autoFocus
             />
           ) : (
             <pre
               data-testid="transcript-text"
-              className="whitespace-pre-wrap break-words font-sans text-[13px] leading-relaxed text-white/90"
+              className="whitespace-pre-wrap break-words font-sans text-xs-tight leading-relaxed text-txt"
             >
               {value || "(empty transcript)"}
             </pre>
           )}
           {saveError ? (
             <p
-              className="mt-2 text-xs text-[color:var(--danger,#f87171)]"
+              className="mt-2 text-xs text-danger"
               data-testid="transcript-save-error"
             >
               {saveError}
@@ -539,16 +539,20 @@ export function TranscriptViewerOverlay({
         </div>
 
         {/* Action bar */}
-        <div className="flex flex-wrap items-center gap-2 border-t border-white/10 px-4 py-3">
+        <div
+          className="flex flex-wrap items-center gap-2 border-t border-border px-4 py-3"
+          style={{
+            paddingBottom: "calc(var(--safe-area-bottom, 0px) + 0.75rem)",
+          }}
+        >
           {!editing ? (
             <Button
               variant="ghost"
               size="sm"
               onClick={() => setEditing(true)}
               data-testid="transcript-edit"
-              className="text-white/85 hover:bg-white/10"
             >
-              <Pencil className="mr-1.5 h-4 w-4" /> Edit
+              <Pencil className="mr-1.5 h-4 w-4" strokeWidth={1.5} /> Edit
             </Button>
           ) : (
             <Button
@@ -557,9 +561,8 @@ export function TranscriptViewerOverlay({
               onClick={() => setValue(pristine)}
               disabled={!dirty}
               data-testid="transcript-undo"
-              className="text-white/85 hover:bg-white/10"
             >
-              <Undo2 className="mr-1.5 h-4 w-4" /> Undo
+              <Undo2 className="mr-1.5 h-4 w-4" strokeWidth={1.5} /> Undo
             </Button>
           )}
           <Button
@@ -567,17 +570,12 @@ export function TranscriptViewerOverlay({
             size="sm"
             onClick={() => void handleCopy()}
             data-testid="transcript-copy"
-            className={cn(
-              "hover:bg-white/10",
-              copyStatus === "failed"
-                ? "text-[color:var(--danger,#f87171)]"
-                : "text-white/85",
-            )}
+            className={cn(copyStatus === "failed" && "text-danger")}
           >
             {copyStatus === "copied" ? (
-              <Check className="mr-1.5 h-4 w-4 text-[color:var(--ok)]" />
+              <Check className="mr-1.5 h-4 w-4 text-status-success" strokeWidth={1.5} />
             ) : (
-              <Copy className="mr-1.5 h-4 w-4" />
+              <Copy className="mr-1.5 h-4 w-4" strokeWidth={1.5} />
             )}
             {copyButtonLabel(copyStatus)}
           </Button>
@@ -586,18 +584,16 @@ export function TranscriptViewerOverlay({
             size="sm"
             onClick={handleShare}
             data-testid="transcript-share"
-            className="text-white/85 hover:bg-white/10"
           >
-            <Share2 className="mr-1.5 h-4 w-4" /> Share
+            <Share2 className="mr-1.5 h-4 w-4" strokeWidth={1.5} /> Share
           </Button>
           <Button
             variant="ghost"
             size="sm"
             onClick={handleSaveToFiles}
             data-testid="transcript-save-to-files"
-            className="text-white/85 hover:bg-white/10"
           >
-            <Download className="mr-1.5 h-4 w-4" /> Download
+            <Download className="mr-1.5 h-4 w-4" strokeWidth={1.5} /> Download
           </Button>
           {resolvedId || audioUrl ? (
             <Button
@@ -605,9 +601,8 @@ export function TranscriptViewerOverlay({
               size="sm"
               onClick={handleOpenInTranscripts}
               data-testid="transcript-open-in-transcripts"
-              className="text-white/85 hover:bg-white/10"
             >
-              <Headphones className="mr-1.5 h-4 w-4" /> Open in Transcripts
+              <Headphones className="mr-1.5 h-4 w-4" strokeWidth={1.5} /> Open in Transcripts
             </Button>
           ) : null}
           {resolvedId ? (
@@ -617,13 +612,11 @@ export function TranscriptViewerOverlay({
               onClick={() => void handleDelete()}
               data-testid="transcript-delete"
               className={cn(
-                "hover:bg-[color:var(--danger,#f87171)]/15",
-                confirmDelete
-                  ? "text-[color:var(--danger,#f87171)]"
-                  : "text-white/70",
+                "hover:bg-destructive-subtle",
+                confirmDelete ? "text-danger" : "text-muted",
               )}
             >
-              <Trash2 className="mr-1.5 h-4 w-4" />
+              <Trash2 className="mr-1.5 h-4 w-4" strokeWidth={1.5} />
               {confirmDelete ? "Confirm delete" : "Delete"}
             </Button>
           ) : null}
@@ -633,7 +626,6 @@ export function TranscriptViewerOverlay({
               size="sm"
               onClick={onClose}
               data-testid="transcript-cancel"
-              className="text-white/70 hover:bg-white/10"
             >
               Cancel
             </Button>

--- a/packages/ui/src/components/chat/widgets/ftu-welcome.tsx
+++ b/packages/ui/src/components/chat/widgets/ftu-welcome.tsx
@@ -69,19 +69,20 @@ function FtuWelcomeWidget({
     markHomeWidgetActed(WIDGET_KEY);
   };
 
-  // Deliberately flat — no card/border/background/rounded-pill chrome. The
-  // welcome sits directly on the home: a greeting line and the starters as plain
-  // tappable text (hover underline is the only affordance).
+  // Deliberately flat: no card chrome. The welcome sits directly on the home as
+  // an editorial intro line, with the starters as warm-tinted tappable chips and
+  // a quiet dismiss. The greeting carries real hierarchy (a serene display line)
+  // so a cold home still feels composed, not empty.
   return (
     <section
       className={spanClassName}
       data-testid="chat-widget-ftu-welcome"
-      aria-label="Welcome — getting started"
+      aria-label="Getting started"
     >
-      <p className="text-sm font-medium text-white">
-        Welcome — ask me anything to get started.
+      <p className="text-sm font-medium leading-snug text-white [text-shadow:0_1px_3px_rgba(0,0,0,0.4)]">
+        Ask me anything to get started.
       </p>
-      <div className="mt-2 flex flex-wrap items-center gap-x-5 gap-y-1.5">
+      <div className="mt-2.5 flex flex-wrap items-center gap-2">
         {suggestions.map((text) => (
           <Button
             key={text}
@@ -89,7 +90,7 @@ function FtuWelcomeWidget({
             onClick={() => onChip(text)}
             variant="ghost"
             size="sm"
-            className="h-auto px-0 py-0 text-sm font-normal text-white/75 underline-offset-4 transition-colors hover:bg-transparent hover:text-white hover:underline"
+            className="h-auto rounded-full border border-accent/25 bg-accent-subtle px-3 py-1.5 text-xs font-medium text-white transition-colors duration-150 hover:border-accent/45 hover:bg-accent/20 active:scale-[0.97] motion-reduce:active:scale-100"
           >
             {text}
           </Button>
@@ -100,7 +101,7 @@ function FtuWelcomeWidget({
           onClick={() => dismissHomeWidget(WIDGET_KEY)}
           variant="ghost"
           size="sm"
-          className="h-auto px-0 py-0 text-sm font-normal text-white/60 transition-colors hover:bg-transparent hover:text-white/80"
+          className="h-auto px-1 py-0 text-xs text-white/60 transition-colors hover:bg-transparent hover:text-white"
         >
           Dismiss
         </Button>

--- a/packages/ui/src/components/chat/widgets/home-widget-card.tsx
+++ b/packages/ui/src/components/chat/widgets/home-widget-card.tsx
@@ -8,9 +8,10 @@
  * action). Because the visible text is intentionally minimal, the full meaning
  * lives in `ariaLabel` for screen readers.
  *
- * Sits on the orange home wallpaper, so it's a translucent neutral glass tile
- * (orange is accent-only; resting neutral → neutral-with-opacity hover, never
- * orange→black — per the hover system).
+ * Sits on the orange home wallpaper as a solid warm-dark card tile (the `card`
+ * surface token). Orange is accent-only: resting neutral, escalating to the
+ * status hue on danger/warn, never orange→black — per the hover system. All
+ * color comes from tokens so the tile stays theme-aware.
  */
 
 import { type ReactNode, useMemo } from "react";
@@ -48,30 +49,29 @@ export function useWidgetNavigation(): {
 
 export type HomeWidgetTone = "default" | "danger" | "warn";
 
-// Every card sits on the ORANGE home wallpaper, and the brand maps the
-// danger/warn/accent tokens to brand orange — so any `text-danger` /
-// `bg-accent-subtle` here is orange-on-orange (the overdrawn amount and its
-// badge rendered invisible). Tone must therefore use wallpaper-safe fixed
-// colors: white text always; tone is carried by the icon dot + the badge chip.
+// The datum tone. Default is high-contrast text on the warm-dark card; danger/
+// warn carry the accent so an at-risk widget reads at a glance. `text-txt-strong`
+// resolves to the brand off-white on the dark ember card (theme-aware, not a
+// baked-in white), keeping the value crisp without a raw color.
 const TONE_VALUE_CLASS: Record<HomeWidgetTone, string> = {
-  default: "text-white",
-  danger: "text-white",
-  warn: "text-white",
+  default: "text-txt-strong",
+  danger: "text-danger",
+  warn: "text-warn",
+};
+
+// The icon chip tone: a warm-tinted resting chip, escalating to the status hue.
+// The default chip is the accent at its subtle fill with the accent glyph — the
+// tokenized equivalent of the old raw peach, so light/dark both resolve.
+const TONE_CHIP_CLASS: Record<HomeWidgetTone, string> = {
+  default: "bg-accent-subtle text-accent",
+  danger: "bg-danger/15 text-danger",
+  warn: "bg-warn/15 text-warn",
 };
 
 const TONE_DOT_CLASS: Record<HomeWidgetTone, string> = {
-  default: "bg-white/60",
-  danger: "bg-white",
-  warn: "bg-white/75",
-};
-
-// Dark glass chips read on the orange field (the token-tinted `bg-danger/15
-// text-danger` chips did not — orange on orange). Danger/warn get the stronger
-// fill so escalations still pop against the default count chips.
-const TONE_BADGE_CLASS: Record<HomeWidgetTone, string> = {
-  default: "bg-black/20 text-white/90",
-  danger: "bg-black/35 text-white",
-  warn: "bg-black/30 text-white",
+  default: "bg-muted",
+  danger: "bg-danger",
+  warn: "bg-warn",
 };
 
 export interface HomeWidgetCardProps {
@@ -113,24 +113,35 @@ export function HomeWidgetCard({
       title={label}
       onClick={onActivate}
       className={cn(
-        // Chromeless (#10708): no border/background/rounded card — content sits
-        // directly on the wallpaper. Neutral-resting hover affordance is an
-        // opacity change (no background fill), per the neutral hover rule.
-        // `flex-wrap` + the value's min-width floor below keep the single datum
-        // legible on half-width mobile cards: without them a wide shrink-0
-        // badge ("Overdrawn") crushed the flex-1 value column to ~0px and the
-        // currency vanished. When the row can't fit, the badge wraps under.
-        "group h-auto w-full flex-wrap justify-start gap-3 whitespace-normal rounded-none bg-transparent px-3 py-2.5 text-left",
-        "transition-opacity hover:bg-transparent hover:opacity-80",
+        // A SOLID warm-dark tile (the card surface token) with a warm hairline
+        // edge, so it sits in the ember field instead of letting it bleed
+        // through (the old bg-black/55 was translucent). A left accent rail keys
+        // the tone. Tactile: a hair lift + warmer edge on hover, scale-press on
+        // tap. Surface/border/hover all resolve through tokens so the tile is
+        // theme-aware, never a baked-in white/black opacity ladder.
+        "group relative flex h-auto w-full items-center gap-3 overflow-hidden whitespace-normal rounded-2xl border border-border bg-card px-3.5 py-3 text-left",
+        "transition-[transform,border-color,background-color] duration-150",
+        "hover:border-border-hover hover:bg-bg-hover",
+        "active:scale-[0.985] motion-reduce:active:scale-100",
       )}
     >
+      {/* Left accent rail: a quiet ember stripe at rest, brightening on hover,
+          a deliberate edge detail, not a generic one-sided border. */}
+      <span
+        aria-hidden
+        className={cn(
+          "absolute inset-y-2.5 left-0 w-[3px] rounded-full transition-colors duration-150",
+          tone === "danger"
+            ? "bg-danger/70"
+            : tone === "warn"
+              ? "bg-warn/70"
+              : "bg-accent/35 group-hover:bg-accent/70",
+        )}
+      />
       <span
         className={cn(
-          // Tonal glyph tints are skipped for the same orange-on-orange reason
-          // as TONE_VALUE_CLASS: the escalated tones brighten to full white and
-          // the corner dot marks the tone.
-          "relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/10 text-white/85 [&>svg]:h-4 [&>svg]:w-4",
-          tone !== "default" && "text-white",
+          "relative inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl [&>svg]:h-[18px] [&>svg]:w-[18px]",
+          TONE_CHIP_CLASS[tone],
         )}
       >
         {icon}
@@ -138,17 +149,20 @@ export function HomeWidgetCard({
           <span
             aria-hidden
             className={cn(
-              "absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full border border-black/40",
+              "absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full border border-card",
               TONE_DOT_CLASS[tone],
             )}
           />
         ) : null}
       </span>
 
-      {/* Icon-only: the lucide icon identifies the widget; the label is folded
-          into the button's aria-label (and the hover title), never shown as a
-          visible eyebrow. Only the single high-priority datum renders. */}
-      <span className="flex min-w-[4.5rem] flex-1 flex-col">
+      {/* The label is now a visible eyebrow (the widgets are the hero, so they
+          read as a real dashboard), with the single high-priority datum below
+          it. When a widget supplies no datum, the label carries the row alone. */}
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="truncate text-xs-tight font-medium uppercase tracking-[0.08em] text-muted">
+          {label}
+        </span>
         {value != null ? (
           <span
             className={cn(
@@ -166,15 +180,19 @@ export function HomeWidgetCard({
       </span>
 
       {meta != null ? (
-        <span className="shrink-0 text-2xs tabular-nums text-white/60">
+        <span className="shrink-0 text-xs-tight tabular-nums text-muted-strong">
           {meta}
         </span>
       ) : null}
       {badge != null ? (
         <span
           className={cn(
-            "shrink-0 rounded-full px-1.5 py-0.5 text-2xs font-semibold",
-            TONE_BADGE_CLASS[tone],
+            "shrink-0 rounded-full px-2 py-0.5 text-xs-tight font-semibold tabular-nums",
+            tone === "danger"
+              ? "bg-danger/15 text-danger"
+              : tone === "warn"
+                ? "bg-warn/15 text-warn"
+                : "bg-accent-subtle text-accent",
           )}
         >
           {badge}

--- a/packages/ui/src/components/chat/widgets/model-download.tsx
+++ b/packages/ui/src/components/chat/widgets/model-download.tsx
@@ -360,7 +360,7 @@ function ModelProgressCard({
       <span className="flex w-full items-center gap-3">
         <span
           className={cn(
-            "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/10 text-white/85 [&>svg]:h-4 [&>svg]:w-4",
+            "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-bg-hover text-txt-strong [&>svg]:h-4 [&>svg]:w-4",
             tone === "danger" && "text-danger",
           )}
         >
@@ -369,13 +369,13 @@ function ModelProgressCard({
         <span
           className={cn(
             "min-w-0 flex-1 truncate text-sm font-semibold leading-tight",
-            tone === "danger" ? "text-danger" : "text-white",
+            tone === "danger" ? "text-danger" : "text-txt-strong",
           )}
         >
           {value}
         </span>
         {meta != null ? (
-          <span className="shrink-0 text-2xs tabular-nums text-white/60">
+          <span className="shrink-0 text-2xs tabular-nums text-muted">
             {meta}
           </span>
         ) : null}
@@ -395,7 +395,7 @@ function ModelProgressCard({
       <span
         aria-hidden="true"
         data-testid="chat-widget-model-download-track"
-        className="h-1.5 w-full overflow-hidden rounded-full bg-white/10"
+        className="h-1.5 w-full overflow-hidden rounded-full bg-bg-hover"
       >
         {indeterminate ? (
           <span className="block h-full w-full animate-pulse rounded-full bg-accent/70 motion-reduce:animate-none" />

--- a/packages/ui/src/components/chat/widgets/notifications.populated.test.tsx
+++ b/packages/ui/src/components/chat/widgets/notifications.populated.test.tsx
@@ -43,6 +43,9 @@ function renderWidget() {
 }
 
 function rowTitles(): string[] {
+  // Each row is a <li><button …>; the title is the first text node inside it
+  // (an aria-hidden icon chip + optional unread dot carry no text, and the
+  // timestamp <time> is right-aligned after the title/body column).
   return screen
     .getAllByRole("listitem")
     .map((li) => within(li).getAllByText(/.+/)[0].textContent ?? "");
@@ -154,12 +157,22 @@ describe("NotificationsWidget — populated (#9304)", () => {
     renderWidget();
 
     expect(screen.getByText("Detail line").textContent).toBe("Detail line");
+    // The with-body row shows both its title and its body line.
+    const withBodyRow = within(screen.getByTestId("widget-notifications"))
+      .getByText("Has body")
+      .closest("li");
+    expect(withBodyRow).not.toBeNull();
+    expect(
+      within(withBodyRow as HTMLElement).queryByText("Detail line"),
+    ).not.toBeNull();
+
+    // The no-body row renders its title but no body line at all.
     const noBodyRow = within(screen.getByTestId("widget-notifications"))
       .getByText("No body")
       .closest("li");
     expect(noBodyRow).not.toBeNull();
-    // The body span is a sibling of the title span; without a body the row has
-    // exactly one text child.
-    expect(within(noBodyRow as HTMLElement).getAllByText(/.+/)).toHaveLength(1);
+    expect(
+      within(noBodyRow as HTMLElement).queryByText("Detail line"),
+    ).toBeNull();
   });
 });

--- a/packages/ui/src/components/chat/widgets/notifications.test.tsx
+++ b/packages/ui/src/components/chat/widgets/notifications.test.tsx
@@ -74,7 +74,12 @@ describe("NotificationsWidget (#9143)", () => {
 
   it("home slot: clicking the card navigates to the inbox (or the deep link)", () => {
     __resetNotificationStoreForTests();
-    __ingestNotificationForTests(notification({ title: "Plain alert" }), 1);
+    // Home-worthy (high) so it clears the aggressive quiet threshold and the
+    // tile actually renders.
+    __ingestNotificationForTests(
+      notification({ title: "Plain alert", priority: "high" }),
+      1,
+    );
 
     const navEvents: string[] = [];
     const onNav = (e: Event) => {
@@ -93,7 +98,11 @@ describe("NotificationsWidget (#9143)", () => {
   it("home slot: prefers the notification's own deep link when present", () => {
     __resetNotificationStoreForTests();
     __ingestNotificationForTests(
-      notification({ title: "Review needed", deepLink: "/tasks" }),
+      notification({
+        title: "Review needed",
+        deepLink: "/tasks",
+        priority: "high",
+      }),
       1,
     );
 
@@ -200,5 +209,57 @@ describe("NotificationsWidget (#9143)", () => {
       <NotificationsWidget pluginId="notifications" slot="home" />,
     );
     expect(container.firstElementChild?.className).toContain("col-span-2");
+  });
+
+  // signal, not noise: the home surface applies an aggressive quiet threshold
+  // and collapses same-category bursts so it never reads as a wall of noise.
+  it("home slot: renders NOTHING when every notification is below the quiet threshold", () => {
+    __resetNotificationStoreForTests();
+    // A wall of normal/low informational notifications = noise, not signal.
+    for (let i = 0; i < 6; i++) {
+      __ingestNotificationForTests(
+        notification({ title: `FYI ${i}`, priority: "normal" }),
+      );
+    }
+    const { container } = render(
+      <NotificationsWidget pluginId="notifications" slot="home" />,
+    );
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId("widget-notifications")).toBeNull();
+  });
+
+  it("home slot: hides read/stale notifications, surfaces only the unread high one", () => {
+    __resetNotificationStoreForTests();
+    __ingestNotificationForTests(
+      notification({ title: "Old read alert", priority: "urgent", readAt: Date.now() }),
+    );
+    __ingestNotificationForTests(
+      notification({ title: "Act now", priority: "high" }),
+      1,
+    );
+    render(<NotificationsWidget pluginId="notifications" slot="home" />);
+    const card = screen.getByTestId("widget-notifications");
+    expect(card.textContent).toContain("Act now");
+    expect(card.textContent).not.toContain("Old read alert");
+  });
+
+  it("home slot: collapses a same-category burst into a grouped 'N updates' tile", () => {
+    __resetNotificationStoreForTests();
+    // Three unread high health notifications = one grouped tile, not three.
+    for (let i = 0; i < 3; i++) {
+      __ingestNotificationForTests(
+        notification({
+          title: `Health ping ${i}`,
+          category: "health",
+          priority: "high",
+        }),
+        i + 1,
+      );
+    }
+    render(<NotificationsWidget pluginId="notifications" slot="home" />);
+    const card = screen.getByTestId("widget-notifications");
+    // The tile summarizes the group instead of showing a single title.
+    expect(card.textContent).toContain("3 health updates");
+    expect(card.getAttribute("aria-label")).toMatch(/3 health updates/i);
   });
 });

--- a/packages/ui/src/components/chat/widgets/notifications.tsx
+++ b/packages/ui/src/components/chat/widgets/notifications.tsx
@@ -5,7 +5,10 @@
  * is real activity so the always-visible home surface stays quiet when empty.
  */
 import type { AgentNotification } from "@elizaos/core";
-import { Bell } from "lucide-react";
+import { Bell, ChevronRight } from "lucide-react";
+import { memo, useCallback } from "react";
+import { cn } from "../../../lib/utils";
+import { useNow } from "../../../hooks/useNow";
 import { categoryIcon } from "../../../state/notifications/category-icon";
 import {
   isSafeDeepLink,
@@ -15,102 +18,224 @@ import {
   markNotificationRead,
   useNotifications,
 } from "../../../state/notifications/notification-store";
-import { rankHomeNotifications } from "../../../widgets/home-priority";
+import {
+  rankHomeNotifications,
+  selectHomeNotifications,
+} from "../../../widgets/home-priority";
+import { formatRelativeTime } from "../../../utils/format";
 import type { WidgetProps } from "../../../widgets/types";
 import { HomeWidgetCard, useWidgetNavigation } from "./home-widget-card";
 import { WidgetSection } from "./shared";
 
+/**
+ * How many home ENTRIES (single rows or grouped rows) the home notification
+ * surface shows. Kept small on purpose — home is a glance, not the inbox.
+ */
 const MAX_HOME_NOTIFICATIONS = 4;
 
-function NotificationRow({
-  notification,
-}: {
-  notification: AgentNotification;
-}) {
-  return (
-    <li className="flex items-start gap-1.5 px-1 py-1">
-      {/* Per-category icon from the one shared map (#10697) — the same iconography
-          the popover NotificationCenter uses, so the two surfaces never drift. */}
-      <span
-        className="mt-0.5 shrink-0 text-muted [&_svg]:h-3.5 [&_svg]:w-3.5"
-        data-testid="notification-row-icon"
-        aria-hidden
-      >
-        {categoryIcon(notification.category)}
-      </span>
-      <span className="flex min-w-0 flex-col gap-0.5">
-        <span className="truncate text-xs font-medium text-txt">
-          {notification.title}
-        </span>
-        {notification.body ? (
-          <span className="truncate text-2xs text-muted">
-            {notification.body}
-          </span>
-        ) : null}
-      </span>
-    </li>
-  );
+/** Human-facing label for a collapsed same-category group of `count` items. */
+function groupTitle(category: string, count: number): string {
+  return `${count} ${category} update${count === 1 ? "" : "s"}`;
 }
 
 /**
+ * One scannable notification row. A whole-row button (comfortable tap target)
+ * that mirrors the popover NotificationCenter's activate behavior — mark read,
+ * then follow a scheme-checked deep link, else open the inbox. Unread rows
+ * stand out with an accent dot + stronger title; read rows recede.
+ *
+ * Memoized: the widget re-renders on the shared `useNow()` 60s recency tick
+ * (needed by the home slot's age-gate) and on any store change; with a stable
+ * `onOpen` (see `useCallback` in the widget) the capped row list then skips
+ * re-rendering every minute when nothing about a row actually changed.
+ */
+const NotificationRow = memo(function NotificationRow({
+  notification,
+  onOpen,
+}: {
+  notification: AgentNotification;
+  onOpen: (notification: AgentNotification) => void;
+}) {
+  const unread = !notification.readAt;
+  const urgent = notification.priority === "urgent";
+  const high = notification.priority === "high";
+  return (
+    <li>
+      <button
+        type="button"
+        data-testid="notification-row"
+        data-unread={unread ? "true" : undefined}
+        aria-label={`${notification.title}${
+          notification.body ? `. ${notification.body}` : ""
+        }${unread ? ". Unread." : ""}`}
+        onClick={() => onOpen(notification)}
+        className={cn(
+          "group flex min-h-touch w-full items-start gap-2 rounded-md px-1.5 py-1.5 text-left",
+          "transition-colors duration-150 hover:bg-bg-hover",
+          "active:scale-[0.99] motion-reduce:active:scale-100",
+        )}
+      >
+        {/* Per-category icon from the one shared map (#10697) — the same
+            iconography the popover NotificationCenter uses, so the two surfaces
+            never drift. Urgent/high tint the chip so severity reads instantly. */}
+        <span
+          className={cn(
+            "mt-px inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-sm [&_svg]:h-3.5 [&_svg]:w-3.5",
+            urgent
+              ? "bg-destructive-subtle text-destructive"
+              : high
+                ? "bg-accent-subtle text-accent"
+                : "bg-bg-muted text-muted",
+          )}
+          data-testid="notification-row-icon"
+          aria-hidden
+        >
+          {categoryIcon(notification.category)}
+        </span>
+
+        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="flex items-center gap-1.5">
+            {/* Unread accent dot: the primary "this needs you" signal, quiet
+                enough to scan a stack of them without noise. */}
+            {unread ? (
+              <span
+                aria-hidden
+                data-testid="notification-unread-dot"
+                className={cn(
+                  "h-1.5 w-1.5 shrink-0 rounded-full",
+                  urgent ? "bg-destructive" : "bg-accent",
+                )}
+              />
+            ) : null}
+            <span
+              className={cn(
+                "truncate text-xs",
+                unread
+                  ? "font-semibold text-txt"
+                  : "font-medium text-muted-strong",
+              )}
+            >
+              {notification.title}
+            </span>
+          </span>
+          {notification.body ? (
+            <span className="truncate text-2xs text-muted">
+              {notification.body}
+            </span>
+          ) : null}
+        </span>
+
+        {/* Timestamp: the subtlest element, right-aligned so titles stay the
+            scan column. Omitted when we have no createdAt to show. */}
+        {typeof notification.createdAt === "number" ? (
+          <time
+            className="mt-px shrink-0 text-3xs tabular-nums text-muted"
+            data-testid="notification-row-time"
+          >
+            {formatRelativeTime(notification.createdAt)}
+          </time>
+        ) : null}
+      </button>
+    </li>
+  );
+});
+
+/**
  * Frontpage Notifications widget (#9143). A "default" home-slot widget showing
- * the most recent agent notifications, so the Launcher home surfaces real
- * activity out of the box rather than only launcher icons. Reads the shared
- * notification store directly (no per-widget polling).
+ * the most attention-worthy agent notifications, so the Launcher home surfaces
+ * real activity out of the box rather than only launcher icons. Reads the
+ * shared notification store directly (no per-widget polling).
+ *
+ * Signal, not noise: the home surface applies an aggressive quiet-threshold
+ * (only unread, recent, high/urgent notifications are eligible) and collapses
+ * same-category bursts into a single grouped row. The full inbox/pull-down
+ * still shows everything — only THIS home surface gets the quiet + grouping.
  */
 export function NotificationsWidget(props: WidgetProps) {
   const { notifications, unreadCount } = useNotifications();
   const nav = useWidgetNavigation();
-  // Rank by attention (unread → priority → recency) so an urgent notification
-  // surfaces ahead of a newer low-priority one, not merely the newest few.
-  const ranked = rankHomeNotifications(notifications);
-  const recent = ranked.slice(0, MAX_HOME_NOTIFICATIONS);
+  // Coarse live clock for the home recency gate. `0` on first render keeps the
+  // render path deterministic (no Date.now in render); the age-gate treats
+  // `now === 0` as "don't age-filter yet" so home never flashes empty on paint.
+  const now = useNow();
 
-  // Render nothing until there's real activity. The always-visible home surface
-  // (#9143) must not show an empty placeholder card — empty-state hints belong
-  // on the dedicated view, not the home slot.
-  if (recent.length === 0) {
-    return null;
-  }
+  // Open a row: mirror NotificationCenter's row behavior exactly — mark read,
+  // then navigate through the scheme-checked deep-link helper (deepLink is
+  // producer/LLM-influenceable — raw pushState both broke https links and
+  // skipped the safety allowlist). Unsafe/missing → inbox.
+  //
+  // Stable across the `useNow()` 60s recency tick (`nav` is memoized) so the
+  // memoized rows don't re-render every minute just because this closure was
+  // re-created.
+  const openNotification = useCallback(
+    (n: AgentNotification) => {
+      if (!n.readAt) void markNotificationRead(n.id);
+      if (n.deepLink && isSafeDeepLink(n.deepLink)) {
+        navigateDeepLink(n.deepLink);
+      } else {
+        nav.openView("/inbox", "inbox");
+      }
+    },
+    [nav],
+  );
 
-  // Home slot: a single compact, icon-first, whole-card-clickable tile —
-  // the top (highest-priority, unread-first) notification as the one datum,
-  // unread count as the badge, urgent → danger. Tapping opens the notification's
-  // own deep link if it has one, else the inbox. The sidebar keeps the list.
+  // ---- HOME SLOT ----------------------------------------------------------
+  // The compact tile only surfaces when a genuinely home-worthy notification
+  // exists. Below the quiet threshold (read / stale / low severity) the tile
+  // renders nothing at all — signal, not noise (#9226 null contract preserved).
   if (props.slot === "home") {
-    const top = recent[0];
-    const urgent = top.priority === "urgent";
+    const homeEntries = selectHomeNotifications(notifications, { now });
+    const top = homeEntries[0];
+    if (!top) return null;
+
+    // The tile's one datum: either the lead notification's title, or a grouped
+    // "N updates" summary when the top entry is a collapsed category.
+    const isGroup = top.kind === "group";
+    const leadNotification = isGroup ? top.lead : top.notification;
+    const value = isGroup
+      ? groupTitle(top.category, top.count)
+      : leadNotification.title;
+    const urgent = leadNotification.priority === "urgent";
+    const high = leadNotification.priority === "high";
+    // The lead of a group shares the group's category, so its typed
+    // NotificationCategory drives the icon in both the single and group cases.
+    const category = leadNotification.category;
+
     return (
       <div
         className={`min-w-0 ${props.spanClassName ?? "col-span-2 row-span-1"}`}
       >
         <HomeWidgetCard
-          // The tile leads with the top notification's own category icon (#10697)
+          // The tile leads with the notification's own category icon (#10697)
           // so the home surface reads its kind at a glance, not a generic bell.
-          icon={categoryIcon(top.category)}
+          icon={categoryIcon(category)}
           label="Notifications"
-          value={top.title}
+          value={value}
           badge={unreadCount > 0 ? unreadCount : undefined}
-          tone={
-            urgent ? "danger" : top.priority === "high" ? "warn" : "default"
-          }
+          tone={urgent ? "danger" : high ? "warn" : "default"}
           testId="widget-notifications"
-          ariaLabel={`Notifications: ${unreadCount} unread, latest ${top.title}. Open inbox.`}
-          onActivate={() => {
-            // Mirror NotificationCenter's row behavior exactly: mark read, then
-            // navigate through the scheme-checked deep-link helper (deepLink is
-            // producer/LLM-influenceable — raw pushState both broke https links
-            // and skipped the safety allowlist). Unsafe/missing → inbox.
-            if (!top.readAt) void markNotificationRead(top.id);
-            if (top.deepLink && isSafeDeepLink(top.deepLink)) {
-              navigateDeepLink(top.deepLink);
-            } else {
-              nav.openView("/inbox", "inbox");
-            }
-          }}
+          ariaLabel={`Notifications: ${unreadCount} unread, ${
+            isGroup ? value : `latest ${value}`
+          }. Open inbox.`}
+          onActivate={() =>
+            isGroup ? nav.openView("/inbox", "inbox") : openNotification(top.notification)
+          }
         />
       </div>
     );
+  }
+
+  // ---- CHAT-SIDEBAR / DEFAULT SLOT ----------------------------------------
+  // The sidebar keeps the fuller list (the inbox-adjacent surface): rank by
+  // attention (unread → priority → recency), capped, so it stays useful without
+  // the home surface's aggressive quiet.
+  const ranked = rankHomeNotifications(notifications);
+  const recent = ranked.slice(0, MAX_HOME_NOTIFICATIONS);
+  const overflow = ranked.length - recent.length;
+
+  // Render nothing until there's real activity (#9226 null contract).
+  if (recent.length === 0) {
+    return null;
   }
 
   return (
@@ -120,17 +245,52 @@ export function NotificationsWidget(props: WidgetProps) {
       testId="widget-notifications"
       action={
         unreadCount > 0 ? (
-          <span className="rounded-full bg-accent-subtle px-1.5 text-2xs font-medium text-accent">
+          <span
+            className="rounded-full bg-accent-subtle px-1.5 py-0.5 text-2xs font-semibold tabular-nums text-accent"
+            aria-label={`${unreadCount} unread`}
+          >
             {unreadCount}
           </span>
-        ) : undefined
+        ) : (
+          // All caught up: a quiet "read" state instead of a stray title with
+          // no counterpart, so the header reads intentional at a glance.
+          <span className="text-3xs font-medium uppercase tracking-[0.08em] text-muted/70">
+            Caught up
+          </span>
+        )
       }
     >
       <ul className="flex flex-col gap-0.5">
         {recent.map((n) => (
-          <NotificationRow key={n.id} notification={n} />
+          <NotificationRow
+            key={n.id}
+            notification={n}
+            onOpen={openNotification}
+          />
         ))}
       </ul>
+      {overflow > 0 ? (
+        <button
+          type="button"
+          data-testid="notification-overflow"
+          onClick={() => nav.openView("/inbox", "inbox")}
+          aria-label={`${overflow} more notification${
+            overflow === 1 ? "" : "s"
+          }. Open inbox.`}
+          className={cn(
+            "mt-0.5 flex min-h-touch w-full items-center justify-between gap-1 rounded-md px-1.5 py-1.5 text-left",
+            "text-2xs font-medium text-muted transition-colors duration-150",
+            "hover:bg-bg-hover hover:text-txt",
+            "active:scale-[0.99] motion-reduce:active:scale-100",
+          )}
+        >
+          <span>
+            {overflow} more{" "}
+            {overflow === 1 ? "notification" : "notifications"}
+          </span>
+          <ChevronRight className="h-3.5 w-3.5 shrink-0" aria-hidden />
+        </button>
+      ) : null}
     </WidgetSection>
   );
 }

--- a/packages/ui/src/components/chat/widgets/shared.tsx
+++ b/packages/ui/src/components/chat/widgets/shared.tsx
@@ -28,7 +28,7 @@ export function WidgetSection({
       <span className="inline-flex shrink-0 items-center justify-center text-muted [&>svg]:h-3.5 [&>svg]:w-3.5">
         {icon}
       </span>
-      <span className="truncate text-[11px] leading-none font-semibold text-muted">
+      <span className="truncate text-xs-tight leading-none font-semibold text-muted">
         {title}
       </span>
     </>

--- a/packages/ui/src/components/chat/widgets/wallet-balance.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.tsx
@@ -109,7 +109,7 @@ export function WalletBalanceWidget(
       variant="ghost"
       className={`${spanClassName} group flex h-auto w-full flex-col items-stretch gap-1 whitespace-normal px-3 py-2.5 text-left font-normal transition-opacity hover:opacity-80`}
     >
-      <span className="flex items-center gap-2 text-xs text-white/70 [&>svg]:h-3.5 [&>svg]:w-3.5">
+      <span className="flex items-center gap-2 text-xs text-muted [&>svg]:h-3.5 [&>svg]:w-3.5">
         <Wallet />
         Wallet
       </span>
@@ -121,9 +121,11 @@ export function WalletBalanceWidget(
             data-testid={`wallet-price-row-${h.symbol}`}
             className="flex items-baseline justify-between gap-2 text-sm"
           >
-            <span className="truncate font-medium text-white">{h.symbol}</span>
+            <span className="truncate font-medium text-txt-strong">
+              {h.symbol}
+            </span>
             <span className="flex shrink-0 items-baseline gap-1.5">
-              <span className="tabular-nums text-white">
+              <span className="tabular-nums text-txt-strong">
                 {formatPrice(h.priceUsd)}
               </span>
               {change ? (

--- a/packages/ui/src/components/shell/NotificationCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationCenter.tsx
@@ -19,6 +19,7 @@ import {
   OPEN_NOTIFICATION_CENTER_EVENT,
 } from "../../events";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
+import { REVEAL_SOFT_MAX } from "./use-notification-pull";
 import {
   Z_NOTIFICATION_BACKDROP,
   Z_NOTIFICATION_OVERLAY,
@@ -49,23 +50,60 @@ import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 type NotificationSortMode = "priority" | "time";
 
 /**
- * Glass-look surface for the controlled shells (sheet + panel): a mostly-opaque
- * dark base, a hairline border, a lit top edge (inset highlight), and a soft
- * drop shadow for depth — deliberately NOT flat. The list cards float on top as
- * their own lighter tiles. NO GPU blur/saturate filter behind the surface: it
- * re-samples the layer underneath every frame (#9141 battery decision,
- * enforced by the ui-package no-blur gate test) — the high base opacity
- * carries readability over live launcher content instead.
+ * Solid surface for the controlled shells (sheet + panel). The system is flat:
+ * an opaque token surface (--card) + a hairline border carries the depth, NOT
+ * backdrop blur/saturation or a drop shadow (both removed app-wide: blur trips
+ * the #9141 battery gate, and all shadow tokens are none). The list cards sit
+ * on top as their own token tiles.
  */
 const GLASS_SURFACE =
-  "border border-white/15 bg-neutral-950/[0.87] [box-shadow:inset_0_1px_0_0_rgba(255,255,255,0.18),0_24px_70px_-18px_rgba(0,0,0,0.8)]";
+  "border border-border-strong bg-card";
 
 /**
- * Finger travel (px) that maps to a fully-revealed sheet during a pull. The
- * open threshold (~60px) lands the reveal a little under half, so a committed
- * pull then eases the rest of the way open.
+ * Finger travel (px) that maps to a fully-revealed sheet during a pull. Locked
+ * to the gesture hook's soft cap ({@link REVEAL_SOFT_MAX}) so the finger CARRIES
+ * the whole sheet 1:1: at the soft cap the sheet is fully revealed, and any
+ * further pull rubber-bands (the hook damps travel past the cap). A mismatch is
+ * what made the old pull feel laggy — the sheet trailed the finger because the
+ * cap (96) revealed only ~74% of a 130px sheet.
  */
-const SHEET_REVEAL_DISTANCE = 130;
+const SHEET_REVEAL_DISTANCE = REVEAL_SOFT_MAX;
+
+/**
+ * Overshoot past the fully-open sheet (px) at the rubber-band ceiling. The hook
+ * damps finger travel above the soft cap to a small extra distance; we translate
+ * that into a tiny downward give (never a second full reveal) so a hard over-pull
+ * feels elastic instead of dead-stopped.
+ */
+const SHEET_OVERSHOOT_MAX = 12;
+
+/**
+ * Query for the OS "reduce motion" setting. When set, the sheet/panel skip the
+ * spring settle + descent and appear/disappear instantly (no transition), the
+ * accessibility contract the rest of the shell already honors
+ * ({@link ../../hooks/useHorizontalPager}).
+ */
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+/**
+ * The resting pull-hint's breathe: a slow, low-amplitude opacity + vertical
+ * bob so the grabber pill catches the eye once as "pullable", then settles into
+ * quiet ambient motion. GPU-only (opacity + transform), and it self-disables
+ * under prefers-reduced-motion (the JS path also gates it out entirely) so the
+ * looping-animation motion rule is satisfied belt-and-suspenders.
+ */
+const PULL_HINT_CSS = `
+@keyframes eliza-notif-hint-breathe {
+  0%, 100% { opacity: 0.55; transform: translateY(0); }
+  50% { opacity: 0.9; transform: translateY(1px); }
+}
+.eliza-notif-hint-breathe {
+  animation: eliza-notif-hint-breathe 3.2s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .eliza-notif-hint-breathe { animation: none; opacity: 0.7; }
+}
+`;
 
 const CATEGORY_LABEL: Record<NotificationCategory, string> = {
   reminder: "Reminders",
@@ -154,14 +192,13 @@ function NotificationRow({
   );
 
   return (
-    // iOS-notification-center card: each notification is its own rounded
-    // tile floating on the dark shell — a hairline border + a faint lit top
-    // edge give it depth with zero GPU backdrop filtering (banned app-wide
-    // for battery, #9141; such filters re-rasterize per frame on the phone).
+    // Notification card: each notification is its own rounded token tile on the
+    // solid shell — a hairline border + a token surface fill carry the depth
+    // (flat system: no GPU blur, no drop/inset shadow).
     <li
       className={cn(
-        "group relative flex items-start gap-3 rounded-2xl border border-white/10 bg-white/[0.07] pr-9 transition-colors [box-shadow:inset_0_1px_0_0_rgba(255,255,255,0.08)] hover:bg-white/[0.12] pointer-coarse:pr-12",
-        unread && "border-white/15 bg-white/[0.11]",
+        "group relative flex items-start gap-3 rounded-2xl border border-border bg-surface pr-9 transition-colors hover:bg-bg-hover pointer-coarse:pr-12",
+        unread && "border-border-strong bg-bg-hover",
       )}
     >
       <Button
@@ -176,14 +213,14 @@ function NotificationRow({
               ? "bg-status-danger/20 text-status-danger"
               : notification.priority === "high"
                 ? "bg-accent/20 text-accent"
-                : "bg-white/15 text-white/85",
+                : "bg-surface text-txt",
           )}
         >
           {categoryIcon(notification.category)}
         </span>
         <span className="min-w-0 flex-1">
           <span className="flex items-center gap-2">
-            <span className="truncate text-sm font-medium text-white">
+            <span className="truncate text-sm font-medium text-txt">
               {notification.title}
             </span>
             {unread && (
@@ -191,11 +228,11 @@ function NotificationRow({
             )}
           </span>
           {notification.body && (
-            <span className="mt-0.5 line-clamp-2 block text-xs text-white/70">
+            <span className="mt-0.5 line-clamp-2 block text-xs text-muted-strong">
               {notification.body}
             </span>
           )}
-          <span className="mt-1 block text-[11px] text-white/50">
+          <span className="mt-1 block text-xs-tight text-muted">
             {formatRelativeTime(notification.createdAt)}
           </span>
         </span>
@@ -213,7 +250,7 @@ function NotificationRow({
         // coarse pointer the hit target grows to the 44px `touch` token (the
         // house `pointer-coarse:min-*-touch` convention) so it isn't a
         // sub-target tap zone on the phone sheet.
-        className="absolute right-1.5 top-2.5 h-auto w-auto shrink-0 rounded-full p-1 text-white/60 opacity-50 transition-opacity pointer-coarse:min-h-touch pointer-coarse:min-w-touch hover:bg-white/10 hover:text-white group-hover:opacity-100"
+        className="absolute right-1.5 top-2.5 h-auto w-auto shrink-0 rounded-full p-1 text-muted opacity-50 transition-opacity pointer-coarse:min-h-touch pointer-coarse:min-w-touch hover:bg-bg-hover hover:text-txt group-hover:opacity-100"
       >
         <X className="h-3.5 w-3.5" />
       </Button>
@@ -283,7 +320,7 @@ function FilterChip({
         "h-auto shrink-0 gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors",
         active
           ? "bg-accent text-accent-foreground hover:bg-accent-hover"
-          : "text-white/70 hover:bg-white/10 hover:text-white",
+          : "text-muted-strong hover:bg-bg-hover hover:text-txt",
       )}
     >
       {icon}
@@ -348,6 +385,10 @@ export function NotificationCenter({
   // the overlay is open re-picks the appropriate treatment.
   const isDesktopSurface = useMediaQuery(DESKTOP_PANEL_QUERY);
   const isShortLandscape = useMediaQuery(SHORT_LANDSCAPE_QUERY);
+  // Honor the OS reduce-motion setting: the sheet/panel appear instantly (no
+  // spring, no descent) instead of animating. Reactive so a live OS toggle takes
+  // effect without a remount.
+  const reduceMotion = useMediaQuery(REDUCED_MOTION_QUERY);
 
   // `variant="auto"` lets a controlled caller (e.g. HomeScreen's notification
   // pull-down) render the surface-appropriate shell without owning the media
@@ -381,12 +422,29 @@ export function NotificationCenter({
   const dragProgress = dragging
     ? Math.min(1, Math.max(0, dragPx / SHEET_REVEAL_DISTANCE))
     : 0;
+  // Rubber-band give past a fully-revealed sheet: the hook damps finger travel
+  // above the soft cap, so anything beyond SHEET_REVEAL_DISTANCE maps to a small
+  // elastic downward nudge (capped) rather than more reveal. Only meaningful
+  // while dragging; 0 once settled.
+  const dragOvershootPx =
+    dragging && dragPx > SHEET_REVEAL_DISTANCE
+      ? Math.min(SHEET_OVERSHOOT_MAX, dragPx - SHEET_REVEAL_DISTANCE)
+      : 0;
   const settledTarget = exiting ? 0 : open ? 1 : 0;
   const revealProgress = dragging ? dragProgress : entered ? settledTarget : 0;
-  // Instant while the finger drives it; eased on settle / retract / enter.
-  const revealTransition = dragging
-    ? "none"
-    : "clip-path 320ms cubic-bezier(0.22,1,0.36,1), opacity 260ms ease-out, transform 320ms cubic-bezier(0.22,1,0.36,1)";
+  // Motion contract:
+  //   • dragging → no transition (the finger IS the animation, tracks 1:1);
+  //   • reduce-motion → no transition (instant appear/disappear);
+  //   • settle/retract/enter → a SPRING: a snappy overshoot-and-settle on the
+  //     transform (the tactile "catch" as the sheet finishes opening or springs
+  //     back closed) while clip/opacity ride a clean ease so the reveal edge and
+  //     fade don't wobble. This is what makes a committed pull feel like it
+  //     "lands" instead of gliding to a stop.
+  const SPRING = "cubic-bezier(0.34, 1.32, 0.5, 1)";
+  const revealTransition =
+    dragging || reduceMotion
+      ? "none"
+      : `clip-path 300ms cubic-bezier(0.22,1,0.36,1), opacity 240ms ease-out, transform 360ms ${SPRING}`;
 
   // Categories actually present in the inbox, in a stable display order. Drives
   // the filter chips — empty/single-category inboxes get no filter clutter.
@@ -581,7 +639,39 @@ export function NotificationCenter({
   // panel on mouse-driven wide surfaces, the full-width pull-down sheet on
   // touch/narrow ones. It stays mounted through its exit animation.
   if (headless) {
-    if (!shellMounted) return null;
+    // At rest (sheet fully closed) the headless owner still renders a quiet
+    // affordance so the pull is DISCOVERABLE: a subtle grabber pill peeking at
+    // the top-center edge that says "there's something to pull here", the same
+    // signal an iOS notch/handle gives. It only shows on the touch/narrow
+    // surface (the pull-down sheet's home) — the desktop panel is reached by the
+    // bell/tray, not a pull, so a handle there would be noise. It is purely
+    // decorative (aria-hidden, no pointer events): the invisible pull-zone button
+    // in HomeScreen owns the tap + gesture; this only advertises them. It fades
+    // + lifts away the instant a pull starts so it never fights the live sheet.
+    if (!shellMounted) {
+      // Desktop is reached by the bell/tray, not a pull — a handle there is
+      // noise. Touch/narrow surfaces get the resting hint.
+      if (isDesktopSurface) return null;
+      return overlayPortal(
+        <div
+          aria-hidden
+          data-testid="notification-pull-hint"
+          className="pointer-events-none fixed inset-x-0 top-0 z-[1] flex justify-center pt-[calc(var(--safe-area-top,0px)+0.375rem)]"
+        >
+          {/* Solid token pill — no blur, no shadow. It gently breathes so the
+              eye catches it once as "pullable", then rests; under reduce-motion
+              it holds a plain static pill (the CSS + the JS flag both drop the
+              animation) so the affordance stays without the motion. */}
+          <span
+            className={cn(
+              "h-1 w-8 rounded-full bg-muted-strong/70",
+              !reduceMotion && "eliza-notif-hint-breathe",
+            )}
+          />
+          <style>{PULL_HINT_CSS}</style>
+        </div>,
+      );
+    }
     return (
       <NotificationCenter
         variant="auto"
@@ -603,7 +693,7 @@ export function NotificationCenter({
           hierarchy separate it from the list (app-wide flat direction). */}
       <div className="flex items-center justify-between gap-2 px-3.5 py-2.5">
         <div className="flex min-w-0 items-center gap-2">
-          <span className="text-sm font-semibold text-white">
+          <span className="text-sm font-semibold text-txt">
             Notifications
           </span>
           {hasUnread && (
@@ -619,7 +709,7 @@ export function NotificationCenter({
               size="icon-sm"
               aria-label="Mark all read"
               title="Mark all read"
-              className="text-white/70 hover:bg-white/10 hover:text-white"
+              className="text-muted-strong hover:bg-bg-hover hover:text-txt"
               onClick={handleMarkAll}
             >
               <CheckCheck className="h-4 w-4" />
@@ -631,7 +721,7 @@ export function NotificationCenter({
               size="icon-sm"
               aria-label="Clear all"
               title="Clear all"
-              className="text-white/70 hover:bg-white/10 hover:text-white"
+              className="text-muted-strong hover:bg-bg-hover hover:text-txt"
               onClick={handleClear}
             >
               <Trash2 className="h-4 w-4" />
@@ -651,10 +741,10 @@ export function NotificationCenter({
       )}
       {notifications.length > 1 && (
         <div className="flex items-center gap-2 px-3 py-1.5">
-          <span className="text-2xs font-medium uppercase tracking-wide text-white/60">
+          <span className="text-2xs font-medium uppercase tracking-wide text-muted">
             Sort
           </span>
-          <div className="ml-auto flex items-center gap-0.5 rounded-md bg-white/10 p-0.5">
+          <div className="ml-auto flex items-center gap-0.5 rounded-md bg-surface p-0.5">
             {(
               [
                 ["priority", "Priority"],
@@ -672,7 +762,7 @@ export function NotificationCenter({
                   "h-auto rounded-sm px-2 py-0.5 text-2xs font-medium transition-colors",
                   sortMode === mode
                     ? "bg-accent/15 text-accent"
-                    : "text-white/60 hover:text-white",
+                    : "text-muted hover:text-txt",
                 )}
               >
                 {label}
@@ -696,13 +786,13 @@ export function NotificationCenter({
               (which would flash then get replaced when rows arrive). */}
           {hydrated ? (
             <>
-              <Inbox className="h-7 w-7 text-white/50" />
-              <span className="text-sm text-white/70">
+              <Inbox className="h-7 w-7 text-muted" />
+              <span className="text-sm text-muted-strong">
                 You're all caught up
               </span>
             </>
           ) : (
-            <span className="text-sm text-white/70">Loading…</span>
+            <span className="text-sm text-muted-strong">Loading…</span>
           )}
         </div>
       ) : (
@@ -759,7 +849,7 @@ export function NotificationCenter({
             transition: revealTransition,
             pointerEvents: open ? "auto" : "none",
           }}
-          className="fixed inset-0 h-auto w-auto rounded-none bg-black/55 p-0 hover:bg-black/55"
+          className="fixed inset-0 h-auto w-auto rounded-none bg-scrim p-0 hover:bg-scrim"
         />
         <div
           ref={dialogRef}
@@ -778,7 +868,12 @@ export function NotificationCenter({
             // lead as it descends; fade + a small settle ride along.
             clipPath: `inset(0px 0px ${(1 - revealProgress) * 100}% 0px)`,
             opacity: Math.min(1, revealProgress * 2),
-            transform: `translateY(${(revealProgress - 1) * 10}px)`,
+            // Descent + rubber-band: a small lift-in as it settles (skipped under
+            // reduce-motion) plus the elastic over-pull give at the fully-open
+            // ceiling, so a hard pull past the bottom feels stretchy, not walled.
+            transform: reduceMotion
+              ? "none"
+              : `translateY(${(revealProgress - 1) * 10 + dragOvershootPx}px)`,
             transition: revealTransition,
             pointerEvents: open ? "auto" : "none",
           }}
@@ -801,7 +896,7 @@ export function NotificationCenter({
             onClick={() => onOpenChange?.(false)}
             className="h-auto shrink-0 rounded-none bg-transparent py-2 hover:bg-transparent"
           >
-            <span className="h-1 w-9 rounded-full bg-white/40" aria-hidden />
+            <span className="h-1 w-9 rounded-full bg-muted-strong" aria-hidden />
           </Button>
         </div>
       </>,
@@ -843,9 +938,12 @@ export function NotificationCenter({
           onKeyDown={onDialogKeyDown}
           style={{
             zIndex: Z_NOTIFICATION_OVERLAY,
-            // No drag on desktop — just a quick fade + small drop on open/close.
+            // No drag on desktop — just a quick fade + small spring-drop on
+            // open/close (instant under reduce-motion).
             opacity: revealProgress,
-            transform: `translateY(${(revealProgress - 1) * 8}px)`,
+            transform: reduceMotion
+              ? "none"
+              : `translateY(${(revealProgress - 1) * 8}px)`,
             transition: revealTransition,
           }}
           className={cn(

--- a/packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx
@@ -81,6 +81,23 @@ const startEmpty = params.has("empty");
 // is visible instead of a long scrolling transcript.
 const firstRun = params.has("firstrun");
 const fewMessages = params.has("few") || firstRun;
+// `?many` seeds a LONG transcript (far taller than any detent) so the scroll
+// container's overflow can be reproduced/measured in a real browser: at the FULL
+// detent the content must exceed the panel height and the thread must scroll
+// natively (the "can't scroll chat on web" repro harness, #chat-scroll-web).
+const manyMessages = params.has("many");
+const MANY_SEED: ShellMessage[] = Array.from({ length: 40 }, (_, i) => {
+  const role: ShellMessage["role"] = i % 2 === 0 ? "user" : "assistant";
+  return {
+    id: `many-${i}`,
+    role,
+    content:
+      role === "user"
+        ? `message number ${i + 1} — a question that takes a full line to read`
+        : `reply ${i + 1}: here is a deliberately long answer so the transcript grows well past the tallest sheet detent and the scroll container has real overflow to scroll through on every viewport.`,
+    createdAt: i + 1,
+  } as ShellMessage;
+});
 const FEW_SEED: ShellMessage[] = [
   {
     id: "f1",
@@ -135,14 +152,21 @@ function Harness(): React.JSX.Element {
   const [messages, setMessages] = React.useState<ShellMessage[]>(
     startEmpty
       ? []
-      : fewMessages
-        ? FEW_SEED
-        : streaming
-          ? [
-              ...SEED,
-              { id: "m-inflight", role: "assistant", content: "", createdAt: 13 },
-            ]
-          : SEED_WITH_FAILURE,
+      : manyMessages
+        ? MANY_SEED
+        : fewMessages
+          ? FEW_SEED
+          : streaming
+            ? [
+                ...SEED,
+                {
+                  id: "m-inflight",
+                  role: "assistant",
+                  content: "",
+                  createdAt: 13,
+                },
+              ]
+            : SEED_WITH_FAILURE,
   );
   const [phase, setPhase] =
     React.useState<ShellController["phase"]>(initialPhase);

--- a/packages/ui/src/components/shell/__e2e__/output-home/home-screen.html
+++ b/packages/ui/src/components/shell/__e2e__/output-home/home-screen.html
@@ -1,8 +1,15 @@
 <!doctype html><html><head><meta charset="utf-8"><title>home screen e2e</title>
-<script src="https://cdn.tailwindcss.com"></script><script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};</script>
-<style>html,body{margin:0;height:100%;background:#0a0d16}</style>
+<!-- Match the real app's viewport (packages/app/index.html): without it a
+     mobile page falls back to the 980px layout viewport, so CSS `vw` units
+     (the sheet's `w-[min(440px,100vw-1rem)]`) mis-measure and the overlay
+     mis-centers — a test-only artifact that hid the real overlay geometry. -->
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
-<style>:root{--eliza-continuous-chat-clearance:5.25rem;--safe-area-bottom:0px;--eliza-mobile-nav-offset:0px}</style>
+<script src="https://cdn.tailwindcss.com"></script>
+<style>html,body{margin:0;height:100%;background:#0a0d16}
+:root{--eliza-continuous-chat-clearance:5.25rem;--safe-area-bottom:0px;--eliza-mobile-nav-offset:0px}</style>
+<!-- Shim node-ish globals some of the dead-in-browser graph touches at module
+     init (e.g. `process.env`). The real code paths never execute at render. -->
+<script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};</script>
 </head><body><div id="root"></div><script>"use strict";
 (() => {
   var __create = Object.create;
@@ -47,9 +54,9 @@
     mod
   ));
 
-  // ../pr-12727-run/node_modules/.bun/scheduler@0.27.0/node_modules/scheduler/cjs/scheduler.production.js
+  // ../../../node_modules/.bun/scheduler@0.27.0/node_modules/scheduler/cjs/scheduler.production.js
   var require_scheduler_production = __commonJS({
-    "../pr-12727-run/node_modules/.bun/scheduler@0.27.0/node_modules/scheduler/cjs/scheduler.production.js"(exports) {
+    "../../../node_modules/.bun/scheduler@0.27.0/node_modules/scheduler/cjs/scheduler.production.js"(exports) {
       "use strict";
       function push(heap, node) {
         var index2 = heap.length;
@@ -320,9 +327,9 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/scheduler@0.27.0/node_modules/scheduler/index.js
+  // ../../../node_modules/.bun/scheduler@0.27.0/node_modules/scheduler/index.js
   var require_scheduler = __commonJS({
-    "../pr-12727-run/node_modules/.bun/scheduler@0.27.0/node_modules/scheduler/index.js"(exports, module) {
+    "../../../node_modules/.bun/scheduler@0.27.0/node_modules/scheduler/index.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_scheduler_production();
@@ -332,9 +339,9 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/react@19.2.5/node_modules/react/cjs/react.production.js
+  // ../../../node_modules/.bun/react@19.2.5/node_modules/react/cjs/react.production.js
   var require_react_production = __commonJS({
-    "../pr-12727-run/node_modules/.bun/react@19.2.5/node_modules/react/cjs/react.production.js"(exports) {
+    "../../../node_modules/.bun/react@19.2.5/node_modules/react/cjs/react.production.js"(exports) {
       "use strict";
       var REACT_ELEMENT_TYPE = /* @__PURE__ */ Symbol.for("react.transitional.element");
       var REACT_PORTAL_TYPE = /* @__PURE__ */ Symbol.for("react.portal");
@@ -773,9 +780,9 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/react@19.2.5/node_modules/react/index.js
+  // ../../../node_modules/.bun/react@19.2.5/node_modules/react/index.js
   var require_react = __commonJS({
-    "../pr-12727-run/node_modules/.bun/react@19.2.5/node_modules/react/index.js"(exports, module) {
+    "../../../node_modules/.bun/react@19.2.5/node_modules/react/index.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_react_production();
@@ -785,11 +792,11 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/react-dom@19.2.5+3f10a4be4e334a9b/node_modules/react-dom/cjs/react-dom.production.js
+  // ../../../node_modules/.bun/react-dom@19.2.5+3f10a4be4e334a9b/node_modules/react-dom/cjs/react-dom.production.js
   var require_react_dom_production = __commonJS({
-    "../pr-12727-run/node_modules/.bun/react-dom@19.2.5+3f10a4be4e334a9b/node_modules/react-dom/cjs/react-dom.production.js"(exports) {
+    "../../../node_modules/.bun/react-dom@19.2.5+3f10a4be4e334a9b/node_modules/react-dom/cjs/react-dom.production.js"(exports) {
       "use strict";
-      var React63 = require_react();
+      var React60 = require_react();
       function formatProdErrorMessage(code) {
         var url2 = "https://react.dev/errors/" + code;
         if (1 < arguments.length) {
@@ -829,7 +836,7 @@
           implementation
         };
       }
-      var ReactSharedInternals = React63.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+      var ReactSharedInternals = React60.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
       function getCrossOriginStringAs(as, input) {
         if ("font" === as) return "";
         if ("string" === typeof input)
@@ -934,9 +941,9 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/react-dom@19.2.5+3f10a4be4e334a9b/node_modules/react-dom/index.js
+  // ../../../node_modules/.bun/react-dom@19.2.5+3f10a4be4e334a9b/node_modules/react-dom/index.js
   var require_react_dom = __commonJS({
-    "../pr-12727-run/node_modules/.bun/react-dom@19.2.5+3f10a4be4e334a9b/node_modules/react-dom/index.js"(exports, module) {
+    "../../../node_modules/.bun/react-dom@19.2.5+3f10a4be4e334a9b/node_modules/react-dom/index.js"(exports, module) {
       "use strict";
       function checkDCE() {
         if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === "undefined" || typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE !== "function") {
@@ -960,12 +967,12 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/react-dom@19.2.5+3f10a4be4e334a9b/node_modules/react-dom/cjs/react-dom-client.production.js
+  // ../../../node_modules/.bun/react-dom@19.2.5+3f10a4be4e334a9b/node_modules/react-dom/cjs/react-dom-client.production.js
   var require_react_dom_client_production = __commonJS({
-    "../pr-12727-run/node_modules/.bun/react-dom@19.2.5+3f10a4be4e334a9b/node_modules/react-dom/cjs/react-dom-client.production.js"(exports) {
+    "../../../node_modules/.bun/react-dom@19.2.5+3f10a4be4e334a9b/node_modules/react-dom/cjs/react-dom-client.production.js"(exports) {
       "use strict";
       var Scheduler = require_scheduler();
-      var React63 = require_react();
+      var React60 = require_react();
       var ReactDOM5 = require_react_dom();
       function formatProdErrorMessage(code) {
         var url2 = "https://react.dev/errors/" + code;
@@ -1156,7 +1163,7 @@
         return null;
       }
       var isArrayImpl = Array.isArray;
-      var ReactSharedInternals = React63.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+      var ReactSharedInternals = React60.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
       var ReactDOMSharedInternals = ReactDOM5.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
       var sharedNotPendingObject = {
         pending: false,
@@ -12602,7 +12609,7 @@
           0 === i && attemptExplicitHydrationTarget(target);
         }
       };
-      var isomorphicReactPackageVersion$jscomp$inline_1840 = React63.version;
+      var isomorphicReactPackageVersion$jscomp$inline_1840 = React60.version;
       if ("19.2.5" !== isomorphicReactPackageVersion$jscomp$inline_1840)
         throw Error(
           formatProdErrorMessage(
@@ -12701,9 +12708,9 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/react-dom@19.2.5+3f10a4be4e334a9b/node_modules/react-dom/client.js
+  // ../../../node_modules/.bun/react-dom@19.2.5+3f10a4be4e334a9b/node_modules/react-dom/client.js
   var require_client = __commonJS({
-    "../pr-12727-run/node_modules/.bun/react-dom@19.2.5+3f10a4be4e334a9b/node_modules/react-dom/client.js"(exports, module) {
+    "../../../node_modules/.bun/react-dom@19.2.5+3f10a4be4e334a9b/node_modules/react-dom/client.js"(exports, module) {
       "use strict";
       function checkDCE() {
         if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === "undefined" || typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE !== "function") {
@@ -12907,10 +12914,10 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/@capacitor+core@8.4.0/node_modules/@capacitor/core/dist/index.js
+  // ../../../node_modules/.bun/@capacitor+core@8.4.0/node_modules/@capacitor/core/dist/index.js
   var ExceptionCode, CapacitorException, getPlatformId, createCapacitor, initCapacitorGlobal, Capacitor, registerPlugin, WebPlugin, encode, decode, CapacitorCookiesPluginWeb, CapacitorCookies, readBlobAsBase64, normalizeHttpHeaders, buildUrlParams, buildRequestInit, CapacitorHttpPluginWeb, CapacitorHttp, SystemBarsStyle, SystemBarType, SystemBarsPluginWeb, SystemBars;
   var init_dist = __esm({
-    "../pr-12727-run/node_modules/.bun/@capacitor+core@8.4.0/node_modules/@capacitor/core/dist/index.js"() {
+    "../../../node_modules/.bun/@capacitor+core@8.4.0/node_modules/@capacitor/core/dist/index.js"() {
       (function(ExceptionCode2) {
         ExceptionCode2["Unimplemented"] = "UNIMPLEMENTED";
         ExceptionCode2["Unavailable"] = "UNAVAILABLE";
@@ -13416,93 +13423,6 @@
     }
   });
 
-  // packages/shared/src/events/index.ts
-  function createNavigateViewEvent(detail) {
-    return new CustomEvent(NAVIGATE_VIEW_EVENT, { detail });
-  }
-  function dispatchNavigateViewEvent(detail) {
-    if (typeof window === "undefined") return;
-    window.dispatchEvent(createNavigateViewEvent(detail));
-  }
-  var NETWORK_STATUS_CHANGE_EVENT, NAVIGATE_VIEW_EVENT, SHELL_NAVIGATE_VIEW_WS_EVENT;
-  var init_events = __esm({
-    "packages/shared/src/events/index.ts"() {
-      "use strict";
-      NETWORK_STATUS_CHANGE_EVENT = "eliza:network-status-change";
-      NAVIGATE_VIEW_EVENT = "eliza:navigate:view";
-      SHELL_NAVIGATE_VIEW_WS_EVENT = "shell:navigate:view";
-    }
-  });
-
-  // packages/shared/src/events.ts
-  var init_events2 = __esm({
-    "packages/shared/src/events.ts"() {
-      "use strict";
-      init_events();
-    }
-  });
-
-  // packages/ui/src/views/view-event-bus.ts
-  var init_view_event_bus = __esm({
-    "packages/ui/src/views/view-event-bus.ts"() {
-      "use strict";
-    }
-  });
-
-  // packages/ui/src/hooks/useViewEvent.ts
-  var import_react2;
-  var init_useViewEvent = __esm({
-    "packages/ui/src/hooks/useViewEvent.ts"() {
-      "use strict";
-      import_react2 = __toESM(require_react(), 1);
-      init_view_event_bus();
-    }
-  });
-
-  // packages/ui/src/views/view-event-types.ts
-  var init_view_event_types = __esm({
-    "packages/ui/src/views/view-event-types.ts"() {
-      "use strict";
-    }
-  });
-
-  // packages/ui/src/events/index.ts
-  function dispatchChatPrefill(detail) {
-    if (typeof window === "undefined") return;
-    window.dispatchEvent(new CustomEvent(CHAT_PREFILL_EVENT, { detail }));
-  }
-  function dispatchChatOpen() {
-    if (typeof window === "undefined") return;
-    window.dispatchEvent(new CustomEvent(CHAT_OPEN_EVENT));
-  }
-  function dispatchOpenNotificationCenter() {
-    if (typeof window === "undefined") return;
-    window.dispatchEvent(new CustomEvent(OPEN_NOTIFICATION_CENTER_EVENT));
-  }
-  function dispatchWindowEvent(name, detail) {
-    if (typeof window === "undefined") return;
-    window.dispatchEvent(new CustomEvent(name, { detail }));
-  }
-  function dispatchCloudHandoffRetry(detail) {
-    dispatchWindowEvent(CLOUD_HANDOFF_RETRY_EVENT, detail);
-  }
-  var CLOUD_HANDOFF_PHASE_EVENT, CLOUD_HANDOFF_RETRY_EVENT, CHAT_PREFILL_EVENT, CHAT_OPEN_EVENT, OPEN_NOTIFICATION_CENTER_EVENT, ELIZA_BACK_INTENT_EVENT;
-  var init_events3 = __esm({
-    "packages/ui/src/events/index.ts"() {
-      "use strict";
-      init_events2();
-      init_useViewEvent();
-      init_view_event_bus();
-      init_view_event_types();
-      CLOUD_HANDOFF_PHASE_EVENT = "eliza:cloud-handoff-phase";
-      CLOUD_HANDOFF_RETRY_EVENT = "eliza:cloud-handoff-retry";
-      CHAT_PREFILL_EVENT = "eliza:chat:prefill";
-      CHAT_OPEN_EVENT = "eliza:chat:open";
-      OPEN_NOTIFICATION_CENTER_EVENT = "eliza:notifications:open";
-      ELIZA_BACK_INTENT_EVENT = "eliza:back-intent";
-    }
-  });
-
   // packages/ui/src/state/notifications/navigate-deep-link.ts
   function isSafeDeepLink(deepLink) {
     if (typeof deepLink !== "string") return false;
@@ -13517,13 +13437,16 @@
     }
     if (deepLink.startsWith("/") && !deepLink.startsWith("//")) {
       const viewId = deepLink.slice(1).split("/")[0] || void 0;
-      dispatchNavigateViewEvent({ viewId, viewPath: deepLink });
+      window.dispatchEvent(
+        new CustomEvent("eliza:navigate:view", {
+          detail: { viewId, viewPath: deepLink }
+        })
+      );
     }
   }
   var init_navigate_deep_link = __esm({
     "packages/ui/src/state/notifications/navigate-deep-link.ts"() {
       "use strict";
-      init_events3();
     }
   });
 
@@ -13541,10 +13464,6 @@
   }
   function getNativePlugin(name) {
     return getCapacitorPlugins()[name] ?? {};
-  }
-  function getAgentPlugin() {
-    const plugins = getCapacitorPlugins();
-    return plugins.Agent ?? Capacitor.registerPlugin("Agent") ?? {};
   }
   var init_native_plugins = __esm({
     "packages/ui/src/bridge/native-plugins.ts"() {
@@ -13855,7 +13774,7 @@
     return state;
   }
   function useNotifications() {
-    return (0, import_react3.useSyncExternalStore)(subscribe2, getSnapshot, getSnapshot);
+    return (0, import_react2.useSyncExternalStore)(subscribe2, getSnapshot, getSnapshot);
   }
   function __resetNotificationStoreForTests() {
     state = { notifications: [], unreadCount: 0, hydrated: false };
@@ -13866,12 +13785,12 @@
   function __ingestNotificationForTests(notification, unreadCount) {
     ingest(notification, unreadCount);
   }
-  var import_core3, import_react3, state, listeners, initialized, toastSink, NOTIFICATION_CATEGORIES, NOTIFICATION_PRIORITIES;
+  var import_core3, import_react2, state, listeners, initialized, toastSink, NOTIFICATION_CATEGORIES, NOTIFICATION_PRIORITIES;
   var init_notification_store = __esm({
     "packages/ui/src/state/notifications/notification-store.ts"() {
       "use strict";
       import_core3 = __toESM(require_core(), 1);
-      import_react3 = __toESM(require_react(), 1);
+      import_react2 = __toESM(require_react(), 1);
       init_home_screen_fixture_api_stub();
       init_electrobun_rpc();
       init_native_notifications();
@@ -14221,9 +14140,9 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/react@19.2.5/node_modules/react/cjs/react-jsx-runtime.production.js
+  // ../../../node_modules/.bun/react@19.2.5/node_modules/react/cjs/react-jsx-runtime.production.js
   var require_react_jsx_runtime_production = __commonJS({
-    "../pr-12727-run/node_modules/.bun/react@19.2.5/node_modules/react/cjs/react-jsx-runtime.production.js"(exports) {
+    "../../../node_modules/.bun/react@19.2.5/node_modules/react/cjs/react-jsx-runtime.production.js"(exports) {
       "use strict";
       var REACT_ELEMENT_TYPE = /* @__PURE__ */ Symbol.for("react.transitional.element");
       var REACT_FRAGMENT_TYPE = /* @__PURE__ */ Symbol.for("react.fragment");
@@ -14251,9 +14170,9 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/react@19.2.5/node_modules/react/jsx-runtime.js
+  // ../../../node_modules/.bun/react@19.2.5/node_modules/react/jsx-runtime.js
   var require_jsx_runtime = __commonJS({
-    "../pr-12727-run/node_modules/.bun/react@19.2.5/node_modules/react/jsx-runtime.js"(exports, module) {
+    "../../../node_modules/.bun/react@19.2.5/node_modules/react/jsx-runtime.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_react_jsx_runtime_production();
@@ -14317,9 +14236,9 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/picocolors@1.1.1/node_modules/picocolors/picocolors.browser.js
+  // ../../../node_modules/.bun/picocolors@1.1.1/node_modules/picocolors/picocolors.browser.js
   var require_picocolors_browser = __commonJS({
-    "../pr-12727-run/node_modules/.bun/picocolors@1.1.1/node_modules/picocolors/picocolors.browser.js"(exports, module) {
+    "../../../node_modules/.bun/picocolors@1.1.1/node_modules/picocolors/picocolors.browser.js"(exports, module) {
       var x = String;
       var create = function() {
         return { isColorSupported: false, reset: x, bold: x, dim: x, italic: x, underline: x, inverse: x, hidden: x, strikethrough: x, black: x, red: x, green: x, yellow: x, blue: x, magenta: x, cyan: x, white: x, gray: x, bgBlack: x, bgRed: x, bgGreen: x, bgYellow: x, bgBlue: x, bgMagenta: x, bgCyan: x, bgWhite: x, blackBright: x, redBright: x, greenBright: x, yellowBright: x, blueBright: x, magentaBright: x, cyanBright: x, whiteBright: x, bgBlackBright: x, bgRedBright: x, bgGreenBright: x, bgYellowBright: x, bgBlueBright: x, bgMagentaBright: x, bgCyanBright: x, bgWhiteBright: x };
@@ -14329,9 +14248,9 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/validator.js
+  // ../../../node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/validator.js
   var require_validator = __commonJS({
-    "../pr-12727-run/node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/validator.js"(exports, module) {
+    "../../../node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/validator.js"(exports, module) {
       "use strict";
       module.exports = validator;
       function validator(opts = {}) {
@@ -14364,17 +14283,17 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/rx.js
+  // ../../../node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/rx.js
   var require_rx = __commonJS({
-    "../pr-12727-run/node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/rx.js"(exports, module) {
+    "../../../node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/rx.js"(exports, module) {
       "use strict";
       module.exports = /[^.[\]]+|\[((?:.)*?)\]/g;
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/parse.js
+  // ../../../node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/parse.js
   var require_parse = __commonJS({
-    "../pr-12727-run/node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/parse.js"(exports, module) {
+    "../../../node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/parse.js"(exports, module) {
       "use strict";
       var rx = require_rx();
       module.exports = parse4;
@@ -14418,9 +14337,9 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/redactor.js
+  // ../../../node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/redactor.js
   var require_redactor = __commonJS({
-    "../pr-12727-run/node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/redactor.js"(exports, module) {
+    "../../../node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/redactor.js"(exports, module) {
       "use strict";
       var rx = require_rx();
       module.exports = redactor;
@@ -14514,9 +14433,9 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/modifiers.js
+  // ../../../node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/modifiers.js
   var require_modifiers = __commonJS({
-    "../pr-12727-run/node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/modifiers.js"(exports, module) {
+    "../../../node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/modifiers.js"(exports, module) {
       "use strict";
       module.exports = {
         groupRedact,
@@ -14734,9 +14653,9 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/restorer.js
+  // ../../../node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/restorer.js
   var require_restorer = __commonJS({
-    "../pr-12727-run/node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/restorer.js"(exports, module) {
+    "../../../node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/restorer.js"(exports, module) {
       "use strict";
       var { groupRestore, nestedRestore } = require_modifiers();
       module.exports = restorer;
@@ -14796,9 +14715,9 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/state.js
+  // ../../../node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/state.js
   var require_state = __commonJS({
-    "../pr-12727-run/node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/state.js"(exports, module) {
+    "../../../node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/lib/state.js"(exports, module) {
       "use strict";
       module.exports = state4;
       function state4(o) {
@@ -14820,9 +14739,9 @@
     }
   });
 
-  // ../pr-12727-run/node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/index.js
+  // ../../../node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/index.js
   var require_fast_redact = __commonJS({
-    "../pr-12727-run/node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/index.js"(exports, module) {
+    "../../../node_modules/.bun/fast-redact@3.5.0/node_modules/fast-redact/index.js"(exports, module) {
       "use strict";
       var validator = require_validator();
       var parse4 = require_parse();
@@ -15026,12 +14945,41 @@
 
   // packages/ui/src/components/pages/LauncherSurface.tsx
   var React35 = __toESM(require_react(), 1);
-  init_events3();
+
+  // packages/shared/src/events/index.ts
+  var NETWORK_STATUS_CHANGE_EVENT = "eliza:network-status-change";
+
+  // packages/ui/src/hooks/useViewEvent.ts
+  var import_react3 = __toESM(require_react(), 1);
+
+  // packages/ui/src/events/index.ts
+  var CLOUD_HANDOFF_PHASE_EVENT = "eliza:cloud-handoff-phase";
+  var CLOUD_HANDOFF_RETRY_EVENT = "eliza:cloud-handoff-retry";
+  var CHAT_PREFILL_EVENT = "eliza:chat:prefill";
+  var CHAT_OPEN_EVENT = "eliza:chat:open";
+  var OPEN_NOTIFICATION_CENTER_EVENT = "eliza:notifications:open";
+  function dispatchChatPrefill(detail) {
+    if (typeof window === "undefined") return;
+    window.dispatchEvent(new CustomEvent(CHAT_PREFILL_EVENT, { detail }));
+  }
+  function dispatchChatOpen() {
+    if (typeof window === "undefined") return;
+    window.dispatchEvent(new CustomEvent(CHAT_OPEN_EVENT));
+  }
+  function dispatchOpenNotificationCenter() {
+    if (typeof window === "undefined") return;
+    window.dispatchEvent(new CustomEvent(OPEN_NOTIFICATION_CENTER_EVENT));
+  }
+  var ELIZA_BACK_INTENT_EVENT = "eliza:back-intent";
+  function dispatchWindowEvent(name, detail) {
+    if (typeof window === "undefined") return;
+    window.dispatchEvent(new CustomEvent(name, { detail }));
+  }
+  function dispatchCloudHandoffRetry(detail) {
+    dispatchWindowEvent(CLOUD_HANDOFF_RETRY_EVENT, detail);
+  }
 
   // packages/ui/src/components/shell/__e2e__/home-screen-fixture.views-stub.ts
-  async function fetchAvailableViews() {
-    return [];
-  }
   function builtinView(id, label, path, icon, visibleInManager = false, heroImageUrl) {
     return {
       id,
@@ -15080,14 +15028,7 @@
         builtinView("chat", "Chat", "/chat"),
         builtinView("views", "Views", "/views"),
         builtinView("shopify", "Shopify", "/shopify", "ShoppingBag", true),
-        // Wallet sub-page: the real plugin-hyperliquid registration carries
-        // `group: "wallet"`, which is what launcher curation keys on to fold it
-        // under the single Wallet tile (#12521) — mirror it here so the e2e
-        // exercises the real group-based hide, not the removed id blocklist.
-        {
-          ...builtinView("hyperliquid", "Hyperliquid", "/hyperliquid", "TrendingUp", true),
-          group: "wallet"
-        },
+        builtinView("hyperliquid", "Hyperliquid", "/hyperliquid", "TrendingUp", true),
         // Page 1 — everyday apps (curated order is enforced by launcher-curation).
         builtinView("wallet", "Wallet", "/wallet", "Wallet", true, heroDataUri(28, "wallet")),
         // Duplicate wallet registration — must collapse to the single Wallet tile.
@@ -15238,7 +15179,6 @@
       developerOnly: view.developerOnly,
       viewKind: view.viewKind,
       order: view.order,
-      group: view.group,
       view
     };
   }
@@ -15246,33 +15186,33 @@
   // packages/ui/src/navigation/index.ts
   init_dist();
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/createLucideIcon.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/createLucideIcon.mjs
   var import_react6 = __toESM(require_react(), 1);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/shared/src/utils/mergeClasses.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/shared/src/utils/mergeClasses.mjs
   var mergeClasses = (...classes) => classes.filter((className, index2, array2) => {
     return Boolean(className) && className.trim() !== "" && array2.indexOf(className) === index2;
   }).join(" ").trim();
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/shared/src/utils/toKebabCase.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/shared/src/utils/toKebabCase.mjs
   var toKebabCase = (string4) => string4.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/shared/src/utils/toCamelCase.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/shared/src/utils/toCamelCase.mjs
   var toCamelCase = (string4) => string4.replace(
     /^([A-Z])|[\s-_]+(\w)/g,
     (match, p1, p2) => p2 ? p2.toUpperCase() : p1.toLowerCase()
   );
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/shared/src/utils/toPascalCase.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/shared/src/utils/toPascalCase.mjs
   var toPascalCase = (string4) => {
     const camelCase = toCamelCase(string4);
     return camelCase.charAt(0).toUpperCase() + camelCase.slice(1);
   };
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/Icon.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/Icon.mjs
   var import_react5 = __toESM(require_react(), 1);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/defaultAttributes.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/defaultAttributes.mjs
   var defaultAttributes = {
     xmlns: "http://www.w3.org/2000/svg",
     width: 24,
@@ -15285,7 +15225,7 @@
     strokeLinejoin: "round"
   };
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/shared/src/utils/hasA11yProp.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/shared/src/utils/hasA11yProp.mjs
   var hasA11yProp = (props) => {
     for (const prop in props) {
       if (prop.startsWith("aria-") || prop === "role" || prop === "title") {
@@ -15295,12 +15235,12 @@
     return false;
   };
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/context.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/context.mjs
   var import_react4 = __toESM(require_react(), 1);
   var LucideContext = (0, import_react4.createContext)({});
   var useLucideContext = () => (0, import_react4.useContext)(LucideContext);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/Icon.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/Icon.mjs
   var Icon = (0, import_react5.forwardRef)(
     ({ color, size: size4, strokeWidth, absoluteStrokeWidth, className = "", children, iconNode, ...rest }, ref) => {
       const {
@@ -15332,7 +15272,7 @@
     }
   );
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/createLucideIcon.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/createLucideIcon.mjs
   var createLucideIcon = (iconName, iconNode) => {
     const Component2 = (0, import_react6.forwardRef)(
       ({ className, ...props }, ref) => (0, import_react6.createElement)(Icon, {
@@ -15350,7 +15290,7 @@
     return Component2;
   };
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/activity.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/activity.mjs
   var __iconNode = [
     [
       "path",
@@ -15362,7 +15302,7 @@
   ];
   var Activity = createLucideIcon("activity", __iconNode);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/app-window.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/app-window.mjs
   var __iconNode2 = [
     ["rect", { x: "2", y: "4", width: "20", height: "16", rx: "2", key: "izxlao" }],
     ["path", { d: "M10 4v4", key: "pp8u80" }],
@@ -15371,7 +15311,7 @@
   ];
   var AppWindow = createLucideIcon("app-window", __iconNode2);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/bell-ring.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/bell-ring.mjs
   var __iconNode3 = [
     ["path", { d: "M10.268 21a2 2 0 0 0 3.464 0", key: "vwvbt9" }],
     ["path", { d: "M22 8c0-2.3-.8-4.3-2-6", key: "5bb3ad" }],
@@ -15386,7 +15326,7 @@
   ];
   var BellRing = createLucideIcon("bell-ring", __iconNode3);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/bell.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/bell.mjs
   var __iconNode4 = [
     ["path", { d: "M10.268 21a2 2 0 0 0 3.464 0", key: "vwvbt9" }],
     [
@@ -15399,7 +15339,7 @@
   ];
   var Bell = createLucideIcon("bell", __iconNode4);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/bot.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/bot.mjs
   var __iconNode5 = [
     ["path", { d: "M12 8V4H8", key: "hb8ula" }],
     ["rect", { width: "16", height: "12", x: "4", y: "8", rx: "2", key: "enze0r" }],
@@ -15410,7 +15350,7 @@
   ];
   var Bot = createLucideIcon("bot", __iconNode5);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/brain-circuit.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/brain-circuit.mjs
   var __iconNode6 = [
     [
       "path",
@@ -15434,14 +15374,14 @@
   ];
   var BrainCircuit = createLucideIcon("brain-circuit", __iconNode6);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/briefcase.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/briefcase.mjs
   var __iconNode7 = [
     ["path", { d: "M16 20V4a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16", key: "jecpp" }],
     ["rect", { width: "20", height: "14", x: "2", y: "6", rx: "2", key: "i6l2r4" }]
   ];
   var Briefcase = createLucideIcon("briefcase", __iconNode7);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/calendar-clock.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/calendar-clock.mjs
   var __iconNode8 = [
     ["path", { d: "M16 14v2.2l1.6 1", key: "fo4ql5" }],
     ["path", { d: "M16 2v4", key: "4m81vk" }],
@@ -15452,7 +15392,7 @@
   ];
   var CalendarClock = createLucideIcon("calendar-clock", __iconNode8);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/calendar-days.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/calendar-days.mjs
   var __iconNode9 = [
     ["path", { d: "M8 2v4", key: "1cmpym" }],
     ["path", { d: "M16 2v4", key: "4m81vk" }],
@@ -15467,7 +15407,7 @@
   ];
   var CalendarDays = createLucideIcon("calendar-days", __iconNode9);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/camera.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/camera.mjs
   var __iconNode10 = [
     [
       "path",
@@ -15480,7 +15420,7 @@
   ];
   var Camera = createLucideIcon("camera", __iconNode10);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/chart-no-axes-column.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/chart-no-axes-column.mjs
   var __iconNode11 = [
     ["path", { d: "M5 21v-6", key: "1hz6c0" }],
     ["path", { d: "M12 21V3", key: "1lcnhd" }],
@@ -15488,34 +15428,34 @@
   ];
   var ChartNoAxesColumn = createLucideIcon("chart-no-axes-column", __iconNode11);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/check-check.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/check-check.mjs
   var __iconNode12 = [
     ["path", { d: "M18 6 7 17l-5-5", key: "116fxf" }],
     ["path", { d: "m22 10-7.5 7.5L13 16", key: "ke71qq" }]
   ];
   var CheckCheck = createLucideIcon("check-check", __iconNode12);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/check.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/check.mjs
   var __iconNode13 = [["path", { d: "M20 6 9 17l-5-5", key: "1gmf2c" }]];
   var Check = createLucideIcon("check", __iconNode13);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/chevron-down.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/chevron-down.mjs
   var __iconNode14 = [["path", { d: "m6 9 6 6 6-6", key: "qrunsl" }]];
   var ChevronDown = createLucideIcon("chevron-down", __iconNode14);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/chevron-left.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/chevron-left.mjs
   var __iconNode15 = [["path", { d: "m15 18-6-6 6-6", key: "1wnfg3" }]];
   var ChevronLeft = createLucideIcon("chevron-left", __iconNode15);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/chevron-right.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/chevron-right.mjs
   var __iconNode16 = [["path", { d: "m9 18 6-6-6-6", key: "mthhwq" }]];
   var ChevronRight = createLucideIcon("chevron-right", __iconNode16);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/chevron-up.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/chevron-up.mjs
   var __iconNode17 = [["path", { d: "m18 15-6-6-6 6", key: "153udz" }]];
   var ChevronUp = createLucideIcon("chevron-up", __iconNode17);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/circle-alert.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/circle-alert.mjs
   var __iconNode18 = [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["line", { x1: "12", x2: "12", y1: "8", y2: "12", key: "1pkeuh" }],
@@ -15523,7 +15463,7 @@
   ];
   var CircleAlert = createLucideIcon("circle-alert", __iconNode18);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/circle-question-mark.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/circle-question-mark.mjs
   var __iconNode19 = [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["path", { d: "M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3", key: "1u773s" }],
@@ -15531,7 +15471,7 @@
   ];
   var CircleQuestionMark = createLucideIcon("circle-question-mark", __iconNode19);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/circle-user.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/circle-user.mjs
   var __iconNode20 = [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["circle", { cx: "12", cy: "10", r: "3", key: "ilqhr7" }],
@@ -15539,21 +15479,21 @@
   ];
   var CircleUser = createLucideIcon("circle-user", __iconNode20);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/clock-3.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/clock-3.mjs
   var __iconNode21 = [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["path", { d: "M12 6v6h4", key: "135r8i" }]
   ];
   var Clock3 = createLucideIcon("clock-3", __iconNode21);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/clock.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/clock.mjs
   var __iconNode22 = [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["path", { d: "M12 6v6l4 2", key: "mmk7yg" }]
   ];
   var Clock = createLucideIcon("clock", __iconNode22);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/cloud-cog.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/cloud-cog.mjs
   var __iconNode23 = [
     ["path", { d: "m10.852 19.772-.383.924", key: "r7sl7d" }],
     ["path", { d: "m13.148 14.228.383-.923", key: "1d5zpm" }],
@@ -15573,7 +15513,7 @@
   ];
   var CloudCog = createLucideIcon("cloud-cog", __iconNode23);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/cloud-fog.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/cloud-fog.mjs
   var __iconNode24 = [
     ["path", { d: "M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242", key: "1pljnt" }],
     ["path", { d: "M16 17H7", key: "pygtm1" }],
@@ -15581,14 +15521,14 @@
   ];
   var CloudFog = createLucideIcon("cloud-fog", __iconNode24);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/cloud-lightning.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/cloud-lightning.mjs
   var __iconNode25 = [
     ["path", { d: "M6 16.326A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 .5 8.973", key: "1cez44" }],
     ["path", { d: "m13 12-3 5h4l-3 5", key: "1t22er" }]
   ];
   var CloudLightning = createLucideIcon("cloud-lightning", __iconNode25);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/cloud-snow.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/cloud-snow.mjs
   var __iconNode26 = [
     ["path", { d: "M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242", key: "1pljnt" }],
     ["path", { d: "M8 15h.01", key: "a7atzg" }],
@@ -15600,7 +15540,7 @@
   ];
   var CloudSnow = createLucideIcon("cloud-snow", __iconNode26);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/cloud-rain.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/cloud-rain.mjs
   var __iconNode27 = [
     ["path", { d: "M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242", key: "1pljnt" }],
     ["path", { d: "M16 14v6", key: "1j4efv" }],
@@ -15609,13 +15549,13 @@
   ];
   var CloudRain = createLucideIcon("cloud-rain", __iconNode27);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/cloud.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/cloud.mjs
   var __iconNode28 = [
     ["path", { d: "M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z", key: "p7xjir" }]
   ];
   var Cloud = createLucideIcon("cloud", __iconNode28);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/contact.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/contact.mjs
   var __iconNode29 = [
     ["path", { d: "M16 2v2", key: "scm5qe" }],
     ["path", { d: "M7 22v-2a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2", key: "1waht3" }],
@@ -15625,7 +15565,7 @@
   ];
   var Contact = createLucideIcon("contact", __iconNode29);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/database.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/database.mjs
   var __iconNode30 = [
     ["ellipse", { cx: "12", cy: "5", rx: "9", ry: "3", key: "msslwz" }],
     ["path", { d: "M3 5V19A9 3 0 0 0 21 19V5", key: "1wlel7" }],
@@ -15633,7 +15573,7 @@
   ];
   var Database = createLucideIcon("database", __iconNode30);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/download.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/download.mjs
   var __iconNode31 = [
     ["path", { d: "M12 15V3", key: "m9g1x1" }],
     ["path", { d: "M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4", key: "ih7n3h" }],
@@ -15641,7 +15581,7 @@
   ];
   var Download = createLucideIcon("download", __iconNode31);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/earth.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/earth.mjs
   var __iconNode32 = [
     ["path", { d: "M21.54 15H17a2 2 0 0 0-2 2v4.54", key: "1djwo0" }],
     [
@@ -15656,7 +15596,7 @@
   ];
   var Earth = createLucideIcon("earth", __iconNode32);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/eye-off.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/eye-off.mjs
   var __iconNode33 = [
     [
       "path",
@@ -15677,7 +15617,7 @@
   ];
   var EyeOff = createLucideIcon("eye-off", __iconNode33);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/eye.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/eye.mjs
   var __iconNode34 = [
     [
       "path",
@@ -15690,7 +15630,7 @@
   ];
   var Eye = createLucideIcon("eye", __iconNode34);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/file-exclamation-point.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/file-exclamation-point.mjs
   var __iconNode35 = [
     [
       "path",
@@ -15704,7 +15644,7 @@
   ];
   var FileExclamationPoint = createLucideIcon("file-exclamation-point", __iconNode35);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/file-text.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/file-text.mjs
   var __iconNode36 = [
     [
       "path",
@@ -15720,7 +15660,7 @@
   ];
   var FileText = createLucideIcon("file-text", __iconNode36);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/focus.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/focus.mjs
   var __iconNode37 = [
     ["circle", { cx: "12", cy: "12", r: "3", key: "1v7zrd" }],
     ["path", { d: "M3 7V5a2 2 0 0 1 2-2h2", key: "aa7l1z" }],
@@ -15730,7 +15670,7 @@
   ];
   var Focus = createLucideIcon("focus", __iconNode37);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/folder-closed.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/folder-closed.mjs
   var __iconNode38 = [
     [
       "path",
@@ -15743,7 +15683,7 @@
   ];
   var FolderClosed = createLucideIcon("folder-closed", __iconNode38);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/gamepad-2.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/gamepad-2.mjs
   var __iconNode39 = [
     ["line", { x1: "6", x2: "10", y1: "11", y2: "11", key: "1gktln" }],
     ["line", { x1: "8", x2: "8", y1: "9", y2: "13", key: "qnk9ow" }],
@@ -15759,7 +15699,7 @@
   ];
   var Gamepad2 = createLucideIcon("gamepad-2", __iconNode39);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/glasses.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/glasses.mjs
   var __iconNode40 = [
     ["circle", { cx: "6", cy: "15", r: "4", key: "vux9w4" }],
     ["circle", { cx: "18", cy: "15", r: "4", key: "18o8ve" }],
@@ -15769,7 +15709,7 @@
   ];
   var Glasses = createLucideIcon("glasses", __iconNode40);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/globe.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/globe.mjs
   var __iconNode41 = [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["path", { d: "M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20", key: "13o1zl" }],
@@ -15777,7 +15717,7 @@
   ];
   var Globe = createLucideIcon("globe", __iconNode41);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/heart-pulse.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/heart-pulse.mjs
   var __iconNode42 = [
     [
       "path",
@@ -15790,7 +15730,7 @@
   ];
   var HeartPulse = createLucideIcon("heart-pulse", __iconNode42);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/heart.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/heart.mjs
   var __iconNode43 = [
     [
       "path",
@@ -15802,7 +15742,7 @@
   ];
   var Heart = createLucideIcon("heart", __iconNode43);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/image.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/image.mjs
   var __iconNode44 = [
     ["rect", { width: "18", height: "18", x: "3", y: "3", rx: "2", ry: "2", key: "1m3agn" }],
     ["circle", { cx: "9", cy: "9", r: "2", key: "af1f0g" }],
@@ -15810,7 +15750,7 @@
   ];
   var Image2 = createLucideIcon("image", __iconNode44);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/inbox.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/inbox.mjs
   var __iconNode45 = [
     ["polyline", { points: "22 12 16 12 14 15 10 15 8 12 2 12", key: "o97t9d" }],
     [
@@ -15823,7 +15763,7 @@
   ];
   var Inbox = createLucideIcon("inbox", __iconNode45);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/key-round.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/key-round.mjs
   var __iconNode46 = [
     [
       "path",
@@ -15836,7 +15776,7 @@
   ];
   var KeyRound = createLucideIcon("key-round", __iconNode46);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/layout-dashboard.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/layout-dashboard.mjs
   var __iconNode47 = [
     ["rect", { width: "7", height: "9", x: "3", y: "3", rx: "1", key: "10lvy0" }],
     ["rect", { width: "7", height: "5", x: "14", y: "3", rx: "1", key: "16une8" }],
@@ -15845,7 +15785,7 @@
   ];
   var LayoutDashboard = createLucideIcon("layout-dashboard", __iconNode47);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/layers.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/layers.mjs
   var __iconNode48 = [
     [
       "path",
@@ -15871,7 +15811,7 @@
   ];
   var Layers = createLucideIcon("layers", __iconNode48);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/layout-grid.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/layout-grid.mjs
   var __iconNode49 = [
     ["rect", { width: "7", height: "7", x: "3", y: "3", rx: "1", key: "1g98yp" }],
     ["rect", { width: "7", height: "7", x: "14", y: "3", rx: "1", key: "6d4xhi" }],
@@ -15880,7 +15820,7 @@
   ];
   var LayoutGrid = createLucideIcon("layout-grid", __iconNode49);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/list-music.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/list-music.mjs
   var __iconNode50 = [
     ["path", { d: "M16 5H3", key: "m91uny" }],
     ["path", { d: "M11 12H3", key: "51ecnj" }],
@@ -15890,7 +15830,7 @@
   ];
   var ListMusic = createLucideIcon("list-music", __iconNode50);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/list-todo.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/list-todo.mjs
   var __iconNode51 = [
     ["path", { d: "M13 5h8", key: "a7qcls" }],
     ["path", { d: "M13 12h8", key: "h98zly" }],
@@ -15900,18 +15840,18 @@
   ];
   var ListTodo = createLucideIcon("list-todo", __iconNode51);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/loader-circle.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/loader-circle.mjs
   var __iconNode52 = [["path", { d: "M21 12a9 9 0 1 1-6.219-8.56", key: "13zald" }]];
   var LoaderCircle = createLucideIcon("loader-circle", __iconNode52);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/mail.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/mail.mjs
   var __iconNode53 = [
     ["path", { d: "m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7", key: "132q7q" }],
     ["rect", { x: "2", y: "4", width: "20", height: "16", rx: "2", key: "izxlao" }]
   ];
   var Mail = createLucideIcon("mail", __iconNode53);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/message-square.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/message-square.mjs
   var __iconNode54 = [
     [
       "path",
@@ -15923,7 +15863,7 @@
   ];
   var MessageSquare = createLucideIcon("message-square", __iconNode54);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/mic.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/mic.mjs
   var __iconNode55 = [
     ["path", { d: "M12 19v3", key: "npa21l" }],
     ["path", { d: "M19 10v2a7 7 0 0 1-14 0v-2", key: "1vc78b" }],
@@ -15931,7 +15871,7 @@
   ];
   var Mic = createLucideIcon("mic", __iconNode55);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/monitor.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/monitor.mjs
   var __iconNode56 = [
     ["rect", { width: "20", height: "14", x: "2", y: "3", rx: "2", key: "48i651" }],
     ["line", { x1: "8", x2: "16", y1: "21", y2: "21", key: "1svkeh" }],
@@ -15939,7 +15879,7 @@
   ];
   var Monitor = createLucideIcon("monitor", __iconNode56);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/moon.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/moon.mjs
   var __iconNode57 = [
     [
       "path",
@@ -15951,7 +15891,7 @@
   ];
   var Moon = createLucideIcon("moon", __iconNode57);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/music.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/music.mjs
   var __iconNode58 = [
     ["path", { d: "M9 18V5l12-2v13", key: "1jmyc2" }],
     ["circle", { cx: "6", cy: "18", r: "3", key: "fqmcym" }],
@@ -15959,7 +15899,7 @@
   ];
   var Music = createLucideIcon("music", __iconNode58);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/network.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/network.mjs
   var __iconNode59 = [
     ["rect", { x: "16", y: "16", width: "6", height: "6", rx: "1", key: "4q2zg0" }],
     ["rect", { x: "2", y: "16", width: "6", height: "6", rx: "1", key: "8cvhb9" }],
@@ -15969,7 +15909,7 @@
   ];
   var Network = createLucideIcon("network", __iconNode59);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/octagon-alert.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/octagon-alert.mjs
   var __iconNode60 = [
     ["path", { d: "M12 16h.01", key: "1drbdi" }],
     ["path", { d: "M12 8v4", key: "1got3b" }],
@@ -15983,7 +15923,7 @@
   ];
   var OctagonAlert = createLucideIcon("octagon-alert", __iconNode60);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/package.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/package.mjs
   var __iconNode61 = [
     [
       "path",
@@ -15998,14 +15938,14 @@
   ];
   var Package = createLucideIcon("package", __iconNode61);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/pause.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/pause.mjs
   var __iconNode62 = [
     ["rect", { x: "14", y: "3", width: "5", height: "18", rx: "1", key: "kaeet6" }],
     ["rect", { x: "5", y: "3", width: "5", height: "18", rx: "1", key: "1wsw3u" }]
   ];
   var Pause = createLucideIcon("pause", __iconNode62);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/phone.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/phone.mjs
   var __iconNode63 = [
     [
       "path",
@@ -16017,7 +15957,7 @@
   ];
   var Phone = createLucideIcon("phone", __iconNode63);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/play.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/play.mjs
   var __iconNode64 = [
     [
       "path",
@@ -16029,7 +15969,7 @@
   ];
   var Play = createLucideIcon("play", __iconNode64);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/plug.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/plug.mjs
   var __iconNode65 = [
     ["path", { d: "M12 22v-5", key: "1ega77" }],
     ["path", { d: "M15 8V2", key: "18g5xt" }],
@@ -16041,14 +15981,14 @@
   ];
   var Plug = createLucideIcon("plug", __iconNode65);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/plus.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/plus.mjs
   var __iconNode66 = [
     ["path", { d: "M5 12h14", key: "1ays0h" }],
     ["path", { d: "M12 5v14", key: "s699le" }]
   ];
   var Plus = createLucideIcon("plus", __iconNode66);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/radio.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/radio.mjs
   var __iconNode67 = [
     ["path", { d: "M16.247 7.761a6 6 0 0 1 0 8.478", key: "1fwjs5" }],
     ["path", { d: "M19.075 4.933a10 10 0 0 1 0 14.134", key: "ehdyv1" }],
@@ -16058,7 +15998,7 @@
   ];
   var Radio = createLucideIcon("radio", __iconNode67);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/refresh-cw.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/refresh-cw.mjs
   var __iconNode68 = [
     ["path", { d: "M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8", key: "v9h5vc" }],
     ["path", { d: "M21 3v5h-5", key: "1q7to0" }],
@@ -16067,7 +16007,7 @@
   ];
   var RefreshCw = createLucideIcon("refresh-cw", __iconNode68);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/rss.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/rss.mjs
   var __iconNode69 = [
     ["path", { d: "M4 11a9 9 0 0 1 9 9", key: "pv89mb" }],
     ["path", { d: "M4 4a16 16 0 0 1 16 16", key: "k0647b" }],
@@ -16075,7 +16015,7 @@
   ];
   var Rss = createLucideIcon("rss", __iconNode69);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/scroll-text.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/scroll-text.mjs
   var __iconNode70 = [
     ["path", { d: "M15 12h-5", key: "r7krc0" }],
     ["path", { d: "M15 8h-5", key: "1khuty" }],
@@ -16090,14 +16030,14 @@
   ];
   var ScrollText = createLucideIcon("scroll-text", __iconNode70);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/search.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/search.mjs
   var __iconNode71 = [
     ["path", { d: "m21 21-4.34-4.34", key: "14j7rj" }],
     ["circle", { cx: "11", cy: "11", r: "8", key: "4ej97u" }]
   ];
   var Search = createLucideIcon("search", __iconNode71);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/settings.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/settings.mjs
   var __iconNode72 = [
     [
       "path",
@@ -16110,7 +16050,7 @@
   ];
   var Settings = createLucideIcon("settings", __iconNode72);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/settings-2.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/settings-2.mjs
   var __iconNode73 = [
     ["path", { d: "M14 17H5", key: "gfn3mx" }],
     ["path", { d: "M19 7h-9", key: "6i9tg" }],
@@ -16119,7 +16059,7 @@
   ];
   var Settings2 = createLucideIcon("settings-2", __iconNode73);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/shield.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/shield.mjs
   var __iconNode74 = [
     [
       "path",
@@ -16131,7 +16071,7 @@
   ];
   var Shield = createLucideIcon("shield", __iconNode74);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/shopping-bag.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/shopping-bag.mjs
   var __iconNode75 = [
     ["path", { d: "M16 10a4 4 0 0 1-8 0", key: "1ltviw" }],
     ["path", { d: "M3.103 6.034h17.794", key: "awc11p" }],
@@ -16145,14 +16085,14 @@
   ];
   var ShoppingBag = createLucideIcon("shopping-bag", __iconNode75);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/smartphone.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/smartphone.mjs
   var __iconNode76 = [
     ["rect", { width: "14", height: "20", x: "5", y: "2", rx: "2", ry: "2", key: "1yt0o3" }],
     ["path", { d: "M12 18h.01", key: "mhygvu" }]
   ];
   var Smartphone = createLucideIcon("smartphone", __iconNode76);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/sparkles.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/sparkles.mjs
   var __iconNode77 = [
     [
       "path",
@@ -16167,7 +16107,7 @@
   ];
   var Sparkles = createLucideIcon("sparkles", __iconNode77);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/square-arrow-out-up-right.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/square-arrow-out-up-right.mjs
   var __iconNode78 = [
     ["path", { d: "M21 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h6", key: "y09zxi" }],
     ["path", { d: "m21 3-9 9", key: "mpx6sq" }],
@@ -16175,7 +16115,7 @@
   ];
   var SquareArrowOutUpRight = createLucideIcon("square-arrow-out-up-right", __iconNode78);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/square-pause.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/square-pause.mjs
   var __iconNode79 = [
     ["rect", { width: "18", height: "18", x: "3", y: "3", rx: "2", key: "afitv7" }],
     ["line", { x1: "10", x2: "10", y1: "15", y2: "9", key: "c1nkhi" }],
@@ -16183,7 +16123,7 @@
   ];
   var SquarePause = createLucideIcon("square-pause", __iconNode79);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/square-terminal.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/square-terminal.mjs
   var __iconNode80 = [
     ["path", { d: "m7 11 2-2-2-2", key: "1lz0vl" }],
     ["path", { d: "M11 13h4", key: "1p7l4v" }],
@@ -16191,13 +16131,13 @@
   ];
   var SquareTerminal = createLucideIcon("square-terminal", __iconNode80);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/square.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/square.mjs
   var __iconNode81 = [
     ["rect", { width: "18", height: "18", x: "3", y: "3", rx: "2", key: "afitv7" }]
   ];
   var Square = createLucideIcon("square", __iconNode81);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/sun.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/sun.mjs
   var __iconNode82 = [
     ["circle", { cx: "12", cy: "12", r: "4", key: "4exip2" }],
     ["path", { d: "M12 2v2", key: "tus03m" }],
@@ -16211,7 +16151,7 @@
   ];
   var Sun = createLucideIcon("sun", __iconNode82);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/target.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/target.mjs
   var __iconNode83 = [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["circle", { cx: "12", cy: "12", r: "6", key: "1vlfrh" }],
@@ -16219,14 +16159,14 @@
   ];
   var Target = createLucideIcon("target", __iconNode83);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/terminal.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/terminal.mjs
   var __iconNode84 = [
     ["path", { d: "M12 19h8", key: "baeox8" }],
     ["path", { d: "m4 17 6-6-6-6", key: "1yngyt" }]
   ];
   var Terminal = createLucideIcon("terminal", __iconNode84);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/test-tube-diagonal.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/test-tube-diagonal.mjs
   var __iconNode85 = [
     [
       "path",
@@ -16237,7 +16177,7 @@
   ];
   var TestTubeDiagonal = createLucideIcon("test-tube-diagonal", __iconNode85);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/trash-2.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/trash-2.mjs
   var __iconNode86 = [
     ["path", { d: "M10 11v6", key: "nco0om" }],
     ["path", { d: "M14 11v6", key: "outv1u" }],
@@ -16247,14 +16187,14 @@
   ];
   var Trash2 = createLucideIcon("trash-2", __iconNode86);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/trending-up.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/trending-up.mjs
   var __iconNode87 = [
     ["path", { d: "M16 7h6v6", key: "box55l" }],
     ["path", { d: "m22 7-8.5 8.5-5-5L2 17", key: "1t1m79" }]
   ];
   var TrendingUp = createLucideIcon("trending-up", __iconNode87);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/triangle-alert.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/triangle-alert.mjs
   var __iconNode88 = [
     [
       "path",
@@ -16268,14 +16208,14 @@
   ];
   var TriangleAlert = createLucideIcon("triangle-alert", __iconNode88);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/user-round.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/user-round.mjs
   var __iconNode89 = [
     ["circle", { cx: "12", cy: "8", r: "5", key: "1hypcn" }],
     ["path", { d: "M20 21a8 8 0 0 0-16 0", key: "rfgkzh" }]
   ];
   var UserRound = createLucideIcon("user-round", __iconNode89);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/users.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/users.mjs
   var __iconNode90 = [
     ["path", { d: "M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2", key: "1yyitq" }],
     ["path", { d: "M16 3.128a4 4 0 0 1 0 7.744", key: "16gr8j" }],
@@ -16284,7 +16224,7 @@
   ];
   var Users = createLucideIcon("users", __iconNode90);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/users-round.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/users-round.mjs
   var __iconNode91 = [
     ["path", { d: "M18 21a8 8 0 0 0-16 0", key: "3ypg7q" }],
     ["circle", { cx: "10", cy: "8", r: "5", key: "o932ke" }],
@@ -16292,7 +16232,7 @@
   ];
   var UsersRound = createLucideIcon("users-round", __iconNode91);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/wallet.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/wallet.mjs
   var __iconNode92 = [
     [
       "path",
@@ -16305,7 +16245,7 @@
   ];
   var Wallet = createLucideIcon("wallet", __iconNode92);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/workflow.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/workflow.mjs
   var __iconNode93 = [
     ["rect", { width: "8", height: "8", x: "3", y: "3", rx: "2", key: "by2w9f" }],
     ["path", { d: "M7 11v4a2 2 0 0 0 2 2h4", key: "xkn7yn" }],
@@ -16313,7 +16253,7 @@
   ];
   var Workflow = createLucideIcon("workflow", __iconNode93);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/wrench.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/wrench.mjs
   var __iconNode94 = [
     [
       "path",
@@ -16325,14 +16265,14 @@
   ];
   var Wrench = createLucideIcon("wrench", __iconNode94);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/x.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/x.mjs
   var __iconNode95 = [
     ["path", { d: "M18 6 6 18", key: "1bl5f8" }],
     ["path", { d: "m6 6 12 12", key: "d8bk6v" }]
   ];
   var X = createLucideIcon("x", __iconNode95);
 
-  // ../pr-12727-run/node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/zap.mjs
+  // ../../../node_modules/.bun/lucide-react@1.18.0+3f10a4be4e334a9b/node_modules/lucide-react/dist/esm/icons/zap.mjs
   var __iconNode96 = [
     [
       "path",
@@ -16343,6 +16283,12 @@
     ]
   ];
   var Zap = createLucideIcon("zap", __iconNode96);
+
+  // packages/ui/src/platform/aosp-user-agent.ts
+  function userAgentHasElizaOSMarker(userAgent) {
+    if (typeof userAgent !== "string" || userAgent.length === 0) return false;
+    return /\bElizaOS\/\S/.test(userAgent);
+  }
 
   // packages/shared/src/utils/string-hash.ts
   function hashString(value) {
@@ -16679,101 +16625,6 @@
     )}`;
   }
 
-  // packages/shared/src/platform/aosp-user-agent.ts
-  function userAgentHasElizaOSMarker(userAgent) {
-    if (typeof userAgent !== "string" || userAgent.length === 0) return false;
-    return /\bElizaOS\/\S/.test(userAgent);
-  }
-
-  // packages/shared/src/registry-host.ts
-  var DefaultUiRegistryHost = class {
-    stores = /* @__PURE__ */ new Map();
-    getStore(key, create) {
-      const existing = this.stores.get(key);
-      if (existing !== void 0) return existing;
-      const created = create();
-      this.stores.set(key, created);
-      return created;
-    }
-  };
-  var activeRegistryHost = new DefaultUiRegistryHost();
-  function getUiRegistryStore(key, create) {
-    return activeRegistryHost.getStore(key, create);
-  }
-
-  // packages/shared/src/apps/overlay-app-registry.ts
-  var OVERLAY_APP_REGISTRY_STORE = "overlay-apps";
-  function getOverlayRegistry() {
-    return getUiRegistryStore(
-      OVERLAY_APP_REGISTRY_STORE,
-      () => /* @__PURE__ */ new Map()
-    );
-  }
-  function getAllOverlayApps() {
-    return Array.from(getOverlayRegistry().values());
-  }
-  function getAvailableOverlayApps(context = detectOverlayAvailabilityContext()) {
-    const availability = typeof context === "string" ? { platform: context, aospAndroid: false } : normalizeOverlayAvailabilityContext(context);
-    const canShowAndroidOnly = availability.platform === "android" && availability.aospAndroid === true;
-    return getAllOverlayApps().filter(
-      (app) => canShowAndroidOnly || app.androidOnly !== true
-    );
-  }
-  function normalizeOverlayAvailabilityContext(context) {
-    const userAgent = context.userAgent ?? (typeof navigator !== "undefined" ? navigator.userAgent : "");
-    const platform5 = context.platform ?? detectPlatformForCatalog(userAgent);
-    return {
-      platform: platform5,
-      aospAndroid: context.aospAndroid ?? (platform5 === "android" && userAgentHasElizaOSMarker(userAgent)),
-      userAgent
-    };
-  }
-  function detectOverlayAvailabilityContext() {
-    const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
-    const platform5 = detectPlatformForCatalog(userAgent);
-    return {
-      platform: platform5,
-      aospAndroid: platform5 === "android" && userAgentHasElizaOSMarker(userAgent),
-      userAgent
-    };
-  }
-  function detectPlatformForCatalog(userAgent) {
-    const cap = globalThis.Capacitor;
-    const fromCap = cap?.getPlatform?.();
-    if (fromCap) return fromCap;
-    if (/Android/i.test(userAgent)) {
-      return "android";
-    }
-    return "web";
-  }
-  function isAospAndroid(context = {}) {
-    const availability = normalizeOverlayAvailabilityContext(context);
-    return availability.platform === "android" && availability.aospAndroid === true;
-  }
-  function overlayAppToRegistryInfo(app) {
-    return {
-      name: app.name,
-      displayName: app.displayName,
-      description: app.description,
-      category: app.category,
-      launchType: "overlay",
-      launchUrl: null,
-      icon: app.icon,
-      heroImage: app.heroImage ?? null,
-      capabilities: [],
-      stars: 0,
-      repository: "",
-      latestVersion: null,
-      supports: { v0: false, v1: false, v2: true },
-      npm: {
-        package: app.name,
-        v0Version: null,
-        v1Version: null,
-        v2Version: null
-      }
-    };
-  }
-
   // packages/shared/src/type-guards.ts
   function asRecord(value) {
     if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -16795,7 +16646,7 @@
   };
   var BRAND_COLORS = {
     blue: "#0B35F1",
-    orange: "#FF5800",
+    orange: "var(--accent)",
     white: "#FFFFFF",
     black: "#000000",
     gray: "#D1D0D4"
@@ -16853,7 +16704,7 @@
     return getBootConfigStore().current;
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/external.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/external.js
   var external_exports = {};
   __export(external_exports, {
     $brand: () => $brand,
@@ -17096,7 +16947,7 @@
     xor: () => xor
   });
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/index.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/index.js
   var core_exports2 = {};
   __export(core_exports2, {
     $ZodAny: () => $ZodAny,
@@ -17375,7 +17226,7 @@
     version: () => version
   });
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/core.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/core.js
   var _a;
   var NEVER = /* @__PURE__ */ Object.freeze({
     status: "aborted"
@@ -17452,7 +17303,7 @@
     return globalConfig;
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/util.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/util.js
   var util_exports = {};
   __export(util_exports, {
     BIGINT_FORMAT_RANGES: () => BIGINT_FORMAT_RANGES,
@@ -18148,7 +17999,7 @@
     }
   };
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/errors.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/errors.js
   var initializer = (inst, def) => {
     inst.name = "$ZodError";
     Object.defineProperty(inst, "_zod", {
@@ -18287,7 +18138,7 @@
     return lines.join("\n");
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/parse.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/parse.js
   var _parse = (_Err) => (schema, value, _ctx, _params) => {
     const ctx = _ctx ? { ..._ctx, async: false } : { async: false };
     const result = schema._zod.run({ value, issues: [] }, ctx);
@@ -18375,7 +18226,7 @@
   };
   var safeDecodeAsync = /* @__PURE__ */ _safeDecodeAsync($ZodRealError);
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/regexes.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/regexes.js
   var regexes_exports = {};
   __export(regexes_exports, {
     base64: () => base64,
@@ -18534,7 +18385,7 @@
   var sha512_base64 = /* @__PURE__ */ fixedBase64(86, "==");
   var sha512_base64url = /* @__PURE__ */ fixedBase64url(86);
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/checks.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/checks.js
   var $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
     var _a3;
     inst._zod ?? (inst._zod = {});
@@ -19082,7 +18933,7 @@
     };
   });
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/doc.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/doc.js
   var Doc = class {
     constructor(args = []) {
       this.content = [];
@@ -19118,14 +18969,14 @@
     }
   };
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/versions.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/versions.js
   var version = {
     major: 4,
     minor: 4,
     patch: 3
   };
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/schemas.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/schemas.js
   var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
     var _a3;
     inst ?? (inst = {});
@@ -21218,7 +21069,7 @@
     }
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/index.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/index.js
   var locales_exports = {};
   __export(locales_exports, {
     ar: () => ar_default,
@@ -21275,7 +21126,7 @@
     zhTW: () => zh_TW_default
   });
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ar.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ar.js
   var error = () => {
     const Sizable = {
       string: { unit: "\u062D\u0631\u0641", verb: "\u0623\u0646 \u064A\u062D\u0648\u064A" },
@@ -21382,7 +21233,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/az.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/az.js
   var error2 = () => {
     const Sizable = {
       string: { unit: "simvol", verb: "olmal\u0131d\u0131r" },
@@ -21488,7 +21339,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/be.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/be.js
   function getBelarusianPlural(count3, one, few, many) {
     const absCount = Math.abs(count3);
     const lastDigit = absCount % 10;
@@ -21645,7 +21496,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/bg.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/bg.js
   var error4 = () => {
     const Sizable = {
       string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0430", verb: "\u0434\u0430 \u0441\u044A\u0434\u044A\u0440\u0436\u0430" },
@@ -21766,7 +21617,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ca.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ca.js
   var error5 = () => {
     const Sizable = {
       string: { unit: "car\xE0cters", verb: "contenir" },
@@ -21875,7 +21726,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/cs.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/cs.js
   var error6 = () => {
     const Sizable = {
       string: { unit: "znak\u016F", verb: "m\xEDt" },
@@ -21987,7 +21838,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/da.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/da.js
   var error7 = () => {
     const Sizable = {
       string: { unit: "tegn", verb: "havde" },
@@ -22103,7 +21954,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/de.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/de.js
   var error8 = () => {
     const Sizable = {
       string: { unit: "Zeichen", verb: "zu haben" },
@@ -22212,7 +22063,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/el.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/el.js
   var error9 = () => {
     const Sizable = {
       string: { unit: "\u03C7\u03B1\u03C1\u03B1\u03BA\u03C4\u03AE\u03C1\u03B5\u03C2", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
@@ -22322,7 +22173,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/en.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/en.js
   var error10 = () => {
     const Sizable = {
       string: { unit: "characters", verb: "to have" },
@@ -22435,7 +22286,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/eo.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/eo.js
   var error11 = () => {
     const Sizable = {
       string: { unit: "karaktrojn", verb: "havi" },
@@ -22545,7 +22396,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/es.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/es.js
   var error12 = () => {
     const Sizable = {
       string: { unit: "caracteres", verb: "tener" },
@@ -22678,7 +22529,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/fa.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/fa.js
   var error13 = () => {
     const Sizable = {
       string: { unit: "\u06A9\u0627\u0631\u0627\u06A9\u062A\u0631", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
@@ -22793,7 +22644,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/fi.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/fi.js
   var error14 = () => {
     const Sizable = {
       string: { unit: "merkki\xE4", subject: "merkkijonon" },
@@ -22906,7 +22757,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/fr.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/fr.js
   var error15 = () => {
     const Sizable = {
       string: { unit: "caract\xE8res", verb: "avoir" },
@@ -23032,7 +22883,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/fr-CA.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/fr-CA.js
   var error16 = () => {
     const Sizable = {
       string: { unit: "caract\xE8res", verb: "avoir" },
@@ -23140,7 +22991,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/he.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/he.js
   var error17 = () => {
     const TypeNames = {
       string: { label: "\u05DE\u05D7\u05E8\u05D5\u05D6\u05EA", gender: "f" },
@@ -23335,7 +23186,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/hr.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/hr.js
   var error18 = () => {
     const Sizable = {
       string: { unit: "znakova", verb: "imati" },
@@ -23458,7 +23309,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/hu.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/hu.js
   var error19 = () => {
     const Sizable = {
       string: { unit: "karakter", verb: "legyen" },
@@ -23567,7 +23418,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/hy.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/hy.js
   function getArmenianPlural(count3, one, many) {
     return Math.abs(count3) === 1 ? one : many;
   }
@@ -23715,7 +23566,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/id.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/id.js
   var error21 = () => {
     const Sizable = {
       string: { unit: "karakter", verb: "memiliki" },
@@ -23822,7 +23673,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/is.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/is.js
   var error22 = () => {
     const Sizable = {
       string: { unit: "stafi", verb: "a\xF0 hafa" },
@@ -23932,7 +23783,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/it.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/it.js
   var error23 = () => {
     const Sizable = {
       string: { unit: "caratteri", verb: "avere" },
@@ -24041,7 +23892,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ja.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ja.js
   var error24 = () => {
     const Sizable = {
       string: { unit: "\u6587\u5B57", verb: "\u3067\u3042\u308B" },
@@ -24149,7 +24000,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ka.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ka.js
   var error25 = () => {
     const Sizable = {
       string: { unit: "\u10E1\u10D8\u10DB\u10D1\u10DD\u10DA\u10DD", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
@@ -24262,7 +24113,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/km.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/km.js
   var error26 = () => {
     const Sizable = {
       string: { unit: "\u178F\u17BD\u17A2\u1780\u17D2\u179F\u179A", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
@@ -24373,12 +24224,12 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/kh.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/kh.js
   function kh_default() {
     return km_default();
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ko.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ko.js
   var error27 = () => {
     const Sizable = {
       string: { unit: "\uBB38\uC790", verb: "to have" },
@@ -24490,7 +24341,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/lt.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/lt.js
   var capitalizeFirstCharacter = (text) => {
     return text.charAt(0).toUpperCase() + text.slice(1);
   };
@@ -24694,7 +24545,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/mk.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/mk.js
   var error29 = () => {
     const Sizable = {
       string: { unit: "\u0437\u043D\u0430\u0446\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
@@ -24804,7 +24655,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ms.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ms.js
   var error30 = () => {
     const Sizable = {
       string: { unit: "aksara", verb: "mempunyai" },
@@ -24912,7 +24763,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/nl.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/nl.js
   var error31 = () => {
     const Sizable = {
       string: { unit: "tekens", verb: "heeft" },
@@ -25023,7 +24874,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/no.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/no.js
   var error32 = () => {
     const Sizable = {
       string: { unit: "tegn", verb: "\xE5 ha" },
@@ -25132,7 +24983,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ota.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ota.js
   var error33 = () => {
     const Sizable = {
       string: { unit: "harf", verb: "olmal\u0131d\u0131r" },
@@ -25242,7 +25093,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ps.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ps.js
   var error34 = () => {
     const Sizable = {
       string: { unit: "\u062A\u0648\u06A9\u064A", verb: "\u0648\u0644\u0631\u064A" },
@@ -25357,7 +25208,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/pl.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/pl.js
   var error35 = () => {
     const Sizable = {
       string: { unit: "znak\xF3w", verb: "mie\u0107" },
@@ -25467,7 +25318,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/pt.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/pt.js
   var error36 = () => {
     const Sizable = {
       string: { unit: "caracteres", verb: "ter" },
@@ -25576,7 +25427,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ro.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ro.js
   var error37 = () => {
     const Sizable = {
       string: { unit: "caractere", verb: "s\u0103 aib\u0103" },
@@ -25696,7 +25547,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ru.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ru.js
   function getRussianPlural(count3, one, few, many) {
     const absCount = Math.abs(count3);
     const lastDigit = absCount % 10;
@@ -25853,7 +25704,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/sl.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/sl.js
   var error39 = () => {
     const Sizable = {
       string: { unit: "znakov", verb: "imeti" },
@@ -25963,7 +25814,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/sv.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/sv.js
   var error40 = () => {
     const Sizable = {
       string: { unit: "tecken", verb: "att ha" },
@@ -26074,7 +25925,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ta.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ta.js
   var error41 = () => {
     const Sizable = {
       string: { unit: "\u0B8E\u0BB4\u0BC1\u0BA4\u0BCD\u0BA4\u0BC1\u0B95\u0BCD\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
@@ -26185,7 +26036,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/th.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/th.js
   var error42 = () => {
     const Sizable = {
       string: { unit: "\u0E15\u0E31\u0E27\u0E2D\u0E31\u0E01\u0E29\u0E23", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
@@ -26296,7 +26147,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/tr.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/tr.js
   var error43 = () => {
     const Sizable = {
       string: { unit: "karakter", verb: "olmal\u0131" },
@@ -26402,7 +26253,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/uk.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/uk.js
   var error44 = () => {
     const Sizable = {
       string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
@@ -26511,12 +26362,12 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ua.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ua.js
   function ua_default() {
     return uk_default();
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ur.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/ur.js
   var error45 = () => {
     const Sizable = {
       string: { unit: "\u062D\u0631\u0648\u0641", verb: "\u06C1\u0648\u0646\u0627" },
@@ -26627,7 +26478,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/uz.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/uz.js
   var error46 = () => {
     const Sizable = {
       string: { unit: "belgi", verb: "bo\u2018lishi kerak" },
@@ -26738,7 +26589,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/vi.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/vi.js
   var error47 = () => {
     const Sizable = {
       string: { unit: "k\xFD t\u1EF1", verb: "c\xF3" },
@@ -26847,7 +26698,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/zh-CN.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/zh-CN.js
   var error48 = () => {
     const Sizable = {
       string: { unit: "\u5B57\u7B26", verb: "\u5305\u542B" },
@@ -26957,7 +26808,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/zh-TW.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/zh-TW.js
   var error49 = () => {
     const Sizable = {
       string: { unit: "\u5B57\u5143", verb: "\u64C1\u6709" },
@@ -27065,7 +26916,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/yo.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/locales/yo.js
   var error50 = () => {
     const Sizable = {
       string: { unit: "\xE0mi", verb: "n\xED" },
@@ -27173,7 +27024,7 @@
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/registries.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/registries.js
   var _a2;
   var $output = /* @__PURE__ */ Symbol("ZodOutput");
   var $input = /* @__PURE__ */ Symbol("ZodInput");
@@ -27223,7 +27074,7 @@
   (_a2 = globalThis).__zod_globalRegistry ?? (_a2.__zod_globalRegistry = registry());
   var globalRegistry = globalThis.__zod_globalRegistry;
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/api.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/api.js
   // @__NO_SIDE_EFFECTS__
   function _string(Class2, params2) {
     return new Class2({
@@ -28262,7 +28113,7 @@
     return inst;
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/to-json-schema.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/to-json-schema.js
   function initializeContext(params2) {
     let target = params2?.target ?? "draft-2020-12";
     if (target === "draft-4")
@@ -28621,7 +28472,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return finalize(ctx, schema);
   };
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/json-schema-processors.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/json-schema-processors.js
   var formatMap = {
     guid: "uuid",
     url: "uri",
@@ -29165,7 +29016,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return finalize(ctx, input);
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/json-schema-generator.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/json-schema-generator.js
   var JSONSchemaGenerator = class {
     /** @deprecated Access via ctx instead */
     get metadataRegistry() {
@@ -29240,10 +29091,10 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     }
   };
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/json-schema.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/core/json-schema.js
   var json_schema_exports = {};
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/schemas.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/schemas.js
   var schemas_exports2 = {};
   __export(schemas_exports2, {
     ZodAny: () => ZodAny,
@@ -29414,7 +29265,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     xor: () => xor
   });
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/checks.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/checks.js
   var checks_exports2 = {};
   __export(checks_exports2, {
     endsWith: () => _endsWith,
@@ -29448,7 +29299,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     uppercase: () => _uppercase
   });
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/iso.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/iso.js
   var iso_exports = {};
   __export(iso_exports, {
     ZodISODate: () => ZodISODate,
@@ -29489,7 +29340,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return _isoDuration(ZodISODuration, params2);
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/errors.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/errors.js
   var initializer2 = (inst, issues) => {
     $ZodError.init(inst, issues);
     inst.name = "ZodError";
@@ -29529,7 +29380,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     Parent: Error
   });
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/parse.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/parse.js
   var parse2 = /* @__PURE__ */ _parse(ZodRealError);
   var parseAsync2 = /* @__PURE__ */ _parseAsync(ZodRealError);
   var safeParse2 = /* @__PURE__ */ _safeParse(ZodRealError);
@@ -29543,7 +29394,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   var safeEncodeAsync2 = /* @__PURE__ */ _safeEncodeAsync(ZodRealError);
   var safeDecodeAsync2 = /* @__PURE__ */ _safeDecodeAsync(ZodRealError);
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/schemas.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/schemas.js
   var _installedGroups = /* @__PURE__ */ new WeakMap();
   function _installLazyMethods(inst, group, methods2) {
     const proto2 = Object.getPrototypeOf(inst);
@@ -30833,7 +30684,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     });
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/compat.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/compat.js
   var ZodIssueCode = {
     invalid_type: "invalid_type",
     too_big: "too_big",
@@ -30859,7 +30710,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   /* @__PURE__ */ (function(ZodFirstPartyTypeKind2) {
   })(ZodFirstPartyTypeKind || (ZodFirstPartyTypeKind = {}));
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/from-json-schema.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/from-json-schema.js
   var z = {
     ...schemas_exports2,
     ...checks_exports2,
@@ -31339,7 +31190,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return convertSchema(normalized, ctx);
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/coerce.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/coerce.js
   var coerce_exports = {};
   __export(coerce_exports, {
     bigint: () => bigint3,
@@ -31364,10 +31215,10 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return _coercedDate(ZodDate, params2);
   }
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/external.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/v4/classic/external.js
   config(en_default());
 
-  // ../pr-12727-run/node_modules/.bun/zod@4.4.3/node_modules/zod/index.js
+  // ../../../node_modules/.bun/zod@4.4.3/node_modules/zod/index.js
   var zod_default = external_exports;
 
   // packages/shared/src/config/config-catalog.ts
@@ -31705,7 +31556,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     }
   });
 
-  // ../pr-12727-run/packages/registry/src/first-party/curated-app-definitions.json
+  // ../../../packages/registry/src/first-party/curated-app-definitions.json
   var curated_app_definitions_default = [
     {
       slug: "contacts",
@@ -31996,40 +31847,6 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   ];
   var PAGE_SCOPE_SET = new Set(PAGE_SCOPES);
 
-  // packages/shared/src/i18n/language.ts
-  var UI_LANGUAGES = [
-    "en",
-    "zh-CN",
-    "ko",
-    "es",
-    "pt",
-    "vi",
-    "tl",
-    "ja"
-  ];
-  var DEFAULT_UI_LANGUAGE = "en";
-  var UI_LANGUAGE_SET = new Set(UI_LANGUAGES);
-  function normalizeLanguage(input) {
-    if (typeof input !== "string") return DEFAULT_UI_LANGUAGE;
-    const trimmed = input.trim();
-    if (!trimmed) return DEFAULT_UI_LANGUAGE;
-    if (UI_LANGUAGE_SET.has(trimmed)) return trimmed;
-    const lower = trimmed.toLowerCase();
-    if (lower === "zh" || lower === "zh-cn" || lower.startsWith("zh-hans")) {
-      return "zh-CN";
-    }
-    if (lower === "en" || lower.startsWith("en-")) {
-      return "en";
-    }
-    if (lower.startsWith("ko")) return "ko";
-    if (lower.startsWith("es")) return "es";
-    if (lower.startsWith("pt")) return "pt";
-    if (lower.startsWith("vi")) return "vi";
-    if (lower.startsWith("tl") || lower.startsWith("fil")) return "tl";
-    if (lower.startsWith("ja")) return "ja";
-    return DEFAULT_UI_LANGUAGE;
-  }
-
   // packages/shared/src/local-inference/catalog.ts
   var ELIZA_1_HF_REPO = "elizaos/eliza-1";
   var ELIZA_1_TIER_IDS = [
@@ -32082,8 +31899,21 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     "eliza-1-27b-256k": "pending"
   };
   function eliza1TierPublishStatus(id) {
+    const override = readPublishStatusOverride(id);
+    if (override) return override;
     const hint = ELIZA_1_TIER_PUBLISH_STATUS[id];
     return hint ?? "published";
+  }
+  function readPublishStatusOverride(id) {
+    const raw2 = typeof process !== "undefined" ? process.env.ELIZA_PUBLISH_STATUS_OVERRIDES : void 0;
+    if (!raw2) return void 0;
+    try {
+      const parsed = JSON.parse(raw2);
+      const value = parsed[id];
+      if (value === "published" || value === "pending") return value;
+    } catch {
+    }
+    return void 0;
   }
   var ELIZA_1_PLACEHOLDER_IDS = new Set(
     ELIZA_1_TIER_IDS
@@ -32448,7 +32278,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return WILDCARD_BIND_RE.test(normalized);
   }
 
-  // ../pr-12727-run/node_modules/.bun/chalk@5.6.2/node_modules/chalk/source/vendor/ansi-styles/index.js
+  // ../../../node_modules/.bun/chalk@5.6.2/node_modules/chalk/source/vendor/ansi-styles/index.js
   var ANSI_BACKGROUND_OFFSET = 10;
   var wrapAnsi16 = (offset4 = 0) => (code) => `\x1B[${code + offset4}m`;
   var wrapAnsi256 = (offset4 = 0) => (code) => `\x1B[${38 + offset4};5;${code}m`;
@@ -32634,7 +32464,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   var ansiStyles = assembleStyles();
   var ansi_styles_default = ansiStyles;
 
-  // ../pr-12727-run/node_modules/.bun/chalk@5.6.2/node_modules/chalk/source/vendor/supports-color/browser.js
+  // ../../../node_modules/.bun/chalk@5.6.2/node_modules/chalk/source/vendor/supports-color/browser.js
   var level = (() => {
     if (!("navigator" in globalThis)) {
       return 0;
@@ -32662,7 +32492,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   };
   var browser_default = supportsColor;
 
-  // ../pr-12727-run/node_modules/.bun/chalk@5.6.2/node_modules/chalk/source/utilities.js
+  // ../../../node_modules/.bun/chalk@5.6.2/node_modules/chalk/source/utilities.js
   function stringReplaceAll(string4, substring, replacer) {
     let index2 = string4.indexOf(substring);
     if (index2 === -1) {
@@ -32692,7 +32522,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return returnValue;
   }
 
-  // ../pr-12727-run/node_modules/.bun/chalk@5.6.2/node_modules/chalk/source/index.js
+  // ../../../node_modules/.bun/chalk@5.6.2/node_modules/chalk/source/index.js
   var { stdout: stdoutColor, stderr: stderrColor } = browser_default;
   var GENERATOR = /* @__PURE__ */ Symbol("GENERATOR");
   var STYLER = /* @__PURE__ */ Symbol("STYLER");
@@ -33457,19 +33287,6 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     }));
   }
 
-  // packages/ui/src/app-shell-registry.ts
-  var APP_SHELL_PAGE_REGISTRY_STORE = "app-shell-pages";
-  function getRegistryStore() {
-    return getUiRegistryStore(APP_SHELL_PAGE_REGISTRY_STORE, () => ({
-      entries: /* @__PURE__ */ new Map(),
-      listeners: /* @__PURE__ */ new Set(),
-      version: 0
-    }));
-  }
-  function listAppShellPages() {
-    return [...getRegistryStore().entries.values()];
-  }
-
   // packages/ui/src/components/apps/apps-cache.ts
   var CACHE_KEY = "eliza:apps:catalog:v1";
   function isRegistryAppInfo(value) {
@@ -33536,14 +33353,6 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     // Legacy hidden alias for old /advanced routes.
     "advanced"
   ];
-  function walletLauncherTabs() {
-    const tabs = listAppShellPages().filter((entry) => entry.group === "wallet").sort(
-      (a, b) => (a.order ?? 100) - (b.order ?? 100) || a.label.localeCompare(b.label) || a.id.localeCompare(b.id)
-    ).map(
-      (entry) => normalizePath(entry.path).toLowerCase() === "/inventory" ? entry.tabAffinity ?? "inventory" : entry.id
-    );
-    return [...new Set(tabs.length ? tabs : ["inventory"])];
-  }
   function hasAndroidTestFlag(search, hash2) {
     const searchParams = new URLSearchParams(search);
     if (searchParams.get("android") === "true") return true;
@@ -33557,16 +33366,6 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     if (hasAndroidTestFlag(search, hash2)) return true;
     return typeof navigator !== "undefined" && userAgentHasElizaOSMarker(navigator.userAgent ?? "");
   }
-  var NATIVE_OS_VIEW_IDS = [
-    "phone",
-    "messages",
-    "contacts",
-    "camera"
-  ];
-  var LAUNCHER_AOSP_ONLY_VIEW_IDS = [
-    ...NATIVE_OS_VIEW_IDS,
-    "files"
-  ];
   var ALL_TAB_GROUPS = [
     {
       label: "Messages",
@@ -33604,10 +33403,9 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
       description: "Avatar identity, style, examples, and knowledge"
     },
     {
+      // Hyperliquid + Polymarket are sub-views of Wallet, not standalone apps.
       label: "Wallet",
-      get tabs() {
-        return walletLauncherTabs();
-      },
+      tabs: ["inventory", "hyperliquid", "polymarket"],
       icon: Wallet,
       description: "Crypto wallets, token balances, perps, and prediction markets"
     },
@@ -33624,12 +33422,12 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
       description: "Live streaming controls"
     },
     {
-      // One consolidated surface — workflows, triggers, and scheduled items share
-      // the Automations feed. `triggers`/`tasks` stay routable aliases (TAB_PATHS).
+      // One consolidated surface — scheduled tasks + recurring workflows share the
+      // Automations feed. `triggers`/`tasks` stay routable aliases (TAB_PATHS).
       label: "Automations",
       tabs: ["automations"],
       icon: Clock3,
-      description: "Workflows, triggers, and scheduled items"
+      description: "Scheduled tasks and recurring workflows"
     },
     {
       label: "Settings",
@@ -33692,14 +33490,6 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     if (base.endsWith("/")) base = base.slice(0, -1);
     return base;
   }
-  function normalizePath(p) {
-    if (!p) return "/";
-    let normalized = p.trim();
-    if (!normalized.startsWith("/")) normalized = `/${normalized}`;
-    if (normalized.length > 1 && normalized.endsWith("/"))
-      normalized = normalized.slice(0, -1);
-    return normalized;
-  }
 
   // packages/ui/src/components/shell/__e2e__/home-screen-fixture.platform-stub.ts
   function getActiveViewModality() {
@@ -33713,10 +33503,10 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   // packages/ui/src/components/ui/confirm-dialog.tsx
   var React31 = __toESM(require_react(), 1);
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-slot@1.3.0+b2e33729a97476bf/node_modules/@radix-ui/react-slot/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-slot@1.3.0+b2e33729a97476bf/node_modules/@radix-ui/react-slot/dist/index.mjs
   var React2 = __toESM(require_react(), 1);
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-compose-refs@1.1.3+b2e33729a97476bf/node_modules/@radix-ui/react-compose-refs/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-compose-refs@1.1.3+b2e33729a97476bf/node_modules/@radix-ui/react-compose-refs/dist/index.mjs
   var React = __toESM(require_react(), 1);
   function setRef(ref, value) {
     if (typeof ref === "function") {
@@ -33753,7 +33543,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return React.useCallback(composeRefs(...refs), refs);
   }
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-slot@1.3.0+b2e33729a97476bf/node_modules/@radix-ui/react-slot/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-slot@1.3.0+b2e33729a97476bf/node_modules/@radix-ui/react-slot/dist/index.mjs
   // @__NO_SIDE_EFFECTS__
   function createSlot(ownerName) {
     const Slot22 = React2.forwardRef((props, forwardedRef) => {
@@ -33873,7 +33663,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   };
   var use = React2[" use ".trim().toString()];
 
-  // ../pr-12727-run/node_modules/.bun/clsx@2.1.1/node_modules/clsx/dist/clsx.mjs
+  // ../../../node_modules/.bun/clsx@2.1.1/node_modules/clsx/dist/clsx.mjs
   function r(e) {
     var t2, f, n = "";
     if ("string" == typeof e || "number" == typeof e) n += e;
@@ -33888,7 +33678,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return n;
   }
 
-  // ../pr-12727-run/node_modules/.bun/class-variance-authority@0.7.1/node_modules/class-variance-authority/dist/index.mjs
+  // ../../../node_modules/.bun/class-variance-authority@0.7.1/node_modules/class-variance-authority/dist/index.mjs
   var falsyToString = (value) => typeof value === "boolean" ? `${value}` : value === 0 ? "0" : value;
   var cx = clsx;
   var cva = (base, config2) => (props) => {
@@ -33933,7 +33723,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   // packages/ui/src/components/ui/button.tsx
   var React3 = __toESM(require_react(), 1);
 
-  // ../pr-12727-run/node_modules/.bun/tailwind-merge@3.4.0/node_modules/tailwind-merge/dist/bundle-mjs.mjs
+  // ../../../node_modules/.bun/tailwind-merge@3.4.0/node_modules/tailwind-merge/dist/bundle-mjs.mjs
   var concatArrays = (array1, array2) => {
     const combinedArray = new Array(array1.length + array2.length);
     for (let i = 0; i < array1.length; i++) {
@@ -37006,10 +36796,10 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   );
   Button.displayName = "Button";
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-dialog@1.1.17+119c4f3973a6d299/node_modules/@radix-ui/react-dialog/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-dialog@1.1.17+119c4f3973a6d299/node_modules/@radix-ui/react-dialog/dist/index.mjs
   var React25 = __toESM(require_react(), 1);
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+primitive@1.1.4/node_modules/@radix-ui/primitive/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+primitive@1.1.4/node_modules/@radix-ui/primitive/dist/index.mjs
   var canUseDOM = !!(typeof window !== "undefined" && window.document && window.document.createElement);
   function composeEventHandlers(originalEventHandler, ourEventHandler, { checkForDefaultPrevented = true } = {}) {
     return function handleEvent(event) {
@@ -37020,7 +36810,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-context@1.1.4+b2e33729a97476bf/node_modules/@radix-ui/react-context/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-context@1.1.4+b2e33729a97476bf/node_modules/@radix-ui/react-context/dist/index.mjs
   var React4 = __toESM(require_react(), 1);
   var import_jsx_runtime3 = __toESM(require_jsx_runtime(), 1);
   function createContextScope(scopeName, createContextScopeDeps = []) {
@@ -37082,15 +36872,15 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return createScope;
   }
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-id@1.1.2+b2e33729a97476bf/node_modules/@radix-ui/react-id/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-id@1.1.2+b2e33729a97476bf/node_modules/@radix-ui/react-id/dist/index.mjs
   var React6 = __toESM(require_react(), 1);
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-use-layout-effect@1.1.2+b2e33729a97476bf/node_modules/@radix-ui/react-use-layout-effect/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-use-layout-effect@1.1.2+b2e33729a97476bf/node_modules/@radix-ui/react-use-layout-effect/dist/index.mjs
   var React5 = __toESM(require_react(), 1);
   var useLayoutEffect2 = globalThis?.document ? React5.useLayoutEffect : () => {
   };
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-id@1.1.2+b2e33729a97476bf/node_modules/@radix-ui/react-id/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-id@1.1.2+b2e33729a97476bf/node_modules/@radix-ui/react-id/dist/index.mjs
   var useReactId = React6[" useId ".trim().toString()] || (() => void 0);
   var count = 0;
   function useId(deterministicId) {
@@ -37101,7 +36891,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return deterministicId || (id ? `radix-${id}` : "");
   }
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-use-controllable-state@1.2.3+b2e33729a97476bf/node_modules/@radix-ui/react-use-controllable-state/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-use-controllable-state@1.2.3+b2e33729a97476bf/node_modules/@radix-ui/react-use-controllable-state/dist/index.mjs
   var React7 = __toESM(require_react(), 1);
   var React22 = __toESM(require_react(), 1);
   var useInsertionEffect = React7[" useInsertionEffect ".trim().toString()] || useLayoutEffect2;
@@ -37169,10 +36959,10 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return typeof value === "function";
   }
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-dismissable-layer@1.1.13+119c4f3973a6d299/node_modules/@radix-ui/react-dismissable-layer/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-dismissable-layer@1.1.13+119c4f3973a6d299/node_modules/@radix-ui/react-dismissable-layer/dist/index.mjs
   var React11 = __toESM(require_react(), 1);
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-primitive@2.1.6+119c4f3973a6d299/node_modules/@radix-ui/react-primitive/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-primitive@2.1.6+119c4f3973a6d299/node_modules/@radix-ui/react-primitive/dist/index.mjs
   var React8 = __toESM(require_react(), 1);
   var ReactDOM = __toESM(require_react_dom(), 1);
   var import_jsx_runtime4 = __toESM(require_jsx_runtime(), 1);
@@ -37212,7 +37002,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     if (target) ReactDOM.flushSync(() => target.dispatchEvent(event));
   }
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-use-callback-ref@1.1.2+b2e33729a97476bf/node_modules/@radix-ui/react-use-callback-ref/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-use-callback-ref@1.1.2+b2e33729a97476bf/node_modules/@radix-ui/react-use-callback-ref/dist/index.mjs
   var React9 = __toESM(require_react(), 1);
   function useCallbackRef(callback) {
     const callbackRef = React9.useRef(callback);
@@ -37222,7 +37012,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return React9.useMemo(() => ((...args) => callbackRef.current?.(...args)), []);
   }
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-use-escape-keydown@1.1.2+b2e33729a97476bf/node_modules/@radix-ui/react-use-escape-keydown/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-use-escape-keydown@1.1.2+b2e33729a97476bf/node_modules/@radix-ui/react-use-escape-keydown/dist/index.mjs
   var React10 = __toESM(require_react(), 1);
   function useEscapeKeydown(onEscapeKeyDownProp, ownerDocument = globalThis?.document) {
     const onEscapeKeyDown = useCallbackRef(onEscapeKeyDownProp);
@@ -37237,7 +37027,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     }, [onEscapeKeyDown, ownerDocument]);
   }
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-dismissable-layer@1.1.13+119c4f3973a6d299/node_modules/@radix-ui/react-dismissable-layer/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-dismissable-layer@1.1.13+119c4f3973a6d299/node_modules/@radix-ui/react-dismissable-layer/dist/index.mjs
   var import_jsx_runtime5 = __toESM(require_jsx_runtime(), 1);
   var DISMISSABLE_LAYER_NAME = "DismissableLayer";
   var CONTEXT_UPDATE = "dismissableLayer.update";
@@ -37552,7 +37342,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     }
   }
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-focus-scope@1.1.10+119c4f3973a6d299/node_modules/@radix-ui/react-focus-scope/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-focus-scope@1.1.10+119c4f3973a6d299/node_modules/@radix-ui/react-focus-scope/dist/index.mjs
   var React12 = __toESM(require_react(), 1);
   var import_jsx_runtime6 = __toESM(require_jsx_runtime(), 1);
   var AUTOFOCUS_ON_MOUNT = "focusScope.autoFocusOnMount";
@@ -37756,7 +37546,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return items.filter((item) => item.tagName !== "A");
   }
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-portal@1.1.12+119c4f3973a6d299/node_modules/@radix-ui/react-portal/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-portal@1.1.12+119c4f3973a6d299/node_modules/@radix-ui/react-portal/dist/index.mjs
   var React13 = __toESM(require_react(), 1);
   var ReactDOM2 = __toESM(require_react_dom(), 1);
   var import_jsx_runtime7 = __toESM(require_jsx_runtime(), 1);
@@ -37770,7 +37560,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   });
   Portal.displayName = PORTAL_NAME;
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-presence@1.1.6+119c4f3973a6d299/node_modules/@radix-ui/react-presence/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-presence@1.1.6+119c4f3973a6d299/node_modules/@radix-ui/react-presence/dist/index.mjs
   var React23 = __toESM(require_react(), 1);
   var React14 = __toESM(require_react(), 1);
   function useStateMachine(initialState, machine) {
@@ -37930,7 +37720,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return element.props.ref || element.ref;
   }
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-focus-guards@1.1.4+b2e33729a97476bf/node_modules/@radix-ui/react-focus-guards/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-focus-guards@1.1.4+b2e33729a97476bf/node_modules/@radix-ui/react-focus-guards/dist/index.mjs
   var React15 = __toESM(require_react(), 1);
   var count2 = 0;
   var guards = null;
@@ -37968,7 +37758,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return element;
   }
 
-  // ../pr-12727-run/node_modules/.bun/tslib@2.8.1/node_modules/tslib/tslib.es6.mjs
+  // ../../../node_modules/.bun/tslib@2.8.1/node_modules/tslib/tslib.es6.mjs
   var __assign = function() {
     __assign = Object.assign || function __assign2(t2) {
       for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -38000,19 +37790,19 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return to.concat(ar || Array.prototype.slice.call(from));
   }
 
-  // ../pr-12727-run/node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/Combination.js
+  // ../../../node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/Combination.js
   var React24 = __toESM(require_react());
 
-  // ../pr-12727-run/node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/UI.js
+  // ../../../node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/UI.js
   var React18 = __toESM(require_react());
 
-  // ../pr-12727-run/node_modules/.bun/react-remove-scroll-bar@2.3.8+b2e33729a97476bf/node_modules/react-remove-scroll-bar/dist/es2015/constants.js
+  // ../../../node_modules/.bun/react-remove-scroll-bar@2.3.8+b2e33729a97476bf/node_modules/react-remove-scroll-bar/dist/es2015/constants.js
   var zeroRightClassName = "right-scroll-bar-position";
   var fullWidthClassName = "width-before-scroll-bar";
   var noScrollbarsClassName = "with-scroll-bars-hidden";
   var removedBarSizeVariable = "--removed-body-scroll-bar-size";
 
-  // ../pr-12727-run/node_modules/.bun/use-callback-ref@1.3.3+b2e33729a97476bf/node_modules/use-callback-ref/dist/es2015/assignRef.js
+  // ../../../node_modules/.bun/use-callback-ref@1.3.3+b2e33729a97476bf/node_modules/use-callback-ref/dist/es2015/assignRef.js
   function assignRef(ref, value) {
     if (typeof ref === "function") {
       ref(value);
@@ -38022,7 +37812,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return ref;
   }
 
-  // ../pr-12727-run/node_modules/.bun/use-callback-ref@1.3.3+b2e33729a97476bf/node_modules/use-callback-ref/dist/es2015/useRef.js
+  // ../../../node_modules/.bun/use-callback-ref@1.3.3+b2e33729a97476bf/node_modules/use-callback-ref/dist/es2015/useRef.js
   var import_react7 = __toESM(require_react());
   function useCallbackRef2(initialValue, callback) {
     var ref = (0, import_react7.useState)(function() {
@@ -38050,7 +37840,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return ref.facade;
   }
 
-  // ../pr-12727-run/node_modules/.bun/use-callback-ref@1.3.3+b2e33729a97476bf/node_modules/use-callback-ref/dist/es2015/useMergeRef.js
+  // ../../../node_modules/.bun/use-callback-ref@1.3.3+b2e33729a97476bf/node_modules/use-callback-ref/dist/es2015/useMergeRef.js
   var React16 = __toESM(require_react());
   var useIsomorphicLayoutEffect = typeof window !== "undefined" ? React16.useLayoutEffect : React16.useEffect;
   var currentValues = /* @__PURE__ */ new WeakMap();
@@ -38082,7 +37872,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return callbackRef;
   }
 
-  // ../pr-12727-run/node_modules/.bun/use-sidecar@1.1.3+b2e33729a97476bf/node_modules/use-sidecar/dist/es2015/medium.js
+  // ../../../node_modules/.bun/use-sidecar@1.1.3+b2e33729a97476bf/node_modules/use-sidecar/dist/es2015/medium.js
   function ItoI(a) {
     return a;
   }
@@ -38168,7 +37958,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return medium;
   }
 
-  // ../pr-12727-run/node_modules/.bun/use-sidecar@1.1.3+b2e33729a97476bf/node_modules/use-sidecar/dist/es2015/exports.js
+  // ../../../node_modules/.bun/use-sidecar@1.1.3+b2e33729a97476bf/node_modules/use-sidecar/dist/es2015/exports.js
   var React17 = __toESM(require_react());
   var SideCar = function(_a3) {
     var sideCar = _a3.sideCar, rest = __rest(_a3, ["sideCar"]);
@@ -38187,10 +37977,10 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return SideCar;
   }
 
-  // ../pr-12727-run/node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/medium.js
+  // ../../../node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/medium.js
   var effectCar = createSidecarMedium();
 
-  // ../pr-12727-run/node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/UI.js
+  // ../../../node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/UI.js
   var nothing = function() {
     return;
   };
@@ -38222,16 +38012,16 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     zeroRight: zeroRightClassName
   };
 
-  // ../pr-12727-run/node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/SideEffect.js
+  // ../../../node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/SideEffect.js
   var React21 = __toESM(require_react());
 
-  // ../pr-12727-run/node_modules/.bun/react-remove-scroll-bar@2.3.8+b2e33729a97476bf/node_modules/react-remove-scroll-bar/dist/es2015/component.js
+  // ../../../node_modules/.bun/react-remove-scroll-bar@2.3.8+b2e33729a97476bf/node_modules/react-remove-scroll-bar/dist/es2015/component.js
   var React20 = __toESM(require_react());
 
-  // ../pr-12727-run/node_modules/.bun/react-style-singleton@2.2.3+b2e33729a97476bf/node_modules/react-style-singleton/dist/es2015/hook.js
+  // ../../../node_modules/.bun/react-style-singleton@2.2.3+b2e33729a97476bf/node_modules/react-style-singleton/dist/es2015/hook.js
   var React19 = __toESM(require_react());
 
-  // ../pr-12727-run/node_modules/.bun/get-nonce@1.0.1/node_modules/get-nonce/dist/es2015/index.js
+  // ../../../node_modules/.bun/get-nonce@1.0.1/node_modules/get-nonce/dist/es2015/index.js
   var currentNonce;
   var getNonce = function() {
     if (currentNonce) {
@@ -38243,7 +38033,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return void 0;
   };
 
-  // ../pr-12727-run/node_modules/.bun/react-style-singleton@2.2.3+b2e33729a97476bf/node_modules/react-style-singleton/dist/es2015/singleton.js
+  // ../../../node_modules/.bun/react-style-singleton@2.2.3+b2e33729a97476bf/node_modules/react-style-singleton/dist/es2015/singleton.js
   function makeStyleTag() {
     if (!document)
       return null;
@@ -38289,7 +38079,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     };
   };
 
-  // ../pr-12727-run/node_modules/.bun/react-style-singleton@2.2.3+b2e33729a97476bf/node_modules/react-style-singleton/dist/es2015/hook.js
+  // ../../../node_modules/.bun/react-style-singleton@2.2.3+b2e33729a97476bf/node_modules/react-style-singleton/dist/es2015/hook.js
   var styleHookSingleton = function() {
     var sheet = stylesheetSingleton();
     return function(styles3, isDynamic) {
@@ -38302,7 +38092,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     };
   };
 
-  // ../pr-12727-run/node_modules/.bun/react-style-singleton@2.2.3+b2e33729a97476bf/node_modules/react-style-singleton/dist/es2015/component.js
+  // ../../../node_modules/.bun/react-style-singleton@2.2.3+b2e33729a97476bf/node_modules/react-style-singleton/dist/es2015/component.js
   var styleSingleton = function() {
     var useStyle = styleHookSingleton();
     var Sheet = function(_a3) {
@@ -38313,7 +38103,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return Sheet;
   };
 
-  // ../pr-12727-run/node_modules/.bun/react-remove-scroll-bar@2.3.8+b2e33729a97476bf/node_modules/react-remove-scroll-bar/dist/es2015/utils.js
+  // ../../../node_modules/.bun/react-remove-scroll-bar@2.3.8+b2e33729a97476bf/node_modules/react-remove-scroll-bar/dist/es2015/utils.js
   var zeroGap = {
     left: 0,
     top: 0,
@@ -38348,7 +38138,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     };
   };
 
-  // ../pr-12727-run/node_modules/.bun/react-remove-scroll-bar@2.3.8+b2e33729a97476bf/node_modules/react-remove-scroll-bar/dist/es2015/component.js
+  // ../../../node_modules/.bun/react-remove-scroll-bar@2.3.8+b2e33729a97476bf/node_modules/react-remove-scroll-bar/dist/es2015/component.js
   var Style = styleSingleton();
   var lockAttribute = "data-scroll-locked";
   var getStyles = function(_a3, allowRelative, gapMode, important) {
@@ -38388,7 +38178,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return React20.createElement(Style, { styles: getStyles(gap, !noRelative, gapMode, !noImportant ? "!important" : "") });
   };
 
-  // ../pr-12727-run/node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/aggresiveCapture.js
+  // ../../../node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/aggresiveCapture.js
   var passiveSupported = false;
   if (typeof window !== "undefined") {
     try {
@@ -38407,7 +38197,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   var options;
   var nonPassive = passiveSupported ? { passive: false } : false;
 
-  // ../pr-12727-run/node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/handleScroll.js
+  // ../../../node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/handleScroll.js
   var alwaysContainsScroll = function(node) {
     return node.tagName === "TEXTAREA";
   };
@@ -38507,7 +38297,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return shouldCancelScroll;
   };
 
-  // ../pr-12727-run/node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/SideEffect.js
+  // ../../../node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/SideEffect.js
   var getTouchXY = function(event) {
     return "changedTouches" in event ? [event.changedTouches[0].clientX, event.changedTouches[0].clientY] : [0, 0];
   };
@@ -38678,17 +38468,17 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return shadowParent;
   }
 
-  // ../pr-12727-run/node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/sidecar.js
+  // ../../../node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/sidecar.js
   var sidecar_default = exportSidecar(effectCar, RemoveScrollSideCar);
 
-  // ../pr-12727-run/node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/Combination.js
+  // ../../../node_modules/.bun/react-remove-scroll@2.7.2+b2e33729a97476bf/node_modules/react-remove-scroll/dist/es2015/Combination.js
   var ReactRemoveScroll = React24.forwardRef(function(props, ref) {
     return React24.createElement(RemoveScroll, __assign({}, props, { ref, sideCar: sidecar_default }));
   });
   ReactRemoveScroll.classNames = RemoveScroll.classNames;
   var Combination_default = ReactRemoveScroll;
 
-  // ../pr-12727-run/node_modules/.bun/aria-hidden@1.2.6/node_modules/aria-hidden/dist/es2015/index.js
+  // ../../../node_modules/.bun/aria-hidden@1.2.6/node_modules/aria-hidden/dist/es2015/index.js
   var getDefaultParent = function(originalTarget) {
     if (typeof document === "undefined") {
       return null;
@@ -38809,7 +38599,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return applyAttributeToOthers(targets, activeParentNode, markerName, "aria-hidden");
   };
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-dialog@1.1.17+119c4f3973a6d299/node_modules/@radix-ui/react-dialog/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-dialog@1.1.17+119c4f3973a6d299/node_modules/@radix-ui/react-dialog/dist/index.mjs
   var import_jsx_runtime8 = __toESM(require_jsx_runtime(), 1);
   var DIALOG_NAME = "Dialog";
   var [createDialogContext, createDialogScope] = createContextScope(DIALOG_NAME);
@@ -39162,7 +38952,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   // packages/ui/src/components/ui/field.tsx
   var React29 = __toESM(require_react(), 1);
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-label@2.1.10+119c4f3973a6d299/node_modules/@radix-ui/react-label/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-label@2.1.10+119c4f3973a6d299/node_modules/@radix-ui/react-label/dist/index.mjs
   var React27 = __toESM(require_react(), 1);
   var import_jsx_runtime10 = __toESM(require_jsx_runtime(), 1);
   var NAME = "Label";
@@ -39352,7 +39142,6 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   );
 
   // packages/ui/src/first-run/mobile-runtime-mode.ts
-  init_events3();
   var MOBILE_LOCAL_AGENT_API_BASE = `http://127.0.0.1:${DEFAULT_DESKTOP_API_PORT}`;
   var MOBILE_LOCAL_AGENT_IPC_BASE = "eliza-local-agent://ipc";
   var MOBILE_LOCAL_AGENT_PORT = String(DEFAULT_DESKTOP_API_PORT);
@@ -39481,7 +39270,6 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
 
   // packages/ui/src/bridge/capacitor-bridge.ts
   init_dist();
-  init_events3();
 
   // packages/ui/src/bridge/plugin-bridge.ts
   init_dist();
@@ -39501,7 +39289,157 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   // packages/ui/src/bridge/storage-bridge.ts
   init_dist();
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/tools.js
+  // packages/ui/src/utils/desktop-dialogs.ts
+  init_electrobun_rpc();
+  function formatFallbackDialogText(options2) {
+    return [options2.title, options2.message, options2.detail].filter(Boolean).join("\n\n");
+  }
+  function coerceButtonIndex(value) {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "bigint") return Number(value);
+    if (typeof value === "string") {
+      const n = Number.parseInt(value.trim(), 10);
+      if (!Number.isNaN(n)) return n;
+    }
+    return null;
+  }
+  function parseMessageBoxButtonIndex(payload) {
+    if (payload === null || payload === void 0) return null;
+    if (typeof payload === "object" && payload !== null) {
+      const o = payload;
+      if ("data" in o) {
+        const inner = parseMessageBoxButtonIndex(o.data);
+        if (inner !== null) return inner;
+      }
+      if ("result" in o) {
+        const inner = parseMessageBoxButtonIndex(o.result);
+        if (inner !== null) return inner;
+      }
+      if ("payload" in o) {
+        const inner = parseMessageBoxButtonIndex(o.payload);
+        if (inner !== null) return inner;
+      }
+    }
+    const direct = coerceButtonIndex(payload);
+    if (direct !== null) return direct;
+    if (typeof payload === "object" && payload !== null && "response" in payload) {
+      return coerceButtonIndex(payload.response);
+    }
+    return null;
+  }
+  async function yieldWebviewAfterNativeDialog() {
+    if (typeof window === "undefined") return;
+    await Promise.resolve();
+    await new Promise((resolve) => {
+      queueMicrotask(() => resolve());
+    });
+    await new Promise((resolve) => {
+      window.setTimeout(() => resolve(), 0);
+    });
+    await new Promise((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      };
+      window.setTimeout(finish, 100);
+      window.requestAnimationFrame(finish);
+    });
+  }
+  async function confirmDesktopAction(options2) {
+    const payload = await invokeDesktopBridgeRequest({
+      rpcMethod: "desktopShowMessageBox",
+      ipcChannel: "desktop:showMessageBox",
+      params: {
+        type: options2.type ?? "question",
+        title: options2.title,
+        message: options2.message,
+        detail: options2.detail,
+        buttons: [
+          options2.confirmLabel ?? "Confirm",
+          options2.cancelLabel ?? "Cancel"
+        ],
+        defaultId: 0,
+        cancelId: 1
+      }
+    });
+    const usedNativeBridge = payload !== null && payload !== void 0;
+    const idx = parseMessageBoxButtonIndex(payload);
+    let confirmed;
+    if (usedNativeBridge && idx !== null) {
+      confirmed = idx === 0;
+    } else if (usedNativeBridge) {
+      if (typeof window === "undefined") {
+        confirmed = false;
+      } else {
+        confirmed = window.confirm(formatFallbackDialogText(options2));
+      }
+    } else if (typeof window === "undefined") {
+      return false;
+    } else {
+      confirmed = window.confirm(formatFallbackDialogText(options2));
+    }
+    if (confirmed && usedNativeBridge && isElectrobunRuntime()) {
+      await yieldWebviewAfterNativeDialog();
+    }
+    return confirmed;
+  }
+
+  // packages/ui/src/utils/desktop-workspace.ts
+  var DESKTOP_WORKSPACE_SURFACES = [
+    {
+      id: "chat",
+      label: "Chat Window",
+      description: "Open a detached chat session window."
+    },
+    {
+      id: "release",
+      label: "Release Center",
+      description: "Open the detached release center window."
+    },
+    {
+      id: "triggers",
+      label: "Heartbeats Window",
+      description: "Open scheduled trigger controls in a detached window."
+    },
+    {
+      id: "plugins",
+      label: "Plugins Window",
+      description: "Open plugin controls in a detached window."
+    },
+    {
+      id: "cloud",
+      label: "Cloud Window",
+      description: "Open Eliza Cloud controls in a detached window."
+    }
+  ];
+
+  // packages/ui/src/utils/format.ts
+  function formatRelativeTime(value, t2) {
+    const date5 = value instanceof Date ? value : new Date(value);
+    const time3 = date5.getTime();
+    if (!Number.isFinite(time3)) {
+      return t2 ? t2("conversations.justNow") : "just now";
+    }
+    const diffMs = Date.now() - time3;
+    const diffMins = Math.floor(diffMs / 6e4);
+    const diffHours = Math.floor(diffMs / 36e5);
+    const diffDays = Math.floor(diffMs / 864e5);
+    if (diffMins < 1) return t2 ? t2("conversations.justNow") : "just now";
+    if (diffMins < 60) {
+      return t2 ? t2("conversations.minutesAgo", { count: diffMins }) : `${diffMins}m ago`;
+    }
+    if (diffHours < 24) {
+      return t2 ? t2("conversations.hoursAgo", { count: diffHours }) : `${diffHours}h ago`;
+    }
+    if (diffDays < 7) {
+      return t2 ? t2("conversations.daysAgo", { count: diffDays }) : `${diffDays}d ago`;
+    }
+    return date5.toLocaleDateString();
+  }
+
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/tools.js
   var Tools = class {
     /**
      * Reference to the global store.
@@ -39553,7 +39491,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     }
   };
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/adze-global.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/adze-global.js
   var AdzeGlobal = class {
     /**
      * Global Adze configuration overrides.
@@ -39666,7 +39604,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     }
   };
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/global.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/global.js
   function setup(cfg) {
     globalThis.$adzeGlobal = new AdzeGlobal(cfg);
     return globalThis.$adzeGlobal;
@@ -39708,7 +39646,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return false;
   }
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/type-guards.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/type-guards.js
   function isString(value) {
     return Object.prototype.toString.call(value) === "[object String]";
   }
@@ -39731,7 +39669,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return Array.isArray(value) && value.length === 3 && value[1] === "-";
   }
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/data.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/data.js
   function stacktrace() {
     return Error().stack?.replace(/^Error\n/, "\n");
   }
@@ -39741,11 +39679,11 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return cfg.levels[cfg.activeLevel].level;
   }
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/picocolors-loader.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/picocolors-loader.js
   var _picocolors = __toESM(require_picocolors_browser(), 1);
   var picocolors = _picocolors.default ?? _picocolors;
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/util.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/util.js
   function initialCaps(str) {
     return str.charAt(0).toUpperCase() + str.slice(1);
   }
@@ -39781,7 +39719,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return typeof val === "object" && val !== null;
   }
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/filters.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/filters.js
   function normalizeLevelSelector(levels, selector) {
     if (selector === "*")
       return Object.values(levels).map((lvl) => lvl.level);
@@ -39843,7 +39781,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     });
   }
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/formatters.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/formatters.js
   function formatNamespace(ns) {
     if (ns && ns.length > 0) {
       return ns.reduce((acc, name) => `${acc}#${name} `, "");
@@ -39863,7 +39801,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return expression !== void 0 && expression ? `${withEmoji ? "\u2705 " : ""}Expression passed:` : "";
   }
 
-  // ../pr-12727-run/node_modules/.bun/@ungap+structured-clone@1.2.0/node_modules/@ungap/structured-clone/esm/types.js
+  // ../../../node_modules/.bun/@ungap+structured-clone@1.2.0/node_modules/@ungap/structured-clone/esm/types.js
   var VOID = -1;
   var PRIMITIVE = 0;
   var ARRAY = 1;
@@ -39875,7 +39813,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   var ERROR = 7;
   var BIGINT = 8;
 
-  // ../pr-12727-run/node_modules/.bun/@ungap+structured-clone@1.2.0/node_modules/@ungap/structured-clone/esm/deserialize.js
+  // ../../../node_modules/.bun/@ungap+structured-clone@1.2.0/node_modules/@ungap/structured-clone/esm/deserialize.js
   var env = typeof self === "object" ? self : globalThis;
   var deserializer = ($, _) => {
     const as = (out, index2) => {
@@ -39935,7 +39873,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   };
   var deserialize = (serialized) => deserializer(/* @__PURE__ */ new Map(), serialized)(0);
 
-  // ../pr-12727-run/node_modules/.bun/@ungap+structured-clone@1.2.0/node_modules/@ungap/structured-clone/esm/serialize.js
+  // ../../../node_modules/.bun/@ungap+structured-clone@1.2.0/node_modules/@ungap/structured-clone/esm/serialize.js
   var EMPTY = "";
   var { toString } = {};
   var { keys } = Object;
@@ -40059,13 +39997,13 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return serializer(!(json3 || lossy), !!json3, /* @__PURE__ */ new Map(), _)(value), _;
   };
 
-  // ../pr-12727-run/node_modules/.bun/@ungap+structured-clone@1.2.0/node_modules/@ungap/structured-clone/esm/index.js
+  // ../../../node_modules/.bun/@ungap+structured-clone@1.2.0/node_modules/@ungap/structured-clone/esm/index.js
   var esm_default = typeof structuredClone === "function" ? (
     /* c8 ignore start */
     (any2, options2) => options2 && ("json" in options2 || "lossy" in options2) ? deserialize(serialize(any2, options2)) : structuredClone(any2)
   ) : (any2, options2) => deserialize(serialize(any2, options2));
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/seal.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/seal.js
   function SealedLog(Base, cfg, mods, modifierQueue) {
     const { formatters, middleware = [], ...cfgWithoutFormatters } = cfg.exportValues();
     const sealing = class Sealing extends Base {
@@ -40081,7 +40019,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return sealed;
   }
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/time.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/functions/time.js
   function formatTime([sec, nano]) {
     return `${sec}s ${nano / 1e6}ms`;
   }
@@ -40141,7 +40079,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return `${day}/${month}/${year}:${hours}:${minutes}:${seconds} ${timezone}`;
   }
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/formatter.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/formatter.js
   var Formatter = class {
     /**
      * The configuration for the adze log.
@@ -40238,7 +40176,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     }
   };
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/common/common.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/common/common.js
   var CommonFormatter = class extends Formatter {
     /**
      * Format the date in the strftime format.
@@ -40276,15 +40214,15 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     }
   };
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/common/index.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/common/index.js
   var common_default = CommonFormatter;
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/json/type-guards.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/json/type-guards.js
   function hasRequiredFields(meta3) {
     return typeof meta3.name === "string" && typeof meta3.hostname === "string";
   }
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/json/json.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/json/json.js
   var JsonFormatter = class extends Formatter {
     /**
      * Format the date in the ISO8601 format by default.
@@ -40379,10 +40317,10 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return value;
   }
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/json/index.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/json/index.js
   var json_default = JsonFormatter;
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/pretty/pretty.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/pretty/pretty.js
   var PrettyFormatter = class extends Formatter {
     /**
      * Format the log message for the browser.
@@ -40452,10 +40390,10 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     }
   };
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/pretty/index.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/pretty/index.js
   var pretty_default = PrettyFormatter;
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/standard/standard.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/formatters/standard/standard.js
   var StandardFormatter = class extends Formatter {
     /**
      * Format the date in the ISO8601 format by default.
@@ -40504,7 +40442,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     }
   };
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/constants.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/constants.js
   var specialMethodsWithArgsAndLeader = ["group", "groupCollapsed"];
   var specialMethodsWithArgs = [
     "dir",
@@ -40654,7 +40592,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/configuration.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/configuration.js
   var Configuration = class {
     /**
      * The log defined configuration.
@@ -40791,7 +40729,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     }
   };
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/log.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/log.js
   function isCallback(maybeFunction) {
     return typeof maybeFunction === "function";
   }
@@ -41917,7 +41855,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     }
   };
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/_types/styles.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/_types/styles.js
   var styles_raw = [
     "black",
     "red",
@@ -41963,7 +41901,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   ];
   var console_styles = Object.freeze(styles_raw);
 
-  // ../pr-12727-run/node_modules/.bun/adze@2.3.0/node_modules/adze/dist/index.js
+  // ../../../node_modules/.bun/adze@2.3.0/node_modules/adze/dist/index.js
   var dist_default = Log;
 
   // packages/logger/src/env.ts
@@ -42580,156 +42518,6 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   }
   var logger = createLogger();
 
-  // packages/ui/src/utils/desktop-dialogs.ts
-  init_electrobun_rpc();
-  function formatFallbackDialogText(options2) {
-    return [options2.title, options2.message, options2.detail].filter(Boolean).join("\n\n");
-  }
-  function coerceButtonIndex(value) {
-    if (typeof value === "number" && Number.isFinite(value)) return value;
-    if (typeof value === "bigint") return Number(value);
-    if (typeof value === "string") {
-      const n = Number.parseInt(value.trim(), 10);
-      if (!Number.isNaN(n)) return n;
-    }
-    return null;
-  }
-  function parseMessageBoxButtonIndex(payload) {
-    if (payload === null || payload === void 0) return null;
-    if (typeof payload === "object" && payload !== null) {
-      const o = payload;
-      if ("data" in o) {
-        const inner = parseMessageBoxButtonIndex(o.data);
-        if (inner !== null) return inner;
-      }
-      if ("result" in o) {
-        const inner = parseMessageBoxButtonIndex(o.result);
-        if (inner !== null) return inner;
-      }
-      if ("payload" in o) {
-        const inner = parseMessageBoxButtonIndex(o.payload);
-        if (inner !== null) return inner;
-      }
-    }
-    const direct = coerceButtonIndex(payload);
-    if (direct !== null) return direct;
-    if (typeof payload === "object" && payload !== null && "response" in payload) {
-      return coerceButtonIndex(payload.response);
-    }
-    return null;
-  }
-  async function yieldWebviewAfterNativeDialog() {
-    if (typeof window === "undefined") return;
-    await Promise.resolve();
-    await new Promise((resolve) => {
-      queueMicrotask(() => resolve());
-    });
-    await new Promise((resolve) => {
-      window.setTimeout(() => resolve(), 0);
-    });
-    await new Promise((resolve) => {
-      let settled = false;
-      const finish = () => {
-        if (settled) return;
-        settled = true;
-        resolve();
-      };
-      window.setTimeout(finish, 100);
-      window.requestAnimationFrame(finish);
-    });
-  }
-  async function confirmDesktopAction(options2) {
-    const payload = await invokeDesktopBridgeRequest({
-      rpcMethod: "desktopShowMessageBox",
-      ipcChannel: "desktop:showMessageBox",
-      params: {
-        type: options2.type ?? "question",
-        title: options2.title,
-        message: options2.message,
-        detail: options2.detail,
-        buttons: [
-          options2.confirmLabel ?? "Confirm",
-          options2.cancelLabel ?? "Cancel"
-        ],
-        defaultId: 0,
-        cancelId: 1
-      }
-    });
-    const usedNativeBridge = payload !== null && payload !== void 0;
-    const idx = parseMessageBoxButtonIndex(payload);
-    let confirmed;
-    if (usedNativeBridge && idx !== null) {
-      confirmed = idx === 0;
-    } else if (usedNativeBridge) {
-      if (typeof window === "undefined") {
-        confirmed = false;
-      } else {
-        confirmed = window.confirm(formatFallbackDialogText(options2));
-      }
-    } else if (typeof window === "undefined") {
-      return false;
-    } else {
-      confirmed = window.confirm(formatFallbackDialogText(options2));
-    }
-    if (confirmed && usedNativeBridge && isElectrobunRuntime()) {
-      await yieldWebviewAfterNativeDialog();
-    }
-    return confirmed;
-  }
-
-  // packages/ui/src/utils/desktop-workspace.ts
-  var DESKTOP_WORKSPACE_SURFACES = [
-    {
-      id: "chat",
-      label: "Chat Window",
-      description: "Open a detached chat session window."
-    },
-    {
-      id: "release",
-      label: "Release Center",
-      description: "Open the detached release center window."
-    },
-    {
-      id: "triggers",
-      label: "Triggers Window",
-      description: "Open scheduled trigger controls in a detached window."
-    },
-    {
-      id: "plugins",
-      label: "Plugins Window",
-      description: "Open plugin controls in a detached window."
-    },
-    {
-      id: "cloud",
-      label: "Cloud Window",
-      description: "Open Eliza Cloud controls in a detached window."
-    }
-  ];
-
-  // packages/ui/src/utils/format.ts
-  function formatRelativeTime(value, t2) {
-    const date5 = value instanceof Date ? value : new Date(value);
-    const time3 = date5.getTime();
-    if (!Number.isFinite(time3)) {
-      return t2 ? t2("conversations.justNow") : "just now";
-    }
-    const diffMs = Date.now() - time3;
-    const diffMins = Math.floor(diffMs / 6e4);
-    const diffHours = Math.floor(diffMs / 36e5);
-    const diffDays = Math.floor(diffMs / 864e5);
-    if (diffMins < 1) return t2 ? t2("conversations.justNow") : "just now";
-    if (diffMins < 60) {
-      return t2 ? t2("conversations.minutesAgo", { count: diffMins }) : `${diffMins}m ago`;
-    }
-    if (diffHours < 24) {
-      return t2 ? t2("conversations.hoursAgo", { count: diffHours }) : `${diffHours}h ago`;
-    }
-    if (diffDays < 7) {
-      return t2 ? t2("conversations.daysAgo", { count: diffDays }) : `${diffDays}d ago`;
-    }
-    return date5.toLocaleDateString();
-  }
-
   // packages/ui/src/terminal/theme.ts
   var hasForceColor = typeof process.env.FORCE_COLOR === "string" && process.env.FORCE_COLOR.trim().length > 0 && process.env.FORCE_COLOR.trim() !== "0";
   var hasNoColor = process.env.NO_COLOR !== void 0;
@@ -42798,7 +42586,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
 
   // packages/ui/src/first-run/local-agent-token.ts
   init_dist();
-  init_native_plugins();
+  var agentPluginName = "Agent";
   function isAndroidLocalAgentUrl(value) {
     return isMobileLocalAgentUrl(value);
   }
@@ -42812,7 +42600,8 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   async function readNativeLocalAgentToken() {
     let agent = null;
     try {
-      agent = getAgentPlugin();
+      const capacitorWithPlugins = Capacitor;
+      agent = capacitorWithPlugins.Plugins?.[agentPluginName] ?? Capacitor.registerPlugin(agentPluginName);
     } catch {
       agent = null;
     }
@@ -42854,8 +42643,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     return bytes;
   }
   async function createNativeStreamingResponse(agent, options2) {
-    const stream = await agent.requestStream(options2);
-    const { streamId } = stream;
+    const { streamId } = await agent.requestStream(options2);
     let controller = null;
     const pending = [];
     let terminal = null;
@@ -42865,13 +42653,6 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
       if (detached) return;
       detached = true;
       for (const handle of handles) void handle.remove();
-    };
-    const trackHandle = (handle) => {
-      if (detached) {
-        void handle.remove();
-        return;
-      }
-      handles.push(handle);
     };
     const body = new ReadableStream({
       start(c) {
@@ -42894,25 +42675,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
       resolveHead = resolve;
       rejectHead = reject;
     });
-    void head.catch(() => {
-    });
     let headSettled = false;
-    const failStream = (reason) => {
-      if (detached) return;
-      const error51 = reason instanceof Error ? reason : new Error(String(reason ?? "Stream failed"));
-      if (!headSettled) {
-        headSettled = true;
-        rejectHead(error51);
-        detach();
-        return;
-      }
-      if (controller) {
-        controller.error(error51);
-        detach();
-      } else {
-        terminal = { error: error51.message };
-      }
-    };
     const onResponse = (event) => {
       const e = event;
       if (!e || e.streamId !== streamId || headSettled) return;
@@ -42949,12 +42712,9 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
         terminal = { error: e.error };
       }
     };
-    if (stream.completion) {
-      void stream.completion.catch(failStream);
-    }
-    trackHandle(await agent.addListener("agentStreamResponse", onResponse));
-    trackHandle(await agent.addListener("agentStreamChunk", onChunk));
-    trackHandle(await agent.addListener("agentStreamComplete", onComplete));
+    handles.push(await agent.addListener("agentStreamResponse", onResponse));
+    handles.push(await agent.addListener("agentStreamChunk", onChunk));
+    handles.push(await agent.addListener("agentStreamComplete", onComplete));
     return head;
   }
 
@@ -42994,7 +42754,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   }
 
   // packages/ui/src/api/android-native-agent-transport.ts
-  var agentPluginName = "Agent";
+  var agentPluginName2 = "Agent";
   var nativeTransportPromise = null;
   function toNativeAgentPlugin(plugin) {
     if (!plugin) return null;
@@ -43035,7 +42795,7 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   async function resolveNativeAgentPlugin() {
     try {
       const capacitorWithPlugins = Capacitor;
-      const registeredAgent = capacitorWithPlugins.Plugins?.[agentPluginName] ?? Capacitor.registerPlugin(agentPluginName);
+      const registeredAgent = capacitorWithPlugins.Plugins?.[agentPluginName2] ?? Capacitor.registerPlugin(agentPluginName2);
       const agent = toNativeAgentPlugin(registeredAgent);
       if (agent) return agent;
     } catch {
@@ -43211,45 +42971,6 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   };
   function desktopHttpTransportForUrl(url2) {
     return isElectrobunRuntime() && (isExternalPlainHttpUrl(url2) || isDesktopExternalHttpApiBaseUrl(url2)) ? desktopHttpTransport : null;
-  }
-
-  // packages/ui/src/api/desktop-local-agent-transport.ts
-  init_electrobun_rpc();
-  function isElectrobunLocalMode(url2) {
-    return isElectrobunRuntime() && isMobileLocalAgentIpcUrl(url2);
-  }
-  var desktopLocalAgentTransport = {
-    async request(url2, init, context) {
-      const rpc = getElectrobunRendererRpc();
-      const request = rpc?.request?.localAgentRequest;
-      if (!request || !rpc?.request) {
-        throw new Error(
-          "Desktop local-agent IPC transport is not available: window.__ELIZA_ELECTROBUN_RPC__.request.localAgentRequest is not registered (#12180 item 4 not yet landed)"
-        );
-      }
-      const method = init.method ?? "GET";
-      const body = bodyToString(init.body);
-      const result = await request.call(rpc.request, {
-        // The path relative to the IPC base; the main process joins it to the
-        // in-process route kernel. Fall back to the raw url if it is not an IPC
-        // URL (should not happen — the resolver gates on isElectrobunLocalMode).
-        path: mobileLocalAgentPathFromUrl(url2) ?? url2,
-        method,
-        headers: headersToRecord(init.headers),
-        body: methodAllowsBody(method) ? body ?? null : null,
-        timeoutMs: context?.timeoutMs
-      });
-      return new Response(result.body ?? "", {
-        status: result.status,
-        statusText: result.statusText ?? "",
-        headers: result.headers
-      });
-    }
-  };
-  function desktopLocalAgentTransportForUrl(url2) {
-    return Promise.resolve(
-      isElectrobunLocalMode(url2) ? desktopLocalAgentTransport : null
-    );
   }
 
   // packages/ui/src/api/ios-local-agent-transport.ts
@@ -46333,39 +46054,6 @@ Assistant:`;
     return json2({ error: "Not found" }, 404);
   }
 
-  // packages/ui/src/api/ios-streaming-agent-plugin.ts
-  function newStreamId() {
-    const uuid3 = typeof globalThis.crypto?.randomUUID === "function" ? globalThis.crypto.randomUUID() : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-    return `ios-stream-${uuid3}`;
-  }
-  function createIosStreamingAgentPlugin(runtime, onStreamError) {
-    return {
-      requestStream(options2) {
-        const streamId = newStreamId();
-        const completion = runtime.call({
-          method: "http_request_stream",
-          args: {
-            method: options2.method,
-            path: options2.path,
-            headers: options2.headers,
-            body: options2.body,
-            timeoutMs: options2.timeoutMs,
-            streamId
-          }
-        }).catch((error51) => {
-          onStreamError?.(error51);
-          throw error51;
-        });
-        void completion.catch(() => {
-        });
-        return Promise.resolve({ streamId, completion });
-      },
-      addListener(eventName, listener) {
-        return runtime.addListener(eventName, listener);
-      }
-    };
-  }
-
   // packages/ui/src/api/ittp-agent-transport.ts
   function dispatchIttpRouteKernel(kernel, request, context) {
     if (typeof kernel === "function") return kernel(request, context);
@@ -46576,13 +46264,6 @@ Assistant:`;
   function normalizeHost(host) {
     return (host ?? "").trim().toLowerCase().replace(/^\[|\]$/g, "");
   }
-  function isLoopbackHost(host) {
-    const normalized = normalizeHost(host);
-    return normalized === "localhost" || normalized === "::1" || normalized.startsWith("127.");
-  }
-  function allowsIosSimulatorLoopback(url2) {
-    return !isNativeIosStoreBuild() && isTruthyBuildFlag(viteEnv2().VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK) && isLoopbackHost(url2.hostname);
-  }
   function isPrivateOrLoopbackHost(host) {
     const normalized = normalizeHost(host);
     return normalized === "localhost" || normalized === "::1" || normalized === "0.0.0.0" || normalized.startsWith("127.") || normalized.startsWith("10.") || normalized.startsWith("192.168.") || /^172\.(1[6-9]|2\d|3[0-1])\./.test(normalized) || /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(normalized) || normalized.startsWith("169.254.") || normalized.includes(":") && (normalized.startsWith("fe80:") || normalized.startsWith("fc") || normalized.startsWith("fd")) || normalized === "local" || normalized === "internal" || normalized === "lan" || normalized === "ts.net" || normalized.endsWith(".local") || normalized.endsWith(".internal") || normalized.endsWith(".lan") || normalized.endsWith(".ts.net");
@@ -46637,8 +46318,7 @@ Assistant:`;
     return {
       start: runtime.start.bind(runtime),
       getStatus: runtime.getStatus.bind(runtime),
-      call: runtime.call.bind(runtime),
-      addListener: runtime.addListener?.bind(runtime)
+      call: runtime.call.bind(runtime)
     };
   }
   function isIosInProcessLocalAgentUrl(url2) {
@@ -46648,7 +46328,7 @@ Assistant:`;
       if (isIosLocalAgentIpcUrl(parsed)) {
         return canUseIosLocalAgentIpc() || isCloudRuntimeAllowedIpcPath(parsed);
       }
-      if (usesStrictIosNetworkPolicy() && isCleartextNetworkUrl(parsed) && isPrivateOrLoopbackHost(parsed.hostname) && !allowsIosSimulatorLoopback(parsed)) {
+      if (usesStrictIosNetworkPolicy() && isCleartextNetworkUrl(parsed) && isPrivateOrLoopbackHost(parsed.hostname)) {
         return false;
       }
     } catch {
@@ -46836,37 +46516,8 @@ Assistant:`;
       headers: result.headers
     });
   }
-  async function tryFullBunStreamingResponse(options2) {
-    const runtime = await getFullBunRuntime();
-    if (!runtime?.addListener) return null;
-    const plugin = createIosStreamingAgentPlugin(
-      { call: runtime.call, addListener: runtime.addListener },
-      (error51) => {
-        console.warn("[ios-local-agent] stream request failed after head", {
-          path: options2.path?.slice(0, 120) ?? null,
-          error: error51 instanceof Error ? error51.message : String(error51)
-        });
-      }
-    );
-    const response = await createNativeStreamingResponse(plugin, {
-      method: options2.method,
-      path: options2.path,
-      headers: options2.headers,
-      body: options2.body ?? null,
-      timeoutMs: options2.timeoutMs
-    });
-    recordIosNativeAgentBootHeartbeat();
-    return response;
-  }
   async function dispatchIosLocalAgentRequest(request, context) {
     const options2 = await requestToNativeBridgeOptions(request, context);
-    if (isStreamingRequest(request.url, request.headers)) {
-      try {
-        const streamed = await tryFullBunStreamingResponse(options2);
-        if (streamed) return streamed;
-      } catch {
-      }
-    }
     return nativeResultToResponse(
       await handleIosLocalAgentNativeRequest(options2)
     );
@@ -46951,7 +46602,7 @@ Assistant:`;
       if (isCloudRuntimeAllowedIpcPath(url2)) return true;
       throw new TypeError(IOS_CLOUD_MODE_LOCAL_IPC_POLICY_MESSAGE);
     }
-    if (usesStrictIosNetworkPolicy() && isCleartextNetworkUrl(url2) && (isNativeIosStoreBuild() || isPrivateOrLoopbackHost(url2.hostname)) && !allowsIosSimulatorLoopback(url2)) {
+    if (usesStrictIosNetworkPolicy() && isCleartextNetworkUrl(url2) && (isNativeIosStoreBuild() || isPrivateOrLoopbackHost(url2.hostname))) {
       throw new TypeError(
         "iOS store/cloud builds block cleartext loopback or private-network requests"
       );
@@ -47168,7 +46819,7 @@ Assistant:`;
       credentials: "include",
       headers
     };
-    const transport2 = await androidNativeAgentTransportForUrl(url2) ?? await iosInProcessAgentTransportForUrl(url2) ?? await desktopLocalAgentTransportForUrl(url2) ?? desktopHttpTransportForUrl(url2) ?? nativeCloudHttpTransportForUrl(url2) ?? fetchAgentTransport;
+    const transport2 = await androidNativeAgentTransportForUrl(url2) ?? await iosInProcessAgentTransportForUrl(url2) ?? desktopHttpTransportForUrl(url2) ?? nativeCloudHttpTransportForUrl(url2) ?? fetchAgentTransport;
     return transport2.request(url2, requestInit, {
       timeoutMs: defaultFetchTimeoutMs(url2, requestInit)
     });
@@ -47373,21 +47024,21 @@ Assistant:`;
     "automations.coordinatorDescriptionPlaceholder": "What should the coordinator do...",
     "automations.coordinatorNamePlaceholder": "Coordinator automation name...",
     "automations.createCoordinator": "Create coordinator",
-    "automations.createTask": "Create prompt automation",
-    "automations.createTaskOrWorkflow": "Create automation",
+    "automations.createTask": "Create Task",
+    "automations.createTaskOrWorkflow": "Create task or workflow",
     "automations.editCoordinator": "Edit coordinator",
-    "automations.editTask": "Edit prompt automation",
+    "automations.editTask": "Edit Task",
     "automations.expand": "Expand automations",
-    "automations.filter.coordinator": "Prompts",
+    "automations.filter.coordinator": "Coordinator",
     "automations.filter.scheduled": "Scheduled",
     "automations.filterTabsLabel": "Filter automations",
     "automations.loadFailed": "Failed to load automations.",
     "automations.nameRequired": "Name is required.",
     "automations.newCoordinator": "New coordinator",
     "automations.newSchedule": "New schedule",
-    "automations.newTask": "New prompt automation",
-    "automations.newTaskButton": "+ New prompt",
-    "automations.newTextTask": "New prompt automation",
+    "automations.newTask": "New Task",
+    "automations.newTaskButton": "+ New task",
+    "automations.newTextTask": "New Text Task",
     "automations.newTriggerButton": "+ New trigger",
     "automations.newWorkflowCTA": "+ New Workflow",
     "automations.newWorkflowDisabled": "Enable Automations in Settings to create workflows",
@@ -47395,15 +47046,15 @@ Assistant:`;
     "automations.openInWorkflowsTab": "Open in Workflows tab",
     "automations.runsWorkflow": "Runs workflow: {{name}}",
     "automations.saveCoordinator": "Save coordinator",
-    "automations.saveTask": "Save prompt automation",
+    "automations.saveTask": "Save Task",
     "automations.searchPlaceholder": "Search automations",
-    "automations.taskCreateFailed": "Failed to create prompt automation.",
-    "automations.taskDeleteFailed": "Failed to delete prompt automation.",
-    "automations.taskDeleteMessage": "Are you sure you want to delete this prompt automation?",
-    "automations.taskDeleteTitle": "Delete prompt automation",
-    "automations.taskLabel": "Prompt automation",
-    "automations.taskName": "Prompt automation name...",
-    "automations.taskUpdateFailed": "Failed to update prompt automation.",
+    "automations.taskCreateFailed": "Failed to create task.",
+    "automations.taskDeleteFailed": "Failed to delete task.",
+    "automations.taskDeleteMessage": "Are you sure you want to delete this task?",
+    "automations.taskDeleteTitle": "Delete task",
+    "automations.taskLabel": "Task",
+    "automations.taskName": "Task name...",
+    "automations.taskUpdateFailed": "Failed to update task.",
     "automations.templateCustom.desc": "Describe your own workflow in chat.",
     "automations.templateCustom.title": "Custom",
     "automations.templates.calendarSlack.desc": "Post your day's agenda to Slack each morning.",
@@ -49352,6 +49003,8 @@ Assistant:`;
     "common.actions": "Actions",
     "common.active": "Active",
     "common.add": "Add",
+    "common.chatSearchActive": "Showing {{noun}} for \u201C{{query}}\u201D",
+    "common.chatSearchHint": "Search {{noun}} by typing in the chat.",
     "common.agent": "Agent",
     "common.all": "All",
     "common.anthropic": "Anthropic",
@@ -49364,8 +49017,6 @@ Assistant:`;
     "common.capabilities": "Capabilities",
     "common.chain": "Chain",
     "common.channel": "Channel",
-    "common.chatSearchActive": "Showing {{noun}} for \u201C{{query}}\u201D",
-    "common.chatSearchHint": "Search {{noun}} by typing in the chat.",
     "common.choose": "Choose",
     "common.clear": "Clear",
     "common.close": "Close",
@@ -49408,6 +49059,7 @@ Assistant:`;
     "common.features": "Features",
     "common.game": "Game",
     "common.google": "Google",
+    "common.heartbeat": "Heartbeat",
     "common.hide": "Hide",
     "common.hosting": "Hosting",
     "common.idle": "Idle",
@@ -49482,7 +49134,6 @@ Assistant:`;
     "common.today": "Today",
     "common.tokens": "Tokens",
     "common.trajectories": "Trajectories",
-    "common.trigger": "Trigger",
     "common.type": "Type",
     "common.unavailable": "Unavailable",
     "common.uninstall": "Uninstall",
@@ -49790,7 +49441,7 @@ Assistant:`;
     "desktopworkspacesection.surface.cloud.label": "Cloud Window",
     "desktopworkspacesection.surface.connectors.label": "Connectors Window",
     "desktopworkspacesection.surface.plugins.label": "Plugins Window",
-    "desktopworkspacesection.surface.triggers.label": "Triggers Window",
+    "desktopworkspacesection.surface.triggers.label": "Heartbeats Window",
     "desktopworkspacesection.SurfaceOpened": "Opened {{surface}}.",
     "desktopworkspacesection.UnmaximizeWindow": "Unmaximize Window",
     "desktopworkspacesection.WindowControls": "Window Controls",
@@ -50280,114 +49931,66 @@ Assistant:`;
     "header.elizaCloudAuthRejected": "Cloud key invalid",
     "header.MobileNavigationDescription": "Navigate between sections",
     "header.nativeMode": "Native Mode",
-    "triggerform.cronFieldOrder": "minute hour day month weekday",
-    "triggerform.cronSchedule": "Cron schedule",
-    "triggerform.enabled": "Enabled",
-    "triggerform.event.calendarEventEnded": "Calendar event ended",
-    "triggerform.event.custom": "Custom event",
-    "triggerform.event.discordMessage": "Discord message",
-    "triggerform.event.gmailMessage": "Gmail message",
-    "triggerform.event.label": "Event",
-    "triggerform.event.messageReceived": "Message received",
-    "triggerform.event.name": "Event name",
-    "triggerform.event.runsWhen": "Runs when {{eventName}} arrives.",
-    "triggerform.event.telegramMessage": "Telegram message",
-    "triggerform.interruptAndRunNow": "Interrupt and run now",
-    "triggerform.oneTime": "One time",
-    "triggerform.preview.nextRuns": "Next runs",
-    "triggerform.preview.waitingFor": "Waiting for {{eventName}}.",
-    "triggerform.prompt": "Prompt",
-    "triggerform.queueForNextCycle": "Queue for next cycle",
-    "triggerform.repeatEvery": "Repeat every",
-    "triggerform.repeatingInterval": "Repeating interval",
-    "triggerform.runAt": "Run at",
-    "triggerform.runBehavior": "Run behavior",
-    "triggerform.runs": "Runs",
-    "triggerform.scheduleName": "Schedule name",
-    "triggerform.stopAfter": "Stop after",
-    "triggerform.taskName": "Task name",
-    "triggerform.triggerType": "Trigger type",
-    "triggerform.unlimited": "Unlimited",
-    "triggerform.whatItDoes": "What it does",
-    "triggerform.whenItFires": "When it fires",
-    "triggerform.whenItStarts": "When it starts",
-    "triggerform.workflow": "Workflow",
-    "triggersview.createFirstTrigger": "Create your first Trigger",
-    "triggersview.createTrigger": "Create Trigger",
-    "triggersview.CronExpression5F": "Cron Expression (5-field)",
-    "triggersview.cronFieldDay": "day",
-    "triggersview.cronFieldHour": "hour",
-    "triggersview.cronFieldMinute": "minute",
-    "triggersview.cronFieldMonth": "month",
-    "triggersview.cronFieldWeekday": "weekday",
-    "triggersview.cronPrefix": "Cron:",
-    "triggersview.CronSchedule": "Cron Schedule",
-    "triggersview.deleteMessage": 'Delete "{{name}}"?',
-    "triggersview.deleteTitle": "Delete Trigger",
-    "triggersview.duplicate": "Duplicate",
-    "triggersview.durationUnitDays": "days",
-    "triggersview.durationUnitHours": "hours",
-    "triggersview.durationUnitMinutes": "minutes",
-    "triggersview.durationUnitSeconds": "seconds",
-    "triggersview.editTitle": "Edit: {{name}}",
-    "triggersview.editTrigger": "Edit Trigger",
-    "triggersview.eGDailyDigestH": "e.g. Daily Digest, Trigger Check",
-    "triggersview.emDash": "\u2014",
-    "triggersview.emptyStateDescription": "Create or select a trigger",
-    "triggersview.every": "Every",
-    "triggersview.EveryIntervalUnit": "Every {{interval}} {{unit}}",
-    "triggersview.InjectAmpWakeIm": "Inject and Wake Immediately",
-    "triggersview.Instructions": "Instructions",
-    "triggersview.interval": "Interval",
-    "triggersview.LastRun": "Last run",
-    "triggersview.maxRuns": "Max Runs",
-    "triggersview.MaxRunsOptional": "Max Runs (optional)",
-    "triggersview.minuteHourDayMont": 'minute hour day month weekday \u2014 e.g. "0 9 * * 1-5" = weekdays at\n                9am',
-    "triggersview.newTrigger": "New Trigger",
-    "triggersview.nextRun": "Next Run",
-    "triggersview.noMatchingTriggers": "No matching triggers",
-    "triggersview.NoRunsRecordedYet": "No runs recorded yet.",
-    "triggersview.noRunsYetMessage": "No runs yet. Trigger one manually to get started.",
-    "triggersview.notScheduled": "Not scheduled",
-    "triggersview.notYetRun": "Not yet run",
-    "triggersview.once": "Once",
-    "triggersview.onceAt": "Once at {{time}}",
-    "triggersview.OneTime": "One-time",
-    "triggersview.QueueForNextCycle": "Queue for next cycle",
-    "triggersview.RepeatingInterval": "Repeating Interval",
-    "triggersview.runCountPlural": "{{count}} runs",
-    "triggersview.RunHistory": "Run History",
-    "triggersview.RunNow": "Run now",
-    "triggersview.runStats": "Run Stats",
-    "triggersview.SaveAsTemplate": "Save as template",
-    "triggersview.saveChanges": "Save Changes",
-    "triggersview.ScheduledTimeISO": "Scheduled Time (ISO)",
-    "triggersview.ScheduleType": "Schedule Type",
-    "triggersview.searchTriggers": "Search triggers\u2026",
-    "triggersview.selectATrigger": "Select a Trigger",
-    "triggersview.StartEnabled": "Start enabled",
-    "triggersview.statusFailed": "Failed",
-    "triggersview.statusSkipped": "Skipped",
-    "triggersview.template.crypto.instructions": "Check the current prices of BTC, ETH, and SOL. Summarize any significant moves in the last hour.",
-    "triggersview.template.crypto.name": "Check crypto prices",
-    "triggersview.template.journal.instructions": "Write a brief, thoughtful journal prompt for the user based on current events or seasonal themes. Keep it under 2 sentences.",
-    "triggersview.template.journal.name": "Daily journal prompt",
-    "triggersview.template.trending.instructions": "Scan for trending topics on crypto Twitter and tech news. Give a 3-bullet summary of what's worth paying attention to.",
-    "triggersview.template.trending.name": "Trending topics digest",
-    "triggersview.TemplateLoadedNotice": 'Template "{{name}}" loaded. Customize and create.',
-    "triggersview.Templates": "Templates",
-    "triggersview.unlimited": "Unlimited",
-    "triggersview.validationCronFiveFields": "Cron expression must have exactly 5 fields (minute hour day month weekday).",
-    "triggersview.validationCronInvalidField": 'Invalid cron {{field}} field: "{{value}}"',
-    "triggersview.validationCronRequired": "Cron expression is required.",
-    "triggersview.validationDisplayNameRequired": "Display name is required.",
-    "triggersview.validationInstructionsRequired": "Instructions are required.",
-    "triggersview.validationIntervalPositive": "Interval must be a positive number.",
-    "triggersview.validationMaxRunsPositive": "Max runs must be a positive integer.",
-    "triggersview.validationScheduledTimeInvalid": "Scheduled time must be a valid ISO date-time.",
-    "triggersview.validationScheduledTimeRequired": "Scheduled time is required for one-time triggers.",
-    "triggersview.WakeMode": "Wake Mode",
-    "triggersview.WhatShouldTheAgen": "What should the agent do when this trigger fires?",
+    "heartbeat.interruptAndRunNow": "Interrupt and run now",
+    "heartbeat.messageReceived": "Message received",
+    "heartbeat.repeatingInterval": "Repeating interval",
+    "heartbeatsview.createFirstHeartbeat": "Create your first Heartbeat",
+    "heartbeatsview.createHeartbeat": "Create Heartbeat",
+    "heartbeatsview.cronFieldDay": "day",
+    "heartbeatsview.cronFieldHour": "hour",
+    "heartbeatsview.cronFieldMinute": "minute",
+    "heartbeatsview.cronFieldMonth": "month",
+    "heartbeatsview.cronFieldWeekday": "weekday",
+    "heartbeatsview.cronPrefix": "Cron:",
+    "heartbeatsview.deleteMessage": 'Delete "{{name}}"?',
+    "heartbeatsview.deleteTitle": "Delete Heartbeat",
+    "heartbeatsview.duplicate": "Duplicate",
+    "heartbeatsview.durationUnitDays": "days",
+    "heartbeatsview.durationUnitHours": "hours",
+    "heartbeatsview.durationUnitMinutes": "minutes",
+    "heartbeatsview.durationUnitSeconds": "seconds",
+    "heartbeatsview.editHeartbeat": "Edit Heartbeat",
+    "heartbeatsview.editTitle": "Edit: {{name}}",
+    "heartbeatsview.emDash": "\u2014",
+    "heartbeatsview.emptyStateDescription": "Create or select a heartbeat",
+    "heartbeatsview.every": "Every",
+    "heartbeatsview.EveryIntervalUnit": "Every {{interval}} {{unit}}",
+    "heartbeatsview.interval": "Interval",
+    "heartbeatsview.maxRuns": "Max Runs",
+    "heartbeatsview.newHeartbeat": "New Heartbeat",
+    "heartbeatsview.nextRun": "Next Run",
+    "heartbeatsview.noMatchingHeartbeats": "No matching heartbeats",
+    "heartbeatsview.noRunsYetMessage": "No runs yet. Trigger one manually to get started.",
+    "heartbeatsview.notScheduled": "Not scheduled",
+    "heartbeatsview.notYetRun": "Not yet run",
+    "heartbeatsview.once": "Once",
+    "heartbeatsview.onceAt": "Once at {{time}}",
+    "heartbeatsview.runCountPlural": "{{count}} runs",
+    "heartbeatsview.runStats": "Run Stats",
+    "heartbeatsview.SaveAsTemplate": "Save as template",
+    "heartbeatsview.saveChanges": "Save Changes",
+    "heartbeatsview.searchHeartbeats": "Search heartbeats\u2026",
+    "heartbeatsview.selectAHeartbeat": "Select a Heartbeat",
+    "heartbeatsview.statusFailed": "Failed",
+    "heartbeatsview.statusSkipped": "Skipped",
+    "heartbeatsview.template.crypto.instructions": "Check the current prices of BTC, ETH, and SOL. Summarize any significant moves in the last hour.",
+    "heartbeatsview.template.crypto.name": "Check crypto prices",
+    "heartbeatsview.template.journal.instructions": "Write a brief, thoughtful journal prompt for the user based on current events or seasonal themes. Keep it under 2 sentences.",
+    "heartbeatsview.template.journal.name": "Daily journal prompt",
+    "heartbeatsview.template.trending.instructions": "Scan for trending topics on crypto Twitter and tech news. Give a 3-bullet summary of what's worth paying attention to.",
+    "heartbeatsview.template.trending.name": "Trending topics digest",
+    "heartbeatsview.TemplateLoadedNotice": 'Template "{{name}}" loaded. Customize and create.',
+    "heartbeatsview.Templates": "Templates",
+    "heartbeatsview.unlimited": "Unlimited",
+    "heartbeatsview.validationCronFiveFields": "Cron expression must have exactly 5 fields (minute hour day month weekday).",
+    "heartbeatsview.validationCronInvalidField": 'Invalid cron {{field}} field: "{{value}}"',
+    "heartbeatsview.validationCronRequired": "Cron expression is required.",
+    "heartbeatsview.validationDisplayNameRequired": "Display name is required.",
+    "heartbeatsview.validationInstructionsRequired": "Instructions are required.",
+    "heartbeatsview.validationIntervalPositive": "Interval must be a positive number.",
+    "heartbeatsview.validationMaxRunsPositive": "Max runs must be a positive integer.",
+    "heartbeatsview.validationScheduledTimeInvalid": "Scheduled time must be a valid ISO date-time.",
+    "heartbeatsview.validationScheduledTimeRequired": "Scheduled time is required for one-time heartbeats.",
     "inboxview.AgentSendWarning": "Agent Send Warning",
     "inboxview.avatarAlt": "{{title}} avatar",
     "inboxview.EmptyRoom": "No messages in this chat yet.",
@@ -50850,11 +50453,11 @@ Assistant:`;
     "nav.description.stream": "Monitor live streams and activity",
     "nav.description.wallet": "Review wallet balances and transaction controls",
     "nav.documents": "Knowledge",
+    "nav.heartbeats": "Heartbeats",
     "nav.lifeops": "LifeOps",
     "nav.settings": "Settings",
     "nav.social": "Connectors",
     "nav.stream": "Stream",
-    "nav.triggers": "Triggers",
     "nav.wallet": "Wallet",
     "nodeCatalog.catalogEmpty": "No nodes available. The agent may still be loading plugins.",
     "nodeCatalog.classAction": "Action",
@@ -51734,6 +51337,25 @@ Assistant:`;
     "triggers.workflowLabel": "Workflow",
     "triggers.workflowPlaceholder": "Select a workflow\u2026",
     "triggers.workflowUnavailable": "No workflows available. Create one in the Workflows tab first.",
+    "triggersview.CronExpression5F": "Cron Expression (5-field)",
+    "triggersview.CronSchedule": "Cron Schedule",
+    "triggersview.eGDailyDigestH": "e.g. Daily Digest, Heartbeat Check",
+    "triggersview.InjectAmpWakeIm": "Inject and Wake Immediately",
+    "triggersview.Instructions": "Instructions",
+    "triggersview.LastRun": "Last run",
+    "triggersview.MaxRunsOptional": "Max Runs (optional)",
+    "triggersview.minuteHourDayMont": 'minute hour day month weekday \u2014 e.g. "0 9 * * 1-5" = weekdays at\n                9am',
+    "triggersview.NoRunsRecordedYet": "No runs recorded yet.",
+    "triggersview.OneTime": "One-time",
+    "triggersview.QueueForNextCycle": "Queue for next cycle",
+    "triggersview.RepeatingInterval": "Repeating Interval",
+    "triggersview.RunHistory": "Run History",
+    "triggersview.RunNow": "Run now",
+    "triggersview.ScheduledTimeISO": "Scheduled Time (ISO)",
+    "triggersview.ScheduleType": "Schedule Type",
+    "triggersview.StartEnabled": "Start enabled",
+    "triggersview.WakeMode": "Wake Mode",
+    "triggersview.WhatShouldTheAgen": "What should the agent do when this trigger fires?",
     "ui-renderer.Larr": "&larr;",
     "ui-renderer.Rarr": "&rarr;",
     "ui-renderer.UnknownComponent": "Unknown component:",
@@ -52457,6 +52079,38 @@ Assistant:`;
     "capabilities.endpoint.modulesAria": "Allowed remote module IDs",
     "capabilities.status.loading": "Loading",
     "capabilities.status.unavailable": "Unavailable",
+    "heartbeatform.scheduleName": "Schedule name",
+    "heartbeatform.taskName": "Task name",
+    "heartbeatform.whatItDoes": "What it does",
+    "heartbeatform.whenItStarts": "When it starts",
+    "heartbeatform.triggerType": "Trigger type",
+    "heartbeatform.repeatingInterval": "Repeating interval",
+    "heartbeatform.oneTime": "One time",
+    "heartbeatform.cronSchedule": "Cron schedule",
+    "heartbeatform.event.label": "Event",
+    "heartbeatform.whenItFires": "When it fires",
+    "heartbeatform.interruptAndRunNow": "Interrupt and run now",
+    "heartbeatform.queueForNextCycle": "Queue for next cycle",
+    "heartbeatform.repeatEvery": "Repeat every",
+    "heartbeatform.runAt": "Run at",
+    "heartbeatform.runBehavior": "Run behavior",
+    "heartbeatform.stopAfter": "Stop after",
+    "heartbeatform.unlimited": "Unlimited",
+    "heartbeatform.enabled": "Enabled",
+    "heartbeatform.runs": "Runs",
+    "heartbeatform.prompt": "Prompt",
+    "heartbeatform.workflow": "Workflow",
+    "heartbeatform.cronFieldOrder": "minute hour day month weekday",
+    "heartbeatform.event.messageReceived": "Message received",
+    "heartbeatform.event.discordMessage": "Discord message",
+    "heartbeatform.event.telegramMessage": "Telegram message",
+    "heartbeatform.event.gmailMessage": "Gmail message",
+    "heartbeatform.event.calendarEventEnded": "Calendar event ended",
+    "heartbeatform.event.custom": "Custom event",
+    "heartbeatform.event.name": "Event name",
+    "heartbeatform.event.runsWhen": "Runs when {{eventName}} arrives.",
+    "heartbeatform.preview.waitingFor": "Waiting for {{eventName}}.",
+    "heartbeatform.preview.nextRuns": "Next runs",
     "memoryviewer.type.messages": "Messages",
     "memoryviewer.type.memories": "Memories",
     "memoryviewer.type.facts": "Facts",
@@ -52689,7 +52343,7 @@ Assistant:`;
     "providerpanels.useProvider": "Use provider",
     "providerpanels.localOnlyApiPaused": "Local-only active. Remote API routing is paused.",
     "automationsfeed.filterAll": "All",
-    "automationsfeed.filterPrompts": "Prompts",
+    "automationsfeed.filterTasks": "Tasks",
     "automationsfeed.filterWorkflows": "Workflows",
     "automationsfeed.filterActive": "Active",
     "automationsfeed.filterInactive": "Inactive",
@@ -52697,17 +52351,15 @@ Assistant:`;
     "automationsfeed.untitled": "Untitled",
     "automationsfeed.loadError": "Failed to load automations.",
     "automationsfeed.title": "Automations",
-    "automationsfeed.promptCount": "{{count}} prompt automation",
+    "automationsfeed.taskCount": "{{count}} task",
     "automationsfeed.workflowCount": "{{count}} workflow",
     "automationsfeed.refresh": "Refresh",
     "automationsfeed.new": "New",
     "automationsfeed.empty": "No automations yet.",
-    "automationsfeed.emptyHeadline": "Nothing scheduled yet",
-    "automationsfeed.emptySub": "Workflows and prompt automations you create run here.",
     "automationsfeed.createFirst": "Create your first automation",
     "automationsfeed.runError": "Failed to run automation.",
     "automationsfeed.workflow": "Workflow",
-    "automationsfeed.promptAutomation": "Prompt automation",
+    "automationsfeed.task": "Task",
     "automationsfeed.active": "Active",
     "automationsfeed.inactive": "Inactive",
     "automationsfeed.updated": "Updated {{date}}",
@@ -52715,8 +52367,8 @@ Assistant:`;
     "automationsfeed.activateWorkflow": "Activate workflow",
     "automationsfeed.close": "Close",
     "automationsfeed.chooserTitle": "What do you want to create?",
-    "automationsfeed.promptOption": "Prompt automation (simple prompt)",
-    "automationsfeed.promptOptionDesc": "One prompt, run once or on a schedule. Pick this if you're not sure.",
+    "automationsfeed.taskOption": "Task (simple prompt)",
+    "automationsfeed.taskOptionDesc": "One prompt, run once or on a schedule. Pick this if you're not sure.",
     "automationsfeed.workflowOption": "Workflow (node graph)",
     "automationsfeed.workflowOptionDesc": "Multi-step. Draft in chat, then review the graph, run it, and inspect logs.",
     "automationsfeed.workflowLoadError": "Failed to load workflow.",
@@ -54662,7 +54314,6 @@ Assistant:`;
     "desktop.tray.sendTestNotification": "Send Test Notification",
     "desktop.tray.showWindow": "Show Window",
     "desktop.tray.hideWindow": "Hide Window",
-    "desktop.tray.openEliza": "Open Eliza",
     "desktop.tray.quit": "Quit",
     "desktop.tray.testNotification.title": "Desktop",
     "desktop.tray.testNotification.body": "Renderer tray actions are wired and responding.",
@@ -54682,6 +54333,17 @@ Assistant:`;
   };
 
   // packages/ui/src/i18n/messages.ts
+  var UI_LANGUAGES = [
+    "en",
+    "zh-CN",
+    "ko",
+    "es",
+    "pt",
+    "vi",
+    "tl",
+    "ja"
+  ];
+  var DEFAULT_UI_LANGUAGE = "en";
   var MESSAGES = {
     en: en_default2,
     "zh-CN": {},
@@ -54694,6 +54356,7 @@ Assistant:`;
   };
 
   // packages/ui/src/i18n/index.ts
+  var UI_LANGUAGE_SET = new Set(UI_LANGUAGES);
   function interpolate(template, vars) {
     if (!vars) return template;
     return template.replace(/\{\{(\w+)\}\}/g, (_, key) => {
@@ -54701,6 +54364,26 @@ Assistant:`;
       if (raw2 == null) return "";
       return String(raw2);
     });
+  }
+  function normalizeLanguage(input) {
+    if (typeof input !== "string") return DEFAULT_UI_LANGUAGE;
+    const trimmed = input.trim();
+    if (!trimmed) return DEFAULT_UI_LANGUAGE;
+    if (UI_LANGUAGE_SET.has(trimmed)) return trimmed;
+    const lower = trimmed.toLowerCase();
+    if (lower === "zh" || lower === "zh-cn" || lower.startsWith("zh-hans")) {
+      return "zh-CN";
+    }
+    if (lower === "en" || lower.startsWith("en-")) {
+      return "en";
+    }
+    if (lower.startsWith("ko")) return "ko";
+    if (lower.startsWith("es")) return "es";
+    if (lower.startsWith("pt")) return "pt";
+    if (lower.startsWith("vi")) return "vi";
+    if (lower.startsWith("tl") || lower.startsWith("fil")) return "tl";
+    if (lower.startsWith("ja")) return "ja";
+    return DEFAULT_UI_LANGUAGE;
   }
   function messageForLanguage(lang) {
     return MESSAGES[lang] ?? MESSAGES[DEFAULT_UI_LANGUAGE];
@@ -55091,9 +54774,6 @@ Assistant:`;
     });
   }
 
-  // packages/ui/src/api/client-base.ts
-  init_events3();
-
   // packages/ui/src/api/client-types-core.ts
   var ApiError = class extends Error {
     kind;
@@ -55126,9 +54806,7 @@ Assistant:`;
     "www.elizacloud.ai",
     "dev.elizacloud.ai"
   ]);
-  var REPLAYABLE_WS_EVENT_TYPES = /* @__PURE__ */ new Set([
-    SHELL_NAVIGATE_VIEW_WS_EVENT
-  ]);
+  var REPLAYABLE_WS_EVENT_TYPES = /* @__PURE__ */ new Set(["shell:navigate:view"]);
   var WS_EVENT_BACKLOG_LIMIT = 8;
   var StreamGenerationError = class extends Error {
     failureKind;
@@ -55702,7 +55380,7 @@ Assistant:`;
       if (this.requestTransport !== fetchAgentTransport) {
         return this.requestTransport;
       }
-      return await androidNativeAgentTransportForUrl(requestUrl) ?? await iosInProcessAgentTransportForUrl(requestUrl) ?? await desktopLocalAgentTransportForUrl(requestUrl) ?? desktopHttpTransportForUrl(requestUrl) ?? nativeCloudHttpTransportForUrl(requestUrl) ?? this.requestTransport;
+      return await androidNativeAgentTransportForUrl(requestUrl) ?? await iosInProcessAgentTransportForUrl(requestUrl) ?? desktopHttpTransportForUrl(requestUrl) ?? nativeCloudHttpTransportForUrl(requestUrl) ?? this.requestTransport;
     }
     throwRawRequestError(err, path, timeoutMs, timedOut, abortController) {
       if (timedOut) {
@@ -58261,7 +57939,6 @@ Assistant:`;
   // packages/ui/src/state/useAppLifecycleEvents.ts
   var import_react17 = __toESM(require_react(), 1);
   init_home_screen_fixture_api_stub();
-  init_events3();
 
   // packages/ui/src/state/useAppProviderEffects.ts
   var import_react18 = __toESM(require_react(), 1);
@@ -58270,24 +57947,20 @@ Assistant:`;
   // packages/ui/src/state/useAppShellState.ts
   var import_react19 = __toESM(require_react(), 1);
   init_home_screen_fixture_api_stub();
-  init_events3();
 
   // packages/ui/src/state/useCharacterState.ts
   var import_react20 = __toESM(require_react(), 1);
   init_home_screen_fixture_api_stub();
 
   // packages/ui/src/state/useChatCallbacks.ts
-  var import_core29 = __toESM(require_core(), 1);
   var import_react23 = __toESM(require_react(), 1);
   init_home_screen_fixture_api_stub();
 
   // packages/ui/src/state/useChatLifecycle.ts
   var import_react21 = __toESM(require_react(), 1);
   init_home_screen_fixture_api_stub();
-  init_events3();
 
   // packages/ui/src/state/useChatSend.ts
-  var import_core28 = __toESM(require_core(), 1);
   var import_react22 = __toESM(require_react(), 1);
   init_home_screen_fixture_api_stub();
 
@@ -58330,16 +58003,12 @@ Assistant:`;
     )
   ];
 
-  // packages/ui/src/state/useChatSend.ts
-  init_events3();
-
   // packages/ui/src/state/useChatState.ts
   var import_react24 = __toESM(require_react(), 1);
 
   // packages/ui/src/state/useCloudState.ts
   var import_react25 = __toESM(require_react(), 1);
   init_home_screen_fixture_api_stub();
-  init_events3();
 
   // packages/ui/src/state/useDataLoaders.ts
   var import_react26 = __toESM(require_react(), 1);
@@ -58419,42 +58088,39 @@ Assistant:`;
   init_home_screen_fixture_api_stub();
 
   // packages/ui/src/state/startup-phase-hydrate.ts
-  var import_core30 = __toESM(require_core(), 1);
   init_home_screen_fixture_api_stub();
 
   // packages/ui/src/components/apps/load-apps-catalog.ts
   init_home_screen_fixture_api_stub();
 
   // packages/ui/src/components/apps/internal-tool-apps.ts
-  var INTERNAL_TOOL_VIEW_DECLARATIONS = [
+  var INTERNAL_TOOL_APPS = [
     {
       name: "@elizaos/app-plugin-viewer",
       displayName: "Plugin Viewer",
       description: "Inspect installed plugins, connectors, and runtime feature flags.",
-      capabilities: ["plugins", "connectors", "viewer"],
       heroImage: null,
       targetTab: "plugins",
-      path: "/apps/plugins",
+      capabilities: ["plugins", "connectors", "viewer"],
       order: 1,
-      hasDetailsPage: false,
-      pinnable: true
+      windowPath: "/apps/plugins"
     },
     {
       name: "@elizaos/app-skills-viewer",
       displayName: "Skills Viewer",
       description: "Create, enable, review, and install custom agent skills.",
-      capabilities: ["skills", "viewer"],
       heroImage: null,
       targetTab: "skills",
-      path: "/apps/skills",
+      capabilities: ["skills", "viewer"],
       order: 2,
-      hasDetailsPage: false,
-      pinnable: true
+      windowPath: "/apps/skills"
     },
     {
       name: "@elizaos/plugin-training",
       displayName: "Fine Tuning",
       description: "Collect training data, inspect trajectories, run Eliza harness evals, benchmark model tiers, and manage fine-tuned models.",
+      heroImage: "/api/apps/hero/training",
+      targetTab: "fine-tuning",
       capabilities: [
         "training",
         "fine-tuning",
@@ -58466,161 +58132,196 @@ Assistant:`;
         "analysis",
         "data-collection"
       ],
-      heroImage: "/api/apps/hero/training",
-      targetTab: "fine-tuning",
-      path: "/apps/fine-tuning",
       order: 3,
-      hasDetailsPage: true,
-      pinnable: true
+      windowPath: "/apps/fine-tuning",
+      hasDetailsPage: true
     },
     {
       name: "@elizaos/app-trajectory-viewer",
       displayName: "Trajectory Viewer",
       description: "Inspect LLM call history, prompts, and execution traces.",
-      capabilities: ["trajectories", "debug", "viewer"],
       heroImage: null,
       targetTab: "trajectories",
-      path: "/apps/trajectories",
+      capabilities: ["trajectories", "debug", "viewer"],
       order: 4,
-      hasDetailsPage: false,
-      pinnable: true
+      windowPath: "/apps/trajectories"
     },
     {
       name: "@elizaos/app-relationship-viewer",
       displayName: "Relationship Viewer",
       description: "Explore cross-channel people, identities, and relationship graphs.",
-      capabilities: ["relationships", "graph", "viewer"],
       heroImage: null,
       targetTab: "relationships",
-      path: "/apps/relationships",
+      capabilities: ["relationships", "graph", "viewer"],
       order: 5,
-      hasDetailsPage: false,
-      pinnable: true
+      windowPath: "/apps/relationships"
     },
     {
       name: "@elizaos/app-memory-viewer",
       displayName: "Memory Viewer",
       description: "Browse memory, fact, and extraction activity.",
-      capabilities: ["memory", "facts", "viewer"],
       heroImage: null,
       targetTab: "memories",
-      path: "/apps/memories",
+      capabilities: ["memory", "facts", "viewer"],
       order: 6,
-      hasDetailsPage: false,
-      pinnable: true
+      windowPath: "/apps/memories"
     },
     {
       name: "@elizaos/app-runtime-debugger",
       displayName: "Runtime Debugger",
       description: "Inspect runtime objects, plugin order, providers, and services.",
-      capabilities: ["runtime", "debug", "viewer"],
       heroImage: null,
       targetTab: "runtime",
-      path: "/apps/runtime",
+      capabilities: ["runtime", "debug", "viewer"],
       order: 8,
-      hasDetailsPage: false,
-      pinnable: true
+      windowPath: "/apps/runtime"
     },
     {
       name: "@elizaos/app-database-viewer",
       displayName: "Database Viewer",
       description: "Inspect tables, media, vectors, and ad-hoc SQL.",
-      capabilities: ["database", "sql", "viewer"],
       heroImage: null,
       targetTab: "database",
-      path: "/apps/database",
+      capabilities: ["database", "sql", "viewer"],
       order: 9,
-      hasDetailsPage: false,
-      pinnable: true
+      windowPath: "/apps/database"
     },
     {
       name: "@elizaos/app-files-viewer",
       displayName: "Files",
       description: "Browse every stored file with download, share, and delete, filtered by type.",
-      capabilities: ["files", "attachments", "media", "viewer"],
       heroImage: null,
       targetTab: "files",
-      path: "/apps/files",
+      capabilities: ["files", "attachments", "media", "viewer"],
       order: 13,
-      hasDetailsPage: false,
-      pinnable: false
+      windowPath: "/apps/files"
     },
     {
       name: "@elizaos/app-log-viewer",
       displayName: "Log Viewer",
       description: "Search runtime and service logs.",
-      capabilities: ["logs", "debug", "viewer"],
       heroImage: null,
       targetTab: "logs",
-      path: "/apps/logs",
+      capabilities: ["logs", "debug", "viewer"],
       order: 11,
-      hasDetailsPage: false,
-      pinnable: true
+      windowPath: "/apps/logs"
     },
     {
       name: "@elizaos/plugin-task-coordinator",
       displayName: "Automations",
-      description: "Create, inspect, and manage workflows, triggers, and scheduled items.",
-      capabilities: ["tasks", "workflows", "automations"],
+      description: "Create, inspect, and manage scheduled tasks and workflows.",
       heroImage: "/api/apps/hero/task-coordinator",
       targetTab: "tasks",
-      path: "/apps/tasks",
+      capabilities: ["tasks", "workflows", "automations"],
       order: 12,
-      hasDetailsPage: false,
-      pinnable: true
+      windowPath: "/apps/tasks"
     }
   ];
   var INTERNAL_TOOL_APP_BY_NAME = new Map(
-    INTERNAL_TOOL_VIEW_DECLARATIONS.map((app) => [app.name, app])
+    INTERNAL_TOOL_APPS.map((app) => [app.name, app])
   );
-  var INTERNAL_TOOL_APP_BY_PATH = new Map(
-    INTERNAL_TOOL_VIEW_DECLARATIONS.map((app) => [app.path, app])
-  );
-  function resolveAppMetadata(declaration, networkViews) {
-    const match = networkViews.find((view) => view.path === declaration.path);
-    return {
-      displayName: match?.label ?? declaration.displayName,
-      description: match?.description ?? declaration.description,
-      capabilities: match?.tags && match.tags.length > 0 ? match.tags : declaration.capabilities,
-      heroImage: match?.hasHeroImage && match.heroImageUrl ? match.heroImageUrl : declaration.heroImage
-    };
-  }
-  function toRegistryAppInfo(declaration, networkViews) {
-    const meta3 = resolveAppMetadata(declaration, networkViews);
-    return {
-      name: declaration.name,
-      displayName: meta3.displayName,
-      description: meta3.description,
+  function getInternalToolApps() {
+    return INTERNAL_TOOL_APPS.map((app) => ({
+      name: app.name,
+      displayName: app.displayName,
+      description: app.description,
       category: "utility",
       launchType: "local",
       launchUrl: null,
       icon: null,
-      heroImage: meta3.heroImage,
-      capabilities: meta3.capabilities,
+      heroImage: app.heroImage ?? null,
+      capabilities: app.capabilities,
       stars: 0,
       repository: "",
       latestVersion: null,
       supports: { v0: false, v1: false, v2: true },
       npm: {
-        package: declaration.name,
+        package: app.name,
+        v0Version: null,
+        v1Version: null,
+        v2Version: null
+      }
+    }));
+  }
+
+  // packages/ui/src/components/apps/overlay-app-registry.ts
+  function getOverlayRegistryHost() {
+    return typeof window !== "undefined" ? window : globalThis;
+  }
+  function getOverlayRegistry() {
+    const host = getOverlayRegistryHost();
+    const existing = host.__elizaosOverlayAppRegistry__;
+    if (existing) {
+      return existing;
+    }
+    const next = /* @__PURE__ */ new Map();
+    host.__elizaosOverlayAppRegistry__ = next;
+    return next;
+  }
+  function getAllOverlayApps() {
+    return Array.from(getOverlayRegistry().values());
+  }
+  function getAvailableOverlayApps(context = detectOverlayAvailabilityContext()) {
+    const availability = typeof context === "string" ? { platform: context, aospAndroid: false } : normalizeOverlayAvailabilityContext(context);
+    const canShowAndroidOnly = availability.platform === "android" && availability.aospAndroid === true;
+    return getAllOverlayApps().filter(
+      (app) => canShowAndroidOnly || app.androidOnly !== true
+    );
+  }
+  function normalizeOverlayAvailabilityContext(context) {
+    const userAgent = context.userAgent ?? (typeof navigator !== "undefined" ? navigator.userAgent : "");
+    const platform5 = context.platform ?? detectPlatformForCatalog(userAgent);
+    return {
+      platform: platform5,
+      aospAndroid: context.aospAndroid ?? (platform5 === "android" && userAgentHasElizaOSMarker(userAgent)),
+      userAgent
+    };
+  }
+  function detectOverlayAvailabilityContext() {
+    const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
+    const platform5 = detectPlatformForCatalog(userAgent);
+    return {
+      platform: platform5,
+      aospAndroid: platform5 === "android" && userAgentHasElizaOSMarker(userAgent),
+      userAgent
+    };
+  }
+  function detectPlatformForCatalog(userAgent) {
+    const cap = globalThis.Capacitor;
+    const fromCap = cap?.getPlatform?.();
+    if (fromCap) return fromCap;
+    if (/Android/i.test(userAgent)) {
+      return "android";
+    }
+    return "web";
+  }
+  function isAospAndroid(context = {}) {
+    const availability = normalizeOverlayAvailabilityContext(context);
+    return availability.platform === "android" && availability.aospAndroid === true;
+  }
+  function overlayAppToRegistryInfo(app) {
+    return {
+      name: app.name,
+      displayName: app.displayName,
+      description: app.description,
+      category: app.category,
+      launchType: "overlay",
+      launchUrl: null,
+      icon: app.icon,
+      heroImage: app.heroImage ?? null,
+      capabilities: [],
+      stars: 0,
+      repository: "",
+      latestVersion: null,
+      supports: { v0: false, v1: false, v2: true },
+      npm: {
+        package: app.name,
         v0Version: null,
         v1Version: null,
         v2Version: null
       }
     };
   }
-  function getInternalToolApps(networkViews = []) {
-    return INTERNAL_TOOL_VIEW_DECLARATIONS.map(
-      (declaration) => toRegistryAppInfo(declaration, networkViews)
-    );
-  }
-
-  // packages/ui/src/state/startup-phase-hydrate.ts
-  init_events3();
-  init_view_event_bus();
-
-  // packages/ui/src/state/switch-runtime.ts
-  init_home_screen_fixture_api_stub();
 
   // packages/ui/src/state/startup-phase-poll.ts
   init_home_screen_fixture_api_stub();
@@ -58632,7 +58333,6 @@ Assistant:`;
   var PENDING_HANDOFF_TTL_MS = 24 * 60 * 60 * 1e3;
 
   // packages/ui/src/cloud/handoff/run-cloud-agent-handoff.ts
-  init_events3();
   var RETRY_ARM_TTL_MS = 10 * 6e4;
 
   // packages/ui/src/cloud/handoff/silent-repoint.ts
@@ -58659,6 +58359,9 @@ Assistant:`;
   // packages/ui/src/state/index.ts
   init_action_notice();
   init_app_store();
+
+  // packages/ui/src/state/switch-runtime.ts
+  init_home_screen_fixture_api_stub();
 
   // packages/ui/src/state/useBackgroundConfig.ts
   init_app_store();
@@ -59260,7 +58963,7 @@ Assistant:`;
   }
 
   // packages/ui/src/components/pages/launcher-curation.ts
-  var import_core31 = __toESM(require_core(), 1);
+  var import_core28 = __toESM(require_core(), 1);
   var LAUNCHER_APPS_ORDER = [
     "chat",
     "settings",
@@ -59292,7 +58995,13 @@ Assistant:`;
     "feed",
     "stream"
   ]);
-  var LAUNCHER_AOSP_ONLY_IDS = LAUNCHER_AOSP_ONLY_VIEW_IDS;
+  var LAUNCHER_AOSP_ONLY_IDS = [
+    "phone",
+    "messages",
+    "contacts",
+    "camera",
+    "files"
+  ];
   var LAUNCHER_HIDDEN_IDS = /* @__PURE__ */ new Set([
     "views",
     "views-manager",
@@ -59306,7 +59015,10 @@ Assistant:`;
     "model-tester",
     "shopify",
     "facewear",
-    "smartglasses"
+    "smartglasses",
+    // Wallet sub-views — reached from inside the Wallet app, not the launcher.
+    "hyperliquid",
+    "polymarket"
   ]);
   var CANONICAL_ID = /* @__PURE__ */ new Map([
     ["inventory", "wallet"],
@@ -59348,10 +59060,7 @@ Assistant:`;
   function launcherViewKind(canonicalId, entry) {
     if (DEVELOPER_INDEX.has(canonicalId)) return "developer";
     if (LAUNCHER_PREVIEW_IDS.has(canonicalId)) return "preview";
-    return (0, import_core31.resolveViewKind)(entry);
-  }
-  function isGroupedLauncherSubPage(canonicalId, entry) {
-    return entry.group === "wallet" && canonicalId !== "wallet";
+    return (0, import_core28.resolveViewKind)(entry);
   }
   function preferenceScore(entry) {
     let score = 0;
@@ -59384,7 +59093,6 @@ Assistant:`;
     for (const entry of entries2) {
       const canonicalId = canonicalLauncherId(entry.id);
       if (LAUNCHER_HIDDEN_IDS.has(canonicalId)) continue;
-      if (isGroupedLauncherSubPage(canonicalId, entry)) continue;
       if (LAUNCHER_CLOUD_IDS.has(canonicalId) && !cloudActive) continue;
       if (AOSP_INDEX.has(canonicalId)) {
         if (!isAosp) continue;
@@ -59392,7 +59100,7 @@ Assistant:`;
         // Every other tile follows the view-kind taxonomy: system + release always
         // show; developer + preview are hidden unless their toggle is on. The
         // curated developer TOOLS count as developer even if declared otherwise.
-        !(0, import_core31.isViewKindEnabled)(launcherViewKind(canonicalId, entry), enabledKinds)
+        !(0, import_core28.isViewKindEnabled)(launcherViewKind(canonicalId, entry), enabledKinds)
       ) {
         continue;
       }
@@ -59479,139 +59187,18 @@ Assistant:`;
   );
 
   // packages/ui/src/components/shell/HomeLauncherSurface.tsx
-  var React42 = __toESM(require_react(), 1);
-
-  // packages/ui/src/hooks/useHorizontalPager.ts
-  var React40 = __toESM(require_react(), 1);
-
-  // packages/ui/src/gestures/constants.ts
-  var TAP_SLOP = 8;
-  var AXIS_COMMIT_SLOP = 8;
-  var PAGER_AXIS_COMMIT_SLOP = 6;
-  var HORIZONTAL_DOMINANCE_RATIO = 0.8;
-  var PAGER_AXIS_DOMINANCE_RATIO = 1.15;
-  var DEFAULT_PULL_DISTANCE = 56;
-  var DEFAULT_PULL_VELOCITY = 0.5;
-  var DEFAULT_SWIPE_DISTANCE = 64;
-  var DEFAULT_SWIPE_VELOCITY = 0.4;
-  var PAGER_FLICK_VELOCITY = 0.45;
-  var OVERSHOOT_RESISTANCE = 0.35;
-
-  // packages/ui/src/gestures/lost-capture.ts
-  function isRealCaptureLoss(event) {
-    return event.target === event.currentTarget;
-  }
-
-  // packages/ui/src/gestures/recognizers.ts
-  function resolveSwipe(deltaLeft, velocityLeft, deltaUp, distanceThresholdX, velocityThresholdX) {
-    if (Math.abs(deltaLeft) < Math.abs(deltaUp) * HORIZONTAL_DOMINANCE_RATIO) {
-      return null;
-    }
-    const passed = Math.abs(deltaLeft) >= distanceThresholdX || Math.abs(velocityLeft) >= velocityThresholdX;
-    if (!passed) return null;
-    return deltaLeft > 0 ? "left" : "right";
-  }
-  function commitAxis(deltaLeft, deltaUp, slop, canSwipe) {
-    const ax = Math.abs(deltaLeft);
-    const ay = Math.abs(deltaUp);
-    if (Math.max(ax, ay) < slop) return null;
-    const horizontalWins = canSwipe ? ax >= ay * HORIZONTAL_DOMINANCE_RATIO : ax > ay;
-    return horizontalWins ? "x" : "y";
-  }
-  function rubberBand(travel, softMax, resistance) {
-    if (travel <= 0) return 0;
-    if (travel <= softMax) return travel;
-    return softMax + (travel - softMax) * resistance;
-  }
-
-  // packages/ui/src/gestures/useClickSuppression.ts
-  var React36 = __toESM(require_react(), 1);
-  function useClickSuppression(options2 = {}) {
-    const { autoDisarm = true } = options2;
-    const armed = React36.useRef(false);
-    const autoDisarmRef = React36.useRef(autoDisarm);
-    autoDisarmRef.current = autoDisarm;
-    const arm = React36.useCallback(() => {
-      armed.current = true;
-      if (!autoDisarmRef.current) return;
-      setTimeout(() => {
-        armed.current = false;
-      }, 0);
-    }, []);
-    const onClickCapture = React36.useCallback((event) => {
-      if (!armed.current) return;
-      armed.current = false;
-      event.preventDefault();
-      event.stopPropagation();
-    }, []);
-    const consumeArmed = React36.useCallback(() => {
-      if (!armed.current) return false;
-      armed.current = false;
-      return true;
-    }, []);
-    return { arm, onClickCapture, consumeArmed };
-  }
-
-  // packages/ui/src/gestures/usePointerPressAndHold.ts
-  var React37 = __toESM(require_react(), 1);
-
-  // packages/ui/src/gestures/usePressAndHold.ts
   var React38 = __toESM(require_react(), 1);
 
-  // packages/ui/src/gestures/useRafCoalescer.ts
-  var React39 = __toESM(require_react(), 1);
-  function raf(cb) {
-    return typeof requestAnimationFrame === "function" ? requestAnimationFrame(cb) : null;
-  }
-  function cancelRaf(handle) {
-    if (typeof cancelAnimationFrame === "function") cancelAnimationFrame(handle);
-  }
-  function useRafCoalescer(sink) {
-    const sinkRef = React39.useRef(sink);
-    sinkRef.current = sink;
-    const pending = React39.useRef(null);
-    const rafId = React39.useRef(0);
-    const flushNow = React39.useCallback(() => {
-      rafId.current = 0;
-      const next = pending.current;
-      pending.current = null;
-      if (next) sinkRef.current(next.value);
-    }, []);
-    const schedule = React39.useCallback(
-      (value) => {
-        pending.current = { value };
-        if (rafId.current !== 0) return;
-        rafId.current = -1;
-        const handle = raf(flushNow);
-        if (handle === null) {
-          if (rafId.current === -1) {
-            rafId.current = 0;
-            flushNow();
-          }
-          return;
-        }
-        if (rafId.current === -1) rafId.current = handle;
-      },
-      [flushNow]
-    );
-    const flush = React39.useCallback(() => {
-      if (rafId.current > 0) cancelRaf(rafId.current);
-      flushNow();
-    }, [flushNow]);
-    const cancel = React39.useCallback(() => {
-      if (rafId.current > 0) cancelRaf(rafId.current);
-      rafId.current = 0;
-      pending.current = null;
-    }, []);
-    React39.useEffect(() => cancel, [cancel]);
-    return { schedule, flush, cancel };
-  }
-
   // packages/ui/src/hooks/useHorizontalPager.ts
+  var React36 = __toESM(require_react(), 1);
+  var AXIS_COMMIT_SLOP = 6;
+  var AXIS_DOMINANCE_RATIO = 1.15;
   var MIN_DISTANCE_THRESHOLD = 64;
   var DISTANCE_THRESHOLD_RATIO = 0.5;
   var MIN_FLICK_DISTANCE = 48;
+  var FLICK_VELOCITY = 0.45;
   var SETTLE_MS = 360;
+  var EDGE_RESISTANCE = 0.35;
   var SETTLE_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
   var MIN_SETTLE_MS = 130;
   var MAX_SETTLE_MS = 440;
@@ -59622,6 +59209,45 @@ Assistant:`;
       return false;
     }
     return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  }
+  var pagerPointerGestures = /* @__PURE__ */ new Map();
+  function registerPagerPointerTracker(pointerId, downEvent, tracker) {
+    const gesture = pagerPointerGestures.get(pointerId);
+    if (!gesture || gesture.downEvent !== downEvent) {
+      pagerPointerGestures.set(pointerId, {
+        downEvent,
+        trackers: [tracker],
+        owner: null
+      });
+      return;
+    }
+    if (!gesture.trackers.includes(tracker)) gesture.trackers.push(tracker);
+  }
+  function unregisterPagerPointerTracker(pointerId, tracker) {
+    const gesture = pagerPointerGestures.get(pointerId);
+    if (!gesture) return;
+    gesture.trackers = gesture.trackers.filter((t2) => t2 !== tracker);
+    if (gesture.owner === tracker) gesture.owner = null;
+    if (gesture.trackers.length === 0) pagerPointerGestures.delete(pointerId);
+  }
+  function isPagerPointerOwnedElsewhere(pointerId, tracker) {
+    const owner = pagerPointerGestures.get(pointerId)?.owner ?? null;
+    return owner !== null && owner !== tracker;
+  }
+  function claimPagerPointer(pointerId, tracker) {
+    const gesture = pagerPointerGestures.get(pointerId);
+    if (!gesture) return true;
+    if (gesture.owner === tracker) return true;
+    if (gesture.owner !== null) return false;
+    gesture.owner = tracker;
+    for (const other of [...gesture.trackers]) {
+      if (other !== tracker) other.onEvicted();
+    }
+    return true;
+  }
+  function isInnermostPagerPointerTracker(pointerId, tracker) {
+    const gesture = pagerPointerGestures.get(pointerId);
+    return !gesture || gesture.trackers[0] === tracker;
   }
   function now() {
     return typeof performance !== "undefined" ? performance.now() : Date.now();
@@ -59687,25 +59313,35 @@ Assistant:`;
   function useHorizontalPager({
     page,
     pageCount,
+    enabled = true,
     onPageChange
   }) {
-    const viewportRef = React40.useRef(null);
-    const railRef = React40.useRef(null);
-    const dragRef = React40.useRef(null);
-    const clickSuppression = useClickSuppression();
-    const pendingSettleRef = React40.useRef(null);
-    const mountedRef = React40.useRef(false);
-    const pageRef = React40.useRef(page);
-    const pageCountRef = React40.useRef(pageCount);
-    const onPageChangeRef = React40.useRef(onPageChange);
+    const viewportRef = React36.useRef(null);
+    const railRef = React36.useRef(null);
+    const dragRef = React36.useRef(null);
+    const rafRef = React36.useRef(0);
+    const pendingOffsetRef = React36.useRef(null);
+    const suppressClickRef = React36.useRef(false);
+    const pendingSettleRef = React36.useRef(null);
+    const mountedRef = React36.useRef(false);
+    const pageRef = React36.useRef(page);
+    const pageCountRef = React36.useRef(pageCount);
+    const enabledRef = React36.useRef(enabled);
+    const onPageChangeRef = React36.useRef(onPageChange);
+    const abandonDragRef = React36.useRef(() => {
+    });
+    const pointerTrackerRef = React36.useRef({
+      onEvicted: () => abandonDragRef.current()
+    });
     pageRef.current = page;
     pageCountRef.current = pageCount;
+    enabledRef.current = enabled;
     onPageChangeRef.current = onPageChange;
-    const measureWidth = React40.useCallback(() => {
+    const measureWidth = React36.useCallback(() => {
       const width = viewportRef.current?.clientWidth || (typeof window !== "undefined" ? window.innerWidth : 1);
       return Math.max(1, width);
     }, []);
-    const writeOffset = React40.useCallback(
+    const writeOffset = React36.useCallback(
       (offset4, transitionMs) => {
         const rail = railRef.current;
         if (!rail) return;
@@ -59715,39 +59351,64 @@ Assistant:`;
       },
       []
     );
-    const railWrite = useRafCoalescer(
-      (offset4) => writeOffset(offset4, null)
+    const flushOffset = React36.useCallback(() => {
+      rafRef.current = 0;
+      const offset4 = pendingOffsetRef.current;
+      pendingOffsetRef.current = null;
+      if (offset4 == null) return;
+      writeOffset(offset4, null);
+    }, [writeOffset]);
+    const scheduleOffset = React36.useCallback(
+      (offset4) => {
+        pendingOffsetRef.current = offset4;
+        if (rafRef.current !== 0) return;
+        if (typeof requestAnimationFrame === "function") {
+          rafRef.current = -1;
+          const handle = requestAnimationFrame(flushOffset);
+          if (rafRef.current === -1) rafRef.current = handle;
+          return;
+        }
+        flushOffset();
+      },
+      [flushOffset]
     );
-    const scheduleOffset = railWrite.schedule;
-    const cancelScheduledOffset = railWrite.cancel;
-    const canMove = React40.useCallback((state4, dx) => {
+    const cancelScheduledOffset = React36.useCallback(() => {
+      if (rafRef.current !== 0 && typeof cancelAnimationFrame === "function") {
+        cancelAnimationFrame(rafRef.current);
+      }
+      rafRef.current = 0;
+      pendingOffsetRef.current = null;
+    }, []);
+    const canMove = React36.useCallback((state4, dx) => {
       if (dx < 0) return state4.page < pageCountRef.current - 1;
       if (dx > 0) return state4.page > 0;
       return false;
     }, []);
-    const visualDragOffset = React40.useCallback((state4, dx) => {
-      if (dx > 0 && state4.page === 0) return dx * OVERSHOOT_RESISTANCE;
+    const visualDragOffset = React36.useCallback((state4, dx) => {
+      if (dx > 0 && state4.page === 0) return dx * EDGE_RESISTANCE;
       if (dx < 0 && state4.page >= pageCountRef.current - 1) {
-        return dx * OVERSHOOT_RESISTANCE;
+        return dx * EDGE_RESISTANCE;
       }
       return dx;
     }, []);
-    const releaseCapture = React40.useCallback((state4) => {
+    const releaseCapture = React36.useCallback((state4) => {
       if (!state4.captured || state4.captureTarget === null) return;
       try {
         state4.captureTarget.releasePointerCapture?.(state4.pointerId);
       } catch {
       }
     }, []);
-    const abandonDrag = React40.useCallback(() => {
+    const abandonDrag = React36.useCallback(() => {
       const state4 = dragRef.current;
       if (!state4) return;
       cancelScheduledOffset();
       dragRef.current = null;
       releaseCapture(state4);
+      unregisterPagerPointerTracker(state4.pointerId, pointerTrackerRef.current);
       writeOffset(pageOffset(state4.page, measureWidth()), SETTLE_MS);
     }, [cancelScheduledOffset, measureWidth, releaseCapture, writeOffset]);
-    React40.useLayoutEffect(() => {
+    abandonDragRef.current = abandonDrag;
+    React36.useLayoutEffect(() => {
       const width = measureWidth();
       const nextPage = clampPage(page, pageCount);
       const pendingSettle = pendingSettleRef.current;
@@ -59759,7 +59420,7 @@ Assistant:`;
       );
       mountedRef.current = true;
     }, [measureWidth, page, pageCount, writeOffset]);
-    React40.useEffect(() => {
+    React36.useEffect(() => {
       if (typeof ResizeObserver === "undefined") return;
       const viewport = viewportRef.current;
       if (!viewport) return;
@@ -59776,13 +59437,16 @@ Assistant:`;
       observer.observe(viewport);
       return () => observer.disconnect();
     }, [measureWidth, writeOffset]);
-    const finish = React40.useCallback(
+    React36.useEffect(() => cancelScheduledOffset, [cancelScheduledOffset]);
+    React36.useEffect(() => () => abandonDragRef.current(), []);
+    const finish = React36.useCallback(
       (event, cancelled = false) => {
         const state4 = dragRef.current;
         if (!state4 || state4.pointerId !== event.pointerId) return;
         cancelScheduledOffset();
         dragRef.current = null;
         releaseCapture(state4);
+        unregisterPagerPointerTracker(event.pointerId, pointerTrackerRef.current);
         const width = measureWidth();
         const base = pageOffset(state4.page, width);
         const dx = event.clientX - state4.startX;
@@ -59801,7 +59465,7 @@ Assistant:`;
           offset4,
           momentumSettleMs(Math.abs(offset4 - lastVisual), velocity)
         );
-        if (cancelled || state4.axis !== "horizontal" || !canMove(state4, dx)) {
+        if (cancelled || state4.axis !== "horizontal" || !canMove(state4, dx) || !claimPagerPointer(event.pointerId, pointerTrackerRef.current)) {
           settleTo(base);
           return;
         }
@@ -59812,7 +59476,7 @@ Assistant:`;
         const shouldAdvance = Math.abs(dx) >= distanceThreshold || // Flick escape hatch: a fast RELEASE (same direction as the drag) commits
         // short of the distance threshold. Direction guard stops a
         // drag-forward-then-fling-back release from committing the wrong way.
-        Math.abs(dx) >= MIN_FLICK_DISTANCE && Math.abs(velocity) >= PAGER_FLICK_VELOCITY && Math.sign(velocity) === Math.sign(dx) && Math.abs(dx) > Math.abs(dy) * PAGER_AXIS_DOMINANCE_RATIO;
+        Math.abs(dx) >= MIN_FLICK_DISTANCE && Math.abs(velocity) >= FLICK_VELOCITY && Math.sign(velocity) === Math.sign(dx) && Math.abs(dx) > Math.abs(dy) * AXIS_DOMINANCE_RATIO;
         if (!shouldAdvance) {
           settleTo(base);
           return;
@@ -59830,7 +59494,10 @@ Assistant:`;
               velocity
             )
           };
-          clickSuppression.arm();
+          suppressClickRef.current = true;
+          setTimeout(() => {
+            suppressClickRef.current = false;
+          }, 0);
           onPageChangeRef.current(targetPage);
         } else {
           settleTo(targetOffset);
@@ -59839,24 +59506,23 @@ Assistant:`;
       [
         canMove,
         cancelScheduledOffset,
-        clickSuppression,
         measureWidth,
         releaseCapture,
         visualDragOffset,
         writeOffset
       ]
     );
-    const goPrev = React40.useCallback(() => {
+    const goPrev = React36.useCallback(() => {
       const target = clampPage(pageRef.current - 1, pageCountRef.current);
       if (target !== pageRef.current) onPageChangeRef.current(target);
     }, []);
-    const goNext = React40.useCallback(() => {
+    const goNext = React36.useCallback(() => {
       const target = clampPage(pageRef.current + 1, pageCountRef.current);
       if (target !== pageRef.current) onPageChangeRef.current(target);
     }, []);
-    const onPointerDown = React40.useCallback(
+    const onPointerDown = React36.useCallback(
       (event) => {
-        if (pageCountRef.current <= 0 || event.isPrimary === false || // Only the primary (left) button starts a drag. A right/middle-button
+        if (!enabledRef.current || pageCountRef.current <= 0 || event.isPrimary === false || // Only the primary (left) button starts a drag. A right/middle-button
         // (or pen barrel-button, button 2) press otherwise starts a real drag
         // that can page while the OS context menu opens, and — since mouse
         // capture is only taken after the axis commit — can go stale if released
@@ -59865,6 +59531,11 @@ Assistant:`;
           return;
         }
         cancelScheduledOffset();
+        registerPagerPointerTracker(
+          event.pointerId,
+          event.nativeEvent,
+          pointerTrackerRef.current
+        );
         const currentPage = clampPage(pageRef.current, pageCountRef.current);
         const width = measureWidth();
         const restingOffset = pageOffset(currentPage, width);
@@ -59888,11 +59559,15 @@ Assistant:`;
       },
       [cancelScheduledOffset, measureWidth, writeOffset]
     );
-    const onPointerMove = React40.useCallback(
+    const onPointerMove = React36.useCallback(
       (event) => {
         const state4 = dragRef.current;
         if (!state4 || state4.pointerId !== event.pointerId) return;
         if (state4.hadButtons && event.pointerType !== "touch" && event.buttons === 0) {
+          abandonDrag();
+          return;
+        }
+        if (isPagerPointerOwnedElsewhere(event.pointerId, pointerTrackerRef.current)) {
           abandonDrag();
           return;
         }
@@ -59901,10 +59576,17 @@ Assistant:`;
         if (state4.axis === "pending") {
           const ax = Math.abs(dx);
           const ay = Math.abs(dy);
-          if (Math.max(ax, ay) < PAGER_AXIS_COMMIT_SLOP) return;
-          state4.axis = ax > ay * PAGER_AXIS_DOMINANCE_RATIO ? "horizontal" : "vertical";
+          if (Math.max(ax, ay) < AXIS_COMMIT_SLOP) return;
+          state4.axis = ax > ay * AXIS_DOMINANCE_RATIO ? "horizontal" : "vertical";
         }
         if (state4.axis !== "horizontal") return;
+        const owned = canMove(state4, dx) ? claimPagerPointer(event.pointerId, pointerTrackerRef.current) : false;
+        if (!owned && !isInnermostPagerPointerTracker(
+          event.pointerId,
+          pointerTrackerRef.current
+        )) {
+          return;
+        }
         if (!state4.captured && event.pointerType !== "touch") {
           try {
             event.currentTarget.setPointerCapture(event.pointerId);
@@ -59920,22 +59602,31 @@ Assistant:`;
         }
         scheduleOffset(state4.baseOffset + visualDragOffset(state4, dx));
       },
-      [abandonDrag, scheduleOffset, visualDragOffset]
+      [abandonDrag, canMove, scheduleOffset, visualDragOffset]
     );
-    const onPointerUp = React40.useCallback(
+    const onPointerUp = React36.useCallback(
       (event) => finish(event),
       [finish]
     );
-    const onPointerCancel = React40.useCallback(
+    const onPointerCancel = React36.useCallback(
       (event) => finish(event, true),
       [finish]
     );
-    const onLostPointerCapture = React40.useCallback(
+    const onLostPointerCapture = React36.useCallback(
       (event) => {
-        if (!isRealCaptureLoss(event)) return;
+        if (event.target !== event.currentTarget) return;
         finish(event, true);
       },
       [finish]
+    );
+    const onClickCapture = React36.useCallback(
+      (event) => {
+        if (!suppressClickRef.current) return;
+        suppressClickRef.current = false;
+        event.preventDefault();
+        event.stopPropagation();
+      },
+      []
     );
     const clampedPage = clampPage(page, pageCount);
     return {
@@ -59947,7 +59638,7 @@ Assistant:`;
         onPointerUp,
         onPointerCancel,
         onLostPointerCapture,
-        onClickCapture: clickSuppression.onClickCapture
+        onClickCapture
       },
       canPrev: clampedPage > 0,
       canNext: clampedPage < pageCount - 1,
@@ -59957,7 +59648,7 @@ Assistant:`;
   }
 
   // packages/ui/src/state/shell-surface-store.ts
-  var React41 = __toESM(require_react(), 1);
+  var React37 = __toESM(require_react(), 1);
   var INITIAL_STATE = { page: "home" };
   function store3() {
     const g = globalThis;
@@ -59984,7 +59675,7 @@ Assistant:`;
   }
   function useShellSurface() {
     const s = store3();
-    return React41.useSyncExternalStore(
+    return React37.useSyncExternalStore(
       (l) => {
         s.listeners.add(l);
         return () => s.listeners.delete(l);
@@ -60082,18 +59773,9 @@ Assistant:`;
     initialPage = "home"
   }) {
     const { page } = useShellSurface();
-    React42.useEffect(() => {
+    React38.useEffect(() => {
       setShellSurfacePage(initialPage);
     }, [initialPage]);
-    React42.useEffect(() => {
-      const inertHalf = document.querySelector(
-        page === "home" ? '[data-testid="home-launcher-launcher-page"]' : '[data-testid="home-launcher-home-page"]'
-      );
-      const active = document.activeElement;
-      if (inertHalf && active instanceof HTMLElement && inertHalf.contains(active)) {
-        active.blur();
-      }
-    }, [page]);
     const pager = useHorizontalPager({
       page: page === "launcher" ? 1 : 0,
       pageCount: 2,
@@ -60178,7 +59860,6 @@ Assistant:`;
 
   // packages/ui/src/components/shell/HomeScreen.tsx
   var import_react81 = __toESM(require_react(), 1);
-  init_events3();
 
   // packages/ui/src/components/shell/__e2e__/home-screen-fixture.activity-stub.ts
   function useActivityEvents() {
@@ -60321,21 +60002,21 @@ Assistant:`;
 `;
 
   // packages/ui/src/widgets/WidgetHost.tsx
-  var import_core35 = __toESM(require_core(), 1);
+  var import_core32 = __toESM(require_core(), 1);
   var import_react80 = __toESM(require_react(), 1);
   init_home_screen_fixture_api_stub();
 
   // packages/ui/src/components/config-ui/ui-renderer.tsx
   var import_react53 = __toESM(require_react(), 1);
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-checkbox@1.3.5+119c4f3973a6d299/node_modules/@radix-ui/react-checkbox/dist/index.mjs
-  var React45 = __toESM(require_react(), 1);
+  // ../../../node_modules/.bun/@radix-ui+react-checkbox@1.3.5+119c4f3973a6d299/node_modules/@radix-ui/react-checkbox/dist/index.mjs
+  var React41 = __toESM(require_react(), 1);
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-use-previous@1.1.2+b2e33729a97476bf/node_modules/@radix-ui/react-use-previous/dist/index.mjs
-  var React43 = __toESM(require_react(), 1);
+  // ../../../node_modules/.bun/@radix-ui+react-use-previous@1.1.2+b2e33729a97476bf/node_modules/@radix-ui/react-use-previous/dist/index.mjs
+  var React39 = __toESM(require_react(), 1);
   function usePrevious(value) {
-    const ref = React43.useRef({ value, previous: value });
-    return React43.useMemo(() => {
+    const ref = React39.useRef({ value, previous: value });
+    return React39.useMemo(() => {
       if (ref.current.value !== value) {
         ref.current.previous = ref.current.value;
         ref.current.value = value;
@@ -60344,10 +60025,10 @@ Assistant:`;
     }, [value]);
   }
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-use-size@1.1.2+b2e33729a97476bf/node_modules/@radix-ui/react-use-size/dist/index.mjs
-  var React44 = __toESM(require_react(), 1);
+  // ../../../node_modules/.bun/@radix-ui+react-use-size@1.1.2+b2e33729a97476bf/node_modules/@radix-ui/react-use-size/dist/index.mjs
+  var React40 = __toESM(require_react(), 1);
   function useSize(element) {
-    const [size4, setSize] = React44.useState(void 0);
+    const [size4, setSize] = React40.useState(void 0);
     useLayoutEffect2(() => {
       if (element) {
         setSize({ width: element.offsetWidth, height: element.offsetHeight });
@@ -60381,7 +60062,7 @@ Assistant:`;
     return size4;
   }
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-checkbox@1.3.5+119c4f3973a6d299/node_modules/@radix-ui/react-checkbox/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-checkbox@1.3.5+119c4f3973a6d299/node_modules/@radix-ui/react-checkbox/dist/index.mjs
   var import_jsx_runtime23 = __toESM(require_jsx_runtime(), 1);
   var CHECKBOX_NAME = "Checkbox";
   var [createCheckboxContext, createCheckboxScope] = createContextScope(CHECKBOX_NAME);
@@ -60407,9 +60088,9 @@ Assistant:`;
       onChange: onCheckedChange,
       caller: CHECKBOX_NAME
     });
-    const [control, setControl] = React45.useState(null);
-    const [bubbleInput, setBubbleInput] = React45.useState(null);
-    const hasConsumerStoppedPropagationRef = React45.useRef(false);
+    const [control, setControl] = React41.useState(null);
+    const [bubbleInput, setBubbleInput] = React41.useState(null);
+    const hasConsumerStoppedPropagationRef = React41.useRef(false);
     const isFormControl = control ? !!form || !!control.closest("form") : (
       // We set this to true by default so that events bubble to forms without JS (SSR)
       true
@@ -60440,7 +60121,7 @@ Assistant:`;
     );
   }
   var TRIGGER_NAME2 = "CheckboxTrigger";
-  var CheckboxTrigger = React45.forwardRef(
+  var CheckboxTrigger = React41.forwardRef(
     ({ __scopeCheckbox, onKeyDown, onClick, ...checkboxProps }, forwardedRef) => {
       const {
         control,
@@ -60455,8 +60136,8 @@ Assistant:`;
         bubbleInput
       } = useCheckboxContext(TRIGGER_NAME2, __scopeCheckbox);
       const composedRefs = useComposedRefs(forwardedRef, setControl);
-      const initialCheckedStateRef = React45.useRef(checked);
-      React45.useEffect(() => {
+      const initialCheckedStateRef = React41.useRef(checked);
+      React41.useEffect(() => {
         const form = control?.form;
         if (form) {
           const reset = () => setChecked(initialCheckedStateRef.current);
@@ -60492,7 +60173,7 @@ Assistant:`;
     }
   );
   CheckboxTrigger.displayName = TRIGGER_NAME2;
-  var Checkbox = React45.forwardRef(
+  var Checkbox = React41.forwardRef(
     (props, forwardedRef) => {
       const {
         __scopeCheckbox,
@@ -60540,7 +60221,7 @@ Assistant:`;
   );
   Checkbox.displayName = CHECKBOX_NAME;
   var INDICATOR_NAME = "CheckboxIndicator";
-  var CheckboxIndicator = React45.forwardRef(
+  var CheckboxIndicator = React41.forwardRef(
     (props, forwardedRef) => {
       const { __scopeCheckbox, forceMount, ...indicatorProps } = props;
       const context = useCheckboxContext(INDICATOR_NAME, __scopeCheckbox);
@@ -60564,7 +60245,7 @@ Assistant:`;
   );
   CheckboxIndicator.displayName = INDICATOR_NAME;
   var BUBBLE_INPUT_NAME = "CheckboxBubbleInput";
-  var CheckboxBubbleInput = React45.forwardRef(
+  var CheckboxBubbleInput = React41.forwardRef(
     ({ __scopeCheckbox, ...props }, forwardedRef) => {
       const {
         control,
@@ -60582,7 +60263,7 @@ Assistant:`;
       const composedRefs = useComposedRefs(forwardedRef, setBubbleInput);
       const prevChecked = usePrevious(checked);
       const controlSize = useSize(control);
-      React45.useEffect(() => {
+      React41.useEffect(() => {
         const input = bubbleInput;
         if (!input) return;
         const inputProto = window.HTMLInputElement.prototype;
@@ -60599,7 +60280,7 @@ Assistant:`;
           input.dispatchEvent(event);
         }
       }, [bubbleInput, prevChecked, checked, hasConsumerStoppedPropagationRef]);
-      const defaultCheckedRef = React45.useRef(isIndeterminate(checked) ? false : checked);
+      const defaultCheckedRef = React41.useRef(isIndeterminate(checked) ? false : checked);
       return /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
         Primitive.input,
         {
@@ -60642,9 +60323,9 @@ Assistant:`;
   }
 
   // packages/ui/src/components/ui/checkbox.tsx
-  var React46 = __toESM(require_react(), 1);
+  var React42 = __toESM(require_react(), 1);
   var import_jsx_runtime24 = __toESM(require_jsx_runtime(), 1);
-  var Checkbox2 = React46.forwardRef(({ className, ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
+  var Checkbox2 = React42.forwardRef(({ className, ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
     Checkbox,
     {
       ref,
@@ -60664,17 +60345,17 @@ Assistant:`;
   ));
   Checkbox2.displayName = Checkbox.displayName;
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-select@2.3.1+119c4f3973a6d299/node_modules/@radix-ui/react-select/dist/index.mjs
-  var React53 = __toESM(require_react(), 1);
+  // ../../../node_modules/.bun/@radix-ui+react-select@2.3.1+119c4f3973a6d299/node_modules/@radix-ui/react-select/dist/index.mjs
+  var React49 = __toESM(require_react(), 1);
   var ReactDOM4 = __toESM(require_react_dom(), 1);
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+number@1.1.2/node_modules/@radix-ui/number/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+number@1.1.2/node_modules/@radix-ui/number/dist/index.mjs
   function clamp2(value, [min2, max2]) {
     return Math.min(max2, Math.max(min2, value));
   }
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-collection@1.1.10+119c4f3973a6d299/node_modules/@radix-ui/react-collection/dist/index.mjs
-  var React47 = __toESM(require_react(), 1);
+  // ../../../node_modules/.bun/@radix-ui+react-collection@1.1.10+119c4f3973a6d299/node_modules/@radix-ui/react-collection/dist/index.mjs
+  var React43 = __toESM(require_react(), 1);
   var import_jsx_runtime25 = __toESM(require_jsx_runtime(), 1);
   var React210 = __toESM(require_react(), 1);
   var import_jsx_runtime26 = __toESM(require_jsx_runtime(), 1);
@@ -60687,14 +60368,14 @@ Assistant:`;
     );
     const CollectionProvider = (props) => {
       const { scope, children } = props;
-      const ref = React47.useRef(null);
-      const itemMap = React47.useRef(/* @__PURE__ */ new Map()).current;
+      const ref = React43.useRef(null);
+      const itemMap = React43.useRef(/* @__PURE__ */ new Map()).current;
       return /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(CollectionProviderImpl, { scope, itemMap, collectionRef: ref, children });
     };
     CollectionProvider.displayName = PROVIDER_NAME2;
     const COLLECTION_SLOT_NAME = name + "CollectionSlot";
     const CollectionSlotImpl = createSlot(COLLECTION_SLOT_NAME);
-    const CollectionSlot = React47.forwardRef(
+    const CollectionSlot = React43.forwardRef(
       (props, forwardedRef) => {
         const { scope, children } = props;
         const context = useCollectionContext(COLLECTION_SLOT_NAME, scope);
@@ -60706,13 +60387,13 @@ Assistant:`;
     const ITEM_SLOT_NAME = name + "CollectionItemSlot";
     const ITEM_DATA_ATTR = "data-radix-collection-item";
     const CollectionItemSlotImpl = createSlot(ITEM_SLOT_NAME);
-    const CollectionItemSlot = React47.forwardRef(
+    const CollectionItemSlot = React43.forwardRef(
       (props, forwardedRef) => {
         const { scope, children, ...itemData } = props;
-        const ref = React47.useRef(null);
+        const ref = React43.useRef(null);
         const composedRefs = useComposedRefs(forwardedRef, ref);
         const context = useCollectionContext(ITEM_SLOT_NAME, scope);
-        React47.useEffect(() => {
+        React43.useEffect(() => {
           context.itemMap.set(ref, { ref, ...itemData });
           return () => void context.itemMap.delete(ref);
         });
@@ -60722,7 +60403,7 @@ Assistant:`;
     CollectionItemSlot.displayName = ITEM_SLOT_NAME;
     function useCollection2(scope) {
       const context = useCollectionContext(name + "CollectionConsumer", scope);
-      const getItems = React47.useCallback(() => {
+      const getItems = React43.useCallback(() => {
         const collectionNode = context.collectionRef.current;
         if (!collectionNode) return [];
         const orderedNodes = Array.from(collectionNode.querySelectorAll(`[${ITEM_DATA_ATTR}]`));
@@ -60741,19 +60422,19 @@ Assistant:`;
     ];
   }
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-direction@1.1.2+b2e33729a97476bf/node_modules/@radix-ui/react-direction/dist/index.mjs
-  var React48 = __toESM(require_react(), 1);
+  // ../../../node_modules/.bun/@radix-ui+react-direction@1.1.2+b2e33729a97476bf/node_modules/@radix-ui/react-direction/dist/index.mjs
+  var React44 = __toESM(require_react(), 1);
   var import_jsx_runtime27 = __toESM(require_jsx_runtime(), 1);
-  var DirectionContext = React48.createContext(void 0);
+  var DirectionContext = React44.createContext(void 0);
   function useDirection(localDir) {
-    const globalDir = React48.useContext(DirectionContext);
+    const globalDir = React44.useContext(DirectionContext);
     return localDir || globalDir || "ltr";
   }
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-popper@1.3.1+119c4f3973a6d299/node_modules/@radix-ui/react-popper/dist/index.mjs
-  var React51 = __toESM(require_react(), 1);
+  // ../../../node_modules/.bun/@radix-ui+react-popper@1.3.1+119c4f3973a6d299/node_modules/@radix-ui/react-popper/dist/index.mjs
+  var React47 = __toESM(require_react(), 1);
 
-  // ../pr-12727-run/node_modules/.bun/@floating-ui+utils@0.2.11/node_modules/@floating-ui/utils/dist/floating-ui.utils.mjs
+  // ../../../node_modules/.bun/@floating-ui+utils@0.2.11/node_modules/@floating-ui/utils/dist/floating-ui.utils.mjs
   var sides = ["top", "right", "bottom", "left"];
   var min = Math.min;
   var max = Math.max;
@@ -60882,7 +60563,7 @@ Assistant:`;
     };
   }
 
-  // ../pr-12727-run/node_modules/.bun/@floating-ui+core@1.7.5/node_modules/@floating-ui/core/dist/floating-ui.core.mjs
+  // ../../../node_modules/.bun/@floating-ui+core@1.7.5/node_modules/@floating-ui/core/dist/floating-ui.core.mjs
   function computeCoordsFromPlacement(_ref, placement, rtl) {
     let {
       reference,
@@ -61599,7 +61280,7 @@ Assistant:`;
     };
   };
 
-  // ../pr-12727-run/node_modules/.bun/@floating-ui+utils@0.2.11/node_modules/@floating-ui/utils/dist/floating-ui.utils.dom.mjs
+  // ../../../node_modules/.bun/@floating-ui+utils@0.2.11/node_modules/@floating-ui/utils/dist/floating-ui.utils.dom.mjs
   function hasWindow() {
     return typeof window !== "undefined";
   }
@@ -61755,7 +61436,7 @@ Assistant:`;
     return win.parent && Object.getPrototypeOf(win.parent) ? win.frameElement : null;
   }
 
-  // ../pr-12727-run/node_modules/.bun/@floating-ui+dom@1.7.6/node_modules/@floating-ui/dom/dist/floating-ui.dom.mjs
+  // ../../../node_modules/.bun/@floating-ui+dom@1.7.6/node_modules/@floating-ui/dom/dist/floating-ui.dom.mjs
   function getCssDimensions(element) {
     const css = getComputedStyle2(element);
     let width = parseFloat(css.width) || 0;
@@ -62370,8 +62051,8 @@ Assistant:`;
     });
   };
 
-  // ../pr-12727-run/node_modules/.bun/@floating-ui+react-dom@2.1.8+21ccd8898788a04d/node_modules/@floating-ui/react-dom/dist/floating-ui.react-dom.mjs
-  var React49 = __toESM(require_react(), 1);
+  // ../../../node_modules/.bun/@floating-ui+react-dom@2.1.8+21ccd8898788a04d/node_modules/@floating-ui/react-dom/dist/floating-ui.react-dom.mjs
+  var React45 = __toESM(require_react(), 1);
   var import_react52 = __toESM(require_react(), 1);
   var ReactDOM3 = __toESM(require_react_dom(), 1);
   var isClient = typeof document !== "undefined";
@@ -62437,7 +62118,7 @@ Assistant:`;
     return Math.round(value * dpr) / dpr;
   }
   function useLatestRef(value) {
-    const ref = React49.useRef(value);
+    const ref = React45.useRef(value);
     index(() => {
       ref.current = value;
     });
@@ -62460,7 +62141,7 @@ Assistant:`;
       whileElementsMounted,
       open
     } = options2;
-    const [data, setData] = React49.useState({
+    const [data, setData] = React45.useState({
       x: 0,
       y: 0,
       strategy,
@@ -62468,19 +62149,19 @@ Assistant:`;
       middlewareData: {},
       isPositioned: false
     });
-    const [latestMiddleware, setLatestMiddleware] = React49.useState(middleware);
+    const [latestMiddleware, setLatestMiddleware] = React45.useState(middleware);
     if (!deepEqual(latestMiddleware, middleware)) {
       setLatestMiddleware(middleware);
     }
-    const [_reference, _setReference] = React49.useState(null);
-    const [_floating, _setFloating] = React49.useState(null);
-    const setReference = React49.useCallback((node) => {
+    const [_reference, _setReference] = React45.useState(null);
+    const [_floating, _setFloating] = React45.useState(null);
+    const setReference = React45.useCallback((node) => {
       if (node !== referenceRef.current) {
         referenceRef.current = node;
         _setReference(node);
       }
     }, []);
-    const setFloating = React49.useCallback((node) => {
+    const setFloating = React45.useCallback((node) => {
       if (node !== floatingRef.current) {
         floatingRef.current = node;
         _setFloating(node);
@@ -62488,14 +62169,14 @@ Assistant:`;
     }, []);
     const referenceEl = externalReference || _reference;
     const floatingEl = externalFloating || _floating;
-    const referenceRef = React49.useRef(null);
-    const floatingRef = React49.useRef(null);
-    const dataRef = React49.useRef(data);
+    const referenceRef = React45.useRef(null);
+    const floatingRef = React45.useRef(null);
+    const dataRef = React45.useRef(data);
     const hasWhileElementsMounted = whileElementsMounted != null;
     const whileElementsMountedRef = useLatestRef(whileElementsMounted);
     const platformRef = useLatestRef(platform5);
     const openRef = useLatestRef(open);
-    const update = React49.useCallback(() => {
+    const update = React45.useCallback(() => {
       if (!referenceRef.current || !floatingRef.current) {
         return;
       }
@@ -62533,7 +62214,7 @@ Assistant:`;
         }));
       }
     }, [open]);
-    const isMountedRef = React49.useRef(false);
+    const isMountedRef = React45.useRef(false);
     index(() => {
       isMountedRef.current = true;
       return () => {
@@ -62550,17 +62231,17 @@ Assistant:`;
         update();
       }
     }, [referenceEl, floatingEl, update, whileElementsMountedRef, hasWhileElementsMounted]);
-    const refs = React49.useMemo(() => ({
+    const refs = React45.useMemo(() => ({
       reference: referenceRef,
       floating: floatingRef,
       setReference,
       setFloating
     }), [setReference, setFloating]);
-    const elements = React49.useMemo(() => ({
+    const elements = React45.useMemo(() => ({
       reference: referenceEl,
       floating: floatingEl
     }), [referenceEl, floatingEl]);
-    const floatingStyles = React49.useMemo(() => {
+    const floatingStyles = React45.useMemo(() => {
       const initialStyles = {
         position: strategy,
         left: 0,
@@ -62586,7 +62267,7 @@ Assistant:`;
         top: y
       };
     }, [strategy, transform2, elements.floating, data.x, data.y]);
-    return React49.useMemo(() => ({
+    return React45.useMemo(() => ({
       ...data,
       update,
       refs,
@@ -62681,11 +62362,11 @@ Assistant:`;
     };
   };
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-arrow@1.1.10+119c4f3973a6d299/node_modules/@radix-ui/react-arrow/dist/index.mjs
-  var React50 = __toESM(require_react(), 1);
+  // ../../../node_modules/.bun/@radix-ui+react-arrow@1.1.10+119c4f3973a6d299/node_modules/@radix-ui/react-arrow/dist/index.mjs
+  var React46 = __toESM(require_react(), 1);
   var import_jsx_runtime28 = __toESM(require_jsx_runtime(), 1);
   var NAME2 = "Arrow";
-  var Arrow = React50.forwardRef((props, forwardedRef) => {
+  var Arrow = React46.forwardRef((props, forwardedRef) => {
     const { children, width = 10, height = 5, ...arrowProps } = props;
     return /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(
       Primitive.svg,
@@ -62703,15 +62384,15 @@ Assistant:`;
   Arrow.displayName = NAME2;
   var Root2 = Arrow;
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-popper@1.3.1+119c4f3973a6d299/node_modules/@radix-ui/react-popper/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-popper@1.3.1+119c4f3973a6d299/node_modules/@radix-ui/react-popper/dist/index.mjs
   var import_jsx_runtime29 = __toESM(require_jsx_runtime(), 1);
   var POPPER_NAME = "Popper";
   var [createPopperContext, createPopperScope] = createContextScope(POPPER_NAME);
   var [PopperProvider, usePopperContext] = createPopperContext(POPPER_NAME);
   var Popper = (props) => {
     const { __scopePopper, children } = props;
-    const [anchor, setAnchor] = React51.useState(null);
-    const [placementState, setPlacementState] = React51.useState(void 0);
+    const [anchor, setAnchor] = React47.useState(null);
+    const [placementState, setPlacementState] = React47.useState(void 0);
     return /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(
       PopperProvider,
       {
@@ -62726,13 +62407,13 @@ Assistant:`;
   };
   Popper.displayName = POPPER_NAME;
   var ANCHOR_NAME = "PopperAnchor";
-  var PopperAnchor = React51.forwardRef(
+  var PopperAnchor = React47.forwardRef(
     (props, forwardedRef) => {
       const { __scopePopper, virtualRef, ...anchorProps } = props;
       const context = usePopperContext(ANCHOR_NAME, __scopePopper);
-      const ref = React51.useRef(null);
+      const ref = React47.useRef(null);
       const onAnchorChange = context.onAnchorChange;
-      const callbackRef = React51.useCallback(
+      const callbackRef = React47.useCallback(
         (node) => {
           ref.current = node;
           if (node) {
@@ -62742,8 +62423,8 @@ Assistant:`;
         [onAnchorChange]
       );
       const composedRefs = useComposedRefs(forwardedRef, callbackRef);
-      const anchorRef = React51.useRef(null);
-      React51.useEffect(() => {
+      const anchorRef = React47.useRef(null);
+      React47.useEffect(() => {
         if (!virtualRef) {
           return;
         }
@@ -62770,7 +62451,7 @@ Assistant:`;
   PopperAnchor.displayName = ANCHOR_NAME;
   var CONTENT_NAME2 = "PopperContent";
   var [PopperContentProvider, useContentContext] = createPopperContext(CONTENT_NAME2);
-  var PopperContent = React51.forwardRef(
+  var PopperContent = React47.forwardRef(
     (props, forwardedRef) => {
       const {
         __scopePopper,
@@ -62789,9 +62470,9 @@ Assistant:`;
         ...contentProps
       } = props;
       const context = usePopperContext(CONTENT_NAME2, __scopePopper);
-      const [content, setContent] = React51.useState(null);
+      const [content, setContent] = React47.useState(null);
       const composedRefs = useComposedRefs(forwardedRef, (node) => setContent(node));
-      const [arrow4, setArrow] = React51.useState(null);
+      const [arrow4, setArrow] = React47.useState(null);
       const arrowSize = useSize(arrow4);
       const arrowWidth = arrowSize?.width ?? 0;
       const arrowHeight = arrowSize?.height ?? 0;
@@ -62871,7 +62552,7 @@ Assistant:`;
       const arrowX = middlewareData.arrow?.x;
       const arrowY = middlewareData.arrow?.y;
       const cannotCenterArrow = middlewareData.arrow?.centerOffset !== 0;
-      const [contentZIndex, setContentZIndex] = React51.useState();
+      const [contentZIndex, setContentZIndex] = React47.useState();
       useLayoutEffect2(() => {
         if (content) setContentZIndex(window.getComputedStyle(content).zIndex);
       }, [content]);
@@ -62938,7 +62619,7 @@ Assistant:`;
     bottom: "top",
     left: "right"
   };
-  var PopperArrow = React51.forwardRef(function PopperArrow2(props, forwardedRef) {
+  var PopperArrow = React47.forwardRef(function PopperArrow2(props, forwardedRef) {
     const { __scopePopper, ...arrowProps } = props;
     const contentContext = useContentContext(ARROW_NAME, __scopePopper);
     const baseSide = OPPOSITE_SIDE[contentContext.placedSide];
@@ -63029,8 +62710,8 @@ Assistant:`;
   var Content = PopperContent;
   var Arrow2 = PopperArrow;
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-visually-hidden@1.2.6+119c4f3973a6d299/node_modules/@radix-ui/react-visually-hidden/dist/index.mjs
-  var React52 = __toESM(require_react(), 1);
+  // ../../../node_modules/.bun/@radix-ui+react-visually-hidden@1.2.6+119c4f3973a6d299/node_modules/@radix-ui/react-visually-hidden/dist/index.mjs
+  var React48 = __toESM(require_react(), 1);
   var import_jsx_runtime30 = __toESM(require_jsx_runtime(), 1);
   var VISUALLY_HIDDEN_STYLES = Object.freeze({
     // See: https://github.com/twbs/bootstrap/blob/main/scss/mixins/_visually-hidden.scss
@@ -63046,7 +62727,7 @@ Assistant:`;
     wordWrap: "normal"
   });
   var NAME3 = "VisuallyHidden";
-  var VisuallyHidden = React52.forwardRef(
+  var VisuallyHidden = React48.forwardRef(
     (props, forwardedRef) => {
       return /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(
         Primitive.span,
@@ -63060,7 +62741,7 @@ Assistant:`;
   );
   VisuallyHidden.displayName = NAME3;
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-select@2.3.1+119c4f3973a6d299/node_modules/@radix-ui/react-select/dist/index.mjs
+  // ../../../node_modules/.bun/@radix-ui+react-select@2.3.1+119c4f3973a6d299/node_modules/@radix-ui/react-select/dist/index.mjs
   var import_jsx_runtime31 = __toESM(require_jsx_runtime(), 1);
   var OPEN_KEYS = [" ", "Enter", "ArrowUp", "ArrowDown"];
   var SELECTION_KEYS = [" ", "Enter"];
@@ -63094,9 +62775,9 @@ Assistant:`;
       internal_do_not_use_render
     } = props;
     const popperScope = usePopperScope(__scopeSelect);
-    const [trigger, setTrigger] = React53.useState(null);
-    const [valueNode, setValueNode] = React53.useState(null);
-    const [valueNodeHasChildren, setValueNodeHasChildren] = React53.useState(false);
+    const [trigger, setTrigger] = React49.useState(null);
+    const [valueNode, setValueNode] = React49.useState(null);
+    const [valueNodeHasChildren, setValueNodeHasChildren] = React49.useState(false);
     const direction = useDirection(dir);
     const [open, setOpen] = useControllableState({
       prop: openProp,
@@ -63110,15 +62791,15 @@ Assistant:`;
       onChange: onValueChange,
       caller: SELECT_NAME
     });
-    const triggerPointerDownPosRef = React53.useRef(null);
+    const triggerPointerDownPosRef = React49.useRef(null);
     const isFormControl = trigger ? !!form || !!trigger.closest("form") : true;
-    const [nativeOptionsSet, setNativeOptionsSet] = React53.useState(/* @__PURE__ */ new Set());
+    const [nativeOptionsSet, setNativeOptionsSet] = React49.useState(/* @__PURE__ */ new Set());
     const contentId = useId();
     const nativeSelectKey = Array.from(nativeOptionsSet).map((option) => option.props.value).join(";");
-    const handleNativeOptionAdd = React53.useCallback((option) => {
+    const handleNativeOptionAdd = React49.useCallback((option) => {
       setNativeOptionsSet((prev) => new Set(prev).add(option));
     }, []);
-    const handleNativeOptionRemove = React53.useCallback((option) => {
+    const handleNativeOptionRemove = React49.useCallback((option) => {
       setNativeOptionsSet((prev) => {
         const optionsSet = new Set(prev);
         optionsSet.delete(option);
@@ -63180,7 +62861,7 @@ Assistant:`;
   };
   Select.displayName = SELECT_NAME;
   var TRIGGER_NAME3 = "SelectTrigger";
-  var SelectTrigger = React53.forwardRef(
+  var SelectTrigger = React49.forwardRef(
     (props, forwardedRef) => {
       const { __scopeSelect, disabled = false, ...triggerProps } = props;
       const popperScope = usePopperScope(__scopeSelect);
@@ -63188,7 +62869,7 @@ Assistant:`;
       const isDisabled = context.disabled || disabled;
       const composedRefs = useComposedRefs(forwardedRef, context.onTriggerChange);
       const getItems = useCollection(__scopeSelect);
-      const pointerTypeRef = React53.useRef("touch");
+      const pointerTypeRef = React49.useRef("touch");
       const [searchRef, handleTypeaheadSearch, resetTypeahead] = useTypeaheadSearch((search) => {
         const enabledItems = getItems().filter((item) => !item.disabled);
         const currentItem = enabledItems.find((item) => item.value === context.value);
@@ -63258,7 +62939,7 @@ Assistant:`;
   );
   SelectTrigger.displayName = TRIGGER_NAME3;
   var VALUE_NAME = "SelectValue";
-  var SelectValue = React53.forwardRef(
+  var SelectValue = React49.forwardRef(
     (props, forwardedRef) => {
       const { __scopeSelect, className, style, children, placeholder = "", ...valueProps } = props;
       const context = useSelectContext(VALUE_NAME, __scopeSelect);
@@ -63276,14 +62957,14 @@ Assistant:`;
           asChild: showPlaceholder ? false : valueProps.asChild,
           ref: composedRefs,
           style: { pointerEvents: "none" },
-          children: /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(React53.Fragment, { children: showPlaceholder ? placeholder : children }, showPlaceholder ? "placeholder" : "value")
+          children: /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(React49.Fragment, { children: showPlaceholder ? placeholder : children }, showPlaceholder ? "placeholder" : "value")
         }
       );
     }
   );
   SelectValue.displayName = VALUE_NAME;
   var ICON_NAME = "SelectIcon";
-  var SelectIcon = React53.forwardRef(
+  var SelectIcon = React49.forwardRef(
     (props, forwardedRef) => {
       const { __scopeSelect, children, ...iconProps } = props;
       return /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Primitive.span, { "aria-hidden": true, ...iconProps, ref: forwardedRef, children: children || "\u25BC" });
@@ -63300,12 +62981,12 @@ Assistant:`;
   };
   SelectPortal.displayName = PORTAL_NAME3;
   var CONTENT_NAME3 = "SelectContent";
-  var SelectContent = React53.forwardRef(
+  var SelectContent = React49.forwardRef(
     (props, forwardedRef) => {
       const portalContext = usePortalContext2(CONTENT_NAME3, props.__scopeSelect);
       const { forceMount = portalContext.forceMount, ...contentProps } = props;
       const context = useSelectContext(CONTENT_NAME3, props.__scopeSelect);
-      const [fragment, setFragment] = React53.useState();
+      const [fragment, setFragment] = React49.useState();
       useLayoutEffect2(() => {
         setFragment(new DocumentFragment());
       }, []);
@@ -63313,7 +62994,7 @@ Assistant:`;
     }
   );
   SelectContent.displayName = CONTENT_NAME3;
-  var SelectContentFragment = React53.forwardRef((props, forwardedRef) => {
+  var SelectContentFragment = React49.forwardRef((props, forwardedRef) => {
     const { __scopeSelect, children, fragment } = props;
     if (!fragment) return null;
     return ReactDOM4.createPortal(
@@ -63326,7 +63007,7 @@ Assistant:`;
   var [SelectContentProvider, useSelectContentContext] = createSelectContext(CONTENT_NAME3);
   var CONTENT_IMPL_NAME = "SelectContentImpl";
   var Slot3 = createSlot("SelectContent.RemoveScroll");
-  var SelectContentImpl = React53.forwardRef(
+  var SelectContentImpl = React49.forwardRef(
     (props, forwardedRef) => {
       const { __scopeSelect } = props;
       const {
@@ -63350,21 +63031,21 @@ Assistant:`;
         ...contentProps
       } = props;
       const context = useSelectContext(CONTENT_NAME3, __scopeSelect);
-      const [content, setContent] = React53.useState(null);
-      const [viewport, setViewport] = React53.useState(null);
+      const [content, setContent] = React49.useState(null);
+      const [viewport, setViewport] = React49.useState(null);
       const composedRefs = useComposedRefs(forwardedRef, (node) => setContent(node));
-      const [selectedItem, setSelectedItem] = React53.useState(null);
-      const [selectedItemText, setSelectedItemText] = React53.useState(
+      const [selectedItem, setSelectedItem] = React49.useState(null);
+      const [selectedItemText, setSelectedItemText] = React49.useState(
         null
       );
       const getItems = useCollection(__scopeSelect);
-      const [isPositioned, setIsPositioned] = React53.useState(false);
-      const firstValidItemFoundRef = React53.useRef(false);
-      React53.useEffect(() => {
+      const [isPositioned, setIsPositioned] = React49.useState(false);
+      const firstValidItemFoundRef = React49.useRef(false);
+      React49.useEffect(() => {
         if (content) return hideOthers(content);
       }, [content]);
       useFocusGuards();
-      const focusFirst2 = React53.useCallback(
+      const focusFirst2 = React49.useCallback(
         (candidates) => {
           const [firstItem, ...restItems] = getItems().map((item) => item.ref.current);
           const [lastItem] = restItems.slice(-1);
@@ -63380,17 +63061,17 @@ Assistant:`;
         },
         [getItems, viewport]
       );
-      const focusSelectedItem = React53.useCallback(
+      const focusSelectedItem = React49.useCallback(
         () => focusFirst2([selectedItem, content]),
         [focusFirst2, selectedItem, content]
       );
-      React53.useEffect(() => {
+      React49.useEffect(() => {
         if (isPositioned) {
           focusSelectedItem();
         }
       }, [isPositioned, focusSelectedItem]);
       const { onOpenChange, triggerPointerDownPosRef } = context;
-      React53.useEffect(() => {
+      React49.useEffect(() => {
         if (content) {
           let pointerMoveDelta = { x: 0, y: 0 };
           const handlePointerMove = (event) => {
@@ -63420,7 +63101,7 @@ Assistant:`;
           };
         }
       }, [content, onOpenChange, triggerPointerDownPosRef]);
-      React53.useEffect(() => {
+      React49.useEffect(() => {
         const close = () => onOpenChange(false);
         window.addEventListener("blur", close);
         window.addEventListener("resize", close);
@@ -63437,7 +63118,7 @@ Assistant:`;
           setTimeout(() => nextItem.ref.current?.focus());
         }
       });
-      const itemRefCallback = React53.useCallback(
+      const itemRefCallback = React49.useCallback(
         (node, value, disabled) => {
           const isFirstValidItem = !firstValidItemFoundRef.current && !disabled;
           const isSelectedItem = context.value !== void 0 && context.value === value;
@@ -63448,8 +63129,8 @@ Assistant:`;
         },
         [context.value]
       );
-      const handleItemLeave = React53.useCallback(() => content?.focus(), [content]);
-      const itemTextRefCallback = React53.useCallback(
+      const handleItemLeave = React49.useCallback(() => content?.focus(), [content]);
+      const itemTextRefCallback = React49.useCallback(
         (node, value, disabled) => {
           const isFirstValidItem = !firstValidItemFoundRef.current && !disabled;
           const isSelectedItem = context.value !== void 0 && context.value === value;
@@ -63560,18 +63241,18 @@ Assistant:`;
   );
   SelectContentImpl.displayName = CONTENT_IMPL_NAME;
   var ITEM_ALIGNED_POSITION_NAME = "SelectItemAlignedPosition";
-  var SelectItemAlignedPosition = React53.forwardRef((props, forwardedRef) => {
+  var SelectItemAlignedPosition = React49.forwardRef((props, forwardedRef) => {
     const { __scopeSelect, onPlaced, ...popperProps } = props;
     const context = useSelectContext(CONTENT_NAME3, __scopeSelect);
     const contentContext = useSelectContentContext(CONTENT_NAME3, __scopeSelect);
-    const [contentWrapper, setContentWrapper] = React53.useState(null);
-    const [content, setContent] = React53.useState(null);
+    const [contentWrapper, setContentWrapper] = React49.useState(null);
+    const [content, setContent] = React49.useState(null);
     const composedRefs = useComposedRefs(forwardedRef, (node) => setContent(node));
     const getItems = useCollection(__scopeSelect);
-    const shouldExpandOnScrollRef = React53.useRef(false);
-    const shouldRepositionRef = React53.useRef(true);
+    const shouldExpandOnScrollRef = React49.useRef(false);
+    const shouldRepositionRef = React49.useRef(true);
     const { viewport, selectedItem, selectedItemText, focusSelectedItem } = contentContext;
-    const position = React53.useCallback(() => {
+    const position = React49.useCallback(() => {
       if (context.trigger && context.valueNode && contentWrapper && content && viewport && selectedItem && selectedItemText) {
         const triggerRect = context.trigger.getBoundingClientRect();
         const contentRect = content.getBoundingClientRect();
@@ -63671,11 +63352,11 @@ Assistant:`;
       onPlaced
     ]);
     useLayoutEffect2(() => position(), [position]);
-    const [contentZIndex, setContentZIndex] = React53.useState();
+    const [contentZIndex, setContentZIndex] = React49.useState();
     useLayoutEffect2(() => {
       if (content) setContentZIndex(window.getComputedStyle(content).zIndex);
     }, [content]);
-    const handleScrollButtonChange = React53.useCallback(
+    const handleScrollButtonChange = React49.useCallback(
       (node) => {
         if (node && shouldRepositionRef.current === true) {
           position();
@@ -63724,7 +63405,7 @@ Assistant:`;
   });
   SelectItemAlignedPosition.displayName = ITEM_ALIGNED_POSITION_NAME;
   var POPPER_POSITION_NAME = "SelectPopperPosition";
-  var SelectPopperPosition = React53.forwardRef((props, forwardedRef) => {
+  var SelectPopperPosition = React49.forwardRef((props, forwardedRef) => {
     const {
       __scopeSelect,
       align = "start",
@@ -63759,13 +63440,13 @@ Assistant:`;
   SelectPopperPosition.displayName = POPPER_POSITION_NAME;
   var [SelectViewportProvider, useSelectViewportContext] = createSelectContext(CONTENT_NAME3, {});
   var VIEWPORT_NAME = "SelectViewport";
-  var SelectViewport = React53.forwardRef(
+  var SelectViewport = React49.forwardRef(
     (props, forwardedRef) => {
       const { __scopeSelect, nonce, ...viewportProps } = props;
       const contentContext = useSelectContentContext(VIEWPORT_NAME, __scopeSelect);
       const viewportContext = useSelectViewportContext(VIEWPORT_NAME, __scopeSelect);
       const composedRefs = useComposedRefs(forwardedRef, contentContext.onViewportChange);
-      const prevScrollTopRef = React53.useRef(0);
+      const prevScrollTopRef = React49.useRef(0);
       return /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)(import_jsx_runtime31.Fragment, { children: [
         /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
           "style",
@@ -63828,7 +63509,7 @@ Assistant:`;
   SelectViewport.displayName = VIEWPORT_NAME;
   var GROUP_NAME = "SelectGroup";
   var [SelectGroupContextProvider, useSelectGroupContext] = createSelectContext(GROUP_NAME);
-  var SelectGroup = React53.forwardRef(
+  var SelectGroup = React49.forwardRef(
     (props, forwardedRef) => {
       const { __scopeSelect, ...groupProps } = props;
       const groupId = useId();
@@ -63837,7 +63518,7 @@ Assistant:`;
   );
   SelectGroup.displayName = GROUP_NAME;
   var LABEL_NAME = "SelectLabel";
-  var SelectLabel = React53.forwardRef(
+  var SelectLabel = React49.forwardRef(
     (props, forwardedRef) => {
       const { __scopeSelect, ...labelProps } = props;
       const groupContext = useSelectGroupContext(LABEL_NAME, __scopeSelect);
@@ -63847,7 +63528,7 @@ Assistant:`;
   SelectLabel.displayName = LABEL_NAME;
   var ITEM_NAME = "SelectItem";
   var [SelectItemContextProvider, useSelectItemContext] = createSelectContext(ITEM_NAME);
-  var SelectItem = React53.forwardRef(
+  var SelectItem = React49.forwardRef(
     (props, forwardedRef) => {
       const {
         __scopeSelect,
@@ -63859,14 +63540,14 @@ Assistant:`;
       const context = useSelectContext(ITEM_NAME, __scopeSelect);
       const contentContext = useSelectContentContext(ITEM_NAME, __scopeSelect);
       const isSelected = context.value === value;
-      const [textValue, setTextValue] = React53.useState(textValueProp ?? "");
-      const [isFocused, setIsFocused] = React53.useState(false);
+      const [textValue, setTextValue] = React49.useState(textValueProp ?? "");
+      const [isFocused, setIsFocused] = React49.useState(false);
       const composedRefs = useComposedRefs(
         forwardedRef,
         (node) => contentContext.itemRefCallback?.(node, value, disabled)
       );
       const textId = useId();
-      const pointerTypeRef = React53.useRef("touch");
+      const pointerTypeRef = React49.useRef("touch");
       const handleSelect = () => {
         if (!disabled) {
           context.onValueChange(value);
@@ -63881,7 +63562,7 @@ Assistant:`;
           disabled,
           textId,
           isSelected,
-          onItemTextChange: React53.useCallback((node) => {
+          onItemTextChange: React49.useCallback((node) => {
             setTextValue((prevTextValue) => prevTextValue || (node?.textContent ?? "").trim());
           }, []),
           children: /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
@@ -63944,14 +63625,14 @@ Assistant:`;
   );
   SelectItem.displayName = ITEM_NAME;
   var ITEM_TEXT_NAME = "SelectItemText";
-  var SelectItemText = React53.forwardRef(
+  var SelectItemText = React49.forwardRef(
     (props, forwardedRef) => {
       const { __scopeSelect, className, style, ...itemTextProps } = props;
       const context = useSelectContext(ITEM_TEXT_NAME, __scopeSelect);
       const contentContext = useSelectContentContext(ITEM_TEXT_NAME, __scopeSelect);
       const itemContext = useSelectItemContext(ITEM_TEXT_NAME, __scopeSelect);
       const nativeOptionsContext = useSelectNativeOptionsContext(ITEM_TEXT_NAME, __scopeSelect);
-      const [itemTextNode, setItemTextNode] = React53.useState(null);
+      const [itemTextNode, setItemTextNode] = React49.useState(null);
       const composedRefs = useComposedRefs(
         forwardedRef,
         (node) => setItemTextNode(node),
@@ -63959,7 +63640,7 @@ Assistant:`;
         (node) => contentContext.itemTextRefCallback?.(node, itemContext.value, itemContext.disabled)
       );
       const textContent = itemTextNode?.textContent;
-      const nativeOption = React53.useMemo(
+      const nativeOption = React49.useMemo(
         () => /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("option", { value: itemContext.value, disabled: itemContext.disabled, children: textContent }, itemContext.value),
         [itemContext.disabled, itemContext.value, textContent]
       );
@@ -63976,7 +63657,7 @@ Assistant:`;
   );
   SelectItemText.displayName = ITEM_TEXT_NAME;
   var ITEM_INDICATOR_NAME = "SelectItemIndicator";
-  var SelectItemIndicator = React53.forwardRef(
+  var SelectItemIndicator = React49.forwardRef(
     (props, forwardedRef) => {
       const { __scopeSelect, ...itemIndicatorProps } = props;
       const itemContext = useSelectItemContext(ITEM_INDICATOR_NAME, __scopeSelect);
@@ -63985,10 +63666,10 @@ Assistant:`;
   );
   SelectItemIndicator.displayName = ITEM_INDICATOR_NAME;
   var SCROLL_UP_BUTTON_NAME = "SelectScrollUpButton";
-  var SelectScrollUpButton = React53.forwardRef((props, forwardedRef) => {
+  var SelectScrollUpButton = React49.forwardRef((props, forwardedRef) => {
     const contentContext = useSelectContentContext(SCROLL_UP_BUTTON_NAME, props.__scopeSelect);
     const viewportContext = useSelectViewportContext(SCROLL_UP_BUTTON_NAME, props.__scopeSelect);
-    const [canScrollUp, setCanScrollUp] = React53.useState(false);
+    const [canScrollUp, setCanScrollUp] = React49.useState(false);
     const composedRefs = useComposedRefs(forwardedRef, viewportContext.onScrollButtonChange);
     useLayoutEffect2(() => {
       if (contentContext.viewport && contentContext.isPositioned) {
@@ -64019,10 +63700,10 @@ Assistant:`;
   });
   SelectScrollUpButton.displayName = SCROLL_UP_BUTTON_NAME;
   var SCROLL_DOWN_BUTTON_NAME = "SelectScrollDownButton";
-  var SelectScrollDownButton = React53.forwardRef((props, forwardedRef) => {
+  var SelectScrollDownButton = React49.forwardRef((props, forwardedRef) => {
     const contentContext = useSelectContentContext(SCROLL_DOWN_BUTTON_NAME, props.__scopeSelect);
     const viewportContext = useSelectViewportContext(SCROLL_DOWN_BUTTON_NAME, props.__scopeSelect);
-    const [canScrollDown, setCanScrollDown] = React53.useState(false);
+    const [canScrollDown, setCanScrollDown] = React49.useState(false);
     const composedRefs = useComposedRefs(forwardedRef, viewportContext.onScrollButtonChange);
     useLayoutEffect2(() => {
       if (contentContext.viewport && contentContext.isPositioned) {
@@ -64053,18 +63734,18 @@ Assistant:`;
     ) : null;
   });
   SelectScrollDownButton.displayName = SCROLL_DOWN_BUTTON_NAME;
-  var SelectScrollButtonImpl = React53.forwardRef((props, forwardedRef) => {
+  var SelectScrollButtonImpl = React49.forwardRef((props, forwardedRef) => {
     const { __scopeSelect, onAutoScroll, ...scrollIndicatorProps } = props;
     const contentContext = useSelectContentContext("SelectScrollButton", __scopeSelect);
-    const autoScrollTimerRef = React53.useRef(null);
+    const autoScrollTimerRef = React49.useRef(null);
     const getItems = useCollection(__scopeSelect);
-    const clearAutoScrollTimer = React53.useCallback(() => {
+    const clearAutoScrollTimer = React49.useCallback(() => {
       if (autoScrollTimerRef.current !== null) {
         window.clearInterval(autoScrollTimerRef.current);
         autoScrollTimerRef.current = null;
       }
     }, []);
-    React53.useEffect(() => {
+    React49.useEffect(() => {
       return () => clearAutoScrollTimer();
     }, [clearAutoScrollTimer]);
     useLayoutEffect2(() => {
@@ -64096,7 +63777,7 @@ Assistant:`;
     );
   });
   var SEPARATOR_NAME = "SelectSeparator";
-  var SelectSeparator = React53.forwardRef(
+  var SelectSeparator = React49.forwardRef(
     (props, forwardedRef) => {
       const { __scopeSelect, ...separatorProps } = props;
       return /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Primitive.div, { "aria-hidden": true, ...separatorProps, ref: forwardedRef });
@@ -64104,7 +63785,7 @@ Assistant:`;
   );
   SelectSeparator.displayName = SEPARATOR_NAME;
   var ARROW_NAME2 = "SelectArrow";
-  var SelectArrow = React53.forwardRef(
+  var SelectArrow = React49.forwardRef(
     (props, forwardedRef) => {
       const { __scopeSelect, ...arrowProps } = props;
       const popperScope = usePopperScope(__scopeSelect);
@@ -64114,19 +63795,19 @@ Assistant:`;
   );
   SelectArrow.displayName = ARROW_NAME2;
   var BUBBLE_INPUT_NAME2 = "SelectBubbleInput";
-  var SelectBubbleInput = React53.forwardRef(
+  var SelectBubbleInput = React49.forwardRef(
     ({ __scopeSelect, ...props }, forwardedRef) => {
       const context = useSelectContext(BUBBLE_INPUT_NAME2, __scopeSelect);
       const { value, onValueChange, required: required2, disabled, name, autoComplete, form } = context;
       const { nativeOptions, nativeSelectKey } = context;
-      const ref = React53.useRef(null);
+      const ref = React49.useRef(null);
       const composedRefs = useComposedRefs(forwardedRef, ref);
       const selectValue = value ?? "";
       const prevValue = usePrevious(selectValue);
       const hasEmptyValueOption = Array.from(nativeOptions).some(
         (option) => (option.props.value ?? "") === ""
       );
-      React53.useEffect(() => {
+      React49.useEffect(() => {
         const select = ref.current;
         if (!select) return;
         const selectProto = window.HTMLSelectElement.prototype;
@@ -64174,9 +63855,9 @@ Assistant:`;
   }
   function useTypeaheadSearch(onSearchChange) {
     const handleSearchChange = useCallbackRef(onSearchChange);
-    const searchRef = React53.useRef("");
-    const timerRef = React53.useRef(0);
-    const handleTypeaheadSearch = React53.useCallback(
+    const searchRef = React49.useRef("");
+    const timerRef = React49.useRef(0);
+    const handleTypeaheadSearch = React49.useCallback(
       (key) => {
         const search = searchRef.current + key;
         handleSearchChange(search);
@@ -64188,11 +63869,11 @@ Assistant:`;
       },
       [handleSearchChange]
     );
-    const resetTypeahead = React53.useCallback(() => {
+    const resetTypeahead = React49.useCallback(() => {
       searchRef.current = "";
       window.clearTimeout(timerRef.current);
     }, []);
-    React53.useEffect(() => {
+    React49.useEffect(() => {
       return () => window.clearTimeout(timerRef.current);
     }, []);
     return [searchRef, handleTypeaheadSearch, resetTypeahead];
@@ -64214,11 +63895,11 @@ Assistant:`;
   }
 
   // packages/ui/src/components/ui/select.tsx
-  var React54 = __toESM(require_react(), 1);
+  var React50 = __toESM(require_react(), 1);
   var import_jsx_runtime32 = __toESM(require_jsx_runtime(), 1);
   var Select2 = Select;
   var SelectValue2 = SelectValue;
-  var SelectTrigger2 = React54.forwardRef(({ className, children, ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
+  var SelectTrigger2 = React50.forwardRef(({ className, children, ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
     SelectTrigger,
     {
       ref,
@@ -64234,7 +63915,7 @@ Assistant:`;
     }
   ));
   SelectTrigger2.displayName = SelectTrigger.displayName;
-  var SelectScrollUpButton2 = React54.forwardRef(({ className, ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+  var SelectScrollUpButton2 = React50.forwardRef(({ className, ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
     SelectScrollUpButton,
     {
       ref,
@@ -64247,7 +63928,7 @@ Assistant:`;
     }
   ));
   SelectScrollUpButton2.displayName = SelectScrollUpButton.displayName;
-  var SelectScrollDownButton2 = React54.forwardRef(({ className, ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+  var SelectScrollDownButton2 = React50.forwardRef(({ className, ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
     SelectScrollDownButton,
     {
       ref,
@@ -64260,7 +63941,7 @@ Assistant:`;
     }
   ));
   SelectScrollDownButton2.displayName = SelectScrollDownButton.displayName;
-  var SelectContent2 = React54.forwardRef(({ className, children, position = "popper", ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(SelectPortal, { children: /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
+  var SelectContent2 = React50.forwardRef(({ className, children, position = "popper", ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(SelectPortal, { children: /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
     SelectContent,
     {
       ref,
@@ -64289,7 +63970,7 @@ Assistant:`;
     }
   ) }));
   SelectContent2.displayName = SelectContent.displayName;
-  var SelectLabel2 = React54.forwardRef(({ className, ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+  var SelectLabel2 = React50.forwardRef(({ className, ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
     SelectLabel,
     {
       ref,
@@ -64298,7 +63979,7 @@ Assistant:`;
     }
   ));
   SelectLabel2.displayName = SelectLabel.displayName;
-  var SelectItem2 = React54.forwardRef(({ className, children, ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
+  var SelectItem2 = React50.forwardRef(({ className, children, ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
     SelectItem,
     {
       ref,
@@ -64314,7 +63995,7 @@ Assistant:`;
     }
   ));
   SelectItem2.displayName = SelectItem.displayName;
-  var SelectSeparator2 = React54.forwardRef(({ className, ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+  var SelectSeparator2 = React50.forwardRef(({ className, ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
     SelectSeparator,
     {
       ref,
@@ -64325,7 +64006,7 @@ Assistant:`;
   SelectSeparator2.displayName = SelectSeparator.displayName;
 
   // packages/ui/src/components/ui/textarea.tsx
-  var React55 = __toESM(require_react(), 1);
+  var React51 = __toESM(require_react(), 1);
   var import_jsx_runtime33 = __toESM(require_jsx_runtime(), 1);
   var textareaVariants = cva(
     "w-full border text-sm resize-y transition-[border-color,box-shadow,background-color] disabled:cursor-not-allowed disabled:opacity-50",
@@ -64348,7 +64029,7 @@ Assistant:`;
       }
     }
   );
-  var Textarea = React55.forwardRef(
+  var Textarea = React51.forwardRef(
     ({ className, variant, density, hasError, ...props }, ref) => {
       return /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
         "textarea",
@@ -66125,24 +65806,8 @@ Assistant:`;
     COMPONENT_REGISTRY ??= /* @__PURE__ */ new Map();
     return COMPONENT_REGISTRY;
   }
-  var registryVersion = 0;
-  var registryListeners = /* @__PURE__ */ new Set();
-  function notifyRegistryChanged() {
-    registryVersion += 1;
-    for (const listener of registryListeners) listener();
-  }
-  function subscribeWidgetRegistry(onChange) {
-    registryListeners.add(onChange);
-    return () => {
-      registryListeners.delete(onChange);
-    };
-  }
-  function getWidgetRegistryVersion() {
-    return registryVersion;
-  }
   function registerWidgetComponent(pluginId, declarationId, Component2) {
     getComponentRegistry().set(`${pluginId}/${declarationId}`, Component2);
-    notifyRegistryChanged();
   }
   function getWidgetComponent(pluginId, declarationId) {
     return getComponentRegistry().get(`${pluginId}/${declarationId}`);
@@ -66234,7 +65899,7 @@ Assistant:`;
   var import_react57 = __toESM(require_react(), 1);
 
   // packages/ui/src/chat/useSlashCommandController.ts
-  var React56 = __toESM(require_react(), 1);
+  var React53 = __toESM(require_react(), 1);
   init_home_screen_fixture_api_stub();
 
   // packages/ui/src/components/settings/settings-section-tokens.ts
@@ -66286,11 +65951,8 @@ Assistant:`;
     new Set(Object.keys(SETTINGS_SECTION_TOKEN_ALIASES))
   );
 
-  // packages/ui/src/chat/useSlashCommandController.ts
-  init_events3();
-
   // packages/ui/src/chat/slash-menu.ts
-  var import_core33 = __toESM(require_core(), 1);
+  var import_core30 = __toESM(require_core(), 1);
 
   // packages/ui/src/chat/useSlashCommandController.ts
   function reportUserViewSwitch(viewId, viewPath) {
@@ -66315,14 +65977,19 @@ Assistant:`;
   }
 
   // packages/ui/src/components/chat/widgets/home-widget-card.tsx
-  init_events3();
   var import_jsx_runtime37 = __toESM(require_jsx_runtime(), 1);
   function useWidgetNavigation() {
     const { setTab } = useAppSelectorShallow((s) => ({ setTab: s.setTab }));
     return (0, import_react57.useMemo)(
       () => ({
         openView(path, viewId) {
-          dispatchNavigateViewEvent({ viewPath: path });
+          if (typeof window !== "undefined") {
+            window.dispatchEvent(
+              new CustomEvent("eliza:navigate:view", {
+                detail: { viewPath: path }
+              })
+            );
+          }
           reportUserViewSwitch(viewId ?? path, path);
         },
         openTab(tab) {
@@ -66335,18 +66002,13 @@ Assistant:`;
   }
   var TONE_VALUE_CLASS = {
     default: "text-white",
-    danger: "text-white",
-    warn: "text-white"
+    danger: "text-danger",
+    warn: "text-warn"
   };
   var TONE_DOT_CLASS = {
-    default: "bg-white/60",
-    danger: "bg-white",
-    warn: "bg-white/75"
-  };
-  var TONE_BADGE_CLASS = {
-    default: "bg-black/20 text-white/90",
-    danger: "bg-black/35 text-white",
-    warn: "bg-black/30 text-white"
+    default: "bg-muted",
+    danger: "bg-danger",
+    warn: "bg-warn"
   };
   function HomeWidgetCard({
     icon,
@@ -66371,11 +66033,7 @@ Assistant:`;
           // Chromeless (#10708): no border/background/rounded card — content sits
           // directly on the wallpaper. Neutral-resting hover affordance is an
           // opacity change (no background fill), per the neutral hover rule.
-          // `flex-wrap` + the value's min-width floor below keep the single datum
-          // legible on half-width mobile cards: without them a wide shrink-0
-          // badge ("Overdrawn") crushed the flex-1 value column to ~0px and the
-          // currency vanished. When the row can't fit, the badge wraps under.
-          "group h-auto w-full flex-wrap justify-start gap-3 whitespace-normal rounded-none bg-transparent px-3 py-2.5 text-left",
+          "group h-auto w-full justify-start gap-3 whitespace-normal rounded-none bg-transparent px-3 py-2.5 text-left",
           "transition-opacity hover:bg-transparent hover:opacity-80"
         ),
         children: [
@@ -66383,11 +66041,9 @@ Assistant:`;
             "span",
             {
               className: cn(
-                // Tonal glyph tints are skipped for the same orange-on-orange reason
-                // as TONE_VALUE_CLASS: the escalated tones brighten to full white and
-                // the corner dot marks the tone.
                 "relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/10 text-white/85 [&>svg]:h-4 [&>svg]:w-4",
-                tone !== "default" && "text-white"
+                tone === "danger" && "text-danger",
+                tone === "warn" && "text-warn"
               ),
               children: [
                 icon,
@@ -66404,7 +66060,7 @@ Assistant:`;
               ]
             }
           ),
-          /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", { className: "flex min-w-[4.5rem] flex-1 flex-col", children: value != null ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", { className: "flex min-w-0 flex-1 flex-col", children: value != null ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(
             "span",
             {
               className: cn(
@@ -66424,7 +66080,7 @@ Assistant:`;
             {
               className: cn(
                 "shrink-0 rounded-full px-1.5 py-0.5 text-2xs font-semibold",
-                TONE_BADGE_CLASS[tone]
+                tone === "danger" ? "bg-danger/15 text-danger" : tone === "warn" ? "bg-warn/15 text-warn" : "bg-accent-subtle text-accent"
               ),
               children: badge
             }
@@ -66758,7 +66414,7 @@ Assistant:`;
   init_home_screen_fixture_api_stub();
 
   // packages/ui/src/components/apps/helpers.ts
-  var import_core34 = __toESM(require_core(), 1);
+  var import_core31 = __toESM(require_core(), 1);
   var APPS_VIEW_HIDDEN_APP_NAMES = [
     "@elizaos/app",
     "@elizaos/browser-bridge-extension",
@@ -66782,15 +66438,13 @@ Assistant:`;
   async function loadMergedCatalogApps({
     includeHiddenApps = false
   } = {}) {
-    const [catalogAppsResult, installedAppsResult, viewsResult] = await Promise.allSettled([
+    const [catalogAppsResult, installedAppsResult] = await Promise.allSettled([
       client.listCatalogApps(),
-      client.listApps(),
-      fetchAvailableViews()
+      client.listApps()
     ]);
     const catalogApps = catalogAppsResult.status === "fulfilled" ? catalogAppsResult.value : [];
     const installedApps = installedAppsResult.status === "fulfilled" ? installedAppsResult.value : [];
-    const networkViews = viewsResult.status === "fulfilled" ? viewsResult.value : [];
-    const staticApps = [...getInternalToolApps(networkViews), ...catalogApps];
+    const staticApps = [...getInternalToolApps(), ...catalogApps];
     const overlayApps = getAvailableOverlayApps().filter(
       (app) => !staticApps.some((candidate) => candidate.name === app.name)
     ).filter(
@@ -68089,11 +67743,9 @@ Assistant:`;
   // packages/ui/src/components/chat/widgets/agent-provisioning.tsx
   var import_react64 = __toESM(require_react(), 1);
   init_home_screen_fixture_api_stub();
-  init_events3();
 
   // packages/ui/src/hooks/useCloudHandoffPhase.ts
   var import_react63 = __toESM(require_react(), 1);
-  init_events3();
   var SUCCESS_LINGER_MS = 4e3;
   function useCloudHandoffPhase() {
     const [detail, setDetail] = (0, import_react63.useState)(null);
@@ -68216,11 +67868,2324 @@ Assistant:`;
     Component: AgentProvisioningWidget
   };
 
-  // packages/ui/src/components/chat/widgets/automations.tsx
+  // packages/ui/src/components/chat/widgets/browser-status.tsx
+  var import_react65 = __toESM(require_react(), 1);
+  init_home_screen_fixture_api_stub();
+  var import_jsx_runtime45 = __toESM(require_jsx_runtime(), 1);
+  var POLL_INTERVAL_MS = 4e3;
+  var MAX_TAB_ROWS = 8;
+  function tabLabel(tab) {
+    const title = tab.title?.trim();
+    if (title) return title;
+    const url2 = tab.url?.trim();
+    if (!url2) return "New tab";
+    try {
+      return new URL(url2).hostname.replace(/^www\./, "") || url2;
+    } catch {
+      return url2;
+    }
+  }
+  function tabStatus(tab) {
+    if (tab.visible) {
+      return {
+        label: "Active",
+        dotClass: "bg-accent",
+        textClass: "text-txt"
+      };
+    }
+    return {
+      label: "Background",
+      dotClass: "bg-muted/50",
+      textClass: "text-muted"
+    };
+  }
+  function BrowserStatusSidebarWidget(_props) {
+    const setTab = useAppSelector((s) => s.setTab);
+    const [snapshot2, setSnapshot] = (0, import_react65.useState)(
+      null
+    );
+    const authenticated = useIsAuthenticated();
+    const poll = (0, import_react65.useCallback)(async () => {
+      if (!authenticated) return;
+      try {
+        const next = await client.getBrowserWorkspace();
+        setSnapshot(next);
+      } catch {
+      }
+    }, [authenticated]);
+    (0, import_react65.useEffect)(() => {
+      void poll();
+    }, [poll]);
+    useIntervalWhenDocumentVisible(() => void poll(), POLL_INTERVAL_MS);
+    const tabs = snapshot2?.tabs ?? [];
+    if (tabs.length === 0) {
+      return null;
+    }
+    const rows = tabs.slice(0, MAX_TAB_ROWS);
+    function handleTabClick(tab) {
+      void (async () => {
+        try {
+          await client.showBrowserWorkspaceTab?.(tab.id);
+        } catch {
+        }
+      })();
+      setTab("browser");
+    }
+    return /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
+      WidgetSection,
+      {
+        title: "Browser",
+        icon: /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(Globe, { className: "h-3.5 w-3.5" }),
+        testId: "chat-widget-browser-status",
+        onTitleClick: () => setTab("browser"),
+        children: /* @__PURE__ */ (0, import_jsx_runtime45.jsx)("div", { className: "flex flex-col gap-0.5 pt-0.5", children: rows.map((tab) => {
+          const label = tabLabel(tab);
+          const status = tabStatus(tab);
+          return /* @__PURE__ */ (0, import_jsx_runtime45.jsxs)(
+            Button,
+            {
+              onClick: () => handleTabClick(tab),
+              title: tab.url ?? label,
+              "data-testid": `chat-widget-browser-tab-${tab.id}`,
+              variant: "ghost",
+              className: "flex h-auto w-full items-center justify-start gap-2 whitespace-normal rounded-sm px-0.5 py-0.5 text-left font-normal transition-colors hover:bg-bg-hover/40",
+              children: [
+                /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
+                  "span",
+                  {
+                    className: `h-1.5 w-1.5 shrink-0 rounded-full ${status.dotClass}`,
+                    "aria-hidden": true
+                  }
+                ),
+                /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
+                  "span",
+                  {
+                    className: `min-w-0 flex-1 truncate text-3xs ${status.textClass}`,
+                    children: label
+                  }
+                ),
+                /* @__PURE__ */ (0, import_jsx_runtime45.jsx)("span", { className: "shrink-0 text-3xs uppercase tracking-wider text-muted/70", children: status.label })
+              ]
+            },
+            tab.id
+          );
+        }) })
+      }
+    );
+  }
+
+  // packages/ui/src/components/chat/widgets/browser-status.helpers.ts
+  var BROWSER_STATUS_WIDGET = {
+    id: "browser.status",
+    pluginId: "browser-workspace",
+    order: 75,
+    defaultEnabled: true,
+    Component: BrowserStatusSidebarWidget
+  };
+
+  // packages/ui/src/components/chat/widgets/calendar-upcoming.tsx
   var import_react66 = __toESM(require_react(), 1);
+  init_home_screen_fixture_api_stub();
+  var import_jsx_runtime46 = __toESM(require_jsx_runtime(), 1);
+  var CALENDAR_WIDGET_KEY = "calendar/calendar.upcoming";
+  var GOOGLE_PROVIDER = "google";
+  var DEFAULT_SPAN2 = "col-span-4 row-span-1";
+  var PROBE_TIMEOUT_MS = 6e3;
+  var FEED_TIMEOUT_MS = 8e3;
+  var CALENDAR_REFRESH_INTERVAL_MS = 6e4;
+  var URGENT_WINDOW_MS = 2 * 60 * 6e4;
+  var LOOKAHEAD_MS = 14 * 24 * 60 * 6e4;
+  function isCalendarFeedEvent(value) {
+    if (typeof value !== "object" || value === null) return false;
+    const event = value;
+    return typeof event.id === "string" && typeof event.title === "string" && typeof event.startAt === "string" && typeof event.endAt === "string" && typeof event.isAllDay === "boolean" && typeof event.location === "string";
+  }
+  function parseCalendarFeed(value) {
+    if (typeof value !== "object" || value === null) return [];
+    const events = value.events;
+    if (!Array.isArray(events)) return [];
+    return events.filter(isCalendarFeedEvent);
+  }
+  function upcomingEvents(events, now2) {
+    return events.filter((event) => {
+      const startMs = Date.parse(event.startAt);
+      return Number.isFinite(startMs) && startMs >= now2;
+    }).sort((a, b) => a.startAt.localeCompare(b.startAt));
+  }
+  function relativeTime2(startAt, now2) {
+    const deltaMs = Date.parse(startAt) - now2;
+    if (!Number.isFinite(deltaMs)) return "";
+    const minutes = Math.round(deltaMs / 6e4);
+    if (minutes <= 0) return "now";
+    if (minutes < 60) return `in ${minutes}m`;
+    const hours = Math.round(minutes / 60);
+    if (hours < 24) return `in ${hours}h`;
+    const days = Math.round(hours / 24);
+    if (days === 1) return "tomorrow";
+    return `in ${days}d`;
+  }
+  function eventsEqual(a, b) {
+    if (a.length !== b.length) return false;
+    return a.every((event, i) => {
+      const other = b[i];
+      return event.id === other.id && event.title === other.title && event.startAt === other.startAt && event.isAllDay === other.isAllDay;
+    });
+  }
+  function CalendarUpcomingWidget({
+    slot,
+    spanClassName = DEFAULT_SPAN2
+  }) {
+    const [events, setEvents] = (0, import_react66.useState)([]);
+    const [feedLoaded, setFeedLoaded] = (0, import_react66.useState)(false);
+    const [connection, setConnection] = (0, import_react66.useState)("unknown");
+    const nav = useWidgetNavigation();
+    const authenticated = useIsAuthenticated();
+    const probeConnection = (0, import_react66.useCallback)(async () => {
+      if (!supportsFullAppShellRoutes(client.getBaseUrl())) {
+        setConnection("unsupported");
+        setFeedLoaded(true);
+        setEvents([]);
+        return false;
+      }
+      if (!authenticated) return false;
+      try {
+        const res = await withTimeout(
+          client.listConnectorAccounts(GOOGLE_PROVIDER),
+          PROBE_TIMEOUT_MS
+        );
+        const linked = res.accounts.some(
+          (account) => account.status === "connected"
+        );
+        setConnection(linked ? "connected" : "disconnected");
+        return linked;
+      } catch {
+        setConnection("disconnected");
+        return false;
+      }
+    }, [authenticated]);
+    const loadEvents = (0, import_react66.useCallback)(async () => {
+      const now3 = /* @__PURE__ */ new Date();
+      const timeMin = now3.toISOString();
+      const timeMax = new Date(now3.getTime() + LOOKAHEAD_MS).toISOString();
+      const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      const params2 = new URLSearchParams({
+        side: "owner",
+        timeMin,
+        timeMax,
+        timeZone
+      });
+      try {
+        const res = await withTimeout(
+          fetch(
+            `${client.getBaseUrl()}/api/lifeops/calendar/feed?${params2.toString()}`
+          ),
+          FEED_TIMEOUT_MS
+        );
+        if (!res.ok) return;
+        const json3 = await res.json();
+        const next2 = parseCalendarFeed(json3);
+        setEvents((prev) => eventsEqual(prev, next2) ? prev : next2);
+      } catch {
+      } finally {
+        setFeedLoaded(true);
+      }
+    }, []);
+    (0, import_react66.useEffect)(() => {
+      let cancelled = false;
+      void (async () => {
+        const linked = await probeConnection();
+        if (cancelled || !linked) return;
+        await loadEvents();
+      })();
+      return () => {
+        cancelled = true;
+      };
+    }, [probeConnection, loadEvents]);
+    useIntervalWhenDocumentVisible(() => {
+      if (authenticated && connection === "connected") void loadEvents();
+    }, CALENDAR_REFRESH_INTERVAL_MS);
+    const now2 = useNow(CALENDAR_REFRESH_INTERVAL_MS);
+    const visible = (0, import_react66.useMemo)(() => upcomingEvents(events, now2), [events, now2]);
+    const onHome = slot === "home";
+    const next = visible[0];
+    const urgent = next != null && !next.isAllDay && Number.isFinite(Date.parse(next.startAt)) && Date.parse(next.startAt) - now2 >= 0 && Date.parse(next.startAt) - now2 <= URGENT_WINDOW_MS;
+    usePublishHomeAttention(
+      CALENDAR_WIDGET_KEY,
+      onHome && urgent ? HOME_SIGNAL_WEIGHTS.reminder : null
+    );
+    if (connection !== "connected" || now2 === 0 || !feedLoaded || next == null) {
+      return null;
+    }
+    const title = next.title.trim().length > 0 ? next.title : "(untitled)";
+    const when = next.isAllDay ? "all day" : relativeTime2(next.startAt, now2);
+    const more = visible.length - 1;
+    return /* @__PURE__ */ (0, import_jsx_runtime46.jsx)("div", { className: spanClassName, children: /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(
+      HomeWidgetCard,
+      {
+        icon: /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(CalendarClock, {}),
+        label: "Next",
+        value: title,
+        meta: when,
+        badge: more > 0 ? `+${more}` : void 0,
+        tone: urgent ? "warn" : "default",
+        testId: "chat-widget-calendar-upcoming",
+        ariaLabel: `Next event: ${title} ${when}${more > 0 ? ` (+${more} more upcoming)` : ""}. Open Calendar.`,
+        onActivate: () => nav.openView("/calendar", "calendar")
+      }
+    ) });
+  }
+  var CALENDAR_HOME_WIDGET = {
+    pluginId: "calendar",
+    id: "calendar.upcoming",
+    order: 110,
+    size: "4x1",
+    signalKinds: ["reminder"],
+    Component: CalendarUpcomingWidget
+  };
+
+  // packages/ui/src/components/chat/widgets/finances-alerts.tsx
+  var import_react67 = __toESM(require_react(), 1);
+  init_home_screen_fixture_api_stub();
+  var import_jsx_runtime47 = __toESM(require_jsx_runtime(), 1);
+  var FINANCES_WIDGET_KEY = "finances/finances.alerts";
+  var FINANCES_REFRESH_INTERVAL_MS = 3e4;
+  var WEEK_MS = 7 * 24 * 60 * 60 * 1e3;
+  var USD = "USD";
+  function isRecord2(value) {
+    return typeof value === "object" && value !== null;
+  }
+  function usdToMinor(amountUsd) {
+    return Math.round(amountUsd * 100);
+  }
+  function parseNetBalanceMinor(dashboard) {
+    if (!isRecord2(dashboard)) return 0;
+    const spending = dashboard.spending;
+    if (!isRecord2(spending) || typeof spending.netUsd !== "number") return 0;
+    return usdToMinor(spending.netUsd);
+  }
+  function parseHasSource(sources) {
+    if (!isRecord2(sources) || !Array.isArray(sources.sources)) return false;
+    return sources.sources.some(
+      (source) => isRecord2(source) && typeof source.status === "string" && source.status !== "disconnected"
+    );
+  }
+  function parseBills(recurring) {
+    if (!isRecord2(recurring) || !Array.isArray(recurring.charges)) return [];
+    const bills = [];
+    for (const charge of recurring.charges) {
+      if (!isRecord2(charge)) continue;
+      if (typeof charge.averageAmountUsd !== "number") continue;
+      const merchantNormalized = typeof charge.merchantNormalized === "string" ? charge.merchantNormalized : "";
+      const merchantDisplay = typeof charge.merchantDisplay === "string" ? charge.merchantDisplay : "";
+      const label = merchantDisplay || merchantNormalized;
+      if (!label) continue;
+      bills.push({
+        id: merchantNormalized || label,
+        label,
+        amountMinor: usdToMinor(charge.averageAmountUsd),
+        currency: USD,
+        nextChargeAt: typeof charge.nextExpectedAt === "string" ? charge.nextExpectedAt : null,
+        active: true
+      });
+    }
+    return bills;
+  }
+  function formatMinor(amountMinor, currency) {
+    const value = amountMinor / 100;
+    try {
+      return new Intl.NumberFormat(void 0, {
+        style: "currency",
+        currency
+      }).format(value);
+    } catch {
+      return `${value.toFixed(2)} ${currency}`;
+    }
+  }
+  function dueInLabel(nextChargeAt, now2) {
+    const due = new Date(nextChargeAt).getTime();
+    const days = Math.round((due - now2) / (24 * 60 * 60 * 1e3));
+    if (days <= 0) return "due today";
+    if (days === 1) return "due tomorrow";
+    return `due in ${days} days`;
+  }
+  async function getJson(path) {
+    const response = await fetch(`${client.getBaseUrl()}${path}`);
+    if (!response.ok) {
+      throw new Error(`Money request failed (${response.status}): ${path}`);
+    }
+    return response.json();
+  }
+  function billsDueWithin7Days(bills, now2) {
+    const weekFromNow = now2 + WEEK_MS;
+    return bills.filter((bill) => {
+      if (!bill.active || !bill.nextChargeAt) return false;
+      const due = new Date(bill.nextChargeAt).getTime();
+      return !Number.isNaN(due) && due >= now2 && due <= weekFromNow;
+    }).sort((left, right) => {
+      const leftDue = new Date(left.nextChargeAt).getTime();
+      const rightDue = new Date(right.nextChargeAt).getTime();
+      return leftDue - rightDue;
+    });
+  }
+  function financesEqual(a, b) {
+    if (!a) return false;
+    if (a.hasSource !== b.hasSource || a.netBalanceMinor !== b.netBalanceMinor || a.bills.length !== b.bills.length) {
+      return false;
+    }
+    return a.bills.every((bill, i) => {
+      const other = b.bills[i];
+      return bill.id === other.id && bill.amountMinor === other.amountMinor && bill.nextChargeAt === other.nextChargeAt;
+    });
+  }
+  function FinancesAlertsWidget({
+    spanClassName = "col-span-2 row-span-1"
+  }) {
+    const [data, setData] = (0, import_react67.useState)(null);
+    const nav = useWidgetNavigation();
+    const authenticated = useIsAuthenticated();
+    const load = (0, import_react67.useCallback)(async () => {
+      if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
+        setData(null);
+        return;
+      }
+      try {
+        const [dashboard, recurring, sources] = await Promise.all([
+          getJson("/api/lifeops/money/dashboard"),
+          getJson("/api/lifeops/money/recurring"),
+          getJson("/api/lifeops/money/sources")
+        ]);
+        const next = {
+          hasSource: parseHasSource(sources),
+          netBalanceMinor: parseNetBalanceMinor(dashboard),
+          currency: USD,
+          bills: parseBills(recurring)
+        };
+        setData((prev) => financesEqual(prev, next) ? prev : next);
+      } catch {
+      }
+    }, [authenticated]);
+    (0, import_react67.useEffect)(() => {
+      void load();
+    }, [load]);
+    useIntervalWhenDocumentVisible(
+      () => void load(),
+      FINANCES_REFRESH_INTERVAL_MS
+    );
+    const now2 = useNow(FINANCES_REFRESH_INTERVAL_MS);
+    const overdrawn = data != null && data.netBalanceMinor < 0;
+    const dueSoon = (0, import_react67.useMemo)(
+      () => data && now2 > 0 ? billsDueWithin7Days(data.bills, now2) : [],
+      [data, now2]
+    );
+    const hasBillsDue = dueSoon.length > 0;
+    const weight = overdrawn ? HOME_SIGNAL_WEIGHTS.escalation : hasBillsDue ? HOME_SIGNAL_WEIGHTS.reminder : null;
+    usePublishHomeAttention(FINANCES_WIDGET_KEY, weight);
+    if (data == null) return null;
+    if (!data.hasSource) return null;
+    if (!overdrawn && !hasBillsDue) return null;
+    if (overdrawn) {
+      const amount = formatMinor(data.netBalanceMinor, data.currency);
+      return /* @__PURE__ */ (0, import_jsx_runtime47.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: /* @__PURE__ */ (0, import_jsx_runtime47.jsx)(
+        HomeWidgetCard,
+        {
+          icon: /* @__PURE__ */ (0, import_jsx_runtime47.jsx)(Wallet, {}),
+          label: "Bills",
+          value: amount,
+          badge: "Overdrawn",
+          tone: "danger",
+          testId: "chat-widget-finances-alerts",
+          ariaLabel: `Bills: account overdrawn ${amount}. Open Finances.`,
+          onActivate: () => nav.openView("/finances", "finances")
+        }
+      ) });
+    }
+    const soonest = dueSoon[0];
+    return /* @__PURE__ */ (0, import_jsx_runtime47.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: /* @__PURE__ */ (0, import_jsx_runtime47.jsx)(
+      HomeWidgetCard,
+      {
+        icon: /* @__PURE__ */ (0, import_jsx_runtime47.jsx)(Wallet, {}),
+        label: "Bills",
+        value: soonest.label,
+        meta: dueInLabel(soonest.nextChargeAt, now2),
+        badge: dueSoon.length > 1 ? `${dueSoon.length} due` : void 0,
+        tone: "warn",
+        testId: "chat-widget-finances-alerts",
+        ariaLabel: `Bills: ${dueSoon.length} due this week, next ${soonest.label} ${dueInLabel(soonest.nextChargeAt, now2)}. Open Finances.`,
+        onActivate: () => nav.openView("/finances", "finances")
+      }
+    ) });
+  }
+  var FINANCES_HOME_WIDGET = {
+    pluginId: "finances",
+    id: "finances.alerts",
+    order: 130,
+    signalKinds: ["escalation", "reminder"],
+    Component: FinancesAlertsWidget
+  };
+
+  // packages/ui/src/components/chat/widgets/ftu-welcome.tsx
+  var import_react68 = __toESM(require_react(), 1);
+
+  // packages/ui/src/components/shell/usePromptSuggestions.ts
+  var React54 = __toESM(require_react(), 1);
+  init_home_screen_fixture_api_stub();
+
+  // packages/ui/src/components/pages/page-scoped-conversations.ts
+  init_home_screen_fixture_api_stub();
+
+  // packages/ui/src/components/shell/usePromptSuggestions.ts
+  var SUGGESTION_COUNT = 3;
+  var MAX_CONTEXT_MESSAGES = 6;
+  var MAX_CONTEXT_CHARS = 240;
+  var FETCH_TIMEOUT_MS = 6e3;
+  var MODEL_SET_CACHE_MAX = 32;
+  var MODEL_SET_STORAGE_KEY = "eliza:chat-suggestions:model-sets:v1";
+  function readPersistedModelSets() {
+    if (typeof window === "undefined") return [];
+    try {
+      const raw2 = window.sessionStorage.getItem(MODEL_SET_STORAGE_KEY);
+      const parsed = raw2 ? JSON.parse(raw2) : null;
+      if (!Array.isArray(parsed)) return [];
+      return parsed.filter(
+        (entry) => Array.isArray(entry) && typeof entry[0] === "string" && Array.isArray(entry[1]) && entry[1].every((item) => typeof item === "string")
+      );
+    } catch {
+      return [];
+    }
+  }
+  function persistModelSets() {
+    if (typeof window === "undefined") return;
+    try {
+      window.sessionStorage.setItem(
+        MODEL_SET_STORAGE_KEY,
+        JSON.stringify([...modelSetCache])
+      );
+    } catch {
+    }
+  }
+  var modelSetCache = new Map(readPersistedModelSets());
+  var inFlightModelSets = /* @__PURE__ */ new Map();
+  function rememberModelSet(key, value) {
+    modelSetCache.delete(key);
+    modelSetCache.set(key, value);
+    if (modelSetCache.size > MODEL_SET_CACHE_MAX) {
+      const oldest = modelSetCache.keys().next().value;
+      if (oldest !== void 0) modelSetCache.delete(oldest);
+    }
+    persistModelSets();
+  }
+  var STARTERS = [
+    "What can you do?",
+    "Summarize my day",
+    "Draft a reply",
+    "What's on my plate?",
+    "Explain this for me"
+  ];
+  var THREAD_FOLLOW_UP = "Continue where we left off";
+  function timeOfDayLead(hour) {
+    if (hour === void 0) return STARTERS[0];
+    if (hour >= 5 && hour < 12) return "Plan my day";
+    if (hour >= 12 && hour < 18) return "What's left today?";
+    return "Recap my day";
+  }
+  function daypartForHour(hour) {
+    if (hour >= 5 && hour < 12) return "morning";
+    if (hour >= 12 && hour < 18) return "afternoon";
+    return "evening";
+  }
+  function computePromptSuggestions(messages, hour) {
+    const hasThread = messages.some((m) => m.content.trim().length > 0);
+    const lead = hasThread ? THREAD_FOLLOW_UP : timeOfDayLead(hour);
+    return Array.from(/* @__PURE__ */ new Set([lead, ...STARTERS])).slice(0, SUGGESTION_COUNT);
+  }
+  function pageScopeFromLocation(pathname, hash2) {
+    const fromHash = hash2.replace(/^#\/?/, "").split(/[/?#]/)[0] ?? "";
+    const fromPath = pathname.replace(/^\//, "").split(/[/?#]/)[0] ?? "";
+    const segment = (fromHash || fromPath).trim().toLowerCase();
+    if (!segment) return void 0;
+    const candidate = `page-${segment}`;
+    return PAGE_SCOPES.includes(candidate) ? candidate : void 0;
+  }
+  function currentPageScope() {
+    if (typeof window === "undefined") return void 0;
+    return pageScopeFromLocation(
+      window.location.pathname ?? "",
+      window.location.hash ?? ""
+    );
+  }
+  function normalizeModelSuggestions(value) {
+    if (!Array.isArray(value)) return [];
+    const seen = /* @__PURE__ */ new Set();
+    const out = [];
+    for (const raw2 of value) {
+      if (typeof raw2 !== "string") continue;
+      const cleaned = raw2.replace(/\s+/g, " ").trim();
+      if (!cleaned) continue;
+      const key = cleaned.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(cleaned);
+      if (out.length >= SUGGESTION_COUNT) break;
+    }
+    return out;
+  }
+  async function fetchModelSuggestions(messages, hour, scope) {
+    const recent = messages.filter((m) => m.content.trim().length > 0).slice(-MAX_CONTEXT_MESSAGES).map((m) => ({
+      role: m.role === "assistant" ? "assistant" : "user",
+      content: m.content.slice(0, MAX_CONTEXT_CHARS)
+    }));
+    const data = await client.fetch(
+      "/api/suggestions",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          messages: recent,
+          hour,
+          ...scope ? { scope } : {}
+        })
+      },
+      { allowNonOk: true, timeoutMs: FETCH_TIMEOUT_MS }
+    );
+    return {
+      set: normalizeModelSuggestions(data?.suggestions),
+      tier: typeof data?.tier === "string" ? data.tier : void 0
+    };
+  }
+  function requestModelSet(messages, hour, scope, key) {
+    const cached3 = modelSetCache.get(key);
+    if (cached3) return Promise.resolve(cached3);
+    const pending = inFlightModelSets.get(key);
+    if (pending) return pending;
+    const request = fetchModelSuggestions(messages, hour, scope).then(({ set: set3, tier }) => {
+      if (tier === "heuristic" || set3.length < SUGGESTION_COUNT) return null;
+      rememberModelSet(key, set3);
+      return set3;
+    }).catch(() => null).finally(() => {
+      inFlightModelSets.delete(key);
+    });
+    inFlightModelSets.set(key, request);
+    return request;
+  }
+  function usePromptSuggestions(messages, options2) {
+    const enabled = options2?.enabled ?? false;
+    const hasThread = messages.some((m) => m.content.trim().length > 0);
+    const hour = (/* @__PURE__ */ new Date()).getHours();
+    const lastId = messages.filter((m) => m.content.trim().length > 0).at(-1)?.id ?? null;
+    const scope = options2?.scope ?? currentPageScope();
+    const fallback = React54.useMemo(
+      () => computePromptSuggestions(messages, hour),
+      [hasThread, hour]
+    );
+    const contextKey = `${scope ?? ""}|${lastId ?? ""}|${daypartForHour(hour)}|${hasThread ? 1 : 0}`;
+    const remembered = modelSetCache.get(contextKey);
+    const [model, setModel] = React54.useState(null);
+    React54.useEffect(() => {
+      if (!enabled || modelSetCache.has(contextKey)) return;
+      let disposed = false;
+      void requestModelSet(messages, hour, scope, contextKey).then((set3) => {
+        if (!disposed && set3) setModel({ key: contextKey, set: set3 });
+      });
+      return () => {
+        disposed = true;
+      };
+    }, [enabled, contextKey]);
+    const modelSet = model && model.key === contextKey ? model.set : null;
+    const source = remembered ?? modelSet ?? fallback;
+    return source.slice(0, SUGGESTION_COUNT);
+  }
+
+  // packages/ui/src/components/chat/widgets/ftu-welcome.tsx
+  var import_jsx_runtime48 = __toESM(require_jsx_runtime(), 1);
+  var PLUGIN_ID = "welcome";
+  var WIDGET_ID = "welcome.ftu";
+  var WIDGET_KEY = `${PLUGIN_ID}/${WIDGET_ID}`;
+  var DEFAULT_SPAN3 = "col-span-4 row-span-1";
+  var FIRST_USER_CHAT_EVENT_TYPES = /* @__PURE__ */ new Set([
+    "message_received",
+    "message_sent"
+  ]);
+  function FtuWelcomeWidget({
+    slot,
+    events,
+    spanClassName = DEFAULT_SPAN3
+  }) {
+    const onHome = slot === "home";
+    usePublishHomeAttention(
+      WIDGET_KEY,
+      onHome ? HOME_SIGNAL_WEIGHTS.welcome : null
+    );
+    useRecordHomeWidgetSeen(WIDGET_KEY, onHome);
+    const suggestions = usePromptSuggestions([], { enabled: onHome });
+    const sentAMessage = (events ?? []).some(
+      (event) => FIRST_USER_CHAT_EVENT_TYPES.has(event.eventType)
+    );
+    (0, import_react68.useEffect)(() => {
+      if (onHome && sentAMessage) markHomeWidgetActed(WIDGET_KEY);
+    }, [onHome, sentAMessage]);
+    if (!onHome) return null;
+    const onChip = (text) => {
+      dispatchChatPrefill({ text, select: true });
+      markHomeWidgetActed(WIDGET_KEY);
+    };
+    return /* @__PURE__ */ (0, import_jsx_runtime48.jsxs)(
+      "section",
+      {
+        className: spanClassName,
+        "data-testid": "chat-widget-ftu-welcome",
+        "aria-label": "Welcome \u2014 getting started",
+        children: [
+          /* @__PURE__ */ (0, import_jsx_runtime48.jsx)("p", { className: "text-sm font-medium text-white", children: "Welcome \u2014 ask me anything to get started." }),
+          /* @__PURE__ */ (0, import_jsx_runtime48.jsxs)("div", { className: "mt-2 flex flex-wrap items-center gap-x-5 gap-y-1.5", children: [
+            suggestions.map((text) => /* @__PURE__ */ (0, import_jsx_runtime48.jsx)(
+              Button,
+              {
+                "data-testid": "ftu-welcome-chip",
+                onClick: () => onChip(text),
+                variant: "ghost",
+                size: "sm",
+                className: "h-auto px-0 py-0 text-sm font-normal text-white/75 underline-offset-4 transition-colors hover:bg-transparent hover:text-white hover:underline",
+                children: text
+              },
+              text
+            )),
+            /* @__PURE__ */ (0, import_jsx_runtime48.jsx)(
+              Button,
+              {
+                "data-testid": "ftu-welcome-dismiss",
+                "aria-label": "Dismiss welcome",
+                onClick: () => dismissHomeWidget(WIDGET_KEY),
+                variant: "ghost",
+                size: "sm",
+                className: "h-auto px-0 py-0 text-sm font-normal text-white/60 transition-colors hover:bg-transparent hover:text-white/80",
+                children: "Dismiss"
+              }
+            )
+          ] })
+        ]
+      }
+    );
+  }
+  var FTU_WELCOME_HOME_WIDGET = {
+    pluginId: PLUGIN_ID,
+    id: WIDGET_ID,
+    // Low order = high base score, so on a cold home (no signals) the welcome card
+    // ranks at the very top; real activity signals on other widgets outrank it.
+    order: 20,
+    signalKinds: ["welcome"],
+    size: { cols: 4, rows: 1 },
+    // The defining lifecycle: gone the moment the user engages or dismisses.
+    sunset: { afterAction: true, dismissible: true },
+    Component: FtuWelcomeWidget
+  };
+
+  // packages/ui/src/components/chat/widgets/goals-attention.tsx
+  var import_react69 = __toESM(require_react(), 1);
+  init_home_screen_fixture_api_stub();
+  var import_jsx_runtime49 = __toESM(require_jsx_runtime(), 1);
+  var GOALS_WIDGET_KEY = "goals/goals.attention";
+  var GOALS_REFRESH_INTERVAL_MS = 2e4;
+  var KNOWN_STATUSES = /* @__PURE__ */ new Set([
+    "active",
+    "paused",
+    "archived",
+    "satisfied"
+  ]);
+  var KNOWN_REVIEW_STATES = /* @__PURE__ */ new Set([
+    "idle",
+    "needs_attention",
+    "on_track",
+    "at_risk"
+  ]);
+  function toStatus(value) {
+    return typeof value === "string" && KNOWN_STATUSES.has(value) ? value : "active";
+  }
+  function toReviewState(value) {
+    return typeof value === "string" && KNOWN_REVIEW_STATES.has(value) ? value : "idle";
+  }
+  function parseGoals(payload) {
+    if (typeof payload !== "object" || payload === null) return [];
+    const records = payload.goals;
+    if (!Array.isArray(records)) return [];
+    const goals = [];
+    for (const record2 of records) {
+      if (typeof record2 !== "object" || record2 === null) continue;
+      const goal = record2.goal;
+      if (typeof goal !== "object" || goal === null) continue;
+      const { id, title, status, reviewState } = goal;
+      if (typeof id !== "string" || typeof title !== "string") continue;
+      goals.push({
+        id,
+        title,
+        status: toStatus(status),
+        reviewState: toReviewState(reviewState)
+      });
+    }
+    return goals;
+  }
+  async function fetchGoals() {
+    const response = await fetch(`${client.getBaseUrl()}/api/lifeops/goals`);
+    if (!response.ok) {
+      throw new Error(`Goals request failed (${response.status})`);
+    }
+    return parseGoals(await response.json());
+  }
+  function liveGoals(goals) {
+    return goals.filter(
+      (goal) => goal.status !== "archived" && goal.status !== "satisfied"
+    );
+  }
+  function mostUrgentGoal(goals) {
+    const live = liveGoals(goals);
+    const byTitle = (left, right) => left.title.localeCompare(right.title);
+    const atRisk = live.filter((goal) => goal.reviewState === "at_risk").sort(byTitle);
+    if (atRisk.length > 0) return atRisk[0];
+    const needsAttention = live.filter((goal) => goal.reviewState === "needs_attention").sort(byTitle);
+    if (needsAttention.length > 0) return needsAttention[0];
+    return null;
+  }
+  function attentionCount(goals) {
+    return liveGoals(goals).filter(
+      (goal) => goal.reviewState === "at_risk" || goal.reviewState === "needs_attention"
+    ).length;
+  }
+  function goalsEqual(a, b) {
+    if (!a || a.length !== b.length) return false;
+    return a.every((goal, i) => {
+      const other = b[i];
+      return goal.id === other.id && goal.title === other.title && goal.status === other.status && goal.reviewState === other.reviewState;
+    });
+  }
+  function GoalsAttentionWidget({
+    spanClassName = "col-span-2 row-span-1"
+  }) {
+    const [goals, setGoals] = (0, import_react69.useState)(null);
+    const nav = useWidgetNavigation();
+    const authenticated = useIsAuthenticated();
+    const load = (0, import_react69.useCallback)(async () => {
+      if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
+        setGoals([]);
+        return;
+      }
+      try {
+        const next = await fetchGoals();
+        setGoals((prev) => goalsEqual(prev, next) ? prev : next);
+      } catch {
+      }
+    }, [authenticated]);
+    (0, import_react69.useEffect)(() => {
+      void load();
+    }, [load]);
+    useIntervalWhenDocumentVisible(() => void load(), GOALS_REFRESH_INTERVAL_MS);
+    const urgent = (0, import_react69.useMemo)(() => goals ? mostUrgentGoal(goals) : null, [goals]);
+    const count3 = (0, import_react69.useMemo)(() => goals ? attentionCount(goals) : 0, [goals]);
+    usePublishHomeAttention(
+      GOALS_WIDGET_KEY,
+      urgent ? HOME_SIGNAL_WEIGHTS.escalation : null
+    );
+    if (goals == null || urgent == null) return null;
+    const tone = urgent.reviewState === "at_risk" ? "danger" : "warn";
+    const status = urgent.reviewState === "at_risk" ? "at risk" : "needs attention";
+    return /* @__PURE__ */ (0, import_jsx_runtime49.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: /* @__PURE__ */ (0, import_jsx_runtime49.jsx)(
+      HomeWidgetCard,
+      {
+        icon: /* @__PURE__ */ (0, import_jsx_runtime49.jsx)(Target, {}),
+        label: "Goals",
+        value: urgent.title,
+        badge: count3 > 1 ? `${count3}` : void 0,
+        tone,
+        testId: "widget-goals-attention",
+        ariaLabel: `Goals: ${count3} need attention, top "${urgent.title}" ${status}. Open Goals.`,
+        onActivate: () => nav.openView("/goals", "goals")
+      }
+    ) });
+  }
+  var GOALS_HOME_WIDGET = {
+    pluginId: "goals",
+    id: "goals.attention",
+    order: 120,
+    signalKinds: ["escalation", "reminder"],
+    Component: GoalsAttentionWidget
+  };
+
+  // packages/ui/src/components/chat/widgets/health-sleep.tsx
+  var import_react70 = __toESM(require_react(), 1);
+  init_home_screen_fixture_api_stub();
+  var import_jsx_runtime50 = __toESM(require_jsx_runtime(), 1);
+  var HEALTH_SLEEP_WIDGET_KEY = "health/health.sleep";
+  var SLEEP_REFRESH_INTERVAL_MS = 2e4;
+  var WINDOW_DAYS = 14;
+  var REGULARITY_CLASSES = /* @__PURE__ */ new Set([
+    "very_regular",
+    "regular",
+    "irregular",
+    "very_irregular",
+    "insufficient_data"
+  ]);
+  var OFF_RHYTHM_LABELS = {
+    irregular: "Irregular",
+    very_irregular: "Very irregular"
+  };
+  function isOffRhythm(classification) {
+    return classification === "irregular" || classification === "very_irregular";
+  }
+  function isEpisode(value) {
+    if (typeof value !== "object" || value === null) return false;
+    const record2 = value;
+    return typeof record2.startedAt === "string" && (record2.endedAt === null || typeof record2.endedAt === "string") && (record2.durationMin === null || typeof record2.durationMin === "number");
+  }
+  function isHistoryResponse(value) {
+    if (typeof value !== "object" || value === null) return false;
+    const episodes = value.episodes;
+    return Array.isArray(episodes) && episodes.every(isEpisode);
+  }
+  function isRegularityResponse(value) {
+    if (typeof value !== "object" || value === null) return false;
+    const classification = value.classification;
+    return typeof classification === "string" && REGULARITY_CLASSES.has(classification);
+  }
+  function parseHistory(value) {
+    if (!isHistoryResponse(value)) return null;
+    return value.episodes[0] ?? null;
+  }
+  function parseRegularity(value) {
+    return isRegularityResponse(value) ? value.classification : null;
+  }
+  async function getJson2(path) {
+    const response = await fetch(`${client.getBaseUrl()}${path}`);
+    if (!response.ok) {
+      throw new Error(`Sleep request failed (${response.status}): ${path}`);
+    }
+    return await response.json();
+  }
+  async function fetchSleep() {
+    const [historyRaw, regularityRaw] = await Promise.all([
+      getJson2(
+        `/api/lifeops/sleep/history?windowDays=${WINDOW_DAYS}&includeNaps=true`
+      ),
+      getJson2(`/api/lifeops/sleep/regularity?windowDays=${WINDOW_DAYS}`)
+    ]);
+    return {
+      latest: parseHistory(historyRaw),
+      classification: parseRegularity(regularityRaw)
+    };
+  }
+  function formatDuration(minutes) {
+    if (minutes === null) return "\u2014";
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    return hours === 0 ? `${mins}m` : `${hours}h ${mins}m`;
+  }
+  function sleepEqual(a, b) {
+    if (!a) return false;
+    if (a.classification !== b.classification) return false;
+    if (a.latest === b.latest) return true;
+    if (a.latest === null || b.latest === null) return false;
+    return a.latest.startedAt === b.latest.startedAt && a.latest.endedAt === b.latest.endedAt && a.latest.durationMin === b.latest.durationMin;
+  }
+  function HealthSleepWidget({
+    spanClassName = "col-span-2 row-span-1"
+  }) {
+    const [data, setData] = (0, import_react70.useState)(null);
+    const nav = useWidgetNavigation();
+    const authenticated = useIsAuthenticated();
+    const load = (0, import_react70.useCallback)(async () => {
+      if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
+        setData({ latest: null, classification: null });
+        return;
+      }
+      try {
+        const next = await fetchSleep();
+        setData((prev) => sleepEqual(prev, next) ? prev : next);
+      } catch {
+      }
+    }, [authenticated]);
+    (0, import_react70.useEffect)(() => {
+      void load();
+    }, [load]);
+    useIntervalWhenDocumentVisible(() => void load(), SLEEP_REFRESH_INTERVAL_MS);
+    const offRhythm = isOffRhythm(data?.classification ?? null);
+    usePublishHomeAttention(
+      HEALTH_SLEEP_WIDGET_KEY,
+      offRhythm ? HOME_SIGNAL_WEIGHTS["check-in"] : null
+    );
+    if (data == null || !data.latest) return null;
+    const duration3 = formatDuration(data.latest.durationMin);
+    const badge = data.classification && isOffRhythm(data.classification) ? OFF_RHYTHM_LABELS[data.classification] : void 0;
+    const ariaLabel = badge ? `Sleep: last ${duration3}, regularity ${badge.toLowerCase()}. Open Health.` : `Sleep: last ${duration3}. Open Health.`;
+    return /* @__PURE__ */ (0, import_jsx_runtime50.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: /* @__PURE__ */ (0, import_jsx_runtime50.jsx)(
+      HomeWidgetCard,
+      {
+        icon: /* @__PURE__ */ (0, import_jsx_runtime50.jsx)(Moon, {}),
+        label: "Sleep",
+        value: duration3,
+        badge,
+        tone: badge ? "warn" : "default",
+        testId: "widget-health-sleep",
+        ariaLabel,
+        onActivate: () => nav.openView("/health", "health")
+      }
+    ) });
+  }
+  var HEALTH_HOME_WIDGET = {
+    pluginId: "health",
+    id: "health.sleep",
+    order: 140,
+    signalKinds: ["check-in"],
+    Component: HealthSleepWidget
+  };
+
+  // packages/ui/src/components/chat/widgets/inbox-unread.tsx
+  var import_react71 = __toESM(require_react(), 1);
+  init_home_screen_fixture_api_stub();
+  var import_jsx_runtime51 = __toESM(require_jsx_runtime(), 1);
+  var INBOX_WIDGET_KEY = "inbox/inbox.unread";
+  var INBOX_REFRESH_INTERVAL_MS = 2e4;
+  function isRecord3(value) {
+    return typeof value === "object" && value !== null;
+  }
+  function parseUnread(payload) {
+    if (!isRecord3(payload) || !Array.isArray(payload.messages)) return [];
+    const threads = [];
+    for (const message of payload.messages) {
+      if (!isRecord3(message)) continue;
+      if (message.unread !== true) continue;
+      const id = typeof message.id === "string" ? message.id : null;
+      if (!id) continue;
+      const sender = isRecord3(message.sender) && typeof message.sender.displayName === "string" ? message.sender.displayName : "Someone";
+      const subject = typeof message.subject === "string" ? message.subject : "";
+      const priorityScore = typeof message.priorityScore === "number" ? message.priorityScore : 0;
+      const important = message.priorityCategory === "important";
+      threads.push({ id, sender, subject, important, priorityScore });
+    }
+    return threads;
+  }
+  function unreadEqual(a, b) {
+    if (a.length !== b.length) return false;
+    return a.every((thread, i) => {
+      const other = b[i];
+      return thread.id === other.id && thread.sender === other.sender && thread.subject === other.subject && thread.important === other.important && thread.priorityScore === other.priorityScore;
+    });
+  }
+  function InboxUnreadWidget({
+    spanClassName = "col-span-2 row-span-1"
+  }) {
+    const [unread, setUnread] = (0, import_react71.useState)([]);
+    const [loaded, setLoaded] = (0, import_react71.useState)(false);
+    const nav = useWidgetNavigation();
+    const authenticated = useIsAuthenticated();
+    const loadInbox = (0, import_react71.useCallback)(async () => {
+      const baseUrl = client.getBaseUrl();
+      if (!authenticated || !supportsFullAppShellRoutes(baseUrl)) {
+        setLoaded(true);
+        setUnread([]);
+        return;
+      }
+      try {
+        const response = await fetch(`${baseUrl}/api/lifeops/inbox`);
+        if (!response.ok) return;
+        const next = parseUnread(await response.json());
+        setUnread((prev) => unreadEqual(prev, next) ? prev : next);
+      } catch {
+      } finally {
+        setLoaded(true);
+      }
+    }, [authenticated]);
+    (0, import_react71.useEffect)(() => {
+      void loadInbox();
+    }, [loadInbox]);
+    useIntervalWhenDocumentVisible(
+      () => void loadInbox(),
+      INBOX_REFRESH_INTERVAL_MS
+    );
+    usePublishHomeAttention(
+      INBOX_WIDGET_KEY,
+      unread.length > 0 ? HOME_SIGNAL_WEIGHTS.message : null
+    );
+    const top = (0, import_react71.useMemo)(() => {
+      if (unread.length === 0) return null;
+      return unread.reduce(
+        (best, thread) => thread.priorityScore > best.priorityScore ? thread : best
+      );
+    }, [unread]);
+    const hasImportant = (0, import_react71.useMemo)(
+      () => unread.some((thread) => thread.important),
+      [unread]
+    );
+    if (!loaded || top == null) return null;
+    const datum = top.sender !== "Someone" ? top.sender : top.subject || top.sender;
+    const tone = hasImportant ? "warn" : "default";
+    return /* @__PURE__ */ (0, import_jsx_runtime51.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: /* @__PURE__ */ (0, import_jsx_runtime51.jsx)(
+      HomeWidgetCard,
+      {
+        icon: /* @__PURE__ */ (0, import_jsx_runtime51.jsx)(Inbox, {}),
+        label: "Inbox",
+        value: datum,
+        badge: unread.length,
+        tone,
+        testId: "chat-widget-inbox-unread",
+        ariaLabel: `Inbox: ${unread.length} unread thread${unread.length === 1 ? "" : "s"} need a reply, top from ${datum}. Open Inbox.`,
+        onActivate: () => nav.openView("/inbox", "inbox")
+      }
+    ) });
+  }
+  var INBOX_HOME_WIDGET = {
+    pluginId: "inbox",
+    id: "inbox.unread",
+    order: 85,
+    signalKinds: ["message", "approval"],
+    Component: InboxUnreadWidget
+  };
+
+  // packages/ui/src/components/chat/widgets/model-download.tsx
+  var import_react72 = __toESM(require_react(), 1);
+  init_home_screen_fixture_api_stub();
+
+  // packages/ui/src/services/local-inference/home-model-status.ts
+  function maxOrNull(values) {
+    return values.length > 0 ? Math.max(...values) : null;
+  }
+  function firstModelName(slots) {
+    for (const slot of slots) {
+      if (slot.displayName) return slot.displayName;
+    }
+    return null;
+  }
+  function deriveHomeModelStatus(readiness) {
+    const assigned = Object.values(readiness.slots).filter(
+      (slot) => slot.assigned
+    );
+    const modelName = firstModelName(assigned);
+    if (assigned.length === 0) {
+      return {
+        kind: "not-required",
+        blocksSend: false,
+        percent: null,
+        etaMs: null,
+        modelName: null,
+        errors: []
+      };
+    }
+    if (assigned.every((slot) => slot.ready)) {
+      return {
+        kind: "ready",
+        blocksSend: false,
+        percent: null,
+        etaMs: null,
+        modelName,
+        errors: []
+      };
+    }
+    const failed = assigned.filter(
+      (slot) => slot.state === "failed" || slot.state === "cancelled"
+    );
+    if (failed.length > 0) {
+      return {
+        kind: "error",
+        blocksSend: true,
+        percent: null,
+        etaMs: null,
+        modelName,
+        errors: [...new Set(failed.flatMap((slot) => slot.errors))]
+      };
+    }
+    const downloading = assigned.filter((slot) => slot.state === "downloading");
+    if (downloading.length > 0) {
+      const percents = downloading.map((slot) => slot.download.percent).filter((value) => value !== null);
+      const etas = downloading.map((slot) => slot.download.etaMs).filter((value) => value !== null);
+      return {
+        kind: "downloading",
+        blocksSend: true,
+        percent: maxOrNull(percents),
+        etaMs: maxOrNull(etas),
+        modelName,
+        errors: []
+      };
+    }
+    const missing = assigned.some(
+      (slot) => slot.state === "missing" || slot.state === "unassigned"
+    );
+    if (missing) {
+      return {
+        kind: "missing",
+        blocksSend: true,
+        percent: null,
+        etaMs: null,
+        modelName,
+        errors: []
+      };
+    }
+    return {
+      kind: "loading",
+      blocksSend: true,
+      percent: 100,
+      etaMs: null,
+      modelName,
+      errors: []
+    };
+  }
+
+  // packages/ui/src/utils/event-source.ts
+  function openEventSource(url2, init) {
+    if (typeof EventSource === "undefined") return null;
+    const base = typeof window !== "undefined" ? window.location.href : "http://localhost";
+    let parsed;
+    try {
+      parsed = new URL(url2, base);
+    } catch {
+      return null;
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    try {
+      return new EventSource(url2, init);
+    } catch {
+      return null;
+    }
+  }
+
+  // packages/ui/src/components/chat/widgets/model-download.tsx
+  var import_jsx_runtime52 = __toESM(require_jsx_runtime(), 1);
+  var DEFAULT_SPAN4 = "col-span-4 row-span-2";
+  var HUB_TIMEOUT_MS = 6e3;
+  var STREAM_REFETCH_DEBOUNCE_MS = 400;
+  var LOCAL_INFERENCE_VIEW_PATH = "/settings#ai-model";
+  var LOCAL_INFERENCE_VIEW_ID = "settings";
+  var NOT_REQUIRED_STATUS = {
+    kind: "not-required",
+    blocksSend: false,
+    percent: null,
+    etaMs: null,
+    modelName: null,
+    errors: []
+  };
+  var INITIAL = {
+    status: NOT_REQUIRED_STATUS,
+    rows: [],
+    loading: true
+  };
+  function appendTokenParam(url2) {
+    const token = getElizaApiToken()?.trim();
+    if (!token) return url2;
+    return `${url2}${url2.includes("?") ? "&" : "?"}token=${encodeURIComponent(token)}`;
+  }
+  function rowsFromReadiness(slots) {
+    return Object.values(slots).filter((slot) => slot.assigned).map((slot) => ({
+      slot: slot.slot,
+      modelId: slot.assignedModelId,
+      displayName: slot.displayName,
+      state: slot.state
+    }));
+  }
+  function useLocalModelDownloads() {
+    const [state4, setState3] = (0, import_react72.useState)(INITIAL);
+    const refreshTimerRef = (0, import_react72.useRef)(null);
+    const authenticated = useIsAuthenticated();
+    (0, import_react72.useEffect)(() => {
+      if (!authenticated) {
+        setState3(INITIAL);
+        return;
+      }
+      let cancelled = false;
+      const refresh = async () => {
+        try {
+          const hub = await withTimeout(
+            client.getLocalInferenceHub(),
+            HUB_TIMEOUT_MS
+          );
+          if (cancelled) return;
+          setState3({
+            status: deriveHomeModelStatus(hub.textReadiness),
+            rows: rowsFromReadiness(hub.textReadiness.slots),
+            loading: false
+          });
+        } catch {
+          if (cancelled) return;
+          setState3((prev) => prev.loading ? { ...prev, loading: false } : prev);
+        }
+      };
+      void refresh();
+      const url2 = appendTokenParam(
+        resolveApiUrl("/api/local-inference/downloads/stream")
+      );
+      const es = openEventSource(url2, { withCredentials: false });
+      if (es) {
+        es.onmessage = () => {
+          if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+          refreshTimerRef.current = setTimeout(
+            () => void refresh(),
+            STREAM_REFETCH_DEBOUNCE_MS
+          );
+        };
+      }
+      return () => {
+        cancelled = true;
+        if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+        es?.close();
+      };
+    }, [authenticated]);
+    return state4;
+  }
+  function roundedPercent(percent) {
+    if (percent == null || !Number.isFinite(percent)) return null;
+    return Math.max(0, Math.min(100, Math.round(percent)));
+  }
+  function formatEta(etaMs) {
+    if (etaMs == null || !Number.isFinite(etaMs) || etaMs <= 0) return null;
+    const totalSeconds = Math.round(etaMs / 1e3);
+    if (totalSeconds < 60) return `~${totalSeconds}s left`;
+    const minutes = Math.round(totalSeconds / 60);
+    if (minutes < 60) return `~${minutes}m left`;
+    const hours = Math.round(minutes / 60);
+    return `~${hours}h left`;
+  }
+  function ModelDownloadWidget({
+    spanClassName = DEFAULT_SPAN4
+  }) {
+    const { status, rows, loading } = useLocalModelDownloads();
+    const nav = useWidgetNavigation();
+    const [retrying, setRetrying] = (0, import_react72.useState)(false);
+    const failedRow = rows.find(
+      (row) => row.state === "failed" || row.state === "cancelled"
+    );
+    const failedModelId = failedRow?.modelId ?? null;
+    (0, import_react72.useEffect)(() => {
+      if (status.kind !== "error") setRetrying(false);
+    }, [status.kind]);
+    const retry = (0, import_react72.useCallback)(async () => {
+      if (!failedModelId) {
+        nav.openView(LOCAL_INFERENCE_VIEW_PATH, LOCAL_INFERENCE_VIEW_ID);
+        return;
+      }
+      setRetrying(true);
+      try {
+        await client.startLocalInferenceDownload(failedModelId);
+      } catch {
+        setRetrying(false);
+      }
+    }, [failedModelId, nav]);
+    const openSettings = (0, import_react72.useCallback)(() => {
+      nav.openView(LOCAL_INFERENCE_VIEW_PATH, LOCAL_INFERENCE_VIEW_ID);
+    }, [nav]);
+    if (loading) return null;
+    if (status.kind === "not-required" || status.kind === "ready") return null;
+    const modelName = status.modelName ?? "Local model";
+    if (status.kind === "error" && !retrying) {
+      const detail = status.errors.find((message) => message.trim().length > 0);
+      return /* @__PURE__ */ (0, import_jsx_runtime52.jsx)("div", { className: spanClassName, children: /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(
+        ModelProgressCard,
+        {
+          icon: /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(TriangleAlert, {}),
+          value: `${modelName} download failed`,
+          meta: detail ? truncateDetail(detail) : void 0,
+          badge: "Retry",
+          tone: "danger",
+          percent: null,
+          ariaLabel: `${modelName} download failed${detail ? `: ${detail}` : ""}. Tap to retry the download.`,
+          onActivate: () => void retry()
+        }
+      ) });
+    }
+    if (status.kind === "downloading" || retrying) {
+      const percent = roundedPercent(status.percent);
+      const eta = formatEta(status.etaMs);
+      return /* @__PURE__ */ (0, import_jsx_runtime52.jsx)("div", { className: spanClassName, children: /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(
+        ModelProgressCard,
+        {
+          icon: /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(Download, {}),
+          value: `Downloading ${modelName}`,
+          meta: percent != null ? `${percent}%${eta ? ` \xB7 ${eta}` : ""}` : void 0,
+          percent: status.percent,
+          ariaLabel: `Downloading ${modelName}${percent != null ? `, ${percent} percent` : ""}${eta ? `, ${eta}` : ""}. Tap to manage local models.`,
+          onActivate: openSettings
+        }
+      ) });
+    }
+    if (status.kind === "loading") {
+      return /* @__PURE__ */ (0, import_jsx_runtime52.jsx)("div", { className: spanClassName, children: /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(
+        ModelProgressCard,
+        {
+          icon: /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(LoaderCircle, { className: "animate-spin" }),
+          value: `Loading ${modelName}\u2026`,
+          percent: null,
+          indeterminate: true,
+          ariaLabel: `Loading ${modelName} into the local runtime. Tap to manage local models.`,
+          onActivate: openSettings
+        }
+      ) });
+    }
+    return /* @__PURE__ */ (0, import_jsx_runtime52.jsx)("div", { className: spanClassName, children: /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(
+      ModelProgressCard,
+      {
+        icon: /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(Download, {}),
+        value: `Queued ${modelName}`,
+        percent: 0,
+        ariaLabel: `${modelName} is queued for download. Tap to manage local models.`,
+        onActivate: openSettings
+      }
+    ) });
+  }
+  function ModelProgressCard({
+    icon,
+    value,
+    meta: meta3,
+    badge,
+    tone = "default",
+    percent,
+    indeterminate = false,
+    ariaLabel,
+    onActivate
+  }) {
+    const fill = percent == null ? null : Math.max(0, Math.min(100, Math.round(percent)));
+    return /* @__PURE__ */ (0, import_jsx_runtime52.jsxs)(
+      Button,
+      {
+        "data-testid": "chat-widget-model-download",
+        "aria-label": ariaLabel,
+        onClick: onActivate,
+        variant: "ghost",
+        className: "group flex h-full w-full flex-col items-stretch justify-center gap-2.5 whitespace-normal px-3 py-2.5 text-left font-normal transition-opacity hover:opacity-80",
+        children: [
+          /* @__PURE__ */ (0, import_jsx_runtime52.jsxs)("span", { className: "flex w-full items-center gap-3", children: [
+            /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(
+              "span",
+              {
+                className: cn(
+                  "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/10 text-white/85 [&>svg]:h-4 [&>svg]:w-4",
+                  tone === "danger" && "text-danger"
+                ),
+                children: icon
+              }
+            ),
+            /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(
+              "span",
+              {
+                className: cn(
+                  "min-w-0 flex-1 truncate text-sm font-semibold leading-tight",
+                  tone === "danger" ? "text-danger" : "text-white"
+                ),
+                children: value
+              }
+            ),
+            meta3 != null ? /* @__PURE__ */ (0, import_jsx_runtime52.jsx)("span", { className: "shrink-0 text-2xs tabular-nums text-white/60", children: meta3 }) : null,
+            badge != null ? /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(
+              "span",
+              {
+                className: cn(
+                  "shrink-0 rounded-full px-1.5 py-0.5 text-2xs font-semibold",
+                  tone === "danger" ? "bg-danger/15 text-danger" : "bg-accent-subtle text-accent"
+                ),
+                children: badge
+              }
+            ) : null
+          ] }),
+          /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(
+            "span",
+            {
+              "aria-hidden": "true",
+              "data-testid": "chat-widget-model-download-track",
+              className: "h-1.5 w-full overflow-hidden rounded-full bg-white/10",
+              children: indeterminate ? /* @__PURE__ */ (0, import_jsx_runtime52.jsx)("span", { className: "block h-full w-full animate-pulse rounded-full bg-accent/70 motion-reduce:animate-none" }) : fill != null ? /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(
+                "span",
+                {
+                  className: cn(
+                    "block h-full rounded-full transition-[width] duration-500",
+                    tone === "danger" ? "bg-danger/70" : "bg-accent"
+                  ),
+                  style: { width: `${fill}%` }
+                }
+              ) : null
+            }
+          )
+        ]
+      }
+    );
+  }
+  function truncateDetail(detail) {
+    const trimmed = detail.trim();
+    return trimmed.length > 40 ? `${trimmed.slice(0, 39)}\u2026` : trimmed;
+  }
+  var MODEL_DOWNLOAD_HOME_WIDGET = {
+    pluginId: "local-inference",
+    id: "local-inference.model-download",
+    // High order so the tile surfaces near the top of the home grid while a model
+    // is downloading (it self-hides once ready, so it never permanently crowds).
+    order: 55,
+    size: "4x2",
+    signalKinds: ["activity", "notification"],
+    Component: ModelDownloadWidget
+  };
+
+  // packages/ui/src/components/chat/widgets/music-player.tsx
+  var import_react73 = __toESM(require_react(), 1);
+  var import_jsx_runtime53 = __toESM(require_jsx_runtime(), 1);
+  var MEDIA_ERROR_NAMES = {
+    1: "MEDIA_ERR_ABORTED",
+    2: "MEDIA_ERR_NETWORK",
+    3: "MEDIA_ERR_DECODE",
+    4: "MEDIA_ERR_SRC_NOT_SUPPORTED"
+  };
+  function statusLabel2(state4) {
+    if (state4.kind === "playing") return state4.isPaused ? "Paused" : "Live";
+    if (state4.kind === "loading") return "Loading";
+    if (state4.kind === "error") return "Unavailable";
+    return "Idle";
+  }
+  function MusicPlayerSidebarWidget(_props) {
+    const audioRef = (0, import_react73.useRef)(null);
+    const lastAttachedTrack = (0, import_react73.useRef)(null);
+    const [player, setPlayer] = (0, import_react73.useState)({ kind: "idle" });
+    const [audioError, setAudioError] = (0, import_react73.useState)(null);
+    const [audioPaused, setAudioPaused] = (0, import_react73.useState)(true);
+    const isPlaying = player.kind === "playing";
+    const authenticated = useIsAuthenticated();
+    const pollOnce = (0, import_react73.useCallback)(async () => {
+      if (!authenticated) return;
+      setPlayer((prev) => prev.kind === "idle" ? { kind: "loading" } : prev);
+      try {
+        const res = await fetchWithCsrf(resolveApiUrl("/music-player/status"));
+        const data = await res.json();
+        if (!res.ok) {
+          setPlayer({ kind: "error", message: data.error ?? res.statusText });
+          return;
+        }
+        if (data.track?.title && data.guildId && data.streamUrl) {
+          setPlayer({
+            kind: "playing",
+            title: data.track.title,
+            guildId: data.guildId,
+            streamUrl: resolveApiUrl(data.streamUrl),
+            isPaused: data.isPaused === true
+          });
+          return;
+        }
+        setPlayer({ kind: "idle" });
+        setAudioPaused(true);
+      } catch {
+        setPlayer({
+          kind: "error",
+          message: "Could not reach the music player."
+        });
+        setAudioPaused(true);
+      }
+    }, [authenticated]);
+    (0, import_react73.useEffect)(() => {
+      void pollOnce();
+    }, [pollOnce]);
+    useIntervalWhenDocumentVisible(() => void pollOnce(), 5e3);
+    (0, import_react73.useEffect)(() => {
+      const el = audioRef.current;
+      if (!el) return;
+      if (player.kind !== "playing") {
+        el.pause();
+        el.removeAttribute("src");
+        el.load();
+        lastAttachedTrack.current = null;
+        return;
+      }
+      const key = `${player.guildId}::${player.title}`;
+      if (lastAttachedTrack.current !== key) {
+        lastAttachedTrack.current = key;
+        setAudioError(null);
+        setAudioPaused(true);
+        el.src = player.streamUrl;
+        el.load();
+      }
+      if (player.isPaused) {
+        el.pause();
+        setAudioPaused(true);
+        return;
+      }
+      el.play().catch(() => {
+      });
+    }, [player]);
+    (0, import_react73.useEffect)(() => {
+      const el = audioRef.current;
+      if (!el) return;
+      const handlePlay = () => setAudioPaused(false);
+      const handlePause = () => setAudioPaused(true);
+      const handler = () => {
+        const err = el.error;
+        const code = err?.code ?? 0;
+        const name = MEDIA_ERROR_NAMES[code] ?? `UNKNOWN(${code})`;
+        setAudioError(`${name}: ${err?.message || "no details"}`);
+      };
+      el.addEventListener("play", handlePlay);
+      el.addEventListener("pause", handlePause);
+      el.addEventListener("error", handler);
+      return () => {
+        el.removeEventListener("play", handlePlay);
+        el.removeEventListener("pause", handlePause);
+        el.removeEventListener("error", handler);
+      };
+    }, []);
+    function togglePlayback() {
+      const el = audioRef.current;
+      if (!el || player.kind !== "playing" || !player.streamUrl) return;
+      if (el.paused) {
+        void el.play();
+        return;
+      }
+      el.pause();
+    }
+    return /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(
+      WidgetSection,
+      {
+        title: "Music",
+        icon: /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(Music, { className: "h-3.5 w-3.5" }),
+        testId: "chat-widget-music-player",
+        action: /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(
+          Button,
+          {
+            variant: "ghost",
+            size: "icon-sm",
+            onClick: () => void pollOnce(),
+            "aria-label": "Refresh music player",
+            className: "h-5 w-5 rounded-sm bg-transparent p-0 text-muted transition-colors hover:bg-transparent hover:text-txt",
+            children: /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(RefreshCw, { className: "h-3 w-3", "aria-hidden": true })
+          }
+        ),
+        children: /* @__PURE__ */ (0, import_jsx_runtime53.jsxs)("div", { className: "flex flex-col gap-2 pt-0.5", children: [
+          isPlaying ? /* @__PURE__ */ (0, import_jsx_runtime53.jsxs)("div", { className: "flex items-center gap-2", children: [
+            /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(
+              Button,
+              {
+                variant: "ghost",
+                size: "icon-sm",
+                onClick: togglePlayback,
+                "aria-label": audioPaused ? "Play music" : "Pause music",
+                title: audioPaused ? "Play" : "Pause",
+                className: "h-7 w-7 shrink-0 rounded-sm bg-transparent p-0 text-muted transition-colors hover:bg-transparent hover:text-txt",
+                children: audioPaused ? /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(Play, { className: "h-3.5 w-3.5", "aria-hidden": true }) : /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(Pause, { className: "h-3.5 w-3.5", "aria-hidden": true })
+              }
+            ),
+            /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(
+              "span",
+              {
+                className: `h-1.5 w-1.5 shrink-0 rounded-full ${player.isPaused ? "bg-warn" : "bg-ok"}`,
+                "aria-hidden": true
+              }
+            ),
+            /* @__PURE__ */ (0, import_jsx_runtime53.jsx)("span", { className: "min-w-0 flex-1 truncate text-3xs font-semibold text-txt", children: player.title }),
+            /* @__PURE__ */ (0, import_jsx_runtime53.jsx)("span", { className: "shrink-0 text-3xs uppercase tracking-wider text-muted/70", children: statusLabel2(player) })
+          ] }) : /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(
+            EmptyWidgetState,
+            {
+              icon: /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(Music, { className: "h-5 w-5" }),
+              title: player.kind === "error" ? player.message : "No music stream is active.",
+              description: "Ask the agent to play music in chat."
+            }
+          ),
+          /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(
+            "audio",
+            {
+              ref: audioRef,
+              className: "hidden",
+              "aria-label": "Agent music stream"
+            }
+          ),
+          audioError ? /* @__PURE__ */ (0, import_jsx_runtime53.jsx)("p", { className: "break-words font-mono text-3xs text-warn", children: audioError }) : null
+        ] })
+      }
+    );
+  }
+
+  // packages/ui/src/components/chat/widgets/music-player.helpers.ts
+  var MUSIC_PLAYER_WIDGET = {
+    id: "music-player.stream",
+    pluginId: "music-player",
+    order: 125,
+    defaultEnabled: true,
+    Component: MusicPlayerSidebarWidget
+  };
+
+  // packages/ui/src/components/chat/widgets/needs-attention.tsx
+  var import_react74 = __toESM(require_react(), 1);
+  init_home_screen_fixture_api_stub();
+  var import_jsx_runtime54 = __toESM(require_jsx_runtime(), 1);
+  var NEEDS_ATTENTION_WIDGET_KEY = "needs-attention/needs-attention.pending";
+  var REFRESH_INTERVAL_MS = 2e4;
+  var STALE_PENDING_AGE_MS = 30 * 6e4;
+  function pendingEqual(a, b) {
+    if (a.length !== b.length) return false;
+    return a.every((item, i) => {
+      const other = b[i];
+      return item.id === other.id && item.title === other.title && item.createdAt === other.createdAt;
+    });
+  }
+  function useApprovals() {
+    const [pending, setPending] = (0, import_react74.useState)([]);
+    const [loaded, setLoaded] = (0, import_react74.useState)(false);
+    const mountedRef = (0, import_react74.useRef)(true);
+    const authenticated = useIsAuthenticated();
+    const load = (0, import_react74.useCallback)(async () => {
+      if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
+        if (mountedRef.current) {
+          setPending([]);
+          setLoaded(true);
+        }
+        return;
+      }
+      try {
+        const { pending: next } = await client.listPendingActions();
+        if (!mountedRef.current) return;
+        setPending((prev) => pendingEqual(prev, next) ? prev : next);
+      } catch {
+      } finally {
+        if (mountedRef.current) {
+          setLoaded(true);
+        }
+      }
+    }, [authenticated]);
+    (0, import_react74.useEffect)(
+      () => () => {
+        mountedRef.current = false;
+      },
+      []
+    );
+    (0, import_react74.useEffect)(() => {
+      void load();
+    }, [load]);
+    useIntervalWhenDocumentVisible(() => void load(), REFRESH_INTERVAL_MS);
+    return { pending, loaded };
+  }
+  function oldestPending(pending) {
+    if (pending.length === 0) return null;
+    return pending.reduce(
+      (oldest, item) => item.createdAt < oldest.createdAt ? item : oldest
+    );
+  }
+  function NeedsAttentionWidget({
+    spanClassName = "col-span-2 row-span-1"
+  }) {
+    const { pending, loaded } = useApprovals();
+    const now2 = useNow(REFRESH_INTERVAL_MS);
+    const top = (0, import_react74.useMemo)(() => oldestPending(pending), [pending]);
+    const weight = (0, import_react74.useMemo)(() => {
+      if (top == null) return null;
+      const stale2 = now2 - top.createdAt >= STALE_PENDING_AGE_MS;
+      return stale2 ? HOME_SIGNAL_WEIGHTS.escalation : HOME_SIGNAL_WEIGHTS.approval;
+    }, [top, now2]);
+    usePublishHomeAttention(NEEDS_ATTENTION_WIDGET_KEY, weight);
+    const onActivate = (0, import_react74.useCallback)(() => {
+      if (top == null) return;
+      dispatchChatPrefill({ text: `Approve: ${top.title}`, select: true });
+    }, [top]);
+    if (!loaded || top == null) return null;
+    const count3 = pending.length;
+    const stale = now2 - top.createdAt >= STALE_PENDING_AGE_MS;
+    return /* @__PURE__ */ (0, import_jsx_runtime54.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(
+      HomeWidgetCard,
+      {
+        icon: /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(CircleQuestionMark, {}),
+        label: "Needs response",
+        value: top.title,
+        badge: count3,
+        tone: stale ? "warn" : "default",
+        testId: "chat-widget-needs-attention",
+        ariaLabel: `${count3} action${count3 === 1 ? "" : "s"} need your response, oldest: ${top.title}. Respond in chat.`,
+        onActivate
+      }
+    ) });
+  }
+  var NEEDS_ATTENTION_HOME_WIDGET = {
+    pluginId: "needs-attention",
+    id: "needs-attention.pending",
+    order: 60,
+    signalKinds: ["approval", "escalation"],
+    Component: NeedsAttentionWidget
+  };
+
+  // packages/ui/src/state/notifications/category-icon.tsx
+  var import_jsx_runtime55 = __toESM(require_jsx_runtime(), 1);
+  var CATEGORY_ICON = {
+    reminder: /* @__PURE__ */ (0, import_jsx_runtime55.jsx)(Clock, { className: "h-4 w-4" }),
+    task: /* @__PURE__ */ (0, import_jsx_runtime55.jsx)(Check, { className: "h-4 w-4" }),
+    workflow: /* @__PURE__ */ (0, import_jsx_runtime55.jsx)(Workflow, { className: "h-4 w-4" }),
+    agent: /* @__PURE__ */ (0, import_jsx_runtime55.jsx)(Bot, { className: "h-4 w-4" }),
+    approval: /* @__PURE__ */ (0, import_jsx_runtime55.jsx)(FileExclamationPoint, { className: "h-4 w-4" }),
+    message: /* @__PURE__ */ (0, import_jsx_runtime55.jsx)(MessageSquare, { className: "h-4 w-4" }),
+    health: /* @__PURE__ */ (0, import_jsx_runtime55.jsx)(HeartPulse, { className: "h-4 w-4" }),
+    system: /* @__PURE__ */ (0, import_jsx_runtime55.jsx)(Settings2, { className: "h-4 w-4" }),
+    general: /* @__PURE__ */ (0, import_jsx_runtime55.jsx)(CircleAlert, { className: "h-4 w-4" })
+  };
+  function categoryIcon(category) {
+    return CATEGORY_ICON[category] ?? CATEGORY_ICON.general;
+  }
+
+  // packages/ui/src/components/chat/widgets/notifications.tsx
+  init_navigate_deep_link();
+  init_notification_store();
+  var import_jsx_runtime56 = __toESM(require_jsx_runtime(), 1);
+  var MAX_HOME_NOTIFICATIONS = 4;
+  function NotificationRow({
+    notification
+  }) {
+    return /* @__PURE__ */ (0, import_jsx_runtime56.jsxs)("li", { className: "flex items-start gap-1.5 px-1 py-1", children: [
+      /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(
+        "span",
+        {
+          className: "mt-0.5 shrink-0 text-muted [&_svg]:h-3.5 [&_svg]:w-3.5",
+          "data-testid": "notification-row-icon",
+          "aria-hidden": true,
+          children: categoryIcon(notification.category)
+        }
+      ),
+      /* @__PURE__ */ (0, import_jsx_runtime56.jsxs)("span", { className: "flex min-w-0 flex-col gap-0.5", children: [
+        /* @__PURE__ */ (0, import_jsx_runtime56.jsx)("span", { className: "truncate text-xs font-medium text-txt", children: notification.title }),
+        notification.body ? /* @__PURE__ */ (0, import_jsx_runtime56.jsx)("span", { className: "truncate text-2xs text-muted", children: notification.body }) : null
+      ] })
+    ] });
+  }
+  function NotificationsWidget(props) {
+    const { notifications, unreadCount } = useNotifications();
+    const nav = useWidgetNavigation();
+    const ranked = rankHomeNotifications(notifications);
+    const recent = ranked.slice(0, MAX_HOME_NOTIFICATIONS);
+    if (recent.length === 0) {
+      return null;
+    }
+    if (props.slot === "home") {
+      const top = recent[0];
+      const urgent = top.priority === "urgent";
+      return /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(
+        "div",
+        {
+          className: `min-w-0 ${props.spanClassName ?? "col-span-2 row-span-1"}`,
+          children: /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(
+            HomeWidgetCard,
+            {
+              icon: categoryIcon(top.category),
+              label: "Notifications",
+              value: top.title,
+              badge: unreadCount > 0 ? unreadCount : void 0,
+              tone: urgent ? "danger" : top.priority === "high" ? "warn" : "default",
+              testId: "widget-notifications",
+              ariaLabel: `Notifications: ${unreadCount} unread, latest ${top.title}. Open inbox.`,
+              onActivate: () => {
+                if (!top.readAt) void markNotificationRead(top.id);
+                if (top.deepLink && isSafeDeepLink(top.deepLink)) {
+                  navigateDeepLink(top.deepLink);
+                } else {
+                  nav.openView("/inbox", "inbox");
+                }
+              }
+            }
+          )
+        }
+      );
+    }
+    return /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(
+      WidgetSection,
+      {
+        title: "Notifications",
+        icon: /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(Bell, {}),
+        testId: "widget-notifications",
+        action: unreadCount > 0 ? /* @__PURE__ */ (0, import_jsx_runtime56.jsx)("span", { className: "rounded-full bg-accent-subtle px-1.5 text-2xs font-medium text-accent", children: unreadCount }) : void 0,
+        children: /* @__PURE__ */ (0, import_jsx_runtime56.jsx)("ul", { className: "flex flex-col gap-0.5", children: recent.map((n) => /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(NotificationRow, { notification: n }, n.id)) })
+      }
+    );
+  }
+
+  // packages/ui/src/components/chat/widgets/relationships-attention.tsx
+  var import_react75 = __toESM(require_react(), 1);
+  init_home_screen_fixture_api_stub();
+  var import_jsx_runtime57 = __toESM(require_jsx_runtime(), 1);
+  var RELATIONSHIPS_WIDGET_KEY = "relationships/relationships.attention";
+  var RELATIONSHIPS_REFRESH_INTERVAL_MS = 3e4;
+  var EMPTY_DATA = {
+    pendingCandidates: [],
+    staleContacts: []
+  };
+  function isRecord4(value) {
+    return typeof value === "object" && value !== null;
+  }
+  function pendingCandidatesFrom(candidates) {
+    if (!Array.isArray(candidates)) return [];
+    return candidates.filter(
+      (candidate) => isRecord4(candidate) && typeof candidate.id === "string" && candidate.status === "pending"
+    );
+  }
+  function toTimestamp(iso) {
+    if (!iso) return 0;
+    const parsed = Date.parse(iso);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+  function staleContactsFrom(people) {
+    if (!Array.isArray(people)) return [];
+    return people.filter(
+      (person) => isRecord4(person) && typeof person.displayName === "string" && !person.isOwner
+    ).sort(
+      (left, right) => toTimestamp(left.lastInteractionAt) - toTimestamp(right.lastInteractionAt)
+    );
+  }
+  function relationshipsEqual(a, b) {
+    if (a.pendingCandidates.length !== b.pendingCandidates.length || a.staleContacts.length !== b.staleContacts.length) {
+      return false;
+    }
+    const sameCandidates = a.pendingCandidates.every(
+      (candidate, i) => candidate.id === b.pendingCandidates[i].id
+    );
+    if (!sameCandidates) return false;
+    return a.staleContacts.every((person, i) => {
+      const other = b.staleContacts[i];
+      return person.groupId === other.groupId && person.lastInteractionAt === other.lastInteractionAt;
+    });
+  }
+  function RelationshipsAttentionWidget({
+    slot,
+    spanClassName = "col-span-2 row-span-1"
+  }) {
+    const [data, setData] = (0, import_react75.useState)(EMPTY_DATA);
+    const nav = useWidgetNavigation();
+    const authenticated = useIsAuthenticated();
+    const load = (0, import_react75.useCallback)(async () => {
+      if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
+        setData(EMPTY_DATA);
+        return;
+      }
+      try {
+        const [peopleResult, candidates] = await Promise.all([
+          client.getRelationshipsPeople(),
+          client.getRelationshipsCandidates()
+        ]);
+        const next = {
+          pendingCandidates: pendingCandidatesFrom(candidates),
+          staleContacts: staleContactsFrom(peopleResult.people)
+        };
+        setData((prev) => relationshipsEqual(prev, next) ? prev : next);
+      } catch {
+      }
+    }, [authenticated]);
+    (0, import_react75.useEffect)(() => {
+      void load();
+    }, [load]);
+    useIntervalWhenDocumentVisible(
+      () => void load(),
+      RELATIONSHIPS_REFRESH_INTERVAL_MS
+    );
+    const pendingCount = data.pendingCandidates.length;
+    const hasPendingMerge = pendingCount > 0;
+    const stalest = (0, import_react75.useMemo)(() => data.staleContacts[0] ?? null, [data]);
+    const hasContacts = stalest != null;
+    const onHome = slot === "home";
+    usePublishHomeAttention(
+      RELATIONSHIPS_WIDGET_KEY,
+      onHome && hasPendingMerge ? HOME_SIGNAL_WEIGHTS.approval : null
+    );
+    if (!hasPendingMerge && !hasContacts) return null;
+    if (hasPendingMerge) {
+      return /* @__PURE__ */ (0, import_jsx_runtime57.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: /* @__PURE__ */ (0, import_jsx_runtime57.jsx)(
+        HomeWidgetCard,
+        {
+          icon: /* @__PURE__ */ (0, import_jsx_runtime57.jsx)(Users, {}),
+          label: "People",
+          value: "Confirm merge?",
+          badge: pendingCount,
+          tone: "warn",
+          testId: "chat-widget-relationships",
+          ariaLabel: `People: ${pendingCount} merge ${pendingCount === 1 ? "candidate" : "candidates"} to confirm. Open Relationships.`,
+          onActivate: () => nav.openView("/relationships", "relationships")
+        }
+      ) });
+    }
+    return /* @__PURE__ */ (0, import_jsx_runtime57.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: /* @__PURE__ */ (0, import_jsx_runtime57.jsx)(
+      HomeWidgetCard,
+      {
+        icon: /* @__PURE__ */ (0, import_jsx_runtime57.jsx)(Users, {}),
+        label: "Reach out",
+        value: stalest.displayName,
+        tone: "default",
+        testId: "chat-widget-relationships",
+        ariaLabel: `Reach out: you haven't talked to ${stalest.displayName} in a while. Open Relationships.`,
+        onActivate: () => nav.openView("/relationships", "relationships")
+      }
+    ) });
+  }
+  var RELATIONSHIPS_HOME_WIDGET = {
+    pluginId: "relationships",
+    id: "relationships.attention",
+    order: 90,
+    signalKinds: ["nudge", "approval"],
+    Component: RelationshipsAttentionWidget
+  };
+
+  // packages/ui/src/components/chat/widgets/todo.tsx
+  var import_react76 = __toESM(require_react(), 1);
+  init_home_screen_fixture_api_stub();
+
+  // packages/ui/src/components/ui/badge.tsx
+  var import_jsx_runtime58 = __toESM(require_jsx_runtime(), 1);
+  var badgeVariants = cva(
+    "inline-flex items-center rounded-sm border px-2.5 py-0.5 text-xs font-semibold transition-colors    ",
+    {
+      variants: {
+        variant: {
+          default: "border-transparent bg-primary text-primary-fg hover:bg-primary/80",
+          secondary: "border-transparent bg-bg-accent text-txt hover:bg-bg-hover",
+          destructive: "border-transparent bg-destructive text-destructive-fg hover:bg-destructive/80",
+          outline: "text-txt border-border"
+        }
+      },
+      defaultVariants: {
+        variant: "default"
+      }
+    }
+  );
+  function Badge({ className, variant, ...props }) {
+    return /* @__PURE__ */ (0, import_jsx_runtime58.jsx)("div", { className: cn(badgeVariants({ variant }), className), ...props });
+  }
+
+  // packages/ui/src/components/chat/widgets/todo.tsx
+  var import_jsx_runtime59 = __toESM(require_jsx_runtime(), 1);
+  var TODO_WIDGET_KEY = "todo/todo.items";
+  var TODO_REFRESH_INTERVAL_MS = 15e3;
+  var MAX_VISIBLE_TODOS = 8;
+  var fallbackTranslate2 = (key, vars) => typeof vars?.defaultValue === "string" ? vars.defaultValue : key;
+  function sortTodosForWidget(todos) {
+    return [...todos].sort((left, right) => {
+      if (left.isCompleted !== right.isCompleted) {
+        return left.isCompleted ? 1 : -1;
+      }
+      if (left.isUrgent !== right.isUrgent) {
+        return left.isUrgent ? -1 : 1;
+      }
+      const leftPriority = left.priority ?? Number.MAX_SAFE_INTEGER;
+      const rightPriority = right.priority ?? Number.MAX_SAFE_INTEGER;
+      if (leftPriority !== rightPriority) {
+        return leftPriority - rightPriority;
+      }
+      return left.name.localeCompare(right.name);
+    });
+  }
+  function dedupeTodos(todos) {
+    const byId = /* @__PURE__ */ new Map();
+    for (const todo of todos) {
+      byId.set(todo.id, todo);
+    }
+    return sortTodosForWidget([...byId.values()]);
+  }
+  function TodoRow({ todo }) {
+    const showDescription = todo.description.trim().length > 0 && todo.description !== todo.name;
+    const showType = todo.type.trim().length > 0 && todo.type !== "task";
+    return /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { className: "rounded-sm border border-border/50 bg-bg/70 p-3", children: /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { className: "flex items-start gap-2", children: [
+      /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+        "span",
+        {
+          className: `mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full ${todo.isUrgent ? "bg-danger" : todo.priority != null ? "bg-accent" : "bg-muted"}`
+        }
+      ),
+      /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { className: "min-w-0 flex-1", children: [
+        /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { className: "flex flex-wrap items-center gap-1.5", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("span", { className: "min-w-0 truncate text-xs font-semibold text-txt", children: todo.name }),
+          todo.isUrgent ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(Badge, { variant: "secondary", className: "text-3xs text-danger", children: "Urgent" }) : null,
+          todo.priority != null ? /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)(Badge, { variant: "secondary", className: "text-3xs", children: [
+            "P",
+            todo.priority
+          ] }) : null,
+          showType ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(Badge, { variant: "secondary", className: "text-3xs", children: todo.type }) : null
+        ] }),
+        showDescription ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("p", { className: "mt-1 line-clamp-2 text-xs-tight leading-5 text-muted", children: todo.description }) : null
+      ] })
+    ] }) });
+  }
+  function TodoItemsContent({
+    todos,
+    loading
+  }) {
+    const openTodos = todos.filter((todo) => !todo.isCompleted);
+    const hiddenCompletedCount = todos.length - openTodos.length;
+    const visibleTodos = openTodos.slice(0, MAX_VISIBLE_TODOS);
+    const remainingCount = openTodos.length - visibleTodos.length;
+    if (loading && todos.length === 0) {
+      return /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { className: "py-3 text-xs text-muted", children: "Refreshing todos\u2026" });
+    }
+    if (openTodos.length === 0) {
+      return /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+        EmptyWidgetState,
+        {
+          icon: /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(ListTodo, { className: "h-8 w-8" }),
+          title: "No open todos"
+        }
+      );
+    }
+    return /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { className: "flex flex-col gap-2", children: [
+      visibleTodos.map((todo) => /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(TodoRow, { todo }, todo.id)),
+      remainingCount > 0 ? /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("p", { className: "px-1 text-xs-tight text-muted", children: [
+        "+",
+        remainingCount,
+        " more open todo",
+        remainingCount === 1 ? "" : "s"
+      ] }) : null,
+      hiddenCompletedCount > 0 ? /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("p", { className: "px-1 text-xs-tight text-muted", children: [
+        hiddenCompletedCount,
+        " completed todo",
+        hiddenCompletedCount === 1 ? "" : "s",
+        " hidden"
+      ] }) : null
+    ] });
+  }
+  function TodoSidebarWidget({
+    slot,
+    spanClassName = "col-span-2 row-span-1"
+  }) {
+    const { workbench, t: appT } = useAppSelectorShallow((s) => ({
+      workbench: s.workbench,
+      t: s.t
+    }));
+    const t2 = appT ?? fallbackTranslate2;
+    const authenticated = useIsAuthenticated();
+    const [todos, setTodos] = (0, import_react76.useState)(
+      () => dedupeTodos(workbench?.todos ?? [])
+    );
+    const [todosLoading, setTodosLoading] = (0, import_react76.useState)(false);
+    const mountedRef = (0, import_react76.useRef)(true);
+    (0, import_react76.useEffect)(() => {
+      mountedRef.current = true;
+      return () => {
+        mountedRef.current = false;
+      };
+    }, []);
+    (0, import_react76.useEffect)(() => {
+      setTodos(dedupeTodos(workbench?.todos ?? []));
+    }, [workbench?.todos]);
+    const loadTodos = (0, import_react76.useCallback)(
+      async (silent = false) => {
+        if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
+          if (mountedRef.current) {
+            setTodos(dedupeTodos(workbench?.todos ?? []));
+            setTodosLoading(false);
+          }
+          return;
+        }
+        if (!silent && mountedRef.current) {
+          setTodosLoading(true);
+        }
+        try {
+          const result = await client.listWorkbenchTodos();
+          if (mountedRef.current) {
+            setTodos(dedupeTodos(result.todos));
+          }
+        } catch {
+          if (mountedRef.current && (workbench?.todos?.length ?? 0) > 0) {
+            setTodos(dedupeTodos(workbench?.todos ?? []));
+          }
+        } finally {
+          if (mountedRef.current) {
+            setTodosLoading(false);
+          }
+        }
+      },
+      [authenticated, workbench?.todos]
+    );
+    (0, import_react76.useEffect)(() => {
+      void loadTodos(todos.length > 0);
+    }, [loadTodos, todos.length]);
+    useIntervalWhenDocumentVisible(
+      () => void loadTodos(true),
+      TODO_REFRESH_INTERVAL_MS
+    );
+    const openTodos = todos.filter((todo) => !todo.isCompleted);
+    const hasUrgent = openTodos.some((todo) => todo.isUrgent);
+    const onHome = slot === "home";
+    usePublishHomeAttention(
+      TODO_WIDGET_KEY,
+      onHome && hasUrgent ? HOME_SIGNAL_WEIGHTS.reminder : null
+    );
+    if (onHome && openTodos.length === 0) return null;
+    const section = /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+      WidgetSection,
+      {
+        title: t2("taskseventspanel.Todos", { defaultValue: "Todos" }),
+        icon: /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(ListTodo, { className: "h-4 w-4" }),
+        testId: "chat-widget-todos",
+        children: /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(TodoItemsContent, { todos, loading: todosLoading })
+      }
+    );
+    if (onHome) {
+      return /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: section });
+    }
+    return section;
+  }
+  var TODO_PLUGIN_WIDGETS = [
+    {
+      id: "todo.items",
+      pluginId: "todo",
+      order: 100,
+      defaultEnabled: true,
+      Component: TodoSidebarWidget
+    }
+  ];
+
+  // packages/ui/src/components/chat/widgets/wallet-balance.tsx
+  var import_react77 = __toESM(require_react(), 1);
+  init_home_screen_fixture_api_stub();
+
+  // packages/ui/src/components/chat/widgets/wallet-price-holdings.ts
+  var MIN_HOLDING_USD = 1;
+  var MAX_PRICED_HOLDINGS = 5;
+  function parseUsd(value) {
+    const n = typeof value === "number" ? value : Number.parseFloat(value ?? "");
+    return Number.isFinite(n) ? n : 0;
+  }
+  function collectHoldings(balances) {
+    const out = [];
+    const { solana, evm } = balances;
+    if (solana) {
+      out.push({ symbol: "SOL", valueUsd: parseUsd(solana.solValueUsd) });
+      for (const t2 of solana.tokens) {
+        out.push({ symbol: t2.symbol, valueUsd: parseUsd(t2.valueUsd) });
+      }
+    }
+    if (evm) {
+      for (const chain of evm.chains) {
+        out.push({
+          symbol: chain.nativeSymbol,
+          valueUsd: parseUsd(chain.nativeValueUsd)
+        });
+        for (const t2 of chain.tokens) {
+          out.push({ symbol: t2.symbol, valueUsd: parseUsd(t2.valueUsd) });
+        }
+      }
+    }
+    return out;
+  }
+  function selectPricedHoldings(balances, prices) {
+    if (!balances) return [];
+    const priceBySymbol = /* @__PURE__ */ new Map();
+    for (const p of prices ?? []) {
+      const key = p.symbol.trim().toUpperCase();
+      if (key && !priceBySymbol.has(key)) priceBySymbol.set(key, p);
+    }
+    const heldValueBySymbol = /* @__PURE__ */ new Map();
+    for (const { symbol: symbol2, valueUsd } of collectHoldings(balances)) {
+      if (valueUsd < MIN_HOLDING_USD) continue;
+      const key = symbol2.trim().toUpperCase();
+      if (!key) continue;
+      heldValueBySymbol.set(key, (heldValueBySymbol.get(key) ?? 0) + valueUsd);
+    }
+    const ranked = [...heldValueBySymbol.entries()].filter(([symbol2]) => priceBySymbol.has(symbol2)).sort((a, b) => {
+      if (b[1] !== a[1]) return b[1] - a[1];
+      return a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0;
+    }).slice(0, MAX_PRICED_HOLDINGS);
+    return ranked.map(([symbol2]) => {
+      const snap = priceBySymbol.get(symbol2);
+      const price = snap;
+      return {
+        symbol: price.symbol,
+        priceUsd: price.priceUsd,
+        change24hPct: price.change24hPct
+      };
+    });
+  }
+
+  // packages/ui/src/components/chat/widgets/wallet-balance.tsx
+  var import_jsx_runtime60 = __toESM(require_jsx_runtime(), 1);
+  var DEFAULT_SPAN5 = "col-span-2 row-span-1";
+  function formatPrice(priceUsd) {
+    const digits = priceUsd > 0 && priceUsd < 1 ? 6 : 2;
+    try {
+      return new Intl.NumberFormat(void 0, {
+        style: "currency",
+        currency: "USD",
+        minimumFractionDigits: 2,
+        maximumFractionDigits: digits
+      }).format(priceUsd);
+    } catch {
+      return `$${priceUsd.toFixed(digits)}`;
+    }
+  }
+  function formatChange(change24hPct) {
+    if (!Number.isFinite(change24hPct) || Math.abs(change24hPct) < 0.01)
+      return "";
+    const sign = change24hPct > 0 ? "+" : "";
+    return `${sign}${change24hPct.toFixed(1)}%`;
+  }
+  function WalletBalanceWidget(props) {
+    const spanClassName = props.spanClassName ?? DEFAULT_SPAN5;
+    const [holdings, setHoldings] = (0, import_react77.useState)(null);
+    const [loading, setLoading] = (0, import_react77.useState)(true);
+    const nav = useWidgetNavigation();
+    const authenticated = useIsAuthenticated();
+    (0, import_react77.useEffect)(() => {
+      if (!authenticated) return;
+      let cancelled = false;
+      void (async () => {
+        try {
+          const [balances, overview] = await Promise.all([
+            client.getWalletBalances(),
+            client.getWalletMarketOverview().catch(() => null)
+          ]);
+          if (cancelled) return;
+          setHoldings(selectPricedHoldings(balances, overview?.prices));
+        } catch {
+          if (!cancelled) setHoldings(null);
+        } finally {
+          if (!cancelled) setLoading(false);
+        }
+      })();
+      return () => {
+        cancelled = true;
+      };
+    }, [authenticated]);
+    if (loading && holdings == null) {
+      return /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
+        "div",
+        {
+          "data-testid": "chat-widget-wallet-balance-loading",
+          "aria-busy": "true",
+          className: `${spanClassName} h-12 animate-pulse`
+        }
+      );
+    }
+    if (!holdings || holdings.length === 0) return null;
+    return /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(
+      Button,
+      {
+        "data-testid": "chat-widget-wallet-prices",
+        "aria-label": `Wallet prices: ${holdings.map((h) => `${h.symbol} ${formatPrice(h.priceUsd)}`).join(", ")}. Open wallet.`,
+        onClick: () => nav.openView("/wallet", "wallet"),
+        variant: "ghost",
+        className: `${spanClassName} group flex h-auto w-full flex-col items-stretch gap-1 whitespace-normal px-3 py-2.5 text-left font-normal transition-opacity hover:opacity-80`,
+        children: [
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("span", { className: "flex items-center gap-2 text-xs text-white/70 [&>svg]:h-3.5 [&>svg]:w-3.5", children: [
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(Wallet, {}),
+            "Wallet"
+          ] }),
+          holdings.map((h) => {
+            const change = formatChange(h.change24hPct);
+            return /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(
+              "span",
+              {
+                "data-testid": `wallet-price-row-${h.symbol}`,
+                className: "flex items-baseline justify-between gap-2 text-sm",
+                children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("span", { className: "truncate font-medium text-white", children: h.symbol }),
+                  /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("span", { className: "flex shrink-0 items-baseline gap-1.5", children: [
+                    /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("span", { className: "tabular-nums text-white", children: formatPrice(h.priceUsd) }),
+                    change ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
+                      "span",
+                      {
+                        className: `tabular-nums text-xs ${h.change24hPct >= 0 ? "text-success" : "text-danger"}`,
+                        children: change
+                      }
+                    ) : null
+                  ] })
+                ]
+              },
+              h.symbol
+            );
+          })
+        ]
+      }
+    );
+  }
+
+  // packages/ui/src/components/chat/widgets/workflows.tsx
+  var import_react79 = __toESM(require_react(), 1);
 
   // packages/ui/src/hooks/useUnifiedTasks.ts
-  var import_react65 = __toESM(require_react(), 1);
+  var import_react78 = __toESM(require_react(), 1);
   init_home_screen_fixture_api_stub();
 
   // packages/ui/src/utils/cron-format.ts
@@ -68442,8 +70407,8 @@ Assistant:`;
   function useUnifiedTasks(options2) {
     const timeoutMs = options2?.timeoutMs ?? DEFAULT_TIMEOUT_MS2;
     const ownerVisibleOnly = options2?.ownerVisibleOnly ?? true;
-    const [state4, setState3] = (0, import_react65.useState)(INITIAL_STATE3);
-    const load = (0, import_react65.useCallback)(
+    const [state4, setState3] = (0, import_react78.useState)(INITIAL_STATE3);
+    const load = (0, import_react78.useCallback)(
       async (signal) => {
         const [automations, scheduled] = await Promise.all([
           settle(
@@ -68467,23 +70432,23 @@ Assistant:`;
       },
       [timeoutMs, ownerVisibleOnly]
     );
-    (0, import_react65.useEffect)(() => {
+    (0, import_react78.useEffect)(() => {
       const signal = { cancelled: false };
       void load(signal);
       return () => {
         signal.cancelled = true;
       };
     }, [load]);
-    const refresh = (0, import_react65.useCallback)(async () => {
+    const refresh = (0, import_react78.useCallback)(async () => {
       await load({ cancelled: false });
     }, [load]);
     return { state: state4, refresh };
   }
 
-  // packages/ui/src/components/chat/widgets/automations.tsx
-  var import_jsx_runtime45 = __toESM(require_jsx_runtime(), 1);
+  // packages/ui/src/components/chat/widgets/workflows.tsx
+  var import_jsx_runtime61 = __toESM(require_jsx_runtime(), 1);
   var AUTOMATIONS_VIEW = "/automations";
-  var AUTOMATIONS_TIMEOUT_MS = 6e3;
+  var TASKS_TIMEOUT_MS = 6e3;
   function isRunning(item) {
     if (item.isDraft) return false;
     if (item.status === "system") return true;
@@ -68493,24 +70458,24 @@ Assistant:`;
     if (a.system !== b.system) return a.system ? -1 : 1;
     return a.title.localeCompare(b.title);
   }
-  function AutomationsWidget({
+  function WorkflowsWidget({
     spanClassName = "col-span-2 row-span-1"
   }) {
-    const { state: state4 } = useUnifiedTasks({ timeoutMs: AUTOMATIONS_TIMEOUT_MS });
+    const { state: state4 } = useUnifiedTasks({ timeoutMs: TASKS_TIMEOUT_MS });
     const nav = useWidgetNavigation();
-    const open = (0, import_react66.useCallback)(
+    const open = (0, import_react79.useCallback)(
       () => nav.openView(AUTOMATIONS_VIEW, "automations"),
       [nav]
     );
     if (state4.loading) {
-      return /* @__PURE__ */ (0, import_jsx_runtime45.jsx)("div", { className: spanClassName, children: /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
+      return /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { className: spanClassName, children: /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
         HomeWidgetCard,
         {
-          icon: /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(Workflow, {}),
-          label: "Automations",
+          icon: /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(Workflow, {}),
+          label: "Tasks",
           value: "Loading\u2026",
-          testId: "chat-widget-automations",
-          ariaLabel: "Automations loading.",
+          testId: "chat-widget-workflows",
+          ariaLabel: "Tasks loading.",
           onActivate: open
         }
       ) });
@@ -68519,2345 +70484,18 @@ Assistant:`;
     const top = running2[0] ?? null;
     if (!top) return null;
     const extraCount = running2.length - 1;
-    return /* @__PURE__ */ (0, import_jsx_runtime45.jsx)("div", { className: spanClassName, children: /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { className: spanClassName, children: /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
       HomeWidgetCard,
       {
-        icon: /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(Workflow, {}),
-        label: "Automations",
+        icon: /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(Workflow, {}),
+        label: "Tasks",
         value: top.title,
         badge: extraCount > 0 ? `+${extraCount}` : void 0,
-        testId: "chat-widget-automations",
-        ariaLabel: `Running automations: ${top.title}${extraCount > 0 ? `, and ${extraCount} more` : ""}. Open automations.`,
+        testId: "chat-widget-workflows",
+        ariaLabel: `Running tasks: ${top.title}${extraCount > 0 ? `, and ${extraCount} more` : ""}. Open tasks.`,
         onActivate: open
       }
     ) });
-  }
-
-  // packages/ui/src/components/chat/widgets/browser-status.tsx
-  var import_react67 = __toESM(require_react(), 1);
-  init_home_screen_fixture_api_stub();
-  var import_jsx_runtime46 = __toESM(require_jsx_runtime(), 1);
-  var POLL_INTERVAL_MS = 4e3;
-  var MAX_TAB_ROWS = 8;
-  function tabLabel(tab) {
-    const title = tab.title?.trim();
-    if (title) return title;
-    const url2 = tab.url?.trim();
-    if (!url2) return "New tab";
-    try {
-      return new URL(url2).hostname.replace(/^www\./, "") || url2;
-    } catch {
-      return url2;
-    }
-  }
-  function tabStatus(tab) {
-    if (tab.visible) {
-      return {
-        label: "Active",
-        dotClass: "bg-accent",
-        textClass: "text-txt"
-      };
-    }
-    return {
-      label: "Background",
-      dotClass: "bg-muted/50",
-      textClass: "text-muted"
-    };
-  }
-  function BrowserStatusSidebarWidget(_props) {
-    const setTab = useAppSelector((s) => s.setTab);
-    const [snapshot2, setSnapshot] = (0, import_react67.useState)(
-      null
-    );
-    const authenticated = useIsAuthenticated();
-    const poll = (0, import_react67.useCallback)(async () => {
-      if (!authenticated) return;
-      try {
-        const next = await client.getBrowserWorkspace();
-        setSnapshot(next);
-      } catch {
-      }
-    }, [authenticated]);
-    (0, import_react67.useEffect)(() => {
-      void poll();
-    }, [poll]);
-    useIntervalWhenDocumentVisible(() => void poll(), POLL_INTERVAL_MS);
-    const tabs = snapshot2?.tabs ?? [];
-    if (tabs.length === 0) {
-      return null;
-    }
-    const rows = tabs.slice(0, MAX_TAB_ROWS);
-    function handleTabClick(tab) {
-      void (async () => {
-        try {
-          await client.showBrowserWorkspaceTab?.(tab.id);
-        } catch {
-        }
-      })();
-      setTab("browser");
-    }
-    return /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(
-      WidgetSection,
-      {
-        title: "Browser",
-        icon: /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(Globe, { className: "h-3.5 w-3.5" }),
-        testId: "chat-widget-browser-status",
-        onTitleClick: () => setTab("browser"),
-        children: /* @__PURE__ */ (0, import_jsx_runtime46.jsx)("div", { className: "flex flex-col gap-0.5 pt-0.5", children: rows.map((tab) => {
-          const label = tabLabel(tab);
-          const status = tabStatus(tab);
-          return /* @__PURE__ */ (0, import_jsx_runtime46.jsxs)(
-            Button,
-            {
-              onClick: () => handleTabClick(tab),
-              title: tab.url ?? label,
-              "data-testid": `chat-widget-browser-tab-${tab.id}`,
-              variant: "ghost",
-              className: "flex h-auto w-full items-center justify-start gap-2 whitespace-normal rounded-sm px-0.5 py-0.5 text-left font-normal transition-colors hover:bg-bg-hover/40",
-              children: [
-                /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(
-                  "span",
-                  {
-                    className: `h-1.5 w-1.5 shrink-0 rounded-full ${status.dotClass}`,
-                    "aria-hidden": true
-                  }
-                ),
-                /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(
-                  "span",
-                  {
-                    className: `min-w-0 flex-1 truncate text-3xs ${status.textClass}`,
-                    children: label
-                  }
-                ),
-                /* @__PURE__ */ (0, import_jsx_runtime46.jsx)("span", { className: "shrink-0 text-3xs uppercase tracking-wider text-muted/70", children: status.label })
-              ]
-            },
-            tab.id
-          );
-        }) })
-      }
-    );
-  }
-
-  // packages/ui/src/components/chat/widgets/browser-status.helpers.ts
-  var BROWSER_STATUS_WIDGET = {
-    id: "browser.status",
-    pluginId: "browser-workspace",
-    order: 75,
-    defaultEnabled: true,
-    Component: BrowserStatusSidebarWidget
-  };
-
-  // packages/ui/src/components/chat/widgets/calendar-upcoming.tsx
-  var import_react68 = __toESM(require_react(), 1);
-  init_home_screen_fixture_api_stub();
-  var import_jsx_runtime47 = __toESM(require_jsx_runtime(), 1);
-  var CALENDAR_WIDGET_KEY = "calendar/calendar.upcoming";
-  var GOOGLE_PROVIDER = "google";
-  var DEFAULT_SPAN2 = "col-span-4 row-span-1";
-  var PROBE_TIMEOUT_MS = 6e3;
-  var FEED_TIMEOUT_MS = 8e3;
-  var CALENDAR_REFRESH_INTERVAL_MS = 6e4;
-  var URGENT_WINDOW_MS = 2 * 60 * 6e4;
-  var LOOKAHEAD_MS = 14 * 24 * 60 * 6e4;
-  function isCalendarFeedEvent(value) {
-    if (typeof value !== "object" || value === null) return false;
-    const event = value;
-    return typeof event.id === "string" && typeof event.title === "string" && typeof event.startAt === "string" && typeof event.endAt === "string" && typeof event.isAllDay === "boolean" && typeof event.location === "string";
-  }
-  function parseCalendarFeed(value) {
-    if (typeof value !== "object" || value === null) return [];
-    const events = value.events;
-    if (!Array.isArray(events)) return [];
-    return events.filter(isCalendarFeedEvent);
-  }
-  function upcomingEvents(events, now2) {
-    return events.filter((event) => {
-      const startMs = Date.parse(event.startAt);
-      return Number.isFinite(startMs) && startMs >= now2;
-    }).sort((a, b) => a.startAt.localeCompare(b.startAt));
-  }
-  function relativeTime2(startAt, now2) {
-    const deltaMs = Date.parse(startAt) - now2;
-    if (!Number.isFinite(deltaMs)) return "";
-    const minutes = Math.round(deltaMs / 6e4);
-    if (minutes <= 0) return "now";
-    if (minutes < 60) return `in ${minutes}m`;
-    const hours = Math.round(minutes / 60);
-    if (hours < 24) return `in ${hours}h`;
-    const days = Math.round(hours / 24);
-    if (days === 1) return "tomorrow";
-    return `in ${days}d`;
-  }
-  function eventsEqual(a, b) {
-    if (a.length !== b.length) return false;
-    return a.every((event, i) => {
-      const other = b[i];
-      return event.id === other.id && event.title === other.title && event.startAt === other.startAt && event.isAllDay === other.isAllDay;
-    });
-  }
-  function CalendarUpcomingWidget({
-    slot,
-    spanClassName = DEFAULT_SPAN2
-  }) {
-    const [events, setEvents] = (0, import_react68.useState)([]);
-    const [feedLoaded, setFeedLoaded] = (0, import_react68.useState)(false);
-    const [connection, setConnection] = (0, import_react68.useState)("unknown");
-    const nav = useWidgetNavigation();
-    const authenticated = useIsAuthenticated();
-    const probeConnection = (0, import_react68.useCallback)(async () => {
-      if (!supportsFullAppShellRoutes(client.getBaseUrl())) {
-        setConnection("unsupported");
-        setFeedLoaded(true);
-        setEvents([]);
-        return false;
-      }
-      if (!authenticated) return false;
-      try {
-        const res = await withTimeout(
-          client.listConnectorAccounts(GOOGLE_PROVIDER),
-          PROBE_TIMEOUT_MS
-        );
-        const linked = res.accounts.some(
-          (account) => account.status === "connected"
-        );
-        setConnection(linked ? "connected" : "disconnected");
-        return linked;
-      } catch {
-        setConnection("disconnected");
-        return false;
-      }
-    }, [authenticated]);
-    const loadEvents = (0, import_react68.useCallback)(async () => {
-      const now3 = /* @__PURE__ */ new Date();
-      const timeMin = now3.toISOString();
-      const timeMax = new Date(now3.getTime() + LOOKAHEAD_MS).toISOString();
-      const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-      const params2 = new URLSearchParams({
-        side: "owner",
-        timeMin,
-        timeMax,
-        timeZone
-      });
-      try {
-        const res = await withTimeout(
-          fetch(
-            `${client.getBaseUrl()}/api/lifeops/calendar/feed?${params2.toString()}`
-          ),
-          FEED_TIMEOUT_MS
-        );
-        if (!res.ok) return;
-        const json3 = await res.json();
-        const next2 = parseCalendarFeed(json3);
-        setEvents((prev) => eventsEqual(prev, next2) ? prev : next2);
-      } catch {
-      } finally {
-        setFeedLoaded(true);
-      }
-    }, []);
-    (0, import_react68.useEffect)(() => {
-      let cancelled = false;
-      void (async () => {
-        const linked = await probeConnection();
-        if (cancelled || !linked) return;
-        await loadEvents();
-      })();
-      return () => {
-        cancelled = true;
-      };
-    }, [probeConnection, loadEvents]);
-    useIntervalWhenDocumentVisible(() => {
-      if (authenticated && connection === "connected") void loadEvents();
-    }, CALENDAR_REFRESH_INTERVAL_MS);
-    const now2 = useNow(CALENDAR_REFRESH_INTERVAL_MS);
-    const visible = (0, import_react68.useMemo)(() => upcomingEvents(events, now2), [events, now2]);
-    const onHome = slot === "home";
-    const next = visible[0];
-    const urgent = next != null && !next.isAllDay && Number.isFinite(Date.parse(next.startAt)) && Date.parse(next.startAt) - now2 >= 0 && Date.parse(next.startAt) - now2 <= URGENT_WINDOW_MS;
-    usePublishHomeAttention(
-      CALENDAR_WIDGET_KEY,
-      onHome && urgent ? HOME_SIGNAL_WEIGHTS.reminder : null
-    );
-    if (connection !== "connected" || now2 === 0 || !feedLoaded || next == null) {
-      return null;
-    }
-    const title = next.title.trim().length > 0 ? next.title : "(untitled)";
-    const when = next.isAllDay ? "all day" : relativeTime2(next.startAt, now2);
-    const more = visible.length - 1;
-    return /* @__PURE__ */ (0, import_jsx_runtime47.jsx)("div", { className: spanClassName, children: /* @__PURE__ */ (0, import_jsx_runtime47.jsx)(
-      HomeWidgetCard,
-      {
-        icon: /* @__PURE__ */ (0, import_jsx_runtime47.jsx)(CalendarClock, {}),
-        label: "Next",
-        value: title,
-        meta: when,
-        badge: more > 0 ? `+${more}` : void 0,
-        tone: urgent ? "warn" : "default",
-        testId: "chat-widget-calendar-upcoming",
-        ariaLabel: `Next event: ${title} ${when}${more > 0 ? ` (+${more} more upcoming)` : ""}. Open Calendar.`,
-        onActivate: () => nav.openView("/calendar", "calendar")
-      }
-    ) });
-  }
-  var CALENDAR_HOME_WIDGET = {
-    pluginId: "calendar",
-    id: "calendar.upcoming",
-    order: 110,
-    size: "4x1",
-    signalKinds: ["reminder"],
-    Component: CalendarUpcomingWidget
-  };
-
-  // packages/ui/src/components/chat/widgets/finances-alerts.tsx
-  var import_react69 = __toESM(require_react(), 1);
-  init_home_screen_fixture_api_stub();
-  var import_jsx_runtime48 = __toESM(require_jsx_runtime(), 1);
-  var FINANCES_WIDGET_KEY = "finances/finances.alerts";
-  var FINANCES_REFRESH_INTERVAL_MS = 3e4;
-  var WEEK_MS = 7 * 24 * 60 * 60 * 1e3;
-  var USD = "USD";
-  function isRecord2(value) {
-    return typeof value === "object" && value !== null;
-  }
-  function usdToMinor(amountUsd) {
-    return Math.round(amountUsd * 100);
-  }
-  function parseNetBalanceMinor(dashboard) {
-    if (!isRecord2(dashboard)) return 0;
-    const spending = dashboard.spending;
-    if (!isRecord2(spending) || typeof spending.netUsd !== "number") return 0;
-    return usdToMinor(spending.netUsd);
-  }
-  function parseHasSource(sources) {
-    if (!isRecord2(sources) || !Array.isArray(sources.sources)) return false;
-    return sources.sources.some(
-      (source) => isRecord2(source) && typeof source.status === "string" && source.status !== "disconnected"
-    );
-  }
-  function parseBills(recurring) {
-    if (!isRecord2(recurring) || !Array.isArray(recurring.charges)) return [];
-    const bills = [];
-    for (const charge of recurring.charges) {
-      if (!isRecord2(charge)) continue;
-      if (typeof charge.averageAmountUsd !== "number") continue;
-      const merchantNormalized = typeof charge.merchantNormalized === "string" ? charge.merchantNormalized : "";
-      const merchantDisplay = typeof charge.merchantDisplay === "string" ? charge.merchantDisplay : "";
-      const label = merchantDisplay || merchantNormalized;
-      if (!label) continue;
-      bills.push({
-        id: merchantNormalized || label,
-        label,
-        amountMinor: usdToMinor(charge.averageAmountUsd),
-        currency: USD,
-        nextChargeAt: typeof charge.nextExpectedAt === "string" ? charge.nextExpectedAt : null,
-        active: true
-      });
-    }
-    return bills;
-  }
-  function formatMinor(amountMinor, currency) {
-    const value = amountMinor / 100;
-    try {
-      return new Intl.NumberFormat(void 0, {
-        style: "currency",
-        currency
-      }).format(value);
-    } catch {
-      return `${value.toFixed(2)} ${currency}`;
-    }
-  }
-  function dueInLabel(nextChargeAt, now2) {
-    const due = new Date(nextChargeAt).getTime();
-    const days = Math.round((due - now2) / (24 * 60 * 60 * 1e3));
-    if (days <= 0) return "due today";
-    if (days === 1) return "due tomorrow";
-    return `due in ${days} days`;
-  }
-  async function getJson(path) {
-    const response = await fetch(`${client.getBaseUrl()}${path}`);
-    if (!response.ok) {
-      throw new Error(`Money request failed (${response.status}): ${path}`);
-    }
-    return response.json();
-  }
-  function billsDueWithin7Days(bills, now2) {
-    const weekFromNow = now2 + WEEK_MS;
-    return bills.filter((bill) => {
-      if (!bill.active || !bill.nextChargeAt) return false;
-      const due = new Date(bill.nextChargeAt).getTime();
-      return !Number.isNaN(due) && due >= now2 && due <= weekFromNow;
-    }).sort((left, right) => {
-      const leftDue = new Date(left.nextChargeAt).getTime();
-      const rightDue = new Date(right.nextChargeAt).getTime();
-      return leftDue - rightDue;
-    });
-  }
-  function financesEqual(a, b) {
-    if (!a) return false;
-    if (a.hasSource !== b.hasSource || a.netBalanceMinor !== b.netBalanceMinor || a.bills.length !== b.bills.length) {
-      return false;
-    }
-    return a.bills.every((bill, i) => {
-      const other = b.bills[i];
-      return bill.id === other.id && bill.amountMinor === other.amountMinor && bill.nextChargeAt === other.nextChargeAt;
-    });
-  }
-  function FinancesAlertsWidget({
-    spanClassName = "col-span-2 row-span-1"
-  }) {
-    const [data, setData] = (0, import_react69.useState)(null);
-    const nav = useWidgetNavigation();
-    const authenticated = useIsAuthenticated();
-    const load = (0, import_react69.useCallback)(async () => {
-      if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
-        setData(null);
-        return;
-      }
-      try {
-        const [dashboard, recurring, sources] = await Promise.all([
-          getJson("/api/lifeops/money/dashboard"),
-          getJson("/api/lifeops/money/recurring"),
-          getJson("/api/lifeops/money/sources")
-        ]);
-        const next = {
-          hasSource: parseHasSource(sources),
-          netBalanceMinor: parseNetBalanceMinor(dashboard),
-          currency: USD,
-          bills: parseBills(recurring)
-        };
-        setData((prev) => financesEqual(prev, next) ? prev : next);
-      } catch {
-      }
-    }, [authenticated]);
-    (0, import_react69.useEffect)(() => {
-      void load();
-    }, [load]);
-    useIntervalWhenDocumentVisible(
-      () => void load(),
-      FINANCES_REFRESH_INTERVAL_MS
-    );
-    const now2 = useNow(FINANCES_REFRESH_INTERVAL_MS);
-    const overdrawn = data != null && data.netBalanceMinor < 0;
-    const dueSoon = (0, import_react69.useMemo)(
-      () => data && now2 > 0 ? billsDueWithin7Days(data.bills, now2) : [],
-      [data, now2]
-    );
-    const hasBillsDue = dueSoon.length > 0;
-    const weight = overdrawn ? HOME_SIGNAL_WEIGHTS.escalation : hasBillsDue ? HOME_SIGNAL_WEIGHTS.reminder : null;
-    usePublishHomeAttention(FINANCES_WIDGET_KEY, weight);
-    if (data == null) return null;
-    if (!data.hasSource) return null;
-    if (!overdrawn && !hasBillsDue) return null;
-    if (overdrawn) {
-      const amount = formatMinor(data.netBalanceMinor, data.currency);
-      return /* @__PURE__ */ (0, import_jsx_runtime48.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: /* @__PURE__ */ (0, import_jsx_runtime48.jsx)(
-        HomeWidgetCard,
-        {
-          icon: /* @__PURE__ */ (0, import_jsx_runtime48.jsx)(Wallet, {}),
-          label: "Bills",
-          value: /* @__PURE__ */ (0, import_jsx_runtime48.jsx)("span", { className: "whitespace-nowrap tabular-nums", children: amount }),
-          badge: "Overdrawn",
-          tone: "danger",
-          testId: "chat-widget-finances-alerts",
-          ariaLabel: `Bills: account overdrawn ${amount}. Open Finances.`,
-          onActivate: () => nav.openView("/finances", "finances")
-        }
-      ) });
-    }
-    const soonest = dueSoon[0];
-    return /* @__PURE__ */ (0, import_jsx_runtime48.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: /* @__PURE__ */ (0, import_jsx_runtime48.jsx)(
-      HomeWidgetCard,
-      {
-        icon: /* @__PURE__ */ (0, import_jsx_runtime48.jsx)(Wallet, {}),
-        label: "Bills",
-        value: soonest.label,
-        meta: dueInLabel(soonest.nextChargeAt, now2),
-        badge: dueSoon.length > 1 ? `${dueSoon.length} due` : void 0,
-        tone: "warn",
-        testId: "chat-widget-finances-alerts",
-        ariaLabel: `Bills: ${dueSoon.length} due this week, next ${soonest.label} ${dueInLabel(soonest.nextChargeAt, now2)}. Open Finances.`,
-        onActivate: () => nav.openView("/finances", "finances")
-      }
-    ) });
-  }
-  var FINANCES_HOME_WIDGET = {
-    pluginId: "finances",
-    id: "finances.alerts",
-    order: 130,
-    signalKinds: ["escalation", "reminder"],
-    Component: FinancesAlertsWidget
-  };
-
-  // packages/ui/src/components/chat/widgets/ftu-welcome.tsx
-  var import_react70 = __toESM(require_react(), 1);
-  init_events3();
-
-  // packages/ui/src/components/shell/usePromptSuggestions.ts
-  var React57 = __toESM(require_react(), 1);
-  init_home_screen_fixture_api_stub();
-
-  // packages/ui/src/components/pages/page-scoped-conversations.ts
-  init_home_screen_fixture_api_stub();
-
-  // packages/ui/src/components/shell/usePromptSuggestions.ts
-  var SUGGESTION_COUNT = 3;
-  var MAX_CONTEXT_MESSAGES = 6;
-  var MAX_CONTEXT_CHARS = 240;
-  var FETCH_TIMEOUT_MS = 6e3;
-  var MODEL_SET_CACHE_MAX = 32;
-  var MODEL_SET_STORAGE_KEY = "eliza:chat-suggestions:model-sets:v1";
-  function readPersistedModelSets() {
-    if (typeof window === "undefined") return [];
-    try {
-      const raw2 = window.sessionStorage.getItem(MODEL_SET_STORAGE_KEY);
-      const parsed = raw2 ? JSON.parse(raw2) : null;
-      if (!Array.isArray(parsed)) return [];
-      return parsed.filter(
-        (entry) => Array.isArray(entry) && typeof entry[0] === "string" && Array.isArray(entry[1]) && entry[1].every((item) => typeof item === "string")
-      );
-    } catch {
-      return [];
-    }
-  }
-  function persistModelSets() {
-    if (typeof window === "undefined") return;
-    try {
-      window.sessionStorage.setItem(
-        MODEL_SET_STORAGE_KEY,
-        JSON.stringify([...modelSetCache])
-      );
-    } catch {
-    }
-  }
-  var modelSetCache = new Map(readPersistedModelSets());
-  var inFlightModelSets = /* @__PURE__ */ new Map();
-  function rememberModelSet(key, value) {
-    modelSetCache.delete(key);
-    modelSetCache.set(key, value);
-    if (modelSetCache.size > MODEL_SET_CACHE_MAX) {
-      const oldest = modelSetCache.keys().next().value;
-      if (oldest !== void 0) modelSetCache.delete(oldest);
-    }
-    persistModelSets();
-  }
-  var STARTERS = [
-    "What can you do?",
-    "Summarize my day",
-    "Draft a reply",
-    "What's on my plate?",
-    "Explain this for me"
-  ];
-  var THREAD_FOLLOW_UP = "Continue where we left off";
-  function timeOfDayLead(hour) {
-    if (hour === void 0) return STARTERS[0];
-    if (hour >= 5 && hour < 12) return "Plan my day";
-    if (hour >= 12 && hour < 18) return "What's left today?";
-    return "Recap my day";
-  }
-  function daypartForHour(hour) {
-    if (hour >= 5 && hour < 12) return "morning";
-    if (hour >= 12 && hour < 18) return "afternoon";
-    return "evening";
-  }
-  function computePromptSuggestions(messages, hour) {
-    const hasThread = messages.some((m) => m.content.trim().length > 0);
-    const lead = hasThread ? THREAD_FOLLOW_UP : timeOfDayLead(hour);
-    return Array.from(/* @__PURE__ */ new Set([lead, ...STARTERS])).slice(0, SUGGESTION_COUNT);
-  }
-  function pageScopeFromLocation(pathname, hash2) {
-    const fromHash = hash2.replace(/^#\/?/, "").split(/[/?#]/)[0] ?? "";
-    const fromPath = pathname.replace(/^\//, "").split(/[/?#]/)[0] ?? "";
-    const segment = (fromHash || fromPath).trim().toLowerCase();
-    if (!segment) return void 0;
-    const candidate = `page-${segment}`;
-    return PAGE_SCOPES.includes(candidate) ? candidate : void 0;
-  }
-  function currentPageScope() {
-    if (typeof window === "undefined") return void 0;
-    return pageScopeFromLocation(
-      window.location.pathname ?? "",
-      window.location.hash ?? ""
-    );
-  }
-  function normalizeModelSuggestions(value) {
-    if (!Array.isArray(value)) return [];
-    const seen = /* @__PURE__ */ new Set();
-    const out = [];
-    for (const raw2 of value) {
-      if (typeof raw2 !== "string") continue;
-      const cleaned = raw2.replace(/\s+/g, " ").trim();
-      if (!cleaned) continue;
-      const key = cleaned.toLowerCase();
-      if (seen.has(key)) continue;
-      seen.add(key);
-      out.push(cleaned);
-      if (out.length >= SUGGESTION_COUNT) break;
-    }
-    return out;
-  }
-  async function fetchModelSuggestions(messages, hour, scope) {
-    const recent = messages.filter((m) => m.content.trim().length > 0).slice(-MAX_CONTEXT_MESSAGES).map((m) => ({
-      role: m.role === "assistant" ? "assistant" : "user",
-      content: m.content.slice(0, MAX_CONTEXT_CHARS)
-    }));
-    const data = await client.fetch(
-      "/api/suggestions",
-      {
-        method: "POST",
-        body: JSON.stringify({
-          messages: recent,
-          hour,
-          ...scope ? { scope } : {}
-        })
-      },
-      { allowNonOk: true, timeoutMs: FETCH_TIMEOUT_MS }
-    );
-    return {
-      set: normalizeModelSuggestions(data?.suggestions),
-      tier: typeof data?.tier === "string" ? data.tier : void 0
-    };
-  }
-  function requestModelSet(messages, hour, scope, key) {
-    const cached3 = modelSetCache.get(key);
-    if (cached3) return Promise.resolve(cached3);
-    const pending = inFlightModelSets.get(key);
-    if (pending) return pending;
-    const request = fetchModelSuggestions(messages, hour, scope).then(({ set: set3, tier }) => {
-      if (tier === "heuristic" || set3.length < SUGGESTION_COUNT) return null;
-      rememberModelSet(key, set3);
-      return set3;
-    }).catch(() => null).finally(() => {
-      inFlightModelSets.delete(key);
-    });
-    inFlightModelSets.set(key, request);
-    return request;
-  }
-  function usePromptSuggestions(messages, options2) {
-    const enabled = options2?.enabled ?? false;
-    const hasThread = messages.some((m) => m.content.trim().length > 0);
-    const hour = (/* @__PURE__ */ new Date()).getHours();
-    const lastId = messages.filter((m) => m.content.trim().length > 0).at(-1)?.id ?? null;
-    const scope = options2?.scope ?? currentPageScope();
-    const fallback = React57.useMemo(
-      () => computePromptSuggestions(messages, hour),
-      [hasThread, hour]
-    );
-    const contextKey = `${scope ?? ""}|${lastId ?? ""}|${daypartForHour(hour)}|${hasThread ? 1 : 0}`;
-    const remembered = modelSetCache.get(contextKey);
-    const [model, setModel] = React57.useState(null);
-    React57.useEffect(() => {
-      if (!enabled || modelSetCache.has(contextKey)) return;
-      let disposed = false;
-      void requestModelSet(messages, hour, scope, contextKey).then((set3) => {
-        if (!disposed && set3) setModel({ key: contextKey, set: set3 });
-      });
-      return () => {
-        disposed = true;
-      };
-    }, [enabled, contextKey]);
-    const modelSet = model && model.key === contextKey ? model.set : null;
-    const source = remembered ?? modelSet ?? fallback;
-    return source.slice(0, SUGGESTION_COUNT);
-  }
-
-  // packages/ui/src/components/chat/widgets/ftu-welcome.tsx
-  var import_jsx_runtime49 = __toESM(require_jsx_runtime(), 1);
-  var PLUGIN_ID = "welcome";
-  var WIDGET_ID = "welcome.ftu";
-  var WIDGET_KEY = `${PLUGIN_ID}/${WIDGET_ID}`;
-  var DEFAULT_SPAN3 = "col-span-4 row-span-1";
-  var FIRST_USER_CHAT_EVENT_TYPES = /* @__PURE__ */ new Set([
-    "message_received",
-    "message_sent"
-  ]);
-  function FtuWelcomeWidget({
-    slot,
-    events,
-    spanClassName = DEFAULT_SPAN3
-  }) {
-    const onHome = slot === "home";
-    usePublishHomeAttention(
-      WIDGET_KEY,
-      onHome ? HOME_SIGNAL_WEIGHTS.welcome : null
-    );
-    useRecordHomeWidgetSeen(WIDGET_KEY, onHome);
-    const suggestions = usePromptSuggestions([], { enabled: onHome });
-    const sentAMessage = (events ?? []).some(
-      (event) => FIRST_USER_CHAT_EVENT_TYPES.has(event.eventType)
-    );
-    (0, import_react70.useEffect)(() => {
-      if (onHome && sentAMessage) markHomeWidgetActed(WIDGET_KEY);
-    }, [onHome, sentAMessage]);
-    if (!onHome) return null;
-    const onChip = (text) => {
-      dispatchChatPrefill({ text, select: true });
-      markHomeWidgetActed(WIDGET_KEY);
-    };
-    return /* @__PURE__ */ (0, import_jsx_runtime49.jsxs)(
-      "section",
-      {
-        className: spanClassName,
-        "data-testid": "chat-widget-ftu-welcome",
-        "aria-label": "Welcome \u2014 getting started",
-        children: [
-          /* @__PURE__ */ (0, import_jsx_runtime49.jsx)("p", { className: "text-sm font-medium text-white", children: "Welcome \u2014 ask me anything to get started." }),
-          /* @__PURE__ */ (0, import_jsx_runtime49.jsxs)("div", { className: "mt-2 flex flex-wrap items-center gap-x-5 gap-y-1.5", children: [
-            suggestions.map((text) => /* @__PURE__ */ (0, import_jsx_runtime49.jsx)(
-              Button,
-              {
-                "data-testid": "ftu-welcome-chip",
-                onClick: () => onChip(text),
-                variant: "ghost",
-                size: "sm",
-                className: "h-auto px-0 py-0 text-sm font-normal text-white/75 underline-offset-4 transition-colors hover:bg-transparent hover:text-white hover:underline",
-                children: text
-              },
-              text
-            )),
-            /* @__PURE__ */ (0, import_jsx_runtime49.jsx)(
-              Button,
-              {
-                "data-testid": "ftu-welcome-dismiss",
-                "aria-label": "Dismiss welcome",
-                onClick: () => dismissHomeWidget(WIDGET_KEY),
-                variant: "ghost",
-                size: "sm",
-                className: "h-auto px-0 py-0 text-sm font-normal text-white/60 transition-colors hover:bg-transparent hover:text-white/80",
-                children: "Dismiss"
-              }
-            )
-          ] })
-        ]
-      }
-    );
-  }
-  var FTU_WELCOME_HOME_WIDGET = {
-    pluginId: PLUGIN_ID,
-    id: WIDGET_ID,
-    // Low order = high base score, so on a cold home (no signals) the welcome card
-    // ranks at the very top; real activity signals on other widgets outrank it.
-    order: 20,
-    signalKinds: ["welcome"],
-    size: { cols: 4, rows: 1 },
-    // The defining lifecycle: gone the moment the user engages or dismisses.
-    sunset: { afterAction: true, dismissible: true },
-    Component: FtuWelcomeWidget
-  };
-
-  // packages/ui/src/components/chat/widgets/goals-attention.tsx
-  var import_react71 = __toESM(require_react(), 1);
-  init_home_screen_fixture_api_stub();
-  var import_jsx_runtime50 = __toESM(require_jsx_runtime(), 1);
-  var GOALS_WIDGET_KEY = "goals/goals.attention";
-  var GOALS_REFRESH_INTERVAL_MS = 2e4;
-  var KNOWN_STATUSES = /* @__PURE__ */ new Set([
-    "active",
-    "paused",
-    "archived",
-    "satisfied"
-  ]);
-  var KNOWN_REVIEW_STATES = /* @__PURE__ */ new Set([
-    "idle",
-    "needs_attention",
-    "on_track",
-    "at_risk"
-  ]);
-  function toStatus(value) {
-    return typeof value === "string" && KNOWN_STATUSES.has(value) ? value : "active";
-  }
-  function toReviewState(value) {
-    return typeof value === "string" && KNOWN_REVIEW_STATES.has(value) ? value : "idle";
-  }
-  function parseGoals(payload) {
-    if (typeof payload !== "object" || payload === null) return [];
-    const records = payload.goals;
-    if (!Array.isArray(records)) return [];
-    const goals = [];
-    for (const record2 of records) {
-      if (typeof record2 !== "object" || record2 === null) continue;
-      const goal = record2.goal;
-      if (typeof goal !== "object" || goal === null) continue;
-      const { id, title, status, reviewState } = goal;
-      if (typeof id !== "string" || typeof title !== "string") continue;
-      goals.push({
-        id,
-        title,
-        status: toStatus(status),
-        reviewState: toReviewState(reviewState)
-      });
-    }
-    return goals;
-  }
-  async function fetchGoals() {
-    const response = await fetch(`${client.getBaseUrl()}/api/lifeops/goals`);
-    if (!response.ok) {
-      throw new Error(`Goals request failed (${response.status})`);
-    }
-    return parseGoals(await response.json());
-  }
-  function liveGoals(goals) {
-    return goals.filter(
-      (goal) => goal.status !== "archived" && goal.status !== "satisfied"
-    );
-  }
-  function mostUrgentGoal(goals) {
-    const live = liveGoals(goals);
-    const byTitle = (left, right) => left.title.localeCompare(right.title);
-    const atRisk = live.filter((goal) => goal.reviewState === "at_risk").sort(byTitle);
-    if (atRisk.length > 0) return atRisk[0];
-    const needsAttention = live.filter((goal) => goal.reviewState === "needs_attention").sort(byTitle);
-    if (needsAttention.length > 0) return needsAttention[0];
-    return null;
-  }
-  function attentionCount(goals) {
-    return liveGoals(goals).filter(
-      (goal) => goal.reviewState === "at_risk" || goal.reviewState === "needs_attention"
-    ).length;
-  }
-  function goalsEqual(a, b) {
-    if (!a || a.length !== b.length) return false;
-    return a.every((goal, i) => {
-      const other = b[i];
-      return goal.id === other.id && goal.title === other.title && goal.status === other.status && goal.reviewState === other.reviewState;
-    });
-  }
-  function GoalsAttentionWidget({
-    spanClassName = "col-span-2 row-span-1"
-  }) {
-    const [goals, setGoals] = (0, import_react71.useState)(null);
-    const nav = useWidgetNavigation();
-    const authenticated = useIsAuthenticated();
-    const load = (0, import_react71.useCallback)(async () => {
-      if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
-        setGoals([]);
-        return;
-      }
-      try {
-        const next = await fetchGoals();
-        setGoals((prev) => goalsEqual(prev, next) ? prev : next);
-      } catch {
-      }
-    }, [authenticated]);
-    (0, import_react71.useEffect)(() => {
-      void load();
-    }, [load]);
-    useIntervalWhenDocumentVisible(() => void load(), GOALS_REFRESH_INTERVAL_MS);
-    const urgent = (0, import_react71.useMemo)(() => goals ? mostUrgentGoal(goals) : null, [goals]);
-    const count3 = (0, import_react71.useMemo)(() => goals ? attentionCount(goals) : 0, [goals]);
-    usePublishHomeAttention(
-      GOALS_WIDGET_KEY,
-      urgent ? HOME_SIGNAL_WEIGHTS.escalation : null
-    );
-    if (goals == null || urgent == null) return null;
-    const tone = urgent.reviewState === "at_risk" ? "danger" : "warn";
-    const status = urgent.reviewState === "at_risk" ? "at risk" : "needs attention";
-    return /* @__PURE__ */ (0, import_jsx_runtime50.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: /* @__PURE__ */ (0, import_jsx_runtime50.jsx)(
-      HomeWidgetCard,
-      {
-        icon: /* @__PURE__ */ (0, import_jsx_runtime50.jsx)(Target, {}),
-        label: "Goals",
-        value: urgent.title,
-        badge: count3 > 1 ? `${count3}` : void 0,
-        tone,
-        testId: "widget-goals-attention",
-        ariaLabel: `Goals: ${count3} need attention, top "${urgent.title}" ${status}. Open Goals.`,
-        onActivate: () => nav.openView("/goals", "goals")
-      }
-    ) });
-  }
-  var GOALS_HOME_WIDGET = {
-    pluginId: "goals",
-    id: "goals.attention",
-    order: 120,
-    signalKinds: ["escalation", "reminder"],
-    Component: GoalsAttentionWidget
-  };
-
-  // packages/ui/src/components/chat/widgets/health-sleep.tsx
-  var import_react72 = __toESM(require_react(), 1);
-  init_home_screen_fixture_api_stub();
-  var import_jsx_runtime51 = __toESM(require_jsx_runtime(), 1);
-  var HEALTH_SLEEP_WIDGET_KEY = "health/health.sleep";
-  var SLEEP_REFRESH_INTERVAL_MS = 2e4;
-  var WINDOW_DAYS = 14;
-  var REGULARITY_CLASSES = /* @__PURE__ */ new Set([
-    "very_regular",
-    "regular",
-    "irregular",
-    "very_irregular",
-    "insufficient_data"
-  ]);
-  var OFF_RHYTHM_LABELS = {
-    irregular: "Irregular",
-    very_irregular: "Very irregular"
-  };
-  function isOffRhythm(classification) {
-    return classification === "irregular" || classification === "very_irregular";
-  }
-  function isEpisode(value) {
-    if (typeof value !== "object" || value === null) return false;
-    const record2 = value;
-    return typeof record2.startedAt === "string" && (record2.endedAt === null || typeof record2.endedAt === "string") && (record2.durationMin === null || typeof record2.durationMin === "number");
-  }
-  function isHistoryResponse(value) {
-    if (typeof value !== "object" || value === null) return false;
-    const episodes = value.episodes;
-    return Array.isArray(episodes) && episodes.every(isEpisode);
-  }
-  function isRegularityResponse(value) {
-    if (typeof value !== "object" || value === null) return false;
-    const classification = value.classification;
-    return typeof classification === "string" && REGULARITY_CLASSES.has(classification);
-  }
-  function parseHistory(value) {
-    if (!isHistoryResponse(value)) return null;
-    return value.episodes[0] ?? null;
-  }
-  function parseRegularity(value) {
-    return isRegularityResponse(value) ? value.classification : null;
-  }
-  async function getJson2(path) {
-    const response = await fetch(`${client.getBaseUrl()}${path}`);
-    if (!response.ok) {
-      throw new Error(`Sleep request failed (${response.status}): ${path}`);
-    }
-    return await response.json();
-  }
-  async function fetchSleep() {
-    const [historyRaw, regularityRaw] = await Promise.all([
-      getJson2(
-        `/api/lifeops/sleep/history?windowDays=${WINDOW_DAYS}&includeNaps=true`
-      ),
-      getJson2(`/api/lifeops/sleep/regularity?windowDays=${WINDOW_DAYS}`)
-    ]);
-    return {
-      latest: parseHistory(historyRaw),
-      classification: parseRegularity(regularityRaw)
-    };
-  }
-  function formatDuration(minutes) {
-    if (minutes === null) return "\u2014";
-    const hours = Math.floor(minutes / 60);
-    const mins = minutes % 60;
-    return hours === 0 ? `${mins}m` : `${hours}h ${mins}m`;
-  }
-  function sleepEqual(a, b) {
-    if (!a) return false;
-    if (a.classification !== b.classification) return false;
-    if (a.latest === b.latest) return true;
-    if (a.latest === null || b.latest === null) return false;
-    return a.latest.startedAt === b.latest.startedAt && a.latest.endedAt === b.latest.endedAt && a.latest.durationMin === b.latest.durationMin;
-  }
-  function HealthSleepWidget({
-    spanClassName = "col-span-2 row-span-1"
-  }) {
-    const [data, setData] = (0, import_react72.useState)(null);
-    const nav = useWidgetNavigation();
-    const authenticated = useIsAuthenticated();
-    const load = (0, import_react72.useCallback)(async () => {
-      if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
-        setData({ latest: null, classification: null });
-        return;
-      }
-      try {
-        const next = await fetchSleep();
-        setData((prev) => sleepEqual(prev, next) ? prev : next);
-      } catch {
-      }
-    }, [authenticated]);
-    (0, import_react72.useEffect)(() => {
-      void load();
-    }, [load]);
-    useIntervalWhenDocumentVisible(() => void load(), SLEEP_REFRESH_INTERVAL_MS);
-    const offRhythm = isOffRhythm(data?.classification ?? null);
-    usePublishHomeAttention(
-      HEALTH_SLEEP_WIDGET_KEY,
-      offRhythm ? HOME_SIGNAL_WEIGHTS["check-in"] : null
-    );
-    if (data == null || !data.latest) return null;
-    const duration3 = formatDuration(data.latest.durationMin);
-    const badge = data.classification && isOffRhythm(data.classification) ? OFF_RHYTHM_LABELS[data.classification] : void 0;
-    const ariaLabel = badge ? `Sleep: last ${duration3}, regularity ${badge.toLowerCase()}. Open Health.` : `Sleep: last ${duration3}. Open Health.`;
-    return /* @__PURE__ */ (0, import_jsx_runtime51.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: /* @__PURE__ */ (0, import_jsx_runtime51.jsx)(
-      HomeWidgetCard,
-      {
-        icon: /* @__PURE__ */ (0, import_jsx_runtime51.jsx)(Moon, {}),
-        label: "Sleep",
-        value: duration3,
-        badge,
-        tone: badge ? "warn" : "default",
-        testId: "widget-health-sleep",
-        ariaLabel,
-        onActivate: () => nav.openView("/health", "health")
-      }
-    ) });
-  }
-  var HEALTH_HOME_WIDGET = {
-    pluginId: "health",
-    id: "health.sleep",
-    order: 140,
-    signalKinds: ["check-in"],
-    Component: HealthSleepWidget
-  };
-
-  // packages/ui/src/components/chat/widgets/inbox-unread.tsx
-  var import_react73 = __toESM(require_react(), 1);
-  init_home_screen_fixture_api_stub();
-  var import_jsx_runtime52 = __toESM(require_jsx_runtime(), 1);
-  var INBOX_WIDGET_KEY = "inbox/inbox.unread";
-  var INBOX_REFRESH_INTERVAL_MS = 2e4;
-  function isRecord3(value) {
-    return typeof value === "object" && value !== null;
-  }
-  function parseUnread(payload) {
-    if (!isRecord3(payload) || !Array.isArray(payload.messages)) return [];
-    const threads = [];
-    for (const message of payload.messages) {
-      if (!isRecord3(message)) continue;
-      if (message.unread !== true) continue;
-      const id = typeof message.id === "string" ? message.id : null;
-      if (!id) continue;
-      const sender = isRecord3(message.sender) && typeof message.sender.displayName === "string" ? message.sender.displayName : "Someone";
-      const subject = typeof message.subject === "string" ? message.subject : "";
-      const priorityScore = typeof message.priorityScore === "number" ? message.priorityScore : 0;
-      const important = message.priorityCategory === "important";
-      threads.push({ id, sender, subject, important, priorityScore });
-    }
-    return threads;
-  }
-  function unreadEqual(a, b) {
-    if (a.length !== b.length) return false;
-    return a.every((thread, i) => {
-      const other = b[i];
-      return thread.id === other.id && thread.sender === other.sender && thread.subject === other.subject && thread.important === other.important && thread.priorityScore === other.priorityScore;
-    });
-  }
-  function InboxUnreadWidget({
-    spanClassName = "col-span-2 row-span-1"
-  }) {
-    const [unread, setUnread] = (0, import_react73.useState)([]);
-    const [loaded, setLoaded] = (0, import_react73.useState)(false);
-    const nav = useWidgetNavigation();
-    const authenticated = useIsAuthenticated();
-    const loadInbox = (0, import_react73.useCallback)(async () => {
-      const baseUrl = client.getBaseUrl();
-      if (!authenticated || !supportsFullAppShellRoutes(baseUrl)) {
-        setLoaded(true);
-        setUnread([]);
-        return;
-      }
-      try {
-        const response = await fetch(`${baseUrl}/api/lifeops/inbox`);
-        if (!response.ok) return;
-        const next = parseUnread(await response.json());
-        setUnread((prev) => unreadEqual(prev, next) ? prev : next);
-      } catch {
-      } finally {
-        setLoaded(true);
-      }
-    }, [authenticated]);
-    (0, import_react73.useEffect)(() => {
-      void loadInbox();
-    }, [loadInbox]);
-    useIntervalWhenDocumentVisible(
-      () => void loadInbox(),
-      INBOX_REFRESH_INTERVAL_MS
-    );
-    usePublishHomeAttention(
-      INBOX_WIDGET_KEY,
-      unread.length > 0 ? HOME_SIGNAL_WEIGHTS.message : null
-    );
-    const top = (0, import_react73.useMemo)(() => {
-      if (unread.length === 0) return null;
-      return unread.reduce(
-        (best, thread) => thread.priorityScore > best.priorityScore ? thread : best
-      );
-    }, [unread]);
-    const hasImportant = (0, import_react73.useMemo)(
-      () => unread.some((thread) => thread.important),
-      [unread]
-    );
-    if (!loaded || top == null) return null;
-    const datum = top.sender !== "Someone" ? top.sender : top.subject || top.sender;
-    const tone = hasImportant ? "warn" : "default";
-    return /* @__PURE__ */ (0, import_jsx_runtime52.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(
-      HomeWidgetCard,
-      {
-        icon: /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(Inbox, {}),
-        label: "Inbox",
-        value: datum,
-        badge: unread.length,
-        tone,
-        testId: "chat-widget-inbox-unread",
-        ariaLabel: `Inbox: ${unread.length} unread thread${unread.length === 1 ? "" : "s"} need a reply, top from ${datum}. Open Inbox.`,
-        onActivate: () => nav.openView("/inbox", "inbox")
-      }
-    ) });
-  }
-  var INBOX_HOME_WIDGET = {
-    pluginId: "inbox",
-    id: "inbox.unread",
-    order: 85,
-    signalKinds: ["message", "approval"],
-    Component: InboxUnreadWidget
-  };
-
-  // packages/ui/src/components/chat/widgets/model-download.tsx
-  var import_react74 = __toESM(require_react(), 1);
-  init_home_screen_fixture_api_stub();
-
-  // packages/ui/src/services/local-inference/home-model-status.ts
-  function maxOrNull(values) {
-    return values.length > 0 ? Math.max(...values) : null;
-  }
-  function firstModelName(slots) {
-    for (const slot of slots) {
-      if (slot.displayName) return slot.displayName;
-    }
-    return null;
-  }
-  function firstModelId(slots) {
-    for (const slot of slots) {
-      if (slot.assignedModelId) return slot.assignedModelId;
-    }
-    return null;
-  }
-  function deriveHomeModelStatus(readiness) {
-    const assigned = Object.values(readiness.slots).filter(
-      (slot) => slot.assigned
-    );
-    const modelName = firstModelName(assigned);
-    const modelId = firstModelId(assigned);
-    if (assigned.length === 0) {
-      return {
-        kind: "not-required",
-        blocksSend: false,
-        percent: null,
-        etaMs: null,
-        modelName: null,
-        errors: []
-      };
-    }
-    if (assigned.every((slot) => slot.ready)) {
-      return {
-        kind: "ready",
-        blocksSend: false,
-        percent: null,
-        etaMs: null,
-        modelName,
-        modelId,
-        errors: []
-      };
-    }
-    const failed = assigned.filter(
-      (slot) => slot.state === "failed" || slot.state === "cancelled"
-    );
-    if (failed.length > 0) {
-      return {
-        kind: "error",
-        blocksSend: true,
-        percent: null,
-        etaMs: null,
-        modelName,
-        modelId,
-        errors: [...new Set(failed.flatMap((slot) => slot.errors))]
-      };
-    }
-    const downloading = assigned.filter((slot) => slot.state === "downloading");
-    if (downloading.length > 0) {
-      const percents = downloading.map((slot) => slot.download.percent).filter((value) => value !== null);
-      const etas = downloading.map((slot) => slot.download.etaMs).filter((value) => value !== null);
-      return {
-        kind: "downloading",
-        blocksSend: true,
-        percent: maxOrNull(percents),
-        etaMs: maxOrNull(etas),
-        modelName,
-        modelId,
-        errors: []
-      };
-    }
-    const missing = assigned.some(
-      (slot) => slot.state === "missing" || slot.state === "unassigned"
-    );
-    if (missing) {
-      return {
-        kind: "missing",
-        blocksSend: true,
-        percent: null,
-        etaMs: null,
-        modelName,
-        modelId,
-        errors: []
-      };
-    }
-    return {
-      kind: "loading",
-      blocksSend: true,
-      percent: 100,
-      etaMs: null,
-      modelName,
-      modelId,
-      errors: []
-    };
-  }
-
-  // packages/ui/src/utils/event-source.ts
-  function openEventSource(url2, init) {
-    if (typeof EventSource === "undefined") return null;
-    const base = typeof window !== "undefined" ? window.location.href : "http://localhost";
-    let parsed;
-    try {
-      parsed = new URL(url2, base);
-    } catch {
-      return null;
-    }
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return null;
-    }
-    try {
-      return new EventSource(url2, init);
-    } catch {
-      return null;
-    }
-  }
-
-  // packages/ui/src/components/chat/widgets/model-download.tsx
-  var import_jsx_runtime53 = __toESM(require_jsx_runtime(), 1);
-  var DEFAULT_SPAN4 = "col-span-4 row-span-2";
-  var HUB_TIMEOUT_MS = 6e3;
-  var STREAM_REFETCH_DEBOUNCE_MS = 400;
-  var LOCAL_INFERENCE_VIEW_PATH = "/settings#ai-model";
-  var LOCAL_INFERENCE_VIEW_ID = "settings";
-  var NOT_REQUIRED_STATUS = {
-    kind: "not-required",
-    blocksSend: false,
-    percent: null,
-    etaMs: null,
-    modelName: null,
-    errors: []
-  };
-  var INITIAL = {
-    status: NOT_REQUIRED_STATUS,
-    rows: [],
-    loading: true
-  };
-  function appendTokenParam(url2) {
-    const token = getElizaApiToken()?.trim();
-    if (!token) return url2;
-    return `${url2}${url2.includes("?") ? "&" : "?"}token=${encodeURIComponent(token)}`;
-  }
-  function rowsFromReadiness(slots) {
-    return Object.values(slots).filter((slot) => slot.assigned).map((slot) => ({
-      slot: slot.slot,
-      modelId: slot.assignedModelId,
-      displayName: slot.displayName,
-      state: slot.state
-    }));
-  }
-  function useLocalModelDownloads() {
-    const [state4, setState3] = (0, import_react74.useState)(INITIAL);
-    const refreshTimerRef = (0, import_react74.useRef)(null);
-    const authenticated = useIsAuthenticated();
-    (0, import_react74.useEffect)(() => {
-      if (!authenticated) {
-        setState3(INITIAL);
-        return;
-      }
-      let cancelled = false;
-      const refresh = async () => {
-        try {
-          const hub = await withTimeout(
-            client.getLocalInferenceHub(),
-            HUB_TIMEOUT_MS
-          );
-          if (cancelled) return;
-          setState3({
-            status: deriveHomeModelStatus(hub.textReadiness),
-            rows: rowsFromReadiness(hub.textReadiness.slots),
-            loading: false
-          });
-        } catch {
-          if (cancelled) return;
-          setState3((prev) => prev.loading ? { ...prev, loading: false } : prev);
-        }
-      };
-      void refresh();
-      const url2 = appendTokenParam(
-        resolveApiUrl("/api/local-inference/downloads/stream")
-      );
-      const es = openEventSource(url2, { withCredentials: false });
-      if (es) {
-        es.onmessage = () => {
-          if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
-          refreshTimerRef.current = setTimeout(
-            () => void refresh(),
-            STREAM_REFETCH_DEBOUNCE_MS
-          );
-        };
-      }
-      return () => {
-        cancelled = true;
-        if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
-        es?.close();
-      };
-    }, [authenticated]);
-    return state4;
-  }
-  function roundedPercent(percent) {
-    if (percent == null || !Number.isFinite(percent)) return null;
-    return Math.max(0, Math.min(100, Math.round(percent)));
-  }
-  function formatEta(etaMs) {
-    if (etaMs == null || !Number.isFinite(etaMs) || etaMs <= 0) return null;
-    const totalSeconds = Math.round(etaMs / 1e3);
-    if (totalSeconds < 60) return `~${totalSeconds}s left`;
-    const minutes = Math.round(totalSeconds / 60);
-    if (minutes < 60) return `~${minutes}m left`;
-    const hours = Math.round(minutes / 60);
-    return `~${hours}h left`;
-  }
-  function ModelDownloadWidget({
-    spanClassName = DEFAULT_SPAN4
-  }) {
-    const { status, rows, loading } = useLocalModelDownloads();
-    const nav = useWidgetNavigation();
-    const [retrying, setRetrying] = (0, import_react74.useState)(false);
-    const failedRow = rows.find(
-      (row) => row.state === "failed" || row.state === "cancelled"
-    );
-    const failedModelId = failedRow?.modelId ?? null;
-    (0, import_react74.useEffect)(() => {
-      if (status.kind !== "error") setRetrying(false);
-    }, [status.kind]);
-    const retry = (0, import_react74.useCallback)(async () => {
-      if (!failedModelId) {
-        nav.openView(LOCAL_INFERENCE_VIEW_PATH, LOCAL_INFERENCE_VIEW_ID);
-        return;
-      }
-      setRetrying(true);
-      try {
-        await client.startLocalInferenceDownload(failedModelId);
-      } catch {
-        setRetrying(false);
-      }
-    }, [failedModelId, nav]);
-    const openSettings = (0, import_react74.useCallback)(() => {
-      nav.openView(LOCAL_INFERENCE_VIEW_PATH, LOCAL_INFERENCE_VIEW_ID);
-    }, [nav]);
-    if (loading) return null;
-    if (status.kind === "not-required" || status.kind === "ready") return null;
-    const modelName = status.modelName ?? "Local model";
-    if (status.kind === "error" && !retrying) {
-      const detail = status.errors.find((message) => message.trim().length > 0);
-      return /* @__PURE__ */ (0, import_jsx_runtime53.jsx)("div", { className: spanClassName, children: /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(
-        ModelProgressCard,
-        {
-          icon: /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(TriangleAlert, {}),
-          value: `${modelName} download failed`,
-          meta: detail ? truncateDetail(detail) : void 0,
-          badge: "Retry",
-          tone: "danger",
-          percent: null,
-          ariaLabel: `${modelName} download failed${detail ? `: ${detail}` : ""}. Tap to retry the download.`,
-          onActivate: () => void retry()
-        }
-      ) });
-    }
-    if (status.kind === "downloading" || retrying) {
-      const percent = roundedPercent(status.percent);
-      const eta = formatEta(status.etaMs);
-      return /* @__PURE__ */ (0, import_jsx_runtime53.jsx)("div", { className: spanClassName, children: /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(
-        ModelProgressCard,
-        {
-          icon: /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(Download, {}),
-          value: `Downloading ${modelName}`,
-          meta: percent != null ? `${percent}%${eta ? ` \xB7 ${eta}` : ""}` : void 0,
-          percent: status.percent,
-          ariaLabel: `Downloading ${modelName}${percent != null ? `, ${percent} percent` : ""}${eta ? `, ${eta}` : ""}. Tap to manage local models.`,
-          onActivate: openSettings
-        }
-      ) });
-    }
-    if (status.kind === "loading") {
-      return /* @__PURE__ */ (0, import_jsx_runtime53.jsx)("div", { className: spanClassName, children: /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(
-        ModelProgressCard,
-        {
-          icon: /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(LoaderCircle, { className: "animate-spin" }),
-          value: `Loading ${modelName}\u2026`,
-          percent: null,
-          indeterminate: true,
-          ariaLabel: `Loading ${modelName} into the local runtime. Tap to manage local models.`,
-          onActivate: openSettings
-        }
-      ) });
-    }
-    return /* @__PURE__ */ (0, import_jsx_runtime53.jsx)("div", { className: spanClassName, children: /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(
-      ModelProgressCard,
-      {
-        icon: /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(Download, {}),
-        value: `Queued ${modelName}`,
-        percent: 0,
-        ariaLabel: `${modelName} is queued for download. Tap to manage local models.`,
-        onActivate: openSettings
-      }
-    ) });
-  }
-  function ModelProgressCard({
-    icon,
-    value,
-    meta: meta3,
-    badge,
-    tone = "default",
-    percent,
-    indeterminate = false,
-    ariaLabel,
-    onActivate
-  }) {
-    const fill = percent == null ? null : Math.max(0, Math.min(100, Math.round(percent)));
-    return /* @__PURE__ */ (0, import_jsx_runtime53.jsxs)(
-      Button,
-      {
-        "data-testid": "chat-widget-model-download",
-        "aria-label": ariaLabel,
-        onClick: onActivate,
-        variant: "ghost",
-        className: "group flex h-full w-full flex-col items-stretch justify-center gap-2.5 whitespace-normal px-3 py-2.5 text-left font-normal transition-opacity hover:opacity-80",
-        children: [
-          /* @__PURE__ */ (0, import_jsx_runtime53.jsxs)("span", { className: "flex w-full items-center gap-3", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(
-              "span",
-              {
-                className: cn(
-                  "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/10 text-white/85 [&>svg]:h-4 [&>svg]:w-4",
-                  tone === "danger" && "text-danger"
-                ),
-                children: icon
-              }
-            ),
-            /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(
-              "span",
-              {
-                className: cn(
-                  "min-w-0 flex-1 truncate text-sm font-semibold leading-tight",
-                  tone === "danger" ? "text-danger" : "text-white"
-                ),
-                children: value
-              }
-            ),
-            meta3 != null ? /* @__PURE__ */ (0, import_jsx_runtime53.jsx)("span", { className: "shrink-0 text-2xs tabular-nums text-white/60", children: meta3 }) : null,
-            badge != null ? /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(
-              "span",
-              {
-                className: cn(
-                  "shrink-0 rounded-full px-1.5 py-0.5 text-2xs font-semibold",
-                  tone === "danger" ? "bg-danger/15 text-danger" : "bg-accent-subtle text-accent"
-                ),
-                children: badge
-              }
-            ) : null
-          ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(
-            "span",
-            {
-              "aria-hidden": "true",
-              "data-testid": "chat-widget-model-download-track",
-              className: "h-1.5 w-full overflow-hidden rounded-full bg-white/10",
-              children: indeterminate ? /* @__PURE__ */ (0, import_jsx_runtime53.jsx)("span", { className: "block h-full w-full animate-pulse rounded-full bg-accent/70 motion-reduce:animate-none" }) : fill != null ? /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(
-                "span",
-                {
-                  className: cn(
-                    "block h-full rounded-full transition-[width] duration-500",
-                    tone === "danger" ? "bg-danger/70" : "bg-accent"
-                  ),
-                  style: { width: `${fill}%` }
-                }
-              ) : null
-            }
-          )
-        ]
-      }
-    );
-  }
-  function truncateDetail(detail) {
-    const trimmed = detail.trim();
-    return trimmed.length > 40 ? `${trimmed.slice(0, 39)}\u2026` : trimmed;
-  }
-  var MODEL_DOWNLOAD_HOME_WIDGET = {
-    pluginId: "local-inference",
-    id: "local-inference.model-download",
-    // High order so the tile surfaces near the top of the home grid while a model
-    // is downloading (it self-hides once ready, so it never permanently crowds).
-    order: 55,
-    size: "4x2",
-    signalKinds: ["activity", "notification"],
-    Component: ModelDownloadWidget
-  };
-
-  // packages/ui/src/components/chat/widgets/music-player.tsx
-  var import_react75 = __toESM(require_react(), 1);
-  var import_jsx_runtime54 = __toESM(require_jsx_runtime(), 1);
-  var MEDIA_ERROR_NAMES = {
-    1: "MEDIA_ERR_ABORTED",
-    2: "MEDIA_ERR_NETWORK",
-    3: "MEDIA_ERR_DECODE",
-    4: "MEDIA_ERR_SRC_NOT_SUPPORTED"
-  };
-  function statusLabel2(state4) {
-    if (state4.kind === "playing") return state4.isPaused ? "Paused" : "Live";
-    if (state4.kind === "loading") return "Loading";
-    if (state4.kind === "error") return "Unavailable";
-    return "Idle";
-  }
-  function MusicPlayerSidebarWidget(_props) {
-    const audioRef = (0, import_react75.useRef)(null);
-    const lastAttachedTrack = (0, import_react75.useRef)(null);
-    const [player, setPlayer] = (0, import_react75.useState)({ kind: "idle" });
-    const [audioError, setAudioError] = (0, import_react75.useState)(null);
-    const [audioPaused, setAudioPaused] = (0, import_react75.useState)(true);
-    const isPlaying = player.kind === "playing";
-    const authenticated = useIsAuthenticated();
-    const pollOnce = (0, import_react75.useCallback)(async () => {
-      if (!authenticated) return;
-      setPlayer((prev) => prev.kind === "idle" ? { kind: "loading" } : prev);
-      try {
-        const res = await fetchWithCsrf(resolveApiUrl("/music-player/status"));
-        const data = await res.json();
-        if (!res.ok) {
-          setPlayer({ kind: "error", message: data.error ?? res.statusText });
-          return;
-        }
-        if (data.track?.title && data.guildId && data.streamUrl) {
-          setPlayer({
-            kind: "playing",
-            title: data.track.title,
-            guildId: data.guildId,
-            streamUrl: resolveApiUrl(data.streamUrl),
-            isPaused: data.isPaused === true
-          });
-          return;
-        }
-        setPlayer({ kind: "idle" });
-        setAudioPaused(true);
-      } catch {
-        setPlayer({
-          kind: "error",
-          message: "Could not reach the music player."
-        });
-        setAudioPaused(true);
-      }
-    }, [authenticated]);
-    (0, import_react75.useEffect)(() => {
-      void pollOnce();
-    }, [pollOnce]);
-    useIntervalWhenDocumentVisible(() => void pollOnce(), 5e3);
-    (0, import_react75.useEffect)(() => {
-      const el = audioRef.current;
-      if (!el) return;
-      if (player.kind !== "playing") {
-        el.pause();
-        el.removeAttribute("src");
-        el.load();
-        lastAttachedTrack.current = null;
-        return;
-      }
-      const key = `${player.guildId}::${player.title}`;
-      if (lastAttachedTrack.current !== key) {
-        lastAttachedTrack.current = key;
-        setAudioError(null);
-        setAudioPaused(true);
-        el.src = player.streamUrl;
-        el.load();
-      }
-      if (player.isPaused) {
-        el.pause();
-        setAudioPaused(true);
-        return;
-      }
-      el.play().catch(() => {
-      });
-    }, [player]);
-    (0, import_react75.useEffect)(() => {
-      const el = audioRef.current;
-      if (!el) return;
-      const handlePlay = () => setAudioPaused(false);
-      const handlePause = () => setAudioPaused(true);
-      const handler = () => {
-        const err = el.error;
-        const code = err?.code ?? 0;
-        const name = MEDIA_ERROR_NAMES[code] ?? `UNKNOWN(${code})`;
-        setAudioError(`${name}: ${err?.message || "no details"}`);
-      };
-      el.addEventListener("play", handlePlay);
-      el.addEventListener("pause", handlePause);
-      el.addEventListener("error", handler);
-      return () => {
-        el.removeEventListener("play", handlePlay);
-        el.removeEventListener("pause", handlePause);
-        el.removeEventListener("error", handler);
-      };
-    }, []);
-    function togglePlayback() {
-      const el = audioRef.current;
-      if (!el || player.kind !== "playing" || !player.streamUrl) return;
-      if (el.paused) {
-        void el.play();
-        return;
-      }
-      el.pause();
-    }
-    return /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(
-      WidgetSection,
-      {
-        title: "Music",
-        icon: /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(Music, { className: "h-3.5 w-3.5" }),
-        testId: "chat-widget-music-player",
-        action: /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(
-          Button,
-          {
-            variant: "ghost",
-            size: "icon-sm",
-            onClick: () => void pollOnce(),
-            "aria-label": "Refresh music player",
-            className: "h-5 w-5 rounded-sm bg-transparent p-0 text-muted transition-colors hover:bg-transparent hover:text-txt",
-            children: /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(RefreshCw, { className: "h-3 w-3", "aria-hidden": true })
-          }
-        ),
-        children: /* @__PURE__ */ (0, import_jsx_runtime54.jsxs)("div", { className: "flex flex-col gap-2 pt-0.5", children: [
-          isPlaying ? /* @__PURE__ */ (0, import_jsx_runtime54.jsxs)("div", { className: "flex items-center gap-2", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(
-              Button,
-              {
-                variant: "ghost",
-                size: "icon-sm",
-                onClick: togglePlayback,
-                "aria-label": audioPaused ? "Play music" : "Pause music",
-                title: audioPaused ? "Play" : "Pause",
-                className: "h-7 w-7 shrink-0 rounded-sm bg-transparent p-0 text-muted transition-colors hover:bg-transparent hover:text-txt",
-                children: audioPaused ? /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(Play, { className: "h-3.5 w-3.5", "aria-hidden": true }) : /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(Pause, { className: "h-3.5 w-3.5", "aria-hidden": true })
-              }
-            ),
-            /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(
-              "span",
-              {
-                className: `h-1.5 w-1.5 shrink-0 rounded-full ${player.isPaused ? "bg-warn" : "bg-ok"}`,
-                "aria-hidden": true
-              }
-            ),
-            /* @__PURE__ */ (0, import_jsx_runtime54.jsx)("span", { className: "min-w-0 flex-1 truncate text-3xs font-semibold text-txt", children: player.title }),
-            /* @__PURE__ */ (0, import_jsx_runtime54.jsx)("span", { className: "shrink-0 text-3xs uppercase tracking-wider text-muted/70", children: statusLabel2(player) })
-          ] }) : /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(
-            EmptyWidgetState,
-            {
-              icon: /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(Music, { className: "h-5 w-5" }),
-              title: player.kind === "error" ? player.message : "No music stream is active.",
-              description: "Ask the agent to play music in chat."
-            }
-          ),
-          /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(
-            "audio",
-            {
-              ref: audioRef,
-              className: "hidden",
-              "aria-label": "Agent music stream"
-            }
-          ),
-          audioError ? /* @__PURE__ */ (0, import_jsx_runtime54.jsx)("p", { className: "break-words font-mono text-3xs text-warn", children: audioError }) : null
-        ] })
-      }
-    );
-  }
-
-  // packages/ui/src/components/chat/widgets/music-player.helpers.ts
-  var MUSIC_PLAYER_WIDGET = {
-    id: "music-player.stream",
-    pluginId: "music-player",
-    order: 125,
-    defaultEnabled: true,
-    Component: MusicPlayerSidebarWidget
-  };
-
-  // packages/ui/src/components/chat/widgets/needs-attention.tsx
-  var import_react76 = __toESM(require_react(), 1);
-  init_home_screen_fixture_api_stub();
-  init_events3();
-  var import_jsx_runtime55 = __toESM(require_jsx_runtime(), 1);
-  var NEEDS_ATTENTION_WIDGET_KEY = "needs-attention/needs-attention.pending";
-  var REFRESH_INTERVAL_MS = 2e4;
-  var STALE_PENDING_AGE_MS = 30 * 6e4;
-  function pendingEqual(a, b) {
-    if (a.length !== b.length) return false;
-    return a.every((item, i) => {
-      const other = b[i];
-      return item.id === other.id && item.title === other.title && item.createdAt === other.createdAt;
-    });
-  }
-  function useApprovals() {
-    const [pending, setPending] = (0, import_react76.useState)([]);
-    const [loaded, setLoaded] = (0, import_react76.useState)(false);
-    const mountedRef = (0, import_react76.useRef)(true);
-    const authenticated = useIsAuthenticated();
-    const load = (0, import_react76.useCallback)(async () => {
-      if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
-        if (mountedRef.current) {
-          setPending([]);
-          setLoaded(true);
-        }
-        return;
-      }
-      try {
-        const { pending: next } = await client.listPendingActions();
-        if (!mountedRef.current) return;
-        setPending((prev) => pendingEqual(prev, next) ? prev : next);
-      } catch {
-      } finally {
-        if (mountedRef.current) {
-          setLoaded(true);
-        }
-      }
-    }, [authenticated]);
-    (0, import_react76.useEffect)(
-      () => () => {
-        mountedRef.current = false;
-      },
-      []
-    );
-    (0, import_react76.useEffect)(() => {
-      void load();
-    }, [load]);
-    useIntervalWhenDocumentVisible(() => void load(), REFRESH_INTERVAL_MS);
-    return { pending, loaded };
-  }
-  function oldestPending(pending) {
-    if (pending.length === 0) return null;
-    return pending.reduce(
-      (oldest, item) => item.createdAt < oldest.createdAt ? item : oldest
-    );
-  }
-  function NeedsAttentionWidget({
-    spanClassName = "col-span-2 row-span-1"
-  }) {
-    const { pending, loaded } = useApprovals();
-    const now2 = useNow(REFRESH_INTERVAL_MS);
-    const top = (0, import_react76.useMemo)(() => oldestPending(pending), [pending]);
-    const weight = (0, import_react76.useMemo)(() => {
-      if (top == null) return null;
-      const stale2 = now2 - top.createdAt >= STALE_PENDING_AGE_MS;
-      return stale2 ? HOME_SIGNAL_WEIGHTS.escalation : HOME_SIGNAL_WEIGHTS.approval;
-    }, [top, now2]);
-    usePublishHomeAttention(NEEDS_ATTENTION_WIDGET_KEY, weight);
-    const onActivate = (0, import_react76.useCallback)(() => {
-      if (top == null) return;
-      dispatchChatPrefill({ text: `Approve: ${top.title}`, select: true });
-    }, [top]);
-    if (!loaded || top == null) return null;
-    const count3 = pending.length;
-    const stale = now2 - top.createdAt >= STALE_PENDING_AGE_MS;
-    return /* @__PURE__ */ (0, import_jsx_runtime55.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: /* @__PURE__ */ (0, import_jsx_runtime55.jsx)(
-      HomeWidgetCard,
-      {
-        icon: /* @__PURE__ */ (0, import_jsx_runtime55.jsx)(CircleQuestionMark, {}),
-        label: "Needs response",
-        value: top.title,
-        badge: count3,
-        tone: stale ? "warn" : "default",
-        testId: "chat-widget-needs-attention",
-        ariaLabel: `${count3} action${count3 === 1 ? "" : "s"} need your response, oldest: ${top.title}. Respond in chat.`,
-        onActivate
-      }
-    ) });
-  }
-  var NEEDS_ATTENTION_HOME_WIDGET = {
-    pluginId: "needs-attention",
-    id: "needs-attention.pending",
-    order: 60,
-    signalKinds: ["approval", "escalation"],
-    Component: NeedsAttentionWidget
-  };
-
-  // packages/ui/src/state/notifications/category-icon.tsx
-  var import_jsx_runtime56 = __toESM(require_jsx_runtime(), 1);
-  var CATEGORY_ICON = {
-    reminder: /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(Clock, { className: "h-4 w-4" }),
-    task: /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(Check, { className: "h-4 w-4" }),
-    workflow: /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(Workflow, { className: "h-4 w-4" }),
-    agent: /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(Bot, { className: "h-4 w-4" }),
-    approval: /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(FileExclamationPoint, { className: "h-4 w-4" }),
-    message: /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(MessageSquare, { className: "h-4 w-4" }),
-    health: /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(HeartPulse, { className: "h-4 w-4" }),
-    system: /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(Settings2, { className: "h-4 w-4" }),
-    general: /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(CircleAlert, { className: "h-4 w-4" })
-  };
-  function categoryIcon(category) {
-    return CATEGORY_ICON[category] ?? CATEGORY_ICON.general;
-  }
-
-  // packages/ui/src/components/chat/widgets/notifications.tsx
-  init_navigate_deep_link();
-  init_notification_store();
-  var import_jsx_runtime57 = __toESM(require_jsx_runtime(), 1);
-  var MAX_HOME_NOTIFICATIONS = 4;
-  function NotificationRow({
-    notification
-  }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime57.jsxs)("li", { className: "flex items-start gap-1.5 px-1 py-1", children: [
-      /* @__PURE__ */ (0, import_jsx_runtime57.jsx)(
-        "span",
-        {
-          className: "mt-0.5 shrink-0 text-muted [&_svg]:h-3.5 [&_svg]:w-3.5",
-          "data-testid": "notification-row-icon",
-          "aria-hidden": true,
-          children: categoryIcon(notification.category)
-        }
-      ),
-      /* @__PURE__ */ (0, import_jsx_runtime57.jsxs)("span", { className: "flex min-w-0 flex-col gap-0.5", children: [
-        /* @__PURE__ */ (0, import_jsx_runtime57.jsx)("span", { className: "truncate text-xs font-medium text-txt", children: notification.title }),
-        notification.body ? /* @__PURE__ */ (0, import_jsx_runtime57.jsx)("span", { className: "truncate text-2xs text-muted", children: notification.body }) : null
-      ] })
-    ] });
-  }
-  function NotificationsWidget(props) {
-    const { notifications, unreadCount } = useNotifications();
-    const nav = useWidgetNavigation();
-    const ranked = rankHomeNotifications(notifications);
-    const recent = ranked.slice(0, MAX_HOME_NOTIFICATIONS);
-    if (recent.length === 0) {
-      return null;
-    }
-    if (props.slot === "home") {
-      const top = recent[0];
-      const urgent = top.priority === "urgent";
-      return /* @__PURE__ */ (0, import_jsx_runtime57.jsx)(
-        "div",
-        {
-          className: `min-w-0 ${props.spanClassName ?? "col-span-2 row-span-1"}`,
-          children: /* @__PURE__ */ (0, import_jsx_runtime57.jsx)(
-            HomeWidgetCard,
-            {
-              icon: categoryIcon(top.category),
-              label: "Notifications",
-              value: top.title,
-              badge: unreadCount > 0 ? unreadCount : void 0,
-              tone: urgent ? "danger" : top.priority === "high" ? "warn" : "default",
-              testId: "widget-notifications",
-              ariaLabel: `Notifications: ${unreadCount} unread, latest ${top.title}. Open inbox.`,
-              onActivate: () => {
-                if (!top.readAt) void markNotificationRead(top.id);
-                if (top.deepLink && isSafeDeepLink(top.deepLink)) {
-                  navigateDeepLink(top.deepLink);
-                } else {
-                  nav.openView("/inbox", "inbox");
-                }
-              }
-            }
-          )
-        }
-      );
-    }
-    return /* @__PURE__ */ (0, import_jsx_runtime57.jsx)(
-      WidgetSection,
-      {
-        title: "Notifications",
-        icon: /* @__PURE__ */ (0, import_jsx_runtime57.jsx)(Bell, {}),
-        testId: "widget-notifications",
-        action: unreadCount > 0 ? /* @__PURE__ */ (0, import_jsx_runtime57.jsx)("span", { className: "rounded-full bg-accent-subtle px-1.5 text-2xs font-medium text-accent", children: unreadCount }) : void 0,
-        children: /* @__PURE__ */ (0, import_jsx_runtime57.jsx)("ul", { className: "flex flex-col gap-0.5", children: recent.map((n) => /* @__PURE__ */ (0, import_jsx_runtime57.jsx)(NotificationRow, { notification: n }, n.id)) })
-      }
-    );
-  }
-
-  // packages/ui/src/components/chat/widgets/relationships-attention.tsx
-  var import_react77 = __toESM(require_react(), 1);
-  init_home_screen_fixture_api_stub();
-  var import_jsx_runtime58 = __toESM(require_jsx_runtime(), 1);
-  var RELATIONSHIPS_WIDGET_KEY = "relationships/relationships.attention";
-  var RELATIONSHIPS_REFRESH_INTERVAL_MS = 3e4;
-  var EMPTY_DATA = {
-    pendingCandidates: [],
-    staleContacts: []
-  };
-  function isRecord4(value) {
-    return typeof value === "object" && value !== null;
-  }
-  function pendingCandidatesFrom(candidates) {
-    if (!Array.isArray(candidates)) return [];
-    return candidates.filter(
-      (candidate) => isRecord4(candidate) && typeof candidate.id === "string" && candidate.status === "pending"
-    );
-  }
-  function toTimestamp(iso) {
-    if (!iso) return 0;
-    const parsed = Date.parse(iso);
-    return Number.isNaN(parsed) ? 0 : parsed;
-  }
-  function staleContactsFrom(people) {
-    if (!Array.isArray(people)) return [];
-    return people.filter(
-      (person) => isRecord4(person) && typeof person.displayName === "string" && !person.isOwner
-    ).sort(
-      (left, right) => toTimestamp(left.lastInteractionAt) - toTimestamp(right.lastInteractionAt)
-    );
-  }
-  function relationshipsEqual(a, b) {
-    if (a.pendingCandidates.length !== b.pendingCandidates.length || a.staleContacts.length !== b.staleContacts.length) {
-      return false;
-    }
-    const sameCandidates = a.pendingCandidates.every(
-      (candidate, i) => candidate.id === b.pendingCandidates[i].id
-    );
-    if (!sameCandidates) return false;
-    return a.staleContacts.every((person, i) => {
-      const other = b.staleContacts[i];
-      return person.groupId === other.groupId && person.lastInteractionAt === other.lastInteractionAt;
-    });
-  }
-  function RelationshipsAttentionWidget({
-    slot,
-    spanClassName = "col-span-2 row-span-1"
-  }) {
-    const [data, setData] = (0, import_react77.useState)(EMPTY_DATA);
-    const nav = useWidgetNavigation();
-    const authenticated = useIsAuthenticated();
-    const load = (0, import_react77.useCallback)(async () => {
-      if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
-        setData(EMPTY_DATA);
-        return;
-      }
-      try {
-        const [peopleResult, candidates] = await Promise.all([
-          client.getRelationshipsPeople(),
-          client.getRelationshipsCandidates()
-        ]);
-        const next = {
-          pendingCandidates: pendingCandidatesFrom(candidates),
-          staleContacts: staleContactsFrom(peopleResult.people)
-        };
-        setData((prev) => relationshipsEqual(prev, next) ? prev : next);
-      } catch {
-      }
-    }, [authenticated]);
-    (0, import_react77.useEffect)(() => {
-      void load();
-    }, [load]);
-    useIntervalWhenDocumentVisible(
-      () => void load(),
-      RELATIONSHIPS_REFRESH_INTERVAL_MS
-    );
-    const pendingCount = data.pendingCandidates.length;
-    const hasPendingMerge = pendingCount > 0;
-    const stalest = (0, import_react77.useMemo)(() => data.staleContacts[0] ?? null, [data]);
-    const hasContacts = stalest != null;
-    const onHome = slot === "home";
-    usePublishHomeAttention(
-      RELATIONSHIPS_WIDGET_KEY,
-      onHome && hasPendingMerge ? HOME_SIGNAL_WEIGHTS.approval : null
-    );
-    if (!hasPendingMerge && !hasContacts) return null;
-    if (hasPendingMerge) {
-      return /* @__PURE__ */ (0, import_jsx_runtime58.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: /* @__PURE__ */ (0, import_jsx_runtime58.jsx)(
-        HomeWidgetCard,
-        {
-          icon: /* @__PURE__ */ (0, import_jsx_runtime58.jsx)(Users, {}),
-          label: "People",
-          value: "Confirm merge?",
-          badge: pendingCount,
-          tone: "warn",
-          testId: "chat-widget-relationships",
-          ariaLabel: `People: ${pendingCount} merge ${pendingCount === 1 ? "candidate" : "candidates"} to confirm. Open Relationships.`,
-          onActivate: () => nav.openView("/relationships", "relationships")
-        }
-      ) });
-    }
-    return /* @__PURE__ */ (0, import_jsx_runtime58.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: /* @__PURE__ */ (0, import_jsx_runtime58.jsx)(
-      HomeWidgetCard,
-      {
-        icon: /* @__PURE__ */ (0, import_jsx_runtime58.jsx)(Users, {}),
-        label: "Reach out",
-        value: stalest.displayName,
-        tone: "default",
-        testId: "chat-widget-relationships",
-        ariaLabel: `Reach out: you haven't talked to ${stalest.displayName} in a while. Open Relationships.`,
-        onActivate: () => nav.openView("/relationships", "relationships")
-      }
-    ) });
-  }
-  var RELATIONSHIPS_HOME_WIDGET = {
-    pluginId: "relationships",
-    id: "relationships.attention",
-    order: 90,
-    signalKinds: ["nudge", "approval"],
-    Component: RelationshipsAttentionWidget
-  };
-
-  // packages/ui/src/components/chat/widgets/todo.tsx
-  var import_react78 = __toESM(require_react(), 1);
-  init_home_screen_fixture_api_stub();
-
-  // packages/ui/src/components/ui/badge.tsx
-  var import_jsx_runtime59 = __toESM(require_jsx_runtime(), 1);
-  var badgeVariants = cva(
-    "inline-flex items-center rounded-sm border px-2.5 py-0.5 text-xs font-semibold transition-colors    ",
-    {
-      variants: {
-        variant: {
-          default: "border-transparent bg-primary text-primary-fg hover:bg-primary/80",
-          secondary: "border-transparent bg-bg-accent text-txt hover:bg-bg-hover",
-          destructive: "border-transparent bg-destructive text-destructive-fg hover:bg-destructive/80",
-          outline: "text-txt border-border"
-        }
-      },
-      defaultVariants: {
-        variant: "default"
-      }
-    }
-  );
-  function Badge({ className, variant, ...props }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { className: cn(badgeVariants({ variant }), className), ...props });
-  }
-
-  // packages/ui/src/components/chat/widgets/todo.tsx
-  var import_jsx_runtime60 = __toESM(require_jsx_runtime(), 1);
-  var TODO_WIDGET_KEY = "todo/todo.items";
-  var TODO_REFRESH_INTERVAL_MS = 15e3;
-  var MAX_VISIBLE_TODOS = 8;
-  var fallbackTranslate2 = (key, vars) => typeof vars?.defaultValue === "string" ? vars.defaultValue : key;
-  function sortTodosForWidget(todos) {
-    return [...todos].sort((left, right) => {
-      if (left.isCompleted !== right.isCompleted) {
-        return left.isCompleted ? 1 : -1;
-      }
-      if (left.isUrgent !== right.isUrgent) {
-        return left.isUrgent ? -1 : 1;
-      }
-      const leftPriority = left.priority ?? Number.MAX_SAFE_INTEGER;
-      const rightPriority = right.priority ?? Number.MAX_SAFE_INTEGER;
-      if (leftPriority !== rightPriority) {
-        return leftPriority - rightPriority;
-      }
-      return left.name.localeCompare(right.name);
-    });
-  }
-  function dedupeTodos(todos) {
-    const byId = /* @__PURE__ */ new Map();
-    for (const todo of todos) {
-      byId.set(todo.id, todo);
-    }
-    return sortTodosForWidget([...byId.values()]);
-  }
-  function TodoRow({ todo }) {
-    const showDescription = todo.description.trim().length > 0 && todo.description !== todo.name;
-    const showType = todo.type.trim().length > 0 && todo.type !== "task";
-    return /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { className: "rounded-sm border border-border/50 bg-bg/70 p-3", children: /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { className: "flex items-start gap-2", children: [
-      /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
-        "span",
-        {
-          className: `mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full ${todo.isUrgent ? "bg-danger" : todo.priority != null ? "bg-accent" : "bg-muted"}`
-        }
-      ),
-      /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { className: "min-w-0 flex-1", children: [
-        /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { className: "flex flex-wrap items-center gap-1.5", children: [
-          /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("span", { className: "min-w-0 truncate text-xs font-semibold text-txt", children: todo.name }),
-          todo.isUrgent ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(Badge, { variant: "secondary", className: "text-3xs text-danger", children: "Urgent" }) : null,
-          todo.priority != null ? /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(Badge, { variant: "secondary", className: "text-3xs", children: [
-            "P",
-            todo.priority
-          ] }) : null,
-          showType ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(Badge, { variant: "secondary", className: "text-3xs", children: todo.type }) : null
-        ] }),
-        showDescription ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("p", { className: "mt-1 line-clamp-2 text-xs-tight leading-5 text-muted", children: todo.description }) : null
-      ] })
-    ] }) });
-  }
-  function TodoItemsContent({
-    todos,
-    loading
-  }) {
-    const openTodos = todos.filter((todo) => !todo.isCompleted);
-    const hiddenCompletedCount = todos.length - openTodos.length;
-    const visibleTodos = openTodos.slice(0, MAX_VISIBLE_TODOS);
-    const remainingCount = openTodos.length - visibleTodos.length;
-    if (loading && todos.length === 0) {
-      return /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { className: "py-3 text-xs text-muted", children: "Refreshing todos\u2026" });
-    }
-    if (openTodos.length === 0) {
-      return /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
-        EmptyWidgetState,
-        {
-          icon: /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(ListTodo, { className: "h-8 w-8" }),
-          title: "No open todos"
-        }
-      );
-    }
-    return /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { className: "flex flex-col gap-2", children: [
-      visibleTodos.map((todo) => /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(TodoRow, { todo }, todo.id)),
-      remainingCount > 0 ? /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("p", { className: "px-1 text-xs-tight text-muted", children: [
-        "+",
-        remainingCount,
-        " more open todo",
-        remainingCount === 1 ? "" : "s"
-      ] }) : null,
-      hiddenCompletedCount > 0 ? /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("p", { className: "px-1 text-xs-tight text-muted", children: [
-        hiddenCompletedCount,
-        " completed todo",
-        hiddenCompletedCount === 1 ? "" : "s",
-        " hidden"
-      ] }) : null
-    ] });
-  }
-  function TodoSidebarWidget({
-    slot,
-    spanClassName = "col-span-2 row-span-1"
-  }) {
-    const { workbench, t: appT } = useAppSelectorShallow((s) => ({
-      workbench: s.workbench,
-      t: s.t
-    }));
-    const t2 = appT ?? fallbackTranslate2;
-    const authenticated = useIsAuthenticated();
-    const [todos, setTodos] = (0, import_react78.useState)(
-      () => dedupeTodos(workbench?.todos ?? [])
-    );
-    const [todosLoading, setTodosLoading] = (0, import_react78.useState)(false);
-    const mountedRef = (0, import_react78.useRef)(true);
-    (0, import_react78.useEffect)(() => {
-      mountedRef.current = true;
-      return () => {
-        mountedRef.current = false;
-      };
-    }, []);
-    (0, import_react78.useEffect)(() => {
-      setTodos(dedupeTodos(workbench?.todos ?? []));
-    }, [workbench?.todos]);
-    const loadTodos = (0, import_react78.useCallback)(
-      async (silent = false) => {
-        if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
-          if (mountedRef.current) {
-            setTodos(dedupeTodos(workbench?.todos ?? []));
-            setTodosLoading(false);
-          }
-          return;
-        }
-        if (!silent && mountedRef.current) {
-          setTodosLoading(true);
-        }
-        try {
-          const result = await client.listWorkbenchTodos();
-          if (mountedRef.current) {
-            setTodos(dedupeTodos(result.todos));
-          }
-        } catch {
-          if (mountedRef.current && (workbench?.todos?.length ?? 0) > 0) {
-            setTodos(dedupeTodos(workbench?.todos ?? []));
-          }
-        } finally {
-          if (mountedRef.current) {
-            setTodosLoading(false);
-          }
-        }
-      },
-      [authenticated, workbench?.todos]
-    );
-    (0, import_react78.useEffect)(() => {
-      void loadTodos(todos.length > 0);
-    }, [loadTodos, todos.length]);
-    useIntervalWhenDocumentVisible(
-      () => void loadTodos(true),
-      TODO_REFRESH_INTERVAL_MS
-    );
-    const openTodos = todos.filter((todo) => !todo.isCompleted);
-    const hasUrgent = openTodos.some((todo) => todo.isUrgent);
-    const onHome = slot === "home";
-    usePublishHomeAttention(
-      TODO_WIDGET_KEY,
-      onHome && hasUrgent ? HOME_SIGNAL_WEIGHTS.reminder : null
-    );
-    if (onHome && openTodos.length === 0) return null;
-    const section = /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
-      WidgetSection,
-      {
-        title: t2("taskseventspanel.Todos", { defaultValue: "Todos" }),
-        icon: /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(ListTodo, { className: "h-4 w-4" }),
-        testId: "chat-widget-todos",
-        children: /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(TodoItemsContent, { todos, loading: todosLoading })
-      }
-    );
-    if (onHome) {
-      return /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { className: `min-w-0 ${spanClassName}`, children: section });
-    }
-    return section;
-  }
-  var TODO_PLUGIN_WIDGETS = [
-    {
-      id: "todo.items",
-      pluginId: "todo",
-      order: 100,
-      defaultEnabled: true,
-      Component: TodoSidebarWidget
-    }
-  ];
-
-  // packages/ui/src/components/chat/widgets/wallet-balance.tsx
-  var import_react79 = __toESM(require_react(), 1);
-  init_home_screen_fixture_api_stub();
-
-  // packages/ui/src/components/chat/widgets/wallet-price-holdings.ts
-  var MIN_HOLDING_USD = 1;
-  var MAX_PRICED_HOLDINGS = 5;
-  function parseUsd(value) {
-    const n = typeof value === "number" ? value : Number.parseFloat(value ?? "");
-    return Number.isFinite(n) ? n : 0;
-  }
-  function collectHoldings(balances) {
-    const out = [];
-    const { solana, evm } = balances;
-    if (solana) {
-      out.push({ symbol: "SOL", valueUsd: parseUsd(solana.solValueUsd) });
-      for (const t2 of solana.tokens) {
-        out.push({ symbol: t2.symbol, valueUsd: parseUsd(t2.valueUsd) });
-      }
-    }
-    if (evm) {
-      for (const chain of evm.chains) {
-        out.push({
-          symbol: chain.nativeSymbol,
-          valueUsd: parseUsd(chain.nativeValueUsd)
-        });
-        for (const t2 of chain.tokens) {
-          out.push({ symbol: t2.symbol, valueUsd: parseUsd(t2.valueUsd) });
-        }
-      }
-    }
-    return out;
-  }
-  function selectPricedHoldings(balances, prices) {
-    if (!balances) return [];
-    const priceBySymbol = /* @__PURE__ */ new Map();
-    for (const p of prices ?? []) {
-      const key = p.symbol.trim().toUpperCase();
-      if (key && !priceBySymbol.has(key)) priceBySymbol.set(key, p);
-    }
-    const heldValueBySymbol = /* @__PURE__ */ new Map();
-    for (const { symbol: symbol2, valueUsd } of collectHoldings(balances)) {
-      if (valueUsd < MIN_HOLDING_USD) continue;
-      const key = symbol2.trim().toUpperCase();
-      if (!key) continue;
-      heldValueBySymbol.set(key, (heldValueBySymbol.get(key) ?? 0) + valueUsd);
-    }
-    const ranked = [...heldValueBySymbol.entries()].filter(([symbol2]) => priceBySymbol.has(symbol2)).sort((a, b) => {
-      if (b[1] !== a[1]) return b[1] - a[1];
-      return a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0;
-    }).slice(0, MAX_PRICED_HOLDINGS);
-    return ranked.map(([symbol2]) => {
-      const snap = priceBySymbol.get(symbol2);
-      const price = snap;
-      return {
-        symbol: price.symbol,
-        priceUsd: price.priceUsd,
-        change24hPct: price.change24hPct
-      };
-    });
-  }
-
-  // packages/ui/src/components/chat/widgets/wallet-balance.tsx
-  var import_jsx_runtime61 = __toESM(require_jsx_runtime(), 1);
-  var DEFAULT_SPAN5 = "col-span-2 row-span-1";
-  function formatPrice(priceUsd) {
-    const digits = priceUsd > 0 && priceUsd < 1 ? 6 : 2;
-    try {
-      return new Intl.NumberFormat(void 0, {
-        style: "currency",
-        currency: "USD",
-        minimumFractionDigits: 2,
-        maximumFractionDigits: digits
-      }).format(priceUsd);
-    } catch {
-      return `$${priceUsd.toFixed(digits)}`;
-    }
-  }
-  function formatChange(change24hPct) {
-    if (!Number.isFinite(change24hPct) || Math.abs(change24hPct) < 0.01)
-      return "";
-    const sign = change24hPct > 0 ? "+" : "";
-    return `${sign}${change24hPct.toFixed(1)}%`;
-  }
-  function WalletBalanceWidget(props) {
-    const spanClassName = props.spanClassName ?? DEFAULT_SPAN5;
-    const [holdings, setHoldings] = (0, import_react79.useState)(null);
-    const [loading, setLoading] = (0, import_react79.useState)(true);
-    const nav = useWidgetNavigation();
-    const authenticated = useIsAuthenticated();
-    (0, import_react79.useEffect)(() => {
-      if (!authenticated) return;
-      let cancelled = false;
-      void (async () => {
-        try {
-          const [balances, overview] = await Promise.all([
-            client.getWalletBalances(),
-            client.getWalletMarketOverview().catch(() => null)
-          ]);
-          if (cancelled) return;
-          setHoldings(selectPricedHoldings(balances, overview?.prices));
-        } catch {
-          if (!cancelled) setHoldings(null);
-        } finally {
-          if (!cancelled) setLoading(false);
-        }
-      })();
-      return () => {
-        cancelled = true;
-      };
-    }, [authenticated]);
-    if (loading && holdings == null) {
-      return /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
-        "div",
-        {
-          "data-testid": "chat-widget-wallet-balance-loading",
-          "aria-busy": "true",
-          className: `${spanClassName} h-12 animate-pulse`
-        }
-      );
-    }
-    if (!holdings || holdings.length === 0) return null;
-    return /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)(
-      Button,
-      {
-        "data-testid": "chat-widget-wallet-prices",
-        "aria-label": `Wallet prices: ${holdings.map((h) => `${h.symbol} ${formatPrice(h.priceUsd)}`).join(", ")}. Open wallet.`,
-        onClick: () => nav.openView("/wallet", "wallet"),
-        variant: "ghost",
-        className: `${spanClassName} group flex h-auto w-full flex-col items-stretch gap-1 whitespace-normal px-3 py-2.5 text-left font-normal transition-opacity hover:opacity-80`,
-        children: [
-          /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("span", { className: "flex items-center gap-2 text-xs text-white/70 [&>svg]:h-3.5 [&>svg]:w-3.5", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(Wallet, {}),
-            "Wallet"
-          ] }),
-          holdings.map((h) => {
-            const change = formatChange(h.change24hPct);
-            return /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)(
-              "span",
-              {
-                "data-testid": `wallet-price-row-${h.symbol}`,
-                className: "flex items-baseline justify-between gap-2 text-sm",
-                children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { className: "truncate font-medium text-white", children: h.symbol }),
-                  /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("span", { className: "flex shrink-0 items-baseline gap-1.5", children: [
-                    /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { className: "tabular-nums text-white", children: formatPrice(h.priceUsd) }),
-                    change ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
-                      "span",
-                      {
-                        className: `tabular-nums text-xs ${h.change24hPct >= 0 ? "text-success" : "text-danger"}`,
-                        children: change
-                      }
-                    ) : null
-                  ] })
-                ]
-              },
-              h.symbol
-            );
-          })
-        ]
-      }
-    );
   }
 
   // packages/ui/src/widgets/registry.ts
@@ -70876,7 +70514,7 @@ Assistant:`;
   );
   registerWidgetComponent("feed", "feed.agent-activity", AgentActivityWidget);
   registerWidgetComponent("wallet", "wallet.balance", WalletBalanceWidget);
-  registerWidgetComponent("workflow", "workflow.running", AutomationsWidget);
+  registerWidgetComponent("workflow", "workflow.running", WorkflowsWidget);
   registerWidgetComponent(
     MODEL_DOWNLOAD_HOME_WIDGET.pluginId,
     MODEL_DOWNLOAD_HOME_WIDGET.id,
@@ -71559,11 +71197,6 @@ Assistant:`;
     );
     const currentBaseUrl = useAppSelectorShallow(() => client.getBaseUrl());
     const enabledKinds = useEnabledViewKinds();
-    const registryVersion2 = (0, import_react80.useSyncExternalStore)(
-      subscribeWidgetRegistry,
-      getWidgetRegistryVersion,
-      getWidgetRegistryVersion
-    );
     const { notifications } = useNotifications();
     const selfAttention = useHomeAttentionSignals();
     const dismissals = useHomeDismissals();
@@ -71586,18 +71219,10 @@ Assistant:`;
       const all = resolveWidgetsForSlot(slot, plugins ?? [], serverDeclarations);
       const fullAppShellRoutesEnabled = supportsFullAppShellRoutes(currentBaseUrl);
       const gated = all.filter(
-        (entry) => (0, import_core35.isViewVisible)(entry.declaration, enabledKinds) && (fullAppShellRoutesEnabled || !FULL_APP_SHELL_WIDGET_PLUGIN_IDS.has(entry.declaration.pluginId) && entry.defaultWidgetSink !== "activity")
+        (entry) => (0, import_core32.isViewVisible)(entry.declaration, enabledKinds) && (fullAppShellRoutesEnabled || !FULL_APP_SHELL_WIDGET_PLUGIN_IDS.has(entry.declaration.pluginId) && entry.defaultWidgetSink !== "activity")
       );
       return filter ? gated.filter((entry) => filter(entry.declaration)) : gated;
-    }, [
-      slot,
-      plugins,
-      serverDeclarations,
-      filter,
-      enabledKinds,
-      currentBaseUrl,
-      registryVersion2
-    ]);
+    }, [slot, plugins, serverDeclarations, filter, enabledKinds, currentBaseUrl]);
     const notificationSignalInputs = (0, import_react80.useMemo)(
       () => notifications.map((n) => ({
         priority: n.priority,
@@ -71718,7 +71343,7 @@ Assistant:`;
   }
 
   // packages/ui/src/hooks/useWeather.ts
-  var React58 = __toESM(require_react(), 1);
+  var React55 = __toESM(require_react(), 1);
   var WEATHER_TTL_MS = 30 * 6e4;
   var WEATHER_CACHE_KEY = "eliza:weather:v1";
   var GEO_TIMEOUT_MS = 8e3;
@@ -71805,8 +71430,8 @@ Assistant:`;
     city: ""
   };
   function useWeather() {
-    const [weather, setWeather] = React58.useState(LOADING);
-    React58.useEffect(() => {
+    const [weather, setWeather] = React55.useState(LOADING);
+    React55.useEffect(() => {
       let cancelled = false;
       const cached3 = readCache();
       if (cached3) {
@@ -71953,11 +71578,16 @@ Assistant:`;
   }
 
   // packages/ui/src/components/shell/use-notification-pull.ts
-  var React59 = __toESM(require_react(), 1);
+  var React56 = __toESM(require_react(), 1);
+  var ENGAGE_SLOP = 8;
   var DEFAULT_DISTANCE_THRESHOLD = 60;
+  var DEFAULT_VELOCITY_THRESHOLD = 0.5;
   var REVEAL_SOFT_MAX = 96;
+  var REVEAL_OVERSHOOT_RESISTANCE = 0.35;
   function revealOffsetForTravel(rawDown) {
-    return rubberBand(rawDown, REVEAL_SOFT_MAX, OVERSHOOT_RESISTANCE);
+    if (rawDown <= 0) return 0;
+    if (rawDown <= REVEAL_SOFT_MAX) return rawDown;
+    return REVEAL_SOFT_MAX + (rawDown - REVEAL_SOFT_MAX) * REVEAL_OVERSHOOT_RESISTANCE;
   }
   function findTouch(list, id) {
     if (!list) return null;
@@ -71967,25 +71597,46 @@ Assistant:`;
     return null;
   }
   function useNotificationPull(options2) {
-    const optsRef = React59.useRef(options2);
+    const optsRef = React56.useRef(options2);
     optsRef.current = options2;
-    const nodeRef = React59.useRef(null);
-    const start = React59.useRef(null);
-    const last = React59.useRef(null);
-    const engaged = React59.useRef(false);
-    const rejected = React59.useRef(false);
-    const reveal = useRafCoalescer(
-      (offset4) => optsRef.current.onReveal(offset4)
+    const nodeRef = React56.useRef(null);
+    const start = React56.useRef(null);
+    const last = React56.useRef(null);
+    const engaged = React56.useRef(false);
+    const rejected = React56.useRef(false);
+    const pending = React56.useRef(null);
+    const raf = React56.useRef(0);
+    const flush = React56.useCallback(() => {
+      raf.current = 0;
+      const next = pending.current;
+      pending.current = null;
+      if (next != null) optsRef.current.onReveal(next);
+    }, []);
+    const schedule = React56.useCallback(
+      (offset4) => {
+        pending.current = offset4;
+        if (raf.current === 0 && typeof requestAnimationFrame === "function") {
+          raf.current = requestAnimationFrame(flush);
+        } else if (typeof requestAnimationFrame !== "function") {
+          flush();
+        }
+      },
+      [flush]
     );
-    const schedule = reveal.schedule;
-    const cancelScheduled = reveal.cancel;
-    const resetGesture = React59.useCallback(() => {
+    const cancelScheduled = React56.useCallback(() => {
+      if (raf.current !== 0 && typeof cancelAnimationFrame === "function") {
+        cancelAnimationFrame(raf.current);
+      }
+      raf.current = 0;
+      pending.current = null;
+    }, []);
+    const resetGesture = React56.useCallback(() => {
       start.current = null;
       last.current = null;
       engaged.current = false;
       rejected.current = false;
     }, []);
-    const onTouchStart = React59.useCallback((event) => {
+    const onTouchStart = React56.useCallback((event) => {
       if (start.current) return;
       const touch = event.changedTouches[0];
       if (!touch) return;
@@ -72001,7 +71652,7 @@ Assistant:`;
       engaged.current = false;
       rejected.current = false;
     }, []);
-    const onTouchMove = React59.useCallback(
+    const onTouchMove = React56.useCallback(
       (event) => {
         const s = start.current;
         if (!s || rejected.current) return;
@@ -72015,15 +71666,15 @@ Assistant:`;
             rejected.current = true;
             return;
           }
-          if (Math.abs(dx) > AXIS_COMMIT_SLOP && Math.abs(dx) > Math.abs(dy)) {
+          if (Math.abs(dx) > ENGAGE_SLOP && Math.abs(dx) > Math.abs(dy)) {
             rejected.current = true;
             return;
           }
-          if (dy <= -AXIS_COMMIT_SLOP) {
+          if (dy <= -ENGAGE_SLOP) {
             rejected.current = true;
             return;
           }
-          if (dy < AXIS_COMMIT_SLOP) return;
+          if (dy < ENGAGE_SLOP) return;
           engaged.current = true;
           optsRef.current.onStart?.();
         }
@@ -72032,7 +71683,7 @@ Assistant:`;
       },
       [schedule]
     );
-    const settle2 = React59.useCallback(
+    const settle2 = React56.useCallback(
       (event, allowCommit) => {
         const s = start.current;
         if (!s) return;
@@ -72048,21 +71699,21 @@ Assistant:`;
         const elapsed = Math.max(1, endT - s.t);
         const velocity = dy / elapsed;
         const distanceThreshold = optsRef.current.distanceThreshold ?? DEFAULT_DISTANCE_THRESHOLD;
-        const velocityThreshold = optsRef.current.velocityThreshold ?? DEFAULT_PULL_VELOCITY;
+        const velocityThreshold = optsRef.current.velocityThreshold ?? DEFAULT_VELOCITY_THRESHOLD;
         const commit2 = allowCommit && (dy >= distanceThreshold || velocity >= velocityThreshold);
         optsRef.current.onEnd(commit2);
       },
       [cancelScheduled, resetGesture]
     );
-    const onTouchEnd = React59.useCallback(
+    const onTouchEnd = React56.useCallback(
       (event) => settle2(event, true),
       [settle2]
     );
-    const onTouchCancel = React59.useCallback(
+    const onTouchCancel = React56.useCallback(
       (event) => settle2(event, false),
       [settle2]
     );
-    const setRef3 = React59.useCallback(
+    const setRef3 = React56.useCallback(
       (node) => {
         const prev = nodeRef.current;
         if (prev) {
@@ -72081,11 +71732,24 @@ Assistant:`;
       },
       [onTouchStart, onTouchMove, onTouchEnd, onTouchCancel]
     );
+    React56.useEffect(() => cancelScheduled, [cancelScheduled]);
     return { ref: setRef3 };
   }
 
   // packages/ui/src/components/shell/use-pull-gesture.ts
-  var React60 = __toESM(require_react(), 1);
+  var React57 = __toESM(require_react(), 1);
+  var PULL_GESTURE_TAP_SLOP = 8;
+  var TAP_SLOP = PULL_GESTURE_TAP_SLOP;
+  var AXIS_COMMIT_SLOP2 = 8;
+  var HORIZONTAL_DOMINANCE_RATIO = 0.8;
+  function resolveSwipe(deltaLeft, velocityLeft, deltaUp, distanceThresholdX, velocityThresholdX) {
+    if (Math.abs(deltaLeft) < Math.abs(deltaUp) * HORIZONTAL_DOMINANCE_RATIO) {
+      return null;
+    }
+    const passed = Math.abs(deltaLeft) >= distanceThresholdX || Math.abs(velocityLeft) >= velocityThresholdX;
+    if (!passed) return null;
+    return deltaLeft > 0 ? "left" : "right";
+  }
   function usePullGesture(options2) {
     const {
       onPullUp,
@@ -72099,33 +71763,57 @@ Assistant:`;
       onSettleFree,
       onCancel,
       swipeEnabled = true,
-      distanceThreshold = DEFAULT_PULL_DISTANCE,
-      velocityThreshold = DEFAULT_PULL_VELOCITY,
-      distanceThresholdX = DEFAULT_SWIPE_DISTANCE,
-      velocityThresholdX = DEFAULT_SWIPE_VELOCITY
+      distanceThreshold = 56,
+      velocityThreshold = 0.5,
+      distanceThresholdX = 64,
+      velocityThresholdX = 0.4
     } = options2;
     const hasSwipe = swipeEnabled && Boolean(onSwipeLeft || onSwipeRight || onDragX);
     const hasVerticalPull = Boolean(
       onDrag || onPullUp || onPullDown || onSettleFree
     );
-    const start = React60.useRef(null);
-    const axis = React60.useRef(null);
-    const last = React60.useRef(null);
-    const onDragRef = React60.useRef(onDrag);
-    const onDragXRef = React60.useRef(onDragX);
+    const start = React57.useRef(null);
+    const axis = React57.useRef(null);
+    const last = React57.useRef(null);
+    const pendingDrag = React57.useRef(
+      null
+    );
+    const dragRaf = React57.useRef(0);
+    const onDragRef = React57.useRef(onDrag);
+    const onDragXRef = React57.useRef(onDragX);
     onDragRef.current = onDrag;
     onDragXRef.current = onDragX;
-    const drag = useRafCoalescer(
-      (pending) => {
-        if (pending.axis === "x") onDragXRef.current?.(pending.value);
-        else onDragRef.current?.(pending.value);
+    const flushDrag = React57.useCallback(() => {
+      dragRaf.current = 0;
+      const pending = pendingDrag.current;
+      pendingDrag.current = null;
+      if (!pending) return;
+      if (pending.axis === "x") onDragXRef.current?.(pending.value);
+      else onDragRef.current?.(pending.value);
+    }, []);
+    const scheduleDrag = React57.useCallback(
+      (nextAxis, value) => {
+        pendingDrag.current = { axis: nextAxis, value };
+        if (dragRaf.current === 0 && typeof requestAnimationFrame === "function") {
+          dragRaf.current = requestAnimationFrame(flushDrag);
+        }
+      },
+      [flushDrag]
+    );
+    const cancelDrag = React57.useCallback(() => {
+      if (dragRaf.current !== 0 && typeof cancelAnimationFrame === "function") {
+        cancelAnimationFrame(dragRaf.current);
       }
-    );
-    const scheduleDrag = React60.useCallback(
-      (nextAxis, value) => drag.schedule({ axis: nextAxis, value }),
-      [drag]
-    );
-    const onPointerDown = React60.useCallback(
+      dragRaf.current = 0;
+      pendingDrag.current = null;
+    }, []);
+    const flushPendingDrag = React57.useCallback(() => {
+      if (dragRaf.current !== 0 && typeof cancelAnimationFrame === "function") {
+        cancelAnimationFrame(dragRaf.current);
+      }
+      flushDrag();
+    }, [flushDrag]);
+    const onPointerDown = React57.useCallback(
       (event) => {
         if (start.current && start.current.pointerId !== event.pointerId) return;
         start.current = {
@@ -72145,7 +71833,7 @@ Assistant:`;
       },
       [hasSwipe, hasVerticalPull]
     );
-    const onPointerMove = React60.useCallback(
+    const onPointerMove = React57.useCallback(
       (event) => {
         const s = start.current;
         if (!s || s.pointerId !== event.pointerId) return;
@@ -72157,16 +71845,18 @@ Assistant:`;
         const dy = s.y - event.clientY;
         const dx = s.x - event.clientX;
         if (axis.current === null) {
-          const committed = commitAxis(dx, dy, AXIS_COMMIT_SLOP, hasSwipe);
-          if (committed !== null) {
-            axis.current = committed;
+          const ax = Math.abs(dx);
+          const ay = Math.abs(dy);
+          if (Math.max(ax, ay) >= AXIS_COMMIT_SLOP2) {
+            const horizontalWins = hasSwipe ? ax >= ay * HORIZONTAL_DOMINANCE_RATIO : ax > ay;
+            axis.current = horizontalWins ? "x" : "y";
             if (hasSwipe && !hasVerticalPull) {
               try {
                 event.currentTarget.setPointerCapture(event.pointerId);
               } catch {
               }
             }
-            drag.cancel();
+            cancelDrag();
             if (axis.current === "x") {
               onDragReset?.();
               if (!hasSwipe) {
@@ -72188,17 +71878,18 @@ Assistant:`;
           scheduleDrag("y", dy);
         }
       },
-      [hasSwipe, hasVerticalPull, onDragReset, onDragX, scheduleDrag, drag]
+      [hasSwipe, hasVerticalPull, onDragReset, onDragX, scheduleDrag, cancelDrag]
     );
-    const finish = React60.useCallback(
+    const finish = React57.useCallback(
       (event) => {
         const s = start.current;
         if (!s || s.pointerId !== event.pointerId) return;
-        drag.flush();
+        flushPendingDrag();
         const committedAxis = axis.current;
         start.current = null;
         axis.current = null;
         last.current = null;
+        if (!s) return;
         const deltaUp = s.y - event.clientY;
         const deltaLeft = s.x - event.clientX;
         const elapsed = Math.max(1, performance.now() - s.t);
@@ -72214,7 +71905,7 @@ Assistant:`;
           onTap?.();
           return;
         }
-        const releaseAxis = committedAxis ?? (hasSwipe && movedX >= AXIS_COMMIT_SLOP && movedX >= movedY * HORIZONTAL_DOMINANCE_RATIO ? "x" : null);
+        const releaseAxis = committedAxis ?? (hasSwipe && movedX >= AXIS_COMMIT_SLOP2 && movedX >= movedY * HORIZONTAL_DOMINANCE_RATIO ? "x" : null);
         if (releaseAxis === "x") {
           if (committedAxis === null) onDragReset?.();
           onDragX?.(0);
@@ -72244,7 +71935,7 @@ Assistant:`;
         }
       },
       [
-        drag,
+        flushPendingDrag,
         hasSwipe,
         onDragReset,
         onDragX,
@@ -72260,13 +71951,13 @@ Assistant:`;
         velocityThresholdX
       ]
     );
-    const cancel = React60.useCallback(
+    const cancel = React57.useCallback(
       (event) => {
         const s = start.current;
         if (!s || s.pointerId !== event.pointerId) return;
         const committedAxis = axis.current;
         const l = last.current;
-        drag.cancel();
+        cancelDrag();
         start.current = null;
         axis.current = null;
         last.current = null;
@@ -72274,7 +71965,7 @@ Assistant:`;
           const deltaUp = s.y - l.y;
           const deltaLeft = s.x - l.x;
           const movedX = Math.abs(deltaLeft);
-          if (movedX >= AXIS_COMMIT_SLOP && movedX >= Math.abs(deltaUp) * HORIZONTAL_DOMINANCE_RATIO) {
+          if (movedX >= AXIS_COMMIT_SLOP2 && movedX >= Math.abs(deltaUp) * HORIZONTAL_DOMINANCE_RATIO) {
             const elapsed = Math.max(1, l.t - s.t);
             const swipe = resolveSwipe(
               deltaLeft,
@@ -72297,7 +71988,7 @@ Assistant:`;
         onCancel?.();
       },
       [
-        drag,
+        cancelDrag,
         hasSwipe,
         onDragReset,
         onDragX,
@@ -72308,13 +71999,14 @@ Assistant:`;
         velocityThresholdX
       ]
     );
-    const lostCapture = React60.useCallback(
+    const lostCapture = React57.useCallback(
       (event) => {
-        if (!isRealCaptureLoss(event)) return;
+        if (event.target !== event.currentTarget) return;
         cancel(event);
       },
       [cancel]
     );
+    React57.useEffect(() => cancelDrag, [cancelDrag]);
     return {
       onPointerDown,
       onPointerMove,
@@ -72510,12 +72202,11 @@ Assistant:`;
   // packages/ui/src/components/shell/NotificationCenter.tsx
   var import_react82 = __toESM(require_react(), 1);
   var import_react_dom2 = __toESM(require_react_dom(), 1);
-  init_events3();
   init_navigate_deep_link();
   init_notification_store();
 
-  // ../pr-12727-run/node_modules/.bun/@radix-ui+react-popover@1.1.17+119c4f3973a6d299/node_modules/@radix-ui/react-popover/dist/index.mjs
-  var React61 = __toESM(require_react(), 1);
+  // ../../../node_modules/.bun/@radix-ui+react-popover@1.1.17+119c4f3973a6d299/node_modules/@radix-ui/react-popover/dist/index.mjs
+  var React58 = __toESM(require_react(), 1);
   var import_jsx_runtime65 = __toESM(require_jsx_runtime(), 1);
   var POPOVER_NAME = "Popover";
   var [createPopoverContext, createPopoverScope] = createContextScope(POPOVER_NAME, [
@@ -72533,8 +72224,8 @@ Assistant:`;
       modal = false
     } = props;
     const popperScope = usePopperScope2(__scopePopover);
-    const triggerRef = React61.useRef(null);
-    const [hasCustomAnchor, setHasCustomAnchor] = React61.useState(false);
+    const triggerRef = React58.useRef(null);
+    const [hasCustomAnchor, setHasCustomAnchor] = React58.useState(false);
     const [open, setOpen] = useControllableState({
       prop: openProp,
       defaultProp: defaultOpen ?? false,
@@ -72549,10 +72240,10 @@ Assistant:`;
         triggerRef,
         open,
         onOpenChange: setOpen,
-        onOpenToggle: React61.useCallback(() => setOpen((prevOpen) => !prevOpen), [setOpen]),
+        onOpenToggle: React58.useCallback(() => setOpen((prevOpen) => !prevOpen), [setOpen]),
         hasCustomAnchor,
-        onCustomAnchorAdd: React61.useCallback(() => setHasCustomAnchor(true), []),
-        onCustomAnchorRemove: React61.useCallback(() => setHasCustomAnchor(false), []),
+        onCustomAnchorAdd: React58.useCallback(() => setHasCustomAnchor(true), []),
+        onCustomAnchorRemove: React58.useCallback(() => setHasCustomAnchor(false), []),
         modal,
         children
       }
@@ -72560,13 +72251,13 @@ Assistant:`;
   };
   Popover.displayName = POPOVER_NAME;
   var ANCHOR_NAME2 = "PopoverAnchor";
-  var PopoverAnchor = React61.forwardRef(
+  var PopoverAnchor = React58.forwardRef(
     (props, forwardedRef) => {
       const { __scopePopover, ...anchorProps } = props;
       const context = usePopoverContext(ANCHOR_NAME2, __scopePopover);
       const popperScope = usePopperScope2(__scopePopover);
       const { onCustomAnchorAdd, onCustomAnchorRemove } = context;
-      React61.useEffect(() => {
+      React58.useEffect(() => {
         onCustomAnchorAdd();
         return () => onCustomAnchorRemove();
       }, [onCustomAnchorAdd, onCustomAnchorRemove]);
@@ -72575,7 +72266,7 @@ Assistant:`;
   );
   PopoverAnchor.displayName = ANCHOR_NAME2;
   var TRIGGER_NAME4 = "PopoverTrigger";
-  var PopoverTrigger = React61.forwardRef(
+  var PopoverTrigger = React58.forwardRef(
     (props, forwardedRef) => {
       const { __scopePopover, ...triggerProps } = props;
       const context = usePopoverContext(TRIGGER_NAME4, __scopePopover);
@@ -72609,7 +72300,7 @@ Assistant:`;
   };
   PopoverPortal.displayName = PORTAL_NAME4;
   var CONTENT_NAME4 = "PopoverContent";
-  var PopoverContent = React61.forwardRef(
+  var PopoverContent = React58.forwardRef(
     (props, forwardedRef) => {
       const portalContext = usePortalContext3(CONTENT_NAME4, props.__scopePopover);
       const { forceMount = portalContext.forceMount, ...contentProps } = props;
@@ -72619,13 +72310,13 @@ Assistant:`;
   );
   PopoverContent.displayName = CONTENT_NAME4;
   var Slot4 = createSlot("PopoverContent.RemoveScroll");
-  var PopoverContentModal = React61.forwardRef(
+  var PopoverContentModal = React58.forwardRef(
     (props, forwardedRef) => {
       const context = usePopoverContext(CONTENT_NAME4, props.__scopePopover);
-      const contentRef = React61.useRef(null);
+      const contentRef = React58.useRef(null);
       const composedRefs = useComposedRefs(forwardedRef, contentRef);
-      const isRightClickOutsideRef = React61.useRef(false);
-      React61.useEffect(() => {
+      const isRightClickOutsideRef = React58.useRef(false);
+      React58.useEffect(() => {
         const content = contentRef.current;
         if (content) return hideOthers(content);
       }, []);
@@ -72659,11 +72350,11 @@ Assistant:`;
       ) });
     }
   );
-  var PopoverContentNonModal = React61.forwardRef(
+  var PopoverContentNonModal = React58.forwardRef(
     (props, forwardedRef) => {
       const context = usePopoverContext(CONTENT_NAME4, props.__scopePopover);
-      const hasInteractedOutsideRef = React61.useRef(false);
-      const hasPointerDownOutsideRef = React61.useRef(false);
+      const hasInteractedOutsideRef = React58.useRef(false);
+      const hasPointerDownOutsideRef = React58.useRef(false);
       return /* @__PURE__ */ (0, import_jsx_runtime65.jsx)(
         PopoverContentImpl,
         {
@@ -72699,7 +72390,7 @@ Assistant:`;
       );
     }
   );
-  var PopoverContentImpl = React61.forwardRef(
+  var PopoverContentImpl = React58.forwardRef(
     (props, forwardedRef) => {
       const {
         __scopePopover,
@@ -72764,7 +72455,7 @@ Assistant:`;
     }
   );
   var CLOSE_NAME2 = "PopoverClose";
-  var PopoverClose = React61.forwardRef(
+  var PopoverClose = React58.forwardRef(
     (props, forwardedRef) => {
       const { __scopePopover, ...closeProps } = props;
       const context = usePopoverContext(CLOSE_NAME2, __scopePopover);
@@ -72781,7 +72472,7 @@ Assistant:`;
   );
   PopoverClose.displayName = CLOSE_NAME2;
   var ARROW_NAME3 = "PopoverArrow";
-  var PopoverArrow = React61.forwardRef(
+  var PopoverArrow = React58.forwardRef(
     (props, forwardedRef) => {
       const { __scopePopover, ...arrowProps } = props;
       const popperScope = usePopperScope2(__scopePopover);
@@ -72798,11 +72489,11 @@ Assistant:`;
   var Content2 = PopoverContent;
 
   // packages/ui/src/components/ui/popover.tsx
-  var React62 = __toESM(require_react(), 1);
+  var React59 = __toESM(require_react(), 1);
   var import_jsx_runtime66 = __toESM(require_jsx_runtime(), 1);
   var Popover2 = Root23;
   var PopoverTrigger2 = Trigger;
-  var PopoverContent2 = React62.forwardRef(({ className, align = "center", sideOffset = 4, ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime66.jsx)(Portal2, { children: /* @__PURE__ */ (0, import_jsx_runtime66.jsx)(
+  var PopoverContent2 = React59.forwardRef(({ className, align = "center", sideOffset = 4, ...props }, ref) => /* @__PURE__ */ (0, import_jsx_runtime66.jsx)(Portal2, { children: /* @__PURE__ */ (0, import_jsx_runtime66.jsx)(
     Content2,
     {
       ref,

--- a/packages/ui/src/components/shell/use-notification-pull.test.ts
+++ b/packages/ui/src/components/shell/use-notification-pull.test.ts
@@ -2,7 +2,7 @@
 // the notification pull gesture: clamps to 0 below zero travel, tracks 1:1 to a
 // soft cap, then rubber-bands (monotonic, diminishing). Pure math, no harness.
 import { describe, expect, it } from "vitest";
-import { revealOffsetForTravel } from "./use-notification-pull";
+import { REVEAL_SOFT_MAX, revealOffsetForTravel } from "./use-notification-pull";
 
 describe("revealOffsetForTravel", () => {
   it("is 0 at or below zero travel (no negative reveal)", () => {
@@ -12,16 +12,28 @@ describe("revealOffsetForTravel", () => {
 
   it("tracks the finger 1:1 up to the soft cap", () => {
     expect(revealOffsetForTravel(20)).toBe(20);
-    expect(revealOffsetForTravel(96)).toBe(96);
+    expect(revealOffsetForTravel(REVEAL_SOFT_MAX)).toBe(REVEAL_SOFT_MAX);
+    // The finger catches the whole sheet by the soft cap (no lag): the panel
+    // maps this same distance to a fully-revealed sheet.
+    expect(revealOffsetForTravel(REVEAL_SOFT_MAX - 12)).toBe(
+      REVEAL_SOFT_MAX - 12,
+    );
   });
 
   it("rubber-bands past the soft cap (diminishing, always monotonic)", () => {
-    // Past 96px, extra travel adds only a damped fraction.
-    expect(revealOffsetForTravel(196)).toBeCloseTo(96 + 100 * 0.35, 5);
-    // Still strictly increasing, but always well under 1:1 (rubber-band).
-    expect(revealOffsetForTravel(400)).toBeGreaterThan(
-      revealOffsetForTravel(196),
+    // Past the soft cap, extra travel adds only a damped fraction.
+    const past = 100;
+    expect(revealOffsetForTravel(REVEAL_SOFT_MAX + past)).toBeCloseTo(
+      REVEAL_SOFT_MAX + past * 0.28,
+      5,
     );
-    expect(revealOffsetForTravel(400)).toBeLessThan(400);
+    // Still strictly increasing, but always well under 1:1 (rubber-band): a
+    // long over-pull keeps giving a little without the sheet sliding forever.
+    expect(revealOffsetForTravel(REVEAL_SOFT_MAX + 400)).toBeGreaterThan(
+      revealOffsetForTravel(REVEAL_SOFT_MAX + past),
+    );
+    expect(revealOffsetForTravel(REVEAL_SOFT_MAX + 400)).toBeLessThan(
+      REVEAL_SOFT_MAX + 400,
+    );
   });
 });

--- a/packages/ui/src/components/shell/use-notification-pull.ts
+++ b/packages/ui/src/components/shell/use-notification-pull.ts
@@ -3,13 +3,7 @@
  * notification surface.
  */
 import * as React from "react";
-import {
-  DEFAULT_PULL_VELOCITY as DEFAULT_VELOCITY_THRESHOLD,
-  AXIS_COMMIT_SLOP as ENGAGE_SLOP,
-  OVERSHOOT_RESISTANCE as REVEAL_OVERSHOOT_RESISTANCE,
-  rubberBand,
-  useRafCoalescer,
-} from "../../gestures";
+import { rubberBand, useRafCoalescer } from "../../gestures";
 
 /**
  * iOS-notification-center pull gesture for the home dashboard.
@@ -39,14 +33,23 @@ import {
  * OR velocity threshold — a deliberate drag and a quick flick both open.
  */
 
-// ENGAGE_SLOP (travel after which a downward-at-top drag becomes a pull),
-// DEFAULT_VELOCITY_THRESHOLD (flick commit speed), and
-// REVEAL_OVERSHOOT_RESISTANCE alias the shared gesture constants above; only
-// the values below are tuned specifically for this surface.
+/** Vertical travel (px) after which a downward-at-top drag becomes a pull. */
+const ENGAGE_SLOP = 6;
 /** Raw downward travel (px) that commits the pull to opening on release. */
-const DEFAULT_DISTANCE_THRESHOLD = 60;
-/** Travel (px) the reveal tracks 1:1 before rubber-banding. */
-const REVEAL_SOFT_MAX = 96;
+const DEFAULT_DISTANCE_THRESHOLD = 72;
+/** Raw downward speed (px/ms) that commits the pull as a flick. */
+const DEFAULT_VELOCITY_THRESHOLD = 0.45;
+/**
+ * Travel (px) the reveal tracks 1:1 before rubber-banding. This is the point at
+ * which the sheet is fully revealed — the panel maps the SAME distance to a full
+ * sheet (SHEET_REVEAL_DISTANCE), so the finger catches and carries the whole
+ * sheet 1:1, then any further pull rubber-bands with resistance. Keep the two in
+ * sync: a mismatch makes the sheet lag behind (cap too high) or snap open before
+ * the finger arrives (cap too low).
+ */
+export const REVEAL_SOFT_MAX = 132;
+/** Resistance applied to travel past {@link REVEAL_SOFT_MAX} (rubber-band). */
+const REVEAL_OVERSHOOT_RESISTANCE = 0.28;
 
 /**
  * Map raw finger travel to the reveal offset: 1:1 up to a soft cap, then a

--- a/packages/ui/src/components/shell/use-pull-gesture.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.ts
@@ -72,6 +72,19 @@ export interface PullGestureOptions {
   distanceThresholdX?: number;
   /** Minimum horizontal speed (px/ms) to count as a swipe flick. Default 0.4. */
   velocityThresholdX?: number;
+  /**
+   * Bias axis commitment toward VERTICAL for a binding that shares a surface
+   * with a native vertical scroller (the conversation transcript, #8929). When
+   * true, the MID-gesture X commit requires horizontal to STRICTLY dominate
+   * (`ax > ay`, not the widened 0.8 cone) and defers the X capture until a
+   * larger horizontal slop is crossed — so a real thumb SCROLL (whose first few
+   * px are usually a little diagonal) is never mistaken for a horizontal swipe,
+   * captured, and blocked from scrolling natively (the "can't scroll chat on
+   * mobile web" bug, #chat-scroll-web). Release-time swipe recognition is
+   * unchanged, so a deliberate horizontal flick still navigates. Default false
+   * keeps the grabber/home rail on the widened cone (#10715).
+   */
+  verticalScrollPriority?: boolean;
 }
 
 /** Movement (px) under which a release is treated as a tap, not a drag. Exported
@@ -79,6 +92,14 @@ export interface PullGestureOptions {
  *  from the same press) use the SAME tap definition as the gesture engine — see
  *  the HomeScreen notification pull zone. Aliases the shared {@link TAP_SLOP}. */
 export const PULL_GESTURE_TAP_SLOP = TAP_SLOP;
+
+/**
+ * Larger axis-commit slop used when {@link PullGestureOptions.verticalScrollPriority}
+ * is set: the binding waits for a clearer horizontal intent before it commits
+ * (and captures) the X axis, so the browser's native vertical pan owns the first
+ * frames of a thumb scroll on the shared transcript surface (#chat-scroll-web).
+ */
+const AXIS_COMMIT_SLOP_SCROLL_SAFE = 16;
 
 export { resolvePull, resolveSwipe };
 
@@ -114,7 +135,15 @@ export function usePullGesture(
     velocityThreshold = DEFAULT_PULL_VELOCITY,
     distanceThresholdX = DEFAULT_SWIPE_DISTANCE,
     velocityThresholdX = DEFAULT_SWIPE_VELOCITY,
+    verticalScrollPriority = false,
   } = options;
+
+  // On a scroll-priority surface the mid-gesture X commit needs a clearer
+  // horizontal intent (larger slop + strict dominance) so a thumb SCROLL is
+  // never captured as a swipe; release-time recognition is unchanged.
+  const midCommitSlop = verticalScrollPriority
+    ? AXIS_COMMIT_SLOP_SCROLL_SAFE
+    : AXIS_COMMIT_SLOP;
 
   const hasSwipe =
     swipeEnabled && Boolean(onSwipeLeft || onSwipeRight || onDragX);
@@ -199,7 +228,19 @@ export function usePullGesture(
         // swipe, a deliberate diagonal (horizontal ≥ 0.8× vertical) commits the
         // X axis. A strict ax > ay would re-narrow the cone to 45° at the first
         // 8px of travel.
-        const committed = commitAxis(dx, dy, AXIS_COMMIT_SLOP, hasSwipe);
+        //
+        // EXCEPTION — `verticalScrollPriority` (the transcript, #chat-scroll-web):
+        // the surface is ALSO a native vertical scroller, so a mid-gesture X
+        // commit here would capture the pointer and BLOCK the scroll. Pass
+        // canSwipe=false so horizontal must STRICTLY dominate (`ax > ay`) and a
+        // mostly-vertical thumb scroll stays on the Y axis (uncaptured → native
+        // scroll wins); release-time recognition still lands a deliberate flick.
+        const committed = commitAxis(
+          dx,
+          dy,
+          midCommitSlop,
+          hasSwipe && !verticalScrollPriority,
+        );
         if (committed !== null) {
           axis.current = committed;
           // Take over the pointer now that intent is clear (deferred-capture path).
@@ -237,7 +278,16 @@ export function usePullGesture(
         scheduleDrag("y", dy); // pre-commit: drive the vertical sheet
       }
     },
-    [hasSwipe, hasVerticalPull, onDragReset, onDragX, scheduleDrag, drag],
+    [
+      hasSwipe,
+      hasVerticalPull,
+      onDragReset,
+      onDragX,
+      scheduleDrag,
+      drag,
+      midCommitSlop,
+      verticalScrollPriority,
+    ],
   );
 
   const finish = React.useCallback(


### PR DESCRIPTION
## Chat surfaces + notification mechanics — tokens, physics, a11y

Chat surfaces and notification mechanics for the shell, built on the design-token foundation.

> **Stacked PR.** Base is `feat/ui-token-foundation-shell` (#13069) so the diff here is exactly the 18 chat/notification files. **Merge #13069 first**, then this retargets cleanly to `develop`.

### Notifications
- **Pull physics** (`use-notification-pull.ts`, `use-pull-gesture.ts`): a tuned pull-to-reveal gesture for the notification center, with tests (`use-notification-pull.test.ts`).
- **Relevance noise reduction** in the notifications widget so low-signal notifications stop crowding the surface, with tests (`notifications.test.tsx`, `notifications.populated.test.tsx`).
- `NotificationCenter` + `ContinuousChatOverlay` shell wiring.

### Chat surfaces
- `MessageAttachments` + `TranscriptViewerOverlay`: chat media rendered with semantic tokens (no hardcoded values) plus an accessible transcript viewer.
- chat widgets (`ftu-welcome`, `home-widget-card`, `model-download`, `wallet-balance`) share a common shell (`widgets/shared.tsx`) for consistent chrome.

### E2E
- chat-sheet fixture + chat-scroll web e2e + output-home snapshot for the home-screen render.

### File count
18 files.

### Validation
- `packages/ui` `tsc --noEmit`: **clean**.
- `use-notification-pull` + `notifications` (base + populated): **19/19 pass**.

### Series
Part of a stacked UI-overhaul series. Depends on **#13069**. See linked siblings.

— [sol-orch]
