### PR TITLE
fix(#12273): computeruse fallback-slop sweep — report failures, annotate justified handlers

### DIFF
--- a/.github/issue-evidence/12273-computeruse-a11y-error-reported.log
+++ b/.github/issue-evidence/12273-computeruse-a11y-error-reported.log
@@ -1,0 +1,23 @@
+# #12273 computeruse — real induced a11y failure -> reportError -> ERROR_REPORTED
+# Host: macOS (darwin). Failing dependency: the 'powershell' binary genuinely absent on this host.
+# Driver: SceneBuilder wired to a real AgentRuntime (runtime.reportError), WindowsAccessibilityProvider, tick("agent-turn").
+# Captured: 2026-07-04T14:16:06Z
+
+[evidence] host=darwin; driving a real UIA scan against a genuinely-missing powershell binary...
+ Warn       [WindowsAccessibilityProvider] a11y snapshot failed; returning no nodes: Executable not found in $PATH: "powershell"
+ Error      #agent:Agent-1  [AGENT] [Computeruse.a11yScan] Executable not found in $PATH: "powershell" (scope=Computeruse.a11yScan, code=UNCLASSIFIED, context={"failedWindows":0,"totalWindows":0,"provider":"win32"}, err=Executable not found in $PATH: "powershell")
+[evidence] ERROR_REPORTED received: scope=Computeruse.a11yScan message=Executable not found in $PATH: "powershell" context={"failedWindows":0,"totalWindows":0,"provider":"win32"}
+[evidence] scene produced: displays=1 ax_nodes=0
+[evidence] runtime.getRecentReportedErrors() ring: [
+  {
+    "scope": "Computeruse.a11yScan",
+    "code": "UNCLASSIFIED",
+    "message": "Executable not found in $PATH: \"powershell\"",
+    "context": {
+      "failedWindows": 0,
+      "totalWindows": 0,
+      "provider": "win32"
+    },
+    "at": 1783174473322
+  }
+]

--- a/.github/issue-evidence/12273-computeruse-triage.md
+++ b/.github/issue-evidence/12273-computeruse-triage.md
@@ -1,0 +1,242 @@
+# #12273 triage inventory — plugins/plugin-computeruse (full src sweep)
+
+Chunk W1-I of the #12273 fallback-slop sweep; extends PR #12885's precision slice.
+Every `catch` handler and promise `.catch` in non-test `src/**/*.ts` was re-derived
+from source at this branch's HEAD and triaged against the binding J1–J7 rubric.
+Verdicts: `J<N>` = kept, annotated `// error-policy:J<N> <reason>` at the site;
+`rethrow` = handler propagates (adds context or classifies then throws) — nothing
+swallowed, outside the sweep's suspect classes; `route-J1` = sandbox/compat route
+boundary translating failures into explicit 4xx/5xx JSON payloads — the issue's
+sanctioned directory-level J1 documentation for `src/routes/**`; `EXEMPT` =
+grep hit inside an embedded PowerShell/JXA script string literal, not a TS handler.
+
+Fixes landed in this chunk (beyond annotations): a11y per-window failure counting +
+once-per-scan `runtime.reportError("Computeruse.a11yScan", …, { failedWindows,
+totalWindows })` (exemplar 2); `fileExists`/`directoryExists` errno narrowing (EACCES
+no longer reads as "absent"); scene/computer-state providers + vision-context now
+report pipeline failures; process/window enumeration failures warn instead of reading
+as an empty machine; approval-mode load/persist failures surfaced; COMPUTER_USE_AGENT
+returns `result.error` on non-finish; progress-callback failures reportError'd (J7).
+
+| site | verdict |
+|---|---|
+| `src/actions/clipboard.ts:181` | J1 (annotated at site) |
+| `src/actions/progress.ts:132` | J5 (annotated at site) |
+| `src/actions/use-computer-agent.ts:285` | J1 (annotated at site) |
+| `src/actions/use-computer-agent.ts:303` | J1 (annotated at site) |
+| `src/actions/use-computer-agent.ts:393` | J7 (annotated at site) |
+| `src/actions/use-computer-agent.ts:433` | J7 (annotated at site) |
+| `src/actions/use-computer-agent.ts:461` | J4 (annotated at site) |
+| `src/actor/actor.ts:223` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/actor/aosp-input-actor.ts:139` | J1 (annotated at site) |
+| `src/actor/aosp-input-actor.ts:172` | J1 (annotated at site) |
+| `src/actor/aosp-input-actor.ts:202` | J1 (annotated at site) |
+| `src/actor/brain.ts:343` | J3 (annotated at site) |
+| `src/actor/brain.ts:373` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/actor/brain.ts:566` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/actor/cascade.ts:394` | J4 (annotated at site) |
+| `src/actor/cascade.ts:432` | J4 (annotated at site) |
+| `src/actor/computer-interface.ts:202` | J4 (annotated at site) |
+| `src/actor/dispatch.ts:72` | J1 (annotated at site) |
+| `src/actor/dispatch.ts:86` | J1 (annotated at site) |
+| `src/actor/dispatch.ts:100` | J1 (annotated at site) |
+| `src/actor/dispatch.ts:114` | J1 (annotated at site) |
+| `src/actor/dispatch.ts:147` | J1 (annotated at site) |
+| `src/actor/dispatch.ts:176` | J1 (annotated at site) |
+| `src/approval-manager.ts:197` | J3 (annotated at site) |
+| `src/approval-manager.ts:220` | J4 (annotated at site) |
+| `src/mcp/server.ts:66` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/mobile/android-scene.ts:52` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/osworld/adapter.ts:70` | J4 (annotated at site) |
+| `src/platform/a11y.ts:67` | J4 (annotated at site) |
+| `src/platform/a11y.ts:155` | J4 (annotated at site) |
+| `src/platform/a11y.ts:207` | J4 (annotated at site) |
+| `src/platform/a11y.ts:257` | J4 (annotated at site) |
+| `src/platform/browser.ts:36` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/platform/browser.ts:137` | J3 (annotated at site) |
+| `src/platform/browser.ts:161` | J3 (annotated at site) |
+| `src/platform/browser.ts:239` | J4 (annotated at site) |
+| `src/platform/browser.ts:260` | J6 (annotated at site) |
+| `src/platform/browser.ts:274` | J6 (annotated at site) |
+| `src/platform/browser.ts:393` | J1 (annotated at site) |
+| `src/platform/browser.ts:507` | J1 (annotated at site) |
+| `src/platform/capture.ts:102` | J6 (annotated at site) |
+| `src/platform/capture.ts:113` | J6 (annotated at site) |
+| `src/platform/capture.ts:152` | J6 (annotated at site) |
+| `src/platform/capture.ts:178` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/platform/capture.ts:308` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/platform/capture.ts:381` | J4 (annotated at site) |
+| `src/platform/clipboard.ts:118` | J4 (annotated at site) |
+| `src/platform/clipboard.ts:159` | J4 (annotated at site) |
+| `src/platform/desktop.ts:906` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/platform/desktop.ts:994` | J4 (annotated at site) |
+| `src/platform/displays.ts:238` | J4 (annotated at site) |
+| `src/platform/displays.ts:255` | J4 (annotated at site) |
+| `src/platform/displays.ts:268` | J4 (annotated at site) |
+| `src/platform/displays.ts:290` | J3 (annotated at site) |
+| `src/platform/displays.ts:329` | J3 (annotated at site) |
+| `src/platform/displays.ts:381` | J3 (annotated at site) |
+| `src/platform/displays.ts:434` | J4 (annotated at site) |
+| `src/platform/displays.ts:468` | J4 (annotated at site) |
+| `src/platform/displays.ts:499` | J3 (annotated at site) |
+| `src/platform/displays.ts:566` | J3 (annotated at site) |
+| `src/platform/displays.ts:625` | J4 (annotated at site) |
+| `src/platform/displays.ts:650` | J4 (annotated at site) |
+| `src/platform/driver.ts:252` | J4 (annotated at site) |
+| `src/platform/file-ops.ts:27` | J1 (annotated at site) |
+| `src/platform/file-ops.ts:54` | J1 (annotated at site) |
+| `src/platform/file-ops.ts:92` | J1 (annotated at site) |
+| `src/platform/file-ops.ts:119` | J1 (annotated at site) |
+| `src/platform/file-ops.ts:144` | J1 (annotated at site) |
+| `src/platform/file-ops.ts:175` | J3 (annotated at site) |
+| `src/platform/file-ops.ts:219` | J1 (annotated at site) |
+| `src/platform/file-ops.ts:244` | J1 (annotated at site) |
+| `src/platform/file-ops.ts:291` | J1 (annotated at site) |
+| `src/platform/file-ops.ts:320` | J1 (annotated at site) |
+| `src/platform/file-ops.ts:344` | J1 (annotated at site) |
+| `src/platform/file-ops.ts:369` | J3 (annotated at site) |
+| `src/platform/file-ops.ts:407` | J1 (annotated at site) |
+| `src/platform/helpers.ts:32` | J3 (annotated at site) |
+| `src/platform/launch.ts:93` | J1 (annotated at site) |
+| `src/platform/nut-driver.ts:81` | J3 (annotated at site) |
+| `src/platform/nut-driver.ts:366` | J4 (annotated at site) |
+| `src/platform/nut-driver.ts:551` | J6 (annotated at site) |
+| `src/platform/permissions.ts:215` | EXEMPT — embedded PS one-liner; the catch emits the explicit 'Unknown' marker, which the TS side maps to probed:false (not a fabricated allow/deny). |
+| `src/platform/permissions.ts:242` | J3 (annotated at site) |
+| `src/platform/permissions.ts:252` | J3 (annotated at site) |
+| `src/platform/permissions.ts:262` | J3 (annotated at site) |
+| `src/platform/process-list.ts:49` | J4 (annotated at site) |
+| `src/platform/process-list.ts:69` | J3 (annotated at site) |
+| `src/platform/process-list.ts:89` | J4 (annotated at site) |
+| `src/platform/process-list.ts:100` | J4 (annotated at site) |
+| `src/platform/process-list.ts:141` | J4 (annotated at site) |
+| `src/platform/process-list.ts:163` | J3 (annotated at site) |
+| `src/platform/ps-host.ts:95` | EXEMPT — `catch {}` inside the embedded PowerShell bootstrap string literal (issue-sanctioned exemption); real host script errors still emit the explicit `PSHOSTERR:` marker the TS side rejects on. |
+| `src/platform/ps-host.ts:107` | EXEMPT — embedded PS literal; the catch WRITES an explicit `PSHOSTERR:` marker the TS side rejects on, so nothing is swallowed. |
+| `src/platform/ps-host.ts:163` | J6 (annotated at site) |
+| `src/platform/ps-host.ts:168` | J6 (annotated at site) |
+| `src/platform/ps-host.ts:175` | J6 (annotated at site) |
+| `src/platform/ps-host.ts:239` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/platform/ps-host.ts:272` | J1 (annotated at site) |
+| `src/platform/ps-host.ts:303` | J5 (annotated immediately above the `.catch` — rejection observed by the documented consumer) |
+| `src/platform/ps-host.ts:349` | J6 (annotated at site) |
+| `src/platform/screenshot.ts:64` | J6 (annotated at site) |
+| `src/platform/screenshot.ts:69` | J6 (annotated at site) |
+| `src/platform/screenshot.ts:72` | J6 (annotated at site) |
+| `src/platform/screenshot.ts:113` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/platform/screenshot.ts:191` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/platform/screenshot.ts:203` | J4 (annotated at site) |
+| `src/platform/screenshot.ts:235` | J4 (annotated at site) |
+| `src/platform/security.ts:239` | J3 (annotated at site) |
+| `src/platform/security.ts:350` | J3 (annotated at site) |
+| `src/platform/security.ts:379` | J3 (annotated at site) |
+| `src/platform/wayland-portal.ts:169` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/platform/windows-list.ts:48` | J4 (annotated at site) — two-tier failover: script-level errors rethrow, host-level failures fall back to the cold one-shot spawn whose own failure propagates |
+| `src/platform/windows-list.ts:247` | J4 (annotated at site) |
+| `src/platform/windows-list.ts:309` | J4 (annotated at site) |
+| `src/platform/windows-list.ts:346` | J4 (annotated at site) |
+| `src/platform/windows-list.ts:393` | J4 (annotated at site) |
+| `src/platform/windows-list.ts:415` | J3 (annotated at site) |
+| `src/platform/windows-list.ts:435` | J4 (annotated at site) |
+| `src/platform/windows-list.ts:503` | J4 (annotated at site) |
+| `src/platform/windows-list.ts:660` | J4 (annotated at site) |
+| `src/platform/windows-list.ts:1067` | J4 (annotated at site) |
+| `src/platform/windows-list.ts:1094` | J4 (annotated at site) |
+| `src/platform/windows-list.ts:1113` | J4 (annotated at site) |
+| `src/platform/windows-list.ts:1134` | J4 (annotated at site) |
+| `src/platform/windows-list.ts:1153` | J4 (annotated at site) |
+| `src/platform/windows-list.ts:1175` | J4 (annotated at site) |
+| `src/platform/windows-list.ts:1198` | J4 (annotated at site) |
+| `src/providers/computer-state.ts:125` | J4 (annotated at site) |
+| `src/providers/scene.ts:55` | J4 (annotated at site) |
+| `src/routes/computer-use-compat-routes.ts:54` | J3 (annotated at site) |
+| `src/routes/computer-use-compat-routes.ts:172` | J1 (annotated at site) |
+| `src/routes/computer-use-compat-routes.ts:191` | J3 (annotated at site) |
+| `src/routes/sandbox-routes.ts:103` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:137` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:150` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:163` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:214` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:240` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:261` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:274` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:288` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:348` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:381` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:404` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:427` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:450` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:476` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:496` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:514` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:539` | route-J1 — route boundary; failure becomes an explicit 4xx/5xx (or error-carrying) JSON payload (directory-documented) |
+| `src/routes/sandbox-routes.ts:872` | J6 (annotated at site) |
+| `src/routes/sandbox-routes.ts:877` | J6 (annotated at site) |
+| `src/routes/sandbox-routes.ts:880` | J6 (annotated at site) |
+| `src/routes/sandbox-routes.ts:921` | J4 (annotated at site) |
+| `src/routes/sandbox-routes.ts:951` | J4 (annotated at site) |
+| `src/routes/sandbox-routes.ts:976` | J4 (annotated at site) |
+| `src/routes/sandbox-routes.ts:1046` | J6 (annotated at site) |
+| `src/routes/sandbox-routes.ts:1085` | J6 (annotated at site) |
+| `src/routes/sandbox-routes.ts:1362` | J3 (annotated at site) |
+| `src/routes/sandbox-routes.ts:1372` | J3 (annotated at site) |
+| `src/routes/sandbox-routes.ts:1382` | J3 (annotated at site) |
+| `src/routes/sandbox-routes.ts:1406` | J3 (annotated at site) |
+| `src/routes/sandbox-routes.ts:1446` | J4 (annotated at site) |
+| `src/routes/sandbox-routes.ts:1479` | J4 (annotated at site) |
+| `src/routes/sandbox-routes.ts:1495` | J4 (annotated at site) |
+| `src/routes/sandbox-routes.ts:1513` | J1 (annotated at site) |
+| `src/routes/sandbox-routes.ts:1531` | J3 (annotated at site) |
+| `src/sandbox/docker-backend.ts:354` | J6 (annotated at site) |
+| `src/sandbox/docker-backend.ts:397` | J3 (annotated at site) |
+| `src/sandbox/remote-guest.ts:160` | J1 (annotated at site) |
+| `src/scene/a11y-provider.ts:227` | J4 (annotated at site) |
+| `src/scene/a11y-provider.ts:255` | J4 (annotated at site) |
+| `src/scene/a11y-provider.ts:270` | J4 (annotated at site) |
+| `src/scene/a11y-provider.ts:293` | J3 (annotated at site) |
+| `src/scene/a11y-provider.ts:342` | J3 (annotated at site) |
+| `src/scene/a11y-provider.ts:492` | FIXED (exemplar 2) — embedded JXA per-window catch now COUNTS the miss (`failed += 1`); reported once per scan via runtime.reportError("Computeruse.a11yScan", …). |
+| `src/scene/a11y-provider.ts:494` | FIXED (exemplar 2) — embedded JXA per-process catch now counts the miss; reported once per scan. |
+| `src/scene/a11y-provider.ts:511` | J4 (annotated at site) |
+| `src/scene/a11y-provider.ts:612` | FIXED — embedded PS UIA per-element catch now counts the miss (`$failed++`); reported once per scan. |
+| `src/scene/a11y-provider.ts:628` | J4 (annotated at site) |
+| `src/scene/apps.ts:172` | J4 (annotated at site) |
+| `src/scene/ocr-adapter.ts:110` | J4 (annotated at site) |
+| `src/scene/ocr-adapter.ts:132` | J4 (annotated at site) |
+| `src/scene/ocr-adapter.ts:177` | J4 (annotated at site) |
+| `src/scene/ocr-adapter.ts:214` | J4 (annotated at site) |
+| `src/scene/scene-builder.ts:332` | J4 (annotated at site) |
+| `src/scene/scene-builder.ts:430` | J4 (annotated at site) |
+| `src/scene/scene-builder.ts:441` | J4 (annotated at site) |
+| `src/scene/scene-builder.ts:455` | J4 (annotated at site) |
+| `src/scene/scene-builder.ts:489` | J4 (annotated at site) |
+| `src/services/computer-use-service.ts:266` | J4 (annotated at site) |
+| `src/services/computer-use-service.ts:297` | J6 (annotated at site) |
+| `src/services/computer-use-service.ts:308` | J6 (annotated at site) |
+| `src/services/computer-use-service.ts:633` | J4 (annotated at site) |
+| `src/services/computer-use-service.ts:643` | J1 (annotated at site) |
+| `src/services/computer-use-service.ts:733` | J1 (annotated at site) |
+| `src/services/computer-use-service.ts:793` | J1 (annotated at site) |
+| `src/services/computer-use-service.ts:829` | J1 (annotated at site) |
+| `src/services/computer-use-service.ts:860` | J1 (annotated at site) |
+| `src/services/computer-use-service.ts:1216` | J1 (annotated at site) |
+| `src/services/computer-use-service.ts:1334` | J1 (annotated at site) |
+| `src/services/computer-use-service.ts:1429` | J1 (annotated at site) |
+| `src/services/computer-use-service.ts:1881` | J4 (annotated at site) |
+| `src/services/computer-use-service.ts:2175` | J4 (annotated at site) |
+| `src/services/desktop-control.ts:61` | J3 (annotated at site) |
+| `src/services/desktop-control.ts:137` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/services/desktop-control.ts:170` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/services/desktop-control.ts:676` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/services/desktop-control.ts:688` | J3 (annotated at site) |
+| `src/services/desktop-control.ts:709` | J3 (annotated at site) |
+| `src/services/desktop-control.ts:719` | J6 (annotated at site) |
+| `src/services/vision-context-provider.ts:163` | J4 (annotated at site) |
+| `src/services/vision-context-provider.ts:193` | J4 (annotated at site) |
+| `src/services/vision-context-provider.ts:205` | J4 (annotated at site) |
+
+Totals: 214 catch sites — 174 J-kept rows carrying 172 `error-policy:J` annotations
+(J1×38 · J3×35 · J4×75 · J5×4 · J6×18 · J7×2 by grep; adjacent best-effort-teardown
+catches share one annotation where they express the same policy), 18
+directory-documented route-J1, 16 rethrows, 6 embedded-script-literal rows (3 exempt
+with explicit failure markers, 3 fixed by counting — the exemplar-2 empty catches).

--- a/plugins/plugin-computeruse/src/__tests__/action-error-path.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/action-error-path.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Real-error-path test for the COMPUTER_USE action boundary (#12273): a
+ * genuinely failing platform operation (spawning a binary that does not
+ * exist — no mocks of the failing dependency) must surface to the caller as
+ * `success:false` + `result.error`, which is what the planner loop shows the
+ * model. Guards against any regression toward catch-and-return-success.
+ */
+
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { afterAll, describe, expect, it } from "vitest";
+import { useComputerAction } from "../actions/use-computer.js";
+import { ComputerUseService } from "../services/computer-use-service.js";
+
+const MISSING_BINARY =
+  process.platform === "win32"
+    ? "C:\\\\eliza-definitely-missing\\\\no-such-binary-12273.exe"
+    : "/eliza-definitely-missing/no-such-binary-12273";
+
+function makeRuntime(): {
+  runtime: IAgentRuntime;
+  attach: (service: ComputerUseService) => void;
+} {
+  let service: ComputerUseService | null = null;
+  const runtime = {
+    character: {},
+    getSetting: (key: string) =>
+      key === "COMPUTER_USE_APPROVAL_MODE" ? "full_control" : undefined,
+    getService: (name: string) => (name === "computeruse" ? service : null),
+    reportError: () => undefined,
+  } as unknown as IAgentRuntime;
+  return {
+    runtime,
+    attach: (s) => {
+      service = s;
+    },
+  };
+}
+
+const message = {
+  id: "00000000-0000-0000-0000-000000000001",
+  entityId: "00000000-0000-0000-0000-000000000002",
+  agentId: "00000000-0000-0000-0000-000000000003",
+  roomId: "00000000-0000-0000-0000-000000000004",
+  content: { action: "launch", app: MISSING_BINARY },
+} as unknown as Memory;
+
+describe("COMPUTER_USE surfaces real platform failures as success:false + error", () => {
+  let stopService: (() => Promise<void>) | null = null;
+
+  afterAll(async () => {
+    await stopService?.();
+  });
+
+  it("launching a nonexistent binary reaches the caller as a structured failure", async () => {
+    const { runtime, attach } = makeRuntime();
+    const service = (await ComputerUseService.start(
+      runtime,
+    )) as ComputerUseService;
+    attach(service);
+    stopService = () => service.stop();
+
+    const handler = useComputerAction.handler;
+    if (!handler) throw new Error("COMPUTER_USE handler missing");
+
+    // The spawn of MISSING_BINARY really fails (ENOENT) — the failing
+    // dependency is the OS itself, not a mock.
+    const result = await handler(runtime, message, undefined, undefined);
+
+    expect(result?.success).toBe(false);
+    expect(typeof result?.error === "string" ? result.error : "").not.toBe("");
+    // The old fabricated-success shape must never come back.
+    expect(result?.data).toMatchObject({
+      source: "computeruse",
+      computerUseAction: "launch",
+    });
+  });
+});

--- a/plugins/plugin-computeruse/src/__tests__/scene-builder.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/scene-builder.test.ts
@@ -143,7 +143,11 @@ function makeBuilder(
     captureAll: async () =>
       captures[Math.min(i++, captures.length - 1)] ??
       captures[captures.length - 1]!,
-    captureOne: async () => captures[0]![0]!,
+    captureOne: async () => {
+      const first = captures[0]?.[0];
+      if (!first) throw new Error("capture fixture list is empty");
+      return first;
+    },
     listDisplays: () => fakeDisplays,
     enumerateApps: () => options.apps ?? [],
     accessibilityProvider: makeFakeAxProvider(options.ax ?? []),

--- a/plugins/plugin-computeruse/src/__tests__/scene-multimon-coords.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/scene-multimon-coords.test.ts
@@ -41,7 +41,7 @@ import {
   pngDimensions,
 } from "../scene/dhash.js";
 import { SceneBuilder } from "../scene/scene-builder.js";
-import type { SceneAxNode, SceneOcrBox } from "../scene/scene-types.js";
+import type { SceneOcrBox } from "../scene/scene-types.js";
 import type { DisplayDescriptor } from "../types.js";
 
 // ── tiny PNG builder (shared shape with scene-builder.test.ts) ──────────────
@@ -322,7 +322,11 @@ describe("dirty-block re-OCR — wired to captureRegion", () => {
       captureAll: async () =>
         captures[Math.min(i++, captures.length - 1)] ??
         captures[captures.length - 1]!,
-      captureOne: async () => captures[0]![0]!,
+      captureOne: async () => {
+        const first = captures[0]?.[0];
+        if (!first) throw new Error("capture fixture list is empty");
+        return first;
+      },
       captureRegion: async (displayId, region) => {
         captureRegionCalls.push({ displayId, region });
         // Return a tiny PNG of arbitrary content; OCR is fully mocked so
@@ -398,7 +402,7 @@ describe("dirty-block re-OCR — wired to captureRegion", () => {
     expect(captureRegionCalls).toHaveLength(1);
     // The dirty rect should be inside the source frame and roughly near
     // (col=4, row=4) for a 16×16 grid on a 256×256 frame → ~(64, 64, 16, 16).
-    const reg = captureRegionCalls[0]!.region;
+    const reg = captureRegionCalls[0]?.region;
     expect(reg.x).toBeGreaterThanOrEqual(60);
     expect(reg.x).toBeLessThanOrEqual(80);
     expect(reg.y).toBeGreaterThanOrEqual(60);
@@ -681,8 +685,8 @@ describe("live smoke — getCurrentScene on this host", () => {
   it("listDisplays returns at least one display with positive bounds", () => {
     const all = listDisplays();
     expect(all.length).toBeGreaterThan(0);
-    expect(all[0]!.bounds[2]).toBeGreaterThan(0);
-    expect(all[0]!.bounds[3]).toBeGreaterThan(0);
+    expect(all[0]?.bounds[2]).toBeGreaterThan(0);
+    expect(all[0]?.bounds[3]).toBeGreaterThan(0);
   });
 });
 

--- a/plugins/plugin-computeruse/src/__tests__/scene-provider.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/scene-provider.test.ts
@@ -89,7 +89,7 @@ function makeScene(): Scene {
 function makeRuntime(
   scene: Scene | null,
   refresh?: () => Promise<Scene>,
-): IAgentRuntime {
+): IAgentRuntime & { reportedErrors: Array<{ scope: string }> } {
   const service = {
     getCurrentScene: () => scene,
     refreshScene:
@@ -98,10 +98,15 @@ function makeRuntime(
         throw new Error("no scene available");
       }),
   };
+  const reportedErrors: Array<{ scope: string }> = [];
   return {
     getService: (name: string) =>
       name === "computeruse" ? (service as unknown) : undefined,
-  } as unknown as IAgentRuntime;
+    reportError: (scope: string) => {
+      reportedErrors.push({ scope });
+    },
+    reportedErrors,
+  } as unknown as IAgentRuntime & { reportedErrors: Array<{ scope: string }> };
 }
 
 const dummyMessage: Memory = {} as Memory;
@@ -148,11 +153,16 @@ describe("sceneProvider", () => {
     expect(result.text).toBe("");
   });
 
-  it("returns empty when refresh fails and no scene is cached", async () => {
+  it("returns empty AND reports the failure when refresh fails and no scene is cached", async () => {
     const runtime = makeRuntime(null, async () => {
       throw new Error("boom");
     });
     const result = await sceneProvider.get(runtime, dummyMessage, dummyState);
     expect(result.text).toBe("");
+    // A broken scene pipeline must be agent-visible (#12273), not a
+    // silently-empty provider result.
+    expect(runtime.reportedErrors).toEqual([
+      { scope: "Computeruse.sceneProvider" },
+    ]);
   });
 });

--- a/plugins/plugin-computeruse/src/actions/clipboard.ts
+++ b/plugins/plugin-computeruse/src/actions/clipboard.ts
@@ -179,6 +179,8 @@ export const clipboardAction: Action = {
         action,
       } satisfies ClipboardActionParams);
     } catch (error) {
+      // error-policy:J1 action boundary — the platform failure becomes a
+      // structured {success:false,error} ActionResult the model sees.
       const message =
         error instanceof ClipboardUnavailableError
           ? error.message

--- a/plugins/plugin-computeruse/src/actions/progress.ts
+++ b/plugins/plugin-computeruse/src/actions/progress.ts
@@ -130,6 +130,9 @@ export async function withApprovalRelay<T>(
           buildApprovalPromptContent(approval, options),
           "COMPUTER_USE_APPROVAL",
         ).catch((error) => {
+          // error-policy:J5 the rejection is observed HERE (warn with the
+          // approval id); a failed relay must not abort the approval flow —
+          // the approval stays queued and resolvable via the routes/UI.
           logger.warn(
             {
               src: "plugin:computeruse",

--- a/plugins/plugin-computeruse/src/actions/use-computer-agent.ts
+++ b/plugins/plugin-computeruse/src/actions/use-computer-agent.ts
@@ -283,6 +283,9 @@ export async function runComputerUseAgentLoop(
     try {
       scene = await service.refreshScene("agent-turn");
     } catch (err) {
+      // error-policy:J1 loop boundary — the failure ends the run as a
+      // structured report (reason="error" + error) the model sees via the
+      // action result; never rethrown into the action plumbing half-run.
       report.reason = "error";
       report.error = `scene refresh failed: ${errorMessage(err)}`;
       return finalize();
@@ -298,6 +301,9 @@ export async function runComputerUseAgentLoop(
     try {
       proposed = await loop.predictStep({ scene, goal, captures });
     } catch (err) {
+      // error-policy:J1 loop boundary — planner failure ends the run as a
+      // structured report (reason="error" + error); the model sees it in the
+      // action result instead of a fabricated partial success.
       report.reason = "error";
       report.error = `agent loop "${loop.name}" failed: ${errorMessage(err)}`;
       return finalize();
@@ -351,8 +357,12 @@ export async function runComputerUseAgentLoop(
         maxSteps,
         ...reportStep,
       };
-      await emitStepProgress(deps.onStepProgress, progress);
-      await emitCompactStepProgress(deps.onCompactStepProgress, progress);
+      await emitStepProgress(runtime, deps.onStepProgress, progress);
+      await emitCompactStepProgress(
+        runtime,
+        deps.onCompactStepProgress,
+        progress,
+      );
     }
     if (!dispatchResult.success) {
       report.reason = "error";
@@ -371,6 +381,7 @@ export async function runComputerUseAgentLoop(
 }
 
 async function emitStepProgress(
+  runtime: IAgentRuntime | null,
   onStepProgress: AgentDeps["onStepProgress"],
   progress: ComputerUseAgentStepProgress,
 ): Promise<void> {
@@ -380,6 +391,9 @@ async function emitStepProgress(
   try {
     await onStepProgress(progress);
   } catch (err) {
+    // error-policy:J7 progress relay is telemetry; it must not kill the run,
+    // but the failure is warned AND reported so a broken progress channel is
+    // agent/owner-visible, not silent.
     logger.warn(
       {
         evt: "computeruse.agent.progress_callback_failed",
@@ -389,10 +403,16 @@ async function emitStepProgress(
       },
       "[computeruse/agent] progress callback failed",
     );
+    runtime?.reportError("Computeruse.agentProgress", err, {
+      step: progress.step,
+      goal: progress.goal,
+      channel: "onStepProgress",
+    });
   }
 }
 
 async function emitCompactStepProgress(
+  runtime: IAgentRuntime | null,
   onCompactStepProgress: AgentDeps["onCompactStepProgress"],
   progress: ComputerUseAgentStepProgress,
 ): Promise<void> {
@@ -411,6 +431,9 @@ async function emitCompactStepProgress(
       }),
     );
   } catch (err) {
+    // error-policy:J7 compact progress relay is telemetry; it must not kill
+    // the run, but the failure is warned AND reported so a broken progress
+    // channel is agent/owner-visible, not silent.
     logger.warn(
       {
         evt: "computeruse.agent.compact_progress_callback_failed",
@@ -420,6 +443,11 @@ async function emitCompactStepProgress(
       },
       "[computeruse/agent] compact progress callback failed",
     );
+    runtime?.reportError("Computeruse.agentProgress", err, {
+      step: progress.step,
+      goal: progress.goal,
+      channel: "onCompactStepProgress",
+    });
   }
 }
 
@@ -431,6 +459,10 @@ async function safeCapture(
     const caps = await captureAll();
     for (const c of caps) out.set(c.display.id, c);
   } catch (err) {
+    // error-policy:J4 the empty map is the explicit failure signal — the run
+    // loop aborts with reason="error" ("no displays captured"), so capture
+    // failure surfaces in the action result rather than reading as a blank
+    // desktop.
     logger.warn(
       `[computeruse/agent] captureAll failed: ${errorMessage(err)} — falling back to per-display lookup`,
     );
@@ -552,6 +584,9 @@ export const computerUseAgentAction: Action = {
     }
     return {
       success: report.reason === "finish",
+      // A non-finish run carries result.error so the planner loop shows the
+      // failure to the model (#12273) instead of a success-shaped text blob.
+      error: report.reason === "finish" ? undefined : (report.error ?? text),
       text,
       data: {
         source: "computeruse",

--- a/plugins/plugin-computeruse/src/actor/aosp-input-actor.ts
+++ b/plugins/plugin-computeruse/src/actor/aosp-input-actor.ts
@@ -137,6 +137,8 @@ export class AospInputActor {
           await this.tap(bridge, x, y);
         }
       } catch (err) {
+        // error-policy:J1 dispatch boundary — the bridge failure returns as a
+        // structured {success:false,error} DispatchResult the loop/model sees.
         return driverError(err);
       }
       return { success: true, issued: action };
@@ -168,6 +170,8 @@ export class AospInputActor {
           DEFAULT_SWIPE_DURATION_MS,
         );
       } catch (err) {
+        // error-policy:J1 dispatch boundary — the bridge failure returns as a
+        // structured {success:false,error} DispatchResult the loop/model sees.
         return driverError(err);
       }
       return { success: true, issued: action };
@@ -196,6 +200,8 @@ export class AospInputActor {
           DEFAULT_SWIPE_DURATION_MS,
         );
       } catch (err) {
+        // error-policy:J1 dispatch boundary — the bridge failure returns as a
+        // structured {success:false,error} DispatchResult the loop/model sees.
         return driverError(err);
       }
       return { success: true, issued: action };

--- a/plugins/plugin-computeruse/src/actor/brain.ts
+++ b/plugins/plugin-computeruse/src/actor/brain.ts
@@ -341,6 +341,9 @@ export class Brain {
       try {
         return parseBrainOutput(raw);
       } catch {
+        // error-policy:J3 untrusted model output; null is the explicit
+        // invalid signal that drives the escalation ladder (imageless →
+        // pixels → strict prompt). Total failure throws BrainParseError.
         return null;
       }
     };

--- a/plugins/plugin-computeruse/src/actor/cascade.ts
+++ b/plugins/plugin-computeruse/src/actor/cascade.ts
@@ -24,12 +24,7 @@ import type { Scene } from "../scene/scene-types.js";
 import type { Actor, ActorGroundArgs } from "./actor.js";
 import { resolveReference } from "./actor.js";
 import { BRAIN_MAX_ROIS, type Brain } from "./brain.js";
-import type {
-  BrainOutput,
-  BrainRoi,
-  CascadeResult,
-  ProposedAction,
-} from "./types.js";
+import type { BrainOutput, BrainRoi, CascadeResult } from "./types.js";
 
 export interface CascadeDeps {
   brain: Brain;
@@ -397,6 +392,9 @@ export class Cascade {
             };
           }
         } catch (err) {
+          // error-policy:J4 grounding refinement is an optional precision
+          // tier; the coarse bbox center below is a legitimate degraded
+          // target, and the miss is warned with the failing ref.
           logger.warn(
             `[computeruse/cascade] actor.ground failed for ref=${ref}: ${err instanceof Error ? err.message : String(err)} — using bbox center`,
           );
@@ -432,6 +430,9 @@ export class Cascade {
         y: Math.round(grounded.y),
       };
     } catch (err) {
+      // error-policy:J4 null is the explicit "ROI grounding unavailable"
+      // signal; the cascade falls back to its non-ROI strategies and the
+      // miss is warned. Never fabricates a coordinate.
       logger.warn(
         `[computeruse/cascade] actor.ground threw for ROI: ${err instanceof Error ? err.message : String(err)}`,
       );

--- a/plugins/plugin-computeruse/src/actor/computer-interface.ts
+++ b/plugins/plugin-computeruse/src/actor/computer-interface.ts
@@ -200,6 +200,9 @@ export class DefaultComputerInterface implements ComputerInterface {
       try {
         return getPrimaryDisplay();
       } catch {
+        // error-policy:J4 seeds only the initial cursor-state display id
+        // (0 = conventional primary). Real display data always flows from
+        // listDisplays/capture, whose failures surface to the caller.
         return { id: 0 } as DisplayDescriptor;
       }
     })();

--- a/plugins/plugin-computeruse/src/actor/dispatch.ts
+++ b/plugins/plugin-computeruse/src/actor/dispatch.ts
@@ -70,6 +70,8 @@ export async function dispatch(
         await deps.interface.doubleClick(displayPoint);
       else await deps.interface.rightClick(displayPoint);
     } catch (err) {
+      // error-policy:J1 dispatch boundary — the driver failure returns as a
+      // structured {success:false,error} DispatchResult the loop/model sees.
       return driverError(err);
     }
     return { success: true, issued: action };
@@ -82,6 +84,8 @@ export async function dispatch(
     try {
       await deps.interface.typeText({ text: action.text });
     } catch (err) {
+      // error-policy:J1 dispatch boundary — the driver failure returns as a
+      // structured {success:false,error} DispatchResult the loop/model sees.
       return driverError(err);
     }
     return { success: true, issued: action };
@@ -94,6 +98,8 @@ export async function dispatch(
     try {
       await deps.interface.pressKey({ key: action.key });
     } catch (err) {
+      // error-policy:J1 dispatch boundary — the driver failure returns as a
+      // structured {success:false,error} DispatchResult the loop/model sees.
       return driverError(err);
     }
     return { success: true, issued: action };
@@ -106,6 +112,8 @@ export async function dispatch(
     try {
       await deps.interface.hotkey({ keys: action.keys });
     } catch (err) {
+      // error-policy:J1 dispatch boundary — the driver failure returns as a
+      // structured {success:false,error} DispatchResult the loop/model sees.
       return driverError(err);
     }
     return { success: true, issued: action };
@@ -137,6 +145,8 @@ export async function dispatch(
         dy: action.dy,
       });
     } catch (err) {
+      // error-policy:J1 dispatch boundary — the driver failure returns as a
+      // structured {success:false,error} DispatchResult the loop/model sees.
       return driverError(err);
     }
     return { success: true, issued: action };
@@ -164,6 +174,8 @@ export async function dispatch(
         ],
       });
     } catch (err) {
+      // error-policy:J1 dispatch boundary — the driver failure returns as a
+      // structured {success:false,error} DispatchResult the loop/model sees.
       return driverError(err);
     }
     return { success: true, issued: action };

--- a/plugins/plugin-computeruse/src/approval-manager.ts
+++ b/plugins/plugin-computeruse/src/approval-manager.ts
@@ -9,6 +9,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { logger } from "@elizaos/core";
 import type {
   ApprovalMode,
   ApprovalResolution,
@@ -193,8 +194,18 @@ export class ComputerUseApprovalManager {
       if (typeof parsed.mode === "string" && isApprovalMode(parsed.mode)) {
         this.mode = parsed.mode;
       }
-    } catch {
-      // Keep the default mode when the config file is missing or invalid.
+    } catch (err) {
+      // error-policy:J3 untrusted on-disk config; a missing file (first run)
+      // keeps the default mode silently, while a corrupt/unreadable file is
+      // warned — smart_approve is the safe direction, but the operator must
+      // know their persisted choice did not load.
+      if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+        logger.warn(
+          `[ComputerUseApprovalManager] approval-mode config unreadable; using default "${this.mode}": ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
     }
   }
 
@@ -206,8 +217,15 @@ export class ComputerUseApprovalManager {
         JSON.stringify({ mode: this.mode }, null, 2),
         "utf8",
       );
-    } catch {
-      // Ignore persistence failures; approval mode still applies in-memory.
+    } catch (err) {
+      // error-policy:J4 the mode still applies in-memory (designed degrade),
+      // but a failed persist means the choice will not survive a restart —
+      // warn so the operator is not silently reverted to the default later.
+      logger.warn(
+        `[ComputerUseApprovalManager] failed to persist approval mode "${this.mode}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
     }
   }
 

--- a/plugins/plugin-computeruse/src/osworld/adapter.ts
+++ b/plugins/plugin-computeruse/src/osworld/adapter.ts
@@ -16,6 +16,7 @@
  *   const result2 = await adapter.executePyAutoGUI("pyautogui.click(100, 200)");
  */
 
+import { logger } from "@elizaos/core";
 import { extractA11yTree, isA11yAvailable } from "../platform/a11y.js";
 import { captureScreenshot } from "../platform/screenshot.js";
 import type { ComputerUseService } from "../services/computer-use-service.js";
@@ -66,8 +67,15 @@ export class OSWorldAdapter {
     try {
       const buf = await captureScreenshot();
       screenshot = buf.toString("base64");
-    } catch {
-      // Screenshot failed — return empty
+    } catch (err) {
+      // error-policy:J4 "" is the explicit missing-screenshot value in the
+      // OSWorld observation protocol; the miss is warned so a benchmark run
+      // with blind observations cannot masquerade as a healthy one.
+      logger.warn(
+        `[osworld] screenshot capture failed; observation has no frame: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
     }
 
     let accessibility_tree: string | null = null;

--- a/plugins/plugin-computeruse/src/platform/a11y.ts
+++ b/plugins/plugin-computeruse/src/platform/a11y.ts
@@ -14,10 +14,8 @@
  */
 
 import { execSync } from "node:child_process";
-import type { WindowInfo } from "../types.js";
+import { logger } from "@elizaos/core";
 import { commandExists, currentPlatform } from "./helpers.js";
-import { listProcesses, type ProcessInfo } from "./process-list.js";
-import { listWindows } from "./windows-list.js";
 
 export interface A11yNode {
   role: string;
@@ -66,7 +64,15 @@ export function extractA11yTree(): string | null {
     if (os === "win32") {
       return extractA11yWindows();
     }
-  } catch {
+  } catch (err) {
+    // error-policy:J4 null is the documented "a11y unavailable" contract for
+    // this OSWorld/benchmark surface; the failure is warned so a permission
+    // regression is distinguishable from an unsupported platform in the logs.
+    logger.warn(
+      `[a11y] extractA11yTree failed on ${os}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
     return null;
   }
 
@@ -146,7 +152,15 @@ function extractA11yDarwin(): string | null {
     });
 
     return output.trim() || null;
-  } catch {
+  } catch (err) {
+    // error-policy:J4 null is the documented "a11y unavailable" signal for
+    // this OSWorld/benchmark surface; the warn keeps a permission regression
+    // distinguishable from an unsupported platform.
+    logger.warn(
+      `[a11y] macOS a11y extraction failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
     return null;
   }
 }
@@ -190,7 +204,15 @@ except Exception as e:
         },
       );
       return output.trim() || null;
-    } catch {
+    } catch (err) {
+      // error-policy:J4 null is the documented "a11y unavailable" signal for
+      // this OSWorld/benchmark surface; the warn keeps a permission
+      // regression distinguishable from an unsupported platform.
+      logger.warn(
+        `[a11y] Linux AT-SPI extraction failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
       return null;
     }
   }
@@ -232,7 +254,15 @@ $lines -join [Environment]::NewLine
       },
     );
     return output.trim() || null;
-  } catch {
+  } catch (err) {
+    // error-policy:J4 null is the documented "a11y unavailable" signal for
+    // this OSWorld/benchmark surface; the warn keeps a permission regression
+    // distinguishable from an unsupported platform.
+    logger.warn(
+      `[a11y] Windows UIA extraction failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
     return null;
   }
 }

--- a/plugins/plugin-computeruse/src/platform/browser.ts
+++ b/plugins/plugin-computeruse/src/platform/browser.ts
@@ -13,6 +13,7 @@ import { existsSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { logger } from "@elizaos/core";
 import { assertBrowserExecuteAllowed } from "../security/browser-script-policy.js";
 import type {
   BrowserInfo,
@@ -134,7 +135,9 @@ function detectBrowserPath(): string | null {
         return match;
       }
     } catch {
-      // Ignore PATH misses.
+      // error-policy:J3 existence probe over PATH lookup candidates; a miss
+      // just advances to the next candidate. null below is the explicit
+      // "no browser found" signal callers turn into a structured failure.
     }
   }
 
@@ -156,7 +159,9 @@ async function ensureBrowser(): Promise<Page> {
       await activePage.evaluate("1");
       return activePage;
     } catch {
-      // Page disconnected, reset
+      // error-policy:J3 liveness probe on the cached page; a disconnected
+      // session resets the cache and falls through to the explicit
+      // "Browser not open" failure below — never a fake-healthy page.
       browser = null;
       activePage = null;
     }
@@ -232,6 +237,9 @@ export async function openBrowser(url?: string): Promise<BrowserState> {
         is_open: true,
       };
     } catch (error) {
+      // error-policy:J4 bounded launch-retry loop; every failure is kept in
+      // lastError and the final attempt's failure throws below with the
+      // retry count — nothing is masked.
       lastError = error;
       await closeBrowser();
       if (attempt < BROWSER_LAUNCH_ATTEMPTS) {
@@ -249,8 +257,12 @@ export async function closeBrowser(): Promise<void> {
   if (browser) {
     try {
       await browser.close();
-    } catch {
-      /* ignore */
+    } catch (err) {
+      // error-policy:J6 best-effort teardown; the session is being discarded
+      // either way, so a close failure is debug-only.
+      logger.debug(
+        `[browser] close failed during teardown: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
     browser = null;
     activePage = null;
@@ -259,8 +271,12 @@ export async function closeBrowser(): Promise<void> {
   if (tempUserDataDir) {
     try {
       await rm(tempUserDataDir, { recursive: true, force: true });
-    } catch {
-      /* ignore */
+    } catch (err) {
+      // error-policy:J6 best-effort teardown of the temp profile dir; a
+      // leaked directory is debug-only, not a failure of the close.
+      logger.debug(
+        `[browser] temp profile cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
     tempUserDataDir = null;
   }
@@ -375,6 +391,8 @@ export async function getBrowserInfo(): Promise<BrowserInfo> {
       ...state,
     };
   } catch (error) {
+    // error-policy:J1 platform boundary — the failure returns as a structured
+    // {success:false,error} state the browser action surfaces to the model.
     return {
       success: false,
       isOpen: false,
@@ -487,6 +505,8 @@ export async function browserWait(
     }
     return { success: true, message: `Waited ${Math.min(timeout, 5000)}ms` };
   } catch (error) {
+    // error-policy:J1 platform boundary — the failure returns as a structured
+    // {success:false,error} result the browser action surfaces to the model.
     return {
       success: false,
       error: error instanceof Error ? error.message : String(error),

--- a/plugins/plugin-computeruse/src/platform/capture.ts
+++ b/plugins/plugin-computeruse/src/platform/capture.ts
@@ -111,7 +111,8 @@ export async function captureDisplay(
     try {
       unlinkSync(tmpFile);
     } catch {
-      /* best effort */
+      // error-policy:J6 best-effort temp-file teardown; capture success or
+      // failure has already been decided above.
     }
   }
 }
@@ -149,7 +150,8 @@ export async function captureDisplayRegion(
     try {
       unlinkSync(tmpFile);
     } catch {
-      /* best effort */
+      // error-policy:J6 best-effort temp-file teardown; capture success or
+      // failure has already been decided above.
     }
   }
 }
@@ -377,7 +379,9 @@ async function captureRegionWindows(
       await runPsHost(psCmd, psSpawnTimeoutMs(15000));
       return;
     } catch {
-      /* warm host unavailable/errored — fall back to one-shot spawn */
+      // error-policy:J4 designed two-tier execution — the one-shot spawn
+      // below runs the SAME script, and its failure throws to the caller;
+      // nothing is masked, only the warm-path speedup is lost.
     }
   }
   execSync(`powershell -NoProfile -Command "${psCmd}"`, {

--- a/plugins/plugin-computeruse/src/platform/clipboard.ts
+++ b/plugins/plugin-computeruse/src/platform/clipboard.ts
@@ -116,7 +116,8 @@ export async function readClipboard(): Promise<string> {
     try {
       return await runPsHost("Get-Clipboard -Raw", clipboardTimeoutMs());
     } catch {
-      /* warm host unavailable/errored — fall back to one-shot spawn */
+      // error-policy:J4 designed two-tier execution — the one-shot spawn
+      // below runs the same read, and its failure throws to the caller.
     }
   }
   const plan = pickPlan();
@@ -156,7 +157,8 @@ export async function writeClipboard(text: string): Promise<void> {
       );
       return;
     } catch {
-      /* warm host unavailable/errored — fall back to one-shot spawn */
+      // error-policy:J4 designed two-tier execution — the one-shot spawn
+      // below performs the same write, and its failure throws to the caller.
     }
   }
   const plan = pickPlan();

--- a/plugins/plugin-computeruse/src/platform/desktop.ts
+++ b/plugins/plugin-computeruse/src/platform/desktop.ts
@@ -992,6 +992,9 @@ export function win32TrySetValueByPattern(
     const out = runCommand("powershell", ["-Command", ps], 10000);
     return out.includes("VALUE_SET");
   } catch {
+    // error-policy:J4 false is the explicit "UIA SetValue tier unavailable"
+    // signal; the caller falls back to focus-click + keystroke typing, whose
+    // failure surfaces to the action result.
     return false;
   }
 }

--- a/plugins/plugin-computeruse/src/platform/displays.ts
+++ b/plugins/plugin-computeruse/src/platform/displays.ts
@@ -236,7 +236,8 @@ function enumerateLinux(): DisplayInfo[] {
     const parsed = parseXrandrMonitors(output);
     if (parsed.length > 0) return parsed;
   } catch {
-    /* xrandr unavailable — fall through to empty */
+    // error-policy:J4 xrandr is one tier of the enumeration failover chain;
+    // [] advances to listDisplays' explicit fallbackPrimary degrade.
   }
   return [];
 }
@@ -252,7 +253,8 @@ function enumerateWayland(): DisplayInfo[] {
     const parsed = parseHyprlandMonitors(output);
     if (parsed.length > 0) return parsed;
   } catch {
-    /* try sway */
+    // error-policy:J4 Hyprland tier of the Wayland failover chain; the Sway
+    // tier below is attempted next.
   }
   // Sway
   try {
@@ -264,7 +266,8 @@ function enumerateWayland(): DisplayInfo[] {
     const parsed = parseSwayOutputs(output);
     if (parsed.length > 0) return parsed;
   } catch {
-    /* fall through to xrandr/xwayland */
+    // error-policy:J4 Sway tier of the Wayland failover chain; enumeration
+    // falls through to the xrandr/XWayland tier.
   }
   return [];
 }
@@ -285,6 +288,8 @@ export function parseHyprlandMonitors(output: string): DisplayInfo[] {
   try {
     raw = JSON.parse(output);
   } catch {
+    // error-policy:J3 untrusted `hyprctl` output; unparseable JSON yields the
+    // explicit empty list, never a fabricated display.
     return [];
   }
   if (!Array.isArray(raw)) return [];
@@ -322,6 +327,8 @@ export function parseSwayOutputs(output: string): DisplayInfo[] {
   try {
     raw = JSON.parse(output);
   } catch {
+    // error-policy:J3 untrusted `swaymsg` output; unparseable JSON yields the
+    // explicit empty list, never a fabricated display.
     return [];
   }
   if (!Array.isArray(raw)) return [];
@@ -372,6 +379,8 @@ export function parseDarwinDisplays(output: string): DisplayInfo[] {
   try {
     raw = JSON.parse(output);
   } catch {
+    // error-policy:J3 untrusted JXA output; unparseable JSON yields the
+    // explicit empty list, never a fabricated display.
     return [];
   }
   if (!Array.isArray(raw)) return [];
@@ -423,7 +432,8 @@ function enumerateDarwin(): DisplayInfo[] {
     const parsed = parseSystemProfilerDisplays(output);
     if (parsed.length > 0) return parsed;
   } catch {
-    /* fall through */
+    // error-policy:J4 system_profiler tier of the macOS failover chain; the
+    // JXA CoreGraphics tier below is attempted next.
   }
   // Last-resort: CGMainDisplay bounds + scale via osascript JXA.
   try {
@@ -456,6 +466,9 @@ function enumerateDarwin(): DisplayInfo[] {
       },
     ];
   } catch {
+    // error-policy:J4 last macOS tier failed; fallbackPrimary() is the
+    // designed synthetic-primary degrade (same value listDisplays substitutes
+    // for an empty enumeration) — a wrong geometry fails loudly at capture.
     return [fallbackPrimary()];
   }
 }
@@ -484,6 +497,8 @@ export function parseSystemProfilerDisplays(output: string): DisplayInfo[] {
   try {
     parsed = JSON.parse(output) as SPDisplaysRoot;
   } catch {
+    // error-policy:J3 untrusted system_profiler output; unparseable JSON
+    // yields the explicit empty list, never a fabricated display.
     return [];
   }
   const cards = parsed.SPDisplaysDataType;
@@ -549,6 +564,8 @@ export function parseWindowsScreens(output: string): DisplayInfo[] {
   try {
     raw = JSON.parse(output);
   } catch {
+    // error-policy:J3 untrusted PowerShell output; unparseable JSON yields
+    // the explicit empty list, never a fabricated display.
     return [];
   }
   const items: WinScreen[] = Array.isArray(raw)
@@ -606,7 +623,9 @@ function enumerateWindows(): DisplayInfo[] {
     const parsed = parseWindowsScreens(output);
     if (parsed.length > 0) return parsed;
   } catch {
-    /* fall through */
+    // error-policy:J4 PowerShell enumeration failed; fallbackPrimary() is the
+    // designed synthetic-primary degrade — a wrong geometry fails loudly at
+    // capture, not silently here.
   }
   return [fallbackPrimary()];
 }
@@ -629,6 +648,8 @@ export async function warmDisplaysCache(): Promise<void> {
       cachedAt = Date.now();
     }
   } catch {
-    /* leave cache untouched; sync enumeration remains the fallback */
+    // error-policy:J4 documented never-throws warm-cache contract; the sync
+    // enumeration path remains the authoritative fallback, so nothing is
+    // masked — only the pre-seeding speedup is lost.
   }
 }

--- a/plugins/plugin-computeruse/src/platform/driver.ts
+++ b/plugins/plugin-computeruse/src/platform/driver.ts
@@ -250,6 +250,9 @@ export async function driverCaptureScreenshot(
     try {
       return await nutCaptureScreenshot(region);
     } catch {
+      // error-policy:J4 designed two-tier capture — the legacy shell driver
+      // performs the same capture, and its failure throws to the caller;
+      // nothing is masked.
       return legacyCaptureScreenshot(region);
     }
   }

--- a/plugins/plugin-computeruse/src/platform/file-ops.ts
+++ b/plugins/plugin-computeruse/src/platform/file-ops.ts
@@ -25,6 +25,8 @@ export async function readFile(
       content: String(content).slice(0, 10000),
     };
   } catch (error) {
+    // error-policy:J1 file-op boundary — the failure returns as a structured
+    // {success:false,error} the action surfaces to the model.
     return {
       success: false,
       error: error instanceof Error ? error.message : String(error),
@@ -50,6 +52,8 @@ export async function writeFile(
       message: "File written.",
     };
   } catch (error) {
+    // error-policy:J1 file-op boundary — the failure returns as a structured
+    // {success:false,error} the action surfaces to the model.
     return {
       success: false,
       error: error instanceof Error ? error.message : String(error),
@@ -86,6 +90,8 @@ export async function editFile(
       message: "File edited.",
     };
   } catch (error) {
+    // error-policy:J1 file-op boundary — the failure returns as a structured
+    // {success:false,error} the action surfaces to the model.
     return {
       success: false,
       error: error instanceof Error ? error.message : String(error),
@@ -111,6 +117,8 @@ export async function appendFile(
       message: "Content appended.",
     };
   } catch (error) {
+    // error-policy:J1 file-op boundary — the failure returns as a structured
+    // {success:false,error} the action surfaces to the model.
     return {
       success: false,
       error: error instanceof Error ? error.message : String(error),
@@ -134,6 +142,8 @@ export async function deleteFile(
       message: "File deleted.",
     };
   } catch (error) {
+    // error-policy:J1 file-op boundary — the failure returns as a structured
+    // {success:false,error} the action surfaces to the model.
     return {
       success: false,
       error: error instanceof Error ? error.message : String(error),
@@ -162,17 +172,25 @@ export async function fileExists(
       is_directory: stat.isDirectory(),
       size: stat.size,
     };
-  } catch {
-    return {
-      success: true,
-      path: check.resolvedPath,
-      exists: false,
-      isFile: false,
-      isDirectory: false,
-      is_file: false,
-      is_directory: false,
-      size: 0,
-    };
+  } catch (error) {
+    // error-policy:J3 existence probe with errno narrowing — only an
+    // expected miss (ENOENT/ENOTDIR) reads as "does not exist"; permission
+    // and I/O failures surface as a structured failure instead of a
+    // fabricated "absent".
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      return {
+        success: true,
+        path: check.resolvedPath,
+        exists: false,
+        isFile: false,
+        isDirectory: false,
+        is_file: false,
+        is_directory: false,
+        size: 0,
+      };
+    }
+    return fileOpError(error);
   }
 }
 
@@ -199,6 +217,8 @@ export async function listDirectory(
       count: items.length,
     };
   } catch (error) {
+    // error-policy:J1 file-op boundary — the failure returns as a structured
+    // {success:false,error} the action surfaces to the model.
     return {
       success: false,
       error: error instanceof Error ? error.message : String(error),
@@ -222,6 +242,8 @@ export async function deleteDirectory(
       message: "Directory deleted.",
     };
   } catch (error) {
+    // error-policy:J1 file-op boundary — the failure returns as a structured
+    // {success:false,error} the action surfaces to the model.
     return {
       success: false,
       error: error instanceof Error ? error.message : String(error),
@@ -267,6 +289,8 @@ export async function readBytes(
       size: buf.length,
     };
   } catch (error) {
+    // error-policy:J1 file-op boundary — the failure returns as a structured
+    // {success:false,error} the action surfaces to the model.
     return fileOpError(error);
   }
 }
@@ -294,6 +318,8 @@ export async function writeBytes(
       message: `Wrote ${buf.length} bytes.`,
     };
   } catch (error) {
+    // error-policy:J1 file-op boundary — the failure returns as a structured
+    // {success:false,error} the action surfaces to the model.
     return fileOpError(error);
   }
 }
@@ -316,6 +342,8 @@ export async function createDirectory(
       message: "Directory created.",
     };
   } catch (error) {
+    // error-policy:J1 file-op boundary — the failure returns as a structured
+    // {success:false,error} the action surfaces to the model.
     return fileOpError(error);
   }
 }
@@ -338,14 +366,22 @@ export async function directoryExists(
       is_directory: isDir,
       isDirectory: isDir,
     };
-  } catch {
-    return {
-      success: true,
-      path: check.resolvedPath,
-      exists: false,
-      is_directory: false,
-      isDirectory: false,
-    };
+  } catch (error) {
+    // error-policy:J3 existence probe with errno narrowing — only an
+    // expected miss (ENOENT/ENOTDIR) reads as "does not exist"; permission
+    // and I/O failures surface as a structured failure instead of a
+    // fabricated "absent".
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      return {
+        success: true,
+        path: check.resolvedPath,
+        exists: false,
+        is_directory: false,
+        isDirectory: false,
+      };
+    }
+    return fileOpError(error);
   }
 }
 
@@ -369,6 +405,8 @@ export async function getFileSize(
       isDirectory: stat.isDirectory(),
     };
   } catch (error) {
+    // error-policy:J1 file-op boundary — the failure returns as a structured
+    // {success:false,error} the action surfaces to the model.
     return fileOpError(error);
   }
 }

--- a/plugins/plugin-computeruse/src/platform/helpers.ts
+++ b/plugins/plugin-computeruse/src/platform/helpers.ts
@@ -30,6 +30,8 @@ export function commandExists(cmd: string): boolean {
     execSync(`${which} ${cmd}`, { stdio: "ignore", timeout: 3000 });
     exists = true;
   } catch {
+    // error-policy:J3 existence probe; a non-zero `which`/`where` exit means
+    // the command is absent — false is the expected-miss signal.
     exists = false;
   }
   commandExistsCache.set(cmd, exists);

--- a/plugins/plugin-computeruse/src/platform/launch.ts
+++ b/plugins/plugin-computeruse/src/platform/launch.ts
@@ -91,6 +91,8 @@ export function launchApp(
         stdio: "ignore",
       });
     } catch (err) {
+      // error-policy:J1 promise boundary — a sync spawn throw is translated
+      // into the rejection callers observe; nothing is swallowed.
       reject(err instanceof Error ? err : new Error(String(err)));
       return;
     }

--- a/plugins/plugin-computeruse/src/platform/nut-driver.ts
+++ b/plugins/plugin-computeruse/src/platform/nut-driver.ts
@@ -79,6 +79,9 @@ function loadNut(): NutModule | null {
     cachedModule = mod;
     return mod;
   } catch (err) {
+    // error-policy:J3 native-module availability probe; null signals
+    // "nutjs unavailable" and the cause is preserved in loadError, surfaced
+    // by loadFailureReason() in the driver-selection warn.
     loadError = err instanceof Error ? err : new Error(String(err));
     return null;
   }
@@ -361,6 +364,9 @@ export async function nutDrag(
     try {
       await m.mouse.move(m.straightTo(new m.Point(sx2, sy2)));
     } catch {
+      // error-policy:J4 designed two-tier drag — manualDragMove performs the
+      // same motion via interpolated setPosition steps, and its failure
+      // throws to the caller.
       await manualDragMove(m, sx1, sy1, sx2, sy2);
     }
   } finally {
@@ -543,7 +549,8 @@ export async function nutCaptureScreenshot(
       try {
         unlinkSync(absolutePath);
       } catch {
-        /* best effort */
+        // error-policy:J6 best-effort temp-file teardown; the capture result
+        // has already been read into memory.
       }
     }
   }

--- a/plugins/plugin-computeruse/src/platform/permissions.ts
+++ b/plugins/plugin-computeruse/src/platform/permissions.ts
@@ -3,7 +3,6 @@
  * Monitoring) into a typed PermissionDeniedError so callers can surface the exact
  * grant the user must enable rather than a generic failure.
  */
-import { execFileSync } from "node:child_process";
 import type { PermissionType } from "../types.js";
 
 type PermissionErrorOptions = {
@@ -241,6 +240,9 @@ export function probePermission(
     try {
       return probeWindowsCapabilityAccess("webcam");
     } catch (err) {
+      // error-policy:J3 registry probe; probed:false is the explicit
+      // "could not determine" signal (distinct from a probed denial) and
+      // details carries the failure for the caller's classification.
       return { granted: false, probed: false, details: toMessage(err) };
     }
   }
@@ -248,6 +250,9 @@ export function probePermission(
     try {
       return probeWindowsCapabilityAccess("microphone");
     } catch (err) {
+      // error-policy:J3 registry probe; probed:false is the explicit
+      // "could not determine" signal (distinct from a probed denial) and
+      // details carries the failure for the caller's classification.
       return { granted: false, probed: false, details: toMessage(err) };
     }
   }
@@ -255,6 +260,9 @@ export function probePermission(
     try {
       return probeWindowsCapabilityAccess("graphicsCaptureProgrammatic");
     } catch (err) {
+      // error-policy:J3 registry probe; probed:false is the explicit
+      // "could not determine" signal (distinct from a probed denial) and
+      // details carries the failure for the caller's classification.
       return { granted: false, probed: false, details: toMessage(err) };
     }
   }

--- a/plugins/plugin-computeruse/src/platform/process-list.ts
+++ b/plugins/plugin-computeruse/src/platform/process-list.ts
@@ -25,6 +25,7 @@
 
 import { execFileSync, execSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
+import { logger } from "@elizaos/core";
 import { currentPlatform } from "./helpers.js";
 
 export interface ProcessInfo {
@@ -45,7 +46,15 @@ function listLinux(): ProcessInfo[] {
   let entries: string[];
   try {
     entries = readdirSync("/proc");
-  } catch {
+  } catch (err) {
+    // error-policy:J4 [] is the explicit "process list unavailable" degrade
+    // for the scene join; /proc being unreadable on Linux is real breakage,
+    // so it is warned rather than read as a machine with no processes.
+    logger.warn(
+      `[process-list] /proc unreadable; process list unavailable: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
     return out;
   }
   for (const entry of entries) {
@@ -58,6 +67,9 @@ function listLinux(): ProcessInfo[] {
       // join-with-windows; a longer name (cmdline arg0 basename) is overkill.
       name = readFileSync(`/proc/${pid}/comm`, "utf8").trim();
     } catch {
+      // error-policy:J3 expected transient miss — the process can exit
+      // between readdir and the comm read; skipping the dead PID is the
+      // truthful result.
       continue;
     }
     if (!name) continue;
@@ -75,6 +87,8 @@ function listDarwin(): ProcessInfo[] {
     });
     return parsePsOutput(text);
   } catch {
+    // error-policy:J4 two-tier `ps` invocation; the BSD variant below is the
+    // designed second tier.
     try {
       // Fallback: BSD ps without `-c` (gives full path in comm).
       const text = execFileSync("ps", ["-axo", "pid=,comm="], {
@@ -83,7 +97,15 @@ function listDarwin(): ProcessInfo[] {
         stdio: ["ignore", "pipe", "ignore"],
       });
       return parsePsOutput(text);
-    } catch {
+    } catch (err) {
+      // error-policy:J4 [] is the explicit "process list unavailable"
+      // degrade for the scene join; both ps variants failing is warned, not
+      // read as a machine with no processes.
+      logger.warn(
+        `[process-list] ps enumeration failed; process list unavailable: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
       return [];
     }
   }
@@ -116,7 +138,15 @@ function listWindows(): ProcessInfo[] {
       { timeout: 8000, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
     );
     return parseWindowsProcessJson(text);
-  } catch {
+  } catch (err) {
+    // error-policy:J4 [] is the explicit "process list unavailable" degrade
+    // for the scene join; the PowerShell failure is warned, not read as a
+    // machine with no processes.
+    logger.warn(
+      `[process-list] Get-Process enumeration failed; process list unavailable: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
     return [];
   }
 }
@@ -131,6 +161,8 @@ export function parseWindowsProcessJson(text: string): ProcessInfo[] {
   try {
     raw = JSON.parse(text);
   } catch {
+    // error-policy:J3 untrusted PowerShell output; unparseable JSON yields
+    // the explicit empty list, never a fabricated process row.
     return [];
   }
   const items: WinProcessRow[] = Array.isArray(raw)

--- a/plugins/plugin-computeruse/src/platform/ps-host.ts
+++ b/plugins/plugin-computeruse/src/platform/ps-host.ts
@@ -161,19 +161,19 @@ export function shutdownPsHost(): void {
     try {
       host.stdin.end();
     } catch {
-      /* best effort */
+      // error-policy:J6 best-effort teardown; the host is being discarded.
     }
     try {
       host.kill();
     } catch {
-      /* best effort */
+      // error-policy:J6 best-effort teardown; the host is being discarded.
     }
   }
   if (loopScriptPath) {
     try {
       unlinkSync(loopScriptPath);
     } catch {
-      /* best effort */
+      // error-policy:J6 best-effort teardown of the loop script temp file.
     }
     loopScriptPath = null;
   }
@@ -270,8 +270,9 @@ function sendRaw(script: string, timeoutMs: number): Promise<string> {
     try {
       host.stdin.write(`${token} ${b64}\n`);
     } catch (err) {
-      // Synchronous write failure (e.g. dead pipe). Surface as a rejection so
-      // the caller falls back, and tear the host down so the next call respawns.
+      // error-policy:J1 promise boundary — a synchronous write failure (e.g.
+      // dead pipe) surfaces as a rejection so the caller falls back to a
+      // one-shot spawn, and the host is torn down so the next call respawns.
       clearTimeout(timer);
       pending = null;
       shutdownPsHost();
@@ -296,6 +297,9 @@ export function runPsHost(script: string, timeoutMs: number): Promise<string> {
     return sendRaw(script, timeoutMs);
   };
   const run = chain.then(task, task);
+  // error-policy:J5 the rejection is observed by the caller of runPsHost()
+  // (which receives `run` itself); this catch only keeps the serialization
+  // chain alive so one failed request cannot wedge every later request.
   chain = run.catch(() => {});
   return run;
 }
@@ -310,6 +314,10 @@ export function warmPsHost(): Promise<void> {
   // (e.g. a service (re)start after a prior dispose).
   spawnAllowed = true;
   if (!psHostAvailable()) return Promise.resolve();
+  // error-policy:J5 the start failure is observed inside ensureHost (which
+  // latches startFailures until the host is disabled); every real consumer
+  // falls back to a one-shot spawn whose failure surfaces to its caller.
+  // This handler only upholds the documented never-rejects warm contract.
   return runPsHost("$null", startupTimeoutMs()).then(
     () => {},
     () => {},
@@ -339,7 +347,8 @@ process.once("exit", () => {
     try {
       host.kill();
     } catch {
-      /* best effort */
+      // error-policy:J6 best-effort teardown on process exit; nothing can
+      // observe a failure here.
     }
   }
 });

--- a/plugins/plugin-computeruse/src/platform/screenshot.ts
+++ b/plugins/plugin-computeruse/src/platform/screenshot.ts
@@ -62,14 +62,16 @@ export async function captureScreenshot(
     try {
       unlinkSync(tmpFile);
     } catch {
-      /* cleanup best effort */
+      // error-policy:J6 best-effort temp-file teardown; the frame is already
+      // in memory.
     }
     return data;
   } catch (err) {
     try {
       unlinkSync(tmpFile);
     } catch {
-      /* ignore */
+      // error-policy:J6 best-effort temp-file teardown on the failure path;
+      // the original error below is what surfaces.
     }
 
     const operation = region ? "screenshot_region" : "screenshot_capture";
@@ -199,7 +201,9 @@ function detectX11ScreenSize(): string {
     const m = out.match(/dimensions:\s+(\d+)x(\d+)/);
     if (m) return `${m[1]}x${m[2]}`;
   } catch {
-    // fall through to the default below
+    // error-policy:J4 designed degrade — the ffmpeg x11grab caller only
+    // needs a plausible capture geometry; a wrong size fails loudly at
+    // capture, not silently here.
   }
   return "1920x1080";
 }
@@ -229,7 +233,8 @@ async function captureWindows(
       await runPsHost(psCmd, 15000);
       return;
     } catch {
-      /* warm host unavailable/errored — fall back to one-shot spawn */
+      // error-policy:J4 designed two-tier execution — the one-shot spawn
+      // below runs the SAME script, and its failure throws to the caller.
     }
   }
   execSync(`powershell -Command "${psCmd}"`, {

--- a/plugins/plugin-computeruse/src/platform/security.ts
+++ b/plugins/plugin-computeruse/src/platform/security.ts
@@ -237,7 +237,9 @@ export function validateFilePath(
         resolved = expanded;
       }
     } catch {
-      // Ignore nonexistent paths; the static blocklists still apply.
+      // error-policy:J3 8.3-shortname expansion probe; a nonexistent path
+      // cannot be expanded, and the static blocklists below still apply to
+      // the unexpanded form — nothing is bypassed.
     }
   }
 
@@ -346,6 +348,9 @@ export async function resolveSafeFileTarget(
     }
     return { allowed: true, resolvedPath: canonical };
   } catch (error) {
+    // error-policy:J3 errno-narrowed realpath probe — only ENOENT (the file
+    // does not exist yet) degrades to static path validation; every other
+    // failure returns an explicit not-allowed result below.
     if (errnoCode(error) === "ENOENT" && operation === "read") {
       const fallback = validateFilePath(resolved, operation);
       if (!fallback.allowed) {
@@ -372,6 +377,9 @@ export async function resolveSafeFileTarget(
         }
         return { allowed: true, resolvedPath: target };
       } catch (parentError) {
+        // error-policy:J3 errno-narrowed parent-dir probe — only ENOENT
+        // degrades to static validation; every other failure returns an
+        // explicit not-allowed result below.
         if (errnoCode(parentError) === "ENOENT") {
           const fallback = validateFilePath(resolved, operation);
           if (!fallback.allowed) {

--- a/plugins/plugin-computeruse/src/platform/windows-list.ts
+++ b/plugins/plugin-computeruse/src/platform/windows-list.ts
@@ -7,6 +7,7 @@
  */
 
 import { execFileSync, execSync } from "node:child_process";
+import { logger } from "@elizaos/core";
 import type { ScreenRegion, ScreenSize, WindowInfo } from "../types.js";
 import {
   commandExists,
@@ -45,12 +46,14 @@ async function runWindowsPowerShell(
     try {
       return await runPsHost(ps, budget);
     } catch (err) {
-      // A SCRIPT-level error (the warm host ran the script and it threw, e.g.
-      // `Window not found`) is authoritative — re-running it through a cold
-      // one-shot spawn can only repeat the same failure (slowly) or, on a
-      // Defender-heavy host where the cold spawn exceeds timeoutMs, mask it as
-      // an opaque ETIMEDOUT. Surface it directly. Only HOST-level failures
-      // (host unavailable / exited / timed out / disposed) fall back.
+      // error-policy:J4 designed two-tier failover. A SCRIPT-level error (the
+      // warm host ran the script and it threw, e.g. `Window not found`) is
+      // authoritative — re-running it through a cold one-shot spawn can only
+      // repeat the same failure (slowly) or, on a Defender-heavy host where
+      // the cold spawn exceeds timeoutMs, mask it as an opaque ETIMEDOUT.
+      // Surface it directly. Only HOST-level failures (host unavailable /
+      // exited / timed out / disposed) fall back to the cold spawn below,
+      // whose own failure propagates to the caller.
       if (
         err instanceof Error &&
         err.message.startsWith("ps-host script error:")
@@ -242,7 +245,8 @@ export async function warmWindowsCache(): Promise<void> {
     windowsCache = parseWindowsWindowList(output);
     windowsCachedAt = Date.now();
   } catch {
-    /* leave cache untouched; sync enumeration remains the fallback */
+    // error-policy:J4 documented never-throws warm-cache contract; the sync
+    // enumeration path remains the authoritative fallback.
   }
 }
 
@@ -303,6 +307,9 @@ function listWindowsDarwinViaSwift(): WindowInfo[] | null {
     });
     return parseDarwinWindowOutput(output);
   } catch {
+    // error-policy:J4 null is the documented "Swift tier unavailable/failed"
+    // signal; the caller falls back to the System Events tier, whose failure
+    // is warned there.
     return null;
   }
 }
@@ -336,7 +343,15 @@ function listWindowsDarwinViaSystemEvents(): WindowInfo[] {
       stdio: ["ignore", "pipe", "ignore"],
     });
     return parseDarwinWindowOutput(output);
-  } catch {
+  } catch (err) {
+    // error-policy:J4 [] is the explicit "window list unavailable" degrade
+    // (last macOS tier); an Accessibility-permission denial lands here, so
+    // it is warned rather than read as a desktop with no windows.
+    logger.warn(
+      `[windows-list] System Events window enumeration failed; window list unavailable: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
     return [];
   }
 }
@@ -375,7 +390,15 @@ function listWindowsLinux(): WindowInfo[] {
         title: line.trim(),
         app: "unknown",
       }));
-  } catch {
+  } catch (err) {
+    // error-policy:J4 [] is the explicit "window list unavailable" degrade;
+    // the wmctrl/xdotool failure is warned rather than read as a desktop
+    // with no windows.
+    logger.warn(
+      `[windows-list] X11 window enumeration failed; window list unavailable: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
     return [];
   }
 }
@@ -390,6 +413,8 @@ export function parseWindowsWindowList(output: string): WindowInfo[] {
       app: "unknown",
     }));
   } catch {
+    // error-policy:J3 untrusted PowerShell output; unparseable JSON yields
+    // the explicit empty list, never a fabricated window row.
     return [];
   }
 }
@@ -407,7 +432,15 @@ function listWindowsWindows(): WindowInfo[] {
       timeout: psSpawnTimeoutMs(15000),
     });
     return parseWindowsWindowList(output);
-  } catch {
+  } catch (err) {
+    // error-policy:J4 [] is the explicit "window list unavailable" degrade
+    // (the #9581 Defender-timeout failure mode); warned so a slow host is
+    // distinguishable from a desktop with no windows.
+    logger.warn(
+      `[windows-list] PowerShell window enumeration failed; window list unavailable: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
     return [];
   }
 }
@@ -468,6 +501,8 @@ export async function getActiveWindow(): Promise<WindowInfo | null> {
       return { id, title: title ?? "", app: app ?? "" };
     }
   } catch {
+    // error-policy:J4 null is the documented "no focused window / query
+    // unavailable" contract for this best-effort M12 probe.
     return null;
   }
   return null;
@@ -623,6 +658,9 @@ export async function focusWindow(windowId: string): Promise<void> {
     try {
       runDarwinWindowScript(commandTarget, "set frontmost of proc to true");
     } catch {
+      // error-policy:J4 designed two-tier focus — app-level `activate` is the
+      // fallback for windows System Events cannot address, and its failure
+      // throws to the caller.
       runCommand(
         "osascript",
         [
@@ -1027,7 +1065,8 @@ export async function warmScreenSizeCache(): Promise<void> {
       screenSizeCache = { width: b.Width, height: b.Height };
     }
   } catch {
-    /* leave cache untouched; computeScreenSize remains the fallback */
+    // error-policy:J4 documented never-throws warm-cache contract; the sync
+    // computeScreenSize path remains the authoritative fallback.
   }
 }
 
@@ -1053,7 +1092,8 @@ function computeScreenSize(): ScreenSize | null {
         return { width, height };
       }
     } catch {
-      /* fallback */
+      // error-policy:J4 one tier of the screen-size failover chain; the next
+      // tier (or the explicit null "unknown" result) follows.
     }
     try {
       const output = execSync(
@@ -1071,7 +1111,8 @@ function computeScreenSize(): ScreenSize | null {
         return { width, height };
       }
     } catch {
-      /* fallback */
+      // error-policy:J4 one tier of the screen-size failover chain; the next
+      // tier (or the explicit null "unknown" result) follows.
     }
     // Fallback: system_profiler
     try {
@@ -1091,7 +1132,8 @@ function computeScreenSize(): ScreenSize | null {
         };
       }
     } catch {
-      /* fallback */
+      // error-policy:J4 one tier of the screen-size failover chain; the next
+      // tier (or the explicit null "unknown" result) follows.
     }
     return null;
   }
@@ -1109,7 +1151,8 @@ function computeScreenSize(): ScreenSize | null {
           };
         }
       } catch {
-        /* fallback */
+        // error-policy:J4 one tier of the screen-size failover chain; the
+        // next tier (or the explicit null "unknown" result) follows.
       }
     }
     if (commandExists("xrandr")) {
@@ -1130,7 +1173,8 @@ function computeScreenSize(): ScreenSize | null {
           };
         }
       } catch {
-        /* fallback */
+        // error-policy:J4 one tier of the screen-size failover chain; the
+        // next tier (or the explicit null "unknown" result) follows.
       }
     }
     return null;
@@ -1152,7 +1196,8 @@ function computeScreenSize(): ScreenSize | null {
         return { width: bounds.Width, height: bounds.Height };
       }
     } catch {
-      /* fallback */
+      // error-policy:J4 one tier of the screen-size failover chain; the next
+      // tier (or the explicit null "unknown" result) follows.
     }
     return null;
   }

--- a/plugins/plugin-computeruse/src/providers/computer-state.ts
+++ b/plugins/plugin-computeruse/src/providers/computer-state.ts
@@ -122,7 +122,11 @@ export const computerStateProvider: Provider = {
           recentActions: recent.slice(-5),
         },
       };
-    } catch {
+    } catch (error) {
+      // error-policy:J4 the empty provider result is the designed degrade
+      // (prompt space is precious), and the failure is reported so the agent
+      // sees it via RECENT_ERRORS instead of a silently-blank computer state.
+      runtime.reportError("Computeruse.computerStateProvider", error);
       return { text: "", values: {}, data: {} };
     }
   },

--- a/plugins/plugin-computeruse/src/providers/scene.ts
+++ b/plugins/plugin-computeruse/src/providers/scene.ts
@@ -52,7 +52,11 @@ export const sceneProvider: Provider = {
     if (!scene) {
       try {
         scene = await service.refreshScene("agent-turn");
-      } catch {
+      } catch (error) {
+        // error-policy:J4 the empty provider result is the designed degrade,
+        // and the failure is reported so the agent sees a broken scene
+        // pipeline via RECENT_ERRORS instead of a silently sceneless turn.
+        runtime.reportError("Computeruse.sceneProvider", error);
         return { text: "" };
       }
     }

--- a/plugins/plugin-computeruse/src/routes/computer-use-compat-routes.ts
+++ b/plugins/plugin-computeruse/src/routes/computer-use-compat-routes.ts
@@ -52,6 +52,8 @@ function isTrustedLocalRequest(
         return false;
       }
     } catch {
+      // error-policy:J3 untrusted Origin header; an unparseable origin is
+      // rejected (fail-closed), never treated as local.
       return false;
     }
   }
@@ -168,6 +170,9 @@ async function readCompatJsonBody(
       chunks.push(buf);
     }
   } catch {
+    // error-policy:J1 route boundary — a broken body stream becomes an
+    // explicit 400; null tells the route handler the response is already
+    // sent.
     sendJsonErrorResponse(res, 400, "Invalid request body");
     return null;
   }
@@ -184,6 +189,8 @@ async function readCompatJsonBody(
     }
     return parsed as Record<string, unknown>;
   } catch {
+    // error-policy:J3 untrusted request body; unparseable JSON becomes an
+    // explicit 400 — never an empty-object fake-valid body.
     sendJsonErrorResponse(res, 400, "Invalid JSON body");
     return null;
   }

--- a/plugins/plugin-computeruse/src/routes/sandbox-routes.ts
+++ b/plugins/plugin-computeruse/src/routes/sandbox-routes.ts
@@ -6,6 +6,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  logger,
   readJsonBody as parseJsonBody,
   readRequestBody,
   sendJson as sendJsonResponse,
@@ -869,15 +870,16 @@ function captureScreenshot(region?: {
     try {
       unlinkSync(tmpFile);
     } catch {
-      /* cleanup best effort */
+      // error-policy:J6 best-effort temp-file teardown; the frame is already
+      // in memory.
     }
     return data;
   } catch (err) {
-    // Clean up temp file on error
     try {
       unlinkSync(tmpFile);
     } catch {
-      /* ignore */
+      // error-policy:J6 best-effort temp-file teardown on the failure path;
+      // the rethrow below is what surfaces.
     }
     throw err;
   }
@@ -916,7 +918,15 @@ function listWindows(): Array<{ id: string; title: string; app: string }> {
             id: parts[2] ?? "0",
           };
         });
-    } catch {
+    } catch (err) {
+      // error-policy:J4 [] is the explicit "window list unavailable" degrade
+      // for this diagnostic sandbox route; warned so an Accessibility denial
+      // is not read as a desktop with no windows.
+      logger.warn(
+        `[sandbox-routes] macOS window enumeration failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
       return [];
     }
   }
@@ -938,7 +948,14 @@ function listWindows(): Array<{ id: string; title: string; app: string }> {
           title: line.trim(),
           app: "unknown",
         }));
-    } catch {
+    } catch (err) {
+      // error-policy:J4 [] is the explicit "window list unavailable" degrade
+      // for this diagnostic sandbox route; the tool failure is warned.
+      logger.warn(
+        `[sandbox-routes] X11 window enumeration failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
       return [];
     }
   }
@@ -956,7 +973,14 @@ function listWindows(): Array<{ id: string; title: string; app: string }> {
         title: p.MainWindowTitle,
         app: "unknown",
       }));
-    } catch {
+    } catch (err) {
+      // error-policy:J4 [] is the explicit "window list unavailable" degrade
+      // for this diagnostic sandbox route; the PowerShell failure is warned.
+      logger.warn(
+        `[sandbox-routes] PowerShell window enumeration failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
       return [];
     }
   }
@@ -1020,7 +1044,8 @@ async function recordAudio(durationMs: number): Promise<Buffer> {
   try {
     unlinkSync(tmpFile);
   } catch {
-    /* cleanup */
+    // error-policy:J6 best-effort temp-file teardown; the recording is
+    // already in memory.
   }
   return data;
 }
@@ -1058,7 +1083,8 @@ async function playAudio(data: Buffer, format: string): Promise<void> {
     try {
       unlinkSync(tmpFile);
     } catch {
-      /* cleanup */
+      // error-policy:J6 best-effort temp-file teardown; playback success or
+      // failure has already been decided.
     }
   }
 }
@@ -1334,7 +1360,8 @@ function getPlatformInfo(): Record<string, string | boolean> {
     execSync(`${which} docker`, { stdio: "ignore", timeout: 3000 });
     dockerInstalled = true;
   } catch {
-    /* not installed */
+    // error-policy:J3 existence probe; a `which` miss means docker is not
+    // installed — the diagnostic payload reports it explicitly.
   }
 
   // Check if docker daemon is running (docker info succeeds only when daemon is up)
@@ -1343,7 +1370,8 @@ function getPlatformInfo(): Record<string, string | boolean> {
       execSync("docker info", { stdio: "ignore", timeout: 5000 });
       dockerRunning = true;
     } catch {
-      /* installed but not running */
+      // error-policy:J3 daemon-liveness probe; failure means "installed but
+      // not running" — the diagnostic payload reports it explicitly.
     }
   }
 
@@ -1352,7 +1380,8 @@ function getPlatformInfo(): Record<string, string | boolean> {
       execSync("which container", { stdio: "ignore", timeout: 3000 });
       appleContainerAvailable = true;
     } catch {
-      /* */
+      // error-policy:J3 existence probe; a `which` miss means the Apple
+      // container CLI is absent — reported explicitly in the payload.
     }
   }
 
@@ -1375,6 +1404,8 @@ function isWsl2Available(): boolean {
     execSync("wsl --status", { stdio: "ignore", timeout: 5000 });
     return true;
   } catch {
+    // error-policy:J3 availability probe; a failing `wsl --status` means
+    // WSL2 is absent — false is the expected-miss signal.
     return false;
   }
 }
@@ -1413,7 +1444,8 @@ function attemptDockerStart(): {
           started = true;
           break;
         } catch {
-          /* try next path */
+          // error-policy:J4 one tier of the install-location failover chain;
+          // the next candidate path (or the start-menu tier) follows.
         }
       }
       if (!started) {
@@ -1445,7 +1477,8 @@ function attemptDockerStart(): {
           waitMs: 5000,
         };
       } catch {
-        /* systemctl may not be available */
+        // error-policy:J4 systemctl tier of the Linux daemon-start chain;
+        // the `service` tier below follows.
       }
 
       // Try service command
@@ -1460,7 +1493,8 @@ function attemptDockerStart(): {
           waitMs: 5000,
         };
       } catch {
-        /* */
+        // error-policy:J4 last Linux tier; the explicit structured failure
+        // below tells the caller exactly what to run manually.
       }
 
       return {
@@ -1477,6 +1511,8 @@ function attemptDockerStart(): {
       waitMs: 0,
     };
   } catch (err) {
+    // error-policy:J1 route-facing boundary — the failure returns as an
+    // explicit structured {success:false,message} payload.
     return {
       success: false,
       message: `Failed: ${String(err)}`,
@@ -1493,6 +1529,8 @@ function commandExists(cmd: string): boolean {
     execSync(`${which} ${cmd}`, { stdio: "ignore", timeout: 3000 });
     return true;
   } catch {
+    // error-policy:J3 existence probe; a `which`/`where` miss means the
+    // command is absent — false is the expected-miss signal.
     return false;
   }
 }

--- a/plugins/plugin-computeruse/src/sandbox/docker-backend.ts
+++ b/plugins/plugin-computeruse/src/sandbox/docker-backend.ts
@@ -352,7 +352,8 @@ export class DockerBackend implements SandboxBackend {
       try {
         this.helper.stdin.end();
       } catch {
-        // ignore
+        // error-policy:J6 best-effort teardown; the helper process is being
+        // discarded and the container kill below still runs.
       }
       this.helper = null;
     }
@@ -394,6 +395,9 @@ export class DockerBackend implements SandboxBackend {
       try {
         parsed = JSON.parse(line);
       } catch (err) {
+        // error-policy:J3 untrusted helper output — unparseable JSON rejects
+        // the pending op with a typed SandboxInvocationError, never a
+        // fake-empty result.
         next.reject(
           new SandboxInvocationError(
             `Helper produced unparseable JSON for ${next.op}: ${err instanceof Error ? err.message : String(err)}`,

--- a/plugins/plugin-computeruse/src/sandbox/remote-guest.ts
+++ b/plugins/plugin-computeruse/src/sandbox/remote-guest.ts
@@ -158,6 +158,8 @@ export class HttpGuestTransport implements RemoteGuestTransport {
       const body = (await res.json()) as GuestRpcResponse;
       return body;
     } catch (err) {
+      // error-policy:J1 RPC boundary — the transport failure returns as a
+      // structured {success:false,error} the sandbox driver surfaces.
       return {
         success: false,
         error: err instanceof Error ? err.message : String(err),

--- a/plugins/plugin-computeruse/src/scene/a11y-provider.error-policy.test.ts
+++ b/plugins/plugin-computeruse/src/scene/a11y-provider.error-policy.test.ts
@@ -1,22 +1,73 @@
 /**
- * Error-policy tests for the accessibility providers' snapshot failure path
- * (#12273). The interface contract is that `snapshot()` returns `[]` for "no
- * reachable nodes" so the scene-builder always produces a Scene — but a genuine
- * failure (the platform a11y binary missing, or permission revoked) must not be
- * silently indistinguishable from an empty desktop. These tests drive the real
- * missing-binary path (osascript/powershell are absent on the Linux CI host) and
- * assert the failure is surfaced via `logger.warn`, not swallowed.
+ * Error-policy tests for the accessibility scan failure paths (#12273). The
+ * interface contract is that `snapshot()` returns `[]` for "no reachable
+ * nodes" so the scene-builder always produces a Scene — but a genuine failure
+ * (the platform a11y binary missing, permission revoked, windows dropped
+ * mid-scan) must not be silently indistinguishable from an empty desktop.
+ * These tests drive the real missing-binary path (osascript/powershell are
+ * absent on non-native hosts), assert the failure lands in `lastScanStats()`
+ * and `logger.warn`, and assert the SceneBuilder reports it exactly once per
+ * scan through its `reportError` seam (wired to `runtime.reportError` →
+ * ERROR_REPORTED by ComputerUseService).
  */
 
 import { logger } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  type A11yScanStats,
+  type AccessibilityProvider,
   DarwinAccessibilityProvider,
+  parseDarwinA11yPayload,
+  parseWindowsUiaPayload,
   WindowsAccessibilityProvider,
 } from "./a11y-provider.js";
+import { SceneBuilder } from "./scene-builder.js";
+import type { SceneAxNode } from "./scene-types.js";
 
 const onDarwin = process.platform === "darwin";
 const onWindows = process.platform === "win32";
+
+// 1x1 PNG so the builder's dHash path has real bytes to chew on.
+const TINY_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+const fakeDisplay = {
+  id: 0,
+  bounds: [0, 0, 4, 4] as [number, number, number, number],
+  scaleFactor: 1,
+  primary: true,
+  name: "fake",
+};
+
+function makeBuilderWith(provider: AccessibilityProvider): {
+  builder: SceneBuilder;
+  reports: Array<{
+    scope: string;
+    error: unknown;
+    context?: Record<string, unknown>;
+  }>;
+} {
+  const reports: Array<{
+    scope: string;
+    error: unknown;
+    context?: Record<string, unknown>;
+  }> = [];
+  const builder = new SceneBuilder({
+    captureAll: async () => [{ display: fakeDisplay, frame: TINY_PNG }],
+    captureOne: async () => ({ display: fakeDisplay, frame: TINY_PNG }),
+    listDisplays: () => [fakeDisplay],
+    enumerateApps: () => [],
+    accessibilityProvider: provider,
+    runOcrOnFrame: async () => [],
+    log: () => {},
+    reportError: (scope, error, context) => {
+      reports.push({ scope, error, context });
+    },
+  });
+  return { builder, reports };
+}
 
 describe("accessibility provider snapshot failure surfacing", () => {
   afterEach(() => {
@@ -24,34 +75,176 @@ describe("accessibility provider snapshot failure surfacing", () => {
   });
 
   it.skipIf(onDarwin)(
-    "Darwin provider surfaces the osascript failure via logger.warn and still returns []",
+    "Darwin provider surfaces the osascript failure via logger.warn, records scan stats, and still returns []",
     async () => {
       const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
 
       // osascript does not exist on a non-macOS host → execFileSync throws.
-      const nodes = await new DarwinAccessibilityProvider().snapshot();
+      const provider = new DarwinAccessibilityProvider();
+      const nodes = await provider.snapshot();
 
       expect(nodes).toEqual([]);
       expect(warn).toHaveBeenCalledTimes(1);
       expect(String(warn.mock.calls[0]?.[0])).toContain(
         "[DarwinAccessibilityProvider]",
       );
+      // The whole-scan failure is recorded so the scene-builder can report it.
+      const stats = provider.lastScanStats();
+      expect(stats).not.toBeNull();
+      expect(stats?.error).toBeTruthy();
     },
   );
 
   it.skipIf(onWindows)(
-    "Windows provider surfaces the PowerShell failure via logger.warn and still returns []",
+    "Windows provider surfaces the PowerShell failure via logger.warn, records scan stats, and still returns []",
     async () => {
       const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
 
       // powershell does not exist on a non-Windows host → execFileSync throws.
-      const nodes = await new WindowsAccessibilityProvider().snapshot();
+      const provider = new WindowsAccessibilityProvider();
+      const nodes = await provider.snapshot();
 
       expect(nodes).toEqual([]);
       expect(warn).toHaveBeenCalledTimes(1);
       expect(String(warn.mock.calls[0]?.[0])).toContain(
         "[WindowsAccessibilityProvider]",
       );
+      const stats = provider.lastScanStats();
+      expect(stats).not.toBeNull();
+      expect(stats?.error).toBeTruthy();
     },
   );
+});
+
+describe("scan payload parsers (untrusted embedded-script output)", () => {
+  it("parseDarwinA11yPayload maps windows and preserves the failure counts", () => {
+    const payload = JSON.stringify({
+      windows: [
+        { app: "Safari", title: "GitHub", bbox: [1, 2, 300, 200] },
+        { app: "Notes" },
+      ],
+      failed: 3,
+      total: 5,
+    });
+    const { nodes, failedWindows, totalWindows } =
+      parseDarwinA11yPayload(payload);
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0]).toMatchObject({
+      role: "window",
+      label: "GitHub",
+      bbox: [1, 2, 300, 200],
+    });
+    expect(nodes[1]?.label).toBe("Notes");
+    expect(failedWindows).toBe(3);
+    expect(totalWindows).toBe(5);
+  });
+
+  it("parseDarwinA11yPayload throws on a non-object payload instead of fabricating an empty scan", () => {
+    expect(() => parseDarwinA11yPayload("[]")).toThrow();
+    expect(() => parseDarwinA11yPayload("not json")).toThrow();
+  });
+
+  it("parseWindowsUiaPayload re-wraps the single-window ConvertTo-Json collapse and preserves counts", () => {
+    const payload = JSON.stringify({
+      windows: {
+        role: "ControlType.Window",
+        label: "Files",
+        bbox: [0, 0, 8, 8],
+      },
+      failed: 2,
+      total: 7,
+    });
+    const { nodes, failedWindows, totalWindows } =
+      parseWindowsUiaPayload(payload);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]?.label).toBe("Files");
+    expect(failedWindows).toBe(2);
+    expect(totalWindows).toBe(7);
+  });
+
+  it("parseWindowsUiaPayload throws on a bare-array payload instead of fabricating an empty scan", () => {
+    expect(() => parseWindowsUiaPayload("[]")).toThrow();
+  });
+});
+
+describe("SceneBuilder reports a11y scan failures once per scan", () => {
+  it.skipIf(onWindows)(
+    "a really-failing provider (missing powershell binary) produces exactly one Computeruse.a11yScan report per tick",
+    async () => {
+      vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+      // Real failing dependency: the PowerShell binary genuinely does not
+      // exist on this host, so the UIA scan fails for real — no mocks.
+      const { builder, reports } = makeBuilderWith(
+        new WindowsAccessibilityProvider(),
+      );
+
+      await builder.tick("agent-turn");
+
+      const scanReports = reports.filter(
+        (r) => r.scope === "Computeruse.a11yScan",
+      );
+      expect(scanReports).toHaveLength(1);
+      expect(scanReports[0]?.context).toMatchObject({ provider: "win32" });
+      expect(scanReports[0]?.error).toBeInstanceOf(Error);
+      vi.restoreAllMocks();
+    },
+  );
+
+  it("per-window misses are reported once per scan with {failedWindows,totalWindows} context", async () => {
+    // Hand-built provider standing in for a scan where some windows were
+    // unreadable (a11y permission revoked mid-session): the SceneBuilder is
+    // the unit under test here; the counting itself is exercised by the
+    // parser tests above and the real-binary test.
+    const provider: AccessibilityProvider = {
+      name: "darwin",
+      available: () => true,
+      snapshot: async (): Promise<SceneAxNode[]> => [
+        {
+          id: "a0-1",
+          role: "window",
+          label: "Notes",
+          bbox: [0, 0, 10, 10],
+          actions: ["focus"],
+          displayId: 0,
+        },
+      ],
+      lastScanStats: (): A11yScanStats => ({
+        failedWindows: 4,
+        totalWindows: 6,
+      }),
+    };
+    const { builder, reports } = makeBuilderWith(provider);
+
+    await builder.tick("agent-turn");
+
+    const scanReports = reports.filter(
+      (r) => r.scope === "Computeruse.a11yScan",
+    );
+    expect(scanReports).toHaveLength(1);
+    expect(scanReports[0]?.context).toMatchObject({
+      failedWindows: 4,
+      totalWindows: 6,
+      provider: "darwin",
+    });
+    expect(String((scanReports[0]?.error as Error).message)).toContain("4/6");
+  });
+
+  it("a clean scan produces no report", async () => {
+    const provider: AccessibilityProvider = {
+      name: "darwin",
+      available: () => true,
+      snapshot: async (): Promise<SceneAxNode[]> => [],
+      lastScanStats: (): A11yScanStats => ({
+        failedWindows: 0,
+        totalWindows: 3,
+      }),
+    };
+    const { builder, reports } = makeBuilderWith(provider);
+
+    await builder.tick("agent-turn");
+
+    expect(
+      reports.filter((r) => r.scope === "Computeruse.a11yScan"),
+    ).toHaveLength(0);
+  });
 });

--- a/plugins/plugin-computeruse/src/scene/a11y-provider.ts
+++ b/plugins/plugin-computeruse/src/scene/a11y-provider.ts
@@ -33,6 +33,22 @@ import { logger } from "@elizaos/core";
 import { commandExists, currentPlatform } from "../platform/helpers.js";
 import type { SceneAxNode } from "./scene-types.js";
 
+/**
+ * Outcome accounting for the most recent `snapshot()` call (#12273). A scan
+ * that silently drops windows (macOS a11y permission revoked mid-session, a
+ * UIA element that stopped responding) yields an ever-thinner scene the agent
+ * trusts as complete — so per-window misses are counted here and the
+ * scene-builder reports them once per scan via `runtime.reportError`.
+ */
+export interface A11yScanStats {
+  /** Windows/processes the scan attempted but could not read. */
+  failedWindows: number;
+  /** Windows/processes the scan attempted in total. */
+  totalWindows: number;
+  /** Set when the whole scan failed (binary missing, permission revoked). */
+  error?: string;
+}
+
 export interface AccessibilityProvider {
   readonly name: string;
   /**
@@ -46,6 +62,12 @@ export interface AccessibilityProvider {
    * scene-builder always produces a Scene.
    */
   snapshot(): Promise<SceneAxNode[]>;
+  /**
+   * Failure accounting for the most recent `snapshot()` call, or null when
+   * the provider cannot count (Null provider, compositor IPC tiers). Optional
+   * so externally-registered providers (Android WS8) keep working unchanged.
+   */
+  lastScanStats?(): A11yScanStats | null;
 }
 
 class NullAccessibilityProvider implements AccessibilityProvider {
@@ -98,6 +120,7 @@ export function assignAxId(state: IdAssignerState, displayId: number): string {
 
 export class LinuxAccessibilityProvider implements AccessibilityProvider {
   readonly name = "linux";
+  private lastStats: A11yScanStats | null = null;
 
   available(): boolean {
     // AT-SPI requires python3 + python3-atspi/gi. Wayland fallback requires
@@ -109,9 +132,16 @@ export class LinuxAccessibilityProvider implements AccessibilityProvider {
     );
   }
 
+  lastScanStats(): A11yScanStats | null {
+    return this.lastStats;
+  }
+
   async snapshot(): Promise<SceneAxNode[]> {
     // Try AT-SPI first (richest data on X11 / GNOME-Wayland), then fall
-    // back to compositor-specific IPC.
+    // back to compositor-specific IPC. Scan stats come from the AT-SPI tier
+    // (the only tier that can count per-window misses); the compositor tiers
+    // report null (unknown) rather than a fabricated clean count.
+    this.lastStats = null;
     const atspiNodes = this.tryAtspi();
     if (atspiNodes.length > 0) return atspiNodes;
     const wayland = this.tryWaylandCompositor();
@@ -120,6 +150,11 @@ export class LinuxAccessibilityProvider implements AccessibilityProvider {
 
   private tryAtspi(): SceneAxNode[] {
     if (!commandExists("python3")) return [];
+    // Per-window failures inside the AT-SPI walk are COUNTED (not silently
+    // degraded) so a scan that drops or half-reads windows is reported once
+    // per scan by the scene-builder instead of read as an emptier desktop
+    // (#12273). The module-level except keeps the designed failover contract:
+    // AT-SPI unavailable (no gi bindings) -> empty payload -> compositor tier.
     const py = `
 import json, sys
 try:
@@ -127,6 +162,8 @@ try:
     gi.require_version('Atspi', '2.0')
     from gi.repository import Atspi
     out = []
+    failed = 0
+    total = 0
     desktop = Atspi.get_desktop(0)
     for i in range(desktop.get_child_count()):
         app = desktop.get_child_at_index(i)
@@ -135,30 +172,35 @@ try:
         for j in range(min(app.get_child_count(), 30)):
             win = app.get_child_at_index(j)
             if not win: continue
+            total += 1
             try:
-                ext = win.get_extents(Atspi.CoordType.SCREEN)
-                bbox = [ext.x, ext.y, ext.width, ext.height]
+                try:
+                    ext = win.get_extents(Atspi.CoordType.SCREEN)
+                    bbox = [ext.x, ext.y, ext.width, ext.height]
+                except Exception:
+                    failed += 1
+                    bbox = [0,0,0,0]
+                try:
+                    action_iface = win.get_action_iface()
+                    actions = []
+                    if action_iface:
+                        n = action_iface.get_n_actions()
+                        for k in range(n):
+                            try: actions.append(action_iface.get_name(k))
+                            except Exception: pass
+                except Exception:
+                    actions = []
+                out.append({
+                    "role": win.get_role_name() or "unknown",
+                    "label": win.get_name() or appname,
+                    "bbox": bbox,
+                    "actions": actions,
+                })
             except Exception:
-                bbox = [0,0,0,0]
-            try:
-                action_iface = win.get_action_iface()
-                actions = []
-                if action_iface:
-                    n = action_iface.get_n_actions()
-                    for k in range(n):
-                        try: actions.append(action_iface.get_name(k))
-                        except Exception: pass
-            except Exception:
-                actions = []
-            out.append({
-                "role": win.get_role_name() or "unknown",
-                "label": win.get_name() or appname,
-                "bbox": bbox,
-                "actions": actions,
-            })
-    print(json.dumps(out))
+                failed += 1
+    print(json.dumps({"nodes": out, "failed": failed, "total": total}))
 except Exception as e:
-    print("[]")
+    print(json.dumps({"nodes": [], "failed": 0, "total": 0}))
 `;
     try {
       const text = execFileSync("python3", ["-c", py], {
@@ -166,11 +208,22 @@ except Exception as e:
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
       });
-      const parsed = JSON.parse(text || "[]");
-      if (!Array.isArray(parsed)) return [];
-      return parsed
+      const parsed: unknown = JSON.parse(text || '{"nodes":[]}');
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return [];
+      }
+      const obj = parsed as Record<string, unknown>;
+      const rawNodes = Array.isArray(obj.nodes) ? obj.nodes : [];
+      const nodes = rawNodes
         .filter((n) => n && typeof n === "object")
         .map((n, i) => mapAtspiNode(n as Record<string, unknown>, i));
+      if (nodes.length > 0) {
+        this.lastStats = {
+          failedWindows: Number(obj.failed) || 0,
+          totalWindows: Number(obj.total) || 0,
+        };
+      }
+      return nodes;
     } catch {
       // error-policy:J4 AT-SPI probe; empty result advances the failover chain
       // to the Wayland compositor tier (see snapshot()).
@@ -351,23 +404,83 @@ function mapAtspiNode(raw: Record<string, unknown>, idx: number): SceneAxNode {
 
 // ── macOS ───────────────────────────────────────────────────────────────────
 
+/**
+ * Parse the JXA scan payload `{windows, failed, total}` into nodes + scan
+ * stats. Exported so the untrusted-output seam is testable without osascript.
+ * Throws on an unrecognizable payload — the caller's catch treats that as a
+ * whole-scan failure rather than fabricating an empty-but-healthy result.
+ */
+export function parseDarwinA11yPayload(text: string): {
+  nodes: SceneAxNode[];
+  failedWindows: number;
+  totalWindows: number;
+} {
+  const parsed: unknown = JSON.parse(text);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "osascript a11y payload is not a {windows,failed,total} object",
+    );
+  }
+  const obj = parsed as Record<string, unknown>;
+  const windows = Array.isArray(obj.windows) ? obj.windows : [];
+  const nodes = windows.map((n, i) => {
+    const rec = (n ?? {}) as Record<string, unknown>;
+    const bbox = Array.isArray(rec.bbox) ? rec.bbox : [0, 0, 0, 0];
+    return {
+      id: `a0-${i + 1}`,
+      role: "window",
+      label:
+        typeof rec.title === "string"
+          ? rec.title
+          : typeof rec.app === "string"
+            ? rec.app
+            : undefined,
+      bbox: [
+        Number(bbox[0]) || 0,
+        Number(bbox[1]) || 0,
+        Number(bbox[2]) || 0,
+        Number(bbox[3]) || 0,
+      ],
+      actions: ["focus", "close"],
+      displayId: 0,
+    } as SceneAxNode;
+  });
+  return {
+    nodes,
+    failedWindows: Number(obj.failed) || 0,
+    totalWindows: Number(obj.total) || 0,
+  };
+}
+
 export class DarwinAccessibilityProvider implements AccessibilityProvider {
   readonly name = "darwin";
+  private lastStats: A11yScanStats | null = null;
 
   available(): boolean {
     return true; // osascript always present; user permission needed at runtime.
   }
 
+  lastScanStats(): A11yScanStats | null {
+    return this.lastStats;
+  }
+
   async snapshot(): Promise<SceneAxNode[]> {
     try {
+      // The per-window/per-process catches inside the JXA script keep one
+      // unreadable window from aborting the whole scan, but every miss is
+      // COUNTED — a11y permission revocation must not read as an emptier
+      // desktop (#12273 exemplar 2).
       const script = `
         const SE = Application("System Events");
         const procs = SE.processes.whose({visible: true})();
         const out = [];
+        let failed = 0;
+        let total = 0;
         for (let p of procs) {
           try {
             const appName = p.name();
             for (let w of p.windows()) {
+              total += 1;
               try {
                 const pos = w.position();
                 const sz = w.size();
@@ -376,11 +489,11 @@ export class DarwinAccessibilityProvider implements AccessibilityProvider {
                   title: w.name(),
                   bbox: [pos[0], pos[1], sz[0], sz[1]],
                 });
-              } catch (e) {}
+              } catch (e) { failed += 1; }
             }
-          } catch (e) {}
+          } catch (e) { failed += 1; total += 1; }
         }
-        JSON.stringify(out);
+        JSON.stringify({windows: out, failed: failed, total: total});
       `;
       const text = execFileSync(
         "osascript",
@@ -391,34 +504,21 @@ export class DarwinAccessibilityProvider implements AccessibilityProvider {
           stdio: ["ignore", "pipe", "ignore"],
         },
       );
-      const parsed = JSON.parse(text || "[]");
-      if (!Array.isArray(parsed)) return [];
-      return parsed.map((n, i) => {
-        const bbox = Array.isArray(n?.bbox) ? n.bbox : [0, 0, 0, 0];
-        return {
-          id: `a0-${i + 1}`,
-          role: "window",
-          label: typeof n?.title === "string" ? n.title : n?.app,
-          bbox: [
-            Number(bbox[0]) || 0,
-            Number(bbox[1]) || 0,
-            Number(bbox[2]) || 0,
-            Number(bbox[3]) || 0,
-          ],
-          actions: ["focus", "close"],
-          displayId: 0,
-        } as SceneAxNode;
-      });
+      const { nodes, failedWindows, totalWindows } =
+        parseDarwinA11yPayload(text);
+      this.lastStats = { failedWindows, totalWindows };
+      return nodes;
     } catch (err) {
       // error-policy:J4 the interface contract is [] = "no reachable nodes" so
       // the scene-builder always produces a Scene; but osascript failing
       // (a11y permission revoked, binary missing) is a failure, not an empty
-      // desktop — surface it so revocation is visible instead of silently
-      // shrinking the scene the agent trusts as complete.
+      // desktop — record it in the scan stats (the scene-builder reports it
+      // via runtime.reportError) and warn, instead of silently shrinking the
+      // scene the agent trusts as complete.
+      const message = err instanceof Error ? err.message : String(err);
+      this.lastStats = { failedWindows: 0, totalWindows: 0, error: message };
       logger.warn(
-        `[DarwinAccessibilityProvider] a11y snapshot failed; returning no nodes: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
+        `[DarwinAccessibilityProvider] a11y snapshot failed; returning no nodes: ${message}`,
       );
       return [];
     }
@@ -427,20 +527,78 @@ export class DarwinAccessibilityProvider implements AccessibilityProvider {
 
 // ── Windows ─────────────────────────────────────────────────────────────────
 
+/**
+ * Parse the UIA scan payload `{windows, failed, total}` into nodes + scan
+ * stats. Exported so the untrusted-output seam is testable without PowerShell.
+ * ConvertTo-Json collapses one-element arrays to a bare object, so `windows`
+ * is re-wrapped. Throws on an unrecognizable payload — the caller's catch
+ * treats that as a whole-scan failure.
+ */
+export function parseWindowsUiaPayload(text: string): {
+  nodes: SceneAxNode[];
+  failedWindows: number;
+  totalWindows: number;
+} {
+  const parsed: unknown = JSON.parse(text);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "PowerShell UIA payload is not a {windows,failed,total} object",
+    );
+  }
+  const obj = parsed as Record<string, unknown>;
+  const windows = Array.isArray(obj.windows)
+    ? obj.windows
+    : obj.windows
+      ? [obj.windows]
+      : [];
+  const nodes = windows
+    .filter((n): n is Record<string, unknown> => !!n && typeof n === "object")
+    .map((n, i) => {
+      const bbox = Array.isArray(n.bbox) ? n.bbox : [0, 0, 0, 0];
+      return {
+        id: `a0-${i + 1}`,
+        role: typeof n.role === "string" ? n.role : "unknown",
+        label: typeof n.label === "string" ? n.label : undefined,
+        bbox: [
+          Number(bbox[0]) || 0,
+          Number(bbox[1]) || 0,
+          Number(bbox[2]) || 0,
+          Number(bbox[3]) || 0,
+        ],
+        actions: [],
+        displayId: 0,
+      } as SceneAxNode;
+    });
+  return {
+    nodes,
+    failedWindows: Number(obj.failed) || 0,
+    totalWindows: Number(obj.total) || 0,
+  };
+}
+
 export class WindowsAccessibilityProvider implements AccessibilityProvider {
   readonly name = "win32";
+  private lastStats: A11yScanStats | null = null;
 
   available(): boolean {
     return true; // PowerShell UIA always available on supported Windows.
   }
 
+  lastScanStats(): A11yScanStats | null {
+    return this.lastStats;
+  }
+
   async snapshot(): Promise<SceneAxNode[]> {
+    // The per-element catch inside the UIA walk keeps one stale element from
+    // aborting the whole scan, but every miss is COUNTED so a scan that drops
+    // windows is reported instead of read as an emptier desktop (#12273).
     const ps = `
 Add-Type -AssemblyName UIAutomationClient,UIAutomationTypes
 $root = [System.Windows.Automation.AutomationElement]::RootElement
 $walker = [System.Windows.Automation.TreeWalker]::ContentViewWalker
 $child = $walker.GetFirstChild($root)
 $out = @()
+$failed = 0
 $count = 0
 while ($child -and $count -lt 50) {
   try {
@@ -451,11 +609,11 @@ while ($child -and $count -lt 50) {
       bbox = @($rect.X, $rect.Y, $rect.Width, $rect.Height)
     }
     $out += $row
-  } catch {}
+  } catch { $failed++ }
   $child = $walker.GetNextSibling($child)
   $count++
 }
-$out | ConvertTo-Json -Depth 4 -Compress
+[PSCustomObject]@{ windows = $out; failed = $failed; total = $count } | ConvertTo-Json -Depth 5 -Compress
 `;
     try {
       const text = execFileSync("powershell", ["-NoProfile", "-Command", ps], {
@@ -463,35 +621,20 @@ $out | ConvertTo-Json -Depth 4 -Compress
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
       });
-      const parsed = JSON.parse(text || "[]");
-      const list = Array.isArray(parsed) ? parsed : [parsed];
-      return list
-        .filter((n) => n && typeof n === "object")
-        .map((n, i) => {
-          const bbox = Array.isArray(n.bbox) ? n.bbox : [0, 0, 0, 0];
-          return {
-            id: `a0-${i + 1}`,
-            role: typeof n.role === "string" ? n.role : "unknown",
-            label: typeof n.label === "string" ? n.label : undefined,
-            bbox: [
-              Number(bbox[0]) || 0,
-              Number(bbox[1]) || 0,
-              Number(bbox[2]) || 0,
-              Number(bbox[3]) || 0,
-            ],
-            actions: [],
-            displayId: 0,
-          } as SceneAxNode;
-        });
+      const { nodes, failedWindows, totalWindows } =
+        parseWindowsUiaPayload(text);
+      this.lastStats = { failedWindows, totalWindows };
+      return nodes;
     } catch (err) {
       // error-policy:J4 the interface contract is [] = "no reachable nodes" so
       // the scene-builder always produces a Scene; but PowerShell/UIA failing
-      // is a failure, not an empty desktop — surface it so the shrunken scene
-      // is visible instead of silently trusted as complete.
+      // is a failure, not an empty desktop — record it in the scan stats (the
+      // scene-builder reports it via runtime.reportError) and warn, so the
+      // shrunken scene is visible instead of silently trusted as complete.
+      const message = err instanceof Error ? err.message : String(err);
+      this.lastStats = { failedWindows: 0, totalWindows: 0, error: message };
       logger.warn(
-        `[WindowsAccessibilityProvider] a11y snapshot failed; returning no nodes: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
+        `[WindowsAccessibilityProvider] a11y snapshot failed; returning no nodes: ${message}`,
       );
       return [];
     }

--- a/plugins/plugin-computeruse/src/scene/apps.ts
+++ b/plugins/plugin-computeruse/src/scene/apps.ts
@@ -170,7 +170,9 @@ function linuxPidMapFromWmctrl(): Map<string, number> {
       }
     }
   } catch {
-    /* best effort */
+    // error-policy:J4 the wmctrl pid-join is enrichment for the app/window
+    // join; an empty map degrades to name-based matching rather than
+    // failing scene assembly.
   }
   return out;
 }

--- a/plugins/plugin-computeruse/src/scene/ocr-adapter.ts
+++ b/plugins/plugin-computeruse/src/scene/ocr-adapter.ts
@@ -108,6 +108,9 @@ export async function runOcrOnPng(
         coordBlockToSceneBox(block, displayId, idState),
       );
     } catch (err) {
+      // error-policy:J4 the scene degrades to AX/pixel-only for this turn;
+      // the provider failure is logged through the scene-builder hook
+      // (logger.warn in the service wiring), never silent.
       logFn(
         `[scene-builder] CoordOcrProvider '${coord.name}' failed: ${err instanceof Error ? err.message : String(err)}`,
       );
@@ -127,6 +130,9 @@ export async function runOcrOnPng(
     });
     return result.lines.map((line) => toSceneBox(line, displayId, idState));
   } catch (err) {
+    // error-policy:J4 the scene degrades to AX/pixel-only for this turn;
+    // the provider failure is logged through the scene-builder hook, never
+    // silent.
     logFn(
       `[scene-builder] OCR provider '${provider.name}' failed: ${err instanceof Error ? err.message : String(err)}`,
     );
@@ -169,6 +175,8 @@ export async function runOcrOnRegions(
           });
           return result.blocks;
         } catch (err) {
+          // error-policy:J4 a failed dirty-region re-OCR degrades that
+          // region to its previous boxes for this turn; logged per region.
           logFn(
             `[scene-builder] CoordOcr region failed at ${crop.bbox.join(",")}: ${
               err instanceof Error ? err.message : String(err)
@@ -204,6 +212,8 @@ export async function runOcrOnRegions(
         });
         return { crop, lines: result.lines };
       } catch (err) {
+        // error-policy:J4 a failed dirty-region re-OCR degrades that region
+        // to its previous boxes for this turn; logged per region.
         logFn(
           `[scene-builder] OCR region failed at ${crop.bbox.join(",")}: ${
             err instanceof Error ? err.message : String(err)

--- a/plugins/plugin-computeruse/src/scene/scene-builder.ts
+++ b/plugins/plugin-computeruse/src/scene/scene-builder.ts
@@ -33,7 +33,7 @@ import {
   captureDisplay,
   captureDisplayRegion,
 } from "../platform/capture.js";
-import { findDisplay, listDisplays } from "../platform/displays.js";
+import { listDisplays } from "../platform/displays.js";
 import type { DisplayDescriptor } from "../types.js";
 import {
   type AccessibilityProvider,
@@ -100,6 +100,18 @@ export interface SceneBuilderDeps {
     idState: OcrAdapterIdState,
   ) => Promise<SceneOcrBox[]>;
   log?: (msg: string) => void;
+  /**
+   * Diagnostic reporter for scan-level failures the agent must see (#12273):
+   * ComputerUseService wires this to `runtime.reportError` so an a11y scan
+   * that fails outright or drops windows (permission revoked mid-session)
+   * emits ERROR_REPORTED instead of silently thinning the scene. Optional —
+   * standalone builders (tests, the default singleton) run without a runtime.
+   */
+  reportError?: (
+    scope: string,
+    error: unknown,
+    context?: Record<string, unknown>,
+  ) => void;
 }
 
 interface PerDisplayState {
@@ -115,8 +127,11 @@ export interface SceneUpdateEvent {
 }
 
 export class SceneBuilder extends EventEmitter {
-  private readonly deps: Required<Omit<SceneBuilderDeps, "log">> & {
+  private readonly deps: Required<
+    Omit<SceneBuilderDeps, "log" | "reportError">
+  > & {
     log: (msg: string) => void;
+    reportError: SceneBuilderDeps["reportError"];
   };
   private readonly perDisplay = new Map<number, PerDisplayState>();
   private readonly ocrIdState: OcrAdapterIdState = makeOcrIdState();
@@ -153,6 +168,7 @@ export class SceneBuilder extends EventEmitter {
         ((crops, displayId, idState) =>
           runOcrOnRegions(crops, displayId, idState)),
       log,
+      reportError: deps.reportError,
     };
     setOcrLoggingHook(log);
   }
@@ -314,6 +330,8 @@ export class SceneBuilder extends EventEmitter {
               }),
             );
           } catch (err) {
+            // error-policy:J4 dirty-region capture is an optimization tier;
+            // empty crops route this display through full-frame OCR below.
             this.deps.log(
               `[scene-builder] captureRegion(${displayId}) failed: ${
                 err instanceof Error ? err.message : String(err)
@@ -410,6 +428,8 @@ export class SceneBuilder extends EventEmitter {
     try {
       return await this.deps.captureAll();
     } catch (err) {
+      // error-policy:J4 designed two-tier capture — the per-display loop
+      // below retries each display individually and logs every miss.
       this.deps.log(
         `[scene-builder] captureAllDisplays failed: ${err instanceof Error ? err.message : String(err)} — falling back to per-display capture`,
       );
@@ -419,6 +439,8 @@ export class SceneBuilder extends EventEmitter {
       try {
         out.push(await this.deps.captureOne(d.id));
       } catch (err) {
+        // error-policy:J4 a missing display is logged and visibly absent
+        // from the Scene rather than aborting the whole tick.
         this.deps.log(
           `[scene-builder] captureDisplay(${d.id}) failed: ${err instanceof Error ? err.message : String(err)} — display will be missing from scene`,
         );
@@ -431,6 +453,9 @@ export class SceneBuilder extends EventEmitter {
     try {
       return this.deps.enumerateApps();
     } catch (err) {
+      // error-policy:J4 the Scene ships without the app join for this tick;
+      // the failure is logged through the builder log hook (logger.warn in
+      // the service wiring), and displays/OCR/AX still populate the Scene.
       this.deps.log(
         `[scene-builder] enumerateApps failed: ${err instanceof Error ? err.message : String(err)}`,
       );
@@ -439,12 +464,39 @@ export class SceneBuilder extends EventEmitter {
   }
 
   private async safeSnapshotAx(): Promise<SceneAxNode[]> {
+    const provider = this.deps.accessibilityProvider;
     try {
-      return await this.deps.accessibilityProvider.snapshot();
+      const nodes = await provider.snapshot();
+      // Per-window misses (or a whole-scan failure the provider degraded to
+      // "no nodes") are reported ONCE per scan so a11y permission revocation
+      // is agent-visible instead of reading as an emptier desktop (#12273).
+      const stats = provider.lastScanStats?.();
+      if (stats && (stats.failedWindows > 0 || stats.error)) {
+        this.deps.reportError?.(
+          "Computeruse.a11yScan",
+          new Error(
+            stats.error ??
+              `a11y scan dropped ${stats.failedWindows}/${stats.totalWindows} windows`,
+          ),
+          {
+            failedWindows: stats.failedWindows,
+            totalWindows: stats.totalWindows,
+            provider: provider.name,
+          },
+        );
+      }
+      return nodes;
     } catch (err) {
+      // error-policy:J4 a sceneless turn is worse than a scene without AX
+      // nodes — the Scene still carries displays/OCR/apps; the failure is
+      // reported (agent-visible via ERROR_REPORTED), never silent.
       this.deps.log(
         `[scene-builder] accessibilityProvider.snapshot failed: ${err instanceof Error ? err.message : String(err)}`,
       );
+      this.deps.reportError?.("Computeruse.a11yScan", err, {
+        provider: provider.name,
+        phase: "snapshot",
+      });
       return [];
     }
   }

--- a/plugins/plugin-computeruse/src/services/computer-use-service.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-service.ts
@@ -233,6 +233,11 @@ export class ComputerUseService extends Service {
   private displayIdDeprecationWarned = false;
   private sceneBuilder: SceneBuilder = new SceneBuilder({
     log: (msg) => logger.warn(msg),
+    // Deferred read of this.runtime: the closure runs at scan time, after the
+    // Service base constructor has bound the runtime. Makes a11y scan
+    // failures agent-visible via ERROR_REPORTED (#12273).
+    reportError: (scope, error, context) =>
+      this.runtime.reportError(scope, error, context),
   });
   /**
    * Single shared per-display capture for the turn (#9105 M3). OCR, the Brain,
@@ -259,6 +264,9 @@ export class ComputerUseService extends Service {
     try {
       instance.screenSize = getScreenSize();
     } catch (error) {
+      // error-policy:J4 the 1920x1080 default is a documented boot-time
+      // placeholder (warned); real geometry flows from listDisplays on every
+      // capture/dispatch, so a wrong guess fails loudly there, not here.
       logger.warn(
         `[computeruse] Falling back to default screen size: ${errorMessage(error)}`,
       );
@@ -282,6 +290,10 @@ export class ComputerUseService extends Service {
             warmScreenSizeCache(),
           ]),
         )
+        // error-policy:J5 each warm helper upholds a documented never-throws
+        // contract (failures latch/log inside ps-host and leave the sync
+        // paths authoritative); this catch only guards the fire-and-forget
+        // chain against an unhandled rejection.
         .catch(() => {});
     }
 
@@ -294,7 +306,8 @@ export class ComputerUseService extends Service {
     try {
       await closeBrowser();
     } catch {
-      // ignore browser shutdown failures
+      // error-policy:J6 best-effort teardown; the service is stopping and a
+      // failed browser close cannot affect the stopped state.
     }
     // Tear down the persistent PowerShell host and latch spawning off so a
     // late fire-and-forget warm continuation can't resurrect it post-stop.
@@ -618,6 +631,9 @@ export class ComputerUseService extends Service {
           result.screenshot = captured.base64;
           result.displayId = captured.displayId;
         } catch (error) {
+          // error-policy:J4 the action itself succeeded; the missing
+          // screenshot attachment is a warned, visible omission in the
+          // result rather than grounds to fail a completed input.
           logger.warn(
             `[computeruse] Post-action screenshot failed: ${errorMessage(error)}`,
           );
@@ -625,6 +641,9 @@ export class ComputerUseService extends Service {
       }
       return this.succeedEntry(entry, result);
     } catch (error) {
+      // error-policy:J1 action boundary — the failure (permission-classified
+      // when possible) returns as a structured {success:false,error} entry
+      // the model sees; permissionDenied flags drive the escalation UX.
       const permissionError = classifyPermissionDeniedError(error, {
         permissionType:
           params.action === "screenshot" ? "screen_recording" : "accessibility",
@@ -712,6 +731,8 @@ export class ComputerUseService extends Service {
         message: `OCR found ${blocks.length} text block(s) on display ${cap.display.id}.`,
       });
     } catch (error) {
+      // error-policy:J1 action boundary — the failure returns as a
+      // structured {success:false,error} entry the model sees.
       return this.failEntry(entry, {
         success: false,
         error: errorMessage(error),
@@ -770,8 +791,9 @@ export class ComputerUseService extends Service {
         message: `Set-of-Marks detected ${elements.length} numbered element(s) on display ${cap.display.id}.`,
       });
     } catch (error) {
-      // SoM is best-effort; surface a clear failure rather than silently
-      // dropping to OCR (the caller already chose SoM by registering it).
+      // error-policy:J1 action boundary — SoM failure surfaces as a clear
+      // structured {success:false,error} rather than silently dropping to
+      // OCR (the caller already chose SoM by registering it).
       return this.failEntry(entry, {
         success: false,
         error: `Set-of-Marks detection failed: ${errorMessage(error)}`,
@@ -805,6 +827,9 @@ export class ComputerUseService extends Service {
         ? this.succeedEntry(entry, result)
         : this.failEntry(entry, result);
     } catch (error) {
+      // error-policy:J1 action boundary — a browser-not-open failure gets one
+      // designed auto-open retry; every other failure (and the retry's own
+      // failure) returns as a structured {success:false,error} entry.
       if (this.shouldAutoOpenBrowser(params.action, error)) {
         return await this.retryBrowserActionAfterOpen(entry, params);
       }
@@ -833,6 +858,8 @@ export class ComputerUseService extends Service {
         ? this.succeedEntry(entry, retryResult)
         : this.failEntry(entry, retryResult);
     } catch (error) {
+      // error-policy:J1 action boundary — the failure returns as a
+      // structured {success:false,error} entry the model sees.
       return this.failEntry(entry, {
         success: false,
         error: errorMessage(error),
@@ -1187,6 +1214,9 @@ export class ComputerUseService extends Service {
           });
       }
     } catch (error) {
+      // error-policy:J1 action boundary — the failure (permission-classified
+      // when possible) returns as a structured {success:false,error} entry
+      // the model sees; permissionDenied flags drive the escalation UX.
       const permissionError = classifyPermissionDeniedError(error, {
         permissionType: "accessibility",
         operation: params.action,
@@ -1302,6 +1332,8 @@ export class ComputerUseService extends Service {
           });
       }
     } catch (error) {
+      // error-policy:J1 action boundary — the failure returns as a
+      // structured {success:false,error} entry the model sees.
       return this.failEntry(entry, {
         success: false,
         error: errorMessage(error),
@@ -1395,6 +1427,8 @@ export class ComputerUseService extends Service {
           });
       }
     } catch (error) {
+      // error-policy:J1 action boundary — the failure returns as a
+      // structured {success:false,error} entry the model sees.
       return this.failEntry(entry, {
         success: false,
         error: errorMessage(error),
@@ -1845,6 +1879,8 @@ export class ComputerUseService extends Service {
         displayId: result.display.id,
       };
     } catch (error) {
+      // error-policy:J4 designed two-tier capture — the driver capture below
+      // grabs the same screen, and its failure throws to the caller.
       logger.debug(
         `[computeruse] per-display capture failed (${errorMessage(error)}); falling back to driver capture`,
       );
@@ -2137,7 +2173,8 @@ export class ComputerUseService extends Service {
           return String(value);
         }
       } catch {
-        // ignore runtime setting lookup failures
+        // error-policy:J4 setting lookup falls through to the env-var tiers
+        // below — the documented config precedence, not a swallowed value.
       }
       return process.env[key] ?? process.env[`ELIZA_${key}`];
     };

--- a/plugins/plugin-computeruse/src/services/desktop-control.ts
+++ b/plugins/plugin-computeruse/src/services/desktop-control.ts
@@ -686,6 +686,8 @@ function canCaptureMacScreen(): boolean {
     runCommand("screencapture", ["-x", "-R0,0,1,1", tmpFile], 5000);
     return true;
   } catch {
+    // error-policy:J3 capability probe; false feeds the capability matrix
+    // and the actual capture path raises its own permission-tagged error.
     return false;
   } finally {
     removeTempFile(tmpFile);
@@ -705,6 +707,8 @@ function canUseMacSystemEvents(): boolean {
     );
     return true;
   } catch {
+    // error-policy:J3 capability probe; false feeds the capability matrix
+    // and the real System Events path raises its own permission error.
     return false;
   }
 }
@@ -713,7 +717,7 @@ function removeTempFile(filePath: string): void {
   try {
     unlinkSync(filePath);
   } catch {
-    // Temp cleanup is best effort.
+    // error-policy:J6 best-effort temp-file teardown.
   }
 }
 

--- a/plugins/plugin-computeruse/src/services/vision-context-provider.ts
+++ b/plugins/plugin-computeruse/src/services/vision-context-provider.ts
@@ -161,7 +161,13 @@ export class VisionContextProvider extends Service {
     try {
       return await source.refreshScene("agent-turn");
     } catch (error) {
+      // error-policy:J4 null is the explicit "scene unavailable" signal in
+      // the VisionContext snapshot; the failure is warned and reported so a
+      // broken scene pipeline is agent-visible, not silently sceneless.
       logger.warn("[vision-context] refreshScene failed:", errorMessage(error));
+      this.runtime.reportError("Computeruse.visionContext", error, {
+        phase: "refreshScene",
+      });
       return null;
     }
   }
@@ -185,6 +191,9 @@ export class VisionContextProvider extends Service {
       );
       if (typeof cached === "string" && cached.trim()) return cached.trim();
     } catch (error) {
+      // error-policy:J4 the cache is one tier of the goal-resolution chain;
+      // the setting tier below follows, and total absence is a legitimate
+      // null (no active task goal).
       logger.debug(
         "[vision-context] task goal cache read failed:",
         errorMessage(error),
@@ -194,7 +203,8 @@ export class VisionContextProvider extends Service {
       const setting = this.runtime.getSetting("VISION_CONTEXT_TASK_GOAL");
       if (typeof setting === "string" && setting.trim()) return setting.trim();
     } catch {
-      // Optional setting.
+      // error-policy:J4 the setting is optional by contract; null below is
+      // the legitimate "no task goal configured" result.
     }
     return null;
   }


### PR DESCRIPTION
Advances #12273 (chunk: full fallback-slop sweep of `plugins/plugin-computeruse`, extending the precision slice PR #12885 without re-litigating its verdicts).

## What landed

- **Full J1–J7 triage of every catch handler in non-test `src/**/*.ts`** — 214 sites inventoried in `.github/issue-evidence/12273-computeruse-triage.md` (site → verdict table committed with this PR): 172 site annotations (`// error-policy:J<N> <reason>`, grep-able), 18 directory-documented route-J1 boundaries in `src/routes/sandbox-routes.ts` (each translates the failure into an explicit 4xx/5xx JSON payload), 16 pure rethrows, 6 embedded-script string-literal rows (3 exempt with explicit failure markers, 3 fixed by counting).
- **Exemplar 2 fixed (a11y scene silently thinner)**: the per-window `catch (e) {}` in the Darwin JXA scan, the per-process catch, and the Windows UIA per-element catch now COUNT every miss; providers expose `lastScanStats()` (`{ failedWindows, totalWindows, error? }`), and `SceneBuilder` reports failures **once per scan** via `runtime.reportError("Computeruse.a11yScan", …, { failedWindows, totalWindows, provider })` — macOS a11y permission revocation now emits `ERROR_REPORTED` instead of reading as an emptier desktop. Payload parsers (`parseDarwinA11yPayload`, `parseWindowsUiaPayload`) throw on unrecognizable output instead of fabricating an empty-but-healthy scan.
- **No action handler converts failure into success-shape**: `COMPUTER_USE_AGENT` returns `result.error` on every non-finish run so the planner loop shows the failure to the model; progress-callback failures warn + `reportError` (J7).
- **Errno narrowing on probes (J3)**: `fileExists`/`directoryExists` treat only `ENOENT`/`ENOTDIR` as "absent" — `EACCES`/IO failures now return a structured failure instead of a fabricated "does not exist".
- **Providers/services report instead of silently degrading**: `sceneProvider`, `computerStateProvider`, `VisionContextProvider` call `runtime.reportError` on pipeline failure; process/window enumeration and approval-mode load/persist failures are warned (with `ENOENT` narrowing on the config read) instead of reading as an empty machine.
- **Zero `console.*` in src; zero unannotated empty catches** (sole remaining grep hit is the issue-sanctioned embedded PowerShell string literal at `src/platform/ps-host.ts:95`).
- **Real-error-path tests (no mocks of the failing dependency)**:
  - `src/scene/a11y-provider.error-policy.test.ts` — really-missing `powershell`/`osascript` binary drives a whole-scan failure: asserts exactly one `Computeruse.a11yScan` report per tick, `{failedWindows,totalWindows}` context for per-window misses, clean scans report nothing, parsers throw on garbage.
  - `src/__tests__/action-error-path.test.ts` — `COMPUTER_USE` launch of a genuinely nonexistent binary (real ENOENT from the OS) surfaces `success:false` + `result.error` to the caller.
  - `src/__tests__/scene-provider.test.ts` strengthened: refresh failure must now ALSO report (`Computeruse.sceneProvider`), not just return empty.
- **Lint-gate fixes in two touched test files** (`scene-builder.test.ts`, `scene-multimon-coords.test.ts`): replaced `captures[0]![0]!` fixture access with an explicit throwing guard — the package's self-fixing lint (`biome check --write --unsafe`) previously rewrote these into `?.[0]!` and then failed itself with `noNonNullAssertedOptionalChain`; `@elizaos/plugin-computeruse#lint` was red on clean develop because of this and is green after this PR.

## Evidence (PR_EVIDENCE.md rows)

- **Backend logs of a real induced failure** — `.github/issue-evidence/12273-computeruse-a11y-error-reported.log` (re-captured against this branch): real missing `powershell` binary → provider warn → `SceneBuilder` → real `AgentRuntime.reportError` → `ERROR_REPORTED` event received with `{failedWindows, totalWindows, provider}` context + the runtime's reported-errors ring.
- **Real-LLM trajectory**: N/A — this chunk changes error propagation/annotation only; no prompt, provider-text, or model-behavior change beyond `result.error` reaching the planner loop, which is asserted by the real-error-path action test above.
- **Screenshots / video / frontend logs**: N/A — no UI surface changed.

## Verification

- `bun run --cwd plugins/plugin-computeruse test`: **739 passed | 15 skipped | 1 failed** — the single failure is `src/__tests__/android-bridge.test.ts > declares default-assistant and voice-command surfaces without privileged voice permissions`, reproduced identically on clean `origin/develop` in this lane (stash → run → pop): the AndroidManifest fixture contains `BIND_VOICE_INTERACTION`, untouched by this PR.
- `bun run --cwd plugins/plugin-computeruse typecheck`: PASS. `bun run --cwd plugins/plugin-computeruse lint`: PASS (exit 0 after the two test-file fixes; red on clean develop before them).
- `bun run audit:error-policy-ratchet`: PASS ("no new fallback-slop in touched files").
- Issue verify greps: empty-catch grep → only the exempt `ps-host.ts:95` string literal; `console.*` grep → 0; `rg -c 'error-policy:J'` → 172 annotations.
- Full `bun run verify`: green except pre-existing develop failures, each reproduced on clean `origin/develop` in this lane: `@elizaos/tui#lint` (biome errors in untouched tui sources) and `audit:turbo-build-deps` (phantom `#build` overrides for example packages). Also the protocol-known `app#typecheck` / `electrobun#typecheck` baseline. None involve files this PR touches; `@elizaos/plugin-computeruse` typecheck+lint+test are green as above (verify's turbo step re-run with `--continue` to confirm no other package regressed).

## Deviations from the issue text

- The `?? <lit>` / `|| <lit>` load-path sweep and the six-plugin scope belong to other chunks of the #12273 swarm split; this PR is the plugin-computeruse chunk only.
- "Delete this slice from the temporary biome-override block": no error-policy biome override exists in `biome.json` (enforcement landed as the diff-scoped `audit:error-policy-ratchet` instead); the only computeruse exclusion there is for `noNonNullAssertion`, unrelated to this issue, left in place.
- `src/platform/windows-list.ts:48` is annotated J4 (two-tier warm-host → cold-spawn failover) rather than left as a bare rethrow row: script-level errors rethrow, host-level failures fall back to a cold spawn whose own failure propagates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
