### PR TITLE
docs(#12860): add agent prose headers

### DIFF
--- a/packages/agent/scripts/mobile-stubs/app-core-runtime.cjs
+++ b/packages/agent/scripts/mobile-stubs/app-core-runtime.cjs
@@ -1,3 +1,5 @@
+// Mobile agent bundle shim for the app-core runtime hooks that the on-device
+// agent can safely import without pulling in the desktop dashboard stack.
 "use strict";
 
 // Mobile agent bundle shim for @elizaos/app-core.

--- a/packages/agent/scripts/mobile-stubs/e2b-capability-router.cjs
+++ b/packages/agent/scripts/mobile-stubs/e2b-capability-router.cjs
@@ -1,3 +1,5 @@
+// Mobile bundle stub for the E2B capability router registration path, which is
+// unavailable in the on-device agent runtime.
 module.exports = {
   registerE2BRemoteCapabilityRouterIfEnabled: async () => ({
     registered: false,

--- a/packages/agent/scripts/mobile-stubs/embedding-presets.cjs
+++ b/packages/agent/scripts/mobile-stubs/embedding-presets.cjs
@@ -1,3 +1,5 @@
+// Compact embedding preset table for mobile agent bundles, pinned to the small
+// CPU-safe local embedding model.
 "use strict";
 
 const COMPACT_ELIZA_1_EMBEDDING = {

--- a/packages/agent/scripts/mobile-stubs/mammoth.cjs
+++ b/packages/agent/scripts/mobile-stubs/mammoth.cjs
@@ -1,3 +1,5 @@
+// Mobile bundle stub for DOCX extraction, which is not shipped into the
+// on-device agent runtime.
 "use strict";
 
 async function extractRawText() {

--- a/packages/agent/scripts/mobile-stubs/source-map.cjs
+++ b/packages/agent/scripts/mobile-stubs/source-map.cjs
@@ -1,3 +1,5 @@
+// Minimal source-map API stub for mobile bundles that only need constructors
+// and stringification shapes at module-evaluation time.
 "use strict";
 
 class SourceNode {

--- a/packages/agent/scripts/mobile-stubs/unpdf.cjs
+++ b/packages/agent/scripts/mobile-stubs/unpdf.cjs
@@ -1,3 +1,5 @@
+// Mobile bundle stub for PDF extraction, which is excluded from the on-device
+// agent runtime.
 "use strict";
 
 function unavailable() {


### PR DESCRIPTION
## Summary
- keep evidence in the PR discussion instead of committed files so `bun run check:comment-only` remains reproducible

- add missing purpose headers across packages/agent scripts, API/local-inference files, TEE support, and tests
- keep the change comment-only; no code tokens changed
- record source audit and diffstat evidence in the PR body/discussion

## Evidence


Verified:

- source audit: `sourceFiles: 726`, `missingHeaders: 0`
- `bun run check:comment-only`
- `git diff --check`
- targeted `bunx @biomejs/biome check` on the 21 changed packages/agent files (pass with one pre-existing warning; no fixes applied)

Root `bun run verify` was attempted and failed on unrelated existing `@elizaos/plugin-computeruse#lint` diagnostics; details are in the evidence file. Unrelated write-mode lint auto-fixes were restored before staging.

Fixes #12860
