### PR TITLE
fix(#12747): make dropped gateway frames observable instead of silent

### DIFF
--- a/.github/issue-evidence/12747-native-gateway-dropped-frames.md
+++ b/.github/issue-evidence/12747-native-gateway-dropped-frames.md
@@ -1,0 +1,72 @@
+# Issue #12747 - plugin-native-gateway dropped frame observability
+
+PR: https://github.com/elizaOS/eliza/pull/13133
+Branch: `fix/12747-native-bridge-failclosed`
+Verified commit: `bad950ff3eded0451b6b182a73121ceecfa73386` plus evidence follow-up
+
+## Scope checked
+
+This slice covers only the browser/WebSocket implementation in
+`plugins/plugin-native-gateway/src/web.ts` and its test coverage in
+`plugins/plugin-native-gateway/src/web.test.ts`.
+
+The change does not alter iOS or Android native bridge code. Malformed inbound
+web gateway frames are still dropped rather than turned into synthetic
+`gatewayEvent` payloads, but each drop now emits a `console.warn` so a drifting
+gateway protocol or bad transport frame is visible instead of looking like an
+idle healthy connection.
+
+Drop classes covered by tests:
+
+- unparseable JSON
+- non-object JSON
+- missing or invalid `type`
+- unhandled frame `type`
+- `res` frame without a valid `id`
+- `res` frame for an unknown request id
+- `event` frame without a valid `event` name
+
+## Passing verification
+
+- PASS `bun run --cwd plugins/plugin-native-gateway test src/web.test.ts`
+  - 1 file passed, 17 tests passed
+- PASS `bun run --cwd plugins/plugin-native-gateway typecheck`
+  - `tsgo --noEmit -p tsconfig.json`
+- PASS `bun run --cwd plugins/plugin-native-gateway lint:check`
+  - Biome checked 7 files; no fixes applied
+- PASS `bun run --cwd plugins/plugin-native-gateway build`
+  - `tsc` plus Rollup generated `dist/plugin.js` and `dist/plugin.cjs.js`
+
+## Repo verify
+
+- `bun run verify`
+  - PASS `check:agents-claude`
+  - PASS `audit:type-safety-ratchet`
+  - PASS `audit:error-policy-ratchet`
+  - BLOCKED by unrelated workspace lint:
+    - `@elizaos/electrobun#lint` formatting diagnostics in
+      `packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts`
+    - `@elizaos/tui#lint` existing diagnostics including Node builtin import
+      protocol, non-null assertions, and control-character regex warnings in
+      `packages/tui`
+
+## Manual review
+
+Reviewed the implementation and tests:
+
+- bad frames return early after warning and do not emit `gatewayEvent`
+- valid event frames still emit unchanged
+- unknown/late response ids warn without resolving or fabricating a pending
+  request
+- the warning channel matches existing browser-side sequence-gap and socket
+  error warnings in this package
+
+## N/A evidence
+
+- Native iOS/Android device capture: N/A for this slice because no Swift,
+  Kotlin, or native discovery/RPC implementation changed. The changed file is
+  the web implementation only.
+- Model trajectory: N/A; this Capacitor gateway transport change has no model
+  interaction.
+- Screenshots/video: N/A; this is a non-UI browser WebSocket frame handling
+  path. The observable artifact is the console warning asserted in tests.

--- a/plugins/plugin-native-gateway/src/web.test.ts
+++ b/plugins/plugin-native-gateway/src/web.test.ts
@@ -135,6 +135,7 @@ describe("GatewayWeb", () => {
   });
 
   it("ignores malformed inbound frames and emits valid gateway events", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const gateway = new GatewayWeb();
     const events: unknown[] = [];
     await gateway.addListener("gatewayEvent", (event) => {
@@ -154,6 +155,7 @@ describe("GatewayWeb", () => {
     );
     await connected;
 
+    warn.mockClear();
     socket.message("not json");
     socket.message(JSON.stringify({ type: "event", event: "", payload: {} }));
     socket.message(
@@ -165,9 +167,75 @@ describe("GatewayWeb", () => {
       }),
     );
 
+    // Valid events still surface — we do not fabricate anything for the bad ones.
     expect(events).toEqual([
       { event: "chat.delta", payload: { n: 1 }, seq: 1 },
     ]);
+    // ...but the two dropped frames must be observable, not silent idle state.
+    const warnings = warn.mock.calls.map((c) => String(c[0]));
+    expect(warnings.some((m) => m.includes("unparseable frame"))).toBe(true);
+    expect(
+      warnings.some((m) => m.includes("missing/invalid `event` name")),
+    ).toBe(true);
+  });
+
+  it.each([
+    {
+      label: "unparseable payload",
+      raw: "not json",
+      needle: "unparseable frame",
+    },
+    { label: "non-object frame", raw: "42", needle: "non-object frame" },
+    {
+      label: "missing type",
+      raw: JSON.stringify({ event: "chat.delta" }),
+      needle: "missing/invalid `type`",
+    },
+    {
+      label: "unhandled type",
+      raw: JSON.stringify({ type: "mystery" }),
+      needle: "unhandled type",
+    },
+    {
+      label: "res without id",
+      raw: JSON.stringify({ type: "res", ok: true }),
+      needle: "res` frame with missing/invalid `id`",
+    },
+    {
+      label: "res for unknown id",
+      raw: JSON.stringify({ type: "res", id: "nope", ok: true }),
+      needle: "unknown request id",
+    },
+  ])("reports dropped inbound frame ($label) instead of swallowing it", async ({
+    raw,
+    needle,
+  }) => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const gateway = new GatewayWeb();
+    const events: unknown[] = [];
+    await gateway.addListener("gatewayEvent", (event) => {
+      events.push(event);
+    });
+    const connected = gateway.connect({ url: "ws://localhost:1234" });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+    const connectFrame = parseSent(socket, 0);
+    socket.message(
+      JSON.stringify({
+        type: "res",
+        id: connectFrame.id,
+        ok: true,
+        payload: {},
+      }),
+    );
+    await connected;
+
+    warn.mockClear();
+    socket.message(raw);
+
+    expect(events).toEqual([]);
+    const warnings = warn.mock.calls.map((c) => String(c[0]));
+    expect(warnings.some((m) => m.includes(needle))).toBe(true);
   });
 
   it.each([

--- a/plugins/plugin-native-gateway/src/web.ts
+++ b/plugins/plugin-native-gateway/src/web.ts
@@ -328,23 +328,37 @@ export class GatewayWeb extends WebPlugin {
     let parsedValue: JsonValue;
     try {
       parsedValue = JSON.parse(raw) as JsonValue;
-    } catch {
+    } catch (err) {
+      // A frame the gateway sent us failed to parse. Dropping it silently would
+      // masquerade a protocol/transport fault as an idle connection, so surface
+      // it the same way the sequence-gap and socket-error paths do.
+      console.warn(
+        "[Gateway] Dropped unparseable frame:",
+        err instanceof Error ? err.message : String(err),
+      );
       return;
     }
 
     if (!isJsonObject(parsedValue)) {
+      console.warn(
+        "[Gateway] Dropped non-object frame (expected a JSON object)",
+      );
       return;
     }
 
     const frameType = getString(parsedValue.type);
     if (!frameType) {
+      console.warn("[Gateway] Dropped frame with missing/invalid `type` field");
       return;
     }
 
     // Handle response frames
     if (frameType === "res") {
       const id = getString(parsedValue.id);
-      if (!id) return;
+      if (!id) {
+        console.warn("[Gateway] Dropped `res` frame with missing/invalid `id`");
+        return;
+      }
       const pending = this.pending.get(id);
       if (pending) {
         this.pending.delete(id);
@@ -354,6 +368,12 @@ export class GatewayWeb extends WebPlugin {
           payload: parsedValue.payload,
           error: parseGatewayError(parsedValue.error),
         });
+      } else {
+        // No caller is waiting on this id (late/duplicate/unknown response).
+        // Note it rather than dropping in silence.
+        console.warn(
+          `[Gateway] Dropped res frame for unknown request id: ${id}`,
+        );
       }
       return;
     }
@@ -361,7 +381,12 @@ export class GatewayWeb extends WebPlugin {
     // Handle event frames
     if (frameType === "event") {
       const event = getString(parsedValue.event);
-      if (!event) return;
+      if (!event) {
+        console.warn(
+          "[Gateway] Dropped `event` frame with missing/invalid `event` name",
+        );
+        return;
+      }
       const payload = parsedValue.payload;
       const seq = getNumber(parsedValue.seq);
 
@@ -387,6 +412,10 @@ export class GatewayWeb extends WebPlugin {
       } as GatewayEvent);
       return;
     }
+
+    // A well-formed frame with a `type` we don't handle. Log it so an evolving
+    // gateway protocol (new frame types) is observable instead of vanishing.
+    console.warn(`[Gateway] Dropped frame with unhandled type: ${frameType}`);
   }
 
   /**


### PR DESCRIPTION
Closes part of #12747 (native bridge non-route sweep, split of #12275-I / #12275 / #12182).

## Problem
`plugin-native-gateway`'s `GatewayWeb.handleMessage` silently `return`ed on **every** malformed inbound WebSocket frame:

- JSON parse failure
- non-object JSON
- missing/invalid `type` field
- `res` frame with missing/invalid `id`
- `res` frame for an **unknown request id** (late/duplicate/stray response)
- `event` frame with an empty/invalid `event` name
- any well-formed frame with a `type` we don't handle

A gateway that starts emitting garbage, drifts its wire protocol, or replies to an id nobody is waiting on would look like a **healthy-but-idle** connection. That is exactly the "failures must be observable and must not masquerade as idle/empty state" slop #12747 targets.

## Fix
Each drop now emits a `console.warn`, in the same house style as the existing sequence-gap warning (`web.ts` ~line 374) and socket-error warning (~line 213). This is the observability channel this Capacitor web plugin already uses; it has no runtime handle for `runtime.reportError`.

Behavior is otherwise unchanged — we still **never fabricate** a `gatewayEvent` for a bad frame, so no fake/success-shaped state is introduced. This is diagnostic hardening, not a control-flow change.

## Tests
`plugins/plugin-native-gateway/src/web.test.ts`:
- Augmented the existing "ignores malformed inbound frames" test to assert the unparseable-frame and empty-event drops are now reported via `console.warn`, while valid events still surface unchanged.
- Added a parametrized suite covering all six drop classes (unparseable, non-object, missing type, unhandled type, res-without-id, res-for-unknown-id), each asserting a warning is emitted **and** no `gatewayEvent` is fabricated.

## Evidence
- `vitest run src/web.test.ts` → **17/17 pass**
- `tsc --noEmit -p tsconfig.json` → **clean (0 errors)**
- `biome check` → **clean**
- `codex review --uncommitted` → "No discrete correctness issues were found in the current changes."

Scope note: touched only `src/web.ts` + `src/web.test.ts` (non-test change is a single non-route file). Route files remain owned by #12275-F. No touch to vite.config.*/index.html/client-base.ts/bun.lock/binaries/dist.

-- [sol-orch]