### PR TITLE
fix(core): provider context gating — honor full contextGate in planner selection, gate-aware materialization, orchestrator/error provider routing (#13203)

### DIFF
--- a/packages/core/src/plugin-lifecycle.context-role-gate.test.ts
+++ b/packages/core/src/plugin-lifecycle.context-role-gate.test.ts
@@ -1,37 +1,48 @@
 /**
- * Regression test (#12089): an action's effective role gate must resolve
- * plugin-registered contexts through the PER-RUNTIME context registry, so a
- * context registered at runtime via `runtime.contexts.register(...)` with
- * `roleGate.minRole = OWNER` participates in the gate. Deriving from a
- * module-level snapshot of only the first-party defaults would leave the plugin
- * context invisible and collapse the effective gate to USER — a permission
- * bypass. Deterministic: a hand-built lifecycle runtime driven through the
+ * Regression tests for plugin-lifecycle access stamping. (#12089): an action's
+ * effective role gate must resolve plugin-registered contexts through the
+ * PER-RUNTIME context registry, so a context registered at runtime via
+ * `runtime.contexts.register(...)` with `roleGate.minRole = OWNER` participates
+ * in the gate — deriving from a module-level snapshot of only the first-party
+ * defaults would collapse the effective gate to USER, a permission bypass.
+ * (#13203): provider registration materializes `contexts` for gate-only
+ * declarations from the gate's anyOf surface (not the `["general"]` default,
+ * which inverts the declared routing) and one-time-warns on the silent general
+ * fallback. Deterministic: a hand-built lifecycle runtime driven through the
  * planned-tool-call gate, no live model or database.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { installRuntimePluginLifecycle } from "./plugin-lifecycle";
+import {
+	_resetProviderContextWarningsForTests,
+	installRuntimePluginLifecycle,
+} from "./plugin-lifecycle";
 import { ContextRegistry } from "./runtime/context-registry";
 import {
 	_resetActionRolePolicyCacheForTests,
 	executePlannedToolCall,
 } from "./runtime/execute-planned-tool-call";
-import type { Action, IAgentRuntime, Memory, UUID } from "./types";
+import type { Action, IAgentRuntime, Memory, Provider, UUID } from "./types";
 
 const noop = () => undefined;
 
-function makeLifecycleRuntime(
-	contexts: ContextRegistry,
-): IAgentRuntime & { actions: Action[] } {
+function makeLifecycleRuntime(contexts: ContextRegistry): IAgentRuntime & {
+	actions: Action[];
+	providers: Provider[];
+	logger: { debug: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn> };
+} {
 	const runtime = {
 		agentId: "00000000-0000-0000-0000-0000000000a1" as UUID,
 		actions: [] as Action[],
+		providers: [] as Provider[],
 		contexts,
 		logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
 		registerAction(action: Action) {
 			runtime.actions.push(action);
 		},
 		registerPlugin: async () => undefined,
-		registerProvider: noop,
+		registerProvider(provider: Provider) {
+			runtime.providers.push(provider);
+		},
 		registerEvaluator: noop,
 		registerShortcut: noop,
 		registerModel: noop,
@@ -39,7 +50,19 @@ function makeLifecycleRuntime(
 		registerService: async () => undefined,
 		registerDatabaseAdapter: noop,
 	};
-	return runtime as unknown as IAgentRuntime & { actions: Action[] };
+	return runtime as unknown as IAgentRuntime & {
+		actions: Action[];
+		providers: Provider[];
+		logger: { debug: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn> };
+	};
+}
+
+function provider(overrides: Partial<Provider> & { name: string }): Provider {
+	return {
+		description: "test provider",
+		get: async () => ({ text: "" }),
+		...overrides,
+	} as Provider;
 }
 
 function msg(): Memory {
@@ -112,5 +135,119 @@ describe("action roleGate resolves plugin-registered contexts (#12089)", () => {
 		);
 		expect(allowed.success).toBe(true);
 		expect(handler).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("provider context materialization at registration (#13203)", () => {
+	afterEach(() => {
+		_resetProviderContextWarningsForTests();
+	});
+
+	function registeredProvider(
+		runtime: ReturnType<typeof makeLifecycleRuntime>,
+		name: string,
+	): Provider | undefined {
+		return runtime.providers.find((p) => p.name === name);
+	}
+
+	it("materializes a gate-only provider from its gate's anyOf surface, not [general]", () => {
+		const runtime = makeLifecycleRuntime(new ContextRegistry());
+		installRuntimePluginLifecycle(runtime);
+
+		runtime.registerProvider(
+			provider({
+				name: "WALLET_GATED_SIGNAL",
+				contextGate: { anyOf: ["wallet"] },
+			}),
+		);
+
+		expect(
+			registeredProvider(runtime, "WALLET_GATED_SIGNAL")?.contexts,
+		).toEqual(["wallet"]);
+		expect(runtime.logger.warn).not.toHaveBeenCalled();
+	});
+
+	it("materializes an allOf-only gate from its allOf terms", () => {
+		const runtime = makeLifecycleRuntime(new ContextRegistry());
+		installRuntimePluginLifecycle(runtime);
+
+		runtime.registerProvider(
+			provider({
+				name: "WALLET_AND_CODE_SIGNAL",
+				contextGate: { allOf: ["wallet", "code"] },
+			}),
+		);
+
+		expect(
+			registeredProvider(runtime, "WALLET_AND_CODE_SIGNAL")?.contexts,
+		).toEqual(["wallet", "code"]);
+	});
+
+	it("keeps a declared-contexts provider untouched (hot-path parity)", () => {
+		const runtime = makeLifecycleRuntime(new ContextRegistry());
+		installRuntimePluginLifecycle(runtime);
+
+		runtime.registerProvider(
+			provider({ name: "DECLARED_SIGNAL", contexts: ["documents"] }),
+		);
+
+		expect(registeredProvider(runtime, "DECLARED_SIGNAL")?.contexts).toEqual([
+			"documents",
+		]);
+		expect(runtime.logger.warn).not.toHaveBeenCalled();
+	});
+
+	it("resolves an undeclared cataloged provider through the catalog without a warning", () => {
+		const runtime = makeLifecycleRuntime(new ContextRegistry());
+		installRuntimePluginLifecycle(runtime);
+
+		runtime.registerProvider(provider({ name: "AVAILABLE_AGENTS" }));
+
+		expect(registeredProvider(runtime, "AVAILABLE_AGENTS")?.contexts).toEqual([
+			"code",
+			"automation",
+		]);
+		expect(runtime.logger.warn).not.toHaveBeenCalled();
+	});
+
+	it("defaults an undeclared uncataloged provider to [general] with a one-time warning", () => {
+		const runtime = makeLifecycleRuntime(new ContextRegistry());
+		installRuntimePluginLifecycle(runtime);
+
+		runtime.registerProvider(provider({ name: "NOISY_PLUGIN_SIGNAL" }));
+		expect(
+			registeredProvider(runtime, "NOISY_PLUGIN_SIGNAL")?.contexts,
+		).toEqual(["general"]);
+		expect(runtime.logger.warn).toHaveBeenCalledTimes(1);
+		const [context, message] = runtime.logger.warn.mock.calls[0] as [
+			Record<string, unknown>,
+			string,
+		];
+		expect(context.provider).toBe("NOISY_PLUGIN_SIGNAL");
+		expect(message).toContain("[PluginLifecycle]");
+
+		// Re-registering the same provider name must not warn again.
+		runtime.registerProvider(provider({ name: "NOISY_PLUGIN_SIGNAL" }));
+		expect(runtime.logger.warn).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not warn for dynamic or always-on undeclared providers", () => {
+		const runtime = makeLifecycleRuntime(new ContextRegistry());
+		installRuntimePluginLifecycle(runtime);
+
+		runtime.registerProvider(
+			provider({ name: "DYNAMIC_UNDECLARED", dynamic: true }),
+		);
+		runtime.registerProvider(
+			provider({ name: "ALWAYS_ON_UNDECLARED", alwaysInResponseState: true }),
+		);
+
+		expect(registeredProvider(runtime, "DYNAMIC_UNDECLARED")?.contexts).toEqual(
+			["general"],
+		);
+		expect(
+			registeredProvider(runtime, "ALWAYS_ON_UNDECLARED")?.contexts,
+		).toEqual(["general"]);
+		expect(runtime.logger.warn).not.toHaveBeenCalled();
 	});
 });

--- a/packages/core/src/plugin-lifecycle.ts
+++ b/packages/core/src/plugin-lifecycle.ts
@@ -41,6 +41,7 @@ import type { IAgentRuntime } from "./types/runtime";
 import type { Service, ServiceTypeName } from "./types/service";
 import type { ShortcutDefinition } from "./types/shortcut";
 import {
+	lookupProviderCatalogContexts,
 	resolveActionContexts,
 	resolveProviderContexts,
 } from "./utils/context-catalog";
@@ -367,9 +368,65 @@ function applyEffectiveActionAccess(
 	};
 }
 
+// One-time-per-name guard for the silent-default registration warning below —
+// re-registration (plugin reload, multi-agent processes) must not spam logs.
+const generalFallbackWarnedProviders = new Set<string>();
+
+/** Test hook: reset the one-time registration-warning guard. */
+export function _resetProviderContextWarningsForTests(): void {
+	generalFallbackWarnedProviders.clear();
+}
+
+/**
+ * Materialize `contexts` for a provider that declares none. A gate-only
+ * declaration (`contextGate` with context terms but no `contexts`) materializes
+ * from the gate's anyOf surface — falling back to allOf when the gate is
+ * allOf-only — instead of the `["general"]` default, which would invert the
+ * declared routing (ride ordinary chat turns, miss its own gated turns,
+ * #13203). Everything else resolves declared → catalog → `["general"]`; the
+ * uncataloged general fallback logs a one-time nudge so plugin authors declare
+ * `contexts`/`contextGate` or opt into `alwaysInResponseState`.
+ */
+function materializeProviderContexts(
+	provider: RuntimeProvider,
+	runtime: RuntimeWithPluginLifecycle,
+): AgentContext[] {
+	const gate = provider.contextGate;
+	const gateAnyOfSurface = [
+		...new Set([...(gate?.contexts ?? []), ...(gate?.anyOf ?? [])]),
+	];
+	if (gateAnyOfSurface.length > 0) {
+		return gateAnyOfSurface;
+	}
+	if ((gate?.allOf?.length ?? 0) > 0) {
+		return [...new Set(gate?.allOf)];
+	}
+
+	const resolved = resolveProviderContexts(provider);
+	if (
+		lookupProviderCatalogContexts(provider.name) === undefined &&
+		!provider.contextGate &&
+		!provider.dynamic &&
+		!provider.alwaysInResponseState &&
+		!generalFallbackWarnedProviders.has(provider.name)
+	) {
+		generalFallbackWarnedProviders.add(provider.name);
+		runtime.logger.warn(
+			{
+				src: "agent",
+				agentId: runtime.agentId,
+				provider: provider.name,
+			},
+			`[PluginLifecycle] Provider "${provider.name}" declares no contexts/contextGate and has no catalog entry; defaulting to ["general"]. Declare contexts or a contextGate to route it, or set alwaysInResponseState for an always-on signal.`,
+		);
+	}
+	return [...resolved];
+}
+
 function applyEffectiveProviderContexts(
 	provider: RuntimeProvider,
 	pluginContexts: Plugin["contexts"] | undefined,
+	runtime: RuntimeWithPluginLifecycle,
 ): RuntimeProvider {
 	const inherited = inheritPluginContexts(provider, pluginContexts);
 	if ((inherited.contexts?.length ?? 0) > 0) {
@@ -377,13 +434,13 @@ function applyEffectiveProviderContexts(
 	}
 
 	if (inherited === provider) {
-		provider.contexts = [...resolveProviderContexts(inherited)];
+		provider.contexts = materializeProviderContexts(inherited, runtime);
 		return provider;
 	}
 
 	return {
 		...inherited,
-		contexts: [...resolveProviderContexts(inherited)],
+		contexts: materializeProviderContexts(inherited, runtime),
 	};
 }
 
@@ -831,6 +888,7 @@ export function installRuntimePluginLifecycle(runtime: IAgentRuntime): void {
 			applyEffectiveProviderContexts(
 				provider,
 				capture?.ownership.plugin.contexts,
+				runtimeWithLifecycle,
 			),
 		);
 		if (!capture || runtimeWithLifecycle.providers.length <= providersBefore)

--- a/packages/core/src/providers/recent-errors.ts
+++ b/packages/core/src/providers/recent-errors.ts
@@ -95,6 +95,10 @@ export const recentErrorsProvider: Provider = {
 	description:
 		"Recent runtime failures reported outside the action path (deduped by code)",
 	dynamic: true,
+	// Failures matter most on the narrow planner/tool turns this provider would
+	// otherwise miss (undeclared → ["general"] routing). Always-on is free on the
+	// happy path: it renders nothing when there are no recent errors (#13203).
+	alwaysInResponseState: true,
 
 	get: async (
 		runtime: IAgentRuntime,

--- a/packages/core/src/runtime/context-gates.test.ts
+++ b/packages/core/src/runtime/context-gates.test.ts
@@ -1,12 +1,18 @@
 /**
  * Unit tests for the role and context gate filters (`filterByContextGate`,
+ * `filterProvidersByContextGate` / `resolveProviderContextGate`,
  * `normalizeGateRole`). Deterministic in-line literal fixtures — no runtime,
  * model, or database.
  */
 import { describe, expect, it } from "vitest";
 import type { AgentContext } from "../types/contexts";
 import type { RoleGateRole } from "./context-gates";
-import { filterByContextGate, normalizeGateRole } from "./context-gates";
+import {
+	filterByContextGate,
+	filterProvidersByContextGate,
+	normalizeGateRole,
+	resolveProviderContextGate,
+} from "./context-gates";
 
 /**
  * Tests for the role-gate normalizer (#8801 / #9943). normalizeGateRole canon-
@@ -32,6 +38,123 @@ describe("filterByContextGate — top-level roleGate under an explicit contextGa
 
 	it("keeps the item for an ADMIN in the active context", () => {
 		expect(filterByContextGate([item], active, ["ADMIN"])).toEqual([item]);
+	});
+});
+
+describe("filterProvidersByContextGate — full declared contextGate honored (#13203)", () => {
+	// A world-style, gate-only provider: contextGate with anyOf and NO contexts.
+	// filterByContextGate's {contexts, roleGate} reduction drops the anyOf terms,
+	// so this provider used to lose its gate entirely on the planner path.
+	const walletGated = {
+		name: "WALLET_GATED_SIGNAL",
+		contextGate: { anyOf: ["wallet"] as AgentContext[] },
+	};
+
+	it("selects a gate-only anyOf provider on its gate turn", () => {
+		expect(
+			filterProvidersByContextGate([walletGated], ["wallet"] as AgentContext[]),
+		).toEqual([walletGated]);
+	});
+
+	it("excludes a gate-only anyOf provider on unrelated turns", () => {
+		expect(
+			filterProvidersByContextGate([walletGated], [
+				"general",
+			] as AgentContext[]),
+		).toEqual([]);
+		expect(filterProvidersByContextGate([walletGated], [])).toEqual([]);
+	});
+
+	it("honors allOf: requires every listed context to be active", () => {
+		const both = {
+			name: "WALLET_AND_CODE",
+			contextGate: { allOf: ["wallet", "code"] as AgentContext[] },
+		};
+		expect(
+			filterProvidersByContextGate([both], [
+				"wallet",
+				"code",
+			] as AgentContext[]),
+		).toEqual([both]);
+		expect(
+			filterProvidersByContextGate([both], ["wallet"] as AgentContext[]),
+		).toEqual([]);
+	});
+
+	it("honors noneOf: an active denied context excludes the provider", () => {
+		const notInCode = {
+			name: "NOT_IN_CODE",
+			contexts: ["general"] as AgentContext[],
+			contextGate: {
+				anyOf: ["general"] as AgentContext[],
+				noneOf: ["code"] as AgentContext[],
+			},
+		};
+		expect(
+			filterProvidersByContextGate([notInCode], ["general"] as AgentContext[]),
+		).toEqual([notInCode]);
+		expect(
+			filterProvidersByContextGate([notInCode], [
+				"general",
+				"code",
+			] as AgentContext[]),
+		).toEqual([]);
+	});
+
+	it("preserves the top-level roleGate under a gate-only contextGate (#12087 Item 14)", () => {
+		const adminOnly = {
+			name: "ADMIN_ONLY_SIGNAL",
+			contextGate: { anyOf: ["admin"] as AgentContext[] },
+			roleGate: { minRole: "ADMIN" as RoleGateRole },
+		};
+		const active = ["admin"] as AgentContext[];
+		expect(filterProvidersByContextGate([adminOnly], active, ["USER"])).toEqual(
+			[],
+		);
+		expect(
+			filterProvidersByContextGate([adminOnly], active, ["ADMIN"]),
+		).toEqual([adminOnly]);
+	});
+
+	it("resolves an undeclared provider through the catalog (AVAILABLE_AGENTS → code/automation, #13203)", () => {
+		const availableAgents = { name: "AVAILABLE_AGENTS" };
+		expect(
+			filterProvidersByContextGate([availableAgents], [
+				"code",
+			] as AgentContext[]),
+		).toEqual([availableAgents]);
+		expect(
+			filterProvidersByContextGate([availableAgents], [
+				"general",
+			] as AgentContext[]),
+		).toEqual([]);
+	});
+
+	it("defaults an undeclared, uncataloged provider to the general context", () => {
+		const undeclared = { name: "TOTALLY_UNDECLARED_SIGNAL" };
+		expect(
+			filterProvidersByContextGate([undeclared], ["general"] as AgentContext[]),
+		).toEqual([undeclared]);
+		expect(
+			filterProvidersByContextGate([undeclared], ["wallet"] as AgentContext[]),
+		).toEqual([]);
+	});
+
+	it("keeps declared-contexts providers on their declared routing (hot-path parity)", () => {
+		const declared = {
+			name: "DECLARED_CONTEXTS",
+			contexts: ["documents"] as AgentContext[],
+		};
+		expect(resolveProviderContextGate(declared)).toEqual({
+			contexts: ["documents"],
+			roleGate: undefined,
+		});
+		expect(
+			filterProvidersByContextGate([declared], ["documents"] as AgentContext[]),
+		).toEqual([declared]);
+		expect(
+			filterProvidersByContextGate([declared], ["general"] as AgentContext[]),
+		).toEqual([]);
 	});
 });
 

--- a/packages/core/src/runtime/context-gates.ts
+++ b/packages/core/src/runtime/context-gates.ts
@@ -12,6 +12,7 @@ import type {
 	RoleGate,
 	RoleGateRole,
 } from "../types/contexts";
+import { resolveProviderContexts } from "../utils/context-catalog";
 import { normalizeContextList } from "./context-normalization";
 
 // #9948: single source of truth for role ranking — delegates to CANONICAL_ROLE_RANK.
@@ -129,4 +130,67 @@ export function filterByContextGate<T extends ContextGateCandidate>(
 		};
 		return satisfiesContextGate(activeContexts, gate, userRoles);
 	});
+}
+
+/** A provider-shaped gate candidate: the name enables the catalog fallback. */
+export interface ProviderContextGateCandidate extends ContextGateCandidate {
+	name: string;
+}
+
+/**
+ * The effective context gate a provider declared, in full (#13203). A declared
+ * `contextGate` with any context terms (contexts/anyOf/allOf/noneOf) is honored
+ * verbatim — `filterByContextGate`'s `{contexts, roleGate}` reduction silently
+ * dropped anyOf/allOf/noneOf, so a world-style `contextGate: { anyOf: [...] }`
+ * provider lost its gate on the v5 planner selection path. Providers declaring
+ * no gate terms resolve declared `contexts` → catalog (PROVIDER_CONTEXT_MAP) →
+ * `["general"]`.
+ *
+ * #12087 Item 14 preserved: a contextGate adds context requirements; it does
+ * not waive the provider's top-level roleGate unless it declares its own.
+ */
+export function resolveProviderContextGate(
+	provider: ProviderContextGateCandidate,
+): ContextGate {
+	const explicit = provider.contextGate;
+	const roleGate = explicit?.roleGate ?? provider.roleGate;
+	const declaresContextTerms =
+		(explicit?.contexts?.length ?? 0) > 0 ||
+		(explicit?.anyOf?.length ?? 0) > 0 ||
+		(explicit?.allOf?.length ?? 0) > 0 ||
+		(explicit?.noneOf?.length ?? 0) > 0;
+
+	if (explicit && declaresContextTerms) {
+		return {
+			contexts: explicit.contexts,
+			anyOf: explicit.anyOf,
+			allOf: explicit.allOf,
+			noneOf: explicit.noneOf,
+			roleGate,
+		};
+	}
+
+	return { contexts: resolveProviderContexts(provider), roleGate };
+}
+
+/**
+ * Filter providers by their FULL effective context gate (see
+ * {@link resolveProviderContextGate}). The v5 planner selection uses this
+ * instead of {@link filterByContextGate} so declared anyOf/allOf/noneOf terms
+ * and the catalog fallback for undeclared providers are honored.
+ */
+export function filterProvidersByContextGate<
+	T extends ProviderContextGateCandidate,
+>(
+	providers: readonly T[],
+	activeContexts: readonly AgentContext[] | undefined,
+	userRoles?: readonly RoleGateRole[],
+): T[] {
+	return providers.filter((provider) =>
+		satisfiesContextGate(
+			activeContexts,
+			resolveProviderContextGate(provider),
+			userRoles,
+		),
+	);
 }

--- a/packages/core/src/services/message.planner-provider-selection.test.ts
+++ b/packages/core/src/services/message.planner-provider-selection.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for selectV5PlannerStateProviderNames, the v5 planner
+ * state-provider selection (#13203): a provider's FULL declared contextGate
+ * (anyOf/allOf/noneOf) must gate its planner inclusion, undeclared providers
+ * resolve through the provider-context catalog, and `alwaysInResponseState`
+ * providers (RECENT_ERRORS) are composed on every turn. Deterministic fake
+ * runtime with literal provider fixtures — no live model or database.
+ */
+import { describe, expect, it } from "vitest";
+import { recentErrorsProvider } from "../providers/recent-errors";
+import type { Provider } from "../types/components";
+import type { AgentContext } from "../types/contexts";
+import type { IAgentRuntime, Memory, UUID } from "../types/index";
+import { selectV5PlannerStateProviderNames } from "./message";
+
+function provider(overrides: Partial<Provider> & { name: string }): Provider {
+	return {
+		description: "test provider",
+		get: async () => ({ text: "" }),
+		...overrides,
+	} as Provider;
+}
+
+function makeRuntime(providers: Provider[]): IAgentRuntime {
+	return { providers } as unknown as IAgentRuntime;
+}
+
+function msg(): Memory {
+	return {
+		id: "00000000-0000-0000-0000-0000000000b2" as UUID,
+		entityId: "00000000-0000-0000-0000-0000000000c2" as UUID,
+		roomId: "00000000-0000-0000-0000-0000000000d2" as UUID,
+		content: { text: "plan it" },
+	} as unknown as Memory;
+}
+
+function select(
+	providers: Provider[],
+	selectedContexts: AgentContext[],
+): string[] {
+	return selectV5PlannerStateProviderNames({
+		runtime: makeRuntime(providers),
+		message: msg(),
+		selectedContexts,
+		userRoles: ["MEMBER"],
+	});
+}
+
+describe("selectV5PlannerStateProviderNames — declared contextGate honored (#13203)", () => {
+	const walletGated = provider({
+		name: "WALLET_GATED_SIGNAL",
+		contextGate: { anyOf: ["wallet"] },
+	});
+
+	it("selects a gate-only anyOf provider on its gate turn", () => {
+		expect(select([walletGated], ["wallet"])).toContain("WALLET_GATED_SIGNAL");
+	});
+
+	it("excludes a gate-only anyOf provider on unrelated turns", () => {
+		expect(select([walletGated], ["documents"])).not.toContain(
+			"WALLET_GATED_SIGNAL",
+		);
+		expect(select([walletGated], [])).not.toContain("WALLET_GATED_SIGNAL");
+	});
+
+	it("honors noneOf: an active denied context excludes the provider", () => {
+		const notInCode = provider({
+			name: "NOT_IN_CODE",
+			contextGate: { anyOf: ["general"], noneOf: ["code"] },
+		});
+		expect(select([notInCode], ["general"])).toContain("NOT_IN_CODE");
+		expect(select([notInCode], ["general", "code"])).not.toContain(
+			"NOT_IN_CODE",
+		);
+	});
+
+	it("routes undeclared orchestrator providers via the catalog to code/automation turns", () => {
+		const availableAgents = provider({
+			name: "AVAILABLE_AGENTS",
+			dynamic: true,
+		});
+		const activeSubAgents = provider({
+			name: "ACTIVE_SUB_AGENTS",
+			dynamic: true,
+		});
+		const onCodeTurn = select([availableAgents, activeSubAgents], ["code"]);
+		expect(onCodeTurn).toContain("AVAILABLE_AGENTS");
+		expect(onCodeTurn).toContain("ACTIVE_SUB_AGENTS");
+
+		const onGeneralTurn = select(
+			[availableAgents, activeSubAgents],
+			["general"],
+		);
+		expect(onGeneralTurn).not.toContain("AVAILABLE_AGENTS");
+		expect(onGeneralTurn).not.toContain("ACTIVE_SUB_AGENTS");
+	});
+
+	it("keeps declared-contexts providers on their declared routing (hot-path parity)", () => {
+		const declared = provider({
+			name: "DECLARED_SIGNAL",
+			contexts: ["documents"],
+		});
+		expect(select([declared], ["documents"])).toContain("DECLARED_SIGNAL");
+		expect(select([declared], ["wallet"])).not.toContain("DECLARED_SIGNAL");
+	});
+
+	it("composes RECENT_ERRORS on every turn via alwaysInResponseState (#13203)", () => {
+		// RECENT_ERRORS is uncataloged and declares no contexts; without the
+		// always-on opt-in it would resolve to ["general"] and miss the narrow
+		// planner/tool turns where failures matter most.
+		expect(recentErrorsProvider.alwaysInResponseState).toBe(true);
+		expect(select([recentErrorsProvider], ["code"])).toContain("RECENT_ERRORS");
+		expect(select([recentErrorsProvider], [])).toContain("RECENT_ERRORS");
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -60,7 +60,7 @@ import {
 	type CandidateActionBackstopRule,
 	getCandidateActionBackstopRules,
 } from "../runtime/candidate-action-backstop";
-import { filterByContextGate } from "../runtime/context-gates";
+import { filterProvidersByContextGate } from "../runtime/context-gates";
 import { computePrefixHashes, hashString } from "../runtime/context-hash";
 import {
 	appendContextEvent,
@@ -1168,7 +1168,7 @@ async function composeProviderGroundedResponseState(
 	);
 }
 
-function selectV5PlannerStateProviderNames(args: {
+export function selectV5PlannerStateProviderNames(args: {
 	runtime: IAgentRuntime;
 	message: Memory;
 	selectedContexts: readonly AgentContext[];
@@ -1189,7 +1189,10 @@ function selectV5PlannerStateProviderNames(args: {
 	for (const name of alwaysOnResponseStateProviderNames(args.runtime)) {
 		providerNames.add(name);
 	}
-	for (const provider of filterByContextGate(
+	// filterProvidersByContextGate honors the FULL declared contextGate
+	// (anyOf/allOf/noneOf) plus the catalog fallback for undeclared providers —
+	// the plain {contexts, roleGate} reduction dropped world-style gates (#13203).
+	for (const provider of filterProvidersByContextGate(
 		providers,
 		args.selectedContexts,
 		args.userRoles,

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -631,10 +631,24 @@ export interface Provider {
 	 * Domain contexts this provider belongs to.
 	 * The context-routing classifier uses these to decide which providers to
 	 * include in the planner's state composition for a given turn.
+	 *
+	 * When neither `contexts` nor a `contextGate` with context terms is
+	 * declared, registration materializes this field from the provider-context
+	 * catalog (`utils/context-catalog.ts`), defaulting to `["general"]` —
+	 * present on ordinary chat turns, absent from narrow planner/tool turns.
+	 * Declare contexts or a gate to route the provider, or opt into
+	 * `alwaysInResponseState` for an always-on signal.
 	 */
 	contexts?: AgentContext[];
 
-	/** Declarative context gate for v5 provider selection. */
+	/**
+	 * Declarative context gate for v5 provider selection. All context terms
+	 * (contexts/anyOf/allOf/noneOf) are honored; a gate-only declaration also
+	 * materializes `contexts` from the gate's anyOf surface at registration.
+	 * A contextGate adds context requirements on top of the provider's
+	 * top-level `roleGate`; it does not waive it unless it declares its own
+	 * (#12087 Item 14).
+	 */
 	contextGate?: ContextGate;
 
 	/** Whether this provider's prompt contribution is stable enough to cache. */
@@ -658,6 +672,12 @@ export interface Provider {
 	 * FACTS / CURRENT_TIME signals). Lets a plugin opt a dynamic provider into
 	 * always-on Stage-1 rendering without core having to name it — keeping the
 	 * core → plugin dependency direction inward-only.
+	 *
+	 * This is the explicit opt-in for FACTS/CURRENT_TIME-class always-on
+	 * signals; it bypasses context routing entirely, so keep the provider's
+	 * happy-path render empty/cheap (e.g. RECENT_ERRORS renders nothing when
+	 * healthy). Providers whose relevance is turn-scoped should declare
+	 * `contexts`/`contextGate` instead.
 	 */
 	alwaysInResponseState?: boolean;
 

--- a/packages/core/src/utils/context-catalog.ts
+++ b/packages/core/src/utils/context-catalog.ts
@@ -201,6 +201,11 @@ export const PROVIDER_CONTEXT_MAP: Record<string, AgentContext[]> = {
 	"solana-wallet": ["wallet"],
 	CODING_AGENT_EXAMPLES: ["code", "automation"],
 	ACTIVE_WORKSPACE_CONTEXT: ["code", "automation"],
+	// Orchestrator inventory (plugin-agent-orchestrator): the coding-backend /
+	// sub-agent listings belong on code/automation planner turns, matching
+	// ACTIVE_WORKSPACE_CONTEXT — not on ordinary "general" chat turns (#13203).
+	AVAILABLE_AGENTS: ["code", "automation"],
+	ACTIVE_SUB_AGENTS: ["code", "automation"],
 	contacts: ["contacts"],
 	trustScores: ["contacts"],
 	platformIdentity: ["messaging"],
@@ -243,15 +248,29 @@ export function resolveActionContexts(action: Action): AgentContext[] {
 	return ACTION_CONTEXT_MAP[action.name.toUpperCase()] ?? ["general"];
 }
 
-export function resolveProviderContexts(provider: Provider): AgentContext[] {
+/**
+ * Catalog lookup for a provider name (exact, lower, upper), or `undefined` when
+ * the provider is uncataloged. Split out so registration can distinguish a
+ * deliberate catalog entry of `["general"]` from the uncataloged default and
+ * warn only on the latter (#13203).
+ */
+export function lookupProviderCatalogContexts(
+	name: string,
+): AgentContext[] | undefined {
+	return (
+		PROVIDER_CONTEXT_MAP[name] ??
+		PROVIDER_CONTEXT_MAP[name.toLowerCase()] ??
+		PROVIDER_CONTEXT_MAP[name.toUpperCase()]
+	);
+}
+
+export function resolveProviderContexts(
+	provider: Pick<Provider, "name" | "contexts">,
+): AgentContext[] {
 	const declared = normalizeContexts(provider.contexts);
 	if (declared.length > 0) {
 		return declared;
 	}
 
-	return (
-		PROVIDER_CONTEXT_MAP[provider.name] ??
-		PROVIDER_CONTEXT_MAP[provider.name.toLowerCase()] ??
-		PROVIDER_CONTEXT_MAP[provider.name.toUpperCase()] ?? ["general"]
-	);
+	return lookupProviderCatalogContexts(provider.name) ?? ["general"];
 }


### PR DESCRIPTION
Fixes #13203. `[phone-ui]` — @lalalune this touches the core provider-selection hot path (runs every agent turn), so it's yours to final-review/merge.

## The 3 holes (before → after)

Repro shape from the issue (bare `AgentRuntime` + `registerProvider`, develop `cd159a8d28`):

| Provider | Before (develop) | After (this PR) |
| --- | --- | --- |
| `NOISY_PLUGIN_SIGNAL` (undeclared, uncataloged) | `contexts: ["general"]`, silent | `contexts: ["general"]` + one-time `[PluginLifecycle]` `logger.warn` nudge (declare `contexts`/`contextGate` or opt into `alwaysInResponseState`) |
| `WALLET_GATED_SIGNAL` (`contextGate: { anyOf: ["wallet"] }`, no `contexts`) | `contexts: ["general"]` — gate ignored; rides chat turns, **misses its own wallet turns** | `contexts: ["wallet"]` (gate's anyOf surface); planner selects it on wallet turns, excludes it elsewhere |
| `AVAILABLE_AGENTS` / `ACTIVE_SUB_AGENTS` (plugin-agent-orchestrator, undeclared) | `["general"]` — absent from the code/automation planner turns that need the coding-backend inventory | catalog entries `["code", "automation"]` (matching `ACTIVE_WORKSPACE_CONTEXT`) |
| `RECENT_ERRORS` (#12182/#12263 error signal, undeclared) | `["general"]` — silently absent from narrow tool/planner turns where failures matter most | `alwaysInResponseState: true` — composed every turn; renders nothing when healthy, so free on the happy path |

### Hole 1 — planner selection dropped declared `contextGate.anyOf/allOf/noneOf`
`filterByContextGate` reduced every candidate to `{contexts, roleGate}`, so a world-style `contextGate: { anyOf: [...] }` provider lost its gate on the v5 planner path. New `resolveProviderContextGate` + `filterProvidersByContextGate` (`packages/core/src/runtime/context-gates.ts`) honor the full declared gate; providers with no gate terms resolve declared `contexts` → catalog (`PROVIDER_CONTEXT_MAP`) → `["general"]`. `selectV5PlannerStateProviderNames` (`packages/core/src/services/message.ts`) now uses it. **#12087 Item 14 preserved**: a contextGate adds context requirements; it does not waive the top-level roleGate unless it declares its own — the original #12087 test passes unmodified and is duplicated against the new filter.

### Hole 2 — registration clobbered gate-only declarations to `["general"]`
`applyEffectiveProviderContexts` (`packages/core/src/plugin-lifecycle.ts`) now materializes gate-only providers from their gate's anyOf surface (deduped `contexts`+`anyOf`; `allOf` fallback for allOf-only gates) instead of injecting `["general"]` — the declared routing is no longer inverted. A one-time-per-name structured warning (`runtime.logger.warn`, `[PluginLifecycle]`) fires when the uncataloged `["general"]` fallback hits a non-dynamic, non-always-on, no-gate provider.

### Hole 3 — catalog misses for orchestrator/error providers
`PROVIDER_CONTEXT_MAP` entries for `AVAILABLE_AGENTS`/`ACTIVE_SUB_AGENTS`; `RECENT_ERRORS` opts into `alwaysInResponseState`; `Provider.contexts` / `Provider.contextGate` / `Provider.alwaysInResponseState` JSDoc now documents the `["general"]` default, full-gate semantics, and the always-on opt-in for FACTS/CURRENT_TIME-class signals.

## Tests (pure, no live model)
- `context-gates.test.ts`: gate-only anyOf selected on gate turn / excluded elsewhere; allOf; noneOf; #12087 roleGate rule under the new filter; catalog resolution; uncataloged general default; declared-contexts hot-path parity.
- `plugin-lifecycle.context-role-gate.test.ts` (existing harness extended — registerProvider now pushes; #12089 action tests untouched): gate-only → anyOf surface; allOf-only → allOf; declared untouched; cataloged no-warn; uncataloged general + one-time warn (re-registration doesn't re-warn); dynamic/always-on no-warn.
- `message.planner-provider-selection.test.ts` (new; `selectV5PlannerStateProviderNames` exported): anyOf gate turn in/out; noneOf; orchestrator providers on code vs general turns; declared-contexts parity; RECENT_ERRORS always-on.

## Mutation results
| Hole | Mutation | Result |
| --- | --- | --- |
| 1 | revert `resolveProviderContextGate` to the `{contexts, roleGate}` reduction | 8 tests fail |
| 2 | revert materialization to plain `resolveProviderContexts` | 3 tests fail |
| 3 | remove catalog entries + `alwaysInResponseState` | 4 tests fail |

All restored; final run green.

## Hot-path safety
Already-correct providers behave identically: declared-`contexts` providers produce the same effective gate (declared contexts pass through `resolveProviderContexts` verbatim); `contextGate:{contexts:[...]}` + roleGate providers produce the same gate (added terms are `undefined` = absent); undeclared-cataloged providers resolve to the same catalog contexts (lookup order exact/lower/upper byte-identical, refactored through `lookupProviderCatalogContexts`); dynamic/private/always-on/exclusion-set handling in the selection loop untouched. Behavior changes only for gate-only providers (now follow their DECLARED gates — core gate-only providers whose anyOf includes `general` keep their chat-turn presence) and the three issue-named providers. Per-turn cost unchanged in order (one small gate object per provider, 1–3 map hits). **No existing test expectation changed** — 41 files / 415 tests across the full services/providers/lifecycle/context suites pass with only additive test changes; core `tsgo` typecheck clean.

## Evidence
- Full suites: `bunx vitest run --no-cache packages/core/src/services/ packages/core/src/plugin-lifecycle.context-role-gate.test.ts packages/core/src/runtime/context-gates.test.ts packages/core/src/utils/context-catalog.test.ts packages/core/src/utils/context-routing.test.ts packages/core/src/providers/` → 415/415.
- Screenshots / video / frontend logs: **N/A — core runtime provider-selection change, no UI surface.**
- Live-LLM trajectory: **N/A-for-this-PR — selection is deterministic and unit-proven at the exact planner chokepoint; happy to capture a scenario-runner trajectory on request before merge.**

`[phone-ui]`

---
**Authored end-to-end by a Fable-5 agent** (verified 100% claude-fable-5), committed + pushed. Main-loop re-verification (this is the provider-selection HOT PATH, so I checked hard): pure-Fable ✓; clean 7-file merge-base diff; 28/28 targeted tests green (--no-cache); **393/393 pass across the full 38-file services+providers+lifecycle suite = no hot-path regressions**; hole-1 (planner gate resolution) mutation independently reproduced (revert context-gates.ts → 14 failures; restore → green). No existing test expectation was changed (only additive). The per-provider-class parity argument in hot_path_safety_notes holds: providers already declaring `contexts`, dynamic providers, and already-cataloged providers behave identically; behavior changes ONLY for gate-only declarations + uncataloged orchestrator/error providers, exactly as the issue specifies. — [phone-ui]