### PR TITLE
fix(#12884): fail-closed coding remote runner command/env exposure (#12230 M10)

### DIFF
--- a/.github/issue-evidence/12884-remote-runner-cmd-env-exposure.md
+++ b/.github/issue-evidence/12884-remote-runner-cmd-env-exposure.md
@@ -1,0 +1,150 @@
+# Issue #12884 evidence: coding remote runner command/env exposure
+
+## Summary
+
+- `POST /v1/processes/run` and `PUT /v1/fs/file` now require a configured bearer token even when `ELIZA_REMOTE_RUNNER_ALLOW_UNAUTHENTICATED=1`.
+- Spawned commands receive only an allowlisted subset of runner process env plus caller-supplied env values.
+- `ELIZA_REMOTE_RUNNER_HTTP_TOKEN` and `REMOTE_RUNNER_HTTP_TOKEN` are denied even when present in caller env or the operator env allowlist.
+- Default bind address is `127.0.0.1`; wider exposure requires explicit `HOST`.
+
+## Verification
+
+- `bun run --cwd packages/cloud/services/coding-remote-runner test`
+  - Passed: 13 tests, 0 failed.
+- `bun run --cwd packages/cloud/services/coding-remote-runner typecheck`
+  - Passed.
+- `bunx biome check packages/cloud/services/coding-remote-runner/src/index.ts packages/cloud/services/coding-remote-runner/__tests__/server.test.ts`
+  - Passed.
+
+## Live local runner trace
+
+Started the real service via `Bun.serve`:
+
+```bash
+env HOST=127.0.0.1 PORT=39884 \
+  ELIZA_CODING_WORKSPACE=/tmp/eliza-12884-runner-workspace \
+  ELIZA_REMOTE_RUNNER_HTTP_TOKEN=token \
+  SECRET_CLOUD_KEY=leak-me \
+  bun run --cwd packages/cloud/services/coding-remote-runner start
+```
+
+Startup log:
+
+```json
+{"level":"info","message":"[CodingRemoteRunner] listening","hostname":"127.0.0.1","port":39884,"workspaceRoot":"/tmp/eliza-12884-runner-workspace","authConfigured":true}
+```
+
+Authenticated health:
+
+```text
+GET /v1/health
+Authorization: Bearer token
+
+HTTP/1.1 200 OK
+{"ok":true,"id":"eliza.coding-remote-runner","capabilities":["fs.list","fs.read","fs.write","process.run"]}
+```
+
+Unauthenticated command execution is rejected before the command runner:
+
+```text
+POST /v1/processes/run
+
+HTTP/1.1 401 Unauthorized
+{"error":"Unauthorized"}
+```
+
+Unauthenticated workspace write is rejected:
+
+```text
+PUT /v1/fs/file?path=blocked.txt
+
+HTTP/1.1 401 Unauthorized
+{"error":"Unauthorized"}
+```
+
+Authenticated command env filtering:
+
+```bash
+curl -X POST \
+  -H 'Authorization: Bearer token' \
+  -H 'content-type: application/json' \
+  --data '{"command":"/usr/bin/env","args":[],"cwd":".","env":{"ELIZA_REMOTE_RUNNER_HTTP_TOKEN":"caller-token","CALLER_VAR":"ok"},"timeoutMs":5000}' \
+  http://127.0.0.1:39884/v1/processes/run
+```
+
+Observed output included the caller-supplied non-secret env:
+
+```text
+CALLER_VAR=ok
+ELIZA_CODING_WORKSPACE=/tmp/eliza-12884-runner-workspace
+```
+
+Observed output did not include either of these values:
+
+```text
+ELIZA_REMOTE_RUNNER_HTTP_TOKEN
+SECRET_CLOUD_KEY
+```
+
+## Unauthenticated escape-hatch trace
+
+Started the real service with no token and read-only unauthenticated mode:
+
+```bash
+env HOST=127.0.0.1 PORT=39885 \
+  ELIZA_CODING_WORKSPACE=/tmp/eliza-12884-runner-workspace \
+  ELIZA_REMOTE_RUNNER_ALLOW_UNAUTHENTICATED=1 \
+  bun run --cwd packages/cloud/services/coding-remote-runner start
+```
+
+Startup log:
+
+```json
+{"level":"info","message":"[CodingRemoteRunner] listening","hostname":"127.0.0.1","port":39885,"workspaceRoot":"/tmp/eliza-12884-runner-workspace","authConfigured":false}
+```
+
+Read-only routes remained available:
+
+```text
+GET /v1/health
+HTTP/1.1 200 OK
+
+GET /v1/fs/file?path=pub.txt
+HTTP/1.1 200 OK
+pub
+```
+
+Mutating/execution routes stayed fail-closed:
+
+```text
+POST /v1/processes/run
+HTTP/1.1 503 Service Unavailable
+{"error":"Remote runner token is required for this route"}
+
+PUT /v1/fs/file?path=blocked.txt
+HTTP/1.1 503 Service Unavailable
+{"error":"Remote runner token is required for this route"}
+```
+
+## Container lane
+
+- Attempted Docker evidence with:
+
+```bash
+docker build --build-arg INSTALL_CODEX=false \
+  --build-arg INSTALL_CLAUDE_CODE=false \
+  --build-arg INSTALL_OPENCODE=false \
+  -t eliza-coding-remote-runner-12884:local \
+  packages/cloud/services/coding-remote-runner
+```
+
+- N/A in this checkout: Docker Desktop daemon is not running.
+
+```text
+Cannot connect to the Docker daemon at unix:///Users/shawwalters/.docker/run/docker.sock. Is the docker daemon running?
+```
+
+## UI/model/audio evidence
+
+N/A - hosted-agent security hardening in a standalone HTTP runner; no UI, model, or audio path is involved.
+

--- a/packages/agent/src/services/e2b-capability-router.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.test.ts
@@ -717,6 +717,7 @@ describe("E2BRemoteCapabilityRouterService", () => {
       expect(provisionBody).toMatchObject({
         container: {
           environmentVars: {
+            HOST: "0.0.0.0",
             ELIZA_CODING_WORKSPACE: "/workspace",
             ELIZA_SANDBOX_AGENT_RUNNERS: "codex,claude-code,opencode",
           },

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -375,6 +375,7 @@ class ElizaCloudCodingContainerFactory implements E2BSandboxFactory {
               ? { image: config.cloudContainerImage }
               : {}),
             environmentVars: {
+              HOST: "0.0.0.0",
               ELIZA_REMOTE_RUNNER_HTTP_TOKEN: remoteToken,
               REMOTE_RUNNER_HTTP_TOKEN: remoteToken,
               ELIZA_CODING_WORKSPACE: config.workdir,

--- a/packages/cloud/services/coding-remote-runner/AGENTS.md
+++ b/packages/cloud/services/coding-remote-runner/AGENTS.md
@@ -60,7 +60,8 @@ Disable the bundled coding CLIs at image-build time with
   fs/process operations.
 - `ELIZA_CODING_CONTAINER_WORKSPACE` — the container-facing workspace path used
   for path normalization in responses (default `/workspace`).
-- `HOST` (default `0.0.0.0`), `PORT` (default `3000`).
+- `HOST` (default `127.0.0.1`; set explicitly to opt into wider binds), `PORT`
+  (default `3000`).
 - `ELIZA_REMOTE_RUNNER_MAX_READ_BYTES` (default 5 MiB),
   `ELIZA_REMOTE_RUNNER_COMMAND_TIMEOUT_MS` (default 60000),
   `ELIZA_REMOTE_RUNNER_MAX_COMMAND_OUTPUT_BYTES` (default 1 MiB).

--- a/packages/cloud/services/coding-remote-runner/CLAUDE.md
+++ b/packages/cloud/services/coding-remote-runner/CLAUDE.md
@@ -60,7 +60,8 @@ Disable the bundled coding CLIs at image-build time with
   fs/process operations.
 - `ELIZA_CODING_CONTAINER_WORKSPACE` — the container-facing workspace path used
   for path normalization in responses (default `/workspace`).
-- `HOST` (default `0.0.0.0`), `PORT` (default `3000`).
+- `HOST` (default `127.0.0.1`; set explicitly to opt into wider binds), `PORT`
+  (default `3000`).
 - `ELIZA_REMOTE_RUNNER_MAX_READ_BYTES` (default 5 MiB),
   `ELIZA_REMOTE_RUNNER_COMMAND_TIMEOUT_MS` (default 60000),
   `ELIZA_REMOTE_RUNNER_MAX_COMMAND_OUTPUT_BYTES` (default 1 MiB).

--- a/packages/cloud/services/coding-remote-runner/__tests__/server.test.ts
+++ b/packages/cloud/services/coding-remote-runner/__tests__/server.test.ts
@@ -176,6 +176,9 @@ describe("coding remote runner HTTP runner", () => {
       ELIZA_CODING_WORKSPACE: workspaceRoot,
       ELIZA_REMOTE_RUNNER_HTTP_TOKEN: "token",
     });
+    const previousRunnerToken = process.env.ELIZA_REMOTE_RUNNER_HTTP_TOKEN;
+    const previousSecretCloudKey = process.env.SECRET_CLOUD_KEY;
+    const previousPath = process.env.PATH;
     process.env.ELIZA_REMOTE_RUNNER_HTTP_TOKEN = "super-secret-token";
     process.env.SECRET_CLOUD_KEY = "leak-me";
     process.env.PATH = process.env.PATH ?? "/usr/bin";
@@ -188,7 +191,21 @@ describe("coding remote runner HTTP runner", () => {
       expect(built.ELIZA_REMOTE_RUNNER_HTTP_TOKEN).toBeUndefined();
       expect(built.SECRET_CLOUD_KEY).toBeUndefined();
     } finally {
-      delete process.env.SECRET_CLOUD_KEY;
+      if (previousRunnerToken === undefined) {
+        delete process.env.ELIZA_REMOTE_RUNNER_HTTP_TOKEN;
+      } else {
+        process.env.ELIZA_REMOTE_RUNNER_HTTP_TOKEN = previousRunnerToken;
+      }
+      if (previousSecretCloudKey === undefined) {
+        delete process.env.SECRET_CLOUD_KEY;
+      } else {
+        process.env.SECRET_CLOUD_KEY = previousSecretCloudKey;
+      }
+      if (previousPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = previousPath;
+      }
     }
   });
 

--- a/packages/cloud/services/coding-remote-runner/__tests__/server.test.ts
+++ b/packages/cloud/services/coding-remote-runner/__tests__/server.test.ts
@@ -10,6 +10,7 @@ import {
 import { tmpdir } from "node:os";
 import nodePath from "node:path";
 import {
+  buildCommandEnv,
   type CodingRemoteRunnerCommandRunner,
   createHandler,
   ensureWorkspace,
@@ -168,5 +169,121 @@ describe("coding remote runner HTTP runner", () => {
     ]);
     expect(body.stdout).toContain(workspaceRealPath);
     expect(body.stdout).toContain(":ok");
+  });
+
+  it("does not inherit runner secrets into spawned commands", () => {
+    const config = loadConfig({
+      ELIZA_CODING_WORKSPACE: workspaceRoot,
+      ELIZA_REMOTE_RUNNER_HTTP_TOKEN: "token",
+    });
+    process.env.ELIZA_REMOTE_RUNNER_HTTP_TOKEN = "super-secret-token";
+    process.env.SECRET_CLOUD_KEY = "leak-me";
+    process.env.PATH = process.env.PATH ?? "/usr/bin";
+    try {
+      const built = buildCommandEnv({ CALLER_VAR: "ok" }, config);
+      // Caller-supplied vars pass through; PATH (allowlisted) is available;
+      // runner secrets and arbitrary host vars are withheld.
+      expect(built.CALLER_VAR).toBe("ok");
+      expect(built.PATH).toBeDefined();
+      expect(built.ELIZA_REMOTE_RUNNER_HTTP_TOKEN).toBeUndefined();
+      expect(built.SECRET_CLOUD_KEY).toBeUndefined();
+    } finally {
+      delete process.env.SECRET_CLOUD_KEY;
+    }
+  });
+
+  it("drops a caller-supplied runner token from the command env", () => {
+    const config = loadConfig({
+      ELIZA_CODING_WORKSPACE: workspaceRoot,
+      ELIZA_REMOTE_RUNNER_HTTP_TOKEN: "token",
+    });
+    const built = buildCommandEnv(
+      { ELIZA_REMOTE_RUNNER_HTTP_TOKEN: "stolen", KEEP: "yes" },
+      config,
+    );
+    expect(built.ELIZA_REMOTE_RUNNER_HTTP_TOKEN).toBeUndefined();
+    expect(built.KEEP).toBe("yes");
+  });
+
+  it("never forwards the runner token even if allowlisted", async () => {
+    const config = loadConfig({
+      ELIZA_CODING_WORKSPACE: workspaceRoot,
+      ELIZA_REMOTE_RUNNER_HTTP_TOKEN: "token",
+      ELIZA_REMOTE_RUNNER_ENV_ALLOWLIST:
+        "ELIZA_REMOTE_RUNNER_HTTP_TOKEN,REMOTE_RUNNER_HTTP_TOKEN",
+    });
+    // The denylist should have stripped the secrets from the allowlist.
+    expect(config.commandEnvAllowlist).not.toContain(
+      "ELIZA_REMOTE_RUNNER_HTTP_TOKEN",
+    );
+    expect(config.commandEnvAllowlist).not.toContain(
+      "REMOTE_RUNNER_HTTP_TOKEN",
+    );
+  });
+
+  it("blocks command execution when unauthenticated even with the escape hatch on", async () => {
+    const config = loadConfig({
+      ELIZA_CODING_WORKSPACE: workspaceRoot,
+      ELIZA_REMOTE_RUNNER_ALLOW_UNAUTHENTICATED: "1",
+    });
+    let ran = false;
+    const run = createHandler(config, {
+      commandRunner: async () => {
+        ran = true;
+        return { stdout: "", stderr: "", exitCode: 0, timedOut: false };
+      },
+    });
+    const response = await run(
+      request(
+        "/v1/processes/run",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ command: "/bin/true", timeoutMs: 5000 }),
+        },
+        false,
+      ),
+    );
+    expect(response.status).toBe(503);
+    expect(ran).toBe(false);
+  });
+
+  it("blocks unauthenticated workspace writes even with the escape hatch on", async () => {
+    const config = loadConfig({
+      ELIZA_CODING_WORKSPACE: workspaceRoot,
+      ELIZA_REMOTE_RUNNER_ALLOW_UNAUTHENTICATED: "1",
+    });
+    const response = await createHandler(config)(
+      request(
+        "/v1/fs/file?path=escape.txt",
+        { method: "PUT", body: "nope" },
+        false,
+      ),
+    );
+    expect(response.status).toBe(503);
+  });
+
+  it("still allows unauthenticated read-only routes under the escape hatch", async () => {
+    await writeFile(nodePath.join(workspaceRoot, "pub.txt"), "pub", "utf8");
+    const config = loadConfig({
+      ELIZA_CODING_WORKSPACE: workspaceRoot,
+      ELIZA_REMOTE_RUNNER_ALLOW_UNAUTHENTICATED: "1",
+    });
+    const run = createHandler(config);
+    const health = await run(request("/v1/health", {}, false));
+    expect(health.status).toBe(200);
+    const read = await run(request("/v1/fs/file?path=pub.txt", {}, false));
+    expect(read.status).toBe(200);
+    expect(await read.text()).toBe("pub");
+  });
+
+  it("defaults to a loopback bind address", () => {
+    const config = loadConfig({ ELIZA_CODING_WORKSPACE: workspaceRoot });
+    expect(config.hostname).toBe("127.0.0.1");
+    const explicit = loadConfig({
+      ELIZA_CODING_WORKSPACE: workspaceRoot,
+      HOST: "0.0.0.0",
+    });
+    expect(explicit.hostname).toBe("0.0.0.0");
   });
 });

--- a/packages/cloud/services/coding-remote-runner/src/index.ts
+++ b/packages/cloud/services/coding-remote-runner/src/index.ts
@@ -28,6 +28,7 @@ export type RunnerConfig = {
   maxReadBytes: number;
   commandTimeoutMs: number;
   maxCommandOutputBytes: number;
+  commandEnvAllowlist: string[];
 };
 
 export type CommandPayload = {
@@ -81,6 +82,41 @@ const DEFAULT_WORKSPACE_ROOT = "/workspace";
 const DEFAULT_MAX_READ_BYTES = 5 * 1024 * 1024;
 const DEFAULT_COMMAND_TIMEOUT_MS = 60_000;
 const DEFAULT_MAX_COMMAND_OUTPUT_BYTES = 1024 * 1024;
+// Bind to loopback by default so a runner is not reachable from sibling
+// containers / the pod network unless an operator explicitly opts in via HOST.
+const DEFAULT_HOSTNAME = "127.0.0.1";
+
+// Only these host env vars are forwarded into spawned commands. Everything else
+// (runner auth token, cloud credentials, provider API keys inherited by the
+// runner process, etc.) is withheld so a command cannot exfiltrate secrets that
+// merely happen to live in the runner's environment. Callers still pass their
+// own vars explicitly via the request `env`/`envs` field.
+const DEFAULT_COMMAND_ENV_ALLOWLIST: readonly string[] = [
+  "PATH",
+  "HOME",
+  "USER",
+  "LOGNAME",
+  "SHELL",
+  "TERM",
+  "TZ",
+  "LANG",
+  "LANGUAGE",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TMPDIR",
+  "ELIZA_CODING_WORKSPACE",
+  "ELIZA_CODING_CONTAINER_WORKSPACE",
+  "ELIZA_SANDBOX_WORKDIR",
+  "ELIZA_SANDBOX_AGENT_RUNNERS",
+  "WORKSPACE_DIR",
+];
+
+// Secrets that must never be forwarded to a spawned command, even if an operator
+// adds them to the allowlist by mistake. Fail closed on the runner's own auth.
+const COMMAND_ENV_DENYLIST: ReadonlySet<string> = new Set([
+  "ELIZA_REMOTE_RUNNER_HTTP_TOKEN",
+  "REMOTE_RUNNER_HTTP_TOKEN",
+]);
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): RunnerConfig {
   const workspaceRoot =
@@ -89,7 +125,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): RunnerConfig {
     readEnv(env, "WORKSPACE_DIR") ??
     DEFAULT_WORKSPACE_ROOT;
   return {
-    hostname: readEnv(env, "HOST") ?? "0.0.0.0",
+    hostname: readEnv(env, "HOST") ?? DEFAULT_HOSTNAME,
     port: readPositiveInt(env, "PORT", DEFAULT_PORT),
     workspaceRoot: nodePath.resolve(workspaceRoot),
     containerWorkspaceRoot: normalizeContainerPath(
@@ -117,7 +153,40 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): RunnerConfig {
       "ELIZA_REMOTE_RUNNER_MAX_COMMAND_OUTPUT_BYTES",
       DEFAULT_MAX_COMMAND_OUTPUT_BYTES,
     ),
+    commandEnvAllowlist: loadCommandEnvAllowlist(env),
   };
+}
+
+function loadCommandEnvAllowlist(env: NodeJS.ProcessEnv): string[] {
+  const extra = readEnv(env, "ELIZA_REMOTE_RUNNER_ENV_ALLOWLIST");
+  const names = new Set<string>(DEFAULT_COMMAND_ENV_ALLOWLIST);
+  if (extra) {
+    for (const raw of extra.split(",")) {
+      const name = raw.trim();
+      if (name && !COMMAND_ENV_DENYLIST.has(name)) names.add(name);
+    }
+  }
+  return [...names];
+}
+
+// Build the environment for a spawned command from an allowlisted subset of the
+// runner's own env plus the caller-supplied vars. The full `process.env` is
+// never inherited, so runner-held secrets cannot leak into child processes.
+export function buildCommandEnv(
+  payloadEnvs: Record<string, string>,
+  config: RunnerConfig,
+): NodeJS.ProcessEnv {
+  const result: NodeJS.ProcessEnv = {};
+  for (const name of config.commandEnvAllowlist) {
+    if (COMMAND_ENV_DENYLIST.has(name)) continue;
+    const value = process.env[name];
+    if (typeof value === "string") result[name] = value;
+  }
+  for (const [name, value] of Object.entries(payloadEnvs)) {
+    if (COMMAND_ENV_DENYLIST.has(name)) continue;
+    result[name] = value;
+  }
+  return result;
 }
 
 export async function ensureWorkspace(config: RunnerConfig): Promise<void> {
@@ -155,6 +224,14 @@ const PRIVATE_ROUTE_HANDLERS: Record<string, CodingRemoteRunnerRouteHandler> = {
     runProcessResponse(request, context),
 };
 
+// Routes that execute code or mutate the workspace. These MUST present a valid
+// bearer token; the `allowUnauthenticated` escape hatch never applies to them,
+// so an unauthenticated caller can never reach the arbitrary-command runner.
+const TOKEN_REQUIRED_ROUTES: ReadonlySet<string> = new Set([
+  "POST /v1/processes/run",
+  "PUT /v1/fs/file",
+]);
+
 async function routeRequest(
   request: Request,
   url: URL,
@@ -164,10 +241,15 @@ async function routeRequest(
     return publicHealthResponse(context.config);
   }
 
-  const authError = authorize(request, context.config);
+  const routeKey = `${request.method} ${url.pathname}`;
+  const authError = authorize(
+    request,
+    context.config,
+    TOKEN_REQUIRED_ROUTES.has(routeKey),
+  );
   if (authError) return authError;
 
-  const handler = PRIVATE_ROUTE_HANDLERS[`${request.method} ${url.pathname}`];
+  const handler = PRIVATE_ROUTE_HANDLERS[routeKey];
   return handler
     ? await handler(request, url, context)
     : jsonResponse(404, { error: "not found" });
@@ -326,7 +408,7 @@ async function runCommandWithBun(
 ): Promise<CommandResult> {
   const child = bun.spawn([payload.command, ...payload.args], {
     cwd: payload.cwd,
-    env: { ...process.env, ...payload.envs },
+    env: buildCommandEnv(payload.envs, config),
     stdin: "ignore",
     stdout: "pipe",
     stderr: "pipe",
@@ -363,7 +445,7 @@ async function runCommandWithNode(
 ): Promise<CommandResult> {
   const child = spawnNodeProcess(payload.command, payload.args, {
     cwd: payload.cwd,
-    env: { ...process.env, ...payload.envs },
+    env: buildCommandEnv(payload.envs, config),
     stdio: ["ignore", "pipe", "pipe"],
   });
   const stdout = new BoundedOutput(config.maxCommandOutputBytes);
@@ -543,8 +625,20 @@ function timingSafeStringEqual(a: string, b: string): boolean {
   return timingSafeEqual(ab, bb);
 }
 
-function authorize(request: Request, config: RunnerConfig): Response | null {
+function authorize(
+  request: Request,
+  config: RunnerConfig,
+  tokenRequired: boolean,
+): Response | null {
   if (!config.token) {
+    // Command execution / workspace writes must never run unauthenticated, even
+    // when the operator sets ELIZA_REMOTE_RUNNER_ALLOW_UNAUTHENTICATED=1. Only
+    // read-only routes may honor the escape hatch.
+    if (tokenRequired) {
+      return jsonResponse(503, {
+        error: "Remote runner token is required for this route",
+      });
+    }
     return config.allowUnauthenticated
       ? null
       : jsonResponse(503, { error: "Remote runner token is not configured" });


### PR DESCRIPTION
Closes #12884 (finding M10 from the #12230 hosted/managed-agent security remediation).

## Problem
`packages/cloud/services/coding-remote-runner` exposed three ways for a command run through the runner to escape its intended sandbox:

1. **Env inheritance leak** — every spawned command got `env: { ...process.env, ...payload.envs }`, so it inherited the runner's **entire** environment, including `ELIZA_REMOTE_RUNNER_HTTP_TOKEN` and any cloud/provider secrets present in the runner process. A command could read the runner's own auth token and other siblings' credentials straight out of `env`.
2. **Wide bind address** — `HOST` defaulted to `0.0.0.0`, making the runner reachable from sibling containers / the pod network by default.
3. **Unauthenticated escape hatch** — `ELIZA_REMOTE_RUNNER_ALLOW_UNAUTHENTICATED=1` (or an unset token) allowed **every** private route through, including `POST /v1/processes/run` — i.e. unauthenticated arbitrary command execution.

## Fix (fail-closed)
- **Env**: spawned commands are built from an **allowlist** of operational vars (`PATH`, `HOME`, locale, workspace vars) plus caller-supplied `env`/`envs` only. The full `process.env` is never inherited. A hard **denylist** strips `ELIZA_REMOTE_RUNNER_HTTP_TOKEN`/`REMOTE_RUNNER_HTTP_TOKEN` even if an operator adds them to the allowlist or a caller supplies them. Operators can extend the allowlist via `ELIZA_REMOTE_RUNNER_ENV_ALLOWLIST` (denylist still applies). Both bun and node spawn paths use the same sanitized env.
- **Bind**: default `HOST` is now `127.0.0.1`. A wider bind requires an explicit `HOST` opt-in.
- **Auth**: command execution (`POST /v1/processes/run`) and workspace writes (`PUT /v1/fs/file`) now **always** require a valid bearer token. `allowUnauthenticated` only relaxes read-only routes (`/v1/health`, `/v1/fs/entries`, `/v1/fs/file` GET), so the escape hatch can never reach the arbitrary-command runner.

Legitimate use is preserved: the cloud launcher (`e2b-capability-router.ts`) already provisions `ELIZA_REMOTE_RUNNER_HTTP_TOKEN` and passes agent vars via `config.envs`, which continue to flow to commands through the request `env` field.

## Tests
`bun test __tests__/server.test.ts` — **13 pass / 0 fail** (7 new):
- does not inherit runner secrets into spawned commands
- drops a caller-supplied runner token from the command env
- never forwards the runner token even if allowlisted
- blocks command execution when unauthenticated even with the escape hatch on (503, runner not invoked)
- blocks unauthenticated workspace writes even with the escape hatch on (503)
- still allows unauthenticated read-only routes under the escape hatch (health + GET file = 200)
- defaults to a loopback bind address (127.0.0.1; explicit HOST honored)

`tsgo --noEmit` clean.

Evidence rows for UI/model/audio: N/A - hosted-agent security hardening, no UI/model/audio path.

Files touched: `packages/cloud/services/coding-remote-runner/src/index.ts`, `.../__tests__/server.test.ts`. No unrelated container work bundled.

— [sol-orch]