### PR TITLE
fix(#12271): deep fallback-slop sweep slice 0/1 — model/inference plugins

### DIFF
--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/text-streaming.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/text-streaming.ts
@@ -214,10 +214,18 @@ export function streamCapacitorPrompt(
 			);
 			return usage;
 		})
+		// error-policy:J5 unhandled-rejection suppression — a completion failure
+		// is observed by the `text`/`textStream` consumers (fullTextPromise does
+		// not catch and rejects). `usage`/`finishReason` are optional metadata
+		// that degrade to their typed `undefined`; the catch only prevents these
+		// companion reads from surfacing the same failure a second time as an
+		// unhandled rejection.
 		.catch(() => undefined);
 
 	const finishReasonPromise: Promise<string | undefined> = completionPromise
 		.then(() => completionFinishReason ?? "stop")
+		// error-policy:J5 unhandled-rejection suppression — see usagePromise above;
+		// the completion failure surfaces via `text`/`textStream`.
 		.catch(() => undefined);
 
 	return {

--- a/plugins/plugin-local-inference/src/routes/voice-profiles-management-routes.ts
+++ b/plugins/plugin-local-inference/src/routes/voice-profiles-management-routes.ts
@@ -335,6 +335,9 @@ async function mergeProfile(
 			allowEntityOverwrite: body.allowEntityOverwrite === true,
 		});
 	} catch (err) {
+		// error-policy:J1 boundary translation — HTTP route boundary. A merge
+		// failure is translated into a structured HTTP error (409 on a conflict,
+		// else 400); `return true` signals the dispatcher the request was handled.
 		const message = err instanceof Error ? err.message : "merge failed";
 		sendJsonError(res, message, /conflict/i.test(message) ? 409 : 400);
 		return true;
@@ -369,6 +372,9 @@ async function splitProfile(
 			sampleIds: utteranceIds,
 		});
 	} catch (err) {
+		// error-policy:J1 boundary translation — HTTP route boundary. A split
+		// failure is translated into a structured HTTP 400; `return true` signals
+		// the dispatcher the request was handled.
 		sendJsonError(
 			res,
 			err instanceof Error ? err.message : "split failed",

--- a/plugins/plugin-local-inference/src/services/downloader.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.ts
@@ -1490,6 +1490,9 @@ export class Downloader {
 				// replaced by the fresh bundle artifact (never accepted as valid).
 			}
 		} else {
+			// error-policy:J6 best-effort teardown — discard any stale staging file
+			// before the fresh download re-creates it; an already-absent file is the
+			// expected no-op and must not abort the download.
 			await fsp.rm(stagingPath, { force: true }).catch(() => undefined);
 		}
 

--- a/plugins/plugin-local-inference/src/services/ffi-streaming-runner.ts
+++ b/plugins/plugin-local-inference/src/services/ffi-streaming-runner.ts
@@ -176,6 +176,10 @@ export class FfiStreamingRunner {
 			return fn();
 		}
 		const prior = this.slotInFlight.get(slotId);
+		// error-policy:J5 unhandled-rejection suppression — the prior slot user's
+		// failure was already observed by that caller (it awaited its own `run`).
+		// Here we only serialize behind its completion; swallowing its rejection
+		// keeps one generation's failure from blocking the next on the same slot.
 		const run = (prior ?? Promise.resolve()).catch(() => {}).then(fn);
 		const tail = run.then(
 			() => {},

--- a/plugins/plugin-local-inference/src/services/imagegen/mflux.ts
+++ b/plugins/plugin-local-inference/src/services/imagegen/mflux.ts
@@ -214,6 +214,8 @@ export async function loadMfluxImageGenBackend(
 		async dispose() {
 			if (disposed) return;
 			disposed = true;
+			// error-policy:J6 best-effort teardown — scratch-dir removal on dispose;
+			// an already-gone dir is the expected no-op and must not fail dispose.
 			await fs.rm(outputDir, { recursive: true, force: true }).catch(() => {});
 		},
 	};

--- a/plugins/plugin-local-inference/src/services/imagegen/sd-cpp.ts
+++ b/plugins/plugin-local-inference/src/services/imagegen/sd-cpp.ts
@@ -278,9 +278,9 @@ export async function loadSdCppImageGenBackend(
 		async dispose() {
 			if (disposed) return;
 			disposed = true;
-			// Best-effort scratch cleanup. We don't fail dispose if the
-			// temp dir is missing — it just means a prior caller already
-			// removed it.
+			// error-policy:J6 best-effort teardown — scratch cleanup on dispose. We
+			// don't fail dispose if the temp dir is missing; it just means a prior
+			// caller already removed it.
 			await fs.rm(outputDir, { recursive: true, force: true }).catch(() => {});
 		},
 	};

--- a/plugins/plugin-local-inference/src/services/imagegen/tensorrt-unavailable.ts
+++ b/plugins/plugin-local-inference/src/services/imagegen/tensorrt-unavailable.ts
@@ -227,6 +227,8 @@ export async function loadTensorRtImageGenBackend(
 		async dispose() {
 			if (disposed) return;
 			disposed = true;
+			// error-policy:J6 best-effort teardown — scratch-dir removal on dispose;
+			// an already-gone dir is the expected no-op and must not fail dispose.
 			await fs.rm(outputDir, { recursive: true, force: true }).catch(() => {});
 		},
 	};

--- a/plugins/plugin-local-inference/src/services/llama-server-metrics.ts
+++ b/plugins/plugin-local-inference/src/services/llama-server-metrics.ts
@@ -298,6 +298,9 @@ export async function fetchMetricsSnapshot(
 		clearTimeout(timer);
 		signal?.removeEventListener("abort", abortFromCaller);
 		if (res?.body && (!bodySettled || controller.signal.aborted)) {
+			// error-policy:J6 best-effort teardown — cancel an unconsumed/aborted
+			// response body in the finally path so the socket is released; a cancel
+			// failure must not overwrite the snapshot the try already returned.
 			await res.body.cancel(controller.signal.reason).catch(() => undefined);
 		}
 	}

--- a/plugins/plugin-local-inference/src/services/memory-monitor.ts
+++ b/plugins/plugin-local-inference/src/services/memory-monitor.ts
@@ -207,6 +207,11 @@ export class MemoryMonitor {
 		const { freeBytes, totalBytes } = this.osMemory();
 		const totalMb = Math.round(totalBytes / BYTES_PER_MB);
 		const freeMb = Math.round(freeBytes / BYTES_PER_MB);
+		// error-policy:J4 designed degrade — `null` is the typed "RSS unavailable"
+		// value (the server metrics endpoint is optional). The block below is
+		// written to skip the RSS-headroom refinement when it is null and fall
+		// back to the OS free figure, so an unreadable RSS degrades the estimate
+		// rather than masking a failure with a fake number.
 		const serverRssMb = await this.serverRssMb().catch(() => null);
 		// If the server process is huge relative to total RAM, treat the
 		// headroom (total - RSS - what other things need) as a tighter free

--- a/plugins/plugin-local-inference/src/services/service-bundled-bootstrap.test.ts
+++ b/plugins/plugin-local-inference/src/services/service-bundled-bootstrap.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Verifies `LocalInferenceService.getInstalled()` surfaces and retries a
+ * bundled-model bootstrap failure (#12271) instead of caching it as a silent
+ * success. Deterministic: `registerBundledModels` and the registry read are
+ * stubbed so the failure path is exercised without touching disk or a model.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const bootstrapMocks = vi.hoisted(() => ({
+	registerBundledModels: vi.fn<() => Promise<number>>(),
+	listInstalledModels: vi.fn(async () => []),
+	error: vi.fn(),
+}));
+
+vi.mock("@elizaos/core", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@elizaos/core")>();
+	return {
+		...actual,
+		logger: { ...actual.logger, error: bootstrapMocks.error },
+	};
+});
+
+vi.mock("./bundled-models", () => ({
+	registerBundledModels: bootstrapMocks.registerBundledModels,
+}));
+
+vi.mock("./registry", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./registry")>();
+	return { ...actual, listInstalledModels: bootstrapMocks.listInstalledModels };
+});
+
+import { LocalInferenceService } from "./service";
+
+describe("LocalInferenceService bundled-model bootstrap failure (#12271)", () => {
+	beforeEach(() => {
+		bootstrapMocks.registerBundledModels.mockReset();
+		bootstrapMocks.listInstalledModels.mockReset();
+		bootstrapMocks.listInstalledModels.mockResolvedValue([]);
+		bootstrapMocks.error.mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("surfaces a bootstrap failure via the logger and does not brick the read", async () => {
+		bootstrapMocks.registerBundledModels.mockRejectedValueOnce(
+			new Error("bundled registry write failed"),
+		);
+		const service = new LocalInferenceService();
+
+		// The read degrades (returns the registry list) rather than throwing…
+		await expect(service.getInstalled()).resolves.toEqual([]);
+		// …but the failure is observable, not swallowed.
+		expect(bootstrapMocks.error).toHaveBeenCalledTimes(1);
+		const [, message] = bootstrapMocks.error.mock.calls[0] as [unknown, string];
+		expect(message).toContain("bundled-model bootstrap failed");
+	});
+
+	it("retries the bootstrap on the next getInstalled() instead of caching the failure", async () => {
+		bootstrapMocks.registerBundledModels
+			.mockRejectedValueOnce(new Error("transient write failure"))
+			.mockResolvedValueOnce(2);
+		const service = new LocalInferenceService();
+
+		await service.getInstalled();
+		await service.getInstalled();
+
+		// A cached-as-success swallow would call registerBundledModels once; the
+		// retry-on-failure contract calls it again after the first rejection.
+		expect(bootstrapMocks.registerBundledModels).toHaveBeenCalledTimes(2);
+	});
+
+	it("caches a successful bootstrap and runs it at most once", async () => {
+		bootstrapMocks.registerBundledModels.mockResolvedValue(1);
+		const service = new LocalInferenceService();
+
+		await service.getInstalled();
+		await service.getInstalled();
+
+		expect(bootstrapMocks.registerBundledModels).toHaveBeenCalledTimes(1);
+		expect(bootstrapMocks.error).not.toHaveBeenCalled();
+	});
+});

--- a/plugins/plugin-local-inference/src/services/service.ts
+++ b/plugins/plugin-local-inference/src/services/service.ts
@@ -183,7 +183,20 @@ export class LocalInferenceService {
 		if (!this.bundledBootstrap) {
 			this.bundledBootstrap = registerBundledModels()
 				.then(() => undefined)
-				.catch(() => undefined);
+				.catch((error) => {
+					// error-policy:J4 designed degrade — a bundled-model registration
+					// failure must not brick the installed-model read (getInstalled
+					// still returns whatever registered), but it may not be swallowed
+					// silently either: surface it through the logger's recent-log ring
+					// so it is observable, and clear the once-latch so the next
+					// getInstalled() retries instead of caching this failure as a
+					// permanent silent success.
+					this.bundledBootstrap = null;
+					logger.error(
+						{ err: error },
+						"[LocalInferenceService] bundled-model bootstrap failed; retrying on next getInstalled()",
+					);
+				});
 		}
 		return this.bundledBootstrap;
 	}

--- a/plugins/plugin-local-inference/src/services/verify-on-device.ts
+++ b/plugins/plugin-local-inference/src/services/verify-on-device.ts
@@ -118,6 +118,9 @@ export function createVerifyBundleOnDevice(
 			// Always release the model the verify pass loaded — the bundle is not
 			// "active" yet, and the active-model coordinator owns load/unload from
 			// here on.
+			// error-policy:J6 best-effort teardown — release the verify-loaded model
+			// in the finally path; an unload failure here must not mask the verify
+			// result (success or the error already propagating out of the try).
 			await engine.unload().catch(() => {});
 		}
 	};

--- a/plugins/plugin-local-inference/src/services/voice/eliza1-eot-scorer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/eliza1-eot-scorer.ts
@@ -143,6 +143,11 @@ export class Eliza1EotScorer {
 		const next = this.inflight.then(() =>
 			this.runOnce(sequence, tokens, endOfTurnId),
 		);
+		// error-policy:J5 unhandled-rejection suppression — the real failure is
+		// observed by `await next` on the following line (and rethrown to the
+		// caller). `this.inflight` only serializes the next scoring call behind
+		// this one, so it stores a settled-either-way promise and must not carry
+		// the rejection forward.
 		this.inflight = next.catch(() => undefined);
 		const probability = await next;
 		return {

--- a/plugins/plugin-local-inference/src/services/voice/pipeline.ts
+++ b/plugins/plugin-local-inference/src/services/voice/pipeline.ts
@@ -358,6 +358,10 @@ export class VoicePipeline {
 		// idle ASR pages now (within-turn RSS trim, AGENTS.md §4). Fire-and-
 		// forget: a slow `madvise` must not delay the drafter kick-off.
 		if (this.events.onAsrPhaseComplete) {
+			// error-policy:J6 best-effort — this is an optional within-turn RSS trim
+			// (madvise page-drop hint), not a data path. A failed or slow hint must
+			// neither delay the drafter kick-off nor surface as an unhandled
+			// rejection; the next turn re-issues it.
 			void Promise.resolve(this.events.onAsrPhaseComplete()).catch(() => {});
 		}
 

--- a/plugins/plugin-local-inference/src/services/voice/profile-store.ts
+++ b/plugins/plugin-local-inference/src/services/voice/profile-store.ts
@@ -361,6 +361,9 @@ export class VoiceProfileStore {
 			if (record && (record.confidence >= 0.5 || record.sampleCount >= 3)) {
 				continue;
 			}
+			// error-policy:J6 best-effort teardown — the index (rewritten below) is
+			// the source of truth; a stale/missing profile file left on disk is
+			// harmless, so eviction must not fail on an unlink error.
 			await fsp.unlink(this.profilePath(victim.profileId)).catch(() => {});
 			index.entries = index.entries.filter(
 				(e) => e.profileId !== victim.profileId,
@@ -691,6 +694,9 @@ export class VoiceProfileStore {
 				`[VoiceProfileStore.deleteProfile] refusing to delete ${args.profileId}: bound to entity ${record.entityId}`,
 			);
 		}
+		// error-policy:J6 best-effort teardown — the index (rewritten below) is the
+		// source of truth; a leftover profile file on disk is harmless, so delete
+		// must not fail on an unlink error.
 		await fsp.unlink(this.profilePath(args.profileId)).catch(() => {});
 		this.hot.delete(args.profileId);
 		const index = await this.readIndex();

--- a/plugins/plugin-local-inference/src/services/voice/self-voice-imprint.ts
+++ b/plugins/plugin-local-inference/src/services/voice/self-voice-imprint.ts
@@ -98,6 +98,10 @@ export class AgentSelfVoiceImprint {
 		const work = this.queue.then(() =>
 			this.observeAudioLocked(pcm, sampleRate),
 		);
+		// error-policy:J5 unhandled-rejection suppression — the caller observes the
+		// failure via the returned `work` promise. `this.queue` only serializes the
+		// next observeAudio behind this one, so it stores a settled-either-way
+		// promise and must not carry the rejection forward.
 		this.queue = work.catch(() => {});
 		return work;
 	}


### PR DESCRIPTION
## Fallback-slop sweep — model/inference plugins, slice 0/1 (Refs #12271)

Deep sweep of the disjoint suspect-file set for the model/inference slice
(`plugin-{anthropic,openai,openrouter,google-genai,groq,ollama,lmstudio,
local-inference,aosp-local-inference,cli-inference,nearai,xai,zai,embeddings,
elevenlabs,edge-tts,anthropic-proxy}`).

Re-deriving the suspect list against `develop` shows the provider plugins were
already swept in prior #12182 waves (`openrouter/utils/helpers.ts`,
`anthropic/models/text.ts`, `xai/models/grok.ts`, etc. already carry
`error-policy:J<N>` annotations and use `ElizaError`). The remaining unannotated
fallback-slop was concentrated in **plugin-local-inference**. This PR converts
the one genuine remaining swallow and annotates every remaining kept handler so
"each remaining handler has a documented justification" is mechanically
checkable.

### Per-category tally

| Category | Count | Disposition |
|---|---|---|
| empty catch (`catch {}`) | 0 unannotated | none remained — all pre-annotated |
| fabricated-healthy-on-error | **1 converted** | `bootstrapBundled` |
| promise-swallow — J5 (annotated) | 4 | text-streaming, ffi-streaming-runner, eliza1-eot-scorer, self-voice-imprint |
| promise-swallow — J6 teardown (annotated) | 7 | mflux/sd-cpp/tensorrt dispose, profile-store ×2, verify-on-device, llama-server-metrics, downloader |
| promise-swallow — J4 degrade (annotated) | 2 | memory-monitor RSS, pipeline madvise hint |
| catch — J1 boundary (annotated) | 2 | voice-profiles-management merge/split routes |
| deferred (ambiguous absent-vs-mask) | ~42 sites | bare `return null/[]/false` probes + `?? <lit>` config defaults |

### The conversion — `LocalInferenceService.bootstrapBundled`

**Before:** `registerBundledModels().then(...).catch(() => undefined)` — a
bundled-model registration failure (e.g. a failed `upsertElizaModel` write) was
swallowed to `undefined` **and cached as a permanent silent success**, so
`getInstalled()` returned a partial model list looking healthy and never
retried.

**After:** the failure is surfaced via the logger's recent-log ring (observable
to the agent per #12263) and the once-latch is cleared so the next
`getInstalled()` retries. The read still degrades (returns whatever registered)
rather than bricking the model list on one bad bundled entry — a designed J4
degrade that no longer masks the failure.

### Kept handlers — why they are justified, not slop

- **J5** sites are the codebase's established `handledPromise`/inflight-latch
  shape (mirrors the already-annotated anthropic/openai/xai stream handlers):
  the real failure is observed by the primary consumer (`textStream`/`text`, the
  `await next`, the returned `work`), and the `.catch` only stops a companion or
  serialization promise from re-surfacing it as an unhandled rejection.
- **J6** sites are teardown only (`dispose`, `finally`, stale-file discard); an
  already-gone file / released handle is the expected no-op.
- **J4** sites degrade to a typed unavailable value with a designed fallback
  (RSS→OS-free; madvise hint is an optional within-turn RSS trim).
- **J1** sites are HTTP route boundaries translating a failure into a structured
  error response.

### Deferred (per this wave's scope)

Bare `return null/[]/false` capability/parse probes (e.g. `readProcMeminfo`,
`computeSupported`, `existsSync`/`readdirSync` guards, `JSON.parse` → null) and
`?? <lit>` config defaults are legitimate-absence-vs-masking judgment calls left
for the per-site pass; they are not clear slop.

### Tests

- New real error-path test `service-bundled-bootstrap.test.ts` (3 cases): a
  rejecting `registerBundledModels` is (1) surfaced via `logger.error` while the
  read degrades to `[]` (no fabricated success), (2) **retried** on the next
  `getInstalled()` (proving it is no longer cached-as-success), (3) a success is
  cached and runs at most once.
- `service.test.ts` (existing, 6 cases) stays green.
- All other edits are comment-only annotations (no behavior change).

### Verify

- `plugin-local-inference` typecheck (`tsgo --noEmit`): clean.
- `bun run audit:error-policy-ratchet`: **no new fallback-slop**; every touched
  file's empty-catch count unchanged (e.g. `downloader.ts` 4→4, `sd-cpp.ts`
  2→2), serverConsole 0→0.
- Touched-module tests green. The 12 `downloader.test.ts` failures are
  **pre-existing on `develop`** (artifact/manifest-dependent under
  `ELIZA_SKIP_ARTIFACT_SYNC=1`) — verified by reproducing them against the
  unmodified `develop` file; my edit there is a single comment line.

Refs #12271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
