### PR TITLE
fix(providers): finish hosted provider tail error-policy sweep

### DIFF
--- a/plugins/plugin-anthropic-proxy/src/proxy/server.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/server.ts
@@ -384,6 +384,8 @@ export class ProxyServer {
         })
       );
     } catch (e) {
+      // error-policy:J6 best-effort diagnostics - /health should return a
+      // structured error payload if stats serialization fails.
       res.writeHead(500, { "Content-Type": "application/json" });
       res.end(
         JSON.stringify({

--- a/plugins/plugin-anthropic-proxy/src/services/proxy-service.ts
+++ b/plugins/plugin-anthropic-proxy/src/services/proxy-service.ts
@@ -180,6 +180,8 @@ function resolveFingerprintConfig(): {
       fingerprintConfig: loadFingerprintConfig(configPath),
     };
   } catch (error) {
+    // error-policy:J3 untrusted-input sanitizing - a bad optional fingerprint
+    // config disables the proxy and reports startError instead of crashing boot.
     return {
       configPath,
       configError: `Invalid anthropic proxy config ${configPath}: ${
@@ -257,6 +259,8 @@ export class AnthropicProxyService extends Service {
       try {
         service.effectiveUrl = validateSharedUpstream(config.upstream);
       } catch (e) {
+        // error-policy:J3 untrusted-input sanitizing - unsafe shared upstreams
+        // degrade the opt-in proxy to off and surface startError.
         service.startError = (e as Error).message;
         logger.warn(`[anthropic-proxy] ${service.startError} — falling back to off`);
         service.effectiveMode = "off";
@@ -301,6 +305,8 @@ export class AnthropicProxyService extends Service {
       setAnthropicBaseUrl(service.effectiveUrl);
       logger.info(`[anthropic-proxy] mode=inline — listening on ${service.effectiveUrl}`);
     } catch (e) {
+      // error-policy:J6 optional-service degradation - proxy startup failure
+      // is reported in status while the agent continues without middleware.
       service.startError = (e as Error).message;
       logger.warn(
         `[anthropic-proxy] failed to start inline proxy (${service.startError}). ` +
@@ -360,6 +366,8 @@ export class AnthropicProxyService extends Service {
         });
         upstream = { reachable: r.ok, status: r.status };
       } catch (e) {
+        // error-policy:J6 best-effort diagnostics - status should report an
+        // unreachable shared proxy, not fail the status action/route.
         upstream = {
           reachable: false,
           error: (e as Error).message,

--- a/plugins/plugin-anthropic-proxy/src/utils/credentials-loader.ts
+++ b/plugins/plugin-anthropic-proxy/src/utils/credentials-loader.ts
@@ -45,6 +45,8 @@ function jwtExpiresAt(token: string): number {
     const parsed = JSON.parse(json) as { exp?: number };
     return typeof parsed.exp === "number" ? parsed.exp * 1000 : 0;
   } catch {
+    // error-policy:J3 untrusted-input sanitizing - token expiry is diagnostic;
+    // malformed JWTs still authenticate via the token itself.
     return 0;
   }
 }
@@ -100,6 +102,8 @@ export function loadCredentials(
         };
       }
     } catch (e) {
+      // error-policy:J3 untrusted-input sanitizing - unreadable credentials
+      // are reported as load errors so the proxy can degrade to off.
       return {
         creds: null,
         error: `failed to read ${resolved}: ${(e as Error).message}`,

--- a/plugins/plugin-groq/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-groq/__tests__/native-plumbing.shape.test.ts
@@ -95,6 +95,35 @@ describe("Groq native text plumbing", () => {
     expect(result).toBe("hello");
   });
 
+  it("rejects empty plain completions instead of fabricating success", async () => {
+    const generateText = vi.fn(async () => ({
+      text: "",
+      finishReason: "content-filter",
+      usage: { inputTokens: 3, outputTokens: 0, totalTokens: 3 },
+    }));
+    vi.doMock("ai", async () => {
+      const actual = await vi.importActual<typeof import("ai")>("ai");
+      return { ...actual, generateText };
+    });
+    vi.doMock("@ai-sdk/groq", () => ({
+      createGroq: () => ({
+        languageModel: (modelName: string) => ({ modelName }),
+      }),
+    }));
+
+    const { groqPlugin } = await import("../index");
+    const runtime = createRuntime();
+    const handler = groqPlugin.models?.TEXT_SMALL as (
+      runtime: IAgentRuntime,
+      params: unknown
+    ) => Promise<unknown>;
+
+    await expect(handler(runtime, { prompt: "blocked prompt" })).rejects.toThrow(
+      "Groq TEXT_SMALL returned an empty completion"
+    );
+    expect(runtime.emitEvent).not.toHaveBeenCalled();
+  });
+
   it("sanitizes malformed generation options before calling the provider", async () => {
     const generateText = vi.fn(async () => ({
       text: "safe",

--- a/plugins/plugin-groq/index.ts
+++ b/plugins/plugin-groq/index.ts
@@ -152,6 +152,8 @@ function stringifyForUsage(value: unknown): string {
   try {
     return JSON.stringify(value);
   } catch {
+    // error-policy:J3 untrusted-input sanitizing - token estimation must not fail
+    // because a provider result contains circular/non-JSON metadata.
     return String(value);
   }
 }
@@ -247,6 +249,8 @@ function getBaseURL(runtime: IAgentRuntime): string {
   try {
     parsed = new URL(configured);
   } catch {
+    // error-policy:J2 context-adding rethrow - expose the invalid setting name
+    // instead of leaking the URL parser's lower-level message.
     throw new Error("GROQ_BASE_URL must be a valid http(s) URL");
   }
 
@@ -622,6 +626,9 @@ async function generateWithRetry(
   while (true) {
     try {
       const result = await generate();
+      if (!params.returnNative && !result.text) {
+        throw new Error(`Groq ${modelType} returned an empty completion`);
+      }
       const usage = normalizeTokenUsage(result.usage) ?? estimateUsage(params.prompt, result.text);
       emitModelUsed(runtime, modelType, model, usage);
       if (params.returnNative) {
@@ -630,6 +637,8 @@ async function generateWithRetry(
       const { text } = result;
       return text;
     } catch (error) {
+      // error-policy:J2 context-aware retry gate - retry only typed rate-limit
+      // and transient failures, then rethrow the original provider failure.
       const kind = classifyRetryError(error);
 
       if (kind === "rate-limit" && rateLimitAttempts < MAX_RATE_LIMIT_RETRIES) {

--- a/plugins/plugin-nearai/models/text.ts
+++ b/plugins/plugin-nearai/models/text.ts
@@ -75,7 +75,8 @@ function createNearAIRequestFetch(baseFetch: NearAIFetch): NearAIFetch {
         }
         init.body = JSON.stringify(body);
       } catch {
-        // Non-JSON request bodies pass through unchanged.
+        // error-policy:J3 untrusted-input sanitizing - non-JSON request bodies
+        // are outside the chat-completion shim and must pass through unchanged.
       }
     }
     return baseFetch(input, init);

--- a/plugins/plugin-xai/models/grok.ts
+++ b/plugins/plugin-xai/models/grok.ts
@@ -54,6 +54,8 @@ function normalizeBaseUrl(value: unknown): string {
   try {
     url = new URL(raw);
   } catch {
+    // error-policy:J2 context-adding rethrow - expose the invalid setting name
+    // instead of leaking the URL parser's lower-level message.
     throw new Error("XAI_BASE_URL must be a valid URL");
   }
   if (url.protocol !== "http:" && url.protocol !== "https:") {
@@ -758,6 +760,8 @@ function parseJsonOrRaw(value: unknown): unknown {
   try {
     return JSON.parse(value);
   } catch {
+    // error-policy:J3 untrusted-input sanitizing - xAI may stream tool
+    // arguments as partial/non-JSON strings; preserve the raw value.
     return value;
   }
 }

--- a/plugins/plugin-zai/models/text.ts
+++ b/plugins/plugin-zai/models/text.ts
@@ -92,7 +92,8 @@ function createZaiRequestFetch(thinking: ZaiThinkingConfig | null, baseFetch: Za
           init.body = JSON.stringify(body);
         }
       } catch {
-        // Non-JSON request bodies pass through unchanged.
+        // error-policy:J3 untrusted-input sanitizing - non-JSON request bodies
+        // are outside the chat-completion shim and must pass through unchanged.
       }
     }
     return baseFetch(input, init);


### PR DESCRIPTION
Part of #12795 (split of #12271; policy #12182). This finishes the non-OpenAI tail called out after #13236: `plugin-anthropic-proxy`, `plugin-groq`, `plugin-xai`, `plugin-zai`, and `plugin-nearai`.

## Inventory

- `plugin-groq`: 3 catch sites annotated, and one real slop behavior removed. Plain text generation now throws on an empty provider completion before emitting `MODEL_USED`, instead of returning `""` as a successful completion. Native/tool-call results remain unchanged.
- `plugin-anthropic-proxy`: 7 catch/degradation sites annotated. The existing behavior is intentional opt-in middleware degradation or status diagnostics: invalid config/upstream/startup failures surface through `startError`, and status/health stays structured.
- `plugin-xai`: 2 catch sites annotated. Existing behavior already rejects empty non-native completions; tool-argument JSON parsing preserves raw provider strings when arguments are non-JSON.
- `plugin-zai` and `plugin-nearai`: request-body shim catches annotated. Non-JSON bodies pass through unchanged; provider failures are not swallowed.

## Tests / Verification

Passed:

```bash
TMPDIR=/private/tmp/codex-test-tmp bun run --cwd plugins/plugin-groq test
TMPDIR=/private/tmp/codex-test-tmp bun run --cwd plugins/plugin-anthropic-proxy test
TMPDIR=/private/tmp/codex-test-tmp bun run --cwd plugins/plugin-xai test
TMPDIR=/private/tmp/codex-test-tmp bun run --cwd plugins/plugin-zai test
TMPDIR=/private/tmp/codex-test-tmp bun run --cwd plugins/plugin-nearai test
TMPDIR=/private/tmp/codex-test-tmp bun run --cwd plugins/plugin-groq typecheck && TMPDIR=/private/tmp/codex-test-tmp bun run --cwd plugins/plugin-groq lint:check
TMPDIR=/private/tmp/codex-test-tmp bun run --cwd plugins/plugin-anthropic-proxy typecheck && TMPDIR=/private/tmp/codex-test-tmp bunx biome check plugins/plugin-anthropic-proxy
TMPDIR=/private/tmp/codex-test-tmp bun run --cwd plugins/plugin-xai typecheck && TMPDIR=/private/tmp/codex-test-tmp bun run --cwd plugins/plugin-xai lint
TMPDIR=/private/tmp/codex-test-tmp bun run --cwd plugins/plugin-zai typecheck && TMPDIR=/private/tmp/codex-test-tmp bun run --cwd plugins/plugin-zai lint:check
TMPDIR=/private/tmp/codex-test-tmp bun run --cwd plugins/plugin-nearai typecheck && TMPDIR=/private/tmp/codex-test-tmp bunx biome check plugins/plugin-nearai
bunx biome check plugins/plugin-anthropic-proxy/src/services/proxy-service.ts plugins/plugin-anthropic-proxy/src/utils/credentials-loader.ts plugins/plugin-anthropic-proxy/src/proxy/server.ts plugins/plugin-groq/index.ts plugins/plugin-groq/__tests__/native-plumbing.shape.test.ts plugins/plugin-xai/models/grok.ts plugins/plugin-zai/models/text.ts plugins/plugin-nearai/models/text.ts
git diff --check
```

Root sync steps completed before opening: `git fetch origin && git rebase origin/develop`, then `bun install`.

Root `bun run verify` was attempted. It passed `check:agents-claude`, `audit:type-safety-ratchet`, and `audit:error-policy-ratchet` for the touched production files, then failed in the broad Turbo lint phase on pre-existing unrelated `@elizaos/tui#lint` diagnostics (`noControlCharactersInRegex` and non-null assertions). Root lint also produced unrelated write-mode Biome side effects, which were restored; the branch worktree is clean.

## PR_EVIDENCE

- Real model trajectories: N/A. This PR changes provider failure/error-policy handling only; no happy-path request shaping or model behavior is changed. The only behavior change is a Groq empty-completion failure path, covered by a deterministic provider-stack unit test asserting no success telemetry is emitted.
- Screenshots/video/frontend logs: N/A, no UI surface.
- Backend logs: N/A beyond test stderr; affected packages are model/proxy handlers with unit-level failure-path coverage.

After this PR, #12795's non-OpenAI remainder is covered. `plugin-openai` remains intentionally outside this PR because the issue thread marks it as a contested separate lane.
