### PR TITLE
docs(#12853): add chat shell prose headers

### DIFF
--- a/packages/ui/src/components/chat/AccountRequiredCard.stories.tsx
+++ b/packages/ui/src/components/chat/AccountRequiredCard.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the AccountRequiredCard chat component used by message
+ * rendering, attachments, and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ConnectorAccountRecord } from "../../api/client-agent";
 import { AccountRequiredCard } from "./AccountRequiredCard";

--- a/packages/ui/src/components/chat/AgentActivityBox.stories.tsx
+++ b/packages/ui/src/components/chat/AgentActivityBox.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the AgentActivityBox chat component used by message
+ * rendering, attachments, and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { CodingAgentSession } from "../../api/client-types-cloud";
 import { mockApp } from "../../storybook/mock-providers.helpers";

--- a/packages/ui/src/components/chat/MessageAttachments.stories.tsx
+++ b/packages/ui/src/components/chat/MessageAttachments.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the MessageAttachments chat component used by message
+ * rendering, attachments, and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { MessageAttachment } from "../../api/client-types-chat";
 import { MessageAttachments } from "./MessageAttachments";

--- a/packages/ui/src/components/chat/MessageContent.stories.tsx
+++ b/packages/ui/src/components/chat/MessageContent.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the MessageContent chat component used by message
+ * rendering, attachments, and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ConversationMessage } from "../../api/client-types-chat";
 import { mockApp } from "../../storybook/mock-providers.helpers";

--- a/packages/ui/src/components/chat/ThinkingBlock.tsx
+++ b/packages/ui/src/components/chat/ThinkingBlock.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders assistant thinking and trace blocks inside chat messages without
+ * changing the message parser contract.
+ */
 import { type ReactElement, useState } from "react";
 import { Button } from "../ui/button";
 

--- a/packages/ui/src/components/chat/WidgetVisibilityPanel.stories.tsx
+++ b/packages/ui/src/components/chat/WidgetVisibilityPanel.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the WidgetVisibilityPanel chat component used by
+ * message rendering, attachments, and composer surfaces.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import type { WidgetVisibilityHook } from "../../widgets/useChatSidebarVisibility";

--- a/packages/ui/src/components/chat/chat-source-registration.tsx
+++ b/packages/ui/src/components/chat/chat-source-registration.tsx
@@ -1,0 +1,4 @@
+/**
+ * Registers chat source renderers so message metadata can attach stable, typed
+ * source rows to chat transcripts.
+ */

--- a/packages/ui/src/components/chat/widgets/ChoiceWidget.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/ChoiceWidget.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the ChoiceWidget chat widget across populated, empty,
+ * and interaction-focused render states.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ChoiceWidget } from "./ChoiceWidget";
 

--- a/packages/ui/src/components/chat/widgets/agent-orchestrator-room-view.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator-room-view.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Agent Orchestrator Room View chat widget across
+ * populated, empty, and interaction-focused render states.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ReactNode } from "react";
 import type { OrchestratorRoomRosterOverview } from "../../../api/client-types-cloud";

--- a/packages/ui/src/components/chat/widgets/agent-provisioning.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-provisioning.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Agent Provisioning chat widget across populated,
+ * empty, and interaction-focused render states.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { useEffect, useState } from "react";
 import {

--- a/packages/ui/src/components/chat/widgets/browser-status.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/browser-status.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Browser Status chat widget across populated, empty,
+ * and interaction-focused render states.
+ */
 import type { Decorator, Meta, StoryObj } from "@storybook/react";
 import { client } from "../../../api";
 import type {

--- a/packages/ui/src/components/chat/widgets/calendar-upcoming.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-upcoming.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Calendar Upcoming chat widget across populated,
+ * empty, and interaction-focused render states.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   assert,

--- a/packages/ui/src/components/chat/widgets/finances-alerts.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/finances-alerts.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Finances Alerts chat widget across populated,
+ * empty, and interaction-focused render states.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   assert,

--- a/packages/ui/src/components/chat/widgets/goals-attention.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/goals-attention.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Goals Attention chat widget across populated,
+ * empty, and interaction-focused render states.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   assert,

--- a/packages/ui/src/components/chat/widgets/health-sleep.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/health-sleep.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Health Sleep chat widget across populated, empty,
+ * and interaction-focused render states.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   assert,

--- a/packages/ui/src/components/chat/widgets/inbox-unread.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/inbox-unread.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Inbox Unread chat widget across populated, empty,
+ * and interaction-focused render states.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   assert,

--- a/packages/ui/src/components/chat/widgets/music-player.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/music-player.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Music Player chat widget across populated, empty,
+ * and interaction-focused render states.
+ */
 import type { Decorator, Meta, StoryObj } from "@storybook/react";
 import { MusicPlayerSidebarWidget } from "./music-player";
 

--- a/packages/ui/src/components/chat/widgets/needs-attention.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/needs-attention.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Needs Attention chat widget across populated,
+ * empty, and interaction-focused render states.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { CHAT_PREFILL_EVENT } from "../../../events";
 import {

--- a/packages/ui/src/components/chat/widgets/notifications.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/notifications.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Notifications chat widget across populated, empty,
+ * and interaction-focused render states.
+ */
 import type { AgentNotification } from "@elizaos/core";
 import type { Decorator, Meta, StoryObj } from "@storybook/react";
 import {

--- a/packages/ui/src/components/chat/widgets/orchestrator-grilling-card.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/orchestrator-grilling-card.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Orchestrator Grilling Card chat widget across
+ * populated, empty, and interaction-focused render states.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ReactNode } from "react";
 import type { GrillingCriterion } from "./orchestrator-grilling-card";

--- a/packages/ui/src/components/chat/widgets/relationships-attention.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/relationships-attention.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Relationships Attention chat widget across
+ * populated, empty, and interaction-focused render states.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   assert,

--- a/packages/ui/src/components/chat/widgets/shared.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/shared.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Shared chat widget across populated, empty, and
+ * interaction-focused render states.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { EmptyWidgetState, WidgetSection } from "./shared";
 

--- a/packages/ui/src/components/chat/widgets/task-widget.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/task-widget.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Task Widget chat widget across populated, empty,
+ * and interaction-focused render states.
+ */
 import type { Decorator, Meta, StoryObj } from "@storybook/react";
 import { client } from "../../../api/client";
 import type {

--- a/packages/ui/src/components/chat/widgets/todo.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Todo chat widget across populated, empty, and
+ * interaction-focused render states.
+ */
 import type { Decorator, Meta, StoryObj } from "@storybook/react";
 import { client } from "../../../api";
 import type {

--- a/packages/ui/src/components/chat/widgets/topic-chips-bar.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/topic-chips-bar.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Topic Chips Bar chat widget across populated,
+ * empty, and interaction-focused render states.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { TopicChip } from "./topic-chips-bar";
 import { TopicChipsBar } from "./topic-chips-bar";

--- a/packages/ui/src/components/chat/widgets/wallet-price-holdings.ts
+++ b/packages/ui/src/components/chat/widgets/wallet-price-holdings.ts
@@ -1,3 +1,7 @@
+/**
+ * Normalizes wallet price and holding data for finance chat widgets before
+ * they render portfolio rows.
+ */
 import type {
   WalletBalancesResponse,
   WalletMarketPriceSnapshot,

--- a/packages/ui/src/components/shell/ActionBanner.tsx
+++ b/packages/ui/src/components/shell/ActionBanner.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders shell action banners for transient commands, recovery prompts, and
+ * dismissible notices.
+ */
 import { useAppSelector } from "../../state";
 import { Button } from "../ui/button";
 

--- a/packages/ui/src/components/shell/AssistantOverlay.tsx
+++ b/packages/ui/src/components/shell/AssistantOverlay.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the assistant overlay layer that hosts chat, notifications, and
+ * launcher-adjacent surfaces.
+ */
 import { X } from "lucide-react";
 import * as React from "react";
 

--- a/packages/ui/src/components/shell/ChatSurface.stories.tsx
+++ b/packages/ui/src/components/shell/ChatSurface.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the ChatSurface shell surface across startup, launcher,
+ * banner, and overlay contexts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { ChatSurface } from "./ChatSurface";
 import type { ShellMessage } from "./shell-state";

--- a/packages/ui/src/components/shell/CloudHandoffBanner.tsx
+++ b/packages/ui/src/components/shell/CloudHandoffBanner.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the shell banner that guides users from local startup into the Cloud
+ * handoff flow.
+ */
 import { Check } from "lucide-react";
 import {
   type CloudHandoffPhase,

--- a/packages/ui/src/components/shell/CommandPalette.stories.tsx
+++ b/packages/ui/src/components/shell/CommandPalette.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the CommandPalette shell surface across startup,
+ * launcher, banner, and overlay contexts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import type * as React from "react";
 import { BugReportProvider } from "../../hooks/BugReportProvider";

--- a/packages/ui/src/components/shell/ConnectionFailedBanner.stories.tsx
+++ b/packages/ui/src/components/shell/ConnectionFailedBanner.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the ConnectionFailedBanner shell surface across
+ * startup, launcher, banner, and overlay contexts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { mockApp } from "../../storybook/mock-providers.helpers";
 import { ConnectionFailedBanner } from "./ConnectionFailedBanner";

--- a/packages/ui/src/components/shell/ConnectionFailedBanner.tsx
+++ b/packages/ui/src/components/shell/ConnectionFailedBanner.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the shell connection failure banner with retry and recovery
+ * affordances.
+ */
 import { useAppSelectorShallow } from "../../state";
 import { Button } from "../ui/button";
 import { Spinner } from "../ui/spinner";

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.stories.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the ContinuousChatOverlay shell surface across startup,
+ * launcher, banner, and overlay contexts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import type * as React from "react";
 import type { SlashCommandCatalogItem } from "../../chat/slash-menu";

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the continuous chat overlay that keeps the composer and transcript
+ * available across views.
+ */
 import { transcriptPlainText } from "@elizaos/shared/transcripts";
 import {
   Check,

--- a/packages/ui/src/components/shell/DefaultHomeWidgets.tsx
+++ b/packages/ui/src/components/shell/DefaultHomeWidgets.tsx
@@ -1,3 +1,6 @@
+/**
+ * Declares the default home widgets shown by the launcher dashboard.
+ */
 import {
   Cloud,
   CloudFog,

--- a/packages/ui/src/components/shell/HomeDashboard.stories.tsx
+++ b/packages/ui/src/components/shell/HomeDashboard.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the HomeDashboard shell surface across startup,
+ * launcher, banner, and overlay contexts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { useEffect, useRef, useState } from "react";
 import { ShaderBackground } from "../../backgrounds/ShaderBackground";

--- a/packages/ui/src/components/shell/HomeLauncherSurface.tsx
+++ b/packages/ui/src/components/shell/HomeLauncherSurface.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the home launcher surface that combines app tiles, widgets, and
+ * shell navigation.
+ */
 import * as React from "react";
 import { useHorizontalPager } from "../../hooks/useHorizontalPager";
 import {

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the compact home pill that anchors launcher access and current shell
+ * status.
+ */
 import * as React from "react";
 
 import { useBranding } from "../../config/branding";

--- a/packages/ui/src/components/shell/HomeScreen.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.tsx
@@ -1,3 +1,7 @@
+/**
+ * Composes the shell home screen from launcher tiles, widgets, topics, and
+ * dashboard affordances.
+ */
 import {
   Camera,
   Contact,

--- a/packages/ui/src/components/shell/KioskViewCanvas.tsx
+++ b/packages/ui/src/components/shell/KioskViewCanvas.tsx
@@ -1,3 +1,7 @@
+/**
+ * Hosts kiosk view content inside the shell canvas with the framing needed for
+ * dedicated display mode.
+ */
 import * as React from "react";
 
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/shell/LoadingScreen.stories.tsx
+++ b/packages/ui/src/components/shell/LoadingScreen.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the LoadingScreen shell surface across startup,
+ * launcher, banner, and overlay contexts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { LoadingScreen } from "./LoadingScreen";

--- a/packages/ui/src/components/shell/NotificationCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationCenter.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the shell notification drawer and action rows backed by the
+ * notification store.
+ */
 import type { AgentNotification, NotificationCategory } from "@elizaos/core";
 import { Bell, BellRing, CheckCheck, Inbox, Trash2, X } from "lucide-react";
 import {

--- a/packages/ui/src/components/shell/PagerEdgeButtons.tsx
+++ b/packages/ui/src/components/shell/PagerEdgeButtons.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders edge paging controls for launcher and carousel surfaces without
+ * owning their page state.
+ */
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type * as React from "react";
 import { useMediaQuery } from "../../hooks/useMediaQuery";

--- a/packages/ui/src/components/shell/PairingCommandHint.stories.tsx
+++ b/packages/ui/src/components/shell/PairingCommandHint.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the PairingCommandHint shell surface across startup,
+ * launcher, banner, and overlay contexts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { PairingCommandHint } from "./PairingCommandHint";

--- a/packages/ui/src/components/shell/RestartBanner.stories.tsx
+++ b/packages/ui/src/components/shell/RestartBanner.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the RestartBanner shell surface across startup,
+ * launcher, banner, and overlay contexts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { mockApp } from "../../storybook/mock-providers.helpers";
 import { RestartBanner } from "./RestartBanner";

--- a/packages/ui/src/components/shell/ShellControllerContext.tsx
+++ b/packages/ui/src/components/shell/ShellControllerContext.tsx
@@ -1,3 +1,7 @@
+/**
+ * Provides shell controller state for overlays, launcher surfaces, and
+ * conversation navigation.
+ */
 import type * as React from "react";
 
 import { ShellControllerContext } from "./ShellControllerContext.hooks";

--- a/packages/ui/src/components/shell/ShortcutsOverlay.stories.tsx
+++ b/packages/ui/src/components/shell/ShortcutsOverlay.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the ShortcutsOverlay shell surface across startup,
+ * launcher, banner, and overlay contexts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { mockApp } from "../../storybook/mock-providers.helpers";
 import { ShortcutsOverlay } from "./ShortcutsOverlay";

--- a/packages/ui/src/components/shell/SlashCommandMenu.tsx
+++ b/packages/ui/src/components/shell/SlashCommandMenu.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders slash-command suggestions and command picking for the shell
+ * composer.
+ */
 import * as React from "react";
 
 import {

--- a/packages/ui/src/components/shell/StartupScreen.stories.tsx
+++ b/packages/ui/src/components/shell/StartupScreen.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the StartupScreen shell surface across startup,
+ * launcher, banner, and overlay contexts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { mockApp, withMockApp } from "../../storybook/mock-providers.helpers";
 import { StartupScreen } from "./StartupScreen";

--- a/packages/ui/src/components/shell/StartupShell.tsx
+++ b/packages/ui/src/components/shell/StartupShell.tsx
@@ -1,3 +1,7 @@
+/**
+ * Composes the startup shell around boot, retry, pairing, and handoff states
+ * before the app is ready.
+ */
 import { type ReactNode, useEffect, useState } from "react";
 import { getBootConfig } from "../../config/boot-config-store";
 import { markStartup } from "../../state/startup-telemetry";

--- a/packages/ui/src/components/shell/SystemWarningBanner.stories.tsx
+++ b/packages/ui/src/components/shell/SystemWarningBanner.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the SystemWarningBanner shell surface across startup,
+ * launcher, banner, and overlay contexts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { mockApp } from "../../storybook/mock-providers.helpers";
 import { SystemWarningBanner } from "./SystemWarningBanner";

--- a/packages/ui/src/components/shell/SystemWarningBanner.tsx
+++ b/packages/ui/src/components/shell/SystemWarningBanner.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders system warning banners for shell-level degraded states and recovery
+ * affordances.
+ */
 import { useEffect, useRef } from "react";
 import { useAppSelector } from "../../state";
 import { TOAST_TTL_MS } from "../../state/action-notice";

--- a/packages/ui/src/components/shell/TopicChipsBar.stories.tsx
+++ b/packages/ui/src/components/shell/TopicChipsBar.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the TopicChipsBar shell surface across startup,
+ * launcher, banner, and overlay contexts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { TopicChipsBar } from "./TopicChipsBar";
 

--- a/packages/ui/src/components/shell/TopicChipsBar.tsx
+++ b/packages/ui/src/components/shell/TopicChipsBar.tsx
@@ -1,3 +1,6 @@
+/**
+ * Renders topic chips that let the shell switch or seed conversation context.
+ */
 import type * as React from "react";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";

--- a/packages/ui/src/components/shell/TopicGroup.stories.tsx
+++ b/packages/ui/src/components/shell/TopicGroup.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the TopicGroup shell surface across startup, launcher,
+ * banner, and overlay contexts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import * as React from "react";
 import { TopicGroup } from "./TopicGroup";

--- a/packages/ui/src/components/shell/TopicGroup.tsx
+++ b/packages/ui/src/components/shell/TopicGroup.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders grouped topic rows in the shell conversation list and launcher
+ * surfaces.
+ */
 import type * as React from "react";
 import { useClickSuppression } from "../../gestures";
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/shell/TrayLauncher.stories.tsx
+++ b/packages/ui/src/components/shell/TrayLauncher.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the TrayLauncher shell surface across startup,
+ * launcher, banner, and overlay contexts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { DesktopLauncherEntry } from "../../state/desktop-tray-launcher";
 import { TrayLauncher } from "./TrayLauncher";

--- a/packages/ui/src/components/shell/TrayLauncher.tsx
+++ b/packages/ui/src/components/shell/TrayLauncher.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the tray launcher surface that exposes navigation, notifications,
+ * and quick app actions.
+ */
 import {
   BookOpen,
   Bot,

--- a/packages/ui/src/components/shell/chat-panel-layout.test.ts
+++ b/packages/ui/src/components/shell/chat-panel-layout.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Covers chat panel layout decisions for responsive shell placement and
+ * transcript sizing.
+ */
 import { describe, expect, it } from "vitest";
 import {
   type ChatPanelLayoutInput,

--- a/packages/ui/src/components/shell/conversation-nav.test.ts
+++ b/packages/ui/src/components/shell/conversation-nav.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Covers shell conversation navigation helpers that choose active chat threads
+ * and fallback destinations.
+ */
 import fc from "fast-check";
 import { describe, expect, it, vi } from "vitest";
 import type { Conversation } from "../../api/client-types-chat";

--- a/packages/ui/src/components/shell/glass-composer.stories.tsx
+++ b/packages/ui/src/components/shell/glass-composer.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook states for the Glass Composer shell surface across startup,
+ * launcher, banner, and overlay contexts.
+ */
 import type { Meta, StoryObj } from "@storybook/react";
 import { GlassIconButton } from "./glass-composer";
 import { GLASS_COMPOSER_CLASS } from "./glass-composer.helpers";

--- a/packages/ui/src/components/shell/glass-composer.tsx
+++ b/packages/ui/src/components/shell/glass-composer.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the glass composer input used by the floating chat and launcher
+ * shell surfaces.
+ */
 import * as React from "react";
 
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/shell/shell-state.ts
+++ b/packages/ui/src/components/shell/shell-state.ts
@@ -1,3 +1,7 @@
+/**
+ * Defines shell reducer state for overlays, launcher mode, notifications, and
+ * surface coordination.
+ */
 import type {
   ChatFailureKind,
   ConversationSecretRequest,

--- a/packages/ui/src/components/shell/use-conversation-reset.ts
+++ b/packages/ui/src/components/shell/use-conversation-reset.ts
@@ -1,3 +1,7 @@
+/**
+ * Coordinates conversation reset side effects so shell state and chat state
+ * clear together.
+ */
 import * as React from "react";
 import { useAppSelectorShallow } from "../../state";
 

--- a/packages/ui/src/components/shell/use-notification-pull.ts
+++ b/packages/ui/src/components/shell/use-notification-pull.ts
@@ -1,3 +1,7 @@
+/**
+ * Implements the pull gesture controller that opens and settles the
+ * notification surface.
+ */
 import * as React from "react";
 import {
   DEFAULT_PULL_VELOCITY as DEFAULT_VELOCITY_THRESHOLD,

--- a/packages/ui/src/components/shell/use-pull-gesture.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.ts
@@ -1,3 +1,7 @@
+/**
+ * Implements the shared pull gesture state machine used by shell drawers and
+ * notification surfaces.
+ */
 import * as React from "react";
 import {
   AXIS_COMMIT_SLOP,

--- a/packages/ui/src/components/shell/useBarSurfaceWindows.ts
+++ b/packages/ui/src/components/shell/useBarSurfaceWindows.ts
@@ -1,3 +1,7 @@
+/**
+ * Tracks bar-surface window placement so launcher and overlay panes stay
+ * within viewport constraints.
+ */
 import * as React from "react";
 
 import {

--- a/packages/ui/src/components/shell/useKioskViewSurfaces.ts
+++ b/packages/ui/src/components/shell/useKioskViewSurfaces.ts
@@ -1,3 +1,6 @@
+/**
+ * Selects kiosk-capable view surfaces for the dedicated display canvas.
+ */
 import { useEffect, useState } from "react";
 import { subscribeDesktopBridgeEvent } from "../../bridge/electrobun-rpc";
 

--- a/packages/ui/src/components/shell/usePromptSuggestions.ts
+++ b/packages/ui/src/components/shell/usePromptSuggestions.ts
@@ -1,3 +1,7 @@
+/**
+ * Builds context-aware prompt suggestions for the home and chat shell
+ * surfaces.
+ */
 import * as React from "react";
 
 import { client } from "../../api/client";

--- a/packages/ui/src/components/shell/useShellVoiceOutput.ts
+++ b/packages/ui/src/components/shell/useShellVoiceOutput.ts
@@ -1,3 +1,7 @@
+/**
+ * Coordinates shell-level voice output state so chat, overlays, and voice
+ * controls share one playback signal.
+ */
 import * as React from "react";
 
 import type { ConversationMessage } from "../../api/client-types-chat";


### PR DESCRIPTION
## Summary
- add top-of-file prose headers across the chat, widget, shell, conversation, transcript, stream, and tool-event component slice
- cover Storybook fixtures plus shell hooks, reducers, overlay surfaces, banners, and chat widget helpers
- keep the batch comment-only with no code, string, export, styling, or package metadata changes

Closes #12853.

## Verification
- `git diff --check origin/develop HEAD -- . && git diff --check`
- `bun run check:comment-only`
- focused self-audit: `files=325 missing_headers=0`
- `git diff --stat origin/develop...HEAD`

## Evidence
- Real-LLM trajectories: N/A - comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- Screenshots/video/audio/domain artifacts: N/A - comments-only UI source header cleanup; no rendered behavior changes.
