### PR TITLE
fix(#12275): deep fallback-slop sweep slice 0/2 — convert empty-catch/fabricated-default/promise-swallow to fail-fast

### DIFF
--- a/plugins/plugin-app-control/src/actions/agent-switch.ts
+++ b/plugins/plugin-app-control/src/actions/agent-switch.ts
@@ -56,6 +56,8 @@ async function defaultSwitchAgent(
 			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
 		},
 	);
+	// error-policy:J3 non-JSON/empty response body -> null; the caller reads
+	// response.ok / fields defensively, so an unparseable body is a handled shape.
 	const body = (await response.json().catch(() => null)) as Record<
 		string,
 		unknown

--- a/plugins/plugin-app-control/src/actions/model-switch.ts
+++ b/plugins/plugin-app-control/src/actions/model-switch.ts
@@ -67,6 +67,8 @@ async function defaultSwitchModel(request: {
 			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
 		},
 	);
+	// error-policy:J3 non-JSON/empty response body -> null; the caller reads
+	// response.ok / fields defensively, so an unparseable body is a handled shape.
 	const body = (await response.json().catch(() => null)) as Record<
 		string,
 		unknown

--- a/plugins/plugin-app-control/src/evaluators/view-followup-routing.ts
+++ b/plugins/plugin-app-control/src/evaluators/view-followup-routing.ts
@@ -147,6 +147,8 @@ async function resolveActiveViewForFamily(
 		}
 		return activeView;
 	} catch {
+		// error-policy:J4 loopback confirm failed -> can't route; the agent's normal
+		// reply stands (designed degrade, per the block comment above).
 		return null;
 	}
 }

--- a/plugins/plugin-app-control/src/services/app-worker-host-service.ts
+++ b/plugins/plugin-app-control/src/services/app-worker-host-service.ts
@@ -232,6 +232,8 @@ export class AppWorkerHostService extends Service {
 	override async stop(): Promise<void> {
 		const slugs = Array.from(this.workers.keys());
 		await Promise.all(
+			// error-policy:J6 best-effort teardown — one worker refusing to stop must
+			// not block stopping the rest during service shutdown.
 			slugs.map((slug) => this.stopWorker(slug).catch(() => {})),
 		);
 	}
@@ -405,6 +407,8 @@ export class AppWorkerHostService extends Service {
 			await spawned.readyPromise;
 		} catch (error) {
 			this.workers.delete(options.slug);
+			// error-policy:J6 best-effort teardown of the failed worker; the real
+			// spawn failure (`error`) is rethrown below and surfaces to the caller.
 			await worker.terminate().catch(() => undefined);
 			throw error;
 		}
@@ -524,6 +528,8 @@ export class AppWorkerHostService extends Service {
 				this.runtime as RuntimeWithServiceLoadPromise | undefined
 			)
 				?.getServiceLoadPromise?.(APP_REGISTRY_SERVICE_TYPE)
+				// error-policy:J4 best-effort auto-start of persisted worker apps — a
+				// not-yet-ready registry degrades to null (skipped below), never crashes boot.
 				.catch(() => null)) as AppRegistryService | null | undefined;
 		}
 		if (!registry?.list) return;

--- a/plugins/plugin-calendar/src/internal/constants.ts
+++ b/plugins/plugin-calendar/src/internal/constants.ts
@@ -50,6 +50,7 @@ export function isValidTimeZone(timeZone: string): boolean {
     new Intl.DateTimeFormat("en-US", { timeZone }).format(new Date());
     return true;
   } catch {
+    // error-policy:J3 Intl throws RangeError on an unknown IANA zone -> "invalid".
     return false;
   }
 }

--- a/plugins/plugin-calendar/src/internal/recurrence.ts
+++ b/plugins/plugin-calendar/src/internal/recurrence.ts
@@ -306,6 +306,7 @@ export function firstRecurrenceRule(
     try {
       return parseRecurrenceRule(line);
     } catch {
+      // error-policy:J3 unparseable RRULE line -> "no usable rule" (null).
       return null;
     }
   }
@@ -507,6 +508,7 @@ export function describeRecurrence(
   try {
     rule = parseRecurrenceRule(firstLine);
   } catch {
+    // error-policy:J3 unparseable RRULE line -> "no usable rule" (null).
     return null;
   }
   if (rule.beyondExpansionSubset) {

--- a/plugins/plugin-commands/src/actions/handlers.ts
+++ b/plugins/plugin-commands/src/actions/handlers.ts
@@ -211,6 +211,8 @@ async function runModelSwitchViaRoute(
 			`Couldn't switch the model: ${err instanceof Error ? err.message : String(err)}.`,
 		);
 	}
+	// error-policy:J3 non-JSON/empty response body -> null; the caller reads
+	// response.ok / fields defensively, so an unparseable body is a handled shape.
 	const body = (await response.json().catch(() => null)) as Record<
 		string,
 		unknown

--- a/plugins/plugin-meetings/src/platforms/googlemeet/recording.test.ts
+++ b/plugins/plugin-meetings/src/platforms/googlemeet/recording.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Participant-count polling error policy for the Google Meet recording loop.
+ * Deterministic: the Playwright Page is a hand-rolled fake — no real browser.
+ * Guards the fix that a failed `page.evaluate` must read as "unknown" (null),
+ * never a fabricated `0` that would trip a premature auto-leave (#12275).
+ */
+
+import type { Page } from "playwright-core";
+import { describe, expect, it } from "vitest";
+import { countParticipants } from "./recording.js";
+
+function fakePage(evaluate: Page["evaluate"]): Page {
+  return { evaluate } as unknown as Page;
+}
+
+describe("countParticipants", () => {
+  it("returns the tile count when the DOM query succeeds", async () => {
+    const page = fakePage((async () => 3) as Page["evaluate"]);
+    expect(await countParticipants(page)).toBe(3);
+  });
+
+  it("returns 0 for a real empty-room reading (distinct from failure)", async () => {
+    const page = fakePage((async () => 0) as Page["evaluate"]);
+    expect(await countParticipants(page)).toBe(0);
+  });
+
+  it("returns null (unknown) when the page evaluate throws, not a fabricated 0", async () => {
+    const page = fakePage((async () => {
+      throw new Error("Execution context was destroyed");
+    }) as Page["evaluate"]);
+    expect(await countParticipants(page)).toBeNull();
+  });
+});

--- a/plugins/plugin-meetings/src/platforms/googlemeet/recording.ts
+++ b/plugins/plugin-meetings/src/platforms/googlemeet/recording.ts
@@ -22,8 +22,14 @@ import { GoogleSpeakerIdentity } from "./speaker-identity.js";
 const TICK_MS = 1_000;
 const AUDIO_GRACE_MS = 120_000;
 
-/** Count non-bot participant tiles present in the meeting DOM. */
-async function countParticipants(page: Page): Promise<number> {
+/**
+ * Count non-bot participant tiles present in the meeting DOM. Returns `null`
+ * when the DOM query could not run (page mid-navigation / layout swap / detached
+ * execution context) — the caller must treat that as "unknown", never as zero:
+ * a fabricated `0` would accrue alone-time and trip a premature auto-leave. Only
+ * a successful evaluate returning `0` is a real "no other participants" reading.
+ */
+export async function countParticipants(page: Page): Promise<number | null> {
   try {
     return await page.evaluate(
       (selectors: string[]) => {
@@ -41,8 +47,14 @@ async function countParticipants(page: Page): Promise<number> {
       },
       [...googleParticipantSelectors],
     );
-  } catch {
-    return 0;
+  } catch (err) {
+    // error-policy:J4 transient DOM-eval failure is "unknown", not "zero" — the
+    // recording loop skips the tick so alone-detection never fires on a failed poll.
+    logger.warn(
+      { err },
+      "[GoogleMeetRecording] participant count query failed; treating as unknown",
+    );
+    return null;
   }
 }
 
@@ -89,6 +101,8 @@ export async function startGoogleRecording(
         return;
       }
       const others = await countParticipants(page);
+      // Unknown reading (poll failed): don't accrue alone-time this tick.
+      if (others === null) return;
       if (others > 0) speakersSeen = true;
 
       if (others > 0) {

--- a/plugins/plugin-xr/simulator/src/mock-agent.ts
+++ b/plugins/plugin-xr/simulator/src/mock-agent.ts
@@ -24,6 +24,12 @@ export interface ReceivedControl {
   receivedAt: number;
 }
 
+export interface DecodeError {
+  kind: "text" | "binary";
+  error: Error;
+  receivedAt: number;
+}
+
 export interface MockAgentServerOptions {
   port?: number;
   /** Automatically send a transcript response after receiving N audio frames */
@@ -37,6 +43,13 @@ export class MockAgentServer {
 
   readonly receivedFrames: ReceivedFrame[] = [];
   readonly receivedControls: ReceivedControl[] = [];
+  /**
+   * Frames the client sent that failed to decode. Recorded rather than
+   * swallowed so a protocol regression in the real client encoder surfaces as a
+   * test-visible fact instead of vanishing — a mock that silently eats malformed
+   * frames hides exactly the bugs its tests exist to catch.
+   */
+  readonly decodeErrors: DecodeError[] = [];
   private waiters = new Map<string, Array<() => void>>();
 
   constructor(private readonly options: MockAgentServerOptions = {}) {}
@@ -114,6 +127,7 @@ export class MockAgentServer {
   reset(): void {
     this.receivedFrames.length = 0;
     this.receivedControls.length = 0;
+    this.decodeErrors.length = 0;
   }
 
   // ── Private ────────────────────────────────────────────────────────────
@@ -147,7 +161,13 @@ export class MockAgentServer {
       if (msg.type === "ping") {
         ws.send(JSON.stringify({ type: "pong" }));
       }
-    } catch {}
+    } catch (err) {
+      this.decodeErrors.push({
+        kind: "text",
+        error: err instanceof Error ? err : new Error(String(err)),
+        receivedAt: Date.now(),
+      });
+    }
   }
 
   private handleBinary(data: Buffer): void {
@@ -170,7 +190,13 @@ export class MockAgentServer {
           this.sendAgentText(`Agent response to: ${text}`);
         }, 50);
       }
-    } catch {}
+    } catch (err) {
+      this.decodeErrors.push({
+        kind: "binary",
+        error: err instanceof Error ? err : new Error(String(err)),
+        receivedAt: Date.now(),
+      });
+    }
   }
 
   private sendText(msg: object): void {

--- a/plugins/plugin-xr/src/__tests__/mock-agent-decode.test.ts
+++ b/plugins/plugin-xr/src/__tests__/mock-agent-decode.test.ts
@@ -1,0 +1,81 @@
+/**
+ * MockAgentServer decode-error observability. Boots the real ws mock on an
+ * ephemeral port, connects a real client, and asserts that a malformed inbound
+ * frame is RECORDED (not silently swallowed) while well-formed traffic is
+ * unaffected — the fix that replaced two empty catches with observable
+ * decode-error capture (#12275).
+ */
+
+import { WebSocket } from "ws";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MockAgentServer } from "../../simulator/src/mock-agent.ts";
+import { encodeBinaryFrame } from "../protocol.ts";
+
+let server: MockAgentServer;
+const PORT = 31801;
+
+function connect(): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${PORT}`);
+  return new Promise((resolve, reject) => {
+    ws.on("open", () => resolve(ws));
+    ws.on("error", reject);
+  });
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 50));
+}
+
+beforeEach(async () => {
+  server = new MockAgentServer({ port: PORT });
+  await server.start();
+});
+
+afterEach(async () => {
+  await server.stop();
+});
+
+describe("MockAgentServer decode-error recording", () => {
+  it("records a malformed text control frame instead of swallowing it", async () => {
+    const ws = await connect();
+    ws.send("this is not json {{{");
+    await flush();
+    ws.close();
+
+    expect(server.decodeErrors).toHaveLength(1);
+    expect(server.decodeErrors[0]?.kind).toBe("text");
+    expect(server.decodeErrors[0]?.error).toBeInstanceOf(Error);
+  });
+
+  it("records a malformed binary frame (bad header length prefix)", async () => {
+    const ws = await connect();
+    // A binary buffer whose declared header length overruns the payload.
+    const bogus = Buffer.from([0x00, 0x00, 0x00, 0xff, 0x7b]);
+    ws.send(bogus, { binary: true });
+    await flush();
+    ws.close();
+
+    expect(server.decodeErrors).toHaveLength(1);
+    expect(server.decodeErrors[0]?.kind).toBe("binary");
+  });
+
+  it("leaves decodeErrors empty for well-formed traffic", async () => {
+    const ws = await connect();
+    ws.send(JSON.stringify({ type: "hello" }));
+    const header = {
+      type: "audio" as const,
+      ts: Date.now(),
+      sampleRate: 16000,
+      encoding: "pcm-f32" as const,
+    };
+    ws.send(encodeBinaryFrame(header, Buffer.from([1, 2, 3, 4])), {
+      binary: true,
+    });
+    await flush();
+    ws.close();
+
+    expect(server.decodeErrors).toHaveLength(0);
+    expect(server.receivedControls).toHaveLength(1);
+    expect(server.receivedFrames).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Deep fallback-slop sweep — long tail (#12275), slice 0 of 2

Behavior-changing sweep of the unambiguous error-handling slop in **slice 0** of the long-tail batch, per the parent policy (#12182 / foundation #12263). Thorough on clear slop, precise on ambiguity: convert only what is unmistakably fabricating-a-healthy-result or silently-swallowing, keep + annotate the justified handlers, and honestly defer the large per-site-judgment tail.

### Slice derivation (disjointness proof)

Slice root (long-tail members present in this tree, minus batch-owned/out-of-scope): `packages/{contracts,elizaos,registry,scenario-runner,scripts,test,tui}` + `plugins/{plugin-app-control,plugin-calendar,plugin-commands,plugin-contacts,plugin-facewear,plugin-finances,plugin-form,plugin-inbox,plugin-meetings,plugin-relationships,plugin-scheduling,plugin-todos,plugin-xr}` (health/computeruse→batch 10; vision/music/browser→batch 11).

Suspect files = union of `rg -l` for empty-catch + `.catch(()=>{}|null|undefined)` + return-default-catch over the slice root, non-test `.ts/.tsx`, `sort -u` → **77 files**. Slice 0 = 0-based `index % 2 == 0` → **39 files** (slice 1 takes the odd indices; the two slices are disjoint).

### What the sweep found

At develop tip the earlier merged #12275 sweeps (#12612/#12616/#12628/#12722/#12886) already removed most real slop. Re-deriving the current list, slice 0's remaining unambiguous slop was small; the rest is legitimate parse-invalid / capability-probe / designed-degrade code that must **not** be "cleaned up" into throws. Conversions are therefore few and each carries a real error-path test; justified keeps are annotated; the ambiguous `return null/false/0` + `?? <lit>` tail is deferred.

### Conversions (behavior-changing, each with a real error-path test)

| Site | Before | After |
|---|---|---|
| `plugin-meetings/src/platforms/googlemeet/recording.ts` `countParticipants` | `catch { return 0 }` — a failed `page.evaluate` read as "empty room", accruing alone-time toward a **premature auto-leave** | returns `number \| null`; `null` = unknown-this-tick, recording loop skips the tick; only a real evaluate `0` counts as empty. `logger.warn` on failure |
| `plugin-xr/simulator/src/mock-agent.ts` (WS test mock) | two `catch {}` silently dropped malformed inbound text/binary frames — hiding the exact protocol regressions the tests exist to catch | recorded in an observable `decodeErrors[]`; well-formed traffic unaffected |

Tests: `recording.test.ts` (evaluate throws → `null`, real empty room → `0`, success → count) and `mock-agent-decode.test.ts` (boots the real `ws` mock, sends a malformed text frame and a bad-length binary frame → recorded; well-formed hello+audio → `decodeErrors` empty). Both green.

### Justified keeps — annotated `// error-policy:J<N>` (10)

- `plugin-app-control/src/services/app-worker-host-service.ts` — **J6** best-effort teardown ×2 (`stop()` fan-out, failed-spawn `worker.terminate()`), **J4** best-effort persisted-worker auto-start (registry not ready → null → skip, never crash boot)
- `plugin-app-control/src/evaluators/view-followup-routing.ts` — **J4** loopback confirm failure → agent's normal reply stands (designed degrade)
- `plugin-app-control/src/actions/{agent-switch,model-switch}.ts`, `plugin-commands/src/actions/handlers.ts` — **J3** non-JSON response body → null (caller reads `response.ok`/fields)
- `plugin-calendar/src/internal/constants.ts` `isValidTimeZone` — **J3** Intl RangeError → invalid; `recurrence.ts` ×2 — **J3** unparseable RRULE → no-usable-rule

### Deferred (ambiguousLeft — this wave is clear-slop only)

~30+ `return null/[]/false` catches and `.catch(()=>null)` on the remaining slice-0 files are legitimate-absence / capability-probe / parse-invalid where masking-vs-legit needs per-site judgment (e.g. `pulseAudioAvailable() → false`, `readFile().catch(()=>null)` file-absence, script fs-walk skips, mock-server request-body parse, teardown in test fixtures). Left untouched per the batch rule "no over-removal". The `?? <lit>` / `|| <lit>` load-path tail is likewise out of scope for this wave.

### Ratchet (diff-scoped `bun run audit:error-policy-ratchet`)

`no new fallback-slop in touched files`. Empty-catch in touched files, before → after:

- `plugin-xr/simulator/src/mock-agent.ts`: **2 → 0**
- all other touched files: 0 → 0

No server-side `console.*` added.

### Tests

- `plugin-meetings/src/platforms/googlemeet/recording.test.ts` — 3/3 pass (new)
- `plugin-xr/src/__tests__/mock-agent-decode.test.ts` — 3/3 pass (new)
- `plugin-commands` suite — 84/84 pass

**Evidence / N/A.** This is a fail-fast/error-policy refactor with no UI, model, or on-device surface: screenshots / trajectories / device capture are `N/A - error-handling refactor, no user-facing or agent-behavior surface`. The observable proof is the two new error-path tests (failure now distinguishable from a real empty/absent value) plus the ratchet delta above.

**Environment note.** This worktree is a reduced checkout; many workspace packages (`playwright-core`, `@elizaos/capacitor-calendar`, `@elizaos/plugin-google`, `webxr-polyfill`, several `@types/*`) are absent, so full per-package `typecheck` / suites red on pre-existing import-resolution failures unrelated to this diff (none of the failing traces reference the touched files). The focused tests above run clean; the touched files add no new type errors.

Refs #12275

🤖 Generated with [Claude Code](https://claude.com/claude-code)
