### PR TITLE
fix(#12489): map Zoom meeting artifacts

### DIFF
--- a/.github/issue-evidence/12489-zoom-artifact-mapping.md
+++ b/.github/issue-evidence/12489-zoom-artifact-mapping.md
@@ -1,0 +1,97 @@
+# Evidence for #12489 - Zoom Adapter Completion
+
+## Code PR
+
+https://github.com/elizaOS/eliza/pull/13206
+
+## Human Follow-Up
+
+https://github.com/elizaOS/eliza/issues/13208
+
+## Agent-Completed Work
+
+- Added `buildZoomCanonicalArtifact()` for saved Zoom cloud meeting metadata,
+  participants, recording files, transcript files, transcript entries, and
+  live bot/raw-data capture events.
+- Added `classifyZoomImportError()` for credential/import/capture failures:
+  revoked access, permission denied, meeting not found, expired media URL,
+  waiting-room timeout, denied entry, host removal, muted participants,
+  recording disabled, transcript unavailable, network loss, and host-ended
+  meeting.
+- Preserved native Zoom participant identifiers separately from diarized
+  speaker identifiers in canonical transcript spans.
+- Represented Meeting SDK/raw-data per-participant streams when available and
+  explicit mixed-audio source-loss metadata when only web-client/bot-free mixed
+  audio is available.
+- Added deterministic fixture coverage for cloud transcript/recording imports,
+  mixed-audio loss, per-participant raw-data capture, quality metrics, and
+  failure classification.
+- Documented the Zoom cloud/bot artifact contract in the plugin README and
+  package agent guide.
+
+## Verification
+
+Commands run on 2026-07-04:
+
+```bash
+bun install
+```
+
+Result: completed; no intended dependency changes were kept in this PR. The
+install synced the repo artifact bundle in the isolated worktree.
+
+```bash
+node packages/shared/scripts/generate-keywords.mjs --target ts
+```
+
+Result: completed; generated ignored i18n data needed by the fresh worktree.
+
+```bash
+bun run --cwd packages/cloud/routing build
+```
+
+Result: completed; generated local `@elizaos/cloud-routing` dist output needed
+for the temporary worktree's package-resolution path.
+
+```bash
+bun --conditions=eliza-source --cwd plugins/plugin-meetings vitest run src/platforms/zoom/__tests__/artifacts.test.ts
+```
+
+Result: 1 test file passed, 4 tests passed.
+
+```bash
+bun run --cwd plugins/plugin-meetings test
+```
+
+Result: 23 test files passed, 206 tests passed.
+
+```bash
+bun run --cwd plugins/plugin-meetings typecheck
+```
+
+Result: passed.
+
+```bash
+bun run --cwd plugins/plugin-meetings lint:check
+```
+
+Result: passed.
+
+```bash
+bun run verify
+```
+
+Result: failed outside this PR in the repo-wide lint lane. The blocking failure
+was `@elizaos/tui#lint` on existing `lint/suspicious/noControlCharactersInRegex`
+and `lint/style/noNonNullAssertion` diagnostics in `packages/tui/src/keys.ts`
+and related TUI files. No `packages/tui` files are touched by this PR.
+
+## Not Captured By Agent
+
+N/A for live Zoom product proof in this code PR. The follow-up human issue must
+capture a live or sandbox Zoom cloud recording/transcript import, a bot or
+Meeting SDK/raw-data capture run where credentials/platform policy allow,
+transcript JSON, recording/audio/video artifacts, bot/capture logs, and
+failure-path evidence for waiting room, denied entry, host removes bot, muted
+participants, recording disabled, transcript unavailable, network loss, and
+host ends meeting.

--- a/plugins/plugin-meetings/AGENTS.md
+++ b/plugins/plugin-meetings/AGENTS.md
@@ -50,6 +50,26 @@ host dispatcher answers 401 for unauthenticated callers.
 | Zoom | `zoom.us/j/<id>`, `app.zoom.us/wc/<id>/join` | Web client guest | `?pwd=` preserved |
 | Discord | — | **Not supported here** | Discord "meetings" are voice channels owned by the Discord connector; `requestJoin` rejects with a clear `unsupported_platform` error |
 
+## Zoom cloud/bot artifact contract
+
+Zoom cloud recording imports and bot/raw-data captures normalize through
+`src/platforms/zoom/artifacts.ts`. `buildZoomCanonicalArtifact()` maps saved Zoom
+cloud meeting metadata, participant lists, recording/transcript files, transcript
+entries, and live capture events into `schemaVersion:
+"elizaos.meeting_artifact.v1"`. The mapper preserves native Zoom participant
+ids (`zoomParticipantId`, `userId`, `userGuid`) separately from diarized speaker
+ids, emits per-participant streams when Meeting SDK/raw-data capture has them,
+and emits mixed-audio source-loss metadata when only a bot/web-client or
+bot-free mixed stream is available.
+
+`classifyZoomImportError()` maps credential/import/capture failures into the
+same missing-artifact vocabulary used by the canonical artifact: revoked access,
+permission denied, missing meeting, expired media URL, waiting-room timeout,
+denied entry, host removal, muted participants, recording disabled, transcript
+unavailable, network loss, and host-ended meeting. The deterministic tests use
+saved response-shaped objects only; live Zoom account/API proof still belongs in
+issue evidence.
+
 ## Transcript persistence
 
 Each session creates one record in the runtime `"transcripts"` memories

--- a/plugins/plugin-meetings/CLAUDE.md
+++ b/plugins/plugin-meetings/CLAUDE.md
@@ -50,6 +50,26 @@ host dispatcher answers 401 for unauthenticated callers.
 | Zoom | `zoom.us/j/<id>`, `app.zoom.us/wc/<id>/join` | Web client guest | `?pwd=` preserved |
 | Discord | — | **Not supported here** | Discord "meetings" are voice channels owned by the Discord connector; `requestJoin` rejects with a clear `unsupported_platform` error |
 
+## Zoom cloud/bot artifact contract
+
+Zoom cloud recording imports and bot/raw-data captures normalize through
+`src/platforms/zoom/artifacts.ts`. `buildZoomCanonicalArtifact()` maps saved Zoom
+cloud meeting metadata, participant lists, recording/transcript files, transcript
+entries, and live capture events into `schemaVersion:
+"elizaos.meeting_artifact.v1"`. The mapper preserves native Zoom participant
+ids (`zoomParticipantId`, `userId`, `userGuid`) separately from diarized speaker
+ids, emits per-participant streams when Meeting SDK/raw-data capture has them,
+and emits mixed-audio source-loss metadata when only a bot/web-client or
+bot-free mixed stream is available.
+
+`classifyZoomImportError()` maps credential/import/capture failures into the
+same missing-artifact vocabulary used by the canonical artifact: revoked access,
+permission denied, missing meeting, expired media URL, waiting-room timeout,
+denied entry, host removal, muted participants, recording disabled, transcript
+unavailable, network loss, and host-ended meeting. The deterministic tests use
+saved response-shaped objects only; live Zoom account/API proof still belongs in
+issue evidence.
+
 ## Transcript persistence
 
 Each session creates one record in the runtime `"transcripts"` memories

--- a/plugins/plugin-meetings/README.md
+++ b/plugins/plugin-meetings/README.md
@@ -50,6 +50,26 @@ host dispatcher answers 401 for unauthenticated callers.
 | Zoom | `zoom.us/j/<id>`, `app.zoom.us/wc/<id>/join` | Web client guest | `?pwd=` preserved |
 | Discord | — | **Not supported here** | Discord "meetings" are voice channels owned by the Discord connector; `requestJoin` rejects with a clear `unsupported_platform` error |
 
+## Zoom cloud/bot artifact contract
+
+Zoom cloud recording imports and bot/raw-data captures normalize through
+`src/platforms/zoom/artifacts.ts`. `buildZoomCanonicalArtifact()` maps saved Zoom
+cloud meeting metadata, participant lists, recording/transcript files, transcript
+entries, and live capture events into `schemaVersion:
+"elizaos.meeting_artifact.v1"`. The mapper preserves native Zoom participant
+ids (`zoomParticipantId`, `userId`, `userGuid`) separately from diarized speaker
+ids, emits per-participant streams when Meeting SDK/raw-data capture has them,
+and emits mixed-audio source-loss metadata when only a bot/web-client or
+bot-free mixed stream is available.
+
+`classifyZoomImportError()` maps credential/import/capture failures into the
+same missing-artifact vocabulary used by the canonical artifact: revoked access,
+permission denied, missing meeting, expired media URL, waiting-room timeout,
+denied entry, host removal, muted participants, recording disabled, transcript
+unavailable, network loss, and host-ended meeting. The deterministic tests use
+saved response-shaped objects only; live Zoom account/API proof still belongs in
+issue evidence.
+
 ## Transcript persistence
 
 Each session creates one record in the runtime `"transcripts"` memories

--- a/plugins/plugin-meetings/src/platforms/zoom/__tests__/artifacts.test.ts
+++ b/plugins/plugin-meetings/src/platforms/zoom/__tests__/artifacts.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Deterministic Zoom artifact import tests. Fixtures are saved response-shaped
+ * objects and bot/raw-data events; no live Zoom API or Meeting SDK is used.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  buildZoomCanonicalArtifact,
+  classifyZoomImportError,
+} from "../artifacts.js";
+
+describe("Zoom canonical artifact mapping", () => {
+  it("maps cloud transcript and recording files into the canonical meeting schema", () => {
+    const artifact = buildZoomCanonicalArtifact({
+      meeting: {
+        id: "987654321",
+        uuid: "zoom-uuid-1",
+        topic: "Zoom planning",
+        hostId: "host_1",
+        hostEmail: "host@example.com",
+        timezone: "America/New_York",
+        startTime: "2026-07-04T14:00:00.000Z",
+        endTime: "2026-07-04T14:30:00.000Z",
+      },
+      participants: [
+        {
+          id: "participant-alice",
+          zoomParticipantId: "zoom-participant-alice",
+          userId: "user-alice",
+          displayName: "Alice",
+          email: "alice@example.com",
+          joinTime: "2026-07-04T14:00:10.000Z",
+          leaveTime: "2026-07-04T14:29:00.000Z",
+        },
+      ],
+      recordingFiles: [
+        {
+          id: "recording-video-1",
+          fileType: "MP4",
+          fileExtension: "MP4",
+          recordingType: "shared_screen_with_speaker_view",
+          status: "completed",
+          downloadUrl: "https://zoom.us/rec/download/video",
+          recordingStart: "2026-07-04T14:00:00.000Z",
+          recordingEnd: "2026-07-04T14:30:00.000Z",
+        },
+        {
+          id: "recording-transcript-1",
+          fileType: "TRANSCRIPT",
+          fileExtension: "VTT",
+          recordingType: "audio_transcript",
+          status: "completed",
+          downloadUrl: "https://zoom.us/rec/download/transcript",
+          recordingStart: "2026-07-04T14:01:00.000Z",
+          recordingEnd: "2026-07-04T14:29:00.000Z",
+        },
+      ],
+      transcriptEntries: [
+        {
+          id: "caption-1",
+          sourceFileId: "recording-transcript-1",
+          speakerId: "zoom-participant-alice",
+          diarizedSpeakerId: "speaker-0",
+          speakerName: "Alice",
+          text: "Alice will send the Zoom notes.",
+          startTime: "2026-07-04T14:02:00.000Z",
+          endTime: "2026-07-04T14:02:04.000Z",
+          languageCode: "en-US",
+        },
+      ],
+      generatedNotes: [
+        {
+          kind: "action_item",
+          text: "Alice will send the Zoom notes.",
+          assignee: "Alice",
+          priority: "medium",
+        },
+      ],
+      qualityMetrics: {
+        participantMappingAccuracy: 1,
+        cloudTranscriptWer: 0.04,
+        cloudTranscriptCer: 0.01,
+      },
+    });
+
+    expect(artifact.schemaVersion).toBe("elizaos.meeting_artifact.v1");
+    expect(artifact.source).toBe("zoom");
+    expect(artifact.meeting.durationMinutes).toBe(30);
+    expect(artifact.streams.map((stream) => stream.kind)).toEqual(
+      expect.arrayContaining(["zoom_cloud_transcript", "zoom_cloud_recording"]),
+    );
+    expect(artifact.participants).toEqual([
+      expect.objectContaining({
+        id: "participant-alice",
+        zoomParticipantId: "zoom-participant-alice",
+        zoomUserId: "user-alice",
+      }),
+    ]);
+    expect(artifact.transcriptSpans).toEqual([
+      expect.objectContaining({
+        participantId: "participant-alice",
+        diarizedSpeakerId: "speaker-0",
+        speakerLabel: "Alice",
+        source: "zoom_cloud_transcript",
+        text: "Alice will send the Zoom notes.",
+        provenance: expect.objectContaining({
+          zoomSpeakerId: "zoom-participant-alice",
+          diarizedSpeakerId: "speaker-0",
+          sourceFileId: "recording-transcript-1",
+        }),
+      }),
+    ]);
+    expect(artifact.generatedNotes).toEqual([
+      expect.objectContaining({
+        kind: "action_item",
+        sourceSpanIds: ["caption-1"],
+      }),
+    ]);
+    expect(artifact.metrics.participantMappingAccuracy).toBe(1);
+    expect(artifact.metrics.cloudTranscriptWer).toBe(0.04);
+    expect(artifact.metrics.transcriptWordCount).toBe(6);
+    expect(artifact.missingArtifacts).toEqual([]);
+  });
+
+  it("records mixed-audio source loss when per-participant Zoom capture is unavailable", () => {
+    const artifact = buildZoomCanonicalArtifact({
+      meeting: {
+        id: "987654321",
+        startTime: "2026-07-04T14:00:00.000Z",
+        endTime: "2026-07-04T14:05:00.000Z",
+      },
+      participants: [
+        {
+          id: "participant-bob",
+          displayName: "Bob",
+          muted: true,
+        },
+      ],
+      recordingFiles: [],
+      transcriptEntries: [],
+      recordingDisabled: true,
+      liveCapture: {
+        id: "zoom-bot-capture-1",
+        capturePath: "bot_web_client",
+        outcome: "captured",
+        startedAt: "2026-07-04T14:00:00.000Z",
+        endedAt: "2026-07-04T14:05:00.000Z",
+        streams: [
+          {
+            id: "mixed-audio",
+            kind: "mixed_audio",
+            uri: "file:///captures/zoom-mixed.wav",
+            sampleRateHz: 16000,
+            channels: 1,
+          },
+          {
+            id: "screen",
+            kind: "screen_video",
+            uri: "file:///captures/zoom-screen.webm",
+          },
+        ],
+        transcriptSpans: [
+          {
+            id: "bot-span-1",
+            speakerName: "Bob",
+            diarizedSpeakerId: "speaker-1",
+            text: "Bob was audible only on the mixed stream.",
+            startOffsetMs: 1200,
+            endOffsetMs: 4200,
+          },
+        ],
+      },
+    });
+
+    expect(artifact.streams).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "zoom_bot_mixed_audio",
+          sourceLoss: expect.arrayContaining([
+            "mixed_audio_only",
+            "per_participant_audio_unavailable",
+          ]),
+        }),
+        expect.objectContaining({ kind: "zoom_bot_screen_video" }),
+      ]),
+    );
+    expect(artifact.transcriptSpans).toEqual([
+      expect.objectContaining({
+        source: "zoom_live_capture",
+        participantId: "participant-bob",
+        diarizedSpeakerId: "speaker-1",
+      }),
+    ]);
+    expect(artifact.warnings.map((warning) => warning.code)).toEqual(
+      expect.arrayContaining([
+        "participant_id_missing",
+        "muted_participant",
+        "mixed_audio_source_loss",
+      ]),
+    );
+    expect(artifact.missingArtifacts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          artifactType: "recording",
+          reason: "recording_disabled",
+        }),
+        expect.objectContaining({
+          artifactType: "participant_audio",
+          reason: "per_participant_audio_unavailable",
+        }),
+      ]),
+    );
+    expect(artifact.metrics.sourceLossCount).toBe(2);
+  });
+
+  it("preserves Meeting SDK raw-data per-participant streams when available", () => {
+    const artifact = buildZoomCanonicalArtifact({
+      meeting: {
+        id: "987654321",
+        durationMinutes: 10,
+      },
+      participants: [
+        {
+          id: "participant-carol",
+          zoomParticipantId: "zoom-participant-carol",
+          displayName: "Carol",
+        },
+      ],
+      recordingFiles: [
+        {
+          id: "recording-audio-1",
+          fileType: "M4A",
+          fileExtension: "M4A",
+          downloadUrl: "https://zoom.us/rec/download/audio",
+        },
+      ],
+      transcriptFiles: [
+        {
+          id: "transcript-1",
+          fileType: "TRANSCRIPT",
+          fileExtension: "VTT",
+          downloadUrl: "https://zoom.us/rec/download/transcript",
+        },
+      ],
+      transcriptEntries: [],
+      liveCapture: {
+        id: "zoom-raw-data-1",
+        capturePath: "meeting_sdk_raw_data",
+        outcome: "captured",
+        streams: [
+          {
+            id: "participant-carol-audio",
+            kind: "participant_audio",
+            participantId: "participant-carol",
+            uri: "file:///captures/carol.wav",
+            sampleRateHz: 16000,
+            channels: 1,
+          },
+          {
+            id: "raw-data",
+            kind: "raw_data",
+            uri: "file:///captures/raw-data.jsonl",
+          },
+        ],
+      },
+      qualityMetrics: {
+        perParticipantDer: 0.02,
+        cpWer: 0.05,
+      },
+    });
+
+    expect(artifact.streams).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "zoom_bot_participant_audio",
+          participantId: "participant-carol",
+          sourceLoss: [],
+        }),
+        expect.objectContaining({ kind: "zoom_bot_raw_data" }),
+      ]),
+    );
+    expect(artifact.missingArtifacts).toEqual([]);
+    expect(artifact.metrics.perParticipantDer).toBe(0.02);
+    expect(artifact.metrics.cpWer).toBe(0.05);
+  });
+
+  it("classifies Zoom import and capture failures into missing artifacts", () => {
+    expect(
+      classifyZoomImportError({ code: 403, message: "Permission denied" }),
+    ).toEqual(expect.objectContaining({ reason: "permission_denied" }));
+    expect(
+      classifyZoomImportError({
+        response: { status: 404 },
+        message: "Not found",
+      }),
+    ).toEqual(expect.objectContaining({ reason: "meeting_not_found" }));
+    expect(
+      classifyZoomImportError({ code: 401, message: "invalid_grant revoked" }),
+    ).toEqual(expect.objectContaining({ reason: "revoked_access" }));
+    expect(
+      classifyZoomImportError({ code: 410, message: "download URL expired" }),
+    ).toEqual(expect.objectContaining({ reason: "expired_media_url" }));
+    expect(
+      classifyZoomImportError(new Error("waiting room admission timed out")),
+    ).toEqual(expect.objectContaining({ reason: "waiting_room_timeout" }));
+    expect(classifyZoomImportError(new Error("host removed bot"))).toEqual(
+      expect.objectContaining({ reason: "host_removed_bot" }),
+    );
+    expect(classifyZoomImportError(new Error("network loss"))).toEqual(
+      expect.objectContaining({ reason: "network_loss" }),
+    );
+    expect(classifyZoomImportError(new Error("host ended meeting"))).toEqual(
+      expect.objectContaining({ reason: "host_ended_meeting" }),
+    );
+  });
+});

--- a/plugins/plugin-meetings/src/platforms/zoom/artifacts.ts
+++ b/plugins/plugin-meetings/src/platforms/zoom/artifacts.ts
@@ -1,0 +1,990 @@
+/**
+ * Pure Zoom artifact normalization for cloud imports and bot/raw-data capture
+ * fixtures. This module deliberately has no Zoom SDK/API dependency so saved
+ * response-shaped objects can be regression-tested without credentials.
+ */
+
+export type ZoomCanonicalStreamKind =
+  | "zoom_cloud_transcript"
+  | "zoom_cloud_recording"
+  | "zoom_bot_participant_audio"
+  | "zoom_bot_mixed_audio"
+  | "zoom_bot_raw_data"
+  | "zoom_bot_screen_video";
+
+export type ZoomTranscriptSource =
+  | "zoom_cloud_transcript"
+  | "zoom_live_capture";
+
+export type ZoomSourceLoss =
+  | "per_participant_audio_unavailable"
+  | "participant_identity_unavailable"
+  | "mixed_audio_only"
+  | "muted_participant"
+  | "network_gap"
+  | "recording_disabled";
+
+export type ZoomCapturePath =
+  | "cloud_recording_import"
+  | "meeting_sdk_raw_data"
+  | "bot_web_client"
+  | "bot_free_desktop";
+
+export type ZoomLiveCaptureOutcome =
+  | "captured"
+  | "waiting_room_timeout"
+  | "denied_entry"
+  | "host_removed_bot"
+  | "recording_disabled"
+  | "transcript_unavailable"
+  | "network_loss"
+  | "host_ended_meeting";
+
+export type ZoomMissingArtifactReason =
+  | "transcript_unavailable"
+  | "transcript_delayed"
+  | "recording_unavailable"
+  | "recording_disabled"
+  | "revoked_access"
+  | "permission_denied"
+  | "meeting_not_found"
+  | "expired_media_url"
+  | "waiting_room_timeout"
+  | "denied_entry"
+  | "host_removed_bot"
+  | "muted_participants"
+  | "network_loss"
+  | "host_ended_meeting"
+  | "per_participant_audio_unavailable";
+
+export interface ZoomCloudMeeting {
+  id: string;
+  uuid?: string;
+  topic?: string;
+  hostId?: string;
+  hostEmail?: string;
+  timezone?: string;
+  startTime?: string;
+  endTime?: string;
+  durationMinutes?: number;
+}
+
+export interface ZoomCloudParticipant {
+  id: string;
+  zoomParticipantId?: string;
+  userId?: string;
+  userGuid?: string;
+  displayName: string;
+  email?: string;
+  joinTime?: string;
+  leaveTime?: string;
+  muted?: boolean;
+}
+
+export interface ZoomCloudRecordingFile {
+  id: string;
+  meetingId?: string;
+  recordingType?: string;
+  fileType?: string;
+  fileExtension?: string;
+  status?: string;
+  downloadUrl?: string;
+  playUrl?: string;
+  recordingStart?: string;
+  recordingEnd?: string;
+}
+
+export interface ZoomCloudTranscriptEntry {
+  id?: string;
+  sourceFileId?: string;
+  speakerName?: string;
+  /** Native Zoom participant/user id, when the transcript has one. */
+  speakerId?: string;
+  /** Diarizer-local speaker id; preserved separately from Zoom ids. */
+  diarizedSpeakerId?: string;
+  text: string;
+  startTime?: string;
+  endTime?: string;
+  startOffsetMs?: number;
+  endOffsetMs?: number;
+  languageCode?: string;
+}
+
+export interface ZoomLiveCaptureStreamInput {
+  id: string;
+  kind: "participant_audio" | "mixed_audio" | "raw_data" | "screen_video";
+  uri?: string;
+  participantId?: string;
+  startedAt?: string;
+  endedAt?: string;
+  sampleRateHz?: number;
+  channels?: number;
+  sourceLoss?: ZoomSourceLoss[];
+}
+
+export interface ZoomLiveCaptureArtifact {
+  id: string;
+  capturePath: Exclude<ZoomCapturePath, "cloud_recording_import">;
+  outcome: ZoomLiveCaptureOutcome;
+  startedAt?: string;
+  endedAt?: string;
+  streams: readonly ZoomLiveCaptureStreamInput[];
+  transcriptSpans?: readonly ZoomCloudTranscriptEntry[];
+}
+
+export interface ZoomGeneratedNoteInput {
+  id?: string;
+  kind: "summary" | "key_point" | "action_item";
+  text: string;
+  assignee?: string;
+  dueDate?: string;
+  priority?: "low" | "medium" | "high";
+}
+
+export interface ZoomQualityMetricsInput {
+  participantMappingAccuracy?: number;
+  cloudTranscriptWer?: number;
+  cloudTranscriptCer?: number;
+  perParticipantDer?: number;
+  mixedCaptureDer?: number;
+  cpWer?: number;
+  captureStartLatencyMs?: number;
+  streamDropoutRate?: number;
+  failureClassificationAccuracy?: number;
+}
+
+export interface ZoomCanonicalStream {
+  id: string;
+  kind: ZoomCanonicalStreamKind;
+  capturePath: ZoomCapturePath;
+  artifactId?: string;
+  uri?: string;
+  participantId?: string;
+  startedAt?: string;
+  endedAt?: string;
+  status?: string;
+  sampleRateHz?: number;
+  channels?: number;
+  sourceLoss: ZoomSourceLoss[];
+}
+
+export interface ZoomCanonicalParticipant {
+  id: string;
+  displayName: string;
+  zoomParticipantId?: string;
+  zoomUserId?: string;
+  userGuid?: string;
+  email?: string;
+  joinedAt?: string;
+  leftAt?: string;
+  muted?: boolean;
+}
+
+export interface ZoomCanonicalTranscriptSpan {
+  id: string;
+  streamId: string;
+  source: ZoomTranscriptSource;
+  text: string;
+  participantId?: string;
+  speakerLabel?: string;
+  diarizedSpeakerId?: string;
+  startedAt?: string;
+  endedAt?: string;
+  startOffsetMs?: number;
+  endOffsetMs?: number;
+  languageCode?: string;
+  provenance: {
+    zoomSpeakerId?: string;
+    diarizedSpeakerId?: string;
+    sourceFileId?: string;
+    captureId?: string;
+  };
+}
+
+export interface ZoomCanonicalGeneratedNote {
+  id: string;
+  kind: ZoomGeneratedNoteInput["kind"];
+  text: string;
+  sourceSpanIds: string[];
+  assignee?: string;
+  dueDate?: string;
+  priority?: ZoomGeneratedNoteInput["priority"];
+}
+
+export interface ZoomMissingArtifact {
+  artifactType:
+    | "meeting"
+    | "transcript"
+    | "recording"
+    | "live_capture"
+    | "participant_audio";
+  reason: ZoomMissingArtifactReason;
+  message: string;
+  sourceName?: string;
+}
+
+export interface ZoomCanonicalWarning {
+  code:
+    | "participant_reference_missing"
+    | "participant_id_missing"
+    | "transcript_entry_empty"
+    | "mixed_audio_source_loss"
+    | "muted_participant"
+    | "network_loss"
+    | "host_ended_meeting"
+    | "recording_disabled"
+    | "expired_media_url";
+  message: string;
+  sourceName?: string;
+}
+
+export interface ZoomCanonicalArtifact {
+  schemaVersion: "elizaos.meeting_artifact.v1";
+  source: "zoom";
+  meeting: {
+    id: string;
+    uuid?: string;
+    topic?: string;
+    hostId?: string;
+    hostEmail?: string;
+    timezone?: string;
+    startedAt?: string;
+    endedAt?: string;
+    durationMinutes: number;
+  };
+  streams: ZoomCanonicalStream[];
+  participants: ZoomCanonicalParticipant[];
+  transcriptSpans: ZoomCanonicalTranscriptSpan[];
+  generatedNotes: ZoomCanonicalGeneratedNote[];
+  recordings: ZoomCloudRecordingFile[];
+  warnings: ZoomCanonicalWarning[];
+  missingArtifacts: ZoomMissingArtifact[];
+  metrics: ZoomQualityMetricsInput & {
+    transcriptWordCount: number;
+    participantCount: number;
+    transcriptSpanCount: number;
+    recordingCount: number;
+    streamCount: number;
+    sourceLossCount: number;
+    missingArtifactCount: number;
+    warningCount: number;
+  };
+}
+
+export interface ZoomCanonicalArtifactInput {
+  meeting: ZoomCloudMeeting;
+  participants: readonly ZoomCloudParticipant[];
+  recordingFiles: readonly ZoomCloudRecordingFile[];
+  transcriptFiles?: readonly ZoomCloudRecordingFile[];
+  transcriptEntries: readonly ZoomCloudTranscriptEntry[];
+  liveCapture?: ZoomLiveCaptureArtifact;
+  generatedNotes?: readonly ZoomGeneratedNoteInput[];
+  qualityMetrics?: ZoomQualityMetricsInput;
+  recordingDisabled?: boolean;
+}
+
+export function buildZoomCanonicalArtifact(
+  input: ZoomCanonicalArtifactInput,
+): ZoomCanonicalArtifact {
+  const participantIndex = indexZoomParticipants(input.participants);
+  const transcriptFiles = canonicalTranscriptFiles(input);
+  const recordingFiles = input.recordingFiles.filter(
+    (file) => !isTranscriptFile(file),
+  );
+  const cloudTranscriptStreams = transcriptFiles.map((file) =>
+    canonicalCloudTranscriptStream(file),
+  );
+  const cloudRecordingStreams = recordingFiles.map((file) =>
+    canonicalCloudRecordingStream(file),
+  );
+  const liveStreams = canonicalLiveStreams(input.liveCapture);
+  const streams = [
+    ...cloudTranscriptStreams,
+    ...cloudRecordingStreams,
+    ...liveStreams,
+  ];
+  const transcriptSpans = [
+    ...input.transcriptEntries.map((entry, index) =>
+      canonicalCloudTranscriptSpan(
+        entry,
+        index,
+        transcriptFiles,
+        participantIndex,
+      ),
+    ),
+    ...canonicalLiveTranscriptSpans(input.liveCapture, participantIndex),
+  ];
+  const warnings = canonicalWarnings(input, transcriptSpans, streams);
+  const missingArtifacts = canonicalMissingArtifacts(
+    input,
+    transcriptFiles,
+    recordingFiles,
+  );
+  const generatedNotes = canonicalGeneratedNotes(
+    input.generatedNotes ?? [],
+    transcriptSpans,
+  );
+
+  return {
+    schemaVersion: "elizaos.meeting_artifact.v1",
+    source: "zoom",
+    meeting: {
+      id: input.meeting.id,
+      uuid: input.meeting.uuid,
+      topic: input.meeting.topic,
+      hostId: input.meeting.hostId,
+      hostEmail: input.meeting.hostEmail,
+      timezone: input.meeting.timezone,
+      startedAt: input.meeting.startTime,
+      endedAt: input.meeting.endTime,
+      durationMinutes: zoomDurationMinutes(input.meeting),
+    },
+    streams,
+    participants: input.participants.map((participant) => ({
+      id: participant.id,
+      displayName: participant.displayName,
+      zoomParticipantId: participant.zoomParticipantId,
+      zoomUserId: participant.userId,
+      userGuid: participant.userGuid,
+      email: participant.email,
+      joinedAt: participant.joinTime,
+      leftAt: participant.leaveTime,
+      muted: participant.muted,
+    })),
+    transcriptSpans,
+    generatedNotes,
+    recordings: recordingFiles,
+    warnings,
+    missingArtifacts,
+    metrics: {
+      ...input.qualityMetrics,
+      transcriptWordCount: transcriptSpans.reduce(
+        (count, span) => count + wordCount(span.text),
+        0,
+      ),
+      participantCount: input.participants.length,
+      transcriptSpanCount: transcriptSpans.length,
+      recordingCount: recordingFiles.length,
+      streamCount: streams.length,
+      sourceLossCount: streams.reduce(
+        (count, stream) => count + stream.sourceLoss.length,
+        0,
+      ),
+      missingArtifactCount: missingArtifacts.length,
+      warningCount: warnings.length,
+    },
+  };
+}
+
+export function classifyZoomImportError(
+  error: unknown,
+): ZoomMissingArtifact | null {
+  const status = errorStatus(error);
+  const message = errorMessage(error);
+  const normalized = message.toLowerCase();
+
+  if (
+    status === 401 ||
+    normalized.includes("invalid_grant") ||
+    normalized.includes("revoked")
+  ) {
+    return {
+      artifactType: "meeting",
+      reason: "revoked_access",
+      message: message || "Zoom OAuth access was revoked.",
+    };
+  }
+  if (status === 403) {
+    return {
+      artifactType: "meeting",
+      reason: "permission_denied",
+      message: message || "Zoom artifacts are not visible to this account.",
+    };
+  }
+  if (status === 404) {
+    return {
+      artifactType: "meeting",
+      reason: "meeting_not_found",
+      message: message || "Zoom meeting was not found.",
+    };
+  }
+  if (status === 410 || normalized.includes("expired")) {
+    return {
+      artifactType: "recording",
+      reason: "expired_media_url",
+      message: message || "Zoom media URL has expired.",
+    };
+  }
+  if (normalized.includes("waiting room")) {
+    return {
+      artifactType: "live_capture",
+      reason: "waiting_room_timeout",
+      message: message || "Zoom bot was not admitted from the waiting room.",
+    };
+  }
+  if (normalized.includes("denied") || normalized.includes("rejected")) {
+    return {
+      artifactType: "live_capture",
+      reason: "denied_entry",
+      message: message || "Zoom host denied bot entry.",
+    };
+  }
+  if (normalized.includes("removed")) {
+    return {
+      artifactType: "live_capture",
+      reason: "host_removed_bot",
+      message: message || "Zoom host removed the bot.",
+    };
+  }
+  if (normalized.includes("muted")) {
+    return {
+      artifactType: "participant_audio",
+      reason: "muted_participants",
+      message: message || "Zoom participant audio was muted.",
+    };
+  }
+  if (normalized.includes("recording disabled")) {
+    return {
+      artifactType: "recording",
+      reason: "recording_disabled",
+      message: message || "Zoom recording was disabled.",
+    };
+  }
+  if (normalized.includes("transcript unavailable")) {
+    return {
+      artifactType: "transcript",
+      reason: "transcript_unavailable",
+      message: message || "Zoom transcript was unavailable.",
+    };
+  }
+  if (normalized.includes("network")) {
+    return {
+      artifactType: "live_capture",
+      reason: "network_loss",
+      message: message || "Zoom capture lost network connectivity.",
+    };
+  }
+  if (
+    normalized.includes("host ended") ||
+    normalized.includes("ended by host")
+  ) {
+    return {
+      artifactType: "live_capture",
+      reason: "host_ended_meeting",
+      message: message || "Zoom host ended the meeting.",
+    };
+  }
+
+  return null;
+}
+
+function indexZoomParticipants(
+  participants: readonly ZoomCloudParticipant[],
+): ReadonlyMap<string, ZoomCloudParticipant> {
+  const index = new Map<string, ZoomCloudParticipant>();
+  for (const participant of participants) {
+    const keys = [
+      participant.id,
+      participant.zoomParticipantId,
+      participant.userId,
+      participant.userGuid,
+      participant.email,
+      participant.displayName,
+    ];
+    for (const key of keys) {
+      if (key) index.set(normalizeKey(key), participant);
+    }
+  }
+  return index;
+}
+
+function canonicalTranscriptFiles(
+  input: ZoomCanonicalArtifactInput,
+): ZoomCloudRecordingFile[] {
+  if (input.transcriptFiles?.length) return [...input.transcriptFiles];
+  return input.recordingFiles.filter((file) => isTranscriptFile(file));
+}
+
+function canonicalCloudTranscriptStream(
+  file: ZoomCloudRecordingFile,
+): ZoomCanonicalStream {
+  return {
+    id: cloudTranscriptStreamId(file.id),
+    kind: "zoom_cloud_transcript",
+    capturePath: "cloud_recording_import",
+    artifactId: file.id,
+    uri: file.downloadUrl ?? file.playUrl,
+    startedAt: file.recordingStart,
+    endedAt: file.recordingEnd,
+    status: file.status,
+    sourceLoss: [],
+  };
+}
+
+function canonicalCloudRecordingStream(
+  file: ZoomCloudRecordingFile,
+): ZoomCanonicalStream {
+  return {
+    id: `zoom-cloud-recording:${file.id}`,
+    kind: "zoom_cloud_recording",
+    capturePath: "cloud_recording_import",
+    artifactId: file.id,
+    uri: file.downloadUrl ?? file.playUrl,
+    startedAt: file.recordingStart,
+    endedAt: file.recordingEnd,
+    status: file.status,
+    sourceLoss:
+      file.status === "recording_disabled" ? ["recording_disabled"] : [],
+  };
+}
+
+function canonicalLiveStreams(
+  capture: ZoomLiveCaptureArtifact | undefined,
+): ZoomCanonicalStream[] {
+  if (!capture) return [];
+  return capture.streams.map((stream) => {
+    const kind = liveStreamKind(stream);
+    const sourceLoss = new Set(stream.sourceLoss ?? []);
+    if (stream.kind === "mixed_audio") {
+      sourceLoss.add("mixed_audio_only");
+      sourceLoss.add("per_participant_audio_unavailable");
+    }
+    if (stream.kind === "participant_audio" && !stream.participantId) {
+      sourceLoss.add("participant_identity_unavailable");
+    }
+    return {
+      id: liveStreamId(capture.id, stream),
+      kind,
+      capturePath: capture.capturePath,
+      artifactId: capture.id,
+      uri: stream.uri,
+      participantId: stream.participantId,
+      startedAt: stream.startedAt ?? capture.startedAt,
+      endedAt: stream.endedAt ?? capture.endedAt,
+      sampleRateHz: stream.sampleRateHz,
+      channels: stream.channels,
+      sourceLoss: [...sourceLoss],
+    };
+  });
+}
+
+function canonicalCloudTranscriptSpan(
+  entry: ZoomCloudTranscriptEntry,
+  index: number,
+  transcriptFiles: readonly ZoomCloudRecordingFile[],
+  participantIndex: ReadonlyMap<string, ZoomCloudParticipant>,
+): ZoomCanonicalTranscriptSpan {
+  const participant = resolveParticipant(entry, participantIndex);
+  const sourceFileId = entry.sourceFileId ?? transcriptFiles[0]?.id;
+  return {
+    id: entry.id ?? `zoom-cloud-transcript-entry-${index + 1}`,
+    streamId: sourceFileId
+      ? cloudTranscriptStreamId(sourceFileId)
+      : "zoom-cloud-transcript",
+    source: "zoom_cloud_transcript",
+    text: entry.text,
+    participantId: participant?.id,
+    speakerLabel: participant?.displayName ?? entry.speakerName,
+    diarizedSpeakerId: entry.diarizedSpeakerId,
+    startedAt: entry.startTime,
+    endedAt: entry.endTime,
+    startOffsetMs: entry.startOffsetMs,
+    endOffsetMs: entry.endOffsetMs,
+    languageCode: entry.languageCode,
+    provenance: {
+      zoomSpeakerId: entry.speakerId,
+      diarizedSpeakerId: entry.diarizedSpeakerId,
+      sourceFileId,
+    },
+  };
+}
+
+function canonicalLiveTranscriptSpans(
+  capture: ZoomLiveCaptureArtifact | undefined,
+  participantIndex: ReadonlyMap<string, ZoomCloudParticipant>,
+): ZoomCanonicalTranscriptSpan[] {
+  if (!capture?.transcriptSpans?.length) return [];
+  const mixedStream = capture.streams.find(
+    (stream) => stream.kind === "mixed_audio",
+  );
+  const firstStream = capture.streams[0];
+
+  return capture.transcriptSpans.map((span, index) => {
+    const participant = resolveParticipant(span, participantIndex);
+    const participantStream = participant
+      ? capture.streams.find(
+          (stream) =>
+            stream.kind === "participant_audio" &&
+            stream.participantId === participant.id,
+        )
+      : undefined;
+    const stream = participantStream ?? mixedStream ?? firstStream;
+    return {
+      id: span.id ?? `zoom-live-transcript-entry-${index + 1}`,
+      streamId: stream
+        ? liveStreamId(capture.id, stream)
+        : `zoom-live:${capture.id}`,
+      source: "zoom_live_capture",
+      text: span.text,
+      participantId: participant?.id,
+      speakerLabel: participant?.displayName ?? span.speakerName,
+      diarizedSpeakerId: span.diarizedSpeakerId,
+      startedAt: span.startTime,
+      endedAt: span.endTime,
+      startOffsetMs: span.startOffsetMs,
+      endOffsetMs: span.endOffsetMs,
+      languageCode: span.languageCode,
+      provenance: {
+        zoomSpeakerId: span.speakerId,
+        diarizedSpeakerId: span.diarizedSpeakerId,
+        sourceFileId: span.sourceFileId,
+        captureId: capture.id,
+      },
+    };
+  });
+}
+
+function canonicalWarnings(
+  input: ZoomCanonicalArtifactInput,
+  spans: readonly ZoomCanonicalTranscriptSpan[],
+  streams: readonly ZoomCanonicalStream[],
+): ZoomCanonicalWarning[] {
+  const warnings: ZoomCanonicalWarning[] = [];
+
+  for (const participant of input.participants) {
+    if (
+      !participant.zoomParticipantId &&
+      !participant.userId &&
+      !participant.userGuid
+    ) {
+      warnings.push({
+        code: "participant_id_missing",
+        message:
+          "Zoom participant has a display name but no native participant/user id.",
+        sourceName: participant.id,
+      });
+    }
+    if (participant.muted) {
+      warnings.push({
+        code: "muted_participant",
+        message:
+          "Zoom participant was muted during at least one capture window.",
+        sourceName: participant.id,
+      });
+    }
+  }
+
+  for (const span of spans) {
+    if (!span.text.trim()) {
+      warnings.push({
+        code: "transcript_entry_empty",
+        message: "Zoom transcript entry contained no text.",
+        sourceName: span.id,
+      });
+    }
+    if (
+      (span.provenance.zoomSpeakerId || span.speakerLabel) &&
+      !span.participantId
+    ) {
+      warnings.push({
+        code: "participant_reference_missing",
+        message:
+          "Zoom transcript entry referenced a speaker that was not present in the participant roster.",
+        sourceName: span.id,
+      });
+    }
+  }
+
+  for (const stream of streams) {
+    if (
+      stream.sourceLoss.includes("mixed_audio_only") ||
+      stream.sourceLoss.includes("per_participant_audio_unavailable")
+    ) {
+      warnings.push({
+        code: "mixed_audio_source_loss",
+        message:
+          "Zoom capture contains mixed audio; per-participant stream identity was unavailable.",
+        sourceName: stream.id,
+      });
+    }
+    if (stream.sourceLoss.includes("network_gap")) {
+      warnings.push({
+        code: "network_loss",
+        message: "Zoom capture stream reported a network gap.",
+        sourceName: stream.id,
+      });
+    }
+    if (stream.sourceLoss.includes("recording_disabled")) {
+      warnings.push({
+        code: "recording_disabled",
+        message:
+          "Zoom recording stream reports recording-disabled source loss.",
+        sourceName: stream.id,
+      });
+    }
+  }
+
+  for (const file of [
+    ...input.recordingFiles,
+    ...(input.transcriptFiles ?? []),
+  ]) {
+    if (file.id && !file.downloadUrl && !file.playUrl) {
+      warnings.push({
+        code: "expired_media_url",
+        message:
+          "Zoom media file exists but no download or playback URL was visible.",
+        sourceName: file.id,
+      });
+    }
+  }
+
+  if (input.liveCapture?.outcome === "network_loss") {
+    warnings.push({
+      code: "network_loss",
+      message: "Zoom live capture ended after network loss.",
+      sourceName: input.liveCapture.id,
+    });
+  }
+  if (input.liveCapture?.outcome === "host_ended_meeting") {
+    warnings.push({
+      code: "host_ended_meeting",
+      message: "Zoom live capture ended because the host ended the meeting.",
+      sourceName: input.liveCapture.id,
+    });
+  }
+
+  return warnings;
+}
+
+function canonicalMissingArtifacts(
+  input: ZoomCanonicalArtifactInput,
+  transcriptFiles: readonly ZoomCloudRecordingFile[],
+  recordingFiles: readonly ZoomCloudRecordingFile[],
+): ZoomMissingArtifact[] {
+  const missing: ZoomMissingArtifact[] = [];
+
+  if (transcriptFiles.length === 0 && input.transcriptEntries.length === 0) {
+    missing.push({
+      artifactType: "transcript",
+      reason: input.meeting.endTime
+        ? "transcript_unavailable"
+        : "transcript_delayed",
+      message: input.meeting.endTime
+        ? "No Zoom cloud transcript file or transcript entries were available."
+        : "Zoom cloud transcript is not available yet for the active meeting.",
+    });
+  }
+
+  if (recordingFiles.length === 0) {
+    missing.push({
+      artifactType: "recording",
+      reason: input.recordingDisabled
+        ? "recording_disabled"
+        : "recording_unavailable",
+      message: input.recordingDisabled
+        ? "Zoom cloud recording was disabled for this meeting."
+        : "No Zoom cloud recording files were available for this meeting.",
+    });
+  }
+
+  for (const file of [...recordingFiles, ...transcriptFiles]) {
+    if (file.id && !file.downloadUrl && !file.playUrl) {
+      missing.push({
+        artifactType: isTranscriptFile(file) ? "transcript" : "recording",
+        reason: "expired_media_url",
+        message:
+          "Zoom media file exists but no download or playback URL was available.",
+        sourceName: file.id,
+      });
+    }
+  }
+
+  if (input.liveCapture) {
+    if (input.liveCapture.outcome !== "captured") {
+      missing.push(
+        liveCaptureMissingArtifact(
+          input.liveCapture,
+          input.liveCapture.outcome,
+        ),
+      );
+    }
+    const hasParticipantStream = input.liveCapture.streams.some(
+      (stream) => stream.kind === "participant_audio",
+    );
+    const hasMixedAudio = input.liveCapture.streams.some(
+      (stream) => stream.kind === "mixed_audio",
+    );
+    if (hasMixedAudio && !hasParticipantStream) {
+      missing.push({
+        artifactType: "participant_audio",
+        reason: "per_participant_audio_unavailable",
+        message:
+          "Zoom capture only provided mixed audio; per-participant audio was unavailable.",
+        sourceName: input.liveCapture.id,
+      });
+    }
+  }
+
+  return missing;
+}
+
+function liveCaptureMissingArtifact(
+  capture: ZoomLiveCaptureArtifact,
+  reason: Exclude<ZoomLiveCaptureOutcome, "captured">,
+): ZoomMissingArtifact {
+  const artifactType =
+    reason === "recording_disabled"
+      ? "recording"
+      : reason === "transcript_unavailable"
+        ? "transcript"
+        : "live_capture";
+  return {
+    artifactType,
+    reason,
+    message: `Zoom live capture ended with outcome: ${reason}.`,
+    sourceName: capture.id,
+  };
+}
+
+function canonicalGeneratedNotes(
+  notes: readonly ZoomGeneratedNoteInput[],
+  spans: readonly ZoomCanonicalTranscriptSpan[],
+): ZoomCanonicalGeneratedNote[] {
+  return notes.map((note, index) => ({
+    id: note.id ?? `${note.kind}-${index + 1}`,
+    kind: note.kind,
+    text: note.text,
+    sourceSpanIds: matchingSpanIds(spans, note.text),
+    assignee: note.assignee,
+    dueDate: note.dueDate,
+    priority: note.priority,
+  }));
+}
+
+function matchingSpanIds(
+  spans: readonly ZoomCanonicalTranscriptSpan[],
+  text: string,
+): string[] {
+  const normalizedText = normalizeText(text);
+  return spans
+    .filter((span) => {
+      const normalizedSpan = normalizeText(span.text);
+      return (
+        normalizedSpan &&
+        (normalizedText.includes(normalizedSpan) ||
+          normalizedSpan.includes(normalizedText))
+      );
+    })
+    .map((span) => span.id);
+}
+
+function resolveParticipant(
+  entry: ZoomCloudTranscriptEntry,
+  participantIndex: ReadonlyMap<string, ZoomCloudParticipant>,
+): ZoomCloudParticipant | undefined {
+  const keys = [entry.speakerId, entry.speakerName];
+  for (const key of keys) {
+    if (!key) continue;
+    const participant = participantIndex.get(normalizeKey(key));
+    if (participant) return participant;
+  }
+  return undefined;
+}
+
+function liveStreamKind(
+  stream: ZoomLiveCaptureStreamInput,
+): ZoomCanonicalStreamKind {
+  if (stream.kind === "participant_audio") return "zoom_bot_participant_audio";
+  if (stream.kind === "raw_data") return "zoom_bot_raw_data";
+  if (stream.kind === "screen_video") return "zoom_bot_screen_video";
+  return "zoom_bot_mixed_audio";
+}
+
+function liveStreamId(
+  captureId: string,
+  stream: ZoomLiveCaptureStreamInput,
+): string {
+  return `zoom-live:${captureId}:${stream.id}`;
+}
+
+function cloudTranscriptStreamId(fileId: string): string {
+  return `zoom-cloud-transcript:${fileId}`;
+}
+
+function isTranscriptFile(file: ZoomCloudRecordingFile): boolean {
+  const fileType = file.fileType?.toLowerCase();
+  const extension = file.fileExtension?.toLowerCase();
+  const recordingType = file.recordingType?.toLowerCase();
+  return (
+    fileType === "transcript" ||
+    fileType === "vtt" ||
+    extension === "vtt" ||
+    extension === "txt" ||
+    recordingType === "audio_transcript"
+  );
+}
+
+function zoomDurationMinutes(meeting: ZoomCloudMeeting): number {
+  if (typeof meeting.durationMinutes === "number")
+    return meeting.durationMinutes;
+  if (!meeting.startTime || !meeting.endTime) return 0;
+  const startedAt = Date.parse(meeting.startTime);
+  const endedAt = Date.parse(meeting.endTime);
+  if (!Number.isFinite(startedAt) || !Number.isFinite(endedAt)) return 0;
+  return Math.max(0, Math.round((endedAt - startedAt) / 60_000));
+}
+
+function wordCount(text: string): number {
+  return text.trim() ? text.trim().split(/\s+/).length : 0;
+}
+
+function normalizeText(text: string): string {
+  return text.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function normalizeKey(key: string): string {
+  return normalizeText(key);
+}
+
+function errorStatus(error: unknown): number | null {
+  if (!isRecord(error)) return null;
+  const code = numberField(error, "code") ?? numberField(error, "status");
+  if (code !== null) return code;
+  const response = error.response;
+  if (isRecord(response)) return numberField(response, "status");
+  return null;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (isRecord(error)) {
+    const message = stringField(error, "message");
+    if (message) return message;
+    const response = error.response;
+    if (isRecord(response)) {
+      const responseMessage = stringField(response, "message");
+      if (responseMessage) return responseMessage;
+    }
+  }
+  return "";
+}
+
+function numberField(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+): number | null {
+  const value = record[key];
+  return typeof value === "number" ? value : null;
+}
+
+function stringField(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+): string | null {
+  const value = record[key];
+  return typeof value === "string" ? value : null;
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null;
+}

--- a/plugins/plugin-meetings/src/platforms/zoom/index.ts
+++ b/plugins/plugin-meetings/src/platforms/zoom/index.ts
@@ -1,5 +1,32 @@
 /** Zoom Web Client adapter public surface. */
+
 export { ZoomAdapter } from "./adapter.js";
+export {
+  buildZoomCanonicalArtifact,
+  classifyZoomImportError,
+  type ZoomCanonicalArtifact,
+  type ZoomCanonicalArtifactInput,
+  type ZoomCanonicalGeneratedNote,
+  type ZoomCanonicalParticipant,
+  type ZoomCanonicalStream,
+  type ZoomCanonicalStreamKind,
+  type ZoomCanonicalTranscriptSpan,
+  type ZoomCanonicalWarning,
+  type ZoomCapturePath,
+  type ZoomCloudMeeting,
+  type ZoomCloudParticipant,
+  type ZoomCloudRecordingFile,
+  type ZoomCloudTranscriptEntry,
+  type ZoomGeneratedNoteInput,
+  type ZoomLiveCaptureArtifact,
+  type ZoomLiveCaptureOutcome,
+  type ZoomLiveCaptureStreamInput,
+  type ZoomMissingArtifact,
+  type ZoomMissingArtifactReason,
+  type ZoomQualityMetricsInput,
+  type ZoomSourceLoss,
+  type ZoomTranscriptSource,
+} from "./artifacts.js";
 export {
   classifyZoomPage,
   isZoomAudioInitUrl,


### PR DESCRIPTION
## Summary

- Adds a pure Zoom canonical artifact mapper for saved cloud meeting metadata, participants, recording/transcript files, transcript entries, and live bot/raw-data capture events.
- Preserves native Zoom participant identifiers separately from diarized speaker IDs in canonical transcript spans.
- Represents Meeting SDK/raw-data per-participant streams when available and emits explicit mixed-audio source-loss metadata when only web-client/bot-free mixed audio is available.
- Adds Zoom import/capture failure classification for waiting-room timeout, denied entry, host removal, muted participants, recording disabled, transcript unavailable, network loss, host-ended meeting, revoked access, permission denied, missing meeting, and expired media URL.
- Adds deterministic fixture tests and package docs for the Zoom cloud/bot artifact contract.

## Evidence

- Evidence file: `.github/issue-evidence/12489-zoom-artifact-mapping.md`.
- Human-only evidence issue: #13208.
- `bun install` completed.
- `node packages/shared/scripts/generate-keywords.mjs --target ts` completed for the fresh worktree.
- `bun run --cwd packages/cloud/routing build` completed for local worktree package resolution.
- `bun --conditions=eliza-source --cwd plugins/plugin-meetings vitest run src/platforms/zoom/__tests__/artifacts.test.ts` passed: 1 file, 4 tests.
- `bun run --cwd plugins/plugin-meetings test` passed: 23 files, 206 tests.
- `bun run --cwd plugins/plugin-meetings typecheck` passed.
- `bun run --cwd plugins/plugin-meetings lint:check` passed.
- `bun run verify` was attempted and failed outside this PR in existing `@elizaos/tui#lint` diagnostics. Details are in the evidence file.

## Human Evidence Still Required

This PR does not claim live Zoom product proof. #13208 tracks live/sandbox Zoom cloud recording and transcript import, bot or Meeting SDK/raw-data capture, transcript JSON, media artifacts, capture logs, and required non-happy-path evidence.

Closes #12489.