### PR TITLE
fix(#12264): deep fallback-slop sweep slice 0/1 — convert empty-catch/fabricated-default/promise-swallow to fail-fast

### DIFF
--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -117,6 +117,9 @@ async function withCoreBuildLock<T>(build: () => Promise<T>): Promise<T> {
 				throw error;
 			}
 
+			// error-policy:J3 existence probe — null means the lock dir vanished (or
+			// cannot be stat'd) between the EEXIST and here; the staleness check below
+			// treats a missing stat as "no owner mtime", never as a masked failure.
 			const stat = await fs.stat(lockDir).catch(() => null);
 			const ownerPid = await readLockOwnerPid();
 			if (
@@ -138,6 +141,8 @@ async function withCoreBuildLock<T>(build: () => Promise<T>): Promise<T> {
 	try {
 		return await build();
 	} finally {
+		// error-policy:J6 best-effort teardown — release the build lock dir; a failed
+		// cleanup must not mask the build result (or error) propagating from the try.
 		await removeLockDir().catch(() => {});
 	}
 }

--- a/packages/core/src/features/plugin-manager/services/coreManagerService.ts
+++ b/packages/core/src/features/plugin-manager/services/coreManagerService.ts
@@ -650,6 +650,9 @@ export class CoreManagerService extends Service {
 		}
 
 		const version = await this.readCorePackageVersion(packageDir);
+		// error-policy:J3 untrusted-input probe — an npm (non-git) install has no
+		// git metadata; null commit / empty status is the explicit "not a checkout"
+		// signal, matching the null-commit npm branch above (not a masked failure).
 		const commitHash = await this.gitStdout(
 			["rev-parse", "HEAD"],
 			monorepoDir,

--- a/packages/core/src/features/plugin-manager/services/pluginManagerService.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginManagerService.ts
@@ -886,7 +886,11 @@ export class PluginManagerService extends Service implements PluginRegistry {
 			);
 			if (registrySourceDir !== tempDir) {
 				await execAsync(`${pm} run build`, { cwd: registrySourceDir }).catch(
-					() => {},
+					(err) =>
+						this.runtime.reportError("PluginManager", err, {
+							targetDir: registrySourceDir,
+							step: "build",
+						}),
 				);
 				await fs.copy(registrySourceDir, targetDir);
 				return;
@@ -894,7 +898,12 @@ export class PluginManagerService extends Service implements PluginRegistry {
 
 			const tsDir = path.join(tempDir, "typescript");
 			if (await fs.pathExists(tsDir)) {
-				await execAsync(`${pm} run build`, { cwd: tsDir }).catch(() => {});
+				await execAsync(`${pm} run build`, { cwd: tsDir }).catch((err) =>
+					this.runtime.reportError("PluginManager", err, {
+						targetDir: tsDir,
+						step: "build",
+					}),
+				);
 				await fs.copy(tsDir, targetDir);
 			} else {
 				await fs.copy(tempDir, targetDir);

--- a/packages/core/src/plugin-lifecycle.ts
+++ b/packages/core/src/plugin-lifecycle.ts
@@ -570,6 +570,8 @@ async function stopOwnedServices(
 		const key = serviceType as ServiceTypeName;
 		const inFlightStart = privateState.startingServices.get(key);
 		if (inFlightStart) {
+			// error-policy:J6 best-effort teardown — wait for an in-flight start to
+			// settle before stopping it; a failed start is irrelevant to the stop path.
 			await inFlightStart.catch(() => null);
 		}
 

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -436,9 +436,11 @@ async function atomicWriteJson(
 			"[TrajectoryRecorder] atomic write failed",
 		);
 		try {
+			// error-policy:J6 best-effort teardown — removing the orphaned tmp file
+			// after a failed write; its own failure is not actionable.
 			await fs.unlink(tmp).catch(() => undefined);
 		} catch {
-			// ignore — best effort cleanup of the tmp file
+			// error-policy:J6 best-effort teardown of the tmp file
 		}
 	}
 }
@@ -460,9 +462,11 @@ async function atomicWriteText(
 			"[TrajectoryRecorder] markdown write failed",
 		);
 		try {
+			// error-policy:J6 best-effort teardown — removing the orphaned tmp file
+			// after a failed write; its own failure is not actionable.
 			await fs.unlink(tmp).catch(() => undefined);
 		} catch {
-			// ignore - best effort cleanup of the tmp file
+			// error-policy:J6 best-effort teardown of the tmp file
 		}
 	}
 }
@@ -1301,10 +1305,14 @@ class JsonFileTrajectoryRecorder implements TrajectoryRecorder {
 		const trajectoryId = trajectory.trajectoryId;
 		const snapshot = cloneForRecord(trajectory);
 		const previous = this.flushQueues.get(trajectoryId) ?? Promise.resolve();
+		// error-policy:J5 rejection-suppression — a prior flush's failure (already
+		// surfaced inside flushSnapshot) must not chain-block this snapshot's flush.
 		const next = previous
 			.catch(() => undefined)
 			.then(() => this.flushSnapshot(snapshot));
 		this.flushQueues.set(trajectoryId, next);
+		// error-policy:J5 rejection-suppression — the returned `next` is observed by
+		// the caller; this branch only cleans up the queue map without re-surfacing.
 		void next
 			.finally(() => {
 				if (this.flushQueues.get(trajectoryId) === next) {
@@ -1424,8 +1432,9 @@ async function awaitBounded(
 		]);
 	} finally {
 		if (timer !== undefined) clearTimeout(timer);
-		// A raced-out `work` may still reject later; keep that from surfacing as
-		// an unhandled rejection.
+		// error-policy:J5 rejection-suppression — a raced-out `work` may still reject
+		// later; the timeout result is already returned, so keep the late rejection
+		// from surfacing as an unhandled rejection.
 		void work.catch(() => undefined);
 	}
 }

--- a/packages/core/src/services/evaluator.ts
+++ b/packages/core/src/services/evaluator.ts
@@ -451,7 +451,14 @@ export class EvaluatorService extends BaseService {
 				completed,
 				...(error ? { error } : {}),
 			})
-			.catch(() => {});
+			// error-policy:J7 diagnostics-must-not-kill-the-loop — a broken event bus
+			// must not abort evaluation, but a swallowed emit is invisible; surface it.
+			.catch((err) =>
+				this.runtime.reportError("EvaluatorService.emitEvent", err, {
+					event: EventType.EVALUATOR_COMPLETED,
+					evaluatorId,
+				}),
+			);
 	}
 
 	private async readEvaluatorOutput(params: {
@@ -702,7 +709,14 @@ export class EvaluatorService extends BaseService {
 				evaluatorName: "post_turn",
 				startTime: Date.now(),
 			})
-			.catch(() => {});
+			// error-policy:J7 diagnostics-must-not-kill-the-loop — a broken event bus
+			// must not abort evaluation, but a swallowed emit is invisible; surface it.
+			.catch((err) =>
+				this.runtime.reportError("EvaluatorService.emitEvent", err, {
+					event: EventType.EVALUATOR_STARTED,
+					evaluatorId,
+				}),
+			);
 
 		const prompt = buildPrompt({
 			runtime: this.runtime,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -4750,6 +4750,8 @@ function synthesizeSimpleReplyFromPlainText(
 				JSON.parse(replyText);
 				return false;
 			} catch {
+				// error-policy:J3 untrusted-input parse probe — a parse failure IS the
+				// signal (text looks like incomplete structured output, not valid JSON).
 				return true;
 			}
 		})();
@@ -6090,11 +6092,16 @@ export async function runV5MessageRuntimeStage1(args: {
 		);
 
 		// RESPONSE_HANDLER_DURING (non-blocking): fire-and-forget alongside the model
-		// call. We don't await — the user contract is "during". Errors are
-		// logged inside `runActionsByMode`.
+		// call. We don't await — the user contract is "during".
+		// error-policy:J7 diagnostics-must-not-kill-the-loop — a rejection escaping
+		// runActionsByMode must not abort the turn, but it must surface.
 		void args.runtime
 			.runActionsByMode("RESPONSE_HANDLER_DURING", args.message, args.state)
-			.catch(() => {});
+			.catch((err) =>
+				args.runtime.reportError("MessageService.runActionsByMode", err, {
+					mode: "RESPONSE_HANDLER_DURING",
+				}),
+			);
 
 		// Per-turn structure forcing. `buildResponseGrammar` composes the
 		// HANDLE_RESPONSE envelope skeleton (fixed key order + the `contexts`
@@ -6837,11 +6844,17 @@ export async function runV5MessageRuntimeStage1(args: {
 			{ selectedContexts },
 		);
 		// CONTEXT_DURING (non-blocking): runs in parallel with the planner.
+		// error-policy:J7 diagnostics-must-not-kill-the-loop — a rejection escaping
+		// runActionsByMode must not abort the planner, but it must surface.
 		void args.runtime
 			.runActionsByMode("CONTEXT_DURING", args.message, plannerState, {
 				selectedContexts,
 			})
-			.catch(() => {});
+			.catch((err) =>
+				args.runtime.reportError("MessageService.runActionsByMode", err, {
+					mode: "CONTEXT_DURING",
+				}),
+			);
 
 		let plannerResult: PlannerLoopResult;
 		try {
@@ -8390,7 +8403,13 @@ export class DefaultMessageService implements IMessageService {
 				await runtime.runActionsByMode("ALWAYS_BEFORE", message);
 				// ALWAYS_DURING (non-blocking): fire-and-forget alongside the
 				// rest of the pipeline. Telemetry, logging, side effects.
-				void runtime.runActionsByMode("ALWAYS_DURING", message).catch(() => {});
+				// error-policy:J7 diagnostics-must-not-kill-the-loop — a rejection
+				// escaping runActionsByMode must not abort the turn, but it must surface.
+				void runtime.runActionsByMode("ALWAYS_DURING", message).catch((err) =>
+					runtime.reportError("MessageService.runActionsByMode", err, {
+						mode: "ALWAYS_DURING",
+					}),
+				);
 			} catch (error) {
 				runtime.logger.warn(
 					{

--- a/packages/core/src/services/relationships.ts
+++ b/packages/core/src/services/relationships.ts
@@ -2038,6 +2038,8 @@ export class RelationshipsService extends Service {
 			);
 			await this.execSql("COMMIT");
 		} catch (err) {
+			// error-policy:J6 best-effort teardown — roll back the aborted transaction;
+			// a failed ROLLBACK must not mask the original error rethrown below.
 			await this.execSql("ROLLBACK").catch(() => undefined);
 			throw err;
 		}

--- a/packages/core/src/utils/batch-queue/task-drain.test.ts
+++ b/packages/core/src/utils/batch-queue/task-drain.test.ts
@@ -97,4 +97,41 @@ describe("TaskDrain", () => {
 			baseInterval: 30_000,
 		});
 	});
+
+	test("dispose surfaces a failed deleteTask via reportError instead of swallowing it", async () => {
+		const createdId = "00000000-0000-0000-0000-0000000000aa";
+		const deleteError = new Error("db handle closed");
+		const reportError = vi.fn();
+		const runtime = createMockRuntime({
+			agentId: AGENT_ID,
+			reportError,
+			getTasksByName: async () => [],
+			createTask: vi.fn(async () => createdId),
+			deleteTask: vi.fn(async () => {
+				throw deleteError;
+			}),
+		});
+
+		const drain = new TaskDrain(
+			{
+				taskName: "BATCHER_DRAIN",
+				intervalMs: 30_000,
+				taskMetadata: { affinityKey: "autonomy" },
+				skipRegisterWorker: true,
+			},
+			30_000,
+		);
+
+		await drain.start(runtime);
+		expect(drain.id).toBe(createdId);
+
+		// dispose must complete (not reject) even though deleteTask fails, and the
+		// failure must be reported rather than silently swallowed.
+		await expect(drain.dispose(runtime)).resolves.toBeUndefined();
+		expect(runtime.deleteTask).toHaveBeenCalledWith(createdId);
+		expect(reportError).toHaveBeenCalledTimes(1);
+		expect(reportError).toHaveBeenCalledWith("TaskDrain.dispose", deleteError, {
+			taskId: createdId,
+		});
+	});
 });

--- a/packages/core/src/utils/batch-queue/task-drain.ts
+++ b/packages/core/src/utils/batch-queue/task-drain.ts
@@ -200,7 +200,14 @@ export class TaskDrain {
 	async dispose(runtime: IAgentRuntime): Promise<void> {
 		this.disposed = true;
 		if (this.taskId && typeof runtime.deleteTask === "function") {
-			await runtime.deleteTask(this.taskId).catch(() => {});
+			const taskId = this.taskId;
+			// error-policy:J7 diagnostics-must-not-kill-the-loop — dispose must always
+			// complete, but a failed delete leaves an orphaned task row; surface it.
+			await runtime
+				.deleteTask(taskId)
+				.catch((err) =>
+					runtime.reportError("TaskDrain.dispose", err, { taskId }),
+				);
 			this.taskId = null;
 		}
 		// Runtime has no unregisterTaskWorker; a later service may call registerTaskWorker again.


### PR DESCRIPTION
## What & why

Deep fallback-slop sweep of `packages/core` (issue #12264, part of #12182) — slice **0/1** (all suspect files). Converts the unambiguous slop categories to fail-fast and annotates every justified handler with a grep-able `// error-policy:J<N>` tag, using the on-develop foundation (`runtime.reportError(scope, error, context?)` → logs `[scope]`, emits `ERROR_REPORTED`, feeds `RECENT_ERRORS` + owner escalation).

**Doctrine:** a swallowed diagnostic on a path that matters makes a broken pipeline look healthy. These conversions preserve the non-blocking degrade (the turn/loop still proceeds) but make the failure *observable* to the agent.

## Per-category tally

| category | count |
|---|---|
| empty catch (`catch {}`) converted | 0 — none present in slice (re-derived) |
| fabricated-healthy-on-error converted | 0 — the one `catch { return true }` is a J3 parse probe, annotated |
| promise-swallow (`.catch(()=>{}\|null\|undefined)`) converted | **8** |
| justified handlers kept + annotated (`error-policy:J<N>`) | 11 sites (J3×3, J5×3, J6×5) + 6 J7 on converted sites |
| deferred (judgment-heavy, out of this wave) | 351 |

### Promise-swallow → `reportError` (J7, degrade preserved)
- `services/evaluator.ts` — `EVALUATOR_STARTED` / `EVALUATOR_COMPLETED` emit swallows (×2)
- `services/message.ts` — `RESPONSE_HANDLER_DURING` / `CONTEXT_DURING` / `ALWAYS_DURING` `runActionsByMode` swallows (×3)
- `features/plugin-manager/services/pluginManagerService.ts` — two `pm run build` swallows (matches the existing `reportError` pattern at `:1000`)
- `utils/batch-queue/task-drain.ts` — `dispose()` `deleteTask` swallow (orphaned-task-row now surfaced)

### Kept + annotated (justified)
- `runtime/trajectory-recorder.ts` — tmp-file unlink teardown (J6 ×2), flush-queue chaining + late-rejection suppression (J5 ×3)
- `services/relationships.ts` — `ROLLBACK` best-effort teardown, original error rethrown (J6)
- `plugin-lifecycle.ts` — settle-before-stop wait on in-flight start (J6)
- `services/message.ts` — `JSON.parse` incomplete-structured-output probe, parse-failure IS the signal (J3)
- `features/plugin-manager/services/coreManagerService.ts` — git-metadata absence in npm (non-git) install (J3)
- `build.ts` — lock-dir stat existence probe (J3) + lock cleanup teardown (J6)

### Deferred (needs per-site judgment — NOT this wave)
optional-streaming-telemetry `.catch(() => undefined)` (usage/finishReason), `readJson` missing/malformed `{}`/`null`, owner display-name resolvers, `checkSenderRole → null` (fail-safe downgrade — an existing test exercises the reject path against a mock without `reportError`, so reverted to defer), plus the broad `return null/[]/false`-from-catch (92) and `?? <lit>` (249, mostly benign option defaults) buckets.

## Error-policy ratchet (emptyCatch before → after, touched files)

`bun run audit:error-policy-ratchet` → **pass**, `no new fallback-slop in touched files`. emptyCatch stays equal (never up) for every touched file:

```
coreManagerService.ts   4->4    pluginManagerService.ts 1->1
plugin-lifecycle.ts     1->1    trajectory-recorder.ts  2->2
evaluator.ts            0->0    message.ts              3->3
relationships.ts        0->0    task-drain.ts           0->0
```

(The residual `catch {`/comment-only counts are pre-existing J-annotated handlers, unchanged by this PR.)

## Tests

- New real error-path test: `task-drain.test.ts` → "dispose surfaces a failed deleteTask via reportError instead of swallowing it" — induces a real `deleteTask` rejection, asserts `dispose()` still resolves AND `reportError("TaskDrain.dispose", err, { taskId })` fires. With the old `.catch(() => {})` this assertion fails, so it genuinely guards the conversion.
- Touched-package suites green: plugin-manager + documents + services (39 files / 438 tests), evaluator/task-drain/report-error, relationships + trajectory-recorder + plugin-lifecycle (4 files / 70 tests).
- `packages/core` typecheck: no `packages/core/src` errors (pre-existing `adze` declaration-file noise in the untouched `../logger` package only).

## Evidence

N/A - no runtime UI/model-behavior surface; this is error-path plumbing. The behavior change (failure now surfaces via `reportError` instead of silent swallow; legitimate absence still returns its value) is proven by the induced-rejection unit test above rather than a live-LLM trajectory.

Refs #12264

🤖 Generated with [Claude Code](https://claude.com/claude-code)
