### PR TITLE
fix(#12882): pin forwarded control-plane database identity fail-closed (H4)

### DIFF
--- a/.github/issue-evidence/12882-control-plane-db-identity.md
+++ b/.github/issue-evidence/12882-control-plane-db-identity.md
@@ -1,0 +1,86 @@
+# Issue #12882 evidence: container control-plane forwarded DB identity
+
+## Summary
+
+- Added a fail-closed guard for `x-eliza-cloud-database-url` before the sidecar calls `runWithCloudBindingsAsync`.
+- Forwarded DB identity is pinned to the sidecar's configured `DATABASE_URL` plus optional full-URL allowlist entries.
+- The identity key includes scheme, credentials, host, port, exact database path, and canonical query params.
+- Different database/user/port on the same host, query override params like `?host=evil`, duplicate query keys, malformed URLs, and missing trusted identity are rejected.
+
+## Verification
+
+- `bun test packages/cloud/shared/src/lib/services/containers/forwarded-database-url-guard.test.ts packages/cloud/shared/src/lib/config/containers-env-db-allowlist.test.ts`
+  - Passed: 35 tests, 0 failed.
+- `bunx biome check packages/cloud/services/container-control-plane/src/index.ts packages/cloud/shared/src/lib/config/containers-env.ts packages/cloud/shared/src/lib/config/containers-env-db-allowlist.test.ts packages/cloud/shared/src/lib/services/containers/forwarded-database-url-guard.ts packages/cloud/shared/src/lib/services/containers/forwarded-database-url-guard.test.ts packages/cloud/services/container-control-plane/CLAUDE.md packages/cloud/services/container-control-plane/AGENTS.md`
+  - Passed.
+- `bun run --cwd packages/cloud/services/container-control-plane typecheck`
+  - Blocked by existing transitive workspace resolution errors outside the touched files, for example missing `@elizaos/auth/*`, `@elizaos/shared/contracts/service-routing`, and `@elizaos/plugin-sql` imports from `app-core` / `cloud-shared`.
+- `bun run --cwd packages/cloud/shared typecheck 2>&1 | rg 'forwarded-database-url-guard|containers-env'`
+  - No touched-file type errors were reported.
+
+## Live sidecar route transcript
+
+Started the real sidecar service via `Bun.serve`:
+
+```bash
+env HOST=127.0.0.1 PORT=39886 \
+  CONTAINER_CONTROL_PLANE_TOKEN=token \
+  DATABASE_URL='postgres://svc:pw@db.internal.example:5432/cloud' \
+  bun run --cwd packages/cloud/services/container-control-plane start
+```
+
+Health route:
+
+```text
+GET /health
+
+HTTP/1.1 200 OK
+{"success":true,"service":"container-control-plane"}
+```
+
+Attack case: valid internal token but attacker-controlled same-host different database in `x-eliza-cloud-database-url`.
+
+```text
+GET /api/v1/cron/deployment-monitor
+x-container-control-plane-token: token
+x-eliza-cloud-database-url: postgres://svc:pw@db.internal.example:5432/exfil
+
+HTTP/1.1 403 Forbidden
+{"success":false,"error":"Forwarded database identity is not trusted"}
+```
+
+Structured backend log:
+
+```text
+[container-control-plane] rejected forwarded database URL (fail-closed) {
+  reason: "forwarded database identity does not match the pinned control-plane database (or allowlist)",
+}
+```
+
+Missing internal token is still rejected before the DB guard:
+
+```text
+GET /api/v1/cron/deployment-monitor
+x-eliza-cloud-database-url: postgres://svc:pw@db.internal.example:5432/exfil
+
+HTTP/1.1 403 Forbidden
+{"success":false,"error":"Forbidden"}
+```
+
+## Container lane
+
+N/A in this checkout: Docker Desktop daemon is not running.
+
+```text
+Cannot connect to the Docker daemon at unix:///Users/shawwalters/.docker/run/docker.sock. Is the docker daemon running?
+```
+
+This change affects sidecar request validation before container operations run; the live `Bun.serve` transcript above exercises the real route and guard without requiring a Docker node.
+
+## DB / migration / UI / model / audio evidence
+
+- DB state: N/A - the rejected attack path returns before `runWithCloudBindingsAsync`, node mirroring, or repository mutation.
+- Migration up/down: N/A - no schema change.
+- UI evidence: N/A - hosted-agent security hardening, no UI path.
+- Model/audio evidence: N/A - no model or audio path.
+

--- a/packages/cloud/services/container-control-plane/AGENTS.md
+++ b/packages/cloud/services/container-control-plane/AGENTS.md
@@ -60,10 +60,18 @@ There are no tests in this package.
   `CONTAINER_CONTROL_PLANE_TOKEN` is set, the request must carry a matching
   `x-container-control-plane-token` or it's rejected 401. Errors are thrown as
   `Response` objects and caught by `handle` / `handleInternal`.
-- **Per-request DB binding.** If a request sends `x-eliza-cloud-database-url`,
-  the handler runs inside `runWithCloudBindingsAsync({ DATABASE_URL })` and
-  first mirrors Docker-node rows via `mirrorControlPlaneNodes`. Without that
-  header the sidecar relies on its own configured `DATABASE_URL`.
+- **Per-request DB binding (pinned, fail-closed, H4/#12882).** If a request
+  sends `x-eliza-cloud-database-url`, the handler runs inside
+  `runWithCloudBindingsAsync({ DATABASE_URL })` and first mirrors Docker-node
+  rows via `mirrorControlPlaneNodes`. The forwarded URL is NOT trusted blindly:
+  `resolveForwardedDatabaseUrl` runs it through `evaluateForwardedDatabaseUrl`
+  (`cloud-shared/.../forwarded-database-url-guard`), which only honors a URL
+  whose whole identity (scheme, credentials, host, port, database, query)
+  matches the sidecar's own configured `DATABASE_URL` or the
+  `CONTAINER_CONTROL_PLANE_DATABASE_URL_ALLOWLIST`. Any other/malformed identity
+  (including a different db/user or a `?host=`-override on the same host) is
+  rejected 403. Without the header the sidecar relies on its own configured
+  `DATABASE_URL`.
 - **`@elizaos/cloud-shared` is the brain.** This package adds HTTP plumbing,
   validation, and error/status mapping only — container logic, SSH, warm pool,
   autoscaling, and provisioning all live in `cloud-shared`. Behavioral changes

--- a/packages/cloud/services/container-control-plane/CLAUDE.md
+++ b/packages/cloud/services/container-control-plane/CLAUDE.md
@@ -60,10 +60,18 @@ There are no tests in this package.
   `CONTAINER_CONTROL_PLANE_TOKEN` is set, the request must carry a matching
   `x-container-control-plane-token` or it's rejected 401. Errors are thrown as
   `Response` objects and caught by `handle` / `handleInternal`.
-- **Per-request DB binding.** If a request sends `x-eliza-cloud-database-url`,
-  the handler runs inside `runWithCloudBindingsAsync({ DATABASE_URL })` and
-  first mirrors Docker-node rows via `mirrorControlPlaneNodes`. Without that
-  header the sidecar relies on its own configured `DATABASE_URL`.
+- **Per-request DB binding (pinned, fail-closed, H4/#12882).** If a request
+  sends `x-eliza-cloud-database-url`, the handler runs inside
+  `runWithCloudBindingsAsync({ DATABASE_URL })` and first mirrors Docker-node
+  rows via `mirrorControlPlaneNodes`. The forwarded URL is NOT trusted blindly:
+  `resolveForwardedDatabaseUrl` runs it through `evaluateForwardedDatabaseUrl`
+  (`cloud-shared/.../forwarded-database-url-guard`), which only honors a URL
+  whose whole identity (scheme, credentials, host, port, database, query)
+  matches the sidecar's own configured `DATABASE_URL` or the
+  `CONTAINER_CONTROL_PLANE_DATABASE_URL_ALLOWLIST`. Any other/malformed identity
+  (including a different db/user or a `?host=`-override on the same host) is
+  rejected 403. Without the header the sidecar relies on its own configured
+  `DATABASE_URL`.
 - **`@elizaos/cloud-shared` is the brain.** This package adds HTTP plumbing,
   validation, and error/status mapping only — container logic, SSH, warm pool,
   autoscaling, and provisioning all live in `cloud-shared`. Behavioral changes

--- a/packages/cloud/services/container-control-plane/src/index.ts
+++ b/packages/cloud/services/container-control-plane/src/index.ts
@@ -12,6 +12,7 @@ import { containersEnv } from "@elizaos/cloud-shared/lib/config/containers-env";
 import { runWithCloudBindingsAsync } from "@elizaos/cloud-shared/lib/runtime/cloud-bindings";
 import { WarmPoolManager } from "@elizaos/cloud-shared/lib/services/containers/agent-warm-pool";
 import { getHetznerPoolContainerCreator } from "@elizaos/cloud-shared/lib/services/containers/agent-warm-pool-creator";
+import { evaluateForwardedDatabaseUrl } from "@elizaos/cloud-shared/lib/services/containers/forwarded-database-url-guard";
 import {
   type ContainerBootstrapFile,
   type ContainerBootstrapSource,
@@ -498,13 +499,47 @@ function toCreateInput(
   };
 }
 
+/**
+ * SECURITY (H4, #12882): resolve the forwarded per-request database URL against
+ * pinned control-plane context and FAIL CLOSED. A caller-supplied
+ * `x-eliza-cloud-database-url` is only honored when its whole identity (scheme,
+ * credentials, host, port, database, query) matches the sidecar's own
+ * configured `DATABASE_URL` or the operator allowlist; anything else throws a
+ * 403 `Response` (caught by the handlers below). Returns the validated URL to
+ * bind, or `undefined` when no header was supplied.
+ */
+function resolveForwardedDatabaseUrl(c: Context): string | undefined {
+  const databaseUrl = c.req.header("x-eliza-cloud-database-url")?.trim();
+  if (!databaseUrl) return undefined;
+
+  const decision = evaluateForwardedDatabaseUrl(databaseUrl, {
+    configuredDatabaseUrl: containersEnv.containerControlPlaneDatabaseUrl(),
+    allowlistDatabaseUrls:
+      containersEnv.containerControlPlaneDatabaseUrlAllowlist(),
+  });
+  if (!decision.allowed) {
+    logger.error(
+      "[container-control-plane] rejected forwarded database URL (fail-closed)",
+      { reason: decision.reason },
+    );
+    throw new Response(
+      JSON.stringify({
+        success: false,
+        error: "Forwarded database identity is not trusted",
+      }),
+      { status: 403, headers: { "content-type": "application/json" } },
+    );
+  }
+  return databaseUrl;
+}
+
 async function handle(
   c: Context,
   fn: (auth: ForwardedAuth) => Promise<Response>,
 ) {
   try {
     const auth = requireForwardedAuth(c);
-    const databaseUrl = c.req.header("x-eliza-cloud-database-url")?.trim();
+    const databaseUrl = resolveForwardedDatabaseUrl(c);
     if (databaseUrl) {
       const controlPlaneNodes = await dockerNodesRepository.findAll();
       return await runWithCloudBindingsAsync(
@@ -528,7 +563,7 @@ async function handle(
 async function handleInternal(c: Context, fn: () => Promise<Response>) {
   try {
     requireInternalToken(c);
-    const databaseUrl = c.req.header("x-eliza-cloud-database-url")?.trim();
+    const databaseUrl = resolveForwardedDatabaseUrl(c);
     if (databaseUrl) {
       const controlPlaneNodes = await dockerNodesRepository.findAll();
       return await runWithCloudBindingsAsync(

--- a/packages/cloud/shared/src/lib/config/containers-env-db-allowlist.test.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env-db-allowlist.test.ts
@@ -1,0 +1,63 @@
+/**
+ * SECURITY (H4, #12882): env-reader coverage for the forwarded-database-URL
+ * allowlist knobs. `containersEnv` reads through `getCloudAwareEnv()`, which
+ * returns `process.env` directly under bun test, so we drive these by mutating +
+ * restoring the two keys.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { containersEnv } from "./containers-env";
+
+const KEYS = ["CONTAINER_CONTROL_PLANE_DATABASE_URL_ALLOWLIST", "DATABASE_URL"] as const;
+
+const saved = new Map<string, string | undefined>();
+function setEnv(values: Partial<Record<(typeof KEYS)[number], string>>): void {
+  for (const key of KEYS) {
+    if (!saved.has(key)) saved.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(values)) {
+    process.env[key] = value;
+  }
+}
+
+afterEach(() => {
+  for (const [key, value] of saved) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  saved.clear();
+});
+
+describe("containerControlPlaneDatabaseUrlAllowlist", () => {
+  test("defaults to an empty list when unset (only the configured DB host is trusted)", () => {
+    setEnv({});
+    expect(containersEnv.containerControlPlaneDatabaseUrlAllowlist()).toEqual([]);
+  });
+
+  test("splits on commas and whitespace, trimming blanks", () => {
+    setEnv({
+      CONTAINER_CONTROL_PLANE_DATABASE_URL_ALLOWLIST:
+        "replica.example:6543,  reader.example  , ,writer.example",
+    });
+    expect(containersEnv.containerControlPlaneDatabaseUrlAllowlist()).toEqual([
+      "replica.example:6543",
+      "reader.example",
+      "writer.example",
+    ]);
+  });
+});
+
+describe("containerControlPlaneDatabaseUrl", () => {
+  test("returns undefined when DATABASE_URL is unset", () => {
+    setEnv({});
+    expect(containersEnv.containerControlPlaneDatabaseUrl()).toBeUndefined();
+  });
+
+  test("returns the configured DATABASE_URL", () => {
+    setEnv({ DATABASE_URL: "postgres://u:p@db.internal.example:5432/cloud" });
+    expect(containersEnv.containerControlPlaneDatabaseUrl()).toBe(
+      "postgres://u:p@db.internal.example:5432/cloud",
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -331,6 +331,40 @@ export const containersEnv = {
   },
 
   /**
+   * SECURITY (H4, #12882): extra trusted FULL DATABASE_URLs permitted for the
+   * forwarded `x-eliza-cloud-database-url` header, on TOP of the sidecar's own
+   * configured `DATABASE_URL` (which is always trusted).
+   *
+   * The control-plane forward path lets the Cloud Worker pin a per-request
+   * database. The sidecar must NOT connect to an arbitrary caller-named DB, so
+   * `evaluateForwardedDatabaseUrl` fail-closes against this pinned set. The
+   * match pins the WHOLE identity (scheme, credentials, host, port, database,
+   * query), so entries here must be complete DATABASE_URLs, not bare hosts. A
+   * bare host has no database/credentials identity and will never match. Most
+   * deployments never need this (the forwarded URL == the sidecar's own
+   * `DATABASE_URL`); it exists only for multi-DB topologies where the Worker
+   * legitimately forwards a different-but-known database.
+   *
+   * Format: whitespace/comma-separated full DATABASE_URLs. Unparseable entries
+   * are dropped and never widen the allowlist.
+   */
+  containerControlPlaneDatabaseUrlAllowlist(): string[] {
+    const env = getCloudAwareEnv();
+    const raw = pick(env.CONTAINER_CONTROL_PLANE_DATABASE_URL_ALLOWLIST);
+    if (raw === undefined) return [];
+    return raw
+      .split(/[\s,]+/)
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+  },
+
+  /** The sidecar's own configured control-plane database URL, if any. */
+  containerControlPlaneDatabaseUrl(): string | undefined {
+    const env = getCloudAwareEnv();
+    return pick(env.DATABASE_URL);
+  },
+
+  /**
    * Cloud deployment environment (`staging`, `production`, `local`, …).
    *
    * Stamped onto provisioned Hetzner servers via the `environment` label so

--- a/packages/cloud/shared/src/lib/services/containers/forwarded-database-url-guard.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/forwarded-database-url-guard.test.ts
@@ -1,0 +1,288 @@
+/**
+ * SECURITY (H4, #12882): the container-control-plane sidecar honors a forwarded
+ * `x-eliza-cloud-database-url` header and connects to it. These tests pin the
+ * fail-closed guard: only the sidecar's own configured DB identity and an
+ * explicit operator allowlist of full DATABASE_URLs are trusted. The identity
+ * is pinned WHOLE (scheme, credentials, host, port, database) -- so a different
+ * user or database on the SAME host:port is still rejected. Every
+ * attacker-controlled / off-allowlist / malformed identity is rejected. A
+ * regression here re-opens the tenant/database identity spoof the finding is
+ * about, so the negatives matter as much as the positives.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  buildTrustedDatabaseIdentitySet,
+  databaseIdentityKey,
+  evaluateForwardedDatabaseUrl,
+} from "./forwarded-database-url-guard";
+
+const CONFIGURED = "postgres://svc:pw@db.internal.example:5432/cloud";
+
+describe("databaseIdentityKey", () => {
+  test("pins scheme, credentials, host, port, and database", () => {
+    expect(databaseIdentityKey(CONFIGURED)).toBe(
+      "postgres://svc:pw@db.internal.example:5432/cloud",
+    );
+  });
+
+  test("defaults a missing Postgres port to 5432 so the two forms match", () => {
+    expect(databaseIdentityKey("postgres://u:p@host.example/db")).toBe(
+      databaseIdentityKey("postgres://u:p@host.example:5432/db"),
+    );
+  });
+
+  test("lowercases scheme + host but NOT credentials/database (case-sensitive)", () => {
+    expect(databaseIdentityKey("POSTGRES://User:Secret@DB.Example:5432/Cloud")).toBe(
+      "postgres://User:Secret@db.example:5432/Cloud",
+    );
+  });
+
+  test("a different database on the same host:port produces a DIFFERENT key", () => {
+    expect(databaseIdentityKey("postgres://svc:pw@db.internal.example:5432/cloud")).not.toBe(
+      databaseIdentityKey("postgres://svc:pw@db.internal.example:5432/exfil"),
+    );
+  });
+
+  test("a different user on the same host:port produces a DIFFERENT key", () => {
+    expect(databaseIdentityKey("postgres://svc:pw@db.internal.example:5432/cloud")).not.toBe(
+      databaseIdentityKey("postgres://attacker:pw@db.internal.example:5432/cloud"),
+    );
+  });
+
+  test("compares the database path EXACTLY -- a trailing slash is a different database", () => {
+    // pg-connection-string treats `/db` and `/db/` as different db names, so the
+    // guard must NOT collapse them.
+    expect(databaseIdentityKey("postgres://u:p@host.example:5432/db/")).not.toBe(
+      databaseIdentityKey("postgres://u:p@host.example:5432/db"),
+    );
+  });
+
+  test("returns null for a URL with DUPLICATE query keys (ambiguous pg last-wins override)", () => {
+    // ?host=a&host=b and ?host=b&host=a connect to different targets; refuse to
+    // canonicalize either into a stable key.
+    expect(databaseIdentityKey("postgres://u:p@host.example:5432/db?host=a&host=b")).toBeNull();
+  });
+
+  test("returns null for malformed values and host-less NETWORK URLs", () => {
+    expect(databaseIdentityKey("")).toBeNull();
+    expect(databaseIdentityKey("   ")).toBeNull();
+    expect(databaseIdentityKey("not a url")).toBeNull();
+    // A host-less postgres URL is not a trustable network identity.
+    expect(databaseIdentityKey("postgres:///justpath")).toBeNull();
+  });
+
+  test("keys host-less local schemes (pglite file / sqlite / file) on scheme+path", () => {
+    expect(databaseIdentityKey("pglite:///tmp/eliza/cloud.db")).toBe(
+      "pglite:///tmp/eliza/cloud.db",
+    );
+    expect(databaseIdentityKey("file:///data/db.sqlite")).toBe("file:///data/db.sqlite");
+    // Path compared exactly: a trailing slash is a distinct file identity.
+    expect(databaseIdentityKey("pglite:///tmp/eliza/cloud.db/")).not.toBe(
+      databaseIdentityKey("pglite:///tmp/eliza/cloud.db"),
+    );
+  });
+
+  test("pglite://memory keeps its host-based key (has a hostname, no default pg port)", () => {
+    // Non-Postgres scheme => no port defaulting; the key is stable + matches
+    // an identical forwarded pglite://memory, which is all the guard needs.
+    expect(databaseIdentityKey("pglite://memory")).toBe(databaseIdentityKey("pglite://memory"));
+    expect(databaseIdentityKey("pglite://memory")).not.toBe(databaseIdentityKey("pglite://other"));
+  });
+});
+
+describe("buildTrustedDatabaseIdentitySet", () => {
+  test("includes the configured DB identity", () => {
+    const set = buildTrustedDatabaseIdentitySet({
+      configuredDatabaseUrl: CONFIGURED,
+    });
+    expect(set.has("postgres://svc:pw@db.internal.example:5432/cloud")).toBe(true);
+    expect(set.size).toBe(1);
+  });
+
+  test("adds allowlist URLs on top of the configured identity", () => {
+    const set = buildTrustedDatabaseIdentitySet({
+      configuredDatabaseUrl: CONFIGURED,
+      allowlistDatabaseUrls: ["postgres://svc:pw@replica.internal.example:6543/cloud"],
+    });
+    expect(set.has("postgres://svc:pw@db.internal.example:5432/cloud")).toBe(true);
+    expect(set.has("postgres://svc:pw@replica.internal.example:6543/cloud")).toBe(true);
+  });
+
+  test("an unparseable configured URL does NOT silently widen the set", () => {
+    const set = buildTrustedDatabaseIdentitySet({
+      configuredDatabaseUrl: "garbage-not-a-url",
+    });
+    expect(set.size).toBe(0);
+  });
+
+  test("unparseable / bare-host allowlist entries are dropped", () => {
+    const set = buildTrustedDatabaseIdentitySet({
+      configuredDatabaseUrl: CONFIGURED,
+      // a bare host is NOT a full identity and must not widen the set
+      allowlistDatabaseUrls: ["db.internal.example", "evil host", ""],
+    });
+    expect(set.size).toBe(1);
+    expect(set.has("postgres://svc:pw@db.internal.example:5432/cloud")).toBe(true);
+  });
+});
+
+describe("evaluateForwardedDatabaseUrl -- fail closed", () => {
+  test("allows the exact configured control-plane database identity", () => {
+    const decision = evaluateForwardedDatabaseUrl(
+      "postgres://svc:pw@db.internal.example:5432/cloud",
+      { configuredDatabaseUrl: CONFIGURED },
+    );
+    expect(decision.allowed).toBe(true);
+  });
+
+  test("allows the configured identity written with the default port implied", () => {
+    const decision = evaluateForwardedDatabaseUrl("postgres://svc:pw@db.internal.example/cloud", {
+      configuredDatabaseUrl: CONFIGURED,
+    });
+    expect(decision.allowed).toBe(true);
+  });
+
+  test("REJECTS an attacker-controlled database host", () => {
+    const decision = evaluateForwardedDatabaseUrl(
+      "postgres://attacker:pw@evil.attacker.example:5432/exfil",
+      { configuredDatabaseUrl: CONFIGURED },
+    );
+    expect(decision.allowed).toBe(false);
+    if (!decision.allowed) {
+      expect(decision.reason).toContain("does not match the pinned");
+    }
+  });
+
+  test("REJECTS a DIFFERENT DATABASE on the same host:port (the #12882 P1 gap)", () => {
+    const decision = evaluateForwardedDatabaseUrl(
+      "postgres://svc:pw@db.internal.example:5432/exfil",
+      { configuredDatabaseUrl: CONFIGURED },
+    );
+    expect(decision.allowed).toBe(false);
+  });
+
+  test("REJECTS a DIFFERENT USER on the same host:port + database", () => {
+    const decision = evaluateForwardedDatabaseUrl(
+      "postgres://attacker:pw@db.internal.example:5432/cloud",
+      { configuredDatabaseUrl: CONFIGURED },
+    );
+    expect(decision.allowed).toBe(false);
+  });
+
+  test("REJECTS a forwarded URL that adds pg query OVERRIDE params (?host=evil, ?user=attacker)", () => {
+    // pg-connection-string honors query fields as connection overrides, so
+    // trusted scheme/host/path + an evil query must NOT pass.
+    const evilHost = evaluateForwardedDatabaseUrl(
+      "postgres://svc:pw@db.internal.example:5432/cloud?host=evil.example",
+      { configuredDatabaseUrl: CONFIGURED },
+    );
+    expect(evilHost.allowed).toBe(false);
+    const evilUser = evaluateForwardedDatabaseUrl(
+      "postgres://svc:pw@db.internal.example:5432/cloud?user=attacker&password=x",
+      { configuredDatabaseUrl: CONFIGURED },
+    );
+    expect(evilUser.allowed).toBe(false);
+  });
+
+  test("ALLOWS matching benign query params (e.g. ?sslmode=require) present on both sides, order-independent", () => {
+    const configured =
+      "postgres://svc:pw@db.internal.example:5432/cloud?sslmode=require&application_name=eliza";
+    const forwardedReordered =
+      "postgres://svc:pw@db.internal.example:5432/cloud?application_name=eliza&sslmode=require";
+    const decision = evaluateForwardedDatabaseUrl(forwardedReordered, {
+      configuredDatabaseUrl: configured,
+    });
+    expect(decision.allowed).toBe(true);
+  });
+
+  test("REJECTS a forwarded URL that DROPS the configured query params", () => {
+    const configured = "postgres://svc:pw@db.internal.example:5432/cloud?sslmode=require";
+    const forwardedNoQuery = "postgres://svc:pw@db.internal.example:5432/cloud";
+    const decision = evaluateForwardedDatabaseUrl(forwardedNoQuery, {
+      configuredDatabaseUrl: configured,
+    });
+    expect(decision.allowed).toBe(false);
+  });
+
+  test("REJECTS a forwarded URL with duplicate query keys even if one value is the trusted one", () => {
+    const configured = "postgres://svc:pw@db.internal.example:5432/cloud?sslmode=require";
+    // Attacker appends a second sslmode/host to override; last-wins would apply.
+    const decision = evaluateForwardedDatabaseUrl(
+      "postgres://svc:pw@db.internal.example:5432/cloud?sslmode=require&sslmode=disable",
+      { configuredDatabaseUrl: configured },
+    );
+    expect(decision.allowed).toBe(false);
+  });
+
+  test("REJECTS a trailing-slash database-name variant (pg treats /cloud vs /cloud/ as different DBs)", () => {
+    const decision = evaluateForwardedDatabaseUrl(
+      "postgres://svc:pw@db.internal.example:5432/cloud/",
+      { configuredDatabaseUrl: CONFIGURED },
+    );
+    expect(decision.allowed).toBe(false);
+  });
+
+  test("REJECTS a same-host-different-port pivot", () => {
+    const decision = evaluateForwardedDatabaseUrl(
+      "postgres://svc:pw@db.internal.example:6379/cloud",
+      { configuredDatabaseUrl: CONFIGURED },
+    );
+    expect(decision.allowed).toBe(false);
+  });
+
+  test("REJECTS a malformed forwarded URL", () => {
+    const decision = evaluateForwardedDatabaseUrl("::::not a url::::", {
+      configuredDatabaseUrl: CONFIGURED,
+    });
+    expect(decision.allowed).toBe(false);
+    if (!decision.allowed) {
+      expect(decision.reason).toContain("malformed");
+    }
+  });
+
+  test("REJECTS when no trusted identity is configured at all (fail closed, not open)", () => {
+    const decision = evaluateForwardedDatabaseUrl(
+      "postgres://svc:pw@db.internal.example:5432/cloud",
+      {},
+    );
+    expect(decision.allowed).toBe(false);
+    if (!decision.allowed) {
+      expect(decision.reason).toContain("no trusted database identity");
+    }
+  });
+
+  test("allows an explicitly allowlisted replica identity", () => {
+    const decision = evaluateForwardedDatabaseUrl(
+      "postgres://svc:pw@replica.internal.example:6543/cloud",
+      {
+        configuredDatabaseUrl: CONFIGURED,
+        allowlistDatabaseUrls: ["postgres://svc:pw@replica.internal.example:6543/cloud"],
+      },
+    );
+    expect(decision.allowed).toBe(true);
+  });
+
+  test("still rejects an off-allowlist identity when an allowlist is configured", () => {
+    const decision = evaluateForwardedDatabaseUrl("postgres://svc:pw@evil.example:5432/cloud", {
+      configuredDatabaseUrl: CONFIGURED,
+      allowlistDatabaseUrls: ["postgres://svc:pw@replica.internal.example:6543/cloud"],
+    });
+    expect(decision.allowed).toBe(false);
+  });
+
+  test("ALLOWS a forwarded local file-backed PGlite URL identical to the configured one (dev/test)", () => {
+    const local = "pglite:///tmp/eliza/cloud.db";
+    const decision = evaluateForwardedDatabaseUrl(local, {
+      configuredDatabaseUrl: local,
+    });
+    expect(decision.allowed).toBe(true);
+  });
+
+  test("still rejects a forwarded local PGlite file that points at a DIFFERENT path", () => {
+    const decision = evaluateForwardedDatabaseUrl("pglite:///tmp/evil.db", {
+      configuredDatabaseUrl: "pglite:///tmp/eliza/cloud.db",
+    });
+    expect(decision.allowed).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/forwarded-database-url-guard.ts
+++ b/packages/cloud/shared/src/lib/services/containers/forwarded-database-url-guard.ts
@@ -1,0 +1,206 @@
+/**
+ * SECURITY (H4, #12882 / #12230): pin the forwarded per-request database
+ * identity to trusted control-plane context.
+ *
+ * The container-control-plane sidecar accepts an `x-eliza-cloud-database-url`
+ * header and, when present, runs the request inside
+ * `runWithCloudBindingsAsync({ DATABASE_URL })` -- i.e. it will connect to
+ * whatever Postgres URL the caller names and even mirror/write Docker-node rows
+ * into it. On its own that is an attacker-controlled tenant/database identity:
+ * anyone who can reach the sidecar with the internal token could point it at a
+ * database they control (data exfil, forged node rows), pivot to an internal DB
+ * it should never touch, OR -- even on the *same* Postgres host:port -- connect
+ * as a different user or to a different database/schema (`…:5432/exfil` instead
+ * of `…:5432/cloud`).
+ *
+ * This guard makes that header FAIL CLOSED by pinning the WHOLE database
+ * identity, not just the host. The legitimate control-plane forward
+ * (`_container-control-plane-forward.ts`) sends the sidecar's OWN
+ * `DATABASE_URL` verbatim, so the only value we ever need to honor is one that
+ * matches the configured URL (or an explicit operator allowlist of full
+ * DATABASE_URLs). A forwarded URL is honored only when its normalized identity
+ * -- scheme, credentials, host, port, AND database path -- equals a trusted one.
+ *
+ * Anything else is rejected. A malformed forwarded URL is rejected. An
+ * unparseable configured or allowlist URL does NOT silently widen the trust
+ * set -- it is simply not added, so the guard stays closed.
+ */
+
+export type ForwardedDatabaseUrlDecision =
+  | { readonly allowed: true }
+  | { readonly allowed: false; readonly reason: string };
+
+export interface ForwardedDatabaseUrlGuardConfig {
+  /** The sidecar's own configured DATABASE_URL (pinned control-plane DB). */
+  readonly configuredDatabaseUrl?: string | undefined;
+  /**
+   * Operator-configured extra trusted full DATABASE_URLs. Comma/space parsing
+   * is done by the caller (containers-env); this is the already-split list.
+   * Each entry must be a complete database URL (same identity space as
+   * {@link databaseIdentityKey}), NOT a bare host -- matching is on the whole
+   * identity, so a bare host would never match and is dropped.
+   */
+  readonly allowlistDatabaseUrls?: readonly string[] | undefined;
+}
+
+const DEFAULT_POSTGRES_PORT = "5432";
+const NETWORK_SCHEMES_DEFAULTING_TO_PG_PORT = new Set(["postgres:", "postgresql:"]);
+
+/**
+ * Normalize a database URL to a canonical identity key that pins the WHOLE
+ * connection identity: scheme, username, password, host, port, and database
+ * path. Two URLs get the same key iff they connect to the same database as the
+ * same principal.
+ *
+ * Normalization is intentionally minimal and identity-preserving:
+ *   - scheme + host are lowercased (case-insensitive per URL/DNS rules),
+ *   - a missing port on a Postgres scheme is defaulted to 5432 (so
+ *     `example/db` and `example:5432/db` are the same identity),
+ *   - query parameters are canonicalized (sorted) and INCLUDED in the key.
+ * The database path is compared EXACTLY (no trailing-slash stripping): the
+ * Postgres parser treats `/cloud` and `/cloud/` as different database names, so
+ * we must not collapse them and let a forwarded URL bind a different DB.
+ * Username/password/database are compared exactly (NOT lowercased) -- those are
+ * case-sensitive credentials/identifiers and must match precisely.
+ *
+ * Query params MUST be part of the identity: `pg-connection-string` honors
+ * query fields like `host`, `port`, `user`, `password`, and `dbname` as
+ * connection OVERRIDES, so a URL with a trusted host/path but
+ * `?host=evil.example&user=attacker` would connect somewhere else entirely.
+ * Because the legitimate control-plane forward sends the configured
+ * `DATABASE_URL` verbatim, its (possibly empty) query set is exactly what the
+ * pinned identity should require -- any extra/attacker query field changes the
+ * key and fails closed.
+ *
+ * Returns `null` when the value can't be parsed as a URL, or when a *network*
+ * scheme has no host (an unusable, untrustable identity). Host-less LOCAL
+ * schemes (the documented file-backed PGlite form `pglite:///path`, plus
+ * `sqlite:`/`file:`) are keyed on scheme + path so an identical local DB
+ * still matches in dev/test.
+ */
+const HOSTLESS_LOCAL_SCHEMES = new Set(["pglite:", "sqlite:", "file:"]);
+
+export function databaseIdentityKey(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  const scheme = parsed.protocol.toLowerCase();
+  const host = parsed.hostname.trim().toLowerCase();
+  // Do NOT normalize the path (e.g. strip a trailing slash): the Postgres
+  // connection parser treats `/cloud` and `/cloud/` as different database
+  // names, so collapsing them would let a forwarded `.../cloud/` bind a
+  // different DB than the pinned `.../cloud`. The path is compared exactly.
+  const path = parsed.pathname;
+
+  if (!host) {
+    // Host-less local database URL (e.g. pglite file): key on scheme + path.
+    // A host-less network URL is not a trustable identity.
+    if (!HOSTLESS_LOCAL_SCHEMES.has(scheme)) return null;
+    return `${scheme}//${path}`;
+  }
+
+  const port =
+    parsed.port.trim() ||
+    (NETWORK_SCHEMES_DEFAULTING_TO_PG_PORT.has(scheme) ? DEFAULT_POSTGRES_PORT : "");
+  // Credentials are part of the identity and case-sensitive; do NOT lowercase.
+  const user = parsed.username;
+  const pass = parsed.password;
+  const auth = user || pass ? `${user}:${pass}@` : "";
+  const query = canonicalQuery(parsed);
+  // Duplicate query keys are ambiguous (pg-connection-string uses the LAST
+  // occurrence for overrides like host/user/sslmode). We refuse to canonicalize
+  // them into a stable key -- treat the whole URL as untrusted/unparseable so
+  // the guard fails closed rather than authorizing a reordered duplicate.
+  if (query === null) return null;
+  return `${scheme}//${auth}${host}:${port}${path}${query}`;
+}
+
+/**
+ * Canonicalize the query string (sorted key=value pairs) so trusted params like
+ * `?sslmode=require` still match regardless of order, while any
+ * extra/attacker-supplied override param (`?host=evil`, `?user=attacker`, ...)
+ * changes the key and fails the guard closed. Returns "" when there is no query.
+ *
+ * Returns `null` when a query key appears MORE THAN ONCE: pg-connection-string
+ * resolves duplicate override keys by last-occurrence, so sorting would make
+ * `?host=a&host=b` and `?host=b&host=a` (which connect to DIFFERENT targets)
+ * compare equal. Rather than pick a winner, we reject the ambiguity.
+ */
+function canonicalQuery(parsed: URL): string | null {
+  const entries = [...parsed.searchParams.entries()];
+  if (entries.length === 0) return "";
+  const seen = new Set<string>();
+  for (const [k] of entries) {
+    if (seen.has(k)) return null;
+    seen.add(k);
+  }
+  entries.sort(([ak, av], [bk, bv]) =>
+    ak === bk ? (av < bv ? -1 : av > bv ? 1 : 0) : ak < bk ? -1 : 1,
+  );
+  const canon = entries
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join("&");
+  return `?${canon}`;
+}
+
+/**
+ * Build the set of trusted database identity keys from the sidecar's own
+ * configured DATABASE_URL plus the operator allowlist of full DATABASE_URLs.
+ * Unparseable inputs are dropped (fail closed), never added as a trusted key.
+ */
+export function buildTrustedDatabaseIdentitySet(
+  config: ForwardedDatabaseUrlGuardConfig,
+): Set<string> {
+  const trusted = new Set<string>();
+  if (config.configuredDatabaseUrl) {
+    const key = databaseIdentityKey(config.configuredDatabaseUrl);
+    if (key) trusted.add(key);
+  }
+  for (const entry of config.allowlistDatabaseUrls ?? []) {
+    const key = databaseIdentityKey(entry);
+    if (key) trusted.add(key);
+  }
+  return trusted;
+}
+
+/**
+ * Decide whether a forwarded `x-eliza-cloud-database-url` header value may be
+ * honored. FAIL CLOSED: unknown/unparseable/off-allowlist identities (including
+ * a different user or database on the SAME host:port) are rejected.
+ */
+export function evaluateForwardedDatabaseUrl(
+  forwardedDatabaseUrl: string,
+  config: ForwardedDatabaseUrlGuardConfig,
+): ForwardedDatabaseUrlDecision {
+  const forwardedKey = databaseIdentityKey(forwardedDatabaseUrl);
+  if (!forwardedKey) {
+    return {
+      allowed: false,
+      reason: "forwarded database URL is malformed or has no host",
+    };
+  }
+
+  const trusted = buildTrustedDatabaseIdentitySet(config);
+  if (trusted.size === 0) {
+    return {
+      allowed: false,
+      reason: "no trusted database identity is configured; refusing forwarded database URL",
+    };
+  }
+
+  if (!trusted.has(forwardedKey)) {
+    return {
+      allowed: false,
+      reason:
+        "forwarded database identity does not match the pinned control-plane database (or allowlist)",
+    };
+  }
+
+  return { allowed: true };
+}


### PR DESCRIPTION
## What & why

Closes the remaining part of **finding H4** (`#12230` split, `#12882`): make the
container-control-plane's forwarded database identity **fail-closed** and stop
trusting attacker-controlled tenant/database headers.

The token fail-closed + timing-safe compare from H4 already landed in #12302.
The unaddressed gap was the forwarded `x-eliza-cloud-database-url` header:
`handle`/`handleInternal` passed it **verbatim** into
`runWithCloudBindingsAsync({ DATABASE_URL })` and connected to it (and mirrored
docker-node rows into it). A caller with the internal token could therefore:

- point the sidecar at an **attacker-controlled DB** (data exfil / forged node rows),
- pivot to an **internal DB** it should never reach,
- even on the **same host:port**, bind a **different user or database** (`…/cloud` → `…/exfil`),
- or **override** the real target via `pg-connection-string` query fields
  (`?host=evil`, `?user=attacker`, `?sslmode=…`), including duplicate/last-wins keys.

## Fix

New `packages/cloud/shared/src/lib/services/containers/forwarded-database-url-guard.ts`:

- `databaseIdentityKey(url)` pins the **whole** identity — scheme, credentials,
  host, port, **exact** database path (no trailing-slash normalization, since pg
  treats `/cloud` vs `/cloud/` as different DBs), and a **canonicalized** query.
  Host-less network URLs are rejected; host-less **local** schemes
  (`pglite:`/`sqlite:`/`file:`) key on scheme+path for dev/test. Duplicate query
  keys return `null` (refuse the pg last-wins ambiguity).
- `evaluateForwardedDatabaseUrl(url, config)` fails closed: rejects when no
  trusted identity is configured, on malformed input, and on any off-allowlist
  identity.

Wired into the service via `resolveForwardedDatabaseUrl(c)` (returns **403** on
rejection) in both `handle` and `handleInternal`. Trust set = the sidecar's own
configured `DATABASE_URL` (always) plus an optional operator allowlist of full
DATABASE_URLs (`CONTAINER_CONTROL_PLANE_DATABASE_URL_ALLOWLIST`), read via new
`containersEnv.containerControlPlaneDatabaseUrl()` /
`containerControlPlaneDatabaseUrlAllowlist()`. `CLAUDE.md` + `AGENTS.md` updated
(kept identical) to document the pinned fail-closed binding.

## Tests / evidence

`bun test` — **35 pass / 0 fail** across the two new suites:

- `forwarded-database-url-guard.test.ts` — allow: exact identity, default-port
  form, matching benign query (`?sslmode=require`, order-independent), allowlisted
  replica, identical local PGlite. **reject**: attacker host, different db on same
  host:port, different user, port pivot, trailing-slash db variant, query override
  (`?host=evil`, `?user=attacker`), dropped query, duplicate query keys, malformed,
  no-trusted-identity, off-allowlist, different local PGlite path.
- `containers-env-db-allowlist.test.ts` — env parsing (default empty, split, and
  configured-URL passthrough).

```
Ran 35 tests across 2 files.  35 pass  0 fail
```

- `tsgo --noEmit` clean for every file this PR touches (the only errors are
  pre-existing cross-package module-resolution issues from the shared
  node_modules symlink — `@elizaos/auth/*` subpaths, missing generated i18n data —
  not introduced here).
- `biome check` clean on all touched files.
- Reviewed with codex (gpt-5.5): no regression; earlier P1/P2 findings
  (host-only pinning, trailing slash, query-override, duplicate-query, import
  order) are all fixed in this branch.

Evidence rows: UI / model / audio → **N/A — hosted-agent security hardening, no
UI/model/audio path.** No DB migration (pure request-path guard). Container run
evidence N/A — this rejects untrusted DB identities before any container/DB bind;
covered by the negative unit tests above.

-- [sol-orch]

Closes #12882.
