### PR TITLE
fix(#12643): drive subscription credential selection from registry

### DIFF
--- a/packages/app-core/src/api/credential-resolver.ts
+++ b/packages/app-core/src/api/credential-resolver.ts
@@ -20,12 +20,11 @@ import {
   DIRECT_ACCOUNT_PROVIDER_ENV,
   type DirectAccountProvider,
   isDirectAccountProvider,
-  isSubscriptionProvider,
 } from "@elizaos/auth/types";
 import {
   getDirectAccountProviderForFirstRunProvider,
   getFirstRunProviderOption,
-  getStoredFirstRunProviderId,
+  getStoredSubscriptionProviderForRequest,
   logger,
   MODEL_PROVIDER_SECRETS,
   normalizeFirstRunProviderId,
@@ -97,10 +96,7 @@ function directAccountProviderForRequest(
 }
 
 function subscriptionProviderForRequest(providerId: string): string | null {
-  const normalized = providerId.trim().toLowerCase();
-  if (isSubscriptionProvider(normalized)) return normalized;
-  const storedProvider = getStoredFirstRunProviderId(providerId);
-  return isSubscriptionProvider(storedProvider) ? storedProvider : null;
+  return getStoredSubscriptionProviderForRequest(providerId);
 }
 
 // ── Public API ───────────────────────────────────────────────────────

--- a/packages/core/src/contracts/first-run-options.ts
+++ b/packages/core/src/contracts/first-run-options.ts
@@ -769,6 +769,20 @@ export function getStoredSubscriptionProvider(
 	);
 }
 
+export function getStoredSubscriptionProviderForRequest(
+	providerId: unknown,
+): StoredSubscriptionProviderId | null {
+	const selection = normalizeSubscriptionProviderSelectionId(providerId);
+	if (selection) return getStoredSubscriptionProvider(selection);
+	if (typeof providerId !== "string") return null;
+	const normalized = providerId.trim().toLowerCase();
+	return (
+		SUBSCRIPTION_PROVIDER_SELECTIONS.find(
+			(provider) => provider.storedProvider === normalized,
+		)?.storedProvider ?? null
+	);
+}
+
 export function getSubscriptionProviderFamily(
 	selectionId: SubscriptionProviderSelectionId,
 ): "anthropic" | "openai" | "gemini" | "zai" | "moonshot" | "deepseek" {

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -53,6 +53,7 @@ export {
 	getDirectAccountProviderForFirstRunProvider,
 	getFirstRunProviderOption,
 	getStoredFirstRunProviderId,
+	getStoredSubscriptionProviderForRequest,
 	isCloudInferenceSelectedInConfig,
 	migrateLegacyRuntimeConfig,
 	normalizeFirstRunProviderId,

--- a/packages/shared/src/contracts/first-run-cerebras.test.ts
+++ b/packages/shared/src/contracts/first-run-cerebras.test.ts
@@ -19,7 +19,9 @@ import { describe, expect, it } from "vitest";
 import {
   FIRST_RUN_PROVIDER_CATALOG as CORE_CATALOG,
   DIRECT_ACCOUNT_PROVIDER_BY_FIRST_RUN_PROVIDER as CORE_DIRECT_ACCOUNT_MAP,
+  SUBSCRIPTION_PROVIDER_SELECTIONS as CORE_SUBSCRIPTION_PROVIDER_SELECTIONS,
   getDirectAccountProviderForFirstRunProvider as coreGetDirectAccountProvider,
+  getStoredSubscriptionProviderForRequest as coreGetStoredSubscriptionProviderForRequest,
   normalizeFirstRunProviderId as coreNormalizeFirstRunProviderId,
 } from "../../../core/src/contracts/first-run-options";
 import {
@@ -28,7 +30,9 @@ import {
   getDirectAccountProviderForFirstRunProvider,
   getFirstRunProviderOption,
   getFirstRunProviderSignalEnvKeys,
+  getStoredSubscriptionProviderForRequest,
   normalizeFirstRunProviderId,
+  SUBSCRIPTION_PROVIDER_SELECTIONS,
 } from "./first-run-options";
 import { isLinkedAccountProviderId } from "./service-routing";
 
@@ -87,6 +91,12 @@ describe("first-run provider catalog core/shared alignment", () => {
     );
   });
 
+  it("core and shared expose identical subscription provider selections", () => {
+    expect(CORE_SUBSCRIPTION_PROVIDER_SELECTIONS).toEqual(
+      SUBSCRIPTION_PROVIDER_SELECTIONS,
+    );
+  });
+
   it("the canonical core copy includes Cerebras", () => {
     const coreCerebras = CORE_CATALOG.find((p) => p.id === "cerebras");
     expect(coreCerebras).toBeDefined();
@@ -99,5 +109,24 @@ describe("first-run provider catalog core/shared alignment", () => {
     expect(coreNormalizeFirstRunProviderId("CEREBRAS")).toBe("cerebras");
     expect(coreNormalizeFirstRunProviderId("cerebras-api")).toBe("cerebras");
     expect(coreGetDirectAccountProvider("cerebras")).toBe("cerebras-api");
+  });
+
+  it("subscription request storage ids are driven by the selection registry", () => {
+    for (const provider of SUBSCRIPTION_PROVIDER_SELECTIONS) {
+      expect(getStoredSubscriptionProviderForRequest(provider.id)).toBe(
+        provider.storedProvider,
+      );
+      expect(
+        getStoredSubscriptionProviderForRequest(provider.id.toUpperCase()),
+      ).toBe(provider.storedProvider);
+      expect(
+        getStoredSubscriptionProviderForRequest(provider.storedProvider),
+      ).toBe(provider.storedProvider);
+      expect(coreGetStoredSubscriptionProviderForRequest(provider.id)).toBe(
+        provider.storedProvider,
+      );
+    }
+    expect(getStoredSubscriptionProviderForRequest("openai")).toBeNull();
+    expect(getStoredSubscriptionProviderForRequest(null)).toBeNull();
   });
 });

--- a/packages/shared/src/contracts/first-run-options.ts
+++ b/packages/shared/src/contracts/first-run-options.ts
@@ -769,6 +769,20 @@ export function getStoredSubscriptionProvider(
   );
 }
 
+export function getStoredSubscriptionProviderForRequest(
+  providerId: unknown,
+): StoredSubscriptionProviderId | null {
+  const selection = normalizeSubscriptionProviderSelectionId(providerId);
+  if (selection) return getStoredSubscriptionProvider(selection);
+  if (typeof providerId !== "string") return null;
+  const normalized = providerId.trim().toLowerCase();
+  return (
+    SUBSCRIPTION_PROVIDER_SELECTIONS.find(
+      (provider) => provider.storedProvider === normalized,
+    )?.storedProvider ?? null
+  );
+}
+
 export function getSubscriptionProviderFamily(
   selectionId: SubscriptionProviderSelectionId,
 ): "anthropic" | "openai" | "gemini" | "zai" | "moonshot" | "deepseek" {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -210,6 +210,7 @@ export {
   getFirstRunProviderOption,
   getFirstRunProviderSignalEnvKeys,
   getStoredFirstRunProviderId,
+  getStoredSubscriptionProviderForRequest,
   normalizeFirstRunProviderId,
   sortFirstRunProviders,
 } from "./contracts/first-run-options.js";


### PR DESCRIPTION
## Summary
- Add `getStoredSubscriptionProviderForRequest()` to the core/shared first-run contracts so subscription request ids resolve through `SUBSCRIPTION_PROVIDER_SELECTIONS` and return `StoredSubscriptionProviderId | null`.
- Use the typed helper in app-core credential resolution instead of a generic string stored-provider branch.
- Extend the first-run contract drift test to pin core/shared subscription selections and selection-id/stored-id normalization.

## Evidence
- `bunx biome check packages/shared/src/contracts/first-run-options.ts packages/core/src/contracts/first-run-options.ts packages/shared/src/contracts/first-run-cerebras.test.ts packages/shared/src/index.ts packages/core/src/index.node.ts packages/app-core/src/api/credential-resolver.ts`
- `bun test packages/shared/src/contracts/first-run-cerebras.test.ts` (10 pass)
- `git diff --check HEAD~1..HEAD`

## Blocked / not run
- `bun run --cwd packages/shared typecheck` is blocked in this sparse checkout by existing declaration resolution failures for `adze`, `adze/dist/log.js`, and `fast-redact` via `packages/logger`.
- `bun run --cwd packages/app-core typecheck` is blocked by existing sparse checkout/dependency failures including missing `@elizaos/auth/*`, `@elizaos/vault`, optional plugin packages, and dist-node_modules declaration resolution for UI dependencies.
- `bun test packages/app-core/src/api/credential-resolver.test.ts packages/app-core/src/api/credential-resolver.multi-account.test.ts` is blocked by missing `@elizaos/auth/credentials` and `@elizaos/auth/account-storage` in this sparse checkout.
