### PR TITLE
docs(#12856): add cockpit training prose headers

### DIFF
--- a/packages/ui/src/components/cockpit/CockpitModePicker.tsx
+++ b/packages/ui/src/components/cockpit/CockpitModePicker.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the cockpit mode cards and Eliza Cloud tier toggle without importing
+ * plugin or server code into the UI package.
+ */
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import { SegmentedControl } from "../ui/segmented-control";
@@ -25,7 +29,7 @@ const BADGE_CLASS: Record<CockpitModeBadge, string> = {
 export interface CockpitModePickerProps {
   /** The currently-selected mode config. */
   value: CockpitModeConfig;
-  /** Called with the new config when the user picks a mode or flips the tier. */
+  /** Called with the selected config when the user picks a mode or flips the tier. */
   onChange: (config: CockpitModeConfig) => void;
   /** Arm the TOS-unsafe experimental options (hidden by default). */
   experimentalEnabled?: boolean;

--- a/packages/ui/src/components/cockpit/CockpitNewSessionForm.stories.tsx
+++ b/packages/ui/src/components/cockpit/CockpitNewSessionForm.stories.tsx
@@ -1,4 +1,4 @@
-/** Storybook stories for the cockpit new-session (spawn) form. */
+/** Storybook stories for the cockpit session-start form. */
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { CockpitNewSessionForm } from "./CockpitNewSessionForm";

--- a/packages/ui/src/components/cockpit/CockpitNewSessionForm.tsx
+++ b/packages/ui/src/components/cockpit/CockpitNewSessionForm.tsx
@@ -1,3 +1,7 @@
+/**
+ * Collects a coding-agent goal and cockpit mode selection, then emits the
+ * orchestrator create-task input used to start a session.
+ */
 import { useState } from "react";
 
 import type { CodingAgentCreateTaskInput } from "../../api/client-types-cloud";
@@ -29,7 +33,7 @@ export interface CockpitNewSessionFormProps {
 }
 
 /**
- * The "spawn a new coding session" form for the cockpit: a free-text goal + the
+ * The "spawn a coding session" form for the cockpit: a free-text goal + the
  * per-session {@link CockpitModePicker}. On submit it lowers the selected mode to
  * the orchestrator `providerPolicy` (via `buildCockpitCreateTaskInput`) and hands
  * the parent a ready `CodingAgentCreateTaskInput` to POST to

--- a/packages/ui/src/components/cockpit/CockpitTierToggle.tsx
+++ b/packages/ui/src/components/cockpit/CockpitTierToggle.tsx
@@ -1,10 +1,14 @@
+/**
+ * Presents the Fast/Smart tier selector that a running cockpit session pane
+ * uses to persist the desired Eliza Cloud provider policy.
+ */
 import { SegmentedControl } from "../ui/segmented-control";
 import type { ElizaCloudTier } from "./cockpit-modes";
 
 export interface CockpitTierToggleProps {
   /** Current Eliza Cloud tier of the running session. */
   value: ElizaCloudTier;
-  /** Called with the new tier when the user flips it. */
+  /** Called with the selected tier when the user flips it. */
   onChange: (tier: ElizaCloudTier) => void;
   disabled?: boolean;
   className?: string;

--- a/packages/ui/src/components/cockpit/CockpitView.tsx
+++ b/packages/ui/src/components/cockpit/CockpitView.tsx
@@ -1,3 +1,7 @@
+/**
+ * Composes the mobile-first coding cockpit deck, active room entry points, and
+ * session-start form without owning the live orchestrator wiring.
+ */
 import { TerminalSquare } from "lucide-react";
 
 import type {
@@ -36,7 +40,7 @@ export interface CockpitViewProps {
  *
  *   - the live **deck** (`OrchestratorRoomView`, shaw's room-view widget) — one
  *     card per active task room with its swarm of sub-agents, and
- *   - the **new-session** form (mode picker → create-task `providerPolicy`).
+ *   - the **session-start** form (mode picker → create-task `providerPolicy`).
  *
  * The driver bubble (host chat) manages these rooms; tapping a room drills into
  * its focused session pane (transcript + `TaskInspector` controls + a terminal-

--- a/packages/ui/src/components/cockpit/MyRuntimesContainer.test.tsx
+++ b/packages/ui/src/components/cockpit/MyRuntimesContainer.test.tsx
@@ -163,7 +163,7 @@ describe("MyRuntimesContainer", () => {
         apiBase: "http://100.72.1.9:3000",
       }),
     );
-    // and it switches to the new one so the client repoints + the Active badge is true
+    // The added profile becomes active so the client repoints and the badge reflects it.
     expect(mocks.switchRuntimeNonDestructive).toHaveBeenCalledWith("new-1");
   });
 

--- a/packages/ui/src/components/cockpit/MyRuntimesContainer.tsx
+++ b/packages/ui/src/components/cockpit/MyRuntimesContainer.tsx
@@ -1,3 +1,7 @@
+/**
+ * Connects the runtime switcher to the persisted agent-profile registry and
+ * enforces trust gates before adding or activating remote runtimes.
+ */
 import { useCallback, useState } from "react";
 
 import { isStoreBuild } from "../../build-variant";
@@ -33,7 +37,7 @@ export function MyRuntimesContainer({ className }: MyRuntimesContainerProps) {
   const hideLocal = isAndroidCloudBuild() || isStoreBuild();
   const visibleProfiles = hideLocal
     ? // Hide local runtimes — but keep the one that's CURRENTLY active visible,
-      // else the Active badge would vanish on a store build whose persisted
+      // otherwise the Active badge vanishes on a store build whose persisted
       // active profile is local (onSwitch still refuses switching TO a local).
       registry.profiles.filter(
         (p) => p.kind !== "local" || p.id === registry.activeProfileId,

--- a/packages/ui/src/components/cockpit/MyRuntimesSection.tsx
+++ b/packages/ui/src/components/cockpit/MyRuntimesSection.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the prop-driven runtime switcher used by Settings and the coding
+ * cockpit to show local, cloud, and remote Eliza agent runtimes.
+ */
 import { Check, Cloud, HardDrive, Server } from "lucide-react";
 import { useState } from "react";
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/cockpit/cockpit-modes.ts
+++ b/packages/ui/src/components/cockpit/cockpit-modes.ts
@@ -221,7 +221,7 @@ function deriveTitle(text: string, max = 80): string {
 }
 
 /**
- * Build the orchestrator create-task input for a new cockpit session from a
+ * Build the orchestrator create-task input for a cockpit session from a
  * free-text goal + the selected mode. `title` defaults to the goal's first line.
  */
 export function buildCockpitCreateTaskInput(opts: {

--- a/packages/ui/src/components/custom-actions/CustomActionsView.tsx
+++ b/packages/ui/src/components/custom-actions/CustomActionsView.tsx
@@ -91,7 +91,7 @@ export function CustomActionsView() {
           ),
         );
       } catch {
-        // toggle failure: optimistic update will be stale until next load
+        // A failed toggle leaves the displayed state to be reconciled by the next load.
       }
     },
     [],
@@ -114,7 +114,7 @@ export function CustomActionsView() {
         await client.deleteCustomAction(id);
         setActions((prev) => prev.filter((action) => action.id !== id));
       } catch {
-        // deletion failure: item remains in list
+        // A failed delete keeps the item visible for retry.
       }
     },
     [t],

--- a/packages/ui/src/components/training/injected.tsx
+++ b/packages/ui/src/components/training/injected.tsx
@@ -1,3 +1,7 @@
+/**
+ * Bridges the app shell's training route to the fine-tuning view injected by
+ * the Training plugin, with a lightweight unavailable-state fallback.
+ */
 import type { FineTuningViewProps } from "../../config/boot-config";
 import { useBootConfig } from "../../config/boot-config-react.hooks";
 


### PR DESCRIPTION
## Summary
- add top-of-file purpose headers for the cockpit runtime/session components and the training injected view
- rewrite small churn comments in the cockpit/custom-actions slice into present-tense facts
- keep the change comment-only with no code, string, export, styling, or package metadata changes

Closes #12856.

## Verification
- `git diff --check origin/develop HEAD -- . && git diff --check`
- `node scripts/assert-comment-only-diff.mjs origin/develop`
- `bun run check:comment-only`
- focused self-audit: `files=33 missing_headers=0`
- `git diff --stat origin/develop...HEAD`

## Evidence
- Real-LLM trajectories: N/A - comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- Screenshots/video/audio/domain artifacts: N/A - comments-only UI/app source header cleanup; no rendered behavior changes.
