### PR TITLE
fix(#12502): register meeting voice benchmark lanes

### DIFF
--- a/.github/issue-evidence/12502-meeting-voice-registry.md
+++ b/.github/issue-evidence/12502-meeting-voice-registry.md
@@ -1,0 +1,102 @@
+# #12502 Meeting Voice Registry Evidence
+
+Branch: `fix/12502-meeting-voice-registry`
+Code PR: #13160
+Human evidence follow-up: #13161
+
+## What Was Proven
+
+- Added first-class registry aliases for `meeting_voice`, `meeting_voice_real`,
+  `meeting_voice_stress`, and `meeting_voice_av`, all backed by the existing
+  `meeting_transcription_proof` harness.
+- Classified the new aliases in CI coverage:
+  - `meeting_voice`: smoke;
+  - `meeting_voice_real`: manual;
+  - `meeting_voice_stress`: manual;
+  - `meeting_voice_av`: manual.
+- Preserved the no-key smoke path while keeping real-matrix commands free of
+  mock/stub defaults.
+- Hardened the `meeting_transcription_proof` scorer so `real_product` reports
+  require named evidence files, required metadata sections, and detailed
+  regression metrics instead of passing on evidence count alone.
+- Added a meeting voice registry note documenting exact ids, manual lanes, and
+  non-orchestrator rationale for `voice` and `voice-emotion`.
+- Added synthetic calibration payload coverage for the meeting proof scorer.
+
+## Verification
+
+```bash
+python -m pytest packages/benchmarks/tests/test_registry_scores.py -q
+```
+
+Result: `9 passed`.
+
+```bash
+python -m pytest packages/benchmarks/tests/test_ci_coverage.py -q
+```
+
+Result: `8 passed`.
+
+```bash
+PYTHONPATH=packages python -m pytest packages/benchmarks/orchestrator/tests/test_adapter_discovery.py::test_synthetic_calibration_payloads_exercise_all_score_extractors -q
+```
+
+Result: `1 passed`.
+
+```bash
+PYTHONPATH=packages python -m pytest packages/benchmarks/orchestrator/tests/test_adapter_discovery.py::test_real_matrix_compatible_commands_do_not_default_to_mock_or_stub -q
+```
+
+Result: `1 passed`.
+
+```bash
+PYTHONPATH=packages python -m pytest packages/benchmarks/orchestrator/tests/test_adapter_discovery.py::test_cross_matrix_validation_constructs_all_compatible_cells -q
+```
+
+Result: `1 passed`.
+
+```bash
+PYTHONPATH=packages/benchmarks/meeting-transcription-proof python -m pytest packages/benchmarks/meeting-transcription-proof/tests -q
+```
+
+Result: `25 passed`.
+
+```bash
+PYTHONPATH=packages python -m benchmarks.orchestrator list-benchmarks | rg 'meeting_voice|meeting_transcription|voicebench|voiceagent|mmau'
+```
+
+Manual output inspection confirmed the new `meeting_voice*` ids, the existing
+`meeting_transcription_proof`, `voicebench`, `voicebench_quality`,
+`voiceagentbench`, and `mmau` registry entries.
+
+```bash
+python -m elizaos_meeting_transcription_proof --lane mocked_plumbing --output /tmp/mtp-12502-smoke
+```
+
+Result: emitted `/tmp/mtp-12502-smoke/meeting-transcription-proof-report.json`.
+
+Broader package check:
+
+```bash
+PYTHONPATH=packages python -m pytest packages/benchmarks/orchestrator/tests/test_adapter_discovery.py -q
+```
+
+Result after the alias fix: `115 passed`, 2 failures from pre-existing local
+ignored benchmark residue:
+
+- `test_discovery_covers_all_real_benchmark_directories`: local
+  `entity-voice-bench` and `lifeops-quality` directories are visible to the
+  test but not covered by public adapters.
+- `test_mmau_uses_canonical_audio_package_without_legacy_shims`: local legacy
+  `packages/benchmarks/mmau` directory exists.
+
+## Evidence Rows
+
+- Registry entries: verified by `list-benchmarks`.
+- CI/nightly configuration: verified by `test_ci_coverage.py`.
+- Sample benchmark report: mocked-plumbing report emitted under `/tmp`.
+- Failure example proving gates fire: `test_registry_scores.py` covers missing
+  named evidence, missing sections, missing detailed metrics, mocked publishable
+  claims, and incomplete real evidence.
+- Real product report: N/A here; requires human-provided manifest with live
+  media, logs, screenshots/video refs, model trajectories, and reviewed metrics.

--- a/packages/benchmarks/docs/MEETING_VOICE_REGISTRY.md
+++ b/packages/benchmarks/docs/MEETING_VOICE_REGISTRY.md
@@ -1,0 +1,24 @@
+# Meeting Voice Registry Lanes
+
+Issue #12502 is tracked through explicit registry ids where the orchestrator can
+run a stable harness, plus non-orchestrator rationale for low-level lab probes
+that are not a single scored benchmark.
+
+| Requested lane | Registry id or rationale | CI lane | Notes |
+| --- | --- | --- | --- |
+| `meeting_voice` | `meeting_voice` | smoke | Provider-aware alias for `meeting_transcription_proof`; mock provider builds the no-key mocked-plumbing route, real provider builds `real_product`. Mocked plumbing is not product proof. |
+| `meeting_voice_real` | `meeting_voice_real` | manual | Requires a real-product manifest with reviewed media, logs, screenshots, model outputs, and metrics. |
+| `meeting_voice_stress` | `meeting_voice_stress` | manual | Real-product manifest focused on music, noise, babble, overlap, far-field, and single-stream multi-speaker stressors. |
+| `meeting_voice_av` | `meeting_voice_av` | manual | Real-product manifest focused on video, active-speaker metadata, screenshots, media refs, and transcript/diarization artifacts. |
+| `voicebench-quality` | `voicebench_quality` | manual | Registry ids use underscores; package path remains `packages/benchmarks/voicebench-quality`. |
+| `voiceagentbench` | `voiceagentbench` | manual | Real audio dataset and STT/model credentials are evidence-gated. |
+| `mmau-audio` | `mmau` | manual | Registry id is the benchmark name; package path remains `packages/benchmarks/mmau-audio`. |
+| `voice` | non-orchestrator rationale | manual direct | `packages/benchmarks/voice` is a collection of device/acoustic/local scripts, not one scored report with a stable JSON schema. Keep it direct until a single report writer and scorer exist. |
+| `voice-emotion` | non-orchestrator rationale | manual direct | `packages/benchmarks/voice-emotion` has its own CLI and ONNX/audio prerequisites. Keep it direct until the registered lane can fail closed on missing models while producing a scored artifact. |
+
+The `meeting_voice*` ids all route through
+`packages/benchmarks/meeting-transcription-proof`. The smoke lane may run with
+the bundled mocked manifest; the real/stress/AV lanes must be run with
+`extra.manifest=<path>` pointing at reviewed evidence. The scorer rejects
+`real_product` reports that are missing named evidence files, required metadata
+sections, or detailed regression metrics.

--- a/packages/benchmarks/docs/RESULTS_MATRIX.md
+++ b/packages/benchmarks/docs/RESULTS_MATRIX.md
@@ -82,6 +82,10 @@ or `gated`.
 | humaneval | smoke | 1.00 | 1.00 | 1.00 | 1.00 |
 | hyperliquid_bench | scheduled | gated | gated | gated | gated |
 | lifeops_bench | scheduled | 1.00 | 1.00 | 1.00 | 1.00 |
+| meeting_voice | smoke | not-run | not-run | not-run | gated |
+| meeting_voice_av | manual | gated | gated | gated | gated |
+| meeting_voice_real | manual | gated | gated | gated | gated |
+| meeting_voice_stress | manual | gated | gated | gated | gated |
 | meeting_transcription_proof | smoke | not-run | not-run | not-run | gated |
 | mind2web | smoke | not-run | not-run | not-run | gated |
 | mint | scheduled | 1.00 | 1.00 | 1.00 | 1.00 |
@@ -112,7 +116,7 @@ or `gated`.
 | webshop | smoke | not-run | not-run | not-run | gated |
 | woobench | smoke | 0.89 | 0.89 | 0.93 | 0.91 |
 
-**Registered totals:** 45 benchmarks. 15 have a real posted score (from the
+**Registered totals:** 49 benchmarks. 15 have a real posted score (from the
 2026-05-28 certification pass, `benchmark_results/latest/`); the rest are
 `not-run` (no committed graded run) or `gated` (infra/credentials required).
 

--- a/packages/benchmarks/orchestrator/adapters.py
+++ b/packages/benchmarks/orchestrator/adapters.py
@@ -2583,6 +2583,10 @@ def discover_adapters(workspace_root: Path) -> AdapterDiscovery:
         "mt_bench": "standard",
         "mmau": "mmau-audio",
         "meeting_transcription_proof": "meeting-transcription-proof",
+        "meeting_voice": "meeting-transcription-proof",
+        "meeting_voice_real": "meeting-transcription-proof",
+        "meeting_voice_stress": "meeting-transcription-proof",
+        "meeting_voice_av": "meeting-transcription-proof",
     }
     hermes_env_benchmark_ids = {
         "hermes_tblite",

--- a/packages/benchmarks/orchestrator/ci_coverage.py
+++ b/packages/benchmarks/orchestrator/ci_coverage.py
@@ -8,11 +8,9 @@ here, and ``tests/test_ci_coverage.py`` asserts the classification stays
 complete: adding a benchmark to the registry or exposing a new adapter without
 giving it a lane (or an explicit manual-only marker) fails CI.
 
-The registry currently declares **45** benchmarks (``registry/commands.py``);
-counting adapter-only ids, **54** benchmarks are publicly runnable and every
-one carries a lane below. Do not hardcode a benchmark count in prose — derive
-it from ``registry_benchmark_ids`` / ``public_benchmark_ids`` so it cannot
-drift, which is exactly what the test gate enforces.
+The registry and adapter counts are derived by ``registry_benchmark_ids`` /
+``public_benchmark_ids`` and every public id carries a lane below. Do not
+hardcode a benchmark count in prose; the test gate owns the live count.
 
 Lanes
 -----
@@ -100,6 +98,10 @@ CI_LANE_BY_BENCHMARK: dict[str, str] = {
     "voicebench": "manual",  # real audio assets
     "voicebench_quality": "manual",  # real audio inputs
     "voiceagentbench": "manual",  # real audio dataset
+    "meeting_voice": "smoke",  # no-key mocked plumbing alias; not product proof
+    "meeting_voice_real": "manual",  # real media/log/model evidence manifest
+    "meeting_voice_stress": "manual",  # acoustic stress real evidence manifest
+    "meeting_voice_av": "manual",  # audio-visual real evidence manifest
     "meeting_transcription_proof": "smoke",  # mocked plumbing lane in CI; real lane is evidence-gated
     "hermes_swe_env": "manual",  # hermes sandbox backend
     "hermes_tblite": "manual",  # hermes sandbox backend

--- a/packages/benchmarks/orchestrator/random_baseline_runner.py
+++ b/packages/benchmarks/orchestrator/random_baseline_runner.py
@@ -652,6 +652,25 @@ def _gauntlet_payload(score: float) -> dict[str, Any]:
     }
 
 
+def _meeting_transcription_proof_payload(score: float) -> dict[str, Any]:
+    return {
+        "kind": "meeting_transcription_proof_report",
+        "version": 1,
+        "issue": 12486,
+        "lane": "mocked_plumbing",
+        "publishable": False,
+        "provider_mode": "synthetic-calibration",
+        "score": score,
+        "metrics": {
+            "transcript_quality": score,
+            "diarization_quality": score,
+            "speaker_identity_quality": score,
+            "consent_retention_quality": score,
+        },
+        "evidence_files": {},
+    }
+
+
 def _generic_payload(benchmark_id: str, harness: str, score: float) -> dict[str, Any]:
     return {
         "benchmark_id": benchmark_id,
@@ -702,6 +721,26 @@ _RESULT_TEMPLATES: dict[str, tuple[str, Any]] = {
     "hyperliquidbench": ("hyperliquid_bench-random_v1.json", _hyperliquid_payload),
     "interrupt_bench": ("report.json", _interrupt_payload),
     "lifeops_bench": ("lifeops-bench-random_v1.json", _lifeops_payload),
+    "meeting_transcription_proof": (
+        "meeting-transcription-proof-report-random_v1.json",
+        _meeting_transcription_proof_payload,
+    ),
+    "meeting_voice": (
+        "meeting-voice-report-random_v1.json",
+        _meeting_transcription_proof_payload,
+    ),
+    "meeting_voice_real": (
+        "meeting-voice-real-report-random_v1.json",
+        _meeting_transcription_proof_payload,
+    ),
+    "meeting_voice_stress": (
+        "meeting-voice-stress-report-random_v1.json",
+        _meeting_transcription_proof_payload,
+    ),
+    "meeting_voice_av": (
+        "meeting-voice-av-report-random_v1.json",
+        _meeting_transcription_proof_payload,
+    ),
     "mind2web": ("mind2web-results.json", _mind2web_payload),
     "mint": ("mint-benchmark-results.json", _mint_payload),
     "mmau": ("mmau_random_v1.json", _mmau_payload),

--- a/packages/benchmarks/registry/commands.py
+++ b/packages/benchmarks/registry/commands.py
@@ -2206,6 +2206,18 @@ def get_benchmark_registry(repo_root: Path) -> list[BenchmarkDefinition]:
             args.extend(["--manifest", manifest.strip()])
         return args
 
+    def _meeting_voice_cmd(
+        output_dir: Path, model: ModelSpec, extra: Mapping[str, JSONValue]
+    ) -> list[str]:
+        return _meeting_transcription_proof_cmd(output_dir, model, extra)
+
+    def _meeting_voice_real_cmd(
+        output_dir: Path, model: ModelSpec, extra: Mapping[str, JSONValue]
+    ) -> list[str]:
+        merged_extra = dict(extra)
+        merged_extra.setdefault("lane", "real_product")
+        return _meeting_transcription_proof_cmd(output_dir, model, merged_extra)
+
     def _meeting_transcription_proof_result(output_dir: Path) -> Path:
         return output_dir / "meeting-transcription-proof-report.json"
 
@@ -2926,6 +2938,95 @@ def get_benchmark_registry(repo_root: Path) -> list[BenchmarkDefinition]:
             build_command=_voiceagentbench_cmd,
             locate_result=_voiceagentbench_result,
             extract_score=_score_from_voiceagentbench_json,
+        ),
+        BenchmarkDefinition(
+            id="meeting_voice",
+            display_name="Meeting Voice Smoke",
+            description=(
+                "No-key smoke lane for meeting voice transcription proof wiring, "
+                "canonical artifact shape, capture-path metadata, and evidence "
+                "bundle validation. Mocked plumbing is never product proof."
+            ),
+            cwd_rel="packages/benchmarks/meeting-transcription-proof",
+            requirements=BenchmarkRequirements(
+                env_vars=(),
+                paths=(
+                    "packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof",
+                    "packages/benchmarks/meeting-transcription-proof/fixtures/mock-meeting-manifest.json",
+                ),
+                notes=(
+                    "Alias for meeting_transcription_proof. With a mock provider it builds "
+                    "the lane='mocked_plumbing' no-key smoke route; with a real provider it "
+                    "builds lane='real_product'. Use meeting_voice_real, meeting_voice_stress, "
+                    "or meeting_voice_av with extra.manifest=<path> for reviewed product evidence."
+                ),
+            ),
+            build_command=_meeting_voice_cmd,
+            locate_result=_meeting_transcription_proof_result,
+            extract_score=_score_from_meeting_transcription_proof_json,
+        ),
+        BenchmarkDefinition(
+            id="meeting_voice_real",
+            display_name="Meeting Voice Real Product Evidence",
+            description=(
+                "Manual real-product lane for Zoom, Google Meet, on-device, cloud-agent, "
+                "and hybrid local/cloud meeting transcription proof"
+            ),
+            cwd_rel="packages/benchmarks/meeting-transcription-proof",
+            requirements=BenchmarkRequirements(
+                env_vars=(),
+                paths=("packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof",),
+                notes=(
+                    "Manual evidence-gated alias for meeting_transcription_proof with "
+                    "lane='real_product'. Requires extra.manifest=<path> containing real "
+                    "media/log/screenshot/model artifact evidence; mock provider runs fail closed."
+                ),
+            ),
+            build_command=_meeting_voice_real_cmd,
+            locate_result=_meeting_transcription_proof_result,
+            extract_score=_score_from_meeting_transcription_proof_json,
+        ),
+        BenchmarkDefinition(
+            id="meeting_voice_stress",
+            display_name="Meeting Voice Acoustic Stress Evidence",
+            description=(
+                "Manual real-product lane for meeting voice stressors: music, noise, "
+                "babble, overlap, far-field room audio, and multi-speaker single-stream cases"
+            ),
+            cwd_rel="packages/benchmarks/meeting-transcription-proof",
+            requirements=BenchmarkRequirements(
+                env_vars=(),
+                paths=("packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof",),
+                notes=(
+                    "Manual evidence-gated alias for meeting_transcription_proof with "
+                    "lane='real_product'. The manifest must include stress dataset sources, "
+                    "metrics, media refs, logs, and reviewed model outputs."
+                ),
+            ),
+            build_command=_meeting_voice_real_cmd,
+            locate_result=_meeting_transcription_proof_result,
+            extract_score=_score_from_meeting_transcription_proof_json,
+        ),
+        BenchmarkDefinition(
+            id="meeting_voice_av",
+            display_name="Meeting Voice Audio-Visual Evidence",
+            description=(
+                "Manual real-product lane for audio-visual meeting proof, active-speaker "
+                "metadata, video evidence, screenshots, and transcript/diarization artifacts"
+            ),
+            cwd_rel="packages/benchmarks/meeting-transcription-proof",
+            requirements=BenchmarkRequirements(
+                env_vars=(),
+                paths=("packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof",),
+                notes=(
+                    "Manual evidence-gated alias for meeting_transcription_proof with "
+                    "lane='real_product'. Requires an AV manifest with video, active speaker, "
+                    "media, logs, screenshots, and manual review artifacts."
+                ),
+            ),
+            build_command=_meeting_voice_real_cmd,
+            locate_result=_meeting_transcription_proof_result,
+            extract_score=_score_from_meeting_transcription_proof_json,
         ),
         BenchmarkDefinition(
             id="meeting_transcription_proof",

--- a/packages/benchmarks/registry/scores.py
+++ b/packages/benchmarks/registry/scores.py
@@ -888,6 +888,45 @@ def _score_from_mmau_json(data: JSONValue) -> ScoreExtraction:
     )
 
 
+_MEETING_PROOF_REQUIRED_EVIDENCE = {
+    "audio",
+    "video",
+    "backend_logs",
+    "frontend_logs",
+    "screenshots",
+    "metrics",
+    "model_trajectories",
+    "transcript_artifact",
+    "speaker_profile_artifact",
+    "consent_record",
+    "retention_artifact",
+}
+
+_MEETING_PROOF_REQUIRED_SECTIONS = (
+    "scenarios",
+    "dataset_sources",
+    "capture_paths",
+    "speaker_operations",
+)
+
+_MEETING_PROOF_REQUIRED_REAL_METRICS = {
+    "wer",
+    "cer",
+    "speaker_attributed_wer",
+    "der",
+    "jer",
+    "overlap_aware_wer",
+    "active_speaker_accuracy",
+    "voice_profile_false_accept_rate",
+    "voice_profile_false_reject_rate",
+    "end_of_turn_latency_ms",
+    "barge_in_latency_ms",
+    "p95_end_to_end_latency_ms",
+    "notes_factuality",
+    "action_item_extraction",
+}
+
+
 def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtraction:
     """Extract the #12486 meeting transcription proof score.
 
@@ -916,8 +955,27 @@ def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtrac
     if lane == "real_product":
         if not publishable:
             raise ValueError("meeting_transcription_proof: real lane must be publishable")
-        if evidence_count < 11:
-            raise ValueError("meeting_transcription_proof: real lane requires complete evidence files")
+        if not isinstance(evidence_files, dict):
+            raise ValueError("meeting_transcription_proof: real lane requires evidence file map")
+        missing_evidence = _MEETING_PROOF_REQUIRED_EVIDENCE - set(evidence_files)
+        if missing_evidence:
+            raise ValueError(
+                "meeting_transcription_proof: real lane requires named evidence files "
+                f"{sorted(missing_evidence)}"
+            )
+        for section in _MEETING_PROOF_REQUIRED_SECTIONS:
+            rows = expect_list(
+                get_required(root, section, ctx="meeting_transcription_proof:root"),
+                ctx=f"meeting_transcription_proof:{section}",
+            )
+            if not rows:
+                raise ValueError(f"meeting_transcription_proof: real lane requires non-empty {section}")
+        missing_metrics = _MEETING_PROOF_REQUIRED_REAL_METRICS - set(metrics)
+        if missing_metrics:
+            raise ValueError(
+                "meeting_transcription_proof: real lane requires detailed metrics "
+                f"{sorted(missing_metrics)}"
+            )
     elif publishable:
         raise ValueError("meeting_transcription_proof: mocked lane cannot be publishable")
 

--- a/packages/benchmarks/tests/test_ci_coverage.py
+++ b/packages/benchmarks/tests/test_ci_coverage.py
@@ -77,6 +77,31 @@ def test_at_least_one_benchmark_per_lane() -> None:
     assert lanes_in_use == set(CI_LANES)
 
 
+def test_meeting_voice_registry_contract_for_issue_12502() -> None:
+    registry_ids = registry_benchmark_ids(_workspace_root())
+
+    assert {
+        "meeting_voice",
+        "meeting_voice_real",
+        "meeting_voice_stress",
+        "meeting_voice_av",
+        "meeting_transcription_proof",
+        "voicebench",
+        "voicebench_quality",
+        "voiceagentbench",
+        "mmau",
+    } <= registry_ids
+    assert ci_lane_for("meeting_voice") == "smoke"
+    assert ci_lane_for("meeting_voice_real") == "manual"
+    assert ci_lane_for("meeting_voice_stress") == "manual"
+    assert ci_lane_for("meeting_voice_av") == "manual"
+
+    rationale = (ROOT / "docs" / "MEETING_VOICE_REGISTRY.md").read_text(encoding="utf-8")
+    assert "`voice`" in rationale
+    assert "`voice-emotion`" in rationale
+    assert "non-orchestrator rationale" in rationale
+
+
 def test_classified_count_equals_public_benchmark_count() -> None:
     # #10193: the classified set is the count of record for "how many public
     # benchmarks exist". Assert it equals the live registry|adapter set so a

--- a/packages/benchmarks/tests/test_registry_scores.py
+++ b/packages/benchmarks/tests/test_registry_scores.py
@@ -97,7 +97,7 @@ def test_meeting_transcription_mock_lane_cannot_claim_publishable() -> None:
 
 
 def test_meeting_transcription_real_lane_requires_complete_evidence() -> None:
-    with pytest.raises(ValueError, match="complete evidence"):
+    with pytest.raises(ValueError, match="named evidence"):
         _score_from_meeting_transcription_proof_json(
             {
                 "kind": "meeting_transcription_proof_report",
@@ -110,24 +110,81 @@ def test_meeting_transcription_real_lane_requires_complete_evidence() -> None:
         )
 
 
+def _meeting_transcription_real_metrics() -> dict[str, float]:
+    return {
+        "transcript_quality": 0.91,
+        "diarization_quality": 0.82,
+        "speaker_identity_quality": 0.77,
+        "consent_retention_quality": 1.0,
+        "wer": 0.09,
+        "cer": 0.04,
+        "speaker_attributed_wer": 0.13,
+        "der": 0.18,
+        "jer": 0.22,
+        "overlap_aware_wer": 0.2,
+        "active_speaker_accuracy": 0.84,
+        "voice_profile_false_accept_rate": 0.03,
+        "voice_profile_false_reject_rate": 0.08,
+        "end_of_turn_latency_ms": 280,
+        "barge_in_latency_ms": 190,
+        "p95_end_to_end_latency_ms": 1300,
+        "notes_factuality": 0.93,
+        "action_item_extraction": 0.89,
+    }
+
+
+def _meeting_transcription_real_evidence() -> dict[str, str]:
+    return {
+        "audio": "/tmp/audio.wav",
+        "video": "/tmp/video.mp4",
+        "backend_logs": "/tmp/backend.log",
+        "frontend_logs": "/tmp/frontend.log",
+        "screenshots": "/tmp/screenshots.zip",
+        "metrics": "/tmp/metrics.json",
+        "model_trajectories": "/tmp/trajectories.jsonl",
+        "transcript_artifact": "/tmp/transcript.json",
+        "speaker_profile_artifact": "/tmp/speaker-profile.json",
+        "consent_record": "/tmp/consent.json",
+        "retention_artifact": "/tmp/retention.json",
+    }
+
+
+def _meeting_transcription_real_report() -> dict[str, object]:
+    return {
+        "kind": "meeting_transcription_proof_report",
+        "lane": "real_product",
+        "publishable": True,
+        "provider_mode": "zoom-meet-live",
+        "score": 0.77,
+        "metrics": _meeting_transcription_real_metrics(),
+        "evidence_files": _meeting_transcription_real_evidence(),
+        "scenarios": [{"id": "zoom_bot_free"}],
+        "dataset_sources": [{"id": "ami"}],
+        "capture_paths": [{"id": "google_meet_bot_free"}],
+        "speaker_operations": [{"id": "speaker_name_correction"}],
+    }
+
+
+def test_meeting_transcription_real_lane_requires_metadata_sections() -> None:
+    report = _meeting_transcription_real_report()
+    report.pop("capture_paths")
+
+    with pytest.raises(ValueError, match="capture_paths"):
+        _score_from_meeting_transcription_proof_json(report)
+
+
+def test_meeting_transcription_real_lane_requires_detailed_metrics() -> None:
+    report = _meeting_transcription_real_report()
+    metrics = report["metrics"]
+    assert isinstance(metrics, dict)
+    metrics.pop("speaker_attributed_wer")
+
+    with pytest.raises(ValueError, match="detailed metrics"):
+        _score_from_meeting_transcription_proof_json(report)
+
+
 def test_meeting_transcription_real_lane_score_is_publishable_with_evidence() -> None:
-    evidence_files = {f"evidence_{index}": f"/tmp/evidence-{index}.txt" for index in range(11)}
-    extraction = _score_from_meeting_transcription_proof_json(
-        {
-            "kind": "meeting_transcription_proof_report",
-            "lane": "real_product",
-            "publishable": True,
-            "provider_mode": "zoom-meet-live",
-            "score": 0.77,
-            "metrics": {
-                "transcript_quality": 0.91,
-                "diarization_quality": 0.82,
-                "speaker_identity_quality": 0.77,
-                "consent_retention_quality": 1.0,
-            },
-            "evidence_files": evidence_files,
-        }
-    )
+    extraction = _score_from_meeting_transcription_proof_json(_meeting_transcription_real_report())
 
     assert extraction.score == pytest.approx(0.77)
     assert extraction.metrics["lane"] == "real_product"


### PR DESCRIPTION
## Summary

- add first-class registry aliases for `meeting_voice`, `meeting_voice_real`, `meeting_voice_stress`, and `meeting_voice_av` backed by the meeting transcription proof harness
- classify the aliases in CI coverage and expose them through adapter discovery/list-benchmarks
- harden `meeting_transcription_proof` scoring so real reports require named evidence files, metadata sections, and detailed regression metrics
- add synthetic calibration payload coverage for the meeting proof scorer
- document related voice benchmark registry ids and non-orchestrator rationale for `voice` / `voice-emotion`

## Evidence

- `.github/issue-evidence/12502-meeting-voice-registry.md`
- Human-gated real-product benchmark evidence follow-up: #13161. The registered manual lanes still require real manifests with live media/log/screenshot/model artifacts and reviewed metrics.

## Verification

```bash
python -m pytest packages/benchmarks/tests/test_registry_scores.py -q
```

Result: `9 passed`

```bash
python -m pytest packages/benchmarks/tests/test_ci_coverage.py -q
```

Result: `8 passed`

```bash
PYTHONPATH=packages python -m pytest packages/benchmarks/orchestrator/tests/test_adapter_discovery.py::test_synthetic_calibration_payloads_exercise_all_score_extractors -q
PYTHONPATH=packages python -m pytest packages/benchmarks/orchestrator/tests/test_adapter_discovery.py::test_real_matrix_compatible_commands_do_not_default_to_mock_or_stub -q
PYTHONPATH=packages python -m pytest packages/benchmarks/orchestrator/tests/test_adapter_discovery.py::test_cross_matrix_validation_constructs_all_compatible_cells -q
```

Result: each focused adapter discovery test passed.

```bash
PYTHONPATH=packages/benchmarks/meeting-transcription-proof python -m pytest packages/benchmarks/meeting-transcription-proof/tests -q
```

Result: `25 passed`

```bash
PYTHONPATH=packages python -m benchmarks.orchestrator list-benchmarks | rg 'meeting_voice|meeting_transcription|voicebench|voiceagent|mmau'
python -m elizaos_meeting_transcription_proof --lane mocked_plumbing --output /tmp/mtp-12502-smoke
```

Result: list output showed the new meeting aliases plus related voice/audio entries; mocked-plumbing report emitted successfully.

Broader adapter discovery:

```bash
PYTHONPATH=packages python -m pytest packages/benchmarks/orchestrator/tests/test_adapter_discovery.py -q
```

Result: `115 passed`; 2 failures from pre-existing local ignored benchmark residue (`entity-voice-bench`, `lifeops-quality`, legacy `packages/benchmarks/mmau`).

Closes #12502
