### PR TITLE
fix(core): make stage-1 provider exclusions skip execution, not just render

### DIFF
--- a/packages/core/src/__tests__/compose-state-trajectory-recording.test.ts
+++ b/packages/core/src/__tests__/compose-state-trajectory-recording.test.ts
@@ -1,0 +1,182 @@
+/**
+ * composeState under trajectory recording (`metadata.trajectoryStepId` set on
+ * every inbound message when the trajectories feature is active): recording
+ * forces provider re-execution so accesses are logged, but must not change
+ * what providers observe — the turn's cached state still reaches them.
+ * Regression: blanking it made RECENT_MESSAGES' turn-recompose gate read
+ * stage-1 on every pass, so cross-room interactions never composed on
+ * trajectory-recording runtimes. Real AgentRuntime + the real provider over
+ * a minimal in-memory adapter; no model, no database server.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { recentMessagesProvider } from "../features/basic-capabilities/providers/recentMessages";
+import { AgentRuntime } from "../runtime";
+import {
+	ChannelType,
+	type Character,
+	type IDatabaseAdapter,
+	type Memory,
+	type Provider,
+	type State,
+	type UUID,
+} from "../types";
+
+const ROOM_ID = "11111111-1111-1111-1111-111111111111" as UUID;
+const OTHER_ROOM_ID = "11111111-1111-1111-1111-222222222222" as UUID;
+const USER_ID = "22222222-2222-2222-2222-222222222222" as UUID;
+
+function makeRecordedMessage(id: string, text = "gm"): Memory {
+	return {
+		id: id as UUID,
+		entityId: USER_ID,
+		roomId: ROOM_ID,
+		content: { text, source: "discord" },
+		metadata: { type: "message", trajectoryStepId: "traj-step-1" },
+	};
+}
+
+describe("composeState under trajectory recording", () => {
+	it("still hands providers the turn's cached state, so the planner recompose fetches cross-room interactions", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "Agent" } as Character,
+		});
+		const agentEntity = {
+			id: runtime.agentId,
+			agentId: runtime.agentId,
+			names: ["Agent"],
+			components: [],
+		};
+		const userEntity = {
+			id: USER_ID,
+			agentId: runtime.agentId,
+			names: ["User"],
+			components: [],
+		};
+		const getRoomsForParticipants = vi.fn(async () => [
+			ROOM_ID,
+			OTHER_ROOM_ID,
+		]);
+		const getMemoriesByRoomIds = vi.fn(async () => [
+			{
+				id: "cross-1" as UUID,
+				agentId: runtime.agentId,
+				roomId: OTHER_ROOM_ID,
+				entityId: USER_ID,
+				createdAt: 500,
+				content: { text: "the blue key is under the mat" },
+			} as Memory,
+		]);
+		runtime.registerDatabaseAdapter({
+			getRoomsByIds: async () => [
+				{
+					id: ROOM_ID,
+					agentId: runtime.agentId,
+					source: "discord",
+					type: ChannelType.GROUP,
+					metadata: {},
+				},
+			],
+			getEntitiesForRooms: async () => [
+				{ roomId: ROOM_ID, entities: [agentEntity, userEntity] },
+			],
+			getEntitiesByIds: async (ids: UUID[]) =>
+				[agentEntity, userEntity].filter((e) => ids.includes(e.id)),
+			getMemories: async () => [
+				{
+					id: "msg-1" as UUID,
+					agentId: runtime.agentId,
+					roomId: ROOM_ID,
+					entityId: USER_ID,
+					createdAt: 1000,
+					content: { text: "hello agent", source: "discord" },
+				} as Memory,
+			],
+			getRoomsForParticipants,
+			getMemoriesByRoomIds,
+		} as unknown as IDatabaseAdapter);
+		runtime.registerProvider(recentMessagesProvider);
+
+		const message = makeRecordedMessage("cccccccc-cccc-cccc-cccc-cccccccccccc");
+
+		// Stage-1 compose: first pass of the turn, lean — no cross-room fetch.
+		const stage1State = await runtime.composeState(
+			message,
+			["RECENT_MESSAGES"],
+			true,
+			false,
+		);
+		expect(getRoomsForParticipants).not.toHaveBeenCalled();
+		expect(getMemoriesByRoomIds).not.toHaveBeenCalled();
+		expect(stage1State.values?.recentMessageInteractions).toBe("");
+
+		// Planner recompose: RECENT_MESSAGES is already in the turn's cached
+		// state, so its recompose gate must see it — trajectory recording
+		// included — and run the cross-room interactions fetch.
+		const plannerState = await runtime.composeState(
+			message,
+			["RECENT_MESSAGES"],
+			true,
+			false,
+			["RECENT_MESSAGES"],
+		);
+		expect(getMemoriesByRoomIds).toHaveBeenCalledWith({
+			tableName: "messages",
+			roomIds: [OTHER_ROOM_ID],
+			limit: 20,
+		});
+		expect(plannerState.values?.recentMessageInteractions).toContain(
+			"the blue key is under the mat",
+		);
+	});
+
+	it("re-executes cached providers outside the refresh list so their accesses are logged", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "Agent" } as Character,
+		});
+		let factsRuns = 0;
+		const seenCachedProviders: string[][] = [];
+		const facts: Provider = {
+			name: "FACTS",
+			get: async (_runtime, _message, state: State) => {
+				factsRuns += 1;
+				seenCachedProviders.push(
+					Object.keys(
+						(state?.data?.providers as Record<string, unknown>) ?? {},
+					),
+				);
+				return { text: `FACTS#${factsRuns}`, values: {}, data: {} };
+			},
+		};
+		const recent: Provider = {
+			name: "RECENT_MESSAGES",
+			get: async () => ({ text: "recent", values: {}, data: {} }),
+		};
+		runtime.registerProvider(facts);
+		runtime.registerProvider(recent);
+
+		const message = makeRecordedMessage("dddddddd-dddd-dddd-dddd-dddddddddddd");
+		await runtime.composeState(
+			message,
+			["FACTS", "RECENT_MESSAGES"],
+			true,
+			false,
+		);
+		const plannerState = await runtime.composeState(
+			message,
+			["FACTS", "RECENT_MESSAGES"],
+			true,
+			false,
+			["RECENT_MESSAGES"],
+		);
+
+		// Recording keeps the refresh-reuse shortcut off: FACTS ran twice (its
+		// access is in the step's log) and its second run observed the turn's
+		// cached state from the first pass.
+		expect(factsRuns).toBe(2);
+		expect(seenCachedProviders[0]).toEqual([]);
+		expect(seenCachedProviders[1]).toEqual(
+			expect.arrayContaining(["FACTS", "RECENT_MESSAGES"]),
+		);
+		expect(plannerState.text).toContain("FACTS#2");
+	});
+});

--- a/packages/core/src/__tests__/stage1-provider-execution.test.ts
+++ b/packages/core/src/__tests__/stage1-provider-execution.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Proves the Stage-1 provider exclusions are EXECUTION exclusions, not just
+ * render exclusions: `stage1ResponseStateProviderNames` subtracts the
+ * stage-1-excluded providers from the compose include list (so ENTITIES /
+ * CURRENT_TIME never run for a turn that dies at Stage 1), while the planner
+ * pass still composes them via composeState's cached-state merge. Uses a real
+ * in-memory AgentRuntime with call-counting providers; no database or model.
+ */
+import { describe, expect, it } from "vitest";
+import { AgentRuntime } from "../runtime";
+import { stage1ResponseStateProviderNames } from "../services/message";
+import type {
+	Character,
+	IAgentRuntime,
+	Memory,
+	Provider,
+	UUID,
+} from "../types";
+
+const ROOM_ID = "11111111-1111-1111-1111-111111111111" as UUID;
+const ENTITY_ID = "22222222-2222-2222-2222-222222222222" as UUID;
+
+function makeMessage(id: string, text = "gm"): Memory {
+	return {
+		id: id as UUID,
+		entityId: ENTITY_ID,
+		roomId: ROOM_ID,
+		content: { text },
+	};
+}
+
+/** Provider whose text changes on every run, so reuse vs re-run is observable. */
+function countingProvider(name: string): {
+	provider: Provider;
+	calls: () => number;
+} {
+	let n = 0;
+	return {
+		provider: {
+			name,
+			get: async () => {
+				n += 1;
+				return { text: `${name}#${n}`, values: {}, data: {} };
+			},
+		},
+		calls: () => n,
+	};
+}
+
+describe("stage1ResponseStateProviderNames", () => {
+	it("subtracts the stage-1 exclusions from the compose include list", () => {
+		const runtime = { providers: [] } as unknown as IAgentRuntime;
+		const names = stage1ResponseStateProviderNames(
+			runtime,
+			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1"),
+		);
+
+		expect(names).not.toContain("ENTITIES");
+		expect(names).not.toContain("CURRENT_TIME");
+		expect(names).not.toContain("DOCUMENTS");
+		// Stage 1 still composes what it renders and routes on.
+		expect(names).toContain("RECENT_MESSAGES");
+		expect(names).toContain("FACTS");
+		expect(names).toContain("ATTACHMENTS");
+	});
+
+	it("keeps CURRENT_TIME when the user is asking about the time", () => {
+		const runtime = { providers: [] } as unknown as IAgentRuntime;
+		const names = stage1ResponseStateProviderNames(
+			runtime,
+			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2", "what time is it?"),
+		);
+
+		expect(names).toContain("CURRENT_TIME");
+		expect(names).not.toContain("ENTITIES");
+	});
+
+	it("includes always-on plugin providers unless they are stage-1-excluded", () => {
+		const runtime = {
+			providers: [
+				{
+					name: "PLUGIN_CTX",
+					alwaysInResponseState: true,
+					get: async () => ({}),
+				},
+				{
+					name: "DOCUMENTS",
+					alwaysInResponseState: true,
+					get: async () => ({}),
+				},
+			],
+		} as unknown as IAgentRuntime;
+		const names = stage1ResponseStateProviderNames(
+			runtime,
+			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3"),
+		);
+
+		expect(names).toContain("PLUGIN_CTX");
+		expect(names).not.toContain("DOCUMENTS");
+	});
+
+	it("skips excluded providers at stage 1 and defers them to the planner recompose", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "stage1-exec-test" } as Character,
+		});
+		const entities = countingProvider("ENTITIES");
+		const currentTime = countingProvider("CURRENT_TIME");
+		const facts = countingProvider("FACTS");
+		const recent = countingProvider("RECENT_MESSAGES");
+		for (const p of [entities, currentTime, facts, recent]) {
+			runtime.registerProvider(p.provider);
+		}
+
+		const message = makeMessage("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+		const stage1Names = stage1ResponseStateProviderNames(runtime, message);
+
+		// Stage-1 compose: excluded providers never execute, so a turn that
+		// ends at Stage 1 (group noise → IGNORE) does none of their work and
+		// its prompt footprint drops accordingly.
+		const stage1State = await runtime.composeState(
+			message,
+			stage1Names,
+			true,
+			false,
+		);
+		expect(entities.calls()).toBe(0);
+		expect(currentTime.calls()).toBe(0);
+		expect(facts.calls()).toBe(1);
+		expect(recent.calls()).toBe(1);
+		expect(stage1State.text).not.toContain("ENTITIES#");
+		expect(stage1State.text).not.toContain("CURRENT_TIME#");
+		expect(stage1State.text).toContain("FACTS#1");
+
+		// Planner recompose (mirrors selectV5PlannerStateProviderNames re-adding
+		// the core response providers, with RECENT_MESSAGES refreshed): the
+		// excluded providers are not in the turn cache, so they run now — once —
+		// and reach the planner prompt; the already-composed FACTS is reused.
+		const plannerState = await runtime.composeState(
+			message,
+			[...stage1Names, "ENTITIES", "CURRENT_TIME"],
+			true,
+			false,
+			["RECENT_MESSAGES"],
+		);
+		expect(entities.calls()).toBe(1);
+		expect(currentTime.calls()).toBe(1);
+		expect(facts.calls()).toBe(1);
+		expect(recent.calls()).toBe(2);
+		expect(plannerState.text).toContain("ENTITIES#1");
+		expect(plannerState.text).toContain("CURRENT_TIME#1");
+		expect(plannerState.text).toContain("FACTS#1");
+		expect(plannerState.text).toContain("RECENT_MESSAGES#2");
+	});
+});

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
@@ -43,6 +43,7 @@ function makeRuntime(
 		metadata?: Record<string, unknown>;
 		conversationLength?: number;
 	} = {},
+	overrides: Record<string, unknown> = {},
 ): IAgentRuntime {
 	return {
 		agentId: AGENT_ID,
@@ -61,7 +62,9 @@ function makeRuntime(
 		getEntityById: vi.fn(async () => null),
 		getMemories: vi.fn(async () => memories),
 		getRoomsForParticipants: vi.fn(async () => []),
+		getMemoriesByRoomIds: vi.fn(async () => []),
 		getService: vi.fn(() => null),
+		...overrides,
 	} as IAgentRuntime;
 }
 
@@ -435,5 +438,91 @@ describe("recentMessagesProvider", () => {
 		]);
 		expect(result.text).toContain("User: message 12");
 		expect(result.text).not.toContain("User: message 9");
+	});
+
+	it("skips the cross-room interactions fetch on the first compose of a turn", async () => {
+		const OTHER_ROOM_ID = "00000000-0000-0000-0000-00000000000a";
+		const memories = [
+			makeMemory("msg-1", USER_ID, "hello agent", "discord", 1000),
+		];
+		const runtime = makeRuntime(
+			memories,
+			{},
+			{
+				getRoomsForParticipants: vi.fn(async () => [OTHER_ROOM_ID]),
+				getMemoriesByRoomIds: vi.fn(async () => [
+					{
+						id: "cross-1",
+						agentId: AGENT_ID,
+						roomId: OTHER_ROOM_ID,
+						entityId: USER_ID,
+						createdAt: 500,
+						content: { text: "the blue key is under the mat" },
+					} as Memory,
+				]),
+			},
+		);
+
+		// Stage-1 compose: no prior provider results in the turn's cached state.
+		const result = await recentMessagesProvider.get(
+			runtime,
+			makeMemory("current", USER_ID, "gm", "discord", 2000),
+			{ values: {}, data: {}, text: "" },
+		);
+
+		expect(runtime.getRoomsForParticipants).not.toHaveBeenCalled();
+		expect(runtime.getMemoriesByRoomIds).not.toHaveBeenCalled();
+		expect(result.values?.recentMessageInteractions).toBe("");
+		expect(result.data?.recentInteractions).toEqual([]);
+		// The in-room transcript is unaffected by the lean pass.
+		expect(result.text).toContain("User: hello agent");
+		expect(result.text).not.toContain("blue key");
+	});
+
+	it("fetches cross-room interactions on a turn recompose (cached state has this provider)", async () => {
+		const OTHER_ROOM_ID = "00000000-0000-0000-0000-00000000000a";
+		const memories = [
+			makeMemory("msg-1", USER_ID, "hello agent", "discord", 1000),
+		];
+		const runtime = makeRuntime(
+			memories,
+			{},
+			{
+				getRoomsForParticipants: vi.fn(async () => [ROOM_ID, OTHER_ROOM_ID]),
+				getMemoriesByRoomIds: vi.fn(async () => [
+					{
+						id: "cross-1",
+						agentId: AGENT_ID,
+						roomId: OTHER_ROOM_ID,
+						entityId: USER_ID,
+						createdAt: 500,
+						content: { text: "the blue key is under the mat" },
+					} as Memory,
+				]),
+			},
+		);
+
+		// Planner/action recompose: the turn's cached state already holds a
+		// RECENT_MESSAGES result from the Stage-1 compose.
+		const result = await recentMessagesProvider.get(
+			runtime,
+			makeMemory("current", USER_ID, "gm", "discord", 2000),
+			{
+				values: {},
+				data: { providers: { RECENT_MESSAGES: { text: "stage-1 result" } } },
+				text: "",
+			},
+		);
+
+		expect(runtime.getRoomsForParticipants).toHaveBeenCalled();
+		expect(runtime.getMemoriesByRoomIds).toHaveBeenCalledWith({
+			tableName: "messages",
+			roomIds: [OTHER_ROOM_ID],
+			limit: 20,
+		});
+		expect(result.data?.recentInteractions).toHaveLength(1);
+		expect(result.values?.recentMessageInteractions).toContain(
+			"the blue key is under the mat",
+		);
 	});
 });

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
@@ -20,6 +20,9 @@
  *
  * Also surfaces cross-room `recentInteractions` between the sender's identity
  * cluster and the agent, rendered as message or post interactions by room type.
+ * That fetch only runs on a turn RECOMPOSE (the provider already present in the
+ * cached state passed in): no Stage-1 template renders it, so the first compose
+ * of a turn skips the cross-room queries entirely.
  */
 
 import { getEntityDetails } from "../../../entities.ts";
@@ -368,13 +371,35 @@ export const recentMessagesProvider: Provider = {
 	get: async (
 		runtime: IAgentRuntime,
 		message: Memory,
-		_state: State,
+		state: State,
 	): Promise<ProviderResult> => {
 		try {
 			const { roomId } = message;
 			const conversationLength = Math.min(
 				runtime.getConversationLength(),
 				MAX_RECENT_MESSAGES_LOOKBACK,
+			);
+
+			// The cross-room interactions fetch (identity-cluster expansion, a
+			// rooms query per identity, then a 20-row pull across every other
+			// shared room) is consumed only by downstream state — action-time
+			// reads like MESSAGE target inference — never by the Stage-1 prompt
+			// or the simple-reply path. Stage 1 is the first compose of a turn
+			// (no prior result for this provider in the turn's cached state), so
+			// gate the fetch on a recompose: any pass whose state can reach a
+			// consumer builds over the cached state where this provider already
+			// ran (the planner names RECENT_MESSAGES in refreshProviders; action
+			// composes reuse the turn cache). Skipping on the first compose
+			// removes per-message cross-room DB work on turns that end at
+			// Stage 1.
+			const cachedProviderResults =
+				state?.data && typeof state.data === "object"
+					? (state.data as { providers?: unknown }).providers
+					: undefined;
+			const isTurnRecompose = Boolean(
+				cachedProviderResults &&
+					typeof cachedProviderResults === "object" &&
+					(cachedProviderResults as Record<string, unknown>)[spec.name],
 			);
 
 			// First get room to check for compaction point
@@ -398,7 +423,7 @@ export const recentMessagesProvider: Provider = {
 						// Use compaction point to filter history
 						start: lastCompactionAt,
 					}),
-					message.entityId !== runtime.agentId
+					message.entityId !== runtime.agentId && isTurnRecompose
 						? getRecentInteractions(
 								runtime,
 								message.entityId,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -4066,12 +4066,14 @@ export class AgentRuntime implements IAgentRuntime {
 				? trajectoryStepIdFromMessage
 				: getTrajectoryContext()?.trajectoryStepId;
 
-		// When composing state for a recorded trajectory step, execute providers
-		// instead of serving a stale cached state so provider accesses are logged.
-		if (trajectoryStepId) {
-			skipCache = true;
-		}
-
+		// When composing state for a recorded trajectory step, every requested
+		// provider re-executes (see providersToRun below) so provider accesses
+		// are logged. Recording must not change what providers OBSERVE: the
+		// turn's cached state still flows to them — and into the merged result —
+		// exactly as it would without the recorder. Blanking it here made
+		// providers that read prior-pass state (e.g. RECENT_MESSAGES' turn-
+		// recompose gate on cross-room interactions) behave differently whenever
+		// trajectories were active.
 		const filterList = onlyInclude ? includeList : null;
 		const emptyObj = {
 			values: {},
@@ -4159,9 +4161,13 @@ export class AgentRuntime implements IAgentRuntime {
 		// already ran for this message.id. The full requested set still drives the
 		// rendered text/order below (pulled from `currentProviderResults`, which
 		// merges cache + fresh); only the run-set shrinks. No-op (run everything)
-		// when `refreshProviders` is null or there is no cached state.
+		// when `refreshProviders` is null or there is no cached state. Also a
+		// no-op while a trajectory step is recording: reusing a cached result
+		// would leave that provider's access out of the step's log, so every
+		// requested provider re-executes (against the same cached state a
+		// non-recording compose would hand it).
 		const refreshSet =
-			refreshProviders && refreshProviders.length > 0
+			refreshProviders && refreshProviders.length > 0 && !trajectoryStepId
 				? new Set(refreshProviders)
 				: null;
 		const cachedProviderNames = refreshSet

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -903,9 +903,19 @@ const MODEL_CONTEXT_PROVIDER_EXCLUSION_SET = new Set<string>(
  * (no per-call CURRENT_TIME drift) so the provider's prefix cache
  * grows with the conversation rather than resetting every turn.
  *
- * Note: we still keep FACTS rendered if present — Stage 1 may need a
- * grounded fact to discriminate ambiguous routing, and FACTS are stable
- * across calls (only refreshed when the underlying store changes).
+ * These exclusions apply to COMPOSITION as well as rendering:
+ * `composeResponseState` subtracts them from the include list it hands
+ * `composeState`, so the providers never execute for a Stage-1-only turn
+ * (ENTITIES is a room-participant DB fetch per inbound message — pure
+ * waste on group noise that ends in IGNORE, since nothing on the Stage-1
+ * or simple-reply path reads its output). Planner turns still get them:
+ * `selectV5PlannerStateProviderNames` re-adds the core set and the
+ * planner recompose runs any provider missing from the turn's cached
+ * state (see composeState's refreshProviders contract in runtime.ts).
+ *
+ * Note: we still keep FACTS composed and rendered — Stage 1 may need a
+ * grounded fact to discriminate ambiguous routing, and stored facts must
+ * be recallable on the simple path (see CORE_RESPONSE_STATE_PROVIDERS).
  */
 const STAGE1_EXTRA_PROVIDER_EXCLUSIONS = [
 	"CURRENT_TIME",
@@ -1097,16 +1107,30 @@ function withMessageHistoryCompactionProviderOptions<
 	} as T;
 }
 
+/**
+ * The provider include list for Stage-1 response-state composition: the core
+ * response providers plus always-on plugin providers, minus the Stage-1
+ * exclusions (which are execution exclusions, not just render exclusions —
+ * see STAGE1_EXTRA_PROVIDER_EXCLUSIONS). Exported for tests.
+ */
+export function stage1ResponseStateProviderNames(
+	runtime: IAgentRuntime,
+	message: Memory,
+): string[] {
+	const exclusions = new Set(stage1ProviderExclusionsForMessage(message));
+	return [
+		...CORE_RESPONSE_STATE_PROVIDERS,
+		...alwaysOnResponseStateProviderNames(runtime),
+		...(hasInboundBenchmarkContext(message) ? ["CONTEXT_BENCH"] : []),
+	].filter((name) => !exclusions.has(name));
+}
+
 async function composeResponseState(
 	runtime: IAgentRuntime,
 	message: Memory,
 	skipCache = false,
 ): Promise<State> {
-	const providers = [
-		...CORE_RESPONSE_STATE_PROVIDERS,
-		...alwaysOnResponseStateProviderNames(runtime),
-		...(hasInboundBenchmarkContext(message) ? ["CONTEXT_BENCH"] : []),
-	];
+	const providers = stage1ResponseStateProviderNames(runtime, message);
 	if (hasPageScopedRoutingMetadata(message)) {
 		const state = await runtime.composeState(
 			message,


### PR DESCRIPTION
## Problem

Stage 1 executes providers it never renders. `STAGE1_EXTRA_PROVIDER_EXCLUSIONS` (`ENTITIES` / `CURRENT_TIME` / `DOCUMENTS`) and the `renderExclusions` in `createV5MessageContextObject` are **render-only** — `composeResponseState` still passes the full `CORE_RESPONSE_STATE_PROVIDERS` list to `composeState` with `onlyInclude=true`, so the excluded providers **execute** on every inbound message and their output is then thrown away:

- `ENTITIES` runs a room-participant fetch (`getEntityDetails`) per message; nothing on the Stage-1 or simple-reply path reads its text (render-excluded), values, or data.
- `RECENT_MESSAGES` additionally runs `getRecentInteractions` — identity-cluster expansion + `getRoomsForParticipants` per related identity + `getMemoriesByRoomIds(limit 20)` across **all** other shared rooms — whose result lands only in `values.recentMessageInteractions`, which no template renders anywhere in the repo; its only consumer is action-time state reads (MESSAGE target inference in `advanced-capabilities/actions/message.ts`), which only ever see recomposed state.

On a live bot this was hundreds of consecutive relay-noise group turns (Stage-1 IGNORE) doing pure wasted DB work per turn.

## Fix (structural — exclusion means exclusion)

1. **`composeResponseState` subtracts the Stage-1 exclusions from the include list** it hands `composeState` (new `stage1ResponseStateProviderNames` helper, exported for tests). The excluded providers no longer execute for a Stage-1-only turn. Planner turns still get them: `selectV5PlannerStateProviderNames` re-adds the core set and the planner recompose runs any provider missing from the turn's cached state (`composeState`'s existing refreshProviders/cache-merge contract — nothing runs twice). The `isCurrentTimeQuestion` carve-out is preserved: asking the time still composes + renders `CURRENT_TIME` at Stage 1.

2. **`RECENT_MESSAGES` gates the cross-room interactions fetch on a turn recompose** (this provider already present in the cached state passed in). Stage 1 is the first compose of a turn, so it skips the cross-room queries; the planner pass names `RECENT_MESSAGES` in `refreshProviders` and re-runs it over the turn cache, so every state that can reach the MESSAGE-action consumer still carries the interactions. In-room transcript behavior is unchanged.

No behavior change for planner turns' prompts: the planner state composes and renders `ENTITIES`/`CURRENT_TIME` exactly as before (now composed at the planner pass instead of earlier).

## Consumer audit (why this is safe)

- Stage-1 render: `stage1ProviderExclusionsForMessage` already stripped these providers from the v5 context object — no prompt change.
- No code reads `values.entities` / `data.entitiesData` / `values.currentTime` etc. from the Stage-1 state between compose and the planner recompose.
- `values.recentMessageInteractions` / `recentPostInteractions` / `recentInteractions`: zero template consumers repo-wide; the only reader is `recentTextFromState` in the MESSAGE action, which receives recomposed (turn-cached) state — gate open there.
- Pre-existing dormant defect (unchanged by this PR): `readRoomEntityRefs` in `runtime/facts-and-relationships.ts` reads `providers.ENTITIES.data.entities`, but the provider publishes `data.entitiesData` — it already always returns `[]` on develop, so the facts stage never saw room entities either way. Follow-up: #13196 (the eventual fix should fetch room entities directly rather than scrape Stage-1 state).

## Tests

- `packages/core/src/__tests__/stage1-provider-execution.test.ts` (new): include-list subtraction, the `CURRENT_TIME`-question carve-out, always-on plugin provider handling, and a real-`AgentRuntime` two-pass test proving the excluded providers run **zero** times at Stage 1 (prompt footprint drops) and exactly **once** at the planner recompose (footprint restored), with `FACTS` reused from cache.
- `packages/core/.../recentMessages.test.ts` (+2): the cross-room fetch is skipped on the first compose of a turn (no `getRoomsForParticipants` / `getMemoriesByRoomIds` calls, empty interaction values, in-room transcript unchanged) and fires on a recompose (values + data populated, `limit: 20`, current room excluded).

## Verification

### Real counts (packages/core, this branch)
- Full suite: **3069 passed | 7 failed | 11 skipped (3087)** across 364 files.
- The same **7 failures in the same 4 files** reproduce on pristine `origin/develop` (`cd159a8d28`) with this diff stashed — `action-handler-callsite-audit`, `tiered-action-surface`, `media/fetch` (network-guarded), `link-extraction` (live URL) — i.e. zero new failures from this change.
- Targeted suites: `stage1-provider-execution` 4/4, `recentMessages` 15/15 (incl. 2 new), `compose-state-refresh-providers` 3/3, `message-runtime-stage1` + `message-stable-prefix` + `message-stage1-context-catalog` + `message-stage1-prompt-tier` 100/100, `facts-and-relationships` green.
- `bun run --cwd packages/core typecheck` (tsgo): clean.
