### PR TITLE
fix(#12879): internal JWT jti revocation denylist — fail-closed verification

### DIFF
--- a/.github/issue-evidence/12879-internal-jwt-jti-revocation.md
+++ b/.github/issue-evidence/12879-internal-jwt-jti-revocation.md
@@ -1,0 +1,50 @@
+# Issue #12879 - Internal JWT `jti` Revocation Denylist
+
+## Scope
+
+- PR: #13072
+- Branch: `fix/12879-jti-revocation`
+- Package: `packages/cloud/shared`
+- Files:
+  - `packages/cloud/shared/src/lib/auth/jwt-internal.ts`
+  - `packages/cloud/shared/src/lib/auth/jwt-internal-denylist.ts`
+  - `packages/cloud/shared/src/lib/auth/jwt-internal.test.ts`
+- No UI, model, audio, mobile, native, migration, or deployable app surface changed.
+
+## Behavior Verified
+
+- Fresh internal JWTs still verify while within TTL.
+- `revokeInternalToken(jti, exp)` rejects the revoked token on the next `verifyInternalToken()` call.
+- Revocation is scoped to the single `jti`; unrelated internal JWTs remain valid.
+- Expired tokens reject through the normal JWT verifier.
+- Redis denylist read errors reject verification, never `catch -> allow`.
+- With no Redis backend configured, `isDenylistConfigured()` reports false, valid tokens still verify under the key-rotation + short-TTL model, and `revokeInternalToken()` throws so callers know per-token revocation did not take effect.
+
+## Commands
+
+| Command | Result |
+| --- | --- |
+| `bun test --isolate packages/cloud/shared/src/lib/auth/jwt-internal.test.ts` | PASS - 8 tests, 13 assertions |
+| `bun run --cwd packages/cloud/shared lint` | PASS - 1387 files, no fixes applied |
+| `bun run --cwd packages/cloud/shared typecheck` | BLOCKED by unrelated transitive `packages/app-core` `@elizaos/auth/*` module resolution/type errors |
+| `bun run --cwd packages/cloud/shared test` | BLOCKED by unrelated package baseline failures; focused JWT auth file passed in this run |
+| `bun run audit:error-policy-ratchet` | PASS - no new fallback-slop in touched files |
+| `git diff --check` | PASS |
+| `bun run verify` | BLOCKED by unrelated workspace lint (`@elizaos/electrobun#lint` reported as failed; log also includes TUI/capacitor lint diagnostics); root write-mode lint side effects were reverted |
+
+Full `packages/cloud/shared test` observed result:
+
+- 2800 pass
+- 59 skip
+- 8 fail
+- 1 module-load error
+- 8077 assertions
+- Failures/errors observed outside touched JWT files: container billing `settled_at` PGlite schema mismatch, advertising dayparting/bid-control assertions, and missing `src/lib/eliza/shared/utils/helpers` test module.
+
+## Evidence N/A
+
+- Screenshots/video: N/A - security/API hardening, no UI path.
+- Browser/network capture: N/A - shared auth helper, no route surface changed in this PR.
+- Real-LLM trajectory: N/A - no prompt, model, action, or agent behavior changed.
+- Audio evidence: N/A - no voice/TTS/STT path changed.
+- Migration up/down and DB state: N/A - Redis TTL marker only; no relational schema or migration changed.

--- a/packages/cloud/shared/src/lib/auth/jwt-internal-denylist.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-internal-denylist.ts
@@ -1,0 +1,157 @@
+/**
+ * Internal JWT `jti` Revocation Denylist
+ *
+ * Backs the `jti` (JWT ID) revocation contract for internal service-to-service
+ * tokens minted by {@link ./jwt-internal.signInternalToken}.
+ *
+ * ## Revocation model
+ * Internal tokens are short-lived (1h, see `TOKEN_LIFETIME_SECONDS`). Two
+ * complementary revocation mechanisms exist:
+ *
+ *  1. **Signing-key rotation** — rotating `JWT_SIGNING_*` invalidates *every*
+ *     outstanding token immediately. This is the blast-radius control.
+ *  2. **Per-`jti` denylist (this module)** — revokes a *single* compromised
+ *     token before its natural expiry, without disrupting every other pod.
+ *
+ * The denylist is stored in the same Redis backend already used across cloud
+ * (rate limits, credit events, A2A task store — see `cache/redis-factory`).
+ * Entries are written with a TTL equal to the token's remaining lifetime, so
+ * the store self-cleans and never grows unbounded: once a revoked token would
+ * have expired anyway, its denylist entry expires too.
+ *
+ * ## Fail-closed
+ * `isJtiRevoked` throws on a store error rather than returning `false`. The
+ * verifier ({@link ./jwt-internal.verifyInternalToken}) treats a thrown
+ * denylist check as a verification failure — a token is never accepted while
+ * the denylist is unreachable. This matches the repo's no-silent-fallback
+ * policy (never `catch → allow`).
+ *
+ * ## Degradation (no Redis configured)
+ * When no Redis backend is configured at all, per-`jti` revocation is
+ * genuinely unsupported and the honest contract is key-rotation + TTL. In that
+ * case {@link isDenylistConfigured} returns `false`; the verifier documents and
+ * enforces this by skipping the (impossible) denylist read instead of failing
+ * every request. Deployments that require same-hour single-token revocation
+ * MUST configure Redis (`REDIS_URL` or `KV_REST_API_*`).
+ */
+
+import {
+  buildRedisClient,
+  type CompatibleRedis,
+  hasRedisConfig,
+  isCloudflareWorkerRuntime,
+} from "../cache/redis-factory";
+import { logger } from "../utils/logger";
+
+/** Redis key prefix for revoked internal-JWT ids. */
+const DENYLIST_KEY_PREFIX = "internal-jwt:revoked:";
+
+/**
+ * Absolute ceiling (seconds) for a denylist entry's TTL. Guards against a
+ * bogus/oversized `expSeconds` pinning a key in Redis indefinitely. No internal
+ * token lives longer than `TOKEN_LIFETIME_SECONDS` (1h), so 2h is generous.
+ */
+const MAX_DENYLIST_TTL_SECONDS = 2 * 60 * 60;
+
+/** Env prefix so dev/prod sharing one Redis instance don't collide. */
+const ENV_PREFIX = process.env.ENVIRONMENT || "local";
+
+function denylistKey(jti: string): string {
+  return `${ENV_PREFIX}:${DENYLIST_KEY_PREFIX}${jti}`;
+}
+
+let cachedRedis: CompatibleRedis | null = null;
+
+/**
+ * Resolve the Redis client. On Workers a client is built per call (a cached TCP
+ * socket belongs to the request that opened it); on Node the client is cached.
+ * Mirrors the pattern in `middleware/rate-limit-redis`.
+ */
+function getRedis(): CompatibleRedis | null {
+  if (!isCloudflareWorkerRuntime() && cachedRedis) return cachedRedis;
+  const client = buildRedisClient();
+  if (client && !isCloudflareWorkerRuntime()) cachedRedis = client;
+  return client;
+}
+
+/**
+ * True when a Redis backend is configured and per-`jti` revocation is therefore
+ * supported. When `false`, revocation falls back to key-rotation + TTL only.
+ */
+export function isDenylistConfigured(): boolean {
+  return hasRedisConfig();
+}
+
+/**
+ * Clamp a token's remaining lifetime to a sane positive TTL for the denylist
+ * entry. Already-expired tokens still get a small floor so a same-instant
+ * revoke+verify race is honored.
+ */
+function computeTtlSeconds(expSeconds: number | undefined): number {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (typeof expSeconds !== "number" || !Number.isFinite(expSeconds)) {
+    // No/invalid exp — fall back to the max token lifetime ceiling.
+    return MAX_DENYLIST_TTL_SECONDS;
+  }
+  const remaining = expSeconds - nowSeconds;
+  if (remaining <= 0) return 1; // floor so a just-expired revoke is still recorded briefly
+  return Math.min(remaining, MAX_DENYLIST_TTL_SECONDS);
+}
+
+/**
+ * Revoke a single internal token by its `jti`. Idempotent.
+ *
+ * @param jti - the token id to revoke (from `payload.jti`).
+ * @param expSeconds - the token's `exp` (Unix seconds). Used to auto-expire the
+ *   denylist entry once the token would have expired anyway.
+ * @throws if no Redis is configured (revocation is impossible — caller must
+ *   know it did NOT take effect) or if the store write fails.
+ */
+export async function revokeInternalToken(jti: string, expSeconds?: number): Promise<void> {
+  if (!jti) {
+    throw new Error("revokeInternalToken: jti is required");
+  }
+  const redis = getRedis();
+  if (!redis) {
+    throw new Error(
+      "revokeInternalToken: no Redis backend configured — per-jti revocation unsupported; rotate JWT_SIGNING_* keys instead",
+    );
+  }
+  const ttl = computeTtlSeconds(expSeconds);
+  // `set key value EX ttl` — value is a marker; presence is what matters.
+  await redis.set(denylistKey(jti), "1", { ex: ttl });
+  logger.info("[internal-jwt] revoked jti", { jti, ttl });
+}
+
+/**
+ * Check whether a `jti` has been revoked.
+ *
+ * @returns `true` if revoked, `false` if not (or if the denylist is not
+ *   configured — see module docs; that path is only reached when Redis is
+ *   entirely absent, i.e. revocation is unsupported by deployment).
+ * @throws if the store read fails while Redis IS configured — the caller must
+ *   fail closed (reject the token) rather than treat an errored check as "not
+ *   revoked".
+ */
+export async function isJtiRevoked(jti: string): Promise<boolean> {
+  if (!jti) {
+    // A missing jti can never have been individually revoked; the verifier
+    // already rejects tokens without a jti claim upstream.
+    return false;
+  }
+  const redis = getRedis();
+  if (!redis) {
+    // No backend configured: per-jti revocation genuinely unsupported.
+    // Honest contract is key-rotation + TTL; do not fabricate a check result.
+    return false;
+  }
+  // Intentionally NOT wrapped in try/catch → allow: a store error must
+  // propagate so the verifier fails closed.
+  const hit = await redis.get(denylistKey(jti));
+  return hit !== null && hit !== undefined;
+}
+
+/** Test-only: drop the cached client so a fresh env is picked up. */
+export function __resetDenylistClientForTests(): void {
+  cachedRedis = null;
+}

--- a/packages/cloud/shared/src/lib/auth/jwt-internal.test.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-internal.test.ts
@@ -10,8 +10,8 @@
  *    (per-jti revocation unsupported → key-rotation model), and `revoke` throws.
  */
 
+import { afterEach, beforeEach, describe, expect, mock, setSystemTime, test } from "bun:test";
 import { generateKeyPairSync } from "node:crypto";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Generate a real ES256 keypair and expose it the way `jwks.ts` reads it:
 // base64-encoded PEM in JWT_SIGNING_PRIVATE_KEY / JWT_SIGNING_PUBLIC_KEY.
@@ -29,17 +29,51 @@ function makeKeys() {
 
 const KEYS = makeKeys();
 
-/** Import the module fresh so cached keys/redis client pick up current env. */
-async function loadModule() {
-  vi.resetModules();
-  return await import("./jwt-internal");
-}
+const denylistStore = new Map<string, string>();
+let denylistConfigured = true;
+let denylistGetError: Error | null = null;
+
+mock.module("../cache/redis-factory", () => ({
+  buildRedisClient: () => {
+    if (!denylistConfigured) return null;
+    return {
+      async get(key: string) {
+        if (denylistGetError) throw denylistGetError;
+        return denylistStore.get(key) ?? null;
+      },
+      async set(key: string, value: unknown, options?: { ex?: number }) {
+        denylistStore.set(key, String(value));
+        if (options?.ex !== undefined) {
+          setTimeout(() => denylistStore.delete(key), options.ex * 1000).unref?.();
+        }
+        return "OK";
+      },
+    };
+  },
+  hasRedisConfig: () => denylistConfigured,
+  isCloudflareWorkerRuntime: () => false,
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+  },
+}));
+
+const mod = await import("./jwt-internal");
+const denylistMod = await import("./jwt-internal-denylist");
 
 describe("internal JWT jti revocation denylist (#12879)", () => {
   beforeEach(() => {
     process.env.JWT_SIGNING_PRIVATE_KEY = KEYS.priv;
     process.env.JWT_SIGNING_PUBLIC_KEY = KEYS.pub;
     process.env.JWT_SIGNING_KEY_ID = "test";
+    process.env.MOCK_REDIS = "1";
+    denylistStore.clear();
+    denylistConfigured = true;
+    denylistGetError = null;
+    denylistMod.__resetDenylistClientForTests();
+    setSystemTime();
   });
 
   afterEach(() => {
@@ -50,8 +84,7 @@ describe("internal JWT jti revocation denylist (#12879)", () => {
     delete process.env.REDIS_URL;
     delete process.env.KV_REST_API_URL;
     delete process.env.KV_REST_API_TOKEN;
-    vi.restoreAllMocks();
-    vi.useRealTimers();
+    setSystemTime();
   });
 
   describe("with a Redis-backed denylist configured", () => {
@@ -59,8 +92,7 @@ describe("internal JWT jti revocation denylist (#12879)", () => {
       process.env.MOCK_REDIS = "1";
     });
 
-    it("verifies a freshly minted token within TTL (positive)", async () => {
-      const mod = await loadModule();
+    test("verifies a freshly minted token within TTL (positive)", async () => {
       const { access_token } = await mod.signInternalToken({
         subject: "pod-1",
         service: "discord-gateway",
@@ -73,8 +105,7 @@ describe("internal JWT jti revocation denylist (#12879)", () => {
       expect(typeof result.payload.jti).toBe("string");
     });
 
-    it("rejects a token after its jti is revoked (negative)", async () => {
-      const mod = await loadModule();
+    test("rejects a token after its jti is revoked (negative)", async () => {
       const { access_token } = await mod.signInternalToken({ subject: "pod-2" });
 
       // Sanity: valid before revocation.
@@ -88,8 +119,7 @@ describe("internal JWT jti revocation denylist (#12879)", () => {
       await expect(mod.verifyInternalToken(access_token)).rejects.toThrow(/revoked/i);
     });
 
-    it("does not revoke unrelated tokens (revocation is per-jti)", async () => {
-      const mod = await loadModule();
+    test("does not revoke unrelated tokens (revocation is per-jti)", async () => {
       const a = await mod.signInternalToken({ subject: "pod-a" });
       const b = await mod.signInternalToken({ subject: "pod-b" });
 
@@ -102,57 +132,37 @@ describe("internal JWT jti revocation denylist (#12879)", () => {
       expect(vb.valid).toBe(true);
     });
 
-    it("rejects an expired token (negative)", async () => {
-      const mod = await loadModule();
+    test("rejects an expired token (negative)", async () => {
       // Mint a token, then advance the system clock past its exp. jose reads
       // the wall clock for exp validation, so fake timers move it forward.
-      vi.useFakeTimers();
+      const now = new Date();
       try {
+        setSystemTime(now);
         const { access_token } = await mod.signInternalToken({
           subject: "pod-exp",
           expiresIn: 1,
         });
 
         // Jump well past exp (+ jose's default clock tolerance).
-        vi.advanceTimersByTime(120_000);
+        setSystemTime(new Date(now.getTime() + 120_000));
 
         await expect(mod.verifyInternalToken(access_token)).rejects.toThrow(/exp/i);
       } finally {
-        vi.useRealTimers();
+        setSystemTime();
       }
     });
 
-    it("fails closed when the denylist store errors (never allow-on-error)", async () => {
+    test("fails closed when the denylist store errors (never allow-on-error)", async () => {
       // Force the underlying Redis GET to throw. The denylist read is
       // intentionally un-try/catch'd, so the error propagates through
       // verifyInternalToken and the token is rejected (never allowed).
-      // `vi.doMock` is NOT hoisted and applies to the dynamic imports that
-      // follow, surviving the `vi.resetModules()` inside loadModule().
-      const throwingGet = vi.fn().mockRejectedValue(new Error("redis unavailable"));
-      vi.doMock("../cache/redis-factory", async () => {
-        const actual =
-          await vi.importActual<typeof import("../cache/redis-factory")>("../cache/redis-factory");
-        return {
-          ...actual,
-          buildRedisClient: () =>
-            ({
-              get: throwingGet,
-              set: vi.fn().mockResolvedValue("OK"),
-            }) as unknown as ReturnType<typeof actual.buildRedisClient>,
-        };
+      denylistGetError = new Error("redis unavailable");
+
+      const { access_token } = await mod.signInternalToken({
+        subject: "pod-err",
       });
 
-      try {
-        const mod = await loadModule();
-        const { access_token } = await mod.signInternalToken({
-          subject: "pod-err",
-        });
-
-        await expect(mod.verifyInternalToken(access_token)).rejects.toThrow(/redis unavailable/i);
-        expect(throwingGet).toHaveBeenCalled();
-      } finally {
-        vi.doUnmock("../cache/redis-factory");
-      }
+      await expect(mod.verifyInternalToken(access_token)).rejects.toThrow(/redis unavailable/i);
     });
   });
 
@@ -163,22 +173,21 @@ describe("internal JWT jti revocation denylist (#12879)", () => {
       delete process.env.REDIS_URL;
       delete process.env.KV_REST_API_URL;
       delete process.env.KV_REST_API_TOKEN;
+      denylistConfigured = false;
+      denylistMod.__resetDenylistClientForTests();
     });
 
-    it("still verifies valid tokens (key-rotation + TTL model)", async () => {
-      const mod = await loadModule();
+    test("still verifies valid tokens (key-rotation + TTL model)", async () => {
       const { access_token } = await mod.signInternalToken({ subject: "pod-nr" });
       const result = await mod.verifyInternalToken(access_token);
       expect(result.valid).toBe(true);
     });
 
-    it("reports the denylist as not configured", async () => {
-      const mod = await loadModule();
+    test("reports the denylist as not configured", async () => {
       expect(mod.isDenylistConfigured()).toBe(false);
     });
 
-    it("revokeInternalToken throws so callers know it did not take effect", async () => {
-      const mod = await loadModule();
+    test("revokeInternalToken throws so callers know it did not take effect", async () => {
       await expect(mod.revokeInternalToken("some-jti", undefined)).rejects.toThrow(
         /no Redis backend configured/i,
       );

--- a/packages/cloud/shared/src/lib/auth/jwt-internal.test.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-internal.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for internal JWT signing/verification and the `jti` revocation denylist.
+ *
+ * Covers finding L12 (#12879):
+ *  - positive: a freshly minted token verifies within TTL.
+ *  - negative: a token whose `jti` is revoked is rejected.
+ *  - negative: an expired token is rejected.
+ *  - fail-closed: a denylist store error rejects the token (never allow-on-error).
+ *  - degradation: with no Redis configured, verification still succeeds
+ *    (per-jti revocation unsupported → key-rotation model), and `revoke` throws.
+ */
+
+import { generateKeyPairSync } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Generate a real ES256 keypair and expose it the way `jwks.ts` reads it:
+// base64-encoded PEM in JWT_SIGNING_PRIVATE_KEY / JWT_SIGNING_PUBLIC_KEY.
+function makeKeys() {
+  const { publicKey, privateKey } = generateKeyPairSync("ec", {
+    namedCurve: "P-256",
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  return {
+    priv: Buffer.from(privateKey).toString("base64"),
+    pub: Buffer.from(publicKey).toString("base64"),
+  };
+}
+
+const KEYS = makeKeys();
+
+/** Import the module fresh so cached keys/redis client pick up current env. */
+async function loadModule() {
+  vi.resetModules();
+  return await import("./jwt-internal");
+}
+
+describe("internal JWT jti revocation denylist (#12879)", () => {
+  beforeEach(() => {
+    process.env.JWT_SIGNING_PRIVATE_KEY = KEYS.priv;
+    process.env.JWT_SIGNING_PUBLIC_KEY = KEYS.pub;
+    process.env.JWT_SIGNING_KEY_ID = "test";
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SIGNING_PRIVATE_KEY;
+    delete process.env.JWT_SIGNING_PUBLIC_KEY;
+    delete process.env.JWT_SIGNING_KEY_ID;
+    delete process.env.MOCK_REDIS;
+    delete process.env.REDIS_URL;
+    delete process.env.KV_REST_API_URL;
+    delete process.env.KV_REST_API_TOKEN;
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe("with a Redis-backed denylist configured", () => {
+    beforeEach(() => {
+      process.env.MOCK_REDIS = "1";
+    });
+
+    it("verifies a freshly minted token within TTL (positive)", async () => {
+      const mod = await loadModule();
+      const { access_token } = await mod.signInternalToken({
+        subject: "pod-1",
+        service: "discord-gateway",
+      });
+
+      const result = await mod.verifyInternalToken(access_token);
+      expect(result.valid).toBe(true);
+      expect(result.payload.sub).toBe("pod-1");
+      expect(result.payload.service).toBe("discord-gateway");
+      expect(typeof result.payload.jti).toBe("string");
+    });
+
+    it("rejects a token after its jti is revoked (negative)", async () => {
+      const mod = await loadModule();
+      const { access_token } = await mod.signInternalToken({ subject: "pod-2" });
+
+      // Sanity: valid before revocation.
+      const before = await mod.verifyInternalToken(access_token);
+      expect(before.valid).toBe(true);
+
+      // Revoke by jti, then verify must reject.
+      const { payload } = before;
+      await mod.revokeInternalToken(payload.jti, payload.exp);
+
+      await expect(mod.verifyInternalToken(access_token)).rejects.toThrow(/revoked/i);
+    });
+
+    it("does not revoke unrelated tokens (revocation is per-jti)", async () => {
+      const mod = await loadModule();
+      const a = await mod.signInternalToken({ subject: "pod-a" });
+      const b = await mod.signInternalToken({ subject: "pod-b" });
+
+      const va = await mod.verifyInternalToken(a.access_token);
+      await mod.revokeInternalToken(va.payload.jti, va.payload.exp);
+
+      // a is revoked, b is untouched.
+      await expect(mod.verifyInternalToken(a.access_token)).rejects.toThrow(/revoked/i);
+      const vb = await mod.verifyInternalToken(b.access_token);
+      expect(vb.valid).toBe(true);
+    });
+
+    it("rejects an expired token (negative)", async () => {
+      const mod = await loadModule();
+      // Mint a token, then advance the system clock past its exp. jose reads
+      // the wall clock for exp validation, so fake timers move it forward.
+      vi.useFakeTimers();
+      try {
+        const { access_token } = await mod.signInternalToken({
+          subject: "pod-exp",
+          expiresIn: 1,
+        });
+
+        // Jump well past exp (+ jose's default clock tolerance).
+        vi.advanceTimersByTime(120_000);
+
+        await expect(mod.verifyInternalToken(access_token)).rejects.toThrow(/exp/i);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("fails closed when the denylist store errors (never allow-on-error)", async () => {
+      // Force the underlying Redis GET to throw. The denylist read is
+      // intentionally un-try/catch'd, so the error propagates through
+      // verifyInternalToken and the token is rejected (never allowed).
+      // `vi.doMock` is NOT hoisted and applies to the dynamic imports that
+      // follow, surviving the `vi.resetModules()` inside loadModule().
+      const throwingGet = vi.fn().mockRejectedValue(new Error("redis unavailable"));
+      vi.doMock("../cache/redis-factory", async () => {
+        const actual =
+          await vi.importActual<typeof import("../cache/redis-factory")>("../cache/redis-factory");
+        return {
+          ...actual,
+          buildRedisClient: () =>
+            ({
+              get: throwingGet,
+              set: vi.fn().mockResolvedValue("OK"),
+            }) as unknown as ReturnType<typeof actual.buildRedisClient>,
+        };
+      });
+
+      try {
+        const mod = await loadModule();
+        const { access_token } = await mod.signInternalToken({
+          subject: "pod-err",
+        });
+
+        await expect(mod.verifyInternalToken(access_token)).rejects.toThrow(/redis unavailable/i);
+        expect(throwingGet).toHaveBeenCalled();
+      } finally {
+        vi.doUnmock("../cache/redis-factory");
+      }
+    });
+  });
+
+  describe("with no Redis backend configured (revocation unsupported)", () => {
+    beforeEach(() => {
+      // Ensure no redis creds are present.
+      delete process.env.MOCK_REDIS;
+      delete process.env.REDIS_URL;
+      delete process.env.KV_REST_API_URL;
+      delete process.env.KV_REST_API_TOKEN;
+    });
+
+    it("still verifies valid tokens (key-rotation + TTL model)", async () => {
+      const mod = await loadModule();
+      const { access_token } = await mod.signInternalToken({ subject: "pod-nr" });
+      const result = await mod.verifyInternalToken(access_token);
+      expect(result.valid).toBe(true);
+    });
+
+    it("reports the denylist as not configured", async () => {
+      const mod = await loadModule();
+      expect(mod.isDenylistConfigured()).toBe(false);
+    });
+
+    it("revokeInternalToken throws so callers know it did not take effect", async () => {
+      const mod = await loadModule();
+      await expect(mod.revokeInternalToken("some-jti", undefined)).rejects.toThrow(
+        /no Redis backend configured/i,
+      );
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/auth/jwt-internal.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-internal.ts
@@ -8,6 +8,13 @@
 import { type JWTPayload, jwtVerify, SignJWT } from "jose";
 import { nanoid } from "nanoid";
 import { getAlgorithm, getKeyId, getPrivateKey, getPublicKey } from "./jwks";
+import { isJtiRevoked } from "./jwt-internal-denylist";
+
+export {
+  isDenylistConfigured,
+  isJtiRevoked,
+  revokeInternalToken,
+} from "./jwt-internal-denylist";
 
 /**
  * JWT token lifetime in seconds (1 hour).
@@ -39,7 +46,15 @@ export interface InternalJWTPayload extends JWTPayload {
   iat: number;
   /** Expiration (Unix timestamp) */
   exp: number;
-  /** JWT ID - unique identifier for revocation */
+  /**
+   * JWT ID — unique per-token nonce.
+   *
+   * Revocation model: a single token can be revoked before its natural expiry
+   * via the `jti` denylist (`revokeInternalToken`), enforced fail-closed in
+   * `verifyInternalToken`. When no Redis backend is configured, per-`jti`
+   * revocation is unsupported and revocation falls back to signing-key
+   * rotation + short TTL. See `./jwt-internal-denylist`.
+   */
   jti: string;
   /** Service type (e.g., "discord-gateway") */
   service?: string;
@@ -105,7 +120,13 @@ export async function signInternalToken(options: SignTokenOptions): Promise<{
 /**
  * Verify an internal JWT and extract its payload.
  *
- * @throws Error if token is invalid, expired, or has wrong issuer/audience
+ * Enforces the `jti` revocation contract: a token whose `jti` has been revoked
+ * via `revokeInternalToken` is rejected. The denylist check is FAIL-CLOSED — if
+ * the denylist store errors while it is configured, verification throws (the
+ * token is NOT accepted). See `./jwt-internal-denylist`.
+ *
+ * @throws Error if token is invalid, expired, has wrong issuer/audience, is
+ *   missing a required claim, has a revoked `jti`, or the denylist check fails.
  */
 export async function verifyInternalToken(token: string): Promise<VerificationResult> {
   const publicKey = await getPublicKey();
@@ -122,6 +143,12 @@ export async function verifyInternalToken(token: string): Promise<VerificationRe
   }
   if (!payload.jti) {
     throw new Error("Token missing JWT ID claim");
+  }
+
+  // Revocation denylist check — fail closed. A thrown store error propagates so
+  // the token is rejected rather than accepted on an unreachable denylist.
+  if (await isJtiRevoked(payload.jti)) {
+    throw new Error("Token has been revoked");
   }
 
   return {


### PR DESCRIPTION
Closes #12879 (finding L12, split from #12227).

## Contract decision: implement the denylist (Option B)

The `jti` claim in `jwt-internal.ts` was documented as "unique identifier for revocation", but **no verifier ever checked it** — `verifyInternalToken` validated signature/exp/aud only, and a repo-wide grep found no `jti` consumer. The contract overclaimed.

The grounded `[cloud-money]` analysis on the issue flagged this as a posture call between **A** (document revocation-as-unsupported: key-rotation + short TTL) and **B** (implement a per-`jti` denylist). I went with **B**, because the issue's own **Verification** and **Done when** sections require a working *"denied JWT `jti` → reject"* path with negative tests and route/unit evidence. A doc-only change (A) would not satisfy those acceptance criteria. I also folded in A's honest-contract point: when no revocation backend exists, the code says so rather than pretending.

## Design

- **Redis-backed, reusing existing infra.** The denylist uses the same `cache/redis-factory` client the rest of cloud already relies on (rate limits, credit events, A2A task store) — no new dependency, no new store to operate.
- **TTL-bounded, self-cleaning.** A revoked `jti` is written with a TTL equal to the token's *remaining* lifetime (clamped to a 2h ceiling). Once the token would have expired anyway, its denylist entry expires too — the store never grows unbounded. This directly addresses the "adds a read on every verify for ≤1h of benefit" concern: the benefit is *same-hour single-token* revocation, and the cost is bounded and self-limiting.
- **Fail-closed.** `isJtiRevoked` does **not** wrap the store read in `catch → return false`. A store error propagates through `verifyInternalToken`, which rejects the token. A token is never accepted while the denylist is unreachable — per the repo's no-silent-fallback policy.
- **Honest degradation.** When *no* Redis backend is configured at all, per-`jti` revocation is genuinely impossible. In that case verification still succeeds (the documented fallback is signing-key rotation + short TTL), `revokeInternalToken` **throws** so callers know the revoke did not take effect, and `isDenylistConfigured()` surfaces the posture. Deployments needing same-hour single-token revocation must configure Redis.
- **Doc fix.** Corrected the `jti` claim comment to describe the actual two-tier revocation model (key-rotation for blast-radius, per-`jti` denylist for single tokens).

New exports (re-exported from `jwt-internal.ts` for callers): `revokeInternalToken`, `isJtiRevoked`, `isDenylistConfigured`.

## Test evidence

`packages/cloud/shared/src/lib/auth/jwt-internal.test.ts` — **8 tests, all green** (real ES256 keypair generated per-run; `MOCK_REDIS` for the configured lane; env stripped for the degradation lane):

**With a Redis-backed denylist configured:**
1. verifies a freshly minted token within TTL (positive)
2. rejects a token after its `jti` is revoked (negative)
3. does not revoke unrelated tokens — revocation is per-`jti`
4. rejects an expired token (negative)
5. fails closed when the denylist store errors — never allow-on-error

**With no Redis backend configured (revocation unsupported):**
6. still verifies valid tokens (key-rotation + TTL model)
7. reports the denylist as not configured
8. `revokeInternalToken` throws so callers know it did not take effect

```
 ✓ src/lib/auth/jwt-internal.test.ts (8 tests) 7567ms
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

**Before/after:** before, a compromised internal token was valid for its full 1h TTL with no way to kill it short of rotating signing keys (which nukes every pod's token). After, an operator can `revokeInternalToken(jti, exp)` and that single token is rejected on the next verify, fail-closed, with the entry auto-expiring at the token's natural exp.

- `tsgo --noEmit`: no errors in the changed files (21 pre-existing baseline errors elsewhere, all unrelated to auth).
- biome check: clean.

## Verification checklist
- UI evidence: `N/A - security/API hardening, no UI/model/audio path`
- Model evidence: `N/A - security/API hardening, no UI/model/audio path`
- Audio evidence: `N/A - security/API hardening, no UI/model/audio path`

— [sol-orch]
