### PR TITLE
fix(#12748): hyperliquid execution-check POST fails closed on unparseable body

### DIFF
--- a/plugins/plugin-hyperliquid/src/hyperliquid-command-client.test.ts
+++ b/plugins/plugin-hyperliquid/src/hyperliquid-command-client.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Error-path tests for `postHyperliquidCommand` (the Hyperliquid execution-check
+ * POST client). This is a market-mutation-adjacent path that POSTs to
+ * `/api/hyperliquid/orders/open`; the regression under test is that an
+ * unparseable provider response body must NOT be swallowed into a fabricated
+ * success object (the previous `response.json().catch(() => ({}))` turned an
+ * unreadable 2xx body into a fake successful execution result). `fetch` is
+ * mocked; no live Hyperliquid API calls.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { postHyperliquidCommand } from "./hyperliquid-command-client";
+
+const PATH = "/api/hyperliquid/orders/open";
+const BODY = { coin: "BTC", side: "buy", size: "0" };
+
+function stubFetch(response: {
+	ok: boolean;
+	status: number;
+	json: () => Promise<unknown>;
+}): void {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async () => response as unknown as Response),
+	);
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe("postHyperliquidCommand fail-closed contract", () => {
+	it("returns the parsed body on a 2xx response with a valid JSON body", async () => {
+		stubFetch({
+			ok: true,
+			status: 200,
+			json: async () => ({ accepted: true, orderId: "abc" }),
+		});
+		await expect(postHyperliquidCommand(PATH, BODY)).resolves.toEqual({
+			accepted: true,
+			orderId: "abc",
+		});
+	});
+
+	it("throws (never fabricates a {} success) on a 2xx response with an unparseable body", async () => {
+		stubFetch({
+			ok: true,
+			status: 200,
+			json: async () => {
+				throw new SyntaxError("Unexpected end of JSON input");
+			},
+		});
+		await expect(postHyperliquidCommand(PATH, BODY)).rejects.toThrow(
+			/unreadable response body/i,
+		);
+	});
+
+	it("surfaces the provider error message on a non-ok response with a parseable {error} body", async () => {
+		stubFetch({
+			ok: false,
+			status: 501,
+			json: async () => ({ error: "execution disabled" }),
+		});
+		await expect(postHyperliquidCommand(PATH, BODY)).rejects.toThrow(
+			"execution disabled",
+		);
+	});
+
+	it("names the unparseable body on a non-ok response with an unparseable body", async () => {
+		stubFetch({
+			ok: false,
+			status: 502,
+			json: async () => {
+				throw new SyntaxError("Unexpected token < in JSON");
+			},
+		});
+		await expect(postHyperliquidCommand(PATH, BODY)).rejects.toThrow(
+			/failed with 502 \(unparseable error body\)/i,
+		);
+	});
+
+	it("preserves the parse error as the thrown error's cause on a non-ok unparseable body", async () => {
+		const cause = new SyntaxError("boom");
+		stubFetch({
+			ok: false,
+			status: 500,
+			json: async () => {
+				throw cause;
+			},
+		});
+		await expect(postHyperliquidCommand(PATH, BODY)).rejects.toMatchObject({
+			cause,
+		});
+	});
+
+	it("falls back to a status message on a non-ok response whose parseable body has no error string", async () => {
+		stubFetch({
+			ok: false,
+			status: 500,
+			json: async () => ({ someOtherShape: 1 }),
+		});
+		await expect(postHyperliquidCommand(PATH, BODY)).rejects.toThrow(
+			/Hyperliquid request failed with 500/,
+		);
+	});
+});

--- a/plugins/plugin-hyperliquid/src/hyperliquid-command-client.ts
+++ b/plugins/plugin-hyperliquid/src/hyperliquid-command-client.ts
@@ -1,0 +1,69 @@
+/**
+ * POST client for Hyperliquid command endpoints, backing the view-bundle
+ * `interact` handler's `terminal-hyperliquid-execution-check` capability (POST
+ * /api/hyperliquid/orders/open and siblings). Kept in its own dependency-light
+ * module with no `@elizaos/ui`/view imports so it resolves and unit-tests in
+ * isolation. Because these are market-mutation-adjacent execution requests,
+ * response handling must fail closed: a truncated/unparseable body is a
+ * provider failure, never a fabricated successful-execution result the
+ * caller/model would trust.
+ */
+
+/**
+ * POST a command to a Hyperliquid route and return the parsed JSON body.
+ *
+ * Fail-closed contract:
+ * - Non-ok response with a parseable `{ error: string }` body -> throw that error.
+ * - Non-ok response with an unparseable body -> throw a status error that names
+ *   the unparseable body (the transport failure is not masked).
+ * - Ok response with an unparseable body -> throw a distinct provider-failure
+ *   error. It must NOT return a fabricated `{}` that the caller/model would read
+ *   as a successful execution.
+ */
+export async function postHyperliquidCommand(
+	path: string,
+	body: Record<string, unknown>,
+): Promise<unknown> {
+	const response = await fetch(path, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	});
+	let parsed: unknown;
+	let parseFailed = false;
+	try {
+		parsed = await response.json();
+	} catch (cause) {
+		// error-policy:J3 untrusted provider body — record the parse failure as an
+		// explicit "invalid" signal instead of substituting a fake-valid {} object.
+		parseFailed = true;
+		parsed = undefined;
+		if (!response.ok) {
+			// non-ok + unparseable: surface a boundary failure that keeps the parse
+			// cause so the transport failure is not masked by a bare status.
+			throw new Error(
+				`Hyperliquid request failed with ${response.status} (unparseable error body)`,
+				{ cause },
+			);
+		}
+	}
+	if (!response.ok) {
+		const message =
+			typeof parsed === "object" &&
+			parsed !== null &&
+			"error" in parsed &&
+			typeof (parsed as { error: unknown }).error === "string"
+				? (parsed as { error: string }).error
+				: `Hyperliquid request failed with ${response.status}`;
+		throw new Error(message);
+	}
+	if (parseFailed) {
+		// error-policy:J1 transport boundary — a 2xx with an unparseable body is a
+		// provider failure on an execution-check path; fail closed rather than
+		// returning a fabricated-success empty result the caller/model would trust.
+		throw new Error(
+			"Hyperliquid returned an unreadable response body for a market execution request",
+		);
+	}
+	return parsed;
+}

--- a/plugins/plugin-hyperliquid/src/hyperliquid-interact.ts
+++ b/plugins/plugin-hyperliquid/src/hyperliquid-interact.ts
@@ -7,6 +7,7 @@
 import { client } from "@elizaos/app-core";
 import "./client";
 import type { HyperliquidClient } from "./client";
+import { postHyperliquidCommand } from "./hyperliquid-command-client";
 import type {
 	HyperliquidMarketsResponse,
 	HyperliquidOrdersResponse,
@@ -31,29 +32,6 @@ export async function loadHyperliquidTuiState(): Promise<{
 		hyperliquidClient.hyperliquidOrders(),
 	]);
 	return { status, markets, positions, orders };
-}
-
-async function postHyperliquidCommand(
-	path: string,
-	body: Record<string, unknown>,
-): Promise<unknown> {
-	const response = await fetch(path, {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify(body),
-	});
-	const data = await response.json().catch(() => ({}));
-	if (!response.ok) {
-		const message =
-			typeof data === "object" &&
-			data !== null &&
-			"error" in data &&
-			typeof data.error === "string"
-				? data.error
-				: `Hyperliquid request failed with ${response.status}`;
-		throw new Error(message);
-	}
-	return data;
 }
 
 export async function interact(


### PR DESCRIPTION
## Summary
Market fail-closed slice of the #12275-J social/media/market/safety non-route sweep (part of #12748), following PR #13136's polymarket slice. Fixes fabricated-success handling of unparseable provider responses on a Hyperliquid market-execution path.

## The slop
`postHyperliquidCommand` — the client behind the `terminal-hyperliquid-execution-check` capability, which POSTs to `/api/hyperliquid/orders/open` — used:

```ts
const data = await response.json().catch(() => ({}));
```

On a **2xx response with a truncated/unparseable body**, `data` became `{}` and was returned as a **successful market-execution result**. A caller/model reading that empty object could not distinguish a real successful execution from an unreadable provider response — a fabricated success on a market-mutation-adjacent path. On a **non-ok response with an unparseable body**, the bare status message masked the transport failure.

## The fix
`plugins/plugin-hyperliquid/src/hyperliquid-command-client.ts` (extracted into a dependency-light module — no `@elizaos/ui`/view imports — so it resolves and unit-tests in isolation):

- **ok + unparseable body** → throw a distinct provider-failure error (`error-policy:J1` transport boundary). Never a fabricated `{}` success.
- **non-ok + unparseable body** → throw a status error that names the unparseable body and carries the parse error as `cause` (`error-policy:J3`).
- **non-ok + parseable `{error}` body** → surface the provider message (unchanged).
- **ok + parseable body** → return it (unchanged).

`hyperliquid-interact.ts` now imports the extracted client. `src/routes/**` untouched (owned by #12275-F).

## Tests
New `hyperliquid-command-client.test.ts`, **6/6 green**, covering:
- valid-body pass-through
- **ok + unparseable → throws (never fabricates `{}` success)**
- non-ok + parseable `{error}` → provider message surfaced
- non-ok + unparseable → status error names the unparseable body
- non-ok + unparseable → parse error preserved as `cause`
- non-ok + parseable-without-error → status-message fallback

## Verification
- Targeted vitest: 6/6 green.
- Full plugin suite: same **7 pre-existing dist-less environment FAILs as pristine develop** (verified via `git stash` — those `.tsx`/route suites can't resolve `@elizaos/ui`/`@elizaos/tui` in the dist-less lane); my new suite adds +6 passing.
- `tsgo` typecheck: **identical 15 baseline errors** vs pristine develop (all pre-existing missing-`@elizaos/ui`/`@elizaos/app-core` dist), **zero in the touched module**.
- `biome check`: clean.
- `audit:error-policy-ratchet`: clean, 2 changed production files, no new fallback-slop.
- codex review: functional change confirmed fail-closed with tests covering intended paths; single P3 header-format finding addressed.

— [sol-orch]
