### PR TITLE
fix(#12272): deep fallback-slop sweep slice 0/1 — connector config fail-closed + fabricated-default/empty-catch conversions

### DIFF
--- a/plugins/plugin-bluesky/__tests__/accounts.test.ts
+++ b/plugins/plugin-bluesky/__tests__/accounts.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for multi-account config resolution and the connector-account
  * provider, driven by an in-memory fake runtime (no network, no real SDK).
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { createBlueSkyConnectorAccountProvider } from "../connector-account-provider";
 import { BlueSkyService } from "../services/bluesky";
@@ -52,15 +52,26 @@ describe("BlueSky account config", () => {
 		expect(config.handle).toBe("support.example.com");
 	});
 
-	it("ignores malformed BLUESKY_ACCOUNTS and falls back to legacy default", () => {
+	it("fails closed for malformed BLUESKY_ACCOUNTS", () => {
 		const rt = runtime({
 			BLUESKY_ACCOUNTS: "{not json",
 			BLUESKY_HANDLE: "agent.example.com",
 			BLUESKY_PASSWORD: "app-password",
 		});
 
-		expect(listBlueSkyAccountIds(rt)).toEqual(["default"]);
-		expect(resolveDefaultBlueSkyAccountId(rt)).toBe("default");
+		expect(() => listBlueSkyAccountIds(rt)).toThrow(ElizaError);
+		try {
+			resolveDefaultBlueSkyAccountId(rt);
+			throw new Error("expected malformed BLUESKY_ACCOUNTS to throw");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe("BLUESKY_CONFIG_INVALID");
+			expect((error as ElizaError).context).toEqual({
+				setting: "BLUESKY_ACCOUNTS",
+			});
+			expect((error as ElizaError).severity).toBe("fatal");
+			expect((error as Error).cause).toBeInstanceOf(SyntaxError);
+		}
 	});
 
 	it("does not leak default env credentials into explicitly requested named accounts", () => {

--- a/plugins/plugin-bluesky/utils/config.ts
+++ b/plugins/plugin-bluesky/utils/config.ts
@@ -7,7 +7,7 @@
  * `resolveDefaultBlueSkyAccountId`) plus the per-setting typed getters
  * (intervals, limits, feature flags) used by the service and agent manager.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import {
 	BLUESKY_ACTION_INTERVAL,
 	BLUESKY_MAX_ACTIONS,
@@ -84,11 +84,13 @@ function parseAccountsJson(
 		return parsed && typeof parsed === "object"
 			? (parsed as Record<string, RawBlueSkyAccountConfig>)
 			: {};
-	} catch {
-		// error-policy:J3 malformed BLUESKY_ACCOUNTS JSON is untrusted config input; the
-		// multi-account blob contributes no entries while single-account env settings
-		// still govern — a corrupt blob must not crash account discovery (accounts.test.ts).
-		return {};
+	} catch (error) {
+		throw new ElizaError("BlueSky accounts config is not valid JSON.", {
+			code: "BLUESKY_CONFIG_INVALID",
+			cause: error,
+			context: { setting: "BLUESKY_ACCOUNTS" },
+			severity: "fatal",
+		});
 	}
 }
 

--- a/plugins/plugin-farcaster/__tests__/accounts.test.ts
+++ b/plugins/plugin-farcaster/__tests__/accounts.test.ts
@@ -3,7 +3,7 @@
  * `FARCASTER_ACCOUNTS` JSON path, and default-account selection — against a
  * fake runtime (vi mocks, no network).
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { FarcasterService } from "../services/FarcasterService";
 import {
@@ -57,13 +57,24 @@ describe("Farcaster account config", () => {
     expect(config.FARCASTER_FID).toBe(456);
   });
 
-  it("ignores malformed FARCASTER_ACCOUNTS JSON instead of crashing account discovery", () => {
+  it("fails closed for malformed FARCASTER_ACCOUNTS JSON", () => {
     const rt = runtime({
       FARCASTER_ACCOUNTS: "{not json",
     });
 
-    expect(listFarcasterAccountIds(rt)).toEqual(["default"]);
-    expect(resolveDefaultFarcasterAccountId(rt)).toBe("default");
+    expect(() => listFarcasterAccountIds(rt)).toThrow(ElizaError);
+    try {
+      resolveDefaultFarcasterAccountId(rt);
+      throw new Error("expected malformed FARCASTER_ACCOUNTS to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe("FARCASTER_CONFIG_INVALID");
+      expect((error as ElizaError).context).toEqual({
+        setting: "FARCASTER_ACCOUNTS",
+      });
+      expect((error as ElizaError).severity).toBe("fatal");
+      expect((error as Error).cause).toBeInstanceOf(SyntaxError);
+    }
   });
 
   it("does not leak legacy env credentials into named account validation", () => {

--- a/plugins/plugin-farcaster/utils/asyncqueue.ts
+++ b/plugins/plugin-farcaster/utils/asyncqueue.ts
@@ -42,6 +42,10 @@ export class AsyncQueue {
     try {
       await work();
     } catch {
+      // error-policy:J5 the queued closure built by `submit` already routes any
+      // rejection to the caller's promise via `reject(err)` and never re-throws,
+      // so this catch cannot fire in practice; it only guards the drain loop from
+      // a defensive standpoint. The real failure surfaces at the `submit()` caller.
     } finally {
       this.running--;
       void this.doNextWork();

--- a/plugins/plugin-farcaster/utils/config.ts
+++ b/plugins/plugin-farcaster/utils/config.ts
@@ -6,7 +6,12 @@
  * hand-roll account discovery; use `listFarcasterAccountIds`,
  * `normalizeFarcasterAccountId`, and `resolveDefaultFarcasterAccountId` here.
  */
-import { type IAgentRuntime, type ProcessEnvLike, parseBooleanFromText } from "@elizaos/core";
+import {
+  ElizaError,
+  type IAgentRuntime,
+  type ProcessEnvLike,
+  parseBooleanFromText,
+} from "@elizaos/core";
 import { z } from "zod";
 import {
   DEFAULT_CAST_INTERVAL_MAX,
@@ -72,11 +77,13 @@ function parseAccountsJson(runtime: IAgentRuntime): Record<string, RawFarcasterA
     return parsed && typeof parsed === "object"
       ? (parsed as Record<string, RawFarcasterAccountConfig>)
       : {};
-  } catch {
-    // error-policy:J3 malformed FARCASTER_ACCOUNTS JSON is untrusted config input; the
-    // multi-account blob contributes no entries while single-account env settings
-    // still govern — a corrupt blob must not crash account discovery (accounts.test.ts).
-    return {};
+  } catch (error) {
+    throw new ElizaError("Farcaster accounts config is not valid JSON.", {
+      code: "FARCASTER_CONFIG_INVALID",
+      cause: error,
+      context: { setting: "FARCASTER_ACCOUNTS" },
+      severity: "fatal",
+    });
   }
 }
 

--- a/plugins/plugin-matrix/src/__tests__/accounts.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/accounts.test.ts
@@ -2,7 +2,7 @@
  * Unit + property tests (fast-check) for Matrix multi-account resolution
  * (`accounts.ts`) against an in-memory `getSetting` stub — no homeserver.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import fc from "fast-check";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -25,7 +25,7 @@ function runtimeWithSettings(
 }
 
 describe("Matrix account settings", () => {
-  it("ignores malformed MATRIX_ACCOUNTS JSON and falls back to single-account env settings", () => {
+  it("fails closed for malformed MATRIX_ACCOUNTS JSON", () => {
     const runtime = runtimeWithSettings({
       MATRIX_ACCOUNTS: "{not-json",
       MATRIX_HOMESERVER: "https://matrix.example",
@@ -33,14 +33,19 @@ describe("Matrix account settings", () => {
       MATRIX_ACCESS_TOKEN: " token ",
     });
 
-    expect(listMatrixAccountIds(runtime)).toEqual([DEFAULT_MATRIX_ACCOUNT_ID]);
-    expect(resolveDefaultMatrixAccountId(runtime)).toBe(DEFAULT_MATRIX_ACCOUNT_ID);
-    expect(resolveMatrixAccountSettings(runtime)).toMatchObject({
-      accountId: DEFAULT_MATRIX_ACCOUNT_ID,
-      homeserver: "https://matrix.example",
-      userId: "@bot:example",
-      accessToken: "token",
-    });
+    expect(() => listMatrixAccountIds(runtime)).toThrow(ElizaError);
+    try {
+      resolveDefaultMatrixAccountId(runtime);
+      throw new Error("expected malformed MATRIX_ACCOUNTS to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe("MATRIX_CONFIG_INVALID");
+      expect((error as ElizaError).context).toEqual({
+        setting: "MATRIX_ACCOUNTS",
+      });
+      expect((error as ElizaError).severity).toBe("fatal");
+      expect((error as Error).cause).toBeInstanceOf(SyntaxError);
+    }
   });
 
   it("normalizes array account config IDs and ignores malformed entries", () => {

--- a/plugins/plugin-matrix/src/accounts.ts
+++ b/plugins/plugin-matrix/src/accounts.ts
@@ -4,7 +4,7 @@
  * `character.settings.matrix`, merging per field. Supplies the Matrix service
  * the homeserver, access token, and room list for each configured account.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import type { MatrixSettings } from "./types.js";
 
 export const DEFAULT_MATRIX_ACCOUNT_ID = "default";
@@ -46,11 +46,13 @@ function parseAccountsJson(runtime: IAgentRuntime): Record<string, MatrixAccount
     return parsed && typeof parsed === "object"
       ? (parsed as Record<string, MatrixAccountConfig>)
       : {};
-  } catch {
-    // error-policy:J3 malformed MATRIX_ACCOUNTS JSON is untrusted config input; the
-    // multi-account blob contributes no entries while single-account env settings
-    // still govern — a corrupt blob must not crash account discovery (accounts.test.ts).
-    return {};
+  } catch (error) {
+    throw new ElizaError("Matrix accounts config is not valid JSON.", {
+      code: "MATRIX_CONFIG_INVALID",
+      cause: error,
+      context: { setting: "MATRIX_ACCOUNTS" },
+      severity: "fatal",
+    });
   }
 }
 

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -976,7 +976,14 @@ export class MatrixService extends Service implements IMatrixService {
       logger.info(
         `Matrix cross-signing bootstrapped for ${state.settings.userId}; senders should now share megolm keys to this device.`
       );
-      await crypto.checkKeyBackupAndEnable().catch(() => {});
+      // Key-backup enable is a distinct best-effort step AFTER bootstrap already
+      // succeeded; a throw here must not reach the outer catch and mislabel the
+      // whole bootstrap as "skipped", but its failure must still be visible.
+      await crypto.checkKeyBackupAndEnable().catch((backupErr) => {
+        logger.warn(
+          `Matrix cross-signing bootstrapped for ${state.settings.userId} but key-backup enable failed (${backupErr instanceof Error ? backupErr.message : String(backupErr)}); megolm history backup is unavailable until this device re-runs backup setup.`
+        );
+      });
     } catch (err) {
       logger.warn(
         `Matrix cross-signing bootstrap skipped (${err instanceof Error ? err.message : String(err)}); cohort senders in exclude-insecure-devices mode may withhold keys until this device is verified once from an operator's Matrix client.`
@@ -1174,6 +1181,9 @@ export class MatrixService extends Service implements IMatrixService {
       }
       verifier.on(VerifierEvent.ShowSas, (callbacks: ShowSasCallbacks) => {
         logger.info(`Matrix auto-confirming SAS with ${other}`);
+        // error-policy:J5 confirm() rejection is observed by the awaited
+        // verifier.verify() below, whose failure is logged in the outer catch;
+        // this no-op guard only suppresses the unhandled-rejection warning.
         void callbacks.confirm().catch(() => {});
       });
       await verifier.verify();

--- a/plugins/plugin-nostr/src/__tests__/accounts.test.ts
+++ b/plugins/plugin-nostr/src/__tests__/accounts.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for Nostr multi-account resolution (`accounts.ts`) against an
  * in-memory `getSetting` stub — no relays, fully offline.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { resolveDefaultNostrAccountId, resolveNostrAccountSettings } from "../accounts.js";
 import { NostrService } from "../service.js";
@@ -40,6 +40,27 @@ describe("Nostr account config", () => {
     const settings = resolveNostrAccountSettings(rt);
     expect(settings.accountId).toBe("publishing");
     expect(settings.privateKey).toBe("b".repeat(64));
+  });
+
+  it("fails closed for malformed NOSTR_ACCOUNTS", () => {
+    const rt = runtime({
+      NOSTR_ACCOUNTS: "{not json",
+      NOSTR_PRIVATE_KEY: "a".repeat(64),
+    });
+
+    expect(() => resolveDefaultNostrAccountId(rt)).toThrow(ElizaError);
+    try {
+      resolveNostrAccountSettings(rt);
+      throw new Error("expected malformed NOSTR_ACCOUNTS to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe("NOSTR_CONFIG_INVALID");
+      expect((error as ElizaError).context).toEqual({
+        setting: "NOSTR_ACCOUNTS",
+      });
+      expect((error as ElizaError).severity).toBe("fatal");
+      expect((error as Error).cause).toBeInstanceOf(SyntaxError);
+    }
   });
 });
 

--- a/plugins/plugin-nostr/src/accounts.ts
+++ b/plugins/plugin-nostr/src/accounts.ts
@@ -6,7 +6,7 @@
  * start one relay pool and subscription set per configured account; the
  * normalized account id also keys connector target resolution.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import { DEFAULT_NOSTR_RELAYS, type NostrDmPolicy, type NostrSettings } from "./types.js";
 
 export const DEFAULT_NOSTR_ACCOUNT_ID = "default";
@@ -52,11 +52,13 @@ function parseAccountsJson(runtime: IAgentRuntime): Record<string, NostrAccountC
     return parsed && typeof parsed === "object"
       ? (parsed as Record<string, NostrAccountConfig>)
       : {};
-  } catch {
-    // error-policy:J3 malformed NOSTR_ACCOUNTS JSON is untrusted config input; the
-    // multi-account blob contributes no entries while single-account env settings
-    // still govern — a corrupt blob must not crash account discovery (accounts.test.ts).
-    return {};
+  } catch (error) {
+    throw new ElizaError("Nostr accounts config is not valid JSON.", {
+      code: "NOSTR_CONFIG_INVALID",
+      cause: error,
+      context: { setting: "NOSTR_ACCOUNTS" },
+      severity: "fatal",
+    });
   }
 }
 


### PR DESCRIPTION
## Deep fallback-slop sweep — connector plugins slice 0/1 (#12272)

Part of the connector-plugin fallback-slop sweep (#12272 -> parent #12182). Uses the #12263 foundation (`ElizaError`, `runtime.reportError`, diff-scoped `audit:error-policy-ratchet`) already on develop.

Slice: all 15 messaging/social connector plugins. Re-derived the full suspect-site list (39 non-test files matching empty-catch / `.catch(()=>{}|null|undefined)` / return-default catch). This wave converts the **unambiguous** slop categories and annotates genuine J-category keeps; the large body of ambiguous `return null/[]/false` parse-guards and `?? <lit>` defaults is left for the per-site judgment pass (see Deferred).

### Converted — fabricated-healthy config default -> fail-closed (4)

Malformed multi-account config JSON silently returned `{}`, booting the connector **configured-but-dead** (the owner never learns their `*_ACCOUNTS` blob is corrupt). Now fails closed exactly like `google-chat` (#12729):

| plugin | file | code |
|---|---|---|
| matrix | `src/accounts.ts` | `MATRIX_CONFIG_INVALID` |
| nostr | `src/accounts.ts` | `NOSTR_CONFIG_INVALID` |
| farcaster | `utils/config.ts` | `FARCASTER_CONFIG_INVALID` |
| bluesky | `utils/config.ts` | `BLUESKY_CONFIG_INVALID` |

Each throws `new ElizaError("<Connector> accounts config is not valid JSON.", { code, cause, context: { setting }, severity: "fatal" })`.

### Converted — promise-swallow hiding a real failure (1)

`plugin-matrix/src/service.ts` — `checkKeyBackupAndEnable().catch(() => {})` sat on the **post-bootstrap success path**; a swallow there hid key-backup failures while the outer catch would have mislabeled them as a "skipped bootstrap". Now `.catch((backupErr) => logger.warn(...))`, so the failure is visible and distinct.

### Converted — empty catch (1)

`plugin-farcaster/utils/asyncqueue.ts` drain-loop `catch {}` -> annotated (see below). Empty-catch count in touched files **1 -> 0**.

### Annotated — genuine J-category keeps

- `asyncqueue.ts` drain loop — **J5**: the closure `submit` enqueues already routes every rejection to the caller's promise via `reject(err)` and never re-throws, so this catch cannot fire; the real failure surfaces at the `submit()` caller.
- `matrix/service.ts` SAS `confirm().catch(() => {})` — **J5**: rejection is observed by the awaited `verifier.verify()` below, logged in the outer catch.

### Deferred (per-site judgment, not this wave)

The remaining suspect sites in this slice are legitimate, not slop:
- **J3 parse/validation guards** returning `null/[]/false` on untrusted input (nostr `normalizePubkey`/`isSafeRelayUrl`/`nip19.decode`, discord URL summarizers) — invalid-input signals, not masked failures.
- **J6 best-effort teardown** swallows (`client.stop/disconnect/destroy/close`, `request.cancel`, `fs.unlink(temp)`, 429 body-drain) — several already annotated on develop.
- **Lookup `.catch(() => null)`** on `fetch`/`getRoom`/`getMemoryById` where null is genuine absence/designed degrade.
- Bare `?? <lit>` / `|| <lit>` payload defaults.

Converting these would be over-removal (the sweep's explicit hazard: reconnect/backoff and designed degrade are J4/J5).

## Tests

Reconciled the 3 pre-existing malformed-config tests from `ignores malformed...` (asserting graceful `{}`) to **fail-closed `toThrow(ElizaError)`** assertions (code + context + `severity:"fatal"` + `cause instanceof SyntaxError`), and **added the missing nostr fail-closed test**.

Verification in this sparse-checkout worktree (connector SDK deps — `@atproto/api`, `@neynar/nodejs-sdk`, `matrix-js-sdk`, `nostr-tools` — are not installable here without materializing the whole workspace, so full plugin suites that import the SDK-backed service classes cannot boot; the config/accounts modules were exercised directly):

- `plugin-matrix/src/__tests__/accounts.test.ts` — **4 passed** (SDK-free, ran through the normal harness incl. the new fail-closed test).
- bluesky / farcaster / nostr config+accounts modules — **green** via isolated tests importing only the config module (nostr with `vi.mock("nostr-tools")`): each asserts the `ElizaError` throw on malformed input **and** that valid `*_ACCOUNTS` still parse.
- `bun run audit:error-policy-ratchet` — **no new fallback-slop in touched files**; empty-catch in touched files 1 -> 0.
- `biome check` on all 10 touched files — clean.

Evidence: N/A live-connector trajectory — this slice is config-parse/teardown error-policy only (no model/agent/prompt path changes); the fail-closed behavior is proven by the unit tests above.

Refs #12272

🤖 Generated with [Claude Code](https://claude.com/claude-code)
