### PR TITLE
test(core): exercise task drain source in dispose coverage

### DIFF
--- a/packages/core/src/utils/batch-queue/task-drain.test.ts
+++ b/packages/core/src/utils/batch-queue/task-drain.test.ts
@@ -7,7 +7,7 @@
 import { describe, expect, test, vi } from "vitest";
 import { createMockRuntime } from "../../testing/mock-runtime";
 import type { Task } from "../../types/task";
-import { TaskDrain } from "./task-drain";
+import { TaskDrain } from "./task-drain.ts";
 
 const AGENT_ID = "00000000-0000-0000-0000-000000000001";
 
@@ -107,9 +107,7 @@ describe("TaskDrain", () => {
 			reportError,
 			getTasksByName: async () => [],
 			createTask: vi.fn(async () => createdId),
-			deleteTask: vi.fn(async () => {
-				throw deleteError;
-			}),
+			deleteTask: vi.fn().mockRejectedValue(deleteError),
 		});
 
 		const drain = new TaskDrain(
@@ -124,10 +122,12 @@ describe("TaskDrain", () => {
 
 		await drain.start(runtime);
 		expect(drain.id).toBe(createdId);
+		expect(runtime.deleteTask).not.toHaveBeenCalled();
 
 		// dispose must complete (not reject) even though deleteTask fails, and the
 		// failure must be reported rather than silently swallowed.
 		await expect(drain.dispose(runtime)).resolves.toBeUndefined();
+		expect(runtime.deleteTask).toHaveBeenCalledTimes(1);
 		expect(runtime.deleteTask).toHaveBeenCalledWith(createdId);
 		expect(reportError).toHaveBeenCalledTimes(1);
 		expect(reportError).toHaveBeenCalledWith("TaskDrain.dispose", deleteError, {


### PR DESCRIPTION
## Summary
- make the new TaskDrain dispose regression test import the TypeScript source explicitly so it does not resolve the stale side-by-side JS emit
- tighten the test around the dispose call count and rejected deleteTask mock

Refs #12264
Follow-up to #13262.

## Verification
- TMPDIR=/private/tmp/codex-test-tmp bun run --cwd packages/core test -- src/utils/batch-queue/task-drain.test.ts
- TMPDIR=/private/tmp/codex-test-tmp bunx biome check packages/core/src/utils/batch-queue/task-drain.test.ts
- TMPDIR=/private/tmp/codex-test-tmp bun run audit:error-policy-ratchet
- git diff --check origin/develop...HEAD