### PR TITLE
feat(#12284): scheduleStyle owner-fact from schedule-insight regularity (WI-5)

### DIFF
--- a/.github/issue-evidence/12284-schedule-style-owner-fact.md
+++ b/.github/issue-evidence/12284-schedule-style-owner-fact.md
@@ -1,0 +1,95 @@
+# #12284 WI-5 — scheduleStyle/chronotype owner-fact from schedule-insight regularity
+
+Phase-by-phase transcript from driving the REAL production writer
+(`learnScheduleStyleFromEpisodes`, `plugins/plugin-personal-assistant/src/lifeops/owner/schedule-style-writer.ts`)
+over the real `OwnerFactStore` (in-memory runtime cache). No facts are
+hand-set in the assertion path; every entry below is produced by the writer
+from synthesized sleep-episode histories, classified by plugin-health's real
+`computeSleepRegularity` / `computePersonalBaseline`.
+
+Personas: irregular (8 chaotic nights), regular (10x 23:00-07:00), rotating
+(4-night block + 4-day block shift pattern), and a user-owned `first_run`
+override the learner must not clobber. The idempotent re-run shows an
+unchanged classification writes nothing.
+
+Captured 2026-07-04 on branch `feat/12284-travel-schedulestyle` (harness:
+vitest spec calling the production modules; transcript verbatim).
+
+```
+[phase] learnScheduleStyleFromEpisodes (irregular persona, 8 chaotic nights)
+[result] {"wrote":true,"updated":["scheduleStyle","chronotype"],"scheduleStyle":"irregular","chronotype":"intermediate"}
+[result idempotent re-run] {"wrote":false,"updated":[],"scheduleStyle":"irregular","chronotype":"intermediate"}
+=== fact store @ irregular persona ===
+{
+  "scheduleStyle": {
+    "value": "irregular",
+    "provenance": {
+      "source": "agent_inferred",
+      "recordedAt": "2026-07-10T12:00:00.000Z",
+      "note": "learned from observed sleep regularity (schedule insight)"
+    }
+  },
+  "chronotype": {
+    "value": "intermediate",
+    "provenance": {
+      "source": "agent_inferred",
+      "recordedAt": "2026-07-10T12:00:00.000Z",
+      "note": "learned from observed sleep regularity (schedule insight)"
+    }
+  }
+}
+[phase] learnScheduleStyleFromEpisodes (regular persona, 10x 23:00-07:00)
+[result] {"wrote":true,"updated":["scheduleStyle","chronotype"],"scheduleStyle":"regular","chronotype":"intermediate"}
+=== fact store @ regular persona ===
+{
+  "scheduleStyle": {
+    "value": "regular",
+    "provenance": {
+      "source": "agent_inferred",
+      "recordedAt": "2026-07-10T12:00:00.000Z",
+      "note": "learned from observed sleep regularity (schedule insight)"
+    }
+  },
+  "chronotype": {
+    "value": "intermediate",
+    "provenance": {
+      "source": "agent_inferred",
+      "recordedAt": "2026-07-10T12:00:00.000Z",
+      "note": "learned from observed sleep regularity (schedule insight)"
+    }
+  }
+}
+[phase] learnScheduleStyleFromEpisodes (rotating persona, 4 night-block + 4 day-block)
+[result] {"wrote":true,"updated":["scheduleStyle"],"scheduleStyle":"rotating","chronotype":null}
+=== fact store @ rotating persona ===
+{
+  "scheduleStyle": {
+    "value": "rotating",
+    "provenance": {
+      "source": "agent_inferred",
+      "recordedAt": "2026-07-10T12:00:00.000Z",
+      "note": "learned from observed sleep regularity (schedule insight)"
+    }
+  }
+}
+[phase] user-owned override (first_run scheduleStyle=regular, then chaotic evidence)
+[result] {"wrote":true,"updated":["chronotype"],"scheduleStyle":"irregular","chronotype":"intermediate"}
+=== fact store @ user-owned override ===
+{
+  "scheduleStyle": {
+    "value": "regular",
+    "provenance": {
+      "source": "first_run",
+      "recordedAt": "2026-07-01T00:00:00.000Z"
+    }
+  },
+  "chronotype": {
+    "value": "intermediate",
+    "provenance": {
+      "source": "agent_inferred",
+      "recordedAt": "2026-07-10T12:00:00.000Z",
+      "note": "learned from observed sleep regularity (schedule insight)"
+    }
+  }
+}
+```

--- a/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.ts
@@ -35,6 +35,7 @@ import {
 } from "../lifeops/background-planner.js";
 import { enqueueIfSensitive } from "../lifeops/background-planner-dispatch.js";
 import { resolveDefaultTimeZone } from "../lifeops/defaults.js";
+import { learnScheduleStyleFacts } from "../lifeops/owner/schedule-style-writer.js";
 import { ensureRuntimeAgentRecord } from "../lifeops/runtime.js";
 import {
   PROACTIVE_TASK_NAME,
@@ -216,6 +217,25 @@ export async function executeProactiveTask(
         error: error instanceof Error ? error.message : String(error),
       },
       "[proactive] rhythm-window learning failed; continuing tick (best-effort learning)",
+    );
+  }
+
+  // Schedule-style learning (#12284 WI-5): classify the observed sleep
+  // regularity into the queryable scheduleStyle/chronotype owner facts.
+  // Same best-effort contract as the window learner above — idempotent, so
+  // an unchanged classification writes nothing.
+  // error-policy:J7 learning is a diagnostic side-effect of the maintenance
+  // tick; a transient store/DB failure must not abort the tick loop.
+  try {
+    await learnScheduleStyleFacts(runtime, now);
+  } catch (error) {
+    logger.warn(
+      {
+        src: "lifeops:activity-profile:proactive-worker",
+        agentId: runtime.agentId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "[proactive] schedule-style learning failed; continuing tick (best-effort learning)",
     );
   }
 

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/fact-store.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/fact-store.ts
@@ -5,10 +5,11 @@
  *
  * The store holds `LifeOpsOwnerProfile` plus the facts
  * (`travelBookingPreferences`, `quietHours`, `morningWindow`,
- * `eveningWindow`, `preferredNotificationChannel`, `locale`). Each entry
- * carries a provenance record so call sites can distinguish a value the user
- * typed in first-run customize from one the agent inferred from a connector
- * — and so audits can trace the origin.
+ * `eveningWindow`, `preferredNotificationChannel`, `locale`, and the learned
+ * `scheduleStyle`/`chronotype` classifications). Each entry carries a
+ * provenance record so call sites can distinguish a value the user typed in
+ * first-run customize from one the agent inferred from a connector — and so
+ * audits can trace the origin.
  *
  * Reminder intensity and escalation policy flows write into the store's policy
  * entries.
@@ -99,6 +100,20 @@ export type ReminderIntensity =
   | "persistent"
   | "high_priority_only";
 
+/**
+ * Learned classification of the owner's day-to-day schedule shape, derived
+ * from observed sleep regularity (`owner/schedule-style.ts`). `rotating`
+ * means the wake times cluster into two distinct, internally-tight bands
+ * (shift-work pattern) rather than being merely noisy.
+ */
+export type OwnerScheduleStyle = "regular" | "irregular" | "rotating";
+
+/**
+ * Learned chronotype label derived from the owner's mid-sleep point
+ * (`owner/schedule-style.ts`). Thresholds approximate MCTQ terciles.
+ */
+export type OwnerChronotype = "early" | "intermediate" | "late";
+
 export interface EscalationRule {
   /** Optional definition id this rule scopes to; null = global default. */
   definitionId: string | null;
@@ -133,6 +148,10 @@ export interface OwnerFacts {
   locale?: OwnerFactEntry<string>;
   timezone?: OwnerFactEntry<string>;
 
+  // Learned rhythm classification (written by owner/schedule-style-writer.ts)
+  scheduleStyle?: OwnerFactEntry<OwnerScheduleStyle>;
+  chronotype?: OwnerFactEntry<OwnerChronotype>;
+
   // Policies (writable via the policy-aware setters; read-only here)
   reminderIntensity?: OwnerFactEntry<ReminderIntensity>;
   escalationRules?: OwnerFactEntry<EscalationRule[]>;
@@ -153,6 +172,8 @@ export interface OwnerFactsPatch {
   preferredNotificationChannel?: string;
   locale?: string;
   timezone?: string;
+  scheduleStyle?: OwnerScheduleStyle;
+  chronotype?: OwnerChronotype;
 }
 
 export interface PolicyPatchReminderIntensity {
@@ -272,6 +293,14 @@ function isReminderIntensity(value: unknown): value is ReminderIntensity {
   );
 }
 
+function isScheduleStyle(value: unknown): value is OwnerScheduleStyle {
+  return value === "regular" || value === "irregular" || value === "rotating";
+}
+
+function isChronotype(value: unknown): value is OwnerChronotype {
+  return value === "early" || value === "intermediate" || value === "late";
+}
+
 function isProvenanceSource(
   value: unknown,
 ): value is OwnerFactProvenanceSource {
@@ -368,6 +397,17 @@ function normalizeReminderIntensityEntry(
   return { value: value.value, provenance };
 }
 
+function normalizeEnumEntry<T>(
+  value: unknown,
+  guard: (candidate: unknown) => candidate is T,
+): OwnerFactEntry<T> | undefined {
+  if (!isPlainRecord(value)) return undefined;
+  if (!guard(value.value)) return undefined;
+  const provenance = normalizeProvenance(value.provenance);
+  if (!provenance) return undefined;
+  return { value: value.value, provenance };
+}
+
 function normalizeEscalationRule(value: unknown): EscalationRule | null {
   if (!isPlainRecord(value)) return null;
   const definitionId =
@@ -436,6 +476,13 @@ function normalizeRecord(value: unknown): PersistedRecord {
   if (quiet) facts.quietHours = quiet;
   const activeTravel = normalizeActiveTravelEntry(stored.activeTravel);
   if (activeTravel) facts.activeTravel = activeTravel;
+  const scheduleStyle = normalizeEnumEntry(
+    stored.scheduleStyle,
+    isScheduleStyle,
+  );
+  if (scheduleStyle) facts.scheduleStyle = scheduleStyle;
+  const chronotype = normalizeEnumEntry(stored.chronotype, isChronotype);
+  if (chronotype) facts.chronotype = chronotype;
   const intensity = normalizeReminderIntensityEntry(stored.reminderIntensity);
   if (intensity) facts.reminderIntensity = intensity;
   const escalation = normalizeEscalationRulesEntry(stored.escalationRules);
@@ -478,6 +525,8 @@ interface NormalizedPatch {
   morningWindow?: OwnerFactWindow;
   eveningWindow?: OwnerFactWindow;
   quietHours?: OwnerQuietHours;
+  scheduleStyle?: OwnerScheduleStyle;
+  chronotype?: OwnerChronotype;
 }
 
 function normalizePatch(patch: OwnerFactsPatch): NormalizedPatch {
@@ -523,6 +572,12 @@ function normalizePatch(patch: OwnerFactsPatch): NormalizedPatch {
       endLocal: patch.quietHours.endLocal,
       timezone: patch.quietHours.timezone,
     };
+  }
+  if (isScheduleStyle(patch.scheduleStyle)) {
+    result.scheduleStyle = patch.scheduleStyle;
+  }
+  if (isChronotype(patch.chronotype)) {
+    result.chronotype = patch.chronotype;
   }
   return result;
 }
@@ -577,7 +632,9 @@ class CacheBackedOwnerFactStore implements OwnerFactStore {
       !hasStringPatch &&
       !normalized.morningWindow &&
       !normalized.eveningWindow &&
-      !normalized.quietHours
+      !normalized.quietHours &&
+      !normalized.scheduleStyle &&
+      !normalized.chronotype
     ) {
       const current = await this.read();
       return current;
@@ -620,6 +677,18 @@ class CacheBackedOwnerFactStore implements OwnerFactStore {
     if (normalized.quietHours) {
       next.quietHours = {
         value: { ...normalized.quietHours },
+        provenance: { ...provenance },
+      };
+    }
+    if (normalized.scheduleStyle) {
+      next.scheduleStyle = {
+        value: normalized.scheduleStyle,
+        provenance: { ...provenance },
+      };
+    }
+    if (normalized.chronotype) {
+      next.chronotype = {
+        value: normalized.chronotype,
         provenance: { ...provenance },
       };
     }
@@ -773,6 +842,18 @@ function cloneFacts(facts: OwnerFacts): OwnerFacts {
   }
   if (facts.locale) next.locale = cloneStringEntry(facts.locale);
   if (facts.timezone) next.timezone = cloneStringEntry(facts.timezone);
+  if (facts.scheduleStyle) {
+    next.scheduleStyle = {
+      value: facts.scheduleStyle.value,
+      provenance: { ...facts.scheduleStyle.provenance },
+    };
+  }
+  if (facts.chronotype) {
+    next.chronotype = {
+      value: facts.chronotype.value,
+      provenance: { ...facts.chronotype.provenance },
+    };
+  }
   if (facts.reminderIntensity) {
     next.reminderIntensity = {
       value: facts.reminderIntensity.value,

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/schedule-style-writer.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/schedule-style-writer.ts
@@ -1,0 +1,131 @@
+/**
+ * Runtime binding for the sleep-regularity → `scheduleStyle`/`chronotype`
+ * owner-fact learner (issue #12284, WI-5). The classification rules live in
+ * `schedule-style.ts` as pure functions; this module loads the persisted
+ * sleep episodes, derives the classes, applies the user-override / idempotency
+ * policy, and writes any delta through `OwnerFactStore.update` with
+ * `agent_inferred` provenance — making the owner's schedule shape queryable
+ * outside the legacy schedule-insight path.
+ *
+ * Called from the activity-profile proactive worker tick (the existing
+ * periodic path — never a second scheduler). Safe at tick cadence: the write
+ * is idempotent, so an unchanged classification produces zero writes.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import type { SleepRegularityEpisodeLike } from "@elizaos/plugin-health";
+import { listHistoricalSleepEpisodes } from "@elizaos/plugin-health";
+import { resolveDefaultTimeZone } from "../defaults.js";
+import { LifeOpsRepository } from "../repository.js";
+import type {
+  OwnerChronotype,
+  OwnerFactProvenance,
+  OwnerScheduleStyle,
+} from "./fact-store.js";
+import { resolveOwnerFactStore } from "./fact-store.js";
+import {
+  buildScheduleStyleSample,
+  deriveChronotype,
+  deriveScheduleStyle,
+  resolveScheduleStylePatch,
+} from "./schedule-style.js";
+
+/** Look-back window feeding the classification (matches the SRI default). */
+const SCHEDULE_STYLE_WINDOW_DAYS = 28;
+
+export interface LearnScheduleStyleResult {
+  /** Whether a patch was written. */
+  wrote: boolean;
+  /** The keys that were updated (subset of scheduleStyle/chronotype). */
+  updated: Array<"scheduleStyle" | "chronotype">;
+  /** Derived classification this pass (null = insufficient evidence). */
+  scheduleStyle: OwnerScheduleStyle | null;
+  chronotype: OwnerChronotype | null;
+}
+
+/**
+ * Derive and persist the schedule-style facts from an explicit episode set.
+ * Split from {@link learnScheduleStyleFacts} so tests can drive the full
+ * writer path without a database. `now` is injectable for tests.
+ */
+export async function learnScheduleStyleFromEpisodes(
+  runtime: IAgentRuntime,
+  args: {
+    episodes: readonly SleepRegularityEpisodeLike[];
+    timezone: string;
+  },
+  now: Date = new Date(),
+): Promise<LearnScheduleStyleResult> {
+  const sample = buildScheduleStyleSample({
+    episodes: args.episodes,
+    timezone: args.timezone,
+    nowMs: now.getTime(),
+  });
+  const scheduleStyle = deriveScheduleStyle(sample);
+  // A rotating sleeper's circular-mean mid-sleep mixes shift blocks into a
+  // meaningless average, so chronotype is only derived for the other styles.
+  const chronotype =
+    scheduleStyle !== null && scheduleStyle !== "rotating"
+      ? deriveChronotype(sample.baseline)
+      : null;
+
+  const store = resolveOwnerFactStore(runtime);
+  const current = await store.read();
+  const patch = resolveScheduleStylePatch(current, {
+    scheduleStyle,
+    chronotype,
+  });
+  if (!patch) {
+    return { wrote: false, updated: [], scheduleStyle, chronotype };
+  }
+
+  const provenance: OwnerFactProvenance = {
+    source: "agent_inferred",
+    recordedAt: now.toISOString(),
+    note: "learned from observed sleep regularity (schedule insight)",
+  };
+  await store.update(patch, provenance);
+
+  const updated: Array<"scheduleStyle" | "chronotype"> = [];
+  if (patch.scheduleStyle) updated.push("scheduleStyle");
+  if (patch.chronotype) updated.push("chronotype");
+
+  logger.info(
+    {
+      src: "lifeops:owner:schedule-style",
+      agentId: runtime.agentId,
+      updated,
+      scheduleStyle,
+      chronotype,
+      regularityClass: sample.regularity.regularityClass,
+      sampleCount: sample.regularity.sampleCount,
+    },
+    "[schedule-style] wrote learned schedule classification into owner facts",
+  );
+
+  return { wrote: true, updated, scheduleStyle, chronotype };
+}
+
+/**
+ * Production entry point: loads the persisted sleep-episode history for the
+ * classification window and delegates to the episode-driven writer. The
+ * timezone is the owner's stored fact (falling back to the host default) so
+ * wake minutes land in the owner's local clock.
+ */
+export async function learnScheduleStyleFacts(
+  runtime: IAgentRuntime,
+  now: Date = new Date(),
+): Promise<LearnScheduleStyleResult> {
+  const store = resolveOwnerFactStore(runtime);
+  const facts = await store.read();
+  const timezone = facts.timezone?.value ?? resolveDefaultTimeZone();
+  const repository = new LifeOpsRepository(runtime);
+  const episodes = await listHistoricalSleepEpisodes({
+    repository,
+    agentId: runtime.agentId,
+    nowMs: now.getTime(),
+    windowDays: SCHEDULE_STYLE_WINDOW_DAYS,
+  });
+  return learnScheduleStyleFromEpisodes(runtime, { episodes, timezone }, now);
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/schedule-style.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/schedule-style.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Tests for the scheduleStyle/chronotype owner-fact learner (issue #12284,
+ * WI-5): the pure classification (style mapping, rotating cluster detection,
+ * chronotype thresholds) and the full writer path over the real fact store
+ * (in-memory runtime cache), including the user-override and idempotency
+ * contracts. Episodes are synthesized in UTC so local-minute math is exact.
+ */
+
+import type { IAgentRuntime, UUID } from "@elizaos/core";
+import type { SleepRegularityEpisodeLike } from "@elizaos/plugin-health";
+import { describe, expect, it } from "vitest";
+import {
+  createOwnerFactStore,
+  registerOwnerFactStore,
+  resolveOwnerFactStore,
+} from "./fact-store.js";
+import {
+  buildScheduleStyleSample,
+  deriveChronotype,
+  deriveScheduleStyle,
+  detectRotatingWakePattern,
+} from "./schedule-style.js";
+import { learnScheduleStyleFromEpisodes } from "./schedule-style-writer.js";
+
+function makeCacheRuntime(): IAgentRuntime {
+  const cache = new Map<string, unknown>();
+  return {
+    agentId: "33333333-3333-3333-3333-333333333333" as UUID,
+    async getCache<T>(key: string): Promise<T | null> {
+      const value = cache.get(key);
+      return value === undefined ? null : (value as T);
+    },
+    async setCache<T>(key: string, value: T): Promise<boolean> {
+      cache.set(key, value);
+      return true;
+    },
+    async deleteCache(key: string): Promise<boolean> {
+      return cache.delete(key);
+    },
+  } as unknown as IAgentRuntime;
+}
+
+function makeRuntimeWithStore(): IAgentRuntime {
+  const runtime = makeCacheRuntime();
+  registerOwnerFactStore(runtime, createOwnerFactStore(runtime));
+  return runtime;
+}
+
+const NOW = new Date("2026-07-10T12:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+/**
+ * One overnight episode per day ending `daysAgo` days before NOW, sleeping
+ * from `bedHour` (previous evening, may exceed 24 for after-midnight) until
+ * `wakeHour`, with optional per-episode minute offsets to inject jitter.
+ */
+function episode(args: {
+  daysAgo: number;
+  bedHour: number;
+  wakeHour: number;
+  jitterMin?: number;
+}): SleepRegularityEpisodeLike {
+  const wakeDayStart = Date.UTC(2026, 6, 10, 0, 0, 0) - args.daysAgo * DAY_MS;
+  const jitterMs = (args.jitterMin ?? 0) * 60_000;
+  const wakeMs = wakeDayStart + args.wakeHour * 3_600_000 + jitterMs;
+  const bedMs = wakeDayStart - DAY_MS + args.bedHour * 3_600_000 + jitterMs;
+  return {
+    startAt: new Date(bedMs).toISOString(),
+    endAt: new Date(wakeMs).toISOString(),
+    cycleType: "overnight",
+  };
+}
+
+function regularWeek(): SleepRegularityEpisodeLike[] {
+  // Ten near-identical nights, 23:00 → 07:00 UTC.
+  return Array.from({ length: 10 }, (_, index) =>
+    episode({ daysAgo: index + 1, bedHour: 23, wakeHour: 7 }),
+  );
+}
+
+function chaoticWeek(): SleepRegularityEpisodeLike[] {
+  // Wake/bed times scattered across many hours with no two tight clusters.
+  const wakes = [5.5, 8.2, 11, 6.7, 9.3, 12.5, 7.8, 10.1];
+  const beds = [21, 25, 23.5, 26.5, 22, 24.5, 27, 23];
+  return wakes.map((wakeHour, index) =>
+    episode({
+      daysAgo: index + 1,
+      bedHour: beds[index] as number,
+      wakeHour,
+    }),
+  );
+}
+
+function rotatingShifts(): SleepRegularityEpisodeLike[] {
+  // Two shift blocks: four nights sleeping 23:00→07:00, then four "days"
+  // sleeping 11:00→19:00 — the classic rotating pattern.
+  const nights = Array.from({ length: 4 }, (_, index) =>
+    episode({ daysAgo: index + 1, bedHour: 23, wakeHour: 7 }),
+  );
+  const days = Array.from({ length: 4 }, (_, index) =>
+    episode({ daysAgo: index + 5, bedHour: 35, wakeHour: 19 }),
+  );
+  return [...nights, ...days];
+}
+
+describe("detectRotatingWakePattern (pure)", () => {
+  it("detects two tight wake clusters far apart", () => {
+    const wakes = [420, 421, 419, 425, 1140, 1141, 1138, 1145];
+    expect(detectRotatingWakePattern(wakes)).toBe(true);
+  });
+
+  it("rejects a single tight cluster", () => {
+    expect(detectRotatingWakePattern([418, 420, 422, 425, 430])).toBe(false);
+  });
+
+  it("rejects scattered wake times without cluster structure", () => {
+    expect(
+      detectRotatingWakePattern([330, 492, 660, 402, 558, 750, 468, 606]),
+    ).toBe(false);
+  });
+
+  it("rejects clusters that wrap midnight only when loose", () => {
+    // Tight cluster straddling midnight (23:50–00:10) + tight noon cluster:
+    // still rotating; the wraparound arc math must not split the first.
+    expect(
+      detectRotatingWakePattern([1430, 1435, 5, 10, 720, 722, 725, 728]),
+    ).toBe(true);
+  });
+
+  it("requires at least two samples per cluster", () => {
+    expect(detectRotatingWakePattern([420, 421, 422, 1140])).toBe(false);
+  });
+});
+
+describe("deriveScheduleStyle / deriveChronotype (pure)", () => {
+  it("classifies a consistent sleeper as regular", () => {
+    const sample = buildScheduleStyleSample({
+      episodes: regularWeek(),
+      timezone: "UTC",
+      nowMs: NOW.getTime(),
+    });
+    expect(deriveScheduleStyle(sample)).toBe("regular");
+  });
+
+  it("classifies a chaotic sleeper as irregular", () => {
+    const sample = buildScheduleStyleSample({
+      episodes: chaoticWeek(),
+      timezone: "UTC",
+      nowMs: NOW.getTime(),
+    });
+    expect(deriveScheduleStyle(sample)).toBe("irregular");
+  });
+
+  it("classifies block-rotating shifts as rotating", () => {
+    const sample = buildScheduleStyleSample({
+      episodes: rotatingShifts(),
+      timezone: "UTC",
+      nowMs: NOW.getTime(),
+    });
+    expect(deriveScheduleStyle(sample)).toBe("rotating");
+  });
+
+  it("returns null below the evidence threshold", () => {
+    const sample = buildScheduleStyleSample({
+      episodes: regularWeek().slice(0, 3),
+      timezone: "UTC",
+      nowMs: NOW.getTime(),
+    });
+    expect(deriveScheduleStyle(sample)).toBeNull();
+  });
+
+  it("ignores naps and open episodes when collecting wake minutes", () => {
+    const sample = buildScheduleStyleSample({
+      episodes: [
+        ...regularWeek(),
+        {
+          startAt: "2026-07-09T13:00:00.000Z",
+          endAt: "2026-07-09T14:00:00.000Z",
+          cycleType: "nap",
+        },
+        {
+          startAt: "2026-07-09T23:00:00.000Z",
+          endAt: null,
+          cycleType: "overnight",
+        },
+      ],
+      timezone: "UTC",
+      nowMs: NOW.getTime(),
+    });
+    expect(sample.wakeMinutesLocal).toHaveLength(10);
+  });
+
+  it("maps mid-sleep to early / intermediate / late chronotypes", () => {
+    const baseline = {
+      medianSleepDurationMin: 480,
+      bedtimeStddevMin: 10,
+      wakeStddevMin: 10,
+      sampleCount: 10,
+      windowDays: 28,
+    };
+    // Bed 21:00 wake 05:00 → mid-sleep 01:00.
+    expect(
+      deriveChronotype({
+        ...baseline,
+        medianBedtimeLocalHour: 21,
+        medianWakeLocalHour: 5,
+      }),
+    ).toBe("early");
+    // Bed 23:00 wake 07:00 → mid-sleep 03:00.
+    expect(
+      deriveChronotype({
+        ...baseline,
+        medianBedtimeLocalHour: 23,
+        medianWakeLocalHour: 7,
+      }),
+    ).toBe("intermediate");
+    // Bed 03:00 (27 normalized) wake 11:00 → mid-sleep 07:00.
+    expect(
+      deriveChronotype({
+        ...baseline,
+        medianBedtimeLocalHour: 27,
+        medianWakeLocalHour: 11,
+      }),
+    ).toBe("late");
+    expect(deriveChronotype(null)).toBeNull();
+  });
+});
+
+describe("learnScheduleStyleFromEpisodes (writer over the real store)", () => {
+  it("writes an irregular persona's scheduleStyle with agent_inferred provenance", async () => {
+    const runtime = makeRuntimeWithStore();
+    const result = await learnScheduleStyleFromEpisodes(
+      runtime,
+      { episodes: chaoticWeek(), timezone: "UTC" },
+      NOW,
+    );
+    expect(result.wrote).toBe(true);
+    expect(result.scheduleStyle).toBe("irregular");
+    expect(result.updated).toContain("scheduleStyle");
+
+    const facts = await resolveOwnerFactStore(runtime).read();
+    expect(facts.scheduleStyle?.value).toBe("irregular");
+    expect(facts.scheduleStyle?.provenance.source).toBe("agent_inferred");
+  });
+
+  it("writes regular + chronotype for a consistent persona", async () => {
+    const runtime = makeRuntimeWithStore();
+    const result = await learnScheduleStyleFromEpisodes(
+      runtime,
+      { episodes: regularWeek(), timezone: "UTC" },
+      NOW,
+    );
+    expect(result.wrote).toBe(true);
+    expect(result.scheduleStyle).toBe("regular");
+    // Bed 23:00 wake 07:00 → mid-sleep 03:00 → intermediate.
+    expect(result.chronotype).toBe("intermediate");
+
+    const facts = await resolveOwnerFactStore(runtime).read();
+    expect(facts.scheduleStyle?.value).toBe("regular");
+    expect(facts.chronotype?.value).toBe("intermediate");
+  });
+
+  it("classifies rotating shifts and skips the chronotype artifact", async () => {
+    const runtime = makeRuntimeWithStore();
+    const result = await learnScheduleStyleFromEpisodes(
+      runtime,
+      { episodes: rotatingShifts(), timezone: "UTC" },
+      NOW,
+    );
+    expect(result.wrote).toBe(true);
+    expect(result.scheduleStyle).toBe("rotating");
+    expect(result.chronotype).toBeNull();
+
+    const facts = await resolveOwnerFactStore(runtime).read();
+    expect(facts.scheduleStyle?.value).toBe("rotating");
+    expect(facts.chronotype).toBeUndefined();
+  });
+
+  it("is idempotent: an unchanged classification writes nothing", async () => {
+    const runtime = makeRuntimeWithStore();
+    const first = await learnScheduleStyleFromEpisodes(
+      runtime,
+      { episodes: regularWeek(), timezone: "UTC" },
+      NOW,
+    );
+    expect(first.wrote).toBe(true);
+    const second = await learnScheduleStyleFromEpisodes(
+      runtime,
+      { episodes: regularWeek(), timezone: "UTC" },
+      NOW,
+    );
+    expect(second.wrote).toBe(false);
+    expect(second.updated).toEqual([]);
+  });
+
+  it("updates when the classification meaningfully changes", async () => {
+    const runtime = makeRuntimeWithStore();
+    await learnScheduleStyleFromEpisodes(
+      runtime,
+      { episodes: regularWeek(), timezone: "UTC" },
+      NOW,
+    );
+    const shifted = await learnScheduleStyleFromEpisodes(
+      runtime,
+      { episodes: chaoticWeek(), timezone: "UTC" },
+      NOW,
+    );
+    expect(shifted.wrote).toBe(true);
+    const facts = await resolveOwnerFactStore(runtime).read();
+    expect(facts.scheduleStyle?.value).toBe("irregular");
+  });
+
+  it("never clobbers a user-owned scheduleStyle", async () => {
+    const runtime = makeRuntimeWithStore();
+    const store = resolveOwnerFactStore(runtime);
+    await store.update(
+      { scheduleStyle: "regular" },
+      { source: "first_run", recordedAt: "2026-07-01T00:00:00.000Z" },
+    );
+    const result = await learnScheduleStyleFromEpisodes(
+      runtime,
+      { episodes: chaoticWeek(), timezone: "UTC" },
+      NOW,
+    );
+    expect(result.scheduleStyle).toBe("irregular");
+    const facts = await store.read();
+    expect(facts.scheduleStyle?.value).toBe("regular");
+    expect(facts.scheduleStyle?.provenance.source).toBe("first_run");
+  });
+
+  it("writes nothing on insufficient evidence and keeps the store empty", async () => {
+    const runtime = makeRuntimeWithStore();
+    const result = await learnScheduleStyleFromEpisodes(
+      runtime,
+      { episodes: regularWeek().slice(0, 3), timezone: "UTC" },
+      NOW,
+    );
+    expect(result.wrote).toBe(false);
+    expect(result.scheduleStyle).toBeNull();
+    const facts = await resolveOwnerFactStore(runtime).read();
+    expect(facts.scheduleStyle).toBeUndefined();
+    expect(facts.chronotype).toBeUndefined();
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/schedule-style.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/schedule-style.ts
@@ -1,0 +1,278 @@
+/**
+ * Pure derivation of the `scheduleStyle` / `chronotype` owner-facts from the
+ * owner's observed sleep episodes (issue #12284, WI-5). The heavy lifting —
+ * SRI, circular stddevs, personal baseline — is plugin-health's
+ * `computeSleepRegularity` / `computePersonalBaseline`; this module maps those
+ * already-computed classes onto the queryable owner-fact vocabulary and adds
+ * the one distinction they cannot express: a *rotating* (shift-work) pattern,
+ * whose wake times form two internally-tight clusters far apart on the clock,
+ * versus a merely *irregular* (noisy) one.
+ *
+ * Everything here is a pure function over episode data — no store, no clock,
+ * no runtime — so the classification rules are unit-testable in isolation.
+ * The runtime binding lives in `schedule-style-writer.ts`, which follows the
+ * same user-override + idempotency contract as the window learner
+ * (`activity-profile/window-learning.ts`).
+ */
+
+import type {
+  LifeOpsPersonalBaseline,
+  LifeOpsScheduleRegularity,
+  SleepRegularityEpisodeLike,
+} from "@elizaos/plugin-health";
+import {
+  computePersonalBaseline,
+  computeSleepRegularity,
+} from "@elizaos/plugin-health";
+import { getZonedDateParts } from "../time.js";
+import type {
+  OwnerChronotype,
+  OwnerFacts,
+  OwnerFactsPatch,
+  OwnerScheduleStyle,
+} from "./fact-store.js";
+
+/** Inputs the style/chronotype derivation consumes, one analysis pass. */
+export interface ScheduleStyleSample {
+  regularity: LifeOpsScheduleRegularity;
+  baseline: LifeOpsPersonalBaseline | null;
+  /**
+   * Local wake minute-of-day for each qualifying episode, in episode order.
+   * Feeds the rotating-pattern cluster detection.
+   */
+  wakeMinutesLocal: readonly number[];
+}
+
+const MINUTES_PER_DAY = 24 * 60;
+
+/** Minimum qualifying-episode duration, mirroring plugin-health's filter. */
+const MIN_EPISODE_MINUTES = 180;
+
+/** Rotating detection: each wake cluster must span at most this many minutes. */
+const ROTATING_CLUSTER_MAX_SPAN_MIN = 120;
+
+/** Rotating detection: clusters must sit at least this far apart (minutes). */
+const ROTATING_MIN_SEPARATION_MIN = 240;
+
+/** Rotating detection: each cluster needs at least this many wake samples. */
+const ROTATING_MIN_CLUSTER_SIZE = 2;
+
+/**
+ * Chronotype thresholds on the mid-sleep hour, approximating MCTQ terciles:
+ * mid-sleep before 02:30 reads as an early type, after 04:30 as a late type.
+ */
+const CHRONOTYPE_EARLY_MAX_MIDSLEEP_HOUR = 2.5;
+const CHRONOTYPE_LATE_MIN_MIDSLEEP_HOUR = 4.5;
+
+/**
+ * Build a `ScheduleStyleSample` from raw sleep episodes: runs plugin-health's
+ * regularity + baseline computations and extracts the qualifying local wake
+ * minutes (same qualification rule plugin-health applies: closed, non-nap,
+ * ended by `nowMs`, at least 3h long) for the rotating detector.
+ */
+export function buildScheduleStyleSample(args: {
+  episodes: readonly SleepRegularityEpisodeLike[];
+  timezone: string;
+  nowMs: number;
+}): ScheduleStyleSample {
+  const regularity = computeSleepRegularity({
+    episodes: args.episodes,
+    timezone: args.timezone,
+    nowMs: args.nowMs,
+  });
+  const baseline = computePersonalBaseline({
+    episodes: args.episodes,
+    timezone: args.timezone,
+    nowMs: args.nowMs,
+  });
+  const wakeMinutesLocal: number[] = [];
+  for (const episode of args.episodes) {
+    if (episode.cycleType === "nap" || episode.endAt === null) continue;
+    const startMs = Date.parse(episode.startAt);
+    const endMs = Date.parse(episode.endAt);
+    if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) continue;
+    if (endMs <= startMs || endMs > args.nowMs) continue;
+    if ((endMs - startMs) / 60_000 < MIN_EPISODE_MINUTES) continue;
+    const parts = getZonedDateParts(new Date(endMs), args.timezone);
+    wakeMinutesLocal.push(parts.hour * 60 + parts.minute);
+  }
+  return { regularity, baseline, wakeMinutesLocal };
+}
+
+/**
+ * Detect a rotating (shift-work-like) wake pattern: the wake minutes split
+ * into exactly two internally-tight clusters separated by a large arc on the
+ * 24h circle. Implementation: sort the minutes, take the two largest circular
+ * gaps as the cluster boundary; both resulting arcs must be populated, tight,
+ * and far apart. A merely noisy sleeper fails the tightness test; a
+ * consistent sleeper fails the two-populated-clusters test.
+ */
+export function detectRotatingWakePattern(
+  wakeMinutes: readonly number[],
+): boolean {
+  if (wakeMinutes.length < ROTATING_MIN_CLUSTER_SIZE * 2) return false;
+  const sorted = [...wakeMinutes].sort((left, right) => left - right);
+  const n = sorted.length;
+
+  // Circular gap after sorted[i]; the final entry wraps to the first.
+  const gaps: number[] = [];
+  for (let index = 0; index < n; index += 1) {
+    const current = sorted[index] as number;
+    const next =
+      index === n - 1
+        ? (sorted[0] as number) + MINUTES_PER_DAY
+        : (sorted[index + 1] as number);
+    gaps.push(next - current);
+  }
+
+  let firstGapIndex = 0;
+  let secondGapIndex = -1;
+  for (let index = 1; index < n; index += 1) {
+    const gap = gaps[index] as number;
+    if (gap > (gaps[firstGapIndex] as number)) {
+      secondGapIndex = firstGapIndex;
+      firstGapIndex = index;
+    } else if (
+      secondGapIndex === -1 ||
+      gap > (gaps[secondGapIndex] as number)
+    ) {
+      secondGapIndex = index;
+    }
+  }
+  if (secondGapIndex === -1) return false;
+
+  const [cutA, cutB] = [firstGapIndex, secondGapIndex].sort(
+    (left, right) => left - right,
+  ) as [number, number];
+
+  // Arc 1: indices (cutA, cutB]; arc 2: (cutB, n-1] ∪ [0, cutA] (wrapping).
+  const clusterA = sorted.slice(cutA + 1, cutB + 1);
+  const clusterB = [...sorted.slice(cutB + 1), ...sorted.slice(0, cutA + 1)];
+  if (
+    clusterA.length < ROTATING_MIN_CLUSTER_SIZE ||
+    clusterB.length < ROTATING_MIN_CLUSTER_SIZE
+  ) {
+    return false;
+  }
+
+  // Each arc's span is the total circular extent between its extremes, i.e.
+  // everything except the two boundary gaps and the other arc.
+  const spanA = arcSpan(clusterA);
+  const spanB = arcSpan(clusterB);
+  if (
+    spanA > ROTATING_CLUSTER_MAX_SPAN_MIN ||
+    spanB > ROTATING_CLUSTER_MAX_SPAN_MIN
+  ) {
+    return false;
+  }
+
+  const separation = Math.min(
+    gaps[firstGapIndex] as number,
+    gaps[secondGapIndex] as number,
+  );
+  return separation >= ROTATING_MIN_SEPARATION_MIN;
+}
+
+/**
+ * Circular extent of a cluster built from consecutive sorted minutes (the
+ * second cluster may wrap midnight, so spans are computed modulo 24h from
+ * first to last member).
+ */
+function arcSpan(cluster: readonly number[]): number {
+  if (cluster.length <= 1) return 0;
+  const first = cluster[0] as number;
+  const last = cluster[cluster.length - 1] as number;
+  return (
+    (((last - first) % MINUTES_PER_DAY) + MINUTES_PER_DAY) % MINUTES_PER_DAY
+  );
+}
+
+/**
+ * Map the computed regularity (plus the rotating cluster check) onto the
+ * owner-fact vocabulary. Returns `null` on insufficient data — a null never
+ * clears a previously-learned value; classifications only move on evidence.
+ */
+export function deriveScheduleStyle(
+  sample: ScheduleStyleSample,
+): OwnerScheduleStyle | null {
+  switch (sample.regularity.regularityClass) {
+    case "insufficient_data":
+      return null;
+    case "very_regular":
+    case "regular":
+      return "regular";
+    case "irregular":
+    case "very_irregular":
+      // A block-rotating shift pattern can land in either irregular class
+      // (its SRI depends on block length), so the cluster test runs for both.
+      return detectRotatingWakePattern(sample.wakeMinutesLocal)
+        ? "rotating"
+        : "irregular";
+  }
+}
+
+/**
+ * Derive the chronotype label from the personal baseline's mid-sleep point.
+ * Returns `null` without a baseline or with a degenerate (zero-length) sleep
+ * duration. Callers should skip chronotype for rotating sleepers — a circular
+ * mean over mixed shift blocks is an artifact, not a trait.
+ */
+export function deriveChronotype(
+  baseline: LifeOpsPersonalBaseline | null,
+): OwnerChronotype | null {
+  if (!baseline) return null;
+  const bedWall = ((baseline.medianBedtimeLocalHour % 24) + 24) % 24;
+  const wake = baseline.medianWakeLocalHour;
+  const durationHours = (((wake - bedWall) % 24) + 24) % 24;
+  if (durationHours === 0) return null;
+  const midSleep = (bedWall + durationHours / 2) % 24;
+  // Fold onto [-12, 12) around midnight so a pre-midnight mid-sleep (extreme
+  // early type) compares below the early threshold instead of above 22.
+  const folded = midSleep >= 12 ? midSleep - 24 : midSleep;
+  if (folded < CHRONOTYPE_EARLY_MAX_MIDSLEEP_HOUR) return "early";
+  if (folded > CHRONOTYPE_LATE_MIN_MIDSLEEP_HOUR) return "late";
+  return "intermediate";
+}
+
+/**
+ * Provenance sources that represent an explicit user choice; a fact carrying
+ * one is never overwritten by learning (same contract as window-learning).
+ */
+const USER_OWNED_SOURCES = new Set(["first_run", "profile_save"]);
+
+/**
+ * Decide which derived classifications should actually be written, honouring
+ * the user-override and idempotency invariants. Returns `null` when nothing
+ * should change, so periodic callers converge and stop writing.
+ */
+export function resolveScheduleStylePatch(
+  current: OwnerFacts,
+  derived: {
+    scheduleStyle: OwnerScheduleStyle | null;
+    chronotype: OwnerChronotype | null;
+  },
+): OwnerFactsPatch | null {
+  const patch: OwnerFactsPatch = {};
+
+  if (derived.scheduleStyle !== null) {
+    const existing = current.scheduleStyle;
+    const userOwned =
+      existing !== undefined &&
+      USER_OWNED_SOURCES.has(existing.provenance.source);
+    if (!userOwned && existing?.value !== derived.scheduleStyle) {
+      patch.scheduleStyle = derived.scheduleStyle;
+    }
+  }
+
+  if (derived.chronotype !== null) {
+    const existing = current.chronotype;
+    const userOwned =
+      existing !== undefined &&
+      USER_OWNED_SOURCES.has(existing.provenance.source);
+    if (!userOwned && existing?.value !== derived.chronotype) {
+      patch.chronotype = derived.chronotype;
+    }
+  }
+
+  return Object.keys(patch).length > 0 ? patch : null;
+}

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -1419,11 +1419,13 @@ export {
 export {
   type EscalationRule,
   getOwnerFactStore,
+  type OwnerChronotype,
   type OwnerFactEntry,
   type OwnerFactProvenance,
   type OwnerFactProvenanceSource,
   type OwnerFactWindow,
   type OwnerQuietHours,
+  type OwnerScheduleStyle,
   ownerFactsToView,
   type PolicyPatchEscalationRule,
   type PolicyPatchReminderIntensity,


### PR DESCRIPTION
# feat(#12284): scheduleStyle owner-fact from schedule-insight regularity (WI-5)

Advances #12284 (work item 5). WI-3 (travelActive) already landed separately in #13211; this PR is WI-5 only.

## What landed

- **`OwnerScheduleStyle` (`"regular" | "irregular" | "rotating"`) and `OwnerChronotype` (`"early" | "intermediate" | "late"`) owner-facts** in `OwnerFactStore` (`plugins/plugin-personal-assistant/src/lifeops/owner/fact-store.ts`): typed entries with provenance, patch/normalize/clone/persist support. Structural facts only — no prompt branching (AGENTS.md LifeOps rules).
- **Pure derivation module** `src/lifeops/owner/schedule-style.ts`: maps plugin-health's already-computed `computeSleepRegularity` classes onto the owner-fact vocabulary (`very_regular`/`regular` → `regular`, `irregular`/`very_irregular` → `irregular`), adds the one distinction they cannot express — a **rotating** (shift-work) wake pattern detected as two internally-tight wake clusters far apart on the 24h circle — and derives chronotype from `computePersonalBaseline`'s mid-sleep point (MCTQ-tercile-style thresholds). All pure functions; unit-testable without a store or clock.
- **Runtime writer** `src/lifeops/owner/schedule-style-writer.ts`: loads the persisted sleep-episode history (`listHistoricalSleepEpisodes`, 28-day window), derives the classes, and writes any delta through `OwnerFactStore.update` with `agent_inferred` provenance. Copies the window-learner's contracts: **idempotent** (unchanged classification writes nothing) and **user-override safe** (`first_run`/`profile_save` values are never clobbered). Chronotype is intentionally skipped for rotating sleepers — a circular-mean mid-sleep over mixed shift blocks is an artifact, not a trait. Insufficient evidence (`insufficient_data`) never clears a previously learned value.
- **Wiring**: called from the existing activity-profile proactive worker tick (`src/activity-profile/proactive-worker.ts`), right after the rhythm-window learner — the existing periodic path, **no new scheduler**. Best-effort guarded (`error-policy:J7`): a transient store/DB failure logs + continues the tick.
- **Exports**: `OwnerScheduleStyle` / `OwnerChronotype` types from `src/plugin.ts`.
- Tests: `src/lifeops/owner/schedule-style.test.ts` — 18 tests covering the pure classification (rotating cluster detection incl. midnight wraparound, style mapping, chronotype thresholds/folding) and the full writer path over the real fact store: irregular persona → queryable `scheduleStyle="irregular"` with `agent_inferred` provenance; regular persona → `regular` + chronotype; rotating persona → `rotating` with chronotype skipped; **idempotency** (second identical pass writes nothing); classification change → update; user-owned fact never clobbered; insufficient evidence → no write.

## Verification

- `schedule-style.test.ts`: **18/18 passed** (vitest).
- Neighboring suites over the touched seams: `travel-active-derivation.test.ts` + `proactive-worker.test.ts` + `window-learning.test.ts`: **3 files, 37/37 passed**.
- Full `plugins/plugin-personal-assistant` suite: **Tests 8 failed | 1112 passed | 5 skipped (1125)**; Test Files 13 failed | 130 passed (143). Every failure is pre-existing (see below); none touch this diff's files.
- `plugins/plugin-scheduling` suite: **19 files, 241/241 passed** (consumer of the owner-facts view; untouched by this diff).
- Full `bun run verify`: verify green except pre-existing develop failures app#typecheck/electrobun#typecheck (untouched by this PR) **plus additional pre-existing develop reds merged since that baseline** — turbo typecheck+lint ran to completion with `--continue`: **567/578 tasks green**, including `plugin-personal-assistant` typecheck+lint, `plugin-scheduling`, `plugin-health`. All 11 failing tasks are in packages whose trees are byte-identical to `origin/develop` on this branch (`git diff origin/develop...HEAD` outside `plugins/plugin-personal-assistant/` + `.github/` is empty):
  - `plugin-discord#typecheck` + its project-reference cascades `agent#typecheck`, `app-core#typecheck`: `messages.ts(1225-1226) TS2339 platformMessageId not on MemoryMetadata`, introduced by develop commit ac05e2096 (#13054).
  - `tui#lint`: `useNodejsImportProtocol` errors in `src/autocomplete.ts`, introduced by 07266319b (#12961).
  - `electrobun#lint` (1 error), `plugin-computeruse#lint` (2 errors): develop-state lint errors.
  - `plugin-sub-agent-claude-code#typecheck`: 35 TS6059 rootDir/project-reference errors resolving `plugin-remote-manifest`/`security` sources.
  - `app#typecheck`, `electrobun#typecheck`: the documented known-red develop baseline.
  - `plugin-calendar#typecheck` and `plugin-capacitor-bridge#typecheck` failed only on the first pass (unbuilt-declaration ordering under the repo's circular-dependency warning) and **pass on re-run** with dependencies built.
- Remaining verify steps: `check:agents-claude` PASS, `audit:type-safety-ratchet` PASS, `audit:error-policy-ratchet` PASS (explicitly reports my 5 touched files clean), `audit:build-model` PASS, `audit:tee-secret-leak` PASS, `audit:scripts` PASS, `audit:test-realness` PASS (report-only), `typecheck:dist` PASS. `audit:turbo-build-deps` FAILS on pre-existing phantom `#build` overrides for example packages — no `package.json`/`turbo.json` is touched by this PR, so the config state is develop's own.

### Pre-existing failures (reproduced on clean origin/develop, unrelated to this diff)

With this branch's work removed (clean `origin/develop` @ b24dec831 in the same worktree), the exact same failure set reproduces:

- `src/actions/life-reminder-datetime.test.ts` — 1 failed ("blocks broad emotional delete-everything requests before any destructive call")
- `src/components/BlockerSettingsCards.test.tsx` — 2 failed (Android app-blocker card tests)
- `src/lifeops/domains/reminders-service.process-scheduled-work.test.ts` — 5 failed (subsystem-failure collection tests)
- Isolated re-run of those 3 files on clean develop: `Tests 8 failed | 29 passed (37)` — identical test names.
- The 10 remaining "failed" test FILES are `(0 test)` env-gated files (e.g. `lifeops-prompt-benchmark*.test.ts`, `scheduler.no-reply-*.test.ts`, `plugin.test.ts`); the identical set of 10 appears on the clean-develop run.

## Evidence (PR_EVIDENCE.md rows)

- **Domain artifacts**: `.github/issue-evidence/12284-schedule-style-owner-fact.md` — verbatim transcript of the real writer driving the real `OwnerFactStore`: irregular/regular/rotating personas, the idempotent re-run (`wrote:false`), the user-override protection, and the exact persisted fact entries with `agent_inferred` provenance. Reviewed by hand — the store rows show the correct values, provenance sources, and timestamps.
- **Backend logs**: the writer logs `[schedule-style] wrote learned schedule classification into owner facts` (structured, `src: lifeops:owner:schedule-style`) on every delta write; vitest suppresses logger output in the captured runs, so the transcript above (writer results + store rows) is the observable proof of the code path firing.
- **Real LLM trajectory**: N/A — no model calls, prompts, providers, or action behavior changed; the classification is deterministic math over persisted sleep episodes.
- **Frontend logs / screenshots / video / audio**: N/A — no UI surface touched.

## Deviations from the issue text

- WI-3 (travelActive writer + tz-change detection) was dropped from this PR's scope: #13211 already implemented it (activeTravel record + derivation + three writers). This PR builds WI-5 on top of that merged state and does not touch the travel paths.
- `chronotype` is written alongside `scheduleStyle` (the issue offers "and/or"); it is skipped for rotating sleepers by design (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
