### PR TITLE
fix(#12741): annotate 2 residual J3 parse-tolerant keeps (finish tooling slop sweep)

### DIFF
--- a/packages/plugin-remote-manifest/src/worker-runtime/envelope.ts
+++ b/packages/plugin-remote-manifest/src/worker-runtime/envelope.ts
@@ -113,8 +113,10 @@ export function createSubprocessChannel(): WorkerChannel {
           const message = JSON.parse(line) as RemotePluginWorkerMessage;
           for (const subscriber of subscribers) subscriber(message);
         } catch {
-          // Malformed line; ignore. The host treats malformed worker
-          // output as a hard error via the subprocess's exit-handler.
+          // error-policy:J3 untrusted-input sanitizing — a malformed worker
+          // stdout line is skipped here; the failure still surfaces because the
+          // host treats malformed worker output as a hard error via the
+          // subprocess's exit-handler.
         }
       }
       newlineIndex = buffer.indexOf("\n");

--- a/packages/scenario-runner/src/cerebras-judge.ts
+++ b/packages/scenario-runner/src/cerebras-judge.ts
@@ -141,7 +141,10 @@ export function tolerantJsonParse(
         return parsed as Record<string, unknown>;
       }
     } catch {
-      // try the next candidate
+      // error-policy:J3 untrusted-input sanitizing — LLM output is tried against
+      // several JSON-extraction candidates; a parse miss falls through to the
+      // next candidate, and an all-candidates-miss returns an explicit null
+      // (invalid signal) below, never a fabricated verdict.
     }
   }
   return null;


### PR DESCRIPTION
## Summary

Finishes the **#12741** tooling-packages fallback-slop sweep. The one real fabricated-success path (sub-agent `SessionRecorder` audit record) was fixed by #13139. A scope census then found **zero** remaining swallow slop — only two legitimate **J3 parse-tolerant** handlers that lacked the grep-able `// error-policy` annotation:

| Site | Verdict |
|---|---|
| `scenario-runner/src/cerebras-judge.ts` | J3 — tries several JSON-extraction candidates over untrusted LLM output; all-miss returns an explicit `null` (invalid signal), never a fabricated verdict |
| `plugin-remote-manifest/src/worker-runtime/envelope.ts` | J3 — skips a malformed worker stdout line; the failure still surfaces via the subprocess exit-handler |

With these annotated, every kept handler in the scope is triaged.

## Evidence

- **Comment-only** — `node scripts/assert-comment-only-diff.mjs` → `OK — 2 source file(s) changed; every code token identical to origin/develop. Comments only.` Zero functional diff.
- Real-LLM trajectory / UI / screenshots / audio: **N/A — comment-only annotation change, machine-verified.**

Closes #12741