### PR TITLE
fix(core): honor provider context gates and lean general default in planner selection

### DIFF
--- a/packages/core/src/__tests__/planner-provider-selection-lean.test.ts
+++ b/packages/core/src/__tests__/planner-provider-selection-lean.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Planner-turn provider selection is lean by default: an undeclared plugin
+ * provider resolves to the "general" context — composed on ordinary chat turns,
+ * skipped on narrow tool/planner turns — while declared contexts, gate-only
+ * declarations (contextGate.anyOf), catalog-mapped names, and
+ * `alwaysInResponseState` opt-ins route as declared, and the composed prompt
+ * footprint actually drops on the narrow turn. Real in-memory AgentRuntime
+ * (real registration path, real composeState); no database or model.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { AgentRuntime } from "../runtime";
+import { selectV5PlannerStateProviderNames } from "../services/message";
+import type { Character, Memory, Provider, UUID } from "../types";
+
+const ROOM_ID = "11111111-1111-1111-1111-111111111111" as UUID;
+const ENTITY_ID = "22222222-2222-2222-2222-222222222222" as UUID;
+
+function makeMessage(id: string): Memory {
+	return {
+		id: id as UUID,
+		entityId: ENTITY_ID,
+		roomId: ROOM_ID,
+		content: { text: "check my wallet" },
+	};
+}
+
+function makeRuntime(): AgentRuntime {
+	const runtime = new AgentRuntime({
+		character: { name: "lean-selection-test" } as Character,
+	});
+	// The flood class: a plugin provider with no contexts/contextGate whose
+	// output would ride every planner turn under include-everything defaults.
+	const noisy: Provider = {
+		name: "NOISY_PLUGIN_SIGNAL",
+		get: async () => ({
+			text: `NOISY-PAYLOAD ${"x".repeat(2000)}`,
+			values: {},
+			data: {},
+		}),
+	};
+	const walletDeclared: Provider = {
+		name: "WALLET_SIGNAL",
+		contexts: ["wallet"],
+		get: async () => ({ text: "WALLET-PAYLOAD", values: {}, data: {} }),
+	};
+	const alwaysOn: Provider = {
+		name: "ALWAYS_ON_SIGNAL",
+		dynamic: true,
+		alwaysInResponseState: true,
+		get: async () => ({ text: "ALWAYS-PAYLOAD", values: {}, data: {} }),
+	};
+	// Declares ONLY a contextGate (the world-provider shape). Registration must
+	// not clobber it with the general fallback, and selection must honor the
+	// gate's anyOf.
+	const gateOnly: Provider = {
+		name: "WALLET_GATED_SIGNAL",
+		contextGate: { anyOf: ["wallet"] },
+		get: async () => ({ text: "GATED-WALLET-PAYLOAD", values: {}, data: {} }),
+	};
+	// Undeclared but catalog-mapped (code/automation): must ride coding planner
+	// turns, not ordinary chat turns.
+	const catalogMapped: Provider = {
+		name: "AVAILABLE_AGENTS",
+		get: async () => ({ text: "AGENTS-PAYLOAD", values: {}, data: {} }),
+	};
+	runtime.registerProvider(noisy);
+	runtime.registerProvider(walletDeclared);
+	runtime.registerProvider(alwaysOn);
+	runtime.registerProvider(gateOnly);
+	runtime.registerProvider(catalogMapped);
+	return runtime;
+}
+
+describe("v5 planner provider selection — lean by default", () => {
+	it("keeps an undeclared provider on a general turn and drops it from a narrow turn", () => {
+		const runtime = makeRuntime();
+		const message = makeMessage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+		const general = selectV5PlannerStateProviderNames({
+			runtime,
+			message,
+			selectedContexts: ["general"],
+			userRoles: ["OWNER"],
+		});
+		expect(general).toContain("NOISY_PLUGIN_SIGNAL");
+		expect(general).toContain("ALWAYS_ON_SIGNAL");
+		expect(general).not.toContain("WALLET_SIGNAL");
+
+		const narrow = selectV5PlannerStateProviderNames({
+			runtime,
+			message,
+			selectedContexts: ["wallet"],
+			userRoles: ["OWNER"],
+		});
+		expect(narrow).not.toContain("NOISY_PLUGIN_SIGNAL");
+		expect(narrow).toContain("WALLET_SIGNAL"); // still fires when relevant
+		expect(narrow).toContain("ALWAYS_ON_SIGNAL"); // explicit always-on opt-in
+	});
+
+	it("honors a contextGate-only declaration instead of clobbering it with the general fallback", () => {
+		const runtime = makeRuntime();
+		const message = makeMessage("cccccccc-cccc-cccc-cccc-cccccccccccc");
+
+		const narrow = selectV5PlannerStateProviderNames({
+			runtime,
+			message,
+			selectedContexts: ["wallet"],
+			userRoles: ["OWNER"],
+		});
+		expect(narrow).toContain("WALLET_GATED_SIGNAL");
+
+		const general = selectV5PlannerStateProviderNames({
+			runtime,
+			message,
+			selectedContexts: ["general"],
+			userRoles: ["OWNER"],
+		});
+		expect(general).not.toContain("WALLET_GATED_SIGNAL");
+	});
+
+	it("routes catalog-mapped orchestrator providers to coding turns, not ordinary chat", () => {
+		const runtime = makeRuntime();
+		const message = makeMessage("dddddddd-dddd-dddd-dddd-dddddddddddd");
+
+		const coding = selectV5PlannerStateProviderNames({
+			runtime,
+			message,
+			selectedContexts: ["code"],
+			userRoles: ["OWNER"],
+		});
+		expect(coding).toContain("AVAILABLE_AGENTS");
+
+		const general = selectV5PlannerStateProviderNames({
+			runtime,
+			message,
+			selectedContexts: ["general"],
+			userRoles: ["OWNER"],
+		});
+		expect(general).not.toContain("AVAILABLE_AGENTS");
+	});
+
+	it("drops the composed prompt footprint on the narrow turn", async () => {
+		const runtime = makeRuntime();
+		const message = makeMessage("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+		const general = selectV5PlannerStateProviderNames({
+			runtime,
+			message,
+			selectedContexts: ["general"],
+			userRoles: ["OWNER"],
+		});
+		const narrow = selectV5PlannerStateProviderNames({
+			runtime,
+			message,
+			selectedContexts: ["wallet"],
+			userRoles: ["OWNER"],
+		});
+
+		const generalState = await runtime.composeState(
+			message,
+			general,
+			true,
+			true,
+		);
+		const narrowState = await runtime.composeState(message, narrow, true, true);
+
+		expect(generalState.text).toContain("NOISY-PAYLOAD");
+		expect(narrowState.text).not.toContain("NOISY-PAYLOAD");
+		expect(narrowState.text).toContain("WALLET-PAYLOAD");
+		expect(narrowState.text).toContain("ALWAYS-PAYLOAD");
+		expect(narrowState.text.length).toBeLessThan(generalState.text.length);
+	});
+
+	it("warns at registration only for an undeclared, non-dynamic, uncataloged provider", () => {
+		const runtime = new AgentRuntime({
+			character: { name: "lean-warning-test" } as Character,
+		});
+		const warnSpy = vi.spyOn(runtime.logger, "warn");
+		const get = async () => ({ text: "", values: {}, data: {} });
+
+		runtime.registerProvider({ name: "UNDECLARED_PLUGIN", get });
+		runtime.registerProvider({ name: "SCOPED", contexts: ["wallet"], get });
+		runtime.registerProvider({
+			name: "ALWAYS",
+			alwaysInResponseState: true,
+			get,
+		});
+		runtime.registerProvider({ name: "DYN", dynamic: true, get });
+		runtime.registerProvider({ name: "walletBalance", get }); // catalog-mapped
+
+		const warned = warnSpy.mock.calls
+			.filter(([, message]) => String(message).includes("declares no contexts"))
+			.map(([context]) => (context as { provider?: string }).provider);
+		expect(warned).toEqual(["UNDECLARED_PLUGIN"]);
+	});
+});

--- a/packages/core/src/plugin-lifecycle.ts
+++ b/packages/core/src/plugin-lifecycle.ts
@@ -41,6 +41,7 @@ import type { IAgentRuntime } from "./types/runtime";
 import type { Service, ServiceTypeName } from "./types/service";
 import type { ShortcutDefinition } from "./types/shortcut";
 import {
+	hasCatalogProviderContexts,
 	resolveActionContexts,
 	resolveProviderContexts,
 } from "./utils/context-catalog";
@@ -370,20 +371,50 @@ function applyEffectiveActionAccess(
 function applyEffectiveProviderContexts(
 	provider: RuntimeProvider,
 	pluginContexts: Plugin["contexts"] | undefined,
+	logger?: IAgentRuntime["logger"],
 ): RuntimeProvider {
 	const inherited = inheritPluginContexts(provider, pluginContexts);
 	if ((inherited.contexts?.length ?? 0) > 0) {
 		return inherited;
 	}
 
+	// A provider gated only via contextGate (world-style `{ anyOf: [...] }`)
+	// materializes its contexts from the gate's own anyOf surface — injecting
+	// the catalog/general fallback would contradict the declared gate (ride
+	// general turns, miss its own contexts). Only a provider with no declared
+	// context surface at all falls back to the catalog and ultimately
+	// ["general"]: composed on ordinary chat turns, skipped on narrow
+	// tool/planner turns.
+	const gate = inherited.contextGate;
+	const gateAnyOf: AgentContext[] = [
+		...(gate?.contexts ?? []),
+		...(gate?.anyOf ?? []),
+	];
+	const contexts =
+		gateAnyOf.length > 0 ? gateAnyOf : resolveProviderContexts(inherited);
+	if (
+		gateAnyOf.length === 0 &&
+		!gate?.allOf?.length &&
+		!gate?.noneOf?.length &&
+		!inherited.private &&
+		!inherited.dynamic &&
+		!inherited.alwaysInResponseState &&
+		!hasCatalogProviderContexts(inherited.name)
+	) {
+		logger?.warn(
+			{ src: "agent", provider: inherited.name },
+			'[PluginLifecycle] Provider declares no contexts/contextGate; defaulting to the "general" context (composed on ordinary chat turns, skipped on narrow tool/planner turns). Declare contexts or a contextGate to scope it, or set alwaysInResponseState for an always-on response-state signal.',
+		);
+	}
+
 	if (inherited === provider) {
-		provider.contexts = [...resolveProviderContexts(inherited)];
+		provider.contexts = [...contexts];
 		return provider;
 	}
 
 	return {
 		...inherited,
-		contexts: [...resolveProviderContexts(inherited)],
+		contexts: [...contexts],
 	};
 }
 
@@ -831,6 +862,7 @@ export function installRuntimePluginLifecycle(runtime: IAgentRuntime): void {
 			applyEffectiveProviderContexts(
 				provider,
 				capture?.ownership.plugin.contexts,
+				runtimeWithLifecycle.logger,
 			),
 		);
 		if (!capture || runtimeWithLifecycle.providers.length <= providersBefore)

--- a/packages/core/src/providers/recent-errors.ts
+++ b/packages/core/src/providers/recent-errors.ts
@@ -95,6 +95,10 @@ export const recentErrorsProvider: Provider = {
 	description:
 		"Recent runtime failures reported outside the action path (deduped by code)",
 	dynamic: true,
+	// Failures must reach the agent on every turn — including narrow
+	// tool/planner turns that lean provider selection skips for undeclared
+	// providers. Free on the healthy path: renders nothing without errors.
+	alwaysInResponseState: true,
 
 	get: async (
 		runtime: IAgentRuntime,

--- a/packages/core/src/runtime/context-gates.test.ts
+++ b/packages/core/src/runtime/context-gates.test.ts
@@ -1,12 +1,17 @@
 /**
  * Unit tests for the role and context gate filters (`filterByContextGate`,
- * `normalizeGateRole`). Deterministic in-line literal fixtures — no runtime,
- * model, or database.
+ * `filterProvidersByContextGate`, `normalizeGateRole`). Deterministic in-line
+ * literal fixtures — no runtime, model, or database.
  */
 import { describe, expect, it } from "vitest";
+import type { Provider } from "../types/components";
 import type { AgentContext } from "../types/contexts";
 import type { RoleGateRole } from "./context-gates";
-import { filterByContextGate, normalizeGateRole } from "./context-gates";
+import {
+	filterByContextGate,
+	filterProvidersByContextGate,
+	normalizeGateRole,
+} from "./context-gates";
 
 /**
  * Tests for the role-gate normalizer (#8801 / #9943). normalizeGateRole canon-
@@ -32,6 +37,98 @@ describe("filterByContextGate — top-level roleGate under an explicit contextGa
 
 	it("keeps the item for an ADMIN in the active context", () => {
 		expect(filterByContextGate([item], active, ["ADMIN"])).toEqual([item]);
+	});
+});
+
+describe("filterProvidersByContextGate — lean-by-default provider selection", () => {
+	const get = async () => ({ text: "", values: {}, data: {} });
+	const names = (result: Provider[]) => result.map((p) => p.name);
+
+	// A third-party plugin provider that declares nothing — the flood class.
+	const undeclared: Provider = { name: "SOME_PLUGIN_SIGNAL", get };
+	// A provider that scopes itself via `contexts`.
+	const walletDeclared: Provider = {
+		name: "WALLET_SIGNAL",
+		contexts: ["wallet"] as AgentContext[],
+		get,
+	};
+	// A provider gated only via contextGate.anyOf (the world-provider shape),
+	// which the generic candidate filter cannot carry.
+	const anyOfGated: Provider = {
+		name: "GENERAL_ONLY_SIGNAL",
+		contextGate: { anyOf: ["general"] as AgentContext[] },
+		get,
+	};
+	// A core-catalog name with no declaration on the object itself.
+	const catalogMapped: Provider = { name: "walletBalance", get };
+
+	it("includes an undeclared provider on an ordinary general turn", () => {
+		expect(
+			names(filterProvidersByContextGate([undeclared], ["general"])),
+		).toEqual(["SOME_PLUGIN_SIGNAL"]);
+	});
+
+	it("excludes an undeclared provider from a narrow tool/planner context", () => {
+		expect(filterProvidersByContextGate([undeclared], ["wallet"])).toEqual([]);
+	});
+
+	it("keeps a declared provider on its matching narrow turn and off general turns", () => {
+		expect(
+			names(filterProvidersByContextGate([walletDeclared], ["wallet"])),
+		).toEqual(["WALLET_SIGNAL"]);
+		expect(filterProvidersByContextGate([walletDeclared], ["general"])).toEqual(
+			[],
+		);
+	});
+
+	it("resolves catalog contexts for known undeclared names", () => {
+		expect(
+			names(filterProvidersByContextGate([catalogMapped], ["wallet"])),
+		).toEqual(["walletBalance"]);
+		expect(filterProvidersByContextGate([catalogMapped], ["general"])).toEqual(
+			[],
+		);
+	});
+
+	it("honors contextGate.anyOf, which filterByContextGate drops", () => {
+		expect(
+			names(filterProvidersByContextGate([anyOfGated], ["general"])),
+		).toEqual(["GENERAL_ONLY_SIGNAL"]);
+		expect(filterProvidersByContextGate([anyOfGated], ["wallet"])).toEqual([]);
+		// The generic candidate filter loses anyOf and floods the narrow turn —
+		// the provider-specific filter is the fix.
+		expect(filterByContextGate([anyOfGated], ["wallet"])).toEqual([anyOfGated]);
+	});
+
+	it("keeps the top-level roleGate under an explicit contextGate (#12087 Item 14)", () => {
+		const adminOnly: Provider = {
+			name: "ADMIN_ONLY_SIGNAL",
+			contextGate: { contexts: ["admin"] as AgentContext[] },
+			roleGate: { minRole: "ADMIN" as RoleGateRole },
+			get,
+		};
+		expect(filterProvidersByContextGate([adminOnly], ["admin"], ["USER"])).toEqual(
+			[],
+		);
+		expect(
+			names(filterProvidersByContextGate([adminOnly], ["admin"], ["ADMIN"])),
+		).toEqual(["ADMIN_ONLY_SIGNAL"]);
+	});
+
+	it("applies the top-level roleGate to an undeclared provider", () => {
+		const gatedUndeclared: Provider = {
+			name: "OWNER_PLUGIN_SIGNAL",
+			roleGate: { minRole: "OWNER" as RoleGateRole },
+			get,
+		};
+		expect(
+			filterProvidersByContextGate([gatedUndeclared], ["general"], ["USER"]),
+		).toEqual([]);
+		expect(
+			names(
+				filterProvidersByContextGate([gatedUndeclared], ["general"], ["OWNER"]),
+			),
+		).toEqual(["OWNER_PLUGIN_SIGNAL"]);
 	});
 });
 

--- a/packages/core/src/runtime/context-gates.ts
+++ b/packages/core/src/runtime/context-gates.ts
@@ -6,12 +6,14 @@
  * comparison.
  */
 import { CANONICAL_ROLE_RANK } from "../roles";
+import type { Provider } from "../types/components";
 import type {
 	AgentContext,
 	ContextGate,
 	RoleGate,
 	RoleGateRole,
 } from "../types/contexts";
+import { resolveProviderContexts } from "../utils/context-catalog";
 import { normalizeContextList } from "./context-normalization";
 
 // #9948: single source of truth for role ranking — delegates to CANONICAL_ROLE_RANK.
@@ -129,4 +131,63 @@ export function filterByContextGate<T extends ContextGateCandidate>(
 		};
 		return satisfiesContextGate(activeContexts, gate, userRoles);
 	});
+}
+
+/**
+ * True when the provider declares any context surface at all — a non-empty
+ * `contexts` list or a `contextGate` with contexts/anyOf/allOf/noneOf. Providers
+ * without one fall back to the static catalog and ultimately the "general"
+ * context at the selection layer (see resolveProviderContextGate).
+ */
+export function providerDeclaresContextSurface(provider: Provider): boolean {
+	const gate = provider.contextGate;
+	return Boolean(
+		provider.contexts?.length ||
+			gate?.contexts?.length ||
+			gate?.anyOf?.length ||
+			gate?.allOf?.length ||
+			gate?.noneOf?.length,
+	);
+}
+
+/**
+ * Effective context gate for a provider at the v5 selection layer. A declared
+ * gate is honored in full — including anyOf/allOf/noneOf, which the generic
+ * candidate filter cannot carry — with the #12087 Item 14 rule that an explicit
+ * contextGate never shadows the provider's top-level roleGate. A provider that
+ * declares no context surface resolves through the static catalog and defaults
+ * to the "general" context: composed on ordinary chat turns, skipped on narrow
+ * tool/planner contexts. Plugin registration (plugin-lifecycle) materializes
+ * the same resolution onto `contexts`; this resolver keeps the selection layer
+ * lean-by-default even for providers that bypass the wrapped registration
+ * path, so an undeclared provider never rides every planner turn.
+ */
+export function resolveProviderContextGate(provider: Provider): ContextGate {
+	const explicit = provider.contextGate;
+	if (!providerDeclaresContextSurface(provider)) {
+		return {
+			contexts: resolveProviderContexts(provider),
+			roleGate: explicit?.roleGate ?? provider.roleGate,
+		};
+	}
+	return {
+		...explicit,
+		contexts: explicit?.contexts ?? provider.contexts,
+		roleGate: explicit?.roleGate ?? provider.roleGate,
+	};
+}
+
+/** Filter providers by their effective context gate (resolveProviderContextGate). */
+export function filterProvidersByContextGate<T extends Provider>(
+	providers: readonly T[],
+	activeContexts: readonly AgentContext[] | undefined,
+	userRoles?: readonly RoleGateRole[],
+): T[] {
+	return providers.filter((provider) =>
+		satisfiesContextGate(
+			activeContexts,
+			resolveProviderContextGate(provider),
+			userRoles,
+		),
+	);
 }

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -60,7 +60,7 @@ import {
 	type CandidateActionBackstopRule,
 	getCandidateActionBackstopRules,
 } from "../runtime/candidate-action-backstop";
-import { filterByContextGate } from "../runtime/context-gates";
+import { filterProvidersByContextGate } from "../runtime/context-gates";
 import { computePrefixHashes, hashString } from "../runtime/context-hash";
 import {
 	appendContextEvent,
@@ -1167,7 +1167,16 @@ async function composeProviderGroundedResponseState(
 	);
 }
 
-function selectV5PlannerStateProviderNames(args: {
+/**
+ * Provider names composed into the v5 planner state for a turn: the core
+ * response-state set, always-on opt-ins, and every registered provider whose
+ * effective context gate matches the turn's selected contexts. Providers with
+ * no declared contexts/contextGate resolve to the "general" context, so an
+ * undeclared plugin provider rides ordinary chat turns but not narrow
+ * tool/planner turns — `alwaysInResponseState` is the opt-in for signals that
+ * must reach every turn.
+ */
+export function selectV5PlannerStateProviderNames(args: {
 	runtime: IAgentRuntime;
 	message: Memory;
 	selectedContexts: readonly AgentContext[];
@@ -1188,7 +1197,7 @@ function selectV5PlannerStateProviderNames(args: {
 	for (const name of alwaysOnResponseStateProviderNames(args.runtime)) {
 		providerNames.add(name);
 	}
-	for (const provider of filterByContextGate(
+	for (const provider of filterProvidersByContextGate(
 		providers,
 		args.selectedContexts,
 		args.userRoles,

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -630,7 +630,12 @@ export interface Provider {
 	/**
 	 * Domain contexts this provider belongs to.
 	 * The context-routing classifier uses these to decide which providers to
-	 * include in the planner's state composition for a given turn.
+	 * include in the planner's state composition for a given turn. Selection is
+	 * lean by default: a provider that declares neither `contexts` nor a
+	 * `contextGate` is treated as `contexts: ["general"]` — composed on ordinary
+	 * chat turns, skipped on narrow tool/planner turns. Declare contexts to
+	 * scope the provider, or set `alwaysInResponseState` for a signal that must
+	 * reach every response turn.
 	 */
 	contexts?: AgentContext[];
 
@@ -657,7 +662,10 @@ export interface Provider {
 	 * state regardless of the turn's selected contexts (like the built-in
 	 * FACTS / CURRENT_TIME signals). Lets a plugin opt a dynamic provider into
 	 * always-on Stage-1 rendering without core having to name it — keeping the
-	 * core → plugin dependency direction inward-only.
+	 * core → plugin dependency direction inward-only. This is the explicit
+	 * opt-in for always-on signals: providers without it (and without declared
+	 * contexts) default to the "general" context and stay out of narrow
+	 * tool/planner turns.
 	 */
 	alwaysInResponseState?: boolean;
 

--- a/packages/core/src/utils/context-catalog.ts
+++ b/packages/core/src/utils/context-catalog.ts
@@ -201,6 +201,8 @@ export const PROVIDER_CONTEXT_MAP: Record<string, AgentContext[]> = {
 	"solana-wallet": ["wallet"],
 	CODING_AGENT_EXAMPLES: ["code", "automation"],
 	ACTIVE_WORKSPACE_CONTEXT: ["code", "automation"],
+	AVAILABLE_AGENTS: ["code", "automation"],
+	ACTIVE_SUB_AGENTS: ["code", "automation"],
 	contacts: ["contacts"],
 	trustScores: ["contacts"],
 	platformIdentity: ["messaging"],
@@ -253,5 +255,18 @@ export function resolveProviderContexts(provider: Provider): AgentContext[] {
 		PROVIDER_CONTEXT_MAP[provider.name] ??
 		PROVIDER_CONTEXT_MAP[provider.name.toLowerCase()] ??
 		PROVIDER_CONTEXT_MAP[provider.name.toUpperCase()] ?? ["general"]
+	);
+}
+
+/**
+ * Whether a provider name has a catalog entry — distinguishes a provider whose
+ * contexts this catalog knows from one falling through to the ["general"]
+ * default, which resolveProviderContexts cannot express.
+ */
+export function hasCatalogProviderContexts(name: string): boolean {
+	return Boolean(
+		PROVIDER_CONTEXT_MAP[name] ??
+			PROVIDER_CONTEXT_MAP[name.toLowerCase()] ??
+			PROVIDER_CONTEXT_MAP[name.toUpperCase()],
 	);
 }

--- a/packages/core/src/utils/context-routing.ts
+++ b/packages/core/src/utils/context-routing.ts
@@ -3,8 +3,10 @@
  * from routing metadata carried on state/message, or by scoring the message
  * text against keyword signals — and gates which actions/providers surface by
  * testing whether a component's declared contexts overlap the active set.
- * Gating is permissive: a component with no declared contexts, or an empty
- * active set, is always included.
+ * shouldIncludeByContext is permissive for an empty declared list or an empty
+ * active set, but runtime callers resolve component contexts first (declared →
+ * catalog → ["general"], utils/context-catalog), so an undeclared component is
+ * gated to "general" rather than included everywhere.
  */
 
 import type { Action, AgentContext, Provider } from "../types/components";


### PR DESCRIPTION
Fixes #13203

## What

Structural fixes to provider context gating so selection is lean by default and declared gates are actually honored:

- **`packages/core/src/runtime/context-gates.ts`** — new `resolveProviderContextGate` / `filterProvidersByContextGate`: a provider's effective gate honors the full declared `contextGate` (anyOf/allOf/noneOf — the generic `filterByContextGate` only carries `contexts` and silently drops the rest), keeps the #12087 Item 14 rule (explicit contextGate never shadows the top-level roleGate), and resolves undeclared providers declared → catalog → `["general"]`.
- **`packages/core/src/services/message.ts`** — the v5 planner selection (`selectV5PlannerStateProviderNames`) filters providers through the provider-specific gate resolver (exported for tests).
- **`packages/core/src/plugin-lifecycle.ts`** — `applyEffectiveProviderContexts` no longer clobbers a gate-only provider (world-style `contextGate: { anyOf: [...] }`) with the injected `["general"]` fallback; it materializes contexts from the gate's own anyOf surface. When the general fallback IS applied to a non-private, non-dynamic, non-`alwaysInResponseState`, uncataloged provider, it emits a one-time registration warning nudging the plugin to declare `contexts`/`contextGate` or opt into `alwaysInResponseState`.
- **`packages/core/src/utils/context-catalog.ts`** — catalog entries for `AVAILABLE_AGENTS` / `ACTIVE_SUB_AGENTS` (`["code", "automation"]`, matching the existing `ACTIVE_WORKSPACE_CONTEXT` entry) + `hasCatalogProviderContexts` helper.
- **`packages/core/src/providers/recent-errors.ts`** — `RECENT_ERRORS` opts into `alwaysInResponseState` so reported failures reach the agent on narrow tool/planner turns too (it renders nothing when healthy, so no cost on the happy path).
- **`packages/core/src/types/components.ts`** — document the `["general"]` default on `Provider.contexts` and `alwaysInResponseState` as the explicit opt-in for FACTS/CURRENT_TIME-class always-on signals (reusing the existing mechanism, no new flag).

## Why

On develop, a provider declaring only `contextGate: { anyOf: ["wallet"] }` gets `contexts: ["general"]` injected at registration and its anyOf is dropped by the planner filter — it rides ordinary chat turns and misses its own wallet turns (inverted routing). Undeclared-but-domain-specific providers (`AVAILABLE_AGENTS`, `ACTIVE_SUB_AGENTS`) fall to `["general"]` and are absent from the code/automation planner turns that need the coding-backend inventory. `RECENT_ERRORS` (the #12182/#12263 error-surfacing signal) likewise stops at general turns.

Reproduced on develop `cd159a8d28` with a bare `AgentRuntime` + `registerProvider`:

```
# develop
NOISY_PLUGIN_SIGNAL (undeclared)               -> contexts: ["general"]
WALLET_GATED_SIGNAL (contextGate anyOf wallet)  -> contexts: ["general"]   # gate ignored
AVAILABLE_AGENTS (undeclared)                   -> contexts: ["general"]   # misses code turns

# with this PR
WALLET_GATED_SIGNAL  -> contexts: ["wallet"]
AVAILABLE_AGENTS     -> contexts: ["code","automation"]
```

## Evidence

- **Tests (real, deterministic — no mocks of the thing under test):**
  - `packages/core/src/runtime/context-gates.test.ts` — 7 new unit cases on `filterProvidersByContextGate` (undeclared included on general / excluded on narrow, catalog resolution, anyOf honored — including an assertion that the generic `filterByContextGate` floods where the new filter gates, roleGate preservation).
  - `packages/core/src/__tests__/planner-provider-selection-lean.test.ts` — real in-memory `AgentRuntime` (real registration path incl. the plugin-lifecycle wrapper, real `composeState`): undeclared provider selected on general and dropped on narrow turns; declared provider still fires when relevant; `alwaysInResponseState` provider rides both; gate-only provider selected on its own context and not on general (fails on develop — inverted there); `AVAILABLE_AGENTS` selected on `["code"]` and not on general (fails on develop); composed prompt footprint drops on the narrow turn (`narrowState.text.length < generalState.text.length`, noisy payload absent); registration warning fires exactly once for the undeclared, non-dynamic, uncataloged provider.
- **Counts:** core suite `bun run --cwd packages/core test`: 3063 passed / 11 skipped; 7-8 failures in 5 files (`media/fetch`, `link-extraction`, `contracts-alignment`, `action-handler-callsite-audit`, `tiered-action-surface`) reproduced byte-identical on pristine develop before this change (stash/run/pop) — pre-existing, untouched by this PR. Typecheck: `tsgo --noEmit` clean.
- **Live-LLM trajectory:** N/A — deterministic selection-layer change; provider selection and materialization are exercised end-to-end by the real-runtime tests above (registration wrapper → gate resolution → composeState text). No model-visible prompt content changes other than leaner selection.
- **Screenshots / video / frontend logs:** N/A — no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
