### PR TITLE
fix(#12661): make optional-plugin import failures observable, not silently swallowed

### DIFF
--- a/packages/agent/src/api/optional-plugin-fallback.test.ts
+++ b/packages/agent/src/api/optional-plugin-fallback.test.ts
@@ -1,0 +1,261 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { logger } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createOptionalPluginFallback,
+  isModuleNotFoundError,
+  resolveOptionalPluginImportFailure,
+} from "./optional-plugin-fallback.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("isModuleNotFoundError", () => {
+  it("classifies Node ERR_MODULE_NOT_FOUND as module-absent", () => {
+    const err = Object.assign(new Error("nope"), {
+      code: "ERR_MODULE_NOT_FOUND",
+    });
+    expect(isModuleNotFoundError(err)).toBe(true);
+  });
+
+  it("classifies legacy MODULE_NOT_FOUND code as module-absent", () => {
+    const err = Object.assign(new Error("nope"), { code: "MODULE_NOT_FOUND" });
+    expect(isModuleNotFoundError(err)).toBe(true);
+  });
+
+  it("classifies a bundler ResolveMessage (by name) as module-absent", () => {
+    const err = Object.assign(new Error("Cannot find module '@x/y'"), {
+      name: "ResolveMessage",
+    });
+    expect(isModuleNotFoundError(err)).toBe(true);
+  });
+
+  it("classifies a plain 'Cannot find module' message as module-absent", () => {
+    expect(
+      isModuleNotFoundError(
+        new Error("Cannot find module '@elizaos/plugin-x'"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT classify an unrelated runtime error as module-absent", () => {
+    // A plugin that resolved but threw during top-level init: this is drift,
+    // not a benign bundle exclusion.
+    expect(isModuleNotFoundError(new TypeError("boom at init"))).toBe(false);
+    expect(isModuleNotFoundError(new Error("db connection refused"))).toBe(
+      false,
+    );
+    expect(isModuleNotFoundError(null)).toBe(false);
+    expect(isModuleNotFoundError(undefined)).toBe(false);
+  });
+
+  it("treats the plugin package (and its subpaths) being absent as benign when a specifier is given", () => {
+    const specifier = "@elizaos/plugin-mcp";
+    const pkgAbsent = Object.assign(
+      new Error(
+        `Cannot find package '${specifier}' imported from /app/server.ts`,
+      ),
+      { code: "ERR_MODULE_NOT_FOUND" },
+    );
+    expect(isModuleNotFoundError(pkgAbsent, specifier)).toBe(true);
+
+    const subpathAbsent = Object.assign(
+      new Error(`Cannot find module '${specifier}/routes'`),
+      { code: "ERR_MODULE_NOT_FOUND" },
+    );
+    expect(isModuleNotFoundError(subpathAbsent, specifier)).toBe(true);
+  });
+
+  it("does NOT treat a broken transitive dep of a PRESENT plugin as benign (codex P2)", () => {
+    // The plugin package resolved, but one of ITS imports is missing. Node/Bun
+    // still report ERR_MODULE_NOT_FOUND — but this is drift, not absence.
+    const specifier = "@elizaos/plugin-mcp";
+    const transitiveMissing = Object.assign(
+      new Error(
+        `Cannot find package 'some-transitive-dep' imported from ${specifier}/dist/index.js`,
+      ),
+      { code: "ERR_MODULE_NOT_FOUND" },
+    );
+    expect(isModuleNotFoundError(transitiveMissing, specifier)).toBe(false);
+  });
+
+  it("preserves legacy 'any resolution error is absence' behavior when no specifier is given", () => {
+    const err = Object.assign(new Error("Cannot find module 'whatever'"), {
+      code: "ERR_MODULE_NOT_FOUND",
+    });
+    expect(isModuleNotFoundError(err)).toBe(true);
+  });
+});
+
+describe("createOptionalPluginFallback", () => {
+  it("returns handlers that resolve to false so route dispatch falls through", () => {
+    const api = createOptionalPluginFallback<{
+      handleFoo: () => boolean;
+    }>("plugin-foo", false);
+    expect(api.handleFoo()).toBe(false);
+  });
+
+  it("is NOT thenable so a promise resolving to it settles (codex P1: no route hang)", async () => {
+    const api = createOptionalPluginFallback<Record<string, unknown>>(
+      "plugin-foo",
+      false,
+    );
+    // Promise assimilation must not treat the fallback as a thenable.
+    expect((api as { then?: unknown }).then).toBeUndefined();
+    expect((api as { catch?: unknown }).catch).toBeUndefined();
+    expect((api as { finally?: unknown }).finally).toBeUndefined();
+    // The real failure mode: awaiting a promise that resolves to the fallback
+    // must settle promptly rather than hang forever.
+    const settled = await Promise.race([
+      Promise.resolve(api).then(() => "settled"),
+      new Promise((resolve) => setTimeout(() => resolve("timeout"), 50)),
+    ]);
+    expect(settled).toBe("settled");
+  });
+
+  it("returns undefined for symbol keys (stays an inert non-iterable object)", () => {
+    const api = createOptionalPluginFallback<Record<PropertyKey, unknown>>(
+      "plugin-foo",
+      true,
+    );
+    expect(
+      (api as Record<symbol, unknown>)[Symbol.iterator as symbol],
+    ).toBeUndefined();
+  });
+
+  it("stays silent on handler access when observeAccess is false (module absent)", () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const api = createOptionalPluginFallback<Record<string, () => boolean>>(
+      "plugin-absent",
+      false,
+    );
+    // benign mobile-bundle exclusion: accessing handlers must NOT warn
+    api.handleA();
+    api.handleB();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns once per distinct absent handler when observeAccess is true (drift)", () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const api = createOptionalPluginFallback<Record<string, () => boolean>>(
+      "plugin-broken",
+      true,
+    );
+    // A present-but-broken plugin: dispatch reaches for a handler that the
+    // Proxy cannot provide -> observable drift signal, deduped per name.
+    api.handleRenamed();
+    api.handleRenamed();
+    api.handleOther();
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn.mock.calls[0]?.[0]).toContain("plugin-broken");
+    expect(warn.mock.calls[0]?.[0]).toContain("handleRenamed");
+    expect(warn.mock.calls[0]?.[0]).toContain("drift");
+  });
+});
+
+describe("server.ts no longer silently swallows optional-plugin drift (grep guard)", () => {
+  const serverSrc = readFileSync(
+    fileURLToPath(new URL("./server.ts", import.meta.url)),
+    "utf8",
+  );
+
+  it("has removed the silent no-op Proxy fallback from executable paths", () => {
+    // The old fabricated fallback `new Proxy({}, { get: () => () => false })`
+    // hid present-but-broken plugins. It must not reappear inline in server.ts.
+    expect(serverSrc).not.toContain("get: () => () => false");
+  });
+
+  it("routes optional-plugin import failures through the observable helper", () => {
+    expect(serverSrc).toContain("resolveOptionalPluginImportFailure");
+    expect(serverSrc).toContain("./optional-plugin-fallback.ts");
+  });
+});
+
+describe("resolveOptionalPluginImportFailure", () => {
+  it("module-not-found -> debug (not warn), quiet fallthrough fallback", () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const debug = vi.spyOn(logger, "debug").mockImplementation(() => {});
+    const err = Object.assign(
+      new Error("Cannot find module '@elizaos/plugin-x'"),
+      {
+        code: "ERR_MODULE_NOT_FOUND",
+      },
+    );
+
+    const api = resolveOptionalPluginImportFailure<{
+      handleX: () => boolean;
+    }>("@elizaos/plugin-x", err, "@elizaos/plugin-x");
+
+    // dispatch still falls through to 404 without erroring
+    expect(api.handleX()).toBe(false);
+    expect(debug).toHaveBeenCalledTimes(1);
+    // benign exclusion must NOT escalate to warn, and handler access stays quiet
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("broken transitive dep of a present plugin -> warn (drift), not quiet debug", () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const debug = vi.spyOn(logger, "debug").mockImplementation(() => {});
+    const err = Object.assign(
+      new Error(
+        "Cannot find package 'left-pad' imported from @elizaos/plugin-mcp/dist/index.js",
+      ),
+      { code: "ERR_MODULE_NOT_FOUND" },
+    );
+
+    const api = resolveOptionalPluginImportFailure<{
+      handleMcp: () => boolean;
+    }>("@elizaos/plugin-mcp", err, "@elizaos/plugin-mcp");
+
+    // still fails closed to 404 (no 500)...
+    expect(api.handleMcp()).toBe(false);
+    // ...but the broken plugin is now observable, not silently debug-logged
+    expect(
+      warn.mock.calls.some((c) => String(c[0]).includes("failed to load")),
+    ).toBe(true);
+    expect(debug).not.toHaveBeenCalled();
+  });
+
+  it("result is awaitable end-to-end without hanging (module-absent path)", async () => {
+    vi.spyOn(logger, "debug").mockImplementation(() => {});
+    const err = Object.assign(
+      new Error("Cannot find module '@elizaos/plugin-z'"),
+      {
+        code: "ERR_MODULE_NOT_FOUND",
+      },
+    );
+    const api = await Promise.resolve(
+      resolveOptionalPluginImportFailure<{ handleZ: () => boolean }>(
+        "@elizaos/plugin-z",
+        err,
+        "@elizaos/plugin-z",
+      ),
+    );
+    expect(api.handleZ()).toBe(false);
+  });
+
+  it("present-but-broken load error -> warn (observable drift), still fails closed to 404", () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const err = new TypeError("plugin threw during init");
+
+    const api = resolveOptionalPluginImportFailure<{
+      handleY: () => boolean;
+    }>("@elizaos/plugin-y", err);
+
+    // route dispatch still falls through (no 500)...
+    expect(api.handleY()).toBe(false);
+    // ...but the regression is now visible: one warn for the failed load,
+    // plus a warn for the accessed-but-absent handler (observeAccess=true).
+    expect(warn.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(
+      warn.mock.calls.some((c) => String(c[0]).includes("failed to load")),
+    ).toBe(true);
+    expect(
+      warn.mock.calls.some((c) => String(c[0]).includes("@elizaos/plugin-y")),
+    ).toBe(true);
+  });
+});

--- a/packages/agent/src/api/optional-plugin-fallback.ts
+++ b/packages/agent/src/api/optional-plugin-fallback.ts
@@ -1,0 +1,172 @@
+// Observability boundary for optional-plugin dynamic imports (#12089 item 11 /
+// #12661). Route handlers pull optional plugin APIs via dynamic import; on the
+// mobile agent bundle many desktop/cloud plugins are deliberately excluded, so
+// their import REJECTS with a module-resolution error. The host must NOT let
+// that rejection 500 every renderer poll, so it falls back to a no-op API whose
+// handlers return `false` (route-dispatch then falls through to the normal 404).
+//
+// The old fallback swallowed BOTH failure modes into one silent debug line +
+// `new Proxy({}, { get: () => () => false })`:
+//   1. module-absent  — expected on the mobile bundle (benign, quiet fallthrough)
+//   2. present-but-broken / renamed-export — a real regression (a plugin that
+//      SHOULD load throws at import time, or an accessed handler export was
+//      removed/renamed). Under the old Proxy this was indistinguishable from (1):
+//      the route silently 404s forever and the drift is invisible.
+//
+// This module keeps the fail-safe fallthrough behavior but makes mode (2)
+// OBSERVABLE: genuine load errors warn (not debug), and the fallback Proxy warns
+// once per accessed-but-absent handler name so a renamed/removed export surfaces
+// instead of returning a silent `false`.
+
+import { logger } from "@elizaos/core";
+
+/** Node/Bun error codes emitted when a module cannot be resolved. */
+function isModuleResolutionError(err: unknown): boolean {
+  if (err == null) return false;
+  const code = (err as { code?: unknown }).code;
+  if (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND") {
+    return true;
+  }
+  const name = (err as { name?: unknown }).name;
+  if (name === "ResolveMessage") return true;
+  const message = (err as { message?: unknown }).message;
+  if (typeof message === "string") {
+    // Cover Bun's ResolveMessage and Node's loader text that don't set `code`.
+    return (
+      message.startsWith("Cannot find module") ||
+      message.includes("Cannot find package") ||
+      /Cannot find module ['"]/.test(message)
+    );
+  }
+  return false;
+}
+
+/**
+ * True only when the resolution failure is about the OPTIONAL PLUGIN PACKAGE
+ * ITSELF being absent from the bundle — the EXPECTED mobile-bundle exclusion
+ * (quiet debug + fallthrough).
+ *
+ * A present-but-broken plugin whose own top-level/transitive import is missing
+ * ALSO reports `ERR_MODULE_NOT_FOUND` (e.g. `Cannot find package 'x' imported
+ * from @elizaos/plugin-mcp/...`). Treating every module-resolution error as
+ * "plugin absent" would silence exactly the drift this module exists to surface,
+ * so we require the error to name the plugin specifier as the UNRESOLVED module
+ * — not merely mention it as the importer. When the failing module isn't the
+ * plugin package itself (a transitive dep), this returns false so the caller
+ * escalates to an observable warning.
+ */
+export function isModuleNotFoundError(
+  err: unknown,
+  specifier?: string,
+): boolean {
+  if (!isModuleResolutionError(err)) return false;
+  if (!specifier) return true; // no specifier context: preserve legacy behavior
+
+  const message = (err as { message?: unknown }).message;
+  if (typeof message !== "string") return true;
+
+  // Node/Bun phrase the failure as:
+  //   Cannot find module '<unresolved>' [imported from '<importer>']
+  //   Cannot find package '<unresolved>' imported from <importer>
+  // We only treat it as a benign absence when the UNRESOLVED module (the quoted
+  // name right after "Cannot find module/package") IS the plugin package itself
+  // (or one of its own subpath exports). If the plugin merely appears as the
+  // IMPORTER of some OTHER missing module, that's a broken transitive dep in a
+  // PRESENT plugin -> drift, not absence.
+  const unresolvedMatch = message.match(
+    /Cannot find (?:module|package) ['"]([^'"]+)['"]/,
+  );
+  if (unresolvedMatch) {
+    const unresolved = unresolvedMatch[1];
+    return unresolved === specifier || unresolved.startsWith(`${specifier}/`);
+  }
+
+  // No quoted unresolved module in the text (unusual): fall back to treating a
+  // bare mention of the specifier as absence, but only when it is not framed as
+  // the importer of some other missing module.
+  if (/imported from/.test(message)) return false;
+  return message.includes(specifier);
+}
+
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Build the no-op fallback API returned when an optional plugin is unavailable.
+ *
+ * Handlers still resolve to `() => false` so route-dispatch
+ * (`if (await handleX(...)) return;`) falls through to the normal 404 instead of
+ * 500ing — but the FIRST access of each distinct handler name emits an
+ * observable warning tagged as drift when `observeAccess` is true. That way a
+ * present-but-renamed export (mode 2) is surfaced, while the benign
+ * module-absent case (mode 1, `observeAccess=false`) stays silent.
+ */
+export function createOptionalPluginFallback<T>(
+  key: string,
+  observeAccess: boolean,
+): T {
+  const warned = new Set<string>();
+  return new Proxy(
+    {},
+    {
+      get: (_target, prop) => {
+        // CRITICAL: this fallback is returned from `async`/Promise catch paths
+        // (getOptionalPluginApi, getWalletApi). When a promise resolves with an
+        // object, the runtime reads its `then` to test for thenable assimilation.
+        // If we returned a callable for `then`, the value would be treated as a
+        // thenable and the awaiting promise would NEVER settle — every affected
+        // optional-plugin route would hang instead of falling through to 404.
+        // Return undefined for promise-assimilation keys and any symbol key
+        // (Symbol.toPrimitive, Symbol.iterator, …) so the object stays an inert,
+        // non-thenable no-op API.
+        if (
+          prop === "then" ||
+          prop === "catch" ||
+          prop === "finally" ||
+          typeof prop === "symbol"
+        ) {
+          return undefined;
+        }
+        if (observeAccess && !warned.has(prop)) {
+          warned.add(prop);
+          logger.warn(
+            `[eliza-api] optional plugin '${key}' loaded but handler '${prop}' ` +
+              `is absent (export missing/renamed?); route dispatch will 404. ` +
+              `This is a drift signal, not an expected mobile-bundle exclusion.`,
+          );
+        }
+        return () => false;
+      },
+    },
+  ) as T;
+}
+
+/**
+ * Classify an optional-plugin import rejection and return the appropriate no-op
+ * fallback. Module-not-found → quiet fallthrough (expected bundle exclusion).
+ * Any OTHER error → the plugin should have loaded but threw: warn (observable
+ * drift) and hand back a fallback whose handler access is also observable.
+ */
+export function resolveOptionalPluginImportFailure<T>(
+  key: string,
+  err: unknown,
+  specifier?: string,
+): T {
+  // Prefer the package specifier for the absence check so a broken transitive
+  // import inside a PRESENT plugin isn't mistaken for a benign bundle exclusion.
+  if (isModuleNotFoundError(err, specifier ?? key)) {
+    logger.debug(
+      `[eliza-api] optional plugin '${key}' not in this bundle: ${describeError(err)}`,
+    );
+    return createOptionalPluginFallback<T>(key, false);
+  }
+  // Present-but-broken: a plugin that resolved but failed to initialize (syntax
+  // error, failed top-level init, missing transitive dep). Under the old code
+  // this was a silent debug line and every route 404'd invisibly. Surface it.
+  logger.warn(
+    `[eliza-api] optional plugin '${key}' failed to load (present but errored): ` +
+      `${describeError(err)}. Routes for this plugin will 404 until fixed.`,
+  );
+  return createOptionalPluginFallback<T>(key, true);
+}

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -152,16 +152,32 @@ async function getX402Plugin(): Promise<X402PluginModule | null> {
   return x402PluginModulePromise;
 }
 
+// Package specifier per optional-plugin key. Kept alongside the import table so
+// the unavailable-plugin fallback can key its "is this the plugin package itself
+// that's absent (benign) vs a broken transitive import (drift)" decision on the
+// real specifier rather than the short key. See optional-plugin-fallback.ts.
+const optionalPluginSpecifiers = {
+  capacitor: "@elizaos/plugin-capacitor-bridge",
+  computerUse: "@elizaos/plugin-computeruse",
+  cloud: "@elizaos/plugin-elizacloud",
+  imessage: "@elizaos/plugin-imessage",
+  mcp: "@elizaos/plugin-mcp",
+  signal: "@elizaos/plugin-signal",
+  streaming: "@elizaos/plugin-streaming",
+  whatsapp: "@elizaos/plugin-whatsapp",
+  workflow: "@elizaos/plugin-workflow",
+} as const;
+
 const optionalPluginImports = {
-  capacitor: () => importOptionalPlugin("@elizaos/plugin-capacitor-bridge"),
-  computerUse: () => importOptionalPlugin("@elizaos/plugin-computeruse"),
-  cloud: () => importOptionalPlugin("@elizaos/plugin-elizacloud"),
-  imessage: () => importOptionalPlugin("@elizaos/plugin-imessage"),
-  mcp: () => importOptionalPlugin("@elizaos/plugin-mcp"),
-  signal: () => importOptionalPlugin("@elizaos/plugin-signal"),
-  streaming: () => importOptionalPlugin("@elizaos/plugin-streaming"),
-  whatsapp: () => importOptionalPlugin("@elizaos/plugin-whatsapp"),
-  workflow: () => importOptionalPlugin("@elizaos/plugin-workflow"),
+  capacitor: () => importOptionalPlugin(optionalPluginSpecifiers.capacitor),
+  computerUse: () => importOptionalPlugin(optionalPluginSpecifiers.computerUse),
+  cloud: () => importOptionalPlugin(optionalPluginSpecifiers.cloud),
+  imessage: () => importOptionalPlugin(optionalPluginSpecifiers.imessage),
+  mcp: () => importOptionalPlugin(optionalPluginSpecifiers.mcp),
+  signal: () => importOptionalPlugin(optionalPluginSpecifiers.signal),
+  streaming: () => importOptionalPlugin(optionalPluginSpecifiers.streaming),
+  whatsapp: () => importOptionalPlugin(optionalPluginSpecifiers.whatsapp),
+  workflow: () => importOptionalPlugin(optionalPluginSpecifiers.workflow),
 };
 
 type LocalInferenceServerApi = LocalInferenceRouteApi &
@@ -188,26 +204,25 @@ async function getOptionalPluginApi<T>(
   try {
     return (await optionalPluginImports[key]()) as T;
   } catch (err) {
-    // The plugin is optional and not in this bundle (on mobile, many
-    // desktop/cloud plugins — cloud, whatsapp, wallet-adjacent, mcp,
-    // streaming, … — are excluded). Its dynamic import REJECTS with a
-    // ResolveMessage; without this catch that rejection propagates to the
-    // top-level request handler as a 500 on EVERY renderer poll of the
-    // plugin's routes. Return a Proxy of no-op handlers so route-dispatch
-    // blocks (`if (await handleX(...)) return;`) fall through to the normal
-    // 404/fallback instead of erroring. On desktop/server the import succeeds,
-    // so this branch never runs there.
-    logger.debug(
-      `[eliza-api] optional plugin '${key}' unavailable in this bundle: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
+    // The plugin is optional and (on mobile) many desktop/cloud plugins — cloud,
+    // whatsapp, wallet-adjacent, mcp, streaming, … — are excluded, so their
+    // dynamic import REJECTS with a module-resolution error. Without this catch
+    // that rejection propagates to the top-level request handler as a 500 on
+    // EVERY renderer poll of the plugin's routes. We fall back to a no-op API so
+    // route-dispatch blocks (`if (await handleX(...)) return;`) fall through to
+    // the normal 404 instead of erroring.
+    //
+    // resolveOptionalPluginImportFailure distinguishes the EXPECTED
+    // module-absent case (quiet debug + fallthrough) from a present-but-broken
+    // plugin (a package that resolved but threw at init, or whose accessed
+    // export was renamed/removed). The latter is a drift regression the old
+    // silent Proxy hid — it now warns so a broken/renamed handler is observable
+    // instead of silently 404ing forever. See optional-plugin-fallback.ts.
+    return resolveOptionalPluginImportFailure<T>(
+      String(key),
+      err,
+      optionalPluginSpecifiers[key],
     );
-    return new Proxy(
-      {},
-      {
-        get: () => () => false,
-      },
-    ) as T;
   }
 }
 type BrowserBridgeKind = BrowserPluginModule["BROWSER_BRIDGE_KINDS"][number];
@@ -252,18 +267,14 @@ function getWalletApi(): Promise<typeof import("@elizaos/plugin-wallet")> {
     typeof import("@elizaos/plugin-wallet")
   >("@elizaos/plugin-wallet").catch((err) => {
     // plugin-wallet is desktop/cloud-only; on mobile it is not in the bundle so
-    // this import REJECTS. Cache a no-op proxy so /api/wallet/* falls through to
-    // 404 instead of 500ing on every renderer poll. Desktop imports succeed, so
-    // this never runs there.
-    logger.debug(
-      `[eliza-api] plugin-wallet unavailable in this bundle: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-    return new Proxy(
-      {},
-      { get: () => () => false },
-    ) as typeof import("@elizaos/plugin-wallet");
+    // this import REJECTS. Cache a no-op fallback so /api/wallet/* falls through
+    // to 404 instead of 500ing on every renderer poll. Desktop imports succeed,
+    // so this branch never runs there. resolveOptionalPluginImportFailure keeps
+    // the benign module-absent case quiet while surfacing a present-but-broken
+    // plugin-wallet load (drift) as an observable warning.
+    return resolveOptionalPluginImportFailure<
+      typeof import("@elizaos/plugin-wallet")
+    >("@elizaos/plugin-wallet", err, "@elizaos/plugin-wallet");
   });
   return walletApiPromise;
 }
@@ -382,6 +393,7 @@ import {
   loadLocalInferenceVoiceRouteApi,
 } from "./local-inference-server-api.ts";
 import { pushWithBatchEvict } from "./memory-bounds.ts";
+import { resolveOptionalPluginImportFailure } from "./optional-plugin-fallback.ts";
 import {
   buildPluginDiagnosticEntry,
   resolveWalletDiagnosticStatus,


### PR DESCRIPTION
## What / Why

Closes #12661 — arch-audit self-registration #12089 item 11: *server.ts centrally enumerates nine optional plugins' handler APIs with silent Proxy fallback.*

`packages/agent/src/api/server.ts` loads optional plugins' handler APIs via `getOptionalPluginApi` / `getWalletApi`. On an import rejection it returned a **silent** no-op `new Proxy({}, { get: () => () => false })` at `debug` level. That collapsed two distinct failure modes into one invisible fallthrough:

1. **module-absent** — expected mobile-bundle exclusion (benign).
2. **present-but-broken / renamed export** — a real regression: a plugin that *should* load throws at init, or an accessed handler export was removed/renamed. Under the old Proxy this silently 404'd forever with no signal (the drift the audit flagged).

## Change

New `packages/agent/src/api/optional-plugin-fallback.ts` owns this boundary as an explicit, tested **legacy host-owned fallback**:

- `isModuleNotFoundError(err, specifier)` — only benign when the **unresolved** module *is the plugin package itself* (or a subpath export). A broken **transitive dep** of a *present* plugin also reports `ERR_MODULE_NOT_FOUND` but names the plugin as the *importer*, not the missing module → classified as **drift** and warned. (Caught in review.)
- `resolveOptionalPluginImportFailure` — module-absent → `debug` + quiet fallthrough; any other error → `logger.warn` (observable drift) + a fallback whose accessed-but-absent handler names warn once each.
- The fallback Proxy is **non-thenable**: it returns `undefined` for `then`/`catch`/`finally` and symbol keys, so a promise resolving to it **settles** instead of hanging every affected optional-plugin route (promise-assimilation trap — caught in review).

`server.ts` gains an `optionalPluginSpecifiers` map so the absence check keys on the real package specifier. **Behavior preserved:** routes still fail closed to 404 (never 500) when a plugin is absent.

## Tests / Evidence

`packages/agent/src/api/optional-plugin-fallback.test.ts` — **19 cases**, all green:
- classification: absent package / subpath export / transitive-dep drift / legacy no-specifier / ResolveMessage / non-resolution runtime error
- `resolveOptionalPluginImportFailure`: module-absent → debug (no warn); broken transitive dep → warn (drift); end-to-end awaitable without hanging
- observable-drift warnings deduped per handler name; silent when `observeAccess=false`
- **non-thenable settlement** regression (P1): `then`/`catch`/`finally` are `undefined`, `Promise.resolve(fallback)` settles < 50ms
- **grep guard**: `get: () => () => false` is gone from `server.ts` executable paths, and failures route through the observable helper

```
Test Files  1 passed (1)
     Tests  19 passed (19)
```

- `tsgo --noEmit -p packages/agent/tsconfig.json`: baseline-clean (9 pre-existing unbuilt-optional-plugin `TS2307`s only; **zero new errors**; new file zero errors)
- `biome check` on all 3 touched files: clean
- codex review: clean (P1 non-thenable proxy + P2 transitive-dep classification + P2 formatting all addressed)

— [sol-orch]