### PR TITLE
fix(#12789): fail-closed on missing message pipeline + drop fabricated agent replies

### DIFF
--- a/packages/cloud/services/agent-server/__tests__/unit/handle-message.test.ts
+++ b/packages/cloud/services/agent-server/__tests__/unit/handle-message.test.ts
@@ -1,0 +1,134 @@
+// Exercises AgentManager.handleMessage fail-closed behavior on a null message
+// service and its honest empty-reply handling (fallback-slop remediation for
+// #12789 / #12268 — the previous `rt.messageService?.` + "No response
+// generated." fabricated a 200 reply that masked a structural pipeline
+// failure end-to-end at the gateway-webhook consumer).
+import { describe, expect, mock, test } from "bun:test";
+import type {
+  HandlerCallback,
+  IAgentRuntime,
+  IMessageService,
+  Memory,
+  MessageProcessingResult,
+} from "@elizaos/core";
+import { AgentManager } from "../../src/agent-manager";
+
+interface FakeRuntimeOptions {
+  messageService: IMessageService | null;
+}
+
+/**
+ * Builds a minimal runtime stub sufficient for handleMessage: ensureConnection
+ * is a no-op and messageService is injectable (nullable) to model a runtime
+ * whose message pipeline failed to initialize.
+ */
+function makeRuntime(opts: FakeRuntimeOptions): IAgentRuntime {
+  return {
+    ensureConnection: mock(async () => {}),
+    messageService: opts.messageService,
+  } as unknown as IAgentRuntime;
+}
+
+/**
+ * Injects a running agent entry into the manager's private registry so
+ * getRuntime resolves without a real startAgent (which needs Redis + plugins).
+ */
+function withRunningAgent(
+  manager: AgentManager,
+  agentId: string,
+  runtime: IAgentRuntime,
+): void {
+  (
+    manager as unknown as {
+      agents: Map<string, unknown>;
+    }
+  ).agents.set(agentId, {
+    agentId,
+    characterRef: "test:character",
+    runtime,
+    state: "running",
+  });
+}
+
+const OK_RESULT = {
+  didRespond: true,
+  responseMessages: [],
+} as unknown as MessageProcessingResult;
+
+describe("AgentManager.handleMessage fail-closed message pipeline", () => {
+  test("throws a structural error when the runtime has no message service", async () => {
+    const manager = new AgentManager();
+    withRunningAgent(manager, "agent-1", makeRuntime({ messageService: null }));
+
+    await expect(
+      manager.handleMessage("agent-1", "user-1", "hello"),
+    ).rejects.toThrow(/no message service|not initialized/i);
+  });
+
+  test("does not fabricate a reply string when message service is missing", async () => {
+    const manager = new AgentManager();
+    withRunningAgent(manager, "agent-1", makeRuntime({ messageService: null }));
+
+    let thrown: unknown;
+    try {
+      await manager.handleMessage("agent-1", "user-1", "hello");
+    } catch (err) {
+      thrown = err;
+    }
+    // The old code silently returned "No response generated." here.
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).not.toContain("No response generated");
+  });
+
+  test("returns accumulated response text from the message pipeline", async () => {
+    const manager = new AgentManager();
+    const handleMessage = mock(
+      async (_rt: IAgentRuntime, _mem: Memory, callback?: HandlerCallback) => {
+        await callback?.({ text: "hello " });
+        await callback?.({ text: "world" });
+        return OK_RESULT;
+      },
+    );
+    withRunningAgent(
+      manager,
+      "agent-1",
+      makeRuntime({
+        messageService: { handleMessage } as unknown as IMessageService,
+      }),
+    );
+
+    const response = await manager.handleMessage("agent-1", "user-1", "hi");
+    expect(response).toBe("hello world");
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns empty string (not a fabricated literal) on a deliberate no-response", async () => {
+    const manager = new AgentManager();
+    const handleMessage = mock(
+      async () =>
+        ({
+          didRespond: false,
+          responseMessages: [],
+        }) as unknown as MessageProcessingResult,
+    );
+    withRunningAgent(
+      manager,
+      "agent-1",
+      makeRuntime({
+        messageService: { handleMessage } as unknown as IMessageService,
+      }),
+    );
+
+    const response = await manager.handleMessage("agent-1", "user-1", "hi");
+    // A deliberate silence must be an empty string (adapters drop it), never
+    // the old "No response generated." fabrication that read like a reply.
+    expect(response).toBe("");
+  });
+
+  test("still surfaces getRuntime not-found as its own error (unchanged)", async () => {
+    const manager = new AgentManager();
+    await expect(
+      manager.handleMessage("missing", "user-1", "hi"),
+    ).rejects.toThrow("Agent not found");
+  });
+});

--- a/packages/cloud/services/agent-server/src/agent-manager.ts
+++ b/packages/cloud/services/agent-server/src/agent-manager.ts
@@ -425,13 +425,38 @@ export class AgentManager {
         },
       });
 
+      // A running runtime always wires a DefaultMessageService (runtime ctor).
+      // A null messageService here means the message pipeline never initialized
+      // for this agent — a structural runtime failure, not an empty reply.
+      // Optional-chaining past it (the previous `rt.messageService?.`) skipped
+      // the pipeline silently and returned a fabricated reply string, which the
+      // gateway-webhook consumer accepts as a legitimate 200 reply (see
+      // parseAgentResponse), hiding a broken agent end-to-end. Fail closed so
+      // the route returns 500. // error-policy:J1 boundary — surface structural
+      // pipeline-init failure instead of fabricating a reply.
+      const messageService = rt.messageService;
+      if (!messageService) {
+        throw new Error(
+          `Agent ${agentId} has no message service; runtime message pipeline is not initialized`,
+        );
+      }
+
       let response = "";
-      await rt.messageService?.handleMessage(rt, mem, async (content) => {
+      await messageService.handleMessage(rt, mem, async (content) => {
         if (content?.text) response += content.text;
         return [];
       });
 
-      return response || "No response generated.";
+      // An empty accumulated response is a real outcome, not a fault: the agent
+      // deliberately did not respond (mute / shouldRespond=no) or emitted no
+      // text. Return the empty string; the gateway-webhook consumer treats an
+      // empty reply as deliberate silence and skips sendReply (see
+      // processMessage), so nothing is delivered. The previous fabricated
+      // "No response generated." string was fail-open slop — it read like an
+      // agent reply and was actually SENT to platform adapters, and (via the
+      // removed `?.`) it also masked a structural pipeline failure. Genuine
+      // structural failures now throw above.
+      return response;
     } finally {
       this.inFlight--;
     }

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -273,4 +273,65 @@ describe("gateway webhook handler e2e routing", () => {
       chatId: "+15551234567",
     });
   });
+
+  test("skips sendReply when the agent server returns an empty (no-response) reply", async () => {
+    // A deliberate agent silence surfaces as an empty `response` string (the
+    // agent-server no longer fabricates a "No response generated." reply). The
+    // gateway must NOT forward the empty string to the platform adapter — an
+    // empty send is invalid on WhatsApp/Twilio/Telegram — and must stay
+    // distinct from a forward failure (which returns without a reply too, but
+    // is logged as an error). Here the forward SUCCEEDS with an empty body, so
+    // no reply is sent and no error is raised.
+    configureEnv();
+    const redis = new MemoryRedis();
+    redis.store.set("agent:agent-1:server", "server-1");
+    redis.store.set("server:server-1:url", "http://agent-server.local");
+    const event = createTwilioEvent({
+      messageId: "SM_silent_1",
+      text: "(a message the agent chooses not to answer)",
+    });
+    const adapter = createAdapter(event);
+
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      if (
+        request.url ===
+        "https://api.elizacloud.ai/api/internal/identity/resolve"
+      ) {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              user: { id: "user-1", organizationId: "org-1" },
+              agent: { id: "agent-1" },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (request.url === "http://agent-server.local/agents/agent-1/message") {
+        return new Response(JSON.stringify({ response: "" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${request.url}`);
+    }) as typeof fetch;
+
+    const response = await handleWebhook(
+      requestFor(event),
+      adapter,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      },
+      "eliza-app",
+    );
+
+    expect(response.status).toBe(200);
+    // Give the fire-and-forget processMessage a moment; assert it NEVER sends.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(adapter.replies).toEqual([]);
+  });
 });

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -177,6 +177,20 @@ async function processMessage(
     return;
   }
 
+  // An empty responseText is a deliberate no-response from the agent (mute /
+  // shouldRespond=no), not content: forwarding it would make platform adapters
+  // (WhatsApp/Twilio/Telegram) attempt an invalid empty send. Skip the reply so
+  // "agent chose silence" sends nothing, staying distinct from a forward
+  // failure (which returned above) and from a real reply.
+  // error-policy:J5 no-op — deliberate agent silence, nothing to deliver.
+  if (responseText.length === 0) {
+    logger.debug("Agent produced no reply; skipping send", {
+      agentId,
+      platform: adapter.platform,
+    });
+    return;
+  }
+
   try {
     await adapter.sendReply(config, event, responseText);
   } catch (err) {


### PR DESCRIPTION
## Summary
Second slice of the `packages/cloud/services` fallback-slop sweep (#12789 / #12268 split). Non-overlapping with prior slice PR #13122 (which hardened `gateway-webhook/src/server-router.ts` `parseAgentResponse` on the consumer side). This slice fixes the **producer** side in `agent-server` and closes the matching empty-send gap in `gateway-webhook/src/webhook-handler.ts`.

## The slop
`AgentManager.handleMessage` (agent-server) had two fail-open sites:

1. **`rt.messageService?.handleMessage(...)`** — optional-chained past a `null` message service. A running runtime always wires a `DefaultMessageService` in its constructor, so a `null` here is a **structural pipeline-init failure**, not an empty reply. The `?.` silently no-op'd and fell through to a fabricated reply → the route returned HTTP 200 with a fake reply that the gateway-webhook consumer (`parseAgentResponse`, hardened in #13122) accepts as legitimate, hiding a broken agent end-to-end.
2. **`return response || "No response generated."`** — fabricated a user-facing reply string on empty output. A deliberate agent silence (mute / `shouldRespond=no`) is a real outcome; the fabricated literal was actually **sent** to platform adapters.

And in `gateway-webhook` `processMessage`, the reply was forwarded **unconditionally** — an empty reply would trigger an invalid empty send on WhatsApp/Twilio/Telegram.

## The fix (fail-closed, real)
- `messageService === null` → **throw** a distinct structural error → route returns **500** (J1 boundary), instead of fabricating a 200 reply.
- Empty accumulated output → return `""` (deliberate silence), not a fabricated literal.
- `processMessage` now **skips `sendReply` on an empty reply** (J5 no-op), keeping deliberate silence distinct from a forward failure (already returns without sending, logged as error) and from a real reply.

## Tests
- `agent-server/__tests__/unit/handle-message.test.ts` (**5 new**): missing `messageService` throws (not a fabricated string), response text accumulates through the callback, deliberate no-response returns `""` not a literal, `getRuntime` not-found error unchanged. **agent-server unit suite 39/39 green.**
- `gateway-webhook/__tests__/webhook-handler.e2e.test.ts` (**1 new**): "skips sendReply when the agent server returns an empty (no-response) reply" asserts the adapter receives no reply when the agent server returns `{response:""}`. **e2e 3/3 green.**
- **Combined: 73/73 across both packages.** `tsgo` zero-new-errors vs baseline (the 4 pre-existing `TS2307` `plugin-*` module-resolution errors are worktree symlink artifacts — identical on pristine `develop`). biome clean. codex clean (round 2: "did not identify a discrete introduced bug"; the round-1 P2 empty-send finding is fixed by the gateway guard).

## Scope note
Producer-side + gateway send-guard only; both are complementary to the #13122 consumer-side parse hardening. No routes/schema/config touched beyond these two service files + their tests.

-- [sol-orch]