### PR TITLE
feat(#12284 item 3): real travelActive owner-fact drives the during_travel gate

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
@@ -107,12 +107,14 @@ import {
 } from "../contact-route-policy.js";
 import {
   computeAdaptiveWindowPolicy,
+  isValidTimeZone,
   resolveDefaultTimeZone,
   windowPolicyMatchesDefaults,
 } from "../defaults.js";
 import { materializeDefinitionOccurrences } from "../engine.js";
 import type { LifeOpsContext } from "../lifeops-context.js";
 import { REMINDER_DISPATCH_INSTRUCTIONS } from "../optimized-prompt-instructions.js";
+import { resolveOwnerFactStore } from "../owner/fact-store.js";
 import { refreshLifeOpsRelativeTime } from "../relative-time.js";
 import {
   createLifeOpsActivitySignal,
@@ -240,6 +242,18 @@ const LIFEOPS_SCHEDULE_DEVICE_KINDS = [
 ] as const;
 
 const DEFAULT_SCHEDULED_TASK_PROCESS_LIMIT = 25;
+
+// Upper bound on a device-timezone-inferred travel window. A device-zone shift
+// is a weak signal (a laptop crossing a border, a VPN, a mislabeled home zone),
+// so the provisional record it opens is always bounded — never open-ended — and
+// clears the moment the device returns to the home zone or the window lapses.
+const MAX_TRAVEL_HORIZON_MS = 30 * 24 * 60 * 60 * 1000;
+
+// Provenance note tagging a travel record the reconciler opened from a device-
+// timezone divergence. The reconciler only clears/refreshes records it owns —
+// it never touches a booking (`connector_inferred`) or a spoken statement
+// (`agent_inferred` with a different note) on a coincidental home-zone match.
+const TZ_PROVISIONAL_TRAVEL_NOTE = "device-timezone divergence";
 
 type AdaptiveWindowProfile = Pick<
   ActivityProfile,
@@ -5318,6 +5332,14 @@ export class RemindersDomain {
           lifeOpsEvents,
         }),
     );
+    // Reconcile the active-travel fact BEFORE the scheduled-tasks pass so the
+    // `during_travel` gate reads an up-to-date `travelActive` this same tick:
+    // an expired window is cleared, so tasks resume, and a returned-home device
+    // zone clears a stale record.
+    await runSubsystem("travel_reconcile", undefined, () =>
+      this.reconcileTravelActive(now),
+    );
+
     const scheduledTaskFallback: ProcessDueScheduledTasksResult = {
       completions: [],
       fires: [],
@@ -5356,6 +5378,95 @@ export class RemindersDomain {
         })),
       subsystemFailures,
     };
+  }
+
+  /**
+   * Keeps the owner's `activeTravel` fact honest each tick so the derived
+   * `travelActive` gate cannot get stuck. Two clear signals:
+   *
+   *  1. A lapsed window — `endIso` is in the past — is cleared, so tasks the
+   *     `during_travel` gate suppressed resume without waiting for a booking or
+   *     an "I'm back" message.
+   *  2. Device-timezone divergence: when the owner's home-zone fact is known and
+   *     the device reports a different valid zone, we open a bounded provisional
+   *     travel record (destination = device zone); when the device returns to
+   *     the home zone we clear the record WE opened. We only ever clear our own
+   *     provisional record (tagged via `TZ_PROVISIONAL_TRAVEL_NOTE`) so a real
+   *     booking or spoken statement is never dropped on a coincidental match.
+   *
+   * On shared-server topology `resolveDefaultTimeZone()` returns the SERVER's
+   * zone, not the owner's device — so leg (2) is effectively a no-op there
+   * (device zone == home zone, or the home-zone fact is absent). That is the
+   * intended graceful degradation: we never fabricate a home zone or infer
+   * travel from the server's own zone.
+   */
+  private async reconcileTravelActive(now: Date): Promise<void> {
+    const store = resolveOwnerFactStore(this.ctx.runtime);
+    const facts = await store.read();
+    const active = facts.activeTravel;
+    const nowMs = now.getTime();
+
+    if (active?.value.endIso !== undefined) {
+      const endMs = Date.parse(active.value.endIso);
+      if (!Number.isNaN(endMs) && nowMs > endMs) {
+        await store.setActiveTravel(null, {
+          source: "policy_action",
+          recordedAt: now.toISOString(),
+          note: "travel window lapsed",
+        });
+        logger.info(
+          { endedAt: active.value.endIso },
+          "[RemindersDomain] cleared lapsed active-travel window",
+        );
+        return;
+      }
+    }
+
+    const homeTz = facts.timezone?.value;
+    const deviceTz = resolveDefaultTimeZone();
+    if (!homeTz || !isValidTimeZone(deviceTz)) {
+      return;
+    }
+
+    const isTzProvisional =
+      active?.provenance.note === TZ_PROVISIONAL_TRAVEL_NOTE;
+
+    if (deviceTz !== homeTz) {
+      // Only open a provisional record when nothing else already asserts
+      // travel — a booking or statement is a stronger signal we defer to.
+      if (!active) {
+        await store.setActiveTravel(
+          {
+            startIso: now.toISOString(),
+            endIso: new Date(nowMs + MAX_TRAVEL_HORIZON_MS).toISOString(),
+            destinationTimezone: deviceTz,
+          },
+          {
+            source: "connector_inferred",
+            recordedAt: now.toISOString(),
+            note: TZ_PROVISIONAL_TRAVEL_NOTE,
+          },
+        );
+        logger.info(
+          { homeTz, deviceTz },
+          "[RemindersDomain] opened provisional travel from device-timezone divergence",
+        );
+      }
+      return;
+    }
+
+    // Device is back on the home zone: clear only the record we opened.
+    if (isTzProvisional) {
+      await store.setActiveTravel(null, {
+        source: "policy_action",
+        recordedAt: now.toISOString(),
+        note: "device returned to home timezone",
+      });
+      logger.info(
+        { homeTz },
+        "[RemindersDomain] cleared provisional travel on return to home timezone",
+      );
+    }
   }
 
   private async processSleepCycleCheckins(args: {

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/fact-store.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/fact-store.ts
@@ -47,6 +47,25 @@ export interface OwnerQuietHours {
 }
 
 /**
+ * A booked or declared travel window. The record is first-class — the
+ * `travelActive` boolean the `during_travel` gate reads is DERIVED from it
+ * against the current instant (see `ownerFactsToView`), never persisted on its
+ * own. A bare boolean has no natural clear point and drifts to a permanent-true
+ * state once set; a window with a start/end self-clears the moment `now` leaves
+ * `[startIso, endIso]`. `endIso` is optimistically bounded by every writer (a
+ * booking's arrival, a parsed return date, or a `MAX_TRAVEL_HORIZON` cap) so an
+ * open-ended relocation can never read as perpetual travel.
+ */
+export interface OwnerActiveTravel {
+  /** ISO-8601 instant the travel window opens. */
+  startIso: string;
+  /** ISO-8601 instant the window closes. Absent = still open (bounded by writers). */
+  endIso?: string;
+  /** IANA timezone of the destination; overrides the owner's home zone while active. */
+  destinationTimezone?: string;
+}
+
+/**
  * Source of truth for a stored fact. `first_run` distinguishes answers
  * captured by the first-run capability from answers captured by the
  * owner-profile extraction evaluator. `connector_inferred` covers values an
@@ -106,6 +125,7 @@ export interface OwnerFacts {
 
   // Preferences
   travelBookingPreferences?: OwnerFactEntry<string>;
+  activeTravel?: OwnerFactEntry<OwnerActiveTravel>;
   morningWindow?: OwnerFactEntry<OwnerFactWindow>;
   eveningWindow?: OwnerFactEntry<OwnerFactWindow>;
   quietHours?: OwnerFactEntry<OwnerQuietHours>;
@@ -160,6 +180,15 @@ export interface OwnerFactStore {
     provenance: OwnerFactProvenance,
   ): Promise<OwnerFacts>;
   /**
+   * Set (non-null value) or clear (null) the owner's active-travel record. A
+   * dedicated setter — not routed through the string-only patch path — because
+   * the value is a structured window whose clear must actually remove the fact.
+   */
+  setActiveTravel(
+    value: OwnerActiveTravel | null,
+    provenance: OwnerFactProvenance,
+  ): Promise<OwnerFacts>;
+  /**
    * Upsert an escalation rule. Rules are matched by `definitionId`
    * (`null` = global). Calling with an existing key replaces it.
    */
@@ -208,6 +237,30 @@ function isQuietHours(value: unknown): value is OwnerQuietHours {
     typeof value.timezone === "string" &&
     value.timezone.length > 0
   );
+}
+
+function isActiveTravel(value: unknown): value is OwnerActiveTravel {
+  if (!isPlainRecord(value)) return false;
+  if (
+    typeof value.startIso !== "string" ||
+    Number.isNaN(Date.parse(value.startIso))
+  ) {
+    return false;
+  }
+  if (
+    value.endIso !== undefined &&
+    (typeof value.endIso !== "string" || Number.isNaN(Date.parse(value.endIso)))
+  ) {
+    return false;
+  }
+  if (
+    value.destinationTimezone !== undefined &&
+    (typeof value.destinationTimezone !== "string" ||
+      value.destinationTimezone.length === 0)
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function isReminderIntensity(value: unknown): value is ReminderIntensity {
@@ -290,6 +343,21 @@ function normalizeQuietHoursEntry(
   };
 }
 
+function normalizeActiveTravelEntry(
+  value: unknown,
+): OwnerFactEntry<OwnerActiveTravel> | undefined {
+  if (!isPlainRecord(value)) return undefined;
+  if (!isActiveTravel(value.value)) return undefined;
+  const provenance = normalizeProvenance(value.provenance);
+  if (!provenance) return undefined;
+  const travel: OwnerActiveTravel = { startIso: value.value.startIso };
+  if (value.value.endIso !== undefined) travel.endIso = value.value.endIso;
+  if (value.value.destinationTimezone !== undefined) {
+    travel.destinationTimezone = value.value.destinationTimezone;
+  }
+  return { value: travel, provenance };
+}
+
 function normalizeReminderIntensityEntry(
   value: unknown,
 ): OwnerFactEntry<ReminderIntensity> | undefined {
@@ -366,6 +434,8 @@ function normalizeRecord(value: unknown): PersistedRecord {
   if (evening) facts.eveningWindow = evening;
   const quiet = normalizeQuietHoursEntry(stored.quietHours);
   if (quiet) facts.quietHours = quiet;
+  const activeTravel = normalizeActiveTravelEntry(stored.activeTravel);
+  if (activeTravel) facts.activeTravel = activeTravel;
   const intensity = normalizeReminderIntensityEntry(stored.reminderIntensity);
   if (intensity) facts.reminderIntensity = intensity;
   const escalation = normalizeEscalationRulesEntry(stored.escalationRules);
@@ -596,6 +666,29 @@ class CacheBackedOwnerFactStore implements OwnerFactStore {
     return cloneFacts(next);
   }
 
+  async setActiveTravel(
+    value: OwnerActiveTravel | null,
+    provenance: OwnerFactProvenance,
+  ): Promise<OwnerFacts> {
+    const record = await this.readRecord();
+    const next = cloneFacts(record.facts);
+    if (value === null) {
+      delete next.activeTravel;
+    } else {
+      if (!isActiveTravel(value)) {
+        throw new Error("Active-travel record requires a valid startIso");
+      }
+      const travel: OwnerActiveTravel = { startIso: value.startIso };
+      if (value.endIso !== undefined) travel.endIso = value.endIso;
+      if (value.destinationTimezone !== undefined) {
+        travel.destinationTimezone = value.destinationTimezone;
+      }
+      next.activeTravel = { value: travel, provenance: { ...provenance } };
+    }
+    await this.writeRecord({ schemaVersion: 1, facts: next });
+    return cloneFacts(next);
+  }
+
   async upsertEscalationRule(
     patch: PolicyPatchEscalationRule,
     provenance: OwnerFactProvenance,
@@ -657,6 +750,12 @@ function cloneFacts(facts: OwnerFacts): OwnerFacts {
     next.travelBookingPreferences = cloneStringEntry(
       facts.travelBookingPreferences,
     );
+  }
+  if (facts.activeTravel) {
+    next.activeTravel = {
+      value: { ...facts.activeTravel.value },
+      provenance: { ...facts.activeTravel.provenance },
+    };
   }
   if (facts.morningWindow) {
     next.morningWindow = cloneWindowEntry(facts.morningWindow);
@@ -758,14 +857,33 @@ export function resolveOwnerFactStore(runtime: IAgentRuntime): OwnerFactStore {
  * Reduces a typed `OwnerFacts` record to the minimal `OwnerFactsView`
  * surface consumed by the `ScheduledTask` runner (gates and completion
  * checks). Provenance is intentionally dropped — readers want the value.
+ *
+ * `now` is required because `travelActive` is DERIVED, not stored: it is true
+ * only when `now` falls inside the `activeTravel` window. Absence of an
+ * `activeTravel` record leaves `travelActive` undefined — "not traveling" is
+ * distinguishable from "no data", so the `during_travel` gate correctly denies
+ * (its allow branch tests `=== true`). While travel is active the destination
+ * timezone, when known, overrides the owner's home zone for the view.
  */
 export function ownerFactsToView(
   facts: OwnerFacts,
+  now: Date,
 ): import("@elizaos/plugin-scheduling").OwnerFactsView {
   const view: import("@elizaos/plugin-scheduling").OwnerFactsView = {};
   if (facts.preferredName) view.preferredName = facts.preferredName.value;
   if (facts.timezone) view.timezone = facts.timezone.value;
   if (facts.locale) view.locale = facts.locale.value;
+  if (facts.activeTravel) {
+    const travel = facts.activeTravel.value;
+    const nowMs = now.getTime();
+    const started = nowMs >= Date.parse(travel.startIso);
+    const notEnded =
+      travel.endIso === undefined || nowMs <= Date.parse(travel.endIso);
+    view.travelActive = started && notEnded;
+    if (view.travelActive && travel.destinationTimezone) {
+      view.timezone = travel.destinationTimezone;
+    }
+  }
   if (facts.morningWindow) {
     view.morningWindow = {
       start: facts.morningWindow.value.startLocal,

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts
@@ -18,6 +18,16 @@ import {
   type ExtractedEdge,
 } from "../relationships/extraction.js";
 
+/**
+ * Upper bound on a declared travel window with no parsed return date. A person
+ * saying "I'm traveling" without an end date is away for a trip, not relocating
+ * permanently — so we cap the derived `travelActive` window rather than leave it
+ * open-ended, which would let a one-off statement silence scheduled tasks
+ * forever. 30 days comfortably covers any normal trip; the reconciler and any
+ * later "I'm back" clear it sooner.
+ */
+const MAX_TRAVEL_HORIZON_MS = 30 * 24 * 60 * 60 * 1000;
+
 type IdentityHint = {
   name: string;
   platform: string;
@@ -29,10 +39,18 @@ type RelationshipHint = {
   type: string;
 };
 
+/**
+ * A detected travel-state transition. `set` opens a window (with an optional
+ * parsed return date); `clear` closes it. Absent when the text carries no
+ * travel signal — distinct from a signal that yields no state change.
+ */
+type TravelSignal = { kind: "set"; endIso?: string } | { kind: "clear" };
+
 type ProfileExtraction = {
   facts: OwnerFactsPatch;
   identities: IdentityHint[];
   relationships: RelationshipHint[];
+  travel: TravelSignal | null;
 };
 
 const FACT_PATTERNS = [
@@ -207,7 +225,57 @@ function collectRelationshipHints(text: string): RelationshipHint[] {
   return hints;
 }
 
-function extractProfileDetails(text: string): ProfileExtraction {
+// "I'm back" / "back home" / "home now" — the owner has returned. Checked
+// first so "I'm back home" clears rather than being read as a trip statement.
+const TRAVEL_CLEAR_PATTERN =
+  /\b(?:i'?m\s+back|i\s+am\s+back|back\s+home|(?:i'?m|i\s+am)\s+home\s+now|got\s+(?:back|home)|(?:i'?m|i\s+am)\s+(?:back\s+)?in\s+(?:town|the\s+office))\b/iu;
+
+// "I'm traveling / away / on a trip / out of town", optionally "until <date>".
+const TRAVEL_SET_PATTERN =
+  /\b(?:i'?m|i\s+am)\s+(?:traveling|travelling|away|on\s+(?:a\s+)?(?:trip|vacation|holiday)|out\s+of\s+(?:town|(?:the\s+)?office))\b/iu;
+
+// Captures the return-date phrase after "until"/"till"/"through"/"back on".
+const TRAVEL_UNTIL_PATTERN =
+  /\b(?:until|till|til|through|thru|back\s+(?:on|by))\s+([A-Za-z0-9 ,/.'-]{3,40})/iu;
+
+/**
+ * Parses a free-text return-date phrase to a bounded ISO end. Returns null when
+ * it cannot resolve a real future date within `MAX_TRAVEL_HORIZON_MS`; the
+ * caller then falls back to the horizon cap. `Date.parse` handles common forms
+ * ("July 20", "2026-07-20", "Aug 3"); the current year is assumed when the
+ * parsed date lands in the past (a bare month/day for a future trip).
+ */
+function parseTravelReturnIso(phrase: string, now: Date): string | null {
+  const trimmed = phrase.trim().replace(/[.,]+$/u, "");
+  if (trimmed.length === 0) return null;
+  let parsed = Date.parse(trimmed);
+  if (Number.isNaN(parsed)) {
+    parsed = Date.parse(`${trimmed} ${now.getFullYear()}`);
+  }
+  if (Number.isNaN(parsed)) return null;
+  // A month/day that resolves to the past almost always means next year.
+  if (parsed < now.getTime()) {
+    const nextYear = Date.parse(`${trimmed} ${now.getFullYear() + 1}`);
+    if (Number.isNaN(nextYear) || nextYear < now.getTime()) return null;
+    parsed = nextYear;
+  }
+  if (parsed - now.getTime() > MAX_TRAVEL_HORIZON_MS) return null;
+  return new Date(parsed).toISOString();
+}
+
+function detectTravelSignal(text: string, now: Date): TravelSignal | null {
+  if (TRAVEL_CLEAR_PATTERN.test(text)) {
+    return { kind: "clear" };
+  }
+  if (TRAVEL_SET_PATTERN.test(text)) {
+    const until = TRAVEL_UNTIL_PATTERN.exec(text)?.[1];
+    const endIso = until ? parseTravelReturnIso(until, now) : null;
+    return endIso ? { kind: "set", endIso } : { kind: "set" };
+  }
+  return null;
+}
+
+function extractProfileDetails(text: string, now: Date): ProfileExtraction {
   const facts: OwnerFactsPatch = {};
   collectFactHints(text, facts);
   collectTravelPreferenceHints(text, facts);
@@ -215,6 +283,7 @@ function extractProfileDetails(text: string): ProfileExtraction {
     facts,
     identities: collectIdentityHints(text),
     relationships: collectRelationshipHints(text),
+    travel: detectTravelSignal(text, now),
   };
 }
 
@@ -222,7 +291,8 @@ function hasExtraction(extraction: ProfileExtraction): boolean {
   return (
     Object.keys(extraction.facts).length > 0 ||
     extraction.identities.length > 0 ||
-    extraction.relationships.length > 0
+    extraction.relationships.length > 0 ||
+    extraction.travel !== null
   );
 }
 
@@ -235,20 +305,23 @@ export const ownerProfileExtractionEvaluator: ResponseHandlerEvaluator = {
     if (!(await hasOwnerAccess(runtime, message))) {
       return false;
     }
-    return hasExtraction(extractProfileDetails(messageText(message)));
+    return hasExtraction(
+      extractProfileDetails(messageText(message), new Date()),
+    );
   },
   async evaluate({
     runtime,
     message,
   }): Promise<ResponseHandlerPatch | undefined> {
     const text = messageText(message);
-    const extraction = extractProfileDetails(text);
+    const now = new Date();
+    const extraction = extractProfileDetails(text, now);
     if (!hasExtraction(extraction)) {
       return undefined;
     }
 
     const evidenceId = `message:${String(message.id ?? Date.now())}`;
-    const recordedAt = new Date().toISOString();
+    const recordedAt = now.toISOString();
     const debug: string[] = [];
 
     if (Object.keys(extraction.facts).length > 0) {
@@ -258,6 +331,30 @@ export const ownerProfileExtractionEvaluator: ResponseHandlerEvaluator = {
         note: `response-handler extraction from ${evidenceId}`,
       });
       debug.push(`facts=${Object.keys(extraction.facts).length}`);
+    }
+
+    if (extraction.travel !== null) {
+      const store = createOwnerFactStore(runtime);
+      const provenance = {
+        source: "agent_inferred" as const,
+        recordedAt,
+        note: `travel-state extraction from ${evidenceId}`,
+      };
+      if (extraction.travel.kind === "clear") {
+        await store.setActiveTravel(null, provenance);
+        debug.push("travel=clear");
+      } else {
+        // Bound every declared window: a parsed return date when present, else
+        // the horizon cap. Never open-ended — see MAX_TRAVEL_HORIZON_MS.
+        const endIso =
+          extraction.travel.endIso ??
+          new Date(now.getTime() + MAX_TRAVEL_HORIZON_MS).toISOString();
+        await store.setActiveTravel(
+          { startIso: recordedAt, endIso },
+          provenance,
+        );
+        debug.push("travel=set");
+      }
     }
 
     if (

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/travel-active-derivation.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/travel-active-derivation.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Pure-transform coverage for the derived `travelActive` field (#12284 item 3).
+ * No runtime graph: exercises `ownerFactsToView` directly against synthetic
+ * `OwnerFacts`, asserting the boolean is DERIVED from the `activeTravel` window
+ * against `now` — true inside the window, false outside, undefined with no
+ * record — and that the destination zone overrides the home zone while active.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type OwnerFactProvenance,
+  type OwnerFacts,
+  ownerFactsToView,
+} from "./fact-store.ts";
+
+const provenance: OwnerFactProvenance = {
+  source: "connector_inferred",
+  recordedAt: "2026-07-01T00:00:00.000Z",
+};
+
+const at = (iso: string): Date => new Date(iso);
+
+function factsWithTravel(
+  travel: { startIso: string; endIso?: string; destinationTimezone?: string },
+  extra: Partial<OwnerFacts> = {},
+): OwnerFacts {
+  return { activeTravel: { value: travel, provenance }, ...extra };
+}
+
+describe("ownerFactsToView — travelActive derivation", () => {
+  it("no activeTravel record => travelActive undefined (missing != not-traveling)", () => {
+    const view = ownerFactsToView({}, at("2026-07-10T12:00:00.000Z"));
+    expect(view.travelActive).toBeUndefined();
+  });
+
+  it("now inside [start, end] => travelActive true", () => {
+    const view = ownerFactsToView(
+      factsWithTravel({
+        startIso: "2026-07-10T00:00:00.000Z",
+        endIso: "2026-07-20T00:00:00.000Z",
+      }),
+      at("2026-07-15T12:00:00.000Z"),
+    );
+    expect(view.travelActive).toBe(true);
+  });
+
+  it("now before start => travelActive false", () => {
+    const view = ownerFactsToView(
+      factsWithTravel({
+        startIso: "2026-07-10T00:00:00.000Z",
+        endIso: "2026-07-20T00:00:00.000Z",
+      }),
+      at("2026-07-05T12:00:00.000Z"),
+    );
+    expect(view.travelActive).toBe(false);
+  });
+
+  it("now after end => travelActive false", () => {
+    const view = ownerFactsToView(
+      factsWithTravel({
+        startIso: "2026-07-10T00:00:00.000Z",
+        endIso: "2026-07-20T00:00:00.000Z",
+      }),
+      at("2026-07-25T12:00:00.000Z"),
+    );
+    expect(view.travelActive).toBe(false);
+  });
+
+  it("boundaries are inclusive (start and end instants count as active)", () => {
+    const window = {
+      startIso: "2026-07-10T00:00:00.000Z",
+      endIso: "2026-07-20T00:00:00.000Z",
+    };
+    expect(
+      ownerFactsToView(factsWithTravel(window), at(window.startIso))
+        .travelActive,
+    ).toBe(true);
+    expect(
+      ownerFactsToView(factsWithTravel(window), at(window.endIso)).travelActive,
+    ).toBe(true);
+  });
+
+  it("open-ended window (no endIso) => active for any now at/after start", () => {
+    const view = ownerFactsToView(
+      factsWithTravel({ startIso: "2026-07-10T00:00:00.000Z" }),
+      at("2027-01-01T00:00:00.000Z"),
+    );
+    expect(view.travelActive).toBe(true);
+  });
+
+  it("destinationTimezone overrides home timezone while travel is active", () => {
+    const view = ownerFactsToView(
+      factsWithTravel(
+        {
+          startIso: "2026-07-10T00:00:00.000Z",
+          endIso: "2026-07-20T00:00:00.000Z",
+          destinationTimezone: "Asia/Tokyo",
+        },
+        { timezone: { value: "America/New_York", provenance } },
+      ),
+      at("2026-07-15T12:00:00.000Z"),
+    );
+    expect(view.travelActive).toBe(true);
+    expect(view.timezone).toBe("Asia/Tokyo");
+  });
+
+  it("destinationTimezone does NOT override once travel is over", () => {
+    const view = ownerFactsToView(
+      factsWithTravel(
+        {
+          startIso: "2026-07-10T00:00:00.000Z",
+          endIso: "2026-07-20T00:00:00.000Z",
+          destinationTimezone: "Asia/Tokyo",
+        },
+        { timezone: { value: "America/New_York", provenance } },
+      ),
+      at("2026-07-25T12:00:00.000Z"),
+    );
+    expect(view.travelActive).toBe(false);
+    expect(view.timezone).toBe("America/New_York");
+  });
+
+  it("home timezone is preserved when travel has no destination zone", () => {
+    const view = ownerFactsToView(
+      factsWithTravel(
+        {
+          startIso: "2026-07-10T00:00:00.000Z",
+          endIso: "2026-07-20T00:00:00.000Z",
+        },
+        { timezone: { value: "America/New_York", provenance } },
+      ),
+      at("2026-07-15T12:00:00.000Z"),
+    );
+    expect(view.travelActive).toBe(true);
+    expect(view.timezone).toBe("America/New_York");
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -186,7 +186,10 @@ function defaultOwnerFactsProvider(
 ): () => Promise<OwnerFactsView> {
   return async () => {
     const store = resolveOwnerFactStore(runtime);
-    const view = ownerFactsToView(await store.read());
+    // `new Date()` drives the derived `travelActive` — the view reflects
+    // whether the owner is inside a booked/declared travel window at this
+    // instant, which is exactly what the `during_travel` gate needs each tick.
+    const view = ownerFactsToView(await store.read(), new Date());
     const timezone = view.timezone ?? resolveDefaultTimeZone();
     try {
       const repo = new LifeOpsRepository(runtime);

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
@@ -355,7 +355,7 @@ export async function processDueScheduledTasks(
     now: () => request.now,
   });
   const ownerFactsRaw = await resolveOwnerFactStore(request.runtime).read();
-  const ownerFacts = ownerFactsToView(ownerFactsRaw);
+  const ownerFacts = ownerFactsToView(ownerFactsRaw, request.now);
   // Owner-wide reminder intensity shapes how persistently the no-reply loop
   // re-nudges (see `applyReminderIntensityToNoReplyPolicy`).
   const reminderIntensity = ownerFactsRaw.reminderIntensity?.value;

--- a/plugins/plugin-personal-assistant/src/lifeops/service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service.ts
@@ -212,6 +212,7 @@ import {
 import { WorkflowsDomain } from "./domains/workflows-service.js";
 import { XReadDomain } from "./domains/x-read-service.js";
 import { XDomain } from "./domains/x-service.js";
+import { resolveOwnerFactStore } from "./owner/fact-store.js";
 import type {
   LifeOpsScheduleInspection,
   LifeOpsScheduleSummary,
@@ -2248,7 +2249,7 @@ export class LifeOpsService extends LifeOpsServiceBase {
     return this.travelDomain.payTravelOrder(args);
   }
 
-  bookFlightItinerary(
+  async bookFlightItinerary(
     requestUrl: URL,
     args: {
       offerId?: string | null;
@@ -2257,7 +2258,34 @@ export class LifeOpsService extends LifeOpsServiceBase {
       calendarSync?: TravelCalendarSyncPlan | null;
     },
   ): Promise<FlightBookingExecutionResult> {
-    return this.travelDomain.bookFlightItinerary(requestUrl, args);
+    const result = await this.travelDomain.bookFlightItinerary(
+      requestUrl,
+      args,
+    );
+    // A confirmed itinerary is the strongest travel signal we have: the owner
+    // will be away for the booked window. Record it as a first-class travel
+    // fact so the `during_travel` scheduling gate can derive `travelActive`.
+    // The window comes from the booked order's own departure/arrival segments;
+    // `calendarSync.timeZone` (when the caller supplied one) is the only
+    // destination-zone signal Duffel exposes — orders carry IATA codes, not
+    // zones. A store-write failure is not swallowed: a silently-dropped travel
+    // fact would leave the gate blind, so we let it surface.
+    const departingAt = result.order.slices[0]?.segments[0]?.departingAt;
+    const lastSlice = result.order.slices[result.order.slices.length - 1];
+    const arrivingAt =
+      lastSlice?.segments[lastSlice.segments.length - 1]?.arrivingAt;
+    if (departingAt) {
+      const destinationTimezone = args.calendarSync?.timeZone ?? undefined;
+      await resolveOwnerFactStore(this.runtime).setActiveTravel(
+        {
+          startIso: departingAt,
+          ...(arrivingAt ? { endIso: arrivingAt } : {}),
+          ...(destinationTimezone ? { destinationTimezone } : {}),
+        },
+        { source: "connector_inferred", recordedAt: new Date().toISOString() },
+      );
+    }
+    return result;
   }
 
   // `this` (a LifeOpsServiceBase subclass) satisfies LifeOpsContext.


### PR DESCRIPTION
## What & why

Owner decision: item 3 should use **a combination of signals** to set travel
state. The `during_travel` scheduling gate
(`plugin-scheduling/.../gate-registry.ts`) reads `ownerFacts.travelActive`, but
**nothing ever wrote it** — the gate was dead on the producer side.

## Design (researched + adversarially reviewed)

Store a first-class `activeTravel` **record** `{ startIso, endIso?,
destinationTimezone? }` and **derive** the boolean in the projection — never
persist a bare boolean (it has no natural clear → permanent-true bug).
`ownerFactsToView(facts, now)` sets `travelActive = started && notEnded`, leaves
it **undefined** with no record (so "not traveling" ≠ "missing"), and prefers
`destinationTimezone` for the view timezone only while active. The spine's
`OwnerFactsView.travelActive` and the gate are **untouched**.

**Three writers of the one fact** (single source of truth):
- **Booking** — `LifeOpsService.bookFlightItinerary` records the booked order's
  departure→arrival window + `calendarSync` tz. Store failure is not swallowed.
- **Explicit statement** — `profile-extraction-evaluator` sets a **bounded**
  window on "I'm traveling/away/on a trip [until <date>]" (parsed return or
  `now + 30d` — never open-ended) and clears on "I'm back / back home".
- **Reconciler** — a `travel_reconcile` subsystem in the LifeOps tick (before
  scheduled tasks fire) clears lapsed windows and opens/closes a bounded
  **provisional** record from device-timezone divergence, deferring to
  booking/statement signals. Documented no-op on shared-server topology.

Dependency direction preserved (only `plugin-personal-assistant` + `@elizaos/shared`).

## Verification

- `plugins/plugin-personal-assistant/src/lifeops/owner/travel-active-derivation.test.ts`
  — **9/9 pure derivation tests** (inside/outside window, inclusive bounds,
  open-ended, undefined-with-no-record, dest-tz override + revert). Runs green
  locally.
- `bun run --cwd plugins/plugin-personal-assistant typecheck` → exit 0; biome clean.

| Evidence | Status |
| --- | --- |
| Unit (derivation) | 9/9 pure tests, run locally. |
| Real path E2E / live statement+booking | Runs in CI — the PA graph vitest lane can't boot in this worktree (pre-existing `adze` vite resolution gap). |
| Domain artifacts | `activeTravel` OwnerFactEntry written by each writer; `travelActive` derived → consumed by the unchanged `during_travel` gate. |

Relates to #12284, #12186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)