### PR TITLE
fix(#12789): fail-closed on malformed agent-server reply in gateway-webhook

### DIFF
--- a/.github/issue-evidence/12789-gateway-webhook-agent-response.md
+++ b/.github/issue-evidence/12789-gateway-webhook-agent-response.md
@@ -1,0 +1,138 @@
+# Evidence: #12789 gateway-webhook malformed agent response
+
+PR: #13122
+Branch: `fix/12789-cloud-services-fallback-slop`
+
+## What Changed
+
+- `forwardToServer` now parses agent-server replies through
+  `parseAgentResponse(raw, agentId)`.
+- Non-JSON responses and JSON bodies missing a string `response` field throw
+  instead of returning `undefined`.
+- Intentional empty-string replies remain valid.
+- The existing async webhook `processMessage` failure path now receives the
+  malformed upstream response as an error, making the failure observable in
+  `[gateway-webhook]` logs instead of being dropped as success-shaped silence.
+
+## Verification
+
+### Package Tests
+
+Command:
+
+```bash
+bun run --cwd packages/cloud/services/gateway-webhook test
+```
+
+Result:
+
+```text
+27 pass
+0 fail
+51 expect() calls
+Ran 27 tests across 6 files.
+```
+
+Manual review:
+
+- `parse-agent-response.test.ts` covers well-formed replies, intentional empty
+  replies, non-JSON bodies, missing fields, `null`, number values, top-level
+  JSON `null`, and agent-id-in-error observability.
+- Existing `webhook-handler.e2e.test.ts` still exercises real webhook handler
+  routing through unresolved and linked Twilio identity flows.
+- Test logs include structured gateway output such as:
+
+```json
+{"level":"info","message":"Identity not linked; routing message to onboarding chat","project":"eliza-app","platform":"twilio","senderId":"+15551234567"}
+```
+
+### Typecheck
+
+Command:
+
+```bash
+bun run --cwd packages/cloud/services/gateway-webhook typecheck
+```
+
+Result:
+
+```text
+tsgo --noEmit
+```
+
+Exit code: 0.
+
+### Touched-File Biome
+
+Command:
+
+```bash
+bunx biome check packages/cloud/services/gateway-webhook/src/server-router.ts packages/cloud/services/gateway-webhook/__tests__/parse-agent-response.test.ts
+```
+
+Result:
+
+```text
+Checked 2 files in 12ms. No fixes applied.
+```
+
+### Service Build
+
+Command:
+
+```bash
+bun run --cwd packages/cloud/services/gateway-webhook build
+```
+
+Result:
+
+```text
+Bundled 185 modules in 31ms
+index.js  1.0 MB  (entry point)
+```
+
+Exit code: 0.
+
+### Root Verify
+
+Command:
+
+```bash
+bun run verify
+```
+
+Result:
+
+```text
+[assert-agents-claude-identical] PASS: 301 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.
+[type-safety-ratchet] scanned 10270 tracked production source files
+[error-policy-ratchet] no new fallback-slop in touched files
+Failed: @elizaos/electrobun#lint
+```
+
+Specific blocker confirmed with:
+
+```bash
+bun run --cwd packages/app-core/platforms/electrobun lint
+```
+
+It fails on pre-existing formatting in
+`packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts`.
+Root `verify` also caused one unrelated write-mode lint side effect in
+`plugins/plugin-computeruse/src/__tests__/computer-interface.test.ts`; it was
+restored before committing evidence.
+
+## Evidence Matrix
+
+- Real request/response trace: covered by the package webhook e2e tests for the
+  service path and parser tests for malformed upstream response bodies. Full
+  `cloud:mock` was not run because this PR changes a pure parser/forwarder
+  failure branch, not deployment wiring.
+- Backend logs: structured gateway logs are emitted during the package e2e
+  tests; malformed parser cases throw with `agentId` so the existing
+  `Forward to server failed` catch logs the operational failure with context.
+- Frontend logs/screenshots/video: N/A. No UI/client surface changed.
+- Real LLM trajectory: N/A. No prompt/model/action/evaluator behavior changed.
+- Audio/voice walkthrough: N/A. No TTS/STT/audio path changed.
+- DB/billing/migration artifacts: N/A. No database, billing, migration, task,
+  wallet, chain, or file artifacts are produced by this change.

--- a/packages/cloud/services/gateway-webhook/__tests__/parse-agent-response.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/parse-agent-response.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { parseAgentResponse } from "../src/server-router";
+
+const AGENT_ID = "agent-123";
+
+describe("parseAgentResponse", () => {
+  test("returns the response string from a well-formed body", () => {
+    const raw = JSON.stringify({ response: "hello there" });
+    expect(parseAgentResponse(raw, AGENT_ID)).toBe("hello there");
+  });
+
+  test("preserves an intentional empty-string reply", () => {
+    // An explicit empty string is a valid (if unusual) agent reply and must
+    // NOT be treated as a failure — only a missing/non-string field is slop.
+    const raw = JSON.stringify({ response: "" });
+    expect(parseAgentResponse(raw, AGENT_ID)).toBe("");
+  });
+
+  test("throws on non-JSON body instead of returning success-shaped output", () => {
+    expect(() =>
+      parseAgentResponse("<html>502 Bad Gateway</html>", AGENT_ID),
+    ).toThrow(/non-JSON response/);
+  });
+
+  test("throws when the response field is missing", () => {
+    const raw = JSON.stringify({ ok: true, data: { foo: "bar" } });
+    expect(() => parseAgentResponse(raw, AGENT_ID)).toThrow(
+      /missing string "response" field/,
+    );
+  });
+
+  test("throws when response is null", () => {
+    const raw = JSON.stringify({ response: null });
+    expect(() => parseAgentResponse(raw, AGENT_ID)).toThrow(
+      /missing string "response" field \(got object\)/,
+    );
+  });
+
+  test("throws when response is a non-string (number)", () => {
+    const raw = JSON.stringify({ response: 42 });
+    expect(() => parseAgentResponse(raw, AGENT_ID)).toThrow(
+      /missing string "response" field \(got number\)/,
+    );
+  });
+
+  test("throws when the top-level body is a JSON null", () => {
+    expect(() => parseAgentResponse("null", AGENT_ID)).toThrow(
+      /missing string "response" field/,
+    );
+  });
+
+  test("includes the agentId in the error for observability", () => {
+    expect(() => parseAgentResponse("{}", AGENT_ID)).toThrow(AGENT_ID);
+  });
+});

--- a/packages/cloud/services/gateway-webhook/src/server-router.ts
+++ b/packages/cloud/services/gateway-webhook/src/server-router.ts
@@ -284,8 +284,38 @@ export async function forwardToServer(
     `/agents/${agentId}/message`,
     JSON.stringify(body),
   );
-  const data = JSON.parse(raw) as { response: string };
-  return data.response;
+  return parseAgentResponse(raw, agentId);
+}
+
+/**
+ * Parses and validates an agent-server message response.
+ *
+ * The agent-server contract is a JSON body with a string `response` field.
+ * A 200 with a malformed body (non-JSON, missing `response`, or a non-string
+ * `response`) is an upstream failure, not an empty reply: returning `undefined`
+ * here would surface as success-shaped silence (adapters drop empty/undefined
+ * text without erroring), hiding the fault from logs and the caller. Fail-closed
+ * by throwing so `processMessage`'s catch logs a structured forward failure.
+ */
+export function parseAgentResponse(raw: string, agentId: string): string {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Agent-server returned non-JSON response for agent ${agentId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  const response = (data as { response?: unknown } | null)?.response;
+  if (typeof response !== "string") {
+    throw new Error(
+      `Agent-server response for agent ${agentId} missing string "response" field (got ${typeof response})`,
+    );
+  }
+  return response;
 }
 
 /**


### PR DESCRIPTION
## What

Fallback-slop fix in the `packages/cloud/services` sweep (#12789 / split from #12268): the webhook gateway's `forwardToServer` masked a malformed agent-server reply as success-shaped silence.

## The slop

`server-router.ts` did:

```ts
const data = JSON.parse(raw) as { response: string };
return data.response;
```

The `as` cast is a lie — nothing validates the body. If the agent-server returns **200 with a body that isn't JSON, or is JSON missing `response`, or has a non-string `response`**, this returns `undefined`. That `undefined` then flows into the platform adapters, where `splitMessage(undefined)` hits `if (!text) return []` and **no message is sent, no error is logged**. The failure is indistinguishable from a real (intentional) empty reply and never reaches `processMessage`'s error path. Classic fallback slop: an upstream failure rendered as healthy-empty output.

## The fix

Extract and harden into `parseAgentResponse(raw, agentId)`:
- `JSON.parse` failure -> throw (`non-JSON response ...`).
- missing / non-string `response` -> throw (`missing string "response" field (got <type>)`).
- an **intentional empty string** reply is preserved (only missing/typed-wrong is treated as slop).

Now a malformed reply throws, so `processMessage`'s existing `catch` logs the structured `Forward to server failed` error with `agentId`/platform context instead of silently dropping the turn. Fail-closed, distinguishing upstream failure from a designed empty state.

## Tests / evidence

- New `__tests__/parse-agent-response.test.ts` — 8 cases: well-formed reply, preserved empty-string reply, and 6 fail-closed cases (non-JSON, missing field, `null`, number, JSON `null`, agentId-in-error). All green.
- Full package suite: **27 pass / 0 fail** (`bun test`).
- Typecheck: `tsgo --noEmit` clean (EXIT 0).
- Lint/format: biome clean on changed files.
- codex review: functional change assessed sound, tests pass (only a P3 header-comment style note, intentionally skipped to match this package's existing header-less test convention and the #12234 header-churn-removal direction).

Evidence rows N/A: `N/A - hosted-agent gateway service hardening, no UI/model/audio path`.

## Scope discipline

Single, tightly-scoped finding in `packages/cloud/services/gateway-webhook`. Did not touch `vite.config.*`, `index.html`, `client-base.ts`, `bun.lock`, binaries, or `dist/`.

-- [sol-orch]
