### PR TITLE
fix(cloud-api): restore the "build" script — unbreak the develop CF deploy lane

### DIFF
--- a/packages/cloud/api/package.json
+++ b/packages/cloud/api/package.json
@@ -15,6 +15,7 @@
     "agent:build": "node ../../scripts/cloud/admin/dev/build-cloud-agent-image.mjs",
     "deploy": "wrangler deploy --env production",
     "codegen": "node src/_generate-router.mjs",
+    "build": "tsc --noEmit",
     "typecheck": "tsgo --noEmit",
     "test": "node test/run-unit-isolated.mjs",
     "test:batch": "bun test __tests__",


### PR DESCRIPTION
## What
The develop **Cloud CF Deploy** workflow fails on every run: its `Build` step (a hard release gate) runs `bun run --cwd packages/cloud/api build`, but the `build` script was dropped from `packages/cloud/api/package.json` — so the step exits 1 and no develop deploy can complete.

## Why it matters
- **develop → staging deploys are dead**, and the emergency-hotfix-through-CI lane is down. (Surfaced by a pre-demo regression-guard.)
- **Not on main** — prod deploys are unaffected — so this is a lane restore, not a prod incident.

## Root cause
The `build` script (`tsc --noEmit`) appears to have been dropped as collateral in a docs/prose-header commit (#12816). Evidence it's supposed to exist:
- `main` still has `"build": "tsc --noEmit"` (verbatim what this restores).
- The package `CLAUDE.md` documents `build # tsc --noEmit (type-only)` as a real command.
- It's a **distinct** type-gate from `typecheck` (`tsgo --noEmit`, the Go compiler) — the workflow deliberately runs both tsc and tsgo as hard gates.

## Change
One line: restore `"build": "tsc --noEmit"` to `packages/cloud/api/package.json`, matching main. **No runtime/product code touched** — config only.

## Verification
- `package.json` re-validated as JSON; `build` value byte-matches main.
- N/A for trajectories/screenshots/DB (build-config only, no runtime surface). The real proof is the next develop deploy run going green on the Build step.

Infra/CI fix in my own lane (cloud-cf-deploy). — [cloud-security]