### PR TITLE
fix(agent): scope memory delete-by-query to the requesting user's identity cluster

### DIFF
--- a/packages/agent/src/actions/memories.test.ts
+++ b/packages/agent/src/actions/memories.test.ts
@@ -13,6 +13,7 @@ const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
 const USER_ID = "00000000-0000-0000-0000-0000000000bb" as UUID;
 const ROOM_ID = "00000000-0000-0000-0000-0000000000cc" as UUID;
 const SIBLING_ID = "00000000-0000-0000-0000-0000000000dd" as UUID;
+const OTHER_USER_ID = "00000000-0000-0000-0000-0000000000ee" as UUID;
 
 type StoredRow = { memory: Memory; tableName: string; unique?: boolean };
 
@@ -337,6 +338,49 @@ describe("MEMORY op:delete by query", () => {
     expect((result.values as { deletedCount: number }).deletedCount).toBe(3);
     expect(rows).toHaveLength(1);
     expect(rows[0].memory.content.text).toBe("nubs lives on a boat");
+  });
+
+  it("scopes delete-by-query to the requesting user's identity cluster", async () => {
+    // Multi-user room: another entity holds a fact with the exact same text.
+    // "Forget that I play guitar" from USER_ID must remove only USER_ID's
+    // row — a text-only match would silently delete the other user's fact.
+    const { runtime, rows } = makeRuntime();
+    seedFact(rows, { text: "i play guitar", entityId: USER_ID });
+    seedFact(rows, { text: "i play guitar", entityId: OTHER_USER_ID });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "delete",
+      query: "i play guitar",
+      confirm: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect((result.values as { deletedCount: number }).deletedCount).toBe(1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].memory.entityId).toBe(OTHER_USER_ID);
+  });
+
+  it("deletes cluster-sibling rows of the requester but not a third user's", async () => {
+    // The requester scope is identity-cluster expanded (getRelatedEntityIds),
+    // so duplicates stored under the requester's sibling ids are still one
+    // logical fact — while an unrelated user's identical text stays out.
+    const { runtime, rows } = makeRuntime({
+      clusters: { [USER_ID]: [SIBLING_ID] },
+    });
+    seedFact(rows, { text: "i play guitar", entityId: USER_ID });
+    seedFact(rows, { text: "i play guitar", entityId: SIBLING_ID });
+    seedFact(rows, { text: "i play guitar", entityId: OTHER_USER_ID });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "delete",
+      query: "i play guitar",
+      confirm: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect((result.values as { deletedCount: number }).deletedCount).toBe(2);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].memory.entityId).toBe(OTHER_USER_ID);
   });
 
   it("refuses an ambiguous query matching distinct memories and lists ids", async () => {

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -367,6 +367,7 @@ async function doUpdate(
 
 async function doDelete(
   runtime: IAgentRuntime,
+  message: Memory,
   params: MemoryParams,
 ): Promise<ActionResult> {
   const memoryParam = parseUuidParam(params.memoryId, "memoryId");
@@ -401,7 +402,7 @@ async function doDelete(
   if (!query) {
     return fail("memoryId or query is required.", "MEMORY_MISSING_ID");
   }
-  return doDeleteByQuery(runtime, params, query);
+  return doDeleteByQuery(runtime, message, params, query);
 }
 
 /**
@@ -411,9 +412,15 @@ async function doDelete(
  * one logical fact — so all rows of the single matched text are removed.
  * A query that strongly matches more than one distinct text is ambiguous:
  * refuse and list the candidates so the model can delete by exact id.
+ *
+ * The read is pinned to the requesting entity's identity cluster: a text-only
+ * match in a multi-user room would also hit another user's identical-text
+ * fact, so "forget that I play guitar" may only remove the asking user's own
+ * rows. Cross-entity deletes must go through op:search + delete by memoryId.
  */
 async function doDeleteByQuery(
   runtime: IAgentRuntime,
+  message: Memory,
   params: MemoryParams,
   query: string,
 ): Promise<ActionResult> {
@@ -424,10 +431,16 @@ async function doDeleteByQuery(
   const roomParam = parseUuidParam(params.roomId, "roomId");
   if (!roomParam.ok) return roomParam.result;
 
+  // Requester wins over a model-supplied entityId: model ids arrive as free
+  // text and could name another user, reopening the cross-user match this
+  // scope exists to close. The parsed param is a fallback only for messages
+  // that carry no entity (internal maintenance invocations).
+  const scopeEntityId = message.entityId ?? entityParam.id;
+
   const limit = clampLimit(params.limit, 50);
   const candidates = await collectCandidates(runtime, {
     type,
-    entityId: entityParam.id,
+    entityId: scopeEntityId,
     roomId: roomParam.id,
     query,
     limit,
@@ -546,7 +559,7 @@ export const memoryAction: Action = {
         case "update":
           return await doUpdate(runtime, params);
         case "delete":
-          return await doDelete(runtime, params);
+          return await doDelete(runtime, message, params);
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -607,7 +620,7 @@ export const memoryAction: Action = {
     {
       name: "query",
       description:
-        "search/delete: case-insensitive text match against memory content. delete: resolves the memory to remove when memoryId is unknown.",
+        "search/delete: case-insensitive text match against memory content. delete: resolves the memory to remove when memoryId is unknown; scoped to the requesting user's own memories.",
       required: false,
       schema: { type: "string" as const },
     },


### PR DESCRIPTION
## What

Follow-up to #12782. The delete-by-query path resolved its target by fact TEXT only: `doDeleteByQuery` passed the (rarely model-supplied) `entityId` param straight to `collectCandidates`, so with no explicit param the entity filter was skipped entirely. In a multi-user room, user A's "forget that I play guitar" matched — and deleted — user B's identical-text fact too. Confirm-gated, but wrong blast radius.

## Fix (structural)

Pin the delete-by-query read scope to the **requesting** message's entity, reusing the same `getRelatedEntityIds` identity-cluster expansion `collectCandidates` already applies for search:

- `doDelete`/`doDeleteByQuery` now receive the triggering `message`; scope = `message.entityId ?? entityParam.id` (the parsed param is a fallback only for messages that carry no entity).
- The requester wins over a model-supplied `entityId` — model ids arrive as free text and could name another user, reopening the exact cross-user match this closes.
- Cluster expansion is preserved: reflection-dedup duplicates stored under the requester's sibling entity ids are still one logical fact and all removed.
- Cross-entity deletes remain possible, but only explicitly: op:search then delete by `memoryId`.

## Proof

New test (the punch-list scenario): two users hold the same-text fact; requester deletes by query with no `entityId` param. **On unmodified develop it fails** — `deletedCount` 2, both rows gone. With the fix: requester's row deleted, the other user's row survives. Second test proves cluster-sibling rows of the requester are still swept while a third user's identical text is untouched.

- `packages/agent` `src/actions/` + `view-memory-lifecycle`: 11 files, **78/78 pass** (memories.test.ts 17/17, 2 new)
- typecheck: identical error set before/after the diff (72 pre-existing env errors, none in `src/actions`) — the change adds zero
- biome clean on both touched files
