### PR TITLE
fix(ui): 3 pure-logic bugs — cron range/list mis-description, Accept-Language q=0 selection, JWT UTF-8 claim mojibake

### DIFF
--- a/packages/ui/src/cloud/lib/jwt.test.ts
+++ b/packages/ui/src/cloud/lib/jwt.test.ts
@@ -12,9 +12,20 @@ function makeToken(payload: Record<string, unknown>): string {
   return `${header}.${body}.sig`;
 }
 
-/** Standard-then-url base64 encode (mirrors a real JWT segment, no padding). */
+/**
+ * Standard-then-url base64 encode of the UTF-8 bytes (mirrors a real JWT
+ * segment, no padding). Real issuers encode UTF-8 JSON (RFC 7519 §3), so the
+ * bytes are produced via TextEncoder — a bare `btoa(json)` would emit latin1
+ * bytes no real token contains.
+ */
 function base64url(input: string): string {
-  return btoa(input).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  const bytes = new TextEncoder().encode(input);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
 }
 
 describe("decodeJwtPayload", () => {
@@ -41,12 +52,27 @@ describe("decodeJwtPayload", () => {
     expect(decodeJwtPayload(token)).toEqual(payload);
   });
 
+  it("decodes non-ASCII UTF-8 claims without mojibake", () => {
+    // Real tokens carry UTF-8 JSON; decoding the atob byte string directly
+    // used to yield "josÃ©@example.com".
+    const payload = { email: "josé@example.com", sub: "u1", exp: 42 };
+    expect(decodeJwtPayload(makeToken(payload))).toEqual(payload);
+  });
+
+  it("decodes claims outside latin1 (CJK, emoji)", () => {
+    const payload = { email: "太郎@example.com", sub: "🙂", exp: 42 };
+    expect(decodeJwtPayload(makeToken(payload))).toEqual(payload);
+  });
+
   it.each([
     ["empty string", ""],
     ["wrong segment count", "a.b"],
     ["too many segments", "a.b.c.d"],
     ["non-base64 payload", "a.!!!.c"],
     ["payload is not JSON", `a.${base64url("not json")}.c`],
+    // 0xFF alone is not valid UTF-8 — the strict decode maps it to null
+    // rather than a fabricated payload.
+    ["payload bytes are not UTF-8", `a.${btoa('{"sub":"ÿ"}')}.c`],
   ])("returns null for %s", (_label, token) => {
     expect(decodeJwtPayload(token)).toBeNull();
   });

--- a/packages/ui/src/cloud/lib/jwt.ts
+++ b/packages/ui/src/cloud/lib/jwt.ts
@@ -31,7 +31,14 @@ export function decodeJwtPayload(token: string): StewardTokenClaims | null {
       base64.length + ((4 - (base64.length % 4)) % 4),
       "=",
     );
-    return JSON.parse(atob(padded)) as StewardTokenClaims;
+    // `atob` yields one char per BYTE (latin1). JWT payloads are UTF-8 JSON
+    // (RFC 7519 §3), so parse the bytes through a UTF-8 decode — feeding the
+    // byte string straight to JSON.parse mojibakes any non-ASCII claim
+    // ("josé" → "josÃ©"). `fatal: true` makes non-UTF-8 bytes throw, which the
+    // catch maps to the contract's `null` for malformed tokens.
+    const bytes = Uint8Array.from(atob(padded), (ch) => ch.charCodeAt(0));
+    const json = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    return JSON.parse(json) as StewardTokenClaims;
   } catch {
     return null;
   }

--- a/packages/ui/src/i18n/region.test.ts
+++ b/packages/ui/src/i18n/region.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit coverage for Accept-Language / region language resolution. Pure
+ * functions, no harness.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  languageFromAcceptLanguage,
+  languageFromRegion,
+  resolveServerLanguage,
+} from "./region";
+
+describe("languageFromAcceptLanguage", () => {
+  it("picks a supported language", () => {
+    expect(languageFromAcceptLanguage("ja")).toBe("ja");
+    expect(languageFromAcceptLanguage("es-MX, en;q=0.5")).toBe("es");
+  });
+
+  it("ranks by q-value", () => {
+    expect(languageFromAcceptLanguage("ko;q=0.3, ja;q=0.9")).toBe("ja");
+  });
+
+  it("skips unsupported tags and wildcards", () => {
+    expect(languageFromAcceptLanguage("de, *;q=0.5")).toBeNull();
+    expect(languageFromAcceptLanguage("de-AT, pt;q=0.4")).toBe("pt");
+  });
+
+  it("excludes q=0 tags entirely (RFC 9110: not acceptable)", () => {
+    // A lone rejected tag must yield null, not the rejected language.
+    expect(languageFromAcceptLanguage("ja;q=0")).toBeNull();
+    expect(languageFromAcceptLanguage("es;q=0, de")).toBeNull();
+    // A rejected tag never outranks an accepted one.
+    expect(languageFromAcceptLanguage("ko;q=0, ja;q=0.8")).toBe("ja");
+  });
+
+  it("returns null for empty/absent headers", () => {
+    expect(languageFromAcceptLanguage("")).toBeNull();
+    expect(languageFromAcceptLanguage(null)).toBeNull();
+    expect(languageFromAcceptLanguage(undefined)).toBeNull();
+  });
+});
+
+describe("languageFromRegion", () => {
+  it("maps a country code case-insensitively", () => {
+    expect(languageFromRegion("br")).toBe("pt");
+    expect(languageFromRegion("KR")).toBe("ko");
+  });
+
+  it("returns null for unmapped or missing codes", () => {
+    expect(languageFromRegion("DE")).toBeNull();
+    expect(languageFromRegion(null)).toBeNull();
+  });
+});
+
+describe("resolveServerLanguage", () => {
+  it("prefers Accept-Language over region", () => {
+    expect(resolveServerLanguage({ acceptLanguage: "ja", country: "BR" })).toBe(
+      "ja",
+    );
+  });
+
+  it("falls through to region when every listed language is rejected", () => {
+    // `ja;q=0` used to resolve to "ja" and shadow the region signal.
+    expect(
+      resolveServerLanguage({ acceptLanguage: "ja;q=0", country: "BR" }),
+    ).toBe("pt");
+  });
+
+  it("returns null when neither signal maps to a supported language", () => {
+    expect(
+      resolveServerLanguage({ acceptLanguage: "de", country: "FR" }),
+    ).toBeNull();
+  });
+});

--- a/packages/ui/src/i18n/region.ts
+++ b/packages/ui/src/i18n/region.ts
@@ -88,7 +88,10 @@ export function languageFromAcceptLanguage(
         ?.slice(2);
       return { tag: tag.trim(), q: q ? Number.parseFloat(q) : 1 };
     })
-    .filter((entry) => entry.tag && entry.tag !== "*")
+    // `q=0` means "not acceptable" (RFC 9110 §12.4.2) — such tags must be
+    // excluded, not merely ranked last, or a lone `ja;q=0` would still select
+    // Japanese. Unparseable q-values are dropped with them (`NaN > 0` is false).
+    .filter((entry) => entry.tag && entry.tag !== "*" && entry.q > 0)
     .sort((a, b) => b.q - a.q);
 
   for (const { tag } of ranked) {

--- a/packages/ui/src/utils/cron-format.test.ts
+++ b/packages/ui/src/utils/cron-format.test.ts
@@ -44,6 +44,15 @@ describe("describeCron", () => {
     expect(describeCron("0 25 * * *")).toBeNull();
   });
 
+  it("returns null for range/list minute or hour fields instead of describing their first value", () => {
+    // These fire many times a day; parseInt used to read "9-17" as 9 and
+    // "0,30" as 0, mis-describing them as a single daily time.
+    expect(describeCron("0 9-17 * * *")).toBeNull();
+    expect(describeCron("0,30 9 * * *")).toBeNull();
+    expect(describeCron("30 6,18 * * *")).toBeNull();
+    expect(describeCron("0 9/2 * * *")).toBeNull();
+  });
+
   it("matches every preset to a friendly description", () => {
     for (const preset of CRON_PRESETS) {
       expect(describeCron(preset.expression)).not.toBeNull();
@@ -58,5 +67,9 @@ describe("formatSchedule", () => {
 
   it("falls back to the raw expression when not recognised", () => {
     expect(formatSchedule("0 9 1 * *")).toBe("0 9 1 * *");
+  });
+
+  it("falls back to the raw expression for range/list minute-hour shapes", () => {
+    expect(formatSchedule("0 9-17 * * *")).toBe("0 9-17 * * *");
   });
 });

--- a/packages/ui/src/utils/cron-format.ts
+++ b/packages/ui/src/utils/cron-format.ts
@@ -74,10 +74,13 @@ export function describeCron(expression: string): string | null {
     return "Every hour";
   }
 
-  // Specific hour:minute, repeated each day or on a dow set
+  // Specific hour:minute, repeated each day or on a dow set. Both fields must
+  // be a single plain integer — `Number.parseInt` alone would read the first
+  // number out of a range/list ("9-17" → 9, "0,30" → 0) and confidently
+  // describe a multi-fire schedule as a single daily time.
+  if (!/^\d+$/.test(minPart) || !/^\d+$/.test(hourPart)) return null;
   const minute = Number.parseInt(minPart, 10);
   const hour = Number.parseInt(hourPart, 10);
-  if (!Number.isFinite(minute) || !Number.isFinite(hour)) return null;
   if (minute < 0 || minute > 59 || hour < 0 || hour > 23) return null;
   const time = formatTime(hour, minute);
 


### PR DESCRIPTION
Three real, probe-verified pure-logic bugs in `@elizaos/ui`, each fixed minimally with a mutation-checked pure vitest (no jsdom, no React render, no live API). Every bug was reproduced against current `develop` BEFORE authoring the fix.

## Bug 1 — `utils/cron-format.ts`: range/list cron fields described as a single daily time

**Concrete failure (probed on develop):**
- `describeCron("0 9-17 * * *")` → `"Every day at 9am"` — the schedule fires 9 times a day.
- `describeCron("0,30 9 * * *")` → `"Every day at 9am"` — fires at 9:00 AND 9:30.
- `formatSchedule("0 9-17 * * *")` → `"Every day at 9am"` instead of the documented raw-expression fallback.

`Number.parseInt` reads the first number out of a range/list field (`"9-17"` → 9, `"0,30"` → 0). The Task editor's free-text cron input surfaces this as a confidently wrong schedule label. Fix: both minute and hour fields must be a plain integer (`/^\d+$/`) before the specific-time branch; everything else returns `null` so `formatSchedule` falls back to the raw expression, per the module's own contract.

## Bug 2 — `i18n/region.ts`: `q=0` Accept-Language tags are selected instead of excluded

**Concrete failure (probed on develop):**
- `languageFromAcceptLanguage("ja;q=0")` → `"ja"` — the client explicitly said Japanese is NOT acceptable (RFC 9110 §12.4.2: weight 0 = "not acceptable").
- `resolveServerLanguage({ acceptLanguage: "ja;q=0", country: "BR" })` → `"ja"` instead of `"pt"` — the rejected tag also shadowed the region-geo fallback.

The old code only ranked q=0 tags last, so a lone rejected tag still won. Fix: filter to `entry.q > 0` (unparseable `q=` values are `NaN` and drop with them).

## Bug 3 — `cloud/lib/jwt.ts`: non-ASCII JWT claims mojibake (`josé` → `josÃ©`)

**Concrete failure (probed on develop):** a UTF-8-encoded token (the only shape real issuers produce — RFC 7519 §3) with `email: "josé@example.com"` decoded to `"josÃ©@example.com"`. `atob` yields one char per byte (latin1) and the byte string went straight to `JSON.parse`, garbling every non-ASCII email/name claim the cloud surfaces read. Fix: decode the payload bytes through `TextDecoder("utf-8", { fatal: true })`; invalid UTF-8 now throws into the existing catch and maps to the documented `null`-for-malformed contract. The test helper's `makeToken` used `btoa(json)` (latin1 bytes no real issuer emits) and was updated to encode UTF-8 like a real token.

## Evidence

| Check | Result |
| --- | --- |
| Unit tests (pure .ts, no jsdom) | 36/36 green: `cron-format.test.ts`, `region.test.ts` (new file), `jwt.test.ts` — `bunx vitest run --no-cache` |
| Mutation check | Each fix reverted in isolation fails its own tests (cron: 2, region: 2, jwt: 4), then restored — no false-green tests |
| Downstream consumers | `scheduled-task-to-automation.test.ts`, `i18n/messages.test.ts`, `cloud/lib/api-client.test.ts`, `cloud/lib/cloud-api-key-token.test.ts` → 29/29 green |
| Lint | `biome check --write` clean on all 6 touched files |
| Typecheck | Only pre-existing unrelated failure (`spatial/__e2e__/immersive-fixture.ts` missing `iwer` dev dep — untouched by this branch) |
| Screenshots / video / trajectories | N/A — pure formatter/parser logic with no rendered surface change; behavior fully proven by concrete input→output unit tests above |

[phone-ui]

---
**Authored end-to-end by a Fable-5 agent** (verified 100% claude-fable-5), committed + pushed. Each bug probe-executed against the real function on develop (concrete input → wrong output) BEFORE authoring. Independently re-verified by main loop: 6-file merge-base diff, 36/36 green (--no-cache), jwt.ts mutation reproduced (revert → non-ASCII tests red; restore → green). All 3 are user-visible on the demo surface (Task cron editor label, server language selection, cloud account email/name display). Agent dropped 4 speculative candidates. — [phone-ui]