### PR TITLE
fix(ui): resource-cache last-write-wins — invalidate/mutate superseded by stale in-flight fetches + refetch() resolves before commit

### DIFF
--- a/packages/ui/src/hooks/resource-cache.ts
+++ b/packages/ui/src/hooks/resource-cache.ts
@@ -33,11 +33,20 @@ const store = new Map<string, CacheEntry<unknown>>();
 /** Shared in-flight revalidations, so concurrent consumers issue one request. */
 const inflight = new Map<string, Promise<unknown>>();
 /**
- * Monotonic request counter per key. A forced refetch can run concurrently with
- * an older in-flight request; only the latest sequence is allowed to commit, so
- * a slow stale response can never clobber a newer one (last-write-wins).
+ * Monotonic write counter per key — the last-write-wins guard. Every request
+ * (`revalidate`) takes the next sequence before fetching, and every committed
+ * write (`setCached` with actually-changed data, `invalidate`) advances it, so
+ * an in-flight response that started before the latest write can never commit
+ * over it: a slow stale fetch neither clobbers a newer forced refetch, nor a
+ * newer direct `setCached` (the `mutate()` optimistic-write path), nor
+ * resurrects a key that `invalidate` just dropped.
  */
 const requestSeq = new Map<string, number>();
+
+/** Advance the per-key write sequence so in-flight reads become stale. */
+function bumpRequestSeq(key: string): void {
+  requestSeq.set(key, (requestSeq.get(key) ?? 0) + 1);
+}
 const subscribers = new Map<string, Set<() => void>>();
 
 /**
@@ -163,13 +172,24 @@ export function setCached<T>(key: string, data: T, persist = false): void {
   }
   const entry: CacheEntry<T> = { data, updatedAt: Date.now() };
   store.set(key, entry);
+  // This write is newer truth than any request already in flight — advance the
+  // sequence so a slower response fetched before it cannot commit over it.
+  bumpRequestSeq(key);
   if (persist) writePersisted(key, { data, updatedAt: entry.updatedAt });
   notify(key);
 }
 
-/** Drop a key (in-memory + persisted) and notify subscribers. */
+/**
+ * Drop a key (in-memory + persisted) and notify subscribers. The invalidation
+ * also supersedes any in-flight revalidation for the key: its response was
+ * fetched before the invalidating event (typically a mutation/delete), so
+ * letting it commit would resurrect the dropped value — and later `revalidate`
+ * calls must issue a fresh request instead of de-duping onto that stale one.
+ */
 export function invalidate(key: string): void {
   store.delete(key);
+  bumpRequestSeq(key);
+  inflight.delete(key);
   if (typeof window !== "undefined") {
     try {
       window.localStorage.removeItem(`${PERSIST_PREFIX}${key}`);

--- a/packages/ui/src/hooks/resource-cache.write-supersede.test.ts
+++ b/packages/ui/src/hooks/resource-cache.write-supersede.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Last-write-wins guard of the shared resource cache: a newer write
+ * (`invalidate` after a delete, `setCached` from an optimistic `mutate()`)
+ * must supersede any revalidation already in flight — the in-flight response
+ * was fetched before the write and committing it would resurrect deleted data
+ * or roll back the user's change. Pure in-memory store, no harness.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetResourceCache,
+  getCached,
+  invalidate,
+  revalidate,
+  setCached,
+} from "./resource-cache";
+
+afterEach(() => {
+  __resetResourceCache();
+});
+
+describe("invalidate() vs in-flight revalidation", () => {
+  it("a stale in-flight fetch cannot resurrect an invalidated key", async () => {
+    const key = "supersede:invalidate:resurrect";
+    setCached(key, "server-v1");
+    let resolveFetch: (v: string) => void = () => {};
+    const slow = revalidate<string>(
+      key,
+      () => new Promise<string>((r) => (resolveFetch = r)),
+    );
+
+    // The item is deleted (mutation) → the cache slot is dropped.
+    invalidate(key);
+    expect(getCached(key)).toBeUndefined();
+
+    // The pre-deletion response lands afterwards — it must NOT commit.
+    resolveFetch("pre-delete-data");
+    await slow;
+    expect(getCached(key)).toBeUndefined();
+  });
+
+  it("a revalidate after invalidate issues a fresh request instead of de-duping onto the pre-invalidation one", async () => {
+    const key = "supersede:invalidate:dedup";
+    let resolveStale: (v: string) => void = () => {};
+    void revalidate<string>(
+      key,
+      () => new Promise<string>((r) => (resolveStale = r)),
+    );
+
+    invalidate(key);
+
+    const freshFetcher = vi.fn(async () => "fresh");
+    const got = await revalidate<string>(key, freshFetcher);
+    resolveStale("stale");
+
+    expect(freshFetcher).toHaveBeenCalledTimes(1);
+    expect(got).toBe("fresh");
+    // Let the stale promise settle too — the fresh value must survive it.
+    await Promise.resolve();
+    expect(getCached(key)?.data).toBe("fresh");
+  });
+});
+
+describe("setCached() vs in-flight revalidation", () => {
+  it("a stale in-flight fetch cannot clobber a newer direct write (the mutate() path)", async () => {
+    const key = "supersede:mutate:clobber";
+    setCached(key, "server-v1");
+    let resolveFetch: (v: string) => void = () => {};
+    const slow = revalidate<string>(
+      key,
+      () => new Promise<string>((r) => (resolveFetch = r)),
+    );
+
+    // Optimistic write lands AFTER the fetch started (e.g. following a POST).
+    setCached(key, "user-v2");
+    expect(getCached(key)?.data).toBe("user-v2");
+
+    // The response fetched before the write resolves late — it must be dropped.
+    resolveFetch("server-v1");
+    await slow;
+    expect(getCached(key)?.data).toBe("user-v2");
+  });
+
+  it("an equal-payload refresh does not supersede the in-flight request", async () => {
+    // The #9141 freshness-refresh path (same payload, new timestamp) is not a
+    // data write — an in-flight revalidation may still commit its result.
+    const key = "supersede:equal:noop";
+    setCached(key, { v: 1 });
+    let resolveFetch: (v: { v: number }) => void = () => {};
+    const slow = revalidate<{ v: number }>(
+      key,
+      () => new Promise<{ v: number }>((r) => (resolveFetch = r)),
+    );
+
+    setCached(key, { v: 1 }); // deep-equal → freshness refresh only
+    resolveFetch({ v: 2 });
+    await slow;
+    expect(getCached(key)?.data).toEqual({ v: 2 });
+  });
+});

--- a/packages/ui/src/hooks/useAvailableViews.test.tsx
+++ b/packages/ui/src/hooks/useAvailableViews.test.tsx
@@ -401,7 +401,9 @@ describe("useAvailableViews", () => {
 
     const { result } = renderHook(() => useAvailableViews());
 
-    act(() => result.current.refresh());
+    act(() => {
+      result.current.refresh();
+    });
     freshGui.resolve(response(200, { views: [view("fresh")] }));
     freshTui.resolve(response(200, { views: [] }));
     freshXr.resolve(response(200, { views: [] }));
@@ -436,7 +438,9 @@ describe("useAvailableViews", () => {
     await flushHookEffects();
     expect(result.current.views[0]?.id).toBe("first");
 
-    act(() => result.current.refresh());
+    act(() => {
+      result.current.refresh();
+    });
     await flushHookEffects();
     expect(result.current.views[0]?.id).toBe("second");
 

--- a/packages/ui/src/hooks/useCachedResource.test.tsx
+++ b/packages/ui/src/hooks/useCachedResource.test.tsx
@@ -97,6 +97,43 @@ describe("useCachedResource", () => {
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
+  it("refetch() settles only after the fresh value is committed to the cache", async () => {
+    let resolveInitial: (v: string) => void = () => {};
+    let resolveRefetch: (v: string) => void = () => {};
+    let call = 0;
+    const fetcher = vi.fn(
+      (_signal: AbortSignal) =>
+        new Promise<string>((r) => {
+          call += 1;
+          if (call === 1) resolveInitial = r;
+          else resolveRefetch = r;
+        }),
+    );
+    const { result } = renderHook(() =>
+      useCachedResource("k-refetch-await", fetcher, { staleTime: 10_000 }),
+    );
+    resolveInitial("v1");
+    await waitFor(() => expect(result.current.status).toBe("success"));
+
+    // Consumers (e.g. useViewCatalog's install flow) `await refetch()` before
+    // clearing optimistic UI — the promise must not resolve while the refetch
+    // is still in flight, or they resume against stale data.
+    let settled = false;
+    const pending = result.current.refetch().then(() => {
+      settled = true;
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(settled).toBe(false);
+
+    resolveRefetch("v2");
+    await pending;
+    await waitFor(() => {
+      if (result.current.status === "success") {
+        expect(result.current.data).toBe("v2");
+      }
+    });
+  });
+
   it("revalidates stale data in the background while showing the cached value", async () => {
     let value = "v1";
     const fetcher = vi.fn(async (_signal: AbortSignal) => value);

--- a/packages/ui/src/hooks/useCachedResource.ts
+++ b/packages/ui/src/hooks/useCachedResource.ts
@@ -27,7 +27,7 @@ import {
   useSyncExternalStore,
 } from "react";
 import { getCached, revalidate, setCached, subscribe } from "./resource-cache";
-import type { FetchState, UseFetchDataResult } from "./useFetchData";
+import type { FetchMutator, FetchState } from "./useFetchData";
 
 export interface CachedResourceOptions {
   /**
@@ -41,9 +41,18 @@ export interface CachedResourceOptions {
   persist?: boolean;
 }
 
-// UseFetchDataResult is a discriminated union intersected with helpers, so this
-// is a type intersection (an interface cannot extend a union-based alias).
-export type UseCachedResourceResult<T> = UseFetchDataResult<T> & {
+// FetchState is a discriminated union intersected with helpers, so this is a
+// type intersection (an interface cannot extend a union-based alias). It
+// mirrors UseFetchDataResult except that `refetch` returns a promise.
+export type UseCachedResourceResult<T> = FetchState<T> & {
+  /**
+   * Force a fresh revalidation. Unlike the base `useFetchData` refetch, the
+   * returned promise settles only after the fresh value is committed to the
+   * shared cache (it never rejects — failures land in the hook's error state),
+   * so post-mutation flows can `await refetch()` before clearing optimistic UI.
+   */
+  refetch: () => Promise<void>;
+  mutate: FetchMutator<T>;
   /** True while a background revalidation is running over cached data. */
   isValidating: boolean;
 };
@@ -95,10 +104,10 @@ export function useCachedResource<T>(
   // Run a shared revalidation. `force` issues a fresh request even when one is
   // in-flight (for explicit refetch); background runs de-dup onto it.
   const doRevalidate = useCallback(
-    (force: boolean) => {
-      if (!key) return;
+    (force: boolean): Promise<void> => {
+      if (!key) return Promise.resolve();
       setIsValidating(true);
-      revalidate<T>(
+      return revalidate<T>(
         key,
         () => fetcherRef.current(new AbortController().signal),
         persist,
@@ -124,12 +133,15 @@ export function useCachedResource<T>(
     const snapshot = getCached<T>(key, persist);
     const isFresh = snapshot && Date.now() - snapshot.updatedAt < staleTime;
     if (isFresh) return;
-    doRevalidate(false);
+    void doRevalidate(false);
   }, [key, enabled, persist, staleTime, doRevalidate]);
 
-  const refetch = useCallback(() => {
-    doRevalidate(true);
-  }, [doRevalidate]);
+  // Return the settled-after-commit promise: callers that `await refetch()`
+  // (e.g. useViewCatalog's install flow clearing its optimistic "installing"
+  // state) must not resume before the fresh value is actually in the cache —
+  // a fire-and-forget void here made that await resolve immediately, so the
+  // optimistic state was dropped while the list still showed stale data.
+  const refetch = useCallback(() => doRevalidate(true), [doRevalidate]);
 
   const mutate = useCallback(
     (next: T | ((prev: T) => T)) => {


### PR DESCRIPTION
## What

Three end-to-end-verified defects in the shared stale-while-revalidate cache layer (`packages/ui/src/hooks/resource-cache.ts` + `useCachedResource.ts`) that backs every cached dashboard resource — `views:available` (router + launcher + desktop tabs), the apps catalog, automations feed, trajectories, memory viewer, runtime snapshots. Branch: `fix/ui-state-batch` @ `0636110`, based on current `origin/develop`.

## Bug 1 — `invalidate()` doesn't supersede in-flight revalidations

**Concrete op-sequence → wrong state (probe-executed on the real module before authoring):**
1. `setCached(k, "server-v1")` → `revalidate(k, slowFetcher)` starts
2. `invalidate(k)` (the delete-mutation path) → cache slot empty ✓
3. `slowFetcher` resolves `"pre-delete-data"` → **`getCached(k).data === "pre-delete-data"`** — the invalidated key is resurrected by a response fetched before the deletion.

And the de-dup half: `revalidate(k, slow)` → `invalidate(k)` → `revalidate(k, freshFetcher)` **returned the old in-flight promise** — `freshFetcher` called 0 times, caller received and committed the stale pre-invalidation value.

**Fix:** `invalidate()` bumps the per-key write sequence (stale responses can no longer commit) and drops the `inflight` marker (post-invalidate revalidations issue a fresh request).

## Bug 2 — `setCached()` (the `mutate()` optimistic write) clobbered by a stale in-flight fetch

**Op-sequence → wrong state (probe-executed):** `setCached(k,"server-v1")` → `revalidate(k, slow)` starts → `setCached(k,"user-v2")` (optimistic write after a POST; also every direct page-level write in AutomationsFeed / TrajectoriesView / MemoryViewerView / RuntimeView) → slow fetch resolves `"server-v1"` → **`getCached(k).data === "server-v1"`** — the newer user write silently rolls back. This violates the module's own `requestSeq` docstring: "a slow stale response can never clobber a newer one (last-write-wins)".

**Fix:** a real (non-equal) `setCached()` advances the write sequence. The #9141 equal-payload freshness-refresh path deliberately does **not** bump — pinned by a dedicated test — so background polls keep committing over an equal-data refresh.

## Bug 3 — `refetch()` drops the revalidation promise; awaiting consumers resume against stale data

`useCachedResource().refetch` was fire-and-forget (`() => void`), but `useViewCatalog.get()` really does `await Promise.all([catalogRes.refetch(), installedRes.refetch()])` after `launchApp()` and then clears the entry's optimistic **"installing"** state. Awaiting `[undefined, undefined]` resolves immediately → the launcher card flips back to the stale **"Get"** state mid-refetch instead of "Open". **Fix:** `doRevalidate`/`refetch` return a promise that settles only after the fresh value is committed to the shared cache (never rejects — failures still land in the hook's error state); `UseCachedResourceResult.refetch` is typed `() => Promise<void>`.

## Tests + mutation checks

| Fix | Test | Green | Revert-only-this-fix |
|---|---|---|---|
| 1 invalidate supersede | `src/hooks/resource-cache.write-supersede.test.ts` (pure, no jsdom) — resurrect + stale-dedup cases | ✅ | ❌ 2 failed / 2 passed |
| 2 setCached supersede | same file — mutate-clobber + equal-payload-non-supersede edge | ✅ | ❌ 1 failed / 3 passed |
| 3 refetch promise | `src/hooks/useCachedResource.test.tsx` — "refetch() settles only after the fresh value is committed" (unsettled while in flight, settled after commit) | ✅ | ❌ 1 failed / 5 passed |

Full affected set green: 63/63 across resource-cache.write-supersede / resource-cache / useCachedResource / useAvailableViews / useFetchData / view-catalog, plus downstream cache-consumer page tests (MemoryViewerView mobile-sidebar, AutomationsFeed, DatabaseView) 10/10. `biome check` clean; `typecheck` shows only the pre-existing unrelated `spatial/__e2e__` `iwer` error (identical on clean develop). Test-side note: the now-thenable `refresh()` return leaked into two `act(() => result.current.refresh())` call sites in `useAvailableViews.test.tsx` (an unawaited async `act` contaminated later fake-timer tests) — brace-wrapped both.

## Evidence N/A rows

- Screenshots / video / audit:app — **N/A**: pure store-logic fix in `@elizaos/ui` hooks; no rendered pixel changes (behavioral effect is "cached views/catalog no longer show resurrected/rolled-back data", proven by the deterministic unit sequences above).
- Real-LLM trajectories — **N/A**: no agent/action/prompt/model surface touched.
- Backend logs / DB artifacts — **N/A**: client-side in-memory cache only; no server code touched.

## Non-overlap

Distinct from the shipped utils/i18n/jwt pass (#13175) and from the already-merged view-lifecycle/desktop-dock batch (PR #11966, re-verified at develop tip). Also audited clean this pass (honest ceiling evidence): bounded-view-lru eviction selection, startupReducer, background-history undo/redo, shell-surface-store, notification-store, useNavigationState/useTabSync/usePreviewMode/useViewKinds, persistence normalizers.

[phone-ui]

---
**Authored end-to-end by a Fable-5 agent** (verified 100% claude-fable-5), committed + pushed. Each bug probe-executed as a concrete op-sequence against the real module on develop (→ wrong state) BEFORE authoring. Independently re-verified by main loop: 5-file merge-base diff, 33/33 green (--no-cache, incl. jsdom .tsx), resource-cache.ts mutation reproduced (revert → write-supersede tests red; restore → green). These back EVERY cached dashboard resource (views:available → router/launcher/desktop-tabs, apps catalog, automations, trajectories, memory) — bug 3 is directly in the create→launch demo path (card flips back to stale 'Get' instead of 'Open'). Agent correctly DROPPED bounded-view-lru + view-lifecycle (already fixed via #11966) as dup, + 5 more speculative. — [phone-ui]