### PR TITLE
test(ui): remove stale overlay scroll suppression

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -1332,7 +1332,6 @@ describe("ContinuousChatOverlay", () => {
         expect.objectContaining({ behavior: "smooth" }),
       );
     } finally {
-      // biome-ignore lint/performance/noDelete: restore the pristine jsdom prototype
       delete (Element.prototype as { scrollTo?: unknown }).scrollTo;
     }
   });


### PR DESCRIPTION
## Summary

Follow-up to #13243: removes a stale Biome suppression comment in packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx that became an unused-suppression warning after the composer refactor landed.

## Verification

- bunx @biomejs/biome check packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
- bun run --cwd packages/ui test -- src/components/shell/ContinuousChatOverlay.test.tsx (139 tests)
