### PR TITLE
fix(#12658): explicit component precedence policy (declared override + observable collisions)

### DIFF
--- a/packages/core/src/__tests__/runtime-component-precedence.test.ts
+++ b/packages/core/src/__tests__/runtime-component-precedence.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Coverage for the explicit component-precedence policy (#12658 / arch-audit
+ * #12089 item 8).
+ *
+ * The three primary component registries (actions, providers, evaluators)
+ * previously resolved same-name collisions with a SILENT first-wins dedupe:
+ * whichever plugin registered first won, later duplicates were dropped at
+ * `debug` with no observable signal, and there was no way to declare that a
+ * later component intentionally supersedes an earlier one.
+ *
+ * These tests pin the new contract:
+ *  - undeclared collision -> keep the incumbent (still deterministic first-wins)
+ *    AND emit an observable `logger.warn` instead of a silent `debug`.
+ *  - `override: true` on the later registrant -> replace the incumbent and log
+ *    the takeover at `info`.
+ *  - the same policy applies whether components arrive via the direct
+ *    `register*` methods or through `registerPlugin` (no silent pre-filter).
+ *
+ * Drives a real `AgentRuntime`; no model.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import { AgentRuntime } from "../runtime";
+import type {
+	Action,
+	ActionResult,
+	Character,
+	Provider,
+	RegisteredEvaluator,
+} from "../types";
+
+function makeRuntime(name: string): AgentRuntime {
+	return new AgentRuntime({ character: { name } as Character });
+}
+
+function makeProvider(name: string, text: string): Provider {
+	return { name, get: async () => ({ text, values: {}, data: {} }) };
+}
+
+function makeAction(name: string, tag: string): Action {
+	return {
+		name,
+		description: tag,
+		validate: async () => true,
+		handler: async (): Promise<ActionResult> => ({
+			success: true,
+			text: tag,
+		}),
+		examples: [],
+	};
+}
+
+function makeEvaluator(name: string, description: string): RegisteredEvaluator {
+	return {
+		name,
+		description,
+		schema: { type: "object" },
+		shouldRun: async () => false,
+		prompt: () => "",
+	} as RegisteredEvaluator;
+}
+
+describe("AgentRuntime component precedence — undeclared collisions (first-wins + WARN)", () => {
+	it("keeps the first provider and WARNs on an undeclared name collision", async () => {
+		const runtime = makeRuntime("provider-collision-warn");
+		const warn = vi.spyOn(runtime.logger, "warn");
+
+		runtime.registerProvider(makeProvider("DUP", "first"));
+		runtime.registerProvider(makeProvider("DUP", "second"));
+
+		const matches = runtime.providers.filter((p) => p.name === "DUP");
+		expect(matches).toHaveLength(1);
+		// Incumbent (first) is authoritative.
+		const dup = matches[0];
+		expect(dup).toBeDefined();
+		const result = await dup!.get(
+			runtime,
+			{} as never,
+			{} as never,
+		);
+		expect(result.text).toBe("first");
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0]?.[1]).toMatch(/name collision/i);
+	});
+
+	it("keeps the first action and WARNs on an undeclared name collision", () => {
+		const runtime = makeRuntime("action-collision-warn");
+		const warn = vi.spyOn(runtime.logger, "warn");
+
+		runtime.registerAction(makeAction("DUP_ACTION", "first"));
+		runtime.registerAction(makeAction("DUP_ACTION", "second"));
+
+		const matches = runtime.actions.filter((a) => a.name === "DUP_ACTION");
+		expect(matches).toHaveLength(1);
+		expect(matches[0]?.description).toBe("first");
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0]?.[1]).toMatch(/name collision/i);
+	});
+
+	it("keeps the first evaluator and WARNs on an undeclared name collision", () => {
+		const runtime = makeRuntime("evaluator-collision-warn");
+		const warn = vi.spyOn(runtime.logger, "warn");
+
+		runtime.registerEvaluator(makeEvaluator("DUP_EVAL", "first"));
+		runtime.registerEvaluator(makeEvaluator("DUP_EVAL", "second"));
+
+		const matches = runtime.evaluators.filter((e) => e.name === "DUP_EVAL");
+		expect(matches).toHaveLength(1);
+		expect(matches[0]?.description).toBe("first");
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0]?.[1]).toMatch(/name collision/i);
+	});
+});
+
+describe("AgentRuntime component precedence — declared override:true supersedes + INFO", () => {
+	it("replaces the incumbent provider when the newcomer declares override:true", async () => {
+		const runtime = makeRuntime("provider-override");
+		const info = vi.spyOn(runtime.logger, "info");
+		const warn = vi.spyOn(runtime.logger, "warn");
+
+		runtime.registerProvider(makeProvider("OVR", "first"));
+		runtime.registerProvider({
+			...makeProvider("OVR", "second"),
+			override: true,
+		});
+
+		const matches = runtime.providers.filter((p) => p.name === "OVR");
+		expect(matches).toHaveLength(1);
+		const ovr = matches[0];
+		expect(ovr).toBeDefined();
+		const result = await ovr!.get(
+			runtime,
+			{} as never,
+			{} as never,
+		);
+		expect(result.text).toBe("second");
+		// Declared override logs at info, never warns.
+		expect(info).toHaveBeenCalled();
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("replaces the incumbent action when the newcomer declares override:true", () => {
+		const runtime = makeRuntime("action-override");
+		const info = vi.spyOn(runtime.logger, "info");
+		const warn = vi.spyOn(runtime.logger, "warn");
+
+		runtime.registerAction(makeAction("OVR_ACTION", "first"));
+		runtime.registerAction({
+			...makeAction("OVR_ACTION", "second"),
+			override: true,
+		});
+
+		const matches = runtime.actions.filter((a) => a.name === "OVR_ACTION");
+		expect(matches).toHaveLength(1);
+		expect(matches[0]?.description).toBe("second");
+		expect(info).toHaveBeenCalled();
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("replaces the incumbent evaluator when the newcomer declares override:true", () => {
+		const runtime = makeRuntime("evaluator-override");
+		const info = vi.spyOn(runtime.logger, "info");
+		const warn = vi.spyOn(runtime.logger, "warn");
+
+		runtime.registerEvaluator(makeEvaluator("OVR_EVAL", "first"));
+		runtime.registerEvaluator({
+			...makeEvaluator("OVR_EVAL", "second"),
+			override: true,
+		});
+
+		const matches = runtime.evaluators.filter((e) => e.name === "OVR_EVAL");
+		expect(matches).toHaveLength(1);
+		expect(matches[0]?.description).toBe("second");
+		expect(info).toHaveBeenCalled();
+		expect(warn).not.toHaveBeenCalled();
+	});
+});
+
+describe("AgentRuntime component precedence — policy applies through registerPlugin", () => {
+	it("routes plugin action collisions through the precedence policy (WARN, not silent)", async () => {
+		const runtime = makeRuntime("plugin-collision-warn");
+		runtime.registerAction(makeAction("PLUGIN_DUP", "incumbent"));
+		const warn = vi.spyOn(runtime.logger, "warn");
+
+		await runtime.registerPlugin({
+			name: "collision-plugin",
+			description: "collides with an already-registered action",
+			actions: [makeAction("PLUGIN_DUP", "from-plugin")],
+		});
+
+		const matches = runtime.actions.filter((a) => a.name === "PLUGIN_DUP");
+		expect(matches).toHaveLength(1);
+		expect(matches[0]?.description).toBe("incumbent");
+		expect(warn).toHaveBeenCalledTimes(1);
+	});
+
+	it("downgrades a plugin action's override:true to safe first-wins (WARNs)", async () => {
+		// Plugin-boundary overrides are unsafe for hot teardown (#12658): the
+		// runtime keeps the incumbent and treats it like an undeclared collision.
+		const runtime = makeRuntime("plugin-override-downgrade");
+		runtime.registerAction(makeAction("PLUGIN_OVR", "incumbent"));
+		const warn = vi.spyOn(runtime.logger, "warn");
+
+		await runtime.registerPlugin({
+			name: "override-plugin",
+			description: "attempts an intentional override across a plugin boundary",
+			actions: [
+				{ ...makeAction("PLUGIN_OVR", "from-plugin"), override: true },
+			],
+		});
+
+		const matches = runtime.actions.filter((a) => a.name === "PLUGIN_OVR");
+		expect(matches).toHaveLength(1);
+		expect(matches[0]?.description).toBe("incumbent");
+		expect(warn).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("AgentRuntime component precedence — grep guard (silent dedupe removed)", () => {
+	it("no longer silently pre-filters plugin action/provider/evaluator duplicates", () => {
+		const runtimeSrc = readFileSync(
+			fileURLToPath(new URL("../runtime.ts", import.meta.url)),
+			"utf8",
+		);
+		// The primary component registries used to drop same-name duplicates via a
+		// silent `debug` pre-filter in registerPlugin. That path is gone; collisions
+		// now flow through resolveComponentCollision (WARN / declared override).
+		expect(runtimeSrc).not.toContain('"Skipping duplicate plugin action"');
+		expect(runtimeSrc).not.toContain('"Skipping duplicate plugin provider"');
+		expect(runtimeSrc).not.toContain('"Skipping duplicate plugin evaluator"');
+		expect(runtimeSrc).not.toContain('"Evaluator already registered, skipping"');
+		// The single-authority collision resolver exists.
+		expect(runtimeSrc).toContain("resolveComponentCollision");
+	});
+});
+
+describe("AgentRuntime component precedence — distinct names still register", () => {
+	it("registers distinctly-named components without warning", () => {
+		const runtime = makeRuntime("distinct-names");
+		const warn = vi.spyOn(runtime.logger, "warn");
+
+		runtime.registerProvider(makeProvider("ALPHA", "a"));
+		runtime.registerProvider(makeProvider("BETA", "b"));
+		runtime.registerAction(makeAction("DO_ALPHA", "a"));
+		runtime.registerAction(makeAction("DO_BETA", "b"));
+		runtime.registerEvaluator(makeEvaluator("EVAL_ALPHA", "a"));
+		runtime.registerEvaluator(makeEvaluator("EVAL_BETA", "b"));
+
+		expect(runtime.providers.some((p) => p.name === "ALPHA")).toBe(true);
+		expect(runtime.providers.some((p) => p.name === "BETA")).toBe(true);
+		expect(runtime.actions.some((a) => a.name === "DO_ALPHA")).toBe(true);
+		expect(runtime.actions.some((a) => a.name === "DO_BETA")).toBe(true);
+		expect(runtime.evaluators.some((e) => e.name === "EVAL_ALPHA")).toBe(true);
+		expect(runtime.evaluators.some((e) => e.name === "EVAL_BETA")).toBe(true);
+		expect(warn).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/src/plugin-lifecycle.ts
+++ b/packages/core/src/plugin-lifecycle.ts
@@ -267,6 +267,32 @@ function pushUniqueRef<T extends object>(items: T[], item: T): void {
 	}
 }
 
+/**
+ * Neutralizes a declared `override: true` on a component being registered
+ * through the plugin lifecycle (#12658).
+ *
+ * The explicit override contract lets a LATER registrant intentionally supersede
+ * an already-registered component of the same name. On the direct host/core
+ * registration path that is safe. Across `registerPlugin` boundaries it is NOT:
+ * an override replaces the incumbent in place, but hot plugin teardown
+ * (unloadPlugin / reloadPlugin / failed-registration rollback) removes owned
+ * components by reference and does not restore a displaced incumbent. So a
+ * plugin overriding another plugin's component and then unloading would leave
+ * the still-loaded original plugin without its action/provider/evaluator.
+ *
+ * Until incumbent save/restore is implemented, plugin-boundary overrides are
+ * downgraded to the safe deterministic first-wins policy (the incumbent is kept
+ * and the register method WARNs). Direct (non-plugin) registration keeps
+ * override.
+ */
+function withoutPluginOverride<T extends { override?: boolean }>(
+	component: T,
+): T {
+	return component.override === true
+		? { ...component, override: false }
+		: component;
+}
+
 function pushUniqueString(items: string[], value: string): void {
 	if (!items.includes(value)) {
 		items.push(value);
@@ -808,9 +834,12 @@ export function installRuntimePluginLifecycle(runtime: IAgentRuntime): void {
 	runtimeWithLifecycle.registerAction = ((action: RuntimeAction) => {
 		const capture = pluginRegistrationContext.getStore();
 		const actionsBefore = runtimeWithLifecycle.actions.length;
+		// Plugin-boundary overrides are unsafe for hot teardown (#12658); downgrade
+		// to first-wins so a plugin never destructively displaces another's action.
+		// Direct (non-plugin, no capture) registration keeps the override contract.
 		originalRegisterAction(
 			applyEffectiveActionAccess(
-				action,
+				capture ? withoutPluginOverride(action) : action,
 				capture?.ownership.plugin.contexts,
 				runtimeWithLifecycle.contexts,
 			),
@@ -829,7 +858,7 @@ export function installRuntimePluginLifecycle(runtime: IAgentRuntime): void {
 		const providersBefore = runtimeWithLifecycle.providers.length;
 		originalRegisterProvider(
 			applyEffectiveProviderContexts(
-				provider,
+				capture ? withoutPluginOverride(provider) : provider,
 				capture?.ownership.plugin.contexts,
 			),
 		);
@@ -845,7 +874,9 @@ export function installRuntimePluginLifecycle(runtime: IAgentRuntime): void {
 	runtimeWithLifecycle.registerEvaluator = ((evaluator: RuntimeEvaluator) => {
 		const capture = pluginRegistrationContext.getStore();
 		const evaluatorsBefore = runtimeWithLifecycle.evaluators.length;
-		originalRegisterEvaluator(evaluator);
+		originalRegisterEvaluator(
+			capture ? withoutPluginOverride(evaluator) : evaluator,
+		);
 		if (!capture || runtimeWithLifecycle.evaluators.length <= evaluatorsBefore)
 			return;
 		for (const registeredEvaluator of runtimeWithLifecycle.evaluators.slice(

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1935,30 +1935,15 @@ export class AgentRuntime implements IAgentRuntime {
 			);
 		}
 		if (pluginToRegister.actions) {
-			const existingActionNames = new Set(
-				this.actions.map((action) => action.name),
-			);
+			// Delegate collision/override policy to registerAction() so a single
+			// authority (resolveComponentCollision) decides first-wins vs declared
+			// override and emits the observable WARN. Pre-filtering here would
+			// silently swallow duplicates before that policy could see them.
 			for (const action of pluginToRegister.actions) {
-				if (existingActionNames.has(action.name)) {
-					this.logger.debug(
-						{
-							src: "agent",
-							agentId: this.agentId,
-							action: action.name,
-							plugin: pluginToRegister.name,
-						},
-						"Skipping duplicate plugin action",
-					);
-					continue;
-				}
 				this.registerAction(action);
-				existingActionNames.add(action.name);
 			}
 		}
 		if (pluginToRegister.providers) {
-			const existingProviderNames = new Set(
-				this.providers.map((provider) => provider.name),
-			);
 			for (const provider of pluginToRegister.providers) {
 				if (provider.registerByDefault === false) {
 					this.logger.debug(
@@ -1972,41 +1957,14 @@ export class AgentRuntime implements IAgentRuntime {
 					);
 					continue;
 				}
-				if (existingProviderNames.has(provider.name)) {
-					this.logger.debug(
-						{
-							src: "agent",
-							agentId: this.agentId,
-							provider: provider.name,
-							plugin: pluginToRegister.name,
-						},
-						"Skipping duplicate plugin provider",
-					);
-					continue;
-				}
+				// Collision/override policy owned by registerProvider().
 				this.registerProvider(provider);
-				existingProviderNames.add(provider.name);
 			}
 		}
 		if (pluginToRegister.evaluators) {
-			const existingEvaluatorNames = new Set(
-				this.evaluators.map((evaluator) => evaluator.name),
-			);
+			// Collision/override policy owned by registerEvaluator().
 			for (const evaluator of pluginToRegister.evaluators) {
-				if (existingEvaluatorNames.has(evaluator.name)) {
-					this.logger.debug(
-						{
-							src: "agent",
-							agentId: this.agentId,
-							evaluator: evaluator.name,
-							plugin: pluginToRegister.name,
-						},
-						"Skipping duplicate plugin evaluator",
-					);
-					continue;
-				}
 				this.registerEvaluator(evaluator);
-				existingEvaluatorNames.add(evaluator.name);
 			}
 		}
 		if (pluginToRegister.shortcuts) {
@@ -3232,13 +3190,58 @@ export class AgentRuntime implements IAgentRuntime {
 		return null;
 	}
 
+	/**
+	 * Shared collision policy for the three primary component registries
+	 * (actions, providers, evaluators). Registration is deterministic first-wins:
+	 * the earliest-registered component of a given name is authoritative and the
+	 * order in which plugins register is stable across a boot.
+	 *
+	 * A later registrant of the same name is either:
+	 *  - a DECLARED override (`override: true`) — an intentional supersede. We log
+	 *    the takeover at INFO and instruct the caller to replace the incumbent.
+	 *  - an UNDECLARED collision — two plugins claimed the same name without one
+	 *    declaring precedence. This is the unsafe, order-sensitive case the
+	 *    arch-audit flagged: which component wins used to be decided by a silent
+	 *    first-wins dedupe. We now keep the incumbent (still deterministic) but
+	 *    surface a WARN so the drift is observable instead of silent.
+	 *
+	 * @returns `true` if the caller should REPLACE the incumbent (declared
+	 *   override), `false` if it should keep the incumbent and skip the newcomer.
+	 */
+	private resolveComponentCollision(
+		kind: "action" | "provider" | "evaluator",
+		name: string,
+		override: boolean | undefined,
+	): boolean {
+		if (override === true) {
+			this.logger.info(
+				{ src: "agent", agentId: this.agentId, [kind]: name },
+				`[AgentRuntime] ${kind} "${name}" declares override:true — superseding the already-registered ${kind} of the same name.`,
+			);
+			return true;
+		}
+		this.logger.warn(
+			{ src: "agent", agentId: this.agentId, [kind]: name },
+			`[AgentRuntime] ${kind} name collision: a ${kind} named "${name}" is already registered; keeping the first and skipping this one. Which one wins is load-order-dependent — give the two distinct names, or set override:true on the ${kind} that should intentionally supersede.`,
+		);
+		return false;
+	}
+
 	registerProvider(provider: Provider) {
 		const canonical = withCanonicalProviderDocs(provider);
-		if (this.providers.find((p) => p.name === canonical.name)) {
-			this.logger.warn(
-				{ src: "agent", agentId: this.agentId, provider: canonical.name },
-				"[AgentRuntime] Provider name collision: a provider with this name is already registered; keeping the first and skipping this one. The context the agent sees for this name is load-order-dependent — give the two providers distinct names.",
-			);
+		const existingIndex = this.providers.findIndex(
+			(p) => p.name === canonical.name,
+		);
+		if (existingIndex !== -1) {
+			if (
+				this.resolveComponentCollision(
+					"provider",
+					canonical.name,
+					canonical.override,
+				)
+			) {
+				this.providers[existingIndex] = canonical;
+			}
 			return;
 		}
 		this.providers.push(canonical);
@@ -3251,11 +3254,13 @@ export class AgentRuntime implements IAgentRuntime {
 	registerAction(action: Action) {
 		const canonical = withCanonicalActionDocs(action);
 		Object.assign(action, canonical);
-		if (this.actions.find((a) => a.name === action.name)) {
-			this.logger.warn(
-				{ src: "agent", agentId: this.agentId, action: action.name },
-				"[AgentRuntime] Action name collision: an action with this name is already registered; keeping the first and skipping this one. Which handler/role-gate wins is load-order-dependent — rename one of the colliding actions to disambiguate.",
-			);
+		const existingIndex = this.actions.findIndex((a) => a.name === action.name);
+		if (existingIndex !== -1) {
+			if (
+				this.resolveComponentCollision("action", action.name, action.override)
+			) {
+				this.actions[existingIndex] = action;
+			}
 		} else {
 			this.actions.push(action);
 			this.logger.debug(
@@ -3318,11 +3323,19 @@ export class AgentRuntime implements IAgentRuntime {
 	}
 
 	registerEvaluator(evaluator: RegisteredEvaluator) {
-		if (this.evaluators.find((item) => item.name === evaluator.name)) {
-			this.logger.debug(
-				{ src: "agent", agentId: this.agentId, evaluator: evaluator.name },
-				"Evaluator already registered, skipping",
-			);
+		const existingIndex = this.evaluators.findIndex(
+			(item) => item.name === evaluator.name,
+		);
+		if (existingIndex !== -1) {
+			if (
+				this.resolveComponentCollision(
+					"evaluator",
+					evaluator.name,
+					evaluator.override,
+				)
+			) {
+				this.evaluators[existingIndex] = evaluator;
+			}
 			return;
 		}
 		this.evaluators.push(evaluator);

--- a/packages/core/src/runtime/plugin-component-override-lifecycle.test.ts
+++ b/packages/core/src/runtime/plugin-component-override-lifecycle.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Guards the hot-plugin-lifecycle safety of the component override policy
+ * (#12658). The explicit `override: true` contract is honored on the DIRECT
+ * host/core registration path, but is intentionally downgraded to deterministic
+ * first-wins across `registerPlugin` boundaries: an override replaces the
+ * incumbent in place, while plugin teardown (unloadPlugin / reloadPlugin /
+ * failed-registration rollback) removes owned components by reference and does
+ * NOT restore a displaced incumbent. Allowing a plugin override would therefore
+ * let one plugin destructively strip another plugin's action/provider/evaluator
+ * on unload. These tests pin the safe behavior. No model or database.
+ */
+import { describe, expect, it } from "vitest";
+import { AgentRuntime } from "../runtime";
+import type { Action, ActionResult } from "../types";
+import type { Plugin } from "../types/plugin";
+
+function makeAction(name: string, tag: string, override?: boolean): Action {
+	return {
+		name,
+		description: tag,
+		validate: async () => true,
+		handler: async (): Promise<ActionResult> => ({ success: true, text: tag }),
+		examples: [],
+		...(override ? { override: true } : {}),
+	};
+}
+
+describe("plugin component override lifecycle safety (#12658)", () => {
+	it("downgrades a plugin's override:true to first-wins (does not displace another plugin's action)", async () => {
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+
+		const base: Plugin = {
+			name: "base-plugin",
+			description: "Registers the incumbent action",
+			actions: [makeAction("SHARED_ACTION", "incumbent")],
+		};
+		const overrider: Plugin = {
+			name: "override-plugin",
+			description: "Attempts to supersede across a plugin boundary",
+			actions: [makeAction("SHARED_ACTION", "override", true)],
+		};
+
+		await runtime.registerPlugin(base);
+		await runtime.registerPlugin(overrider);
+
+		// Plugin-boundary override is downgraded: the incumbent is kept.
+		const active = runtime.actions.filter((a) => a.name === "SHARED_ACTION");
+		expect(active).toHaveLength(1);
+		expect(active[0]?.description).toBe("incumbent");
+
+		// The overriding plugin does NOT own the incumbent, and unloading it must
+		// leave base-plugin's action intact (no destructive teardown).
+		const ownedByOverrider = runtime
+			.getPluginOwnership("override-plugin")
+			?.actions.map((a) => a.name);
+		expect(ownedByOverrider ?? []).not.toContain("SHARED_ACTION");
+
+		await runtime.unloadPlugin("override-plugin");
+		expect(
+			runtime.actions.some(
+				(a) => a.name === "SHARED_ACTION" && a.description === "incumbent",
+			),
+		).toBe(true);
+	});
+
+	it("does NOT attribute the incumbent to a plugin whose undeclared duplicate was skipped", async () => {
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+
+		const base: Plugin = {
+			name: "base-plugin",
+			description: "Registers the incumbent action",
+			actions: [makeAction("DUP_ACTION", "incumbent")],
+		};
+		const collider: Plugin = {
+			name: "collider-plugin",
+			description: "Undeclared duplicate — should be skipped, not owned",
+			actions: [makeAction("DUP_ACTION", "loser")],
+		};
+
+		await runtime.registerPlugin(base);
+		await runtime.registerPlugin(collider);
+
+		const active = runtime.actions.filter((a) => a.name === "DUP_ACTION");
+		expect(active).toHaveLength(1);
+		expect(active[0]?.description).toBe("incumbent");
+
+		const ownedByCollider = runtime
+			.getPluginOwnership("collider-plugin")
+			?.actions.map((a) => a.name);
+		expect(ownedByCollider ?? []).not.toContain("DUP_ACTION");
+
+		await runtime.unloadPlugin("collider-plugin");
+		expect(runtime.actions.some((a) => a.name === "DUP_ACTION")).toBe(true);
+	});
+});

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -314,6 +314,25 @@ export interface Action {
 	/** Optional priority for action ordering */
 	priority?: number;
 
+	/**
+	 * Explicit override policy for name collisions during registration.
+	 *
+	 * When two components register under the same `name`, the runtime keeps the
+	 * first-registered instance (deterministic first-wins) and emits a WARN for
+	 * the undeclared collision. Set `override: true` on the LATER registrant to
+	 * declare that it intentionally supersedes an already-registered component of
+	 * the same name; the runtime then replaces the incumbent and logs the
+	 * override at INFO instead of warning. This turns a silent, order-sensitive
+	 * dedupe into an explicit, declared precedence contract.
+	 *
+	 * NOTE: `override` is honored on the DIRECT host/core registration path only.
+	 * Across `registerPlugin` boundaries it is downgraded to safe first-wins,
+	 * because hot plugin teardown (unload/reload/rollback) does not restore a
+	 * displaced incumbent — a plugin override would otherwise destructively strip
+	 * another plugin's component on unload.
+	 */
+	override?: boolean;
+
 	/** Optional tags for categorization */
 	tags?: string[];
 
@@ -616,6 +635,14 @@ export interface Provider {
 
 	/** Position of the provider in the provider list, positive or negative */
 	position?: number;
+
+	/**
+	 * Explicit override policy for name collisions during registration.
+	 * See {@link Action.override}: set `override: true` on the later registrant
+	 * to intentionally supersede an already-registered provider of the same name.
+	 * Undeclared collisions keep the incumbent (first-wins) and emit a WARN.
+	 */
+	override?: boolean;
 
 	/**
 	 * Whether the provider is private

--- a/packages/core/src/types/evaluator.ts
+++ b/packages/core/src/types/evaluator.ts
@@ -51,6 +51,13 @@ export interface Evaluator<TOutput = JsonValue, TPrepared = unknown> {
 	description: string;
 	similes?: string[];
 	priority?: number;
+	/**
+	 * Explicit override policy for name collisions during registration.
+	 * See {@link Action.override}: set `override: true` on the later registrant
+	 * to intentionally supersede an already-registered evaluator of the same
+	 * name. Undeclared collisions keep the incumbent (first-wins) + emit a WARN.
+	 */
+	override?: boolean;
 	providers?: string[];
 	schema: JSONSchema;
 	modelType?: ModelTypeName;


### PR DESCRIPTION
Closes #12658 (arch-audit self-registration #12089 item 8).

## Problem
Component precedence was decided by a **silent first-wins dedupe**. In `registerPlugin`, duplicate actions/providers/evaluators were pre-filtered at `debug` before the register methods could see them, and there was **no way to declare** that a later component intentionally supersedes an earlier one. So which component won a name collision was load-order-dependent and unobservable — exactly the unsafe coupling the audit flagged.

## Change (packages/core only)
- Add `override?: boolean` to `Action` / `Provider` / `Evaluator`. A later registrant declares `override: true` to intentionally supersede an already-registered component of the same name.
- Route the three primary registries through a single authority `resolveComponentCollision(kind, name, override)`:
  - **declared override** -> replace the incumbent, log at **INFO**
  - **undeclared collision** -> keep the incumbent (deterministic first-wins) and emit an observable **WARN** (was a silent `debug`)
- Remove the silent pre-filter `Set`s in `registerPlugin` so the policy applies consistently whether components arrive directly or via a plugin.
- **Plugin-boundary safety:** `override` is honored on the direct host/core registration path only. Across `registerPlugin` it is downgraded to safe first-wins — hot plugin teardown (unload/reload/rollback) removes owned components by reference and does not restore a displaced incumbent, so a plugin override would otherwise destructively strip another plugin's component on unload. Documented on the `override` field.

## Done-when coverage
- Brittle silent dedupe replaced by an explicit, declared precedence contract routed through one resolver. ✅
- Regression tests cover the failure mode (undeclared collision is now observable; declared override supersedes; plugin-boundary override is non-destructive). ✅
- Grep-guard test asserts the old `"Skipping duplicate plugin action/provider/evaluator"` + `"Evaluator already registered, skipping"` silent strings are gone from executable paths and `resolveComponentCollision` exists. ✅

## Tests / evidence
- `packages/core/src/__tests__/runtime-component-precedence.test.ts` (new): undeclared-collision WARN + first-wins for all three kinds; declared `override:true` supersede + INFO (direct path); plugin-path routing through the policy; plugin override **downgrade** WARN; grep-guard; distinct names register without warning.
- `packages/core/src/runtime/plugin-component-override-lifecycle.test.ts` (new): plugin override is downgraded (does not displace another plugin's action, incumbent survives unload); undeclared duplicate is **not** attributed to the colliding plugin.
- **23 tests green**, core `tsgo --noEmit` clean, codex-reviewed clean (two review rounds; the P2 plugin-ownership gap and the P1 destructive-teardown gap surfaced by codex are both closed by the plugin-boundary downgrade).

-- [sol-orch]