### PR TITLE
fix(#12635): route local-provider detection through declared capability metadata

### DIFF
--- a/.github/issue-evidence/12635-local-provider-capability-metadata.md
+++ b/.github/issue-evidence/12635-local-provider-capability-metadata.md
@@ -1,0 +1,134 @@
+# Evidence: #12635 local provider capability metadata
+
+PR: #13129
+Branch: `fix/12635-local-provider-capability-metadata`
+
+## What Changed
+
+- `ModelRegistrationMetadata` now carries provider-declared `local` and
+  `streamable` capability flags.
+- Action model routing resolves the `LOCAL` strategy through
+  capability-first `isLocalHandler({ provider, metadata })`, with the provider
+  name heuristic retained only as the legacy fallback.
+- Trajectory pricing consumes declared `local` capability and no longer keeps a
+  separate drifting local-provider list.
+- `AgentRuntime.useModel` consumes declared `streamable` capability for the
+  handler-facing stream callback. `streamable: true` opts in even for
+  cloud-looking names; `streamable: false` opts out even for local-looking
+  names. The existing `eliza-router` streaming exception is preserved.
+
+## Verification
+
+### Focused Runtime Tests
+
+Command:
+
+```bash
+bun run --cwd packages/core test src/runtime/__tests__/action-model-routing.test.ts src/features/trajectories/pricing.test.ts src/runtime/__tests__/streaming-use-model.test.ts
+```
+
+Result:
+
+```text
+Test Files  3 passed (3)
+Tests  97 passed (97)
+```
+
+Manual review:
+
+- Routing tests cover declared `metadata.local: true` selecting a
+  cloud-looking provider and `metadata.local: false` excluding a local-looking
+  provider.
+- Pricing tests cover declared local override suppressing missing-price warnings
+  and declared non-local override preserving the warning path.
+- Streaming tests cover `metadata.streamable: true` passing `onStreamChunk` to
+  a cloud-looking provider and `metadata.streamable: false` withholding it from
+  a local-looking provider.
+
+### Typecheck
+
+Command:
+
+```bash
+bun run --cwd packages/core typecheck
+```
+
+Result:
+
+```text
+tsgo --noEmit -p ./tsconfig.json
+```
+
+Exit code: 0.
+
+### Touched-File Biome
+
+Command:
+
+```bash
+bunx biome check packages/core/src/runtime.ts packages/core/src/runtime/action-model-routing.ts packages/core/src/runtime/__tests__/action-model-routing.test.ts packages/core/src/runtime/__tests__/streaming-use-model.test.ts packages/core/src/features/trajectories/pricing.ts packages/core/src/features/trajectories/pricing.test.ts packages/core/src/types/model.ts
+```
+
+Result:
+
+```text
+Checked 7 files in 109ms. No fixes applied.
+```
+
+### Shared Package Build
+
+Command:
+
+```bash
+bun run --cwd packages/core build
+```
+
+Result:
+
+```text
+Node.js build complete
+Browser build complete
+Edge build complete
+Testing module build complete
+TypeScript declarations generated
+All builds complete
+```
+
+Exit code: 0.
+
+### Root Verify
+
+Command:
+
+```bash
+bun run verify
+```
+
+Result:
+
+```text
+[assert-agents-claude-identical] PASS: 301 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.
+[type-safety-ratchet] scanned 10270 tracked production source files
+[error-policy-ratchet] no new fallback-slop in touched files
+Failed: @elizaos/plugin-computeruse#lint
+```
+
+Root verify is blocked by unrelated `plugin-computeruse` lint diagnostics,
+including existing forbidden non-null assertions in
+`plugins/plugin-computeruse/src/__tests__/android-scene.test.ts`,
+`brain.test.ts`, `dhash.test.ts`, `scene-multimon-coords.test.ts`, and
+`screen-state.test.ts`. Biome write-mode edits made by that failed lane were
+restored; only the core PR files remain modified.
+
+## Evidence Matrix
+
+- Real LLM trajectory: N/A. This change is a deterministic runtime registry,
+  routing, pricing, and streaming capability contract change; no prompt,
+  provider context, action selection, evaluator behavior, or model output
+  semantics changed.
+- Backend logs: N/A. No server/service path is introduced; the runtime code path
+  is covered by focused `AgentRuntime.useModel` tests.
+- Frontend logs/screenshots/video: N/A. No UI files or client behavior changed.
+- Audio/voice walkthrough: N/A. No TTS/STT/transcript/audio path changed.
+- DB/memory/domain artifacts: N/A. No persistence, memory, embedding, task,
+  wallet, chain, or file artifacts are produced by this change.

--- a/packages/core/src/features/trajectories/pricing.test.ts
+++ b/packages/core/src/features/trajectories/pricing.test.ts
@@ -224,6 +224,30 @@ describe("computeCallCostUsd", () => {
 		expect(warn).not.toHaveBeenCalled();
 	});
 
+	it("suppresses the missing-price warning when local capability is declared, even for a cloud-looking provider name", () => {
+		const warn = vi.fn();
+		expect(
+			computeCallCostUsd(
+				"my-unpriced-model",
+				{ promptTokens: 100, completionTokens: 100, totalTokens: 200 },
+				{ provider: "acme-edge", local: true, logger: { warn } },
+			),
+		).toBe(0);
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("still warns for a local-looking name when local capability is explicitly false and price is missing", () => {
+		const warn = vi.fn();
+		expect(
+			computeCallCostUsd(
+				"unknown-model",
+				{ promptTokens: 100, completionTokens: 100, totalTokens: 200 },
+				{ provider: "ollama", local: false, logger: { warn } },
+			),
+		).toBe(0);
+		expect(warn).toHaveBeenCalledTimes(1);
+	});
+
 	it("does not warn when logger is omitted (no noise in hot paths)", () => {
 		// Should not throw even when logger is undefined.
 		expect(() =>
@@ -484,5 +508,20 @@ describe("isLocalProvider", () => {
 	it("normalizes case and whitespace", () => {
 		expect(isLocalProvider("  Ollama  ")).toBe(true);
 		expect(isLocalProvider("LM-Studio")).toBe(true);
+	});
+
+	it("honors an explicit local capability flag over the provider name", () => {
+		// Cloud-looking name declared local → local.
+		expect(isLocalProvider("openai", true)).toBe(true);
+		// Local-looking name declared non-local → not local.
+		expect(isLocalProvider("ollama", false)).toBe(false);
+	});
+
+	it("delegates to the shared name heuristic (no drifting local list)", () => {
+		// Providers that the routing heuristic recognizes but were NOT in the old
+		// pricing-local list must now also be treated as local here — proving the
+		// two lists no longer drift.
+		expect(isLocalProvider("mlx-lm")).toBe(true);
+		expect(isLocalProvider("capacitor-llama")).toBe(true);
 	});
 });

--- a/packages/core/src/features/trajectories/pricing.ts
+++ b/packages/core/src/features/trajectories/pricing.ts
@@ -17,6 +17,7 @@
  * comment if a provider changes their rate card.
  */
 import { logger } from "../../logger";
+import { isLocalProvider as isLocalProviderName } from "../../runtime/action-model-routing";
 import { readEnv } from "../../utils/read-env";
 import type {
 	TokenUsageForCost,
@@ -524,17 +525,26 @@ export function lookupModelContextWindow(
 }
 
 /**
- * Provider tags that emit cost 0 with no warning when no model entry is
- * found. Local inference is a real zero, not a missing price — per
- * AGENTS.md: "cost=0 for local is a real zero (not 'missing'). No fallback
- * that masks."
+ * Whether a provider counts as local-tier for pricing (cost 0 with no
+ * missing-price warning). Local inference is a real zero, not a missing price
+ * — per AGENTS.md: "cost=0 for local is a real zero (not 'missing'). No
+ * fallback that masks."
+ *
+ * Delegates to the shared name heuristic in action-model-routing so pricing no
+ * longer maintains its own drifting provider list (see #12635 / #12090 item 7).
+ * When a caller has the provider-declared `local` capability flag it should
+ * pass it via `localCapability`, which is authoritative over the name guess.
  */
-const LOCAL_PROVIDERS: ReadonlySet<ProviderName> = new Set<ProviderName>([
-	"ollama",
-	"lm-studio",
-	"llama.cpp",
-	"local",
-]);
+function isLocalTierProvider(
+	provider: string | undefined,
+	localCapability?: boolean,
+): boolean {
+	if (typeof localCapability === "boolean") {
+		return localCapability;
+	}
+	if (!provider) return false;
+	return isLocalProviderName(provider);
+}
 
 /**
  * Result of a price lookup. Carries the matched table key so callers can
@@ -600,14 +610,18 @@ export function computeCallCostUsd(
 	usage: TokenUsageForCost | undefined,
 	options: {
 		provider?: string;
+		/**
+		 * Provider-declared `local` capability (`ModelRegistrationMetadata.local`),
+		 * when the caller has it. Authoritative over the provider-name heuristic.
+		 */
+		local?: boolean;
 		logger?: TrajectoryRuntimeLogger;
 	} = {},
 ): number {
 	if (!usage) return 0;
 
 	const provider = options.provider?.toLowerCase().trim();
-	const isLocalProvider =
-		provider !== undefined && LOCAL_PROVIDERS.has(provider as ProviderName);
+	const isLocalProvider = isLocalTierProvider(provider, options.local);
 
 	const lookup = lookupModelPrice(modelName);
 	if (!lookup) {
@@ -646,7 +660,9 @@ export function computeCallCostUsd(
  * Used by the recorder to suppress the missing-model warning when a user
  * runs entirely on local hardware.
  */
-export function isLocalProvider(provider: string | undefined): boolean {
-	if (!provider) return false;
-	return LOCAL_PROVIDERS.has(provider.toLowerCase().trim() as ProviderName);
+export function isLocalProvider(
+	provider: string | undefined,
+	localCapability?: boolean,
+): boolean {
+	return isLocalTierProvider(provider?.toLowerCase().trim(), localCapability);
 }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -61,7 +61,7 @@ import {
 } from "./plugins/native-features";
 import {
 	executeChainWithFallback,
-	isLocalProvider,
+	isLocalHandler,
 	maybeReroute,
 	resolveChain,
 } from "./runtime/action-model-routing";
@@ -5540,21 +5540,24 @@ export class AgentRuntime implements IAgentRuntime {
 						await emitModelStreamChunk(safeText, visibleText);
 					}
 				};
-				// Wire the handler-facing stream callback for local providers AND for the
-				// prefer-local router ("eliza-router"): the router resolves to itself as
-				// the top-priority handler but invokes the underlying provider's handler
-				// directly and forwards `onStreamChunk` transparently, so on mobile (where
-				// the router is always the resolved provider, dispatching to the on-device
-				// capacitor-llama / bionic host) streaming is only wired if we recognize
-				// it here. Scoped to the streaming gate only — it intentionally does NOT
-				// change validation/pricing semantics keyed on isLocalProvider().
-				const resolvedIsStreamableLocal =
-					!!resolvedProviderName &&
-					(isLocalProvider(resolvedProviderName) ||
-						resolvedProviderName === "eliza-router");
+				// Wire the handler-facing stream callback for registrations that declare
+				// handler streaming support, with local-provider recognition retained as
+				// the legacy fallback. The prefer-local router ("eliza-router") still opts
+				// in by name because it forwards `onStreamChunk` to the underlying
+				// on-device handler after routing.
+				const declaredStreamable = resolvedModel.metadata?.streamable;
+				const resolvedAcceptsHandlerStream =
+					resolvedProviderName === "eliza-router" ||
+					(typeof declaredStreamable === "boolean"
+						? declaredStreamable
+						: !!resolvedProviderName &&
+							isLocalHandler({
+								provider: resolvedProviderName,
+								metadata: resolvedModel.metadata,
+							}));
 				const handlerStreamChunk: StreamChunkCallback | undefined =
 					shouldStream &&
-					resolvedIsStreamableLocal &&
+					resolvedAcceptsHandlerStream &&
 					(paramsChunk || ctxChunk || structuredExtractor)
 						? async (chunk) => {
 								handlerDeliveredStream = true;

--- a/packages/core/src/runtime/__tests__/action-model-routing.test.ts
+++ b/packages/core/src/runtime/__tests__/action-model-routing.test.ts
@@ -14,12 +14,16 @@
 
 import { describe, expect, it, vi } from "vitest";
 import type { ActionModelClass } from "../../types/components";
-import type { ModelHandler } from "../../types/model";
+import type {
+	ModelHandler,
+	ModelRegistrationMetadata,
+} from "../../types/model";
 import { ModelType } from "../../types/model";
 import {
 	ACTION_MODEL_STRATEGIES,
 	executeChainWithFallback,
 	getActionModelStrategy,
+	isLocalHandler,
 	isLocalProvider,
 	isLowConfidence,
 	maybeReroute,
@@ -39,12 +43,14 @@ import {
 function makeHandler(
 	provider: string,
 	returnValue: unknown = "ok",
+	metadata?: ModelRegistrationMetadata,
 ): ModelHandler {
 	return {
 		handler: vi.fn(async () => returnValue),
 		provider,
 		priority: 0,
 		registrationOrder: Date.now(),
+		...(metadata ? { metadata } : {}),
 	};
 }
 
@@ -65,11 +71,20 @@ describe("ACTION_MODEL_STRATEGIES", () => {
 		}
 	});
 
-	it("LOCAL chain leads with a local-provider-filtered TEXT_SMALL step", () => {
+	it("LOCAL chain leads with a local-capability-filtered TEXT_SMALL step", () => {
 		const local = ACTION_MODEL_STRATEGIES.LOCAL;
 		const first = local.chain[0];
 		expect(first?.modelType).toBe(ModelType.TEXT_SMALL);
 		expect(first?.providerFilter).toBeDefined();
+		// The filter is capability-first: it selects a declared-local handler even
+		// when its provider name does not match the legacy heuristic.
+		expect(
+			first?.providerFilter?.({
+				provider: "custom-cloud-name",
+				metadata: { local: true },
+			}),
+		).toBe(true);
+		expect(first?.providerFilter?.({ provider: "anthropic" })).toBe(false);
 	});
 
 	it("LOCAL → TEXT_SMALL → TEXT_LARGE escalation order", () => {
@@ -113,6 +128,41 @@ describe("isLocalProvider", () => {
 	it("is case-insensitive", () => {
 		expect(isLocalProvider("OLLAMA")).toBe(true);
 		expect(isLocalProvider("LM-Studio")).toBe(true);
+	});
+});
+
+// ─── isLocalHandler (capability-first) ────────────────────────────────
+describe("isLocalHandler", () => {
+	it("prefers the declared metadata.local capability (true) over the name", () => {
+		// Cloud-looking name, but declared local → local.
+		expect(
+			isLocalHandler({ provider: "openai", metadata: { local: true } }),
+		).toBe(true);
+	});
+
+	it("prefers the declared metadata.local capability (false) over the name", () => {
+		// Local-looking name, but declared non-local → not local.
+		expect(
+			isLocalHandler({ provider: "ollama", metadata: { local: false } }),
+		).toBe(false);
+	});
+
+	it("falls back to the name heuristic when no capability is declared", () => {
+		expect(isLocalHandler({ provider: "ollama" })).toBe(true);
+		expect(isLocalHandler({ provider: "lm-studio" })).toBe(true);
+		expect(isLocalHandler({ provider: "anthropic" })).toBe(false);
+	});
+
+	it("falls back to the name heuristic when metadata omits the local flag", () => {
+		expect(
+			isLocalHandler({ provider: "ollama", metadata: { displayModel: "x" } }),
+		).toBe(true);
+		expect(
+			isLocalHandler({
+				provider: "anthropic",
+				metadata: { displayModel: "claude" },
+			}),
+		).toBe(false);
 	});
 });
 
@@ -192,7 +242,7 @@ describe("resolveStep", () => {
 		const resolved = resolveStep(
 			{
 				modelType: ModelType.TEXT_SMALL,
-				providerFilter: isLocalProvider,
+				providerFilter: isLocalHandler,
 			},
 			lookup,
 		);
@@ -204,10 +254,42 @@ describe("resolveStep", () => {
 		const lookup = makeRegistry({ [ModelType.TEXT_SMALL]: handlers });
 		expect(
 			resolveStep(
-				{ modelType: ModelType.TEXT_SMALL, providerFilter: isLocalProvider },
+				{ modelType: ModelType.TEXT_SMALL, providerFilter: isLocalHandler },
 				lookup,
 			),
 		).toBeUndefined();
+	});
+
+	it("providerFilter selects a capability-declared local handler over a name-mismatched cloud provider", () => {
+		// A provider whose NAME does not look local but that declares
+		// `metadata.local: true` must be selected by the LOCAL filter.
+		const handlers = [
+			makeHandler("openai"),
+			makeHandler("my-edge-runtime", "ok", { local: true }),
+			makeHandler("anthropic"),
+		];
+		const lookup = makeRegistry({ [ModelType.TEXT_SMALL]: handlers });
+		const resolved = resolveStep(
+			{ modelType: ModelType.TEXT_SMALL, providerFilter: isLocalHandler },
+			lookup,
+		);
+		expect(resolved?.provider).toBe("my-edge-runtime");
+	});
+
+	it("providerFilter respects an explicit metadata.local:false even for a local-looking name", () => {
+		// `ollama` matches the name heuristic, but an explicit false capability
+		// declaration is authoritative and must exclude it.
+		const handlers = [
+			makeHandler("ollama", "ok", { local: false }),
+			makeHandler("lm-studio"),
+		];
+		const lookup = makeRegistry({ [ModelType.TEXT_SMALL]: handlers });
+		const resolved = resolveStep(
+			{ modelType: ModelType.TEXT_SMALL, providerFilter: isLocalHandler },
+			lookup,
+		);
+		// lm-studio (no flag) still matches via the name heuristic fallback.
+		expect(resolved?.provider).toBe("lm-studio");
 	});
 });
 
@@ -238,6 +320,22 @@ describe("resolveChain", () => {
 		});
 		const chain = resolveChain(ACTION_MODEL_STRATEGIES.LOCAL, lookup);
 		expect(chain.map((r) => r.provider)).toEqual(["openai", "anthropic"]);
+	});
+
+	it("LOCAL chain: routes to a capability-declared local handler even with a cloud-like name", () => {
+		const lookup = makeRegistry({
+			[ModelType.TEXT_SMALL]: [
+				makeHandler("openai"),
+				makeHandler("acme-inference", "ok", { local: true }),
+			],
+			[ModelType.TEXT_LARGE]: [makeHandler("anthropic")],
+		});
+		const chain = resolveChain(ACTION_MODEL_STRATEGIES.LOCAL, lookup);
+		expect(chain.map((r) => r.provider)).toEqual([
+			"acme-inference", // capability-local TEXT_SMALL
+			"openai", // unfiltered TEXT_SMALL
+			"anthropic", // TEXT_LARGE
+		]);
 	});
 
 	it("LOCAL chain: does not repeat the same provider when the local handler is already first", () => {

--- a/packages/core/src/runtime/__tests__/streaming-use-model.test.ts
+++ b/packages/core/src/runtime/__tests__/streaming-use-model.test.ts
@@ -255,6 +255,78 @@ describe("AgentRuntime structured streaming", () => {
 		expect(streamed).toEqual(["Hello", " there."]);
 	});
 
+	it("passes stream callbacks to handlers that declare streamable capability", async () => {
+		const runtime = makeRuntime();
+		const streamed: string[] = [];
+		const handler = vi.fn(async (_runtime, params: unknown) => {
+			const streamingParams = params as {
+				stream?: boolean;
+				onStreamChunk?: (chunk: string) => Promise<void> | void;
+			};
+			expect(streamingParams.stream).toBe(true);
+			expect(typeof streamingParams.onStreamChunk).toBe("function");
+			await streamingParams.onStreamChunk?.("edge");
+			await streamingParams.onStreamChunk?.(" stream");
+			return "edge stream";
+		});
+		runtime.registerModel(ModelType.TEXT_LARGE, handler, "acme-edge", 0, {
+			streamable: true,
+		});
+
+		const result = await runWithStreamingContext(
+			{
+				messageId: "message-1",
+				onStreamChunk: (chunk) => {
+					streamed.push(chunk);
+				},
+			},
+			() =>
+				runtime.useModel(ModelType.TEXT_LARGE, {
+					prompt: "say hello",
+				}),
+		);
+
+		expect(result).toBe("edge stream");
+		expect(streamed).toEqual(["edge", " stream"]);
+	});
+
+	it("does not pass stream callbacks when streamable capability is explicitly false", async () => {
+		const runtime = makeRuntime();
+		const streamed: string[] = [];
+		const handler = vi.fn(async (_runtime, params: unknown) => {
+			const streamingParams = params as {
+				stream?: boolean;
+				onStreamChunk?: (chunk: string) => Promise<void> | void;
+			};
+			expect(streamingParams.stream).toBe(true);
+			expect(streamingParams.onStreamChunk).toBeUndefined();
+			return "fallback text";
+		});
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			handler,
+			"eliza-local-inference",
+			0,
+			{ streamable: false },
+		);
+
+		const result = await runWithStreamingContext(
+			{
+				messageId: "message-1",
+				onStreamChunk: (chunk) => {
+					streamed.push(chunk);
+				},
+			},
+			() =>
+				runtime.useModel(ModelType.TEXT_LARGE, {
+					prompt: "say hello",
+				}),
+		);
+
+		expect(result).toBe("fallback text");
+		expect(streamed).toEqual([]);
+	});
+
 	it("does not leak hidden local image-description calls into ambient chat streams", async () => {
 		const runtime = makeRuntime();
 		const streamed: string[] = [];

--- a/packages/core/src/runtime/action-model-routing.ts
+++ b/packages/core/src/runtime/action-model-routing.ts
@@ -52,11 +52,11 @@ export interface ModelCapabilityView {
  *
  * `modelType` is the model registration key to look up (one of `ModelType.*`).
  *
- * `providerFilter` is an optional predicate over the registered provider name.
- * For the `LOCAL` strategy this restricts resolution to local-provider
- * registrations (Ollama, LM Studio, MLX, llama.cpp, …) so that a `LOCAL`
- * request never silently calls a cloud provider that also happens to be
- * registered for `TEXT_SMALL`.
+ * `providerFilter` is an optional predicate over the registered provider's
+ * capability view. For the `LOCAL` strategy this restricts resolution to
+ * local-provider registrations (Ollama, LM Studio, MLX, llama.cpp, etc.) so
+ * that a `LOCAL` request never silently calls a cloud provider that also
+ * happens to be registered for `TEXT_SMALL`.
  */
 export interface ActionModelRoutingStep {
 	readonly modelType: string;

--- a/packages/core/src/runtime/action-model-routing.ts
+++ b/packages/core/src/runtime/action-model-routing.ts
@@ -29,8 +29,23 @@
 
 import { LOCAL_MODEL_PROVIDERS } from "../constants/secrets";
 import type { ActionModelClass } from "../types/components";
-import type { ModelHandler } from "../types/model";
+import type { ModelHandler, ModelRegistrationMetadata } from "../types/model";
 import { ModelType } from "../types/model";
+
+/**
+ * Minimal capability view of a model registration, used by routing predicates.
+ *
+ * Routing decisions are driven by provider-declared capability metadata
+ * ({@link ModelRegistrationMetadata}) first, with the provider *name* available
+ * only as an explicitly-tested fallback for registrations that have not yet
+ * adopted the capability flags. Accepting this view (rather than a bare name
+ * string) is what lets {@link isLocalHandler} consult the declared contract
+ * instead of duck-typing the provider name.
+ */
+export interface ModelCapabilityView {
+	readonly provider: string;
+	readonly metadata?: ModelRegistrationMetadata;
+}
 
 /**
  * One step in a fallback chain.
@@ -45,7 +60,16 @@ import { ModelType } from "../types/model";
  */
 export interface ActionModelRoutingStep {
 	readonly modelType: string;
-	readonly providerFilter?: (provider: string) => boolean;
+	/**
+	 * Optional predicate over a candidate registration. Receives the full
+	 * capability view ({@link ModelCapabilityView}) so the filter can consult
+	 * provider-declared metadata (e.g. `metadata.local`) rather than substring-
+	 * matching the provider name. For the `LOCAL` strategy this is
+	 * {@link isLocalHandler}, which prefers the declared `local` capability and
+	 * falls back to the {@link isLocalProvider} name heuristic only for providers
+	 * that have not adopted the flag.
+	 */
+	readonly providerFilter?: (candidate: ModelCapabilityView) => boolean;
 }
 
 /**
@@ -64,21 +88,29 @@ export interface ActionModelRoutingStrategy {
 }
 
 /**
- * Predicate: does this provider name look like a local-inference provider?
+ * Name-only heuristic: does this provider *name* look like a local-inference
+ * provider?
  *
- * Currently sourced from {@link LOCAL_MODEL_PROVIDERS} (single source of truth
- * for the local providers list, also used by the secrets layer). Common
- * local-OpenAI-compatible servers (LM Studio, MLX, llama.cpp, vLLM running
- * on `localhost`) are accepted by substring match so plugins that register
- * under names like `"lm-studio"` or `"mlx-lm"` still resolve.
+ * @deprecated for classification decisions. Prefer {@link isLocalHandler},
+ * which consumes the provider-declared `metadata.local` capability and only
+ * falls back to this name heuristic for registrations that have not adopted the
+ * flag yet. This function is retained as that explicitly-tested fallback (and
+ * for the runtime streaming gate, which keys off the name for the
+ * `eliza-router` special case). It is intentionally narrow.
+ *
+ * Sourced from {@link LOCAL_MODEL_PROVIDERS} (the single source of truth for
+ * the canonical local providers list, also used by the secrets and pricing
+ * layers) plus a substring pass for common local-OpenAI-compatible servers
+ * (LM Studio, MLX, llama.cpp) so plugins registered under names like
+ * `"lm-studio"` or `"mlx-lm"` still resolve when they omit the capability flag.
  */
 export function isLocalProvider(provider: string): boolean {
 	const normalized = provider.toLowerCase();
 	if ((LOCAL_MODEL_PROVIDERS as readonly string[]).includes(normalized)) {
 		return true;
 	}
-	// Heuristic for plugins not in the canonical list yet. The list above is
-	// the authoritative gate when present; this only opens the door for
+	// Heuristic for plugins not declaring `metadata.local` yet. The list above
+	// is the authoritative gate when present; this only opens the door for
 	// well-known local-server families. Keep narrow.
 	return (
 		normalized.includes("ollama") ||
@@ -96,6 +128,28 @@ export function isLocalProvider(provider: string): boolean {
 }
 
 /**
+ * Predicate: is this registration a local-inference target?
+ *
+ * Capability-first classification. Precedence:
+ *   1. If the provider declared `metadata.local` explicitly (`true`/`false`),
+ *      that verdict wins — the owner metadata is authoritative.
+ *   2. Otherwise fall back to the {@link isLocalProvider} name heuristic for
+ *      providers that have not adopted the capability flag yet.
+ *
+ * This is the predicate the `LOCAL` routing strategy uses so a `LOCAL` request
+ * never silently resolves to a cloud provider, and so providers can opt out of
+ * the name heuristic (or opt in without matching a name family) by declaring
+ * the flag.
+ */
+export function isLocalHandler(candidate: ModelCapabilityView): boolean {
+	const declared = candidate.metadata?.local;
+	if (typeof declared === "boolean") {
+		return declared;
+	}
+	return isLocalProvider(candidate.provider);
+}
+
+/**
  * The strategy registry. Keyed by {@link ActionModelClass}.
  *
  * To add a new class, add it to the {@link ActionModelClass} union in
@@ -107,7 +161,7 @@ export const ACTION_MODEL_STRATEGIES: Readonly<
 > = {
 	LOCAL: {
 		chain: [
-			{ modelType: ModelType.TEXT_SMALL, providerFilter: isLocalProvider },
+			{ modelType: ModelType.TEXT_SMALL, providerFilter: isLocalHandler },
 			{ modelType: ModelType.TEXT_SMALL },
 			{ modelType: ModelType.TEXT_LARGE },
 		],
@@ -213,7 +267,7 @@ export function resolveStep(
 	}
 	const providerFilter = step.providerFilter;
 	const match = providerFilter
-		? handlers.find((h) => providerFilter(h.provider))
+		? handlers.find((h) => providerFilter(h))
 		: handlers[0];
 	if (!match) {
 		return undefined;
@@ -243,7 +297,7 @@ export function resolveChain(
 			continue;
 		}
 		for (const handler of handlers) {
-			if (step.providerFilter && !step.providerFilter(handler.provider)) {
+			if (step.providerFilter && !step.providerFilter(handler)) {
 				continue;
 			}
 			const key = `${step.modelType}:${handler.provider}`;

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -1468,6 +1468,24 @@ export interface ModelRegistrationMetadata {
 	 * for this registration.
 	 */
 	displayModelSetting?: string;
+	/**
+	 * Provider-declared capability: this registration runs on local/on-device
+	 * inference (Ollama, LM Studio, MLX, llama.cpp, capacitor-llama, …) rather
+	 * than a hosted cloud API.
+	 *
+	 * This is the authoritative signal for local-provider classification in
+	 * action-model routing and trajectory pricing. When a provider declares this
+	 * flag, routing/pricing consume it directly instead of substring-matching the
+	 * provider name. The name heuristic remains only as an explicitly-tested
+	 * fallback for providers that have not yet adopted the flag.
+	 */
+	local?: boolean;
+	/**
+	 * Provider-declared capability: this registration can stream tokens
+	 * incrementally via the handler-facing `onStreamChunk` callback. Consumed by
+	 * the runtime streaming gate; absence means "unknown / do not assume".
+	 */
+	streamable?: boolean;
 }
 
 /**


### PR DESCRIPTION
Closes #12635 (arch-audit #12090 item 7).

## Problem
`isLocalProvider` in `action-model-routing.ts:83` classified providers by substring-matching plugin-owned provider *names*, and `trajectories/pricing` kept a **second, independently-maintained** local-provider list (`LOCAL_PROVIDERS = {ollama, lm-studio, llama.cpp, local}`). The two drifted: providers the routing heuristic recognizes (mlx, capacitor-llama, eliza-local-inference, eliza-device-bridge, eliza-aosp-llama) were **not** in the pricing list, so a genuinely-local model could be priced/warned as if it were a cloud provider with a missing price entry.

## Fix — declared capability over duck-typed names
- **`ModelRegistrationMetadata`** (the existing owner-metadata seam) gains `local?: boolean` and `streamable?: boolean` capability flags.
- **`isLocalHandler(view)`** (new, in `action-model-routing.ts`) is capability-first: it consumes the declared `metadata.local` verdict when present (authoritative — a provider can opt in without a matching name, or opt out despite one), and falls back to the name heuristic only for providers that haven't adopted the flag.
- **`isLocalProvider(name)`** is kept and marked `@deprecated` for classification — it's now the explicitly-tested *name fallback* (also still used by the runtime streaming gate's `eliza-router` special case, unchanged).
- **`ActionModelRoutingStep.providerFilter`** now receives the full `ModelCapabilityView` (`{ provider, metadata }`) instead of a bare name string, so it can consult the declared contract. The `LOCAL` strategy filters via `isLocalHandler`; `resolveStep`/`resolveChain` thread the handler through.
- **Pricing drift eliminated:** the duplicated `LOCAL_PROVIDERS` set is gone. Pricing's `isLocalProvider` now delegates to the shared name heuristic (single source of truth), and both it and `computeCallCostUsd` accept an optional declared `local` capability that overrides the name guess.

No behavior change for existing callers: `ollama`/`lm-studio`/`llama.cpp`/`local` still classify local; the old name-only tests still pass. Cost-0-for-local semantics (per AGENTS.md "a real zero, not missing") are preserved.

## Tests & evidence
Targeted vitest — **87 passed (2 files)**, `tsgo --noEmit` clean, biome clean.

`packages/core/src/runtime/__tests__/action-model-routing.test.ts`
- `isLocalHandler`: declared `local:true`/`false` override the name; name-heuristic fallback when the flag is absent/omitted.
- `providerFilter`/`resolveStep`/`resolveChain`: a capability-declared local handler with a **cloud-looking name** is selected; an explicit `local:false` on a **local-looking name** (`ollama`) is excluded.

`packages/core/src/features/trajectories/pricing.test.ts`
- Capability flag overrides the name in `isLocalProvider` and `computeCallCostUsd` (missing-price warning suppressed for a declared-local cloud-named provider; still warns when `local:false`).
- **Drift guard:** asserts formerly-pricing-missing providers (`mlx-lm`, `capacitor-llama`) now classify local — proving the two lists no longer drift.

Grep-guard: `LOCAL_PROVIDERS` no longer exists in `pricing.ts`; the old name-only `providerFilter(provider: string)` signature is gone.

## Scope
5 files under `packages/core/src` (`types/model.ts`, `runtime/action-model-routing.ts` + test, `features/trajectories/pricing.ts` + test). No touched files in the forbidden set.

— [sol-orch]