### PR TITLE
fix(#12795): fail-close google-genai IMAGE_DESCRIPTION provider errors

### DIFF
--- a/.github/issue-evidence/12795-google-genai-image-failclosed.md
+++ b/.github/issue-evidence/12795-google-genai-image-failclosed.md
@@ -1,0 +1,59 @@
+# Issue #12795 - Google GenAI image description fail-closed
+
+PR: https://github.com/elizaOS/eliza/pull/13084
+Branch: `fix/12795-hosted-provider-failclose`
+Verified commit: `e6d588ed23fc3de0b90f4d62f893ef355c302cc0` plus evidence follow-up
+
+## Scope checked
+
+This slice covers `plugins/plugin-google-genai/models/image.ts`, the
+`IMAGE_DESCRIPTION` model handler, plus
+`plugins/plugin-google-genai/__tests__/image-description.shape.test.ts`.
+
+The handler no longer turns provider/image-fetch failures into a successful
+`{ title, description }` object. It now rethrows the real error, and an empty
+model completion throws `Google GenAI API returned an empty image description`
+instead of fabricating `Image Analysis` with a blank description.
+
+## Passing verification
+
+- PASS `bun run --cwd plugins/plugin-google-genai test`
+  - 4 files passed, 1 skipped
+  - 22 tests passed, 1 skipped
+- PASS `bun run --cwd plugins/plugin-google-genai typecheck`
+  - `tsgo --noEmit -p tsconfig.json`
+- PASS `bun run --cwd plugins/plugin-google-genai lint:check`
+  - Biome checked 22 files; no fixes applied
+- PASS `bun run --cwd plugins/plugin-google-genai build`
+  - Node, browser, CJS bundles, and TypeScript declarations generated
+
+## Repo verify
+
+- `bun run verify`
+  - PASS `check:agents-claude`
+  - PASS `audit:type-safety-ratchet`
+  - PASS `audit:error-policy-ratchet`
+  - BLOCKED by unrelated `@elizaos/electrobun#lint` formatting diagnostics.
+    The verify run also replayed unrelated lint diagnostics in other packages;
+    write-mode formatter side effects in `plugins/plugin-computeruse` were
+    restored before committing this evidence.
+
+## Failure paths proven by tests
+
+- uninitialized Google GenAI client rejects
+- image fetch failure rejects with the fetch error
+- provider `generateContent` rejection propagates the provider error
+- empty/whitespace completion rejects
+- success paths still parse JSON and prose responses into title/description
+
+## Live provider trajectory
+
+N/A in this lane: `GOOGLE_GENERATIVE_AI_API_KEY` is not set in the execution
+environment. I verified the absence with `printenv GOOGLE_GENERATIVE_AI_API_KEY`.
+The added unit suite covers the changed fail-closed behavior without making a
+mocked provider look like live evidence.
+
+## Other N/A evidence
+
+- UI screenshots/video: N/A; model-provider error-policy change, no UI surface.
+- Audio: N/A; image description path, no audio.

--- a/plugins/plugin-google-genai/__tests__/image-description.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/image-description.shape.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for `handleImageDescription`: the JSON and prose parse paths plus
+ * the failure paths that must surface as typed errors instead of a fabricated
+ * `{ title, description }` result — uninitialized client, image fetch failure,
+ * provider (`generateContent`) rejection, and an empty model completion. The
+ * config, tokenization, `recordLlmCall`, and global `fetch` layers are mocked;
+ * no live model or network call is made.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createGoogleGenAI: vi.fn(),
+  generateContent: vi.fn(),
+  countTokens: vi.fn(),
+  recordLlmCall: vi.fn(),
+}));
+
+vi.mock("@elizaos/core", () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  },
+  recordLlmCall: mocks.recordLlmCall,
+}));
+
+vi.mock("../utils/config", () => ({
+  createGoogleGenAI: mocks.createGoogleGenAI,
+  getImageModel: vi.fn(() => "gemini-2.0-flash"),
+  getSafetySettings: vi.fn(() => []),
+}));
+
+vi.mock("../utils/tokenization", () => ({
+  countTokens: mocks.countTokens,
+}));
+
+import { handleImageDescription } from "../models/image";
+
+function createRuntime(): IAgentRuntime {
+  return {
+    getSetting: vi.fn(() => null),
+  } as unknown as IAgentRuntime;
+}
+
+function mockFetchOk() {
+  const fetchMock = vi.fn(async () => ({
+    ok: true,
+    statusText: "OK",
+    headers: { get: () => "image/png" },
+    arrayBuffer: async () => new ArrayBuffer(8),
+  }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("Google GenAI image description", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.countTokens.mockResolvedValue(5);
+    // recordLlmCall just runs the wrapped work and returns its result.
+    mocks.recordLlmCall.mockImplementation(async (_runtime, _details, fn) =>
+      fn(),
+    );
+    mocks.createGoogleGenAI.mockReturnValue({
+      models: { generateContent: mocks.generateContent },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the model's JSON title/description on success", async () => {
+    mockFetchOk();
+    mocks.generateContent.mockResolvedValue({
+      text: JSON.stringify({
+        title: "A cat",
+        description: "A ginger cat on a sofa.",
+      }),
+    });
+
+    const result = await handleImageDescription(
+      createRuntime(),
+      "https://example.com/cat.png",
+    );
+
+    expect(result).toEqual({
+      title: "A cat",
+      description: "A ginger cat on a sofa.",
+    });
+  });
+
+  it("parses a title/description out of prose when the model returns non-JSON", async () => {
+    mockFetchOk();
+    mocks.generateContent.mockResolvedValue({
+      text: "Title: Sunset\nA warm orange sunset over the ocean.",
+    });
+
+    const result = await handleImageDescription(
+      createRuntime(),
+      "https://example.com/sunset.png",
+    );
+
+    expect(result.title).toBe("Sunset");
+    expect(result.description).toContain("warm orange sunset");
+  });
+
+  it("throws when the client is not initialized instead of fabricating a result", async () => {
+    mockFetchOk();
+    mocks.createGoogleGenAI.mockReturnValue(null);
+
+    await expect(
+      handleImageDescription(createRuntime(), "https://example.com/x.png"),
+    ).rejects.toThrow("Google Generative AI client not initialized");
+
+    expect(mocks.generateContent).not.toHaveBeenCalled();
+  });
+
+  it("throws when the image fetch fails instead of fabricating a result", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      statusText: "Not Found",
+      headers: { get: () => null },
+      arrayBuffer: async () => new ArrayBuffer(0),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = handleImageDescription(
+      createRuntime(),
+      "https://example.com/missing.png",
+    );
+
+    await expect(result).rejects.toThrow("Failed to fetch image: Not Found");
+    // Must not swallow into a { title: "Failed to analyze image", ... } object.
+    await expect(result).rejects.not.toHaveProperty("title");
+    expect(mocks.generateContent).not.toHaveBeenCalled();
+  });
+
+  it("propagates a provider rejection instead of fabricating a result", async () => {
+    mockFetchOk();
+    mocks.generateContent.mockRejectedValue(
+      new Error("429 rate limit exceeded"),
+    );
+
+    const call = handleImageDescription(
+      createRuntime(),
+      "https://example.com/rate-limited.png",
+    );
+
+    await expect(call).rejects.toThrow("429 rate limit exceeded");
+    // The rejection value is the real error, not a fabricated description object.
+    await expect(call).rejects.toBeInstanceOf(Error);
+    await expect(call).rejects.not.toHaveProperty("title");
+  });
+
+  it("throws on an empty model completion instead of returning an empty description", async () => {
+    mockFetchOk();
+    mocks.generateContent.mockResolvedValue({ text: "   " });
+
+    await expect(
+      handleImageDescription(createRuntime(), "https://example.com/blank.png"),
+    ).rejects.toThrow("Google GenAI API returned an empty image description");
+  });
+});

--- a/plugins/plugin-google-genai/models/image.ts
+++ b/plugins/plugin-google-genai/models/image.ts
@@ -3,6 +3,11 @@
  * asks the multimodal Gemini model for a `{ title, description }`. Prefers the
  * model's JSON output and falls back to regex title extraction from prose. The
  * call is wrapped in `recordLlmCall` for trajectory capture.
+ *
+ * Provider failures (image fetch error, bad key, model-not-found, rate-limit,
+ * timeout, safety block, empty completion) surface as typed errors so the caller
+ * and model see a real failure — they are never fabricated into a
+ * `{ title, description }` result the runtime would read as a real description.
  */
 import type {
   IAgentRuntime,
@@ -95,7 +100,13 @@ export async function handleImageDescription(
       return result;
     });
 
-    const responseText = response.text || "";
+    const responseText = (response.text || "").trim();
+    if (!responseText) {
+      // An empty completion is a provider failure (safety block, truncation,
+      // model error), not a describable image. Surface it instead of returning
+      // a fabricated "Image Analysis" / empty-description result.
+      throw new Error("Google GenAI API returned an empty image description");
+    }
 
     try {
       const jsonResponse = JSON.parse(responseText) as {
@@ -119,15 +130,15 @@ export async function handleImageDescription(
     const title = titleMatch?.[1]?.trim() || "Image Analysis";
     const description = titleMatch
       ? responseText.replace(/title[:\s]+(.+?)(?:\n|$)/i, "").trim()
-      : responseText.trim();
+      : responseText;
 
     return { title, description };
   } catch (error) {
+    // Do not fabricate a `{ title, description }` on failure — the caller/model
+    // must see the real error, not an "Error: ..." string dressed up as a
+    // successful image description.
     const message = error instanceof Error ? error.message : String(error);
     logger.error(`Error analyzing image: ${message}`);
-    return {
-      title: "Failed to analyze image",
-      description: `Error: ${message}`,
-    };
+    throw error instanceof Error ? error : new Error(message);
   }
 }


### PR DESCRIPTION
## What

Closes the fallback-slop finding in the `plugin-google-genai` IMAGE_DESCRIPTION handler (part of #12795, hosted API plugins fast-fail sweep, split from #12271).

`plugins/plugin-google-genai/models/image.ts` swallowed **every** failure — image fetch error, bad key, model-not-found, rate-limit, timeout, safety block, mid-call error — and returned a fabricated `ImageDescriptionResponse`:

```ts
} catch (error) {
  const message = error instanceof Error ? error.message : String(error);
  logger.error(`Error analyzing image: ${message}`);
  return {
    title: "Failed to analyze image",
    description: `Error: ${message}`,   // <-- error dressed up as a real description
  };
}
```

The caller/model reads that object as a real image description instead of seeing a typed failure. Separately, an **empty model completion** produced a fabricated `{ title: "Image Analysis", description: "" }`.

## Fix

- The `catch` block now **rethrows the real error** instead of fabricating a `{ title, description }`. This matches the sibling providers:
  - `plugin-anthropic/models/image.ts` → `throw formatModelError(operationName, error)`
  - `plugin-openai/models/image.ts` → throws on empty/failed responses
- An empty/whitespace completion now throws `Google GenAI API returned an empty image description` rather than returning an empty-description result (mirrors `plugin-google-genai/models/embedding.ts`, which already throws on empty vectors).

Only `models/image.ts` in this plugin fabricated on failure — `embedding.ts` and `text.ts` already surface typed errors, so the sweep for this provider is a single-site fix plus tests.

## Tests

Adds `__tests__/image-description.shape.test.ts` (6 tests) covering:
- JSON success path
- prose title/description parse path
- **failure paths**: uninitialized client, image fetch failure (`ok:false`), provider rejection (`429 rate limit`), empty completion — each asserts the call **rejects with the real error** and never resolves to a fabricated `title`/`description`.

Evidence (worktree run on `origin/develop`):
- `bunx vitest run --config vitest.config.ts` → **22 passed, 1 skipped** (live trajectory self-skips without `GOOGLE_GENERATIVE_AI_API_KEY`).
- `bunx tsgo --noEmit -p tsconfig.json` → clean (EXIT 0).
- Live provider trajectory: `N/A — no API key in this lane; failure-path behavior is proven via the unit suite (fetch failure, provider rejection, empty completion all rethrow). Live IMAGE_DESCRIPTION trajectory requires a real GOOGLE_GENERATIVE_AI_API_KEY.`

## Evidence rows
- UI: `N/A — model-provider error-policy change, no UI path`
- Audio: `N/A — image description path, no audio`

— [sol-orch]
