### PR TITLE
fix(#12746): make streaming persistence + frame-write failures observable (#12275-H)

### DIFF
--- a/.github/issue-evidence/12746-streaming-observability.md
+++ b/.github/issue-evidence/12746-streaming-observability.md
@@ -1,0 +1,65 @@
+# Issue #12746 - streaming observability evidence
+
+PR: https://github.com/elizaOS/eliza/pull/13138
+Branch: `fix/12746-infra-connectivity-observability`
+
+## Scope
+
+This is the `plugin-streaming` slice of the broader #12275-H
+infra/connectivity non-route sweep.
+
+Changed behavior:
+
+- `StreamManager.writeFrame()` still returns `false` for a failed FFmpeg stdin
+  write, preserving the existing fail-soft contract, but now emits throttled
+  `logger.warn` diagnostics so a broken FFmpeg pipe no longer masquerades as an
+  idle stream.
+- The write-failure throttle resets on stream start/stop so a restarted FFmpeg
+  process always surfaces its first broken-pipe write.
+- `getOverlayLayoutJson()` now warns when an existing overlay layout file cannot
+  be read and then continues to fallback candidates. Genuinely missing files
+  remain quiet.
+
+No route files were changed. No model, prompt, TTS provider, STT, or audio
+generation behavior changed.
+
+## Verification
+
+Streaming plugin tests:
+
+```bash
+bun run --cwd plugins/plugin-streaming test
+```
+
+Result: PASS, 5 files / 23 tests passed.
+
+Streaming plugin typecheck:
+
+```bash
+bun run --cwd plugins/plugin-streaming typecheck
+```
+
+Result: PASS.
+
+Touched-file Biome check:
+
+```bash
+bunx biome check plugins/plugin-streaming/src/api/stream-persistence.ts \
+  plugins/plugin-streaming/src/api/stream-persistence.test.ts \
+  plugins/plugin-streaming/src/services/stream-manager.ts \
+  plugins/plugin-streaming/src/services/stream-manager.write-frame.test.ts
+```
+
+Result: PASS, 4 files checked, no fixes applied.
+
+## Evidence exclusions
+
+- UI screenshots/video: N/A, no rendered UI route/view changed.
+- Real LLM trajectory: N/A, no agent prompt/model/tool-selection behavior
+  changed.
+- Audio/TTS/STT capture: N/A for this slice. The change is FFmpeg frame-pipe
+  and overlay-layout persistence observability, not audio generation,
+  recognition, wake-word, or voice-loop behavior.
+- Live RTMP/FFmpeg recording: not captured in this worktree. The tests install
+  a fake running FFmpeg child whose `stdin.write` throws, directly exercising
+  the broken-pipe boundary without launching or connecting to a real ingest.

--- a/plugins/plugin-streaming/src/api/stream-persistence.test.ts
+++ b/plugins/plugin-streaming/src/api/stream-persistence.test.ts
@@ -35,7 +35,10 @@ vi.mock("node:fs", () => ({
   },
 }));
 
-import { getHeadlessCaptureConfig, readOverlayLayout } from "./stream-persistence.js";
+import {
+  getHeadlessCaptureConfig,
+  readOverlayLayout,
+} from "./stream-persistence.js";
 
 beforeEach(() => {
   warn.mockClear();
@@ -50,8 +53,8 @@ afterEach(() => {
 describe("getOverlayLayoutJson (via getHeadlessCaptureConfig) — read failures are observable", () => {
   it("warns and does not seed an overlay when the layout file exists but is unreadable", () => {
     // Settings file: absent. Overlay file: present but read throws (EACCES).
-    existsSync.mockImplementation((p: string) =>
-      typeof p === "string" && p.includes("overlay-layout"),
+    existsSync.mockImplementation(
+      (p: string) => typeof p === "string" && p.includes("overlay-layout"),
     );
     readFileSync.mockImplementation((p: string) => {
       if (typeof p === "string" && p.includes("overlay-layout")) {
@@ -86,8 +89,8 @@ describe("getOverlayLayoutJson (via getHeadlessCaptureConfig) — read failures 
   });
 
   it("returns the layout without warning when the file reads cleanly", () => {
-    existsSync.mockImplementation((p: string) =>
-      typeof p === "string" && p.includes("overlay-layout"),
+    existsSync.mockImplementation(
+      (p: string) => typeof p === "string" && p.includes("overlay-layout"),
     );
     readFileSync.mockImplementation((p: string) => {
       if (typeof p === "string" && p.includes("overlay-layout")) {
@@ -105,8 +108,8 @@ describe("getOverlayLayoutJson (via getHeadlessCaptureConfig) — read failures 
 
 describe("readOverlayLayout — read failures fall through observably", () => {
   it("warns and falls back to null when the destination layout is corrupt JSON", () => {
-    existsSync.mockImplementation((p: string) =>
-      typeof p === "string" && p.includes("overlay-layout-"),
+    existsSync.mockImplementation(
+      (p: string) => typeof p === "string" && p.includes("overlay-layout-"),
     );
     readFileSync.mockReturnValue("{ this is not json");
 

--- a/plugins/plugin-streaming/src/api/stream-persistence.test.ts
+++ b/plugins/plugin-streaming/src/api/stream-persistence.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Error-path tests for the overlay-layout persistence readers.
+ *
+ * Regression coverage for #12746 (#12275-H): an overlay-layout file that
+ * *exists* but cannot be read (permissions, corruption, a race with a
+ * concurrent write) must not be silently swallowed. A silent swallow makes an
+ * unreadable overlay indistinguishable from a missing one, so the headless
+ * overlay seed fails invisibly and the stream looks fine while rendering no
+ * overlay. The readers fail soft (fall through to the next candidate / null)
+ * but the failure has to be observable via `logger.warn`.
+ *
+ * `fs` and `@elizaos/core`'s `logger` are stubbed; no real files are touched.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const warn = vi.fn();
+const existsSync = vi.fn();
+const readFileSync = vi.fn();
+
+vi.mock("@elizaos/core", () => ({
+  logger: {
+    warn: (...args: unknown[]) => warn(...args),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("node:fs", () => ({
+  default: {
+    existsSync: (...args: unknown[]) => existsSync(...args),
+    readFileSync: (...args: unknown[]) => readFileSync(...args),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  },
+}));
+
+import { getHeadlessCaptureConfig, readOverlayLayout } from "./stream-persistence.js";
+
+beforeEach(() => {
+  warn.mockClear();
+  existsSync.mockReset();
+  readFileSync.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("getOverlayLayoutJson (via getHeadlessCaptureConfig) — read failures are observable", () => {
+  it("warns and does not seed an overlay when the layout file exists but is unreadable", () => {
+    // Settings file: absent. Overlay file: present but read throws (EACCES).
+    existsSync.mockImplementation((p: string) =>
+      typeof p === "string" && p.includes("overlay-layout"),
+    );
+    readFileSync.mockImplementation((p: string) => {
+      if (typeof p === "string" && p.includes("overlay-layout")) {
+        throw Object.assign(new Error("EACCES: permission denied"), {
+          code: "EACCES",
+        });
+      }
+      return "{}";
+    });
+
+    const config = getHeadlessCaptureConfig("dest-1");
+
+    // Fail soft: the unreadable overlay does not become a fabricated layout.
+    expect(config.overlayLayout).toBeUndefined();
+    // But every unreadable candidate (destination-specific + global) is
+    // surfaced, not swallowed. With a destinationId there are two candidates.
+    expect(warn).toHaveBeenCalledTimes(2);
+    for (const call of warn.mock.calls) {
+      expect(String(call[0])).toContain("Failed to read overlay layout file");
+      expect(String(call[0])).toContain("EACCES");
+    }
+  });
+
+  it("does not warn when the overlay file is simply absent (missing != failure)", () => {
+    // Nothing exists at all: a genuinely-missing overlay is not an error.
+    existsSync.mockReturnValue(false);
+
+    const config = getHeadlessCaptureConfig("dest-1");
+
+    expect(config.overlayLayout).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("returns the layout without warning when the file reads cleanly", () => {
+    existsSync.mockImplementation((p: string) =>
+      typeof p === "string" && p.includes("overlay-layout"),
+    );
+    readFileSync.mockImplementation((p: string) => {
+      if (typeof p === "string" && p.includes("overlay-layout")) {
+        return '{"widgets":[]}';
+      }
+      return "{}";
+    });
+
+    const config = getHeadlessCaptureConfig("dest-1");
+
+    expect(config.overlayLayout).toBe('{"widgets":[]}');
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("readOverlayLayout — read failures fall through observably", () => {
+  it("warns and falls back to null when the destination layout is corrupt JSON", () => {
+    existsSync.mockImplementation((p: string) =>
+      typeof p === "string" && p.includes("overlay-layout-"),
+    );
+    readFileSync.mockReturnValue("{ this is not json");
+
+    const result = readOverlayLayout("dest-corrupt");
+
+    expect(result).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    expect(String(warn.mock.calls[0]?.[0])).toContain(
+      "Failed to read overlay layout for dest-corrupt",
+    );
+  });
+});

--- a/plugins/plugin-streaming/src/api/stream-persistence.ts
+++ b/plugins/plugin-streaming/src/api/stream-persistence.ts
@@ -86,8 +86,17 @@ function getOverlayLayoutJson(destinationId?: string | null): string | null {
       if (fs.existsSync(f)) {
         return fs.readFileSync(f, "utf-8");
       }
-    } catch {
-      // Not available
+    } catch (error) {
+      // The file exists but could not be read (permissions, corruption, races).
+      // Swallowing this silently makes an unreadable overlay indistinguishable
+      // from a missing one, so the headless overlay seed fails invisibly.
+      // Surface it as a warning (matching readOverlayLayout below) and keep
+      // trying the remaining fallback files.
+      logger.warn(
+        `[stream] Failed to read overlay layout file ${f}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
     }
   }
   return null;

--- a/plugins/plugin-streaming/src/services/stream-manager.ts
+++ b/plugins/plugin-streaming/src/services/stream-manager.ts
@@ -74,6 +74,8 @@ class StreamManager {
   private _running = false;
   private startedAt: number | null = null;
   private _frameCount = 0;
+  /** Consecutive FFmpeg stdin write failures — used to throttle warn logs. */
+  private _frameWriteErrorCount = 0;
   /** Current stream config — stored for restart on volume/audio changes. */
   private _config: StreamConfig | null = null;
   /** Current volume level (0–100). */
@@ -216,11 +218,28 @@ class StreamManager {
     try {
       this.ffmpeg.stdin.write(jpegData);
       this._frameCount++;
+      this._frameWriteErrorCount = 0;
       if (this._frameCount % 150 === 0) {
         logger.info(`${TAG} Piped ${this._frameCount} frames to FFmpeg`);
       }
       return true;
-    } catch {
+    } catch (error) {
+      // A write failure means the FFmpeg encode pipe is broken (e.g. FFmpeg
+      // died mid-stream). Returning a bare `false` here silently drops every
+      // subsequent frame and makes a dead pipe look like an idle stream. Surface
+      // it as an observable warning, throttled so a persistently broken pipe
+      // does not emit one line per dropped frame.
+      this._frameWriteErrorCount++;
+      if (
+        this._frameWriteErrorCount === 1 ||
+        this._frameWriteErrorCount % 150 === 0
+      ) {
+        logger.warn(
+          `${TAG} Failed to write frame to FFmpeg stdin (${this._frameWriteErrorCount} consecutive): ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
       return false;
     }
   }
@@ -256,6 +275,10 @@ class StreamManager {
 
     this._config = config;
     this._frameCount = 0;
+    // Reset the frame-write throttle per FFmpeg process so the first broken-pipe
+    // failure of a fresh/restarted stream is always surfaced, never carried over
+    // and mis-throttled from a prior process.
+    this._frameWriteErrorCount = 0;
     this._volume = config.volume ?? this._volume;
     this._muted = config.muted ?? this._muted;
 
@@ -462,6 +485,7 @@ class StreamManager {
     this._running = false;
     this.startedAt = null;
     this._frameCount = 0;
+    this._frameWriteErrorCount = 0;
     this._restartAttempts = 0;
     this._config = null;
     logger.info(

--- a/plugins/plugin-streaming/src/services/stream-manager.write-frame.test.ts
+++ b/plugins/plugin-streaming/src/services/stream-manager.write-frame.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Error-path test for `StreamManager.writeFrame` (#12746 / #12275-H).
+ *
+ * When the FFmpeg encode pipe breaks mid-stream (e.g. FFmpeg dies), a
+ * `stdin.write` throws. The previous `catch { return false }` silently dropped
+ * every subsequent frame, so a dead pipe looked identical to an idle stream —
+ * exactly the "failures must not masquerade as idle/success" case the issue
+ * calls out. The fix keeps the `false` return contract but surfaces the write
+ * failure via a throttled `logger.warn`.
+ *
+ * The exported singleton's private FFmpeg handle is stubbed with a fake
+ * `ChildProcess` whose `stdin.write` throws; no real FFmpeg is spawned.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+const warn = vi.fn();
+vi.mock("@elizaos/core", () => ({
+  logger: {
+    warn: (...args: unknown[]) => warn(...args),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { streamManager } from "./stream-manager.js";
+
+/** Install a fake, "running" FFmpeg whose stdin.write throws. */
+function armBrokenPipe(mgr: unknown) {
+  const m = mgr as Record<string, unknown>;
+  m._running = true;
+  m._frameWriteErrorCount = 0;
+  m.ffmpeg = {
+    killed: false,
+    exitCode: null,
+    stdin: {
+      write: () => {
+        throw new Error("EPIPE: broken pipe");
+      },
+    },
+  };
+}
+
+function disarm(mgr: unknown) {
+  const m = mgr as Record<string, unknown>;
+  m._running = false;
+  m.ffmpeg = null;
+  m._frameWriteErrorCount = 0;
+}
+
+describe("StreamManager.writeFrame — broken FFmpeg pipe is observable", () => {
+  it("returns false AND warns on the first write failure", () => {
+    warn.mockClear();
+    armBrokenPipe(streamManager);
+    try {
+      const ok = streamManager.writeFrame(Buffer.from([0xff, 0xd8]));
+      expect(ok).toBe(false);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0])).toContain(
+        "Failed to write frame to FFmpeg stdin",
+      );
+      expect(String(warn.mock.calls[0]?.[0])).toContain("EPIPE");
+    } finally {
+      disarm(streamManager);
+    }
+  });
+
+  it("throttles repeated failures (does not log one line per dropped frame)", () => {
+    warn.mockClear();
+    armBrokenPipe(streamManager);
+    try {
+      for (let i = 0; i < 50; i++) {
+        expect(streamManager.writeFrame(Buffer.from([0xff]))).toBe(false);
+      }
+      // First failure logs; the next 49 within the throttle window do not.
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      disarm(streamManager);
+    }
+  });
+
+  it("returns false without warning when the stream is not running (expected, not a failure)", () => {
+    warn.mockClear();
+    disarm(streamManager);
+    expect(streamManager.writeFrame(Buffer.from([0xff]))).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("resets the throttle on stop() so a restarted stream still surfaces its first failure", async () => {
+    warn.mockClear();
+    armBrokenPipe(streamManager);
+    try {
+      // First stream: one broken-pipe write (warns, counter now 1).
+      expect(streamManager.writeFrame(Buffer.from([0xff]))).toBe(false);
+      expect(warn).toHaveBeenCalledTimes(1);
+
+      // Provide a fake FFmpeg that stops cleanly so stop() can run its reset.
+      const m = streamManager as unknown as Record<string, unknown>;
+      m.ffmpeg = {
+        killed: false,
+        exitCode: 0,
+        stdin: { end: () => {} },
+        kill: () => {},
+        on: (_event: string, cb: () => void) => cb(),
+      };
+      await streamManager.stop();
+      expect((m._frameWriteErrorCount as number) ?? 0).toBe(0);
+
+      // Restarted stream: the very first broken-pipe write must warn again,
+      // not be silently mis-counted as a continuation of the old stream.
+      warn.mockClear();
+      armBrokenPipe(streamManager);
+      expect(streamManager.writeFrame(Buffer.from([0xff]))).toBe(false);
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      disarm(streamManager);
+    }
+  });
+});


### PR DESCRIPTION
Part of #12746 (#12275-H infra/connectivity plugin non-route sweep). Scoped slice: the **background/tunnel/streaming observability** cases the issue explicitly calls out — *"Background runner, tunnel/network, PTY, remote desktop, streaming, registry, and cloud-apps failures must be observable and must not masquerade as idle/success/empty state."*

## What was slop

Two silent-failure sites in `plugins/plugin-streaming` where a real failure was indistinguishable from idle/empty/success:

1. **`src/services/stream-manager.ts` — `writeFrame`**
   A broken FFmpeg encode pipe (FFmpeg died mid-stream) throws on `stdin.write`. The old `catch { return false }` swallowed it and silently dropped every subsequent frame, so a dead pipe looked identical to an idle stream.

2. **`src/api/stream-persistence.ts` — `getOverlayLayoutJson`**
   An overlay-layout file that *exists* but cannot be read (permissions, corruption, a race with a concurrent write) was swallowed with an empty `catch { /* Not available */ }`. That made an unreadable overlay indistinguishable from a missing one, so the headless overlay seed failed invisibly. Its sibling `readOverlayLayout` already warns on the same failure — this brings the two into line.

## The fix (fail-soft contract preserved, failure now observable)

- `writeFrame` still returns `false`, but now emits a throttled `logger.warn` (first failure + every 150th) so a broken pipe is visible without one log line per dropped frame. The throttle counter is reset per FFmpeg process (on `start` and `stop`) so a **restarted** stream always surfaces its first failure (addresses a codex P3 on cross-process counter persistence).
- `getOverlayLayoutJson` now warns on a read failure and falls through to the next candidate file. A genuinely-**missing** file stays quiet (missing != failure).

No behavioral change to the fail-soft return values; the failures are simply no longer silent. No routes touched (`src/routes/**` and `src/api/*routes*` unchanged); no forbidden files (vite config / index.html / client-base / bun.lock / dist) touched.

## Tests (real error paths)

`plugins/plugin-streaming/src/api/stream-persistence.test.ts`
- unreadable overlay (EACCES) → warns per unreadable candidate, does not seed a fabricated layout
- genuinely-missing overlay → no warning
- clean read → returns layout, no warning
- corrupt destination layout JSON → warns + falls back to null

`plugins/plugin-streaming/src/services/stream-manager.write-frame.test.ts`
- broken pipe (EPIPE) → returns `false` AND warns on the first failure
- repeated failures → throttled to one log (not one per frame)
- not-running write → returns `false`, no warning (expected, not a failure)
- `stop()` resets the throttle → a restarted stream re-surfaces its first failure

## Evidence

- `vitest run src/` → **5 files / 23 tests pass** (8 new + 15 existing, no regressions)
- `tsgo --noEmit` → **clean**
- `codex review --uncommitted` → **clean** ("failures observable without altering the existing fail-soft contracts; added tests cover the new behavior"), initial P3 throttle-reset addressed

— [sol-orch]