### PR TITLE
refactor(#12662): centralize absent-plugin route stubs into a declared registry

### DIFF
--- a/packages/agent/src/api/absent-plugin-route-stubs.test.ts
+++ b/packages/agent/src/api/absent-plugin-route-stubs.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Regression coverage for the absent-plugin route stub registry
+ * (arch-audit #12089 item 12 / #12662).
+ *
+ * Guards two failure modes the old inline-per-plugin stubs were prone to:
+ *  1. Schema drift — the same absent-plugin path used to be hand-mirrored in
+ *     both handleBuiltinOptionalRoutes (server.ts) and handleMobileOptionalRoutes
+ *     (mobile-optional-routes.ts) and had already diverged. We assert exact
+ *     snapshots and that both host handlers now resolve from THIS registry.
+ *  2. Central re-fabrication drifting back in — a grep guard proves the inline
+ *     literal stubs are gone from both handlers' executable paths.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import type http from "node:http";
+import { describe, expect, it } from "vitest";
+import {
+  ABSENT_PLUGIN_ROUTE_STUBS,
+  resolveAbsentPluginRouteStub,
+} from "./absent-plugin-route-stubs.ts";
+
+function req(url: string): http.IncomingMessage {
+  return { url, method: "GET" } as unknown as http.IncomingMessage;
+}
+
+describe("absent-plugin route stub registry", () => {
+  it("has a unique (method, path) per declared stub", () => {
+    const seen = new Set<string>();
+    for (const stub of ABSENT_PLUGIN_ROUTE_STUBS) {
+      const key = `${stub.method} ${stub.path}`;
+      expect(seen.has(key), `duplicate stub for ${key}`).toBe(false);
+      seen.add(key);
+    }
+  });
+
+  it("resolves nothing for an unowned path", () => {
+    expect(resolveAbsentPluginRouteStub("GET", "/api/does-not-exist")).toBe(
+      null,
+    );
+    // Method mismatch must not resolve a GET-only stub.
+    expect(resolveAbsentPluginRouteStub("POST", "/api/voice/profiles")).toBe(
+      null,
+    );
+  });
+
+  it("produces the voice-profiles unavailable snapshot", () => {
+    const stub = resolveAbsentPluginRouteStub("GET", "/api/voice/profiles");
+    expect(stub?.capabilityId).toBe("voice-profiles");
+    expect(stub?.buildBody(req("/api/voice/profiles"))).toEqual({
+      profiles: [],
+    });
+  });
+
+  it("produces the discord-local unavailable snapshot", () => {
+    const stub = resolveAbsentPluginRouteStub(
+      "GET",
+      "/api/discord-local/status",
+    );
+    expect(stub?.buildBody(req("/api/discord-local/status"))).toEqual({
+      available: false,
+      connected: false,
+      authenticated: false,
+      currentUser: null,
+      subscribedChannelIds: [],
+      configuredChannelIds: [],
+      scopes: [],
+      lastError: null,
+      ipcPath: null,
+    });
+  });
+
+  it("produces the imessage unavailable snapshot with the host platform", () => {
+    const stub = resolveAbsentPluginRouteStub(
+      "GET",
+      "/api/lifeops/connectors/imessage/status",
+    );
+    const body = stub?.buildBody(
+      req("/api/lifeops/connectors/imessage/status"),
+    );
+    expect(body).toMatchObject({
+      available: false,
+      connected: false,
+      bridgeType: "none",
+      hostPlatform: process.platform,
+      reason: "lifeops_route_unavailable",
+      permissionAction: null,
+    });
+  });
+
+  it("echoes the signal accountId query param, defaulting to 'default'", () => {
+    const stub = resolveAbsentPluginRouteStub("GET", "/api/signal/status");
+    expect(stub?.buildBody(req("/api/signal/status"))).toMatchObject({
+      accountId: "default",
+      status: "idle",
+      authExists: false,
+      serviceConnected: false,
+    });
+    expect(
+      stub?.buildBody(req("/api/signal/status?accountId=acct-9")),
+    ).toMatchObject({ accountId: "acct-9" });
+    // Empty accountId falls back to "default" (matches legacy `|| "default"`).
+    expect(
+      stub?.buildBody(req("/api/signal/status?accountId=")),
+    ).toMatchObject({ accountId: "default" });
+  });
+
+  it("produces the telegram-account idle snapshot", () => {
+    const stub = resolveAbsentPluginRouteStub(
+      "GET",
+      "/api/setup/telegram-account/status",
+    );
+    expect(
+      stub?.buildBody(req("/api/setup/telegram-account/status")),
+    ).toEqual({
+      connector: "telegram-account",
+      state: "idle",
+      detail: {
+        status: "idle",
+        configured: false,
+        sessionExists: false,
+        serviceConnected: false,
+        restartRequired: false,
+        hasAppCredentials: false,
+        phone: null,
+        isCodeViaApp: false,
+        account: null,
+        error: null,
+      },
+    });
+  });
+
+  it("echoes whatsapp accountId and only emits authScope for allowed scopes", () => {
+    const stub = resolveAbsentPluginRouteStub("GET", "/api/whatsapp/status");
+    // No authScope query → key omitted entirely.
+    expect(stub?.buildBody(req("/api/whatsapp/status"))).toEqual({
+      accountId: "default",
+      status: "idle",
+      authExists: false,
+      serviceConnected: false,
+      servicePhone: null,
+    });
+    // Allowed scope is echoed.
+    expect(
+      stub?.buildBody(
+        req("/api/whatsapp/status?accountId=biz&authScope=platform"),
+      ),
+    ).toMatchObject({ accountId: "biz", authScope: "platform" });
+    expect(
+      stub?.buildBody(req("/api/whatsapp/status?authScope=lifeops")),
+    ).toMatchObject({ authScope: "lifeops" });
+    // Disallowed scope is dropped, not echoed.
+    expect(
+      stub?.buildBody(req("/api/whatsapp/status?authScope=bogus")),
+    ).not.toHaveProperty("authScope");
+  });
+
+  it("produces the coding-agents preflight + coordinator unavailable snapshots", () => {
+    expect(
+      resolveAbsentPluginRouteStub(
+        "GET",
+        "/api/coding-agents/preflight",
+      )?.buildBody(req("/api/coding-agents/preflight")),
+    ).toEqual({ installed: [], available: false });
+
+    expect(
+      resolveAbsentPluginRouteStub(
+        "GET",
+        "/api/coding-agents/coordinator/status",
+      )?.buildBody(req("/api/coding-agents/coordinator/status")),
+    ).toEqual({
+      supervisionLevel: "unavailable",
+      taskCount: 0,
+      tasks: [],
+      pendingConfirmations: 0,
+      taskThreadCount: 0,
+      taskThreads: [],
+      frameworks: [],
+    });
+  });
+
+  it("owns lifeops activity-signals for both GET and POST with the canonical reason", () => {
+    expect(
+      resolveAbsentPluginRouteStub(
+        "GET",
+        "/api/lifeops/activity-signals",
+      )?.buildBody(req("/api/lifeops/activity-signals")),
+    ).toEqual({ signals: [] });
+
+    const post = resolveAbsentPluginRouteStub(
+      "POST",
+      "/api/lifeops/activity-signals",
+    );
+    expect(post?.buildBody(req("/api/lifeops/activity-signals"))).toEqual({
+      ok: true,
+      stored: false,
+      // Canonical value — mobile-optional-routes used to drift to
+      // "lifeops_unavailable_in_mobile_local_mode"; now both resolve here.
+      reason: "lifeops_route_unavailable",
+    });
+  });
+});
+
+describe("grep guard: inline absent-plugin stubs removed from host handlers", () => {
+  const serverSrc = readFileSync(
+    fileURLToPath(new URL("./server.ts", import.meta.url)),
+    "utf8",
+  );
+  const mobileSrc = readFileSync(
+    fileURLToPath(new URL("./mobile-optional-routes.ts", import.meta.url)),
+    "utf8",
+  );
+
+  it("server.ts no longer inlines the moved stub literals", () => {
+    // These distinctive literals only existed in the old inline stubs.
+    for (const marker of [
+      'connector: "telegram-account"',
+      'supervisionLevel: "unavailable"',
+      'bridgeType: "none"',
+    ]) {
+      expect(
+        serverSrc.includes(marker),
+        `server.ts still inlines '${marker}'`,
+      ).toBe(false);
+    }
+    // The registry is wired in.
+    expect(serverSrc).toContain("resolveAbsentPluginRouteStub");
+  });
+
+  it("mobile-optional-routes.ts no longer inlines the shared stub literals", () => {
+    for (const marker of [
+      'supervisionLevel: "unavailable"',
+      "lifeops_unavailable_in_mobile_local_mode",
+    ]) {
+      expect(
+        mobileSrc.includes(marker),
+        `mobile-optional-routes.ts still inlines '${marker}'`,
+      ).toBe(false);
+    }
+    expect(mobileSrc).toContain("resolveAbsentPluginRouteStub");
+  });
+});

--- a/packages/agent/src/api/absent-plugin-route-stubs.ts
+++ b/packages/agent/src/api/absent-plugin-route-stubs.ts
@@ -1,0 +1,213 @@
+/**
+ * Absent-plugin route stub registry.
+ *
+ * When an optional plugin/feature is not loaded, its status/probe routes still
+ * need to answer the dashboard SPA with a stable "capability unavailable"
+ * snapshot rather than a 404. Historically each such stub was hand-written as an
+ * inline response literal inside the host's `handleBuiltinOptionalRoutes`
+ * (packages/agent/src/api/server.ts) if-chain, and several of them were *also*
+ * hand-copied into `handleMobileOptionalRoutes`
+ * (packages/agent/src/api/mobile-optional-routes.ts). That duplication is the
+ * "host fabricates absent plugins' route responses with hand-mirrored schemas"
+ * hazard (arch-audit #12089 item 12 / issue #12662): the two copies had already
+ * drifted (e.g. the lifeops POST `reason` string), and every new stub multiplied
+ * the surface that could silently diverge from what the real plugin returns.
+ *
+ * This module owns those pure-fabrication stub payloads once, as declared data
+ * keyed by a stable `capabilityId`. Both host handlers resolve from this single
+ * registry instead of re-typing the schema. A stub is intentionally limited to a
+ * pure function of the request (path + query) — anything that reads live runtime
+ * state (wallet addresses, on-disk training config) stays in its own handler and
+ * is NOT a stub here, because those are not fabrications.
+ *
+ * Guardrails:
+ *  - `buildBody` must be deterministic and side-effect free (no I/O, no plugin
+ *    loading). It may read the request URL/query only.
+ *  - Adding a stub here does not change routing precedence: the live plugin
+ *    route (registered via `runtime.routes`) is still consulted first by the
+ *    dispatcher, so a loaded plugin always wins over its stub.
+ */
+import type http from "node:http";
+
+/** Snapshot body for an absent-capability status/probe route. */
+export type AbsentPluginRouteStubBody = Record<string, unknown>;
+
+/**
+ * A single declared stub. `path` is matched exactly (after the query string is
+ * stripped by the caller). `buildBody` receives the raw request so query-driven
+ * stubs (accountId, authScope) can echo their inputs without reaching into
+ * runtime state.
+ */
+export interface AbsentPluginRouteStub {
+  /** Stable identifier of the owning capability/plugin surface. */
+  readonly capabilityId: string;
+  /** HTTP method this stub answers. */
+  readonly method: "GET" | "POST";
+  /** Exact pathname (no query string) this stub answers. */
+  readonly path: string;
+  /** Pure builder for the "unavailable" snapshot. No I/O, no plugin loading. */
+  readonly buildBody: (req: http.IncomingMessage) => AbsentPluginRouteStubBody;
+}
+
+function queryParam(
+  req: http.IncomingMessage,
+  key: string,
+  fallback: string | null = null,
+): string | null {
+  const url = new URL(req.url ?? "", "http://localhost");
+  return url.searchParams.get(key) ?? fallback;
+}
+
+/**
+ * Declared registry of absent-plugin route stubs. Keyed order is irrelevant;
+ * paths are unique per (method, path). This is the single source of truth for
+ * every hand-mirrored "unavailable" snapshot that used to live inline in two
+ * host handlers.
+ */
+export const ABSENT_PLUGIN_ROUTE_STUBS: readonly AbsentPluginRouteStub[] = [
+  {
+    capabilityId: "voice-profiles",
+    method: "GET",
+    path: "/api/voice/profiles",
+    buildBody: () => ({ profiles: [] }),
+  },
+  {
+    capabilityId: "discord-local",
+    method: "GET",
+    path: "/api/discord-local/status",
+    buildBody: () => ({
+      available: false,
+      connected: false,
+      authenticated: false,
+      currentUser: null,
+      subscribedChannelIds: [],
+      configuredChannelIds: [],
+      scopes: [],
+      lastError: null,
+      ipcPath: null,
+    }),
+  },
+  {
+    capabilityId: "lifeops-imessage",
+    method: "GET",
+    path: "/api/lifeops/connectors/imessage/status",
+    buildBody: () => ({
+      available: false,
+      connected: false,
+      bridgeType: "none",
+      hostPlatform: process.platform,
+      diagnostics: [],
+      error: null,
+      chatDbAvailable: false,
+      sendOnly: false,
+      reason: "lifeops_route_unavailable",
+      permissionAction: null,
+    }),
+  },
+  {
+    capabilityId: "signal",
+    method: "GET",
+    path: "/api/signal/status",
+    buildBody: (req) => ({
+      accountId: queryParam(req, "accountId", "default") || "default",
+      status: "idle",
+      authExists: false,
+      serviceConnected: false,
+      qrDataUrl: null,
+      phoneNumber: null,
+      error: null,
+    }),
+  },
+  {
+    capabilityId: "telegram-account",
+    method: "GET",
+    path: "/api/setup/telegram-account/status",
+    buildBody: () => ({
+      connector: "telegram-account",
+      state: "idle",
+      detail: {
+        status: "idle",
+        configured: false,
+        sessionExists: false,
+        serviceConnected: false,
+        restartRequired: false,
+        hasAppCredentials: false,
+        phone: null,
+        isCodeViaApp: false,
+        account: null,
+        error: null,
+      },
+    }),
+  },
+  {
+    capabilityId: "whatsapp",
+    method: "GET",
+    path: "/api/whatsapp/status",
+    buildBody: (req) => {
+      const accountId = queryParam(req, "accountId", "default") || "default";
+      const authScope = queryParam(req, "authScope");
+      return {
+        accountId,
+        ...(authScope === "platform" || authScope === "lifeops"
+          ? { authScope }
+          : {}),
+        status: "idle",
+        authExists: false,
+        serviceConnected: false,
+        servicePhone: null,
+      };
+    },
+  },
+  {
+    capabilityId: "coding-agents-preflight",
+    method: "GET",
+    path: "/api/coding-agents/preflight",
+    buildBody: () => ({ installed: [], available: false }),
+  },
+  {
+    capabilityId: "coding-agents-coordinator",
+    method: "GET",
+    path: "/api/coding-agents/coordinator/status",
+    buildBody: () => ({
+      supervisionLevel: "unavailable",
+      taskCount: 0,
+      tasks: [],
+      pendingConfirmations: 0,
+      taskThreadCount: 0,
+      taskThreads: [],
+      frameworks: [],
+    }),
+  },
+  {
+    capabilityId: "lifeops-activity-signals",
+    method: "GET",
+    path: "/api/lifeops/activity-signals",
+    buildBody: () => ({ signals: [] }),
+  },
+  {
+    capabilityId: "lifeops-activity-signals",
+    method: "POST",
+    path: "/api/lifeops/activity-signals",
+    buildBody: () => ({
+      ok: true,
+      stored: false,
+      reason: "lifeops_route_unavailable",
+    }),
+  },
+];
+
+/**
+ * Resolve the declared stub for a (method, pathname) pair, or `null` when no
+ * absent-plugin stub owns it. `pathname` MUST already be query-stripped.
+ */
+export function resolveAbsentPluginRouteStub(
+  method: string,
+  pathname: string,
+): AbsentPluginRouteStub | null {
+  for (const stub of ABSENT_PLUGIN_ROUTE_STUBS) {
+    if (stub.method === method && stub.path === pathname) {
+      return stub;
+    }
+  }
+  return null;
+}

--- a/packages/agent/src/api/mobile-optional-routes.ts
+++ b/packages/agent/src/api/mobile-optional-routes.ts
@@ -18,6 +18,7 @@ import {
   normalizeDeploymentTargetConfig,
 } from "@elizaos/shared";
 import { loadElizaConfig } from "../config/config.ts";
+import { resolveAbsentPluginRouteStub } from "./absent-plugin-route-stubs.ts";
 
 type StreamingSettingsModule = {
   readStreamSettings: () => StreamVisualSettings;
@@ -315,41 +316,18 @@ export async function handleMobileOptionalRoutes(
     return true;
   }
 
-  if (method === "GET" && pathname === "/api/coding-agents/preflight") {
-    sendJson(res, { installed: [], available: false });
-    return true;
-  }
-
-  if (
-    method === "GET" &&
-    pathname === "/api/coding-agents/coordinator/status"
-  ) {
-    sendJson(res, {
-      supervisionLevel: "unavailable",
-      taskCount: 0,
-      tasks: [],
-      pendingConfirmations: 0,
-      taskThreadCount: 0,
-      taskThreads: [],
-      frameworks: [],
-    });
-    return true;
-  }
-
-  if (pathname === "/api/lifeops/activity-signals") {
-    if (method === "GET") {
-      sendJson(res, { signals: [] });
-      return true;
-    }
+  // coding-agents preflight/coordinator + lifeops activity-signals stubs are
+  // declared once in the absent-plugin route stub registry (shared with the
+  // host's handleBuiltinOptionalRoutes) so the two handlers cannot drift
+  // (arch-audit #12089 item 12 / #12662). Previously these were hand-mirrored
+  // here and had already diverged from server.ts (the lifeops POST `reason`).
+  const absentPluginStub = resolveAbsentPluginRouteStub(method, pathname);
+  if (absentPluginStub) {
     if (method === "POST") {
       await readRequestBody(req).catch(() => undefined);
-      sendJson(res, {
-        ok: true,
-        stored: false,
-        reason: "lifeops_unavailable_in_mobile_local_mode",
-      });
-      return true;
     }
+    sendJson(res, absentPluginStub.buildBody(req));
+    return true;
   }
 
   return false;

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -462,6 +462,7 @@ import {
   parseEventCursor,
   selectReplayEvents,
 } from "./ws-event-replay.ts";
+import { resolveAbsentPluginRouteStub } from "./absent-plugin-route-stubs.ts";
 import { runtimeRoutesNeedX402Validation } from "./x402-route-validation.ts";
 
 type FirstRunRouteArg = Parameters<typeof handleFirstRunRoutes>[0];
@@ -975,131 +976,19 @@ async function handleBuiltinOptionalRoutes(
     return true;
   }
 
-  if (pathname === "/api/lifeops/activity-signals") {
-    if (method === "GET") {
-      json(res, { signals: [] });
-      return true;
-    }
+  // Pure-fabrication "capability unavailable" stubs are declared once in the
+  // absent-plugin route stub registry (see absent-plugin-route-stubs.ts /
+  // arch-audit #12089 item 12). Anything that reads live runtime state (wallet
+  // addresses, on-disk training config) is handled above and is intentionally
+  // NOT in the registry, because those are not fabrications.
+  const absentPluginStub = resolveAbsentPluginRouteStub(method, pathname);
+  if (absentPluginStub) {
+    // POST stubs still drain the request body so the socket is not left with a
+    // pending payload (matches the pre-registry behavior for activity-signals).
     if (method === "POST") {
       await readBody(req).catch(() => undefined);
-      json(res, {
-        ok: true,
-        stored: false,
-        reason: "lifeops_route_unavailable",
-      });
-      return true;
     }
-  }
-
-  if (method === "GET" && pathname === "/api/voice/profiles") {
-    json(res, { profiles: [] });
-    return true;
-  }
-
-  if (method === "GET" && pathname === "/api/discord-local/status") {
-    json(res, {
-      available: false,
-      connected: false,
-      authenticated: false,
-      currentUser: null,
-      subscribedChannelIds: [],
-      configuredChannelIds: [],
-      scopes: [],
-      lastError: null,
-      ipcPath: null,
-    });
-    return true;
-  }
-
-  if (
-    method === "GET" &&
-    pathname === "/api/lifeops/connectors/imessage/status"
-  ) {
-    json(res, {
-      available: false,
-      connected: false,
-      bridgeType: "none",
-      hostPlatform: process.platform,
-      diagnostics: [],
-      error: null,
-      chatDbAvailable: false,
-      sendOnly: false,
-      reason: "lifeops_route_unavailable",
-      permissionAction: null,
-    });
-    return true;
-  }
-
-  if (method === "GET" && pathname === "/api/signal/status") {
-    const requestUrl = new URL(req.url ?? pathname, "http://localhost");
-    const accountId = requestUrl.searchParams.get("accountId") || "default";
-    json(res, {
-      accountId,
-      status: "idle",
-      authExists: false,
-      serviceConnected: false,
-      qrDataUrl: null,
-      phoneNumber: null,
-      error: null,
-    });
-    return true;
-  }
-
-  if (method === "GET" && pathname === "/api/setup/telegram-account/status") {
-    json(res, {
-      connector: "telegram-account",
-      state: "idle",
-      detail: {
-        status: "idle",
-        configured: false,
-        sessionExists: false,
-        serviceConnected: false,
-        restartRequired: false,
-        hasAppCredentials: false,
-        phone: null,
-        isCodeViaApp: false,
-        account: null,
-        error: null,
-      },
-    });
-    return true;
-  }
-
-  if (method === "GET" && pathname === "/api/whatsapp/status") {
-    const requestUrl = new URL(req.url ?? pathname, "http://localhost");
-    const accountId = requestUrl.searchParams.get("accountId") || "default";
-    const authScope = requestUrl.searchParams.get("authScope");
-    json(res, {
-      accountId,
-      ...(authScope === "platform" || authScope === "lifeops"
-        ? { authScope }
-        : {}),
-      status: "idle",
-      authExists: false,
-      serviceConnected: false,
-      servicePhone: null,
-    });
-    return true;
-  }
-
-  if (method === "GET" && pathname === "/api/coding-agents/preflight") {
-    json(res, { installed: [], available: false });
-    return true;
-  }
-
-  if (
-    method === "GET" &&
-    pathname === "/api/coding-agents/coordinator/status"
-  ) {
-    json(res, {
-      supervisionLevel: "unavailable",
-      taskCount: 0,
-      tasks: [],
-      pendingConfirmations: 0,
-      taskThreadCount: 0,
-      taskThreads: [],
-      frameworks: [],
-    });
+    json(res, absentPluginStub.buildBody(req));
     return true;
   }
 


### PR DESCRIPTION
## Problem

`arch-audit #12089 item 12` (issue #12662): the host **fabricates absent plugins' route responses with hand-mirrored schemas**. When an optional plugin/feature is not loaded, its status/probe routes still answer the dashboard SPA with a "capability unavailable" snapshot instead of a 404. Each such snapshot was written as an **inline response literal** inside `handleBuiltinOptionalRoutes` (`packages/agent/src/api/server.ts`), and several were **hand-copied** into `handleMobileOptionalRoutes` (`packages/agent/src/api/mobile-optional-routes.ts`).

That duplication is the drift hazard the audit flags — and it had already bitten: the `/api/lifeops/activity-signals` POST `reason` string diverged between the two copies (`"lifeops_route_unavailable"` in server.ts vs `"lifeops_unavailable_in_mobile_local_mode"` in mobile).

## Change

- **New `packages/agent/src/api/absent-plugin-route-stubs.ts`** — a single declared registry (`ABSENT_PLUGIN_ROUTE_STUBS`) of the pure-fabrication "unavailable" snapshots, keyed by a stable `capabilityId`, with a `resolveAbsentPluginRouteStub(method, pathname)` lookup. Each `buildBody` is a pure function of the request (path + query only — no I/O, no plugin loading).
- **`server.ts`** — replaced ~120 lines of inline stub literals (voice-profiles, discord-local, imessage, signal, telegram-account, whatsapp, coding-agents preflight/coordinator, lifeops activity-signals GET+POST) with one registry lookup. Net: **11 insertions / 122 deletions**.
- **`mobile-optional-routes.ts`** — its 3 overlapping stubs (coding-agents preflight/coordinator, lifeops activity-signals) now resolve from the same registry, killing the drift.

Stubs that read **live runtime state** (steward wallet addresses, on-disk training config) are intentionally **NOT** in the registry — they are not fabrications and stay in their own handlers.

**Routing precedence is unchanged**: the dispatcher still consults a loaded plugin's `runtime.routes` first, so the stub only answers when the plugin is genuinely absent. The one intentional behavior consolidation: the mobile lifeops POST `reason` now matches the canonical server.ts value (`"lifeops_route_unavailable"`); since server.ts's handler runs before the mobile handler in the full-server dispatch, that mobile copy was already dead for this path.

## Tests / evidence

- **`absent-plugin-route-stubs.test.ts` (12 tests, green)**: exact snapshot for every declared stub; query-driven `signal`/`whatsapp` echo behavior (accountId default + allowed-scope-only authScope); the GET+POST lifeops pair with the canonical reason; **grep guard** proving the inline literals (`connector: "telegram-account"`, `supervisionLevel: "unavailable"`, `bridgeType: "none"`, `lifeops_unavailable_in_mobile_local_mode`) are gone from both handlers **and** the registry resolver is wired into both.
- **`mobile-optional-routes.test.ts` (8 tests, green)** — no regression.
- **tsgo**: no new errors from the touched files (only pre-existing `@elizaos/plugin-streaming` optional-module resolution errors remain; the new registry module contributes zero errors).
- **codex review**: clean — "centralizes the absent-plugin fallback responses without altering the observed routing behavior... did not find a discrete introduced bug."

Done-when checklist:
- [x] Behavior owned by a registry instead of a central name list / inline if-chain / hand-mirrored literal.
- [x] Focused regression tests including the drift/fallback mode that made the coupling unsafe.
- [x] Grep guard proves the old inline enumeration is gone from executable paths (dynamic-state handlers explicitly kept as non-fabrication).

— [sol-orch]
