### PR TITLE
refactor(#12677): fold settings-section visuals + bypass registrations into one canonical list

### DIFF
--- a/packages/ui/src/components/settings/settings-sections.registration.test.ts
+++ b/packages/ui/src/components/settings/settings-sections.registration.test.ts
@@ -1,11 +1,16 @@
 // @vitest-environment jsdom
 
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-// Static import: evaluating the heavy module runs its top-level registration
-// side effects, exactly as the lazy `SettingsView` does when it mounts.
-import "./settings-sections";
 import { SETTINGS_SECTION_META } from "./settings-section-meta";
 import { getAllSettingsSections } from "./settings-section-registry";
+// Static import: evaluating the heavy module runs its top-level registration
+// side effects, exactly as the lazy `SettingsView` does when it mounts.
+import {
+  assertMetaCatalogParity,
+  SETTINGS_SECTIONS,
+} from "./settings-sections";
 
 /**
  * Guards the #10724 lazy-load seam: the eager boot barrels (`index.ts` /
@@ -30,9 +35,102 @@ describe("settings-sections registration (lazy boot seam)", () => {
     }
   });
 
-  it("also registers the registry-contributed cloud + runtime sections", () => {
+  it("also registers the folded-in cloud + runtime sections", () => {
+    // These used to be ad-hoc `registerSettingsSection(...)` bypass calls; they
+    // are now single-source entries in BUILTIN_SECTION_DEFINITIONS carrying
+    // `catalog: false`, registered by the same data-driven loop.
     for (const id of ["cloud-overview", "cloud-agents", "my-runtimes"]) {
       expect(registeredIds.has(id), `section "${id}" missing`).toBe(true);
     }
+  });
+});
+
+/**
+ * The audit fix (#12089 item 31 / #12677) folds the parallel `SECTION_VISUALS`
+ * map and the three ad-hoc `registerSettingsSection(...)` bypass calls into one
+ * canonical per-id definition list, with an explicit two-way parity guard
+ * against the pinned pure-data META. These tests pin that the merge holds and
+ * the old central couplings do not creep back.
+ */
+describe("settings-sections canonical definitions (no META/VISUALS drift)", () => {
+  it("passes the module-load META parity guard", () => {
+    // Already runs at import time; calling again proves it is a pure, callable
+    // check and did not throw for the current definitions.
+    expect(() => assertMetaCatalogParity()).not.toThrow();
+  });
+
+  it("exposes the catalog sections in exact META id + label + order", () => {
+    expect(
+      SETTINGS_SECTIONS.map((s) => ({ id: s.id, label: s.defaultLabel })),
+    ).toEqual(
+      SETTINGS_SECTION_META.map((m) => ({ id: m.id, label: m.defaultLabel })),
+    );
+  });
+
+  it("carries each catalog section's declared META aliases onto the registered def", () => {
+    const byId = new Map(
+      getAllSettingsSections().map((s) => [s.id, s] as const),
+    );
+    for (const meta of SETTINGS_SECTION_META) {
+      const registered = byId.get(meta.id);
+      expect(registered, `section "${meta.id}" not registered`).toBeDefined();
+      expect([...(registered?.aliases ?? [])]).toEqual([
+        ...(meta.aliases ?? []),
+      ]);
+    }
+  });
+
+  it("registers the non-catalog sections OUTSIDE the pinned META catalog", () => {
+    const metaIds = new Set(SETTINGS_SECTION_META.map((m) => m.id));
+    for (const id of ["cloud-overview", "cloud-agents", "my-runtimes"]) {
+      expect(metaIds.has(id), `"${id}" leaked into the pinned catalog`).toBe(
+        false,
+      );
+    }
+    // ...but they still resolve from the live registry (Settings renders them).
+    const registeredIds = new Set(getAllSettingsSections().map((s) => s.id));
+    for (const id of ["cloud-overview", "cloud-agents", "my-runtimes"]) {
+      expect(registeredIds.has(id)).toBe(true);
+    }
+  });
+
+  it("preserves the folded-in sections' group + order (behavior-preserving fold)", () => {
+    const byId = new Map(
+      getAllSettingsSections().map((s) => [s.id, s] as const),
+    );
+    expect(byId.get("cloud-overview")?.order).toBe(1.45);
+    expect(byId.get("cloud-agents")?.order).toBe(1.55);
+    expect(byId.get("my-runtimes")?.order).toBe(3.5);
+    expect(byId.get("my-runtimes")?.group).toBe("system");
+  });
+
+  it("grep-guard: the parallel SECTION_VISUALS map and ad-hoc bypass calls are gone from executable paths", () => {
+    // Read the module source cwd-independently: vitest's transformed
+    // `import.meta.url` is not a usable file: URL here, so resolve the file by
+    // trying the package-root-relative path (cwd = packages/ui) and the
+    // repo-root-relative path (cwd = repo root, e.g. a direct root invocation).
+    const rel = "src/components/settings/settings-sections.ts";
+    const candidates = [
+      join(process.cwd(), rel),
+      join(process.cwd(), "packages/ui", rel),
+    ];
+    const modulePath = candidates.find((p) => existsSync(p));
+    expect(
+      modulePath,
+      `could not locate settings-sections.ts from cwd ${process.cwd()}`,
+    ).toBeDefined();
+    const source = readFileSync(modulePath as string, "utf8");
+    // Strip line + block comments so historical mentions in doc comments don't
+    // trip the guard — only executable code is checked.
+    const code = source
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/[^\n]*/g, "");
+    expect(code).not.toMatch(/SECTION_VISUALS/);
+    // Exactly one registerSettingsSection call site survives: the data-driven
+    // loop. The three inline object-literal bypass calls must be gone.
+    const registerCalls = code.match(/\bregisterSettingsSection\s*\(/g) ?? [];
+    expect(registerCalls.length).toBe(1);
+    // The old runtime hand-sync error string must not survive.
+    expect(code).not.toMatch(/Missing settings-section visuals/);
   });
 });

--- a/packages/ui/src/components/settings/settings-sections.ts
+++ b/packages/ui/src/components/settings/settings-sections.ts
@@ -185,8 +185,35 @@ export const SECTION_HUE_MEDALLION_CLASS: Record<SettingsSectionHue, string> = {
   slate: "bg-surface text-txt-strong  ",
 };
 
-/** Per-section visuals + component, keyed by the id declared in the meta list. */
-interface SectionVisual {
+/**
+ * Canonical, per-id settings-section definition: a single declaration that
+ * carries BOTH the pure-data catalog fields (id / label / group / aliases) AND
+ * the React visuals (icon / tone / hue / component) for one section. Every
+ * built-in section — catalog and non-catalog alike — is declared exactly once
+ * in {@link BUILTIN_SECTION_DEFINITIONS}, which a single loop registers.
+ *
+ * Invariant: the catalog subset (`catalog !== false`) is the pure-data set that
+ * app-core's `dev-route-catalog` parity test mirrors through
+ * `SETTINGS_SECTION_META`; {@link assertMetaCatalogParity} enforces that those
+ * definitions match META in id, order, label, group, and aliases (both
+ * directions) at module load. `catalog: false` marks a section that registers
+ * into Settings but stays out of that pinned QA catalog — the late-registered
+ * Cloud group (`cloud-overview`, `cloud-agents`) and cockpit runtime registry
+ * (`my-runtimes`).
+ */
+interface BuiltinSectionDefinition {
+  /** Stable id — URL hash + agent-surface address. */
+  id: string;
+  /** English display label (the i18n default value). Must match META when catalog. */
+  defaultLabel: string;
+  /** Top-level group. Custom groups (e.g. Cloud) allowed for non-catalog sections. */
+  group: SettingsSectionGroup | (string & {});
+  /**
+   * Extra friendly tokens for `/settings <token>`. For catalog sections this
+   * must equal the declared META aliases (parity-checked); non-catalog sections
+   * own their aliases here directly.
+   */
+  aliases?: readonly string[];
   icon: LucideIcon;
   tone: SettingsSectionTone;
   hue: SettingsSectionHue;
@@ -194,37 +221,83 @@ interface SectionVisual {
   labelKey: string;
   /** i18n key for the section header, when it differs from the label. */
   titleKey?: string;
+  /**
+   * English fallback for the section header, when it differs from
+   * {@link defaultLabel}. Used when the `titleKey` locale entry is absent. For
+   * catalog sections the header falls back to the nav label, so this is only
+   * needed for sections (e.g. the Cloud group) whose header text differs.
+   */
+  defaultTitle?: string;
   bodyClassName?: string;
   /** Hide unless Developer Mode is on. */
   developerOnly?: boolean;
   /** Hide on the cloud mobile build (no host machine). */
   hideOnCloud?: boolean;
+  /**
+   * Explicit sort order override. Catalog sections default to their META list
+   * index; the late-registered Cloud/runtime sections declare fractional orders
+   * that interleave with the built-in groups.
+   */
+  order?: number;
+  /**
+   * Whether this section is part of the pinned pure-data catalog mirrored by
+   * app-core's `dev-route-catalog` test (`SETTINGS_SECTION_META`). `true` (the
+   * default) = a built-in local section that MUST appear in META in the same
+   * order/label/group. `false` = a section that registers into Settings but is
+   * intentionally outside the QA catalog (Cloud group upsell/agents, cockpit
+   * runtimes).
+   */
+  catalog?: boolean;
   Component: ComponentType | LazyExoticComponent<ComponentType>;
 }
 
-const SECTION_VISUALS: Record<string, SectionVisual> = {
-  identity: {
+/**
+ * The single source of truth for every built-in settings section's full
+ * definition (catalog data + visuals + component). Order here is display order
+ * within the resolved group ordering. Catalog sections (`catalog !== false`)
+ * are parity-checked against `SETTINGS_SECTION_META`; non-catalog sections
+ * (`catalog: false`) live in the Cloud group / cockpit runtime registry and
+ * stay out of the pinned QA catalog.
+ */
+const BUILTIN_SECTION_DEFINITIONS: readonly BuiltinSectionDefinition[] = [
+  {
+    id: "identity",
+    defaultLabel: "Basics",
+    group: "agent",
+    aliases: ["basics", "profile"],
     icon: User,
     tone: "neutral",
     hue: "slate",
     labelKey: "settings.sections.identity.label",
     Component: IdentitySettingsSection,
   },
-  "ai-model": {
+  {
+    id: "ai-model",
+    defaultLabel: "Models & Providers",
+    group: "agent",
+    aliases: ["model", "models", "provider", "providers", "ai", "cloud"],
     icon: Brain,
     tone: "accent",
     hue: "accent",
     labelKey: "settings.sections.aimodel.label",
     Component: ProviderSwitcher,
   },
-  voice: {
+  {
+    id: "voice",
+    defaultLabel: "Voice",
+    group: "agent",
+    aliases: ["tts", "speech"],
     icon: Mic,
     tone: "accent",
     hue: "accent",
     labelKey: "settings.sections.voice.label",
     Component: VoiceSectionMount,
   },
-  capabilities: {
+  {
+    id: "capabilities",
+    defaultLabel: "Capabilities",
+    group: "agent",
+    aliases: ["abilities"],
     icon: SlidersHorizontal,
     tone: "accent",
     hue: "accent",
@@ -232,35 +305,53 @@ const SECTION_VISUALS: Record<string, SectionVisual> = {
     titleKey: "common.capabilities",
     Component: CapabilitiesSection,
   },
-  apps: {
+  {
+    id: "apps",
+    defaultLabel: "Apps",
+    group: "agent",
+    aliases: ["views"],
     icon: LayoutGrid,
     tone: "accent",
     hue: "accent",
     labelKey: "settings.sections.apps.label",
     Component: AppsManagementSection,
   },
-  connectors: {
+  {
+    id: "connectors",
+    defaultLabel: "Connectors",
+    group: "agent",
+    aliases: ["connections", "integrations"],
     icon: Webhook,
     tone: "accent",
     hue: "accent",
     labelKey: "settings.sections.connectors.label",
     Component: ConnectorsSection,
   },
-  runtime: {
+  {
+    id: "runtime",
+    defaultLabel: "Runtime",
+    group: "system",
     icon: Server,
     tone: "neutral",
     hue: "slate",
     labelKey: "settings.sections.runtime.label",
     Component: RuntimeSettingsSection,
   },
-  appearance: {
+  {
+    id: "appearance",
+    defaultLabel: "Appearance",
+    group: "system",
+    aliases: ["theme", "look"],
     icon: Palette,
     tone: "neutral",
     hue: "rose",
     labelKey: "settings.sections.appearance.label",
     Component: AppearanceSettingsSection,
   },
-  background: {
+  {
+    id: "background",
+    defaultLabel: "Background",
+    group: "system",
     icon: Wallpaper,
     tone: "neutral",
     hue: "rose",
@@ -268,7 +359,11 @@ const SECTION_VISUALS: Record<string, SectionVisual> = {
     // Chrome-light so the live wallpaper shows through while choices apply.
     Component: BackgroundSettingsSection,
   },
-  "remote-plugins": {
+  {
+    id: "remote-plugins",
+    defaultLabel: "Remote Plugins",
+    group: "system",
+    aliases: ["remote"],
     icon: Puzzle,
     tone: "accent",
     hue: "rose",
@@ -276,7 +371,11 @@ const SECTION_VISUALS: Record<string, SectionVisual> = {
     developerOnly: true,
     Component: RemotePluginHostSection,
   },
-  "wallet-rpc": {
+  {
+    id: "wallet-rpc",
+    defaultLabel: "Wallet & RPC",
+    group: "system",
+    aliases: ["wallet", "rpc"],
     icon: Wallet,
     tone: "neutral",
     hue: "slate",
@@ -284,28 +383,43 @@ const SECTION_VISUALS: Record<string, SectionVisual> = {
     bodyClassName: "p-4 sm:p-5",
     Component: WalletRpcSection,
   },
-  updates: {
+  {
+    id: "updates",
+    defaultLabel: "Updates",
+    group: "system",
+    aliases: ["update"],
     icon: RefreshCw,
     tone: "neutral",
     hue: "slate",
     labelKey: "settings.sections.updates.label",
     Component: ReleaseCenterView,
   },
-  advanced: {
+  {
+    id: "advanced",
+    defaultLabel: "Backup & Reset",
+    group: "system",
+    aliases: ["fine-tuning"],
     icon: Archive,
     tone: "neutral",
     hue: "slate",
     labelKey: "settings.sections.backupReset.label",
     Component: AdvancedSection,
   },
-  "app-permissions": {
+  {
+    id: "app-permissions",
+    defaultLabel: "App Permissions",
+    group: "security",
     icon: ShieldCheck,
     tone: "warn",
     hue: "amber",
     labelKey: "settings.sections.apppermissions.label",
     Component: AppPermissionsSection,
   },
-  permissions: {
+  {
+    id: "permissions",
+    defaultLabel: "Permissions",
+    group: "security",
+    aliases: ["perms"],
     icon: Shield,
     tone: "warn",
     hue: "amber",
@@ -313,14 +427,21 @@ const SECTION_VISUALS: Record<string, SectionVisual> = {
     titleKey: "common.permissions",
     Component: PermissionsSection,
   },
-  secrets: {
+  {
+    id: "secrets",
+    defaultLabel: "Vault",
+    group: "security",
+    aliases: ["vault", "keys"],
     icon: KeyRound,
     tone: "warn",
     hue: "amber",
     labelKey: "settings.sections.secrets.label",
     Component: SecretsManagerSection,
   },
-  security: {
+  {
+    id: "security",
+    defaultLabel: "Security",
+    group: "security",
     icon: Lock,
     tone: "warn",
     hue: "amber",
@@ -331,93 +452,189 @@ const SECTION_VISUALS: Record<string, SectionVisual> = {
     hideOnCloud: true,
     Component: SecuritySettingsSection,
   },
-};
 
-/** Built-in sections, in display order, derived from the canonical meta list. */
-export const SETTINGS_SECTIONS: SettingsSectionDef[] =
-  SETTINGS_SECTION_META.map((meta, index): SettingsSectionDef => {
-    const visual = SECTION_VISUALS[meta.id];
-    if (!visual) {
-      throw new Error(`Missing settings-section visuals for "${meta.id}"`);
+  // ---------------------------------------------------------------------------
+  // Non-catalog sections (`catalog: false`): declared in this one canonical list
+  // + registered by the shared loop, but kept OUT of the pinned
+  // `SETTINGS_SECTION_META` that app-core's dev-route-catalog test mirrors. They
+  // live in the late-registered Cloud group / cockpit runtime registry, not the
+  // built-in QA route catalog.
+  // ---------------------------------------------------------------------------
+  {
+    id: "cloud-overview",
+    defaultLabel: "Overview",
+    group: CLOUD_SETTINGS_GROUP_ID,
+    catalog: false,
+    icon: Cloud,
+    tone: "accent",
+    hue: "accent",
+    labelKey: "settings.sections.cloudOverview.label",
+    titleKey: "settings.sections.cloudOverview.title",
+    defaultTitle: "Eliza Cloud",
+    order: 1.45,
+    Component: CloudOverviewSection,
+  },
+  // Eliza Cloud agent manager — surfaces in Settings (list / switch /
+  // create+name / delete agents) under the local Cloud group with the upsell
+  // overview, while full Cloud-only account/billing/API surfaces remain opt-in
+  // through registerCloudSettingsSections().
+  {
+    id: "cloud-agents",
+    defaultLabel: "Agents",
+    group: CLOUD_SETTINGS_GROUP_ID,
+    catalog: false,
+    icon: Bot,
+    tone: "accent",
+    hue: "accent",
+    labelKey: "settings.sections.cloudAgents.label",
+    titleKey: "settings.sections.cloudAgents.title",
+    defaultTitle: "Eliza Cloud Agents",
+    order: 1.55,
+    Component: CloudAgentsSection,
+  },
+  // "My Runtimes" — manage + switch between local / cloud-dedicated /
+  // VPS-remote runtimes (the cockpit's runtime registry).
+  {
+    id: "my-runtimes",
+    defaultLabel: "My Runtimes",
+    group: "system",
+    catalog: false,
+    icon: Server,
+    tone: "neutral",
+    hue: "slate",
+    labelKey: "settings.sections.myRuntimes.label",
+    titleKey: "settings.sections.myRuntimes.title",
+    order: 3.5,
+    Component: MyRuntimesContainer,
+  },
+] as const;
+
+/** The default-title fallback: explicit `defaultTitle` if declared, else the label. */
+function sectionDefaultTitle(def: BuiltinSectionDefinition): string {
+  return def.defaultTitle ?? def.defaultLabel;
+}
+
+/** Project a canonical definition into the registry's `SettingsSectionDef`. */
+function toSettingsSectionDef(
+  def: BuiltinSectionDefinition,
+  order: number,
+): SettingsSectionDef {
+  return {
+    id: def.id,
+    aliases: def.aliases,
+    label: def.labelKey,
+    defaultLabel: def.defaultLabel,
+    icon: def.icon,
+    tone: def.tone,
+    hue: def.hue,
+    group: def.group,
+    titleKey: def.titleKey ?? def.labelKey,
+    defaultTitle: sectionDefaultTitle(def),
+    bodyClassName: def.bodyClassName,
+    developerOnly: def.developerOnly,
+    hideOnCloud: def.hideOnCloud,
+    order: def.order ?? order,
+    Component: def.Component,
+  };
+}
+
+/** True when the definition is part of the pinned pure-data QA catalog. */
+function isCatalogSection(def: BuiltinSectionDefinition): boolean {
+  return def.catalog !== false;
+}
+
+/**
+ * Two-way drift guard between the catalog subset of the merged per-id
+ * definitions and the pinned pure-data `SETTINGS_SECTION_META` list that
+ * app-core mirrors. A catalog section whose id / label / group / aliases /
+ * order falls out of sync with META fails loudly at module load (and is
+ * asserted by a focused test), so the two sources cannot silently diverge.
+ */
+export function assertMetaCatalogParity(): void {
+  const catalogDefs = BUILTIN_SECTION_DEFINITIONS.filter(isCatalogSection);
+
+  // Same set + same order as the pinned META list.
+  const defIds = catalogDefs.map((d) => d.id);
+  const metaIds = SETTINGS_SECTION_META.map((m) => m.id);
+  if (defIds.length !== metaIds.length) {
+    throw new Error(
+      `settings-section catalog drift: ${defIds.length} catalog definition(s) ` +
+        `vs ${metaIds.length} META entr(ies). Definitions: [${defIds.join(
+          ", ",
+        )}] META: [${metaIds.join(", ")}].`,
+    );
+  }
+  for (let i = 0; i < metaIds.length; i += 1) {
+    if (defIds[i] !== metaIds[i]) {
+      throw new Error(
+        `settings-section catalog drift at index ${i}: definition "${defIds[i]}" ` +
+          `!= META "${metaIds[i]}". Catalog definitions must match ` +
+          "SETTINGS_SECTION_META in id and order.",
+      );
     }
-    return {
-      id: meta.id,
-      aliases: meta.aliases,
-      label: visual.labelKey,
-      defaultLabel: meta.defaultLabel,
-      icon: visual.icon,
-      tone: visual.tone,
-      hue: visual.hue,
-      group: meta.group,
-      titleKey: visual.titleKey ?? visual.labelKey,
-      defaultTitle: meta.defaultLabel,
-      bodyClassName: visual.bodyClassName,
-      developerOnly: visual.developerOnly,
-      hideOnCloud: visual.hideOnCloud,
-      order: index,
-      Component: visual.Component,
-    };
-  });
+  }
 
-for (const section of SETTINGS_SECTIONS) registerSettingsSection(section);
+  // Per-id: label + group + aliases must agree with the pure-data META.
+  const metaById = new Map(SETTINGS_SECTION_META.map((m) => [m.id, m]));
+  for (const def of catalogDefs) {
+    const meta = metaById.get(def.id);
+    // Membership + order already validated above; this is the field parity.
+    if (!meta) continue;
+    if (def.defaultLabel !== meta.defaultLabel) {
+      throw new Error(
+        `settings-section "${def.id}" label drift: definition ` +
+          `"${def.defaultLabel}" != META "${meta.defaultLabel}".`,
+      );
+    }
+    if (def.group !== meta.group) {
+      throw new Error(
+        `settings-section "${def.id}" group drift: definition ` +
+          `"${def.group}" != META "${meta.group}".`,
+      );
+    }
+    const defAliases = [...(def.aliases ?? [])];
+    const metaAliases = [...(meta.aliases ?? [])];
+    const aliasesMatch =
+      defAliases.length === metaAliases.length &&
+      defAliases.every((a, idx) => a === metaAliases[idx]);
+    if (!aliasesMatch) {
+      throw new Error(
+        `settings-section "${def.id}" alias drift: definition ` +
+          `[${defAliases.join(", ")}] != META [${metaAliases.join(", ")}].`,
+      );
+    }
+  }
+}
 
+assertMetaCatalogParity();
+
+/**
+ * The built-in local sections that are part of the pinned QA catalog, in
+ * display order. Derived from the canonical definitions (catalog subset).
+ * Retained as a named export for backward compatibility; runtime consumers read
+ * the live registry via {@link getAllSettingsSections}.
+ */
+export const SETTINGS_SECTIONS: SettingsSectionDef[] =
+  BUILTIN_SECTION_DEFINITIONS.filter(isCatalogSection).map((def, index) =>
+    toSettingsSectionDef(def, index),
+  );
+
+// The Cloud group must exist before its member sections register into it.
 registerSettingsGroup({
   id: CLOUD_SETTINGS_GROUP_ID,
   label: "Cloud",
   order: 1.5,
 });
 
-registerSettingsSection({
-  id: "cloud-overview",
-  label: "settings.sections.cloudOverview.label",
-  defaultLabel: "Overview",
-  icon: Cloud,
-  tone: "accent",
-  hue: "accent",
-  group: CLOUD_SETTINGS_GROUP_ID,
-  titleKey: "settings.sections.cloudOverview.title",
-  defaultTitle: "Eliza Cloud",
-  order: 1.45,
-  Component: CloudOverviewSection,
-});
-
-// Eliza Cloud agent manager — contributed through the pluggable registry rather
-// than the canonical META list, so it surfaces in Settings (list / switch /
-// create+name / delete agents) without changing the built-in section count that
-// the dev-route-catalog test pins. It lives under the local Cloud group with the
-// upsell overview, while full Cloud-only account/billing/API surfaces remain
-// opt-in through registerCloudSettingsSections().
-registerSettingsSection({
-  id: "cloud-agents",
-  label: "settings.sections.cloudAgents.label",
-  defaultLabel: "Agents",
-  icon: Bot,
-  tone: "accent",
-  hue: "accent",
-  group: CLOUD_SETTINGS_GROUP_ID,
-  titleKey: "settings.sections.cloudAgents.title",
-  defaultTitle: "Eliza Cloud Agents",
-  order: 1.55,
-  Component: CloudAgentsSection,
-});
-
-// "My Runtimes" — manage + switch between local / cloud-dedicated / VPS-remote
-// runtimes (the cockpit's runtime registry). Contributed through the registry
-// (not the pinned META list) so it doesn't change the built-in section count the
-// dev-route-catalog test pins.
-registerSettingsSection({
-  id: "my-runtimes",
-  label: "settings.sections.myRuntimes.label",
-  defaultLabel: "My Runtimes",
-  icon: Server,
-  tone: "neutral",
-  hue: "slate",
-  group: "system",
-  titleKey: "settings.sections.myRuntimes.title",
-  defaultTitle: "My Runtimes",
-  order: 3.5,
-  Component: MyRuntimesContainer,
-});
+// One data-driven registration pass for every built-in section (catalog +
+// non-catalog alike) — no per-section side calls. Catalog sections keep their
+// META list index as the default order; non-catalog sections use their declared
+// fractional order to interleave with the built-in groups.
+let catalogIndex = 0;
+for (const def of BUILTIN_SECTION_DEFINITIONS) {
+  const order = isCatalogSection(def) ? catalogIndex++ : (def.order ?? 0);
+  registerSettingsSection(toSettingsSectionDef(def, order));
+}
 
 registerCloudConnectorsSettingsSection();
 


### PR DESCRIPTION
## What

Fixes #12677 (arch-audit self-registration, #12089 item 31): **settings sections were split between a pinned central META list and ad-hoc registry bypasses.** Folds them into one canonical per-id definition and merges visuals into per-id definitions, as the audit's "Done when" requires.

### The smell

Built-in section data lived in **three** hand-synced places:
1. pure-data `SETTINGS_SECTION_META` (id / label / group / aliases) — mirrored by app-core's `dev-route-catalog` parity test,
2. a **parallel `SECTION_VISUALS`** map keyed by the same id (icon / tone / hue / component), reconciled at boot by a silent `throw new Error("Missing settings-section visuals for ...")`, and
3. **three inline `registerSettingsSection(...)` bypass calls** (`cloud-overview`, `cloud-agents`, `my-runtimes`) that duplicated the full `SettingsSectionDef` shape a third time.

Two lists that must be hand-synced + a runtime-only reconciliation is exactly the drift-prone central coupling the audit flags.

### The fix

- One canonical `BUILTIN_SECTION_DEFINITIONS` list: each entry carries catalog data **and** visuals **and** component for a section. A single data-driven loop registers all of them — no per-section side calls.
- The three former bypass sections are now entries with `catalog: false` (a declared property, not a side registration). Behavior preserved: they still register into the Cloud group / cockpit runtime registry, keep their fractional `order` (1.45 / 1.55 / 3.5), their `group`, and their explicit header titles ("Eliza Cloud" / "Eliza Cloud Agents").
- `assertMetaCatalogParity()` replaces the silent boot `throw` with a **two-way, load-time drift guard**: the catalog subset (`catalog !== false`) must match `SETTINGS_SECTION_META` in id, order, label, group, and aliases. Drift now fails loudly + is test-asserted.
- `SETTINGS_SECTION_META` stays pure-data (no React/icons) so app-core's parity test imports it unchanged — the pinned QA catalog is **untouched**.

## Tests / evidence

- `settings-sections.registration.test.ts` — **8/8**. New cases: META parity guard is a pure callable check; catalog sections expose exact META id+label+order; each catalog section carries its declared META aliases; non-catalog sections stay OUT of the pinned catalog but resolve from the live registry; folded-in sections keep group+order; **grep-guard** proves `SECTION_VISUALS`, the `Missing settings-section visuals` string, and the inline bypass calls are gone from executable paths and exactly **one** `registerSettingsSection(` call site survives (the loop).
- `settings-section-tokens.test.ts` + `SettingsView.test.tsx` + `slash-menu.test.ts` — **50/50** (token derivation, nav render, `/settings <token>` all still resolve).
- app-core `dev-route-catalog.test.ts` — **9/9** (mirrors `SETTINGS_SECTION_META` exactly; parity holds).
- `tsgo --noEmit` clean (0 errors); `biome check` clean.
- **codex-reviewed** (2 rounds): P2 cloud header-title regression + P3 test cwd-path both fixed; final round only a doc-style P3, also addressed.

Files touched: `packages/ui/src/components/settings/settings-sections.ts`, `packages/ui/src/components/settings/settings-sections.registration.test.ts`.

— [sol-orch]