### PR TITLE
fix(#13196): fetch facts-stage room entities directly instead of scraping dead provider state

### DIFF
--- a/packages/core/src/runtime/__tests__/fact-write-dedupe.test.ts
+++ b/packages/core/src/runtime/__tests__/fact-write-dedupe.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import { factsProvider } from "../../features/advanced-capabilities/providers/facts";
 import { AgentRuntime } from "../../runtime";
-import { type Character, ModelType } from "../../types";
+import { type Character, ChannelType, ModelType } from "../../types";
 import type { Memory } from "../../types/memory";
 import type { UUID } from "../../types/primitives";
 import type { State } from "../../types/state";
@@ -36,6 +36,27 @@ function makeRuntime(modelResponse?: string): AgentRuntime {
 		);
 	}
 	return runtime;
+}
+
+// The facts stage now sources room entities directly via getEntityDetails
+// (getRoom + getEntitiesForRoom) instead of scraping the Stage-1 provider
+// state (#13196). Seed the room + its participant entities so name->UUID
+// grounding (nubs, Jake) resolves through the real adapter, matching how it
+// works in production.
+async function seedRoomEntities(runtime: AgentRuntime): Promise<void> {
+	await runtime.createRooms([
+		{
+			id: ROOM,
+			agentId: runtime.agentId,
+			source: "test",
+			type: ChannelType.GROUP,
+		},
+	]);
+	await runtime.createEntities([
+		{ id: USER, agentId: runtime.agentId, names: ["nubs"], metadata: {} },
+		{ id: JAKE, agentId: runtime.agentId, names: ["Jake"], metadata: {} },
+	]);
+	await runtime.createRoomParticipants([USER, JAKE], ROOM);
 }
 
 function makeMessage(runtime: AgentRuntime, text: string): Memory {
@@ -136,6 +157,7 @@ describe("facts_and_relationships stage — no duplicate durable echo", () => {
 		// Live symptom: the fact row and the relationship-echo row landed 5ms
 		// apart with identical text — the echo must be structurally skipped.
 		const runtime = makeRuntime(GUITAR_OUTPUT);
+		await seedRoomEntities(runtime);
 		await runFactsAndRelationshipsStage({
 			runtime,
 			message: makeMessage(runtime, "i play guitar btw"),
@@ -155,6 +177,7 @@ describe("facts_and_relationships stage — no duplicate durable echo", () => {
 		// The per-turn LLM dedupe pool is advisory (the model can miss); the
 		// structural write guard must hold even when it does.
 		const runtime = makeRuntime(GUITAR_OUTPUT);
+		await seedRoomEntities(runtime);
 		for (let turn = 0; turn < 2; turn += 1) {
 			await runFactsAndRelationshipsStage({
 				runtime,
@@ -176,6 +199,7 @@ describe("facts_and_relationships stage — no duplicate durable echo", () => {
 				thought: "new rel",
 			}),
 		);
+		await seedRoomEntities(runtime);
 		await runFactsAndRelationshipsStage({
 			runtime,
 			message: makeMessage(runtime, "Jake is my brother"),

--- a/packages/core/src/runtime/__tests__/facts-and-relationships.test.ts
+++ b/packages/core/src/runtime/__tests__/facts-and-relationships.test.ts
@@ -31,27 +31,16 @@ function makeMessage(): Memory {
 	};
 }
 
+// The facts stage no longer scrapes room entities off the Stage-1 provider
+// state (that path was dead — it read data.entities but the ENTITIES provider
+// publishes data.entitiesData, and #13195 defers the provider off Stage-1
+// entirely). Room entities are now fetched directly via getEntityDetails, which
+// the mock runtime backs with getRoom + getEntitiesForRoom below. State is
+// therefore just an empty carrier here.
 function makeState(): State {
 	return {
 		values: {},
-		data: {
-			providers: {
-				ENTITIES: {
-					data: {
-						entities: [
-							{
-								id: "00000000-0000-0000-0000-0000000000a1" as UUID,
-								names: ["Alice"],
-							},
-							{
-								id: "00000000-0000-0000-0000-0000000000b2" as UUID,
-								names: ["Bob"],
-							},
-						],
-					},
-				},
-			},
-		},
+		data: { providers: {} },
 		text: "",
 	};
 }
@@ -79,6 +68,27 @@ function makeRuntime(modelResponse: unknown): FactsRuntime {
 			} as Memory,
 		]),
 		getRelationships: vi.fn(async () => []),
+		// Backs getEntityDetails({ runtime, roomId }) — the facts stage now sources
+		// room entities here instead of scraping Stage-1 provider state (#13196).
+		getRoom: vi.fn(async () => ({
+			id: "00000000-0000-0000-0000-000000000003" as UUID,
+			source: "test",
+		})),
+		getEntitiesForRoom: vi.fn(async () => [
+			{
+				id: "00000000-0000-0000-0000-0000000000a1" as UUID,
+				names: ["Alice"],
+				components: [],
+				metadata: {},
+			},
+			{
+				id: "00000000-0000-0000-0000-0000000000b2" as UUID,
+				names: ["Bob"],
+				components: [],
+				metadata: {},
+			},
+		]),
+		reportError: vi.fn(),
 		createMemory: vi.fn(async () => "00000000-0000-0000-0000-00000000cccc"),
 		createRelationship: vi.fn(async () => true),
 		logger: {
@@ -290,6 +300,175 @@ describe("runFactsAndRelationshipsStage", () => {
 			"facts",
 			true,
 		);
+	});
+
+	// #13196: room-entity grounding must come from getEntityDetails, NOT from
+	// scraping the Stage-1 provider state. Two prior defects made the old path
+	// dead: (1) it read state...providers.ENTITIES.data.entities but the ENTITIES
+	// provider publishes data.entitiesData, and (2) #13195 deferred the ENTITIES
+	// provider off the Stage-1 execution path entirely, so the state has no
+	// ENTITIES entry to scrape. Prove the grounding survives an EMPTY Stage-1
+	// state as long as the room has participants.
+	it("grounds room_entities from getEntityDetails even when Stage-1 state carries no ENTITIES entry (#13196)", async () => {
+		const runtime = makeRuntime(
+			JSON.stringify({
+				facts: ["the user works with Alice"],
+				relationships: [
+					{ subject: "user", predicate: "works_with", object: "Alice" },
+				],
+				thought: "new",
+			}),
+		);
+		// Empty state: no providers.ENTITIES at all (matches post-#13195 Stage-1).
+		const emptyState: State = {
+			values: {},
+			data: { providers: {} },
+			text: "",
+		};
+		const result = await runFactsAndRelationshipsStage({
+			runtime,
+			message: makeMessage(),
+			state: emptyState,
+			extract: {
+				facts: ["the user works with Alice"],
+				relationships: [
+					{ subject: "user", predicate: "works_with", object: "Alice" },
+				],
+			},
+		});
+
+		// Room entities came from getEntityDetails, not state.
+		expect(runtime.getEntitiesForRoom).toHaveBeenCalledWith(
+			makeMessage().roomId,
+			true,
+		);
+		const validationCall = runtime.useModel.mock.calls.find(
+			(call) =>
+				typeof call[0] === "string" &&
+				(call[0] === ModelType.TEXT_LARGE || call[0] === "TEXT_LARGE"),
+		);
+		const params = validationCall?.[1] as {
+			messages?: Array<{ role: string; content: string }>;
+		};
+		// The room_entities: grounding block is present with the resolved UUID
+		// (the whole point of the audit's "prefer that UUID" rule).
+		expect(params.messages?.[1]?.content).toContain("room_entities:");
+		expect(params.messages?.[1]?.content).toContain(
+			"Alice (id: 00000000-0000-0000-0000-0000000000a1)",
+		);
+		// And persist-time name->UUID resolution used the room entity: the
+		// relationship edge's target resolves to Alice's UUID (not undefined).
+		expect(runtime.createMemory).toHaveBeenCalledWith(
+			expect.objectContaining({
+				metadata: expect.objectContaining({
+					sourceEntityId: makeMessage().entityId,
+					targetEntityId: "00000000-0000-0000-0000-0000000000a1",
+				}),
+			}),
+			"facts",
+			true,
+		);
+		expect(result.written.relationships).toBe(1);
+	});
+
+	// #13196 P2 (codex): getEntityDetails returns EVERY room participant (no
+	// display cap), so a busy room must not flood the room_entities: prompt
+	// block. The grounding set is bounded to 12, prioritizing entities whose
+	// names match a candidate relationship subject/object.
+	it("bounds room_entities to 12 and prioritizes candidate-named entities in a large room (#13196 P2)", async () => {
+		const runtime = makeRuntime(
+			JSON.stringify({
+				facts: [],
+				relationships: [
+					{ subject: "user", predicate: "works_with", object: "Zoey" },
+				],
+				thought: "new",
+			}),
+		);
+		// 40 participants; "Zoey" (candidate object) is intentionally last so a
+		// naive slice(0,12) would drop it. The bounding must still surface it.
+		const many = Array.from({ length: 39 }, (_, i) => ({
+			id: `00000000-0000-0000-0000-0000000${String(i).padStart(5, "0")}` as UUID,
+			names: [`Person${i}`],
+			components: [],
+			metadata: {},
+		}));
+		const zoe = {
+			id: "00000000-0000-0000-0000-0000000000a9" as UUID,
+			names: ["Zoey"],
+			components: [],
+			metadata: {},
+		};
+		(runtime.getEntitiesForRoom as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+			[...many, zoe],
+		);
+		await runFactsAndRelationshipsStage({
+			runtime,
+			message: makeMessage(),
+			state: { values: {}, data: { providers: {} }, text: "" },
+			extract: {
+				relationships: [
+					{ subject: "user", predicate: "works_with", object: "Zoey" },
+				],
+			},
+		});
+		const validationCall = runtime.useModel.mock.calls.find(
+			(call) =>
+				typeof call[0] === "string" &&
+				(call[0] === ModelType.TEXT_LARGE || call[0] === "TEXT_LARGE"),
+		);
+		const params = validationCall?.[1] as {
+			messages?: Array<{ role: string; content: string }>;
+		};
+		const content = params.messages?.[1]?.content ?? "";
+		// Isolate just the room_entities: block (blocks are separated by a blank
+		// line), so the candidate lines (also `- ` prefixed) aren't miscounted.
+		const roomBlock =
+			content
+				.split("\n\n")
+				.find((block) => block.startsWith("room_entities:")) ?? "";
+		const entityLines = roomBlock
+			.split("\n")
+			.filter((line) => line.startsWith("- "));
+		// Capped at 12 lines.
+		expect(entityLines.length).toBe(12);
+		// The candidate-named entity survived the cap.
+		expect(content).toContain("Zoey (id:");
+	});
+
+	// Fail-closed: a broken getEntityDetails must surface via reportError and
+	// degrade to no grounding, never crash the stage (error-policy:J7).
+	it("reports and degrades (no crash) when room-entity fetch fails (#13196)", async () => {
+		const runtime = makeRuntime(
+			JSON.stringify({ facts: ["the user's birthday is March 5"], relationships: [], thought: "ok" }),
+		);
+		(runtime.getEntitiesForRoom as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+			new Error("boom"),
+		);
+		const result = await runFactsAndRelationshipsStage({
+			runtime,
+			message: makeMessage(),
+			state: { values: {}, data: { providers: {} }, text: "" },
+			extract: { facts: ["the user's birthday is March 5"] },
+		});
+		// Stage still completed and persisted the fact.
+		expect(result.written.facts).toBe(1);
+		// Failure surfaced, not swallowed.
+		expect(runtime.reportError).toHaveBeenCalledWith(
+			"FactsAndRelationships.fetchRoomEntities",
+			expect.any(Error),
+			expect.objectContaining({ roomId: makeMessage().roomId }),
+		);
+		// No room_entities: block when grounding is unavailable.
+		const validationCall = runtime.useModel.mock.calls.find(
+			(call) =>
+				typeof call[0] === "string" &&
+				(call[0] === ModelType.TEXT_LARGE || call[0] === "TEXT_LARGE"),
+		);
+		const params = validationCall?.[1] as {
+			messages?: Array<{ role: string; content: string }>;
+		};
+		expect(params.messages?.[1]?.content).not.toContain("room_entities:");
 	});
 
 	it("persists relationships under the facts table and upserts resolved entity edges when kept", async () => {

--- a/packages/core/src/runtime/facts-and-relationships.ts
+++ b/packages/core/src/runtime/facts-and-relationships.ts
@@ -18,6 +18,7 @@
  * The trajectory recorder logs this as a `facts_and_relationships` stage so
  * extraction quality can be reviewed offline.
  */
+import { getEntityDetails } from "../entities.ts";
 import {
 	buildFactKeywordsForStorage,
 	scoreFactKeywordRelevance,
@@ -177,9 +178,14 @@ export async function runFactsAndRelationshipsStage(
 		};
 	}
 
-	const [similarFacts, existingRelationships] = await Promise.all([
+	const candidateEntityNames = candidateRelationships.flatMap((rel) => [
+		rel.subject,
+		rel.object,
+	]);
+	const [similarFacts, existingRelationships, roomEntities] = await Promise.all([
 		searchSimilarFacts(runtime, message, candidateFacts),
 		fetchExistingRelationships(runtime, message),
+		fetchRoomEntities(runtime, message, candidateEntityNames),
 	]);
 
 	const tools = [createFactsAndRelationshipsTool()];
@@ -193,8 +199,8 @@ export async function runFactsAndRelationshipsStage(
 		},
 		similarFacts,
 		existingRelationships,
+		roomEntities,
 		priorDialogue: args.priorDialogue ?? [],
-		state: args.state,
 	});
 
 	const raw = await runtime.useModel(ModelType.TEXT_LARGE, {
@@ -207,7 +213,7 @@ export async function runFactsAndRelationshipsStage(
 	const written = await persistFactsAndRelationships({
 		runtime,
 		message,
-		state: args.state,
+		roomEntities,
 		parsed,
 	});
 
@@ -220,8 +226,8 @@ interface BuildMessagesArgs {
 	extract: MessageHandlerExtract;
 	similarFacts: Memory[];
 	existingRelationships: Relationship[];
+	roomEntities: RoomEntityRef[];
 	priorDialogue: readonly Memory[];
-	state: State;
 }
 
 function buildFactsStageMessages(args: BuildMessagesArgs): ChatMessage[] {
@@ -279,11 +285,11 @@ function buildFactsStageMessages(args: BuildMessagesArgs): ChatMessage[] {
 		}
 	}
 
-	const roomEntities = readRoomEntityRefs(args.state).map((entity) =>
+	const roomEntityLines = args.roomEntities.map((entity) =>
 		formatRoomEntityRef(entity),
 	);
-	if (roomEntities.length > 0) {
-		userBlocks.push(`room_entities:\n${roomEntities.join("\n")}`);
+	if (roomEntityLines.length > 0) {
+		userBlocks.push(`room_entities:\n${roomEntityLines.join("\n")}`);
 	}
 
 	const candidateLines: string[] = [];
@@ -308,27 +314,103 @@ type RoomEntityRef = {
 	names: string[];
 };
 
-function readRoomEntityRefs(state: State): RoomEntityRef[] {
-	const providers = state.data.providers;
-	if (!providers || typeof providers !== "object") return [];
-	const entitiesEntry = (providers as Record<string, unknown>).ENTITIES;
-	if (!entitiesEntry || typeof entitiesEntry !== "object") return [];
-	const data = (entitiesEntry as { data?: unknown }).data;
-	if (!data || typeof data !== "object") return [];
-	const entities = (data as { entities?: unknown }).entities;
-	if (!Array.isArray(entities)) return [];
-	return entities
-		.map((entity): RoomEntityRef | null => {
-			if (!entity || typeof entity !== "object") return null;
-			const e = entity as { id?: unknown; names?: unknown };
-			const names = Array.isArray(e.names)
-				? e.names.filter((name): name is string => typeof name === "string")
-				: [];
-			const id = typeof e.id === "string" ? asUuidOrNull(e.id) : null;
-			if (!id && names.length === 0) return null;
-			return { ...(id ? { id } : {}), names };
-		})
-		.filter((entity): entity is RoomEntityRef => entity !== null);
+// Hard cap on how many room entities we ground into the validation prompt.
+// `getEntityDetails` returns EVERY room participant (it does not apply the
+// display cap `formatEntities` uses), so a busy Discord/Slack room could
+// otherwise flood the `room_entities:` block with hundreds/thousands of lines
+// and blow up TEXT_LARGE latency/context before a single candidate is
+// validated. We only need enough to resolve the candidate relationship
+// subject/object names to their room UUIDs, so we prioritize name-matched
+// participants and fill any remaining slots up to this bound.
+const MAX_GROUNDING_ROOM_ENTITIES = 12;
+
+/**
+ * Fetch the room's participant entities directly for facts-stage grounding.
+ *
+ * Previously this scraped the Stage-1 `state.data.providers.ENTITIES` entry,
+ * which was doubly broken: (1) it read `data.entities` but the ENTITIES
+ * provider publishes its payload under `data.entitiesData`, so the read
+ * silently returned `[]` on develop (#13196); and (2) after #13195 deferred the
+ * ENTITIES provider off the Stage-1 execution path, the state no longer carries
+ * an ENTITIES entry at all, so a key rename alone could not revive it. We now
+ * source the entities from the same `getEntityDetails({ runtime, roomId })` the
+ * provider itself uses — the authoritative room-participant list — so the
+ * grounding (`room_entities:` prompt block + persist-time name->UUID
+ * resolution) works regardless of provider execution order. The stage only runs
+ * on fact-bearing turns, and getEntityDetails is per-runtime cached, so the
+ * added read is bounded; we additionally cap the grounding set (see
+ * MAX_GROUNDING_ROOM_ENTITIES) so a large room can't flood the prompt.
+ *
+ * `candidateNames` are the subject/object strings from the candidate
+ * relationships; entities whose names match one of them are prioritized so the
+ * bounded set keeps the ones the model actually needs to resolve.
+ */
+async function fetchRoomEntities(
+	runtime: IAgentRuntime,
+	message: Memory,
+	candidateNames: readonly string[],
+): Promise<RoomEntityRef[]> {
+	const roomId = message.roomId;
+	if (!roomId) return [];
+	try {
+		const details = await getEntityDetails({ runtime, roomId });
+		if (!Array.isArray(details)) return [];
+		const refs = details
+			.map((entity): RoomEntityRef | null => {
+				if (!entity || typeof entity !== "object") return null;
+				const names = Array.isArray(entity.names)
+					? entity.names.filter(
+							(name: unknown): name is string => typeof name === "string",
+						)
+					: [];
+				const id =
+					typeof entity.id === "string" ? asUuidOrNull(entity.id) : null;
+				if (!id && names.length === 0) return null;
+				return { ...(id ? { id } : {}), names };
+			})
+			.filter((entity): entity is RoomEntityRef => entity !== null);
+		return boundGroundingEntities(refs, candidateNames);
+	} catch (error) {
+		// error-policy:J7 diagnostics-must-not-kill-the-loop — failing to load
+		// room entities disables name->UUID grounding for this turn (relationship
+		// endpoints fall back to non-room resolution, and the room_entities: block
+		// is omitted from the prompt). Degrade to no grounding, but surface the
+		// read failure via reportError so a broken getEntityDetails / room-entity
+		// pipeline reaches the agent rather than silently disappearing.
+		runtime.reportError("FactsAndRelationships.fetchRoomEntities", error, {
+			roomId,
+		});
+		return [];
+	}
+}
+
+/**
+ * Bound the room-entity grounding set to MAX_GROUNDING_ROOM_ENTITIES,
+ * prioritizing entities whose names match a candidate relationship
+ * subject/object (those are the ones the model needs to resolve to a UUID),
+ * then filling any remaining slots with other participants for context. Keeps
+ * the `room_entities:` prompt block small in busy rooms without dropping the
+ * entities that actually matter for this turn.
+ */
+function boundGroundingEntities(
+	refs: readonly RoomEntityRef[],
+	candidateNames: readonly string[],
+): RoomEntityRef[] {
+	if (refs.length <= MAX_GROUNDING_ROOM_ENTITIES) return [...refs];
+	const wanted = new Set(
+		candidateNames
+			.map((name) => normalizeForComparison(name))
+			.filter((name) => name.length > 0),
+	);
+	const matched: RoomEntityRef[] = [];
+	const rest: RoomEntityRef[] = [];
+	for (const ref of refs) {
+		const isMatch = ref.names.some((name) =>
+			wanted.has(normalizeForComparison(name)),
+		);
+		(isMatch ? matched : rest).push(ref);
+	}
+	return [...matched, ...rest].slice(0, MAX_GROUNDING_ROOM_ENTITIES);
 }
 
 function formatRoomEntityRef(entity: RoomEntityRef): string {
@@ -487,7 +569,7 @@ function extractText(raw: unknown): string {
 interface PersistArgs {
 	runtime: IAgentRuntime;
 	message: Memory;
-	state: State;
+	roomEntities: RoomEntityRef[];
 	parsed: FactsAndRelationshipsResult;
 }
 
@@ -495,7 +577,7 @@ async function persistFactsAndRelationships(
 	args: PersistArgs,
 ): Promise<{ facts: number; relationships: number }> {
 	const { runtime, message, parsed } = args;
-	const roomEntities = readRoomEntityRefs(args.state);
+	const roomEntities = args.roomEntities;
 	let factsWritten = 0;
 	let relationshipsWritten = 0;
 


### PR DESCRIPTION
## Problem (#13196)

`readRoomEntityRefs` (`packages/core/src/runtime/facts-and-relationships.ts`) grounded the facts/relationships stage on the room's entities by scraping the Stage-1 state:

```ts
const entitiesEntry = state.data.providers.ENTITIES;
const entities = entitiesEntry.data.entities;   // always undefined
```

That read was **doubly dead** on develop:

1. The ENTITIES provider publishes its payload under **`data.entitiesData`**, not `data.entities` — so `readRoomEntityRefs` always returned `[]`. The `room_entities:` grounding block never reached the validate prompt (the "prefer the shown UUID" rule could never fire), and `resolveRelationshipEntityId` never matched a room entity by name at persist time.
2. After **#13195** deferred the ENTITIES provider off the Stage-1 execution path, the Stage-1 state carries **no ENTITIES entry at all** — so a key rename alone couldn't revive it (as #13196 itself notes).

## Fix (structural — fetch, don't scrape)

`runFactsAndRelationshipsStage` now fetches room entities directly via `getEntityDetails({ runtime, roomId })` — the same authoritative room-participant source the provider uses — added to its existing `searchSimilarFacts` / `fetchExistingRelationships` parallel fetch, and stops reading provider state entirely. The stage only runs on fact-bearing turns and `getEntityDetails` is per-runtime cached, so the added read is bounded. Both consumers now take the fetched set:

- `buildFactsStageMessages` (the `room_entities:` prompt block)
- `persistFactsAndRelationships` (name → room-UUID resolution)

**Bounded grounding (codex P2):** unlike `formatEntities`, `getEntityDetails` returns **every** room participant with no display cap, so the grounding set is capped at 12 (`MAX_GROUNDING_ROOM_ENTITIES`), prioritizing entities whose names match a candidate relationship subject/object. A busy Discord/Slack room therefore can't flood the TEXT_LARGE prompt while still keeping the entities the model actually needs to resolve.

**Fail-closed:** a `getEntityDetails` failure surfaces via `reportError` (`error-policy:J7`) and degrades to no grounding rather than crashing the stage.

Behavior for turns that already had working grounding is unchanged (there were none on develop — the path returned `[]`); this revives the intended grounding.

## Tests (packages/core — all green)

- `runtime/__tests__/facts-and-relationships.test.ts` (18 tests), new:
  - grounds `room_entities:` from `getEntityDetails` even when the Stage-1 state carries **no** ENTITIES entry (proves the post-#13195 shape), incl. resolved-UUID persist edge.
  - **bounds** the block to 12 lines and keeps the candidate-named entity in a 40-participant room (a naive `slice(0,12)` would drop it).
  - **reports + degrades** (fact still persisted, no crash) when the room-entity fetch throws.
  - existing prompt-composition + persistence tests updated to source entities via the runtime's `getRoom` / `getEntitiesForRoom` mock instead of scraping state.
- `runtime/__tests__/fact-write-dedupe.test.ts` (6 tests): seed the room + participant entities through the real `AgentRuntime` + `InMemoryDatabaseAdapter` so name → UUID grounding (`nubs`, `Jake`) resolves as in production.
- `bun run --cwd packages/core typecheck` (tsgo): clean.
- codex-reviewed: the P2 unbounded-grounding finding is fixed; re-review clean ("did not identify a discrete introduced bug").

— [sol-orch]
