### PR TITLE
fix(#12491): add meeting corpus importer contracts

### DIFF
--- a/.github/issue-evidence/12491-meeting-corpus-importers.md
+++ b/.github/issue-evidence/12491-meeting-corpus-importers.md
@@ -1,0 +1,76 @@
+# #12491 Meeting Corpus Importers Evidence
+
+Branch: `fix/12491-meeting-corpus-importers`
+Code PR: #13155
+Human evidence follow-up: #13156
+
+## What Was Proven
+
+- Added a self-contained `packages/benchmarks/meeting-corpus-importers`
+  package for license-gated meeting corpus importer contracts.
+- Added P0 registry entries for:
+  - AMI Meeting Corpus;
+  - CHiME-6;
+  - CHiME-7 DASR;
+  - DiPCo;
+  - LibriCSS;
+  - VoxConverse;
+  - DIHARD;
+  - MUSAN;
+  - WHAM!/WHAMR!;
+  - LibriMix / Libri2Mix / Libri3Mix.
+- Added P1 registry entries for AISHELL-4, AliMeeting, ICSI, MISP 2025,
+  AVA-ActiveSpeaker, and EasyCom.
+- Each corpus spec carries license/citation metadata, required local cache paths,
+  annotation coverage, and supported metrics.
+- `build_cache_manifest()` discovers local cache folders deterministically and
+  marks unavailable corpora as `status: "missing"` / `canRun: false`.
+- `load_fixture_references()` and `parse_fixture_reference()` parse synthetic
+  legal fixtures into transcript, speaker-turn, source-stream, RTTM, coverage,
+  and metric metadata.
+- Added one synthetic fixture per P0 corpus to validate parser behavior without
+  downloading or committing licensed audio bytes.
+- Added docs and local agent guide; package is intentionally not orchestrator
+  registered yet.
+
+## Verification
+
+```bash
+python -m pytest tests -q
+```
+
+Result:
+
+```text
+7 passed in 0.02s
+```
+
+```bash
+python -m compileall -q elizaos_meeting_corpus_importers tests
+```
+
+Result: passed.
+
+Manual parser/manifest inspection:
+
+```text
+reference_count: 10
+corpora: ami, chime6, chime7_dasr, dihard, dipco, libricss, librimix, musan, voxconverse, whamr
+first_rttm: SPEAKER ami-synth-001 1 0.000 1.000 <NA> <NA> ami-a <NA> <NA>
+manifest_schema: eliza.meeting_corpus_manifest.v1
+missing_count: 10
+can_run_any: False
+```
+
+## Evidence Rows
+
+- Dataset manifest examples: `fixtures/synthetic_p0_fixtures.json`.
+- License/citation manifest: encoded in each `CorpusSpec` and parsed reference.
+- Importer unit/integration output: `python -m pytest tests -q` passed.
+- One parsed reference artifact per enabled P0 corpus: covered by
+  `test_synthetic_fixture_file_parses_one_reference_per_p0_corpus`.
+- Real model run over a small subset with reviewed WER/DER/cpWER metrics:
+  N/A for this code-only importer contract; requires local licensed corpora,
+  model artifacts, and human review of outputs.
+- Real corpus downloads: N/A - package intentionally does not download or vendor
+  licensed corpora.

--- a/.github/issue-evidence/12491-meeting-corpus-importers.md
+++ b/.github/issue-evidence/12491-meeting-corpus-importers.md
@@ -42,7 +42,7 @@ python -m pytest tests -q
 Result:
 
 ```text
-7 passed in 0.02s
+7 passed in 0.17s
 ```
 
 ```bash
@@ -60,7 +60,29 @@ first_rttm: SPEAKER ami-synth-001 1 0.000 1.000 <NA> <NA> ami-a <NA> <NA>
 manifest_schema: eliza.meeting_corpus_manifest.v1
 missing_count: 10
 can_run_any: False
+licenses_present: True
+metrics_present: True
 ```
+
+## Repo-Level Checks
+
+```bash
+bun run audit:type-safety-ratchet
+bun run audit:error-policy-ratchet
+git diff --check
+```
+
+Result: passed. The error-policy ratchet reported `0 changed production source
+file(s)` for this Python benchmark package.
+
+```bash
+bun run verify
+```
+
+Result: blocked after the CLAUDE/AGENTS check and both ratchets passed. Turbo
+stopped on unrelated current-baseline `@elizaos/electrobun#lint` diagnostics.
+The same run replayed unrelated `@elizaos/tui#lint` diagnostics around Node
+protocol imports, non-null assertions, and control-character regexes.
 
 ## Evidence Rows
 

--- a/packages/benchmarks/meeting-corpus-importers/AGENTS.md
+++ b/packages/benchmarks/meeting-corpus-importers/AGENTS.md
@@ -1,0 +1,27 @@
+# Meeting Corpus Importers — Agent Guide
+
+Self-contained #12491 importer contract package. Not registered in the benchmark
+orchestrator; run directly with pytest.
+
+## Run
+
+```bash
+python -m pytest tests -q
+```
+
+## Layout
+
+| Path | Role |
+| --- | --- |
+| `elizaos_meeting_corpus_importers/corpora.py` | Corpus registry, cache discovery, fixture parser, RTTM emitter |
+| `fixtures/synthetic_p0_fixtures.json` | Legal synthetic annotations for every P0 corpus id |
+| `tests/test_corpus_importers.py` | Registry, missing-cache, parser, RTTM, and manifest tests |
+
+## Notes
+
+- This package never downloads or vendors real corpora.
+- Missing local cache paths return `status: "missing"` and `canRun: false`;
+  missing corpora must never count as a pass.
+- Fixture annotations are synthetic and exist only to validate parser behavior
+  without licensed audio bytes.
+- Real model runs and reviewed media artifacts belong in the human evidence lane.

--- a/packages/benchmarks/meeting-corpus-importers/CLAUDE.md
+++ b/packages/benchmarks/meeting-corpus-importers/CLAUDE.md
@@ -1,0 +1,27 @@
+# Meeting Corpus Importers — Agent Guide
+
+Self-contained #12491 importer contract package. Not registered in the benchmark
+orchestrator; run directly with pytest.
+
+## Run
+
+```bash
+python -m pytest tests -q
+```
+
+## Layout
+
+| Path | Role |
+| --- | --- |
+| `elizaos_meeting_corpus_importers/corpora.py` | Corpus registry, cache discovery, fixture parser, RTTM emitter |
+| `fixtures/synthetic_p0_fixtures.json` | Legal synthetic annotations for every P0 corpus id |
+| `tests/test_corpus_importers.py` | Registry, missing-cache, parser, RTTM, and manifest tests |
+
+## Notes
+
+- This package never downloads or vendors real corpora.
+- Missing local cache paths return `status: "missing"` and `canRun: false`;
+  missing corpora must never count as a pass.
+- Fixture annotations are synthetic and exist only to validate parser behavior
+  without licensed audio bytes.
+- Real model runs and reviewed media artifacts belong in the human evidence lane.

--- a/packages/benchmarks/meeting-corpus-importers/README.md
+++ b/packages/benchmarks/meeting-corpus-importers/README.md
@@ -1,0 +1,24 @@
+# Meeting Corpus Importers
+
+License-gated importer contracts for #12491. The package does not download or
+bundle real corpora. It discovers local cache folders, reports missing corpora
+honestly, and parses small synthetic fixture annotations that exercise the same
+manifest shape expected from real AMI, CHiME/DiPCo, LibriCSS, VoxConverse,
+DIHARD, MUSAN, WHAMR, and LibriMix imports.
+
+## Run
+
+```bash
+python -m pytest tests -q
+```
+
+## Scope
+
+- P0 corpus registry with license/citation metadata.
+- Deterministic local-cache manifest generation.
+- Fixture parser that emits transcript, speaker-turn, source-stream, RTTM, and
+  annotation-coverage data.
+- Honest skip/missing status for unavailable licensed corpora.
+
+Real corpus downloads, terms review, and live model runs are human-gated and
+tracked outside this code-only package.

--- a/packages/benchmarks/meeting-corpus-importers/elizaos_meeting_corpus_importers/__init__.py
+++ b/packages/benchmarks/meeting-corpus-importers/elizaos_meeting_corpus_importers/__init__.py
@@ -1,0 +1,21 @@
+from .corpora import (
+    P0_CORPUS_IDS,
+    P1_CORPUS_IDS,
+    CorpusSpec,
+    build_cache_manifest,
+    load_fixture_references,
+    parse_fixture_reference,
+    reference_to_rttm,
+    registry,
+)
+
+__all__ = [
+    "P0_CORPUS_IDS",
+    "P1_CORPUS_IDS",
+    "CorpusSpec",
+    "build_cache_manifest",
+    "load_fixture_references",
+    "parse_fixture_reference",
+    "reference_to_rttm",
+    "registry",
+]

--- a/packages/benchmarks/meeting-corpus-importers/elizaos_meeting_corpus_importers/corpora.py
+++ b/packages/benchmarks/meeting-corpus-importers/elizaos_meeting_corpus_importers/corpora.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+REFERENCE_SCHEMA = "eliza.meeting_corpus_reference.v1"
+MANIFEST_SCHEMA = "eliza.meeting_corpus_manifest.v1"
+
+
+@dataclass(frozen=True)
+class CorpusSpec:
+    corpus_id: str
+    name: str
+    priority: str
+    license: str
+    citation: str
+    required_paths: tuple[str, ...]
+    annotation_coverage: dict[str, bool]
+    metrics_supported: tuple[str, ...]
+
+
+def _coverage(
+    *,
+    transcript: bool = False,
+    word_timestamps: bool = False,
+    speaker_turns: bool = False,
+    overlap_labels: bool = False,
+    channels: bool = False,
+    video_frames: bool = False,
+    noise_music: bool = False,
+) -> dict[str, bool]:
+    return {
+        "transcript": transcript,
+        "wordTimestamps": word_timestamps,
+        "speakerTurns": speaker_turns,
+        "overlapLabels": overlap_labels,
+        "channels": channels,
+        "videoFrames": video_frames,
+        "noiseMusic": noise_music,
+    }
+
+
+P0_CORPUS_IDS = (
+    "ami",
+    "chime6",
+    "chime7_dasr",
+    "dipco",
+    "libricss",
+    "voxconverse",
+    "dihard",
+    "musan",
+    "whamr",
+    "librimix",
+)
+
+P1_CORPUS_IDS = ("aishell4", "alimeeting", "icsi", "misp2025", "ava_active_speaker", "easycom")
+
+
+_REGISTRY: dict[str, CorpusSpec] = {
+    "ami": CorpusSpec(
+        "ami",
+        "AMI Meeting Corpus",
+        "P0",
+        "AMI license / local acceptance required",
+        "Carletta et al., The AMI Meeting Corpus",
+        ("audio", "annotations/segments.json"),
+        _coverage(transcript=True, word_timestamps=True, speaker_turns=True, channels=True),
+        ("WER", "DER", "JER", "cpWER", "WDER"),
+    ),
+    "chime6": CorpusSpec(
+        "chime6",
+        "CHiME-6",
+        "P0",
+        "CHiME data license / local acceptance required",
+        "CHiME-6 challenge corpus",
+        ("audio", "transcriptions"),
+        _coverage(transcript=True, speaker_turns=True, overlap_labels=True, channels=True),
+        ("WER", "DER", "JER", "cpWER", "WDER", "overlapDER"),
+    ),
+    "chime7_dasr": CorpusSpec(
+        "chime7_dasr",
+        "CHiME-7 DASR",
+        "P0",
+        "CHiME data license / local acceptance required",
+        "CHiME-7 DASR challenge corpus",
+        ("audio", "annotations"),
+        _coverage(transcript=True, speaker_turns=True, overlap_labels=True, channels=True),
+        ("WER", "DER", "JER", "cpWER", "WDER", "overlapDER"),
+    ),
+    "dipco": CorpusSpec(
+        "dipco",
+        "DiPCo",
+        "P0",
+        "DiPCo license / local acceptance required",
+        "Dinner Party Corpus",
+        ("audio", "annotations"),
+        _coverage(transcript=True, speaker_turns=True, overlap_labels=True, channels=True),
+        ("WER", "DER", "JER", "cpWER", "WDER", "overlapDER"),
+    ),
+    "libricss": CorpusSpec(
+        "libricss",
+        "LibriCSS",
+        "P0",
+        "LibriCSS license / local acceptance required",
+        "LibriCSS overlapped speech corpus",
+        ("audio", "rttm"),
+        _coverage(transcript=True, speaker_turns=True, overlap_labels=True, channels=True),
+        ("WER", "DER", "JER", "cpWER", "WDER", "overlapDER"),
+    ),
+    "voxconverse": CorpusSpec(
+        "voxconverse",
+        "VoxConverse",
+        "P0",
+        "VoxConverse license / local acceptance required",
+        "VoxConverse speaker diarization corpus",
+        ("audio", "rttm"),
+        _coverage(speaker_turns=True, overlap_labels=True),
+        ("DER", "JER", "overlapDER"),
+    ),
+    "dihard": CorpusSpec(
+        "dihard",
+        "DIHARD",
+        "P0",
+        "DIHARD license / local acceptance required",
+        "DIHARD diarization challenge corpus",
+        ("audio", "rttm"),
+        _coverage(speaker_turns=True, overlap_labels=True, channels=True),
+        ("DER", "JER", "overlapDER"),
+    ),
+    "musan": CorpusSpec(
+        "musan",
+        "MUSAN",
+        "P0",
+        "MUSAN license / local acceptance required",
+        "MUSAN music, speech, and noise corpus",
+        ("music", "noise", "speech"),
+        _coverage(noise_music=True),
+        ("noiseCoverage", "snr"),
+    ),
+    "whamr": CorpusSpec(
+        "whamr",
+        "WHAM!/WHAMR!",
+        "P0",
+        "WHAMR license / local acceptance required",
+        "WHAMR noisy reverberant speech separation corpus",
+        ("audio", "metadata"),
+        _coverage(transcript=True, speaker_turns=True, overlap_labels=True),
+        ("WER", "DER", "cpWER", "WDER", "reverbStress"),
+    ),
+    "librimix": CorpusSpec(
+        "librimix",
+        "LibriMix / Libri2Mix / Libri3Mix",
+        "P0",
+        "LibriMix license / local acceptance required",
+        "LibriMix multi-speaker mixture corpus",
+        ("audio", "metadata"),
+        _coverage(transcript=True, speaker_turns=True, overlap_labels=True),
+        ("WER", "DER", "cpWER", "WDER", "overlapDER"),
+    ),
+    "aishell4": CorpusSpec(
+        "aishell4",
+        "AISHELL-4",
+        "P1",
+        "AISHELL-4 license / local acceptance required",
+        "AISHELL-4 Mandarin meeting corpus",
+        ("audio", "transcripts"),
+        _coverage(transcript=True, speaker_turns=True, channels=True),
+        ("WER", "CER", "DER", "JER"),
+    ),
+    "alimeeting": CorpusSpec(
+        "alimeeting",
+        "AliMeeting",
+        "P1",
+        "AliMeeting license / local acceptance required",
+        "AliMeeting Mandarin meeting corpus",
+        ("audio", "transcripts"),
+        _coverage(transcript=True, speaker_turns=True, overlap_labels=True),
+        ("WER", "CER", "DER", "JER", "cpWER"),
+    ),
+    "icsi": CorpusSpec(
+        "icsi",
+        "ICSI Meeting Corpus",
+        "P1",
+        "ICSI license / local acceptance required",
+        "ICSI Meeting Corpus",
+        ("audio", "annotations"),
+        _coverage(transcript=True, speaker_turns=True, channels=True),
+        ("WER", "DER", "JER", "cpWER"),
+    ),
+    "misp2025": CorpusSpec(
+        "misp2025",
+        "MISP 2025",
+        "P1",
+        "MISP terms / local acceptance required",
+        "MISP 2025 challenge corpus",
+        ("audio", "annotations"),
+        _coverage(transcript=True, speaker_turns=True, overlap_labels=True, video_frames=True),
+        ("WER", "CER", "DER", "activeSpeaker"),
+    ),
+    "ava_active_speaker": CorpusSpec(
+        "ava_active_speaker",
+        "AVA-ActiveSpeaker",
+        "P1",
+        "AVA terms / local acceptance required",
+        "AVA-ActiveSpeaker dataset",
+        ("video", "annotations"),
+        _coverage(speaker_turns=True, video_frames=True),
+        ("activeSpeaker",),
+    ),
+    "easycom": CorpusSpec(
+        "easycom",
+        "EasyCom",
+        "P1",
+        "EasyCom license / local acceptance required",
+        "EasyCom egocentric communication corpus",
+        ("audio", "video", "annotations"),
+        _coverage(transcript=True, speaker_turns=True, channels=True, video_frames=True),
+        ("WER", "DER", "activeSpeaker"),
+    ),
+}
+
+
+def registry() -> dict[str, CorpusSpec]:
+    return dict(_REGISTRY)
+
+
+def build_cache_manifest(
+    cache_root: Path | str,
+    corpus_ids: Iterable[str] = P0_CORPUS_IDS,
+) -> dict[str, Any]:
+    root = Path(cache_root)
+    entries = []
+    for corpus_id in corpus_ids:
+        spec = _REGISTRY[corpus_id]
+        missing_paths = [
+            relative for relative in spec.required_paths if not (root / corpus_id / relative).exists()
+        ]
+        status = "available" if not missing_paths else "missing"
+        entries.append(
+            {
+                "corpusId": corpus_id,
+                "name": spec.name,
+                "priority": spec.priority,
+                "status": status,
+                "canRun": status == "available",
+                "root": str(root / corpus_id),
+                "requiredPaths": list(spec.required_paths),
+                "missingPaths": missing_paths,
+                "license": spec.license,
+                "citation": spec.citation,
+                "annotationCoverage": spec.annotation_coverage,
+                "metricsSupported": list(spec.metrics_supported),
+            }
+        )
+    return {
+        "schemaVersion": MANIFEST_SCHEMA,
+        "cacheRoot": str(root),
+        "entries": entries,
+    }
+
+
+def load_fixture_references(path: Path | str) -> list[dict[str, Any]]:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    fixtures = data.get("fixtures")
+    if not isinstance(fixtures, list):
+        raise ValueError("fixture file must contain a fixtures array")
+    return [parse_fixture_reference(fixture) for fixture in fixtures]
+
+
+def parse_fixture_reference(raw: dict[str, Any]) -> dict[str, Any]:
+    corpus_id = _required_str(raw, "corpusId")
+    if corpus_id not in _REGISTRY:
+        raise ValueError(f"unknown corpusId: {corpus_id}")
+    spec = _REGISTRY[corpus_id]
+    recording_id = _required_str(raw, "recordingId")
+    license_value = _required_str(raw, "license")
+    citation = _required_str(raw, "citation")
+    audio = _required_dict(raw, "audio")
+    source_streams = _required_list(raw, "sourceStreams")
+    transcript = _required_list(raw, "transcript")
+    speaker_turns = _required_list(raw, "speakerTurns")
+    _validate_turns(speaker_turns, "speakerTurns")
+    _validate_turns(transcript, "transcript")
+    reference = {
+        "schemaVersion": REFERENCE_SCHEMA,
+        "corpusId": corpus_id,
+        "recordingId": recording_id,
+        "license": license_value,
+        "citation": citation,
+        "declaredLicense": spec.license,
+        "declaredCitation": spec.citation,
+        "audio": {
+            "uri": _required_str(audio, "uri"),
+            "durationMs": _required_int(audio, "durationMs"),
+            "sampleRateHz": _required_int(audio, "sampleRateHz"),
+            "channels": _required_int(audio, "channels"),
+        },
+        "sourceStreams": source_streams,
+        "transcript": transcript,
+        "speakerTurns": speaker_turns,
+        "rttm": reference_to_rttm(
+            {"recordingId": recording_id, "speakerTurns": speaker_turns}
+        ),
+        "annotationCoverage": spec.annotation_coverage,
+        "metricsSupported": list(spec.metrics_supported),
+        "metadata": raw.get("metadata", {}),
+    }
+    return reference
+
+
+def reference_to_rttm(reference: dict[str, Any]) -> str:
+    recording_id = _required_str(reference, "recordingId")
+    turns = _required_list(reference, "speakerTurns")
+    lines: list[str] = []
+    for turn in turns:
+        if not isinstance(turn, dict):
+            raise ValueError("speaker turn must be an object")
+        speaker_id = _required_str(turn, "speakerId")
+        start_ms = _required_int(turn, "startMs")
+        end_ms = _required_int(turn, "endMs")
+        if end_ms <= start_ms:
+            raise ValueError("speaker turn endMs must be greater than startMs")
+        start_s = start_ms / 1000
+        duration_s = (end_ms - start_ms) / 1000
+        lines.append(
+            f"SPEAKER {recording_id} 1 {start_s:.3f} {duration_s:.3f} <NA> <NA> {speaker_id} <NA> <NA>"
+        )
+    return "\n".join(lines)
+
+
+def specs_as_dicts(corpus_ids: Iterable[str] = P0_CORPUS_IDS) -> list[dict[str, Any]]:
+    return [asdict(_REGISTRY[corpus_id]) for corpus_id in corpus_ids]
+
+
+def _required_str(row: dict[str, Any], key: str) -> str:
+    value = row.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} is required")
+    return value
+
+
+def _required_int(row: dict[str, Any], key: str) -> int:
+    value = row.get(key)
+    if not isinstance(value, int) or value < 0:
+        raise ValueError(f"{key} must be a non-negative integer")
+    return value
+
+
+def _required_dict(row: dict[str, Any], key: str) -> dict[str, Any]:
+    value = row.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"{key} must be an object")
+    return value
+
+
+def _required_list(row: dict[str, Any], key: str) -> list[Any]:
+    value = row.get(key)
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{key} must be a non-empty array")
+    return value
+
+
+def _validate_turns(turns: list[Any], key: str) -> None:
+    for index, turn in enumerate(turns):
+        if not isinstance(turn, dict):
+            raise ValueError(f"{key}[{index}] must be an object")
+        _required_str(turn, "speakerId")
+        start_ms = _required_int(turn, "startMs")
+        end_ms = _required_int(turn, "endMs")
+        if end_ms <= start_ms:
+            raise ValueError(f"{key}[{index}].endMs must be greater than startMs")

--- a/packages/benchmarks/meeting-corpus-importers/fixtures/synthetic_p0_fixtures.json
+++ b/packages/benchmarks/meeting-corpus-importers/fixtures/synthetic_p0_fixtures.json
@@ -1,0 +1,125 @@
+{
+  "fixtures": [
+    {
+      "corpusId": "ami",
+      "recordingId": "ami-synth-001",
+      "license": "synthetic-fixture-only",
+      "citation": "Synthetic fixture exercising AMI parser shape",
+      "audio": { "uri": "fixtures/ami-synth-001.wav", "durationMs": 2200, "sampleRateHz": 16000, "channels": 1 },
+      "sourceStreams": [{ "id": "mix", "kind": "room_mic", "channel": 1 }],
+      "speakerTurns": [
+        { "speakerId": "ami-a", "startMs": 0, "endMs": 1000 },
+        { "speakerId": "ami-b", "startMs": 900, "endMs": 2200 }
+      ],
+      "transcript": [
+        { "speakerId": "ami-a", "startMs": 0, "endMs": 1000, "text": "project update", "words": [{ "text": "project", "startMs": 0, "endMs": 450 }] },
+        { "speakerId": "ami-b", "startMs": 900, "endMs": 2200, "text": "overlap response", "words": [{ "text": "overlap", "startMs": 900, "endMs": 1400 }] }
+      ],
+      "metadata": { "language": "en", "overlapRatio": 0.1 }
+    },
+    {
+      "corpusId": "chime6",
+      "recordingId": "chime6-synth-001",
+      "license": "synthetic-fixture-only",
+      "citation": "Synthetic fixture exercising CHiME-6 parser shape",
+      "audio": { "uri": "fixtures/chime6-synth-001.wav", "durationMs": 1800, "sampleRateHz": 16000, "channels": 6 },
+      "sourceStreams": [{ "id": "array", "kind": "array_mic", "channel": 1 }],
+      "speakerTurns": [{ "speakerId": "chime-a", "startMs": 0, "endMs": 1800 }],
+      "transcript": [{ "speakerId": "chime-a", "startMs": 0, "endMs": 1800, "text": "distant kitchen speech", "words": [{ "text": "distant", "startMs": 0, "endMs": 500 }] }],
+      "metadata": { "room": "kitchen" }
+    },
+    {
+      "corpusId": "chime7_dasr",
+      "recordingId": "chime7-synth-001",
+      "license": "synthetic-fixture-only",
+      "citation": "Synthetic fixture exercising CHiME-7 DASR parser shape",
+      "audio": { "uri": "fixtures/chime7-synth-001.wav", "durationMs": 1600, "sampleRateHz": 16000, "channels": 4 },
+      "sourceStreams": [{ "id": "dasr", "kind": "array_mic", "channel": 1 }],
+      "speakerTurns": [{ "speakerId": "dasr-a", "startMs": 0, "endMs": 1600 }],
+      "transcript": [{ "speakerId": "dasr-a", "startMs": 0, "endMs": 1600, "text": "distributed asr", "words": [{ "text": "distributed", "startMs": 0, "endMs": 700 }] }]
+    },
+    {
+      "corpusId": "dipco",
+      "recordingId": "dipco-synth-001",
+      "license": "synthetic-fixture-only",
+      "citation": "Synthetic fixture exercising DiPCo parser shape",
+      "audio": { "uri": "fixtures/dipco-synth-001.wav", "durationMs": 1700, "sampleRateHz": 16000, "channels": 5 },
+      "sourceStreams": [{ "id": "dinner-array", "kind": "array_mic", "channel": 1 }],
+      "speakerTurns": [{ "speakerId": "dipco-a", "startMs": 0, "endMs": 1700 }],
+      "transcript": [{ "speakerId": "dipco-a", "startMs": 0, "endMs": 1700, "text": "dinner party turn", "words": [{ "text": "dinner", "startMs": 0, "endMs": 500 }] }]
+    },
+    {
+      "corpusId": "libricss",
+      "recordingId": "libricss-synth-001",
+      "license": "synthetic-fixture-only",
+      "citation": "Synthetic fixture exercising LibriCSS parser shape",
+      "audio": { "uri": "fixtures/libricss-synth-001.wav", "durationMs": 2000, "sampleRateHz": 16000, "channels": 7 },
+      "sourceStreams": [{ "id": "css-array", "kind": "array_mic", "channel": 1 }],
+      "speakerTurns": [
+        { "speakerId": "css-a", "startMs": 0, "endMs": 1200 },
+        { "speakerId": "css-b", "startMs": 800, "endMs": 2000 }
+      ],
+      "transcript": [{ "speakerId": "css-a", "startMs": 0, "endMs": 1200, "text": "overlapped read speech", "words": [{ "text": "overlapped", "startMs": 0, "endMs": 600 }] }]
+    },
+    {
+      "corpusId": "voxconverse",
+      "recordingId": "voxconverse-synth-001",
+      "license": "synthetic-fixture-only",
+      "citation": "Synthetic fixture exercising VoxConverse parser shape",
+      "audio": { "uri": "fixtures/voxconverse-synth-001.wav", "durationMs": 2100, "sampleRateHz": 16000, "channels": 1 },
+      "sourceStreams": [{ "id": "web-audio", "kind": "recording", "channel": 1 }],
+      "speakerTurns": [
+        { "speakerId": "vox-a", "startMs": 0, "endMs": 900 },
+        { "speakerId": "vox-b", "startMs": 1000, "endMs": 2100 }
+      ],
+      "transcript": [{ "speakerId": "vox-a", "startMs": 0, "endMs": 900, "text": "speaker diarization only", "words": [{ "text": "speaker", "startMs": 0, "endMs": 400 }] }]
+    },
+    {
+      "corpusId": "dihard",
+      "recordingId": "dihard-synth-001",
+      "license": "synthetic-fixture-only",
+      "citation": "Synthetic fixture exercising DIHARD parser shape",
+      "audio": { "uri": "fixtures/dihard-synth-001.wav", "durationMs": 1300, "sampleRateHz": 16000, "channels": 2 },
+      "sourceStreams": [{ "id": "hard-audio", "kind": "wild_audio", "channel": 1 }],
+      "speakerTurns": [{ "speakerId": "dihard-a", "startMs": 0, "endMs": 1300 }],
+      "transcript": [{ "speakerId": "dihard-a", "startMs": 0, "endMs": 1300, "text": "hard diarization", "words": [{ "text": "hard", "startMs": 0, "endMs": 500 }] }]
+    },
+    {
+      "corpusId": "musan",
+      "recordingId": "musan-synth-001",
+      "license": "synthetic-fixture-only",
+      "citation": "Synthetic fixture exercising MUSAN parser shape",
+      "audio": { "uri": "fixtures/musan-noise.wav", "durationMs": 1000, "sampleRateHz": 16000, "channels": 1 },
+      "sourceStreams": [{ "id": "noise", "kind": "noise_music", "channel": 1 }],
+      "speakerTurns": [{ "speakerId": "noise", "startMs": 0, "endMs": 1000 }],
+      "transcript": [{ "speakerId": "noise", "startMs": 0, "endMs": 1000, "text": "noise bed", "words": [{ "text": "noise", "startMs": 0, "endMs": 500 }] }],
+      "metadata": { "augmentationOnly": true }
+    },
+    {
+      "corpusId": "whamr",
+      "recordingId": "whamr-synth-001",
+      "license": "synthetic-fixture-only",
+      "citation": "Synthetic fixture exercising WHAMR parser shape",
+      "audio": { "uri": "fixtures/whamr-synth-001.wav", "durationMs": 2000, "sampleRateHz": 8000, "channels": 1 },
+      "sourceStreams": [{ "id": "reverb-mix", "kind": "reverberant_mix", "channel": 1 }],
+      "speakerTurns": [
+        { "speakerId": "wham-a", "startMs": 0, "endMs": 1500 },
+        { "speakerId": "wham-b", "startMs": 500, "endMs": 2000 }
+      ],
+      "transcript": [{ "speakerId": "wham-a", "startMs": 0, "endMs": 1500, "text": "noisy reverberant speech", "words": [{ "text": "noisy", "startMs": 0, "endMs": 400 }] }]
+    },
+    {
+      "corpusId": "librimix",
+      "recordingId": "librimix-synth-001",
+      "license": "synthetic-fixture-only",
+      "citation": "Synthetic fixture exercising LibriMix parser shape",
+      "audio": { "uri": "fixtures/librimix-synth-001.wav", "durationMs": 1900, "sampleRateHz": 16000, "channels": 1 },
+      "sourceStreams": [{ "id": "mix", "kind": "speaker_mix", "channel": 1 }],
+      "speakerTurns": [
+        { "speakerId": "mix-a", "startMs": 0, "endMs": 1200 },
+        { "speakerId": "mix-b", "startMs": 700, "endMs": 1900 }
+      ],
+      "transcript": [{ "speakerId": "mix-a", "startMs": 0, "endMs": 1200, "text": "two speaker mix", "words": [{ "text": "two", "startMs": 0, "endMs": 300 }] }]
+    }
+  ]
+}

--- a/packages/benchmarks/meeting-corpus-importers/pyproject.toml
+++ b/packages/benchmarks/meeting-corpus-importers/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "elizaos-meeting-corpus-importers"
+version = "0.1.0"
+description = "License-gated meeting corpus importer contracts for elizaOS"
+requires-python = ">=3.10"
+dependencies = ["pytest>=8.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]

--- a/packages/benchmarks/meeting-corpus-importers/tests/test_corpus_importers.py
+++ b/packages/benchmarks/meeting-corpus-importers/tests/test_corpus_importers.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from elizaos_meeting_corpus_importers import (
+    P0_CORPUS_IDS,
+    P1_CORPUS_IDS,
+    build_cache_manifest,
+    load_fixture_references,
+    parse_fixture_reference,
+    reference_to_rttm,
+    registry,
+)
+
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "synthetic_p0_fixtures.json"
+
+
+def test_registry_covers_required_p0_and_p1_corpora():
+    specs = registry()
+
+    assert set(P0_CORPUS_IDS) <= set(specs)
+    assert set(P1_CORPUS_IDS) <= set(specs)
+    assert set(P0_CORPUS_IDS) == {
+        "ami",
+        "chime6",
+        "chime7_dasr",
+        "dipco",
+        "libricss",
+        "voxconverse",
+        "dihard",
+        "musan",
+        "whamr",
+        "librimix",
+    }
+    for corpus_id in P0_CORPUS_IDS:
+        spec = specs[corpus_id]
+        assert spec.license
+        assert spec.citation
+        assert spec.required_paths
+        assert spec.metrics_supported
+
+
+def test_missing_local_corpora_fail_honestly(tmp_path: Path):
+    manifest = build_cache_manifest(tmp_path)
+
+    assert manifest["schemaVersion"] == "eliza.meeting_corpus_manifest.v1"
+    assert len(manifest["entries"]) == len(P0_CORPUS_IDS)
+    assert {entry["status"] for entry in manifest["entries"]} == {"missing"}
+    assert all(entry["canRun"] is False for entry in manifest["entries"])
+    assert all(entry["missingPaths"] for entry in manifest["entries"])
+
+
+def test_available_cache_manifest_is_deterministic(tmp_path: Path):
+    for corpus_id, spec in registry().items():
+        if corpus_id not in P0_CORPUS_IDS:
+            continue
+        for relative in spec.required_paths:
+            path = tmp_path / corpus_id / relative
+            if "." in Path(relative).name:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("fixture", encoding="utf-8")
+            else:
+                path.mkdir(parents=True, exist_ok=True)
+
+    first = build_cache_manifest(tmp_path)
+    second = build_cache_manifest(tmp_path)
+
+    assert first == second
+    assert {entry["status"] for entry in first["entries"]} == {"available"}
+    assert all(entry["canRun"] is True for entry in first["entries"])
+
+
+def test_synthetic_fixture_file_parses_one_reference_per_p0_corpus():
+    references = load_fixture_references(FIXTURES)
+
+    assert {reference["corpusId"] for reference in references} == set(P0_CORPUS_IDS)
+    for reference in references:
+        assert reference["schemaVersion"] == "eliza.meeting_corpus_reference.v1"
+        assert reference["license"] == "synthetic-fixture-only"
+        assert reference["citation"]
+        assert reference["audio"]["uri"].startswith("fixtures/")
+        assert reference["speakerTurns"]
+        assert reference["transcript"]
+        assert reference["rttm"].startswith(f"SPEAKER {reference['recordingId']}")
+        assert reference["annotationCoverage"]
+        assert reference["metricsSupported"]
+
+
+def test_rttm_output_uses_seconds_and_speaker_ids():
+    reference = {
+        "recordingId": "demo",
+        "speakerTurns": [
+            {"speakerId": "speaker_a", "startMs": 250, "endMs": 1250},
+            {"speakerId": "speaker_b", "startMs": 1500, "endMs": 2250},
+        ],
+    }
+
+    assert reference_to_rttm(reference).splitlines() == [
+        "SPEAKER demo 1 0.250 1.000 <NA> <NA> speaker_a <NA> <NA>",
+        "SPEAKER demo 1 1.500 0.750 <NA> <NA> speaker_b <NA> <NA>",
+    ]
+
+
+def test_parser_rejects_unknown_corpus_and_missing_license():
+    with pytest.raises(ValueError, match="unknown corpusId"):
+        parse_fixture_reference(
+            {
+                "corpusId": "not-real",
+                "recordingId": "x",
+                "license": "fixture",
+                "citation": "fixture",
+                "audio": {"uri": "x.wav", "durationMs": 1, "sampleRateHz": 16000, "channels": 1},
+                "sourceStreams": [{"id": "s"}],
+                "speakerTurns": [{"speakerId": "a", "startMs": 0, "endMs": 1}],
+                "transcript": [{"speakerId": "a", "startMs": 0, "endMs": 1}],
+            }
+        )
+
+    with pytest.raises(ValueError, match="license is required"):
+        parse_fixture_reference(
+            {
+                "corpusId": "ami",
+                "recordingId": "x",
+                "citation": "fixture",
+                "audio": {"uri": "x.wav", "durationMs": 1, "sampleRateHz": 16000, "channels": 1},
+                "sourceStreams": [{"id": "s"}],
+                "speakerTurns": [{"speakerId": "a", "startMs": 0, "endMs": 1}],
+                "transcript": [{"speakerId": "a", "startMs": 0, "endMs": 1}],
+            }
+        )
+
+
+def test_parser_rejects_inverted_turn_boundaries():
+    with pytest.raises(ValueError, match="endMs must be greater than startMs"):
+        parse_fixture_reference(
+            {
+                "corpusId": "ami",
+                "recordingId": "x",
+                "license": "fixture",
+                "citation": "fixture",
+                "audio": {"uri": "x.wav", "durationMs": 1, "sampleRateHz": 16000, "channels": 1},
+                "sourceStreams": [{"id": "s"}],
+                "speakerTurns": [{"speakerId": "a", "startMs": 5, "endMs": 1}],
+                "transcript": [{"speakerId": "a", "startMs": 0, "endMs": 1}],
+            }
+        )


### PR DESCRIPTION
## Summary

- add a self-contained `packages/benchmarks/meeting-corpus-importers` package for #12491
- define P0/P1 corpus registry metadata with license/citation, required cache paths, annotation coverage, and supported metrics
- add deterministic local cache manifest generation that marks missing licensed corpora as `status: "missing"` / `canRun: false`
- add a synthetic fixture parser that emits transcript, speaker-turn, source-stream, RTTM, coverage, and metric metadata without downloading or committing real corpus bytes
- add focused tests and evidence for the code-only importer contract

## Evidence

- `.github/issue-evidence/12491-meeting-corpus-importers.md`
- Human-gated real-corpus/model evidence follow-up: #13156. This requires licensed corpora, local model artifacts, and manual review of real WER/DER/cpWER output.

## Verification

```bash
python -m pytest tests -q
```

Result: `7 passed in 0.01s`

```bash
python -m compileall -q elizaos_meeting_corpus_importers tests
```

Result: passed.

Manual inspection confirmed 10 synthetic P0 references, deterministic missing-cache manifest output, and RTTM conversion for the first fixture.

Closes #12491
