### PR TITLE
fix(#12741): triage registry packaged-build degrade + document intentional CLI console

### DIFF
--- a/packages/registry/src/first-party/index.ts
+++ b/packages/registry/src/first-party/index.ts
@@ -127,8 +127,11 @@ var cacheSlot: { value: LoadedRegistry | null } = { value: null };
 function readEntriesFromDisk(): RegistryEntry[] {
   const generatedPath = resolveGeneratedPath();
   if (!existsSync(generatedPath)) {
-    // In packaged builds the aggregated registry may not be bundled. Log and
-    // continue rather than crashing the agent subprocess.
+    // error-policy:J4 explicit designed degrade — in packaged builds the
+    // aggregated registry is legitimately not bundled, so an empty first-party
+    // set is a valid state (not a load failure). Warn and continue rather than
+    // crashing the agent subprocess. `console` is intentional: this low-level
+    // package has no `@elizaos/logger` dependency and must stay dependency-free.
     console.warn(`[registry] generated.json missing: ${generatedPath}`);
     return [];
   }


### PR DESCRIPTION
## Summary

Part of the fallback-slop long-tail sweep for `packages/registry` (#12741, parent #12182).

`readEntriesFromDisk()` in `first-party/index.ts` returns `[]` when the aggregated `generated.json` is absent. This is an **explicit designed degrade**, not the banned "not-loaded-reads-as-empty" pattern: in packaged builds the aggregated registry is legitimately not bundled, so an empty first-party set is a *valid* state. It is now annotated `// error-policy:J4` per the binding rubric, with the rationale that the `console.warn` is intentional (this low-level package has no `@elizaos/logger` dependency and stays dependency-free).

The other registry console sites (`validate-cli.ts`, `generate.ts`, `first-party/generate.ts`) are CLI/generator entry points whose file headers already document them as intentional command output ("CLI:", "Run directly …") — no change needed. This completes the triage of `packages/registry` for #12741.

## Validation

- `node packages/scripts/error-policy-ratchet.mjs` → **`no new fallback-slop in touched files`**.
- `bunx @biomejs/biome check` on the touched file → clean.
- No behavior change (annotation/comment only).

## Evidence rows
- Real-LLM trajectory / logs / screenshots — **N/A**: annotation-only comment on an existing designed-degrade path; zero runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)