### PR TITLE
fix(#12680): route builtin surfaces via a single tab registry, not parallel name-keyed if-chains

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -172,6 +172,10 @@ import {
   listAppShellPages,
   subscribeAppShellPages,
 } from "./app-shell-registry";
+import {
+  resolveBuiltinBackgroundPolicy,
+  resolveBuiltinTabId,
+} from "./builtin-tab-registry";
 // DesktopTabBar and FineTuningView stay static: they are already pulled
 // eagerly elsewhere in the app graph (plugin-loader / boot-config), so a
 // lazy() boundary here would only fold back into main. The remaining page
@@ -802,12 +806,13 @@ function builtinRouteBackgroundPolicy(
   tab: string,
   navigationPath: string,
 ): AppShellBackgroundPolicy | null {
-  const normalizedPath = trimmedNavigationPath(navigationPath);
-  if (tab === "chat" || tab === "background") return "shared";
-  if (tab === "settings") return "shared";
-  if (tab === "views" && normalizedPath === "/views") return "shared";
-  if (tab === "apps" && normalizedPath === "/apps") return "shared";
-  return null;
+  // Data-driven lookup over the single builtin-tab registry (see
+  // builtin-tab-registry.ts) — replaces the former per-tab if-chain that ran
+  // parallel to the router's own tab enumeration and could silently drift.
+  return resolveBuiltinBackgroundPolicy(
+    tab,
+    trimmedNavigationPath(navigationPath),
+  );
 }
 
 function resolveActiveScreenBackgroundPolicy({
@@ -1132,6 +1137,105 @@ function renderAppsSurface(navigationPath: string): ReactNode {
   );
 }
 
+/** Runtime context a builtin static-tab renderer may read. */
+interface StaticTabRenderContext {
+  nativeOsSurfaceEnabled: boolean;
+  navigationPath: string;
+  settingsInitialSection?: string | null;
+  walletNav?: ReactNode;
+}
+
+/**
+ * The single builtin static-tab render registry: canonical-id -> renderer.
+ *
+ * This replaces the former split between a `directViews` object literal and a
+ * trailing `if (tab === "...")` chain (App.tsx audit item #34). Both were
+ * hand-maintained tab enumerations sitting next to a SECOND enumeration in
+ * `builtinRouteBackgroundPolicy`; a tab added to one and forgotten in another
+ * was an unobservable drift bug. Now every builtin surface (simple or one that
+ * needs runtime context / a custom wrapper) is ONE keyed entry, and alias tabs
+ * (`triggers` -> `automations`, `advanced` -> `fine-tuning`) resolve through
+ * the shared `builtin-tab-registry` so the router and the background resolver
+ * read the same alias table.
+ *
+ * Built lazily per-call (not a module constant) because several renderers close
+ * over per-render context (settings section, wallet nav, native-surface gate).
+ */
+function buildStaticTabRenderers(): Record<
+  string,
+  (ctx: StaticTabRenderContext) => ReactNode
+> {
+  const wrap = (node: ReactNode) => () => (
+    <TabContentView>{node}</TabContentView>
+  );
+  return {
+    tutorial: wrap(<TutorialView />),
+    help: wrap(<HelpView />),
+    chat: () => <ViewUnavailableFallback />,
+    browser: () => <BrowserWorkspaceView />,
+    stream: () => <StreamView />,
+    tasks: wrap(<TasksPageView />),
+    automations: () => <AutomationsFeed />,
+    plugins: wrap(<PluginsPageView />),
+    skills: wrap(<SkillsView />),
+    trajectories: wrap(<TrajectoriesView />),
+    transcripts: wrap(<TranscriptsPageView />),
+    relationships: wrap(<RelationshipsView />),
+    documents: wrap(<KnowledgeView />),
+    experience: wrap(<CharacterExperienceView />),
+    "character-skills": wrap(<CharacterSkillsView />),
+    memories: wrap(<MemoryViewerView />),
+    files: () => (
+      <TabScrollView>
+        <FilesView />
+      </TabScrollView>
+    ),
+    runtime: wrap(<RuntimeView />),
+    database: wrap(<DatabasePageView />),
+    logs: wrap(<LogsView />),
+    desktop: wrap(<DesktopWorkspaceSection />),
+    settings: ({ settingsInitialSection }) => (
+      <TabContentView surface="transparent">
+        <SettingsView
+          key="settings-root"
+          initialSection={settingsInitialSection ?? undefined}
+        />
+      </TabContentView>
+    ),
+    // Camera is an AOSP-ElizaOS-fork-only surface — gate the route on the same
+    // marker as the home tile, so a deep-link off the fork falls back to
+    // "unavailable" instead of rendering on web/desktop/iOS/Play-Store Android.
+    camera: () => renderPhoneSurface(isAospShellEnabled(), CameraPageView),
+    phone: ({ nativeOsSurfaceEnabled }) =>
+      renderPhoneSurface(nativeOsSurfaceEnabled, PhonePageView),
+    messages: ({ nativeOsSurfaceEnabled }) =>
+      renderPhoneSurface(nativeOsSurfaceEnabled, MessagesPageView),
+    contacts: ({ nativeOsSurfaceEnabled }) =>
+      renderPhoneSurface(nativeOsSurfaceEnabled, ContactsPageView),
+    views: ({ navigationPath }) => renderAppsSurface(navigationPath),
+    apps: ({ navigationPath }) => renderAppsSurface(navigationPath),
+    // Rendered directly (no opaque TabContentView chrome) so the live app
+    // background shows through behind the controls.
+    background: () => <BackgroundView />,
+    character: () => (
+      <TabContentView>
+        <CharacterEditor />
+      </TabContentView>
+    ),
+    "character-select": () => (
+      <TabContentView>
+        <CharacterEditor />
+      </TabContentView>
+    ),
+    inventory: ({ walletNav }) => (
+      <TabScrollView nav={walletNav}>
+        <WalletInventoryPage />
+      </TabScrollView>
+    ),
+    "fine-tuning": wrap(<FineTuningView />),
+  };
+}
+
 function renderStaticViewRouterTab({
   tab,
   nativeOsSurfaceEnabled,
@@ -1145,151 +1249,20 @@ function renderStaticViewRouterTab({
   settingsInitialSection?: string | null;
   walletNav?: ReactNode;
 }): ReactNode {
-  const directViews: Record<string, ReactNode> = {
-    tutorial: (
-      <TabContentView>
-        <TutorialView />
-      </TabContentView>
-    ),
-    help: (
-      <TabContentView>
-        <HelpView />
-      </TabContentView>
-    ),
-    chat: <ViewUnavailableFallback />,
-    browser: <BrowserWorkspaceView />,
-    stream: <StreamView />,
-    tasks: (
-      <TabContentView>
-        <TasksPageView />
-      </TabContentView>
-    ),
-    automations: <AutomationsFeed />,
-    triggers: <AutomationsFeed />,
-    settings: (
-      <TabContentView surface="transparent">
-        <SettingsView
-          key="settings-root"
-          initialSection={settingsInitialSection ?? undefined}
-        />
-      </TabContentView>
-    ),
-    plugins: (
-      <TabContentView>
-        <PluginsPageView />
-      </TabContentView>
-    ),
-    skills: (
-      <TabContentView>
-        <SkillsView />
-      </TabContentView>
-    ),
-    trajectories: (
-      <TabContentView>
-        <TrajectoriesView />
-      </TabContentView>
-    ),
-    transcripts: (
-      <TabContentView>
-        <TranscriptsPageView />
-      </TabContentView>
-    ),
-    relationships: (
-      <TabContentView>
-        <RelationshipsView />
-      </TabContentView>
-    ),
-    documents: (
-      <TabContentView>
-        <KnowledgeView />
-      </TabContentView>
-    ),
-    experience: (
-      <TabContentView>
-        <CharacterExperienceView />
-      </TabContentView>
-    ),
-    "character-skills": (
-      <TabContentView>
-        <CharacterSkillsView />
-      </TabContentView>
-    ),
-    memories: (
-      <TabContentView>
-        <MemoryViewerView />
-      </TabContentView>
-    ),
-    files: (
-      <TabScrollView>
-        <FilesView />
-      </TabScrollView>
-    ),
-    runtime: (
-      <TabContentView>
-        <RuntimeView />
-      </TabContentView>
-    ),
-    database: (
-      <TabContentView>
-        <DatabasePageView />
-      </TabContentView>
-    ),
-    logs: (
-      <TabContentView>
-        <LogsView />
-      </TabContentView>
-    ),
-    desktop: (
-      <TabContentView>
-        <DesktopWorkspaceSection />
-      </TabContentView>
-    ),
-  };
-  if (tab === "camera") {
-    // Camera is an AOSP-ElizaOS-fork-only surface — gate the route on the same
-    // marker as the home tile, so a deep-link off the fork falls back to
-    // "unavailable" instead of rendering on web/desktop/iOS/Play-Store Android.
-    return renderPhoneSurface(isAospShellEnabled(), CameraPageView);
+  // Resolve legacy alias ids (e.g. `triggers` -> `automations`, `advanced` ->
+  // `fine-tuning`) onto their canonical builtin id via the shared registry, so
+  // the router and background resolver honor the same alias table.
+  const canonicalTab = resolveBuiltinTabId(tab);
+  const render = buildStaticTabRenderers()[canonicalTab];
+  if (render) {
+    return render({
+      nativeOsSurfaceEnabled,
+      navigationPath,
+      settingsInitialSection,
+      walletNav,
+    });
   }
-  if (tab === "phone") {
-    return renderPhoneSurface(nativeOsSurfaceEnabled, PhonePageView);
-  }
-  if (tab === "messages") {
-    return renderPhoneSurface(nativeOsSurfaceEnabled, MessagesPageView);
-  }
-  if (tab === "contacts") {
-    return renderPhoneSurface(nativeOsSurfaceEnabled, ContactsPageView);
-  }
-  if (tab === "views" || tab === "apps") {
-    return renderAppsSurface(navigationPath);
-  }
-  if (tab === "background") {
-    // Rendered directly (no opaque TabContentView chrome) so the live app
-    // background shows through behind the controls.
-    return <BackgroundView />;
-  }
-  if (tab === "character" || tab === "character-select") {
-    return (
-      <TabContentView>
-        <CharacterEditor />
-      </TabContentView>
-    );
-  }
-  if (tab === "inventory") {
-    return (
-      <TabScrollView nav={walletNav}>
-        <WalletInventoryPage />
-      </TabScrollView>
-    );
-  }
-  if (tab === "fine-tuning" || tab === "advanced") {
-    return (
-      <TabContentView>
-        <FineTuningView />
-      </TabContentView>
-    );
-  }
-  return directViews[tab] ?? <ViewUnavailableFallback />;
+  return <ViewUnavailableFallback />;
 }
 
 function renderViewRouterContent({

--- a/packages/ui/src/builtin-tab-registry.test.ts
+++ b/packages/ui/src/builtin-tab-registry.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit + drift-guard coverage for the builtin static-tab registry that owns
+ * (a) the router's canonical-id / alias resolution and (b) the builtin-level
+ * screen background policy — the two enumerations that used to live as parallel
+ * name-keyed if-chains in App.tsx (audit item #34, #12680).
+ *
+ * These tests pin the exact legacy behavior of `builtinRouteBackgroundPolicy`
+ * and the router's alias handling, and a grep-guard proves the old central
+ * if-chains are gone from App.tsx's executable paths.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  BUILTIN_TAB_METADATA,
+  resolveBuiltinBackgroundPolicy,
+  resolveBuiltinTabId,
+} from "./builtin-tab-registry";
+
+describe("builtin-tab-registry: table integrity", () => {
+  it("has unique canonical ids and no id/alias collisions", () => {
+    const seen = new Set<string>();
+    for (const entry of BUILTIN_TAB_METADATA) {
+      expect(seen.has(entry.id), `duplicate id ${entry.id}`).toBe(false);
+      seen.add(entry.id);
+      for (const alias of entry.aliases ?? []) {
+        expect(
+          seen.has(alias),
+          `alias ${alias} collides with an existing id/alias`,
+        ).toBe(false);
+        seen.add(alias);
+      }
+    }
+  });
+
+  it("every alias resolves to its canonical owner id", () => {
+    for (const entry of BUILTIN_TAB_METADATA) {
+      for (const alias of entry.aliases ?? []) {
+        expect(resolveBuiltinTabId(alias)).toBe(entry.id);
+      }
+    }
+  });
+});
+
+describe("resolveBuiltinTabId: alias resolution", () => {
+  it("maps the known legacy aliases onto canonical ids", () => {
+    expect(resolveBuiltinTabId("triggers")).toBe("automations");
+    expect(resolveBuiltinTabId("advanced")).toBe("fine-tuning");
+  });
+
+  it("returns canonical ids unchanged", () => {
+    expect(resolveBuiltinTabId("automations")).toBe("automations");
+    expect(resolveBuiltinTabId("fine-tuning")).toBe("fine-tuning");
+    expect(resolveBuiltinTabId("settings")).toBe("settings");
+  });
+
+  it("passes non-builtin / plugin tab ids straight through", () => {
+    expect(resolveBuiltinTabId("some-plugin-tab")).toBe("some-plugin-tab");
+    expect(resolveBuiltinTabId("")).toBe("");
+  });
+});
+
+describe("resolveBuiltinBackgroundPolicy: legacy parity", () => {
+  // Golden table mirroring the pre-refactor builtinRouteBackgroundPolicy chain:
+  //   chat / background       -> "shared"
+  //   settings                -> "shared"
+  //   views  && path==/views  -> "shared"
+  //   apps   && path==/apps   -> "shared"
+  //   otherwise               -> null (fall through to downstream resolution)
+  it.each([
+    ["chat", "/chat", "shared"],
+    ["chat", "/anything", "shared"],
+    ["background", "/background", "shared"],
+    ["settings", "/settings", "shared"],
+  ] as const)("%s @ %s -> %s (unconditional shared)", (tab, path, expected) => {
+    expect(resolveBuiltinBackgroundPolicy(tab, path)).toBe(expected);
+  });
+
+  it("views is shared only at /views, else null", () => {
+    expect(resolveBuiltinBackgroundPolicy("views", "/views")).toBe("shared");
+    expect(resolveBuiltinBackgroundPolicy("views", "/views/thing")).toBeNull();
+  });
+
+  it("apps is shared only at /apps, else null", () => {
+    expect(resolveBuiltinBackgroundPolicy("apps", "/apps")).toBe("shared");
+    expect(resolveBuiltinBackgroundPolicy("apps", "/apps/tasks")).toBeNull();
+  });
+
+  it.each([
+    ["voice", "/voice"],
+    ["files", "/apps/files"],
+    ["memories", "/apps/memories"],
+    ["some-plugin-tab", "/plugin"],
+    ["triggers", "/automations"],
+  ] as const)("%s @ %s -> null (no builtin policy)", (tab, path) => {
+    expect(resolveBuiltinBackgroundPolicy(tab, path)).toBeNull();
+  });
+});
+
+describe("App.tsx drift guard: legacy central enumerations removed", () => {
+  const appSource = readFileSync(
+    fileURLToPath(new URL("./App.tsx", import.meta.url)),
+    "utf8",
+  );
+
+  it("builtinRouteBackgroundPolicy no longer inlines the per-tab if-chain", () => {
+    // The background resolver must delegate to the registry, not re-derive
+    // policy from `tab === "..."` string branches.
+    const fnStart = appSource.indexOf("function builtinRouteBackgroundPolicy(");
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnBody = appSource.slice(fnStart, fnStart + 600);
+    expect(fnBody).toContain("resolveBuiltinBackgroundPolicy");
+    expect(fnBody).not.toContain('tab === "chat"');
+    expect(fnBody).not.toContain('tab === "settings"');
+    expect(fnBody).not.toContain('tab === "views"');
+    expect(fnBody).not.toContain('tab === "apps"');
+  });
+
+  it("renderStaticViewRouterTab routes via a keyed registry, not the alias if-chain", () => {
+    const fnStart = appSource.indexOf("function renderStaticViewRouterTab(");
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnBody = appSource.slice(fnStart, fnStart + 900);
+    expect(fnBody).toContain("resolveBuiltinTabId");
+    expect(fnBody).toContain("buildStaticTabRenderers()");
+    // The alias / special-surface if-chain that lived at the tail of the old
+    // renderStaticViewRouterTab is gone from its body.
+    expect(fnBody).not.toContain('tab === "fine-tuning" || tab === "advanced"');
+    expect(fnBody).not.toContain(
+      'tab === "character" || tab === "character-select"',
+    );
+    expect(fnBody).not.toContain('tab === "views" || tab === "apps"');
+  });
+});

--- a/packages/ui/src/builtin-tab-registry.ts
+++ b/packages/ui/src/builtin-tab-registry.ts
@@ -1,0 +1,137 @@
+import type { AppShellBackgroundPolicy } from "@elizaos/core";
+
+/**
+ * Declarative registry for the app's builtin (host-owned) tab surfaces.
+ *
+ * Historically `App.tsx` routed builtin surfaces through TWO parallel,
+ * hand-maintained name-keyed enumerations that could silently drift:
+ *
+ *  1. `renderStaticViewRouterTab` — a `directViews` object literal plus a chain
+ *     of `if (tab === "...")` branches deciding which component + wrapper each
+ *     builtin tab renders (App.tsx item #34, target line ~1218).
+ *  2. `builtinRouteBackgroundPolicy` — a second `if (tab === "...")` chain
+ *     deciding each builtin tab's screen background policy (target line ~770).
+ *
+ * A tab present in one chain but absent (or aliased differently) in the other
+ * was an unobservable drift bug: e.g. a builtin surface that renders fine but
+ * paints the wrong background layer, or an alias (`advanced` -> `fine-tuning`)
+ * honored by the router but not the background resolver.
+ *
+ * This module is the single source of truth for builtin-tab METADATA: the
+ * canonical id, any legacy aliases that resolve onto it, and its background
+ * policy declaration. Both the router and the background resolver in `App.tsx`
+ * derive from it, so adding/renaming a builtin surface is a one-line data edit
+ * that both consumers pick up — no second list to keep in sync.
+ *
+ * The React render functions themselves stay co-located in `App.tsx` (they
+ * close over many local view components), but they are keyed off the canonical
+ * ids declared here, and alias resolution is owned here too.
+ */
+
+/**
+ * How a builtin tab declares its screen background policy.
+ *
+ *  - `"shared"` / `"opaque"` — an unconditional policy for every route under
+ *    the tab.
+ *  - `{ shared: (path) => boolean }` — the tab is `"shared"` only when the
+ *    live navigation path satisfies the predicate (e.g. the launcher root of a
+ *    tab that owns sub-routes), otherwise it falls through to the caller's
+ *    default resolution. This mirrors the two path-conditional branches the
+ *    legacy `builtinRouteBackgroundPolicy` encoded for `views` and `apps`.
+ *
+ * A tab with no `backgroundPolicy` field declares no builtin-level policy and
+ * falls through to the caller's downstream resolution (registered views etc.),
+ * exactly as the legacy `return null` did.
+ */
+export type BuiltinTabBackgroundPolicyDecl =
+  | AppShellBackgroundPolicy
+  | { readonly shared: (trimmedNavigationPath: string) => boolean };
+
+export interface BuiltinTabMetadata {
+  /** Canonical builtin tab id (the id the render map is keyed by). */
+  readonly id: string;
+  /**
+   * Legacy tab ids that resolve onto this canonical id. Kept as an explicit,
+   * tested host-owned alias table (e.g. `advanced` -> `fine-tuning`,
+   * `triggers` -> `automations`) rather than duplicated if-branches.
+   */
+  readonly aliases?: readonly string[];
+  /**
+   * Builtin-level background policy declaration. Omitted = no builtin policy
+   * (fall through to downstream resolution).
+   */
+  readonly backgroundPolicy?: BuiltinTabBackgroundPolicyDecl;
+}
+
+/**
+ * The canonical builtin-tab table. IDs here are the keys the `App.tsx` render
+ * map uses; aliases and background policy are consumed by the resolvers below.
+ *
+ * Only tabs that need an alias or a non-default (`shared` / path-conditional)
+ * background policy carry those fields; the rest declare id-only, which is the
+ * common case and keeps drift surface minimal.
+ */
+export const BUILTIN_TAB_METADATA: readonly BuiltinTabMetadata[] = [
+  // ── Background policy: unconditionally "shared" (wallpaper shows through) ──
+  { id: "chat", backgroundPolicy: "shared" },
+  { id: "background", backgroundPolicy: "shared" },
+  { id: "settings", backgroundPolicy: "shared" },
+  // ── Background policy: "shared" only at the tab's launcher root ──
+  {
+    id: "views",
+    backgroundPolicy: { shared: (path) => path === "/views" },
+  },
+  {
+    id: "apps",
+    backgroundPolicy: { shared: (path) => path === "/apps" },
+  },
+  // ── Aliases (canonical id + legacy id that routes onto it) ──
+  { id: "automations", aliases: ["triggers"] },
+  { id: "fine-tuning", aliases: ["advanced"] },
+] as const;
+
+/** Fast id -> metadata lookup, including alias ids. */
+const BUILTIN_TAB_BY_ID: ReadonlyMap<string, BuiltinTabMetadata> = (() => {
+  const map = new Map<string, BuiltinTabMetadata>();
+  for (const entry of BUILTIN_TAB_METADATA) {
+    if (map.has(entry.id)) {
+      throw new Error(
+        `Duplicate builtin tab id "${entry.id}" in BUILTIN_TAB_METADATA`,
+      );
+    }
+    map.set(entry.id, entry);
+    for (const alias of entry.aliases ?? []) {
+      if (map.has(alias)) {
+        throw new Error(
+          `Builtin tab alias "${alias}" (of "${entry.id}") collides with an existing id/alias`,
+        );
+      }
+      map.set(alias, entry);
+    }
+  }
+  return map;
+})();
+
+/**
+ * Resolve a (possibly aliased) tab id to its canonical builtin id. Tabs that
+ * are not declared builtin aliases are returned unchanged, so plugin/dynamic
+ * tabs pass straight through.
+ */
+export function resolveBuiltinTabId(tab: string): string {
+  return BUILTIN_TAB_BY_ID.get(tab)?.id ?? tab;
+}
+
+/**
+ * The builtin-level background policy for a tab/route, or `null` to fall
+ * through to downstream resolution. Direct data-driven replacement for the
+ * legacy `builtinRouteBackgroundPolicy` if-chain — same inputs, same outputs.
+ */
+export function resolveBuiltinBackgroundPolicy(
+  tab: string,
+  trimmedNavigationPath: string,
+): AppShellBackgroundPolicy | null {
+  const decl = BUILTIN_TAB_BY_ID.get(tab)?.backgroundPolicy;
+  if (decl === undefined) return null;
+  if (decl === "shared" || decl === "opaque") return decl;
+  return decl.shared(trimmedNavigationPath) ? "shared" : null;
+}


### PR DESCRIPTION
## Problem (#12680, #12089 item 34)

`packages/ui/src/App.tsx` routed builtin surfaces through **two parallel, hand-maintained name-keyed enumerations** that could silently drift:

1. **`renderStaticViewRouterTab`** — a `directViews` object literal plus a trailing `if (tab === "...")` chain deciding component + wrapper per builtin tab (target ~line 1218).
2. **`builtinRouteBackgroundPolicy`** — a *second* `if (tab === "...")` chain deciding each builtin tab's screen background policy (target ~line 770).

A tab present/aliased in one chain but not the other is an unobservable drift bug: a builtin surface that renders fine but paints the wrong background layer, or an alias (`advanced` → `fine-tuning`) honored by the router but not the background resolver.

## Fix

New **`packages/ui/src/builtin-tab-registry.ts`** — the single source of truth for builtin-tab metadata (canonical id, legacy aliases, background policy declaration):

- `resolveBuiltinTabId()` owns the alias table (`triggers` → `automations`, `advanced` → `fine-tuning`); the router resolves through it.
- `resolveBuiltinBackgroundPolicy()` is a **direct data-driven replacement** for the old `builtinRouteBackgroundPolicy` chain (identical inputs/outputs).
- registry construction throws on duplicate id / alias collision (**fail-loud**).

`renderStaticViewRouterTab` now builds **one** canonical-id-keyed render map (`buildStaticTabRenderers`) and looks up the alias-resolved tab; the tail if-chain and `directViews` literal are gone. `builtinRouteBackgroundPolicy` delegates to the registry.

Behavior-preserving: same components, same wrappers, same background policy, same aliases.

## Tests — `builtin-tab-registry.test.ts` (18 green)

- **table integrity**: unique ids, no id/alias collisions, every alias resolves to its canonical owner
- **alias resolution** + plugin/unknown-tab pass-through
- **golden-table parity** pinning the exact legacy `builtinRouteBackgroundPolicy` truth table (`chat`/`background`/`settings` → shared; `views`@`/views` + `apps`@`/apps` conditional-shared; everything else null)
- **App.tsx drift guards** proving the old central if-chains are gone from both `builtinRouteBackgroundPolicy` and `renderStaticViewRouterTab` executable paths ("or is explicitly marked and tested as legacy host-owned fallback" — here the parallel enumeration is *removed*, not kept)

## Verification

- `bun run typecheck` (tsgo) — **clean, zero new errors vs baseline** (baseline captured green pre-change)
- `builtin-tab-registry.test.ts` — **18/18 green**
- `app-navigate-view` suites — **21/21 green**
- biome — clean
- codex review (uncommitted) — **clean, no findings** ("preserves the existing static tab routing behavior and background policy resolution, including legacy aliases")

### Env note (out of scope)
`App.screen-background-fuzz.test.tsx` + `App.navigate-view-wiring.test.tsx` (full-App-mount suites) fail on **pristine `origin/develop` too** — a stale `./hooks/useAuthStatus` mock missing a `useIsAuthenticated` export. Verified via `git stash` (identical 5/5 + 7/10 failures on the unmodified tree). Unrelated to this change. The golden-table parity test replicates the fuzz test's background-invariant coverage at the unit level.

Fixes #12680

-- [sol-orch]