### PR TITLE
fix(#12889): hold tail-off pauses

### DIFF
--- a/.github/issue-evidence/12889-tail-off-pause/README.md
+++ b/.github/issue-evidence/12889-tail-off-pause/README.md
@@ -1,0 +1,31 @@
+# Issue #12889 evidence - tail-off semantic pause handling
+
+## Summary
+
+- Added canonical EOT tail-off scoring for spoken fillers/hedges (`um`, `uh`, `hmm`, `maybe`) and dangling modal/auxiliary endings (`could`, `would`, `is`, etc.).
+- Added state-machine coverage proving filler + long pause and mid-clause pause >=700 ms stay in `LISTENING`, do not commit, and extend EOT hangover.
+- Added workbench scenarios:
+  - `tail-off-filler-pause`
+  - `tail-off-midclause-long-pause`
+
+## Verification
+
+| Check | Result |
+| --- | --- |
+| `bun test packages/shared/src/voice-eot.test.ts plugins/plugin-local-inference/src/services/voice/__tests__/eot-classifier.test.ts plugins/plugin-local-inference/src/services/voice/voice-hardening.fuzz.test.ts plugins/plugin-local-inference/src/services/voice/workbench-headless-runner.test.ts` | PASS - 72 tests pass after `bun run --cwd packages/shared build:i18n` restored the generated i18n module required by plugin imports. |
+| `bun run --cwd plugins/plugin-local-inference voice:workbench --mock --out ../../.github/issue-evidence/12889-tail-off-pause/workbench-mock` | PASS - 26 ran, 0 skipped. Reports: `workbench-mock/report.json`, `workbench-mock/report.md`. |
+| `bun run --cwd plugins/plugin-local-inference voice:workbench --logic --out ../../.github/issue-evidence/12889-tail-off-pause/workbench-logic` | PASS - 26 ran, 0 skipped. Reports: `workbench-logic/report.json`, `workbench-logic/report.md`. |
+| `bunx biome check packages/shared/src/voice-eot.ts packages/shared/src/voice-eot.test.ts plugins/plugin-local-inference/src/services/voice/__tests__/eot-classifier.test.ts plugins/plugin-local-inference/src/services/voice/voice-hardening.fuzz.test.ts plugins/plugin-local-inference/src/services/voice/workbench-scenarios.ts` | PASS. |
+| `bun run --cwd packages/shared typecheck` | PASS. |
+| `bun run --cwd plugins/plugin-local-inference typecheck` | PASS. |
+| `git diff --check` | PASS. |
+| `git fetch origin && git rebase origin/develop && bun install` | PASS - branch was already up to date; install completed and synced artifacts. Artifact-bundle side effects were restored/removed before push. |
+
+## Blocked / N/A evidence
+
+| Evidence | Status |
+| --- | --- |
+| Real-audio workbench capture / narrated walkthrough | N/A in this environment: `bun run --cwd plugins/plugin-local-inference voice:workbench --real --out ../../.github/issue-evidence/12889-tail-off-pause/workbench-real` fails fast with missing local ASR bundle: `/Users/shawwalters/.eliza/local-inference/models/eliza-1-2b.bundle`. No acoustic model artifacts were available to produce honest real-audio output. |
+| Package-wide `packages/shared lint:check` | Blocked by existing unrelated formatting issue in `packages/shared/src/voice/aec/echo-alignment.ts`. Touched-file Biome passed. |
+| Package-wide `plugins/plugin-local-inference lint:check` | Blocked by existing unrelated formatting issue in `plugins/plugin-local-inference/src/services/voice/__fixtures__/voice-workbench-logic-baseline.json`. Touched-file Biome passed. |
+| Root `bun run verify` | Blocked by existing unrelated `@elizaos/tui#lint` diagnostics (`node:` import protocol, non-null assertions, and control-character regex checks). Write-mode side effects in unrelated core files were restored after the attempt. |

--- a/.github/issue-evidence/12889-tail-off-pause/workbench-logic/report.json
+++ b/.github/issue-evidence/12889-tail-off-pause/workbench-logic/report.json
@@ -1,0 +1,384 @@
+{
+  "schemaVersion": 1,
+  "overall": "pass",
+  "scenariosTotal": 26,
+  "scenariosRan": 26,
+  "scenariosSkipped": 0,
+  "scenarios": [
+    {
+      "scenarioId": "multi-voice-greeting",
+      "classes": [
+        "multi-voice",
+        "diarization"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "respond-vs-bystander",
+      "classes": [
+        "respond-no-respond",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 9,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "pauses-midutterance",
+      "classes": [
+        "pauses",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "entity-from-speech",
+      "classes": [
+        "entity-extraction",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "transcription-mode-dictation",
+      "classes": [
+        "transcription-mode",
+        "long-form-monologue"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 5,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "multi-agent-room-address",
+      "classes": [
+        "multi-agent-room",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "noisy-room-commands",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "music-background-commands",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "far-field-reverb",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "background-talkers",
+      "classes": [
+        "robustness",
+        "overlapping-speech",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "echo-self-trigger",
+      "classes": [
+        "echo-rejection",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "multi-speaker-name-capture",
+      "classes": [
+        "diarization",
+        "entity-extraction",
+        "multi-speaker",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 13,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-names-clean",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition",
+        "diarization"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 11,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-names-noisy",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition",
+        "robustness"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 13,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-name-garbled-transcript",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 11,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "echo-mistranscribed",
+      "classes": [
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "owner-enrollment-inference",
+      "classes": [
+        "owner-security",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 15,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "owner-vs-intruder",
+      "classes": [
+        "owner-security",
+        "respond-no-respond",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "endpoint-latency",
+      "classes": [
+        "endpoint-latency",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "tail-off-thinking",
+      "classes": [
+        "tail-off",
+        "eot",
+        "pauses"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "tail-off-filler-pause",
+      "classes": [
+        "tail-off",
+        "eot",
+        "pauses"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "tail-off-midclause-long-pause",
+      "classes": [
+        "tail-off",
+        "eot",
+        "pauses"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "streaming-partials-monotonic",
+      "classes": [
+        "streaming-partials",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "speaker-gated-barge-in",
+      "classes": [
+        "speaker-gated-barge-in",
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 14,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "desktop-aec-echo",
+      "classes": [
+        "desktop-aec",
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "long-turn-diarization",
+      "classes": [
+        "long-turn-diarization",
+        "diarization",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 20,
+      "failedCaseKinds": []
+    }
+  ],
+  "metrics": {
+    "wer": {
+      "count": 69,
+      "mean": 0,
+      "worst": 0
+    },
+    "eotFalseTriggerRate": {
+      "count": 26,
+      "mean": 0,
+      "worst": 0
+    },
+    "eotLatencyP50Ms": null,
+    "eotLatencyP95Ms": null,
+    "der": {
+      "count": 26,
+      "mean": 0.0092,
+      "worst": 0.2394
+    },
+    "respondAccuracy": {
+      "count": 26,
+      "mean": 1,
+      "worst": 1
+    },
+    "entityF1": {
+      "count": 5,
+      "mean": 1,
+      "worst": 1
+    },
+    "voiceEntityMatchRate": {
+      "count": 26,
+      "mean": 1,
+      "worst": 1
+    },
+    "firstAudioMs": {
+      "count": 57,
+      "mean": 250,
+      "worst": 250
+    },
+    "echoRejectionRate": {
+      "count": 4,
+      "mean": 1,
+      "worst": 1
+    },
+    "ownerAccuracy": {
+      "count": 2,
+      "mean": 1,
+      "worst": 1
+    },
+    "impostorAcceptRate": {
+      "count": 2,
+      "mean": 0,
+      "worst": 0
+    },
+    "bargeInGatingAccuracy": {
+      "count": 1,
+      "mean": 1,
+      "worst": 1
+    },
+    "bargeInCancelMs": {
+      "count": 1,
+      "mean": 120,
+      "worst": 120
+    },
+    "erleDb": {
+      "count": 0,
+      "mean": null,
+      "worst": null
+    },
+    "partialRetractions": {
+      "count": 0,
+      "mean": null,
+      "worst": null
+    }
+  }
+}

--- a/.github/issue-evidence/12889-tail-off-pause/workbench-logic/report.md
+++ b/.github/issue-evidence/12889-tail-off-pause/workbench-logic/report.md
@@ -1,0 +1,55 @@
+# Voice Workbench report
+
+**Overall:** PASS — 26 ran, 0 skipped of 26
+
+## Metrics
+
+| Metric | Mean | Worst | n |
+| --- | --- | --- | --- |
+| WER | 0 | 0 | 69 |
+| EOT false-trigger rate | 0 | 0 | 26 |
+| EOT latency p50 (ms) | — | | |
+| EOT latency p95 (ms) | — | | |
+| Diarization DER | 0.0092 | 0.2394 | 26 |
+| Respond accuracy | 1 | 1 | 26 |
+| Entity F1 | 1 | 1 | 5 |
+| Voice→entity match | 1 | 1 | 26 |
+| First-audio (ms) | 250 | 250 | 57 |
+| Echo rejection rate | 1 | 1 | 4 |
+| Owner accuracy | 1 | 1 | 2 |
+| Impostor-accept rate | 0 | 0 | 2 |
+| Barge-in gating accuracy | 1 | 1 | 1 |
+| Barge-in cancel (ms) | 120 | 120 | 1 |
+| ERLE (dB) | — | — | 0 |
+| Partial retractions | — | — | 0 |
+
+## Scenarios
+
+| Scenario | Classes | Verdict | Cases | Failed |
+| --- | --- | --- | --- | --- |
+| multi-voice-greeting | multi-voice, diarization | pass | 8 | — |
+| respond-vs-bystander | respond-no-respond, multi-speaker | pass | 9 | — |
+| pauses-midutterance | pauses, eot | pass | 7 | — |
+| entity-from-speech | entity-extraction, voice-recognition | pass | 7 | — |
+| transcription-mode-dictation | transcription-mode, long-form-monologue | pass | 5 | — |
+| multi-agent-room-address | multi-agent-room, respond-no-respond | pass | 8 | — |
+| noisy-room-commands | robustness, respond-no-respond | pass | 8 | — |
+| music-background-commands | robustness, respond-no-respond | pass | 8 | — |
+| far-field-reverb | robustness, respond-no-respond | pass | 6 | — |
+| background-talkers | robustness, overlapping-speech, multi-speaker | pass | 6 | — |
+| echo-self-trigger | echo-rejection, respond-no-respond | pass | 10 | — |
+| multi-speaker-name-capture | diarization, entity-extraction, multi-speaker, voice-recognition | pass | 13 | — |
+| confusable-names-clean | entity-extraction, name-disambiguation, multi-speaker, voice-recognition, diarization | pass | 11 | — |
+| confusable-names-noisy | entity-extraction, name-disambiguation, multi-speaker, voice-recognition, robustness | pass | 13 | — |
+| confusable-name-garbled-transcript | entity-extraction, name-disambiguation, multi-speaker, voice-recognition | pass | 11 | — |
+| echo-mistranscribed | echo-rejection | pass | 8 | — |
+| owner-enrollment-inference | owner-security, voice-recognition | pass | 15 | — |
+| owner-vs-intruder | owner-security, respond-no-respond, multi-speaker | pass | 10 | — |
+| endpoint-latency | endpoint-latency, eot | pass | 8 | — |
+| tail-off-thinking | tail-off, eot, pauses | pass | 7 | — |
+| tail-off-filler-pause | tail-off, eot, pauses | pass | 7 | — |
+| tail-off-midclause-long-pause | tail-off, eot, pauses | pass | 7 | — |
+| streaming-partials-monotonic | streaming-partials, eot | pass | 6 | — |
+| speaker-gated-barge-in | speaker-gated-barge-in, echo-rejection | pass | 14 | — |
+| desktop-aec-echo | desktop-aec, echo-rejection | pass | 10 | — |
+| long-turn-diarization | long-turn-diarization, diarization, multi-speaker | pass | 20 | — |

--- a/.github/issue-evidence/12889-tail-off-pause/workbench-mock/report.json
+++ b/.github/issue-evidence/12889-tail-off-pause/workbench-mock/report.json
@@ -1,0 +1,384 @@
+{
+  "schemaVersion": 1,
+  "overall": "pass",
+  "scenariosTotal": 26,
+  "scenariosRan": 26,
+  "scenariosSkipped": 0,
+  "scenarios": [
+    {
+      "scenarioId": "multi-voice-greeting",
+      "classes": [
+        "multi-voice",
+        "diarization"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "respond-vs-bystander",
+      "classes": [
+        "respond-no-respond",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 9,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "pauses-midutterance",
+      "classes": [
+        "pauses",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "entity-from-speech",
+      "classes": [
+        "entity-extraction",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "transcription-mode-dictation",
+      "classes": [
+        "transcription-mode",
+        "long-form-monologue"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 5,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "multi-agent-room-address",
+      "classes": [
+        "multi-agent-room",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "noisy-room-commands",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "music-background-commands",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "far-field-reverb",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "background-talkers",
+      "classes": [
+        "robustness",
+        "overlapping-speech",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "echo-self-trigger",
+      "classes": [
+        "echo-rejection",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "multi-speaker-name-capture",
+      "classes": [
+        "diarization",
+        "entity-extraction",
+        "multi-speaker",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 13,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-names-clean",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition",
+        "diarization"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 11,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-names-noisy",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition",
+        "robustness"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 13,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-name-garbled-transcript",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 11,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "echo-mistranscribed",
+      "classes": [
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "owner-enrollment-inference",
+      "classes": [
+        "owner-security",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 15,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "owner-vs-intruder",
+      "classes": [
+        "owner-security",
+        "respond-no-respond",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "endpoint-latency",
+      "classes": [
+        "endpoint-latency",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "tail-off-thinking",
+      "classes": [
+        "tail-off",
+        "eot",
+        "pauses"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "tail-off-filler-pause",
+      "classes": [
+        "tail-off",
+        "eot",
+        "pauses"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "tail-off-midclause-long-pause",
+      "classes": [
+        "tail-off",
+        "eot",
+        "pauses"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "streaming-partials-monotonic",
+      "classes": [
+        "streaming-partials",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "speaker-gated-barge-in",
+      "classes": [
+        "speaker-gated-barge-in",
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 14,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "desktop-aec-echo",
+      "classes": [
+        "desktop-aec",
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 11,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "long-turn-diarization",
+      "classes": [
+        "long-turn-diarization",
+        "diarization",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 20,
+      "failedCaseKinds": []
+    }
+  ],
+  "metrics": {
+    "wer": {
+      "count": 69,
+      "mean": 0,
+      "worst": 0
+    },
+    "eotFalseTriggerRate": {
+      "count": 26,
+      "mean": 0,
+      "worst": 0
+    },
+    "eotLatencyP50Ms": 80,
+    "eotLatencyP95Ms": 80,
+    "der": {
+      "count": 26,
+      "mean": 0,
+      "worst": 0
+    },
+    "respondAccuracy": {
+      "count": 26,
+      "mean": 1,
+      "worst": 1
+    },
+    "entityF1": {
+      "count": 5,
+      "mean": 1,
+      "worst": 1
+    },
+    "voiceEntityMatchRate": {
+      "count": 26,
+      "mean": 1,
+      "worst": 1
+    },
+    "firstAudioMs": {
+      "count": 57,
+      "mean": 250,
+      "worst": 250
+    },
+    "echoRejectionRate": {
+      "count": 4,
+      "mean": 1,
+      "worst": 1
+    },
+    "ownerAccuracy": {
+      "count": 2,
+      "mean": 1,
+      "worst": 1
+    },
+    "impostorAcceptRate": {
+      "count": 2,
+      "mean": 0,
+      "worst": 0
+    },
+    "bargeInGatingAccuracy": {
+      "count": 1,
+      "mean": 1,
+      "worst": 1
+    },
+    "bargeInCancelMs": {
+      "count": 1,
+      "mean": 120,
+      "worst": 120
+    },
+    "erleDb": {
+      "count": 1,
+      "mean": 24,
+      "worst": 24
+    },
+    "partialRetractions": {
+      "count": 1,
+      "mean": 0,
+      "worst": 0
+    }
+  }
+}

--- a/.github/issue-evidence/12889-tail-off-pause/workbench-mock/report.md
+++ b/.github/issue-evidence/12889-tail-off-pause/workbench-mock/report.md
@@ -1,0 +1,55 @@
+# Voice Workbench report
+
+**Overall:** PASS — 26 ran, 0 skipped of 26
+
+## Metrics
+
+| Metric | Mean | Worst | n |
+| --- | --- | --- | --- |
+| WER | 0 | 0 | 69 |
+| EOT false-trigger rate | 0 | 0 | 26 |
+| EOT latency p50 (ms) | 80 | | |
+| EOT latency p95 (ms) | 80 | | |
+| Diarization DER | 0 | 0 | 26 |
+| Respond accuracy | 1 | 1 | 26 |
+| Entity F1 | 1 | 1 | 5 |
+| Voice→entity match | 1 | 1 | 26 |
+| First-audio (ms) | 250 | 250 | 57 |
+| Echo rejection rate | 1 | 1 | 4 |
+| Owner accuracy | 1 | 1 | 2 |
+| Impostor-accept rate | 0 | 0 | 2 |
+| Barge-in gating accuracy | 1 | 1 | 1 |
+| Barge-in cancel (ms) | 120 | 120 | 1 |
+| ERLE (dB) | 24 | 24 | 1 |
+| Partial retractions | 0 | 0 | 1 |
+
+## Scenarios
+
+| Scenario | Classes | Verdict | Cases | Failed |
+| --- | --- | --- | --- | --- |
+| multi-voice-greeting | multi-voice, diarization | pass | 8 | — |
+| respond-vs-bystander | respond-no-respond, multi-speaker | pass | 9 | — |
+| pauses-midutterance | pauses, eot | pass | 7 | — |
+| entity-from-speech | entity-extraction, voice-recognition | pass | 7 | — |
+| transcription-mode-dictation | transcription-mode, long-form-monologue | pass | 5 | — |
+| multi-agent-room-address | multi-agent-room, respond-no-respond | pass | 8 | — |
+| noisy-room-commands | robustness, respond-no-respond | pass | 8 | — |
+| music-background-commands | robustness, respond-no-respond | pass | 8 | — |
+| far-field-reverb | robustness, respond-no-respond | pass | 6 | — |
+| background-talkers | robustness, overlapping-speech, multi-speaker | pass | 6 | — |
+| echo-self-trigger | echo-rejection, respond-no-respond | pass | 10 | — |
+| multi-speaker-name-capture | diarization, entity-extraction, multi-speaker, voice-recognition | pass | 13 | — |
+| confusable-names-clean | entity-extraction, name-disambiguation, multi-speaker, voice-recognition, diarization | pass | 11 | — |
+| confusable-names-noisy | entity-extraction, name-disambiguation, multi-speaker, voice-recognition, robustness | pass | 13 | — |
+| confusable-name-garbled-transcript | entity-extraction, name-disambiguation, multi-speaker, voice-recognition | pass | 11 | — |
+| echo-mistranscribed | echo-rejection | pass | 8 | — |
+| owner-enrollment-inference | owner-security, voice-recognition | pass | 15 | — |
+| owner-vs-intruder | owner-security, respond-no-respond, multi-speaker | pass | 10 | — |
+| endpoint-latency | endpoint-latency, eot | pass | 8 | — |
+| tail-off-thinking | tail-off, eot, pauses | pass | 7 | — |
+| tail-off-filler-pause | tail-off, eot, pauses | pass | 7 | — |
+| tail-off-midclause-long-pause | tail-off, eot, pauses | pass | 7 | — |
+| streaming-partials-monotonic | streaming-partials, eot | pass | 7 | — |
+| speaker-gated-barge-in | speaker-gated-barge-in, echo-rejection | pass | 14 | — |
+| desktop-aec-echo | desktop-aec, echo-rejection | pass | 11 | — |
+| long-turn-diarization | long-turn-diarization, diarization, multi-speaker | pass | 20 | — |

--- a/packages/shared/src/voice-eot.test.ts
+++ b/packages/shared/src/voice-eot.test.ts
@@ -33,19 +33,31 @@ describe("scoreEndOfTurnHeuristic — canonical heuristic", () => {
     expect(score("i went to the store but")).toBe(0.15);
   });
 
-  it("rule 5: trailing preposition/article → incomplete NP (0.2)", () => {
+  it("rule 6: trailing preposition/article → incomplete NP (0.2)", () => {
     expect(score("schedule a meeting with")).toBe(0.2);
     expect(score("put it on the")).toBe(0.2);
     expect(score("i need a")).toBe(0.2);
   });
 
-  it("rule 6: short utterance with no trail-off → complete (0.7)", () => {
+  it("rule 5: trailing filler or hedge → tail-off hold (0.2)", () => {
+    expect(score("let me think um")).toBe(0.2);
+    expect(score("i was going to say uh")).toBe(0.2);
+    expect(score("we could do maybe")).toBe(0.2);
+  });
+
+  it("rule 7: dangling modal/auxiliary → incomplete clause (0.2)", () => {
+    expect(score("i was thinking we could")).toBe(0.2);
+    expect(score("the thing is")).toBe(0.2);
+    expect(score("what i would")).toBe(0.2);
+  });
+
+  it("rule 8: short utterance with no trail-off → complete (0.7)", () => {
     expect(score("go home")).toBe(0.7);
     expect(score("yes")).toBe(0.7);
     expect(score("no thanks")).toBe(0.7);
   });
 
-  it("rule 7: no signal → neutral (0.5)", () => {
+  it("rule 9: no signal → neutral (0.5)", () => {
     expect(score("tell me about the weather in london")).toBe(0.5);
     expect(score("buy milk and eggs")).toBe(0.5);
   });
@@ -55,6 +67,13 @@ describe("scoreEndOfTurnHeuristic — canonical heuristic", () => {
     expect(score("and so")).toBe(0.15); // trailing conjunction, not 0.7
     expect(score("going to")).toBe(0.2); // trailing preposition, not 0.7
     expect(score("set the")).toBe(0.2); // trailing article, not 0.7
+    expect(score("maybe uh")).toBe(0.2); // trailing filler, not 0.7
+    expect(score("we could")).toBe(0.2); // dangling modal, not 0.7
+  });
+
+  it("sentence-final punctuation still commits within budget", () => {
+    expect(score("let me think um.")).toBe(0.95);
+    expect(score("we could do that.")).toBe(0.95);
   });
 
   it("empty / whitespace → neutral (0.5)", () => {

--- a/packages/shared/src/voice-eot.ts
+++ b/packages/shared/src/voice-eot.ts
@@ -83,6 +83,48 @@ const TRAILING_INCOMPLETE = new Set([
   "via",
 ]);
 
+/** Spoken fillers / hedges that usually mean the user is holding the floor. */
+const TRAILING_FILLERS = new Set([
+  "um",
+  "uh",
+  "uhh",
+  "umm",
+  "erm",
+  "er",
+  "hmm",
+  "hm",
+  "ah",
+  "like",
+  "maybe",
+]);
+
+/** Dangling auxiliaries/modals that need another clause or phrase to land. */
+const TRAILING_CONTINUATIONS = new Set([
+  "am",
+  "is",
+  "are",
+  "was",
+  "were",
+  "be",
+  "being",
+  "been",
+  "do",
+  "does",
+  "did",
+  "have",
+  "has",
+  "had",
+  "can",
+  "could",
+  "will",
+  "would",
+  "shall",
+  "should",
+  "may",
+  "might",
+  "must",
+]);
+
 /**
  * Question-tag suffixes that end an utterance (matched case-insensitively).
  * The union of both prior surfaces: punctuated forms (the UI set) plus the
@@ -114,13 +156,15 @@ const QUESTION_TAGS = [
  *   2  Sentence-final punctuation (. ! ?)                   0.95
  *   3  Question-tag suffix ("right?", "yeah", "correct")    0.85
  *   4  Trailing conjunction (and / but / because / …)       0.15  (mid-clause)
- *   5  Trailing preposition / article (to / the / with …)   0.20  (incomplete NP)
- *   6  Short utterance (< 3 words, no trail-off)            0.70  (command/ack)
- *   7  No signal                                            0.50
+ *   5  Trailing filler / hedge (um / uh / maybe / …)        0.20  (holding floor)
+ *   6  Trailing preposition / article (to / the / with …)   0.20  (incomplete NP)
+ *   7  Dangling modal/auxiliary (could / would / is / …)    0.20  (incomplete clause)
+ *   8  Short utterance (< 3 words, no trail-off)            0.70  (command/ack)
+ *   9  No signal                                            0.50
  *
- * Note the conjunction/preposition checks precede the short-utterance rule so a
- * 2-word trail-off ("and so", "going to") is NOT misread as a complete short
- * command.
+ * Note the continuation checks precede the short-utterance rule so a 2-word
+ * trail-off ("and so", "going to", "we could") is NOT misread as a complete
+ * short command.
  */
 export function scoreEndOfTurnHeuristic(transcript: string): number {
   const text = transcript.trim();
@@ -144,11 +188,13 @@ export function scoreEndOfTurnHeuristic(transcript: string): number {
   if (words.length === 0) return 0.5;
 
   const lastWord = words[words.length - 1].replace(/[',;:-]+$/, "");
-  // Trailing conjunction / preposition / article → mid-clause, the speaker is
-  // continuing. Checked BEFORE the short-utterance rule so a 2-word trail-off
-  // ("going to", "and so") is NOT misread as a complete short command.
+  // Trailing conjunction / filler / incomplete phrase → mid-clause, the speaker
+  // is continuing. Checked BEFORE the short-utterance rule so a 2-word trail-off
+  // ("going to", "and so", "we could") is NOT misread as a complete command.
   if (TRAILING_CONJUNCTIONS.has(lastWord)) return 0.15;
+  if (TRAILING_FILLERS.has(lastWord)) return 0.2;
   if (TRAILING_INCOMPLETE.has(lastWord)) return 0.2;
+  if (TRAILING_CONTINUATIONS.has(lastWord)) return 0.2;
 
   // Short utterance that doesn't trail off (a command / acknowledgement) →
   // likely complete ("go home", "yes", "stop").

--- a/plugins/plugin-local-inference/src/services/voice/VOICE_WORKBENCH.md
+++ b/plugins/plugin-local-inference/src/services/voice/VOICE_WORKBENCH.md
@@ -74,8 +74,9 @@ The sibling-behavior classes (#12258) each pin a settled ceiling:
 
 - **`endpoint-latency`** — a clean, sentence-final command commits at the
   endpoint; `maxFirstAudioMs: 800` on the real lane (#12254).
-- **`tail-off`** — a filler / trailing-conjunction pause must NOT commit
-  (`maxEotFalseTriggerRate`); the fused semantic-EOT gate holds (#12255).
+- **`tail-off`** — a filler, dangling-modal, or trailing-conjunction pause must
+  NOT commit (`maxEotFalseTriggerRate`); the fused semantic-EOT gate holds
+  (#12255 / #12889).
 - **`streaming-partials`** — a streaming-ASR partial stream's committed prefix
   never retracts (`scorePartialMonotonicity`); scored only where a partial feed
   exists, skipped honestly in batch-only lanes (#12254).
@@ -88,7 +89,7 @@ The sibling-behavior classes (#12258) each pin a settled ceiling:
 - **`long-turn-diarization`** — a ~30 s three-voice exchange, windowed
   incrementally, within the AMI meeting DER budget (#12257).
 
-The 24 built-in scenarios in `workbench-scenarios.ts` span every class.
+The 26 built-in scenarios in `workbench-scenarios.ts` span every class.
 
 ### Assertion ceilings (parent decision #10)
 

--- a/plugins/plugin-local-inference/src/services/voice/__tests__/eot-classifier.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/__tests__/eot-classifier.test.ts
@@ -143,6 +143,21 @@ describe("HeuristicEotClassifier — rule coverage", () => {
 		expect(await clf.score("I need a")).toBe(0.2);
 	});
 
+	it("trailing filler plus pause cue → P=0.20", async () => {
+		expect(await clf.score("Let me think um")).toBe(0.2);
+		expect(await clf.score("I was going to say uh")).toBe(0.2);
+	});
+
+	it("mid-clause dangling modal/auxiliary → P=0.20", async () => {
+		expect(await clf.score("I was thinking we could")).toBe(0.2);
+		expect(await clf.score("The reason is")).toBe(0.2);
+	});
+
+	it("sentence-final filler/modals still commit when punctuated", async () => {
+		expect(await clf.score("Let me think um.")).toBe(0.95);
+		expect(await clf.score("We could do that.")).toBe(0.95);
+	});
+
 	it("no signal (neutral content) → P=0.50", async () => {
 		expect(await clf.score("Tell me about the weather in London")).toBe(0.5);
 	});
@@ -265,6 +280,57 @@ describe("VoiceStateMachine — EOT classifier integration", () => {
 		});
 
 		expect(machine.getEotHangoverExtensionMs()).toBe(EOT_HANGOVER_EXTENSION_MS);
+	});
+
+	it("filler + long pause holds instead of committing", async () => {
+		const clf = new HeuristicEotClassifier();
+		const { machine, commits } = makeMachine(clf);
+
+		await machine.dispatch({ type: "speech-start", timestampMs: 0 });
+		await machine.dispatch({
+			type: "partial-transcript",
+			timestampMs: 700,
+			text: "Let me think um",
+			silenceSinceMs: 700,
+		});
+
+		expect(machine.getState()).toBe("LISTENING");
+		expect(commits).toHaveLength(0);
+		expect(machine.getEotHangoverExtensionMs()).toBe(EOT_HANGOVER_EXTENSION_MS);
+	});
+
+	it("mid-clause pause ≥700ms holds instead of committing", async () => {
+		const clf = new HeuristicEotClassifier();
+		const { machine, commits } = makeMachine(clf);
+
+		await machine.dispatch({ type: "speech-start", timestampMs: 0 });
+		await machine.dispatch({
+			type: "partial-transcript",
+			timestampMs: 900,
+			text: "I was thinking we could",
+			silenceSinceMs: 900,
+		});
+
+		expect(machine.getState()).toBe("LISTENING");
+		expect(commits).toHaveLength(0);
+		expect(machine.getEotHangoverExtensionMs()).toBe(EOT_HANGOVER_EXTENSION_MS);
+	});
+
+	it("genuine sentence-final pause still commits within budget", async () => {
+		const clf = new HeuristicEotClassifier();
+		const { machine, commits } = makeMachine(clf);
+
+		await machine.dispatch({ type: "speech-start", timestampMs: 0 });
+		await machine.dispatch({
+			type: "partial-transcript",
+			timestampMs: 80,
+			text: "We could do that.",
+			silenceSinceMs: EOT_COMMIT_SILENCE_MS,
+		});
+
+		expect(machine.getState()).toBe("SPEAKING");
+		expect(commits).toHaveLength(1);
+		expect(commits[0].transcript).toBe("We could do that.");
 	});
 
 	it("P<0.4 across two chunks → extension accumulates additively", async () => {

--- a/plugins/plugin-local-inference/src/services/voice/voice-hardening.fuzz.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-hardening.fuzz.test.ts
@@ -6,7 +6,12 @@
 // the declared contract. A seeded LCG makes failures reproducible.
 
 import { describe, expect, it } from "vitest";
-import { clampProbability, turnSignalFromProbability } from "./eot-classifier";
+import {
+	clampProbability,
+	EOT_MID_CLAUSE_THRESHOLD,
+	HeuristicEotClassifier,
+	turnSignalFromProbability,
+} from "./eot-classifier";
 import { type VoiceScenario, validateVoiceScenario } from "./voice-scenario";
 
 function makeRng(seed: number): () => number {
@@ -111,6 +116,28 @@ describe("turnSignalFromProbability / clampProbability - fuzz", () => {
 			expect(sig.endOfTurnProbability).toBeGreaterThanOrEqual(0);
 			expect(sig.endOfTurnProbability).toBeLessThanOrEqual(1);
 			expect([true, false, null]).toContain(sig.agentShouldSpeak);
+		}
+	});
+});
+
+describe("HeuristicEotClassifier tail-off cues - fuzz", () => {
+	it("keeps filler and dangling-modal endings below the mid-clause threshold", async () => {
+		const rng = makeRng(0x12889);
+		const classifier = new HeuristicEotClassifier();
+		const prefixes = [
+			"let me think",
+			"i was going to say",
+			"the thing is",
+			"we could do that but",
+			"what i would",
+			"maybe we",
+		];
+		const endings = ["um", "uh", "hmm", "maybe", "could", "would", "is"];
+		for (let i = 0; i < 500; i++) {
+			const prefix = prefixes[Math.floor(rng() * prefixes.length)];
+			const ending = endings[Math.floor(rng() * endings.length)];
+			const score = await classifier.score(`${prefix} ${ending}`);
+			expect(score).toBeLessThan(EOT_MID_CLAUSE_THRESHOLD);
 		}
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/workbench-scenarios.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-scenarios.ts
@@ -575,6 +575,54 @@ export const VOICE_WORKBENCH_SCENARIOS: VoiceScenario[] = [
 		assertions: { maxEotFalseTriggerRate: 0 },
 	},
 	{
+		id: "tail-off-filler-pause",
+		description:
+			"The owner holds the floor with a filler before a long pause; EOT must extend/hold rather than commit on silence (#12889).",
+		classes: ["tail-off", "eot", "pauses"],
+		knownSpeakerEntityIds: ["entity-owner"],
+		participants: [{ label: "owner", entityId: "entity-owner", isOwner: true }],
+		turns: [
+			{
+				speaker: "owner",
+				text: "Eliza let me think um",
+				expectRespond: false,
+				expectEndOfTurn: false,
+				pausesMs: [900],
+			},
+			{
+				speaker: "owner",
+				text: "remind me to renew the passport tomorrow",
+				expectRespond: true,
+				expectEndOfTurn: true,
+			},
+		],
+		assertions: { maxEotFalseTriggerRate: 0 },
+	},
+	{
+		id: "tail-off-midclause-long-pause",
+		description:
+			"A dangling modal before a >=700 ms pause is still mid-clause; genuine completion follows in the next segment (#12889).",
+		classes: ["tail-off", "eot", "pauses"],
+		knownSpeakerEntityIds: ["entity-owner"],
+		participants: [{ label: "owner", entityId: "entity-owner", isOwner: true }],
+		turns: [
+			{
+				speaker: "owner",
+				text: "Eliza I was thinking we could",
+				expectRespond: false,
+				expectEndOfTurn: false,
+				pausesMs: [700],
+			},
+			{
+				speaker: "owner",
+				text: "move the dentist appointment to friday",
+				expectRespond: true,
+				expectEndOfTurn: true,
+			},
+		],
+		assertions: { maxEotFalseTriggerRate: 0 },
+	},
+	{
 		id: "streaming-partials-monotonic",
 		description:
 			"Streaming ASR emits growing partial hypotheses; the committed prefix must never retract as later audio arrives (#12254). Scored only where a streaming-ASR partial feed exists; batch lanes skip it honestly.",


### PR DESCRIPTION
## Summary
- classify spoken fillers/hedges and dangling modal/auxiliary endings as tail-off EOT signals in the shared heuristic
- prove filler + long pause and mid-clause >=700 ms pauses hold instead of committing, while punctuated completions still commit
- add stable workbench scenarios `tail-off-filler-pause` and `tail-off-midclause-long-pause` with mock + logic reports

Fixes #12889

## Evidence
- `.github/issue-evidence/12889-tail-off-pause/README.md`
- `.github/issue-evidence/12889-tail-off-pause/workbench-mock/report.json` and `.md`
- `.github/issue-evidence/12889-tail-off-pause/workbench-logic/report.json` and `.md`

## Verification
- `bun test packages/shared/src/voice-eot.test.ts plugins/plugin-local-inference/src/services/voice/__tests__/eot-classifier.test.ts plugins/plugin-local-inference/src/services/voice/voice-hardening.fuzz.test.ts plugins/plugin-local-inference/src/services/voice/workbench-headless-runner.test.ts`
- `bun run --cwd plugins/plugin-local-inference voice:workbench --mock --out ../../.github/issue-evidence/12889-tail-off-pause/workbench-mock`
- `bun run --cwd plugins/plugin-local-inference voice:workbench --logic --out ../../.github/issue-evidence/12889-tail-off-pause/workbench-logic`
- `bunx biome check <touched files>`
- `bun run --cwd packages/shared typecheck`
- `bun run --cwd plugins/plugin-local-inference typecheck`
- `git fetch origin && git rebase origin/develop && bun install`
- `git diff --check`

## Known blockers / N/A
- `bun run --cwd plugins/plugin-local-inference voice:workbench --real ...` failed fast because the local ASR bundle is absent: `/Users/shawwalters/.eliza/local-inference/models/eliza-1-2b.bundle`.
- `bun run --cwd packages/shared lint:check` is blocked by unrelated formatting in `packages/shared/src/voice/aec/echo-alignment.ts`.
- `bun run --cwd plugins/plugin-local-inference lint:check` is blocked by unrelated formatting in `plugins/plugin-local-inference/src/services/voice/__fixtures__/voice-workbench-logic-baseline.json`.
- root `bun run verify` is blocked by unrelated `@elizaos/tui#lint` diagnostics; unrelated write-mode side effects were restored after the attempt.
