### PR TITLE
fix(agent-orchestrator): register built apps from the durable-task spawn path

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/built-apps-registry.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/built-apps-registry.test.ts
@@ -20,6 +20,8 @@ import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeGrillingRuntime } from "../../test/scenarios/_helpers/orchestrator-grilling-harness.ts";
+import { makeSpawnCapturingAcp } from "../../test/scenarios/_helpers/reflexion-scenario.ts";
 import {
   BUILT_APPS_CACHE_KEY,
   type BuiltAppRecord,
@@ -28,6 +30,8 @@ import {
   registerBuiltApp,
   registerBuiltAppsForCompletion,
 } from "../services/built-apps-registry.ts";
+import { OrchestratorTaskService } from "../services/orchestrator-task-service.ts";
+import { OrchestratorTaskStore } from "../services/orchestrator-task-store.ts";
 import { SubAgentRouter } from "../services/sub-agent-router.ts";
 
 const ROOM = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
@@ -164,6 +168,85 @@ describe("registry round-trip", () => {
         "https://example.org/apps/x/",
       ]),
     ).toBeNull();
+  });
+});
+
+describe("durable-task spawn path (#12036 follow-up)", () => {
+  // The durable-task route stamps `goal` (not `initialTask`) on session
+  // metadata, so the register handoff must gate the eliza-cloud target on
+  // either key — otherwise an app built via a durable task never registers.
+  const savedEnv: Record<string, string | undefined> = {};
+  const ENV_KEYS = ["ELIZA_CONFIG_PATH", "ELIZA_APP_DEPLOY_TARGET"];
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
+    process.env.ELIZA_CONFIG_PATH = "/nonexistent/built-apps-test.json";
+    process.env.ELIZA_APP_DEPLOY_TARGET = "eliza-cloud";
+  });
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  it("a spawnAgentForTask session carries the task text and its cloud deploy registers", async () => {
+    const goal = "build a website for tracking my workouts and deploy it";
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const detail = await store.createTask({
+      title: "Workout tracker",
+      goal,
+      acceptanceCriteria: [],
+      roomId: ROOM,
+      taskRoomId: ROOM,
+      worldId: "scenario-world",
+    });
+    const acp = makeSpawnCapturingAcp();
+    const base = {
+      agentId: AGENT_ID,
+      character: { name: "Tester" },
+      databaseAdapter: undefined,
+      logger: {
+        debug: () => undefined,
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+      },
+      getSetting: () => undefined,
+      getService: () => undefined,
+      useModel: async () => "{}",
+    } as unknown as IAgentRuntime;
+    const service = new OrchestratorTaskService(
+      makeGrillingRuntime(base, acp.service, async () => "{}"),
+      { store },
+    );
+    await service.start();
+    try {
+      await service.spawnAgentForTask(detail.task.id);
+    } finally {
+      await service.stop().catch(() => undefined);
+    }
+
+    // The durable spawn persists the bare goal on session metadata (the same
+    // key the direct-API spawn stamps)…
+    const spawned = acp.spawns.at(0);
+    expect(spawned?.metadata?.goal).toBe(goal);
+
+    // …and the SAME register handoff the router runs at task_complete gates
+    // the eliza-cloud target on it: the durable-built app lands in the
+    // registry exactly like a chat-spawned one.
+    const { runtime, cache } = cacheRuntime();
+    const registered = await registerBuiltAppsForCompletion(
+      runtime,
+      { id: spawned?.sessionId ?? "", metadata: spawned?.metadata },
+      ["https://workouts.apps.elizacloud.example/"],
+    );
+    expect(registered).toMatchObject({
+      slug: "workouts",
+      target: "eliza-cloud",
+      url: "https://workouts.apps.elizacloud.example/",
+    });
+    expect(cache.get(BUILT_APPS_CACHE_KEY)).toHaveLength(1);
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/src/services/built-apps-registry.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/built-apps-registry.ts
@@ -184,8 +184,18 @@ export async function registerBuiltAppsForCompletion(
 ): Promise<BuiltAppRecord | null> {
   try {
     const meta = session.metadata;
+    // The task text's metadata carrier differs by spawn path: TASKS
+    // op=spawn_agent stamps the full `initialTask`, while the durable-task
+    // route (`spawnAgentForTask`) and the direct API spawn persist the bare
+    // `goal`. Accept either so the eliza-cloud app-build gate sees the task
+    // on every spawn path — an app built via a durable task must register
+    // the same way a chat-spawned one does.
     const initialTask =
-      typeof meta?.initialTask === "string" ? meta.initialTask : undefined;
+      typeof meta?.initialTask === "string"
+        ? meta.initialTask
+        : typeof meta?.goal === "string"
+          ? meta.goal
+          : undefined;
     const derived = deriveBuiltApp(
       verifiedUrls,
       resolveAppDeployConfig(),

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -2693,6 +2693,11 @@ export class OrchestratorTaskService extends Service {
         roomId: doc.task.taskRoomId ?? doc.task.roomId,
         label: agentName,
         source: "orchestrator",
+        // Persist the bare goal (the same key the direct-API spawn stamps) so
+        // completion-time consumers that read the task text off session
+        // metadata — the built-apps registry's app-build gate, interruption
+        // relevance — see what this session is building.
+        goal: doc.task.goal,
         // Orchestrator sessions outlive their first prompt so follow-ups and
         // validation re-dispatch can reuse them.
         keepAliveAfterComplete: true,

--- a/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/reflexion-scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/reflexion-scenario.ts
@@ -56,15 +56,19 @@ export const reflexionVerifierModel: VerifierModel = async (
   );
 };
 
-/** A scripted ACP that records the goal prompt handed to each spawned session
- * (`spawns[i].initialTask`) and lets the driver emit `task_complete` events. */
+/** A scripted ACP that records the goal prompt + session metadata handed to
+ * each spawned session and lets the driver emit `task_complete` events. */
 export function makeSpawnCapturingAcp() {
   let handler:
     | ((sessionId: string, event: string, data: unknown) => void)
     | undefined;
   let counter = 0;
   const sent: Array<{ sessionId: string; text: string }> = [];
-  const spawns: Array<{ sessionId: string; initialTask: string }> = [];
+  const spawns: Array<{
+    sessionId: string;
+    initialTask: string;
+    metadata?: Record<string, unknown>;
+  }> = [];
   const service = {
     onSessionEvent(
       cb: (sessionId: string, event: string, data: unknown) => void,
@@ -85,7 +89,11 @@ export function makeSpawnCapturingAcp() {
     spawnSession: async (opts: SpawnOptions): Promise<SpawnResult> => {
       counter += 1;
       const sessionId = `reflexion-spawn-${counter}`;
-      spawns.push({ sessionId, initialTask: opts.initialTask ?? "" });
+      spawns.push({
+        sessionId,
+        initialTask: opts.initialTask ?? "",
+        metadata: opts.metadata,
+      });
       return {
         sessionId,
         id: sessionId,


### PR DESCRIPTION
## Problem

#12036 wired the build→register handoff (`registerBuiltAppsForCompletion`) so bot-built apps land in the built-apps registry and show up in management surfaces — but only for the chat spawn path. `TASKS op=spawn_agent` stamps the task text on session metadata as `initialTask`, and the eliza-cloud register gate reads exactly that key.

The durable-task spawn path (`OrchestratorTaskService.spawnAgentForTask`) stamps **no task text at all** on session metadata (`{taskId, roomId, label, source, keepAliveAfterComplete, nestingDepth}`). The router's register handoff does run for those sessions at `task_complete`, but the eliza-cloud app-build gate (`isAppBuildTask(meta.initialTask)`) sees `undefined` → `deriveBuiltApp` returns null → an app built via a durable task never registers and never appears in the management UI. The direct-API spawn (`agent-routes.ts`) had the same hole: it stamps `goal`, which the gate ignored.

## Fix (structural, reuses the existing helper)

- `spawnAgentForTask` now persists the bare `goal` on session metadata — the same key the direct-API spawn already stamps.
- `registerBuiltAppsForCompletion`'s gate text accepts `initialTask ?? goal`, so the SAME register handoff covers the chat, durable-task, and direct-API spawn paths.

Deliberately NOT stamped as `initialTask`: that key also arms the router's state-lost respawn / verify-retry recovery, which would double up with the durable task layer's own recovery (#8899). `goal` is inert for those paths.

## Test

New test drives the REAL `spawnAgentForTask` (in-memory store + spawn-capturing ACP), asserts the spawned session's metadata carries the goal, then feeds that exact metadata through `registerBuiltAppsForCompletion` with a verified cloud URL and asserts the registry record lands.

On develop without the fix it fails at the gap:
```
AssertionError: expected undefined to be 'build a website for tracking my workouts and deploy it'
```

## Verification

- `plugin-agent-orchestrator` tests: **155 files passed | 4 skipped, 1628 tests passed | 8 skipped**
- `bun run typecheck` (plugin): clean
- `bunx biome check`: clean (286 files)

Follow-up to #12036.