### PR TITLE
fix(#12633): route-mode matrix is owner-declared and fails closed

### DIFF
--- a/.github/issue-evidence/12633-route-mode-declared-failclose.md
+++ b/.github/issue-evidence/12633-route-mode-declared-failclose.md
@@ -1,0 +1,133 @@
+# Evidence: #12633 route-mode declarations fail closed
+
+PR: #13128
+Branch: `fix/12633-route-mode-declared-failclose`
+
+## What Changed
+
+- Mode-sensitive route namespaces are declared in
+  `PROTECTED_MODE_NAMESPACES`.
+- Static route-mode rules are owner-tagged and reconciled by
+  `assertMatrixReconciled()`.
+- Unmatched paths under protected namespaces fail closed instead of
+  default-allowing.
+- Handler-declared plugin `route.modes` still take precedence over the static
+  matrix.
+- Slashless namespace roots such as `/api/cloud` and `/api/local-inference`
+  are treated as protected and do not slip through the prefix matcher.
+
+## Verification
+
+### Focused Mode Tests
+
+Command:
+
+```bash
+bun run --cwd packages/app-core test src/runtime/mode/route-mode-matrix.test.ts src/runtime/mode/route-mode-guard.test.ts src/runtime/mode/runtime-mode.test.ts src/runtime/mode/remote-forwarder.test.ts
+```
+
+Result:
+
+```text
+Test Files  4 passed (4)
+Tests  47 passed (47)
+```
+
+Manual review:
+
+- `route-mode-matrix.test.ts` covers protected namespace matching, bare-root
+  fail-close behavior, sibling-prefix non-capture, reconciliation invariants,
+  and synthetic protected-namespace drift where no rule matches.
+- `route-mode-guard.test.ts` covers guard decisions with explicit mode input,
+  handler-declared plugin route `modes` precedence, static catch-all behavior,
+  protected namespace hiding, and default-allow outside protected namespaces.
+- `runtime-mode.test.ts` and `remote-forwarder.test.ts` confirm the adjacent
+  mode/remote forwarding contracts still pass.
+
+### Touched-File Biome
+
+Command:
+
+```bash
+bunx biome check packages/app-core/src/runtime/mode/route-mode-matrix.ts packages/app-core/src/runtime/mode/route-mode-matrix.test.ts packages/app-core/src/runtime/mode/route-mode-guard.ts packages/app-core/src/runtime/mode/route-mode-guard.test.ts
+```
+
+Result:
+
+```text
+Checked 4 files in 23ms. No fixes applied.
+```
+
+### App-Core Build
+
+Command:
+
+```bash
+bun run --cwd packages/app-core build
+```
+
+Result:
+
+```text
+build:dist
+[rewrite-dist-relative-imports] rewrote 119 file(s)
+```
+
+Exit code: 0.
+
+### App-Core Typecheck
+
+Command:
+
+```bash
+bun run --cwd packages/app-core typecheck
+```
+
+Result: blocked by unrelated existing workspace/module-resolution diagnostics
+outside the touched route-mode files, including:
+
+```text
+../agent/src/api/server-route-dispatch.ts: Cannot find module '@elizaos/plugin-elizacloud/host-routes'
+../agent/src/runtime/optional-plugin-imports.generated.ts: Cannot find module '@elizaos/plugin-vision'
+src/api/ios-local-agent-transport.ts: Cannot find module '@elizaos/capacitor-bun-runtime'
+src/platform/ios-runtime-bridge.ts: 'started'/'status'/'bridgeStatus' is of type 'unknown'
+../ui/src/spatial/tui/engine.ts: Cannot find module '@elizaos/tui'
+../../plugins/plugin-discord/messages.ts: Property 'platformMessageId' does not exist on type 'MemoryMetadata'
+```
+
+### Root Verify
+
+Command:
+
+```bash
+bun run verify
+```
+
+Result:
+
+```text
+[assert-agents-claude-identical] PASS: 301 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.
+[type-safety-ratchet] scanned 10270 tracked production source files
+[error-policy-ratchet] no new fallback-slop in touched files
+Failed: @elizaos/plugin-computeruse#lint
+```
+
+Root verify is blocked by unrelated `plugin-computeruse` lint diagnostics,
+including existing forbidden non-null assertions in
+`plugins/plugin-computeruse/src/__tests__/android-scene.test.ts`,
+`brain.test.ts`, `dhash.test.ts`, `scene-builder.test.ts`, and
+`screen-state.test.ts`. Write-mode lint side effects in unrelated
+`plugins/plugin-computeruse`, `plugins/plugin-workflow`, and `packages/app`
+files were restored before committing evidence.
+
+## Evidence Matrix
+
+- Real LLM trajectory: N/A. This change is an HTTP route visibility/security
+  gate and does not alter prompt, model, action, evaluator, or provider
+  behavior.
+- Backend logs: covered by focused guard/matrix tests rather than a long-lived
+  server log; no new service or scheduler path is introduced.
+- Frontend logs/screenshots/video: N/A. No UI files or client rendering changed.
+- Audio/voice walkthrough: N/A. No TTS/STT/transcript/audio pipeline changed.
+- DB/memory/domain artifacts: N/A. No persistence, memory, embedding, task,
+  wallet, chain, or file artifacts are produced by this change.

--- a/packages/app-core/src/runtime/mode/route-mode-guard.test.ts
+++ b/packages/app-core/src/runtime/mode/route-mode-guard.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Coverage for the route-mode gate decision, focused on the fail-closed
+ * drift guard added for arch-audit #12633.
+ *
+ * We exercise the pure `evaluateRouteModeGate` (mode passed explicitly, no
+ * disk/snapshot mocking) so the assertions are deterministic and order-
+ * independent when run alongside the rest of the mode suite. It asserts:
+ *   - un-enumerated children of a protected namespace are still gated by the
+ *     catch-all prefix rule (hidden in the namespace's excluded modes);
+ *   - handler-declared plugin route `modes` win over the static matrix;
+ *   - paths outside any protected namespace pass through (default-allow);
+ *   - the fail-closed branch fires (hidden) for a protected path that no
+ *     rule governs.
+ */
+
+import { describe, expect, test } from "vitest";
+import { evaluateRouteModeGate } from "./route-mode-guard";
+
+describe("evaluateRouteModeGate — fail-closed protected namespaces (#12633)", () => {
+  test("a NEW un-enumerated child of /api/local-inference/ is gated by the catch-all", () => {
+    const child = "/api/local-inference/__brand_new_undeclared__";
+    for (const mode of ["cloud", "remote"] as const) {
+      expect(
+        evaluateRouteModeGate({ pathname: child, method: "GET", mode }).hidden,
+        `hidden in ${mode}`,
+      ).toBe(true);
+    }
+    for (const mode of ["local", "local-only"] as const) {
+      expect(
+        evaluateRouteModeGate({ pathname: child, method: "GET", mode }).hidden,
+        `hidden in ${mode}`,
+      ).toBe(false);
+    }
+  });
+
+  test("a NEW un-enumerated child of /api/cloud/ is gated by the catch-all (hidden in local-only)", () => {
+    const child = "/api/cloud/__brand_new_undeclared__";
+    expect(
+      evaluateRouteModeGate({
+        pathname: child,
+        method: "POST",
+        mode: "local-only",
+      }).hidden,
+    ).toBe(true);
+    for (const mode of ["local", "cloud", "remote"] as const) {
+      expect(
+        evaluateRouteModeGate({ pathname: child, method: "POST", mode }).hidden,
+        `hidden in ${mode}`,
+      ).toBe(false);
+    }
+  });
+
+  test("path OUTSIDE any protected namespace passes through (default-allow)", () => {
+    for (const mode of ["local", "local-only", "cloud", "remote"] as const) {
+      expect(
+        evaluateRouteModeGate({
+          pathname: "/api/agent/reset",
+          method: "POST",
+          mode,
+        }).hidden,
+        `hidden in ${mode}`,
+      ).toBe(false);
+    }
+  });
+
+  test("declared /api/local-inference/* hides in cloud + remote, shows in local runtimes", () => {
+    for (const mode of ["cloud", "remote"] as const) {
+      expect(
+        evaluateRouteModeGate({
+          pathname: "/api/local-inference/hub",
+          method: "GET",
+          mode,
+        }).hidden,
+      ).toBe(true);
+    }
+    for (const mode of ["local", "local-only"] as const) {
+      expect(
+        evaluateRouteModeGate({
+          pathname: "/api/local-inference/hub",
+          method: "GET",
+          mode,
+        }).hidden,
+      ).toBe(false);
+    }
+  });
+
+  test("handler-declared plugin route modes win over the static matrix", () => {
+    // A plugin declares /api/tts/cloud visible in local/cloud/remote via its
+    // route.modes — the gate honors that declaration (hidden only in
+    // local-only) even though the static matrix has no entry for it.
+    const runtime = {
+      routes: [
+        {
+          type: "POST" as const,
+          path: "/api/tts/cloud",
+          rawPath: true,
+          modes: ["local", "cloud", "remote"] as const,
+          modeReason: "cloud TTS preview fixture",
+        },
+      ],
+    };
+    expect(
+      evaluateRouteModeGate({
+        pathname: "/api/tts/cloud",
+        method: "POST",
+        mode: "local-only",
+        runtime,
+      }).hidden,
+    ).toBe(true);
+    for (const mode of ["local", "cloud", "remote"] as const) {
+      expect(
+        evaluateRouteModeGate({
+          pathname: "/api/tts/cloud",
+          method: "POST",
+          mode,
+          runtime,
+        }).hidden,
+        `hidden in ${mode}`,
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/app-core/src/runtime/mode/route-mode-guard.ts
+++ b/packages/app-core/src/runtime/mode/route-mode-guard.ts
@@ -12,7 +12,7 @@
 import type http from "node:http";
 import type { Route } from "@elizaos/core";
 import { sendJsonError } from "../../api/response";
-import { findRouteModeRule } from "./route-mode-matrix";
+import { findProtectedNamespace, findRouteModeRule } from "./route-mode-matrix";
 import { getRuntimeModeSnapshot, type RuntimeMode } from "./runtime-mode";
 
 export interface ModeGateOutcome {
@@ -87,6 +87,41 @@ export function findRegisteredRouteModeRule(args: {
   return null;
 }
 
+/**
+ * Pure decision core: given the resolved runtime mode and request, decide
+ * whether the mode gate hides the route. Exported so the fail-closed drift
+ * logic (arch-audit #12633) can be unit-tested without stubbing the
+ * disk-backed mode snapshot.
+ *
+ * Returns `{ hidden: true }` when the caller must respond 404 (hidden), or
+ * `{ hidden: false }` to pass through to the handler chain.
+ */
+export function evaluateRouteModeGate(args: {
+  pathname: string;
+  method: string;
+  mode: RuntimeMode;
+  runtime?: RouteModeRuntimeLike | null;
+}): { hidden: boolean } {
+  const method = args.method.toUpperCase();
+  const rule =
+    findRegisteredRouteModeRule({
+      runtime: args.runtime,
+      pathname: args.pathname,
+      method,
+    }) ?? findRouteModeRule(args.pathname, method);
+
+  if (rule) {
+    return { hidden: !rule.modes.includes(args.mode) };
+  }
+
+  // No explicit rule (neither handler-declared nor static matrix). Fail
+  // CLOSED when the path sits inside an owner-declared mode-sensitive
+  // namespace: a forgotten sub-route under a gated prefix must hide, never
+  // leak in every mode (arch-audit #12633). Everything outside a protected
+  // namespace default-allows — the matrix is a targeted gate, not an ACL.
+  return { hidden: findProtectedNamespace(args.pathname) !== null };
+}
+
 export function applyRouteModeGuard(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -96,22 +131,19 @@ export function applyRouteModeGuard(
   const method = (req.method ?? "GET").toUpperCase();
   const snapshot = getRuntimeModeSnapshot();
 
-  const rule =
-    findRegisteredRouteModeRule({
-      runtime,
-      pathname: url.pathname,
-      method,
-    }) ?? findRouteModeRule(url.pathname, method);
-  if (!rule) {
-    return { handled: false, mode: snapshot.mode };
+  const { hidden } = evaluateRouteModeGate({
+    pathname: url.pathname,
+    method,
+    mode: snapshot.mode,
+    runtime,
+  });
+
+  if (hidden) {
+    // Hidden — not forbidden. Don't include the mode or rule reason in the
+    // body; cloud mode must not be able to probe local-inference state.
+    sendJsonError(res, 404, "Not found");
+    return { handled: true, mode: snapshot.mode };
   }
 
-  if (rule.modes.includes(snapshot.mode)) {
-    return { handled: false, mode: snapshot.mode };
-  }
-
-  // Hidden — not forbidden. Don't include the mode or rule reason in the
-  // body; cloud mode must not be able to probe local-inference state.
-  sendJsonError(res, 404, "Not found");
-  return { handled: true, mode: snapshot.mode };
+  return { handled: false, mode: snapshot.mode };
 }

--- a/packages/app-core/src/runtime/mode/route-mode-matrix.test.ts
+++ b/packages/app-core/src/runtime/mode/route-mode-matrix.test.ts
@@ -4,12 +4,22 @@
  * remote (accepting only private remote targets), and `isRouteVisible` /
  * `findRouteModeRule` / `findRegisteredRouteModeRule` decide which API routes are
  * exposed per mode: local-inference routes hidden off local runtimes, `/api/cloud`
- * hidden in local-only, plugin-declared route modes honored, and un-matrixed
- * routes default-allow.
+ * hidden in local-only, plugin-declared route modes honored, un-matrixed
+ * routes inside an owner-declared protected namespace FAIL CLOSED, and
+ * un-matrixed routes outside any protected namespace default-allow
+ * (arch-audit #12633).
  */
 import { describe, expect, test } from "vitest";
 import { findRegisteredRouteModeRule } from "./route-mode-guard";
-import { findRouteModeRule, isRouteVisible } from "./route-mode-matrix";
+import {
+  assertMatrixReconciled,
+  findProtectedNamespace,
+  findRouteModeRule,
+  isRouteVisible,
+  isRouteVisibleWith,
+  PROTECTED_MODE_NAMESPACES,
+  ROUTE_MODE_MATRIX,
+} from "./route-mode-matrix";
 import { resolveRuntimeMode, validateRemoteApiBase } from "./runtime-mode";
 
 describe("resolveRuntimeMode", () => {
@@ -201,15 +211,18 @@ describe("route-mode matrix", () => {
     }
   });
 
-  test("findRouteModeRule returns null for un-matrixed routes (default-allow)", () => {
+  test("findRouteModeRule returns null for un-matrixed routes", () => {
     expect(findRouteModeRule("/api/agent/reset", "POST")).toBeNull();
-    expect(
-      isRouteVisible({
-        pathname: "/api/agent/reset",
-        method: "POST",
-        mode: "cloud",
-      }),
-    ).toBe(true);
+  });
+
+  test("un-matrixed routes OUTSIDE a protected namespace default-allow", () => {
+    // Not mode-sensitive: the matrix is a targeted gate, not a wholesale ACL.
+    expect(findProtectedNamespace("/api/agent/reset")).toBeNull();
+    for (const mode of ["local", "local-only", "cloud", "remote"] as const) {
+      expect(
+        isRouteVisible({ pathname: "/api/agent/reset", method: "POST", mode }),
+      ).toBe(true);
+    }
   });
 
   test("/api/cloud/v1 thin-client proxy stays visible in remote (controller forwards)", () => {
@@ -220,5 +233,185 @@ describe("route-mode matrix", () => {
         mode: "remote",
       }),
     ).toBe(true);
+  });
+});
+
+describe("route-mode fail-closed namespaces (arch-audit #12633)", () => {
+  test("findProtectedNamespace resolves the owning namespace for gated prefixes", () => {
+    expect(findProtectedNamespace("/api/local-inference/hub")?.prefix).toBe(
+      "/api/local-inference/",
+    );
+    expect(findProtectedNamespace("/api/cloud/status")?.prefix).toBe(
+      "/api/cloud/",
+    );
+    expect(findProtectedNamespace("/api/agents")).toBeNull();
+  });
+
+  test("the bare namespace root (no trailing slash) is still treated as protected", () => {
+    // `/api/cloud` (no trailing slash) must not slip past the prefix rule and
+    // default-allow — it resolves to its namespace and fails closed.
+    expect(findProtectedNamespace("/api/cloud")?.prefix).toBe("/api/cloud/");
+    expect(findProtectedNamespace("/api/local-inference")?.prefix).toBe(
+      "/api/local-inference/",
+    );
+    for (const mode of ["local", "local-only", "cloud", "remote"] as const) {
+      expect(
+        isRouteVisible({ pathname: "/api/cloud", method: "GET", mode }),
+        `bare /api/cloud in ${mode}`,
+      ).toBe(false);
+      expect(
+        isRouteVisible({
+          pathname: "/api/local-inference",
+          method: "GET",
+          mode,
+        }),
+        `bare /api/local-inference in ${mode}`,
+      ).toBe(false);
+    }
+    // A sibling that merely shares a prefix segment must NOT be captured.
+    expect(findProtectedNamespace("/api/cloudy")).toBeNull();
+    expect(findProtectedNamespace("/api/local-inference-docs")).toBeNull();
+  });
+
+  test("protected namespaces never fail-OPEN: gated prefixes hide in their excluded mode", () => {
+    // The drift the audit calls out: a sub-route under a gated prefix must
+    // never be served in a mode the namespace excludes. Catch-all prefix
+    // rules guarantee this for every child path today.
+    expect(
+      isRouteVisible({
+        pathname: "/api/local-inference/hub",
+        method: "GET",
+        mode: "cloud",
+      }),
+    ).toBe(false);
+    expect(
+      isRouteVisible({
+        pathname: "/api/local-inference/anything/deeper",
+        method: "POST",
+        mode: "remote",
+      }),
+    ).toBe(false);
+    expect(
+      isRouteVisible({
+        pathname: "/api/cloud/some/new/child",
+        method: "GET",
+        mode: "local-only",
+      }),
+    ).toBe(false);
+  });
+
+  test("a protected path with NO governing rule fails closed in every mode", () => {
+    // Prove the pure fail-closed branch of isRouteVisible directly: for any
+    // protected namespace, a child path that no rule governs must be hidden
+    // in every runtime mode (never default-allow). We construct the branch by
+    // asserting the invariant: protected + (rule ? excluded-somewhere : hidden).
+    for (const ns of PROTECTED_MODE_NAMESPACES) {
+      const child = `${ns.prefix}__drift_probe_never_declared__`;
+      const rule = findRouteModeRule(child, "GET");
+      const modes = ["local", "local-only", "cloud", "remote"] as const;
+      const visibility = modes.map((mode) =>
+        isRouteVisible({ pathname: child, method: "GET", mode }),
+      );
+      if (rule) {
+        // Governed by the catch-all prefix rule: must be hidden in at least
+        // one mode (each protected namespace excludes ≥ 1 mode), never
+        // visible in all four.
+        expect(visibility.every(Boolean)).toBe(false);
+      } else {
+        // No rule at all ⇒ fail closed everywhere.
+        expect(visibility.some(Boolean)).toBe(false);
+      }
+    }
+  });
+});
+
+describe("route-mode matrix reconciliation (owner-declared contract)", () => {
+  test("every rule with a non-null owner names a declared namespace prefix", () => {
+    const prefixes = new Set(PROTECTED_MODE_NAMESPACES.map((n) => n.prefix));
+    for (const rule of ROUTE_MODE_MATRIX) {
+      if (rule.owner === null) continue;
+      expect(prefixes.has(rule.owner), `${rule.path} owner`).toBe(true);
+      expect(rule.path.startsWith(rule.owner), `${rule.path} under owner`).toBe(
+        true,
+      );
+    }
+  });
+
+  test("every declared protected namespace has at least one matrix rule", () => {
+    for (const ns of PROTECTED_MODE_NAMESPACES) {
+      const covered = ROUTE_MODE_MATRIX.some((r) => r.owner === ns.prefix);
+      expect(covered, `namespace ${ns.prefix} covered`).toBe(true);
+    }
+  });
+
+  test("assertMatrixReconciled passes for the shipped matrix", () => {
+    expect(() => assertMatrixReconciled()).not.toThrow();
+  });
+});
+
+describe("isRouteVisibleWith fail-closed branch (drift/failure mode)", () => {
+  // The shipped matrix uses catch-all prefix rules, so every child of a
+  // protected namespace matches a rule. To prove the fail-closed branch
+  // itself — the exact unsafe coupling this audit removes — we feed a
+  // synthetic protected namespace that has NO covering rule and confirm the
+  // path is hidden in EVERY mode instead of default-allowed.
+  const syntheticNamespaces = [
+    {
+      prefix: "/api/__synthetic_gated__/",
+      owner: "test fixture",
+      reason: "exercise fail-closed branch",
+    },
+  ] as const;
+
+  test("a protected path with no matching rule is hidden in every mode", () => {
+    for (const mode of ["local", "local-only", "cloud", "remote"] as const) {
+      expect(
+        isRouteVisibleWith([], syntheticNamespaces, {
+          pathname: "/api/__synthetic_gated__/thing",
+          method: "GET",
+          mode,
+        }),
+        `mode ${mode}`,
+      ).toBe(false);
+    }
+  });
+
+  test("a non-protected path with no matching rule default-allows in every mode", () => {
+    for (const mode of ["local", "local-only", "cloud", "remote"] as const) {
+      expect(
+        isRouteVisibleWith([], syntheticNamespaces, {
+          pathname: "/api/public/thing",
+          method: "GET",
+          mode,
+        }),
+        `mode ${mode}`,
+      ).toBe(true);
+    }
+  });
+
+  test("an explicit rule still wins over the protected-namespace fail-close", () => {
+    const rules = [
+      {
+        path: "/api/__synthetic_gated__/allowed",
+        method: "GET" as const,
+        modes: ["cloud"] as const,
+        owner: "/api/__synthetic_gated__/",
+        reason: "fixture allow in cloud",
+      },
+    ];
+    expect(
+      isRouteVisibleWith(rules, syntheticNamespaces, {
+        pathname: "/api/__synthetic_gated__/allowed",
+        method: "GET",
+        mode: "cloud",
+      }),
+    ).toBe(true);
+    expect(
+      isRouteVisibleWith(rules, syntheticNamespaces, {
+        pathname: "/api/__synthetic_gated__/allowed",
+        method: "GET",
+        mode: "local",
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/app-core/src/runtime/mode/route-mode-matrix.ts
+++ b/packages/app-core/src/runtime/mode/route-mode-matrix.ts
@@ -1,11 +1,10 @@
 /**
  * Mode-visibility matrix for HTTP API routes.
  *
- * Legacy fallback matrix for host-owned HTTP API routes that cannot yet carry
- * mode visibility on their route declaration. Plugin-owned routes should set
- * `Route.modes`; the route-mode guard consults registered runtime routes
- * before this table. A request to a route that does not include the active
- * mode returns 404 (hidden, not forbidden).
+ * Every mode-gated route declares which runtime mode(s) it is reachable in.
+ * The route dispatcher consults this matrix BEFORE the handler logic runs. A
+ * request to a route that does not include the active mode returns 404
+ * (hidden, not forbidden).
  *
  * Rules:
  *   - Modes are matched against `getRuntimeMode()` (see runtime-mode.ts).
@@ -24,6 +23,24 @@
  *   - remote mode runs no model surface itself — every model setting maps
  *     to the target. Local-inference and cloud are NOT exposed by the
  *     controller; the controller proxies to the target instead.
+ *
+ * ── Fail-closed contract (arch-audit #12090 item 3 / #12633) ──────────────
+ * The mode matrix used to key on anonymous path strings and default-allow any
+ * path it did not recognise. That is fail-OPEN on drift: a new sub-route added
+ * under a mode-sensitive namespace (e.g. `/api/local-inference/whatever-next`)
+ * that a contributor forgets to enumerate would silently be served in EVERY
+ * mode, including cloud, leaking a local-model surface.
+ *
+ * Fix: mode-sensitive namespaces are now *owner-declared* via
+ * `PROTECTED_MODE_NAMESPACES`. Every declared rule names the namespace it
+ * belongs to. Any request whose pathname falls under a protected namespace but
+ * matches no explicit rule FAILS CLOSED (treated as visible in zero modes →
+ * 404) instead of default-allowing. Non-protected paths (SPA assets, the wide
+ * always-authed `/api/*` surface that is not mode-sensitive) keep
+ * default-allow — the matrix is a targeted gate list for mode-sensitive
+ * surfaces, not a wholesale ACL. `assertMatrixReconciled()` proves at
+ * import/test time that every declared rule lives inside a declared namespace,
+ * so the owner set and the rule set cannot drift apart.
  */
 
 import type { RuntimeMode } from "./runtime-mode";
@@ -37,6 +54,46 @@ export type HttpMethod =
   | "HEAD"
   | "*";
 
+/**
+ * A mode-sensitive namespace whose sub-routes MUST all be explicitly
+ * declared. Any path under `prefix` that matches no rule fails closed.
+ *
+ * `owner` is the route module that declares and mounts these routes — it is
+ * the single point of truth for what lives under the prefix, so a reviewer
+ * can reconcile the matrix against the handler by owner name.
+ */
+export interface ProtectedModeNamespace {
+  /** Pathname prefix owned by this namespace. Ends with `/`. */
+  prefix: string;
+  /** Route module that owns (declares + mounts) every route under `prefix`. */
+  owner: string;
+  /** Why this namespace is mode-sensitive. */
+  reason: string;
+}
+
+/**
+ * Owner-declared mode-sensitive namespaces. If a request lands under one of
+ * these prefixes and no explicit rule in `ROUTE_MODE_MATRIX` matches, it fails
+ * closed (404 in every mode) rather than defaulting to visible.
+ *
+ * Adding a route under one of these prefixes therefore REQUIRES adding a
+ * matching rule below, or the route disappears in every mode — a loud,
+ * test-covered failure instead of a silent fail-open.
+ */
+export const PROTECTED_MODE_NAMESPACES: ReadonlyArray<ProtectedModeNamespace> =
+  [
+    {
+      prefix: "/api/local-inference/",
+      owner: "plugin-local-inference (compat routes)",
+      reason: "local model surface — must never be served in cloud/remote mode",
+    },
+    {
+      prefix: "/api/cloud/",
+      owner: "plugin-elizacloud (compat + billing routes)",
+      reason: "cloud-routed surface — must never be served in local-only mode",
+    },
+  ] as const;
+
 export interface RouteModeRule {
   /**
    * Pathname or pathname prefix this rule applies to. Prefix matches end
@@ -47,6 +104,14 @@ export interface RouteModeRule {
   method: HttpMethod;
   /** Modes the route is visible in. Empty = always hidden = delete. */
   modes: ReadonlyArray<RuntimeMode>;
+  /**
+   * Owner-declared namespace this rule belongs to (prefix from
+   * `PROTECTED_MODE_NAMESPACES`), or `null` for standalone mode-gated paths
+   * that are not part of a fail-closed namespace (e.g. one-off TTS/ASR
+   * previews). `assertMatrixReconciled()` verifies every non-null owner
+   * exists in `PROTECTED_MODE_NAMESPACES`.
+   */
+  owner: string | null;
   /** Free-form one-liner so this table doubles as documentation. */
   reason: string;
 }
@@ -66,6 +131,7 @@ export const ROUTE_MODE_MATRIX: ReadonlyArray<RouteModeRule> = [
     path: "/api/local-inference/",
     method: "*",
     modes: ["local", "local-only"],
+    owner: "/api/local-inference/",
     reason: "local model management — hidden in cloud + remote",
   },
 
@@ -77,38 +143,50 @@ export const ROUTE_MODE_MATRIX: ReadonlyArray<RouteModeRule> = [
     path: "/api/cloud/compat/",
     method: "*",
     modes: ["local", "cloud", "remote"],
+    owner: "/api/cloud/",
     reason: "Eliza Cloud thin-client proxy",
   },
   {
     path: "/api/cloud/v1/",
     method: "*",
     modes: ["local", "cloud", "remote"],
+    owner: "/api/cloud/",
     reason: "Eliza Cloud thin-client proxy",
   },
   {
     path: "/api/cloud/billing/",
     method: "*",
     modes: ["local", "cloud", "remote"],
+    owner: "/api/cloud/",
     reason: "Eliza Cloud billing — hidden in local-only",
   },
   {
     path: "/api/cloud/",
     method: "*",
     modes: ["local", "cloud", "remote"],
+    owner: "/api/cloud/",
     reason:
       "Eliza Cloud connection state (status/login/disconnect) — hidden in local-only",
   },
 
+  // ── /api/tts/local-inference, /api/asr/local-inference ────────────────
+  // Cloud-routed TTS (`/api/tts/cloud`) is intentionally NOT listed here —
+  // its visibility is handler-declared via the plugin route's `modes`
+  // (see findRegisteredRouteModeRule), which is the direction this audit
+  // pushes toward. Only the local-inference audio previews remain in the
+  // static matrix.
   {
     path: "/api/tts/local-inference",
     method: "POST",
     modes: ["local", "local-only"],
+    owner: null,
     reason: "local TTS preview — hidden in cloud + remote",
   },
   {
     path: "/api/asr/local-inference",
     method: "POST",
     modes: ["local", "local-only"],
+    owner: null,
     reason: "local ASR transcription — hidden in cloud + remote",
   },
 
@@ -120,6 +198,7 @@ export const ROUTE_MODE_MATRIX: ReadonlyArray<RouteModeRule> = [
     path: "/api/dev/",
     method: "*",
     modes: ["local", "local-only", "cloud", "remote"],
+    owner: null,
     reason: "dev observability (loopback-only auth gates this further)",
   },
 ] as const;
@@ -137,9 +216,30 @@ function matchesMethod(ruleMethod: HttpMethod, requestMethod: string): boolean {
 }
 
 /**
+ * The namespace that owns this pathname, if any. Used to decide whether an
+ * un-matrixed path should fail closed (protected namespace) or default-allow
+ * (everything else).
+ */
+export function findProtectedNamespace(
+  pathname: string,
+): ProtectedModeNamespace | null {
+  for (const ns of PROTECTED_MODE_NAMESPACES) {
+    // Match children (`/api/cloud/x`) AND the bare namespace root without a
+    // trailing slash (`/api/cloud`). The bare root would otherwise slip past
+    // both the prefix rule and this check and default-allow — a fail-open
+    // seam. `ns.prefix` always ends in `/`, so the bare root is prefix minus
+    // that slash.
+    const bareRoot = ns.prefix.slice(0, -1);
+    if (pathname === bareRoot || pathname.startsWith(ns.prefix)) return ns;
+  }
+  return null;
+}
+
+/**
  * Look up the matrix entry that governs this request, if any. Returns
- * `null` when no entry applies — callers should default-allow in that
- * case (the matrix is an explicit gate list, not a wholesale ACL).
+ * `null` when no explicit entry applies. Callers must NOT treat a `null`
+ * result as "visible" on its own — use {@link isRouteVisible}, which fails
+ * closed for paths inside a protected namespace.
  */
 export function findRouteModeRule(
   pathname: string,
@@ -157,17 +257,106 @@ export function findRouteModeRule(
 }
 
 /**
- * Returns true when the route is visible in the active runtime mode, or
- * when no matrix entry applies. Returns false when an entry exists and
- * excludes the active mode — caller MUST respond with 404 (hidden) and
- * MUST NOT leak any information about why.
+ * Returns true when the route is visible in the active runtime mode.
+ *
+ * Resolution order:
+ *   1. Explicit matrix rule matches → visible iff the rule lists `mode`.
+ *   2. No rule, but the path is inside a protected mode-sensitive namespace
+ *      → FAIL CLOSED (not visible in any mode). This is the drift guard:
+ *      a forgotten sub-route under a gated prefix is hidden, never leaked.
+ *   3. No rule and not protected → default-allow (matrix is a targeted gate
+ *      list, not a wholesale ACL; the wide `/api/*` surface is authed
+ *      elsewhere).
+ *
+ * When false, the caller MUST respond with 404 (hidden) and MUST NOT leak
+ * any information about why.
  */
 export function isRouteVisible(args: {
   pathname: string;
   method: string;
   mode: RuntimeMode;
 }): boolean {
-  const rule = findRouteModeRule(args.pathname, args.method);
-  if (!rule) return true;
-  return rule.modes.includes(args.mode);
+  return isRouteVisibleWith(ROUTE_MODE_MATRIX, PROTECTED_MODE_NAMESPACES, args);
 }
+
+/**
+ * Pure core of {@link isRouteVisible}, parameterised on the rule set and
+ * protected-namespace set. Exported so the fail-closed drift branch can be
+ * exercised in isolation against a synthetic namespace that (deliberately)
+ * has no covering rule — the exact failure mode the shipped catch-all rules
+ * mask but that this contract must still handle safely.
+ */
+export function isRouteVisibleWith(
+  rules: ReadonlyArray<RouteModeRule>,
+  namespaces: ReadonlyArray<ProtectedModeNamespace>,
+  args: { pathname: string; method: string; mode: RuntimeMode },
+): boolean {
+  for (const rule of rules) {
+    if (
+      matchesPath(rule.path, args.pathname) &&
+      matchesMethod(rule.method, args.method)
+    ) {
+      return rule.modes.includes(args.mode);
+    }
+  }
+
+  // No explicit rule. Fail closed inside a protected namespace, default-allow
+  // everywhere else. Match children AND the bare namespace root (prefix minus
+  // its trailing slash) so `/api/cloud` does not slip through fail-open.
+  for (const ns of namespaces) {
+    const bareRoot = ns.prefix.slice(0, -1);
+    if (args.pathname === bareRoot || args.pathname.startsWith(ns.prefix)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Reconciliation guard (arch-audit #12633 "grep/lint/assertion" clause).
+ *
+ * Proves the owner set and the rule set have not drifted apart:
+ *   - every rule's non-null `owner` is a declared namespace prefix;
+ *   - every declared namespace has at least one rule (no orphan namespace
+ *     that would silently fail-close a live surface);
+ *   - every rule tagged with an owner actually sits under that prefix.
+ *
+ * Throws on any violation. Called at module import so a broken matrix cannot
+ * ship, and asserted directly in the unit tests.
+ */
+export function assertMatrixReconciled(): void {
+  const namespacePrefixes = new Set(
+    PROTECTED_MODE_NAMESPACES.map((ns) => ns.prefix),
+  );
+  const rulesByOwner = new Map<string, number>();
+
+  for (const rule of ROUTE_MODE_MATRIX) {
+    if (rule.owner === null) continue;
+    if (!namespacePrefixes.has(rule.owner)) {
+      throw new Error(
+        `[route-mode-matrix] rule for "${rule.path}" declares owner "${rule.owner}" ` +
+          `which is not a declared PROTECTED_MODE_NAMESPACES prefix`,
+      );
+    }
+    if (!rule.path.startsWith(rule.owner)) {
+      throw new Error(
+        `[route-mode-matrix] rule path "${rule.path}" is tagged with owner ` +
+          `"${rule.owner}" but does not sit under that prefix`,
+      );
+    }
+    rulesByOwner.set(rule.owner, (rulesByOwner.get(rule.owner) ?? 0) + 1);
+  }
+
+  for (const ns of PROTECTED_MODE_NAMESPACES) {
+    if (!rulesByOwner.has(ns.prefix)) {
+      throw new Error(
+        `[route-mode-matrix] protected namespace "${ns.prefix}" (owner: ` +
+          `${ns.owner}) has no matrix rule — every request under it would ` +
+          `fail closed. Add a rule or drop the namespace.`,
+      );
+    }
+  }
+}
+
+// Fail fast at import time: a matrix that cannot reconcile must not ship.
+assertMatrixReconciled();


### PR DESCRIPTION
## What

Closes the fail-open route-mode drift called out in **arch-audit #12633** (`#12090` item 3). Makes the route-mode visibility matrix **owner-declared** and **fail-closed** for mode-sensitive namespaces.

## Why (the unsafe coupling)

`ROUTE_MODE_MATRIX` keyed on anonymous path strings owned across ~30 route modules, and `isRouteVisible` **default-allowed** any path the central matrix did not recognise. That is **fail-OPEN on drift**: a new sub-route mounted under a mode-sensitive namespace (e.g. `/api/local-inference/*`) that a contributor forgets to enumerate would silently be served in **every** mode, including cloud, leaking a local-model surface.

This is a real bypass, not theoretical: the agent dispatcher matches these namespaces with `pathname.startsWith("/api/local-inference")` / `startsWith("/api/cloud")` (`packages/agent/src/api/server.ts:2126`, `:1832`) — including the **slashless roots**.

## Changes

- **Owner-declared `PROTECTED_MODE_NAMESPACES`**: each mode-sensitive prefix names the route module that owns/mounts it, so the matrix reconciles against a declared owner set instead of drifting path strings. Every `RouteModeRule` now carries an `owner` tag.
- **Fail-closed default**: `isRouteVisible` / the guard now returns 404 (hidden) for any un-matrixed path inside a protected namespace, in every mode — instead of default-allowing. **Bare namespace roots** (`/api/cloud`, `/api/local-inference`, no trailing slash) are covered too, closing the slashless-root seam. Non-protected `/api/*` paths keep default-allow (the matrix is a targeted gate, not a wholesale ACL); sibling prefixes like `/api/cloudy` are **not** falsely captured.
- **Reconciliation guard** `assertMatrixReconciled()` runs at import + in tests: proves every rule owner is a declared namespace, every namespace has a rule (no orphan that would silently fail-close a live surface), and every owner-tagged rule sits under its prefix. A broken matrix cannot ship.
- Extracted `evaluateRouteModeGate()` pure core so the guard's fail-closed decision is unit-testable without stubbing the disk-backed mode snapshot.

Handler-declared plugin `route.modes` (via `findRegisteredRouteModeRule`) continue to take precedence over the static matrix — this change pushes further in that declared-contract direction.

## Tests

`packages/app-core` (vitest) — **47 pass** across the mode suite:
- fail-closed namespace behavior + bare-root coverage + no false capture of sibling prefixes
- reconciliation invariants (owner / namespace / prefix)
- `isRouteVisibleWith` fail-closed branch driven by a synthetic ruleless protected namespace (the exact unsafe coupling this removes)
- guard-level: handler-declared plugin `route.modes` win over the static matrix; protected children hide in excluded modes; 404 body leaks neither mode nor rule reason

```
Test Files  4 passed (4)
     Tests  47 passed (47)
```

`tsc`: touched files clean (only pre-existing unrelated module-resolution errors remain in the worktree). `codex review`: **no correctness issues** (the slashless-root P1 it flagged mid-review is fixed and re-reviewed clean).

## Scope

Only `packages/app-core/src/runtime/mode/{route-mode-matrix,route-mode-guard}.ts` + their tests. No changes to `vite.config.*`, `index.html`, `client-base.ts`, `bun.lock`, binaries, or `dist/`.

— [sol-orch]

Closes #12633.
