### PR TITLE
fix(#12645): migrate action contexts onto owner actions, shrink static catalog

### DIFF
--- a/packages/core/src/features/payments/actions/payment.ts
+++ b/packages/core/src/features/payments/actions/payment.ts
@@ -673,6 +673,9 @@ export const paymentAction: Action = {
 		"Payment ops. action=create_request, deliver_link, verify_payload, settle, await_callback, cancel_request.",
 	descriptionCompressed:
 		"Payment create_request|deliver_link|verify_payload|settle|await_callback|cancel_request",
+	// Domain context declared on the owner action (#12090 item 35).
+	// Previously only present in core's static ACTION_CONTEXT_MAP fallback.
+	contexts: ["payments"],
 	parameters: [
 		{
 			name: "action",

--- a/packages/core/src/utils/context-catalog.test.ts
+++ b/packages/core/src/utils/context-catalog.test.ts
@@ -1,12 +1,108 @@
 /**
  * Verifies resolveProviderContexts (context-catalog) surfaces the ACTION_STATE
- * provider in every first-party context. Vitest, direct function calls.
+ * provider in every first-party context, and guards the action-context contract:
+ * declared `action.contexts` wins over the LEGACY_ACTION_CONTEXT_FALLBACK table,
+ * and no core-owned action that declares its own contexts leaks back into the
+ * legacy fallback (#12090 item 35 drift guard). Vitest, direct function calls.
  */
 
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { actionStateProvider } from "../features/basic-capabilities/providers/actionState";
 import { FIRST_PARTY_CONTEXT_IDS } from "../runtime/context-normalization";
-import { resolveProviderContexts } from "./context-catalog";
+import type { Action, AgentContext } from "../types/components";
+import {
+	LEGACY_ACTION_CONTEXT_FALLBACK,
+	resolveActionContexts,
+	resolveProviderContexts,
+} from "./context-catalog";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function makeAction(name: string, contexts?: AgentContext[]): Action {
+	return { name, contexts } as unknown as Action;
+}
+
+/**
+ * Core-owned actions that used to depend on the static fallback table and now
+ * declare `contexts` on their own definition. Each row is the action NAME and the
+ * source file whose action object must carry a `contexts:` declaration.
+ */
+const MIGRATED_CORE_ACTIONS: ReadonlyArray<{ name: string; file: string }> = [
+	{ name: "ATTACHMENT", file: "../features/working-memory/readAttachmentAction.ts" },
+	{ name: "DOCUMENT", file: "../features/documents/actions.ts" },
+	{
+		name: "GENERATE_MEDIA",
+		file: "../features/advanced-capabilities/actions/generateMedia.ts",
+	},
+	{
+		name: "MESSAGE",
+		file: "../features/advanced-capabilities/actions/message.ts",
+	},
+	{ name: "POST", file: "../features/advanced-capabilities/actions/post.ts" },
+	{ name: "MANAGE_PLUGINS", file: "../features/plugin-manager/actions/plugin.ts" },
+	{ name: "PAYMENT", file: "../features/payments/actions/payment.ts" },
+];
+
+describe("resolveActionContexts", () => {
+	it("prefers an action's declared contexts over the legacy fallback", () => {
+		// NONE has a legacy fallback of ["general"]; a declared array must win.
+		expect(
+			resolveActionContexts(makeAction("NONE", ["wallet", "code"])),
+		).toEqual(["wallet", "code"]);
+	});
+
+	it("falls back to the legacy table for plugin-owned names without declared contexts", () => {
+		// SEND_TOKEN is a plugin-owned (third-party) action name kept in the fallback.
+		expect(resolveActionContexts(makeAction("SEND_TOKEN"))).toEqual(["wallet"]);
+		expect(resolveActionContexts(makeAction("send_token"))).toEqual(["wallet"]);
+	});
+
+	it("defaults unknown, undeclared action names to [\"general\"]", () => {
+		expect(
+			resolveActionContexts(makeAction("TOTALLY_UNKNOWN_ACTION")),
+		).toEqual(["general"]);
+	});
+
+	it("treats an empty declared contexts array as undeclared (falls through)", () => {
+		expect(resolveActionContexts(makeAction("REPLY", []))).toEqual(["general"]);
+	});
+});
+
+describe("LEGACY_ACTION_CONTEXT_FALLBACK drift guard (#12090 item 35)", () => {
+	it("does not keep any migrated core-owned action name as a key", () => {
+		for (const { name } of MIGRATED_CORE_ACTIONS) {
+			expect(
+				Object.prototype.hasOwnProperty.call(
+					LEGACY_ACTION_CONTEXT_FALLBACK,
+					name,
+				),
+			).toBe(false);
+		}
+	});
+
+	it("proves each migrated core action declares contexts on its own definition", () => {
+		for (const { name, file } of MIGRATED_CORE_ACTIONS) {
+			const src = readFileSync(resolve(__dirname, file), "utf8");
+			// The action object must carry a `contexts:` declaration; without it the
+			// action would silently fall back to ["general"] now that the static
+			// entry is gone. This is the executable-path guard for the coupling.
+			expect(src, `${name} (${file}) must declare contexts`).toMatch(
+				/\bcontexts:\s*(\[|[A-Z_]+_CONTEXTS)/,
+			);
+		}
+	});
+
+	it("only retains uppercase action-name keys (legacy fallback shape)", () => {
+		for (const key of Object.keys(LEGACY_ACTION_CONTEXT_FALLBACK)) {
+			expect(key, `${key} should be an UPPER_SNAKE action name`).toMatch(
+				/^[A-Z][A-Z0-9_]*$/,
+			);
+		}
+	});
+});
 
 describe("resolveProviderContexts", () => {
 	it("exposes ACTION_STATE in every first-party context", () => {

--- a/packages/core/src/utils/context-catalog.ts
+++ b/packages/core/src/utils/context-catalog.ts
@@ -1,15 +1,40 @@
 /**
- * Static catalog mapping built-in action and provider names to the agent
- * contexts they belong to, and the resolvers that pick a component's contexts —
- * its own declared `contexts` when present, otherwise this catalog's entry,
- * defaulting to "general". The source of routing context for components that do
- * not declare their own.
+ * Context resolvers that pick a component's contexts: its own declared `contexts`
+ * when present, otherwise a legacy fallback table, defaulting to "general".
+ *
+ * Actions are the source of truth for their own contexts and should declare
+ * `contexts` on the action definition. LEGACY_ACTION_CONTEXT_FALLBACK is retained
+ * only for plugin-owned / third-party action names that have not yet migrated (see its
+ * doc comment). PROVIDER_CONTEXT_MAP still maps built-in provider names.
  */
 
 import { FIRST_PARTY_CONTEXT_IDS } from "../runtime/context-normalization";
 import type { Action, AgentContext, Provider } from "../types/components";
 
-export const ACTION_CONTEXT_MAP: Record<string, AgentContext[]> = {
+/**
+ * LEGACY_ACTION_CONTEXT_FALLBACK is a legacy, host-owned fallback map from action
+ * NAME to domain contexts, consulted ONLY when an action does not declare its own
+ * `contexts` array (see {@link resolveActionContexts}).
+ *
+ * The contexts contract now lives on the owner action: every action should declare
+ * `contexts` on its own definition, and `resolveActionContexts` always prefers a
+ * declared array over this table (declared wins, proven by the guard test in
+ * `context-catalog.test.ts`).
+ *
+ * This table is retained ONLY for plugin-owned / third-party action NAMES whose
+ * definitions live outside this repo (wallet, cron, browser, media, connector, and
+ * other loadable plugins) and have not yet migrated their contexts onto the action.
+ * It is NOT the source of truth and must not be extended with in-repo core actions.
+ *
+ * Invariant (enforced by `context-catalog.test.ts`): no core-owned action that
+ * declares its own `contexts` may appear as a key here. Core owners that previously
+ * relied on this table (ATTACHMENT, DOCUMENT, GENERATE_MEDIA, MESSAGE, POST,
+ * MANAGE_PLUGINS, PAYMENT) now declare `contexts` on the action itself and were
+ * removed from here. Several had drifted: the ATTACHMENT, GENERATE_MEDIA, and
+ * MESSAGE map entries were narrower than the owner declaration, so the static entry
+ * was silently wrong for those actions.
+ */
+export const LEGACY_ACTION_CONTEXT_FALLBACK: Record<string, AgentContext[]> = {
 	NONE: ["general"],
 	IGNORE: ["general"],
 	CONTINUE: ["general"],
@@ -61,7 +86,9 @@ export const ACTION_CONTEXT_MAP: Record<string, AgentContext[]> = {
 	GET_PORTFOLIO: ["wallet"],
 	CREATE_WALLET: ["wallet"],
 	IMPORT_WALLET: ["wallet"],
-	DOCUMENT: ["documents"],
+	// DOCUMENT, GENERATE_MEDIA, MESSAGE, POST, ATTACHMENT, PAYMENT, MANAGE_PLUGINS
+	// were core-owned entries here; they now declare `contexts` on their own action
+	// (#12090 item 35) and were removed from this fallback (drift-guarded by test).
 	SEARCH: ["documents", "browser"],
 	REMEMBER: ["documents"],
 	RECALL: ["documents"],
@@ -97,7 +124,6 @@ export const ACTION_CONTEXT_MAP: Record<string, AgentContext[]> = {
 	CREATE_SUBTASK: ["code", "automation"],
 	COMPLETE_TASK: ["code", "automation"],
 	CANCEL_TASK: ["code", "automation"],
-	GENERATE_MEDIA: ["media"],
 	DESCRIBE_IMAGE: ["media", "documents"],
 	DESCRIBE_VIDEO: ["media", "documents"],
 	DESCRIBE_AUDIO: ["media", "documents"],
@@ -114,8 +140,6 @@ export const ACTION_CONTEXT_MAP: Record<string, AgentContext[]> = {
 	TASK: ["tasks", "automation"],
 	TRIGGER: ["automation", "tasks"],
 	TRIGGER_WEBHOOK: ["automation"],
-	MESSAGE: ["messaging", "connectors", "documents", "automation"],
-	POST: ["social_posting", "connectors"],
 	CONTACT: ["contacts", "messaging", "documents"],
 	ENTITY: ["contacts", "messaging", "documents"],
 	CALENDAR: ["calendar", "automation"],
@@ -125,7 +149,6 @@ export const ACTION_CONTEXT_MAP: Record<string, AgentContext[]> = {
 	SEARCH_CONTACTS: ["contacts"],
 	SUMMARIZE_CONVERSATION: ["messaging", "documents"],
 	CHAT_WITH_ATTACHMENTS: ["messaging", "documents", "media"],
-	ATTACHMENT: ["documents", "media"],
 	DOWNLOAD_MEDIA: ["messaging", "media"],
 	TRANSCRIBE_MEDIA: ["messaging", "documents", "media"],
 	SERVER_INFO: ["messaging"],
@@ -145,14 +168,12 @@ export const ACTION_CONTEXT_MAP: Record<string, AgentContext[]> = {
 	RESOLVE_REQUEST: ["tasks", "automation", "admin", "general"],
 	CREDENTIALS: ["browser", "settings", "secrets"],
 	CHAT_THREAD: ["messaging"],
-	PAYMENT: ["payments"],
 	X: ["social_posting", "messaging"],
 	CONNECTOR: ["connectors"],
 	ELEVATE_TRUST: ["contacts", "admin"],
 	REVOKE_TRUST: ["contacts", "admin"],
 	BLOCK_USER: ["messaging", "admin"],
 	UNBLOCK_USER: ["messaging", "admin"],
-	MANAGE_PLUGINS: ["connectors", "admin"],
 	MANAGE_SECRETS: ["secrets", "admin"],
 	SHELL_EXEC: ["terminal", "code", "admin"],
 	RESTART: ["admin"],
@@ -240,7 +261,7 @@ export function resolveActionContexts(action: Action): AgentContext[] {
 		return declared;
 	}
 
-	return ACTION_CONTEXT_MAP[action.name.toUpperCase()] ?? ["general"];
+	return LEGACY_ACTION_CONTEXT_FALLBACK[action.name.toUpperCase()] ?? ["general"];
 }
 
 export function resolveProviderContexts(provider: Provider): AgentContext[] {


### PR DESCRIPTION
Closes #12645 (arch-audit brittle strings, #12090 item 35).

## Problem
`packages/core/src/utils/context-catalog.ts` kept a large static `ACTION_CONTEXT_MAP` mapping action NAMES to domain contexts. For **core-owned** actions this duplicated the `contexts` array declared on the action itself, and had **drifted** from it — so the static entry was silently wrong:

- `ATTACHMENT` map = `["documents","media"]` vs owner declaration `["general","files","media","messaging","documents","web"]`
- `GENERATE_MEDIA` map = `["media"]` vs owner `["media","files"]`
- `MESSAGE` map = `["messaging","connectors","documents","automation"]` vs owner `["messaging","email","contacts","connectors"]`

`PAYMENT` was worse: it existed **only** in the static map (`["payments"]`) and the owner action declared nothing, so its contexts lived entirely in the brittle table.

## Change
- Rename `ACTION_CONTEXT_MAP` → `LEGACY_ACTION_CONTEXT_FALLBACK` and document it as a legacy, host-owned fallback consulted **only** when an action declares no `contexts`. Retained solely for plugin-owned / third-party action names (wallet, cron, browser, media, connector, …) not yet migrated. Not publicly re-exported, so the rename is internal-only.
- Remove the core-owned keys whose owner action already declares contexts: `ATTACHMENT`, `DOCUMENT`, `GENERATE_MEDIA`, `MESSAGE`, `POST`, `MANAGE_PLUGINS`. These now resolve purely from their own declaration (fixing the three drifted cases above).
- Migrate `PAYMENT` onto its owner: `paymentAction` now declares `contexts: ["payments"]`; the stale static key is removed.
- `resolveActionContexts` behavior is unchanged: declared `action.contexts` wins, else the legacy fallback, else `["general"]`.

## Tests / evidence
New/expanded `packages/core/src/utils/context-catalog.test.ts` (8 tests):
- **declared-wins**: `resolveActionContexts` prefers a declared array over the fallback; an empty declared array falls through
- plugin-owned names (`SEND_TOKEN`) still resolve via the legacy fallback (case-insensitive)
- unknown/undeclared names default to `["general"]`
- **drift guard**: none of the migrated core action names (`ATTACHMENT`, `DOCUMENT`, `GENERATE_MEDIA`, `MESSAGE`, `POST`, `MANAGE_PLUGINS`, `PAYMENT`) remains a fallback key, **and** each migrated core action source declares its own `contexts` (executable-path guard proving the coupling is gone)
- fallback keys are `UPPER_SNAKE` action names only

Green:
- `context-catalog.test.ts` 8/8
- `payment.test.ts` 17/17 + `message-stage1-context-catalog.test.ts` 5/5 (no regression)
- `tsgo --noEmit -p packages/core` clean (exit 0)
- `codex review --uncommitted`: no correctness issues

— [sol-orch]