### PR TITLE
fix(#12267): mobile UI fallback-slop batch A — chat, onboarding, voice, views

### DIFF
--- a/packages/app/src/boot-failure.ts
+++ b/packages/app/src/boot-failure.ts
@@ -20,7 +20,7 @@ export function renderBootFailure(
   try {
     console.error("[boot] app failed to start", error);
   } catch {
-    // never let logging mask the recovery UI
+    // error-policy:J7 never let logging mask the recovery UI
   }
 
   const root = doc.getElementById("root");

--- a/packages/app/src/deep-link-handler.ts
+++ b/packages/app/src/deep-link-handler.ts
@@ -86,6 +86,7 @@ export function createDeepLinkHandler(ctx: DeepLinkHandlerContext) {
     try {
       parsed = new URL(url);
     } catch {
+      // error-policy:J3 untrusted deep-link URL — unparseable means "not ours"
       return;
     }
 
@@ -166,6 +167,7 @@ export function createDeepLinkHandler(ctx: DeepLinkHandlerContext) {
     try {
       validatedUrl = new URL(gatewayUrl);
     } catch {
+      // error-policy:J3 untrusted gateway URL — reject loudly, never connect
       console.error(`${ctx.logPrefix} Invalid gateway URL format`);
       return;
     }

--- a/packages/app/src/embed-bootstrap.ts
+++ b/packages/app/src/embed-bootstrap.ts
@@ -164,6 +164,8 @@ export async function runEmbedHandshake(
     }
     response = result;
   } catch {
+    // error-policy:J1 auth boundary — structured failure the embed shell
+    // renders
     return { status: "failed", reason: "network_error" };
   } finally {
     if (timeoutHandle) clearTimeout(timeoutHandle);
@@ -177,6 +179,8 @@ export async function runEmbedHandshake(
   try {
     body = (await response.json()) as typeof body;
   } catch {
+    // error-policy:J3 unparseable auth response — explicit failure, never a
+    // fake-valid token
     return { status: "failed", reason: "bad_response" };
   }
 

--- a/packages/app/src/ios-attachment-smoke.ts
+++ b/packages/app/src/ios-attachment-smoke.ts
@@ -99,6 +99,7 @@ function parseIosAttachmentSmokeRequest(
           : fallback.dataUrl,
     };
   } catch {
+    // error-policy:J3 corrupt smoke-request blob — run with the defaults
     return fallback;
   }
 }
@@ -163,8 +164,9 @@ function resolveIosAttachmentSmokeApiUrl(
   try {
     return new URL(path).toString();
   } catch {
-    // Relative API paths inside a Capacitor WKWebView resolve to the app origin,
-    // so use the same configured agent base as the rest of the UI client.
+    // error-policy:J3 not an absolute URL — relative API paths inside a
+    // Capacitor WKWebView resolve to the app origin, so use the same
+    // configured agent base as the rest of the UI client
   }
   const base = (fallbackBase.trim() || getApiBaseUrl()).replace(/\/+$/, "");
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
@@ -226,7 +228,8 @@ async function readSmokePreference(
     const value = window.localStorage.getItem(key);
     if (value) return value;
   } catch {
-    // Preferences is the authoritative native store for the simulator harness.
+    // error-policy:J4 unavailable localStorage — Preferences (already read
+    // above) is the authoritative native store for the simulator harness
   }
   return null;
 }
@@ -265,6 +268,8 @@ async function waitForOnboardingSmokeResultIfPresent(
         );
       }
     } catch (error) {
+      // error-policy:J3 corrupt interim result blob — keep polling; a parsed
+      // "failed" result still propagates
       if (error instanceof Error && error.message.includes("failed")) {
         throw error;
       }
@@ -289,6 +294,8 @@ export async function runIosAttachmentSmokeIfRequested({
   try {
     rawRequest = window.localStorage.getItem(IOS_ATTACHMENT_SMOKE_REQUEST_KEY);
   } catch {
+    // error-policy:J3 unavailable storage reads as "no request"; the
+    // Preferences read below still serves the simulator harness
     rawRequest = null;
   }
   if (!rawRequest) {
@@ -453,6 +460,7 @@ export async function runIosAttachmentSmokeIfRequested({
             : { attempted: true, settled: true };
       });
     } catch (error) {
+      // error-policy:J1 the share failure is recorded in the smoke result
       shareOutcome = {
         attempted: true,
         rejected: true,
@@ -480,6 +488,8 @@ export async function runIosAttachmentSmokeIfRequested({
       share: shareOutcome,
     });
   } catch (error) {
+    // error-policy:J1 smoke boundary — the failure is written to the
+    // harness result sink
     const filesystem = readCapacitorFilesystemForSmoke();
     const share = readCapacitorShareForSmoke();
     await writeAttachmentResult(writeResult, {
@@ -498,7 +508,8 @@ export async function runIosAttachmentSmokeIfRequested({
     try {
       window.localStorage.removeItem(IOS_ATTACHMENT_SMOKE_REQUEST_KEY);
     } catch {
-      // Preferences removal below is authoritative for the simulator harness.
+      // error-policy:J6 best-effort cleanup — Preferences removal below is
+      // authoritative for the simulator harness
     }
     await removePreference(IOS_ATTACHMENT_SMOKE_REQUEST_KEY);
   }

--- a/packages/app/src/keyboard-dictation.ts
+++ b/packages/app/src/keyboard-dictation.ts
@@ -396,6 +396,8 @@ export function startKeyboardDictationSession(
 
   void writeState("recording").then((ok) => {
     if (!ok || settled || !capture) return;
+    // error-policy:J1 session boundary — a failed start terminates the
+    // dictation session through fail(), which records the error for the host
     capture.start().catch((error: unknown) => {
       if (!settled) {
         fail(

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -410,7 +410,8 @@ function applyCloudPairSessionToken(): void {
     if (!token) return;
     client.setToken(token);
   } catch {
-    // sessionStorage can be unavailable in hardened browser contexts.
+    // error-policy:J4 sessionStorage can be unavailable in hardened browser
+    // contexts — the pairing token is simply not adopted
   }
 }
 
@@ -522,6 +523,8 @@ function scheduleAppModuleIdleLoads(
       nextIndex += 1;
       activeCount += 1;
       void importSideEffectAppModule(key, load)
+        // error-policy:J4 deferred enhancement modules — a load failure is
+        // logged and the app stays usable without that module
         .catch((error) => {
           console.warn(`${APP_LOG_PREFIX} Failed to load ${key}:`, error);
         })
@@ -676,7 +679,8 @@ async function writeIosPreferenceSmokeResult(
   try {
     Storage.prototype.setItem.call(window.localStorage, key, value);
   } catch {
-    // Ignore localStorage failures; Preferences is the simulator harness source of truth.
+    // error-policy:J6 best-effort echo — Preferences is the simulator
+    // harness source of truth
   }
   await boundedPreferenceWrite(() =>
     Preferences.set({
@@ -728,7 +732,8 @@ function renderIosFullBunSmokeStatus(message: string): void {
     container.appendChild(text);
     document.body.appendChild(container);
   } catch {
-    // Smoke diagnostics are best-effort.
+    // error-policy:J7 smoke diagnostics are best-effort — a failed status
+    // render must not kill the smoke run
   }
 }
 
@@ -746,6 +751,7 @@ function parseIosOnboardingSmokeRequest(raw: string | null): {
           : fallback.apiBase,
     };
   } catch {
+    // error-policy:J3 corrupt smoke-request blob — run with the defaults
     return fallback;
   }
 }
@@ -788,6 +794,7 @@ function readIosOnboardingSmokeStorageSnapshot(): Record<
       try {
         return [key, window.localStorage.getItem(key)];
       } catch {
+        // error-policy:J7 diagnostics snapshot — an unreadable key reports null
         return [key, null];
       }
     }),
@@ -818,6 +825,8 @@ async function runIosOnboardingSmokeIfRequested(): Promise<boolean> {
   try {
     rawRequest = window.localStorage.getItem(IOS_ONBOARDING_SMOKE_REQUEST_KEY);
   } catch {
+    // error-policy:J3 unavailable storage reads as "no request"; the
+    // Preferences fallback below still serves the simulator harness
     rawRequest = null;
   }
   if (!rawRequest) {
@@ -870,6 +879,8 @@ async function runIosOnboardingSmokeIfRequested(): Promise<boolean> {
       storage,
     });
   } catch (error) {
+    // error-policy:J1 smoke boundary — the failure is written to the
+    // harness result sink
     await writeIosOnboardingSmokeResult({
       ok: false,
       phase: "failed",
@@ -882,7 +893,8 @@ async function runIosOnboardingSmokeIfRequested(): Promise<boolean> {
     try {
       window.localStorage.removeItem(IOS_ONBOARDING_SMOKE_REQUEST_KEY);
     } catch {
-      // Preferences removal below is authoritative for the simulator harness.
+      // error-policy:J6 best-effort cleanup — Preferences removal below is
+      // authoritative for the simulator harness
     }
     await boundedPreferenceWrite(() =>
       Preferences.remove({ key: IOS_ONBOARDING_SMOKE_REQUEST_KEY }),
@@ -923,10 +935,12 @@ async function fetchIosFullBunSmokeJson<T>(
   try {
     return JSON.parse(text) as T;
   } catch (error) {
+    // error-policy:J2 context-adding rethrow
     throw new Error(
       `${label} returned invalid JSON: ${
         error instanceof Error ? error.message : String(error)
       }`,
+      { cause: error },
     );
   }
 }
@@ -975,10 +989,12 @@ function parseIosFullBunSmokeHttpJson<T>(label: string, value: unknown): T {
   try {
     return JSON.parse(body) as T;
   } catch (error) {
+    // error-policy:J2 context-adding rethrow
     throw new Error(
       `${label} returned invalid JSON: ${
         error instanceof Error ? error.message : String(error)
       }`,
+      { cause: error },
     );
   }
 }
@@ -1022,6 +1038,8 @@ async function runIosFullBunSmokeIfRequested(): Promise<boolean> {
     requested =
       window.localStorage.getItem(IOS_FULL_BUN_SMOKE_REQUEST_KEY) === "1";
   } catch {
+    // error-policy:J3 unavailable storage reads as "not requested"; the
+    // Preferences read below still serves the simulator harness
     requested = false;
   }
   try {
@@ -1030,14 +1048,16 @@ async function runIosFullBunSmokeIfRequested(): Promise<boolean> {
         (await boundedPreferenceGet(IOS_FULL_BUN_SMOKE_REQUEST_KEY)) === "1";
     }
   } catch {
-    // Keep the localStorage result from the storage bridge hydration.
+    // error-policy:J4 Preferences unavailable — keep the localStorage
+    // result from the storage bridge hydration
   }
   if (!requested) return false;
   iosFullBunSmokeStarted = true;
   try {
     window.localStorage.setItem(IOS_FULL_BUN_SMOKE_REQUEST_KEY, "1");
   } catch {
-    // Preferences can request the smoke before localStorage is hydrated.
+    // error-policy:J6 best-effort echo — Preferences can request the smoke
+    // before localStorage is hydrated
   }
   renderIosFullBunSmokeStatus("Running iOS full Bun backend smoke...");
   window.__ELIZA_IOS_LOCAL_AGENT_DEBUG__ = (event) => {
@@ -1450,6 +1470,8 @@ async function runIosFullBunSmokeIfRequested(): Promise<boolean> {
       streamMessage,
     });
   } catch (error) {
+    // error-policy:J1 smoke boundary — the failure is written to the
+    // harness result sink
     await writeIosFullBunSmokeResult({
       ok: false,
       phase: "failed",
@@ -1461,7 +1483,8 @@ async function runIosFullBunSmokeIfRequested(): Promise<boolean> {
     try {
       window.localStorage.removeItem(IOS_FULL_BUN_SMOKE_REQUEST_KEY);
     } catch {
-      // Ignore localStorage failures; Preferences removal below is authoritative.
+      // error-policy:J6 best-effort cleanup — Preferences removal below is
+      // authoritative
     }
     await boundedPreferenceWrite(() =>
       Preferences.remove({ key: IOS_FULL_BUN_SMOKE_REQUEST_KEY }),
@@ -1475,6 +1498,8 @@ async function initializeAgent(): Promise<void> {
     const status = await Agent.getStatus();
     dispatchAppEvent(AGENT_READY_EVENT, status);
   } catch (err) {
+    // error-policy:J4 the native agent plugin is optional (absent on web) —
+    // the app runs against a remote agent instead; logged for triage
     console.warn(
       `${APP_LOG_PREFIX} Agent not available:`,
       err instanceof Error ? err.message : err,
@@ -1555,6 +1580,7 @@ async function registerMobileBlockerBackends(): Promise<void> {
       appNative.createNativeAppBlockerBackend(appNative.AppBlocker),
     );
   } catch (error) {
+    // error-policy:J4 optional native plugin — absence is a designed degrade
     logNativePluginUnavailable("Blocker backends", error);
   }
 }
@@ -1576,6 +1602,7 @@ async function initializeStatusBar(): Promise<void> {
       await StatusBar.setBackgroundColor({ color: "#00000000" });
     }
   } catch (error) {
+    // error-policy:J4 optional native plugin — absence is a designed degrade
     logNativePluginUnavailable("StatusBar", error);
   }
 }
@@ -1607,6 +1634,7 @@ async function initializeKeyboard(): Promise<void> {
       document.body.classList.remove("keyboard-open");
     });
   } catch (error) {
+    // error-policy:J4 optional native plugin — absence is a designed degrade
     logNativePluginUnavailable("Keyboard", error);
   }
 }
@@ -1657,6 +1685,7 @@ function connectFirstRunRemoteDeepLink(rawApiBase: string): void {
   try {
     validatedUrl = new URL(rawApiBase);
   } catch {
+    // error-policy:J3 untrusted deep-link input — rejected loudly
     console.error(`${APP_LOG_PREFIX} Invalid first-run remote URL format`);
     return;
   }
@@ -1695,6 +1724,8 @@ function connectFirstRunRemoteDeepLink(rawApiBase: string): void {
     label: validatedUrl.hostname || "Remote agent",
     apiBase: connection.apiBase,
   });
+  // error-policy:J6 best-effort persist — the connect below still lands;
+  // only re-selection after restart is lost, and the failure is logged
   void setStorageValue("elizaos:active-server", activeServer).catch((error) => {
     console.warn(
       `${APP_LOG_PREFIX} Failed to persist first-run remote active server:`,
@@ -1721,6 +1752,9 @@ function handleDeepLink(url: string): void {
   try {
     parsed = new URL(url);
   } catch {
+    // error-policy:J3 untrusted deep-link input — unparseable links are
+    // dropped loudly so a broken link is diagnosable
+    console.warn(`${APP_LOG_PREFIX} Ignoring unparseable deep link`);
     return;
   }
 
@@ -1831,6 +1865,7 @@ function handleDeepLink(url: string): void {
             token: connection.token ?? undefined,
           });
         } catch {
+          // error-policy:J3 untrusted deep-link input — rejected loudly
           console.error(`${APP_LOG_PREFIX} Invalid gateway URL format`);
         }
       }
@@ -2345,6 +2380,8 @@ function validateAndSetApiBase(apiBase: string): void {
       );
     }
   } catch {
+    // error-policy:J3 not an absolute URL — accept only a same-origin
+    // relative path, otherwise reject loudly
     if (apiBase.startsWith("/") && !apiBase.startsWith("//")) {
       setBootConfig({ ...getBootConfig(), apiBase });
     } else {
@@ -2407,6 +2444,7 @@ function getCurrentIosRuntimeConfig(): IosRuntimeConfig {
     if (!mode) return IOS_RUNTIME_ENV_CONFIG;
     return { ...IOS_RUNTIME_ENV_CONFIG, mode };
   } catch {
+    // error-policy:J3 unavailable storage — build-time runtime config
     return IOS_RUNTIME_ENV_CONFIG;
   }
 }
@@ -2452,7 +2490,8 @@ async function getOrCreateDeviceBridgeId(): Promise<string> {
       ).value?.trim();
       if (fromPrefs) return fromPrefs;
     } catch {
-      // Preferences unavailable on this platform; fall through to localStorage.
+      // error-policy:J4 Preferences unavailable on this platform — fall
+      // through to localStorage
     }
     return (
       globalThis.localStorage?.getItem(DEVICE_BRIDGE_ID_KEY)?.trim() ||
@@ -2470,12 +2509,14 @@ async function getOrCreateDeviceBridgeId(): Promise<string> {
   try {
     await Preferences.set({ key: DEVICE_BRIDGE_ID_KEY, value: generated });
   } catch {
-    // Preferences unavailable; localStorage below is the durable fallback.
+    // error-policy:J6 Preferences unavailable — localStorage below is the
+    // durable fallback
   }
   try {
     globalThis.localStorage?.setItem(DEVICE_BRIDGE_ID_KEY, generated);
   } catch {
-    // No persistent store available; the id is still usable for this session.
+    // error-policy:J6 no persistent store available — the id is still
+    // usable for this session
   }
   return generated;
 }
@@ -2559,6 +2600,7 @@ async function configureMobileBackgroundRunner(retry = 0): Promise<void> {
       details,
     });
   } catch (error) {
+    // error-policy:J4 optional native module — absence logged, app degrades
     console.warn(
       `${APP_LOG_PREFIX} Background runner unavailable:`,
       error instanceof Error ? error.message : error,
@@ -2617,6 +2659,7 @@ async function initializeMobileDeviceBridge(): Promise<void> {
         },
       });
     } catch (error) {
+      // error-policy:J4 optional native module — absence logged, app degrades
       console.warn(
         `${APP_LOG_PREFIX} Device bridge unavailable:`,
         error instanceof Error ? error.message : error,
@@ -2685,6 +2728,7 @@ async function initializeMobileAgentTunnel(): Promise<void> {
         status.lastError ?? "",
       );
     } catch (error) {
+      // error-policy:J4 optional native module — absence logged, app degrades
       console.warn(
         `${APP_LOG_PREFIX} Mobile agent tunnel unavailable:`,
         error instanceof Error ? error.message : error,
@@ -2705,6 +2749,7 @@ async function stopMobileAgentTunnel(): Promise<void> {
     );
     await MobileAgentBridge.stopInboundTunnel();
   } catch (error) {
+    // error-policy:J6 teardown — stop failure is logged
     console.warn(
       `${APP_LOG_PREFIX} Mobile agent tunnel stop failed:`,
       error instanceof Error ? error.message : error,
@@ -2713,7 +2758,8 @@ async function stopMobileAgentTunnel(): Promise<void> {
   try {
     await mobileAgentTunnelListener?.remove();
   } catch {
-    // Native tunnel stop above is authoritative.
+    // error-policy:J6 teardown — the native tunnel stop above is
+    // authoritative
   }
   mobileAgentTunnelListener = null;
 }
@@ -2786,6 +2832,8 @@ async function main(): Promise<void> {
   try {
     await applyLaunchConnectionFromUrl();
   } catch (err) {
+    // error-policy:J4 the launch-URL session apply is best-effort — the
+    // failure is logged and normal boot (with its own auth flows) proceeds
     console.error(
       `${APP_LOG_PREFIX} Failed to apply managed cloud launch session:`,
       err instanceof Error ? err.message : err,
@@ -2885,6 +2933,8 @@ async function main(): Promise<void> {
     const { registerDesktopFusedWake } = await import("@elizaos/ui/voice");
     registerDesktopFusedWake();
   } catch (error) {
+    // error-policy:J4 never let a voice-chunk load failure (e.g. a stale
+    // index.html pointing at a purged hash) gate mounting the app
     console.warn("[boot] fused-wake voice module unavailable", error);
   }
   markStartup("bridges:end", { platform });
@@ -2898,6 +2948,7 @@ async function main(): Promise<void> {
 // rejection unhandled and the page permanently blank. Route every boot failure
 // to an actionable reload card instead.
 function boot(): void {
+  // error-policy:J1 boot boundary — every rejection renders the reload card
   void main().catch(renderBootFailure);
 }
 

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -390,6 +390,7 @@ function hasFirstRunRuntimeOverride(): boolean {
     const runtime = getWindowUrlSearchParams().get("runtime");
     return runtime === "first-run";
   } catch {
+    // error-policy:J3 unparseable location params — no override requested
     return false;
   }
 }
@@ -694,7 +695,8 @@ async function boundedPreferenceWrite(
       new Promise((resolve) => window.setTimeout(resolve, 2_000)),
     ]);
   } catch {
-    // The storage bridge also issued a fire-and-forget Preferences write from
+    // error-policy:J7 smoke-harness diagnostics write — the storage bridge
+    // also issued a fire-and-forget Preferences write from
     // localStorage.setItem. The simulator smoke will keep polling the native
     // defaults domain, but the WebView must not block forever on persistence.
   }
@@ -708,6 +710,8 @@ async function boundedPreferenceGet(key: string): Promise<string | null> {
     ]);
     return result?.value ?? null;
   } catch {
+    // error-policy:J7 smoke-harness preference probe — a blocked Preferences
+    // bridge must not wedge the smoke; the poll loop retries
     return null;
   }
 }
@@ -2256,6 +2260,7 @@ function isConfiguredCloudApiHost(host: string): boolean {
   try {
     return host === new URL(configured).hostname;
   } catch {
+    // error-policy:J3 unparseable configured base — fail closed (untrusted)
     return false;
   }
 }
@@ -2318,6 +2323,7 @@ function isTrustedNativeWebSocketUrl(value: string): boolean {
       parsed.protocol === "wss:" && !isPrivateOrLoopbackApiHost(parsed.hostname)
     );
   } catch {
+    // error-policy:J3 unparseable bridge URL — fail closed (untrusted)
     return false;
   }
 }
@@ -2497,6 +2503,7 @@ function resolveDeviceBridgeUrl(config: IosRuntimeConfig): string | null {
     const bridgeUrl = apiBaseToDeviceBridgeUrl(apiBase);
     return isTrustedNativeWebSocketUrl(bridgeUrl) ? bridgeUrl : null;
   } catch {
+    // error-policy:J3 underivable/untrusted bridge URL — fail closed (no bridge)
     return null;
   }
 }
@@ -2508,6 +2515,8 @@ async function readAndroidLocalAgentToken(): Promise<string | undefined> {
     const token = result?.token?.trim();
     return token ? token : undefined;
   } catch {
+    // error-policy:J4 bridge probe — tokenless config proceeds and the local
+    // agent's 401 surfaces through the request path
     return undefined;
   }
 }

--- a/packages/app/src/mobile-bridges.ts
+++ b/packages/app/src/mobile-bridges.ts
@@ -109,6 +109,7 @@ export function createMobileBridges(ctx: MobileBridgeContext) {
         ? bridgeUrl
         : null;
     } catch {
+      // error-policy:J3 underivable/untrusted bridge URL — fail closed (no bridge)
       return null;
     }
   }
@@ -120,6 +121,8 @@ export function createMobileBridges(ctx: MobileBridgeContext) {
       const token = result?.token?.trim();
       return token ? token : undefined;
     } catch {
+      // error-policy:J4 bridge probe — tokenless config proceeds and the
+      // local agent's 401 surfaces through the request path
       return undefined;
     }
   }
@@ -334,7 +337,7 @@ export function createMobileBridges(ctx: MobileBridgeContext) {
     try {
       await agentTunnelListener?.remove();
     } catch {
-      // Native tunnel stop above is authoritative.
+      // error-policy:J6 teardown — native tunnel stop above is authoritative
     }
     agentTunnelListener = null;
   }

--- a/packages/app/src/mobile-bridges.ts
+++ b/packages/app/src/mobile-bridges.ts
@@ -168,6 +168,7 @@ export function createMobileBridges(ctx: MobileBridgeContext) {
         details,
       });
     } catch (error) {
+      // error-policy:J4 optional native module — absence logged, app degrades
       console.warn(
         `${ctx.logPrefix} Background runner unavailable:`,
         error instanceof Error ? error.message : error,
@@ -231,6 +232,7 @@ export function createMobileBridges(ctx: MobileBridgeContext) {
           },
         });
       } catch (error) {
+        // error-policy:J4 bounded retry below; absence after that is logged
         console.warn(
           `${ctx.logPrefix} Device bridge unavailable:`,
           error instanceof Error ? error.message : error,
@@ -309,6 +311,7 @@ export function createMobileBridges(ctx: MobileBridgeContext) {
           status.lastError ?? "",
         );
       } catch (error) {
+        // error-policy:J4 optional native module — absence logged, app degrades
         console.warn(
           `${ctx.logPrefix} Mobile agent tunnel unavailable:`,
           error instanceof Error ? error.message : error,
@@ -329,6 +332,7 @@ export function createMobileBridges(ctx: MobileBridgeContext) {
       );
       await MobileAgentBridge.stopInboundTunnel();
     } catch (error) {
+      // error-policy:J6 teardown — stop failure is logged
       console.warn(
         `${ctx.logPrefix} Mobile agent tunnel stop failed:`,
         error instanceof Error ? error.message : error,

--- a/packages/app/src/mobile-lifecycle.ts
+++ b/packages/app/src/mobile-lifecycle.ts
@@ -69,6 +69,7 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
         await StatusBar.setBackgroundColor({ color: "#00000000" });
       }
     } catch (error) {
+      // error-policy:J4 optional native plugin — absence is a designed degrade
       logNativePluginUnavailable("StatusBar", error);
     }
   }
@@ -99,6 +100,7 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
         document.body.classList.remove("keyboard-open");
       });
     } catch (error) {
+      // error-policy:J4 optional native plugin — absence is a designed degrade
       logNativePluginUnavailable("Keyboard", error);
     }
   }
@@ -131,6 +133,8 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
       CapacitorApp.addListener("appStateChange", ({ isActive }) => {
         setAppActive(isActive);
       }),
+      // error-policy:J4 App plugin unavailable — the visibilitychange
+      // fallback below still drives pause/resume
     ).catch((error) => {
       logNativePluginUnavailable("App", error);
     });
@@ -174,6 +178,7 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
           });
         }
       }),
+      // error-policy:J4 App plugin unavailable — the back press no-ops
     ).catch((error) => {
       logNativePluginUnavailable("App", error);
     });
@@ -182,6 +187,8 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
       CapacitorApp.addListener("appUrlOpen", ({ url }) => {
         handleDeepLinkOnce(url);
       }),
+      // error-policy:J4 App plugin unavailable — deep links degrade to the
+      // cold-launch replay below / web routing
     ).catch((error) => {
       logNativePluginUnavailable("App", error);
     });
@@ -198,6 +205,7 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
         .then((result) => {
           if (handleDeepLinkOnce(result?.url)) stopReplay();
         })
+        // error-policy:J4 App plugin unavailable — stop the replay loop
         .catch((error) => {
           stopReplay();
           logNativePluginUnavailable("App", error);
@@ -249,8 +257,9 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
         setConnected(status.connected);
       });
     } catch (error) {
-      // The online/offline fallback above remains active, so leave the listener
-      // marked registered rather than resetting for a native retry.
+      // error-policy:J4 the online/offline fallback above remains active, so
+      // leave the listener marked registered rather than resetting for a
+      // native retry
       logNativePluginUnavailable("Network", error);
     }
   }

--- a/packages/app/src/mobile-lifecycle.ts
+++ b/packages/app/src/mobile-lifecycle.ts
@@ -169,7 +169,8 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
           // background (minimize) rather than killing it, so the agent + state
           // survive.
           void CapacitorApp.minimizeApp().catch(() => {
-            // minimizeApp is Android-only; ignore where unavailable.
+            // error-policy:J4 minimizeApp is Android-only; elsewhere the back
+            // press simply no-ops at the root view.
           });
         }
       }),

--- a/packages/app/src/model-tester-entry.tsx
+++ b/packages/app/src/model-tester-entry.tsx
@@ -210,6 +210,7 @@ async function runTest(id: string): Promise<void> {
     });
     renderOutput(id, await response.json());
   } catch (error) {
+    // error-policy:J4 failure renders as the test's error output
     renderOutput(id, {
       ok: false,
       test: id,
@@ -240,6 +241,7 @@ el<HTMLInputElement>("audio-file").addEventListener("change", async (event) => {
     el("audio-name").textContent = file.name;
     el("asset-error").textContent = "";
   } catch (error) {
+    // error-policy:J4 failure renders in the asset-error line
     el("asset-error").textContent =
       error instanceof Error ? error.message : String(error);
   }

--- a/packages/app/src/renderer-build-stamp.ts
+++ b/packages/app/src/renderer-build-stamp.ts
@@ -68,7 +68,8 @@ export async function loadRendererBuildStamp(): Promise<RendererBuildStamp | nul
     );
     return stamp;
   } catch {
-    // No manifest (dev) or a transient fetch failure — never block boot.
+    // error-policy:J4 no manifest (dev) or a transient fetch failure — the
+    // stamp is diagnostics only and must never block boot.
     window.__ELIZA_RENDERER_BUILD__ = null;
     return null;
   }

--- a/packages/app/src/services/android-update-checker.ts
+++ b/packages/app/src/services/android-update-checker.ts
@@ -53,10 +53,12 @@ export const AndroidUpdateChecker = {
           return true;
         }
       } catch {
-        // Device plugin unavailable — fall back to userAgent
+        // error-policy:J4 Device plugin unavailable — fall back to userAgent
       }
       return navigator.userAgent.includes("Android");
     } catch {
+      // error-policy:J4 sideload probe failed — read as "not sideload" so
+      // the OTA prompt never fires on an unknown install channel
       return false;
     }
   },
@@ -106,6 +108,8 @@ export const AndroidUpdateChecker = {
         currentVersionCode = parseInt(appInfo.build, 10);
         currentVersion = appInfo.version;
       } catch {
+        // error-policy:J4 best-effort OTA — null is the explicit "no check
+        // result" callers handle; the failure is logged
         console.warn(
           "[AndroidUpdateChecker] Could not read app info via @capacitor/app",
         );
@@ -119,6 +123,8 @@ export const AndroidUpdateChecker = {
         currentVersionCode,
       };
     } catch (err) {
+      // error-policy:J4 best-effort OTA — null is the explicit "no check
+      // result"; the failure is logged
       console.warn("[AndroidUpdateChecker] check() error:", err);
       return null;
     }

--- a/packages/app/src/shims/cookie.ts
+++ b/packages/app/src/shims/cookie.ts
@@ -40,8 +40,10 @@ function defaultDecode(value: string): string {
   try {
     return decodeURIComponent(value);
   } catch {
-    return value;
+    // error-policy:J3 malformed escape — keep the raw value, matching the
+    // cookie package's tolerant decode
   }
+  return value;
 }
 
 function defaultEncode(value: string): string {

--- a/packages/app/src/shims/cookie.ts
+++ b/packages/app/src/shims/cookie.ts
@@ -42,8 +42,8 @@ function defaultDecode(value: string): string {
   } catch {
     // error-policy:J3 malformed escape — keep the raw value, matching the
     // cookie package's tolerant decode
+    return value;
   }
-  return value;
 }
 
 function defaultEncode(value: string): string {

--- a/packages/app/src/shims/debug.ts
+++ b/packages/app/src/shims/debug.ts
@@ -35,7 +35,8 @@ export function enable(namespaces: string): void {
   try {
     globalThis.localStorage?.setItem("debug", namespaces);
   } catch {
-    // localStorage can be unavailable in sandboxed browser contexts.
+    // error-policy:J6 best-effort persistence — localStorage can be
+    // unavailable in sandboxed browser contexts
   }
 }
 
@@ -45,7 +46,8 @@ export function disable(): string {
   try {
     globalThis.localStorage?.removeItem("debug");
   } catch {
-    // localStorage can be unavailable in sandboxed browser contexts.
+    // error-policy:J6 best-effort cleanup — localStorage can be unavailable
+    // in sandboxed browser contexts
   }
   return namespaces;
 }
@@ -86,6 +88,7 @@ function createDebug(namespace: string): DebugLogger {
 try {
   refresh(globalThis.localStorage?.getItem("debug") ?? "");
 } catch {
+  // error-policy:J3 unavailable storage — no namespaces enabled
   refresh("");
 }
 

--- a/packages/app/src/shims/set-cookie-parser.ts
+++ b/packages/app/src/shims/set-cookie-parser.ts
@@ -47,7 +47,8 @@ export function parseString(
     try {
       value = decodeURIComponent(value);
     } catch {
-      // Match set-cookie-parser's tolerant browser behavior.
+      // error-policy:J3 malformed escape — keep the raw value, matching
+      // set-cookie-parser's tolerant browser behavior
     }
   }
 

--- a/packages/app/src/sw-registration.ts
+++ b/packages/app/src/sw-registration.ts
@@ -18,6 +18,7 @@ function isCapacitorNative(): boolean {
       typeof cap?.isNativePlatform === "function" && cap.isNativePlatform()
     );
   } catch {
+    // error-policy:J4 capability probe — no Capacitor bridge means not native
     return false;
   }
 }

--- a/packages/app/src/sw-registration.ts
+++ b/packages/app/src/sw-registration.ts
@@ -51,6 +51,8 @@ export function registerViewServiceWorker(): void {
     .then((registration) => {
       console.info("[SW] Registered, scope:", registration.scope);
     })
+    // error-policy:J4 the service worker is a PWA enhancement — the app
+    // works without it; the failure is logged for triage
     .catch((err: unknown) => {
       console.error(
         "[SW] Registration failed:",

--- a/packages/ui/src/app-navigate-view.ts
+++ b/packages/ui/src/app-navigate-view.ts
@@ -2,6 +2,7 @@
  * Fires the shared navigate-view event to open a registered view, the imperative
  * entry the agent's view actions and the shell use to switch views.
  */
+import { logger } from "@elizaos/logger";
 import {
   dispatchNavigateViewEvent,
   type NavigateViewDetail,
@@ -136,8 +137,11 @@ export function navigateBrowserPath(path: string): void {
     }
     window.history.pushState(null, "", path);
     window.dispatchEvent(new PopStateEvent("popstate"));
-  } catch {
-    return;
+  } catch (err) {
+    // error-policy:J4 sandboxed webviews can reject history navigation with a
+    // SecurityError; navigation degrades to a no-op there. Logged so silent
+    // dead navigation is diagnosable.
+    logger.warn({ err, path }, "[app-navigate-view] browser navigation failed");
   }
 }
 
@@ -260,7 +264,15 @@ export function createNavigateViewHandler({
             navigatePath(viewPath);
           }
         })
-        .catch(() => {
+        .catch((err: unknown) => {
+          // error-policy:J4 designed degrade: when the desktop bridge cannot
+          // open a separate window, the view opens as an in-shell tab instead —
+          // the user still lands on the view. Logged so a broken bridge is
+          // observable.
+          logger.warn(
+            { err, viewPath },
+            "[app-navigate-view] desktop openAppWindow failed; opening in-shell",
+          );
           activateTabForPath(viewPath);
           navigatePath(viewPath);
         });

--- a/packages/ui/src/chat/useSlashCommandController.ts
+++ b/packages/ui/src/chat/useSlashCommandController.ts
@@ -5,6 +5,7 @@
  * new-conversation, fullscreen) to run a command.
  */
 
+import { logger } from "@elizaos/logger";
 import type { CustomActionDef } from "@elizaos/shared";
 import * as React from "react";
 import { client } from "../api";
@@ -53,9 +54,16 @@ export function reportUserViewSwitch(viewId: string, viewPath?: string): void {
         source: "user",
         ...(viewPath ? { path: viewPath } : {}),
       }),
-    }).catch(() => {});
+    }).catch((err) => {
+      // error-policy:J7 telemetry write must not break navigation; warn keeps
+      // a dead reporting endpoint observable in the console.
+      logger.warn(
+        `[useSlashCommandController] view-switch report failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
   } catch {
-    // Best-effort observability only.
+    // error-policy:J7 same guard for synchronous setup failures — telemetry
+    // must never break navigation.
   }
 }
 
@@ -84,9 +92,16 @@ export function reportShortcutFired(
         shortcutId,
         ...(context ? { context } : {}),
       }),
-    }).catch(() => {});
+    }).catch((err) => {
+      // error-policy:J7 telemetry write must not break the shortcut; warn keeps
+      // a dead reporting endpoint observable in the console.
+      logger.warn(
+        `[useSlashCommandController] shortcut report failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
   } catch {
-    // Best-effort observability only.
+    // error-policy:J7 same guard for synchronous setup failures — telemetry
+    // must never break the shortcut.
   }
 }
 

--- a/packages/ui/src/chat/useSlashCommandController.ts
+++ b/packages/ui/src/chat/useSlashCommandController.ts
@@ -234,6 +234,7 @@ export function useSlashCommandController(
       // made #11112 needlessly hard to diagnose.
       const catalog: SlashCommandCatalogItem[] = await client
         .listCommands("gui")
+        // error-policy:J4 degrade to an empty catalog with the failure logged
         .catch((error: unknown) => {
           console.error(
             "[useSlashCommandController] Failed to load the slash-command catalog; slash menu will be empty",
@@ -243,6 +244,7 @@ export function useSlashCommandController(
         });
       const customActions: CustomActionDef[] = await client
         .listCustomActions()
+        // error-policy:J4 omit custom actions with the failure logged
         .catch((error: unknown) => {
           console.error(
             "[useSlashCommandController] Failed to load custom actions; omitting them from the slash menu",

--- a/packages/ui/src/components/chat/AppsSection.tsx
+++ b/packages/ui/src/components/chat/AppsSection.tsx
@@ -134,6 +134,7 @@ export function AppsSection({ headerAction }: AppsSectionProps = {}) {
           3000,
         );
       } catch (err) {
+        // error-policy:J4 failure surfaces as an action notice
         setActionNotice(
           err instanceof Error
             ? err.message
@@ -162,6 +163,7 @@ export function AppsSection({ headerAction }: AppsSectionProps = {}) {
           3500,
         );
       } catch (err) {
+        // error-policy:J4 failure surfaces as an action notice
         setActionNotice(
           err instanceof Error
             ? err.message
@@ -184,6 +186,7 @@ export function AppsSection({ headerAction }: AppsSectionProps = {}) {
           3000,
         );
       } catch (err) {
+        // error-policy:J4 failure surfaces as an action notice
         setActionNotice(
           err instanceof Error
             ? err.message
@@ -232,6 +235,7 @@ export function AppsSection({ headerAction }: AppsSectionProps = {}) {
               2600,
             );
           } catch {
+            // error-policy:J4 popup blocked — surfaced as an action notice
             setActionNotice(
               t("appsview.PopupBlockedOpen", {
                 name: app.displayName ?? app.name,
@@ -255,6 +259,7 @@ export function AppsSection({ headerAction }: AppsSectionProps = {}) {
           4000,
         );
       } catch (err) {
+        // error-policy:J4 failure surfaces as an action notice
         setActionNotice(
           t("appsview.LaunchFailed", {
             name: app.displayName ?? app.name,

--- a/packages/ui/src/components/chat/AppsSection.tsx
+++ b/packages/ui/src/components/chat/AppsSection.tsx
@@ -5,6 +5,7 @@
  * that are not currently running. Clicking an app launches / focuses it.
  */
 
+import { logger } from "@elizaos/logger";
 import { LayoutGrid, MoreHorizontal } from "lucide-react";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -74,7 +75,12 @@ export function AppsSection({ headerAction }: AppsSectionProps = {}) {
           setCatalogApps(apps);
         }
       })
-      .catch(() => undefined);
+      .catch((err: unknown) => {
+        // error-policy:J4 a failed catalog load hides the sidebar app
+        // launchers only (chat itself is unaffected) — logged so a broken
+        // catalog endpoint is distinguishable from "no apps installed".
+        logger.warn({ err }, "[AppsSection] app catalog load failed");
+      });
     return () => {
       cancelled = true;
     };

--- a/packages/ui/src/components/chat/InlineWidgetText.tsx
+++ b/packages/ui/src/components/chat/InlineWidgetText.tsx
@@ -53,6 +53,7 @@ export function InlineWidgetText({ content }: { content: string }): ReactNode {
     try {
       return parseSegments(content, false);
     } catch {
+      // error-policy:J3 malformed markup — render the raw text as-is
       return [{ kind: "text", text: content }];
     }
   }, [content]);

--- a/packages/ui/src/components/chat/MessageAttachments.tsx
+++ b/packages/ui/src/components/chat/MessageAttachments.tsx
@@ -186,7 +186,8 @@ function attachmentPath(url: string): string {
   try {
     return new URL(u, "http://x").pathname;
   } catch {
-    // Strip query/hash manually for malformed-but-extension-bearing strings.
+    // error-policy:J3 malformed URL — strip query/hash manually for
+    // malformed-but-extension-bearing strings
     return u.split(/[?#]/)[0] ?? u;
   }
 }
@@ -272,7 +273,7 @@ function attachmentLabel(att: MessageAttachment): string {
     const base = u.split("/").filter(Boolean).at(-1);
     if (base) return decodeURIComponent(base);
   } catch {
-    // fall through
+    // error-policy:J3 malformed URL/escape — generic label below
   }
   return "attachment";
 }
@@ -671,6 +672,7 @@ function Model3dTile({
         setStatus("ready");
         animate();
       } catch {
+        // error-policy:J4 failed model load renders the error/fallback body
         if (!disposed) setStatus("error");
       }
     })();
@@ -682,7 +684,7 @@ function Model3dTile({
         renderer?.domElement?.remove();
         renderer?.dispose?.();
       } catch {
-        // best-effort teardown
+        // error-policy:J6 best-effort teardown
       }
     };
   }, [inlineable, src]);

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -193,6 +193,7 @@ export function InlinePluginConfig({
       const found = plugins.find((p) => p.id === pluginId);
       setPlugin(found ?? null);
     } catch {
+      // error-policy:J4 load failure renders the card's error state
       if (mountedRef.current) {
         setError(
           t("messagecontent.LoadPluginInfoFailed", {
@@ -233,6 +234,7 @@ export function InlinePluginConfig({
       if (mountedRef.current) setSaved(true);
       await fetchPlugin();
     } catch (e: unknown) {
+      // error-policy:J4 save failure renders the card's error state
       if (mountedRef.current) {
         setError(
           e instanceof Error
@@ -293,6 +295,7 @@ export function InlinePluginConfig({
         // Wait for agent restart then refresh (with cleanup on unmount)
         refreshTimerRef.current = setTimeout(() => void fetchPlugin(), 3000);
       } catch (e: unknown) {
+        // error-policy:J4 toggle failure renders the card's error state
         if (mountedRef.current) {
           setError(
             e instanceof Error
@@ -504,6 +507,7 @@ export function MessageUiSpecBlock({
               `[Plugin ${pluginId} configuration saved successfully]`,
             ),
           )
+          // error-policy:J4 the failure is surfaced as a chat action message
           .catch((err: unknown) =>
             sendActionMessage(
               `[Failed to save plugin config: ${err instanceof Error ? err.message : "unknown error"}]`,
@@ -519,7 +523,12 @@ export function MessageUiSpecBlock({
               `[Plugin ${params.pluginId} enabled. Restart required.]`,
             ),
           )
-          .catch(() => sendActionMessage(`[Failed to enable plugin]`));
+          // error-policy:J4 the failure is surfaced as a chat action message
+          .catch((err: unknown) =>
+            sendActionMessage(
+              `[Failed to enable plugin: ${err instanceof Error ? err.message : "unknown error"}]`,
+            ),
+          );
         return;
       }
       if (action === "plugin:test" && params?.pluginId) {
@@ -654,7 +663,8 @@ export function SensitiveRequestBlock({
           try {
             normalized = normalizeRemoteAgentUrl(values.url ?? "");
           } catch (caught) {
-            // A typo'd URL must not flip the block to "failed" (which unmounts
+            // error-policy:J4 a typo'd URL must not flip the block to "failed"
+            // (which unmounts
             // the form) — surface the message and keep the form editable.
             setError(
               caught instanceof Error
@@ -702,6 +712,7 @@ export function SensitiveRequestBlock({
         setValues({});
         setStatus("saved");
       } catch (caught) {
+        // error-policy:J4 submit failure renders the form's error state
         setError(
           caught instanceof Error
             ? caught.message
@@ -878,12 +889,14 @@ export function SensitiveRequestBlock({
               try {
                 popup.opener = null;
               } catch {
-                // Some browsers throw when reassigning opener cross-origin;
-                // `noreferrer` already mitigates this. Swallow.
+                // error-policy:J6 best-effort hardening — some browsers throw
+                // when reassigning opener cross-origin; `noreferrer` already
+                // mitigates this.
               }
               setAuthorizing(true);
               setError(null);
             } catch (caught) {
+              // error-policy:J4 failure renders the block's error state
               setError(
                 caught instanceof Error
                   ? caught.message
@@ -1013,7 +1026,8 @@ export function MessageContent({
     try {
       return parseSegments(message.text, analysisMode);
     } catch {
-      // If parsing fails, just show plain text
+      // error-policy:J3 malformed message markup — render the raw text as-is
+      // rather than dropping the message
       return [{ kind: "text" as const, text: message.text }];
     }
   }, [message.text, analysisMode]);
@@ -1043,6 +1057,7 @@ export function MessageContent({
       await client.startLocalInferenceDownload(modelId);
       setLocalDownloadState("queued");
     } catch (error) {
+      // error-policy:J4 failure renders the download card's error state
       setLocalDownloadError(
         error instanceof Error ? error.message : "Failed to start download",
       );

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -88,6 +88,7 @@ function isHttpsAuthorizationUrl(url: unknown): url is string {
   try {
     return new URL(url).protocol === "https:";
   } catch {
+    // error-policy:J3 untrusted URL from message content — fail closed
     return false;
   }
 }

--- a/packages/ui/src/components/chat/TasksEventsPanel.tsx
+++ b/packages/ui/src/components/chat/TasksEventsPanel.tsx
@@ -84,7 +84,7 @@ export function TasksEventsPanel({
         return Math.min(Math.max(parsed, WIDGETS_MIN_WIDTH), WIDGETS_MAX_WIDTH);
       }
     } catch {
-      /* ignore */
+      // error-policy:J3 corrupt/blocked localStorage — default width
     }
     return WIDGETS_DEFAULT_WIDTH;
   });
@@ -93,7 +93,8 @@ export function TasksEventsPanel({
     try {
       window.localStorage.setItem(WIDGETS_WIDTH_KEY, String(next));
     } catch {
-      /* ignore */
+      // error-policy:J6 best-effort persistence — width still applies for
+      // this session; private-mode storage may reject writes
     }
   }, []);
   const collapseThreshold = Math.max(WIDGETS_MIN_WIDTH - 40, 80);
@@ -107,7 +108,8 @@ export function TasksEventsPanel({
       try {
         target.setPointerCapture(event.pointerId);
       } catch {
-        /* ignore */
+        // error-policy:J6 pointer capture is an enhancement — the drag still
+        // works via the window listeners below
       }
       const onMove = (ev: PointerEvent) => {
         const delta = ev.clientX - startX;
@@ -129,7 +131,7 @@ export function TasksEventsPanel({
         try {
           target.releasePointerCapture(event.pointerId);
         } catch {
-          /* ignore */
+          // error-policy:J6 teardown — capture may already be released
         }
         window.removeEventListener("pointermove", onMove);
         window.removeEventListener("pointerup", onUp);

--- a/packages/ui/src/components/chat/TranscriptViewerOverlay.test.tsx
+++ b/packages/ui/src/components/chat/TranscriptViewerOverlay.test.tsx
@@ -330,4 +330,32 @@ describe("TranscriptViewerOverlay", () => {
     expect(navigateBrowserPath).toHaveBeenCalledWith("/apps/transcripts");
     expect(onClose).toHaveBeenCalled();
   });
+
+  it("renders a load error — never '(empty transcript)' — when the inline read fails with no stored record", async () => {
+    // Served-URL attachment with no inline text and no transcriptId: the
+    // fetch rejecting must surface as the designed error state (three-state
+    // rule), not as a healthy-empty transcript.
+    const failingFetch = vi.fn().mockRejectedValue(new Error("offline"));
+    vi.stubGlobal("fetch", failingFetch);
+    try {
+      render(
+        <TranscriptViewerOverlay
+          attachment={{
+            id: "att-2",
+            url: "/api/media/deadbeef.md",
+            contentType: "document",
+            mimeType: "text/markdown",
+            title: "Broken transcript.md",
+          }}
+          onClose={() => {}}
+        />,
+      );
+      await waitFor(() => screen.getByTestId("transcript-load-error"));
+      expect(failingFetch).toHaveBeenCalled();
+      expect(screen.queryByTestId("transcript-text")).toBeNull();
+      expect(getTranscript).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });

--- a/packages/ui/src/components/chat/TranscriptViewerOverlay.tsx
+++ b/packages/ui/src/components/chat/TranscriptViewerOverlay.tsx
@@ -87,6 +87,7 @@ export interface TranscriptViewerOverlayProps {
 
 type LoadState =
   | { status: "loading" }
+  | { status: "error"; message: string }
   | {
       status: "ready";
       title: string;
@@ -117,7 +118,7 @@ function copyButtonLabel(status: CopyStatus): string {
  */
 async function readInlineText(
   att: MessageAttachment,
-): Promise<{ transcriptId?: string; text: string }> {
+): Promise<{ transcriptId?: string; text: string; loadFailed?: boolean }> {
   if (att.text?.trim()) return splitTranscriptMarker(att.text);
   const src = resolveUrl(att.url);
   if (src.startsWith("data:")) {
@@ -130,16 +131,19 @@ async function readInlineText(
         : decodeURIComponent(payload);
       return splitTranscriptMarker(raw);
     } catch {
-      return { text: "" };
+      // error-policy:J3 corrupt inline payload — flag the failure so the
+      // viewer can render an error instead of a healthy-empty transcript
+      return { text: "", loadFailed: true };
     }
   }
   try {
     const res = await fetch(src);
     if (res.ok) return splitTranscriptMarker(await res.text());
   } catch {
-    // fall through to empty
+    // error-policy:J4 transport failure — flagged below; the viewer renders
+    // an error state when no stored record covers for it
   }
-  return { text: "" };
+  return { text: "", loadFailed: true };
 }
 
 /**
@@ -241,10 +245,20 @@ export function TranscriptViewerOverlay({
           setValue(text);
           return;
         } catch {
-          // record gone/unreachable — fall back to the inline text.
+          // error-policy:J4 record gone/unreachable — fall back to the inline
+          // text below (or the error render when that failed too).
         }
       }
       if (!live) return;
+      if (inline.loadFailed && !inline.text) {
+        // Never render "(empty transcript)" for a transcript we failed to
+        // read — loading, empty, and error must stay distinguishable.
+        setLoad({
+          status: "error",
+          message: "Couldn't load this transcript. Close and try again.",
+        });
+        return;
+      }
       setLoad({
         status: "ready",
         title: attachment.title?.trim() || "Transcript",
@@ -300,7 +314,8 @@ export function TranscriptViewerOverlay({
         await nav.share({ title, text: value });
         return;
       } catch (err) {
-        // User-cancelled share is not an error; anything else falls to copy.
+        // error-policy:J4 user-cancelled share is not an error; anything else
+        // falls through to the copy path below.
         if (err instanceof DOMException && err.name === "AbortError") return;
       }
     }
@@ -360,6 +375,8 @@ export function TranscriptViewerOverlay({
         }
       }
     } catch (err) {
+      // error-policy:J4 cancelled share ends the flow; failures fall through
+      // to the URL-share / download fallbacks below.
       if (err instanceof DOMException && err.name === "AbortError") return;
     }
     // Fall back to sharing the URL, then to downloading it.
@@ -369,6 +386,8 @@ export function TranscriptViewerOverlay({
         return;
       }
     } catch (err) {
+      // error-policy:J4 cancelled share ends the flow; failures fall through
+      // to the plain download.
       if (err instanceof DOMException && err.name === "AbortError") return;
     }
     handleDownloadAudio();
@@ -392,6 +411,8 @@ export function TranscriptViewerOverlay({
       try {
         await client.deleteTranscript(resolvedId);
       } catch (err) {
+        // error-policy:J4 failed delete renders the error line and keeps the
+        // overlay open — the transcript never silently looks deleted
         setSaveError(err instanceof Error ? err.message : "Couldn't delete");
         return;
       }
@@ -418,6 +439,7 @@ export function TranscriptViewerOverlay({
       await client.updateTranscript(resolvedId, { segments });
       onClose();
     } catch (err) {
+      // error-policy:J4 failed save renders the error line; the edit stays
       setSaveError(err instanceof Error ? err.message : "Couldn't save");
       setSaving(false);
     }
@@ -512,6 +534,13 @@ export function TranscriptViewerOverlay({
             <div className="flex items-center gap-2 py-8 text-sm text-muted">
               <Spinner size={16} /> Loading transcript…
             </div>
+          ) : load.status === "error" ? (
+            <p
+              className="py-8 text-sm text-[color:var(--danger,#f87171)]"
+              data-testid="transcript-load-error"
+            >
+              {load.message}
+            </p>
           ) : editing ? (
             <Textarea
               value={value}

--- a/packages/ui/src/components/chat/TranscriptViewerOverlay.tsx
+++ b/packages/ui/src/components/chat/TranscriptViewerOverlay.tsx
@@ -282,8 +282,9 @@ export function TranscriptViewerOverlay({
       window.setTimeout(() => setCopyStatus("idle"), 1500);
       return true;
     } catch {
-      // Clipboard blocked/missing (e.g. insecure context) — surface the failure
-      // (share/download remain as alternatives) instead of a phantom success.
+      // error-policy:J4 clipboard blocked/missing (e.g. insecure context) —
+      // surface the failure (share/download remain as alternatives) instead of
+      // a phantom success.
       setCopyStatus("failed");
       window.setTimeout(() => setCopyStatus("idle"), 2500);
       return false;

--- a/packages/ui/src/components/chat/message-form-parser.ts
+++ b/packages/ui/src/components/chat/message-form-parser.ts
@@ -115,6 +115,8 @@ export function parseFormBody(body: string): FormRequestSpec | null {
   try {
     parsed = JSON.parse(body);
   } catch {
+    // error-policy:J3 untrusted model output — null is the explicit
+    // "malformed form" signal (the block renders as plain text)
     return null;
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {

--- a/packages/ui/src/components/chat/message-parser-helpers.ts
+++ b/packages/ui/src/components/chat/message-parser-helpers.ts
@@ -125,6 +125,8 @@ export function tryParse(s: string): unknown {
   try {
     return JSON.parse(s);
   } catch {
+    // error-policy:J3 "is this JSON?" probe over untrusted message text —
+    // null is the explicit "not a spec" signal
     return null;
   }
 }
@@ -160,6 +162,7 @@ export function tryParsePatch(line: string): PatchOp | null {
       return obj as PatchOp;
     return null;
   } catch {
+    // error-policy:J3 untrusted stream line — null means "not a patch op"
     return null;
   }
 }

--- a/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
+++ b/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
@@ -62,6 +62,8 @@ export function MessageSearchPanel({
         setResults(found);
         setStatus("ready");
       } catch (err) {
+        // error-policy:J4 aborted searches are expected; real failures render
+        // the panel's error state
         if (
           controller.signal.aborted ||
           (err as Error)?.name === "AbortError"

--- a/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
+++ b/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
@@ -187,6 +187,8 @@ function formatTimestamp(createdAt: number): string {
       day: "numeric",
     });
   } catch {
+    // error-policy:J3 invalid stored timestamp — a date label is decoration;
+    // omit it rather than render "Invalid Date"
     return "";
   }
 }

--- a/packages/ui/src/components/chat/widgets/agent-activity.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-activity.tsx
@@ -103,8 +103,8 @@ export function AgentActivityWidget({
           : items.length;
       setState({ items, total, loading: false });
     } catch {
-      // Network/agent failure — settle to empty so the card resolves rather than
-      // spinning forever; never surface a broken card.
+      // error-policy:J4 glance tile — settle to empty so the card resolves
+      // rather than spinning forever; never surface a broken card.
       if (signal.cancelled) return;
       setState({ items: [], total: 0, loading: false });
     }

--- a/packages/ui/src/components/chat/widgets/agent-orchestrator.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator.tsx
@@ -487,6 +487,7 @@ function AppRunsWidget({
           if (changed) setState("appRuns", nextRunsSafe);
         });
       } catch (refreshError) {
+        // error-policy:J4 load failure renders the widget's error state
         if (cancelled) return;
         setError(
           getClientErrorMessage(
@@ -829,7 +830,8 @@ function OrchestratorRoomWidget(_props: ChatSidebarWidgetProps) {
       const next = await client.getOrchestratorRooms();
       setRooms(next);
     } catch {
-      // Leave the last good roster in place on a transient poll failure.
+      // error-policy:J4 poll — leave the last good roster in place on a
+      // transient failure; the next tick refreshes.
     } finally {
       setLoading(false);
     }

--- a/packages/ui/src/components/chat/widgets/agent-orchestrator.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator.tsx
@@ -16,6 +16,7 @@
  * plugin just provides the backend capabilities it consumes.
  */
 
+import { logger } from "@elizaos/logger";
 import {
   Activity,
   AlertTriangle,
@@ -437,7 +438,13 @@ function AppRunsWidget({
           setCatalogApps(apps);
         }
       })
-      .catch(() => undefined);
+      .catch((err: unknown) => {
+        // error-policy:J4 the catalog only enriches run rows with app
+        // names/icons; runs render from their own load (which surfaces errors
+        // via the widget's error state). Logged so a broken catalog is
+        // observable.
+        logger.warn({ err }, "[agent-orchestrator] app catalog load failed");
+      });
 
     return () => {
       cancelled = true;

--- a/packages/ui/src/components/chat/widgets/browser-launch-widget.tsx
+++ b/packages/ui/src/components/chat/widgets/browser-launch-widget.tsx
@@ -43,6 +43,7 @@ function hostnameOf(url: string): string {
   try {
     return new URL(url).hostname.replace(/^www\./, "") || url;
   } catch {
+    // error-policy:J3 unparseable URL — label with the raw string
     return url;
   }
 }

--- a/packages/ui/src/components/chat/widgets/browser-status.tsx
+++ b/packages/ui/src/components/chat/widgets/browser-status.tsx
@@ -34,6 +34,7 @@ function tabLabel(tab: BrowserWorkspaceTab): string {
   try {
     return new URL(url).hostname.replace(/^www\./, "") || url;
   } catch {
+    // error-policy:J3 unparseable tab URL — label with the raw string
     return url;
   }
 }
@@ -74,7 +75,8 @@ export function BrowserStatusSidebarWidget(_props: ChatSidebarWidgetProps) {
       const next = await client.getBrowserWorkspace();
       setSnapshot(next);
     } catch {
-      // Transient errors — keep the last snapshot.
+      // error-policy:J4 4s poll — keep the last good snapshot on a transient
+      // failure; the next tick refreshes.
     }
   }, [authenticated]);
 
@@ -102,7 +104,9 @@ export function BrowserStatusSidebarWidget(_props: ChatSidebarWidgetProps) {
       try {
         await client.showBrowserWorkspaceTab?.(tab.id);
       } catch {
-        // Ignore — navigation still happens.
+        // error-policy:J4 focusing the tab is a best-effort enhancement (web
+        // mode has no backend for it); the /browser navigation below is the
+        // outcome the user sees either way.
       }
     })();
     setTab("browser");

--- a/packages/ui/src/components/chat/widgets/calendar-upcoming.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-upcoming.tsx
@@ -202,7 +202,8 @@ export function CalendarUpcomingWidget({
       // Skip the state update (and the re-render) when the poll is unchanged.
       setEvents((prev) => (eventsEqual(prev, next) ? prev : next));
     } catch {
-      // Timeout / network — settle via the finally so the tile shows
+      // error-policy:J4 timeout / network — settle via the finally so the
+      // glance tile shows
       // "No events today" instead of spinning on "Loading…".
     } finally {
       setFeedLoaded(true);

--- a/packages/ui/src/components/chat/widgets/calendar-upcoming.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-upcoming.tsx
@@ -169,9 +169,10 @@ export function CalendarUpcomingWidget({
       setConnection(linked ? "connected" : "disconnected");
       return linked;
     } catch {
-      // A probe failure must SETTLE the widget (show the connect affordance),
-      // never leave it on "unknown" → a permanent "Loading…" tile (the reported
-      // stuck-loading bug: listConnectorAccounts failing/timing out on device).
+      // error-policy:J4 a probe failure must SETTLE the widget (show the
+      // connect affordance), never leave it on "unknown" → a permanent
+      // "Loading…" tile (the reported stuck-loading bug:
+      // listConnectorAccounts failing/timing out on device).
       setConnection("disconnected");
       return false;
     }

--- a/packages/ui/src/components/chat/widgets/finances-alerts.tsx
+++ b/packages/ui/src/components/chat/widgets/finances-alerts.tsx
@@ -133,6 +133,8 @@ function formatMinor(amountMinor: number, currency: string): string {
       currency,
     }).format(value);
   } catch {
+    // error-policy:J3 Intl throws on an unknown currency code from the feed —
+    // render the amount with a plain suffix instead
     return `${value.toFixed(2)} ${currency}`;
   }
 }
@@ -225,7 +227,8 @@ function FinancesAlertsWidget({
       // Skip the state update (and the re-render) when the poll is unchanged.
       setData((prev) => (financesEqual(prev, next) ? prev : next));
     } catch {
-      // Transient/poll failure: keep the last good snapshot (todo.tsx pattern).
+      // error-policy:J4 glance-tile poll — keep the last good snapshot on a
+      // transient failure (todo.tsx pattern); the next tick refreshes.
     }
   }, [authenticated]);
 

--- a/packages/ui/src/components/chat/widgets/goals-attention.tsx
+++ b/packages/ui/src/components/chat/widgets/goals-attention.tsx
@@ -181,7 +181,8 @@ export function GoalsAttentionWidget({
       // Skip the state update (and the re-render) when the poll is unchanged.
       setGoals((prev) => (goalsEqual(prev, next) ? prev : next));
     } catch {
-      // Silent fallback to the last good render (matches todo.tsx); never log.
+      // error-policy:J4 glance tile — keep the last good render on a poll
+      // failure (todo.tsx pattern); the next tick refreshes.
     }
   }, [authenticated]);
 

--- a/packages/ui/src/components/chat/widgets/health-sleep.tsx
+++ b/packages/ui/src/components/chat/widgets/health-sleep.tsx
@@ -203,7 +203,8 @@ export function HealthSleepWidget({
       // Skip the state update (and the re-render) when the poll is unchanged.
       setData((prev) => (sleepEqual(prev, next) ? prev : next));
     } catch {
-      // Silent fallback to the last good render (matches todo.tsx); never log.
+      // error-policy:J4 glance tile — keep the last good render on a poll
+      // failure (todo.tsx pattern); the next tick refreshes.
     }
   }, [authenticated]);
 

--- a/packages/ui/src/components/chat/widgets/inbox-unread.tsx
+++ b/packages/ui/src/components/chat/widgets/inbox-unread.tsx
@@ -112,7 +112,8 @@ export function InboxUnreadWidget({
       // Skip the state update (and the re-render) when the poll is unchanged.
       setUnread((prev) => (unreadEqual(prev, next) ? prev : next));
     } catch {
-      // Best-effort: keep the last good data on a transient fetch failure.
+      // error-policy:J4 glance tile — keep the last good data on a transient
+      // fetch failure; the next tick refreshes.
     } finally {
       setLoaded(true);
     }

--- a/packages/ui/src/components/chat/widgets/model-download.tsx
+++ b/packages/ui/src/components/chat/widgets/model-download.tsx
@@ -138,7 +138,8 @@ export function useLocalModelDownloads(): LocalModelDownloads {
           loading: false,
         });
       } catch {
-        // Settle (keep last-good status, drop the loading flag) so the tile
+        // error-policy:J4 settle (keep last-good status, drop the loading
+        // flag) so the tile
         // resolves to not-required/null instead of spinning. A hung native
         // bridge or a transient error must never leave a permanent "Loading…".
         if (cancelled) return;
@@ -233,7 +234,8 @@ export function ModelDownloadWidget({
     try {
       await client.startLocalInferenceDownload(failedModelId);
     } catch {
-      // Re-enqueue failed (e.g. all tiers pending on the hub) — drop the
+      // error-policy:J4 re-enqueue failed (e.g. all tiers pending on the hub)
+      // — drop the
       // optimistic flip so the error state (with its retry affordance) returns.
       setRetrying(false);
     }

--- a/packages/ui/src/components/chat/widgets/music-player.tsx
+++ b/packages/ui/src/components/chat/widgets/music-player.tsx
@@ -82,6 +82,7 @@ export function MusicPlayerSidebarWidget(_props: ChatSidebarWidgetProps) {
       setPlayer({ kind: "idle" });
       setAudioPaused(true);
     } catch {
+      // error-policy:J4 designed error state — the tile renders the failure
       setPlayer({
         kind: "error",
         message: "Could not reach the music player.",
@@ -120,9 +121,9 @@ export function MusicPlayerSidebarWidget(_props: ChatSidebarWidgetProps) {
       setAudioPaused(true);
       return;
     }
-    el.play().catch(() => {
-      /* Browser autoplay policy may require the user to press play. */
-    });
+    // error-policy:J4 browser autoplay policy can reject play(); the audio
+    // element stays paused and the user presses play manually.
+    el.play().catch(() => {});
   }, [player]);
 
   useEffect(() => {

--- a/packages/ui/src/components/chat/widgets/needs-attention.tsx
+++ b/packages/ui/src/components/chat/widgets/needs-attention.tsx
@@ -80,7 +80,8 @@ export function useApprovals(): {
       if (!mountedRef.current) return;
       setPending((prev) => (pendingEqual(prev, next) ? prev : next));
     } catch {
-      // Best-effort: keep the last good data on a transient fetch failure.
+      // error-policy:J4 glance tile — keep the last good data on a transient
+      // fetch failure; the next tick refreshes.
     } finally {
       if (mountedRef.current) {
         setLoaded(true);

--- a/packages/ui/src/components/chat/widgets/relationships-attention.tsx
+++ b/packages/ui/src/components/chat/widgets/relationships-attention.tsx
@@ -155,8 +155,8 @@ export function RelationshipsAttentionWidget({
       // Skip the state update (and the re-render) when the poll is unchanged.
       setData((prev) => (relationshipsEqual(prev, next) ? prev : next));
     } catch {
-      // Network/agent failure — keep the last good data (or empty); never
-      // surface a broken card. Matches todo.tsx's silent-fallback catch.
+      // error-policy:J4 glance tile — keep the last good data on a poll
+      // failure; never surface a broken card (todo.tsx pattern).
     }
   }, [authenticated]);
 

--- a/packages/ui/src/components/chat/widgets/task-widget.tsx
+++ b/packages/ui/src/components/chat/widgets/task-widget.tsx
@@ -147,7 +147,8 @@ export function TaskWidget({ threadId, fallbackTitle }: TaskWidgetProps) {
       }
       setDetail(next);
     } catch {
-      // Silent for transient failures, but count consecutive errors so a
+      // error-policy:J4 silent for transient poll failures, but count
+      // consecutive errors so a
       // 401/403 stale-token loop can't poll the endpoint forever. After
       // MAX_CONSECUTIVE_ERRORS we freeze on the last good state.
       if (cancelledRef.current) return;

--- a/packages/ui/src/components/chat/widgets/todo.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.tsx
@@ -201,6 +201,8 @@ function TodoSidebarWidget({
           setTodos(dedupeTodos(result.todos));
         }
       } catch {
+        // error-policy:J4 glance tile — fall back to the workbench snapshot
+        // already in view state rather than surfacing a broken card.
         if (mountedRef.current && (workbench?.todos?.length ?? 0) > 0) {
           setTodos(dedupeTodos(workbench?.todos ?? []));
         }

--- a/packages/ui/src/components/chat/widgets/wallet-balance.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.tsx
@@ -67,6 +67,8 @@ export function WalletBalanceWidget(
         // shows prices only, so a balances failure means "nothing to show".
         const [balances, overview] = await Promise.all([
           client.getWalletBalances() as Promise<WalletBalancesResponse>,
+          // error-policy:J4 prices are the widget's optional decoration; the
+          // hide-on-failure degrade below covers a missing overview too
           client.getWalletMarketOverview().catch(() => null),
         ]);
         if (cancelled) return;

--- a/packages/ui/src/components/chat/widgets/wallet-balance.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.tsx
@@ -34,6 +34,7 @@ function formatPrice(priceUsd: number): string {
       maximumFractionDigits: digits,
     }).format(priceUsd);
   } catch {
+    // error-policy:J3 Intl rejected the locale/currency — plain formatting
     return `$${priceUsd.toFixed(digits)}`;
   }
 }

--- a/packages/ui/src/components/conversations/ConversationsSidebar.tsx
+++ b/packages/ui/src/components/conversations/ConversationsSidebar.tsx
@@ -225,7 +225,7 @@ export function ConversationsSidebar({
         );
       }
     } catch {
-      /* ignore */
+      // error-policy:J3 corrupt/blocked localStorage — default width
     }
     return CHAT_SIDEBAR_DEFAULT_WIDTH;
   });
@@ -234,7 +234,8 @@ export function ConversationsSidebar({
     try {
       window.localStorage.setItem(CHAT_SIDEBAR_WIDTH_KEY, String(next));
     } catch {
-      /* ignore */
+      // error-policy:J6 best-effort persistence — width still applies for
+      // this session; private-mode storage may reject writes
     }
   }, []);
   const toggleSectionCollapsed = useCallback((key: string) => {
@@ -269,7 +270,8 @@ export function ConversationsSidebar({
         })),
       );
     } catch {
-      // Keep the last successful snapshot on transient failures.
+      // error-policy:J4 poll — keep the last successful snapshot on transient
+      // failures; the next tick refreshes.
     }
   }, []);
 
@@ -403,6 +405,7 @@ export function ConversationsSidebar({
       setState("activeTerminalSessionId", sessionId);
       setTab("chat");
     } catch (err) {
+      // error-policy:J4 failure surfaces as an action notice
       setActionNotice(
         t("conversations.newTerminalFailed", {
           defaultValue: "Failed to start terminal: {{message}}",
@@ -632,6 +635,8 @@ export function ConversationsSidebar({
           }),
         );
       } catch (err) {
+        // error-policy:J4 failure surfaces as an action notice — the optimistic
+        // row state was not applied
         setActionNotice(
           t("conversations.muteFailed", {
             defaultValue: "Failed to update mute state: {{message}}",

--- a/packages/ui/src/components/conversations/ConversationsSidebar.tsx
+++ b/packages/ui/src/components/conversations/ConversationsSidebar.tsx
@@ -306,6 +306,8 @@ export function ConversationsSidebar({
           );
           return hasUserTurn ? null : conversation.id;
         } catch {
+          // error-policy:J4 hide-empty-draft probe — on failure the
+          // conversation stays visible (fail open), never wrongly hidden
           return null;
         }
       }),

--- a/packages/ui/src/components/pages/LauncherSurface.tsx
+++ b/packages/ui/src/components/pages/LauncherSurface.tsx
@@ -5,6 +5,7 @@
  * and the tutorial start. `Launcher` itself is pure presentation; this component
  * owns the runtime data so the rail/home shell can mount it directly.
  */
+import { logger } from "@elizaos/logger";
 import * as React from "react";
 import { dispatchChatOpen } from "../../events";
 import { useRoutableViews } from "../../hooks/useAvailableViews";
@@ -67,8 +68,12 @@ export const LauncherSurface = React.memo(
           // so the user arrives in a conversation, not on a collapsed pill.
           dispatchChatOpen();
         }
-      } catch {
-        // Sandboxed navigation is best-effort.
+      } catch (err) {
+        // error-policy:J4 sandboxed webviews (embeds) can reject history
+        // navigation with a SecurityError; the tile tap degrades to a no-op
+        // there. Logged so a launcher that silently stops navigating is
+        // diagnosable.
+        logger.warn({ err, path }, "[LauncherSurface] tile navigation failed");
       }
     }, []);
 

--- a/packages/ui/src/first-run/adopt-remote-first-run.ts
+++ b/packages/ui/src/first-run/adopt-remote-first-run.ts
@@ -38,6 +38,7 @@ export function normalizeRemoteAgentUrl(value: string): string {
   try {
     parsed = new URL(candidate);
   } catch {
+    // error-policy:J3 untrusted user input — explicit invalid signal
     throw new Error("Enter a valid remote agent URL.");
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
@@ -85,10 +86,10 @@ export async function adoptRemoteAgentFirstRun(
   try {
     alreadyComplete = (await client.getFirstRunStatus()).complete === true;
   } catch {
-    // A fresh host with no persisted first-run state, or one whose build
-    // predates the status route, is the expected "needs adoption" shape — fall
-    // through to the completion write below. A genuinely unreachable remote
-    // re-fails there, so the failure still surfaces; it is not hidden here.
+    // error-policy:J4 a fresh host with no persisted first-run state, or one
+    // whose build predates the status route, is the expected "needs adoption"
+    // shape — fall through to the completion write below. A genuinely
+    // unreachable remote re-fails there, so the failure still surfaces.
     alreadyComplete = false;
   }
 

--- a/packages/ui/src/first-run/auto-download-recommended.ts
+++ b/packages/ui/src/first-run/auto-download-recommended.ts
@@ -62,7 +62,8 @@ async function waitForLocalAgent(apiBase: string): Promise<boolean> {
       const res = await fetchWithCsrf(url, { method: "GET" });
       if (res.ok) return true;
     } catch {
-      // network not ready yet; fall through to sleep
+      // error-policy:J4 boot poll — network not ready yet; retry until the
+      // deadline, after which the caller skips auto-download for this boot
     }
     await new Promise<void>((r) => setTimeout(r, HEALTH_POLL_INTERVAL_MS));
   }
@@ -103,6 +104,8 @@ export async function autoDownloadRecommendedLocalModelInBackground(
   try {
     snapshot = await client.getLocalInferenceHub();
   } catch {
+    // error-policy:J4 leave the marker unset — a later boot retries the
+    // auto-download once the hub responds
     return;
   }
 
@@ -120,8 +123,8 @@ export async function autoDownloadRecommendedLocalModelInBackground(
     try {
       await client.setLocalInferenceActive(installedElizaDownload);
     } catch {
-      // Leave the marker unset so a later boot retries activation after the
-      // local runtime stabilizes.
+      // error-policy:J4 leave the marker unset so a later boot retries
+      // activation after the local runtime stabilizes
       return;
     }
     writeMarker();
@@ -138,7 +141,7 @@ export async function autoDownloadRecommendedLocalModelInBackground(
     await client.startLocalInferenceDownload(recommended.id);
     writeMarker();
   } catch {
-    // Leave the marker unset so a later boot retries once the runtime
-    // stabilizes — e.g. the user toggled Local while the network was off.
+    // error-policy:J4 leave the marker unset so a later boot retries once
+    // the runtime stabilizes — e.g. the user toggled Local while offline
   }
 }

--- a/packages/ui/src/first-run/auto-download-recommended.ts
+++ b/packages/ui/src/first-run/auto-download-recommended.ts
@@ -38,6 +38,8 @@ function readMarker(): boolean {
   try {
     return window.localStorage?.getItem(AUTO_DOWNLOAD_MARKER_KEY) === "1";
   } catch {
+    // error-policy:J3 storage blocked (embedded shell) — treat as "not yet
+    // downloaded"; the worst case is re-offering the download
     return false;
   }
 }
@@ -47,7 +49,8 @@ function writeMarker(): void {
   try {
     window.localStorage?.setItem(AUTO_DOWNLOAD_MARKER_KEY, "1");
   } catch {
-    // Embedded shells without storage simply lose dedupe across sessions.
+    // error-policy:J6 storage blocked — dedupe marker is best-effort; losing
+    // it only re-offers the download next session
   }
 }
 

--- a/packages/ui/src/first-run/deep-link-handler.ts
+++ b/packages/ui/src/first-run/deep-link-handler.ts
@@ -213,6 +213,8 @@ export async function installFirstRunDeepLinkListener(options: {
     )) as { App: CapacitorAppShape };
     capacitorApp = mod.App;
   } catch (error) {
+    // error-policy:J1 optional native module missing/broken — deliver the
+    // failure to the caller's onError and disable deep links
     onError?.(error);
     return () => {};
   }
@@ -226,6 +228,7 @@ export async function installFirstRunDeepLinkListener(options: {
   try {
     listenerHandle = await capacitorApp.addListener("appUrlOpen", handler);
   } catch (error) {
+    // error-policy:J1 listener registration failed — deliver to onError
     onError?.(error);
     return () => {};
   }
@@ -236,11 +239,14 @@ export async function installFirstRunDeepLinkListener(options: {
     const launch = await capacitorApp.getLaunchUrl();
     if (launch?.url) handler({ url: launch.url });
   } catch (error) {
+    // error-policy:J1 cold-launch URL read failed — deliver to onError;
+    // live appUrlOpen links still work
     onError?.(error);
   }
 
   return () => {
     if (!listenerHandle) return;
+    // error-policy:J6 teardown — removal failure is still reported
     void listenerHandle.remove().catch((error) => {
       onError?.(error);
     });

--- a/packages/ui/src/first-run/deep-link-handler.ts
+++ b/packages/ui/src/first-run/deep-link-handler.ts
@@ -88,6 +88,7 @@ export function parseFirstRunRemoteConnectDeepLink(
   try {
     parsed = new URL(url);
   } catch {
+    // error-policy:J3 untrusted deep-link URL — unparseable means "not ours"
     return null;
   }
 
@@ -129,6 +130,7 @@ export function routeFirstRunDeepLink(url: string, urlScheme: string): boolean {
   try {
     parsed = new URL(url);
   } catch {
+    // error-policy:J3 untrusted deep-link URL — unparseable means "not routed"
     return false;
   }
 

--- a/packages/ui/src/first-run/first-run-cloud-resume.ts
+++ b/packages/ui/src/first-run/first-run-cloud-resume.ts
@@ -78,7 +78,9 @@ export function clearCloudLoginPending(): void {
   try {
     window.localStorage.removeItem(CLOUD_RESUME_STORAGE_KEY);
   } catch {
-    // Non-fatal.
+    // error-policy:J6 best-effort cleanup — a storage that rejects removeItem
+    // also rejected the setItem in markCloudLoginPending, so there is no
+    // persisted marker to clear
   }
 }
 

--- a/packages/ui/src/first-run/first-run-cloud-resume.ts
+++ b/packages/ui/src/first-run/first-run-cloud-resume.ts
@@ -42,8 +42,8 @@ export function markCloudLoginPending(
       } satisfies CloudResumeMarker),
     );
   } catch {
-    // Storage unavailable → the flow still works in-session (in-memory refs);
-    // it just won't survive a WebView eviction. Non-fatal.
+    // error-policy:J6 storage unavailable → the flow still works in-session
+    // (in-memory refs); it just won't survive a WebView eviction.
   }
 }
 
@@ -67,6 +67,8 @@ export function readCloudLoginPending(): CloudResumeMarker | null {
       agentName: typeof parsed.agentName === "string" ? parsed.agentName : "",
     };
   } catch {
+    // error-policy:J3 corrupt persisted marker — treat as "no pending resume"
+    // so a bad blob can't wedge first-run
     return null;
   }
 }

--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -162,6 +162,7 @@ function isHttpLoopbackBase(value: string): boolean {
       url.hostname === "[::1]"
     );
   } catch {
+    // error-policy:J3 unparseable base — fail closed as "not loopback"
     return false;
   }
 }
@@ -174,6 +175,7 @@ function shouldUseAppShellLocalAgentProxy(apiBase: string): boolean {
   try {
     return new URL(apiBase).origin !== origin;
   } catch {
+    // error-policy:J3 unparseable base — fail closed as "no proxy"
     return false;
   }
 }
@@ -210,6 +212,8 @@ function canProbeCloudStatus(): boolean {
 
 async function getCloudStatusIfSupported() {
   if (!canProbeCloudStatus()) return null;
+  // error-policy:J4 cloud-status probe — unreachable/unsupported means the
+  // finish flow skips the cloud handoff, which is the designed degrade
   return client.getCloudStatus().catch(() => null);
 }
 

--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -229,6 +229,8 @@ function readSyncOnDeviceAgentBearer(): string | null {
     const trimmed = token.trim();
     return trimmed.length > 0 ? trimmed : null;
   } catch {
+    // error-policy:J4 native-bridge probe — no token means the request path
+    // proceeds tokenless and the local agent's 401 surfaces there
     return null;
   }
 }
@@ -241,6 +243,8 @@ async function startMobileLocalAgent(): Promise<void> {
       mode: "local",
     });
   } catch {
+    // error-policy:J4 the agent plugin is not registered on this host —
+    // load it directly; a failure of this direct start still propagates
     const agentPluginId = "@elizaos/capacitor-agent";
     const { Agent } = await import(/* @vite-ignore */ agentPluginId);
     await (Agent as AgentPluginLike | undefined)?.start?.({
@@ -253,6 +257,8 @@ async function startMobileLocalAgent(): Promise<void> {
 async function startLocalRuntime(): Promise<void> {
   if (isDesktopPlatform()) {
     try {
+      // error-policy:J4 mode probe — unknown mode proceeds with the local
+      // start below, whose failure is handled explicitly
       const desktopRuntimeMode = await getDesktopRuntimeMode().catch(
         () => null,
       );
@@ -265,10 +271,13 @@ async function startLocalRuntime(): Promise<void> {
       });
       return;
     } catch (error) {
+      // error-policy:J4 the bridge start can fail when the agent is already
+      // running — probe the API; only rethrow when it is truly unreachable
       try {
         await client.getAuthStatus();
         return;
       } catch {
+        // error-policy:J2 agent unreachable — surface the original failure
         throw error;
       }
     }
@@ -284,6 +293,8 @@ async function waitForAgentApi(): Promise<void> {
       await client.getAuthStatus();
       return;
     } catch {
+      // error-policy:J4 boot poll — retry with backoff; the loop throws a
+      // deadline error below when the agent never comes up
       await new Promise((resolve) => setTimeout(resolve, delayMs));
       delayMs = Math.min(Math.round(delayMs * 1.35), 4_000);
     }
@@ -605,7 +616,8 @@ export async function listOrAutoProvisionCloudAgent(
   try {
     list = await client.getCloudCompatAgents();
   } catch {
-    // A thrown error here is a TRANSPORT failure (offline / DNS / timeout),
+    // error-policy:J1 a thrown error here is a TRANSPORT failure (offline /
+    // DNS / timeout),
     // not an API message — the client returns { success:false } for real API
     // errors. Surface a friendly, actionable line instead of leaking the raw
     // `Unable to resolve host "api.elizacloud.ai"` UnknownHostException to the
@@ -666,6 +678,8 @@ export async function runFirstRunFinish(
     }
     return await finishLocal(sourceDraft, ports);
   } catch (err) {
+    // error-policy:J1 finish boundary — translate the failure into the
+    // structured error outcome the onboarding chat renders
     ports.onStatus?.(null);
     return {
       kind: "error",

--- a/packages/ui/src/first-run/first-run.ts
+++ b/packages/ui/src/first-run/first-run.ts
@@ -139,6 +139,7 @@ function looksLikeRemoteTarget(value: string): boolean {
         parsed.hostname.trim().length > 0
       );
     } catch {
+      // error-policy:J3 user-typed target — unparseable means "not a remote URL"
       return false;
     }
   }

--- a/packages/ui/src/first-run/first-run.ts
+++ b/packages/ui/src/first-run/first-run.ts
@@ -75,6 +75,8 @@ export function clearPersistedFirstRunState(): void {
   try {
     window.localStorage.removeItem(FIRST_RUN_STATE_STORAGE_KEY);
   } catch {
+    // error-policy:J6 best-effort cleanup of a legacy key — storage may be
+    // unavailable (private mode)
     return;
   }
 }

--- a/packages/ui/src/first-run/local-agent-token.ts
+++ b/packages/ui/src/first-run/local-agent-token.ts
@@ -16,6 +16,7 @@ function isNativeAndroid(): boolean {
   try {
     return Capacitor.getPlatform() === "android";
   } catch {
+    // error-policy:J4 capability probe — no Capacitor bridge means not native
     return false;
   }
 }
@@ -25,6 +26,7 @@ async function readNativeLocalAgentToken(): Promise<string | null> {
   try {
     agent = getAgentPlugin();
   } catch {
+    // error-policy:J4 capability probe — missing native plugin means no token
     agent = null;
   }
 
@@ -33,6 +35,8 @@ async function readNativeLocalAgentToken(): Promise<string | null> {
     const token = result?.token?.trim();
     return result?.available && token ? token : null;
   } catch {
+    // error-policy:J4 bridge call failed — auth proceeds tokenless and the
+    // local agent's 401 surfaces through the request path
     return null;
   }
 }

--- a/packages/ui/src/first-run/mobile-runtime-mode.ts
+++ b/packages/ui/src/first-run/mobile-runtime-mode.ts
@@ -3,6 +3,7 @@
  * base constants + URL predicates the transports and runtime-target resolver
  * share. Emits MOBILE_RUNTIME_MODE_CHANGED_EVENT on change.
  */
+import { logger } from "@elizaos/logger";
 import { DEFAULT_DESKTOP_API_PORT } from "@elizaos/shared";
 import { dispatchAppEvent, MOBILE_RUNTIME_MODE_CHANGED_EVENT } from "../events";
 import type { FirstRunRuntimeTarget } from "./runtime-target";
@@ -63,6 +64,7 @@ export function isMobileLocalAgentIpcUrl(
       pathname.startsWith(`//${MOBILE_LOCAL_AGENT_IPC_HOST}/`)
     );
   } catch {
+    // error-policy:J3 unparseable value — fail closed as "not the IPC URL"
     return false;
   }
 }
@@ -99,6 +101,7 @@ export function mobileLocalAgentPathFromUrl(
   try {
     parsed = value instanceof URL ? value : new URL(trimmed);
   } catch {
+    // error-policy:J3 unparseable value — no IPC path can be derived
     return null;
   }
 
@@ -138,6 +141,7 @@ export function isMobileLocalAgentUrl(
   try {
     parsed = value instanceof URL ? value : new URL(value.toString());
   } catch {
+    // error-policy:J3 unparseable value — fail closed as "not the local agent"
     return false;
   }
   return (
@@ -194,6 +198,7 @@ export function readPersistedMobileRuntimeMode(): MobileRuntimeMode | null {
       window.localStorage.getItem(MOBILE_RUNTIME_MODE_STORAGE_KEY),
     );
   } catch {
+    // error-policy:J3 storage blocked — treat as "no persisted mode"
     return null;
   }
 }
@@ -220,8 +225,14 @@ async function persistNativeMobileRuntimeMode(
     } else {
       await Preferences.remove({ key: MOBILE_RUNTIME_MODE_STORAGE_KEY });
     }
-  } catch {
-    // Capacitor Preferences is unavailable in web/unit-test shells.
+  } catch (err) {
+    // error-policy:J4 Capacitor Preferences is absent in web/unit-test shells
+    // (expected). On native, a lost write means the runtime mode silently
+    // diverges across restarts (#11030 boot-hang class) — log it.
+    logger.warn(
+      { err, mode },
+      "[mobile-runtime-mode] native runtime-mode persist failed",
+    );
   }
 }
 
@@ -240,8 +251,14 @@ export function persistMobileRuntimeMode(mode: MobileRuntimeMode | null): void {
       } else {
         window.localStorage.removeItem(MOBILE_RUNTIME_MODE_STORAGE_KEY);
       }
-    } catch {
-      // localStorage can be unavailable in embedded shells.
+    } catch (err) {
+      // error-policy:J4 localStorage can be blocked in embedded shells; the
+      // native Preferences write below is the durable copy there. Logged so a
+      // lost mode write is not silent.
+      logger.warn(
+        { err, mode },
+        "[mobile-runtime-mode] localStorage runtime-mode persist failed",
+      );
     }
   }
 

--- a/packages/ui/src/first-run/pre-seed-local-runtime.ts
+++ b/packages/ui/src/first-run/pre-seed-local-runtime.ts
@@ -34,6 +34,8 @@ function hasPersistedActiveServer(): boolean {
       parsed.id.length > 0
     );
   } catch {
+    // error-policy:J3 corrupt persisted server blob — treat as "none" so the
+    // pre-seed can write a fresh one
     return false;
   }
 }
@@ -52,7 +54,8 @@ function writeLocalAgentActiveServer(): void {
       JSON.stringify(payload),
     );
   } catch {
-    // localStorage can be unavailable in embedded shells.
+    // error-policy:J6 storage blocked (embedded shells) — the pre-seed is an
+    // optimization; first-run still resolves the server interactively
   }
 }
 

--- a/packages/ui/src/first-run/probe-local-agent.ts
+++ b/packages/ui/src/first-run/probe-local-agent.ts
@@ -48,6 +48,7 @@ function isNativeAndroid(): boolean {
   try {
     return Capacitor.getPlatform() === "android";
   } catch {
+    // error-policy:J4 capability probe — no Capacitor bridge means not native
     return false;
   }
 }
@@ -56,6 +57,7 @@ function isNativeIos(): boolean {
   try {
     return Capacitor.isNativePlatform() && Capacitor.getPlatform() === "ios";
   } catch {
+    // error-policy:J4 capability probe — no Capacitor bridge means not native
     return false;
   }
 }
@@ -68,6 +70,8 @@ async function resolveNativeAgentPlugin(): Promise<Pick<
     const agent = toAgentRequestPlugin(getAgentPlugin());
     if (agent) return agent;
   } catch {
+    // error-policy:J4 capability probe — missing native plugin means the
+    // native transport is unavailable, not an error
     return null;
   }
 
@@ -137,6 +141,7 @@ async function runNativeAndroidProbe(
   try {
     parsed = new URL(url);
   } catch {
+    // error-policy:J3 unparseable probe URL — fail closed as "not healthy"
     return false;
   }
 
@@ -152,6 +157,7 @@ async function runNativeAndroidProbe(
       timeoutMs,
     });
   } catch {
+    // error-policy:J4 liveness probe — unreachable IS the negative result
     return false;
   }
 
@@ -161,6 +167,7 @@ async function runNativeAndroidProbe(
   try {
     body = JSON.parse(result.body ?? "");
   } catch {
+    // error-policy:J3 non-JSON health body — fail closed as "not healthy"
     return false;
   }
 
@@ -183,6 +190,7 @@ async function runProbe(url: string, timeoutMs: number): Promise<boolean> {
       headers: { Accept: "application/json" },
     });
   } catch {
+    // error-policy:J4 liveness probe — unreachable/timeout IS the negative result
     return false;
   } finally {
     clearTimeout(timer);
@@ -194,6 +202,7 @@ async function runProbe(url: string, timeoutMs: number): Promise<boolean> {
   try {
     body = await res.json();
   } catch {
+    // error-policy:J3 non-JSON health body — fail closed as "not healthy"
     return false;
   }
 

--- a/packages/ui/src/first-run/reconcile-mobile-runtime-mode.ts
+++ b/packages/ui/src/first-run/reconcile-mobile-runtime-mode.ts
@@ -178,6 +178,7 @@ function capacitorNativePlatform(): MobileNativePlatform | null {
     const platform = cap.getPlatform?.();
     return platform === "ios" || platform === "android" ? platform : null;
   } catch {
+    // error-policy:J4 capability probe — no Capacitor bridge means not native
     return null;
   }
 }

--- a/packages/ui/src/first-run/reload-into-first-run-runtime.ts
+++ b/packages/ui/src/first-run/reload-into-first-run-runtime.ts
@@ -41,7 +41,8 @@ export function reloadIntoFirstRunRuntime(target?: FirstRunReloadTarget): void {
   try {
     window.localStorage.removeItem(ACTIVE_SERVER_STORAGE_KEY);
   } catch {
-    // The query navigation still forces first-run when storage is unavailable.
+    // error-policy:J6 best-effort cleanup — the query navigation below still
+    // forces first-run when storage is unavailable
   }
   const url = new URL(window.location.href);
   url.searchParams.set(FIRST_RUN_QUERY_NAME, FIRST_RUN_QUERY_VALUE);

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -34,6 +34,7 @@
  *   connect-and-resume continuation (`pendingCloudResumeRef`).
  */
 
+import { logger } from "@elizaos/logger";
 import * as React from "react";
 import type {
   ConversationMessage,
@@ -1009,7 +1010,15 @@ export function useFirstRunConductor(): void {
       .then((backups) => {
         if (!cancelled && backups.length > 0) seedBackupRestoreChoice(backups);
       })
-      .catch(() => {});
+      .catch((err: unknown) => {
+        // error-policy:J4 the backup probe is a purely additive upgrade (see
+        // above): on failure first-run proceeds without the restore choice.
+        // Logged so a wedged local agent is diagnosable.
+        logger.debug(
+          { err },
+          "[useFirstRunConductor] local-agent backup probe failed",
+        );
+      });
     return () => {
       cancelled = true;
       setFirstRunActionHandler(null);

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -577,9 +577,9 @@ export function useFirstRunConductor(): void {
         }
         handleOutcome(outcome);
       })
-      // Unlike runFirstRunFinish (which funnels throws to seedError), these
-      // cloud entrypoints can reject (OAuth/network); without this the
-      // "Connecting…" turn strands on screen as an unhandled rejection.
+      // error-policy:J4 unlike runFirstRunFinish (which funnels throws to
+      // seedError), these cloud entrypoints can reject (OAuth/network);
+      // without this the "Connecting…" turn strands as an unhandled rejection
       .catch((err: unknown) => seedError(cloudFailureMessage(err)))
       .finally(() => {
         busyRef.current = false;
@@ -764,6 +764,7 @@ export function useFirstRunConductor(): void {
                 ),
               );
             })
+            // error-policy:J4 restore failure is surfaced as an onboarding turn
             .catch((error) => {
               const message =
                 error instanceof Error ? error.message : String(error);
@@ -838,6 +839,7 @@ export function useFirstRunConductor(): void {
           portsRef.current,
         )
           .then(handleOutcome)
+          // error-policy:J4 bind failure is surfaced as an onboarding error turn
           .catch((err: unknown) => seedError(cloudFailureMessage(err)))
           .finally(() => {
             busyRef.current = false;

--- a/packages/ui/src/first-run/use-microphone-permission.ts
+++ b/packages/ui/src/first-run/use-microphone-permission.ts
@@ -60,6 +60,8 @@ async function probeMicrophoneViaGetUserMedia(): Promise<MicrophonePermissionSta
     }
     return "granted";
   } catch {
+    // error-policy:J4 permission probe — a rejected getUserMedia reads as
+    // denied; the step renders the settings affordance either way
     return "denied";
   }
 }
@@ -69,8 +71,8 @@ async function openMicrophoneSettingsViaClient(): Promise<void> {
   try {
     await client.openPermissionSettings(MICROPHONE);
   } catch {
-    // Opening OS settings is best-effort; a failure here must not break
-    // onboarding. The user can still grant access through the OS directly.
+    // error-policy:J4 opening OS settings is best-effort; a failure must
+    // not break onboarding — the user can still grant access via the OS
   }
 }
 
@@ -96,9 +98,9 @@ export function useMicrophonePermission(): MicrophonePermissionController {
         status = result.status;
         canRequest = result.canRequest;
       } catch {
-        // The platform permission client failed (older renderer, missing
-        // bridge); fall back to the browser probe rather than surfacing an
-        // error the user cannot act on.
+        // error-policy:J4 the platform permission client failed (older
+        // renderer, missing bridge); fall back to the browser probe rather
+        // than surfacing an error the user cannot act on
         status = await probeMicrophoneViaGetUserMedia();
         canRequest = status !== "denied";
       }

--- a/packages/ui/src/navigation/index.ts
+++ b/packages/ui/src/navigation/index.ts
@@ -230,6 +230,7 @@ export function isAppWindowRoute(
   try {
     return new URLSearchParams(location.search).get("appWindow") === "1";
   } catch {
+    // error-policy:J3 unparseable location.search — treat as the main window
     return false;
   }
 }

--- a/packages/ui/src/retained-lazy.tsx
+++ b/packages/ui/src/retained-lazy.tsx
@@ -127,7 +127,8 @@ function runCleanup(cleanup: RetainedCleanup | undefined): void {
   void Promise.resolve()
     .then(() => cleanup())
     .catch(() => {
-      // Module cleanup is best-effort and must never crash the host shell.
+      // error-policy:J6 module cleanup is best-effort teardown and must never
+      // crash the host shell.
     });
 }
 

--- a/packages/ui/src/state/first-run-bootstrap.ts
+++ b/packages/ui/src/state/first-run-bootstrap.ts
@@ -66,6 +66,8 @@ export async function detectExistingFirstRunConnection(args: {
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   const result = await Promise.race([
     (async () => {
+      // error-policy:J4 existing-install probe — an unreachable agent means
+      // "no existing install detected" and first-run proceeds normally
       const status = await args.client.getFirstRunStatus().catch(() => null);
       if (!status) {
         return null;
@@ -78,6 +80,8 @@ export async function detectExistingFirstRunConnection(args: {
         } satisfies ExistingFirstRunProbeResult;
       }
 
+      // error-policy:J4 same probe semantics — no readable config means "no
+      // existing install detected"
       const config = await args.client.getConfig().catch(() => null);
       if (!hasPersistedExistingInstallConfig(config)) {
         return null;

--- a/packages/ui/src/state/startup-phase-hydrate.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.ts
@@ -345,7 +345,15 @@ export function bindReadyPhase(
         if (s?.tasks)
           depsRef.current?.setPtySessions(mapServerTasksToSessions(s.tasks));
       })
-      .catch(() => {});
+      .catch((err: unknown) => {
+        // error-policy:J4 PTY-session hydration decorates the coding-agent
+        // panel; the panel's own load path surfaces hard failures. Logged so a
+        // persistently broken orchestrator route is not invisible.
+        logger.debug(
+          { err },
+          "[startup-phase-hydrate] coding-agent status hydrate failed",
+        );
+      });
   };
   // Recovery/refresh triggers (reconnect, visibility, periodic) only hit the
   // orchestrator/ACP routes once the agent runtime is running. Before that those

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -710,6 +710,8 @@ export async function runPollingBackend(
           try {
             const [options, config] = await Promise.all([
               client.getFirstRunOptions(),
+              // error-policy:J4 config only pre-fills resume fields; the
+              // required options fetch fails loudly via the loop's deadline
               client.getConfig().catch(() => null),
             ]);
             // The effect may have been torn down (unmount / re-run) while the

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -129,6 +129,8 @@ async function backfillCloudApiBase(
   client.setBaseUrl(DIRECT_CLOUD_API_BASE);
   try {
     if (active.accessToken) client.setToken(active.accessToken);
+    // error-policy:J4 lookup probe — on failure the restore falls back to the
+    // id-derived api base below rather than blocking session restore
     const res = await client.getCloudCompatAgent(agentId).catch(() => null);
     const data = res?.success ? res.data : null;
     const rawApiBase = data
@@ -414,6 +416,8 @@ async function resolveRestoredStewardToken(): Promise<string | null> {
 
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const refreshed = await Promise.race([
+    // error-policy:J4 refresh failure is handled explicitly below: an expired
+    // token is dropped (restore unauthenticated), a still-valid one is kept
     refreshCloudStewardSession({
       endpoint: resolveRestoreStewardRefreshEndpoint(),
     }).catch(() => null),
@@ -435,7 +439,8 @@ async function resolveRestoredStewardToken(): Promise<string | null> {
         window.dispatchEvent(new CustomEvent("steward-token-sync"));
       }
     } catch {
-      // best-effort — listeners re-read on their next tick regardless
+      // error-policy:J6 best-effort nudge — listeners re-read on their next
+      // tick regardless
     }
     return refreshed.token;
   }

--- a/packages/ui/src/state/startup-phase-runtime.ts
+++ b/packages/ui/src/state/startup-phase-runtime.ts
@@ -242,6 +242,9 @@ export async function runStartingRuntime(
       return;
     }
     try {
+      // error-policy:J4 boot poll — the API is expected to be unreachable
+      // while the backend comes up; the loop's deadline surfaces a visible
+      // startup error (setStartupError) when it never recovers
       const launchProgress = await client.getLaunchProgress().catch(() => null);
       if (launchProgress) {
         const launchStatus = mapLaunchProgressToAgentStatus(launchProgress);
@@ -299,6 +302,7 @@ export async function runStartingRuntime(
         continue;
       }
 
+      // error-policy:J4 boot poll — same deadline-guarded probe as above
       const bootProgress = await client.getBootProgress().catch(() => null);
       if (bootProgress) {
         const bootStatus = mapBootProgressToAgentStatus(bootProgress);

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -509,7 +509,7 @@ describe("useChatSend 404 recovery", () => {
     ).toBe(true);
   });
 
-  it("does NOT notify on a non-cloud base when createConversation 404s (preserves prior behaviour)", async () => {
+  it("surfaces a send-failure notice on a non-cloud base when createConversation 404s (#12267: a silent return read as a lost message)", async () => {
     mockStream404();
     mocks.client.createConversation.mockRejectedValue(http404());
     mocks.client.getBaseUrl.mockReturnValue("http://127.0.0.1:31337");
@@ -526,8 +526,14 @@ describe("useChatSend 404 recovery", () => {
       });
     });
 
-    expect(deps.setActionNotice).not.toHaveBeenCalled();
-    // Prior behaviour: the empty assistant placeholder is dropped.
+    // The recovery could not produce a conversation to replay into: the user
+    // must see the failure instead of a message that silently vanished.
+    expect(deps.setActionNotice).toHaveBeenCalledWith(
+      expect.stringMatching(/didn't go through/i),
+      "error",
+      8_000,
+    );
+    // The stuck empty assistant placeholder is still dropped.
     const remaining = deps.conversationMessagesRef.current;
     expect(
       remaining.some((m) => m.role === "assistant" && !m.text.trim()),

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -6,6 +6,7 @@
  */
 
 import { MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core";
+import { logger } from "@elizaos/logger";
 import { asRecord } from "@elizaos/shared";
 import { type MutableRefObject, useCallback, useEffect, useRef } from "react";
 import type { Conversation, CustomActionDef } from "../api";
@@ -214,7 +215,13 @@ function abortServerConversationTurn(
   reason: string,
 ): void {
   if (!roomId) return;
-  void client.abortConversationTurn(roomId, reason).catch(() => {});
+  // error-policy:J6 best-effort abort signal for a turn the user already
+  // stopped locally; the server also ends the turn when the SSE closes.
+  void client.abortConversationTurn(roomId, reason).catch((err) => {
+    logger.warn(
+      `[useChatSend] abortConversationTurn(${roomId}) failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  });
 }
 
 function normalizeViewPath(path: string | null | undefined): string {
@@ -728,8 +735,13 @@ export function useChatSend(deps: UseChatSendDeps) {
           customActions = (await client.listCustomActions()).filter(
             (action) => action.enabled,
           );
-        } catch {
-          // If custom actions can't be loaded, fall back to normal slash routing.
+        } catch (err) {
+          // error-policy:J4 designed degrade: a broken custom-action catalog
+          // must not block the send — the slash text falls through to normal
+          // chat routing, and the failure is logged so it stays observable.
+          logger.warn(
+            `[useChatSend] listCustomActions failed; falling back to normal slash routing: ${err instanceof Error ? err.message : String(err)}`,
+          );
           return { handled: false };
         }
 
@@ -1047,6 +1059,7 @@ export function useChatSend(deps: UseChatSendDeps) {
           convId = conversation.id;
           convRoomId = conversation.roomId;
         } catch {
+          // error-policy:J4 surfaced user-facing failure state.
           // First-message conversation creation failed (cold open on weak
           // signal). The composer was already cleared upstream and the
           // optimistic bubble hasn't rendered yet, so a bare return drops the
@@ -1293,9 +1306,11 @@ export function useChatSend(deps: UseChatSendDeps) {
               void loadConversations();
             })
             .catch((err) => {
-              console.warn(
-                "Failed to generate conversation title",
-                err instanceof Error ? err.message : err,
+              // error-policy:J4 title generation is decorative — the snippet
+              // fallback title is already applied; the reload keeps the list
+              // fresh either way.
+              logger.warn(
+                `[useChatSend] conversation title generation failed: ${err instanceof Error ? err.message : String(err)}`,
               );
               void loadConversations();
             });
@@ -1374,12 +1389,20 @@ export function useChatSend(deps: UseChatSendDeps) {
               dropEmptyAssistantPlaceholder(assistantMsgId);
               return;
             }
-            // Non-cloud base, or a different create failure — preserve the prior
-            // behaviour (drop the empty assistant placeholder).
+            // Non-cloud base, or a different create failure — the recovery
+            // could not produce a conversation to replay into. Drop the empty
+            // placeholder and tell the user; a silent return here read as a
+            // lost message.
             dropEmptyAssistantPlaceholder(assistantMsgId);
+            setActionNotice(buildSendFailureNotice(createErr), "error", 8_000);
             return;
           }
 
+          // Seed ids live above the try so the failure handler below can
+          // remove the replay's own placeholder (the original assistant id no
+          // longer exists once the thread is re-seeded).
+          const replayUserId = `temp-${Date.now()}`;
+          const replayAssistantId = `temp-resp-${Date.now()}`;
           try {
             const nextCutoffTs = Date.now();
             setConversations((prev) => [conversation, ...prev]);
@@ -1395,8 +1418,6 @@ export function useChatSend(deps: UseChatSendDeps) {
             // assistant placeholder, then REPLAY as a token stream — the 404
             // recovery must stream like the primary send, not pop the whole
             // reply in at once with the non-streaming endpoint (#10231).
-            const replayUserId = `temp-${Date.now()}`;
-            const replayAssistantId = `temp-resp-${Date.now()}`;
             // Seed unfiltered (like the primary send path) — the empty assistant
             // placeholder must survive so streamed tokens have a target;
             // filterRenderableConversationMessages would drop an empty turn.
@@ -1454,8 +1475,24 @@ export function useChatSend(deps: UseChatSendDeps) {
                   : {}),
               });
             }
-          } catch {
-            dropEmptyAssistantPlaceholder(assistantMsgId);
+          } catch (replayErr) {
+            // The re-seed above replaced the whole thread, so the ORIGINAL
+            // placeholder id is gone — dropping it was a no-op that left the
+            // replay's empty bubble stuck forever and the failure invisible.
+            // Clean up the replay placeholder and surface the failure exactly
+            // like the primary send path (aborts stay silent by design).
+            flushStreamingText();
+            dropEmptyAssistantPlaceholder(replayAssistantId);
+            if (
+              (replayErr as Error).name !== "AbortError" &&
+              !controller?.signal.aborted
+            ) {
+              setActionNotice(
+                buildSendFailureNotice(replayErr),
+                "error",
+                8_000,
+              );
+            }
           }
         } else {
           // Non-abort, non-404 send failure (network/timeout/5xx/auth/429/4xx).
@@ -1776,6 +1813,15 @@ export function useChatSend(deps: UseChatSendDeps) {
             convId = conversation.id;
             convRoomId = conversation.roomId;
           } catch {
+            // error-policy:J4 surfaced user-facing failure state. An
+            // action/inbox send that can't start a conversation must not
+            // vanish silently (mirrors the cold-open path in
+            // runQueuedChatSend).
+            setActionNotice(
+              "Couldn't start the conversation — check your connection and try again.",
+              "error",
+              8_000,
+            );
             return;
           }
         }
@@ -2007,7 +2053,13 @@ export function useChatSend(deps: UseChatSendDeps) {
     // Also stop any active PTY sessions — the user wants everything to halt.
     // Read from the ref so this callback stays stable even as ptySessions polls.
     for (const session of ptySessionsRef.current) {
-      client.stopCodingAgent(session.sessionId).catch(() => {});
+      // error-policy:J6 best-effort bulk stop on user-initiated halt; a session
+      // that fails to stop keeps reporting its live status in the PTY panel.
+      client.stopCodingAgent(session.sessionId).catch((err) => {
+        logger.warn(
+          `[useChatSend] stopCodingAgent(${session.sessionId}) failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
     }
     // ptySessionsRef is a stable ref object — only include the ref itself, not .current
   }, [interruptActiveChatPipeline, ptySessionsRef]);

--- a/packages/ui/src/state/useDataLoaders.ts
+++ b/packages/ui/src/state/useDataLoaders.ts
@@ -378,7 +378,19 @@ export function useDataLoaders(deps: DataLoadersDeps) {
         }
         const status = (err as { status?: number }).status;
         if (status === 404) {
-          const refreshed = await client.listConversations().catch(() => null);
+          // error-policy:J4 the 404 already settled the thread's fate (gone);
+          // this refresh only re-syncs the sidebar list. Its failure degrades to
+          // the stale list + cleared selection below — logged so a broken
+          // list endpoint is not silent.
+          const refreshed = await client
+            .listConversations()
+            .catch((refreshErr: unknown) => {
+              logger.warn(
+                { err: refreshErr },
+                "[useDataLoaders] conversation-list refresh after 404 failed",
+              );
+              return null;
+            });
           if (refreshed) {
             const normalized = normalizeConversationList(
               refreshed.conversations,

--- a/packages/ui/src/state/useStartupCoordinator.ts
+++ b/packages/ui/src/state/useStartupCoordinator.ts
@@ -213,7 +213,16 @@ export function useStartupCoordinator(
     // local-agent transports stay policy-locked and boot hangs. No-op on
     // web/desktop and whenever the persisted mode is still usable.
     reconcilePersistedMobileRuntimeModeAtBoot();
-    runRestoringSession(d, dispatch, _ctx, cancelled).catch(() => {});
+    // error-policy:J5 expected failures are dispatched to the state machine
+    // inside the runner; this catch only keeps an unexpected runner bug from
+    // becoming an unhandled rejection, logged so a wedged boot phase is
+    // diagnosable instead of silent.
+    runRestoringSession(d, dispatch, _ctx, cancelled).catch((err: unknown) => {
+      logger.error(
+        { err },
+        "[useStartupCoordinator] restoring-session phase runner threw",
+      );
+    });
 
     return () => {
       cancelled.current = true;
@@ -245,7 +254,14 @@ export function useStartupCoordinator(
       effectRunRef,
       cancelled,
       tidRef,
-    ).catch(() => {});
+    ).catch((err: unknown) => {
+      // error-policy:J5 expected failures are dispatched to the state machine
+      // inside the runner; log unexpected runner bugs instead of dropping them.
+      logger.error(
+        { err },
+        "[useStartupCoordinator] polling-backend phase runner threw",
+      );
+    });
 
     return () => {
       cancelled.current = true;
@@ -278,7 +294,14 @@ export function useStartupCoordinator(
       cancelled,
       tidRef,
       startingRuntimeTarget,
-    ).catch(() => {});
+    ).catch((err: unknown) => {
+      // error-policy:J5 expected failures are dispatched to the state machine
+      // inside the runner; log unexpected runner bugs instead of dropping them.
+      logger.error(
+        { err },
+        "[useStartupCoordinator] starting-runtime phase runner threw",
+      );
+    });
 
     return () => {
       cancelled.current = true;

--- a/packages/ui/src/views/view-event-bus.ts
+++ b/packages/ui/src/views/view-event-bus.ts
@@ -39,7 +39,8 @@ function getChannel(): BroadcastChannel | null {
   try {
     _channel = new BroadcastChannel(CHANNEL_NAME);
   } catch {
-    // Some environments (SSR, restricted workers) throw on construction.
+    // error-policy:J4 some environments (SSR, restricted workers) throw on
+    // construction; the same-window CustomEvent transport still delivers.
     return null;
   }
   return _channel;

--- a/packages/ui/src/voice/aec-loop-harness.ts
+++ b/packages/ui/src/voice/aec-loop-harness.ts
@@ -331,6 +331,7 @@ async function runAecLoop(
         statusBefore = await getJson("/api/voice/audio-frames/status");
         break;
       } catch (err) {
+        // error-policy:J4 boot poll — retry until the deadline, then rethrow
         if (Date.now() > bootDeadline) throw err;
         log("agent not ready; retrying");
         await new Promise((r) => setTimeout(r, 3000));
@@ -446,6 +447,8 @@ async function runAecLoop(
           micPosts += 1;
         }
       } catch (err) {
+        // error-policy:J7 frame-ship failure is recorded as shipError in the
+        // run result; the loop keeps capturing the remaining evidence
         shipError = String(err);
       }
     };
@@ -523,12 +526,16 @@ async function runAecLoop(
         const wrote = await writeResultToDocuments(JSON.stringify(result));
         log(wrote ? "result written to Documents" : "no native file sink");
       } catch (err) {
+        // error-policy:J6 best-effort Documents sink — the result already
+        // lives in lastResult; the failure is logged in the run log
         log(`file sink failed: ${String(err)}`);
       }
     }
     log("done");
     return result;
   } catch (err) {
+    // error-policy:J1 harness boundary — record state/lastError for the
+    // status API and the Documents sink, then rethrow to the caller
     lastError = err instanceof Error ? (err.stack ?? err.message) : String(err);
     state = "error";
     log(`ERROR ${lastError}`);
@@ -538,7 +545,8 @@ async function runAecLoop(
           JSON.stringify({ tag, error: lastError, log: runLog }),
         );
       } catch {
-        // The error is already surfaced via state/lastError.
+        // error-policy:J6 best-effort error sink — the error is already
+        // surfaced via state/lastError
       }
     }
     throw err;
@@ -548,7 +556,7 @@ async function runAecLoop(
       try {
         await ctx.close();
       } catch {
-        // Context may already be closed by the platform.
+        // error-policy:J6 teardown — context may already be closed
       }
     }
   }
@@ -610,7 +618,8 @@ export function installAecLoopHarness(): AecLoopControl {
     const options = parseAecLoopHash(window.location.hash);
     if (!options || state === "running") return;
     void runAecLoop(options).catch(() => {
-      // Surfaced via state()/lastError() and the Documents sink.
+      // error-policy:J5 rejection observed via state()/lastError() and the
+      // Documents sink written inside runAecLoop
     });
   };
   window.addEventListener("hashchange", maybeRun);

--- a/packages/ui/src/voice/aec-loop-harness.ts
+++ b/packages/ui/src/voice/aec-loop-harness.ts
@@ -238,6 +238,8 @@ async function postJson(path: string, body: unknown): Promise<unknown> {
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
   });
+  // error-policy:J3 body parse is best-effort context for the thrown error;
+  // non-2xx always throws below with the status either way
   const json: unknown = await res.json().catch(() => null);
   if (!res.ok) {
     throw new Error(`${path} -> ${res.status} ${JSON.stringify(json)}`);
@@ -249,6 +251,8 @@ async function getJson(path: string): Promise<unknown> {
   const res = await fetch(resolveApiUrl(path), {
     headers: { accept: "application/json" },
   });
+  // error-policy:J3 body parse is best-effort context for the thrown error;
+  // non-2xx always throws below with the status either way
   const json: unknown = await res.json().catch(() => null);
   if (!res.ok) {
     throw new Error(`${path} -> ${res.status} ${JSON.stringify(json)}`);

--- a/packages/ui/src/voice/jni-voice-harness.ts
+++ b/packages/ui/src/voice/jni-voice-harness.ts
@@ -122,6 +122,7 @@ async function forwardCompletedPcmTurnToLocalAgent(
     }),
   });
   if (!res.ok) {
+    // error-policy:J6 best-effort error detail — the throw carries the status
     const detail = await res.text().catch(() => "");
     throw new Error(
       `[JniVoiceHarness] native PCM turn handoff failed (${res.status}): ${detail}`,
@@ -176,6 +177,8 @@ export function installJniVoiceHarness(
       try {
         abi = await getElizaVoicePlugin().voiceAbiVersion();
       } catch (err) {
+        // error-policy:J1 status boundary — the failure is returned as the
+        // structured status' error field
         return {
           running: pipeline?.isRunning ?? false,
           framesSent: pipeline?.framesSent ?? 0,

--- a/packages/ui/src/voice/jni-voice-pipeline.ts
+++ b/packages/ui/src/voice/jni-voice-pipeline.ts
@@ -552,6 +552,8 @@ export class JniVoicePipeline {
         signal,
       }),
     ).catch((error) => {
+      // error-policy:J7 a turn-listener failure must not kill the voice
+      // pipeline loop; it is logged with the turn id
       logger.warn(
         { error, turnId: raw.turnId },
         "[JniVoicePipeline] completed PCM turn listener failed",

--- a/packages/ui/src/voice/local-asr-capture.test.ts
+++ b/packages/ui/src/voice/local-asr-capture.test.ts
@@ -1,13 +1,15 @@
 /**
  * Unit coverage for local-ASR capture helpers: WAV encoding, silence detection,
- * and audio measurement. Pure functions over PCM buffers, no mic.
+ * audio measurement (pure functions over PCM buffers, no mic), plus the
+ * recorder-start failure path driven through a fake browser audio stack.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createLocalAsrAutoStopDetector,
   encodeMonoPcm16Wav,
   isSilentPcmAudio,
   measurePcmAudio,
+  startLocalAsrRecorder,
 } from "./local-asr-capture";
 
 describe("local ASR capture", () => {
@@ -112,5 +114,36 @@ describe("local ASR capture", () => {
       shouldBuffer: true,
       shouldStop: false,
     });
+  });
+});
+
+describe("startLocalAsrRecorder resume failure", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects and releases the mic when the AudioContext cannot resume", async () => {
+    // A suspended context that never resumes records pure silence; a swallowed
+    // resume failure would make that look like a healthy (dead) session.
+    const trackStop = vi.fn();
+    const stream = {
+      getTracks: () => [{ stop: trackStop }],
+    } as unknown as MediaStream;
+    const getUserMedia = vi.fn().mockResolvedValue(stream);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+
+    const contextClose = vi.fn().mockResolvedValue(undefined);
+    class FakeAudioContext {
+      state = "suspended";
+      resume = vi.fn().mockRejectedValue(new Error("autoplay policy"));
+      close = contextClose;
+    }
+    vi.stubGlobal("window", { AudioContext: FakeAudioContext });
+
+    await expect(startLocalAsrRecorder()).rejects.toThrow(
+      "AudioContext could not resume for local ASR capture",
+    );
+    expect(trackStop).toHaveBeenCalledTimes(1);
+    expect(contextClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/voice/local-asr-capture.ts
+++ b/packages/ui/src/voice/local-asr-capture.ts
@@ -274,8 +274,19 @@ export async function startLocalAsrRecorder(
   if (context.state === "suspended") {
     // A context that cannot resume produces silence — surface the failure to
     // the caller (voice-capture-factory setState("error")) instead of
-    // recording a dead stream.
-    await context.resume();
+    // recording a dead stream. Release the mic + context first so the failed
+    // start does not leave the capture indicator on.
+    try {
+      await context.resume();
+    } catch (err) {
+      // error-policy:J2 release the hot mic, then rethrow with context
+      for (const track of stream.getTracks()) track.stop();
+      // error-policy:J6 teardown — the context may already be closed
+      await context.close().catch(() => undefined);
+      throw new Error("AudioContext could not resume for local ASR capture", {
+        cause: err,
+      });
+    }
   }
 
   const source = context.createMediaStreamSource(stream);

--- a/packages/ui/src/voice/local-asr-capture.ts
+++ b/packages/ui/src/voice/local-asr-capture.ts
@@ -272,7 +272,10 @@ export async function startLocalAsrRecorder(
   });
   const context = new AudioContextCtor();
   if (context.state === "suspended") {
-    await context.resume().catch(() => {});
+    // A context that cannot resume produces silence — surface the failure to
+    // the caller (voice-capture-factory setState("error")) instead of
+    // recording a dead stream.
+    await context.resume();
   }
 
   const source = context.createMediaStreamSource(stream);
@@ -322,23 +325,24 @@ export async function startLocalAsrRecorder(
     try {
       analyser?.disconnect();
     } catch {
-      /* already disconnected */
+      // error-policy:J6 teardown — node already disconnected
     }
     analyser = null;
     try {
       source.disconnect();
     } catch {
-      /* already disconnected */
+      // error-policy:J6 teardown — node already disconnected
     }
     try {
       processor.disconnect();
     } catch {
-      /* already disconnected */
+      // error-policy:J6 teardown — node already disconnected
     }
     for (const track of stream.getTracks()) {
       track.stop();
     }
-    await context.close().catch(() => {});
+    // error-policy:J6 teardown — closing an already-closed context throws
+    await context.close().catch(() => undefined);
   };
 
   return {

--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -73,6 +73,7 @@ export async function isLocalInferenceAsrReady(
       },
     );
     if (!res.ok) return false;
+    // error-policy:J3 non-JSON body reads as "not ready"
     const parsed = (await res.json().catch(() => null)) as {
       ready?: unknown;
     } | null;
@@ -112,9 +113,12 @@ export async function transcribeLocalInferenceWav(
     signal: options?.signal,
   });
   if (!res.ok) {
+    // error-policy:J6 best-effort error detail — the throw carries the status
     const body = await res.text().catch(() => "");
     throw new Error(`Local inference ASR ${res.status}: ${body.slice(0, 200)}`);
   }
+  // error-policy:J3 unparseable body falls through to the explicit
+  // empty-transcript throw below
   const parsed = (await res.json().catch(() => null)) as {
     text?: unknown;
     words?: unknown;

--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -78,6 +78,8 @@ export async function isLocalInferenceAsrReady(
     } | null;
     return parsed?.ready === true;
   } catch {
+    // error-policy:J4 readiness probe — "unknown readiness" deliberately reads
+    // as "not ready" (see header) so we never capture untranscribable audio
     return false;
   }
 }

--- a/packages/ui/src/voice/playback-frame-pump.ts
+++ b/packages/ui/src/voice/playback-frame-pump.ts
@@ -364,6 +364,8 @@ class PlaybackFrameSession implements PlaybackFrameTap {
       });
       if (!res.ok) this.failed = true;
     } catch {
+      // error-policy:J4 ship failure sets the `failed` flag the pump exposes;
+      // the AEC consumer observes it instead of an exploded audio graph
       this.failed = true;
     }
   }
@@ -394,6 +396,8 @@ export class PlaybackFramePump {
     source: AudioNode,
     fallbackBuffer: AudioBuffer,
   ): Promise<PlaybackFrameTap | null> {
+    // error-policy:J4 AudioWorklet unsupported/failed — fall back to the
+    // scheduled-buffer session, which taps the same frames less precisely
     const workletSession = await this.createWorkletSession(ctx, source).catch(
       () => null,
     );
@@ -433,17 +437,17 @@ export class PlaybackFramePump {
         try {
           source.disconnect(node);
         } catch {
-          /* ok */
+          // error-policy:J6 teardown — node may already be disconnected
         }
         try {
           node.disconnect();
         } catch {
-          /* ok */
+          // error-policy:J6 teardown
         }
         try {
           silentGain.disconnect();
         } catch {
-          /* ok */
+          // error-policy:J6 teardown
         }
       },
     });

--- a/packages/ui/src/voice/tts-playback-activity.test.ts
+++ b/packages/ui/src/voice/tts-playback-activity.test.ts
@@ -31,9 +31,9 @@ describe("tts-playback-activity", () => {
     markTtsPlaybackStarted();
     markTtsPlaybackEnded(5000);
     expect(isTtsEchoGateActive(5000 + DEFAULT_POST_TTS_COOLDOWN_MS)).toBe(true);
-    expect(
-      isTtsEchoGateActive(5000 + DEFAULT_POST_TTS_COOLDOWN_MS + 1),
-    ).toBe(false);
+    expect(isTtsEchoGateActive(5000 + DEFAULT_POST_TTS_COOLDOWN_MS + 1)).toBe(
+      false,
+    );
   });
 
   it("honors a custom cooldown", () => {

--- a/packages/ui/src/voice/useVoiceConfig.ts
+++ b/packages/ui/src/voice/useVoiceConfig.ts
@@ -48,8 +48,9 @@ export function useVoiceConfig(uiLanguage: string): UseVoiceConfigResult {
       if (!isMountedRef.current) return;
       setVoiceConfig(resolved.voiceConfig);
       if (resolved.shouldPersist && resolved.voiceConfig) {
-        // A lost persist means the resolved voice silently diverges from the
-        // server copy across restarts — log it instead of swallowing.
+        // error-policy:J6 best-effort background persist — a lost persist
+        // means the resolved voice diverges from the server copy across
+        // restarts, so the failure is logged, never swallowed
         void client
           .updateConfig({ messages: { tts: resolved.voiceConfig } })
           .catch((err: unknown) => {

--- a/packages/ui/src/voice/useVoiceConfig.ts
+++ b/packages/ui/src/voice/useVoiceConfig.ts
@@ -2,6 +2,7 @@
  * Hook that loads, applies defaults to, and persists the character's voice
  * config, staying in sync via VOICE_CONFIG_UPDATED_EVENT.
  */
+import { logger } from "@elizaos/logger";
 import * as React from "react";
 
 import { client } from "../api/client";
@@ -47,13 +48,21 @@ export function useVoiceConfig(uiLanguage: string): UseVoiceConfigResult {
       if (!isMountedRef.current) return;
       setVoiceConfig(resolved.voiceConfig);
       if (resolved.shouldPersist && resolved.voiceConfig) {
+        // A lost persist means the resolved voice silently diverges from the
+        // server copy across restarts — log it instead of swallowing.
         void client
           .updateConfig({ messages: { tts: resolved.voiceConfig } })
-          .catch(() => {});
+          .catch((err: unknown) => {
+            logger.warn(
+              { err },
+              "[useVoiceConfig] failed to persist resolved voice config",
+            );
+          });
       }
     } catch {
       if (!isMountedRef.current) return;
-      // No config endpoint / parse failure — fall back to provider defaults.
+      // error-policy:J4 no config endpoint (minimal shells) or unreadable
+      // config — voice degrades to provider defaults rather than blocking.
       setVoiceConfig(null);
     } finally {
       if (isMountedRef.current) {

--- a/packages/ui/src/voice/useWakeController.ts
+++ b/packages/ui/src/voice/useWakeController.ts
@@ -190,7 +190,8 @@ export function useWakeController(
         if (cancelled) void h.remove();
         else handle = h;
       } catch {
-        // Plugin unavailable — wake never fires, no-op.
+        // error-policy:J4 wake-word plugin unavailable on this platform — the
+        // opt-in feature degrades to "wake never fires"
       }
     })();
     return () => {

--- a/packages/ui/src/voice/voice-capture-factory.ts
+++ b/packages/ui/src/voice/voice-capture-factory.ts
@@ -242,18 +242,23 @@ export function createVoiceCapture(
       try {
         await handle.remove();
       } catch {
-        /* listener already gone — fine */
+        // error-policy:J6 teardown — listener already gone
       }
     }
   }
 
   async function startTalkMode(): Promise<void> {
     const talkMode = getTalkModePlugin();
+    // error-policy:J4 the permission probe returning null means "unknown" —
+    // start proceeds and the native start()/error listener below fails loudly
+    // if the mic is actually denied.
     let permissions = await talkMode.checkPermissions().catch(() => null);
     if (permissions?.speechRecognition === "not_supported") {
       throw new Error("Speech recognition is not available on this device");
     }
     if (permissions?.microphone === "prompt") {
+      // error-policy:J5 the request's outcome is observed by the re-check on
+      // the next line; a rejected prompt shows up there (or in start()).
       await talkMode.requestPermissions().catch(() => {});
       permissions = await talkMode.checkPermissions().catch(() => permissions);
     }
@@ -389,6 +394,7 @@ export function createVoiceCapture(
       if (finalizeOnStop && pending) {
         onTranscript({ text: pending, final: true, backend: "talkmode" });
       }
+      // error-policy:J6 teardown — the recognizer may already be stopped
       await getTalkModePlugin()
         .stop()
         .catch(() => {});
@@ -448,6 +454,7 @@ export function createVoiceCapture(
     disposed = true;
     if (talkModeHandles.length > 0) {
       void removeTalkModeHandles();
+      // error-policy:J6 teardown — dispose is best-effort by design
       void getTalkModePlugin()
         .stop?.()
         .catch(() => {});

--- a/packages/ui/src/voice/voice-capture-factory.ts
+++ b/packages/ui/src/voice/voice-capture-factory.ts
@@ -373,6 +373,8 @@ export function createVoiceCapture(
         startBrowser();
       }
     } catch (err) {
+      // error-policy:J1 capture boundary — the failure renders the voice
+      // error state and still propagates to the caller
       const error = err instanceof Error ? err : new Error(String(err));
       setState("error", error);
       throw error;
@@ -425,6 +427,8 @@ export function createVoiceCapture(
         });
         setState("stopped");
       } catch (err) {
+        // error-policy:J1 stop/transcribe boundary — the failure renders the
+        // voice error state and still propagates to the caller
         const error = err instanceof Error ? err : new Error(String(err));
         setState("error", error);
         throw error;

--- a/packages/ui/src/voice/voice-chat-playback.ts
+++ b/packages/ui/src/voice/voice-chat-playback.ts
@@ -65,6 +65,8 @@ function parseJsonObject(input: string): Record<string, unknown> | null {
       ? (parsed as Record<string, unknown>)
       : null;
   } catch {
+    // error-policy:J3 "is this structured?" probe — non-JSON message text is
+    // the normal case and speaks as plain text
     return null;
   }
 }

--- a/packages/ui/src/voice/voice-chat-types.ts
+++ b/packages/ui/src/voice/voice-chat-types.ts
@@ -395,6 +395,7 @@ export function describeTtsCloudFetchTargetForDebug(): string {
     try {
       return `${new URL(target).origin} (absolute)`;
     } catch {
+      // error-policy:J3 unparseable target — show the raw string (debug-only)
       return target.slice(0, 120);
     }
   }

--- a/packages/ui/src/voice/voice-selftest/VoiceSelfTestShell.tsx
+++ b/packages/ui/src/voice/voice-selftest/VoiceSelfTestShell.tsx
@@ -84,6 +84,8 @@ export function VoiceSelfTestShell() {
         clientRef.current ??= new ElizaClient();
         audioRef.current ??= getAudioCtx();
         if (audioRef.current.state === "suspended") {
+          // error-policy:J5 a dead AudioContext is observed in the report's
+          // playback stage; the run itself must not abort here
           await audioRef.current.resume().catch(() => {});
         }
         const result = await runVoiceSelfTest({

--- a/packages/ui/src/voice/voice-selftest/VoiceWorkbenchShell.tsx
+++ b/packages/ui/src/voice/voice-selftest/VoiceWorkbenchShell.tsx
@@ -100,6 +100,8 @@ export function VoiceWorkbenchShell() {
         clientRef.current ??= new ElizaClient();
         audioRef.current ??= getAudioCtx();
         if (audioRef.current.state === "suspended") {
+          // error-policy:J5 a dead AudioContext is observed in the report's
+          // playback/TTS rows; the run itself must not abort here
           await audioRef.current.resume().catch(() => {});
         }
         const result = await runVoiceWorkbench({

--- a/packages/ui/src/voice/voice-selftest/voice-selftest-harness.ts
+++ b/packages/ui/src/voice/voice-selftest/voice-selftest-harness.ts
@@ -153,6 +153,8 @@ async function playThroughDestination(
 ): Promise<{ started: boolean; outputObserved: boolean }> {
   try {
     if (ctx.state === "suspended") {
+      // error-policy:J4 a stuck-suspended context surfaces as started:false /
+      // outputObserved:false in the returned playback result
       await ctx.resume().catch(() => {});
     }
     const source = ctx.createBufferSource();
@@ -180,12 +182,14 @@ async function playThroughDestination(
     try {
       source.stop();
     } catch {
-      // already stopped
+      // error-policy:J6 teardown — already stopped
     }
     source.disconnect();
     analyser.disconnect();
     return { started: true, outputObserved };
   } catch {
+    // error-policy:J1 playback-stage boundary — the failure is the explicit
+    // started:false result the report renders
     return { started: false, outputObserved: false };
   }
 }
@@ -252,6 +256,7 @@ export async function runVoiceSelfTest(
         });
       }
     } catch (error) {
+      // error-policy:J1 stage boundary — failure becomes a fail stage row
       stages.push({
         stage: "asr",
         status: "fail",
@@ -325,6 +330,7 @@ export async function runVoiceSelfTest(
               : "agent produced no reply / did not complete",
       });
     } catch (error) {
+      // error-policy:J1 stage boundary — failure becomes a fail stage row
       stages.push({
         stage: "send",
         status: "fail",
@@ -393,6 +399,7 @@ export async function runVoiceSelfTest(
               : "decoded audio has zero duration",
       });
     } catch (error) {
+      // error-policy:J1 stage boundary — failure becomes a fail stage row
       stages.push({
         stage: "tts",
         status: "fail",

--- a/packages/ui/src/voice/voice-selftest/voice-workbench-player.ts
+++ b/packages/ui/src/voice/voice-selftest/voice-workbench-player.ts
@@ -260,7 +260,8 @@ async function runTurn(
   try {
     wav = await opts.resolveTurnWav(turn, index);
   } catch (error) {
-    // No corpus clip for this turn on this host — skip, never pass.
+    // error-policy:J4 no corpus clip for this turn on this host — an
+    // explicit "skipped" row, never a fabricated pass
     return {
       index,
       speaker: turn.speaker,
@@ -287,6 +288,7 @@ async function runTurn(
       speakerAttributionRan = predictedSpeakerLabel !== null;
     }
   } catch (error) {
+    // error-policy:J1 turn boundary — failure becomes an explicit fail row
     return {
       index,
       speaker: turn.speaker,
@@ -313,6 +315,7 @@ async function runTurn(
     });
     transcript = result.text;
   } catch (error) {
+    // error-policy:J1 turn boundary — failure becomes an explicit fail row
     return {
       index,
       speaker: turn.speaker,
@@ -354,6 +357,7 @@ async function runTurn(
     agentName = send.agentName;
     noResponseReason = send.noResponseReason;
   } catch (error) {
+    // error-policy:J1 turn boundary — failure becomes an explicit fail row
     return {
       index,
       speaker: turn.speaker,
@@ -386,6 +390,7 @@ async function runTurn(
       ttsOk = tts.ok;
       ttsError = tts.error;
     } catch (error) {
+      // error-policy:J1 stage boundary — failure is recorded on the turn row
       ttsOk = false;
       ttsError = error instanceof Error ? error.message : String(error);
     }


### PR DESCRIPTION
Part of #12267 (batch A of the mobile-UI fallback-slop sweep; split issues #12784 packages/ui / #12785 packages/app). Disjoint from merged sibling PR #12826 — this batch owns **chat surfaces, onboarding (first-run) flow, voice/dictation UI, launcher + views host, and mobile navigation/gestures** in `packages/ui/**` + `packages/app/**`.

## What changed

### Behavioral fixes (swallow → observable)

| Site | Before | After |
|---|---|---|
| `ui/state/useChatSend.ts` 404-recovery (non-cloud base) | create failure silently dropped the user's turn | send-failure notice + placeholder cleanup |
| `ui/state/useChatSend.ts` replay-stream failure | stuck empty assistant placeholder | placeholder removed + failure notice |
| `ui/chat/useSlashCommandController.ts` `sendActionMessage` | bare return on conversation-create failure | error notice |
| `ui/state/useChatSend.ts` abort/telemetry `.catch(() => {})` | silent | logged (J5/J6 annotated) |
| `ui/state/startup-phase-hydrate.ts` PTY hydrate | `.catch(() => {})` | logged (J4) |
| `ui/first-run/mobile-runtime-mode.ts` persist | silent | surfaced |
| `ui/voice/local-asr-capture.ts` AudioContext resume | swallowed → dead silent session | mic + context released, rethrow with `cause` |
| `ui/components/chat/TranscriptViewerOverlay.tsx` load | transport/decode failure rendered "(empty transcript)" | designed error panel (three-state rule) |
| `ui/components/chat/MessageContent.tsx` plugin enable | `[Failed to enable plugin]` (no reason) | notice carries the error message |
| `app/src/main.tsx` deep-link parse | silent `return` on unparseable link | logged before dropping (J3) |
| `app/src/main.tsx` smoke JSON-parse rethrows | message-only | `{ cause }` attached (J2) |

### Annotation sweep (kept handlers, `// error-policy:J<N> <reason>`)

Counts added by this branch (grep `error-policy:J` on the diff):

| J1 | J2 | J3 | J4 | J5 | J6 | J7 | total |
|---|---|---|---|---|---|---|---|
| 24 | 4 | 62 | 145 | 7 | 49 | 11 | **302** |

Clusters: chat home-tile widgets (18 files — keep-last-good polling / settle-don't-spin is the designed glance-tile degrade), chat message surfaces (MessageContent, attachments, transcript overlay, conversations sidebar), first-run onboarding (boot polls, permission probes, native-bridge fallbacks, finish boundary), voice (capture factory, self-test/AEC harness fail-row boundaries, playback teardown), packages/app boot host (optional-native-plugin degrades, smoke-harness result sinks, storage fallback chains, shims).

### Tests

- **Added** `local-asr-capture.test.ts`: rejecting `AudioContext.resume` → recorder rejects and releases the mic (real fake-browser audio stack).
- **Added** `TranscriptViewerOverlay.test.tsx`: rejecting `fetch` with no stored record → `transcript-load-error` renders, never "(empty transcript)".
- **Updated** `useChatSend.test.tsx`: the test pinning the old silent-drop on non-cloud 404-recovery now asserts the failure notice.

### Left by design (residuals)

- The `?? <lit>` / `|| <lit>` mass in this slice is dominated by genuine option defaults, `noUncheckedIndexedAccess` array-index normalization (`pcm[i] ?? 0`), and tolerant shim behavior — not failed-pipeline substitutions. Left untouched per the issue's "not genuine option defaults" scoping and the precision-first approach of merged #12826.
- Non-slice `packages/ui` surfaces (settings, plugins, cloud-ui, state hooks owned by the sibling batch) untouched.

## Verification

- `bun run audit:error-policy-ratchet` — **no new fallback-slop in touched files**
- Empty-catch grep over the slice — **0**
- `biome check` over all 91 touched files — clean (1 pre-existing warning outside the diff hunks)
- packages/ui scoped vitest: chat+conversations 627 ✓, first-run 201 ✓, voice 241 ✓, state/views/navigation 644/645 ✓ (the 1 failure, `startup-phase-poll.test.ts` D1 dead-cloud recovery timeout, reproduces byte-identically with pristine `origin/develop` sources swapped in — inherited from develop, this branch's diff on that module is comment-only)
- packages/app vitest: 89 ✓
- packages/ui `tsc -p tsconfig.json`: 0 errors in touched files (32 pre-existing cloud-ui react-type-dup errors from the shared-worktree node_modules symlink)

Screenshots/visual audit: the only render-affecting changes are the transcript-viewer error panel (covered by the new DOM assertions) and notice toasts on existing error paths; no layout/theme surface changed, so no `audit:app` loop was run — flagged here rather than silently skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
