### PR TITLE
docs(#12854): add cloud app page prose headers

### DIFF
--- a/packages/ui/src/components/apps/EmbeddedAppViewer.tsx
+++ b/packages/ui/src/components/apps/EmbeddedAppViewer.tsx
@@ -1,3 +1,7 @@
+/**
+ * Embeds an app-run viewer iframe and coordinates the origin-pinned
+ * postMessage authentication handshake for hosted app surfaces.
+ */
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { AppViewerAuthMessage } from "../../api/client-types-cloud";
 import {
@@ -34,7 +38,7 @@ export interface EmbeddedAppViewerProps {
  * postMessage auth payload) runs the `*_READY` → auth handshake so the embedded
  * app loads authenticated — e.g. the full Feed web app signed in as the agent.
  *
- * Extracted from {@link FullscreenView} so any view (Feed, future embedded apps) can
+ * Extracted from {@link FullscreenView} so any view or embedded app can
  * reuse the exact same secure, origin-pinned handshake. The auth payload carries
  * a session/agent token, so it is only ever posted to a concrete, verified
  * http(s) `targetOrigin`; an unparseable/non-http(s)/opaque viewer origin fails

--- a/packages/ui/src/components/apps/load-apps-catalog.ts
+++ b/packages/ui/src/components/apps/load-apps-catalog.ts
@@ -1,3 +1,7 @@
+/**
+ * Loads and warms the Apps catalog by merging internal tools, server apps,
+ * catalog entries, and overlay app registrations.
+ */
 import { client, type RegistryAppInfo } from "../../api";
 import { fetchAvailableViews } from "../../hooks/useAvailableViews";
 import { writeAppsCache } from "./apps-cache";
@@ -19,7 +23,7 @@ export async function loadAppsCatalog(): Promise<RegistryAppInfo[]> {
     .catch((reason) => ({ status: "rejected" as const, reason }));
   const serverApps =
     serverAppsResult.status === "fulfilled" ? serverAppsResult.value : [];
-  // non-transient server list failure is silent; catalog + overlay entries fill the gap
+  // A server list failure leaves catalog and overlay entries to fill the gap.
 
   const networkViews = await fetchAvailableViews();
 
@@ -50,13 +54,13 @@ export async function loadAppsCatalog(): Promise<RegistryAppInfo[]> {
 
 /**
  * Fire-and-forget prefetch used at hydration so the Apps tab opens warm.
- * Errors are swallowed — the UI's own loadApps will retry on mount.
+ * Errors are ignored here because the UI's own loadApps retries on mount.
  */
 export async function prefetchAppsCatalog(): Promise<void> {
   try {
     const apps = await loadAppsCatalog();
     writeAppsCache(apps);
   } catch {
-    // prefetch failure is silent; AppsView loads on mount
+    // AppsView performs the visible load path on mount.
   }
 }

--- a/packages/ui/src/components/pages/AutomationsFeed.stories.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the automations feed, including backendless loading and
+ * connected-credential context variants.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { AutomationsFeed } from "./AutomationsFeed";

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.stories.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the browser workspace page under mocked app context,
+ * including absent bridge, installed bridge plugin, and wallet-connected cases.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { mockApp } from "../../storybook/mock-providers.helpers";
 import { BrowserWorkspaceView } from "./BrowserWorkspaceView";

--- a/packages/ui/src/components/pages/ChatView.terminal-focus.ts
+++ b/packages/ui/src/components/pages/ChatView.terminal-focus.ts
@@ -1,3 +1,7 @@
+/**
+ * Chooses when blocked or failed coding-agent sessions should pull focus into
+ * the Terminal channel without repeatedly stealing attention.
+ */
 import type { CodingAgentSession } from "../../api/client";
 
 /**
@@ -25,7 +29,7 @@ export function isProblemSessionStatus(
  * - A problem session the user is already viewing is marked handled for the
  *   same reason.
  * - Sessions that left the problem state (or left the list) are evicted, so a
- *   NEW error/blocked transition can auto-focus again.
+ *   fresh error/blocked transition can auto-focus again.
  *
  * Returns the sessionId to focus, or null when nothing new needs attention.
  */
@@ -42,7 +46,7 @@ export function pickProblemSessionToAutoFocus(
   }
 
   // Evict sessions that recovered/finished: their next problem transition is a
-  // new event and may auto-focus again.
+  // The next problem state is a fresh event and may auto-focus again.
   for (const id of handledSessionIds) {
     if (!problemIds.has(id)) {
       handledSessionIds.delete(id);

--- a/packages/ui/src/components/pages/DatabasePageView.stories.tsx
+++ b/packages/ui/src/components/pages/DatabasePageView.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Database page shell across tables, media, vectors,
+ * and optional content-header layouts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { mockApp } from "../../storybook/mock-providers.helpers";
 import { DatabasePageView } from "./DatabasePageView";

--- a/packages/ui/src/components/pages/DatabaseView.stories.tsx
+++ b/packages/ui/src/components/pages/DatabaseView.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook coverage for the database table editor in standalone and
+ * externally-navigated page layouts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { DatabaseView } from "./DatabaseView";

--- a/packages/ui/src/components/pages/DocumentsView.stories.tsx
+++ b/packages/ui/src/components/pages/DocumentsView.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook layouts for the Documents page across full-page, modal, embedded,
+ * compact, and controlled-selection surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { DocumentsView } from "./DocumentsView";

--- a/packages/ui/src/components/pages/ElizaCloudDashboard.stories.tsx
+++ b/packages/ui/src/components/pages/ElizaCloudDashboard.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Eliza Cloud dashboard connection, credits, billing,
+ * and authentication status surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { mockApp } from "../../storybook/mock-providers.helpers";
 import { CloudDashboard } from "./ElizaCloudDashboard";

--- a/packages/ui/src/components/pages/ElizaOsAppsView.permission-gate.test.ts
+++ b/packages/ui/src/components/pages/ElizaOsAppsView.permission-gate.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies the native-app read permission gate blocks denied Contacts and
+ * Messages bridge reads before Capacitor emits raw plugin errors.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { ensureNativeReadGranted } from "./ElizaOsAppsView";
 

--- a/packages/ui/src/components/pages/ElizaOsAppsView.stories.tsx
+++ b/packages/ui/src/components/pages/ElizaOsAppsView.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Android-native Phone, Messages, and Contacts app
+ * pages when the native plugin bridge is absent.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import {

--- a/packages/ui/src/components/pages/FilesView.stories.tsx
+++ b/packages/ui/src/components/pages/FilesView.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Files page using deterministic stored-file fixtures
+ * and stubbed file client methods.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { client, type StoredFile } from "../../api";
 import { withMockApp } from "../../storybook/mock-providers.helpers";

--- a/packages/ui/src/components/pages/GeneratedViewHero.stories.tsx
+++ b/packages/ui/src/components/pages/GeneratedViewHero.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for generated view hero tiles, including deterministic
+ * palette selection, pinned built-in palettes, and icon fallbacks.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { GeneratedViewHero } from "./GeneratedViewHero";
 

--- a/packages/ui/src/components/pages/MemoryViewerView.stories.tsx
+++ b/packages/ui/src/components/pages/MemoryViewerView.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the agent memory dashboard as API-backed people, stats,
+ * and memory feeds resolve into loading or empty states.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { MemoryViewerView } from "./MemoryViewerView";

--- a/packages/ui/src/components/pages/PluginVisual.tsx
+++ b/packages/ui/src/components/pages/PluginVisual.tsx
@@ -1,3 +1,7 @@
+/**
+ * Resolves and renders the strongest available plugin visual, from connector
+ * brand icons through provider logos to deterministic monogram tiles.
+ */
 import { useState } from "react";
 import type { PluginInfo } from "../../api";
 import { getProviderLogo } from "../../providers";

--- a/packages/ui/src/components/pages/TasksPageView.tsx
+++ b/packages/ui/src/components/pages/TasksPageView.tsx
@@ -1,3 +1,7 @@
+/**
+ * Hosts the full-page task coordinator panel inside the Tasks shell view
+ * without duplicating the panel's own header or empty state.
+ */
 import { CodingAgentTasksPanel } from "../../slots/task-coordinator-slots.js";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 

--- a/packages/ui/src/components/views/DynamicViewLoader.stories.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the dynamic view bundle loader, covering loading,
+ * rejected imports, view-type variants, and forwarded props.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { DynamicViewLoader } from "./DynamicViewLoader";

--- a/packages/ui/src/components/views/ViewTileImage.tsx
+++ b/packages/ui/src/components/views/ViewTileImage.tsx
@@ -1,3 +1,7 @@
+/**
+ * Paints launcher and catalog tile imagery with deterministic fallback glyph
+ * styling and runtime-safe API URL resolution.
+ */
 import { type CSSProperties, useState } from "react";
 import { client } from "../../api";
 import {

--- a/packages/ui/src/components/workspace/AppWorkspaceChrome.tsx
+++ b/packages/ui/src/components/workspace/AppWorkspaceChrome.tsx
@@ -1,3 +1,7 @@
+/**
+ * Provides the routed app workspace chrome that stacks optional navigation over
+ * the main pane while leaving chat to the global shell overlay.
+ */
 import type React from "react";
 import type { ReactNode } from "react";
 import { useMediaQuery } from "../../hooks";


### PR DESCRIPTION
## Summary
- add top-of-file purpose headers across the cloud/apps/pages/workspace/views component slice
- rewrite a few churn comments into stable present-tense explanations
- keep the batch comment-only with no code, string, export, styling, or package metadata changes

Closes #12854.

## Verification
- `git diff --check origin/develop HEAD -- . && git diff --check`
- `bun run check:comment-only`
- focused self-audit: `files=241 missing_headers=0`
- `git diff --stat origin/develop...HEAD`

## Evidence
- Real-LLM trajectories: N/A - comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- Screenshots/video/audio/domain artifacts: N/A - comments-only UI source header cleanup; no rendered behavior changes.
