### PR TITLE
test(shared): guard subscription provider selection drift

### DIFF
--- a/packages/shared/src/contracts/first-run-cerebras.test.ts
+++ b/packages/shared/src/contracts/first-run-cerebras.test.ts
@@ -19,8 +19,12 @@ import { describe, expect, it } from "vitest";
 import {
   FIRST_RUN_PROVIDER_CATALOG as CORE_CATALOG,
   DIRECT_ACCOUNT_PROVIDER_BY_FIRST_RUN_PROVIDER as CORE_DIRECT_ACCOUNT_MAP,
+  SUBSCRIPTION_PROVIDER_SELECTIONS as CORE_SUBSCRIPTION_PROVIDER_SELECTIONS,
   getDirectAccountProviderForFirstRunProvider as coreGetDirectAccountProvider,
+  getStoredSubscriptionProvider as coreGetStoredSubscriptionProvider,
+  getSubscriptionProviderFamily as coreGetSubscriptionProviderFamily,
   normalizeFirstRunProviderId as coreNormalizeFirstRunProviderId,
+  normalizeSubscriptionProviderSelectionId as coreNormalizeSubscriptionProviderSelectionId,
 } from "../../../core/src/contracts/first-run-options";
 import {
   DIRECT_ACCOUNT_PROVIDER_BY_FIRST_RUN_PROVIDER,
@@ -28,7 +32,11 @@ import {
   getDirectAccountProviderForFirstRunProvider,
   getFirstRunProviderOption,
   getFirstRunProviderSignalEnvKeys,
+  getStoredSubscriptionProvider,
+  getSubscriptionProviderFamily,
   normalizeFirstRunProviderId,
+  normalizeSubscriptionProviderSelectionId,
+  SUBSCRIPTION_PROVIDER_SELECTIONS,
 } from "./first-run-options";
 import { isLinkedAccountProviderId } from "./service-routing";
 
@@ -99,5 +107,46 @@ describe("first-run provider catalog core/shared alignment", () => {
     expect(coreNormalizeFirstRunProviderId("CEREBRAS")).toBe("cerebras");
     expect(coreNormalizeFirstRunProviderId("cerebras-api")).toBe("cerebras");
     expect(coreGetDirectAccountProvider("cerebras")).toBe("cerebras-api");
+  });
+});
+
+describe("subscription provider selection registry", () => {
+  it("core and shared expose identical subscription selections", () => {
+    expect(CORE_SUBSCRIPTION_PROVIDER_SELECTIONS).toEqual(
+      SUBSCRIPTION_PROVIDER_SELECTIONS,
+    );
+  });
+
+  it("drives stored-provider and family lookup from each registered selection", () => {
+    for (const selection of SUBSCRIPTION_PROVIDER_SELECTIONS) {
+      expect(normalizeSubscriptionProviderSelectionId(selection.id)).toBe(
+        selection.id,
+      );
+      expect(getStoredSubscriptionProvider(selection.id)).toBe(
+        selection.storedProvider,
+      );
+      expect(getSubscriptionProviderFamily(selection.id)).toBe(
+        selection.family,
+      );
+
+      const catalogEntry = getFirstRunProviderOption(selection.id);
+      expect(catalogEntry?.authMode).toBe("subscription");
+      expect(catalogEntry?.storedProvider).toBe(selection.storedProvider);
+      expect(catalogEntry?.family).toBe(selection.family);
+    }
+  });
+
+  it("keeps core subscription helpers aligned with the shared registry", () => {
+    for (const selection of SUBSCRIPTION_PROVIDER_SELECTIONS) {
+      expect(coreNormalizeSubscriptionProviderSelectionId(selection.id)).toBe(
+        selection.id,
+      );
+      expect(coreGetStoredSubscriptionProvider(selection.id)).toBe(
+        selection.storedProvider,
+      );
+      expect(coreGetSubscriptionProviderFamily(selection.id)).toBe(
+        selection.family,
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary

Part of #12643. Adds focused contract coverage for the subscription provider selection registry so provider selection IDs, stored provider IDs, families, and the duplicated core/shared registries cannot drift silently.

The new assertions verify:

- `SUBSCRIPTION_PROVIDER_SELECTIONS` is identical between the canonical core copy and the shared mirror.
- Every registered selection normalizes through the public helper.
- `getStoredSubscriptionProvider()` and `getSubscriptionProviderFamily()` return the registry-owned values for every selection.
- Each subscription selection has a matching first-run catalog entry with `authMode: "subscription"`, the same `storedProvider`, and the same family.

## Verification

- `bun test packages/shared/src/contracts/first-run-cerebras.test.ts` passed: 11 tests / 78 expects.
- `bunx @biomejs/biome check packages/shared/src/contracts/first-run-cerebras.test.ts` passed.
- `bun run --cwd packages/shared typecheck` passed.
- `git diff --check github/develop...HEAD` passed.
- `bun run --cwd packages/shared lint:check` was run and still fails outside this change on existing formatting in `packages/shared/src/voice/aec/echo-alignment.ts`; the touched test file passes Biome directly.

## Evidence

- UI screenshots/video: N/A - contract test only; no UI runtime or rendered surface changed.
- Frontend console/network logs: N/A - no browser workflow changed.
- Real LLM trajectories: N/A - no agent/model/prompt behavior changed.
- Backend logs: N/A - no server runtime path changed.
- Domain artifacts: the focused test output above proves the subscription selection registry and core/shared mirror stay aligned.
