### PR TITLE
fix(#12656): compat HTTP dispatcher to an ordered route registry

### DIFF
--- a/packages/app-core/src/api/compat-route-chain.test.ts
+++ b/packages/app-core/src/api/compat-route-chain.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for the ordered compat-route registry primitives (#12089 item 5).
+ *
+ * The compat HTTP dispatcher (`handleCompatRouteInner` in server.ts) used to be
+ * a ~30-branch order-dependent if-chain where each branch was
+ * `if (await handleX(...)) return true`. That ordering + short-circuit contract
+ * was implicit in source line order and impossible to assert directly. It is
+ * now an explicit ordered array walked by `runCompatRouteChain`, so these tests
+ * pin the exact semantics the old if-chain relied on:
+ *   - entries run in ARRAY ORDER,
+ *   - the FIRST entry that returns truthy wins and STOPS the chain (no later
+ *     entry runs — matching the old `return true`),
+ *   - an all-declining chain returns false so the caller falls through to its
+ *     terminal handler (matching the old final `return handleDatabaseRows...`).
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  type CompatRouteChainEntry,
+  type CompatRouteContext,
+  type CompatRuntimeState,
+  runCompatRouteChain,
+} from "./compat-route-shared.js";
+
+// A minimal fake context. The chain iterator never touches these fields — it
+// only threads them to handlers — so opaque stand-ins are sufficient here.
+function makeCtx(): CompatRouteContext {
+  const state: CompatRuntimeState = {
+    current: null,
+    pendingAgentName: null,
+    pendingRestartReasons: [],
+  };
+  return {
+    req: {} as CompatRouteContext["req"],
+    res: {} as CompatRouteContext["res"],
+    state,
+    method: "GET",
+    url: new URL("http://localhost/api/anything"),
+  };
+}
+
+function entry(
+  id: string,
+  handler: CompatRouteChainEntry["handler"],
+): CompatRouteChainEntry {
+  return { id, handler };
+}
+
+describe("runCompatRouteChain", () => {
+  it("runs entries in array order and stops at the first that handles", async () => {
+    const calls: string[] = [];
+    const chain: CompatRouteChainEntry[] = [
+      entry("a", () => {
+        calls.push("a");
+        return false;
+      }),
+      entry("b", () => {
+        calls.push("b");
+        return true; // handles — chain must stop here
+      }),
+      entry("c", () => {
+        calls.push("c");
+        return true;
+      }),
+    ];
+
+    const handled = await runCompatRouteChain(chain, makeCtx());
+
+    expect(handled).toBe(true);
+    // "c" must NOT run: short-circuit is the whole point of the old `return true`.
+    expect(calls).toEqual(["a", "b"]);
+  });
+
+  it("returns false and runs every entry when none handle the request", async () => {
+    const calls: string[] = [];
+    const chain: CompatRouteChainEntry[] = [
+      entry("a", () => {
+        calls.push("a");
+        return false;
+      }),
+      entry("b", () => {
+        calls.push("b");
+        return false;
+      }),
+    ];
+
+    const handled = await runCompatRouteChain(chain, makeCtx());
+
+    // false => the dispatcher falls through to its terminal db-rows handler.
+    expect(handled).toBe(false);
+    expect(calls).toEqual(["a", "b"]);
+  });
+
+  it("awaits async handlers and honours a later async truthy result", async () => {
+    const calls: string[] = [];
+    const chain: CompatRouteChainEntry[] = [
+      entry("a", async () => {
+        await Promise.resolve();
+        calls.push("a");
+        return false;
+      }),
+      entry("b", async () => {
+        await Promise.resolve();
+        calls.push("b");
+        return true;
+      }),
+      entry("c", () => {
+        calls.push("c");
+        return true;
+      }),
+    ];
+
+    const handled = await runCompatRouteChain(chain, makeCtx());
+
+    expect(handled).toBe(true);
+    expect(calls).toEqual(["a", "b"]);
+  });
+
+  it("threads the same context object to every entry it runs", async () => {
+    const ctx = makeCtx();
+    const seen: CompatRouteContext[] = [];
+    const chain: CompatRouteChainEntry[] = [
+      entry("a", (c) => {
+        seen.push(c);
+        return false;
+      }),
+      entry("b", (c) => {
+        seen.push(c);
+        return false;
+      }),
+    ];
+
+    await runCompatRouteChain(chain, ctx);
+
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toBe(ctx);
+    expect(seen[1]).toBe(ctx);
+  });
+
+  it("does not run any entry for an empty chain", async () => {
+    const spy = vi.fn();
+    const handled = await runCompatRouteChain([], makeCtx());
+    expect(handled).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-core/src/api/compat-route-shared.ts
+++ b/packages/app-core/src/api/compat-route-shared.ts
@@ -30,6 +30,54 @@ export interface CompatRuntimeState {
   pendingRestartReasons: string[];
 }
 
+/**
+ * Per-request context handed to every ordered compat-route entry. Carries the
+ * pre-parsed `method`/`url` so entries do not each re-derive them, matching the
+ * values the dispatcher already computed for the mode gate.
+ */
+export interface CompatRouteContext {
+  req: http.IncomingMessage;
+  res: http.ServerResponse;
+  state: CompatRuntimeState;
+  method: string;
+  url: URL;
+}
+
+/**
+ * One entry in the ordered compat-route registry (#12089 item 5). Replaces the
+ * former ~30-branch fixed if-chain in `handleCompatRouteInner`: registration
+ * ORDER is now the array order (data), not source line order (a hardcoded
+ * if-chain). `handler` returns `true` when it fully handled the request (the
+ * dispatcher then short-circuits, exactly like the old `return true`), or
+ * `false` to fall through to the next entry.
+ */
+export interface CompatRouteChainEntry {
+  /** Stable id for tests, drift guards, and per-route timing/telemetry. */
+  id: string;
+  handler: (ctx: CompatRouteContext) => Promise<boolean> | boolean;
+}
+
+/**
+ * Iterate an ordered compat-route chain, short-circuiting on the first entry
+ * that reports it handled the request. Pure over the entry list so the
+ * order/short-circuit contract that used to be implicit in the if-chain is
+ * now directly unit-testable. Preserves the legacy semantics exactly: entries
+ * run in array order, the first `true` wins and stops the chain, and an
+ * all-`false` chain returns `false` so the caller can fall through to its
+ * terminal handler.
+ */
+export async function runCompatRouteChain(
+  chain: readonly CompatRouteChainEntry[],
+  ctx: CompatRouteContext,
+): Promise<boolean> {
+  for (const entry of chain) {
+    if (await entry.handler(ctx)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function clearCompatRuntimeRestart(state: CompatRuntimeState): void {
   state.pendingRestartReasons = [];
 }

--- a/packages/app-core/src/api/server-compat-route-chain.guard.test.ts
+++ b/packages/app-core/src/api/server-compat-route-chain.guard.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Drift / grep guard for the compat-route registry refactor (#12089 item 5).
+ *
+ * `handleCompatRouteInner` in server.ts used to enumerate ~30 compat routes as a
+ * fixed, order-dependent if-chain (`if (await handleX(...)) return true`) and
+ * hardwired the four plugin-local-inference route handlers inline in the
+ * dispatcher body. The audit item requires that central enumeration to be an
+ * ordered registry that route modules register into, with a guard proving the
+ * old central if-chain / name-keyed special case is gone from the executable
+ * path.
+ *
+ * This test reads server.ts as source text and asserts:
+ *   1. the dispatcher delegates to the ordered registry via runCompatRouteChain,
+ *   2. the registry const exists and is typed as an ordered entry list,
+ *   3. the old inline hardwired local-inference block (the destructured
+ *      getLocalInferenceRoutes() call sitting directly in the dispatcher body,
+ *      guarded by nothing) is now a single registered entry, i.e. it appears
+ *      inside COMPAT_ROUTE_CHAIN, not in handleCompatRouteInner,
+ *   4. the dispatcher body no longer carries the long `if (await handleX...)`
+ *      route if-chain (only the pre-route policy gates + the registry call).
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const serverSrc = readFileSync(
+  fileURLToPath(new URL("./server.ts", import.meta.url)),
+  "utf8",
+);
+
+/** Extract the body of a top-level `function name(...) { ... }` block. */
+function extractFunctionBody(source: string, signature: string): string {
+  const start = source.indexOf(signature);
+  expect(start, `signature not found: ${signature}`).toBeGreaterThanOrEqual(0);
+  const braceStart = source.indexOf("{", start);
+  let depth = 0;
+  for (let i = braceStart; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        return source.slice(braceStart + 1, i);
+      }
+    }
+  }
+  throw new Error(`unterminated function body for: ${signature}`);
+}
+
+describe("compat-route registry drift guard (#12089 item 5)", () => {
+  it("dispatcher delegates to the ordered registry", () => {
+    const body = extractFunctionBody(
+      serverSrc,
+      "async function handleCompatRouteInner(",
+    );
+    // The dispatcher must walk the registry rather than open-code the chain.
+    expect(body).toContain("runCompatRouteChain(COMPAT_ROUTE_CHAIN");
+  });
+
+  it("declares COMPAT_ROUTE_CHAIN as an ordered entry list", () => {
+    expect(serverSrc).toMatch(
+      /const COMPAT_ROUTE_CHAIN:\s*readonly CompatRouteChainEntry\[\]\s*=\s*\[/,
+    );
+  });
+
+  it("no longer carries the inline compat-route if-chain in the dispatcher body", () => {
+    const body = extractFunctionBody(
+      serverSrc,
+      "async function handleCompatRouteInner(",
+    );
+    // Count `if (await handle...` route branches directly in the dispatcher.
+    // The old if-chain had ~20 of them; the registry-driven dispatcher should
+    // have zero (routes live in COMPAT_ROUTE_CHAIN entries instead). We allow a
+    // small budget of 2 in case an unrelated pre-route gate uses the pattern.
+    const matches = body.match(/if\s*\(await handle[A-Z]\w+CompatRoute/g) ?? [];
+    expect(matches.length).toBeLessThanOrEqual(2);
+    // Specifically, the terminal db-rows handler is the only remaining
+    // hardcoded route call in the dispatcher body, and it is a fallthrough
+    // (return), not an if-branch.
+    expect(body).toContain("return handleDatabaseRowsCompatRoute(");
+  });
+
+  it("local-inference handlers are a registered entry, not an inline dispatcher block", () => {
+    const dispatcherBody = extractFunctionBody(
+      serverSrc,
+      "async function handleCompatRouteInner(",
+    );
+    // The old hardwired block destructured all four handlers off
+    // getLocalInferenceRoutes() directly inside the dispatcher. That call must
+    // no longer live in the dispatcher body.
+    expect(dispatcherBody).not.toContain("getLocalInferenceRoutes()");
+
+    // Instead it lives inside the registry, under a "local-inference" entry.
+    const chainStart = serverSrc.indexOf("const COMPAT_ROUTE_CHAIN");
+    expect(chainStart).toBeGreaterThanOrEqual(0);
+    const chainRegion = serverSrc.slice(chainStart);
+    expect(chainRegion).toContain('id: "local-inference"');
+    expect(chainRegion).toContain("getLocalInferenceRoutes()");
+    // All four local-inference sub-handlers still dispatch, preserving behavior.
+    for (const fn of [
+      "handleLocalInferenceCompatRoutes",
+      "handleLocalInferenceAsrRoute",
+      "handleLocalInferenceTtsRoute",
+      "handleLiveDiarizationRoute",
+    ]) {
+      expect(chainRegion, `${fn} missing from registry`).toContain(fn);
+    }
+  });
+
+  it("preserves the legacy dispatch ORDER of the migrated compat routes", () => {
+    // The registry array order IS the dispatch order. Pin the exact sequence
+    // that the old top-to-bottom if-chain produced so a re-order is caught.
+    const chainStart = serverSrc.indexOf("const COMPAT_ROUTE_CHAIN");
+    const chainRegion = serverSrc.slice(chainStart);
+    const ids = [...chainRegion.matchAll(/\bid:\s*"([^"]+)"/g)].map(
+      (m) => m[1],
+    );
+    expect(ids).toEqual([
+      "runtime-mode",
+      "i18n-locale",
+      "cloud-compat-proxy",
+      "cloud-billing",
+      "dev-compat",
+      "cloud-pair",
+      "auth-bootstrap",
+      "auth-session",
+      "auth-pairing",
+      "embed-auth",
+      "sensitive-request",
+      "credential-tunnel",
+      "background-tasks",
+      "internal-wake",
+      "local-inference",
+      "automations",
+      "secrets",
+      "drop-status",
+      "agent-reset",
+      "plugins",
+      "catalog",
+      "first-run",
+      "plugin-ui-spec",
+      "agents",
+      "config",
+    ]);
+  });
+});

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -55,9 +55,12 @@ import {
 } from "./auth.ts";
 import { handleAutomationsCompatRoutes } from "./automations-compat-routes";
 import {
+  type CompatRouteChainEntry,
+  type CompatRouteContext,
   type CompatRuntimeState,
   clearCompatRuntimeRestart,
   getConfiguredCompatAgentName,
+  runCompatRouteChain,
 } from "./compat-route-shared";
 import { sendJson as sendJsonResponse } from "./response";
 import { enforceCompatRouteAuthPolicy } from "./route-auth-policy";
@@ -699,237 +702,362 @@ async function handleCompatRouteInner(
   if (authPolicyDecision === "denied") return true;
   if (authPolicyDecision === "unmanaged") return false;
 
-  // Runtime mode introspection — UI shells hit this on boot for the
-  // useRuntimeMode() hook.
-  if (await handleRuntimeModeRoute(req, res, state)) return true;
-
-  // First-paint UI language suggestion. Public/advisory only; the client
-  // falls back to English when it is absent, but serving it avoids noisy 404s.
-  if (handleI18nLocaleRoute(req, res)) return true;
-
-  // Eliza Cloud thin-client proxy (compat agents, jobs, OAuth, …). Keep this
-  // before the local /api/cloud handler so /api/cloud/v1/* forwards to Cloud.
-  if (
-    url.pathname.startsWith("/api/cloud/compat/") ||
-    url.pathname.startsWith("/api/cloud/v1/")
-  ) {
-    if (!(await ensureRouteAuthorized(req, res, state))) {
-      return true;
-    }
-    return handleCloudCompatRoute(req, res, url.pathname, method, {
-      config: resolveCloudConfig(state.current),
-      runtime: state.current,
-    });
-  }
-
-  // Cloud billing routes — handle with fresh config from disk so a cloud
-  // API key persisted during login is always available, even if the
-  // upstream's in-memory state.config hasn't been refreshed.
-  if (url.pathname.startsWith("/api/cloud/billing/")) {
-    if (!(await ensureRouteAuthorized(req, res, state))) {
-      return true;
-    }
-    return handleCloudBillingRoute(req, res, url.pathname, method, {
-      config: resolveCloudConfig(state.current),
-      runtime: state.current,
-    });
-  }
-
-  // Dev observability routes.
-  if (await handleDevCompatRoutes(req, res, state)) return true;
-
-  // Cloud SSO popup landing — `/pair?token=X` calls cloud-api server-side,
-  // serves HTML that pins the API token on the SPA's window global. Mounted
-  // before any other auth handler so it owns the root `/pair` URL.
-  if (await handleCloudPairRoute(req, res)) return true;
-
-  // Must precede the auth-pairing handler so the rate-limited route owns /api/auth/bootstrap/exchange.
-  if (await handleAuthBootstrapRoutes(req, res, state)) return true;
-
-  // Cookie + CSRF session lifecycle (setup, login, logout, me, sessions).
-  if (await handleAuthSessionRoutes(req, res, state)) return true;
-
-  // Auth / pairing / first-run status.
-  if (await handleAuthPairingCompatRoutes(req, res, state)) return true;
-  // Embedded-app launch verification (Discord Activity / Telegram Mini App).
-  if (await handleEmbedAuthRoutes(req, res, state)) return true;
-  // Sensitive-request REST surface (create/get/submit/cancel) for owner secret
-  // collection — e.g. orchestrator provider keys land in the shared vault
-  // instead of plain config. Each branch self-authorizes via
-  // ensureCallerAuthorized (trusted-local, API token, or session), matching the
-  // sibling compat handlers, so mounting it does not widen the unauth surface.
-  if (await handleSensitiveRequestRoutes(req, res, state)) return true;
-  if (await handleCredentialTunnelRoute(req, res, state)) return true;
-  if (await handleBackgroundTasksRoute(req, res, state)) return true;
-  // Internal wake route called by Capacitor BackgroundRunner JSContexts on
-  // iOS/Android. Bearer-authed via the device secret; not part of the
-  // cookie session pipeline.
-  if (await handleInternalWakeRoute(req, res, state)) return true;
-  // Local-inference compat routes — loaded via lazy getter to avoid a static
-  // boundary violation (app-core must not statically import plugin packages).
-  {
-    const {
-      handleLiveDiarizationRoute,
-      handleLocalInferenceAsrRoute,
-      handleLocalInferenceCompatRoutes,
-      handleLocalInferenceTtsRoute,
-    } = await getLocalInferenceRoutes();
-    if (await handleLocalInferenceCompatRoutes(req, res, state)) return true;
-    if (await handleLocalInferenceAsrRoute(req, res, state)) return true;
-    if (await handleLocalInferenceTtsRoute(req, res, state)) return true;
-    // WebView → agent PCM transport for live on-device speaker diarization.
-    if (await handleLiveDiarizationRoute(req, res, state)) return true;
-  }
-  if (await handleAutomationsCompatRoutes(req, res, state)) return true;
-
-  // Workbench todos CRUD is owned by @elizaos/plugin-workflow and served on the
-  // runtime plugin route system (`/api/workbench/todos*`).
-
-  if (url.pathname.startsWith("/api/secrets/")) {
-    // #12087 Item 4: each secrets handler self-gates at OWNER (ensureRouteMinRole
-    // in the handler), so the auth no longer lives only in this dispatch prefix.
-    if (
-      await handleSecretsInventoryRoute(req, res, url.pathname, method, state)
-    ) {
-      return true;
-    }
-    if (
-      await handleSecretsManagerRoute(req, res, url.pathname, method, state)
-    ) {
-      return true;
-    }
-  }
-
-  // `/api/cloud/compat/*` and `/api/cloud/billing/*` dispatch above this
-  // point through @elizaos/agent — thin proxies to Eliza Cloud, not local
-  // cloud-connection management. `/api/cloud/*` connection management is
-  // served by elizaCloudRoutePlugin.routes on the runtime plugin route system.
-
-  if (handleDropStatusCompatRoute(req, res, method, url.pathname)) return true;
-
-  if (method === "POST" && url.pathname === "/api/agent/reset") {
-    if (!ensureCompatSensitiveRouteAuthorized(req, res)) {
-      logger.warn(
-        "[eliza][reset] POST /api/agent/reset rejected (sensitive route not authorized)",
-      );
-      return true;
-    }
-
-    try {
-      logger.info(
-        "[eliza][reset] POST /api/agent/reset: loading config, will clear first-run state, persisted provider config, and cloud keys (GGUF / MODELS_DIR untouched)",
-      );
-      const config = loadElizaConfig();
-      logger.info(
-        "[eliza][reset] Skipping loopback API cleanup; runtime stop plus PGlite data-dir removal clears conversations, knowledge, and trajectories without re-entering the HTTP server.",
-      );
-      await clearCompatPgliteDataDir(state.current, config);
-      state.current = null;
-      clearPersistedFirstRunConfig(config);
-      saveElizaConfig(config);
-      clearCloudSecrets();
-      try {
-        await deleteWalletSecretsFromOsStore();
-      } catch (osErr) {
-        logger.warn(
-          `[eliza][reset] OS wallet store cleanup: ${osErr instanceof Error ? osErr.message : String(osErr)}`,
-        );
-      }
-      logger.info(
-        "[eliza][reset] POST /api/agent/reset: eliza.json saved — renderer should restart API process if embedded/external dev",
-      );
-      sendJsonResponse(res, 200, { ok: true });
-    } catch (err) {
-      logger.warn(
-        `[eliza][reset] POST /api/agent/reset failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      sendJsonResponse(res, 500, {
-        error: err instanceof Error ? err.message : "Reset failed",
-      });
-    }
+  // #12089 item 5: the compat route surface below used to be a ~30-branch
+  // order-dependent if-chain (each branch `if (await handleX(...)) return true`)
+  // with the plugin-local-inference handlers hardwired inline. It is now an
+  // ORDERED registry (see `COMPAT_ROUTE_CHAIN`) that route modules/plugins
+  // register entries into; `runCompatRouteChain` walks it in array order,
+  // short-circuiting on the first entry that reports it handled the request.
+  // Ordering is data (array order), not source line order, and the
+  // local-inference coupling is a single registered entry that loads via the
+  // lazy boundary getter instead of an inline special-case block.
+  const ctx: CompatRouteContext = { req, res, state, method, url };
+  if (await runCompatRouteChain(COMPAT_ROUTE_CHAIN, ctx)) {
     return true;
   }
 
-  // Plugin routes load @elizaos/plugin-registry lazily: that package pulls in
-  // heavyweight registry/install code, so keep it out of the startup path and
-  // only load it for plugin-management requests.
-  if (url.pathname.startsWith("/api/plugins")) {
-    const { handlePluginsCompatRoutes } = await getPluginRegistryApi();
-    if (await handlePluginsCompatRoutes(req, res, state)) return true;
-  }
-
-  // Catalog routes — registry SoT projections (apps, plugins, connectors)
-  if (await handleCatalogRoutes(req, res, state)) return true;
-
-  if (await handleFirstRunRoute(req, res, state)) return true;
-
-  // GET /api/plugins/:id/ui-spec — generate a UiSpec for plugin configuration.
-  // Used by the agent to spawn interactive config forms in chat.
-  const uiSpecMatch =
-    method === "GET" &&
-    url.pathname.match(/^\/api\/plugins\/([^/]+)\/ui-spec$/);
-  if (uiSpecMatch) {
-    if (!(await ensureRouteAuthorized(req, res, state))) return true;
-    const pluginId = decodeURIComponent(uiSpecMatch[1]);
-    const { buildPluginConfigUiSpec } = await import(
-      "@elizaos/shared/config/plugin-ui-spec"
-    );
-    const { buildPluginListResponse } = await getPluginRegistryApi();
-    const pluginList = buildPluginListResponse(state.current);
-    const plugin = pluginList.plugins.find(
-      (p: { id: string }) => p.id === pluginId,
-    );
-    if (!plugin) {
-      sendJsonResponse(res, 404, { error: `Plugin "${pluginId}" not found` });
-      return true;
-    }
-    const spec = buildPluginConfigUiSpec(
-      plugin as Parameters<typeof buildPluginConfigUiSpec>[0],
-    );
-    sendJsonResponse(res, 200, { spec });
-    return true;
-  }
-
-  // GET /api/agents — return the running agent's info.
-  // The app runs a single agent; expose it under an `agents` array so older
-  // health probes and desktop callers can use the same response shape.
-  if (method === "GET" && url.pathname === "/api/agents") {
-    if (!(await ensureRouteAuthorized(req, res, state))) {
-      return true;
-    }
-    const config = loadElizaConfig();
-    const character = buildCharacterFromConfig(config);
-    const agentId =
-      state.current?.agentId ??
-      character.id ??
-      "00000000-0000-0000-0000-000000000000";
-    sendJsonResponse(res, 200, {
-      agents: [
-        {
-          id: agentId,
-          name: character.name,
-          status: state.current ? "running" : "stopped",
-        },
-      ],
-    });
-    return true;
-  }
-
-  if (method === "GET" && url.pathname === "/api/config") {
-    if (!(await ensureRouteAuthorized(req, res, state))) {
-      return true;
-    }
-
-    sendJsonResponse(
-      res,
-      200,
-      _filterConfigEnvForResponse(loadElizaConfig() as Record<string, unknown>),
-    );
-    return true;
-  }
-
+  // Terminal fallthrough: database-rows compat surface owns any request the
+  // ordered chain declined. Kept as the explicit chain terminator (not a
+  // registry entry) because it never falls through: it always resolves the
+  // request (200/404/503), so it must run last and unconditionally.
   return handleDatabaseRowsCompatRoute(req, res, state);
 }
+
+// Ordered compat-route registry (#12089 item 5). Replaces the former fixed
+// if-chain in `handleCompatRouteInner`. Entries run in ARRAY ORDER
+// (data-driven), first `true` wins. Preserves the exact legacy ordering and
+// per-route auth gating; the only behavioral change is that order is now an
+// explicit, testable list instead of source-line ordering, and the
+// plugin-local-inference handlers are one lazily-loaded entry rather than an
+// inline hardwired block. Route modules and plugins that need to mount ahead of
+// or behind a given surface splice into this array instead of editing the
+// dispatcher body.
+const COMPAT_ROUTE_CHAIN: readonly CompatRouteChainEntry[] = [
+  {
+    // Runtime mode introspection: UI shells hit this on boot for the
+    // useRuntimeMode() hook.
+    id: "runtime-mode",
+    handler: ({ req, res, state }) => handleRuntimeModeRoute(req, res, state),
+  },
+  {
+    // First-paint UI language suggestion. Public/advisory only; the client
+    // falls back to English when it is absent, but serving it avoids noisy 404s.
+    id: "i18n-locale",
+    handler: ({ req, res }) => handleI18nLocaleRoute(req, res),
+  },
+  {
+    // Eliza Cloud thin-client proxy (compat agents, jobs, OAuth). Keep this
+    // before the local /api/cloud handler so /api/cloud/v1/* forwards to Cloud.
+    id: "cloud-compat-proxy",
+    handler: async ({ req, res, state, method, url }) => {
+      if (
+        !(
+          url.pathname.startsWith("/api/cloud/compat/") ||
+          url.pathname.startsWith("/api/cloud/v1/")
+        )
+      ) {
+        return false;
+      }
+      if (!(await ensureRouteAuthorized(req, res, state))) {
+        return true;
+      }
+      return handleCloudCompatRoute(req, res, url.pathname, method, {
+        config: resolveCloudConfig(state.current),
+        runtime: state.current,
+      });
+    },
+  },
+  {
+    // Cloud billing routes: handle with fresh config from disk so a cloud
+    // API key persisted during login is always available, even if the
+    // upstream's in-memory state.config hasn't been refreshed.
+    id: "cloud-billing",
+    handler: async ({ req, res, state, method, url }) => {
+      if (!url.pathname.startsWith("/api/cloud/billing/")) {
+        return false;
+      }
+      if (!(await ensureRouteAuthorized(req, res, state))) {
+        return true;
+      }
+      return handleCloudBillingRoute(req, res, url.pathname, method, {
+        config: resolveCloudConfig(state.current),
+        runtime: state.current,
+      });
+    },
+  },
+  {
+    // Dev observability routes.
+    id: "dev-compat",
+    handler: ({ req, res, state }) => handleDevCompatRoutes(req, res, state),
+  },
+  {
+    // Cloud SSO popup landing: `/pair?token=X` calls cloud-api server-side,
+    // serves HTML that pins the API token on the SPA's window global. Mounted
+    // before any other auth handler so it owns the root `/pair` URL.
+    id: "cloud-pair",
+    handler: ({ req, res }) => handleCloudPairRoute(req, res),
+  },
+  {
+    // Must precede the auth-pairing handler so the rate-limited route owns
+    // /api/auth/bootstrap/exchange.
+    id: "auth-bootstrap",
+    handler: ({ req, res, state }) =>
+      handleAuthBootstrapRoutes(req, res, state),
+  },
+  {
+    // Cookie + CSRF session lifecycle (setup, login, logout, me, sessions).
+    id: "auth-session",
+    handler: ({ req, res, state }) => handleAuthSessionRoutes(req, res, state),
+  },
+  {
+    // Auth / pairing / first-run status.
+    id: "auth-pairing",
+    handler: ({ req, res, state }) =>
+      handleAuthPairingCompatRoutes(req, res, state),
+  },
+  {
+    // Embedded-app launch verification (Discord Activity / Telegram Mini App).
+    id: "embed-auth",
+    handler: ({ req, res, state }) => handleEmbedAuthRoutes(req, res, state),
+  },
+  {
+    // Sensitive-request REST surface (create/get/submit/cancel) for owner
+    // secret collection: e.g. orchestrator provider keys land in the shared
+    // vault instead of plain config. Each branch self-authorizes via
+    // ensureCallerAuthorized (trusted-local, API token, or session), matching
+    // the sibling compat handlers, so mounting it does not widen the unauth
+    // surface.
+    id: "sensitive-request",
+    handler: ({ req, res, state }) =>
+      handleSensitiveRequestRoutes(req, res, state),
+  },
+  {
+    id: "credential-tunnel",
+    handler: ({ req, res, state }) =>
+      handleCredentialTunnelRoute(req, res, state),
+  },
+  {
+    id: "background-tasks",
+    handler: ({ req, res, state }) =>
+      handleBackgroundTasksRoute(req, res, state),
+  },
+  {
+    // Internal wake route called by Capacitor BackgroundRunner JSContexts on
+    // iOS/Android. Bearer-authed via the device secret; not part of the
+    // cookie session pipeline.
+    id: "internal-wake",
+    handler: ({ req, res, state }) => handleInternalWakeRoute(req, res, state),
+  },
+  {
+    // Local-inference compat routes. Single ordered entry that loads the plugin
+    // route handlers via the lazy getter to avoid a static boundary violation
+    // (app-core must not statically import plugin packages). This replaces the
+    // former inline hardwired block that enumerated the four plugin handlers
+    // directly in the dispatcher body (#12089 item 5).
+    id: "local-inference",
+    handler: async ({ req, res, state }) => {
+      const {
+        handleLiveDiarizationRoute,
+        handleLocalInferenceAsrRoute,
+        handleLocalInferenceCompatRoutes,
+        handleLocalInferenceTtsRoute,
+      } = await getLocalInferenceRoutes();
+      if (await handleLocalInferenceCompatRoutes(req, res, state)) return true;
+      if (await handleLocalInferenceAsrRoute(req, res, state)) return true;
+      if (await handleLocalInferenceTtsRoute(req, res, state)) return true;
+      // WebView -> agent PCM transport for live on-device speaker diarization.
+      return handleLiveDiarizationRoute(req, res, state);
+    },
+  },
+  {
+    id: "automations",
+    handler: ({ req, res, state }) =>
+      handleAutomationsCompatRoutes(req, res, state),
+  },
+  {
+    // Workbench todos CRUD is owned by @elizaos/plugin-workflow and served on
+    // the runtime plugin route system (`/api/workbench/todos*`).
+    //
+    // Secrets inventory/manager. #12087 Item 4: each secrets handler self-gates
+    // at OWNER (ensureRouteMinRole in the handler), so the auth no longer lives
+    // only in this dispatch prefix.
+    id: "secrets",
+    handler: async ({ req, res, state, method, url }) => {
+      if (!url.pathname.startsWith("/api/secrets/")) {
+        return false;
+      }
+      if (
+        await handleSecretsInventoryRoute(req, res, url.pathname, method, state)
+      ) {
+        return true;
+      }
+      return handleSecretsManagerRoute(req, res, url.pathname, method, state);
+    },
+  },
+  {
+    // `/api/cloud/compat/*` and `/api/cloud/billing/*` dispatch through the
+    // cloud entries above: thin proxies to Eliza Cloud, not local
+    // cloud-connection management. `/api/cloud/*` connection management is
+    // served by elizaCloudRoutePlugin.routes on the runtime plugin route system.
+    id: "drop-status",
+    handler: ({ req, res, method, url }) =>
+      handleDropStatusCompatRoute(req, res, method, url.pathname),
+  },
+  {
+    id: "agent-reset",
+    handler: async ({ req, res, state, method, url }) => {
+      if (!(method === "POST" && url.pathname === "/api/agent/reset")) {
+        return false;
+      }
+      if (!ensureCompatSensitiveRouteAuthorized(req, res)) {
+        logger.warn(
+          "[eliza][reset] POST /api/agent/reset rejected (sensitive route not authorized)",
+        );
+        return true;
+      }
+
+      try {
+        logger.info(
+          "[eliza][reset] POST /api/agent/reset: loading config, will clear first-run state, persisted provider config, and cloud keys (GGUF / MODELS_DIR untouched)",
+        );
+        const config = loadElizaConfig();
+        logger.info(
+          "[eliza][reset] Skipping loopback API cleanup; runtime stop plus PGlite data-dir removal clears conversations, knowledge, and trajectories without re-entering the HTTP server.",
+        );
+        await clearCompatPgliteDataDir(state.current, config);
+        state.current = null;
+        clearPersistedFirstRunConfig(config);
+        saveElizaConfig(config);
+        clearCloudSecrets();
+        try {
+          await deleteWalletSecretsFromOsStore();
+        } catch (osErr) {
+          logger.warn(
+            `[eliza][reset] OS wallet store cleanup: ${osErr instanceof Error ? osErr.message : String(osErr)}`,
+          );
+        }
+        logger.info(
+          "[eliza][reset] POST /api/agent/reset: eliza.json saved; renderer should restart API process if embedded/third-party dev",
+        );
+        sendJsonResponse(res, 200, { ok: true });
+      } catch (err) {
+        logger.warn(
+          `[eliza][reset] POST /api/agent/reset failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        sendJsonResponse(res, 500, {
+          error: err instanceof Error ? err.message : "Reset failed",
+        });
+      }
+      return true;
+    },
+  },
+  {
+    // Plugin routes load @elizaos/plugin-registry lazily: that package pulls in
+    // heavyweight registry/install code, so keep it out of the startup path and
+    // only load it for plugin-management requests.
+    id: "plugins",
+    handler: async ({ req, res, state, url }) => {
+      if (!url.pathname.startsWith("/api/plugins")) {
+        return false;
+      }
+      const { handlePluginsCompatRoutes } = await getPluginRegistryApi();
+      return handlePluginsCompatRoutes(req, res, state);
+    },
+  },
+  {
+    // Catalog routes: registry SoT projections (apps, plugins, connectors).
+    id: "catalog",
+    handler: ({ req, res, state }) => handleCatalogRoutes(req, res, state),
+  },
+  {
+    id: "first-run",
+    handler: ({ req, res, state }) => handleFirstRunRoute(req, res, state),
+  },
+  {
+    // GET /api/plugins/:id/ui-spec: generate a UiSpec for plugin configuration.
+    // Used by the agent to spawn interactive config forms in chat. Registered
+    // AFTER the `/api/plugins` handler; the generic handler declines the
+    // ui-spec path (its matcher does not claim it), so this more specific
+    // entry still resolves it, matching the legacy line ordering.
+    id: "plugin-ui-spec",
+    handler: async ({ req, res, state, method, url }) => {
+      const uiSpecMatch =
+        method === "GET" &&
+        url.pathname.match(/^\/api\/plugins\/([^/]+)\/ui-spec$/);
+      if (!uiSpecMatch) {
+        return false;
+      }
+      if (!(await ensureRouteAuthorized(req, res, state))) return true;
+      const pluginId = decodeURIComponent(uiSpecMatch[1]);
+      const { buildPluginConfigUiSpec } = await import(
+        "@elizaos/shared/config/plugin-ui-spec"
+      );
+      const { buildPluginListResponse } = await getPluginRegistryApi();
+      const pluginList = buildPluginListResponse(state.current);
+      const plugin = pluginList.plugins.find(
+        (p: { id: string }) => p.id === pluginId,
+      );
+      if (!plugin) {
+        sendJsonResponse(res, 404, { error: `Plugin "${pluginId}" not found` });
+        return true;
+      }
+      const spec = buildPluginConfigUiSpec(
+        plugin as Parameters<typeof buildPluginConfigUiSpec>[0],
+      );
+      sendJsonResponse(res, 200, { spec });
+      return true;
+    },
+  },
+  {
+    // GET /api/agents: return the running agent's info. The app runs a single
+    // agent; expose it under an `agents` array so older health probes and
+    // desktop callers can use the same response shape.
+    id: "agents",
+    handler: async ({ req, res, state, method, url }) => {
+      if (!(method === "GET" && url.pathname === "/api/agents")) {
+        return false;
+      }
+      if (!(await ensureRouteAuthorized(req, res, state))) {
+        return true;
+      }
+      const config = loadElizaConfig();
+      const character = buildCharacterFromConfig(config);
+      const agentId =
+        state.current?.agentId ??
+        character.id ??
+        "00000000-0000-0000-0000-000000000000";
+      sendJsonResponse(res, 200, {
+        agents: [
+          {
+            id: agentId,
+            name: character.name,
+            status: state.current ? "running" : "stopped",
+          },
+        ],
+      });
+      return true;
+    },
+  },
+  {
+    id: "config",
+    handler: async ({ req, res, state, method, url }) => {
+      if (!(method === "GET" && url.pathname === "/api/config")) {
+        return false;
+      }
+      if (!(await ensureRouteAuthorized(req, res, state))) {
+        return true;
+      }
+      sendJsonResponse(
+        res,
+        200,
+        _filterConfigEnvForResponse(
+          loadElizaConfig() as Record<string, unknown>,
+        ),
+      );
+      return true;
+    },
+  },
+];
 
 export async function handleElizaCompatRoute(
   req: http.IncomingMessage,


### PR DESCRIPTION
Closes #12656 (arch-audit self-registration #12089 item 5).

## Problem
`handleCompatRouteInner` in `packages/app-core/src/api/server.ts` enumerated ~30 compat routes as a fixed, **order-dependent if-chain** (`if (await handleX(...)) return true`) and **hardwired the four plugin-local-inference route handlers inline** in the dispatcher body via a destructured `getLocalInferenceRoutes()` call. Adding/reordering a compat route required editing the central dispatcher, and the local-inference coupling was a name-keyed special case sitting in the executable path — exactly the central-enumeration / fixed-if-chain anti-pattern the audit item targets.

## Change
- Add `CompatRouteChainEntry` / `CompatRouteContext` + a pure `runCompatRouteChain(chain, ctx)` iterator to `compat-route-shared.ts`. It preserves the **exact legacy semantics**: entries run in array order, the first truthy result wins and short-circuits (like the old `return true`), and an all-false chain returns `false` so the caller falls through to its terminal handler (like the old final `return handleDatabaseRowsCompatRoute(...)`).
- Replace the dispatcher if-chain with an ordered `COMPAT_ROUTE_CHAIN` registry (25 entries) the dispatcher walks. **Ordering is now data (array order), not source line order**; route modules/plugins splice into the array instead of editing the dispatcher body.
- Migrate the hardwired plugin-local-inference block into a single registered `local-inference` entry that still loads via the lazy boundary getter (no static plugin import). The inline enumeration is **gone from the executable dispatcher path**.
- Pre-route policy gates (mode-visibility guard, remote-mode forward, auth-policy) stay inline as cross-cutting **pre-route policy** (they are not routes); the terminal `handleDatabaseRowsCompatRoute` stays as the explicit unconditional chain terminator (it never falls through — always resolves 200/404/503).

Behavior-preserving: same handlers, same per-route auth gates, same dispatch order.

## Tests
- **`compat-route-chain.test.ts`** — unit-pins the iterator order / short-circuit / all-false / async-await / context-threading contract the old if-chain relied on (5 tests).
- **`server-compat-route-chain.guard.test.ts`** — grep/drift guard proving: the dispatcher delegates to `runCompatRouteChain(COMPAT_ROUTE_CHAIN, ...)`; the inline `if (await handle...CompatRoute)` if-chain and the inline `getLocalInferenceRoutes()` block are gone from the dispatcher body; local-inference is a registered entry with all four sub-handlers; and the **exact legacy dispatch ORDER of all 25 entries is pinned** so a re-order is caught (5 tests).

**Evidence**
- `10/10` new tests green.
- `tsgo --noEmit` clean for touched files (`server.ts`, `compat-route-shared.ts`, both tests). Remaining tsc errors are **pre-existing** missing-optional-module baseline (`@elizaos/plugin-*`, `@elizaos/capacitor-bun-runtime`, `@elizaos/tui`, discord metadata) — none in touched files.
- biome clean; codex review clean (**no findings**: "No discrete correctness issues were found in the compat-route chain refactor").
- `route-auth-policy.dispatch.test.ts` (imports the dispatcher) is **environmentally blocked on this branch AND pristine develop** by a stale symlinked-node_modules `@elizaos/registry` missing the `first-party/short-id-plugin-map.json` export — verified identical failure with my changes stashed, so it is not a regression from this PR.

-- [sol-orch]