### PR TITLE
fix(local-inference): slot load-balance skip, stream single-flight gap, duplicate latency keys

### DIFF
--- a/plugins/plugin-local-inference/src/services/conversation-registry.test.ts
+++ b/plugins/plugin-local-inference/src/services/conversation-registry.test.ts
@@ -234,3 +234,24 @@ describe("ConversationRegistry.__resetForTests", () => {
 		expect(conversationRegistry.size()).toBe(0);
 	});
 });
+
+describe("ConversationRegistry slot pinning under uneven load", () => {
+	// Hash parities used below (sha256(id) first-u32 % 2):
+	//   conv-a → 1, conv-b → 0, conv-c → 1, conv-e → 1.
+	it("prefers the strictly lowest-loaded slot over the hash tie-break", () => {
+		const registry = new ConversationRegistry();
+		const open = (id: string): number =>
+			registry.open({ conversationId: id, modelId: "m", parallel: 2 }).slotId;
+		const a = open("conv-a"); // empty pool → first free slot
+		const b = open("conv-b"); // other slot (load 0)
+		expect(new Set([a, b]).size).toBe(2);
+		// True tie (1/1) → deterministic hash tie-break; conv-c hashes to slot 1.
+		const c = open("conv-c");
+		expect(c).toBe(1);
+		// Loads are now uneven (slot 1 holds 2, slot 0 holds 1). conv-e also
+		// hashes to slot 1 — the registry must still pin it to the lighter slot 0
+		// instead of stacking a third conversation onto the hottest KV slot.
+		const e = open("conv-e");
+		expect(e).toBe(0);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/conversation-registry.ts
+++ b/plugins/plugin-local-inference/src/services/conversation-registry.ts
@@ -237,14 +237,20 @@ export class ConversationRegistry {
 		if (parallel <= 1) return 0;
 		let bestSlot = 0;
 		let bestLoad = Number.POSITIVE_INFINITY;
+		let worstLoad = 0;
 		for (let slot = 0; slot < parallel; slot += 1) {
 			const load = this.slotLoad.get(slot) ?? 0;
 			if (load < bestLoad) {
 				bestLoad = load;
 				bestSlot = slot;
 			}
+			if (load > worstLoad) {
+				worstLoad = load;
+			}
 		}
-		if (bestLoad === 0) return bestSlot;
+		// A strictly lower-loaded slot always wins — hashing here could pin the
+		// conversation onto the hottest slot and thrash its KV cache.
+		if (bestLoad < worstLoad || bestLoad === 0) return bestSlot;
 		// All slots are loaded equally — use the conversation hash for a
 		// deterministic tie-break. Same conversation, same slot when reopened.
 		const digest = createHash("sha256").update(conversationId).digest();

--- a/plugins/plugin-local-inference/src/services/ffi-streaming-runner.test.ts
+++ b/plugins/plugin-local-inference/src/services/ffi-streaming-runner.test.ts
@@ -219,3 +219,83 @@ describe("FfiStreamingRunner per-step granularity (#9174)", () => {
 		});
 	});
 });
+
+describe("FfiStreamingRunner generateStream slot single-flight", () => {
+	/** Binding with per-stream step state + an open/close event log. */
+	function makeSerializingProbeBinding(): {
+		binding: LlmStreamingBinding;
+		events: string[];
+	} {
+		const events: string[] = [];
+		let streamCounter = 0n;
+		const stepByStream = new Map<bigint, number>();
+		const binding: LlmStreamingBinding = {
+			llmStreamSupported: () => true,
+			llmStreamOpen: vi.fn((): LlmStreamHandle => {
+				streamCounter += 1n;
+				stepByStream.set(streamCounter, 0);
+				events.push("open");
+				return streamCounter as LlmStreamHandle;
+			}),
+			llmStreamPrefill: vi.fn(),
+			llmStreamNext: vi.fn(
+				(args: { stream: LlmStreamHandle }): LlmStreamStep => {
+					const i = stepByStream.get(args.stream as bigint) ?? 0;
+					stepByStream.set(args.stream as bigint, i + 1);
+					return {
+						tokens: [i],
+						text: i === 0 ? "a" : "b",
+						done: i >= 1,
+						drafterDrafted: 0,
+						drafterAccepted: 0,
+					};
+				},
+			),
+			llmStreamCancel: vi.fn(),
+			llmStreamClose: vi.fn(() => {
+				events.push("close");
+			}),
+		};
+		return { binding, events };
+	}
+
+	it("serializes generateStream against generateWithUsage on the same pinned slot", async () => {
+		const { binding, events } = makeSerializingProbeBinding();
+		const runner = new FfiStreamingRunner(binding, 1n as LlmCtxHandle);
+
+		let releaseFirstChunk!: () => void;
+		const firstChunkGate = new Promise<void>((resolve) => {
+			releaseFirstChunk = resolve;
+		});
+		const streamIter = runner
+			.generateStream({
+				...BASE_ARGS,
+				promptTokens: new Int32Array([1]),
+				onTextChunk: () => firstChunkGate,
+			})
+			[Symbol.asyncIterator]();
+
+		// Pull the first step: stream A is open and parked awaiting its chunk gate.
+		const first = await streamIter.next();
+		expect(first.value?.text).toBe("a");
+		expect(events).toEqual(["open"]);
+
+		// A second generation on the SAME pinned slot must not open a session
+		// while A is still in flight — interleaving would corrupt the slot's KV.
+		const second = runner.generateWithUsage({
+			...BASE_ARGS,
+			promptTokens: new Int32Array([1]),
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(events).toEqual(["open"]);
+
+		releaseFirstChunk();
+		// Drain A, then let B finish.
+		while (!(await streamIter.next()).done) {
+			// draining
+		}
+		const result = await second;
+		expect(result.text).toBe("ab");
+		expect(events).toEqual(["open", "close", "open", "close"]);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/ffi-streaming-runner.ts
+++ b/plugins/plugin-local-inference/src/services/ffi-streaming-runner.ts
@@ -159,23 +159,34 @@ export class FfiStreamingRunner {
 	async generateWithUsage(
 		args: FfiStreamingGenerateArgs,
 	): Promise<FfiStreamingGenerateResult> {
-		if (args.slotId < 0) {
-			return this.runGenerate(args);
+		return this.withSlotLock(args.slotId, () => this.runGenerate(args));
+	}
+
+	/**
+	 * Serialize `fn` behind any in-flight generation on the same pinned slot.
+	 * Slot id `-1` (unpinned) runs immediately. Both `generateWithUsage` and
+	 * `generateStream` route through here — two concurrent generations against
+	 * the same pinned slot would interleave the slot's KV cache state.
+	 */
+	private async withSlotLock<T>(
+		slotId: number,
+		fn: () => Promise<T>,
+	): Promise<T> {
+		if (slotId < 0) {
+			return fn();
 		}
-		const prior = this.slotInFlight.get(args.slotId);
-		const run = (prior ?? Promise.resolve())
-			.catch(() => {})
-			.then(() => this.runGenerate(args));
+		const prior = this.slotInFlight.get(slotId);
+		const run = (prior ?? Promise.resolve()).catch(() => {}).then(fn);
 		const tail = run.then(
 			() => {},
 			() => {},
 		);
-		this.slotInFlight.set(args.slotId, tail);
+		this.slotInFlight.set(slotId, tail);
 		try {
 			return await run;
 		} finally {
-			if (this.slotInFlight.get(args.slotId) === tail) {
-				this.slotInFlight.delete(args.slotId);
+			if (this.slotInFlight.get(slotId) === tail) {
+				this.slotInFlight.delete(slotId);
 			}
 		}
 	}
@@ -184,8 +195,8 @@ export class FfiStreamingRunner {
 	 * Async-iterable variant. Yields each accepted-token batch as it lands
 	 * so callers that want token-grained control (e.g. the voice scheduler
 	 * driving phrase-chunking off accept/reject events) don't have to
-	 * register a callback. Internally still routes through `generateWithUsage`
-	 * via a pump so the single-flight rule applies.
+	 * register a callback. The pump acquires the same per-slot lock as
+	 * `generateWithUsage`, so the single-flight rule applies to streams too.
 	 */
 	async *generateStream(
 		args: FfiStreamingGenerateArgs,
@@ -209,7 +220,7 @@ export class FfiStreamingRunner {
 			wakeConsumer();
 		};
 
-		const work = (async () => {
+		const work = this.withSlotLock(args.slotId, async () => {
 			try {
 				await this.runGenerateInner(args, onStep);
 			} catch (err) {
@@ -218,7 +229,7 @@ export class FfiStreamingRunner {
 				finished = true;
 				wakeConsumer();
 			}
-		})();
+		});
 
 		try {
 			while (true) {

--- a/plugins/plugin-local-inference/src/services/latency-trace.test.ts
+++ b/plugins/plugin-local-inference/src/services/latency-trace.test.ts
@@ -265,3 +265,26 @@ describe("EndToEndLatencyTracer", () => {
 		expect(tracer.histogramSummaries().ttftMs.count).toBe(0);
 	});
 });
+
+describe("LATENCY_DERIVED_KEYS histogram accounting", () => {
+	it("contains each derived-metric key exactly once", () => {
+		expect(new Set(LATENCY_DERIVED_KEYS).size).toBe(
+			LATENCY_DERIVED_KEYS.length,
+		);
+	});
+
+	it("folds one duet turn into each duet histogram exactly once", () => {
+		const tracer = new EndToEndLatencyTracer();
+		const turnId = tracer.beginTurn({});
+		tracer.mark(turnId, "peer-utterance-end", 1_000);
+		tracer.mark(turnId, "llm-first-token", 1_100);
+		tracer.mark(turnId, "replyText-first-emotion-tag", 1_150);
+		tracer.mark(turnId, "audio-first-into-peer-ring", 1_500);
+		tracer.endTurn(turnId);
+		const h = tracer.histogramSummaries();
+		expect(h.ttftFromUtteranceEndMs.count).toBe(1);
+		expect(h.ttftFromUtteranceEndMs.p50).toBe(100);
+		expect(h.firstAudioIntoPeerRingFromUtteranceEndMs.count).toBe(1);
+		expect(h.emotionTagOverheadMs.count).toBe(1);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/latency-trace.ts
+++ b/plugins/plugin-local-inference/src/services/latency-trace.ts
@@ -171,7 +171,11 @@ export interface LatencyDerived {
 	emotionTagOverheadMs: number | null;
 }
 
-/** The derived-metric keys, in display order. */
+/**
+ * The derived-metric keys, in display order (duet headline numbers first).
+ * Every `LatencyDerived` key must appear exactly once: `endTurn` folds one
+ * histogram sample per entry, so a duplicate would double-count that metric.
+ */
 export const LATENCY_DERIVED_KEYS = [
 	"ttftFromUtteranceEndMs",
 	"firstAudioIntoPeerRingFromUtteranceEndMs",
@@ -187,11 +191,8 @@ export const LATENCY_DERIVED_KEYS = [
 	"replyTextToPhrase1Ms",
 	"ttsFirstChunkMs",
 	"audioSinkLatencyMs",
-	"ttftFromUtteranceEndMs",
 	"replyTextFirstCharFromUtteranceEndMs",
 	"firstTtsPcmFromUtteranceEndMs",
-	"firstAudioIntoPeerRingFromUtteranceEndMs",
-	"emotionTagOverheadMs",
 ] as const satisfies ReadonlyArray<keyof LatencyDerived>;
 
 export type LatencyDerivedKey = (typeof LATENCY_DERIVED_KEYS)[number];


### PR DESCRIPTION
## Summary
Three real, mutation-checked pure-logic correctness bugs in `@elizaos/plugin-local-inference` services (slot scheduling + voice-latency accounting). No native binding / model-load paths touched; all pure TS logic.

### 1. `conversation-registry.ts` — least-loaded slot skipped unless its load is exactly 0
`pickSlot` tracked the least-loaded slot (`bestLoad`) but only short-circuited to it with `if (bestLoad === 0) return bestSlot`. When **all slots carry non-zero but unequal load** (e.g. loads `[1, 3, 5]`), `bestLoad` is `1` (≠ 0), so the guard fails and execution falls through to the SHA-256 hash tie-break — which can deterministically pin the conversation onto a *more*-loaded slot, thrashing that slot's KV cache instead of using the genuinely idle-est one.

**Fix:** `if (bestLoad < worstLoad || bestLoad === 0) return bestSlot;` — a strictly-lower-loaded slot always wins; the hash tie-break is reserved for the genuine all-equal case (`bestLoad === worstLoad`).

### 2. `ffi-streaming-runner.ts` — `generateStream` bypassed the per-slot single-flight lock
`generateWithUsage` serialized generations on a pinned slot via `slotInFlight`, but the async-iterable `generateStream` did not route through that lock (the doc-comment claimed it did "via a pump", but the pump called `runGenerate` without acquiring `slotInFlight`). Two concurrent generations against the **same pinned slot** could therefore interleave the slot's KV-cache state.

**Fix:** extracted `withSlotLock(slotId, fn)` (slot `-1`/unpinned runs immediately; pinned slots chain behind any in-flight run on that slot) and routed **both** `generateWithUsage` and the stream pump through it, so single-flight applies to streams too.

### 3. `latency-trace.ts` — `LATENCY_DERIVED_KEYS` double-counted three metrics
The derived-metric key list repeated `ttftFromUtteranceEndMs`, `firstAudioIntoPeerRingFromUtteranceEndMs`, and `emotionTagOverheadMs`. `endTurn` folds one histogram sample per key entry, so those three duet-latency metrics were **counted twice per turn** — inflating their sample count and skewing the aggregates. Removed the duplicate entries (each key now appears exactly once, `satisfies` guarantees coverage).

## Evidence
| Check | Result |
|---|---|
| Service tests (all 3 files) | `bunx vitest run --no-cache …conversation-registry.test.ts …ffi-streaming-runner.test.ts …latency-trace.test.ts` → **42/42 green** |
| Mutation — conversation-registry | revert src → its test FAILS (1 failed / 18); restore → green |
| Mutation — ffi-streaming-runner | revert src → its test FAILS (1 failed / 10); restore → green |
| Mutation — latency-trace | revert src → its test FAILS (2 failed / 14); restore → green |
| biome | clean on all 6 files |
| Real-LLM trajectories | N/A — no model/prompt behavior change; slot-scheduling + metric-accounting logic |
| Frontend/UI evidence | N/A — service-layer logic, no UI surface |

---
**Authored end-to-end by a Fable-5 agent** (workflow transcript verified 100% claude-fable-5). The agent hit its session cap after writing all three fixes + tests but before the commit/self-verify step; I (main loop) rescued the uncommitted Fable-authored tree, ran the purity check, ran all 3 tests (42/42), and independently mutation-checked each fix (revert src → exactly its test reds → restore) before committing. No code was authored in the main loop — this is verify-and-ship of Fable work. — [phone-ui]
