### PR TITLE
fix(#12742): import-conversations parsers fail closed on corrupt/unreadable exports

### DIFF
--- a/.github/issue-evidence/12742-import-conversations-parser-fail-closed.md
+++ b/.github/issue-evidence/12742-import-conversations-parser-fail-closed.md
@@ -1,0 +1,79 @@
+# #12742 fallback-slop: import-conversations parser fail-closed evidence
+
+Part of #12275-E (browser/homepage/native package sweep, split of #12182).
+Slice: `packages/import-conversations` parsers. The rest of #12275-E's package
+list (`packages/browser-extension`, `packages/contracts`, `packages/homepage`,
+`packages/os`, `packages/native`) was audited and its remaining handlers are
+already legitimate/correct (see inventory below); this PR removes the concrete
+fallback slop found in the conversation-export parsers.
+
+## The slop
+
+The three export parsers (`chatgpt`, `claude`, `hermes`) each wrapped their
+`detect()` probe — and hermes wrapped `parse()`'s directory reads — in a blanket
+`catch { return false }` / `catch { entries = [] }`. That conflated two very
+different conditions:
+
+1. **"input is not this format"** — the honest answer to `detect()`, e.g. the
+   path resolves to nothing recognizable. This *should* return `false`.
+2. **"input IS this format but the required payload is corrupt/unreadable"** —
+   a resolved `conversations.json` whose body is truncated JSON, or an existing
+   `sessions/` dir that fails to read (EACCES/EIO/ENOTDIR). This is a real
+   failure on required input and was being **swallowed as `false`**, so an
+   import of a genuinely-corrupt export reported "no parser recognized this
+   export" instead of surfacing the corruption.
+
+## Per-site inventory
+
+| path | line (pre) | pattern | verdict |
+|---|---|---|---|
+| parsers/claude.ts | `resolveInput` stat `catch { return undefined }` | swallow-all | **fix**: ENOENT → undefined (not an export), else throw |
+| parsers/claude.ts | `detect` `catch { return false }` | swallow-all | **fix**: removed; corrupt resolved payload now throws |
+| parsers/chatgpt.ts | `resolveInput` outer stat `catch { return undefined }` | swallow-all | **fix**: ENOENT → undefined, else throw |
+| parsers/chatgpt.ts | `resolveInput` inner file-stat `catch { return undefined }` | swallow-all | **fix**: ENOENT → undefined, else throw |
+| parsers/chatgpt.ts | `detect` `catch { return false }` | swallow-all | **fix**: removed; corrupt resolved payload now throws |
+| parsers/hermes.ts | `detect` stat `catch { return false }` | swallow-all | **fix**: ENOENT → false, else throw |
+| parsers/hermes.ts | `detect` readdir `catch { return false }` | swallow-all (dir already existsSync'd) | **fix**: removed; readdir failure now surfaces |
+| parsers/hermes.ts | `detect` signature-peek `catch { return false }` | untrusted line parse | **keep J3** (annotated): non-JSON signature line = not recognizable |
+| parsers/hermes.ts | `parse` sessions readdir `catch { entries = [] }` | swallow-all → empty | **fix**: removed; failure surfaces instead of importing zero sessions |
+| parsers/hermes.ts | `parse` memories readdir `catch { entries = [] }` | swallow-all → empty | **fix**: removed; failure surfaces instead of dropping notes |
+| parsers/hermes.ts | `parseSessionFile` per-line `JSON.parse` catch | truncated JSONL tail | **keep J3** (annotated): skip corrupt line on still-appending log |
+| parsers/hermes.ts | `parseMemoryFile` readFile `catch { return undefined }` | swallow-all | **fix**: ENOENT (benign readdir/read race) → skip, else throw |
+
+Kept handlers each carry a grep-able `// error-policy:J3 <reason>` annotation.
+
+### Audited-and-already-correct (no change) in the rest of #12275-E
+
+- `packages/browser-extension`: `throwApiError` catch still throws
+  `RelayApiError` (J1 boundary; body-parse failure only degrades the message);
+  `isReachableAgentApiBaseUrl`'s catch is an honest reachability probe (failure
+  = not reachable); URL-normalizer catches return `null` as a J3 "invalid input"
+  validator signal. No masking.
+- `packages/contracts`: no error-handling catches (only a `catchphrase` field).
+- `packages/import-conversations` core (`pipeline`, `manifest`, `render`,
+  `redact`, `sink`, `document-service`, `zip-entry`, `json-array-stream`):
+  already fail-closed — they throw on missing sink / malformed JSON / malformed
+  zip; no default-return-from-catch slop.
+
+## Verification
+
+```bash
+bun run --cwd packages/import-conversations test
+```
+Result: 10 files / 113 tests passed (5 new fail-closed tests added: claude +2,
+chatgpt +1, hermes +4 net; corrupt-payload throws + I/O-failure surfaces + still
+returns false on genuinely-absent input).
+
+```bash
+bun run --cwd packages/import-conversations typecheck
+```
+Result: passed (`useUnknownInCatchVariables` on; `isNotFound(error: unknown)`
+narrows correctly).
+
+```bash
+bunx @biomejs/biome check src/parsers/*.ts
+```
+Result: clean.
+
+N/A rows: no rendered UI/native/device behavior changed in this slice, so no
+screenshots/recordings — `N/A - parser library, no UI surface`.

--- a/.github/issue-evidence/12742-import-conversations-parser-fail-closed.md
+++ b/.github/issue-evidence/12742-import-conversations-parser-fail-closed.md
@@ -60,8 +60,8 @@ Kept handlers each carry a grep-able `// error-policy:J3 <reason>` annotation.
 ```bash
 bun run --cwd packages/import-conversations test
 ```
-Result: 10 files / 113 tests passed (5 new fail-closed tests added: claude +2,
-chatgpt +1, hermes +4 net; corrupt-payload throws + I/O-failure surfaces + still
+Result: 10 files / 113 tests passed (6 new fail-closed tests added: claude +2,
+chatgpt +1, hermes +3; corrupt-payload throws + I/O-failure surfaces + still
 returns false on genuinely-absent input).
 
 ```bash

--- a/packages/import-conversations/src/parsers/chatgpt.test.ts
+++ b/packages/import-conversations/src/parsers/chatgpt.test.ts
@@ -257,6 +257,19 @@ describe("chatgpt parser: detect() + registry", () => {
     expect(await detect(path.join(here, "does-not-exist"))).toBe(false);
   });
 
+  it("throws on a resolved-but-corrupt conversations.json instead of reporting 'not a ChatGPT export'", async () => {
+    // Directory resolves to a conversations.json whose body is a truncated JSON
+    // array. Corrupt required input for a resolved export must surface, not be
+    // swallowed by detect() as a plain false.
+    const tmp = await mkdtemp(path.join(tmpdir(), "chatgpt-corrupt-"));
+    await writeFile(
+      path.join(tmp, "conversations.json"),
+      '[{"mapping":{"a":',
+      "utf8",
+    );
+    await expect(detect(tmp)).rejects.toThrow();
+  });
+
   it("resolves via the registry by detect()", async () => {
     const registry = new ConversationImporterRegistry();
     registry.register(chatgptParser);

--- a/packages/import-conversations/src/parsers/chatgpt.ts
+++ b/packages/import-conversations/src/parsers/chatgpt.ts
@@ -423,6 +423,14 @@ export async function* streamJsonArrayElements(
 
 // --- ConversationImporter surface -------------------------------------------
 
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: string }).code === "ENOENT"
+  );
+}
+
 async function resolveInput(
   input: string,
 ): Promise<
@@ -431,8 +439,12 @@ async function resolveInput(
   let st: Awaited<ReturnType<typeof stat>>;
   try {
     st = await stat(input);
-  } catch {
-    return undefined;
+  } catch (error) {
+    // error-policy:J3 an absent path is "not a ChatGPT export"; any other stat
+    // failure (EACCES, EIO, ...) is a real I/O error on required input and must
+    // surface rather than masquerade as an unrecognized/absent input.
+    if (isNotFound(error)) return undefined;
+    throw error;
   }
 
   if (st.isDirectory()) {
@@ -440,8 +452,12 @@ async function resolveInput(
     try {
       const fileStat = await stat(file);
       return fileStat.isFile() ? { kind: "json", path: file } : undefined;
-    } catch {
-      return undefined;
+    } catch (error) {
+      // error-policy:J3 a missing conversations.json inside a directory means
+      // "not a ChatGPT export"; a non-ENOENT failure reading it is a real I/O
+      // error on required input and must surface.
+      if (isNotFound(error)) return undefined;
+      throw error;
     }
   }
 
@@ -478,24 +494,25 @@ async function openConversationsStream(input: string): Promise<Readable> {
  * (which has `chat_messages`).
  */
 async function detect(input: string): Promise<boolean> {
-  try {
-    const resolved = await resolveInput(input);
-    if (!resolved) return false;
-    if (resolved.kind === "zip") {
-      const metadata = await findZipEntryMetadata(
-        resolved.path,
-        CONVERSATIONS_FILE,
-      );
-      if (!metadata) return false;
-    }
-
-    const first = await readFirstJsonArrayObject(
-      await openConversationsStream(input),
+  // Resolution decides recognition: an input that does not resolve to a ChatGPT
+  // `conversations.json` (or a zip carrying one) is not a ChatGPT export and
+  // returns false. Once it resolves, the payload is required input — a corrupt
+  // or unreadable body throws so callers see a "corrupt ChatGPT export" failure
+  // rather than a silent "unrecognized format".
+  const resolved = await resolveInput(input);
+  if (!resolved) return false;
+  if (resolved.kind === "zip") {
+    const metadata = await findZipEntryMetadata(
+      resolved.path,
+      CONVERSATIONS_FILE,
     );
-    return isRecord(first) && isRecord((first as ChatGptConversation).mapping);
-  } catch {
-    return false;
+    if (!metadata) return false;
   }
+
+  const first = await readFirstJsonArrayObject(
+    await openConversationsStream(input),
+  );
+  return isRecord(first) && isRecord((first as ChatGptConversation).mapping);
 }
 
 /**

--- a/packages/import-conversations/src/parsers/claude.test.ts
+++ b/packages/import-conversations/src/parsers/claude.test.ts
@@ -112,6 +112,25 @@ describe("claude parser: detect()", () => {
     await writeFile(zipPath, makeZipWithConversationsJson(json));
     expect(await detect(zipPath)).toBe(true);
   });
+
+  it("returns false for a genuinely absent path (not a Claude export)", async () => {
+    expect(await detect(path.join(here, "fixtures", "does-not-exist"))).toBe(
+      false,
+    );
+  });
+
+  it("throws on a resolved-but-corrupt conversations.json instead of silently reporting 'not a Claude export'", async () => {
+    // A directory that DOES resolve to a conversations.json whose body is a
+    // truncated/corrupt JSON array. This is required input for a resolved
+    // export: detect() must surface the corruption, not swallow it as false.
+    const tmp = await mkdtemp(path.join(tmpdir(), "claude-corrupt-"));
+    await writeFile(
+      path.join(tmp, "conversations.json"),
+      '[{"uuid":"x","chat_messages":[',
+      "utf8",
+    );
+    await expect(detect(tmp)).rejects.toThrow();
+  });
 });
 
 describe("claude parser: parse() mapping", () => {

--- a/packages/import-conversations/src/parsers/claude.ts
+++ b/packages/import-conversations/src/parsers/claude.ts
@@ -288,6 +288,14 @@ function looksLikeClaudeConversation(value: unknown): boolean {
   return isRecord(value) && Array.isArray(value.chat_messages);
 }
 
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: string }).code === "ENOENT"
+  );
+}
+
 async function resolveInput(
   input: string,
 ): Promise<
@@ -296,8 +304,12 @@ async function resolveInput(
   let st: Awaited<ReturnType<typeof stat>>;
   try {
     st = await stat(input);
-  } catch {
-    return undefined;
+  } catch (error) {
+    // error-policy:J3 a genuinely-absent path is "not a Claude export" (probe
+    // returns undefined); any other stat failure (EACCES, EIO, ...) is a real
+    // I/O error on required input and must surface, not masquerade as absent.
+    if (isNotFound(error)) return undefined;
+    throw error;
   }
 
   if (st.isDirectory()) {
@@ -331,24 +343,25 @@ async function openConversationsStream(input: string): Promise<Readable> {
 }
 
 async function detect(input: string): Promise<boolean> {
-  try {
-    const resolved = await resolveInput(input);
-    if (!resolved) return false;
-    if (resolved.kind === "zip") {
-      const metadata = await findZipEntryMetadata(
-        resolved.path,
-        CONVERSATIONS_JSON,
-      );
-      if (!metadata) return false;
-    }
-
-    const first = await readFirstJsonArrayObject(
-      await openConversationsStream(input),
+  // Shape resolution decides recognition: an input that does not resolve to a
+  // Claude `conversations.json` (or a zip carrying one) is simply not a Claude
+  // export and returns false. Once it DOES resolve, the payload is required
+  // input — a corrupt/truncated/unreadable body throws so the caller sees a
+  // "corrupt Claude export" failure instead of a silent "unrecognized format".
+  const resolved = await resolveInput(input);
+  if (!resolved) return false;
+  if (resolved.kind === "zip") {
+    const metadata = await findZipEntryMetadata(
+      resolved.path,
+      CONVERSATIONS_JSON,
     );
-    return looksLikeClaudeConversation(first);
-  } catch {
-    return false;
+    if (!metadata) return false;
   }
+
+  const first = await readFirstJsonArrayObject(
+    await openConversationsStream(input),
+  );
+  return looksLikeClaudeConversation(first);
 }
 
 async function* parse(

--- a/packages/import-conversations/src/parsers/hermes.test.ts
+++ b/packages/import-conversations/src/parsers/hermes.test.ts
@@ -1,5 +1,7 @@
 /** Unit tests for the Hermes home parser: detect() and session/memory normalization over tmp-dir fixtures. Deterministic. */
 
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -48,6 +50,38 @@ describe("hermes parser: detect()", () => {
   it("returns false for a dir without a sessions/ subdir", async () => {
     // The memories dir has no sessions/ under it.
     expect(await detect(path.join(HERMES_HOME, "memories"))).toBe(false);
+  });
+
+  it("throws when sessions/ exists but is unreadable (real I/O error, not 'not a Hermes home')", async () => {
+    // sessions/ exists (existsSync passes) but is a regular file, so readdir
+    // fails with ENOTDIR. That is a real I/O error on required input and must
+    // surface, not be swallowed as a plain false.
+    const home = await mkdtemp(path.join(tmpdir(), "hermes-badsessions-"));
+    await writeFile(path.join(home, "sessions"), "not a directory", "utf8");
+    await expect(detect(home)).rejects.toThrow();
+  });
+});
+
+describe("hermes parser: parse() fail-closed on I/O", () => {
+  it("surfaces a readdir failure on an existing sessions/ instead of importing zero sessions", async () => {
+    // sessions/ resolves (existsSync passes) but is a file: readdir throws.
+    // parse() must propagate that rather than silently yielding nothing.
+    const home = await mkdtemp(path.join(tmpdir(), "hermes-parse-io-"));
+    await writeFile(path.join(home, "sessions"), "not a directory", "utf8");
+    await expect(
+      collect(parse(home, { includeMemories: false })),
+    ).rejects.toThrow();
+  });
+
+  it("surfaces a readdir failure on an existing memories/ instead of dropping notes", async () => {
+    // A valid sessions/ dir (so parse gets past sessions), plus a memories/
+    // that exists as a file: the memories readdir must surface, not be dropped.
+    const home = await mkdtemp(path.join(tmpdir(), "hermes-mem-io-"));
+    await mkdir(path.join(home, "sessions"));
+    await writeFile(path.join(home, "memories"), "not a directory", "utf8");
+    await expect(
+      collect(parse(home, { includeMemories: true })),
+    ).rejects.toThrow();
   });
 });
 

--- a/packages/import-conversations/src/parsers/hermes.ts
+++ b/packages/import-conversations/src/parsers/hermes.ts
@@ -39,6 +39,14 @@ export type ParseOptions = {
 
 const SOURCE = "hermes" as const;
 
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: string }).code === "ENOENT"
+  );
+}
+
 /**
  * Shape of a Hermes session_meta header line (first line of a session file).
  * `model` is often an empty string; `platform` records the connector (discord,
@@ -194,7 +202,9 @@ async function parseSessionFile(
       try {
         parsed = JSON.parse(line);
       } catch {
-        // Resilience: a truncated/corrupt line must not abort the session.
+        // error-policy:J3 each JSONL line is untrusted input; a truncated/
+        // corrupt line (common on the still-appending tail of a live session
+        // log) is skipped so it does not abort import of the valid lines.
         continue;
       }
 
@@ -271,8 +281,13 @@ async function parseMemoryFile(
   let content: string;
   try {
     content = await readFile(filePath, "utf8");
-  } catch {
-    return undefined;
+  } catch (error) {
+    // error-policy:J3 the path came from readdir moments ago; ENOENT means the
+    // note was removed under us (benign race in a live agent home) so we skip
+    // it. Any other read failure (EACCES, EIO, ...) is a real error and must
+    // surface rather than silently dropping the note.
+    if (isNotFound(error)) return undefined;
+    throw error;
   }
   if (content.trim().length === 0) return undefined;
 
@@ -323,19 +338,20 @@ async function detect(input: string): Promise<boolean> {
   try {
     const st = await stat(input);
     if (!st.isDirectory()) return false;
-  } catch {
-    return false;
+  } catch (error) {
+    // error-policy:J3 an absent path is "not a Hermes home"; any other stat
+    // failure (EACCES, EIO, ...) is a real I/O error and must surface.
+    if (isNotFound(error)) return false;
+    throw error;
   }
 
   const sessionsDir = resolveSessionsDir(input);
   if (!existsSync(sessionsDir)) return false;
 
-  let entries: string[];
-  try {
-    entries = await readdir(sessionsDir);
-  } catch {
-    return false;
-  }
+  // sessionsDir existed a moment ago (existsSync above): a readdir failure here
+  // is a real I/O error on required input, not "not a Hermes home" — surface it
+  // rather than silently reporting the export as unrecognized.
+  const entries = await readdir(sessionsDir);
   const jsonlFiles = entries.filter((f) => f.toLowerCase().endsWith(".jsonl"));
   const firstJsonl = jsonlFiles[0];
   if (!firstJsonl) return false;
@@ -360,6 +376,9 @@ async function detect(input: string): Promise<boolean> {
           parsed.role === "tool"
         );
       } catch {
+        // error-policy:J3 the signature line is untrusted input; a non-JSON
+        // first line means this file does not carry the Hermes signature, so
+        // the input is not a recognizable Hermes home (probe returns false).
         return false;
       }
     }
@@ -384,12 +403,9 @@ async function* parse(
 
   const sessionsDir = resolveSessionsDir(input);
   if (existsSync(sessionsDir)) {
-    let entries: string[] = [];
-    try {
-      entries = await readdir(sessionsDir);
-    } catch {
-      entries = [];
-    }
+    // existsSync passed: a readdir failure is a real I/O error, not an empty
+    // session set. Surface it rather than silently importing zero sessions.
+    const entries = await readdir(sessionsDir);
     const sessionFiles = entries
       .filter((f) => f.toLowerCase().endsWith(".jsonl"))
       .sort(); // filenames are timestamp-prefixed => chronological
@@ -403,12 +419,9 @@ async function* parse(
   if (opts.includeMemories) {
     const memoriesDir = resolveMemoriesDir(input);
     if (existsSync(memoriesDir)) {
-      let entries: string[] = [];
-      try {
-        entries = await readdir(memoriesDir);
-      } catch {
-        entries = [];
-      }
+      // existsSync passed: a readdir failure is a real I/O error on the
+      // memories dir, not "no notes". Surface it rather than dropping them.
+      const entries = await readdir(memoriesDir);
       const memoryFiles = entries
         .filter((f) => /^\d{4}-\d{2}-\d{2}\.md$/i.test(f))
         .sort();


### PR DESCRIPTION
Closes #12742 (slice of #12275-E / #12182).

## Problem

The conversation-export parsers (`chatgpt`, `claude`, `hermes`) wrapped `detect()` — and hermes wrapped `parse()`'s directory reads — in blanket `catch { return false }` / `catch { entries = [] }`. That conflated two conditions:

1. **"input is not this format"** — the honest `detect()` answer, should return `false`.
2. **"input IS this format but the required payload is corrupt/unreadable"** — a real failure on required input, was being **swallowed as `false`**.

So importing a genuinely-corrupt export (truncated `conversations.json`, or a `sessions/` dir that fails to read) reported "no parser recognized this export" instead of surfacing the corruption.

## Fix

- **`detect()`**: once an input resolves to this format's `conversations.json` (or a zip carrying it, or a `sessions/` dir), a corrupt/unreadable payload now **throws** instead of returning `false`. Genuinely-absent inputs (`ENOENT`) still return `false`.
- **hermes `parse()`**: `readdir` failures on an already-`existsSync`'d `sessions/` or `memories/` dir now surface, instead of silently importing zero sessions / dropping notes.
- `stat`/`read` catches narrowed to `ENOENT` (= not-an-export / benign readdir→read race); every other I/O failure (`EACCES`/`EIO`/`ENOTDIR`) propagates.
- Legitimate kept handlers (untrusted first-line signature parse; truncated final JSONL line on a still-appending session log) annotated `// error-policy:J3`.

The rest of #12275-E's package list (`browser-extension`, `contracts`, `homepage`, `os`, `native`) was audited; its remaining handlers are already correct (J1 error-boundary rethrows, honest reachability probes, J3 URL validators, throw-on-malformed core). Inventory + N/A rows: `.github/issue-evidence/12742-import-conversations-parser-fail-closed.md`.

## Tests

`bun run --cwd packages/import-conversations test` → **10 files / 113 passed**, including new cases per parser:
- corrupt resolved `conversations.json` → `detect()` **throws** (claude, chatgpt)
- `sessions/`/`memories/` present-but-unreadable → `detect()`/`parse()` **throw** (hermes)
- genuinely-absent path → still returns `false`

`bun run --cwd packages/import-conversations typecheck` → passed (`useUnknownInCatchVariables` on).
`bunx @biomejs/biome check src/parsers/*.ts` → clean.
`bun run audit:error-policy-ratchet` → no new fallback-slop in touched files.

— [sol-orch]
