### PR TITLE
test(computeruse): guard scene fixture accesses after fallback sweep

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/scene-multimon-coords.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/scene-multimon-coords.test.ts
@@ -403,6 +403,7 @@ describe("dirty-block re-OCR — wired to captureRegion", () => {
     // The dirty rect should be inside the source frame and roughly near
     // (col=4, row=4) for a 16×16 grid on a 256×256 frame → ~(64, 64, 16, 16).
     const reg = captureRegionCalls[0]?.region;
+    if (!reg) throw new Error("expected dirty-region capture call");
     expect(reg.x).toBeGreaterThanOrEqual(60);
     expect(reg.x).toBeLessThanOrEqual(80);
     expect(reg.y).toBeGreaterThanOrEqual(60);
@@ -685,8 +686,10 @@ describe("live smoke — getCurrentScene on this host", () => {
   it("listDisplays returns at least one display with positive bounds", () => {
     const all = listDisplays();
     expect(all.length).toBeGreaterThan(0);
-    expect(all[0]?.bounds[2]).toBeGreaterThan(0);
-    expect(all[0]?.bounds[3]).toBeGreaterThan(0);
+    const firstDisplay = all[0];
+    if (!firstDisplay) throw new Error("expected at least one display");
+    expect(firstDisplay.bounds[2]).toBeGreaterThan(0);
+    expect(firstDisplay.bounds[3]).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
Follow-up to merged #13228.

During review of the computeruse fallback-slop sweep, two test fixture accesses in `scene-multimon-coords.test.ts` had been changed from non-null assertions to optional chaining while still being immediately dereferenced. That preserved unclear failure behavior (`reg.x` on undefined) instead of the explicit throwing guard style used elsewhere in the same PR.

This tiny follow-up keeps the merged behavior unchanged and only makes the test fixtures fail with explicit messages:

- missing dirty-region capture call -> `expected dirty-region capture call`
- missing first display in live smoke -> `expected at least one display`

Validation:
- PASS: `bunx @biomejs/biome check plugins/plugin-computeruse/src/__tests__/scene-multimon-coords.test.ts`
- PASS: `node packages/scripts/error-policy-ratchet.mjs`
- BLOCKED locally: focused Vitest for computeruse starts but cannot resolve local workspace package `@elizaos/cloud-routing` in this temporary checkout; GitHub CI remains the merge gate.