### PR TITLE
fix(#12496): add audio visual meeting benchmark contract

### DIFF
--- a/.github/issue-evidence/12496-audio-visual-meeting-benchmark.md
+++ b/.github/issue-evidence/12496-audio-visual-meeting-benchmark.md
@@ -1,0 +1,79 @@
+# #12496 Audio-Visual Meeting Benchmark Evidence
+
+Branch: `fix/12496-av-meeting-benchmark`
+Code PR: #13162
+Human evidence follow-up: #13163
+
+## What Was Proven
+
+- Added an `audio_visual_cases` manifest/report section to
+  `meeting_transcription_proof`.
+- Required AV case ids cover:
+  - `ava_active_speaker`;
+  - `misp_2025_meeting`;
+  - `easycom_license_permitting`;
+  - `synthetic_room_feed_smoke`;
+  - `off_screen_speaker`;
+  - `visual_acoustic_disagreement`;
+  - `audio_video_association`.
+- Required AV coverage includes video frames, face tracks, audio streams,
+  transcripts, speaker ids, source metadata, active-speaker labels,
+  person-count labels, off-screen speaker labels, audio/video association
+  labels, and room-feed labels.
+- Added AV metrics to the contract: face-count accuracy, active-speaker F1/mAP,
+  audio-video association accuracy, off-screen speaker detection accuracy,
+  room-feed heuristic precision/recall, and visual/acoustic disagreement rate.
+- Added identity-policy guardrails: face tracks cannot silently bind personal
+  identity, and sensitive-attribute shortcuts are forbidden.
+- Updated the mock fixture and docs.
+- Registry scoring now requires `audio_visual_cases` and the AV metrics for
+  real meeting-transcription reports.
+
+## Verification
+
+```bash
+PYTHONPATH=packages/benchmarks/meeting-transcription-proof python -m pytest packages/benchmarks/meeting-transcription-proof/tests -q
+```
+
+Result: `28 passed`.
+
+```bash
+python -m pytest packages/benchmarks/tests/test_registry_scores.py -q
+```
+
+Result: `9 passed`.
+
+```bash
+python -m py_compile packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/cli.py packages/benchmarks/meeting-transcription-proof/tests/test_cli.py
+```
+
+Result: passed.
+
+```bash
+python -m elizaos_meeting_transcription_proof --lane mocked_plumbing --output /tmp/mtp-smoke-audio-visual-cases-12496
+```
+
+Result: emitted
+`/tmp/mtp-smoke-audio-visual-cases-12496/meeting-transcription-proof-report.json`.
+
+Manual report inspection:
+
+```text
+audio_visual_case_count: 7
+ids: audio_video_association, ava_active_speaker, easycom_license_permitting, misp_2025_meeting, off_screen_speaker, synthetic_room_feed_smoke, visual_acoustic_disagreement
+av_metrics: face_count_accuracy=1.0, active_speaker_f1=1.0, active_speaker_map=1.0, audio_video_association_accuracy=1.0, off_screen_speaker_detection_accuracy=1.0, room_feed_heuristic_precision=1.0, room_feed_heuristic_recall=1.0, visual_acoustic_disagreement_rate=0.0
+identity_policies: forbidden_without_explicit_opt_in
+```
+
+## Evidence Rows
+
+- Parsed audio-visual fixture: mocked fixture and generated report inspected.
+- Active speaker metrics: present in generated report.
+- Video screenshot/contact sheet: N/A for code-only mocked contract; real
+  contact sheets require licensed video or live product capture.
+- Example room-feed classifier JSON: represented by the synthetic room-feed
+  case contract; real classifier output remains evidence-gated.
+- Manual review notes: this file records manual inspection of the generated
+  mocked report; real video/audio review remains human-gated.
+- Real AV dataset/model run: N/A here; requires licensed AVA/MISP/EasyCom data
+  or live capture, model artifacts, and manual review.

--- a/packages/benchmarks/meeting-transcription-proof/AGENTS.md
+++ b/packages/benchmarks/meeting-transcription-proof/AGENTS.md
@@ -49,6 +49,23 @@ overlap-aware WER, active-speaker accuracy, voice-profile false accept/reject
 rates, end-of-turn latency, barge-in latency, P95 end-to-end latency, notes
 factuality, and action-item extraction.
 
+## Audio-Visual Contract
+
+The manifest must enumerate audio-visual case coverage for AVA-ActiveSpeaker,
+MISP 2025, EasyCom where license permits, synthetic room-feed smoke,
+off-screen speaker handling, visual/acoustic disagreement, and audio/video
+association. Each case declares video frames, face tracks, audio streams,
+transcripts, speaker ids, source metadata, active-speaker labels, person-count
+labels, off-screen labels, association labels, and room-feed labels as
+applicable. Case metrics include face-count accuracy, active-speaker F1/mAP,
+audio-video association accuracy, off-screen speaker detection accuracy,
+room-feed precision/recall, and visual/acoustic disagreement rate.
+
+Face tracks are localization evidence only. Identity binding from face data is
+forbidden without an explicit opt-in identity source such as a voice profile,
+user correction, calendar participant, or platform roster. Sensitive-attribute
+shortcuts are always forbidden.
+
 ## Dataset Contract
 
 The real lane requires external dataset sources covering speech over music,

--- a/packages/benchmarks/meeting-transcription-proof/CLAUDE.md
+++ b/packages/benchmarks/meeting-transcription-proof/CLAUDE.md
@@ -49,6 +49,23 @@ overlap-aware WER, active-speaker accuracy, voice-profile false accept/reject
 rates, end-of-turn latency, barge-in latency, P95 end-to-end latency, notes
 factuality, and action-item extraction.
 
+## Audio-Visual Contract
+
+The manifest must enumerate audio-visual case coverage for AVA-ActiveSpeaker,
+MISP 2025, EasyCom where license permits, synthetic room-feed smoke,
+off-screen speaker handling, visual/acoustic disagreement, and audio/video
+association. Each case declares video frames, face tracks, audio streams,
+transcripts, speaker ids, source metadata, active-speaker labels, person-count
+labels, off-screen labels, association labels, and room-feed labels as
+applicable. Case metrics include face-count accuracy, active-speaker F1/mAP,
+audio-video association accuracy, off-screen speaker detection accuracy,
+room-feed precision/recall, and visual/acoustic disagreement rate.
+
+Face tracks are localization evidence only. Identity binding from face data is
+forbidden without an explicit opt-in identity source such as a voice profile,
+user correction, calendar participant, or platform roster. Sensitive-attribute
+shortcuts are always forbidden.
+
 ## Dataset Contract
 
 The real lane requires external dataset sources covering speech over music,

--- a/packages/benchmarks/meeting-transcription-proof/README.md
+++ b/packages/benchmarks/meeting-transcription-proof/README.md
@@ -82,6 +82,16 @@ policy, and expected resolution. Low-confidence inferred names cannot be
 reported as confirmed identities; they must request confirmation, withhold the
 name, or preserve an unknown speaker label.
 
+Real manifests must include audio-visual case metadata for AVA-ActiveSpeaker,
+MISP 2025, EasyCom where license permits, synthetic room-feed smoke, off-screen
+speaker handling, visual/acoustic disagreement, and audio/video association.
+These rows declare video frame, face-track, audio stream, transcript, speaker,
+source metadata, active-speaker, person-count, off-screen, association, and
+room-feed coverage. The contract reports face-count accuracy, active-speaker
+F1/mAP, audio-video association accuracy, off-screen speaker detection accuracy,
+room-feed precision/recall, and visual/acoustic disagreement rate while
+forbidding face-only identity binding and sensitive attribute shortcuts.
+
 ## Fixture Manifest
 
 `fixtures/mock-meeting-manifest.json` describes the minimum canonical meeting

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/cli.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/cli.py
@@ -60,6 +60,62 @@ REQUIRED_SPEAKER_OPERATION_FIELDS = {
     "privacy_control",
     "confidence_policy",
 }
+REQUIRED_AUDIO_VISUAL_CASES = {
+    "ava_active_speaker",
+    "misp_2025_meeting",
+    "easycom_license_permitting",
+    "synthetic_room_feed_smoke",
+    "off_screen_speaker",
+    "visual_acoustic_disagreement",
+    "audio_video_association",
+}
+REQUIRED_AUDIO_VISUAL_FIELDS = {
+    "id",
+    "dataset",
+    "coverage",
+    "tasks",
+    "metrics",
+    "evidence",
+    "identity_policy",
+}
+REQUIRED_AUDIO_VISUAL_COVERAGE = {
+    "video_frames",
+    "face_tracks",
+    "audio_streams",
+    "transcripts",
+    "speaker_ids",
+    "source_metadata",
+    "active_speaker_labels",
+    "person_count_labels",
+    "off_screen_speaker_labels",
+    "audio_video_association_labels",
+    "room_feed_labels",
+}
+REQUIRED_AUDIO_VISUAL_TASKS = {
+    "face_count",
+    "active_speaker",
+    "off_screen_speaker",
+    "audio_video_association",
+    "room_feed",
+    "visual_acoustic_disagreement",
+}
+REQUIRED_AUDIO_VISUAL_METRICS = {
+    "face_count_accuracy",
+    "active_speaker_f1",
+    "active_speaker_map",
+    "audio_video_association_accuracy",
+    "off_screen_speaker_detection_accuracy",
+    "room_feed_heuristic_precision",
+    "room_feed_heuristic_recall",
+    "visual_acoustic_disagreement_rate",
+}
+ALLOWED_AUDIO_VISUAL_IDENTITY_SOURCES = {
+    "voice_profile",
+    "user_correction",
+    "calendar_participant",
+    "platform_roster",
+    "none",
+}
 REQUIRED_SPEAKER_NAME_PROVENANCE_CASES = {
     "platform_roster_name",
     "calendar_attendee_name",
@@ -193,6 +249,7 @@ REQUIRED_DETAILED_METRICS = {
     "p95_end_to_end_latency_ms",
     "notes_factuality",
     "action_item_extraction",
+    *REQUIRED_AUDIO_VISUAL_METRICS,
 }
 RATIO_METRICS = {
     *REQUIRED_QUALITY_METRICS,
@@ -207,6 +264,7 @@ RATIO_METRICS = {
     "voice_profile_false_reject_rate",
     "notes_factuality",
     "action_item_extraction",
+    *REQUIRED_AUDIO_VISUAL_METRICS,
 }
 LATENCY_METRICS = {"end_of_turn_latency_ms", "barge_in_latency_ms", "p95_end_to_end_latency_ms"}
 KNOWN_METRICS = REQUIRED_QUALITY_METRICS | REQUIRED_DETAILED_METRICS
@@ -659,6 +717,105 @@ def _validate_speaker_name_provenance(manifest: dict[str, Any]) -> tuple[list[di
     return sorted(normalized, key=lambda speaker_name: speaker_name["id"]), referenced_evidence
 
 
+def _validate_audio_visual_cases(manifest: dict[str, Any]) -> tuple[list[dict[str, Any]], set[str]]:
+    cases = manifest.get("audio_visual_cases")
+    if not isinstance(cases, list) or not cases:
+        raise ValueError("audio_visual_cases must be a non-empty array")
+
+    case_ids: set[str] = set()
+    covered_fields: set[str] = set()
+    covered_tasks: set[str] = set()
+    covered_metrics: set[str] = set()
+    referenced_evidence: set[str] = set()
+    normalized: list[dict[str, Any]] = []
+    for index, case in enumerate(cases):
+        if not isinstance(case, dict):
+            raise ValueError(f"audio_visual_cases[{index}] must be an object")
+        missing_fields = REQUIRED_AUDIO_VISUAL_FIELDS - set(case)
+        if missing_fields:
+            raise ValueError(f"audio_visual_cases[{index}] missing fields: {sorted(missing_fields)}")
+        case_id = case.get("id")
+        if not isinstance(case_id, str) or not case_id.strip():
+            raise ValueError(f"audio_visual_cases[{index}].id must be a non-empty string")
+        case_ids.add(case_id)
+        dataset = case.get("dataset")
+        if not isinstance(dataset, str) or not dataset.strip():
+            raise ValueError(f"audio_visual_cases[{index}].dataset must be a non-empty string")
+        coverage = _as_set(case.get("coverage"), field=f"audio_visual_cases[{index}].coverage")
+        unknown_coverage = coverage - REQUIRED_AUDIO_VISUAL_COVERAGE
+        if unknown_coverage:
+            raise ValueError(f"audio_visual_cases[{index}] references unknown coverage: {sorted(unknown_coverage)}")
+        tasks = _as_set(case.get("tasks"), field=f"audio_visual_cases[{index}].tasks")
+        unknown_tasks = tasks - REQUIRED_AUDIO_VISUAL_TASKS
+        if unknown_tasks:
+            raise ValueError(f"audio_visual_cases[{index}] references unknown tasks: {sorted(unknown_tasks)}")
+        metrics = _as_set(case.get("metrics"), field=f"audio_visual_cases[{index}].metrics")
+        unknown_metrics = metrics - REQUIRED_AUDIO_VISUAL_METRICS
+        if unknown_metrics:
+            raise ValueError(f"audio_visual_cases[{index}] references unknown metrics: {sorted(unknown_metrics)}")
+        evidence = _as_set(case.get("evidence"), field=f"audio_visual_cases[{index}].evidence")
+        unknown_evidence = evidence - REQUIRED_EVIDENCE
+        if unknown_evidence:
+            raise ValueError(f"audio_visual_cases[{index}] references unknown evidence: {sorted(unknown_evidence)}")
+
+        identity_policy = case.get("identity_policy")
+        if not isinstance(identity_policy, dict):
+            raise ValueError(f"audio_visual_cases[{index}].identity_policy must be an object")
+        face_binding = identity_policy.get("face_identity_binding")
+        if face_binding != "forbidden_without_explicit_opt_in":
+            raise ValueError(
+                f"audio_visual_cases[{index}].identity_policy.face_identity_binding "
+                "must be forbidden_without_explicit_opt_in"
+            )
+        sensitive_policy = identity_policy.get("sensitive_attribute_policy")
+        if sensitive_policy != "forbidden":
+            raise ValueError(
+                f"audio_visual_cases[{index}].identity_policy.sensitive_attribute_policy must be forbidden"
+            )
+        identity_sources = _as_set(
+            identity_policy.get("allowed_identity_sources"),
+            field=f"audio_visual_cases[{index}].identity_policy.allowed_identity_sources",
+        )
+        unknown_sources = identity_sources - ALLOWED_AUDIO_VISUAL_IDENTITY_SOURCES
+        if unknown_sources:
+            raise ValueError(
+                f"audio_visual_cases[{index}] references unknown identity sources: {sorted(unknown_sources)}"
+            )
+        covered_fields.update(coverage)
+        covered_tasks.update(tasks)
+        covered_metrics.update(metrics)
+        referenced_evidence.update(evidence)
+        normalized.append(
+            {
+                "id": case_id,
+                "dataset": dataset,
+                "coverage": sorted(coverage),
+                "tasks": sorted(tasks),
+                "metrics": sorted(metrics),
+                "evidence": sorted(evidence),
+                "identity_policy": {
+                    "face_identity_binding": face_binding,
+                    "sensitive_attribute_policy": sensitive_policy,
+                    "allowed_identity_sources": sorted(identity_sources),
+                },
+            }
+        )
+
+    missing_cases = REQUIRED_AUDIO_VISUAL_CASES - case_ids
+    if missing_cases:
+        raise ValueError(f"missing audio visual cases: {sorted(missing_cases)}")
+    missing_coverage = REQUIRED_AUDIO_VISUAL_COVERAGE - covered_fields
+    if missing_coverage:
+        raise ValueError(f"audio_visual_cases missing coverage: {sorted(missing_coverage)}")
+    missing_tasks = REQUIRED_AUDIO_VISUAL_TASKS - covered_tasks
+    if missing_tasks:
+        raise ValueError(f"audio_visual_cases missing tasks: {sorted(missing_tasks)}")
+    missing_metrics = REQUIRED_AUDIO_VISUAL_METRICS - covered_metrics
+    if missing_metrics:
+        raise ValueError(f"audio_visual_cases missing metrics: {sorted(missing_metrics)}")
+    return sorted(normalized, key=lambda case: case["id"]), referenced_evidence
+
+
 def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Path) -> dict[str, Any]:
     if lane not in LANES:
         raise ValueError(f"lane must be one of {sorted(LANES)}")
@@ -717,6 +874,7 @@ def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Pat
     capture_paths, capture_evidence_types = _validate_capture_paths(manifest)
     speaker_operations, speaker_operation_evidence_types = _validate_speaker_operations(manifest)
     speaker_name_provenance, speaker_name_evidence_types = _validate_speaker_name_provenance(manifest)
+    audio_visual_cases, audio_visual_evidence_types = _validate_audio_visual_cases(manifest)
 
     metric_values = _validate_metrics(manifest.get("metrics"), lane=lane)
 
@@ -744,6 +902,9 @@ def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Pat
         missing_speaker_name_evidence = speaker_name_evidence_types - set(evidence_files)
         if missing_speaker_name_evidence:
             raise ValueError(f"speaker name evidence files missing: {sorted(missing_speaker_name_evidence)}")
+        missing_audio_visual_evidence = audio_visual_evidence_types - set(evidence_files)
+        if missing_audio_visual_evidence:
+            raise ValueError(f"audio visual evidence files missing: {sorted(missing_audio_visual_evidence)}")
 
     return {
         "surfaces": sorted(surfaces),
@@ -755,6 +916,7 @@ def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Pat
         "capture_paths": capture_paths,
         "speaker_operations": speaker_operations,
         "speaker_name_provenance": speaker_name_provenance,
+        "audio_visual_cases": audio_visual_cases,
         "metrics": metric_values,
         "evidence_files": evidence_files,
         "provider_mode": provider_mode,

--- a/packages/benchmarks/meeting-transcription-proof/fixtures/mock-meeting-manifest.json
+++ b/packages/benchmarks/meeting-transcription-proof/fixtures/mock-meeting-manifest.json
@@ -482,6 +482,147 @@
       "expected_resolution": "preserve_unknown"
     }
   ],
+  "audio_visual_cases": [
+    {
+      "id": "ava_active_speaker",
+      "dataset": "AVA-ActiveSpeaker",
+      "coverage": ["video_frames", "face_tracks", "active_speaker_labels", "source_metadata"],
+      "tasks": ["active_speaker", "face_count"],
+      "metrics": ["active_speaker_f1", "active_speaker_map", "face_count_accuracy"],
+      "evidence": ["video", "screenshots", "metrics"],
+      "identity_policy": {
+        "face_identity_binding": "forbidden_without_explicit_opt_in",
+        "sensitive_attribute_policy": "forbidden",
+        "allowed_identity_sources": ["none"]
+      }
+    },
+    {
+      "id": "misp_2025_meeting",
+      "dataset": "MISP 2025",
+      "coverage": [
+        "video_frames",
+        "face_tracks",
+        "audio_streams",
+        "transcripts",
+        "speaker_ids",
+        "active_speaker_labels",
+        "source_metadata"
+      ],
+      "tasks": ["active_speaker", "audio_video_association", "face_count"],
+      "metrics": ["active_speaker_f1", "active_speaker_map", "audio_video_association_accuracy", "face_count_accuracy"],
+      "evidence": ["audio", "video", "transcript_artifact", "speaker_profile_artifact", "metrics"],
+      "identity_policy": {
+        "face_identity_binding": "forbidden_without_explicit_opt_in",
+        "sensitive_attribute_policy": "forbidden",
+        "allowed_identity_sources": ["voice_profile", "user_correction"]
+      }
+    },
+    {
+      "id": "easycom_license_permitting",
+      "dataset": "EasyCom",
+      "coverage": [
+        "video_frames",
+        "face_tracks",
+        "audio_streams",
+        "transcripts",
+        "speaker_ids",
+        "audio_video_association_labels",
+        "source_metadata"
+      ],
+      "tasks": ["audio_video_association", "face_count"],
+      "metrics": ["audio_video_association_accuracy", "face_count_accuracy"],
+      "evidence": ["audio", "video", "transcript_artifact", "speaker_profile_artifact", "metrics"],
+      "identity_policy": {
+        "face_identity_binding": "forbidden_without_explicit_opt_in",
+        "sensitive_attribute_policy": "forbidden",
+        "allowed_identity_sources": ["voice_profile", "calendar_participant", "user_correction"]
+      }
+    },
+    {
+      "id": "synthetic_room_feed_smoke",
+      "dataset": "synthetic",
+      "coverage": [
+        "video_frames",
+        "face_tracks",
+        "audio_streams",
+        "transcripts",
+        "speaker_ids",
+        "room_feed_labels",
+        "person_count_labels",
+        "source_metadata"
+      ],
+      "tasks": ["room_feed", "face_count"],
+      "metrics": ["room_feed_heuristic_precision", "room_feed_heuristic_recall", "face_count_accuracy"],
+      "evidence": ["audio", "video", "screenshots", "metrics"],
+      "identity_policy": {
+        "face_identity_binding": "forbidden_without_explicit_opt_in",
+        "sensitive_attribute_policy": "forbidden",
+        "allowed_identity_sources": ["none"]
+      }
+    },
+    {
+      "id": "off_screen_speaker",
+      "dataset": "synthetic",
+      "coverage": [
+        "video_frames",
+        "audio_streams",
+        "transcripts",
+        "speaker_ids",
+        "off_screen_speaker_labels",
+        "source_metadata"
+      ],
+      "tasks": ["off_screen_speaker", "audio_video_association"],
+      "metrics": ["off_screen_speaker_detection_accuracy", "audio_video_association_accuracy"],
+      "evidence": ["audio", "video", "transcript_artifact", "metrics"],
+      "identity_policy": {
+        "face_identity_binding": "forbidden_without_explicit_opt_in",
+        "sensitive_attribute_policy": "forbidden",
+        "allowed_identity_sources": ["voice_profile", "user_correction"]
+      }
+    },
+    {
+      "id": "visual_acoustic_disagreement",
+      "dataset": "synthetic",
+      "coverage": [
+        "video_frames",
+        "face_tracks",
+        "audio_streams",
+        "transcripts",
+        "speaker_ids",
+        "active_speaker_labels",
+        "source_metadata"
+      ],
+      "tasks": ["visual_acoustic_disagreement", "active_speaker"],
+      "metrics": ["visual_acoustic_disagreement_rate", "active_speaker_f1"],
+      "evidence": ["audio", "video", "speaker_profile_artifact", "metrics"],
+      "identity_policy": {
+        "face_identity_binding": "forbidden_without_explicit_opt_in",
+        "sensitive_attribute_policy": "forbidden",
+        "allowed_identity_sources": ["voice_profile", "user_correction"]
+      }
+    },
+    {
+      "id": "audio_video_association",
+      "dataset": "synthetic",
+      "coverage": [
+        "video_frames",
+        "face_tracks",
+        "audio_streams",
+        "transcripts",
+        "speaker_ids",
+        "audio_video_association_labels",
+        "source_metadata"
+      ],
+      "tasks": ["audio_video_association", "active_speaker"],
+      "metrics": ["audio_video_association_accuracy", "active_speaker_f1"],
+      "evidence": ["audio", "video", "transcript_artifact", "speaker_profile_artifact", "metrics"],
+      "identity_policy": {
+        "face_identity_binding": "forbidden_without_explicit_opt_in",
+        "sensitive_attribute_policy": "forbidden",
+        "allowed_identity_sources": ["voice_profile", "platform_roster", "user_correction"]
+      }
+    }
+  ],
   "metrics": {
     "transcript_quality": 1.0,
     "diarization_quality": 1.0,
@@ -494,6 +635,14 @@
     "jer": 0.0,
     "overlap_aware_wer": 0.0,
     "active_speaker_accuracy": 1.0,
+    "face_count_accuracy": 1.0,
+    "active_speaker_f1": 1.0,
+    "active_speaker_map": 1.0,
+    "audio_video_association_accuracy": 1.0,
+    "off_screen_speaker_detection_accuracy": 1.0,
+    "room_feed_heuristic_precision": 1.0,
+    "room_feed_heuristic_recall": 1.0,
+    "visual_acoustic_disagreement_rate": 0.0,
     "voice_profile_false_accept_rate": 0.0,
     "voice_profile_false_reject_rate": 0.0,
     "end_of_turn_latency_ms": 0,

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_cli.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_cli.py
@@ -31,6 +31,10 @@ def _fixture_speaker_name_provenance() -> list[object]:
     return json.loads(FIXTURE_MANIFEST.read_text(encoding="utf-8"))["speaker_name_provenance"]
 
 
+def _fixture_audio_visual_cases() -> list[object]:
+    return json.loads(FIXTURE_MANIFEST.read_text(encoding="utf-8"))["audio_visual_cases"]
+
+
 def _base_manifest(provider_mode: str = "real_zoom_meet") -> dict[str, object]:
     return {
         "provider_mode": provider_mode,
@@ -57,6 +61,7 @@ def _base_manifest(provider_mode: str = "real_zoom_meet") -> dict[str, object]:
         "capture_paths": _fixture_capture_paths(),
         "speaker_operations": _fixture_speaker_operations(),
         "speaker_name_provenance": _fixture_speaker_name_provenance(),
+        "audio_visual_cases": _fixture_audio_visual_cases(),
         "metrics": {
             "transcript_quality": 0.91,
             "diarization_quality": 0.82,
@@ -69,6 +74,14 @@ def _base_manifest(provider_mode: str = "real_zoom_meet") -> dict[str, object]:
             "jer": 0.22,
             "overlap_aware_wer": 0.2,
             "active_speaker_accuracy": 0.84,
+            "face_count_accuracy": 0.9,
+            "active_speaker_f1": 0.88,
+            "active_speaker_map": 0.87,
+            "audio_video_association_accuracy": 0.86,
+            "off_screen_speaker_detection_accuracy": 0.85,
+            "room_feed_heuristic_precision": 0.83,
+            "room_feed_heuristic_recall": 0.82,
+            "visual_acoustic_disagreement_rate": 0.12,
             "voice_profile_false_accept_rate": 0.03,
             "voice_profile_false_reject_rate": 0.08,
             "end_of_turn_latency_ms": 280,
@@ -98,6 +111,7 @@ def test_mocked_plumbing_fixture_is_not_publishable() -> None:
     assert len(report["capture_paths"]) == len(_fixture_capture_paths())
     assert len(report["speaker_operations"]) == len(_fixture_speaker_operations())
     assert len(report["speaker_name_provenance"]) == len(_fixture_speaker_name_provenance())
+    assert len(report["audio_visual_cases"]) == len(_fixture_audio_visual_cases())
 
 
 def test_real_lane_requires_non_mock_provider(tmp_path: Path) -> None:
@@ -432,6 +446,56 @@ def test_speaker_name_policies_reject_sensitive_attribute_shortcuts(tmp_path: Pa
         build_report(lane="real_product", manifest_path=manifest)
 
 
+def test_real_lane_requires_audio_visual_cases(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    manifest_data.pop("audio_visual_cases")
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="audio_visual_cases must be a non-empty array"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_audio_visual_cases_require_all_case_ids(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    manifest_data["audio_visual_cases"] = [
+        case
+        for case in _fixture_audio_visual_cases()
+        if isinstance(case, dict) and case.get("id") != "ava_active_speaker"
+    ]
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="missing audio visual cases"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_audio_visual_cases_forbid_face_identity_binding(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    cases = _fixture_audio_visual_cases()
+    assert isinstance(cases[0], dict)
+    policy = cases[0].get("identity_policy")
+    assert isinstance(policy, dict)
+    cases[0] = {**cases[0], "identity_policy": {**policy, "face_identity_binding": "allowed"}}
+    manifest_data["audio_visual_cases"] = cases
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="face_identity_binding"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_audio_visual_cases_reject_sensitive_attribute_policy(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    cases = _fixture_audio_visual_cases()
+    assert isinstance(cases[0], dict)
+    policy = cases[0].get("identity_policy")
+    assert isinstance(policy, dict)
+    cases[0] = {**cases[0], "identity_policy": {**policy, "sensitive_attribute_policy": "allowed"}}
+    manifest_data["audio_visual_cases"] = cases
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="sensitive_attribute_policy"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
 def test_real_lane_scores_lowest_required_quality_and_resolves_evidence(tmp_path: Path) -> None:
     evidence_names = [
         "audio",
@@ -487,6 +551,21 @@ def test_real_lane_scores_lowest_required_quality_and_resolves_evidence(tmp_path
         "preserve_unknown",
     }
     assert all("confidence" in case for case in report["speaker_name_provenance"])
+    assert {case["id"] for case in report["audio_visual_cases"]} >= {
+        "ava_active_speaker",
+        "misp_2025_meeting",
+        "easycom_license_permitting",
+        "synthetic_room_feed_smoke",
+        "off_screen_speaker",
+        "visual_acoustic_disagreement",
+        "audio_video_association",
+    }
+    assert all(
+        case["identity_policy"]["face_identity_binding"] == "forbidden_without_explicit_opt_in"
+        for case in report["audio_visual_cases"]
+    )
+    assert report["metrics"]["active_speaker_f1"] == pytest.approx(0.88)
+    assert report["metrics"]["visual_acoustic_disagreement_rate"] == pytest.approx(0.12)
     assert all(dataset["version"] for dataset in report["dataset_sources"])
     assert all(dataset["checksum"] for dataset in report["dataset_sources"])
     assert all(dataset["sample_count"] > 0 for dataset in report["dataset_sources"])

--- a/packages/benchmarks/registry/scores.py
+++ b/packages/benchmarks/registry/scores.py
@@ -926,6 +926,17 @@ _MEETING_PROOF_REQUIRED_REAL_METRICS = {
     "action_item_extraction",
 }
 
+_MEETING_PROOF_REQUIRED_AV_METRICS = {
+    "face_count_accuracy",
+    "active_speaker_f1",
+    "active_speaker_map",
+    "audio_video_association_accuracy",
+    "off_screen_speaker_detection_accuracy",
+    "room_feed_heuristic_precision",
+    "room_feed_heuristic_recall",
+    "visual_acoustic_disagreement_rate",
+}
+
 
 def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtraction:
     """Extract the #12486 meeting transcription proof score.
@@ -955,6 +966,8 @@ def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtrac
     speaker_name_provenance_count = (
         len(speaker_name_provenance) if isinstance(speaker_name_provenance, list) else 0
     )
+    audio_visual_cases = root.get("audio_visual_cases")
+    audio_visual_case_count = len(audio_visual_cases) if isinstance(audio_visual_cases, list) else 0
     publishable = root.get("publishable") is True
     if lane == "real_product":
         if not publishable:
@@ -984,6 +997,14 @@ def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtrac
         # check; the speaker-name provenance requirement is additive on top of it.
         if speaker_name_provenance_count < 8:
             raise ValueError("meeting_transcription_proof: real lane requires speaker name provenance")
+        if audio_visual_case_count < 7:
+            raise ValueError("meeting_transcription_proof: real lane requires audio_visual_cases")
+        missing_av_metrics = _MEETING_PROOF_REQUIRED_AV_METRICS - set(metrics)
+        if missing_av_metrics:
+            raise ValueError(
+                "meeting_transcription_proof: real lane requires audio-visual metrics "
+                f"{sorted(missing_av_metrics)}"
+            )
     elif publishable:
         raise ValueError("meeting_transcription_proof: mocked lane cannot be publishable")
 
@@ -996,10 +1017,19 @@ def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtrac
             "publishable": publishable,
             "evidence_file_count": evidence_count,
             "speaker_name_provenance_count": speaker_name_provenance_count,
+            "audio_visual_case_count": audio_visual_case_count,
             "transcript_quality": metrics.get("transcript_quality") or 0,
             "diarization_quality": metrics.get("diarization_quality") or 0,
             "speaker_identity_quality": metrics.get("speaker_identity_quality") or 0,
             "consent_retention_quality": metrics.get("consent_retention_quality") or 0,
+            "face_count_accuracy": metrics.get("face_count_accuracy") or 0,
+            "active_speaker_f1": metrics.get("active_speaker_f1") or 0,
+            "active_speaker_map": metrics.get("active_speaker_map") or 0,
+            "audio_video_association_accuracy": metrics.get("audio_video_association_accuracy") or 0,
+            "off_screen_speaker_detection_accuracy": metrics.get("off_screen_speaker_detection_accuracy") or 0,
+            "room_feed_heuristic_precision": metrics.get("room_feed_heuristic_precision") or 0,
+            "room_feed_heuristic_recall": metrics.get("room_feed_heuristic_recall") or 0,
+            "visual_acoustic_disagreement_rate": metrics.get("visual_acoustic_disagreement_rate") or 0,
             "provider_mode": root.get("provider_mode") or "",
         },
     )

--- a/packages/benchmarks/tests/test_registry_scores.py
+++ b/packages/benchmarks/tests/test_registry_scores.py
@@ -131,6 +131,14 @@ def _meeting_transcription_real_metrics() -> dict[str, float]:
         "p95_end_to_end_latency_ms": 1300,
         "notes_factuality": 0.93,
         "action_item_extraction": 0.89,
+        "face_count_accuracy": 0.9,
+        "active_speaker_f1": 0.88,
+        "active_speaker_map": 0.87,
+        "audio_video_association_accuracy": 0.86,
+        "off_screen_speaker_detection_accuracy": 0.85,
+        "room_feed_heuristic_precision": 0.83,
+        "room_feed_heuristic_recall": 0.82,
+        "visual_acoustic_disagreement_rate": 0.12,
     }
 
 
@@ -164,6 +172,7 @@ def _meeting_transcription_real_report() -> dict[str, object]:
         "capture_paths": [{"id": "google_meet_bot_free"}],
         "speaker_operations": [{"id": "speaker_name_correction"}],
         "speaker_name_provenance": [{} for _ in range(8)],
+        "audio_visual_cases": [{} for _ in range(7)],
     }
 
 
@@ -195,6 +204,24 @@ def test_meeting_transcription_real_lane_requires_speaker_name_provenance() -> N
         _score_from_meeting_transcription_proof_json(report)
 
 
+def test_meeting_transcription_real_lane_requires_audio_visual_cases() -> None:
+    report = _meeting_transcription_real_report()
+    report["audio_visual_cases"] = [{} for _ in range(6)]
+
+    with pytest.raises(ValueError, match="audio_visual_cases"):
+        _score_from_meeting_transcription_proof_json(report)
+
+
+def test_meeting_transcription_real_lane_requires_audio_visual_metrics() -> None:
+    report = _meeting_transcription_real_report()
+    metrics = report["metrics"]
+    assert isinstance(metrics, dict)
+    metrics.pop("active_speaker_f1")
+
+    with pytest.raises(ValueError, match="audio-visual metrics"):
+        _score_from_meeting_transcription_proof_json(report)
+
+
 def test_meeting_transcription_real_lane_score_is_publishable_with_evidence() -> None:
     extraction = _score_from_meeting_transcription_proof_json(_meeting_transcription_real_report())
 
@@ -203,3 +230,6 @@ def test_meeting_transcription_real_lane_score_is_publishable_with_evidence() ->
     assert extraction.metrics["publishable"] is True
     assert extraction.metrics["evidence_file_count"] == 11
     assert extraction.metrics["speaker_name_provenance_count"] == 8
+    assert extraction.metrics["audio_visual_case_count"] == 7
+    assert extraction.metrics["active_speaker_f1"] == pytest.approx(0.88)
+    assert extraction.metrics["visual_acoustic_disagreement_rate"] == pytest.approx(0.12)


### PR DESCRIPTION
## Summary

- add an `audio_visual_cases` manifest/report section to `meeting_transcription_proof`
- require seven AV case ids for AVA, MISP 2025, EasyCom, synthetic room feed, off-screen speakers, visual/acoustic disagreement, and audio-video association
- add AV coverage fields, AV metrics, and identity-policy guardrails that forbid face-only identity binding and sensitive-attribute shortcuts
- update the mock fixture, docs, CLI validation, CLI tests, and registry score extraction

## Evidence

- `.github/issue-evidence/12496-audio-visual-meeting-benchmark.md`
- Human-gated real AV dataset/model evidence follow-up: #13163. Real contact sheets, video/audio artifacts, AVA/MISP/EasyCom imports, model outputs, and manual review require licensed data or live capture.

## Verification

```bash
PYTHONPATH=packages/benchmarks/meeting-transcription-proof python -m pytest packages/benchmarks/meeting-transcription-proof/tests -q
```

Result: `28 passed`

```bash
python -m pytest packages/benchmarks/tests/test_registry_scores.py -q
```

Result: `9 passed`

```bash
python -m py_compile packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/cli.py packages/benchmarks/meeting-transcription-proof/tests/test_cli.py
```

Result: passed.

```bash
python -m elizaos_meeting_transcription_proof --lane mocked_plumbing --output /tmp/mtp-smoke-audio-visual-cases-12496
```

Result: mocked report emitted successfully. Manual inspection confirmed all 7 `audio_visual_cases`, new AV metric fields, and `forbidden_without_explicit_opt_in` identity policy guardrails.

Closes #12496
