### PR TITLE
fix(#12490): add bot-free meeting audio capture primitive

### DIFF
--- a/.github/issue-evidence/12490-bot-free-meeting-capture.md
+++ b/.github/issue-evidence/12490-bot-free-meeting-capture.md
@@ -1,0 +1,96 @@
+# Evidence for #12490 - Bot-Free Meeting Capture
+
+## Code PR
+
+https://github.com/elizaOS/eliza/pull/13225
+
+## Human Follow-Up
+
+https://github.com/elizaOS/eliza/issues/13226
+
+## Agent-Completed Work
+
+- Added a browser/desktop bot-free meeting audio capture primitive in
+  `@elizaos/ui/voice`.
+- Captures tab/system display audio through `getDisplayMedia({ audio: true })`
+  and local microphone audio through `getUserMedia`.
+- Keeps local mic and remote tab/system sources separate when both expose audio
+  tracks.
+- Emits explicit source metadata for requested, captured, unavailable, denied,
+  and error states.
+- Records sample rate, channel count, sample count, duration, RMS/peak, display
+  surface, device/group ids, and local-vs-remote sync offset when measurable.
+- Generates source-labeled PCM16 WAV artifacts plus a mixed fallback/reference
+  WAV when both separate sources are available.
+- Exposes support detection without prompting for permissions.
+- Added deterministic unit coverage for support detection, source-mode
+  classification, PCM mixing/clipping, WAV artifact metadata, and permission
+  denied/no-source errors.
+
+## Verification
+
+Commands run on 2026-07-04:
+
+```bash
+bun install
+```
+
+Result: completed. The install synced the shared artifact bundle at
+`2026-06-18.1`; generated artifact changes were restored before committing.
+
+```bash
+bun run --cwd packages/ui test -- bot-free-meeting-audio-capture.test.ts
+```
+
+Result: 1 file passed, 5 tests passed.
+
+```bash
+bunx @biomejs/biome check packages/ui/src/voice/bot-free-meeting-audio-capture.ts packages/ui/src/voice/bot-free-meeting-audio-capture.test.ts packages/ui/src/voice/index.ts
+```
+
+Result: passed with no fixes applied.
+
+```bash
+node packages/shared/scripts/generate-keywords.mjs --target ts
+bun run --cwd packages/contracts build
+bun run --cwd packages/cloud/routing build
+```
+
+Result: passed. These generated/build prerequisites were needed in the fresh
+worktree before package typecheck could resolve shared/core generated keyword
+data and workspace package declarations.
+
+```bash
+bun run --cwd packages/ui typecheck
+```
+
+Result: passed.
+
+```bash
+bun run --cwd packages/ui lint:check
+```
+
+Result: failed outside the files touched by this PR. Existing package-wide
+diagnostics include `src/cloud/shell/cloud-route-gate.test.tsx` useless
+fragments, `src/first-run/use-first-run-conductor.ts:940` assignment in an
+expression, formatting in `src/state/useChatCallbacks.select-race.test.tsx`,
+and formatting in `src/voice/tts-playback-activity.test.ts`. The three touched
+files passed the targeted Biome check above.
+
+```bash
+bun run verify
+```
+
+Result: failed outside this PR in `@elizaos/tui#lint` on existing control
+character regular-expression diagnostics and related TUI lint warnings. The
+type-safety ratchet and error-policy ratchet passed for this branch. Biome
+auto-fixes in unrelated packages were restored before publishing.
+
+## Not Captured By Agent
+
+Live Google Meet and Zoom capture evidence remains human-blocked. The follow-up
+issue must capture a real desktop walkthrough video, source-separated local mic
+and tab/system audio artifacts where platform policy allows, mixed fallback
+audio where separation is impossible, transcript artifact, frontend console and
+network logs, backend logs, permission-denied screenshot, and retention/delete
+proof.

--- a/packages/ui/src/voice/bot-free-meeting-audio-capture.test.ts
+++ b/packages/ui/src/voice/bot-free-meeting-audio-capture.test.ts
@@ -142,6 +142,30 @@ describe("bot-free meeting audio capture helpers", () => {
     ).toBe("browser");
   });
 
+  it("does not create a mixed fallback from a single non-empty source", () => {
+    const artifacts = buildBotFreeMeetingAudioArtifacts([
+      {
+        sourceId: "local-mic",
+        kind: "local_mic",
+        label: "Local microphone",
+        pcm: new Float32Array([0.1, 0.2, 0.3]),
+        sampleRateHz: BOT_FREE_MEETING_AUDIO_SAMPLE_RATE,
+        channelCount: 1,
+      },
+      {
+        sourceId: "remote-tab-or-system",
+        kind: "remote_tab_or_system",
+        label: "Tab/system audio",
+        pcm: new Float32Array(),
+        sampleRateHz: BOT_FREE_MEETING_AUDIO_SAMPLE_RATE,
+        channelCount: 2,
+        displaySurface: "browser",
+      },
+    ]);
+
+    expect(artifacts.map((artifact) => artifact.kind)).toEqual(["local_mic"]);
+  });
+
   it("throws a typed error when no requested source can open", async () => {
     Object.defineProperty(globalThis, "window", {
       configurable: true,

--- a/packages/ui/src/voice/bot-free-meeting-audio-capture.test.ts
+++ b/packages/ui/src/voice/bot-free-meeting-audio-capture.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  BOT_FREE_MEETING_AUDIO_SAMPLE_RATE,
+  type BotFreeMeetingAudioSourceMetadata,
+  buildBotFreeMeetingAudioArtifacts,
+  classifyBotFreeMeetingAudioCaptureMode,
+  getBotFreeMeetingAudioSupport,
+  mixBotFreeMeetingPcm,
+  startBotFreeMeetingAudioCapture,
+} from "./bot-free-meeting-audio-capture";
+
+function source(
+  kind: BotFreeMeetingAudioSourceMetadata["kind"],
+  status: BotFreeMeetingAudioSourceMetadata["status"],
+  sampleCount: number,
+): BotFreeMeetingAudioSourceMetadata {
+  return {
+    id: kind,
+    kind,
+    label: kind,
+    status,
+    requested: true,
+    audioTrackCount: sampleCount > 0 ? 1 : 0,
+    videoTrackCount: 0,
+    channelCount: sampleCount > 0 ? 1 : 0,
+    sampleRateHz: BOT_FREE_MEETING_AUDIO_SAMPLE_RATE,
+    sampleCount,
+    durationMs: Math.round(
+      (sampleCount / BOT_FREE_MEETING_AUDIO_SAMPLE_RATE) * 1000,
+    ),
+    peak: sampleCount > 0 ? 0.1 : 0,
+    rms: sampleCount > 0 ? 0.05 : 0,
+  };
+}
+
+describe("bot-free meeting audio capture helpers", () => {
+  const originalNavigator = globalThis.navigator;
+  const originalWindow = globalThis.window;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: originalNavigator,
+    });
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+  });
+
+  it("reports support without prompting for permissions", () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { AudioContext: class AudioContext {} },
+    });
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {
+        mediaDevices: {
+          getUserMedia: vi.fn(),
+          getDisplayMedia: vi.fn(),
+        },
+        userActivation: { isActive: true },
+      },
+    });
+
+    expect(getBotFreeMeetingAudioSupport()).toEqual({
+      audioContext: true,
+      microphone: true,
+      displayAudio: true,
+      userActivationActive: true,
+    });
+  });
+
+  it("classifies separated, fallback, and unavailable captures from source metadata", () => {
+    expect(
+      classifyBotFreeMeetingAudioCaptureMode([
+        source("local_mic", "captured", 1600),
+        source("remote_tab_or_system", "captured", 1600),
+      ]),
+    ).toBe("separate");
+
+    expect(
+      classifyBotFreeMeetingAudioCaptureMode([
+        source("mixed_fallback", "captured", 1600),
+      ]),
+    ).toBe("mixed_fallback");
+
+    expect(
+      classifyBotFreeMeetingAudioCaptureMode([
+        source("local_mic", "denied", 0),
+        source("remote_tab_or_system", "unavailable", 0),
+      ]),
+    ).toBe("unavailable");
+  });
+
+  it("mixes local and remote PCM with clipping and padding", () => {
+    const mixed = mixBotFreeMeetingPcm([
+      new Float32Array([0.6, -0.7, 0.25]),
+      new Float32Array([0.6, -0.5]),
+    ]);
+
+    expect(Array.from(mixed)).toEqual([1, -1, 0.25]);
+  });
+
+  it("builds source WAV artifacts plus a mixed fallback artifact", () => {
+    const artifacts = buildBotFreeMeetingAudioArtifacts([
+      {
+        sourceId: "local-mic",
+        kind: "local_mic",
+        label: "Local microphone",
+        pcm: new Float32Array([0.1, 0.2, 0.3]),
+        sampleRateHz: BOT_FREE_MEETING_AUDIO_SAMPLE_RATE,
+        channelCount: 1,
+      },
+      {
+        sourceId: "remote-tab-or-system",
+        kind: "remote_tab_or_system",
+        label: "Tab/system audio",
+        pcm: new Float32Array([0.2, 0.1, 0]),
+        sampleRateHz: BOT_FREE_MEETING_AUDIO_SAMPLE_RATE,
+        channelCount: 2,
+        displaySurface: "browser",
+      },
+    ]);
+
+    expect(artifacts.map((artifact) => artifact.kind)).toEqual([
+      "local_mic",
+      "remote_tab_or_system",
+      "mixed_fallback",
+    ]);
+    for (const artifact of artifacts) {
+      expect(artifact.mimeType).toBe("audio/wav");
+      expect(artifact.byteLength).toBeGreaterThan(44);
+      expect(String.fromCharCode(...artifact.audio.slice(0, 4))).toBe("RIFF");
+      expect(artifact.metadata.sampleCount).toBe(3);
+    }
+    expect(
+      artifacts.find((artifact) => artifact.kind === "remote_tab_or_system")
+        ?.metadata.displaySurface,
+    ).toBe("browser");
+  });
+
+  it("throws a typed error when no requested source can open", async () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        AudioContext: class AudioContext {
+          state = "running";
+          sampleRate = BOT_FREE_MEETING_AUDIO_SAMPLE_RATE;
+          close = vi.fn(async () => undefined);
+        },
+      },
+    });
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {
+        mediaDevices: {
+          getDisplayMedia: vi.fn(async () => {
+            throw new DOMException("blocked", "NotAllowedError");
+          }),
+          getUserMedia: vi.fn(async () => {
+            throw new DOMException("blocked", "NotAllowedError");
+          }),
+        },
+        userActivation: { isActive: true },
+      },
+    });
+
+    await expect(startBotFreeMeetingAudioCapture()).rejects.toMatchObject({
+      name: "BotFreeMeetingAudioCaptureError",
+      sources: [
+        expect.objectContaining({
+          kind: "remote_tab_or_system",
+          status: "denied",
+        }),
+        expect.objectContaining({ kind: "local_mic", status: "denied" }),
+      ],
+    });
+  });
+});

--- a/packages/ui/src/voice/bot-free-meeting-audio-capture.ts
+++ b/packages/ui/src/voice/bot-free-meeting-audio-capture.ts
@@ -1,0 +1,726 @@
+/**
+ * Bot-free meeting capture for browser/desktop renderers.
+ *
+ * Captures the local microphone and tab/system audio as separate PCM streams
+ * when browser policy allows `getDisplayMedia({ audio: true })`. The caller
+ * must invoke `startBotFreeMeetingAudioCapture()` from an explicit user action:
+ * browsers intentionally prompt every display-audio capture request.
+ */
+import {
+  encodeMonoPcm16Wav,
+  measurePcmAudio,
+  type PcmAudioStats,
+} from "./local-asr-capture";
+
+export const BOT_FREE_MEETING_AUDIO_SAMPLE_RATE = 16_000;
+const PROCESSOR_BUFFER_SIZE = 4096;
+
+type AudioContextConstructor = typeof AudioContext;
+
+type WindowWithAudioContext = Window & {
+  AudioContext?: AudioContextConstructor;
+  webkitAudioContext?: AudioContextConstructor;
+};
+
+type DisplayAudioConstraints = MediaTrackConstraints & {
+  systemAudio?: "include" | "exclude";
+  windowAudio?: "exclude" | "window" | "system";
+  suppressLocalAudioPlayback?: boolean;
+};
+
+type BotFreeDisplayMediaOptions = DisplayMediaStreamOptions & {
+  audio?: boolean | DisplayAudioConstraints;
+};
+
+type MediaDevicesWithDisplayMedia = MediaDevices & {
+  getDisplayMedia?: (
+    constraints?: BotFreeDisplayMediaOptions,
+  ) => Promise<MediaStream>;
+};
+
+export type BotFreeMeetingAudioSourceKind =
+  | "local_mic"
+  | "remote_tab_or_system"
+  | "mixed_fallback";
+
+export type BotFreeMeetingAudioSourceStatus =
+  | "requested"
+  | "capturing"
+  | "captured"
+  | "unavailable"
+  | "denied"
+  | "error";
+
+export type BotFreeMeetingAudioCaptureMode =
+  | "separate"
+  | "mixed_fallback"
+  | "local_only"
+  | "remote_only"
+  | "unavailable";
+
+export interface BotFreeMeetingAudioSupport {
+  audioContext: boolean;
+  microphone: boolean;
+  displayAudio: boolean;
+  /** `null` outside browsers that expose the User Activation API. */
+  userActivationActive: boolean | null;
+}
+
+export interface BotFreeMeetingAudioSourceMetadata {
+  id: string;
+  kind: BotFreeMeetingAudioSourceKind;
+  label: string;
+  status: BotFreeMeetingAudioSourceStatus;
+  requested: boolean;
+  audioTrackCount: number;
+  videoTrackCount: number;
+  channelCount: number;
+  sampleRateHz: number;
+  sampleCount: number;
+  durationMs: number;
+  peak: number;
+  rms: number;
+  syncOffsetMs?: number;
+  displaySurface?: string;
+  deviceId?: string;
+  groupId?: string;
+  errorName?: string;
+  errorMessage?: string;
+}
+
+export interface BotFreeMeetingAudioArtifact {
+  sourceId: string;
+  kind: BotFreeMeetingAudioSourceKind;
+  mimeType: "audio/wav";
+  sampleRateHz: number;
+  durationMs: number;
+  byteLength: number;
+  audio: Uint8Array;
+  metadata: BotFreeMeetingAudioSourceMetadata;
+}
+
+export interface BotFreeMeetingAudioCaptureResult {
+  mode: BotFreeMeetingAudioCaptureMode;
+  startedAtUnixMs: number;
+  endedAtUnixMs: number;
+  durationMs: number;
+  userActivationAtStart: boolean | null;
+  sources: BotFreeMeetingAudioSourceMetadata[];
+  artifacts: BotFreeMeetingAudioArtifact[];
+}
+
+export interface BotFreeMeetingAudioCaptureOptions {
+  captureLocalMic?: boolean;
+  captureRemoteAudio?: boolean;
+  includeMixedFallbackArtifact?: boolean;
+  stopDisplayVideoTracks?: boolean;
+  localMicConstraints?: MediaTrackConstraints;
+  remoteAudioConstraints?: DisplayAudioConstraints;
+  now?: () => number;
+}
+
+export interface BotFreeMeetingAudioCaptureHandle {
+  stop(): Promise<BotFreeMeetingAudioCaptureResult>;
+  cancel(): void;
+  snapshot(): BotFreeMeetingAudioSourceMetadata[];
+}
+
+export class BotFreeMeetingAudioCaptureError extends Error {
+  readonly sources: BotFreeMeetingAudioSourceMetadata[];
+
+  constructor(message: string, sources: BotFreeMeetingAudioSourceMetadata[]) {
+    super(message);
+    this.name = "BotFreeMeetingAudioCaptureError";
+    this.sources = sources;
+  }
+}
+
+export interface BotFreeMeetingCapturedPcm {
+  sourceId: string;
+  kind: Exclude<BotFreeMeetingAudioSourceKind, "mixed_fallback">;
+  label: string;
+  pcm: Float32Array;
+  sampleRateHz: number;
+  channelCount: number;
+  firstFrameContextTime?: number;
+  displaySurface?: string;
+  deviceId?: string;
+  groupId?: string;
+}
+
+interface SourceRecorder {
+  metadata: BotFreeMeetingAudioSourceMetadata;
+  stop(): BotFreeMeetingCapturedPcm;
+  cancel(): void;
+}
+
+function getAudioContextCtor(): AudioContextConstructor | undefined {
+  if (typeof window === "undefined") return undefined;
+  const win = window as WindowWithAudioContext;
+  return win.AudioContext ?? win.webkitAudioContext;
+}
+
+function getMediaDevices(): MediaDevicesWithDisplayMedia | null {
+  if (typeof navigator === "undefined") return null;
+  return (navigator.mediaDevices ??
+    null) as MediaDevicesWithDisplayMedia | null;
+}
+
+function currentUserActivation(): boolean | null {
+  if (typeof navigator === "undefined") return null;
+  const activation = navigator.userActivation;
+  return activation ? activation.isActive : null;
+}
+
+function emptyMetadata(
+  id: string,
+  kind: BotFreeMeetingAudioSourceKind,
+  label: string,
+  status: BotFreeMeetingAudioSourceStatus,
+  requested = true,
+): BotFreeMeetingAudioSourceMetadata {
+  return {
+    id,
+    kind,
+    label,
+    status,
+    requested,
+    audioTrackCount: 0,
+    videoTrackCount: 0,
+    channelCount: 0,
+    sampleRateHz: BOT_FREE_MEETING_AUDIO_SAMPLE_RATE,
+    sampleCount: 0,
+    durationMs: 0,
+    peak: 0,
+    rms: 0,
+  };
+}
+
+function captureErrorMetadata(
+  id: string,
+  kind: BotFreeMeetingAudioSourceKind,
+  label: string,
+  err: unknown,
+): BotFreeMeetingAudioSourceMetadata {
+  const domName =
+    err instanceof DOMException
+      ? err.name
+      : err instanceof Error
+        ? err.name
+        : "";
+  const status: BotFreeMeetingAudioSourceStatus =
+    domName === "NotAllowedError" || domName === "SecurityError"
+      ? "denied"
+      : "error";
+  const message = err instanceof Error ? err.message : String(err);
+  return {
+    ...emptyMetadata(id, kind, label, status),
+    ...(domName ? { errorName: domName } : {}),
+    errorMessage: message,
+  };
+}
+
+function trackSetting(
+  track: MediaStreamTrack | undefined,
+  key: keyof MediaTrackSettings,
+): string | undefined {
+  if (!track) return undefined;
+  const value = track.getSettings()[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function displaySurface(
+  track: MediaStreamTrack | undefined,
+): string | undefined {
+  if (!track) return undefined;
+  const settings = track.getSettings() as MediaTrackSettings & {
+    displaySurface?: string;
+  };
+  return settings.displaySurface;
+}
+
+export function getBotFreeMeetingAudioSupport(): BotFreeMeetingAudioSupport {
+  const mediaDevices = getMediaDevices();
+  return {
+    audioContext: !!getAudioContextCtor(),
+    microphone: typeof mediaDevices?.getUserMedia === "function",
+    displayAudio: typeof mediaDevices?.getDisplayMedia === "function",
+    userActivationActive: currentUserActivation(),
+  };
+}
+
+export function classifyBotFreeMeetingAudioCaptureMode(
+  sources: ReadonlyArray<BotFreeMeetingAudioSourceMetadata>,
+): BotFreeMeetingAudioCaptureMode {
+  const active = (kind: BotFreeMeetingAudioSourceKind): boolean =>
+    sources.some(
+      (source) =>
+        source.kind === kind &&
+        (source.status === "capturing" || source.status === "captured") &&
+        source.sampleCount > 0,
+    );
+
+  const local = active("local_mic");
+  const remote = active("remote_tab_or_system");
+  const mixed = active("mixed_fallback");
+  if (local && remote) return "separate";
+  if (mixed) return "mixed_fallback";
+  if (local) return "local_only";
+  if (remote) return "remote_only";
+  return "unavailable";
+}
+
+export function mixBotFreeMeetingPcm(
+  sources: ReadonlyArray<Float32Array>,
+): Float32Array {
+  const maxLength = sources.reduce(
+    (max, source) => Math.max(max, source.length),
+    0,
+  );
+  const mixed = new Float32Array(maxLength);
+  for (const source of sources) {
+    for (let index = 0; index < source.length; index += 1) {
+      const sum = mixed[index] + source[index];
+      mixed[index] = Math.max(-1, Math.min(1, sum));
+    }
+  }
+  return mixed;
+}
+
+export function buildBotFreeMeetingAudioArtifacts(
+  captured: ReadonlyArray<BotFreeMeetingCapturedPcm>,
+  includeMixedFallbackArtifact = true,
+): BotFreeMeetingAudioArtifact[] {
+  const artifacts: BotFreeMeetingAudioArtifact[] = captured
+    .filter((source) => source.pcm.length > 0)
+    .map((source) => {
+      const metadata = capturedMetadata(source, "captured");
+      const audio = encodeMonoPcm16Wav(source.pcm, source.sampleRateHz);
+      return {
+        sourceId: source.sourceId,
+        kind: source.kind,
+        mimeType: "audio/wav" as const,
+        sampleRateHz: source.sampleRateHz,
+        durationMs: metadata.durationMs,
+        byteLength: audio.byteLength,
+        audio,
+        metadata,
+      };
+    });
+
+  if (includeMixedFallbackArtifact && captured.length > 1) {
+    const sampleRateHz =
+      captured[0]?.sampleRateHz ?? BOT_FREE_MEETING_AUDIO_SAMPLE_RATE;
+    const mixed = mixBotFreeMeetingPcm(captured.map((source) => source.pcm));
+    const stats = measurePcmAudio(mixed);
+    const durationMs = Math.round((mixed.length / sampleRateHz) * 1000);
+    const metadata: BotFreeMeetingAudioSourceMetadata = {
+      ...emptyMetadata(
+        "mixed-fallback",
+        "mixed_fallback",
+        "Mixed local + remote fallback",
+        "captured",
+      ),
+      audioTrackCount: captured.length,
+      channelCount: 1,
+      sampleRateHz,
+      sampleCount: mixed.length,
+      durationMs,
+      ...stats,
+    };
+    const audio = encodeMonoPcm16Wav(mixed, sampleRateHz);
+    artifacts.push({
+      sourceId: metadata.id,
+      kind: "mixed_fallback",
+      mimeType: "audio/wav",
+      sampleRateHz,
+      durationMs,
+      byteLength: audio.byteLength,
+      audio,
+      metadata,
+    });
+  }
+
+  return artifacts;
+}
+
+function capturedMetadata(
+  source: BotFreeMeetingCapturedPcm,
+  status: BotFreeMeetingAudioSourceStatus,
+): BotFreeMeetingAudioSourceMetadata {
+  const stats: PcmAudioStats = measurePcmAudio(source.pcm);
+  const durationMs = Math.round(
+    (source.pcm.length / source.sampleRateHz) * 1000,
+  );
+  return {
+    ...emptyMetadata(source.sourceId, source.kind, source.label, status),
+    audioTrackCount: 1,
+    channelCount: source.channelCount,
+    sampleRateHz: source.sampleRateHz,
+    sampleCount: source.pcm.length,
+    durationMs,
+    ...stats,
+    ...(source.displaySurface ? { displaySurface: source.displaySurface } : {}),
+    ...(source.deviceId ? { deviceId: source.deviceId } : {}),
+    ...(source.groupId ? { groupId: source.groupId } : {}),
+  };
+}
+
+function concatPcm(chunks: Float32Array[]): Float32Array {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const out = new Float32Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+function ignoreAudioGraphTeardownError(_err: unknown): void {
+  // WebAudio nodes may already be disconnected when a track ends during stop().
+}
+
+function createSourceRecorder(
+  context: AudioContext,
+  stream: MediaStream,
+  sourceId: string,
+  kind: Exclude<BotFreeMeetingAudioSourceKind, "mixed_fallback">,
+  label: string,
+): SourceRecorder {
+  const audioTracks = stream.getAudioTracks();
+  const videoTracks = stream.getVideoTracks();
+  const primaryAudio = audioTracks[0];
+  const primaryVideo = videoTracks[0];
+  const chunks: Float32Array[] = [];
+  const source = context.createMediaStreamSource(stream);
+  const processor = context.createScriptProcessor(PROCESSOR_BUFFER_SIZE, 2, 1);
+  const gain = context.createGain();
+  gain.gain.value = 0;
+
+  let channelCount = primaryAudio?.getSettings().channelCount ?? 1;
+  let firstFrameContextTime: number | undefined;
+  let sumSquares = 0;
+  let peak = 0;
+  let stopped = false;
+
+  const metadata: BotFreeMeetingAudioSourceMetadata = {
+    ...emptyMetadata(sourceId, kind, label, "capturing"),
+    audioTrackCount: audioTracks.length,
+    videoTrackCount: videoTracks.length,
+    channelCount,
+    sampleRateHz: context.sampleRate,
+    ...(displaySurface(primaryVideo)
+      ? { displaySurface: displaySurface(primaryVideo) }
+      : {}),
+    ...(trackSetting(primaryAudio, "deviceId")
+      ? { deviceId: trackSetting(primaryAudio, "deviceId") }
+      : {}),
+    ...(trackSetting(primaryAudio, "groupId")
+      ? { groupId: trackSetting(primaryAudio, "groupId") }
+      : {}),
+  };
+
+  processor.onaudioprocess = (event: AudioProcessingEvent) => {
+    if (stopped) return;
+    const input = event.inputBuffer;
+    const frameCount = input.length;
+    channelCount = Math.max(1, input.numberOfChannels);
+    if (firstFrameContextTime === undefined) {
+      firstFrameContextTime = event.playbackTime;
+    }
+    const mono = new Float32Array(frameCount);
+    for (let channel = 0; channel < channelCount; channel += 1) {
+      const data = input.getChannelData(channel);
+      for (let index = 0; index < frameCount; index += 1) {
+        mono[index] += (data[index] ?? 0) / channelCount;
+      }
+    }
+    chunks.push(mono);
+    for (const sample of mono) {
+      const value = Number.isFinite(sample) ? sample : 0;
+      const abs = Math.abs(value);
+      sumSquares += value * value;
+      if (abs > peak) peak = abs;
+    }
+    metadata.channelCount = channelCount;
+    metadata.sampleCount += mono.length;
+    metadata.durationMs = Math.round(
+      (metadata.sampleCount / context.sampleRate) * 1000,
+    );
+    metadata.rms =
+      metadata.sampleCount > 0
+        ? Math.sqrt(sumSquares / metadata.sampleCount)
+        : 0;
+    metadata.peak = peak;
+  };
+
+  source.connect(processor);
+  processor.connect(gain);
+  gain.connect(context.destination);
+
+  const disconnect = () => {
+    stopped = true;
+    processor.onaudioprocess = null;
+    try {
+      source.disconnect();
+    } catch (err) {
+      ignoreAudioGraphTeardownError(err);
+    }
+    try {
+      processor.disconnect();
+    } catch (err) {
+      ignoreAudioGraphTeardownError(err);
+    }
+    try {
+      gain.disconnect();
+    } catch (err) {
+      ignoreAudioGraphTeardownError(err);
+    }
+    for (const track of stream.getTracks()) {
+      track.stop();
+    }
+  };
+
+  return {
+    metadata,
+    stop() {
+      disconnect();
+      const pcm = concatPcm(chunks);
+      return {
+        sourceId,
+        kind,
+        label,
+        pcm,
+        sampleRateHz: context.sampleRate,
+        channelCount,
+        ...(firstFrameContextTime !== undefined
+          ? { firstFrameContextTime }
+          : {}),
+        ...(metadata.displaySurface
+          ? { displaySurface: metadata.displaySurface }
+          : {}),
+        ...(metadata.deviceId ? { deviceId: metadata.deviceId } : {}),
+        ...(metadata.groupId ? { groupId: metadata.groupId } : {}),
+      };
+    },
+    cancel: disconnect,
+  };
+}
+
+async function openLocalMic(
+  devices: MediaDevicesWithDisplayMedia,
+  constraints?: MediaTrackConstraints,
+): Promise<MediaStream> {
+  return devices.getUserMedia({
+    audio: {
+      channelCount: 1,
+      sampleRate: BOT_FREE_MEETING_AUDIO_SAMPLE_RATE,
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+      ...constraints,
+    },
+    video: false,
+  });
+}
+
+async function openRemoteDisplayAudio(
+  devices: MediaDevicesWithDisplayMedia,
+  constraints?: DisplayAudioConstraints,
+): Promise<MediaStream> {
+  if (typeof devices.getDisplayMedia !== "function") {
+    throw new Error("Display audio capture is not available in this renderer");
+  }
+  return devices.getDisplayMedia({
+    audio: {
+      channelCount: 2,
+      echoCancellation: false,
+      noiseSuppression: false,
+      autoGainControl: false,
+      systemAudio: "include",
+      windowAudio: "system",
+      suppressLocalAudioPlayback: false,
+      ...constraints,
+    },
+    video: true,
+  });
+}
+
+export async function startBotFreeMeetingAudioCapture(
+  options: BotFreeMeetingAudioCaptureOptions = {},
+): Promise<BotFreeMeetingAudioCaptureHandle> {
+  const AudioContextCtor = getAudioContextCtor();
+  if (!AudioContextCtor) {
+    throw new BotFreeMeetingAudioCaptureError(
+      "AudioContext is not available for bot-free meeting capture",
+      [],
+    );
+  }
+  const devices = getMediaDevices();
+  if (!devices) {
+    throw new BotFreeMeetingAudioCaptureError(
+      "Media devices are not available for bot-free meeting capture",
+      [],
+    );
+  }
+
+  const captureLocalMic = options.captureLocalMic ?? true;
+  const captureRemoteAudio = options.captureRemoteAudio ?? true;
+  const includeMixedFallbackArtifact =
+    options.includeMixedFallbackArtifact ?? true;
+  const stopDisplayVideoTracks = options.stopDisplayVideoTracks ?? true;
+  const now = options.now ?? Date.now;
+  const userActivationAtStart = currentUserActivation();
+  const startedAtUnixMs = now();
+  const context = new AudioContextCtor({
+    sampleRate: BOT_FREE_MEETING_AUDIO_SAMPLE_RATE,
+  });
+  if (context.state === "suspended") {
+    await context.resume().catch(() => {});
+  }
+
+  const recorders: SourceRecorder[] = [];
+  const sourceMetadata: BotFreeMeetingAudioSourceMetadata[] = [];
+
+  if (captureRemoteAudio) {
+    try {
+      const stream = await openRemoteDisplayAudio(
+        devices,
+        options.remoteAudioConstraints,
+      );
+      if (stopDisplayVideoTracks) {
+        for (const track of stream.getVideoTracks()) {
+          track.stop();
+        }
+      }
+      if (stream.getAudioTracks().length === 0) {
+        for (const track of stream.getTracks()) {
+          track.stop();
+        }
+        sourceMetadata.push({
+          ...emptyMetadata(
+            "remote-tab-or-system",
+            "remote_tab_or_system",
+            "Tab/system audio",
+            "unavailable",
+          ),
+          videoTrackCount: stream.getVideoTracks().length,
+          errorMessage:
+            "The selected display surface did not expose an audio track.",
+        });
+      } else {
+        const recorder = createSourceRecorder(
+          context,
+          stream,
+          "remote-tab-or-system",
+          "remote_tab_or_system",
+          "Tab/system audio",
+        );
+        recorders.push(recorder);
+        sourceMetadata.push(recorder.metadata);
+      }
+    } catch (err) {
+      sourceMetadata.push(
+        captureErrorMetadata(
+          "remote-tab-or-system",
+          "remote_tab_or_system",
+          "Tab/system audio",
+          err,
+        ),
+      );
+    }
+  }
+
+  if (captureLocalMic) {
+    try {
+      const stream = await openLocalMic(devices, options.localMicConstraints);
+      const recorder = createSourceRecorder(
+        context,
+        stream,
+        "local-mic",
+        "local_mic",
+        "Local microphone",
+      );
+      recorders.push(recorder);
+      sourceMetadata.push(recorder.metadata);
+    } catch (err) {
+      sourceMetadata.push(
+        captureErrorMetadata("local-mic", "local_mic", "Local microphone", err),
+      );
+    }
+  }
+
+  if (recorders.length === 0) {
+    await context.close().catch(() => {});
+    throw new BotFreeMeetingAudioCaptureError(
+      "No meeting audio source could be captured",
+      sourceMetadata,
+    );
+  }
+
+  let stopped = false;
+  let cachedResult: BotFreeMeetingAudioCaptureResult | null = null;
+
+  const stop = async (): Promise<BotFreeMeetingAudioCaptureResult> => {
+    if (cachedResult) return cachedResult;
+    stopped = true;
+    const captured = recorders.map((recorder) => recorder.stop());
+    await context.close().catch(() => {});
+    const artifacts = buildBotFreeMeetingAudioArtifacts(
+      captured,
+      includeMixedFallbackArtifact,
+    );
+    const artifactMetadata = artifacts.map((artifact) => artifact.metadata);
+    const endedAtUnixMs = now();
+    const sources = [
+      ...sourceMetadata.filter(
+        (source) =>
+          !artifactMetadata.some((artifact) => artifact.id === source.id),
+      ),
+      ...artifactMetadata,
+    ];
+    const remoteFirst = captured.find(
+      (source) => source.kind === "remote_tab_or_system",
+    )?.firstFrameContextTime;
+    const localFirst = captured.find(
+      (source) => source.kind === "local_mic",
+    )?.firstFrameContextTime;
+    if (remoteFirst !== undefined && localFirst !== undefined) {
+      const syncOffsetMs = Math.round((localFirst - remoteFirst) * 1000);
+      for (const source of sources) {
+        if (
+          source.kind === "local_mic" ||
+          source.kind === "remote_tab_or_system"
+        ) {
+          source.syncOffsetMs = syncOffsetMs;
+        }
+      }
+    }
+    cachedResult = {
+      mode: classifyBotFreeMeetingAudioCaptureMode(sources),
+      startedAtUnixMs,
+      endedAtUnixMs,
+      durationMs: Math.max(0, endedAtUnixMs - startedAtUnixMs),
+      userActivationAtStart,
+      sources,
+      artifacts,
+    };
+    return cachedResult;
+  };
+
+  const cancel = (): void => {
+    if (stopped) return;
+    stopped = true;
+    for (const recorder of recorders) {
+      recorder.cancel();
+    }
+    void context.close().catch(() => {});
+  };
+
+  return {
+    stop,
+    cancel,
+    snapshot: () => sourceMetadata.map((source) => ({ ...source })),
+  };
+}

--- a/packages/ui/src/voice/bot-free-meeting-audio-capture.ts
+++ b/packages/ui/src/voice/bot-free-meeting-audio-capture.ts
@@ -291,9 +291,9 @@ export function buildBotFreeMeetingAudioArtifacts(
   captured: ReadonlyArray<BotFreeMeetingCapturedPcm>,
   includeMixedFallbackArtifact = true,
 ): BotFreeMeetingAudioArtifact[] {
-  const artifacts: BotFreeMeetingAudioArtifact[] = captured
-    .filter((source) => source.pcm.length > 0)
-    .map((source) => {
+  const capturedWithAudio = captured.filter((source) => source.pcm.length > 0);
+  const artifacts: BotFreeMeetingAudioArtifact[] = capturedWithAudio.map(
+    (source) => {
       const metadata = capturedMetadata(source, "captured");
       const audio = encodeMonoPcm16Wav(source.pcm, source.sampleRateHz);
       return {
@@ -306,12 +306,15 @@ export function buildBotFreeMeetingAudioArtifacts(
         audio,
         metadata,
       };
-    });
+    },
+  );
 
-  if (includeMixedFallbackArtifact && captured.length > 1) {
+  if (includeMixedFallbackArtifact && capturedWithAudio.length > 1) {
     const sampleRateHz =
-      captured[0]?.sampleRateHz ?? BOT_FREE_MEETING_AUDIO_SAMPLE_RATE;
-    const mixed = mixBotFreeMeetingPcm(captured.map((source) => source.pcm));
+      capturedWithAudio[0]?.sampleRateHz ?? BOT_FREE_MEETING_AUDIO_SAMPLE_RATE;
+    const mixed = mixBotFreeMeetingPcm(
+      capturedWithAudio.map((source) => source.pcm),
+    );
     const stats = measurePcmAudio(mixed);
     const durationMs = Math.round((mixed.length / sampleRateHz) * 1000);
     const metadata: BotFreeMeetingAudioSourceMetadata = {
@@ -321,7 +324,7 @@ export function buildBotFreeMeetingAudioArtifacts(
         "Mixed local + remote fallback",
         "captured",
       ),
-      audioTrackCount: captured.length,
+      audioTrackCount: capturedWithAudio.length,
       channelCount: 1,
       sampleRateHz,
       sampleCount: mixed.length,

--- a/packages/ui/src/voice/index.ts
+++ b/packages/ui/src/voice/index.ts
@@ -18,6 +18,25 @@ export {
   type AudioFramePumpOptions,
   type AudioFramePumpStartResult,
 } from "./audio-frame-pump";
+export {
+  BOT_FREE_MEETING_AUDIO_SAMPLE_RATE,
+  type BotFreeMeetingAudioArtifact,
+  BotFreeMeetingAudioCaptureError,
+  type BotFreeMeetingAudioCaptureHandle,
+  type BotFreeMeetingAudioCaptureMode,
+  type BotFreeMeetingAudioCaptureOptions,
+  type BotFreeMeetingAudioCaptureResult,
+  type BotFreeMeetingAudioSourceKind,
+  type BotFreeMeetingAudioSourceMetadata,
+  type BotFreeMeetingAudioSourceStatus,
+  type BotFreeMeetingAudioSupport,
+  type BotFreeMeetingCapturedPcm,
+  buildBotFreeMeetingAudioArtifacts,
+  classifyBotFreeMeetingAudioCaptureMode,
+  getBotFreeMeetingAudioSupport,
+  mixBotFreeMeetingPcm,
+  startBotFreeMeetingAudioCapture,
+} from "./bot-free-meeting-audio-capture";
 export * from "./character-voice-config";
 export * from "./emotion";
 export {


### PR DESCRIPTION
## Summary

- Add a browser/desktop bot-free meeting capture primitive under `@elizaos/ui/voice`.
- Capture local mic and tab/system display audio separately when browser policy exposes both streams.
- Emit explicit source metadata for captured, unavailable, denied, and error states.
- Produce source-labeled PCM16 WAV artifacts and a mixed fallback/reference WAV for downstream retention/transcript flows.
- Add deterministic unit coverage for support detection, classification, PCM mixing, artifact metadata, and permission-denied/no-source errors.

## Human follow-up

- #13226 tracks the remaining real Meet/Zoom desktop capture evidence, permission screenshots/video, logs, transcript artifacts, and retention/delete proof.

## Verification

- `bun install` -> completed; artifact sync at `2026-06-18.1`, generated artifact changes restored.
- `bun run --cwd packages/ui test -- bot-free-meeting-audio-capture.test.ts` -> 1 file passed, 5 tests passed.
- `bunx @biomejs/biome check packages/ui/src/voice/bot-free-meeting-audio-capture.ts packages/ui/src/voice/bot-free-meeting-audio-capture.test.ts packages/ui/src/voice/index.ts` -> passed.
- `node packages/shared/scripts/generate-keywords.mjs --target ts` -> passed.
- `bun run --cwd packages/contracts build` -> passed.
- `bun run --cwd packages/cloud/routing build` -> passed.
- `bun run --cwd packages/ui typecheck` -> passed.
- `bun run --cwd packages/ui lint:check` -> failed outside touched files on existing package-wide diagnostics in `src/cloud/shell/cloud-route-gate.test.tsx`, `src/first-run/use-first-run-conductor.ts`, `src/state/useChatCallbacks.select-race.test.tsx`, and `src/voice/tts-playback-activity.test.ts`. The touched files pass targeted Biome.
- `bun run verify` -> failed outside this PR in `@elizaos/tui#lint` on existing control-character regex diagnostics and related TUI lint warnings. Type-safety and error-policy ratchets passed for this branch; unrelated Biome auto-fixes were restored.

## Evidence

- `.github/issue-evidence/12490-bot-free-meeting-capture.md`
