### PR TITLE
fix(#12798): distinguish failed Google Fit sleep fetch from fabricated zero sleep

### DIFF
--- a/.github/issue-evidence/12798-google-fit-sleep-unavailable.md
+++ b/.github/issue-evidence/12798-google-fit-sleep-unavailable.md
@@ -1,0 +1,47 @@
+# Issue #12798: Google Fit sleep failure is distinct from zero sleep
+
+Date: 2026-07-04
+
+## Change
+
+- `plugins/plugin-health/src/health-bridge/health-bridge.ts` now marks failed Google Fit sleep aggregation with `HealthDailySummary.sleepUnavailable = true` instead of leaving the day indistinguishable from a known `sleepHours: 0` day.
+- The same failure path logs a structured `logger.warn` containing:
+  - `boundary: "lifeops"`
+  - `integration: "google-fit"`
+  - `date`
+  - connector error message
+- `getDataPoints({ metric: "sleep_hours" })` omits `sleepUnavailable` days so connector failure does not emit fabricated zero-sleep points.
+- `plugins/plugin-health/src/health-bridge/health-bridge.google-fit-sleep.test.ts` covers:
+  - failed sleep sub-fetch returns steps/active data but marks `sleepUnavailable`
+  - failed sleep sub-fetch emits the structured warning
+  - successful sleep fetch reports real sleep and no unavailable flag
+  - genuine empty sleep dataset stays a known zero without the unavailable flag
+  - sleep-unavailable windows emit no fabricated data points
+
+## Verification
+
+- PASS: `bun test plugins/plugin-health/src/health-bridge/health-bridge.google-fit-sleep.test.ts plugins/plugin-health/src/health-bridge/service-normalize-health.test.ts`
+  - 2 files passed; 12 tests passed.
+  - Test output includes the expected structured warning logs for the unavailable sleep data-point path.
+- PASS: `bunx biome check plugins/plugin-health/src/health-bridge/health-bridge.ts plugins/plugin-health/src/health-bridge/health-bridge.google-fit-sleep.test.ts`
+  - 2 files checked; no fixes applied.
+- PASS: `bun run --cwd plugins/plugin-health build`
+  - JS, view bundle, and type artifact build completed.
+- PASS: `bun run verify` preflight stages before workspace lint:
+  - `check:agents-claude`
+  - `audit:type-safety-ratchet`
+  - `audit:error-policy-ratchet` reported `no new fallback-slop in touched files`.
+
+## Blocked / unrelated checks
+
+- BLOCKED: `bun run --cwd plugins/plugin-health typecheck`
+  - Existing unrelated package error:
+    `src/default-packs/gate-coverage.test.ts(17,8): error TS2307: Cannot find module '@elizaos/plugin-scheduling' or its corresponding type declarations.`
+- BLOCKED: full `bun run verify`
+  - Stops in unrelated `@elizaos/tui#lint` control-character regex diagnostics.
+  - Root lint write-mode side effects in `plugins/plugin-browser/src/workspace/browser-workspace-elements.ts` and `plugins/plugin-browser/src/workspace/browser-workspace-web.ts` were restored before committing.
+
+## Evidence notes
+
+- Live Google Fit capture was not run in this worktree because no real `ELIZA_GOOGLE_FIT_ACCESS_TOKEN`/account fixture is configured here. This scoped PR changes the connector failure path and is covered with deterministic aggregate-response tests that exercise the real `getDailySummary` and `getDataPoints` public bridge functions.
+- No app UI surface was changed, so app visual audit and screenshots are N/A.

--- a/plugins/plugin-health/src/health-bridge/health-bridge.google-fit-sleep.test.ts
+++ b/plugins/plugin-health/src/health-bridge/health-bridge.google-fit-sleep.test.ts
@@ -1,3 +1,4 @@
+import { logger } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getDailySummary, getDataPoints } from "./health-bridge.js";
@@ -97,7 +98,12 @@ describe("googleFitDailySummary sleep sub-fetch failure (#12798)", () => {
   });
 
   it("marks the day sleepUnavailable when the sleep aggregation fails (does not fabricate sleepHours: 0)", async () => {
-    fetchSpy.mockImplementation((async (_url: FetchArgs[0], init: FetchArgs[1]) => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    fetchSpy.mockImplementation((async (
+      _url: FetchArgs[0],
+      init: FetchArgs[1],
+    ) => {
       if (isSleepRequest(init)) {
         return failResponse(503);
       }
@@ -114,10 +120,22 @@ describe("googleFitDailySummary sleep sub-fetch failure (#12798)", () => {
     expect(summary.sleepHours).toBe(0);
     // The failure must have hit the aggregate endpoint twice (metrics + sleep).
     expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      {
+        boundary: "lifeops",
+        integration: "google-fit",
+        date: "2026-07-01",
+        error: "Google Fit request failed: HTTP 503",
+      },
+      "[lifeops] Google Fit sleep aggregation failed; sleep marked unavailable for this day",
+    );
   });
 
   it("does NOT set sleepUnavailable and reports real sleep when the sleep call succeeds", async () => {
-    fetchSpy.mockImplementation((async (_url: FetchArgs[0], init: FetchArgs[1]) => {
+    fetchSpy.mockImplementation((async (
+      _url: FetchArgs[0],
+      init: FetchArgs[1],
+    ) => {
       if (isSleepRequest(init)) {
         return okResponse(sleepResponseBody());
       }
@@ -134,7 +152,10 @@ describe("googleFitDailySummary sleep sub-fetch failure (#12798)", () => {
     const emptySleepBody = JSON.stringify({
       bucket: [{ dataset: [{ point: [] }] }],
     });
-    fetchSpy.mockImplementation((async (_url: FetchArgs[0], init: FetchArgs[1]) => {
+    fetchSpy.mockImplementation((async (
+      _url: FetchArgs[0],
+      init: FetchArgs[1],
+    ) => {
       if (isSleepRequest(init)) {
         return okResponse(emptySleepBody);
       }
@@ -151,7 +172,10 @@ describe("googleFitDailySummary sleep sub-fetch failure (#12798)", () => {
   it("omits sleep-unavailable days from sleep data-point series (no fabricated points)", async () => {
     // Sleep aggregate fails for every day in the window -> no points emitted,
     // rather than a run of fabricated zero-sleep points.
-    fetchSpy.mockImplementation((async (_url: FetchArgs[0], init: FetchArgs[1]) => {
+    fetchSpy.mockImplementation((async (
+      _url: FetchArgs[0],
+      init: FetchArgs[1],
+    ) => {
       if (isSleepRequest(init)) {
         return failResponse(500);
       }

--- a/plugins/plugin-health/src/health-bridge/health-bridge.google-fit-sleep.test.ts
+++ b/plugins/plugin-health/src/health-bridge/health-bridge.google-fit-sleep.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getDailySummary, getDataPoints } from "./health-bridge.js";
+
+/**
+ * Regression coverage for #12798 (fallback-slop LifeOps/health):
+ *
+ * Google Fit daily summaries fetch steps/active-minutes with one aggregate
+ * call and sleep with a second, dedicated call. Previously a failure of the
+ * sleep sub-fetch was swallowed and the summary kept `sleepHours: 0`, which is
+ * indistinguishable from a genuine zero-sleep day and silently corrupts
+ * circadian/regularity inference downstream.
+ *
+ * The fix marks such days `sleepUnavailable: true` (distinct from
+ * "slept 0 hours") and logs the failure as a structured warn so it is
+ * observable, and omits those days from sleep data-point series instead of
+ * emitting fabricated zero-sleep points.
+ */
+
+type FetchArgs = Parameters<typeof fetch>;
+
+const GOOGLE_FIT_CONFIG = {
+  preferredBackend: "google-fit" as const,
+  googleFitAccessToken: "test-token",
+};
+
+function requestBodyText(init: FetchArgs[1]): string {
+  const body = init?.body;
+  return typeof body === "string" ? body : String(body ?? "");
+}
+
+function isSleepRequest(init: FetchArgs[1]): boolean {
+  return requestBodyText(init).includes("com.google.sleep.segment");
+}
+
+/** A metrics-aggregate response with real step/active data but no sleep. */
+function metricsResponseBody(): string {
+  return JSON.stringify({
+    bucket: [
+      {
+        startTimeMillis: "0",
+        endTimeMillis: "86400000",
+        dataset: [
+          { point: [{ value: [{ intVal: 8000 }] }] }, // steps
+          { point: [{ value: [{ fpVal: 42 }] }] }, // active minutes
+          { point: [] }, // calories
+          { point: [] }, // distance
+          { point: [] }, // heart rate
+        ],
+      },
+    ],
+  });
+}
+
+/** A sleep-aggregate response carrying ~7h of sleep. */
+function sleepResponseBody(): string {
+  const startNanos = "0";
+  const endNanos = String(7 * 60 * 60 * 1_000_000_000); // 7h in ns
+  return JSON.stringify({
+    bucket: [
+      {
+        dataset: [
+          {
+            point: [{ startTimeNanos: startNanos, endTimeNanos: endNanos }],
+          },
+        ],
+      },
+    ],
+  });
+}
+
+function okResponse(bodyText: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => JSON.parse(bodyText),
+  } as unknown as Response;
+}
+
+function failResponse(status: number): Response {
+  return {
+    ok: false,
+    status,
+    json: async () => ({}),
+  } as unknown as Response;
+}
+
+describe("googleFitDailySummary sleep sub-fetch failure (#12798)", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("marks the day sleepUnavailable when the sleep aggregation fails (does not fabricate sleepHours: 0)", async () => {
+    fetchSpy.mockImplementation((async (_url: FetchArgs[0], init: FetchArgs[1]) => {
+      if (isSleepRequest(init)) {
+        return failResponse(503);
+      }
+      return okResponse(metricsResponseBody());
+    }) as typeof fetch);
+
+    const summary = await getDailySummary("2026-07-01", GOOGLE_FIT_CONFIG);
+
+    // Steps/active minutes from the successful metrics call still land.
+    expect(summary.steps).toBe(8000);
+    expect(summary.activeMinutes).toBe(42);
+    // The failed sleep sub-fetch must be flagged, NOT reported as 0h slept.
+    expect(summary.sleepUnavailable).toBe(true);
+    expect(summary.sleepHours).toBe(0);
+    // The failure must have hit the aggregate endpoint twice (metrics + sleep).
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT set sleepUnavailable and reports real sleep when the sleep call succeeds", async () => {
+    fetchSpy.mockImplementation((async (_url: FetchArgs[0], init: FetchArgs[1]) => {
+      if (isSleepRequest(init)) {
+        return okResponse(sleepResponseBody());
+      }
+      return okResponse(metricsResponseBody());
+    }) as typeof fetch);
+
+    const summary = await getDailySummary("2026-07-01", GOOGLE_FIT_CONFIG);
+
+    expect(summary.sleepUnavailable).toBeUndefined();
+    expect(summary.sleepHours).toBeCloseTo(7, 5);
+  });
+
+  it("does NOT set sleepUnavailable for a genuine zero-sleep day (empty sleep dataset)", async () => {
+    const emptySleepBody = JSON.stringify({
+      bucket: [{ dataset: [{ point: [] }] }],
+    });
+    fetchSpy.mockImplementation((async (_url: FetchArgs[0], init: FetchArgs[1]) => {
+      if (isSleepRequest(init)) {
+        return okResponse(emptySleepBody);
+      }
+      return okResponse(metricsResponseBody());
+    }) as typeof fetch);
+
+    const summary = await getDailySummary("2026-07-01", GOOGLE_FIT_CONFIG);
+
+    // Real zero-sleep: known 0, distinct from a failed connector.
+    expect(summary.sleepUnavailable).toBeUndefined();
+    expect(summary.sleepHours).toBe(0);
+  });
+
+  it("omits sleep-unavailable days from sleep data-point series (no fabricated points)", async () => {
+    // Sleep aggregate fails for every day in the window -> no points emitted,
+    // rather than a run of fabricated zero-sleep points.
+    fetchSpy.mockImplementation((async (_url: FetchArgs[0], init: FetchArgs[1]) => {
+      if (isSleepRequest(init)) {
+        return failResponse(500);
+      }
+      return okResponse(metricsResponseBody());
+    }) as typeof fetch);
+
+    const points = await getDataPoints(
+      {
+        metric: "sleep_hours",
+        startAt: "2026-07-01T00:00:00.000Z",
+        endAt: "2026-07-02T00:00:00.000Z",
+      },
+      GOOGLE_FIT_CONFIG,
+    );
+
+    expect(points).toEqual([]);
+  });
+});

--- a/plugins/plugin-health/src/health-bridge/health-bridge.ts
+++ b/plugins/plugin-health/src/health-bridge/health-bridge.ts
@@ -63,6 +63,14 @@ export interface HealthDailySummary {
   steps: number;
   activeMinutes: number;
   sleepHours: number;
+  /**
+   * True when the sleep sub-fetch for this day failed (connector/transport
+   * error) rather than returning zero sleep. Consumers must treat this as
+   * "sleep unknown for this day", NOT as "slept 0 hours": a swallowed failure
+   * that leaves `sleepHours: 0` otherwise fabricates a genuine-looking
+   * zero-sleep reading and corrupts circadian/regularity inference.
+   */
+  sleepUnavailable?: boolean;
   heartRateAvg?: number;
   calories?: number;
   distanceMeters?: number;
@@ -652,12 +660,22 @@ async function googleFitDailySummary(
       summary.sleepHours = sleepMs / (1000 * 60 * 60);
     }
   } catch (error) {
-    // Sleep is optional — record via debug without exposing values.
-    logger.debug(
-      { boundary: "lifeops", integration: "google-fit" },
-      "[lifeops] Google Fit sleep aggregation failed",
+    // Sleep is a separate best-effort sub-fetch: steps/active-minutes above
+    // already succeeded, so we return the summary instead of throwing. But we
+    // must NOT let the swallowed failure masquerade as `sleepHours: 0` — that
+    // fabricates a real-looking zero-sleep reading. Flag the day as
+    // sleep-unavailable and surface the failure through a structured warn so
+    // it is observable rather than silently discarded.
+    summary.sleepUnavailable = true;
+    logger.warn(
+      {
+        boundary: "lifeops",
+        integration: "google-fit",
+        date,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "[lifeops] Google Fit sleep aggregation failed; sleep marked unavailable for this day",
     );
-    void error;
   }
 
   return summary;
@@ -671,7 +689,11 @@ async function googleFitDataPoints(
     const points: HealthDataPoint[] = [];
     for (const date of enumerateGoogleFitDates(opts.startAt, opts.endAt)) {
       const summary = await googleFitDailySummary(date, accessToken);
-      if (summary.sleepHours <= 0) {
+      // Skip days with no sleep points OR a failed sleep sub-fetch: emitting a
+      // point for a `sleepUnavailable` day would surface a fabricated value.
+      // The failure is already logged as a structured warn in
+      // googleFitDailySummary; here we simply omit the unknown day.
+      if (summary.sleepUnavailable || summary.sleepHours <= 0) {
         continue;
       }
       points.push({


### PR DESCRIPTION
Closes part of #12798 (Fallback slop app plugins A: LifeOps and health structural failures, #12273 split).

## Problem

`googleFitDailySummary` in `plugins/plugin-health/src/health-bridge/health-bridge.ts` fetches steps/active-minutes with one aggregate call and sleep with a **separate** aggregate call. When the sleep sub-fetch failed, the `catch` swallowed the error into a value-less `logger.debug` and left `summary.sleepHours = 0`.

That is exactly the fabricated-empty-state pattern the #12182 policy targets: a **failed connector** (sleep API 5xx/timeout) becomes indistinguishable from a **genuine zero-sleep day**. Downstream consumers (`daily.sleepHours > 0 ? ... : null` in `providers/health.ts`, plus circadian/regularity inference) then treat a transport failure as "slept 0 hours" and silently corrupt owner health state.

## Fix (fail-observably, not fail-silently)

- Add `HealthDailySummary.sleepUnavailable?: boolean` — a distinct signal that the sleep sub-fetch failed, separate from `sleepHours: 0` (known zero).
- On sleep-fetch failure: set `sleepUnavailable = true` and log a **structured `logger.warn`** (with `date` + `error` message) instead of a value-less debug, so the failure is observable.
- `getDataPoints` sleep series now skips `sleepUnavailable` days so no fabricated zero-sleep points are emitted for connector failures.

Steps/active-minutes from the successful metrics call still land, so the summary is returned rather than thrown; only the genuinely-unknown sleep dimension is flagged. No forbidden files touched (only `health-bridge.ts` + a new test).

## Tests / evidence

New: `plugins/plugin-health/src/health-bridge/health-bridge.google-fit-sleep.test.ts` (4 real error-path tests, stubbing `fetch` to fail only the sleep sub-request):

- sleep-fetch failure -> `sleepUnavailable: true`, `sleepHours: 0`, steps/active still populated, **no fabrication**
- successful sleep fetch -> real `~7h`, no flag
- genuine empty sleep dataset -> `sleepHours: 0`, **no** flag (known zero stays distinct from failure)
- failed sleep across a window -> `getDataPoints` returns `[]` (no fabricated series)

```
✓ src/health-bridge/service-normalize-health.test.ts (8 tests)
✓ src/health-bridge/health-bridge.google-fit-sleep.test.ts (4 tests)
Test Files  2 passed (2)
     Tests  12 passed (12)
```

`tsgo --noEmit -p tsconfig.json`: clean on touched files. (The one pre-existing unrelated error in `default-packs/gate-coverage.test.ts` — missing `@elizaos/plugin-scheduling` — is present on `origin/develop` and untouched here.)

-- [sol-orch]