### PR TITLE
test(#12362): dispatch_workflow step e2e + keyless WORKFLOW action run (WI-6/WI-7 close-out)

### DIFF
--- a/.github/issue-evidence/12362-dispatch-step-action-run.md
+++ b/.github/issue-evidence/12362-dispatch-step-action-run.md
@@ -1,0 +1,111 @@
+# Evidence — #12362 residual: dispatch_workflow step e2e + keyless WORKFLOW action run (WI-6/WI-7 close-out)
+
+Issue: elizaOS/eliza#12362 (parent #12177; decomposed follow-ups #12898/#12899/#12900).
+Branch: `test/12362-dispatch-step-action-run`. Prior evidence for this issue:
+`12362-workflow-lifeops-integration.md` (PR #12913) and PR #12385.
+
+## What this change is
+
+**Test-only.** No runtime, action, provider, prompt, or model code is touched —
+the change proves existing behavior. It closes the last two coverage gaps a
+fresh audit of #12362's Done-when found after #12385 and #12913 merged:
+
+### 1. `dispatch_workflow` LifeOps workflow step → real embedded execution
+
+`plugins/plugin-workflow/__tests__/integration/dispatch-workflow-step-e2e.test.ts`
+
+The LifeOps owner-workflow step `kind: "dispatch_workflow"`
+(`plugins/plugin-personal-assistant/src/lifeops/registries/workflow-step-default-pack.ts`)
+had no test driving it to a real workflow execution. The new suite registers
+the REAL default WorkflowStepRegistry pack on the runtime (the same wiring
+plugin-personal-assistant's init performs) and invokes the step exactly the
+way the LifeOps dispatcher (`WorkflowsDomain.executeWorkflowDefinition`) does —
+runtime-bound registry lookup → `paramSchema.parse` → `contribution.execute` —
+never by calling the WORKFLOW_DISPATCH service directly. Underneath is the
+REAL dispatch service over a REAL PGlite-backed `EmbeddedWorkflowService`.
+
+Cases: (a) real `workflow.embedded_executions` row + parent `request` and
+accumulated `outputs` threaded into the nested run's `customData.triggerData`;
+(b) two step fires sharing an `__idempotencyKey` collapse onto ONE execution
+row (`dedup: true`); (c) missing WORKFLOW_DISPATCH → structured
+`{ ok: false, error: "WORKFLOW_DISPATCH service not registered" }`, no row;
+(d) unknown workflowId → structured not-found failure from the real dispatch,
+no row; (e) a step without `workflowId` is rejected by the contribution's zod
+schema before any dispatch.
+
+Placement note: the full `WorkflowsDomain` class is not importable from this
+package (its repository value-imports built dists of
+plugin-browser/finances/inbox), so the suite drives the registry seam the
+dispatcher consults; the dispatcher's loop mechanics around that seam are
+covered by `plugins/plugin-personal-assistant/test/workflow-step-registry.test.ts`.
+
+### 2. Keyless WORKFLOW action `run` op against the real service stack
+
+`plugins/plugin-workflow/__tests__/integration/workflow-action-run-e2e.test.ts`
+
+The action's `run` op (`workflow.ts` → `handleRunWorkflow` →
+`WorkflowService.runWorkflow`) previously had only mocked-unit coverage plus
+the live-only scenario. The new suite starts a REAL `WorkflowService` via
+`WorkflowService.start()` (keyless — no model, no API key) over the real
+embedded engine and invokes the real action handler. No workflow-service mocks.
+
+Cases: (a) run → `success: true`, callback metadata reports the real
+execution, and a finished manual-mode row is read back through the same real
+service layer the `executions` op uses; (b) a workflow whose code node throws
+→ `success: false` AND a persisted error-status execution row whose
+diagnostics name the failing node (`Node "Work" failed`, the
+throwOnError:false contract); (c) missing workflowId → structured failure,
+zero executions; (d) unknown workflowId → the real store's not-found failure;
+(e) `validate()` flips with real service registration.
+
+Shared harness: `__tests__/integration/embedded-harness.ts` (the
+trigger-dispatch-e2e makeHarness pattern extracted for the two new suites —
+real PGlite DB, real services map; the only double is the in-memory task
+store, same as workflow-task-worker.test.ts).
+
+## Domain artifacts (inspected in-test)
+
+- `workflow.embedded_executions` rows — exactly 1 per successful dispatch/run;
+  exactly 1 after an idempotent double-fire; 0 on every failure path except
+  the failing-node run, which persists exactly 1 `status: "error"` row.
+- `customData.triggerData` on the nested execution — carries the step payload
+  plus the parent run's `request` and `outputs` (the contribution's contract).
+- Error-run diagnostics — `data.resultData.error.message` names the failing
+  node.
+
+## Backend logs (real code path firing)
+
+```
+Info  [PLUGIN:WORKFLOW:EMBEDDED] Embedded workflow service registered (lazy runtime load)
+Info  [PLUGIN:WORKFLOW:SMITHERS] workflow executed (workflowId=9242111b-87ef-4a44-995a-94afa218bca1, executionId=f95c996b-2aa1-4728-b598-dee61373b1ef, nodes=2, levels=2, maxConcurrency=1, started=2, finished=2, failed=0, skipped=0, retries=0)
+Warn  [PLUGIN:WORKFLOW:DISPATCH] Workflow execution failed for no-such-workflow: Workflow not found: no-such-workflow
+Info  [PLUGIN:WORKFLOW:SERVICE:MAIN] Workflow Service started - connected to in-process
+Warn  [PLUGIN:WORKFLOW:ACTION:RUN] Workflow not found: no-such-workflow
+```
+
+Each `workflow executed` line is a real Smithers engine run against PGlite.
+
+## Verification (commands + results)
+
+```
+bun test __tests__/integration/dispatch-workflow-step-e2e.test.ts
+  → 5 pass, 0 fail, 20 expect() calls
+
+bun test __tests__/integration/workflow-action-run-e2e.test.ts
+  → 5 pass, 0 fail, 24 expect() calls
+
+bun run --cwd plugins/plugin-workflow test
+  → 366 pass, 0 fail, 1108 expect() calls, 36 files   (was 356 across 34 files)
+
+bun run --cwd plugins/plugin-agent-orchestrator test
+  → 156 files passed | 3 skipped; 1629 tests passed | 6 skipped (pre-existing skips)
+```
+
+## Evidence rows
+
+| Evidence | Status |
+| --- | --- |
+| Real-LLM trajectory | N/A — test-only change, no agent/action/prompt/model behavior altered; the live WORKFLOW-action trajectory for this issue was captured + reviewed in PR #12913 (`12362-lifeops-live/live-workflow-action-executions.report.json`). |
+| Backend logs | Attached above (Smithers `workflow executed`, dispatch/action warn paths, service lifecycle). |
+| Domain artifacts | `embedded_executions` rows (success, error, dedup), `customData.triggerData` threading, failing-node diagnostics — asserted in-test and listed above. |
+| Frontend logs / screenshots / video | N/A — no UI surface changed (test-only). |

--- a/plugins/plugin-workflow/__tests__/integration/dispatch-workflow-step-e2e.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/dispatch-workflow-step-e2e.test.ts
@@ -1,0 +1,270 @@
+/**
+ * #12362 WI-7 residual — the LifeOps `dispatch_workflow` workflow step drives
+ * a REAL embedded workflow execution end to end.
+ *
+ * The subject under test is the seam between the two workflow layers: a
+ * LifeOps owner-workflow step (`kind: "dispatch_workflow"`, contributed by
+ * plugin-personal-assistant's default WorkflowStepRegistry pack) resolves the
+ * REAL `WORKFLOW_DISPATCH` service and lands a row in the REAL
+ * `workflow.embedded_executions` table (PGlite-backed EmbeddedWorkflowService).
+ *
+ * The step is invoked exactly the way the LifeOps dispatcher
+ * (`WorkflowsDomain.executeWorkflowDefinition`,
+ * plugin-personal-assistant/src/lifeops/domains/workflows-service.ts) invokes
+ * it: registry bound to the runtime → `registry.get(step.kind)` →
+ * `paramSchema.parse(step)` → `contribution.execute(validated, args, ctx)` —
+ * NOT by calling the dispatch service directly. The full `WorkflowsDomain`
+ * class is not importable here (its repository pulls built dists of
+ * plugin-browser/finances/inbox), so this file drives the registry seam the
+ * dispatcher consults; the loop mechanics around that seam are covered by
+ * plugin-personal-assistant/test/workflow-step-registry.test.ts.
+ *
+ * Cases:
+ *   (a) dispatch_workflow step → real execution row; the parent run's
+ *       request + accumulated outputs are threaded into the nested
+ *       execution's triggerData (the contribution's contract)
+ *   (b) idempotent double-fire: same payload `__idempotencyKey` collapses two
+ *       step executions onto one embedded execution row
+ *   (c) WORKFLOW_DISPATCH not registered → structured failure, no execution
+ *   (d) unknown workflowId → structured failure from the real dispatch, no row
+ *   (e) malformed step (no workflowId) fails schema validation before dispatch
+ */
+
+import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from 'bun:test';
+import { registerDefaultWorkflowStepPack } from '../../../plugin-personal-assistant/src/lifeops/registries/workflow-step-default-pack.ts';
+import {
+  createWorkflowStepRegistry,
+  getWorkflowStepRegistry,
+  registerWorkflowStepRegistry,
+  type WorkflowStepExecuteArgs,
+  type WorkflowStepExecuteContext,
+} from '../../../plugin-personal-assistant/src/lifeops/registries/workflow-step-registry.ts';
+import type { EmbeddedWorkflowService } from '../../src/services/embedded-workflow-service';
+import {
+  registerWorkflowDispatchService,
+  WORKFLOW_DISPATCH_SERVICE_TYPE,
+  type WorkflowDispatchResult,
+} from '../../src/services/workflow-dispatch';
+import { type EmbeddedHarness, makeEmbeddedHarness } from './embedded-harness';
+
+setDefaultTimeout(60_000);
+
+/** A runnable two-node workflow the nested dispatch executes for real. */
+async function createDispatchableWorkflow(
+  workflow: EmbeddedWorkflowService,
+  name: string
+): Promise<string> {
+  const created = await workflow.createWorkflow({
+    name,
+    nodes: [
+      {
+        id: 'sched',
+        name: 'Schedule Trigger',
+        type: 'workflows-nodes-base.scheduleTrigger',
+        typeVersion: 1.2,
+        position: [0, 0],
+        parameters: { intervalMs: 60_000 },
+      },
+      {
+        id: 'set',
+        name: 'Set',
+        type: 'workflows-nodes-base.set',
+        typeVersion: 3.4,
+        position: [200, 0],
+        parameters: { assignments: { assignments: [] } },
+      },
+    ],
+    connections: {
+      'Schedule Trigger': { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
+    },
+  });
+  return created.id;
+}
+
+/** The minimal owner-workflow definition the step args carry; only ownership
+ * defaults are read from it by contributions, none by dispatch_workflow. */
+function makeLifeOpsDefinition(): WorkflowStepExecuteArgs['definition'] {
+  return {
+    id: 'lifeops-wf-1',
+    agentId: 'agent',
+    domain: 'personal',
+    subjectType: 'agent',
+    subjectId: 'agent',
+    visibilityScope: 'owner_only',
+    contextPolicy: 'default',
+    title: 'Nested dispatch',
+    triggerType: 'manual',
+    schedule: { kind: 'manual' },
+    actionPlan: { steps: [] },
+    permissionPolicy: {
+      allowBrowserActions: false,
+      trustedBrowserActions: false,
+    },
+    status: 'active',
+    createdBy: 'user',
+    metadata: {},
+    createdAt: '2026-07-04T00:00:00.000Z',
+    updatedAt: '2026-07-04T00:00:00.000Z',
+  } as unknown as WorkflowStepExecuteArgs['definition'];
+}
+
+function makeStepArgs(overrides: Partial<WorkflowStepExecuteArgs> = {}): WorkflowStepExecuteArgs {
+  return {
+    definition: makeLifeOpsDefinition(),
+    startedAt: new Date().toISOString(),
+    confirmBrowserActions: false,
+    request: {},
+    outputs: {},
+    previousStepValue: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Execute one step the way `WorkflowsDomain.executeWorkflowDefinition` does:
+ * consult the runtime-bound registry, validate against the contribution's
+ * schema, then execute with the run args + service context.
+ */
+async function executeStepViaRegistry(
+  h: EmbeddedHarness,
+  step: Record<string, unknown>,
+  args: WorkflowStepExecuteArgs
+): Promise<unknown> {
+  const registry = getWorkflowStepRegistry(h.runtime);
+  if (!registry) throw new Error('registry not bound to runtime');
+  const contribution = registry.get(String(step.kind));
+  if (!contribution) throw new Error(`no contribution for kind ${step.kind}`);
+  const validated = contribution.paramSchema.parse(step);
+  const ctx = { runtime: h.runtime } as unknown as WorkflowStepExecuteContext;
+  return contribution.execute(validated, args, ctx);
+}
+
+describe('dispatch_workflow step e2e (LifeOps registry -> WORKFLOW_DISPATCH -> embedded execution)', () => {
+  let h: EmbeddedHarness;
+
+  beforeEach(async () => {
+    h = await makeEmbeddedHarness('dispatch-step-e2e-agent');
+    registerWorkflowDispatchService(h.runtime);
+    // The same wiring plugin-personal-assistant's init performs: default pack
+    // registered into a registry bound to this runtime.
+    const registry = createWorkflowStepRegistry();
+    registerDefaultWorkflowStepPack(registry);
+    registerWorkflowStepRegistry(h.runtime, registry);
+  });
+
+  afterEach(async () => {
+    await h.close();
+  });
+
+  test("(a) the step lands a real execution row and threads request + outputs into the nested run's triggerData", async () => {
+    const workflowId = await createDispatchableWorkflow(h.workflow, 'Nested digest');
+
+    const args = makeStepArgs({
+      request: { reason: 'parent-run' },
+      outputs: { calendar: { eventCount: 3 } },
+    });
+    const result = (await executeStepViaRegistry(
+      h,
+      {
+        kind: 'dispatch_workflow',
+        workflowId,
+        payload: { note: 'from-step' },
+      },
+      args
+    )) as WorkflowDispatchResult;
+
+    expect(result.ok).toBe(true);
+    expect(result.executionId).toBeDefined();
+
+    // Domain artifact: a real row in workflow.embedded_executions.
+    const { data: executions } = await h.workflow.listExecutions({
+      workflowId,
+    });
+    expect(executions).toHaveLength(1);
+    const execution = executions[0];
+    expect(execution.id).toBe(result.executionId as string);
+    expect(execution.status).toBe('success');
+    expect(execution.finished).toBe(true);
+    expect(execution.mode).toBe('trigger');
+
+    // The contribution's contract: step payload + parent request + accumulated
+    // outputs all arrive as the nested execution's trigger data.
+    const triggerData = execution.customData?.triggerData as Record<string, unknown>;
+    expect(triggerData).toMatchObject({
+      note: 'from-step',
+      request: { reason: 'parent-run' },
+      outputs: { calendar: { eventCount: 3 } },
+    });
+  });
+
+  test('(b) two step fires sharing an idempotency key collapse onto one execution row', async () => {
+    const workflowId = await createDispatchableWorkflow(h.workflow, 'Nested dedup');
+
+    const step = {
+      kind: 'dispatch_workflow',
+      workflowId,
+      // The dispatch layer's legacy payload contract: __idempotencyKey rides
+      // inside the payload when the caller cannot pass a second argument —
+      // exactly how a LifeOps step would express at-most-once semantics.
+      payload: { __idempotencyKey: 'step-fire-1' },
+    };
+
+    const first = (await executeStepViaRegistry(h, step, makeStepArgs())) as WorkflowDispatchResult;
+    const second = (await executeStepViaRegistry(
+      h,
+      step,
+      makeStepArgs()
+    )) as WorkflowDispatchResult;
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(second.dedup).toBe(true);
+    expect(second.executionId).toBe(first.executionId as string);
+
+    const { data: executions } = await h.workflow.listExecutions({
+      workflowId,
+    });
+    expect(executions).toHaveLength(1);
+  });
+
+  test('(c) missing WORKFLOW_DISPATCH service yields a structured failure and no execution', async () => {
+    const workflowId = await createDispatchableWorkflow(h.workflow, 'Nested orphan');
+    h.services.delete(WORKFLOW_DISPATCH_SERVICE_TYPE);
+
+    const result = (await executeStepViaRegistry(
+      h,
+      { kind: 'dispatch_workflow', workflowId },
+      makeStepArgs()
+    )) as { ok: boolean; error?: string };
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('WORKFLOW_DISPATCH service not registered');
+    const { data: executions } = await h.workflow.listExecutions({
+      workflowId,
+    });
+    expect(executions).toHaveLength(0);
+  });
+
+  test('(d) unknown workflowId is a structured failure from the real dispatch, not a throw', async () => {
+    const result = (await executeStepViaRegistry(
+      h,
+      { kind: 'dispatch_workflow', workflowId: 'no-such-workflow' },
+      makeStepArgs()
+    )) as WorkflowDispatchResult;
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+    const { data: executions } = await h.workflow.listExecutions({
+      workflowId: 'no-such-workflow',
+    });
+    expect(executions).toHaveLength(0);
+  });
+
+  test('(e) a step without workflowId fails schema validation before any dispatch', async () => {
+    // The dispatcher parses against the contribution's schema before execute;
+    // a malformed step must be rejected there, never reaching the service.
+    await expect(
+      executeStepViaRegistry(h, { kind: 'dispatch_workflow' }, makeStepArgs())
+    ).rejects.toThrow();
+  });
+});

--- a/plugins/plugin-workflow/__tests__/integration/embedded-harness.ts
+++ b/plugins/plugin-workflow/__tests__/integration/embedded-harness.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared PGlite-backed runtime harness for workflow integration e2e suites.
+ *
+ * Mirrors the harness pattern established in trigger-dispatch-e2e.test.ts: a
+ * runtime whose DB is a real PGlite instance and whose services registry is a
+ * real map, with the REAL EmbeddedWorkflowService started against it. The only
+ * test double is the runtime's task STORE (an in-memory map — same as
+ * workflow-task-worker.test.ts). Callers register whatever additional real
+ * services their suite drives (WORKFLOW_DISPATCH, WorkflowService, …) on the
+ * exposed `services` map.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PGlite } from '@electric-sql/pglite';
+import type { IAgentRuntime, Task, TaskWorker, UUID } from '@elizaos/core';
+import { stringToUuid } from '@elizaos/core';
+import { drizzle } from 'drizzle-orm/pglite';
+import * as dbSchema from '../../src/db/schema';
+import {
+  EMBEDDED_WORKFLOW_SERVICE_TYPE,
+  EmbeddedWorkflowService,
+} from '../../src/services/embedded-workflow-service';
+
+export interface EmbeddedHarness {
+  runtime: IAgentRuntime;
+  agentId: UUID;
+  tasks: Map<UUID, Task>;
+  /** The runtime's real service registry, exposed so suites can register the
+   * additional real services they exercise. */
+  services: Map<string, unknown[]>;
+  workflow: EmbeddedWorkflowService;
+  close: () => Promise<void>;
+}
+
+export async function makeEmbeddedHarness(agentSeed: string): Promise<EmbeddedHarness> {
+  const agentId = stringToUuid(agentSeed);
+  const dir = await mkdtemp(join(tmpdir(), 'workflow-e2e-'));
+  const client = new PGlite({ dataDir: join(dir, 'pglite') });
+  const db = drizzle(client, { schema: dbSchema });
+
+  const tasks = new Map<UUID, Task>();
+  const workers = new Map<string, TaskWorker>();
+  const services = new Map<string, unknown[]>();
+  let nextId = 1;
+
+  const runtime = {
+    agentId,
+    character: { settings: {} },
+    db,
+    serverless: true, // no scheduler loop; suites drive execution explicitly
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+    services,
+    getSetting: () => null,
+    getService: (type: string) => {
+      const entries = services.get(type);
+      return entries && entries.length > 0 ? entries[0] : null;
+    },
+    registerTaskWorker: (worker: TaskWorker) => {
+      workers.set(worker.name, worker);
+    },
+    getTaskWorker: (name: string) => workers.get(name),
+    createTask: async (task: Task) => {
+      const id = (task.id ?? stringToUuid(`${agentSeed}-task-${nextId++}`)) as UUID;
+      tasks.set(id, { ...task, id, agentId });
+      return id;
+    },
+    getTask: async (id: UUID) => tasks.get(id) ?? null,
+    getTasks: async (params: { tags?: string[] }) => {
+      const wanted = params?.tags ?? [];
+      return [...tasks.values()].filter((t) => wanted.every((tag) => t.tags?.includes(tag)));
+    },
+    getTasksByName: async (name: string) => [...tasks.values()].filter((t) => t.name === name),
+    updateTask: async (id: UUID, patch: Partial<Task>) => {
+      const existing = tasks.get(id);
+      if (existing) tasks.set(id, { ...existing, ...patch });
+    },
+    deleteTask: async (id: UUID) => {
+      tasks.delete(id);
+    },
+  } as unknown as IAgentRuntime;
+
+  const workflow = await EmbeddedWorkflowService.start(runtime);
+  services.set(EMBEDDED_WORKFLOW_SERVICE_TYPE, [workflow]);
+
+  return {
+    runtime,
+    agentId,
+    tasks,
+    services,
+    workflow,
+    async close() {
+      await client.close();
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}

--- a/plugins/plugin-workflow/__tests__/integration/workflow-action-run-e2e.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/workflow-action-run-e2e.test.ts
@@ -1,0 +1,200 @@
+/**
+ * #12362 WI-7 residual — the WORKFLOW action's `run` op executes a workflow
+ * for real, keylessly (no model, no API key): action handler →
+ * WorkflowService.runWorkflow → EmbeddedWorkflowService → a row in
+ * workflow.embedded_executions.
+ *
+ * Complements the mocked-unit coverage in
+ * __tests__/unit/workflow-action.test.ts (op dispatch against a mocked
+ * service) and the live-only scenario
+ * packages/scenario-runner/test/scenarios/live-workflow-action-executions.scenario.ts
+ * (model routing): here the service stack under the action is entirely REAL —
+ * a real WorkflowService started via WorkflowService.start() over a real
+ * PGlite-backed EmbeddedWorkflowService. No workflow-service mocks.
+ *
+ * Cases:
+ *   (a) run op → real execution row, asserted through the same real service
+ *       layer the executions op reads (listExecutions)
+ *   (b) a workflow whose node throws → success:false result AND a real
+ *       error-status execution row (throwOnError:false path)
+ *   (c) missing workflowId → structured failure, nothing executed
+ *   (d) unknown workflowId → structured failure from the real store
+ *   (e) validate() gates on the real service registration
+ */
+
+import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from 'bun:test';
+import type { HandlerCallback, HandlerOptions, IAgentRuntime, Memory } from '@elizaos/core';
+import { workflowAction } from '../../src/actions/workflow';
+import type { EmbeddedWorkflowService } from '../../src/services/embedded-workflow-service';
+import { WORKFLOW_SERVICE_TYPE, WorkflowService } from '../../src/services/workflow-service';
+import type { WorkflowExecution } from '../../src/types/index';
+import { type EmbeddedHarness, makeEmbeddedHarness } from './embedded-harness';
+
+setDefaultTimeout(60_000);
+
+const message = { entityId: 'owner-test' } as Memory;
+
+interface ActionHarness extends EmbeddedHarness {
+  service: WorkflowService;
+}
+
+async function makeActionHarness(): Promise<ActionHarness> {
+  const h = await makeEmbeddedHarness('workflow-action-run-agent');
+  // The REAL service the action resolves — started keylessly the same way the
+  // plugin's service lifecycle does; it adopts the registered embedded engine.
+  const service = await WorkflowService.start(h.runtime);
+  h.services.set(WORKFLOW_SERVICE_TYPE, [service]);
+  return { ...h, service };
+}
+
+async function runOp(
+  runtime: IAgentRuntime,
+  parameters: Record<string, unknown>,
+  callback?: HandlerCallback
+) {
+  if (!workflowAction.handler) throw new Error('workflow action missing handler');
+  return workflowAction.handler(
+    runtime,
+    message,
+    undefined,
+    { parameters } as HandlerOptions,
+    callback
+  );
+}
+
+/** A manual-trigger workflow; `run` executes in manual mode. */
+async function createManualWorkflow(
+  workflow: EmbeddedWorkflowService,
+  name: string,
+  secondNode: { type: string; parameters: Record<string, unknown> }
+): Promise<string> {
+  const created = await workflow.createWorkflow({
+    name,
+    nodes: [
+      {
+        id: 'manual',
+        name: 'Manual Trigger',
+        type: 'workflows-nodes-base.manualTrigger',
+        typeVersion: 1,
+        position: [0, 0],
+        parameters: {},
+      },
+      {
+        id: 'work',
+        name: 'Work',
+        type: secondNode.type,
+        typeVersion: 1,
+        position: [200, 0],
+        parameters: secondNode.parameters,
+      },
+    ],
+    connections: {
+      'Manual Trigger': { main: [[{ node: 'Work', type: 'main', index: 0 }]] },
+    },
+  });
+  return created.id;
+}
+
+describe('WORKFLOW action run op e2e (real WorkflowService + embedded engine, keyless)', () => {
+  let h: ActionHarness;
+
+  beforeEach(async () => {
+    h = await makeActionHarness();
+  });
+
+  afterEach(async () => {
+    await h.service.stop();
+    await h.close();
+  });
+
+  test('(a) run executes the workflow and a real execution row is readable back through the service', async () => {
+    const workflowId = await createManualWorkflow(h.workflow, 'Run me', {
+      type: 'workflows-nodes-base.set',
+      parameters: { assignments: { assignments: [] } },
+    });
+
+    const callbackContents: Array<Record<string, unknown>> = [];
+    const callback: HandlerCallback = async (content) => {
+      callbackContents.push(content as Record<string, unknown>);
+      return [];
+    };
+
+    const result = await runOp(h.runtime, { action: 'run', workflowId }, callback);
+
+    expect(result.success).toBe(true);
+    expect(result.values?.status).toBe('success');
+    const executionId = result.values?.executionId as string;
+    expect(executionId).toBeDefined();
+
+    // The user-facing callback reported the same real execution.
+    expect(callbackContents).toHaveLength(1);
+    expect(callbackContents[0].metadata).toMatchObject({
+      workflowId,
+      executionId,
+      status: 'success',
+    });
+
+    // Domain artifact through the SAME real service layer the executions op
+    // uses: a finished manual-mode row in workflow.embedded_executions.
+    const { data: executions } = await h.service.listExecutions({ workflowId });
+    expect(executions).toHaveLength(1);
+    const execution = executions[0];
+    expect(execution.id).toBe(executionId);
+    expect(execution.status).toBe('success');
+    expect(execution.finished).toBe(true);
+    expect(execution.mode).toBe('manual');
+  });
+
+  test('(b) a workflow whose node throws yields success:false AND a real error-status execution row', async () => {
+    const workflowId = await createManualWorkflow(h.workflow, 'Run me broken', {
+      type: 'workflows-nodes-base.code',
+      parameters: { jsCode: 'throw new Error("boom")' },
+    });
+
+    const result = await runOp(h.runtime, { action: 'run', workflowId });
+
+    expect(result.success).toBe(false);
+    expect(result.values?.status).toBe('error');
+
+    // The failed run is still a persisted domain artifact (throwOnError:false
+    // records the error execution instead of raising).
+    const { data: executions } = await h.service.listExecutions({ workflowId });
+    expect(executions).toHaveLength(1);
+    expect(executions[0].status).toBe('error');
+    expect(executions[0].finished).toBe(true);
+    // The persisted diagnostics name the failing node (the embedded engine
+    // echoes the node failure ahead of Smithers' wrapper error).
+    const runError = (executions[0] as WorkflowExecution).data?.resultData?.error as
+      | { message?: string }
+      | undefined;
+    expect(runError?.message ?? '').toContain('Node "Work" failed');
+  });
+
+  test('(c) run without workflowId is a structured failure and executes nothing', async () => {
+    const result = await runOp(h.runtime, { action: 'run' });
+    expect(result.success).toBe(false);
+    expect(result.text).toBe('workflowId is required to run a workflow.');
+
+    const { data: executions } = await h.service.listExecutions();
+    expect(executions).toHaveLength(0);
+  });
+
+  test("(d) run with an unknown workflowId surfaces the real store's not-found failure", async () => {
+    const result = await runOp(h.runtime, {
+      action: 'run',
+      workflowId: 'no-such-workflow',
+    });
+    expect(result.success).toBe(false);
+    expect(result.text).toMatch(/not found/i);
+
+    const { data: executions } = await h.service.listExecutions();
+    expect(executions).toHaveLength(0);
+  });
+
+  test('(e) validate() reflects real service registration', async () => {
+    if (!workflowAction.validate) throw new Error('workflow action missing validate');
+    expect(await workflowAction.validate(h.runtime, message, undefined)).toBe(true);
+    h.services.delete(WORKFLOW_SERVICE_TYPE);
+    expect(await workflowAction.validate(h.runtime, message, undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
Part of #12362 (parent #12177 WI-6/WI-7). Companion to the merged #12913/#12385 coverage — this PR adds the two remaining test gaps:

- **`dispatch_workflow` workflow-step e2e**: drives the LifeOps workflow-step registry's `kind:"dispatch_workflow"` step through a real `WORKFLOW_DISPATCH` service to a real embedded workflow execution row (no mocks of workflow services).
- **Keyless WORKFLOW action `run` op integration test**: real WorkflowService + EmbeddedWorkflowService registered; the action handler's `run` op produces a real execution row via `listExecutions`.

Coordinator note: the implementing agent was interrupted by session limits after committing; this PR was opened by the wave coordinator from the agent's lane. The commit's suites were green at commit time per the in-lane logs; the wave's cross-reviewer will independently re-run the gates (`bun run --cwd plugins/plugin-workflow test`, PA step-test suite, verify chain) before merge and post results on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)