### PR TITLE
fix(#12795): triage plugin-openai error handlers per J1-J7 (finish hosted-provider slop sweep)

### DIFF
--- a/plugins/plugin-openai/init.ts
+++ b/plugins/plugin-openai/init.ts
@@ -49,6 +49,9 @@ async function validateOpenAIConfiguration(runtime: IAgentRuntime): Promise<void
       return;
     }
   } catch (error) {
+    // error-policy:J7 diagnostics-must-not-kill-the-loop — key validation is an
+    // advisory startup probe; a network/transport failure must not block plugin
+    // init. The real request failure surfaces at call time on the model path.
     const message = error instanceof Error ? error.message : String(error);
     logger.warn(`[OpenAI] API validation error: ${message}. OpenAI functionality may be limited.`);
   }

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -660,6 +660,9 @@ function parseJsonIfPossible(value: unknown): unknown {
   try {
     return JSON.parse(value);
   } catch {
+    // error-policy:J3 untrusted-input sanitizing — tool-call `arguments` may be a
+    // plain (non-JSON) string; returning the raw value is the correct parse of a
+    // non-JSON argument, not a swallowed failure.
     return value;
   }
 }
@@ -1010,9 +1013,10 @@ function buildNativeTextResult(
 function handledPromise<T>(value: T | PromiseLike<T>): Promise<T> {
   const promise = Promise.resolve(value);
   promise.catch(() => {
-    // The streaming path primarily consumes `textStream`. AI SDK companion
-    // promises such as `text` can reject later on empty streams even when no
-    // caller requested them, which otherwise surfaces as an unhandled rejection.
+    // error-policy:J5 unhandled-rejection suppression — the streaming path
+    // primarily consumes `textStream`. AI SDK companion promises such as `text`
+    // can reject later on empty streams even when no caller requested them; the
+    // real error is still observed by whoever awaits `textStream`.
   });
   return promise;
 }
@@ -1120,6 +1124,9 @@ function toTrajectoryJsonSafe(value: unknown): unknown {
       })
     ) as unknown;
   } catch {
+    // error-policy:J7 diagnostics-must-not-kill-the-loop — trajectory JSON
+    // serialization is a telemetry artifact; on a non-serializable value fall
+    // back to a string repr rather than failing the model call being logged.
     return String(value);
   }
 }
@@ -1205,6 +1212,8 @@ async function generateTextWithTransientRetry(
         // biome-ignore lint/suspicious/noExplicitAny: see above.
       )) as any;
     } catch (error) {
+      // error-policy:J2 context-adding rethrow — terminal or retry-exhausted
+      // errors rethrow unchanged; only bounded transient provider errors retry.
       if (attempt >= maxRetries || !isTransientProviderError(error)) throw error;
       attempt++;
       const backoffMs = Math.min(3000, 300 * 2 ** (attempt - 1)) + Math.floor(Math.random() * 200);
@@ -1269,6 +1278,8 @@ async function consumeStreamWithTransientRetry(
       if (capturedError) throw capturedError;
       return { text, toolCalls, usage, finishReason };
     } catch (error) {
+      // error-policy:J2 context-adding rethrow — terminal or retry-exhausted
+      // errors rethrow unchanged; only bounded transient provider errors retry.
       if (attempt >= maxRetries || !isTransientProviderError(error)) throw error;
       attempt++;
       const backoffMs = Math.min(3000, 300 * 2 ** (attempt - 1)) + Math.floor(Math.random() * 200);
@@ -1522,6 +1533,8 @@ async function generateTextByModelType(
             yield chunk;
           }
         } catch (error) {
+          // error-policy:J2 context-adding rethrow — capture the stream-iteration
+          // error so `finally` can finalize telemetry, then rethrow it below.
           streamIterationError = error;
         } finally {
           await finalizeStreamingTelemetry();

--- a/plugins/plugin-openai/utils/tokenization.ts
+++ b/plugins/plugin-openai/utils/tokenization.ts
@@ -24,6 +24,9 @@ function resolveTokenizerEncoding(modelName: string): Tiktoken {
   try {
     return encodingForModel(modelName as TiktokenModel);
   } catch {
+    // error-policy:J3 untrusted-input sanitizing — js-tiktoken throws on model
+    // names outside its static registry (custom/newer models); fall back to the
+    // closest base encoding so token estimates stay usable instead of throwing.
     return getEncoding(fallbackEncoding as TiktokenEncoding);
   }
 }


### PR DESCRIPTION
## Summary

Completes the **#12795** hosted-provider fallback-slop sweep by triaging the one remaining plugin — `plugin-openai`. The 8 sibling providers were swept by #13236/#13247; the openai tail (#13248) was closed unmerged, leaving openai with **zero** `error-policy:J<N>` annotations.

Every openai error handler is a **justified keep** (no fabricated-success, no swallow-on-write, no log-and-continue producing a result). This annotates each so the scope's triage is grep-complete:

| Site | Verdict |
|---|---|
| `init.ts` API-key validation probe | J7 — advisory startup diagnostic; real request failures surface at call time |
| `utils/tokenization.ts` unknown model | J3 — js-tiktoken registry miss → closest base encoding |
| `models/text.ts` `parseJsonIfPossible` | J3 — non-JSON tool args parse to the raw value |
| `models/text.ts` `handledPromise` | J5 — AI SDK companion-promise rejection suppression; observed via `textStream` |
| `models/text.ts` `toTrajectoryJsonSafe` | J7 — telemetry serialization degrade |
| `models/text.ts` 2 retry loops + 1 stream-capture | J2 — rethrow terminal/exhausted; retry only bounded transient errors |

The `response.text().catch(() => "Unknown error")` error-message extraction sites are left as-is, matching the swept siblings (e.g. `plugin-openrouter/models/audio.ts:222`).

## Evidence

- **Comment-only** — `node scripts/assert-comment-only-diff.mjs` → `OK — 3 source file(s) changed; every code token identical to origin/develop. Comments only.` No behavior change; the empty-catch census is unchanged.
- **Ratchet** — `error-policy-ratchet` reports no new fallback-slop in touched files.
- Real-LLM trajectory / UI / screenshots / audio: **N/A — comment-only annotation change, zero functional diff, machine-verified.**

Closes #12795