### PR TITLE
fix(#12642): drive connector UI branching from registry metadata

### DIFF
--- a/packages/ui/src/components/connectors/connector-mode-registry.test.ts
+++ b/packages/ui/src/components/connectors/connector-mode-registry.test.ts
@@ -4,6 +4,8 @@
  * fully working mode selector. In-memory registry, no runtime.
  */
 
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import type { ComponentType } from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { getBootConfig, setBootConfig } from "../../config/boot-config";
@@ -15,6 +17,10 @@ import {
 import { hasConnectorSetupPanel } from "./ConnectorSetupPanel.helpers";
 import {
   type ConnectorModeDeclaration,
+  connectorDeclaresCloudGatewaySetup,
+  getConnectorManagedGatewayProvider,
+  getConnectorModeCloudGatewaySetup,
+  getConnectorModeConfigFormHint,
   registerConnectorModes,
 } from "./connector-mode-registry";
 import { resolveConnectorSetupPanelToken } from "./connector-setup-panel-registry";
@@ -145,5 +151,158 @@ describe("browser-bridge panel availability gating", () => {
     );
     expect(hasConnectorSetupPanel("lifeopsbrowser")).toBe(true);
     expect(hasConnectorSetupPanel("@elizaos/plugin-browser-bridge")).toBe(true);
+  });
+});
+
+/**
+ * Seam tests for the connector-mode UI-affordance metadata (#12090 item 28).
+ * The connector page and settings config form used to decide which gateway
+ * surface / config hint to render by matching `plugin.id` + mode id string
+ * literals (`plugin.id === "discord" && selectedMode === "managed"`, etc.).
+ * That branching now reads owner-declared metadata, so a connector plugin
+ * absent from ui source gets the right affordance purely from its declaration.
+ */
+describe("connector-mode UI-affordance metadata (#12090 item 28)", () => {
+  it("resolves the cloud-gateway setup affordance from the selected mode's declaration", () => {
+    // Built-in connectors declare their gateway affordance, not a hardcoded id.
+    expect(getConnectorModeCloudGatewaySetup("discord", "managed")).toBe(
+      "managed-agent-picker",
+    );
+    expect(getConnectorModeCloudGatewaySetup("telegram", "cloud-bot")).toBe(
+      "webhook-notice",
+    );
+    // Non-gateway modes and unknown modes declare nothing.
+    expect(getConnectorModeCloudGatewaySetup("discord", "bot")).toBeNull();
+    expect(getConnectorModeCloudGatewaySetup("discord", "nope")).toBeNull();
+    expect(getConnectorModeCloudGatewaySetup("discord", null)).toBeNull();
+  });
+
+  it("resolves the managed-gateway provisioning provider a connector declares", () => {
+    // The Discord managed picker is keyed on the declared provider, not the
+    // plugin id, so the connector page renders the Discord-specific
+    // provisioning flow only for the connector that declared it.
+    expect(getConnectorManagedGatewayProvider("discord")).toBe(
+      "eliza-cloud-discord",
+    );
+    // Telegram's gateway is a webhook-notice, not a managed-agent picker, so it
+    // declares no provisioning provider.
+    expect(getConnectorManagedGatewayProvider("telegram")).toBeNull();
+    expect(getConnectorManagedGatewayProvider("x")).toBeNull();
+  });
+
+  it("reports whether a connector declares any mode of a gateway-setup kind", () => {
+    expect(
+      connectorDeclaresCloudGatewaySetup("telegram", "webhook-notice"),
+    ).toBe(true);
+    expect(
+      connectorDeclaresCloudGatewaySetup("discord", "managed-agent-picker"),
+    ).toBe(true);
+    // Discord has no webhook-notice mode; telegram has no managed-agent picker.
+    expect(
+      connectorDeclaresCloudGatewaySetup("discord", "webhook-notice"),
+    ).toBe(false);
+    expect(
+      connectorDeclaresCloudGatewaySetup("telegram", "managed-agent-picker"),
+    ).toBe(false);
+  });
+
+  it("resolves the owner-declared config-form hint for a connector mode", () => {
+    const hint = getConnectorModeConfigFormHint("discord", "bot");
+    expect(hint?.key).toBe("settings.sections.connectors.discordAppIdHint");
+    expect(hint?.fallback).toContain("Application ID is optional");
+    // Falls back to the connector's declared hint when no mode id is given
+    // (single-mode connectors have no selector), and is null for connectors
+    // that declare none.
+    expect(getConnectorModeConfigFormHint("discord", null)?.fallback).toContain(
+      "Application ID is optional",
+    );
+    expect(getConnectorModeConfigFormHint("telegram", "bot")).toBeNull();
+  });
+
+  it("drives the affordance for a connector absent from ui source (no hardcoded id)", () => {
+    // A fictional connector whose id appears in no switch/branch in the ui
+    // package. It only exists via registration, yet resolves affordances.
+    registerConnectorModes("acmegateway", [
+      {
+        id: "hosted",
+        label: "Acme Hosted",
+        description: "Route Acme through the Acme Cloud gateway agent.",
+        managementMode: "cloud-managed",
+        setupPluginId: "acmegateway",
+        cloudOnly: true,
+        cloudGatewaySetup: "managed-agent-picker",
+      },
+      {
+        id: "webhook",
+        label: "Acme Webhook",
+        description: "Acme still needs a token; the cloud hosts its webhook.",
+        managementMode: "cloud-managed",
+        setupPluginId: "acmegateway",
+        cloudOnly: true,
+        cloudGatewaySetup: "webhook-notice",
+      },
+      {
+        id: "token",
+        label: "Acme Token",
+        description: "Use an Acme API token.",
+        managementMode: "local-config",
+        setupPluginId: "acmegateway",
+        configFormHintKey: "connectors.acme.tokenHint",
+        configFormHint: "Acme token is scoped per workspace.",
+      },
+    ]);
+
+    expect(getConnectorModeCloudGatewaySetup("acmegateway", "hosted")).toBe(
+      "managed-agent-picker",
+    );
+    expect(getConnectorModeCloudGatewaySetup("acmegateway", "webhook")).toBe(
+      "webhook-notice",
+    );
+    expect(
+      connectorDeclaresCloudGatewaySetup("acmegateway", "webhook-notice"),
+    ).toBe(true);
+    // Acme declares a managed-agent picker but no provisioning provider, so it
+    // is NOT routed through the Discord provisioning flow — the connector page
+    // renders the Discord picker only for the declared eliza-cloud-discord
+    // provider (regression guard for the generic-vs-Discord-provisioning gap).
+    expect(getConnectorManagedGatewayProvider("acmegateway")).toBeNull();
+    expect(
+      getConnectorModeConfigFormHint("acmegateway", "token")?.fallback,
+    ).toBe("Acme token is scoped per workspace.");
+  });
+});
+
+/**
+ * Grep guard (#12090 item 28): the connector page and settings config form must
+ * not reintroduce hardcoded connector-id branching for the gateway/notice/hint
+ * affordances that are now declared in the connector-mode registry.
+ */
+describe("connector UI branching drift guard (#12090 item 28)", () => {
+  const readSource = (relPath: string): string => {
+    // Resolve against this test file so it works from any cwd/worktree.
+    const url = new URL(relPath, import.meta.url);
+    return readFileSync(fileURLToPath(url), "utf8");
+  };
+
+  it("plugin-view-connectors.tsx has no plugin-id/mode-literal gateway branches", () => {
+    const src = readSource("../pages/plugin-view-connectors.tsx");
+    // The old duck-typed capability branches must be gone from executable code.
+    expect(src).not.toMatch(/plugin\.id\s*===\s*"discord"/);
+    expect(src).not.toMatch(/plugin\.id\s*===\s*"telegram"/);
+    expect(src).not.toMatch(/selectedMode\s*===\s*"managed"/);
+    expect(src).not.toMatch(/selectedMode\s*===\s*"cloud-bot"/);
+    // The twitter OAuth-initiation dispatch is registry-driven now.
+    expect(src).not.toMatch(/\.platform\s*===\s*"twitter"/);
+    // It reads the declared affordance helpers instead — including keying the
+    // managed picker on the declared provisioning provider, not the plugin id.
+    expect(src).toContain("getConnectorModeCloudGatewaySetup");
+    expect(src).toContain("connectorDeclaresCloudGatewaySetup");
+    expect(src).toContain("getConnectorManagedGatewayProvider");
+  });
+
+  it("ConnectorsSection.tsx resolves the config-form hint from the registry", () => {
+    const src = readSource("../settings/ConnectorsSection.tsx");
+    expect(src).not.toMatch(/plugin\.id\s*===\s*"discord"/);
+    expect(src).toContain("getConnectorModeConfigFormHint");
   });
 });

--- a/packages/ui/src/components/connectors/connector-mode-registry.ts
+++ b/packages/ui/src/components/connectors/connector-mode-registry.ts
@@ -20,6 +20,22 @@ import {
  * connector plugin declares (in its registry entry / manifest) so the setup UI
  * can render its mode selector without hardcoding the connector.
  */
+/**
+ * The kind of cloud-gateway setup affordance a connector mode declares. Read by
+ * the connector page to render the correct gateway surface without hardcoding
+ * connector ids. See {@link ConnectorModeDeclaration.cloudGatewaySetup}.
+ */
+export type ConnectorCloudGatewaySetup =
+  | "managed-agent-picker"
+  | "webhook-notice";
+
+/**
+ * The hosted-gateway provisioning flow backing a `"managed-agent-picker"` mode.
+ * Each value maps to a bespoke provisioning handler + copy in the connector
+ * page. Currently only the managed-Discord flow exists.
+ */
+export type ConnectorManagedGatewayProvider = "eliza-cloud-discord";
+
 export interface ConnectorModeDeclaration {
   /** Mode id, unique within a connector. */
   id: string;
@@ -35,6 +51,42 @@ export interface ConnectorModeDeclaration {
   setupPluginId: string;
   /** Mode is only offered when Eliza Cloud is connected. */
   cloudOnly?: boolean;
+  /**
+   * UI affordance a cloud-managed gateway mode declares so the connector page
+   * renders the right gateway setup surface generically, instead of matching
+   * `plugin.id` + mode id string literals (#12090 item 28).
+   *
+   * - `"managed-agent-picker"`: this mode is backed by a hosted Eliza Cloud
+   *   gateway the user provisions/picks an agent for (e.g. managed Discord).
+   *   Treated as cloud-backed for the connector's Ready state.
+   * - `"webhook-notice"`: this mode still needs local credentials but Eliza
+   *   Cloud can host its inbound webhook, so the page shows a gateway hint
+   *   (e.g. Telegram cloud gateway) without picking a hosted agent.
+   *
+   * Omitted for modes that need no cloud-gateway affordance. The picker/notice
+   * bodies themselves stay owned by the connector (their copy + handlers), but
+   * *which* affordance to show is resolved from this declared capability.
+   */
+  cloudGatewaySetup?: ConnectorCloudGatewaySetup;
+  /**
+   * For a `"managed-agent-picker"` mode, the id of the hosted-gateway
+   * provisioning flow that backs it. The connector page renders the matching
+   * provider-specific picker (its bespoke provisioning handler + copy) keyed on
+   * this declared value instead of the connector's plugin id (#12090 item 28).
+   * Only `"eliza-cloud-discord"` exists today (managed Discord); a connector
+   * declaring `managed-agent-picker` with an unknown/undeclared provider gets
+   * no picker rather than being misrouted through the Discord flow.
+   */
+  cloudGatewayProvider?: ConnectorManagedGatewayProvider;
+  /**
+   * Optional owner-declared footnote rendered beneath this mode's env-config
+   * form (e.g. Discord's "Application ID is optional, auto-resolved from the
+   * bot token" hint). Declared here so the settings config form does not match
+   * `plugin.id === "discord"` to decide whether to show it (#12090 item 28).
+   * `configFormHintKey` is the i18n key; `configFormHint` is the default copy.
+   */
+  configFormHintKey?: string;
+  configFormHint?: string;
   /**
    * Preference rank when picking the default selected mode (lower wins). Ties
    * are broken by declaration order. Modes without a rank are never chosen as
@@ -70,6 +122,95 @@ export function getDeclaredConnectorModes(
   return registry.get(normalizeConnectorCatalogId(connectorId)) ?? [];
 }
 
+/**
+ * Resolves the cloud-gateway setup affordance a connector's *selected* mode
+ * declares, or `null` when the mode declares none (or is unknown). Lets the
+ * connector page decide which gateway surface to render from owner-declared
+ * metadata instead of matching `plugin.id` + mode id string literals
+ * (#12090 item 28).
+ */
+export function getConnectorModeCloudGatewaySetup(
+  connectorId: string,
+  modeId: string | null | undefined,
+): ConnectorCloudGatewaySetup | null {
+  if (!modeId) return null;
+  return (
+    getDeclaredConnectorModes(connectorId).find((mode) => mode.id === modeId)
+      ?.cloudGatewaySetup ?? null
+  );
+}
+
+/**
+ * Whether a connector declares *any* mode with the given cloud-gateway setup
+ * affordance, regardless of which mode is currently selected. Lets the
+ * connector page show a gateway hint (e.g. "connect Eliza Cloud for webhook
+ * hosting") for connectors that support that gateway kind, without hardcoding
+ * the connector id (#12090 item 28).
+ */
+export function connectorDeclaresCloudGatewaySetup(
+  connectorId: string,
+  setup: ConnectorCloudGatewaySetup,
+): boolean {
+  return getDeclaredConnectorModes(connectorId).some(
+    (mode) => mode.cloudGatewaySetup === setup,
+  );
+}
+
+/**
+ * The managed-gateway provisioning provider a connector declares for its
+ * `"managed-agent-picker"` mode, or `null` when the connector declares no such
+ * mode or leaves the provider undeclared. The connector page renders the
+ * matching provider-specific picker keyed on this value, so a connector cannot
+ * be misrouted through a provider flow it did not declare (#12090 item 28).
+ */
+export function getConnectorManagedGatewayProvider(
+  connectorId: string,
+): ConnectorManagedGatewayProvider | null {
+  return (
+    getDeclaredConnectorModes(connectorId).find(
+      (mode) => mode.cloudGatewaySetup === "managed-agent-picker",
+    )?.cloudGatewayProvider ?? null
+  );
+}
+
+/**
+ * A connector-declared config-form footnote: its default copy plus an optional
+ * i18n key. `key` is omitted when the declaration provides no translation key,
+ * so the consumer renders `fallback` directly instead of calling `t("")`.
+ */
+export interface ConnectorConfigFormHint {
+  key?: string;
+  fallback: string;
+}
+
+/**
+ * Resolves the config-form footnote a connector's *selected* mode declares, or
+ * `null` when that mode declares none. Lets the settings config form render the
+ * hint generically instead of matching `plugin.id` (#12090 item 28).
+ *
+ * When `modeId` is null/undefined (single-mode connectors have no mode
+ * selector) the connector's first hint-bearing mode is used. When `modeId` is
+ * given but that specific mode declares no hint, `null` is returned — the hint
+ * is scoped to the modes that declare it, so it does not leak onto an unrelated
+ * selected mode.
+ */
+export function getConnectorModeConfigFormHint(
+  connectorId: string,
+  modeId: string | null | undefined,
+): ConnectorConfigFormHint | null {
+  const modes = getDeclaredConnectorModes(connectorId);
+  const declaration = modeId
+    ? modes.find((mode) => mode.id === modeId)
+    : modes.find((mode) => mode.configFormHint !== undefined);
+  if (!declaration?.configFormHint) return null;
+  return declaration.configFormHintKey
+    ? {
+        key: declaration.configFormHintKey,
+        fallback: declaration.configFormHint,
+      }
+    : { fallback: declaration.configFormHint };
+}
+
 // ---------------------------------------------------------------------------
 // Built-in connector mode declarations.
 //
@@ -91,6 +232,8 @@ registerConnectorModes("discord", [
     managementMode: "cloud-managed",
     setupPluginId: "discord",
     cloudOnly: true,
+    cloudGatewaySetup: "managed-agent-picker",
+    cloudGatewayProvider: "eliza-cloud-discord",
   },
   {
     id: "local",
@@ -111,6 +254,9 @@ registerConnectorModes("discord", [
     managementMode: "local-config",
     setupPluginId: "discord",
     defaultPriority: 1,
+    configFormHintKey: "settings.sections.connectors.discordAppIdHint",
+    configFormHint:
+      "Application ID is optional; it is auto-resolved from the bot token when possible.",
   },
 ]);
 
@@ -125,6 +271,7 @@ registerConnectorModes("telegram", [
     managementMode: "cloud-managed",
     setupPluginId: "telegram",
     cloudOnly: true,
+    cloudGatewaySetup: "webhook-notice",
   },
   {
     id: "bot",

--- a/packages/ui/src/components/pages/plugin-view-connectors.test.ts
+++ b/packages/ui/src/components/pages/plugin-view-connectors.test.ts
@@ -12,7 +12,7 @@ describe("shouldRenderConnectorPluginConfig", () => {
       shouldRenderConnectorPluginConfig({
         hasParams: true,
         isCloudOAuthMode: false,
-        isDiscordManagedMode: false,
+        isManagedAgentGatewayMode: false,
       }),
     ).toBe(true);
   });
@@ -22,17 +22,17 @@ describe("shouldRenderConnectorPluginConfig", () => {
       shouldRenderConnectorPluginConfig({
         hasParams: true,
         isCloudOAuthMode: true,
-        isDiscordManagedMode: false,
+        isManagedAgentGatewayMode: false,
       }),
     ).toBe(false);
   });
 
-  it("hides local params for managed Discord mode", () => {
+  it("hides local params for managed agent gateway mode", () => {
     expect(
       shouldRenderConnectorPluginConfig({
         hasParams: true,
         isCloudOAuthMode: false,
-        isDiscordManagedMode: true,
+        isManagedAgentGatewayMode: true,
       }),
     ).toBe(false);
   });
@@ -42,19 +42,19 @@ describe("shouldRenderConnectorPluginConfig", () => {
       shouldRenderConnectorPluginConfig({
         hasParams: true,
         isCloudOAuthMode: true,
-        isDiscordManagedMode: true,
+        isManagedAgentGatewayMode: true,
       }),
     ).toBe(false);
   });
 
   it("renders nothing when the plugin exposes no params, regardless of mode", () => {
     for (const isCloudOAuthMode of [false, true]) {
-      for (const isDiscordManagedMode of [false, true]) {
+      for (const isManagedAgentGatewayMode of [false, true]) {
         expect(
           shouldRenderConnectorPluginConfig({
             hasParams: false,
             isCloudOAuthMode,
-            isDiscordManagedMode,
+            isManagedAgentGatewayMode,
           }),
         ).toBe(false);
       }

--- a/packages/ui/src/components/pages/plugin-view-connectors.tsx
+++ b/packages/ui/src/components/pages/plugin-view-connectors.tsx
@@ -29,6 +29,11 @@ import { ConnectorModeSelector } from "../connectors/ConnectorModeSelector";
 import { useConnectorMode } from "../connectors/ConnectorModeSelector.hooks";
 import { ConnectorSetupPanel } from "../connectors/ConnectorSetupPanel";
 import { hasConnectorSetupPanel } from "../connectors/ConnectorSetupPanel.helpers";
+import {
+  connectorDeclaresCloudGatewaySetup,
+  getConnectorManagedGatewayProvider,
+  getConnectorModeCloudGatewaySetup,
+} from "../connectors/connector-mode-registry";
 import { getBrandIcon } from "../conversations/brand-icons";
 import { Button } from "../ui/button";
 import {
@@ -121,13 +126,13 @@ interface ConnectorPluginCardProps
 export function shouldRenderConnectorPluginConfig({
   hasParams,
   isCloudOAuthMode,
-  isDiscordManagedMode,
+  isManagedAgentGatewayMode,
 }: {
   hasParams: boolean;
   isCloudOAuthMode: boolean;
-  isDiscordManagedMode: boolean;
+  isManagedAgentGatewayMode: boolean;
 }): boolean {
-  return hasParams && !isDiscordManagedMode && !isCloudOAuthMode;
+  return hasParams && !isManagedAgentGatewayMode && !isCloudOAuthMode;
 }
 
 type CloudOAuthConnectorCopy = {
@@ -145,6 +150,14 @@ type CloudOAuthConnectorCopy = {
   connectedHint: string;
   disconnectedHint: string;
   successNotice: string;
+  /**
+   * Which cloud OAuth-initiation client method this connector uses, declared on
+   * the connector copy instead of matching `platform === "twitter"` at the call
+   * site (#12090 item 28):
+   * - `"twitter-endpoint"`: the dedicated `initiateCloudTwitterOauth` method.
+   * - `"generic"` (default): `initiateCloudOauth(platform, ...)`.
+   */
+  oauthInitiation?: "twitter-endpoint" | "generic";
 };
 
 const ROLE_BUTTON_SUFFIX: Record<CloudOAuthConnectionRole, string> = {
@@ -190,6 +203,7 @@ const CLOUD_OAUTH_CONNECTORS: Record<string, CloudOAuthConnectorCopy> = {
     disconnectedHint:
       "Connect Eliza Cloud first to use X/Twitter OAuth instead of local developer tokens.",
     successNotice: "Finish X/Twitter OAuth in your browser, then return here.",
+    oauthInitiation: "twitter-endpoint",
   },
   google: {
     platform: "google",
@@ -424,15 +438,34 @@ function ConnectorPluginCard({
     selectedCloudOAuthConnector ??
     (!elizaCloudConnected ? (CLOUD_OAUTH_CONNECTORS[plugin.id] ?? null) : null);
   const isCloudOAuthMode = Boolean(selectedCloudOAuthConnector);
-  const isDiscordManagedMode =
-    plugin.id === "discord" && connectorMode.selectedMode === "managed";
-  const isTelegramCloudGatewayMode =
-    plugin.id === "telegram" && connectorMode.selectedMode === "cloud-bot";
-  const showTelegramCloudGatewayNotice =
-    isTelegramCloudGatewayMode ||
-    (!elizaCloudConnected && plugin.id === "telegram");
+  // Which cloud-gateway setup affordance the *selected* mode declares, resolved
+  // from owner-declared connector-mode metadata instead of matching plugin id +
+  // mode id string literals (#12090 item 28). Connectors declare
+  // `cloudGatewaySetup` on their mode in connector-mode-registry.ts.
+  const selectedModeCloudGatewaySetup = getConnectorModeCloudGatewaySetup(
+    plugin.id,
+    connectorMode.selectedMode,
+  );
+  // A hosted managed-agent gateway (e.g. managed Discord) — treated as
+  // cloud-backed for the connector Ready state and rendered with the managed
+  // agent picker below.
+  const isManagedAgentGatewayMode =
+    selectedModeCloudGatewaySetup === "managed-agent-picker";
+  // A local-credential mode whose inbound webhook Eliza Cloud can host (e.g.
+  // Telegram cloud gateway) — shown as an informational gateway notice.
+  const isWebhookGatewayMode =
+    selectedModeCloudGatewaySetup === "webhook-notice";
+  // Any connector that declares a webhook-notice mode should also surface the
+  // "connect Eliza Cloud for webhook hosting" hint before cloud is connected,
+  // even if that mode is not the currently selected one — matching the prior
+  // behavior that showed the Telegram gateway notice whenever cloud was not
+  // connected.
+  const showCloudGatewayNotice =
+    isWebhookGatewayMode ||
+    (!elizaCloudConnected &&
+      connectorDeclaresCloudGatewaySetup(plugin.id, "webhook-notice"));
   const cloudBackedConnectorMode =
-    elizaCloudConnected && (isCloudOAuthMode || isDiscordManagedMode);
+    elizaCloudConnected && (isCloudOAuthMode || isManagedAgentGatewayMode);
   const hasParams =
     (plugin.parameters?.length ?? 0) > 0 && plugin.id !== "__ui-showcase__";
   const isExpanded = connectorExpandedIds.has(plugin.id);
@@ -771,7 +804,7 @@ function ConnectorPluginCard({
       const redirectUrl =
         typeof window !== "undefined" ? window.location.href : undefined;
       const oauthResponse =
-        cloudOAuthConnector.platform === "twitter"
+        cloudOAuthConnector.oauthInitiation === "twitter-endpoint"
           ? await client.initiateCloudTwitterOauth({
               redirectUrl,
               connectionRole,
@@ -926,7 +959,7 @@ function ConnectorPluginCard({
   const showPluginConfig = shouldRenderConnectorPluginConfig({
     hasParams,
     isCloudOAuthMode,
-    isDiscordManagedMode,
+    isManagedAgentGatewayMode,
   });
 
   return (
@@ -955,9 +988,9 @@ function ConnectorPluginCard({
           />
         )}
 
-        {plugin.id === "discord" &&
-          (!elizaCloudConnected ||
-            connectorMode.selectedMode === "managed") && (
+        {getConnectorManagedGatewayProvider(plugin.id) ===
+          "eliza-cloud-discord" &&
+          (!elizaCloudConnected || isManagedAgentGatewayMode) && (
             <PagePanel.Notice
               tone="default"
               className="mb-4"
@@ -1102,7 +1135,7 @@ function ConnectorPluginCard({
           </PagePanel.Notice>
         ) : null}
 
-        {showTelegramCloudGatewayNotice ? (
+        {showCloudGatewayNotice ? (
           <PagePanel.Notice
             tone="default"
             className="mb-4"

--- a/packages/ui/src/components/settings/ConnectorsSection.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.tsx
@@ -29,6 +29,7 @@ import type { ConnectorMode } from "../connectors/ConnectorModeSelector.helpers"
 import { useConnectorMode } from "../connectors/ConnectorModeSelector.hooks";
 import { ConnectorSetupPanel } from "../connectors/ConnectorSetupPanel";
 import { hasConnectorSetupPanel } from "../connectors/ConnectorSetupPanel.helpers";
+import { getConnectorModeConfigFormHint } from "../connectors/connector-mode-registry";
 import { getBrandIcon } from "../conversations/brand-icons";
 import { PluginConfigForm } from "../pages/PluginConfigForm";
 import {
@@ -138,6 +139,13 @@ function ConnectorBody({ plugin }: { plugin: PluginInfo }) {
   const selectedMode = connectorMode.modes.find(
     (mode) => mode.id === connectorMode.selectedMode,
   );
+  // Owner-declared config-form footnote for the selected mode (e.g. Discord's
+  // "Application ID is optional" hint), resolved from connector-mode metadata
+  // instead of matching plugin.id (#12090 item 28).
+  const configFormHint = getConnectorModeConfigFormHint(
+    plugin.id,
+    connectorMode.selectedMode,
+  );
   const showPluginConfig = shouldRenderConnectorConfigForm({
     managementMode: selectedMode?.managementMode,
     hasParameters: plugin.parameters.length > 0,
@@ -218,12 +226,13 @@ function ConnectorBody({ plugin }: { plugin: PluginInfo }) {
                       defaultValue: "Save settings",
                     })}
             </Button>
-            {plugin.id === "discord" ? (
+            {configFormHint ? (
               <span className="text-xs-tight text-muted">
-                {t("settings.sections.connectors.discordAppIdHint", {
-                  defaultValue:
-                    "Application ID is optional; it is auto-resolved from the bot token when possible.",
-                })}
+                {configFormHint.key
+                  ? t(configFormHint.key, {
+                      defaultValue: configFormHint.fallback,
+                    })
+                  : configFormHint.fallback}
               </span>
             ) : null}
           </div>


### PR DESCRIPTION
Closes #12642 (arch-audit #12090 item 28: connector UI branching should be registry-driven).

## Problem
Connector UI branched on hardcoded plugin ids + mode-id string literals to decide which gateway surface / config hint to render, duplicating per-connector capability details outside their owning declarations:

- `plugin-view-connectors.tsx`: `plugin.id === "discord" && selectedMode === "managed"`, `plugin.id === "telegram" && selectedMode === "cloud-bot"`, `!elizaCloudConnected && plugin.id === "telegram"`, the managed-Discord picker gated on `plugin.id === "discord"`, and `cloudOAuthConnector.platform === "twitter"` selecting the OAuth-initiation method.
- `ConnectorsSection.tsx`: `plugin.id === "discord"` deciding whether to show the "Application ID is optional" config-form hint.

## Change
Consolidated per-connector metadata into the connector-mode registry and migrated the UI branches to registry lookups.

- **Gateway affordances**: added owner-declared `cloudGatewaySetup` (`"managed-agent-picker"` | `"webhook-notice"`) + `cloudGatewayProvider` to `ConnectorModeDeclaration`, seeded on the built-in discord `managed` and telegram `cloud-bot` modes. New helpers `getConnectorModeCloudGatewaySetup` / `connectorDeclaresCloudGatewaySetup` / `getConnectorManagedGatewayProvider` replace the duck-typed id+mode branches. The Discord managed picker is keyed on the declared `eliza-cloud-discord` provider, so a connector declaring `managed-agent-picker` **without** that provider is not misrouted through the Discord-specific provisioning/OAuth flow.
- **Config-form hint**: added owner-declared `configFormHint`/`configFormHintKey` (discord `bot` mode), resolved via `getConnectorModeConfigFormHint`, replacing the `plugin.id === "discord"` branch. Scoped to the declaring mode so the hint no longer leaks onto unrelated modes.
- **Cloud OAuth initiation**: declared `oauthInitiation: "twitter-endpoint"` on the `CLOUD_OAUTH_CONNECTORS` copy, replacing `platform === "twitter"` at the initiation call site.

Behavior-preserving for the built-in connectors; the picker/notice bodies (their copy + bespoke handlers) stay owned by the connector — only *which* affordance to show is now resolved from declared metadata.

## Tests
- `connector-mode-registry.test.ts`: seam tests proving a connector absent from ui source (fictional `acmegateway`) resolves its gateway/notice/hint affordances purely from its declaration, incl. a regression guard that a `managed-agent-picker` mode with no declared provider returns no Discord provisioning provider. Grep guards assert the `plugin.id === "discord"/"telegram"`, `selectedMode === "managed"/"cloud-bot"`, and `.platform === "twitter"` branches are gone from executable paths and the UI reads the declared helpers.
- `plugin-view-connectors.test.ts`: updated for the renamed `shouldRenderConnectorPluginConfig` predicate arg.
- Targeted vitest **23/23 green** (connector-mode-registry 13, plugin-view-connectors 5, ConnectorsSection.routing 5).
- `packages/ui` tsgo typecheck clean, biome clean.
- codex-reviewed: round-1 flagged a P2 (generic managed gateway routed through Discord provisioning) — fixed via the declared `cloudGatewayProvider`; round-2 clean, no findings.

No forbidden files touched (no vite.config/index.html/client-base/bun.lock/dist).

-- [sol-orch]