### PR TITLE
fix(#12788): fail closed on corrupt credit_balance reads (cloud-shared)

### DIFF
--- a/.github/issue-evidence/12788-cloud-shared-credit-balance-fail-closed.md
+++ b/.github/issue-evidence/12788-cloud-shared-credit-balance-fail-closed.md
@@ -1,0 +1,34 @@
+# Issue #12788 - cloud-shared credit_balance fail-closed evidence
+
+## Scope
+
+- Hardened the cloud-shared credit balance read paths so corrupt `credit_balance`
+  rows fail closed instead of returning success-shaped values.
+- `CreditsService.getOrganizationBalanceUsd` still returns `0` for a missing
+  organization as the documented gate fail-safe, annotated with
+  `error-policy:J6`.
+- `getCreditBalanceResponse` preserves missing-organization `404` behavior and
+  throws `500 internal_error` for corrupt balances.
+- No schema, migration, UI, model, prompt, or deployment changes.
+
+## Verification
+
+Commands run from `/private/tmp/codex-12845-cloud-shared-db`.
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `bun test --isolate packages/cloud/shared/src/lib/services/__tests__/credit-balance-fail-closed.test.ts` | PASS | 8 tests passed; covers corrupt/missing/happy-path behavior for both read paths. |
+| `bun test --isolate packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts` | PASS | 21 tests passed; adjacent inference billing ledger coverage. |
+| `bunx biome check packages/cloud/shared/src/lib/services/credits.ts packages/cloud/shared/src/lib/services/credit-balance-response.ts packages/cloud/shared/src/lib/services/__tests__/credit-balance-fail-closed.test.ts` | PASS | Touched-file formatting/lint check passed after applying Biome to touched files only. |
+| `bun run --cwd packages/cloud/shared typecheck` | BLOCKED | Fails before this change on transitive `packages/app-core/src/services/account-pool.ts` / `coding-account-bridge.ts` missing `@elizaos/auth/*` modules and related implicit-any errors. |
+| `bun run audit:error-policy-ratchet` | PASS | No new fallback-slop in touched production files. |
+| `git diff --check` | PASS | No whitespace errors. |
+| `bun run verify` | BLOCKED | Reached unrelated workspace lint failures in `@elizaos/electrobun#lint`, `@elizaos/tui#lint`, `@elizaos/plugin-training#lint`, and `@elizaos/bun-ios-runtime#lint`; write-mode side effects in native runtime scripts were restored. |
+
+## Evidence Not Applicable
+
+- UI screenshots/video: N/A, no UI surface changed.
+- Real-LLM trajectory: N/A, no prompt/model/action behavior changed.
+- Backend runtime logs: N/A, no route was exercised in a running cloud stack; the
+  changed code paths are covered by isolated service tests.
+- Database migration evidence: N/A, no schema or migration changed.

--- a/packages/cloud/shared/src/lib/services/__tests__/credit-balance-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credit-balance-fail-closed.test.ts
@@ -9,17 +9,16 @@
  *     gate and is written back as a KV balance hint.
  *   - `getCreditBalanceResponse` — the DTO returned to the dashboard / API.
  *
- * `Number(null)` / `Number("not-a-number")` is `NaN`, which is a FAILED read
- * masquerading as a success-shaped value: it serializes to `balance: null` over
- * JSON and pollutes the gate hint. These tests assert both paths now fail loudly
- * on a non-finite balance instead of returning a wrong-but-plausible number, and
- * that the happy path + documented missing-org fail-safe still behave.
+ * `Number(null)` becomes a fake $0 and `Number("not-a-number")` becomes `NaN`
+ * that serializes to `balance: null` over JSON. These tests assert both paths
+ * now fail loudly on corrupt reads instead of returning a wrong-but-plausible
+ * number, and that the happy path + documented missing-org fail-safe still
+ * behave.
  */
 
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
-
-import type { Organization } from "../../../db/schemas/organizations";
 import { organizationsRepository } from "../../../db/repositories";
+import type { Organization } from "../../../db/schemas/organizations";
 import { ApiError } from "../../api/cloud-worker-errors";
 import { getCreditBalanceResponse } from "../credit-balance-response";
 import { creditsService } from "../credits";
@@ -40,9 +39,7 @@ afterEach(() => {
 
 describe("CreditsService.getOrganizationBalanceUsd fail-closed", () => {
   test("parses a well-formed numeric-string balance", async () => {
-    const s = spyOn(organizationsRepository, "findById").mockResolvedValue(
-      orgWithBalance("12.5"),
-    );
+    const s = spyOn(organizationsRepository, "findById").mockResolvedValue(orgWithBalance("12.5"));
     spies.push(s);
     expect(await creditsService.getOrganizationBalanceUsd(ORG_ID)).toBe(12.5);
   });
@@ -54,9 +51,7 @@ describe("CreditsService.getOrganizationBalanceUsd fail-closed", () => {
   });
 
   test("present org with null balance THROWS instead of coercing to NaN", async () => {
-    const s = spyOn(organizationsRepository, "findById").mockResolvedValue(
-      orgWithBalance(null),
-    );
+    const s = spyOn(organizationsRepository, "findById").mockResolvedValue(orgWithBalance(null));
     spies.push(s);
     await expect(creditsService.getOrganizationBalanceUsd(ORG_ID)).rejects.toThrow(
       /credit_balance/,
@@ -76,9 +71,7 @@ describe("CreditsService.getOrganizationBalanceUsd fail-closed", () => {
 
 describe("getCreditBalanceResponse fail-closed", () => {
   test("returns the parsed balance for a well-formed row", async () => {
-    const s = spyOn(organizationsService, "getById").mockResolvedValue(
-      orgWithBalance("42.000000"),
-    );
+    const s = spyOn(organizationsService, "getById").mockResolvedValue(orgWithBalance("42.000000"));
     spies.push(s);
     expect(await getCreditBalanceResponse(ORG_ID)).toEqual({ balance: 42 });
   });
@@ -92,9 +85,7 @@ describe("getCreditBalanceResponse fail-closed", () => {
   });
 
   test("null balance throws a 500 internal_error, not a fake $0 (Number(null)===0)", async () => {
-    const s = spyOn(organizationsService, "getById").mockResolvedValue(
-      orgWithBalance(null),
-    );
+    const s = spyOn(organizationsService, "getById").mockResolvedValue(orgWithBalance(null));
     spies.push(s);
     let thrown: unknown;
     try {

--- a/packages/cloud/shared/src/lib/services/__tests__/credit-balance-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credit-balance-fail-closed.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Fail-closed coverage for credit-balance READ paths (#12268 fallback-slop sweep).
+ *
+ * `credit_balance` is a Drizzle `numeric` column, so it arrives at the row
+ * boundary as a string (or null/garbage on a corrupt read). Two read paths
+ * used to coerce it with a bare `Number(...)`:
+ *
+ *   - `CreditsService.getOrganizationBalanceUsd` — feeds the optimistic-billing
+ *     gate and is written back as a KV balance hint.
+ *   - `getCreditBalanceResponse` — the DTO returned to the dashboard / API.
+ *
+ * `Number(null)` / `Number("not-a-number")` is `NaN`, which is a FAILED read
+ * masquerading as a success-shaped value: it serializes to `balance: null` over
+ * JSON and pollutes the gate hint. These tests assert both paths now fail loudly
+ * on a non-finite balance instead of returning a wrong-but-plausible number, and
+ * that the happy path + documented missing-org fail-safe still behave.
+ */
+
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+
+import type { Organization } from "../../../db/schemas/organizations";
+import { organizationsRepository } from "../../../db/repositories";
+import { ApiError } from "../../api/cloud-worker-errors";
+import { getCreditBalanceResponse } from "../credit-balance-response";
+import { creditsService } from "../credits";
+import { organizationsService } from "../organizations";
+
+const ORG_ID = "00000000-0000-0000-0000-0000000000f1";
+
+function orgWithBalance(credit_balance: unknown): Organization {
+  // Only `credit_balance` is exercised by the code under test; the rest of the
+  // row is irrelevant, so cast a minimal object to the row type.
+  return { id: ORG_ID, credit_balance } as unknown as Organization;
+}
+
+const spies: Array<{ mockRestore: () => void }> = [];
+afterEach(() => {
+  while (spies.length) spies.pop()?.mockRestore();
+});
+
+describe("CreditsService.getOrganizationBalanceUsd fail-closed", () => {
+  test("parses a well-formed numeric-string balance", async () => {
+    const s = spyOn(organizationsRepository, "findById").mockResolvedValue(
+      orgWithBalance("12.5"),
+    );
+    spies.push(s);
+    expect(await creditsService.getOrganizationBalanceUsd(ORG_ID)).toBe(12.5);
+  });
+
+  test("missing org returns 0 (documented gate fail-safe -> slow path)", async () => {
+    const s = spyOn(organizationsRepository, "findById").mockResolvedValue(undefined);
+    spies.push(s);
+    expect(await creditsService.getOrganizationBalanceUsd(ORG_ID)).toBe(0);
+  });
+
+  test("present org with null balance THROWS instead of coercing to NaN", async () => {
+    const s = spyOn(organizationsRepository, "findById").mockResolvedValue(
+      orgWithBalance(null),
+    );
+    spies.push(s);
+    await expect(creditsService.getOrganizationBalanceUsd(ORG_ID)).rejects.toThrow(
+      /credit_balance/,
+    );
+  });
+
+  test("present org with non-numeric balance THROWS (no NaN gate hint)", async () => {
+    const s = spyOn(organizationsRepository, "findById").mockResolvedValue(
+      orgWithBalance("not-a-number"),
+    );
+    spies.push(s);
+    await expect(creditsService.getOrganizationBalanceUsd(ORG_ID)).rejects.toThrow(
+      /credit_balance/,
+    );
+  });
+});
+
+describe("getCreditBalanceResponse fail-closed", () => {
+  test("returns the parsed balance for a well-formed row", async () => {
+    const s = spyOn(organizationsService, "getById").mockResolvedValue(
+      orgWithBalance("42.000000"),
+    );
+    spies.push(s);
+    expect(await getCreditBalanceResponse(ORG_ID)).toEqual({ balance: 42 });
+  });
+
+  test("missing org throws a 404 (unchanged behavior)", async () => {
+    const s = spyOn(organizationsService, "getById").mockResolvedValue(undefined);
+    spies.push(s);
+    await expect(getCreditBalanceResponse(ORG_ID)).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  test("null balance throws a 500 internal_error, not a fake $0 (Number(null)===0)", async () => {
+    const s = spyOn(organizationsService, "getById").mockResolvedValue(
+      orgWithBalance(null),
+    );
+    spies.push(s);
+    let thrown: unknown;
+    try {
+      await getCreditBalanceResponse(ORG_ID);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(ApiError);
+    expect((thrown as ApiError).status).toBe(500);
+    expect((thrown as ApiError).code).toBe("internal_error");
+  });
+
+  test("non-numeric balance throws a 500 internal_error, not balance:null", async () => {
+    const s = spyOn(organizationsService, "getById").mockResolvedValue(
+      orgWithBalance("not-a-number"),
+    );
+    spies.push(s);
+    let thrown: unknown;
+    try {
+      await getCreditBalanceResponse(ORG_ID);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(ApiError);
+    expect((thrown as ApiError).status).toBe(500);
+    expect((thrown as ApiError).code).toBe("internal_error");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/credit-balance-response.ts
+++ b/packages/cloud/shared/src/lib/services/credit-balance-response.ts
@@ -19,11 +19,7 @@ export async function getCreditBalanceResponse(
   // balance (#12268 fallback-slop sweep).
   const balance = Number.parseFloat(String(organization.credit_balance ?? ""));
   if (!Number.isFinite(balance)) {
-    throw new ApiError(
-      500,
-      "internal_error",
-      "Unable to read credit balance for organization",
-    );
+    throw new ApiError(500, "internal_error", "Unable to read credit balance for organization");
   }
 
   return { balance };

--- a/packages/cloud/shared/src/lib/services/credit-balance-response.ts
+++ b/packages/cloud/shared/src/lib/services/credit-balance-response.ts
@@ -1,4 +1,4 @@
-import { NotFoundError } from "../api/cloud-worker-errors";
+import { ApiError, NotFoundError } from "../api/cloud-worker-errors";
 import type { CreditBalanceResponse } from "../types/cloud-api";
 import { organizationsService } from "./organizations";
 
@@ -10,5 +10,21 @@ export async function getCreditBalanceResponse(
     throw NotFoundError("Organization not found");
   }
 
-  return { balance: Number(organization.credit_balance) };
+  // `credit_balance` is a Drizzle numeric (string at the row boundary). A
+  // null/non-numeric value is a corrupt read, not a $0 balance. `Number(...)`
+  // would hide the fault two ways: `Number(null)` is a plausible-but-wrong `0`,
+  // and `Number("garbage")` is `NaN` that serializes to `balance: null`. Parse
+  // via string so null/undefined/garbage all land on the same non-finite guard,
+  // and fail closed with a 500 rather than reporting a success-shaped, wrong
+  // balance (#12268 fallback-slop sweep).
+  const balance = Number.parseFloat(String(organization.credit_balance ?? ""));
+  if (!Number.isFinite(balance)) {
+    throw new ApiError(
+      500,
+      "internal_error",
+      "Unable to read credit balance for organization",
+    );
+  }
+
+  return { balance };
 }

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -427,10 +427,18 @@ export class CreditsService {
    * cached one. Called only on the gate's COLD path (the gate caches its own
    * short-lived hint), so it is not on the per-request hot path. Returns 0 for a
    * missing org so the gate fails safe (slow path).
+   *
+   * A PRESENT org with a null/non-numeric `credit_balance` is a corrupt read,
+   * not a $0 balance: `parseNumeric` throws rather than coercing it to `NaN`.
+   * A silent `NaN` here would be written as a poisoned gate hint and, in
+   * `getCreditBalanceResponse`, serialized to the client as `balance: null`
+   * (#12268 fallback-slop: failed data must not become a success-shaped value).
    */
   async getOrganizationBalanceUsd(organizationId: string): Promise<number> {
     const org = await organizationsRepository.findById(organizationId);
-    return org ? Number(org.credit_balance) : 0;
+    // error-policy:J6 missing org → 0 is the documented fail-safe (gate slow-paths).
+    if (!org) return 0;
+    return parseNumeric(org.credit_balance, "credit_balance");
   }
 
   async getTransactionByStripePaymentIntent(


### PR DESCRIPTION
## What

Two credit-balance **read** paths in `packages/cloud/shared` coerced the Drizzle
`numeric` `credit_balance` column with a bare `Number(...)`, converting a
failed/corrupt read into a **success-shaped value** — the exact anti-pattern
#12788 / #12268 targets ("domain computations must not convert missing/failed
data into zero/empty success-shaped values").

`credit_balance` arrives at the row boundary as a **string** (Drizzle numeric).
`Number(null) === 0` and `Number("garbage") === NaN`, so both a missing and a
corrupt value silently became a plausible-but-wrong number.

### `CreditsService.getOrganizationBalanceUsd`
Feeds the optimistic-billing gate and is written back as a KV balance hint. A
present org with a null/non-numeric balance yielded `NaN`, which then gets
persisted as a **poisoned gate hint**. Now parses via the in-file `parseNumeric`
(throws on non-finite). The documented missing-org `return 0` fail-safe (gate
slow-paths) is preserved and annotated `// error-policy:J6`.

### `getCreditBalanceResponse`
The DTO returned to the dashboard / API. `Number(credit_balance)` hid faults two
ways: `Number(null)` is a wrong `0`, and `Number("garbage")` is `NaN` that
serializes to `balance: null` over JSON. Now parses via
`Number.parseFloat(String(x ?? ""))` and **fails closed with a 500
`internal_error`** on a non-finite balance instead of reporting a wrong balance.
The existing 404-on-missing-org behavior is unchanged.

## Tests & evidence

New `packages/cloud/shared/src/lib/services/__tests__/credit-balance-fail-closed.test.ts`
(`bun test --isolate`), **8/8 green**:

- `getOrganizationBalanceUsd`: well-formed string parses; missing org → `0`
  (documented fail-safe); present org with `null` and with non-numeric string
  both **throw** (no `NaN` gate hint).
- `getCreditBalanceResponse`: well-formed parses; missing org → **404**
  (unchanged); `null` balance → **500 internal_error** (not a fake `$0`);
  non-numeric balance → **500 internal_error** (not `balance: null`).

Regression check:
- `inference-billing-fast-path.test.ts` — 28/28 green (the primary consumer of
  `getOrganizationBalanceUsd`).
- The 2 `reconcile()` timeouts in `credits-deduct-guard.test.ts` are a
  **pre-existing PGlite flake on clean `origin/develop`** (verified by stashing
  this diff and re-running: identical 9 pass / 2 fail), unrelated to this change.
- `tsgo` typecheck surfaces only pre-existing environmental errors (missing
  `@elizaos/auth` subpath decls from the shared node_modules, redis / anthropic
  SDK drift); **zero in the touched files**.

## Scope note

Focused fail-closed slice of the #12788 (`packages/cloud/shared`) sweep: the two
credit-balance read paths that surface a value to a consumer (billing gate hint
+ API DTO). Route files remain owned by their own splits; the billing markup
math (`billing/markup.ts`, `billing/credit-markup.ts`) is already fail-loud
(throws `RangeError` on invalid input) and left untouched.

— [sol-orch]
