### PR TITLE
fix(#12679): derive nav /apps + /character sub-tab routing from TAB_PATHS registry

### DIFF
--- a/packages/ui/src/navigation/index.test.ts
+++ b/packages/ui/src/navigation/index.test.ts
@@ -2,10 +2,17 @@
  * Unit coverage for path→tab resolution against the app-shell registry. In-memory
  * registry, no runtime.
  */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { registerAppShellPage } from "../app-shell-registry";
 import { resetUiRegistryHostForTests } from "../registry-host";
-import { ALL_TAB_GROUPS, tabFromPath } from "./index";
+import {
+  ALL_TAB_GROUPS,
+  LEGACY_PREFIX_TAB_ALIASES,
+  TAB_PATHS,
+  tabFromPath,
+} from "./index";
 
 beforeEach(() => {
   resetUiRegistryHostForTests();
@@ -80,5 +87,75 @@ describe("navigation tabFromPath", () => {
       (group) => group.label === "Wallet",
     );
     expect(walletGroup?.tabs).toEqual(["inventory", "test.perps"]);
+  });
+});
+
+describe("navigation prefix sub-tab resolution is registry-derived", () => {
+  // Built-in `/apps/<sub>` and `/character/<sub>` routes must resolve to the
+  // tab declared for that exact path in TAB_PATHS, so the routing table never
+  // drifts from the canonical path registry. Every case below is derived from
+  // TAB_PATHS, not from a second hand-maintained alias record.
+  it("resolves /apps/<sub> tool routes from the TAB_PATHS registry", () => {
+    expect(tabFromPath("/apps/plugins")).toBe("plugins");
+    expect(tabFromPath("/apps/skills")).toBe("skills");
+    expect(tabFromPath("/apps/trajectories")).toBe("trajectories");
+    expect(tabFromPath("/apps/transcripts")).toBe("transcripts");
+    expect(tabFromPath("/apps/relationships")).toBe("relationships");
+    expect(tabFromPath("/apps/memories")).toBe("memories");
+    expect(tabFromPath("/apps/files")).toBe("files");
+    expect(tabFromPath("/apps/runtime")).toBe("runtime");
+    expect(tabFromPath("/apps/database")).toBe("database");
+    expect(tabFromPath("/apps/logs")).toBe("logs");
+    expect(tabFromPath("/apps/tasks")).toBe("tasks");
+    // advanced + fine-tuning share /apps/fine-tuning; the registry resolves it
+    // to the canonical fine-tuning tab exactly as the old record did.
+    expect(tabFromPath("/apps/fine-tuning")).toBe("fine-tuning");
+  });
+
+  it("resolves /character/<sub> hub routes from the TAB_PATHS registry", () => {
+    expect(tabFromPath("/character/documents")).toBe("documents");
+    expect(tabFromPath("/character/select")).toBe("character-select");
+    expect(tabFromPath("/character/experience")).toBe("experience");
+    expect(tabFromPath("/character/skills")).toBe("character-skills");
+  });
+
+  it("defaults unknown sub-paths to their prefix owner", () => {
+    // Unknown /apps/<sub> is an app slug catch-all; unknown /character/<sub>
+    // falls back to the character hub; a nested /apps/<sub>/<x> is a view.
+    expect(tabFromPath("/apps/some-unknown-slug")).toBe("apps");
+    expect(tabFromPath("/apps/plugins/nested")).toBe("views");
+    expect(tabFromPath("/character/unknown-section")).toBe("character");
+  });
+
+  it("keeps only the two irreducible legacy prefix aliases", () => {
+    // /apps/inventory (canonical tab path is /wallet) and
+    // /character/relationships (canonical tab path is /apps/relationships) are
+    // the ONLY paths whose target tab lives under a different prefix, so they
+    // stay as an explicitly-marked host-owned fallback.
+    expect(tabFromPath("/apps/inventory")).toBe("inventory");
+    expect(tabFromPath("/character/relationships")).toBe("relationships");
+  });
+
+  it("legacy alias table holds no path already derivable from TAB_PATHS (drift guard)", () => {
+    const canonicalPaths = new Set(Object.values(TAB_PATHS));
+    for (const aliasPath of Object.keys(LEGACY_PREFIX_TAB_ALIASES)) {
+      // If a legacy-alias path were also a canonical TAB_PATHS value, the
+      // registry would already own it and the alias would be dead duplication.
+      expect(canonicalPaths.has(aliasPath)).toBe(false);
+    }
+  });
+});
+
+describe("navigation index: no reintroduced hardcoded prefix alias record", () => {
+  it("has no APPS_SUB_TABS record or inline /character/<sub> if-chain (grep guard)", () => {
+    const source = readFileSync(
+      fileURLToPath(new URL("./index.ts", import.meta.url)),
+      "utf8",
+    );
+    // The old hand-maintained record declaration and the inline character sub
+    // if-chain are gone from executable paths; resolution is registry-driven.
+    expect(source).not.toMatch(/(?:const|let|var)\s+APPS_SUB_TABS\b/);
+    expect(source).not.toMatch(/if\s*\(\s*sub\s*===\s*"documents"\s*\)/);
+    expect(source).not.toMatch(/if\s*\(\s*sub\s*===\s*"select"\s*\)/);
   });
 });

--- a/packages/ui/src/navigation/index.ts
+++ b/packages/ui/src/navigation/index.ts
@@ -416,26 +416,46 @@ export function resolveInitialTabForPath(
   return tabFromPath(pathname, basePath) ?? fallbackTab;
 }
 
-/** Known apps-tool sub-paths under /apps/ (not actual app slugs). */
-const APPS_SUB_TABS: Record<string, Tab> = {
-  tasks: "tasks",
-  plugins: "plugins",
-  skills: "skills",
-  "fine-tuning": "fine-tuning",
-  trajectories: "trajectories",
-  transcripts: "transcripts",
-  relationships: "relationships",
-  memories: "memories",
-  files: "files",
-  runtime: "runtime",
-  database: "database",
-  logs: "logs",
-  // Internal-tool window targets that hit non-`/apps/` shell tabs. The window
-  // path is `/apps/<slug>` so the route stays consistent with other internal
-  // tools, but the renderer mounts the tab the original `targetTab` pointed
-  // at (e.g. wallet for steward).
-  inventory: "inventory",
+/**
+ * Legacy host-owned prefix aliases: `/<prefix>/<sub>` paths whose target tab is
+ * NOT derivable from `TAB_PATHS` because the tab's canonical path lives under a
+ * different prefix. Everything else under `/apps/*` and `/character/*` resolves
+ * from the `TAB_PATHS`-derived {@link PATH_TO_TAB} registry (see
+ * {@link prefixSubTabFromPath}); only these two irreducible aliases remain, and
+ * the `no-derivable-alias` drift guard in `index.test.ts` proves that any alias
+ * whose full path IS already in `TAB_PATHS` was dropped from this table.
+ *
+ * - `/apps/inventory` → inventory: an internal-tool window target. The window
+ *   path is `/apps/<slug>` so it stays consistent with other internal tools,
+ *   but the renderer mounts the wallet tab the original `targetTab` pointed at
+ *   (canonical `TAB_PATHS.inventory` = `/wallet`).
+ * - `/character/relationships` → relationships: a character-hub deep-link alias.
+ *   Relationships lives at canonical `TAB_PATHS.relationships` = `/apps/relationships`,
+ *   but the promoted character sections keep a `/character/*` alias for old deep
+ *   links.
+ */
+export const LEGACY_PREFIX_TAB_ALIASES: Record<string, Tab> = {
+  "/apps/inventory": "inventory",
+  "/character/relationships": "relationships",
 };
+
+/**
+ * Resolve a `/<prefix>/<sub>` path to its tab from the canonical `TAB_PATHS`
+ * registry (via {@link PATH_TO_TAB}), falling back to the explicitly-marked
+ * {@link LEGACY_PREFIX_TAB_ALIASES} for the handful of paths whose target tab
+ * declares a different canonical path. Returns `null` when neither owns it, so
+ * callers apply their own default (app slug for `/apps/*`, `character` for
+ * `/character/*`). This replaces the hand-maintained sub-path record and the
+ * inline `/character/<sub>` if-chain, both of which duplicated — and could drift
+ * from — the paths already declared in `TAB_PATHS`.
+ */
+function prefixSubTabFromPath(normalizedPath: string): Tab | null {
+  return (
+    PATH_TO_TAB.get(normalizedPath) ??
+    LEGACY_PREFIX_TAB_ALIASES[normalizedPath] ??
+    null
+  );
+}
 
 export function tabFromPath(pathname: string, basePath = ""): Tab | null {
   const normalized = normalizePathForLookup(pathname, basePath);
@@ -470,15 +490,12 @@ export function tabFromPath(pathname: string, basePath = ""): Tab | null {
 
   // /character/<sub> — resolve nested character paths. The character hub's
   // sections are now top-level views, but their routes keep the /character/*
-  // prefix so existing deep links resolve to the promoted tab.
+  // prefix so existing deep links resolve to the promoted tab. Resolution reads
+  // the canonical TAB_PATHS registry (via prefixSubTabFromPath) instead of a
+  // hardcoded sub if-chain; anything the registry does not own defaults to the
+  // character hub.
   if (normalized.startsWith("/character/")) {
-    const sub = normalized.slice("/character/".length);
-    if (sub === "documents") return "documents";
-    if (sub === "select") return "character-select";
-    if (sub === "experience") return "experience";
-    if (sub === "skills") return "character-skills";
-    if (sub === "relationships") return "relationships";
-    return "character";
+    return prefixSubTabFromPath(normalized) ?? "character";
   }
 
   const registeredAppShellPage = listAppShellPages().find(
@@ -488,11 +505,13 @@ export function tabFromPath(pathname: string, basePath = ""): Tab | null {
     return registeredAppShellPage.tabAffinity ?? registeredAppShellPage.id;
   }
 
-  // /apps/<sub> — known tool tabs resolve to their tab; everything else is an app slug
+  // /apps/<sub> — known tool tabs resolve to their tab from the TAB_PATHS
+  // registry (via prefixSubTabFromPath); a nested sub-path is a plugin view,
+  // and everything else is an app slug.
   if (normalized.startsWith("/apps/")) {
     const sub = normalized.slice("/apps/".length);
     if (sub.includes("/")) return "views";
-    return APPS_SUB_TABS[sub] ?? "apps";
+    return prefixSubTabFromPath(normalized) ?? "apps";
   }
 
   // /settings/<sub> — resolve nested settings paths


### PR DESCRIPTION
Closes #12679 (arch-audit self-registration #12089 item 33: *Navigation table maps plugin page ids/paths to tabs via hardcoded alias records*).

## Problem
`packages/ui/src/navigation/index.ts` resolved built-in `/apps/<sub>` and `/character/<sub>` routes to tabs through **two hand-maintained alias records** that duplicated path→tab information already declared in the canonical `TAB_PATHS` registry:

- `APPS_SUB_TABS` — a `Record<string, Tab>` re-listing every `/apps/<sub>` tool tab.
- an inline `if (sub === "documents") …` chain for `/character/<sub>`.

Both could silently **drift** from `TAB_PATHS` (adding a new `/apps` tool meant editing two tables in lockstep; a rename in one place left the other stale).

## Change
Resolution is now **registry-driven**. A single `prefixSubTabFromPath(normalizedPath)` reads the canonical `TAB_PATHS`-derived `PATH_TO_TAB` map. Only the two paths whose target tab declares a **different** canonical path remain, as an explicitly-marked host-owned fallback `LEGACY_PREFIX_TAB_ALIASES`:

- `/apps/inventory` → `inventory` (internal-tool window target; canonical `TAB_PATHS.inventory` = `/wallet`)
- `/character/relationships` → `relationships` (character-hub deep-link alias; canonical = `/apps/relationships`)

Everything else under `/apps/*` and `/character/*` is derived from `TAB_PATHS`. **Behavior-preserving**: `advanced`+`fine-tuning` sharing `/apps/fine-tuning`, nested `/apps/<sub>/<x>` → `views`, unknown-sub → app-slug / character-hub defaults all resolve exactly as before.

## Tests
`packages/ui/src/navigation/index.test.ts` (10/10 green):
- `/apps/<sub>` and `/character/<sub>` resolve from the `TAB_PATHS` registry
- the two legacy aliases still resolve
- default fallbacks preserved (app slug / character hub / nested → views)
- **drift guard**: no `LEGACY_PREFIX_TAB_ALIASES` path is already a `TAB_PATHS` value (proves no dead-duplicate alias)
- **grep guard**: no `const APPS_SUB_TABS` record or inline `/character/<sub>` if-chain survives in executable paths

Full `packages/ui/src/navigation/` + `ConnectorsSection.routing` + `useNavigationPathSync` + `internal-tool-apps` suites: **31/31 green**.
`packages/ui` `tsgo --noEmit`: clean. biome: clean. codex review: clean (no findings).

-- [sol-orch]