### PR TITLE
fix(core): redact bare Stripe secret/restricted keys in log sink (#13164)

### DIFF
--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -59,6 +59,20 @@ describe("redactSensitiveText (pattern detection)", () => {
 		expect(redactSensitiveText(bearer)).not.toContain("a".repeat(40));
 	});
 
+	it("masks Stripe secret + restricted keys (underscore form)", () => {
+		// Stripe is the payment processor — a leaked sk_live_ is catastrophic, and these
+		// often appear as bare values (not under a *_SECRET name) in logged request bodies.
+		// Assemble the token from fragments at runtime so a contiguous Stripe-shaped key
+		// never sits in source — GitHub push-protection blocks even a fake literal one.
+		const body = "0123456789abcdefghijABCDEF";
+		for (const prefix of ["sk_live_", "sk_test_", "rk_live_", "rk_test_"]) {
+			const key = `${prefix}${body}`;
+			const out = redactSensitiveText(`stripe key ${key} end`);
+			expect(out).not.toContain(key);
+			expect(out).toContain("…");
+		}
+	});
+
 	it("mode:off is a passthrough", () => {
 		const key = "sk-0123456789abcdefghij";
 		expect(redactSensitiveText(key, { mode: "off" })).toBe(key);

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -44,6 +44,10 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
 	String.raw`-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----`,
 	// Common token prefixes.
 	String.raw`\b(sk-[A-Za-z0-9_-]{8,})\b`,
+	// Stripe secret + restricted keys (underscore form) — sk_live_/sk_test_/rk_live_/rk_test_.
+	// Distinct shape from the OpenAI sk- above; Stripe is the payment processor so a leaked
+	// sk_live_ is catastrophic, and these often appear as bare values (not under a *_SECRET name).
+	String.raw`\b((?:sk|rk)_(?:live|test)_[A-Za-z0-9]{10,})\b`,
 	String.raw`\b(ghp_[A-Za-z0-9]{20,})\b`,
 	String.raw`\b(github_pat_[A-Za-z0-9_]{20,})\b`,
 	String.raw`\b(xox[baprs]-[A-Za-z0-9-]{10,})\b`,


### PR DESCRIPTION
Closes #13164.

## What

`packages/core/src/security/redact.ts` `DEFAULT_REDACT_PATTERNS` — the value-shape redactor behind `redactLogArgs` (the log sink) — had **no pattern for Stripe keys in their underscore form**: `sk_live_`/`sk_test_` (secret) and `rk_live_`/`rk_test_` (restricted). The only `sk`-shaped pattern was `\b(sk-[A-Za-z0-9_-]{8,})\b` — the **OpenAI hyphen** form (`sk-`), which does **not** match Stripe's **underscore** form (`sk_`). So a bare Stripe key logged as a plain value (not under a `*_SECRET`/`*_KEY` name the name-based redactor catches) was emitted **unredacted**.

Note: the *PII-detector* subsystem (`pii-detectors.ts`, a distinct code path) already knew the `stripe-key` shape — this closes the parallel gap in the log-sink redactor so the two agree.

## Why it matters

Stripe is the payment processor for Eliza Cloud. A leaked `sk_live_` grants full API access to the Stripe account (charges, refunds, payouts, customer PII). Request bodies, webhook payloads, and error contexts routinely flow through the structured logger; the value-shape redactor is the last line of defense before the sink. Defense-in-depth, cheap, zero behavior change to the OpenAI `sk-` path.

## Change

- Add `\b((?:sk|rk)_(?:live|test)_[A-Za-z0-9]{10,})\b` to `DEFAULT_REDACT_PATTERNS`, right after the OpenAI `sk-` pattern.
- Add a **red/green** unit test in `redact.test.ts` asserting `sk_live_`/`sk_test_`/`rk_live_`/`rk_test_` values are masked.

## Evidence

- **Red without the pattern** (proves the test is real, not false-green):
  ```
  × masks Stripe secret + restricted keys (underscore form)
  Tests  1 failed | 22 passed (23)
  ```
- **Green with the pattern**:
  ```
  Test Files  1 passed (1)
  Tests  23 passed (23)
  ```
- `bun run --cwd packages/core typecheck` → clean (exit 0). Biome clean.
- The test assembles the key from fragments at runtime (`${prefix}${body}`) so no contiguous Stripe-shaped literal sits in source — GitHub push-protection blocks even a fake literal one; behavior under test is identical.

N/A rows (non-UI, non-model core-security unit change): screenshots / video / LLM trajectories / device capture — this touches only a synchronous string-redaction pattern with deterministic unit coverage.

Money/security lane — please review; not self-merging.

— [cloud-money]