### PR TITLE
refactor(#12251): additive alias-aware env reader (slice 1)

### DIFF
--- a/packages/core/src/boot-env.test.ts
+++ b/packages/core/src/boot-env.test.ts
@@ -8,6 +8,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { peekAmbientSingleton } from "./ambient-context";
 import {
+	resolveAliasedEnvValue,
 	syncAppEnvToEliza,
 	syncBrandEnvToEliza,
 	syncElizaEnvToBrand,
@@ -170,5 +171,98 @@ describe("boot config store is write-once", () => {
 		const viaAccessor = peekAmbientSingleton(STORE_KEY);
 		expect(viaAccessor).toBeDefined();
 		expect(viaAccessor).toBe(slot[STORE_KEY]);
+	});
+});
+
+// resolveAliasedEnvValue is the additive read-side migration target (#12251
+// slice 1): it resolves a brand<->eliza alias WITHOUT mutating process.env, so a
+// read site can stop depending on the sync* mutation. These cases prove it
+// resolves both directions, prefers the exact key, and never writes.
+describe("resolveAliasedEnvValue (non-mutating alias reader)", () => {
+	const BRAND = "MYBRAND_STATE_DIR";
+	const ELIZA = "ELIZA_STATE_DIR";
+	const OTHER = "MYBRAND_API_TOKEN";
+	const ELIZA_OTHER = "ELIZA_API_TOKEN";
+	const savedEnv: Record<string, string | undefined> = {};
+	const tracked = [BRAND, ELIZA, OTHER, ELIZA_OTHER];
+	const ALIASES = [
+		[BRAND, ELIZA],
+		[OTHER, ELIZA_OTHER],
+	] as const;
+
+	beforeEach(() => {
+		for (const key of tracked) {
+			savedEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+	});
+
+	afterEach(() => {
+		for (const key of tracked) {
+			if (savedEnv[key] === undefined) delete process.env[key];
+			else process.env[key] = savedEnv[key];
+		}
+	});
+
+	it("resolves the branded value when only the branded key is set", () => {
+		process.env[BRAND] = "branded-state-dir";
+		expect(resolveAliasedEnvValue(ELIZA, ALIASES)).toBe("branded-state-dir");
+	});
+
+	it("resolves the eliza value when only the eliza key is set", () => {
+		process.env[ELIZA] = "eliza-state-dir";
+		expect(resolveAliasedEnvValue(BRAND, ALIASES)).toBe("eliza-state-dir");
+	});
+
+	it("prefers the exact requested key over its alias partner", () => {
+		process.env[BRAND] = "branded";
+		process.env[ELIZA] = "eliza";
+		expect(resolveAliasedEnvValue(ELIZA, ALIASES)).toBe("eliza");
+		expect(resolveAliasedEnvValue(BRAND, ALIASES)).toBe("branded");
+	});
+
+	it("returns undefined when neither the key nor its alias is set", () => {
+		expect(resolveAliasedEnvValue(ELIZA, ALIASES)).toBeUndefined();
+	});
+
+	it("does not resolve across unrelated alias pairs", () => {
+		process.env[ELIZA_OTHER] = "token-value";
+		// STATE_DIR must not pick up an API_TOKEN value from a different pair.
+		expect(resolveAliasedEnvValue(ELIZA, ALIASES)).toBeUndefined();
+	});
+
+	it("never mutates process.env while resolving", () => {
+		process.env[BRAND] = "branded-only";
+		const before = { ...process.env };
+		resolveAliasedEnvValue(ELIZA, ALIASES);
+		resolveAliasedEnvValue(BRAND, ALIASES);
+		// The eliza target must remain unset — the reader is additive, not a mirror.
+		expect(process.env[ELIZA]).toBeUndefined();
+		expect(process.env).toEqual(before);
+	});
+
+	it("treats an empty alias table as no aliasing", () => {
+		process.env[BRAND] = "branded-only";
+		expect(resolveAliasedEnvValue(ELIZA, [])).toBeUndefined();
+		expect(resolveAliasedEnvValue(BRAND, [])).toBe("branded-only");
+	});
+
+	it("a blank canonical value does not shadow a present branded alias", () => {
+		// Regression for the empty-string masking bug: the old sync path never
+		// let a blank ELIZA_ value suppress a real branded alias, so the reader
+		// must fall through to the branded value instead of resolving as unset.
+		process.env[ELIZA] = "";
+		process.env[BRAND] = "real-branded";
+		expect(resolveAliasedEnvValue(ELIZA, ALIASES)).toBe("real-branded");
+
+		process.env[ELIZA_OTHER] = "   ";
+		process.env[OTHER] = "real-token";
+		expect(resolveAliasedEnvValue(ELIZA_OTHER, ALIASES)).toBe("real-token");
+	});
+
+	it("returns undefined when both key and alias are blank", () => {
+		process.env[ELIZA] = "";
+		process.env[BRAND] = "  ";
+		expect(resolveAliasedEnvValue(ELIZA, ALIASES)).toBeUndefined();
 	});
 });

--- a/packages/core/src/boot-env.ts
+++ b/packages/core/src/boot-env.ts
@@ -129,3 +129,87 @@ export function syncElizaEnvAliases(): void {
 	const aliases = getBootConfig().envAliases;
 	if (aliases) syncElizaEnvToBrand(aliases);
 }
+
+/**
+ * Build a bidirectional key -> alias-partners lookup from the alias pair table.
+ *
+ * Each `[brandKey, elizaKey]` pair contributes both directions so a lookup of
+ * either name yields its partner(s). A single key can participate in more than
+ * one pair (kept as a list) so no alias is silently dropped.
+ */
+function buildAliasPartnerMap(
+	aliases: readonly (readonly [string, string])[],
+): Map<string, string[]> {
+	const map = new Map<string, string[]>();
+	const link = (from: string, to: string): void => {
+		if (from === to) return;
+		const existing = map.get(from);
+		if (existing) {
+			if (!existing.includes(to)) existing.push(to);
+		} else {
+			map.set(from, [to]);
+		}
+	};
+	for (const [brandKey, elizaKey] of aliases) {
+		link(brandKey, elizaKey);
+		link(elizaKey, brandKey);
+	}
+	return map;
+}
+
+/**
+ * An env value counts as "present" only when it is a non-empty (after trim)
+ * string. This mirrors the shared `normalizeEnvValue` / `readEnv` contract
+ * (empty / whitespace-only = unset) AND the `syncBrandEnvToEliza` mutation,
+ * which only mirrors a source when `typeof value === "string"` but a blank
+ * ELIZA_ value never suppressed a non-blank branded alias in the old sync path.
+ * Treating a blank direct value as present would let `ELIZA_API_TOKEN=""`
+ * shadow a real `ACME_API_TOKEN`, resolving a set alias as missing.
+ */
+function presentEnvValue(value: string | undefined): string | undefined {
+	if (typeof value !== "string") return undefined;
+	return value.trim() ? value : undefined;
+}
+
+/**
+ * Additive, NON-mutating alias-aware env reader (arch-audit #12251, slice 1).
+ *
+ * Resolves an env value for `key` by consulting the brand<->eliza alias table
+ * WITHOUT writing anything to `process.env`. The requested key wins when it is
+ * present (non-empty); a blank/whitespace value is treated as absent so a real
+ * alias partner still surfaces. If the key is absent, the first present alias
+ * partner (in alias-table order) is returned. This is the read-side migration
+ * target that lets call sites stop depending on the `syncBrandEnvToEliza` /
+ * `syncElizaEnvToBrand` mutation — the mutation stays in place as a fallback
+ * until every raw aliased read is migrated (per the staged plan on the issue).
+ *
+ * @param key       the env key a caller wants to read
+ * @param aliases   alias pair table; defaults to the immutable BootConfig list
+ * @param env       env source; defaults to the live `process.env`
+ * @returns the resolved value, or `undefined` when neither key nor an alias
+ *          partner is present
+ */
+export function resolveAliasedEnvValue(
+	key: string,
+	aliases: readonly (readonly [string, string])[] | undefined = getBootConfig()
+		.envAliases,
+	env: Record<string, string | undefined> | null = getProcessEnv(),
+): string | undefined {
+	if (!env) return undefined;
+
+	// The exact key takes precedence when it carries a real value — but a blank
+	// value must NOT shadow a present alias partner (see presentEnvValue).
+	const direct = presentEnvValue(env[key]);
+	if (direct !== undefined) return direct;
+
+	if (!aliases || aliases.length === 0) return undefined;
+
+	const partners = buildAliasPartnerMap(aliases).get(key);
+	if (!partners) return undefined;
+
+	for (const partner of partners) {
+		const value = presentEnvValue(env[partner]);
+		if (value !== undefined) return value;
+	}
+	return undefined;
+}

--- a/packages/shared/src/config/boot-config-store.ts
+++ b/packages/shared/src/config/boot-config-store.ts
@@ -8,7 +8,11 @@
 
 import type { BrandingConfig } from "./branding.js";
 
-export { syncBrandEnvToEliza, syncElizaEnvToBrand } from "@elizaos/core";
+export {
+  resolveAliasedEnvValue,
+  syncBrandEnvToEliza,
+  syncElizaEnvToBrand,
+} from "@elizaos/core";
 
 export interface BundledVrmAsset {
   title: string;

--- a/packages/shared/src/utils/env.test.ts
+++ b/packages/shared/src/utils/env.test.ts
@@ -3,12 +3,14 @@
  * normalize to absent, and isEnvDisabled must treat only explicit falsy tokens
  * as "off" (default-enabled) — a loose check here would flip feature defaults.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getBootConfig, setBootConfig } from "../config/boot-config.js";
 import {
   DEFAULT_APP_ROUTE_PLUGIN_MODULES,
   isEnvDisabled,
   normalizeEnvValue,
   normalizeEnvValueOrNull,
+  readAliasedEnv,
   syncElizaEnvAliases,
 } from "./env";
 
@@ -30,6 +32,104 @@ describe("isEnvDisabled", () => {
     for (const v of ["1", "true", "on", "yes", "", undefined]) {
       expect(isEnvDisabled(v)).toBe(false);
     }
+  });
+});
+
+// #12251 slice 1: readAliasedEnv resolves brand<->eliza aliases from the
+// immutable BootConfig WITHOUT mutating process.env. This fixture uses a
+// NON-ELIZA brand prefix (an in-repo ELIZA->ELIZA self-mirror is not sufficient
+// proof per the issue) and asserts the security-/boot-critical settings the
+// original issue names — state dir, API token, ports, CORS — resolve correctly
+// with ZERO runtime alias writes to process.env.
+describe("readAliasedEnv (non-ELIZA brand, zero-mutation resolution)", () => {
+  const BRAND = "ACME";
+  const savedConfig = getBootConfig();
+  // The security-/boot-critical settings the issue calls out, plus their
+  // branded aliases, tracked so each case starts from a clean slate.
+  const pairs: Array<readonly [string, string]> = [
+    [`${BRAND}_STATE_DIR`, "ELIZA_STATE_DIR"],
+    [`${BRAND}_API_TOKEN`, "ELIZA_API_TOKEN"],
+    [`${BRAND}_API_PORT`, "ELIZA_API_PORT"],
+    [`${BRAND}_HOME_PORT`, "ELIZA_HOME_PORT"],
+    [`${BRAND}_GATEWAY_PORT`, "ELIZA_GATEWAY_PORT"],
+    [`${BRAND}_ALLOWED_ORIGINS`, "ELIZA_ALLOWED_ORIGINS"],
+  ];
+  const tracked = pairs.flat();
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of tracked) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    // Pin the alias table on the immutable BootConfig, as the app boot path does.
+    setBootConfig({ ...savedConfig, envAliases: pairs });
+  });
+
+  afterEach(() => {
+    for (const key of tracked) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+    setBootConfig(savedConfig);
+  });
+
+  it("resolves state dir, API token, ports, and CORS from branded keys", () => {
+    process.env[`${BRAND}_STATE_DIR`] = "/var/acme/state";
+    process.env[`${BRAND}_API_TOKEN`] = "acme-secret-token";
+    process.env[`${BRAND}_API_PORT`] = "7777";
+    process.env[`${BRAND}_HOME_PORT`] = "7778";
+    process.env[`${BRAND}_GATEWAY_PORT`] = "7779";
+    process.env[`${BRAND}_ALLOWED_ORIGINS`] = "https://acme.example";
+
+    // A read site asking for the ELIZA_ canonical name resolves the branded
+    // value — no sync mutation required.
+    expect(readAliasedEnv("ELIZA_STATE_DIR")).toBe("/var/acme/state");
+    expect(readAliasedEnv("ELIZA_API_TOKEN")).toBe("acme-secret-token");
+    expect(readAliasedEnv("ELIZA_API_PORT")).toBe("7777");
+    expect(readAliasedEnv("ELIZA_HOME_PORT")).toBe("7778");
+    expect(readAliasedEnv("ELIZA_GATEWAY_PORT")).toBe("7779");
+    expect(readAliasedEnv("ELIZA_ALLOWED_ORIGINS")).toBe(
+      "https://acme.example",
+    );
+  });
+
+  it("performs zero alias writes to process.env while resolving", () => {
+    process.env[`${BRAND}_STATE_DIR`] = "/var/acme/state";
+    process.env[`${BRAND}_API_TOKEN`] = "acme-secret-token";
+    const before = { ...process.env };
+
+    readAliasedEnv("ELIZA_STATE_DIR");
+    readAliasedEnv("ELIZA_API_TOKEN");
+    readAliasedEnv("ELIZA_API_PORT");
+
+    // The ELIZA_ targets must never be materialized by a read — that is exactly
+    // the process.env mutation #12251 exists to remove.
+    expect(process.env.ELIZA_STATE_DIR).toBeUndefined();
+    expect(process.env.ELIZA_API_TOKEN).toBeUndefined();
+    expect(process.env).toEqual(before);
+  });
+
+  it("trims and drops empty branded values (normalizeEnvValue contract)", () => {
+    process.env[`${BRAND}_STATE_DIR`] = "  /var/acme/state  ";
+    process.env[`${BRAND}_API_TOKEN`] = "   ";
+    expect(readAliasedEnv("ELIZA_STATE_DIR")).toBe("/var/acme/state");
+    expect(readAliasedEnv("ELIZA_API_TOKEN")).toBeUndefined();
+  });
+
+  it("prefers an explicit ELIZA_ value over the branded alias", () => {
+    process.env.ELIZA_API_TOKEN = "canonical";
+    process.env[`${BRAND}_API_TOKEN`] = "branded";
+    expect(readAliasedEnv("ELIZA_API_TOKEN")).toBe("canonical");
+  });
+
+  it("a blank ELIZA_ value does not mask a present branded alias", () => {
+    // Regression: an empty canonical API token must not resolve as missing when
+    // a real branded token is set — that would fail security-critical auth on a
+    // non-ELIZA brand deployment.
+    process.env.ELIZA_API_TOKEN = "";
+    process.env[`${BRAND}_API_TOKEN`] = "real-token";
+    expect(readAliasedEnv("ELIZA_API_TOKEN")).toBe("real-token");
   });
 });
 

--- a/packages/shared/src/utils/env.ts
+++ b/packages/shared/src/utils/env.ts
@@ -44,6 +44,7 @@ export {
 
 import {
   getBootConfig,
+  resolveAliasedEnvValue,
   syncBrandEnvToEliza,
   syncElizaEnvToBrand,
 } from "../config/boot-config.js";
@@ -123,6 +124,21 @@ function buildEnvPairs(
     [prefixed("APP_ROUTE_PLUGIN_MODULES"), "ELIZA_APP_ROUTE_PLUGIN_MODULES"],
     [prefixed("PORT"), "ELIZA_UI_PORT"],
   ];
+}
+
+/**
+ * Read an env value resolving brand<->eliza aliases from the immutable
+ * BootConfig, WITHOUT mutating `process.env` (arch-audit #12251, slice 1).
+ *
+ * Thin wrapper over core's {@link resolveAliasedEnvValue} that pins the alias
+ * table to `getBootConfig().envAliases` and normalizes the result via
+ * {@link normalizeEnvValue} (trim + empty -> undefined), so migrated read sites
+ * get the same trimmed-or-undefined contract they get today from a normalized
+ * `process.env.<key>` read. The `syncBrandEnvToEliza` / `syncElizaEnvToBrand`
+ * mutation remains as a fallback for not-yet-migrated raw reads.
+ */
+export function readAliasedEnv(key: string): string | undefined {
+  return normalizeEnvValue(resolveAliasedEnvValue(key));
 }
 
 export function syncAppEnvToEliza(): void {


### PR DESCRIPTION
## What

First staged step toward arch-audit **#12251** — *resolve brand↔eliza env aliases into immutable `BootConfig` instead of mutating `process.env`*.

Per lalalune's staged-migration contract on the issue ("start with an **additive** alias-aware reader that resolves brand↔eliza aliases into immutable boot/config state while keeping existing mutation as fallback until read sites are migrated"), this PR lands **only the additive read-side migration target**:

- No read sites are migrated.
- The `syncBrandEnvToEliza` / `syncElizaEnvToBrand` mutation is **untouched** and remains the fallback for not-yet-migrated raw reads.
- Nothing is removed.

This is a small, self-contained, verifiable first slice of a deep cross-package cascade (~235 raw aliased reads) that the issue explicitly says must not be landed as a single slice.

## Changes

- **`packages/core/src/boot-env.ts`** — new `resolveAliasedEnvValue(key, aliases?, env?)`: a **pure, non-mutating** alias reader. Builds a bidirectional key→partner lookup from the alias-pair table (defaults to `getBootConfig().envAliases`) and resolves a value **without writing `process.env`**. The requested key wins **only when it carries a real (non-blank) value**, so a blank `ELIZA_` value cannot shadow a present branded alias — matching the existing `normalizeEnvValue`/`readEnv` empty-is-unset contract and the old sync path's behavior.
- **`packages/shared/src/config/boot-config-store.ts`** — re-export `resolveAliasedEnvValue` from `@elizaos/core` (alongside the existing `syncBrandEnvToEliza`/`syncElizaEnvToBrand` re-exports).
- **`packages/shared/src/utils/env.ts`** — new `readAliasedEnv(key)` wrapper that pins the alias table to `getBootConfig().envAliases` and normalizes the result to the trim-or-`undefined` contract migrated reads expect.

## Tests

- **core `boot-env.test.ts` (+9)** — both-direction resolution, exact-key precedence, unrelated-pair isolation, a `never mutates process.env` assertion, empty-table = no-aliasing, and the **blank-canonical-does-not-shadow-alias** regression.
- **shared `env.test.ts` (+5)** — a **NON-`ELIZA` (`ACME`) brand fixture** proving `STATE_DIR`, `API_TOKEN`, `API_PORT`/`HOME_PORT`/`GATEWAY_PORT`, and `ALLOWED_ORIGINS` resolve from branded keys with **zero `process.env` alias writes**, plus the blank-canonical regression. (An in-repo `ELIZA→ELIZA` self-mirror is explicitly *not* sufficient proof per the issue — this uses a real non-`ELIZA` prefix.)

## Verification

- core `boot-env.test.ts` **14/14** green; shared `env.test.ts` **9/9** green
- `tsgo --noEmit` clean on **core** and **shared**
- biome check clean on all touched files
- shared `build:dist` clean
- **codex-reviewed**: found a P2 (blank canonical value masking a present branded alias) — **fixed** (empty/whitespace direct value now treated as absent before falling through to the alias) **and regression-tested**; re-review clean.

## Not in this PR (follow-up slices per the issue)

Codemodding the ~235 raw aliased `process.env.<key>` reads onto the reader, then deleting `syncBrandEnvToEliza`/`syncElizaEnvToBrand`, the wrapper helpers, and the `.mjs` copies. Those are the read-site migration + mutation-removal slices the issue's `Done-when` covers.

-- [sol-orch]