### PR TITLE
feat(ios): --skip-appexes device-deploy mode for main-app-only testing

### DIFF
--- a/packages/app/scripts/ios-device-deploy.mjs
+++ b/packages/app/scripts/ios-device-deploy.mjs
@@ -21,8 +21,14 @@
  *
  * Usage:
  *   node scripts/ios-device-deploy.mjs [--device <devicectl-id|udid|name>]
- *     [--skip-build] [--no-launch] [--staging <dir>] [--identity <sha1>]
- *     [--derived-data <dir>] [--bundle-id <id>] [--configuration Debug|Release]
+ *     [--skip-build] [--no-launch] [--skip-appexes] [--staging <dir>]
+ *     [--identity <sha1>] [--derived-data <dir>] [--bundle-id <id>]
+ *     [--configuration Debug|Release]
+ *
+ * --skip-appexes strips PlugIns/*.appex from the staged app before signing,
+ * so the main app can be deployed for on-device testing when only the app's
+ * own provisioning profile exists (each appex otherwise requires its own
+ * profile, which only an Xcode account session or ASC API key can mint).
  *
  * Device id falls back to ELIZA_IOS_DEVICE_ID. Fails with actionable
  * remediation when no profile matches.
@@ -329,11 +335,11 @@ function signApp({
 
 async function main() {
   const args = parseCliArgs(process.argv.slice(2), {
-    booleans: ["skip-build", "no-launch", "help"],
+    booleans: ["skip-build", "no-launch", "skip-appexes", "help"],
   });
   if (args.help) {
     console.log(
-      "Usage: node scripts/ios-device-deploy.mjs [--device <id>] [--skip-build] [--no-launch] [--staging <dir>] [--identity <sha1>] [--derived-data <dir>] [--bundle-id <id>] [--configuration Debug|Release]",
+      "Usage: node scripts/ios-device-deploy.mjs [--device <id>] [--skip-build] [--no-launch] [--skip-appexes] [--staging <dir>] [--identity <sha1>] [--derived-data <dir>] [--bundle-id <id>] [--configuration Debug|Release]",
     );
     return;
   }
@@ -416,6 +422,24 @@ async function main() {
   const stagedApp = path.join(stagingRoot, "App.app");
   runInherit("ditto", [builtApp, stagedApp]);
   log(`staged ${builtApp} → ${stagedApp}`);
+
+  // Optional: strip app extensions so the main app can deploy with only its
+  // own profile. Extension surfaces (widgets, keyboard, …) are absent from
+  // the installed build — main-app-only testing, stated loudly in the log.
+  if (args["skip-appexes"]) {
+    const plugInsDir = path.join(stagedApp, "PlugIns");
+    if (fs.existsSync(plugInsDir)) {
+      const stripped = fs
+        .readdirSync(plugInsDir)
+        .filter((n) => n.endsWith(".appex"));
+      fs.rmSync(plugInsDir, { recursive: true, force: true });
+      log(
+        `--skip-appexes: stripped ${stripped.length} extension(s): ${stripped.join(", ")} — widgets/keyboard/device-activity surfaces will be MISSING from this install`,
+      );
+    } else {
+      log("--skip-appexes: no PlugIns directory present");
+    }
+  }
 
   // 3–4. Profile graft + explicit nested signing + verify.
   signApp({


### PR DESCRIPTION
## What

Adds a `--skip-appexes` flag to `packages/app/scripts/ios-device-deploy.mjs`: strips `PlugIns/*.appex` from the staged app before profile grafting, so the main app can be deployed to a physical iPhone when only the app's own provisioning profile exists.

## Why

Each app extension requires its own provisioning profile (`ai.elizaos.app.<Appex>`). Minting those requires an Xcode account session or an ASC API key with issuer ID — neither is available headlessly on this machine (only the main-app team profile exists). Without this flag the deploy hard-fails at the first appex, blocking all on-device testing of the app itself. The strip is loud: the log states exactly which extensions are missing from the install.

The app now ships 5 extensions (DeviceActivityMonitor/Report, ElizaKeyboard, ElizaWidgets, WebsiteBlockerContent), so this failure mode hits any machine without per-appex profiles.

## Evidence

Real run against develop tip (`718aed83d26`), MoonCycles/Shaw's iPhone:
- unsigned device build: **BUILD SUCCEEDED**
- `--skip-appexes: stripped 5 extension(s): DeviceActivityMonitorExtension.appex, DeviceActivityReportExtension.appex, ElizaKeyboard.appex, ElizaWidgets.appex, WebsiteBlockerContentExtension.appex — widgets/keyboard/device-activity surfaces will be MISSING from this install`
- codesign graft + verify: OK; `devicectl` install succeeded on Shaw's iPhone (15 Pro, Wi-Fi tunnel). (MoonCycles rejects Wi-Fi install with CoreDeviceError 1001 — device-side transport limitation, unrelated.)
- Full extension-covered deploy remains the default path; this flag is opt-in for profile-constrained environments.

Other PR_EVIDENCE rows: N/A - script-lane change only; no UI/renderer/agent behavior. On-device boot-trace capture from this install follows in the parent issue evidence.

Part of the mobile on-device verification lane (#12185 verification, #12394/#12395 device evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)