### PR TITLE
fix(#12636): route shell-direct behavior through declared action tags

### DIFF
--- a/.github/issue-evidence/12636-shell-direct-action-tags.md
+++ b/.github/issue-evidence/12636-shell-direct-action-tags.md
@@ -1,0 +1,117 @@
+# #12636 Shell-Direct Action Tags Evidence
+
+Branch: `fix/12636-shell-direct-action-tags`
+Code PR: #13153
+
+## What Was Proven
+
+- Removed the executable-path `SHELL_DIRECT_ACTIONS` hardcoded set from
+  `packages/core/src/services/message.ts`.
+- Added `SHELL_DIRECT_ACTION_TAGS` as the declared behavior contract for
+  shell-direct actions:
+  - `domain:system`
+  - `resource:shell`
+  - `capability:execute`
+- Added `findShellDirectActionName()` and `isShellDirectActionName()` so the
+  message pipeline resolves shell-direct routing through action metadata first,
+  then through the covered legacy name/simile fallback.
+- Migrated `packages/agent/src/actions/terminal.ts` to declare the tags.
+- Added regression coverage for an owner-renamed action (`RUN_OS_COMMAND`) that
+  keeps the tags and still routes/promotes.
+- Added a compatibility regression caught during review: a tagless action named
+  `LOCAL_COMMAND` with legacy simile `RUN_IN_TERMINAL` now resolves and
+  classifies consistently. Before the review fix, inference could resolve the
+  action through its simile while promotion failed to classify it.
+- Added a grep guard proving the removed `SHELL_DIRECT_ACTIONS` set and
+  `.has()` gate are not present in `message.ts`.
+
+## Focused Verification
+
+```bash
+bun run --cwd packages/core test \
+  src/services/message/direct-action-heuristics.test.ts \
+  src/__tests__/message-routing-live-regression.test.ts
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       59 passed (59)
+Duration    1.37s
+```
+
+```bash
+bun run --cwd packages/core typecheck
+```
+
+Result: passed (`tsgo --noEmit -p ./tsconfig.json`).
+
+```bash
+bun run --cwd packages/agent typecheck
+```
+
+Result: blocked by unrelated existing diagnostics:
+
+- missing optional plugin modules such as `@elizaos/plugin-streaming`,
+  `@elizaos/plugin-vision`, `@elizaos/plugin-background-runner`, and
+  `@elizaos/plugin-meetings`;
+- existing Discord metadata diagnostics for `platformMessageId`.
+
+No diagnostic points at the touched `packages/agent/src/actions/terminal.ts`.
+
+```bash
+bunx @biomejs/biome check \
+  packages/core/src/services/message/direct-action-heuristics.ts \
+  packages/core/src/services/message/direct-action-heuristics.test.ts \
+  packages/core/src/services/message.ts \
+  packages/core/src/__tests__/message-routing-live-regression.test.ts \
+  packages/agent/src/actions/terminal.ts
+```
+
+Result:
+
+```text
+Checked 5 files in 106ms. No fixes applied.
+```
+
+```bash
+bun run --cwd packages/core build
+bun run --cwd packages/agent build
+```
+
+Result: both passed. `packages/core build` completed node, browser, edge, and
+testing bundles plus declarations; `packages/agent build` completed dist output.
+
+## Repo-Level Checks
+
+```bash
+bun run audit:type-safety-ratchet
+bun run audit:error-policy-ratchet
+git diff --check
+```
+
+Result: passed. The error-policy ratchet reported no new fallback-slop in the
+three touched production files:
+
+- `packages/agent/src/actions/terminal.ts`
+- `packages/core/src/services/message.ts`
+- `packages/core/src/services/message/direct-action-heuristics.ts`
+
+```bash
+bun run verify
+```
+
+Result: blocked after the CLAUDE/AGENTS check and both ratchets passed. Turbo
+stopped on unrelated current-baseline `@elizaos/electrobun#lint` formatting in
+`packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts`.
+
+## Evidence Rows
+
+- Focused routing regression: covered by
+  `packages/core/src/__tests__/message-routing-live-regression.test.ts`.
+- Tag/legacy/simile behavior and grep guard: covered by
+  `packages/core/src/services/message/direct-action-heuristics.test.ts`.
+- Runtime/log/UI artifacts: N/A for this code-path refactor; no UI surface was
+  changed. The behavior is covered at the message-routing helper and live
+  routing regression levels.

--- a/packages/agent/src/actions/terminal.ts
+++ b/packages/agent/src/actions/terminal.ts
@@ -268,6 +268,13 @@ export const terminalAction: Action = {
   contexts: ["terminal", "code", "files", "admin"],
   roleGate: { minRole: "OWNER" },
 
+  // Declared shell-direct behavior class (see SHELL_DIRECT_ACTION_TAGS in
+  // core/services/message/direct-action-heuristics). The core message pipeline
+  // resolves shell-direct routing/termination off these tags first, so this
+  // action can rename itself without breaking the pipeline; the legacy name/
+  // simile list remains only as a covered compatibility fallback.
+  tags: ["domain:system", "resource:shell", "capability:execute"],
+
   similes: ["RUN_IN_TERMINAL", "EXECUTE_COMMAND", "TERMINAL", "RUN_SHELL"],
 
   description:

--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -562,6 +562,52 @@ describe("live routing regressions", () => {
 		).toBe(true);
 	});
 
+	it("resolves shell-direct routing off declared tags when the owner renamed the action (#12636)", () => {
+		// The crux of #12636: an owner plugin renames its shell action away from
+		// every legacy name/simile (SHELL, TERMINAL_SHELL, EXEC, …) but keeps the
+		// declared SHELL_DIRECT_ACTION_TAGS. Before the fix the core pipeline
+		// duck-typed shell-direct routing off a hardcoded name set, so this action
+		// silently stopped being recognised. With the tag contract it still routes.
+		const renamedShellActions: Array<
+			Pick<Action, "name" | "similes" | "tags">
+		> = [
+			{
+				name: "RUN_OS_COMMAND",
+				similes: [],
+				tags: ["domain:system", "resource:shell", "capability:execute"],
+			},
+			{ name: "REPLY", similes: ["RESPOND"] },
+		];
+		const shellText = "run df -h on this VPS";
+
+		const directCandidateActions = inferDirectCurrentRequestCandidateActions(
+			renamedShellActions,
+			shellText,
+		);
+		expect(directCandidateActions).toEqual(["RUN_OS_COMMAND"]);
+
+		// The preference gate must promote it too — but ONLY when it can see the
+		// live action registry (so it can resolve the tag). Passing the same
+		// renamed candidate WITHOUT the registry falls back to legacy membership
+		// and correctly does not recognise the new name, proving the gate is
+		// registry-driven rather than hardcoding RUN_OS_COMMAND.
+		expect(
+			shouldPreferDirectCurrentCandidateActions({
+				candidateActions: ["REPLY", "RUN_OS_COMMAND"],
+				currentMessageText: shellText,
+				directCandidateActions,
+				actions: renamedShellActions,
+			}),
+		).toBe(true);
+		expect(
+			shouldPreferDirectCurrentCandidateActions({
+				candidateActions: ["REPLY", "RUN_OS_COMMAND"],
+				currentMessageText: shellText,
+				directCandidateActions,
+			}),
+		).toBe(false);
+	});
+
 	it("promotes explicit reply to direct shell/search action aliases", () => {
 		expect(
 			shouldPromoteExplicitReplyToOwnedAction(

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -252,13 +252,14 @@ import { ChannelTopicsService } from "./channel-topics";
 import { runPostTurnEvaluators } from "./evaluator";
 import { runBotNoiseTriage } from "./message/bot-noise-triage";
 import {
-	findAvailableActionName,
 	findCodingDelegationActionName,
+	findShellDirectActionName,
 	findWebLookupActionName,
 	findWebLookupActionNames,
 	inferDirectCurrentRequestCandidateActions as inferDirectCurrentRequestCandidateActionsFromHeuristics,
 	inferLocalShellCommandFromMessageText,
 	inferWebSearchQueryFromMessageText,
+	isShellDirectActionName,
 	LEGACY_CODING_DELEGATION_ACTION_NAMES,
 	looksLikeLocalShellRequest,
 	looksLikeWebSearchRequest,
@@ -3867,6 +3868,7 @@ export function messageHandlerFromFieldResult(
 			candidateActions,
 			currentMessageText,
 			directCandidateActions: directCurrentCandidateActions,
+			actions: runtimeContext?.actions,
 		});
 	const inferredDirectCandidateActions =
 		!preferDirectCurrentCandidateActions &&
@@ -4422,30 +4424,23 @@ const WEAK_DIRECT_REPLY_OVERRIDE_ACTIONS = new Set(
 	].map(normalizeActionIdentifier),
 );
 
-const SHELL_DIRECT_ACTIONS = new Set(
-	[
-		"SHELL",
-		"TERMINAL_SHELL",
-		"RUN_IN_TERMINAL",
-		"RUN_COMMAND",
-		"EXECUTE_COMMAND",
-		"TERMINAL",
-		"RUN_SHELL",
-		"EXEC",
-	].map(normalizeActionIdentifier),
-);
-
 export function shouldPreferDirectCurrentCandidateActions(args: {
 	candidateActions: readonly string[];
 	currentMessageText: string;
 	directCandidateActions: readonly string[];
+	// Optional live action registry. When supplied, shell-direct membership is
+	// resolved through the declared SHELL_DIRECT_ACTION_TAGS contract (with the
+	// legacy name set as a covered fallback) instead of a hardcoded literal set;
+	// when omitted (e.g. pure unit call sites), the legacy name membership still
+	// applies so behavior is unchanged for owner actions that predate the tags.
+	actions?: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
 }): boolean {
 	if (args.candidateActions.length === 0) return false;
 	if (!looksLikeLocalShellRequest(args.currentMessageText)) return false;
 	if (looksLikeCodingWorkRequest(args.currentMessageText)) return false;
 	if (
 		!args.directCandidateActions.some((name) =>
-			SHELL_DIRECT_ACTIONS.has(normalizeActionIdentifier(name)),
+			isShellDirectActionName(name, args.actions),
 		)
 	) {
 		return false;
@@ -4454,7 +4449,13 @@ export function shouldPreferDirectCurrentCandidateActions(args: {
 		const normalized = normalizeActionIdentifier(name);
 		return (
 			WEAK_DIRECT_REPLY_OVERRIDE_ACTIONS.has(normalized) ||
-			canonicalPlannerControlActionName(normalized) !== null
+			canonicalPlannerControlActionName(normalized) !== null ||
+			// A shell-direct action resolved through the declared tag contract counts
+			// as a weak/overridable signal too — same class as the shell names
+			// enumerated in WEAK_DIRECT_REPLY_OVERRIDE_ACTIONS — so an owner that
+			// renamed its shell action but kept SHELL_DIRECT_ACTION_TAGS still
+			// promotes the direct shell turn instead of falling through to planning.
+			isShellDirectActionName(normalized, args.actions)
 		);
 	});
 }
@@ -4515,16 +4516,7 @@ function inferAckIntentCandidateActions(
 	const actionText = [intentText, fallbackText].filter(Boolean).join("\n");
 	if (!actionText.trim()) return [];
 	if (looksLikeLocalShellRequest(actionText)) {
-		const shellAction = findAvailableActionName(actions, [
-			"SHELL",
-			"TERMINAL_SHELL",
-			"RUN_IN_TERMINAL",
-			"RUN_COMMAND",
-			"EXECUTE_COMMAND",
-			"TERMINAL",
-			"RUN_SHELL",
-			"EXEC",
-		]);
+		const shellAction = findShellDirectActionName(actions);
 		if (shellAction) return [shellAction];
 	}
 	// Coding-work precedes web-search: "build an app that shows the bitcoin price"

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -5,12 +5,17 @@
  * "don't browse the web"), since a false positive runs an unwanted
  * side-effecting action.
  */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import type { Action } from "../../types/components";
 import {
 	findAvailableActionName,
 	findCodingDelegationActionName,
+	findShellDirectActionName,
 	hasActionTags,
+	inferDirectCurrentRequestCandidateActions,
+	isShellDirectActionName,
 	looksLikeLocalShellRequest,
 	looksLikeWebSearchRequest,
 } from "./direct-action-heuristics.ts";
@@ -94,5 +99,120 @@ describe("hasActionTags", () => {
 				"capability:delegate",
 			]),
 		).toBe(true);
+	});
+});
+
+describe("findShellDirectActionName", () => {
+	it("prefers a declared shell-direct tag over the legacy name list", () => {
+		// The owner renamed SHELL -> RUN_OS_COMMAND but kept the declared tags, so
+		// the pipeline must still resolve it even though the new name is not in the
+		// legacy fallback set. This is the whole point of the tag contract.
+		const actions = [
+			{
+				name: "RUN_OS_COMMAND",
+				similes: [],
+				tags: ["domain:system", "resource:shell", "capability:execute"],
+			},
+		] as unknown as ReadonlyArray<
+			Pick<Action, "name" | "similes" | "tags">
+		>;
+
+		expect(findShellDirectActionName(actions)).toBe("RUN_OS_COMMAND");
+	});
+
+	it("falls back to the legacy name/simile set while plugins migrate", () => {
+		const actions = [
+			{ name: "SHELL", similes: ["RUN_IN_TERMINAL", "EXEC"], tags: [] },
+		] as unknown as ReadonlyArray<
+			Pick<Action, "name" | "similes" | "tags">
+		>;
+
+		expect(findShellDirectActionName(actions)).toBe("SHELL");
+	});
+
+	it("returns undefined when no shell-direct action is exposed", () => {
+		const actions = [
+			{ name: "REPLY", similes: [], tags: [] },
+		] as unknown as ReadonlyArray<
+			Pick<Action, "name" | "similes" | "tags">
+		>;
+
+		expect(findShellDirectActionName(actions)).toBeUndefined();
+	});
+});
+
+describe("isShellDirectActionName", () => {
+	it("classifies a declared shell-direct action by tag, not by name", () => {
+		const actions = [
+			{
+				name: "RUN_OS_COMMAND",
+				similes: [],
+				tags: ["domain:system", "resource:shell", "capability:execute"],
+			},
+		] as unknown as ReadonlyArray<
+			Pick<Action, "name" | "similes" | "tags">
+		>;
+
+		expect(isShellDirectActionName("RUN_OS_COMMAND", actions)).toBe(true);
+		expect(isShellDirectActionName("REPLY", actions)).toBe(false);
+	});
+
+	it("honors the legacy name membership when no action set is supplied", () => {
+		expect(isShellDirectActionName("SHELL")).toBe(true);
+		expect(isShellDirectActionName("terminal_shell")).toBe(true);
+		expect(isShellDirectActionName("REPLY")).toBe(false);
+		expect(isShellDirectActionName("")).toBe(false);
+	});
+
+	it("does not classify a tagless renamed action off its new name alone", () => {
+		// A renamed action that dropped both the legacy name AND the declared tags
+		// must NOT be treated as shell-direct — the coupling is gone by design.
+		const actions = [
+			{ name: "RUN_OS_COMMAND", similes: [], tags: [] },
+		] as unknown as ReadonlyArray<
+			Pick<Action, "name" | "similes" | "tags">
+		>;
+
+		expect(isShellDirectActionName("RUN_OS_COMMAND", actions)).toBe(false);
+	});
+});
+
+describe("inferDirectCurrentRequestCandidateActions shell routing", () => {
+	it("routes a local shell ask to a tag-declared shell action", () => {
+		const actions = [
+			{ name: "REPLY", similes: [], tags: [] },
+			{
+				name: "RUN_OS_COMMAND",
+				similes: [],
+				tags: ["domain:system", "resource:shell", "capability:execute"],
+			},
+		] as unknown as ReadonlyArray<
+			Pick<Action, "name" | "similes" | "tags">
+		>;
+
+		expect(
+			inferDirectCurrentRequestCandidateActions(
+				actions,
+				"check git status locally",
+			),
+		).toEqual(["RUN_OS_COMMAND"]);
+	});
+});
+
+describe("shell-direct coupling grep guard (#12636)", () => {
+	it("message.ts no longer duck-types shell-direct routing off a hardcoded name Set", () => {
+		// The audit item's brittle literal was a `SHELL_DIRECT_ACTIONS = new Set([...])`
+		// hardcoded in the core pipeline. Prove it is gone from the executable path
+		// and that routing resolves through the declared-tag helpers instead. If a
+		// future edit reintroduces the literal set, this fails loudly.
+		const messagePath = fileURLToPath(
+			new URL("../message.ts", import.meta.url),
+		);
+		const src = readFileSync(messagePath, "utf8");
+		expect(src).not.toContain("const SHELL_DIRECT_ACTIONS");
+		expect(src).not.toContain("SHELL_DIRECT_ACTIONS.has(");
+		// And it routes through the tag-aware resolver/classifier.
+		expect(src).toContain("findShellDirectActionName");
+		expect(src).toContain("isShellDirectActionName");
 	});
 });

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -113,9 +113,7 @@ describe("findShellDirectActionName", () => {
 				similes: [],
 				tags: ["domain:system", "resource:shell", "capability:execute"],
 			},
-		] as unknown as ReadonlyArray<
-			Pick<Action, "name" | "similes" | "tags">
-		>;
+		] as unknown as ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
 
 		expect(findShellDirectActionName(actions)).toBe("RUN_OS_COMMAND");
 	});
@@ -123,19 +121,24 @@ describe("findShellDirectActionName", () => {
 	it("falls back to the legacy name/simile set while plugins migrate", () => {
 		const actions = [
 			{ name: "SHELL", similes: ["RUN_IN_TERMINAL", "EXEC"], tags: [] },
-		] as unknown as ReadonlyArray<
-			Pick<Action, "name" | "similes" | "tags">
-		>;
+		] as unknown as ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
 
 		expect(findShellDirectActionName(actions)).toBe("SHELL");
+	});
+
+	it("keeps legacy simile fallback aligned with shell-direct classification", () => {
+		const actions = [
+			{ name: "LOCAL_COMMAND", similes: ["RUN_IN_TERMINAL"], tags: [] },
+		] as unknown as ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
+
+		expect(findShellDirectActionName(actions)).toBe("LOCAL_COMMAND");
+		expect(isShellDirectActionName("LOCAL_COMMAND", actions)).toBe(true);
 	});
 
 	it("returns undefined when no shell-direct action is exposed", () => {
 		const actions = [
 			{ name: "REPLY", similes: [], tags: [] },
-		] as unknown as ReadonlyArray<
-			Pick<Action, "name" | "similes" | "tags">
-		>;
+		] as unknown as ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
 
 		expect(findShellDirectActionName(actions)).toBeUndefined();
 	});
@@ -149,9 +152,7 @@ describe("isShellDirectActionName", () => {
 				similes: [],
 				tags: ["domain:system", "resource:shell", "capability:execute"],
 			},
-		] as unknown as ReadonlyArray<
-			Pick<Action, "name" | "similes" | "tags">
-		>;
+		] as unknown as ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
 
 		expect(isShellDirectActionName("RUN_OS_COMMAND", actions)).toBe(true);
 		expect(isShellDirectActionName("REPLY", actions)).toBe(false);
@@ -169,9 +170,7 @@ describe("isShellDirectActionName", () => {
 		// must NOT be treated as shell-direct — the coupling is gone by design.
 		const actions = [
 			{ name: "RUN_OS_COMMAND", similes: [], tags: [] },
-		] as unknown as ReadonlyArray<
-			Pick<Action, "name" | "similes" | "tags">
-		>;
+		] as unknown as ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
 
 		expect(isShellDirectActionName("RUN_OS_COMMAND", actions)).toBe(false);
 	});
@@ -186,9 +185,7 @@ describe("inferDirectCurrentRequestCandidateActions shell routing", () => {
 				similes: [],
 				tags: ["domain:system", "resource:shell", "capability:execute"],
 			},
-		] as unknown as ReadonlyArray<
-			Pick<Action, "name" | "similes" | "tags">
-		>;
+		] as unknown as ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
 
 		expect(
 			inferDirectCurrentRequestCandidateActions(

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -260,15 +260,9 @@ export function isShellDirectActionName(
 	const normalized = normalizeActionIdentifier(actionName);
 	if (!normalized) return false;
 	if (actions && actions.length > 0) {
-		const match = actions.find(
-			(action) => normalizeActionIdentifier(action.name) === normalized,
-		);
-		if (match) {
-			if (hasActionTags(match, SHELL_DIRECT_ACTION_TAGS)) return true;
-			return LEGACY_SHELL_DIRECT_ACTION_NAMES.some(
-				(name) => normalizeActionIdentifier(name) === normalized,
-			);
-		}
+		const shellActionName = findShellDirectActionName(actions);
+		if (!shellActionName) return false;
+		return normalizeActionIdentifier(shellActionName) === normalized;
 	}
 	return LEGACY_SHELL_DIRECT_ACTION_NAMES.some(
 		(name) => normalizeActionIdentifier(name) === normalized,

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -188,6 +188,33 @@ export const LEGACY_CODING_DELEGATION_ACTION_NAMES = [
 	"SPAWN_CODING_AGENT",
 ] as const;
 
+// Declared-tag contract for the shell-direct behavior class: an action an owner
+// plugin exposes to run a single explicit user-provided shell command directly
+// (the SHELL/terminal action). Owner plugins should migrate to declaring these
+// tags so the core message pipeline stops duck-typing shell-direct routing off
+// a brittle hardcoded name list. Resolved tags-first, then the legacy name set
+// below as a covered compatibility fallback — mirrors CODING_DELEGATION.
+export const SHELL_DIRECT_ACTION_TAGS = [
+	"domain:system",
+	"resource:shell",
+	"capability:execute",
+] as const;
+
+// Legacy name/simile fallback for shell-direct resolution. Kept ONLY as a
+// covered compatibility path for owner actions that have not yet declared
+// SHELL_DIRECT_ACTION_TAGS. Do not extend — add the tags to the owning action
+// instead. Priority order: the canonical action name first, then similes.
+export const LEGACY_SHELL_DIRECT_ACTION_NAMES = [
+	"SHELL",
+	"TERMINAL_SHELL",
+	"RUN_IN_TERMINAL",
+	"RUN_COMMAND",
+	"EXECUTE_COMMAND",
+	"TERMINAL",
+	"RUN_SHELL",
+	"EXEC",
+] as const;
+
 export function hasActionTags(
 	action: Pick<Action, "tags">,
 	requiredTags: readonly string[],
@@ -207,22 +234,54 @@ export function findCodingDelegationActionName(
 	);
 }
 
+// Resolve the registered shell-direct action, tags-first then legacy names — the
+// single source of truth for shell-direct routing decisions in the message
+// pipeline. Returns the resolved action's canonical name so callers can compare
+// candidate lists against a live action rather than a hardcoded literal set.
+export function findShellDirectActionName(
+	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
+): string | undefined {
+	return (
+		actions.find((action) => hasActionTags(action, SHELL_DIRECT_ACTION_TAGS))
+			?.name ??
+		findAvailableActionName(actions, LEGACY_SHELL_DIRECT_ACTION_NAMES)
+	);
+}
+
+// True when `actionName` is the shell-direct behavior class, resolved against the
+// live action set: an action declaring SHELL_DIRECT_ACTION_TAGS, or (legacy
+// fallback) one whose name/simile is in LEGACY_SHELL_DIRECT_ACTION_NAMES. When
+// no action set is available, falls back to the legacy name membership so pure
+// name-list call sites keep working during migration.
+export function isShellDirectActionName(
+	actionName: string,
+	actions?: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
+): boolean {
+	const normalized = normalizeActionIdentifier(actionName);
+	if (!normalized) return false;
+	if (actions && actions.length > 0) {
+		const match = actions.find(
+			(action) => normalizeActionIdentifier(action.name) === normalized,
+		);
+		if (match) {
+			if (hasActionTags(match, SHELL_DIRECT_ACTION_TAGS)) return true;
+			return LEGACY_SHELL_DIRECT_ACTION_NAMES.some(
+				(name) => normalizeActionIdentifier(name) === normalized,
+			);
+		}
+	}
+	return LEGACY_SHELL_DIRECT_ACTION_NAMES.some(
+		(name) => normalizeActionIdentifier(name) === normalized,
+	);
+}
+
 export function inferDirectCurrentRequestCandidateActions(
 	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
 	messageText: string,
 	hooks: DirectActionInferenceHooks = {},
 ): string[] {
 	if (looksLikeLocalShellRequest(messageText)) {
-		const shellAction = findAvailableActionName(actions, [
-			"SHELL",
-			"TERMINAL_SHELL",
-			"RUN_IN_TERMINAL",
-			"RUN_COMMAND",
-			"EXECUTE_COMMAND",
-			"TERMINAL",
-			"RUN_SHELL",
-			"EXEC",
-		]);
+		const shellAction = findShellDirectActionName(actions);
 		if (shellAction) return [shellAction];
 	}
 	if (hooks.looksLikeCodingWorkRequest?.(messageText)) {


### PR DESCRIPTION
Closes #12636 (arch-audit brittle strings, #12090 item 8).

## Problem
`packages/core/src/services/message.ts` hardcoded plugin-owned shell action names in a `SHELL_DIRECT_ACTIONS` `Set` plus two inline `["SHELL","TERMINAL_SHELL",…]` lists, duck-typing shell-direct routing/termination off brittle literals. An owner plugin that renamed its shell action (or dropped a legacy simile) silently stopped being recognised by the pipeline — the exact drift/failure mode the audit item calls out.

## Change
Extend the existing action-tag mechanism (the same tags-first-then-legacy-names pattern already used for `CODING_DELEGATION_ACTION_TAGS` / `findCodingDelegationActionName`) to the shell-direct behavior class:

- **`direct-action-heuristics.ts`**: add `SHELL_DIRECT_ACTION_TAGS` (`domain:system`, `resource:shell`, `capability:execute`) + `LEGACY_SHELL_DIRECT_ACTION_NAMES`, and `findShellDirectActionName` / `isShellDirectActionName`. Tags win; the legacy name/simile set remains only as a covered compatibility fallback. `inferDirectCurrentRequestCandidateActions` now resolves the shell action through the tag helper instead of an inline list.
- **`message.ts`**: remove the hardcoded `SHELL_DIRECT_ACTIONS` Set from the executable path; route `inferAckIntentCandidateActions` and `shouldPreferDirectCurrentCandidateActions` through the tag-aware helpers. `shouldPreferDirectCurrentCandidateActions` takes an optional live action registry so a tag-declared shell action is recognised even when renamed away from all legacy names; without the registry it falls back to legacy membership (behavior unchanged for pre-tag owners). The final override `.every()` gate also accepts shell-direct-by-tag.
- **`packages/agent/src/actions/terminal.ts`**: migrate the owning `terminalAction` to declare the tags, so the coupling is real and the action can rename itself safely.

## Tests (58/58 green)
`packages/core/src/services/message/direct-action-heuristics.test.ts`:
- `findShellDirectActionName` prefers a declared tag over legacy names; falls back to legacy name/simile; returns undefined when absent.
- `isShellDirectActionName` classifies by tag (not name), honors legacy membership without a registry, and does NOT classify a tagless renamed action off its new name (proves the coupling is gone by design).
- shell routing through `inferDirectCurrentRequestCandidateActions`.
- **grep guard**: asserts `const SHELL_DIRECT_ACTIONS` / `SHELL_DIRECT_ACTIONS.has(` are gone from `message.ts` and that it routes through `findShellDirectActionName` / `isShellDirectActionName` — fails loudly if the literal set is reintroduced.

`packages/core/src/__tests__/message-routing-live-regression.test.ts`:
- end-to-end: an owner action renamed to `RUN_OS_COMMAND` (away from every legacy name/simile) still routes + gets promoted **only** when the gate can see the live registry, proving it is registry-driven, not a new hardcoded name.

## Verification
- `vitest run` on both files: 58 passed / 0 failed.
- `tsgo --noEmit` on `packages/core`: clean.
- `tsgo --noEmit` on `packages/agent`: only pre-existing baseline errors (missing optional plugin modules — `@elizaos/plugin-streaming` etc.), none in touched files.

-- [sol-orch]