### PR TITLE
fix(#12499): add meeting intelligence scoring contract

### DIFF
--- a/.github/issue-evidence/12499-meeting-intelligence-benchmark.md
+++ b/.github/issue-evidence/12499-meeting-intelligence-benchmark.md
@@ -1,0 +1,72 @@
+# Evidence for #12499 - Meeting Intelligence Benchmark
+
+## Code PR
+
+https://github.com/elizaOS/eliza/pull/13169
+
+## Human Follow-Up
+
+https://github.com/elizaOS/eliza/issues/13170
+
+## Agent-Completed Work
+
+- Added `generated_artifact_scores` validation to the meeting transcription proof manifest/report contract.
+- Added deterministic generated-artifact scoring for summaries, action items, decisions, open questions, memory entities, hallucination rate, omission rate, and source grounding.
+- Added mock fixture coverage for all eight generated meeting-intelligence score rows.
+- Added registry gating so real product reports cannot publish without the complete generated-artifact score set.
+- Documented deterministic, live-model, and manual proof requirements.
+
+## Verification
+
+Commands run on 2026-07-04:
+
+```bash
+bun install
+```
+
+Result: completed; no intended dependency changes were kept in this PR.
+
+```bash
+bun run verify
+```
+
+Result: failed in the repo-wide lint lane before reaching this benchmark package. The failing task was `@elizaos/tui#lint`, with existing `lint/suspicious/noControlCharactersInRegex` diagnostics in `packages/tui/src/keys.ts` and `packages/tui/src/terminal.ts`. The same run also reported existing warnings in `@elizaos/security#lint` and `@elizaos/capacitor-llama#lint`. None of those files are touched by this PR.
+
+```bash
+pytest packages/benchmarks/meeting-transcription-proof/tests -q
+```
+
+Result: 31 focused meeting-transcription-proof tests passed.
+
+```bash
+pytest packages/benchmarks/tests/test_registry_scores.py -q
+```
+
+Result: 8 registry score tests passed.
+
+```bash
+python -m py_compile \
+  packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/artifact_scoring.py \
+  packages/benchmarks/meeting-transcription-proof/tests/test_artifact_scoring.py
+```
+
+Result: passed with no syntax errors.
+
+```bash
+PYTHONPATH=packages/benchmarks/meeting-transcription-proof python -m elizaos_meeting_transcription_proof \
+  --lane mocked_plumbing \
+  --output /tmp/mtp-smoke-generated-artifacts-12499
+```
+
+Result: wrote `/tmp/mtp-smoke-generated-artifacts-12499/meeting-transcription-proof-report.json`.
+
+Manual report inspection confirmed:
+
+- `lane`: `mocked_plumbing`
+- `publishable`: `false`
+- `generated_artifact_scores`: 8 rows
+- generated metric values present for `summary_factuality`, `action_item_owner_date`, `decision_extraction`, `open_question_extraction`, `memory_entity_correctness`, `hallucination_rate`, `omission_rate`, and `source_grounding`
+
+## Not Captured By Agent
+
+N/A for live model/product proof in this code PR. The follow-up human issue must capture real meeting product runs, live LLM trajectories, manually reviewed generated artifacts, UI/video evidence, structured backend and frontend logs, and domain artifacts from memory/knowledge writes.

--- a/packages/benchmarks/meeting-transcription-proof/AGENTS.md
+++ b/packages/benchmarks/meeting-transcription-proof/AGENTS.md
@@ -28,6 +28,7 @@ pytest packages/benchmarks/meeting-transcription-proof/tests -q
 | Path | Role |
 | --- | --- |
 | `elizaos_meeting_transcription_proof/cli.py` | CLI, manifest validation, report writer |
+| `elizaos_meeting_transcription_proof/artifact_scoring.py` | Deterministic generated-artifact scoring |
 | `fixtures/mock-meeting-manifest.json` | Hermetic schema/capture/evidence fixture |
 | `tests/` | Lane separation and real evidence validation tests |
 
@@ -65,6 +66,16 @@ Face tracks are localization evidence only. Identity binding from face data is
 forbidden without an explicit opt-in identity source such as a voice profile,
 user correction, calendar participant, or platform roster. Sensitive-attribute
 shortcuts are always forbidden.
+
+The real lane also requires generated meeting intelligence scores:
+`summary_factuality`, `action_item_owner_date`, `decision_extraction`,
+`open_question_extraction`, `memory_entity_correctness`, `hallucination_rate`,
+`omission_rate`, and `source_grounding`. Each manifest row must include
+`observed_score`, `threshold`, `higher_is_better`, `passed`, `judge_mode`, and
+`proof`; the validator rejects rows whose `passed` flag does not match the
+threshold direction. `deterministic` rows require `score_report`, `live_model`
+rows require `model_trajectory_jsonl`, `raw_prompt`, `model_output`, and
+`judge_output`, and `manual` rows require `manual_review`.
 
 ## Dataset Contract
 

--- a/packages/benchmarks/meeting-transcription-proof/CLAUDE.md
+++ b/packages/benchmarks/meeting-transcription-proof/CLAUDE.md
@@ -28,6 +28,7 @@ pytest packages/benchmarks/meeting-transcription-proof/tests -q
 | Path | Role |
 | --- | --- |
 | `elizaos_meeting_transcription_proof/cli.py` | CLI, manifest validation, report writer |
+| `elizaos_meeting_transcription_proof/artifact_scoring.py` | Deterministic generated-artifact scoring |
 | `fixtures/mock-meeting-manifest.json` | Hermetic schema/capture/evidence fixture |
 | `tests/` | Lane separation and real evidence validation tests |
 
@@ -65,6 +66,16 @@ Face tracks are localization evidence only. Identity binding from face data is
 forbidden without an explicit opt-in identity source such as a voice profile,
 user correction, calendar participant, or platform roster. Sensitive-attribute
 shortcuts are always forbidden.
+
+The real lane also requires generated meeting intelligence scores:
+`summary_factuality`, `action_item_owner_date`, `decision_extraction`,
+`open_question_extraction`, `memory_entity_correctness`, `hallucination_rate`,
+`omission_rate`, and `source_grounding`. Each manifest row must include
+`observed_score`, `threshold`, `higher_is_better`, `passed`, `judge_mode`, and
+`proof`; the validator rejects rows whose `passed` flag does not match the
+threshold direction. `deterministic` rows require `score_report`, `live_model`
+rows require `model_trajectory_jsonl`, `raw_prompt`, `model_output`, and
+`judge_output`, and `manual` rows require `manual_review`.
 
 ## Dataset Contract
 

--- a/packages/benchmarks/meeting-transcription-proof/README.md
+++ b/packages/benchmarks/meeting-transcription-proof/README.md
@@ -140,6 +140,22 @@ F1/mAP, audio-video association accuracy, off-screen speaker detection accuracy,
 room-feed precision/recall, and visual/acoustic disagreement rate while
 forbidding face-only identity binding and sensitive attribute shortcuts.
 
+Real manifests must include `generated_artifact_scores` for meeting
+intelligence outputs. Required rows are `summary_factuality`,
+`action_item_owner_date`, `decision_extraction`, `open_question_extraction`,
+`memory_entity_correctness`, `hallucination_rate`, `omission_rate`, and
+`source_grounding`. Each row carries `observed_score`, `threshold`,
+`higher_is_better`, `passed`, `judge_mode`, and `proof`; the validator checks
+that `passed` matches the threshold direction. Deterministic rows must point to
+a score report, live-model rows must include the trajectory JSONL, raw prompt,
+model output, and judge output, and manual rows must point to a manual review.
+
+`elizaos_meeting_transcription_proof.artifact_scoring` provides the
+deterministic artifact scorer for transcript-grounded generated summaries,
+action items, decisions, open questions, memory entities, hallucination rate,
+omission rate, and source grounding. Live-model artifact scores are still
+expected to attach real trajectories and reviewed outputs in the manifest.
+
 ## Fixture Manifest
 
 `fixtures/mock-meeting-manifest.json` describes the minimum canonical meeting

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/artifact_scoring.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/artifact_scoring.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import Any
+
+
+GENERATED_ARTIFACT_SCORE_IDS = (
+    "summary_factuality",
+    "action_item_owner_date",
+    "decision_extraction",
+    "open_question_extraction",
+    "memory_entity_correctness",
+    "hallucination_rate",
+    "omission_rate",
+    "source_grounding",
+)
+
+
+def _normalize(value: object) -> str:
+    text = str(value or "").lower()
+    return re.sub(r"[^a-z0-9]+", " ", text).strip()
+
+
+def _key(row: dict[str, Any], *fields: str) -> tuple[str, ...]:
+    return tuple(_normalize(row.get(field)) for field in fields)
+
+
+def _rows(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [row for row in value if isinstance(row, dict)]
+
+
+def _span_text(transcript_segments: list[dict[str, Any]], span_ids: Iterable[object]) -> str:
+    wanted = {_normalize(span_id) for span_id in span_ids}
+    parts = []
+    for segment in transcript_segments:
+        segment_id = _normalize(segment.get("id"))
+        if segment_id in wanted:
+            parts.append(str(segment.get("text") or ""))
+    return " ".join(parts)
+
+
+def _valid_span_ids(transcript_segments: list[dict[str, Any]]) -> set[str]:
+    return {_normalize(segment.get("id")) for segment in transcript_segments}
+
+
+def _has_valid_grounding(row: dict[str, Any], valid_span_ids: set[str]) -> bool:
+    span_ids = row.get("source_span_ids")
+    if not isinstance(span_ids, list) or not span_ids:
+        return False
+    return all(_normalize(span_id) in valid_span_ids for span_id in span_ids)
+
+
+def _claim_supported(row: dict[str, Any], transcript_segments: list[dict[str, Any]]) -> bool:
+    span_ids = row.get("source_span_ids")
+    if not isinstance(span_ids, list):
+        return False
+    claim = _normalize(row.get("text") or row.get("claim") or row.get("title"))
+    if not claim:
+        return False
+    source = _normalize(_span_text(transcript_segments, span_ids))
+    return bool(source) and (claim in source or source in claim)
+
+
+def _precision_recall_f1(generated: set[tuple[str, ...]], reference: set[tuple[str, ...]]) -> dict[str, float]:
+    if not generated and not reference:
+        return {"precision": 1.0, "recall": 1.0, "f1": 1.0}
+    if not generated:
+        return {"precision": 0.0, "recall": 0.0, "f1": 0.0}
+    true_positive = len(generated & reference)
+    precision = true_positive / len(generated)
+    recall = true_positive / len(reference) if reference else 1.0
+    f1 = 0.0 if precision + recall == 0 else (2 * precision * recall) / (precision + recall)
+    return {
+        "precision": round(precision, 6),
+        "recall": round(recall, 6),
+        "f1": round(f1, 6),
+    }
+
+
+def _unsupported_count(
+    generated_rows: list[dict[str, Any]],
+    reference_keys: set[tuple[str, ...]],
+    key_fields: tuple[str, ...],
+    transcript_segments: list[dict[str, Any]],
+) -> int:
+    count = 0
+    for row in generated_rows:
+        if _key(row, *key_fields) not in reference_keys and not _claim_supported(row, transcript_segments):
+            count += 1
+    return count
+
+
+def score_generated_artifacts(
+    *,
+    transcript_segments: list[dict[str, Any]],
+    generated_artifacts: dict[str, Any],
+    reference_artifacts: dict[str, Any],
+) -> dict[str, Any]:
+    valid_span_ids = _valid_span_ids(transcript_segments)
+    summary_rows = _rows(generated_artifacts.get("summary_claims"))
+    supported_summary = sum(1 for row in summary_rows if _claim_supported(row, transcript_segments))
+    summary_factuality = supported_summary / len(summary_rows) if summary_rows else 1.0
+
+    generated_actions = {_key(row, "text", "owner", "due") for row in _rows(generated_artifacts.get("action_items"))}
+    reference_actions = {_key(row, "text", "owner", "due") for row in _rows(reference_artifacts.get("action_items"))}
+    action_scores = _precision_recall_f1(generated_actions, reference_actions)
+
+    generated_decisions = {_key(row, "text") for row in _rows(generated_artifacts.get("decisions"))}
+    reference_decisions = {_key(row, "text") for row in _rows(reference_artifacts.get("decisions"))}
+    decision_scores = _precision_recall_f1(generated_decisions, reference_decisions)
+
+    generated_questions = {_key(row, "text") for row in _rows(generated_artifacts.get("open_questions"))}
+    reference_questions = {_key(row, "text") for row in _rows(reference_artifacts.get("open_questions"))}
+    question_scores = _precision_recall_f1(generated_questions, reference_questions)
+
+    generated_memory = {
+        _key(row, "entity_id", "name", "fact") for row in _rows(generated_artifacts.get("memory_entities"))
+    }
+    reference_memory = {
+        _key(row, "entity_id", "name", "fact") for row in _rows(reference_artifacts.get("memory_entities"))
+    }
+    memory_scores = _precision_recall_f1(generated_memory, reference_memory)
+
+    generated_summary_keys = {_key(row, "text") for row in summary_rows}
+    reference_summary_keys = {_key(row, "text") for row in _rows(reference_artifacts.get("summary_claims"))}
+    unsupported = 0
+    unsupported += _unsupported_count(summary_rows, reference_summary_keys, ("text",), transcript_segments)
+    unsupported += _unsupported_count(
+        _rows(generated_artifacts.get("action_items")),
+        reference_actions,
+        ("text", "owner", "due"),
+        transcript_segments,
+    )
+    unsupported += _unsupported_count(
+        _rows(generated_artifacts.get("decisions")),
+        reference_decisions,
+        ("text",),
+        transcript_segments,
+    )
+    unsupported += _unsupported_count(
+        _rows(generated_artifacts.get("open_questions")),
+        reference_questions,
+        ("text",),
+        transcript_segments,
+    )
+    generated_total = (
+        len(generated_summary_keys)
+        + len(generated_actions)
+        + len(generated_decisions)
+        + len(generated_questions)
+        + len(generated_memory)
+    )
+    hallucination_rate = unsupported / generated_total if generated_total else 0.0
+
+    reference_total = (
+        len(reference_summary_keys)
+        + len(reference_actions)
+        + len(reference_decisions)
+        + len(reference_questions)
+        + len(reference_memory)
+    )
+    covered = (
+        len(generated_summary_keys & reference_summary_keys)
+        + len(generated_actions & reference_actions)
+        + len(generated_decisions & reference_decisions)
+        + len(generated_questions & reference_questions)
+        + len(generated_memory & reference_memory)
+    )
+    omission_rate = (reference_total - covered) / reference_total if reference_total else 0.0
+
+    grounded_rows = []
+    for section in ("summary_claims", "action_items", "decisions", "open_questions", "memory_entities"):
+        grounded_rows.extend(_rows(generated_artifacts.get(section)))
+    grounded_count = sum(1 for row in grounded_rows if _has_valid_grounding(row, valid_span_ids))
+    source_grounding = grounded_count / len(grounded_rows) if grounded_rows else 1.0
+
+    return {
+        "summary_factuality": round(summary_factuality, 6),
+        "action_item_owner_date": action_scores["f1"],
+        "decision_extraction": decision_scores["f1"],
+        "open_question_extraction": question_scores["f1"],
+        "memory_entity_correctness": memory_scores["f1"],
+        "hallucination_rate": round(hallucination_rate, 6),
+        "omission_rate": round(omission_rate, 6),
+        "source_grounding": round(source_grounding, 6),
+        "details": {
+            "action_items": action_scores,
+            "decisions": decision_scores,
+            "open_questions": question_scores,
+            "memory_entities": memory_scores,
+            "unsupported_generated_items": unsupported,
+            "generated_items": generated_total,
+            "reference_items": reference_total,
+            "grounded_items": grounded_count,
+        },
+    }

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/artifact_scoring.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/artifact_scoring.py
@@ -104,20 +104,25 @@ def score_generated_artifacts(
     supported_summary = sum(1 for row in summary_rows if _claim_supported(row, transcript_segments))
     summary_factuality = supported_summary / len(summary_rows) if summary_rows else 1.0
 
-    generated_actions = {_key(row, "text", "owner", "due") for row in _rows(generated_artifacts.get("action_items"))}
+    generated_action_rows = _rows(generated_artifacts.get("action_items"))
+    generated_decision_rows = _rows(generated_artifacts.get("decisions"))
+    generated_question_rows = _rows(generated_artifacts.get("open_questions"))
+    generated_memory_rows = _rows(generated_artifacts.get("memory_entities"))
+
+    generated_actions = {_key(row, "text", "owner", "due") for row in generated_action_rows}
     reference_actions = {_key(row, "text", "owner", "due") for row in _rows(reference_artifacts.get("action_items"))}
     action_scores = _precision_recall_f1(generated_actions, reference_actions)
 
-    generated_decisions = {_key(row, "text") for row in _rows(generated_artifacts.get("decisions"))}
+    generated_decisions = {_key(row, "text") for row in generated_decision_rows}
     reference_decisions = {_key(row, "text") for row in _rows(reference_artifacts.get("decisions"))}
     decision_scores = _precision_recall_f1(generated_decisions, reference_decisions)
 
-    generated_questions = {_key(row, "text") for row in _rows(generated_artifacts.get("open_questions"))}
+    generated_questions = {_key(row, "text") for row in generated_question_rows}
     reference_questions = {_key(row, "text") for row in _rows(reference_artifacts.get("open_questions"))}
     question_scores = _precision_recall_f1(generated_questions, reference_questions)
 
     generated_memory = {
-        _key(row, "entity_id", "name", "fact") for row in _rows(generated_artifacts.get("memory_entities"))
+        _key(row, "entity_id", "name", "fact") for row in generated_memory_rows
     }
     reference_memory = {
         _key(row, "entity_id", "name", "fact") for row in _rows(reference_artifacts.get("memory_entities"))
@@ -129,31 +134,31 @@ def score_generated_artifacts(
     unsupported = 0
     unsupported += _unsupported_count(summary_rows, reference_summary_keys, ("text",), transcript_segments)
     unsupported += _unsupported_count(
-        _rows(generated_artifacts.get("action_items")),
+        generated_action_rows,
         reference_actions,
         ("text", "owner", "due"),
         transcript_segments,
     )
     unsupported += _unsupported_count(
-        _rows(generated_artifacts.get("decisions")),
+        generated_decision_rows,
         reference_decisions,
         ("text",),
         transcript_segments,
     )
     unsupported += _unsupported_count(
-        _rows(generated_artifacts.get("open_questions")),
+        generated_question_rows,
         reference_questions,
         ("text",),
         transcript_segments,
     )
-    generated_total = (
-        len(generated_summary_keys)
-        + len(generated_actions)
-        + len(generated_decisions)
-        + len(generated_questions)
-        + len(generated_memory)
+    generated_total_rows = (
+        len(summary_rows)
+        + len(generated_action_rows)
+        + len(generated_decision_rows)
+        + len(generated_question_rows)
+        + len(generated_memory_rows)
     )
-    hallucination_rate = unsupported / generated_total if generated_total else 0.0
+    hallucination_rate = unsupported / generated_total_rows if generated_total_rows else 0.0
 
     reference_total = (
         len(reference_summary_keys)
@@ -192,7 +197,7 @@ def score_generated_artifacts(
             "open_questions": question_scores,
             "memory_entities": memory_scores,
             "unsupported_generated_items": unsupported,
-            "generated_items": generated_total,
+            "generated_items": generated_total_rows,
             "reference_items": reference_total,
             "grounded_items": grounded_count,
         },

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/cli.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/cli.py
@@ -116,6 +116,26 @@ ALLOWED_AUDIO_VISUAL_IDENTITY_SOURCES = {
     "platform_roster",
     "none",
 }
+REQUIRED_GENERATED_ARTIFACT_SCORE_IDS = {
+    "summary_factuality",
+    "action_item_owner_date",
+    "decision_extraction",
+    "open_question_extraction",
+    "memory_entity_correctness",
+    "hallucination_rate",
+    "omission_rate",
+    "source_grounding",
+}
+REQUIRED_GENERATED_ARTIFACT_SCORE_FIELDS = {
+    "id",
+    "judge_mode",
+    "observed_score",
+    "threshold",
+    "higher_is_better",
+    "passed",
+    "proof",
+}
+GENERATED_ARTIFACT_JUDGE_MODES = {"deterministic", "live_model", "manual"}
 REQUIRED_SPEAKER_NAME_PROVENANCE_CASES = {
     "platform_roster_name",
     "calendar_attendee_name",
@@ -250,6 +270,14 @@ REQUIRED_DETAILED_METRICS = {
     "notes_factuality",
     "action_item_extraction",
     *REQUIRED_AUDIO_VISUAL_METRICS,
+    "summary_factuality",
+    "action_item_owner_date",
+    "decision_extraction",
+    "open_question_extraction",
+    "memory_entity_correctness",
+    "hallucination_rate",
+    "omission_rate",
+    "source_grounding",
 }
 RATIO_METRICS = {
     *REQUIRED_QUALITY_METRICS,
@@ -265,6 +293,14 @@ RATIO_METRICS = {
     "notes_factuality",
     "action_item_extraction",
     *REQUIRED_AUDIO_VISUAL_METRICS,
+    "summary_factuality",
+    "action_item_owner_date",
+    "decision_extraction",
+    "open_question_extraction",
+    "memory_entity_correctness",
+    "hallucination_rate",
+    "omission_rate",
+    "source_grounding",
 }
 LATENCY_METRICS = {"end_of_turn_latency_ms", "barge_in_latency_ms", "p95_end_to_end_latency_ms"}
 KNOWN_METRICS = REQUIRED_QUALITY_METRICS | REQUIRED_DETAILED_METRICS
@@ -816,6 +852,82 @@ def _validate_audio_visual_cases(manifest: dict[str, Any]) -> tuple[list[dict[st
     return sorted(normalized, key=lambda case: case["id"]), referenced_evidence
 
 
+def _validate_generated_artifact_scores(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = manifest.get("generated_artifact_scores")
+    if not isinstance(rows, list) or not rows:
+        raise ValueError("generated_artifact_scores must be a non-empty array")
+
+    score_ids: set[str] = set()
+    normalized: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise ValueError(f"generated_artifact_scores[{index}] must be an object")
+        missing_fields = REQUIRED_GENERATED_ARTIFACT_SCORE_FIELDS - set(row)
+        if missing_fields:
+            raise ValueError(f"generated_artifact_scores[{index}] missing fields: {sorted(missing_fields)}")
+        score_id = row.get("id")
+        if not isinstance(score_id, str) or not score_id.strip():
+            raise ValueError(f"generated_artifact_scores[{index}].id must be a non-empty string")
+        if score_id not in REQUIRED_GENERATED_ARTIFACT_SCORE_IDS:
+            raise ValueError(f"generated_artifact_scores[{index}].id is unknown: {score_id}")
+        score_ids.add(score_id)
+        judge_mode = row.get("judge_mode")
+        if judge_mode not in GENERATED_ARTIFACT_JUDGE_MODES:
+            raise ValueError(
+                f"generated_artifact_scores[{index}].judge_mode must be one of {sorted(GENERATED_ARTIFACT_JUDGE_MODES)}"
+            )
+        observed_score = row.get("observed_score")
+        threshold = row.get("threshold")
+        if isinstance(observed_score, bool) or not isinstance(observed_score, int | float):
+            raise ValueError(f"generated_artifact_scores[{index}].observed_score must be numeric")
+        if isinstance(threshold, bool) or not isinstance(threshold, int | float):
+            raise ValueError(f"generated_artifact_scores[{index}].threshold must be numeric")
+        observed = float(observed_score)
+        threshold_value = float(threshold)
+        if not 0 <= observed <= 1:
+            raise ValueError(f"generated_artifact_scores[{index}].observed_score must be in [0, 1]")
+        if not 0 <= threshold_value <= 1:
+            raise ValueError(f"generated_artifact_scores[{index}].threshold must be in [0, 1]")
+        higher_is_better = row.get("higher_is_better")
+        if not isinstance(higher_is_better, bool):
+            raise ValueError(f"generated_artifact_scores[{index}].higher_is_better must be boolean")
+        passed = row.get("passed")
+        if not isinstance(passed, bool):
+            raise ValueError(f"generated_artifact_scores[{index}].passed must be boolean")
+        expected_pass = observed >= threshold_value if higher_is_better else observed <= threshold_value
+        if passed != expected_pass:
+            raise ValueError(
+                f"generated_artifact_scores[{index}].passed does not match threshold direction"
+            )
+        proof = row.get("proof")
+        if not isinstance(proof, dict):
+            raise ValueError(f"generated_artifact_scores[{index}].proof must be an object")
+        required_proof = {
+            "deterministic": {"score_report"},
+            "live_model": {"model_trajectory_jsonl", "raw_prompt", "model_output", "judge_output"},
+            "manual": {"manual_review"},
+        }[judge_mode]
+        missing_proof = required_proof - set(proof)
+        if missing_proof:
+            raise ValueError(f"generated_artifact_scores[{index}] missing proof: {sorted(missing_proof)}")
+        normalized.append(
+            {
+                "id": score_id,
+                "judge_mode": judge_mode,
+                "observed_score": observed,
+                "threshold": threshold_value,
+                "higher_is_better": higher_is_better,
+                "passed": passed,
+                "proof": {key: proof[key] for key in sorted(proof)},
+            }
+        )
+
+    missing_scores = REQUIRED_GENERATED_ARTIFACT_SCORE_IDS - score_ids
+    if missing_scores:
+        raise ValueError(f"missing generated artifact scores: {sorted(missing_scores)}")
+    return sorted(normalized, key=lambda row: row["id"])
+
+
 def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Path) -> dict[str, Any]:
     if lane not in LANES:
         raise ValueError(f"lane must be one of {sorted(LANES)}")
@@ -875,6 +987,7 @@ def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Pat
     speaker_operations, speaker_operation_evidence_types = _validate_speaker_operations(manifest)
     speaker_name_provenance, speaker_name_evidence_types = _validate_speaker_name_provenance(manifest)
     audio_visual_cases, audio_visual_evidence_types = _validate_audio_visual_cases(manifest)
+    generated_artifact_scores = _validate_generated_artifact_scores(manifest)
 
     metric_values = _validate_metrics(manifest.get("metrics"), lane=lane)
 
@@ -917,6 +1030,7 @@ def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Pat
         "speaker_operations": speaker_operations,
         "speaker_name_provenance": speaker_name_provenance,
         "audio_visual_cases": audio_visual_cases,
+        "generated_artifact_scores": generated_artifact_scores,
         "metrics": metric_values,
         "evidence_files": evidence_files,
         "provider_mode": provider_mode,

--- a/packages/benchmarks/meeting-transcription-proof/fixtures/mock-meeting-manifest.json
+++ b/packages/benchmarks/meeting-transcription-proof/fixtures/mock-meeting-manifest.json
@@ -623,6 +623,99 @@
       }
     }
   ],
+  "generated_artifact_scores": [
+    {
+      "id": "summary_factuality",
+      "judge_mode": "deterministic",
+      "observed_score": 1.0,
+      "threshold": 0.9,
+      "higher_is_better": true,
+      "passed": true,
+      "proof": {
+        "score_report": "mock-generated-artifacts/summary-score.json"
+      }
+    },
+    {
+      "id": "action_item_owner_date",
+      "judge_mode": "deterministic",
+      "observed_score": 1.0,
+      "threshold": 0.85,
+      "higher_is_better": true,
+      "passed": true,
+      "proof": {
+        "score_report": "mock-generated-artifacts/action-items-score.json"
+      }
+    },
+    {
+      "id": "decision_extraction",
+      "judge_mode": "deterministic",
+      "observed_score": 1.0,
+      "threshold": 0.85,
+      "higher_is_better": true,
+      "passed": true,
+      "proof": {
+        "score_report": "mock-generated-artifacts/decisions-score.json"
+      }
+    },
+    {
+      "id": "open_question_extraction",
+      "judge_mode": "manual",
+      "observed_score": 1.0,
+      "threshold": 0.8,
+      "higher_is_better": true,
+      "passed": true,
+      "proof": {
+        "manual_review": "mock-generated-artifacts/open-questions-review.md"
+      }
+    },
+    {
+      "id": "memory_entity_correctness",
+      "judge_mode": "deterministic",
+      "observed_score": 1.0,
+      "threshold": 0.9,
+      "higher_is_better": true,
+      "passed": true,
+      "proof": {
+        "score_report": "mock-generated-artifacts/memory-score.json"
+      }
+    },
+    {
+      "id": "hallucination_rate",
+      "judge_mode": "live_model",
+      "observed_score": 0.0,
+      "threshold": 0.05,
+      "higher_is_better": false,
+      "passed": true,
+      "proof": {
+        "judge_output": "mock-generated-artifacts/hallucination-judge.json",
+        "model_output": "mock-generated-artifacts/hallucination-output.txt",
+        "model_trajectory_jsonl": "mock-generated-artifacts/hallucination-trajectory.jsonl",
+        "raw_prompt": "mock-generated-artifacts/hallucination-prompt.txt"
+      }
+    },
+    {
+      "id": "omission_rate",
+      "judge_mode": "deterministic",
+      "observed_score": 0.0,
+      "threshold": 0.1,
+      "higher_is_better": false,
+      "passed": true,
+      "proof": {
+        "score_report": "mock-generated-artifacts/omission-score.json"
+      }
+    },
+    {
+      "id": "source_grounding",
+      "judge_mode": "deterministic",
+      "observed_score": 1.0,
+      "threshold": 0.95,
+      "higher_is_better": true,
+      "passed": true,
+      "proof": {
+        "score_report": "mock-generated-artifacts/source-grounding-score.json"
+      }
+    }
+  ],
   "metrics": {
     "transcript_quality": 1.0,
     "diarization_quality": 1.0,
@@ -649,6 +742,14 @@
     "barge_in_latency_ms": 0,
     "p95_end_to_end_latency_ms": 0,
     "notes_factuality": 1.0,
-    "action_item_extraction": 1.0
+    "action_item_extraction": 1.0,
+    "summary_factuality": 1.0,
+    "action_item_owner_date": 1.0,
+    "decision_extraction": 1.0,
+    "open_question_extraction": 1.0,
+    "memory_entity_correctness": 1.0,
+    "hallucination_rate": 0.0,
+    "omission_rate": 0.0,
+    "source_grounding": 1.0
   }
 }

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_artifact_scoring.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_artifact_scoring.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+
+from elizaos_meeting_transcription_proof.artifact_scoring import score_generated_artifacts
+
+
+TRANSCRIPT_SEGMENTS = [
+    {"id": "s1", "text": "Alice will send the budget by Friday."},
+    {"id": "s2", "text": "The team decided to launch beta."},
+    {"id": "s3", "text": "Bob asked whether legal approved."},
+    {"id": "s4", "text": "Alice owns the budget follow-up."},
+]
+
+
+def _reference_artifacts() -> dict[str, object]:
+    return {
+        "summary_claims": [
+            {"text": "Alice will send the budget by Friday", "source_span_ids": ["s1"]},
+        ],
+        "action_items": [
+            {
+                "text": "Alice will send the budget by Friday",
+                "owner": "Alice",
+                "due": "Friday",
+                "source_span_ids": ["s1"],
+            }
+        ],
+        "decisions": [
+            {"text": "The team decided to launch beta", "source_span_ids": ["s2"]},
+        ],
+        "open_questions": [
+            {"text": "Bob asked whether legal approved", "source_span_ids": ["s3"]},
+        ],
+        "memory_entities": [
+            {
+                "entity_id": "person-alice",
+                "name": "Alice",
+                "fact": "owns the budget follow-up",
+                "source_span_ids": ["s4"],
+            }
+        ],
+    }
+
+
+def test_scores_perfect_generated_artifacts() -> None:
+    artifacts = _reference_artifacts()
+
+    scores = score_generated_artifacts(
+        transcript_segments=TRANSCRIPT_SEGMENTS,
+        generated_artifacts=artifacts,
+        reference_artifacts=artifacts,
+    )
+
+    assert scores["summary_factuality"] == pytest.approx(1.0)
+    assert scores["action_item_owner_date"] == pytest.approx(1.0)
+    assert scores["decision_extraction"] == pytest.approx(1.0)
+    assert scores["open_question_extraction"] == pytest.approx(1.0)
+    assert scores["memory_entity_correctness"] == pytest.approx(1.0)
+    assert scores["hallucination_rate"] == pytest.approx(0.0)
+    assert scores["omission_rate"] == pytest.approx(0.0)
+    assert scores["source_grounding"] == pytest.approx(1.0)
+
+
+def test_unsupported_claim_raises_hallucination_and_grounding_rates() -> None:
+    reference = _reference_artifacts()
+    generated = dict(reference)
+    generated["summary_claims"] = [
+        *reference["summary_claims"],
+        {"text": "Pricing was approved", "source_span_ids": ["missing"]},
+    ]
+
+    scores = score_generated_artifacts(
+        transcript_segments=TRANSCRIPT_SEGMENTS,
+        generated_artifacts=generated,
+        reference_artifacts=reference,
+    )
+
+    assert scores["summary_factuality"] == pytest.approx(0.5)
+    assert scores["hallucination_rate"] > 0
+    assert scores["source_grounding"] < 1
+
+
+def test_wrong_memory_entity_counts_as_incorrect_and_omitted() -> None:
+    reference = _reference_artifacts()
+    generated = dict(reference)
+    generated["memory_entities"] = [
+        {
+            "entity_id": "person-wrong",
+            "name": "Alice",
+            "fact": "owns the budget follow-up",
+            "source_span_ids": ["s4"],
+        }
+    ]
+
+    scores = score_generated_artifacts(
+        transcript_segments=TRANSCRIPT_SEGMENTS,
+        generated_artifacts=generated,
+        reference_artifacts=reference,
+    )
+
+    assert scores["memory_entity_correctness"] == pytest.approx(0.0)
+    assert scores["omission_rate"] > 0

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_artifact_scoring.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_artifact_scoring.py
@@ -81,6 +81,23 @@ def test_unsupported_claim_raises_hallucination_and_grounding_rates() -> None:
     assert scores["source_grounding"] < 1
 
 
+def test_duplicate_unsupported_claims_keep_hallucination_rate_in_range() -> None:
+    generated = {
+        "summary_claims": [
+            {"text": "Pricing was approved", "source_span_ids": ["missing"]},
+            {"text": "Pricing was approved", "source_span_ids": ["missing"]},
+        ],
+    }
+
+    scores = score_generated_artifacts(
+        transcript_segments=TRANSCRIPT_SEGMENTS,
+        generated_artifacts=generated,
+        reference_artifacts=_reference_artifacts(),
+    )
+
+    assert scores["hallucination_rate"] == pytest.approx(1.0)
+
+
 def test_wrong_memory_entity_counts_as_incorrect_and_omitted() -> None:
     reference = _reference_artifacts()
     generated = dict(reference)

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_cli.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_cli.py
@@ -35,6 +35,10 @@ def _fixture_audio_visual_cases() -> list[object]:
     return json.loads(FIXTURE_MANIFEST.read_text(encoding="utf-8"))["audio_visual_cases"]
 
 
+def _fixture_generated_artifact_scores() -> list[object]:
+    return json.loads(FIXTURE_MANIFEST.read_text(encoding="utf-8"))["generated_artifact_scores"]
+
+
 def _base_manifest(provider_mode: str = "real_zoom_meet") -> dict[str, object]:
     return {
         "provider_mode": provider_mode,
@@ -62,6 +66,7 @@ def _base_manifest(provider_mode: str = "real_zoom_meet") -> dict[str, object]:
         "speaker_operations": _fixture_speaker_operations(),
         "speaker_name_provenance": _fixture_speaker_name_provenance(),
         "audio_visual_cases": _fixture_audio_visual_cases(),
+        "generated_artifact_scores": _fixture_generated_artifact_scores(),
         "metrics": {
             "transcript_quality": 0.91,
             "diarization_quality": 0.82,
@@ -89,6 +94,14 @@ def _base_manifest(provider_mode: str = "real_zoom_meet") -> dict[str, object]:
             "p95_end_to_end_latency_ms": 1300,
             "notes_factuality": 0.93,
             "action_item_extraction": 0.89,
+            "summary_factuality": 0.92,
+            "action_item_owner_date": 0.88,
+            "decision_extraction": 0.86,
+            "open_question_extraction": 0.84,
+            "memory_entity_correctness": 0.9,
+            "hallucination_rate": 0.02,
+            "omission_rate": 0.04,
+            "source_grounding": 0.95,
         },
     }
 
@@ -112,6 +125,7 @@ def test_mocked_plumbing_fixture_is_not_publishable() -> None:
     assert len(report["speaker_operations"]) == len(_fixture_speaker_operations())
     assert len(report["speaker_name_provenance"]) == len(_fixture_speaker_name_provenance())
     assert len(report["audio_visual_cases"]) == len(_fixture_audio_visual_cases())
+    assert len(report["generated_artifact_scores"]) == len(_fixture_generated_artifact_scores())
 
 
 def test_real_lane_requires_non_mock_provider(tmp_path: Path) -> None:
@@ -496,6 +510,52 @@ def test_audio_visual_cases_reject_sensitive_attribute_policy(tmp_path: Path) ->
         build_report(lane="real_product", manifest_path=manifest)
 
 
+def test_real_lane_requires_generated_artifact_scores(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    manifest_data.pop("generated_artifact_scores")
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="generated_artifact_scores must be a non-empty array"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_generated_artifact_scores_require_all_rows(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    manifest_data["generated_artifact_scores"] = [
+        row
+        for row in _fixture_generated_artifact_scores()
+        if isinstance(row, dict) and row.get("id") != "source_grounding"
+    ]
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="missing generated artifact scores"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_generated_artifact_scores_validate_threshold_direction(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    rows = _fixture_generated_artifact_scores()
+    assert isinstance(rows[0], dict)
+    rows[0] = {**rows[0], "observed_score": 0.1, "threshold": 0.9, "higher_is_better": True, "passed": True}
+    manifest_data["generated_artifact_scores"] = rows
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="passed does not match threshold direction"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_generated_artifact_scores_require_judge_proof(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    rows = _fixture_generated_artifact_scores()
+    assert isinstance(rows[0], dict)
+    rows[0] = {**rows[0], "proof": {}}
+    manifest_data["generated_artifact_scores"] = rows
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="missing proof"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
 def test_real_lane_scores_lowest_required_quality_and_resolves_evidence(tmp_path: Path) -> None:
     evidence_names = [
         "audio",
@@ -566,6 +626,18 @@ def test_real_lane_scores_lowest_required_quality_and_resolves_evidence(tmp_path
     )
     assert report["metrics"]["active_speaker_f1"] == pytest.approx(0.88)
     assert report["metrics"]["visual_acoustic_disagreement_rate"] == pytest.approx(0.12)
+    assert {row["id"] for row in report["generated_artifact_scores"]} == {
+        "summary_factuality",
+        "action_item_owner_date",
+        "decision_extraction",
+        "open_question_extraction",
+        "memory_entity_correctness",
+        "hallucination_rate",
+        "omission_rate",
+        "source_grounding",
+    }
+    assert report["metrics"]["summary_factuality"] == pytest.approx(0.92)
+    assert report["metrics"]["hallucination_rate"] == pytest.approx(0.02)
     assert all(dataset["version"] for dataset in report["dataset_sources"])
     assert all(dataset["checksum"] for dataset in report["dataset_sources"])
     assert all(dataset["sample_count"] > 0 for dataset in report["dataset_sources"])

--- a/packages/benchmarks/meeting-transcription-proof/uv.lock
+++ b/packages/benchmarks/meeting-transcription-proof/uv.lock
@@ -1,0 +1,78 @@
+version = 1
+revision = 2
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "elizaos-meeting-transcription-proof"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pytest", marker = "extra == 'test'", specifier = ">=8.0" }]
+provides-extras = ["test"]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]

--- a/packages/benchmarks/registry/scores.py
+++ b/packages/benchmarks/registry/scores.py
@@ -937,6 +937,17 @@ _MEETING_PROOF_REQUIRED_AV_METRICS = {
     "visual_acoustic_disagreement_rate",
 }
 
+MEETING_PROOF_REQUIRED_GENERATED_ARTIFACT_SCORE_IDS = {
+    "summary_factuality",
+    "action_item_owner_date",
+    "decision_extraction",
+    "open_question_extraction",
+    "memory_entity_correctness",
+    "hallucination_rate",
+    "omission_rate",
+    "source_grounding",
+}
+
 
 def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtraction:
     """Extract the #12486 meeting transcription proof score.
@@ -968,6 +979,25 @@ def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtrac
     )
     audio_visual_cases = root.get("audio_visual_cases")
     audio_visual_case_count = len(audio_visual_cases) if isinstance(audio_visual_cases, list) else 0
+    generated_artifact_observed: dict[str, float] = {}
+    generated_artifact_ids: set[str] = set()
+    generated_artifact_scores = root.get("generated_artifact_scores")
+    if isinstance(generated_artifact_scores, list):
+        for index, row in enumerate(generated_artifact_scores):
+            score_row = expect_dict(row, ctx=f"meeting_transcription_proof:generated_artifact_scores[{index}]")
+            score_id = str(
+                get_required(
+                    score_row,
+                    "id",
+                    ctx=f"meeting_transcription_proof:generated_artifact_scores[{index}]",
+                )
+            )
+            generated_artifact_ids.add(score_id)
+            if "observed_score" in score_row:
+                generated_artifact_observed[score_id] = expect_float(
+                    score_row["observed_score"],
+                    ctx=f"meeting_transcription_proof:generated_artifact_scores[{index}].observed_score",
+                )
     publishable = root.get("publishable") is True
     if lane == "real_product":
         if not publishable:
@@ -1005,8 +1035,21 @@ def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtrac
                 "meeting_transcription_proof: real lane requires audio-visual metrics "
                 f"{sorted(missing_av_metrics)}"
             )
+        missing_generated_scores = MEETING_PROOF_REQUIRED_GENERATED_ARTIFACT_SCORE_IDS - generated_artifact_ids
+        if missing_generated_scores:
+            raise ValueError(
+                "meeting_transcription_proof: real lane requires complete generated artifact scores"
+            )
     elif publishable:
         raise ValueError("meeting_transcription_proof: mocked lane cannot be publishable")
+
+    generated_artifact_metrics: dict[str, JSONValue] = {}
+    for metric_id in sorted(MEETING_PROOF_REQUIRED_GENERATED_ARTIFACT_SCORE_IDS):
+        metric_value = metrics.get(metric_id)
+        if isinstance(metric_value, (int, float)) and not isinstance(metric_value, bool):
+            generated_artifact_metrics[metric_id] = float(metric_value)
+        else:
+            generated_artifact_metrics[metric_id] = generated_artifact_observed.get(metric_id, 0)
 
     return ScoreExtraction(
         score=score,
@@ -1030,6 +1073,7 @@ def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtrac
             "room_feed_heuristic_precision": metrics.get("room_feed_heuristic_precision") or 0,
             "room_feed_heuristic_recall": metrics.get("room_feed_heuristic_recall") or 0,
             "visual_acoustic_disagreement_rate": metrics.get("visual_acoustic_disagreement_rate") or 0,
+            **generated_artifact_metrics,
             "provider_mode": root.get("provider_mode") or "",
         },
     )

--- a/packages/benchmarks/tests/test_registry_scores.py
+++ b/packages/benchmarks/tests/test_registry_scores.py
@@ -16,6 +16,28 @@ from registry.scores import (  # noqa: E402
 )
 
 
+GENERATED_ARTIFACT_SCORE_IDS = (
+    "summary_factuality",
+    "action_item_owner_date",
+    "decision_extraction",
+    "open_question_extraction",
+    "memory_entity_correctness",
+    "hallucination_rate",
+    "omission_rate",
+    "source_grounding",
+)
+
+
+def _meeting_generated_artifact_scores() -> list[dict[str, object]]:
+    return [
+        {
+            "id": score_id,
+            "observed_score": 0.0 if score_id in {"hallucination_rate", "omission_rate"} else 1.0,
+        }
+        for score_id in GENERATED_ARTIFACT_SCORE_IDS
+    ]
+
+
 def test_hermes_env_placeholder_only_score_is_not_publishable() -> None:
     with pytest.raises(ValueError, match="placeholder-only"):
         _score_from_hermes_env_json(
@@ -173,6 +195,7 @@ def _meeting_transcription_real_report() -> dict[str, object]:
         "speaker_operations": [{"id": "speaker_name_correction"}],
         "speaker_name_provenance": [{} for _ in range(8)],
         "audio_visual_cases": [{} for _ in range(7)],
+        "generated_artifact_scores": _meeting_generated_artifact_scores(),
     }
 
 
@@ -222,6 +245,14 @@ def test_meeting_transcription_real_lane_requires_audio_visual_metrics() -> None
         _score_from_meeting_transcription_proof_json(report)
 
 
+def test_meeting_transcription_real_lane_requires_generated_artifact_scores() -> None:
+    report = _meeting_transcription_real_report()
+    report["generated_artifact_scores"] = _meeting_generated_artifact_scores()[:-1]
+
+    with pytest.raises(ValueError, match="generated artifact scores"):
+        _score_from_meeting_transcription_proof_json(report)
+
+
 def test_meeting_transcription_real_lane_score_is_publishable_with_evidence() -> None:
     extraction = _score_from_meeting_transcription_proof_json(_meeting_transcription_real_report())
 
@@ -233,3 +264,5 @@ def test_meeting_transcription_real_lane_score_is_publishable_with_evidence() ->
     assert extraction.metrics["audio_visual_case_count"] == 7
     assert extraction.metrics["active_speaker_f1"] == pytest.approx(0.88)
     assert extraction.metrics["visual_acoustic_disagreement_rate"] == pytest.approx(0.12)
+    assert extraction.metrics["summary_factuality"] == pytest.approx(1.0)
+    assert extraction.metrics["hallucination_rate"] == pytest.approx(0.0)


### PR DESCRIPTION
## Summary

- Adds a generated meeting-intelligence artifact scoring contract to the meeting transcription proof benchmark.
- Validates all eight required generated artifact score rows, judge modes, threshold direction, and proof artifacts.
- Adds deterministic scoring for summary factuality, action item owner/date extraction, decision/open-question extraction, memory entity correctness, hallucination rate, omission rate, and source grounding.
- Gates real registry extraction on complete generated artifact score coverage.

## Evidence

- Evidence file: `.github/issue-evidence/12499-meeting-intelligence-benchmark.md`.
- Human follow-up: #13170.
- `bun install` completed; no intended dependency changes kept.
- `bun run verify` failed outside this PR in `@elizaos/tui#lint` on existing `lint/suspicious/noControlCharactersInRegex` diagnostics in `packages/tui/src/keys.ts` and `packages/tui/src/terminal.ts`; existing warnings also appeared in `@elizaos/security#lint` and `@elizaos/capacitor-llama#lint`.
- `pytest packages/benchmarks/meeting-transcription-proof/tests -q` passed: 31 tests.
- `pytest packages/benchmarks/tests/test_registry_scores.py -q` passed: 8 tests.
- `python -m py_compile packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/artifact_scoring.py packages/benchmarks/meeting-transcription-proof/tests/test_artifact_scoring.py` passed.
- Mocked smoke report generated at `/tmp/mtp-smoke-generated-artifacts-12499/meeting-transcription-proof-report.json`; manual `jq` inspection confirmed 8 generated score rows and all 8 generated metrics.

## Human Evidence Still Required

This PR intentionally does not claim live product proof. Human issue #13170 must capture real meeting runs, live LLM trajectories, manually reviewed generated artifacts, UI/video evidence, backend/frontend logs, and memory/knowledge artifacts.

Closes #12499; human-only remaining work is split to #13170.
