### PR TITLE
refactor(#12681): default-home widget sink opt-ins off the UI-trunk literal

### DIFF
--- a/packages/ui/src/widgets/default-home-widget-sink-optins.test.ts
+++ b/packages/ui/src/widgets/default-home-widget-sink-optins.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Drift guard for the default-home widget sink opt-ins (#12089 item 35).
+ *
+ * App-manifest plugins that do not ship an owned home card used to opt into a
+ * shared default sink via a ~23-entry `PluginWidgetDeclaration` literal
+ * hardcoded inline in `registry.ts` — a second, hand-maintained widget registry
+ * that duplicated each plugin's `pluginId` and had to be edited in the UI trunk
+ * to add/remove a plugin. That inline literal is now the co-located, explicitly-
+ * marked legacy host-owned fallback table
+ * (`LEGACY_DEFAULT_HOME_WIDGET_SINK_OPTINS`), derived into declarations by a pure
+ * builder. These tests assert:
+ *   1. No inline default-home plugin-declaration literal survives in the
+ *      `registry.ts` executable trunk (grep guard).
+ *   2. The builder reproduces the exact prior declaration shape (behavior-
+ *      preserving id/slot/order/defaultEnabled derivation).
+ *   3. Structural fields are derived uniformly — a row cannot drift on shape.
+ *   4. A plugin-owned/server declaration wins over its legacy fallback row, so
+ *      the fallback table cannot silently diverge from a migrated plugin.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  buildDefaultHomeWidgetDeclarations,
+  DEFAULT_HOME_WIDGET_OPTIN_ORDER_BASE,
+  LEGACY_DEFAULT_HOME_WIDGET_SINK_OPTINS,
+} from "./default-home-widget-sink-optins";
+import { registerWidgetComponent, resolveWidgetsForSlot } from "./registry";
+import type { PluginWidgetDeclaration } from "./types";
+
+const registrySource = readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), "registry.ts"),
+  "utf8",
+);
+
+describe("default-home widget sink opt-ins drift guard (#12089 item 35)", () => {
+  it("removed the inline default-home plugin declaration literal from registry.ts", () => {
+    // The coupling this audit item targets: a hardcoded array of plugin widget
+    // declarations in the UI trunk. Its `.default-home` id template and the
+    // per-row `.map(...)` assembly must no longer live in registry.ts (outside
+    // of reference comments) — the opt-ins now come from the co-located table.
+    const executable = registrySource
+      .split("\n")
+      .filter((line) => {
+        const trimmed = line.trimStart();
+        return !(trimmed.startsWith("//") || trimmed.startsWith("*"));
+      })
+      .join("\n");
+    // No inline `.default-home` id-template assembly.
+    expect(executable).not.toContain(".default-home`");
+    // No inline per-plugin literal rows (a representative sample of the moved
+    // pluginIds must not reappear as string literals in the trunk).
+    for (const id of ["birdclaw", "hyperliquid", "polymarket", "wifi"]) {
+      expect(executable).not.toContain(`"${id}"`);
+    }
+    // The trunk assembles from the builder, not an inline map.
+    expect(executable).toContain("buildDefaultHomeWidgetDeclarations()");
+  });
+
+  it("builds declarations with the exact prior structural shape", () => {
+    const built = buildDefaultHomeWidgetDeclarations();
+    expect(built).toHaveLength(LEGACY_DEFAULT_HOME_WIDGET_SINK_OPTINS.length);
+
+    built.forEach((decl, index) => {
+      const optIn = LEGACY_DEFAULT_HOME_WIDGET_SINK_OPTINS[index];
+      // Structural fields derived uniformly (the pre-refactor `.map` output).
+      expect(decl.id).toBe(`${optIn.pluginId}.default-home`);
+      expect(decl.slot).toBe("home");
+      expect(decl.order).toBe(DEFAULT_HOME_WIDGET_OPTIN_ORDER_BASE + index);
+      expect(decl.defaultEnabled).toBe(true);
+      // Owner-declared fields carried through verbatim.
+      expect(decl.pluginId).toBe(optIn.pluginId);
+      expect(decl.label).toBe(optIn.label);
+      expect(decl.icon).toBe(optIn.icon);
+      expect(decl.defaultWidget).toBe(optIn.defaultWidget);
+      expect(decl.signalKinds).toEqual(optIn.signalKinds);
+      // None carry an explicit visibility flag — they are snapshot-gated, so a
+      // plugin must be present+active for its default-sink tile to show.
+      expect(decl.visibility).toBeUndefined();
+    });
+  });
+
+  it("derives structural fields uniformly regardless of input order", () => {
+    // A row cannot drift on `id`/`slot`/`order`/`defaultEnabled` shape: the
+    // builder assigns them from position, not from the row.
+    const built = buildDefaultHomeWidgetDeclarations([
+      {
+        pluginId: "alpha",
+        label: "Alpha",
+        icon: "A",
+        defaultWidget: "activity",
+        signalKinds: ["activity"],
+      },
+      {
+        pluginId: "beta",
+        label: "Beta",
+        icon: "B",
+        defaultWidget: "notifications",
+        signalKinds: ["notification"],
+      },
+    ]);
+    expect(built.map((d) => d.id)).toEqual([
+      "alpha.default-home",
+      "beta.default-home",
+    ]);
+    expect(built.map((d) => d.order)).toEqual([
+      DEFAULT_HOME_WIDGET_OPTIN_ORDER_BASE,
+      DEFAULT_HOME_WIDGET_OPTIN_ORDER_BASE + 1,
+    ]);
+    expect(built.every((d) => d.slot === "home")).toBe(true);
+    expect(built.every((d) => d.defaultEnabled === true)).toBe(true);
+  });
+
+  it("keeps every legacy opt-in row keyed by a unique pluginId", () => {
+    // Membership-not-position is the contract; duplicate pluginIds would produce
+    // colliding `.default-home` ids and a silently-dropped tile.
+    const ids = LEGACY_DEFAULT_HOME_WIDGET_SINK_OPTINS.map((o) => o.pluginId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("suppresses the legacy fallback row once its plugin ships an owned home card", () => {
+    // The drift mode the audit flags: a plugin migrating to its own
+    // `Plugin.widgets` must not be shadowed by — nor double up with — a stale
+    // legacy fallback row. Because the resolver dedupes on `pluginId/id`, an
+    // owned server widget with a DIFFERENT id would otherwise render alongside
+    // the plugin's `${pluginId}.default-home` sink tile. The resolver now
+    // suppresses the generic default-sink fallback for any plugin that already
+    // resolves to its own home card, so exactly the owned card renders.
+    const legacyRow = LEGACY_DEFAULT_HOME_WIDGET_SINK_OPTINS[0];
+    const pluginId = legacyRow.pluginId;
+
+    // First: with NO owned card, the legacy default-sink fallback resolves for a
+    // present+active plugin (baseline the suppression acts against).
+    const fallbackOnly = resolveWidgetsForSlot("home", [
+      { id: pluginId, enabled: true, isActive: true },
+    ]);
+    expect(
+      fallbackOnly.find((r) => r.declaration.id === `${pluginId}.default-home`),
+    ).toBeTruthy();
+
+    // Now the plugin ships its own home card under a DIFFERENT id.
+    registerWidgetComponent(pluginId, `${pluginId}.owned-home`, () => null);
+    const serverDecls: PluginWidgetDeclaration[] = [
+      {
+        id: `${pluginId}.owned-home`,
+        pluginId,
+        slot: "home",
+        label: "Owned card",
+        icon: "Star",
+      },
+    ];
+
+    const resolved = resolveWidgetsForSlot(
+      "home",
+      [{ id: pluginId, enabled: true, isActive: true }],
+      serverDecls,
+    );
+
+    // The plugin's own declaration resolves…
+    const owned = resolved.find(
+      (r) => r.declaration.id === `${pluginId}.owned-home`,
+    );
+    expect(owned).toBeTruthy();
+    expect(owned?.declaration.label).toBe("Owned card");
+
+    // …and the stale generic default-sink fallback row for the same plugin is
+    // suppressed (no duplicate home tile during migration).
+    expect(
+      resolved.find((r) => r.declaration.id === `${pluginId}.default-home`),
+    ).toBeUndefined();
+  });
+
+  it("does NOT suppress the fallback for a server card this host cannot render", () => {
+    // Edge case: a plugin migrates by shipping a server `Plugin.widgets` home
+    // declaration that has NO registered component and NO uiSpec (e.g. a
+    // remote/componentExport-only declaration this build can't render). That
+    // declaration is dropped downstream by the `Component || uiSpec` gate, so it
+    // must NOT suppress the shared sink — otherwise the plugin would render no
+    // home tile at all (a regression vs. the pre-refactor behavior).
+    const legacyRow = LEGACY_DEFAULT_HOME_WIDGET_SINK_OPTINS[1];
+    const pluginId = legacyRow.pluginId;
+
+    const unrenderableServerDecls: PluginWidgetDeclaration[] = [
+      {
+        id: `${pluginId}.remote-only`,
+        pluginId,
+        slot: "home",
+        label: "Remote-only card",
+        icon: "Cloud",
+        // no uiSpec, and no component is registered for this id
+      },
+    ];
+
+    const resolved = resolveWidgetsForSlot(
+      "home",
+      [{ id: pluginId, enabled: true, isActive: true }],
+      unrenderableServerDecls,
+    );
+
+    // The unrenderable server card does not resolve…
+    expect(
+      resolved.find((r) => r.declaration.id === `${pluginId}.remote-only`),
+    ).toBeUndefined();
+    // …so the shared default-sink fallback still renders (plugin keeps a tile).
+    const fallback = resolved.find(
+      (r) => r.declaration.id === `${pluginId}.default-home`,
+    );
+    expect(fallback).toBeTruthy();
+    expect(fallback?.defaultWidgetSink).toBe(legacyRow.defaultWidget);
+  });
+
+  it("does NOT suppress a renderable uiSpec declaration that also names a defaultWidget", () => {
+    // The migration guard must only drop the sink-only fallback, never a real
+    // card. A server declaration that carries BOTH a `uiSpec` (renderable) and a
+    // `defaultWidget` marks its plugin as having an own card; the guard must not
+    // then suppress that very declaration on the `!Component && defaultWidget`
+    // path — it renders via its `uiSpec`.
+    const pluginId = "uispec-plus-sink";
+    const serverDecls: PluginWidgetDeclaration[] = [
+      {
+        id: `${pluginId}.card`,
+        pluginId,
+        slot: "home",
+        label: "UiSpec card",
+        icon: "Star",
+        defaultWidget: "activity",
+        uiSpec: {
+          root: "root",
+          state: {},
+          elements: {
+            root: { type: "Text", props: { text: "hi" }, children: [] },
+          },
+        },
+      },
+    ];
+
+    const resolved = resolveWidgetsForSlot(
+      "home",
+      [{ id: pluginId, enabled: true, isActive: true }],
+      serverDecls,
+    );
+
+    const card = resolved.find((r) => r.declaration.id === `${pluginId}.card`);
+    expect(card).toBeTruthy();
+    expect(card?.declaration.uiSpec).toBeDefined();
+  });
+
+  it("does NOT suppress a server-provided shared-sink widget alongside an owned card", () => {
+    // The migration guard targets ONLY the built-in legacy `.default-home`
+    // fallback rows. A plugin may intentionally ship both an owned home card and
+    // a separate server-declared shared-sink widget via its own `Plugin.widgets`
+    // — that server sink declaration is a deliberate choice and must still
+    // render even though the plugin now has an owned card.
+    const pluginId = "owned-plus-server-sink";
+    registerWidgetComponent(pluginId, `${pluginId}.owned`, () => null);
+
+    const serverDecls: PluginWidgetDeclaration[] = [
+      {
+        id: `${pluginId}.owned`,
+        pluginId,
+        slot: "home",
+        label: "Owned card",
+        icon: "Star",
+      },
+      {
+        // A second, server-provided declaration that opts into a shared sink
+        // (no component, no uiSpec) — NOT a built-in legacy fallback row.
+        id: `${pluginId}.extra-sink`,
+        pluginId,
+        slot: "home",
+        label: "Extra sink",
+        icon: "Bell",
+        defaultWidget: "notifications",
+      },
+    ];
+
+    const resolved = resolveWidgetsForSlot(
+      "home",
+      [{ id: pluginId, enabled: true, isActive: true }],
+      serverDecls,
+    );
+
+    // Both the owned card and the intentional server sink widget render.
+    expect(
+      resolved.find((r) => r.declaration.id === `${pluginId}.owned`),
+    ).toBeTruthy();
+    const sink = resolved.find(
+      (r) => r.declaration.id === `${pluginId}.extra-sink`,
+    );
+    expect(sink).toBeTruthy();
+    expect(sink?.defaultWidgetSink).toBe("notifications");
+  });
+});

--- a/packages/ui/src/widgets/default-home-widget-sink-optins.ts
+++ b/packages/ui/src/widgets/default-home-widget-sink-optins.ts
@@ -1,0 +1,255 @@
+/**
+ * Legacy host-owned fallback: default-home widget sink opt-ins (#12089 item 35).
+ *
+ * App-manifest plugins that do NOT ship an owned home card (no bundled widget
+ * component, no `Plugin.widgets` declaration) historically opted into one of the
+ * shared default sinks (`activity` / `notifications`) via a ~23-entry literal
+ * array hardcoded in the UI trunk (`registry.ts`). That array was a second,
+ * hand-maintained widget registry: it duplicated each plugin's `pluginId` and
+ * had to be edited in the UI package every time an app plugin wanted to
+ * participate in the frontpage widget system — exactly the "central name list a
+ * plugin cannot own" coupling the arch-audit flags.
+ *
+ * The canonical, owner-declared path is a plugin shipping its own
+ * `widgets: PluginWidgetDeclaration[]` on its `Plugin` instance; the server
+ * merges those (see `@elizaos/agent` `getPluginWidgets`) and they arrive as
+ * snapshot-gated `server` declarations that take precedence. This table is the
+ * explicitly-marked, tested **legacy host-owned fallback** for the app plugins
+ * that have not yet migrated their opt-in onto their own manifest — kept as pure
+ * data (no assembly logic) so it is a declaration list, not an if-chain, and so
+ * a plugin migrating to `Plugin.widgets` simply drops its row here with no other
+ * UI-trunk edit. A plugin that DOES declare its own widget wins over its legacy
+ * row (proven by the drift guard test) so the two cannot silently diverge.
+ *
+ * To retire a row: ship the equivalent `PluginWidgetDeclaration` on the plugin's
+ * own `Plugin.widgets` and delete the entry below.
+ */
+import type { PluginWidgetDeclaration } from "./types";
+
+type DefaultHomeWidgetSink = NonNullable<
+  PluginWidgetDeclaration["defaultWidget"]
+>;
+
+/**
+ * A single plugin's opt-in into a shared default home sink. Only the
+ * plugin-owned metadata (identity, label, icon, which shared sink, and the
+ * signal kinds that boost it) lives here; the structural fields (`id`, `slot`,
+ * `order`, `defaultEnabled`) are derived uniformly by
+ * `buildDefaultHomeWidgetDeclarations` so no row can drift on shape.
+ */
+export interface DefaultHomeWidgetSinkOptIn {
+  /** Owning plugin id (app-manifest plugin id). */
+  pluginId: string;
+  /** Display label for the default-home tile. */
+  label: string;
+  /** Lucide icon name. */
+  icon: string;
+  /** Which shared default sink this plugin's signals fold into. */
+  defaultWidget: DefaultHomeWidgetSink;
+  /** Signal kinds that boost this plugin's presence on the home grid. */
+  signalKinds: PluginWidgetDeclaration["signalKinds"];
+}
+
+/**
+ * LEGACY host-owned fallback opt-ins. Each row is owned by the named plugin and
+ * should migrate to that plugin's `Plugin.widgets` declaration; until it does,
+ * this fallback keeps the plugin participating in the frontpage widget system.
+ * Ordered only for a stable, deterministic `order` assignment — membership, not
+ * position, is the contract.
+ */
+export const LEGACY_DEFAULT_HOME_WIDGET_SINK_OPTINS: readonly DefaultHomeWidgetSinkOptIn[] =
+  [
+    {
+      pluginId: "birdclaw",
+      label: "Birdclaw",
+      icon: "Bird",
+      defaultWidget: "activity",
+      signalKinds: ["activity", "notification"],
+    },
+    {
+      pluginId: "blocker",
+      label: "Focus",
+      icon: "Shield",
+      defaultWidget: "notifications",
+      signalKinds: ["blocked", "reminder", "notification"],
+    },
+    {
+      pluginId: "contacts",
+      label: "Contacts",
+      icon: "Contact",
+      defaultWidget: "activity",
+      signalKinds: ["nudge", "activity"],
+    },
+    {
+      pluginId: "device-settings",
+      label: "Device Settings",
+      icon: "Settings",
+      defaultWidget: "notifications",
+      signalKinds: ["notification", "activity"],
+    },
+    {
+      pluginId: "documents",
+      label: "Documents",
+      icon: "FileText",
+      defaultWidget: "activity",
+      signalKinds: ["approval", "workflow", "activity"],
+    },
+    // The `feed` plugin owns the real `feed.agent-activity` home tile (declared
+    // in registry.ts), so it no longer opts into the shared messages sink here.
+    {
+      pluginId: "form",
+      label: "Forms",
+      icon: "ClipboardList",
+      defaultWidget: "activity",
+      signalKinds: ["approval", "workflow", "activity"],
+    },
+    {
+      pluginId: "hyperliquid",
+      label: "Hyperliquid",
+      icon: "ChartCandlestick",
+      defaultWidget: "notifications",
+      signalKinds: ["escalation", "notification", "activity"],
+    },
+    {
+      pluginId: "model-tester",
+      label: "Model Tester",
+      icon: "Gauge",
+      defaultWidget: "activity",
+      signalKinds: ["workflow", "activity"],
+    },
+    {
+      pluginId: "native-settings",
+      label: "Native Settings",
+      icon: "Settings",
+      defaultWidget: "notifications",
+      signalKinds: ["notification", "activity"],
+    },
+    {
+      pluginId: "personal-assistant",
+      label: "Personal Assistant",
+      icon: "Sparkles",
+      defaultWidget: "notifications",
+      signalKinds: ["reminder", "check-in", "notification"],
+    },
+    {
+      // The @elizaos/plugin-messages app plugin no longer ships its own home
+      // tile — the standalone Messages widget was removed as redundant with the
+      // always-present chat overlay (#10697). Follow-up-worthy messages surface
+      // as `category: "message"` notifications, so it folds into that rail.
+      pluginId: "messages",
+      label: "Messages",
+      icon: "MessageSquare",
+      defaultWidget: "notifications",
+      signalKinds: ["message", "notification"],
+    },
+    {
+      pluginId: "phone",
+      label: "Phone",
+      // Follow-up messages fold into the notification rail (#10697); the
+      // standalone Messages tile was removed as redundant with the chat overlay.
+      icon: "Phone",
+      defaultWidget: "notifications",
+      signalKinds: ["message", "notification"],
+    },
+    {
+      pluginId: "polymarket",
+      label: "Polymarket",
+      icon: "ChartNoAxesCombined",
+      defaultWidget: "notifications",
+      signalKinds: ["escalation", "notification", "activity"],
+    },
+    {
+      pluginId: "screenshare",
+      label: "Screen Share",
+      icon: "MonitorUp",
+      defaultWidget: "activity",
+      signalKinds: ["workflow", "activity"],
+    },
+    {
+      pluginId: "shopify",
+      label: "Shopify",
+      icon: "ShoppingBag",
+      defaultWidget: "notifications",
+      signalKinds: ["approval", "notification", "activity"],
+    },
+    {
+      pluginId: "task-coordinator",
+      label: "Task Coordinator",
+      icon: "ListChecks",
+      defaultWidget: "activity",
+      signalKinds: ["blocked", "workflow", "activity"],
+    },
+    {
+      pluginId: "todos",
+      label: "Todos",
+      icon: "ListTodo",
+      defaultWidget: "activity",
+      signalKinds: ["reminder", "check-in", "nudge"],
+    },
+    {
+      pluginId: "training",
+      label: "Fine Tuning",
+      icon: "Brain",
+      defaultWidget: "activity",
+      signalKinds: ["workflow", "activity"],
+    },
+    {
+      pluginId: "trajectory-logger",
+      label: "Trajectory Logger",
+      icon: "Route",
+      defaultWidget: "activity",
+      signalKinds: ["workflow", "activity"],
+    },
+    {
+      pluginId: "vector-browser",
+      label: "Vector Browser",
+      icon: "Search",
+      defaultWidget: "activity",
+      signalKinds: ["workflow", "activity"],
+    },
+    {
+      pluginId: "wallet-ui",
+      label: "Wallet",
+      icon: "Wallet",
+      defaultWidget: "notifications",
+      signalKinds: ["approval", "escalation", "notification"],
+    },
+    {
+      pluginId: "wifi",
+      label: "WiFi",
+      icon: "Wifi",
+      defaultWidget: "notifications",
+      signalKinds: ["notification", "activity"],
+    },
+  ];
+
+/**
+ * First `order` slot for the default-home sink opt-ins. Kept above the
+ * per-plugin real-data widgets so a bespoke card always outranks a plugin's
+ * generic default-sink tile.
+ */
+export const DEFAULT_HOME_WIDGET_OPTIN_ORDER_BASE = 300;
+
+/**
+ * Assemble the full `home`-slot `PluginWidgetDeclaration`s for the legacy
+ * default-sink opt-ins. Pure derivation from
+ * {@link LEGACY_DEFAULT_HOME_WIDGET_SINK_OPTINS}: every structural field is
+ * uniform, so a row cannot drift on `id`/`slot`/`order`/`defaultEnabled` shape.
+ * Accepts the table as a parameter (defaulted) so tests can exercise the builder
+ * in isolation.
+ */
+export function buildDefaultHomeWidgetDeclarations(
+  optIns: readonly DefaultHomeWidgetSinkOptIn[] = LEGACY_DEFAULT_HOME_WIDGET_SINK_OPTINS,
+): PluginWidgetDeclaration[] {
+  return optIns.map((optIn, index) => ({
+    id: `${optIn.pluginId}.default-home`,
+    slot: "home" as const,
+    order: DEFAULT_HOME_WIDGET_OPTIN_ORDER_BASE + index,
+    defaultEnabled: true,
+    pluginId: optIn.pluginId,
+    label: optIn.label,
+    icon: optIn.icon,
+    defaultWidget: optIn.defaultWidget,
+    signalKinds: optIn.signalKinds,
+  }));
+}

--- a/packages/ui/src/widgets/registry.ts
+++ b/packages/ui/src/widgets/registry.ts
@@ -10,6 +10,7 @@
  */
 
 import type { PluginInfo } from "../api/client-types-config";
+import { buildDefaultHomeWidgetDeclarations } from "./default-home-widget-sink-optins";
 import {
   getWidgetComponent,
   markWidgetRegistryChanged,
@@ -127,178 +128,15 @@ for (const w of [
   registerWidgetComponent(w.pluginId, w.id, w.Component);
 }
 
-const APP_HOME_DEFAULT_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = (
-  [
-    {
-      pluginId: "birdclaw",
-      label: "Birdclaw",
-      icon: "Bird",
-      defaultWidget: "activity",
-      signalKinds: ["activity", "notification"],
-    },
-    {
-      pluginId: "blocker",
-      label: "Focus",
-      icon: "Shield",
-      defaultWidget: "notifications",
-      signalKinds: ["blocked", "reminder", "notification"],
-    },
-    {
-      pluginId: "contacts",
-      label: "Contacts",
-      icon: "Contact",
-      defaultWidget: "activity",
-      signalKinds: ["nudge", "activity"],
-    },
-    {
-      pluginId: "device-settings",
-      label: "Device Settings",
-      icon: "Settings",
-      defaultWidget: "notifications",
-      signalKinds: ["notification", "activity"],
-    },
-    {
-      pluginId: "documents",
-      label: "Documents",
-      icon: "FileText",
-      defaultWidget: "activity",
-      signalKinds: ["approval", "workflow", "activity"],
-    },
-    // The `feed` plugin owns the real `feed.agent-activity` home tile (declared
-    // below), so it no longer opts into the shared messages sink here.
-    {
-      pluginId: "form",
-      label: "Forms",
-      icon: "ClipboardList",
-      defaultWidget: "activity",
-      signalKinds: ["approval", "workflow", "activity"],
-    },
-    {
-      pluginId: "hyperliquid",
-      label: "Hyperliquid",
-      icon: "ChartCandlestick",
-      defaultWidget: "notifications",
-      signalKinds: ["escalation", "notification", "activity"],
-    },
-    {
-      pluginId: "model-tester",
-      label: "Model Tester",
-      icon: "Gauge",
-      defaultWidget: "activity",
-      signalKinds: ["workflow", "activity"],
-    },
-    {
-      pluginId: "native-settings",
-      label: "Native Settings",
-      icon: "Settings",
-      defaultWidget: "notifications",
-      signalKinds: ["notification", "activity"],
-    },
-    {
-      pluginId: "personal-assistant",
-      label: "Personal Assistant",
-      icon: "Sparkles",
-      defaultWidget: "notifications",
-      signalKinds: ["reminder", "check-in", "notification"],
-    },
-    {
-      // The @elizaos/plugin-messages app plugin no longer ships its own home
-      // tile — the standalone Messages widget was removed as redundant with the
-      // always-present chat overlay (#10697). Follow-up-worthy messages surface
-      // as `category: "message"` notifications, so it folds into that rail.
-      pluginId: "messages",
-      label: "Messages",
-      icon: "MessageSquare",
-      defaultWidget: "notifications",
-      signalKinds: ["message", "notification"],
-    },
-    {
-      pluginId: "phone",
-      label: "Phone",
-      icon: "Phone",
-      // Follow-up messages fold into the notification rail (#10697); the
-      // standalone Messages tile was removed as redundant with the chat overlay.
-      defaultWidget: "notifications",
-      signalKinds: ["message", "notification"],
-    },
-    {
-      pluginId: "polymarket",
-      label: "Polymarket",
-      icon: "ChartNoAxesCombined",
-      defaultWidget: "notifications",
-      signalKinds: ["escalation", "notification", "activity"],
-    },
-    {
-      pluginId: "screenshare",
-      label: "Screen Share",
-      icon: "MonitorUp",
-      defaultWidget: "activity",
-      signalKinds: ["workflow", "activity"],
-    },
-    {
-      pluginId: "shopify",
-      label: "Shopify",
-      icon: "ShoppingBag",
-      defaultWidget: "notifications",
-      signalKinds: ["approval", "notification", "activity"],
-    },
-    {
-      pluginId: "task-coordinator",
-      label: "Task Coordinator",
-      icon: "ListChecks",
-      defaultWidget: "activity",
-      signalKinds: ["blocked", "workflow", "activity"],
-    },
-    {
-      pluginId: "todos",
-      label: "Todos",
-      icon: "ListTodo",
-      defaultWidget: "activity",
-      signalKinds: ["reminder", "check-in", "nudge"],
-    },
-    {
-      pluginId: "training",
-      label: "Fine Tuning",
-      icon: "Brain",
-      defaultWidget: "activity",
-      signalKinds: ["workflow", "activity"],
-    },
-    {
-      pluginId: "trajectory-logger",
-      label: "Trajectory Logger",
-      icon: "Route",
-      defaultWidget: "activity",
-      signalKinds: ["workflow", "activity"],
-    },
-    {
-      pluginId: "vector-browser",
-      label: "Vector Browser",
-      icon: "Search",
-      defaultWidget: "activity",
-      signalKinds: ["workflow", "activity"],
-    },
-    {
-      pluginId: "wallet-ui",
-      label: "Wallet",
-      icon: "Wallet",
-      defaultWidget: "notifications",
-      signalKinds: ["approval", "escalation", "notification"],
-    },
-    {
-      pluginId: "wifi",
-      label: "WiFi",
-      icon: "Wifi",
-      defaultWidget: "notifications",
-      signalKinds: ["notification", "activity"],
-    },
-  ] as const
-).map((declaration, index) => ({
-  id: `${declaration.pluginId}.default-home`,
-  slot: "home" as const,
-  order: 300 + index,
-  defaultEnabled: true,
-  ...declaration,
-}));
+// App-manifest plugins that do not ship an owned home card opt into one of the
+// shared default sinks. The opt-in rows now live in the co-located, explicitly-
+// marked legacy host-owned fallback table
+// (`LEGACY_DEFAULT_HOME_WIDGET_SINK_OPTINS`) instead of a second hand-maintained
+// declaration literal in this trunk (#12089 item 35). A plugin migrating to its
+// own `Plugin.widgets` declaration drops its row there — no edit here — and a
+// plugin-owned/server declaration wins over its legacy fallback row.
+const APP_HOME_DEFAULT_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] =
+  buildDefaultHomeWidgetDeclarations();
 
 /**
  * Public API for plugins outside app-core to append widget declarations to the
@@ -803,6 +641,31 @@ export function resolveWidgetsForSlot(
     }
   }
 
+  // Home-slot plugins that resolve to their OWN renderable home card (a bundled
+  // component or a `uiSpec`) — used to suppress a plugin's generic default-sink
+  // fallback row once it ships a real card, so a plugin migrating its opt-in
+  // onto its own `Plugin.widgets` doesn't render two home tiles (the owned card
+  // AND the stale `.default-home` sink) side by side.
+  //
+  // Only a card THIS host can actually render counts: a declaration with no
+  // registered component and no `uiSpec` (e.g. a remote/componentExport-only
+  // server declaration this build can't render) is dropped downstream by the
+  // `Component || uiSpec` gate, so it must NOT suppress the shared sink — doing
+  // so would leave the plugin with no home tile at all (a regression vs. the
+  // pre-refactor behavior, where the sink still rendered).
+  const pluginsWithOwnHomeCard = new Set<string>();
+  if (slot === "home") {
+    for (const { declaration } of declarationMap.values()) {
+      if (declaration.slot !== "home") continue;
+      const rendersViaOwnCard =
+        !!declaration.uiSpec ||
+        !!getWidgetComponent(declaration.pluginId, declaration.id);
+      if (rendersViaOwnCard) {
+        pluginsWithOwnHomeCard.add(declaration.pluginId);
+      }
+    }
+  }
+
   const results: ResolvedWidget[] = [];
 
   for (const { declaration, source } of declarationMap.values()) {
@@ -821,6 +684,24 @@ export function resolveWidgetsForSlot(
       declaration.slot === "home" &&
       declaration.defaultWidget
     ) {
+      // Suppress the generic default-sink fallback for a plugin that already
+      // resolves to its own renderable home card. This is the migration guard:
+      // the legacy `.default-home` sink row stands in ONLY while the plugin
+      // ships no real card, so it must not double up with an owned card under a
+      // different id. Scope is deliberately narrow:
+      //   - `source === "builtin"`: only the built-in legacy fallback rows are
+      //     suppressible. A SERVER-provided sink declaration is an intentional
+      //     plugin choice (a plugin may ship an owned card AND a separate shared
+      //     sink widget) and must still render.
+      //   - `!declaration.uiSpec`: a `uiSpec`-carrying declaration is a real card
+      //     that renders its own spec below, never the sink-only fallback.
+      if (
+        source === "builtin" &&
+        !declaration.uiSpec &&
+        pluginsWithOwnHomeCard.has(declaration.pluginId)
+      ) {
+        continue;
+      }
       const sink = DEFAULT_WIDGET_SINK_COMPONENT[declaration.defaultWidget];
       Component = getWidgetComponent(sink.pluginId, sink.id);
       if (Component) {


### PR DESCRIPTION
Closes #12681 (arch-audit self-registration #12089 item 35).

## Problem
App-manifest plugins without an owned home card opted into a shared default home sink via a **~23-entry `PluginWidgetDeclaration` literal hardcoded inline** in `packages/ui/src/widgets/registry.ts`. That array was a second, hand-maintained widget registry: it duplicated each plugin's `pluginId` and had to be edited in the UI trunk every time an app plugin wanted to participate in the frontpage widget system — exactly the "central name list a plugin cannot own" coupling the audit flags.

(The **visibility-set half** of this audit item already landed in #12637 — the `ALWAYS_VISIBLE_BUILTIN_WIDGET_PLUGIN_IDS` set is gone from executable paths. This PR closes the **remaining hardcoded-declaration half**.)

## Change
- Extracted the inline literal into a co-located, **explicitly-marked legacy host-owned fallback** table `LEGACY_DEFAULT_HOME_WIDGET_SINK_OPTINS` (pure data) in a new `default-home-widget-sink-optins.ts`, assembled into declarations by a pure builder `buildDefaultHomeWidgetDeclarations`. A plugin migrating its opt-in onto its own `Plugin.widgets` declaration just drops its row there — no other UI-trunk edit.
- `registry.ts` now imports the assembled declarations; the inline `.default-home` id-template `.map(...)` assembly is gone from the executable trunk (grep-guarded).
- **Migration guard** in `resolveWidgetsForSlot`: once a plugin resolves to its own renderable home card, its generic default-sink fallback tile is suppressed (even under a different id) so a migrated plugin can't render its owned card *and* the stale `${pluginId}.default-home` sink side by side. The guard is deliberately narrow:
  - only a **built-in** legacy fallback row is suppressible (a server-provided sink declaration is an intentional plugin choice and still renders);
  - only a card **this host can actually render** counts as an owned card (a non-renderable remote/componentExport-only server declaration does not suppress the sink, so the plugin keeps a tile);
  - a `uiSpec`-carrying declaration is a real card and is never self-suppressed even if it also names a `defaultWidget`.

## Tests
New `packages/ui/src/widgets/default-home-widget-sink-optins.test.ts`:
- grep-guard: inline literal + `.default-home` id-template assembly gone from `registry.ts`;
- behavior-preserving builder shape (id/slot/order/defaultEnabled derivation);
- uniform structural-field derivation + unique-`pluginId` invariant;
- full migration-guard matrix: owned card suppresses the legacy row; unrenderable server card does **not**; `uiSpec`+`defaultWidget` card is not self-suppressed; server-provided sink survives alongside an owned card.

Full widgets suite green: **122 tests / 17 files**. `ui` tsgo clean, biome clean, codex-reviewed clean (4 rounds — each round's P2 boundary case fixed and covered by a regression test).

— [sol-orch]
