### PR TITLE
fix(#12273): coding-tools + shell fallback-slop sweep — fail fast, annotate justified probes

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/bash.error-path.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.error-path.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Real-error-path tests for the SHELL action (#12273): drive the action against
+ * a genuinely missing binary and a genuinely failing command through the *real*
+ * host shell (no capability router, no mocked failure) and assert the failure
+ * surfaces as `success: false` + `result.error` — the shape the planner loop
+ * shows the model. Guards the fallback-slop invariant that a shell failure is
+ * never repackaged as success-shaped output.
+ */
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { SandboxService, SessionCwdService } from "../services/index.js";
+import { SANDBOX_SERVICE, SESSION_CWD_SERVICE } from "../types.js";
+import { shellAction } from "./bash.js";
+
+// The assertions pin bash exit-code framing (127 = command not found), so the
+// suite targets POSIX hosts; the Windows path routes to powershell separately.
+const describeIfPosix = process.platform === "win32" ? describe.skip : describe;
+
+async function makeHostRuntime(): Promise<IAgentRuntime> {
+  const services = new Map<string, unknown>();
+  const runtime = {
+    agentId: "11111111-1111-1111-1111-111111111111" as UUID,
+    getSetting: vi.fn(() => undefined),
+    getService: vi.fn(<T>(type: string) => services.get(type) as T | null),
+    reportError: vi.fn(),
+  } as unknown as IAgentRuntime;
+  services.set(SANDBOX_SERVICE, await SandboxService.start(runtime));
+  services.set(SESSION_CWD_SERVICE, await SessionCwdService.start(runtime));
+  return runtime;
+}
+
+function makeMessage(text = ""): Memory {
+  return {
+    id: "33333333-3333-3333-3333-333333333333" as UUID,
+    entityId: "44444444-4444-4444-4444-444444444444" as UUID,
+    roomId: "11111111-aaaa-bbbb-cccc-222222222222" as UUID,
+    agentId: "11111111-1111-1111-1111-111111111111" as UUID,
+    content: { text },
+    createdAt: Date.now(),
+  } as Memory;
+}
+
+describeIfPosix("SHELL action real error paths", () => {
+  it("surfaces a missing binary as success:false + result.error (exit 127)", async () => {
+    const runtime = await makeHostRuntime();
+
+    const result = await shellAction.handler?.(
+      runtime,
+      makeMessage(),
+      undefined,
+      {
+        command: "definitely-not-a-real-binary-xyzzy-12345 --version",
+      },
+    );
+
+    // The failure reaches the caller unmasked — not a fabricated success.
+    expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(Error);
+    expect(String(result.error?.message)).toContain(
+      "command exited with code 127",
+    );
+    const data = result.data as Record<string, unknown> | undefined;
+    expect(data?.exit_code).toBe(127);
+    // The real shell diagnostic (not a canned default) is carried through.
+    expect(String(data?.output ?? "")).toMatch(/not found|No such file/i);
+  });
+
+  it("surfaces a failing command (unreadable path) as success:false + result.error", async () => {
+    const runtime = await makeHostRuntime();
+
+    const result = await shellAction.handler?.(
+      runtime,
+      makeMessage(),
+      undefined,
+      {
+        command: "cat /no/such/path/eliza-12273-does-not-exist",
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(Error);
+    const data = result.data as Record<string, unknown> | undefined;
+    expect(data?.exit_code).not.toBe(0);
+    expect(String(result.error?.message)).toContain("command exited with code");
+  });
+});

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -823,6 +823,8 @@ function extractJsonPayload(text: string): unknown {
   try {
     return JSON.parse(trimmed);
   } catch {
+    // error-policy:J3 untrusted command output; unparseable JSON yields the
+    // explicit "no payload" signal rather than a fabricated object.
     return undefined;
   }
 }
@@ -1258,6 +1260,10 @@ export const shellAction: Action = {
           });
         }
       } catch (err) {
+        // error-policy:J3 cwd existence probe distinguished from breakage; a
+        // genuine stat failure (EACCES, etc.) becomes a success:false
+        // ActionResult, while the expected-miss (ENOENT) degrades to the
+        // session cwd with a warning rather than masking a real error.
         if (!isMissingPathError(err)) {
           return failureToActionResult({
             reason: "io_error",
@@ -1395,6 +1401,9 @@ export const shellAction: Action = {
     try {
       result = await runShell(runtime, { command, cwd, timeoutMs: timeout });
     } catch (err) {
+      // error-policy:J1 SHELL action boundary; a dispatch failure is logged and
+      // returned as a success:false ActionResult carrying the real message, so
+      // the planner loop shows the failure to the model.
       const message = (err as Error).message;
       coreLogger.error(
         `${CODING_TOOLS_LOG_PREFIX} SHELL dispatch failed: ${message}`,

--- a/plugins/plugin-coding-tools/src/actions/edit.ts
+++ b/plugins/plugin-coding-tools/src/actions/edit.ts
@@ -123,6 +123,8 @@ export async function editFileHandler(
   try {
     original = await fs.readFile(resolved, "utf8");
   } catch (err) {
+    // error-policy:J1 action boundary; a read failure becomes a success:false
+    // ActionResult carrying the real message, surfaced to the model.
     const msg = err instanceof Error ? err.message : String(err);
     return failureToActionResult({
       reason: "io_error",
@@ -166,6 +168,8 @@ export async function editFileHandler(
   try {
     await fs.writeFile(resolved, updated, "utf8");
   } catch (err) {
+    // error-policy:J1 action boundary; a write failure becomes a success:false
+    // ActionResult carrying the real message, surfaced to the model.
     const msg = err instanceof Error ? err.message : String(err);
     return failureToActionResult({
       reason: "io_error",

--- a/plugins/plugin-coding-tools/src/actions/enter-worktree.ts
+++ b/plugins/plugin-coding-tools/src/actions/enter-worktree.ts
@@ -147,6 +147,8 @@ export async function enterWorktreeHandler(
       timeoutMs,
     });
   } catch (err) {
+    // error-policy:J1 action boundary; a failed `git worktree add` becomes a
+    // success:false ActionResult carrying the git error, surfaced to the model.
     return failureToActionResult({
       reason: "io_error",
       message: `git worktree add failed: ${gitErrorMessage(err)}`,

--- a/plugins/plugin-coding-tools/src/actions/exit-worktree.ts
+++ b/plugins/plugin-coding-tools/src/actions/exit-worktree.ts
@@ -79,6 +79,8 @@ export async function exitWorktreeHandler(
       });
       cleaned = true;
     } catch (err) {
+      // error-policy:J1 action boundary; a failed `git worktree remove` becomes
+      // a success:false ActionResult carrying the stderr/message for the model.
       const stderr =
         err && typeof err === "object" && "stderr" in err
           ? String((err as { stderr: unknown }).stderr ?? "")

--- a/plugins/plugin-coding-tools/src/actions/glob.ts
+++ b/plugins/plugin-coding-tools/src/actions/glob.ts
@@ -94,6 +94,8 @@ async function walkFallback(root: string, pattern: string): Promise<string[]> {
     try {
       names = await fs.readdir(dir);
     } catch {
+      // error-policy:J6 best-effort walk; a directory that became unreadable
+      // (permissions, race) is skipped so the remaining tree is still globbed.
       return;
     }
     for (const name of names) {
@@ -110,7 +112,8 @@ async function walkFallback(root: string, pattern: string): Promise<string[]> {
           }
         }
       } catch {
-        // Ignore unreadable entries.
+        // error-policy:J6 best-effort per-entry lstat; an entry that vanished
+        // or is unreadable is skipped rather than aborting the whole walk.
       }
     }
   }
@@ -195,6 +198,9 @@ export async function globHandler(
     try {
       candidates = await nodeGlob(builtinGlob, root, pattern);
     } catch (err) {
+      // error-policy:J4 designed degrade; the native `node:fs.glob` and the
+      // manual walker compute the same match set, so a native-glob failure
+      // falls back to the walker with a warning rather than failing the action.
       const msg = err instanceof Error ? err.message : String(err);
       coreLogger.warn(
         `${CODING_TOOLS_LOG_PREFIX} GLOB node:fs.glob failed (${msg}); falling back to walker`,
@@ -212,6 +218,8 @@ export async function globHandler(
         if (!stat.isFile()) return undefined;
         return { filePath, mtimeMs: stat.mtimeMs };
       } catch {
+        // error-policy:J6 best-effort mtime enrichment; a candidate that
+        // vanished between glob and stat drops out of the sorted result.
         return undefined;
       }
     }),

--- a/plugins/plugin-coding-tools/src/actions/grep.ts
+++ b/plugins/plugin-coding-tools/src/actions/grep.ts
@@ -191,6 +191,8 @@ export async function grepHandler(
       truncated,
     });
   } catch (error) {
+    // error-policy:J1 action boundary; any grep failure becomes a success:false
+    // ActionResult carrying the real message, surfaced to the model.
     const messageText = error instanceof Error ? error.message : String(error);
     return failureToActionResult({
       reason: "internal",

--- a/plugins/plugin-coding-tools/src/actions/ls.ts
+++ b/plugins/plugin-coding-tools/src/actions/ls.ts
@@ -102,6 +102,9 @@ async function listWithCapabilityRouter(params: {
     });
     return { ok: true, payload: result };
   } catch (error) {
+    // error-policy:J1 capability-router boundary; the routed listing is
+    // translated into a typed failure DTO — CAPABILITY_UNAVAILABLE degrades to
+    // "unavailable", any other error to "failed" — never a fabricated payload.
     if (
       error instanceof CapabilityError &&
       error.code === "CAPABILITY_UNAVAILABLE"
@@ -234,6 +237,8 @@ export async function lsHandler(
   try {
     names = await fs.readdir(dir);
   } catch (err) {
+    // error-policy:J1 action boundary; a readdir failure becomes a success:false
+    // ActionResult carrying the real message, surfaced to the model.
     const msg = err instanceof Error ? err.message : String(err);
     return failureToActionResult({
       reason: "io_error",

--- a/plugins/plugin-coding-tools/src/actions/read.ts
+++ b/plugins/plugin-coding-tools/src/actions/read.ts
@@ -122,6 +122,9 @@ async function readWithCapabilityRouter(params: {
       },
     };
   } catch (error) {
+    // error-policy:J1 capability-router boundary; the routed read is translated
+    // into a typed failure DTO — CAPABILITY_UNAVAILABLE degrades to
+    // "unavailable", any other error to "failed" — never a fabricated payload.
     if (
       error instanceof CapabilityError &&
       error.code === "CAPABILITY_UNAVAILABLE"
@@ -214,6 +217,8 @@ export async function readFileHandler(
   try {
     stat = await fs.stat(resolved);
   } catch (err) {
+    // error-policy:J1 action boundary; a stat failure becomes a success:false
+    // ActionResult carrying the real message, surfaced to the model.
     const msg = err instanceof Error ? err.message : String(err);
     return failureToActionResult({
       reason: "io_error",
@@ -239,6 +244,8 @@ export async function readFileHandler(
   try {
     buffer = await fs.readFile(resolved);
   } catch (err) {
+    // error-policy:J1 action boundary; a read failure becomes a success:false
+    // ActionResult carrying the real message, surfaced to the model.
     const msg = err instanceof Error ? err.message : String(err);
     return failureToActionResult({
       reason: "io_error",

--- a/plugins/plugin-coding-tools/src/actions/write.ts
+++ b/plugins/plugin-coding-tools/src/actions/write.ts
@@ -51,6 +51,9 @@ async function writeWithCapabilityRouter(params: {
     });
     return { ok: true, bytesWritten: result.bytesWritten };
   } catch (error) {
+    // error-policy:J1 capability-router boundary; the routed write is translated
+    // into a typed failure DTO — CAPABILITY_UNAVAILABLE degrades to
+    // "unavailable", any other error to "failed" — never a fabricated success.
     if (
       error instanceof CapabilityError &&
       error.code === "CAPABILITY_UNAVAILABLE"
@@ -150,6 +153,8 @@ export async function writeFileHandler(
       await fs.mkdir(path.dirname(resolved), { recursive: true });
       await fs.writeFile(resolved, content, "utf8");
     } catch (err) {
+      // error-policy:J1 action boundary; the direct-write failure becomes a
+      // success:false ActionResult carrying the real message for the model.
       const msg = err instanceof Error ? err.message : String(err);
       return failureToActionResult({
         reason: "io_error",

--- a/plugins/plugin-coding-tools/src/lib/path-utils.ts
+++ b/plugins/plugin-coding-tools/src/lib/path-utils.ts
@@ -37,6 +37,9 @@ export async function resolveRealPath(p: string): Promise<string> {
   try {
     return await fs.realpath(p);
   } catch {
+    // error-policy:J3 realpath requires the path to exist on disk; for a
+    // not-yet-created target the lexical resolve is the designed fallback the
+    // sandbox root check relies on (symlinks simply resolve to themselves).
     return path.resolve(p);
   }
 }

--- a/plugins/plugin-coding-tools/src/lib/run-git-command.ts
+++ b/plugins/plugin-coding-tools/src/lib/run-git-command.ts
@@ -52,6 +52,10 @@ export async function runGitCommand(
       });
       return routedResult(result.operation);
     } catch (error) {
+      // error-policy:J4 only the expected "no git capability" shape
+      // (CAPABILITY_UNAVAILABLE) degrades to the local-git fallback below; any
+      // other router error rethrows so a real git failure surfaces instead of
+      // being masked by the local path.
       if (
         error instanceof CapabilityError &&
         error.code === "CAPABILITY_UNAVAILABLE"

--- a/plugins/plugin-coding-tools/src/lib/run-shell.ts
+++ b/plugins/plugin-coding-tools/src/lib/run-shell.ts
@@ -142,7 +142,8 @@ function killHostProcess(
     }
     proc.kill(signal);
   } catch {
-    // The process may have exited between the timeout firing and kill delivery.
+    // error-policy:J6 best-effort teardown; the process may have exited between
+    // the timeout firing and kill delivery, so a failed signal is a no-op.
   }
 }
 
@@ -298,6 +299,10 @@ async function runThroughCapabilityRouter(
       sandbox: "capability-router",
     };
   } catch (error) {
+    // error-policy:J4 only the expected "no PTY capability" shape
+    // (CAPABILITY_UNAVAILABLE) degrades to null below (advancing to the
+    // host-shell fallback); any other router error rethrows so a genuine
+    // execution failure reaches the SHELL action.
     if (
       error instanceof CapabilityError &&
       error.code === "CAPABILITY_UNAVAILABLE"

--- a/plugins/plugin-coding-tools/src/lib/terminal-capabilities.ts
+++ b/plugins/plugin-coding-tools/src/lib/terminal-capabilities.ts
@@ -103,6 +103,8 @@ function canExecute(filePath: string): boolean {
     accessSync(filePath, constants.X_OK);
     return true;
   } catch {
+    // error-policy:J3 existence/permission probe; an access failure means the
+    // path is absent or not executable — false is the expected-miss signal.
     return false;
   }
 }

--- a/plugins/plugin-coding-tools/src/services/coding-task-executor.ts
+++ b/plugins/plugin-coding-tools/src/services/coding-task-executor.ts
@@ -91,6 +91,10 @@ async function rewriteCodingActionText(args: {
       ? parsed.response.trim()
       : fallback();
   } catch {
+    // error-policy:J4 the model call only prettifies already-computed output
+    // into the character voice; on failure the deterministic fallback preserves
+    // that the action ran (its authoritative success/error is carried by the
+    // TaskResult, not by this cosmetic rewrite).
     return fallback();
   }
 }
@@ -234,6 +238,8 @@ export class CodingTaskExecutor implements TaskExecutor {
         durationMs: Date.now() - startTime,
       };
     } catch (error) {
+      // error-policy:J1 task-executor boundary; an execution failure becomes a
+      // structured TaskResult with success:false and the real error message.
       return {
         taskId: spec.id,
         success: false,

--- a/plugins/plugin-coding-tools/src/services/file-state-service.ts
+++ b/plugins/plugin-coding-tools/src/services/file-state-service.ts
@@ -79,8 +79,10 @@ export class FileStateService extends Service {
     try {
       stat = await fs.stat(absPath);
     } catch {
-      // File doesn't exist — Write is allowed (creating new file). Edit must
-      // separately verify existence.
+      // error-policy:J3 existence probe — any stat failure routes to the
+      // create-new-file path (Write is allowed; Edit re-verifies existence
+      // separately). A genuine permission error is not masked: the subsequent
+      // fs.writeFile surfaces it to the caller as an `io_error` failure.
       return { ok: true };
     }
     const meta = this.get(conversationId, absPath);

--- a/plugins/plugin-coding-tools/src/services/ripgrep-service.ts
+++ b/plugins/plugin-coding-tools/src/services/ripgrep-service.ts
@@ -70,7 +70,10 @@ export class RipgrepService extends Service {
         return;
       }
     } catch {
-      // fall through to system rg
+      // error-policy:J4 the bundled `@vscode/ripgrep` import is optional; when
+      // it is absent we degrade to a system `rg` on PATH (the resolved binary
+      // is logged at service start). `search()` surfaces a missing `rg` as a
+      // spawn error, so this fallback cannot silently hide an unusable binary.
     }
     this.rgPath = "rg";
   }
@@ -127,6 +130,9 @@ function resolveExecutionPath(targetPath: string): {
       searchPath: path.basename(targetPath),
     };
   } catch {
+    // error-policy:J3 existence probe on the search target; when stat fails the
+    // literal path is handed to ripgrep as the search argument so ripgrep
+    // itself reports the miss, rather than fabricating a cwd/searchPath split.
     return { searchPath: targetPath };
   }
 }

--- a/plugins/plugin-health/src/actions/health.ts
+++ b/plugins/plugin-health/src/actions/health.ts
@@ -521,6 +521,14 @@ export function createHealthActionRunner(
         days: plannedDays ?? params.days ?? 7,
       });
     } catch (error) {
+      // error-policy:J4 the connector summary is one input to the health
+      // response; a load failure must not read as "no providers connected", so
+      // reportError surfaces it (via RECENT_ERRORS the agent can retry/reconnect)
+      // while the response still renders from the separate connectorStatus.
+      runtime.reportError("Health.connectorSummary", error, {
+        subaction,
+        days: plannedDays ?? params.days ?? 7,
+      });
       runtime.logger.warn(
         {
           src: "action:health",

--- a/plugins/plugin-health/src/actions/screen-time.ts
+++ b/plugins/plugin-health/src/actions/screen-time.ts
@@ -301,6 +301,8 @@ function normalizeDomain(value: string): string {
   try {
     return new URL(trimmed).hostname.toLowerCase();
   } catch {
+    // error-policy:J3 untrusted domain input; an unparseable URL yields the
+    // empty invalid signal rather than a fabricated hostname.
     return "";
   }
 }

--- a/plugins/plugin-health/src/health-bridge/health-bridge.ts
+++ b/plugins/plugin-health/src/health-bridge/health-bridge.ts
@@ -279,6 +279,8 @@ function isExecutable(path: string): boolean {
     accessSync(path, fsConstants.X_OK);
     return true;
   } catch {
+    // error-policy:J3 existence/permission probe; an access failure means the
+    // HealthKit CLI is absent or not executable — false is the expected miss.
     return false;
   }
 }
@@ -660,6 +662,11 @@ async function googleFitDailySummary(
       summary.sleepHours = sleepMs / (1000 * 60 * 60);
     }
   } catch (error) {
+    // error-policy:J4 optional secondary dataset degrade; the primary activity
+    // summary already succeeded, so a failed sleep sub-fetch flags the day
+    // sleep-unavailable (distinguishable from a real 0) and warns — never a
+    // fabricated zero-sleep reading.
+    //
     // Sleep is a separate best-effort sub-fetch: steps/active-minutes above
     // already succeeded, so we return the summary instead of throwing. But we
     // must NOT let the swallowed failure masquerade as `sleepHours: 0` — that

--- a/plugins/plugin-health/src/providers/health.ts
+++ b/plugins/plugin-health/src/providers/health.ts
@@ -134,6 +134,9 @@ export function createHealthProvider(
         const summary = await options.getSummary(runtime, { days: 3 });
         return buildHealthProviderResult(summary);
       } catch (error) {
+        // error-policy:J4 designed unavailable render; the failure is built into
+        // a distinguishable "health unavailable" provider result carrying the
+        // error text, never a healthy-looking empty summary.
         return buildUnavailableHealthProviderResult(error);
       }
     },

--- a/plugins/plugin-health/src/register.ts
+++ b/plugins/plugin-health/src/register.ts
@@ -7,10 +7,18 @@
  * this a no-op (a DOM is present), so the same import is safe everywhere.
  */
 
+import { logger } from "@elizaos/core";
+
 if (typeof window === "undefined") {
   void import("./register-terminal-view.js")
     .then((m) => m.registerHealthTerminalView())
-    .catch(() => {
-      // Terminal rendering is best-effort; never block plugin load.
+    .catch((error) => {
+      // error-policy:J6 optional terminal-view registration; it runs at module
+      // load with no runtime in scope to reportError, so the failure is recorded
+      // via debug (diagnosable) and never blocks plugin load.
+      logger.debug(
+        { error: error instanceof Error ? error.message : String(error) },
+        "[plugin-health] terminal view registration skipped",
+      );
     });
 }

--- a/plugins/plugin-health/src/routes/sleep.ts
+++ b/plugins/plugin-health/src/routes/sleep.ts
@@ -137,6 +137,9 @@ export function createHealthSleepRouteHandler<
       await fn(service);
       return true;
     } catch (error) {
+      // error-policy:J1 HTTP route boundary; an expected client-error shape is
+      // translated into a status response, while an unexpected failure is
+      // logged at error and rethrown to the host (never a fabricated 200).
       const status = routeErrorStatus(error);
       if (status !== null) {
         logger.warn(

--- a/plugins/plugin-health/src/screen-time/social-taxonomy.ts
+++ b/plugins/plugin-health/src/screen-time/social-taxonomy.ts
@@ -207,6 +207,8 @@ function hostnameFromValue(value: string): string | null {
     }
     return parsed.hostname.replace(/\.+$/, "") || null;
   } catch {
+    // error-policy:J3 untrusted value; an unparseable URL yields null (invalid)
+    // so the caller skips it, never a fabricated hostname.
     return null;
   }
 }

--- a/plugins/plugin-shell/approvals/allowlist.ts
+++ b/plugins/plugin-shell/approvals/allowlist.ts
@@ -195,6 +195,9 @@ export function readApprovalsSnapshot(): ExecApprovalsSnapshot {
   try {
     parsed = JSON.parse(raw) as ExecApprovalsFile;
   } catch (parseError) {
+    // error-policy:J3 untrusted on-disk config; a corrupt snapshot yields the
+    // explicit null so the caller falls back to the deny-all default below,
+    // never a fake-valid parse.
     logger.warn(
       { src: "exec-approval", parseError, filePath },
       "Failed to parse approval config snapshot - file may be corrupted"
@@ -244,6 +247,9 @@ export function loadApprovals(): ExecApprovalsFile {
     try {
       parsed = JSON.parse(raw) as ExecApprovalsFile;
     } catch (parseError) {
+      // error-policy:J3 untrusted on-disk config; a corrupt file resolves to
+      // the fail-closed deny-all default (empty agents), never a permissive
+      // fabricated config.
       logger.error(
         { src: "exec-approval", parseError, filePath },
         "Failed to parse approval config JSON - file may be corrupted. Using defaults."
@@ -261,6 +267,9 @@ export function loadApprovals(): ExecApprovalsFile {
 
     return normalizeApprovals(parsed);
   } catch (error) {
+    // error-policy:J4 read failure (e.g. EACCES) degrades to the fail-closed
+    // deny-all default so the gate never opens on a load error; logged at error
+    // so the permissions problem is visible to the operator.
     logger.error(
       { src: "exec-approval", error, filePath },
       "Failed to load approval config - using defaults. This may indicate a permissions issue."
@@ -284,14 +293,20 @@ export function saveApprovals(file: ExecApprovalsFile): void {
     try {
       fs.chmodSync(filePath, 0o600);
     } catch {
-      // Best-effort on platforms without chmod (e.g., Windows)
+      // error-policy:J6 best-effort hardening; platforms without POSIX chmod
+      // (e.g. Windows) skip the mode tightening — the file is already written.
     }
   } catch (error) {
+    // error-policy:J2 boundary rethrow with `cause`; the write failure is
+    // re-raised (approvals must not silently fail to persist) with the original
+    // error preserved for diagnosis.
     logger.error(
       { src: "exec-approval", error, filePath },
       "Failed to save approval configuration"
     );
-    throw new Error(`Failed to save approval configuration to ${filePath}: ${error}`);
+    throw new Error(`Failed to save approval configuration to ${filePath}`, {
+      cause: error,
+    });
   }
 }
 
@@ -319,12 +334,14 @@ export function ensureApprovals(): ExecApprovalsFile {
   try {
     saveApprovals(updated);
   } catch (error) {
+    // error-policy:J2 warn for operator visibility, then rethrow the original
+    // error unchanged so the caller (resolveApprovals) owns the degrade
+    // decision rather than this helper silently returning a non-persisted config.
     logger.warn(
       { src: "exec-approval", error },
       "Failed to save approval config during ensureApprovals - " +
         "returning in-memory config. Changes will not persist."
     );
-    // Re-throw so caller knows something went wrong
     throw error;
   }
 
@@ -365,7 +382,9 @@ export function resolveApprovals(
   try {
     file = ensureApprovals();
   } catch (error) {
-    // ensureApprovals failed (likely can't write) - use loadApprovals which is read-only
+    // error-policy:J4 write path unavailable (read-only FS / EACCES) → degrade
+    // to the read-only loaded config so the gate still resolves; logged so the
+    // non-persistent state is visible. loadApprovals itself fails closed.
     logger.warn(
       { src: "exec-approval", error },
       "Could not ensure approval config exists - using read-only config"
@@ -518,6 +537,8 @@ function tryRealpath(value: string): string | null {
   try {
     return fs.realpathSync(value);
   } catch {
+    // error-policy:J3 realpath probe; an unresolvable path (absent, broken
+    // symlink) yields null so the caller keeps the original value.
     return null;
   }
 }
@@ -593,6 +614,9 @@ export function recordAllowlistUse(
     saveApprovals(approvals);
     return true;
   } catch (error) {
+    // error-policy:J6 best-effort usage bookkeeping (lastUsedAt); failing to
+    // persist a usage timestamp must not block the already-granted command, so
+    // it returns false (not-recorded) after a warn.
     logger.warn(
       { src: "exec-approval", error, pattern: entry.pattern },
       "Failed to record allowlist usage - continuing without update"
@@ -643,6 +667,9 @@ export function addAllowlistEntry(
     );
     return true;
   } catch (error) {
+    // error-policy:J1 boundary — the save failure is reported to the caller as
+    // `false` (entry not persisted) and logged at error; callers must treat
+    // false as "not added", never as success.
     logger.error(
       { src: "exec-approval", error, pattern: trimmed },
       "Failed to save allowlist after adding entry"

--- a/plugins/plugin-shell/approvals/analysis.ts
+++ b/plugins/plugin-shell/approvals/analysis.ts
@@ -64,6 +64,8 @@ function isExecutableFile(filePath: string): boolean {
     }
     return true;
   } catch {
+    // error-policy:J3 existence/executable probe; stat/access failure means the
+    // file is absent or not executable — false is the expected-miss signal.
     return false;
   }
 }
@@ -697,6 +699,8 @@ function defaultFileExists(filePath: string): boolean {
   try {
     return fs.existsSync(filePath);
   } catch {
+    // error-policy:J3 existence probe; an existsSync throw (e.g. EACCES on a
+    // path segment) is treated as "not present" — false is the miss signal.
     return false;
   }
 }

--- a/plugins/plugin-shell/approvals/service.ts
+++ b/plugins/plugin-shell/approvals/service.ts
@@ -112,6 +112,13 @@ export class ExecApprovalService extends Service {
     try {
       service.approvalConfig = resolveApprovals(runtime.agentId);
     } catch (error) {
+      // error-policy:J4 config load failed at startup → degrade to a fail-closed
+      // (deny-all) in-memory config so the gate never fails open. reportError
+      // surfaces the failure to the agent/owner (approvals won't persist) rather
+      // than leaving a silently non-persistent gate.
+      runtime.reportError("ExecApprovalService.startup", error, {
+        agentId: runtime.agentId,
+      });
       logger.error(
         { src: "service:exec_approval", error, agentId: runtime.agentId },
         "Failed to load approval config during startup - using in-memory defaults. " +
@@ -538,6 +545,12 @@ export class ExecApprovalService extends Service {
           };
         });
     } catch (error) {
+      // error-policy:J4 a failed task query must not read as "no pending
+      // approvals" (that would silently drop an approval prompt); reportError
+      // surfaces the breakage to the agent/owner while the UI degrades to empty.
+      this.runtime.reportError("ExecApprovalService.getPendingApprovals", error, {
+        roomId,
+      });
       logger.error(
         { src: "service:exec_approval", error, roomId },
         "Failed to get pending approvals"

--- a/plugins/plugin-shell/providers/shellHistoryProvider.ts
+++ b/plugins/plugin-shell/providers/shellHistoryProvider.ts
@@ -147,6 +147,10 @@ ${addHeader("# Shell History (Last 10)", historyText)}${fileOpsText}`;
         },
       };
     } catch (error) {
+      // error-policy:J4 designed unavailable render; the provider emits a
+      // distinguishable "Shell history is unavailable: <msg>" status AND reports
+      // the failure via reportError — never a healthy-looking empty history.
+      //
       // Surface the failure through the runtime diagnostic boundary AND as a
       // model-visible status line. A bare `catch {}` that returned an empty
       // string here hid real ShellService failures from both the operator logs

--- a/plugins/plugin-shell/services/shellService.ts
+++ b/plugins/plugin-shell/services/shellService.ts
@@ -117,6 +117,8 @@ export class ShellService extends Service {
         killSession(session);
         logger.debug(`Killed shell session: ${session.id}`);
       } catch (err) {
+        // error-policy:J6 best-effort teardown on service stop; a session that
+        // refuses to die is warned and the remaining sessions are still killed.
         logger.warn(`Failed to kill shell session ${session.id}: ${err}`);
       }
     }
@@ -294,6 +296,9 @@ export class ShellService extends Service {
           executedIn: this.currentDirectory,
         };
       } catch (err) {
+        // error-policy:J1 execution boundary; a sandbox exec failure is
+        // translated into a structured `success:false` ExecResult carrying the
+        // real message, which the SHELL action forwards to the model.
         const errMsg = err instanceof Error ? err.message : String(err);
         logger.error(`[shell:sandbox] exec failed: ${errMsg}`);
         return {
@@ -1348,6 +1353,9 @@ export class ShellService extends Service {
               pty?.write(data);
               cb?.(null);
             } catch (err) {
+              // error-policy:J1 stream-write boundary; a PTY write failure is
+              // forwarded to the Node stream callback as cb(err) (the stream
+              // error channel), never swallowed.
               cb?.(err as Error);
             }
           },
@@ -1356,16 +1364,19 @@ export class ShellService extends Service {
               const eof = process.platform === "win32" ? "\x1a" : "\x04";
               pty?.write(eof);
             } catch {
-              // ignore EOF errors
+              // error-policy:J6 best-effort EOF on stream teardown; a PTY that
+              // already closed cannot accept the EOF byte and needs no action.
             }
           },
         };
       } catch (err) {
+        // error-policy:J4 optional native PTY (`@lydell/node-pty`) unavailable
+        // → designed degrade to plain cross-spawn; the failure is surfaced to
+        // the caller as a warning appended to `opts.warnings`, not swallowed.
         const errText = String(err);
         const warning = `Warning: PTY spawn failed (${errText}); retrying without PTY.`;
         logger.warn(`exec: PTY spawn failed (${errText}); retrying without PTY.`);
         opts.warnings.push(warning);
-        // Fall through to non-PTY execution
       }
     }
 

--- a/plugins/plugin-shell/utils/config.ts
+++ b/plugins/plugin-shell/utils/config.ts
@@ -93,12 +93,17 @@ export function loadShellConfig(): ShellConfig {
         `background: ${allowBackground}, timeout: ${timeout}ms`
     );
   } catch (error) {
+    // error-policy:J1 config boundary; translate the expected ENOENT into a
+    // clear "does not exist" message (preserving the original via `cause`) and
+    // rethrow every other stat failure unchanged so it is not masked.
     if (
       error instanceof Error &&
       "code" in error &&
       (error as NodeJS.ErrnoException).code === "ENOENT"
     ) {
-      throw new Error(`SHELL_ALLOWED_DIRECTORY does not exist: ${allowedDirectory}`);
+      throw new Error(`SHELL_ALLOWED_DIRECTORY does not exist: ${allowedDirectory}`, {
+        cause: error,
+      });
     }
     throw error;
   }

--- a/plugins/plugin-shell/utils/processQueue.ts
+++ b/plugins/plugin-shell/utils/processQueue.ts
@@ -274,6 +274,9 @@ function drainLane(lane: string) {
           pump();
           entry.resolve(result);
         } catch (err) {
+          // error-policy:J1 queue-worker boundary; the task failure is
+          // propagated to the awaiting caller via entry.reject (never
+          // swallowed), and the active count is decremented so the pump drains.
           state.active -= 1;
           pump();
           entry.reject(err);
@@ -430,14 +433,16 @@ export function attachChildProcessBridge(
       try {
         child.kill(signal);
       } catch {
-        // ignore - child may have already exited
+        // error-policy:J6 best-effort signal forwarding; the child may have
+        // already exited, so a failed kill is a no-op.
       }
     };
     try {
       process.on(signal, listener);
       listeners.set(signal, listener);
     } catch {
-      // Unsupported signal on this platform
+      // error-policy:J6 the signal is unsupported on this platform (e.g. SIGHUP
+      // on Windows); skipping its listener is the designed degrade.
     }
   }
 

--- a/plugins/plugin-shell/utils/shellUtils.ts
+++ b/plugins/plugin-shell/utils/shellUtils.ts
@@ -105,7 +105,8 @@ export function killProcessTree(pid: number): void {
         detached: true,
       });
     } catch {
-      // ignore errors if taskkill fails
+      // error-policy:J6 best-effort teardown; a failed taskkill spawn leaves
+      // the tree for the OS to reap and must not throw out of cleanup.
     }
     return;
   }
@@ -113,10 +114,12 @@ export function killProcessTree(pid: number): void {
   try {
     process.kill(-pid, "SIGKILL");
   } catch {
+    // error-policy:J6 process-group kill failed (no group / already gone) →
+    // fall back to a single-pid kill during teardown.
     try {
       process.kill(pid, "SIGKILL");
     } catch {
-      // process already dead
+      // error-policy:J6 best-effort teardown; the process is already dead.
     }
   }
 }
@@ -164,7 +167,9 @@ export function resolveWorkdir(workdir: string, warnings: string[]): string {
       return workdir;
     }
   } catch {
-    // ignore, fallback below
+    // error-policy:J4 designed degrade; an unavailable workdir falls back to the
+    // process cwd/home and the substitution is surfaced to the caller via the
+    // `warnings` array below (never silently swapped).
   }
   warnings.push(`Warning: workdir "${workdir}" is unavailable; using "${fallback}".`);
   return fallback;
@@ -175,6 +180,8 @@ function safeCwd(): string | null {
     const cwd = process.cwd();
     return existsSync(cwd) ? cwd : null;
   } catch {
+    // error-policy:J3 cwd probe; process.cwd() throws when the working
+    // directory was deleted out from under the process — null is the miss.
     return null;
   }
 }
@@ -460,6 +467,10 @@ export async function spawnWithFallback(
         fallbackLabel: attempt.label,
       };
     } catch (err) {
+      // error-policy:J4 designed spawn-fallback retry; a retryable spawn error
+      // advances to the next fallback shell, but a non-retryable error (or the
+      // exhausted fallback list) rethrows immediately — the failure is surfaced,
+      // not masked by silently trying alternatives forever.
       lastError = err;
       const nextFallback = fallbacks[index];
       if (!nextFallback || !shouldRetry(err, retryCodes)) {

--- a/plugins/plugin-shell/utils/terminalCapabilities.ts
+++ b/plugins/plugin-shell/utils/terminalCapabilities.ts
@@ -88,6 +88,8 @@ function executableExists(candidate: string): boolean {
     fs.accessSync(candidate, fs.constants.X_OK);
     return true;
   } catch {
+    // error-policy:J3 existence/permission probe; access failure means the
+    // candidate is absent or not executable — false is the expected miss.
     return false;
   }
 }


### PR DESCRIPTION
## What this is

Fallback-slop sweep of **`plugin-coding-tools`**, **`plugin-shell`**, and **`plugin-health`** (the J-chunk of #12273). Every error handler in these three plugins now either surfaces the failure observably (action `success:false` + `result.error`, or `runtime.reportError` for background/service paths) or carries a grep-able `// error-policy:J<N> <reason>` justification. No handler fabricates a success-shaped result from a failure.

Advances #12273 · Part of #12182. Builds on the merged precision slice #12885 (whose verdicts for `ls.ts`/`session-cwd-service.ts`/computeruse/personal-assistant are kept, not redone) and complements sibling fixes #12798 (health-bridge Google-Fit sleep) and #12799 (shell-history provider), whose already-landed logic this PR only annotates.

## What landed

- **Every catch in the three plugins is now annotated** (`error-policy:J<N>`) or fixed. A detector confirms zero unannotated catches outside embedded-script string literals.
- **68 `error-policy:J` annotations added by this PR** — J1×20, J2×2, J3×16, J4×16, J6×14 — covering action-handler boundaries, capability-router degrades, OS existence/permission probes, best-effort teardown, and untrusted-input parses.
- **Real fail-fast fixes (not just annotations):**
  - `plugin-shell/approvals/service.ts` — startup config-load failure and `getPendingApprovals` query failure now call `runtime.reportError` (fail-closed deny-all gate + agent-visible failure) instead of silently degrading to an empty/non-persistent gate.
  - `plugin-health/src/actions/health.ts` — connector-summary load failure now `reportError`s (via `RECENT_ERRORS` the agent can retry/reconnect) so it never reads as "no providers connected".
  - `plugin-shell/approvals/allowlist.ts` + `plugin-shell/utils/config.ts` — save/stat rethrows now preserve the original via `{ cause }` (J2).
  - `plugin-health/src/register.ts` — the best-effort terminal-view registration `.catch(() => {})` now records the reason via `logger.debug` (J6) rather than swallowing silently.
- **`console.*` in runtime code:** none present in these plugins (only a string-literal example inside `plugin-shell/prompts.ts` and generated PowerShell inside `plugin-coding-tools/src/actions/bash.ts`, both non-code).
- **Real-error-path test** (`plugin-coding-tools/src/actions/bash.error-path.test.ts`): drives the real `SHELL` action against a genuinely missing binary and a genuinely failing command through the real host shell — **no mocked failure** — and asserts `success:false` + `result.error` (Error) + real `exit_code` (127) + the real shell diagnostic reach the caller. This is the shape the planner loop shows the model.

## Site → verdict inventory (categories)

| Category | Meaning | Count (added) |
|---|---|---|
| J1 | boundary translation → structured failure (action `success:false`, rejection, callback-error, rethrow) | 20 |
| J2 | context-adding rethrow with `cause` | 2 |
| J3 | untrusted-input / existence-probe → explicit invalid/false (never fake-valid) | 16 |
| J4 | designed unavailable/degrade with surfacing (warning / reportError / distinguishable state) | 16 |
| J6 | best-effort teardown (debug/warn only) | 14 |

Notable keeps: capability-router `CAPABILITY_UNAVAILABLE` degrades (`run-shell.ts`, `run-git-command.ts`) rethrow every non-expected error; `bash.ts` cwd probe distinguishes expected-miss (ENOENT → session cwd + warn) from breakage (→ `success:false`); `health-bridge.ts` Google-Fit sleep sub-fetch flags `sleepUnavailable` distinct from a real `0`; `shellHistoryProvider.ts` renders a distinguishable "unavailable" status **and** `reportError`s.

## Verification

Targeted turbo typecheck (all deps built in dependency order): **64/64 tasks successful**, including all three of my packages.

Biome `lint:check` (read-only), all clean:
- `plugin-coding-tools`: Checked 58 files, no fixes
- `plugin-shell`: Checked 37 files, no fixes
- `plugin-health`: Checked 117 files, no fixes

Package test suites:
- `plugin-coding-tools`: **202 passed** (20 files), incl. the new `bash.error-path.test.ts` (2 passed)
- `plugin-shell`: **26 passed** (4 files)
- `plugin-health`: **153 passed, 4 skipped**; the one failing suite `src/__tests__/smoke.test.ts` fails **identically on clean `origin/develop`** with my changes reverted (collection-time `TypeError` from the `../index.js`/`../connectors` import — the connectors module is being rewritten concurrently in a sibling lane; per this chunk's scope I did **not** touch `plugin-health/src/connectors/index.ts`). Pre-existing, unrelated to this diff.

Grep audits (issue's gates):
- empty catch (`catch {}`) in these plugins: **0** outside the exempt embedded-PowerShell string literals in `bash.ts`.
- `console.*` in runtime code: **0** (only a string-literal example in `prompts.ts`).
- `rg -c 'error-policy:J'`: coding-tools 31, shell 31, health 8 — all > 0.

**Full `bun run verify`:** green for this PR's three packages. Every failure surfaced by the whole-repo gate is in a package this PR does **not** touch and is pre-existing on `origin/develop` (my diff is comment + additive-runtime-only — it changes no exported type, so it cannot introduce a downstream failure):

- Typecheck (clean-tree `turbo run typecheck --continue`, 336/343): `agent`, `app-core` — both fail on the identical root cause `plugins/plugin-discord/messages.ts:1225 error TS2339: Property 'platformMessageId' does not exist on type 'MemoryMetadata'` (a plugin-discord baseline break; `agent`/`app-core` only transitively typecheck it); `plugin-discord`, `plugin-capacitor-bridge`, `plugin-sub-agent-claude-code` (the latter two don't even depend on my plugins); plus the documented known-red `app#typecheck` / `electrobun#typecheck`.
- Lint: `plugin-computeruse#lint` — `noNonNullAssertion` in its own test files (`dhash.test.ts:21` `bytes[i]!`, `brain.test.ts:333` `scene.focused_window!`), present **verbatim on `origin/develop`**; plus `electrobun#lint` / `tui#lint`.

None of these reference any file under `plugin-coding-tools` / `plugin-shell` / `plugin-health`.

## Deviations

- **`?? <lit>` / `|| <lit>` load-path sweep deferred.** This chunk's Work items are catch-focused (surface failures, annotate keeps, remove `console.*`, real-error-path test); the broad literal-fallback sweep (42 `?? <lit>` candidates across these plugins, most benign defaults) is left to the wider #12273 rollout, consistent with the merged precision-slice precedent (#12885). No egregious data-fabrication-on-load-failure `?? <lit>` sites were found in the catch triage.
- **`plugin-health/src/connectors/index.ts` not touched** — being rewritten concurrently in a sibling lane; its suspect sites are deferred there.
- **Scope expanded to `plugin-health`** per the chunk's post-#12885 update (its ~15 suspect sites were previously left out of this chunk).

## Evidence (per PR_EVIDENCE.md)

- **Real end-to-end test of the fixed behavior:** `bash.error-path.test.ts` — real missing binary / failing command, no mock, asserts `success:false` + `result.error` reaches the caller. This is the deterministic proof that a shell failure is never repackaged as success.
- **Real-LLM trajectory / rendered UI / device capture:** `N/A` — this is an internal error-handling refactor (annotations + fail-fast surfacing) with no new user-facing surface; the behavioral change (failures reach the caller/agent) is proven by the deterministic real-error-path test above, and the planner-loop delivery of `result.error` to the model is existing, unchanged machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
