### PR TITLE
fix(#12493): add multi-speaker single-stream gate

### DIFF
--- a/.github/issue-evidence/12493-multi-speaker-single-stream.md
+++ b/.github/issue-evidence/12493-multi-speaker-single-stream.md
@@ -36,7 +36,7 @@ Result:
 
 ```text
 tests/test_single_stream_gate.py ......                                  [100%]
-6 passed, 1 warning in 0.03s
+6 passed, 1 warning in 0.18s
 ```
 
 The warning is the existing package config warning because `pytest-timeout` is
@@ -53,7 +53,7 @@ Result: passed.
 Generated artifact:
 
 ```text
-packages/benchmarks/voice-speaker-validation/artifacts/run-1783165016/single-stream-gate.json
+packages/benchmarks/voice-speaker-validation/artifacts/codex-12493-review/single-stream-gate.json
 ```
 
 The artifact is gitignored by the repo-wide `artifacts/` ignore rule and was
@@ -90,7 +90,9 @@ Manual inspection summary:
     "wder"
   ],
   "roomEvidence": ["room_feed_suspected", "multi_speaker_room"],
-  "platformIds": ["platform-room-tile-1"]
+  "platformIds": ["platform-room-tile-1"],
+  "detectedCounts": [2, 3, 5, 8],
+  "artifactBytes": 89898
 }
 ```
 
@@ -111,6 +113,26 @@ This is the existing package setup constraint documented in
 `packages/benchmarks/voice-speaker-validation/AGENTS.md`: live diarization tests
 need SpeechBrain/ECAPA dependencies and WAV fixtures. The new #12493 artifact
 gate intentionally runs without those live assets.
+
+## Repo-Level Checks
+
+```bash
+bun run audit:type-safety-ratchet
+bun run audit:error-policy-ratchet
+git diff --check
+```
+
+Result: passed. The error-policy ratchet reported `0 changed production source
+file(s)` for this Python benchmark slice.
+
+```bash
+bun run verify
+```
+
+Result: blocked after the CLAUDE/AGENTS check and both ratchets passed. Turbo
+stopped on unrelated current-baseline `@elizaos/electrobun#lint` diagnostics.
+The same run replayed unrelated `@elizaos/tui#lint` diagnostics around Node
+protocol imports, non-null assertions, and control-character regexes.
 
 ## Evidence Rows
 

--- a/.github/issue-evidence/12493-multi-speaker-single-stream.md
+++ b/.github/issue-evidence/12493-multi-speaker-single-stream.md
@@ -1,0 +1,128 @@
+# #12493 Multi-Speaker Single-Stream Gate Evidence
+
+Branch: `fix/12493-multi-speaker-single-stream`
+Code PR: #13149
+Human evidence follow-up: #13150
+
+## What Was Proven
+
+- Added an artifact-level gate for one platform participant/tile containing
+  multiple acoustic speakers.
+- The deterministic scenario matrix covers:
+  - Speaker counts: `2`, `3`, `5`, `8`.
+  - Acoustic variants: `clean`, `music`, `babble`, `overlap`, `far_field`,
+    `reverberant`.
+  - One source platform participant id: `platform-room-tile-1`.
+  - Multiple diarized speaker ids derived from that one platform participant.
+  - Room evidence flags: `room_feed_suspected`, `multi_speaker_room`.
+- The report includes the requested gate metrics:
+  `speaker_count_accuracy`, `der`, `jer`, `wder`, `overlap_der`, `cpwer`,
+  `tcpwer`, `speaker_attribution_errors`, disappeared/over-split/under-split
+  counts, and speaker-turn boundary timing error.
+- Added deterministic failure tests for:
+  - overlapping speech collapsed into one speaker;
+  - a secondary speaker disappearing from the transcript;
+  - source platform participant id not being preserved.
+- Made the benchmark `conftest.py` lazy-load the heavy audio dependencies so
+  artifact-only tests can run without ECAPA/SpeechBrain or WAV fixtures.
+
+## Focused Verification
+
+```bash
+python -m pytest tests/test_single_stream_gate.py -q
+```
+
+Result:
+
+```text
+tests/test_single_stream_gate.py ......                                  [100%]
+6 passed, 1 warning in 0.03s
+```
+
+The warning is the existing package config warning because `pytest-timeout` is
+not installed in this Python environment.
+
+```bash
+python -m compileall -q single_stream_gate.py tests/test_single_stream_gate.py tests/conftest.py
+```
+
+Result: passed.
+
+## Generated Artifact Inspection
+
+Generated artifact:
+
+```text
+packages/benchmarks/voice-speaker-validation/artifacts/run-1783165016/single-stream-gate.json
+```
+
+The artifact is gitignored by the repo-wide `artifacts/` ignore rule and was
+not committed.
+
+Manual inspection summary:
+
+```json
+{
+  "issue": 12493,
+  "scenario_count": 24,
+  "speakerCounts": [2, 3, 5, 8],
+  "variants": [
+    "babble",
+    "clean",
+    "far_field",
+    "music",
+    "overlap",
+    "reverberant"
+  ],
+  "allPass": true,
+  "metrics": [
+    "cpwer",
+    "der",
+    "disappeared_speaker_count",
+    "jer",
+    "over_split_count",
+    "overlap_der",
+    "speaker_attribution_errors",
+    "speaker_count_accuracy",
+    "speaker_turn_boundary_timing_error_ms",
+    "tcpwer",
+    "under_split_count",
+    "wder"
+  ],
+  "roomEvidence": ["room_feed_suspected", "multi_speaker_room"],
+  "platformIds": ["platform-room-tile-1"]
+}
+```
+
+## Full Package Test Status
+
+```bash
+python -m pytest tests -q
+```
+
+Result: failed due to missing current live-audio benchmark dependencies:
+
+- 31 setup errors from `ModuleNotFoundError: No module named 'speechbrain'`.
+- `tests/test_single_stream_gate.py` still passed inside the full run.
+- Production-stack tests were skipped by their existing skip guards.
+- Summary: `8 passed, 7 skipped, 1 warning, 31 errors`.
+
+This is the existing package setup constraint documented in
+`packages/benchmarks/voice-speaker-validation/AGENTS.md`: live diarization tests
+need SpeechBrain/ECAPA dependencies and WAV fixtures. The new #12493 artifact
+gate intentionally runs without those live assets.
+
+## Evidence Rows
+
+- Scenario manifests: generated in `single-stream-gate.json`, manually inspected.
+- Source/generated audio: N/A - artifact-level gate; live audio evidence is
+  tracked in human follow-up #13150.
+- Transcript JSON / diarization JSON: deterministic hypothesis/reference
+  artifacts generated in `single-stream-gate.json`.
+- Metrics report: generated in `single-stream-gate.json`, manually inspected.
+- Reviewed audio/video evidence: N/A - tracked in human follow-up #13150 because
+  it requires human review of real or generated WAV/video artifacts.
+- Broken one-speaker-only baseline: covered by
+  `test_overlap_collapse_baseline_fails_gate`.
+- Secondary speaker disappearance baseline: covered by
+  `test_secondary_speaker_disappearing_baseline_fails_gate`.

--- a/packages/benchmarks/voice-speaker-validation/AGENTS.md
+++ b/packages/benchmarks/voice-speaker-validation/AGENTS.md
@@ -24,6 +24,7 @@ Individual test modules:
 
 ```bash
 pytest tests/test_diarization.py -v         # DER and speaker-count assertions
+pytest tests/test_single_stream_gate.py -v  # #12493 artifact gate, no WAV fixtures
 pytest tests/test_speaker_id.py -v          # intra/inter cosine thresholds
 pytest tests/test_entity_creation.py -v    # Jill scenario end-to-end
 pytest tests/test_owner_lru_cache.py -v    # hot-profile latency < 50 ms
@@ -36,6 +37,7 @@ pytest tests/test_async_search.py -v       # async profile search
 | --- | --- |
 | `tests/conftest.py` | SpeechBrain ECAPA-TDNN encoder, energy-VAD diarizer, InMemoryVoiceProfileStore fixtures |
 | `tests/test_diarization.py` | DER ≤ 0.45 and speaker-count correctness across all 5 fixtures |
+| `tests/test_single_stream_gate.py` | Single-platform-participant room-mic gate for 2/3/5/8 speaker artifacts; no WAV fixtures required |
 | `tests/test_speaker_id.py` | Intra-cluster cosine ≥ 0.40, inter-cluster ≤ 0.46 (ECAPA-TDNN on TTS) |
 | `tests/test_entity_creation.py` | Full Jill scenario: 2 entities, partner_of edge, no duplicates |
 | `tests/test_owner_lru_cache.py` | Owner hot-profile lookup latency < 50 ms |
@@ -50,6 +52,8 @@ pytest tests/test_async_search.py -v       # async profile search
 - Fixtures (f1–f5 WAV files) are **not committed** — they must be generated or
   provided before running. The manifest defines expected paths and ground-truth
   boundaries.
+- `tests/test_single_stream_gate.py` is an artifact-level smoke/gate for #12493
+  and does not require WAV fixtures or model downloads.
 - The diarizer in tests uses energy-VAD + ECAPA-TDNN clustering (no Hugging Face
   token required). Production uses pyannote; thresholds differ.
 - Artifacts are written to `artifacts/<W3_6_RUN_ID>/` (set env var to name the

--- a/packages/benchmarks/voice-speaker-validation/CLAUDE.md
+++ b/packages/benchmarks/voice-speaker-validation/CLAUDE.md
@@ -24,6 +24,7 @@ Individual test modules:
 
 ```bash
 pytest tests/test_diarization.py -v         # DER and speaker-count assertions
+pytest tests/test_single_stream_gate.py -v  # #12493 artifact gate, no WAV fixtures
 pytest tests/test_speaker_id.py -v          # intra/inter cosine thresholds
 pytest tests/test_entity_creation.py -v    # Jill scenario end-to-end
 pytest tests/test_owner_lru_cache.py -v    # hot-profile latency < 50 ms
@@ -36,6 +37,7 @@ pytest tests/test_async_search.py -v       # async profile search
 | --- | --- |
 | `tests/conftest.py` | SpeechBrain ECAPA-TDNN encoder, energy-VAD diarizer, InMemoryVoiceProfileStore fixtures |
 | `tests/test_diarization.py` | DER ≤ 0.45 and speaker-count correctness across all 5 fixtures |
+| `tests/test_single_stream_gate.py` | Single-platform-participant room-mic gate for 2/3/5/8 speaker artifacts; no WAV fixtures required |
 | `tests/test_speaker_id.py` | Intra-cluster cosine ≥ 0.40, inter-cluster ≤ 0.46 (ECAPA-TDNN on TTS) |
 | `tests/test_entity_creation.py` | Full Jill scenario: 2 entities, partner_of edge, no duplicates |
 | `tests/test_owner_lru_cache.py` | Owner hot-profile lookup latency < 50 ms |
@@ -50,6 +52,8 @@ pytest tests/test_async_search.py -v       # async profile search
 - Fixtures (f1–f5 WAV files) are **not committed** — they must be generated or
   provided before running. The manifest defines expected paths and ground-truth
   boundaries.
+- `tests/test_single_stream_gate.py` is an artifact-level smoke/gate for #12493
+  and does not require WAV fixtures or model downloads.
 - The diarizer in tests uses energy-VAD + ECAPA-TDNN clustering (no Hugging Face
   token required). Production uses pyannote; thresholds differ.
 - Artifacts are written to `artifacts/<W3_6_RUN_ID>/` (set env var to name the

--- a/packages/benchmarks/voice-speaker-validation/README.md
+++ b/packages/benchmarks/voice-speaker-validation/README.md
@@ -19,6 +19,9 @@ pytest tests/ -v
 
 # Run a single module
 pytest tests/test_diarization.py -v
+
+# Run the #12493 single-stream artifact gate without WAV fixtures/model downloads
+pytest tests/test_single_stream_gate.py -v
 ```
 
 See [AGENTS.md](AGENTS.md) for the full layout, per-module commands, and notes on

--- a/packages/benchmarks/voice-speaker-validation/single_stream_gate.py
+++ b/packages/benchmarks/voice-speaker-validation/single_stream_gate.py
@@ -1,0 +1,466 @@
+"""Single-stream multi-speaker meeting gate.
+
+This module validates diarization artifacts for the case where one platform
+participant/tile contains several acoustic speakers, such as a conference-room
+microphone or shared laptop. It is intentionally artifact-level: real audio and
+model runs can feed the same schema, while deterministic tests prove that the
+gate catches the two regressions called out in #12493.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from itertools import count
+from typing import Any
+
+
+REQUIRED_SPEAKER_COUNTS = (2, 3, 5, 8)
+REQUIRED_VARIANTS = ("clean", "music", "babble", "overlap", "far_field", "reverberant")
+ROOM_FEED_FLAGS = ("room_feed_suspected", "multi_speaker_room")
+PLATFORM_PARTICIPANT_ID = "platform-room-tile-1"
+
+
+@dataclass(frozen=True)
+class ReferenceTurn:
+    speaker_id: str
+    start_ms: int
+    end_ms: int
+    text: str
+    overlaps: bool = False
+
+
+@dataclass(frozen=True)
+class HypothesisTurn:
+    diarized_speaker_id: str
+    platform_participant_id: str
+    start_ms: int
+    end_ms: int
+    text: str
+
+
+@dataclass(frozen=True)
+class SingleStreamScenario:
+    scenario_id: str
+    speaker_count: int
+    acoustic_variant: str
+    source_platform_participant_id: str
+    source_stream_id: str
+    room_feed_evidence: tuple[str, ...]
+    reference_turns: tuple[ReferenceTurn, ...]
+
+
+def build_single_stream_scenarios() -> list[SingleStreamScenario]:
+    """Build the deterministic #12493 scenario matrix."""
+    scenarios: list[SingleStreamScenario] = []
+    for speaker_count in REQUIRED_SPEAKER_COUNTS:
+        for variant in REQUIRED_VARIANTS:
+            scenario_id = f"single_stream_{speaker_count}spk_{variant}"
+            source_stream_id = _source_stream_id(variant)
+            scenarios.append(
+                SingleStreamScenario(
+                    scenario_id=scenario_id,
+                    speaker_count=speaker_count,
+                    acoustic_variant=variant,
+                    source_platform_participant_id=PLATFORM_PARTICIPANT_ID,
+                    source_stream_id=source_stream_id,
+                    room_feed_evidence=ROOM_FEED_FLAGS,
+                    reference_turns=tuple(_build_reference_turns(speaker_count, variant)),
+                )
+            )
+    return scenarios
+
+
+def build_reference_hypothesis(scenario: SingleStreamScenario) -> list[HypothesisTurn]:
+    """Create a perfect hypothesis artifact for a scenario."""
+    return [
+        HypothesisTurn(
+            diarized_speaker_id=f"{scenario.source_platform_participant_id}/{turn.speaker_id}",
+            platform_participant_id=scenario.source_platform_participant_id,
+            start_ms=turn.start_ms,
+            end_ms=turn.end_ms,
+            text=turn.text,
+        )
+        for turn in scenario.reference_turns
+    ]
+
+
+def evaluate_single_stream_gate(
+    scenario: SingleStreamScenario,
+    hypothesis_turns: list[HypothesisTurn],
+) -> dict[str, Any]:
+    """Evaluate one single-stream diarization artifact and return a report dict."""
+    diarized_speaker_ids = tuple(
+        dict.fromkeys(turn.diarized_speaker_id for turn in hypothesis_turns)
+    )
+    platform_ids = tuple(dict.fromkeys(turn.platform_participant_id for turn in hypothesis_turns))
+    mapping = _map_hypothesis_speakers(scenario.reference_turns, hypothesis_turns)
+    coverage = _speaker_coverage(scenario.reference_turns, hypothesis_turns, mapping)
+    disappeared = tuple(
+        speaker_id
+        for speaker_id, covered_ratio in coverage.items()
+        if covered_ratio < 0.5
+    )
+
+    der, overlap_der = _der_metrics(scenario.reference_turns, hypothesis_turns, mapping)
+    jer = _jer(scenario.reference_turns, hypothesis_turns, mapping)
+    speaker_attribution_errors = _speaker_attribution_errors(
+        scenario.reference_turns, hypothesis_turns, mapping
+    )
+    total_ref_words = sum(len(_tokens(turn.text)) for turn in scenario.reference_turns)
+    wder = speaker_attribution_errors / max(total_ref_words, 1)
+    cpwer = _word_error_rate(scenario.reference_turns, hypothesis_turns, mapping)
+    boundary_error_ms = _turn_boundary_error_ms(
+        scenario.reference_turns, hypothesis_turns, mapping
+    )
+    tcpwer = min(1.0, cpwer + boundary_error_ms / 100_000)
+
+    failures = _gate_failures(
+        scenario=scenario,
+        detected_speaker_count=len(diarized_speaker_ids),
+        platform_ids=platform_ids,
+        disappeared_speakers=disappeared,
+        der=der,
+        overlap_der=overlap_der,
+    )
+
+    return {
+        "scenario_id": scenario.scenario_id,
+        "source_platform_participant_id": scenario.source_platform_participant_id,
+        "source_stream_id": scenario.source_stream_id,
+        "acoustic_variant": scenario.acoustic_variant,
+        "expected_speaker_count": scenario.speaker_count,
+        "detected_speaker_count": len(diarized_speaker_ids),
+        "diarized_speaker_ids": list(diarized_speaker_ids),
+        "platform_participant_ids": list(platform_ids),
+        "room_feed_evidence": list(scenario.room_feed_evidence),
+        "metrics": {
+            "speaker_count_accuracy": 1.0
+            if len(diarized_speaker_ids) == scenario.speaker_count
+            else 0.0,
+            "der": round(der, 4),
+            "jer": round(jer, 4),
+            "wder": round(wder, 4),
+            "overlap_der": round(overlap_der, 4),
+            "cpwer": round(cpwer, 4),
+            "tcpwer": round(tcpwer, 4),
+            "speaker_attribution_errors": speaker_attribution_errors,
+            "disappeared_speaker_count": len(disappeared),
+            "over_split_count": max(0, len(diarized_speaker_ids) - scenario.speaker_count),
+            "under_split_count": max(0, scenario.speaker_count - len(diarized_speaker_ids)),
+            "speaker_turn_boundary_timing_error_ms": round(boundary_error_ms, 2),
+        },
+        "disappeared_speakers": list(disappeared),
+        "speaker_mapping": dict(mapping),
+        "pass": not failures,
+        "failures": failures,
+    }
+
+
+def scenario_to_manifest(scenario: SingleStreamScenario) -> dict[str, Any]:
+    """Serialize a scenario for fixture/report artifacts."""
+    payload = asdict(scenario)
+    payload["room_feed_evidence"] = list(scenario.room_feed_evidence)
+    payload["reference_turns"] = [asdict(turn) for turn in scenario.reference_turns]
+    return payload
+
+
+def _source_stream_id(variant: str) -> str:
+    if variant == "far_field":
+        return "room-mic-far-field"
+    if variant == "reverberant":
+        return "room-mic-reverb"
+    return "room-mic-mixed"
+
+
+def _build_reference_turns(speaker_count: int, variant: str) -> list[ReferenceTurn]:
+    turns: list[ReferenceTurn] = []
+    cursor = 0
+    turn_counter = count(1)
+    for index in range(speaker_count * 2):
+        speaker_number = index % speaker_count + 1
+        duration = 900 + (index % 3) * 180
+        overlaps = variant == "overlap" and index % 2 == 1
+        start_ms = max(0, cursor - 320) if overlaps else cursor
+        end_ms = start_ms + duration
+        speaker_id = f"room_speaker_{speaker_number}"
+        turns.append(
+            ReferenceTurn(
+                speaker_id=speaker_id,
+                start_ms=start_ms,
+                end_ms=end_ms,
+                text=(
+                    f"{speaker_id} turn {next(turn_counter)} "
+                    f"{variant.replace('_', ' ')} checkpoint"
+                ),
+                overlaps=overlaps,
+            )
+        )
+        cursor = end_ms + 160
+    return turns
+
+
+def _intersection_ms(
+    left_start_ms: int,
+    left_end_ms: int,
+    right_start_ms: int,
+    right_end_ms: int,
+) -> int:
+    return max(0, min(left_end_ms, right_end_ms) - max(left_start_ms, right_start_ms))
+
+
+def _duration_ms(turn: ReferenceTurn | HypothesisTurn) -> int:
+    return max(0, turn.end_ms - turn.start_ms)
+
+
+def _tokens(text: str) -> list[str]:
+    return [part for part in text.lower().replace("/", " ").split() if part]
+
+
+def _map_hypothesis_speakers(
+    reference_turns: tuple[ReferenceTurn, ...],
+    hypothesis_turns: list[HypothesisTurn],
+) -> dict[str, str]:
+    confusion: dict[tuple[str, str], int] = {}
+    for hyp in hypothesis_turns:
+        for ref in reference_turns:
+            overlap = _intersection_ms(hyp.start_ms, hyp.end_ms, ref.start_ms, ref.end_ms)
+            if overlap:
+                key = (hyp.diarized_speaker_id, ref.speaker_id)
+                confusion[key] = confusion.get(key, 0) + overlap
+
+    mapping: dict[str, str] = {}
+    for hyp_id in dict.fromkeys(turn.diarized_speaker_id for turn in hypothesis_turns):
+        best_ref = ""
+        best_overlap = -1
+        for ref in dict.fromkeys(turn.speaker_id for turn in reference_turns):
+            overlap = confusion.get((hyp_id, ref), 0)
+            if overlap > best_overlap:
+                best_ref = ref
+                best_overlap = overlap
+        if best_ref:
+            mapping[hyp_id] = best_ref
+    return mapping
+
+
+def _speaker_coverage(
+    reference_turns: tuple[ReferenceTurn, ...],
+    hypothesis_turns: list[HypothesisTurn],
+    mapping: dict[str, str],
+) -> dict[str, float]:
+    coverage: dict[str, int] = {
+        speaker_id: 0 for speaker_id in dict.fromkeys(turn.speaker_id for turn in reference_turns)
+    }
+    totals: dict[str, int] = {speaker_id: 0 for speaker_id in coverage}
+    for ref in reference_turns:
+        totals[ref.speaker_id] += _duration_ms(ref)
+        for hyp in hypothesis_turns:
+            if mapping.get(hyp.diarized_speaker_id) != ref.speaker_id:
+                continue
+            coverage[ref.speaker_id] += _intersection_ms(
+                ref.start_ms,
+                ref.end_ms,
+                hyp.start_ms,
+                hyp.end_ms,
+            )
+    return {
+        speaker_id: min(1.0, coverage[speaker_id] / max(total_ms, 1))
+        for speaker_id, total_ms in totals.items()
+    }
+
+
+def _der_metrics(
+    reference_turns: tuple[ReferenceTurn, ...],
+    hypothesis_turns: list[HypothesisTurn],
+    mapping: dict[str, str],
+) -> tuple[float, float]:
+    missed = 0
+    speaker_error = 0
+    overlap_missed = 0
+    overlap_error = 0
+    overlap_total = 0
+    total_ref = sum(_duration_ms(turn) for turn in reference_turns)
+    total_hyp = sum(_duration_ms(turn) for turn in hypothesis_turns)
+    hyp_ref_overlap = 0
+
+    for ref in reference_turns:
+        ref_correct = 0
+        ref_wrong = 0
+        for hyp in hypothesis_turns:
+            intersection = _intersection_ms(ref.start_ms, ref.end_ms, hyp.start_ms, hyp.end_ms)
+            if not intersection:
+                continue
+            hyp_ref_overlap += intersection
+            if mapping.get(hyp.diarized_speaker_id) != ref.speaker_id:
+                ref_wrong += intersection
+            else:
+                ref_correct += intersection
+        ref_missed = max(0, _duration_ms(ref) - min(_duration_ms(ref), ref_correct))
+        ref_error = 0 if ref_missed == 0 else min(ref_wrong, ref_missed)
+        missed += ref_missed
+        speaker_error += ref_error
+        if ref.overlaps:
+            overlap_total += _duration_ms(ref)
+            overlap_missed += ref_missed
+            overlap_error += ref_error
+
+    false_alarm = max(0, total_hyp - hyp_ref_overlap)
+    der = (missed + speaker_error + false_alarm) / max(total_ref, 1)
+    overlap_der = (
+        (overlap_missed + overlap_error) / max(overlap_total, 1)
+        if overlap_total
+        else 0.0
+    )
+    return min(1.0, der), min(1.0, overlap_der)
+
+
+def _jer(
+    reference_turns: tuple[ReferenceTurn, ...],
+    hypothesis_turns: list[HypothesisTurn],
+    mapping: dict[str, str],
+) -> float:
+    speaker_ids = tuple(dict.fromkeys(turn.speaker_id for turn in reference_turns))
+    errors: list[float] = []
+    for speaker_id in speaker_ids:
+        ref_duration = sum(
+            _duration_ms(turn)
+            for turn in reference_turns
+            if turn.speaker_id == speaker_id
+        )
+        hyp_duration = sum(
+            _duration_ms(turn)
+            for turn in hypothesis_turns
+            if mapping.get(turn.diarized_speaker_id) == speaker_id
+        )
+        intersection = 0
+        for ref in reference_turns:
+            if ref.speaker_id != speaker_id:
+                continue
+            for hyp in hypothesis_turns:
+                if mapping.get(hyp.diarized_speaker_id) != speaker_id:
+                    continue
+                intersection += _intersection_ms(
+                    ref.start_ms,
+                    ref.end_ms,
+                    hyp.start_ms,
+                    hyp.end_ms,
+                )
+        union = max(ref_duration + hyp_duration - intersection, 1)
+        errors.append(1.0 - min(1.0, intersection / union))
+    return sum(errors) / max(len(errors), 1)
+
+
+def _speaker_attribution_errors(
+    reference_turns: tuple[ReferenceTurn, ...],
+    hypothesis_turns: list[HypothesisTurn],
+    mapping: dict[str, str],
+) -> int:
+    errors = 0
+    for hyp in hypothesis_turns:
+        best_ref: ReferenceTurn | None = None
+        best_overlap = 0
+        for ref in reference_turns:
+            overlap = _intersection_ms(hyp.start_ms, hyp.end_ms, ref.start_ms, ref.end_ms)
+            if overlap > best_overlap:
+                best_ref = ref
+                best_overlap = overlap
+        if best_ref and mapping.get(hyp.diarized_speaker_id) != best_ref.speaker_id:
+            errors += len(_tokens(hyp.text))
+    return errors
+
+
+def _word_error_rate(
+    reference_turns: tuple[ReferenceTurn, ...],
+    hypothesis_turns: list[HypothesisTurn],
+    mapping: dict[str, str],
+) -> float:
+    speaker_ids = tuple(dict.fromkeys(turn.speaker_id for turn in reference_turns))
+    edits = 0
+    ref_words = 0
+    for speaker_id in speaker_ids:
+        reference_tokens = _tokens(
+            " ".join(turn.text for turn in reference_turns if turn.speaker_id == speaker_id)
+        )
+        hypothesis_tokens = _tokens(
+            " ".join(
+                turn.text
+                for turn in hypothesis_turns
+                if mapping.get(turn.diarized_speaker_id) == speaker_id
+            )
+        )
+        edits += _levenshtein(reference_tokens, hypothesis_tokens)
+        ref_words += len(reference_tokens)
+    return min(1.0, edits / max(ref_words, 1))
+
+
+def _levenshtein(left: list[str], right: list[str]) -> int:
+    previous = list(range(len(right) + 1))
+    for i, left_token in enumerate(left, start=1):
+        current = [i]
+        for j, right_token in enumerate(right, start=1):
+            current.append(
+                min(
+                    previous[j] + 1,
+                    current[j - 1] + 1,
+                    previous[j - 1] + (0 if left_token == right_token else 1),
+                )
+            )
+        previous = current
+    return previous[-1]
+
+
+def _turn_boundary_error_ms(
+    reference_turns: tuple[ReferenceTurn, ...],
+    hypothesis_turns: list[HypothesisTurn],
+    mapping: dict[str, str],
+) -> float:
+    errors: list[int] = []
+    for ref in reference_turns:
+        candidates = [
+            hyp
+            for hyp in hypothesis_turns
+            if mapping.get(hyp.diarized_speaker_id) == ref.speaker_id
+        ]
+        if not candidates:
+            continue
+        best = max(
+            candidates,
+            key=lambda hyp: _intersection_ms(ref.start_ms, ref.end_ms, hyp.start_ms, hyp.end_ms),
+        )
+        errors.append(abs(ref.start_ms - best.start_ms) + abs(ref.end_ms - best.end_ms))
+    return sum(errors) / max(len(errors), 1)
+
+
+def _gate_failures(
+    *,
+    scenario: SingleStreamScenario,
+    detected_speaker_count: int,
+    platform_ids: tuple[str, ...],
+    disappeared_speakers: tuple[str, ...],
+    der: float,
+    overlap_der: float,
+) -> list[str]:
+    failures: list[str] = []
+    if detected_speaker_count < scenario.speaker_count:
+        failures.append(
+            f"detected {detected_speaker_count} speakers; expected {scenario.speaker_count}"
+        )
+    if detected_speaker_count > scenario.speaker_count:
+        failures.append(
+            f"detected {detected_speaker_count} speakers; expected no over-split"
+        )
+    if disappeared_speakers:
+        failures.append(f"secondary speaker disappeared: {', '.join(disappeared_speakers)}")
+    if scenario.acoustic_variant == "overlap" and detected_speaker_count == 1:
+        failures.append("overlapping speech collapsed into one speaker")
+    if platform_ids != (scenario.source_platform_participant_id,):
+        failures.append(
+            "source platform participant id was not preserved on every diarized turn"
+        )
+    for required_flag in ROOM_FEED_FLAGS:
+        if required_flag not in scenario.room_feed_evidence:
+            failures.append(f"missing room-feed evidence flag: {required_flag}")
+    if der > 0.45:
+        failures.append(f"DER {der:.3f} exceeds 0.45 gate")
+    if scenario.acoustic_variant == "overlap" and overlap_der > 0.55:
+        failures.append(f"overlap DER {overlap_der:.3f} exceeds 0.55 gate")
+    return failures

--- a/packages/benchmarks/voice-speaker-validation/tests/conftest.py
+++ b/packages/benchmarks/voice-speaker-validation/tests/conftest.py
@@ -21,8 +21,6 @@ from typing import Any
 
 import numpy as np
 import pytest
-import soundfile as sf
-import torch
 
 FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
 ARTIFACTS_DIR = Path(__file__).parent.parent / "artifacts"
@@ -36,6 +34,8 @@ TARGET_SR = 16_000
 def load_wav_mono16k(path: Path) -> np.ndarray:
     """Load a WAV file and return float32 mono PCM at 16 kHz."""
     import librosa
+    import soundfile as sf
+
     audio, sr = sf.read(str(path))
     if audio.ndim > 1:
         audio = audio.mean(axis=1)

--- a/packages/benchmarks/voice-speaker-validation/tests/test_single_stream_gate.py
+++ b/packages/benchmarks/voice-speaker-validation/tests/test_single_stream_gate.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+from single_stream_gate import (
+    REQUIRED_SPEAKER_COUNTS,
+    REQUIRED_VARIANTS,
+    HypothesisTurn,
+    build_reference_hypothesis,
+    build_single_stream_scenarios,
+    evaluate_single_stream_gate,
+    scenario_to_manifest,
+)
+
+
+REQUIRED_METRICS = {
+    "speaker_count_accuracy",
+    "der",
+    "jer",
+    "wder",
+    "overlap_der",
+    "cpwer",
+    "tcpwer",
+    "speaker_attribution_errors",
+    "disappeared_speaker_count",
+    "over_split_count",
+    "under_split_count",
+    "speaker_turn_boundary_timing_error_ms",
+}
+
+
+def test_single_stream_matrix_covers_required_axes():
+    scenarios = build_single_stream_scenarios()
+
+    assert {scenario.speaker_count for scenario in scenarios} == set(REQUIRED_SPEAKER_COUNTS)
+    assert {scenario.acoustic_variant for scenario in scenarios} == set(REQUIRED_VARIANTS)
+    assert len(scenarios) == len(REQUIRED_SPEAKER_COUNTS) * len(REQUIRED_VARIANTS)
+    assert len({scenario.scenario_id for scenario in scenarios}) == len(scenarios)
+
+    for scenario in scenarios:
+        assert scenario.source_platform_participant_id == "platform-room-tile-1"
+        assert scenario.source_stream_id.startswith("room-mic-")
+        assert "room_feed_suspected" in scenario.room_feed_evidence
+        assert "multi_speaker_room" in scenario.room_feed_evidence
+        assert len({turn.speaker_id for turn in scenario.reference_turns}) == scenario.speaker_count
+
+
+def test_reference_hypotheses_pass_and_report_required_metrics():
+    for scenario in build_single_stream_scenarios():
+        report = evaluate_single_stream_gate(scenario, build_reference_hypothesis(scenario))
+
+        assert report["pass"], report["failures"]
+        assert report["detected_speaker_count"] == scenario.speaker_count
+        assert report["platform_participant_ids"] == [scenario.source_platform_participant_id]
+        assert set(report["metrics"]) == REQUIRED_METRICS
+        assert report["metrics"]["der"] == 0
+        assert report["metrics"]["jer"] == 0
+        assert report["metrics"]["cpwer"] == 0
+        assert report["metrics"]["tcpwer"] == 0
+        assert report["metrics"]["speaker_attribution_errors"] == 0
+
+
+def test_overlap_collapse_baseline_fails_gate():
+    scenario = next(
+        scenario
+        for scenario in build_single_stream_scenarios()
+        if scenario.speaker_count == 3 and scenario.acoustic_variant == "overlap"
+    )
+    collapsed = [
+        replace(turn, diarized_speaker_id="platform-room-tile-1/collapsed-speaker")
+        for turn in build_reference_hypothesis(scenario)
+    ]
+
+    report = evaluate_single_stream_gate(scenario, collapsed)
+
+    assert not report["pass"]
+    assert report["metrics"]["under_split_count"] == 2
+    assert any(
+        "overlapping speech collapsed into one speaker" in item
+        for item in report["failures"]
+    )
+
+
+def test_secondary_speaker_disappearing_baseline_fails_gate():
+    scenario = next(
+        scenario
+        for scenario in build_single_stream_scenarios()
+        if scenario.speaker_count == 5 and scenario.acoustic_variant == "babble"
+    )
+    missing_last_speaker = [
+        turn
+        for turn in build_reference_hypothesis(scenario)
+        if not turn.diarized_speaker_id.endswith("room_speaker_5")
+    ]
+
+    report = evaluate_single_stream_gate(scenario, missing_last_speaker)
+
+    assert not report["pass"]
+    assert "room_speaker_5" in report["disappeared_speakers"]
+    assert report["metrics"]["disappeared_speaker_count"] == 1
+    assert any("secondary speaker disappeared" in item for item in report["failures"])
+
+
+def test_platform_participant_id_must_be_preserved_with_multiple_diarized_speakers():
+    scenario = next(
+        scenario
+        for scenario in build_single_stream_scenarios()
+        if scenario.speaker_count == 2 and scenario.acoustic_variant == "far_field"
+    )
+    hypothesis = build_reference_hypothesis(scenario)
+    report = evaluate_single_stream_gate(scenario, hypothesis)
+
+    assert report["pass"], report["failures"]
+    assert report["platform_participant_ids"] == [scenario.source_platform_participant_id]
+    assert len(report["diarized_speaker_ids"]) == 2
+
+    wrong_platform = [
+        HypothesisTurn(
+            diarized_speaker_id=turn.diarized_speaker_id,
+            platform_participant_id="platform-person-tile-2",
+            start_ms=turn.start_ms,
+            end_ms=turn.end_ms,
+            text=turn.text,
+        )
+        for turn in hypothesis
+    ]
+    failed = evaluate_single_stream_gate(scenario, wrong_platform)
+
+    assert not failed["pass"]
+    assert any(
+        "platform participant id was not preserved" in item
+        for item in failed["failures"]
+    )
+
+
+def test_gate_writes_reviewable_manifest_and_report_artifact(artifacts_dir: Path):
+    scenarios = build_single_stream_scenarios()
+    reports = [
+        evaluate_single_stream_gate(scenario, build_reference_hypothesis(scenario))
+        for scenario in scenarios
+    ]
+    output = {
+        "issue": 12493,
+        "scenario_count": len(scenarios),
+        "scenarios": [scenario_to_manifest(scenario) for scenario in scenarios],
+        "reports": reports,
+    }
+    out_path = artifacts_dir / "single-stream-gate.json"
+    out_path.write_text(json.dumps(output, indent=2), encoding="utf-8")
+
+    loaded = json.loads(out_path.read_text(encoding="utf-8"))
+    assert loaded["scenario_count"] == 24
+    assert all(report["pass"] for report in loaded["reports"])
+    assert out_path.exists()


### PR DESCRIPTION
## Summary

- Adds an artifact-level single-stream meeting gate for one platform participant/tile containing multiple acoustic speakers.
- Covers the #12493 matrix for 2, 3, 5, and 8 speakers across clean, music, babble, overlap, far-field, and reverberant variants.
- Reports speaker count, DER, JER, WDER, overlap DER, cpWER, tcpWER, speaker attribution errors, disappeared/over-split/under-split counts, and turn boundary timing error.
- Adds deterministic failure coverage for one-speaker overlap collapse, disappearing secondary speakers, and platform participant id drift.
- Lazy-loads heavy audio dependencies in the benchmark conftest so the artifact-only gate runs without ECAPA/SpeechBrain or WAV fixtures.

## Evidence

- Evidence note: `.github/issue-evidence/12493-multi-speaker-single-stream.md`
- Generated artifact manually inspected: `packages/benchmarks/voice-speaker-validation/artifacts/run-1783165016/single-stream-gate.json`
- Generated artifact is gitignored under `artifacts/` and is not committed.
- Live audio/model evidence is tracked in needs-human follow-up #13150 because it requires SpeechBrain/ECAPA setup, fixture WAVs or real captures, and human review of audio/transcript artifacts.

## Verification

- `python -m pytest tests/test_single_stream_gate.py -q`
  - Passed: 6 tests.
  - Warning: existing package config references `pytest-timeout`, which is not installed in this Python environment.
- `python -m compileall -q single_stream_gate.py tests/test_single_stream_gate.py tests/conftest.py`
  - Passed.
- Manual artifact inspection confirmed 24 scenarios, speaker counts `[2, 3, 5, 8]`, variants `[babble, clean, far_field, music, overlap, reverberant]`, all reports passing, required metric keys, room-feed evidence flags, and platform id `platform-room-tile-1`.
- `python -m pytest tests -q`
  - Failed on current live-audio package setup: 31 setup errors from `ModuleNotFoundError: No module named 'speechbrain'`.
  - The new `tests/test_single_stream_gate.py` still passed inside that full run.
  - Production-stack tests skipped via existing guards.

Closes #12493
