### PR TITLE
fix(#12788): strictly parse projection credit balances

### DIFF
--- a/packages/cloud/shared/src/lib/actions/analytics-enhanced.test.ts
+++ b/packages/cloud/shared/src/lib/actions/analytics-enhanced.test.ts
@@ -32,4 +32,10 @@ describe("parseProjectionCreditBalance", () => {
       /credit_balance/,
     );
   });
+
+  test("throws on partially numeric corrupt balance strings", () => {
+    expect(() => parseProjectionCreditBalance(orgWithBalance("12.5oops"), ORG_ID)).toThrow(
+      /credit_balance/,
+    );
+  });
 });

--- a/packages/cloud/shared/src/lib/actions/analytics-enhanced.ts
+++ b/packages/cloud/shared/src/lib/actions/analytics-enhanced.ts
@@ -44,7 +44,9 @@ export function parseProjectionCreditBalance(
   // missing/corrupt value is not a $0 balance: projections and low-balance
   // alerts are user-facing billing signals, so fail closed instead of emitting
   // a success-shaped analytics payload with a fabricated zero.
-  const balance = Number.parseFloat(String(organization.credit_balance ?? ""));
+  const rawBalance = organization.credit_balance;
+  const balanceText = rawBalance == null ? "" : String(rawBalance).trim();
+  const balance = balanceText === "" ? Number.NaN : Number(balanceText);
   if (!Number.isFinite(balance)) {
     throw new Error(`Unable to read projection credit_balance for organization ${organizationId}`);
   }


### PR DESCRIPTION
## Summary
- tighten projection credit-balance parsing to convert the full trimmed value with `Number()` instead of `Number.parseFloat()`
- keep null/undefined/blank/corrupt balances fail-closed instead of allowing success-shaped analytics output
- add a regression test for partially numeric corrupt strings such as `12.5oops`

## Evidence
- `git fetch origin develop && git rebase origin/develop` passed
- `TMPDIR=/private/tmp/codex-test-tmp bun test packages/cloud/shared/src/lib/actions/analytics-enhanced.test.ts` passed: 5 tests, including the new partial-string corruption case
- `TMPDIR=/private/tmp/codex-test-tmp bunx biome check packages/cloud/shared/src/lib/actions/analytics-enhanced.ts packages/cloud/shared/src/lib/actions/analytics-enhanced.test.ts` passed
- `git diff --check` passed

## Blocked / not run
- `bun install` is blocked in this sparse checkout because root `package.json` references workspace paths that are not materialized locally, including `packages/benchmarks/*`, `packages/cloud/api`, `packages/cloud/infra`, and `packages/cloud/sdk`.
- `TMPDIR=/private/tmp/codex-test-tmp bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "analytics-enhanced|error TS" || true` was attempted; it reports existing transitive declaration/module failures outside this change, including missing `@elizaos/auth/*`, missing declaration files for `drizzle-orm`/`drizzle-orm/*`, `drizzle-kit/api`, `exceljs`, and plugin-sql transitive declarations. No touched-file-specific error was identified in the targeted output.

## PR Evidence Matrix
- Real-LLM trajectory: N/A - no agent/action/prompt/model behavior changed.
- Backend logs: N/A - focused parser/unit-test change in cloud shared server action code; no live server path was run.
- Frontend screenshots/video: N/A - no UI surface changed.
- Native/mobile/desktop capture: N/A - no native surface changed.

Fixes part of #12788.