### PR TITLE
refactor(#12668): boot tail drains a generic pre-ready boot-hook channel instead of hard-wiring plugin-local-inference internals

### DIFF
--- a/packages/app-core/src/runtime/boot-hook-channel.test.ts
+++ b/packages/app-core/src/runtime/boot-hook-channel.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit coverage for `drainBootHookContributors`, the generic PRE-READY boot-hook
+ * channel that `repairRuntimeAfterBoot` drains before the runtime is marked
+ * ready. It invokes each registry-declared contributor's `invoke(runtime)` in
+ * declared order, silently skips a contributor whose optional plugin is absent
+ * (OptionalAppRoutePluginUnavailableError), and rethrows any real failure —
+ * short-circuiting the remaining contributors (matching the fixed if-chain it
+ * replaced for plugin-local-inference's boot, arch-audit #12089 item 18).
+ */
+import type { AgentRuntime } from "@elizaos/core";
+import { OptionalAppRoutePluginUnavailableError } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  drainBootHookContributors,
+  resolveBootHookContributors,
+} from "./eliza.ts";
+
+// The generic boot-hook channel the pre-ready boot path drains. A "contributor"
+// is an app/plugin that declared a `bootHook` in the registry; the drain invokes
+// each against the runtime, skips an uninstalled optional plugin gracefully, and
+// rethrows a real failure.
+function makeFakeRuntime(): AgentRuntime {
+  return {} as AgentRuntime;
+}
+
+describe("drainBootHookContributors — generic pre-ready boot-hook channel", () => {
+  it("invokes a registered contributor with the runtime", async () => {
+    const runtime = makeFakeRuntime();
+    const invoke = vi.fn().mockResolvedValue(undefined);
+
+    await drainBootHookContributors(runtime, [
+      { id: "@elizaos/plugin-local-inference", invoke },
+    ]);
+
+    expect(invoke).toHaveBeenCalledOnce();
+    expect(invoke).toHaveBeenCalledWith(runtime);
+  });
+
+  it("invokes every contributor in declared order", async () => {
+    const runtime = makeFakeRuntime();
+    const order: string[] = [];
+
+    await drainBootHookContributors(runtime, [
+      {
+        id: "a",
+        invoke: async () => {
+          order.push("a");
+        },
+      },
+      {
+        id: "b",
+        invoke: async () => {
+          order.push("b");
+        },
+      },
+    ]);
+
+    expect(order).toEqual(["a", "b"]);
+  });
+
+  it("no-ops when there are no contributors", async () => {
+    const runtime = makeFakeRuntime();
+    await expect(
+      drainBootHookContributors(runtime, []),
+    ).resolves.toBeUndefined();
+  });
+
+  it("skips a contributor whose optional plugin is unavailable", async () => {
+    const runtime = makeFakeRuntime();
+    const after = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      drainBootHookContributors(runtime, [
+        {
+          id: "@elizaos/plugin-missing",
+          invoke: () =>
+            Promise.reject(
+              new OptionalAppRoutePluginUnavailableError(
+                "@elizaos/plugin-missing",
+              ),
+            ),
+        },
+        { id: "@elizaos/plugin-present", invoke: after },
+      ]),
+    ).resolves.toBeUndefined();
+
+    // The graceful skip does not abort the rest of the drain.
+    expect(after).toHaveBeenCalledOnce();
+  });
+
+  it("rethrows a real contributor failure (not mistaken for a benign absence)", async () => {
+    const runtime = makeFakeRuntime();
+    const boom = new Error("boot hook init blew up");
+    const after = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      drainBootHookContributors(runtime, [
+        { id: "@elizaos/plugin-broken", invoke: () => Promise.reject(boom) },
+        { id: "@elizaos/plugin-never", invoke: after },
+      ]),
+    ).rejects.toThrow(boom);
+
+    // A real failure short-circuits the remaining contributors — a broken
+    // pre-ready boot step must fail loud, not silently skip to the next.
+    expect(after).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveBootHookContributors — legacy local-inference fallback", () => {
+  it("falls back to the legacy local-inference boot hook when the registry is empty", () => {
+    // Packaged builds can ship without generated.json, so loadRegistry() is
+    // empty. The fallback guarantees the local model handlers still install
+    // (the pre-migration guarantee the hard-wired path used to provide).
+    const contributors = resolveBootHookContributors([]);
+    expect(contributors.map((c) => c.id)).toEqual([
+      "@elizaos/plugin-local-inference",
+    ]);
+  });
+
+  it("uses the registry-declared local-inference boot hook (no duplicate) when present", () => {
+    const contributors = resolveBootHookContributors([
+      {
+        id: "@elizaos/plugin-local-inference",
+        specifier: "@elizaos/plugin-local-inference/runtime",
+        exportName: "registerLocalInferenceBoot",
+      },
+    ]);
+    // Registry entry wins by id — the fallback must NOT add a second
+    // local-inference contributor.
+    expect(contributors.map((c) => c.id)).toEqual([
+      "@elizaos/plugin-local-inference",
+    ]);
+  });
+
+  it("includes other registry-declared boot hooks alongside the fallback", () => {
+    const contributors = resolveBootHookContributors([
+      {
+        id: "@elizaos/plugin-some-app",
+        specifier: "@elizaos/plugin-some-app",
+        exportName: "registerSomeBoot",
+      },
+    ]);
+    const ids = contributors.map((c) => c.id);
+    // The declared app hook plus the legacy local-inference fallback.
+    expect(ids).toContain("@elizaos/plugin-some-app");
+    expect(ids).toContain("@elizaos/plugin-local-inference");
+    expect(ids).toHaveLength(2);
+  });
+});

--- a/packages/app-core/src/runtime/boot-hook-decoupling.test.ts
+++ b/packages/app-core/src/runtime/boot-hook-decoupling.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Grep-guard for arch-audit #12089 item 18: the boot tail no longer hard-wires
+ * plugin-local-inference internals at fixed init points. The pre-ready
+ * local-inference boot (mobile-gate warning + platform-appropriate model-handler
+ * registration) moved into the plugin's `registerLocalInferenceBoot` hook,
+ * declared in its `registry-entry.json` and drained by the generic boot-hook
+ * channel (`runBootHooks` / `drainBootHookContributors`). This statically scans
+ * the real `eliza.ts` source to prove the old fixed-point coupling is gone from
+ * the executable path — matching the audit's "grep guard proves the old central
+ * name-keyed special case is gone" done-when. Runs against the real source tree,
+ * no mocks.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ELIZA_TS = join(HERE, "eliza.ts");
+
+function readElizaSource(): string {
+  return readFileSync(ELIZA_TS, "utf8");
+}
+
+/**
+ * The body of `repairRuntimeAfterBoot`, where the local-inference boot handler
+ * was hard-wired at fixed init points. We scope the grep to this function so a
+ * legitimate reference elsewhere (e.g. the still-lazy embedding-warmup accessor,
+ * which is a separate subsystem, or a doc comment) does not defeat the guard.
+ */
+function repairRuntimeAfterBootBody(source: string): string {
+  const start = source.indexOf("async function repairRuntimeAfterBoot(");
+  expect(start).toBeGreaterThan(-1);
+  // The next top-level `async function` / `function` declaration ends the body.
+  const rest = source.slice(start + 1);
+  const nextDecl = rest.search(/\n(?:async function|function) /);
+  expect(nextDecl).toBeGreaterThan(-1);
+  return rest.slice(0, nextDecl);
+}
+
+describe("boot-tail local-inference decoupling (arch-audit #12089 item 18)", () => {
+  it("repairRuntimeAfterBoot drains the generic boot-hook channel instead of naming local-inference internals", () => {
+    const body = repairRuntimeAfterBootBody(readElizaSource());
+
+    // The migration: the boot tail now drains registry-declared boot hooks.
+    expect(body).toContain("runBootHooks(runtime)");
+
+    // The old fixed-point coupling must be gone from the executable boot path:
+    // no direct calls to the local-inference boot internals the audit flagged.
+    expect(body).not.toContain("ensureLocalInferenceHandler(runtime)");
+    expect(body).not.toContain("shouldEnableMobileLocalInference()");
+    expect(body).not.toContain("warnIfMobileGateActiveWithoutPlatform(");
+  });
+
+  it("resolves boot-hook contributors from the registry by data, naming no plugin", () => {
+    const source = readElizaSource();
+    // The contributor resolver scans the registry (apps + plugins) for a
+    // declared `bootHook` — data-driven, no hard-wired specifier.
+    expect(source).toContain("entry.launch?.bootHook");
+    expect(source).toContain("getBootHookContributors");
+  });
+});

--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -76,7 +76,7 @@ import {
   syncElizaEnvAliases,
   syncResolvedApiPort,
 } from "@elizaos/shared";
-import { getApps, loadRegistry } from "../registry";
+import { getApps, getPlugins, loadRegistry } from "../registry";
 import { registerSubAgentCredentialBridgeAdapter } from "../services/credential-tunnel-service";
 import { registerCoreSensitiveRequestAdapters } from "../services/sensitive-requests/index.js";
 import {
@@ -683,6 +683,167 @@ async function registerRuntimeHooks(runtime: AgentRuntime): Promise<void> {
   await drainRuntimeHookContributors(runtime, getRuntimeHookContributors());
 }
 
+/**
+ * A PRE-READY boot-hook contributor: an app/plugin's optional init step run at a
+ * fixed point in {@link repairRuntimeAfterBoot}, BEFORE the runtime is marked
+ * ready, to install handlers / warm subsystems that must exist before the first
+ * turn (e.g. the local model handler). `invoke` loads the declared hook module
+ * and calls it with the runtime. Resolved from the registry ({@link
+ * getBootHookContributors}) — no feature plugin is hard-wired by name here; the
+ * host drains whatever entries declare a `bootHook`. Parallel to {@link
+ * RuntimeHookContributor}, but pre-ready instead of post-ready.
+ */
+interface BootHookContributor {
+  id: string;
+  invoke: (runtime: AgentRuntime) => Promise<void>;
+}
+
+/**
+ * LEGACY host-owned fallback for plugin-local-inference's pre-ready boot hook.
+ *
+ * The canonical source of this binding is the plugin's own `registry-entry.json`
+ * (`launch.bootHook`), resolved data-driven by {@link getBootHookContributors}.
+ * But a packaged build can ship WITHOUT the aggregated
+ * `@elizaos/registry/first-party/generated.json`; in that case `loadRegistry()`
+ * intentionally returns an EMPTY registry (it logs and continues rather than
+ * crashing the agent — see `readEntriesFromDisk`). Without this fallback the
+ * resolver would then yield no contributors and the local model handlers would
+ * never install — a regression from the previous hard-wired path, which always
+ * installed them regardless of registry presence. So when the registry does not
+ * supply the local-inference boot hook, we fall back to this explicitly-marked
+ * legacy host-owned binding. `importAppModuleFromSpecifier` still treats an
+ * actually-absent optional plugin as a graceful skip, so this is safe on
+ * deployments that ship no local-inference at all.
+ */
+const LEGACY_LOCAL_INFERENCE_BOOT_HOOK = {
+  id: "@elizaos/plugin-local-inference",
+  specifier: "@elizaos/plugin-local-inference/runtime",
+  exportName: "registerLocalInferenceBoot",
+} as const;
+
+/**
+ * Resolve every registry entry (app OR plugin) that declares a `bootHook` into a
+ * contributor. Data-driven and generic: the registry owns the package bindings
+ * (each plugin self-declares its hook in its own `registry-entry.json`), so the
+ * boot path names no plugin. Scans both apps and plugins because a pre-ready
+ * boot hook typically belongs to a provider plugin (e.g. plugin-local-inference)
+ * rather than a launchable app.
+ *
+ * When the registry does not supply the local-inference boot hook (e.g. a
+ * packaged build shipped without `generated.json`, so `loadRegistry()` is
+ * empty), the {@link LEGACY_LOCAL_INFERENCE_BOOT_HOOK} fallback is appended so
+ * the local model handlers still install — preserving the pre-migration
+ * guarantee. The registry entry, when present, takes precedence (deduped by id).
+ */
+function getBootHookContributors(): BootHookContributor[] {
+  const registry = loadRegistry();
+  // Extract just the boot-hook shape from each entry at the call site (an
+  // explicit projection off the wide AppEntry/PluginEntry union) so the pure
+  // resolver takes a narrow, test-friendly declaration type — no wide-union
+  // assignability coupling.
+  const declarations: BootHookDeclaration[] = [];
+  for (const entry of [...getApps(registry), ...getPlugins(registry)]) {
+    const bootHook = entry.launch?.bootHook;
+    if (!bootHook) continue;
+    declarations.push({
+      id: entry.npmName ?? entry.id,
+      specifier: bootHook.specifier,
+      exportName: bootHook.exportName,
+    });
+  }
+  return resolveBootHookContributors(declarations);
+}
+
+/**
+ * A registry entry's projected boot-hook declaration: the resolved contributor
+ * id plus the module specifier/export the host loads and invokes. Projected off
+ * the wide registry entry union by {@link getBootHookContributors} so the
+ * resolver stays decoupled from the full entry type.
+ */
+interface BootHookDeclaration {
+  id: string;
+  specifier: string;
+  exportName: string;
+}
+
+/**
+ * Pure resolver for the boot-hook contributors, split out so a focused unit test
+ * can drive it with hand-built declarations (empty registry, registry-declared
+ * entry, both) without loading the real registry. Registry-declared boot hooks
+ * win by id; the {@link LEGACY_LOCAL_INFERENCE_BOOT_HOOK} fallback is appended
+ * only when the registry did not already supply the local-inference boot hook.
+ */
+export function resolveBootHookContributors(
+  declarations: BootHookDeclaration[],
+): BootHookContributor[] {
+  const byId = new Map<string, BootHookContributor>();
+  for (const { id, specifier, exportName } of declarations) {
+    byId.set(id, {
+      id,
+      invoke: (runtime: AgentRuntime) =>
+        loadAndInvokeRuntimeHook(specifier, exportName, runtime),
+    });
+  }
+
+  // Legacy host-owned fallback: only when the registry did not already declare
+  // the local-inference boot hook (registry entry wins when present).
+  if (!byId.has(LEGACY_LOCAL_INFERENCE_BOOT_HOOK.id)) {
+    byId.set(LEGACY_LOCAL_INFERENCE_BOOT_HOOK.id, {
+      id: LEGACY_LOCAL_INFERENCE_BOOT_HOOK.id,
+      invoke: (runtime: AgentRuntime) =>
+        loadAndInvokeRuntimeHook(
+          LEGACY_LOCAL_INFERENCE_BOOT_HOOK.specifier,
+          LEGACY_LOCAL_INFERENCE_BOOT_HOOK.exportName,
+          runtime,
+        ),
+    });
+  }
+
+  return [...byId.values()];
+}
+
+/**
+ * Drain pre-ready boot-hook contributors in order, invoking each against the
+ * runtime. An optional plugin that is not installed is skipped gracefully
+ * (debug-logged); any real failure is logged and rethrown so a broken hook is
+ * never mistaken for a benign absence — matching the fixed if-chain it replaces,
+ * which would have thrown at that step. Exported for a focused unit test of the
+ * generic channel.
+ */
+export async function drainBootHookContributors(
+  runtime: AgentRuntime,
+  contributors: BootHookContributor[],
+): Promise<void> {
+  for (const { id, invoke } of contributors) {
+    try {
+      await invoke(runtime);
+    } catch (err) {
+      if (isOptionalAppRoutePluginUnavailableError(err)) {
+        logger.debug(
+          `[eliza] Boot-hook contributor ${id} unavailable, skipping`,
+        );
+        continue;
+      }
+      logger.error(
+        `[eliza] Boot-hook contributor ${id} failed: ${formatErrorWithStack(err)}`,
+      );
+      throw err;
+    }
+  }
+}
+
+/**
+ * Run the registry-declared pre-ready boot hooks. Replaces the hard-wired
+ * `@elizaos/plugin-local-inference/runtime` internals that used to be called at
+ * fixed init points in {@link repairRuntimeAfterBoot} (arch-audit #12089 item
+ * 18): the local-inference boot (mobile-gate warning + platform-appropriate
+ * model-handler registration) is now owned by the plugin's `registerLocalInferenceBoot`
+ * hook, declared in its `registry-entry.json` and drained here by data.
+ */
+async function runBootHooks(runtime: AgentRuntime): Promise<void> {
+  await drainBootHookContributors(runtime, getBootHookContributors());
+}
+
 // The most recent runtime handed to the post-ready boot tail. A backgrounded
 // (deferred) tail compares against this so a hot-restart that boots a newer
 // runtime supersedes the old one's still-running tail, preventing route/service
@@ -699,20 +860,21 @@ async function repairRuntimeAfterBoot(
   // Make the app-bundled fused libelizainference (staged into the desktop
   // package) discoverable before any local-inference handler probes
   // `supported()`. No-op in dev / on mobile and when an explicit override is
-  // set. Must run before the ensureLocalInferenceHandler calls below.
+  // set. Must run before the boot hooks (which install the local-inference
+  // handler) below.
   ensureBundledFusedLibDir();
 
-  // Invariant guard: the mobile voice backend selector pins phones to the
-  // Kokoro-exclusive TTS path via `mobile: isMobilePlatform()`, which keys off
-  // ELIZA_PLATFORM. The mobile local-inference gate can fire on the
-  // device-bridge / ELIZA_LOCAL_LLAMA / riscv64 triggers without ELIZA_PLATFORM
-  // being set, leaving `mobile` false in the selector — risking OmniVoice on a
-  // phone. Evaluate both predicates here (outside the mobile branch below) so
-  // the warning is actually reachable on the real mismatch.
-  (await _localInference()).warnIfMobileGateActiveWithoutPlatform({
-    mobilePlatform: isMobilePlatform(),
-    warn: logger.warn,
-  });
+  // Pre-ready boot hooks: registry-declared init steps that must run before the
+  // runtime is marked ready (e.g. installing the local model handler so it's
+  // present for the first turn). This is where plugin-local-inference's boot
+  // now lives — the mobile-voice-invariant warning + the platform-appropriate
+  // model-handler registration are owned by its `registerLocalInferenceBoot`
+  // hook (declared in registry-entry.json), NOT hard-wired here by name
+  // (arch-audit #12089 item 18). The hook owns its platform gating, so it runs
+  // identically on mobile (gated handler-ensure) and desktop (unconditional
+  // handler-ensure), and emits the mobile-gate warning regardless of platform —
+  // matching the previous fixed-point ordering exactly.
+  await runBootHooks(runtime);
 
   // Mobile (Android / iOS) shortcut: the runtime is already serving from
   // PGlite + the AI provider plugin. The remaining boot steps either spawn
@@ -722,17 +884,15 @@ async function repairRuntimeAfterBoot(
   // (registered app route plugins and app runtime hooks). Skipping
   // them here is what the mobile bundle has to do to avoid crashing on first
   // turn — feature parity comes from cloud-side services, not on-device state.
+  // (The local model handler, when a mobile-safe backend is wired, was already
+  // installed by the boot hooks above.)
   if (isMobilePlatform()) {
-    if ((await _localInference()).shouldEnableMobileLocalInference()) {
-      await (await _localInference()).ensureLocalInferenceHandler(runtime);
-    }
     logger.info(
       "[eliza] Mobile platform detected — skipping desktop-only boot helpers",
     );
     return runtime;
   }
 
-  await (await _localInference()).ensureLocalInferenceHandler(runtime);
   const autonomyLoopEnabled = isRuntimeAutonomyEnabled(process.env);
   if (autonomyLoopEnabled) {
     await ensureAutonomyBootstrapContext(runtime);

--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -4129,7 +4129,15 @@
       "dependsOn": [],
       "channels": [],
       "kind": "plugin",
-      "subtype": "ai-provider"
+      "subtype": "ai-provider",
+      "launch": {
+        "type": "server-launch",
+        "capabilities": [],
+        "bootHook": {
+          "specifier": "@elizaos/plugin-local-inference/runtime",
+          "exportName": "registerLocalInferenceBoot"
+        }
+      }
     },
     {
       "id": "local-storage",

--- a/packages/registry/src/first-party/local-inference-boot-hook.test.ts
+++ b/packages/registry/src/first-party/local-inference-boot-hook.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Verifies plugin-local-inference self-declares its PRE-READY boot hook in the
+ * first-party registry, so the app-core host drains it through the generic
+ * boot-hook channel instead of hard-wiring the
+ * `@elizaos/plugin-local-inference/runtime` internals at fixed init points in
+ * `repairRuntimeAfterBoot` (arch-audit #12089 item 18).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearRegistryCacheForTests,
+  getEntryByNpmName,
+  loadRegistry,
+} from "./index";
+import type { PluginEntry } from "./schema";
+
+describe("local-inference boot-hook registry declaration", () => {
+  afterEach(() => {
+    clearRegistryCacheForTests();
+  });
+
+  it("declares registerLocalInferenceBoot as its pre-ready bootHook", () => {
+    const entry = getEntryByNpmName(
+      loadRegistry(),
+      "@elizaos/plugin-local-inference",
+    ) as PluginEntry | undefined;
+
+    expect(entry).toBeDefined();
+    expect(entry?.kind).toBe("plugin");
+    // Self-declared boot hook: the host drains this through the generic
+    // pre-ready boot-hook channel instead of hard-wiring the local-inference
+    // specifier + its internals in `repairRuntimeAfterBoot`.
+    expect(entry?.launch?.bootHook).toEqual({
+      specifier: "@elizaos/plugin-local-inference/runtime",
+      exportName: "registerLocalInferenceBoot",
+    });
+  });
+});

--- a/packages/registry/src/first-party/schema.ts
+++ b/packages/registry/src/first-party/schema.ts
@@ -219,6 +219,20 @@ const appRuntimeHookSchema = z.object({
   exportName: z.string().min(1),
 });
 
+// An app's optional PRE-READY boot hook: a named export
+// `(runtime) => void | Promise<void>` the host invokes once, at a fixed point in
+// `repairRuntimeAfterBoot` BEFORE the runtime is marked ready, to install
+// handlers / warm subsystems that must exist before the first turn (e.g. a local
+// model handler). Parallel to `runtimeHook`, but pre-ready instead of post-ready:
+// the host resolves it by data (naming no plugin) and drains it through the
+// generic boot-hook registry. The hook owns its own applicability gating
+// (platform/config checks) — it is a no-op when it does not apply. `exportName`
+// is required (a hook must name its function).
+const appBootHookSchema = z.object({
+  specifier: packageRoutePluginSpecifierSchema,
+  exportName: z.string().min(1),
+});
+
 export const appLaunchSchema = z.object({
   type: z.enum(["internal-tab", "overlay", "server-launch"]),
   target: z.string().optional(),
@@ -232,6 +246,7 @@ export const appLaunchSchema = z.object({
   curatedSlug: z.string().optional(),
   routePlugin: appRoutePluginSchema.optional(),
   runtimeHook: appRuntimeHookSchema.optional(),
+  bootHook: appBootHookSchema.optional(),
   /**
    * If true, the app declares itself as the default landing tab.
    * Mirrors `package.json#elizaos.app.mainTab`. Consumed by

--- a/plugins/plugin-local-inference/registry-entry.json
+++ b/plugins/plugin-local-inference/registry-entry.json
@@ -133,5 +133,13 @@
 	},
 	"dependsOn": [],
 	"kind": "plugin",
-	"subtype": "ai-provider"
+	"subtype": "ai-provider",
+	"launch": {
+		"type": "server-launch",
+		"capabilities": [],
+		"bootHook": {
+			"specifier": "@elizaos/plugin-local-inference/runtime",
+			"exportName": "registerLocalInferenceBoot"
+		}
+	}
 }

--- a/plugins/plugin-local-inference/src/runtime/boot.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/boot.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for `registerLocalInferenceBoot` — the plugin-owned PRE-READY boot
+ * hook the app-core host drains through the generic boot-hook channel (instead
+ * of hard-wiring these internals at fixed init points, arch-audit #12089 item
+ * 18). Verifies the encapsulated ordering / platform gating that used to live in
+ * `repairRuntimeAfterBoot`:
+ *   - the mobile-voice-invariant warning fires regardless of platform,
+ *   - on mobile the model handler installs ONLY when the mobile gate is on,
+ *   - on desktop the model handler installs unconditionally.
+ */
+import type { AgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock the collaborators so the test exercises boot.ts's control flow only.
+const ensureLocalInferenceHandler = vi.fn(async (_runtime: AgentRuntime) => {});
+const shouldEnableMobileLocalInference = vi.fn(() => false);
+const warnIfMobileGateActiveWithoutPlatform = vi.fn(() => false);
+const isMobilePlatform = vi.fn(() => false);
+
+vi.mock("./ensure-local-inference-handler", () => ({
+	ensureLocalInferenceHandler: (r: AgentRuntime) =>
+		ensureLocalInferenceHandler(r),
+}));
+vi.mock("./mobile-local-inference-gate", () => ({
+	shouldEnableMobileLocalInference: () => shouldEnableMobileLocalInference(),
+	warnIfMobileGateActiveWithoutPlatform: (args: unknown) =>
+		warnIfMobileGateActiveWithoutPlatform(),
+}));
+vi.mock("@elizaos/core", () => ({
+	isMobilePlatform: () => isMobilePlatform(),
+	logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+import { registerLocalInferenceBoot } from "./boot";
+
+function makeFakeRuntime(): AgentRuntime {
+	return {} as AgentRuntime;
+}
+
+describe("registerLocalInferenceBoot", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+		isMobilePlatform.mockReturnValue(false);
+		shouldEnableMobileLocalInference.mockReturnValue(false);
+	});
+
+	it("always emits the mobile-voice-invariant warning (evaluated regardless of platform)", async () => {
+		isMobilePlatform.mockReturnValue(false);
+		await registerLocalInferenceBoot(makeFakeRuntime());
+		expect(warnIfMobileGateActiveWithoutPlatform).toHaveBeenCalledOnce();
+	});
+
+	it("installs the local model handler unconditionally on desktop", async () => {
+		isMobilePlatform.mockReturnValue(false);
+		const runtime = makeFakeRuntime();
+		await registerLocalInferenceBoot(runtime);
+		expect(ensureLocalInferenceHandler).toHaveBeenCalledOnce();
+		expect(ensureLocalInferenceHandler).toHaveBeenCalledWith(runtime);
+		// Desktop path must not consult the mobile gate for the handler decision.
+		expect(shouldEnableMobileLocalInference).not.toHaveBeenCalled();
+	});
+
+	it("installs the handler on mobile ONLY when the mobile gate is on", async () => {
+		isMobilePlatform.mockReturnValue(true);
+		shouldEnableMobileLocalInference.mockReturnValue(true);
+		const runtime = makeFakeRuntime();
+		await registerLocalInferenceBoot(runtime);
+		expect(shouldEnableMobileLocalInference).toHaveBeenCalledOnce();
+		expect(ensureLocalInferenceHandler).toHaveBeenCalledOnce();
+		expect(ensureLocalInferenceHandler).toHaveBeenCalledWith(runtime);
+	});
+
+	it("skips the handler on mobile when the mobile gate is off", async () => {
+		isMobilePlatform.mockReturnValue(true);
+		shouldEnableMobileLocalInference.mockReturnValue(false);
+		await registerLocalInferenceBoot(makeFakeRuntime());
+		expect(shouldEnableMobileLocalInference).toHaveBeenCalledOnce();
+		expect(ensureLocalInferenceHandler).not.toHaveBeenCalled();
+		// The invariant warning still fired even though no handler installed.
+		expect(warnIfMobileGateActiveWithoutPlatform).toHaveBeenCalledOnce();
+	});
+});

--- a/plugins/plugin-local-inference/src/runtime/boot.ts
+++ b/plugins/plugin-local-inference/src/runtime/boot.ts
@@ -1,0 +1,69 @@
+/**
+ * Pre-ready boot entrypoint for plugin-local-inference.
+ *
+ * The app-core host used to hard-wire this plugin's boot internals at fixed
+ * init points in `repairRuntimeAfterBoot` — importing
+ * `@elizaos/plugin-local-inference/runtime` by name and calling
+ * `warnIfMobileGateActiveWithoutPlatform` + `shouldEnableMobileLocalInference` +
+ * `ensureLocalInferenceHandler` inline (arch-audit #12089 item 18). This single
+ * exported hook lets the plugin OWN that boot coupling: it is declared as the
+ * app's `bootHook` in `registry-entry.json`, and the host drains it through the
+ * generic pre-ready boot-hook channel (naming no plugin).
+ *
+ * It encapsulates exactly what the host inlined, in the same order and with the
+ * same platform gating:
+ *   1. Emit the mobile-voice-invariant warning when the mobile local-inference
+ *      gate is active but `ELIZA_PLATFORM` is unset (evaluated regardless of
+ *      platform, as the host did outside the mobile branch).
+ *   2. On a mobile platform, install the local model handler ONLY when the
+ *      mobile local-inference gate says a mobile-safe backend is wired.
+ *   3. On desktop / server, install the local model handler unconditionally
+ *      (`ensureLocalInferenceHandler` self-skips when the runtime mode is cloud
+ *      or no backend is available).
+ *
+ * The host keeps its own `isMobilePlatform()` control flow for the host-only
+ * boot steps it skips on mobile (telegram polling, app-route plugins, etc.);
+ * this hook only owns the local-inference-specific init.
+ */
+import { type AgentRuntime, isMobilePlatform, logger } from "@elizaos/core";
+
+import { ensureLocalInferenceHandler } from "./ensure-local-inference-handler";
+import {
+	shouldEnableMobileLocalInference,
+	warnIfMobileGateActiveWithoutPlatform,
+} from "./mobile-local-inference-gate";
+
+/**
+ * Install the local-inference model handler at the pre-ready boot phase.
+ *
+ * Owns the platform gating the host previously inlined. A no-op when local
+ * inference does not apply on this platform/config (mobile without a wired
+ * mobile-safe backend, or a runtime mode / missing backend that
+ * `ensureLocalInferenceHandler` self-skips). Invoked once via the app-core
+ * boot-hook channel.
+ */
+export async function registerLocalInferenceBoot(
+	runtime: AgentRuntime,
+): Promise<void> {
+	// Mobile-voice-invariant diagnostic: evaluated on every platform (the host
+	// ran it outside the mobile branch) so the mismatch — gate active without
+	// ELIZA_PLATFORM — is actually reachable.
+	warnIfMobileGateActiveWithoutPlatform({
+		mobilePlatform: isMobilePlatform(),
+		warn: logger.warn,
+	});
+
+	if (isMobilePlatform()) {
+		// Mobile bundle wires the local model handler only when a mobile-safe
+		// backend (device-bridge / AOSP FFI / bionic host / riscv64) is enabled;
+		// otherwise the runtime serves from a remote/cloud provider.
+		if (shouldEnableMobileLocalInference()) {
+			await ensureLocalInferenceHandler(runtime);
+		}
+		return;
+	}
+
+	// Desktop / server: ensureLocalInferenceHandler self-skips on a cloud
+	// runtime mode or when no local backend is available.
+	await ensureLocalInferenceHandler(runtime);
+}

--- a/plugins/plugin-local-inference/src/runtime/index.ts
+++ b/plugins/plugin-local-inference/src/runtime/index.ts
@@ -29,6 +29,7 @@ export {
 	selectEmbeddingPresetFromHardware,
 	selectEmbeddingTierFromHardware,
 } from "./embedding-presets.js";
+export { registerLocalInferenceBoot } from "./boot.js";
 export { shouldWarmupLocalEmbeddingModel } from "./embedding-warmup-policy.js";
 export { ensureLocalInferenceHandler } from "./ensure-local-inference-handler.js";
 export {


### PR DESCRIPTION
## What

Arch-audit **#12089 item 18** — "Boot tail hardwires plugin-local-inference internals and a plugin-training import at fixed init points" (`packages/app-core/src/runtime/eliza.ts`).

The **plugin-training** half was already migrated to the generic runtime-hook channel by #12200. This PR completes the item by migrating the **plugin-local-inference** half off its fixed init points onto a generic, registry-driven **pre-ready boot-hook channel**.

### Before
`repairRuntimeAfterBoot` imported `@elizaos/plugin-local-inference/runtime` by name and called its internals inline at fixed points:
- `warnIfMobileGateActiveWithoutPlatform(...)`
- `shouldEnableMobileLocalInference()` → `ensureLocalInferenceHandler(runtime)` (mobile)
- `ensureLocalInferenceHandler(runtime)` (desktop)

### After
- **Generic `bootHook` channel** (mirrors the existing `runtimeHook` channel, but pre-ready): the registry `appLaunchSchema` gains a `bootHook` declaration; the host resolves it **data-driven** from apps *and* plugins (local-inference is a provider plugin) and drains it through `drainBootHookContributors` (graceful optional-skip, fail-loud on real errors) before the runtime is marked ready. **The host names no plugin.**
- **plugin-local-inference owns its boot**: new `registerLocalInferenceBoot(runtime)` encapsulates the mobile-gate warning + platform-appropriate model-handler registration — identical ordering/gating to the old fixed points — declared in its `registry-entry.json` (`launch.bootHook`).
- **Legacy host-owned fallback**: packaged builds can ship without the aggregated `generated.json`, so `loadRegistry()` returns empty. An explicitly-marked `LEGACY_LOCAL_INFERENCE_BOOT_HOOK` fallback keeps local-inference boot installing in that case — preserving the pre-migration guarantee. The registry entry wins when present (deduped by id).

The embedding-warmup subsystem's separate lazy `_localInference()` accessor is intentionally untouched (it is not a fixed-point boot coupling).

## Tests (all green)
- `packages/app-core/.../boot-hook-channel.test.ts` — drain ordering / optional-skip / fail-loud, plus resolver empty-registry fallback + no-duplicate-when-declared (10 tests)
- `packages/app-core/.../boot-hook-decoupling.test.ts` — **grep-guard** proving `repairRuntimeAfterBoot` no longer calls the local-inference boot internals and resolves by data (2 tests)
- `plugins/plugin-local-inference/.../boot.test.ts` — `registerLocalInferenceBoot` warns-always + platform gating (4 tests)
- `packages/registry/.../local-inference-boot-hook.test.ts` — registry `bootHook` declaration present (1 test)
- Existing `repair-boot-phase` + `runtime-hook-channel` + local-inference gate/handler suites unchanged and green.

## Verification
- `packages/registry` tsc clean; `plugins/plugin-local-inference` tsc clean.
- `packages/app-core` tsc adds **zero** new errors vs the pre-existing baseline (verified with the in-tree registry path; the only apparent error in the shared-node_modules worktree setup is a stale sibling-schema resolution artifact, not a code defect).
- `bun run --cwd packages/registry generate:first-party --check` → up to date.
- codex review: **"No discrete, actionable correctness issues were found."**

Touches no forbidden files (vite.config.*, root index.html, client-base.ts, bun.lock, binaries, dist/).

-- [sol-orch]
