### PR TITLE
refactor(#12654): derive CORE_STATIC_PLUGIN_REGISTRATIONS from one manifest

### DIFF
--- a/packages/agent/src/runtime/core-static-plugin-registrations.test.ts
+++ b/packages/agent/src/runtime/core-static-plugin-registrations.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Drift guard for the CORE_STATIC_PLUGIN_REGISTRATIONS descriptor table
+ * (#12089 item 3). The descriptor table in eliza.ts used to be a SECOND parallel
+ * registry hand-mirroring the bundle-manifest lists: adding an optional plugin
+ * to OPTIONAL_STATIC_PLUGIN_PACKAGES (bundleability) without also hand-adding a
+ * descriptor row (registration) — or vice versa — drifted silently, leaving a
+ * plugin either non-bundleable or bundled-but-never-registered. The blocking
+ * pair likewise hand-mirrored BLOCKING_CORE_PLUGINS.
+ *
+ * The table is now DERIVED:
+ *   - deferred rows  <- OPTIONAL_STATIC_PLUGIN_REGISTRATIONS (+ declared overrides)
+ *   - blocking rows  <- BLOCKING_CORE_PLUGINS (+ declared bespoke loaders)
+ *
+ * These tests assert the derivation wiring holds and that the old hand-written
+ * object-literal rows are gone from the executable path, so the two lists can no
+ * longer diverge without a test failure.
+ *
+ * eliza.ts is read as TEXT (not imported) so vitest never eagerly resolves the
+ * heavy runtime module and its transitive optional-plugin specifiers — the same
+ * technique optional-plugins.test.ts and eliza-local-agent-port-gate.test.ts use.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { BLOCKING_CORE_PLUGINS } from "./core-plugins.ts";
+import {
+  OPTIONAL_STATIC_PLUGIN_OVERRIDES,
+  OPTIONAL_STATIC_PLUGIN_PACKAGES,
+  OPTIONAL_STATIC_PLUGIN_REGISTRATIONS,
+  UNBUNDLED_OPTIONAL_PLUGINS,
+} from "./optional-plugins.ts";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+function elizaSource(): string {
+  return readFileSync(path.join(here, "eliza.ts"), "utf8");
+}
+
+describe("optional static-plugin source of truth", () => {
+  it("OPTIONAL_STATIC_PLUGIN_REGISTRATIONS = bundled ++ unbundled, in order", () => {
+    // One list feeds both the mobile-bundle importer codegen (bundled subset)
+    // and the runtime descriptor table (whole list). If they ever came from two
+    // hand-written lists again, this composition is the seam that would drift.
+    expect(OPTIONAL_STATIC_PLUGIN_REGISTRATIONS).toEqual([
+      ...OPTIONAL_STATIC_PLUGIN_PACKAGES,
+      ...UNBUNDLED_OPTIONAL_PLUGINS,
+    ]);
+  });
+
+  it("has no duplicate package entries", () => {
+    expect(new Set(OPTIONAL_STATIC_PLUGIN_REGISTRATIONS).size).toBe(
+      OPTIONAL_STATIC_PLUGIN_REGISTRATIONS.length,
+    );
+  });
+
+  it("every declared override annotates a real optional plugin", () => {
+    // A stale override (typo'd or removed package) would silently apply to
+    // nothing; keep overrides pinned to the list they annotate.
+    const known = new Set(OPTIONAL_STATIC_PLUGIN_REGISTRATIONS);
+    for (const pkg of Object.keys(OPTIONAL_STATIC_PLUGIN_OVERRIDES)) {
+      expect(known.has(pkg), `override for unlisted plugin ${pkg}`).toBe(true);
+    }
+  });
+
+  it("agent-orchestrator declares its short-name registry key via override", () => {
+    // Regression: the orchestrator registers/looks-up as "agent-orchestrator",
+    // not its package name. That must live in the declared override, not a
+    // hand-written descriptor row.
+    expect(
+      OPTIONAL_STATIC_PLUGIN_OVERRIDES["@elizaos/plugin-agent-orchestrator"]
+        ?.registryName,
+    ).toBe("agent-orchestrator");
+  });
+
+  it("gitpathologist declares its mobile-skip via override, not a bespoke row", () => {
+    expect(
+      OPTIONAL_STATIC_PLUGIN_OVERRIDES["@elizaos/plugin-gitpathologist"]
+        ?.skipOnMobile,
+    ).toBe(true);
+  });
+});
+
+describe("descriptor table derivation (eliza.ts source guard, #12089 item 3)", () => {
+  it('declares no inline `packageName: "@elizaos/plugin-..."` object-literal rows', () => {
+    // The old CORE_STATIC_PLUGIN_REGISTRATIONS was ~18 hand-written object
+    // literals of this exact shape — the parallel list #12089 item 3 flagged.
+    // The bespoke blocking loaders use a different shape
+    // (`"@elizaos/plugin-sql": { required: ... }`), so this guard fires only if
+    // someone reintroduces a hand-written descriptor row.
+    const inlineRows = [
+      ...elizaSource().matchAll(/packageName:\s*"@elizaos\/plugin-[^"]+"/g),
+    ];
+    expect(
+      inlineRows.length,
+      `found ${inlineRows.length} hand-written descriptor row(s); derive from OPTIONAL_STATIC_PLUGIN_REGISTRATIONS / BLOCKING_CORE_PLUGINS instead`,
+    ).toBe(0);
+  });
+
+  it("builds the descriptor table from the derivation helpers", () => {
+    const source = elizaSource();
+    expect(source).toContain("...buildBlockingStaticRegistrations()");
+    expect(source).toContain("...buildDeferredStaticRegistrations()");
+  });
+
+  it("derives deferred rows from OPTIONAL_STATIC_PLUGIN_REGISTRATIONS", () => {
+    // buildDeferredStaticRegistrations() maps over the single source of truth.
+    const source = elizaSource();
+    expect(source).toMatch(
+      /OPTIONAL_STATIC_PLUGIN_REGISTRATIONS\.map\(\(packageName\)/,
+    );
+    expect(source).toContain("OPTIONAL_STATIC_PLUGIN_OVERRIDES");
+  });
+
+  it("derives blocking rows from BLOCKING_CORE_PLUGINS and fails loud on a missing loader", () => {
+    const source = elizaSource();
+    expect(source).toMatch(/BLOCKING_CORE_PLUGINS\.map\(\(packageName\)/);
+    // The fail-loud guard is what turns a blocking-set drift (a plugin declared
+    // blocking with no bespoke loader) into a hard boot error instead of a
+    // silent non-registration.
+    expect(source).toContain(
+      "no blocking static loader is declared for it in eliza.ts",
+    );
+  });
+
+  it("declares a bespoke blocking loader for every BLOCKING_CORE_PLUGINS entry", () => {
+    // Text-assert the loader map covers the blocking set so the fail-loud guard
+    // never actually trips at boot on the current lists. Scope the scan to the
+    // BLOCKING_STATIC_PLUGIN_LOADERS object so a stray package mention elsewhere
+    // can't satisfy the check. Formatting-tolerant: biome may wrap a loader
+    // entry onto multiple lines, so match `"pkg": {` (a map key), not the full
+    // one-line shape.
+    const source = elizaSource();
+    const loaderBlock = source.slice(
+      source.indexOf("const BLOCKING_STATIC_PLUGIN_LOADERS"),
+      source.indexOf("function buildBlockingStaticRegistrations"),
+    );
+    expect(
+      loaderBlock.length,
+      "could not locate the BLOCKING_STATIC_PLUGIN_LOADERS block in eliza.ts",
+    ).toBeGreaterThan(0);
+    for (const pkg of BLOCKING_CORE_PLUGINS) {
+      expect(
+        loaderBlock.includes(`"${pkg}": {`),
+        `BLOCKING_STATIC_PLUGIN_LOADERS is missing a bespoke loader for ${pkg}`,
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -39,6 +39,10 @@ import { startMemoryWatchdog } from "./memory-watchdog.ts";
 import { resolveConfigEnvForProcess } from "./operations/vault-bridge.ts";
 import { OPTIONAL_PLUGIN_IMPORTERS } from "./optional-plugin-imports.generated.ts";
 import {
+  OPTIONAL_STATIC_PLUGIN_OVERRIDES,
+  OPTIONAL_STATIC_PLUGIN_REGISTRATIONS,
+} from "./optional-plugins.ts";
+import {
   isWorkspacePluginSourceFallbackAllowed,
   type PluginResolutionPhase,
   resolvePlugins,
@@ -415,129 +419,76 @@ type CoreStaticPluginRegistration = {
   load: () => Promise<unknown>;
 };
 
+// Blocking-phase loaders. These two plugins each need a bespoke loader (the
+// required SQL adapter with a workspace-source fallback; the local-inference
+// pre-init hook), so they are the only descriptor rows whose `load` is not the
+// generic optional loader. Their membership + required-ness is derived from
+// BLOCKING_CORE_PLUGINS (the single source of truth for the blocking set) rather
+// than re-listed here — buildBlockingStaticRegistrations() below asserts the two
+// stay in lockstep so a change to BLOCKING_CORE_PLUGINS can't silently orphan a
+// loader or register a plugin with no loader.
+const BLOCKING_STATIC_PLUGIN_LOADERS: Readonly<
+  Record<string, { required: boolean; load: () => Promise<unknown> }>
+> = {
+  "@elizaos/plugin-sql": { required: true, load: () => getPluginSql() },
+  "@elizaos/plugin-local-inference": {
+    required: false,
+    load: () => getPluginLocalEmbedding(),
+  },
+};
+
+function buildBlockingStaticRegistrations(): CoreStaticPluginRegistration[] {
+  return BLOCKING_CORE_PLUGINS.map((packageName) => {
+    const loader = BLOCKING_STATIC_PLUGIN_LOADERS[packageName];
+    if (!loader) {
+      // Fail loud rather than silently skip: a plugin declared blocking with no
+      // bespoke loader here would otherwise never register, stranding the
+      // runtime's readiness dependency (this is exactly the parallel-list drift
+      // #12089 item 3 flagged).
+      throw new Error(
+        `[boot] BLOCKING_CORE_PLUGINS lists ${packageName} but no blocking static loader is declared for it in eliza.ts`,
+      );
+    }
+    return {
+      packageName,
+      phase: "blocking" as const,
+      required: loader.required,
+      load: loader.load,
+    };
+  });
+}
+
+function buildDeferredStaticRegistrations(): CoreStaticPluginRegistration[] {
+  // Derived from the single optional-plugin source of truth
+  // (OPTIONAL_STATIC_PLUGIN_REGISTRATIONS) so the runtime descriptor table and
+  // the bundle-manifest layer can no longer drift into two parallel lists
+  // (#12089 item 3). Per-plugin variance (short-name registry key, mobile skip)
+  // comes from the declared OPTIONAL_STATIC_PLUGIN_OVERRIDES beside that list,
+  // not from hand-written rows here.
+  return OPTIONAL_STATIC_PLUGIN_REGISTRATIONS.map((packageName) => {
+    const override = OPTIONAL_STATIC_PLUGIN_OVERRIDES[packageName];
+    const load = override?.skipOnMobile
+      ? () =>
+          isMobilePlatform()
+            ? Promise.resolve(null)
+            : getOptionalPlugin(packageName)
+      : () => getOptionalPlugin(packageName);
+    return {
+      packageName,
+      ...(override?.registryName
+        ? { registryName: override.registryName }
+        : {}),
+      phase: "deferred" as const,
+      required: false,
+      load,
+    };
+  });
+}
+
 const CORE_STATIC_PLUGIN_REGISTRATIONS: readonly CoreStaticPluginRegistration[] =
   [
-    {
-      packageName: "@elizaos/plugin-sql",
-      phase: "blocking",
-      required: true,
-      load: () => getPluginSql(),
-    },
-    {
-      packageName: "@elizaos/plugin-local-inference",
-      phase: "blocking",
-      required: false,
-      load: () => getPluginLocalEmbedding(),
-    },
-    {
-      packageName: "@elizaos/plugin-agent-orchestrator",
-      registryName: "agent-orchestrator",
-      phase: "deferred",
-      required: false,
-      load: () => getOptionalPlugin("@elizaos/plugin-agent-orchestrator"),
-    },
-    {
-      packageName: "@elizaos/plugin-task-coordinator",
-      phase: "deferred",
-      required: false,
-      load: () => getOptionalPlugin("@elizaos/plugin-task-coordinator"),
-    },
-    {
-      packageName: "@elizaos/plugin-shell",
-      phase: "deferred",
-      required: false,
-      load: () => getOptionalPlugin("@elizaos/plugin-shell"),
-    },
-    {
-      packageName: "@elizaos/plugin-coding-tools",
-      phase: "deferred",
-      required: false,
-      load: () => getOptionalPlugin("@elizaos/plugin-coding-tools"),
-    },
-    {
-      // Opt-in only: dormant unless a character lists @elizaos/plugin-pty (no
-      // autoEnable). Registers PTY_SERVICE so the web terminal can drive a real
-      // interactive CLI (eliza-code on Eliza Cloud/cerebras).
-      packageName: "@elizaos/plugin-pty",
-      phase: "deferred",
-      required: false,
-      load: () => getOptionalPlugin("@elizaos/plugin-pty"),
-    },
-    {
-      // Auto-on only when the host has the birdclaw CLI or an existing
-      // ~/.birdclaw data root (see birdclawRequested in plugin-collector.ts).
-      // Registers BIRDCLAW_SERVICE + the local Twitter/X archive view/action.
-      packageName: "@elizaos/plugin-birdclaw",
-      phase: "deferred",
-      required: false,
-      load: () => getOptionalPlugin("@elizaos/plugin-birdclaw"),
-    },
-    {
-      packageName: "@elizaos/plugin-commands",
-      phase: "deferred",
-      required: false,
-      load: () => getOptionalPlugin("@elizaos/plugin-commands"),
-    },
-    {
-      packageName: "@elizaos/plugin-video",
-      phase: "deferred",
-      required: false,
-      load: () => getOptionalPlugin("@elizaos/plugin-video"),
-    },
-    {
-      // MOBILE_CORE_PLUGINS lists plugin-vision (screen understanding on
-      // mobile — GET_SCREEN, the renderer-pulled screen-capture bridge, and
-      // the #11111 ML Kit OCR bridge routes), but without a static
-      // registration the mobile agent bundle could never resolve it: the
-      // renderer OCR poller polled /api/vision/ocr-requests into a 404
-      // forever (verified live on emulator-5554).
-      packageName: "@elizaos/plugin-vision",
-      phase: "deferred",
-      required: false,
-      load: () => getOptionalPlugin("@elizaos/plugin-vision"),
-    },
-    {
-      packageName: "@elizaos/plugin-background-runner",
-      phase: "deferred",
-      required: false,
-      load: () => getOptionalPlugin("@elizaos/plugin-background-runner"),
-    },
-    {
-      packageName: "@elizaos/plugin-elizacloud",
-      phase: "deferred",
-      required: false,
-      load: () => getOptionalPlugin("@elizaos/plugin-elizacloud"),
-    },
-    {
-      packageName: "@elizaos/plugin-ollama",
-      phase: "deferred",
-      required: false,
-      load: () => getOptionalPlugin("@elizaos/plugin-ollama"),
-    },
-    {
-      packageName: "@elizaos/plugin-anthropic",
-      phase: "deferred",
-      required: false,
-      load: () => getOptionalPlugin("@elizaos/plugin-anthropic"),
-    },
-    {
-      packageName: "@elizaos/plugin-openai",
-      phase: "deferred",
-      required: false,
-      load: () => getOptionalPlugin("@elizaos/plugin-openai"),
-    },
-    {
-      packageName: "@elizaos/plugin-gitpathologist",
-      phase: "deferred",
-      required: false,
-      // Not in the mobile bundle — attempting the import there hangs the full
-      // 30s deferred-plugin timeout before being skipped. Skip it up front on
-      // android/ios (it's a desktop dev tool, already gated in plugin-collector).
-      load: () =>
-        isMobilePlatform()
-          ? Promise.resolve(null)
-          : getOptionalPlugin("@elizaos/plugin-gitpathologist"),
-    },
+    ...buildBlockingStaticRegistrations(),
+    ...buildDeferredStaticRegistrations(),
   ];
 
 let _blockingStaticPluginsRegistered = false;

--- a/packages/agent/src/runtime/optional-plugins.test.ts
+++ b/packages/agent/src/runtime/optional-plugins.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   OPTIONAL_STATIC_PLUGIN_PACKAGES,
+  OPTIONAL_STATIC_PLUGIN_REGISTRATIONS,
   renderOptionalPluginImportsModule,
   UNBUNDLED_OPTIONAL_PLUGINS,
 } from "./optional-plugins.ts";
@@ -41,13 +42,15 @@ function generatedImporterEntries(): { key: string; specifier: string }[] {
 
 /**
  * Optional plugin packages the descriptor table (CORE_STATIC_PLUGIN_REGISTRATIONS
- * in eliza.ts) loads via getOptionalPlugin(...). Scanned from source so the
- * check needs no heavy import of eliza.ts.
+ * in eliza.ts) registers in the deferred phase. The descriptor table is now
+ * DERIVED from OPTIONAL_STATIC_PLUGIN_REGISTRATIONS (the single source of truth)
+ * rather than hand-listing `getOptionalPlugin("pkg")` literals (#12089 item 3),
+ * so this reads that source directly. A dedicated grep guard in
+ * core-static-plugin-registrations.test.ts proves eliza.ts no longer hand-mirrors
+ * the list; here we assert the manifest/importer consistency built on top of it.
  */
 function descriptorTableOptionalPackages(): string[] {
-  const source = readSource("eliza.ts");
-  const matches = source.matchAll(/getOptionalPlugin\(\s*"([^"]+)"\s*\)/g);
-  return [...new Set([...matches].map((m) => m[1]))];
+  return [...new Set(OPTIONAL_STATIC_PLUGIN_REGISTRATIONS)];
 }
 
 describe("optional-plugin literal-import codegen", () => {

--- a/packages/agent/src/runtime/optional-plugins.ts
+++ b/packages/agent/src/runtime/optional-plugins.ts
@@ -30,12 +30,23 @@ export const OPTIONAL_STATIC_PLUGIN_PACKAGES: readonly string[] = [
   "@elizaos/plugin-task-coordinator",
   "@elizaos/plugin-shell",
   "@elizaos/plugin-coding-tools",
+  // Opt-in only: dormant unless a character lists @elizaos/plugin-pty (no
+  // autoEnable). Registers PTY_SERVICE so the web terminal can drive a real
+  // interactive CLI (eliza-code on Eliza Cloud/cerebras).
   "@elizaos/plugin-pty",
+  // Auto-on only when the host has the birdclaw CLI or an existing ~/.birdclaw
+  // data root (see birdclawRequested in plugin-collector.ts). Registers
+  // BIRDCLAW_SERVICE + the local Twitter/X archive view/action.
   "@elizaos/plugin-birdclaw",
   "@elizaos/plugin-ollama",
   "@elizaos/plugin-elizacloud",
   "@elizaos/plugin-commands",
   "@elizaos/plugin-video",
+  // MOBILE_CORE_PLUGINS lists plugin-vision (screen understanding on mobile —
+  // GET_SCREEN, the renderer-pulled screen-capture bridge, and the #11111 ML
+  // Kit OCR bridge routes), but without a static registration the mobile agent
+  // bundle could never resolve it: the renderer OCR poller polled
+  // /api/vision/ocr-requests into a 404 forever (verified on emulator-5554).
   "@elizaos/plugin-vision",
   "@elizaos/plugin-background-runner",
   "@elizaos/plugin-anthropic",
@@ -54,6 +65,60 @@ export const OPTIONAL_STATIC_PLUGIN_PACKAGES: readonly string[] = [
 export const UNBUNDLED_OPTIONAL_PLUGINS: readonly string[] = [
   "@elizaos/plugin-gitpathologist",
 ];
+
+/**
+ * The single ordered source of truth for the optional (deferred-phase) static
+ * plugin registrations the runtime installs at boot. Both the bundle-manifest
+ * layer (`OPTIONAL_STATIC_PLUGIN_PACKAGES`, which decides mobile-bundleability)
+ * and the runtime descriptor table (`CORE_STATIC_PLUGIN_REGISTRATIONS` in
+ * `eliza.ts`, which decides what actually registers into `STATIC_ELIZA_PLUGINS`)
+ * MUST derive their optional-plugin set from this list — they used to be two
+ * hand-mirrored parallel lists that silently drifted (a plugin added to one but
+ * not the other became either non-bundleable or bundled-but-never-registered).
+ *
+ * Order is bundled-first then unbundled; the deferred boot phase iterates this
+ * order, but registration only populates the name-keyed `STATIC_ELIZA_PLUGINS`
+ * map (capability winners are decided later by the model router / plugin
+ * resolver, not by this order), so order is a stable-diff / log-sequence
+ * concern, not a behavioral one.
+ */
+export const OPTIONAL_STATIC_PLUGIN_REGISTRATIONS: readonly string[] = [
+  ...OPTIONAL_STATIC_PLUGIN_PACKAGES,
+  ...UNBUNDLED_OPTIONAL_PLUGINS,
+];
+
+/**
+ * Per-plugin descriptor overrides for the optional static registrations above.
+ * Everything not listed here uses the defaults (registryName = packageName,
+ * bundled = literal import, no platform skip). Keeping the overrides declared
+ * beside the list they annotate means the `eliza.ts` descriptor builder stays a
+ * pure map over {@link OPTIONAL_STATIC_PLUGIN_REGISTRATIONS} with no per-plugin
+ * special-casing baked into the runtime module.
+ */
+export interface OptionalStaticPluginOverride {
+  /**
+   * Registry key the module is stored under in `STATIC_ELIZA_PLUGINS` when it
+   * differs from the package name (short-name resolution, e.g. the
+   * orchestrator resolves as `"agent-orchestrator"`).
+   */
+  readonly registryName?: string;
+  /**
+   * When true, skip the import up front on android/ios instead of paying the
+   * full deferred-plugin boot timeout before it is dropped (desktop-only tools
+   * absent from the mobile bundle).
+   */
+  readonly skipOnMobile?: boolean;
+}
+
+export const OPTIONAL_STATIC_PLUGIN_OVERRIDES: Readonly<
+  Record<string, OptionalStaticPluginOverride>
+> = {
+  "@elizaos/plugin-agent-orchestrator": { registryName: "agent-orchestrator" },
+  // Not in the mobile bundle — attempting the import there hangs the full
+  // deferred-plugin timeout before being skipped. Skip it up front on
+  // android/ios (it is a desktop dev tool, already gated in plugin-collector).
+  "@elizaos/plugin-gitpathologist": { skipOnMobile: true },
+};
 
 const RELATIVE_GENERATED_PATH = "./optional-plugin-imports.generated.ts";
 


### PR DESCRIPTION
## Problem (#12089 item 3, parent #12089)

`CORE_STATIC_PLUGIN_REGISTRATIONS` in `packages/agent/src/runtime/eliza.ts` was a **second parallel registry** that hand-mirrored the bundle-manifest lists. Adding an optional plugin to `OPTIONAL_STATIC_PLUGIN_PACKAGES` (which decides mobile-bundleability) without also hand-adding a descriptor row (which decides what actually registers into `STATIC_ELIZA_PLUGINS`) — or vice versa — drifted **silently**, leaving a plugin either non-bundleable or bundled-but-never-registered. The two lists had **already diverged in ordering** (same set, different order). The blocking pair (`plugin-sql`, `plugin-local-inference`) likewise hand-mirrored `BLOCKING_CORE_PLUGINS`.

## Change — selection & loadability now share one source of truth

- **Deferred rows** are derived from `OPTIONAL_STATIC_PLUGIN_REGISTRATIONS` (`= OPTIONAL_STATIC_PLUGIN_PACKAGES ++ UNBUNDLED_OPTIONAL_PLUGINS`) via `buildDeferredStaticRegistrations()`. Per-plugin variance (agent-orchestrator's short-name registry key, gitpathologist's mobile skip) is declared in a new `OPTIONAL_STATIC_PLUGIN_OVERRIDES` map beside that list — no hand-written rows.
- **Blocking rows** are derived from `BLOCKING_CORE_PLUGINS` via `buildBlockingStaticRegistrations()`, which pairs each with a bespoke loader (`BLOCKING_STATIC_PLUGIN_LOADERS`) and **throws fail-loud** if a blocking plugin has no loader — turning what was a silent non-registration into a hard boot error.

### Behavior-preserving
The descriptor set is unchanged. Registration only populates the **name-keyed** `STATIC_ELIZA_PLUGINS` map — capability winners are decided later by the model router / plugin resolver, not by this order — so canonicalizing the deferred order to the manifest is a log-sequence change, not a runtime one. Per-plugin rationale comments (pty opt-in, birdclaw auto-on, vision #11111 mobile-404 regression) were moved to the authoritative list, not lost.

## Done-when coverage
- ✅ Central name list replaced by a declared registry + owner metadata.
- ✅ Drift/fallback mode covered by focused tests.
- ✅ Grep guard proves the old coupling is gone from executable paths.

## Tests (`packages/agent`)
- **New** `core-static-plugin-registrations.test.ts` (10 tests): source-of-truth composition, no-duplicate + override-pinning guards, agent-orchestrator/gitpathologist override regressions, and a **grep guard** proving `eliza.ts` no longer hand-mirrors the list (no inline `packageName: "@elizaos/plugin-..."` rows) and derives via the helpers + fail-loud blocking guard.
- **Updated** `optional-plugins.test.ts`: descriptor-table↔importer consistency now reads the derived `OPTIONAL_STATIC_PLUGIN_REGISTRATIONS` instead of scanning the removed `getOptionalPlugin("...")` literals.
- `bunx vitest run` (my new suite + `optional-plugins.test.ts` + `core-plugins.test.ts`): **19/19 green**.
- `bun run typecheck` (tsgo): **zero new errors** — only pre-existing baseline (unlinked optional-plugin type decls: plugin-streaming/vision/background-runner/meetings + plugin-discord `MemoryMetadata`), identical before and after.
- `bun run --cwd packages/agent gen:optional-plugin-imports`: generated importer file **round-trips unchanged** (no drift).
- `codex review --uncommitted`: **"No discrete correctness issues were found in the changed runtime plugin-registration derivation or associated tests."**

Files: `packages/agent/src/runtime/{eliza.ts, optional-plugins.ts, optional-plugins.test.ts, core-static-plugin-registrations.test.ts}`. No forbidden files touched.

-- [sol-orch]
