### PR TITLE
fix(app-core): account-pool availability/rotation + first-run masked-key persistence (sign-in→home path)

### DIFF
--- a/packages/app-core/src/api/server-first-run-helpers.masked-key.test.ts
+++ b/packages/app-core/src/api/server-first-run-helpers.masked-key.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Guards `extractAndPersistFirstRunApiKey` against persisting a MASKED
+ * provider key. The dashboard's GET /api/first-run response masks stored keys
+ * as `****xxxx`; a client that echoes that placeholder back must never have it
+ * written into config/env as if it were the credential — it either resolves to
+ * the real key from local stores (process.env) or the persist is refused, so a
+ * previously-working key on disk is never clobbered by the placeholder.
+ *
+ * Runs the REAL helper against the real on-disk eliza.json in a throwaway
+ * ELIZA_STATE_DIR (same harness as first-run-persistence.restart.test.ts).
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadElizaConfig } from "@elizaos/agent";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { extractAndPersistFirstRunApiKey } from "./server-first-run-helpers";
+
+let stateDir: string;
+let prevStateDir: string | undefined;
+let prevHome: string | undefined;
+let prevPersistPath: string | undefined;
+let prevOpenAiKey: string | undefined;
+
+beforeEach(() => {
+  prevStateDir = process.env.ELIZA_STATE_DIR;
+  prevHome = process.env.ELIZA_HOME;
+  prevPersistPath = process.env.ELIZA_PERSIST_CONFIG_PATH;
+  prevOpenAiKey = process.env.OPENAI_API_KEY;
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "first-run-masked-key-"));
+  process.env.ELIZA_STATE_DIR = stateDir;
+  process.env.ELIZA_HOME = stateDir;
+  delete process.env.ELIZA_PERSIST_CONFIG_PATH;
+  delete process.env.OPENAI_API_KEY;
+});
+
+afterEach(() => {
+  const restore = (key: string, value: string | undefined) => {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  };
+  restore("ELIZA_STATE_DIR", prevStateDir);
+  restore("ELIZA_HOME", prevHome);
+  restore("ELIZA_PERSIST_CONFIG_PATH", prevPersistPath);
+  restore("OPENAI_API_KEY", prevOpenAiKey);
+  fs.rmSync(stateDir, { recursive: true, force: true });
+});
+
+function readPersistedOpenAiKey(): unknown {
+  const env = (loadElizaConfig() as Record<string, unknown>).env as
+    | { vars?: Record<string, unknown> }
+    | undefined;
+  return env?.vars?.OPENAI_API_KEY;
+}
+
+function maskedBody(): Record<string, unknown> {
+  return {
+    credentialInputs: { llmApiKey: "****ab12" },
+    serviceRouting: { llmText: { backend: "openai", transport: "direct" } },
+  };
+}
+
+describe("extractAndPersistFirstRunApiKey masked-key handling", () => {
+  it("refuses to persist a masked key when no real key is resolvable (and never clobbers the stored one)", async () => {
+    // Seed the durable config with a REAL key — the state a masked echo-back
+    // request arrives in (the mask was produced FROM this stored key).
+    const seeded = await extractAndPersistFirstRunApiKey({
+      credentialInputs: { llmApiKey: "sk-real-abc123" },
+      serviceRouting: { llmText: { backend: "openai", transport: "direct" } },
+    });
+    expect(seeded).toBe("OPENAI_API_KEY");
+    expect(readPersistedOpenAiKey()).toBe("sk-real-abc123");
+
+    // Simulate a boot where the key lives only on disk (nothing resolvable
+    // from process.env), then replay the masked placeholder.
+    delete process.env.OPENAI_API_KEY;
+    const result = await extractAndPersistFirstRunApiKey(maskedBody());
+
+    expect(result).toBeNull();
+    // The placeholder must not leak into the process env…
+    expect(process.env.OPENAI_API_KEY).toBeUndefined();
+    // …and the stored real key must survive untouched.
+    expect(readPersistedOpenAiKey()).toBe("sk-real-abc123");
+  });
+
+  it("resolves a masked key to the real local credential instead of persisting the placeholder", async () => {
+    process.env.OPENAI_API_KEY = "sk-env-real-999";
+
+    const result = await extractAndPersistFirstRunApiKey(maskedBody());
+
+    expect(result).toBe("OPENAI_API_KEY");
+    expect(readPersistedOpenAiKey()).toBe("sk-env-real-999");
+    expect(process.env.OPENAI_API_KEY).toBe("sk-env-real-999");
+  });
+
+  it("still persists a real user-typed key unchanged", async () => {
+    const result = await extractAndPersistFirstRunApiKey({
+      credentialInputs: { llmApiKey: "sk-typed-777" },
+      serviceRouting: { llmText: { backend: "openai", transport: "direct" } },
+    });
+    expect(result).toBe("OPENAI_API_KEY");
+    expect(readPersistedOpenAiKey()).toBe("sk-typed-777");
+  });
+});

--- a/packages/app-core/src/api/server-first-run-helpers.ts
+++ b/packages/app-core/src/api/server-first-run-helpers.ts
@@ -133,11 +133,15 @@ export async function extractAndPersistFirstRunApiKey(
   );
 
   // If the key is masked (from IPC) or missing, try to resolve the real
-  // key from local credential stores (files, keychain, env).
+  // key from local credential stores (files, keychain, env). A "****xxxx"
+  // value is the server's own GET-response masking echoed back by the
+  // client — never a real credential — so it must be replaced by a resolved
+  // key or dropped, not persisted (persisting it clobbers a working key
+  // with an unusable placeholder).
+  const llmApiKeyMasked = Boolean(llmSelection?.apiKey?.startsWith("****"));
   if (
     llmSelection?.transport === "direct" &&
-    llmSelection.backend !== "elizacloud" &&
-    !llmSelection.apiKey?.startsWith("****")
+    llmSelection.backend !== "elizacloud"
   ) {
     const resolved = resolveProviderCredential(llmSelection.backend);
     if (resolved && resolved.authType === "subscription") {
@@ -164,9 +168,9 @@ export async function extractAndPersistFirstRunApiKey(
       logger.info(
         `[first-run] Resolved real key for ${llmSelection.backend} via credential-resolver`,
       );
-    } else if (!llmSelection.apiKey) {
+    } else if (!llmSelection.apiKey || llmApiKeyMasked) {
       logger.warn(
-        `[first-run] No key found for ${llmSelection.backend} — cannot persist`,
+        `[first-run] No real key available for ${llmSelection.backend} (input key ${llmApiKeyMasked ? "masked" : "missing"}) — cannot persist`,
       );
       return null;
     }

--- a/packages/app-core/src/services/account-pool-availability.test.ts
+++ b/packages/app-core/src/services/account-pool-availability.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Consistency guards for the two account-pool surfaces the orchestrator's
+ * failover/readiness gates depend on:
+ *
+ *  1. Round-robin must actually alternate in the production sequence
+ *     (select → recordCall → select): `recordCall` bumps `lastUsedAt`, and a
+ *     ring ordered by a mutable field reshuffles under the cursor, serving the
+ *     same account back-to-back (a,a,b,b,…).
+ *  2. The coding-agent bridge's `describe()` healthy count must agree with
+ *     what `select()` would serve: a rate-limited account whose
+ *     `healthDetail.until` reset has elapsed is selectable again, so reporting
+ *     it `healthy: 0` makes the SubAgentRouter refuse a failover respawn that
+ *     the pool would happily serve.
+ *
+ * The pool is driven through injected readAccounts/writeAccount; only
+ * `recordCall`'s JSONL usage counter touches disk (a throwaway state dir).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { getCodingAgentSelectorBridge } from "@elizaos/core";
+import type { LinkedAccountConfig } from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AccountPool, isAccountSelectableNow } from "./account-pool";
+import { installCodingAgentSelectorBridge } from "./coding-account-bridge";
+
+let stateDir: string;
+let prevStateDir: string | undefined;
+
+beforeEach(() => {
+  prevStateDir = process.env.ELIZA_STATE_DIR;
+  stateDir = mkdtempSync(path.join(tmpdir(), "account-pool-availability-"));
+  process.env.ELIZA_STATE_DIR = stateDir;
+});
+
+afterEach(() => {
+  if (prevStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+  else process.env.ELIZA_STATE_DIR = prevStateDir;
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+function account(
+  id: string,
+  overrides: Partial<LinkedAccountConfig> = {},
+): LinkedAccountConfig {
+  return {
+    id,
+    providerId: "anthropic-subscription",
+    label: id,
+    source: "oauth",
+    enabled: true,
+    priority: 0,
+    createdAt: 1,
+    health: "ok",
+    ...overrides,
+  };
+}
+
+function poolOf(accounts: Record<string, LinkedAccountConfig>): AccountPool {
+  return new AccountPool({
+    readAccounts: () => accounts,
+    writeAccount: async (next) => {
+      accounts[`${next.providerId}:${next.id}`] = next;
+    },
+  });
+}
+
+describe("round-robin ring stability under usage recording", () => {
+  it("alternates across two equal-priority accounts when recordCall runs between selects", async () => {
+    const accounts = {
+      "anthropic-subscription:a": account("a", { createdAt: 1 }),
+      "anthropic-subscription:b": account("b", { createdAt: 2 }),
+    };
+    const pool = poolOf(accounts);
+
+    const picks: string[] = [];
+    for (let i = 0; i < 4; i++) {
+      const sel = await pool.select({
+        providerId: "anthropic-subscription",
+        strategy: "round-robin",
+      });
+      expect(sel).not.toBeNull();
+      picks.push(sel?.id ?? "none");
+      // The production sequence: every served call is recorded, which bumps
+      // the account's persisted lastUsedAt before the next selection.
+      await pool.recordCall(
+        sel?.id ?? "",
+        { ok: true },
+        { providerId: "anthropic-subscription" },
+      );
+    }
+
+    // Strict alternation — no back-to-back repeats, both accounts used.
+    expect(picks[0]).not.toBe(picks[1]);
+    expect(picks[1]).not.toBe(picks[2]);
+    expect(picks[2]).not.toBe(picks[3]);
+    expect(new Set(picks)).toEqual(new Set(["a", "b"]));
+  });
+});
+
+describe("describe() healthy count agrees with select() eligibility", () => {
+  it("counts a rate-limited account with an ELAPSED reset as healthy (it is selectable)", async () => {
+    const accounts = {
+      "anthropic-subscription:solo": account("solo", {
+        health: "rate-limited",
+        healthDetail: { until: Date.now() - 60_000, lastChecked: Date.now() },
+      }),
+    };
+    const pool = poolOf(accounts);
+    installCodingAgentSelectorBridge(pool);
+    const bridge = getCodingAgentSelectorBridge();
+    expect(bridge).not.toBeNull();
+
+    // The pool serves the account (its rate-limit window has elapsed)…
+    const sel = await pool.select({ providerId: "anthropic-subscription" });
+    expect(sel?.id).toBe("solo");
+
+    // …so availability must report it, or the router's failover gate
+    // (rows.some(r => r.healthy > 0)) refuses a respawn the pool would serve.
+    const sub = bridge
+      ?.describe()
+      .claude?.find((p) => p.providerId === "anthropic-subscription");
+    expect(sub).toMatchObject({ total: 1, enabled: 1, healthy: 1 });
+  });
+
+  it("still reports 0 healthy for future rate-limits, invalid, needs-reauth, and disabled accounts", () => {
+    const future = Date.now() + 3_600_000;
+    const accounts = {
+      "anthropic-subscription:rl": account("rl", {
+        health: "rate-limited",
+        healthDetail: { until: future },
+      }),
+      "anthropic-subscription:bad": account("bad", { health: "invalid" }),
+      "anthropic-subscription:reauth": account("reauth", {
+        health: "needs-reauth",
+      }),
+      "anthropic-subscription:off": account("off", { enabled: false }),
+    };
+    installCodingAgentSelectorBridge(poolOf(accounts));
+    const sub = getCodingAgentSelectorBridge()
+      ?.describe()
+      .claude?.find((p) => p.providerId === "anthropic-subscription");
+    expect(sub).toMatchObject({ total: 4, enabled: 3, healthy: 0 });
+  });
+
+  it("isAccountSelectableNow mirrors the eligibility gate's health rules", () => {
+    const now = 1_000_000;
+    expect(isAccountSelectableNow(account("x"), now)).toBe(true);
+    expect(
+      isAccountSelectableNow(
+        account("x", {
+          health: "rate-limited",
+          healthDetail: { until: now - 1 },
+        }),
+        now,
+      ),
+    ).toBe(true);
+    expect(
+      isAccountSelectableNow(
+        account("x", {
+          health: "rate-limited",
+          healthDetail: { until: now + 1 },
+        }),
+        now,
+      ),
+    ).toBe(false);
+    // rate-limited with no reset timestamp never self-readmits.
+    expect(
+      isAccountSelectableNow(account("x", { health: "rate-limited" }), now),
+    ).toBe(false);
+    expect(
+      isAccountSelectableNow(account("x", { health: "invalid" }), now),
+    ).toBe(false);
+    expect(
+      isAccountSelectableNow(account("x", { health: "needs-reauth" }), now),
+    ).toBe(false);
+  });
+});

--- a/packages/app-core/src/services/account-pool.ts
+++ b/packages/app-core/src/services/account-pool.ts
@@ -221,16 +221,7 @@ export class AccountPool {
       if (!account.enabled) return false;
       if (exclude.has(account.id)) return false;
       if (explicit && !explicit.has(account.id)) return false;
-      if (account.health === "ok") return true;
-      // Allow rate-limited accounts back in once their reset has passed.
-      if (
-        account.health === "rate-limited" &&
-        typeof account.healthDetail?.until === "number" &&
-        account.healthDetail.until < now
-      ) {
-        return true;
-      }
-      return false;
+      return isAccountSelectableNow(account, now);
     });
   }
 
@@ -244,7 +235,11 @@ export class AccountPool {
 
     switch (strategy) {
       case "round-robin": {
-        const sorted = [...eligible].sort(byPriorityThenAge);
+        // The ring MUST have a stable order: byPriorityThenAge tiebreaks on
+        // lastUsedAt, which recordCall bumps between selects, so the ring
+        // would reshuffle under the cursor and serve the same account
+        // back-to-back (a,a,b,b,…) in the normal select→record→select flow.
+        const sorted = [...eligible].sort(byPriorityThenStableIdentity);
         const cursor = (this.roundRobinCursor.get(providerId) ?? -1) + 1;
         const index = cursor % sorted.length;
         this.roundRobinCursor.set(providerId, index);
@@ -526,6 +521,28 @@ export class AccountPool {
   }
 }
 
+/**
+ * Health half of the eligibility gate, shared with the coding-agent bridge's
+ * `describe()` so availability reporting can never disagree with what
+ * `select()` would actually serve: `ok` is selectable, and a rate-limited
+ * account is selectable again once its `healthDetail.until` reset has elapsed
+ * (`invalid` / `needs-reauth` never re-admit on their own). Counting only
+ * `health === "ok"` here used to report `healthy: 0` for a pool whose
+ * rate-limit window had already elapsed — making the orchestrator's failover
+ * gate refuse a respawn that `select()` would have served.
+ */
+export function isAccountSelectableNow(
+  account: LinkedAccountConfig,
+  now: number = Date.now(),
+): boolean {
+  if (account.health === "ok") return true;
+  return (
+    account.health === "rate-limited" &&
+    typeof account.healthDetail?.until === "number" &&
+    account.healthDetail.until < now
+  );
+}
+
 function poolRecordKey(providerId: PoolProviderId, accountId: string): string {
   return `${providerId}:${accountId}`;
 }
@@ -558,6 +575,18 @@ function byPriorityThenAge(
   const aLast = accountLastUsedAt(a);
   const bLast = accountLastUsedAt(b);
   return aLast - bLast; // older first
+}
+
+/** Mutation-free ordering for the round-robin ring: identity fields only
+ * (priority, createdAt, id), so the cursor walks the same sequence no matter
+ * how usage recording mutates `lastUsedAt` between selects. */
+function byPriorityThenStableIdentity(
+  a: LinkedAccountConfig,
+  b: LinkedAccountConfig,
+): number {
+  if (a.priority !== b.priority) return a.priority - b.priority;
+  if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
 }
 
 function _byLeastUsedThenPriority(

--- a/packages/app-core/src/services/coding-account-bridge.ts
+++ b/packages/app-core/src/services/coding-account-bridge.ts
@@ -47,6 +47,7 @@ import {
 import type { LinkedAccountProviderId } from "@elizaos/shared/contracts/service-routing";
 import {
   type AccountPool,
+  isAccountSelectableNow,
   type Strategy,
   selectionForProvider,
 } from "./account-pool.js";
@@ -322,6 +323,7 @@ function makeBridge(pool: AccountPool): CodingAgentSelectorBridge {
   return {
     describe() {
       const out: Record<string, CodingProviderAvailability[]> = {};
+      const now = Date.now();
       for (const [agentType, providers] of Object.entries(
         AGENT_PROVIDER_CANDIDATES,
       )) {
@@ -331,8 +333,13 @@ function makeBridge(pool: AccountPool): CodingAgentSelectorBridge {
             providerId,
             total: accounts.length,
             enabled: accounts.filter((a) => a.enabled).length,
-            healthy: accounts.filter((a) => a.enabled && a.health === "ok")
-              .length,
+            // `healthy` must match select()'s own eligibility gate — the
+            // SubAgentRouter's failover gate and the readiness verdicts read
+            // this count, so a rate-limited account whose reset has elapsed
+            // (selectable again) must not be reported as unavailable.
+            healthy: accounts.filter(
+              (a) => a.enabled && isAccountSelectableNow(a, now),
+            ).length,
           };
         });
       }


### PR DESCRIPTION
Three probe-confirmed bugs in `@elizaos/app-core` account-pool / first-run pure logic, each fixed minimally with a mutation-checked unit test. Branch: `fix/app-core-batch` off `origin/develop`, head `6f98acdeda`.

## Bug 1 — `describe()` healthy-count disagrees with `select()` eligibility
`packages/app-core/src/services/coding-account-bridge.ts` (+ shared predicate in `services/account-pool.ts`)

- **Concrete failure input → wrong output:** single `anthropic-subscription` account with `health:"rate-limited"`, `healthDetail.until = Date.now() - 60_000` (reset elapsed). `pool.select()` **serves it** (the eligibility gate readmits elapsed rate-limits), but `bridge.describe()` reported `healthy: 0`.
- **Impact:** `sub-agent-router.ts#hasHealthyPooledAccount()` gates failover respawns on `rows.some(r => r.healthy > 0)`, and `coding-account-selection.ts` readiness verdicts sum `r.healthy` — both wrongly refuse a respawn / report "0 healthy" for up to the ~5-min keep-alive window even though selection works.
- **Fix:** one exported `isAccountSelectableNow(account, now)` predicate, used by both `filterEligible` and `describe()` so the two surfaces can never diverge. Future-reset / invalid / needs-reauth / disabled still count 0 (existing exhaustion test unchanged, still green).

## Bug 2 — round-robin serves the same account back-to-back in the production sequence
`packages/app-core/src/services/account-pool.ts`

- **Concrete failure input → wrong output:** two equal-priority accounts; alternating `select({strategy:"round-robin"})` + `recordCall(picked)` (i.e. every served call is recorded, as production does) yields picks `a,a,b,b` — probe-verified on develop.
- **Root cause:** the RR ring was sorted with `byPriorityThenAge`, whose `lastUsedAt` tiebreak `recordCall` mutates between selects — the ring reshuffles under the modular cursor.
- **Fix:** ring ordered by immutable identity only (`priority`, `createdAt`, `id`). All existing RR tests (alternation, affinity re-selection window, rotation suite) still pass.

## Bug 3 — masked `****xxxx` first-run key persisted verbatim, clobbering the real key
`packages/app-core/src/api/server-first-run-helpers.ts`

- **Concrete failure input → wrong output:** POST body `{credentialInputs:{llmApiKey:"****ab12"}, serviceRouting:{llmText:{backend:"openai",transport:"direct"}}}` → `extractAndPersistFirstRunApiKey` returned success (`"OPENAI_API_KEY"`) and wrote `OPENAI_API_KEY="****ab12"` into **both** `process.env` and the durable config env (probe-verified on develop). The mask is the server's own GET-response redaction (`****` + last 4) echoed back by a client — persisting it overwrites a working key with an unusable placeholder and every later provider call 401s.
- **Root cause:** the resolve-guard's comment says "If the key is masked (from IPC) or missing, try to resolve the real key", but the condition was `!apiKey?.startsWith("****")` — skipping resolution for exactly the masked case.
- **Fix:** masked keys enter the resolve path (replaced by the real local credential when resolvable); when nothing real resolves the persist is **refused** (same semantics as the existing missing-key bail), so the stored key survives. Real user-typed keys behave byte-identically (pinned by test).
- **Scope note:** distinct from the excluded `credential-resolver.ts` value-import (#12834) and session-auth `nativeCloudApiKey` gating (#12084/#12097) — `resolveProviderCredential` is only called, never modified.

## Tests & evidence
- New: `services/account-pool-availability.test.ts` (4 tests: RR alternation under recordCall churn; elapsed-rate-limit describe/select consistency; future/invalid/needs-reauth/disabled still 0; predicate edge table) and `api/server-first-run-helpers.masked-key.test.ts` (3 tests: refuse-and-don't-clobber, resolve-mask-to-real-env-key, real-typed-key unchanged — real on-disk `eliza.json` in a throwaway `ELIZA_STATE_DIR`, same harness as `first-run-persistence.restart.test.ts`).
- **Mutation-checked:** each fix reverted individually → exactly its guarding test(s) fail (1 / 1 / 2 failures respectively), restored → green.
- Full related sweep: **10 files / 77 tests green** (`account-pool`, `multi-account-rotation`, `multi-account-affinity-failover`, `multi-account-refresh-failover`, `coding-account-bridge`, `first-run-persistence.restart`, `credential-resolver`, `credential-resolver.multi-account`, + 2 new) via `bunx vitest run --no-cache`.
- Typecheck: zero errors in touched files (pre-existing unrelated `plugin-discord` errors exist on develop). Biome clean on the diff (one pre-existing unused-import warning in `account-pool.ts` predates this branch).
- N/A rows: screenshots/video — N/A, server-side pure logic with no rendered surface; live-LLM trajectories — N/A, no agent/prompt/model behavior change; audio — N/A, no voice path.

[phone-ui]

---
**Authored end-to-end by a Fable-5 agent** (verified 100% claude-fable-5), committed + pushed. Each bug probe-executed against the real function on develop (concrete input → wrong output) BEFORE authoring; the agent ran the full related suite (77 tests) green + mutation-checked each fix in its (deps-built) environment. Main-loop re-verification: pure-Fable ✓; clean 5-file merge-base diff; fix LOGIC independently confirmed by reading each diff (masked-key: the old `&& !apiKey?.startsWith('****')` guard skipped real-key resolution precisely when masked — the fix removes it + refuses to persist a placeholder; describe(): now shares `isAccountSelectableNow` with select()). NOTE: the 2 new test files fail to *collect* in a bare worktree (`Cannot find package '@elizaos/auth/credentials'`) — a pre-existing vitest monorepo-symlink issue, NOT this branch: the EXISTING `account-pool.test.ts` fails identically on clean origin/develop, and Bun itself resolves the subpath fine (`import('@elizaos/auth/credentials')` returns its exports). CI builds deps first and runs them green. — [phone-ui]