### PR TITLE
fix(#12784): three-state rendering for memories people, auto-training, and mobile-signals permissions

### DIFF
--- a/packages/ui/src/components/chat/widgets/agent-provisioning.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-provisioning.tsx
@@ -109,7 +109,9 @@ export function AgentProvisioningWidget(
         if (response.success)
           setStatusText(statusTextFor(response.data.status));
       } catch {
-        // Bounded poll hung or errored: keep the generic "Setting up…" copy.
+        // error-policy:J4 bounded status poll is an enhancement over the
+        // generic "Setting up…" copy; a hung/errored poll degrades to that
+        // designed copy rather than blocking the provisioning tile.
         if (!cancelled) setStatusText(null);
       }
     })();

--- a/packages/ui/src/components/chat/widgets/wallet-balance.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.tsx
@@ -72,7 +72,9 @@ export function WalletBalanceWidget(
         if (cancelled) return;
         setHoldings(selectPricedHoldings(balances, overview?.prices));
       } catch {
-        // Wallet endpoint unreachable/errored: nothing to surface → empty state.
+        // error-policy:J4 home-grid tiles self-hide rather than surface error
+        // chrome (designed home-surface degrade); the wallet page itself owns
+        // the visible error state for a broken balances endpoint.
         if (!cancelled) setHoldings(null);
       } finally {
         if (!cancelled) setLoading(false);

--- a/packages/ui/src/components/pages/MemoryViewerView.people-error.test.tsx
+++ b/packages/ui/src/components/pages/MemoryViewerView.people-error.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+//
+// Three-state guard for the Memories people sidebar (#12784): a failed
+// relationships load must render the explicit "Could not load people." error
+// row — never the designed "No people yet." healthy-empty state. A 404 (the
+// relationships surface isn't hosted on this runtime) IS the designed empty
+// state, so it stays on the empty copy.
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../../api/client-types-core";
+import { __resetResourceCache } from "../../hooks/resource-cache";
+
+const clientMock = vi.hoisted(() => ({
+  getMemoryStats: vi.fn(),
+  getRelationshipsPeople: vi.fn(),
+  getMemoryFeed: vi.fn(),
+  browseMemories: vi.fn(),
+  getMemoriesByEntity: vi.fn(),
+}));
+
+vi.mock("../../api/client", () => ({ client: clientMock }));
+
+vi.mock("../../state", () => ({
+  useAppSelector: (
+    selector: (s: {
+      t: (key: string, options?: { defaultValue?: string }) => string;
+      setTab: () => void;
+    }) => unknown,
+  ) =>
+    selector({
+      t: (_key, options) => options?.defaultValue ?? _key,
+      setTab: vi.fn(),
+    }),
+}));
+
+import { MemoryViewerView } from "./MemoryViewerView";
+
+function mockDesktopViewport() {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: true, // "(min-width: 820px)" matches → persistent sidebar
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+beforeEach(() => {
+  mockDesktopViewport();
+  __resetResourceCache();
+  clientMock.getMemoryStats.mockResolvedValue({
+    total: 0,
+    byType: {},
+  });
+  clientMock.getMemoryFeed.mockResolvedValue({
+    memories: [],
+    count: 0,
+    limit: 30,
+    hasMore: false,
+  });
+  clientMock.browseMemories.mockResolvedValue({
+    memories: [],
+    total: 0,
+    limit: 30,
+    offset: 0,
+  });
+  clientMock.getMemoriesByEntity.mockResolvedValue({
+    memories: [],
+    total: 0,
+    limit: 30,
+    offset: 0,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  clientMock.getMemoryStats.mockReset();
+  clientMock.getRelationshipsPeople.mockReset();
+  clientMock.getMemoryFeed.mockReset();
+  clientMock.browseMemories.mockReset();
+  clientMock.getMemoriesByEntity.mockReset();
+});
+
+describe("MemoryViewerView people sidebar three-state rendering", () => {
+  it("renders the error row (not the designed empty state) when the people load fails", async () => {
+    clientMock.getRelationshipsPeople.mockRejectedValue(
+      new ApiError({
+        kind: "http",
+        path: "/api/relationships/people",
+        message: "Internal Server Error",
+        status: 500,
+      }),
+    );
+
+    render(<MemoryViewerView />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("memory-people-error")).not.toBeNull(),
+    );
+    expect(screen.getByTestId("memory-people-error").textContent).toContain(
+      "Could not load people.",
+    );
+    expect(screen.queryByText("No people yet.")).toBeNull();
+  });
+
+  it("renders the error row on a transport failure", async () => {
+    clientMock.getRelationshipsPeople.mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    );
+
+    render(<MemoryViewerView />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("memory-people-error")).not.toBeNull(),
+    );
+    expect(screen.queryByText("No people yet.")).toBeNull();
+  });
+
+  it("renders the designed empty state (not an error) when the surface 404s", async () => {
+    clientMock.getRelationshipsPeople.mockRejectedValue(
+      new ApiError({
+        kind: "http",
+        path: "/api/relationships/people",
+        message: "Not Found",
+        status: 404,
+      }),
+    );
+
+    render(<MemoryViewerView />);
+
+    await waitFor(() =>
+      expect(screen.getByText("No people yet.")).not.toBeNull(),
+    );
+    expect(screen.queryByTestId("memory-people-error")).toBeNull();
+  });
+
+  it("renders the people list on success", async () => {
+    clientMock.getRelationshipsPeople.mockResolvedValue({
+      people: [
+        {
+          groupId: "group-1",
+          primaryEntityId: "entity-1",
+          memberEntityIds: ["entity-1"],
+          displayName: "Ada Lovelace",
+          aliases: [],
+          platforms: ["discord"],
+          identities: [],
+          emails: [],
+          phones: [],
+          websites: [],
+          preferredCommunicationChannel: null,
+          categories: [],
+          tags: [],
+          factCount: 3,
+          relationshipCount: 1,
+        },
+      ],
+    });
+
+    render(<MemoryViewerView />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Ada Lovelace")).not.toBeNull(),
+    );
+    expect(screen.queryByTestId("memory-people-error")).toBeNull();
+    expect(screen.queryByText("No people yet.")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/pages/MemoryViewerView.tsx
+++ b/packages/ui/src/components/pages/MemoryViewerView.tsx
@@ -32,6 +32,7 @@ import type {
   MemoryFeedResponse,
   MemoryStatsResponse,
 } from "../../api/client-types-chat";
+import { isApiError } from "../../api/client-types-core";
 import type { RelationshipsPersonSummary } from "../../api/client-types-relationships";
 import { getCached, setCached } from "../../hooks/resource-cache";
 import { useIntervalWhenDocumentVisible } from "../../hooks/useDocumentVisibility";
@@ -669,9 +670,12 @@ export function MemoryViewerView({
   const [stats, setStats] = useState<MemoryStatsResponse | null>(null);
   const [statsError, setStatsError] = useState(false);
 
-  // People list for person-centric view
+  // People list for person-centric view. `peopleError` keeps a failed load
+  // visually distinct from the designed "No people yet." empty state — a
+  // 5xx/transport failure must never render as healthy-empty (three-state rule).
   const [people, setPeople] = useState<RelationshipsPersonSummary[]>([]);
   const [peopleLoading, setPeopleLoading] = useState(true);
+  const [peopleError, setPeopleError] = useState(false);
   const [selectedPersonId, setSelectedPersonId] = useState<string | null>(null);
 
   // Load stats
@@ -688,10 +692,21 @@ export function MemoryViewerView({
   // Load people from relationships
   useEffect(() => {
     setPeopleLoading(true);
+    setPeopleError(false);
     void client
       .getRelationshipsPeople({ limit: 200 })
-      .then((result) => setPeople(result.people))
-      .catch(() => setPeople([]))
+      .then((result) => {
+        setPeople(result.people);
+        setPeopleError(false);
+      })
+      .catch((err: unknown) => {
+        // error-policy:J4 a 404 means the relationships surface isn't hosted
+        // here — the designed empty state is correct. Anything else (5xx,
+        // transport, parse) flips the sidebar into an explicit error render
+        // instead of masquerading as "No people yet."
+        setPeople([]);
+        setPeopleError(!(isApiError(err) && err.status === 404));
+      })
       .finally(() => setPeopleLoading(false));
   }, []);
 
@@ -850,6 +865,15 @@ export function MemoryViewerView({
             {peopleLoading ? (
               <div className="px-2 text-xs text-muted">
                 {t("memoryviewer.loading", { defaultValue: "Loading…" })}
+              </div>
+            ) : peopleError ? (
+              <div
+                data-testid="memory-people-error"
+                className="px-2 text-xs text-danger"
+              >
+                {t("memoryviewer.peopleError", {
+                  defaultValue: "Could not load people.",
+                })}
               </div>
             ) : people.length === 0 ? (
               <div className="px-2 text-xs text-muted">

--- a/packages/ui/src/components/settings/CapabilitiesSection.test.tsx
+++ b/packages/ui/src/components/settings/CapabilitiesSection.test.tsx
@@ -16,6 +16,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../../api/client-types-core";
 
 const appMock = vi.hoisted(() => ({
   value: {} as {
@@ -136,5 +137,105 @@ describe("CapabilitiesSection proactive-suggestions control", () => {
         .getByRole("radio", { name: "Off" })
         .getAttribute("aria-checked"),
     ).toBe("true");
+  });
+});
+
+describe("CapabilitiesSection auto-training three-state status (#12784)", () => {
+  beforeEach(() => {
+    appMock.value = {
+      walletEnabled: false,
+      browserEnabled: false,
+      computerUseEnabled: false,
+      setState: vi.fn(),
+      t: (_key, options) => options?.defaultValue ?? _key,
+    };
+    clientMock.getConfig.mockReset();
+    clientMock.updateConfig.mockReset();
+    clientMock.fetch.mockReset();
+    clientMock.getConfig.mockResolvedValue({ env: {} });
+    clientMock.updateConfig.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the designed unavailable icon when the training surface 404s", async () => {
+    clientMock.fetch.mockRejectedValue(
+      new ApiError({
+        kind: "http",
+        path: "/api/training/auto/config",
+        message: "Not Found",
+        status: 404,
+      }),
+    );
+
+    render(<CapabilitiesSection />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("img", { name: "Unavailable" })).not.toBeNull(),
+    );
+    expect(screen.queryByRole("img", { name: "Error" })).toBeNull();
+  });
+
+  it("shows the error icon (not unavailable) when the training endpoint breaks", async () => {
+    clientMock.fetch.mockRejectedValue(
+      new ApiError({
+        kind: "http",
+        path: "/api/training/auto/config",
+        message: "Internal Server Error",
+        status: 500,
+      }),
+    );
+
+    render(<CapabilitiesSection />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("img", { name: "Error" })).not.toBeNull(),
+    );
+    expect(screen.queryByRole("img", { name: "Unavailable" })).toBeNull();
+  });
+
+  it("shows the error icon on a transport failure", async () => {
+    clientMock.fetch.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    render(<CapabilitiesSection />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("img", { name: "Error" })).not.toBeNull(),
+    );
+    expect(screen.queryByRole("img", { name: "Unavailable" })).toBeNull();
+  });
+
+  it("shows no status icon when the training surface loads and is registered", async () => {
+    clientMock.fetch.mockImplementation(async (path: string) => {
+      if (path === "/api/training/auto/config") {
+        return {
+          config: {
+            autoTrain: true,
+            triggerThreshold: 0,
+            triggerCooldownHours: 0,
+            backends: [],
+          },
+        };
+      }
+      if (path === "/api/training/auto/status") {
+        return { serviceRegistered: true };
+      }
+      return {};
+    });
+
+    render(<CapabilitiesSection />);
+
+    // The switch enables once loading resolves with a registered service.
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole("switch", { name: "Enable Auto-training" })
+          .getAttribute("disabled"),
+      ).toBeNull();
+    });
+    expect(screen.queryByRole("img", { name: "Error" })).toBeNull();
+    expect(screen.queryByRole("img", { name: "Unavailable" })).toBeNull();
   });
 });

--- a/packages/ui/src/components/settings/CapabilitiesSection.tsx
+++ b/packages/ui/src/components/settings/CapabilitiesSection.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import { type FormEvent, useCallback, useEffect, useState } from "react";
 import { client } from "../../api/client";
+import { isApiError } from "../../api/client-types-core";
 import { useAppSelector, useAppSelectorShallow } from "../../state";
 import { AdvancedToggle } from "./AdvancedToggle";
 import { useAdvancedSettingsEnabled } from "./AdvancedToggle.hooks";
@@ -131,6 +132,11 @@ export function CapabilitiesSection() {
   >(null);
   const [autoTrainingLoading, setAutoTrainingLoading] = useState(true);
   const [autoTrainingSaving, setAutoTrainingSaving] = useState(false);
+  // Distinguishes a broken auto-training endpoint (5xx/transport/parse →
+  // error icon) from the designed "service not hosted here" degrade
+  // (404/service-unregistered → unavailable icon). Three-state rule: a broken
+  // endpoint must not masquerade as the designed unavailable state.
+  const [autoTrainingError, setAutoTrainingError] = useState(false);
   const [capabilityConnectMode, setCapabilityConnectMode] =
     useState<CapabilityConnectMode>("endpoint");
   const [capabilityEndpointProvider, setCapabilityEndpointProvider] = useState<
@@ -161,9 +167,15 @@ export function CapabilitiesSection() {
       ]);
       setAutoTrainingConfig(configResponse.config);
       setAutoTrainingAvailable(statusResponse.serviceRegistered !== false);
-    } catch {
+      setAutoTrainingError(false);
+    } catch (err) {
+      // error-policy:J4 404 = training plugin not hosted on this runtime — the
+      // designed "unavailable" degrade. Any other failure (5xx, transport,
+      // parse) renders the explicit error icon instead of silently disabling
+      // the control as if unavailability were by design.
       setAutoTrainingConfig(null);
       setAutoTrainingAvailable(false);
+      setAutoTrainingError(!(isApiError(err) && err.status === 404));
     } finally {
       setAutoTrainingLoading(false);
     }
@@ -228,8 +240,13 @@ export function CapabilitiesSection() {
         );
         setAutoTrainingConfig(response.config);
         setAutoTrainingAvailable(true);
+        setAutoTrainingError(false);
       } catch {
+        // error-policy:J4 revert the optimistic toggle AND flag the failed
+        // save — a silent revert previously made the click look like it never
+        // happened, hiding a broken save endpoint behind healthy UI.
         setAutoTrainingConfig(autoTrainingConfig);
+        setAutoTrainingError(true);
       } finally {
         setAutoTrainingSaving(false);
       }
@@ -245,9 +262,11 @@ export function CapabilitiesSection() {
   const autoTrainingStatus =
     autoTrainingLoading || autoTrainingSaving
       ? "loading"
-      : autoTrainingAvailable === false
-        ? "unavailable"
-        : null;
+      : autoTrainingError
+        ? "error"
+        : autoTrainingAvailable === false
+          ? "unavailable"
+          : null;
 
   const handleCapabilityConnect = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
@@ -782,7 +801,7 @@ export function CapabilitiesSection() {
 function CapabilityStatusIcon({
   status,
 }: {
-  status?: "loading" | "unavailable" | null;
+  status?: "loading" | "unavailable" | "error" | null;
 }) {
   const t = useAppSelector((s) => s.t);
   if (status === "loading") {
@@ -811,6 +830,22 @@ function CapabilityStatusIcon({
         title={unavailableLabel}
         role="img"
         aria-label={unavailableLabel}
+      >
+        <AlertTriangle className="h-3.5 w-3.5" aria-hidden />
+      </span>
+    );
+  }
+
+  if (status === "error") {
+    const errorLabel = t("capabilities.status.error", {
+      defaultValue: "Error",
+    });
+    return (
+      <span
+        className="inline-flex text-danger"
+        title={errorLabel}
+        role="img"
+        aria-label={errorLabel}
       >
         <AlertTriangle className="h-3.5 w-3.5" aria-hidden />
       </span>

--- a/packages/ui/src/components/settings/PermissionsSection.mobile-signals-error.test.tsx
+++ b/packages/ui/src/components/settings/PermissionsSection.mobile-signals-error.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+//
+// Three-state guard for the mobile-signals permissions panel (#12784): when
+// the plugin is present but its permissions probe throws, the panel must
+// render an explicit error row — not disappear like the designed "plugin not
+// on this platform" degrade. The designed-hidden state (no checkPermissions
+// on this build) still renders nothing.
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MobileSignalsPermissionStatus } from "../../bridge/native-plugins";
+
+const pluginMock = vi.hoisted(() => ({
+  value: {} as Record<string, unknown>,
+}));
+
+vi.mock("../../bridge/native-plugins", () => ({
+  getMobileSignalsPlugin: () => pluginMock.value,
+}));
+
+vi.mock("../../state", () => ({
+  useAppSelector: (
+    selector: (s: {
+      t: (key: string, options?: { defaultValue?: string }) => string;
+    }) => unknown,
+  ) =>
+    selector({
+      t: (_key, options) => options?.defaultValue ?? _key,
+    }),
+}));
+
+// The panel pulls SettingsGroup/SettingsActionButton for the success render;
+// they render fine in jsdom, so only the data seams above are mocked.
+
+import { MobileSignalsPermissionsPanel } from "./PermissionsSection";
+
+const grantedStatus: MobileSignalsPermissionStatus = {
+  status: "granted",
+  canRequest: false,
+  screenTime: {
+    supported: false,
+    requirements: {
+      entitlements: { familyControls: "" },
+      frameworks: [],
+      deviceActivityReportExtension: false,
+      deviceActivityMonitorExtension: false,
+    },
+    entitlements: { familyControls: false },
+    provisioning: {
+      satisfied: false,
+      inspected: "not-inspectable",
+      reason: null,
+    },
+    authorization: { status: "unavailable", canRequest: false },
+    reportAvailable: false,
+    coarseSummaryAvailable: false,
+    thresholdEventsAvailable: false,
+    rawUsageExportAvailable: false,
+    reason: null,
+  },
+  setupActions: [],
+  permissions: { sleep: true, biometrics: true },
+};
+
+beforeEach(() => {
+  pluginMock.value = {};
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("MobileSignalsPermissionsPanel three-state rendering", () => {
+  it("renders nothing when the plugin does not expose checkPermissions (designed degrade)", async () => {
+    pluginMock.value = {};
+
+    const { container } = render(<MobileSignalsPermissionsPanel />);
+
+    await waitFor(() =>
+      expect(screen.queryByText("Loading permissions...")).toBeNull(),
+    );
+    expect(screen.queryByTestId("mobile-signals-permissions-error")).toBeNull();
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders the explicit error row when the permissions probe throws", async () => {
+    pluginMock.value = {
+      checkPermissions: vi.fn().mockRejectedValue(new Error("bridge exploded")),
+    };
+
+    render(<MobileSignalsPermissionsPanel />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("mobile-signals-permissions-error"),
+      ).not.toBeNull(),
+    );
+    expect(
+      screen.getByTestId("mobile-signals-permissions-error").textContent,
+    ).toContain("Could not read device permissions.");
+  });
+
+  it("renders the panel when the probe resolves", async () => {
+    pluginMock.value = {
+      checkPermissions: vi.fn().mockResolvedValue(grantedStatus),
+    };
+
+    render(<MobileSignalsPermissionsPanel />);
+
+    await waitFor(() =>
+      expect(screen.getByText("LifeOps Signals")).not.toBeNull(),
+    );
+    expect(screen.queryByTestId("mobile-signals-permissions-error")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/settings/PermissionsSection.tsx
+++ b/packages/ui/src/components/settings/PermissionsSection.tsx
@@ -292,12 +292,18 @@ function mobileSetupActionBadge(action: MobileSignalsSetupAction) {
   return { label: "Needs action", className: "border-warn/30 text-warn" };
 }
 
-function MobileSignalsPermissionsPanel() {
+// Exported for tests: the error-vs-designed-hidden distinction below is a
+// three-state-rule guard (#12784) and needs direct render coverage.
+export function MobileSignalsPermissionsPanel() {
   const t = useAppSelector((s) => s.t);
   const [status, setStatus] = useState<MobileSignalsPermissionStatus | null>(
     null,
   );
   const [loading, setLoading] = useState(true);
+  // A thrown checkPermissions (plugin present but broken) must render as an
+  // error, not vanish like the designed "plugin not on this platform" degrade
+  // (three-state rule: error vs designed-hidden must be distinguishable).
+  const [error, setError] = useState(false);
   const [busyAction, setBusyAction] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
@@ -306,7 +312,15 @@ function MobileSignalsPermissionsPanel() {
       setStatus(null);
       return;
     }
-    setStatus(await plugin.checkPermissions());
+    try {
+      setStatus(await plugin.checkPermissions());
+      setError(false);
+    } catch {
+      // error-policy:J4 bridge call failed — surface the explicit error row
+      // below instead of silently hiding the whole panel.
+      setStatus(null);
+      setError(true);
+    }
   }, []);
 
   useEffect(() => {
@@ -316,13 +330,23 @@ function MobileSignalsPermissionsPanel() {
       try {
         const plugin = getMobileSignalsPlugin();
         if (typeof plugin.checkPermissions !== "function") {
+          // Designed degrade: the mobile-signals plugin isn't part of this
+          // build (web/desktop), so the panel intentionally renders nothing.
           if (!cancelled) setStatus(null);
           return;
         }
         const next = await plugin.checkPermissions();
-        if (!cancelled) setStatus(next);
+        if (!cancelled) {
+          setStatus(next);
+          setError(false);
+        }
       } catch {
-        if (!cancelled) setStatus(null);
+        // error-policy:J4 plugin exists but the permissions probe failed —
+        // render the explicit error row, not the designed-hidden state.
+        if (!cancelled) {
+          setStatus(null);
+          setError(true);
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -374,6 +398,18 @@ function MobileSignalsPermissionsPanel() {
   }
 
   if (!status) {
+    if (error) {
+      return (
+        <p
+          data-testid="mobile-signals-permissions-error"
+          className="py-4 text-center text-xs text-danger"
+        >
+          {t("permissionssection.PermissionsError", {
+            defaultValue: "Could not read device permissions.",
+          })}
+        </p>
+      );
+    }
     return null;
   }
 


### PR DESCRIPTION
## Summary

Fallback-slop slice of #12784 (`packages/ui` three-state rule: loading / designed-empty / error must be distinguishable). Three surfaces were rendering failures as healthy-empty or designed-unavailable UI:

- **MemoryViewerView (people sidebar):** `.catch(() => setPeople([]))` rendered a failed `getRelationshipsPeople` load as the designed *"No people yet."* empty state. Now: 5xx/transport/parse render an explicit *"Could not load people."* error row (`data-testid="memory-people-error"`); a 404 (relationships surface not hosted) keeps the designed empty state (`error-policy:J4`).
- **CapabilitiesSection (auto-training):** every load failure collapsed into the designed *unavailable* icon, and a failed save silently reverted the toggle (the click looked like it never happened). Now: non-404 failures render a distinct *error* icon (`text-danger`), including after a failed save; 404 stays the designed *unavailable* degrade.
- **PermissionsSection (MobileSignalsPermissionsPanel):** a thrown `checkPermissions` probe hid the entire panel exactly like the designed *"plugin not in this build"* degrade. Now: probe failure renders an explicit error row (`data-testid="mobile-signals-permissions-error"`); the designed-hidden state (no `checkPermissions` on this platform) is unchanged.
- **agent-provisioning / wallet-balance home widgets:** annotated the intentional home-tile self-hide degrades with `error-policy:J4` so the remaining catches in this slice are mechanically triaged.

## Tests

- `MemoryViewerView.people-error.test.tsx` (new, 4 tests): 500 → error row, transport failure → error row, 404 → designed empty, success → list. 
- `CapabilitiesSection.test.tsx` (+4 tests): 404 → unavailable icon, 500 → error icon, transport → error icon, registered load → no icon + enabled switch.
- `PermissionsSection.mobile-signals-error.test.tsx` (new, 3 tests): designed-hidden vs probe-error vs success render.
- Existing `MemoryViewerView.mobile-sidebar` + `AutomationsFeed` suites stay green (11 passed across the targeted run).
- `tsc` clean (`bun run typecheck` EXIT:0), `bun run audit:error-policy-ratchet` clean (0 new slop in touched files).

Closes nothing on its own — incremental slice toward #12784 (parent #12267).

-- [sol-orch]