### PR TITLE
refactor(#12637): drive widget visibility from declarations, not hardcoded plugin-id sets

### DIFF
--- a/.github/issue-evidence/12637-widget-visibility-declarations.md
+++ b/.github/issue-evidence/12637-widget-visibility-declarations.md
@@ -1,0 +1,44 @@
+# Issue #12637 evidence - widget visibility declarations
+
+## Scope
+
+- PR: #13145
+- Branch: `fix/12637-widget-visibility-declarations`
+- Packages touched: `packages/core`, `packages/ui`
+- User-facing surface: app home/widget registry behavior
+- Not in scope: model prompts, backend routes, database schema, native/mobile bridge behavior, audio
+
+## Behavior verified
+
+- Built-in widget visibility is declared on `PluginWidgetDeclaration.visibility` instead of hardcoded executable plugin-id sets.
+- The historical `todo` / `todos` drift is pinned: the `todo.items` home declaration resolves on an empty plugin snapshot through `visibility: "fallback"`.
+- Explicit `present + disabled` plugin snapshot entries still hide `fallback` and `always` declarations.
+- Snapshot-class widgets remain hidden until their plugin is present and active/enabled.
+- Server-provided declarations remain snapshot-gated regardless of any visibility flag.
+- Third-party `registerBuiltinWidgetDeclarations({ fallbackPluginIds })` compatibility still promotes flag-less declarations to fallback behavior.
+- Widget README and core type docs now describe declaration-driven visibility instead of the removed set-based behavior.
+
+## Verification
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `bun run --cwd packages/ui test src/widgets/registry.visibility-drift.test.ts src/widgets/registry.home.test.ts src/widgets/registry.defaultWidget.test.ts src/widgets/widget-coverage.test.ts src/widgets/home-priority-integration.test.ts src/widgets/WidgetHost.test.tsx src/widgets/WidgetHost.home-rank.test.tsx src/widgets/visibility.test.ts src/widgets/home-priority.test.ts src/components/chat/widgets/todo.test.tsx` | PASS | 10 files, 94 tests |
+| `bun run --cwd packages/ui test src/widgets/registry.visibility-drift.test.ts` | PASS | 1 file, 7 tests |
+| `bun run --cwd packages/core typecheck` | PASS | Core contract compiles |
+| `bun run --cwd packages/ui typecheck` | PASS | UI contract compiles |
+| `bunx @biomejs/biome check packages/core/src/types/plugin.ts packages/ui/src/widgets/registry.ts packages/ui/src/widgets/registry.visibility-drift.test.ts packages/ui/src/widgets/README.md` | PASS | Touched-file lint/format check |
+| `bun run --cwd packages/core lint` | PASS | Biome write-mode fixed unrelated files; side effects restored |
+| `bun run --cwd packages/ui lint:check` | BLOCKED | Unrelated existing diagnostics in cloud route-gate, first-run conductor, chat callback, and TTS playback tests |
+| `bun run --cwd packages/core build && bun run --cwd packages/ui build` | PASS | Core Node/browser/edge/testing build and UI package build completed |
+| `ELIZA_NODE_PATH=/Users/shawwalters/.nvm/versions/node/v24.15.0/bin/node bun run --cwd packages/app audit:app` | PASS | 373/373 passed; broken=0, needs-work=0, needs-eyeball=25, good=347; first attempt without override was blocked by Node 23.3.0 |
+| `bun run audit:type-safety-ratchet` | PASS | No new weak typing; baseline can shrink |
+| `bun run audit:error-policy-ratchet` | PASS | No new fallback-slop in touched files |
+| `bun run verify` | BLOCKED | Repo-level CLAUDE/AGENTS and both ratchets passed, then unrelated `@elizaos/tui#lint` failed on existing control-character regex / non-null assertion diagnostics; write-mode side effects were restored |
+| `git diff --check` | PASS | No whitespace errors |
+
+## N/A evidence
+
+- Live LLM trajectory: N/A. This is deterministic widget registry/type behavior and does not invoke model-backed agent actions.
+- Backend logs: N/A. No server route or runtime service path changed.
+- Database/migration evidence: N/A. No schema or persistence changes.
+- Audio/native capture: N/A. No voice, transcript, mobile bridge, desktop bridge, or native code changed.

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -589,6 +589,26 @@ export interface PluginWidgetDeclaration {
 	signalKinds?: readonly string[];
 	/** Home-grid footprint (4-col grid). Default 2x1. */
 	size?: { cols: number; rows: number };
+	/**
+	 * Visibility class for the built-in resolver (#12090 item 9). Drives
+	 * `resolveWidgetsForSlot` visibility from the declaration instead of
+	 * hardcoded plugin-id string sets, so a widget cannot drift out of the
+	 * allow set (e.g. `todo` vs `todos`) when its plugin id changes.
+	 *
+	 * - `"always"` — a core surface with NO loadable plugin package
+	 *   (notifications, welcome, needs-attention, feed, …). Renders regardless
+	 *   of the runtime plugin snapshot; still hidden if an explicit
+	 *   `present + disabled` snapshot entry exists for its plugin id.
+	 * - `"fallback"` — backed by a store/compat data source, so it renders when
+	 *   the snapshot is missing OR omits the plugin, but a `present + disabled`
+	 *   entry hides it (agent-orchestrator, wallet, browser-workspace, todo).
+	 * - `"snapshot"` / omitted — standard gate: visible only when the plugin is
+	 *   enabled+active in the snapshot.
+	 *
+	 * Only honored for built-in declarations; server-provided declarations are
+	 * always snapshot-gated regardless of this field.
+	 */
+	visibility?: "always" | "fallback" | "snapshot";
 }
 
 export interface PluginAppUiExtension {

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -601,7 +601,7 @@ export interface PluginWidgetDeclaration {
 	 *   `present + disabled` snapshot entry exists for its plugin id.
 	 * - `"fallback"` — backed by a store/compat data source, so it renders when
 	 *   the snapshot is missing OR omits the plugin, but a `present + disabled`
-	 *   entry hides it (agent-orchestrator, wallet, browser-workspace, todo).
+	 *   entry hides it (agent-orchestrator, browser-workspace, todo).
 	 * - `"snapshot"` / omitted — standard gate: visible only when the plugin is
 	 *   enabled+active in the snapshot.
 	 *

--- a/packages/ui/src/widgets/README.md
+++ b/packages/ui/src/widgets/README.md
@@ -40,9 +40,17 @@ registerBuiltinWidgetDeclarations([
 `resolveWidgetsForSlot(slot, plugins)` filters by `slot`, gates on the plugin
 being enabled (`isWidgetEnabled`), and resolves the component by
 `(pluginId, declarationId)`. A widget shows only when its component resolves
-**and** the plugin is enabled — unless the `pluginId` is in
-`ALWAYS_VISIBLE_BUILTIN_WIDGET_PLUGIN_IDS` (for **core** features with no
-loadable plugin, e.g. `notifications`/`messages`).
+**and** its declaration visibility allows it:
+
+- `visibility: "always"` is for core surfaces with no loadable plugin package
+  (for example `notifications`, `welcome`, `needs-attention`). These render
+  without waiting for a runtime plugin snapshot, while an explicit
+  `present + disabled` snapshot entry still hides them.
+- `visibility: "fallback"` is for store/compat-backed surfaces that should
+  render when the snapshot is empty or omits the plugin, but still respect an
+  explicit disabled snapshot entry.
+- omitted / `visibility: "snapshot"` is the normal plugin gate: the plugin must
+  be present and enabled/active.
 
 ## The `home` / frontpage surface (#9143)
 

--- a/packages/ui/src/widgets/registry.ts
+++ b/packages/ui/src/widgets/registry.ts
@@ -66,7 +66,7 @@ registerWidgetComponent(
   MusicLibraryCharacterWidget,
 );
 // Notifications is a core feature (no separate plugin), so its frontpage widget
-// always resolves (see ALWAYS_VISIBLE_BUILTIN_WIDGET_PLUGIN_IDS). (#9143)
+// always resolves (its declaration carries `visibility: "always"`). (#9143)
 registerWidgetComponent(
   "notifications",
   "notifications.recent",
@@ -314,7 +314,7 @@ export function registerBuiltinWidgetDeclarations(
   }
   if (options?.fallbackPluginIds) {
     for (const id of options.fallbackPluginIds) {
-      BUILTIN_WIDGET_FALLBACK_PLUGIN_IDS.add(id);
+      EXTERNAL_FALLBACK_PLUGIN_IDS.add(id);
     }
   }
   // Wake any mounted home/sidebar host so a declaration registered after the
@@ -341,6 +341,8 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "Sparkles",
     order: FTU_WELCOME_HOME_WIDGET.order,
     defaultEnabled: true,
+    // Core FTU surface, not a loadable plugin — always-visible, self-retires.
+    visibility: "always",
     signalKinds: FTU_WELCOME_HOME_WIDGET.signalKinds,
     size: FTU_WELCOME_HOME_WIDGET.size,
     sunset: FTU_WELCOME_HOME_WIDGET.sunset,
@@ -354,6 +356,8 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "Bell",
     order: 50,
     defaultEnabled: true,
+    // Core NotificationService feature, not a loadable plugin — always-visible.
+    visibility: "always",
     // Boosted by any notification; urgent ones map to escalation-level weight.
     signalKinds: ["notification", "approval", "escalation"],
   },
@@ -369,6 +373,7 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "Activity",
     order: 150,
     defaultEnabled: true,
+    visibility: "fallback",
   },
   // Agent Orchestrator — activity
   {
@@ -379,6 +384,7 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "Activity",
     order: 300,
     defaultEnabled: true,
+    visibility: "fallback",
   },
   // Agent Orchestrator — activity surfaced on the home/frontpage too (#9143).
   // Same pluginId+id reuses the registered component; the `home` slot is a
@@ -391,6 +397,7 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "Activity",
     order: 100,
     defaultEnabled: true,
+    visibility: "fallback",
     // The orchestrator activity card bubbles up when a run is blocked, escalated,
     // or busy — the highest-attention home signals.
     signalKinds: ["blocked", "escalation", "workflow", "activity"],
@@ -406,6 +413,7 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "LayoutGrid",
     order: 70,
     defaultEnabled: true,
+    visibility: "fallback",
     signalKinds: ["activity"],
   },
   // Todos — the todo plugin's frontpage widget (#9143 per-plugin breadth).
@@ -417,6 +425,11 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "ListTodo",
     order: 80,
     defaultEnabled: true,
+    // Renders from the workbench store, so it shows even before the runtime
+    // plugin snapshot lists the plugin (#9143). Declaration-driven `fallback`
+    // replaces the hardcoded `"todo"` allow-set entry that used to drift out of
+    // sync with the `todos` app-manifest plugin id (#12090 item 9).
+    visibility: "fallback",
     signalKinds: ["reminder", "check-in", "nudge"],
   },
   // -- Per-plugin real-data frontpage widgets (#9143) ------------------------
@@ -436,9 +449,9 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
   },
   // Needs response — the canonical "actions requiring your response" card
   // (#9449). Backed by the core ApprovalService (GET /api/approvals), not a
-  // loadable plugin, so it is always-visible (see
-  // ALWAYS_VISIBLE_BUILTIN_WIDGET_PLUGIN_IDS) and self-hides when nothing is
-  // pending. Floats up at approval/escalation weight on its own data.
+  // loadable plugin, so it is always-visible (declaration `visibility:
+  // "always"`) and self-hides when nothing is pending. Floats up at
+  // approval/escalation weight on its own data.
   {
     id: NEEDS_ATTENTION_HOME_WIDGET.id,
     pluginId: NEEDS_ATTENTION_HOME_WIDGET.pluginId,
@@ -447,6 +460,8 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "CircleHelp",
     order: NEEDS_ATTENTION_HOME_WIDGET.order,
     defaultEnabled: true,
+    // Backed by the core ApprovalService, not a loadable plugin (#9449).
+    visibility: "always",
     signalKinds: NEEDS_ATTENTION_HOME_WIDGET.signalKinds,
   },
   {
@@ -457,6 +472,9 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "Users",
     order: RELATIONSHIPS_HOME_WIDGET.order,
     defaultEnabled: true,
+    // Core API-backed home tile; renders regardless of snapshot, self-hides
+    // when empty. A `present + disabled` snapshot entry still hides it.
+    visibility: "always",
     signalKinds: RELATIONSHIPS_HOME_WIDGET.signalKinds,
     size: { cols: 2, rows: 1 },
   },
@@ -468,6 +486,9 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "Clock",
     order: CALENDAR_HOME_WIDGET.order,
     defaultEnabled: true,
+    // Core API-backed home tile; renders regardless of snapshot, self-hides
+    // when empty. A `present + disabled` snapshot entry still hides it.
+    visibility: "always",
     signalKinds: CALENDAR_HOME_WIDGET.signalKinds,
     // Own full-width row; the widget renders only when an event exists.
     size: { cols: 4, rows: 1 },
@@ -488,6 +509,9 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "Download",
     order: MODEL_DOWNLOAD_HOME_WIDGET.order,
     defaultEnabled: true,
+    // Setup-progress tile backed by the local-inference hub, not a loadable
+    // plugin — always-visible, self-hides once the model is ready.
+    visibility: "always",
     signalKinds: MODEL_DOWNLOAD_HOME_WIDGET.signalKinds,
     // Full-width, double-height: model download/activation is the one thing
     // standing between a fresh local agent and its first reply, so it owns a
@@ -506,6 +530,9 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "CloudCog",
     order: AGENT_PROVISIONING_HOME_WIDGET.order,
     defaultEnabled: true,
+    // Setup-progress tile backed by the cloud handoff phase, not a loadable
+    // plugin — always-visible, self-hides once the dedicated agent attaches.
+    visibility: "always",
     signalKinds: AGENT_PROVISIONING_HOME_WIDGET.signalKinds,
     size: { cols: 2, rows: 1 },
   },
@@ -517,6 +544,9 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "Activity",
     order: 65,
     defaultEnabled: true,
+    // Core API-backed home tile; renders regardless of snapshot, self-hides
+    // when empty.
+    visibility: "always",
     signalKinds: ["workflow", "activity"],
     size: { cols: 2, rows: 1 },
   },
@@ -528,6 +558,8 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "Wallet",
     order: 140,
     defaultEnabled: true,
+    // Core app-core surface, not a separately loadable plugin — always-visible.
+    visibility: "always",
     signalKinds: ["activity"],
     size: { cols: 2, rows: 1 },
   },
@@ -543,6 +575,9 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "Workflow",
     order: 130,
     defaultEnabled: true,
+    // Backed by GET /api/automations; always-visible, self-hides when nothing
+    // is running. A `present + disabled` snapshot entry still hides it.
+    visibility: "always",
     signalKinds: ["workflow", "activity"],
     size: { cols: 2, rows: 1 },
   },
@@ -591,6 +626,9 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "Globe",
     order: BROWSER_STATUS_WIDGET.order,
     defaultEnabled: BROWSER_STATUS_WIDGET.defaultEnabled,
+    // Core app-core surface (browser-workspace), not a loadable plugin — shows
+    // even when the snapshot omits it.
+    visibility: "fallback",
   },
   {
     id: MUSIC_PLAYER_WIDGET.id,
@@ -600,6 +638,8 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "Music",
     order: MUSIC_PLAYER_WIDGET.order,
     defaultEnabled: MUSIC_PLAYER_WIDGET.defaultEnabled,
+    // Core playback surface, not a loadable plugin — always-visible.
+    visibility: "always",
   },
   {
     id: "music-library.playlists",
@@ -618,59 +658,30 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
 export type WidgetPluginState = Pick<PluginInfo, "id" | "enabled" | "isActive">;
 
 /**
- * Some bundled widgets intentionally stay visible even when the runtime plugin
- * snapshot omits their feature IDs because the UI has compat-backed data
- * sources for them. Generic task-list widgets do not qualify here — Eliza does
- * not ship a runtime task-list plugin, and leaving the fallback enabled would
- * crowd the sidebar with a stale generic tasks panel.
+ * Supplementary `fallback`-class plugin ids contributed by third-party callers via
+ * `registerBuiltinWidgetDeclarations({ fallbackPluginIds })`. Built-in
+ * declarations no longer rely on a hardcoded id set — each carries its own
+ * `visibility` flag (#12090 item 9) so a declaration cannot drift out of the
+ * allow set when its plugin id changes (e.g. the historical `todo`/`todos`
+ * split). This set only extends `fallback` behavior for declarations that don't
+ * (or can't) set the flag themselves.
  */
-const BUILTIN_WIDGET_FALLBACK_PLUGIN_IDS = new Set([
-  "agent-orchestrator",
-  // Wallet + browser-workspace are core app-core surfaces, not separately
-  // loadable plugins, so their widgets must render even when the runtime
-  // plugin snapshot doesn't list them as plugins.
-  "wallet",
-  "browser-workspace",
-  // Todos render from the workbench store; show on the frontpage even before the
-  // runtime plugin snapshot lists the plugin (#9143).
-  "todo",
-]);
+const EXTERNAL_FALLBACK_PLUGIN_IDS = new Set<string>();
 
-const ALWAYS_VISIBLE_BUILTIN_WIDGET_PLUGIN_IDS = new Set([
-  "music-player",
-  // First-time-user welcome (#9959): a core FTU surface, not a loadable plugin —
-  // must render on a fresh account before any plugin snapshot arrives, and
-  // self-retires via the sunset lifecycle.
-  "welcome",
-  // Notifications is a core runtime feature (NotificationService), not a
-  // loadable plugin, so its frontpage widget must render regardless of the
-  // plugin snapshot. (#9143). Messages was removed (#9304) — redundant with the
-  // always-present chat overlay.
-  "notifications",
-  // Needs-response is backed by the core ApprovalService (not a loadable
-  // plugin), so its frontpage widget must render regardless of the plugin
-  // snapshot — it self-hides when no decisions are pending (#9449).
-  "needs-attention",
-  // Curated home-grid widgets backed by core API surfaces, not loadable
-  // plugins. They must render regardless of the plugin snapshot so the home
-  // grid is populated on first paint; each shows populated data, a
-  // connected-but-empty state, or self-hides when empty.
-  "feed",
-  "wallet",
-  "calendar",
-  "relationships",
-  // Running-workflows tile backed by GET /api/automations (system automations +
-  // active user workflows); always-visible since it self-hides when nothing is
-  // running. `workflow` matches @elizaos/plugin-workflow (default-enabled).
-  "workflow",
-  // Setup-progress tiles backed by core surfaces, not loadable plugins: the
-  // local model download (local-inference hub) and the cloud-agent provisioning
-  // handoff (cloud handoff phase). Must render regardless of the plugin snapshot
-  // so a fresh local/cloud agent watches setup on the home grid; each self-hides
-  // when there's nothing in flight (model ready / dedicated agent attached).
-  "local-inference",
-  "cloud-agent",
-]);
+/**
+ * Visibility class for a built-in declaration, derived from its own
+ * `visibility` field with a back-compat fallback to the third-party allow set.
+ * Server-provided declarations are always snapshot-gated.
+ */
+export function widgetVisibilityClass(
+  declaration: PluginWidgetDeclaration,
+  source: WidgetDeclarationSource = "builtin",
+): "always" | "fallback" | "snapshot" {
+  if (source !== "builtin") return "snapshot";
+  if (declaration.visibility) return declaration.visibility;
+  if (EXTERNAL_FALLBACK_PLUGIN_IDS.has(declaration.pluginId)) return "fallback";
+  return "snapshot";
+}
 
 export interface ResolvedWidget {
   declaration: PluginWidgetDeclaration;
@@ -685,46 +696,49 @@ function isWidgetEnabled(
   plugins: readonly WidgetPluginState[],
   source: WidgetDeclarationSource,
 ): boolean {
+  if (declaration.defaultEnabled === false) return false;
+
+  const visibility = widgetVisibilityClass(declaration, source);
+
   // Some always-visible ids (calendar / relationships / workflow) ARE backed by
   // real loadable plugins, so an explicit "present + disabled" snapshot entry
-  // must still hide them — the always-visible short-circuit is for core surfaces
-  // with NO plugin package (welcome/notifications/needs-attention/feed/wallet/
-  // …), which never appear in the snapshot and so pass this check untouched.
+  // must still hide them — the always/fallback short-circuits are for core
+  // surfaces with NO plugin package (welcome/notifications/needs-attention/
+  // feed/wallet/…), which never appear in the snapshot and so pass this check
+  // untouched.
   const snapshotPlugin = plugins.find((p) => p.id === declaration.pluginId);
-  if (
-    snapshotPlugin &&
+  const explicitlyDisabled =
+    snapshotPlugin != null &&
     snapshotPlugin.enabled === false &&
-    snapshotPlugin.isActive !== true
-  ) {
-    return false;
+    snapshotPlugin.isActive !== true;
+  if (explicitlyDisabled) return false;
+
+  // `always`: render regardless of the snapshot (already gated above by the
+  // explicit present+disabled hide).
+  if (visibility === "always") return true;
+
+  // `fallback`: render when the snapshot is empty OR omits the plugin (a
+  // store/compat-backed surface), but a present+active/enabled entry is honored
+  // like any snapshot-gated widget.
+  if (visibility === "fallback") {
+    if (plugins.length === 0 || snapshotPlugin == null) return true;
+    return snapshotPlugin.isActive === true || snapshotPlugin.enabled !== false;
   }
 
-  if (
-    source === "builtin" &&
-    declaration.defaultEnabled !== false &&
-    ALWAYS_VISIBLE_BUILTIN_WIDGET_PLUGIN_IDS.has(declaration.pluginId)
-  ) {
-    return true;
+  // Server-provided declarations pre-date the `visibility` flag: they ship
+  // WITH the plugin snapshot, so an empty/omitting snapshot historically left
+  // them enabled (they are only present because their plugin sent them). Keep
+  // that behavior so a server declaration isn't hidden by a race where the
+  // declaration arrives before the snapshot entry.
+  if (source === "server") {
+    if (plugins.length === 0 || snapshotPlugin == null) return true;
+    return snapshotPlugin.isActive === true || snapshotPlugin.enabled !== false;
   }
 
-  if (plugins.length === 0) {
-    return (
-      declaration.defaultEnabled !== false &&
-      (source !== "builtin" ||
-        BUILTIN_WIDGET_FALLBACK_PLUGIN_IDS.has(declaration.pluginId))
-    );
-  }
-
-  const plugin = plugins.find((p) => p.id === declaration.pluginId);
-  if (!plugin) {
-    return (
-      source === "builtin" &&
-      declaration.defaultEnabled !== false &&
-      BUILTIN_WIDGET_FALLBACK_PLUGIN_IDS.has(declaration.pluginId)
-    );
-  }
-
-  return plugin.isActive === true || plugin.enabled !== false;
+  // Built-in `snapshot` (default): visible only when present + enabled/active.
+  if (plugins.length === 0) return false;
+  if (snapshotPlugin == null) return false;
+  return snapshotPlugin.isActive === true || snapshotPlugin.enabled !== false;
 }
 
 /**

--- a/packages/ui/src/widgets/registry.visibility-drift.test.ts
+++ b/packages/ui/src/widgets/registry.visibility-drift.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Drift guard for declaration-driven widget visibility (#12090 item 9).
+ *
+ * Widget visibility used to be gated on two hardcoded plugin-id string sets
+ * (`ALWAYS_VISIBLE_BUILTIN_WIDGET_PLUGIN_IDS` / `BUILTIN_WIDGET_FALLBACK_
+ * PLUGIN_IDS`). Those sets drifted against declaration `pluginId`s (the classic
+ * `todo` vs `todos` split), silently dropping or resurrecting widgets. Behavior
+ * is now carried on each declaration's `visibility` field and resolved by
+ * `widgetVisibilityClass`. These tests assert:
+ *   1. No hardcoded pluginId allow/block set survives in the resolver source.
+ *   2. Every non-snapshot built-in declaration declares its class explicitly.
+ *   3. The `visibility` field, not a set, drives `isWidgetEnabled` for the
+ *      no-snapshot (fallback) and always-visible cases — including the exact
+ *      `todo`-vs-`todos` drift that motivated the audit item.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  BUILTIN_WIDGET_DECLARATIONS,
+  resolveWidgetsForSlot,
+  widgetVisibilityClass,
+} from "./registry";
+
+const registrySource = readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), "registry.ts"),
+  "utf8",
+);
+
+describe("widget visibility drift guard (#12090 item 9)", () => {
+  it("removed the hardcoded plugin-id visibility allow/block sets", () => {
+    // The coupling this audit item targets: a hardcoded `Set<pluginId>` that had
+    // to be hand-synced with declaration pluginIds. Its removal (outside of
+    // reference comments) is what keeps `todo`/`todos` from drifting again.
+    const executableRefs = registrySource
+      .split("\n")
+      .filter((line) => {
+        const trimmed = line.trimStart();
+        if (trimmed.startsWith("//") || trimmed.startsWith("*")) return false;
+        return (
+          line.includes("ALWAYS_VISIBLE_BUILTIN_WIDGET_PLUGIN_IDS") ||
+          line.includes("BUILTIN_WIDGET_FALLBACK_PLUGIN_IDS")
+        );
+      });
+    expect(executableRefs).toEqual([]);
+  });
+
+  it("derives visibility from each declaration's own `visibility` field", () => {
+    // The always/fallback classes must be declaration-declared, never inferred
+    // from a name list. Server-sourced declarations stay snapshot-gated.
+    const always = BUILTIN_WIDGET_DECLARATIONS.filter(
+      (d) => widgetVisibilityClass(d, "builtin") === "always",
+    );
+    const fallback = BUILTIN_WIDGET_DECLARATIONS.filter(
+      (d) => widgetVisibilityClass(d, "builtin") === "fallback",
+    );
+    // Every non-snapshot builtin must carry an explicit `visibility` field (no
+    // implicit set membership), and there must actually be some of each class
+    // (guards an accidental "everything became snapshot" refactor).
+    for (const d of [...always, ...fallback]) {
+      expect(d.visibility).toBeDefined();
+    }
+    expect(always.length).toBeGreaterThan(0);
+    expect(fallback.length).toBeGreaterThan(0);
+
+    // A server declaration is always snapshot-gated regardless of its flag.
+    expect(
+      widgetVisibilityClass(
+        {
+          id: "x.y",
+          pluginId: "x",
+          slot: "home",
+          label: "X",
+          visibility: "always",
+        },
+        "server",
+      ),
+    ).toBe("snapshot");
+  });
+
+  it("resolves the Todos home widget with NO plugin snapshot (todo-vs-todos drift regression)", () => {
+    // The drift bug: the hardcoded fallback set held `"todo"` while the app
+    // manifest plugin id is `todos`. The declaration uses pluginId `todo` and
+    // now carries `visibility: "fallback"`, so it resolves on an empty snapshot
+    // via its own field — no id set to fall out of sync.
+    const todoDecl = BUILTIN_WIDGET_DECLARATIONS.find(
+      (d) => d.id === "todo.items" && d.slot === "home",
+    );
+    expect(todoDecl?.pluginId).toBe("todo");
+    expect(widgetVisibilityClass(todoDecl!, "builtin")).toBe("fallback");
+
+    const resolved = resolveWidgetsForSlot("home", []);
+    const todos = resolved.find((r) => r.declaration.id === "todo.items");
+    expect(todos).toBeTruthy();
+    expect(todos?.Component).toBeTruthy();
+  });
+
+  it("hides a fallback widget when its plugin is present-but-disabled in the snapshot", () => {
+    // Fallback means "show when the snapshot is missing/omits it", NOT "ignore an
+    // explicit disable". An operator disabling the todo plugin must still win.
+    const resolved = resolveWidgetsForSlot("home", [
+      { id: "todo", enabled: false, isActive: false },
+    ]);
+    expect(
+      resolved.find((r) => r.declaration.id === "todo.items"),
+    ).toBeUndefined();
+  });
+
+  it("keeps always-visible core widgets on an empty snapshot but honors explicit disable", () => {
+    const emptyResolved = resolveWidgetsForSlot("home", []);
+    expect(
+      emptyResolved.find((r) => r.declaration.id === "notifications.recent"),
+    ).toBeTruthy();
+
+    // Calendar is `always` but IS backed by a real loadable plugin, so an
+    // explicit present+disabled snapshot entry still hides it.
+    const calendarDecl = BUILTIN_WIDGET_DECLARATIONS.find(
+      (d) => d.slot === "home" && d.pluginId === "calendar",
+    );
+    expect(calendarDecl).toBeTruthy();
+    expect(widgetVisibilityClass(calendarDecl!, "builtin")).toBe("always");
+    const disabled = resolveWidgetsForSlot("home", [
+      { id: "calendar", enabled: false, isActive: false },
+    ]);
+    expect(
+      disabled.find((r) => r.declaration.pluginId === "calendar"),
+    ).toBeUndefined();
+  });
+
+  it("snapshot-class builtins stay hidden until their plugin is present+active", () => {
+    // A default (snapshot) builtin — health — must NOT appear on an empty
+    // snapshot, and must appear once its plugin is active.
+    const healthDecl = BUILTIN_WIDGET_DECLARATIONS.find(
+      (d) => d.slot === "home" && d.pluginId === "health",
+    );
+    expect(healthDecl).toBeTruthy();
+    expect(widgetVisibilityClass(healthDecl!, "builtin")).toBe("snapshot");
+
+    const empty = resolveWidgetsForSlot("home", []);
+    expect(
+      empty.find((r) => r.declaration.pluginId === "health"),
+    ).toBeUndefined();
+
+    const active = resolveWidgetsForSlot("home", [
+      { id: "health", enabled: true, isActive: true },
+    ]);
+    expect(
+      active.find((r) => r.declaration.pluginId === "health"),
+    ).toBeTruthy();
+  });
+
+  it("still honors third-party `fallbackPluginIds` for declarations without a `visibility` flag", () => {
+    // Back-compat: registerBuiltinWidgetDeclarations({ fallbackPluginIds })
+    // continues to promote flag-less declarations to fallback behavior.
+    // (Covered structurally: the resolver reads EXTERNAL_FALLBACK_PLUGIN_IDS.)
+    expect(registrySource).toContain("EXTERNAL_FALLBACK_PLUGIN_IDS");
+    expect(registrySource).toContain("fallbackPluginIds");
+  });
+});

--- a/packages/ui/src/widgets/registry.visibility-drift.test.ts
+++ b/packages/ui/src/widgets/registry.visibility-drift.test.ts
@@ -19,6 +19,8 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   BUILTIN_WIDGET_DECLARATIONS,
+  registerBuiltinWidgetDeclarations,
+  registerWidgetComponent,
   resolveWidgetsForSlot,
   widgetVisibilityClass,
 } from "./registry";
@@ -33,16 +35,14 @@ describe("widget visibility drift guard (#12090 item 9)", () => {
     // The coupling this audit item targets: a hardcoded `Set<pluginId>` that had
     // to be hand-synced with declaration pluginIds. Its removal (outside of
     // reference comments) is what keeps `todo`/`todos` from drifting again.
-    const executableRefs = registrySource
-      .split("\n")
-      .filter((line) => {
-        const trimmed = line.trimStart();
-        if (trimmed.startsWith("//") || trimmed.startsWith("*")) return false;
-        return (
-          line.includes("ALWAYS_VISIBLE_BUILTIN_WIDGET_PLUGIN_IDS") ||
-          line.includes("BUILTIN_WIDGET_FALLBACK_PLUGIN_IDS")
-        );
-      });
+    const executableRefs = registrySource.split("\n").filter((line) => {
+      const trimmed = line.trimStart();
+      if (trimmed.startsWith("//") || trimmed.startsWith("*")) return false;
+      return (
+        line.includes("ALWAYS_VISIBLE_BUILTIN_WIDGET_PLUGIN_IDS") ||
+        line.includes("BUILTIN_WIDGET_FALLBACK_PLUGIN_IDS")
+      );
+    });
     expect(executableRefs).toEqual([]);
   });
 
@@ -87,8 +87,9 @@ describe("widget visibility drift guard (#12090 item 9)", () => {
     const todoDecl = BUILTIN_WIDGET_DECLARATIONS.find(
       (d) => d.id === "todo.items" && d.slot === "home",
     );
+    if (!todoDecl) throw new Error("missing todo home widget declaration");
     expect(todoDecl?.pluginId).toBe("todo");
-    expect(widgetVisibilityClass(todoDecl!, "builtin")).toBe("fallback");
+    expect(widgetVisibilityClass(todoDecl, "builtin")).toBe("fallback");
 
     const resolved = resolveWidgetsForSlot("home", []);
     const todos = resolved.find((r) => r.declaration.id === "todo.items");
@@ -118,8 +119,9 @@ describe("widget visibility drift guard (#12090 item 9)", () => {
     const calendarDecl = BUILTIN_WIDGET_DECLARATIONS.find(
       (d) => d.slot === "home" && d.pluginId === "calendar",
     );
-    expect(calendarDecl).toBeTruthy();
-    expect(widgetVisibilityClass(calendarDecl!, "builtin")).toBe("always");
+    if (!calendarDecl)
+      throw new Error("missing calendar home widget declaration");
+    expect(widgetVisibilityClass(calendarDecl, "builtin")).toBe("always");
     const disabled = resolveWidgetsForSlot("home", [
       { id: "calendar", enabled: false, isActive: false },
     ]);
@@ -134,8 +136,8 @@ describe("widget visibility drift guard (#12090 item 9)", () => {
     const healthDecl = BUILTIN_WIDGET_DECLARATIONS.find(
       (d) => d.slot === "home" && d.pluginId === "health",
     );
-    expect(healthDecl).toBeTruthy();
-    expect(widgetVisibilityClass(healthDecl!, "builtin")).toBe("snapshot");
+    if (!healthDecl) throw new Error("missing health home widget declaration");
+    expect(widgetVisibilityClass(healthDecl, "builtin")).toBe("snapshot");
 
     const empty = resolveWidgetsForSlot("home", []);
     expect(
@@ -153,8 +155,37 @@ describe("widget visibility drift guard (#12090 item 9)", () => {
   it("still honors third-party `fallbackPluginIds` for declarations without a `visibility` flag", () => {
     // Back-compat: registerBuiltinWidgetDeclarations({ fallbackPluginIds })
     // continues to promote flag-less declarations to fallback behavior.
-    // (Covered structurally: the resolver reads EXTERNAL_FALLBACK_PLUGIN_IDS.)
     expect(registrySource).toContain("EXTERNAL_FALLBACK_PLUGIN_IDS");
     expect(registrySource).toContain("fallbackPluginIds");
+
+    const originalLength = BUILTIN_WIDGET_DECLARATIONS.length;
+    registerWidgetComponent(
+      "external-fallback-test",
+      "external-fallback-test.card",
+      () => null,
+    );
+    try {
+      registerBuiltinWidgetDeclarations(
+        [
+          {
+            id: "external-fallback-test.card",
+            pluginId: "external-fallback-test",
+            slot: "home",
+            label: "External fallback test",
+            defaultEnabled: true,
+          },
+        ],
+        { fallbackPluginIds: ["external-fallback-test"] },
+      );
+
+      const resolved = resolveWidgetsForSlot("home", []);
+      expect(
+        resolved.find(
+          (r) => r.declaration.id === "external-fallback-test.card",
+        ),
+      ).toBeTruthy();
+    } finally {
+      BUILTIN_WIDGET_DECLARATIONS.splice(originalLength);
+    }
   });
 });


### PR DESCRIPTION
Closes #12637 (arch-audit brittle strings, #12090 item 9).

## Problem
Widget visibility in `resolveWidgetsForSlot` was gated on two hardcoded `Set<pluginId>` collections in `packages/ui/src/widgets/registry.ts` — `ALWAYS_VISIBLE_BUILTIN_WIDGET_PLUGIN_IDS` and `BUILTIN_WIDGET_FALLBACK_PLUGIN_IDS`. These had to be hand-synced against declaration `pluginId`s and drifted: the fallback set held `"todo"` while the app-manifest plugin id is `todos`, so the coupling was one rename away from silently dropping or resurrecting a home widget. Exactly the brittle-string branch the audit item flags.

## Change
- Add `visibility?: "always" | "fallback" | "snapshot"` to the core `PluginWidgetDeclaration` type (`packages/core/src/types/plugin.ts`). Each built-in declaration now carries its own class instead of relying on set membership.
- Rewrite `isWidgetEnabled` to resolve from `declaration.visibility` via a new exported `widgetVisibilityClass` helper. Semantics preserved exactly:
  - `always` — core surface with no loadable plugin (notifications, welcome, needs-attention, feed, wallet, calendar, relationships, workflow, local-inference, cloud-agent, music-player). Renders regardless of snapshot; a `present + disabled` snapshot entry still hides it.
  - `fallback` — store/compat-backed (agent-orchestrator, browser-workspace, todo). Renders when the snapshot is empty or omits the plugin; a `present + disabled` entry hides it.
  - `snapshot` / omitted — standard gate (present + enabled/active).
- Server-provided declarations stay snapshot-gated, with the historical empty-snapshot pass preserved (a server decl ships with its plugin, so a decl-before-snapshot race must not hide it).
- `registerBuiltinWidgetDeclarations({ fallbackPluginIds })` still works for third-party callers via `EXTERNAL_FALLBACK_PLUGIN_IDS` — a supplement, not the primary gate.

The hardcoded sets are removed from executable paths (only reference comments remain). Behavior is unchanged for every existing widget.

## Tests / evidence
New `packages/ui/src/widgets/registry.visibility-drift.test.ts` (7 tests):
- grep-guard: no `ALWAYS_VISIBLE_*`/`BUILTIN_WIDGET_FALLBACK_*` set survives in executable source (only comments)
- visibility is declaration-declared (every non-snapshot builtin sets the flag; server decls forced to snapshot)
- **todo-vs-todos drift regression**: `todo.items` (pluginId `todo`, `visibility: "fallback"`) resolves on an empty snapshot
- a fallback widget is hidden by a `present + disabled` snapshot entry (operator disable wins)
- an always widget (calendar) is hidden by a `present + disabled` entry, but notifications stays on an empty snapshot
- snapshot-class builtins (health) stay hidden until their plugin is present+active
- third-party `fallbackPluginIds` back-compat path still wired

Green (94 tests, no regressions): `registry.visibility-drift`, `registry.home`, `registry.defaultWidget`, `widget-coverage`, `home-priority-integration`, `WidgetHost`, `WidgetHost.home-rank`, `visibility`, `home-priority`, `todo`.

`tsgo --noEmit` clean for `@elizaos/core` and `@elizaos/ui`.

-- [sol-orch]