### PR TITLE
fix(#12738): fail closed on corrupt .elizaos/template.json (packages/elizaos CLI J1 boundary)

### DIFF
--- a/.github/issue-evidence/12738-elizaos-cli-fail-closed.md
+++ b/.github/issue-evidence/12738-elizaos-cli-fail-closed.md
@@ -1,0 +1,73 @@
+# Evidence - #12738 (packages/elizaos CLI fast-fail slice)
+
+Scope of this slice: the `.elizaos/template.json` J1 command boundary consumed by
+`elizaos upgrade`. Before this change, `readProjectMetadata` did a bare
+`JSON.parse` and no shape validation, so a corrupt ledger surfaced as an
+unhandled `SyntaxError` stack trace, and a syntactically-valid-but-malformed
+ledger (e.g. `{}`) was accepted as fabricated metadata and let `upgrade`
+proceed past corrupt required input (crashing later mid-render).
+
+## Inventory (this slice)
+
+| path | line | pattern | verdict |
+|------|------|---------|---------|
+| src/project-metadata.ts | readProjectMetadata | bare `JSON.parse`, no shape guard | REMOVE SLOP → typed `ProjectMetadataError`, fail closed |
+| src/commands/upgrade.ts | upgrade() read site | uncaught throw → ugly stack | REMOVE SLOP → catch typed error, `clack.cancel` + exit 1 |
+| src/scaffold.ts | isShallowGitRepo catch | `catch { return false }` | KEEP → `// error-policy:J4` optional reference-repo probe |
+
+Other catches in this package audited and left as-is (documented file-presence
+probes in `migrate/ocplatform-reader.ts` where "not present" is a valid no-data
+state; `package-info.ts` reads of the always-shipped package.json throw
+naturally). Those are not fabricated defaults on required paths.
+
+## Real end-to-end CLI transcript (built dist/cli.js)
+
+    ########## CASE 1: corrupt (unparseable) template.json ##########
+    fixture: { this is not valid json
+    $ node dist/cli.js upgrade
+    └  Corrupt project metadata at .../.elizaos/template.json: invalid JSON
+       (Expected property name or '}' in JSON at position 2 ...).
+       Fix or remove the file and re-run, or re-create the project.
+    EXIT CODE: 1
+
+    ########## CASE 2: valid JSON, wrong shape (empty object) ##########
+    fixture: {}
+    $ node dist/cli.js upgrade
+    └  Corrupt project metadata at .../.elizaos/template.json:
+       missing or invalid 'templateId'. Fix or remove the file and re-run...
+    EXIT CODE: 1
+
+    ########## CASE 3: no metadata at all (valid no-op) ##########
+    $ node dist/cli.js upgrade
+    └  No .elizaos/template.json metadata found in the current directory.
+    EXIT CODE: 1  (unchanged pre-existing behavior)
+
+Case 1 previously emitted a raw `SyntaxError` stack trace; Case 2 previously
+proceeded on fabricated metadata and failed later. Both now fail closed with a
+clear message and non-zero exit at the boundary.
+
+## Unit tests
+
+`src/project-metadata.test.ts` - 9 tests, real temp `.elizaos/template.json`
+fixtures (missing → null, valid round-trip, unparseable, bare string, array,
+empty object, non-string values, missing managedFiles, non-string hashes).
+
+    $ bun run test src/project-metadata.test.ts
+    ✓ src/project-metadata.test.ts (9 tests) 15ms
+    Test Files  1 passed (1)
+    Tests  9 passed (9)
+
+## Full-suite / typecheck
+
+    $ bun run test
+    Test Files  1 failed | 9 passed (10)   Tests  65 passed (65)
+    # the 1 "failed" file is src/migrate/migrate.test.ts - PRE-EXISTING on
+    # origin/develop: it imports the optional cross-package dev dep
+    # `@elizaos/agent/services/agent-export`, absent from this lane's
+    # node_modules. Untouched by this change (no migrate files edited).
+
+    $ bun run typecheck   # tsgo --noEmit
+    EXIT: 0
+
+N/A: model trajectory / screenshots - this slice is a CLI metadata boundary with
+no model interaction or UI surface.

--- a/.github/issue-evidence/12738-elizaos-cli-fail-closed.md
+++ b/.github/issue-evidence/12738-elizaos-cli-fail-closed.md
@@ -69,5 +69,27 @@ empty object, non-string values, missing managedFiles, non-string hashes).
     $ bun run typecheck   # tsgo --noEmit
     EXIT: 0
 
+    $ bun run lint:check
+    Checked 42 files in 84ms. No fixes applied.
+    Checked 11 files in 6ms. No fixes applied.
+    Checked 63 files in 48ms. No fixes applied.
+    EXIT: 0
+
+    $ bun run build
+    EXIT: 0
+
+## Repo verify
+
+    $ bun run verify
+    PASS: check:agents-claude
+    PASS: audit:type-safety-ratchet
+    PASS: audit:error-policy-ratchet
+    BLOCKED: unrelated workspace lint:
+      - @elizaos/tui#lint control-character regex diagnostics in
+        packages/tui/src/keys.ts, packages/tui/src/terminal.ts, and
+        packages/tui/test/truncated-text.test.ts.
+      - @elizaos/electrobun#lint formatting diagnostics in
+        packages/electrobun/src/voice/voice-service.test.ts.
+
 N/A: model trajectory / screenshots - this slice is a CLI metadata boundary with
 no model interaction or UI surface.

--- a/packages/elizaos/src/commands/upgrade.ts
+++ b/packages/elizaos/src/commands/upgrade.ts
@@ -8,6 +8,7 @@ import pc from "picocolors";
 import { getTemplateById, getTemplatesDir } from "../manifest.js";
 import { getCliVersion } from "../package-info.js";
 import {
+  ProjectMetadataError,
   readProjectMetadata,
   writeProjectMetadata,
 } from "../project-metadata.js";
@@ -26,7 +27,18 @@ import type { UpgradeOptions } from "../types.js";
 
 export async function upgrade(options: UpgradeOptions): Promise<void> {
   const projectRoot = process.cwd();
-  const metadata = readProjectMetadata(projectRoot);
+  let metadata: ReturnType<typeof readProjectMetadata>;
+  try {
+    metadata = readProjectMetadata(projectRoot);
+  } catch (error) {
+    // J1 command boundary: corrupt required metadata must fail closed with a
+    // clear message and non-zero exit, never proceed on fabricated defaults.
+    if (error instanceof ProjectMetadataError) {
+      clack.cancel(error.message);
+      process.exit(1);
+    }
+    throw error;
+  }
   if (!metadata) {
     clack.cancel(
       "No .elizaos/template.json metadata found in the current directory.",

--- a/packages/elizaos/src/project-metadata.test.ts
+++ b/packages/elizaos/src/project-metadata.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Project-metadata read tests use real temporary `.elizaos/template.json`
+ * fixtures to prove the J1 command boundary: a missing ledger is a valid
+ * no-data outcome (null), while a corrupt or malformed ledger fails closed with
+ * a typed {@link ProjectMetadataError} rather than being read as fabricated
+ * defaults.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ProjectMetadataError,
+  readProjectMetadata,
+  writeProjectMetadata,
+} from "./project-metadata.js";
+import type { ProjectTemplateMetadata } from "./types.js";
+
+let tempDirs: string[] = [];
+
+function makeProjectRoot(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "elizaos-metadata-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeRawMetadata(projectRoot: string, contents: string): string {
+  const metadataDir = path.join(projectRoot, ".elizaos");
+  mkdirSync(metadataDir, { recursive: true });
+  const metadataPath = path.join(metadataDir, "template.json");
+  writeFileSync(metadataPath, contents);
+  return metadataPath;
+}
+
+function validMetadata(): ProjectTemplateMetadata {
+  return {
+    cliVersion: "1.2.3",
+    createdAt: "2026-07-04T00:00:00.000Z",
+    updatedAt: "2026-07-04T00:00:00.000Z",
+    templateId: "plugin",
+    templateVersion: 1,
+    values: { PLUGINNAME: "acme" },
+    managedFiles: { "src/index.ts": "deadbeef" },
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+});
+
+describe("readProjectMetadata", () => {
+  it("returns null when the ledger is absent (valid no-upgrade-state)", () => {
+    const projectRoot = makeProjectRoot();
+    expect(readProjectMetadata(projectRoot)).toBeNull();
+  });
+
+  it("round-trips a valid ledger written by writeProjectMetadata", () => {
+    const projectRoot = makeProjectRoot();
+    const metadata = validMetadata();
+    writeProjectMetadata(projectRoot, metadata);
+    expect(readProjectMetadata(projectRoot)).toEqual(metadata);
+  });
+
+  it("fails closed on a genuinely corrupt (unparseable) ledger", () => {
+    const projectRoot = makeProjectRoot();
+    const metadataPath = writeRawMetadata(projectRoot, "{ this is not json ");
+    expect(() => readProjectMetadata(projectRoot)).toThrow(
+      ProjectMetadataError,
+    );
+    try {
+      readProjectMetadata(projectRoot);
+      throw new Error("expected readProjectMetadata to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProjectMetadataError);
+      const err = error as ProjectMetadataError;
+      expect(err.metadataPath).toBe(metadataPath);
+      expect(err.message).toContain("invalid JSON");
+    }
+  });
+
+  it("rejects valid JSON that is not an object (bare string)", () => {
+    const projectRoot = makeProjectRoot();
+    writeRawMetadata(projectRoot, '"not-an-object"');
+    expect(() => readProjectMetadata(projectRoot)).toThrow(
+      /expected a JSON object/,
+    );
+  });
+
+  it("rejects valid JSON that is an array", () => {
+    const projectRoot = makeProjectRoot();
+    writeRawMetadata(projectRoot, "[]");
+    expect(() => readProjectMetadata(projectRoot)).toThrow(
+      /expected a JSON object/,
+    );
+  });
+
+  it("rejects an empty object (missing required templateId)", () => {
+    const projectRoot = makeProjectRoot();
+    writeRawMetadata(projectRoot, "{}");
+    expect(() => readProjectMetadata(projectRoot)).toThrow(
+      /missing or invalid 'templateId'/,
+    );
+  });
+
+  it("rejects a ledger with a non-string values map", () => {
+    const projectRoot = makeProjectRoot();
+    writeRawMetadata(
+      projectRoot,
+      JSON.stringify({ templateId: "plugin", values: { n: 5 }, managedFiles: {} }),
+    );
+    expect(() => readProjectMetadata(projectRoot)).toThrow(
+      /missing or invalid 'values'/,
+    );
+  });
+
+  it("rejects a ledger missing managedFiles", () => {
+    const projectRoot = makeProjectRoot();
+    writeRawMetadata(
+      projectRoot,
+      JSON.stringify({ templateId: "plugin", values: {} }),
+    );
+    expect(() => readProjectMetadata(projectRoot)).toThrow(
+      /missing or invalid 'managedFiles'/,
+    );
+  });
+
+  it("rejects a ledger whose managedFiles hashes are not strings", () => {
+    const projectRoot = makeProjectRoot();
+    writeRawMetadata(
+      projectRoot,
+      JSON.stringify({
+        templateId: "plugin",
+        values: {},
+        managedFiles: { "src/index.ts": 123 },
+      }),
+    );
+    expect(() => readProjectMetadata(projectRoot)).toThrow(
+      /missing or invalid 'managedFiles'/,
+    );
+  });
+});

--- a/packages/elizaos/src/project-metadata.test.ts
+++ b/packages/elizaos/src/project-metadata.test.ts
@@ -110,7 +110,11 @@ describe("readProjectMetadata", () => {
     const projectRoot = makeProjectRoot();
     writeRawMetadata(
       projectRoot,
-      JSON.stringify({ templateId: "plugin", values: { n: 5 }, managedFiles: {} }),
+      JSON.stringify({
+        templateId: "plugin",
+        values: { n: 5 },
+        managedFiles: {},
+      }),
     );
     expect(() => readProjectMetadata(projectRoot)).toThrow(
       /missing or invalid 'values'/,

--- a/packages/elizaos/src/project-metadata.ts
+++ b/packages/elizaos/src/project-metadata.ts
@@ -18,7 +18,11 @@ const METADATA_FILE = "template.json";
 export class ProjectMetadataError extends Error {
   readonly metadataPath: string;
 
-  constructor(metadataPath: string, detail: string, options?: { cause?: unknown }) {
+  constructor(
+    metadataPath: string,
+    detail: string,
+    options?: { cause?: unknown },
+  ) {
     super(
       `Corrupt project metadata at ${metadataPath}: ${detail}. ` +
         "Fix or remove the file and re-run, or re-create the project.",
@@ -101,7 +105,9 @@ export function readProjectMetadata(
     parsed = JSON.parse(raw);
   } catch (error) {
     const detail =
-      error instanceof Error ? `invalid JSON (${error.message})` : "invalid JSON";
+      error instanceof Error
+        ? `invalid JSON (${error.message})`
+        : "invalid JSON";
     throw new ProjectMetadataError(metadataPath, detail, { cause: error });
   }
 

--- a/packages/elizaos/src/project-metadata.ts
+++ b/packages/elizaos/src/project-metadata.ts
@@ -10,10 +10,75 @@ import type { ProjectTemplateMetadata } from "./types.js";
 const METADATA_DIR = ".elizaos";
 const METADATA_FILE = "template.json";
 
+/**
+ * Thrown when `.elizaos/template.json` exists but is unreadable, unparseable,
+ * or structurally invalid. This is a J1 command boundary: `upgrade` must fail
+ * closed with a clear error rather than proceed on corrupt/fabricated metadata.
+ */
+export class ProjectMetadataError extends Error {
+  readonly metadataPath: string;
+
+  constructor(metadataPath: string, detail: string, options?: { cause?: unknown }) {
+    super(
+      `Corrupt project metadata at ${metadataPath}: ${detail}. ` +
+        "Fix or remove the file and re-run, or re-create the project.",
+      options,
+    );
+    this.name = "ProjectMetadataError";
+    this.metadataPath = metadataPath;
+  }
+}
+
 function getMetadataPath(projectRoot: string): string {
   return path.join(projectRoot, METADATA_DIR, METADATA_FILE);
 }
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  return Object.values(value as Record<string, unknown>).every(
+    (entry) => typeof entry === "string",
+  );
+}
+
+/**
+ * Validate the parsed JSON against the required shape of
+ * `ProjectTemplateMetadata`. Only the fields `upgrade` actually depends on are
+ * enforced as hard requirements; a file that parses to the wrong shape (e.g.
+ * `{}`, an array, or a bare string) must be rejected so the caller never runs
+ * on fabricated defaults. Returns a human-readable reason string when invalid.
+ */
+function validateMetadataShape(value: unknown): string | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return "expected a JSON object";
+  }
+  const record = value as Record<string, unknown>;
+  if (!isNonEmptyString(record.templateId)) {
+    return "missing or invalid 'templateId'";
+  }
+  if (!isStringRecord(record.values)) {
+    return "missing or invalid 'values' (expected a string map)";
+  }
+  if (!isStringRecord(record.managedFiles)) {
+    return "missing or invalid 'managedFiles' (expected a path->hash map)";
+  }
+  return null;
+}
+
+/**
+ * Read the managed-file ledger for a generated project.
+ *
+ * Returns `null` only when the file is genuinely absent (a project that was
+ * never scaffolded from a template has no upgrade state, a valid non-error
+ * "no-data" outcome). If the file exists but cannot be read, parsed, or fails
+ * shape validation, this throws {@link ProjectMetadataError} so `upgrade` stops
+ * at the corrupt input instead of fabricating an empty/default metadata object.
+ */
 export function readProjectMetadata(
   projectRoot: string,
 ): ProjectTemplateMetadata | null {
@@ -22,9 +87,30 @@ export function readProjectMetadata(
     return null;
   }
 
-  return JSON.parse(
-    fs.readFileSync(metadataPath, "utf-8"),
-  ) as ProjectTemplateMetadata;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(metadataPath, "utf-8");
+  } catch (error) {
+    throw new ProjectMetadataError(metadataPath, "file could not be read", {
+      cause: error,
+    });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const detail =
+      error instanceof Error ? `invalid JSON (${error.message})` : "invalid JSON";
+    throw new ProjectMetadataError(metadataPath, detail, { cause: error });
+  }
+
+  const shapeError = validateMetadataShape(parsed);
+  if (shapeError) {
+    throw new ProjectMetadataError(metadataPath, shapeError);
+  }
+
+  return parsed as ProjectTemplateMetadata;
 }
 
 export function writeProjectMetadata(

--- a/packages/elizaos/src/scaffold.ts
+++ b/packages/elizaos/src/scaffold.ts
@@ -97,6 +97,9 @@ function isShallowGitRepo(repoRoot: string): boolean {
     );
     return result.trim() === "true";
   } catch {
+    // error-policy:J4 optional reference-repo probe; a failed `git rev-parse`
+    // (no git, not a repo, permission) means "treat as non-shallow" for the
+    // clone optimization, not a fabricated result on a required path.
     return false;
   }
 }


### PR DESCRIPTION
Closes #12738 (packages/elizaos CLI fast-fail slice — the `.elizaos/template.json` J1 command boundary).

## Problem
`readProjectMetadata` (`packages/elizaos/src/project-metadata.ts`) did a bare `JSON.parse` with **no shape validation**. Two fail-open slop paths resulted:

1. A genuinely corrupt ledger (invalid JSON) surfaced as a raw `SyntaxError` stack trace instead of a clear CLI failure.
2. A syntactically-valid-but-malformed ledger (e.g. `{}`, an array, or a bare string) was accepted as fabricated metadata, so `elizaos upgrade` **proceeded past corrupt required input** and crashed later mid-render.

This is exactly the J1 boundary #12738 requires: "CLI never proceeds past corrupt required input."

## Fix
- Add a typed `ProjectMetadataError`. `readProjectMetadata` now distinguishes:
  - **missing file** -> `null` (valid "no upgrade state" for a project never scaffolded from a template),
  - **unreadable / unparseable / wrong-shape** -> throws `ProjectMetadataError`.
- Validate the required shape (`templateId` non-empty string, `values` string-map, `managedFiles` path->hash string-map) so a wrong-shape ledger fails closed rather than running on defaults.
- `upgrade` catches `ProjectMetadataError` at the read site and emits a clear `clack.cancel` message + non-zero exit.
- Annotate the one legitimate keep in `scaffold.ts` (`isShallowGitRepo` git probe) as `// error-policy:J4` (optional reference-repo optimization; a failed probe correctly means "treat as non-shallow", not a fabricated result on a required path).

Other catches in this package were audited and left as-is: documented file-presence probes in `migrate/ocplatform-reader.ts` (where "not present" is a valid no-data state) and the always-shipped `package.json` read in `package-info.ts` (throws naturally). None are fabricated defaults on required paths.

## Tests / evidence
- **`src/project-metadata.test.ts` — 9 real temp-fixture cases**: missing->null, valid round-trip, unparseable JSON, bare string, array, empty object, non-string `values`, missing `managedFiles`, non-string hash values.

      $ bun run test src/project-metadata.test.ts
      ✓ src/project-metadata.test.ts (9 tests)
      Test Files  1 passed (1)   Tests  9 passed (9)

- **Real end-to-end CLI transcript** (built `dist/cli.js`) in `.github/issue-evidence/12738-elizaos-cli-fail-closed.md`:
  - corrupt (unparseable) ledger -> `Corrupt project metadata ...: invalid JSON (...)`, **exit 1**
  - malformed (`{}`) ledger -> `Corrupt project metadata ...: missing or invalid 'templateId'`, **exit 1**
  - missing ledger -> unchanged `No .elizaos/template.json metadata found`, exit 1
- `bun run typecheck` (tsgo --noEmit): **clean, exit 0**.
- `bun run test` (full package): 65 tests pass. The single non-green file `src/migrate/migrate.test.ts` is **pre-existing on `origin/develop`** — it imports the optional cross-package dev dep `@elizaos/agent/services/agent-export`, absent from this lane's `node_modules`; untouched by this change (no migrate files edited).

No forbidden files touched (no `vite.config.*`, `index.html`, `client-base.ts`, `bun.lock`, binaries, or `dist/`).

-- [sol-orch]
