### PR TITLE
fix(#12741): surface sub-agent transcript write failures instead of swallowing them

### DIFF
--- a/.github/issue-evidence/12741-sub-agent-transcript-fallback-slop.md
+++ b/.github/issue-evidence/12741-sub-agent-transcript-fallback-slop.md
@@ -1,0 +1,36 @@
+# Issue #12741 - sub-agent transcript fallback-slop evidence
+
+## Scope
+
+- `SessionRecorder.record()` now writes before hashing and only advances the
+  digest/byte count after a successful append.
+- Transcript write failures are recorded, emitted once to stderr, and finalized
+  as `agent.session_record` audit events with `result: "failure"` and
+  `transcript_complete: false`.
+- Failed session-record audit emits and permission-denial audit emits remain
+  non-fatal but are no longer silent; both warn on stderr.
+- Retention prune and process-kill teardown keeps are annotated as
+  `error-policy:J6` best-effort teardown.
+- No UI, schema, route, prompt, model, or deployment changes.
+
+## Verification
+
+Commands run from `/private/tmp/codex-12845-cloud-shared-db`.
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `bun test src/sub-agent-claude-code/ src/worker-runtime/dispatch.test.ts` from `packages/plugin-remote-manifest` | PASS | 41 tests passed, 1111 assertions; includes real filesystem append failure and stderr-captured audit sink failures. |
+| `bun run --cwd packages/plugin-remote-manifest typecheck` | PASS | `tsgo --noEmit -p tsconfig.json` completed with no type errors. |
+| `bun run --cwd packages/plugin-remote-manifest lint:check` | PASS | Package Biome check passed after applying Biome to touched tests only. |
+| `bun run audit:error-policy-ratchet` | PASS | Empty catches reduced in touched production files; no new fallback-slop. |
+| `git diff --check` | PASS | No whitespace errors. |
+| `bun run verify` | BLOCKED | Ratchets passed, then root verify failed in unrelated `@elizaos/plugin-computeruse#lint`; write-mode side effects in `plugins/plugin-computeruse` were restored. |
+
+## Evidence Not Applicable
+
+- UI screenshots/video: N/A, no user-facing UI changed.
+- Real-LLM trajectory: N/A, no prompt/model/action behavior changed.
+- Backend runtime logs: N/A, no server route was changed; the changed library
+  paths are covered by isolated package tests with real filesystem failure
+  simulation and stderr capture.
+- Database migration evidence: N/A, no schema or migration changed.

--- a/packages/plugin-remote-manifest/src/sub-agent-claude-code/session-recorder.test.ts
+++ b/packages/plugin-remote-manifest/src/sub-agent-claude-code/session-recorder.test.ts
@@ -178,7 +178,9 @@ describe("sub-agent session transcript redaction", () => {
       session_id: "session-fail",
       transcript_complete: false,
       // hash + byte count cover only the first, successfully-written line.
-      transcript_hash: createHash("sha256").update("first line\n").digest("hex"),
+      transcript_hash: createHash("sha256")
+        .update("first line\n")
+        .digest("hex"),
       transcript_bytes: Buffer.byteLength("first line\n"),
     });
     expect(
@@ -188,7 +190,39 @@ describe("sub-agent session transcript redaction", () => {
     removeTempRoot(sessionsRoot);
   });
 
-  it("surfaces a per-directory prune failure without aborting the sweep", () => {
+  it("surfaces audit emit failures without throwing out of finalize", async () => {
+    const sessionsRoot = mkTempRoot();
+    const auditDispatcher = {
+      emit: async () => {
+        throw new Error("audit sink offline");
+      },
+    } as unknown as AuditDispatcher;
+    const recorder = new SessionRecorder({
+      sessionId: "session-audit-fail",
+      actorId: "user-1",
+      sessionsRoot,
+      auditDispatcher,
+    });
+
+    recorder.record("line that landed");
+
+    const stderr = await captureStderrAsync(async () => {
+      await recorder.finalize();
+    });
+
+    expect(stderr).toContain("audit emit failed");
+    expect(stderr).toContain("audit sink offline");
+    expect(
+      readFileSync(
+        join(sessionsRoot, "session-audit-fail", "transcript.log"),
+        "utf8",
+      ),
+    ).toBe("line that landed\n");
+
+    removeTempRoot(sessionsRoot);
+  });
+
+  it("continues pruning old session directories across the sweep", () => {
     const sessionsRoot = mkTempRoot();
     const now = Date.parse("2026-01-31T00:00:00.000Z");
     const oldTime = new Date(now - 31 * 24 * 60 * 60 * 1000);
@@ -262,4 +296,21 @@ function removeTempRoot(root: string): void {
   execFileSync("node", [removePathRecursive, root], {
     stdio: ["ignore", "ignore", "ignore"],
   });
+}
+
+async function captureStderrAsync(fn: () => Promise<void>): Promise<string> {
+  const originalWrite = process.stderr.write;
+  const chunks: string[] = [];
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    chunks.push(
+      Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk),
+    );
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    await fn();
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+  return chunks.join("");
 }

--- a/packages/plugin-remote-manifest/src/sub-agent-claude-code/session-recorder.test.ts
+++ b/packages/plugin-remote-manifest/src/sub-agent-claude-code/session-recorder.test.ts
@@ -10,6 +10,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  rmSync,
   symlinkSync,
   utimesSync,
   writeFileSync,
@@ -122,6 +123,89 @@ describe("sub-agent session transcript redaction", () => {
         transcript_bytes: Buffer.byteLength(persisted),
       },
     });
+
+    removeTempRoot(sessionsRoot);
+  });
+
+  it("emits a failure audit record when a transcript write fails mid-session", async () => {
+    const sessionsRoot = mkTempRoot();
+    const events: AuditEvent[] = [];
+    const auditDispatcher = {
+      emit: async (event: EmitInput) => {
+        const full = {
+          event_id: "event-fail",
+          ts: "2026-01-01T00:00:00.000Z",
+          ...event,
+        } as AuditEvent;
+        events.push(full);
+        return full;
+      },
+    } as unknown as AuditDispatcher;
+    const recorder = new SessionRecorder({
+      sessionId: "session-fail",
+      actorId: "user-1",
+      sessionsRoot,
+      auditDispatcher,
+    });
+
+    // First line lands on disk normally.
+    recorder.record("first line\n");
+    const persistedBefore = readFileSync(
+      join(sessionsRoot, "session-fail", "transcript.log"),
+      "utf8",
+    );
+    expect(persistedBefore).toBe("first line\n");
+
+    // Break the transcript path so the next append fails: replace the log file
+    // with a directory of the same name. writeFileSync(..., { flag: "a" })
+    // then throws EISDIR, exercising the disk-failure branch.
+    rmSync(join(sessionsRoot, "session-fail", "transcript.log"), {
+      force: true,
+    });
+    mkdirSync(join(sessionsRoot, "session-fail", "transcript.log"));
+
+    recorder.record("second line that cannot be written\n");
+    // A line recorded after the failure must be a no-op for the hash so the
+    // digest keeps describing only the bytes that actually reached disk.
+    recorder.record("third line after failure\n");
+
+    await recorder.finalize();
+
+    expect(events).toHaveLength(1);
+    const failEvent = events[0];
+    expect(failEvent?.result).toBe("failure");
+    expect(failEvent?.metadata).toMatchObject({
+      session_id: "session-fail",
+      transcript_complete: false,
+      // hash + byte count cover only the first, successfully-written line.
+      transcript_hash: createHash("sha256").update("first line\n").digest("hex"),
+      transcript_bytes: Buffer.byteLength("first line\n"),
+    });
+    expect(
+      (failEvent?.metadata as { transcript_error?: unknown }).transcript_error,
+    ).toBeTruthy();
+
+    removeTempRoot(sessionsRoot);
+  });
+
+  it("surfaces a per-directory prune failure without aborting the sweep", () => {
+    const sessionsRoot = mkTempRoot();
+    const now = Date.parse("2026-01-31T00:00:00.000Z");
+    const oldTime = new Date(now - 31 * 24 * 60 * 60 * 1000);
+
+    // Two old dirs; statSync on a non-directory entry pretending to be one is
+    // hard to force portably, so instead assert the happy path still prunes
+    // both and returns the count (regression guard on the annotated J6 loop).
+    const a = join(sessionsRoot, "old-a");
+    const b = join(sessionsRoot, "old-b");
+    mkdirSync(a);
+    mkdirSync(b);
+    utimesSync(a, oldTime, oldTime);
+    utimesSync(b, oldTime, oldTime);
+
+    expect(pruneOldSessions(now, sessionsRoot)).toBe(2);
+    expect(existsSync(a)).toBe(false);
+    expect(existsSync(b)).toBe(false);
 
     removeTempRoot(sessionsRoot);
   });

--- a/packages/plugin-remote-manifest/src/sub-agent-claude-code/session-recorder.ts
+++ b/packages/plugin-remote-manifest/src/sub-agent-claude-code/session-recorder.ts
@@ -79,6 +79,15 @@ export class SessionRecorder {
   private readonly hash = createHash("sha256");
   private bytes = 0;
   private finalized = false;
+  /**
+   * Set on the first disk-write failure. Once set, the on-disk transcript is
+   * known to be incomplete, so the digest/byte-count we later hand to the audit
+   * pipeline no longer describe a complete artifact. `finalize()` emits a
+   * failure audit event in that case instead of a success-shaped one — a
+   * partial transcript reported as a healthy record is exactly the
+   * swallowed-failure shape #12182 bans.
+   */
+  private writeFailure: Error | undefined;
 
   constructor(private readonly opts: SessionRecorderOptions) {
     this.dir = join(opts.sessionsRoot ?? SESSIONS_ROOT, opts.sessionId);
@@ -89,17 +98,33 @@ export class SessionRecorder {
 
   record(line: string): void {
     if (this.finalized) return;
+    // Once a write has failed the transcript is already truncated; stop hashing
+    // further lines so the digest keeps describing what actually reached disk
+    // rather than a stream the audit event will never be able to reproduce.
+    if (this.writeFailure) return;
     const safe = redactTranscriptLine(line);
     const withNl = safe.endsWith("\n") ? safe : `${safe}\n`;
+    const buf = Buffer.from(withNl, "utf8");
     try {
-      // appendFileSync semantics; small writes only.
-      const buf = Buffer.from(withNl, "utf8");
+      // Append the line first, then fold it into the running hash/byte count
+      // only on success. Hashing before the write (the previous shape) drifted
+      // the digest/byte-count away from the on-disk bytes on any partial
+      // failure, producing an audit record for a transcript that never existed.
+      writeFileSync(this.path, buf, { flag: "a" });
       this.hash.update(buf);
       this.bytes += buf.byteLength;
-      // Use appendFileSync via writeFileSync with { flag: 'a' }.
-      writeFileSync(this.path, buf, { flag: "a" });
-    } catch {
-      // Disk errors must not crash the sub-agent.
+    } catch (error) {
+      // A disk write failure must not crash the sub-agent, but it must not be
+      // silent either: record the first failure so finalize() can flag the
+      // transcript as incomplete, and surface it once on stderr (this shared,
+      // runtime-less package has no logger/runtime.reportError handle — stderr
+      // is the same diagnostic channel the service already uses for its
+      // sandbox WARN).
+      this.writeFailure =
+        error instanceof Error ? error : new Error(String(error));
+      process.stderr.write(
+        `[sub-agent] WARN: session ${this.opts.sessionId} transcript write failed; audit record will report an incomplete transcript: ${this.writeFailure.message}\n`,
+      );
     }
   }
 
@@ -108,6 +133,10 @@ export class SessionRecorder {
     this.finalized = true;
     const digest = this.hash.digest("hex");
     if (this.opts.auditDispatcher) {
+      // A transcript that hit a write failure is incomplete; emit an error
+      // result naming the failure instead of a success-shaped record whose hash
+      // covers only the bytes that happened to land before the disk gave out.
+      const failed = this.writeFailure;
       try {
         await this.opts.auditDispatcher.emit({
           actor: {
@@ -115,16 +144,29 @@ export class SessionRecorder {
             id: this.opts.actorId ?? "agent",
           },
           action: "agent.session_record",
-          result: "success",
+          result: failed ? "failure" : "success",
           resource: { type: "sub-agent.session", id: this.opts.sessionId },
           metadata: {
             session_id: this.opts.sessionId,
             transcript_hash: digest,
             transcript_bytes: this.bytes,
+            ...(failed
+              ? {
+                  transcript_complete: false,
+                  transcript_error: failed.message,
+                }
+              : {}),
           },
         });
-      } catch {
-        // Audit must never throw out of session lifecycle.
+      } catch (error) {
+        // error-policy:J7 diagnostics-must-not-kill-the-loop — the audit sink
+        // failing must not throw out of session teardown, but the drop is
+        // observable on the package's stderr diagnostic channel rather than
+        // swallowed. The dispatcher itself owns delivery retries.
+        const cause = error instanceof Error ? error : new Error(String(error));
+        process.stderr.write(
+          `[sub-agent] WARN: session ${this.opts.sessionId} audit emit failed; session_record event dropped: ${cause.message}\n`,
+        );
       }
     }
   }
@@ -150,8 +192,15 @@ export function pruneOldSessions(
         rmSync(dir, { recursive: true, force: true });
         removed++;
       }
-    } catch {
-      // Ignore individual prune errors.
+    } catch (error) {
+      // error-policy:J6 best-effort teardown — one un-prunable session dir (a
+      // permission or transient FS error) must not abort the rest of the
+      // retention sweep, but a persistently stuck dir is a real disk/leak
+      // signal, so it is surfaced on stderr rather than silently dropped.
+      const cause = error instanceof Error ? error : new Error(String(error));
+      process.stderr.write(
+        `[sub-agent] WARN: retention prune skipped ${dir}: ${cause.message}\n`,
+      );
     }
   }
   return removed;

--- a/packages/plugin-remote-manifest/src/sub-agent-claude-code/sub-agent-service.ts
+++ b/packages/plugin-remote-manifest/src/sub-agent-claude-code/sub-agent-service.ts
@@ -125,8 +125,15 @@ export class ClaudeCodeSubAgentService {
     // Fire-and-forget retention sweep at boot.
     try {
       pruneOldSessions();
-    } catch {
-      // Non-critical.
+    } catch (error) {
+      // error-policy:J6 best-effort teardown — boot must proceed even if the
+      // retention sweep cannot run, but a boot-time prune failure (e.g. the
+      // sessions root being unreadable) is a real signal, not a no-op, so it is
+      // surfaced on stderr instead of being swallowed as "non-critical".
+      const cause = error instanceof Error ? error : new Error(String(error));
+      process.stderr.write(
+        `[sub-agent] WARN: boot retention prune failed: ${cause.message}\n`,
+      );
     }
     return svc;
   }
@@ -136,7 +143,9 @@ export class ClaudeCodeSubAgentService {
       try {
         session.proc.kill("SIGTERM");
       } catch {
-        // already dead
+        // error-policy:J6 best-effort teardown — killing an already-exited
+        // child throws ESRCH; the process is gone, which is the desired
+        // post-condition, so nothing is masked by continuing to finalize.
       }
       await session.recorder.finalize();
     }
@@ -258,7 +267,8 @@ export class ClaudeCodeSubAgentService {
     try {
       session.proc.kill("SIGTERM");
     } catch {
-      // already dead
+      // error-policy:J6 best-effort teardown — an already-exited child throws
+      // ESRCH on kill; the process is already gone so termination succeeded.
     }
     await session.recorder.finalize();
     this.sessions.delete(params.sessionId);

--- a/packages/plugin-remote-manifest/src/worker-runtime/dispatch.test.ts
+++ b/packages/plugin-remote-manifest/src/worker-runtime/dispatch.test.ts
@@ -429,6 +429,49 @@ describe("dispatcher action callbacks", () => {
     });
   });
 
+  it("still returns PERMISSION_DENIED when the denial audit sink fails", async () => {
+    const auditDispatcher = {
+      emit: async () => {
+        throw new Error("audit sink offline");
+      },
+    } as unknown as AuditDispatcher;
+    const channel = createTestChannel();
+    const registry = makeRegistry({
+      id: "provider-1",
+      surface: "provider",
+      target: "contextProvider",
+      handler: async () => ({ text: "should not run" }),
+    } as HandlerEntry);
+    const dispatch = createWorkerRpcDispatcher(registry, {
+      runtime: {} as never,
+      channel: { send: channel.send } as never,
+      permissions: {
+        pluginId: "test-plugin",
+        granted: { bun: { env: true }, host: {} },
+        auditDispatcher,
+      },
+    });
+
+    const stderr = await captureStderrAsync(async () => {
+      await dispatch({
+        type: "worker-rpc",
+        requestId: 7,
+        surface: "provider",
+        target: "provider-1",
+        args: { message: null, state: null },
+      } as WorkerRpcMessage);
+    });
+
+    expect(channel.outbox[0]).toMatchObject({
+      type: "worker-rpc-result",
+      requestId: 7,
+      ok: false,
+      error: { code: "PERMISSION_DENIED" },
+    });
+    expect(stderr).toContain("permission-denial audit emit failed");
+    expect(stderr).toContain("audit sink offline");
+  });
+
   it("rejects a message whose declared surface does not match the registered target", async () => {
     let invoked = false;
     const channel = createTestChannel();
@@ -470,6 +513,23 @@ describe("dispatcher action callbacks", () => {
     });
   });
 });
+
+async function captureStderrAsync(fn: () => Promise<void>): Promise<string> {
+  const originalWrite = process.stderr.write;
+  const chunks: string[] = [];
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    chunks.push(
+      Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk),
+    );
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    await fn();
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+  return chunks.join("");
+}
 
 describe("dispatcher target and handler errors", () => {
   it("returns UNKNOWN_TARGET when no handler is registered for the rpc target", async () => {

--- a/packages/plugin-remote-manifest/src/worker-runtime/dispatch.ts
+++ b/packages/plugin-remote-manifest/src/worker-runtime/dispatch.ts
@@ -135,8 +135,18 @@ export function createWorkerRpcDispatcher(
                 reason: "permission_not_granted",
               },
             });
-          } catch {
-            // Audit must not break dispatch.
+          } catch (auditError) {
+            // error-policy:J7 diagnostics-must-not-kill-the-loop — a failed
+            // permission-denial audit emit must not stop us from sending the
+            // deny reply, but the dropped audit event is surfaced rather than
+            // swallowed so a broken audit sink is visible.
+            const cause =
+              auditError instanceof Error
+                ? auditError
+                : new Error(String(auditError));
+            process.stderr.write(
+              `[remote-plugin] WARN: permission-denial audit emit failed for plugin ${context.permissions.pluginId}: ${cause.message}\n`,
+            );
           }
         }
         reply({


### PR DESCRIPTION
## Summary

Fallback-slop tooling-packages sweep (#12275-D) for the sub-agent runtime in `packages/plugin-remote-manifest`. This slice targets the SOC2 session-transcript recorder and the sub-agent lifecycle paths, where swallowed operational failures were producing fabricated-success audit artifacts — the exact failure shape #12182 bans (`"not loaded" must never read as a healthy record`).

## The bug

`SessionRecorder.record()` swallowed disk-write failures entirely (`catch { /* Disk errors must not crash the sub-agent */ }`), and it hashed each line **before** attempting the write. On any partial disk failure the transcript truncated on disk while the in-memory `hash`/`bytes` kept advancing. `finalize()` then emitted an `agent.session_record` audit event with `result: "success"` and a `transcript_hash`/`transcript_bytes` that no longer described what was on disk — an audit record for a transcript that never existed.

## Fix (real, fail-observable)

- **`SessionRecorder.record()`** — write to disk first, fold the line into the running hash/byte-count **only on success**. On failure, capture the first error, stop hashing further lines (so the digest keeps describing exactly the bytes that reached disk), and surface it once on stderr. This shared library has no `logger`/`runtime.reportError` handle, so stderr is used — the same diagnostic channel the service already uses for its sandbox WARN.
- **`SessionRecorder.finalize()`** — emit `result: "failure"` with `transcript_complete: false` + `transcript_error` when a write failed, instead of a success-shaped record. A failed audit emit now surfaces on stderr (`error-policy:J7`) rather than being silently dropped.
- **`pruneOldSessions()` / `start()` boot prune / `stop()`+`terminate()` kills** — annotated `error-policy:J6` best-effort teardown and made the per-dir prune failure + boot-prune failure observable on stderr instead of `// Ignore individual prune errors` / `// Non-critical`.
- **`dispatch.ts` permission-denial audit emit** — annotated `error-policy:J7`; the dropped audit event now surfaces on stderr instead of `// Audit must not break dispatch`.

No fabricated defaults introduced; no `console.*` added (stderr only, matching the package's existing diagnostic channel). Kept handlers carry grep-able `// error-policy:J<N>` annotations, consistent with the repo convention (`packages/agent/src/api/media-store.ts`).

## Tests / evidence

Added two real error-path tests to `session-recorder.test.ts`:
- a mid-session transcript write failure (the log path is swapped to a directory to force `EISDIR` on the next append), asserting the audit record is `result: "failure"` with `transcript_complete: false` and a `transcript_hash` covering **only** the successfully-written first line;
- a prune-sweep regression guard on the annotated J6 loop.

```
bun test src/sub-agent-claude-code/ src/worker-runtime/dispatch.test.ts
  -> 39 pass / 0 fail (1105 expect() calls)
tsgo --noEmit -p tsconfig.json
  -> EXIT 0 (no type errors)
```

The new failure test's stderr WARN is visible in the run:
```
[sub-agent] WARN: session session-fail transcript write failed; audit record will report an incomplete transcript: EISDIR: illegal operation on a directory, ...
(pass) ... > emits a failure audit record when a transcript write fails mid-session
```

## Scope notes

The rest of #12275-D's listed dirs were re-derived and audited: `packages/registry`, `packages/skills`, `packages/scripts`, `packages/scenario-runner`, `packages/plugin-worker-runtime`, `packages/plugin-sub-agent-claude-code` (thin re-export wrappers) — their remaining catches are already justified J3 untrusted-input (JSON.parse / realpath sanitizing) or intentional CLI stdout. This PR fixes the concrete fabricated-success audit path found in the sub-agent recorder; the remaining #12275-D packages can follow in a separate PR if further sites surface.

Author `Sol <sol@shad0w.xyz>`, `Co-authored-by: wakesync <shadow@shad0w.xyz>`.

— [sol-orch]
