### PR TITLE
fix(#12788): fail closed on projection balance reads

### DIFF
--- a/packages/cloud/shared/src/lib/actions/analytics-enhanced.test.ts
+++ b/packages/cloud/shared/src/lib/actions/analytics-enhanced.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Fail-closed coverage for analytics projection credit-balance reads (#12788).
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Organization } from "../../db/schemas/organizations";
+import { parseProjectionCreditBalance } from "./analytics-enhanced";
+
+const ORG_ID = "00000000-0000-0000-0000-0000000000a1";
+
+function orgWithBalance(credit_balance: unknown): Organization {
+  return { id: ORG_ID, credit_balance } as unknown as Organization;
+}
+
+describe("parseProjectionCreditBalance", () => {
+  test("parses a valid numeric-string balance", () => {
+    expect(parseProjectionCreditBalance(orgWithBalance("12.500000"), ORG_ID)).toBe(12.5);
+  });
+
+  test("throws when the authenticated organization row is missing", () => {
+    expect(() => parseProjectionCreditBalance(undefined, ORG_ID)).toThrow(/not found/);
+  });
+
+  test("throws on null balance instead of fabricating zero", () => {
+    expect(() => parseProjectionCreditBalance(orgWithBalance(null), ORG_ID)).toThrow(
+      /credit_balance/,
+    );
+  });
+
+  test("throws on non-numeric balance instead of returning NaN", () => {
+    expect(() => parseProjectionCreditBalance(orgWithBalance("not-a-number"), ORG_ID)).toThrow(
+      /credit_balance/,
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/actions/analytics-enhanced.ts
+++ b/packages/cloud/shared/src/lib/actions/analytics-enhanced.ts
@@ -16,7 +16,7 @@ import {
   getUsageTimeSeries,
   type TimeGranularity,
 } from "../services/analytics";
-import { organizationsService } from "../services/organizations";
+import { type Organization, organizationsService } from "../services/organizations";
 
 /**
  * Enhanced filters for analytics queries with time range presets.
@@ -30,6 +30,25 @@ export interface EnhancedAnalyticsFilters {
   granularity?: TimeGranularity;
   /** Preset time range (overrides startDate/endDate if provided). */
   timeRange?: "daily" | "weekly" | "monthly";
+}
+
+export function parseProjectionCreditBalance(
+  organization: Organization | undefined,
+  organizationId: string,
+): number {
+  if (!organization) {
+    throw new Error(`Organization ${organizationId} not found while reading projection balance`);
+  }
+
+  // `credit_balance` is a Drizzle numeric string at the row boundary. A
+  // missing/corrupt value is not a $0 balance: projections and low-balance
+  // alerts are user-facing billing signals, so fail closed instead of emitting
+  // a success-shaped analytics payload with a fabricated zero.
+  const balance = Number.parseFloat(String(organization.credit_balance ?? ""));
+  if (!Number.isFinite(balance)) {
+    throw new Error(`Unable to read projection credit_balance for organization ${organizationId}`);
+  }
+  return balance;
 }
 
 /**
@@ -142,7 +161,7 @@ export async function getProjectionsData(request: Request, periods: number = 7) 
     organizationsService.getById(organizationId),
   ]);
 
-  const creditBalance = Number(org?.credit_balance || 0);
+  const creditBalance = parseProjectionCreditBalance(org, organizationId);
   const projections = generateProjections(historicalData, periods);
   const alerts = generateProjectionAlerts(historicalData, projections, creditBalance);
 


### PR DESCRIPTION
## Summary
- add a focused parser for analytics projection organization credit balances
- throw when the organization row is missing or credit_balance is null/non-numeric instead of fabricating zero
- cover valid, missing, null, and corrupt balance cases with a Bun unit test

## Evidence
- `git fetch origin && git rebase origin/develop` completed after stashing/reapplying the local patch
- `bun install` completed with no package changes
- `TMPDIR=/private/tmp/codex-test-tmp bun test packages/cloud/shared/src/lib/actions/analytics-enhanced.test.ts` passed: 4 tests, 4 assertions
- `TMPDIR=/private/tmp/codex-test-tmp bunx biome check packages/cloud/shared/src/lib/actions/analytics-enhanced.ts packages/cloud/shared/src/lib/actions/analytics-enhanced.test.ts` passed
- `git diff --check` passed
- `TMPDIR=/private/tmp/codex-test-tmp bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "analytics-enhanced|error TS" || true` reported no analytics-enhanced errors; it still reports existing transitive app-core auth module errors in `account-pool.ts` / `coding-account-bridge.ts`
- `TMPDIR=/private/tmp/codex-test-tmp bun run verify` attempted and failed outside this change at `@elizaos/electrobun#lint` (`packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts` formatting), with additional unrelated lint warnings in packages such as plugin-computeruse and bun-ios-runtime; write-mode lint side effects were restored

## PR Evidence Matrix
- Real-LLM trajectory: N/A, no agent/action/prompt/model behavior changed
- Backend logs: N/A, focused parser/unit-test change in cloud shared server action code
- Frontend screenshots/video: N/A, no UI surface changed
- Native/mobile/desktop capture: N/A, no native surface changed

Fixes part of #12788.