### PR TITLE
fix(#12488): map Google Meet artifacts

### DIFF
--- a/.github/issue-evidence/12488-google-meet-adapter.md
+++ b/.github/issue-evidence/12488-google-meet-adapter.md
@@ -1,0 +1,56 @@
+# Evidence for #12488 - Google Meet Adapter Completion
+
+## Code PR
+
+https://github.com/elizaOS/eliza/pull/13198
+
+## Human Follow-Up
+
+https://github.com/elizaOS/eliza/issues/13199
+
+## Agent-Completed Work
+
+- Added Google Meet participant-session import via `participantSessions.list`.
+- Added a canonical `elizaos.meeting_artifact.v1` artifact mapper for Google Meet conference records, participants, participant sessions, transcript artifacts/entries, Google Docs transcript text, recordings, generated notes, and bot-free capture artifacts.
+- Preserved transcript-entry vs Google Docs transcript mismatch warnings.
+- Added missing-artifact classifications for no transcript, delayed transcript, missing recording, revoked access, permission denied, meeting not found, organizer-only artifacts, and expired media URLs.
+- Added deterministic fixture tests over saved Google API response-shaped objects; no live Google API was contacted.
+- Documented the Google Meet canonical artifact contract in the plugin README and package agent guide.
+
+## Verification
+
+Commands run on 2026-07-04:
+
+```bash
+bun install
+```
+
+Result: completed; no intended dependency changes were kept in this PR.
+
+```bash
+bun run verify
+```
+
+Result: failed in the repo-wide lint lane outside this PR. `@elizaos/plugin-google#lint` passed, but `@elizaos/tui#lint` failed on existing `lint/suspicious/noControlCharactersInRegex` diagnostics in `packages/tui/src/keys.ts`, `packages/tui/src/terminal.ts`, and `packages/tui/test/key-tester.ts`, plus existing style diagnostics in the same package. No `packages/tui` files are touched by this PR.
+
+```bash
+bun run --cwd plugins/plugin-google typecheck
+```
+
+Result: passed.
+
+```bash
+bun run --cwd plugins/plugin-google test
+```
+
+Result: 4 test files passed, 29 tests passed.
+
+```bash
+bun run --cwd plugins/plugin-google lint:check
+```
+
+Result: passed.
+
+## Not Captured By Agent
+
+N/A for live Google product proof in this code PR. The follow-up human issue must capture a live sandbox Google Meet import, a bot-free Google Meet desktop/web capture walkthrough, structured backend logs, imported canonical artifact JSON, transcript text artifact, recording/media artifact or explicit `N/A - <reason>`, and failure-path evidence for no transcript, revoked access, delayed transcript, permission denied, organizer-only artifacts, and expired media URLs.

--- a/plugins/plugin-google/AGENTS.md
+++ b/plugins/plugin-google/AGENTS.md
@@ -40,9 +40,10 @@ Drive (`src/drive.ts` via `GoogleDriveClient`):
 
 Meet (`src/meet.ts` via `GoogleMeetClient`):
 - `createMeeting` / `getMeeting` / `getMeetingSpace` — space management.
-- `getConferenceRecord` / `listMeetingParticipants` / `listMeetingTranscripts` / `getMeetingTranscript` / `listMeetingRecordings` / `getMeetingRecordingUrl` — conference artifacts.
+- `getConferenceRecord` / `listMeetingParticipants` / `listMeetingParticipantSessions` / `listMeetingTranscripts` / `getMeetingTranscript` / `listMeetingRecordings` / `getMeetingRecordingUrl` — conference artifacts.
 - `endMeeting` — ends an active conference.
-- `generateReport` — builds a structured `GoogleMeetReport` from transcript + recording artifacts.
+- `generateReport` — builds a structured `GoogleMeetReport` from transcript + recording artifacts and includes a canonical `elizaos.meeting_artifact.v1` artifact.
+- `buildGoogleMeetCanonicalArtifact` / `classifyGoogleMeetImportError` — deterministic fixture helpers for saved Google API responses, Google Docs transcript mismatch warnings, missing-artifact classifications, and bot-free capture mapping.
 
 OAuth helpers (`src/auth.ts`):
 - `getGoogleOAuthProviderMetadata()` / `getGoogleOAuthProviderConfig(capabilities)` — returns the OAuth provider metadata and a capability-scoped config for the connector manager.
@@ -67,6 +68,19 @@ src/
   drive.ts                     GoogleDriveClient — Drive/Docs/Sheets operations
   meet.ts                      GoogleMeetClient — Meet space/conference/artifact operations
 ```
+
+## Meet Artifact Contract
+
+The Google Meet import path maps native Meet conference records, participants,
+participant sessions, transcript artifacts/entries, Google Docs transcript text,
+recordings, and optional bot-free capture artifacts into
+`GoogleMeetCanonicalArtifact` (`schemaVersion: "elizaos.meeting_artifact.v1"`).
+The canonical artifact preserves streams, participants, participant sessions,
+transcript spans, generated summary/key-point/action-item notes, warnings, and
+missing-artifact classifications for no transcript, delayed transcript, missing
+recording, revoked access, permission denied, meeting not found,
+organizer-only artifacts, and expired media URLs. Live sandbox evidence still
+requires real Google account access and belongs in `.github/issue-evidence/`.
 
 ## Commands
 

--- a/plugins/plugin-google/CLAUDE.md
+++ b/plugins/plugin-google/CLAUDE.md
@@ -40,9 +40,10 @@ Drive (`src/drive.ts` via `GoogleDriveClient`):
 
 Meet (`src/meet.ts` via `GoogleMeetClient`):
 - `createMeeting` / `getMeeting` / `getMeetingSpace` — space management.
-- `getConferenceRecord` / `listMeetingParticipants` / `listMeetingTranscripts` / `getMeetingTranscript` / `listMeetingRecordings` / `getMeetingRecordingUrl` — conference artifacts.
+- `getConferenceRecord` / `listMeetingParticipants` / `listMeetingParticipantSessions` / `listMeetingTranscripts` / `getMeetingTranscript` / `listMeetingRecordings` / `getMeetingRecordingUrl` — conference artifacts.
 - `endMeeting` — ends an active conference.
-- `generateReport` — builds a structured `GoogleMeetReport` from transcript + recording artifacts.
+- `generateReport` — builds a structured `GoogleMeetReport` from transcript + recording artifacts and includes a canonical `elizaos.meeting_artifact.v1` artifact.
+- `buildGoogleMeetCanonicalArtifact` / `classifyGoogleMeetImportError` — deterministic fixture helpers for saved Google API responses, Google Docs transcript mismatch warnings, missing-artifact classifications, and bot-free capture mapping.
 
 OAuth helpers (`src/auth.ts`):
 - `getGoogleOAuthProviderMetadata()` / `getGoogleOAuthProviderConfig(capabilities)` — returns the OAuth provider metadata and a capability-scoped config for the connector manager.
@@ -67,6 +68,19 @@ src/
   drive.ts                     GoogleDriveClient — Drive/Docs/Sheets operations
   meet.ts                      GoogleMeetClient — Meet space/conference/artifact operations
 ```
+
+## Meet Artifact Contract
+
+The Google Meet import path maps native Meet conference records, participants,
+participant sessions, transcript artifacts/entries, Google Docs transcript text,
+recordings, and optional bot-free capture artifacts into
+`GoogleMeetCanonicalArtifact` (`schemaVersion: "elizaos.meeting_artifact.v1"`).
+The canonical artifact preserves streams, participants, participant sessions,
+transcript spans, generated summary/key-point/action-item notes, warnings, and
+missing-artifact classifications for no transcript, delayed transcript, missing
+recording, revoked access, permission denied, meeting not found,
+organizer-only artifacts, and expired media URLs. Live sandbox evidence still
+requires real Google account access and belongs in `.github/issue-evidence/`.
 
 ## Commands
 

--- a/plugins/plugin-google/README.md
+++ b/plugins/plugin-google/README.md
@@ -43,10 +43,15 @@ The plugin also registers with the elizaOS `ConnectorAccountManager` so the buil
 
 - Create meeting spaces
 - Get space details and active conference records
-- List participants, transcripts, and recordings
+- List participants, participant sessions, transcripts, and recordings
 - Fetch full transcript entries
 - End an active conference
 - Generate a structured meeting report (summary, key points, action items, full transcript)
+- Build a canonical `elizaos.meeting_artifact.v1` artifact from Google Meet API
+  responses, Google Docs transcript text, recordings, and bot-free capture
+  artifacts. The canonical artifact preserves streams, participants, participant
+  sessions, transcript spans, generated notes, mismatch warnings, missing
+  artifact classifications, and import metrics.
 
 ## Requirements
 

--- a/plugins/plugin-google/src/index.test.ts
+++ b/plugins/plugin-google/src/index.test.ts
@@ -113,6 +113,7 @@ describe("google plugin", () => {
       "getMeetingSpace",
       "getConferenceRecord",
       "listMeetingParticipants",
+      "listMeetingParticipantSessions",
       "listMeetingTranscripts",
       "getMeetingTranscript",
       "listMeetingRecordings",

--- a/plugins/plugin-google/src/meet.canonical-artifact.test.ts
+++ b/plugins/plugin-google/src/meet.canonical-artifact.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Deterministic Google Meet artifact import tests. The Google API clients are
+ * stubbed with saved response-shaped objects; no live Google API is contacted.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { GoogleApiClientFactory } from "./client-factory.js";
+import {
+  buildGoogleMeetCanonicalArtifact,
+  classifyGoogleMeetImportError,
+  GoogleMeetClient,
+} from "./meet.js";
+
+const CONFERENCE_RECORD = "conferenceRecords/conf_1";
+const PARTICIPANT = `${CONFERENCE_RECORD}/participants/alice`;
+const TRANSCRIPT = `${CONFERENCE_RECORD}/transcripts/transcript_1`;
+
+describe("Google Meet canonical artifact mapping", () => {
+  it("maps saved Google and bot-free artifacts into the canonical meeting schema", () => {
+    const artifact = buildGoogleMeetCanonicalArtifact({
+      meetingId: CONFERENCE_RECORD,
+      conferenceRecordName: CONFERENCE_RECORD,
+      conference: {
+        id: CONFERENCE_RECORD,
+        name: CONFERENCE_RECORD,
+        spaceName: "spaces/abc-defg-hij",
+        startTime: "2026-07-04T14:00:00.000Z",
+        endTime: "2026-07-04T14:30:00.000Z",
+        expireTime: "2026-08-03T14:30:00.000Z",
+      },
+      participants: [
+        {
+          id: PARTICIPANT,
+          name: "Alice",
+          displayName: "Alice",
+          joinTime: "2026-07-04T14:00:10.000Z",
+          leaveTime: "2026-07-04T14:29:00.000Z",
+          isActive: false,
+          userType: "signed_in",
+        },
+      ],
+      participantSessions: [
+        {
+          id: `${PARTICIPANT}/participantSessions/session_1`,
+          name: `${PARTICIPANT}/participantSessions/session_1`,
+          participantId: PARTICIPANT,
+          participantName: PARTICIPANT,
+          startTime: "2026-07-04T14:00:10.000Z",
+          endTime: "2026-07-04T14:29:00.000Z",
+          isActive: false,
+        },
+      ],
+      transcriptArtifacts: [
+        {
+          id: TRANSCRIPT,
+          name: TRANSCRIPT,
+          documentId: "doc_1",
+          documentUri: "https://docs.google.com/document/d/doc_1",
+          startTime: "2026-07-04T14:01:00.000Z",
+          endTime: "2026-07-04T14:29:30.000Z",
+          state: "FILE_GENERATED",
+        },
+      ],
+      transcriptEntries: [
+        {
+          id: `${TRANSCRIPT}/entries/entry_1`,
+          speakerName: PARTICIPANT,
+          speakerId: PARTICIPANT,
+          text: "Alice will send notes.",
+          startTime: "2026-07-04T14:02:00.000Z",
+          endTime: "2026-07-04T14:02:05.000Z",
+          languageCode: "en-US",
+        },
+      ],
+      recordings: [
+        {
+          id: `${CONFERENCE_RECORD}/recordings/recording_1`,
+          name: `${CONFERENCE_RECORD}/recordings/recording_1`,
+          uri: "https://drive.google.com/file/d/file_1/view",
+          fileId: "file_1",
+          startTime: "2026-07-04T14:00:00.000Z",
+          endTime: "2026-07-04T14:30:00.000Z",
+          state: "FILE_GENERATED",
+        },
+        {
+          id: `${CONFERENCE_RECORD}/recordings/recording_2`,
+          name: `${CONFERENCE_RECORD}/recordings/recording_2`,
+          fileId: "file_2",
+          startTime: "2026-07-04T14:10:00.000Z",
+          endTime: "2026-07-04T14:20:00.000Z",
+          state: "FILE_GENERATED",
+        },
+      ],
+      summary: "Alice will send notes.",
+      keyPoints: ["Alice will send notes."],
+      actionItems: [{ description: "Alice will send notes.", priority: "medium" }],
+      googleDocsTranscriptText: "Alice edited the Google Docs transcript after the meeting.",
+      botFreeCapture: {
+        id: "bot-free-meet-1",
+        systemAudioUri: "file:///captures/system.wav",
+        microphoneAudioUri: "file:///captures/mic.wav",
+        screenVideoUri: "file:///captures/screen.webm",
+        startedAt: "2026-07-04T14:00:00.000Z",
+        endedAt: "2026-07-04T14:30:00.000Z",
+        transcriptSpans: [
+          {
+            id: "bot-free-entry-1",
+            speakerName: "Alice",
+            speakerId: PARTICIPANT,
+            text: "Alice will send notes.",
+            startTime: "2026-07-04T14:02:00.000Z",
+            endTime: "2026-07-04T14:02:05.000Z",
+          },
+        ],
+      },
+    });
+
+    expect(artifact.schemaVersion).toBe("elizaos.meeting_artifact.v1");
+    expect(artifact.meeting.durationMinutes).toBe(30);
+    expect(artifact.participants).toEqual([
+      expect.objectContaining({
+        id: PARTICIPANT,
+        displayName: "Alice",
+        nameProvenance: "google_signed_in",
+      }),
+    ]);
+    expect(artifact.participantSessions).toHaveLength(1);
+    expect(artifact.streams.map((stream) => stream.kind)).toEqual(
+      expect.arrayContaining([
+        "google_transcript_entries",
+        "google_docs_transcript",
+        "google_recording",
+        "bot_free_system_audio",
+        "bot_free_microphone",
+        "bot_free_screen_video",
+      ])
+    );
+    expect(artifact.transcriptSpans).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "google_meet_transcript_entry",
+          participantId: PARTICIPANT,
+          speakerLabel: "Alice",
+          text: "Alice will send notes.",
+        }),
+        expect.objectContaining({
+          source: "bot_free_capture",
+          participantId: PARTICIPANT,
+        }),
+      ])
+    );
+    expect(artifact.generatedNotes.map((note) => note.kind)).toEqual([
+      "summary",
+      "key_point",
+      "action_item",
+    ]);
+    expect(artifact.warnings.map((warning) => warning.code)).toEqual(
+      expect.arrayContaining(["docs_transcript_mismatch", "expired_media_url"])
+    );
+    expect(artifact.missingArtifacts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          artifactType: "recording",
+          reason: "expired_media_url",
+        }),
+      ])
+    );
+    expect(artifact.metrics.transcriptWordCount).toBe(8);
+  });
+
+  it("classifies Google Meet import failures into human-readable missing artifacts", () => {
+    expect(classifyGoogleMeetImportError({ code: 403, message: "Permission denied" })).toEqual(
+      expect.objectContaining({ reason: "permission_denied" })
+    );
+    expect(
+      classifyGoogleMeetImportError({ response: { status: 404 }, message: "Not found" })
+    ).toEqual(expect.objectContaining({ reason: "meeting_not_found" }));
+    expect(classifyGoogleMeetImportError({ code: 401, message: "invalid_grant revoked" })).toEqual(
+      expect.objectContaining({ reason: "revoked_access" })
+    );
+    expect(classifyGoogleMeetImportError({ code: 410, message: "media URL expired" })).toEqual(
+      expect.objectContaining({ reason: "expired_media_url" })
+    );
+  });
+
+  it("generates a canonical artifact from paged Google Meet API responses", async () => {
+    const fakeMeet = {
+      conferenceRecords: {
+        get: vi.fn(async () => ({
+          data: {
+            name: CONFERENCE_RECORD,
+            space: "spaces/abc-defg-hij",
+            startTime: "2026-07-04T14:00:00.000Z",
+            endTime: "2026-07-04T14:30:00.000Z",
+          },
+        })),
+        participants: {
+          list: vi.fn(async () => ({
+            data: {
+              participants: [
+                {
+                  name: PARTICIPANT,
+                  earliestStartTime: "2026-07-04T14:00:10.000Z",
+                  latestEndTime: "2026-07-04T14:29:00.000Z",
+                  signedinUser: { displayName: "Alice", user: "users/alice" },
+                },
+              ],
+            },
+          })),
+          participantSessions: {
+            list: vi.fn(async () => ({
+              data: {
+                participantSessions: [
+                  {
+                    name: `${PARTICIPANT}/participantSessions/session_1`,
+                    startTime: "2026-07-04T14:00:10.000Z",
+                    endTime: "2026-07-04T14:29:00.000Z",
+                  },
+                ],
+              },
+            })),
+          },
+        },
+        transcripts: {
+          list: vi.fn(async () => ({
+            data: {
+              transcripts: [
+                {
+                  name: TRANSCRIPT,
+                  docsDestination: {
+                    document: "doc_1",
+                    exportUri: "https://docs.google.com/document/d/doc_1",
+                  },
+                  startTime: "2026-07-04T14:01:00.000Z",
+                  endTime: "2026-07-04T14:29:30.000Z",
+                  state: "FILE_GENERATED",
+                },
+              ],
+            },
+          })),
+          entries: {
+            list: vi.fn(async () => ({
+              data: {
+                transcriptEntries: [
+                  {
+                    name: `${TRANSCRIPT}/entries/entry_1`,
+                    participant: PARTICIPANT,
+                    text: "Alice will send notes.",
+                    startTime: "2026-07-04T14:02:00.000Z",
+                    endTime: "2026-07-04T14:02:05.000Z",
+                    languageCode: "en-US",
+                  },
+                ],
+              },
+            })),
+          },
+        },
+        recordings: {
+          list: vi.fn(async () => ({
+            data: {
+              recordings: [
+                {
+                  name: `${CONFERENCE_RECORD}/recordings/recording_1`,
+                  driveDestination: {
+                    file: "file_1",
+                    exportUri: "https://drive.google.com/file/d/file_1/view",
+                  },
+                  startTime: "2026-07-04T14:00:00.000Z",
+                  endTime: "2026-07-04T14:30:00.000Z",
+                  state: "FILE_GENERATED",
+                },
+              ],
+            },
+          })),
+        },
+      },
+    };
+    const factory = { meet: vi.fn(async () => fakeMeet) } as unknown as GoogleApiClientFactory;
+    const client = new GoogleMeetClient(factory);
+
+    const report = await client.generateReport({
+      accountId: "acct_google_1",
+      conferenceRecordName: CONFERENCE_RECORD,
+      googleDocsTranscriptText: "Alice will send notes.",
+    });
+
+    expect(report.participantSessions).toHaveLength(1);
+    expect(report.canonicalArtifact.participantSessions).toHaveLength(1);
+    expect(report.canonicalArtifact.transcriptSpans).toEqual([
+      expect.objectContaining({
+        participantId: PARTICIPANT,
+        speakerLabel: "Alice",
+        text: "Alice will send notes.",
+      }),
+    ]);
+    expect(report.canonicalArtifact.streams.map((stream) => stream.kind)).toEqual(
+      expect.arrayContaining([
+        "google_transcript_entries",
+        "google_docs_transcript",
+        "google_recording",
+      ])
+    );
+    expect(report.canonicalArtifact.missingArtifacts).toEqual([]);
+    expect(fakeMeet.conferenceRecords.participants.participantSessions.list).toHaveBeenCalledWith({
+      parent: PARTICIPANT,
+      pageSize: 100,
+      pageToken: undefined,
+    });
+  });
+});

--- a/plugins/plugin-google/src/meet.ts
+++ b/plugins/plugin-google/src/meet.ts
@@ -10,12 +10,19 @@ import type { GoogleApiClientFactory } from "./client-factory.js";
 import type {
   GoogleAccountRef,
   GoogleMeetAccessType,
+  GoogleMeetCanonicalArtifact,
+  GoogleMeetCanonicalArtifactInput,
+  GoogleMeetCanonicalStream,
+  GoogleMeetCanonicalTranscriptSpan,
   GoogleMeetConferenceRecord,
   GoogleMeetConferenceRecordInput,
   GoogleMeetCreateMeetingInput,
   GoogleMeetGenerateReportInput,
   GoogleMeetMeeting,
+  GoogleMeetMissingArtifact,
   GoogleMeetParticipant,
+  GoogleMeetParticipantSession,
+  GoogleMeetParticipantSessionInput,
   GoogleMeetRecording,
   GoogleMeetRecordingInput,
   GoogleMeetReport,
@@ -32,6 +39,7 @@ export const GOOGLE_MEET_API_SURFACE = [
   { method: "getMeetingSpace", capabilities: ["meet.read"] },
   { method: "getConferenceRecord", capabilities: ["meet.read"] },
   { method: "listMeetingParticipants", capabilities: ["meet.read"] },
+  { method: "listMeetingParticipantSessions", capabilities: ["meet.read"] },
   { method: "listMeetingTranscripts", capabilities: ["meet.read"] },
   { method: "getMeetingTranscript", capabilities: ["meet.read"] },
   { method: "listMeetingRecordings", capabilities: ["meet.read"] },
@@ -115,6 +123,34 @@ export class GoogleMeetClient {
     } while (pageToken && (!params.limit || participants.length < params.limit));
 
     return params.limit ? participants.slice(0, params.limit) : participants;
+  }
+
+  async listMeetingParticipantSessions(
+    params: GoogleMeetParticipantSessionInput & { limit?: number }
+  ): Promise<GoogleMeetParticipantSession[]> {
+    const meet = await this.clientFactory.meet(
+      params,
+      ["meet.read"],
+      "meet.listMeetingParticipantSessions"
+    );
+    const sessions: GoogleMeetParticipantSession[] = [];
+    let pageToken: string | undefined;
+
+    do {
+      const response = await meet.conferenceRecords.participants.participantSessions.list({
+        parent: params.participantName,
+        pageSize: Math.min(params.limit ?? 100, 250),
+        pageToken,
+      });
+      sessions.push(
+        ...(response.data.participantSessions ?? []).map((session) =>
+          mapParticipantSession(session, params.participantName)
+        )
+      );
+      pageToken = response.data.nextPageToken ?? undefined;
+    } while (pageToken && (!params.limit || sessions.length < params.limit));
+
+    return params.limit ? sessions.slice(0, params.limit) : sessions;
   }
 
   async listMeetingTranscripts(
@@ -210,7 +246,9 @@ export class GoogleMeetClient {
       accountId: params.accountId,
       conferenceRecordName,
     });
-    const transcriptEntries = await this.collectTranscriptEntries(params, conferenceRecordName);
+    const participantSessions = await this.collectParticipantSessions(params, participants);
+    const transcriptArtifacts = await this.collectTranscriptArtifacts(params, conferenceRecordName);
+    const transcriptEntries = await this.collectTranscriptEntries(params, transcriptArtifacts);
     const summary = summarizeTranscript(transcriptEntries);
     const recordings =
       params.includeRecordings === false
@@ -219,6 +257,21 @@ export class GoogleMeetClient {
             accountId: params.accountId,
             conferenceRecordName,
           });
+    const canonicalArtifact = buildGoogleMeetCanonicalArtifact({
+      meetingId: params.meetingId ?? conferenceRecordName,
+      conferenceRecordName,
+      conference,
+      participants,
+      participantSessions,
+      transcriptArtifacts,
+      transcriptEntries,
+      recordings,
+      summary: params.includeSummary === false ? "" : summary.summary,
+      keyPoints: params.includeSummary === false ? [] : summary.keyPoints,
+      actionItems: params.includeActionItems === false ? [] : summary.actionItems,
+      googleDocsTranscriptText: params.googleDocsTranscriptText,
+      botFreeCapture: params.botFreeCapture,
+    });
 
     return {
       meetingId: params.meetingId ?? conferenceRecordName,
@@ -232,13 +285,34 @@ export class GoogleMeetClient {
       actionItems: params.includeActionItems === false ? [] : summary.actionItems,
       fullTranscript: params.includeTranscript === false ? [] : transcriptEntries,
       recordings,
+      participantSessions,
+      canonicalArtifact,
     };
   }
 
-  private async collectTranscriptEntries(
+  private async collectParticipantSessions(
+    params: GoogleMeetGenerateReportInput,
+    participants: readonly GoogleMeetParticipant[]
+  ): Promise<GoogleMeetParticipantSession[]> {
+    const sessionGroups = await Promise.all(
+      participants
+        .map((participant) => participant.id || participant.name)
+        .filter(Boolean)
+        .map((participantName) =>
+          this.listMeetingParticipantSessions({
+            accountId: params.accountId,
+            participantName,
+          })
+        )
+    );
+
+    return sessionGroups.flat();
+  }
+
+  private async collectTranscriptArtifacts(
     params: GoogleMeetGenerateReportInput,
     conferenceRecordName: string
-  ): Promise<GoogleMeetTranscript[]> {
+  ): Promise<GoogleMeetTranscriptArtifact[]> {
     if (
       params.includeSummary === false &&
       params.includeActionItems === false &&
@@ -247,14 +321,23 @@ export class GoogleMeetClient {
       return [];
     }
 
-    const transcriptNames = params.transcriptName
-      ? [params.transcriptName]
-      : (
-          await this.listMeetingTranscripts({
-            accountId: params.accountId,
-            conferenceRecordName,
-          })
-        ).map((transcript) => transcript.name);
+    if (params.transcriptName) {
+      return [{ id: params.transcriptName, name: params.transcriptName }];
+    }
+
+    return this.listMeetingTranscripts({
+      accountId: params.accountId,
+      conferenceRecordName,
+    });
+  }
+
+  private async collectTranscriptEntries(
+    params: GoogleMeetGenerateReportInput,
+    transcriptArtifacts: readonly GoogleMeetTranscriptArtifact[]
+  ): Promise<GoogleMeetTranscript[]> {
+    const transcriptNames = transcriptArtifacts
+      .map((transcript) => transcript.name)
+      .filter(Boolean);
 
     const transcriptGroups = await Promise.all(
       transcriptNames.map((transcriptName) =>
@@ -305,6 +388,23 @@ function mapParticipant(participant: meet_v2.Schema$Participant): GoogleMeetPart
     leaveTime: participant.latestEndTime ?? undefined,
     isActive: !participant.latestEndTime,
     userType: display.userType,
+  };
+}
+
+function mapParticipantSession(
+  session: meet_v2.Schema$ParticipantSession,
+  participantName: string
+): GoogleMeetParticipantSession {
+  const sessionName = session.name ?? "";
+
+  return {
+    id: sessionName,
+    name: sessionName,
+    participantId: participantName,
+    participantName,
+    startTime: session.startTime ?? undefined,
+    endTime: session.endTime ?? undefined,
+    isActive: !session.endTime,
   };
 }
 
@@ -443,4 +543,478 @@ function summarizeTranscript(entries: readonly GoogleMeetTranscript[]): {
     }));
 
   return { summary, keyPoints, actionItems };
+}
+
+export function buildGoogleMeetCanonicalArtifact(
+  input: GoogleMeetCanonicalArtifactInput
+): GoogleMeetCanonicalArtifact {
+  const participantById = new Map(
+    input.participants.map((participant) => [participant.id, participant])
+  );
+  const transcriptStreams = input.transcriptArtifacts.map((artifact) => ({
+    id: transcriptStreamId(artifact.name),
+    kind: "google_transcript_entries" as const,
+    artifactId: artifact.name,
+    uri: artifact.documentUri,
+    startedAt: artifact.startTime,
+    endedAt: artifact.endTime,
+    state: artifact.state,
+  }));
+  const docsStreams = input.transcriptArtifacts
+    .filter(
+      (artifact) => artifact.documentId || artifact.documentUri || input.googleDocsTranscriptText
+    )
+    .map((artifact) => ({
+      id: `${transcriptStreamId(artifact.name)}:docs`,
+      kind: "google_docs_transcript" as const,
+      artifactId: artifact.documentId ?? artifact.name,
+      uri: artifact.documentUri,
+      startedAt: artifact.startTime,
+      endedAt: artifact.endTime,
+      state: artifact.state,
+    }));
+  const recordingStreams = input.recordings.map((recording) => ({
+    id: `google-recording:${recording.name || recording.id}`,
+    kind: "google_recording" as const,
+    artifactId: recording.name || recording.id,
+    uri: recording.uri,
+    fileId: recording.fileId,
+    startedAt: recording.startTime,
+    endedAt: recording.endTime,
+    state: recording.state,
+  }));
+  const botFreeStreams = botFreeCaptureStreams(input.botFreeCapture);
+  const transcriptSpans = [
+    ...input.transcriptEntries.map((entry, index) =>
+      canonicalSpanFromEntry(entry, index, participantById)
+    ),
+    ...botFreeTranscriptSpans(input.botFreeCapture, participantById),
+  ];
+  const warnings = canonicalWarnings(input, participantById);
+  const missingArtifacts = canonicalMissingArtifacts(input);
+  const generatedNotes = canonicalGeneratedNotes({
+    summary: input.summary,
+    keyPoints: input.keyPoints,
+    actionItems: input.actionItems,
+    transcriptSpans,
+  });
+
+  return {
+    schemaVersion: "elizaos.meeting_artifact.v1",
+    source: "google_meet",
+    meeting: {
+      id: input.meetingId,
+      conferenceRecordName: input.conferenceRecordName,
+      spaceName: input.conference.spaceName,
+      startedAt: input.conference.startTime,
+      endedAt: input.conference.endTime,
+      expireTime: input.conference.expireTime,
+      durationMinutes: durationMinutes(input.conference),
+    },
+    streams: [...transcriptStreams, ...docsStreams, ...recordingStreams, ...botFreeStreams],
+    participants: input.participants.map((participant) => ({
+      id: participant.id,
+      displayName: participant.displayName ?? participant.name,
+      userType: participant.userType,
+      nameProvenance: participantNameProvenance(participant),
+    })),
+    participantSessions:
+      input.participantSessions?.map((session) => ({
+        id: session.id,
+        participantId: session.participantId,
+        startedAt: session.startTime,
+        endedAt: session.endTime,
+        isActive: session.isActive,
+      })) ?? [],
+    transcriptSpans,
+    generatedNotes,
+    recordings: [...input.recordings],
+    warnings,
+    missingArtifacts,
+    metrics: {
+      transcriptWordCount: transcriptSpans.reduce((count, span) => count + wordCount(span.text), 0),
+      participantCount: input.participants.length,
+      participantSessionCount: input.participantSessions?.length ?? 0,
+      transcriptSpanCount: transcriptSpans.length,
+      recordingCount: input.recordings.length,
+      missingArtifactCount: missingArtifacts.length,
+      warningCount: warnings.length,
+    },
+  };
+}
+
+export function classifyGoogleMeetImportError(error: unknown): GoogleMeetMissingArtifact | null {
+  const status = errorStatus(error);
+  const message = errorMessage(error);
+  const normalized = message.toLowerCase();
+
+  if (status === 401 || normalized.includes("invalid_grant") || normalized.includes("revoked")) {
+    return {
+      artifactType: "conference",
+      reason: "revoked_access",
+      message: message || "Google Meet access was revoked.",
+    };
+  }
+  if (status === 403) {
+    return {
+      artifactType: "conference",
+      reason: normalized.includes("organizer") ? "organizer_only_artifact" : "permission_denied",
+      message: message || "Google Meet artifacts are not visible to this account.",
+    };
+  }
+  if (status === 404) {
+    return {
+      artifactType: "conference",
+      reason: "meeting_not_found",
+      message: message || "Google Meet conference record was not found.",
+    };
+  }
+  if (status === 410 || normalized.includes("expired")) {
+    return {
+      artifactType: "recording",
+      reason: "expired_media_url",
+      message: message || "Google Meet media URL has expired.",
+    };
+  }
+
+  return null;
+}
+
+function canonicalSpanFromEntry(
+  entry: GoogleMeetTranscript,
+  index: number,
+  participantById: ReadonlyMap<string, GoogleMeetParticipant>
+): GoogleMeetCanonicalTranscriptSpan {
+  const participant = entry.speakerId ? participantById.get(entry.speakerId) : undefined;
+  const entryId = entry.id || `transcript-entry-${index + 1}`;
+
+  return {
+    id: entryId,
+    streamId: transcriptStreamId(transcriptNameFromEntry(entry.id)),
+    source: "google_meet_transcript_entry" as const,
+    text: entry.text,
+    participantId: entry.speakerId,
+    speakerLabel: participant?.displayName ?? participant?.name ?? entry.speakerName,
+    startedAt: entry.startTime ?? entry.timestamp,
+    endedAt: entry.endTime,
+    languageCode: entry.languageCode,
+    provenance: {
+      transcriptName: transcriptNameFromEntry(entry.id),
+      entryName: entry.id,
+      participantName: entry.speakerId,
+    },
+  };
+}
+
+function botFreeTranscriptSpans(
+  capture: GoogleMeetCanonicalArtifactInput["botFreeCapture"],
+  participantById: ReadonlyMap<string, GoogleMeetParticipant>
+): GoogleMeetCanonicalTranscriptSpan[] {
+  if (!capture?.transcriptSpans?.length) {
+    return [];
+  }
+  const streamId = capture.microphoneAudioUri
+    ? `bot-free:${capture.id}:microphone`
+    : `bot-free:${capture.id}:system-audio`;
+  return capture.transcriptSpans.map((span, index) => {
+    const participant = span.speakerId ? participantById.get(span.speakerId) : undefined;
+    return {
+      id: span.id || `bot-free-entry-${index + 1}`,
+      streamId,
+      source: "bot_free_capture" as const,
+      text: span.text,
+      participantId: span.speakerId,
+      speakerLabel: participant?.displayName ?? participant?.name ?? span.speakerName,
+      startedAt: span.startTime ?? span.timestamp,
+      endedAt: span.endTime,
+      languageCode: span.languageCode,
+      provenance: {
+        entryName: span.id,
+        participantName: span.speakerId,
+      },
+    };
+  });
+}
+
+function botFreeCaptureStreams(
+  capture: GoogleMeetCanonicalArtifactInput["botFreeCapture"]
+): GoogleMeetCanonicalStream[] {
+  if (!capture) {
+    return [];
+  }
+  const streams: GoogleMeetCanonicalStream[] = [];
+  if (capture.systemAudioUri) {
+    streams.push({
+      id: `bot-free:${capture.id}:system-audio`,
+      kind: "bot_free_system_audio",
+      artifactId: capture.id,
+      uri: capture.systemAudioUri,
+      startedAt: capture.startedAt,
+      endedAt: capture.endedAt,
+    });
+  }
+  if (capture.microphoneAudioUri) {
+    streams.push({
+      id: `bot-free:${capture.id}:microphone`,
+      kind: "bot_free_microphone",
+      artifactId: capture.id,
+      uri: capture.microphoneAudioUri,
+      startedAt: capture.startedAt,
+      endedAt: capture.endedAt,
+    });
+  }
+  if (capture.screenVideoUri) {
+    streams.push({
+      id: `bot-free:${capture.id}:screen-video`,
+      kind: "bot_free_screen_video",
+      artifactId: capture.id,
+      uri: capture.screenVideoUri,
+      startedAt: capture.startedAt,
+      endedAt: capture.endedAt,
+    });
+  }
+  return streams;
+}
+
+function canonicalWarnings(
+  input: GoogleMeetCanonicalArtifactInput,
+  participantById: ReadonlyMap<string, GoogleMeetParticipant>
+) {
+  const warnings = [];
+  const entriesText = normalizeText(input.transcriptEntries.map((entry) => entry.text).join(" "));
+  const docsText = normalizeText(input.googleDocsTranscriptText ?? "");
+  if (docsText && docsText !== entriesText) {
+    warnings.push({
+      code: "docs_transcript_mismatch" as const,
+      message:
+        "Google Meet transcript entries do not match the provided Google Docs transcript text.",
+    });
+  }
+  for (const artifact of input.transcriptArtifacts) {
+    if (artifact.documentId && !artifact.documentUri) {
+      warnings.push({
+        code: "organizer_only_artifact" as const,
+        message: "Google Docs transcript exists but no document URI was visible to this account.",
+        sourceName: artifact.name,
+      });
+    }
+  }
+  for (const recording of input.recordings) {
+    if (recording.fileId && !recording.uri) {
+      warnings.push({
+        code: "expired_media_url" as const,
+        message: "Google Meet recording file exists but no playback URI was visible.",
+        sourceName: recording.name,
+      });
+    }
+  }
+  for (const entry of input.transcriptEntries) {
+    if (!entry.text.trim()) {
+      warnings.push({
+        code: "transcript_entry_empty" as const,
+        message: "Google Meet transcript entry contained no text.",
+        sourceName: entry.id,
+      });
+    }
+    if (entry.speakerId && !participantById.has(entry.speakerId)) {
+      warnings.push({
+        code: "speaker_reference_missing" as const,
+        message: "Google Meet transcript entry referenced a participant not present in the roster.",
+        sourceName: entry.id,
+      });
+    }
+  }
+  return warnings;
+}
+
+function canonicalMissingArtifacts(input: GoogleMeetCanonicalArtifactInput) {
+  const missing: GoogleMeetMissingArtifact[] = [];
+  if (input.transcriptArtifacts.length === 0) {
+    missing.push({
+      artifactType: "transcript",
+      reason: input.conference.endTime ? "no_transcript" : "transcript_delayed",
+      message: input.conference.endTime
+        ? "No Google Meet transcript artifacts were available for the completed conference."
+        : "Google Meet transcript artifacts are not available yet for the active conference.",
+    });
+  }
+  for (const artifact of input.transcriptArtifacts) {
+    if (
+      artifact.state &&
+      artifact.state !== "FILE_GENERATED" &&
+      input.transcriptEntries.length === 0
+    ) {
+      missing.push({
+        artifactType: "transcript",
+        reason: "transcript_delayed",
+        message: "Google Meet transcript artifact exists but entries are not available yet.",
+        sourceName: artifact.name,
+      });
+    }
+    if (artifact.documentId && !artifact.documentUri) {
+      missing.push({
+        artifactType: "transcript",
+        reason: "organizer_only_artifact",
+        message: "Google Docs transcript is organizer-only or not visible to this account.",
+        sourceName: artifact.name,
+      });
+    }
+  }
+  if (input.recordings.length === 0) {
+    missing.push({
+      artifactType: "recording",
+      reason: "missing_recording",
+      message: "No Google Meet recording artifacts were available for this conference record.",
+    });
+  }
+  for (const recording of input.recordings) {
+    if (recording.fileId && !recording.uri) {
+      missing.push({
+        artifactType: "recording",
+        reason: "expired_media_url",
+        message: "Google Meet recording playback URI was unavailable or expired.",
+        sourceName: recording.name,
+      });
+    }
+  }
+  if (input.participants.length > 0 && !input.participantSessions?.length) {
+    missing.push({
+      artifactType: "participant_sessions",
+      reason: "permission_denied",
+      message: "Participants were available but no participant sessions were imported.",
+    });
+  }
+  return missing;
+}
+
+function canonicalGeneratedNotes(params: {
+  summary: string;
+  keyPoints: readonly string[];
+  actionItems: GoogleMeetCanonicalArtifactInput["actionItems"];
+  transcriptSpans: readonly GoogleMeetCanonicalTranscriptSpan[];
+}) {
+  const notes = [];
+  if (params.summary.trim()) {
+    notes.push({
+      id: "summary",
+      kind: "summary" as const,
+      text: params.summary,
+      sourceSpanIds: matchingSpanIds(params.transcriptSpans, params.summary),
+    });
+  }
+  params.keyPoints.forEach((keyPoint, index) => {
+    notes.push({
+      id: `key-point-${index + 1}`,
+      kind: "key_point" as const,
+      text: keyPoint,
+      sourceSpanIds: matchingSpanIds(params.transcriptSpans, keyPoint),
+    });
+  });
+  params.actionItems.forEach((actionItem, index) => {
+    notes.push({
+      id: `action-item-${index + 1}`,
+      kind: "action_item" as const,
+      text: actionItem.description,
+      sourceSpanIds: matchingSpanIds(params.transcriptSpans, actionItem.description),
+      assignee: actionItem.assignee,
+      dueDate: actionItem.dueDate,
+      priority: actionItem.priority,
+    });
+  });
+  return notes;
+}
+
+function matchingSpanIds(
+  spans: readonly GoogleMeetCanonicalTranscriptSpan[],
+  text: string
+): string[] {
+  const normalizedText = normalizeText(text);
+  const matches = spans
+    .filter((span) => {
+      const normalizedSpan = normalizeText(span.text);
+      return (
+        normalizedSpan &&
+        (normalizedText.includes(normalizedSpan) || normalizedSpan.includes(normalizedText))
+      );
+    })
+    .map((span) => span.id);
+  return matches.length > 0 ? matches : spans.map((span) => span.id);
+}
+
+function transcriptNameFromEntry(entryName: string | undefined): string {
+  if (!entryName) {
+    return "google-transcript";
+  }
+  const marker = "/entries/";
+  const markerIndex = entryName.indexOf(marker);
+  return markerIndex === -1 ? "google-transcript" : entryName.slice(0, markerIndex);
+}
+
+function transcriptStreamId(transcriptName: string): string {
+  return `google-transcript:${transcriptName || "unknown"}`;
+}
+
+function participantNameProvenance(
+  participant: GoogleMeetParticipant
+): GoogleMeetCanonicalArtifact["participants"][number]["nameProvenance"] {
+  if (participant.userType === "signed_in") {
+    return "google_signed_in";
+  }
+  if (participant.userType === "anonymous") {
+    return "google_anonymous";
+  }
+  if (participant.userType === "phone") {
+    return "phone";
+  }
+  return "unknown";
+}
+
+function normalizeText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function wordCount(value: string): number {
+  const normalized = normalizeText(value);
+  return normalized ? normalized.split(/\s+/).length : 0;
+}
+
+function errorStatus(error: unknown): number | null {
+  if (!isRecord(error)) {
+    return null;
+  }
+  const code = error.code;
+  if (typeof code === "number") {
+    return code;
+  }
+  const status = error.status;
+  if (typeof status === "number") {
+    return status;
+  }
+  const response = error.response;
+  if (isRecord(response) && typeof response.status === "number") {
+    return response.status;
+  }
+  return null;
+}
+
+function errorMessage(error: unknown): string {
+  if (!isRecord(error)) {
+    return String(error ?? "");
+  }
+  const message = error.message;
+  if (typeof message === "string") {
+    return message;
+  }
+  const response = error.response;
+  if (isRecord(response) && typeof response.statusText === "string") {
+    return response.statusText;
+  }
+  return "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }

--- a/plugins/plugin-google/src/service.ts
+++ b/plugins/plugin-google/src/service.ts
@@ -42,6 +42,8 @@ import {
   type GoogleMeetGetMeetingInput,
   type GoogleMeetMeeting,
   type GoogleMeetParticipant,
+  type GoogleMeetParticipantSession,
+  type GoogleMeetParticipantSessionInput,
   type GoogleMeetRecording,
   type GoogleMeetRecordingInput,
   type GoogleMeetReport,
@@ -336,6 +338,12 @@ export class GoogleWorkspaceService extends Service implements IGoogleWorkspaceS
     params: GoogleMeetConferenceRecordInput & { limit?: number }
   ): Promise<GoogleMeetParticipant[]> {
     return this.meetClient.listMeetingParticipants(params);
+  }
+
+  listMeetingParticipantSessions(
+    params: GoogleMeetParticipantSessionInput & { limit?: number }
+  ): Promise<GoogleMeetParticipantSession[]> {
+    return this.meetClient.listMeetingParticipantSessions(params);
   }
 
   listMeetingTranscripts(

--- a/plugins/plugin-google/src/types.ts
+++ b/plugins/plugin-google/src/types.ts
@@ -323,6 +323,16 @@ export interface GoogleMeetParticipant {
   userType?: "signed_in" | "anonymous" | "phone" | "unknown";
 }
 
+export interface GoogleMeetParticipantSession {
+  id: string;
+  name: string;
+  participantId: string;
+  participantName: string;
+  startTime?: string;
+  endTime?: string;
+  isActive: boolean;
+}
+
 export interface GoogleMeetTranscript {
   id: string;
   speakerName?: string;
@@ -362,6 +372,152 @@ export interface GoogleMeetActionItem {
   priority: "low" | "medium" | "high";
 }
 
+export type GoogleMeetCanonicalStreamKind =
+  | "google_transcript_entries"
+  | "google_docs_transcript"
+  | "google_recording"
+  | "bot_free_system_audio"
+  | "bot_free_microphone"
+  | "bot_free_screen_video";
+
+export interface GoogleMeetCanonicalStream {
+  id: string;
+  kind: GoogleMeetCanonicalStreamKind;
+  artifactId?: string;
+  uri?: string;
+  fileId?: string;
+  startedAt?: string;
+  endedAt?: string;
+  state?: string;
+}
+
+export interface GoogleMeetCanonicalParticipant {
+  id: string;
+  displayName: string;
+  userType?: GoogleMeetParticipant["userType"];
+  nameProvenance: "google_signed_in" | "google_anonymous" | "phone" | "unknown";
+}
+
+export interface GoogleMeetCanonicalParticipantSession {
+  id: string;
+  participantId: string;
+  startedAt?: string;
+  endedAt?: string;
+  isActive: boolean;
+}
+
+export interface GoogleMeetCanonicalTranscriptSpan {
+  id: string;
+  streamId: string;
+  source: "google_meet_transcript_entry" | "bot_free_capture";
+  text: string;
+  participantId?: string;
+  speakerLabel?: string;
+  startedAt?: string;
+  endedAt?: string;
+  languageCode?: string;
+  provenance: {
+    transcriptName?: string;
+    entryName?: string;
+    participantName?: string;
+  };
+}
+
+export interface GoogleMeetCanonicalGeneratedNote {
+  id: string;
+  kind: "summary" | "key_point" | "action_item";
+  text: string;
+  sourceSpanIds: string[];
+  assignee?: string;
+  dueDate?: string;
+  priority?: GoogleMeetActionItem["priority"];
+}
+
+export type GoogleMeetMissingArtifactReason =
+  | "no_transcript"
+  | "transcript_delayed"
+  | "missing_recording"
+  | "revoked_access"
+  | "permission_denied"
+  | "meeting_not_found"
+  | "organizer_only_artifact"
+  | "expired_media_url";
+
+export interface GoogleMeetMissingArtifact {
+  artifactType: "conference" | "transcript" | "recording" | "participant_sessions";
+  reason: GoogleMeetMissingArtifactReason;
+  message: string;
+  sourceName?: string;
+}
+
+export interface GoogleMeetCanonicalWarning {
+  code:
+    | "docs_transcript_mismatch"
+    | "speaker_reference_missing"
+    | "transcript_entry_empty"
+    | "organizer_only_artifact"
+    | "expired_media_url";
+  message: string;
+  sourceName?: string;
+}
+
+export interface GoogleMeetBotFreeCaptureArtifact {
+  id: string;
+  systemAudioUri?: string;
+  microphoneAudioUri?: string;
+  screenVideoUri?: string;
+  startedAt?: string;
+  endedAt?: string;
+  transcriptSpans?: GoogleMeetTranscript[];
+}
+
+export interface GoogleMeetCanonicalArtifact {
+  schemaVersion: "elizaos.meeting_artifact.v1";
+  source: "google_meet";
+  meeting: {
+    id: string;
+    conferenceRecordName: string;
+    spaceName?: string;
+    startedAt?: string;
+    endedAt?: string;
+    expireTime?: string;
+    durationMinutes: number;
+  };
+  streams: GoogleMeetCanonicalStream[];
+  participants: GoogleMeetCanonicalParticipant[];
+  participantSessions: GoogleMeetCanonicalParticipantSession[];
+  transcriptSpans: GoogleMeetCanonicalTranscriptSpan[];
+  generatedNotes: GoogleMeetCanonicalGeneratedNote[];
+  recordings: GoogleMeetRecording[];
+  warnings: GoogleMeetCanonicalWarning[];
+  missingArtifacts: GoogleMeetMissingArtifact[];
+  metrics: {
+    transcriptWordCount: number;
+    participantCount: number;
+    participantSessionCount: number;
+    transcriptSpanCount: number;
+    recordingCount: number;
+    missingArtifactCount: number;
+    warningCount: number;
+  };
+}
+
+export interface GoogleMeetCanonicalArtifactInput {
+  meetingId: string;
+  conferenceRecordName: string;
+  conference: GoogleMeetConferenceRecord;
+  participants: readonly GoogleMeetParticipant[];
+  participantSessions?: readonly GoogleMeetParticipantSession[];
+  transcriptArtifacts: readonly GoogleMeetTranscriptArtifact[];
+  transcriptEntries: readonly GoogleMeetTranscript[];
+  recordings: readonly GoogleMeetRecording[];
+  summary: string;
+  keyPoints: readonly string[];
+  actionItems: readonly GoogleMeetActionItem[];
+  googleDocsTranscriptText?: string;
+  botFreeCapture?: GoogleMeetBotFreeCaptureArtifact;
+}
+
 export interface GoogleMeetReport {
   meetingId: string;
   conferenceRecordName: string;
@@ -374,6 +530,8 @@ export interface GoogleMeetReport {
   actionItems: GoogleMeetActionItem[];
   fullTranscript: GoogleMeetTranscript[];
   recordings: GoogleMeetRecording[];
+  participantSessions: GoogleMeetParticipantSession[];
+  canonicalArtifact: GoogleMeetCanonicalArtifact;
 }
 
 export interface GoogleMeetCreateMeetingInput extends GoogleAccountRef {
@@ -387,6 +545,10 @@ export interface GoogleMeetGetMeetingInput extends GoogleAccountRef {
 
 export interface GoogleMeetConferenceRecordInput extends GoogleAccountRef {
   conferenceRecordName: string;
+}
+
+export interface GoogleMeetParticipantSessionInput extends GoogleAccountRef {
+  participantName: string;
 }
 
 export interface GoogleMeetTranscriptInput extends GoogleAccountRef {
@@ -405,6 +567,8 @@ export interface GoogleMeetGenerateReportInput extends GoogleAccountRef {
   includeActionItems?: boolean;
   includeTranscript?: boolean;
   includeRecordings?: boolean;
+  googleDocsTranscriptText?: string;
+  botFreeCapture?: GoogleMeetBotFreeCaptureArtifact;
 }
 
 export interface IGoogleGmailService extends Service {
@@ -537,6 +701,9 @@ export interface IGoogleMeetService extends Service {
   listMeetingParticipants(
     params: GoogleMeetConferenceRecordInput & { limit?: number }
   ): Promise<GoogleMeetParticipant[]>;
+  listMeetingParticipantSessions(
+    params: GoogleMeetParticipantSessionInput & { limit?: number }
+  ): Promise<GoogleMeetParticipantSession[]>;
   listMeetingTranscripts(
     params: GoogleMeetConferenceRecordInput
   ): Promise<GoogleMeetTranscriptArtifact[]>;


### PR DESCRIPTION
## Summary

- Adds Google Meet participant-session import through the Meet API `participantSessions.list` surface.
- Adds a canonical `elizaos.meeting_artifact.v1` artifact mapper for Meet conference records, participants, sessions, transcript entries, Google Docs transcript text, recordings, generated notes, and bot-free capture artifacts.
- Preserves Google Docs transcript mismatch warnings and missing-artifact classifications for no/delayed transcripts, missing recordings, permission/revocation/not-found cases, organizer-only artifacts, and expired media URLs.
- Adds deterministic Google Meet fixture tests and updates plugin docs.

## Evidence

- Evidence file: `.github/issue-evidence/12488-google-meet-adapter.md`.
- Human-only evidence issue: #13199.
- `bun run --cwd plugins/plugin-google typecheck` passed in the main checkout before isolated branch publishing.
- `bun run --cwd plugins/plugin-google test` passed: 4 files, 29 tests.
- `bun run --cwd plugins/plugin-google lint:check` passed.
- `bun install` completed.
- `bun run verify` was attempted and failed outside this PR in `@elizaos/tui#lint`; `@elizaos/plugin-google#lint` passed. Details are in the evidence file.

## Human Evidence Still Required

This PR does not claim live Google product proof. #13199 tracks the live sandbox Google Meet import, bot-free desktop/web capture walkthrough, structured backend logs, imported canonical artifact JSON, transcript/media artifacts, and failure-path evidence for no transcript, delayed transcript, revoked access, permission denied, organizer-only artifacts, and expired media URLs.

Closes #12488.