### PR TITLE
refactor(#12641): derive launcher package-name canonicalization from owner declarations

### DIFF
--- a/packages/ui/src/components/pages/launcher-curation.test.ts
+++ b/packages/ui/src/components/pages/launcher-curation.test.ts
@@ -3,8 +3,11 @@
  * launcher-page composition (system + release always, developer + preview gated
  * by their toggles) that `LauncherSurface` feeds into `Launcher`.
  */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import type { ViewEntry } from "../../hooks/view-catalog";
+import { getInternalToolAppTargetTab } from "../apps/internal-tool-apps";
 import { canonicalLauncherId, curateLauncherPages } from "./launcher-curation";
 
 const ENABLED = { developer: true, preview: true } as const;
@@ -483,5 +486,81 @@ describe("canonicalLauncherId", () => {
     expect(canonicalLauncherId("plugins-page")).toBe("plugins");
     expect(canonicalLauncherId("trajectory-logger")).toBe("trajectories");
     expect(canonicalLauncherId("browser")).toBe("browser");
+  });
+});
+
+describe("canonicalLauncherId derives package-name mapping from owner declarations", () => {
+  // #12641: the `@elizaos/...` package-name -> canonical switch used to be a
+  // hand-kept literal map inside launcher-curation that silently drifted from
+  // the internal-tool app declarations. It now derives from each declaration's
+  // own `targetTab`, so a package rename/add flows through with no edit here.
+  it("canonicalizes an internal-tool app package name to its declared targetTab", () => {
+    // Live case: the fine-tuning surface used to require a literal
+    // `["@elizaos/plugin-training", "fine-tuning"]` row in launcher-curation.
+    expect(getInternalToolAppTargetTab("@elizaos/plugin-training")).toBe(
+      "fine-tuning",
+    );
+    expect(canonicalLauncherId("@elizaos/plugin-training")).toBe("fine-tuning");
+
+    // The task-coordinator PACKAGE NAME collapses onto the tasks tile via its
+    // declaration (the short `task-coordinator` alias keeps its legacy row).
+    expect(canonicalLauncherId("@elizaos/plugin-task-coordinator")).toBe(
+      "tasks",
+    );
+    expect(canonicalLauncherId("task-coordinator")).toBe("tasks");
+  });
+
+  it("collapses an internal-tool app catalog card onto its canonical tile without a curation edit", () => {
+    // An internal-tool app surfaces in the launcher as a catalog card whose id
+    // IS the package name (appToEntry uses `id: app.name`). Curation must fold
+    // it onto the owning tab tile from the declaration alone.
+    const targetTab = getInternalToolAppTargetTab("@elizaos/plugin-training");
+    expect(targetTab).toBe("fine-tuning");
+    const page = curateLauncherPages(
+      [
+        entry("chat"),
+        entry("fine-tuning", { viewKind: "developer" }),
+        // Catalog card for the same surface, keyed by package name.
+        entry("@elizaos/plugin-training", {
+          kind: "app",
+          state: "available",
+          viewKind: "developer",
+        }),
+      ],
+      { isAosp: false, enabledKinds: ENABLED, cloudActive: true },
+    );
+    // One "fine-tuning" tile, no stray `@elizaos/...` package-name tile.
+    expect(ids(page).filter((id) => id === "fine-tuning")).toHaveLength(1);
+    expect(ids(page)).not.toContain("@elizaos/plugin-training");
+  });
+});
+
+describe("launcher-curation brittle-package-name grep guard (#12641)", () => {
+  const sourcePath = fileURLToPath(
+    new URL("./launcher-curation.ts", import.meta.url),
+  );
+  const source = readFileSync(sourcePath, "utf8");
+
+  it("no plugin/app package-name literal survives as a curation switch", () => {
+    // The audit finding: launcher curation hardcodes plugin package names. Any
+    // `@elizaos/plugin-*` / `@elizaos/app-*` literal reintroduced into this
+    // module is a regression — the package-name -> canonical mapping must come
+    // from owner declarations. (Strip line/block comments so the doc references
+    // above don't false-fail; the `@elizaos/core` runtime import is not a
+    // package-name SWITCH so the guard targets plugin/app package literals.)
+    const executable = source
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/[^\n]*/g, "");
+    // The `@elizaos/core` framework import is a dependency, not a curation
+    // switch. The regression the audit flagged is plugin/app PACKAGE-NAME
+    // literals (`@elizaos/plugin-*`, `@elizaos/app-*`) being hand-mapped to a
+    // canonical id here; those must come from the owner declarations instead.
+    expect(executable).not.toMatch(/@elizaos\/(?:plugin|app)-/);
+  });
+
+  it("reads package-name canonicalization from the internal-tool declarations", () => {
+    // Proves the coupling is inverted: curation imports the owner metadata
+    // helper instead of re-listing package names.
+    expect(source).toContain("getInternalToolAppTargetTab");
   });
 });

--- a/packages/ui/src/components/pages/launcher-curation.ts
+++ b/packages/ui/src/components/pages/launcher-curation.ts
@@ -30,6 +30,7 @@ import {
 } from "@elizaos/core";
 import type { ViewEntry } from "../../hooks/view-catalog";
 import { LAUNCHER_AOSP_ONLY_VIEW_IDS, pathForTab } from "../../navigation";
+import { getInternalToolAppTargetTab } from "../apps/internal-tool-apps";
 
 /** Everyday apps, in display order. They lead the single launcher page; other
  *  loaded apps append after (alphabetically). */
@@ -109,22 +110,30 @@ export const LAUNCHER_HIDDEN_IDS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Duplicate/alias ids collapsed onto one canonical launcher id. Kills the double
- * "Wallet" (standalone `wallet` view + `wallet.inventory` app-shell page +
- * builtin `inventory` tab) and double "Automations" (`automations` + `triggers`)
- * tiles, and folds the standalone tasks/todos surfaces into Automations.
+ * Legacy id-alias fallback: duplicate/short-id aliases collapsed onto one
+ * canonical launcher id. Kills the double "Wallet" (standalone `wallet` view +
+ * `wallet.inventory` app-shell page + builtin `inventory` tab) and double
+ * "Automations" (`automations` + `triggers`) tiles, and folds the standalone
+ * tasks/todos surfaces into Automations.
+ *
+ * These are SHORT builtin-tab / view-id aliases only — NOT package names. The
+ * package-name → canonical mapping (`@elizaos/plugin-training` →
+ * `fine-tuning`, …) used to live here as a hand-maintained `@elizaos/...`
+ * switch that silently drifted from the owning app declarations; it now derives
+ * from the internal-tool app declarations' own `targetTab` metadata via
+ * {@link getInternalToolAppTargetTab} (see `canonicalLauncherId`). This map is
+ * the covered legacy host-owned fallback for the remaining id aliases that have
+ * no owning declaration.
  */
-const CANONICAL_ID: ReadonlyMap<string, string> = new Map([
+const LEGACY_ID_ALIAS_FALLBACK: ReadonlyMap<string, string> = new Map([
   ["inventory", "wallet"],
   ["wallet.inventory", "wallet"],
-  ["@elizaos/plugin-wallet-ui", "wallet"],
   ["triggers", "automations"],
   ["todos", "automations"],
   // The task-coordinator plugin view + the builtin Tasks tab are the one Tasks
   // orchestrator surface (/apps/tasks); collapse to a single tile.
   ["task-coordinator", "tasks"],
   ["knowledge", "documents"],
-  ["@elizaos/plugin-documents-routes", "documents"],
   ["plugins-page", "plugins"],
   ["trajectory-logger", "trajectories"],
   ["trajectory-viewer", "trajectories"],
@@ -137,15 +146,29 @@ const CANONICAL_ID: ReadonlyMap<string, string> = new Map([
   // Triple "Fine-Tuning" tile: the `advanced` builtin tab alias, the
   // `fine-tuning` builtin tab, and the plugin-training app registration
   // (view id `training`) all route to /apps/fine-tuning — collapse to one
-  // tile (#10710).
+  // tile (#10710). The `@elizaos/plugin-training` package name is handled by
+  // its declaration's `targetTab`, not a literal here.
   ["advanced", "fine-tuning"],
   ["training", "fine-tuning"],
-  ["plugin-training", "fine-tuning"],
-  ["@elizaos/plugin-training", "fine-tuning"],
 ]);
 
+/**
+ * Resolve the canonical launcher id an entry id collapses onto.
+ *
+ * Precedence:
+ *  1. Owner-declared metadata: if `id` is an internal-tool app package name, its
+ *     declaration's `targetTab` IS the canonical launcher id (so a package
+ *     rename/add flows through with no edit here — the coupling the audit
+ *     flagged). This replaces the old hand-kept `@elizaos/...` → canonical
+ *     switch.
+ *  2. Legacy id-alias fallback: covered short builtin-tab / view-id aliases with
+ *     no owning declaration (`inventory`, `triggers`, `rolodex`, …).
+ *  3. Identity: the id is already canonical.
+ */
 export function canonicalLauncherId(id: string): string {
-  return CANONICAL_ID.get(id) ?? id;
+  const declaredTargetTab = getInternalToolAppTargetTab(id);
+  if (declaredTargetTab) return declaredTargetTab;
+  return LEGACY_ID_ALIAS_FALLBACK.get(id) ?? id;
 }
 
 const APPS_INDEX = new Map(LAUNCHER_APPS_ORDER.map((id, i) => [id, i]));


### PR DESCRIPTION
## What

`arch-audit brittle strings` item #12090-27: launcher curation should use owner metadata instead of plugin-id / package-name switches.

Launcher curation (`packages/ui/src/components/pages/launcher-curation.ts`) hardcoded plugin **package names** in a hand-maintained `CANONICAL_ID` map:

```ts
["@elizaos/plugin-wallet-ui", "wallet"],
["@elizaos/plugin-documents-routes", "documents"],
["@elizaos/plugin-training", "fine-tuning"],
["plugin-training", "fine-tuning"],
```

These `@elizaos/...` literals silently drifted from the app declarations that actually own those views. The internal-tool app declarations (`internal-tool-apps.ts`) already declare each package `name` → `targetTab`, so the canonical launcher id was derivable from owner metadata — the curation file was duplicating (and drifting from) it.

## Change

- `canonicalLauncherId(id)` now resolves in precedence order:
  1. **Owner-declared metadata** — if `id` is an internal-tool app package name, its declaration's `targetTab` IS the canonical launcher id (`getInternalToolAppTargetTab`). A package rename/add flows through with **no edit to this file** — the coupling the audit flagged.
  2. **Legacy id-alias fallback** — the remaining SHORT builtin-tab / view-id aliases (`inventory`, `triggers`, `rolodex`, ...) that have no owning declaration, renamed `CANONICAL_ID` → `LEGACY_ID_ALIAS_FALLBACK` and explicitly documented + test-covered as a legacy host-owned fallback.
  3. Identity.
- Removed all `@elizaos/plugin-*` package-name keys and the dead bare `plugin-training` key from the curation map.

## Tests (`launcher-curation.test.ts`: 23/23 green)

- All **19 existing** behavior tests preserved (curation order, dedup, AOSP gating, dead-tile guard, canonical alias mapping).
- **+4 new:**
  - `@elizaos/plugin-training` / `@elizaos/plugin-task-coordinator` package names canonicalize via declared `targetTab` (not a literal).
  - an internal-tool catalog card (id = package name) collapses onto its canonical tab tile with no curation edit — proves the coupling is inverted.
  - **grep guard**: asserts no `@elizaos/plugin-*` / `@elizaos/app-*` literal survives as a curation switch in this module (drift regression guard).
  - asserts curation imports `getInternalToolAppTargetTab` (owner metadata) instead of re-listing package names.

## Verification

- `bun run typecheck` (tsgo) in `packages/ui` — **clean, 0 errors**.
- biome check on both files — **clean**.
- `Launcher.test.tsx` (12/12) + all `components/apps` suites green (no downstream breakage in curation consumers).

> Out of scope: the `LauncherSurface` `hyperliquid` tile assertion failure reproduces on clean `origin/develop` (verified via `git stash`), so it is a pre-existing failure unrelated to this change.

— [sol-orch]
