### PR TITLE
fix(#12497): add room feed FST

### DIFF
--- a/.github/issue-evidence/12497-room-feed-fst.md
+++ b/.github/issue-evidence/12497-room-feed-fst.md
@@ -1,0 +1,84 @@
+# #12497 Room Feed FST Evidence
+
+Branch: `fix/12497-room-feed-fst`
+
+## What Was Proven
+
+- Added deterministic room-feed FST classification for meeting audio/video feeds.
+- Covered all issue states:
+  - `unknown`
+  - `individual_feed_likely`
+  - `room_feed_suspected`
+  - `room_feed_confirmed`
+  - `multi_speaker_room`
+  - `speaker_candidates_split`
+  - `profile_bound`
+- Covered confidence, reason codes, UI hints, candidate speaker provenance,
+  sensitive-attribute withholding, input validation, and invalid transition
+  handling.
+- Exported the FST from the voice service barrel for meeting UI/benchmark use.
+
+## Focused Verification
+
+```bash
+bun run --cwd plugins/plugin-local-inference test src/services/voice/room-feed-fst.test.ts
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       10 passed (10)
+```
+
+```bash
+bunx @biomejs/biome check \
+  plugins/plugin-local-inference/src/services/voice/room-feed-fst.ts \
+  plugins/plugin-local-inference/src/services/voice/room-feed-fst.test.ts \
+  plugins/plugin-local-inference/src/services/voice/index.ts
+```
+
+Result:
+
+```text
+Checked 3 files in 10ms. No fixes applied.
+```
+
+```bash
+bun run --cwd plugins/plugin-local-inference typecheck
+```
+
+Result:
+
+```text
+tsgo --noEmit -p tsconfig.json
+```
+
+## Full Plugin Test Status
+
+```bash
+bun run --cwd plugins/plugin-local-inference test
+```
+
+Result: failed with 14 unrelated failures in existing tests:
+
+- `src/routes/local-inference-route-contracts.fuzz.test.ts` expects an ASR
+  response without the current `aec` metadata field.
+- `src/services/downloader.test.ts` reports invalid Eliza-1 manifest fixtures
+  missing required MTP kernel metadata.
+- `__tests__/mmproj-routing.test.ts` expects a pre-cutover missing-drafter
+  fallback, while current code throws `MissingMtpDrafterError`.
+
+No `room-feed-fst` tests failed in the full run.
+
+## Artifact / Evidence Rows
+
+- UI screenshots/video: N/A - pure classifier module, no UI surface changed.
+- Audio artifacts: N/A - deterministic classifier logic only, no audio model or
+  capture path changed.
+- Real LLM trajectories: N/A - no model prompt, provider, action, or evaluator
+  behavior changed.
+- Backend/frontend logs: N/A - no route or runtime side effect changed.
+- Example classifier output: covered by the focused Vitest assertions for room
+  suspected, confirmed, multi-speaker room, split candidate, profile-bound, and
+  sensitive-guardrail states.

--- a/.github/issue-evidence/12497-room-feed-fst.md
+++ b/.github/issue-evidence/12497-room-feed-fst.md
@@ -14,8 +14,9 @@ Branch: `fix/12497-room-feed-fst`
   - `speaker_candidates_split`
   - `profile_bound`
 - Covered confidence, reason codes, UI hints, candidate speaker provenance,
-  sensitive-attribute withholding, input validation, and invalid transition
-  handling.
+  sensitive-attribute withholding, input validation, invalid transition
+  handling, and a declared room feed with multiple diarized speakers but no
+  visual count staying in `multi_speaker_room` with speaker-split hints.
 - Exported the FST from the voice service barrel for meeting UI/benchmark use.
 
 ## Focused Verification
@@ -28,7 +29,7 @@ Result:
 
 ```text
 Test Files  1 passed (1)
-Tests       10 passed (10)
+Tests       11 passed (11)
 ```
 
 ```bash
@@ -62,6 +63,11 @@ bun run --cwd plugins/plugin-local-inference test
 
 Result: failed with 14 unrelated failures in existing tests:
 
+```text
+Test Files  3 failed | 244 passed (247)
+Tests       14 failed | 2490 passed | 20 skipped (2524)
+```
+
 - `src/routes/local-inference-route-contracts.fuzz.test.ts` expects an ASR
   response without the current `aec` metadata field.
 - `src/services/downloader.test.ts` reports invalid Eliza-1 manifest fixtures
@@ -70,6 +76,18 @@ Result: failed with 14 unrelated failures in existing tests:
   fallback, while current code throws `MissingMtpDrafterError`.
 
 No `room-feed-fst` tests failed in the full run.
+
+## Root Verify Status
+
+```bash
+bun run verify
+```
+
+Result: blocked after ratchets passed by unrelated
+`@elizaos/electrobun#lint` formatting diagnostics in
+`packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts`.
+The root verify run rewrote an unrelated core file via write-mode lint; that
+side effect was restored before pushing this branch.
 
 ## Artifact / Evidence Rows
 

--- a/plugins/plugin-local-inference/src/services/voice/index.ts
+++ b/plugins/plugin-local-inference/src/services/voice/index.ts
@@ -266,6 +266,25 @@ export {
 export { InMemoryAudioSink, PcmRingBuffer } from "./ring-buffer";
 export { type RollbackEvent, RollbackQueue } from "./rollback-queue";
 export {
+	assertRoomFeedTransition,
+	type ClassifyRoomFeedInput,
+	classifyRoomFeed,
+	isRoomFeedTransitionAllowed,
+	type RoomFeedCandidateSpeaker,
+	type RoomFeedCaptureMode,
+	type RoomFeedClassification,
+	type RoomFeedNameEvidence,
+	type RoomFeedNameEvidenceSource,
+	type RoomFeedParticipantKind,
+	type RoomFeedParticipantMetadata,
+	type RoomFeedReasonCode,
+	type RoomFeedSourceKind,
+	type RoomFeedSourceStreamMetadata,
+	type RoomFeedState,
+	type RoomFeedUiHint,
+	type RoomFeedVoiceProfileMatch,
+} from "./room-feed-fst";
+export {
 	type SchedulerDeps,
 	type SchedulerEvents,
 	VoiceScheduler,

--- a/plugins/plugin-local-inference/src/services/voice/room-feed-fst.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/room-feed-fst.test.ts
@@ -83,6 +83,28 @@ describe("room-feed-fst", () => {
 		]);
 	});
 
+	it("keeps a declared room with multiple diarized speakers in the multi-speaker room state", () => {
+		const result = classifyRoomFeed({
+			captureMode: "bot",
+			platformParticipant: {
+				id: "conf-room-2",
+				kind: "room",
+				isRoomResource: true,
+			},
+			sourceStream: { id: "room-feed", kind: "participant_audio" },
+			diarizedSpeakerCount: 3,
+			speakerCountConfidence: 0.91,
+		});
+
+		expect(result.state).toBe("multi_speaker_room");
+		expect(result.reasonCodes).toContain("participant_declared_room");
+		expect(result.reasonCodes).toContain("diarized_multiple_speakers");
+		expect(result.uiHints.map((hint) => hint.code)).toEqual([
+			"participant_may_represent_room",
+			"split_speaker_candidates",
+		]);
+	});
+
 	it("flags several diarized speakers inside one person participant for split review", () => {
 		const result = classifyRoomFeed({
 			captureMode: "bot",

--- a/plugins/plugin-local-inference/src/services/voice/room-feed-fst.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/room-feed-fst.test.ts
@@ -1,0 +1,276 @@
+/** Covers deterministic room-feed FST states, provenance gating, and transitions. */
+import { describe, expect, it } from "vitest";
+import {
+	assertRoomFeedTransition,
+	classifyRoomFeed,
+	isRoomFeedTransitionAllowed,
+	type RoomFeedState,
+} from "./room-feed-fst";
+
+describe("room-feed-fst", () => {
+	it("classifies a single platform person as an individual feed", () => {
+		const result = classifyRoomFeed({
+			captureMode: "bot",
+			platformParticipant: { id: "p1", kind: "person", displayName: "Ari" },
+			sourceStream: { id: "s1", kind: "participant_audio" },
+			diarizedSpeakerCount: 1,
+			speakerCountConfidence: 0.9,
+			visiblePersonCount: 1,
+			faceCountConfidence: 0.88,
+			activeSpeakerContinuity: 0.92,
+		});
+
+		expect(result.state).toBe("individual_feed_likely");
+		expect(result.confidenceLevel).toBe("high");
+		expect(result.requiresReview).toBe(false);
+		expect(result.reasonCodes).toContain("single_speaker_single_face");
+		expect(result.reasonCodes).toContain("participant_declared_person");
+	});
+
+	it("suspects a room feed from weak mixed-source evidence", () => {
+		const result = classifyRoomFeed({
+			captureMode: "system_audio",
+			sourceStream: { id: "screen-audio", kind: "mixed_system_audio" },
+			diarizedSpeakerCount: 2,
+			speakerCountConfidence: 0.52,
+			visiblePersonCount: 1,
+			faceCountConfidence: 0.6,
+		});
+
+		expect(result.state).toBe("room_feed_suspected");
+		expect(result.requiresReview).toBe(true);
+		expect(result.reasonCodes).toContain("mixed_capture_source");
+		expect(result.uiHints.map((hint) => hint.code)).toContain(
+			"participant_may_represent_room",
+		);
+	});
+
+	it("confirms a declared room participant", () => {
+		const result = classifyRoomFeed({
+			captureMode: "bot",
+			platformParticipant: {
+				id: "conf-room-1",
+				kind: "room",
+				isRoomResource: true,
+			},
+			sourceStream: { id: "room-feed", kind: "participant_audio" },
+			diarizedSpeakerCount: 1,
+			speakerCountConfidence: 0.82,
+		});
+
+		expect(result.state).toBe("room_feed_confirmed");
+		expect(result.requiresReview).toBe(false);
+		expect(result.reasonCodes).toContain("participant_declared_room");
+	});
+
+	it("classifies a room mic with matching audio and video counts as multi-speaker room", () => {
+		const result = classifyRoomFeed({
+			captureMode: "room_mic",
+			sourceStream: { id: "room-mic", kind: "room_mic", isMixed: true },
+			diarizedSpeakerCount: 3,
+			speakerCountConfidence: 0.93,
+			visiblePersonCount: 4,
+			faceCountConfidence: 0.89,
+			overlapRatio: 0.24,
+		});
+
+		expect(result.state).toBe("multi_speaker_room");
+		expect(result.confidenceLevel).toBe("high");
+		expect(result.reasonCodes).toContain("audio_visual_count_agree");
+		expect(result.uiHints.map((hint) => hint.code)).toEqual([
+			"participant_may_represent_room",
+			"split_speaker_candidates",
+		]);
+	});
+
+	it("flags several diarized speakers inside one person participant for split review", () => {
+		const result = classifyRoomFeed({
+			captureMode: "bot",
+			platformParticipant: { id: "tile-1", kind: "person" },
+			sourceStream: { id: "tile-1-audio", kind: "participant_audio" },
+			diarizedSpeakerCount: 2,
+			speakerCountConfidence: 0.9,
+			visiblePersonCount: 1,
+			faceCountConfidence: 0.9,
+			overlapRatio: 0.18,
+			nameEvidence: [
+				{
+					speakerId: "spk-a",
+					name: "Mira",
+					source: "platform_roster",
+					confidence: 0.72,
+				},
+				{
+					speakerId: "spk-b",
+					name: "Jon",
+					source: "self_introduction",
+					confidence: 0.77,
+				},
+			],
+		});
+
+		expect(result.state).toBe("speaker_candidates_split");
+		expect(result.requiresReview).toBe(true);
+		expect(result.reasonCodes).toContain(
+			"candidate_speakers_inside_participant",
+		);
+		expect(result.candidateSpeakers).toEqual([
+			{
+				speakerId: "spk-a",
+				displayName: "Mira",
+				confidence: 0.72,
+				provenance: ["platform_roster"],
+				bindingAllowed: false,
+				requiresReview: true,
+			},
+			{
+				speakerId: "spk-b",
+				displayName: "Jon",
+				confidence: 0.77,
+				provenance: ["self_introduction"],
+				bindingAllowed: false,
+				requiresReview: true,
+			},
+		]);
+	});
+
+	it("binds a single speaker only with explicit profile or user-correction provenance", () => {
+		const result = classifyRoomFeed({
+			captureMode: "bot",
+			platformParticipant: { id: "p1", kind: "person" },
+			diarizedSpeakerCount: 1,
+			speakerCountConfidence: 0.96,
+			visiblePersonCount: 1,
+			faceCountConfidence: 0.9,
+			activeSpeakerContinuity: 0.9,
+			voiceProfileMatches: [
+				{
+					speakerId: "speaker-owner",
+					profileId: "profile-owner",
+					entityId: "entity-owner",
+					displayName: "Owner",
+					confidence: 0.94,
+				},
+			],
+			nameEvidence: [
+				{
+					speakerId: "speaker-owner",
+					name: "Owner corrected",
+					source: "user_correction",
+					confidence: 0.96,
+				},
+			],
+		});
+
+		expect(result.state).toBe("profile_bound");
+		expect(result.requiresReview).toBe(false);
+		expect(result.reasonCodes).toContain("profile_match_with_provenance");
+		expect(result.reasonCodes).toContain("user_corrected_identity");
+		expect(result.candidateSpeakers).toEqual([
+			{
+				speakerId: "speaker-owner",
+				displayName: "Owner corrected",
+				profileId: "profile-owner",
+				entityId: "entity-owner",
+				confidence: 0.96,
+				provenance: ["user_correction", "voice_profile"],
+				bindingAllowed: true,
+				requiresReview: false,
+			},
+		]);
+	});
+
+	it("requires review on contradictory strong evidence", () => {
+		const result = classifyRoomFeed({
+			captureMode: "bot",
+			platformParticipant: { id: "p1", kind: "person" },
+			sourceStream: { id: "s1", kind: "participant_audio" },
+			diarizedSpeakerCount: 3,
+			speakerCountConfidence: 0.94,
+			visiblePersonCount: 1,
+			faceCountConfidence: 0.88,
+			activeSpeakerContinuity: 0.95,
+			overlapRatio: 0.02,
+		});
+
+		expect(result.state).toBe("speaker_candidates_split");
+		expect(result.reasonCodes).toContain("contradictory_signals");
+		expect(result.requiresReview).toBe(true);
+	});
+
+	it("withholds names when sensitive guardrails are present", () => {
+		const result = classifyRoomFeed({
+			diarizedSpeakerCount: 1,
+			speakerCountConfidence: 0.92,
+			voiceProfileMatches: [
+				{
+					speakerId: "speaker-1",
+					profileId: "profile-1",
+					entityId: "entity-1",
+					displayName: "Sensitive Name",
+					confidence: 0.98,
+				},
+			],
+			sensitiveAttributeGuardrail: true,
+		});
+
+		expect(result.state).toBe("unknown");
+		expect(result.withholdSpeakerNames).toBe(true);
+		expect(result.candidateSpeakers[0]).toEqual({
+			speakerId: "speaker-1",
+			profileId: "profile-1",
+			confidence: 0.98,
+			provenance: ["voice_profile"],
+			bindingAllowed: true,
+			requiresReview: true,
+		});
+		expect(result.uiHints.map((hint) => hint.code)).toContain(
+			"withhold_sensitive_identity",
+		);
+	});
+
+	it("fails loud on invalid metrics and invalid transitions", () => {
+		expect(() =>
+			classifyRoomFeed({
+				diarizedSpeakerCount: 1.5,
+			}),
+		).toThrow(/diarizedSpeakerCount/);
+		expect(() =>
+			classifyRoomFeed({
+				speakerCountConfidence: 1.2,
+			}),
+		).toThrow(/speakerCountConfidence/);
+
+		expect(
+			isRoomFeedTransitionAllowed(
+				"room_feed_confirmed",
+				"individual_feed_likely",
+			),
+		).toBe(false);
+		expect(() =>
+			assertRoomFeedTransition("room_feed_confirmed", "individual_feed_likely"),
+		).toThrow(/invalid transition/);
+	});
+
+	it("declares allowed transitions for every state", () => {
+		const states: RoomFeedState[] = [
+			"unknown",
+			"individual_feed_likely",
+			"room_feed_suspected",
+			"room_feed_confirmed",
+			"multi_speaker_room",
+			"speaker_candidates_split",
+			"profile_bound",
+		];
+
+		for (const state of states) {
+			expect(isRoomFeedTransitionAllowed(state, state)).toBe(true);
+		}
+		expect(
+			isRoomFeedTransitionAllowed("room_feed_suspected", "multi_speaker_room"),
+		).toBe(true);
+		expect(
+			isRoomFeedTransitionAllowed("speaker_candidates_split", "profile_bound"),
+		).toBe(true);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/room-feed-fst.ts
+++ b/plugins/plugin-local-inference/src/services/voice/room-feed-fst.ts
@@ -421,11 +421,7 @@ export function classifyRoomFeed(
 			0.85,
 		);
 		requiresReview = confidence < 0.92;
-	} else if (
-		audioMulti &&
-		visualMulti &&
-		(participantRoom || mixedSource || roomCapture)
-	) {
+	} else if (audioMulti && (participantRoom || mixedSource || roomCapture)) {
 		state = "multi_speaker_room";
 		confidence = maxConfidence(
 			[speakerConfidence, faceConfidence, overlap >= 0.2 ? 0.86 : undefined],

--- a/plugins/plugin-local-inference/src/services/voice/room-feed-fst.ts
+++ b/plugins/plugin-local-inference/src/services/voice/room-feed-fst.ts
@@ -1,0 +1,534 @@
+/**
+ * Deterministic room-feed finite-state classifier for meeting audio/video.
+ * It classifies whether one platform participant is likely one person, a room
+ * feed, a multi-speaker room, or a speaker-split candidate without binding
+ * identity unless provenance comes from voice profile or user correction.
+ */
+
+export type RoomFeedState =
+	| "unknown"
+	| "individual_feed_likely"
+	| "room_feed_suspected"
+	| "room_feed_confirmed"
+	| "multi_speaker_room"
+	| "speaker_candidates_split"
+	| "profile_bound";
+
+export type RoomFeedCaptureMode =
+	| "bot"
+	| "platform_artifact"
+	| "bot_free_tab"
+	| "system_audio"
+	| "local_mic"
+	| "mobile_room_mic"
+	| "room_mic"
+	| "benchmark_import"
+	| "unknown";
+
+export type RoomFeedParticipantKind =
+	| "person"
+	| "room"
+	| "device"
+	| "shared_screen"
+	| "unknown";
+
+export type RoomFeedSourceKind =
+	| "participant_audio"
+	| "mixed_system_audio"
+	| "tab_audio"
+	| "local_mic"
+	| "mobile_mic"
+	| "room_mic"
+	| "recording"
+	| "benchmark_corpus"
+	| "unknown";
+
+export type RoomFeedNameEvidenceSource =
+	| "platform_roster"
+	| "calendar"
+	| "self_introduction"
+	| "user_correction"
+	| "voice_profile";
+
+export type RoomFeedReasonCode =
+	| "active_speaker_continuity"
+	| "ambiguous_low_confidence"
+	| "audio_visual_count_agree"
+	| "candidate_speakers_inside_participant"
+	| "capture_mode_room"
+	| "contradictory_signals"
+	| "diarized_multiple_speakers"
+	| "insufficient_evidence"
+	| "mixed_capture_source"
+	| "participant_declared_person"
+	| "participant_declared_room"
+	| "profile_match_with_provenance"
+	| "review_required"
+	| "sensitive_attribute_guardrail"
+	| "single_speaker_single_face"
+	| "user_corrected_identity"
+	| "visible_multiple_people";
+
+export interface RoomFeedParticipantMetadata {
+	id?: string;
+	displayName?: string;
+	kind?: RoomFeedParticipantKind;
+	isRoomResource?: boolean;
+}
+
+export interface RoomFeedSourceStreamMetadata {
+	id?: string;
+	kind?: RoomFeedSourceKind;
+	isMixed?: boolean;
+}
+
+export interface RoomFeedNameEvidence {
+	speakerId: string;
+	name: string;
+	source: RoomFeedNameEvidenceSource;
+	confidence: number;
+}
+
+export interface RoomFeedVoiceProfileMatch {
+	speakerId: string;
+	profileId: string;
+	entityId?: string;
+	displayName?: string;
+	confidence: number;
+}
+
+export interface ClassifyRoomFeedInput {
+	captureMode?: RoomFeedCaptureMode;
+	platformParticipant?: RoomFeedParticipantMetadata;
+	sourceStream?: RoomFeedSourceStreamMetadata;
+	diarizedSpeakerCount?: number;
+	speakerCountConfidence?: number;
+	overlapRatio?: number;
+	visiblePersonCount?: number;
+	faceCountConfidence?: number;
+	activeSpeakerContinuity?: number;
+	nameEvidence?: RoomFeedNameEvidence[];
+	voiceProfileMatches?: RoomFeedVoiceProfileMatch[];
+	sensitiveAttributeGuardrail?: boolean;
+}
+
+export interface RoomFeedCandidateSpeaker {
+	speakerId: string;
+	displayName?: string;
+	profileId?: string;
+	entityId?: string;
+	confidence: number;
+	provenance: RoomFeedNameEvidenceSource[];
+	bindingAllowed: boolean;
+	requiresReview: boolean;
+}
+
+export interface RoomFeedUiHint {
+	code:
+		| "participant_may_represent_room"
+		| "split_speaker_candidates"
+		| "review_before_identity_binding"
+		| "withhold_sensitive_identity";
+	message: string;
+}
+
+export interface RoomFeedClassification {
+	state: RoomFeedState;
+	confidence: number;
+	confidenceLevel: "low" | "medium" | "high";
+	reasonCodes: RoomFeedReasonCode[];
+	candidateSpeakers: RoomFeedCandidateSpeaker[];
+	uiHints: RoomFeedUiHint[];
+	requiresReview: boolean;
+	withholdSpeakerNames: boolean;
+}
+
+const ROOM_CAPTURE_MODES = new Set<RoomFeedCaptureMode>([
+	"local_mic",
+	"mobile_room_mic",
+	"room_mic",
+	"system_audio",
+	"bot_free_tab",
+]);
+
+const MIXED_SOURCE_KINDS = new Set<RoomFeedSourceKind>([
+	"mixed_system_audio",
+	"tab_audio",
+	"local_mic",
+	"mobile_mic",
+	"room_mic",
+	"recording",
+	"benchmark_corpus",
+]);
+
+const BINDING_PROVENANCE = new Set<RoomFeedNameEvidenceSource>([
+	"user_correction",
+	"voice_profile",
+]);
+
+const ALLOWED_TRANSITIONS: Record<RoomFeedState, ReadonlySet<RoomFeedState>> = {
+	unknown: new Set([
+		"unknown",
+		"individual_feed_likely",
+		"room_feed_suspected",
+		"room_feed_confirmed",
+		"multi_speaker_room",
+		"speaker_candidates_split",
+		"profile_bound",
+	]),
+	individual_feed_likely: new Set([
+		"individual_feed_likely",
+		"room_feed_suspected",
+		"profile_bound",
+		"unknown",
+	]),
+	room_feed_suspected: new Set([
+		"room_feed_suspected",
+		"room_feed_confirmed",
+		"multi_speaker_room",
+		"speaker_candidates_split",
+		"unknown",
+	]),
+	room_feed_confirmed: new Set([
+		"room_feed_confirmed",
+		"multi_speaker_room",
+		"speaker_candidates_split",
+		"unknown",
+	]),
+	multi_speaker_room: new Set([
+		"multi_speaker_room",
+		"speaker_candidates_split",
+		"profile_bound",
+		"unknown",
+	]),
+	speaker_candidates_split: new Set([
+		"speaker_candidates_split",
+		"multi_speaker_room",
+		"profile_bound",
+		"unknown",
+	]),
+	profile_bound: new Set(["profile_bound", "room_feed_suspected", "unknown"]),
+};
+
+function assertNonNegativeInteger(
+	name: string,
+	value: number | undefined,
+): void {
+	if (value === undefined) return;
+	if (!Number.isInteger(value) || value < 0) {
+		throw new Error(`[room-feed-fst] ${name} must be a non-negative integer`);
+	}
+}
+
+function assertRatio(name: string, value: number | undefined): void {
+	if (value === undefined) return;
+	if (!Number.isFinite(value) || value < 0 || value > 1) {
+		throw new Error(`[room-feed-fst] ${name} must be between 0 and 1`);
+	}
+}
+
+function round(value: number): number {
+	return Math.round(Math.max(0, Math.min(1, value)) * 1000) / 1000;
+}
+
+function confidenceLevel(
+	confidence: number,
+): RoomFeedClassification["confidenceLevel"] {
+	if (confidence >= 0.8) return "high";
+	if (confidence >= 0.55) return "medium";
+	return "low";
+}
+
+function uniqueReasons(reasons: RoomFeedReasonCode[]): RoomFeedReasonCode[] {
+	return [...new Set(reasons)].sort();
+}
+
+function maxConfidence(
+	values: Array<number | undefined>,
+	fallback: number,
+): number {
+	let max = fallback;
+	for (const value of values) {
+		if (value !== undefined && value > max) max = value;
+	}
+	return max;
+}
+
+function validateInput(input: ClassifyRoomFeedInput): void {
+	assertNonNegativeInteger("diarizedSpeakerCount", input.diarizedSpeakerCount);
+	assertNonNegativeInteger("visiblePersonCount", input.visiblePersonCount);
+	assertRatio("speakerCountConfidence", input.speakerCountConfidence);
+	assertRatio("overlapRatio", input.overlapRatio);
+	assertRatio("faceCountConfidence", input.faceCountConfidence);
+	assertRatio("activeSpeakerContinuity", input.activeSpeakerContinuity);
+	for (const evidence of input.nameEvidence ?? []) {
+		assertRatio(
+			`nameEvidence.${evidence.speakerId}.confidence`,
+			evidence.confidence,
+		);
+	}
+	for (const match of input.voiceProfileMatches ?? []) {
+		assertRatio(
+			`voiceProfileMatches.${match.speakerId}.confidence`,
+			match.confidence,
+		);
+	}
+}
+
+function buildCandidates(
+	input: ClassifyRoomFeedInput,
+	withholdSpeakerNames: boolean,
+): RoomFeedCandidateSpeaker[] {
+	const candidates = new Map<string, RoomFeedCandidateSpeaker>();
+	const ensure = (speakerId: string): RoomFeedCandidateSpeaker => {
+		const existing = candidates.get(speakerId);
+		if (existing) return existing;
+		const created: RoomFeedCandidateSpeaker = {
+			speakerId,
+			confidence: 0,
+			provenance: [],
+			bindingAllowed: false,
+			requiresReview: true,
+		};
+		candidates.set(speakerId, created);
+		return created;
+	};
+
+	for (const evidence of input.nameEvidence ?? []) {
+		const candidate = ensure(evidence.speakerId);
+		candidate.confidence = Math.max(candidate.confidence, evidence.confidence);
+		if (!candidate.provenance.includes(evidence.source)) {
+			candidate.provenance.push(evidence.source);
+		}
+		if (!withholdSpeakerNames && !candidate.displayName) {
+			candidate.displayName = evidence.name;
+		}
+		if (BINDING_PROVENANCE.has(evidence.source)) {
+			candidate.bindingAllowed = true;
+		}
+	}
+
+	for (const match of input.voiceProfileMatches ?? []) {
+		const candidate = ensure(match.speakerId);
+		candidate.confidence = Math.max(candidate.confidence, match.confidence);
+		candidate.profileId = match.profileId;
+		candidate.entityId = match.entityId;
+		if (!candidate.provenance.includes("voice_profile")) {
+			candidate.provenance.push("voice_profile");
+		}
+		if (!withholdSpeakerNames && !candidate.displayName) {
+			candidate.displayName = match.displayName;
+		}
+		candidate.bindingAllowed = true;
+	}
+
+	for (const candidate of candidates.values()) {
+		candidate.provenance.sort();
+		candidate.requiresReview =
+			withholdSpeakerNames ||
+			!candidate.bindingAllowed ||
+			candidate.confidence < 0.85;
+		if (withholdSpeakerNames) {
+			delete candidate.displayName;
+			delete candidate.entityId;
+		}
+	}
+
+	return [...candidates.values()].sort((a, b) =>
+		a.speakerId.localeCompare(b.speakerId),
+	);
+}
+
+export function classifyRoomFeed(
+	input: ClassifyRoomFeedInput,
+): RoomFeedClassification {
+	validateInput(input);
+
+	const participant = input.platformParticipant;
+	const stream = input.sourceStream;
+	const speakerCount = input.diarizedSpeakerCount ?? 0;
+	const speakerConfidence = input.speakerCountConfidence ?? 0;
+	const visibleCount = input.visiblePersonCount ?? 0;
+	const faceConfidence = input.faceCountConfidence ?? 0;
+	const activeContinuity = input.activeSpeakerContinuity ?? 0;
+	const overlap = input.overlapRatio ?? 0;
+	const captureMode = input.captureMode ?? "unknown";
+
+	const reasons: RoomFeedReasonCode[] = [];
+	const uiHints: RoomFeedUiHint[] = [];
+	const participantRoom =
+		participant?.isRoomResource === true || participant?.kind === "room";
+	const participantPerson = participant?.kind === "person";
+	const mixedSource =
+		stream?.isMixed === true ||
+		(stream?.kind !== undefined && MIXED_SOURCE_KINDS.has(stream.kind));
+	const roomCapture = ROOM_CAPTURE_MODES.has(captureMode);
+	const audioMulti = speakerCount >= 2 && speakerConfidence >= 0.7;
+	const visualMulti = visibleCount >= 2 && faceConfidence >= 0.65;
+	const highProfileMatches = (input.voiceProfileMatches ?? []).filter(
+		(match) => match.confidence >= 0.85,
+	);
+	const userCorrections = (input.nameEvidence ?? []).filter(
+		(evidence) =>
+			evidence.source === "user_correction" && evidence.confidence >= 0.85,
+	);
+	const withholdSpeakerNames = input.sensitiveAttributeGuardrail === true;
+
+	if (input.sensitiveAttributeGuardrail)
+		reasons.push("sensitive_attribute_guardrail");
+	if (participantRoom) reasons.push("participant_declared_room");
+	if (participantPerson) reasons.push("participant_declared_person");
+	if (mixedSource) reasons.push("mixed_capture_source");
+	if (roomCapture) reasons.push("capture_mode_room");
+	if (audioMulti) reasons.push("diarized_multiple_speakers");
+	if (visualMulti) reasons.push("visible_multiple_people");
+	if (activeContinuity >= 0.85) reasons.push("active_speaker_continuity");
+	if (speakerCount <= 1 && visibleCount <= 1 && activeContinuity >= 0.7) {
+		reasons.push("single_speaker_single_face");
+	}
+	if (audioMulti && visualMulti) reasons.push("audio_visual_count_agree");
+	if (highProfileMatches.length > 0)
+		reasons.push("profile_match_with_provenance");
+	if (userCorrections.length > 0) reasons.push("user_corrected_identity");
+
+	const contradictory =
+		(participantPerson &&
+			audioMulti &&
+			visibleCount <= 1 &&
+			faceConfidence >= 0.75) ||
+		(activeContinuity >= 0.9 && audioMulti && overlap < 0.08);
+	if (contradictory) reasons.push("contradictory_signals");
+
+	let state: RoomFeedState = "unknown";
+	let confidence = 0.35;
+	let requiresReview = true;
+
+	if (withholdSpeakerNames) {
+		state = "unknown";
+		confidence = 0.2;
+		reasons.push("review_required");
+	} else if (
+		(highProfileMatches.length > 0 || userCorrections.length > 0) &&
+		speakerCount <= 1 &&
+		!audioMulti
+	) {
+		state = "profile_bound";
+		confidence = maxConfidence(
+			[
+				...highProfileMatches.map((match) => match.confidence),
+				...userCorrections.map((evidence) => evidence.confidence),
+			],
+			0.85,
+		);
+		requiresReview = confidence < 0.92;
+	} else if (
+		audioMulti &&
+		visualMulti &&
+		(participantRoom || mixedSource || roomCapture)
+	) {
+		state = "multi_speaker_room";
+		confidence = maxConfidence(
+			[speakerConfidence, faceConfidence, overlap >= 0.2 ? 0.86 : undefined],
+			0.82,
+		);
+		requiresReview = false;
+	} else if (audioMulti && participantPerson && !participantRoom) {
+		state = "speaker_candidates_split";
+		confidence = maxConfidence([speakerConfidence], 0.78);
+		requiresReview = true;
+		reasons.push("candidate_speakers_inside_participant", "review_required");
+	} else if (
+		participantRoom ||
+		(mixedSource && roomCapture && (audioMulti || visualMulti))
+	) {
+		state = "room_feed_confirmed";
+		confidence = maxConfidence([speakerConfidence, faceConfidence], 0.8);
+		requiresReview = false;
+	} else if (audioMulti || visualMulti || mixedSource || roomCapture) {
+		state = "room_feed_suspected";
+		confidence = maxConfidence([speakerConfidence, faceConfidence], 0.58);
+		requiresReview = true;
+		reasons.push("review_required");
+	} else if (
+		participantPerson &&
+		speakerCount <= 1 &&
+		visibleCount <= 1 &&
+		activeContinuity >= 0.7
+	) {
+		state = "individual_feed_likely";
+		confidence = maxConfidence(
+			[activeContinuity, speakerConfidence, faceConfidence],
+			0.74,
+		);
+		requiresReview = false;
+	} else {
+		state = "unknown";
+		confidence = 0.35;
+		reasons.push("insufficient_evidence");
+	}
+
+	if (contradictory && state !== "speaker_candidates_split") {
+		state = "unknown";
+		confidence = 0.38;
+		requiresReview = true;
+		reasons.push("review_required");
+	}
+	if (confidence < 0.55) reasons.push("ambiguous_low_confidence");
+
+	if (
+		state === "room_feed_suspected" ||
+		state === "room_feed_confirmed" ||
+		state === "multi_speaker_room"
+	) {
+		uiHints.push({
+			code: "participant_may_represent_room",
+			message: "This participant may represent a room or shared audio feed.",
+		});
+	}
+	if (state === "speaker_candidates_split" || state === "multi_speaker_room") {
+		uiHints.push({
+			code: "split_speaker_candidates",
+			message: "Suggest splitting transcript speakers inside this participant.",
+		});
+	}
+	if (requiresReview) {
+		uiHints.push({
+			code: "review_before_identity_binding",
+			message: "Review evidence before binding speaker identity.",
+		});
+	}
+	if (withholdSpeakerNames) {
+		uiHints.push({
+			code: "withhold_sensitive_identity",
+			message:
+				"Speaker names are withheld until sensitive-attribute review is complete.",
+		});
+	}
+
+	return {
+		state,
+		confidence: round(confidence),
+		confidenceLevel: confidenceLevel(confidence),
+		reasonCodes: uniqueReasons(reasons),
+		candidateSpeakers: buildCandidates(input, withholdSpeakerNames),
+		uiHints,
+		requiresReview,
+		withholdSpeakerNames,
+	};
+}
+
+export function isRoomFeedTransitionAllowed(
+	from: RoomFeedState,
+	to: RoomFeedState,
+): boolean {
+	return ALLOWED_TRANSITIONS[from].has(to);
+}
+
+export function assertRoomFeedTransition(
+	from: RoomFeedState,
+	to: RoomFeedState,
+): void {
+	if (!isRoomFeedTransitionAllowed(from, to)) {
+		throw new Error(`[room-feed-fst] invalid transition ${from} -> ${to}`);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a deterministic room-feed finite-state classifier for meeting audio/video feeds.
- Covers #12497 room-feed states, confidence levels, reason codes, UI hints, speaker candidate provenance, and identity-binding guardrails.
- Exports the classifier from the voice service barrel and adds focused Vitest coverage for states, transitions, provenance gating, sensitive-name withholding, and invalid metric failures.

## Verification

- `bun run --cwd plugins/plugin-local-inference test src/services/voice/room-feed-fst.test.ts`
  - `Test Files  1 passed (1)`
  - `Tests       10 passed (10)`
- `bunx @biomejs/biome check plugins/plugin-local-inference/src/services/voice/room-feed-fst.ts plugins/plugin-local-inference/src/services/voice/room-feed-fst.test.ts plugins/plugin-local-inference/src/services/voice/index.ts`
  - `Checked 3 files in 10ms. No fixes applied.`
- `bun run --cwd plugins/plugin-local-inference typecheck`
  - `tsgo --noEmit -p tsconfig.json`

## Full Plugin Test Status

- `bun run --cwd plugins/plugin-local-inference test` failed on current baseline failures unrelated to this change:
  - `src/routes/local-inference-route-contracts.fuzz.test.ts` expects an ASR response without the current `aec` metadata field.
  - `src/services/downloader.test.ts` reports invalid Eliza-1 manifest fixtures missing required MTP kernel metadata.
  - `__tests__/mmproj-routing.test.ts` expects a pre-cutover missing-drafter fallback, while current code throws `MissingMtpDrafterError`.
- No `room-feed-fst` tests failed in the full plugin run.

## Evidence

- Evidence note: `.github/issue-evidence/12497-room-feed-fst.md`
- UI screenshots/video: N/A - pure classifier module, no UI surface changed.
- Audio artifacts: N/A - deterministic classifier logic only, no audio model or capture path changed.
- Real LLM trajectories: N/A - no model prompt, provider, action, or evaluator behavior changed.
- Backend/frontend logs: N/A - no route or runtime side effect changed.

Closes #12497
