### PR TITLE
docs(#12852): add settings auth prose headers

### DIFF
--- a/packages/ui/src/components/accounts/AccountList.stories.tsx
+++ b/packages/ui/src/components/accounts/AccountList.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook coverage for account-list provider variants and the backendless
+ * empty state produced by the account client hook.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { AccountList } from "./AccountList";

--- a/packages/ui/src/components/config-ui/config-field.tsx
+++ b/packages/ui/src/components/config-ui/config-field.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders one plugin configuration field with the standard label, status,
+ * renderer, validation, and help-text structure used by config panels.
+ */
 import type {
   FieldRenderer,
   FieldRenderProps,

--- a/packages/ui/src/components/connectors/connector-setup-panel-registry.ts
+++ b/packages/ui/src/components/connectors/connector-setup-panel-registry.ts
@@ -1,3 +1,7 @@
+/**
+ * Maps connector plugin ids to built-in setup panel tokens while keeping panel
+ * availability checks outside the connector list renderer.
+ */
 import { getBootConfig } from "../../config/boot-config";
 
 /**

--- a/packages/ui/src/components/permissions/PermissionPrimingModal.tsx
+++ b/packages/ui/src/components/permissions/PermissionPrimingModal.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the post-login permission soft-ask modal and its injected-controller
+ * seam for tests and stories.
+ */
 import type { PermissionId } from "@elizaos/shared/contracts/permissions";
 import {
   AudioLines,

--- a/packages/ui/src/components/permissions/PermissionPrimingOverlay.tsx
+++ b/packages/ui/src/components/permissions/PermissionPrimingOverlay.tsx
@@ -1,3 +1,7 @@
+/**
+ * Mounts permission priming at the shell root once first-run and tutorial
+ * gates allow the post-login soft-ask sequence to appear.
+ */
 import * as React from "react";
 import { useIsAuthenticated } from "../../hooks/useAuthStatus";
 import { useAppSelector } from "../../state";

--- a/packages/ui/src/components/permissions/StreamingPermissions.stories.tsx
+++ b/packages/ui/src/components/permissions/StreamingPermissions.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the streaming permission settings card across web,
+ * mobile, and voice-focused copy variants.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { StreamingPermissionsSettingsView } from "./StreamingPermissions";

--- a/packages/ui/src/components/permissions/permission-priming.ts
+++ b/packages/ui/src/components/permissions/permission-priming.ts
@@ -1,3 +1,7 @@
+/**
+ * Declares the platform-specific permission priming sets, rationale copy, and
+ * persisted shown-state for the onboarding soft-ask flow.
+ */
 import type { PermissionId } from "@elizaos/shared/contracts/permissions";
 import { getFrontendPlatform } from "../../platform/platform-guards";
 

--- a/packages/ui/src/components/permissions/use-permission-priming.ts
+++ b/packages/ui/src/components/permissions/use-permission-priming.ts
@@ -1,3 +1,7 @@
+/**
+ * Coordinates the onboarding soft-ask permission sequence across web, desktop,
+ * and native registries without prompting the OS until the user opts in.
+ */
 import type {
   IPermissionsRegistry,
   PermissionId,

--- a/packages/ui/src/components/settings/AppPermissionsSection.stories.tsx
+++ b/packages/ui/src/components/settings/AppPermissionsSection.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook coverage for the app permissions settings panel as it settles from
+ * backend fetch into empty/error and responsive states.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { AppPermissionsSection } from "./AppPermissionsSection";

--- a/packages/ui/src/components/settings/AppsManagementSection.stories.tsx
+++ b/packages/ui/src/components/settings/AppsManagementSection.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook coverage for the apps management settings panel and its backendless
+ * loading, empty, error, and responsive toolbar states.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { mockApp, withMockApp } from "../../storybook/mock-providers.helpers";
 import { AppsManagementSection } from "./AppsManagementSection";

--- a/packages/ui/src/components/settings/BackgroundSettingsSection.tsx
+++ b/packages/ui/src/components/settings/BackgroundSettingsSection.tsx
@@ -1,3 +1,7 @@
+/**
+ * Hosts the unified background controls inside the Settings surface without
+ * adding extra chrome that would hide the live wallpaper preview.
+ */
 import { BackgroundSettingsControls } from "./BackgroundSettingsControls";
 
 /**

--- a/packages/ui/src/components/settings/DesktopWorkspaceSection.stories.tsx
+++ b/packages/ui/src/components/settings/DesktopWorkspaceSection.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the desktop workspace settings section, including the
+ * web-shell fallback where Electrobun bridges are unavailable.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { DesktopWorkspaceSection } from "./DesktopWorkspaceSection";

--- a/packages/ui/src/components/settings/PermissionsSection.stories.tsx
+++ b/packages/ui/src/components/settings/PermissionsSection.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Settings permissions section across roomy, narrow,
+ * and card-framed layouts with the web permission surface selected.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { PermissionsSection } from "./PermissionsSection";

--- a/packages/ui/src/components/settings/settings-layout.tsx
+++ b/packages/ui/src/components/settings/settings-layout.tsx
@@ -1,3 +1,7 @@
+/**
+ * Defines the shared Settings layout primitives that keep section groups and
+ * rows consistent across built-in and plugin-provided settings panels.
+ */
 import { ChevronRight } from "lucide-react";
 import type * as React from "react";
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/settings/settings-section-registry.ts
+++ b/packages/ui/src/components/settings/settings-section-registry.ts
@@ -1,3 +1,7 @@
+/**
+ * Owns the dynamic settings-section registry shared by built-ins, hosts, and
+ * plugins so the Settings view can render declared sections in one order.
+ */
 import type { ViewKind } from "@elizaos/core";
 import type { LucideIcon } from "lucide-react";
 import type { ComponentType, LazyExoticComponent } from "react";


### PR DESCRIPTION
## Summary
- add required top-of-file prose headers across the settings/auth/connectors/permissions/config/accounts slice
- keep the edit comment-only with no code, string, export, styling, or package metadata changes
- verify the focused slice has no remaining files missing top headers

Closes #12852.

## Verification
- `git diff --check origin/develop HEAD -- . && git diff --check`
- `bun run check:comment-only`
- focused self-audit: `files=185 missing_headers=0`
- `git diff --stat origin/develop...HEAD`

## Evidence
- Real-LLM trajectories: N/A - comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- Screenshots/video/audio/domain artifacts: N/A - comments-only UI source header cleanup; no rendered behavior changes.
