### PR TITLE
fix(#12744): surface Linear provider failures via reportError (J4 degrade)

### DIFF
--- a/.github/issue-evidence/12744-linear-provider-failure-observability.md
+++ b/.github/issue-evidence/12744-linear-provider-failure-observability.md
@@ -1,0 +1,39 @@
+# Issue #12744 evidence: Linear provider failure observability slice
+
+## Summary
+
+- Scoped slice: Linear context providers only (`LINEAR_ISSUES`, `LINEAR_TEAMS`, `LINEAR_PROJECTS`, `LINEAR_ACTIVITY`).
+- API/auth/network failures inside provider `get()` now call `runtime.reportError("<provider>.provider", error)`.
+- The prompt context still renders the designed J4 user-facing degrade text (`Error retrieving ...`) and does not fabricate an empty success state.
+- Designed absence (`No ... found`) and missing-service states remain non-error states and do not call `reportError`.
+
+## Verification
+
+- `bun run --cwd plugins/plugin-linear test`
+  - Passed: 6 files, 34 tests, 0 failed.
+- `bun run --cwd plugins/plugin-linear typecheck`
+  - Passed.
+- `bunx biome check plugins/plugin-linear/src/providers/activity.ts plugins/plugin-linear/src/providers/issues.ts plugins/plugin-linear/src/providers/projects.ts plugins/plugin-linear/src/providers/teams.ts plugins/plugin-linear/src/providers/providers.test.ts`
+  - Passed.
+
+## Failure-path proof
+
+New provider tests drive each provider with a throwing service method:
+
+- `LINEAR_ISSUES.provider` reports the original Linear error and returns `Error retrieving Linear issues`.
+- `LINEAR_TEAMS.provider` reports the original Linear error and returns `Error retrieving Linear teams`.
+- `LINEAR_PROJECTS.provider` reports the original Linear error and returns `Error retrieving Linear projects`.
+- `LINEAR_ACTIVITY.provider` reports the original Linear error and returns `Error retrieving Linear activity`.
+
+Each test also asserts the result is not the empty/designed-absence text. Separate tests prove empty and missing-service paths do not call `reportError`.
+
+## Live Linear lane
+
+N/A in this checkout: no `LINEAR_API_KEY` is configured, so a real Linear/sandbox API round-trip cannot be run here.
+
+## UI / model / audio evidence
+
+- UI evidence: N/A - provider prompt-context error observability, no app UI path changed.
+- Model trajectory: N/A - no model-backed action or turn execution changed in this slice.
+- Audio evidence: N/A - no audio path.
+

--- a/plugins/plugin-linear/src/providers/activity.ts
+++ b/plugins/plugin-linear/src/providers/activity.ts
@@ -74,7 +74,13 @@ export const linearActivityProvider: Provider = {
           })) as Array<Record<string, string | boolean | undefined>>,
         },
       };
-    } catch (_error) {
+    } catch (error) {
+      // error-policy:J4 explicit user-facing degrade — a failure reading the
+      // in-memory activity log renders the distinguishable "error" prompt state
+      // (never a fabricated "no recent activity"), and reportError makes the
+      // underlying failure observable in RECENT_ERRORS + owner-escalation instead
+      // of being silently swallowed.
+      runtime.reportError?.("LINEAR_ACTIVITY.provider", error);
       return {
         text: "Error retrieving Linear activity",
       };

--- a/plugins/plugin-linear/src/providers/issues.ts
+++ b/plugins/plugin-linear/src/providers/issues.ts
@@ -53,7 +53,13 @@ export const linearIssuesProvider: Provider = {
           })),
         },
       };
-    } catch (_error) {
+    } catch (error) {
+      // error-policy:J4 explicit user-facing degrade — a Linear API/auth/network
+      // failure renders the distinguishable "error" prompt state (never a
+      // fabricated "no issues found"), and reportError makes the underlying
+      // failure observable in RECENT_ERRORS + owner-escalation instead of being
+      // silently swallowed.
+      runtime.reportError?.("LINEAR_ISSUES.provider", error);
       return {
         text: "Error retrieving Linear issues",
       };

--- a/plugins/plugin-linear/src/providers/projects.ts
+++ b/plugins/plugin-linear/src/providers/projects.ts
@@ -56,7 +56,13 @@ export const linearProjectsProvider: Provider = {
           })),
         },
       };
-    } catch (_error) {
+    } catch (error) {
+      // error-policy:J4 explicit user-facing degrade — a Linear API/auth/network
+      // failure renders the distinguishable "error" prompt state (never a
+      // fabricated "no projects found"), and reportError makes the underlying
+      // failure observable in RECENT_ERRORS + owner-escalation instead of being
+      // silently swallowed.
+      runtime.reportError?.("LINEAR_PROJECTS.provider", error);
       return {
         text: "Error retrieving Linear projects",
       };

--- a/plugins/plugin-linear/src/providers/providers.test.ts
+++ b/plugins/plugin-linear/src/providers/providers.test.ts
@@ -20,12 +20,10 @@ const state = {} as State;
 
 function runtimeWith(
   service: Record<string, unknown> | undefined,
-  reportError = vi.fn(),
+  reportError = vi.fn()
 ): IAgentRuntime {
   return {
-    getService: vi.fn((name: string) =>
-      name === "linear" ? service : undefined,
-    ),
+    getService: vi.fn((name: string) => (name === "linear" ? service : undefined)),
     reportError,
   } as unknown as IAgentRuntime;
 }

--- a/plugins/plugin-linear/src/providers/providers.test.ts
+++ b/plugins/plugin-linear/src/providers/providers.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Failure-path tests for the four Linear context providers.
+ *
+ * Guards #12744 (#12275-G fallback-slop sweep): a Linear API/auth/network
+ * failure inside a provider `get()` must (a) render the designed J4
+ * user-facing "Error retrieving …" degrade state — never a fabricated
+ * "no X found" success shape — and (b) surface the underlying error through
+ * `runtime.reportError` so the failure is observable in RECENT_ERRORS /
+ * owner-escalation instead of being silently swallowed.
+ */
+import type { IAgentRuntime, Memory, State } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { linearActivityProvider } from "./activity";
+import { linearIssuesProvider } from "./issues";
+import { linearProjectsProvider } from "./projects";
+import { linearTeamsProvider } from "./teams";
+
+const message = { id: "m", content: { text: "" } } as unknown as Memory;
+const state = {} as State;
+
+function runtimeWith(
+  service: Record<string, unknown> | undefined,
+  reportError = vi.fn(),
+): IAgentRuntime {
+  return {
+    getService: vi.fn((name: string) =>
+      name === "linear" ? service : undefined,
+    ),
+    reportError,
+  } as unknown as IAgentRuntime;
+}
+
+const cases = [
+  {
+    label: "LINEAR_ISSUES",
+    provider: linearIssuesProvider,
+    method: "searchIssues",
+    scope: "LINEAR_ISSUES.provider",
+    degradeText: "Error retrieving Linear issues",
+    emptyText: "No recent Linear issues found",
+    successService: () => ({ searchIssues: vi.fn(async () => []) }),
+  },
+  {
+    label: "LINEAR_TEAMS",
+    provider: linearTeamsProvider,
+    method: "getTeams",
+    scope: "LINEAR_TEAMS.provider",
+    degradeText: "Error retrieving Linear teams",
+    emptyText: "No Linear teams found",
+    successService: () => ({ getTeams: vi.fn(async () => []) }),
+  },
+  {
+    label: "LINEAR_PROJECTS",
+    provider: linearProjectsProvider,
+    method: "getProjects",
+    scope: "LINEAR_PROJECTS.provider",
+    degradeText: "Error retrieving Linear projects",
+    emptyText: "No Linear projects found",
+    successService: () => ({ getProjects: vi.fn(async () => []) }),
+  },
+  {
+    label: "LINEAR_ACTIVITY",
+    provider: linearActivityProvider,
+    method: "getActivityLog",
+    scope: "LINEAR_ACTIVITY.provider",
+    degradeText: "Error retrieving Linear activity",
+    emptyText: "No recent Linear activity",
+    successService: () => ({ getActivityLog: vi.fn(() => []) }),
+  },
+] as const;
+
+describe("Linear providers — failure-path observability", () => {
+  for (const c of cases) {
+    describe(c.label, () => {
+      it("reports the error and renders the J4 degrade state on service failure", async () => {
+        const boom = new Error("Linear API 503");
+        const reportError = vi.fn();
+        const service = {
+          [c.method]: vi.fn(() => {
+            throw boom;
+          }),
+        };
+        const runtime = runtimeWith(service, reportError);
+
+        const result = await c.provider.get(runtime, message, state);
+
+        // J4: distinguishable error state, NOT a fabricated "no X found".
+        expect(result.text).toBe(c.degradeText);
+        expect(result.text).not.toBe(c.emptyText);
+
+        // Observability: the real error is surfaced with the provider scope.
+        expect(reportError).toHaveBeenCalledTimes(1);
+        expect(reportError).toHaveBeenCalledWith(c.scope, boom);
+      });
+
+      it("does not call reportError on the empty (designed-absence) path", async () => {
+        const reportError = vi.fn();
+        const runtime = runtimeWith(c.successService(), reportError);
+
+        const result = await c.provider.get(runtime, message, state);
+
+        expect(result.text).toBe(c.emptyText);
+        expect(reportError).not.toHaveBeenCalled();
+      });
+
+      it("returns the service-unavailable state without reporting when the service is missing", async () => {
+        const reportError = vi.fn();
+        const runtime = runtimeWith(undefined, reportError);
+
+        const result = await c.provider.get(runtime, message, state);
+
+        expect(result.text).toBe("Linear service is not available");
+        expect(reportError).not.toHaveBeenCalled();
+      });
+    });
+  }
+});

--- a/plugins/plugin-linear/src/providers/teams.ts
+++ b/plugins/plugin-linear/src/providers/teams.ts
@@ -55,7 +55,13 @@ export const linearTeamsProvider: Provider = {
           truncated: teams.length > listedTeams.length,
         },
       };
-    } catch (_error) {
+    } catch (error) {
+      // error-policy:J4 explicit user-facing degrade — a Linear API/auth/network
+      // failure renders the distinguishable "error" prompt state (never a
+      // fabricated "no teams found"), and reportError makes the underlying
+      // failure observable in RECENT_ERRORS + owner-escalation instead of being
+      // silently swallowed.
+      runtime.reportError?.("LINEAR_TEAMS.provider", error);
       return {
         text: "Error retrieving Linear teams",
       };


### PR DESCRIPTION
Closes part of #12744 (#12275-G, non-route work/productivity fallback-slop sweep; parent #12182 / #12275).

## Problem
The four Linear context providers — `LINEAR_ISSUES`, `LINEAR_TEAMS`, `LINEAR_PROJECTS`, `LINEAR_ACTIVITY` (`packages`→`plugins/plugin-linear/src/providers/*.ts`) — each caught with `catch (_error)`, **discarded the error entirely**, and returned an `"Error retrieving …"` degrade string.

The user-facing degrade text was already correct (it's a designed **J4** state, and it is NOT a fabricated `"no X found"` success shape). The slop was the **discarded `_error`**: a genuine Linear API / auth / network failure was silently swallowed — invisible to `RECENT_ERRORS`, the owner-escalation ring, structured logs, and the `ERROR_REPORTED` event stream. An expired API key looked identical to a healthy "nothing to show."

## Fix
Keep the J4 degrade (never fabricate `"no X found"`), but route the real error through `runtime.reportError(scope, error)` — the `#12263` diagnostic boundary, which never throws — so the failure becomes observable. Each kept handler now carries a grep-able `// error-policy:J4 …` annotation with its reason.

This mirrors the sanctioned pattern already used in core (`packages/core/src/runtime/facts-and-relationships.ts`, `packages/core/src/media/image-description-cache.ts`): degrade for the caller, `reportError` for observability.

No behavior change on the happy path or the designed-absence (empty) path — only the previously-silent failure path now reports.

## Tests
New `plugins/plugin-linear/src/providers/providers.test.ts` — **12 tests** (3 × 4 providers):
- **failure path** — service throws → `reportError` called exactly once with `(scope, error)`, and result renders the J4 degrade text (explicitly asserted **NOT** the empty `"no X found"` shape).
- **designed-absence path** — empty result → returns the empty state and does **not** report.
- **missing-service path** — service unavailable → returns `"Linear service is not available"` and does **not** report.

## Evidence
- Targeted suite: `providers.test.ts` — 12/12 green.
- Full plugin suite: **34/34 green** (`bun run --cwd plugins/plugin-linear test`).
- `tsc --noEmit` clean on the plugin.
- `bun run audit:error-policy-ratchet`: clean on touched files (`no new fallback-slop`).
- Codex (gpt-5.5) reviewed the commit + independently re-ran typecheck/tests: "did not identify a discrete introduced bug."

_UI/model/audio evidence: N/A — internal context-provider observability hardening, no UI/model/audio path._

— [sol-orch]
