### PR TITLE
docs(#12859): add app dashboard prose headers

### DIFF
--- a/packages/app/capacitor.config.ts
+++ b/packages/app/capacitor.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Builds the Capacitor mobile configuration from the shared app identity and
+ * runtime settings.
+ */
 import type { CapacitorConfig } from "@capacitor/cli";
 import appConfig from "./app.config";
 

--- a/packages/app/playwright.android-browser.config.ts
+++ b/packages/app/playwright.android-browser.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright configuration for the Playwright Android Browser app test lane,
+ * including browser projects and app-server wiring.
+ */
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/playwright.android.config.ts
+++ b/packages/app/playwright.android.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright configuration for the Playwright Android app test lane, including
+ * browser projects and app-server wiring.
+ */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "@playwright/test";

--- a/packages/app/playwright.dev-smoke.config.ts
+++ b/packages/app/playwright.dev-smoke.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright configuration for the Playwright Dev Smoke app test lane,
+ * including browser projects and app-server wiring.
+ */
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/playwright.electrobun.packaged.config.ts
+++ b/packages/app/playwright.electrobun.packaged.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright configuration for the Playwright Electrobun Packaged app test
+ * lane, including browser projects and app-server wiring.
+ */
 import { defineConfig } from "@playwright/test";
 
 // NOTE: this config intentionally has no `webServer`. The packaged Electrobun

--- a/packages/app/playwright.hmr.config.ts
+++ b/packages/app/playwright.hmr.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright configuration for the Playwright Hmr app test lane, including
+ * browser projects and app-server wiring.
+ */
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/playwright.ui-packaged.config.ts
+++ b/packages/app/playwright.ui-packaged.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright configuration for the Playwright Ui Packaged app test lane,
+ * including browser projects and app-server wiring.
+ */
 import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({

--- a/packages/app/playwright.ui-smoke.config.ts
+++ b/packages/app/playwright.ui-smoke.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright configuration for the Playwright Ui Smoke app test lane,
+ * including browser projects and app-server wiring.
+ */
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/playwright.web-views.config.ts
+++ b/packages/app/playwright.web-views.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright configuration for the Playwright Web Views app test lane,
+ * including browser projects and app-server wiring.
+ */
 import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({

--- a/packages/app/public/runners/eliza-tasks.js
+++ b/packages/app/public/runners/eliza-tasks.js
@@ -1,3 +1,7 @@
+/**
+ * Browser-runner script that hosts Eliza task execution inside the app public
+ * runner sandbox.
+ */
 const CONFIG_KEY = "eliza.background.config";
 const LAST_WAKE_KEY = "eliza.background.lastWake";
 const LAST_RESULT_KEY = "eliza.background.lastResult";

--- a/packages/app/scripts/android-adb-install.mjs
+++ b/packages/app/scripts/android-adb-install.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/**
+ * Command-line helper for the Android Adb Install app packaging, mobile, or
+ * Playwright automation lane.
+ */
 
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";

--- a/packages/app/scripts/capacitor-plugin-names.mjs
+++ b/packages/app/scripts/capacitor-plugin-names.mjs
@@ -1,3 +1,7 @@
+/**
+ * Command-line helper for the Capacitor Plugin Names app packaging, mobile, or
+ * Playwright automation lane.
+ */
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/scripts/ensure-capacitor-platform.mjs
+++ b/packages/app/scripts/ensure-capacitor-platform.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/**
+ * Command-line helper for the Ensure Capacitor Platform app packaging, mobile,
+ * or Playwright automation lane.
+ */
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";

--- a/packages/app/scripts/ios-sideload-helper.mjs
+++ b/packages/app/scripts/ios-sideload-helper.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/**
+ * Command-line helper for the Ios Sideload Helper app packaging, mobile, or
+ * Playwright automation lane.
+ */
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";

--- a/packages/app/scripts/ios-store-engine-gate.test.mjs
+++ b/packages/app/scripts/ios-store-engine-gate.test.mjs
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Ios Store Engine Gate app packaging script behavior and
+ * platform guardrails.
+ */
 import { describe, expect, it } from "vitest";
 import { evaluateIosStoreEngineGate } from "./ios-store-engine-gate.mjs";
 

--- a/packages/app/scripts/lib/android-capture.mjs
+++ b/packages/app/scripts/lib/android-capture.mjs
@@ -1,3 +1,7 @@
+/**
+ * Shared script library for Android Capture capture and packaging helpers used
+ * by app automation.
+ */
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";

--- a/packages/app/scripts/lib/asset-cdn.mjs
+++ b/packages/app/scripts/lib/asset-cdn.mjs
@@ -1,3 +1,7 @@
+/**
+ * Shared script library for Asset Cdn capture and packaging helpers used by
+ * app automation.
+ */
 export {
   buildJsDelivrAssetBase,
   buildManagedAssetUrl,

--- a/packages/app/scripts/lib/ios-simulator-capture.mjs
+++ b/packages/app/scripts/lib/ios-simulator-capture.mjs
@@ -1,3 +1,7 @@
+/**
+ * Shared script library for Ios Simulator Capture capture and packaging
+ * helpers used by app automation.
+ */
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";

--- a/packages/app/scripts/macos-shortcuts/eliza-assistant-handoff.test.ts
+++ b/packages/app/scripts/macos-shortcuts/eliza-assistant-handoff.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Test coverage for macOS Shortcuts handoff automation used by the desktop app
+ * shell.
+ */
 import { execFile, spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/**
+ * Command-line helper for the Mobile Local Chat Smoke app packaging, mobile,
+ * or Playwright automation lane.
+ */
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";

--- a/packages/app/scripts/mobile-release-preflight.mjs
+++ b/packages/app/scripts/mobile-release-preflight.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/**
+ * Command-line helper for the Mobile Release Preflight app packaging, mobile,
+ * or Playwright automation lane.
+ */
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";

--- a/packages/app/scripts/patch-ios-plist.test.mjs
+++ b/packages/app/scripts/patch-ios-plist.test.mjs
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Patch Ios Plist app packaging script behavior and
+ * platform guardrails.
+ */
 import { describe, expect, it } from "vitest";
 
 import { ensurePlistUrlScheme } from "../../app-core/scripts/lib/ios-plist-url-scheme.mjs";

--- a/packages/app/scripts/plugin-build.mjs
+++ b/packages/app/scripts/plugin-build.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/**
+ * Command-line helper for the Plugin Build app packaging, mobile, or
+ * Playwright automation lane.
+ */
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";

--- a/packages/app/scripts/run-ui-playwright.mjs
+++ b/packages/app/scripts/run-ui-playwright.mjs
@@ -1,3 +1,7 @@
+/**
+ * Command-line helper for the Run Ui Playwright app packaging, mobile, or
+ * Playwright automation lane.
+ */
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";

--- a/packages/app/test/android-browser/onboarding-to-home.android-browser.spec.ts
+++ b/packages/app/test/android-browser/onboarding-to-home.android-browser.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Android-browser Playwright spec for the Onboarding To Home Android Browser
+ * mobile app onboarding flow.
+ */
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import {

--- a/packages/app/test/android/native-plugin-view-smoke.android.spec.ts
+++ b/packages/app/test/android/native-plugin-view-smoke.android.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Android device smoke spec for the Native Plugin View Smoke Android native
+ * plugin app surface.
+ */
 import fs from "node:fs";
 import path from "node:path";
 import {

--- a/packages/app/test/audit/aesthetic-audit-rules.test.ts
+++ b/packages/app/test/audit/aesthetic-audit-rules.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Aesthetic Audit Rules app audit helper used by visual
+ * review evidence.
+ */
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";

--- a/packages/app/test/audit/ai-qa-review-lib.test.ts
+++ b/packages/app/test/audit/ai-qa-review-lib.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Ai Qa Review Lib app audit helper used by visual review
+ * evidence.
+ */
 import { describe, expect, it } from "vitest";
 import {
   aggregateVerdicts,

--- a/packages/app/test/background-runner.test.ts
+++ b/packages/app/test/background-runner.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Background Runner app shell contract and coverage
+ * guardrail.
+ */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import vm from "node:vm";

--- a/packages/app/test/chat-gesture-coverage.test.ts
+++ b/packages/app/test/chat-gesture-coverage.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Chat Gesture Coverage app shell contract and coverage
+ * guardrail.
+ */
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/test/core-view-action-surface-coverage.test.ts
+++ b/packages/app/test/core-view-action-surface-coverage.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Core View Action Surface Coverage app shell contract and
+ * coverage guardrail.
+ */
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/test/core-view-interaction-coverage.test.ts
+++ b/packages/app/test/core-view-interaction-coverage.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Core View Interaction Coverage app shell contract and
+ * coverage guardrail.
+ */
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/test/design-review/run-design-review.ts
+++ b/packages/app/test/design-review/run-design-review.ts
@@ -1,3 +1,7 @@
+/**
+ * Runs the app design-review capture workflow over generated screenshots and
+ * review prompts.
+ */
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/test/dev-smoke/bun-dev-app-shell.spec.ts
+++ b/packages/app/test/dev-smoke/bun-dev-app-shell.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * Development smoke spec for the Bun Dev App Shell Bun dev app boot path.
+ */
 import { expect, test } from "@playwright/test";
 
 /**

--- a/packages/app/test/dev-smoke/bun-dev-onboarding-chat.spec.ts
+++ b/packages/app/test/dev-smoke/bun-dev-onboarding-chat.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Development smoke spec for the Bun Dev Onboarding Chat Bun dev app boot
+ * path.
+ */
 import { expect, test } from "@playwright/test";
 import {
   browserFailureCollector,

--- a/packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Packaged Electrobun spec for the Electrobun Bottom Bar E2e desktop app
+ * behavior.
+ */
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-packaged-regressions.e2e.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Packaged Electrobun spec for the Electrobun Packaged Regressions E2e desktop
+ * app behavior.
+ */
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/packages/app/test/electrobun-packaged/electrobun-relaunch.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-relaunch.e2e.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Packaged Electrobun spec for the Electrobun Relaunch E2e desktop app
+ * behavior.
+ */
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/packages/app/test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Packaged Electrobun spec for the Electrobun Windows Startup E2e desktop app
+ * behavior.
+ */
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/packages/app/test/electrobun-packaged/live-api.ts
+++ b/packages/app/test/electrobun-packaged/live-api.ts
@@ -1,3 +1,7 @@
+/**
+ * Live API helper used by packaged Electrobun specs that exercise a real app
+ * backend.
+ */
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { startApiServer } from "../../../app-core/src/api/server.ts";

--- a/packages/app/test/electrobun-packaged/mock-api.ts
+++ b/packages/app/test/electrobun-packaged/mock-api.ts
@@ -1,3 +1,7 @@
+/**
+ * Mock API helper used by packaged Electrobun specs that isolate renderer
+ * startup behavior.
+ */
 import { randomUUID } from "node:crypto";
 import http from "node:http";
 import type { AddressInfo } from "node:net";

--- a/packages/app/test/electrobun-packaged/packaged-app-helpers.ts
+++ b/packages/app/test/electrobun-packaged/packaged-app-helpers.ts
@@ -1,3 +1,7 @@
+/**
+ * Shared helpers for launching and inspecting packaged Electrobun app builds
+ * in tests.
+ */
 import { type ChildProcess, execFile, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";

--- a/packages/app/test/electrobun-packaged/windows-bootstrap.ts
+++ b/packages/app/test/electrobun-packaged/windows-bootstrap.ts
@@ -1,3 +1,7 @@
+/**
+ * Windows packaged-test bootstrap for preparing Electrobun app paths before
+ * specs run.
+ */
 function hasRequestForPath(
   requests: readonly string[],
   pathname: string,

--- a/packages/app/test/electrobun-packaged/windows-test-env.ts
+++ b/packages/app/test/electrobun-packaged/windows-test-env.ts
@@ -1,3 +1,7 @@
+/**
+ * Windows packaged-test environment helpers for Electrobun startup and
+ * filesystem paths.
+ */
 const STRIPPED_ENV_KEYS = [
   "ELIZA_API_BASE",
   "ELIZA_API_BASE_URL",

--- a/packages/app/test/hmr-coverage.test.ts
+++ b/packages/app/test/hmr-coverage.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Unit tests for the Hmr Coverage app shell contract and coverage guardrail.
+ */
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/test/hmr/hmr-dependency-levels.spec.ts
+++ b/packages/app/test/hmr/hmr-dependency-levels.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright HMR spec for the Hmr Dependency Levels app development-server
+ * behavior.
+ */
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/test/index-html-fetch-bridge.test.ts
+++ b/packages/app/test/index-html-fetch-bridge.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Index Html Fetch Bridge app shell contract and coverage
+ * guardrail.
+ */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/app/test/ios-app-intents-registration.test.ts
+++ b/packages/app/test/ios-app-intents-registration.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Ios App Intents Registration app shell contract and
+ * coverage guardrail.
+ */
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/test/launcher-view-coverage.test.ts
+++ b/packages/app/test/launcher-view-coverage.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Launcher View Coverage app shell contract and coverage
+ * guardrail.
+ */
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/test/native-module-stub-plugin.test.ts
+++ b/packages/app/test/native-module-stub-plugin.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Native Module Stub Plugin app shell contract and coverage
+ * guardrail.
+ */
 import { createRequire } from "node:module";
 import { describe, expect, it } from "vitest";
 

--- a/packages/app/test/pages-csp.test.ts
+++ b/packages/app/test/pages-csp.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Unit tests for the Pages Csp app shell contract and coverage guardrail.
+ */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/packages/app/test/route-coverage.test.ts
+++ b/packages/app/test/route-coverage.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Unit tests for the Route Coverage app shell contract and coverage guardrail.
+ */
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/test/screenshot-quality.test.ts
+++ b/packages/app/test/screenshot-quality.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Screenshot Quality app shell contract and coverage
+ * guardrail.
+ */
 import sharp from "sharp";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/packages/app/test/ui-smoke-coverage.test.ts
+++ b/packages/app/test/ui-smoke-coverage.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Ui Smoke Coverage app shell contract and coverage
+ * guardrail.
+ */
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/test/ui-smoke/ai-qa-capture.spec.ts
+++ b/packages/app/test/ui-smoke/ai-qa-capture.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Ai Qa Capture app flow using the real
+ * renderer fixture.
+ */
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
+++ b/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the All Pages Clicksafe app flow using the real
+ * renderer fixture.
+ */
 import { expect, type Locator, type Page, test } from "@playwright/test";
 import {
   DIRECT_ROUTE_CASES,

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the All Views Aesthetic Audit app flow using
+ * the real renderer fixture.
+ */
 import { readFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";

--- a/packages/app/test/ui-smoke/all-views-interaction.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-interaction.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the All Views Interaction app flow using the
+ * real renderer fixture.
+ */
 import {
   type ElementHandle,
   expect,

--- a/packages/app/test/ui-smoke/android-system-apps.spec.ts
+++ b/packages/app/test/ui-smoke/android-system-apps.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Android System Apps app flow using the real
+ * renderer fixture.
+ */
 import { type BrowserContext, expect, type Page, test } from "@playwright/test";
 import {
   assertReadyChecks,

--- a/packages/app/test/ui-smoke/apps-comms-device-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-comms-device-interactions.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Apps Comms Device Interactions app flow
+ * using the real renderer fixture.
+ */
 import { expect, type Page, test } from "@playwright/test";
 import {
   assertReadyChecks,

--- a/packages/app/test/ui-smoke/apps-model-training-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-model-training-interactions.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Apps Model Training Interactions app flow
+ * using the real renderer fixture.
+ */
 import {
   expect,
   type Locator,

--- a/packages/app/test/ui-smoke/apps-personal-assistant-feed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-feed-interactions.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Apps Personal Assistant Feed Interactions
+ * app flow using the real renderer fixture.
+ */
 import { expect, type Page, type Route, test } from "@playwright/test";
 import {
   assertReadyChecks,

--- a/packages/app/test/ui-smoke/apps-session-direct-a.spec.ts
+++ b/packages/app/test/ui-smoke/apps-session-direct-a.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Apps Session Direct A app flow using the
+ * real renderer fixture.
+ */
 import { expect, test } from "@playwright/test";
 import { DIRECT_ROUTE_CASES, escapeRegExp } from "./apps-session-route-cases";
 import {

--- a/packages/app/test/ui-smoke/apps-session-direct-b.spec.ts
+++ b/packages/app/test/ui-smoke/apps-session-direct-b.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Apps Session Direct B app flow using the
+ * real renderer fixture.
+ */
 import { expect, test } from "@playwright/test";
 import { DIRECT_ROUTE_CASES, escapeRegExp } from "./apps-session-route-cases";
 import {

--- a/packages/app/test/ui-smoke/apps-session-route-cases.ts
+++ b/packages/app/test/ui-smoke/apps-session-route-cases.ts
@@ -1,3 +1,7 @@
+/**
+ * Route-case fixtures for apps-session UI-smoke coverage across direct and
+ * shell navigation paths.
+ */
 export function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/packages/app/test/ui-smoke/apps-session.spec.ts
+++ b/packages/app/test/ui-smoke/apps-session.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Apps Session app flow using the real
+ * renderer fixture.
+ */
 import { test } from "@playwright/test";
 import {
   assertReadyChecks,

--- a/packages/app/test/ui-smoke/apps-utility-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-utility-interactions.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Apps Utility Interactions app flow using
+ * the real renderer fixture.
+ */
 import { expect, type Locator, type Page, test } from "@playwright/test";
 import { DIRECT_ROUTE_CASES } from "./apps-session-route-cases";
 import {

--- a/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
+++ b/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Assistant Home Flow app flow using the real
+ * renderer fixture.
+ */
 import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Page, type Route, test } from "@playwright/test";

--- a/packages/app/test/ui-smoke/auth-startup.spec.ts
+++ b/packages/app/test/ui-smoke/auth-startup.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Auth Startup app flow using the real
+ * renderer fixture.
+ */
 import { expect, type Page, type Route, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,

--- a/packages/app/test/ui-smoke/browser-workspace.spec.ts
+++ b/packages/app/test/ui-smoke/browser-workspace.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Browser Workspace app flow using the real
+ * renderer fixture.
+ */
 import { type APIRequestContext, expect, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,

--- a/packages/app/test/ui-smoke/builtin-views-visual.spec.ts
+++ b/packages/app/test/ui-smoke/builtin-views-visual.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Builtin Views Visual app flow using the
+ * real renderer fixture.
+ */
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, test } from "@playwright/test";

--- a/packages/app/test/ui-smoke/character-editor.spec.ts
+++ b/packages/app/test/ui-smoke/character-editor.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Character Editor app flow using the real
+ * renderer fixture.
+ */
 import { expect, type Page, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,

--- a/packages/app/test/ui-smoke/chat-view-memory-stability.spec.ts
+++ b/packages/app/test/ui-smoke/chat-view-memory-stability.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Chat View Memory Stability app flow using
+ * the real renderer fixture.
+ */
 import { expect, type Locator, type Page, test } from "@playwright/test";
 import { CHAT_PREFILL_EVENT } from "../../../ui/src/events";
 import {

--- a/packages/app/test/ui-smoke/cloud-agent-lifecycle.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-agent-lifecycle.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Cloud Agent Lifecycle app flow using the
+ * real renderer fixture.
+ */
 import { expect, type Page, type Route, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,

--- a/packages/app/test/ui-smoke/cloud-console-routes.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-console-routes.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Cloud Console Routes app flow using the
+ * real renderer fixture.
+ */
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { expect, type Page, test } from "@playwright/test";
 import {

--- a/packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Cloud Provisioning Startup app flow using
+ * the real renderer fixture.
+ */
 import {
   expect,
   type Locator,

--- a/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Cloud Surfaces Aesthetic Audit app flow
+ * using the real renderer fixture.
+ */
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";

--- a/packages/app/test/ui-smoke/cloud-wallet-import.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-wallet-import.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Cloud Wallet Import app flow using the real
+ * renderer fixture.
+ */
 import { expect, type Page, test } from "@playwright/test";
 import {
   installCloudWalletImportApiOverrides,

--- a/packages/app/test/ui-smoke/computer-use.spec.ts
+++ b/packages/app/test/ui-smoke/computer-use.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Computer Use app flow using the real
+ * renderer fixture.
+ */
 import { expect, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,

--- a/packages/app/test/ui-smoke/connectors.spec.ts
+++ b/packages/app/test/ui-smoke/connectors.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Connectors app flow using the real renderer
+ * fixture.
+ */
 import { expect, type Page, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,

--- a/packages/app/test/ui-smoke/device-matrix.ts
+++ b/packages/app/test/ui-smoke/device-matrix.ts
@@ -1,3 +1,7 @@
+/**
+ * Device matrix fixtures for UI-smoke specs that compare desktop and mobile
+ * app layouts.
+ */
 export const ASSERTION_GRADE_DASHBOARD_SPECS =
   /(browser-workspace|character-editor|wallet-inventory|workflow-editor)\.spec\.ts/;
 

--- a/packages/app/test/ui-smoke/documents-view.spec.ts
+++ b/packages/app/test/ui-smoke/documents-view.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Documents View app flow using the real
+ * renderer fixture.
+ */
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, test } from "@playwright/test";

--- a/packages/app/test/ui-smoke/files-view.spec.ts
+++ b/packages/app/test/ui-smoke/files-view.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Files View app flow using the real renderer
+ * fixture.
+ */
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, test } from "@playwright/test";

--- a/packages/app/test/ui-smoke/first-run-startup.spec.ts
+++ b/packages/app/test/ui-smoke/first-run-startup.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the First Run Startup app flow using the real
+ * renderer fixture.
+ */
 import { copyFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Page, type Route, test } from "@playwright/test";

--- a/packages/app/test/ui-smoke/helpers.ts
+++ b/packages/app/test/ui-smoke/helpers.ts
@@ -1,3 +1,7 @@
+/**
+ * Shared Playwright helpers for app UI-smoke fixtures, navigation, logging,
+ * and assertions.
+ */
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { expect, type Locator, type Page, type Route } from "@playwright/test";

--- a/packages/app/test/ui-smoke/helpers/brand-color-scans.ts
+++ b/packages/app/test/ui-smoke/helpers/brand-color-scans.ts
@@ -1,3 +1,7 @@
+/**
+ * Brand-color scanner helpers that flag forbidden palette drift in UI-smoke
+ * screenshots.
+ */
 import type { Page } from "@playwright/test";
 import { bucket } from "../aesthetic-audit-rules";
 

--- a/packages/app/test/ui-smoke/helpers/screenshot-quality.ts
+++ b/packages/app/test/ui-smoke/helpers/screenshot-quality.ts
@@ -1,3 +1,7 @@
+/**
+ * Screenshot-quality helper used by UI-smoke specs to reject blank or
+ * low-signal captures.
+ */
 import type { Page } from "@playwright/test";
 import sharp from "sharp";
 

--- a/packages/app/test/ui-smoke/history-navigation.spec.ts
+++ b/packages/app/test/ui-smoke/history-navigation.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the History Navigation app flow using the real
+ * renderer fixture.
+ */
 import { expect, test } from "@playwright/test";
 import {
   assertReadyChecks,

--- a/packages/app/test/ui-smoke/home-widget-priority.spec.ts
+++ b/packages/app/test/ui-smoke/home-widget-priority.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Home Widget Priority app flow using the
+ * real renderer fixture.
+ */
 import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Page, type Route, test } from "@playwright/test";

--- a/packages/app/test/ui-smoke/launcher-cloud-gating.spec.ts
+++ b/packages/app/test/ui-smoke/launcher-cloud-gating.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Launcher Cloud Gating app flow using the
+ * real renderer fixture.
+ */
 import { copyFile, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/test/ui-smoke/launcher-interaction.spec.ts
+++ b/packages/app/test/ui-smoke/launcher-interaction.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Launcher Interaction app flow using the
+ * real renderer fixture.
+ */
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Locator, type Page, test } from "@playwright/test";

--- a/packages/app/test/ui-smoke/model-download-deferral.spec.ts
+++ b/packages/app/test/ui-smoke/model-download-deferral.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Model Download Deferral app flow using the
+ * real renderer fixture.
+ */
 import { expect, type Page, type Route, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,

--- a/packages/app/test/ui-smoke/multi-client-desync.spec.ts
+++ b/packages/app/test/ui-smoke/multi-client-desync.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Multi Client Desync app flow using the real
+ * renderer fixture.
+ */
 import { type BrowserContext, expect, type Page, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,

--- a/packages/app/test/ui-smoke/onboarding-confused-user.spec.ts
+++ b/packages/app/test/ui-smoke/onboarding-confused-user.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Onboarding Confused User app flow using the
+ * real renderer fixture.
+ */
 import path from "node:path";
 import { expect, type Page, test } from "@playwright/test";
 import {

--- a/packages/app/test/ui-smoke/onboarding-to-home-mobile.spec.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home-mobile.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Onboarding To Home Mobile app flow using
+ * the real renderer fixture.
+ */
 import { rm } from "node:fs/promises";
 import path from "node:path";
 import { devices, expect, type Locator, test } from "@playwright/test";

--- a/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
@@ -1,3 +1,7 @@
+/**
+ * Shared onboarding-to-home flow helpers used by desktop and mobile UI-smoke
+ * specs.
+ */
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Locator, type Page, type Route } from "@playwright/test";

--- a/packages/app/test/ui-smoke/onboarding-to-home.spec.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Onboarding To Home app flow using the real
+ * renderer fixture.
+ */
 import { rm } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Locator, test } from "@playwright/test";

--- a/packages/app/test/ui-smoke/orchestrator-gui-workbench.spec.ts
+++ b/packages/app/test/ui-smoke/orchestrator-gui-workbench.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Orchestrator Gui Workbench app flow using
+ * the real renderer fixture.
+ */
 import { expect, type Page, type Route, test } from "@playwright/test";
 import {
   hideContinuousChatOverlay,

--- a/packages/app/test/ui-smoke/perf-load-kpi.spec.ts
+++ b/packages/app/test/ui-smoke/perf-load-kpi.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Perf Load Kpi app flow using the real
+ * renderer fixture.
+ */
 import { expect, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,

--- a/packages/app/test/ui-smoke/plugin-view-cases.ts
+++ b/packages/app/test/ui-smoke/plugin-view-cases.ts
@@ -1,3 +1,7 @@
+/**
+ * Plugin-view case fixtures used by UI-smoke specs to exercise registered
+ * plugin surfaces.
+ */
 export type ViewCase = {
   id: string;
   viewType: "gui" | "tui";

--- a/packages/app/test/ui-smoke/plugin-views-interaction.spec.ts
+++ b/packages/app/test/ui-smoke/plugin-views-interaction.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Plugin Views Interaction app flow using the
+ * real renderer fixture.
+ */
 import { expect, type Locator, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,

--- a/packages/app/test/ui-smoke/plugin-views-lifecycle.spec.ts
+++ b/packages/app/test/ui-smoke/plugin-views-lifecycle.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Plugin Views Lifecycle app flow using the
+ * real renderer fixture.
+ */
 import { expect, type Page, test } from "@playwright/test";
 import {
   expectNoPageDiagnostics,

--- a/packages/app/test/ui-smoke/plugin-views-visual.spec.ts
+++ b/packages/app/test/ui-smoke/plugin-views-visual.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Plugin Views Visual app flow using the real
+ * renderer fixture.
+ */
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Page, test } from "@playwright/test";

--- a/packages/app/test/ui-smoke/remote-capability-view.spec.ts
+++ b/packages/app/test/ui-smoke/remote-capability-view.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Remote Capability View app flow using the
+ * real renderer fixture.
+ */
 import {
   createServer,
   type IncomingMessage,

--- a/packages/app/test/ui-smoke/reset-returns-to-onboarding.spec.ts
+++ b/packages/app/test/ui-smoke/reset-returns-to-onboarding.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Reset Returns To Onboarding app flow using
+ * the real renderer fixture.
+ */
 import { expect, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,

--- a/packages/app/test/ui-smoke/runtime-configurability.spec.ts
+++ b/packages/app/test/ui-smoke/runtime-configurability.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Runtime Configurability app flow using the
+ * real renderer fixture.
+ */
 import { expect, type Page, type Route, test } from "@playwright/test";
 import {
   expectNoRenderTelemetryErrors,

--- a/packages/app/test/ui-smoke/screenshare-gui-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/screenshare-gui-interactions.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Screenshare Gui Interactions app flow using
+ * the real renderer fixture.
+ */
 import { expect, type Page, type Route, test } from "@playwright/test";
 import {
   expectNoPageDiagnostics,

--- a/packages/app/test/ui-smoke/settings-background.spec.ts
+++ b/packages/app/test/ui-smoke/settings-background.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Settings Background app flow using the real
+ * renderer fixture.
+ */
 import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Page, type Route, test } from "@playwright/test";

--- a/packages/app/test/ui-smoke/task-coordinator-gui-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/task-coordinator-gui-interactions.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Task Coordinator Gui Interactions app flow
+ * using the real renderer fixture.
+ */
 import { expect, type Page, type Route, test } from "@playwright/test";
 import {
   expectNoPageDiagnostics,

--- a/packages/app/test/ui-smoke/terminal-plugin-view-command-contract.spec.ts
+++ b/packages/app/test/ui-smoke/terminal-plugin-view-command-contract.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Terminal Plugin View Command Contract app
+ * flow using the real renderer fixture.
+ */
 import { expect, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,

--- a/packages/app/test/ui-smoke/titlebar-navigation.spec.ts
+++ b/packages/app/test/ui-smoke/titlebar-navigation.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Titlebar Navigation app flow using the real
+ * renderer fixture.
+ */
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import {

--- a/packages/app/test/ui-smoke/tutorial-help-views.spec.ts
+++ b/packages/app/test/ui-smoke/tutorial-help-views.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Tutorial Help Views app flow using the real
+ * renderer fixture.
+ */
 import { expect, test } from "@playwright/test";
 import { installDefaultAppRoutes, openAppPath } from "./helpers";
 

--- a/packages/app/test/ui-smoke/tutorial-help-walkthrough.spec.ts
+++ b/packages/app/test/ui-smoke/tutorial-help-walkthrough.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Tutorial Help Walkthrough app flow using
+ * the real renderer fixture.
+ */
 import { expect, type Page, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,

--- a/packages/app/test/ui-smoke/ui-smoke.spec.ts
+++ b/packages/app/test/ui-smoke/ui-smoke.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Ui Smoke app flow using the real renderer
+ * fixture.
+ */
 import { expect, test } from "@playwright/test";
 import {
   assertReadyChecks,

--- a/packages/app/test/ui-smoke/view-switching-core-matrix.spec.ts
+++ b/packages/app/test/ui-smoke/view-switching-core-matrix.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the View Switching Core Matrix app flow using
+ * the real renderer fixture.
+ */
 import { expect, type Page, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,

--- a/packages/app/test/ui-smoke/view-switching-core-matrix.ts
+++ b/packages/app/test/ui-smoke/view-switching-core-matrix.ts
@@ -1,3 +1,7 @@
+/**
+ * Shared view-switching matrix used by UI-smoke specs to cover core app
+ * navigation paths.
+ */
 export type CoreViewSwitchTarget = {
   id: string;
   label: string;

--- a/packages/app/test/ui-smoke/walkthrough/walkthrough-capture-smoke.spec.ts
+++ b/packages/app/test/ui-smoke/walkthrough/walkthrough-capture-smoke.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Walkthrough Capture Smoke app flow using
+ * the real renderer fixture.
+ */
 import {
   expect,
   type Page,

--- a/packages/app/test/ui-smoke/wallet-inventory.spec.ts
+++ b/packages/app/test/ui-smoke/wallet-inventory.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Wallet Inventory app flow using the real
+ * renderer fixture.
+ */
 import { expect, type Locator, type Page, test } from "@playwright/test";
 import {
   hideContinuousChatOverlay,

--- a/packages/app/test/ui-smoke/warming-shell-startup.spec.ts
+++ b/packages/app/test/ui-smoke/warming-shell-startup.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Playwright UI-smoke spec for the Warming Shell Startup app flow using the
+ * real renderer fixture.
+ */
 import { expect, type Page, test } from "@playwright/test";
 import { installDefaultAppRoutes, openAppPath } from "./helpers";
 

--- a/packages/app/test/url-scheme-registration.test.ts
+++ b/packages/app/test/url-scheme-registration.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Url Scheme Registration app shell contract and coverage
+ * guardrail.
+ */
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/test/utils/get-free-port.mjs
+++ b/packages/app/test/utils/get-free-port.mjs
@@ -1,3 +1,7 @@
+/**
+ * Test helper that finds an available local port for app smoke servers and
+ * Playwright fixtures.
+ */
 import { createServer } from "node:net";
 
 export function getFreePort() {

--- a/packages/app/test/verify-chunk-safety.test.ts
+++ b/packages/app/test/verify-chunk-safety.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Verify Chunk Safety app shell contract and coverage
+ * guardrail.
+ */
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/packages/app/test/view-interaction-coverage.test.ts
+++ b/packages/app/test/view-interaction-coverage.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the View Interaction Coverage app shell contract and coverage
+ * guardrail.
+ */
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/app/test/view-screenshots/vite.config.mjs
+++ b/packages/app/test/view-screenshots/vite.config.mjs
@@ -1,3 +1,7 @@
+/**
+ * Vite config for the view screenshot harness that renders app views for
+ * visual evidence.
+ */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import react from "@vitejs/plugin-react";

--- a/packages/app/test/view-switching-core-matrix-coverage.test.ts
+++ b/packages/app/test/view-switching-core-matrix-coverage.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the View Switching Core Matrix Coverage app shell contract
+ * and coverage guardrail.
+ */
 import { describe, expect, it } from "vitest";
 import { SETTINGS_SECTION_META } from "../../ui/src/components/settings/settings-section-meta";
 import {

--- a/packages/app/test/wallet-optimized-chunk-matcher.test.ts
+++ b/packages/app/test/wallet-optimized-chunk-matcher.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the Wallet Optimized Chunk Matcher app shell contract and
+ * coverage guardrail.
+ */
 import { describe, expect, it } from "vitest";
 import { VENDOR_OPTIMIZED_WALLET_TEST } from "../vite/wallet-chunk-matcher.ts";
 

--- a/packages/app/vite-dev-origin.ts
+++ b/packages/app/vite-dev-origin.ts
@@ -1,3 +1,7 @@
+/**
+ * Resolves the Vite dev server origin and port used by the app renderer and
+ * desktop shell during development.
+ */
 export interface ViteHmrConfig {
   host?: string;
   port: number;

--- a/packages/app/vite/app-side-effect-modules.ts
+++ b/packages/app/vite/app-side-effect-modules.ts
@@ -1,3 +1,7 @@
+/**
+ * Declares side-effect app modules that must stay visible to the renderer
+ * bundler.
+ */
 import fs from "node:fs";
 import path from "node:path";
 

--- a/packages/app/vite/native-module-stub-plugin.ts
+++ b/packages/app/vite/native-module-stub-plugin.ts
@@ -1,3 +1,7 @@
+/**
+ * Vite plugin that replaces Node and native-only modules with browser-safe
+ * renderer stubs.
+ */
 import path from "node:path";
 import type { Plugin } from "vite";
 

--- a/packages/app/vite/renderer-build-manifest-plugin.ts
+++ b/packages/app/vite/renderer-build-manifest-plugin.ts
@@ -1,3 +1,7 @@
+/**
+ * Vite plugin that records renderer build outputs for desktop and mobile
+ * packaging steps.
+ */
 import { execSync } from "node:child_process";
 import type { Plugin } from "vite";
 import {

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -1,3 +1,7 @@
+/**
+ * Configures the app package Vitest suite, including jsdom setup and
+ * package-local test boundaries.
+ */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";


### PR DESCRIPTION
## Summary
- add top-of-file prose headers across the packages/app dashboard source, configs, scripts, Playwright specs, smoke helpers, packaged desktop tests, and audit helpers
- preserve shebang placement where present and keep the batch strictly comment-only
- exclude `vite.config.ts` per issue scope

Closes #12859.

## Verification
- `git diff --check origin/develop HEAD -- . && git diff --check`
- `bun run check:comment-only`
- focused self-audit: `files=360 missing_headers=0`
- `git diff --stat origin/develop...HEAD`

## Evidence
- Real-LLM trajectories: N/A - comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- Screenshots/video/domain artifacts: N/A - comments-only app source header cleanup; no rendered behavior changes and `audit:app` is not required for comments-only per #12859.
