### PR TITLE
fix(#12498): add speaker name provenance policy

### DIFF
--- a/.github/issue-evidence/12498-speaker-name-provenance.md
+++ b/.github/issue-evidence/12498-speaker-name-provenance.md
@@ -52,7 +52,7 @@ bunx @biomejs/biome check \
 Result:
 
 ```text
-Checked 3 files in 20ms. No fixes applied.
+Checked 3 files in 14ms. No fixes applied.
 ```
 
 ```bash
@@ -70,6 +70,40 @@ Result:
 ```text
 8 passed
 ```
+
+```bash
+bun run --cwd plugins/plugin-local-inference build
+```
+
+Result:
+
+```text
+Build complete
+```
+
+```bash
+bun run --cwd plugins/plugin-local-inference lint:check
+```
+
+Result: blocked by an unrelated existing fixture-format diagnostic in
+`src/services/voice/__fixtures__/voice-workbench-logic-baseline.json`.
+
+```bash
+bun run audit:type-safety-ratchet
+bun run audit:error-policy-ratchet
+git diff --check
+```
+
+Result: passed. The type-safety ratchet reported that the baseline can shrink;
+the error-policy ratchet found no new fallback-slop in touched production files.
+
+```bash
+bun run verify
+```
+
+Result: blocked after repo-level CLAUDE/AGENTS and both ratchets passed. Turbo
+stopped at unrelated `@elizaos/electrobun#lint` formatting diagnostics in
+`src/voice/voice-service.test.ts`.
 
 ```bash
 python -m elizaos_meeting_transcription_proof \
@@ -127,7 +161,8 @@ Result: failed with 14 unrelated current-baseline failures:
   fallback, while current code throws `MissingMtpDrafterError`.
 
 The new `src/runtime/speaker-name-inference.test.ts` suite passed in the full
-run.
+run. Final count: 3 failed files, 244 passed files, 14 failed tests, 2488
+passed tests, 20 skipped tests.
 
 ## Artifact / Evidence Rows
 

--- a/.github/issue-evidence/12498-speaker-name-provenance.md
+++ b/.github/issue-evidence/12498-speaker-name-provenance.md
@@ -1,0 +1,144 @@
+# #12498 Speaker Name Provenance Evidence
+
+Branch: `fix/12498-speaker-name-provenance`
+
+## What Was Proven
+
+- Added deterministic speaker-name inference for platform roster, calendar,
+  self-introduction, user correction, voice profile, and recurring-memory
+  evidence.
+- Every candidate name carries confidence plus source provenance.
+- Low-confidence inferred names are not returned as confirmed identities.
+- User corrections produce a binding plan for the existing
+  `VOICE_TURN_OBSERVED` voice/entity seam.
+- Same-first-name ambiguity, borrowed-device conflicts, sensitive guardrails,
+  and duplicate entity correction paths are covered by focused tests.
+- Added `speaker_name_provenance` to the meeting-transcription-proof manifest
+  and report contract, including all #12498 named cases and expected
+  resolutions.
+- Made the benchmark registry scorer reject publishable real reports that omit
+  speaker-name provenance.
+
+## Focused Verification
+
+```bash
+bun run --cwd plugins/plugin-local-inference test src/runtime/speaker-name-inference.test.ts
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       9 passed (9)
+```
+
+```bash
+bun run --cwd plugins/plugin-local-inference typecheck
+```
+
+Result:
+
+```text
+tsgo --noEmit -p tsconfig.json
+```
+
+```bash
+bunx @biomejs/biome check \
+  plugins/plugin-local-inference/src/runtime/speaker-name-inference.ts \
+  plugins/plugin-local-inference/src/runtime/speaker-name-inference.test.ts \
+  plugins/plugin-local-inference/src/runtime/index.ts
+```
+
+Result:
+
+```text
+Checked 3 files in 20ms. No fixes applied.
+```
+
+```bash
+python -m pytest packages/benchmarks/meeting-transcription-proof/tests -q
+```
+
+Result: passed.
+
+```bash
+python -m pytest packages/benchmarks/tests/test_registry_scores.py -q
+```
+
+Result:
+
+```text
+8 passed
+```
+
+```bash
+python -m elizaos_meeting_transcription_proof \
+  --lane mocked_plumbing \
+  --output /tmp/mtp-smoke-speaker-provenance
+```
+
+Result report:
+
+```text
+/tmp/mtp-smoke-speaker-provenance/meeting-transcription-proof-report.json
+```
+
+Manual report inspection:
+
+```json
+{
+  "lane": "mocked_plumbing",
+  "publishable": false,
+  "score": 1,
+  "speaker_name_provenance_count": 8,
+  "case_ids": [
+    "borrowed_device_guardrail",
+    "calendar_attendee_name",
+    "platform_roster_name",
+    "recurring_speaker_memory",
+    "same_first_name_ambiguity",
+    "self_introduction_name",
+    "user_correction_name",
+    "voice_profile_match_name"
+  ],
+  "resolutions": [
+    "apply_name",
+    "prefer_user_correction",
+    "preserve_unknown",
+    "request_confirmation",
+    "withhold_name"
+  ]
+}
+```
+
+## Full Plugin Test Status
+
+```bash
+bun run --cwd plugins/plugin-local-inference test
+```
+
+Result: failed with 14 unrelated current-baseline failures:
+
+- `src/routes/local-inference-route-contracts.fuzz.test.ts` expects an ASR
+  response without the current `aec` metadata field.
+- `src/services/downloader.test.ts` reports invalid Eliza-1 manifest fixtures
+  missing required MTP kernel metadata.
+- `__tests__/mmproj-routing.test.ts` expects a pre-cutover missing-drafter
+  fallback, while current code throws `MissingMtpDrafterError`.
+
+The new `src/runtime/speaker-name-inference.test.ts` suite passed in the full
+run.
+
+## Artifact / Evidence Rows
+
+- UI correction walkthrough: N/A - this change adds deterministic runtime
+  policy plus benchmark/report enforcement, with no UI surface changed.
+- Audio artifacts: N/A - no audio model, capture path, or acoustic classifier
+  changed.
+- Real LLM trajectories: N/A - no prompt, model provider, action selection, or
+  evaluator behavior changed.
+- Real product lane report: N/A - requires reviewed live meeting artifacts and
+  evidence files outside this deterministic contract change; tracked in
+  follow-up #13142.
+- Backend/frontend logs: N/A - no route or runtime side effect changed; the
+  binding path is returned as a deterministic `voiceTurnBindingPlan`.

--- a/packages/benchmarks/meeting-transcription-proof/AGENTS.md
+++ b/packages/benchmarks/meeting-transcription-proof/AGENTS.md
@@ -74,6 +74,17 @@ shared-room uncertainty. Each operation must describe evidence types, metrics,
 privacy controls, and the confidence policy for applying or withholding speaker
 names.
 
+## Speaker Name Provenance Contract
+
+The real lane requires speaker-name provenance cases for platform roster names,
+calendar attendees, self-introductions, user corrections, voice profile matches,
+recurring speaker memory after correction, same-first-name ambiguity, and
+borrowed-device guardrails. Each case must describe source, surface, evidence,
+signals, confidence, conflict policy, confidence policy, privacy policy, and the
+expected resolution. Low-confidence inferred names cannot be reported as
+confirmed identities; they must request confirmation, withhold the name, or
+preserve an unknown speaker label.
+
 ## Evidence
 
 Mocked reports prove plumbing only. Real reports must reference reviewed audio,

--- a/packages/benchmarks/meeting-transcription-proof/CLAUDE.md
+++ b/packages/benchmarks/meeting-transcription-proof/CLAUDE.md
@@ -74,6 +74,17 @@ shared-room uncertainty. Each operation must describe evidence types, metrics,
 privacy controls, and the confidence policy for applying or withholding speaker
 names.
 
+## Speaker Name Provenance Contract
+
+The real lane requires speaker-name provenance cases for platform roster names,
+calendar attendees, self-introductions, user corrections, voice profile matches,
+recurring speaker memory after correction, same-first-name ambiguity, and
+borrowed-device guardrails. Each case must describe source, surface, evidence,
+signals, confidence, conflict policy, confidence policy, privacy policy, and the
+expected resolution. Low-confidence inferred names cannot be reported as
+confirmed identities; they must request confirmation, withhold the name, or
+preserve an unknown speaker label.
+
 ## Evidence
 
 Mocked reports prove plumbing only. Real reports must reference reviewed audio,

--- a/packages/benchmarks/meeting-transcription-proof/README.md
+++ b/packages/benchmarks/meeting-transcription-proof/README.md
@@ -73,6 +73,15 @@ non-recognition, multi-speaker single-stream attribution, and shared-room
 uncertainty handling. Each operation must name evidence types, metrics, privacy
 controls, and the confidence policy used before applying speaker names.
 
+Real manifests must include speaker-name provenance cases for platform roster
+names, calendar attendees, self-introductions, user corrections, voice profile
+matches, recurring speaker memory after correction, same-first-name ambiguity,
+and borrowed-device guardrails. Each case must name the source, surface,
+evidence, signals, confidence, conflict policy, confidence policy, privacy
+policy, and expected resolution. Low-confidence inferred names cannot be
+reported as confirmed identities; they must request confirmation, withhold the
+name, or preserve an unknown speaker label.
+
 ## Fixture Manifest
 
 `fixtures/mock-meeting-manifest.json` describes the minimum canonical meeting

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/cli.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/cli.py
@@ -60,6 +60,64 @@ REQUIRED_SPEAKER_OPERATION_FIELDS = {
     "privacy_control",
     "confidence_policy",
 }
+REQUIRED_SPEAKER_NAME_PROVENANCE_CASES = {
+    "platform_roster_name",
+    "calendar_attendee_name",
+    "self_introduction_name",
+    "user_correction_name",
+    "voice_profile_match_name",
+    "recurring_speaker_memory",
+    "same_first_name_ambiguity",
+    "borrowed_device_guardrail",
+}
+REQUIRED_SPEAKER_NAME_PROVENANCE_FIELDS = {
+    "id",
+    "source",
+    "surface",
+    "evidence",
+    "signals",
+    "confidence",
+    "conflict_policy",
+    "confidence_policy",
+    "privacy_policy",
+    "expected_resolution",
+}
+REQUIRED_SPEAKER_NAME_SOURCES = {
+    "platform_roster",
+    "calendar_attendee",
+    "self_introduction",
+    "user_correction",
+    "voice_profile",
+    "speaker_memory",
+}
+REQUIRED_SPEAKER_NAME_SIGNALS = {
+    "platform_label",
+    "calendar_attendee",
+    "self_introduction",
+    "user_correction",
+    "voice_profile_match",
+    "recurring_meeting_memory",
+    "same_first_name_ambiguity",
+    "borrowed_device_guardrail",
+}
+REQUIRED_SPEAKER_NAME_RESOLUTIONS = {
+    "apply_name",
+    "withhold_name",
+    "request_confirmation",
+    "prefer_user_correction",
+    "preserve_unknown",
+}
+CONFIRMED_SPEAKER_NAME_RESOLUTIONS = {"apply_name", "prefer_user_correction"}
+FORBIDDEN_SPEAKER_NAME_POLICY_TERMS = {
+    "age",
+    "disability",
+    "ethnicity",
+    "gender",
+    "nationality",
+    "race",
+    "religion",
+    "sexual orientation",
+}
 REQUIRED_SCENARIOS = {
     "clean_single_speaker",
     "zoom_bot",
@@ -174,11 +232,15 @@ def _as_set(value: Any, *, field: str) -> set[str]:
 
 def _require_number(metrics: dict[str, Any], key: str) -> float:
     value = metrics.get(key)
+    return _require_ratio_value(f"metrics.{key}", value)
+
+
+def _require_ratio_value(field: str, value: Any) -> float:
     if isinstance(value, bool) or not isinstance(value, int | float):
-        raise ValueError(f"metrics.{key} must be numeric")
+        raise ValueError(f"{field} must be numeric")
     number = float(value)
     if number < 0 or number > 1:
-        raise ValueError(f"metrics.{key} must be in [0, 1]")
+        raise ValueError(f"{field} must be in [0, 1]")
     return number
 
 
@@ -488,6 +550,115 @@ def _validate_speaker_operations(manifest: dict[str, Any]) -> tuple[list[dict[st
     return sorted(normalized, key=lambda operation: operation["id"]), referenced_evidence
 
 
+def _reject_sensitive_name_policy(field: str, value: str) -> None:
+    lowered = value.lower()
+    for term in sorted(FORBIDDEN_SPEAKER_NAME_POLICY_TERMS):
+        if term in lowered:
+            raise ValueError(f"{field} must not use sensitive attributes for speaker naming: {term}")
+
+
+def _validate_speaker_name_provenance(manifest: dict[str, Any]) -> tuple[list[dict[str, Any]], set[str]]:
+    speaker_names = manifest.get("speaker_name_provenance")
+    if not isinstance(speaker_names, list) or not speaker_names:
+        raise ValueError("speaker_name_provenance must be a non-empty array")
+
+    case_ids: set[str] = set()
+    covered_sources: set[str] = set()
+    covered_signals: set[str] = set()
+    covered_resolutions: set[str] = set()
+    referenced_evidence: set[str] = set()
+    normalized: list[dict[str, Any]] = []
+    for index, speaker_name in enumerate(speaker_names):
+        if not isinstance(speaker_name, dict):
+            raise ValueError(f"speaker_name_provenance[{index}] must be an object")
+        missing_fields = REQUIRED_SPEAKER_NAME_PROVENANCE_FIELDS - set(speaker_name)
+        if missing_fields:
+            raise ValueError(f"speaker_name_provenance[{index}] missing fields: {sorted(missing_fields)}")
+        case_id = speaker_name.get("id")
+        if not isinstance(case_id, str) or not case_id.strip():
+            raise ValueError(f"speaker_name_provenance[{index}].id must be a non-empty string")
+        case_ids.add(case_id)
+        source = speaker_name.get("source")
+        if not isinstance(source, str) or source not in REQUIRED_SPEAKER_NAME_SOURCES:
+            raise ValueError(
+                f"speaker_name_provenance[{index}].source must be one of {sorted(REQUIRED_SPEAKER_NAME_SOURCES)}"
+            )
+        covered_sources.add(source)
+        surface = speaker_name.get("surface")
+        if not isinstance(surface, str) or not surface.strip():
+            raise ValueError(f"speaker_name_provenance[{index}].surface must be a non-empty string")
+        evidence = _as_set(speaker_name.get("evidence"), field=f"speaker_name_provenance[{index}].evidence")
+        unknown_evidence = evidence - REQUIRED_EVIDENCE
+        if unknown_evidence:
+            raise ValueError(
+                f"speaker_name_provenance[{index}] references unknown evidence: {sorted(unknown_evidence)}"
+            )
+        signals = _as_set(speaker_name.get("signals"), field=f"speaker_name_provenance[{index}].signals")
+        unknown_signals = signals - REQUIRED_SPEAKER_NAME_SIGNALS
+        if unknown_signals:
+            raise ValueError(
+                f"speaker_name_provenance[{index}] references unknown signals: {sorted(unknown_signals)}"
+            )
+        confidence = _require_ratio_value(
+            f"speaker_name_provenance[{index}].confidence",
+            speaker_name.get("confidence"),
+        )
+        conflict_policy = speaker_name.get("conflict_policy")
+        if not isinstance(conflict_policy, str) or not conflict_policy.strip():
+            raise ValueError(f"speaker_name_provenance[{index}].conflict_policy must be a non-empty string")
+        confidence_policy = speaker_name.get("confidence_policy")
+        if not isinstance(confidence_policy, str) or not confidence_policy.strip():
+            raise ValueError(f"speaker_name_provenance[{index}].confidence_policy must be a non-empty string")
+        privacy_policy = speaker_name.get("privacy_policy")
+        if not isinstance(privacy_policy, str) or not privacy_policy.strip():
+            raise ValueError(f"speaker_name_provenance[{index}].privacy_policy must be a non-empty string")
+        _reject_sensitive_name_policy(f"speaker_name_provenance[{index}].conflict_policy", conflict_policy)
+        _reject_sensitive_name_policy(f"speaker_name_provenance[{index}].confidence_policy", confidence_policy)
+        expected_resolution = speaker_name.get("expected_resolution")
+        if not isinstance(expected_resolution, str) or expected_resolution not in REQUIRED_SPEAKER_NAME_RESOLUTIONS:
+            raise ValueError(
+                "speaker_name_provenance"
+                f"[{index}].expected_resolution must be one of {sorted(REQUIRED_SPEAKER_NAME_RESOLUTIONS)}"
+            )
+        if confidence < 0.85 and expected_resolution in CONFIRMED_SPEAKER_NAME_RESOLUTIONS:
+            raise ValueError(
+                "speaker_name_provenance"
+                f"[{index}] low-confidence inferred names cannot use confirmed resolution {expected_resolution}"
+            )
+
+        covered_signals.update(signals)
+        covered_resolutions.add(expected_resolution)
+        referenced_evidence.update(evidence)
+        normalized.append(
+            {
+                "id": case_id,
+                "source": source,
+                "surface": surface,
+                "evidence": sorted(evidence),
+                "signals": sorted(signals),
+                "confidence": confidence,
+                "conflict_policy": conflict_policy,
+                "confidence_policy": confidence_policy,
+                "privacy_policy": privacy_policy,
+                "expected_resolution": expected_resolution,
+            }
+        )
+
+    missing_cases = REQUIRED_SPEAKER_NAME_PROVENANCE_CASES - case_ids
+    if missing_cases:
+        raise ValueError(f"speaker_name_provenance missing cases: {sorted(missing_cases)}")
+    missing_sources = REQUIRED_SPEAKER_NAME_SOURCES - covered_sources
+    if missing_sources:
+        raise ValueError(f"speaker_name_provenance missing sources: {sorted(missing_sources)}")
+    missing_signals = REQUIRED_SPEAKER_NAME_SIGNALS - covered_signals
+    if missing_signals:
+        raise ValueError(f"speaker_name_provenance missing signals: {sorted(missing_signals)}")
+    missing_resolutions = REQUIRED_SPEAKER_NAME_RESOLUTIONS - covered_resolutions
+    if missing_resolutions:
+        raise ValueError(f"speaker_name_provenance missing expected resolutions: {sorted(missing_resolutions)}")
+    return sorted(normalized, key=lambda speaker_name: speaker_name["id"]), referenced_evidence
+
+
 def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Path) -> dict[str, Any]:
     if lane not in LANES:
         raise ValueError(f"lane must be one of {sorted(LANES)}")
@@ -545,6 +716,7 @@ def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Pat
     dataset_sources, dataset_evidence_types = _validate_dataset_sources(manifest)
     capture_paths, capture_evidence_types = _validate_capture_paths(manifest)
     speaker_operations, speaker_operation_evidence_types = _validate_speaker_operations(manifest)
+    speaker_name_provenance, speaker_name_evidence_types = _validate_speaker_name_provenance(manifest)
 
     metric_values = _validate_metrics(manifest.get("metrics"), lane=lane)
 
@@ -569,6 +741,9 @@ def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Pat
         missing_speaker_operation_evidence = speaker_operation_evidence_types - set(evidence_files)
         if missing_speaker_operation_evidence:
             raise ValueError(f"speaker operation evidence files missing: {sorted(missing_speaker_operation_evidence)}")
+        missing_speaker_name_evidence = speaker_name_evidence_types - set(evidence_files)
+        if missing_speaker_name_evidence:
+            raise ValueError(f"speaker name evidence files missing: {sorted(missing_speaker_name_evidence)}")
 
     return {
         "surfaces": sorted(surfaces),
@@ -579,6 +754,7 @@ def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Pat
         "dataset_sources": dataset_sources,
         "capture_paths": capture_paths,
         "speaker_operations": speaker_operations,
+        "speaker_name_provenance": speaker_name_provenance,
         "metrics": metric_values,
         "evidence_files": evidence_files,
         "provider_mode": provider_mode,

--- a/packages/benchmarks/meeting-transcription-proof/fixtures/mock-meeting-manifest.json
+++ b/packages/benchmarks/meeting-transcription-proof/fixtures/mock-meeting-manifest.json
@@ -384,6 +384,104 @@
       "confidence_policy": "prefer room-level labels when visual or voice evidence is ambiguous"
     }
   ],
+  "speaker_name_provenance": [
+    {
+      "id": "platform_roster_name",
+      "source": "platform_roster",
+      "surface": "zoom",
+      "evidence": ["transcript_artifact", "speaker_profile_artifact"],
+      "signals": ["platform_label"],
+      "confidence": 0.91,
+      "conflict_policy": "apply only when roster, diarization, and profile context do not conflict",
+      "confidence_policy": "confirmed labels require high confidence and provenance in the transcript JSON",
+      "privacy_policy": "show source and confidence next to the displayed name",
+      "expected_resolution": "apply_name"
+    },
+    {
+      "id": "calendar_attendee_name",
+      "source": "calendar_attendee",
+      "surface": "google_meet",
+      "evidence": ["transcript_artifact", "screenshots"],
+      "signals": ["calendar_attendee"],
+      "confidence": 0.72,
+      "conflict_policy": "calendar-only matches stay tentative when roster or voice evidence is absent",
+      "confidence_policy": "medium confidence attendee matches ask the user before confirmed display",
+      "privacy_policy": "calendar attendee names remain scoped to the meeting artifact",
+      "expected_resolution": "request_confirmation"
+    },
+    {
+      "id": "self_introduction_name",
+      "source": "self_introduction",
+      "surface": "hybrid_local_cloud",
+      "evidence": ["audio", "transcript_artifact"],
+      "signals": ["self_introduction"],
+      "confidence": 0.9,
+      "conflict_policy": "self-introduction wins only for the diarized speaker segment that contains it",
+      "confidence_policy": "apply when transcript confidence and speaker attribution are both high",
+      "privacy_policy": "store the quote-backed provenance with the transcript segment",
+      "expected_resolution": "apply_name"
+    },
+    {
+      "id": "user_correction_name",
+      "source": "user_correction",
+      "surface": "hybrid_local_cloud",
+      "evidence": ["screenshots", "speaker_profile_artifact", "transcript_artifact"],
+      "signals": ["user_correction"],
+      "confidence": 0.99,
+      "conflict_policy": "manual correction overrides lower-priority inferred labels",
+      "confidence_policy": "user-confirmed correction becomes the binding source for future opted-in runs",
+      "privacy_policy": "correction history remains auditable and reversible",
+      "expected_resolution": "prefer_user_correction"
+    },
+    {
+      "id": "voice_profile_match_name",
+      "source": "voice_profile",
+      "surface": "on_device",
+      "evidence": ["audio", "speaker_profile_artifact", "metrics"],
+      "signals": ["voice_profile_match"],
+      "confidence": 0.94,
+      "conflict_policy": "voice profile labels apply only when false-accept controls pass",
+      "confidence_policy": "confirmed display requires a high-confidence profile match",
+      "privacy_policy": "profile provenance and confidence are visible before sharing",
+      "expected_resolution": "apply_name"
+    },
+    {
+      "id": "recurring_speaker_memory",
+      "source": "speaker_memory",
+      "surface": "hybrid_local_cloud",
+      "evidence": ["speaker_profile_artifact", "transcript_artifact"],
+      "signals": ["user_correction", "recurring_meeting_memory"],
+      "confidence": 0.96,
+      "conflict_policy": "previous user correction carries into recurring meetings unless new evidence conflicts",
+      "confidence_policy": "recurring Speaker 2 becomes Sarah only after correction-backed memory is present",
+      "privacy_policy": "recurring memory is attached to the meeting series and can be deleted",
+      "expected_resolution": "prefer_user_correction"
+    },
+    {
+      "id": "same_first_name_ambiguity",
+      "source": "calendar_attendee",
+      "surface": "google_meet",
+      "evidence": ["transcript_artifact", "speaker_profile_artifact", "screenshots"],
+      "signals": ["calendar_attendee", "same_first_name_ambiguity", "voice_profile_match"],
+      "confidence": 0.64,
+      "conflict_policy": "same-first-name cases with mixed signals must not choose a last name without review",
+      "confidence_policy": "ambiguous first-name matches are withheld until a stronger source disambiguates",
+      "privacy_policy": "candidate names are shown as review choices, not confirmed identity",
+      "expected_resolution": "withhold_name"
+    },
+    {
+      "id": "borrowed_device_guardrail",
+      "source": "platform_roster",
+      "surface": "zoom",
+      "evidence": ["audio", "transcript_artifact", "speaker_profile_artifact"],
+      "signals": ["platform_label", "borrowed_device_guardrail", "self_introduction"],
+      "confidence": 0.58,
+      "conflict_policy": "platform laptop owner labels do not bind when voice or self-introduction conflict",
+      "confidence_policy": "borrowed-device conflicts preserve unknown labels until user correction",
+      "privacy_policy": "avoid propagating the device owner's name onto another speaker",
+      "expected_resolution": "preserve_unknown"
+    }
+  ],
   "metrics": {
     "transcript_quality": 1.0,
     "diarization_quality": 1.0,

--- a/packages/benchmarks/meeting-transcription-proof/tests/conftest.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_cli.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_cli.py
@@ -27,6 +27,10 @@ def _fixture_speaker_operations() -> list[object]:
     return json.loads(FIXTURE_MANIFEST.read_text(encoding="utf-8"))["speaker_operations"]
 
 
+def _fixture_speaker_name_provenance() -> list[object]:
+    return json.loads(FIXTURE_MANIFEST.read_text(encoding="utf-8"))["speaker_name_provenance"]
+
+
 def _base_manifest(provider_mode: str = "real_zoom_meet") -> dict[str, object]:
     return {
         "provider_mode": provider_mode,
@@ -52,6 +56,7 @@ def _base_manifest(provider_mode: str = "real_zoom_meet") -> dict[str, object]:
         "dataset_sources": _fixture_dataset_sources(),
         "capture_paths": _fixture_capture_paths(),
         "speaker_operations": _fixture_speaker_operations(),
+        "speaker_name_provenance": _fixture_speaker_name_provenance(),
         "metrics": {
             "transcript_quality": 0.91,
             "diarization_quality": 0.82,
@@ -92,6 +97,7 @@ def test_mocked_plumbing_fixture_is_not_publishable() -> None:
     assert len(report["dataset_sources"]) == len(_fixture_dataset_sources())
     assert len(report["capture_paths"]) == len(_fixture_capture_paths())
     assert len(report["speaker_operations"]) == len(_fixture_speaker_operations())
+    assert len(report["speaker_name_provenance"]) == len(_fixture_speaker_name_provenance())
 
 
 def test_real_lane_requires_non_mock_provider(tmp_path: Path) -> None:
@@ -368,6 +374,64 @@ def test_speaker_operations_may_only_reference_known_metrics(tmp_path: Path) -> 
         build_report(lane="real_product", manifest_path=manifest)
 
 
+def test_real_lane_requires_all_speaker_name_provenance_cases(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    manifest_data["speaker_name_provenance"] = [
+        case
+        for case in _fixture_speaker_name_provenance()
+        if isinstance(case, dict) and case.get("id") != "borrowed_device_guardrail"
+    ]
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="speaker_name_provenance missing cases"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_speaker_name_provenance_requires_source_and_confidence(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    speaker_names = _fixture_speaker_name_provenance()
+    assert isinstance(speaker_names[0], dict)
+    speaker_names[0] = {key: value for key, value in speaker_names[0].items() if key != "confidence"}
+    manifest_data["speaker_name_provenance"] = speaker_names
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="missing fields"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+    speaker_names = _fixture_speaker_name_provenance()
+    assert isinstance(speaker_names[0], dict)
+    speaker_names[0] = {**speaker_names[0], "source": "chat_guess"}
+    manifest_data["speaker_name_provenance"] = speaker_names
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match=r"speaker_name_provenance\[0\]\.source must be one of"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_low_confidence_speaker_name_cannot_be_confirmed(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    speaker_names = _fixture_speaker_name_provenance()
+    assert isinstance(speaker_names[1], dict)
+    speaker_names[1] = {**speaker_names[1], "expected_resolution": "apply_name"}
+    manifest_data["speaker_name_provenance"] = speaker_names
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="low-confidence inferred names cannot use confirmed resolution"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_speaker_name_policies_reject_sensitive_attribute_shortcuts(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    speaker_names = _fixture_speaker_name_provenance()
+    assert isinstance(speaker_names[0], dict)
+    speaker_names[0] = {**speaker_names[0], "confidence_policy": "use gender and voice profile as a shortcut"}
+    manifest_data["speaker_name_provenance"] = speaker_names
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="must not use sensitive attributes"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
 def test_real_lane_scores_lowest_required_quality_and_resolves_evidence(tmp_path: Path) -> None:
     evidence_names = [
         "audio",
@@ -405,6 +469,24 @@ def test_real_lane_scores_lowest_required_quality_and_resolves_evidence(tmp_path
         "post_deletion_non_recognition",
         "multi_speaker_single_stream_attribution",
     }
+    assert {case["id"] for case in report["speaker_name_provenance"]} >= {
+        "platform_roster_name",
+        "calendar_attendee_name",
+        "self_introduction_name",
+        "user_correction_name",
+        "voice_profile_match_name",
+        "recurring_speaker_memory",
+        "same_first_name_ambiguity",
+        "borrowed_device_guardrail",
+    }
+    assert {case["expected_resolution"] for case in report["speaker_name_provenance"]} >= {
+        "apply_name",
+        "withhold_name",
+        "request_confirmation",
+        "prefer_user_correction",
+        "preserve_unknown",
+    }
+    assert all("confidence" in case for case in report["speaker_name_provenance"])
     assert all(dataset["version"] for dataset in report["dataset_sources"])
     assert all(dataset["checksum"] for dataset in report["dataset_sources"])
     assert all(dataset["sample_count"] > 0 for dataset in report["dataset_sources"])

--- a/packages/benchmarks/registry/scores.py
+++ b/packages/benchmarks/registry/scores.py
@@ -912,12 +912,18 @@ def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtrac
     )
     evidence_files = root.get("evidence_files")
     evidence_count = len(evidence_files) if isinstance(evidence_files, dict) else 0
+    speaker_name_provenance = root.get("speaker_name_provenance")
+    speaker_name_provenance_count = (
+        len(speaker_name_provenance) if isinstance(speaker_name_provenance, list) else 0
+    )
     publishable = root.get("publishable") is True
     if lane == "real_product":
         if not publishable:
             raise ValueError("meeting_transcription_proof: real lane must be publishable")
         if evidence_count < 11:
             raise ValueError("meeting_transcription_proof: real lane requires complete evidence files")
+        if speaker_name_provenance_count < 8:
+            raise ValueError("meeting_transcription_proof: real lane requires speaker name provenance")
     elif publishable:
         raise ValueError("meeting_transcription_proof: mocked lane cannot be publishable")
 
@@ -929,6 +935,7 @@ def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtrac
             "lane": lane,
             "publishable": publishable,
             "evidence_file_count": evidence_count,
+            "speaker_name_provenance_count": speaker_name_provenance_count,
             "transcript_quality": metrics.get("transcript_quality") or 0,
             "diarization_quality": metrics.get("diarization_quality") or 0,
             "speaker_identity_quality": metrics.get("speaker_identity_quality") or 0,

--- a/packages/benchmarks/tests/test_registry_scores.py
+++ b/packages/benchmarks/tests/test_registry_scores.py
@@ -80,6 +80,7 @@ def test_meeting_transcription_mock_lane_is_non_publishable_smoke_score() -> Non
     assert extraction.score == pytest.approx(1.0)
     assert extraction.metrics["lane"] == "mocked_plumbing"
     assert extraction.metrics["publishable"] is False
+    assert extraction.metrics["speaker_name_provenance_count"] == 0
 
 
 def test_meeting_transcription_mock_lane_cannot_claim_publishable() -> None:
@@ -110,6 +111,22 @@ def test_meeting_transcription_real_lane_requires_complete_evidence() -> None:
         )
 
 
+def test_meeting_transcription_real_lane_requires_speaker_name_provenance() -> None:
+    evidence_files = {f"evidence_{index}": f"/tmp/evidence-{index}.txt" for index in range(11)}
+    with pytest.raises(ValueError, match="speaker name provenance"):
+        _score_from_meeting_transcription_proof_json(
+            {
+                "kind": "meeting_transcription_proof_report",
+                "lane": "real_product",
+                "publishable": True,
+                "score": 0.8,
+                "metrics": {},
+                "evidence_files": evidence_files,
+                "speaker_name_provenance": [{} for _ in range(7)],
+            }
+        )
+
+
 def test_meeting_transcription_real_lane_score_is_publishable_with_evidence() -> None:
     evidence_files = {f"evidence_{index}": f"/tmp/evidence-{index}.txt" for index in range(11)}
     extraction = _score_from_meeting_transcription_proof_json(
@@ -126,6 +143,7 @@ def test_meeting_transcription_real_lane_score_is_publishable_with_evidence() ->
                 "consent_retention_quality": 1.0,
             },
             "evidence_files": evidence_files,
+            "speaker_name_provenance": [{} for _ in range(8)],
         }
     )
 
@@ -133,3 +151,4 @@ def test_meeting_transcription_real_lane_score_is_publishable_with_evidence() ->
     assert extraction.metrics["lane"] == "real_product"
     assert extraction.metrics["publishable"] is True
     assert extraction.metrics["evidence_file_count"] == 11
+    assert extraction.metrics["speaker_name_provenance_count"] == 8

--- a/plugins/plugin-local-inference/src/runtime/index.ts
+++ b/plugins/plugin-local-inference/src/runtime/index.ts
@@ -36,6 +36,21 @@ export {
 	warnIfMobileGateActiveWithoutPlatform,
 } from "./mobile-local-inference-gate.js";
 export {
+	type ExistingSpeakerEntity,
+	type InferSpeakerNameInput,
+	inferSpeakerName,
+	type SpeakerNameBindingAction,
+	type SpeakerNameBindingPlan,
+	type SpeakerNameCandidate,
+	type SpeakerNameEvidence,
+	type SpeakerNameEvidenceSource,
+	type SpeakerNameInference,
+	type SpeakerNameProvenance,
+	type SpeakerNameReasonCode,
+	type SpeakerNameResolution,
+	type SpeakerNameVoiceTurnBindingPlan,
+} from "./speaker-name-inference.js";
+export {
 	type EmitVoiceTurnObservedArgs,
 	emitVoiceTurnObserved,
 	getVoiceProfileStore,

--- a/plugins/plugin-local-inference/src/runtime/speaker-name-inference.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/speaker-name-inference.test.ts
@@ -1,0 +1,210 @@
+/** Covers meeting speaker-name inference, provenance, and correction binding. */
+import { describe, expect, it } from "vitest";
+import { inferSpeakerName } from "./speaker-name-inference.js";
+
+describe("inferSpeakerName", () => {
+	it("keeps conflicting platform and calendar names as review candidates", () => {
+		const result = inferSpeakerName({
+			speakerId: "speaker-1",
+			evidence: [
+				{
+					source: "platform_roster",
+					name: "Alex",
+					confidence: 0.78,
+					evidenceId: "zoom-roster",
+				},
+				{
+					source: "calendar_attendee",
+					name: "Alexandra Gray",
+					confidence: 0.74,
+					evidenceId: "calendar",
+				},
+			],
+		});
+
+		expect(result.resolution).toBe("needs_confirmation");
+		expect(result.displayName).toBeUndefined();
+		expect(result.reasonCodes).toContain("conflicting_name_evidence");
+		expect(result.candidateNames).toHaveLength(2);
+		expect(
+			result.candidateNames.every(
+				(candidate) =>
+					candidate.confidence > 0 && candidate.provenance.length > 0,
+			),
+		).toBe(true);
+	});
+
+	it("does not confirm low-confidence inferred names even when sources agree", () => {
+		const result = inferSpeakerName({
+			speakerId: "speaker-1",
+			evidence: [
+				{ source: "platform_roster", name: "Ari", confidence: 0.72 },
+				{ source: "calendar_attendee", name: "Ari", confidence: 0.74 },
+			],
+		});
+
+		expect(result.resolution).toBe("needs_confirmation");
+		expect(result.displayName).toBeUndefined();
+		expect(result.reasonCodes).toContain("source_agreement");
+		expect(result.reasonCodes).toContain("low_confidence_name");
+	});
+
+	it("prefers self-introduction over a borrowed laptop platform label", () => {
+		const result = inferSpeakerName({
+			speakerId: "speaker-1",
+			evidence: [
+				{
+					source: "platform_roster",
+					name: "Taylor Owner",
+					confidence: 0.93,
+					deviceOwnerEntityId: "entity-device-owner",
+				},
+				{
+					source: "self_introduction",
+					name: "Mina Chen",
+					confidence: 0.9,
+				},
+			],
+		});
+
+		expect(result.resolution).toBe("confirmed");
+		expect(result.displayName).toBe("Mina Chen");
+		expect(result.reasonCodes).toContain("borrowed_device_guardrail");
+		expect(result.bindingPlan.action).toBe("create_entity");
+	});
+
+	it("confirms voice-profile matches with entity/profile provenance", () => {
+		const result = inferSpeakerName({
+			speakerId: "speaker-voice",
+			evidence: [
+				{
+					source: "voice_profile",
+					name: "Jon Reed",
+					confidence: 0.94,
+					entityId: "entity-jon",
+					profileId: "profile-jon",
+				},
+			],
+		});
+
+		expect(result.resolution).toBe("confirmed");
+		expect(result.displayName).toBe("Jon Reed");
+		expect(result.entityId).toBe("entity-jon");
+		expect(result.profileId).toBe("profile-jon");
+		expect(result.reasonCodes).toContain("voice_profile_match");
+		expect(result.bindingPlan).toMatchObject({
+			action: "bind_existing_entity",
+			entityId: "entity-jon",
+			profileId: "profile-jon",
+		});
+	});
+
+	it("turns recurring Speaker 2 into Sarah after user correction without creating a duplicate entity", () => {
+		const result = inferSpeakerName({
+			speakerId: "speaker-2",
+			imprintClusterId: "cluster-speaker-2",
+			existingEntities: [{ entityId: "entity-sarah", displayName: "Sarah" }],
+			evidence: [
+				{ source: "calendar_attendee", name: "Speaker 2", confidence: 0.45 },
+				{ source: "user_correction", name: "Sarah", confidence: 0.99 },
+				{ source: "speaker_memory", name: "Sarah", confidence: 0.96 },
+			],
+		});
+
+		expect(result.resolution).toBe("confirmed");
+		expect(result.displayName).toBe("Sarah");
+		expect(result.entityId).toBe("entity-sarah");
+		expect(result.bindingPlan.action).toBe("bind_existing_entity");
+		expect(result.bindingPlan.mergeEntityIds).toEqual([]);
+		expect(result.voiceTurnBindingPlan).toEqual({
+			text: "This is Sarah.",
+			imprintClusterId: "cluster-speaker-2",
+			matchConfidence: 0.99,
+			matchedEntityId: "entity-sarah",
+		});
+		expect(result.reasonCodes).toEqual(
+			expect.arrayContaining([
+				"user_correction_applied",
+				"recurring_memory_applied",
+			]),
+		);
+	});
+
+	it("flags duplicate entities after correction instead of creating another Sarah", () => {
+		const result = inferSpeakerName({
+			speakerId: "speaker-2",
+			existingEntities: [
+				{ entityId: "entity-sarah-a", displayName: "Sarah" },
+				{ entityId: "entity-sarah-b", displayName: "Sarah" },
+			],
+			evidence: [
+				{ source: "user_correction", name: "Sarah", confidence: 0.99 },
+			],
+		});
+
+		expect(result.resolution).toBe("confirmed");
+		expect(result.requiresReview).toBe(true);
+		expect(result.bindingPlan.action).toBe("merge_duplicate_entities");
+		expect(result.bindingPlan.mergeEntityIds).toEqual([
+			"entity-sarah-a",
+			"entity-sarah-b",
+		]);
+		expect(result.bindingPlan.reasonCodes).toContain(
+			"duplicate_entity_merge_required",
+		);
+	});
+
+	it("withholds two same-first-name candidates until disambiguated", () => {
+		const result = inferSpeakerName({
+			speakerId: "speaker-ambiguous",
+			evidence: [
+				{
+					source: "calendar_attendee",
+					name: "Sarah Kim",
+					confidence: 0.82,
+				},
+				{
+					source: "voice_profile",
+					name: "Sarah Patel",
+					confidence: 0.83,
+					entityId: "entity-sarah-patel",
+				},
+			],
+		});
+
+		expect(result.resolution).toBe("withheld");
+		expect(result.displayName).toBeUndefined();
+		expect(result.bindingPlan.action).toBe("none");
+		expect(result.reasonCodes).toContain("same_first_name_ambiguity");
+	});
+
+	it("withholds confirmed-looking names behind sensitive-attribute guardrails", () => {
+		const result = inferSpeakerName({
+			speakerId: "speaker-sensitive",
+			sensitiveAttributeGuardrail: true,
+			evidence: [
+				{
+					source: "voice_profile",
+					name: "Riley",
+					confidence: 0.96,
+					entityId: "entity-riley",
+				},
+			],
+		});
+
+		expect(result.resolution).toBe("withheld");
+		expect(result.displayName).toBeUndefined();
+		expect(result.entityId).toBeUndefined();
+		expect(result.bindingPlan.action).toBe("none");
+		expect(result.reasonCodes).toContain("sensitive_attribute_guardrail");
+	});
+
+	it("fails loud on invalid confidence", () => {
+		expect(() =>
+			inferSpeakerName({
+				speakerId: "speaker-bad",
+				evidence: [{ source: "voice_profile", name: "Bad", confidence: 1.2 }],
+			}),
+		).toThrow(/confidence/);
+	});
+});

--- a/plugins/plugin-local-inference/src/runtime/speaker-name-inference.ts
+++ b/plugins/plugin-local-inference/src/runtime/speaker-name-inference.ts
@@ -1,0 +1,481 @@
+/**
+ * Deterministic speaker-name policy for meeting transcripts.
+ *
+ * This folds platform roster, calendar, self-introduction, user correction,
+ * voice profile, and recurring-memory evidence into explicit name candidates.
+ * It never reports a low-confidence inferred label as confirmed identity, and
+ * it turns user corrections into a binding plan for the existing voice/entity
+ * event seam.
+ */
+
+export type SpeakerNameEvidenceSource =
+	| "platform_roster"
+	| "calendar_attendee"
+	| "self_introduction"
+	| "user_correction"
+	| "voice_profile"
+	| "speaker_memory";
+
+export type SpeakerNameResolution =
+	| "confirmed"
+	| "needs_confirmation"
+	| "withheld"
+	| "unknown";
+
+export type SpeakerNameBindingAction =
+	| "bind_existing_entity"
+	| "create_entity"
+	| "merge_duplicate_entities"
+	| "none";
+
+export type SpeakerNameReasonCode =
+	| "borrowed_device_guardrail"
+	| "conflicting_name_evidence"
+	| "duplicate_entity_merge_required"
+	| "high_confidence_name"
+	| "low_confidence_name"
+	| "no_name_evidence"
+	| "recurring_memory_applied"
+	| "same_first_name_ambiguity"
+	| "sensitive_attribute_guardrail"
+	| "source_agreement"
+	| "user_correction_applied"
+	| "voice_profile_match";
+
+export interface SpeakerNameEvidence {
+	source: SpeakerNameEvidenceSource;
+	confidence: number;
+	name?: string;
+	evidenceId?: string;
+	entityId?: string;
+	profileId?: string;
+	observedAt?: string;
+	deviceOwnerEntityId?: string;
+}
+
+export interface ExistingSpeakerEntity {
+	entityId: string;
+	displayName: string;
+	profileIds?: readonly string[];
+	speakerIds?: readonly string[];
+}
+
+export interface InferSpeakerNameInput {
+	speakerId: string;
+	evidence: readonly SpeakerNameEvidence[];
+	existingEntities?: readonly ExistingSpeakerEntity[];
+	imprintClusterId?: string;
+	sensitiveAttributeGuardrail?: boolean;
+	minConfirmedConfidence?: number;
+}
+
+export interface SpeakerNameProvenance {
+	source: SpeakerNameEvidenceSource;
+	confidence: number;
+	evidenceId?: string;
+	entityId?: string;
+	profileId?: string;
+	observedAt?: string;
+}
+
+export interface SpeakerNameCandidate {
+	name: string;
+	normalizedName: string;
+	confidence: number;
+	sources: SpeakerNameEvidenceSource[];
+	provenance: SpeakerNameProvenance[];
+}
+
+export interface SpeakerNameBindingPlan {
+	action: SpeakerNameBindingAction;
+	displayName?: string;
+	entityId?: string;
+	profileId?: string;
+	mergeEntityIds: string[];
+	reasonCodes: SpeakerNameReasonCode[];
+}
+
+export interface SpeakerNameVoiceTurnBindingPlan {
+	text: string;
+	imprintClusterId: string;
+	matchConfidence: number;
+	matchedEntityId: string | null;
+}
+
+export interface SpeakerNameInference {
+	speakerId: string;
+	resolution: SpeakerNameResolution;
+	displayName?: string;
+	entityId?: string;
+	profileId?: string;
+	confidence: number;
+	candidateNames: SpeakerNameCandidate[];
+	provenance: SpeakerNameProvenance[];
+	reasonCodes: SpeakerNameReasonCode[];
+	requiresReview: boolean;
+	bindingPlan: SpeakerNameBindingPlan;
+	voiceTurnBindingPlan?: SpeakerNameVoiceTurnBindingPlan;
+}
+
+interface MutableCandidate extends SpeakerNameCandidate {
+	score: number;
+}
+
+const DEFAULT_MIN_CONFIRMED_CONFIDENCE = 0.85;
+const SOURCE_PRIORITY: Record<SpeakerNameEvidenceSource, number> = {
+	user_correction: 1,
+	voice_profile: 0.96,
+	speaker_memory: 0.94,
+	self_introduction: 0.9,
+	platform_roster: 0.74,
+	calendar_attendee: 0.7,
+};
+
+const STRONG_SOURCES = new Set<SpeakerNameEvidenceSource>([
+	"user_correction",
+	"voice_profile",
+	"speaker_memory",
+	"self_introduction",
+]);
+
+function assertRatio(field: string, value: number): void {
+	if (!Number.isFinite(value) || value < 0 || value > 1) {
+		throw new Error(
+			`[speaker-name-inference] ${field} must be between 0 and 1`,
+		);
+	}
+}
+
+function normalizeName(name: string): string {
+	return name
+		.trim()
+		.replace(/\s+/g, " ")
+		.replace(/[.,;:!?]+$/g, "")
+		.toLocaleLowerCase();
+}
+
+function displayName(name: string): string {
+	return name
+		.trim()
+		.replace(/\s+/g, " ")
+		.replace(/[.,;:!?]+$/g, "");
+}
+
+function firstName(name: string): string {
+	return normalizeName(name).split(" ")[0] ?? "";
+}
+
+function uniqueReasonCodes(
+	reasonCodes: SpeakerNameReasonCode[],
+): SpeakerNameReasonCode[] {
+	return [...new Set(reasonCodes)].sort();
+}
+
+function groupCandidates(
+	evidence: readonly SpeakerNameEvidence[],
+): MutableCandidate[] {
+	const candidates = new Map<string, MutableCandidate>();
+	for (const item of evidence) {
+		assertRatio(`${item.source}.confidence`, item.confidence);
+		if (!item.name?.trim()) continue;
+		const name = displayName(item.name);
+		const normalizedName = normalizeName(name);
+		if (!normalizedName) continue;
+		const existing = candidates.get(normalizedName);
+		const candidate =
+			existing ??
+			({
+				name,
+				normalizedName,
+				confidence: 0,
+				sources: [],
+				provenance: [],
+				score: 0,
+			} satisfies MutableCandidate);
+		candidate.confidence = Math.max(candidate.confidence, item.confidence);
+		candidate.score = Math.max(
+			candidate.score,
+			item.confidence * SOURCE_PRIORITY[item.source],
+		);
+		if (!candidate.sources.includes(item.source)) {
+			candidate.sources.push(item.source);
+		}
+		candidate.provenance.push({
+			source: item.source,
+			confidence: item.confidence,
+			...(item.evidenceId ? { evidenceId: item.evidenceId } : {}),
+			...(item.entityId ? { entityId: item.entityId } : {}),
+			...(item.profileId ? { profileId: item.profileId } : {}),
+			...(item.observedAt ? { observedAt: item.observedAt } : {}),
+		});
+		candidates.set(normalizedName, candidate);
+	}
+	return [...candidates.values()]
+		.map((candidate) => ({
+			...candidate,
+			sources: [...candidate.sources].sort(),
+			provenance: [...candidate.provenance].sort(
+				(a, b) => SOURCE_PRIORITY[b.source] - SOURCE_PRIORITY[a.source],
+			),
+		}))
+		.sort((a, b) => b.score - a.score || b.confidence - a.confidence);
+}
+
+function hasSource(
+	candidate: SpeakerNameCandidate,
+	source: SpeakerNameEvidenceSource,
+): boolean {
+	return candidate.sources.includes(source);
+}
+
+function hasStrongSource(candidate: SpeakerNameCandidate): boolean {
+	return candidate.sources.some((source) => STRONG_SOURCES.has(source));
+}
+
+function findExistingEntities(
+	candidate: SpeakerNameCandidate,
+	existingEntities: readonly ExistingSpeakerEntity[],
+): ExistingSpeakerEntity[] {
+	return existingEntities.filter(
+		(entity) => normalizeName(entity.displayName) === candidate.normalizedName,
+	);
+}
+
+function detectBorrowedDeviceConflict(
+	evidence: readonly SpeakerNameEvidence[],
+	candidates: readonly SpeakerNameCandidate[],
+): boolean {
+	const platformNames = new Set(
+		evidence
+			.filter(
+				(item) =>
+					item.source === "platform_roster" &&
+					typeof item.deviceOwnerEntityId === "string" &&
+					item.name,
+			)
+			.map((item) => normalizeName(item.name ?? "")),
+	);
+	if (platformNames.size === 0) return false;
+	return candidates.some(
+		(candidate) =>
+			!platformNames.has(candidate.normalizedName) &&
+			candidate.confidence >= 0.7 &&
+			candidate.sources.some((source) =>
+				["self_introduction", "voice_profile", "user_correction"].includes(
+					source,
+				),
+			),
+	);
+}
+
+function detectSameFirstNameAmbiguity(
+	candidates: readonly SpeakerNameCandidate[],
+): boolean {
+	for (let i = 0; i < candidates.length; i += 1) {
+		const left = candidates[i];
+		if (!left || left.confidence < 0.6) continue;
+		for (let j = i + 1; j < candidates.length; j += 1) {
+			const right = candidates[j];
+			if (!right || right.confidence < 0.6) continue;
+			if (
+				left.normalizedName !== right.normalizedName &&
+				firstName(left.name) === firstName(right.name)
+			) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+function detectUnresolvedConflict(
+	candidates: readonly SpeakerNameCandidate[],
+): boolean {
+	const [first, second] = candidates;
+	if (!first || !second) return false;
+	if (hasSource(first, "user_correction")) return false;
+	return (
+		first.normalizedName !== second.normalizedName &&
+		first.confidence >= 0.7 &&
+		second.confidence >= 0.7 &&
+		Math.abs(first.confidence - second.confidence) < 0.18
+	);
+}
+
+function buildBindingPlan(
+	candidate: SpeakerNameCandidate | null,
+	input: InferSpeakerNameInput,
+	reasonCodes: SpeakerNameReasonCode[],
+): SpeakerNameBindingPlan {
+	if (!candidate) {
+		return { action: "none", mergeEntityIds: [], reasonCodes: [] };
+	}
+	const existing = findExistingEntities(
+		candidate,
+		input.existingEntities ?? [],
+	);
+	const profileId = candidate.provenance.find(
+		(item) => item.profileId,
+	)?.profileId;
+	const directEntityId = candidate.provenance.find(
+		(item) => item.entityId,
+	)?.entityId;
+	if (existing.length > 1) {
+		return {
+			action: "merge_duplicate_entities",
+			displayName: candidate.name,
+			entityId: existing[0]?.entityId,
+			...(profileId ? { profileId } : {}),
+			mergeEntityIds: existing.map((entity) => entity.entityId),
+			reasonCodes: uniqueReasonCodes([
+				...reasonCodes,
+				"duplicate_entity_merge_required",
+			]),
+		};
+	}
+	if (existing.length === 1 || directEntityId) {
+		return {
+			action: "bind_existing_entity",
+			displayName: candidate.name,
+			entityId: existing[0]?.entityId ?? directEntityId,
+			...(profileId ? { profileId } : {}),
+			mergeEntityIds: [],
+			reasonCodes,
+		};
+	}
+	return {
+		action: "create_entity",
+		displayName: candidate.name,
+		...(profileId ? { profileId } : {}),
+		mergeEntityIds: [],
+		reasonCodes,
+	};
+}
+
+export function inferSpeakerName(
+	input: InferSpeakerNameInput,
+): SpeakerNameInference {
+	assertRatio(
+		"minConfirmedConfidence",
+		input.minConfirmedConfidence ?? DEFAULT_MIN_CONFIRMED_CONFIDENCE,
+	);
+	const minConfirmedConfidence =
+		input.minConfirmedConfidence ?? DEFAULT_MIN_CONFIRMED_CONFIDENCE;
+	const candidates = groupCandidates(input.evidence);
+	const reasonCodes: SpeakerNameReasonCode[] = [];
+
+	if (candidates.length === 0) {
+		reasonCodes.push("no_name_evidence");
+		return {
+			speakerId: input.speakerId,
+			resolution: "unknown",
+			confidence: 0,
+			candidateNames: [],
+			provenance: [],
+			reasonCodes,
+			requiresReview: true,
+			bindingPlan: { action: "none", mergeEntityIds: [], reasonCodes: [] },
+		};
+	}
+
+	const borrowedDeviceConflict = detectBorrowedDeviceConflict(
+		input.evidence,
+		candidates,
+	);
+	if (borrowedDeviceConflict) reasonCodes.push("borrowed_device_guardrail");
+	const correction = candidates.find((candidate) =>
+		hasSource(candidate, "user_correction"),
+	);
+	const chosen =
+		correction ??
+		candidates.find(
+			(candidate) =>
+				borrowedDeviceConflict && !hasSource(candidate, "platform_roster"),
+		) ??
+		candidates[0] ??
+		null;
+
+	const sameFirstNameAmbiguity =
+		correction === undefined && detectSameFirstNameAmbiguity(candidates);
+	const unresolvedConflict =
+		correction === undefined &&
+		!borrowedDeviceConflict &&
+		detectUnresolvedConflict(candidates);
+	if (sameFirstNameAmbiguity) reasonCodes.push("same_first_name_ambiguity");
+	if (unresolvedConflict) reasonCodes.push("conflicting_name_evidence");
+	if (input.sensitiveAttributeGuardrail) {
+		reasonCodes.push("sensitive_attribute_guardrail");
+	}
+	if (chosen?.sources.length && chosen.sources.length > 1) {
+		reasonCodes.push("source_agreement");
+	}
+	if (chosen && hasSource(chosen, "voice_profile")) {
+		reasonCodes.push("voice_profile_match");
+	}
+	if (chosen && hasSource(chosen, "speaker_memory")) {
+		reasonCodes.push("recurring_memory_applied");
+	}
+	if (chosen && hasSource(chosen, "user_correction")) {
+		reasonCodes.push("user_correction_applied");
+	}
+
+	const canConfirm =
+		chosen !== null &&
+		chosen.confidence >= minConfirmedConfidence &&
+		(hasStrongSource(chosen) || chosen.sources.length > 1) &&
+		!sameFirstNameAmbiguity &&
+		!unresolvedConflict &&
+		input.sensitiveAttributeGuardrail !== true;
+	if (canConfirm) reasonCodes.push("high_confidence_name");
+	if (chosen && !canConfirm) reasonCodes.push("low_confidence_name");
+
+	const resolution: SpeakerNameResolution = input.sensitiveAttributeGuardrail
+		? "withheld"
+		: !chosen
+			? "unknown"
+			: canConfirm
+				? "confirmed"
+				: sameFirstNameAmbiguity || borrowedDeviceConflict
+					? "withheld"
+					: "needs_confirmation";
+	const confirmed = resolution === "confirmed";
+	const bindingPlan = confirmed
+		? buildBindingPlan(chosen, input, uniqueReasonCodes(reasonCodes))
+		: { action: "none" as const, mergeEntityIds: [], reasonCodes: [] };
+	const uniqueReasons = uniqueReasonCodes(reasonCodes);
+	const voiceTurnBindingPlan =
+		confirmed &&
+		chosen &&
+		input.imprintClusterId &&
+		(hasSource(chosen, "user_correction") ||
+			hasSource(chosen, "speaker_memory"))
+			? {
+					text: `This is ${chosen.name}.`,
+					imprintClusterId: input.imprintClusterId,
+					matchConfidence: chosen.confidence,
+					matchedEntityId: bindingPlan.entityId ?? null,
+				}
+			: undefined;
+
+	return {
+		speakerId: input.speakerId,
+		resolution,
+		...(confirmed && chosen ? { displayName: chosen.name } : {}),
+		...(confirmed && bindingPlan.entityId
+			? { entityId: bindingPlan.entityId }
+			: {}),
+		...(confirmed && bindingPlan.profileId
+			? { profileId: bindingPlan.profileId }
+			: {}),
+		confidence: chosen?.confidence ?? 0,
+		candidateNames: candidates.map(
+			({ score: _score, ...candidate }) => candidate,
+		),
+		provenance: chosen?.provenance ?? [],
+		reasonCodes: uniqueReasons,
+		requiresReview:
+			!confirmed || bindingPlan.action === "merge_duplicate_entities",
+		bindingPlan,
+		...(voiceTurnBindingPlan ? { voiceTurnBindingPlan } : {}),
+	};
+}


### PR DESCRIPTION
## Summary

- Adds deterministic speaker-name inference for platform roster, calendar attendee, self-introduction, user correction, voice profile, and recurring-memory evidence.
- Returns confidence/provenance for every candidate, prevents low-confidence inferred names from becoming confirmed identity, and emits a binding plan for the existing `VOICE_TURN_OBSERVED` voice/entity seam.
- Covers #12498 edge cases: conflicting platform/calendar names, recurring Speaker 2 -> Sarah after correction, same-first-name ambiguity, borrowed-device guardrails, sensitive guardrails, and duplicate-entity correction handling.
- Adds `speaker_name_provenance` to the meeting-transcription-proof manifest/report contract and makes the registry scorer reject publishable real reports that omit the eight required cases.

## Verification

- `bun run --cwd plugins/plugin-local-inference test src/runtime/speaker-name-inference.test.ts`
  - `Test Files  1 passed (1)`
  - `Tests       9 passed (9)`
- `bun run --cwd plugins/plugin-local-inference typecheck`
  - `tsgo --noEmit -p tsconfig.json`
- `bunx @biomejs/biome check plugins/plugin-local-inference/src/runtime/speaker-name-inference.ts plugins/plugin-local-inference/src/runtime/speaker-name-inference.test.ts plugins/plugin-local-inference/src/runtime/index.ts`
  - `Checked 3 files in 20ms. No fixes applied.`
- `python -m pytest packages/benchmarks/meeting-transcription-proof/tests -q`
  - passed
- `python -m pytest packages/benchmarks/tests/test_registry_scores.py -q`
  - `8 passed`
- `python -m elizaos_meeting_transcription_proof --lane mocked_plumbing --output /tmp/mtp-smoke-speaker-provenance`
  - report emitted and manually inspected: `speaker_name_provenance_count: 8`

## Full Plugin Test Status

- `bun run --cwd plugins/plugin-local-inference test` failed on unrelated current-baseline failures:
  - `src/routes/local-inference-route-contracts.fuzz.test.ts` expects an ASR response without the current `aec` metadata field.
  - `src/services/downloader.test.ts` reports invalid Eliza-1 manifest fixtures missing required MTP kernel metadata.
  - `__tests__/mmproj-routing.test.ts` expects a pre-cutover missing-drafter fallback, while current code throws `MissingMtpDrafterError`.
- The new `src/runtime/speaker-name-inference.test.ts` suite passed in the full run.

## Evidence

- Evidence note: `.github/issue-evidence/12498-speaker-name-provenance.md`
- UI correction walkthrough: N/A - no UI surface changed in this PR.
- Audio artifacts: N/A - no audio model, capture path, or acoustic classifier changed.
- Real LLM trajectories: N/A - no prompt, model provider, action selection, or evaluator behavior changed.
- Backend/frontend logs: N/A - no route or runtime side effect changed.
- Real product lane report: N/A here because it requires reviewed live meeting artifacts and evidence files; tracked in #13142.

Closes #12498
