### PR TITLE
fix(#12878): validate webhook forwarder signatures

### DIFF
--- a/.github/issue-evidence/12878-webhook-auth-replay.md
+++ b/.github/issue-evidence/12878-webhook-auth-replay.md
@@ -1,0 +1,75 @@
+# Issue #12878 Webhook Auth and Replay Evidence
+
+## Scope
+
+- `packages/cloud/api/eliza-app/webhook/_forward.ts`
+  - Added local platform-native signature validation before forwarding to the internal webhook gateway.
+  - Telegram: `x-telegram-bot-api-secret-token`.
+  - Blooio: timestamped `x-blooio-signature` HMAC-SHA256 with a 120 second freshness window.
+  - WhatsApp: `x-hub-signature-256` HMAC-SHA256.
+  - Twilio: `x-twilio-signature` over canonical URL plus sorted form fields.
+  - Production fails closed when a platform secret is not configured; non-production preserves existing local/e2e behavior and logs the skip.
+- `packages/cloud/api/v1/telegram/webhook/[orgId]/route.ts`
+  - Removed the implicit unverified development bypass.
+  - Local tunnel testing now requires `NODE_ENV=development` plus `TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED_DEV=1`.
+- Existing replay dedupe coverage on develop was re-run for BlueBubbles and Stripe Connect.
+
+## Verification
+
+Commands run from `/private/tmp/codex-12878-webhooks`:
+
+```bash
+bun run --cwd packages/cloud/api test __tests__/eliza-app-webhook-suffix.test.ts
+```
+
+Result: passed, 17 tests / 21 expects.
+
+```bash
+bun test 'packages/cloud/api/v1/telegram/webhook/[orgId]/auth-policy.test.ts'
+```
+
+Result: passed, 2 tests / 4 expects.
+
+```bash
+bun run --cwd packages/cloud/api typecheck
+```
+
+Result: no errors for touched files when filtered for `eliza-app/webhook|v1/telegram/webhook|auth-policy|_forward`.
+
+```bash
+bun run build:core
+```
+
+Result: passed, 68 tasks successful.
+
+```bash
+bun test packages/cloud/api/webhooks/bluebubbles/dedupe.test.ts
+```
+
+Result: passed, 2 tests / 8 expects.
+
+```bash
+bun test packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/dedupe.test.ts
+```
+
+Result: passed, 1 test / 4 expects.
+
+```bash
+bunx @biomejs/biome check packages/cloud/api/eliza-app/webhook/_forward.ts packages/cloud/api/__tests__/eliza-app-webhook-suffix.test.ts 'packages/cloud/api/v1/telegram/webhook/[orgId]/route.ts' 'packages/cloud/api/v1/telegram/webhook/[orgId]/auth-policy.test.ts'
+```
+
+Result: passed.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Evidence Matrix
+
+- Backend logs: covered by route/logger assertions and rejection paths in unit tests.
+- Frontend screenshots/video: N/A, backend-only webhook hardening.
+- Real LLM trajectory: N/A, no agent action, prompt, or model behavior change.
+- Native/mobile/desktop capture: N/A, backend-only webhook hardening.
+- Audio walkthrough: N/A, no voice/TTS/STT surface touched.

--- a/packages/cloud/api/__tests__/eliza-app-webhook-suffix.test.ts
+++ b/packages/cloud/api/__tests__/eliza-app-webhook-suffix.test.ts
@@ -1,5 +1,6 @@
 /**
- * Path-traversal guard for the eliza-app webhook forwarder (finding L3, #12878).
+ * Path-traversal and signature guards for the eliza-app webhook forwarder
+ * (finding L3/L4, #12878).
  *
  * `_forward.ts` appends the request's trailing path onto the internal gateway
  * URL. These tests pin that only empty/benign safe-char suffixes survive, and
@@ -15,7 +16,7 @@ mock.module("@/lib/utils/logger", () => ({
   logger: { error: mock(), info: mock(), warn: mock(), debug: mock() },
 }));
 
-const { safeWebhookSuffix } = (await import(
+const { safeWebhookSuffix, verifyLocalWebhookSignature } = (await import(
   "../eliza-app/webhook/_forward"
 )) as typeof import("../eliza-app/webhook/_forward");
 
@@ -51,5 +52,137 @@ describe("safeWebhookSuffix", () => {
     `${base}/foo%00`,
   ])("rejects a traversal/encoded suffix: %s", (pathname) => {
     expect(safeWebhookSuffix(pathname, P)).toBeNull();
+  });
+});
+
+async function hmacHex(
+  secret: string,
+  payload: string,
+  algorithm = "SHA-256",
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: algorithm },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(payload),
+  );
+  return Array.from(new Uint8Array(signature))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function hmacBase64(
+  secret: string,
+  payload: string,
+  algorithm = "SHA-1",
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: algorithm },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(payload),
+  );
+  return btoa(String.fromCharCode(...new Uint8Array(signature)));
+}
+
+describe("verifyLocalWebhookSignature", () => {
+  test("accepts and rejects Telegram secret-token headers", async () => {
+    const request = new Request(
+      "https://api.example.test/api/eliza-app/webhook/telegram",
+      {
+        method: "POST",
+        headers: { "x-telegram-bot-api-secret-token": "telegram-secret" },
+        body: "{}",
+      },
+    );
+
+    await expect(
+      verifyLocalWebhookSignature(request, "telegram", "", "telegram-secret"),
+    ).resolves.toBe(true);
+    await expect(
+      verifyLocalWebhookSignature(request, "telegram", "", "wrong-secret"),
+    ).resolves.toBe(false);
+  });
+
+  test("accepts and rejects Blooio timestamped HMAC signatures", async () => {
+    const body = JSON.stringify({
+      event: "message.received",
+      message_id: "m1",
+    });
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = await hmacHex("blooio-secret", `${timestamp}.${body}`);
+    const request = new Request(
+      "https://api.example.test/api/eliza-app/webhook/blooio",
+      {
+        method: "POST",
+        headers: { "x-blooio-signature": `t=${timestamp},v1=${signature}` },
+        body,
+      },
+    );
+
+    await expect(
+      verifyLocalWebhookSignature(request, "blooio", body, "blooio-secret"),
+    ).resolves.toBe(true);
+    await expect(
+      verifyLocalWebhookSignature(request, "blooio", body, "wrong-secret"),
+    ).resolves.toBe(false);
+  });
+
+  test("accepts and rejects WhatsApp sha256 signatures", async () => {
+    const body = JSON.stringify({ object: "whatsapp_business_account" });
+    const signature = await hmacHex("whatsapp-secret", body);
+    const request = new Request(
+      "https://api.example.test/api/eliza-app/webhook/whatsapp",
+      {
+        method: "POST",
+        headers: { "x-hub-signature-256": `sha256=${signature}` },
+        body,
+      },
+    );
+
+    await expect(
+      verifyLocalWebhookSignature(request, "whatsapp", body, "whatsapp-secret"),
+    ).resolves.toBe(true);
+    await expect(
+      verifyLocalWebhookSignature(request, "whatsapp", body, "wrong-secret"),
+    ).resolves.toBe(false);
+  });
+
+  test("accepts and rejects Twilio signatures over URL plus sorted form params", async () => {
+    const body = new URLSearchParams({
+      From: "+15551234567",
+      MessageSid: "SM_test",
+      To: "+15550000000",
+    }).toString();
+    const url = "https://api.example.test/api/eliza-app/webhook/twilio";
+    const signedPayload = `${url}From+15551234567MessageSidSM_testTo+15550000000`;
+    const signature = await hmacBase64("twilio-secret", signedPayload);
+    const request = new Request(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-twilio-signature": signature,
+      },
+      body,
+    });
+
+    await expect(
+      verifyLocalWebhookSignature(request, "twilio", body, "twilio-secret"),
+    ).resolves.toBe(true);
+    await expect(
+      verifyLocalWebhookSignature(request, "twilio", body, "wrong-secret"),
+    ).resolves.toBe(false);
   });
 });

--- a/packages/cloud/api/eliza-app/webhook/_forward.ts
+++ b/packages/cloud/api/eliza-app/webhook/_forward.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqualSecret } from "@/lib/auth/cron";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext } from "@/types/cloud-worker-env";
 
@@ -45,6 +46,229 @@ export function safeWebhookSuffix(
 
 function requestSuffix(c: AppContext, platform: string): string | null {
   return safeWebhookSuffix(new URL(c.req.url).pathname, platform);
+}
+
+function isProduction(c: AppContext): boolean {
+  return (
+    c.env.NODE_ENV === "production" || process.env.NODE_ENV === "production"
+  );
+}
+
+function platformSecret(
+  c: AppContext,
+  platform: GatewayPlatform,
+): string | null {
+  switch (platform) {
+    case "telegram":
+      return readStringEnv(c, [
+        "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
+        "TELEGRAM_WEBHOOK_SECRET",
+      ]);
+    case "blooio":
+      return readStringEnv(c, [
+        "ELIZA_APP_BLOOIO_WEBHOOK_SECRET",
+        "BLOOIO_WEBHOOK_SECRET",
+      ]);
+    case "twilio":
+      return readStringEnv(c, [
+        "ELIZA_APP_TWILIO_AUTH_TOKEN",
+        "TWILIO_AUTH_TOKEN",
+      ]);
+    case "whatsapp":
+      return readStringEnv(c, [
+        "ELIZA_APP_WHATSAPP_APP_SECRET",
+        "WHATSAPP_APP_SECRET",
+      ]);
+  }
+}
+
+async function hmacHex(
+  secret: string,
+  payload: string,
+  algorithm: AlgorithmIdentifier,
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: algorithm },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(payload),
+  );
+  return Array.from(new Uint8Array(signature))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function hmacBase64(
+  secret: string,
+  payload: string,
+  algorithm: AlgorithmIdentifier,
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: algorithm },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(payload),
+  );
+  return btoa(String.fromCharCode(...new Uint8Array(signature)));
+}
+
+function constantTimeHexEqual(actual: string, expected: string): boolean {
+  return timingSafeEqualSecret(actual.toLowerCase(), expected.toLowerCase());
+}
+
+async function verifyBlooioSignature(
+  request: Request,
+  rawBody: string,
+  secret: string,
+): Promise<boolean> {
+  const signatureHeader = request.headers.get("x-blooio-signature") ?? "";
+  const parts = signatureHeader.split(",");
+  const timestampPart = parts.find((p) => p.startsWith("t="));
+  const signaturePart = parts.find((p) => p.startsWith("v1="));
+  if (!timestampPart || !signaturePart) return false;
+
+  const timestamp = Number.parseInt(timestampPart.slice(2), 10);
+  if (!Number.isFinite(timestamp)) return false;
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - timestamp) > 120) return false;
+
+  const expected = signaturePart.slice(3);
+  const computed = await hmacHex(secret, `${timestamp}.${rawBody}`, "SHA-256");
+  return constantTimeHexEqual(computed, expected);
+}
+
+async function verifyWhatsAppSignature(
+  request: Request,
+  rawBody: string,
+  secret: string,
+): Promise<boolean> {
+  const header = request.headers.get("x-hub-signature-256") ?? "";
+  if (!header.startsWith("sha256=")) return false;
+  const expected = header.slice("sha256=".length);
+  const computed = await hmacHex(secret, rawBody, "SHA-256");
+  return constantTimeHexEqual(computed, expected);
+}
+
+async function verifyTwilioSignature(
+  request: Request,
+  rawBody: string,
+  secret: string,
+): Promise<boolean> {
+  const signature = request.headers.get("x-twilio-signature") ?? "";
+  if (!signature) return false;
+
+  const url = new URL(request.url);
+  const forwardedProto = request.headers.get("x-forwarded-proto");
+  const forwardedHost = request.headers.get("x-forwarded-host");
+  if (forwardedProto) url.protocol = `${forwardedProto}:`;
+  if (forwardedHost) url.host = forwardedHost;
+
+  const params = new URLSearchParams(rawBody);
+  const sorted = Array.from(params.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}${value}`)
+    .join("");
+
+  const computed = await hmacBase64(
+    secret,
+    `${url.toString()}${sorted}`,
+    "SHA-1",
+  );
+  return timingSafeEqualSecret(computed, signature);
+}
+
+export async function verifyLocalWebhookSignature(
+  request: Request,
+  platform: GatewayPlatform,
+  rawBody: string,
+  secret: string,
+): Promise<boolean> {
+  switch (platform) {
+    case "telegram": {
+      const header =
+        request.headers.get("x-telegram-bot-api-secret-token") ?? "";
+      return timingSafeEqualSecret(header, secret);
+    }
+    case "blooio":
+      return verifyBlooioSignature(request, rawBody, secret);
+    case "twilio":
+      return verifyTwilioSignature(request, rawBody, secret);
+    case "whatsapp":
+      return verifyWhatsAppSignature(request, rawBody, secret);
+  }
+}
+
+async function validateLocalWebhookSignature(
+  c: AppContext,
+  platform: GatewayPlatform,
+): Promise<{ response?: Response; body?: string }> {
+  const secret = platformSecret(c, platform);
+  if (!secret) {
+    if (isProduction(c)) {
+      logger.error(
+        "[ElizaAppWebhook] webhook signature secret is not configured",
+        { platform },
+      );
+      return {
+        response: c.json(
+          {
+            success: false,
+            code: "WEBHOOK_SIGNATURE_NOT_CONFIGURED",
+            error: "Webhook signature secret is not configured",
+          },
+          503,
+        ),
+      };
+    }
+    logger.warn(
+      "[ElizaAppWebhook] webhook signature validation skipped outside production",
+      {
+        platform,
+      },
+    );
+    return {};
+  }
+
+  const needsBody =
+    platform !== "telegram" &&
+    c.req.method !== "GET" &&
+    c.req.method !== "HEAD";
+  const body = needsBody ? await c.req.text() : undefined;
+  const valid = await verifyLocalWebhookSignature(
+    c.req.raw,
+    platform,
+    body ?? "",
+    secret,
+  );
+  if (!valid) {
+    logger.warn("[ElizaAppWebhook] rejected invalid webhook signature", {
+      platform,
+    });
+    return {
+      response: c.json(
+        {
+          success: false,
+          code: "WEBHOOK_SIGNATURE_INVALID",
+          error: "Invalid webhook signature",
+        },
+        401,
+      ),
+    };
+  }
+
+  return { body };
 }
 
 interface ForwardOptions {
@@ -127,6 +351,9 @@ export async function forwardToWebhookGateway(
     );
   }
 
+  const validation = await validateLocalWebhookSignature(c, platform);
+  if (validation.response) return validation.response;
+
   const project =
     readStringEnv(c, ["ELIZA_APP_WEBHOOK_PROJECT"]) ?? "eliza-app";
   const target = new URL(baseUrl);
@@ -134,7 +361,10 @@ export async function forwardToWebhookGateway(
   target.pathname = `/webhook/${encodeURIComponent(project)}/${platform}${suffix}`;
   target.search = sourceUrl.search;
 
-  return proxyRequest(c, target, "webhook gateway", options);
+  return proxyRequest(c, target, "webhook gateway", {
+    ...options,
+    body: options.body ?? validation.body,
+  });
 }
 
 export async function forwardToDiscordWebhookHandler(

--- a/packages/cloud/api/v1/telegram/webhook/[orgId]/auth-policy.test.ts
+++ b/packages/cloud/api/v1/telegram/webhook/[orgId]/auth-policy.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Telegram webhook auth policy for local development (#12878 L4).
+ *
+ * A missing per-org webhook secret used to allow unverified development
+ * deliveries implicitly. The route now defaults closed; local tunnel testing
+ * must opt in with TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED_DEV=1.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+mock.module("@/lib/services/telegram-automation", () => ({
+  telegramAutomationService: {
+    getWebhookSecret: mock(async () => null),
+    getBotToken: mock(async () => null),
+  },
+}));
+
+mock.module("@/lib/services/telegram-automation/app-automation", () => ({
+  telegramAppAutomationService: {
+    getAppsWithActiveAutomation: mock(async () => []),
+  },
+}));
+
+mock.module("@/db/repositories/telegram-chats", () => ({
+  telegramChatsRepository: {
+    findByChatId: mock(async () => null),
+    upsert: mock(async () => undefined),
+    delete: mock(async () => undefined),
+  },
+}));
+
+mock.module("@/lib/services/agent-gateway-router", () => ({
+  agentGatewayRouterService: {
+    routePhoneMessage: mock(async () => ({ handled: false })),
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: mock(() => undefined),
+    error: mock(() => undefined),
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
+
+const { default: route } = await import("./route");
+
+function delivery() {
+  const app = new Hono();
+  app.route("/:orgId", route);
+  return app.fetch(
+    new Request("https://api.example.test/org-1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        update_id: 1,
+        message: { chat: { id: 1, type: "private" } },
+      }),
+    }),
+  );
+}
+
+describe("Telegram webhook auth policy", () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = "development";
+    delete process.env.TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED_DEV;
+    delete process.env.TELEGRAM_BOT_TOKEN;
+  });
+
+  afterEach(() => {
+    delete process.env.NODE_ENV;
+    delete process.env.TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED_DEV;
+    delete process.env.TELEGRAM_BOT_TOKEN;
+  });
+
+  test("rejects unverified development webhooks by default", async () => {
+    const response = await delivery();
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Unauthorized",
+    });
+  });
+
+  test("explicit local-dev opt-in reaches bot-token resolution", async () => {
+    process.env.TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED_DEV = "1";
+
+    const response = await delivery();
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Bot not configured",
+    });
+  });
+});

--- a/packages/cloud/api/v1/telegram/webhook/[orgId]/route.ts
+++ b/packages/cloud/api/v1/telegram/webhook/[orgId]/route.ts
@@ -27,6 +27,13 @@ import { logger } from "@/lib/utils/logger";
 import { isCommand } from "@/lib/utils/telegram-helpers";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
+function allowUnverifiedTelegramDevWebhook(): boolean {
+  return (
+    process.env.NODE_ENV === "development" &&
+    process.env.TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED_DEV === "1"
+  );
+}
+
 async function handleTelegramWebhook(
   request: Request,
   context?: RouteContext<{ orgId: string }>,
@@ -39,8 +46,6 @@ async function handleTelegramWebhook(
   const secretToken = request.headers.get("x-telegram-bot-api-secret-token");
   const storedSecret = await telegramAutomationService.getWebhookSecret(orgId);
 
-  // In production, require secret token verification
-  // In development, allow requests without secret for testing (but log a warning)
   if (storedSecret) {
     if (!secretToken) {
       logger.warn("[Telegram Webhook] Missing secret token header", { orgId });
@@ -57,12 +62,22 @@ async function handleTelegramWebhook(
       orgId,
     });
     return Response.json({ ok: true, status: "not_configured" });
+  } else if (!allowUnverifiedTelegramDevWebhook()) {
+    logger.warn("[Telegram Webhook] No webhook secret configured - rejecting", {
+      orgId,
+      hint: "Set TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED_DEV=1 for local tunnel testing only.",
+    });
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  } else {
+    logger.warn("[Telegram Webhook] Accepting unverified development webhook", {
+      orgId,
+    });
   }
 
   let botToken = await telegramAutomationService.getBotToken(orgId);
 
-  // DEV ONLY: Fallback to env variable for testing
-  if (!botToken && process.env.NODE_ENV === "development") {
+  // DEV ONLY: explicit opt-in fallback for local tunnel testing.
+  if (!botToken && allowUnverifiedTelegramDevWebhook()) {
     botToken = process.env.TELEGRAM_BOT_TOKEN || null;
     if (botToken) {
       logger.info("[Telegram Webhook] Using fallback bot token from env", {


### PR DESCRIPTION
## Summary

- add platform-native signature verification to the eliza-app webhook forwarder before proxying to the internal gateway
- fail closed in production when forwarding secrets are missing, while preserving non-production local/e2e behavior with explicit logs
- make Telegram unverified development webhook delivery an explicit opt-in and cover the auth policy with tests
- re-run existing BlueBubbles and Stripe Connect replay dedupe coverage for this split

## Evidence

See `.github/issue-evidence/12878-webhook-auth-replay.md`.

Verified:

- `bun run --cwd packages/cloud/api test __tests__/eliza-app-webhook-suffix.test.ts`
- `bun test 'packages/cloud/api/v1/telegram/webhook/[orgId]/auth-policy.test.ts'`
- `bun run --cwd packages/cloud/api typecheck` (no touched-file errors)
- `bun run build:core`
- `bun test packages/cloud/api/webhooks/bluebubbles/dedupe.test.ts`
- `bun test packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/dedupe.test.ts`
- `bunx @biomejs/biome check packages/cloud/api/eliza-app/webhook/_forward.ts packages/cloud/api/__tests__/eliza-app-webhook-suffix.test.ts 'packages/cloud/api/v1/telegram/webhook/[orgId]/route.ts' 'packages/cloud/api/v1/telegram/webhook/[orgId]/auth-policy.test.ts'`
- `git diff --check`

Fixes #12878
