### PR TITLE
fix(#12268): deep fallback-slop sweep slice 0/2 — cloud promise-swallow → fail-fast

### DIFF
--- a/packages/cloud/api/auth/steward-session/route.ts
+++ b/packages/cloud/api/auth/steward-session/route.ts
@@ -214,7 +214,12 @@ app.post("/", async (c) => {
           request_id: c.get("requestId"),
           metadata: { provider: "steward", reason: "invalid_token" },
         })
-        .catch(() => undefined);
+        // error-policy:J7 audit write must not block the 401; a dropped auth audit is logged.
+        .catch((err) =>
+          logger.error("[StewardSession] audit emit for failed login failed", {
+            error: err instanceof Error ? err.message : String(err),
+          }),
+        );
       return c.json(errorBody("Invalid token", "invalid_token"), 401);
     }
 
@@ -289,7 +294,16 @@ app.post("/", async (c) => {
         request_id: c.get("requestId"),
         metadata: { provider: "steward", method: "session_exchange" },
       })
-      .catch(() => undefined);
+      // error-policy:J7 audit write must not block the login response; a dropped auth audit is logged.
+      .catch((err) =>
+        logger.error(
+          "[StewardSession] audit emit for successful login failed",
+          {
+            userId: cloudUser.id,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        ),
+      );
     const response: StewardSessionResponse = {
       ok: true,
       userId: cloudUser.id,

--- a/packages/cloud/api/stripe/webhook/route.ts
+++ b/packages/cloud/api/stripe/webhook/route.ts
@@ -134,7 +134,16 @@ async function handleStripeWebhook(c: AppContext): Promise<Response> {
         request_id: c.get("requestId"),
         metadata: { provider: "stripe", reason },
       })
-      .catch(() => undefined);
+      // error-policy:J7 audit write must not block the 400; a dropped security audit is logged.
+      .catch((err) =>
+        logger.error(
+          "[Stripe Webhook] audit emit for denied signature failed",
+          {
+            reason,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        ),
+      );
     return c.json({ error: "Webhook signature verification failed" }, 400);
   }
 

--- a/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/route.ts
+++ b/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/route.ts
@@ -98,7 +98,13 @@ async function handlePOST(c: AppContext): Promise<Response> {
         request_id: c.get("requestId"),
         metadata: { provider: "stripe-connect", reason },
       })
-      .catch(() => undefined);
+      // error-policy:J7 audit write must not block the 400; a dropped security audit is logged.
+      .catch((err) =>
+        logger.error("[StripeConnect] audit emit for denied signature failed", {
+          reason,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
     return c.json(
       { success: false, error: "Webhook signature verification failed" },
       400,

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.ts
@@ -360,7 +360,19 @@ async function __hono_POST(
       if (typeof executionCtx?.waitUntil === "function") {
         executionCtx.waitUntil(triggerPromise);
       } else {
-        triggerPromise.catch(() => undefined);
+        // No Worker execution context to hand the promise to (non-Worker runtime):
+        // the provisioning job is already persisted, so a failed immediate nudge only
+        // defers execution to the next poll. Log it rather than swallow so a stuck
+        // orchestrator surfaces.
+        // error-policy:J7 nudge failure only delays an already-enqueued job; logged, not fatal.
+        triggerPromise.catch((err) =>
+          logger.warn(
+            "[provision] provisioning triggerImmediate nudge failed",
+            {
+              error: err instanceof Error ? err.message : String(err),
+            },
+          ),
+        );
       }
     }
 

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -555,6 +555,7 @@ export class GatewayManager {
     // Release Eliza App bot leadership for faster failover
     if (this.isElizaAppLeader && this.redis) {
       logger.info("Releasing Eliza App bot leadership");
+      // error-policy:J6 best-effort teardown; the leader key carries a TTL so a failed release still expires.
       await this.redis.del(ELIZA_APP_LEADER_KEY).catch(() => {});
       if (this.elizaAppClient) {
         this.elizaAppClient.destroy();

--- a/packages/cloud/shared/src/lib/cache/socket-redis.ts
+++ b/packages/cloud/shared/src/lib/cache/socket-redis.ts
@@ -295,6 +295,7 @@ class Connection {
       ]);
       if (queueTimer) clearTimeout(queueTimer);
       if (queueWait === "orphaned") {
+        // error-policy:J6 best-effort teardown of a poisoned socket; the reconnect below is the real path.
         await this.close().catch(() => {});
       }
       let opGeneration = -1;
@@ -312,6 +313,7 @@ class Connection {
         // generation: if a queued caller already reconnected, this failure
         // belongs to the previous socket and must not tear down the current one.
         if (opGeneration === -1 || opGeneration === this.generation) {
+          // error-policy:J6 best-effort teardown of a poisoned socket; the original error is rethrown below.
           await this.close().catch(() => {});
         }
         throw error;
@@ -332,6 +334,7 @@ class Connection {
     const op = fn();
     // The losing side of the race keeps running; swallow its late rejection so
     // a post-timeout socket error doesn't surface as an unhandled rejection.
+    // error-policy:J5 the winning side's error is observed by the caller via `op`/`timeout`.
     op.catch(() => {});
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {

--- a/packages/cloud/shared/src/lib/services/active-billing.ts
+++ b/packages/cloud/shared/src/lib/services/active-billing.ts
@@ -514,7 +514,18 @@ async function cancelAgentInfrastructure(
         userId,
       });
     }
-    void provisioningJobService.triggerImmediate(triggerEnv).catch(() => {});
+    // The teardown job is already durably enqueued above; triggerImmediate is a
+    // best-effort nudge to run it now rather than on the next poll. A failed nudge
+    // only delays teardown, so it must not fail this call — but it is logged so a
+    // stuck orchestrator is observable.
+    // error-policy:J7 nudge failure only delays an already-enqueued job; logged, not fatal.
+    void provisioningJobService.triggerImmediate(triggerEnv).catch((err) =>
+      logger.warn("[ActiveBilling] provisioning triggerImmediate nudge failed", {
+        agentId,
+        organizationId,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
 
     return {
       attempted: true,

--- a/packages/cloud/shared/src/lib/services/agent-managed-github.ts
+++ b/packages/cloud/shared/src/lib/services/agent-managed-github.ts
@@ -108,7 +108,17 @@ export class ManagedAgentGithubService {
         organizationId: params.organizationId,
         userId: sandbox.user_id,
       });
-      void provisioningJobService.triggerImmediate().catch(() => {});
+      // The restart job is already enqueued above; triggerImmediate only nudges the
+      // daemon to pick it up now. A failed nudge delays the restart to the next poll,
+      // so it is logged rather than swallowed or thrown.
+      // error-policy:J7 nudge failure only delays an already-enqueued restart; logged, not fatal.
+      void provisioningJobService.triggerImmediate().catch((err) =>
+        logger.warn("[managed-github] provisioning triggerImmediate nudge failed", {
+          agentId: sandbox.id,
+          organizationId: params.organizationId,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
       restarted = true;
     }
 
@@ -172,7 +182,17 @@ export class ManagedAgentGithubService {
         organizationId: params.organizationId,
         userId: sandbox.user_id,
       });
-      void provisioningJobService.triggerImmediate().catch(() => {});
+      // The restart job is already enqueued above; triggerImmediate only nudges the
+      // daemon to pick it up now. A failed nudge delays the restart to the next poll,
+      // so it is logged rather than swallowed or thrown.
+      // error-policy:J7 nudge failure only delays an already-enqueued restart; logged, not fatal.
+      void provisioningJobService.triggerImmediate().catch((err) =>
+        logger.warn("[managed-github] provisioning triggerImmediate nudge failed", {
+          agentId: sandbox.id,
+          organizationId: params.organizationId,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
       restarted = true;
     }
 

--- a/packages/cloud/shared/src/lib/services/inference-billing-invalidation-logged.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-invalidation-logged.test.ts
@@ -1,0 +1,101 @@
+/**
+ * #12268 regression: a post-commit cache-invalidation failure on the settle path
+ * must degrade (the debit already committed to Postgres, the source of truth) but
+ * must NOT be swallowed silently — it is logged at warn so a stale balance view is
+ * observable. The DB transaction and the three cache clients are mocked at their
+ * boundary; the settle + logging code under test (`createLedgerDebitSettler` →
+ * `settleLedgerCharge` post-commit block) runs for real. Before the fix these were
+ * `.catch(() => {})` and a failed invalidation produced zero output.
+ */
+
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+afterAll(() => {
+  mock.restore();
+});
+
+const warn = mock((_msg: string, _ctx?: unknown) => {});
+mock.module("../utils/logger", () => ({
+  logger: { info: () => {}, warn, error: () => {}, debug: () => {} },
+}));
+
+// The transaction "commits" a debited outcome without touching a real DB, so the
+// post-commit side-effect block (the code under test) runs.
+mock.module("../../db/helpers", () => ({
+  dbWrite: {},
+  writeTransaction: async () => ({
+    claimed: true,
+    debited: true,
+    uncollected: false,
+    newBalance: 5,
+  }),
+}));
+
+// The induced failure: every cache invalidation rejects.
+const invalidationErr = new Error("redis unavailable");
+mock.module("../cache/invalidation", () => ({
+  CacheInvalidation: {
+    onCreditMutation: async () => {
+      throw invalidationErr;
+    },
+  },
+}));
+mock.module("../cache/organizations-cache", () => ({
+  invalidateOrganizationCache: async () => {
+    throw invalidationErr;
+  },
+}));
+mock.module("./inference-auth-cache", () => ({
+  invalidateOrgBalanceHint: async () => {
+    throw invalidationErr;
+  },
+}));
+mock.module("./credits", () => ({
+  creditsService: { notifyBalanceDecrease: () => {} },
+}));
+
+const { createLedgerDebitSettler } = await import("./inference-billing-ledger");
+
+const CTX = {
+  requestId: "req-inv-1",
+  organizationId: "org-inv-1",
+  userId: "user-inv-1",
+  apiKeyId: null,
+  model: "gpt-oss-120b",
+  provider: "cerebras",
+  billingSource: "platform",
+};
+
+describe("settle post-commit cache invalidation failure is logged, not swallowed", () => {
+  test("a debited settle whose invalidations all reject still resolves AND warns per target", async () => {
+    warn.mockClear();
+    const settle = createLedgerDebitSettler(CTX);
+
+    // The invalidation failures must not fail the (already-committed) settle.
+    await expect(settle(0.01)).resolves.toBeNull();
+
+    // Flush the two fire-and-forget `.catch` microtasks.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const staleWarnings = warn.mock.calls.filter(
+      ([msg]) => typeof msg === "string" && msg.includes("cache invalidation failed"),
+    );
+    // All three invalidation failures surfaced (credit-mutation, organization-cache,
+    // balance-hint) instead of vanishing into `.catch(() => {})`.
+    expect(staleWarnings.length).toBe(3);
+
+    const targets = staleWarnings
+      .map(([, ctx]) => (ctx as { target?: string })?.target)
+      .filter(Boolean);
+    expect(new Set(targets)).toEqual(
+      new Set(["credit-mutation", "organization-cache", "balance-hint"]),
+    );
+
+    // The failure carries the org id and the underlying error message for diagnosis.
+    for (const [, ctx] of staleWarnings) {
+      const c = ctx as { organizationId?: string; error?: string };
+      expect(c.organizationId).toBe("org-inv-1");
+      expect(c.error).toBe("redis unavailable");
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
@@ -200,6 +200,23 @@ interface DebitRow {
  * `pending` row) and no concurrent admission ever sees a claimed-but-undebited
  * state. A refused debit (would overdraw) marks the row `uncollected`. Never throws.
  */
+// Post-commit cache-freshness side-effects tolerate failure (the debit already
+// committed to Postgres, the source of truth) but must not fail silently: a
+// dropped invalidation leaves a stale balance view, so surface it at warn with
+// the org + target so the staleness is observable instead of invisible.
+// error-policy:J7 side-effect must not fail the settled charge; failure is logged.
+function reportInvalidationFailure(organizationId: string, target: string): (err: unknown) => void {
+  return (err: unknown) =>
+    logger.warn(
+      "[InferenceLedger] post-commit cache invalidation failed; balance view may be stale",
+      {
+        organizationId,
+        target,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+}
+
 async function settleLedgerCharge(
   ctx: LedgerChargeContext,
   amountUsd: number,
@@ -286,9 +303,15 @@ async function settleLedgerCharge(
   // Post-commit side-effects (cache freshness; alerting). Outside the transaction.
   if (!outcome.claimed) return outcome;
   if (outcome.debited) {
-    await CacheInvalidation.onCreditMutation(ctx.organizationId).catch(() => {});
-    invalidateOrganizationCache(ctx.organizationId).catch(() => {});
-    invalidateOrgBalanceHint(ctx.organizationId).catch(() => {});
+    await CacheInvalidation.onCreditMutation(ctx.organizationId).catch(
+      reportInvalidationFailure(ctx.organizationId, "credit-mutation"),
+    );
+    invalidateOrganizationCache(ctx.organizationId).catch(
+      reportInvalidationFailure(ctx.organizationId, "organization-cache"),
+    );
+    invalidateOrgBalanceHint(ctx.organizationId).catch(
+      reportInvalidationFailure(ctx.organizationId, "balance-hint"),
+    );
     // Parity with deductCredits: fire low-credits email + auto-top-up + the waifu
     // hosted-agent pause webhook so an org draining via optimistic inference still
     // gets low-balance warnings (the ledger debits with its own SQL, not deductCredits).
@@ -311,7 +334,9 @@ async function settleLedgerCharge(
       amountUsd,
       source,
     });
-    invalidateOrgBalanceHint(ctx.organizationId).catch(() => {});
+    invalidateOrgBalanceHint(ctx.organizationId).catch(
+      reportInvalidationFailure(ctx.organizationId, "balance-hint"),
+    );
   }
   return outcome;
 }


### PR DESCRIPTION
## Deep fallback-slop sweep — `packages/cloud/*` slice 0/2 (#12268)

Part of the #12182 error-policy sweep. This slice converts the **unambiguous
invisible-failure** slop categories to observable, logged degrades and annotates
genuine J-category keeps. It deliberately defers the judgment-heavy
`?? <lit>` / `return null|[]|false` sites to a later per-site pass.

Uses the #12263 foundation on `develop` (`ElizaError`, `error-policy:J<N>`
annotations, diff-scoped `audit:error-policy-ratchet`).

### Slice computation

Suspect list = `rg -l` union of empty-catch + `.catch(()=>{}|null|undefined)` +
return-default catch over `packages/cloud/**` (non-test `.ts/.tsx`), sorted `-u`
→ 157 files. This PR handles **slice 0** = sorted index `% 2 == 0` (79 files);
slice 1 handles the odd indices (disjoint).

### Conversions (promise-swallow → observable degrade, J7)

| file | sites | before → after |
|---|---|---|
| `shared/.../inference-billing-ledger.ts` | 4 | post-commit cache invalidation `.catch(() => {})` → `.catch(reportInvalidationFailure(org, target))` (warn per target; debit already committed, degrade preserved) |
| `shared/.../active-billing.ts` | 1 | `triggerImmediate().catch(() => {})` → log warn (job already durably enqueued) |
| `shared/.../agent-managed-github.ts` | 2 | `triggerImmediate().catch(() => {})` → log warn |
| `api/v1/eliza/agents/[agentId]/provision/route.ts` | 1 | `triggerPromise.catch(() => undefined)` → log warn |
| `api/stripe/webhook/route.ts` | 1 | denied-signature audit `emit().catch(() => undefined)` → log error |
| `api/v1/earnings/.../stripe-connect/webhook/route.ts` | 1 | denied-signature audit `emit().catch(() => undefined)` → log error |
| `api/auth/steward-session/route.ts` | 2 | auth-login audit `emit().catch(() => undefined)` → log error |

**Total: 12 conversions.** Each previously produced **zero** output on failure;
now the failure surfaces via the structured logger while the main flow (an
already-committed debit / an already-enqueued job / a 4xx response) is preserved
— the J7 "diagnostics-must-not-kill-the-loop" pattern.

### Annotated keeps (J-category, behavior unchanged)

| file | sites | verdict |
|---|---|---|
| `shared/.../cache/socket-redis.ts` | 3 | J6 poisoned-socket teardown (×2) + J5 timeout-race loser rejection-suppression (winner observed by caller) |
| `services/gateway-discord/.../gateway-manager.ts` | 1 | J6 leader-key release on teardown (TTL-backed) |

### Triaged — kept without per-site annotation (documented boundaries)

- **Empty catches** in this slice (`agent-github-return.ts:172/178/186`,
  `app-frontend-hosting.ts:563`) are all inside **browser `<script>` template
  strings** (client best-effort `try { postMessage/close } catch {}`), not
  server code — the AST ratchet does not count them. Left as-is.
- **Request-body-parse `.catch(() => null)`** across ~25 `packages/cloud/api/**/route.ts`
  handlers are **J3 boundaries**: every one was verified to route `null →
  schema.safeParse fail (or explicit null check) → 4xx structured body`, never a
  fabricated success. Documented here as a route-boundary category rather than
  annotating each handler individually (per #12268 guidance for the 843 route
  handlers).

### Still deferred (counted as ambiguous, NOT touched this pass)

`?? <literal>` / `|| <literal>` load-path defaults and `return null|[]|false`
catches where masking-a-failure vs legitimate-absence needs per-site judgment
(e.g. `x402-facilitator` secret-lookup fallback chains, `ai-pricing/lookup`
documented catalog-miss degrade, `payout-processor` Solana-ATA existence,
`api-route-discovery` file-not-found). These are the judgment-heavy sites the
issue explicitly holds for a later pass. socket-redis also carries 5 pre-existing
multi-line `catch {}` blocks outside the promise-swallow focus (ratchet-neutral,
left for a dedicated pass).

### Tests

New real-path regression test
`shared/.../inference-billing-invalidation-logged.test.ts`: drives the **real**
`createLedgerDebitSettler → settleLedgerCharge` post-commit block with the DB
transaction and the three cache clients mocked **at their boundary** (the cache
rejection is the induced failure; the code under test runs real). Asserts the
settle still resolves (degrade preserved) AND all three invalidation failures
surface at warn with org id + target + error (before the fix: 0 warns).

```
bun test --isolate \
  shared/.../inference-billing-invalidation-logged.test.ts \
  shared/.../inference-billing-fast-path.test.ts \
  shared/.../inference-billing-cache-failure.test.ts \
  shared/.../cache/socket-redis-resilience.test.ts
→ 34 pass, 0 fail
```

(The PGlite-backed `__tests__/inference-billing-ledger.test.ts` cannot init
PGlite in this sparse/skip-artifact environment — a pre-existing limitation
unrelated to this diff; my touched files are not in that harness's failing path.)

### Ratchet (diff-scoped, emptyCatch before → after in touched files)

```
gateway-manager.ts:        emptyCatch 0->0
socket-redis.ts:           emptyCatch 5->5   (pre-existing, untouched)
active-billing.ts:         emptyCatch 0->0
agent-managed-github.ts:   emptyCatch 0->0
inference-billing-ledger.ts: emptyCatch 0->0
→ no new fallback-slop in touched files
```

Server-side `console.*` introduced: **0**. Biome check + touched-file typecheck
clean (the only typecheck output is the pre-existing `drizzle-orm`
declaration-resolution noise documented in `packages/cloud/shared/CLAUDE.md`, at
import lines this PR never touched).

Refs #12268

🤖 Generated with [Claude Code](https://claude.com/claude-code)
