### PR TITLE
docs(#12242): B12 headers — LifeOps send/approval, privacy, registries, domains + website-blocker (comment-only)

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/channels/registry.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/channels/registry.ts
@@ -1,4 +1,11 @@
-// Registers LifeOps delivery channels and channel priority posture.
+/**
+ * In-memory {@link ChannelRegistry} backing the LifeOps channel contract. A
+ * channel is a delivery surface keyed by `kind` (`in_app`, `push`, `imessage`,
+ * `telegram`, `sms`, …) with capability flags; connector plugins register
+ * contributions here and the scheduled-task runner's escalation/dispatch stage
+ * queries it — by `kind` or by required capabilities — to pick a channel.
+ * Registration is exclusive: a duplicate `kind` throws rather than overwriting.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import type {
   ChannelCapabilities,

--- a/plugins/plugin-personal-assistant/src/lifeops/checkin/schedule-resolver.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/checkin/schedule-resolver.ts
@@ -1,18 +1,16 @@
-// Resolves LifeOps check-in schedules into runner-ready timing windows.
-import type { IAgentRuntime } from "@elizaos/core";
-import type { LifeOpsOwnerProfile } from "../owner-profile.js";
-import { readLifeOpsOwnerProfile } from "../owner-profile.js";
-
 /**
- * Reads the owner's configured morning/night check-in times from the existing
- * owner-profile row. Returns null for a slot if the owner hasn't configured it.
+ * Reads the owner's configured morning/night check-in times from the
+ * owner-profile row. Returns null for a slot the owner has not configured.
  *
  * `nightCheckinTime` is consumed by `shouldRunNightCheckinFromSleepCycle` as a
  * fallback bedtime anchor for irregular owners. `morningCheckinTime` is read
- * here for parity but the morning dispatcher currently relies exclusively on
- * the inferred `circadianState === "awake"` transition; an explicit timer
- * fallback is intentionally not wired.
+ * here for parity, but the morning dispatcher relies exclusively on the inferred
+ * `circadianState === "awake"` transition; an explicit timer fallback is
+ * intentionally not wired.
  */
+import type { IAgentRuntime } from "@elizaos/core";
+import type { LifeOpsOwnerProfile } from "../owner-profile.js";
+import { readLifeOpsOwnerProfile } from "../owner-profile.js";
 
 export interface CheckinSchedule {
   readonly morningCheckinTime: string | null;

--- a/plugins/plugin-personal-assistant/src/lifeops/connectors/registry.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/connectors/registry.ts
@@ -1,4 +1,11 @@
-// Registers LifeOps connector projections without owning connector transports.
+/**
+ * In-memory {@link ConnectorRegistry} backing the LifeOps connector contract.
+ * Connectors are capability- and mode-tagged owner integrations, populated by
+ * `plugin-health` and the connector default pack; the messaging and send-policy
+ * layers look them up by `kind` or `capability` to route and gate owner-facing
+ * dispatch (a connector's `requiresApproval` flag drives the owner-send policy).
+ * Registration is exclusive: a duplicate `kind` throws.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import type {
   ConnectorContribution,

--- a/plugins/plugin-personal-assistant/src/lifeops/device-bus-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/device-bus-service.ts
@@ -1,4 +1,8 @@
-// Supports the LifeOps scheduled-task spine, owner facts, and assistant context.
+/**
+ * Service-layer wrappers around the local intent store (`intent-sync.ts`):
+ * acknowledge, prune-expired, and list-pending helpers that callers invoke
+ * directly rather than reaching into the store's raw SQL surface.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import {
   acknowledgeIntent,
@@ -7,11 +11,6 @@ import {
   pruneExpiredIntents,
   receivePendingIntents,
 } from "./intent-sync.js";
-
-/**
- * Service-layer wrappers around the local intent store. These helpers
- * cover the management operations invoked directly by callers.
- */
 
 export async function acknowledgeDeviceIntent(
   runtime: IAgentRuntime,

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/email-unsubscribe-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/email-unsubscribe-service.ts
@@ -1,4 +1,14 @@
-// Implements a LifeOps domain service behind the assistant orchestration layer.
+/**
+ * Thin LifeOps delegation layer over `@elizaos/plugin-inbox`'s
+ * {@link InboxUnsubscribeService}, which owns the email-unsubscribe back-end.
+ * This domain keeps the `LifeOpsService` method surface stable (including the
+ * `requestUrl` argument route callers pass) and forwards to the inbox service,
+ * which resolves Gmail through the `@elizaos/plugin-google` runtime service and
+ * persists to the `app_inbox.life_email_unsubscribes` table.
+ *
+ * The two-phase confirmation gate (`requireConfirmation`) stays in the PA route
+ * layer; the inbox service trusts the pre-confirmed `userAuthorization` flag.
+ */
 import type {
   EmailSubscriptionScanResult,
   EmailUnsubscribeRecord,
@@ -8,18 +18,6 @@ import type {
 } from "@elizaos/plugin-inbox/inbox/email-unsubscribe-types";
 import { InboxUnsubscribeService } from "@elizaos/plugin-inbox/inbox/unsubscribe-service";
 import type { LifeOpsContext } from "../lifeops-context.js";
-
-/**
- * Email-unsubscribe back-end moved to `@elizaos/plugin-inbox`
- * ({@link InboxUnsubscribeService}). This domain is a thin delegation layer: it
- * preserves the LifeOpsService method surface (the `requestUrl` argument the
- * route callers pass), but forwards to the standalone inbox service, which
- * resolves Gmail through the `@elizaos/plugin-google` runtime service and
- * persists to the same `app_inbox.life_email_unsubscribes` table.
- *
- * The two-phase confirmation gate (`requireConfirmation`) stays in the PA route
- * layer; the inbox service trusts the pre-confirmed `userAuthorization` flag.
- */
 export class EmailUnsubscribeDomain {
   constructor(private readonly ctx: LifeOpsContext) {}
 

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminder-notification-priority.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminder-notification-priority.test.ts
@@ -1,4 +1,9 @@
-// Exercises LifeOps domain priority and notification behavior.
+/**
+ * Calendar-reminder priority tiering (#10697), tested as a pure function with no
+ * runtime. "Starting soon" must outrank "tomorrow" on the notification rail, so
+ * the soon/later/distant window edges are pinned against a regression that would
+ * flatten them into a single tier.
+ */
 import { describe, expect, it } from "vitest";
 import {
   REMINDER_DISTANT_WINDOW_MS,
@@ -6,12 +11,6 @@ import {
   resolveReminderNotificationPriority,
 } from "./reminder-notification-priority.ts";
 
-/**
- * Calendar-reminder priority tiering (#10697). "Starting soon" must outrank
- * "tomorrow" on the notification rail; a regression that flattens them back to a
- * single tier is exactly what this issue fixes, so the soon/later/distant edges
- * are pinned.
- */
 const NOW = 1_700_000_000_000;
 const at = (offsetMs: number): string => new Date(NOW + offsetMs).toISOString();
 const priority = (

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/sleep-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/sleep-service.ts
@@ -1,4 +1,9 @@
-// Implements a LifeOps domain service behind the assistant orchestration layer.
+/**
+ * Sleep history / regularity / personal-baseline reads, delegated to
+ * `@elizaos/plugin-health`'s sleep service methods (health/circadian logic
+ * belongs to plugin-health; LifeOps only projects it for the owner). Base-only
+ * domain — no cross-domain dependencies.
+ */
 import { createHealthSleepServiceMethods } from "@elizaos/plugin-health";
 import type {
   LifeOpsPersonalBaselineResponse,
@@ -7,12 +12,6 @@ import type {
 } from "@elizaos/shared";
 import { resolveDefaultTimeZone } from "../defaults.js";
 import type { LifeOpsContext } from "../lifeops-context.js";
-
-/**
- * Sleep history / regularity / personal-baseline reads, delegated to
- * `@elizaos/plugin-health`'s sleep service methods. Base-only domain (no
- * cross-domain dependencies).
- */
 export class SleepDomain {
   constructor(private readonly ctx: LifeOpsContext) {}
 

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/subscriptions-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/subscriptions-service.ts
@@ -1,4 +1,12 @@
-// Implements a LifeOps domain service behind the assistant orchestration layer.
+/**
+ * Subscriptions audit / cancellation reads + mutations, delegated to
+ * `@elizaos/plugin-finances` (`SubscriptionsService`), which owns the finance
+ * tables and reaches Gmail + the browser bridge through runtime-service seams.
+ * Keeps the LifeOps service surface stable for route + action call sites. The
+ * `auditSubscriptions(requestUrl, request)` signature keeps its `requestUrl`
+ * argument for call-site stability but ignores it — the finances Gmail seam
+ * resolves the connector account directly.
+ */
 import { SubscriptionsService } from "@elizaos/plugin-finances/services/subscriptions-service";
 import type { LifeOpsSubscriptionPlaybook } from "@elizaos/plugin-finances/subscriptions-playbooks";
 import type {
@@ -9,16 +17,6 @@ import type {
   LifeOpsSubscriptionExecutor,
 } from "@elizaos/plugin-finances/subscriptions-types";
 import type { LifeOpsContext } from "../lifeops-context.js";
-
-/**
- * Subscriptions audit / cancellation reads + mutations, delegated to
- * `@elizaos/plugin-finances` (`SubscriptionsService`), which owns the finance
- * tables and reaches Gmail + the browser bridge through runtime-service seams.
- * Keeps the LifeOps service surface stable for existing route + action call
- * sites. The legacy `auditSubscriptions(requestUrl, request)` signature is
- * preserved; the `requestUrl` argument is no longer needed (the finances Gmail
- * seam resolves the connector account directly) and is ignored.
- */
 export class SubscriptionsDomain {
   constructor(private readonly ctx: LifeOpsContext) {}
 

--- a/plugins/plugin-personal-assistant/src/lifeops/intent-sync.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/intent-sync.ts
@@ -1,23 +1,21 @@
-// Supports the LifeOps scheduled-task spine, owner facts, and assistant context.
+/**
+ * Local intent store for the owner's logical devices.
+ *
+ * An intent is a small structured message targeted at one or more of the
+ * owner's logical devices (desktop, mobile, or a specific device). Intents are
+ * persisted in a single local database table, and any process attached to that
+ * database polls its pending queue; once acknowledged they are no longer
+ * returned.
+ *
+ * This module is *local-only*: there is no wire-level replication across
+ * machines, so two agent processes on different machines will NOT see each
+ * other's intents. A cross-device replication bridge (e.g. Eliza Cloud
+ * device-bus) is out of scope here — if it exists, it sits alongside this
+ * table, not inside it.
+ */
 import crypto from "node:crypto";
 import type { IAgentRuntime } from "@elizaos/core";
 import { executeRawSql, parseJsonRecord, sqlText, toText } from "./sql.js";
-
-/**
- * Local intent store (formerly called "cross-device intent sync").
- *
- * An intent is a small structured message targeted at one or more of the
- * owner's logical devices (desktop, mobile, specific device). Intents are
- * persisted in a single local database table, and any process attached to
- * that database polls its pending queue; once acknowledged they are no
- * longer returned.
- *
- * NOTE: this module is *local-only*. There is no wire-level replication
- * across machines. Two separate agent processes running on different
- * machines will NOT see each other's intents. A cross-device replication
- * bridge (e.g. Eliza Cloud device-bus) is out of scope here — if/when that
- * bridge exists, it would sit alongside this table, not inside it.
- */
 
 export const LIFE_INTENT_KINDS = [
   "user_action_requested",

--- a/plugins/plugin-personal-assistant/src/lifeops/lifeops-context.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/lifeops-context.ts
@@ -1,6 +1,3 @@
-// Supports the LifeOps scheduled-task spine, owner facts, and assistant context.
-import type { LifeOpsServiceBase } from "./service-mixin-core.js";
-
 /**
  * Shared state and infrastructure every LifeOps domain sub-service depends on.
  *
@@ -9,12 +6,13 @@ import type { LifeOpsServiceBase } from "./service-mixin-core.js";
  * extends `LifeOpsServiceBase`) satisfies this structurally, so the composition
  * root passes `this` as the context when constructing domain sub-services.
  *
- * Domain-specific helpers that historically lived on the base (browser-settings
- * reads, google/x grant mutation, workflow-definition lookup, the per-domain
- * `record*Audit` wrappers, the adaptive-window cache, the reminder-processing
- * lock) are intentionally NOT part of the shared context — they belong to their
- * owning domain and are injected as typed sub-service dependencies instead.
+ * Domain-specific helpers on the base (browser-settings reads, google/x grant
+ * mutation, workflow-definition lookup, the per-domain `record*Audit` wrappers,
+ * the adaptive-window cache, the reminder-processing lock) are intentionally NOT
+ * part of the shared context — they belong to their owning domain and are
+ * injected as typed sub-service dependencies instead.
  */
+import type { LifeOpsServiceBase } from "./service-mixin-core.js";
 export type LifeOpsContext = Pick<
   LifeOpsServiceBase,
   | "runtime"

--- a/plugins/plugin-personal-assistant/src/lifeops/messaging/owner-send-policy.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/messaging/owner-send-policy.ts
@@ -1,4 +1,18 @@
-// Applies owner messaging policy before connector dispatch.
+/**
+ * Owner send-approval policy: the {@link SendPolicy} that forces outbound
+ * messages on approval-gated connectors through explicit owner confirmation
+ * before dispatch. `shouldRequireApproval` consults the connector registry (a
+ * connector's `requiresApproval` flag); `enqueueApproval` persists the draft as
+ * a CHOOSE_OPTION `ScheduledTask` on the owner approval queue.
+ *
+ * Approval executes through one stable task worker (`OWNER_SEND_APPROVAL`) that
+ * core's CHOOSE_OPTION action resolves by task name, dispatching on task
+ * metadata rather than a per-task name. The worker reconstructs the send purely
+ * from the draft payload persisted in the task row — never from an in-memory
+ * closure — so an approved send survives a process restart (#10721), and an
+ * in-process claim set makes a concurrent duplicate confirm fail rather than
+ * double-send (#11090).
+ */
 import type {
   DraftRecord,
   DraftRequest,

--- a/plugins/plugin-personal-assistant/src/lifeops/policy-memory.validation.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/policy-memory.validation.test.ts
@@ -1,15 +1,14 @@
-// Exercises LifeOps policy, scheduling, or owner-context invariants.
+/**
+ * LifeOps policy-rule validation (#8801). A policy rule governs what an
+ * automation may do (read_aloud, delete, send, spend_money…) and with what
+ * effect (allow / deny / require_approval). It is loaded from untrusted memory,
+ * so a malformed rule must be REJECTED with a precise error rather than silently
+ * treated as permissive. Each field check is asserted to fire only when that
+ * field is wrong (robust to the rule's other sub-checks).
+ */
 import { describe, expect, it } from "vitest";
 import { validateLifeOpsPolicyRule } from "./policy-memory.ts";
 
-/**
- * LifeOps policy-rule validation (#8801 — shipped untested). A policy rule
- * governs what an automation may do (read_aloud, delete, send, spend_money…) and
- * with what effect (allow / deny / require_approval). It is loaded from
- * untrusted memory, so a malformed rule must be REJECTED with a precise error
- * rather than silently treated as permissive. Each field check is asserted to
- * fire only when that field is wrong (robust to the rule's other sub-checks).
- */
 const base = {
   kind: "lifeops_policy_rule",
   id: "rule-1",

--- a/plugins/plugin-personal-assistant/src/lifeops/privacy.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/privacy.ts
@@ -1,4 +1,12 @@
-// Supports the LifeOps scheduled-task spine, owner facts, and assistant context.
+/**
+ * Privacy lattice for surfacing connector-account content to an audience. Maps a
+ * stored account {@link PrivacyLevel} (`owner_only` → `public`) against a
+ * {@link LifeOpsAudience} and answers whether the account may be shown, filters
+ * account lists down to the surfaceable subset, and supplies the redaction
+ * placeholder for blocked accounts. A missing or unloadable account is treated
+ * as not-surfaceable (fail closed), and filtering logs only counts, never
+ * account data.
+ */
 import {
   type ConnectorAccount,
   DEFAULT_PRIVACY_LEVEL,

--- a/plugins/plugin-personal-assistant/src/lifeops/send-policy/registry.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/send-policy/registry.ts
@@ -1,4 +1,12 @@
-// Registers connector send-policy rules for approval-aware dispatch.
+/**
+ * In-memory {@link SendPolicyRegistry} backing the LifeOps send-policy contract.
+ * Send policies gate outbound dispatch on a connector or channel; the registry
+ * evaluates them in ascending-priority order and returns the first non-`allow`
+ * decision (`require_approval` / `deny`), defaulting to `allow` when every
+ * policy passes. The canonical contributor is the owner-send policy in
+ * `messaging/owner-send-policy.ts`, which forces Gmail drafts through owner
+ * approval.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import type {
   SendPolicyContext,

--- a/plugins/plugin-personal-assistant/src/lifeops/service-mixin-relationships.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service-mixin-relationships.ts
@@ -1,12 +1,14 @@
-// Adds a focused LifeOpsService mixin for a domain capability.
+/**
+ * Type-only public surface the `withRelationships` mixin contributes to
+ * `LifeOpsService` — relationship upsert/get/list plus interaction logging. It
+ * is declared here and declaration-merged onto `LifeOpsService` because the
+ * mixin composition exceeds TypeScript's inference depth.
+ */
 import type {
   LifeOpsMessageChannel,
   LifeOpsRelationship,
   LifeOpsRelationshipInteraction,
 } from "@elizaos/shared";
-
-/** Public surface added by {@link withRelationships}; listed on the LifeOpsService
- * declaration-merge (mixin composition exceeds TS inference depth). Type-only. */
 export interface LifeOpsRelationshipService {
   upsertRelationship(
     input: Omit<

--- a/plugins/plugin-personal-assistant/src/lifeops/stretch-decider.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/stretch-decider.test.ts
@@ -1,4 +1,10 @@
-// Exercises LifeOps policy, scheduling, or owner-context invariants.
+/**
+ * Stretch-reminder pacing (#8795 LifeOps), tested as pure functions with no
+ * reminder service. `shouldStretchNow` layers the stretch-specific cadence
+ * rules (weekend/busy/late-evening skips, the 6h cooldown, and the "a recent
+ * walk rearms the cooldown" reset) on top of the generic reminder loop, and
+ * `pickStretchReminderCopy` rotates copy deterministically by day.
+ */
 import { describe, expect, it } from "vitest";
 import {
   pickStretchReminderCopy,
@@ -6,15 +12,6 @@ import {
   STRETCH_REMINDER_VARIANTS,
   shouldStretchNow,
 } from "./stretch-decider";
-
-/**
- * Stretch-reminder pacing (#8795 LifeOps). `shouldStretchNow` layers the
- * stretch-specific cadence rules (weekend/busy/late-evening skips, the 6h
- * cooldown, and the "a recent walk rearms the cooldown" reset) on top of the
- * generic reminder loop, and `pickStretchReminderCopy` rotates copy
- * deterministically by day. Both are pure primitives chosen precisely so they
- * can be unit-tested without the reminder service — but had no test.
- */
 
 const H = 3_600_000; // 1 hour in ms
 const NOW = 1_700_000_000_000;

--- a/plugins/plugin-personal-assistant/src/website-blocker/chat-integration/block-rule-service.ts
+++ b/plugins/plugin-personal-assistant/src/website-blocker/chat-integration/block-rule-service.ts
@@ -1,4 +1,17 @@
-// Reconciles LifeOps block rules with website blocker chat requests.
+/**
+ * Persistence for website block rules — the `app_lifeops` block-rule table
+ * behind the website-blocker chat integration. Split CQRS-style into a
+ * {@link BlockRuleWriter} (create / release / gate-fulfil mutations) and a
+ * {@link BlockRuleReader} (active-block and gate queries); both live here
+ * because they share the row encoders, but stay separate classes so their
+ * pipelines can be exercised independently.
+ *
+ * The rule row is the source of truth: writers reconcile OS-level SelfControl
+ * state via `syncOsBlockToRules` after a mutation, but an activation failure is
+ * logged, not fatal — the reconciler retries the OS sync on each tick. A
+ * `harsh_no_bypass` rule refuses user-confirmed release entirely and exits only
+ * through its gate todo.
+ */
 import crypto from "node:crypto";
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
@@ -11,13 +24,6 @@ import {
   type CreateBlockRuleInput,
   rowToBlockRule,
 } from "./block-rule-schema.js";
-
-/**
- * CQRS: writers only mutate. They return the new id or void. Readers return
- * domain objects. Both live in the same module because they share the table
- * encoders, but they are separate classes so tests exercise the pipelines
- * independently.
- */
 
 function nowMs(): number {
   return Date.now();
@@ -64,7 +70,7 @@ function assertCreateInput(input: CreateBlockRuleInput): void {
     throw new Error("[BlockRuleWriter] until_todo gate requires gateTodoId");
   }
   // A harsh rule refuses every manual bypass (confirmed release, chat unblock,
-  // HTTP DELETE) and the reconciler only releases it via its gate task item. Without
+  // HTTP DELETE) and the reconciler only releases it via its gate todo. Without
   // a gateTodoId it would be a permanent lock with no exit path at all.
   if (input.gateType === "harsh_no_bypass" && !input.gateTodoId) {
     throw new Error(

--- a/plugins/plugin-personal-assistant/src/website-blocker/chat-integration/harsh-mode-check.ts
+++ b/plugins/plugin-personal-assistant/src/website-blocker/chat-integration/harsh-mode-check.ts
@@ -1,4 +1,8 @@
-// Reconciles LifeOps block rules with website blocker chat requests.
+/**
+ * Guard for the website-block unblock flow: reports whether any active
+ * `harsh_no_bypass` block rule exists for the agent, so the unblock path can
+ * refuse a soft hosts-file restore the reconciler would immediately re-apply.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { executeRawSql, sqlQuote } from "../../lifeops/sql.js";
 import { BLOCK_RULES_TABLE } from "./block-rule-schema.js";


### PR DESCRIPTION
Part of #12242 (Comment cleanup B12: LifeOps + assistant plugins). Comment-only, machine-checked — zero functional diff.

This slice finishes the B12 tail for the LifeOps `src/lifeops/**` and `src/website-blocker/**` subtrees. A fresh headerless audit on develop (`da8b55c8a`, re-run per the issue's awk one-liner) shows the calendar / inbox / health / scheduling / relationships tail files from the original brief already landed via earlier B12 PRs; the only files still headerless in my assigned subtrees were these 18 personal-assistant source files.

## What landed (18 files — prose file headers)

Added a `/** … */` prose header (before imports) locating each file in the one-scheduler / approval-queue architecture, and rewrote five change-narration comments into present-tense fact.

New headers written from reading the file:
- `src/lifeops/channels/registry.ts`, `src/lifeops/connectors/registry.ts`, `src/lifeops/send-policy/registry.ts` — the in-memory contribution registries (channels are delivery surfaces; connectors are capability/mode-tagged integrations; send-policies gate outbound dispatch in priority order).
- `src/lifeops/messaging/owner-send-policy.ts` — load-bearing: the owner send-approval `SendPolicy`, its one stable `OWNER_SEND_APPROVAL` CHOOSE_OPTION worker, and the restart-safe / duplicate-safe execution contract (#10721, #11090).
- `src/lifeops/privacy.ts` — the `owner_only → public` privacy lattice for surfacing connector-account content, fail-closed.
- `src/website-blocker/chat-integration/block-rule-service.ts` — the CQRS `BlockRuleWriter` / `BlockRuleReader` block-rule persistence (folded the mid-file CQRS note into the header).
- `src/website-blocker/chat-integration/harsh-mode-check.ts` — the `harsh_no_bypass` guard for the unblock flow.

Relocated an existing after-imports file-description block to the top (with churn rewrites where noted):
- `src/lifeops/checkin/schedule-resolver.ts`, `src/lifeops/device-bus-service.ts`, `src/lifeops/domains/sleep-service.ts`, `src/lifeops/domains/email-unsubscribe-service.ts` (churn: "back-end moved to" → present tense), `src/lifeops/domains/subscriptions-service.ts` (churn: "requestUrl … is no longer needed" → "kept for call-site stability but ignored"), `src/lifeops/intent-sync.ts` (churn: dropped 'formerly called "cross-device intent sync"'), `src/lifeops/lifeops-context.ts` (churn: dropped "historically lived on the base"), `src/lifeops/service-mixin-relationships.ts`.
- Test headers (surface + harness realness, ≤ pure-function note): `src/lifeops/domains/reminder-notification-priority.test.ts`, `src/lifeops/policy-memory.validation.test.ts` (dropped "shipped untested"), `src/lifeops/stretch-decider.test.ts` (dropped "— but had no test").

`owner-send-policy.ts:191` matched the churn grep but is a log **string literal** (`… no longer exists (already sent or cancelled)`), not a comment — left untouched.

## Deferred (coordination — concurrent code wave)

Per the W1-G brief's CRITICAL coordination rule, the two headerless `src/activity-profile/*` files are being edited concurrently by the wave-1 code lanes, so they are deferred to a later slice to avoid conflicting hunks:
- `src/activity-profile/focus-session.ts`
- `src/activity-profile/profile-metadata.ts`

## Flagged / undeterminable

None — every in-scope file's purpose was determinable from the code + package `CLAUDE.md`.

## Verification

- `bun run check:comment-only` — **PASS**: `OK — 18 source file(s) changed; every code token identical to origin/develop. Comments only.`
- Touched package typecheck + lint — **green**: `turbo run typecheck lint --filter=@elizaos/plugin-personal-assistant` → `77 successful, 77 total` (exit 0), incl. `@elizaos/plugin-personal-assistant:typecheck` and `:lint`.
- Touched test files — **green** (`vitest run`): 3 files / 22 tests passed (`reminder-notification-priority.test.ts`, `policy-memory.validation.test.ts`, `stretch-decider.test.ts`).
- Full `bun run verify`: the first (and only genuine) failure is pre-existing `@elizaos/electrobun#lint`, a file untouched by this PR — a Biome formatting drift in `packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts`, which is byte-identical to `origin/develop` here (`git diff origin/develop` empty) and reproduces on that unchanged file (`biome check` → "Found 1 error"). This is a newer instance than the coordinator's documented baseline (`app#typecheck` / `electrobun#typecheck`); develop moved to `da8b55c8a`.
- A follow-up full `typecheck lint --continue` sweep (to enumerate everything) hit **environmental OOM** on this machine, not develop red: `@elizaos/plugin-health` and `@elizaos/plugin-wallet` `build:types` were `SIGKILL`ed (exit 137) under the concurrency-8 whole-workspace build, which cascaded into `TS2307 Cannot find module '@elizaos/plugin-app-manager'` typecheck errors in unrelated packages whose `.d.ts` never got emitted. None of these are `plugin-personal-assistant`, and the comment-only proof guarantees this diff introduces zero type/lint/build change anywhere. The authoritative signal for the touched package is the scoped `--filter=@elizaos/plugin-personal-assistant` run above (77/77 green).

Ran `bun run --cwd packages/cloud/routing build` once for the known `@elizaos/cloud-routing` build-order gap (draft PR #12650) before verify.

## Evidence (PR_EVIDENCE.md)

- Trajectory / screenshot (before/after) / video walkthrough / audio / domain-artifact rows: **N/A — comments-only change, zero functional diff (machine-checked by `scripts/assert-comment-only-diff.mjs`).**
- Backend / frontend logs: **N/A — no runtime surface changed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
