### PR TITLE
chore(benchmarks): format entity voice metrics test

### DIFF
--- a/packages/benchmarks/entity-voice-bench/metrics.test.ts
+++ b/packages/benchmarks/entity-voice-bench/metrics.test.ts
@@ -6,9 +6,9 @@ import {
   isGrounded,
   nameHitRate,
   nameMatches,
+  type SessionObservation,
   scoreBindings,
   scoreCreation,
-  type SessionObservation,
   wordErrorRate,
 } from "./metrics.ts";
 
@@ -72,12 +72,37 @@ describe("scoreBindings", () => {
     const observation = emptyObservation("household");
     observation.speakerEntities = { jill: "e-jill", bob: "e-bob" };
     observation.turns = [
-      { utteranceId: "household-04", transcript: "", boundEntityId: "e-jill", wasCreated: false },
-      { utteranceId: "household-05", transcript: "", boundEntityId: "e-bob", wasCreated: false },
+      {
+        utteranceId: "household-04",
+        transcript: "",
+        boundEntityId: "e-jill",
+        wasCreated: false,
+      },
+      {
+        utteranceId: "household-05",
+        transcript: "",
+        boundEntityId: "e-bob",
+        wasCreated: false,
+      },
       // profile-reset turn creates a duplicate instead of re-binding
-      { utteranceId: "household-08", transcript: "", boundEntityId: "e-dupe", wasCreated: true },
-      { utteranceId: "household-11", transcript: "", boundEntityId: "e-jill", wasCreated: false },
-      { utteranceId: "household-12", transcript: "", boundEntityId: "e-bob", wasCreated: false },
+      {
+        utteranceId: "household-08",
+        transcript: "",
+        boundEntityId: "e-dupe",
+        wasCreated: true,
+      },
+      {
+        utteranceId: "household-11",
+        transcript: "",
+        boundEntityId: "e-jill",
+        wasCreated: false,
+      },
+      {
+        utteranceId: "household-12",
+        transcript: "",
+        boundEntityId: "e-bob",
+        wasCreated: false,
+      },
     ];
     const details: string[] = [];
     const cell = scoreBindings(session, observation, "recognition", details);
@@ -107,8 +132,12 @@ describe("countFalseMerges", () => {
 describe("isGrounded", () => {
   it("accepts facts traceable to an utterance and rejects fabrications", () => {
     const session = sessionById("household");
-    expect(isGrounded("Jill's birthday is on June twelfth", session)).toBe(true);
-    expect(isGrounded("Jill owns a red sailboat in Miami", session)).toBe(false);
+    expect(isGrounded("Jill's birthday is on June twelfth", session)).toBe(
+      true,
+    );
+    expect(isGrounded("Jill owns a red sailboat in Miami", session)).toBe(
+      false,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- apply Biome import ordering and formatter output to entity voice benchmark metrics test
- unblock the comment-only benchmark headers PR without changing behavior

## Validation
- bunx @biomejs/biome check packages/benchmarks/entity-voice-bench/metrics.test.ts
- bun run --cwd packages/benchmarks/entity-voice-bench test