### PR TITLE
feat(#12284): observed health-anchor resolvers + ActivitySignalBus wake/sleep publisher (WI-1, WI-4)

### DIFF
--- a/plugins/plugin-health/src/__tests__/anchor-resolvers.test.ts
+++ b/plugins/plugin-health/src/__tests__/anchor-resolvers.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Observed-anchor resolvers (#12284 WI-1) through the real
+ * `registerHealthAnchors` contributions and a deterministic
+ * ActivitySignalReader: same-day observations resolve to their actual
+ * instant; stale/future/degraded inputs resolve `null`, never throw.
+ */
+
+import { describe, expect, it } from "vitest";
+import type {
+  ActivitySignalReader,
+  ActivitySignalRecord,
+  AnchorContribution,
+  AnchorRegistry,
+  RuntimeWithHealthRegistries,
+} from "../connectors/contract-types.js";
+import {
+  HEALTH_ANCHORS,
+  HEALTH_BUS_FAMILIES,
+  registerHealthAnchors,
+} from "../connectors/index.js";
+import type { LifeOpsDerivedEvent } from "../sleep/sleep-wake-events.js";
+import { healthBusFamilyForDerivedEventKind } from "../sleep/sleep-wake-events.js";
+
+/** 2026-05-09 09:00 EDT — the "now" used across the fixed timeline. */
+const NOW_ISO = "2026-05-09T13:00:00.000Z";
+const NY = "America/New_York";
+
+function makeAnchorRegistry(): {
+  registry: AnchorRegistry;
+  anchors: AnchorContribution[];
+} {
+  const anchors: AnchorContribution[] = [];
+  const registry: AnchorRegistry = {
+    register: (anchor) => {
+      anchors.push(anchor);
+    },
+    list: () => anchors,
+    get: (anchorKey) =>
+      anchors.find((anchor) => anchor.anchorKey === anchorKey) ?? null,
+  };
+  return { registry, anchors };
+}
+
+function makeReader(
+  records: ActivitySignalRecord[],
+  options: { honorFamilyFilter?: boolean; throwOnRecent?: boolean } = {},
+): ActivitySignalReader {
+  return {
+    recent(args) {
+      if (options.throwOnRecent) {
+        throw new Error("reader exploded");
+      }
+      const sinceMs = Date.parse(args.sinceIso);
+      return records.filter((record) => {
+        const occurredMs = Date.parse(record.occurredAt);
+        if (Number.isFinite(occurredMs) && occurredMs < sinceMs) return false;
+        if (options.honorFamilyFilter === false) return true;
+        return args.family === undefined || record.family === args.family;
+      });
+    },
+  };
+}
+
+async function resolveAnchor(args: {
+  anchorKey: string;
+  records?: ActivitySignalRecord[];
+  reader?: ActivitySignalReader | null;
+  nowIso?: string;
+  timezone?: string;
+}): Promise<{ atIso: string } | null> {
+  const { registry } = makeAnchorRegistry();
+  const runtimeStub: RuntimeWithHealthRegistries = {
+    anchorRegistry: registry,
+  };
+  if (args.reader !== null) {
+    runtimeStub.activitySignalBus =
+      args.reader ?? makeReader(args.records ?? []);
+  }
+  registerHealthAnchors(runtimeStub);
+  const contribution = registry.get(args.anchorKey);
+  expect(contribution).not.toBeNull();
+  if (!contribution?.resolve) {
+    throw new Error(`anchor ${args.anchorKey} has no resolver`);
+  }
+  return contribution.resolve({
+    nowIso: args.nowIso ?? NOW_ISO,
+    ownerFacts: { timezone: args.timezone ?? NY },
+  });
+}
+
+describe("plugin-health observed-anchor resolvers (#12284 WI-1)", () => {
+  it("registers all 4 anchors with real resolvers", () => {
+    const { registry, anchors } = makeAnchorRegistry();
+    registerHealthAnchors({ anchorRegistry: registry });
+    expect(anchors.map((anchor) => anchor.anchorKey)).toEqual([
+      ...HEALTH_ANCHORS,
+    ]);
+    for (const anchor of anchors) {
+      expect(typeof anchor.resolve).toBe("function");
+    }
+  });
+
+  it("wake.confirmed resolves to the actual observed wake on the day it occurred", async () => {
+    const resolved = await resolveAnchor({
+      anchorKey: "wake.confirmed",
+      records: [
+        // 06:47 EDT the same local day as NOW_ISO.
+        {
+          family: "health.wake.confirmed",
+          occurredAt: "2026-05-09T10:47:00.000Z",
+        },
+      ],
+    });
+    expect(resolved).toEqual({ atIso: "2026-05-09T10:47:00.000Z" });
+  });
+
+  it("picks the LATEST same-day observation when several exist", async () => {
+    const resolved = await resolveAnchor({
+      anchorKey: "wake.observed",
+      records: [
+        {
+          family: "health.wake.observed",
+          occurredAt: "2026-05-09T09:50:00.000Z",
+        },
+        {
+          family: "health.wake.observed",
+          occurredAt: "2026-05-09T11:40:00.000Z",
+        },
+        {
+          family: "health.wake.observed",
+          occurredAt: "2026-05-09T10:15:00.000Z",
+        },
+      ],
+    });
+    expect(resolved).toEqual({ atIso: "2026-05-09T11:40:00.000Z" });
+  });
+
+  it("resolves null when no observation exists (spine falls back to the static default)", async () => {
+    const resolved = await resolveAnchor({
+      anchorKey: "wake.confirmed",
+      records: [],
+    });
+    expect(resolved).toBeNull();
+  });
+
+  it("rejects yesterday's observation after local midnight even when <24h old", async () => {
+    const resolved = await resolveAnchor({
+      anchorKey: "wake.confirmed",
+      records: [
+        // 19:30 EDT on May 8 — only 13.5h before NOW_ISO but the previous
+        // local day, so the same-local-day freshness rule must reject it.
+        {
+          family: "health.wake.confirmed",
+          occurredAt: "2026-05-08T23:30:00.000Z",
+        },
+      ],
+    });
+    expect(resolved).toBeNull();
+  });
+
+  it("rejects a multi-day-old observation", async () => {
+    const resolved = await resolveAnchor({
+      anchorKey: "wake.confirmed",
+      records: [
+        {
+          family: "health.wake.confirmed",
+          occurredAt: "2026-05-07T10:47:00.000Z",
+        },
+      ],
+    });
+    expect(resolved).toBeNull();
+  });
+
+  it("rejects an observation in the future beyond clock skew", async () => {
+    const resolved = await resolveAnchor({
+      anchorKey: "wake.observed",
+      records: [
+        {
+          family: "health.wake.observed",
+          occurredAt: "2026-05-09T13:10:00.000Z",
+        },
+      ],
+    });
+    expect(resolved).toBeNull();
+  });
+
+  it("re-checks family membership even when the reader ignores the filter", async () => {
+    const mixed: ActivitySignalRecord[] = [
+      {
+        family: "health.sleep.detected",
+        occurredAt: "2026-05-09T04:00:00.000Z",
+      },
+      {
+        family: "health.wake.confirmed",
+        occurredAt: "2026-05-09T10:47:00.000Z",
+      },
+    ];
+    const napResolved = await resolveAnchor({
+      anchorKey: "nap.start",
+      reader: makeReader(mixed, { honorFamilyFilter: false }),
+    });
+    expect(napResolved).toBeNull();
+    const wakeResolved = await resolveAnchor({
+      anchorKey: "wake.confirmed",
+      reader: makeReader(mixed, { honorFamilyFilter: false }),
+    });
+    expect(wakeResolved).toEqual({ atIso: "2026-05-09T10:47:00.000Z" });
+  });
+
+  it("nap.start resolves from today's health.nap.detected transition", async () => {
+    const resolved = await resolveAnchor({
+      anchorKey: "nap.start",
+      records: [
+        {
+          family: "health.nap.detected",
+          occurredAt: "2026-05-09T17:05:00.000Z",
+        },
+      ],
+      nowIso: "2026-05-09T18:00:00.000Z",
+    });
+    expect(resolved).toEqual({ atIso: "2026-05-09T17:05:00.000Z" });
+  });
+
+  it("bedtime.target resolves the target carried on health.bedtime.imminent (near-future ok)", async () => {
+    const resolved = await resolveAnchor({
+      anchorKey: "bedtime.target",
+      records: [
+        // The imminent edge's occurredAt IS the resolved bedtime target,
+        // published up to 30 minutes before the target instant.
+        {
+          family: "health.bedtime.imminent",
+          occurredAt: "2026-05-09T13:20:00.000Z",
+        },
+      ],
+    });
+    expect(resolved).toEqual({ atIso: "2026-05-09T13:20:00.000Z" });
+  });
+
+  it("bedtime.target rejects targets further than 12h from now", async () => {
+    const staleTarget = await resolveAnchor({
+      anchorKey: "bedtime.target",
+      records: [
+        {
+          family: "health.bedtime.imminent",
+          occurredAt: "2026-05-09T00:00:00.000Z",
+        },
+      ],
+    });
+    expect(staleTarget).toBeNull();
+  });
+
+  it("degrades the same-day comparison to UTC on an invalid owner timezone without throwing", async () => {
+    const resolved = await resolveAnchor({
+      anchorKey: "wake.confirmed",
+      records: [
+        {
+          family: "health.wake.confirmed",
+          occurredAt: "2026-05-09T06:00:00.000Z",
+        },
+      ],
+      timezone: "Not/AZone",
+    });
+    expect(resolved).toEqual({ atIso: "2026-05-09T06:00:00.000Z" });
+  });
+
+  it("resolves null (never throws) when the reader throws", async () => {
+    const resolved = await resolveAnchor({
+      anchorKey: "wake.confirmed",
+      reader: makeReader([], { throwOnRecent: true }),
+    });
+    expect(resolved).toBeNull();
+  });
+
+  it("skips envelopes with unparseable occurredAt", async () => {
+    const resolved = await resolveAnchor({
+      anchorKey: "wake.confirmed",
+      records: [
+        { family: "health.wake.confirmed", occurredAt: "not-a-date" },
+        {
+          family: "health.wake.confirmed",
+          occurredAt: "2026-05-09T10:47:00.000Z",
+        },
+      ],
+    });
+    expect(resolved).toEqual({ atIso: "2026-05-09T10:47:00.000Z" });
+  });
+
+  it("resolves null when the runtime exposes no ActivitySignalReader", async () => {
+    const resolved = await resolveAnchor({
+      anchorKey: "wake.confirmed",
+      reader: null,
+    });
+    expect(resolved).toBeNull();
+  });
+
+  it("resolves null (never throws) on malformed resolve contexts", async () => {
+    const { registry } = makeAnchorRegistry();
+    registerHealthAnchors({
+      anchorRegistry: registry,
+      activitySignalBus: makeReader([
+        {
+          family: "health.wake.confirmed",
+          occurredAt: "2026-05-09T10:47:00.000Z",
+        },
+      ]),
+    });
+    const contribution = registry.get("wake.confirmed");
+    if (!contribution?.resolve) throw new Error("missing resolver");
+    for (const context of [
+      null,
+      undefined,
+      42,
+      {},
+      { nowIso: "garbage" },
+      { nowIso: 12345 },
+    ]) {
+      expect(await contribution.resolve(context)).toBeNull();
+    }
+  });
+});
+
+describe("derived-event kind → bus family mapping (#12284 WI-4)", () => {
+  it("maps every circadian transition kind to its registered health.* family", () => {
+    const expected: Array<[LifeOpsDerivedEvent["kind"], string]> = [
+      ["lifeops.sleep.detected", "health.sleep.detected"],
+      ["lifeops.sleep.ended", "health.sleep.ended"],
+      ["lifeops.wake.observed", "health.wake.observed"],
+      ["lifeops.wake.confirmed", "health.wake.confirmed"],
+      ["lifeops.nap.detected", "health.nap.detected"],
+      ["lifeops.bedtime.imminent", "health.bedtime.imminent"],
+      ["lifeops.regularity.changed", "health.regularity.changed"],
+    ];
+    for (const [kind, family] of expected) {
+      expect(healthBusFamilyForDerivedEventKind(kind)).toBe(family);
+      expect(HEALTH_BUS_FAMILIES).toContain(family);
+    }
+  });
+
+  it("maps sleep.onset_candidate to null (no bus family; paired with sleep.detected)", () => {
+    expect(
+      healthBusFamilyForDerivedEventKind("lifeops.sleep.onset_candidate"),
+    ).toBeNull();
+  });
+});

--- a/plugins/plugin-health/src/connectors/contract-types.ts
+++ b/plugins/plugin-health/src/connectors/contract-types.ts
@@ -106,6 +106,25 @@ export interface BusFamilyRegistry {
   list(): BusFamilyContribution[];
 }
 
+/** A single signal envelope as read back from the `ActivitySignalBus`. */
+export interface ActivitySignalRecord {
+  family: string;
+  occurredAt: string;
+  payload?: unknown;
+}
+
+/**
+ * Read-side view of the host's `ActivitySignalBus` — the minimum surface the
+ * observed-anchor resolvers need ("which transitions of family X happened
+ * since Y?"). Structural on purpose: the concrete bus lives in
+ * `@elizaos/plugin-personal-assistant` (`lifeops/signals/bus.ts`), which
+ * plugin-health must not import (the dependency points the other way). The
+ * host exposes its bus on the runtime as `activitySignalBus`.
+ */
+export interface ActivitySignalReader {
+  recent(args: { sinceIso: string; family?: string }): ActivitySignalRecord[];
+}
+
 export interface BusFamilyContribution {
   family: string;
   description: string;
@@ -121,4 +140,12 @@ export interface RuntimeWithHealthRegistries {
   connectorRegistry?: ConnectorRegistry;
   anchorRegistry?: AnchorRegistry;
   busFamilyRegistry?: BusFamilyRegistry;
+  /**
+   * Read-side of the host's `ActivitySignalBus`. The observed-anchor
+   * resolvers registered by `registerHealthAnchors` read wake/sleep/nap
+   * transition envelopes through this seam; when absent, every anchor
+   * resolves `null` and `relative_to_anchor` falls back to the static
+   * owner-window defaults in the scheduling spine.
+   */
+  activitySignalBus?: ActivitySignalReader;
 }

--- a/plugins/plugin-health/src/connectors/index.ts
+++ b/plugins/plugin-health/src/connectors/index.ts
@@ -19,7 +19,9 @@
 
 import { logger } from "@elizaos/core";
 import { getHealthProviderSpec } from "../health-bridge/health-provider-registry.js";
+import { getLocalDateKey, getZonedDateParts } from "../util/time.js";
 import type {
+  ActivitySignalReader,
   AnchorContribution,
   AnchorRegistry,
   BusFamilyContribution,
@@ -186,7 +188,111 @@ function buildConnectorContribution(
   };
 }
 
-function buildAnchorContribution(anchorKey: string): AnchorContribution {
+/**
+ * Where each health anchor reads its observation from, and how freshness is
+ * judged. `observation` anchors point at a transition that already happened
+ * (a wake or nap edge); `target` anchors point at a resolved future/near
+ * instant (the bedtime target carried on the `health.bedtime.imminent`
+ * edge, whose `occurredAt` IS the target instant).
+ */
+const OBSERVED_ANCHOR_SOURCES: Record<
+  (typeof HEALTH_ANCHORS)[number],
+  {
+    family: (typeof HEALTH_BUS_FAMILIES)[number];
+    semantics: "observation" | "target";
+  }
+> = {
+  "wake.observed": {
+    family: "health.wake.observed",
+    semantics: "observation",
+  },
+  "wake.confirmed": {
+    family: "health.wake.confirmed",
+    semantics: "observation",
+  },
+  "bedtime.target": {
+    family: "health.bedtime.imminent",
+    semantics: "target",
+  },
+  "nap.start": { family: "health.nap.detected", semantics: "observation" },
+};
+
+/**
+ * Bus read window. Wider than any freshness rule below so the rules — not
+ * the query bound — decide staleness; the bus itself retains only 24h.
+ */
+const ANCHOR_SIGNAL_QUERY_LOOKBACK_MS = 48 * 60 * 60 * 1000;
+
+/** Clock-skew tolerance for "an observation must not be in the future". */
+const OBSERVATION_FUTURE_SKEW_MS = 5 * 60 * 1000;
+
+/**
+ * Freshness bound for `target`-semantics anchors: a bedtime target is usable
+ * from 12h before to 12h after the instant it names. Beyond that the static
+ * `eveningWindow.end` default is more trustworthy than the stale target.
+ */
+const TARGET_FRESHNESS_MS = 12 * 60 * 60 * 1000;
+
+/**
+ * Local calendar-day key for an instant, degrading to UTC when the
+ * owner-fact timezone is not a valid IANA id.
+ */
+function localDayKey(ms: number, timeZone: string): string | null {
+  try {
+    return getLocalDateKey(getZonedDateParts(new Date(ms), timeZone));
+  } catch (error) {
+    // error-policy:J3 — ownerFacts.timezone is owner-supplied input; an
+    // invalid IANA id degrades the same-local-day comparison to UTC instead
+    // of throwing out of the scheduler tick that calls resolve().
+    if (timeZone === "UTC") {
+      logger.warn(
+        { src: "plugin:health", error },
+        "Anchor freshness day-key computation failed even in UTC",
+      );
+      return null;
+    }
+    return localDayKey(ms, "UTC");
+  }
+}
+
+function anchorTimezone(ownerFacts: unknown): string {
+  if (
+    typeof ownerFacts === "object" &&
+    ownerFacts !== null &&
+    "timezone" in ownerFacts &&
+    typeof (ownerFacts as { timezone?: unknown }).timezone === "string" &&
+    (ownerFacts as { timezone: string }).timezone.length > 0
+  ) {
+    return (ownerFacts as { timezone: string }).timezone;
+  }
+  return "UTC";
+}
+
+/**
+ * Observed-anchor resolver (#12284 WI-1). Reads the most recent transition
+ * envelope for the anchor's bus family and returns its instant, so
+ * `relative_to_anchor("wake.confirmed", offset)` anchors to the ACTUAL
+ * observed wake instead of the configured morning window.
+ *
+ * Freshness rules (documented for the tests that pin them):
+ *   - `observation` anchors (wake.observed / wake.confirmed / nap.start):
+ *     the transition must have occurred on the SAME local calendar day as
+ *     `nowIso` in the owner's timezone, and not in the future beyond clock
+ *     skew. Same-local-day is deliberately tighter than the issue's 24-48h
+ *     staleness bound: after local midnight yesterday's wake must never
+ *     anchor today's schedule.
+ *   - `target` anchors (bedtime.target): usable within ±12h of now.
+ *
+ * Returning `null` is the designed degrade — the spine's `nextAnchorIso` /
+ * `resolveAnchorIso` fall through to the static owner-window defaults
+ * (`morningWindow.start`, `eveningWindow.end`/22:30). resolve() never
+ * throws: a broken reader must not break the scheduler tick.
+ */
+function buildAnchorContribution(
+  anchorKey: (typeof HEALTH_ANCHORS)[number],
+  readSignals: () => ActivitySignalReader | null,
+): AnchorContribution {
+  const signalSource = OBSERVED_ANCHOR_SOURCES[anchorKey];
   return {
     anchorKey,
     description: `plugin-health anchor: ${anchorKey}`,
@@ -195,7 +301,70 @@ function buildAnchorContribution(anchorKey: string): AnchorContribution {
       label: `plugin-health anchor: ${anchorKey}`,
       provider: "plugin-health",
     },
-    resolve: async () => null,
+    resolve: async (context: unknown): Promise<{ atIso: string } | null> => {
+      const nowIso =
+        typeof context === "object" &&
+        context !== null &&
+        "nowIso" in context &&
+        typeof (context as { nowIso?: unknown }).nowIso === "string"
+          ? (context as { nowIso: string }).nowIso
+          : null;
+      const nowMs = nowIso === null ? Number.NaN : Date.parse(nowIso);
+      if (!Number.isFinite(nowMs)) return null;
+
+      let latestMs: number | null = null;
+      try {
+        const reader = readSignals();
+        if (!reader) return null;
+        const envelopes = reader.recent({
+          sinceIso: new Date(
+            nowMs - ANCHOR_SIGNAL_QUERY_LOOKBACK_MS,
+          ).toISOString(),
+          family: signalSource.family,
+        });
+        for (const envelope of envelopes) {
+          // Defensive family re-check: readers are only obligated to treat
+          // `family` as a filter hint, and a mixed result must not let a
+          // sleep edge masquerade as a wake anchor.
+          if (envelope.family !== signalSource.family) continue;
+          const occurredMs = Date.parse(envelope.occurredAt);
+          if (!Number.isFinite(occurredMs)) continue;
+          if (latestMs === null || occurredMs > latestMs) {
+            latestMs = occurredMs;
+          }
+        }
+      } catch (error) {
+        // error-policy:J4 — anchor resolution is a designed degrade: a
+        // failed signal read falls back to the static owner-window default
+        // instead of breaking the scheduler tick. The warn keeps the
+        // failure observable.
+        logger.warn(
+          { src: "plugin:health", anchorKey, error },
+          "Observed-anchor signal read failed; falling back to static anchor default",
+        );
+        return null;
+      }
+      if (latestMs === null) return null;
+
+      if (signalSource.semantics === "target") {
+        if (Math.abs(latestMs - nowMs) > TARGET_FRESHNESS_MS) return null;
+      } else {
+        if (latestMs > nowMs + OBSERVATION_FUTURE_SKEW_MS) return null;
+        const timeZone = anchorTimezone(
+          (context as { ownerFacts?: unknown }).ownerFacts,
+        );
+        const observedDay = localDayKey(latestMs, timeZone);
+        const currentDay = localDayKey(nowMs, timeZone);
+        if (
+          observedDay === null ||
+          currentDay === null ||
+          observedDay !== currentDay
+        ) {
+          return null;
+        }
+      }
+      return { atIso: new Date(latestMs).toISOString() };
+    },
   };
 }
 
@@ -263,11 +432,16 @@ export function registerHealthAnchors(
     );
     return;
   }
+  // Late-bound reader: the host may attach its ActivitySignalBus after the
+  // anchors register (boot-order tolerance, same posture as the registries
+  // themselves). resolve() re-reads the runtime property on every call.
+  const readSignals = (): ActivitySignalReader | null =>
+    runtime.activitySignalBus ?? null;
   for (const anchorKey of HEALTH_ANCHORS) {
     if (registry.get(anchorKey)) {
       continue;
     }
-    registry.register(buildAnchorContribution(anchorKey));
+    registry.register(buildAnchorContribution(anchorKey, readSignals));
   }
   logger.info(
     {

--- a/plugins/plugin-health/src/sleep/sleep-wake-events.ts
+++ b/plugins/plugin-health/src/sleep/sleep-wake-events.ts
@@ -57,6 +57,40 @@ export interface LifeOpsDerivedEvent {
   payload: LifeOpsDerivedEventPayload;
 }
 
+/**
+ * ActivitySignalBus family carried for each derived circadian event kind.
+ * Values are members of `HEALTH_BUS_FAMILIES` (`../connectors/index.ts`);
+ * kept as literals here so the sleep domain stays import-free of the
+ * connector registration module. `lifeops.sleep.onset_candidate` maps to
+ * nothing on purpose: it has no registered bus family and always fires
+ * paired with `lifeops.sleep.detected`, which does.
+ */
+const HEALTH_BUS_FAMILY_BY_DERIVED_EVENT_KIND: Partial<
+  Record<LifeOpsDerivedEvent["kind"], string>
+> = {
+  "lifeops.sleep.detected": "health.sleep.detected",
+  "lifeops.sleep.ended": "health.sleep.ended",
+  "lifeops.wake.observed": "health.wake.observed",
+  "lifeops.wake.confirmed": "health.wake.confirmed",
+  "lifeops.nap.detected": "health.nap.detected",
+  "lifeops.bedtime.imminent": "health.bedtime.imminent",
+  "lifeops.regularity.changed": "health.regularity.changed",
+};
+
+/**
+ * Resolves the bus family a derived circadian event publishes under, or
+ * `null` for kinds that intentionally do not reach the bus. The production
+ * publisher (`plugin-personal-assistant`'s circadian tick) and the
+ * observed-anchor resolvers read/write the SAME families, which is what
+ * makes the anchors and `health_signal_observed` completion checks agree
+ * on one source of truth (#12284 WI-1 + WI-4).
+ */
+export function healthBusFamilyForDerivedEventKind(
+  kind: LifeOpsDerivedEvent["kind"],
+): string | null {
+  return HEALTH_BUS_FAMILY_BY_DERIVED_EVENT_KIND[kind] ?? null;
+}
+
 function buildEvent(args: {
   kind: LifeOpsDerivedEvent["kind"];
   occurredAt: string;

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
@@ -223,6 +223,8 @@ import {
   requireNonEmptyString,
 } from "../service-normalize.js";
 import type { ReminderActivityProfileSnapshot } from "../service-types.js";
+import { getActivitySignalBus } from "../signals/bus.js";
+import { publishDerivedHealthSignals } from "../signals/health-signal-publisher.js";
 import {
   DEFAULT_TELEMETRY_RETENTION_DAYS,
   runTelemetryRetention,
@@ -5294,6 +5296,29 @@ export class RemindersDomain {
               payload: event.payload,
             };
             await this.ctx.runtime.emitEvent(event.kind, eventPayload);
+          }
+        }
+        // Mirror the newly inserted transitions onto the ActivitySignalBus
+        // under their `health.*` families (#12284 WI-4) so the ScheduledTask
+        // spine sees them: `health_signal_observed` completion checks and the
+        // plugin-health observed-anchor resolvers read these envelopes. Only
+        // inserted events publish — the audit dedup above already filtered
+        // restart replays. The emitEvent dispatch above stays: event
+        // workflows (`runDueEventWorkflows`) and the scheduled-task event
+        // bridge consume it.
+        if (insertedEvents.length > 0) {
+          const activityBus = getActivitySignalBus(this.ctx.runtime);
+          if (activityBus) {
+            publishDerivedHealthSignals(activityBus, insertedEvents);
+          } else {
+            logger.warn(
+              {
+                src: "lifeops:reminders-service",
+                agentId: this.ctx.agentId(),
+                eventKinds: insertedEvents.map((event) => event.kind),
+              },
+              "ActivitySignalBus not registered; circadian transitions were not published to the bus (health_signal_observed checks and observed anchors will fall back)",
+            );
           }
         }
         return {

--- a/plugins/plugin-personal-assistant/src/lifeops/signals/health-signal-publisher.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/signals/health-signal-publisher.ts
@@ -1,0 +1,63 @@
+/**
+ * Production publisher bridging derived circadian transitions onto the
+ * ActivitySignalBus (#12284 WI-4). The legacy scheduler tick
+ * (`domains/reminders-service.ts`, circadian_state subsystem) derives
+ * wake/sleep/nap/bedtime edge events via plugin-health's
+ * `deriveSleepWakeEvents` and dispatches them through `runtime.emitEvent`;
+ * this module mirrors those SAME events onto the bus under the matching
+ * `health.*` family so the ScheduledTask spine finally sees them:
+ * `health_signal_observed` completion checks flip via `hasSignalSince`, and
+ * plugin-health's observed-anchor resolvers read the envelopes back through
+ * `runtime.activitySignalBus`.
+ *
+ * Publishing is family-validated by the bus (throws on an unregistered
+ * family); the caller's subsystem boundary handles that wiring failure. The
+ * `runtime.emitEvent` dispatch stays alongside — event workflows
+ * (`runDueEventWorkflows`) and the scheduled-task event bridge consume it.
+ */
+
+import {
+  healthBusFamilyForDerivedEventKind,
+  type LifeOpsDerivedEvent,
+} from "@elizaos/plugin-health";
+import type { ActivitySignalBus } from "./bus.js";
+
+export interface PublishDerivedHealthSignalsResult {
+  /** Envelopes actually published to the bus. */
+  published: number;
+  /** Events whose kind intentionally carries no bus family (onset candidates). */
+  unmapped: number;
+}
+
+/**
+ * Publishes each mappable derived event as one bus envelope. `occurredAt`
+ * carries the transition instant (e.g. the observed wake time), which is
+ * exactly what the observed-anchor resolvers return as the anchor instant.
+ */
+export function publishDerivedHealthSignals(
+  bus: ActivitySignalBus,
+  events: readonly LifeOpsDerivedEvent[],
+): PublishDerivedHealthSignalsResult {
+  let published = 0;
+  let unmapped = 0;
+  for (const event of events) {
+    const family = healthBusFamilyForDerivedEventKind(event.kind);
+    if (family === null) {
+      unmapped += 1;
+      continue;
+    }
+    bus.publish({
+      family,
+      occurredAt: event.occurredAt,
+      payload: event.payload,
+      metadata: {
+        source: "lifeops-circadian-tick",
+        eventKind: event.kind,
+        eventId: event.id,
+        confidence: event.confidence,
+      },
+    });
+    published += 1;
+  }
+  return { published, unmapped };
+}

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -1099,6 +1099,16 @@ const rawPersonalAssistantPlugin: Plugin = {
 
     const activitySignalBus = createActivitySignalBus({ familyRegistry });
     registerActivitySignalBus(runtime, activitySignalBus);
+    // Structural runtime property (same pattern as anchorRegistry /
+    // busFamilyRegistry above): plugin-health's observed-anchor resolvers
+    // read wake/sleep transition envelopes back through
+    // `runtime.activitySignalBus` (its `ActivitySignalReader` contract)
+    // without importing this plugin.
+    (
+      runtime as IAgentRuntime & {
+        activitySignalBus?: typeof activitySignalBus;
+      }
+    ).activitySignalBus = activitySignalBus;
 
     await ensureLifeOpsHealthPluginRegistered(runtime);
 

--- a/plugins/plugin-personal-assistant/test/health-signal-bus.test.ts
+++ b/plugins/plugin-personal-assistant/test/health-signal-bus.test.ts
@@ -1,0 +1,401 @@
+/**
+ * #12284 WI-1 + WI-4 end to end across the real seams: real
+ * `deriveSleepWakeEvents` → `publishDerivedHealthSignals` → real
+ * FamilyRegistry-validated bus → real `health_signal_observed` completion
+ * check and real `computeNextFireAt` anchor resolution — no mock stands in
+ * for anything under test. Fixed 2026-05-09 timeline; the bus gets a large
+ * retentionMs because its eviction cutoff is wall-clock `Date.now()`.
+ */
+
+import type {
+  ActivitySignalReader,
+  AnchorRegistry as HealthAnchorRegistry,
+  BusFamilyRegistry as HealthBusFamilyRegistry,
+  LifeOpsScheduleMergedStateRecord,
+} from "@elizaos/plugin-health";
+import {
+  deriveSleepWakeEvents,
+  HEALTH_BUS_FAMILIES,
+  registerHealthAnchors,
+  registerHealthBusFamilies,
+} from "@elizaos/plugin-health";
+import type {
+  AnchorContribution,
+  CompletionCheckContext,
+  OwnerFactsView,
+  ScheduledTask,
+} from "@elizaos/plugin-scheduling";
+import {
+  computeNextFireAt,
+  createAnchorRegistry,
+  createCompletionCheckRegistry,
+  registerBuiltInCompletionChecks,
+} from "@elizaos/plugin-scheduling";
+import { describe, expect, it } from "vitest";
+import {
+  createFamilyRegistry,
+  registerAppLifeOpsBusFamilies,
+  registerBuiltinTelemetryFamilies,
+} from "../src/lifeops/registries/family-registry.js";
+import type { ActivitySignalBus } from "../src/lifeops/signals/bus.js";
+import { createActivitySignalBus } from "../src/lifeops/signals/bus.js";
+import { publishDerivedHealthSignals } from "../src/lifeops/signals/health-signal-publisher.js";
+
+const NY = "America/New_York";
+/** 2026-05-09 09:00 EDT. */
+const NOW_ISO = "2026-05-09T13:00:00.000Z";
+/** 06:47 EDT — the observed wake instant on the fixture day. */
+const WAKE_AT_ISO = "2026-05-09T10:47:00.000Z";
+
+const OWNER_FACTS: OwnerFactsView = {
+  timezone: NY,
+  morningWindow: { start: "07:30", end: "11:00" },
+};
+
+function makeBusWithHealthFamilies(): ActivitySignalBus {
+  const familyRegistry = createFamilyRegistry();
+  registerBuiltinTelemetryFamilies(familyRegistry);
+  registerAppLifeOpsBusFamilies(familyRegistry);
+  registerHealthBusFamilies({
+    busFamilyRegistry: familyRegistry as HealthBusFamilyRegistry,
+  });
+  return createActivitySignalBus({
+    familyRegistry,
+    // Fixture instants are fixed dates; the default 24h sliding window is
+    // anchored on wall-clock Date.now() and would evict them at publish.
+    retentionMs: Number.MAX_SAFE_INTEGER,
+  });
+}
+
+function makeStateRecord(
+  overrides: Partial<LifeOpsScheduleMergedStateRecord> = {},
+): LifeOpsScheduleMergedStateRecord {
+  const baseInsight = {
+    effectiveDayKey: "2026-05-09",
+    localDate: "2026-05-09",
+    timezone: NY,
+    inferredAt: "2026-05-09T10:50:00.000Z",
+    circadianState: "awake" as const,
+    stateConfidence: 0.92,
+    uncertaintyReason: null,
+    relativeTime: {
+      computedAt: "2026-05-09T10:50:00.000Z",
+      localNowAt: "2026-05-09T10:50:00.000Z",
+      circadianState: "awake" as const,
+      stateConfidence: 0.92,
+      uncertaintyReason: null,
+      awakeProbability: {
+        pAwake: 0.9,
+        pAsleep: 0.05,
+        pUnknown: 0.05,
+        contributingSources: [],
+        computedAt: "2026-05-09T10:50:00.000Z",
+      },
+      wakeAnchorAt: WAKE_AT_ISO,
+      wakeAnchorSource: "sleep_cycle" as const,
+      minutesSinceWake: 5,
+      minutesAwake: 5,
+      bedtimeTargetAt: "2026-05-10T03:00:00.000Z",
+      bedtimeTargetSource: "typical_sleep" as const,
+      minutesUntilBedtimeTarget: 960,
+      minutesSinceBedtimeTarget: null,
+      dayBoundaryStartAt: "2026-05-09T09:00:00.000Z",
+      dayBoundaryEndAt: "2026-05-10T09:00:00.000Z",
+      minutesSinceDayBoundaryStart: 120,
+      minutesUntilDayBoundaryEnd: 1320,
+      confidence: 0.92,
+    },
+    awakeProbability: {
+      pAwake: 0.9,
+      pAsleep: 0.05,
+      pUnknown: 0.05,
+      contributingSources: [],
+      computedAt: "2026-05-09T10:50:00.000Z",
+    },
+    regularity: {
+      sri: 78,
+      bedtimeStddevMin: 28,
+      wakeStddevMin: 32,
+      midSleepStddevMin: 30,
+      regularityClass: "regular" as const,
+      sampleCount: 14,
+      windowDays: 28,
+    },
+    baseline: null,
+    circadianRuleFirings: [],
+    sleepStatus: "slept" as const,
+    sleepConfidence: 0.85,
+    currentSleepStartedAt: null,
+    lastSleepStartedAt: "2026-05-09T03:30:00.000Z",
+    lastSleepEndedAt: WAKE_AT_ISO,
+    lastSleepDurationMinutes: 437,
+    wakeAt: WAKE_AT_ISO,
+    firstActiveAt: WAKE_AT_ISO,
+    lastActiveAt: "2026-05-09T10:50:00.000Z",
+    meals: [],
+    lastMealAt: null,
+    nextMealLabel: null,
+    nextMealWindowStartAt: null,
+    nextMealWindowEndAt: null,
+    nextMealConfidence: 0,
+  };
+  return {
+    id: "merged-state-1",
+    agentId: "agent-1",
+    ...baseInsight,
+    ...overrides,
+  } as LifeOpsScheduleMergedStateRecord;
+}
+
+/** sleeping → waking edge: derives `lifeops.wake.observed`. */
+function deriveWakeObserved() {
+  return deriveSleepWakeEvents({
+    previous: makeStateRecord({
+      circadianState: "sleeping",
+      currentSleepStartedAt: "2026-05-09T03:30:00.000Z",
+    }),
+    current: makeStateRecord({ circadianState: "waking" }),
+    now: new Date("2026-05-09T10:47:00.000Z"),
+  });
+}
+
+/** waking → awake edge: derives `lifeops.wake.confirmed` + `lifeops.sleep.ended`. */
+function deriveWakeConfirmed() {
+  return deriveSleepWakeEvents({
+    previous: makeStateRecord({ circadianState: "waking" }),
+    current: makeStateRecord({ circadianState: "awake" }),
+    now: new Date("2026-05-09T10:57:00.000Z"),
+  });
+}
+
+describe("#12284 WI-4 — production publisher onto the real ActivitySignalBus", () => {
+  it("plugin-health registers every health.* family into the real FamilyRegistry", () => {
+    const familyRegistry = createFamilyRegistry();
+    registerBuiltinTelemetryFamilies(familyRegistry);
+    registerAppLifeOpsBusFamilies(familyRegistry);
+    registerHealthBusFamilies({
+      busFamilyRegistry: familyRegistry as HealthBusFamilyRegistry,
+    });
+    for (const family of HEALTH_BUS_FAMILIES) {
+      expect(familyRegistry.has(family)).toBe(true);
+    }
+  });
+
+  it("simulated wake transition → bus hasSignalSince flips true for the family", () => {
+    const bus = makeBusWithHealthFamilies();
+    const sinceIso = "2026-05-09T05:00:00.000Z";
+
+    expect(
+      bus.hasSignalSince({ signalKind: "health.wake.observed", sinceIso }),
+    ).toBe(false);
+
+    const events = deriveWakeObserved();
+    expect(events.map((event) => event.kind)).toEqual([
+      "lifeops.wake.observed",
+    ]);
+    const result = publishDerivedHealthSignals(bus, events);
+    expect(result).toEqual({ published: 1, unmapped: 0 });
+
+    expect(
+      bus.hasSignalSince({ signalKind: "health.wake.observed", sinceIso }),
+    ).toBe(true);
+    // The envelope instant is the observed wake time itself.
+    const envelopes = bus.recent({
+      sinceIso,
+      family: "health.wake.observed",
+    });
+    expect(envelopes).toHaveLength(1);
+    expect(envelopes[0]?.occurredAt).toBe(WAKE_AT_ISO);
+  });
+
+  it("wake.confirmed edge publishes wake.confirmed + sleep.ended; onset candidates stay unmapped", () => {
+    const bus = makeBusWithHealthFamilies();
+    const confirmResult = publishDerivedHealthSignals(
+      bus,
+      deriveWakeConfirmed(),
+    );
+    expect(confirmResult).toEqual({ published: 2, unmapped: 0 });
+    expect(
+      bus.hasSignalSince({
+        signalKind: "health.wake.confirmed",
+        sinceIso: "2026-05-09T05:00:00.000Z",
+      }),
+    ).toBe(true);
+    expect(
+      bus.hasSignalSince({
+        signalKind: "health.sleep.ended",
+        sinceIso: "2026-05-09T05:00:00.000Z",
+      }),
+    ).toBe(true);
+
+    // any → sleeping derives onset_candidate + sleep.detected; the onset
+    // candidate intentionally has no bus family and must be skipped, not
+    // crash the publisher against the validating registry.
+    const sleepEvents = deriveSleepWakeEvents({
+      previous: makeStateRecord({ circadianState: "awake" }),
+      current: makeStateRecord({
+        circadianState: "sleeping",
+        currentSleepStartedAt: "2026-05-10T03:10:00.000Z",
+      }),
+      now: new Date("2026-05-10T03:20:00.000Z"),
+    });
+    expect(sleepEvents.map((event) => event.kind).sort()).toEqual([
+      "lifeops.sleep.detected",
+      "lifeops.sleep.onset_candidate",
+    ]);
+    const sleepResult = publishDerivedHealthSignals(bus, sleepEvents);
+    expect(sleepResult).toEqual({ published: 1, unmapped: 1 });
+  });
+
+  it("health_signal_observed completion check passes through the real bus (no longer always-false)", async () => {
+    const bus = makeBusWithHealthFamilies();
+    const registry = createCompletionCheckRegistry();
+    registerBuiltInCompletionChecks(registry);
+    const check = registry.get("health_signal_observed");
+    expect(check).not.toBeNull();
+    if (!check) throw new Error("health_signal_observed not registered");
+
+    const task: ScheduledTask = {
+      taskId: "task-wake-check",
+      kind: "checkin",
+      promptInstructions: "confirm the owner is up",
+      trigger: {
+        kind: "relative_to_anchor",
+        anchorKey: "wake.confirmed",
+        offsetMinutes: 0,
+      },
+      priority: "medium",
+      respectsGlobalPause: true,
+      source: "default_pack",
+      createdBy: "plugin-health-default-pack",
+      ownerVisible: true,
+      completionCheck: {
+        kind: "health_signal_observed",
+        params: {
+          signalKind: "health.wake.confirmed",
+          requireSinceTaskFired: true,
+        },
+      },
+      state: {
+        status: "fired",
+        firedAt: "2026-05-09T10:00:00.000Z",
+        followupCount: 0,
+      },
+    };
+    const context: CompletionCheckContext = {
+      task,
+      nowIso: NOW_ISO,
+      ownerFacts: OWNER_FACTS,
+      activity: bus,
+      subjectStore: { wasUpdatedSince: () => false },
+      acknowledged: false,
+    };
+
+    expect(await check.shouldComplete(task, context)).toBe(false);
+    publishDerivedHealthSignals(bus, deriveWakeConfirmed());
+    expect(await check.shouldComplete(task, context)).toBe(true);
+  });
+});
+
+describe("#12284 WI-1 — observed anchors resolve through the spine's real anchor path", () => {
+  function makeAnchorsWiredToBus(bus: ActivitySignalBus) {
+    const anchors = createAnchorRegistry();
+    // Same adapter shape the production wiring uses: plugin-health sees the
+    // registry + bus through its structural runtime properties.
+    const registryAdapter: HealthAnchorRegistry = {
+      register(contribution) {
+        anchors.register(contribution as unknown as AnchorContribution, {
+          override: true,
+        });
+      },
+      list: () => [],
+      get: (anchorKey) =>
+        (anchors.get(anchorKey) as unknown as ReturnType<
+          HealthAnchorRegistry["get"]
+        >) ?? null,
+    };
+    registerHealthAnchors({
+      anchorRegistry: registryAdapter,
+      activitySignalBus: bus as ActivitySignalReader,
+    });
+    return anchors;
+  }
+
+  it("relative_to_anchor('wake.confirmed', 30) resolves to observed wake + 30", async () => {
+    const bus = makeBusWithHealthFamilies();
+    const anchors = makeAnchorsWiredToBus(bus);
+    publishDerivedHealthSignals(bus, deriveWakeConfirmed());
+
+    const nextFireAt = await computeNextFireAt(
+      {
+        trigger: {
+          kind: "relative_to_anchor",
+          anchorKey: "wake.confirmed",
+          offsetMinutes: 30,
+        },
+        state: { status: "scheduled", followupCount: 0 },
+        metadata: undefined,
+      },
+      {
+        now: new Date(NOW_ISO),
+        ownerFacts: OWNER_FACTS,
+        anchors,
+      },
+    );
+    // Observed wake 10:47Z (06:47 EDT) + 30min — NOT the configured
+    // morning-window start.
+    expect(nextFireAt).toBe("2026-05-09T11:17:00.000Z");
+  });
+
+  it("falls back to morningWindow.start when no observation exists", async () => {
+    const bus = makeBusWithHealthFamilies();
+    const anchors = makeAnchorsWiredToBus(bus);
+
+    const nextFireAt = await computeNextFireAt(
+      {
+        trigger: {
+          kind: "relative_to_anchor",
+          anchorKey: "wake.confirmed",
+          offsetMinutes: 30,
+        },
+        state: { status: "scheduled", followupCount: 0 },
+        metadata: undefined,
+      },
+      {
+        now: new Date(NOW_ISO),
+        ownerFacts: OWNER_FACTS,
+        anchors,
+      },
+    );
+    // Static default: 07:30 EDT (11:30Z) + 30min.
+    expect(nextFireAt).toBe("2026-05-09T12:00:00.000Z");
+  });
+
+  it("ignores a stale prior-day observation and falls back", async () => {
+    const bus = makeBusWithHealthFamilies();
+    const anchors = makeAnchorsWiredToBus(bus);
+    // Yesterday's confirmed wake, published directly onto the bus.
+    bus.publish({
+      family: "health.wake.confirmed",
+      occurredAt: "2026-05-08T10:47:00.000Z",
+    });
+
+    const nextFireAt = await computeNextFireAt(
+      {
+        trigger: {
+          kind: "relative_to_anchor",
+          anchorKey: "wake.confirmed",
+          offsetMinutes: 30,
+        },
+        state: { status: "scheduled", followupCount: 0 },
+        metadata: undefined,
+      },
+      {
+        now: new Date(NOW_ISO),
+        ownerFacts: OWNER_FACTS,
+        anchors,
+      },
+    );
+    expect(nextFireAt).toBe("2026-05-09T12:00:00.000Z");
+  });
+});


### PR DESCRIPTION
Advances #12284 (work items 1 and 4 — D1 observed-anchor resolution + D2 ActivitySignalBus bridge).

## What landed

**WI-4 — first production `ActivitySignalBus` publisher (wake/sleep transitions):**
- `plugins/plugin-personal-assistant/src/lifeops/signals/health-signal-publisher.ts` (new): `publishDerivedHealthSignals` maps each derived circadian transition (`lifeops.wake.observed`, `lifeops.wake.confirmed`, `lifeops.sleep.detected/ended`, `lifeops.nap.detected`, `lifeops.bedtime.imminent`, `lifeops.regularity.changed`) onto its registered `health.*` bus family and publishes one envelope per event, `occurredAt` = the transition instant. `lifeops.sleep.onset_candidate` intentionally stays off the bus (no registered family; always fires paired with `sleep.detected`).
- `plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts` (circadian_state subsystem of the legacy tick): after the existing audit-dedup + `runtime.emitEvent` dispatch, newly inserted transitions are ALSO published to the bus. The `runtime.emitEvent` call stays — `runDueEventWorkflows` and the scheduled-task event bridge (`installLifeOpsScheduledTaskEventBridge`) still consume those events, so removal is not safe (verified: `trigger {kind:"event"}` tasks route through `runtime.emitEvent`).
- `plugins/plugin-health/src/sleep/sleep-wake-events.ts`: `healthBusFamilyForDerivedEventKind` — the single event-kind→bus-family mapping both the publisher and the anchor resolvers agree on.
- `plugins/plugin-personal-assistant/src/plugin.ts`: the bus is additionally attached as the structural runtime property `runtime.activitySignalBus` (same pattern as `anchorRegistry`/`busFamilyRegistry`) so plugin-health reads envelopes back without importing PA.

**WI-1 — real health-anchor resolvers (replaces `resolve: async () => null`):**
- `plugins/plugin-health/src/connectors/index.ts`: `buildAnchorContribution` now resolves each of the 4 anchors from the most recent bus envelope of its family — `wake.observed`→`health.wake.observed`, `wake.confirmed`→`health.wake.confirmed`, `nap.start`→`health.nap.detected`, `bedtime.target`→`health.bedtime.imminent`. `relative_to_anchor("wake.confirmed", offset)` now anchors on the ACTUAL observed wake instant.
- Freshness rules (pinned by tests): observation anchors accept only a transition on the SAME local calendar day as `nowIso` in the owner's timezone (tighter than the issue's 24–48h bound: after local midnight, yesterday's wake must never anchor today's schedule) and not >5min in the future; `bedtime.target` accepts the target within ±12h of now. Anything else resolves `null` → the spine's existing static defaults (`morningWindow.start` / `eveningWindow.end`/22:30 in `next-fire-at.ts`) take over. `resolve()` never throws (J4-annotated catch; a broken reader degrades to the static default with a warn).
- `plugins/plugin-health/src/connectors/contract-types.ts`: structural `ActivitySignalReader`/`ActivitySignalRecord` contracts + optional `activitySignalBus` on `RuntimeWithHealthRegistries` (plugin-health must not import PA; the dependency points the other way).

**Binding constraints respected:** everything bridges into the existing `ScheduledTask` spine — no second scheduler, no `promptInstructions` branching (root `AGENTS.md:156-171`); anchors keep the soft-dependency posture (absent registry/bus → logged skip / static fallback, never a throw).

## Done-when (from the issue)

- `relative_to_anchor("wake.confirmed", offset)` resolves to actual observed wake on a day it occurred, static fallback otherwise — pinned by `test/health-signal-bus.test.ts` driving the REAL `computeNextFireAt` + REAL `createAnchorRegistry` + REAL bus: observed 10:47Z+30 → `11:17Z`, no observation → `12:00Z` (07:30 EDT window + 30).
- `ActivitySignalBus` has ≥1 real production publisher — the circadian tick in `reminders-service.ts` (production path, not test-only).
- `health_signal_observed` can pass in a test — the REAL registered check flips false→true through the real bus after a simulated wake transition.

## Verification

New tests (all through real seams — real `FamilyRegistry` + `registerHealthBusFamilies`, real bus, real completion-check/anchor registries from `@elizaos/plugin-scheduling`, real `deriveSleepWakeEvents`; no mock stand-ins for anything under test):

- `plugins/plugin-health/src/__tests__/anchor-resolvers.test.ts` — 18 tests: observed resolution, latest-of-day selection, static-fallback on none, prior-local-day rejection (<24h old but yesterday), multi-day-stale rejection, future-beyond-skew rejection, family re-check against a filter-ignoring reader, nap + bedtime-target semantics, ±12h target bound, invalid-timezone UTC degrade, throwing reader → null, unparseable envelopes skipped, missing reader → null, malformed resolve contexts → null (never throws), kind→family mapping totality.
- `plugins/plugin-personal-assistant/test/health-signal-bus.test.ts` — 7 tests: families registered in the real registry; wake transition → `hasSignalSince` flips true with `occurredAt` = wake instant; wake-confirmed edge publishes `wake.confirmed`+`sleep.ended` while onset candidates stay unmapped (validating bus does not throw); `health_signal_observed` false→true through the real bus; `computeNextFireAt` resolves observed wake+30; morning-window fallback when no observation; stale prior-day observation ignored → fallback.

Suite results (lane, develop @ 76c9253d1 + this diff, after `bun install`):

```
plugins/plugin-health          bun run test   → 33/34 files passed | 171 tests passed, 4 skipped
                                                (1 pre-existing failure, see below)
  └─ src/__tests__/anchor-resolvers.test.ts   → 18/18 passed
plugins/plugin-personal-assistant (scoped)    → test/health-signal-bus.test.ts 7/7 passed
plugins/plugin-scheduling      bun run test   → 19 files, 241/241 tests passed
plugin-health typecheck (tsgo)                → clean; both touched packages green in the turbo run below
```

Full verify chain (`bun run verify` steps run individually; turbo step with `--continue`):

```
check:agents-claude                 PASS (301 pairs byte-identical)
audit:type-safety-ratchet           PASS
audit:error-policy-ratchet          PASS (no new fallback-slop in touched files)
turbo typecheck+lint (578 tasks)    571 successful — plugin-health / plugin-personal-assistant /
                                    plugin-scheduling typecheck+lint ALL GREEN; failures below
audit:build-model                   PASS
audit:turbo-build-deps              FAIL — pre-existing, reproduced identically on clean develop (see below)
audit:tee-secret-leak               PASS
audit:scripts                       PASS
audit:test-realness                 PASS (report-only)
typecheck:dist                      PASS (28 configs)
```

verify green except pre-existing develop failures app#typecheck/electrobun#typecheck (untouched by this PR).

Additional develop-side drift, each REPRODUCED on clean origin/develop @ 76c9253d1 with this branch's diff fully stashed (this diff touches none of the involved files; `git diff origin/develop` on this branch contains only the 8 files listed above):
- `@elizaos/tui#lint` — 45 biome errors (e.g. `noControlCharactersInRegex` in `src/keys.ts`, `test/editor.test.ts`); exit 1 with and without this diff.
- `@elizaos/electrobun#lint`, `@elizaos/plugin-computeruse#lint` — exit 1 with and without this diff.
- `@elizaos/plugin-sub-agent-claude-code#typecheck` — exit 1 with and without this diff.
- `audit:turbo-build-deps` — phantom `#build` overrides for ~15 example packages (`example-telegram`, `registry`, `@moltbook/eliza-agent`, …); exit 1 with and without this diff.
- `@elizaos/plugin-capacitor-bridge#typecheck` failed once inside the concurrent turbo run but passes standalone both with and without this diff (transient dist churn during the parallel build).
- `plugins/plugin-health/src/__tests__/smoke.test.ts` fails at import time (`TypeError: Cannot convert undefined or null to object`) because it imports the package barrel, which pulls the real `@elizaos/ui` root export chain. Reproduced identically with the diff stashed at the same base. All other 33 plugin-health test files pass, including both new test files.

## Evidence rows (PR_EVIDENCE.md)

| Evidence | Status |
| --- | --- |
| Real LLM-call trajectory | N/A - no agent/action/provider/prompt/model behavior change; this is deterministic scheduler/bus data-path code, exercised end-to-end through the real registries in the tests above |
| Backend logs | Test-run output above shows the real code path (real bus publish → real completion check → real `computeNextFireAt`); production warn paths (`ActivitySignalBus not registered`, anchor read failure) are code-reviewed and unit-pinned |
| Frontend logs | N/A - no UI surface |
| Full-page screenshots / video | N/A - no UI surface |
| Domain artifacts | Bus envelopes + `nextFireAt` values asserted in tests (`occurredAt` = observed wake instant; `2026-05-09T11:17:00.000Z` vs fallback `12:00Z`) |

## Deviations from the issue text

- Observation freshness is same-local-day (owner timezone) rather than a 24–48h sliding bound — strictly tighter, prevents yesterday's wake from anchoring today after midnight; documented in code and pinned by a dedicated test.
- `runtime.emitEvent` NOT removed (issue allowed either): the scheduled-task event bridge and event workflows still consume those emissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
