### PR TITLE
ci: restore develop/schedule CI coverage — stop concurrency cancellation + skipped-as-pass (#12337 phase 1)

### DIFF
--- a/.github/issue-evidence/12191-ci-baseline.md
+++ b/.github/issue-evidence/12191-ci-baseline.md
@@ -1,0 +1,71 @@
+# CI baseline — #12191 / phase 1 (#12337)
+
+Snapshot of `develop` post-merge CI health **before** the phase-1 concurrency
+restoration, so phases 2/4/5 have a fixed before/after reference. Measured on
+`develop` at the time the phase-1 branch (`fix/12337-ci-concurrency-restore`)
+was cut.
+
+## Method
+
+```bash
+gh run list --repo elizaos/eliza --workflow <wf> --branch develop --event push \
+  --limit <N> --json conclusion,createdAt
+```
+
+## Headline: develop post-merge CI does not complete
+
+Every push to `develop` shared one concurrency group keyed by
+`${{ github.ref }}` (constant `refs/heads/develop`). GitHub keeps at most one
+running + one pending run per group and cancels the older pending run when a
+newer one arrives — regardless of `cancel-in-progress` — so under ~300–400
+pushes/day only the newest push's run survives, and it is itself superseded
+seconds later. Result: coverage runs are cancelled before they finish.
+
+| Workflow (develop, event=push) | Window | Runs sampled | cancelled | success/failure | in‑progress |
+| --- | --- | --- | --- | --- | --- |
+| `test.yml` (Tests) | last 100 | 100 | 99 | **0** | 1 |
+| `test.yml` (Tests) | last 200 | 200 | 199 | **0** | 1 |
+| `quality.yml` (Quality Extended) | last 100 | 100 | 99 | **0** | 1 |
+
+- The 100 sampled `test.yml` runs span **2026-07-04T07:20:25Z →
+  2026-07-04T15:19:30Z** (~8 h) — ≈12.5 push runs/hour on `test.yml` alone
+  (≈300/day).
+- **0 completed** `test.yml` develop-push runs in the last 200 (≈16 h of pure
+  cancellation). Matches the epic-#12191 research finding (last completed
+  develop push run 2026‑06‑18; 398/400 cancelled).
+- Scheduled `test.yml` (cron `17 9 * * *`) shared the same
+  `test-refs/heads/develop` group as push traffic, so the nightly smoke was
+  cancelled by pushes too.
+
+## Skipped-as-pass gap
+
+`test.yml`'s `ci-ok` aggregate treated only `merge_group`,
+`workflow_dispatch`, and `schedule` as strict events — a real lane that came
+back `skipped` on **`push`** counted as pass. Lane `if:` guards
+(`github.event_name != 'pull_request' || …`) already force every deterministic
+lane to *run* on push, so a `skipped` there signals a real misconfiguration,
+not a path-gate.
+
+## Scope of concurrency groups affected
+
+66 workflows trigger on `push: develop` or `schedule`; the deterministic
+coverage/gate lanes among them were ref-keyed and thus mutually cancelling.
+Deploy/publish, singleton janitors, native-artifact builds, and scheduled-only
+heavy benchmark/live lanes are intentionally excluded (they carry deliberate
+serialization or latest-only semantics and are not develop coverage).
+
+## Fix applied (phase 1)
+
+- Coverage/gate lanes re-keyed to
+  `group: <prefix>-${{ github.event.pull_request.number || github.run_id }}`
+  with `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`, so each
+  develop push and each scheduled run gets its own group and completes, while
+  PRs still cancel superseded runs.
+- `ci-ok` `strict_results` now includes `push`, so a skipped real lane on
+  `develop` fails the aggregate instead of passing silently.
+
+## After metrics (to be filled by phase 5, #12342)
+
+Re-run the same `gh run list` census once the change has been on `develop` long
+enough to accumulate completed push runs; record completion rate, cancel rate,
+wall-clock p50/p95, and billable-minute deltas against this baseline.

--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -1,8 +1,8 @@
 name: Benchmark Bridge Tests
 
 concurrency:
-  group: benchmark-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: benchmark-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   push:

--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -37,7 +37,7 @@ env:
 # capacity. only cancels pull_request runs; push runs on protected branches
 # (main/develop) are never cancelled mid-flight.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -51,8 +51,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: chat-shell-gestures-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: chat-shell-gestures-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -37,8 +37,8 @@ on:
       - ".github/actions/cloud-setup-test-env/**"
 
 concurrency:
-  group: cloud-tests-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: cloud-tests-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   DATABASE_URL: postgresql://postgres@127.0.0.1:5432/postgres

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ on:
 # capacity. only cancels pull_request runs; push runs on protected branches
 # (main/develop) are never cancelled mid-flight.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -18,8 +18,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: dev-smoke-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: dev-smoke-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/docker-ci-smoke.yml
+++ b/.github/workflows/docker-ci-smoke.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docker-ci-smoke-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: docker-ci-smoke-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/e1-chip.yml
+++ b/.github/workflows/e1-chip.yml
@@ -12,8 +12,8 @@ on:
       - ".github/workflows/e1-chip.yml"
 
 concurrency:
-  group: e1-chip-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: e1-chip-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Default to least privilege. Override per-job where needed.
 permissions:

--- a/.github/workflows/electrobun-submodule-guard.yml
+++ b/.github/workflows/electrobun-submodule-guard.yml
@@ -29,7 +29,7 @@ on:
 # capacity. only cancels pull_request runs; push runs on protected branches
 # (main/develop) are never cancelled mid-flight.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/feed-env-audit.yml
+++ b/.github/workflows/feed-env-audit.yml
@@ -6,8 +6,8 @@ on:
     branches: [develop]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CI: true

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -14,7 +14,7 @@ on:
 # capacity. only cancels pull_request runs; push runs on protected branches
 # (main/develop) are never cancelled mid-flight.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -32,8 +32,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: quality-${{ github.ref }}
-  cancel-in-progress: true
+  group: quality-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   BUN_VERSION: "canary"

--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -37,8 +37,8 @@ on:
         default: ""
 
 concurrency:
-  group: scenario-matrix-${{ github.ref }}
-  cancel-in-progress: true
+  group: scenario-matrix-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CI: "true"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ on:
     - cron: "17 9 * * *"
 
 concurrency:
-  group: test-${{ github.ref }}
+  group: test-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
@@ -1285,7 +1285,7 @@ jobs:
           echo "provider-live-e2e:${{ needs.provider-live-e2e.result }}"
           echo "github-live-artifact-validate:${{ needs.github-live-artifact-validate.result }}"
           echo "==================================="
-          strict_results="${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}"
+          strict_results="${{ github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}"
           bad=0
           for pair in \
             "changes:${{ needs.changes.result }}" \

--- a/.github/workflows/training-stack.yml
+++ b/.github/workflows/training-stack.yml
@@ -32,8 +32,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: training-stack-${{ github.ref }}
-  cancel-in-progress: true
+  group: training-stack-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ui-e2e-gate.yml
+++ b/.github/workflows/ui-e2e-gate.yml
@@ -37,8 +37,8 @@ on:
       - "packages/agent/src/api/server-helpers-swarm.ts"
 
 concurrency:
-  group: ui-e2e-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ui-e2e-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ui-fixture-e2e.yml
+++ b/.github/workflows/ui-fixture-e2e.yml
@@ -28,8 +28,8 @@ on:
       - "packages/ui/src/**"
 
 concurrency:
-  group: ui-fixture-e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ui-fixture-e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ui-story-gate.yml
+++ b/.github/workflows/ui-story-gate.yml
@@ -21,8 +21,8 @@ on:
       - "plugins/plugin-companion/src/**"
 
 concurrency:
-  group: ui-story-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ui-story-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/vault-ci.yaml
+++ b/.github/workflows/vault-ci.yaml
@@ -8,8 +8,8 @@ name: vault-ci
 # wiring that consumes it.
 
 concurrency:
-  group: vault-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: vault-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   push:

--- a/.github/workflows/verify-patches.yml
+++ b/.github/workflows/verify-patches.yml
@@ -19,7 +19,7 @@ on:
 # capacity. only cancels pull_request runs; push runs on protected branches
 # (main/develop) are never cancelled mid-flight.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -10,8 +10,8 @@ name: Windows CI
 # paths run on their existing dedicated workflows.
 
 concurrency:
-  group: windows-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: windows-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   push:


### PR DESCRIPTION
Closes #12337 (CI review epic #12191, phase 1).

## Problem (measured baseline)

`develop` post-merge CI **does not complete**. Every push to `develop` shared
one concurrency group keyed by `${{ github.ref }}` (constant
`refs/heads/develop`). GitHub keeps at most one running + one pending run per
group and cancels the **older pending** run when a newer one arrives —
regardless of `cancel-in-progress` — so at ~300-400 pushes/day only the newest
push's run survives, and it is itself superseded seconds later.

| Workflow (develop, event=push) | Window | cancelled | success/failure |
| --- | --- | --- | --- |
| `test.yml` (Tests) | last 200 | 199 | **0** |
| `quality.yml` (Quality Extended) | last 100 | 99 | **0** |

The 100 sampled `test.yml` runs span ~8 h (≈300/day). The nightly `test.yml`
smoke (cron `17 9 * * *`) shared the same `test-refs/heads/develop` group and
was cancelled by push traffic too. Full baseline:
[`.github/issue-evidence/12191-ci-baseline.md`](.github/issue-evidence/12191-ci-baseline.md).

## Fix

**1. Re-key deterministic coverage/gate lanes** so each develop push and each
scheduled run gets its own group and runs to completion, while PRs still cancel
superseded runs:

```yaml
concurrency:
  group: <prefix>-${{ github.event.pull_request.number || github.run_id }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Applied to 21 workflows: `test.yml`, `quality.yml`, `scenario-matrix.yml`,
`docker-ci-smoke.yml`, `feed-env-audit.yml`, `dev-smoke.yml`, `windows-ci.yml`,
`cloud-tests.yml`, `vault-ci.yaml`, `ui-e2e-gate.yml`, `ui-fixture-e2e.yml`,
`ui-story-gate.yml`, `chat-shell-gestures.yml`, `benchmark-tests.yml`,
`e1-chip.yml`, `training-stack.yml`, plus `gitleaks.yml`, `codeql.yml`,
`build-agent-image.yml`, `verify-patches.yml`, `electrobun-submodule-guard.yml`
(these already had the conditional `cancel-in-progress`; only the ref-keyed
group needed run_id keying).

**2. Close the skipped-as-pass trap.** `test.yml`'s `ci-ok` aggregate treated
only `merge_group` / `workflow_dispatch` / `schedule` as strict, so a real lane
returning `skipped` on **push** counted as pass. Every deterministic lane's
`if:` guard (`github.event_name != 'pull_request' || …`) already forces it to
run on push, so a `skipped` there is a real misconfiguration — `push` is now in
`strict_results` and fails the aggregate. The one legitimately-skipped-on-push
lane (`github-live-artifact-validate`, observed only on dispatch/schedule) is
already special-cased before the strict check, and the live lanes
(`cloud-live-e2e`, `provider-live-e2e`) run and self-signal skips via outputs
(job result = success), so no false red.

## Out of scope (intentionally excluded)

Deploy/publish workflows (deliberate per-env serialization), singleton
janitors, native-artifact builds, and scheduled-only heavy benchmark/live lanes
— these carry deliberate serialization or latest-only semantics and are not
`develop` coverage.

## Verification

- `node packages/scripts/ci-workflow-dedup-contract.mjs` → passed
- `node packages/scripts/ci-path-gate.self-test.mjs` → passed
- `actionlint` on all 21 changed workflows → no errors (only pre-existing
  `hetzner-robot` custom-label notices)
- Post-merge: `gh run list --workflow test.yml --branch develop --event push`
  should show **completed** runs (phase 5 / #12342 records the after-metrics).

## Evidence
Baseline metrics committed at `.github/issue-evidence/12191-ci-baseline.md`.
N/A for UI screenshots, model trajectories, audio, or product domain artifacts
(CI-config-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)