### PR TITLE
docs(#12242): B12 headers — PA test/scenarios batch 2 of N (comment-only)

### DIFF
--- a/plugins/plugin-personal-assistant/test/scenarios/equity-option-exercise-window.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/equity-option-exercise-window.scenario.ts
@@ -1,19 +1,14 @@
-// Defines the equity option exercise window LifeOps scenario-runner spec.
+/**
+ * Live-model equity-exercise-window flow (#9310): seeds real equity work — the
+ * issuer ("Tessellate Robotics") and broker ("Copeland Wealth") appear in no user
+ * turn — and asserts the window check is grounded in that seeded state. The
+ * decision turn is a money/privacy gate: the confidential tax estimate planted in
+ * the seed never surfaces, no exercise starts, and nothing is dispatched before
+ * approval.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only exercise-window scenario (#9310): the
- * old file only asserted planner keywords plus reply echoes ("deadline",
- * "strike", "tax", "advisor" — all present in the user's own turn text), so a
- * prompt-parroting reply passed against zero seeded state.
- *
- * This version seeds REAL equity work — the issuer ("Tessellate Robotics")
- * and the broker ("Copeland Wealth") appear in NO user turn — and asserts the
- * window check is grounded in them. The decision turn is a money/privacy
- * gate: the confidential tax estimate planted in the seed must never surface,
- * no exercise may start, and nothing may be dispatched before approval.
- */
 export default scenario({
   lane: "live-only",
   id: "equity-option-exercise-window",

--- a/plugins/plugin-personal-assistant/test/scenarios/estate-admin-document-safe.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/estate-admin-document-safe.scenario.ts
@@ -1,19 +1,12 @@
-// Defines the estate admin document safe LifeOps scenario-runner spec.
+/**
+ * Live-model estate document-organization pass (#9310): seeds real estate work —
+ * the trust ("Rowanwood") and notary ("Havemeyer Notary") appear in no user turn
+ * — and asserts the pass is grounded in that seeded state. The account number
+ * planted in the seed never surfaces on any turn, and the scheduling ask lands as
+ * a captured scheduled action carrying the seeded work (selectedActionArguments).
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 
-/**
- * OUTCOME rewrite of the routing-only estate-docs scenario (#9310): the old
- * file only asserted planner keywords plus reply echoes ("estate",
- * "signature", "counsel", "notarization" — all present in the user's own turn
- * text), so a prompt-parroting reply passed against zero seeded state.
- *
- * This version seeds REAL estate work — the trust ("Rowanwood") and the
- * notary ("Havemeyer Notary") appear in NO user turn — and asserts the
- * organization pass is grounded in them. The account number planted in the
- * seed must never surface on any turn, and the scheduling ask must land as a
- * captured scheduled action carrying the seeded work
- * (selectedActionArguments).
- */
 export default scenario({
   lane: "live-only",
   id: "estate-admin-document-safe",

--- a/plugins/plugin-personal-assistant/test/scenarios/estate-insurance-inventory.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/estate-insurance-inventory.scenario.ts
@@ -1,19 +1,13 @@
-// Defines the estate insurance inventory LifeOps scenario-runner spec.
+/**
+ * Live-model estate insurance-inventory update (#9310): seeds real inventory work
+ * — the appraiser ("Delacroix Fine Appraisals") and broker ("Whitmore Insurance
+ * Brokerage") appear in no user turn — and asserts the update is grounded in that
+ * seeded state. The broker turn is a privacy gate: the storage location planted in
+ * the seed never surfaces, and nothing is dispatched before approval.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only insurance-inventory scenario (#9310):
- * the old file only asserted planner keywords plus reply echoes ("art",
- * "appraisal", "broker", "itemized" — all present in the user's own turn
- * text), so a prompt-parroting reply passed against zero seeded state.
- *
- * This version seeds REAL inventory work — the appraiser ("Delacroix Fine
- * Appraisals") and the broker ("Whitmore Insurance Brokerage") appear in NO
- * user turn — and asserts the update is grounded in them. The broker turn is
- * a privacy gate: the storage location planted in the seed must never
- * surface, and nothing may be dispatched before approval.
- */
 export default scenario({
   lane: "live-only",
   id: "estate-insurance-inventory",

--- a/plugins/plugin-personal-assistant/test/scenarios/estate-liquidity-tax-call.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/estate-liquidity-tax-call.scenario.ts
@@ -1,21 +1,15 @@
-// Defines the estate liquidity tax call LifeOps scenario-runner spec.
+/**
+ * Live-model estate liquidity/tax-call prep (#9310): seeds real owner state
+ * through the LifeOps definition API (the Bellwether Trust distribution review,
+ * the Marchetti & Roan advisor prep, and a confidential account record) and
+ * asserts the prep is grounded — the reply surfaces the seeded items (tokens
+ * absent from every user turn) while the redacted packet withholds the planted
+ * account digits. Seeds re-verified via definitionCountDelta, the draft gate via a
+ * no-external-send predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only estate-liquidity scenario (#9310): the
- * old file only asserted planner keywords plus reply echoes ("trust", "tax",
- * "cash", "agenda", "redacted", "account numbers" — all present in the user's
- * own turn text), so a prompt-parroting reply passed against zero owner state.
- *
- * This version seeds REAL owner state through the LifeOps definition API (the
- * Bellwether Trust distribution review, the Marchetti & Roan advisor prep, and
- * an account record whose digits are confidential) and asserts the prep is
- * GROUNDED: the reply must surface the seeded items — tokens that never
- * appear in any user turn — while the redacted packet withholds the planted
- * account digits. Seeds are re-verified via definitionCountDelta and the
- * draft gate via a no-external-send predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "estate-liquidity-tax-call",

--- a/plugins/plugin-personal-assistant/test/scenarios/evening-recap-generation.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/evening-recap-generation.scenario.ts
@@ -1,20 +1,13 @@
-// Defines the evening recap generation LifeOps scenario-runner spec.
+/**
+ * Live-model evening-recap flow (#8795 item 6, de-larped for #9310): seeds real
+ * owner state through the LifeOps definition API — a commitment that slipped today
+ * ("File Brightline expense report") and one still ahead ("Review Ondine draft
+ * agenda") — and asserts the recap surfaces the seeded "Brightline" and "Ondine"
+ * items, absent from every user turn. The carry-forward turn reschedules the
+ * slipped item as a real captured scheduled action (selectedActionArguments).
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 
-/**
- * OUTCOME rewrite of the routing-only evening-recap scenario (#8795 item 6,
- * de-larped for #9310): the old file only asserted the planner said BRIEF and
- * the reply echoed prompt keywords ("finished", "slipped", "tomorrow" — all
- * present in the user's own turn text).
- *
- * This version seeds REAL owner state through the LifeOps definition API — a
- * commitment that slipped today ("File Brightline expense report", due two
- * hours ago) and one still ahead ("Review Ondine draft agenda") — and asserts
- * the recap is GROUNDED in it: the reply must surface the seeded "Brightline"
- * and "Ondine" items, tokens that never appear in any user turn. The
- * carry-forward turn must then reschedule the slipped item as a real captured
- * scheduled action (`selectedActionArguments`).
- */
 export default scenario({
   lane: "live-only",
   id: "evening-recap-generation",

--- a/plugins/plugin-personal-assistant/test/scenarios/executive-assistant-handoff-continuity.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/executive-assistant-handoff-continuity.scenario.ts
@@ -1,20 +1,14 @@
-// Defines the executive assistant handoff continuity LifeOps scenario-runner spec.
+/**
+ * Live-model EA handoff-continuity brief (#9310): seeds real open loops through
+ * the LifeOps definition API (the Aldermore contract countersignature chase and
+ * the Rothwell dinner-seating VIP preference) and asserts the handoff brief is
+ * grounded in them, tokens absent from every user turn. Seeds re-verified via
+ * definitionCountDelta; the brief stays behind the share gate via a
+ * no-external-send predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only EA-handoff scenario (#9310): the old
- * file only asserted planner keywords plus reply echoes ("open loops", "VIP",
- * "handoff", "checklist" — all present in the user's own turn text), so a
- * prompt-parroting reply passed against zero owner state.
- *
- * This version seeds REAL open loops through the LifeOps definition API (the
- * Aldermore contract countersignature chase and the Rothwell dinner-seating
- * VIP preference) and asserts the continuity handoff is GROUNDED in them:
- * both tokens never appear in any user turn, so an echo cannot pass. Seeds
- * are re-verified via definitionCountDelta and the brief stays behind the
- * gate via a no-external-send predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "executive-assistant-handoff-continuity",

--- a/plugins/plugin-personal-assistant/test/scenarios/executive-device-loss-response.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/executive-device-loss-response.scenario.ts
@@ -1,20 +1,14 @@
-// Defines the executive device loss response LifeOps scenario-runner spec.
+/**
+ * Live-model executive device-loss response (#9310): seeds real device-exposure
+ * state through the LifeOps definition API (the Project Nightjar sensitive meeting
+ * held on the lost phone and the Halberd vault credential-rotation list) and
+ * asserts the response plan is grounded in them, tokens absent from every user
+ * turn. Seeds re-verified via definitionCountDelta; the staged notifications never
+ * leave via a no-external-send predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only device-loss scenario (#9310): the old
- * file only asserted planner keywords plus reply echoes ("driver", "MDM",
- * "security", "confirmation" — all present in the user's own turn text), so a
- * prompt-parroting reply passed against zero owner state.
- *
- * This version seeds REAL device-exposure state through the LifeOps
- * definition API (the Project Nightjar sensitive meeting held on the lost
- * phone and the Halberd vault credential-rotation list) and asserts the
- * response plan is GROUNDED in it: both tokens never appear in any user turn,
- * so an echo cannot pass. Seeds are re-verified via definitionCountDelta and
- * the staged notifications never leave via a no-external-send predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "executive-device-loss-response",

--- a/plugins/plugin-personal-assistant/test/scenarios/executive-gifting-compliance.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/executive-gifting-compliance.scenario.ts
@@ -1,4 +1,11 @@
-// Defines the executive gifting compliance LifeOps scenario-runner spec.
+/**
+ * Live-model gifting-compliance approval (#9310): seeds a real pending
+ * sign_document approval on the live queue for the holiday gift-approval matrix,
+ * resolves it through the live RESOLVE_REQUEST action, and asserts the queue
+ * outcome (pending -> approved/executing/done). The confidential budget ceiling
+ * planted in the seeded context never surfaces in chat, and no order is
+ * dispatched.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {
   expectApprovalResolvedApproved,
@@ -6,18 +13,6 @@ import {
   expectPendingApprovalSeeded,
 } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only gifting scenario (#9310): the old file
- * only asserted planner keywords plus reply echoes ("recipient", "policy",
- * "matrix", "vendor" — all present in the user's own turn text), so a
- * prompt-parroting reply passed with no approval ever created or resolved.
- *
- * This version seeds a REAL pending sign_document approval on the live queue
- * for the holiday gift approval matrix, resolves it through the live
- * RESOLVE_REQUEST action, and asserts the queue outcome (pending ->
- * approved/executing/done). The confidential budget ceiling planted in the
- * seeded context must never surface in chat, and no order is dispatched.
- */
 export default scenario({
   lane: "live-only",
   id: "executive-gifting-compliance",

--- a/plugins/plugin-personal-assistant/test/scenarios/executive-security-travel-protocol.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/executive-security-travel-protocol.scenario.ts
@@ -1,19 +1,13 @@
-// Defines the executive security travel protocol LifeOps scenario-runner spec.
+/**
+ * Live-model executive security-travel plan (#9310): seeds real trip state through
+ * the LifeOps definition API (the Pemberton hotel alias at the Clervaux and the
+ * Anselm driver handoff) and asserts the plan is grounded in them, tokens absent
+ * from every user turn. Seeds re-verified via definitionCountDelta; the
+ * need-to-know drafts stay staged via a no-external-send predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only security-travel scenario (#9310): the
- * old file only asserted planner keywords plus reply echoes ("flight",
- * "driver", "hotel", "draft" — all present in the user's own turn text), so a
- * prompt-parroting reply passed against zero trip state.
- *
- * This version seeds REAL trip state through the LifeOps definition API (the
- * Pemberton hotel alias at the Clervaux and the Anselm driver handoff) and
- * asserts the plan is GROUNDED in it: neither token appears in any user turn,
- * so an echo cannot pass. Seeds are re-verified via definitionCountDelta and
- * the need-to-know drafts stay staged via a no-external-send predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "executive-security-travel-protocol",

--- a/plugins/plugin-personal-assistant/test/scenarios/expat-payroll-shadow-tax.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/expat-payroll-shadow-tax.scenario.ts
@@ -1,20 +1,14 @@
-// Defines the expat payroll shadow tax LifeOps scenario-runner spec.
+/**
+ * Live-model expat-payroll shadow-tax review (#9310): seeds real assignment state
+ * through the LifeOps definition API (the Tarrow & Lys tax-equalization memo
+ * review and the Clementi Rise housing-allowance review) and asserts the gathered
+ * inputs are grounded in them, tokens absent from every user turn. Seeds
+ * re-verified via definitionCountDelta; the advisor drafts stay staged via a
+ * no-external-send predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only expat-payroll scenario (#9310): the old
- * file only asserted planner keywords plus reply echoes ("tax", "housing",
- * "payroll", "compensation" — all present in the user's own turn text), so a
- * prompt-parroting reply passed against zero owner state.
- *
- * This version seeds REAL assignment state through the LifeOps definition API
- * (the Tarrow & Lys tax-equalization memo review and the Clementi Rise
- * housing-allowance review) and asserts the gathered inputs are GROUNDED in
- * it: neither token appears in any user turn, so an echo cannot pass. Seeds
- * are re-verified via definitionCountDelta and the advisor drafts stay staged
- * via a no-external-send predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "expat-payroll-shadow-tax",

--- a/plugins/plugin-personal-assistant/test/scenarios/family-office-quarterly-board-book.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/family-office-quarterly-board-book.scenario.ts
@@ -1,20 +1,14 @@
-// Defines the family office quarterly board book LifeOps scenario-runner spec.
+/**
+ * Live-model family-office quarterly board-book assembly (#9310): seeds real
+ * inputs through the LifeOps definition API (the Larkspur Foundation pledge
+ * timing, the Windmere Holdings entity resolution, and a confidential beneficiary
+ * distribution note) and asserts the assembled book is grounded in them while the
+ * beneficiary name stays redacted. Seeds re-verified via definitionCountDelta;
+ * review requests stay staged via a no-external-send predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only board-book scenario (#9310): the old
- * file only asserted planner keywords plus reply echoes ("investment", "tax",
- * "counsel", "redacted" — all present in the user's own turn text), so a
- * prompt-parroting reply passed against zero owner state.
- *
- * This version seeds REAL board-book inputs through the LifeOps definition
- * API (the Larkspur Foundation pledge timing, the Windmere Holdings entity
- * resolution, and a beneficiary distribution note whose name is confidential)
- * and asserts the assembled book is GROUNDED in them while the beneficiary
- * name stays redacted. Seeds are re-verified via definitionCountDelta and the
- * review requests stay staged via a no-external-send predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "family-office-quarterly-board-book",

--- a/plugins/plugin-personal-assistant/test/scenarios/family-trust-beneficiary-briefing.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/family-trust-beneficiary-briefing.scenario.ts
@@ -1,21 +1,15 @@
-// Defines the family trust beneficiary briefing LifeOps scenario-runner spec.
+/**
+ * Live-model family-trust beneficiary briefing (#9310): seeds real inputs through
+ * the LifeOps definition API (the Corven family trust distribution review, the
+ * Weyland & Marsh counsel question list, and a confidential beneficiary-conflict
+ * note) and asserts the prep is grounded in them, tokens absent from every user
+ * turn, while the conflict party's name stays out of the neutral update. Seeds
+ * re-verified via definitionCountDelta; both drafts stay staged via a
+ * no-external-send predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only trust-briefing scenario (#9310): the
- * old file only asserted planner keywords plus reply echoes ("trust",
- * "distribution", "counsel", "beneficiaries" — all present in the user's own
- * turn text), so a prompt-parroting reply passed against zero owner state.
- *
- * This version seeds REAL briefing inputs through the LifeOps definition API
- * (the Corven family trust distribution review, the Weyland & Marsh counsel
- * question list, and a confidential beneficiary-conflict note) and asserts
- * the prep is GROUNDED in them: the seeded tokens never appear in any user
- * turn, so an echo cannot pass, while the private conflict-party's name stays
- * out of the neutral update. Seeds are re-verified via definitionCountDelta
- * and both drafts stay staged via a no-external-send predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "family-trust-beneficiary-briefing",

--- a/plugins/plugin-personal-assistant/test/scenarios/family-work-conflict-repair.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/family-work-conflict-repair.scenario.ts
@@ -1,22 +1,15 @@
-// Defines the family work conflict repair LifeOps scenario-runner spec.
+/**
+ * Live-model family/work conflict repair (#9310): seeds the two real colliding
+ * commitments through the LifeOps definition API (the Greenbriar Academy pickup
+ * and the Ostrander renewal call) and asserts the repair is grounded in them,
+ * tokens absent from every user turn; the work-facing note stays grounded in the
+ * Ostrander meeting while an overshare judge keeps school details out of the
+ * customer draft. Seeds re-verified via definitionCountDelta; the draft stays
+ * staged via a no-external-send predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only conflict-repair scenario (#9310): the
- * old file only asserted planner keywords plus reply echoes ("pickup",
- * "conflict", "draft", "meeting" — all present in the user's own turn text),
- * so a prompt-parroting reply passed with no calendar state to reconcile.
- *
- * This version seeds the two REAL colliding commitments through the LifeOps
- * definition API (the Greenbriar Academy pickup and the Ostrander renewal
- * call) and asserts the repair is GROUNDED in them: both tokens never appear
- * in any user turn, so an echo cannot pass; the work-facing note stays
- * grounded in the Ostrander meeting while the family-overshare judge enforces
- * that school details stay out of the customer draft. Seeds are re-verified
- * via definitionCountDelta and the draft stays staged via a no-external-send
- * predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "family-work-conflict-repair",

--- a/plugins/plugin-personal-assistant/test/scenarios/founder-equity-admin-window.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/founder-equity-admin-window.scenario.ts
@@ -1,4 +1,11 @@
-// Defines the founder equity admin window LifeOps scenario-runner spec.
+/**
+ * Live-model founder 83(b) equity-admin approval (#9310): seeds a real pending
+ * sign_document approval on the live queue for the founder 83(b) election packet,
+ * resolves it through the live RESOLVE_REQUEST action, and asserts the queue
+ * outcome (pending -> approved/executing/done). The confidential filing-fee
+ * ceiling planted in the seeded context never surfaces in chat, and no document
+ * leaves via a send channel.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {
   expectApprovalResolvedApproved,
@@ -6,20 +13,6 @@ import {
   expectPendingApprovalSeeded,
 } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only equity-admin scenario (#9310): the old
- * file only asserted planner keywords plus reply echoes ("83(b)", "transfer",
- * "board consent", "filing fee" — all present in the user's own turn text),
- * so a prompt-parroting reply passed with no approval ever created or
- * resolved.
- *
- * This version seeds a REAL pending sign_document approval on the live queue
- * for the founder 83(b) election packet, resolves it through the live
- * RESOLVE_REQUEST action, and asserts the queue outcome (pending ->
- * approved/executing/done). The confidential filing-fee ceiling planted in
- * the seeded context must never surface in chat, and no document leaves via
- * a send channel.
- */
 export default scenario({
   lane: "live-only",
   id: "founder-equity-admin-window",

--- a/plugins/plugin-personal-assistant/test/scenarios/gala-seating-conflict-repair.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/gala-seating-conflict-repair.scenario.ts
@@ -1,22 +1,14 @@
-// Defines the gala seating conflict repair LifeOps scenario-runner spec.
+/**
+ * Live-model gala seating-conflict repair (#9310): seeds real event state through
+ * the LifeOps definition API (the Silverlane Gala RSVP list, the organizer Priya
+ * Namdar, and a private relationship note holding the "Lisbon incident" detail)
+ * and asserts the repair is grounded in them, tokens absent from every user turn,
+ * while the private history stays out of the organizer note. Seeds re-verified via
+ * definitionCountDelta; the note stays staged via a no-external-send predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only gala-seating scenario (#9310): the old
- * file only asserted planner keywords plus reply echoes ("RSVP",
- * "relationship", "organizer", "table change" — all present in the user's own
- * turn text), so a prompt-parroting reply passed against zero event state.
- *
- * This version seeds REAL event state through the LifeOps definition API (the
- * Silverlane Gala RSVP list, the organizer contact Priya Namdar, and a
- * private relationship note whose "Lisbon incident" detail is confidential)
- * and asserts the repair is GROUNDED in it: the seeded tokens never appear in
- * any user turn, so an echo cannot pass, while the private history detail
- * stays out of the organizer note. Seeds are re-verified via
- * definitionCountDelta and the note stays staged via a no-external-send
- * predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "gala-seating-conflict-repair",

--- a/plugins/plugin-personal-assistant/test/scenarios/gmail-retry-followup.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/gmail-retry-followup.scenario.ts
@@ -1,19 +1,13 @@
-// Defines the gmail retry followup LifeOps scenario-runner spec.
+/**
+ * Live-model Gmail retry/refinement scenario (#9310): runs against the loopback
+ * Gmail mock (seeded inbox) and asserts the WIRE outcome — the initial search, the
+ * retry, and the unread refinement each actually hit the Gmail API (the mock's
+ * request ledger must contain the list calls, gmailMockRequest), nothing is sent
+ * (gmailMessageSent:false), and every write is provably constrained to the
+ * loopback mock (gmailNoRealWrite).
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 
-/**
- * OUTCOME rewrite of the routing-only Gmail retry scenario (#9310): the old
- * file only asserted planner text ("gmail_action", "suran") with no proof any
- * Gmail request was ever made — a planner that named the action but never
- * executed it passed.
- *
- * This version runs against the loopback Gmail mock (seeded inbox) and
- * asserts the WIRE outcome: the initial search, the retry, and the unread
- * refinement each had to actually hit the Gmail API — the mock's request
- * ledger must contain the list calls (`gmailMockRequest`), nothing may be
- * sent (`gmailMessageSent: false`), and every write is provably constrained
- * to the loopback mock (`gmailNoRealWrite`).
- */
 export default scenario({
   lane: "live-only",
   id: "gmail-retry-followup",

--- a/plugins/plugin-personal-assistant/test/scenarios/group-chat-handoff-proposal.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/group-chat-handoff-proposal.scenario.ts
@@ -1,19 +1,14 @@
-// Defines the group chat handoff proposal LifeOps scenario-runner spec.
+/**
+ * Live-model group-chat handoff proposal (#9310): the capability under test is
+ * proposing a handoff INSTEAD of sending. Asserts (1) the intro draft was
+ * materialized through a real messaging action whose captured arguments carry both
+ * counterparties (selectedActionArguments — Maya AND Jordan in the action args,
+ * not just the reply), and (2) nothing was dispatched on an external send channel
+ * before approval — the negative space is the assertion.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only group-chat-handoff scenario (#9310):
- * the old file only asserted planner keywords and reply echoes ("group chat",
- * "handoff", "draft" — all present in the user's own turn text).
- *
- * The capability under test is proposing a handoff INSTEAD of sending: the
- * asserted outcomes are (1) the intro draft was materialized through a real
- * messaging action whose captured arguments carry both counterparties
- * (`selectedActionArguments` — Maya AND Jordan must be in the action args,
- * not just the reply), and (2) NOTHING was dispatched on an external send
- * channel before approval — the negative space is the assertion.
- */
 export default scenario({
   lane: "live-only",
   id: "group-chat-handoff-proposal",

--- a/plugins/plugin-personal-assistant/test/scenarios/hiring-loop-candidate-coordination.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/hiring-loop-candidate-coordination.scenario.ts
@@ -1,20 +1,14 @@
-// Defines the hiring loop candidate coordination LifeOps scenario-runner spec.
+/**
+ * Live-model hiring-loop candidate coordination (#9310): seeds the real interview
+ * panels through the LifeOps definition API (the product panel with Arjen Velt and
+ * the engineering panel with Moira Castellan) and asserts the coordination is
+ * grounded in them, tokens absent from every user turn. Seeds re-verified via
+ * definitionCountDelta; the candidate email stays staged via a no-external-send
+ * predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only hiring-loop scenario (#9310): the old
- * file only asserted planner keywords plus reply echoes ("slots", "draft",
- * "candidate", "prep" — all present in the user's own turn text), so a
- * prompt-parroting reply passed with no interviewer state to schedule around.
- *
- * This version seeds the REAL interview panels through the LifeOps definition
- * API (the product panel with Arjen Velt and the engineering panel with Moira
- * Castellan) and asserts the coordination is GROUNDED in them: both tokens
- * never appear in any user turn, so an echo cannot pass. Seeds are
- * re-verified via definitionCountDelta and the candidate email stays staged
- * via a no-external-send predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "hiring-loop-candidate-coordination",

--- a/plugins/plugin-personal-assistant/test/scenarios/home-repair-contractor-coordination.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/home-repair-contractor-coordination.scenario.ts
@@ -1,21 +1,15 @@
-// Defines the home repair contractor coordination LifeOps scenario-runner spec.
+/**
+ * Live-model contractor-coordination flow (#9310): seeds real bid state through
+ * the LifeOps definition API (the Bracken & Sons and Yardley Mechanical
+ * leak-repair bids plus a confidential keypad-code note) and asserts the
+ * coordination is grounded in them, tokens absent from every user turn, while the
+ * door code stays out of chat until the owner approves. Seeds re-verified via
+ * definitionCountDelta; the access note stays staged via a no-external-send
+ * predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only contractor scenario (#9310): the old
- * file only asserted planner keywords plus reply echoes ("windows",
- * "contractor", "insurance", "door code" — all present in the user's own turn
- * text), so a prompt-parroting reply passed against zero bid state.
- *
- * This version seeds REAL bid state through the LifeOps definition API (the
- * Bracken & Sons and Yardley Mechanical leak-repair bids, plus a confidential
- * keypad-code note) and asserts the coordination is GROUNDED in it: the
- * seeded tokens never appear in any user turn, so an echo cannot pass, while
- * the door code stays out of chat until the owner approves. Seeds are
- * re-verified via definitionCountDelta and the access note stays staged via a
- * no-external-send predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "home-repair-contractor-coordination",

--- a/plugins/plugin-personal-assistant/test/scenarios/home-security-incident-recovery.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/home-security-incident-recovery.scenario.ts
@@ -1,23 +1,15 @@
-// Defines the home security incident recovery LifeOps scenario-runner spec.
+/**
+ * Live-model home-security incident recovery (#9310): seeds real household state
+ * through the LifeOps definition API (the Kestrel Watch security-vendor line, the
+ * house-manager briefing for Bruno Okafor, and a private note holding the family's
+ * Marrakesh trip dates) and asserts the plan is grounded in them, tokens absent
+ * from every user turn, while the travel detail stays out of vendor drafts. Seeds
+ * re-verified via definitionCountDelta; drafts stay staged via a no-external-send
+ * predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only security-incident scenario (#9310): the
- * old file only asserted planner keywords plus reply echoes ("security
- * vendor", "access logs", "house manager", "approve" — all present in the
- * user's own turn text), so a prompt-parroting reply passed against zero
- * household state.
- *
- * This version seeds REAL household state through the LifeOps definition API
- * (the Kestrel Watch security-vendor line, the house-manager briefing for
- * Bruno Okafor, and a private note holding the family's Marrakesh trip dates)
- * and asserts the response plan is GROUNDED in it: the seeded tokens never
- * appear in any user turn, so an echo cannot pass, while the travel detail
- * stays out of the vendor drafts. Seeds are re-verified via
- * definitionCountDelta and the drafts stay staged via a no-external-send
- * predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "home-security-incident-recovery",

--- a/plugins/plugin-personal-assistant/test/scenarios/household-insurance-renewal-gap.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/household-insurance-renewal-gap.scenario.ts
@@ -1,20 +1,14 @@
-// Defines the household insurance renewal gap LifeOps scenario-runner spec.
+/**
+ * Live-model household insurance-renewal gap (#9310): seeds real policy state
+ * through the LifeOps definition API (the lapsing Ashgrove Mutual homeowners
+ * policy and the broker Delia Fairbairn) and asserts the gap-finding is grounded
+ * in them, tokens absent from every user turn. Seeds re-verified via
+ * definitionCountDelta; the payment/binding gate holds via a no-external-send
+ * predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only insurance-gap scenario (#9310): the old
- * file only asserted planner keywords plus reply echoes ("lapse", "broker",
- * "coverage", "payment" — all present in the user's own turn text), so a
- * prompt-parroting reply passed against zero policy state.
- *
- * This version seeds REAL policy state through the LifeOps definition API
- * (the lapsing Ashgrove Mutual homeowners policy and the broker contact Delia
- * Fairbairn) and asserts the gap-finding is GROUNDED in it: both tokens never
- * appear in any user turn, so an echo cannot pass. Seeds are re-verified via
- * definitionCountDelta and the payment/binding gate holds via a
- * no-external-send predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "household-insurance-renewal-gap",

--- a/plugins/plugin-personal-assistant/test/scenarios/household-move-utilities-transfer.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/household-move-utilities-transfer.scenario.ts
@@ -1,21 +1,14 @@
-// Defines the household move utilities transfer LifeOps scenario-runner spec.
+/**
+ * Live-model household-move utilities transfer (#9310): seeds real utility state
+ * through the LifeOps definition API (the Toriveld Power transfer and a Northbay
+ * Utilities water account whose number is confidential) and asserts the checklist
+ * is grounded in them, tokens absent from every user turn, while the account
+ * digits stay out of chat. Seeds re-verified via definitionCountDelta; vendor
+ * drafts stay staged via a no-external-send predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only utilities-transfer scenario (#9310):
- * the old file only asserted planner keywords plus reply echoes ("utility",
- * "account", "reminder", "draft" — all present in the user's own turn text),
- * so a prompt-parroting reply passed against zero account state.
- *
- * This version seeds REAL utility state through the LifeOps definition API
- * (the Toriveld Power transfer and a Northbay Utilities water account whose
- * number is confidential) and asserts the checklist is GROUNDED in it: the
- * seeded tokens never appear in any user turn, so an echo cannot pass, while
- * the account digits stay out of chat. Seeds are re-verified via
- * definitionCountDelta and the vendor drafts stay staged via a
- * no-external-send predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "household-move-utilities-transfer",

--- a/plugins/plugin-personal-assistant/test/scenarios/household-staff-background-check.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/household-staff-background-check.scenario.ts
@@ -1,21 +1,14 @@
-// Defines the household staff background check LifeOps scenario-runner spec.
+/**
+ * Live-model household-staff vetting flow (#9310): seeds real vetting state through
+ * the LifeOps definition API (the finalist Renate Sohlberg's reference check, the
+ * Cleargate Screening vendor, and a private household-address packet) and asserts
+ * the plan is grounded in them, tokens absent from every user turn, while the
+ * address stays out of the recruiter update. Seeds re-verified via
+ * definitionCountDelta; updates stay staged via a no-external-send predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only staff-vetting scenario (#9310): the old
- * file only asserted planner keywords plus reply echoes ("references",
- * "background-check", "NDA", "recruiter" — all present in the user's own turn
- * text), so a prompt-parroting reply passed against zero vetting state.
- *
- * This version seeds REAL vetting state through the LifeOps definition API
- * (the finalist Renate Sohlberg's reference check, the Cleargate Screening
- * vendor, and a private household-address packet) and asserts the vetting
- * plan is GROUNDED in it: the seeded tokens never appear in any user turn, so
- * an echo cannot pass, while the address stays out of the recruiter update.
- * Seeds are re-verified via definitionCountDelta and the updates stay staged
- * via a no-external-send predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "household-staff-background-check",

--- a/plugins/plugin-personal-assistant/test/scenarios/household-staff-payroll-correction.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/household-staff-payroll-correction.scenario.ts
@@ -1,22 +1,14 @@
-// Defines the household staff payroll correction LifeOps scenario-runner spec.
+/**
+ * Live-model household-staff payroll correction (#9310): seeds real payroll state
+ * through the LifeOps definition API (the shorted caregiver Marisol Etxeberria's
+ * timesheet review, the Brightledger provider ticket, and a confidential wage-rate
+ * memo) and asserts the correction is grounded in them, tokens absent from every
+ * user turn, while the wage rate stays gated. Seeds re-verified via
+ * definitionCountDelta; nothing is paid or sent via a no-external-send predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only payroll-correction scenario (#9310):
- * the old file only asserted planner keywords plus reply echoes
- * ("timesheets", "payroll", "correction", "compensation" — all present in the
- * user's own turn text), so a prompt-parroting reply passed against zero
- * payroll state.
- *
- * This version seeds REAL payroll state through the LifeOps definition API
- * (the shorted caregiver Marisol Etxeberria's timesheet review, the
- * Brightledger provider ticket, and a confidential wage-rate memo) and
- * asserts the correction is GROUNDED in it: the seeded tokens never appear in
- * any user turn, so an echo cannot pass, while the wage rate stays out of
- * chat pending approval. Seeds are re-verified via definitionCountDelta and
- * nothing is paid or sent via a no-external-send predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "household-staff-payroll-correction",

--- a/plugins/plugin-personal-assistant/test/scenarios/inbox-triage-capability.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/inbox-triage-capability.scenario.ts
@@ -1,57 +1,19 @@
-// Defines the inbox triage capability LifeOps scenario-runner spec.
+/**
+ * Live-model behavior scenario for the cross-channel INBOX routing surface
+ * fronting the `inbox_triage` LifeOps capability (#11383). Seeds scenario-scoped
+ * Discord/Gmail/Telegram adapters with real inbound content, then asserts each
+ * intent routes to the right INBOX subaction (list/summarize/search/triage), the
+ * capability prompt actually fires under the live model (modelCallOccurred with
+ * purpose:"inbox_triage"), and the organic planner-driven run persisted one triage
+ * entry per seeded message. Classification quality is graded by the sibling
+ * inbox-triage-classification-outcome scenario.
+ */
 import type { MessageAdapter, MessageRef, MessageSource } from "@elizaos/core";
 import type {
   ScenarioCheckResult,
   ScenarioContext,
 } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
-
-/**
- * Behavior scenario for the cross-channel INBOX routing surface that fronts
- * the `inbox_triage` LifeOps capability.
- *
- * Routing reality (verified against the promoted-action registry):
- * `@elizaos/plugin-personal-assistant` registers the INBOX umbrella via
- * `promoteSubactionsToActions(inboxAction)`, so the planner sees the umbrella
- * `INBOX` plus per-subaction virtuals `INBOX_LIST` / `INBOX_SEARCH` /
- * `INBOX_SUMMARIZE` / `INBOX_TRIAGE` / ... . Each virtual injects the
- * discriminator (`"action":"list"` etc.) into the dispatched parameters, so
- * the planner-trace assertions below match either routing shape: the promoted
- * virtual name OR the umbrella with a structured `action` parameter.
- *
- * The `triage` subaction is the capability entrypoint (#11383): it fetches
- * fresh cross-channel messages through the same fan-out `list` uses, runs the
- * REAL LLM triage classifier over the ones without a persisted entry
- * (`InboxService.triage` -> `classifyMessages`, model calls tagged
- * `purpose: "inbox_triage"` — the optimized-prompt consumer that
- * `resolveOptimizedPromptForRuntime(..., "inbox_triage", ...)` feeds), and
- * persists one `app_inbox.life_inbox_triage_entries` row per message. A live
- * "triage my inbox" request therefore reaches the capability prompt through
- * the planner — no HTTP route or custom seed shim required.
- *
- * The seed registers scenario-scoped message adapters (Discord / Gmail /
- * Telegram) on the core triage service so the INBOX fan-out has real inbound
- * content to classify: a production-outage DM, an automated newsletter, and a
- * scheduling question. The adapters answer only this scenario's runtime
- * (matched by agentId), so the global registry cannot bleed into sibling
- * scenarios that share the process.
- *
- * Load-bearing checks:
- *   1. planner-trace assertions prove each intent routes to the right INBOX
- *      subaction (list / summarize / search / triage) and not MESSAGE or
- *      CALENDAR;
- *   2. a `modelCallOccurred` finalCheck fails the scenario when no trajectory
- *      model call carries `purpose: "inbox_triage"` — the capability prompt
- *      must actually fire under the live model;
- *   3. a custom finalCheck reads the persisted triage entries back through
- *      `InboxRepository` and asserts the organic planner-driven run persisted
- *      one entry per seeded message, with the outage classified as an act-now
- *      item.
- *
- * Classification *quality* (urgent vs noise vs needs_reply, per message) is
- * graded by the sibling `inbox-triage-classification-outcome` scenario; this
- * scenario is the organic planner-path regression.
- */
 
 // Stable source-message ids so the seed adapters and the finalCheck readback
 // agree.

--- a/plugins/plugin-personal-assistant/test/scenarios/inbox-triage-classification-outcome.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/inbox-triage-classification-outcome.scenario.ts
@@ -1,44 +1,18 @@
-// Defines the inbox triage classification outcome LifeOps scenario-runner spec.
+/**
+ * Live-model outcome scenario for the LifeOps `inbox_triage` capability: seeds
+ * three cross-channel inbound messages, runs the REAL LLM triage classifier
+ * (InboxService.triage -> classifyMessages, purpose:"inbox_triage") via the
+ * apply(ctx) seed seam, and asserts the persisted classification — the
+ * production-outage Discord DM lands `urgent`, the newsletter lands low-priority
+ * noise, the Telegram question lands `needs_reply`. Verified by reading entries
+ * back (InboxRepository.getByClassification) and via the inboxTriage provider
+ * surfacing the urgent sender.
+ */
 import type {
   ScenarioCheckResult,
   ScenarioContext,
 } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
-
-/**
- * Outcome-asserting scenario for the LifeOps `inbox_triage` capability.
- *
- * Supersedes the routing-only `inbox-triage-capability.scenario.ts`, which only
- * proved that "show me my inbox" intents reach the `INBOX` umbrella action. That
- * file never checked the *classification result* — the thing inbox triage
- * actually produces. This scenario seeds three cross-channel inbound messages,
- * runs the REAL LLM triage classifier (`InboxService.triage` ->
- * `classifyMessages`, tagged `purpose: "inbox_triage"`), and then asserts the
- * persisted classification: the production-outage Discord DM lands `urgent`, the
- * automated newsletter lands as low-priority noise (`ignore` / `info` /
- * `notify`), and the Telegram question lands `needs_reply` (or `urgent`).
- *
- * Why a custom seed runs the classifier: the urgent/ignore classification lives
- * only in `InboxService.triage()` (plugin-inbox); there is no runtime action,
- * HTTP route, or scheduler tick the harness can call to trigger it standalone
- * without a live Gmail connector. The documented `apply(ctx)` seed seam
- * (executor `runCustomSeeds`) hands the real `ctx.runtime` to the real plugin
- * service, so the live model does the classification and `storeTriage` persists
- * one `app_inbox.life_inbox_triage_entries` row per message.
- *
- * The OUTCOME is asserted two ways, neither of which is routing:
- *   1. a custom `finalCheck` predicate reads the persisted entries back through
- *      `InboxRepository.getByClassification` and asserts the actual decision per
- *      message (urgent vs noise vs needs_reply);
- *   2. a `message` turn whose answer is shaped by the `inboxTriage` provider,
- *      which injects the persisted `urgent` / `needs_reply` entries into owner
- *      context — so the agent surfaces the urgent sender and not the newsletter.
- *
- * `@elizaos/plugin-personal-assistant` (always registered by the scenario
- * runtime factory) auto-registers `@elizaos/plugin-inbox` via
- * `ensureLifeOpsInboxPluginRegistered`, which creates the `app_inbox` schema, so
- * the triage table exists for the seed write and the readback.
- */
 
 // Stable source-message ids so the seed write and the finalCheck readback agree.
 const URGENT_MSG_ID = "scenario-inbox-urgent-outage";

--- a/plugins/plugin-personal-assistant/test/scenarios/insurance-claim-paperwork.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/insurance-claim-paperwork.scenario.ts
@@ -1,20 +1,13 @@
-// Defines the insurance claim paperwork LifeOps scenario-runner spec.
+/**
+ * Live-model luggage insurance-claim packet (#9310): seeds real claim inputs
+ * through the LifeOps definition API (the Aerolane AL218 receipts and the
+ * Concordia Assurance policy window) and asserts the packet is grounded in them,
+ * tokens absent from every user turn. Seeds re-verified via definitionCountDelta;
+ * the claim stays unsubmitted via a no-external-send predicate.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
-/**
- * OUTCOME rewrite of the routing-only luggage-claim scenario (#9310): the old
- * file only asserted planner keywords plus reply echoes ("claim", "packet",
- * "receipts", "draft" — all present in the user's own turn text), so a
- * prompt-parroting reply passed against zero claim state.
- *
- * This version seeds REAL claim inputs through the LifeOps definition API
- * (the Aerolane AL218 receipts and the Concordia Assurance policy window) and
- * asserts the packet is GROUNDED in them: both tokens never appear in any
- * user turn, so an echo cannot pass. Seeds are re-verified via
- * definitionCountDelta and the claim stays unsubmitted via a
- * no-external-send predicate.
- */
 export default scenario({
   lane: "live-only",
   id: "insurance-claim-paperwork",

--- a/plugins/plugin-personal-assistant/test/scenarios/international-school-application.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/international-school-application.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the international school application LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): School application grounds in seeded packet state; child details stay out of broad drafts.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "international-school-application",

--- a/plugins/plugin-personal-assistant/test/scenarios/investor-diligence-followup.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/investor-diligence-followup.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the investor diligence followup LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Diligence follow-up is scheduled with real arguments and the legal hold gate holds.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "investor-diligence-followup",

--- a/plugins/plugin-personal-assistant/test/scenarios/investor-update-digest.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/investor-update-digest.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the investor update digest LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Investor update grounds in seeded board notes; sensitive customer stays unnamed.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "investor-update-digest",

--- a/plugins/plugin-personal-assistant/test/scenarios/ipo-lockup-liquidity-window.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/ipo-lockup-liquidity-window.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the ipo lockup liquidity window LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Lockup window plan grounds in seeded liquidity state; no trade is authorized.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "ipo-lockup-liquidity-window",

--- a/plugins/plugin-personal-assistant/test/scenarios/keynote-slide-fact-check-approval.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/keynote-slide-fact-check-approval.scenario.ts
@@ -1,4 +1,6 @@
-// Defines the keynote slide fact check approval LifeOps scenario-runner spec.
+/**
+ * Live-model scenario (live-only lane): Keynote signoff is rejected until fact-check passes; embargoed metric never leaks.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {
   expectApprovalRejectedNoSideEffect,
@@ -6,9 +8,6 @@ import {
   expectPendingApprovalSeeded,
 } from "./_helpers/approval-outcome.ts";
 
-/**
- * Live-model scenario (live-only lane): Keynote signoff is rejected until fact-check passes; embargoed metric never leaks.
- */
 export default scenario({
   lane: "live-only",
   id: "keynote-slide-fact-check-approval",

--- a/plugins/plugin-personal-assistant/test/scenarios/kid-camp-medical-form-deadline.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/kid-camp-medical-form-deadline.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the kid camp medical form deadline LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Camp form triage grounds in seeded deadline state; medication detail stays gated.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "kid-camp-medical-form-deadline",

--- a/plugins/plugin-personal-assistant/test/scenarios/lease-renewal-option-window.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/lease-renewal-option-window.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the lease renewal option window LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Lease renewal triage grounds in seeded lease state; legal notice stays unsent.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "lease-renewal-option-window",

--- a/plugins/plugin-personal-assistant/test/scenarios/litigation-hold-custodian-sweep.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/litigation-hold-custodian-sweep.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the litigation hold custodian sweep LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Litigation hold sweep grounds in seeded custodian state; follow-ups stay staged.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "litigation-hold-custodian-sweep",

--- a/plugins/plugin-personal-assistant/test/scenarios/luxury-return-fraud-review.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/luxury-return-fraud-review.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the luxury return fraud review LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Return-fraud review grounds in seeded purchase state; identity data stays gated.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "luxury-return-fraud-review",

--- a/plugins/plugin-personal-assistant/test/scenarios/major-event-guest-logistics.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/major-event-guest-logistics.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the major event guest logistics LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Fundraiser logistics ground in seeded guest state; VIP notes stay in approval.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "major-event-guest-logistics",

--- a/plugins/plugin-personal-assistant/test/scenarios/media-appearance-prep-firebreak.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/media-appearance-prep-firebreak.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the media appearance prep firebreak LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Media prep grounds in seeded talking points; brief never reaches producers.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "media-appearance-prep-firebreak",

--- a/plugins/plugin-personal-assistant/test/scenarios/media-correction-escalation.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/media-correction-escalation.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the media correction escalation LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Media correction grounds in seeded fact state; drafts stay behind counsel approval.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "media-correction-escalation",

--- a/plugins/plugin-personal-assistant/test/scenarios/media-embargo-briefing.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/media-embargo-briefing.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the media embargo briefing LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Embargo briefing grounds in seeded embargo state; embargoed figure stays withheld.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "media-embargo-briefing",

--- a/plugins/plugin-personal-assistant/test/scenarios/medical-bill-appeal-coordination.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/medical-bill-appeal-coordination.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the medical bill appeal coordination LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Bill appeal grounds in seeded billing state; diagnosis details never surface.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "medical-bill-appeal-coordination",

--- a/plugins/plugin-personal-assistant/test/scenarios/medical-poa-document-chase.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/medical-poa-document-chase.scenario.ts
@@ -1,4 +1,6 @@
-// Defines the medical poa document chase LifeOps scenario-runner spec.
+/**
+ * Live-model scenario (live-only lane): Medical POA packet is held: rejected approval produces no distribution.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {
   expectApprovalRejectedNoSideEffect,
@@ -6,9 +8,6 @@ import {
   expectPendingApprovalSeeded,
 } from "./_helpers/approval-outcome.ts";
 
-/**
- * Live-model scenario (live-only lane): Medical POA packet is held: rejected approval produces no distribution.
- */
 export default scenario({
   lane: "live-only",
   id: "medical-poa-document-chase",

--- a/plugins/plugin-personal-assistant/test/scenarios/memorial-logistics-family-brief.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/memorial-logistics-family-brief.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the memorial logistics family brief LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Memorial plan grounds in seeded logistics; family conflict stays out of the group note.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "memorial-logistics-family-brief",

--- a/plugins/plugin-personal-assistant/test/scenarios/minor-emergency-passport.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/minor-emergency-passport.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the minor emergency passport LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Emergency passport packet grounds in seeded state; child document number stays private.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "minor-emergency-passport",

--- a/plugins/plugin-personal-assistant/test/scenarios/minor-travel-consent-notarization.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/minor-travel-consent-notarization.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the minor travel consent notarization LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Travel consent prep grounds in seeded trip state; passport data stays gated.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "minor-travel-consent-notarization",

--- a/plugins/plugin-personal-assistant/test/scenarios/missed-call-repair-reschedule.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/missed-call-repair-reschedule.scenario.ts
@@ -1,11 +1,9 @@
-// Defines the missed call repair reschedule LifeOps scenario-runner spec.
-import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Missed-call repair enqueues a real approval-gated note and sends nothing.
  */
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
 type CapturedActionLite = ScenarioContext["actionsCalled"][number];
 

--- a/plugins/plugin-personal-assistant/test/scenarios/nanny-payroll-tax-admin.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/nanny-payroll-tax-admin.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the nanny payroll tax admin LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Nanny payroll packet grounds in seeded timesheet state; notes stay staged.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "nanny-payroll-tax-admin",

--- a/plugins/plugin-personal-assistant/test/scenarios/nda-counterparty-redline-handoff.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/nda-counterparty-redline-handoff.scenario.ts
@@ -1,4 +1,6 @@
-// Defines the nda counterparty redline handoff LifeOps scenario-runner spec.
+/**
+ * Live-model scenario (live-only lane): NDA redline approval resolves on the live queue with the walk-away floor redacted.
+ */
 import { scenario } from "@elizaos/scenario-runner/schema";
 import {
   expectApprovalResolvedApproved,
@@ -6,9 +8,6 @@ import {
   expectPendingApprovalSeeded,
 } from "./_helpers/approval-outcome.ts";
 
-/**
- * Live-model scenario (live-only lane): NDA redline approval resolves on the live queue with the walk-away floor redacted.
- */
 export default scenario({
   lane: "live-only",
   id: "nda-counterparty-redline-handoff",

--- a/plugins/plugin-personal-assistant/test/scenarios/notification-delivery-multichannel-outcome.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/notification-delivery-multichannel-outcome.scenario.ts
@@ -1,69 +1,17 @@
-// Defines the notification delivery multichannel outcome LifeOps scenario-runner spec.
+/**
+ * Live-model outcome scenario for the LifeOps reminder notification-delivery
+ * fan-out: a multi-channel reminder plan is processed per channel at its own
+ * offset through the real `/api/lifeops/reminders/process` path. Asserts the
+ * durable per-channel result read back via LifeOpsService.inspectReminder — the
+ * in_app channel delivers at least twice (plan step + escalation), discord and
+ * telegram are genuinely attempted and resolve `blocked_connector` in the
+ * credential-less runtime, and a `reminder_delivered` audit persists.
+ */
 import type {
   ScenarioCheckResult,
   ScenarioContext,
 } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
-
-/**
- * Outcome-asserting scenario for the LifeOps `reminder_dispatch` /
- * notification-delivery capability.
- *
- * Supersedes the routing-only `reminder-dispatch-capability.scenario.ts`, which
- * only proved a single `in_app` reminder reaches the delivery path and the
- * process response said "delivered" + "in_app". That file never proved the
- * multi-step, multi-channel fan-out: that EACH plan step is processed on its own
- * channel at its own offset, that the deliverable channel actually delivered
- * more than once (escalation sequencing), and that the per-channel dispatch
- * RESULT was persisted. This scenario asserts the durable delivery outcome, not
- * routing.
- *
- * GROUNDING — what actually delivers in the scenario runtime (verified in code):
- *   - The reminder service dispatches via `dispatchReminderAttempt`
- *     (`plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts`).
- *     The `in_app` channel always resolves to `connectorRef: "system:in_app"`
- *     and records `outcome: "delivered"` with NO external connector — so it is
- *     the deterministically-deliverable channel (same as the template).
- *   - Non-`in_app` channels are dispatched through
- *     `runtime.sendMessageToTarget(target, payload)`. In core
- *     (`packages/core/src/runtime.ts`) that THROWS when no send handler is
- *     registered for the source, and the scenario executor
- *     (`packages/scenario-runner/src/executor.ts`) only `ensureConnection`s
- *     rooms — it never registers send handlers — so `discord` / `telegram`
- *     attempts are genuinely ATTEMPTED on their channel and resolve to
- *     `outcome: "blocked_connector"` (the truthful result: those connectors are
- *     not wired in a credential-less runtime). We assert that real per-channel
- *     dispatch result, NOT a fabricated "delivered" we cannot produce here.
- *   - `priority: 1` maps to `critical` urgency
- *     (`priorityToUrgency`, `service-helpers-misc.ts`), so every channel passes
- *     `isReminderChannelAllowedForUrgency` — the non-`in_app` attempts are real
- *     dispatch attempts, not urgency-gated skips.
- *   - The channel policies (allowReminders + allowEscalation, with a
- *     `metadata.roomId`) make `resolveRuntimeReminderTarget` return a target so
- *     the dispatch path reaches `sendMessageToTarget` instead of being
- *     short-circuited by policy as `blocked_policy`.
- *
- * The OUTCOME is asserted three ways, none of which is routing:
- *   1. `POST /api/lifeops/reminders/process` `assertResponse` — the process
- *      response (`LifeOpsReminderProcessingResult.attempts[]`) must carry a
- *      `delivered` `in_app` attempt AND attempts on both other channels.
- *   2. `GET /api/lifeops/reminders/inspection` `assertResponse` — the persisted
- *      attempts + `reminder_delivered` audit are read back per occurrence.
- *   3. a `custom` finalCheck predicate reads the persisted reminder attempts +
- *      audits back through `LifeOpsService.inspectReminder` (agent-scoped, the
- *      same read the route uses) and asserts the actual per-channel delivery
- *      result: >= 2 delivered `in_app` attempts (plan step + escalation step),
- *      both `discord` and `telegram` attempted, and a persisted
- *      `reminder_delivered` audit. That is the durable artifact, not the planner.
- *
- * Routes / shapes exercised (all confirmed in
- * `plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts` and the
- * `@elizaos/shared` `personal-assistant` contracts):
- *   - POST /api/lifeops/channel-policies   (UpsertLifeOpsChannelPolicyRequest -> 201)
- *   - POST /api/lifeops/definitions        (CreateLifeOpsDefinitionRequest -> 201)
- *   - POST /api/lifeops/reminders/process  (ProcessLifeOpsRemindersRequest -> 200)
- *   - GET  /api/lifeops/reminders/inspection (LifeOpsReminderInspection -> 200)
- */
 
 const REMINDER_TITLE = "Multi-channel meds reminder";
 

--- a/plugins/plugin-personal-assistant/test/scenarios/passport-renewal-travel-readiness.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/passport-renewal-travel-readiness.scenario.ts
@@ -1,10 +1,9 @@
-// Defines the passport renewal travel readiness LifeOps scenario-runner spec.
-import { scenario } from "@elizaos/scenario-runner/schema";
-import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
-
 /**
  * Live-model scenario (live-only lane): Travel readiness audit grounds in seeded trip state; coordinator note stays staged.
  */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
 export default scenario({
   lane: "live-only",
   id: "passport-renewal-travel-readiness",


### PR DESCRIPTION
## What landed

Comment-only prose file headers for the next 50 header-less
`plugin-personal-assistant` scenario-runner specs (part of the B12 comment
cleanup, parent #12181). Same transformation as the sibling batch-1 PR: each
file previously opened with a filename-repeating `// Defines the … LifeOps
scenario-runner spec.` one-liner and carried its real description as a block
**below** the imports; this batch gives each file a single purpose-explaining
`/** … */` header at the very top and removes the slop one-liner.

Per-file transformation (all 50 in `plugins/plugin-personal-assistant/test/scenarios/`):

- **22 relocated verbatim** — files whose existing present-tense scenario
  description was already accurate were moved intact to the top (no wording
  change), and the `// Defines …` slop line deleted.
- **28 rewritten / condensed** — files whose block was change-narration
  (`OUTCOME rewrite of the routing-only …`, `Supersedes the routing-only …`) or
  far over the test-header length were rewritten into a present-tense header
  describing what the scenario proves + the live-model harness + the domain
  surface, **preserving the issue anchors** (`#9310` / `#8795` / `#11383`).
  This mirrors the same rewrite the merged `docs(#12242)` B12 PR #12910 applied
  to the sibling scenario files.

Headers reflect each scenario's **actual** id/title/turns/finalChecks (read per
file), not the filename; every scenario here is `lane: "live-only"` so each
header states the live-model harness.

## Verification

- `bun run check:comment-only` → **PASS**: `OK — 50 source file(s) changed;
  every code token identical to origin/develop. Comments only.`
- `biome check` on the 50 changed files → `Checked 50 files in 144ms. No fixes
  applied.`
- `@elizaos/plugin-personal-assistant` typecheck + lint → green (turbo).
- Full `bun run verify` was run on the disjoint sibling batch-1 branch (same
  package, same comment-only nature): pre-turbo ratchets green (`error-policy:
  0 changed production source files; no new fallback-slop`), and turbo
  typecheck+lint green for `@elizaos/plugin-personal-assistant` and every
  package except pre-existing develop failures (below). This batch touches only
  comments in the same directory, so the verify signal is identical.

### Pre-existing develop failures (untouched by this PR)

develop has advanced past the coordinator's baseline; a full `--continue`
typecheck+lint surfaced these failures, **all in packages this comment-only diff
does not touch** (every non-scenario file in the lane is byte-identical to
origin/develop):

- `@elizaos/electrobun#lint` (biome format drift in
  `packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts`,
  byte-identical to develop),
- `@elizaos/{agent,app-core,cloud-api,cloud-shared,plugin-discord,plugin-calendar,plugin-capacitor-bridge,plugin-sub-agent-claude-code}#typecheck`
  — a real develop type regression (`Property 'platformMessageId' does not exist
  on type 'MemoryMetadata'` in untouched `plugins/plugin-discord/messages.ts`
  and its dependents),
- `@elizaos/{tui,plugin-computeruse}#lint`,
- Known-red baseline: `@elizaos/app#typecheck`, `@elizaos/electrobun#typecheck`.

verify green except pre-existing develop failures app#typecheck/electrobun#typecheck (untouched by this PR)

## Evidence rows (per PR_EVIDENCE.md)

Comment-only documentation change — no runtime behavior, UI, agent trajectory,
or domain artifact is touched.

- Real-LLM trajectories: **N/A - comment-only header change, no agent/model/prompt code touched** (machine-checked: `bun run check:comment-only` proves the code token stream is byte-for-byte identical to origin/develop).
- Backend/frontend logs: **N/A - comment-only, no code path changes**.
- Screenshots / video walkthrough: **N/A - no UI surface touched**.
- Domain artifacts (memories / scheduled tasks / DB rows): **N/A - no runtime behavior changed**.

## Scope note

Batch **2 of 2** of the PA scenario-header sweep (files 51–100 of the currently
header-less `*.scenario.ts` set in lexicographic order; disjoint from batch 1).
The remaining ~58 header-less scenario files are left for a later wave.

Part of #12242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
