### PR TITLE
fix(providers): #12182 error-policy compliance for groq / xai / zai / nearai / anthropic-proxy (part of #12795, closes non-openai scope)

### DIFF
--- a/plugins/plugin-anthropic-proxy/AGENTS.md
+++ b/plugins/plugin-anthropic-proxy/AGENTS.md
@@ -58,7 +58,8 @@ plugins/plugin-anthropic-proxy/
     ├── manifest-engine.integration.test.ts
     ├── process-body.edge.test.ts
     ├── proxy-server.routing.test.ts
-    └── sse-rewrite.test.ts
+    ├── sse-rewrite.test.ts
+    └── error-policy.shape.test.ts
 ```
 
 ## Commands

--- a/plugins/plugin-anthropic-proxy/CLAUDE.md
+++ b/plugins/plugin-anthropic-proxy/CLAUDE.md
@@ -58,7 +58,8 @@ plugins/plugin-anthropic-proxy/
     ├── manifest-engine.integration.test.ts
     ├── process-body.edge.test.ts
     ├── proxy-server.routing.test.ts
-    └── sse-rewrite.test.ts
+    ├── sse-rewrite.test.ts
+    └── error-policy.shape.test.ts
 ```
 
 ## Commands

--- a/plugins/plugin-anthropic-proxy/__tests__/error-policy.shape.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/error-policy.shape.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Failure-path tests for the #12182 error-handling policy (#12795): a
+ * malformed/incomplete credentials file must become a typed LoadResult
+ * failure (never a fabricated credential), and an invalid fingerprint config
+ * must surface as startError + documented off-mode degrade (never a silently
+ * fabricated config). Deterministic: temp files + env overrides, no live API.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { AnthropicProxyService } from "../src/services/proxy-service.js";
+import { loadCredentials } from "../src/utils/credentials-loader.js";
+
+const cleanup: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  while (cleanup.length) {
+    await cleanup.pop()?.();
+  }
+});
+
+function withEnv<T>(overrides: Record<string, string | undefined>, fn: () => T): T {
+  const prev: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(overrides)) {
+    prev[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  const restore = () => {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  };
+  try {
+    const result = fn();
+    if (result instanceof Promise) {
+      return result.finally(restore) as T;
+    }
+    restore();
+    return result;
+  } catch (error) {
+    restore();
+    throw error;
+  }
+}
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "anthropic-proxy-errpolicy-"));
+  cleanup.push(() => rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+describe("credentials loader failure surfaces", () => {
+  it("returns a typed failure for a malformed credentials file, never a fabricated credential", () => {
+    const dir = tempDir();
+    const credsPath = join(dir, "credentials.json");
+    writeFileSync(credsPath, "{ not json ");
+
+    const result = withEnv({ CLAUDE_CODE_OAUTH_TOKEN: undefined }, () =>
+      loadCredentials({ credentialsPath: credsPath })
+    );
+    expect(result.creds).toBeNull();
+    expect(result.error).toMatch(/failed to read/);
+    expect(result.error).toContain(credsPath);
+  });
+
+  it("returns a typed failure when the file parses but has no accessToken", () => {
+    const dir = tempDir();
+    const credsPath = join(dir, "credentials.json");
+    writeFileSync(credsPath, JSON.stringify({ claudeAiOauth: { subscriptionType: "max" } }));
+
+    const result = withEnv({ CLAUDE_CODE_OAUTH_TOKEN: undefined }, () =>
+      loadCredentials({ credentialsPath: credsPath })
+    );
+    expect(result.creds).toBeNull();
+    expect(result.error).toMatch(/missing claudeAiOauth\.accessToken/);
+  });
+});
+
+describe("service config failure surfaces", () => {
+  it("degrades to off with an observable startError when the fingerprint config is invalid JSON", async () => {
+    const dir = tempDir();
+    const configPath = join(dir, "config.json");
+    writeFileSync(configPath, "{ definitely not json");
+
+    const service = await withEnv(
+      {
+        CLAUDE_MAX_PROXY_MODE: "inline",
+        CLAUDE_MAX_PROXY_CONFIG_PATH: configPath,
+        CLAUDE_CODE_OAUTH_TOKEN: "test-oauth-token-not-real",
+      },
+      () => AnthropicProxyService.start({} as unknown as never)
+    );
+    cleanup.push(() => service.stop());
+
+    expect(service.getEffectiveMode()).toBe("off");
+    expect(service.getStartError()).toMatch(/Invalid anthropic proxy config/);
+    const status = await service.getStatus();
+    expect(status.startError).toMatch(/Invalid anthropic proxy config/);
+  });
+
+  it("degrades to off with an observable startError when the config schema is wrong", async () => {
+    const dir = tempDir();
+    const configPath = join(dir, "config.json");
+    writeFileSync(configPath, JSON.stringify({ replacements: "not-an-array" }));
+
+    const service = await withEnv(
+      {
+        CLAUDE_MAX_PROXY_MODE: "inline",
+        CLAUDE_MAX_PROXY_CONFIG_PATH: configPath,
+        CLAUDE_CODE_OAUTH_TOKEN: "test-oauth-token-not-real",
+      },
+      () => AnthropicProxyService.start({} as unknown as never)
+    );
+    cleanup.push(() => service.stop());
+
+    expect(service.getEffectiveMode()).toBe("off");
+    expect(service.getStartError()).toMatch(/Invalid anthropic proxy config/);
+  });
+});

--- a/plugins/plugin-anthropic-proxy/src/proxy/server.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/server.ts
@@ -384,6 +384,9 @@ export class ProxyServer {
         })
       );
     } catch (e) {
+      // error-policy:J1 boundary translation — outermost handler for the
+      // /health HTTP route; the failure becomes a structured 500 body instead
+      // of tearing down the proxy's request loop.
       res.writeHead(500, { "Content-Type": "application/json" });
       res.end(
         JSON.stringify({

--- a/plugins/plugin-anthropic-proxy/src/services/proxy-service.ts
+++ b/plugins/plugin-anthropic-proxy/src/services/proxy-service.ts
@@ -180,6 +180,10 @@ function resolveFingerprintConfig(): {
       fingerprintConfig: loadFingerprintConfig(configPath),
     };
   } catch (error) {
+    // error-policy:J3 untrusted-input sanitizing — an unreadable/invalid
+    // fingerprint config becomes an explicit typed configError (the service
+    // then refuses to start the proxy and surfaces it via startError +
+    // PROXY_STATUS); no partial/default config is fabricated.
     return {
       configPath,
       configError: `Invalid anthropic proxy config ${configPath}: ${
@@ -257,6 +261,10 @@ export class AnthropicProxyService extends Service {
       try {
         service.effectiveUrl = validateSharedUpstream(config.upstream);
       } catch (e) {
+        // error-policy:J4 explicit user-facing degrade — an invalid shared
+        // upstream degrades to the documented "off" mode (agent keeps running
+        // on direct billing); the failure stays observable via startError,
+        // the PROXY_STATUS action, and GET /api/anthropic-proxy/status.
         service.startError = (e as Error).message;
         logger.warn(`[anthropic-proxy] ${service.startError} — falling back to off`);
         service.effectiveMode = "off";
@@ -301,6 +309,11 @@ export class AnthropicProxyService extends Service {
       setAnthropicBaseUrl(service.effectiveUrl);
       logger.info(`[anthropic-proxy] mode=inline — listening on ${service.effectiveUrl}`);
     } catch (e) {
+      // error-policy:J4 explicit user-facing degrade — a failed inline proxy
+      // start (missing credentials, port in use) degrades to the documented
+      // "off" mode instead of crashing agent boot; the failure stays
+      // observable via startError, the PROXY_STATUS action, and
+      // GET /api/anthropic-proxy/status.
       service.startError = (e as Error).message;
       logger.warn(
         `[anthropic-proxy] failed to start inline proxy (${service.startError}). ` +
@@ -360,6 +373,9 @@ export class AnthropicProxyService extends Service {
         });
         upstream = { reachable: r.ok, status: r.status };
       } catch (e) {
+        // error-policy:J4 explicit user-facing degrade — the upstream health
+        // probe's failure IS the answer: the status DTO reports an explicit
+        // { reachable: false, error } state, never a fake-healthy upstream.
         upstream = {
           reachable: false,
           error: (e as Error).message,

--- a/plugins/plugin-anthropic-proxy/src/utils/credentials-loader.ts
+++ b/plugins/plugin-anthropic-proxy/src/utils/credentials-loader.ts
@@ -45,6 +45,9 @@ function jwtExpiresAt(token: string): number {
     const parsed = JSON.parse(json) as { exp?: number };
     return typeof parsed.exp === "number" ? parsed.exp * 1000 : 0;
   } catch {
+    // error-policy:J3 untrusted-input sanitizing — a non-JWT/undecodable token
+    // yields the explicit 0 = "unknown expiry" marker used only for expiry
+    // diagnostics in getStats(); no credential is fabricated.
     return 0;
   }
 }
@@ -100,6 +103,10 @@ export function loadCredentials(
         };
       }
     } catch (e) {
+      // error-policy:J1 boundary translation — an unreadable/unparseable
+      // credentials file becomes a typed LoadResult failure; the proxy server
+      // surfaces it as a 503 auth error and the service exposes it via
+      // startError/PROXY_STATUS. No credential is fabricated.
       return {
         creds: null,
         error: `failed to read ${resolved}: ${(e as Error).message}`,

--- a/plugins/plugin-groq/AGENTS.md
+++ b/plugins/plugin-groq/AGENTS.md
@@ -38,6 +38,7 @@ plugins/plugin-groq/
     retry.test.ts               classifyRetryError unit tests
     model-usage.test.ts         Token usage normalisation tests
     native-plumbing.shape.test.ts  Native tool-call / structured-output plumbing
+    error-policy.shape.test.ts  #12182 failure-path surfaces (typed errors, no fabricated completions)
     core-test-mock.ts           Shared mock helpers
   prompts/
     evaluators.json     (bundled prompt data)

--- a/plugins/plugin-groq/CLAUDE.md
+++ b/plugins/plugin-groq/CLAUDE.md
@@ -38,6 +38,7 @@ plugins/plugin-groq/
     retry.test.ts               classifyRetryError unit tests
     model-usage.test.ts         Token usage normalisation tests
     native-plumbing.shape.test.ts  Native tool-call / structured-output plumbing
+    error-policy.shape.test.ts  #12182 failure-path surfaces (typed errors, no fabricated completions)
     core-test-mock.ts           Shared mock helpers
   prompts/
     evaluators.json     (bundled prompt data)

--- a/plugins/plugin-groq/__tests__/core-test-mock.ts
+++ b/plugins/plugin-groq/__tests__/core-test-mock.ts
@@ -15,7 +15,24 @@ vi.mock("@elizaos/core", () => {
     warn: vi.fn(),
   };
 
+  // Mirrors core's ElizaError shape ({ code, context, cause }) so the plugin's
+  // typed failure paths can be asserted without booting the real core.
+  class ElizaError extends Error {
+    override readonly name = "ElizaError";
+    readonly code: string;
+    readonly context?: Record<string, unknown>;
+    constructor(
+      message: string,
+      options: { code: string; context?: Record<string, unknown>; cause?: unknown }
+    ) {
+      super(message, options.cause !== undefined ? { cause: options.cause } : undefined);
+      this.code = options.code;
+      this.context = options.context;
+    }
+  }
+
   return {
+    ElizaError,
     EventType: {
       MODEL_USED: "MODEL_USED",
     },

--- a/plugins/plugin-groq/__tests__/error-policy.shape.test.ts
+++ b/plugins/plugin-groq/__tests__/error-policy.shape.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Failure-path tests for the #12182 error-handling policy (#12795): missing
+ * credential, provider 4xx rejection, and empty-completion fabrication for the
+ * Groq handlers, driven through the REAL `ai` + `@ai-sdk/groq` stack against a
+ * stubbed transport (`runtime.fetch` / global `fetch`) — no live API. Every
+ * failure must surface as a typed error — never a fabricated "" completion or
+ * a success MODEL_USED event.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { groqPlugin } from "../index";
+
+type Handler = (runtime: IAgentRuntime, params: unknown) => Promise<unknown>;
+
+function chatCompletion(
+  content: string | null,
+  options?: {
+    finishReason?: string;
+    toolCalls?: Array<{
+      id: string;
+      type: "function";
+      function: { name: string; arguments: string };
+    }>;
+  }
+): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl-test",
+      object: "chat.completion",
+      created: 0,
+      model: "openai/gpt-oss-120b",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content,
+            ...(options?.toolCalls ? { tool_calls: options.toolCalls } : {}),
+          },
+          finish_reason: options?.finishReason ?? "stop",
+        },
+      ],
+      usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+}
+
+function errorResponse(status: number, message: string): Response {
+  return new Response(JSON.stringify({ error: { message, type: "invalid_request_error" } }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function createRuntime(
+  fetchImpl: typeof fetch | undefined,
+  settings: Record<string, string | null> = {}
+): IAgentRuntime {
+  const defaults: Record<string, string> = { GROQ_API_KEY: "test-key" };
+  return {
+    character: { system: "system prompt" },
+    emitEvent: vi.fn(async () => undefined),
+    fetch: fetchImpl,
+    getSetting: vi.fn((key: string) => (key in settings ? settings[key] : (defaults[key] ?? null))),
+  } as unknown as IAgentRuntime;
+}
+
+const textSmall = groqPlugin.models?.TEXT_SMALL as Handler;
+const transcription = groqPlugin.models?.TRANSCRIPTION as Handler;
+const tts = groqPlugin.models?.TEXT_TO_SPEECH as Handler;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("Groq text failure surfaces (real ai + @ai-sdk/groq, stubbed transport)", () => {
+  it("surfaces a 401 bad credential as a typed rejection without retry or usage event", async () => {
+    const fetchMock = vi.fn(async () => errorResponse(401, "Invalid API Key"));
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(textSmall(runtime, { prompt: "hi" })).rejects.toMatchObject({
+      statusCode: 401,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(
+      (runtime as unknown as { emitEvent: ReturnType<typeof vi.fn> }).emitEvent
+    ).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a 400 invalid request as a typed rejection", async () => {
+    const fetchMock = vi.fn(async () => errorResponse(400, "bad request"));
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(textSmall(runtime, { prompt: "hi" })).rejects.toMatchObject({
+      statusCode: 400,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws MODEL_EMPTY_COMPLETION for an empty completion instead of returning ''", async () => {
+    const fetchMock = vi.fn(async () => chatCompletion("", { finishReason: "stop" }));
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(textSmall(runtime, { prompt: "hi" })).rejects.toMatchObject({
+      code: "MODEL_EMPTY_COMPLETION",
+    });
+    // No success telemetry for a fabricated-empty result.
+    expect(
+      (runtime as unknown as { emitEvent: ReturnType<typeof vi.fn> }).emitEvent
+    ).not.toHaveBeenCalled();
+  });
+
+  it("still succeeds for a tool-call-only completion (no empty-completion false positive)", async () => {
+    const fetchMock = vi.fn(async () =>
+      chatCompletion(null, {
+        finishReason: "tool_calls",
+        toolCalls: [
+          { id: "call_1", type: "function", function: { name: "lookup", arguments: '{"q":1}' } },
+        ],
+      })
+    );
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    const result = (await textSmall(runtime, {
+      prompt: "use the tool",
+      tools: [{ name: "lookup", description: "Lookup", parameters: { type: "object" } }],
+    })) as { text: string; toolCalls: unknown[] };
+
+    expect(result.text).toBe("");
+    expect(result.toolCalls).toHaveLength(1);
+    expect(
+      (runtime as unknown as { emitEvent: ReturnType<typeof vi.fn> }).emitEvent
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the success path intact: non-empty completion resolves and emits usage", async () => {
+    const fetchMock = vi.fn(async () => chatCompletion("hello"));
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(textSmall(runtime, { prompt: "hi" })).resolves.toBe("hello");
+    expect(
+      (runtime as unknown as { emitEvent: ReturnType<typeof vi.fn> }).emitEvent
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a misconfigured GROQ_BASE_URL with the original parse failure as cause", async () => {
+    const runtime = createRuntime(undefined, { GROQ_BASE_URL: "not a url" });
+
+    const error = await textSmall(runtime, { prompt: "hi" }).then(
+      () => {
+        throw new Error("expected rejection");
+      },
+      (e: unknown) => e as Error
+    );
+    expect(error.message).toBe("GROQ_BASE_URL must be a valid http(s) URL");
+    expect(error.cause).toBeDefined();
+  });
+});
+
+describe("Groq audio credential/failure surfaces", () => {
+  it("TRANSCRIPTION throws a typed missing-credential error before any request", async () => {
+    const fetchSpy = vi.fn(async () => new Response("{}"));
+    vi.stubGlobal("fetch", fetchSpy);
+    const runtime = createRuntime(undefined, { GROQ_API_KEY: null });
+
+    await expect(transcription(runtime, "aGVsbG8=")).rejects.toMatchObject({
+      code: "MODEL_MISSING_CREDENTIAL",
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("TEXT_TO_SPEECH throws a typed missing-credential error before any request", async () => {
+    const fetchSpy = vi.fn(async () => new Response("{}"));
+    vi.stubGlobal("fetch", fetchSpy);
+    const runtime = createRuntime(undefined, { GROQ_API_KEY: null });
+
+    await expect(tts(runtime, { text: "hello" })).rejects.toMatchObject({
+      code: "MODEL_MISSING_CREDENTIAL",
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("TRANSCRIPTION surfaces a provider 5xx as a typed error, never an empty transcript", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("upstream exploded", { status: 502 }))
+    );
+    const runtime = createRuntime(undefined);
+
+    await expect(transcription(runtime, "aGVsbG8=")).rejects.toThrow("Transcription failed: 502");
+  });
+
+  it("TEXT_TO_SPEECH surfaces a provider 4xx as a typed error, never empty audio", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("bad voice", { status: 422 }))
+    );
+    const runtime = createRuntime(undefined);
+
+    await expect(tts(runtime, { text: "hello" })).rejects.toThrow("TTS failed: 422");
+  });
+});

--- a/plugins/plugin-groq/index.ts
+++ b/plugins/plugin-groq/index.ts
@@ -16,6 +16,7 @@ import type {
 } from "@elizaos/core";
 import {
   buildCanonicalSystemPrompt,
+  ElizaError,
   EventType,
   type GenerateTextParams,
   logger,
@@ -152,6 +153,9 @@ function stringifyForUsage(value: unknown): string {
   try {
     return JSON.stringify(value);
   } catch {
+    // error-policy:J3 untrusted-input sanitizing — a circular/unstringifiable
+    // response degrades to String() for token *estimation* only (the usage
+    // event is flagged `estimated`); no completion data is fabricated.
     return String(value);
   }
 }
@@ -246,8 +250,10 @@ function getBaseURL(runtime: IAgentRuntime): string {
   let parsed: URL;
   try {
     parsed = new URL(configured);
-  } catch {
-    throw new Error("GROQ_BASE_URL must be a valid http(s) URL");
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow — names the misconfigured setting;
+    // the original URL parse failure travels as `cause`.
+    throw new Error("GROQ_BASE_URL must be a valid http(s) URL", { cause: error });
   }
 
   if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
@@ -622,6 +628,23 @@ async function generateWithRetry(
   while (true) {
     try {
       const result = await generate();
+      // A completion with no text and no tool calls is a provider failure
+      // (moderation block, truncation, upstream bug) — never a legitimate
+      // result. Returning "" here would fabricate a healthy-empty completion
+      // the planner cannot distinguish from a real answer (#9324: throw,
+      // never fabricate) — and would emit success usage telemetry for it.
+      const resultToolCalls = Array.isArray(result.toolCalls) ? result.toolCalls : [];
+      if (result.text.length === 0 && resultToolCalls.length === 0) {
+        throw new ElizaError(
+          `[Groq] ${modelType} returned an empty completion${
+            result.finishReason ? ` (finishReason: ${result.finishReason})` : ""
+          }`,
+          {
+            code: "MODEL_EMPTY_COMPLETION",
+            context: { modelType, model, finishReason: result.finishReason },
+          }
+        );
+      }
       const usage = normalizeTokenUsage(result.usage) ?? estimateUsage(params.prompt, result.text);
       emitModelUsed(runtime, modelType, model, usage);
       if (params.returnNative) {
@@ -630,6 +653,9 @@ async function generateWithRetry(
       const { text } = result;
       return text;
     } catch (error) {
+      // error-policy:J2 context-adding rethrow — rate-limit/transient errors
+      // are retried with backoff; fatal errors and exhausted attempts rethrow
+      // the original provider error unchanged. No failure becomes a result.
       const kind = classifyRetryError(error);
 
       if (kind === "rate-limit" && rateLimitAttempts < MAX_RATE_LIMIT_RETRIES) {
@@ -861,6 +887,15 @@ export const groqPlugin: Plugin = {
       formData.append("model", transcriptionModel);
 
       const apiKey = nonEmptyString(runtime.getSetting("GROQ_API_KEY"));
+      // A missing credential must surface as a typed failure before the
+      // request goes out — an empty bearer token would masquerade as a
+      // provider-side 401 and hide the real misconfiguration.
+      if (!apiKey) {
+        throw new ElizaError("[Groq] TRANSCRIPTION requires GROQ_API_KEY", {
+          code: "MODEL_MISSING_CREDENTIAL",
+          context: { modelType: ModelType.TRANSCRIPTION },
+        });
+      }
       const details: RecordLlmCallDetails = {
         model: transcriptionModel,
         systemPrompt: "",
@@ -874,7 +909,7 @@ export const groqPlugin: Plugin = {
         const response = await fetch(`${baseURL}/audio/transcriptions`, {
           method: "POST",
           headers: {
-            Authorization: `Bearer ${apiKey ?? ""}`,
+            Authorization: `Bearer ${apiKey}`,
           },
           body: formData,
         });
@@ -938,6 +973,14 @@ export const groqPlugin: Plugin = {
               : DEFAULT_TTS_RESPONSE_FORMAT;
 
       const apiKey = nonEmptyString(runtime.getSetting("GROQ_API_KEY"));
+      // Same rule as TRANSCRIPTION: a missing credential is a typed local
+      // failure, never an empty bearer token sent upstream.
+      if (!apiKey) {
+        throw new ElizaError("[Groq] TEXT_TO_SPEECH requires GROQ_API_KEY", {
+          code: "MODEL_MISSING_CREDENTIAL",
+          context: { modelType: ModelType.TEXT_TO_SPEECH },
+        });
+      }
       const details: RecordLlmCallDetails = {
         model,
         systemPrompt: "",
@@ -951,7 +994,7 @@ export const groqPlugin: Plugin = {
         const response = await fetch(`${baseURL}/audio/speech`, {
           method: "POST",
           headers: {
-            Authorization: `Bearer ${apiKey ?? ""}`,
+            Authorization: `Bearer ${apiKey}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({

--- a/plugins/plugin-nearai/__tests__/error-policy.shape.test.ts
+++ b/plugins/plugin-nearai/__tests__/error-policy.shape.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Failure-path tests for the #12182 error-handling policy (#12795): missing
+ * credential, provider 4xx rejection, malformed responses, and
+ * empty-completion fabrication for the NEAR AI text handlers, driven through
+ * the REAL `ai` + `@ai-sdk/openai-compatible` stack against a stubbed
+ * `runtime.fetch` transport — no live API. Every failure must surface as a
+ * typed error — never a fabricated "" completion or success MODEL_USED event.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleTextSmall } from "../models/text";
+
+function createRuntime(
+  fetchImpl: typeof fetch | undefined,
+  settings: Record<string, string | null> = {}
+): IAgentRuntime {
+  const defaults: Record<string, string> = { NEARAI_API_KEY: "test-key" };
+  return {
+    character: { system: "system prompt" },
+    emitEvent: vi.fn(async () => undefined),
+    fetch: fetchImpl,
+    getSetting: vi.fn((key: string) =>
+      key in settings ? settings[key] : (defaults[key] ?? undefined)
+    ),
+  } as unknown as IAgentRuntime;
+}
+
+function chatCompletion(content: string, finishReason = "stop"): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl-test",
+      object: "chat.completion",
+      created: 0,
+      model: "google/gemma-4-31B-it",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content },
+          finish_reason: finishReason,
+        },
+      ],
+      usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+}
+
+const emitEventOf = (runtime: IAgentRuntime) =>
+  (runtime as unknown as { emitEvent: ReturnType<typeof vi.fn> }).emitEvent;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("NEAR AI failure surfaces (real ai + @ai-sdk/openai-compatible, stubbed transport)", () => {
+  it("throws a typed missing-credential error before any request", async () => {
+    const fetchMock = vi.fn(async () => chatCompletion("hi"));
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch, {
+      NEARAI_API_KEY: null,
+    });
+
+    await expect(handleTextSmall(runtime, { prompt: "hi" })).rejects.toThrow(
+      "NEARAI_API_KEY is required"
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a 401 bad credential as a typed rejection without a usage event", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: { message: "Invalid API key" } }), { status: 401 })
+    );
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(handleTextSmall(runtime, { prompt: "hi" })).rejects.toMatchObject({
+      statusCode: 401,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(emitEventOf(runtime)).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a malformed (non-JSON) 200 response as a typed error", async () => {
+    const fetchMock = vi.fn(async () => new Response("<html>oops</html>", { status: 200 }));
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(handleTextSmall(runtime, { prompt: "hi" })).rejects.toThrow();
+    expect(emitEventOf(runtime)).not.toHaveBeenCalled();
+  });
+
+  it("throws MODEL_EMPTY_COMPLETION for an empty completion instead of returning ''", async () => {
+    const fetchMock = vi.fn(async () => chatCompletion("", "stop"));
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(handleTextSmall(runtime, { prompt: "hi" })).rejects.toMatchObject({
+      code: "MODEL_EMPTY_COMPLETION",
+    });
+    // No success telemetry for a fabricated-empty result.
+    expect(emitEventOf(runtime)).not.toHaveBeenCalled();
+  });
+
+  it("keeps the success path intact: non-empty completion resolves and emits usage", async () => {
+    const fetchMock = vi.fn(async () => chatCompletion("hello"));
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(handleTextSmall(runtime, { prompt: "hi" })).resolves.toBe("hello");
+    expect(emitEventOf(runtime)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-nearai/__tests__/text-params.test.ts
+++ b/plugins/plugin-nearai/__tests__/text-params.test.ts
@@ -18,6 +18,18 @@ vi.mock("@ai-sdk/openai-compatible", () => ({
 }));
 
 vi.mock("@elizaos/core", () => ({
+  ElizaError: class extends Error {
+    readonly code: string;
+    readonly context?: Record<string, unknown>;
+    constructor(
+      message: string,
+      options: { code: string; context?: Record<string, unknown>; cause?: unknown }
+    ) {
+      super(message, options.cause !== undefined ? { cause: options.cause } : undefined);
+      this.code = options.code;
+      this.context = options.context;
+    }
+  },
   EventType: { MODEL_USED: "MODEL_USED" },
   logger: { log: vi.fn() },
   ModelType: { TEXT_SMALL: "TEXT_SMALL", TEXT_LARGE: "TEXT_LARGE" },

--- a/plugins/plugin-nearai/models/text.ts
+++ b/plugins/plugin-nearai/models/text.ts
@@ -11,11 +11,17 @@
  * that shim if the upstream API changes what it accepts.
  */
 import type { GenerateTextParams, IAgentRuntime } from "@elizaos/core";
-import { logger, ModelType } from "@elizaos/core";
+import { ElizaError, logger, ModelType } from "@elizaos/core";
 import { generateText, type ToolSet } from "ai";
 import { createNearAIClient, type NearAIFetch } from "../providers";
 import type { ModelName, ProviderOptions } from "../types";
-import { getExperimentalTelemetry, getLargeModel, getSmallModel } from "../utils/config";
+import {
+  getApiKey,
+  getExperimentalTelemetry,
+  getLargeModel,
+  getSmallModel,
+  isBrowser,
+} from "../utils/config";
 import { emitModelUsageEvent } from "../utils/events";
 
 // Extract the native generateText parameter type to avoid unsafe casts at call sites.
@@ -75,7 +81,9 @@ function createNearAIRequestFetch(baseFetch: NearAIFetch): NearAIFetch {
         }
         init.body = JSON.stringify(body);
       } catch {
-        // Non-JSON request bodies pass through unchanged.
+        // error-policy:J3 untrusted-input sanitizing — the compatibility shim
+        // can only rewrite a JSON body; non-JSON request bodies pass through
+        // unchanged rather than being replaced with a fabricated one.
       }
     }
     return baseFetch(input, init);
@@ -89,6 +97,14 @@ async function generateTextWithModel(
   modelName: ModelName,
   modelType: typeof ModelType.TEXT_SMALL | typeof ModelType.TEXT_LARGE
 ): Promise<string> {
+  // A missing credential must surface as a typed local failure before any
+  // request goes out — an anonymous request would masquerade as a
+  // provider-side 401 and hide the real misconfiguration. Browser builds are
+  // exempt: they route through a proxy that holds the key
+  // (NEARAI_BROWSER_BASE_URL).
+  if (!isBrowser()) {
+    getApiKey(runtime);
+  }
   const experimentalTelemetry = getExperimentalTelemetry(runtime);
   const requestFetch = createNearAIRequestFetch((runtime.fetch ?? fetch) as NearAIFetch);
   const nearai = createNearAIClient(runtime, { fetch: requestFetch });
@@ -117,7 +133,24 @@ async function generateTextWithModel(
     topP: resolved.topP,
   };
 
-  const { text, usage } = await generateText(generateParams);
+  const { text, usage, finishReason } = await generateText(generateParams);
+
+  // An empty completion is a provider failure (moderation, truncation,
+  // upstream bug) — never a legitimate result for this prompt-only handler.
+  // Returning "" would fabricate a healthy-empty completion the planner
+  // cannot distinguish from a real answer, and emit success usage telemetry
+  // for it (#9324: throw, never fabricate).
+  if (text.length === 0) {
+    throw new ElizaError(
+      `[NEAR AI] ${modelType} returned an empty completion${
+        finishReason ? ` (finishReason: ${finishReason})` : ""
+      }`,
+      {
+        code: "MODEL_EMPTY_COMPLETION",
+        context: { modelType, modelName, finishReason },
+      }
+    );
+  }
 
   if (usage) {
     emitModelUsageEvent(runtime, modelType, usage);

--- a/plugins/plugin-xai/AGENTS.md
+++ b/plugins/plugin-xai/AGENTS.md
@@ -46,6 +46,7 @@ plugins/plugin-xai/
     index.ts            Re-exports grok.ts
   __tests__/
     native-plumbing.shape.test.ts   Unit tests for tool-call normalization shapes
+    error-policy.shape.test.ts      #12182 failure-path surfaces (typed errors, no fabricated completions)
     plugin.live.test.ts             Live API integration test (requires XAI_API_KEY)
   build.ts              Bun.build script (produces node ESM, browser ESM, CJS)
   vitest.config.ts      Vitest config

--- a/plugins/plugin-xai/CLAUDE.md
+++ b/plugins/plugin-xai/CLAUDE.md
@@ -46,6 +46,7 @@ plugins/plugin-xai/
     index.ts            Re-exports grok.ts
   __tests__/
     native-plumbing.shape.test.ts   Unit tests for tool-call normalization shapes
+    error-policy.shape.test.ts      #12182 failure-path surfaces (typed errors, no fabricated completions)
     plugin.live.test.ts             Live API integration test (requires XAI_API_KEY)
   build.ts              Bun.build script (produces node ESM, browser ESM, CJS)
   vitest.config.ts      Vitest config

--- a/plugins/plugin-xai/__tests__/error-policy.shape.test.ts
+++ b/plugins/plugin-xai/__tests__/error-policy.shape.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Failure-path tests for the #12182 error-handling policy (#12795): missing
+ * credential, provider 4xx/5xx and rate-limit rejections, malformed responses,
+ * and empty-completion fabrication for the xAI handlers, which call the REST
+ * API through a stubbed `runtime.fetch` — no live API. Every failure must
+ * surface as a typed error — never a fabricated "" completion, empty native
+ * result, or success MODEL_USED event.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleTextEmbedding, handleTextSmall } from "../models/grok";
+
+function createRuntime(
+  fetchImpl: typeof fetch | undefined,
+  settings: Record<string, string | null> = {},
+): IAgentRuntime {
+  const defaults: Record<string, string> = { XAI_API_KEY: "test-key" };
+  return {
+    character: { name: "Grokky", system: "character system prompt" },
+    emitEvent: vi.fn(async () => undefined),
+    fetch: fetchImpl,
+    getSetting: vi.fn((key: string) =>
+      key in settings ? settings[key] : (defaults[key] ?? null),
+    ),
+  } as unknown as IAgentRuntime;
+}
+
+function chatCompletion(
+  content: string | null,
+  options?: {
+    finishReason?: string;
+    toolCalls?: Array<{
+      id: string;
+      type: "function";
+      function: { name: string; arguments: string };
+    }>;
+  },
+): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl-test",
+      object: "chat.completion",
+      created: 0,
+      model: "grok-3-mini",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content,
+            ...(options?.toolCalls ? { tool_calls: options.toolCalls } : {}),
+          },
+          finish_reason: options?.finishReason ?? "stop",
+        },
+      ],
+      usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function sseResponse(lines: string[]): Response {
+  return new Response(lines.join("\n"), {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+const emitEventOf = (runtime: IAgentRuntime) =>
+  (runtime as unknown as { emitEvent: ReturnType<typeof vi.fn> }).emitEvent;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("xAI credential and config failure surfaces", () => {
+  it("throws a typed missing-credential error before any request", async () => {
+    const fetchMock = vi.fn(async () => chatCompletion("hi"));
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch, {
+      XAI_API_KEY: null,
+      GROK_API_KEY: null,
+    });
+
+    await expect(handleTextSmall(runtime, { prompt: "hi" })).rejects.toThrow(
+      "XAI_API_KEY is required",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a misconfigured XAI_BASE_URL with the original parse failure as cause", async () => {
+    const runtime = createRuntime(undefined, { XAI_BASE_URL: "not a url" });
+
+    const error = await handleTextSmall(runtime, { prompt: "hi" }).then(
+      () => {
+        throw new Error("expected rejection");
+      },
+      (e: unknown) => e as Error,
+    );
+    expect(error.message).toBe("XAI_BASE_URL must be a valid URL");
+    expect(error.cause).toBeDefined();
+  });
+});
+
+describe("xAI provider rejection surfaces", () => {
+  it.each([
+    [401, "Invalid API key"],
+    [429, "rate limited"],
+    [500, "internal error"],
+  ])("surfaces a %d as a typed error without a usage event", async (status, message) => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ error: message }), { status }),
+    );
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(handleTextSmall(runtime, { prompt: "hi" })).rejects.toThrow(
+      `Grok API error (${status})`,
+    );
+    expect(emitEventOf(runtime)).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a malformed (non-JSON) 200 response as a typed error", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response("<html>oops</html>", { status: 200 }),
+    );
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(handleTextSmall(runtime, { prompt: "hi" })).rejects.toThrow();
+    expect(emitEventOf(runtime)).not.toHaveBeenCalled();
+  });
+});
+
+describe("xAI empty-completion surfaces (throw, never fabricate)", () => {
+  it("keeps the prompt-only empty-content failure typed (regression)", async () => {
+    const fetchMock = vi.fn(async () =>
+      chatCompletion(null, { finishReason: "stop" }),
+    );
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(handleTextSmall(runtime, { prompt: "hi" })).rejects.toThrow(
+      "No content in Grok response",
+    );
+    expect(emitEventOf(runtime)).not.toHaveBeenCalled();
+  });
+
+  it("throws MODEL_EMPTY_COMPLETION for a native call with no text and no tool calls", async () => {
+    const fetchMock = vi.fn(async () =>
+      chatCompletion(null, { finishReason: "stop" }),
+    );
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(
+      handleTextSmall(runtime, {
+        prompt: "use the tool",
+        tools: [{ name: "lookup", parameters: { type: "object" } }],
+      } as never),
+    ).rejects.toMatchObject({ code: "MODEL_EMPTY_COMPLETION" });
+    expect(emitEventOf(runtime)).not.toHaveBeenCalled();
+  });
+
+  it("still succeeds for a tool-call-only native completion", async () => {
+    const fetchMock = vi.fn(async () =>
+      chatCompletion(null, {
+        finishReason: "tool_calls",
+        toolCalls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: { name: "lookup", arguments: '{"q":1}' },
+          },
+        ],
+      }),
+    );
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    const result = (await handleTextSmall(runtime, {
+      prompt: "use the tool",
+      tools: [{ name: "lookup", parameters: { type: "object" } }],
+    } as never)) as unknown as {
+      text: string;
+      toolCalls: Array<{ toolName: string }>;
+    };
+
+    expect(result.text).toBe("");
+    expect(result.toolCalls).toEqual([
+      expect.objectContaining({ toolName: "lookup", input: { q: 1 } }),
+    ]);
+    expect(emitEventOf(runtime)).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("xAI stream failure surfaces", () => {
+  it("throws MODEL_EMPTY_COMPLETION when the stream delivers zero content chunks", async () => {
+    const fetchMock = vi.fn(async () => sseResponse(["data: [DONE]", ""]));
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    const result = await handleTextSmall(runtime, {
+      prompt: "hi",
+      stream: true,
+    } as never);
+    const consume = async () => {
+      for await (const _chunk of (
+        result as { textStream: AsyncIterable<string> }
+      ).textStream) {
+        // drain
+      }
+    };
+    await expect(consume()).rejects.toMatchObject({
+      code: "MODEL_EMPTY_COMPLETION",
+    });
+    expect(emitEventOf(runtime)).not.toHaveBeenCalled();
+  });
+
+  it("keeps the stream success path intact: chunks delivered, usage emitted", async () => {
+    const fetchMock = vi.fn(async () =>
+      sseResponse([
+        'data: {"choices":[{"delta":{"content":"hel"},"finish_reason":null}]}',
+        'data: {"choices":[{"delta":{"content":"lo"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}',
+        "data: [DONE]",
+        "",
+      ]),
+    );
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    const result = (await handleTextSmall(runtime, {
+      prompt: "hi",
+      stream: true,
+    } as never)) as unknown as {
+      textStream: AsyncIterable<string>;
+      text: Promise<string>;
+      finishReason: Promise<string | undefined>;
+    };
+    const chunks: string[] = [];
+    for await (const chunk of result.textStream) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual(["hel", "lo"]);
+    await expect(result.text).resolves.toBe("hello");
+    await expect(result.finishReason).resolves.toBe("stop");
+    expect(emitEventOf(runtime)).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("xAI embedding failure surfaces", () => {
+  it("surfaces a 429 as a typed error, never a fabricated vector", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "rate limited" }), {
+          status: 429,
+        }),
+    );
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(handleTextEmbedding(runtime, "hello")).rejects.toThrow(
+      "Grok Embedding API error (429)",
+    );
+    expect(emitEventOf(runtime)).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a malformed embedding response (no vector) as a typed error", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ object: "list", data: [], model: "grok-embedding" }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    );
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(handleTextEmbedding(runtime, "hello")).rejects.toThrow(
+      "No embedding in Grok response",
+    );
+  });
+});

--- a/plugins/plugin-xai/models/grok.ts
+++ b/plugins/plugin-xai/models/grok.ts
@@ -8,6 +8,7 @@
 import {
   buildCanonicalSystemPrompt,
   dropDuplicateLeadingSystemMessage,
+  ElizaError,
   type EventPayload,
   EventType,
   type GenerateTextParams,
@@ -53,8 +54,10 @@ function normalizeBaseUrl(value: unknown): string {
   let url: URL;
   try {
     url = new URL(raw);
-  } catch {
-    throw new Error("XAI_BASE_URL must be a valid URL");
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow — names the misconfigured
+    // setting; the original URL parse failure travels as `cause`.
+    throw new Error("XAI_BASE_URL must be a valid URL", { cause: error });
   }
   if (url.protocol !== "http:" && url.protocol !== "https:") {
     throw new Error("XAI_BASE_URL must use http or https");
@@ -599,6 +602,25 @@ async function generateText(
         throw new Error("No content in Grok response");
       }
 
+      // A native completion with no text and no tool calls is a provider
+      // failure (empty choices, moderation, truncation) — never a legitimate
+      // result. Returning an empty native shape would fabricate a
+      // healthy-empty completion and emit success usage telemetry for it
+      // (#9324: throw, never fabricate). Tool-call-only completions pass.
+      if (!rawText && rawToolCalls.length === 0) {
+        throw new ElizaError(
+          `[xAI] ${modelType} returned an empty completion${
+            choice?.finish_reason
+              ? ` (finishReason: ${choice.finish_reason})`
+              : ""
+          }`,
+          {
+            code: "MODEL_EMPTY_COMPLETION",
+            context: { modelType, model, finishReason: choice?.finish_reason },
+          },
+        );
+      }
+
       emitModelUsed(
         runtime,
         modelType,
@@ -730,6 +752,21 @@ function createStreamTextResult(
       }
 
       const fullText = chunks.join("");
+      // A stream that delivered zero content chunks is a provider failure
+      // (empty body, non-SSE payload, moderation) — ending it as a healthy ""
+      // completion with success usage telemetry would hide the broken
+      // pipeline from the planner (#9324: throw, never fabricate).
+      if (chunks.length === 0) {
+        throw new ElizaError(
+          `[xAI] ${modelType} stream produced no content${
+            finishReason ? ` (finishReason: ${finishReason})` : ""
+          }`,
+          {
+            code: "MODEL_EMPTY_COMPLETION",
+            context: { modelType, model, finishReason },
+          },
+        );
+      }
       const finalUsage = usage ?? estimateUsage(promptText, fullText);
       emitModelUsed(runtime, modelType, responseModel, finalUsage);
 
@@ -742,14 +779,26 @@ function createStreamTextResult(
     },
   );
 
+  // error-policy:J5 unhandled-rejection suppression — consumers typically
+  // iterate only `textStream`; the companion promises (text/usage/finishReason)
+  // would otherwise each surface a stream failure as an unhandled rejection.
+  // The failure IS observed by the textStream consumer (the generator awaits
+  // `state` and rethrows). Mirrors plugin-anthropic/plugin-openai
+  // `handledPromise`.
+  const handledPromise = <T>(value: T | PromiseLike<T>): Promise<T> => {
+    const promise = Promise.resolve(value);
+    promise.catch(() => {});
+    return promise;
+  };
+
   return {
     textStream: (async function* () {
       const result = await state;
       yield* result.chunks;
     })(),
-    text: state.then((result) => result.fullText),
-    usage: state.then((result) => result.usage),
-    finishReason: state.then((result) => result.finishReason),
+    text: handledPromise(state.then((result) => result.fullText)),
+    usage: handledPromise(state.then((result) => result.usage)),
+    finishReason: handledPromise(state.then((result) => result.finishReason)),
   };
 }
 
@@ -758,6 +807,10 @@ function parseJsonOrRaw(value: unknown): unknown {
   try {
     return JSON.parse(value);
   } catch {
+    // error-policy:J3 untrusted-input sanitizing — model-emitted tool-call
+    // arguments that are not valid JSON pass through as the raw string, so
+    // the consumer sees exactly what the model produced; nothing fake-valid
+    // is fabricated.
     return value;
   }
 }

--- a/plugins/plugin-zai/__tests__/error-policy.shape.test.ts
+++ b/plugins/plugin-zai/__tests__/error-policy.shape.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Failure-path tests for the #12182 error-handling policy (#12795): missing
+ * credential, provider 4xx rejection, malformed responses, and
+ * empty-completion fabrication for the z.ai text handlers, driven through the
+ * REAL `ai` + `@ai-sdk/openai-compatible` stack against a stubbed
+ * `runtime.fetch` transport — no live API. Every failure must surface as a
+ * typed error — never a fabricated "" completion or success MODEL_USED event.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleTextSmall } from "../models/text";
+
+function createRuntime(
+  fetchImpl: typeof fetch | undefined,
+  settings: Record<string, string | null> = {}
+): IAgentRuntime {
+  const defaults: Record<string, string> = { ZAI_API_KEY: "test-key" };
+  return {
+    character: { system: "system prompt" },
+    emitEvent: vi.fn(async () => undefined),
+    fetch: fetchImpl,
+    getSetting: vi.fn((key: string) =>
+      key in settings ? settings[key] : (defaults[key] ?? undefined)
+    ),
+  } as unknown as IAgentRuntime;
+}
+
+function chatCompletion(content: string, finishReason = "stop"): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl-test",
+      object: "chat.completion",
+      created: 0,
+      model: "glm-4.5-air",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content },
+          finish_reason: finishReason,
+        },
+      ],
+      usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+}
+
+const emitEventOf = (runtime: IAgentRuntime) =>
+  (runtime as unknown as { emitEvent: ReturnType<typeof vi.fn> }).emitEvent;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("z.ai failure surfaces (real ai + @ai-sdk/openai-compatible, stubbed transport)", () => {
+  it("throws a typed missing-credential error before any request", async () => {
+    const fetchMock = vi.fn(async () => chatCompletion("hi"));
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch, {
+      ZAI_API_KEY: null,
+      Z_AI_API_KEY: null,
+    });
+
+    await expect(handleTextSmall(runtime, { prompt: "hi" })).rejects.toThrow(
+      "ZAI_API_KEY is required"
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a 401 bad credential as a typed rejection without a usage event", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: { message: "Invalid API key" } }), { status: 401 })
+    );
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(handleTextSmall(runtime, { prompt: "hi" })).rejects.toMatchObject({
+      statusCode: 401,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(emitEventOf(runtime)).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a malformed (non-JSON) 200 response as a typed error", async () => {
+    const fetchMock = vi.fn(async () => new Response("<html>oops</html>", { status: 200 }));
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(handleTextSmall(runtime, { prompt: "hi" })).rejects.toThrow();
+    expect(emitEventOf(runtime)).not.toHaveBeenCalled();
+  });
+
+  it("throws MODEL_EMPTY_COMPLETION for an empty completion instead of returning ''", async () => {
+    const fetchMock = vi.fn(async () => chatCompletion("", "stop"));
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(handleTextSmall(runtime, { prompt: "hi" })).rejects.toMatchObject({
+      code: "MODEL_EMPTY_COMPLETION",
+    });
+    // No success telemetry for a fabricated-empty result.
+    expect(emitEventOf(runtime)).not.toHaveBeenCalled();
+  });
+
+  it("keeps the success path intact: non-empty completion resolves and emits usage", async () => {
+    const fetchMock = vi.fn(async () => chatCompletion("hello"));
+    const runtime = createRuntime(fetchMock as unknown as typeof fetch);
+
+    await expect(handleTextSmall(runtime, { prompt: "hi" })).resolves.toBe("hello");
+    expect(emitEventOf(runtime)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-zai/__tests__/text-params.test.ts
+++ b/plugins/plugin-zai/__tests__/text-params.test.ts
@@ -13,6 +13,18 @@ vi.mock("@ai-sdk/openai-compatible", () => ({
 }));
 
 vi.mock("@elizaos/core", () => ({
+  ElizaError: class extends Error {
+    readonly code: string;
+    readonly context?: Record<string, unknown>;
+    constructor(
+      message: string,
+      options: { code: string; context?: Record<string, unknown>; cause?: unknown }
+    ) {
+      super(message, options.cause !== undefined ? { cause: options.cause } : undefined);
+      this.code = options.code;
+      this.context = options.context;
+    }
+  },
   logger: { log: vi.fn() },
   ModelType: { TEXT_SMALL: "TEXT_SMALL", TEXT_LARGE: "TEXT_LARGE" },
 }));

--- a/plugins/plugin-zai/models/text.ts
+++ b/plugins/plugin-zai/models/text.ts
@@ -10,15 +10,17 @@
  * expects a top-level `thinking` body field the SDK does not natively emit.
  */
 import type { GenerateTextParams, IAgentRuntime } from "@elizaos/core";
-import { logger, ModelType } from "@elizaos/core";
+import { ElizaError, logger, ModelType } from "@elizaos/core";
 import { generateText } from "ai";
 import { createZaiClient, type ZaiFetch } from "../providers";
 import { createModelName, type ModelName, type ModelSize, type ProviderOptions } from "../types";
 import {
+  getApiKey,
   getExperimentalTelemetry,
   getLargeModel,
   getSmallModel,
   getThinkingConfig,
+  isBrowser,
   type ZaiThinkingConfig,
 } from "../utils/config";
 import { emitModelUsageEvent } from "../utils/events";
@@ -92,7 +94,9 @@ function createZaiRequestFetch(thinking: ZaiThinkingConfig | null, baseFetch: Za
           init.body = JSON.stringify(body);
         }
       } catch {
-        // Non-JSON request bodies pass through unchanged.
+        // error-policy:J3 untrusted-input sanitizing — the thinking field is
+        // only injectable into a JSON body; non-JSON request bodies pass
+        // through unchanged rather than being replaced with a fabricated one.
       }
     }
     return baseFetch(input, init);
@@ -107,6 +111,14 @@ async function generateTextWithModel(
   modelSize: ModelSize,
   modelType: typeof ModelType.TEXT_SMALL | typeof ModelType.TEXT_LARGE
 ): Promise<string> {
+  // A missing credential must surface as a typed local failure before any
+  // request goes out — an anonymous request would masquerade as a
+  // provider-side 401 and hide the real misconfiguration. Browser builds are
+  // exempt: they route through a proxy that holds the key
+  // (ZAI_BROWSER_BASE_URL).
+  if (!isBrowser()) {
+    getApiKey(runtime);
+  }
   const experimentalTelemetry = getExperimentalTelemetry(runtime);
   const thinking = getThinkingConfig(runtime, modelSize);
   const requestFetch = createZaiRequestFetch(thinking, (runtime.fetch ?? fetch) as ZaiFetch);
@@ -136,7 +148,26 @@ async function generateTextWithModel(
     ...(typeof resolved.maxTokens === "number" ? { maxTokens: resolved.maxTokens } : {}),
   };
 
-  const { text, usage } = await generateText(generateParams as Parameters<typeof generateText>[0]);
+  const { text, usage, finishReason } = await generateText(
+    generateParams as Parameters<typeof generateText>[0]
+  );
+
+  // An empty completion is a provider failure (moderation, truncation,
+  // upstream bug) — never a legitimate result for this prompt-only handler.
+  // Returning "" would fabricate a healthy-empty completion the planner
+  // cannot distinguish from a real answer, and emit success usage telemetry
+  // for it (#9324: throw, never fabricate).
+  if (text.length === 0) {
+    throw new ElizaError(
+      `[z.ai] ${modelType} returned an empty completion${
+        finishReason ? ` (finishReason: ${finishReason})` : ""
+      }`,
+      {
+        code: "MODEL_EMPTY_COMPLETION",
+        context: { modelType, modelName, finishReason },
+      }
+    );
+  }
 
   if (usage) {
     emitModelUsageEvent(runtime, modelType, usage);


### PR DESCRIPTION
Part of #12795 (closes the non-openai scope; policy #12182; part 1 = #13236 covering anthropic/openrouter/google-genai). Applies the error-handling policy end-to-end to the 5 remaining small hosted-provider plugins. Failure-path handling only — success-path behavior is byte-identical except where a fabricated success is now a typed failure (table below). No request/response shaping changes (that lane is #12752).

## Inventory — fallback sites found / removed / annotated

| Plugin | Sites inventoried | Slop removed | Justified + annotated |
|---|---|---|---|
| plugin-groq | 8 (3 catches, 2 `?? ""` bearer, empty-completion fabrication, retry loop, usage-estimation `?? estimate`) | 4 (empty-completion `""`, 2× empty-bearer missing-credential, cause-less rethrow) | 3 tags (J2×2, J3×1) |
| plugin-xai | 7 (2 catches, native + stream empty fabrication, companion-promise rejections, `?? estimate` usage) | 4 (native empty, stream empty `""` + success event, cause-less rethrow, unguarded companion rejections→J5) | 3 tags (J2, J3, J5) |
| plugin-zai | 3 (1 catch, empty-completion fabrication, keyless anonymous request) | 2 | 1 tag (J3) |
| plugin-nearai | 3 (same trio as zai) | 2 | 1 tag (J3) |
| plugin-anthropic-proxy | 7 catches | 0 — **already compliant** (typed LoadResult failures, documented degrade-to-off with observable startError, structured 500 at the /health boundary) | 7 tags (J1×2, J3×2, J4×3) |

15 grep-able `// error-policy:J<N> <reason>` annotations added; every remaining catch/`.catch` in the 5 plugins now carries one (or throws typed already). Reviewed and left as NOT slop: config-default literals (`?? 0.7` penalties, `?? 8192` caps, `?? "127.0.0.1"` bind host, CoT-budget `return 0` = disabled), dual-field usage normalization (`promptTokens ?? inputTokens ?? 0` in zai/nearai `utils/events.ts` and the groq/xai equivalents), estimated-usage fallbacks (documented, flagged `estimated: true`), and the anthropic-proxy billing-fingerprint `return ""` (part of the hashing algorithm, not error handling).

## Behavior changes (failure paths only)

| File | Before | After |
|---|---|---|
| `plugin-groq/index.ts` | Empty completion (no text, no tool calls) returned `""` as healthy **and emitted a success MODEL_USED event** | Throws `ElizaError { code: MODEL_EMPTY_COMPLETION }` incl. `finishReason`; no success telemetry; tool-call-only completions unaffected |
| `plugin-groq/index.ts` (TRANSCRIPTION, TEXT_TO_SPEECH) | Missing `GROQ_API_KEY` sent `Authorization: Bearer ` (empty, `?? ""`) upstream → masked as a provider 401 | Typed `MODEL_MISSING_CREDENTIAL` throw before any fetch |
| `plugin-groq/index.ts` / `plugin-xai/models/grok.ts` | Invalid `GROQ_BASE_URL`/`XAI_BASE_URL` rethrew without `cause` | Same typed throw, now with `{ cause }` (J2) |
| `plugin-xai/models/grok.ts` (native) | No-text/no-tool-calls native response returned a fabricated empty `XaiNativeTextResult` + success usage event | Throws `MODEL_EMPTY_COMPLETION` incl. `finish_reason`; prompt-only "No content in Grok response" throw unchanged (regression-pinned) |
| `plugin-xai/models/grok.ts` (stream) | Zero-chunk stream resolved `""` + success usage event | textStream consumer gets thrown `MODEL_EMPTY_COMPLETION`; companion promises `handledPromise`-guarded (J5, failure observed via textStream) |
| `plugin-zai/models/text.ts`, `plugin-nearai/models/text.ts` | (a) empty completion → `""` + success MODEL_USED; (b) missing key on Node → anonymous request (provider-side 401 masks local misconfig) | (a) `MODEL_EMPTY_COMPLETION` incl. `finishReason`, no telemetry; (b) the plugin's own typed `*_API_KEY is required` throw before any request. Browser proxy builds exempt (unchanged) |
| `plugin-anthropic-proxy` | — | **No behavior change** — clean result; annotations only |

## Failure-path tests (37 new, all green, all deterministic)

- `plugin-groq/__tests__/error-policy.shape.test.ts` (10) — driven through the **real `ai` + `@ai-sdk/groq` stack** against a stubbed transport: 401/400 typed rejection with no retry + no usage event; `MODEL_EMPTY_COMPLETION` with no telemetry; tool-call-only + non-empty success regressions; misconfigured base URL with `cause`; TRANSCRIPTION/TTS missing-credential (fetch never called) and 502/422 provider failures.
- `plugin-xai/__tests__/error-policy.shape.test.ts` (13) — stubbed `runtime.fetch`: missing key (no fetch); base-URL `cause`; 401/429/500 typed; malformed non-JSON 200; prompt-only empty regression; native `MODEL_EMPTY_COMPLETION`; tool-call-only success; zero-chunk stream throws / successful stream regression (chunks + usage event); embedding 429 + no-vector malformed response.
- `plugin-zai/__tests__/error-policy.shape.test.ts` (5) + `plugin-nearai/__tests__/error-policy.shape.test.ts` (5) — **real `ai` + `@ai-sdk/openai-compatible` stack** over stubbed `runtime.fetch`: missing credential (no fetch), 401 typed with no usage event, malformed 200, `MODEL_EMPTY_COMPLETION` with no telemetry, success regression.
- `plugin-anthropic-proxy/__tests__/error-policy.shape.test.ts` (4) — malformed credentials JSON → typed LoadResult failure; parsed-but-missing accessToken → typed failure; invalid fingerprint config (bad JSON + bad schema) → off-mode degrade with observable `startError` on the service and the status DTO.

Mutation check: disabling the zai empty-completion guard turns its suite red (1 failed), restoring turns it green — the guards are load-bearing (groq/xai/nearai use the identical pattern asserted the same way).

`bunx vitest run --no-cache` per plugin: groq 41 passed / 1 skipped (keyless live guard), xai 40 / 1 skipped (live), zai 34, nearai 22, anthropic-proxy 58 — **195 passed, 2 skipped**. `tsgo --noEmit` clean ×5; biome clean on all touched files; CLAUDE.md/AGENTS.md byte-identical (parity check PASS, 302 pairs).

## Ratchet

`bun run audit:error-policy-ratchet` → **PASS** ("no new fallback-slop in touched files"; the 3 anthropic-proxy `/src/` files matched its production filter, all `emptyCatch 0->0, serverConsole 0->0`). The other 4 plugins keep sources at the plugin root so the filter skips them — manually verified the diff adds zero empty catches and zero `console.*` (the one new `.catch(() => {})` is the J5-annotated `handledPromise` mirror of plugin-anthropic/plugin-openai, and is a method call, not a catch clause).

Not covered on purpose: a live-timing 429-exhaustion e2e for groq's outer retry loop (its server-hinted delays are ≥10s per attempt; `classifyRetryError` classification stays covered by the existing `retry.test.ts`), and zai/nearai 5xx (AI SDK default backoff makes them slow; 401/malformed exercise the same rethrow path immediately).

## PR_EVIDENCE

- Real-model trajectories: **N/A — no happy-path model behavior change**; this PR only changes what happens when the provider FAILS, and those paths are reproduced deterministically at the transport layer through the real AI SDK stacks (groq/zai/nearai) and the real REST parsers (xai).
- Screenshots / video / frontend logs: **N/A — no UI surface**; these plugins register model handlers (+ one diagnostic status route/action, unchanged).
- Backend logs: vitest stderr from the runs shows the real code paths firing (`Groq rate limit`/transient warnings, `[anthropic-proxy] Invalid anthropic proxy config … — falling back to off`, typed throw messages asserted by code/message/cause).
- Domain artifacts: the typed errors themselves (code + finishReason + cause asserted) and the asserted **absence** of success MODEL_USED events on every failure path.

Remaining scope (per the #12795 split): `plugin-openai` only — contested lane, its owner handles it; with #13236 + this PR, 8 of the 9 hosted-provider plugins are done.

[phone-ui]

---
**Authored end-to-end by a Fable-5 agent** (verified 100% claude-fable-5), recovered + pushed by main loop. RECOVERY NOTE: the agent's original push landed on a polluted branch (its `fix/...-pt2` remote ref ended up pointing at an unrelated sibling's computeruse commit — the agent's real commit cbf76b1cf5 didn't become the branch tip). I caught it via mutation-check (the fetched branch was empty), located the agent's complete commit cbf76b1cf5 (correctly based on post-#13236 develop 9f83ba8752), verified it, and re-pushed to this clean branch. Verification on the REAL commit: pure-Fable ✓; all 5 plugins present; 197/198 tests green (1 skipped keyless-live guard) incl. 37 new failure-path tests; groq mutation independently reproduced (revert index.ts → 4 red; restore → green). Same THROW-never-fabricate class as part-1 (#13236). CLOSES the non-openai scope of #12795 (8/9); plugin-openai remains with its lane owner. — [phone-ui]