### PR TITLE
feat(#12284): reminderIntensity-driven no-reply/escalation policy + quiet-watcher softening (WI-6, WI-8)

### DIFF
--- a/.github/issue-evidence/12284-quiet-streak-softening.md
+++ b/.github/issue-evidence/12284-quiet-streak-softening.md
@@ -1,0 +1,71 @@
+# #12284 items 6+8 — quiet-streak softening of the no-reply ladder (evidence)
+
+Branch `feat/12284-intensity-quiet-watcher`, based on `develop` @ b24dec831.
+Companion to `12284-reminder-intensity-noreply.md` (#12952, item 6's lookup):
+this change gives the quiet-user-watcher signal its structural consumer (item
+8) through the SAME intensity lookup, and gives the recent-task-states log its
+production writer so a real quiet streak can actually form.
+
+## Targeted suites (local, real repository-backed runtime — no scheduler mocks)
+
+`bunx vitest run --config vitest.config.ts src/lifeops/scheduled-task/no-reply-intensity.test.ts src/lifeops/scheduled-task/scheduler.no-reply-policy.test.ts src/lifeops/scheduled-task/scheduler.quiet-streak.test.ts`
+
+```
+ Test Files  3 passed (3)
+      Tests  23 passed (23)
+```
+
+Per file: `no-reply-intensity.test.ts` 8 (6 existing + 2 softener unit cases) ·
+`scheduler.no-reply-policy.test.ts` 9 (8 existing + 1 new auditability case) ·
+`scheduler.quiet-streak.test.ts` 6 (new).
+
+The quiet-streak suite drives REAL scheduler ticks end to end: three
+consecutive ignored check-ins flow through fire → completion-timeout →
+terminal `expired`, each transition appended to the recent-task-states log by
+the production writer (`recordTaskStateEntry`), and the day-4 reminder's
+resolved ladder is asserted from the persisted task record:
+
+- softened: `metadata.noReplyPolicy { maxRetries: 0, retryCadenceMinutes: [] }`,
+  `metadata.noReplyState { quietStreakSoftened: true, quietStreakDays: 3, appliedReminderIntensity: "minimal" }`
+- contrast persona (no history): `{ maxRetries: 1, retryCadenceMinutes: [60] }`, no softening flags
+- streak broken by a reply (`completed` entry): no softening
+- explicit `persistent` owner + streak: one notch to `normal` (1 retry, not 2)
+- approvals: full 2-retry 30/120 cadence preserved (never softened)
+- owner reply through the real `MESSAGE_RECEIVED` seam appends the
+  streak-breaking `completed` log entry
+
+## Adjacent suites
+
+- `inbound-reply-completion.integration.test.ts` — 5 passed (its completion
+  path now appends the streak-breaking entry)
+- `test/recent-task-states.integration.test.ts` — 2 passed
+- `test/default-pack-spine-seeding.test.ts` + `test/default-packs.smoke.test.ts` — 9 passed
+- `bun run --cwd plugins/plugin-scheduling test` — 19 files, 238 passed
+  (package untouched; PA-side seam chosen, same rationale as #12952)
+- `bun run --cwd plugins/plugin-personal-assistant typecheck` — exit 0
+
+## Full package suite + pre-existing develop failures
+
+`bun run --cwd plugins/plugin-personal-assistant test`:
+
+```
+ Test Files  4 failed | 139 passed (143)
+      Tests  9 failed | 1144 passed | 7 skipped (1160)
+```
+
+All 9 failures reproduce verbatim (same tests, same files) on a detached
+clean checkout of `origin/develop` @ b24dec831 — none of the 4 files is
+touched by this branch:
+
+```
+ Test Files  4 failed (4)
+      Tests  9 failed | 29 passed (38)
+```
+
+- `src/actions/life-reminder-datetime.test.ts` (1) — #12998's rage-quit
+  delete-trap regression, merged as a known safety gap
+- `src/lifeops/domains/reminders-service.process-scheduled-work.test.ts` (5) —
+  `travel_reconcile` subsystem (#13211) calls `cache.getCache` against that
+  test's mock runtime
+- `test/signature-deadline-scheduler.test.ts` (1)
+- `src/components/BlockerSettingsCards.test.tsx` (2)

--- a/plugins/plugin-personal-assistant/src/default-packs/contract-types.ts
+++ b/plugins/plugin-personal-assistant/src/default-packs/contract-types.ts
@@ -203,6 +203,8 @@ export interface RecentTaskStatesProvider {
     kinds?: ScheduledTaskKind[];
     subjectIds?: string[];
     lookbackDays?: number;
+    /** Pins the lookback window's upper bound; defaults to wall clock. */
+    asOf?: Date;
   }): Promise<RecentTaskStatesSummary>;
 }
 

--- a/plugins/plugin-personal-assistant/src/default-packs/quiet-user-watcher.ts
+++ b/plugins/plugin-personal-assistant/src/default-packs/quiet-user-watcher.ts
@@ -11,6 +11,13 @@
  * morning-brief pack to fold in; it does **not** send a separate
  * notification (that's what the consolidation policy on `wake.confirmed` is
  * for — see `consolidation-policies.ts`).
+ *
+ * The observations also have one structural consumer (#12284 item 8): the
+ * scheduled-task tick derives the quiet streak through the same helpers and
+ * softens the next no-reply ladder one intensity notch
+ * (`softenReminderIntensityForQuietStreak` in
+ * `../lifeops/scheduled-task/no-reply-intensity.ts`) — back off a silent
+ * owner instead of repeating the same cadence at them.
  */
 
 import type {
@@ -141,16 +148,32 @@ export function deriveQuietObservations(
 }
 
 /**
+ * Extract the quiet-streak length (in ignored check-ins/follow-ups) from a
+ * set of watcher observations, or `undefined` when the owner is not quiet.
+ * The structural seam the scheduler's no-reply softening keys on.
+ */
+export function quietStreakDaysFromObservations(
+  observations: QuietUserWatcherObservation[],
+): number | undefined {
+  const quiet = observations.find(
+    (observation) => observation.kind === "quiet_for_days",
+  );
+  return quiet?.days;
+}
+
+/**
  * Convenience wrapper for the runtime: ask the provider for a summary, then
- * derive observations.
+ * derive observations. `asOf` pins the lookback window for deterministic
+ * tick-time evaluation (defaults to wall clock inside the provider).
  */
 export async function runQuietUserWatcher(
   provider: RecentTaskStatesProvider,
-  options: { thresholdDays?: number; lookbackDays?: number } = {},
+  options: { thresholdDays?: number; lookbackDays?: number; asOf?: Date } = {},
 ): Promise<QuietUserWatcherObservation[]> {
   const summary = await provider.summarize({
     kinds: ["checkin", "followup"],
     lookbackDays: options.lookbackDays ?? 7,
+    ...(options.asOf ? { asOf: options.asOf } : {}),
   });
   return deriveQuietObservations(summary, {
     thresholdDays: options.thresholdDays,

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.ts
@@ -32,6 +32,7 @@ import {
   pendingPromptRoomIdForTask,
 } from "@elizaos/plugin-scheduling";
 import { resolvePendingPromptsStore } from "../pending-prompts/store.js";
+import { recordTaskStateEntry } from "./scheduler.js";
 
 const LOG_SRC = "lifeops:scheduled-task:inbound-reply-completion";
 
@@ -81,6 +82,14 @@ export async function completeFiredTasksOnOwnerReply(
       if (updated.state.status === "completed") {
         result.completed.push(task.taskId);
         await resolvePendingPromptsStore(runtime).forgetTask(task.taskId);
+        // Feed the recent-task-states log: the reply is the engagement
+        // signal that breaks a quiet streak (#12284 item 8). Never throws.
+        await recordTaskStateEntry(
+          runtime,
+          updated,
+          "completed",
+          new Date(repliedAtIso),
+        );
         logger.info(
           {
             src: LOG_SRC,

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/no-reply-intensity.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/no-reply-intensity.test.ts
@@ -1,11 +1,13 @@
 /**
  * Pure-transform coverage for reminder-intensity → no-reply ladder (#12284 D3).
- * No runtime graph: exercises `applyReminderIntensityToNoReplyPolicy` directly.
+ * No runtime graph: exercises `applyReminderIntensityToNoReplyPolicy` and the
+ * quiet-streak intensity softener directly.
  */
 import { describe, expect, it } from "vitest";
 import {
   applyReminderIntensityToNoReplyPolicy,
   type NoReplyLadder,
+  softenReminderIntensityForQuietStreak,
 } from "./no-reply-intensity.ts";
 
 const base: NoReplyLadder = { maxRetries: 1, retryCadenceMinutes: [60] };
@@ -76,5 +78,23 @@ describe("applyReminderIntensityToNoReplyPolicy", () => {
     expect(
       applyReminderIntensityToNoReplyPolicy(rich, "minimal", "high"),
     ).toMatchObject({ terminalStatus: "skipped", sensitive: true });
+    expect(
+      applyReminderIntensityToNoReplyPolicy(rich, "persistent", "high"),
+    ).toMatchObject({ terminalStatus: "skipped", sensitive: true });
+  });
+});
+
+describe("softenReminderIntensityForQuietStreak", () => {
+  it("steps each intensity one notch down toward less chasing", () => {
+    expect(softenReminderIntensityForQuietStreak("persistent")).toBe("normal");
+    expect(softenReminderIntensityForQuietStreak("normal")).toBe("minimal");
+    expect(softenReminderIntensityForQuietStreak(undefined)).toBe("minimal");
+  });
+
+  it("keeps the already-suppressive intensities as fixed points", () => {
+    expect(softenReminderIntensityForQuietStreak("minimal")).toBe("minimal");
+    expect(softenReminderIntensityForQuietStreak("high_priority_only")).toBe(
+      "high_priority_only",
+    );
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/no-reply-intensity.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/no-reply-intensity.ts
@@ -1,5 +1,5 @@
 /**
- * Pure reminder-intensity → no-reply-policy transform (#12284 D3).
+ * Pure reminder-intensity → no-reply-policy transforms (#12284 D3 items 6+8).
  *
  * The owner's `reminderIntensity` fact shapes how persistently the tick-driven
  * no-reply loop re-nudges when the owner does not reply. This is the structural
@@ -7,8 +7,13 @@
  * (which shapes the legacy reminder-plan steps): the initial fire always
  * happens; intensity only reshapes the *follow-up* ladder.
  *
- * Kept as a standalone pure function so it is unit-testable without booting the
- * scheduler's runtime graph. `scheduler.ts` calls it against the default
+ * The quiet-streak softener lives here too so the quiet-user-watcher signal
+ * modulates behavior through the SAME intensity lookup instead of a second
+ * policy mechanism: a ≥3-day silent streak steps the effective intensity one
+ * notch down, and the regular intensity table does the rest.
+ *
+ * Kept as standalone pure functions so they are unit-testable without booting
+ * the scheduler's runtime graph. `scheduler.ts` calls them against the default
  * per-kind policy before merging any explicit per-task `metadata.noReplyPolicy`
  * override (which still wins).
  */
@@ -55,5 +60,28 @@ export function applyReminderIntensityToNoReplyPolicy<T extends NoReplyLadder>(
     }
     default:
       return policy;
+  }
+}
+
+/**
+ * Step the effective reminder intensity one notch DOWN for a quiet streak
+ * (#12284 item 8): when the owner has ignored ≥3 consecutive check-ins, the
+ * next no-reply ladder is selected as if the owner had asked for one level
+ * less chasing — never a guilt-framed extra poke. `minimal` has no lower
+ * notch, and `high_priority_only` already suppresses everything non-critical,
+ * so both are fixed points. An unset intensity softens like `normal`.
+ */
+export function softenReminderIntensityForQuietStreak(
+  intensity: ReminderIntensity | undefined,
+): ReminderIntensity {
+  switch (intensity) {
+    case "persistent":
+      return "normal";
+    case "minimal":
+      return "minimal";
+    case "high_priority_only":
+      return "high_priority_only";
+    default:
+      return "minimal";
   }
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.no-reply-policy.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.no-reply-policy.test.ts
@@ -493,4 +493,27 @@ describe("processDueScheduledTasks — reminder intensity modulates the no-reply
     );
     expect(retried?.metadata?.noReplyPolicy).toMatchObject({ maxRetries: 1 });
   });
+
+  it("records the applied intensity on the task so the ladder choice is auditable", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const repo = new LifeOpsRepository(runtime);
+    await resolveOwnerFactStore(runtime).setReminderIntensity(
+      { intensity: "persistent" },
+      provenance,
+    );
+    const reminder = await seedFiredReminder(runtime, "high");
+
+    const result = await timeoutTick(runtime);
+
+    expect(result.errors).toEqual([]);
+    const retried = await repo.getScheduledTask(
+      runtime.agentId,
+      reminder.taskId,
+    );
+    expect(retried?.metadata?.noReplyState).toMatchObject({
+      retryCount: 1,
+      appliedReminderIntensity: "persistent",
+    });
+  });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.quiet-streak.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.quiet-streak.test.ts
@@ -1,0 +1,431 @@
+/**
+ * Quiet-streak no-reply softening (#12284 item 8), end to end on the real
+ * repository-backed runtime: three consecutive ignored check-ins — driven
+ * through actual scheduler ticks that also exercise the recent-task-states
+ * log's production writer — step the next reminder's effective intensity one
+ * notch down, observable in the persisted policy object. Contrast personas
+ * (no history, streak broken by a reply, approvals) prove the softening is
+ * scoped and reversible.
+ */
+import { EventType, type Memory } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createLifeOpsTestRuntime,
+  type RealTestRuntimeResult,
+} from "../../../test/helpers/runtime.ts";
+import {
+  appendScheduledTaskLogEntry,
+  readScheduledTaskLog,
+} from "../../providers/recent-task-states.ts";
+import { resolveOwnerFactStore } from "../owner/fact-store.ts";
+import { resolvePendingPromptsStore } from "../pending-prompts/store.ts";
+import { LifeOpsRepository } from "../repository.ts";
+import type { ScheduledTask } from "./index.ts";
+import {
+  type ProcessDueScheduledTasksResult,
+  processDueScheduledTasks,
+} from "./scheduler.ts";
+
+type Runtime = RealTestRuntimeResult["runtime"];
+
+let runtimeResult: RealTestRuntimeResult | undefined;
+
+afterEach(async () => {
+  await runtimeResult?.cleanup?.();
+  runtimeResult = undefined;
+});
+
+function tick(
+  runtime: Runtime,
+  nowIso: string,
+): Promise<ProcessDueScheduledTasksResult> {
+  return processDueScheduledTasks({
+    runtime,
+    agentId: runtime.agentId,
+    now: new Date(nowIso),
+    limit: 10,
+  });
+}
+
+interface Seed extends Omit<ScheduledTask, "taskId" | "state" | "createdBy"> {
+  taskId: string;
+  state?: ScheduledTask["state"];
+}
+
+async function seedTask(runtime: Runtime, seed: Seed): Promise<ScheduledTask> {
+  const repo = new LifeOpsRepository(runtime);
+  const task: ScheduledTask = {
+    taskId: seed.taskId,
+    kind: seed.kind,
+    promptInstructions: seed.promptInstructions,
+    trigger: seed.trigger,
+    priority: seed.priority,
+    respectsGlobalPause: seed.respectsGlobalPause,
+    source: seed.source,
+    createdBy: runtime.agentId,
+    ownerVisible: seed.ownerVisible,
+    state: seed.state ?? { status: "scheduled", followupCount: 0 },
+    ...(seed.completionCheck ? { completionCheck: seed.completionCheck } : {}),
+    ...(seed.metadata ? { metadata: seed.metadata } : {}),
+  };
+  await repo.upsertScheduledTask(runtime.agentId, task);
+  return task;
+}
+
+/** A checkin that goes terminal `expired` on its FIRST unanswered timeout. */
+function quietCheckinSeed(taskId: string, day: string): Seed {
+  return {
+    taskId,
+    kind: "checkin",
+    promptInstructions: "How are you doing today?",
+    trigger: { kind: "once", atIso: `${day}T08:00:00.000Z` },
+    priority: "medium",
+    respectsGlobalPause: false,
+    source: "default_pack",
+    ownerVisible: true,
+    completionCheck: { kind: "user_replied_within", followupAfterMinutes: 60 },
+    metadata: {
+      noReplyPolicy: {
+        maxRetries: 0,
+        terminalStatus: "expired",
+        terminalReason: "no_reply_checkin_expired",
+      },
+    },
+  };
+}
+
+function firedReminderSeed(
+  taskId: string,
+  firedAtIso: string,
+  priority: ScheduledTask["priority"] = "medium",
+): Seed {
+  return {
+    taskId,
+    kind: "reminder",
+    promptInstructions: "Stretch for five minutes.",
+    trigger: { kind: "once", atIso: firedAtIso },
+    priority,
+    respectsGlobalPause: false,
+    source: "user_chat",
+    ownerVisible: true,
+    completionCheck: { kind: "user_acknowledged", followupAfterMinutes: 30 },
+    state: { status: "fired", followupCount: 0, firedAt: firedAtIso },
+  };
+}
+
+/** Directly seed a 3-day ignored-checkin history into the task-states log. */
+async function seedQuietHistory(runtime: Runtime): Promise<void> {
+  for (const day of ["2026-05-09", "2026-05-10", "2026-05-11"]) {
+    await appendScheduledTaskLogEntry(runtime, {
+      taskId: `st_history_${day}`,
+      kind: "checkin",
+      outcome: "expired",
+      recordedAt: `${day}T09:00:00.000Z`,
+    });
+  }
+}
+
+describe("processDueScheduledTasks — quiet streak softens the next no-reply ladder (#12284)", () => {
+  it("3 ignored check-ins driven through REAL ticks soften the next reminder to fire-once", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const repo = new LifeOpsRepository(runtime);
+
+    // Day 1 check-in is already fired and unanswered; days 2-3 fire through
+    // the tick loop so the log's fired/terminal writer paths both run.
+    await seedTask(runtime, {
+      ...quietCheckinSeed("st_quiet_checkin_d1", "2026-05-09"),
+      state: {
+        status: "fired",
+        followupCount: 0,
+        firedAt: "2026-05-09T08:00:00.000Z",
+      },
+    });
+    await seedTask(
+      runtime,
+      quietCheckinSeed("st_quiet_checkin_d2", "2026-05-10"),
+    );
+    await seedTask(
+      runtime,
+      quietCheckinSeed("st_quiet_checkin_d3", "2026-05-11"),
+    );
+
+    // Day 1: the unanswered check-in expires terminally (maxRetries 0).
+    const day1 = await tick(runtime, "2026-05-09T09:01:00.000Z");
+    expect(day1.errors).toEqual([]);
+    expect(day1.completionTimeouts).toMatchObject([
+      { taskId: "st_quiet_checkin_d1", status: "expired" },
+    ]);
+
+    // Day 2: fire, then expire unanswered.
+    const day2Fire = await tick(runtime, "2026-05-10T08:01:00.000Z");
+    expect(day2Fire.errors).toEqual([]);
+    expect(
+      day2Fire.fires.find((fire) => fire.taskId === "st_quiet_checkin_d2")
+        ?.status,
+    ).toBe("fired");
+    const day2Timeout = await tick(runtime, "2026-05-10T09:02:00.000Z");
+    expect(day2Timeout.completionTimeouts).toMatchObject([
+      { taskId: "st_quiet_checkin_d2", status: "expired" },
+    ]);
+
+    // Day 3: fire, then expire unanswered — the streak reaches 3.
+    const day3Fire = await tick(runtime, "2026-05-11T08:01:00.000Z");
+    expect(
+      day3Fire.fires.find((fire) => fire.taskId === "st_quiet_checkin_d3")
+        ?.status,
+    ).toBe("fired");
+    const day3Timeout = await tick(runtime, "2026-05-11T09:02:00.000Z");
+    expect(day3Timeout.completionTimeouts).toMatchObject([
+      { taskId: "st_quiet_checkin_d3", status: "expired" },
+    ]);
+
+    // The production log writer recorded the real activity: 2 fires + 3
+    // terminal expiries, in tick order.
+    const log = await readScheduledTaskLog(runtime);
+    expect(
+      log
+        .filter((entry) => entry.kind === "checkin")
+        .map((entry) => entry.outcome),
+    ).toEqual(["expired", "fired", "expired", "fired", "expired"]);
+
+    // Day 4: an otherwise-normal reminder times out. Without the streak it
+    // would earn a 60-minute retry; the quiet streak softens the effective
+    // intensity (normal → minimal) so it settles terminally instead of
+    // re-poking a silent owner.
+    await seedTask(
+      runtime,
+      firedReminderSeed("st_quiet_reminder", "2026-05-12T08:00:00.000Z"),
+    );
+    const day4 = await tick(runtime, "2026-05-12T08:31:00.000Z");
+    expect(day4.errors).toEqual([]);
+    expect(day4.completionTimeouts).toMatchObject([
+      { taskId: "st_quiet_reminder", status: "skipped" },
+    ]);
+    const softened = await repo.getScheduledTask(
+      runtime.agentId,
+      "st_quiet_reminder",
+    );
+    expect(softened?.state.status).toBe("skipped");
+    // The softening decision is structural AND observable in the record.
+    expect(softened?.metadata?.noReplyPolicy).toMatchObject({
+      maxRetries: 0,
+      retryCadenceMinutes: [],
+    });
+    expect(softened?.metadata?.noReplyState).toMatchObject({
+      quietStreakSoftened: true,
+      quietStreakDays: 3,
+      appliedReminderIntensity: "minimal",
+    });
+  });
+
+  it("contrast persona with NO quiet history keeps the normal 60-minute re-nudge", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const repo = new LifeOpsRepository(runtime);
+
+    await seedTask(
+      runtime,
+      firedReminderSeed("st_active_reminder", "2026-05-12T08:00:00.000Z"),
+    );
+    const result = await tick(runtime, "2026-05-12T08:31:00.000Z");
+    expect(result.errors).toEqual([]);
+    expect(result.completionTimeouts).toMatchObject([
+      {
+        taskId: "st_active_reminder",
+        status: "scheduled",
+        reason: "no_reply_retry_1",
+      },
+    ]);
+    const retried = await repo.getScheduledTask(
+      runtime.agentId,
+      "st_active_reminder",
+    );
+    expect(retried?.state.firedAt).toBe("2026-05-12T09:31:00.000Z");
+    expect(retried?.metadata?.noReplyPolicy).toMatchObject({
+      maxRetries: 1,
+      retryCadenceMinutes: [60],
+    });
+    expect(retried?.metadata?.noReplyState).not.toMatchObject({
+      quietStreakSoftened: true,
+    });
+  });
+
+  it("a reply breaks the streak: expired,expired,expired,completed → no softening", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const repo = new LifeOpsRepository(runtime);
+
+    await seedQuietHistory(runtime);
+    await appendScheduledTaskLogEntry(runtime, {
+      taskId: "st_history_reply",
+      kind: "checkin",
+      outcome: "completed",
+      recordedAt: "2026-05-12T07:00:00.000Z",
+    });
+
+    await seedTask(
+      runtime,
+      firedReminderSeed("st_reengaged_reminder", "2026-05-12T08:00:00.000Z"),
+    );
+    const result = await tick(runtime, "2026-05-12T08:31:00.000Z");
+    expect(result.completionTimeouts).toMatchObject([
+      {
+        taskId: "st_reengaged_reminder",
+        status: "scheduled",
+        reason: "no_reply_retry_1",
+      },
+    ]);
+    const retried = await repo.getScheduledTask(
+      runtime.agentId,
+      "st_reengaged_reminder",
+    );
+    expect(retried?.metadata?.noReplyState).not.toMatchObject({
+      quietStreakSoftened: true,
+    });
+  });
+
+  it("softens an explicit `persistent` owner one notch to `normal` — same lookup, fewer nudges", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const repo = new LifeOpsRepository(runtime);
+
+    await resolveOwnerFactStore(runtime).setReminderIntensity(
+      { intensity: "persistent" },
+      { source: "policy_action", recordedAt: "2026-05-08T10:00:00.000Z" },
+    );
+    await seedQuietHistory(runtime);
+    await seedTask(
+      runtime,
+      firedReminderSeed(
+        "st_persistent_quiet_reminder",
+        "2026-05-12T08:00:00.000Z",
+        "high",
+      ),
+    );
+
+    const result = await tick(runtime, "2026-05-12T08:31:00.000Z");
+    // Still one retry (normal), NOT the persistent two-retry ladder.
+    expect(result.completionTimeouts).toMatchObject([
+      {
+        taskId: "st_persistent_quiet_reminder",
+        status: "scheduled",
+        reason: "no_reply_retry_1",
+      },
+    ]);
+    const retried = await repo.getScheduledTask(
+      runtime.agentId,
+      "st_persistent_quiet_reminder",
+    );
+    expect(retried?.metadata?.noReplyPolicy).toMatchObject({
+      maxRetries: 1,
+      retryCadenceMinutes: [60],
+    });
+    expect(retried?.metadata?.noReplyState).toMatchObject({
+      quietStreakSoftened: true,
+      quietStreakDays: 3,
+      appliedReminderIntensity: "normal",
+    });
+  });
+
+  it("approvals are NOT softened by a quiet streak (they gate agent actions)", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const repo = new LifeOpsRepository(runtime);
+
+    await seedQuietHistory(runtime);
+    await seedTask(runtime, {
+      taskId: "st_quiet_approval",
+      kind: "approval",
+      promptInstructions: "Approve the low-risk plan?",
+      trigger: { kind: "once", atIso: "2026-05-12T08:00:00.000Z" },
+      priority: "medium",
+      respectsGlobalPause: false,
+      source: "user_chat",
+      ownerVisible: true,
+      completionCheck: { kind: "user_acknowledged", followupAfterMinutes: 30 },
+      state: {
+        status: "fired",
+        followupCount: 0,
+        firedAt: "2026-05-12T08:00:00.000Z",
+      },
+    });
+
+    const result = await tick(runtime, "2026-05-12T08:31:00.000Z");
+    expect(result.completionTimeouts).toMatchObject([
+      {
+        taskId: "st_quiet_approval",
+        status: "scheduled",
+        reason: "no_reply_retry_1",
+      },
+    ]);
+    const retried = await repo.getScheduledTask(
+      runtime.agentId,
+      "st_quiet_approval",
+    );
+    // Full approval cadence preserved: 2 retries at 30/120 minutes.
+    expect(retried?.metadata?.noReplyPolicy).toMatchObject({
+      maxRetries: 2,
+      retryCadenceMinutes: [30, 120],
+    });
+    expect(retried?.state.firedAt).toBe("2026-05-12T09:01:00.000Z");
+    expect(retried?.metadata?.noReplyState).not.toMatchObject({
+      quietStreakSoftened: true,
+    });
+  });
+
+  it("an owner reply through the REAL MESSAGE_RECEIVED seam appends the streak-breaking log entry", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const roomId = "room-quiet-streak-1";
+
+    const repo = new LifeOpsRepository(runtime);
+    const firedAtIso = new Date(Date.now() - 5 * 60_000).toISOString();
+    const checkin: ScheduledTask = {
+      taskId: "st_replyable_checkin",
+      kind: "checkin",
+      promptInstructions: "How did the afternoon go?",
+      trigger: { kind: "manual" },
+      priority: "medium",
+      respectsGlobalPause: false,
+      source: "default_pack",
+      createdBy: runtime.agentId,
+      ownerVisible: true,
+      completionCheck: { kind: "user_replied_within" },
+      metadata: { pendingPromptRoomId: roomId },
+      state: { status: "fired", firedAt: firedAtIso, followupCount: 0 },
+    };
+    await repo.upsertScheduledTask(runtime.agentId, checkin);
+    await resolvePendingPromptsStore(runtime).record({
+      roomId,
+      taskId: checkin.taskId,
+      promptSnippet: checkin.promptInstructions,
+      firedAt: firedAtIso,
+      expectedReplyKind: "free_form",
+    });
+
+    await runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
+      message: {
+        id: "msg-quiet-streak-reply",
+        entityId: "owner-entity-1",
+        roomId,
+        agentId: runtime.agentId,
+        content: { text: "pretty good actually" },
+        createdAt: Date.now(),
+      } as unknown as Memory,
+    });
+
+    const persisted = await repo.getScheduledTask(
+      runtime.agentId,
+      checkin.taskId,
+    );
+    expect(persisted?.state.status).toBe("completed");
+    const log = await readScheduledTaskLog(runtime);
+    expect(
+      log.find(
+        (entry) =>
+          entry.taskId === checkin.taskId && entry.outcome === "completed",
+      ),
+    ).toBeDefined();
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
@@ -8,6 +8,12 @@
  * shouldFire, completionCheck, recurrence, due time), never on promptInstructions
  * text. The always-loaded scheduling plugin owns the runner service; this module
  * is the pure due/fire computation it drives.
+ *
+ * The no-reply ladder is owner-adaptive (#12284): the `reminderIntensity`
+ * owner fact reshapes the default per-kind policy, and a ≥3-day quiet streak
+ * (derived from the recent-task-states log this tick also feeds) steps the
+ * effective intensity one notch down so a silent owner gets backed off, not
+ * chased harder.
  */
 import { hasOwnerAccess } from "@elizaos/agent";
 import {
@@ -16,7 +22,7 @@ import {
   type Memory,
   type MessagePayload,
 } from "@elizaos/core";
-import type { ScheduledTask } from "@elizaos/plugin-scheduling";
+import type { ScheduledTask, TerminalState } from "@elizaos/plugin-scheduling";
 import {
   expectedReplyKindForTask,
   getAnchorRegistry,
@@ -27,6 +33,15 @@ import {
   pendingPromptRoomIdForTask,
 } from "@elizaos/plugin-scheduling";
 import {
+  quietStreakDaysFromObservations,
+  runQuietUserWatcher,
+} from "../../default-packs/quiet-user-watcher.js";
+import {
+  appendScheduledTaskLogEntry,
+  createRecentTaskStatesProvider,
+  type RecentTaskStateEntry,
+} from "../../providers/recent-task-states.js";
+import {
   ownerFactsToView,
   type ReminderIntensity,
   resolveOwnerFactStore,
@@ -36,7 +51,10 @@ import {
   resolvePendingPromptsStore,
 } from "../pending-prompts/store.js";
 import { LifeOpsRepository } from "../repository.js";
-import { applyReminderIntensityToNoReplyPolicy } from "./no-reply-intensity.js";
+import {
+  applyReminderIntensityToNoReplyPolicy,
+  softenReminderIntensityForQuietStreak,
+} from "./no-reply-intensity.js";
 import { getScheduledTaskRunner } from "./service.js";
 
 type NoReplyTerminalStatus = "skipped" | "expired" | "failed";
@@ -135,7 +153,9 @@ function isTickDrivenCompletionCheck(task: ScheduledTask): boolean {
   );
 }
 
-function isTerminalStatus(status: ScheduledTask["state"]["status"]): boolean {
+function isTerminalStatus(
+  status: ScheduledTask["state"]["status"],
+): status is TerminalState {
   return (
     status === "completed" ||
     status === "skipped" ||
@@ -246,17 +266,43 @@ function defaultNoReplyPolicyFor(task: ScheduledTask): NoReplyPolicy | null {
   }
 }
 
+interface NoReplyPolicyResolution {
+  policy: NoReplyPolicy;
+  /** Intensity the ladder was actually derived with (post-softening). */
+  appliedIntensity?: ReminderIntensity;
+  /** True when a quiet streak stepped the effective intensity down. */
+  quietStreakSoftened: boolean;
+}
+
+/**
+ * Quiet-streak softening applies only to the "poke" kinds. Approvals stay at
+ * full cadence: they gate agent-side actions, and silently under-chasing one
+ * changes what the agent is allowed to do (sensitive approvals fail closed).
+ */
+function isQuietSoftenableKind(kind: ScheduledTask["kind"]): boolean {
+  return kind === "reminder" || kind === "checkin";
+}
+
 function resolveNoReplyPolicy(
   task: ScheduledTask,
   intensity?: ReminderIntensity,
-): NoReplyPolicy | null {
+  quietStreakDays?: number,
+): NoReplyPolicyResolution | null {
   const defaultPolicy = defaultNoReplyPolicyFor(task);
+  // Quiet-streak softening (#12284 item 8): a silent owner steps the
+  // effective intensity one notch down, then the regular intensity lookup
+  // shapes the ladder — one mechanism, two signals.
+  const quietStreakSoftened =
+    quietStreakDays !== undefined && isQuietSoftenableKind(task.kind);
+  const appliedIntensity = quietStreakSoftened
+    ? softenReminderIntensityForQuietStreak(intensity)
+    : intensity;
   // Owner intensity shapes the DEFAULT ladder; an explicit per-task
   // `metadata.noReplyPolicy` override (merged below) still wins field-by-field.
   const base = defaultPolicy
     ? applyReminderIntensityToNoReplyPolicy(
         defaultPolicy,
-        intensity,
+        appliedIntensity,
         task.priority,
       )
     : null;
@@ -280,26 +326,85 @@ function resolveNoReplyPolicy(
       ? raw.terminalStatus
       : fallback.terminalStatus;
   return {
-    maxRetries: readPositiveInteger(raw?.maxRetries) ?? fallback.maxRetries,
-    retryCadenceMinutes:
-      readPositiveIntegerArray(raw?.retryCadenceMinutes) ??
-      fallback.retryCadenceMinutes,
-    terminalStatus,
-    terminalReason:
-      typeof raw?.terminalReason === "string" && raw.terminalReason.length > 0
-        ? raw.terminalReason
-        : fallback.terminalReason,
-    sensitive:
-      typeof raw?.sensitive === "boolean" ? raw.sensitive : fallback.sensitive,
-    allowCrossChannel:
-      typeof raw?.allowCrossChannel === "boolean"
-        ? raw.allowCrossChannel
-        : fallback.allowCrossChannel,
-    allowNonOwnerNotification:
-      typeof raw?.allowNonOwnerNotification === "boolean"
-        ? raw.allowNonOwnerNotification
-        : fallback.allowNonOwnerNotification,
+    policy: {
+      maxRetries: readPositiveInteger(raw?.maxRetries) ?? fallback.maxRetries,
+      retryCadenceMinutes:
+        readPositiveIntegerArray(raw?.retryCadenceMinutes) ??
+        fallback.retryCadenceMinutes,
+      terminalStatus,
+      terminalReason:
+        typeof raw?.terminalReason === "string" && raw.terminalReason.length > 0
+          ? raw.terminalReason
+          : fallback.terminalReason,
+      sensitive:
+        typeof raw?.sensitive === "boolean"
+          ? raw.sensitive
+          : fallback.sensitive,
+      allowCrossChannel:
+        typeof raw?.allowCrossChannel === "boolean"
+          ? raw.allowCrossChannel
+          : fallback.allowCrossChannel,
+      allowNonOwnerNotification:
+        typeof raw?.allowNonOwnerNotification === "boolean"
+          ? raw.allowNonOwnerNotification
+          : fallback.allowNonOwnerNotification,
+    },
+    ...(appliedIntensity ? { appliedIntensity } : {}),
+    quietStreakSoftened,
   };
+}
+
+/**
+ * Derive the owner's quiet streak (consecutive ignored check-ins/follow-ups)
+ * from the recent-task-states log, evaluated as of the tick's `now`. Returns
+ * `undefined` when the owner is not quiet — the softening no-op.
+ */
+async function resolveQuietStreakDays(
+  runtime: IAgentRuntime,
+  now: Date,
+): Promise<number | undefined> {
+  const observations = await runQuietUserWatcher(
+    createRecentTaskStatesProvider(runtime),
+    { asOf: now },
+  );
+  return quietStreakDaysFromObservations(observations);
+}
+
+/**
+ * Mirror a task transition into the recent-task-states log — the feed the
+ * quiet-user watcher and the quiet-streak no-reply softening read. Only the
+ * transitions that say something about the OWNER's engagement are recorded
+ * (fires, completions, no-reply terminals); gate denials and dispatch retries
+ * are runner mechanics, not owner behavior, and would pollute the streaks.
+ * Never throws (J7 inside) — safe to call after a committed transition.
+ * Also called by `inbound-reply-completion.ts` for its completion path.
+ */
+export async function recordTaskStateEntry(
+  runtime: IAgentRuntime,
+  task: ScheduledTask,
+  outcome: RecentTaskStateEntry["outcome"],
+  recordedAt: Date,
+): Promise<void> {
+  try {
+    await appendScheduledTaskLogEntry(runtime, {
+      taskId: task.taskId,
+      kind: task.kind,
+      outcome,
+      recordedAt: recordedAt.toISOString(),
+      ...(task.subject ? { subjectId: task.subject.id } : {}),
+    });
+  } catch (error) {
+    // error-policy:J7 telemetry write; a failed log append must not undo or
+    // re-error a task transition that already committed. Surfaced via
+    // reportError so repeated failures escalate.
+    logger.warn(
+      `[lifeops-scheduled-task] task-state log append failed for ${task.taskId}: ${errorMessage(error)}`,
+    );
+    runtime.reportError("lifeops:scheduled-task:state-log", error, {
+      taskId: task.taskId,
+      outcome,
+    });
+  }
 }
 
 function readMessageOccurredAt(message: Memory, fallback: Date): Date {
@@ -359,6 +464,12 @@ export async function processDueScheduledTasks(
   // Owner-wide reminder intensity shapes how persistently the no-reply loop
   // re-nudges (see `applyReminderIntensityToNoReplyPolicy`).
   const reminderIntensity = ownerFactsRaw.reminderIntensity?.value;
+  // Quiet streak (#12284 item 8): read once per tick; when present it steps
+  // the effective intensity one notch down for reminder/checkin ladders.
+  const quietStreakDays = await resolveQuietStreakDays(
+    request.runtime,
+    request.now,
+  );
   const dueContext = {
     now: request.now,
     ownerFacts,
@@ -416,6 +527,12 @@ export async function processDueScheduledTasks(
       if (evaluated.state.status === "completed") {
         result.completions.push(completionResult(evaluated));
         completedTaskIds.add(evaluated.taskId);
+        await recordTaskStateEntry(
+          request.runtime,
+          evaluated,
+          "completed",
+          request.now,
+        );
       }
     } catch (error) {
       const message = errorMessage(error);
@@ -450,6 +567,7 @@ export async function processDueScheduledTasks(
           agentId: request.agentId,
           task,
           reminderIntensity,
+          quietStreakDays,
           now: request.now,
           reason: timeout.reason,
         });
@@ -460,6 +578,15 @@ export async function processDueScheduledTasks(
           occurrenceAtIso: timeout.occurrenceAtIso,
         });
         timeoutTaskIds.add(timedOut.task.taskId);
+        const timedOutStatus = timedOut.task.state.status;
+        if (isTerminalStatus(timedOutStatus)) {
+          await recordTaskStateEntry(
+            request.runtime,
+            timedOut.task,
+            timedOutStatus,
+            request.now,
+          );
+        }
       } catch (error) {
         const message = errorMessage(error);
         logger.warn(
@@ -515,14 +642,30 @@ async function handleCompletionTimeout(args: {
   now: Date;
   reason: string;
   reminderIntensity?: ReminderIntensity;
+  quietStreakDays?: number;
 }): Promise<{ task: ScheduledTask; reason: string }> {
-  const policy = resolveNoReplyPolicy(args.task, args.reminderIntensity);
-  if (!policy) {
+  const resolution = resolveNoReplyPolicy(
+    args.task,
+    args.reminderIntensity,
+    args.quietStreakDays,
+  );
+  if (!resolution) {
     const skipped = await args.runner.apply(args.task.taskId, "skip", {
       reason: args.reason,
     });
     return { task: skipped, reason: args.reason };
   }
+  const { policy } = resolution;
+  // Persisted alongside the resolved ladder so the softening decision is
+  // observable in the task record (#12284 item 8), not just in behavior.
+  const appliedIntensityMetadata = {
+    ...(resolution.appliedIntensity
+      ? { appliedReminderIntensity: resolution.appliedIntensity }
+      : {}),
+    ...(resolution.quietStreakSoftened
+      ? { quietStreakSoftened: true, quietStreakDays: args.quietStreakDays }
+      : {}),
+  };
 
   const state = readNoReplyState(args.task);
   if (state.retryCount < policy.maxRetries) {
@@ -550,6 +693,7 @@ async function handleCompletionTimeout(args: {
         retryCount: state.retryCount + 1,
         lastTimedOutAt: args.now.toISOString(),
         nextRetryAt,
+        ...appliedIntensityMetadata,
       },
     };
     await args.repo.upsertScheduledTask(args.agentId, args.task);
@@ -589,6 +733,7 @@ async function handleCompletionTimeout(args: {
       lastTimedOutAt: args.now.toISOString(),
       terminalReason: policy.terminalReason,
       terminalOutcome: policy.sensitive ? "denied" : policy.terminalStatus,
+      ...appliedIntensityMetadata,
     },
   };
   await args.repo.upsertScheduledTask(args.agentId, args.task);
@@ -663,6 +808,14 @@ export async function processScheduledTaskInboundMessage(
       if (evaluated.state.status === "completed") {
         result.completions.push(completionResult(evaluated));
         await promptStore.resolve(roomId, prompt.taskId);
+        // The reply is the streak-breaking engagement signal: without this
+        // append a quiet streak would survive the owner coming back.
+        await recordTaskStateEntry(
+          request.runtime,
+          evaluated,
+          "completed",
+          now,
+        );
       }
     } catch (error) {
       const message = errorMessage(error);
@@ -787,6 +940,12 @@ async function handleFireResult(args: {
         reason: decision.reason,
         occurrenceAtIso: decision.occurrenceAtIso,
       });
+      await recordTaskStateEntry(
+        request.runtime,
+        persisted,
+        "fired",
+        request.now,
+      );
       try {
         const recorded = await recordPendingPromptIfNeeded({
           runtime: request.runtime,

--- a/plugins/plugin-personal-assistant/src/providers/recent-task-states.ts
+++ b/plugins/plugin-personal-assistant/src/providers/recent-task-states.ts
@@ -6,8 +6,12 @@
  *
  * Contract: summarize(opts?): Promise<{ summary, streaks, notable }>
  *
- * Reads the cache-backed task log maintained by the scheduled-task runner
- * via `readScheduledTaskLog`.
+ * Reads the cache-backed task log via `readScheduledTaskLog`. The log's
+ * production writer is the LifeOps scheduled-task tick
+ * (`../lifeops/scheduled-task/scheduler.ts`), which appends fires,
+ * completions, and no-reply terminal outcomes so the summarized streaks —
+ * including the quiet-user softening signal (#12284 item 8) — reflect real
+ * spine activity, not just test seeds.
  */
 
 import { hasOwnerAccess } from "@elizaos/agent";
@@ -49,11 +53,19 @@ export interface RecentTaskStatesProvider {
     kinds?: ScheduledTaskKind[];
     subjectIds?: string[];
     lookbackDays?: number;
+    /** Pins the lookback window's upper bound; defaults to wall clock. */
+    asOf?: Date;
   }): Promise<RecentTaskStatesSummary>;
 }
 
 const TASK_LOG_CACHE_KEY = "eliza:lifeops:scheduled-task-log:v1";
 const DEFAULT_LOOKBACK_DAYS = 7;
+/**
+ * Hard cap on retained log entries. The summarize window is 7 days by
+ * default; even a chatty agent (dozens of fires/outcomes a day) stays far
+ * below this, so the cap only guards the cache row against unbounded growth.
+ */
+const TASK_LOG_MAX_ENTRIES = 500;
 
 /**
  * Read the scheduled-task log from the cache-backed list maintained alongside
@@ -78,7 +90,10 @@ export async function readScheduledTaskLog(
 }
 
 /**
- * Test/integration helper — append an entry to the log.
+ * Append an entry to the log, retaining only the newest
+ * {@link TASK_LOG_MAX_ENTRIES}. Called by the scheduled-task tick for fires,
+ * completions, and no-reply terminal outcomes (and by tests to seed
+ * histories directly).
  */
 export async function appendScheduledTaskLogEntry(
   runtime: IAgentRuntime,
@@ -88,7 +103,10 @@ export async function appendScheduledTaskLogEntry(
   const existing =
     (await cache.getCache<RecentTaskStateEntry[]>(TASK_LOG_CACHE_KEY)) ?? [];
   existing.push(entry);
-  await cache.setCache<RecentTaskStateEntry[]>(TASK_LOG_CACHE_KEY, existing);
+  await cache.setCache<RecentTaskStateEntry[]>(
+    TASK_LOG_CACHE_KEY,
+    existing.slice(-TASK_LOG_MAX_ENTRIES),
+  );
 }
 
 const TERMINAL_OUTCOMES: ReadonlySet<TerminalState> = new Set<TerminalState>([
@@ -191,11 +209,16 @@ export function createRecentTaskStatesProvider(
   return {
     async summarize(opts = {}) {
       const lookbackDays = opts.lookbackDays ?? DEFAULT_LOOKBACK_DAYS;
-      const cutoffMs = Date.now() - lookbackDays * 86_400_000;
+      const asOfMs = opts.asOf?.getTime() ?? Date.now();
+      const cutoffMs = asOfMs - lookbackDays * 86_400_000;
       const log = await readScheduledTaskLog(runtime);
       const filtered = log.filter((entry) => {
         const recordedMs = Date.parse(entry.recordedAt);
-        if (!Number.isFinite(recordedMs) || recordedMs < cutoffMs) {
+        if (
+          !Number.isFinite(recordedMs) ||
+          recordedMs < cutoffMs ||
+          recordedMs > asOfMs
+        ) {
           return false;
         }
         if (


### PR DESCRIPTION
## What & why

Advances #12284 (parent #12186) — work items **6 + 8**. Item 6's intensity lookup landed in #12952 (`reminderIntensity` → no-reply ladder, PA-side `resolveNoReplyPolicy` seam). What was still missing:

- The **quiet-user-watcher signal had no structural consumer** — a ≥3-day silent streak only produced morning-brief text, never a cadence change (WI-8).
- The recent-task-states log the watcher reads had **no production writer** — only tests seeded it, so a real quiet streak could never form.
- The intensity actually applied to a ladder was **not observable** in the task record.

## The change

One mechanism, two signals: the quiet streak modulates behavior through the **same** `reminderIntensity` lookup #12952 added, not a second policy engine.

- `no-reply-intensity.ts` — new pure `softenReminderIntensityForQuietStreak`: a ≥3-day ignored-checkin/followup streak steps the effective intensity one notch down (`persistent`→`normal`, `normal`/unset→`minimal`; `minimal` and `high_priority_only` are fixed points). Never a guilt-framed extra poke — strictly less chasing.
- `scheduler.ts` — `processDueScheduledTasks` derives the quiet streak once per tick (via the same `deriveQuietObservations` helpers the watcher uses, `asOf`-pinned to the tick's `now`) and threads it into `resolveNoReplyPolicy`. Softening applies to `reminder`/`checkin` only; **approvals keep full cadence** (they gate agent-side actions; sensitive approvals fail closed). The applied intensity + softening decision are persisted on `metadata.noReplyState` (`appliedReminderIntensity`, `quietStreakSoftened`, `quietStreakDays`) so the ladder choice is auditable in the task record, not just in behavior.
- The tick now **feeds the recent-task-states log for real**: fires, completions, and no-reply terminal outcomes (`recordTaskStateEntry`, J7-guarded — a failed telemetry append never undoes a committed transition). Owner replies append the streak-breaking `completed` entry through **both** completion seams (`processScheduledTaskInboundMessage` and `inbound-reply-completion.ts`).
- `recent-task-states.ts` — `summarize({ asOf })` pins the lookback window for deterministic tick-time evaluation; the log gets a 500-entry retention cap now that production writes exist.
- `quiet-user-watcher.ts` — exports `quietStreakDaysFromObservations`; `runQuietUserWatcher` accepts `asOf`. Brief-text behavior unchanged.

Frozen `ScheduledTask` contract intact: no trigger-union or schema changes — this is policy-selection lookup only, exactly as AGENTS.md:156-171 requires (structural fields, never `promptInstructions` text; no second scheduler).

## Deviations from the issue text

- Issue mentions an `escalated` intensity; the `ReminderIntensity` enum on develop is `minimal | normal | persistent | high_priority_only` — there is no `escalated` value to handle.
- Seam choice (allowed by the WI): PA-side `resolveNoReplyPolicy`, not `plugin-scheduling`'s escalation ladder — same rationale as #12952: the spine escalation ladder drives dispatch-*failure* channel advance, a delivery concern owner intensity must not touch. `plugin-scheduling` is untouched.

## Verification

- `scheduler.quiet-streak.test.ts` (new, real repository-backed runtime, no scheduler mocks) — **6 passed**: 3 ignored check-ins driven through REAL ticks (log's production writer exercised on fire + terminal paths) soften the next reminder to fire-once with the decision visible in `noReplyState`; contrast persona with no history keeps the 60-min re-nudge; a reply breaks the streak (no softening); explicit `persistent` owner softens one notch to `normal`; approvals not softened; owner reply through the real `MESSAGE_RECEIVED` seam appends the streak-breaking log entry.
- `no-reply-intensity.test.ts` — **8 passed** (existing 6 kept green + 2 softener unit cases).
- `scheduler.no-reply-policy.test.ts` — **9 passed** (existing 8 kept green + new auditability case asserting `appliedReminderIntensity` persisted on retry). Two otherwise-identical tasks with different `reminderIntensity` facts → measurably different retry/ladder behavior (pre-existing #12952 cases, still green).
- `inbound-reply-completion.integration.test.ts` — **5 passed**; `recent-task-states.integration.test.ts` — **2 passed**; default-pack spine-seeding + smoke — **9 passed**.
- `bun run --cwd plugins/plugin-scheduling test` — **238 passed (19 files)**, untouched package stays green.
- `bun run --cwd plugins/plugin-personal-assistant typecheck` — exit 0; package `lint:check` — 0 errors (17 pre-existing warnings).
- Full PA suite (`bun run --cwd plugins/plugin-personal-assistant test`): **1144 passed | 9 failed | 7 skipped (1160)**. All 9 failures are pre-existing on clean `origin/develop` (b24dec831) in 4 files this PR does not touch — reproduced verbatim on a detached clean checkout (same 9 tests, same 4 files): `life-reminder-datetime.test.ts` (1 — the #12998 rage-quit delete-trap known-gap regression), `reminders-service.process-scheduled-work.test.ts` (5 — `travel_reconcile` subsystem from #13211, `cache.getCache is not a function` against that test's mock runtime), `signature-deadline-scheduler.test.ts` (1), `BlockerSettingsCards.test.tsx` (2). Every scheduled-task/no-reply/quiet-streak/recent-task-states suite is green.

### Full verify gate (rebased on develop @ 76c9253d1)

`bun run verify` component-by-component: `check:agents-claude` PASS · `audit:type-safety-ratchet` PASS · `audit:error-policy-ratchet` PASS ("no new fallback-slop in touched files") · turbo `typecheck lint --continue`: **571/578 tasks green — the 7 failures (`app#typecheck`, `electrobun#typecheck` = the known-red baseline, plus `electrobun#lint`, `plugin-capacitor-bridge#typecheck`, `plugin-computeruse#lint`, `plugin-sub-agent-claude-code#typecheck`, `tui#lint`) reproduce as the byte-identical failure set on a clean detached checkout of `origin/develop` @ 76c9253d1** (this branch touches only `plugins/plugin-personal-assistant` + one evidence file; every failing package is byte-identical to develop here) · `audit:build-model` PASS · `audit:turbo-build-deps` FAIL — **pre-existing, reproduced identically on clean develop** (phantom turbo.json `#build` overrides for example packages left by the recent script-normalization merges; turbo.json and those packages are untouched by this branch) · `audit:tee-secret-leak` PASS · `audit:scripts` PASS · `audit:test-realness` PASS (report-only) · `typecheck:dist` PASS (28 configs).

So: verify green except pre-existing develop failures app#typecheck/electrobun#typecheck (untouched by this PR), plus the five newer pre-existing develop-drift failures and the pre-existing `audit:turbo-build-deps` break listed above, each reproduced on clean develop.

| Evidence | Status |
| --- | --- |
| Real-LLM trajectory | N/A — scheduler-tick policy-selection logic, not model/prompt/action behavior (same as #12952). Domain artifacts are the evidence. |
| Domain artifacts | ScheduledTask `noReplyPolicy`/`noReplyState` (incl. `appliedReminderIntensity`, `quietStreakSoftened`, `quietStreakDays`) + recent-task-states log entries — asserted against the real repository in the integration tests above. |
| Backend logs | Structured `[lifeops-scheduled-task]` warn + `runtime.reportError` path on log-append failure (J7). |
| Frontend / screenshots | N/A — no UI surface changed. |

Advances #12284. Relates to #12186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
