### PR TITLE
refactor(#12646): derive settings-section tokens from the section registry

### DIFF
--- a/.github/issue-evidence/12646-settings-section-tokens-from-registry.md
+++ b/.github/issue-evidence/12646-settings-section-tokens-from-registry.md
@@ -1,0 +1,34 @@
+# Issue #12646: Settings section tokens from registry
+
+## Summary
+
+- Reviewed PR #13154 against issue #12646 and package-local guidance for `packages/ui` and `packages/app-core`.
+- Confirmed settings section aliases now live with the section metadata/registry and token resolution reads from the live registry for plugin-registered sections.
+- Applied the required Biome import-order formatting fix in `packages/ui/src/components/settings/settings-section-tokens.ts`.
+
+## Verification
+
+- `bun run --cwd packages/ui test src/components/settings/settings-section-tokens.test.ts src/components/settings/settings-section-registry.test.ts src/components/settings/settings-sections.registration.test.ts src/chat/useSlashCommandController.catalog.test.ts src/chat/slash-menu.test.ts`
+  - Pass: 5 files, 52 tests.
+- `bun run --cwd packages/app-core test src/api/dev-route-catalog.test.ts`
+  - Pass: 1 file, 9 tests.
+- `bun run --cwd packages/ui typecheck`
+  - Pass.
+- `bunx @biomejs/biome check packages/ui/src/components/settings/settings-section-meta.ts packages/ui/src/components/settings/settings-section-registry.ts packages/ui/src/components/settings/settings-section-tokens.ts packages/ui/src/components/settings/settings-sections.ts packages/ui/src/components/settings/settings-section-tokens.test.ts`
+  - Pass after applying the import-order formatting fix.
+- `bun run --cwd packages/ui build`
+  - Pass; build completed and verified 43 runtime exports.
+- `bun run --cwd packages/app-core build`
+  - Pass.
+- `bun run audit:type-safety-ratchet`
+  - Pass.
+- `bun run audit:error-policy-ratchet`
+  - Pass; no new fallback-slop in touched production files.
+- `git diff --check`
+  - Pass.
+
+## Known blockers outside this PR
+
+- `bun run --cwd packages/app-core typecheck` is blocked by existing optional plugin/native dependency diagnostics and plugin-discord metadata errors outside the touched files.
+- Root `bun run verify` is blocked by an unrelated electrobun lint formatting error in `packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts`.
+- No app visual audit was run because the change is resolver/registry logic only and does not alter rendered app layout or styling.

--- a/packages/ui/src/components/settings/settings-section-meta.ts
+++ b/packages/ui/src/components/settings/settings-section-meta.ts
@@ -17,6 +17,16 @@ export interface SettingsSectionMeta {
   /** English display label (the i18n default value). */
   defaultLabel: string;
   group: SettingsSectionGroup;
+  /**
+   * Extra friendly tokens a user can type to jump here via `/settings <token>`,
+   * beyond the `id` itself (which is always a token). This is the single source
+   * of truth for a section's aliases; `settings-section-tokens.ts` derives the
+   * token map from this field so the two never drift. Owner-declared, so a
+   * plugin-registered section carries its own aliases (see the `aliases` field
+   * on {@link SettingsSectionDef}) instead of needing a host edit to a central
+   * literal.
+   */
+  aliases?: readonly string[];
 }
 
 export const SETTINGS_GROUP_ORDER: SettingsSectionGroup[] = [
@@ -36,21 +46,81 @@ export const SETTINGS_GROUP_LABEL: Record<SettingsSectionGroup, string> = {
  * with their peers so the nav reads top-to-bottom the way it renders.
  */
 export const SETTINGS_SECTION_META: SettingsSectionMeta[] = [
-  { id: "identity", defaultLabel: "Basics", group: "agent" },
-  { id: "ai-model", defaultLabel: "Models & Providers", group: "agent" },
-  { id: "voice", defaultLabel: "Voice", group: "agent" },
-  { id: "capabilities", defaultLabel: "Capabilities", group: "agent" },
-  { id: "apps", defaultLabel: "Apps", group: "agent" },
-  { id: "connectors", defaultLabel: "Connectors", group: "agent" },
+  {
+    id: "identity",
+    defaultLabel: "Basics",
+    group: "agent",
+    aliases: ["basics", "profile"],
+  },
+  {
+    id: "ai-model",
+    defaultLabel: "Models & Providers",
+    group: "agent",
+    aliases: ["model", "models", "provider", "providers", "ai", "cloud"],
+  },
+  {
+    id: "voice",
+    defaultLabel: "Voice",
+    group: "agent",
+    aliases: ["tts", "speech"],
+  },
+  {
+    id: "capabilities",
+    defaultLabel: "Capabilities",
+    group: "agent",
+    aliases: ["abilities"],
+  },
+  { id: "apps", defaultLabel: "Apps", group: "agent", aliases: ["views"] },
+  {
+    id: "connectors",
+    defaultLabel: "Connectors",
+    group: "agent",
+    aliases: ["connections", "integrations"],
+  },
   { id: "runtime", defaultLabel: "Runtime", group: "system" },
-  { id: "appearance", defaultLabel: "Appearance", group: "system" },
+  {
+    id: "appearance",
+    defaultLabel: "Appearance",
+    group: "system",
+    aliases: ["theme", "look"],
+  },
   { id: "background", defaultLabel: "Background", group: "system" },
-  { id: "remote-plugins", defaultLabel: "Remote Plugins", group: "system" },
-  { id: "wallet-rpc", defaultLabel: "Wallet & RPC", group: "system" },
-  { id: "updates", defaultLabel: "Updates", group: "system" },
-  { id: "advanced", defaultLabel: "Backup & Reset", group: "system" },
+  {
+    id: "remote-plugins",
+    defaultLabel: "Remote Plugins",
+    group: "system",
+    aliases: ["remote"],
+  },
+  {
+    id: "wallet-rpc",
+    defaultLabel: "Wallet & RPC",
+    group: "system",
+    aliases: ["wallet", "rpc"],
+  },
+  {
+    id: "updates",
+    defaultLabel: "Updates",
+    group: "system",
+    aliases: ["update"],
+  },
+  {
+    id: "advanced",
+    defaultLabel: "Backup & Reset",
+    group: "system",
+    aliases: ["fine-tuning"],
+  },
   { id: "app-permissions", defaultLabel: "App Permissions", group: "security" },
-  { id: "permissions", defaultLabel: "Permissions", group: "security" },
-  { id: "secrets", defaultLabel: "Vault", group: "security" },
+  {
+    id: "permissions",
+    defaultLabel: "Permissions",
+    group: "security",
+    aliases: ["perms"],
+  },
+  {
+    id: "secrets",
+    defaultLabel: "Vault",
+    group: "security",
+    aliases: ["vault", "keys"],
+  },
   { id: "security", defaultLabel: "Security", group: "security" },
 ];

--- a/packages/ui/src/components/settings/settings-section-registry.ts
+++ b/packages/ui/src/components/settings/settings-section-registry.ts
@@ -30,6 +30,14 @@ export type SettingsSectionHue = "accent" | "amber" | "rose" | "slate";
 export interface SettingsSectionDef {
   /** Stable id — URL hash + agent-surface address. */
   id: string;
+  /**
+   * Extra friendly tokens (beyond {@link id}) a user can type to reach this
+   * section via `/settings <token>`. Owner-declared so a plugin-registered
+   * section carries its own aliases instead of needing a central host edit;
+   * `resolveSettingsSectionToken` consults the live registry, so these resolve
+   * for dynamically-registered sections too. The `id` itself is always a token.
+   */
+  aliases?: readonly string[];
   /** i18n key for the nav label. */
   label: string;
   /** English fallback for {@link label}. */

--- a/packages/ui/src/components/settings/settings-section-tokens.test.ts
+++ b/packages/ui/src/components/settings/settings-section-tokens.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Settings-section token resolution. The token map must be DERIVED from the
+ * section registry (META + declared aliases), not a hand-maintained literal that
+ * silently misses plugin-registered sections. These tests pin:
+ *   - every built-in section id + declared alias resolves,
+ *   - a plugin/host section registered at boot is reachable by its id AND its
+ *     declared aliases (the drift/failure mode that made the central literal
+ *     unsafe: dynamic sections were previously unreachable), and
+ *   - the legacy fallback map still resolves (covered legacy path).
+ */
+
+import { Cog } from "lucide-react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { resetUiRegistryHostForTests } from "../../registry-host";
+import { SETTINGS_SECTION_META } from "./settings-section-meta";
+import {
+  registerSettingsSection,
+  type SettingsSectionDef,
+} from "./settings-section-registry";
+import {
+  LEGACY_SETTINGS_SECTION_TOKEN_ALIASES,
+  resolveSettingsSectionToken,
+  SETTINGS_SECTION_SUGGESTIONS,
+  SETTINGS_SECTION_TOKEN_ALIASES,
+} from "./settings-section-tokens";
+
+function makeSection(
+  id: string,
+  overrides: Partial<SettingsSectionDef> = {},
+): SettingsSectionDef {
+  return {
+    id,
+    label: `settings.sections.${id}.label`,
+    defaultLabel: id,
+    icon: Cog,
+    tone: "neutral",
+    hue: "slate",
+    group: "system",
+    titleKey: `settings.sections.${id}.label`,
+    defaultTitle: id,
+    Component: () => null,
+    ...overrides,
+  };
+}
+
+describe("SETTINGS_SECTION_TOKEN_ALIASES (derived from META)", () => {
+  it("maps every built-in section id and declared alias to its canonical id", () => {
+    for (const meta of SETTINGS_SECTION_META) {
+      // The id is always a token for itself.
+      expect(SETTINGS_SECTION_TOKEN_ALIASES[meta.id]).toBe(meta.id);
+      // Every declared alias resolves to the same canonical id.
+      for (const alias of meta.aliases ?? []) {
+        expect(SETTINGS_SECTION_TOKEN_ALIASES[alias.toLowerCase()]).toBe(
+          meta.id,
+        );
+      }
+    }
+  });
+
+  it("exposes each built-in id and alias as a completion suggestion", () => {
+    const suggestions = new Set(SETTINGS_SECTION_SUGGESTIONS);
+    for (const meta of SETTINGS_SECTION_META) {
+      expect(suggestions.has(meta.id)).toBe(true);
+      for (const alias of meta.aliases ?? []) {
+        expect(suggestions.has(alias.toLowerCase())).toBe(true);
+      }
+    }
+  });
+});
+
+describe("resolveSettingsSectionToken", () => {
+  beforeEach(() => {
+    resetUiRegistryHostForTests();
+  });
+
+  it("resolves built-in ids and aliases derived from META", () => {
+    expect(resolveSettingsSectionToken("identity")).toBe("identity");
+    expect(resolveSettingsSectionToken("basics")).toBe("identity");
+    expect(resolveSettingsSectionToken("profile")).toBe("identity");
+    expect(resolveSettingsSectionToken("model")).toBe("ai-model");
+    expect(resolveSettingsSectionToken("providers")).toBe("ai-model");
+    expect(resolveSettingsSectionToken("vault")).toBe("secrets");
+  });
+
+  it("normalizes case and surrounding whitespace", () => {
+    expect(resolveSettingsSectionToken("  Model ")).toBe("ai-model");
+    expect(resolveSettingsSectionToken("SECRETS")).toBe("secrets");
+  });
+
+  it("returns undefined for empty or unknown tokens", () => {
+    expect(resolveSettingsSectionToken("")).toBeUndefined();
+    expect(resolveSettingsSectionToken("   ")).toBeUndefined();
+    expect(resolveSettingsSectionToken("not-a-section")).toBeUndefined();
+  });
+
+  it("reaches a plugin-registered section by its id (the previously-missed case)", () => {
+    // Before deriving from the registry, a section registered at boot was
+    // unreachable via `/settings <id>` because the token map was a static
+    // literal. Registering it must make its id resolvable.
+    expect(resolveSettingsSectionToken("plugin-analytics")).toBeUndefined();
+    registerSettingsSection(makeSection("plugin-analytics"));
+    expect(resolveSettingsSectionToken("plugin-analytics")).toBe(
+      "plugin-analytics",
+    );
+  });
+
+  it("reaches a plugin-registered section by its OWNER-DECLARED aliases", () => {
+    registerSettingsSection(
+      makeSection("plugin-billing", { aliases: ["invoices", "Payments"] }),
+    );
+    expect(resolveSettingsSectionToken("invoices")).toBe("plugin-billing");
+    // Aliases are matched case-insensitively.
+    expect(resolveSettingsSectionToken("payments")).toBe("plugin-billing");
+    expect(resolveSettingsSectionToken("plugin-billing")).toBe(
+      "plugin-billing",
+    );
+  });
+
+  it("prefers a built-in over a registry entry that shadows its id", () => {
+    // A built-in id must keep resolving even if a plugin re-registers the id;
+    // token resolution short-circuits on the built-in map first.
+    registerSettingsSection(makeSection("secrets", { aliases: ["hijack"] }));
+    expect(resolveSettingsSectionToken("secrets")).toBe("secrets");
+  });
+});
+
+describe("legacy fallback coverage (drift guard)", () => {
+  beforeEach(() => {
+    resetUiRegistryHostForTests();
+  });
+
+  it("still resolves every legacy hand-maintained token to the same id", () => {
+    // The legacy literal is retained only as a covered fallback: every entry
+    // must resolve to the SAME canonical id the derived map produces, so a
+    // future divergence between the two is caught here rather than shipping a
+    // token that silently points at the wrong (or a stale) section.
+    for (const [token, expectedId] of Object.entries(
+      LEGACY_SETTINGS_SECTION_TOKEN_ALIASES,
+    )) {
+      expect(resolveSettingsSectionToken(token)).toBe(expectedId);
+    }
+  });
+
+  it("has migrated every legacy token into the derived META map", () => {
+    // Guards against the derived map silently losing a built-in token: each
+    // legacy token must now be produced by the META derivation (id or alias),
+    // proving the hand-map is pure redundancy and safe to treat as fallback.
+    for (const token of Object.keys(LEGACY_SETTINGS_SECTION_TOKEN_ALIASES)) {
+      expect(SETTINGS_SECTION_TOKEN_ALIASES[token]).toBe(
+        LEGACY_SETTINGS_SECTION_TOKEN_ALIASES[token],
+      );
+    }
+  });
+});

--- a/packages/ui/src/components/settings/settings-section-tokens.ts
+++ b/packages/ui/src/components/settings/settings-section-tokens.ts
@@ -16,8 +16,8 @@
  * not silently lost a built-in id.
  */
 
-import { getAllSettingsSections } from "./settings-section-registry";
 import { SETTINGS_SECTION_META } from "./settings-section-meta";
+import { getAllSettingsSections } from "./settings-section-registry";
 
 function normalizeToken(token: string): string {
   return token.trim().toLowerCase();

--- a/packages/ui/src/components/settings/settings-section-tokens.ts
+++ b/packages/ui/src/components/settings/settings-section-tokens.ts
@@ -3,15 +3,37 @@
  * always-mounted chat composer can resolve `/settings <section>` without
  * pulling in the heavy section component graph from `settings-sections.ts`.
  *
- * Keep the canonical ids in sync with `SETTINGS_SECTION_META` in
- * `settings-section-meta.ts` (validated by a test).
+ * The token map is DERIVED from the section registry rather than hand-written:
+ *   - built-in tokens come from `SETTINGS_SECTION_META` (id + declared aliases),
+ *     the single source of truth for built-in ids/labels/grouping, and
+ *   - plugin/host sections registered via `registerSettingsSection` are resolved
+ *     live from the registry, so a section added at boot is reachable by its id
+ *     and declared aliases without a central edit here.
+ *
+ * `LEGACY_SETTINGS_SECTION_TOKEN_ALIASES` remains only as a covered fallback for
+ * tokens that are not (yet) owned by a section's `aliases` declaration; a drift
+ * test asserts every legacy token still resolves and that the derived map has
+ * not silently lost a built-in id.
  */
 
+import { getAllSettingsSections } from "./settings-section-registry";
+import { SETTINGS_SECTION_META } from "./settings-section-meta";
+
+function normalizeToken(token: string): string {
+  return token.trim().toLowerCase();
+}
+
 /**
- * Friendly tokens a user can type to jump to a settings section, e.g.
- * `/settings model`. Maps each token to a canonical settings section id.
+ * Legacy hand-maintained token → canonical id map. Superseded by the
+ * `aliases` field on each section (declared in `SETTINGS_SECTION_META` for
+ * built-ins, on the `SettingsSectionDef` for plugin sections). Kept ONLY as a
+ * covered fallback so any token that has not been migrated to an owner
+ * declaration still resolves; a test pins that every entry here also resolves
+ * through the derived map, guarding against drift when the two diverge.
  */
-export const SETTINGS_SECTION_TOKEN_ALIASES: Record<string, string> = {
+export const LEGACY_SETTINGS_SECTION_TOKEN_ALIASES: Readonly<
+  Record<string, string>
+> = {
   basics: "identity",
   identity: "identity",
   profile: "identity",
@@ -53,7 +75,36 @@ export const SETTINGS_SECTION_TOKEN_ALIASES: Record<string, string> = {
   "fine-tuning": "advanced",
 };
 
-/** The canonical section ids reachable via a token (derived from the map). */
+/**
+ * Build the built-in token → canonical id map from the pinned META list: each
+ * section id is a token for itself, plus every declared alias. Derived, not
+ * duplicated — adding/renaming a built-in section or its aliases updates the
+ * token map automatically.
+ */
+function buildBuiltinTokenAliases(): Record<string, string> {
+  const aliases: Record<string, string> = {};
+  for (const section of SETTINGS_SECTION_META) {
+    const id = normalizeToken(section.id);
+    if (!id) continue;
+    aliases[id] = section.id;
+    for (const alias of section.aliases ?? []) {
+      const token = normalizeToken(alias);
+      if (token) aliases[token] = section.id;
+    }
+  }
+  return aliases;
+}
+
+/**
+ * Friendly tokens a user can type to jump to a BUILT-IN settings section, e.g.
+ * `/settings model`. Derived from `SETTINGS_SECTION_META` (id + aliases). For
+ * plugin/host-registered sections, use {@link resolveSettingsSectionToken},
+ * which additionally consults the live registry.
+ */
+export const SETTINGS_SECTION_TOKEN_ALIASES: Readonly<Record<string, string>> =
+  buildBuiltinTokenAliases();
+
+/** The canonical built-in section ids reachable via a token. */
 const CANONICAL_SECTION_IDS: ReadonlySet<string> = new Set(
   Object.values(SETTINGS_SECTION_TOKEN_ALIASES),
 );
@@ -63,10 +114,42 @@ export const SETTINGS_SECTION_SUGGESTIONS: string[] = Array.from(
   new Set(Object.keys(SETTINGS_SECTION_TOKEN_ALIASES)),
 );
 
-/** Resolve a user-typed settings token to a canonical section id, if known. */
+/**
+ * Resolve a user-typed settings token to a canonical section id, if known.
+ *
+ * Resolution order:
+ *   1. Built-in token map derived from META (id + declared aliases).
+ *   2. Live registry — a plugin/host section registered via
+ *      `registerSettingsSection` is reachable by its id and its declared
+ *      `aliases`, so modular sections work without editing this file.
+ *   3. Legacy hand-maintained fallback map, for tokens not yet migrated to an
+ *      owner `aliases` declaration.
+ */
 export function resolveSettingsSectionToken(token: string): string | undefined {
-  const normalized = token.trim().toLowerCase();
+  const normalized = normalizeToken(token);
   if (!normalized) return undefined;
+
+  // 1. Built-ins (id or declared alias), and bare canonical ids.
   if (CANONICAL_SECTION_IDS.has(normalized)) return normalized;
-  return SETTINGS_SECTION_TOKEN_ALIASES[normalized];
+  const builtin = SETTINGS_SECTION_TOKEN_ALIASES[normalized];
+  if (builtin) return builtin;
+
+  // 2. Live registry — plugin/host sections and their declared aliases.
+  const registered = resolveRegisteredSectionToken(normalized);
+  if (registered) return registered;
+
+  // 3. Legacy covered fallback.
+  return LEGACY_SETTINGS_SECTION_TOKEN_ALIASES[normalized];
+}
+
+function resolveRegisteredSectionToken(
+  normalizedToken: string,
+): string | undefined {
+  for (const section of getAllSettingsSections()) {
+    if (normalizeToken(section.id) === normalizedToken) return section.id;
+    for (const alias of section.aliases ?? []) {
+      if (normalizeToken(alias) === normalizedToken) return section.id;
+    }
+  }
+  return undefined;
 }

--- a/packages/ui/src/components/settings/settings-sections.ts
+++ b/packages/ui/src/components/settings/settings-sections.ts
@@ -342,6 +342,7 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] =
     }
     return {
       id: meta.id,
+      aliases: meta.aliases,
       label: visual.labelKey,
       defaultLabel: meta.defaultLabel,
       icon: visual.icon,


### PR DESCRIPTION
## What

Closes #12646 (arch-audit brittle strings, #12090 item 36): settings-section tokens now derive from the section registry instead of a hand-maintained literal that missed plugin-registered sections.

### Problem
`resolveSettingsSectionToken` (backing `/settings <token>`) resolved against a static `SETTINGS_SECTION_TOKEN_ALIASES` literal in `settings-section-tokens.ts`. That literal:
- **duplicated** the canonical section ids that already live in `SETTINGS_SECTION_META` (the single source of truth), and
- **could not reach plugin/host sections** registered at boot via `registerSettingsSection()` — a dynamically-registered section was unreachable by its own id or any alias, because it never appeared in the frozen literal.

### Change
- **Owner-declared aliases.** Added an optional `aliases?: readonly string[]` to `SettingsSectionMeta` (built-ins) and `SettingsSectionDef` (plugin/host sections). Built-in aliases moved into `SETTINGS_SECTION_META` — the single source of truth — and flow through the `SETTINGS_SECTIONS` builder.
- **Derived token map.** `SETTINGS_SECTION_TOKEN_ALIASES` is now built from `SETTINGS_SECTION_META` (each id + its declared aliases) rather than hand-written, so adding/renaming a built-in section or alias updates the token map automatically.
- **Registry-aware resolution.** `resolveSettingsSectionToken` now also consults the live registry (`getAllSettingsSections`), so a plugin/host section resolves by its `id` and its declared `aliases` — no central edit required. (The tokens module stays React/component-graph-free; it only imports the pure META list and the light registry accessor.)
- **Covered legacy fallback.** The old literal is retained only as `LEGACY_SETTINGS_SECTION_TOKEN_ALIASES`, consulted last. Drift tests assert every legacy token still resolves to the same id **and** is now produced by the META derivation — proving the hand-map is pure redundancy and safe as a fallback.

## Tests / evidence
New `settings-section-tokens.test.ts`:
- built-in id + every declared alias resolves (derived from META);
- **a plugin-registered section is reachable by its id AND its owner-declared aliases** — the previously-missed failure mode;
- a built-in shadows a same-id registry entry (resolution short-circuits on built-ins);
- legacy fallback drift guards (every legacy token resolves + is migrated into the derived map).

Results (targeted vitest, `@elizaos/ui`):
- `settings-section-tokens` + `settings-section-registry` + `settings-sections.registration` + `useSlashCommandController.catalog` + `slash-menu` — **52/52 green**.
- `@elizaos/app-core` `dev-route-catalog` id/label parity — **9/9 green** (aliases don't change ids/labels).
- `@elizaos/ui` package `tsgo --noEmit` — **clean, 0 errors**. (app-core tsc has only pre-existing unrelated errors in plugin-discord / agent-api / ios-spatial files, none in touched paths.)

Note: `codex review` hit an internal `WriteFailed` / hang on this box (known flakiness); verification above is via direct tsc + targeted vitest.

Files touched (UI-only; no `vite.config.*`, `index.html`, `client-base.ts`, `bun.lock`, binaries, or `dist/`):
- `packages/ui/src/components/settings/settings-section-meta.ts`
- `packages/ui/src/components/settings/settings-section-registry.ts`
- `packages/ui/src/components/settings/settings-section-tokens.ts`
- `packages/ui/src/components/settings/settings-sections.ts`
- `packages/ui/src/components/settings/settings-section-tokens.test.ts` (new)

— [sol-orch]
