### PR TITLE
fix(core): skip direct-candidate injection backstop on sub-agent completion relays

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -3813,3 +3813,172 @@ describe("runV5MessageRuntimeStage1", () => {
 		expect(useModelCalls(runtime)).toHaveLength(1);
 	});
 });
+
+// A sub-agent completion relay's envelope echoes the ORIGINAL task text
+// ("[sub-agent: Build and deploy…]"), so the direct-candidate injection
+// backstop used to read a FINISHED task as fresh task intent: it forced
+// requiresTool + a delegation candidate onto the relay turn, the planner
+// rejected REPLY up to the required-tool miss cap, and some turns re-spawned
+// the already-completed task. Relay turns are detected by their structural
+// markers (content.metadata.subAgent / the relay envelope prefix), never by
+// classifying LLM text — genuine user task-intent turns keep the backstop.
+describe("sub-agent completion relay vs the direct-candidate injection backstop", () => {
+	const RELAY_ENVELOPE_TEXT =
+		"[sub-agent: Build and deploy a dice roller web app (opencode) — completed]\n" +
+		"Done. I built the dice roller web app and deployed it. " +
+		"The app is live at https://apps.example.test/dice/ — repo updated on branch feat/dice.";
+
+	function makeSpawnAction(handler: () => Promise<unknown>) {
+		return {
+			name: "TASKS_SPAWN_AGENT",
+			similes: [],
+			tags: ["domain:coding", "resource:agent-task", "capability:delegate"],
+			description: "Spawn a coding sub-agent for a delegated task.",
+			parameters: [
+				{
+					name: "task",
+					description: "Task description",
+					required: true,
+					schema: { type: "string" },
+				},
+			],
+			examples: [],
+			validate: async () => true,
+			handler,
+		};
+	}
+
+	it("lets REPLY through on a metadata-marked relay turn (structured Stage 1) — no force-tools, no re-spawn", async () => {
+		const spawnHandler = vi.fn(async () => ({
+			success: true,
+			text: "spawned",
+			data: { actionName: "TASKS_SPAWN_AGENT" },
+		}));
+		// A terse relay reply fails looksLikeCompleteDirectReply, so nothing but
+		// the relay gate itself keeps the injection backstop off this turn — the
+		// exact shape that used to be force-planned into the miss-cap loop.
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "Done.",
+			}),
+		]);
+		runtime.actions = [makeSpawnAction(spawnHandler)] as never;
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: RELAY_ENVELOPE_TEXT,
+				source: "sub_agent",
+				metadata: { subAgent: true },
+			}),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		expect(result.messageHandler.plan.requiresTool).toBe(false);
+		expect(result.messageHandler.plan.candidateActions ?? []).not.toContain(
+			"TASKS_SPAWN_AGENT",
+		);
+		expect(spawnHandler).not.toHaveBeenCalled();
+		// Stage 1 only — no planner stage, no required-tool miss loop.
+		expect(useModelCalls(runtime)).toHaveLength(1);
+		if (result.kind === "direct_reply") {
+			expect(result.result.responseContent?.text).toBe("Done.");
+		}
+	});
+
+	it("lets REPLY through on an envelope-prefix relay turn (plain-text Stage 1 fallback)", async () => {
+		const spawnHandler = vi.fn(async () => ({
+			success: true,
+			text: "spawned",
+			data: { actionName: "TASKS_SPAWN_AGENT" },
+		}));
+		// Plain-text Stage 1 output exercises the
+		// applyDirectCurrentCandidateBackstopToMessageHandler path; the relay is
+		// recognized by its envelope prefix alone (no metadata on the memory).
+		const runtime = makeRuntime([
+			"Build finished — the dice roller app is deployed and the link was shared above.",
+		]);
+		runtime.actions = [makeSpawnAction(spawnHandler)] as never;
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: RELAY_ENVELOPE_TEXT,
+				source: "sub_agent",
+			}),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		// The plain-text synthesizer leaves requiresTool unset; the defect was
+		// the backstop PROMOTING it to true — assert the promotion never happens.
+		expect(result.messageHandler.plan.requiresTool).not.toBe(true);
+		expect(result.messageHandler.plan.candidateActions ?? []).not.toContain(
+			"TASKS_SPAWN_AGENT",
+		);
+		expect(spawnHandler).not.toHaveBeenCalled();
+		expect(useModelCalls(runtime)).toHaveLength(1);
+	});
+
+	it("keeps the backstop on a genuine user task-intent turn with the same task words", async () => {
+		const spawnHandler = vi.fn(async () => ({
+			success: true,
+			text: "sub-agent session started",
+			data: { actionName: "TASKS_SPAWN_AGENT" },
+		}));
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: [],
+				replyText: "On it.",
+			}),
+			{
+				thought: "Delegate the build to a coding sub-agent.",
+				toolCalls: [
+					{
+						id: "spawn-1",
+						name: "TASKS_SPAWN_AGENT",
+						args: { task: "Build and deploy a dice roller web app" },
+					},
+				],
+			},
+			JSON.stringify({
+				success: true,
+				decision: "FINISH",
+				thought: "Sub-agent spawned.",
+				messageToUser: "Spawned a coding agent to build the dice roller.",
+			}),
+		]);
+		runtime.actions = [makeSpawnAction(spawnHandler)] as never;
+
+		const message = makeMessage();
+		message.content = {
+			...message.content,
+			text: "Build and deploy a dice roller web app",
+			mentionContext: { isMention: true },
+		};
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message,
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		expect(spawnHandler).toHaveBeenCalledTimes(1);
+		const calls = useModelCalls(runtime);
+		expect(calls[1]?.[0]).toBe(ModelType.ACTION_PLANNER);
+		const plannerCall = calls[1]?.[1] as {
+			messages?: Array<{ role?: string; content?: string | null }>;
+		};
+		const plannerUserContent = plannerCall.messages?.[1]?.content ?? "";
+		expect(plannerUserContent).toContain('"requiresTool":true');
+		expect(plannerUserContent).toContain(
+			'"candidateActions":["TASKS_SPAWN_AGENT"]',
+		);
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3807,6 +3807,7 @@ export function messageHandlerFromFieldResult(
 		actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
 		messageText?: string;
 		candidateBackstopRules?: readonly CandidateActionBackstopRule[];
+		subAgentCompletionRelay?: boolean;
 	},
 ): MessageHandlerResult {
 	const rawContexts = Array.isArray(result.contexts)
@@ -3818,12 +3819,27 @@ export function messageHandlerFromFieldResult(
 				.filter(Boolean)
 		: [];
 	const currentMessageText = runtimeContext?.messageText ?? "";
-	const candidateBackstop = applyCodingCandidateBackstop({
-		candidateActions: rawCandidateActions,
-		actions: runtimeContext?.actions ?? [],
-		messageText: currentMessageText,
-		backstopRules: runtimeContext?.candidateBackstopRules ?? [],
-	});
+	// A sub-agent completion relay's envelope echoes the original task text
+	// ("[sub-agent: Build and deploy…]"), so every text-intent inference over
+	// the CURRENT message reads a FINISHED task as fresh task intent. Disable
+	// the text-derived candidate injections (coding backstop, ack-intent
+	// inference, direct-current inference) on relay turns — the relay's only
+	// job is to deliver the result, and forcing a tool over it rejects REPLY up
+	// to the required-tool miss cap or re-spawns completed work. Structural:
+	// the flag comes from the relay's own markers (metadata.subAgent / router
+	// source / envelope prefix), not from classifying LLM text. The model's OWN
+	// explicit routing (contexts + candidateActionNames it emitted) is
+	// untouched, so genuine user task-intent turns keep the full backstop.
+	const subAgentCompletionRelay =
+		runtimeContext?.subAgentCompletionRelay === true;
+	const candidateBackstop = subAgentCompletionRelay
+		? { candidateActions: [...rawCandidateActions], forceCodeContext: false }
+		: applyCodingCandidateBackstop({
+				candidateActions: rawCandidateActions,
+				actions: runtimeContext?.actions ?? [],
+				messageText: currentMessageText,
+				backstopRules: runtimeContext?.candidateBackstopRules ?? [],
+			});
 	const candidateActions = candidateBackstop.candidateActions;
 	const contexts =
 		candidateBackstop.forceCodeContext &&
@@ -3838,6 +3854,7 @@ export function messageHandlerFromFieldResult(
 		runtimeContext,
 	);
 	const inferredAckCandidateActions =
+		!subAgentCompletionRelay &&
 		!hasRunnableCandidateAction &&
 		hasAckOnlyActionableIntent(result, replyTextRaw, currentMessageText)
 			? inferAckIntentCandidateActions(
@@ -3857,7 +3874,7 @@ export function messageHandlerFromFieldResult(
 				})
 			: candidateActions.length > 0;
 	const directCurrentCandidateActions =
-		currentMessageText.trim().length > 0
+		!subAgentCompletionRelay && currentMessageText.trim().length > 0
 			? inferDirectCurrentRequestCandidateActions(
 					runtimeContext?.actions ?? [],
 					currentMessageText,
@@ -4206,13 +4223,24 @@ export function applyDirectCurrentCandidateBackstopToMessageHandler(
 		| {
 				actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
 				messageText?: string;
+				subAgentCompletionRelay?: boolean;
 		  }
 		| undefined,
 ): MessageHandlerResult {
 	const currentMessageText = runtimeContext?.messageText ?? "";
+	// A sub-agent completion relay is not a user request — its envelope ECHOES
+	// the original task text ("[sub-agent: Build and deploy…]"), so the intent
+	// inference below reads a FINISHED task as fresh task intent, promotes the
+	// turn to requiresTool, and the planner rejects REPLY up to the
+	// required-tool miss cap (or re-runs the injected delegation candidate,
+	// re-spawning completed work). The flag is derived from the relay's
+	// structural markers (metadata.subAgent / router source / envelope
+	// prefix), never from classifying LLM text, so genuine user task-intent
+	// turns keep the backstop.
 	if (
 		messageHandler.processMessage !== "RESPOND" ||
 		!runtimeContext ||
+		runtimeContext.subAgentCompletionRelay === true ||
 		currentMessageText.trim().length === 0
 	) {
 		return messageHandler;
@@ -4810,6 +4838,7 @@ function parseMessageHandlerModelOutput(
 	runtimeContext?: {
 		actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
 		messageText?: string;
+		subAgentCompletionRelay?: boolean;
 	},
 ): MessageHandlerResult | null {
 	const applyBackstops = (result: MessageHandlerResult | null) =>
@@ -6145,6 +6174,7 @@ export async function runV5MessageRuntimeStage1(args: {
 					actions: args.runtime.actions,
 					messageText: getUserMessageText(args.message),
 					candidateBackstopRules: getCandidateActionBackstopRules(args.runtime),
+					subAgentCompletionRelay: isSubAgentCompletionArtifact(args.message),
 				},
 			);
 		}
@@ -6152,6 +6182,7 @@ export async function runV5MessageRuntimeStage1(args: {
 			messageHandler = parseMessageHandlerModelOutput(rawMessageHandler, {
 				actions: args.runtime.actions,
 				messageText: getUserMessageText(args.message),
+				subAgentCompletionRelay: isSubAgentCompletionArtifact(args.message),
 			});
 		}
 		const stage1CompletionLimitHit = stage1HitCompletionLimit(


### PR DESCRIPTION
## Problem

The direct-candidate injection backstop (Stage-1 text-intent inference in `packages/core/src/services/message.ts`) treats a **sub-agent completion relay** as a fresh task-intent turn. The relay envelope echoes the original task text (`[sub-agent: Build and deploy a dice roller web app (opencode) — completed] …`), so the coding/shell/web keyword inference matches the envelope itself and force-injects `requiresTool: true` + a delegation candidate onto the turn whose only job is to deliver the finished result.

Observed on live trajectories (wide-trajectory hunt, re-verified on develop tip):
- ~118/369 relay turns had REPLY rejected up to the required-tool miss cap (~160–225K prompt tokens each, ~27.9M tokens burned since 06-21), with a successful task frequently reported as a false "hit a snag".
- ~9% (22/238) of affected completions **re-spawned a task that had already finished** via the injected delegation candidate.

## Fix (structural — no regex on LLM text)

Relay turns are identified by the relay's own structural markers, exactly what `isSubAgentCompletionArtifact` already checks (`content.metadata.subAgent === true` set by the sub-agent router, the router source, or the relay envelope prefix the router writes). On those turns the pipeline now skips the **text-derived candidate injections only**:

- `messageHandlerFromFieldResult`: coding-candidate backstop, ack-intent inference, and direct-current-request inference are disabled when `subAgentCompletionRelay` is set.
- `applyDirectCurrentCandidateBackstopToMessageHandler` (plain-text Stage-1 fallback): returns the handler unchanged on relay turns.
- Both Stage-1 parse call sites derive the flag from the message memory via `isSubAgentCompletionArtifact(args.message)`.

The backstop is load-bearing for genuine user task intent (planner misroutes without it), so nothing else changes: the model's OWN explicit routing (contexts + `candidateActionNames` it emitted) is untouched, and non-relay turns keep the full backstop. This mirrors the guard the `core.simple_registered_action_request` field evaluator already has for the same reason.

## Repro (develop tip, pre-fix)

Feeding the relay envelope above through Stage 1 with a terse relay reply ("Done."):

- structured path → `{"contexts":["general"],"simple":false,"requiresTool":true,"candidateActions":["TASKS_SPAWN_AGENT"]}`
- plain-text fallback path → same promotion

i.e. the completion relay is force-planned into the miss-cap loop with a spawn candidate.

## Tests

New pipeline-level tests in `packages/core/src/__tests__/message-runtime-stage1.test.ts` drive the real `runV5MessageRuntimeStage1`:

1. metadata-marked relay turn (structured Stage 1) → `direct_reply`, `requiresTool: false`, no spawn candidate, spawn handler never called, exactly 1 model call (no planner stage, no miss loop);
2. envelope-prefix relay turn (plain-text Stage-1 fallback path) → same;
3. control: a genuine user ask with the same task words ("Build and deploy a dice roller web app") still routes `planned_reply` with `"requiresTool":true` + `"candidateActions":["TASKS_SPAWN_AGENT"]` and executes the spawn — the backstop is not weakened.

Both relay tests FAIL on unfixed develop (verified by stashing the fix) and pass with it; the control passes both ways.

## Verification

- `packages/core` stage-1 test file: **84/84 passed** (81 existing + 3 new)
- Neighboring routing/backstop files (`message-routing-live-regression`, `message-handler-bogus-candidates`, `candidate-action-backstop`): **87/87 passed**
- Full `packages/core` suite: **3091 passed / 7 failed / 11 skipped (363 files)** — the same 7 failures reproduce on clean develop with the fix stashed (pre-existing infra: contracts-alignment package-entry resolution, media fetch-guard network tests, callsite/tiered-surface audits, link-extraction), zero new failures
- `packages/core` typecheck (`tsgo --noEmit`): clean, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
