### PR TITLE
docs(#12855): add shared component prose headers

### DIFF
--- a/packages/ui/src/components/brand/eliza-mark.tsx
+++ b/packages/ui/src/components/brand/eliza-mark.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the Eliza brand mark as a reusable UI component for shell and
+ * marketing-adjacent surfaces.
+ */
 import type * as React from "react";
 
 /**

--- a/packages/ui/src/components/character/CharacterExperienceView.tsx
+++ b/packages/ui/src/components/character/CharacterExperienceView.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the character experience page for inspecting and editing agent
+ * persona-facing fields.
+ */
 import { useCallback, useMemo, useState } from "react";
 import { client } from "../../api/client";
 import type { ExperienceRecord } from "../../api/client-types";

--- a/packages/ui/src/components/character/CharacterSkillsView.tsx
+++ b/packages/ui/src/components/character/CharacterSkillsView.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the character skills page that lists capability and skill
+ * configuration for an agent profile.
+ */
 import { ViewHeader } from "../shared/ViewHeader";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 import { CharacterLearnedSkillsSection } from "./CharacterLearnedSkillsSection";

--- a/packages/ui/src/components/composites/OwnerBadge.stories.tsx
+++ b/packages/ui/src/components/composites/OwnerBadge.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the OwnerBadge shared UI component across
+ * representative layouts and variants.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { OwnerBadge } from "./OwnerBadge";
 

--- a/packages/ui/src/components/composites/chat/ChatEmptyStateWithRecommendations.stories.tsx
+++ b/packages/ui/src/components/composites/chat/ChatEmptyStateWithRecommendations.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the ChatEmptyStateWithRecommendations chat composite
+ * used by shared conversation and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { FileText, KeyRound } from "lucide-react";
 import { ChatEmptyStateWithRecommendations } from "./ChatEmptyStateWithRecommendations";

--- a/packages/ui/src/components/composites/chat/ChatVoiceStatusBar.stories.tsx
+++ b/packages/ui/src/components/composites/chat/ChatVoiceStatusBar.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the ChatVoiceStatusBar chat composite used by shared
+ * conversation and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ChatVoiceStatusBar } from "./ChatVoiceStatusBar";
 

--- a/packages/ui/src/components/composites/chat/ContinuousChatToggle.stories.tsx
+++ b/packages/ui/src/components/composites/chat/ContinuousChatToggle.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the ContinuousChatToggle chat composite used by shared
+ * conversation and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ContinuousChatToggle } from "./ContinuousChatToggle";
 

--- a/packages/ui/src/components/composites/chat/chat-attachment-strip.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-attachment-strip.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Chat Attachment Strip chat composite used by shared
+ * conversation and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ChatAttachmentStrip } from "./chat-attachment-strip";
 import type { ChatAttachmentItem } from "./chat-types";

--- a/packages/ui/src/components/composites/chat/chat-bubble.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-bubble.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Chat Bubble chat composite used by shared
+ * conversation and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ChatBubble } from "./chat-bubble";
 

--- a/packages/ui/src/components/composites/chat/chat-composer-shell.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer-shell.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Chat Composer Shell chat composite used by shared
+ * conversation and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ChatComposerShell } from "./chat-composer-shell";
 

--- a/packages/ui/src/components/composites/chat/chat-composer.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Chat Composer chat composite used by shared
+ * conversation and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { useRef } from "react";
 import { ChatComposer, type ChatComposerVoiceState } from "./chat-composer";

--- a/packages/ui/src/components/composites/chat/chat-conversation-item.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-conversation-item.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Chat Conversation Item chat composite used by
+ * shared conversation and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ChatConversationItem } from "./chat-conversation-item";
 import type { ChatConversationSummary } from "./chat-types";

--- a/packages/ui/src/components/composites/chat/chat-conversation-rename-dialog.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-conversation-rename-dialog.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Chat Conversation Rename Dialog chat composite used
+ * by shared conversation and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ChatConversationRenameDialog } from "./chat-conversation-rename-dialog";
 

--- a/packages/ui/src/components/composites/chat/chat-empty-state.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-empty-state.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Chat Empty State chat composite used by shared
+ * conversation and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "../../ui/button";
 import { ChatEmptyState } from "./chat-empty-state";

--- a/packages/ui/src/components/composites/chat/chat-message-actions.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Chat Message Actions chat composite used by shared
+ * conversation and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ChatMessageActions } from "./chat-message-actions";
 

--- a/packages/ui/src/components/composites/chat/chat-message.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Chat Message chat composite used by shared
+ * conversation and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ChatMessage } from "./chat-message";
 

--- a/packages/ui/src/components/composites/chat/chat-source.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-source.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Chat Source chat composite used by shared
+ * conversation and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ChatSourceIcon } from "./chat-source";
 

--- a/packages/ui/src/components/composites/chat/chat-thread-layout.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-thread-layout.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Chat Thread Layout chat composite used by shared
+ * conversation and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ChatThreadLayout } from "./chat-thread-layout";
 

--- a/packages/ui/src/components/composites/chat/chat-transcript.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-transcript.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Chat Transcript chat composite used by shared
+ * conversation and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ChatTranscript } from "./chat-transcript";
 import type { ChatMessageData } from "./chat-types";

--- a/packages/ui/src/components/composites/chat/chat-typing-indicator.stories.tsx
+++ b/packages/ui/src/components/composites/chat/chat-typing-indicator.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Chat Typing Indicator chat composite used by shared
+ * conversation and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { TypingIndicator } from "./chat-typing-indicator";
 

--- a/packages/ui/src/components/composites/chat/permission-card.stories.tsx
+++ b/packages/ui/src/components/composites/chat/permission-card.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Permission Card chat composite used by shared
+ * conversation and composer surfaces.
+ */
 import type { PermissionState } from "@elizaos/shared";
 import type { Meta, StoryObj } from "@storybook/react";
 import { PermissionCard } from "./permission-card";

--- a/packages/ui/src/components/composites/code/index.ts
+++ b/packages/ui/src/components/composites/code/index.ts
@@ -1,1 +1,5 @@
+/**
+ * Barrel exports the code-oriented composite panels used by review and tooling
+ * surfaces.
+ */
 export * from "./DiffReviewPanel";

--- a/packages/ui/src/components/composites/form-field/index.ts
+++ b/packages/ui/src/components/composites/form-field/index.ts
@@ -1,1 +1,5 @@
+/**
+ * Barrel exports form-field composites that standardize labels, help text, and
+ * validation layout.
+ */
 export { FormField, type FormFieldProps } from "./form-field";

--- a/packages/ui/src/components/composites/page-panel/page-panel-collapsible-section.stories.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-collapsible-section.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Page Panel Collapsible Section page-panel primitive
+ * used to compose dense dashboard pages.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { PagePanelCollapsibleSection } from "./page-panel-collapsible-section";
 

--- a/packages/ui/src/components/composites/page-panel/page-panel-empty.stories.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-empty.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Page Panel Empty page-panel primitive used to
+ * compose dense dashboard pages.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "../../ui/button";
 import { PageEmptyState } from "./page-panel-empty";

--- a/packages/ui/src/components/composites/page-panel/page-panel-feature-empty.stories.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-feature-empty.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Page Panel Feature Empty page-panel primitive used
+ * to compose dense dashboard pages.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Bell, Inbox, MessageSquare, Sparkles, Zap } from "lucide-react";
 import { PagePanelFeatureEmpty } from "./page-panel-feature-empty";

--- a/packages/ui/src/components/composites/page-panel/page-panel-frame.stories.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-frame.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Page Panel Frame page-panel primitive used to
+ * compose dense dashboard pages.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { PagePanelContentArea, PagePanelFrame } from "./page-panel-frame";
 

--- a/packages/ui/src/components/composites/page-panel/page-panel-header.stories.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-header.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Page Panel Header page-panel primitive used to
+ * compose dense dashboard pages.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "../../ui/button";
 import { MetaPill, PanelHeader } from "./page-panel-header";

--- a/packages/ui/src/components/composites/page-panel/page-panel-loading.stories.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-loading.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Page Panel Loading page-panel primitive used to
+ * compose dense dashboard pages.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { PageLoadingState } from "./page-panel-loading";
 

--- a/packages/ui/src/components/composites/page-panel/page-panel-root.stories.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-root.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Page Panel Root page-panel primitive used to
+ * compose dense dashboard pages.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { PagePanelRoot } from "./page-panel-root";
 

--- a/packages/ui/src/components/composites/page-panel/page-panel-toolbar.stories.tsx
+++ b/packages/ui/src/components/composites/page-panel/page-panel-toolbar.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Page Panel Toolbar page-panel primitive used to
+ * compose dense dashboard pages.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";

--- a/packages/ui/src/components/composites/search/index.ts
+++ b/packages/ui/src/components/composites/search/index.ts
@@ -1,1 +1,5 @@
+/**
+ * Barrel exports the shared search composites used by sidebar and page
+ * filtering surfaces.
+ */
 export * from "./searchbar";

--- a/packages/ui/src/components/composites/search/searchbar.stories.tsx
+++ b/packages/ui/src/components/composites/search/searchbar.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Searchbar search composite used by filterable lists
+ * and sidebars.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { SidebarSearchBar } from "./searchbar";
 

--- a/packages/ui/src/components/composites/sidebar/sidebar-body.stories.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-body.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Sidebar Body sidebar composite across expanded,
+ * collapsed, and shell navigation layouts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { SidebarBody } from "./sidebar-body";
 

--- a/packages/ui/src/components/composites/sidebar/sidebar-collapsed-rail.stories.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-collapsed-rail.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Sidebar Collapsed Rail sidebar composite across
+ * expanded, collapsed, and shell navigation layouts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   SidebarCollapsedActionButton,

--- a/packages/ui/src/components/composites/sidebar/sidebar-content.stories.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-content.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Sidebar Content sidebar composite across expanded,
+ * collapsed, and shell navigation layouts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   SidebarContent,

--- a/packages/ui/src/components/composites/sidebar/sidebar-header-stack.stories.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-header-stack.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Sidebar Header Stack sidebar composite across
+ * expanded, collapsed, and shell navigation layouts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { SidebarHeaderStack } from "./sidebar-header-stack";
 

--- a/packages/ui/src/components/composites/sidebar/sidebar-header.stories.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-header.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Sidebar Header sidebar composite across expanded,
+ * collapsed, and shell navigation layouts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { SidebarHeader } from "./sidebar-header";
 

--- a/packages/ui/src/components/composites/sidebar/sidebar-panel.stories.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-panel.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Sidebar Panel sidebar composite across expanded,
+ * collapsed, and shell navigation layouts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { SidebarPanel } from "./sidebar-panel";
 

--- a/packages/ui/src/components/composites/sidebar/sidebar-root.stories.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-root.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Sidebar Root sidebar composite across expanded,
+ * collapsed, and shell navigation layouts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Sidebar } from "./sidebar-root";
 

--- a/packages/ui/src/components/composites/sidebar/sidebar-scroll-region.stories.tsx
+++ b/packages/ui/src/components/composites/sidebar/sidebar-scroll-region.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Sidebar Scroll Region sidebar composite across
+ * expanded, collapsed, and shell navigation layouts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { SidebarScrollRegion } from "./sidebar-scroll-region";
 

--- a/packages/ui/src/components/composites/skills/skill-sidebar-item.stories.tsx
+++ b/packages/ui/src/components/composites/skills/skill-sidebar-item.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Skill Sidebar Item skill navigation composite used
+ * by skill marketplace sidebars.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { SkillSidebarItem } from "./skill-sidebar-item";
 

--- a/packages/ui/src/components/composites/trajectories/trajectory-cache-stats.stories.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-cache-stats.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Trajectory Cache Stats trajectory visualizer used
+ * by run-detail and evidence surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { TrajectoryCacheStats } from "./trajectory-cache-stats";
 

--- a/packages/ui/src/components/composites/trajectories/trajectory-code-block.stories.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-code-block.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Trajectory Code Block trajectory visualizer used by
+ * run-detail and evidence surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { TrajectoryCodeBlock } from "./trajectory-code-block";
 

--- a/packages/ui/src/components/composites/trajectories/trajectory-context-diff-list.stories.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-context-diff-list.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Trajectory Context Diff List trajectory visualizer
+ * used by run-detail and evidence surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { TrajectoryContextDiffList } from "./trajectory-context-diff-list";
 

--- a/packages/ui/src/components/composites/trajectories/trajectory-event-timeline.stories.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-event-timeline.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Trajectory Event Timeline trajectory visualizer
+ * used by run-detail and evidence surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   TrajectoryEventTimeline,

--- a/packages/ui/src/components/composites/trajectories/trajectory-llm-call-card.stories.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-llm-call-card.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Trajectory Llm Call Card trajectory visualizer used
+ * by run-detail and evidence surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { TrajectoryLlmCallCard } from "./trajectory-llm-call-card";
 

--- a/packages/ui/src/components/composites/trajectories/trajectory-pipeline-graph.stories.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-pipeline-graph.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Trajectory Pipeline Graph trajectory visualizer
+ * used by run-detail and evidence surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   Brain,

--- a/packages/ui/src/components/composites/trajectories/trajectory-sidebar-item.stories.tsx
+++ b/packages/ui/src/components/composites/trajectories/trajectory-sidebar-item.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Trajectory Sidebar Item trajectory visualizer used
+ * by run-detail and evidence surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { TrajectorySidebarItem } from "./trajectory-sidebar-item";
 

--- a/packages/ui/src/components/shared/ViewHeader.tsx
+++ b/packages/ui/src/components/shared/ViewHeader.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the standard view header slots used by dashboard pages, including
+ * mobile sidebar affordances.
+ */
 import { ArrowLeft } from "lucide-react";
 import type { ReactNode } from "react";
 import { useAgentElement } from "../../agent-surface";

--- a/packages/ui/src/components/shared/ViewHeaderSidebarTrigger.tsx
+++ b/packages/ui/src/components/shared/ViewHeaderSidebarTrigger.tsx
@@ -1,3 +1,7 @@
+/**
+ * Bridges view headers to the mobile workspace sidebar trigger supplied by the
+ * surrounding page layout.
+ */
 import { PanelLeftOpen } from "lucide-react";
 import type * as React from "react";
 

--- a/packages/ui/src/components/ui/skeleton-layouts.tsx
+++ b/packages/ui/src/components/ui/skeleton-layouts.tsx
@@ -1,3 +1,7 @@
+/**
+ * Provides reusable skeleton loading layouts for cards, lists, and page
+ * sections in shared UI surfaces.
+ */
 import { cn } from "../../lib/utils";
 import { Skeleton } from "./skeleton";
 

--- a/packages/ui/src/components/ui/skeleton.tsx
+++ b/packages/ui/src/components/ui/skeleton.tsx
@@ -1,3 +1,7 @@
+/**
+ * Exports the base skeleton loading primitive used by shared components and
+ * page-level loading states.
+ */
 import * as React from "react";
 
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/ui/tooltip-extended.tsx
+++ b/packages/ui/src/components/ui/tooltip-extended.tsx
@@ -1,3 +1,7 @@
+/**
+ * Extends the tooltip primitive with richer content and trigger helpers while
+ * preserving the shared tooltip provider contract.
+ */
 import { cn } from "../../lib/utils";
 
 // z-[200] mirrors Z_OVERLAY in ../../lib/floating-layers.ts. Tailwind v4


### PR DESCRIPTION
## Summary
- add top-of-file prose headers across the primitive/shared/composite/brand/character component slice
- cover Storybook state files, barrel exports, primitives, shared headers, brand mark, and character page surfaces
- keep the batch comment-only with no code, string, export, styling, or package metadata changes

Closes #12855.

## Verification
- `git diff --check origin/develop HEAD -- . && git diff --check`
- `bun run check:comment-only`
- focused self-audit: `files=285 missing_headers=0`
- `git diff --stat origin/develop...HEAD`

## Evidence
- Real-LLM trajectories: N/A - comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- Screenshots/video/audio/domain artifacts: N/A - comments-only UI source header cleanup; no rendered behavior changes.
