### PR TITLE
fix(#12787): elevenlabs voice-verify fails closed on upstream failure (cloud-API slice)

### DIFF
--- a/packages/cloud/api/__tests__/elevenlabs-voice-verify-fail-closed.test.ts
+++ b/packages/cloud/api/__tests__/elevenlabs-voice-verify-fail-closed.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Guard tests for #12787 (cloud API fallback-slop sweep, elevenlabs slice).
+ *
+ * `GET /api/elevenlabs/voices/verify/[id]` used to catch EVERY upstream
+ * ElevenLabs error inside the handler and return
+ * `200 { success: true, status: { isReady: false, message: "Voice not found
+ * in ElevenLabs or still processing" } }`. That collapsed two distinct
+ * outcomes into one fabricated "still processing" verdict:
+ *   - a voice that genuinely isn't materialized upstream yet (a real 404 for a
+ *     fresh professional voice), which SHOULD degrade to a not-ready state, and
+ *   - ElevenLabs being broken (transport failure / 401 bad key / 429 / 5xx),
+ *     which is a service fault the caller must see so it stops polling a dead
+ *     service forever believing the voice just isn't done baking.
+ *
+ * The TTS readiness probe additionally only caught THROWN fetches, so a non-2xx
+ * HTTP response (401/429/5xx from ElevenLabs) counted as `canGenerateTTS: true`
+ * — a fabricated-ready voice in the other direction.
+ *
+ * These tests drive the REAL Hono route handler; only the deep service
+ * boundaries (auth, voice-cloning DB lookup, ElevenLabs SDK client) and
+ * `global.fetch` (the TTS probe) are stubbed.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import {
+  ElevenLabsError,
+  ElevenLabsTimeoutError,
+} from "@elevenlabs/elevenlabs-js";
+import * as authActual from "@/lib/auth";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.ELEVENLABS_API_KEY ||= "test-elevenlabs-key";
+
+const ORG = "00000000-0000-4000-8000-0000000000aa";
+const USER = "00000000-0000-4000-8000-0000000000bb";
+
+// Per-test knobs.
+let dbVoice: {
+  id: string;
+  name: string;
+  elevenlabsVoiceId: string;
+  cloneType: "instant" | "professional";
+} | null = null;
+let getVoiceByIdImpl: () => Promise<unknown> = async () => ({
+  category: "cloned",
+  samples: [{}, {}],
+  fineTuning: { state: { model_a: "fine_tuned" } },
+});
+
+mock.module("@/lib/auth", () => ({
+  ...authActual,
+  requireAuthOrApiKeyWithOrg: async () => ({
+    user: { id: USER, organization_id: ORG },
+    apiKey: { id: "api-key-id" },
+  }),
+}));
+
+mock.module("@/lib/services/voice-cloning", () => ({
+  voiceCloningService: {
+    getVoiceById: async () => dbVoice,
+  },
+}));
+
+mock.module("@/lib/services/elevenlabs", () => ({
+  getElevenLabsService: () => ({
+    getVoiceById: () => getVoiceByIdImpl(),
+  }),
+}));
+
+// Import AFTER the mocks are registered so the route binds the stubs.
+const { default: app } = await import("../elevenlabs/voices/verify/[id]/route");
+
+const ENV = {} as unknown as Record<string, unknown>;
+const EXEC_CTX = {
+  waitUntil: (_p: Promise<unknown>) => undefined,
+  passThroughOnException: () => undefined,
+  props: {},
+} as unknown as ExecutionContext;
+
+function verify() {
+  return app.request(
+    `/`,
+    {
+      method: "GET",
+      headers: { authorization: "Bearer test-key" },
+    },
+    ENV,
+    EXEC_CTX,
+  );
+}
+
+const realFetch = globalThis.fetch;
+
+// Bun's `mock()` lacks the `preconnect` member of the DOM `fetch` type; the TTS
+// probe only calls `fetch(url, init)`, so a thin cast keeps the assignment
+// type-safe without pulling in a full fetch polyfill.
+function stubFetch(impl: () => Promise<Response>): void {
+  globalThis.fetch = mock(impl) as unknown as typeof fetch;
+}
+
+describe("#12787 elevenlabs voices/verify — fail closed on upstream failure", () => {
+  beforeEach(() => {
+    dbVoice = {
+      id: "voice-1",
+      name: "My Voice",
+      elevenlabsVoiceId: "el-voice-1",
+      cloneType: "instant",
+    };
+    getVoiceByIdImpl = async () => ({
+      category: "cloned",
+      samples: [{}, {}],
+      fineTuning: {},
+    });
+    // Default: TTS probe succeeds.
+    stubFetch(async () => new Response(null, { status: 200 }));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  afterAll(() => {
+    mock.module("@/lib/auth", () => authActual);
+  });
+
+  test("ElevenLabs 5xx surfaces a structured failure, never a fabricated 'still processing' success", async () => {
+    getVoiceByIdImpl = async () => {
+      throw new ElevenLabsError({
+        message: "upstream boom",
+        statusCode: 503,
+      });
+    };
+
+    const res = await verify();
+
+    // The old handler returned 200 { success: true } here. Upstream 5xx now maps
+    // to a retryable 503 (the provider faulted, not our worker).
+    expect(res.status).toBe(503);
+    const json = (await res.json()) as { success?: boolean; status?: unknown };
+    expect(json.success).not.toBe(true);
+    // No fabricated readiness verdict handed back.
+    expect(json.status).toBeUndefined();
+  });
+
+  test("ElevenLabs 429 rate limit keeps the canonical rate_limit_exceeded code (not internal_error)", async () => {
+    getVoiceByIdImpl = async () => {
+      throw new ElevenLabsError({ message: "slow down", statusCode: 429 });
+    };
+
+    const res = await verify();
+
+    // 4xx client errors pass through verbatim so callers can branch on the code.
+    expect(res.status).toBe(429);
+    const json = (await res.json()) as { success?: boolean; code?: string };
+    expect(json.success).not.toBe(true);
+    expect(json.code).toBe("rate_limit_exceeded");
+  });
+
+  test("ElevenLabs transport timeout maps to a retryable 503, not a generic 500", async () => {
+    getVoiceByIdImpl = async () => {
+      throw new ElevenLabsTimeoutError(
+        "Timeout exceeded when calling GET /voices.",
+      );
+    };
+
+    const res = await verify();
+
+    // A provider timeout means the upstream is unavailable, not our worker.
+    expect(res.status).toBe(503);
+    const json = (await res.json()) as { success?: boolean; status?: unknown };
+    expect(json.success).not.toBe(true);
+    expect(json.status).toBeUndefined();
+  });
+
+  test("ElevenLabs 401 (bad key) surfaces as an auth failure, not a healthy 'still processing' body", async () => {
+    getVoiceByIdImpl = async () => {
+      throw new ElevenLabsError({
+        message: "invalid api key",
+        statusCode: 401,
+      });
+    };
+
+    const res = await verify();
+
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as { success?: boolean };
+    expect(json.success).not.toBe(true);
+  });
+
+  test("ElevenLabs 404 (voice not materialized yet) degrades to a distinct not-ready verdict", async () => {
+    dbVoice = {
+      id: "voice-1",
+      name: "My Voice",
+      elevenlabsVoiceId: "el-voice-1",
+      cloneType: "professional",
+    };
+    getVoiceByIdImpl = async () => {
+      throw new ElevenLabsError({ message: "not found", statusCode: 404 });
+    };
+
+    const res = await verify();
+
+    // A genuinely-absent upstream voice is an EXPECTED not-ready state, not a 5xx.
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      success: boolean;
+      status: { isReady: boolean; canGenerateTTS: boolean; message: string };
+    };
+    expect(json.success).toBe(true);
+    expect(json.status.isReady).toBe(false);
+    expect(json.status.canGenerateTTS).toBe(false);
+    expect(json.status.message).toContain("still being processed");
+  });
+
+  test("TTS probe non-2xx counts as canGenerateTTS:false (not a fabricated ready voice)", async () => {
+    // getVoiceById succeeds; the TTS smoke call returns 429.
+    stubFetch(async () => new Response(null, { status: 429 }));
+
+    const res = await verify();
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      status: { isReady: boolean; canGenerateTTS: boolean };
+    };
+    // Instant voice is "ready" per fine-tune status but the probe failed, so
+    // it must not report generatable. Old code only caught THROWS, so a 429
+    // HTTP response used to set canGenerateTTS=true.
+    expect(json.status.canGenerateTTS).toBe(false);
+    expect(json.status.isReady).toBe(false);
+  });
+
+  test("TTS probe thrown fetch degrades to canGenerateTTS:false observably", async () => {
+    stubFetch(async () => {
+      throw new Error("network down");
+    });
+
+    const res = await verify();
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      status: { canGenerateTTS: boolean };
+    };
+    expect(json.status.canGenerateTTS).toBe(false);
+  });
+
+  test("happy path: upstream ok + TTS probe 2xx => ready", async () => {
+    const res = await verify();
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      success: boolean;
+      status: { isReady: boolean; canGenerateTTS: boolean };
+    };
+    expect(json.success).toBe(true);
+    expect(json.status.canGenerateTTS).toBe(true);
+    expect(json.status.isReady).toBe(true);
+  });
+
+  test("voice missing from DB is a 404, unaffected by the fix", async () => {
+    dbVoice = null;
+
+    const res = await verify();
+
+    expect(res.status).toBe(404);
+    const json = (await res.json()) as { error?: string; success?: boolean };
+    expect(json.success).not.toBe(true);
+    expect(json.error).toBe("Voice not found");
+  });
+});

--- a/packages/cloud/api/elevenlabs/voices/verify/[id]/route.ts
+++ b/packages/cloud/api/elevenlabs/voices/verify/[id]/route.ts
@@ -1,10 +1,131 @@
 // Handles cloud API elevenlabs voices verify id route traffic with route-local auth expectations.
+//
+// Verification reports whether a cloned voice is usable. It distinguishes THREE
+// outcomes so callers never conflate "voice legitimately not ready yet" with
+// "ElevenLabs is broken" (#12787 / #12182):
+//   - voice missing FROM ElevenLabs (upstream 404) => a real "still processing /
+//     not found" verdict (J4 degrade), because a just-created professional voice
+//     is genuinely absent until fine-tuning materializes it.
+//   - ElevenLabs transport / 5xx / auth failure => surfaced as a route failure
+//     (J1), NOT a fabricated `success:true, isReady:false` body. The old handler
+//     swallowed EVERY upstream error into a 200 "still processing" verdict, so a
+//     dead ElevenLabs looked identical to a voice mid-bake — the client would
+//     poll forever against a broken service believing the voice just wasn't done.
+//   - the TTS smoke call is a best-effort readiness probe: its result feeds
+//     `canGenerateTTS`, but a NON-2xx HTTP response or a thrown fetch must read
+//     as "cannot generate" (observably), never silently count as success.
+
+import {
+  ElevenLabsError,
+  ElevenLabsTimeoutError,
+} from "@elevenlabs/elevenlabs-js";
 import { Hono } from "hono";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
+import { getErrorStatusCode, nextJsonFromCaughtError } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { getElevenLabsService } from "@/lib/services/elevenlabs";
 import { voiceCloningService } from "@/lib/services/voice-cloning";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+
+/**
+ * An ElevenLabs lookup that 404s means the voice row exists in our DB but the
+ * upstream voice is not materialized yet (a normal state for a fresh
+ * professional/fine-tuned voice). Anything else — network error, 401 bad key,
+ * 429, 5xx — is a genuine upstream failure that must not masquerade as
+ * "still processing".
+ */
+function isUpstreamVoiceAbsent(error: unknown): boolean {
+  return error instanceof ElevenLabsError && error.statusCode === 404;
+}
+
+/**
+ * Translate an upstream ElevenLabs failure into a boundary error that carries
+ * its REAL HTTP status AND the canonical error code for that status.
+ *
+ * `getErrorStatusCode` doesn't read `ElevenLabsError.statusCode` and
+ * `ElevenLabsTimeoutError` isn't even an `ElevenLabsError`, so without this:
+ *   - a 401 bad-key / 429 rate-limit / 422 validation from ElevenLabs would
+ *     collapse to a generic 500 at the J1 boundary, and
+ *   - a transport timeout would surface as a 500 implying OUR worker faulted.
+ *
+ * Client-error statuses (4xx) pass through verbatim so the JSON contract keeps
+ * the canonical code (`rate_limit_exceeded`, `validation_error`, …) callers
+ * branch on for retry. A 5xx / timeout / unknown upstream fault becomes a
+ * retryable 503 "provider unavailable" — the provider is down, not us. The
+ * single-arg `ApiError(status)` overload derives the canonical code from the
+ * status, so we never mislabel a rate limit as an internal error.
+ */
+function toUpstreamBoundaryError(error: unknown): unknown {
+  // A transport timeout means the provider is unreachable, not a worker fault.
+  if (error instanceof ElevenLabsTimeoutError) {
+    return new ApiError(503);
+  }
+  if (!(error instanceof ElevenLabsError)) {
+    return error;
+  }
+  const upstream = error.statusCode;
+  const isClientError =
+    upstream !== undefined && upstream >= 400 && upstream < 500;
+  const status = isClientError ? upstream : 503;
+  return new ApiError(
+    status,
+    // Positional overload derives the canonical code from the status
+    // (429 -> rate_limit_exceeded, 422 -> validation_error, 401 -> auth, …).
+    undefined,
+    status >= 500
+      ? "Voice provider is temporarily unavailable"
+      : error.message || "Voice provider request failed",
+  );
+}
+
+/**
+ * Best-effort TTS readiness probe. Returns whether a one-word synthesis call
+ * succeeded. A thrown fetch or a non-2xx HTTP response both read as "cannot
+ * generate" — but observably (warn), never a silently-swallowed false that
+ * looks the same as a voice that simply isn't fine-tuned yet.
+ */
+async function probeTtsReadiness(
+  elevenlabsVoiceId: string,
+  apiKey: string,
+): Promise<boolean> {
+  try {
+    const res = await fetch(
+      `https://api.elevenlabs.io/v1/text-to-speech/${elevenlabsVoiceId}`,
+      {
+        method: "POST",
+        headers: {
+          "xi-api-key": apiKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          text: "Test",
+          model_id: "eleven_multilingual_v2",
+        }),
+      },
+    );
+    if (!res.ok) {
+      // A non-2xx here is meaningful signal the voice can't synthesize yet
+      // (or the key is bad). Previously this counted as canGenerateTTS=true
+      // because only THROWS were caught, so a 401/429/5xx faked a ready voice.
+      logger.warn("[Voice Verify API] TTS readiness probe returned non-2xx", {
+        elevenlabsVoiceId,
+        status: res.status,
+      });
+      return false;
+    }
+    return true;
+  } catch (error) {
+    // error-policy:J4 readiness-probe transport failure degrades to
+    // canGenerateTTS=false — observable, feeds a user-facing "not ready" verdict,
+    // never a fabricated success.
+    logger.warn("[Voice Verify API] TTS readiness probe failed", {
+      elevenlabsVoiceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
 
 /**
  * GET /api/elevenlabs/voices/verify/[id]
@@ -38,85 +159,93 @@ async function __hono_GET(
 
     // Check status in ElevenLabs
     const elevenlabs = getElevenLabsService();
-
-    try {
-      const elevenLabsVoice = await elevenlabs.getVoiceById(
-        voice.elevenlabsVoiceId,
-      );
-
-      // For professional voices, check fine-tuning status
-      const isProfessional = voice.cloneType === "professional";
-      const isReady = isProfessional
-        ? elevenLabsVoice.fineTuning?.state &&
-          Object.keys(elevenLabsVoice.fineTuning.state).length > 0
-        : true; // Instant voices are ready immediately
-
-      // Try a test TTS call to verify it actually works
-      let canGenerateTTS = false;
-      try {
-        await fetch(
-          `https://api.elevenlabs.io/v1/text-to-speech/${voice.elevenlabsVoiceId}`,
-          {
-            method: "POST",
-            headers: {
-              "xi-api-key": process.env.ELEVENLABS_API_KEY!,
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              text: "Test",
-              model_id: "eleven_multilingual_v2",
-            }),
-          },
-        );
-        canGenerateTTS = true;
-      } catch {
-        canGenerateTTS = false;
-      }
-
-      return Response.json({
-        success: true,
-        voice: {
-          id: voice.id,
-          name: voice.name,
-          elevenlabsVoiceId: voice.elevenlabsVoiceId,
-          cloneType: voice.cloneType,
-        },
-        status: {
-          isReady: isReady && canGenerateTTS,
-          canGenerateTTS,
-          category: elevenLabsVoice.category,
-          sampleCount: elevenLabsVoice.samples?.length || 0,
-          fineTuningStatus: isProfessional ? elevenLabsVoice.fineTuning : null,
-          message: !canGenerateTTS
-            ? "Voice is still being processed. Please wait."
-            : isReady
-              ? "Voice is ready to use"
-              : "Voice is not yet fine-tuned",
-        },
-      });
-    } catch (error) {
-      logger.error(`[Voice Verify API] ElevenLabs error:`, error);
-
-      return Response.json({
-        success: true,
-        voice: {
-          id: voice.id,
-          name: voice.name,
-        },
-        status: {
-          isReady: false,
-          canGenerateTTS: false,
-          message: "Voice not found in ElevenLabs or still processing",
-        },
-      });
+    const apiKey = process.env.ELEVENLABS_API_KEY;
+    if (!apiKey) {
+      // Fail closed: without a key we cannot verify anything. Do not fabricate
+      // a "still processing" verdict from a service-config gap.
+      throw new Error("ELEVENLABS_API_KEY environment variable is required");
     }
-  } catch (error) {
-    logger.error("[Voice Verify API] Error:", error);
 
-    return Response.json(
-      { error: "Failed to verify voice status" },
-      { status: 500 },
+    let elevenLabsVoice: Awaited<ReturnType<typeof elevenlabs.getVoiceById>>;
+    try {
+      elevenLabsVoice = await elevenlabs.getVoiceById(voice.elevenlabsVoiceId);
+    } catch (error) {
+      if (isUpstreamVoiceAbsent(error)) {
+        // error-policy:J4 upstream 404 is an EXPECTED not-ready state for a
+        // freshly-created professional voice — degrade to a distinct
+        // "still processing" verdict (not a synthesis failure, not a 500).
+        logger.info("[Voice Verify API] Voice not yet present in ElevenLabs", {
+          voiceId: voice.id,
+          elevenlabsVoiceId: voice.elevenlabsVoiceId,
+        });
+        return Response.json({
+          success: true,
+          voice: {
+            id: voice.id,
+            name: voice.name,
+            elevenlabsVoiceId: voice.elevenlabsVoiceId,
+            cloneType: voice.cloneType,
+          },
+          status: {
+            isReady: false,
+            canGenerateTTS: false,
+            message: "Voice is still being processed. Please wait.",
+          },
+        });
+      }
+      // A real upstream failure (transport / 401 / 429 / 5xx) is NOT a
+      // "still processing" state. Rethrow to the J1 boundary (carrying the
+      // real upstream status) so the caller gets a structured failure and
+      // stops polling a broken service.
+      throw toUpstreamBoundaryError(error);
+    }
+
+    // For professional voices, check fine-tuning status
+    const isProfessional = voice.cloneType === "professional";
+    const isReady = isProfessional
+      ? Boolean(
+          elevenLabsVoice.fineTuning?.state &&
+            Object.keys(elevenLabsVoice.fineTuning.state).length > 0,
+        )
+      : true; // Instant voices are ready immediately
+
+    // Probe a one-word synthesis to confirm the voice actually generates. A
+    // non-2xx or thrown fetch reads observably as canGenerateTTS=false.
+    const canGenerateTTS = await probeTtsReadiness(
+      voice.elevenlabsVoiceId,
+      apiKey,
     );
+
+    return Response.json({
+      success: true,
+      voice: {
+        id: voice.id,
+        name: voice.name,
+        elevenlabsVoiceId: voice.elevenlabsVoiceId,
+        cloneType: voice.cloneType,
+      },
+      status: {
+        isReady: isReady && canGenerateTTS,
+        canGenerateTTS,
+        category: elevenLabsVoice.category,
+        sampleCount: elevenLabsVoice.samples?.length || 0,
+        fineTuningStatus: isProfessional ? elevenLabsVoice.fineTuning : null,
+        message: !canGenerateTTS
+          ? "Voice is still being processed. Please wait."
+          : isReady
+            ? "Voice is ready to use"
+            : "Voice is not yet fine-tuned",
+      },
+    });
+  } catch (error) {
+    // error-policy:J1 outermost route boundary — structured failure, never a
+    // fabricated success. Surfaces auth (401/403), rate limit, and upstream
+    // transport/5xx as their real statuses; only genuine 5xx are logged as
+    // errors (a 401 is a caller problem, not a server fault).
+    if (getErrorStatusCode(error) >= 500) {
+      logger.error("[Voice Verify API] Error:", error);
+    }
+    return nextJsonFromCaughtError(error);
   }
 }
 


### PR DESCRIPTION
Split slice of #12787 (cloud API fallback-slop sweep, `packages/cloud/api`). Prior slice #13146 covered the affiliate routes; this one hits the elevenlabs voice-verify route the sweep left open.

## The bug
`GET /api/elevenlabs/voices/verify/[id]` caught **every** upstream ElevenLabs error inside the handler and returned:

```
200 { success: true, status: { isReady: false, message: "Voice not found in ElevenLabs or still processing" } }
```

That fabricated-success collapsed two genuinely-distinct outcomes into one "still processing" verdict:
- a voice **genuinely not materialized upstream yet** (a real 404 for a fresh professional/fine-tuned voice) — which *should* degrade, and
- **ElevenLabs being broken** (transport failure / 401 bad key / 429 rate-limit / 5xx) — a service fault the caller must see so it stops polling a dead service forever, believing the voice just isn't done baking.

The TTS readiness probe additionally only caught **thrown** fetches, so a non-2xx HTTP response (401/429/5xx) from ElevenLabs counted as `canGenerateTTS: true` — a fabricated-*ready* voice in the other direction. (It also never checked `res.ok`.)

## The fix (per #12182 / `packages/cloud/api/AGENTS.md`)
- **upstream 404** => distinct **J4** "still being processed" degrade (`200, isReady:false, canGenerateTTS:false`), not a synthesis failure, not a 500.
- **upstream 4xx** (401/422/429/…) => passed through verbatim with the **canonical error code** (`rate_limit_exceeded`, `validation_error`, `authentication_required`, …) so callers can branch on the retry path. Previously all upstream errors would have collapsed to a generic 500.
- **upstream 5xx / SDK transport timeout** (`ElevenLabsTimeoutError`, which is *not* an `ElevenLabsError` subclass) => retryable **503** "provider unavailable" (the provider faulted, not us), never a generic 500.
- all upstream errors reach the outermost **J1** route boundary (`nextJsonFromCaughtError`) — a structured failure, never a fabricated success. A missing `ELEVENLABS_API_KEY` **fails closed** instead of faking a verdict.
- TTS probe: a non-2xx **and** a thrown fetch both read as `canGenerateTTS: false` **observably** (`logger.warn`), never a silently-swallowed false.

## Tests
`packages/cloud/api/__tests__/elevenlabs-voice-verify-fail-closed.test.ts` drives the **real** Hono route handler; only the deep boundaries (auth, voice-cloning DB lookup, ElevenLabs SDK client, `global.fetch`) are stubbed. **9/9 green:**
- upstream 5xx => 503 (no fabricated `success:true` / `status`)
- upstream 429 => `code: rate_limit_exceeded` (not `internal_error`)
- transport timeout => 503 (not 500)
- upstream 401 => 401 auth failure
- upstream 404 => 200 degrade `isReady:false, canGenerateTTS:false, "still being processed"`
- TTS probe non-2xx => `canGenerateTTS:false`
- TTS probe thrown fetch => `canGenerateTTS:false`
- happy path (upstream ok + probe 2xx) => ready
- DB-miss => 404 (unaffected by the fix)

`tsgo --noEmit` clean for the touched files; `biome check` clean; **codex-reviewed** (2 rounds — round-1 flagged the 429-code + timeout-mapping P2s, both fixed; round-2 no findings).

### Collision receipts
- No open PR on #12787 (`gh pr list --search 12787` empty at claim time; #13146 merged).
- No `fleet-12787` worktree owned by a sibling lane; created a uniquely-named worktree, staged only the two intended files (no `git add -A`), diff-checked for foreign paths.
- `lalalune`/`NubsCarson`/`roninjin10` had no PR touching this route in the last day.

Closes a slice of #12787; the rest of `packages/cloud/api` remains open for follow-up slices.

-- [sol-orch]