### PR TITLE
fix(core): stop facts provider attributing room facts to relay/webhook senders

### DIFF
--- a/packages/core/src/__tests__/compose-state-role-gate.test.ts
+++ b/packages/core/src/__tests__/compose-state-role-gate.test.ts
@@ -1,12 +1,11 @@
 /**
- * Exercises provider roleGate enforcement on the `composeState` onlyInclude
- * path: role-gated providers are dropped for automated (connector-stamped
- * bot/webhook or bridge-source) senders that resolve to GUEST, kept for
- * automated senders with an explicit world role, kept unconditionally for
- * human senders (unassigned humans default to GUEST, so blanket enforcement
- * would strip Stage-1 recall), and the agent's own synthetic turns act as
- * OWNER. Uses a real AgentRuntime + InMemoryDatabaseAdapter with a real world
- * and room; no model.
+ * Pins that the `composeState` onlyInclude path honors the explicit provider
+ * list without enforcing declared roleGates, for every sender kind. Stage-1
+ * force-includes recall providers (FACTS declares minRole USER) for all
+ * senders, and both unassigned humans AND relay/webhook bridges resolve to
+ * GUEST by default — so gate enforcement here would strip cross-turn recall
+ * from relayed human conversation (the ZenithProxy pattern). Uses a real
+ * AgentRuntime + InMemoryDatabaseAdapter with a real world and room; no model.
  */
 import { describe, expect, it } from "vitest";
 import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter";
@@ -17,7 +16,6 @@ import { ChannelType } from "../types";
 const WORLD_ID = "11111111-1111-1111-1111-111111111110" as UUID;
 const ROOM_ID = "11111111-1111-1111-1111-111111111111" as UUID;
 const UNASSIGNED_SENDER = "22222222-2222-2222-2222-222222222221" as UUID;
-const GRANTED_SENDER = "22222222-2222-2222-2222-222222222222" as UUID;
 
 function staticProvider(name: string, extra: Partial<Provider> = {}): Provider {
 	return {
@@ -39,7 +37,7 @@ async function makeRuntime(): Promise<AgentRuntime> {
 			id: WORLD_ID,
 			agentId: runtime.agentId,
 			name: "test world",
-			metadata: { roles: { [GRANTED_SENDER]: "USER" } },
+			metadata: { roles: {} },
 		},
 	]);
 	await adapter.createRooms([
@@ -61,26 +59,29 @@ async function makeRuntime(): Promise<AgentRuntime> {
 function makeMessage(
 	id: string,
 	entityId: UUID,
-	contentMetadata?: Record<string, unknown>,
+	overrides: {
+		contentMetadata?: Record<string, unknown>;
+		source?: string;
+	} = {},
 ): Memory {
 	return {
 		id: id as UUID,
 		entityId,
 		roomId: ROOM_ID,
 		worldId: WORLD_ID,
-		content: { text: "gm", source: "discord", metadata: contentMetadata },
+		content: {
+			text: "gm",
+			source: overrides.source ?? "discord",
+			metadata: overrides.contentMetadata,
+		},
 	} as Memory;
 }
 
-describe("composeState onlyInclude provider roleGate", () => {
-	it("keeps role-gated providers for human senders regardless of world role", async () => {
+describe("composeState onlyInclude ignores provider roleGates", () => {
+	it("keeps role-gated providers for human senders without a world role", async () => {
 		const runtime = await makeRuntime();
-		const message = makeMessage(
-			"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
-			UNASSIGNED_SENDER,
-		);
 		const state = await runtime.composeState(
-			message,
+			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1", UNASSIGNED_SENDER),
 			["GATED", "OPEN"],
 			true,
 			true,
@@ -89,33 +90,28 @@ describe("composeState onlyInclude provider roleGate", () => {
 		expect(state.text).toContain("OPEN-content");
 	});
 
-	it("drops role-gated providers for bot-authored senders without a world role", async () => {
+	it("keeps role-gated providers for bot-authored senders without a world role", async () => {
+		// A roleless relay webhook resolves to GUEST; if the gate were enforced
+		// here, FACTS-style recall providers would silently vanish from every
+		// relayed human turn.
 		const runtime = await makeRuntime();
-		const humanState = await runtime.composeState(
-			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2", UNASSIGNED_SENDER),
+		const state = await runtime.composeState(
+			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2", UNASSIGNED_SENDER, {
+				contentMetadata: { fromBot: true },
+			}),
 			["GATED", "OPEN"],
 			true,
 			true,
 		);
-		const botState = await runtime.composeState(
+		expect(state.text).toContain("GATED-content");
+		expect(state.text).toContain("OPEN-content");
+	});
+
+	it("keeps role-gated providers for internal bridge sources without a world role", async () => {
+		const runtime = await makeRuntime();
+		const state = await runtime.composeState(
 			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3", UNASSIGNED_SENDER, {
-				fromBot: true,
-			}),
-			["GATED", "OPEN"],
-			true,
-			true,
-		);
-		expect(botState.text).toContain("OPEN-content");
-		expect(botState.text).not.toContain("GATED-content");
-		// The prompt footprint drops on the automated turn.
-		expect(botState.text.length).toBeLessThan(humanState.text.length);
-	});
-
-	it("keeps role-gated providers for bot senders granted an explicit world role", async () => {
-		const runtime = await makeRuntime();
-		const state = await runtime.composeState(
-			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa4", GRANTED_SENDER, {
-				fromBot: true,
+				source: "acpx:sub-agent-router",
 			}),
 			["GATED", "OPEN"],
 			true,
@@ -123,21 +119,5 @@ describe("composeState onlyInclude provider roleGate", () => {
 		);
 		expect(state.text).toContain("GATED-content");
 		expect(state.text).toContain("OPEN-content");
-	});
-
-	it("treats the agent's own synthetic turns as OWNER", async () => {
-		const runtime = await makeRuntime();
-		runtime.registerProvider(
-			staticProvider("ADMIN_GATED", { roleGate: { minRole: "ADMIN" } }),
-		);
-		const state = await runtime.composeState(
-			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa5", runtime.agentId, {
-				fromBot: true,
-			}),
-			["ADMIN_GATED", "OPEN"],
-			true,
-			true,
-		);
-		expect(state.text).toContain("ADMIN_GATED-content");
 	});
 });

--- a/packages/core/src/__tests__/compose-state-role-gate.test.ts
+++ b/packages/core/src/__tests__/compose-state-role-gate.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Exercises provider roleGate enforcement on the `composeState` onlyInclude
+ * path: role-gated providers are dropped for automated (connector-stamped
+ * bot/webhook or bridge-source) senders that resolve to GUEST, kept for
+ * automated senders with an explicit world role, kept unconditionally for
+ * human senders (unassigned humans default to GUEST, so blanket enforcement
+ * would strip Stage-1 recall), and the agent's own synthetic turns act as
+ * OWNER. Uses a real AgentRuntime + InMemoryDatabaseAdapter with a real world
+ * and room; no model.
+ */
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter";
+import { AgentRuntime } from "../runtime";
+import type { Character, Memory, Provider, UUID } from "../types";
+import { ChannelType } from "../types";
+
+const WORLD_ID = "11111111-1111-1111-1111-111111111110" as UUID;
+const ROOM_ID = "11111111-1111-1111-1111-111111111111" as UUID;
+const UNASSIGNED_SENDER = "22222222-2222-2222-2222-222222222221" as UUID;
+const GRANTED_SENDER = "22222222-2222-2222-2222-222222222222" as UUID;
+
+function staticProvider(name: string, extra: Partial<Provider> = {}): Provider {
+	return {
+		name,
+		get: async () => ({ text: `${name}-content`, values: {}, data: {} }),
+		...extra,
+	};
+}
+
+async function makeRuntime(): Promise<AgentRuntime> {
+	const adapter = new InMemoryDatabaseAdapter();
+	const runtime = new AgentRuntime({
+		character: { name: "role-gate-test" } as Character,
+		adapter,
+		logLevel: "fatal",
+	});
+	await adapter.createWorlds([
+		{
+			id: WORLD_ID,
+			agentId: runtime.agentId,
+			name: "test world",
+			metadata: { roles: { [GRANTED_SENDER]: "USER" } },
+		},
+	]);
+	await adapter.createRooms([
+		{
+			id: ROOM_ID,
+			agentId: runtime.agentId,
+			source: "test",
+			type: ChannelType.GROUP,
+			worldId: WORLD_ID,
+		},
+	]);
+	runtime.registerProvider(
+		staticProvider("GATED", { roleGate: { minRole: "USER" } }),
+	);
+	runtime.registerProvider(staticProvider("OPEN"));
+	return runtime;
+}
+
+function makeMessage(
+	id: string,
+	entityId: UUID,
+	contentMetadata?: Record<string, unknown>,
+): Memory {
+	return {
+		id: id as UUID,
+		entityId,
+		roomId: ROOM_ID,
+		worldId: WORLD_ID,
+		content: { text: "gm", source: "discord", metadata: contentMetadata },
+	} as Memory;
+}
+
+describe("composeState onlyInclude provider roleGate", () => {
+	it("keeps role-gated providers for human senders regardless of world role", async () => {
+		const runtime = await makeRuntime();
+		const message = makeMessage(
+			"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+			UNASSIGNED_SENDER,
+		);
+		const state = await runtime.composeState(
+			message,
+			["GATED", "OPEN"],
+			true,
+			true,
+		);
+		expect(state.text).toContain("GATED-content");
+		expect(state.text).toContain("OPEN-content");
+	});
+
+	it("drops role-gated providers for bot-authored senders without a world role", async () => {
+		const runtime = await makeRuntime();
+		const humanState = await runtime.composeState(
+			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2", UNASSIGNED_SENDER),
+			["GATED", "OPEN"],
+			true,
+			true,
+		);
+		const botState = await runtime.composeState(
+			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3", UNASSIGNED_SENDER, {
+				fromBot: true,
+			}),
+			["GATED", "OPEN"],
+			true,
+			true,
+		);
+		expect(botState.text).toContain("OPEN-content");
+		expect(botState.text).not.toContain("GATED-content");
+		// The prompt footprint drops on the automated turn.
+		expect(botState.text.length).toBeLessThan(humanState.text.length);
+	});
+
+	it("keeps role-gated providers for bot senders granted an explicit world role", async () => {
+		const runtime = await makeRuntime();
+		const state = await runtime.composeState(
+			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa4", GRANTED_SENDER, {
+				fromBot: true,
+			}),
+			["GATED", "OPEN"],
+			true,
+			true,
+		);
+		expect(state.text).toContain("GATED-content");
+		expect(state.text).toContain("OPEN-content");
+	});
+
+	it("treats the agent's own synthetic turns as OWNER", async () => {
+		const runtime = await makeRuntime();
+		runtime.registerProvider(
+			staticProvider("ADMIN_GATED", { roleGate: { minRole: "ADMIN" } }),
+		);
+		const state = await runtime.composeState(
+			makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa5", runtime.agentId, {
+				fromBot: true,
+			}),
+			["ADMIN_GATED", "OPEN"],
+			true,
+			true,
+		);
+		expect(state.text).toContain("ADMIN_GATED-content");
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
@@ -2,10 +2,11 @@
  * Unit tests for `factsProvider` (advanced-capabilities): asserts BM25 keyword
  * retrieval surfaces the relevant durable/current facts (including a direct-recall
  * fallback and current-fact time weighting), that rendering attributes facts by
- * provenance (speaker vs room, with the room pool skipped for bot/bridge
- * senders), and that the provider never requests embeddings. Uses a hand-built
- * deterministic runtime mock — no live model, no DB — whose `useModel` throws
- * to enforce the no-embeddings invariant.
+ * provenance (speaker vs neutral room header) while room-fact recall stays
+ * intact for bot/bridge senders — relays carry real human questions — and that
+ * the provider never requests embeddings. Uses a hand-built deterministic
+ * runtime mock — no live model, no DB — whose `useModel` throws to enforce the
+ * no-embeddings invariant.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { IAgentRuntime, Memory, UUID } from "../../../types/index.ts";
@@ -278,17 +279,10 @@ describe("factsProvider provenance attribution", () => {
 		expect(result.text).not.toContain("Known facts in this room");
 	});
 
-	it("skips the room pool entirely for connector-stamped bot/webhook senders", async () => {
-		const humanRuntime = makeRuntime({
-			roomFacts: [roomFactAboutSomeoneElse],
-			entityFacts: [],
-		});
-		const humanResult = await factsProvider.get(
-			humanRuntime,
-			memory("msg-human", "who created the remilio project?"),
-			{ values: {}, data: {}, text: "" },
-		);
-
+	it("keeps room facts recallable for connector-stamped bot/webhook senders, under the neutral header", async () => {
+		// Relays carry real human questions (the ZenithProxy pattern): a human
+		// asks through the bridge, so the room pool must stay recallable on the
+		// bot-stamped turn — only the attribution changes.
 		const botRuntime = makeRuntime({
 			roomFacts: [roomFactAboutSomeoneElse],
 			entityFacts: [],
@@ -307,22 +301,20 @@ describe("factsProvider provenance attribution", () => {
 			text: "",
 		});
 
-		// Room-scoped fetch never happens on the bot turn.
+		// The room-scoped fetch still happens on the bot turn.
 		const botFactCalls = botRuntime.getMemories.mock.calls.filter(
 			([params]: [{ tableName: string; roomId?: UUID }]) =>
 				params.tableName === "facts" && params.roomId,
 		);
-		expect(botFactCalls.length).toBe(0);
+		expect(botFactCalls.length).toBe(1);
 
-		// No misattributed facts, and the prompt footprint drops vs the same
-		// pools on a human turn.
-		expect(botResult.text).toBe("No facts available.");
-		expect(botResult.text).not.toContain("nubs created");
-		expect(humanResult.text).toContain("nubs created the remilio project");
-		expect(botResult.text.length).toBeLessThan(humanResult.text.length);
+		// Recall preserved; the room fact is never attributed to the bridge bot.
+		expect(botResult.text).toContain("nubs created the remilio project");
+		expect(botResult.text).toContain("Known facts in this room");
+		expect(botResult.text).not.toContain("knows about");
 	});
 
-	it("skips the room pool for internal bridge sources but keeps the sender's own facts", async () => {
+	it("keeps both the sender's own facts and room facts for internal bridge sources", async () => {
 		const bridgeOwnFact = memory(
 			"fact-bridge-1",
 			"the relay mirrors the minecraft server chat",
@@ -337,7 +329,10 @@ describe("factsProvider provenance attribution", () => {
 			roomFacts: [roomFactAboutSomeoneElse],
 			entityFacts: [bridgeOwnFact],
 		});
-		const message = memory("msg-bridge", "what does the relay mirror?");
+		const message = memory(
+			"msg-bridge",
+			"who created the remilio project the relay mirrors?",
+		);
 		message.content.source = "acpx:sub-agent-router";
 		const result = await factsProvider.get(runtime, message, {
 			values: {},
@@ -345,12 +340,10 @@ describe("factsProvider provenance attribution", () => {
 			text: "",
 		});
 
-		const roomFactCalls = runtime.getMemories.mock.calls.filter(
-			([params]: [{ tableName: string; roomId?: UUID }]) =>
-				params.tableName === "facts" && params.roomId,
-		);
-		expect(roomFactCalls.length).toBe(0);
+		// Sender-cluster facts keep the speaker header; room facts about other
+		// participants stay recallable under the neutral header.
 		expect(result.text).toContain("mirrors the minecraft server chat");
-		expect(result.text).not.toContain("nubs created");
+		expect(result.text).toContain("nubs created the remilio project");
+		expect(result.text).toContain("Known facts in this room");
 	});
 });

--- a/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
@@ -1,9 +1,11 @@
 /**
  * Unit tests for `factsProvider` (advanced-capabilities): asserts BM25 keyword
  * retrieval surfaces the relevant durable/current facts (including a direct-recall
- * fallback and current-fact time weighting) and that the provider never requests
- * embeddings. Uses a hand-built deterministic runtime mock — no live model, no
- * DB — whose `useModel` throws to enforce the no-embeddings invariant.
+ * fallback and current-fact time weighting), that rendering attributes facts by
+ * provenance (speaker vs room, with the room pool skipped for bot/bridge
+ * senders), and that the provider never requests embeddings. Uses a hand-built
+ * deterministic runtime mock — no live model, no DB — whose `useModel` throws
+ * to enforce the no-embeddings invariant.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { IAgentRuntime, Memory, UUID } from "../../../types/index.ts";
@@ -12,16 +14,18 @@ import { factsProvider } from "./facts.ts";
 const agentId = "00000000-0000-0000-0000-0000000000aa" as UUID;
 const entityId = "00000000-0000-0000-0000-0000000000bb" as UUID;
 const roomId = "00000000-0000-0000-0000-0000000000cc" as UUID;
+const otherEntityId = "00000000-0000-0000-0000-0000000000dd" as UUID;
 
 function memory(
 	id: string,
 	text: string,
 	metadata: Record<string, unknown> = {},
 	createdAt = Date.now(),
+	factEntityId: UUID = entityId,
 ): Memory {
 	return {
 		id: id as UUID,
-		entityId,
+		entityId: factEntityId,
 		agentId,
 		roomId,
 		content: { text },
@@ -31,7 +35,9 @@ function memory(
 }
 
 function makeRuntime(args: {
-	facts: Memory[];
+	facts?: Memory[];
+	roomFacts?: Memory[];
+	entityFacts?: Memory[];
 	recentMessages?: Memory[];
 }): IAgentRuntime & {
 	getMemories: ReturnType<typeof vi.fn>;
@@ -41,15 +47,23 @@ function makeRuntime(args: {
 		agentId,
 		character: { name: "Eliza", bio: "", system: "" },
 		getService: vi.fn(() => null),
-		getMemories: vi.fn(async (params: { tableName: string }) => {
-			if (params.tableName === "messages") {
-				return args.recentMessages ?? [];
-			}
-			if (params.tableName === "facts") {
-				return args.facts;
-			}
-			return [];
-		}),
+		getMemories: vi.fn(
+			async (params: { tableName: string; roomId?: UUID; entityId?: UUID }) => {
+				if (params.tableName === "messages") {
+					return args.recentMessages ?? [];
+				}
+				if (params.tableName === "facts") {
+					if (params.roomId) {
+						return args.roomFacts ?? args.facts ?? [];
+					}
+					if (params.entityId) {
+						return args.entityFacts ?? args.facts ?? [];
+					}
+					return args.facts ?? [];
+				}
+				return [];
+			},
+		),
 		useModel: vi.fn(async () => {
 			throw new Error("FACTS provider must not request embeddings");
 		}),
@@ -197,5 +211,146 @@ describe("factsProvider keyword retrieval", () => {
 			"fact-new",
 			"fact-old",
 		]);
+	});
+});
+
+describe("factsProvider provenance attribution", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	const roomFactAboutSomeoneElse = memory(
+		"fact-room-1",
+		"nubs created the remilio project last spring",
+		{
+			kind: "durable",
+			category: "identity",
+			confidence: 0.9,
+			keywords: ["nubs", "remilio", "project"],
+		},
+		Date.now(),
+		otherEntityId,
+	);
+
+	it("renders room-pool facts about other entities under the neutral room header, not as speaker facts", async () => {
+		const runtime = makeRuntime({
+			roomFacts: [roomFactAboutSomeoneElse],
+			entityFacts: [],
+		});
+
+		const result = await factsProvider.get(
+			runtime,
+			memory("msg-current", "who created the remilio project?", {
+				source: "discord",
+			}),
+			{ values: {}, data: {}, text: "" },
+		);
+
+		expect(result.text).toContain("nubs created the remilio project");
+		expect(result.text).toContain("Known facts in this room");
+		// The room fact is about otherEntityId — it must NOT be attributed to
+		// the current speaker.
+		expect(result.text).not.toContain("knows about");
+	});
+
+	it("keeps the speaker header for facts stored against the sender's own entity", async () => {
+		const senderFact = memory("fact-sender-1", "the user lives in Berlin", {
+			kind: "durable",
+			category: "identity",
+			confidence: 0.9,
+			keywords: ["berlin", "lives"],
+		});
+		const runtime = makeRuntime({
+			roomFacts: [senderFact],
+			entityFacts: [senderFact],
+		});
+
+		const message = memory("msg-current", "anything about Berlin?");
+		message.content.senderName = "Alice";
+		const result = await factsProvider.get(runtime, message, {
+			values: {},
+			data: {},
+			text: "",
+		});
+
+		expect(result.text).toContain("Things Eliza knows about Alice:");
+		expect(result.text).toContain("the user lives in Berlin");
+		expect(result.text).not.toContain("Known facts in this room");
+	});
+
+	it("skips the room pool entirely for connector-stamped bot/webhook senders", async () => {
+		const humanRuntime = makeRuntime({
+			roomFacts: [roomFactAboutSomeoneElse],
+			entityFacts: [],
+		});
+		const humanResult = await factsProvider.get(
+			humanRuntime,
+			memory("msg-human", "who created the remilio project?"),
+			{ values: {}, data: {}, text: "" },
+		);
+
+		const botRuntime = makeRuntime({
+			roomFacts: [roomFactAboutSomeoneElse],
+			entityFacts: [],
+		});
+		const botMessage = memory(
+			"msg-bot",
+			"who created the remilio project?",
+			{},
+			Date.now(),
+		);
+		botMessage.content.metadata = { fromBot: true };
+		botMessage.content.senderName = "2fingersBTW | ZenithProxy";
+		const botResult = await factsProvider.get(botRuntime, botMessage, {
+			values: {},
+			data: {},
+			text: "",
+		});
+
+		// Room-scoped fetch never happens on the bot turn.
+		const botFactCalls = botRuntime.getMemories.mock.calls.filter(
+			([params]: [{ tableName: string; roomId?: UUID }]) =>
+				params.tableName === "facts" && params.roomId,
+		);
+		expect(botFactCalls.length).toBe(0);
+
+		// No misattributed facts, and the prompt footprint drops vs the same
+		// pools on a human turn.
+		expect(botResult.text).toBe("No facts available.");
+		expect(botResult.text).not.toContain("nubs created");
+		expect(humanResult.text).toContain("nubs created the remilio project");
+		expect(botResult.text.length).toBeLessThan(humanResult.text.length);
+	});
+
+	it("skips the room pool for internal bridge sources but keeps the sender's own facts", async () => {
+		const bridgeOwnFact = memory(
+			"fact-bridge-1",
+			"the relay mirrors the minecraft server chat",
+			{
+				kind: "durable",
+				category: "identity",
+				confidence: 0.9,
+				keywords: ["relay", "minecraft", "chat"],
+			},
+		);
+		const runtime = makeRuntime({
+			roomFacts: [roomFactAboutSomeoneElse],
+			entityFacts: [bridgeOwnFact],
+		});
+		const message = memory("msg-bridge", "what does the relay mirror?");
+		message.content.source = "acpx:sub-agent-router";
+		const result = await factsProvider.get(runtime, message, {
+			values: {},
+			data: {},
+			text: "",
+		});
+
+		const roomFactCalls = runtime.getMemories.mock.calls.filter(
+			([params]: [{ tableName: string; roomId?: UUID }]) =>
+				params.tableName === "facts" && params.roomId,
+		);
+		expect(roomFactCalls.length).toBe(0);
+		expect(result.text).toContain("mirrors the minecraft server chat");
+		expect(result.text).not.toContain("nubs created");
 	});
 });

--- a/packages/core/src/features/advanced-capabilities/providers/facts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.ts
@@ -1,10 +1,14 @@
 /**
  * FACTS provider: injects the durable and current facts the agent knows about
- * the speaker into the prompt context. Pulls bounded recent candidate pools
- * from the `facts` memory table (one room-scoped, one per related entity in the
- * speaker's identity cluster), partitions them into durable (identity-level,
- * never decays) and current (time-decayed) kinds, then ranks each kind locally
- * with BM25 keyword scoring weighted by a per-kind confidence × recency prior.
+ * the speaker and the room into the prompt context. Pulls bounded recent
+ * candidate pools from the `facts` memory table (one room-scoped, one per
+ * related entity in the speaker's identity cluster), partitions them into
+ * durable (identity-level, never decays) and current (time-decayed) kinds,
+ * then ranks each kind locally with BM25 keyword scoring weighted by a
+ * per-kind confidence × recency prior. Rendering attributes facts by
+ * provenance — only sender-cluster facts appear under the "about the speaker"
+ * header, room-pool facts render under a neutral room header — and the room
+ * pool is skipped entirely for automated (webhook/bridge-bot) senders.
  * Retrieval deliberately avoids vector search so relevance is computed from the
  * fact's own words and extracted keywords; a keyword-miss on durable facts
  * falls back to the highest-prior candidates so direct recall still works. The
@@ -13,6 +17,7 @@
  */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { getRelatedEntityIds } from "../../../identity-clusters.ts";
+import { isAutomatedSenderTurn } from "../../../messaging/automated-turns.ts";
 import type {
 	FactKind,
 	FactMetadata,
@@ -272,18 +277,29 @@ const factsProvider: Provider = {
 			// both over the `facts` table. We intentionally use `getMemories`
 			// instead of vector search: relevance is computed locally from extracted
 			// fact keywords and the fact's own words.
+			//
+			// The room pool holds facts about EVERY participant in the room, so it
+			// is skipped entirely when the sender is automation (a relay webhook,
+			// bridge bot, or sub-agent row): those turns arrive in bulk, the room
+			// facts describe other people, and rendering them here floods every
+			// relay turn's prompt with context that has nothing to do with the
+			// sender. Facts stored against the automated sender's own entity still
+			// load — they genuinely describe the speaker.
 			const relatedEntityIds = await getRelatedEntityIds(
 				runtime,
 				message.entityId,
 			);
+			const includeRoomPool = !isAutomatedSenderTurn(message);
 			const [roomFacts, ...entityFactPools] = await Promise.all([
-				runtime.getMemories({
-					tableName: "facts",
-					roomId: message.roomId,
-					worldId: message.worldId,
-					count: CANDIDATE_POOL_PER_SEARCH,
-					unique: false,
-				}),
+				includeRoomPool
+					? runtime.getMemories({
+							tableName: "facts",
+							roomId: message.roomId,
+							worldId: message.worldId,
+							count: CANDIDATE_POOL_PER_SEARCH,
+							unique: false,
+						})
+					: Promise.resolve([] as Memory[]),
 				...relatedEntityIds.map((entityId) =>
 					runtime.getMemories({
 						tableName: "facts",
@@ -354,17 +370,42 @@ const factsProvider: Provider = {
 				(typeof message.content.name === "string" && message.content.name) ||
 				"the speaker";
 
+			// Attribute by provenance: only facts stored against the sender's
+			// identity cluster are "about the speaker". The room pool also carries
+			// facts about OTHER participants — rendering those under the speaker
+			// header told the model that facts about other people described
+			// whoever happened to send the current message (worst on relay/webhook
+			// turns, where every room fact got attributed to the bridge bot).
+			const senderEntityIds = new Set<string>(relatedEntityIds);
+			const isAboutSender = (memory: Memory): boolean =>
+				typeof memory.entityId === "string" &&
+				senderEntityIds.has(memory.entityId);
+			const senderDurable = durableFacts.filter(isAboutSender);
+			const roomDurable = durableFacts.filter((m) => !isAboutSender(m));
+			const senderCurrent = currentFacts.filter(isAboutSender);
+			const roomCurrent = currentFacts.filter((m) => !isAboutSender(m));
+
 			const sections: string[] = [];
-			if (durableFacts.length > 0) {
+			if (senderDurable.length > 0) {
 				const durableHeader = `Things ${agentName} knows about ${senderName}:`;
 				sections.push(
-					`${durableHeader}\n${formatLines(durableFacts, "durable")}`,
+					`${durableHeader}\n${formatLines(senderDurable, "durable")}`,
 				);
 			}
-			if (currentFacts.length > 0) {
+			if (senderCurrent.length > 0) {
 				const currentHeader = `What's currently happening for ${senderName}:`;
 				sections.push(
-					`${currentHeader}\n${formatLines(currentFacts, "current")}`,
+					`${currentHeader}\n${formatLines(senderCurrent, "current")}`,
+				);
+			}
+			if (roomDurable.length > 0) {
+				sections.push(
+					`Known facts in this room (about other participants):\n${formatLines(roomDurable, "durable")}`,
+				);
+			}
+			if (roomCurrent.length > 0) {
+				sections.push(
+					`What's currently happening in this room:\n${formatLines(roomCurrent, "current")}`,
 				);
 			}
 

--- a/packages/core/src/features/advanced-capabilities/providers/facts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.ts
@@ -7,8 +7,9 @@
  * then ranks each kind locally with BM25 keyword scoring weighted by a
  * per-kind confidence × recency prior. Rendering attributes facts by
  * provenance — only sender-cluster facts appear under the "about the speaker"
- * header, room-pool facts render under a neutral room header — and the room
- * pool is skipped entirely for automated (webhook/bridge-bot) senders.
+ * header; room-pool facts about other participants render under a neutral
+ * room header, so relay/webhook turns keep room recall without the room's
+ * facts being misattributed to the bridge sender.
  * Retrieval deliberately avoids vector search so relevance is computed from the
  * fact's own words and extracted keywords; a keyword-miss on durable facts
  * falls back to the highest-prior candidates so direct recall still works. The
@@ -17,7 +18,6 @@
  */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { getRelatedEntityIds } from "../../../identity-clusters.ts";
-import { isAutomatedSenderTurn } from "../../../messaging/automated-turns.ts";
 import type {
 	FactKind,
 	FactMetadata,
@@ -278,28 +278,24 @@ const factsProvider: Provider = {
 			// instead of vector search: relevance is computed locally from extracted
 			// fact keywords and the fact's own words.
 			//
-			// The room pool holds facts about EVERY participant in the room, so it
-			// is skipped entirely when the sender is automation (a relay webhook,
-			// bridge bot, or sub-agent row): those turns arrive in bulk, the room
-			// facts describe other people, and rendering them here floods every
-			// relay turn's prompt with context that has nothing to do with the
-			// sender. Facts stored against the automated sender's own entity still
-			// load — they genuinely describe the speaker.
+			// The room pool is fetched for every sender, automated or human: relay
+			// webhooks and bridge bots carry real human conversation, so dropping
+			// the room pool for them would zero out fact recall on exactly those
+			// turns. Misattribution is prevented at render time instead — facts
+			// are attributed by provenance, so room facts about other participants
+			// never render under the sender's header.
 			const relatedEntityIds = await getRelatedEntityIds(
 				runtime,
 				message.entityId,
 			);
-			const includeRoomPool = !isAutomatedSenderTurn(message);
 			const [roomFacts, ...entityFactPools] = await Promise.all([
-				includeRoomPool
-					? runtime.getMemories({
-							tableName: "facts",
-							roomId: message.roomId,
-							worldId: message.worldId,
-							count: CANDIDATE_POOL_PER_SEARCH,
-							unique: false,
-						})
-					: Promise.resolve([] as Memory[]),
+				runtime.getMemories({
+					tableName: "facts",
+					roomId: message.roomId,
+					worldId: message.worldId,
+					count: CANDIDATE_POOL_PER_SEARCH,
+					unique: false,
+				}),
 				...relatedEntityIds.map((entityId) =>
 					runtime.getMemories({
 						tableName: "facts",

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
@@ -25,6 +25,7 @@
 import { getEntityDetails } from "../../../entities.ts";
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { getRelatedEntityIds } from "../../../identity-clusters.ts";
+import { isInternalBridgeMessage } from "../../../messaging/automated-turns.ts";
 import type {
 	CustomMetadata,
 	Entity,
@@ -43,10 +44,6 @@ const spec = requireProviderSpec("RECENT_MESSAGES");
 const MAX_RECENT_MESSAGES_LOOKBACK = 50;
 const MAX_RECENT_INTERACTIONS = 20;
 const MAX_COMPACT_LEDGER_CHARS = 4000;
-const INTERNAL_BRIDGE_MESSAGE_SOURCES = new Set([
-	"acpx:sub-agent-router",
-	"swarm_synthesis",
-]);
 const INTERNAL_TOOL_TRANSCRIPT_MARKERS = [
 	"[tool output:",
 	"[/tool output]",
@@ -146,20 +143,6 @@ function isSyntheticAssistantFailureMessage(
 	return (
 		/\bprovider issue\b/.test(normalized) ||
 		/^something went wrong on my end\b/.test(normalized)
-	);
-}
-
-function isInternalBridgeMessage(memory: Memory): boolean {
-	const source =
-		typeof memory.content.source === "string"
-			? memory.content.source.trim()
-			: "";
-	const metadata =
-		memory.content?.metadata && typeof memory.content.metadata === "object"
-			? (memory.content.metadata as Record<string, unknown>)
-			: {};
-	return (
-		INTERNAL_BRIDGE_MESSAGE_SOURCES.has(source) || metadata.subAgent === true
 	);
 }
 

--- a/packages/core/src/messaging/automated-turns.test.ts
+++ b/packages/core/src/messaging/automated-turns.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for the automated-turn classifiers: connector-stamped `fromBot`
+ * (both metadata locations), internal bridge sources, sub-agent metadata, and
+ * the human default when no structural signal is present.
+ */
+import { describe, expect, it } from "vitest";
+import type { Memory, UUID } from "../types/index.ts";
+import {
+	isAutomatedSenderTurn,
+	isBotAuthoredMessage,
+	isInternalBridgeMessage,
+} from "./automated-turns.ts";
+
+function makeMemory(overrides: Partial<Memory> = {}): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000001" as UUID,
+		entityId: "00000000-0000-0000-0000-000000000002" as UUID,
+		roomId: "00000000-0000-0000-0000-000000000003" as UUID,
+		content: { text: "hello" },
+		...overrides,
+	} as Memory;
+}
+
+describe("automated-turn classifiers", () => {
+	it("treats unstamped messages as human", () => {
+		const memory = makeMemory({ content: { text: "gm", source: "discord" } });
+		expect(isBotAuthoredMessage(memory)).toBe(false);
+		expect(isInternalBridgeMessage(memory)).toBe(false);
+		expect(isAutomatedSenderTurn(memory)).toBe(false);
+	});
+
+	it("detects connector-stamped fromBot in content metadata", () => {
+		const memory = makeMemory({
+			content: {
+				text: "relayed",
+				source: "discord",
+				metadata: { fromBot: true },
+			},
+		});
+		expect(isBotAuthoredMessage(memory)).toBe(true);
+		expect(isAutomatedSenderTurn(memory)).toBe(true);
+	});
+
+	it("detects connector-stamped fromBot in top-level metadata", () => {
+		const memory = makeMemory({
+			metadata: { fromBot: true } as Memory["metadata"],
+		});
+		expect(isBotAuthoredMessage(memory)).toBe(true);
+		expect(isAutomatedSenderTurn(memory)).toBe(true);
+	});
+
+	it("detects internal bridge sources", () => {
+		for (const source of ["acpx:sub-agent-router", "swarm_synthesis"]) {
+			const memory = makeMemory({ content: { text: "x", source } });
+			expect(isInternalBridgeMessage(memory)).toBe(true);
+			expect(isAutomatedSenderTurn(memory)).toBe(true);
+		}
+	});
+
+	it("detects sub-agent rows via content metadata", () => {
+		const memory = makeMemory({
+			content: { text: "done", metadata: { subAgent: true } },
+		});
+		expect(isInternalBridgeMessage(memory)).toBe(true);
+	});
+
+	it("does not treat a truthy non-boolean stamp as automation", () => {
+		const memory = makeMemory({
+			content: { text: "gm", metadata: { fromBot: "yes" } },
+		});
+		expect(isBotAuthoredMessage(memory)).toBe(false);
+	});
+});

--- a/packages/core/src/messaging/automated-turns.test.ts
+++ b/packages/core/src/messaging/automated-turns.test.ts
@@ -1,15 +1,11 @@
 /**
- * Unit tests for the automated-turn classifiers: connector-stamped `fromBot`
- * (both metadata locations), internal bridge sources, sub-agent metadata, and
- * the human default when no structural signal is present.
+ * Unit tests for the internal-bridge-row classifier: bridge sources,
+ * sub-agent metadata, and the human default when no structural signal is
+ * present.
  */
 import { describe, expect, it } from "vitest";
 import type { Memory, UUID } from "../types/index.ts";
-import {
-	isAutomatedSenderTurn,
-	isBotAuthoredMessage,
-	isInternalBridgeMessage,
-} from "./automated-turns.ts";
+import { isInternalBridgeMessage } from "./automated-turns.ts";
 
 function makeMemory(overrides: Partial<Memory> = {}): Memory {
 	return {
@@ -21,39 +17,16 @@ function makeMemory(overrides: Partial<Memory> = {}): Memory {
 	} as Memory;
 }
 
-describe("automated-turn classifiers", () => {
+describe("isInternalBridgeMessage", () => {
 	it("treats unstamped messages as human", () => {
 		const memory = makeMemory({ content: { text: "gm", source: "discord" } });
-		expect(isBotAuthoredMessage(memory)).toBe(false);
 		expect(isInternalBridgeMessage(memory)).toBe(false);
-		expect(isAutomatedSenderTurn(memory)).toBe(false);
-	});
-
-	it("detects connector-stamped fromBot in content metadata", () => {
-		const memory = makeMemory({
-			content: {
-				text: "relayed",
-				source: "discord",
-				metadata: { fromBot: true },
-			},
-		});
-		expect(isBotAuthoredMessage(memory)).toBe(true);
-		expect(isAutomatedSenderTurn(memory)).toBe(true);
-	});
-
-	it("detects connector-stamped fromBot in top-level metadata", () => {
-		const memory = makeMemory({
-			metadata: { fromBot: true } as Memory["metadata"],
-		});
-		expect(isBotAuthoredMessage(memory)).toBe(true);
-		expect(isAutomatedSenderTurn(memory)).toBe(true);
 	});
 
 	it("detects internal bridge sources", () => {
 		for (const source of ["acpx:sub-agent-router", "swarm_synthesis"]) {
 			const memory = makeMemory({ content: { text: "x", source } });
 			expect(isInternalBridgeMessage(memory)).toBe(true);
-			expect(isAutomatedSenderTurn(memory)).toBe(true);
 		}
 	});
 
@@ -66,8 +39,8 @@ describe("automated-turn classifiers", () => {
 
 	it("does not treat a truthy non-boolean stamp as automation", () => {
 		const memory = makeMemory({
-			content: { text: "gm", metadata: { fromBot: "yes" } },
+			content: { text: "gm", metadata: { subAgent: "yes" } },
 		});
-		expect(isBotAuthoredMessage(memory)).toBe(false);
+		expect(isInternalBridgeMessage(memory)).toBe(false);
 	});
 });

--- a/packages/core/src/messaging/automated-turns.ts
+++ b/packages/core/src/messaging/automated-turns.ts
@@ -1,20 +1,13 @@
 /**
- * Structural classifiers for message turns authored by automation rather than
- * a human speaker. Two independent signals, both stamped structurally (never
- * inferred from message text):
- *
- *   - internal bridge rows — messages injected by the agent's own machinery
- *     (sub-agent relay, swarm synthesis), identified by `content.source` or
- *     sub-agent metadata; and
- *   - connector-stamped bot/webhook authorship — the `fromBot` metadata flag
- *     connectors set at ingestion for webhook and bot-account senders.
- *
- * Prompt-composition consumers gate on these: RECENT_MESSAGES strips bridge
- * rows from the transcript, FACTS skips room-scoped fact pools for automated
- * senders (room facts describe other participants and must not be attributed
- * to a relay bot), and the composeState onlyInclude path enforces provider
- * roleGates for automated senders. Absence of every signal means the turn is
- * treated as human — connectors that stamp nothing keep today's behavior.
+ * Structural classifier for message rows injected by the agent's own bridge
+ * machinery (sub-agent relay, swarm synthesis), identified by `content.source`
+ * or sub-agent metadata — stamped structurally, never inferred from message
+ * text. RECENT_MESSAGES uses it to strip bridge rows from the transcript.
+ * Consumers must only use this signal to change HOW a turn is presented,
+ * never to withhold recall: bridge rows sit inside real human conversation,
+ * so gating context providers off this signal silently blinds the agent on
+ * exactly those turns. Absence of the signal means the turn is treated as
+ * human — connectors that stamp nothing keep today's behavior.
  */
 import type { Memory } from "../types/memory";
 
@@ -39,17 +32,4 @@ export function isInternalBridgeMessage(memory: Memory): boolean {
 		return true;
 	}
 	return metadataRecord(memory.content?.metadata)?.subAgent === true;
-}
-
-/** Message whose sender the connector positively stamped as a bot/webhook. */
-export function isBotAuthoredMessage(memory: Memory): boolean {
-	return (
-		metadataRecord(memory.content?.metadata)?.fromBot === true ||
-		metadataRecord(memory.metadata)?.fromBot === true
-	);
-}
-
-/** Either automation signal — the turn was not authored by a human speaker. */
-export function isAutomatedSenderTurn(memory: Memory): boolean {
-	return isBotAuthoredMessage(memory) || isInternalBridgeMessage(memory);
 }

--- a/packages/core/src/messaging/automated-turns.ts
+++ b/packages/core/src/messaging/automated-turns.ts
@@ -1,0 +1,55 @@
+/**
+ * Structural classifiers for message turns authored by automation rather than
+ * a human speaker. Two independent signals, both stamped structurally (never
+ * inferred from message text):
+ *
+ *   - internal bridge rows — messages injected by the agent's own machinery
+ *     (sub-agent relay, swarm synthesis), identified by `content.source` or
+ *     sub-agent metadata; and
+ *   - connector-stamped bot/webhook authorship — the `fromBot` metadata flag
+ *     connectors set at ingestion for webhook and bot-account senders.
+ *
+ * Prompt-composition consumers gate on these: RECENT_MESSAGES strips bridge
+ * rows from the transcript, FACTS skips room-scoped fact pools for automated
+ * senders (room facts describe other participants and must not be attributed
+ * to a relay bot), and the composeState onlyInclude path enforces provider
+ * roleGates for automated senders. Absence of every signal means the turn is
+ * treated as human — connectors that stamp nothing keep today's behavior.
+ */
+import type { Memory } from "../types/memory";
+
+export const INTERNAL_BRIDGE_MESSAGE_SOURCES: ReadonlySet<string> = new Set([
+	"acpx:sub-agent-router",
+	"swarm_synthesis",
+]);
+
+function metadataRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+/** Message injected by the agent's own sub-agent/swarm bridge machinery. */
+export function isInternalBridgeMessage(memory: Memory): boolean {
+	const source =
+		typeof memory.content?.source === "string"
+			? memory.content.source.trim()
+			: "";
+	if (INTERNAL_BRIDGE_MESSAGE_SOURCES.has(source)) {
+		return true;
+	}
+	return metadataRecord(memory.content?.metadata)?.subAgent === true;
+}
+
+/** Message whose sender the connector positively stamped as a bot/webhook. */
+export function isBotAuthoredMessage(memory: Memory): boolean {
+	return (
+		metadataRecord(memory.content?.metadata)?.fromBot === true ||
+		metadataRecord(memory.metadata)?.fromBot === true
+	);
+}
+
+/** Either automation signal — the turn was not authored by a human speaker. */
+export function isAutomatedSenderTurn(memory: Memory): boolean {
+	return isBotAuthoredMessage(memory) || isInternalBridgeMessage(memory);
+}

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -47,7 +47,6 @@ import {
 	setInferenceModelProvider,
 } from "./inference-timing";
 import { createLogger } from "./logger";
-import { isAutomatedSenderTurn } from "./messaging/automated-turns";
 import { simpleHash } from "./optimization/ab-analysis";
 import { getOptimizationRootDir } from "./optimization-root-dir";
 import { installRuntimePluginLifecycle } from "./plugin-lifecycle";
@@ -60,7 +59,6 @@ import {
 	resolveNativeRuntimeFeatureFromPluginName,
 	resolveNativeRuntimeFeatureFromServiceType,
 } from "./plugins/native-features";
-import { checkSenderRole } from "./roles";
 import {
 	executeChainWithFallback,
 	isLocalProvider,
@@ -75,7 +73,6 @@ import {
 } from "./runtime/action-routing-context";
 import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "./runtime/builtin-field-evaluators";
 import { ChatPreHandlerRegistry } from "./runtime/chat-pre-handler-registry";
-import { satisfiesRoleGate } from "./runtime/context-gates";
 import { ContextRegistry } from "./runtime/context-registry";
 import { DEFAULT_CONTEXT_DEFINITIONS } from "./runtime/default-contexts";
 import { findEquivalentFactId } from "./runtime/fact-write-dedupe";
@@ -242,7 +239,7 @@ import type {
 	ChatPreHandlerContext,
 	ChatPreHandlerResult,
 } from "./types/chat-pre-handler";
-import type { AgentContext, RoleGateRole } from "./types/contexts";
+import type { AgentContext } from "./types/contexts";
 import type { IMessageService } from "./types/message-service";
 import {
 	afterMemoryPersistedPipelineHookContext,
@@ -4050,39 +4047,6 @@ export class AgentRuntime implements IAgentRuntime {
 		);
 	}
 
-	/**
-	 * Sender roles used to enforce provider roleGates on explicitly-requested
-	 * provider lists (composeState onlyInclude). Mirrors Stage-1 semantics:
-	 * the agent's own synthetic messages act as OWNER, and a failed or absent
-	 * world-role lookup degrades to the lenient USER default so local-only
-	 * usage is never blocked.
-	 */
-	private async resolveSenderRolesForProviderGating(
-		message: Memory,
-	): Promise<RoleGateRole[]> {
-		if (
-			typeof message.entityId === "string" &&
-			message.entityId === this.agentId
-		) {
-			return ["OWNER"];
-		}
-		try {
-			const result = await checkSenderRole(this, message);
-			if (result?.role) {
-				return [result.role as RoleGateRole];
-			}
-		} catch (error) {
-			// error-policy:J4 role lookup is best-effort prompt gating — degrade to
-			// the lenient USER default (same as resolveStage1SenderRole) instead of
-			// failing the whole state composition.
-			this.logger.debug(
-				{ src: "agent", agentId: this.agentId, error },
-				"Sender role lookup for provider gating failed; defaulting to USER",
-			);
-		}
-		return ["USER"];
-	}
-
 	async composeState(
 		message: Memory,
 		includeList: string[] | null = null,
@@ -4124,31 +4088,15 @@ export class AgentRuntime implements IAgentRuntime {
 		);
 		const providerNames = new Set<string>();
 		if (filterList && filterList.length > 0) {
-			// The onlyInclude path hands a fixed name list straight through, which
-			// historically bypassed every provider's declared roleGate — the Stage-1
-			// response state force-includes FACTS for every sender, so relay
-			// webhooks and bridge bots pulled role-gated personal fact pools into
-			// their prompts. Enforce the declared gate here, but ONLY for turns
-			// structurally stamped as automation (`fromBot` / bridge sources):
-			// unassigned human world members resolve to GUEST by default
-			// (roles.ts getEntityRole), so blanket enforcement would silently strip
-			// FACTS recall and baseline context from ordinary humans. Role lookup
-			// is lazy — lists with no role-gated providers pay nothing.
-			const roleGateByName = new Map<string, Provider["roleGate"]>();
-			for (const provider of this.providers) {
-				if (provider.roleGate && filterList.includes(provider.name)) {
-					roleGateByName.set(provider.name, provider.roleGate);
-				}
-			}
-			const senderRoles =
-				roleGateByName.size > 0 && isAutomatedSenderTurn(message)
-					? await this.resolveSenderRolesForProviderGating(message)
-					: null;
+			// The onlyInclude path honors the explicit name list without enforcing
+			// provider roleGates: the Stage-1 response state deliberately
+			// force-includes recall providers like FACTS for every sender, and
+			// unassigned senders (ordinary humans AND relay/webhook bridges
+			// carrying human conversation) resolve to GUEST by default (roles.ts
+			// getEntityRole), so gate enforcement here would silently strip
+			// cross-turn recall from exactly the turns that need it. Callers that
+			// name a provider explicitly own that inclusion decision.
 			for (const name of filterList) {
-				const gate = roleGateByName.get(name);
-				if (gate && senderRoles && !satisfiesRoleGate(senderRoles, gate)) {
-					continue;
-				}
 				providerNames.add(name);
 			}
 		} else {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -47,6 +47,7 @@ import {
 	setInferenceModelProvider,
 } from "./inference-timing";
 import { createLogger } from "./logger";
+import { isAutomatedSenderTurn } from "./messaging/automated-turns";
 import { simpleHash } from "./optimization/ab-analysis";
 import { getOptimizationRootDir } from "./optimization-root-dir";
 import { installRuntimePluginLifecycle } from "./plugin-lifecycle";
@@ -59,6 +60,7 @@ import {
 	resolveNativeRuntimeFeatureFromPluginName,
 	resolveNativeRuntimeFeatureFromServiceType,
 } from "./plugins/native-features";
+import { checkSenderRole } from "./roles";
 import {
 	executeChainWithFallback,
 	isLocalProvider,
@@ -73,6 +75,7 @@ import {
 } from "./runtime/action-routing-context";
 import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "./runtime/builtin-field-evaluators";
 import { ChatPreHandlerRegistry } from "./runtime/chat-pre-handler-registry";
+import { satisfiesRoleGate } from "./runtime/context-gates";
 import { ContextRegistry } from "./runtime/context-registry";
 import { DEFAULT_CONTEXT_DEFINITIONS } from "./runtime/default-contexts";
 import { findEquivalentFactId } from "./runtime/fact-write-dedupe";
@@ -239,7 +242,7 @@ import type {
 	ChatPreHandlerContext,
 	ChatPreHandlerResult,
 } from "./types/chat-pre-handler";
-import type { AgentContext } from "./types/contexts";
+import type { AgentContext, RoleGateRole } from "./types/contexts";
 import type { IMessageService } from "./types/message-service";
 import {
 	afterMemoryPersistedPipelineHookContext,
@@ -4047,6 +4050,39 @@ export class AgentRuntime implements IAgentRuntime {
 		);
 	}
 
+	/**
+	 * Sender roles used to enforce provider roleGates on explicitly-requested
+	 * provider lists (composeState onlyInclude). Mirrors Stage-1 semantics:
+	 * the agent's own synthetic messages act as OWNER, and a failed or absent
+	 * world-role lookup degrades to the lenient USER default so local-only
+	 * usage is never blocked.
+	 */
+	private async resolveSenderRolesForProviderGating(
+		message: Memory,
+	): Promise<RoleGateRole[]> {
+		if (
+			typeof message.entityId === "string" &&
+			message.entityId === this.agentId
+		) {
+			return ["OWNER"];
+		}
+		try {
+			const result = await checkSenderRole(this, message);
+			if (result?.role) {
+				return [result.role as RoleGateRole];
+			}
+		} catch (error) {
+			// error-policy:J4 role lookup is best-effort prompt gating — degrade to
+			// the lenient USER default (same as resolveStage1SenderRole) instead of
+			// failing the whole state composition.
+			this.logger.debug(
+				{ src: "agent", agentId: this.agentId, error },
+				"Sender role lookup for provider gating failed; defaulting to USER",
+			);
+		}
+		return ["USER"];
+	}
+
 	async composeState(
 		message: Memory,
 		includeList: string[] | null = null,
@@ -4088,7 +4124,31 @@ export class AgentRuntime implements IAgentRuntime {
 		);
 		const providerNames = new Set<string>();
 		if (filterList && filterList.length > 0) {
+			// The onlyInclude path hands a fixed name list straight through, which
+			// historically bypassed every provider's declared roleGate — the Stage-1
+			// response state force-includes FACTS for every sender, so relay
+			// webhooks and bridge bots pulled role-gated personal fact pools into
+			// their prompts. Enforce the declared gate here, but ONLY for turns
+			// structurally stamped as automation (`fromBot` / bridge sources):
+			// unassigned human world members resolve to GUEST by default
+			// (roles.ts getEntityRole), so blanket enforcement would silently strip
+			// FACTS recall and baseline context from ordinary humans. Role lookup
+			// is lazy — lists with no role-gated providers pay nothing.
+			const roleGateByName = new Map<string, Provider["roleGate"]>();
+			for (const provider of this.providers) {
+				if (provider.roleGate && filterList.includes(provider.name)) {
+					roleGateByName.set(provider.name, provider.roleGate);
+				}
+			}
+			const senderRoles =
+				roleGateByName.size > 0 && isAutomatedSenderTurn(message)
+					? await this.resolveSenderRolesForProviderGating(message)
+					: null;
 			for (const name of filterList) {
+				const gate = roleGateByName.get(name);
+				if (gate && senderRoles && !satisfiesRoleGate(senderRoles, gate)) {
+					continue;
+				}
 				providerNames.add(name);
 			}
 		} else {


### PR DESCRIPTION
## Problem

On relay/webhook turns the FACTS provider renders room-scoped facts as facts about the sender. Live noise trajectory `tj-9964e1860d01c1` seg 4 (435 chars): the sender is the "2fingersBTW | ZenithProxy" relay webhook, yet the prompt block reads `Things remilio nubilio knows about the speaker: [durable] nubs created remilio_nubilio / Odilitime authored ruby-high PR #48...` — facts about other people, attributed to the bridge bot, re-rendered on every relay turn.

Root cause: `facts.ts` merges the room/world-scoped candidate pool with the sender-entity pools, then renders **everything** under the sender-attributed `Things <agent> knows about <sender>:` header.

## Fix (structural, one layer)

**Provenance split in `facts.ts`**: only facts stored against the sender's identity cluster (`getRelatedEntityIds`) render under the speaker headers; room-pool facts about other participants render under a neutral `Known facts in this room (about other participants):` / `What's currently happening in this room:` header. Correct attribution for every sender, human or bot — and recall is unchanged.

### Why attribution-only, not suppression (revised after adversarial review)

The first cut of this PR added two extra suppression layers — skipping the room-pool fetch for automated senders in `facts.ts`, and enforcing provider `roleGate`s on the `composeState` onlyInclude path for automated senders. Adversarial review showed the two layers contradict and together zero out recall on relay turns:

- FACTS declares `roleGate: { minRole: "USER" }` (pre-existing), and a roleless relay/webhook bridge entity resolves to **GUEST** (`roles.ts` `getEntityRole`) — so the onlyInclude enforcement dropped the **entire FACTS provider** from Stage-1 compose on automated turns, making the "facts stored against the automated sender's own entity still load" branch in `facts.ts` dead code for exactly the senders it was written for.
- Even where FACTS composed (bridge granted an explicit role), the room-pool skip meant a human question relayed through the bridge (the ZenithProxy pattern above — bridges carry real human conversation) went from "room facts recallable with a misattributing header" to `No facts available.` — a recall regression.

The neutral-header provenance split alone fixes the misattribution without dropping recall, so both suppression layers are removed: the room pool is always fetched, the onlyInclude path honors the explicit provider list without roleGate enforcement (a why-comment now pins that invariant at the call site), and the now-unconsumed `isAutomatedSenderTurn`/`isBotAuthoredMessage` classifiers are deleted. `recentMessages.ts` keeps the shared `isInternalBridgeMessage` module (deduplicating its former private copy).

## Verification

Regression tests red on the suppression-layer version (4 failed, everything else green — proving they pin the defect):

```
× keeps role-gated providers for bot-authored senders without a world role
× keeps role-gated providers for internal bridge sources without a world role
× keeps room facts recallable for connector-stamped bot/webhook senders, under the neutral header
× keeps both the sender's own facts and room facts for internal bridge sources
Tests  4 failed | 7 passed (11)
```

Green with the fix:

- Directly-affected suites (facts, automated-turns, compose-state-role-gate, compose-state-refresh): **27/27 passed (4 files)**.
- `packages/core src/__tests__`: **346/348** — the 2 fails (`action-handler-callsite-audit`, `tiered-action-surface`) reproduce identically on clean develop (pre-existing).
- `packages/core src/features + src/messaging`: **622/623** — the 1 fail (`link-extraction`) also reproduces on clean develop (pre-existing).
- `bun run --cwd packages/core typecheck`: clean (exit 0).
- `biome lint` (rules) on all changed files: 0 diagnostics.

The misattribution fix is asserted structurally: room facts about other entities render under `Known facts in this room` and never under a `knows about <sender>` header, on human, `fromBot`-stamped, and bridge-source turns alike; sender-cluster facts keep the speaker header.

Evidence not applicable: UI screenshots/video N/A — server-side prompt composition with no rendered surface; behavior is pinned by deterministic tests asserting the exact rendered provider text. Live-LLM trajectory N/A for this PR — the defect and fix are in deterministic prompt assembly upstream of the model; the failing prompt block from live trajectory `tj-9964e1860d01c1` is quoted above as the originating evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
