### PR TITLE
perf(app): drop no-op app-core dynamic import + dead CharacterEditor wiring from the startup entry chunk (fixes #13187)

### DIFF
--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -60,12 +60,12 @@ packages/app/
 
 - `app.config.ts` (package root) — single source of truth for app identity. `appId: "ai.elizaos.app"`, `cliName: "eliza"`, `envPrefix: "ELIZA"`, desktop `urlScheme: "elizaos"`. `src/app-config.ts` re-exports it as `APP_CONFIG` plus derived `APP_BRANDING_BASE`/`APP_LOG_PREFIX`/`APP_NAMESPACE`/`APP_URL_SCHEME`. Copy `app.config.ts` to white-label a new app.
 - `src/plugin-registrations.ts` — `SIDE_EFFECT_APP_MODULE_LOADERS`: plugins imported for their self-registration side effects (feed, scape, shopify, etc.), not for exported components.
-- `src/main.tsx` — React entry point. Owns `initializeAppModules()` + `buildAppBootConfig()` inline (parallel-loads plugins, assembles `AppBootConfig`), then mounts React, then `initializePlatform()` (storage bridge, Capacitor listeners, desktop shell) concurrently after mount.
+- `src/main.tsx` — React entry point. Owns `initializeAppModules()` + `buildAppBootConfig()` inline (assembles `AppBootConfig` synchronously; plugin modules ride the deferred idle loaders), then mounts React, then `initializePlatform()` (storage bridge, Capacitor listeners, desktop shell) concurrently after mount.
 
 ## Boot sequence
 
 1. `src/main.tsx` runs before React mounts.
-2. `initializeAppModules()` — parallel-loads all `@elizaos/app-*` / `@elizaos/plugin-*` modules, calls `registerCompanionApp()`, assembles `AppBootConfig`, calls `setBootConfig()`.
+2. `initializeAppModules()` — assembles `AppBootConfig` and calls `setBootConfig()` synchronously (`@elizaos/app-core` is already evaluated via this module's static imports); `@elizaos/plugin-*` modules load later on the deferred idle path.
 3. React `createRoot` renders `<AppProvider><App /></AppProvider>` from `@elizaos/ui`.
 4. `initializePlatform()` — per-platform init: storage bridge, keyboard, lifecycle, network, mobile device bridge, desktop shell. Runs concurrently after mount (not before).
 
@@ -213,7 +213,7 @@ bun run --cwd packages/app test:e2e
 - **No exports.** This is a private app shell. Nothing else should import from it.
 - **`app.config.ts` is the white-label seam.** To create a new branded app: copy this package, change `app.config.ts` values, update `capacitor.config.ts` if targeting mobile.
 - **Plugin module caching.** `main.tsx` resolves each plugin module exactly once via the `initializeAppModules()` Promise.all; `React.lazy()` consumers share the same promise via `lazyNamedComponent()`.
-- **`@elizaos/app-core` must load first** before other plugins — it owns the `AppBootConfig` singleton. `initializeAppModules()` awaits it before the parallel batch.
+- **`@elizaos/app-core` must be evaluated before the boot config is assembled** — it owns the `AppBootConfig` singleton. `main.tsx` statically imports its desktop bindings, so the package loads with the entry chunk; never re-add a dynamic `import("@elizaos/app-core")` on the boot path — its escaping namespace anchors the whole `@elizaos/ui/browser` barrel into the entry chunk (#13187).
 - **Desktop API base injection.** Electrobun injects `window.__ELIZA_APP_API_BASE__` before React boots via its static server; Vite dev uses a `<script>` tag injected by `appDevWsBasePlugin()`.
 - **iOS store CSP.** When `ELIZA_BUILD_VARIANT=store` + `ELIZA_RELEASE_AUTHORITY=apple-app-store`, the build strips all `localhost`/`127.0.0.1` CSP sources and Capacitor allowNavigation entries. Do not hardcode local origins.
 - **Capacitor `ios/` and `android/` dirs are generated.** Run `bun run --cwd packages/app cap:sync` after any `capacitor.config.ts` change. Do not hand-edit the native project settings that Capacitor generates.

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -60,12 +60,12 @@ packages/app/
 
 - `app.config.ts` (package root) — single source of truth for app identity. `appId: "ai.elizaos.app"`, `cliName: "eliza"`, `envPrefix: "ELIZA"`, desktop `urlScheme: "elizaos"`. `src/app-config.ts` re-exports it as `APP_CONFIG` plus derived `APP_BRANDING_BASE`/`APP_LOG_PREFIX`/`APP_NAMESPACE`/`APP_URL_SCHEME`. Copy `app.config.ts` to white-label a new app.
 - `src/plugin-registrations.ts` — `SIDE_EFFECT_APP_MODULE_LOADERS`: plugins imported for their self-registration side effects (feed, scape, shopify, etc.), not for exported components.
-- `src/main.tsx` — React entry point. Owns `initializeAppModules()` + `buildAppBootConfig()` inline (parallel-loads plugins, assembles `AppBootConfig`), then mounts React, then `initializePlatform()` (storage bridge, Capacitor listeners, desktop shell) concurrently after mount.
+- `src/main.tsx` — React entry point. Owns `initializeAppModules()` + `buildAppBootConfig()` inline (assembles `AppBootConfig` synchronously; plugin modules ride the deferred idle loaders), then mounts React, then `initializePlatform()` (storage bridge, Capacitor listeners, desktop shell) concurrently after mount.
 
 ## Boot sequence
 
 1. `src/main.tsx` runs before React mounts.
-2. `initializeAppModules()` — parallel-loads all `@elizaos/app-*` / `@elizaos/plugin-*` modules, calls `registerCompanionApp()`, assembles `AppBootConfig`, calls `setBootConfig()`.
+2. `initializeAppModules()` — assembles `AppBootConfig` and calls `setBootConfig()` synchronously (`@elizaos/app-core` is already evaluated via this module's static imports); `@elizaos/plugin-*` modules load later on the deferred idle path.
 3. React `createRoot` renders `<AppProvider><App /></AppProvider>` from `@elizaos/ui`.
 4. `initializePlatform()` — per-platform init: storage bridge, keyboard, lifecycle, network, mobile device bridge, desktop shell. Runs concurrently after mount (not before).
 
@@ -213,7 +213,7 @@ bun run --cwd packages/app test:e2e
 - **No exports.** This is a private app shell. Nothing else should import from it.
 - **`app.config.ts` is the white-label seam.** To create a new branded app: copy this package, change `app.config.ts` values, update `capacitor.config.ts` if targeting mobile.
 - **Plugin module caching.** `main.tsx` resolves each plugin module exactly once via the `initializeAppModules()` Promise.all; `React.lazy()` consumers share the same promise via `lazyNamedComponent()`.
-- **`@elizaos/app-core` must load first** before other plugins — it owns the `AppBootConfig` singleton. `initializeAppModules()` awaits it before the parallel batch.
+- **`@elizaos/app-core` must be evaluated before the boot config is assembled** — it owns the `AppBootConfig` singleton. `main.tsx` statically imports its desktop bindings, so the package loads with the entry chunk; never re-add a dynamic `import("@elizaos/app-core")` on the boot path — its escaping namespace anchors the whole `@elizaos/ui/browser` barrel into the entry chunk (#13187).
 - **Desktop API base injection.** Electrobun injects `window.__ELIZA_APP_API_BASE__` before React boots via its static server; Vite dev uses a `<script>` tag injected by `appDevWsBasePlugin()`.
 - **iOS store CSP.** When `ELIZA_BUILD_VARIANT=store` + `ELIZA_RELEASE_AUTHORITY=apple-app-store`, the build strips all `localhost`/`127.0.0.1` CSP sources and Capacitor allowNavigation entries. Do not hardcode local origins.
 - **Capacitor `ios/` and `android/` dirs are generated.** Run `bun run --cwd packages/app cap:sync` after any `capacitor.config.ts` change. Do not hand-edit the native project settings that Capacitor generates.

--- a/packages/app/src/boot-failure.ts
+++ b/packages/app/src/boot-failure.ts
@@ -1,7 +1,7 @@
 /**
  * Last-resort boot error surface.
  *
- * `main()` awaits several fallible pre-mount steps (the dynamic `app-core` and
+ * `main()` awaits several fallible pre-mount steps (e.g. the dynamic
  * `@elizaos/ui/voice` chunks). If any rejects, React never mounts and the user
  * is stranded on a permanent blank page with no recovery — most commonly a
  * stale `index.html` pointing at purged hashed chunks right after a prod

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -70,7 +70,6 @@ import {
 } from "@elizaos/ui/bridge/storage-bridge";
 import { RenderTelemetryProfiler } from "@elizaos/ui/cloud-ui/runtime/render-telemetry";
 import { AppWindowRenderer } from "@elizaos/ui/components/apps/AppWindowRenderer";
-import { CharacterEditor } from "@elizaos/ui/components/character/CharacterEditor";
 import { ShellModalityProvider } from "@elizaos/ui/components/ShellModalityProvider";
 import { ShellRoleProvider } from "@elizaos/ui/components/ShellRoleProvider";
 import type {
@@ -194,7 +193,6 @@ declare const __ELIZA_WEB_SHELL__: boolean | undefined;
 declare global {
   interface Window {
     __ELIZA_APP_SHARE_QUEUE__?: ShareTargetPayload[];
-    __ELIZA_APP_CHARACTER_EDITOR__?: typeof CharacterEditor;
     __ELIZA_APP_API_BASE__?: string;
     __ELIZA_IOS_LOCAL_AGENT_DEBUG__?: (event: Record<string, unknown>) => void;
   }
@@ -226,13 +224,6 @@ function cachedDynamicImport<T>(
   const promise = loader();
   appModuleCache.set(key, promise);
   return promise;
-}
-
-function importAppCore() {
-  return cachedDynamicImport(
-    "@elizaos/app-core",
-    () => import("@elizaos/app-core"),
-  );
 }
 
 function importPersonalAssistant() {
@@ -301,7 +292,6 @@ const FineTuningView = lazyNamedComponent<FineTuningViewProps>(
 
 const BRANDED_WINDOW_KEYS = {
   apiBase: `__${APP_ENV_PREFIX}_API_BASE__`,
-  characterEditor: `__${APP_ENV_PREFIX}_CHARACTER_EDITOR__`,
   shareQueue: `__${APP_ENV_PREFIX}_SHARE_QUEUE__`,
 } as const;
 
@@ -463,9 +453,6 @@ if (!hasFirstRunRuntimeOverride()) {
   preSeedAndroidLocalRuntimeIfFresh();
 }
 
-window.__ELIZA_APP_CHARACTER_EDITOR__ = CharacterEditor;
-Reflect.set(window, BRANDED_WINDOW_KEYS.characterEditor, CharacterEditor);
-
 const APP_STYLE_PRESETS = getStylePresets();
 
 const APP_VRM_ASSETS = APP_STYLE_PRESETS.slice()
@@ -576,7 +563,6 @@ function buildAppBootConfig(): AppBootConfig {
     cloudApiBase: IOS_RUNTIME_ENV_CONFIG.cloudApiBase,
     vrmAssets: APP_VRM_ASSETS,
     firstRunStyles: APP_STYLE_PRESETS,
-    characterEditor: CharacterEditor,
     codingAgentTasksPanel: CodingAgentTasksPanel,
     codingAgentSettingsSection: CodingAgentSettingsSection,
     codingAgentControlChip: CodingAgentControlChip,
@@ -618,13 +604,18 @@ const BOOT_CONFIG_DEFERRED_MODULE_LOADERS: readonly SideEffectAppModuleLoader[] 
   ];
 
 function initializeAppModules(): Promise<void> {
-  appModulesInitialized ??= (async () => {
-    // app-core owns the AppBootConfig singleton, so it must load before the
-    // config is assembled. Everything else exposed through the boot config is a
-    // React.lazy handle that loads on render, so its import is deferred onto the
-    // idle path instead of gating the first visible shell (#9565).
-    await importAppCore();
+  appModulesInitialized ??= (() => {
+    // app-core owns the AppBootConfig singleton and is already evaluated: this
+    // module statically imports its desktop bindings, so the whole package
+    // loads with the entry chunk before main() runs. A dynamic
+    // import("@elizaos/app-core") here would be a runtime no-op, but its
+    // escaping namespace would force Rollup to retain every export of the
+    // barrel (`export * from "@elizaos/ui/browser"`) in the startup-critical
+    // entry chunk (#13187). Everything else exposed through the boot config is
+    // a React.lazy handle that loads on render, so its import is deferred onto
+    // the idle path instead of gating the first visible shell (#9565).
     setBootConfig(buildAppBootConfig());
+    return Promise.resolve();
   })();
 
   return appModulesInitialized;

--- a/packages/app/test/route-coverage.test.ts
+++ b/packages/app/test/route-coverage.test.ts
@@ -140,7 +140,6 @@ const NOT_APP_BOOT_LOADED_VIEW_MANIFESTS: Readonly<Record<string, string>> = {
 };
 
 const BOOT_PLUGIN_VIEW_MANIFEST_BY_MODULE: Record<string, string | null> = {
-  "@elizaos/app-core": null,
   "@elizaos/plugin-contacts": "plugins/plugin-contacts/src/plugin.ts",
   "@elizaos/plugin-native-settings": null,
   "@elizaos/plugin-facewear": "plugins/plugin-facewear/src/index.ts",

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -172,11 +172,10 @@ import {
   listAppShellPages,
   subscribeAppShellPages,
 } from "./app-shell-registry";
-// CharacterEditor, DesktopTabBar, and FineTuningView stay static: they are
-// already pulled eagerly elsewhere in the app graph (main.tsx / plugin-loader /
-// boot-config), so a lazy() boundary here would only fold back into main. The
-// remaining page views are lazy-split below.
-import { CharacterEditor } from "./components/character/CharacterEditor";
+// DesktopTabBar and FineTuningView stay static: they are already pulled
+// eagerly elsewhere in the app graph (plugin-loader / boot-config), so a
+// lazy() boundary here would only fold back into main. The remaining page
+// views are lazy-split below.
 import { DesktopTabBar } from "./components/desktop/DesktopTabBar";
 import { LauncherSurface } from "./components/pages/LauncherSurface";
 import {
@@ -197,6 +196,10 @@ import { WidgetHost } from "./widgets";
 const BackgroundView = lazyNamedView(
   () => import("./components/pages/BackgroundView"),
   "BackgroundView",
+);
+const CharacterEditor = lazyNamedView(
+  () => import("./components/character/CharacterEditor"),
+  "CharacterEditor",
 );
 const AutomationsFeed = lazyNamedView(
   () => import("./components/pages/AutomationsFeed"),


### PR DESCRIPTION
Fixes #13187

## What

Three changes to the renderer boot path (`packages/app/src/main.tsx` + `packages/ui/src/App.tsx`), exactly as specified in the issue:

1. **Removed the no-op dynamic `import("@elizaos/app-core")`** from `initializeAppModules()`. main.tsx statically imports the package's desktop bindings, so the module always evaluated with the entry chunk before `main()` ran — the dynamic import was a runtime no-op, but its escaping namespace forced Rollup to retain every export of the barrel (`export * from "@elizaos/ui/browser"`) in the startup-critical entry chunk. The initializer now assembles the boot config synchronously (still returning the cached `Promise<void>` so every awaiter and the #9565 ordering invariant are unchanged — `first-paint-guard.test.ts` passes unmodified, 4/4).
2. **Deleted the dead `CharacterEditor` wiring**: the eager deep import, `window.__ELIZA_APP_CHARACTER_EDITOR__`, the branded `__ELIZA_CHARACTER_EDITOR__` key, and `bootConfig.characterEditor`. Repo-wide grep (ts/tsx/js/mjs/swift/kt/html across `packages/`, `plugins/`, `scripts/`) finds **zero readers** for any of them — only the main.tsx writers, the optional field declaration in `boot-config-store.ts`, and the standalone CLI project template's own scaffold (untouched; the optional field stays declared for it).
3. **Routed `CharacterEditor` through the same `lazyNamedView` + `LazyViewBoundary` pattern as its ~25 sibling route views** in App.tsx. Its only render site (the `character`/`character-select` tab) already flows through the shared `LazyViewBoundary` Suspense + `ViewErrorBoundary` wrapping, and `lazyNamedView` registers the loader with the existing idle route-chunk prefetch.

Also updated: the route-coverage ratchet (removed the now-stale `"@elizaos/app-core"` loader key), the `boot-failure.ts` header comment, and the stale boot-sequence bullets in `packages/app/CLAUDE.md`/`AGENTS.md`.

## Bundle evidence (`bun run --cwd packages/app build:web`, same machine, same install)

| | entry chunk | raw | gzip |
|---|---|---|---|
| before (develop `a5c4c81614`) | `index-DX0x3xuF.js` | 3,071,342 B | 1,323,069 B |
| after | `index-DCJ9YJq1.js` | **2,958,353 B** | **1,292,286 B** |
| delta | | **−112,989 B (−3.7%)** | **−30,783 B** |

- `CharacterEditor` now ships as its own on-demand chunk `CharacterEditor-Ch90C4vY.js` (55,659 B) — its body (`character-editor-view` testid) and the `DiffReviewPanel` marker are **gone from the entry chunk** (both present before).
- `verify-chunk-safety.mjs` passes on the new chunk graph.

## Boot safety

- The removed dynamic import could never have been the first evaluation of app-core (static imports win), so no side-effect reordering is possible; `setBootConfig` now runs strictly earlier (synchronously at first call), still strictly before `mountReactApp()`.
- `initializeAppModules()` keeps its `Promise<void>` contract — `await initializeAppModules()` in `main()` is untouched.
- Lazy `CharacterEditor` renders under the same designed `Loading…` Suspense fallback as every sibling lazy view; the App test mocks (`vi.mock` of the same module path) intercept the dynamic import identically.

## Tests

- `packages/app` vitest suite: 362/368 — the 6 failing coverage-ratchet tests fail **byte-identically on pristine develop** (verified by swapping baseline files in and diffing the failure lists; pre-existing repo drift, e.g. plugin-scheduling manifest missing from the ratchet).
- `first-paint-guard` 4/4 green unmodified; `main.network-fallback` 2/2 green.
- `packages/ui` typecheck green; `App.chat-overlay-first-run` 3/3 green; the two App test files that fail do so identically on develop (pre-existing `useIsAuthenticated` mock drift). `packages/app` typecheck fails with the same 2 pre-existing TS2305 errors on pristine develop.
- biome clean on all changed files.

[phone-ui]

---
**Authored end-to-end by a Fable-5 agent** (verified 100% claude-fable-5), committed + pushed. Main-loop re-verification: pure-Fable ✓; clean 6-file merge-base diff; all 3 specified changes confirmed applied (no-op dynamic import removed — only a durable rationale comment remains; dead __ELIZA_APP_CHARACTER_EDITOR__ wiring gone from main.tsx; CharacterEditor now `lazyNamedView(...)` in App.tsx like its ~25 siblings). Boot-safety is provable: main.tsx STATICALLY imports @elizaos/app-core (line 45), so ES-module semantics fully evaluate the module before any main.tsx statement runs — the removed dynamic import was definitionally a no-op, and first-paint-guard.test.ts stays 4/4. Bundle evidence (agent-measured, build:web): entry chunk −112,989 bytes raw (−3.7%) / −30,783 bytes gzip; CharacterEditor (55.7KB) moved to its own on-demand chunk off the boot path. Pre-existing unrelated test/typecheck drift (route-coverage ratchets, @elizaos/ui/navigation TS2305) verified identical on clean develop. — [phone-ui]