### PR TITLE
fix: expose meeting capture privacy state

### DIFF
--- a/.github/issue-evidence/12500-consent-privacy-retention-state.md
+++ b/.github/issue-evidence/12500-consent-privacy-retention-state.md
@@ -1,0 +1,123 @@
+# Issue #12500 — consent, privacy, and retention UX
+
+Parent issue: https://github.com/elizaOS/eliza/issues/12500
+Code PR: https://github.com/elizaOS/eliza/pull/13259
+Human follow-up issue: https://github.com/elizaOS/eliza/issues/13260
+
+## Agent-completed scope
+
+- Added a shared `TranscriptCapturePrivacyState` contract and
+  `transcriptCapturePrivacyState()` normalizer for meeting capture mode,
+  consent, policy, permission, retention, source-audio deletion, and independent
+  transcript/notes/source-audio/artifact sharing states.
+- Added Transcripts view chips for meeting records so capture/privacy/retention
+  metadata is visible in the detail pane.
+- Persisted default meeting transcript privacy metadata from
+  `MeetingTranscriptWriter`:
+  - capture mode: `bot`
+  - policy: `allowed`
+  - permission: `not_required`
+  - retention: `transcript_only` or `audio_retained`
+  - sharing: owner-private transcript/notes/artifacts, source audio disabled
+    unless retained.
+
+## Verification
+
+- `bun install`
+  - Completed in the isolated worktree.
+  - Artifact sync completed at `2026-06-18.1`.
+  - Generated lock/artifact drift was restored before commit.
+  - Reran after `git fetch origin && git rebase origin/develop`; artifacts were
+    already current and lockfile ordering drift was restored.
+- `node packages/shared/scripts/generate-keywords.mjs --target ts`
+  - Generated the local core/shared validation keyword modules required by
+    focused tests.
+- `bun run --cwd packages/cloud/routing build`
+  - Passed; required so Vitest could resolve `@elizaos/cloud-routing`.
+- `bun run --cwd packages/contracts build`
+  - Passed; required by shared/core package typechecks.
+- `bun run --cwd packages/shared build`
+  - Passed.
+- `bun run --cwd packages/core build`
+  - Passed.
+- `bunx biome check packages/shared/src/transcripts.ts packages/shared/src/transcripts.test.ts packages/ui/src/components/transcripts/TranscriptsView.tsx packages/ui/src/components/transcripts/TranscriptsView.test.tsx plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.ts plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.test.ts`
+  - Passed.
+- `bun run --cwd packages/shared test -- transcripts.test.ts`
+  - Passed: 1 file, 20 tests.
+- `bun run --cwd packages/ui test -- TranscriptsView.test.tsx`
+  - Passed: 1 file, 8 tests.
+- `bun run --cwd plugins/plugin-meetings test -- src/transcripts/meeting-transcript-writer.test.ts`
+  - Passed: 1 file, 7 tests.
+- `bun run --cwd packages/shared typecheck`
+  - Passed.
+- `bun run --cwd plugins/plugin-meetings typecheck`
+  - Passed.
+- `bun run --cwd plugins/plugin-meetings lint:check`
+  - Passed.
+- `bun run --cwd packages/ui typecheck`
+  - Passed before the final `origin/develop` rebase.
+  - On final base `c971b10c275`, failed outside this PR on
+    `packages/ui/src/components/chat/widgets/notifications.tsx` because
+    `selectHomeNotifications` is not exported from
+    `packages/ui/src/widgets/home-priority`.
+- `bun run --cwd packages/app audit:app`
+  - Passed before and after rebasing onto latest `origin/develop`.
+  - Post-rebase result: 373 Playwright audit checks passed.
+  - Summary: `broken=0`, `needs-work=0`, `needs-eyeball=25`, `good=347`,
+    `minimalism-budget-failures=0`, `minimalism-ratchet-failures=0`.
+  - Known hover-probe timeouts included `builtin-transcripts` "Join meeting" in
+    all four viewports; screenshots showed no visible layout breakage.
+  - Manually reviewed Transcripts screenshots:
+    - `packages/app/aesthetic-audit-output/desktop-landscape/builtin-transcripts.png`
+    - `packages/app/aesthetic-audit-output/mobile-portrait/builtin-transcripts.png`
+    - `packages/app/aesthetic-audit-output/mobile-landscape/builtin-transcripts.png`
+    - `packages/app/aesthetic-audit-output/ipad-portrait/builtin-transcripts.png`
+  - Filled Transcripts manual-review notes:
+    - `packages/app/aesthetic-audit-output/manual-review/builtin-transcripts-desktop-landscape.md`
+    - `packages/app/aesthetic-audit-output/manual-review/builtin-transcripts-mobile-portrait.md`
+    - `packages/app/aesthetic-audit-output/manual-review/builtin-transcripts-mobile-landscape.md`
+    - `packages/app/aesthetic-audit-output/manual-review/builtin-transcripts-ipad-portrait.md`
+- `bun run verify`
+  - Failed outside this PR during workspace lint after the AGENTS/CLAUDE
+    identity check, type-safety ratchet, and error-policy ratchet passed against
+    final base `c971b10c275`.
+  - Turbo reported `@elizaos/electrobun#lint` as the failing task.
+- `bun run --cwd packages/app-core/platforms/electrobun lint`
+  - Reproduced the final root-verify blocker.
+  - Failed on existing unrelated formatting in
+    `packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts`.
+
+## Known out-of-scope verification failures
+
+- Earlier post-rebase `bun run verify`
+  - Failed outside this PR at `@elizaos/tui#lint`.
+  - Direct repro: `bun run --cwd packages/tui lint` failed on existing
+    unrelated TUI lint debt, including
+    `lint/suspicious/noControlCharactersInRegex` in `packages/tui/src/keys.ts`
+    and `packages/tui/src/terminal.ts`, plus existing non-null assertion/import
+    diagnostics.
+- `bun run --cwd packages/shared lint:check`
+  - Failed on existing unrelated formatting in
+    `packages/shared/src/voice/aec/echo-alignment.ts`.
+- `bun run --cwd packages/ui lint:check`
+  - Failed on existing unrelated diagnostics in:
+    - `packages/ui/src/cloud/shell/cloud-route-gate.test.tsx`
+    - `packages/ui/src/first-run/use-first-run-conductor.ts`
+    - `packages/ui/src/state/useChatCallbacks.select-race.test.tsx`
+    - `packages/ui/src/voice/tts-playback-activity.test.ts`
+
+## Still needs human proof
+
+- Headful screenshots/video showing real meeting records with these capture
+  modes: bot, platform import, bot-free tab/system, local mic, mobile room mic,
+  benchmark import, and imported artifact.
+- Real org-policy-denied flow proving capture is blocked before audio starts,
+  with frontend and backend logs.
+- Permission-denied, capture-stopped, bot-removed, meeting-ended, and
+  policy-denied failure-state proof.
+- Retention proof deleting source audio, invalidating replay, and preserving
+  allowed transcript references.
+- Sharing-control proof that transcript, notes, source audio, and generated
+  artifacts can be controlled independently.
+- Domain artifacts from the real run: transcript metadata rows, source-audio
+  media handles before/after deletion, generated notes/artifacts, and logs.

--- a/packages/shared/src/transcripts.test.ts
+++ b/packages/shared/src/transcripts.test.ts
@@ -13,6 +13,7 @@ import {
   type Transcript,
   type TranscriptSegment,
   type TranscriptWord,
+  transcriptCapturePrivacyState,
   transcriptDurationMs,
   transcriptPlainText,
   transcriptPreview,
@@ -207,6 +208,115 @@ describe("summarizeTranscript", () => {
       metadata: {},
     };
     expect(summarizeTranscript(bare).meeting).toEqual({ participantCount: 0 });
+  });
+});
+
+describe("transcriptCapturePrivacyState", () => {
+  it("normalizes flat capture, consent, retention, policy, permission, and sharing metadata", () => {
+    const transcript: Transcript = {
+      id: "m-policy",
+      title: "Policy sync",
+      createdAt: 4000,
+      durationMs: 1000,
+      audioUrl: "/api/media/source.wav",
+      segments: segs.slice(0, 1),
+      source: "meeting",
+      scope: "owner-private",
+      status: "ready",
+      speakerCount: 1,
+      metadata: {
+        captureMode: "bot_free_tab_system",
+        consentState: "granted",
+        policyState: "allowed",
+        permissionState: "granted",
+        retentionState: "audio_retained",
+        transcriptSharingState: "owner_private",
+        notesSharingState: "restricted",
+        sourceAudioSharingState: "disabled",
+        artifactsSharingState: "shared",
+      },
+    };
+
+    expect(transcriptCapturePrivacyState(transcript)).toEqual({
+      captureMode: "bot_free_tab_system",
+      consentState: "granted",
+      policyState: "allowed",
+      permissionState: "granted",
+      retentionState: "audio_retained",
+      sharing: {
+        transcript: "owner_private",
+        notes: "restricted",
+        sourceAudio: "disabled",
+        artifacts: "shared",
+      },
+      sourceAudioDeleted: false,
+      hasExplicitState: true,
+    });
+  });
+
+  it("normalizes nested metadata and derives audio-deleted transcript retention", () => {
+    const transcript: Transcript = {
+      id: "m-deleted",
+      title: "Deleted audio",
+      createdAt: 5000,
+      durationMs: 1000,
+      segments: segs.slice(0, 1),
+      source: "meeting",
+      scope: "owner-private",
+      status: "ready",
+      speakerCount: 1,
+      metadata: {
+        capture: { mode: "platform_import" },
+        consent: { state: "not_required" },
+        policy: { state: "org_blocked" },
+        permission: { state: "denied" },
+        retention: { sourceAudioDeleted: true },
+        sharing: {
+          transcript: "owner_private",
+          sourceAudio: "disabled",
+        },
+      },
+    };
+
+    expect(transcriptCapturePrivacyState(transcript)).toEqual({
+      captureMode: "platform_import",
+      consentState: "not_required",
+      policyState: "org_blocked",
+      permissionState: "denied",
+      retentionState: "audio_deleted_transcript_retained",
+      sharing: {
+        transcript: "owner_private",
+        sourceAudio: "disabled",
+      },
+      sourceAudioDeleted: true,
+      hasExplicitState: true,
+    });
+  });
+
+  it("derives retained audio from audioUrl and ignores unknown enum values", () => {
+    const transcript: Transcript = {
+      id: "m-audio",
+      title: "Audio retained",
+      createdAt: 6000,
+      durationMs: 1000,
+      audioUrl: "/api/media/retained.wav",
+      segments: segs.slice(0, 1),
+      source: "meeting",
+      scope: "owner-private",
+      status: "ready",
+      speakerCount: 1,
+      metadata: {
+        captureMode: "made_up_mode",
+        sharing: { transcript: "public" },
+      },
+    };
+
+    expect(transcriptCapturePrivacyState(transcript)).toEqual({
+      retentionState: "audio_retained",
+      sharing: { transcript: "public" },
+      sourceAudioDeleted: false,
+      hasExplicitState: true,
+    });
   });
 });
 

--- a/packages/shared/src/transcripts.ts
+++ b/packages/shared/src/transcripts.ts
@@ -94,6 +94,93 @@ export interface TranscriptSummaryMeetingMeta {
   participantCount: number;
 }
 
+export const TRANSCRIPT_CAPTURE_MODES = [
+  "bot",
+  "platform_import",
+  "bot_free_tab_system",
+  "local_mic",
+  "mobile_room_mic",
+  "benchmark_import",
+  "imported_artifact",
+  "unknown",
+] as const;
+
+export type TranscriptCaptureMode = (typeof TRANSCRIPT_CAPTURE_MODES)[number];
+
+export const TRANSCRIPT_CONSENT_STATES = [
+  "not_required",
+  "pending",
+  "granted",
+  "denied",
+  "revoked",
+  "unknown",
+] as const;
+
+export type TranscriptConsentState = (typeof TRANSCRIPT_CONSENT_STATES)[number];
+
+export const TRANSCRIPT_POLICY_STATES = [
+  "allowed",
+  "org_blocked",
+  "user_blocked",
+  "unknown",
+] as const;
+
+export type TranscriptPolicyState = (typeof TRANSCRIPT_POLICY_STATES)[number];
+
+export const TRANSCRIPT_PERMISSION_STATES = [
+  "prompt",
+  "granted",
+  "denied",
+  "stopped",
+  "revoked",
+  "not_required",
+  "unknown",
+] as const;
+
+export type TranscriptPermissionState =
+  (typeof TRANSCRIPT_PERMISSION_STATES)[number];
+
+export const TRANSCRIPT_RETENTION_STATES = [
+  "audio_retained",
+  "audio_deleted_transcript_retained",
+  "transcript_only",
+  "delete_pending",
+  "unknown",
+] as const;
+
+export type TranscriptRetentionState =
+  (typeof TRANSCRIPT_RETENTION_STATES)[number];
+
+export const TRANSCRIPT_SHARING_STATES = [
+  "owner_private",
+  "restricted",
+  "shared",
+  "public",
+  "disabled",
+  "unknown",
+] as const;
+
+export type TranscriptSharingState = (typeof TRANSCRIPT_SHARING_STATES)[number];
+
+export interface TranscriptCaptureSharingState {
+  transcript?: TranscriptSharingState;
+  notes?: TranscriptSharingState;
+  sourceAudio?: TranscriptSharingState;
+  artifacts?: TranscriptSharingState;
+}
+
+export interface TranscriptCapturePrivacyState {
+  captureMode?: TranscriptCaptureMode;
+  consentState?: TranscriptConsentState;
+  policyState?: TranscriptPolicyState;
+  permissionState?: TranscriptPermissionState;
+  retentionState?: TranscriptRetentionState;
+  sharing: TranscriptCaptureSharingState;
+  sourceAudioDeleted: boolean;
+  /** True only when metadata explicitly carried policy/privacy fields. */
+  hasExplicitState: boolean;
+}
+
 /** Compact list-row projection for the transcripts index. */
 export interface TranscriptSummary {
   id: string;
@@ -184,6 +271,139 @@ function summarizeMeetingMeta(
   return platform === undefined
     ? { participantCount }
     : { platform, participantCount };
+}
+
+function recordProp(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = metadata?.[key];
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+function stringProp(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = metadata?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function booleanProp(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+): boolean | undefined {
+  const value = metadata?.[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function enumProp<const Values extends readonly string[]>(
+  value: string | undefined,
+  values: Values,
+): Values[number] | undefined {
+  return value !== undefined && values.includes(value) ? value : undefined;
+}
+
+function sharingState(
+  metadata: Record<string, unknown> | undefined,
+  sharing: Record<string, unknown> | undefined,
+  key: keyof TranscriptCaptureSharingState,
+): TranscriptSharingState | undefined {
+  const flatKey =
+    key === "sourceAudio" ? "sourceAudioSharingState" : `${key}SharingState`;
+  return enumProp(
+    stringProp(metadata, flatKey) ?? stringProp(sharing, key),
+    TRANSCRIPT_SHARING_STATES,
+  );
+}
+
+/**
+ * Normalize capture/consent/privacy/retention metadata from a transcript.
+ *
+ * Writers may store either flat fields (`captureMode`, `retentionState`) or
+ * nested groups (`capture.mode`, `retention.state`, `sharing.transcript`).
+ * The UI renders this normalized server-provided state; it does not derive
+ * policy or privacy from raw metadata on its own.
+ */
+export function transcriptCapturePrivacyState(
+  transcript: Transcript,
+): TranscriptCapturePrivacyState {
+  const metadata = transcript.metadata;
+  const capture = recordProp(metadata, "capture");
+  const consent = recordProp(metadata, "consent");
+  const policy = recordProp(metadata, "policy");
+  const permission = recordProp(metadata, "permission");
+  const retention = recordProp(metadata, "retention");
+  const sharing = recordProp(metadata, "sharing");
+
+  const captureMode = enumProp(
+    stringProp(metadata, "captureMode") ?? stringProp(capture, "mode"),
+    TRANSCRIPT_CAPTURE_MODES,
+  );
+  const consentState = enumProp(
+    stringProp(metadata, "consentState") ?? stringProp(consent, "state"),
+    TRANSCRIPT_CONSENT_STATES,
+  );
+  const policyState = enumProp(
+    stringProp(metadata, "policyState") ?? stringProp(policy, "state"),
+    TRANSCRIPT_POLICY_STATES,
+  );
+  const permissionState = enumProp(
+    stringProp(metadata, "permissionState") ?? stringProp(permission, "state"),
+    TRANSCRIPT_PERMISSION_STATES,
+  );
+  const sourceAudioDeleted =
+    booleanProp(metadata, "sourceAudioDeleted") ??
+    booleanProp(retention, "sourceAudioDeleted") ??
+    false;
+  const explicitRetentionState = enumProp(
+    stringProp(metadata, "retentionState") ?? stringProp(retention, "state"),
+    TRANSCRIPT_RETENTION_STATES,
+  );
+  const retentionState =
+    explicitRetentionState ??
+    (sourceAudioDeleted
+      ? "audio_deleted_transcript_retained"
+      : transcript.audioUrl
+        ? "audio_retained"
+        : undefined);
+
+  const normalizedSharing: TranscriptCaptureSharingState = {
+    ...(sharingState(metadata, sharing, "transcript")
+      ? { transcript: sharingState(metadata, sharing, "transcript") }
+      : {}),
+    ...(sharingState(metadata, sharing, "notes")
+      ? { notes: sharingState(metadata, sharing, "notes") }
+      : {}),
+    ...(sharingState(metadata, sharing, "sourceAudio")
+      ? { sourceAudio: sharingState(metadata, sharing, "sourceAudio") }
+      : {}),
+    ...(sharingState(metadata, sharing, "artifacts")
+      ? { artifacts: sharingState(metadata, sharing, "artifacts") }
+      : {}),
+  };
+
+  return {
+    ...(captureMode ? { captureMode } : {}),
+    ...(consentState ? { consentState } : {}),
+    ...(policyState ? { policyState } : {}),
+    ...(permissionState ? { permissionState } : {}),
+    ...(retentionState ? { retentionState } : {}),
+    sharing: normalizedSharing,
+    sourceAudioDeleted,
+    hasExplicitState: Boolean(
+      captureMode ||
+        consentState ||
+        policyState ||
+        permissionState ||
+        explicitRetentionState ||
+        sourceAudioDeleted ||
+        Object.keys(normalizedSharing).length > 0,
+    ),
+  };
 }
 
 /** Project a full transcript to its list-row summary. */

--- a/packages/ui/src/components/transcripts/TranscriptsView.test.tsx
+++ b/packages/ui/src/components/transcripts/TranscriptsView.test.tsx
@@ -214,6 +214,50 @@ describe("TranscriptsView", () => {
     expect(screen.queryByTestId("live-meeting-pane")).toBeNull();
   });
 
+  it("shows capture, consent, retention, and sharing states from meeting metadata", () => {
+    const archivedMeeting: Transcript = {
+      ...selected,
+      id: "m1",
+      title: "Weekly sync",
+      source: "meeting",
+      status: "ready",
+      metadata: {
+        ...meetingDetailMetadata,
+        captureMode: "bot_free_tab_system",
+        consentState: "granted",
+        policyState: "org_blocked",
+        permissionState: "denied",
+        retentionState: "audio_deleted_transcript_retained",
+        transcriptSharingState: "owner_private",
+        notesSharingState: "restricted",
+        sourceAudioSharingState: "disabled",
+        artifactsSharingState: "shared",
+        sourceAudioDeleted: true,
+      },
+    };
+    render(
+      <TranscriptsView
+        transcripts={[{ ...meetingSummary, status: "ready" }]}
+        selectedId="m1"
+        selected={archivedMeeting}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const state = screen.getByTestId("meeting-capture-privacy-state");
+    expect(state.textContent).toContain("Capture: Bot-free tab/system");
+    expect(state.textContent).toContain("Consent: Granted");
+    expect(state.textContent).toContain("Policy: Org blocked");
+    expect(state.textContent).toContain("Permission: Denied");
+    expect(state.textContent).toContain(
+      "Retention: Audio deleted, transcript retained",
+    );
+    expect(state.textContent).toContain("Transcript: Private");
+    expect(state.textContent).toContain("Notes: Restricted");
+    expect(state.textContent).toContain("Source audio: Disabled");
+    expect(state.textContent).toContain("Artifacts: Shared");
+  });
+
   it("renders the join bar and forwards a join request", () => {
     const onJoinMeeting = vi.fn();
     render(

--- a/packages/ui/src/components/transcripts/TranscriptsView.tsx
+++ b/packages/ui/src/components/transcripts/TranscriptsView.tsx
@@ -19,9 +19,14 @@ import {
 } from "@elizaos/shared";
 import type {
   Transcript,
+  TranscriptCapturePrivacyState,
+  TranscriptConsentState,
+  TranscriptRetentionState,
+  TranscriptSharingState,
   TranscriptStatus,
   TranscriptSummary,
 } from "@elizaos/shared/transcripts";
+import { transcriptCapturePrivacyState } from "@elizaos/shared/transcripts";
 import { AudioLines } from "lucide-react";
 import type * as React from "react";
 import { useAgentElement } from "../../agent-surface";
@@ -93,6 +98,60 @@ const STATUS_LABEL: Record<TranscriptStatus, string> = {
   processing: "Processing",
   ready: "",
   failed: "Failed",
+};
+
+const CAPTURE_MODE_LABEL: Record<string, string> = {
+  bot: "Bot",
+  platform_import: "Platform import",
+  bot_free_tab_system: "Bot-free tab/system",
+  local_mic: "Local mic",
+  mobile_room_mic: "Mobile room mic",
+  benchmark_import: "Benchmark",
+  imported_artifact: "Imported artifact",
+  unknown: "Unknown capture",
+};
+
+const CONSENT_LABEL: Record<TranscriptConsentState, string> = {
+  not_required: "Not required",
+  pending: "Pending",
+  granted: "Granted",
+  denied: "Denied",
+  revoked: "Revoked",
+  unknown: "Unknown",
+};
+
+const POLICY_LABEL: Record<string, string> = {
+  allowed: "Allowed",
+  org_blocked: "Org blocked",
+  user_blocked: "User blocked",
+  unknown: "Unknown",
+};
+
+const PERMISSION_LABEL: Record<string, string> = {
+  prompt: "Prompt",
+  granted: "Granted",
+  denied: "Denied",
+  stopped: "Stopped",
+  revoked: "Revoked",
+  not_required: "Not required",
+  unknown: "Unknown",
+};
+
+const RETENTION_LABEL: Record<TranscriptRetentionState, string> = {
+  audio_retained: "Audio retained",
+  audio_deleted_transcript_retained: "Audio deleted, transcript retained",
+  transcript_only: "Transcript only",
+  delete_pending: "Delete pending",
+  unknown: "Unknown",
+};
+
+const SHARING_LABEL: Record<TranscriptSharingState, string> = {
+  owner_private: "Private",
+  restricted: "Restricted",
+  shared: "Shared",
+  public: "Public",
+  disabled: "Disabled",
+  unknown: "Unknown",
 };
 
 /** Small accent dot + label shown on live meeting rows/headers. */
@@ -230,6 +289,107 @@ function MeetingDetailHeader({
   );
 }
 
+function MeetingCapturePrivacyStrip({
+  transcript,
+}: {
+  transcript: Transcript;
+}): React.JSX.Element | null {
+  const state = transcriptCapturePrivacyState(transcript);
+  const chips = capturePrivacyChips(state);
+  if (chips.length === 0) return null;
+
+  return (
+    <div
+      data-testid="meeting-capture-privacy-state"
+      className="flex flex-wrap gap-1.5 text-xs"
+    >
+      {chips.map((chip) => (
+        <span
+          key={`${chip.label}:${chip.value}`}
+          data-testid={`meeting-privacy-chip-${agentSafeId(chip.label)}`}
+          className={cn(
+            "rounded-sm border px-1.5 py-0.5",
+            chip.alert
+              ? "border-destructive/40 text-destructive"
+              : "border-border text-muted",
+          )}
+        >
+          <span className="font-medium text-txt">{chip.label}:</span>{" "}
+          {chip.value}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function capturePrivacyChips(
+  state: TranscriptCapturePrivacyState,
+): Array<{ label: string; value: string; alert?: boolean }> {
+  const chips: Array<{ label: string; value: string; alert?: boolean }> = [];
+  if (state.captureMode) {
+    chips.push({
+      label: "Capture",
+      value: CAPTURE_MODE_LABEL[state.captureMode] ?? state.captureMode,
+    });
+  }
+  if (state.consentState) {
+    chips.push({
+      label: "Consent",
+      value: CONSENT_LABEL[state.consentState],
+      alert:
+        state.consentState === "denied" || state.consentState === "revoked",
+    });
+  }
+  if (state.policyState) {
+    chips.push({
+      label: "Policy",
+      value: POLICY_LABEL[state.policyState] ?? state.policyState,
+      alert:
+        state.policyState === "org_blocked" ||
+        state.policyState === "user_blocked",
+    });
+  }
+  if (state.permissionState) {
+    chips.push({
+      label: "Permission",
+      value: PERMISSION_LABEL[state.permissionState] ?? state.permissionState,
+      alert:
+        state.permissionState === "denied" ||
+        state.permissionState === "revoked",
+    });
+  }
+  if (state.retentionState) {
+    chips.push({
+      label: "Retention",
+      value: RETENTION_LABEL[state.retentionState],
+      alert: state.retentionState === "delete_pending",
+    });
+  }
+  if (state.sharing.transcript) {
+    chips.push({
+      label: "Transcript",
+      value: SHARING_LABEL[state.sharing.transcript],
+    });
+  }
+  if (state.sharing.notes) {
+    chips.push({ label: "Notes", value: SHARING_LABEL[state.sharing.notes] });
+  }
+  if (state.sharing.sourceAudio) {
+    chips.push({
+      label: "Source audio",
+      value: SHARING_LABEL[state.sharing.sourceAudio],
+      alert: state.sourceAudioDeleted,
+    });
+  }
+  if (state.sharing.artifacts) {
+    chips.push({
+      label: "Artifacts",
+      value: SHARING_LABEL[state.sharing.artifacts],
+    });
+  }
+  return chips;
+}
+
 export function TranscriptsView({
   transcripts,
   selectedId,
@@ -332,7 +492,10 @@ export function TranscriptsView({
                   ) : null}
                 </div>
                 {selected.source === "meeting" ? (
-                  <MeetingDetailHeader transcript={selected} />
+                  <>
+                    <MeetingDetailHeader transcript={selected} />
+                    <MeetingCapturePrivacyStrip transcript={selected} />
+                  </>
                 ) : null}
                 {selectedIsLiveMeeting ? (
                   <LiveMeetingPane transcript={selected} />

--- a/plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.test.ts
+++ b/plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.test.ts
@@ -10,6 +10,7 @@ import type { Memory, UUID } from "@elizaos/core";
 import {
   summarizeTranscript,
   type Transcript,
+  transcriptCapturePrivacyState,
   transcriptPreview,
 } from "@elizaos/shared/transcripts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -76,6 +77,20 @@ describe("MeetingTranscriptWriter — record shape golden", () => {
     expect(summarizeTranscript(recording as Transcript).id).toBe(
       writer.transcriptId,
     );
+    expect(transcriptCapturePrivacyState(recording as Transcript)).toEqual({
+      captureMode: "bot",
+      policyState: "allowed",
+      permissionState: "not_required",
+      retentionState: "transcript_only",
+      sharing: {
+        transcript: "owner_private",
+        notes: "owner_private",
+        sourceAudio: "disabled",
+        artifacts: "owner_private",
+      },
+      sourceAudioDeleted: false,
+      hasExplicitState: true,
+    });
 
     // Incremental update: preview text + timing metadata stay consistent.
     const segments = [
@@ -112,6 +127,22 @@ describe("MeetingTranscriptWriter — record shape golden", () => {
       nativeMeetingId: "abc-defg-hij",
       endReason: "normal_completion",
     });
+    expect(transcriptCapturePrivacyState(readBack as Transcript)).toMatchObject(
+      {
+        captureMode: "bot",
+        policyState: "allowed",
+        permissionState: "not_required",
+        retentionState: "transcript_only",
+        sharing: {
+          transcript: "owner_private",
+          notes: "owner_private",
+          sourceAudio: "disabled",
+          artifacts: "owner_private",
+        },
+        sourceAudioDeleted: false,
+        hasExplicitState: true,
+      },
+    );
     // Local reader helper agrees with the view reader.
     expect(readTranscriptRow(finalRow)).toEqual(readBack);
     // Knowledge mirror: tag "transcript", clientDocumentId = transcript id, textBacked.
@@ -206,6 +237,15 @@ describe("MeetingTranscriptWriter — finalize edges", () => {
       });
       expect(finalB.audioUrl).toMatch(/^\/api\/media\/[0-9a-f]{64}\.wav$/);
       expect(finalB.audioContentType).toBe("audio/wav");
+      expect(transcriptCapturePrivacyState(finalB)).toMatchObject({
+        retentionState: "audio_retained",
+        sharing: {
+          transcript: "owner_private",
+          notes: "owner_private",
+          sourceAudio: "owner_private",
+          artifacts: "owner_private",
+        },
+      });
       const hash = finalB.audioUrl?.slice("/api/media/".length) as string;
       expect(existsSync(join(dir, "media", hash))).toBe(true);
 

--- a/plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.ts
+++ b/plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.ts
@@ -203,6 +203,19 @@ export class MeetingTranscriptWriter {
         nativeMeetingId: input.nativeMeetingId,
         sessionId: input.sessionId,
         participants: [],
+        capture: { mode: "bot" },
+        policy: { state: "allowed" },
+        permission: { state: "not_required" },
+        retention: {
+          state: "transcript_only",
+          sourceAudioDeleted: false,
+        },
+        sharing: {
+          transcript: "owner_private",
+          notes: "owner_private",
+          sourceAudio: "disabled",
+          artifacts: "owner_private",
+        },
       },
     };
     const { content, metadata } = transcriptContentAndMetadata(transcript);
@@ -329,6 +342,16 @@ export class MeetingTranscriptWriter {
         ...this.transcript.metadata,
         endReason: input.endReason,
         participants: input.participants,
+        retention: {
+          state: audioUrl ? "audio_retained" : "transcript_only",
+          sourceAudioDeleted: false,
+        },
+        sharing: {
+          transcript: "owner_private",
+          notes: "owner_private",
+          sourceAudio: audioUrl ? "owner_private" : "disabled",
+          artifacts: "owner_private",
+        },
       },
     };
 


### PR DESCRIPTION
## Summary

- Add shared transcript capture/privacy/retention state types and a normalizer for flat and nested meeting metadata.
- Show meeting capture, consent, policy, permission, retention, source-audio deletion, and sharing state chips in the Transcripts detail pane.
- Persist default privacy metadata from the meetings transcript writer and cover it in golden writer tests.

## Evidence

- Evidence file: `.github/issue-evidence/12500-consent-privacy-retention-state.md`
- `bun install` after `git fetch origin && git rebase origin/develop` completed; artifacts already at `2026-06-18.1`; lockfile ordering drift restored.
- `bunx biome check packages/shared/src/transcripts.ts packages/shared/src/transcripts.test.ts packages/ui/src/components/transcripts/TranscriptsView.tsx packages/ui/src/components/transcripts/TranscriptsView.test.tsx plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.ts plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.test.ts` passed.
- `bun run --cwd packages/shared test -- transcripts.test.ts` passed: 1 file, 20 tests.
- `bun run --cwd packages/ui test -- TranscriptsView.test.tsx` passed: 1 file, 8 tests.
- `bun run --cwd plugins/plugin-meetings test -- src/transcripts/meeting-transcript-writer.test.ts` passed: 1 file, 7 tests.
- `bun run --cwd packages/shared typecheck` passed.
- `bun run --cwd plugins/plugin-meetings typecheck` passed.
- `bun run --cwd plugins/plugin-meetings lint:check` passed.
- `bun run --cwd packages/app audit:app` passed after rebase: 373 checks; `broken=0`, `needs-work=0`, `needs-eyeball=25`, `good=347`.

## Known unrelated failures

- `bun run verify` fails outside this PR at `@elizaos/electrobun#lint` on existing formatting in `packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts`.
- `bun run --cwd packages/ui typecheck` now fails on final base `c971b10c275` outside this PR: `selectHomeNotifications` is not exported from `packages/ui/src/widgets/home-priority` for `packages/ui/src/components/chat/widgets/notifications.tsx`.
- `bun run --cwd packages/shared lint:check` fails on existing formatting in `packages/shared/src/voice/aec/echo-alignment.ts`.
- `bun run --cwd packages/ui lint:check` fails on existing unrelated package-wide diagnostics listed in the evidence file.

## Human follow-up

This PR handles deterministic code/test/UI surfacing only. Remaining real-world proof is split into #13260.
