### PR TITLE
fix(#12274): deep fallback-slop sweep slice 0/1 — fail-fast over fabricated defaults

### DIFF
--- a/plugins/plugin-agent-skills/src/api/skill-discovery-helpers.test.ts
+++ b/plugins/plugin-agent-skills/src/api/skill-discovery-helpers.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for the skill preference/acknowledgment loaders, driven against a
+ * hand-built runtime stub (no real DB). Asserts the fast-fail contract: a
+ * genuinely-empty cache reads as `{}`, but a cache *read failure* propagates
+ * instead of being masked as "no preferences" — the callers read-modify-write
+ * these maps before saving them back, so a fabricated empty would wipe state.
+ */
+
+import type { AgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  loadSkillAcknowledgments,
+  loadSkillPreferences,
+} from "./skill-discovery-helpers";
+
+function runtimeWithCache(getCache: () => Promise<unknown>): AgentRuntime {
+  return { getCache: vi.fn(getCache) } as unknown as AgentRuntime;
+}
+
+describe("loadSkillPreferences", () => {
+  it("returns an empty map when no runtime is available", async () => {
+    await expect(loadSkillPreferences(null)).resolves.toEqual({});
+  });
+
+  it("returns an empty map when nothing has been persisted yet", async () => {
+    const runtime = runtimeWithCache(async () => undefined);
+    await expect(loadSkillPreferences(runtime)).resolves.toEqual({});
+  });
+
+  it("returns the persisted map when the cache read succeeds", async () => {
+    const runtime = runtimeWithCache(async () => ({ "skill-a": true }));
+    await expect(loadSkillPreferences(runtime)).resolves.toEqual({
+      "skill-a": true,
+    });
+  });
+
+  it("propagates a cache read failure instead of masking it as an empty map", async () => {
+    const dbError = new Error("cache backend down");
+    const runtime = runtimeWithCache(async () => {
+      throw dbError;
+    });
+    await expect(loadSkillPreferences(runtime)).rejects.toBe(dbError);
+  });
+});
+
+describe("loadSkillAcknowledgments", () => {
+  it("returns an empty map when no runtime is available", async () => {
+    await expect(loadSkillAcknowledgments(null)).resolves.toEqual({});
+  });
+
+  it("returns an empty map when nothing has been persisted yet", async () => {
+    const runtime = runtimeWithCache(async () => undefined);
+    await expect(loadSkillAcknowledgments(runtime)).resolves.toEqual({});
+  });
+
+  it("propagates a cache read failure instead of masking it as an empty map", async () => {
+    const dbError = new Error("cache backend down");
+    const runtime = runtimeWithCache(async () => {
+      throw dbError;
+    });
+    await expect(loadSkillAcknowledgments(runtime)).rejects.toBe(dbError);
+  });
+});

--- a/plugins/plugin-agent-skills/src/api/skill-discovery-helpers.ts
+++ b/plugins/plugin-agent-skills/src/api/skill-discovery-helpers.ts
@@ -37,21 +37,21 @@ function isAgentSkillsServiceLike(
 }
 
 /**
- * Load persisted skill preferences from the agent's database.
- * Returns an empty map when the runtime or database isn't available.
+ * Load persisted skill preferences from the agent's database. Returns an empty
+ * map when no runtime is available or nothing has been persisted yet; a cache
+ * read *failure* is reported and rethrown, never masked as "no preferences".
+ * Callers read-modify-write this map (`prefs[id] = x; save(prefs)`), so a
+ * fabricated empty map on a transient DB error would overwrite every other
+ * skill's saved preference — the failure must surface, not read as empty.
  */
 export async function loadSkillPreferences(
   runtime: AgentRuntime | null,
 ): Promise<SkillPreferencesMap> {
   if (!runtime) return {};
-  try {
-    const prefs = await runtime.getCache<SkillPreferencesMap>(
-      SKILL_PREFS_CACHE_KEY,
-    );
-    return prefs ?? {};
-  } catch {
-    return {};
-  }
+  const prefs = await runtime.getCache<SkillPreferencesMap>(
+    SKILL_PREFS_CACHE_KEY,
+  );
+  return prefs ?? {};
 }
 
 /**
@@ -81,17 +81,19 @@ type SkillAcknowledgmentMap = Record<
   { acknowledgedAt: string; findingCount: number }
 >;
 
+/**
+ * Load persisted skill scan acknowledgments. Same contract as
+ * {@link loadSkillPreferences}: an empty map means "none persisted yet"; a cache
+ * read failure propagates so a broken DB read is never merged over and saved
+ * back as an acknowledgment wipe.
+ */
 export async function loadSkillAcknowledgments(
   runtime: AgentRuntime | null,
 ): Promise<SkillAcknowledgmentMap> {
   if (!runtime) return {};
-  try {
-    const acks =
-      await runtime.getCache<SkillAcknowledgmentMap>(SKILL_ACK_CACHE_KEY);
-    return acks ?? {};
-  } catch {
-    return {};
-  }
+  const acks =
+    await runtime.getCache<SkillAcknowledgmentMap>(SKILL_ACK_CACHE_KEY);
+  return acks ?? {};
 }
 
 export async function saveSkillAcknowledgments(

--- a/plugins/plugin-agent-skills/src/api/skills-routes.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.ts
@@ -230,18 +230,18 @@ function shouldExposeBinanceSkillRecord(skill: {
 const SKILL_PREFS_CACHE_KEY = "eliza:skill-preferences";
 type SkillPreferencesMap = Record<string, boolean>;
 
+// An empty map means "none persisted yet" (the `?? {}` below); a cache read
+// *failure* propagates. Callers read-modify-write this map before saving it
+// back, so masking a transient DB error as `{}` would overwrite every other
+// skill's saved preference — the read failure must surface, not read as empty.
 async function loadSkillPreferences(
   runtime: AgentRuntime | null,
 ): Promise<SkillPreferencesMap> {
   if (!runtime) return {};
-  try {
-    const prefs = await runtime.getCache<SkillPreferencesMap>(
-      SKILL_PREFS_CACHE_KEY,
-    );
-    return prefs ?? {};
-  } catch {
-    return {};
-  }
+  const prefs = await runtime.getCache<SkillPreferencesMap>(
+    SKILL_PREFS_CACHE_KEY,
+  );
+  return prefs ?? {};
 }
 
 async function saveSkillPreferences(
@@ -268,17 +268,16 @@ type SkillAcknowledgmentMap = Record<
   { acknowledgedAt: string; findingCount: number }
 >;
 
+// Same contract as loadSkillPreferences: `{}` means "none acknowledged yet"; a
+// cache read failure propagates rather than being merged over and saved back as
+// an acknowledgment wipe.
 async function loadSkillAcknowledgments(
   runtime: AgentRuntime | null,
 ): Promise<SkillAcknowledgmentMap> {
   if (!runtime) return {};
-  try {
-    const acks =
-      await runtime.getCache<SkillAcknowledgmentMap>(SKILL_ACK_CACHE_KEY);
-    return acks ?? {};
-  } catch {
-    return {};
-  }
+  const acks =
+    await runtime.getCache<SkillAcknowledgmentMap>(SKILL_ACK_CACHE_KEY);
+  return acks ?? {};
 }
 
 async function saveSkillAcknowledgments(

--- a/plugins/plugin-browser/src/__tests__/browser-service.test.ts
+++ b/plugins/plugin-browser/src/__tests__/browser-service.test.ts
@@ -2,7 +2,7 @@
  * BrowserService tests for target registration, resolution, and dispatch behavior.
  */
 
-import { ElizaError } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BrowserService, type BrowserTarget } from "../browser-service.js";
 
@@ -68,6 +68,37 @@ describe("BrowserService target routing", () => {
     expect(result.value).toBe("bridge");
     expect(workspace.execute).toHaveBeenCalledTimes(1);
     expect(bridge.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("excludes an unpinned target whose availability check throws, still resolves a healthy one, and logs the exclusion", async () => {
+    const logSpy = vi
+      .spyOn(logger, "debug")
+      .mockImplementation(() => logger as never);
+    const service = new BrowserService();
+    const broken = createTarget({
+      id: "broken",
+      priority: 200,
+      availableError: new Error("probe boom"),
+    });
+    const workspace = createTarget({ id: "workspace", priority: 100 });
+    service.registerTarget(broken);
+    service.registerTarget(workspace);
+
+    // Automatic (unpinned) resolution must not throw: the broken candidate is
+    // skipped and the next healthy target is selected (designed failover).
+    const result = await service.execute({ subaction: "state" });
+    expect(result.value).toBe("workspace");
+    expect(broken.execute).not.toHaveBeenCalled();
+    // The exclusion is observable, not silently swallowed by an empty catch.
+    expect(
+      logSpy.mock.calls.some(
+        (call) =>
+          typeof call[0] === "string" &&
+          call[0].includes('"broken"') &&
+          call[0].includes("probe boom"),
+      ),
+    ).toBe(true);
+    logSpy.mockRestore();
   });
 
   it("does not fall back when the caller pins a target", async () => {

--- a/plugins/plugin-browser/src/browser-service.ts
+++ b/plugins/plugin-browser/src/browser-service.ts
@@ -233,8 +233,16 @@ export class BrowserService extends Service {
             target,
           });
         }
-      } catch {
-        // Ignore unhealthy targets during target resolution.
+      } catch (err) {
+        // error-policy:J4 failover scan — a candidate whose availability check
+        // throws is excluded so the other registered targets can still be
+        // selected (unlike the pinned-`preferredId` path, which throws). Log so
+        // a systemically broken target is observable instead of silently gone.
+        logger.debug(
+          `[BrowserService] target "${id}" excluded from resolution; availability check failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
       }
     }
 


### PR DESCRIPTION
## Deep fallback-slop sweep — app plugins B, slice 0/1 (#12274)

Residual **deep** sweep over the app-plugins-B slice (`plugin-{wallet,vision,music,agent-skills,browser,workflow,training}`) after the primary #12274 sweep already merged as #12825. This pass re-derived the full suspect list, converted the clear slop that survived, kept + annotated genuine J-categories, and deferred the ambiguous tail for a per-site judgment pass.

Scope per the parent convention (#12182 / foundation #12263): the **unambiguous** slop categories only — empty catch, fabricated-healthy-on-error, promise-swallow. Ambiguous `return null/[]/false` and `?? <lit>` defaults are explicitly **deferred** (they need per-site judgment; over-removing a legitimate not-found→empty is a bug).

### Per-category tally

| Category | Converted | Notes |
|---|---|---|
| Fabricated-healthy (`return {}` on read failure) | **4 sites** | agent-skills preference/acknowledgment loaders — DB read failure masked as "no data" (data-loss bug, see below). Fixed in the exported helpers **and** the duplicated local copies in `skills-routes.ts`. |
| Empty catch (`catch {}`) | **1 site** | browser-service target-resolution failover scan → kept as designed failover, annotated `// error-policy:J4`, now logs the exclusion. |
| Promise-swallow | 0 | Surviving `.catch(()=>{})` in the slice are J6 best-effort temp-file teardown / J3 parse-invalid — left for the annotation pass, not masking-a-failure. |
| Annotated justified (J1–J7) | 1 | `// error-policy:J4` on the browser failover scan. |

### The data-loss fix (fabricated-healthy)

`loadSkillPreferences` / `loadSkillAcknowledgments` returned `{}` when the cache **read** threw, conflating "DB read failed" with "nothing persisted yet". The callers read-modify-write these maps and save them back:

```ts
const prefs = await loadSkillPreferences(state.runtime); // threw → returned {}
prefs[skillId] = true;
await saveSkillPreferences(state.runtime, prefs);         // overwrites ALL other prefs
```

So a **transient** cache-read error silently wiped every other skill's saved preference. Now the read failure propagates to the route boundary (which surfaces it), while a genuinely-empty cache still returns `{}` via the existing `?? {}`. This is the parent's canonical "not loaded must never read as empty" rule.

### The empty-catch fix (browser-service)

The target-resolution scan swallowed an unhealthy candidate's `available()` error with a bare `catch {}`. This is legitimate failover — the other registered targets must still be selectable (unlike the pinned-`preferredId` path, which correctly throws `BROWSER_TARGET_UNAVAILABLE`). Kept the failover, annotated `// error-policy:J4`, and now `logger.debug`s the exclusion so a systemically broken target is observable instead of silently vanishing.

### Ratchet (diff-scoped empty-catch, touched files)

```
plugin-agent-skills/src/api/skill-discovery-helpers.ts: emptyCatch 2->2
plugin-agent-skills/src/api/skills-routes.ts:            emptyCatch 3->3
plugin-browser/src/browser-service.ts:                  emptyCatch 1->0   ← down
no new fallback-slop in touched files
```

Empty-catch count goes **down** (browser-service 1→0) or stays equal — never up. Remaining empty catches in the agent-skills files are pre-existing comment-only J3 parse sites left for the annotation pass.

### Tests

- **New** `plugin-agent-skills/src/api/skill-discovery-helpers.test.ts` — asserts a cache **read failure now throws** (would have resolved `{}` against the pre-change code), and that a genuinely-empty/absent cache still returns `{}`. 7 cases.
- `plugin-browser/src/__tests__/browser-service.test.ts` — new failover-scan case: a target whose `available()` throws is excluded, a healthy target still resolves, and the exclusion is logged.

```
plugin-agent-skills  test: 9 files, 42 passed
plugin-browser       test: 27 files, 148 passed
```

### Deferred (ambiguousLeft — not touched this pass)

The slice's large residual tail is genuine J-categories and judgment-heavy sites: URL/JSON/base58 parse-invalid → `null/false/[]` (J3), executable/model-file existence probes (`accessSync`/`fs.access` → false), provider health/availability degrades (J4), best-effort temp-file `unlink().catch(()=>{})` teardown (J6), and `?? <lit>` load defaults. Notably the PaddleOCR `describe()` → `{blocks:[]}`-on-error path is a coordinated J7 vision-loop / OCR-service-family decision (no runtime handle at the leaf; all sibling OCR services share the shape) — left for a dedicated pass rather than a risky partial conversion. These need per-site judgment and are the next wave, not clear slop.

### Evidence

- Backend behavior proven by the new unit tests driving the **real** helpers (real `getCache` throw → real propagation; no mock-swallow of the thing under test). Real-LLM trajectory / rendered-UI evidence: N/A — this is a server-side error-handling refactor with no new user-facing surface; the observable behavior is "a failed cache read becomes a 500 instead of a silent preference wipe", asserted by the tests.

Refs #12274

🤖 Generated with [Claude Code](https://claude.com/claude-code)
