### PR TITLE
fix(#12537): add meeting adversarial QA gates

### DIFF
--- a/.github/issue-evidence/12537-adversarial-qa-gates.md
+++ b/.github/issue-evidence/12537-adversarial-qa-gates.md
@@ -1,0 +1,102 @@
+# Evidence for #12537 - Adversarial Fuzz and QA Gates
+
+## Code PR
+
+https://github.com/elizaOS/eliza/pull/13219
+
+## Human Follow-Up
+
+https://github.com/elizaOS/eliza/issues/13220
+
+## Agent-Completed Work
+
+- Added `adversarial_cases` to the meeting transcription proof manifest/report.
+- Required adversarial scenario classes for overlapping similar voices,
+  duplicate display names, borrowed-laptop identity, transcript prompt
+  injection, side conversations, sarcastic/negated action items,
+  music/noise false VAD, bot removal or permission revocation, audio deletion
+  with transcript retention, and malformed artifact shapes.
+- Required fuzz targets for canonical artifact schema, transcript span
+  alignment, RTTM/diarization segments, speaker profile lifecycle,
+  capture-source state machine, ASR media references, meeting-note grounding,
+  and importer response shapes.
+- Required deterministic fuzz seeds, expected invariants, evidence, metrics, and
+  failure policies for every adversarial case.
+- Added `qa_review_checklist` rows with machine-readable verdicts for
+  permission denied, capture stopped, speaker correction, delete audio, and
+  share/privacy state.
+- Made the registry scorer reject publishable real reports that omit
+  adversarial cases or QA checklist verdicts.
+- Added mocked fixture rows and docs for the adversarial/fuzz and QA contract.
+
+## Verification
+
+Commands run on 2026-07-04:
+
+```bash
+bun install
+```
+
+Result: completed after rebasing onto current `origin/develop`; artifact sync
+was already current at `2026-06-18.1`. Local Bun reordered `bun.lock`, which was
+restored because no dependency change is part of this issue.
+
+```bash
+PYTHONPATH=packages/benchmarks/meeting-transcription-proof pytest packages/benchmarks/meeting-transcription-proof/tests -q
+```
+
+Result: 32 tests passed.
+
+```bash
+pytest packages/benchmarks/tests/test_registry_scores.py -q
+```
+
+Result: 8 tests passed.
+
+```bash
+python -m py_compile packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/cli.py packages/benchmarks/registry/scores.py packages/benchmarks/meeting-transcription-proof/tests/test_cli.py packages/benchmarks/tests/test_registry_scores.py
+```
+
+Result: passed.
+
+```bash
+PYTHONPATH=packages/benchmarks/meeting-transcription-proof python -m elizaos_meeting_transcription_proof --lane mocked_plumbing --output /tmp/mtp-smoke-adversarial-qa-12537-current
+```
+
+Result: completed. The emitted report was manually inspected: kind
+`meeting_transcription_proof_report`, `adversarial_cases` count `10`, fuzz
+target count `8`, `qa_review_checklist` count `5`, score `1.0`, publishable
+`false`.
+
+```bash
+bun run --cwd packages/docs test
+```
+
+Result: 15 tests passed.
+
+```bash
+bun run --cwd packages/docs lint:check
+```
+
+Result: passed.
+
+```bash
+bun run verify
+```
+
+Result: failed outside this PR in `@elizaos/plugin-computeruse#lint`. The
+reported diagnostics were pre-existing non-null assertion violations, including
+`plugins/plugin-computeruse/src/__tests__/scene-builder.test.ts:146`,
+`plugins/plugin-computeruse/src/__tests__/scene-multimon-coords.test.ts:52`,
+`plugins/plugin-computeruse/src/__tests__/screen-state.test.ts:136`, and
+`plugins/plugin-computeruse/src/actor/brain.ts:276`. Biome auto-fixes in
+unrelated packages were restored before publishing this branch.
+
+## Not Captured By Agent
+
+N/A for live model trajectories and headful QA evidence in this code PR. The
+follow-up human issue must capture live-model scenario-runner reports and native
+JSONL trajectories for notes/action-item adversarial cases, headful screenshots
+and video for permission denied/capture stopped/correction/delete/share flows,
+frontend/backend/network logs, reviewed manual QA checklist output, and real
+artifact links.

--- a/packages/benchmarks/meeting-transcription-proof/AGENTS.md
+++ b/packages/benchmarks/meeting-transcription-proof/AGENTS.md
@@ -125,6 +125,19 @@ Rows track capture/privacy mode, covered meeting conditions, comparison
 metrics, artifact references, manual review status, evidence, and the failure
 policy.
 
+## Adversarial + QA Contract
+
+The real lane requires adversarial cases and QA review checklist rows.
+Adversarial cases cover canonical artifact schema fuzzing, transcript/span
+alignment, RTTM/diarization segment parsing, speaker profile lifecycle,
+capture-source state machines, ASR media refs, meeting-note grounding, and
+importer response shapes. Required scenario classes include prompt injection,
+negated action items, side conversations, duplicate names, borrowed laptops,
+permission revocation, audio deletion, false VAD, overlapping similar voices,
+and malformed artifact shapes. QA checklist rows must produce machine-readable
+verdicts for permission denied, capture stopped, speaker correction, delete
+audio, and share/privacy state.
+
 ## Evidence
 
 Mocked reports prove plumbing only. Real reports must reference reviewed audio,

--- a/packages/benchmarks/meeting-transcription-proof/CLAUDE.md
+++ b/packages/benchmarks/meeting-transcription-proof/CLAUDE.md
@@ -125,6 +125,19 @@ Rows track capture/privacy mode, covered meeting conditions, comparison
 metrics, artifact references, manual review status, evidence, and the failure
 policy.
 
+## Adversarial + QA Contract
+
+The real lane requires adversarial cases and QA review checklist rows.
+Adversarial cases cover canonical artifact schema fuzzing, transcript/span
+alignment, RTTM/diarization segment parsing, speaker profile lifecycle,
+capture-source state machines, ASR media refs, meeting-note grounding, and
+importer response shapes. Required scenario classes include prompt injection,
+negated action items, side conversations, duplicate names, borrowed laptops,
+permission revocation, audio deletion, false VAD, overlapping similar voices,
+and malformed artifact shapes. QA checklist rows must produce machine-readable
+verdicts for permission denied, capture stopped, speaker correction, delete
+audio, and share/privacy state.
+
 ## Evidence
 
 Mocked reports prove plumbing only. Real reports must reference reviewed audio,

--- a/packages/benchmarks/meeting-transcription-proof/README.md
+++ b/packages/benchmarks/meeting-transcription-proof/README.md
@@ -165,6 +165,17 @@ imported, and the current Eliza production baseline must always be present. Rows
 track capture/privacy mode, covered meeting conditions, comparison metrics,
 artifact references, manual review status, evidence, and the failure policy.
 
+Real manifests must include adversarial cases and QA review checklist rows.
+Adversarial cases cover canonical artifact schema fuzzing, transcript/span
+alignment, RTTM/diarization segment parsing, speaker profile lifecycle,
+capture-source state machines, ASR media refs, meeting-note grounding, and
+importer response shapes. Required scenario classes include prompt injection,
+negated action items, side conversations, duplicate names, borrowed laptops,
+permission revocation, audio deletion, false VAD, overlapping similar voices,
+and malformed artifact shapes. QA checklist rows must produce machine-readable
+verdicts for permission denied, capture stopped, speaker correction, delete
+audio, and share/privacy state.
+
 ## Fixture Manifest
 
 `fixtures/mock-meeting-manifest.json` describes the minimum canonical meeting

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/cli.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/cli.py
@@ -190,6 +190,57 @@ REQUIRED_BASELINE_METRICS = {
     "latency_ms",
     "privacy_capture_mode",
 }
+REQUIRED_FUZZ_TARGETS = {
+    "canonical_artifact_schema",
+    "transcript_span_alignment",
+    "rttm_diarization_segments",
+    "speaker_profile_lifecycle",
+    "capture_source_state_machine",
+    "asr_media_refs",
+    "meeting_notes_grounding",
+    "importer_response_shapes",
+}
+REQUIRED_ADVERSARIAL_CLASSES = {
+    "overlapping_similar_voices",
+    "duplicate_display_names",
+    "borrowed_laptop_identity",
+    "transcript_prompt_injection",
+    "side_conversation_not_action_item",
+    "sarcastic_or_negated_action_item",
+    "music_noise_false_vad",
+    "bot_removed_or_permission_revoked",
+    "audio_deleted_transcript_allowed",
+    "malformed_artifact_shape",
+}
+REQUIRED_ADVERSARIAL_FIELDS = {
+    "id",
+    "class",
+    "fuzz_targets",
+    "seed",
+    "scenario_id",
+    "expected_invariants",
+    "evidence",
+    "metrics",
+    "failure_policy",
+}
+REQUIRED_QA_FLOWS = {
+    "permission_denied",
+    "capture_stopped",
+    "speaker_correction",
+    "delete_audio",
+    "share_privacy_state",
+}
+REQUIRED_QA_FIELDS = {
+    "id",
+    "flow",
+    "surface",
+    "verdict",
+    "machine_verdict",
+    "reviewed_artifacts",
+    "evidence",
+    "failure_policy",
+}
+QA_VERDICTS = {"pass", "fail", "needs_human"}
 REQUIRED_SPEAKER_NAME_PROVENANCE_CASES = {
     "platform_roster_name",
     "calendar_attendee_name",
@@ -1100,6 +1151,147 @@ def _validate_baseline_comparisons(manifest: dict[str, Any]) -> tuple[list[dict[
     return sorted(normalized, key=lambda comparison: comparison["id"]), referenced_evidence
 
 
+def _validate_adversarial_cases(manifest: dict[str, Any]) -> tuple[list[dict[str, Any]], set[str]]:
+    adversarial_cases = manifest.get("adversarial_cases")
+    if not isinstance(adversarial_cases, list) or not adversarial_cases:
+        raise ValueError("adversarial_cases must be a non-empty array")
+
+    covered_classes: set[str] = set()
+    covered_targets: set[str] = set()
+    referenced_evidence: set[str] = set()
+    normalized: list[dict[str, Any]] = []
+
+    for index, case in enumerate(adversarial_cases):
+        if not isinstance(case, dict):
+            raise ValueError(f"adversarial_cases[{index}] must be an object")
+        missing_fields = REQUIRED_ADVERSARIAL_FIELDS - set(case)
+        if missing_fields:
+            raise ValueError(f"adversarial_cases[{index}] missing fields: {sorted(missing_fields)}")
+        case_id = case.get("id")
+        if not isinstance(case_id, str) or not case_id.strip():
+            raise ValueError(f"adversarial_cases[{index}].id must be a non-empty string")
+        case_class = case.get("class")
+        if not isinstance(case_class, str) or case_class not in REQUIRED_ADVERSARIAL_CLASSES:
+            raise ValueError(
+                f"adversarial_cases[{index}].class must be one of {sorted(REQUIRED_ADVERSARIAL_CLASSES)}"
+            )
+        fuzz_targets = _as_set(case.get("fuzz_targets"), field=f"adversarial_cases[{index}].fuzz_targets")
+        unknown_targets = fuzz_targets - REQUIRED_FUZZ_TARGETS
+        if unknown_targets:
+            raise ValueError(f"adversarial_cases[{index}] references unknown fuzz targets: {sorted(unknown_targets)}")
+        seed = case.get("seed")
+        if isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
+            raise ValueError(f"adversarial_cases[{index}].seed must be a non-negative integer")
+        scenario_id = case.get("scenario_id")
+        if not isinstance(scenario_id, str) or not scenario_id.strip():
+            raise ValueError(f"adversarial_cases[{index}].scenario_id must be a non-empty string")
+        expected_invariants = _as_set(
+            case.get("expected_invariants"), field=f"adversarial_cases[{index}].expected_invariants"
+        )
+        if not expected_invariants:
+            raise ValueError(f"adversarial_cases[{index}].expected_invariants must be non-empty")
+        evidence = _as_set(case.get("evidence"), field=f"adversarial_cases[{index}].evidence")
+        unknown_evidence = evidence - REQUIRED_EVIDENCE
+        if unknown_evidence:
+            raise ValueError(f"adversarial_cases[{index}] references unknown evidence: {sorted(unknown_evidence)}")
+        metrics = _as_set(case.get("metrics"), field=f"adversarial_cases[{index}].metrics")
+        unknown_metrics = metrics - KNOWN_METRICS
+        if unknown_metrics:
+            raise ValueError(f"adversarial_cases[{index}] references unknown metrics: {sorted(unknown_metrics)}")
+        failure_policy = case.get("failure_policy")
+        if not isinstance(failure_policy, str) or not failure_policy.strip():
+            raise ValueError(f"adversarial_cases[{index}].failure_policy must be a non-empty string")
+
+        covered_classes.add(case_class)
+        covered_targets.update(fuzz_targets)
+        referenced_evidence.update(evidence)
+        normalized.append(
+            {
+                "id": case_id,
+                "class": case_class,
+                "fuzz_targets": sorted(fuzz_targets),
+                "seed": seed,
+                "scenario_id": scenario_id,
+                "expected_invariants": sorted(expected_invariants),
+                "evidence": sorted(evidence),
+                "metrics": sorted(metrics),
+                "failure_policy": failure_policy,
+            }
+        )
+
+    missing_classes = REQUIRED_ADVERSARIAL_CLASSES - covered_classes
+    if missing_classes:
+        raise ValueError(f"adversarial_cases missing classes: {sorted(missing_classes)}")
+    missing_targets = REQUIRED_FUZZ_TARGETS - covered_targets
+    if missing_targets:
+        raise ValueError(f"adversarial_cases missing fuzz targets: {sorted(missing_targets)}")
+    return sorted(normalized, key=lambda case: case["id"]), referenced_evidence
+
+
+def _validate_qa_review_checklist(manifest: dict[str, Any]) -> tuple[list[dict[str, Any]], set[str]]:
+    qa_items = manifest.get("qa_review_checklist")
+    if not isinstance(qa_items, list) or not qa_items:
+        raise ValueError("qa_review_checklist must be a non-empty array")
+
+    covered_flows: set[str] = set()
+    referenced_evidence: set[str] = set()
+    normalized: list[dict[str, Any]] = []
+
+    for index, item in enumerate(qa_items):
+        if not isinstance(item, dict):
+            raise ValueError(f"qa_review_checklist[{index}] must be an object")
+        missing_fields = REQUIRED_QA_FIELDS - set(item)
+        if missing_fields:
+            raise ValueError(f"qa_review_checklist[{index}] missing fields: {sorted(missing_fields)}")
+        item_id = item.get("id")
+        if not isinstance(item_id, str) or not item_id.strip():
+            raise ValueError(f"qa_review_checklist[{index}].id must be a non-empty string")
+        flow = item.get("flow")
+        if not isinstance(flow, str) or flow not in REQUIRED_QA_FLOWS:
+            raise ValueError(f"qa_review_checklist[{index}].flow must be one of {sorted(REQUIRED_QA_FLOWS)}")
+        surface = item.get("surface")
+        if not isinstance(surface, str) or not surface.strip():
+            raise ValueError(f"qa_review_checklist[{index}].surface must be a non-empty string")
+        verdict = item.get("verdict")
+        if not isinstance(verdict, str) or verdict not in QA_VERDICTS:
+            raise ValueError(f"qa_review_checklist[{index}].verdict must be one of {sorted(QA_VERDICTS)}")
+        machine_verdict = item.get("machine_verdict")
+        if not isinstance(machine_verdict, str) or machine_verdict not in QA_VERDICTS:
+            raise ValueError(f"qa_review_checklist[{index}].machine_verdict must be one of {sorted(QA_VERDICTS)}")
+        reviewed_artifacts = _as_set(
+            item.get("reviewed_artifacts"), field=f"qa_review_checklist[{index}].reviewed_artifacts"
+        )
+        if not reviewed_artifacts:
+            raise ValueError(f"qa_review_checklist[{index}].reviewed_artifacts must be non-empty")
+        evidence = _as_set(item.get("evidence"), field=f"qa_review_checklist[{index}].evidence")
+        unknown_evidence = evidence - REQUIRED_EVIDENCE
+        if unknown_evidence:
+            raise ValueError(f"qa_review_checklist[{index}] references unknown evidence: {sorted(unknown_evidence)}")
+        failure_policy = item.get("failure_policy")
+        if not isinstance(failure_policy, str) or not failure_policy.strip():
+            raise ValueError(f"qa_review_checklist[{index}].failure_policy must be a non-empty string")
+
+        covered_flows.add(flow)
+        referenced_evidence.update(evidence)
+        normalized.append(
+            {
+                "id": item_id,
+                "flow": flow,
+                "surface": surface,
+                "verdict": verdict,
+                "machine_verdict": machine_verdict,
+                "reviewed_artifacts": sorted(reviewed_artifacts),
+                "evidence": sorted(evidence),
+                "failure_policy": failure_policy,
+            }
+        )
+
+    missing_flows = REQUIRED_QA_FLOWS - covered_flows
+    if missing_flows:
+        raise ValueError(f"qa_review_checklist missing flows: {sorted(missing_flows)}")
+    return sorted(normalized, key=lambda item: item["id"]), referenced_evidence
+
+
 def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Path) -> dict[str, Any]:
     if lane not in LANES:
         raise ValueError(f"lane must be one of {sorted(LANES)}")
@@ -1161,6 +1353,8 @@ def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Pat
     audio_visual_cases, audio_visual_evidence_types = _validate_audio_visual_cases(manifest)
     generated_artifact_scores = _validate_generated_artifact_scores(manifest)
     baseline_comparisons, baseline_evidence_types = _validate_baseline_comparisons(manifest)
+    adversarial_cases, adversarial_evidence_types = _validate_adversarial_cases(manifest)
+    qa_review_checklist, qa_evidence_types = _validate_qa_review_checklist(manifest)
 
     metric_values = _validate_metrics(manifest.get("metrics"), lane=lane)
 
@@ -1194,6 +1388,22 @@ def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Pat
         missing_baseline_evidence = baseline_evidence_types - set(evidence_files)
         if missing_baseline_evidence:
             raise ValueError(f"baseline comparison evidence files missing: {sorted(missing_baseline_evidence)}")
+        missing_adversarial_evidence = adversarial_evidence_types - set(evidence_files)
+        if missing_adversarial_evidence:
+            raise ValueError(f"adversarial case evidence files missing: {sorted(missing_adversarial_evidence)}")
+        missing_qa_evidence = qa_evidence_types - set(evidence_files)
+        if missing_qa_evidence:
+            raise ValueError(f"QA checklist evidence files missing: {sorted(missing_qa_evidence)}")
+        failing_qa = [
+            item["id"]
+            for item in qa_review_checklist
+            if item["verdict"] != "pass" or item["machine_verdict"] != "pass"
+        ]
+        if failing_qa:
+            raise ValueError(
+                "qa_review_checklist real_product rows must have pass verdicts: "
+                f"{sorted(failing_qa)}"
+            )
 
     return {
         "surfaces": sorted(surfaces),
@@ -1208,6 +1418,8 @@ def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Pat
         "audio_visual_cases": audio_visual_cases,
         "generated_artifact_scores": generated_artifact_scores,
         "baseline_comparisons": baseline_comparisons,
+        "adversarial_cases": adversarial_cases,
+        "qa_review_checklist": qa_review_checklist,
         "metrics": metric_values,
         "evidence_files": evidence_files,
         "provider_mode": provider_mode,

--- a/packages/benchmarks/meeting-transcription-proof/fixtures/mock-meeting-manifest.json
+++ b/packages/benchmarks/meeting-transcription-proof/fixtures/mock-meeting-manifest.json
@@ -866,6 +866,170 @@
       "failure_policy": "not-run open-source systems require installation reason and cannot count as pass"
     }
   ],
+  "adversarial_cases": [
+    {
+      "id": "adv_overlapping_similar_voices",
+      "class": "overlapping_similar_voices",
+      "fuzz_targets": ["transcript_span_alignment", "rttm_diarization_segments"],
+      "seed": 12537001,
+      "scenario_id": "overlapped_speech",
+      "expected_invariants": ["non_negative_durations", "overlap_retained", "speaker_ids_stable"],
+      "evidence": ["audio", "metrics", "speaker_profile_artifact"],
+      "metrics": ["der", "jer", "speaker_attributed_wer"],
+      "failure_policy": "minimize to seed and attach diarization/transcript span diff"
+    },
+    {
+      "id": "adv_duplicate_display_names",
+      "class": "duplicate_display_names",
+      "fuzz_targets": ["speaker_profile_lifecycle"],
+      "seed": 12537002,
+      "scenario_id": "known_speaker_recognition",
+      "expected_invariants": ["display_name_not_identity", "manual_correction_required_before_merge"],
+      "evidence": ["speaker_profile_artifact", "transcript_artifact", "metrics"],
+      "metrics": ["speaker_identity_quality", "voice_profile_false_accept_rate"],
+      "failure_policy": "minimize to seed and attach speaker profile merge/split trace"
+    },
+    {
+      "id": "adv_borrowed_laptop_identity",
+      "class": "borrowed_laptop_identity",
+      "fuzz_targets": ["speaker_profile_lifecycle", "capture_source_state_machine"],
+      "seed": 12537003,
+      "scenario_id": "shared_room_microphone",
+      "expected_invariants": ["device_owner_not_assumed_speaker", "uncertain_room_label_allowed"],
+      "evidence": ["audio", "screenshots", "speaker_profile_artifact"],
+      "metrics": ["speaker_identity_quality", "active_speaker_accuracy"],
+      "failure_policy": "minimize to seed and attach identity-binding decision trace"
+    },
+    {
+      "id": "adv_transcript_prompt_injection",
+      "class": "transcript_prompt_injection",
+      "fuzz_targets": ["meeting_notes_grounding", "canonical_artifact_schema"],
+      "seed": 12537004,
+      "scenario_id": "cloud_agent_capture",
+      "expected_invariants": ["quoted_injection_not_instruction", "notes_grounded_to_spans"],
+      "evidence": ["model_trajectories", "transcript_artifact", "metrics"],
+      "metrics": ["notes_factuality", "action_item_extraction"],
+      "failure_policy": "minimize to seed and attach model trajectory plus offending span"
+    },
+    {
+      "id": "adv_side_conversation",
+      "class": "side_conversation_not_action_item",
+      "fuzz_targets": ["meeting_notes_grounding"],
+      "seed": 12537005,
+      "scenario_id": "google_meet_bot",
+      "expected_invariants": ["side_conversation_not_promoted", "action_items_have_directive_support"],
+      "evidence": ["model_trajectories", "transcript_artifact", "metrics"],
+      "metrics": ["notes_factuality", "action_item_extraction"],
+      "failure_policy": "minimize to seed and attach unsupported action-item report"
+    },
+    {
+      "id": "adv_negated_action_item",
+      "class": "sarcastic_or_negated_action_item",
+      "fuzz_targets": ["meeting_notes_grounding"],
+      "seed": 12537006,
+      "scenario_id": "zoom_bot",
+      "expected_invariants": ["negated_task_not_action_item", "sarcasm_requires_review"],
+      "evidence": ["model_trajectories", "transcript_artifact", "metrics"],
+      "metrics": ["notes_factuality", "action_item_extraction"],
+      "failure_policy": "minimize to seed and attach note/action grounding diff"
+    },
+    {
+      "id": "adv_music_noise_false_vad",
+      "class": "music_noise_false_vad",
+      "fuzz_targets": ["capture_source_state_machine", "transcript_span_alignment"],
+      "seed": 12537007,
+      "scenario_id": "speech_over_music",
+      "expected_invariants": ["music_not_speaker", "silence_windows_not_transcribed"],
+      "evidence": ["audio", "metrics", "transcript_artifact"],
+      "metrics": ["wer", "cer", "end_of_turn_latency_ms"],
+      "failure_policy": "minimize to seed and attach VAD window report"
+    },
+    {
+      "id": "adv_bot_removed_permission_revoked",
+      "class": "bot_removed_or_permission_revoked",
+      "fuzz_targets": ["capture_source_state_machine", "asr_media_refs"],
+      "seed": 12537008,
+      "scenario_id": "zoom_bot",
+      "expected_invariants": ["terminal_error_classified", "partial_transcript_marked_partial"],
+      "evidence": ["backend_logs", "frontend_logs", "transcript_artifact"],
+      "metrics": ["consent_retention_quality"],
+      "failure_policy": "minimize to seed and attach state transition log"
+    },
+    {
+      "id": "adv_audio_deleted_transcript_allowed",
+      "class": "audio_deleted_transcript_allowed",
+      "fuzz_targets": ["asr_media_refs", "canonical_artifact_schema"],
+      "seed": 12537009,
+      "scenario_id": "transcript_sharing_export_delete",
+      "expected_invariants": ["audio_replay_invalidated", "allowed_transcript_refs_survive"],
+      "evidence": ["retention_artifact", "screenshots", "transcript_artifact"],
+      "metrics": ["consent_retention_quality"],
+      "failure_policy": "minimize to seed and attach retention/delete artifact"
+    },
+    {
+      "id": "adv_malformed_artifact_shape",
+      "class": "malformed_artifact_shape",
+      "fuzz_targets": ["canonical_artifact_schema", "importer_response_shapes"],
+      "seed": 12537010,
+      "scenario_id": "hybrid_local_cloud",
+      "expected_invariants": ["schema_errors_are_actionable", "negative_durations_rejected"],
+      "evidence": ["backend_logs", "metrics", "transcript_artifact"],
+      "metrics": ["transcript_quality", "diarization_quality"],
+      "failure_policy": "minimize to seed and attach malformed artifact fixture"
+    }
+  ],
+  "qa_review_checklist": [
+    {
+      "id": "qa_permission_denied",
+      "flow": "permission_denied",
+      "surface": "zoom_bot_free",
+      "verdict": "needs_human",
+      "machine_verdict": "pass",
+      "reviewed_artifacts": ["permission-denied-screenshot", "frontend-console-log"],
+      "evidence": ["screenshots", "frontend_logs"],
+      "failure_policy": "permission denial must be visible and recoverable before capture starts"
+    },
+    {
+      "id": "qa_capture_stopped",
+      "flow": "capture_stopped",
+      "surface": "google_meet_bot_free",
+      "verdict": "needs_human",
+      "machine_verdict": "pass",
+      "reviewed_artifacts": ["capture-stop-video", "partial-transcript-artifact"],
+      "evidence": ["video", "transcript_artifact", "frontend_logs"],
+      "failure_policy": "capture stop must finalize partial transcript and mark audio completeness"
+    },
+    {
+      "id": "qa_speaker_correction",
+      "flow": "speaker_correction",
+      "surface": "hybrid_local_cloud",
+      "verdict": "needs_human",
+      "machine_verdict": "pass",
+      "reviewed_artifacts": ["speaker-correction-screenshot", "speaker-profile-artifact"],
+      "evidence": ["screenshots", "speaker_profile_artifact"],
+      "failure_policy": "manual correction must be auditable and reversible"
+    },
+    {
+      "id": "qa_delete_audio",
+      "flow": "delete_audio",
+      "surface": "on_device",
+      "verdict": "needs_human",
+      "machine_verdict": "pass",
+      "reviewed_artifacts": ["retention-delete-proof", "transcript-after-delete"],
+      "evidence": ["retention_artifact", "transcript_artifact"],
+      "failure_policy": "deleting audio must invalidate replay without deleting allowed transcript text"
+    },
+    {
+      "id": "qa_share_privacy_state",
+      "flow": "share_privacy_state",
+      "surface": "cloud_agent",
+      "verdict": "needs_human",
+      "machine_verdict": "pass",
+      "reviewed_artifacts": ["share-dialog-screenshot", "consent-record"],
+      "evidence": ["screenshots", "consent_record", "backend_logs"],
+      "failure_policy": "share controls must distinguish transcript, notes, audio, and generated artifacts"
+    }
+  ],
   "metrics": {
     "transcript_quality": 1.0,
     "diarization_quality": 1.0,

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_cli.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_cli.py
@@ -43,6 +43,14 @@ def _fixture_baseline_comparisons() -> list[object]:
     return json.loads(FIXTURE_MANIFEST.read_text(encoding="utf-8"))["baseline_comparisons"]
 
 
+def _fixture_adversarial_cases() -> list[object]:
+    return json.loads(FIXTURE_MANIFEST.read_text(encoding="utf-8"))["adversarial_cases"]
+
+
+def _fixture_qa_review_checklist() -> list[object]:
+    return json.loads(FIXTURE_MANIFEST.read_text(encoding="utf-8"))["qa_review_checklist"]
+
+
 def _base_manifest(provider_mode: str = "real_zoom_meet") -> dict[str, object]:
     return {
         "provider_mode": provider_mode,
@@ -72,6 +80,8 @@ def _base_manifest(provider_mode: str = "real_zoom_meet") -> dict[str, object]:
         "audio_visual_cases": _fixture_audio_visual_cases(),
         "generated_artifact_scores": _fixture_generated_artifact_scores(),
         "baseline_comparisons": _fixture_baseline_comparisons(),
+        "adversarial_cases": _fixture_adversarial_cases(),
+        "qa_review_checklist": _fixture_qa_review_checklist(),
         "metrics": {
             "transcript_quality": 0.91,
             "diarization_quality": 0.82,
@@ -132,6 +142,8 @@ def test_mocked_plumbing_fixture_is_not_publishable() -> None:
     assert len(report["audio_visual_cases"]) == len(_fixture_audio_visual_cases())
     assert len(report["generated_artifact_scores"]) == len(_fixture_generated_artifact_scores())
     assert len(report["baseline_comparisons"]) == len(_fixture_baseline_comparisons())
+    assert len(report["adversarial_cases"]) == len(_fixture_adversarial_cases())
+    assert len(report["qa_review_checklist"]) == len(_fixture_qa_review_checklist())
 
 
 def test_real_lane_requires_non_mock_provider(tmp_path: Path) -> None:
@@ -611,6 +623,115 @@ def test_baseline_comparisons_require_open_source_run_or_import(tmp_path: Path) 
         build_report(lane="real_product", manifest_path=manifest)
 
 
+def test_real_lane_requires_adversarial_cases(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    manifest_data.pop("adversarial_cases")
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="adversarial_cases must be a non-empty array"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_adversarial_cases_require_all_classes(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    manifest_data["adversarial_cases"] = [
+        case
+        for case in _fixture_adversarial_cases()
+        if isinstance(case, dict) and case.get("class") != "transcript_prompt_injection"
+    ]
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="adversarial_cases missing classes"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_adversarial_cases_may_only_reference_known_fuzz_targets(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    cases = _fixture_adversarial_cases()
+    assert isinstance(cases[0], dict)
+    cases[0] = {**cases[0], "fuzz_targets": ["canonical_artifact_schema", "imaginary_fuzzer"]}
+    manifest_data["adversarial_cases"] = cases
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="unknown fuzz targets"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_adversarial_case_seed_must_be_non_negative_integer(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    cases = _fixture_adversarial_cases()
+    assert isinstance(cases[0], dict)
+    cases[0] = {**cases[0], "seed": -1}
+    manifest_data["adversarial_cases"] = cases
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="seed must be a non-negative integer"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_real_lane_requires_qa_review_checklist(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    manifest_data.pop("qa_review_checklist")
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="qa_review_checklist must be a non-empty array"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_qa_review_checklist_requires_all_flows(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    manifest_data["qa_review_checklist"] = [
+        item for item in _fixture_qa_review_checklist() if isinstance(item, dict) and item.get("flow") != "delete_audio"
+    ]
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="qa_review_checklist missing flows"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_qa_review_checklist_verdicts_are_machine_readable(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    items = _fixture_qa_review_checklist()
+    assert isinstance(items[0], dict)
+    items[0] = {**items[0], "machine_verdict": "maybe"}
+    manifest_data["qa_review_checklist"] = items
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="machine_verdict must be one of"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_real_lane_requires_passing_qa_review_verdicts(tmp_path: Path) -> None:
+    evidence_names = [
+        "audio",
+        "video",
+        "backend_logs",
+        "frontend_logs",
+        "screenshots",
+        "metrics",
+        "model_trajectories",
+        "transcript_artifact",
+        "speaker_profile_artifact",
+        "consent_record",
+        "retention_artifact",
+    ]
+    evidence = {}
+    for name in evidence_names:
+        filename = f"{name}.txt"
+        (tmp_path / filename).write_text(name, encoding="utf-8")
+        evidence[name] = filename
+    manifest_data = _base_manifest()
+    items = _fixture_qa_review_checklist()
+    assert isinstance(items[0], dict)
+    items[0] = {**items[0], "machine_verdict": "fail"}
+    manifest_data["qa_review_checklist"] = items
+    manifest_data["evidence"] = evidence
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="pass verdicts"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
 def test_real_lane_scores_lowest_required_quality_and_resolves_evidence(tmp_path: Path) -> None:
     evidence_names = [
         "audio",
@@ -631,6 +752,12 @@ def test_real_lane_scores_lowest_required_quality_and_resolves_evidence(tmp_path
         (tmp_path / filename).write_text(name, encoding="utf-8")
         evidence[name] = filename
     manifest_data = _base_manifest()
+    qa_review_checklist = _fixture_qa_review_checklist()
+    manifest_data["qa_review_checklist"] = [
+        {**item, "verdict": "pass", "machine_verdict": "pass"}
+        for item in qa_review_checklist
+        if isinstance(item, dict)
+    ]
     manifest_data["evidence"] = evidence
     manifest = _write_manifest(tmp_path, manifest_data)
 
@@ -707,6 +834,18 @@ def test_real_lane_scores_lowest_required_quality_and_resolves_evidence(tmp_path
         for row in report["baseline_comparisons"]
     )
     assert any(row["comparison_type"] == "internal_baseline" for row in report["baseline_comparisons"])
+    assert {case["class"] for case in report["adversarial_cases"]} >= {
+        "transcript_prompt_injection",
+        "malformed_artifact_shape",
+        "audio_deleted_transcript_allowed",
+    }
+    assert {item["flow"] for item in report["qa_review_checklist"]} == {
+        "permission_denied",
+        "capture_stopped",
+        "speaker_correction",
+        "delete_audio",
+        "share_privacy_state",
+    }
     assert all(dataset["version"] for dataset in report["dataset_sources"])
     assert all(dataset["checksum"] for dataset in report["dataset_sources"])
     assert all(dataset["sample_count"] > 0 for dataset in report["dataset_sources"])

--- a/packages/benchmarks/registry/scores.py
+++ b/packages/benchmarks/registry/scores.py
@@ -1016,6 +1016,19 @@ def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtrac
                 and comparison.get("comparison_type") == "internal_baseline"
             ):
                 internal_baseline_count += 1
+    adversarial_cases = root.get("adversarial_cases")
+    adversarial_count = len(adversarial_cases) if isinstance(adversarial_cases, list) else 0
+    qa_items = root.get("qa_review_checklist")
+    qa_count = len(qa_items) if isinstance(qa_items, list) else 0
+    qa_machine_pass_count = 0
+    qa_human_pass_count = 0
+    if isinstance(qa_items, list):
+        qa_machine_pass_count = sum(
+            1 for item in qa_items if isinstance(item, dict) and item.get("machine_verdict") == "pass"
+        )
+        qa_human_pass_count = sum(
+            1 for item in qa_items if isinstance(item, dict) and item.get("verdict") == "pass"
+        )
     publishable = root.get("publishable") is True
     if lane == "real_product":
         if not publishable:
@@ -1064,6 +1077,12 @@ def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtrac
             raise ValueError("meeting_transcription_proof: real lane requires an open-source baseline run")
         if internal_baseline_count < 1:
             raise ValueError("meeting_transcription_proof: real lane requires current Eliza baseline")
+        if adversarial_count < 10:
+            raise ValueError("meeting_transcription_proof: real lane requires adversarial cases")
+        if qa_count < 5:
+            raise ValueError("meeting_transcription_proof: real lane requires QA checklist verdicts")
+        if qa_machine_pass_count != qa_count or qa_human_pass_count != qa_count:
+            raise ValueError("meeting_transcription_proof: real lane requires passing QA checklist verdicts")
     elif publishable:
         raise ValueError("meeting_transcription_proof: mocked lane cannot be publishable")
 
@@ -1088,6 +1107,10 @@ def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtrac
             "baseline_comparison_count": baseline_count,
             "open_source_baseline_run_count": open_source_run_count,
             "internal_baseline_count": internal_baseline_count,
+            "adversarial_case_count": adversarial_count,
+            "qa_checklist_count": qa_count,
+            "qa_machine_pass_count": qa_machine_pass_count,
+            "qa_human_pass_count": qa_human_pass_count,
             "transcript_quality": metrics.get("transcript_quality") or 0,
             "diarization_quality": metrics.get("diarization_quality") or 0,
             "speaker_identity_quality": metrics.get("speaker_identity_quality") or 0,

--- a/packages/benchmarks/tests/test_registry_scores.py
+++ b/packages/benchmarks/tests/test_registry_scores.py
@@ -62,6 +62,14 @@ def _meeting_baseline_comparisons() -> list[dict[str, object]]:
     ]
 
 
+def _meeting_adversarial_cases() -> list[dict[str, object]]:
+    return [{"id": f"adv_{index}", "class": f"class_{index}"} for index in range(10)]
+
+
+def _meeting_qa_checklist() -> list[dict[str, object]]:
+    return [{"id": f"qa_{index}", "verdict": "pass", "machine_verdict": "pass"} for index in range(5)]
+
+
 def test_hermes_env_placeholder_only_score_is_not_publishable() -> None:
     with pytest.raises(ValueError, match="placeholder-only"):
         _score_from_hermes_env_json(
@@ -221,6 +229,8 @@ def _meeting_transcription_real_report() -> dict[str, object]:
         "audio_visual_cases": [{} for _ in range(7)],
         "generated_artifact_scores": _meeting_generated_artifact_scores(),
         "baseline_comparisons": _meeting_baseline_comparisons(),
+        "adversarial_cases": _meeting_adversarial_cases(),
+        "qa_review_checklist": _meeting_qa_checklist(),
     }
 
 
@@ -309,6 +319,30 @@ def test_meeting_transcription_real_lane_requires_current_eliza_baseline() -> No
         _score_from_meeting_transcription_proof_json(report)
 
 
+def test_meeting_transcription_real_lane_requires_adversarial_and_qa_rows() -> None:
+    report = _meeting_transcription_real_report()
+    report["adversarial_cases"] = []
+
+    with pytest.raises(ValueError, match="adversarial cases"):
+        _score_from_meeting_transcription_proof_json(report)
+
+    report = _meeting_transcription_real_report()
+    report["qa_review_checklist"] = _meeting_qa_checklist()[:4]
+
+    with pytest.raises(ValueError, match="QA checklist"):
+        _score_from_meeting_transcription_proof_json(report)
+
+
+def test_meeting_transcription_real_lane_requires_passing_qa_verdicts() -> None:
+    report = _meeting_transcription_real_report()
+    qa = _meeting_qa_checklist()
+    qa[0] = {**qa[0], "machine_verdict": "fail"}
+    report["qa_review_checklist"] = qa
+
+    with pytest.raises(ValueError, match="passing QA checklist"):
+        _score_from_meeting_transcription_proof_json(report)
+
+
 def test_meeting_transcription_real_lane_score_is_publishable_with_evidence() -> None:
     extraction = _score_from_meeting_transcription_proof_json(_meeting_transcription_real_report())
 
@@ -325,3 +359,7 @@ def test_meeting_transcription_real_lane_score_is_publishable_with_evidence() ->
     assert extraction.metrics["baseline_comparison_count"] == 7
     assert extraction.metrics["open_source_baseline_run_count"] == 1
     assert extraction.metrics["internal_baseline_count"] == 1
+    assert extraction.metrics["adversarial_case_count"] == 10
+    assert extraction.metrics["qa_checklist_count"] == 5
+    assert extraction.metrics["qa_machine_pass_count"] == 5
+    assert extraction.metrics["qa_human_pass_count"] == 5

--- a/packages/docs/meeting-transcription-benchmark-plan.md
+++ b/packages/docs/meeting-transcription-benchmark-plan.md
@@ -63,6 +63,17 @@ WhisperX + pyannote, NeMo Sortformer, and `eliza_current_baseline`. Commercial
 systems that cannot be run are `not_run` with a reason, never counted as pass.
 At least one open-source row must be run or imported.
 
+Every manifest must also enumerate adversarial cases and QA review checklist
+rows. The adversarial section covers canonical artifact schema fuzzing,
+transcript/span alignment, RTTM/diarization parsing, speaker profile lifecycle,
+capture-source state machines, ASR media references, meeting-note grounding,
+and importer response shapes. Required scenario classes include prompt
+injection, negated action items, side conversations, duplicate names, borrowed
+laptops, permission revocation, audio deletion, false VAD, overlapping similar
+voices, and malformed artifacts. QA checklist rows cover permission denied,
+capture stopped, speaker correction, delete audio, and share/privacy state with
+machine-readable verdicts.
+
 ## Registry Contract
 
 The integrated benchmark id is `meeting_transcription_proof`.
@@ -92,6 +103,10 @@ The real lane refuses non-evidence reports. It requires:
 - baseline comparison coverage for required external product, open-source, and
   internal baseline rows, with at least one open-source run/import and the
   current Eliza production baseline;
+- adversarial case coverage for required fuzz targets and scenario classes,
+  including minimized seeds and failure policies;
+- QA checklist coverage for permission denied, capture stopped, correction,
+  delete audio, and share/privacy state with machine-readable verdicts;
 - all required scenario coverage IDs;
 - each scenario's evidence references are valid and covered by the manifest's
   evidence inventory;
@@ -144,3 +159,5 @@ without reading code:
 - baseline comparison artifacts for each compared system, including terms/usage
   notes for commercial imports and manual review notes for at least one
   transcript and one notes artifact per compared system.
+- fuzz reports with seeds, minimized repro inputs, and manual QA checklist
+  output with reviewed artifact links.


### PR DESCRIPTION
## Summary

- Add manifest/report validation for adversarial meeting cases and deterministic fuzz targets.
- Add machine-readable QA checklist rows for permission-denied, capture-stopped, speaker-correction, delete-audio, and share/privacy flows.
- Make registry scoring reject publishable real-lane reports that omit adversarial cases or QA checklist coverage.
- Document the new adversarial/fuzz/QA evidence contract and add tracked issue evidence.

## Human follow-up

- #13220 tracks the remaining human-run live-model trajectories and headful QA evidence.

## Verification

- `bun install` completed after rebasing onto current `origin/develop`; artifact sync was already current at `2026-06-18.1`. Local Bun reordered `bun.lock`, which was restored because this PR has no dependency changes.
- `PYTHONPATH=packages/benchmarks/meeting-transcription-proof pytest packages/benchmarks/meeting-transcription-proof/tests -q` -> 32 passed.
- `pytest packages/benchmarks/tests/test_registry_scores.py -q` -> 8 passed.
- `python -m py_compile packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/cli.py packages/benchmarks/registry/scores.py packages/benchmarks/meeting-transcription-proof/tests/test_cli.py packages/benchmarks/tests/test_registry_scores.py` -> passed.
- `PYTHONPATH=packages/benchmarks/meeting-transcription-proof python -m elizaos_meeting_transcription_proof --lane mocked_plumbing --output /tmp/mtp-smoke-adversarial-qa-12537-current` -> report manually inspected: 10 adversarial cases, 8 fuzz targets, 5 QA rows, score `1.0`, publishable `false`.
- `bun run --cwd packages/docs test` -> 15 passed.
- `bun run --cwd packages/docs lint:check` -> passed.
- `bun run verify` -> failed outside this PR in `@elizaos/plugin-computeruse#lint` on existing non-null assertion diagnostics, including `plugins/plugin-computeruse/src/__tests__/scene-builder.test.ts:146`, `plugins/plugin-computeruse/src/__tests__/scene-multimon-coords.test.ts:52`, `plugins/plugin-computeruse/src/__tests__/screen-state.test.ts:136`, and `plugins/plugin-computeruse/src/actor/brain.ts:276`. Biome auto-fixes in unrelated packages were restored before publishing.

## Evidence

- `.github/issue-evidence/12537-adversarial-qa-gates.md`
