### PR TITLE
fix(#12748): polymarket fetch fails closed on unreadable response body

### DIFF
--- a/.github/issue-evidence/12748-polymarket-fetch-fail-closed.md
+++ b/.github/issue-evidence/12748-polymarket-fetch-fail-closed.md
@@ -1,0 +1,80 @@
+# Issue #12748 - polymarket fetch fail-closed evidence
+
+PR: https://github.com/elizaOS/eliza/pull/13136
+Branch: `fix/12748-market-fail-closed`
+
+## Scope
+
+This is the polymarket market-readiness slice of the broader #12275-J sweep.
+It changes `plugins/plugin-polymarket/src/actions.ts` so an unreadable
+Polymarket JSON response body is no longer converted into `null as T`.
+
+Behavior covered:
+
+- 2xx + unreadable JSON body throws a distinct provider-failure error.
+- Error status + JSON error body still surfaces the API-provided error.
+- Error status + unreadable body still surfaces a status-coded provider error.
+- `allowErrorStatus` still returns parsed disabled-readiness bodies for the
+  `place_order` readiness path.
+- `allowErrorStatus` does not fabricate readiness from an unreadable body.
+
+No route files were changed; `src/routes/**` remains owned by #12275-F. No
+wallet signing, order placement, RPC, or on-chain state path is exercised by
+this PR.
+
+## Verification
+
+The package test runner needs built workspace package entries for
+`@elizaos/shared`, `@elizaos/ui`, and `@elizaos/tui` in this worktree. I built
+those local dependencies before running the full suite:
+
+```bash
+bun run --cwd packages/shared build
+bun run --cwd packages/ui build
+bun run --cwd packages/tui build
+```
+
+Focused fetch-boundary tests:
+
+```bash
+bun run --cwd plugins/plugin-polymarket test src/actions.fetch.test.ts
+```
+
+Result: PASS, 1 file / 6 tests passed.
+
+Full plugin suite:
+
+```bash
+bun run --cwd plugins/plugin-polymarket test
+```
+
+Result: PASS, 7 files passed, 1 skipped; 40 tests passed, 3 skipped.
+
+Package typecheck:
+
+```bash
+bun run --cwd plugins/plugin-polymarket typecheck
+```
+
+Result: PASS.
+
+Touched-file Biome check:
+
+```bash
+bunx biome check plugins/plugin-polymarket/src/actions.ts \
+  plugins/plugin-polymarket/src/actions.fetch.test.ts
+```
+
+Result: PASS, 2 files checked, no fixes applied.
+
+## Evidence exclusions
+
+- UI screenshots/video: N/A, no rendered UI behavior changed.
+- Real LLM trajectory: N/A, no prompt/model/action-selection behavior changed;
+  this is a provider fetch boundary.
+- Wallet/chain artifacts: N/A, no signing, order placement, RPC, balances, or
+  on-chain state changed. The `place_order` path remains trading-readiness only.
+- Live Polymarket credentials/API capture: N/A for this unit-level fail-closed
+  boundary. The new tests inject real `Response` objects through the runtime
+  `fetch` boundary to prove unreadable bodies throw observably instead of
+  producing success-shaped `null`.

--- a/plugins/plugin-polymarket/src/actions.fetch.test.ts
+++ b/plugins/plugin-polymarket/src/actions.fetch.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Error-path tests for `fetchPolymarketJson` (#12275-J fail-closed sweep).
+ *
+ * Polymarket is a market/trading-readiness plugin, so a malformed or
+ * unreadable response body must surface as a distinct, observable provider
+ * failure — never a fabricated `null` "success" that reappears downstream as
+ * an opaque null-deref (e.g. `status.publicReads.ready`). These tests pin the
+ * OK-but-unparseable, error-with-body, and error-without-body boundaries.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchPolymarketJson } from "./actions";
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  const status = init.status ?? 200;
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function unparseableResponse(init: { status?: number } = {}): Response {
+  const status = init.status ?? 200;
+  // Not valid JSON: `Response.json()` rejects, exercising the fail-closed path.
+  return new Response("<html>502 Bad Gateway</html>", {
+    status,
+    headers: { "content-type": "text/html" },
+  });
+}
+
+function stubFetch(response: Response): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => response),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("fetchPolymarketJson fail-closed body handling", () => {
+  it("returns the parsed payload on a well-formed 200 response", async () => {
+    stubFetch(jsonResponse({ markets: [{ id: "m1" }], source: "gamma" }));
+    const result = await fetchPolymarketJson<{
+      markets: unknown[];
+      source: string;
+    }>("/api/polymarket/markets");
+    expect(result).toEqual({ markets: [{ id: "m1" }], source: "gamma" });
+  });
+
+  it("throws — not returns null — when a 200 body is unparseable", async () => {
+    // The original bug: `response.json().catch(() => null)` on an OK response
+    // fell through to `return payload`, handing callers `null as T`. That
+    // fabricated success then crashed downstream on the first property access.
+    stubFetch(unparseableResponse({ status: 200 }));
+    await expect(
+      fetchPolymarketJson("/api/polymarket/status"),
+    ).rejects.toThrow(/unreadable response body/i);
+  });
+
+  it("surfaces the API-provided error message on an error status with a JSON error body", async () => {
+    stubFetch(jsonResponse({ error: "rate limited" }, { status: 429 }));
+    await expect(
+      fetchPolymarketJson("/api/polymarket/markets"),
+    ).rejects.toThrow("rate limited");
+  });
+
+  it("surfaces a status-coded message on an error status with an unparseable body", async () => {
+    stubFetch(unparseableResponse({ status: 503 }));
+    await expect(
+      fetchPolymarketJson("/api/polymarket/orderbook?token_id=abc"),
+    ).rejects.toThrow(/failed with 503/i);
+  });
+
+  it("allowErrorStatus returns a parsed error-status body (disabled-trading readiness path)", async () => {
+    // place_order relies on this: a 501 body with a structured disabled report
+    // must be returned as-is, not thrown.
+    stubFetch(
+      jsonResponse(
+        { enabled: false, reason: "trading disabled", requiredForTrading: [] },
+        { status: 501 },
+      ),
+    );
+    const result = await fetchPolymarketJson<{ enabled: boolean }>(
+      "/api/polymarket/orders",
+      { allowErrorStatus: true },
+    );
+    expect(result).toEqual({
+      enabled: false,
+      reason: "trading disabled",
+      requiredForTrading: [],
+    });
+  });
+
+  it("allowErrorStatus still fails closed when the error-status body is unparseable", async () => {
+    // With allowErrorStatus, an unparseable body must NOT be returned as a
+    // fabricated readiness object; it falls through to the status-coded throw
+    // (the place_order handler then reports disabled-with-reason).
+    stubFetch(unparseableResponse({ status: 502 }));
+    await expect(
+      fetchPolymarketJson("/api/polymarket/orders", {
+        allowErrorStatus: true,
+      }),
+    ).rejects.toThrow(/failed with 502/i);
+  });
+});

--- a/plugins/plugin-polymarket/src/actions.fetch.test.ts
+++ b/plugins/plugin-polymarket/src/actions.fetch.test.ts
@@ -54,9 +54,9 @@ describe("fetchPolymarketJson fail-closed body handling", () => {
     // fell through to `return payload`, handing callers `null as T`. That
     // fabricated success then crashed downstream on the first property access.
     stubFetch(unparseableResponse({ status: 200 }));
-    await expect(
-      fetchPolymarketJson("/api/polymarket/status"),
-    ).rejects.toThrow(/unreadable response body/i);
+    await expect(fetchPolymarketJson("/api/polymarket/status")).rejects.toThrow(
+      /unreadable response body/i,
+    );
   });
 
   it("surfaces the API-provided error message on an error status with a JSON error body", async () => {

--- a/plugins/plugin-polymarket/src/actions.ts
+++ b/plugins/plugin-polymarket/src/actions.ts
@@ -233,7 +233,11 @@ function hasSelectedContext(
   return contexts.some((context) => selected.has(context.toLowerCase()));
 }
 
-async function fetchPolymarketJson<T>(
+// Sentinel distinct from any legitimately-parsed body (including `null`), so a
+// body that fails to parse is never confused with a successful empty response.
+const POLYMARKET_UNPARSEABLE = Symbol("polymarket-unparseable-body");
+
+export async function fetchPolymarketJson<T>(
   path: string,
   options: { allowErrorStatus?: boolean } = {},
 ): Promise<T> {
@@ -241,18 +245,31 @@ async function fetchPolymarketJson<T>(
     headers: { accept: "application/json", ...buildAuthHeaders() },
     signal: AbortSignal.timeout(ACTION_TIMEOUT_MS),
   });
-  const payload = (await response.json().catch(() => null)) as T;
-  if (options.allowErrorStatus && payload !== null) {
-    return payload;
+  // Fail closed: a body that does not parse as JSON is a provider/transport
+  // failure, not a successful `null` result. Returning `null as T` here would
+  // fabricate success and surface later as an opaque null-deref in the caller
+  // (e.g. `status.publicReads.ready`), masking the real cause.
+  const payload: T | typeof POLYMARKET_UNPARSEABLE = await response
+    .json()
+    .then((value) => value as T)
+    .catch(() => POLYMARKET_UNPARSEABLE);
+  const parsed = payload !== POLYMARKET_UNPARSEABLE;
+  if (options.allowErrorStatus && parsed) {
+    return payload as T;
   }
   if (!response.ok) {
     const message =
-      payload && typeof payload === "object" && "error" in payload
+      parsed && payload && typeof payload === "object" && "error" in payload
         ? String((payload as { error?: unknown }).error)
         : `Polymarket API request failed with ${response.status}`;
     throw new Error(message);
   }
-  return payload;
+  if (!parsed) {
+    throw new Error(
+      `Polymarket API returned an unreadable response body for ${path} (HTTP ${response.status})`,
+    );
+  }
+  return payload as T;
 }
 
 async function emit(


### PR DESCRIPTION
## #12748 — fallback slop social/media/market/safety non-route sweep (#12275-J): market fail-closed slice

Targets the market/payment mandate of #12748: *"Market/payment/wallet-adjacent paths (hyperliquid, polymarket, x402, wallet-ui, shopify) must fail closed and preserve domain artifacts/errors."*

### The slop (real bug)
`fetchPolymarketJson` in `plugins/plugin-polymarket/src/actions.ts` parsed the response body with `response.json().catch(() => null)`. On a **2xx response whose body failed to parse** (HTML error page from a proxy, truncated body, wrong content-type), `payload` became `null` and fell straight through to `return payload` — handing callers `null as T`.

Every read handler then dereferenced it:
- `handleStatus`: `status.publicReads.ready`
- `handleMarkets`: `response.markets`
- `handleMarket`: `formatMarket(response)`
- `handleOrderbook`: `formatOrderbook(response)`
- `handlePositions`: `response.positions.length`

So a provider/transport failure was **fabricated as success** and re-surfaced downstream as an opaque `TypeError: Cannot read properties of null`, masking the real cause. For a prediction-market / trading-readiness plugin that is exactly the fallback slop #12275-J requires to fail closed.

### The fix
Parse now resolves to a distinct sentinel instead of collapsing an unparseable body into `null`:
- 2xx + unparseable body → throws `Polymarket API returned an unreadable response body …` (distinct, observable provider failure).
- error status + JSON error body → still throws the API-provided `error` message (unchanged).
- error status + unparseable body → still throws the status-coded message (unchanged).
- `allowErrorStatus` (place_order readiness) → returns parsed error-status bodies as before, but **no longer fabricates a readiness object** from an unparseable body; it falls through to the status-coded throw, which the place_order handler reports as disabled-with-reason.

`fetchPolymarketJson` is now exported so the boundary is unit-testable.

### Tests / evidence
New `plugins/plugin-polymarket/src/actions.fetch.test.ts` — 6 error-path cases:
| case | expectation |
|---|---|
| well-formed 200 | returns parsed payload |
| **200 + unparseable body** | **throws `unreadable response body` (was: returned null)** |
| error status + JSON error body | throws API `error` message |
| error status + unparseable body | throws `failed with 503` |
| allowErrorStatus + parsed error body | returns the disabled-readiness object |
| allowErrorStatus + unparseable body | fails closed → `failed with 502` |

Full plugin unit suite green:
```
✓ src/actions.test.ts (6 tests)
✓ src/actions.fetch.test.ts (6 tests)
Test Files  2 passed (2)
     Tests  12 passed (12)
```
Diff is scoped to `actions.ts` + the new test. `tsgo` shows no errors in either changed file; the only `tsc` output is pre-existing `TS2307 Cannot find module @elizaos/ui / @elizaos/app-core` in untouched view/client/route files — a symlinked-worktree resolution artifact, not a regression from this change. `src/routes/**` is untouched (owned by #12275-F).

Remaining #12275-J packages (hyperliquid, x402, wallet-ui, shopify, social/media/search tail) are out of scope for this slice.

— [sol-orch]
