### PR TITLE
docs(#12242): B12 header — health-bridge google-fit-sleep test header hoist (comment-only)

### DIFF
--- a/plugins/plugin-health/src/health-bridge/health-bridge.google-fit-sleep.test.ts
+++ b/plugins/plugin-health/src/health-bridge/health-bridge.google-fit-sleep.test.ts
@@ -1,10 +1,8 @@
-import { logger } from "@elizaos/core";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-import { getDailySummary, getDataPoints } from "./health-bridge.js";
-
 /**
- * Regression coverage for #12798 (fallback-slop LifeOps/health):
+ * Real-fetch regression coverage for the health-bridge Google Fit REST
+ * fallback: spies on the global `fetch` and drives the actual
+ * `getDailySummary`/`getDataPoints` code paths (no connector stub) to pin the
+ * fix for #12798 (fallback-slop LifeOps/health).
  *
  * Google Fit daily summaries fetch steps/active-minutes with one aggregate
  * call and sleep with a second, dedicated call. Previously a failure of the
@@ -17,6 +15,10 @@ import { getDailySummary, getDataPoints } from "./health-bridge.js";
  * observable, and omits those days from sleep data-point series instead of
  * emitting fabricated zero-sleep points.
  */
+import { logger } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getDailySummary, getDataPoints } from "./health-bridge.js";
 
 type FetchArgs = Parameters<typeof fetch>;
 


### PR DESCRIPTION
## What landed

Comment-only. Adds a top-of-file `/** … */` header to the one remaining headerless file in the W1-G slice subtrees:

- `plugins/plugin-health/src/health-bridge/health-bridge.google-fit-sleep.test.ts` — the file already carried a `/** … */` regression-rationale block, but it sat **after** the imports, so the header self-audit (first meaningful line must be `/*` or `//`) flagged it. This PR **relocates** that block above the imports so it is the file header, and leads the first sentence with the surface under test and harness realness (spies the global `fetch` and drives the real `getDailySummary` / `getDataPoints` code paths in `health-bridge.ts` — no connector stub). No prose was lost; the code token stream is byte-for-byte unchanged.

## Why this slice is one file (not ~48)

W1-G was scoped as the B12 comment tails for calendar/inbox/health/scheduling/relationships (28 files) plus the PA `src/lifeops` + `src/website-blocker` remnants (18 files). Between the brief being written and this run, `develop` advanced from `da8b55c8a` to `b24dec8312`:

- The 18 PA `src/lifeops` + `src/website-blocker` headers from this lane's prior (killed) attempt **already merged upstream** — the rebase dropped that commit as "patch contents already upstream."
- All 28 calendar/inbox/health/scheduling/relationships tail files **received headers via other merged slices**. A fresh headerless self-audit (the issue's `awk` one-liner) over every W1-G subtree on `b24dec8312` returns exactly one file: the health-bridge test above — a file that did not exist in the original stale list.
- The two `src/activity-profile/*` files the brief told me to defer for the concurrent code wave **also received headers upstream** (`// …` line comments), so there is nothing left to defer.

Post-change, the self-audit over all W1-G subtrees (`plugin-calendar`, `plugin-inbox`, `plugin-health`, `plugin-scheduling`, `plugin-relationships`, `plugin-personal-assistant/src/{lifeops,website-blocker,activity-profile}`) prints **nothing**.

## Deferred / flagged

None. No undeterminable files; no concurrent-code-wave conflicts remain in scope.

## Verification

```
$ bun run check:comment-only
[assert-comment-only-diff] OK — 1 source file(s) changed; every code token identical to origin/develop. Comments only.

$ bunx vitest run health-bridge.google-fit-sleep
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Touched-package gates (all green):

```
$ bun run --cwd plugins/plugin-health typecheck   # tsgo --noEmit
(exit 0)
$ bun run --cwd plugins/plugin-health lint:check   # biome check
Checked 117 files in 395ms. No fixes applied.
```

Full-gate `bun run verify` fails on **one pre-existing, unrelated task**: `@elizaos/plugin-computeruse#lint`. This is **not** my diff — plugin-computeruse is byte-for-byte identical to `origin/develop` on this branch (`git diff origin/develop -- plugins/plugin-computeruse` is empty). Reproduction on the pristine tree:

```
$ node -e "console.log(require('./plugins/plugin-computeruse/package.json').scripts.lint)"
bunx @biomejs/biome check --write --unsafe .
$ bun run --cwd plugins/plugin-computeruse lint      # on code identical to origin/develop
src/actor/brain.ts:276:21     lint/style/noNonNullAssertion
src/__tests__/scene-builder.test.ts:146:29  lint/suspicious/noNonNullAssertedOptionalChain
Found 2 errors.  →  exit 1
```

The `--unsafe` biome auto-rewrites introduce non-null-assertion diagnostics that the read-only `lint:check` does not surface — a develop-wide gate breakage independent of this comment-only change. Turbo aborts on the first failed task, so it stopped before reaching the two documented known-red baseline failures (`@elizaos/plugin-app#typecheck`, `@elizaos/electrobun#typecheck`, untouched by this PR). In the verify run, the only `Found N errors` line in the whole log is plugin-computeruse; no typecheck errors anywhere; my subtree packages that ran (`plugin-relationships`, `plugin-scheduling`) report "No fixes applied."

## Evidence rows (PR_EVIDENCE.md)

This is a comment-only documentation change with **zero runtime-behavior delta** — `scripts/assert-comment-only-diff.mjs` mechanically asserts the code token stream is byte-for-byte identical to `origin/develop`. All behavioral/visual/trajectory evidence rows are therefore:

- Real-LLM trajectories — N/A - comment-only, no agent/action/prompt/model change.
- Backend / frontend logs — N/A - comment-only, no code path changed.
- Before/after screenshots + video — N/A - comment-only, no UI surface.
- Domain artifacts — N/A - comment-only, no data produced.
- Machine check — `bun run check:comment-only` PASS (code tokens byte-for-byte unchanged); header self-audit prints nothing across all W1-G subtrees.

Part of #12242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
