### PR TITLE
fix(#12639): drive Discord role metadata off the connector registry

### DIFF
--- a/.github/issue-evidence/12639-roles-discord-decouple.md
+++ b/.github/issue-evidence/12639-roles-discord-decouple.md
@@ -1,0 +1,51 @@
+# Issue #12639 evidence - roles metadata connector registry
+
+## Scope
+
+- PR: #13144
+- Branch: `fix/12639-roles-discord-decouple`
+- Packages touched: `packages/core`, `packages/shared`, `plugins/plugin-discord-local`
+- Behavior surface: core role/world resolution and connector metadata declarations
+- Not in scope: Discord desktop send/receive automation, UI, model prompts, database schema, native/mobile capture
+
+## Behavior verified
+
+- Core role identity projection no longer branches on `source === "discord"` in `roles.ts`.
+- Discord flat metadata fields are declared as connector metadata (`fromId` / `entityName`) and projected generically into nested connector identity.
+- Discord world id derivation is declared as ordered connector metadata (`discordServerId`, then `discordChannelId`) and resolved generically.
+- Missing or blank declared user-id fields fail closed.
+- Explicit nested `metadata[source]` identity takes precedence over flat-field projection.
+- A new connector can opt into identity projection by registering connector metadata, with no core role-code edit.
+- Runtime-registered metadata can override the legacy Discord default and unregistering the owner restores the default.
+- `plugin-discord-local` declares the same mapping on its `connectorSources` contract.
+- Core source-mode barrel now exports `./connectors.ts`, so tests and shared source-mode consumers do not resolve stale checked-in sidecar JavaScript.
+
+## Verification
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `bun run --cwd packages/core test src/roles.test.ts src/access-context.test.ts src/entities.trusted-components.test.ts` | PASS | 3 files, 46 tests |
+| `bun run --cwd packages/shared test src/connectors.test.ts` | PASS | 1 file, 9 tests |
+| `bun run --cwd packages/core typecheck` | PASS | Core typecheck clean |
+| `bun run --cwd packages/shared typecheck` | PASS | Shared typecheck clean |
+| `bun run --cwd plugins/plugin-discord-local typecheck` | PASS | Discord-local connector declaration compiles |
+| `bunx @biomejs/biome check packages/core/src/connectors.ts packages/core/src/index.node.ts packages/core/src/roles.ts packages/core/src/roles.test.ts packages/shared/src/connectors.ts packages/shared/src/connectors.test.ts plugins/plugin-discord-local/src/index.ts` | PASS | Touched-file lint/format/import-order check |
+| `bun run --cwd packages/core build` | PASS | Core Node/browser/edge/testing build completed |
+| `bun run --cwd packages/shared build:dist` | PASS | Shared package build completed |
+| `bun run --cwd plugins/plugin-discord-local build` | PASS | Discord-local build completed |
+| `rg -n "source\\s*===\\s*['\\\"]discord['\\\"]|discordServerId|discordChannelId" packages/core/src/roles.ts; test $? -eq 1` | PASS | Old Discord role literals absent from executable `roles.ts` |
+| `bun run --cwd plugins/plugin-discord-local lint:check` | PASS | Package lint clean |
+| `bun run --cwd packages/core lint:check` | BLOCKED | Unrelated existing formatting diagnostics in PII swap tests and prompt batcher |
+| `bun run --cwd packages/shared lint:check` | BLOCKED | Unrelated existing formatting diagnostic in `src/voice/aec/echo-alignment.ts` |
+| `bun run audit:type-safety-ratchet` | PASS | No new weak typing; baseline can shrink |
+| `bun run audit:error-policy-ratchet` | PASS | No new fallback-slop in touched files |
+| `git diff --check` | PASS | No whitespace errors |
+| `bun run verify` | BLOCKED | Repo-level CLAUDE/AGENTS and both ratchets passed; Turbo then stopped at unrelated `@elizaos/tui#lint` diagnostics around control-character regex/node-protocol/non-null assertions. Verify write-mode side effects in native runtime scripts were restored. |
+
+## Notes
+
+- Initial focused tests exposed stale source-mode sidecar resolution: `roles.ts` and the core source barrel used extensionless imports/exports that resolved checked-in stale `.js` files during Vitest/shared source-mode tests. This update points the touched role path and source barrel at `connectors.ts`, matching the new connector registry contract.
+- Live Discord desktop round-trip evidence is N/A because this PR changes connector-owned metadata declarations and core role/world resolution, not Discord IPC, OAuth, message ingestion, or outbound UI automation.
+- Screenshots/video are N/A because no UI surface changed.
+- Live LLM trajectory is N/A because no model/action/provider turn behavior changed.
+- Database/migration evidence is N/A because no schema or persistence changes were made.

--- a/packages/core/src/connectors.ts
+++ b/packages/core/src/connectors.ts
@@ -282,13 +282,14 @@ export const LEGACY_DISCORD_CONNECTOR_SOURCE_OWNER =
  * generically. `fromId`/`entityName` were the flat Memory metadata keys Discord
  * stamps; `discordServerId`/`discordChannelId` were the world-id derivation keys.
  */
-export const LEGACY_DISCORD_CONNECTOR_SOURCE_METADATA: ConnectorSourceMetadata = {
-	identityMetadataMapping: {
-		userIdField: "fromId",
-		nameField: "entityName",
-	},
-	worldIdMetadataKeys: ["discordServerId", "discordChannelId"],
-};
+export const LEGACY_DISCORD_CONNECTOR_SOURCE_METADATA: ConnectorSourceMetadata =
+	{
+		identityMetadataMapping: {
+			userIdField: "fromId",
+			nameField: "entityName",
+		},
+		worldIdMetadataKeys: ["discordServerId", "discordChannelId"],
+	};
 
 registerConnectorSourceMetadata(
 	"discord",

--- a/packages/core/src/connectors.ts
+++ b/packages/core/src/connectors.ts
@@ -12,10 +12,39 @@
  */
 export type ConnectorSourceKind = "passive" | "active";
 
+/**
+ * Declares how a connector projects the flat identity fields it stamps on a
+ * Memory's top-level metadata into the nested `metadata[source]` identity object
+ * that role resolution consumes (`{ userId, id, name, username }`). Owning this
+ * mapping on the connector's registered source metadata is what lets core stop
+ * special-casing individual connectors (e.g. Discord's `fromId`/`entityName`)
+ * inside `roles.ts` — the projection lives with the connector, not in a trunk
+ * `source === "discord"` branch (#12090 item 22 / #12087).
+ */
+export interface ConnectorIdentityMetadataMapping {
+	/** Flat metadata key holding the stable platform user id (maps to `userId` + `id`). */
+	userIdField: string;
+	/** Optional flat metadata key holding a display/handle (maps to `name` + `username`). */
+	nameField?: string;
+}
+
 export interface ConnectorSourceMetadata {
 	aliases?: readonly string[];
 	sourceKind?: ConnectorSourceKind;
 	isPassive?: boolean;
+	/**
+	 * How this connector's flat Memory metadata fields project into the nested
+	 * `metadata[source]` identity object used by role resolution. When present,
+	 * core reads identity from the declared fields instead of a connector-specific
+	 * literal branch.
+	 */
+	identityMetadataMapping?: ConnectorIdentityMetadataMapping;
+	/**
+	 * Ordered list of flat Memory metadata keys this connector uses to derive a
+	 * world id (first present, non-empty string wins). Replaces connector-specific
+	 * literals like `discordServerId`/`discordChannelId` in core.
+	 */
+	worldIdMetadataKeys?: readonly string[];
 }
 
 export interface ConnectorSourceDefinition extends ConnectorSourceMetadata {
@@ -40,6 +69,10 @@ function mergeMetadata(
 		),
 		sourceKind: registered?.sourceKind ?? base?.sourceKind,
 		isPassive: registered?.isPassive ?? base?.isPassive,
+		identityMetadataMapping:
+			registered?.identityMetadataMapping ?? base?.identityMetadataMapping,
+		worldIdMetadataKeys:
+			registered?.worldIdMetadataKeys ?? base?.worldIdMetadataKeys,
 	};
 }
 
@@ -173,6 +206,49 @@ export function isPassiveConnectorSource(
 	return Boolean(metadata?.isPassive || metadata?.sourceKind === "passive");
 }
 
+/**
+ * The declared flat-field → nested-identity projection for a connector source,
+ * or `null` if the connector registered none. Lets core read a connector's
+ * identity mapping from the registry instead of a `source === "..."` literal.
+ */
+export function getConnectorIdentityMetadataMapping(
+	source: string | null | undefined,
+): ConnectorIdentityMetadataMapping | null {
+	const metadata = getConnectorSourceMetadata(source);
+	const mapping = metadata?.identityMetadataMapping;
+	if (!mapping || typeof mapping.userIdField !== "string") {
+		return null;
+	}
+	const userIdField = mapping.userIdField.trim();
+	if (!userIdField) {
+		return null;
+	}
+	const nameField =
+		typeof mapping.nameField === "string" && mapping.nameField.trim()
+			? mapping.nameField.trim()
+			: undefined;
+	return { userIdField, ...(nameField ? { nameField } : {}) };
+}
+
+/**
+ * The ordered flat metadata keys a connector uses to derive a world id, or an
+ * empty array if none were declared. Replaces connector-specific world-id
+ * literals in core.
+ */
+export function getConnectorWorldIdMetadataKeys(
+	source: string | null | undefined,
+): string[] {
+	const metadata = getConnectorSourceMetadata(source);
+	const keys = metadata?.worldIdMetadataKeys;
+	if (!Array.isArray(keys)) {
+		return [];
+	}
+	return keys
+		.filter((key): key is string => typeof key === "string")
+		.map((key) => key.trim())
+		.filter((key) => key.length > 0);
+}
+
 export function expandConnectorSourceFilter(
 	sources: Iterable<string> | null | undefined,
 ): Set<string> {
@@ -186,3 +262,36 @@ export function expandConnectorSourceFilter(
 
 	return expanded;
 }
+
+/**
+ * Owner key for the built-in, legacy Discord connector-source metadata registered
+ * below. The Discord plugin lives outside this monorepo, so the flat-field →
+ * identity / world-id projection it needs is registered here as an explicit,
+ * grep-able legacy default instead of remaining as `source === "discord"`
+ * literal branches inside core's `roles.ts` (#12090 item 22 / #12087). When the
+ * Discord plugin registers its own `connectorSources` mapping at runtime, that
+ * owner-scoped registration merges over this default (registered metadata wins in
+ * {@link mergeMetadata}); this default only backstops back-compat.
+ */
+export const LEGACY_DISCORD_CONNECTOR_SOURCE_OWNER =
+	"core:legacy-discord-metadata";
+
+/**
+ * The Discord identity/world-id field projection previously hardcoded in
+ * `roles.ts`. Declared here as connector-owned registry metadata so core reads it
+ * generically. `fromId`/`entityName` were the flat Memory metadata keys Discord
+ * stamps; `discordServerId`/`discordChannelId` were the world-id derivation keys.
+ */
+export const LEGACY_DISCORD_CONNECTOR_SOURCE_METADATA: ConnectorSourceMetadata = {
+	identityMetadataMapping: {
+		userIdField: "fromId",
+		nameField: "entityName",
+	},
+	worldIdMetadataKeys: ["discordServerId", "discordChannelId"],
+};
+
+registerConnectorSourceMetadata(
+	"discord",
+	LEGACY_DISCORD_CONNECTOR_SOURCE_METADATA,
+	LEGACY_DISCORD_CONNECTOR_SOURCE_OWNER,
+);

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -28,12 +28,12 @@ export * from "./cloud-auth-service";
 export * from "./cloud-routing";
 // Connection management (ensureConnection/ensureConnections) - standalone batch helpers
 export * from "./connection";
-export * from "./connectors";
 export * from "./connectors/account-manager";
 export * from "./connectors/attachments";
 export * from "./connectors/connector-config";
 export * from "./connectors/oauth-role";
 export * from "./connectors/privacy";
+export * from "./connectors.ts";
 // Export additional constants not re-exported by character-utils
 export {
 	CANONICAL_SECRET_KEYS,

--- a/packages/core/src/roles.test.ts
+++ b/packages/core/src/roles.test.ts
@@ -7,17 +7,29 @@
  * (never silently grant a higher role), and the connector-admin whitelist
  * matches an entity only on its stable platform id.
  */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import {
+	getConnectorIdentityMetadataMapping,
+	getConnectorWorldIdMetadataKeys,
+	LEGACY_DISCORD_CONNECTOR_SOURCE_METADATA,
+	registerConnectorSourceMetadata,
+	unregisterConnectorSourceMetadataOwner,
+} from "./connectors.ts";
+import { createUniqueUuid } from "./entities.ts";
 import {
 	CANONICAL_ROLE_RANK,
 	canModifyRole,
 	getEntityRole,
+	getLiveEntityMetadataFromMessage,
 	hasAtLeastRole,
 	hasRoleAccess,
 	isAdminRank,
 	isAgentSelf,
 	matchEntityToConnectorAdminWhitelist,
 	normalizeRole,
+	resolveWorldForMessage,
 	ROLE_RANK,
 	recordOwnerGrant,
 	recordRoleGrant,
@@ -336,5 +348,190 @@ describe("recordOwnerGrant (#9948 explicit auditable owner grant)", () => {
 				"owner-1"
 			],
 		).toBe("owner");
+	});
+});
+
+describe("connector metadata is registry-driven, not Discord-special-cased (#12090 item 22 / #12087)", () => {
+	// The two paths that used to carry a `source === "discord"` literal branch in
+	// core (identity projection + world-id derivation) now read a connector-owned
+	// mapping from the connector-source registry. Discord's legacy fields are
+	// registered as declared metadata in connectors.ts, so the coupling moved out
+	// of core's authorization code and the same generic path serves any connector.
+
+	it("keeps Discord's legacy flat->identity mapping declared in the registry", () => {
+		expect(getConnectorIdentityMetadataMapping("discord")).toEqual({
+			userIdField: "fromId",
+			nameField: "entityName",
+		});
+		expect(getConnectorWorldIdMetadataKeys("discord")).toEqual([
+			"discordServerId",
+			"discordChannelId",
+		]);
+		// The exported legacy default is the single source of those literals now.
+		expect(
+			LEGACY_DISCORD_CONNECTOR_SOURCE_METADATA.identityMetadataMapping,
+		).toEqual({ userIdField: "fromId", nameField: "entityName" });
+	});
+
+	it("projects flat Discord metadata into nested identity via the registry (behavior preserved)", () => {
+		const message = {
+			entityId: "e-1",
+			roomId: "room-1",
+			content: { text: "hi", source: "discord" },
+			metadata: { fromId: "user-123", entityName: "alice" },
+		} as unknown as Memory;
+
+		// Same nested identity object the old `source === "discord"` branch built.
+		expect(getLiveEntityMetadataFromMessage(message)).toEqual({
+			discord: {
+				userId: "user-123",
+				id: "user-123",
+				name: "alice",
+				username: "alice",
+			},
+		});
+	});
+
+	it("omits name/username when the declared name field is absent", () => {
+		const message = {
+			entityId: "e-1",
+			roomId: "room-1",
+			content: { text: "hi", source: "discord" },
+			metadata: { fromId: "user-123" },
+		} as unknown as Memory;
+		expect(getLiveEntityMetadataFromMessage(message)).toEqual({
+			discord: { userId: "user-123", id: "user-123" },
+		});
+	});
+
+	it("fails closed: no identity when the declared user-id field is missing/blank", () => {
+		const blank = {
+			entityId: "e-1",
+			roomId: "room-1",
+			content: { text: "hi", source: "discord" },
+			metadata: { fromId: "   ", entityName: "alice" },
+		} as unknown as Memory;
+		expect(getLiveEntityMetadataFromMessage(blank)).toBeUndefined();
+
+		const missing = {
+			entityId: "e-1",
+			roomId: "room-1",
+			content: { text: "hi", source: "discord" },
+			metadata: { entityName: "alice" },
+		} as unknown as Memory;
+		expect(getLiveEntityMetadataFromMessage(missing)).toBeUndefined();
+	});
+
+	it("still prefers an explicit nested metadata[source] object over the flat mapping", () => {
+		const message = {
+			entityId: "e-1",
+			roomId: "room-1",
+			content: { text: "hi", source: "discord" },
+			metadata: { discord: { userId: "nested-1" }, fromId: "flat-1" },
+		} as unknown as Memory;
+		expect(getLiveEntityMetadataFromMessage(message)).toEqual({
+			discord: { userId: "nested-1" },
+		});
+	});
+
+	it("yields no identity for a connector with no registered mapping", () => {
+		const message = {
+			entityId: "e-1",
+			roomId: "room-1",
+			content: { text: "hi", source: "telegram" },
+			metadata: { fromId: "user-123" },
+		} as unknown as Memory;
+		// Telegram declares no identityMetadataMapping default -> no fabricated identity.
+		expect(getLiveEntityMetadataFromMessage(message)).toBeUndefined();
+	});
+
+	it("works for a NEW connector purely by registering mapping metadata (no core edit)", () => {
+		const owner = "test:matrix-connector";
+		try {
+			registerConnectorSourceMetadata(
+				"matrix",
+				{
+					identityMetadataMapping: {
+						userIdField: "senderMxid",
+						nameField: "displayName",
+					},
+				},
+				owner,
+			);
+			const message = {
+				entityId: "e-1",
+				roomId: "room-1",
+				content: { text: "hi", source: "matrix" },
+				metadata: { senderMxid: "@bob:hs", displayName: "bob" },
+			} as unknown as Memory;
+			expect(getLiveEntityMetadataFromMessage(message)).toEqual({
+				matrix: {
+					userId: "@bob:hs",
+					id: "@bob:hs",
+					name: "bob",
+					username: "bob",
+				},
+			});
+		} finally {
+			unregisterConnectorSourceMetadataOwner(owner);
+		}
+	});
+
+	it("derives the world id from the declared world-id keys (first present wins)", async () => {
+		const runtime = {
+			agentId: "agent-1",
+			getRoom: async () => null,
+			getWorld: async (id: string) => ({ id, metadata: {} }),
+		} as unknown as IAgentRuntime;
+
+		const serverMsg = {
+			entityId: "e-1",
+			roomId: "room-1",
+			content: { text: "hi", source: "discord" },
+			metadata: { discordServerId: "srv-9", discordChannelId: "chan-9" },
+		} as unknown as Memory;
+		const resolvedServer = await resolveWorldForMessage(runtime, serverMsg);
+		// serverId is preferred (first key), matching the prior literal-branch order.
+		expect(resolvedServer?.world?.id).toBe(
+			createUniqueUuid(runtime, "srv-9"),
+		);
+
+		const channelMsg = {
+			entityId: "e-1",
+			roomId: "room-1",
+			content: { text: "hi", source: "discord" },
+			metadata: { discordChannelId: "chan-9" },
+		} as unknown as Memory;
+		const resolvedChannel = await resolveWorldForMessage(runtime, channelMsg);
+		expect(resolvedChannel?.world?.id).toBe(
+			createUniqueUuid(runtime, "chan-9"),
+		);
+	});
+
+	it("derives no world id when none of the declared keys are present", async () => {
+		const runtime = {
+			agentId: "agent-1",
+			getRoom: async () => null,
+			getWorld: async (id: string) => ({ id, metadata: {} }),
+		} as unknown as IAgentRuntime;
+		const msg = {
+			entityId: "e-1",
+			roomId: "room-1",
+			content: { text: "hi", source: "discord" },
+			metadata: { unrelated: "x" },
+		} as unknown as Memory;
+		expect(await resolveWorldForMessage(runtime, msg)).toBeNull();
+	});
+
+	it("grep guard: no `source === \"discord\"` literal branch survives in roles.ts", () => {
+		const rolesSource = readFileSync(
+			fileURLToPath(new URL("./roles.ts", import.meta.url)),
+			"utf8",
+		);
+		// The Discord authorization coupling now lives in the connector-source
+		// registry (connectors.ts), not as a literal branch in core's roles.ts.
+		expect(rolesSource).not.toMatch(/source\s*===\s*["']discord["']/);
+		expect(rolesSource).not.toContain("discordServerId");
+		expect(rolesSource).not.toContain("discordChannelId");
 	});
 });

--- a/packages/core/src/roles.test.ts
+++ b/packages/core/src/roles.test.ts
@@ -29,10 +29,10 @@ import {
 	isAgentSelf,
 	matchEntityToConnectorAdminWhitelist,
 	normalizeRole,
-	resolveWorldForMessage,
 	ROLE_RANK,
 	recordOwnerGrant,
 	recordRoleGrant,
+	resolveWorldForMessage,
 } from "./roles.ts";
 import {
 	roleRank as gateRoleRank,
@@ -492,9 +492,7 @@ describe("connector metadata is registry-driven, not Discord-special-cased (#120
 		} as unknown as Memory;
 		const resolvedServer = await resolveWorldForMessage(runtime, serverMsg);
 		// serverId is preferred (first key), matching the prior literal-branch order.
-		expect(resolvedServer?.world?.id).toBe(
-			createUniqueUuid(runtime, "srv-9"),
-		);
+		expect(resolvedServer?.world?.id).toBe(createUniqueUuid(runtime, "srv-9"));
 
 		const channelMsg = {
 			entityId: "e-1",
@@ -523,7 +521,7 @@ describe("connector metadata is registry-driven, not Discord-special-cased (#120
 		expect(await resolveWorldForMessage(runtime, msg)).toBeNull();
 	});
 
-	it("grep guard: no `source === \"discord\"` literal branch survives in roles.ts", () => {
+	it('grep guard: no `source === "discord"` literal branch survives in roles.ts', () => {
 		const rolesSource = readFileSync(
 			fileURLToPath(new URL("./roles.ts", import.meta.url)),
 			"utf8",

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -24,7 +24,7 @@ import {
 	getConnectorIdentityMetadataMapping,
 	getConnectorWorldIdMetadataKeys,
 	normalizeConnectorSource,
-} from "./connectors";
+} from "./connectors.ts";
 import { createUniqueUuid } from "./entities";
 import { logger } from "./logger";
 import type { IAgentRuntime, Memory, UUID, World } from "./types";
@@ -246,8 +246,7 @@ function getConnectorMetadataFromMemory(
 
 	const canonicalSource = normalizeConnectorSource(source) || source;
 	const displayName =
-		mapping.nameField &&
-		typeof memoryMetadata?.[mapping.nameField] === "string"
+		mapping.nameField && typeof memoryMetadata?.[mapping.nameField] === "string"
 			? (memoryMetadata[mapping.nameField] as string)
 			: undefined;
 

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -20,6 +20,11 @@
  * unresolvable sender is treated as USER, never a higher tier. Owner and role
  * grants are recorded explicitly with their source so they stay auditable.
  */
+import {
+	getConnectorIdentityMetadataMapping,
+	getConnectorWorldIdMetadataKeys,
+	normalizeConnectorSource,
+} from "./connectors";
 import { createUniqueUuid } from "./entities";
 import { logger } from "./logger";
 import type { IAgentRuntime, Memory, UUID, World } from "./types";
@@ -223,27 +228,36 @@ function getConnectorMetadataFromMemory(
 		return { [source]: sourceMetadata };
 	}
 
-	if (source === "discord") {
-		const fromId = memoryMetadata?.fromId;
-		if (typeof fromId !== "string" || fromId.trim().length === 0) {
-			return undefined;
-		}
-
-		const entityName =
-			typeof memoryMetadata?.entityName === "string"
-				? memoryMetadata.entityName
-				: undefined;
-
-		return {
-			discord: {
-				userId: fromId,
-				id: fromId,
-				...(entityName ? { name: entityName, username: entityName } : {}),
-			},
-		};
+	// No nested `metadata[source]` object present. Fall back to the connector's
+	// DECLARED flat-field -> identity projection from the connector-source
+	// registry (owner metadata), instead of a connector-specific literal branch
+	// baked into core (#12090 item 22 / #12087). The Discord legacy mapping
+	// (fromId/entityName) is registered as connector-owned metadata in
+	// connectors.ts, so this path is generic across connectors.
+	const mapping = getConnectorIdentityMetadataMapping(source);
+	if (!mapping) {
+		return undefined;
 	}
 
-	return undefined;
+	const userId = memoryMetadata?.[mapping.userIdField];
+	if (typeof userId !== "string" || userId.trim().length === 0) {
+		return undefined;
+	}
+
+	const canonicalSource = normalizeConnectorSource(source) || source;
+	const displayName =
+		mapping.nameField &&
+		typeof memoryMetadata?.[mapping.nameField] === "string"
+			? (memoryMetadata[mapping.nameField] as string)
+			: undefined;
+
+	return {
+		[canonicalSource]: {
+			userId,
+			id: userId,
+			...(displayName ? { name: displayName, username: displayName } : {}),
+		},
+	};
 }
 
 async function getEntityMetadata(
@@ -477,20 +491,22 @@ function resolveWorldIdFromMessageMetadata(
 	message: Memory,
 ): UUID | null {
 	const source = getMessageSource(message);
+	if (!source) {
+		return null;
+	}
 	const metadata = getMemoryMetadata(message);
-	if (source === "discord") {
-		const serverId =
-			typeof metadata?.discordServerId === "string"
-				? metadata.discordServerId
-				: typeof metadata?.discordChannelId === "string"
-					? metadata.discordChannelId
-					: null;
 
-		if (!serverId) {
-			return null;
+	// Derive the world id from the connector's DECLARED flat world-id keys
+	// (registry, owner metadata) instead of a connector-specific literal that
+	// hardcodes per-connector world-id fields in core (#12090 item 22 / #12087).
+	// The Discord legacy keys are registered as connector-owned metadata in
+	// connectors.ts; first present, non-empty string wins.
+	const worldIdKeys = getConnectorWorldIdMetadataKeys(source);
+	for (const key of worldIdKeys) {
+		const value = metadata?.[key];
+		if (typeof value === "string" && value.trim().length > 0) {
+			return createUniqueUuid(runtime, value) as UUID;
 		}
-
-		return createUniqueUuid(runtime, serverId) as UUID;
 	}
 
 	return null;

--- a/packages/shared/src/connectors.test.ts
+++ b/packages/shared/src/connectors.test.ts
@@ -8,8 +8,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   expandConnectorSourceFilter,
+  getConnectorIdentityMetadataMapping,
   getConnectorSourceAliases,
   getConnectorSourceMetadata,
+  getConnectorWorldIdMetadataKeys,
   isPassiveConnectorSource,
   normalizeConnectorSource,
   registerConnectorSourceAliases,
@@ -85,5 +87,114 @@ describe("connector source aliases", () => {
     expect(getConnectorSourceMetadata("custom-passive-account")).toMatchObject({
       sourceKind: "passive",
     });
+  });
+});
+
+// #12090 item 22 / #12087: the flat-field -> identity projection and world-id
+// derivation keys are declared connector-owned registry metadata now, so core's
+// roles.ts reads them generically instead of special-casing individual
+// connectors. These cover the registry contract those helpers depend on.
+describe("connector identity / world-id metadata mapping", () => {
+  it("round-trips a registered identity mapping and normalizes blank fields to null", () => {
+    const owner = "identity-mapping-test";
+    try {
+      registerConnectorSourceMetadata(
+        "map-chat",
+        {
+          identityMetadataMapping: {
+            userIdField: "  senderId  ",
+            nameField: "  handle  ",
+          },
+        },
+        owner,
+      );
+      expect(getConnectorIdentityMetadataMapping("map-chat")).toEqual({
+        userIdField: "senderId",
+        nameField: "handle",
+      });
+    } finally {
+      unregisterConnectorSourceMetadataOwner(owner);
+    }
+  });
+
+  it("drops an identity mapping whose user-id field is blank (fails closed)", () => {
+    const owner = "identity-mapping-blank-test";
+    try {
+      registerConnectorSourceMetadata(
+        "blank-chat",
+        { identityMetadataMapping: { userIdField: "   " } },
+        owner,
+      );
+      expect(getConnectorIdentityMetadataMapping("blank-chat")).toBeNull();
+    } finally {
+      unregisterConnectorSourceMetadataOwner(owner);
+    }
+  });
+
+  it("returns null / empty for a source with no mapping declared", () => {
+    expect(getConnectorIdentityMetadataMapping("never-registered")).toBeNull();
+    expect(getConnectorWorldIdMetadataKeys("never-registered")).toEqual([]);
+  });
+
+  it("filters non-string / blank world-id keys and trims survivors", () => {
+    const owner = "worldid-keys-test";
+    try {
+      registerConnectorSourceMetadata(
+        "world-chat",
+        {
+          worldIdMetadataKeys: [
+            " primaryId ",
+            "",
+            42 as unknown as string,
+            "secondaryId",
+          ],
+        },
+        owner,
+      );
+      expect(getConnectorWorldIdMetadataKeys("world-chat")).toEqual([
+        "primaryId",
+        "secondaryId",
+      ]);
+    } finally {
+      unregisterConnectorSourceMetadataOwner(owner);
+    }
+  });
+
+  it("ships the Discord legacy mapping as a built-in default (moved out of core roles.ts)", () => {
+    expect(getConnectorIdentityMetadataMapping("discord")).toEqual({
+      userIdField: "fromId",
+      nameField: "entityName",
+    });
+    expect(getConnectorWorldIdMetadataKeys("discord")).toEqual([
+      "discordServerId",
+      "discordChannelId",
+    ]);
+  });
+
+  it("lets a runtime-registered mapping override the built-in default (registered wins)", () => {
+    const owner = "discord-override-test";
+    try {
+      registerConnectorSourceMetadata(
+        "discord",
+        {
+          identityMetadataMapping: {
+            userIdField: "authorId",
+            nameField: "authorName",
+          },
+        },
+        owner,
+      );
+      expect(getConnectorIdentityMetadataMapping("discord")).toEqual({
+        userIdField: "authorId",
+        nameField: "authorName",
+      });
+    } finally {
+      unregisterConnectorSourceMetadataOwner(owner);
+      // Built-in default is restored once the override owner is removed.
+      expect(getConnectorIdentityMetadataMapping("discord")).toEqual({
+        userIdField: "fromId",
+        nameField: "entityName",
+      });
+    }
   });
 });

--- a/packages/shared/src/connectors.ts
+++ b/packages/shared/src/connectors.ts
@@ -1,11 +1,14 @@
 /** Re-exports the core connector-source registry helpers (normalize, alias, metadata lookup) so shared consumers avoid a direct `@elizaos/core` import. */
 export {
+  type ConnectorIdentityMetadataMapping,
   type ConnectorSourceDefinition,
   type ConnectorSourceKind,
   type ConnectorSourceMetadata,
   expandConnectorSourceFilter,
+  getConnectorIdentityMetadataMapping,
   getConnectorSourceAliases,
   getConnectorSourceMetadata,
+  getConnectorWorldIdMetadataKeys,
   isPassiveConnectorSource,
   normalizeConnectorSource,
   registerConnectorSourceAliases,

--- a/plugins/plugin-discord-local/src/index.ts
+++ b/plugins/plugin-discord-local/src/index.ts
@@ -1510,6 +1510,17 @@ const discordLocalPlugin: Plugin = {
       aliases: ["discord", "discord-local"],
       sourceKind: "passive",
       isPassive: true,
+      // Connector-owned projection of the flat Discord fields stamped on inbound
+      // Memory metadata into the nested `metadata.discord` identity object and
+      // the world-id derivation keys. Declaring this here (and matching core's
+      // back-compat default) is what lets core's roles.ts read Discord identity
+      // generically instead of a `source === "discord"` literal branch
+      // (#12090 item 22 / #12087).
+      identityMetadataMapping: {
+        userIdField: "fromId",
+        nameField: "entityName",
+      },
+      worldIdMetadataKeys: ["discordServerId", "discordChannelId"],
     },
   ],
   services: [DiscordLocalService],


### PR DESCRIPTION
Closes #12639 (arch-audit roles-permissions / brittle strings #12090 item 22).

## Problem
`packages/core/src/roles.ts` special-cased `source === "discord"` in two authorization paths, coupling core role resolution to one connector's field names:

- **`getConnectorMetadataFromMemory`** hardcoded Discord's flat `fromId`/`entityName` → nested `{ discord: { userId, id, name, username } }` identity projection.
- **`resolveWorldIdFromMessageMetadata`** hardcoded `discordServerId`/`discordChannelId` as the world-id derivation keys.

Adding a new connector meant editing core authorization code, and the literals could drift from what a connector actually stamps.

## Change
Both paths are now **registry-driven**. `ConnectorSourceMetadata` gains two declarative, connector-owned contracts:

- `identityMetadataMapping` — `{ userIdField, nameField? }` projection of flat Memory fields into the nested `metadata[source]` identity object.
- `worldIdMetadataKeys` — ordered flat keys for world-id derivation (first present, non-empty string wins).

Plus lookups `getConnectorIdentityMetadataMapping` / `getConnectorWorldIdMetadataKeys`. Core reads the declared mapping for the message's source instead of a literal branch, so **any connector works generically**, and identity is keyed by the canonical (alias-normalized) source — consistent with how the connector-admin whitelist already normalizes.

The Discord mapping now lives **with the connector**:
- declared on `plugin-discord-local`'s `connectorSources`, and
- registered in core as an explicit, grep-able **legacy default** (`LEGACY_DISCORD_CONNECTOR_SOURCE_*`, owner `core:legacy-discord-metadata`) that back-compat backstops third-party Discord connectors. A runtime-registered mapping merges over the default (registered wins).

## Behavior preserved / fail-closed
- Same nested identity object shape; same server-before-channel world-id order.
- Fails closed: no identity when the declared user-id field is blank/missing; no world id when no declared key is present.
- Still prefers an explicit nested `metadata[source]` object over the flat mapping.

## Tests
- **`packages/core/src/roles.test.ts` — 39/39 pass.** New coverage: registry-driven identity projection (behavior parity), name/username omission, fail-closed on blank/missing id, explicit-nested-metadata precedence, no-mapping connector yields nothing, a NEW connector works purely by registering mapping metadata (no core edit), world-id first-key-wins + none-present, and a **grep guard** asserting no `source === "discord"` / `discordServerId` / `discordChannelId` literal survives in `roles.ts`.
- **`packages/shared/src/connectors.test.ts` — 9/9 pass.** New coverage: mapping round-trip + field trim, fail-closed on blank user-id field, empty result for undeclared source, world-id key filtering (non-string/blank dropped), the Discord legacy default, and registered-overrides-default (default restored on unregister).

## Verification
- `tsgo --noEmit` clean for `packages/core` and `packages/shared`.
- Targeted vitest green: roles (39), shared connectors (9), access-context + entities.trusted-components (7) as regression on the consuming seams.
- Grep guard proves the old coupling is gone from executable paths in `roles.ts`; the Discord literals are marked and tested as a legacy fallback per the audit's Done-when criteria.

Files: `packages/core/src/connectors.ts`, `packages/core/src/roles.ts`, `packages/shared/src/connectors.ts`, `plugins/plugin-discord-local/src/index.ts` (+ two test files). No `vite.config.*`/`index.html`/`client-base.ts`/`bun.lock`/`dist` touched.

— [sol-orch]
