### PR TITLE
fix(#12276): deep fallback-slop sweep (feed) slice 0/1 — fabricated-404 -> fail-fast + J3 annotations

### DIFF
--- a/packages/feed/apps/web/src/app/api/follow/route.ts
+++ b/packages/feed/apps/web/src/app/api/follow/route.ts
@@ -14,6 +14,8 @@ async function resolveUserId(request: NextRequest): Promise<string> {
     return queryUserId;
   }
 
+  // error-policy:J3 untrusted request body; a malformed/empty body is invalid input,
+  // null is the explicit "no usable body" signal validated below (throws USER_ID_REQUIRED).
   const body = await request.json().catch(() => null);
   const bodyUserId = typeof body?.userId === "string" ? body.userId.trim() : "";
 

--- a/packages/feed/apps/web/src/app/api/markets/predictions/[id]/route.test.ts
+++ b/packages/feed/apps/web/src/app/api/markets/predictions/[id]/route.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Error-path test for GET /api/markets/predictions/[id]: a market that cannot be
+ * loaded must distinguish a legitimate "not found" (404, preserved body) from a
+ * real infra fault, which now propagates to withErrorHandling (500 + Sentry)
+ * instead of being masked as a fabricated 404 (#12276). Deterministic — the
+ * PredictionMarketService and DB layer are mocked; no live DB.
+ */
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { NextRequest } from "next/server";
+
+class NotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "NOT_FOUND";
+  constructor(resource: string, id?: string) {
+    super(id ? `${resource} not found: ${id}` : `${resource} not found`);
+    this.name = "NotFoundError";
+  }
+}
+
+const mockGetMarket = mock(async () => null as unknown);
+const mockEnsureMarketExists = mock(async () => ({}) as unknown);
+
+mock.module("@feed/api", () => ({
+  addPublicReadHeaders: mock(() => undefined),
+  publicRateLimit: mock(async () => ({
+    error: null,
+    user: null,
+    rateLimitInfo: null,
+  })),
+  successResponse: (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    }),
+  // Faithful mini-boundary: maps a thrown FeedError-shaped statusCode to the
+  // response status, otherwise 500 — the real withErrorHandling contract.
+  withErrorHandling:
+    (
+      handler: (
+        request: NextRequest,
+        context: unknown,
+      ) => Promise<Response> | Response,
+    ) =>
+    async (request: NextRequest, context: unknown) => {
+      try {
+        return await handler(request, context);
+      } catch (error) {
+        const status =
+          error &&
+          typeof (error as { statusCode?: unknown }).statusCode === "number"
+            ? (error as { statusCode: number }).statusCode
+            : 500;
+        return new Response(
+          JSON.stringify({
+            error: { message: (error as Error)?.message ?? "error" },
+          }),
+          { status, headers: { "content-type": "application/json" } },
+        );
+      }
+    },
+}));
+
+mock.module("@feed/core/markets/prediction", () => ({
+  PredictionDbAdapter: class {},
+  PredictionMarketService: class {
+    getMarket = mockGetMarket;
+    ensureMarketExists = mockEnsureMarketExists;
+    listUserPositions = mock(async () => []);
+  },
+  PredictionPricing: { getCurrentPrice: () => 0.5 },
+}));
+
+mock.module("@feed/db", () => ({
+  db: { select: () => ({ from: () => ({ where: async () => [] }) }) },
+  and: () => undefined,
+  balanceTransactions: {},
+  count: () => undefined,
+  eq: () => undefined,
+  inArray: () => undefined,
+  npcTrades: {},
+}));
+
+mock.module("@feed/engine", () => ({
+  FEE_CONFIG: {
+    TRADING_FEE_RATE: 0,
+    PLATFORM_SHARE: 0,
+    REFERRER_SHARE: 0,
+    MIN_FEE_AMOUNT: 0,
+  },
+  WalletService: {
+    debit: async () => undefined,
+    credit: async () => undefined,
+    recordPnL: async () => undefined,
+    getBalance: async () => 0,
+  },
+}));
+
+mock.module("@feed/shared", () => ({
+  logger: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  },
+  MarketQuerySchema: {
+    merge: () => ({
+      partial: () => ({ safeParse: () => ({ success: true, data: {} }) }),
+    }),
+  },
+  NotFoundError,
+  PredictionMarketIdSchema: { parse: (v: { id: string }) => v },
+  toISOOrNull: () => null,
+}));
+
+mock.module("../_position-snapshot", () => ({
+  buildPredictionUserPositionSnapshot: () => null,
+}));
+mock.module("../_resolution-audit", () => ({
+  getPublicResolutionAudit: async () => null,
+}));
+
+const { GET } = await import("./route");
+
+function makeRequest(): NextRequest {
+  return {
+    url: "https://feed.test/api/markets/predictions/mkt-1",
+    method: "GET",
+    headers: new Headers(),
+    cookies: { get: () => undefined },
+  } as unknown as NextRequest;
+}
+
+const ctx = { params: Promise.resolve({ id: "mkt-1" }) };
+
+describe("GET /api/markets/predictions/[id] — error paths", () => {
+  beforeEach(() => {
+    mockGetMarket.mockReset();
+    mockEnsureMarketExists.mockReset();
+    mockGetMarket.mockResolvedValue(null);
+  });
+
+  it("returns a 404 with the canonical body when the market genuinely does not exist", async () => {
+    mockEnsureMarketExists.mockRejectedValue(
+      new NotFoundError("Market", "mkt-1"),
+    );
+    const res = await GET(makeRequest(), ctx);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Market not found" });
+  });
+
+  it("propagates a real infra fault as a 500 instead of masking it as a fabricated 404", async () => {
+    mockEnsureMarketExists.mockRejectedValue(
+      new Error("connection terminated"),
+    );
+    const res = await GET(makeRequest(), ctx);
+    expect(res.status).toBe(500);
+    expect(res.status).not.toBe(404);
+  });
+});

--- a/packages/feed/apps/web/src/app/api/markets/predictions/[id]/route.ts
+++ b/packages/feed/apps/web/src/app/api/markets/predictions/[id]/route.ts
@@ -22,6 +22,7 @@ import { FEE_CONFIG, WalletService } from "@feed/engine";
 import {
   logger,
   MarketQuerySchema,
+  NotFoundError,
   PredictionMarketIdSchema,
   toISOOrNull,
 } from "@feed/shared";
@@ -105,7 +106,13 @@ export const GET = withErrorHandling(
 
     const market =
       (await service.getMarket(marketId)) ??
-      (await service.ensureMarketExists({ marketId }).catch(() => null));
+      (await service.ensureMarketExists({ marketId }).catch((err: unknown) => {
+        // error-policy:J3 an absent question is a legitimate "market not found"
+        // (NotFoundError → 404 below); any other failure is a real fault and must
+        // surface via withErrorHandling (500 + Sentry), never be masked as a 404.
+        if (err instanceof NotFoundError) return null;
+        throw err;
+      }));
 
     if (!market) {
       return successResponse({ error: "Market not found" }, 404);

--- a/packages/feed/apps/web/src/app/api/model-pilot-inquiry/route.ts
+++ b/packages/feed/apps/web/src/app/api/model-pilot-inquiry/route.ts
@@ -55,6 +55,8 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     return rateLimitError(limit.retryAfter);
   }
 
+  // error-policy:J3 untrusted request body; unparseable JSON is invalid input, null is
+  // the explicit "not valid JSON" signal that BodySchema.safeParse rejects with a 400.
   const json: unknown = await request.json().catch(() => null);
   const parsed = BodySchema.safeParse(json);
   if (!parsed.success) {


### PR DESCRIPTION
## What & why

Deep fallback-slop sweep of `packages/feed` (issue #12276, part of #12182), slice **0/1**. The bulk of this sweep already landed via **#12750** (world-state / `getQuestionOutcome` domain exemplars → fail-loud) and **#12827** (19 justified catch-blocks annotated; feed already has **zero unannotated empty catches**). This slice re-derives the suspect list at current `develop` and closes the remaining **unambiguous** gaps the prior sweep did not: one genuine fabricated-default conversion plus two J3 annotations the earlier pass missed (it annotated catch *blocks* but not inline `.catch(() => …)` guards).

### Re-derived suspect inventory (non-test `.ts`/`.tsx`, sparse-checkout materialized)

| category | count | disposition |
|---|---|---|
| empty catch (`catch {}`) | **0** | none in feed — nothing to convert |
| promise-swallow `.catch(() => {}\|null\|undefined)` | 37 sites / 26 files | 1 converted; rest are J3 parse / J4 degrade / J5 abort-suppression / J6 teardown |
| return-default catch blocks | 32 files | already handled/annotated by #12750/#12827, or deferred `?? <lit>` per over-removal guard |

## Converted — fabricated-healthy → fail-fast (1)

`apps/web/src/app/api/markets/predictions/[id]/route.ts`

```ts
// BEFORE — a DB write failure in ensureMarketExists is swallowed to null and
// the route returns a fabricated 404 "Market not found"
(await service.ensureMarketExists({ marketId }).catch(() => null));

// AFTER — only the legitimate NotFoundError (question genuinely absent) → null → 404;
// any real fault rethrows to withErrorHandling (500 + Sentry), never a fake 404
(await service.ensureMarketExists({ marketId }).catch((err: unknown) => {
  // error-policy:J3 an absent question is a legitimate "market not found" (NotFoundError → 404 below);
  // any other failure is a real fault and must surface via withErrorHandling (500 + Sentry).
  if (err instanceof NotFoundError) return null;
  throw err;
}));
```

This is the exact banned conflation from the issue exemplars: a broken read/write masquerading as domain absence. The route is wrapped in `withErrorHandling` (a J1 boundary that maps `FeedError.statusCode` → response and captures 5xx to Sentry), so rethrowing is all that's needed for the failure to surface observably.

## Annotated — J3 untrusted-input parse guards (2)

- `apps/web/src/app/api/follow/route.ts` — `request.json().catch(() => null)`; null → `USER_ID_REQUIRED` throw.
- `apps/web/src/app/api/model-pilot-inquiry/route.ts` — `request.json().catch(() => null)`; null → `BodySchema.safeParse` → 400.

Both are legitimate KEEPs (null is the explicit typed-invalid signal, not a fabricated value) that lacked a grep-able `// error-policy:J3` marker.

## Deferred (ambiguousLeft) — per the over-removal guard

Not touched this pass; each needs per-site judgment that risks over-removal:
- `optionalAuth(...).catch(() => null)` on **public** widget/read routes — `optionalAuth` already returns null internally for missing/invalid tokens; the outer catch is a borderline degrade-to-anonymous, not clean slop.
- Client-side `.catch(() => null)` on `AbortController`-driven fetches (`TerminalSocialFeed`, `ProfilePageClient`, `DagVisualizerClient`) — these also suppress the **expected** `AbortError`, so conversion would break the supersede/unmount flow (J5 territory).
- `tools/chroma/**` and `apps/cli` teardown swallows — J6 best-effort test/teardown.
- The ~330 `?? <lit>` / `|| <lit>` numeric config defaults — explicitly deferred by the parent sweep.

## Tests

New deterministic error-path test `apps/web/src/app/api/markets/predictions/[id]/route.test.ts` (mocked service + DB, no live DB):
- **NotFoundError → 404** with the canonical `{ error: "Market not found" }` body (behavior preserved).
- **Generic infra error → 500**, asserts `.not.toBe(404)` (the regression this fixes).

Verified the test is a real guard: it **fails on the old slop** (returns 404) and **passes on the fix** (returns 500).

```
bun test .../predictions/[id]/route.test.ts   -> 2 pass
bun test .../model-pilot-inquiry/route.test.ts -> 6 pass (unchanged, annotation is comment-only)
bunx biome check (touched files)               -> clean
node packages/scripts/error-policy-ratchet.mjs -> no new fallback-slop in touched files
```

**Ratchet — empty-catch in touched files: 0 -> 0** (never up).

## Evidence

- Backend fail-loud path proven by the 500-not-404 test assertion (a stopped-DB `ensureMarketExists` throw now reaches `withErrorHandling` -> 500 + Sentry). Full live stopped-DB capture: **N/A** — feed's integration DB harness (Postgres :5433) is not stood up in this worktree; the conversion is proven at the route boundary with a deterministic reject that exercises the identical code path.
- Screenshots / video: **N/A** — no rendered UI surface changed (server route status-code + two comment annotations).

Refs #12276

🤖 Generated with [Claude Code](https://claude.com/claude-code)
