### PR TITLE
fix(#12265): deep fallback-slop sweep slice 0/1 — providers + access fail-fast

### DIFF
--- a/packages/agent/src/api/views-registry.ts
+++ b/packages/agent/src/api/views-registry.ts
@@ -322,6 +322,9 @@ export async function registerPluginViews(
   if (runtime && registered.length > 0) {
     setImmediate(() => {
       for (const entry of registered) {
+        // error-policy:J5 indexView self-degrades (its own catch logs and falls
+        // back to keyword search); this only suppresses a stray rejection from a
+        // synchronous pre-embed throw so a background task cannot crash the loop.
         void viewSearchIndex.indexView(entry, runtime).catch(() => {});
       }
     });
@@ -421,6 +424,9 @@ export function registerBuiltinViews(runtime?: IAgentRuntime): void {
   if (runtime && registered.length > 0) {
     setImmediate(() => {
       for (const entry of registered) {
+        // error-policy:J5 indexView self-degrades (its own catch logs and falls
+        // back to keyword search); this only suppresses a stray rejection from a
+        // synchronous pre-embed throw so a background task cannot crash the loop.
         void viewSearchIndex.indexView(entry, runtime).catch(() => {});
       }
     });

--- a/packages/agent/src/providers/recent-conversations.test.ts
+++ b/packages/agent/src/providers/recent-conversations.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Error-path coverage for recentConversationsProvider (#12265): a recall failure
+ * must surface through runtime.reportError (feeding RECENT_ERRORS / owner
+ * escalation) while still degrading to empty context, never fabricating recent
+ * history. The provider is real; only the runtime collaborator (getRoom) is
+ * stubbed to throw a real error.
+ */
+
+import type { IAgentRuntime, Memory, State, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { recentConversationsProvider } from "./recent-conversations.ts";
+
+const ROOM_ID = "00000000-0000-0000-0000-0000000000c1" as UUID;
+const EMPTY_STATE: State = { values: {}, data: {}, text: "" };
+
+function message(): Memory {
+  return {
+    id: "00000000-0000-0000-0000-0000000000a1" as UUID,
+    entityId: "00000000-0000-0000-0000-0000000000e0" as UUID,
+    roomId: ROOM_ID,
+    content: { text: "hello there" },
+    createdAt: 2,
+  } as Memory;
+}
+
+describe("recentConversationsProvider fast-fail (#12265)", () => {
+  it("reports a recall failure and degrades to empty context, not fabricated history", async () => {
+    const reportError = vi.fn();
+    const runtime = {
+      getRoom: async () => {
+        throw new Error("room store unavailable");
+      },
+      reportError,
+    } as unknown as IAgentRuntime;
+
+    const result = await recentConversationsProvider.get(
+      runtime,
+      message(),
+      EMPTY_STATE,
+    );
+
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError.mock.calls[0]?.[0]).toBe("RecentConversationsProvider");
+    expect(reportError.mock.calls[0]?.[1]).toBeInstanceOf(Error);
+    // Degrade is an EMPTY context — never a fabricated recent-history line.
+    expect(result.text).toBe("");
+    expect(result.text).not.toContain("Recent");
+    expect(result.values).toEqual({});
+    expect(result.data).toEqual({});
+  });
+
+  it("returns empty context without reporting when there is no entity id", async () => {
+    const reportError = vi.fn();
+    const runtime = { reportError } as unknown as IAgentRuntime;
+
+    const result = await recentConversationsProvider.get(
+      runtime,
+      { ...message(), entityId: undefined } as unknown as Memory,
+      EMPTY_STATE,
+    );
+
+    // Legit absence (no entity) is not an error — it must not report.
+    expect(reportError).not.toHaveBeenCalled();
+    expect(result).toEqual({ text: "", values: {}, data: {} });
+  });
+});

--- a/packages/agent/src/providers/recent-conversations.ts
+++ b/packages/agent/src/providers/recent-conversations.ts
@@ -14,7 +14,6 @@ import type {
   State,
   UUID,
 } from "@elizaos/core";
-import { logger } from "@elizaos/core";
 import { getValidationKeywordTerms } from "@elizaos/shared";
 import {
   extractConversationMetadataFromRoom,
@@ -137,10 +136,14 @@ export const recentConversationsProvider: Provider = {
         },
       };
     } catch (error) {
-      logger.error(
-        "[recent-conversations] Error:",
-        error instanceof Error ? error.message : String(error),
-      );
+      // error-policy:J4 recall failure degrades to no recent-conversations text,
+      // but must be distinguishable from a legit-empty recall: reportError
+      // surfaces the broken pipeline to the agent via RECENT_ERRORS instead of
+      // it reading as "no recent history".
+      runtime.reportError("RecentConversationsProvider", error, {
+        entityId: message.entityId,
+        roomId: message.roomId,
+      });
       return { text: "", values: {}, data: {} };
     }
   },

--- a/packages/agent/src/providers/relevant-conversations.fastfail.test.ts
+++ b/packages/agent/src/providers/relevant-conversations.fastfail.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Error-path coverage for relevantConversationsProvider (#12265): a recall
+ * failure must surface through runtime.reportError (feeding RECENT_ERRORS /
+ * owner escalation) while still degrading to empty context, never fabricating
+ * relevant history. The throw is induced at the first recall call (getRoom),
+ * before any embed, so the provider is real and only the runtime collaborator is
+ * stubbed. Kept separate from relevant-conversations.test.ts so the fast-fail
+ * assertions do not depend on the createMockRuntime harness.
+ */
+
+import type { IAgentRuntime, Memory, State, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { relevantConversationsProvider } from "./relevant-conversations.ts";
+
+const ROOM_ID = "00000000-0000-0000-0000-0000000000c1" as UUID;
+const EMPTY_STATE: State = { values: {}, data: {}, text: "" };
+
+function message(): Memory {
+  return {
+    id: "00000000-0000-0000-0000-0000000000a1" as UUID,
+    entityId: "00000000-0000-0000-0000-0000000000e0" as UUID,
+    roomId: ROOM_ID,
+    content: { text: "what did we decide about the launch date" },
+    createdAt: 2,
+  } as Memory;
+}
+
+describe("relevantConversationsProvider fast-fail (#12265)", () => {
+  it("reports a recall failure and degrades to empty context, not fabricated history", async () => {
+    const reportError = vi.fn();
+    const runtime = {
+      getRoom: async () => {
+        throw new Error("room store unavailable");
+      },
+      reportError,
+    } as unknown as IAgentRuntime;
+
+    const result = await relevantConversationsProvider.get(
+      runtime,
+      message(),
+      EMPTY_STATE,
+    );
+
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError.mock.calls[0]?.[0]).toBe(
+      "RelevantConversationsProvider",
+    );
+    expect(reportError.mock.calls[0]?.[1]).toBeInstanceOf(Error);
+    // Degrade is an EMPTY context — never a fabricated relevant-history line.
+    expect(result.text).toBe("");
+    expect(result.text).not.toContain("Relevant past conversations:");
+    expect(result.values).toEqual({});
+  });
+
+  it("short messages short-circuit before recall and do not report", async () => {
+    const reportError = vi.fn();
+    const runtime = {
+      getRoom: async () => {
+        throw new Error("should not be reached");
+      },
+      reportError,
+    } as unknown as IAgentRuntime;
+
+    const result = await relevantConversationsProvider.get(
+      runtime,
+      { ...message(), content: { text: "hi" } } as Memory,
+      EMPTY_STATE,
+    );
+
+    // Legit short-circuit (too-short query) is not an error — must not report.
+    expect(reportError).not.toHaveBeenCalled();
+    expect(result).toEqual({ text: "", values: {}, data: {} });
+  });
+});

--- a/packages/agent/src/providers/relevant-conversations.ts
+++ b/packages/agent/src/providers/relevant-conversations.ts
@@ -16,7 +16,7 @@ import type {
   State,
   UUID,
 } from "@elizaos/core";
-import { embedRecallQuery, logger, stringToUuid } from "@elizaos/core";
+import { embedRecallQuery, stringToUuid } from "@elizaos/core";
 import { getValidationKeywordTerms } from "@elizaos/shared";
 import {
   extractConversationMetadataFromRoom,
@@ -170,6 +170,9 @@ export const relevantConversationsProvider: Provider = {
           try {
             roomCache.set(rid, await runtime.getRoom(rid));
           } catch {
+            // error-policy:J4 one room's source tag degrades to untagged; the
+            // outer catch reports a wholesale recall failure, this per-room miss
+            // is cosmetic and must not abort the whole provider.
             roomCache.set(rid, null);
           }
         }
@@ -204,10 +207,14 @@ export const relevantConversationsProvider: Provider = {
         },
       };
     } catch (error) {
-      logger.error(
-        "[relevant-conversations] Error:",
-        error instanceof Error ? error.message : String(error),
-      );
+      // error-policy:J4 recall failure degrades to no relevant-conversations
+      // text, but must be distinguishable from a legit-empty recall: reportError
+      // surfaces the broken pipeline to the agent via RECENT_ERRORS instead of
+      // it reading as "no relevant history".
+      runtime.reportError("RelevantConversationsProvider", error, {
+        entityId: message.entityId,
+        roomId: message.roomId,
+      });
       return { text: "", values: {}, data: {} };
     }
   },

--- a/packages/agent/src/security/access.test.ts
+++ b/packages/agent/src/security/access.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Fail-closed error-path coverage for hasPrivateAccess (#12265). A throw from
+ * the core private-access check is a broken role/world-resolution pipeline (a
+ * missing world returns null upstream, not a throw). The handler must stay
+ * fail-closed (deny) AND surface the failure via runtime.reportError so a
+ * silently-denying broken check becomes observable. The tests drive the real
+ * agent access wrapper and core role primitives with minimal typed runtime
+ * collaborators.
+ */
+
+import type { IAgentRuntime, Memory, Room, UUID, World } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { hasPrivateAccess } from "./access.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const ENTITY_ID = "00000000-0000-0000-0000-0000000000dd" as UUID;
+
+function runtimeWith(
+  reportError: () => void,
+  overrides: Partial<IAgentRuntime> = {},
+): IAgentRuntime {
+  return {
+    agentId: AGENT_ID,
+    getSetting: () => undefined,
+    reportError,
+    ...overrides,
+  } as unknown as IAgentRuntime;
+}
+
+function message(): Memory {
+  return {
+    id: "00000000-0000-0000-0000-0000000000cc" as UUID,
+    entityId: ENTITY_ID,
+    roomId: "00000000-0000-0000-0000-0000000000aa" as UUID,
+    content: { text: "x" },
+  } as Memory;
+}
+
+describe("hasPrivateAccess fail-closed reporting (#12265)", () => {
+  it("denies AND reports when the core private-access check throws", async () => {
+    const roleError = new Error("role resolution failed");
+    const reportError = vi.fn();
+
+    const granted = await hasPrivateAccess(
+      runtimeWith(reportError, {
+        getRoom: async () => {
+          throw roleError;
+        },
+      }),
+      message(),
+    );
+
+    // Fail closed: a broken check must never grant access.
+    expect(granted).toBe(false);
+    // But the broken pipeline is surfaced, not silently swallowed.
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError.mock.calls[0]?.[0]).toBe("Access.hasPrivateAccess");
+    expect(reportError.mock.calls[0]?.[1]).toBeInstanceOf(Error);
+  });
+
+  it("grants without reporting when the check succeeds", async () => {
+    const reportError = vi.fn();
+    const worldId = "00000000-0000-0000-0000-0000000000ee" as UUID;
+    const privateRoom: Room = {
+      id: message().roomId,
+      agentId: AGENT_ID,
+      source: "test",
+      type: "DM",
+      worldId,
+    };
+    const privateWorld: World = {
+      id: worldId,
+      agentId: AGENT_ID,
+      name: "private",
+      metadata: {
+        roles: { [ENTITY_ID]: "MEMBER" },
+      },
+    };
+
+    const granted = await hasPrivateAccess(
+      runtimeWith(reportError, {
+        getRoom: async () => privateRoom,
+        getWorld: async () => privateWorld,
+      }),
+      message(),
+    );
+
+    expect(granted).toBe(true);
+    expect(reportError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/security/access.ts
+++ b/packages/agent/src/security/access.ts
@@ -95,7 +95,14 @@ export async function hasPrivateAccess(
       context.message,
     );
     return access?.hasPrivateAccess === true;
-  } catch {
+  } catch (err) {
+    // error-policy:J4 fail closed — deny private access on a failed check, but
+    // surface it: a throw here is a broken role/world-resolution pipeline (a
+    // missing world already returns null upstream, not a throw), and a silently
+    // denied check would keep denying forever with no signal to fix it.
+    context.runtime.reportError("Access.hasPrivateAccess", err, {
+      entityId: context.message.entityId,
+    });
     return false;
   }
 }


### PR DESCRIPTION
## What

Deep re-sweep of the remaining fallback-slop in `packages/agent` (issue #12265, slice 0/1), after the headline files (`media-store.ts`, `page-scoped-context.ts`, boot empty catches) were handled by the already-merged #12766 / #12921. Empty-catch count in this slice is already **0**, so this pass targets the residual **log-and-return-empty catches that make a broken pipeline read as a legitimately-empty result**, plus a fail-closed security swallow. Uses the #12263 foundation (`runtime.reportError` → `ERROR_REPORTED` → `RECENT_ERRORS` provider).

## Per-category tally

| Category | Count | Sites |
|---|---|---|
| empty-catch converted | 0 | none remain in slice (prior PRs) |
| fabricated-default / log-and-return-empty converted → fail-fast | 3 | `providers/recent-conversations.ts`, `providers/relevant-conversations.ts`, `security/access.ts` |
| promise-swallow converted | 0 | (see "kept" — the two candidates self-degrade) |
| J-annotated (evaluated, kept) | 3 | `api/views-registry.ts` ×2 (J5), `providers/relevant-conversations.ts` inner room-lookup (J4) |
| ambiguous-deferred | — | bare `return null/[]/false` catches + `?? <lit>` where absence-vs-failure can't be cleanly told apart |

### Converted (behavior-changing, fail-fast)

- **`providers/recent-conversations.ts` + `relevant-conversations.ts`** — on a recall failure both providers returned the **identical** empty context (`{ text: "", values: {}, data: {} }`) as a legit-empty recall — the banned *"not loaded reads as empty"* conflation. Now `runtime.reportError(...)` surfaces the broken pipeline to the agent (RECENT_ERRORS / owner escalation) while the provider still degrades to empty rather than aborting the turn (`// error-policy:J4`). Removed the now-unused `logger` imports (`reportError` logs).
- **`security/access.ts` `hasPrivateAccess`** — a throw from the core private-access check was silently swallowed to `return false`. Fail-closed is correct (a missing world returns `null` upstream, not a throw — so a throw here is a *broken* role/world-resolution pipeline), but a silently-denying broken check would deny forever with no signal. Now reports via `runtime.reportError` and stays **fail-closed** (`// error-policy:J4`).

### Kept + annotated (not slop)

- **`api/views-registry.ts` ×2** — `void viewSearchIndex.indexView(entry, runtime).catch(() => {})`. `indexView` **self-degrades** (its own catch logs at debug and falls back to keyword search), so the call-site catch only suppresses a stray rejection from a synchronous pre-embed throw so a background `setImmediate` task cannot crash the loop → `// error-policy:J5`. Converting to `reportError` here would double-report a designed degrade — deliberately **not** converted.

### Deferred (this wave = clear-slop only)

Bare `return null/[]/false` catches (e.g. `network-policy.ts` IPv6 parse → J3, `update-checker.ts` net-fail → null, `whichSync` → null) and `?? <lit>` / `|| <lit>` defaults where legitimate-absence cannot be cleanly distinguished from masking-a-failure. These need per-site judgment.

## Ratchet — `bun run audit:error-policy-ratchet`

```
base origin/develop (511d1a0a84); 4 changed production source file(s)
  api/views-registry.ts:          emptyCatch 2->2, serverConsole 0->0
  providers/recent-conversations.ts:   emptyCatch 0->0, serverConsole 0->0
  providers/relevant-conversations.ts: emptyCatch 0->0, serverConsole 0->0
  security/access.ts:             emptyCatch 0->0, serverConsole 0->0
no new fallback-slop in touched files
```

emptyCatch in touched files: **2 → 2** (equal, never up; the views-registry `.catch(() => {})` pair is now J5-annotated).

## Tests — all green

6 new fast-fail assertions across 3 files, each asserting `reportError` fires on the **real** induced failure (stubbed collaborator throws a real error) AND that a legit-absence path does **not** report:

- `providers/recent-conversations.test.ts` (new) — 2 tests
- `providers/relevant-conversations.faildast.test.ts` (new) — 2 tests
- `security/access.test.ts` (new) — 2 tests

```
Test Files  3 passed (3)
     Tests  6 passed (6)
```

Typecheck: 0 errors in the 4 touched source files (remaining `packages/agent` typecheck errors are pre-existing trimmed-tree module-resolution noise: `@elizaos/auth`, `drizzle-orm`, etc. — unrelated).

## Evidence

- N/A — real-LLM trajectory / screenshots: this is a server-side error-handling refactor with no UI surface; the behavior change is "a swallowed failure now calls `runtime.reportError`", proven by the 6 fail-fast unit tests that drive the real provider/access code with a throwing collaborator (no mock stands in for the code under test).

Refs #12265 · parent #12182 · foundation #12263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
