### PR TITLE
fix(#12883): pin docker nodes and deny agent egress

### DIFF
--- a/.github/issue-evidence/12883-per-node-ssh-egress.md
+++ b/.github/issue-evidence/12883-per-node-ssh-egress.md
@@ -1,0 +1,70 @@
+# Issue #12883 — per-node SSH pinning and hosted-agent egress default-deny
+
+## Scope
+
+- Replaced Docker SSH trust-on-first-use behavior with fail-closed host-key pinning.
+- Required docker-node bootstrap/admin registration to carry a `hostKeyFingerprint`.
+- Added cloud-init host-key fingerprint capture to the node self-registration payload.
+- Moved non-Headscale hosted-agent Docker containers to a separate `--internal` bridge network (`<base>-agent-deny`).
+- Added an operator-generated Kubernetes `NetworkPolicy` with `policyTypes: ["Egress"]` and `egress: []` for operator-managed agent pods.
+
+## Command / run-spec evidence
+
+- Non-Headscale Docker agent run-spec test asserts:
+  - `--network 'containers-isolated-agent-deny'`
+  - `docker network create --driver bridge --internal 'containers-isolated-agent-deny'`
+- Headscale Docker agent run-spec test asserts:
+  - `--network 'containers-isolated'`
+  - no `--internal`, preserving VPN bootstrap reachability.
+- Operator pod spec test asserts:
+  - `apiVersion: networking.k8s.io/v1`
+  - `kind: NetworkPolicy`
+  - `podSelector.matchLabels["eliza.ai/server"]`
+  - `policyTypes: ["Egress"]`
+  - `egress: []`
+- Bootstrap callback tests assert:
+  - missing host-key fingerprint rejects before DB update
+  - wrong fingerprint rejects node identity mutation
+  - matching fingerprint permits liveness/identity update
+  - existing autoscaler placeholder can set its first fingerprint only when hostname/user/port are unchanged
+  - brand-new node creation stores the provided fingerprint
+- Node bootstrap test asserts:
+  - `ssh-keygen -l -E sha256 -f /etc/ssh/ssh_host_ed25519_key.pub`
+  - RSA fallback
+  - fail-closed `exit 1` when no host-key fingerprint can be read
+
+## Verification
+
+- `bun test packages/cloud/shared/src/lib/services/__tests__/agent-container-security.test.ts packages/cloud/shared/src/lib/services/containers/node-bootstrap.test.ts packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts packages/cloud/services/operator/capabilities/__tests__/generators-network-policy.test.ts`
+  - Pass: 26 tests, 0 failures.
+- `bun test --cwd packages/cloud/services/operator`
+  - Pass: 7 tests, 0 failures.
+- `bunx biome check <11 touched files>`
+  - Pass.
+- `bun run --cwd packages/cloud/shared lint`
+  - Pass.
+- `bun run --cwd packages/cloud/api lint`
+  - Pass.
+- `bun run --cwd packages/cloud/services/operator lint`
+  - Pass.
+- `bun run --cwd packages/cloud/services/operator typecheck`
+  - Pass.
+- `bun run --cwd packages/cloud/shared typecheck`
+  - Blocked by existing transitive baseline errors in `packages/app-core/src/services/account-pool.ts`, `packages/app-core/src/services/coding-account-bridge.ts`, and `packages/shared/src/i18n/keyword-matching.ts`; no touched-file errors were reported.
+- `bun run --cwd packages/cloud/api typecheck`
+  - Same existing transitive baseline errors as shared typecheck; no touched-file errors were reported.
+- `docker version --format '{{.Server.Version}}'`
+  - Blocked: Docker daemon unavailable at `unix:///Users/shawwalters/.docker/run/docker.sock`.
+- `git diff --check`
+  - Pass.
+- `bun run verify`
+  - Attempted. Pre-turbo audits passed (`check:agents-claude`, type-safety ratchet, error-policy ratchet).
+  - Failed in unrelated `@elizaos/plugin-calendar#typecheck` with existing missing workspace/module errors under `packages/agent`, `packages/shared`, `packages/ui`, and `plugins/plugin-calendar`.
+  - Write-mode lint side effects from the verify attempt were restored before staging.
+
+## Evidence rows
+
+- UI evidence: N/A - hosted-agent security hardening, no UI path.
+- Model trajectory: N/A - no model-backed path changed.
+- Audio evidence: N/A - no voice/transcript/TTS/STT path changed.
+- Real Docker container execution: blocked by local Docker daemon unavailability; command/run-spec inspections above cover the changed Docker command boundary.

--- a/packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts
+++ b/packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts
@@ -101,16 +101,16 @@ describe("bootstrap-callback node-identity guard (#12876)", () => {
     mockFindByNodeId.mockClear();
   });
 
-  test("rejects hostname mutation on existing node without a fingerprint (409, server values preserved)", async () => {
+  test("rejects hostname mutation on existing node without the required fingerprint", async () => {
     const res = await post({
       nodeId: "node-1",
       hostname: "10.6.6.6", // attacker-controlled MITM host
     });
 
-    expect(res.status).toBe(409);
+    expect(res.status).toBe(400);
     const json = (await res.json()) as { success: boolean; error: string };
     expect(json.success).toBe(false);
-    expect(json.error).toContain("host key fingerprint");
+    expect(json.error).toContain("Validation failed");
 
     // The SSH identity must NOT have been written.
     expect(mockUpdate).not.toHaveBeenCalled();
@@ -137,6 +137,7 @@ describe("bootstrap-callback node-identity guard (#12876)", () => {
       nodeId: "node-1",
       hostname: "10.0.0.1",
       sshPort: 2222,
+      hostKeyFingerprint: "SHA256:wrong-fingerprint",
     });
 
     expect(res.status).toBe(409);
@@ -162,6 +163,27 @@ describe("bootstrap-callback node-identity guard (#12876)", () => {
     expect(stored?.hostname).toBe("10.0.0.1");
   });
 
+  test("allows first host-key pin on an existing autoscaler placeholder when identity is unchanged", async () => {
+    stored = {
+      ...EXISTING,
+      host_key_fingerprint: null,
+      metadata: { provider: "hetzner-cloud", autoscaled: true },
+    };
+
+    const res = await post({
+      nodeId: "node-1",
+      hostname: "10.0.0.1",
+      sshUser: "root",
+      sshPort: 22,
+      hostKeyFingerprint: "SHA256:first-real-pin",
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(lastUpdateArg?.host_key_fingerprint).toBe("SHA256:first-real-pin");
+    expect(stored?.host_key_fingerprint).toBe("SHA256:first-real-pin");
+  });
+
   test("allows identity mutation with a matching pinned fingerprint", async () => {
     const res = await post({
       nodeId: "node-1",
@@ -181,13 +203,14 @@ describe("bootstrap-callback node-identity guard (#12876)", () => {
     expect(lastUpdateArg?.ssh_port).toBe(2200);
   });
 
-  test("liveness re-bootstrap with unchanged identity succeeds without a fingerprint", async () => {
+  test("liveness re-bootstrap with unchanged identity succeeds with the matching fingerprint", async () => {
     const res = await post({
       nodeId: "node-1",
       hostname: "10.0.0.1",
       sshUser: "root",
       sshPort: 22,
       capacity: 16,
+      hostKeyFingerprint: "SHA256:pinned-fingerprint",
     });
 
     expect(res.status).toBe(200);
@@ -197,6 +220,18 @@ describe("bootstrap-callback node-identity guard (#12876)", () => {
     expect(lastUpdateArg?.ssh_user).toBe("root");
     expect(lastUpdateArg?.ssh_port).toBe(22);
     expect(lastUpdateArg?.capacity).toBe(16);
+  });
+
+  test("rejects liveness re-bootstrap without the required pinned fingerprint", async () => {
+    const res = await post({
+      nodeId: "node-1",
+      hostname: "10.0.0.1",
+      sshUser: "root",
+      sshPort: 22,
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 
   test("rejects host-key fingerprint mutation even when SSH identity is unchanged", async () => {

--- a/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
+++ b/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
@@ -35,7 +35,7 @@ const callbackSchema = z.object({
   capacity: z.number().int().min(1).max(64).optional().default(8),
   sshPort: z.number().int().min(1).max(65535).optional().default(22),
   sshUser: z.string().min(1).max(32).optional().default("root"),
-  hostKeyFingerprint: z.string().min(1).max(128).optional(),
+  hostKeyFingerprint: z.string().min(1).max(128),
 });
 
 async function __hono_POST(request: Request) {
@@ -103,13 +103,11 @@ async function __hono_POST(request: Request) {
         sshUser !== existing.ssh_user ||
         sshPort !== existing.ssh_port;
       const pinned = existing.host_key_fingerprint;
+      const hasPinnedFingerprint = pinned !== null;
       const fingerprintMatches =
-        pinned !== null &&
-        hostKeyFingerprint !== undefined &&
-        timingSafeEquals(hostKeyFingerprint, pinned);
+        hasPinnedFingerprint && timingSafeEquals(hostKeyFingerprint, pinned);
       const fingerprintChanged =
-        hostKeyFingerprint !== undefined &&
-        (pinned === null || !timingSafeEquals(hostKeyFingerprint, pinned));
+        hasPinnedFingerprint && !timingSafeEquals(hostKeyFingerprint, pinned);
 
       if (identityChanged) {
         if (!fingerprintMatches) {
@@ -136,7 +134,7 @@ async function __hono_POST(request: Request) {
           {
             success: false,
             error:
-              "Host key fingerprint cannot be changed through re-bootstrap; rotate it through an authenticated control-plane operation.",
+              "Host key fingerprint is required and must match the existing node pin; rotate it through an authenticated control-plane operation.",
           },
           { status: 409 },
         );
@@ -151,7 +149,9 @@ async function __hono_POST(request: Request) {
         ssh_port: identityChanged ? sshPort : existing.ssh_port,
         ssh_user: identityChanged ? sshUser : existing.ssh_user,
         capacity,
-        host_key_fingerprint: existing.host_key_fingerprint,
+        host_key_fingerprint: hasPinnedFingerprint
+          ? existing.host_key_fingerprint
+          : hostKeyFingerprint,
         status: "unknown",
         metadata: {
           ...((existing.metadata as Record<string, unknown>) ?? {}),

--- a/packages/cloud/api/v1/admin/docker-nodes/route.ts
+++ b/packages/cloud/api/v1/admin/docker-nodes/route.ts
@@ -99,7 +99,7 @@ const createNodeSchema = z.object({
   sshPort: z.number().int().min(1).max(65535).optional().default(22),
   capacity: z.number().int().min(1).optional().default(8),
   sshUser: z.string().min(1).optional().default("root"),
-  hostKeyFingerprint: z.string().min(1).optional(),
+  hostKeyFingerprint: z.string().min(1),
 });
 
 app.post("/", async (c) => {
@@ -148,7 +148,7 @@ app.post("/", async (c) => {
       ssh_port: sshPort,
       capacity,
       ssh_user: sshUser,
-      host_key_fingerprint: hostKeyFingerprint ?? null,
+      host_key_fingerprint: hostKeyFingerprint,
     });
 
     logger.info("[Admin Docker Nodes] Node registered", {
@@ -168,7 +168,6 @@ app.post("/", async (c) => {
       enabled: boolean;
       status: string;
       createdAt: Date;
-      warning?: string;
     } = {
       id: node.id,
       nodeId: node.node_id,
@@ -181,11 +180,6 @@ app.post("/", async (c) => {
       status: node.status,
       createdAt: node.created_at,
     };
-
-    if (!hostKeyFingerprint) {
-      responseData.warning =
-        "No host key fingerprint set. SSH connections to this node are vulnerable to MITM attacks. Set host_key_fingerprint to pin the host key.";
-    }
 
     return c.json(
       {

--- a/packages/cloud/services/operator/capabilities/__tests__/generators-network-policy.test.ts
+++ b/packages/cloud/services/operator/capabilities/__tests__/generators-network-policy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { generateNetworkPolicy } from "../controller/generators";
+import type { Server } from "../crd/generated/server-v1alpha1";
+
+function server(): Server {
+  return {
+    metadata: {
+      name: "server-a",
+      namespace: "eliza-agents",
+      uid: "server-uid",
+    },
+    spec: {
+      image: "ghcr.io/elizaos/eliza:stable",
+      tier: "standard",
+      capacity: 1,
+    },
+  } as Server;
+}
+
+describe("generateNetworkPolicy", () => {
+  test("generates an explicit default-deny egress policy for operator-managed agent pods", () => {
+    const policy = generateNetworkPolicy(server());
+
+    expect(policy.apiVersion).toBe("networking.k8s.io/v1");
+    expect(policy.kind).toBe("NetworkPolicy");
+    expect(policy.metadata.name).toBe("server-a-default-deny-egress");
+    expect(policy.metadata.namespace).toBe("eliza-agents");
+    expect(policy.spec.podSelector.matchLabels).toEqual({
+      "eliza.ai/server": "server-a",
+    });
+    expect(policy.spec.policyTypes).toEqual(["Egress"]);
+    expect(policy.spec.egress).toEqual([]);
+  });
+});

--- a/packages/cloud/services/operator/capabilities/controller/generators.ts
+++ b/packages/cloud/services/operator/capabilities/controller/generators.ts
@@ -78,7 +78,7 @@ function getRedisAddress(): string {
   return "redis.eliza-infra.svc:6379";
 }
 
-function generateDeployment(server: Server) {
+export function generateDeployment(server: Server) {
   const { name, namespace: ns } = serverMetadata(server);
 
   return {
@@ -165,7 +165,7 @@ function generateDeployment(server: Server) {
   };
 }
 
-function generateService(server: Server) {
+export function generateService(server: Server) {
   const { name, namespace: ns } = serverMetadata(server);
 
   return {
@@ -185,7 +185,7 @@ function generateService(server: Server) {
   };
 }
 
-function generateScaledObject(server: Server) {
+export function generateScaledObject(server: Server) {
   const { name, namespace: ns } = serverMetadata(server);
 
   return {
@@ -234,10 +234,35 @@ function generateScaledObject(server: Server) {
   };
 }
 
+export function generateNetworkPolicy(server: Server) {
+  const { name, namespace: ns } = serverMetadata(server);
+
+  return {
+    apiVersion: "networking.k8s.io/v1",
+    kind: "NetworkPolicy",
+    metadata: {
+      name: `${name}-default-deny-egress`,
+      namespace: ns,
+      labels: labels(server),
+      ownerReferences: ownerRef(server),
+    },
+    spec: {
+      podSelector: {
+        matchLabels: { "eliza.ai/server": name },
+      },
+      policyTypes: ["Egress"],
+      egress: [],
+    },
+  };
+}
+
 export async function applyResources(server: Server) {
   await K8s(kind.Deployment).Apply(generateDeployment(server), {
     force: true,
   });
   await K8s(kind.Service).Apply(generateService(server), { force: true });
   await K8s(ScaledObject).Apply(generateScaledObject(server), { force: true });
+  await K8s(kind.NetworkPolicy).Apply(generateNetworkPolicy(server), {
+    force: true,
+  });
 }

--- a/packages/cloud/shared/src/lib/services/__tests__/agent-container-security.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/agent-container-security.test.ts
@@ -5,7 +5,12 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { buildAgentContainerSecurityFlags } from "../agent-container-security";
+import {
+  buildAgentContainerSecurityFlags,
+  buildAgentNetworkFlag,
+  buildAgentNetworkName,
+  buildEnsureAgentNetworkCmd,
+} from "../agent-container-security";
 
 describe("buildAgentContainerSecurityFlags — hosted-agent escape hardening (#12468)", () => {
   test("always drops all caps, forbids priv-escalation, and bounds pids (default 512)", () => {
@@ -49,5 +54,23 @@ describe("buildAgentContainerSecurityFlags — hosted-agent escape hardening (#1
     expect(buildAgentContainerSecurityFlags({ headscaleEnabled: true, pidsLimit: 1024 })).toContain(
       "--pids-limit=1024",
     );
+  });
+
+  test("non-headscale agents use a separate internal default-deny bridge", () => {
+    const opts = { baseNetwork: "containers-isolated", headscaleEnabled: false };
+    expect(buildAgentNetworkName(opts)).toBe("containers-isolated-agent-deny");
+    expect(buildAgentNetworkFlag(opts)).toBe("--network 'containers-isolated-agent-deny'");
+    expect(buildEnsureAgentNetworkCmd(opts)).toContain(
+      "docker network create --driver bridge --internal 'containers-isolated-agent-deny'",
+    );
+  });
+
+  test("headscale agents keep the routable shared bridge for VPN bootstrap", () => {
+    const opts = { baseNetwork: "containers-isolated", headscaleEnabled: true };
+    expect(buildAgentNetworkName(opts)).toBe("containers-isolated");
+    expect(buildAgentNetworkFlag(opts)).toBe("--network 'containers-isolated'");
+    const ensureCmd = buildEnsureAgentNetworkCmd(opts);
+    expect(ensureCmd).toContain("docker network create --driver bridge 'containers-isolated'");
+    expect(ensureCmd).not.toContain("--internal");
   });
 });

--- a/packages/cloud/shared/src/lib/services/agent-container-security.ts
+++ b/packages/cloud/shared/src/lib/services/agent-container-security.ts
@@ -17,6 +17,7 @@
  */
 
 import { buildAppContainerSecurityFlags } from "./app-network-utils";
+import { shellQuote } from "./docker-sandbox-utils";
 
 /**
  * Build the ordered `docker create` capability/security flags for a hosted-agent
@@ -31,4 +32,31 @@ export function buildAgentContainerSecurityFlags(opts: {
     ...buildAppContainerSecurityFlags({ pidsLimit: opts.pidsLimit }),
     ...(opts.headscaleEnabled ? ["--cap-add=NET_ADMIN", "--device /dev/net/tun"] : []),
   ];
+}
+
+export function agentDefaultDenyNetworkName(baseNetwork: string): string {
+  return `${baseNetwork}-agent-deny`.replace(/[^A-Za-z0-9_.-]/g, "-").slice(0, 63);
+}
+
+export function buildAgentNetworkName(opts: {
+  baseNetwork: string;
+  headscaleEnabled: boolean;
+}): string {
+  return opts.headscaleEnabled ? opts.baseNetwork : agentDefaultDenyNetworkName(opts.baseNetwork);
+}
+
+export function buildAgentNetworkFlag(opts: {
+  baseNetwork: string;
+  headscaleEnabled: boolean;
+}): string {
+  return `--network ${shellQuote(buildAgentNetworkName(opts))}`;
+}
+
+export function buildEnsureAgentNetworkCmd(opts: {
+  baseNetwork: string;
+  headscaleEnabled: boolean;
+}): string {
+  const network = shellQuote(buildAgentNetworkName(opts));
+  const internalFlag = opts.headscaleEnabled ? "" : " --internal";
+  return `docker network inspect ${network} >/dev/null 2>&1 || docker network create --driver bridge${internalFlag} ${network} >/dev/null 2>&1 || docker network inspect ${network} >/dev/null`;
 }

--- a/packages/cloud/shared/src/lib/services/containers/node-bootstrap.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-bootstrap.test.ts
@@ -86,4 +86,21 @@ describe("buildContainerNodeUserData — ghcr access", () => {
     expect(guardIdx).toBeGreaterThan(dockerIdx);
     expect(networkIdx).toBeGreaterThan(guardIdx);
   });
+
+  test("self-registration includes the node host-key fingerprint and fails closed if it cannot be read", () => {
+    clearRegistryEnv();
+    const userData = buildContainerNodeUserData({
+      ...baseInput,
+      registrationUrl: "https://control.example.test/api/v1/admin/docker-nodes/bootstrap-callback",
+      registrationSecret: "bootstrap-secret",
+    });
+
+    expect(userData).toContain(
+      "HOST_KEY_FINGERPRINT=$(ssh-keygen -l -E sha256 -f /etc/ssh/ssh_host_ed25519_key.pub",
+    );
+    expect(userData).toContain("ssh_host_rsa_key.pub");
+    expect(userData).toContain("hostKeyFingerprint");
+    expect(userData).toContain("host key fingerprint unavailable; refusing self-registration");
+    expect(userData).toContain("exit 1");
+  });
 });

--- a/packages/cloud/shared/src/lib/services/containers/node-bootstrap.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-bootstrap.ts
@@ -111,7 +111,15 @@ export function buildContainerNodeUserData(input: NodeBootstrapInput): string {
   - |
     HOSTNAME=$(hostname -f 2>/dev/null || hostname)
     PUBLIC_IP=$(curl -fsS ifconfig.me 2>/dev/null || hostname -I | awk '{print $1}')
-    PAYLOAD=$(printf '{"nodeId":"%s","hostname":"%s","capacity":%d}' '${nodeId}' "$PUBLIC_IP" ${capacity})
+    HOST_KEY_FINGERPRINT=$(ssh-keygen -l -E sha256 -f /etc/ssh/ssh_host_ed25519_key.pub 2>/dev/null | awk '{print $2}')
+    if [ -z "$HOST_KEY_FINGERPRINT" ]; then
+      HOST_KEY_FINGERPRINT=$(ssh-keygen -l -E sha256 -f /etc/ssh/ssh_host_rsa_key.pub 2>/dev/null | awk '{print $2}')
+    fi
+    if [ -z "$HOST_KEY_FINGERPRINT" ]; then
+      echo '[bootstrap] host key fingerprint unavailable; refusing self-registration'
+      exit 1
+    fi
+    PAYLOAD=$(printf '{"nodeId":"%s","hostname":"%s","capacity":%d,"sshPort":22,"sshUser":"root","hostKeyFingerprint":"%s"}' '${nodeId}' "$PUBLIC_IP" ${capacity} "$HOST_KEY_FINGERPRINT")
     curl -fsS -X POST '${registerUrl}' \\
       -H 'Content-Type: application/json' \\
       ${registerSecret ? `-H 'X-Bootstrap-Secret: ${registerSecret}'` : ""} \\

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -20,7 +20,11 @@ import { signStewardMutatingRequest } from "../steward/sign";
 import { resolveServerStewardApiUrlFromEnv } from "../steward-url";
 import { logger } from "../utils/logger";
 import { withTimeout } from "../utils/with-timeout";
-import { buildAgentContainerSecurityFlags } from "./agent-container-security";
+import {
+  buildAgentContainerSecurityFlags,
+  buildAgentNetworkFlag,
+  buildEnsureAgentNetworkCmd,
+} from "./agent-container-security";
 import { ensureRegistryAccess } from "./containers/hetzner-client/registry";
 import { getNodeAutoscaler } from "./containers/node-autoscaler";
 import { resolveImageDigest } from "./containers/registry-probe";
@@ -31,7 +35,6 @@ import {
   allocatePort,
   BRIDGE_PORT_MAX,
   BRIDGE_PORT_MIN,
-  buildEnsureNetworkCmd,
   dockerPlatformFlag,
   extractDockerCreateContainerId,
   getContainerName,
@@ -928,7 +931,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     let sshPort = DEFAULT_SSH_PORT;
     let sshUser = DEFAULT_SSH_USERNAME;
 
-    // host_key_fingerprint from DB node (null for env-var fallback, TOFU applies)
+    // host_key_fingerprint from DB node. Missing pins now fail closed in DockerSSHClient.
     let hostKeyFingerprint: string | undefined;
 
     if (dbNode) {
@@ -958,10 +961,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       const envNode = envNodes[Math.floor(Math.random() * envNodes.length)]!;
       nodeId = envNode.nodeId;
       hostname = envNode.hostname;
-      // Env-var nodes use defaults for SSH port/user — log a warning since
-      // host key fingerprint is unavailable (TOFU applies)
+      // Env-var nodes use defaults for SSH port/user and cannot provide a host
+      // key pin, so SSH will fail closed. Register nodes in docker_nodes for production.
       logger.warn(
-        `[docker-sandbox] Env-var fallback node ${nodeId}: using SSH defaults (port ${sshPort}, user ${sshUser}, no fingerprint)`,
+        `[docker-sandbox] Env-var fallback node ${nodeId}: using SSH defaults (port ${sshPort}, user ${sshUser}, no fingerprint; SSH will fail closed)`,
       );
     }
 
@@ -1252,7 +1255,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         ...platformFlags,
         `--name ${shellQuote(containerName)}`,
         "--restart unless-stopped",
-        `--network ${shellQuote(DOCKER_NETWORK)}`,
+        buildAgentNetworkFlag({ baseNetwork: DOCKER_NETWORK, headscaleEnabled }),
         ...(requiresDockerHostGateway(stewardContainerUrl) || Object.keys(proxyEnv).length > 0
           ? ["--add-host host.docker.internal:host-gateway"]
           : []),
@@ -1284,7 +1287,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       // run the cloud-init bootstrap; the network can also be pruned away).
       // Without this, `docker create --network` below fails with an opaque
       // "network not found" and the provision retries forever.
-      await ssh.exec(buildEnsureNetworkCmd(DOCKER_NETWORK), DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        buildEnsureAgentNetworkCmd({ baseNetwork: DOCKER_NETWORK, headscaleEnabled }),
+        DOCKER_CMD_TIMEOUT_MS,
+      );
 
       const containerId = extractDockerCreateContainerId(
         await ssh.exec(dockerCreateCmd, DOCKER_CMD_TIMEOUT_MS),

--- a/packages/cloud/shared/src/lib/services/docker-ssh.ts
+++ b/packages/cloud/shared/src/lib/services/docker-ssh.ts
@@ -102,8 +102,8 @@ export class DockerSSHClient {
    * two nodes share a hostname but use different SSH ports or users.
    *
    * When hostKeyFingerprint is provided, the pooled client will reject
-   * connections if the remote key doesn't match. When omitted, TOFU
-   * (trust-on-first-use) applies: the fingerprint is logged on first connect.
+   * connections if the remote key doesn't match. When omitted, connections
+   * fail closed; Docker nodes must carry a pinned host key in docker_nodes.
    */
   static getClient(
     hostname: string,
@@ -126,8 +126,12 @@ export class DockerSSHClient {
         DockerSSHClient.pool.delete(poolKey);
         client = undefined;
       }
-      // Evict if fingerprint requirements changed
-      if (client && hostKeyFingerprint && client.pinnedFingerprint !== hostKeyFingerprint) {
+      // Evict if fingerprint requirements changed, including pin removal.
+      if (
+        client &&
+        normalizeSshFingerprint(client.pinnedFingerprint ?? "") !==
+          normalizeSshFingerprint(hostKeyFingerprint ?? "")
+      ) {
         logger.info(`[docker-ssh] Evicting pooled connection for ${poolKey} — fingerprint changed`);
         client.disconnect().catch(() => {});
         DockerSSHClient.pool.delete(poolKey);
@@ -300,11 +304,10 @@ export class DockerSSHClient {
         hostVerifier: (key: Buffer) => {
           const fingerprint = crypto.createHash("sha256").update(key).digest("base64");
           if (!this.hostKeyFingerprint) {
-            // No fingerprint configured — TOFU: accept and log at warn for operator visibility
-            logger.warn(
-              `[docker-ssh] Host key for ${this.hostname}: SHA256:${fingerprint} (not verified — set hostKeyFingerprint to pin)`,
+            logger.error(
+              `[docker-ssh] Refusing unpinned host key for ${this.hostname}: SHA256:${fingerprint}. Register host_key_fingerprint before SSH.`,
             );
-            return true;
+            return false;
           }
           if (
             normalizeSshFingerprint(fingerprint) !==
@@ -627,9 +630,9 @@ export class DockerSSHClient {
   }
 }
 
-function normalizeSshFingerprint(fingerprint: string): string {
+export function normalizeSshFingerprint(fingerprint: string): string {
   return fingerprint
     .trim()
-    .replace(/^SHA256:/, "")
-    .replace(/=+$/, "");
+    .replace(/^SHA256:/i, "")
+    .replace(/=+$/g, "");
 }


### PR DESCRIPTION
## Summary
- fail closed on Docker SSH when a node has no pinned host-key fingerprint
- require/admin bootstrap node registrations to provide hostKeyFingerprint, with autoscaler placeholder first-pin support
- move non-Headscale hosted-agent containers onto an internal default-deny Docker bridge and add operator pod egress-deny NetworkPolicy
- add regression tests and evidence under `.github/issue-evidence/12883-per-node-ssh-egress.md`

Fixes #12883

## Verification
- `bun test packages/cloud/shared/src/lib/services/__tests__/agent-container-security.test.ts packages/cloud/shared/src/lib/services/containers/node-bootstrap.test.ts packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts packages/cloud/services/operator/capabilities/__tests__/generators-network-policy.test.ts` (26 pass)
- `bun test --cwd packages/cloud/services/operator` (7 pass)
- `bunx biome check <11 touched files>`
- `bun run --cwd packages/cloud/shared lint`
- `bun run --cwd packages/cloud/api lint`
- `bun run --cwd packages/cloud/services/operator lint`
- `bun run --cwd packages/cloud/services/operator typecheck`
- `git diff --check`

## Notes
- `bun run --cwd packages/cloud/shared typecheck` and `bun run --cwd packages/cloud/api typecheck` are blocked by existing transitive baseline errors in app-core/shared; no touched-file errors reported.
- `bun run verify` was attempted; pre-turbo audits passed, then it failed in unrelated `@elizaos/plugin-calendar#typecheck` baseline missing-module/implicit-any errors. Write-mode lint side effects were restored before staging.
- Real Docker execution could not be captured because the local Docker daemon is unavailable at `unix:///Users/shawwalters/.docker/run/docker.sock`; run-spec assertions are captured in tests and evidence.