### PR TITLE
fix: gate voice barge-in interrupts

### DIFF
--- a/.github/issue-evidence/12890-barge-in-deny-resume/README.md
+++ b/.github/issue-evidence/12890-barge-in-deny-resume/README.md
@@ -1,0 +1,37 @@
+# Issue #12890 evidence: speaker-gated barge-in and deny-resume continuity
+
+## Summary
+
+- Added an optional `BargeInInterruptGate` to the barge-in controller. Confirmed ASR words still hard-stop by default, but a gate can now deny self-echo/bystander speech and resume TTS instead.
+- Threaded transcript and speaker evidence through `VoiceTurnController` into the barge-in gate.
+- Added deny-resume scheduler coverage proving a denied self-echo resumes exactly the buffered audio without cancelling TTS, replaying audio, or skipping buffered samples.
+- Wake-word evidence remains authoritative and can hard-stop even when the gate denies ordinary speech.
+
+## Verification
+
+- `bunx biome check plugins/plugin-local-inference/src/services/voice/types.ts plugins/plugin-local-inference/src/services/voice/barge-in.ts plugins/plugin-local-inference/src/services/voice/barge-in.test.ts plugins/plugin-local-inference/src/services/voice/turn-controller.ts plugins/plugin-local-inference/src/services/voice/turn-controller.test.ts plugins/plugin-local-inference/src/services/voice/voice.test.ts`
+  - Passed.
+- `bun test plugins/plugin-local-inference/src/services/voice/barge-in.test.ts plugins/plugin-local-inference/src/services/voice/turn-controller.test.ts plugins/plugin-local-inference/src/services/voice/voice.test.ts`
+  - Passed: 75 tests, 0 failed.
+- `bun test plugins/plugin-local-inference/src/services/voice/e2e-harness.test.ts plugins/plugin-local-inference/src/services/voice/workbench-headless-runner.test.ts plugins/plugin-local-inference/src/services/voice/workbench-logic-services.test.ts`
+  - Passed: 45 tests, 0 failed.
+  - Covers `scoreBargeInInterruption`, `scorePauseContinuation`, `scoreBargeInGating`, echo rejection, ERLE, and the speaker-gated workbench scenario.
+- `bun run --cwd plugins/plugin-local-inference typecheck`
+  - Passed.
+- `bun run --cwd plugins/plugin-local-inference voice:workbench --mock --out ../../.github/issue-evidence/12890-barge-in-deny-resume/workbench-mock`
+  - Passed: 24 ran, 0 skipped.
+  - `speaker-gated-barge-in` passed.
+  - Barge-in gating accuracy: 1.0; cancel latency: 120 ms.
+  - Echo rejection rate: 1.0; ERLE: 24 dB.
+- `bun run --cwd plugins/plugin-local-inference voice:workbench --logic --out ../../.github/issue-evidence/12890-barge-in-deny-resume/workbench-logic`
+  - Passed: 24 ran, 0 skipped.
+  - `speaker-gated-barge-in`, `echo-self-trigger`, `echo-mistranscribed`, and `desktop-aec-echo` passed.
+  - Barge-in gating accuracy: 1.0; cancel latency: 120 ms.
+  - Echo rejection rate: 1.0.
+
+## Real-audio lane
+
+- `bun run --cwd plugins/plugin-local-inference voice:workbench --real --out ../../.github/issue-evidence/12890-barge-in-deny-resume/workbench-real`
+  - N/A in this checkout: missing `ELIZA_ASR_BUNDLE` at `/Users/shawwalters/.eliza/local-inference/models/eliza-1-2b.bundle`.
+  - No real-audio report was produced because the workbench exits before running without that local model artifact.
+

--- a/.github/issue-evidence/12890-barge-in-deny-resume/workbench-logic/report.json
+++ b/.github/issue-evidence/12890-barge-in-deny-resume/workbench-logic/report.json
@@ -1,0 +1,360 @@
+{
+  "schemaVersion": 1,
+  "overall": "pass",
+  "scenariosTotal": 24,
+  "scenariosRan": 24,
+  "scenariosSkipped": 0,
+  "scenarios": [
+    {
+      "scenarioId": "multi-voice-greeting",
+      "classes": [
+        "multi-voice",
+        "diarization"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "respond-vs-bystander",
+      "classes": [
+        "respond-no-respond",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 9,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "pauses-midutterance",
+      "classes": [
+        "pauses",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "entity-from-speech",
+      "classes": [
+        "entity-extraction",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "transcription-mode-dictation",
+      "classes": [
+        "transcription-mode",
+        "long-form-monologue"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 5,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "multi-agent-room-address",
+      "classes": [
+        "multi-agent-room",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "noisy-room-commands",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "music-background-commands",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "far-field-reverb",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "background-talkers",
+      "classes": [
+        "robustness",
+        "overlapping-speech",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "echo-self-trigger",
+      "classes": [
+        "echo-rejection",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "multi-speaker-name-capture",
+      "classes": [
+        "diarization",
+        "entity-extraction",
+        "multi-speaker",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 13,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-names-clean",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition",
+        "diarization"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 11,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-names-noisy",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition",
+        "robustness"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 13,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-name-garbled-transcript",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 11,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "echo-mistranscribed",
+      "classes": [
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "owner-enrollment-inference",
+      "classes": [
+        "owner-security",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 15,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "owner-vs-intruder",
+      "classes": [
+        "owner-security",
+        "respond-no-respond",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "endpoint-latency",
+      "classes": [
+        "endpoint-latency",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "tail-off-thinking",
+      "classes": [
+        "tail-off",
+        "eot",
+        "pauses"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "streaming-partials-monotonic",
+      "classes": [
+        "streaming-partials",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "speaker-gated-barge-in",
+      "classes": [
+        "speaker-gated-barge-in",
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 14,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "desktop-aec-echo",
+      "classes": [
+        "desktop-aec",
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "long-turn-diarization",
+      "classes": [
+        "long-turn-diarization",
+        "diarization",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 20,
+      "failedCaseKinds": []
+    }
+  ],
+  "metrics": {
+    "wer": {
+      "count": 65,
+      "mean": 0,
+      "worst": 0
+    },
+    "eotFalseTriggerRate": {
+      "count": 24,
+      "mean": 0,
+      "worst": 0
+    },
+    "eotLatencyP50Ms": null,
+    "eotLatencyP95Ms": null,
+    "der": {
+      "count": 24,
+      "mean": 0.01,
+      "worst": 0.2394
+    },
+    "respondAccuracy": {
+      "count": 24,
+      "mean": 1,
+      "worst": 1
+    },
+    "entityF1": {
+      "count": 5,
+      "mean": 1,
+      "worst": 1
+    },
+    "voiceEntityMatchRate": {
+      "count": 24,
+      "mean": 1,
+      "worst": 1
+    },
+    "firstAudioMs": {
+      "count": 55,
+      "mean": 250,
+      "worst": 250
+    },
+    "echoRejectionRate": {
+      "count": 4,
+      "mean": 1,
+      "worst": 1
+    },
+    "ownerAccuracy": {
+      "count": 2,
+      "mean": 1,
+      "worst": 1
+    },
+    "impostorAcceptRate": {
+      "count": 2,
+      "mean": 0,
+      "worst": 0
+    },
+    "bargeInGatingAccuracy": {
+      "count": 1,
+      "mean": 1,
+      "worst": 1
+    },
+    "bargeInCancelMs": {
+      "count": 1,
+      "mean": 120,
+      "worst": 120
+    },
+    "erleDb": {
+      "count": 0,
+      "mean": null,
+      "worst": null
+    },
+    "partialRetractions": {
+      "count": 0,
+      "mean": null,
+      "worst": null
+    }
+  }
+}

--- a/.github/issue-evidence/12890-barge-in-deny-resume/workbench-logic/report.md
+++ b/.github/issue-evidence/12890-barge-in-deny-resume/workbench-logic/report.md
@@ -1,0 +1,53 @@
+# Voice Workbench report
+
+**Overall:** PASS — 24 ran, 0 skipped of 24
+
+## Metrics
+
+| Metric | Mean | Worst | n |
+| --- | --- | --- | --- |
+| WER | 0 | 0 | 65 |
+| EOT false-trigger rate | 0 | 0 | 24 |
+| EOT latency p50 (ms) | — | | |
+| EOT latency p95 (ms) | — | | |
+| Diarization DER | 0.01 | 0.2394 | 24 |
+| Respond accuracy | 1 | 1 | 24 |
+| Entity F1 | 1 | 1 | 5 |
+| Voice→entity match | 1 | 1 | 24 |
+| First-audio (ms) | 250 | 250 | 55 |
+| Echo rejection rate | 1 | 1 | 4 |
+| Owner accuracy | 1 | 1 | 2 |
+| Impostor-accept rate | 0 | 0 | 2 |
+| Barge-in gating accuracy | 1 | 1 | 1 |
+| Barge-in cancel (ms) | 120 | 120 | 1 |
+| ERLE (dB) | — | — | 0 |
+| Partial retractions | — | — | 0 |
+
+## Scenarios
+
+| Scenario | Classes | Verdict | Cases | Failed |
+| --- | --- | --- | --- | --- |
+| multi-voice-greeting | multi-voice, diarization | pass | 8 | — |
+| respond-vs-bystander | respond-no-respond, multi-speaker | pass | 9 | — |
+| pauses-midutterance | pauses, eot | pass | 7 | — |
+| entity-from-speech | entity-extraction, voice-recognition | pass | 7 | — |
+| transcription-mode-dictation | transcription-mode, long-form-monologue | pass | 5 | — |
+| multi-agent-room-address | multi-agent-room, respond-no-respond | pass | 8 | — |
+| noisy-room-commands | robustness, respond-no-respond | pass | 8 | — |
+| music-background-commands | robustness, respond-no-respond | pass | 8 | — |
+| far-field-reverb | robustness, respond-no-respond | pass | 6 | — |
+| background-talkers | robustness, overlapping-speech, multi-speaker | pass | 6 | — |
+| echo-self-trigger | echo-rejection, respond-no-respond | pass | 10 | — |
+| multi-speaker-name-capture | diarization, entity-extraction, multi-speaker, voice-recognition | pass | 13 | — |
+| confusable-names-clean | entity-extraction, name-disambiguation, multi-speaker, voice-recognition, diarization | pass | 11 | — |
+| confusable-names-noisy | entity-extraction, name-disambiguation, multi-speaker, voice-recognition, robustness | pass | 13 | — |
+| confusable-name-garbled-transcript | entity-extraction, name-disambiguation, multi-speaker, voice-recognition | pass | 11 | — |
+| echo-mistranscribed | echo-rejection | pass | 8 | — |
+| owner-enrollment-inference | owner-security, voice-recognition | pass | 15 | — |
+| owner-vs-intruder | owner-security, respond-no-respond, multi-speaker | pass | 10 | — |
+| endpoint-latency | endpoint-latency, eot | pass | 8 | — |
+| tail-off-thinking | tail-off, eot, pauses | pass | 7 | — |
+| streaming-partials-monotonic | streaming-partials, eot | pass | 6 | — |
+| speaker-gated-barge-in | speaker-gated-barge-in, echo-rejection | pass | 14 | — |
+| desktop-aec-echo | desktop-aec, echo-rejection | pass | 10 | — |
+| long-turn-diarization | long-turn-diarization, diarization, multi-speaker | pass | 20 | — |

--- a/.github/issue-evidence/12890-barge-in-deny-resume/workbench-mock/report.json
+++ b/.github/issue-evidence/12890-barge-in-deny-resume/workbench-mock/report.json
@@ -1,0 +1,360 @@
+{
+  "schemaVersion": 1,
+  "overall": "pass",
+  "scenariosTotal": 24,
+  "scenariosRan": 24,
+  "scenariosSkipped": 0,
+  "scenarios": [
+    {
+      "scenarioId": "multi-voice-greeting",
+      "classes": [
+        "multi-voice",
+        "diarization"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "respond-vs-bystander",
+      "classes": [
+        "respond-no-respond",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 9,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "pauses-midutterance",
+      "classes": [
+        "pauses",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "entity-from-speech",
+      "classes": [
+        "entity-extraction",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "transcription-mode-dictation",
+      "classes": [
+        "transcription-mode",
+        "long-form-monologue"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 5,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "multi-agent-room-address",
+      "classes": [
+        "multi-agent-room",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "noisy-room-commands",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "music-background-commands",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "far-field-reverb",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "background-talkers",
+      "classes": [
+        "robustness",
+        "overlapping-speech",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "echo-self-trigger",
+      "classes": [
+        "echo-rejection",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "multi-speaker-name-capture",
+      "classes": [
+        "diarization",
+        "entity-extraction",
+        "multi-speaker",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 13,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-names-clean",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition",
+        "diarization"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 11,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-names-noisy",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition",
+        "robustness"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 13,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-name-garbled-transcript",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 11,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "echo-mistranscribed",
+      "classes": [
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "owner-enrollment-inference",
+      "classes": [
+        "owner-security",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 15,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "owner-vs-intruder",
+      "classes": [
+        "owner-security",
+        "respond-no-respond",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "endpoint-latency",
+      "classes": [
+        "endpoint-latency",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "tail-off-thinking",
+      "classes": [
+        "tail-off",
+        "eot",
+        "pauses"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "streaming-partials-monotonic",
+      "classes": [
+        "streaming-partials",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "speaker-gated-barge-in",
+      "classes": [
+        "speaker-gated-barge-in",
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 14,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "desktop-aec-echo",
+      "classes": [
+        "desktop-aec",
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 11,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "long-turn-diarization",
+      "classes": [
+        "long-turn-diarization",
+        "diarization",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 20,
+      "failedCaseKinds": []
+    }
+  ],
+  "metrics": {
+    "wer": {
+      "count": 65,
+      "mean": 0,
+      "worst": 0
+    },
+    "eotFalseTriggerRate": {
+      "count": 24,
+      "mean": 0,
+      "worst": 0
+    },
+    "eotLatencyP50Ms": 80,
+    "eotLatencyP95Ms": 80,
+    "der": {
+      "count": 24,
+      "mean": 0,
+      "worst": 0
+    },
+    "respondAccuracy": {
+      "count": 24,
+      "mean": 1,
+      "worst": 1
+    },
+    "entityF1": {
+      "count": 5,
+      "mean": 1,
+      "worst": 1
+    },
+    "voiceEntityMatchRate": {
+      "count": 24,
+      "mean": 1,
+      "worst": 1
+    },
+    "firstAudioMs": {
+      "count": 55,
+      "mean": 250,
+      "worst": 250
+    },
+    "echoRejectionRate": {
+      "count": 4,
+      "mean": 1,
+      "worst": 1
+    },
+    "ownerAccuracy": {
+      "count": 2,
+      "mean": 1,
+      "worst": 1
+    },
+    "impostorAcceptRate": {
+      "count": 2,
+      "mean": 0,
+      "worst": 0
+    },
+    "bargeInGatingAccuracy": {
+      "count": 1,
+      "mean": 1,
+      "worst": 1
+    },
+    "bargeInCancelMs": {
+      "count": 1,
+      "mean": 120,
+      "worst": 120
+    },
+    "erleDb": {
+      "count": 1,
+      "mean": 24,
+      "worst": 24
+    },
+    "partialRetractions": {
+      "count": 1,
+      "mean": 0,
+      "worst": 0
+    }
+  }
+}

--- a/.github/issue-evidence/12890-barge-in-deny-resume/workbench-mock/report.md
+++ b/.github/issue-evidence/12890-barge-in-deny-resume/workbench-mock/report.md
@@ -1,0 +1,53 @@
+# Voice Workbench report
+
+**Overall:** PASS — 24 ran, 0 skipped of 24
+
+## Metrics
+
+| Metric | Mean | Worst | n |
+| --- | --- | --- | --- |
+| WER | 0 | 0 | 65 |
+| EOT false-trigger rate | 0 | 0 | 24 |
+| EOT latency p50 (ms) | 80 | | |
+| EOT latency p95 (ms) | 80 | | |
+| Diarization DER | 0 | 0 | 24 |
+| Respond accuracy | 1 | 1 | 24 |
+| Entity F1 | 1 | 1 | 5 |
+| Voice→entity match | 1 | 1 | 24 |
+| First-audio (ms) | 250 | 250 | 55 |
+| Echo rejection rate | 1 | 1 | 4 |
+| Owner accuracy | 1 | 1 | 2 |
+| Impostor-accept rate | 0 | 0 | 2 |
+| Barge-in gating accuracy | 1 | 1 | 1 |
+| Barge-in cancel (ms) | 120 | 120 | 1 |
+| ERLE (dB) | 24 | 24 | 1 |
+| Partial retractions | 0 | 0 | 1 |
+
+## Scenarios
+
+| Scenario | Classes | Verdict | Cases | Failed |
+| --- | --- | --- | --- | --- |
+| multi-voice-greeting | multi-voice, diarization | pass | 8 | — |
+| respond-vs-bystander | respond-no-respond, multi-speaker | pass | 9 | — |
+| pauses-midutterance | pauses, eot | pass | 7 | — |
+| entity-from-speech | entity-extraction, voice-recognition | pass | 7 | — |
+| transcription-mode-dictation | transcription-mode, long-form-monologue | pass | 5 | — |
+| multi-agent-room-address | multi-agent-room, respond-no-respond | pass | 8 | — |
+| noisy-room-commands | robustness, respond-no-respond | pass | 8 | — |
+| music-background-commands | robustness, respond-no-respond | pass | 8 | — |
+| far-field-reverb | robustness, respond-no-respond | pass | 6 | — |
+| background-talkers | robustness, overlapping-speech, multi-speaker | pass | 6 | — |
+| echo-self-trigger | echo-rejection, respond-no-respond | pass | 10 | — |
+| multi-speaker-name-capture | diarization, entity-extraction, multi-speaker, voice-recognition | pass | 13 | — |
+| confusable-names-clean | entity-extraction, name-disambiguation, multi-speaker, voice-recognition, diarization | pass | 11 | — |
+| confusable-names-noisy | entity-extraction, name-disambiguation, multi-speaker, voice-recognition, robustness | pass | 13 | — |
+| confusable-name-garbled-transcript | entity-extraction, name-disambiguation, multi-speaker, voice-recognition | pass | 11 | — |
+| echo-mistranscribed | echo-rejection | pass | 8 | — |
+| owner-enrollment-inference | owner-security, voice-recognition | pass | 15 | — |
+| owner-vs-intruder | owner-security, respond-no-respond, multi-speaker | pass | 10 | — |
+| endpoint-latency | endpoint-latency, eot | pass | 8 | — |
+| tail-off-thinking | tail-off, eot, pauses | pass | 7 | — |
+| streaming-partials-monotonic | streaming-partials, eot | pass | 7 | — |
+| speaker-gated-barge-in | speaker-gated-barge-in, echo-rejection | pass | 14 | — |
+| desktop-aec-echo | desktop-aec, echo-rejection | pass | 11 | — |
+| long-turn-diarization | long-turn-diarization, diarization, multi-speaker | pass | 20 | — |

--- a/plugins/plugin-local-inference/src/services/voice/barge-in.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/barge-in.test.ts
@@ -122,6 +122,92 @@ describe("BargeInController — VAD-driven barge-in", () => {
 		expect(onCancelCalls).toBe(1);
 	});
 
+	it("denies a gated self-echo word confirmation and resumes TTS", () => {
+		const c = new BargeInController({
+			interruptGate: (evidence) =>
+				evidence.selfVoiceSimilarity && evidence.selfVoiceSimilarity >= 0.8
+					? { allow: false, reason: "self-echo" }
+					: { allow: true },
+		});
+		const vad = new FakeVad();
+		c.bindVad(vad);
+		c.setAgentSpeaking(true);
+		const signals: BargeInSignal[] = [];
+		c.onSignal((s) => signals.push(s));
+
+		vad.emit(speechActive(100));
+		c.onWordsDetected({
+			wordCount: 2,
+			partialText: "forecast echo",
+			timestampMs: 180,
+			evidence: { selfVoiceSimilarity: 0.91 },
+		});
+
+		expect(signals.map((s) => s.type)).toEqual(["pause-tts", "resume-tts"]);
+		const resume = signals.find((s) => s.type === "resume-tts");
+		expect(resume?.reason).toBe("self-echo");
+		expect(c.currentCancelToken()).toBeNull();
+		expect(c.cancelSignal().cancelled).toBe(false);
+	});
+
+	it("lets a wake-word interjection hard-stop even when a gate would deny other speech", () => {
+		const c = new BargeInController({
+			interruptGate: (evidence) =>
+				evidence.wakeWordActive
+					? { allow: true, reason: "wake-word" }
+					: { allow: false, reason: "not-addressed" },
+		});
+		const vad = new FakeVad();
+		c.bindVad(vad);
+		c.setAgentSpeaking(true);
+		const signals: BargeInSignal[] = [];
+		c.onSignal((s) => signals.push(s));
+
+		vad.emit(speechActive(100));
+		c.onWordsDetected({
+			wordCount: 3,
+			partialText: "hey Eliza stop",
+			timestampMs: 190,
+			evidence: { wakeWordActive: true },
+		});
+
+		expect(signals.map((s) => s.type)).toEqual(["pause-tts", "hard-stop"]);
+		const hard = signals.find((s) => s.type === "hard-stop");
+		expect(hard?.reason).toBe("wake-word");
+		expect(c.currentCancelToken()?.reason).toBe("barge-in-words");
+	});
+
+	it("ignores a late async gate allow after the agent has stopped speaking", async () => {
+		let resolveGate:
+			| ((decision: { allow: true; reason: string }) => void)
+			| undefined;
+		const c = new BargeInController({
+			interruptGate: () =>
+				new Promise((resolve) => {
+					resolveGate = resolve;
+				}),
+		});
+		const vad = new FakeVad();
+		c.bindVad(vad);
+		c.setAgentSpeaking(true);
+		const signals: BargeInSignal[] = [];
+		c.onSignal((s) => signals.push(s));
+
+		vad.emit(speechActive(100));
+		c.onWordsDetected({
+			wordCount: 1,
+			partialText: "wait",
+			timestampMs: 180,
+		});
+		c.setAgentSpeaking(false);
+		resolveGate?.({ allow: true, reason: "late-allow" });
+		await Promise.resolve();
+
+		expect(signals.map((s) => s.type)).toEqual(["pause-tts"]);
+		expect(c.currentCancelToken()).toBeNull();
+		expect(c.cancelSignal().cancelled).toBe(false);
+	});
+
 	it("ignores onWordsDetected with zero words", () => {
 		const c = new BargeInController();
 		const vad = new FakeVad();

--- a/plugins/plugin-local-inference/src/services/voice/barge-in.ts
+++ b/plugins/plugin-local-inference/src/services/voice/barge-in.ts
@@ -37,6 +37,9 @@
 
 import type {
 	BargeInCancelToken,
+	BargeInInterruptDecision,
+	BargeInInterruptEvidence,
+	BargeInInterruptGate,
 	BargeInSignal,
 	BargeInSignalListener,
 	VadEvent,
@@ -92,6 +95,15 @@ function tripToken(
 	if (trip) trip(reason);
 }
 
+function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"then" in value &&
+		typeof (value as { then?: unknown }).then === "function"
+	);
+}
+
 export interface BargeInControllerConfig {
 	/**
 	 * After a `speech-active` (TTS paused) with no ASR word confirmation,
@@ -100,12 +112,19 @@ export interface BargeInControllerConfig {
 	 * cough doesn't keep the agent muted.
 	 */
 	wordsGraceMs?: number;
+	/**
+	 * Optional speaker/echo/wake-word gate. When it denies an ASR-confirmed
+	 * interjection, the controller resumes TTS instead of hard-stopping it.
+	 * Omit to preserve the historical "any confirmed word interrupts" behavior.
+	 */
+	interruptGate?: BargeInInterruptGate | null;
 }
 
 export class BargeInController implements WordsDetectedSink {
 	private readonly listeners = new Set<BargeInListener>();
 	private readonly signalListeners = new Set<BargeInSignalListener>();
 	private readonly wordsGraceMs: number;
+	private interruptGate: BargeInInterruptGate | null;
 
 	/** Legacy single-shot cancel flag, reset by `reset()`. */
 	private signal: CancelSignal = { cancelled: false };
@@ -124,6 +143,7 @@ export class BargeInController implements WordsDetectedSink {
 
 	constructor(config: BargeInControllerConfig = {}) {
 		this.wordsGraceMs = config.wordsGraceMs ?? 600;
+		this.interruptGate = config.interruptGate ?? null;
 	}
 
 	// --- New subscription API ---------------------------------------------------
@@ -161,6 +181,10 @@ export class BargeInController implements WordsDetectedSink {
 
 	get isAgentSpeaking(): boolean {
 		return this.agentSpeaking;
+	}
+
+	setInterruptGate(gate: BargeInInterruptGate | null | undefined): void {
+		this.interruptGate = gate ?? null;
 	}
 
 	// --- VAD event handling -----------------------------------------------------
@@ -215,6 +239,7 @@ export class BargeInController implements WordsDetectedSink {
 		wordCount: number;
 		partialText: string;
 		timestampMs: number;
+		evidence?: Partial<BargeInInterruptEvidence>;
 	}): void {
 		if (args.wordCount < 1) return;
 		const withinConfirmWindow =
@@ -226,8 +251,45 @@ export class BargeInController implements WordsDetectedSink {
 		) {
 			return;
 		}
+		const decision = this.evaluateInterrupt(args);
+		if (isPromiseLike(decision)) {
+			void decision.then(
+				(resolved) => this.applyInterruptDecision(args, resolved),
+				() =>
+					this.applyInterruptDecision(args, {
+						allow: false,
+						reason: "interrupt-gate-error",
+					}),
+			);
+			return;
+		}
+		this.applyInterruptDecision(args, decision);
+	}
+
+	private applyInterruptDecision(
+		args: {
+			wordCount: number;
+			partialText: string;
+			timestampMs: number;
+			evidence?: Partial<BargeInInterruptEvidence>;
+		},
+		decision: BargeInInterruptDecision,
+	): void {
+		const withinConfirmWindow =
+			this.wordConfirmExpiresAtMs != null &&
+			args.timestampMs <= this.wordConfirmExpiresAtMs;
+		if (
+			!this.agentSpeaking ||
+			(!this.awaitingWordConfirm && !withinConfirmWindow)
+		) {
+			return;
+		}
+		if (!decision.allow) {
+			this.denyInterrupt(args.timestampMs, decision.reason);
+			return;
+		}
 		// Authoritative: real user speech. Hard-stop.
-		this.hardStop("barge-in-words", args.timestampMs);
+		this.hardStop("barge-in-words", args.timestampMs, decision.reason);
 	}
 
 	// --- Hard stop --------------------------------------------------------------
@@ -241,6 +303,7 @@ export class BargeInController implements WordsDetectedSink {
 	hardStop(
 		reason: NonNullable<BargeInCancelToken["reason"]> = "manual",
 		timestampMs: number = this.lastEventTimestampMs || Date.now(),
+		decisionReason?: string,
 	): BargeInCancelToken {
 		this.clearWordConfirm();
 		this.awaitingWordConfirm = false;
@@ -255,6 +318,7 @@ export class BargeInController implements WordsDetectedSink {
 			type: "hard-stop",
 			timestampMs,
 			token: this.activeToken,
+			...(decisionReason ? { reason: decisionReason } : {}),
 		});
 		return this.activeToken;
 	}
@@ -295,6 +359,36 @@ export class BargeInController implements WordsDetectedSink {
 
 	private emitSignal(signal: BargeInSignal): void {
 		for (const l of this.signalListeners) l(signal);
+	}
+
+	private evaluateInterrupt(args: {
+		wordCount: number;
+		partialText: string;
+		timestampMs: number;
+		evidence?: Partial<BargeInInterruptEvidence>;
+	}): BargeInInterruptDecision | Promise<BargeInInterruptDecision> {
+		if (!this.interruptGate) return { allow: true, reason: "no-gate" };
+		try {
+			return this.interruptGate({
+				wordCount: args.wordCount,
+				partialText: args.partialText,
+				timestampMs: args.timestampMs,
+				agentSpeaking: this.agentSpeaking,
+				...args.evidence,
+			});
+		} catch {
+			return { allow: false, reason: "interrupt-gate-error" };
+		}
+	}
+
+	private denyInterrupt(timestampMs: number, reason: string): void {
+		this.awaitingWordConfirm = false;
+		this.clearWordConfirm();
+		this.emitSignal({
+			type: "resume-tts",
+			timestampMs,
+			reason,
+		});
 	}
 
 	private armWordConfirmDeadline(timestampMs: number): void {

--- a/plugins/plugin-local-inference/src/services/voice/turn-controller.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/turn-controller.test.ts
@@ -25,6 +25,7 @@ import {
 	type VoiceTurnOutcome,
 } from "./turn-controller";
 import type {
+	BargeInInterruptGate,
 	SpeakerPreset,
 	StreamingTranscriber,
 	TranscriberEvent,
@@ -164,7 +165,11 @@ interface Harness {
 }
 
 function makeHarness(
-	opts: { speculatePauseMs?: number; turnDetector?: EotClassifier } = {},
+	opts: {
+		speculatePauseMs?: number;
+		turnDetector?: EotClassifier;
+		bargeInInterruptGate?: BargeInInterruptGate;
+	} = {},
 ): Harness {
 	const vad = new FakeVad();
 	const transcriber = new FakeTranscriber();
@@ -187,6 +192,9 @@ function makeHarness(
 			scheduler,
 			prewarm,
 			...(opts.turnDetector ? { turnDetector: opts.turnDetector } : {}),
+			...(opts.bargeInInterruptGate
+				? { bargeInInterruptGate: opts.bargeInInterruptGate }
+				: {}),
 			generate: (request) => {
 				generateCalls.push(request);
 				return new Promise<VoiceTurnOutcome>((resolve, reject) => {
@@ -524,6 +532,68 @@ describe("VoiceTurnController", () => {
 		// ASR confirms real words → hard-stop.
 		h.transcriber.emit({ kind: "words", words: ["wait", "stop"] });
 		expect(hardStopped).toBe(true);
+	});
+
+	it("threads self-echo evidence into the barge-in gate and resumes without hard-stop", () => {
+		const decisions: Array<{
+			partialText: string;
+			selfVoiceSimilarity?: number;
+		}> = [];
+		const h = makeHarness({
+			bargeInInterruptGate: (evidence) => {
+				decisions.push({
+					partialText: evidence.partialText,
+					selfVoiceSimilarity: evidence.selfVoiceSimilarity,
+				});
+				return evidence.selfVoiceSimilarity &&
+					evidence.selfVoiceSimilarity >= 0.8
+					? { allow: false, reason: "self-echo" }
+					: { allow: true };
+			},
+		});
+		h.controller.start();
+		h.scheduler.bargeIn.setAgentSpeaking(true);
+		const signals: string[] = [];
+		h.scheduler.bargeIn.onSignal((s) => signals.push(s.type));
+		h.vad.emit(vadEvent({ type: "speech-active" }));
+
+		h.transcriber.emit({
+			kind: "words",
+			words: ["weekly", "forecast"],
+			evidence: { selfVoiceSimilarity: 0.93 },
+		});
+
+		expect(decisions).toEqual([
+			{ partialText: "weekly forecast", selfVoiceSimilarity: 0.93 },
+		]);
+		expect(signals).toEqual(["pause-tts", "resume-tts"]);
+		expect(h.scheduler.bargeIn.currentCancelToken()).toBeNull();
+	});
+
+	it("threads wake-word evidence into the barge-in gate and allows hard-stop", () => {
+		const h = makeHarness({
+			bargeInInterruptGate: (evidence) =>
+				evidence.wakeWordActive
+					? { allow: true, reason: "wake-word" }
+					: { allow: false, reason: "not-addressed" },
+		});
+		h.controller.start();
+		h.scheduler.bargeIn.setAgentSpeaking(true);
+		const signals: string[] = [];
+		h.scheduler.bargeIn.onSignal((s) => signals.push(s.type));
+		h.vad.emit(vadEvent({ type: "speech-active" }));
+
+		h.transcriber.emit({
+			kind: "words",
+			words: ["hey", "Eliza", "stop"],
+			evidence: { wakeWordActive: true },
+		});
+
+		expect(signals).toEqual(["pause-tts", "hard-stop"]);
+		expect(h.scheduler.bargeIn.currentCancelToken()?.cancelled).toBe(true);
+		expect(h.scheduler.bargeIn.currentCancelToken()?.reason).toBe(
+			"barge-in-words",
+		);
 	});
 
 	it("surfaces a prewarm rejection via onError without killing the turn", async () => {

--- a/plugins/plugin-local-inference/src/services/voice/turn-controller.ts
+++ b/plugins/plugin-local-inference/src/services/voice/turn-controller.ts
@@ -46,6 +46,8 @@ import {
 } from "./eot-classifier";
 import type { VoiceScheduler } from "./scheduler";
 import type {
+	BargeInInterruptEvidence,
+	BargeInInterruptGate,
 	StreamingTranscriber,
 	TranscriberEvent,
 	TranscriptUpdate,
@@ -116,6 +118,12 @@ export interface VoiceTurnControllerDeps {
 	 * wait for the user to continue.
 	 */
 	turnDetector?: EotClassifier;
+	/**
+	 * Optional speaker/echo/wake-word interrupt gate for barge-in while the agent
+	 * is speaking. When absent, confirmed ASR words preserve the legacy behavior
+	 * and hard-stop immediately.
+	 */
+	bargeInInterruptGate?: BargeInInterruptGate;
 	/**
 	 * Run a generation pass. The callee builds the message, calls the runtime
 	 * message handler / `useModel`, and streams `replyText` into TTS via the
@@ -210,6 +218,7 @@ export class VoiceTurnController {
 		// Barge-in controller takes the VAD directly so it can pause/resume TTS
 		// while the agent is speaking; the scheduler already listens to its
 		// `onSignal` stream.
+		this.bargeIn.setInterruptGate(this.deps.bargeInInterruptGate ?? null);
 		this.bargeIn.bindVad(this.deps.vad);
 		this.bargeSignalUnsub = this.bargeIn.onSignal((signal) => {
 			if (signal.type !== "hard-stop") return;
@@ -238,6 +247,7 @@ export class VoiceTurnController {
 		this.bargeIn.unbindVad();
 		this.bargeSignalUnsub?.();
 		this.bargeSignalUnsub = null;
+		this.bargeIn.setInterruptGate(null);
 		this.abortSpeculative();
 		if (
 			this.activeFinalController &&
@@ -315,9 +325,20 @@ export class VoiceTurnController {
 					wordCount: event.words.length,
 					partialText: event.words.join(" "),
 					timestampMs: Date.now(),
+					evidence: this.bargeInEvidenceForWords(event),
 				});
 				break;
 		}
+	}
+
+	private bargeInEvidenceForWords(
+		event: Extract<TranscriberEvent, { kind: "words" }>,
+	): Partial<BargeInInterruptEvidence> {
+		const update = event.update ?? this.latestUpdate;
+		return {
+			...voiceRequestMetadata(update),
+			...event.evidence,
+		};
 	}
 
 	// --- prewarm -----------------------------------------------------------

--- a/plugins/plugin-local-inference/src/services/voice/types.ts
+++ b/plugins/plugin-local-inference/src/services/voice/types.ts
@@ -312,7 +312,12 @@ export type TranscriberEvent =
 	 * (`onWordsDetected`) so the agent hard-stops TTS + aborts in-flight
 	 * LLM/drafter generation only on real speech, not a blip.
 	 */
-	| { kind: "words"; words: string[] };
+	| {
+			kind: "words";
+			words: string[];
+			update?: TranscriptUpdate;
+			evidence?: Partial<BargeInInterruptEvidence>;
+	  };
 
 export type TranscriberEventListener = (event: TranscriberEvent) => void;
 
@@ -521,11 +526,41 @@ export interface BargeInCancelToken {
 	readonly signal: AbortSignal;
 }
 
+export type BargeInInterruptDecision =
+	| { allow: true; reason?: string }
+	| { allow: false; reason: string };
+
+export interface BargeInInterruptEvidence {
+	wordCount: number;
+	partialText: string;
+	timestampMs: number;
+	source?: VoiceInputSource;
+	speaker?: VoiceSpeaker;
+	segments?: VoiceSegment[];
+	turn?: VoiceTurnMetadata;
+	wakeWordActive?: boolean;
+	knownSpeakerEntityIds?: readonly string[];
+	selfVoiceSimilarity?: number;
+	selfVoiceThreshold?: number;
+	recentAgentReply?: string;
+	replyAgeMs?: number;
+	agentSpeaking?: boolean;
+}
+
+export type BargeInInterruptGate = (
+	evidence: BargeInInterruptEvidence,
+) => BargeInInterruptDecision | Promise<BargeInInterruptDecision>;
+
 /** Signal emitted by `BargeInController` to the scheduler / engine. */
 export type BargeInSignal =
 	| { type: "pause-tts"; timestampMs: number }
-	| { type: "resume-tts"; timestampMs: number }
-	| { type: "hard-stop"; timestampMs: number; token: BargeInCancelToken };
+	| { type: "resume-tts"; timestampMs: number; reason?: string }
+	| {
+			type: "hard-stop";
+			timestampMs: number;
+			token: BargeInCancelToken;
+			reason?: string;
+	  };
 
 export type BargeInSignalListener = (signal: BargeInSignal) => void;
 
@@ -544,6 +579,7 @@ export interface WordsDetectedSink {
 		/** Best partial transcript so far (may be empty). */
 		partialText: string;
 		timestampMs: number;
+		evidence?: Partial<BargeInInterruptEvidence>;
 	}): void;
 }
 

--- a/plugins/plugin-local-inference/src/services/voice/voice.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice.test.ts
@@ -439,7 +439,8 @@ describe("VoiceScheduler end-to-end", () => {
 
 			expect(sink.totalWritten()).toBeGreaterThan(0);
 			expect(sched.bargeIn.isAgentSpeaking).toBe(true);
-			await vi.advanceTimersByTimeAsync(100);
+			vi.advanceTimersByTime(100);
+			await Promise.resolve();
 			expect(sched.bargeIn.isAgentSpeaking).toBe(false);
 		} finally {
 			vi.useRealTimers();
@@ -466,7 +467,8 @@ describe("VoiceScheduler end-to-end", () => {
 			await sched.accept(tok(0, "Hello"));
 			expect(phraseEvents).toHaveLength(0);
 
-			await vi.advanceTimersByTimeAsync(51);
+			vi.advanceTimersByTime(51);
+			await Promise.resolve();
 			await sched.waitIdle();
 
 			expect(phraseEvents.map((p) => p.text)).toEqual(["Hello"]);
@@ -734,6 +736,69 @@ describe("VoiceScheduler end-to-end", () => {
 		expect(sched.ttsPaused).toBe(false);
 		expect(resumed).toHaveLength(1);
 		expect(sink.totalWritten()).toBeGreaterThan(0);
+	});
+
+	it("denied self-echo barge-in resumes buffered TTS without replay or hard-stop", async () => {
+		const backend = new FakeBackend();
+		const sink = new InMemoryAudioSink();
+		let cancels = 0;
+		const resumed: number[] = [];
+		const sched = new VoiceScheduler(
+			{
+				chunkerConfig: { maxTokensPerPhrase: 10 },
+				preset: makePreset(),
+				ringBufferCapacity: 4096,
+				sampleRate: 24000,
+			},
+			{ backend, sink },
+			{
+				onCancel: () => cancels++,
+				onTtsResume: () => resumed.push(1),
+			},
+		);
+		const listeners = new Set<(e: VadEvent) => void>();
+		sched.bargeIn.bindVad({
+			onVadEvent: (l) => {
+				listeners.add(l);
+				return () => listeners.delete(l);
+			},
+		});
+		sched.bargeIn.setInterruptGate((evidence) =>
+			evidence.selfVoiceSimilarity && evidence.selfVoiceSimilarity >= 0.8
+				? { allow: false, reason: "self-echo" }
+				: { allow: true },
+		);
+		sched.bargeIn.setAgentSpeaking(true);
+		const emit = (e: VadEvent) => {
+			for (const l of listeners) l(e);
+		};
+
+		emit({
+			type: "speech-active",
+			timestampMs: 1,
+			probability: 0.9,
+			speechDurationMs: 100,
+		});
+		await sched.accept(tok(0, "Stay"));
+		await sched.accept(tok(1, " smooth"));
+		await sched.accept(tok(2, "."));
+		await sched.waitIdle();
+		const buffered = sched.ringBuffer.size();
+		expect(buffered).toBeGreaterThan(0);
+		expect(sink.totalWritten()).toBe(0);
+
+		sched.bargeIn.onWordsDetected({
+			wordCount: 2,
+			partialText: "echo words",
+			timestampMs: 2,
+			evidence: { selfVoiceSimilarity: 0.92 },
+		});
+
+		expect(cancels).toBe(0);
+		expect(resumed).toHaveLength(1);
+		expect(sched.ttsPaused).toBe(false);
+		expect(sched.ringBuffer.size()).toBe(0);
+		expect(sink.totalWritten()).toBe(buffered);
 	});
 
 	it("hard-stop barge-in drains the ring buffer and cancels in-flight TTS", async () => {


### PR DESCRIPTION
## Summary
- add an optional BargeInInterruptGate so ASR-confirmed speech can be denied as self-echo/bystander audio and resume TTS instead of hard-stopping
- thread transcript, speaker, wake-word, and turn metadata through VoiceTurnController into the barge-in gate
- add deny-resume scheduler coverage proving buffered TTS resumes without replay, skip, or cancellation while wake-word barge-in still hard-stops

Fixes #12890

## Evidence
- Added evidence under `.github/issue-evidence/12890-barge-in-deny-resume/`
- `bunx biome check plugins/plugin-local-inference/src/services/voice/types.ts plugins/plugin-local-inference/src/services/voice/barge-in.ts plugins/plugin-local-inference/src/services/voice/barge-in.test.ts plugins/plugin-local-inference/src/services/voice/turn-controller.ts plugins/plugin-local-inference/src/services/voice/turn-controller.test.ts plugins/plugin-local-inference/src/services/voice/voice.test.ts` - passed
- `bun test plugins/plugin-local-inference/src/services/voice/barge-in.test.ts plugins/plugin-local-inference/src/services/voice/turn-controller.test.ts plugins/plugin-local-inference/src/services/voice/voice.test.ts` - passed, 75 tests
- `bun test plugins/plugin-local-inference/src/services/voice/e2e-harness.test.ts plugins/plugin-local-inference/src/services/voice/workbench-headless-runner.test.ts plugins/plugin-local-inference/src/services/voice/workbench-logic-services.test.ts` - passed, 45 tests; covers scoreBargeInInterruption, scorePauseContinuation, scoreBargeInGating, echo rejection, ERLE, and speaker-gated workbench scenarios
- `bun run --cwd plugins/plugin-local-inference typecheck` - passed
- `bun run --cwd plugins/plugin-local-inference voice:workbench --mock --out ../../.github/issue-evidence/12890-barge-in-deny-resume/workbench-mock` - passed, 24 ran, 0 skipped; speaker-gated-barge-in passed with 120 ms cancel latency
- `bun run --cwd plugins/plugin-local-inference voice:workbench --logic --out ../../.github/issue-evidence/12890-barge-in-deny-resume/workbench-logic` - passed, 24 ran, 0 skipped; speaker-gated-barge-in and echo scenarios passed with 120 ms cancel latency
- `git fetch origin && git rebase origin/develop && bun install` - passed
- `bun run verify` - blocked by unrelated baseline lint failures in `@elizaos/tui#lint`; the run also surfaced pre-existing `@elizaos/capacitor-llama` lint diagnostics before Turbo stopped. No touched #12890 files failed.

## Real-audio lane
- `bun run --cwd plugins/plugin-local-inference voice:workbench --real --out ../../.github/issue-evidence/12890-barge-in-deny-resume/workbench-real` - N/A in this checkout because `ELIZA_ASR_BUNDLE` is missing at `/Users/shawwalters/.eliza/local-inference/models/eliza-1-2b.bundle`; the workbench exits before running without that local artifact.
