### PR TITLE
fix(#12275): deep fallback-slop sweep slice 1/2 — empty-catch/promise-swallow annotations

### DIFF
--- a/packages/scripts/capability-router-fixture-conformance-smoke.ts
+++ b/packages/scripts/capability-router-fixture-conformance-smoke.ts
@@ -154,6 +154,7 @@ try {
 } finally {
   if (child && !child.killed) {
     child.kill("SIGTERM");
+    // error-policy:J6 best-effort wait for child exit during cleanup
     await once(child, "exit").catch(() => undefined);
   }
   if (workspace) {

--- a/packages/scripts/cloud/admin/dev/pglite-server.ts
+++ b/packages/scripts/cloud/admin/dev/pglite-server.ts
@@ -70,6 +70,7 @@ console.log(
 
 async function shutdown(signal: string) {
   console.log(`${tag} ${signal} — closing server`);
+  // error-policy:J6 best-effort teardown on shutdown signal; process exits regardless
   await server.stop().catch(() => {});
   await db.close().catch(() => {});
   process.exit(0);

--- a/packages/scripts/cloud/admin/onboard-docker-node.ts
+++ b/packages/scripts/cloud/admin/onboard-docker-node.ts
@@ -318,6 +318,7 @@ async function main(): Promise<void> {
       summary.push(`docker_nodes row created (${args.nodeId})`);
     }
   } finally {
+    // error-policy:J6 best-effort SSH teardown; the onboarding result already stands
     await ssh.disconnect().catch(() => {});
   }
 

--- a/packages/scripts/cloud/admin/typecheck-split.ts
+++ b/packages/scripts/cloud/admin/typecheck-split.ts
@@ -200,6 +200,7 @@ async function checkDirectory(directory: string): Promise<CheckResult> {
     return { directory, success: false, output, duration };
   } finally {
     if (tempConfigPath) {
+      // error-policy:J6 best-effort temp-file cleanup; result already computed
       await unlink(tempConfigPath).catch(() => {});
     }
   }

--- a/packages/scripts/cloud/eliza1/dashboard-alerts.ts
+++ b/packages/scripts/cloud/eliza1/dashboard-alerts.ts
@@ -267,6 +267,8 @@ async function verifyDashboardRender(dashboardUrl?: string) {
       waitUntil: "networkidle",
       timeout: 60_000,
     });
+    // error-policy:J4 best-effort UI navigation; the actual render state is measured
+    // by the .count() assertions below, so a missing tab/alert is observed there.
     await page
       .locator(
         'button[value="projections"], [role="tab"]:has-text("Projections")',

--- a/packages/test/cloud-e2e/src/helpers/provisioning.ts
+++ b/packages/test/cloud-e2e/src/helpers/provisioning.ts
@@ -201,7 +201,9 @@ export async function agentLifecycleAction(
   let body: unknown = text;
   try {
     body = JSON.parse(text);
-  } catch {}
+  } catch {
+    // error-policy:J3 non-JSON response body preserved as raw text; status still asserted below
+  }
   expect(
     acceptable,
     `agent ${action} returned ${res.status}: ${text}`,
@@ -402,7 +404,9 @@ export async function getSandboxState(
   let body: unknown = text;
   try {
     body = JSON.parse(text);
-  } catch {}
+  } catch {
+    // error-policy:J3 non-JSON response body preserved as raw text; status still asserted below
+  }
   return { status: res.status, body };
 }
 

--- a/packages/test/scenarios/lifeops.inbox-triage/inbox-triage.draft-respects-tone-prefs.scenario.ts
+++ b/packages/test/scenarios/lifeops.inbox-triage/inbox-triage.draft-respects-tone-prefs.scenario.ts
@@ -111,6 +111,8 @@ export default scenario({
              ${sqlQuote(now)}
            )
            ON CONFLICT DO NOTHING`,
+          // error-policy:J5 best-effort seed; a genuinely missing row fails the
+          // scenario's downstream tone assertion loudly, so the reject is observed there.
         ).catch(() => undefined);
         await executeRawSql(
           runtime,

--- a/packages/test/scenarios/lifeops.inbox-triage/inbox-triage.imap-only-account-degraded.scenario.ts
+++ b/packages/test/scenarios/lifeops.inbox-triage/inbox-triage.imap-only-account-degraded.scenario.ts
@@ -123,6 +123,8 @@ export default scenario({
              ${sqlQuote(now)}
            )
            ON CONFLICT DO NOTHING`,
+          // error-policy:J5 best-effort seed; a genuinely missing row fails the
+          // scenario's downstream assertions loudly, so the reject is observed there.
         ).catch(() => undefined);
         for (let i = 0; i < 3; i++) {
           await executeRawSql(

--- a/packages/test/scenarios/linear/search-issues.scenario.ts
+++ b/packages/test/scenarios/linear/search-issues.scenario.ts
@@ -68,7 +68,9 @@ export default scenario({
             let query = "";
             try {
               query = JSON.parse(String(init?.body ?? "{}")).query ?? "";
-            } catch {}
+            } catch {
+              // error-policy:J3 untrusted request body; unparseable -> empty query (routes to default mock reply)
+            }
             linearMockQueries.push(query);
             const data: Record<string, unknown> = {};
             if (/issues/i.test(query)) {

--- a/plugins/plugin-app-control/src/actions/background.ts
+++ b/plugins/plugin-app-control/src/actions/background.ts
@@ -445,6 +445,7 @@ async function defaultGenerateImage(prompt: string): Promise<string> {
 			signal: AbortSignal.timeout(120_000),
 		},
 	);
+	// error-policy:J3 unparseable body -> null, then fast-fails below with a clear message
 	const data = (await resp.json().catch(() => null)) as {
 		url?: string;
 		error?: string;

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -1643,6 +1643,7 @@ async function completeSplitTargetsWithCurrentView({
 	placement?: "left" | "right" | "top" | "bottom";
 }): Promise<ViewSummary[]> {
 	if (targets.length !== 1) return targets;
+	// error-policy:J4 current-view read over loopback; unreachable -> null -> keep given targets
 	const currentView = await client.getCurrentView().catch(() => null);
 	const currentId = currentView?.viewId;
 	if (!currentId || currentId === targets[0].id) return targets;
@@ -1666,6 +1667,7 @@ async function completeSplitTargetsFromCurrentLayout({
 	views: readonly ViewSummary[];
 	preferCurrentLayout?: boolean;
 }): Promise<ViewSummary[]> {
+	// error-policy:J4 current-view read over loopback; unreachable -> null -> no layout completion
 	const currentView = await client.getCurrentView().catch(() => null);
 	const currentLayoutIds = currentView?.views ?? [];
 	const byId = new Map(views.map((view) => [view.id, view]));

--- a/plugins/plugin-contacts/src/components/ContactsAppView.tsx
+++ b/plugins/plugin-contacts/src/components/ContactsAppView.tsx
@@ -142,6 +142,7 @@ export function ContactsAppView({ exitToApps, t }: OverlayAppContext) {
       // Contacts view opens (idempotent — already-granted returns granted with
       // no prompt). Nothing requests this at app launch. Tolerates older bridges
       // without the request path by falling through to listContacts.
+      // error-policy:J4 older-bridge compat degrade; null -> fall through to listContacts (which surfaces a real error)
       const status = await Contacts.requestPermissions().catch(() => null);
       if (status && status.contacts !== "granted") {
         setContacts([]);

--- a/plugins/plugin-meetings/src/platforms/msteams/strategies.ts
+++ b/plugins/plugin-meetings/src/platforms/msteams/strategies.ts
@@ -3,6 +3,13 @@
  * caption-driven per-speaker capture, removal monitoring, and leave.
  * Ported from Vexa (services/vexa-bot/core/src/platforms/msteams/*,
  * Apache-2.0) onto the shared meeting-flow strategy contract.
+ *
+ * error-policy:J4 — the `.catch(() => {})` / `.catch(() => null)` guards on
+ * `page.locator(...).click()`/`waitFor()`/`getAttribute()` are designed
+ * best-effort UI automation against a Teams page whose optional controls vary
+ * per build. A missing optional control is an expected degrade, not a failure;
+ * the join outcome is decided by the presence/admission checks and the returned
+ * `MeetingEndReason`, not by any single click succeeding.
  */
 
 import { logger } from "@elizaos/core";

--- a/plugins/plugin-meetings/src/platforms/zoom/strategies.ts
+++ b/plugins/plugin-meetings/src/platforms/zoom/strategies.ts
@@ -6,6 +6,13 @@
  * attribution, removal monitoring, and leave. Ported from Vexa
  * (services/vexa-bot/core/src/platforms/zoom/web/*, Apache-2.0). No native
  * Zoom SDK.
+ *
+ * error-policy:J4 — the many `.catch(() => {})` / `.catch(() => null)` guards on
+ * `page.locator(...).click()`/`waitFor()`/`getAttribute()` are designed
+ * best-effort UI automation against a page whose exact controls vary per Zoom
+ * build/AB-test. A missing optional control is an expected degrade, not a
+ * failure; the join outcome is decided by the presence checks and the
+ * `MeetingEndReason` the strategy returns, not by any single click succeeding.
  */
 
 import { logger } from "@elizaos/core";

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsView.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsView.tsx
@@ -308,6 +308,8 @@ export function RelationshipsView(
                 },
           );
         })
+        // error-policy:J4 background poll refresh; a transient failure keeps the
+        // last-good render (the initial load owns the error state), so it is not swallowed silently.
         .catch(() => {});
     }, RELATIONSHIPS_POLL_INTERVAL_MS);
     return () => clearInterval(id);

--- a/plugins/plugin-xr/simulator/src/emulator.ts
+++ b/plugins/plugin-xr/simulator/src/emulator.ts
@@ -187,6 +187,8 @@ async function dispatchGuarded(
   params: Record<string, unknown>,
 ): Promise<void> {
   await Promise.race([
+    // error-policy:J5 best-effort simulator input; a rejected dispatch is raced
+    // against the 1s timeout guard so it can never hang the test.
     xrDevice.remote.dispatch(method, params).catch(() => undefined),
     new Promise((resolve) => setTimeout(resolve, 1000)),
   ]);


### PR DESCRIPTION
## Deep fallback-slop sweep — long tail (#12275), slice 1 of 2

Part of #12182 / #12275 (long-tail batch). This is the **odd-indexed half** of the
suspect-file list (2-way disjoint split with slice 2/2). Behavior-changing work,
run against the foundation on develop (#12263: `ElizaError`,
`runtime.reportError`, `ERROR_REPORTED`, diff-scoped `audit:error-policy-ratchet`).

### Disjointness — slice mechanics

Suspect files were derived mechanically over the slice roots present in this
checkout (union of `rg -l` for empty-catch, `.catch(()=>{}|null|undefined)`, and
return-default catches; non-test `.ts/.tsx`; sorted `-u`). This slice handles the
files at **0-based index `% 2 == 1`**; slice 2/2 handles `% 2 == 0`. File sets are
disjoint.

Slice roots on disk (many #12275 members are submodule/absent here):
`packages/{contracts,elizaos,registry,scenario-runner,scripts,test,tui}`,
`plugins/{plugin-app-control,plugin-calendar,plugin-commands,plugin-contacts,plugin-facewear,plugin-finances,plugin-form,plugin-inbox,plugin-meetings,plugin-relationships,plugin-scheduling,plugin-todos,plugin-xr}`.

### What this slice actually contained

After reading every suspect site, this odd-indexed half is **well-maintained**:
the only unambiguous slop category present is **empty catches (3 sites)** — and
all three are genuine **J3 parse-guards** (untrusted input → preserved raw value
/ explicit default, never a fabricated success). There were **no
fabricated-healthy-on-error defaults** and **no promise-swallows on
operations-that-matter** — every `.catch(() => …)` in the slice is a designed
J-category degrade (best-effort UI automation, teardown, existence/availability
probe, or parse). Per the rubric's **no-over-removal** rule these are annotated,
not removed.

### Per-category tally

| category | count | disposition |
|---|---|---|
| empty catch → **annotated J3** | 3 | untrusted-parse guards (mock request body; non-JSON HTTP response kept as raw text) |
| fabricated-default → converted | 0 | none found in this slice |
| promise-swallow → converted (matters) | 0 | none found; all are J-category |
| promise-swallow → **annotated J4/J5/J6** | 15 | teardown (J6), best-effort playwright UI (J4, per-file header on `meetings/{zoom,msteams}`), best-effort sim input (J5), best-effort seed (J5, observed by downstream scenario assert), current-view/permission degrade (J4), parse→fast-fail (J3) |
| **total `// error-policy:J<N>` tags added** | **18** | across 16 files |
| return-default `catch { return null/[]/false/{} }` | 25 | **deferred** — legitimate-absence vs masking is judgment-heavy per site (this wave = clear-slop categories only) |

### Why the deferred return-default catches are not touched here

They are legitimate-absence / parse guards, e.g. `parseCalendarJsonRecord`,
`judge.parseJudgeJson`, `isLoopbackUrl`, `even-bridge.normalizeJsonData`,
`x11-input.isAvailable`, `openclaw-reader` fs probes (documented DETECT+WARN),
`app-verification.readProjectPackage` (corrupt package.json is already surfaced
downstream by the typecheck/build checks). Cleanly separating "masking a failure"
from "legitimate absence" needs per-site judgment + a real test each; that is the
next wave, not this clear-slop pass.

### Ratchet + verification

- `bun run audit:error-policy-ratchet` → **green** ("no new fallback-slop in
  touched files"). Empty-catch count in touched files: **3 → 3** (equal; all now
  carry a grep-able `// error-policy:J3` tag — the AST-based ratchet counts a
  comment-annotated catch as empty, so this is documented-and-equal, never up).
- **All 16 changes are comment-only.** `node scripts/assert-comment-only-diff.mjs`
  → *"every code token identical to origin/develop. Comments only."* Because no
  code token changed, existing suites and typecheck for every touched package are
  unaffected by construction — the runtime behavior is byte-identical to develop.

### Evidence

- Ratchet output: green (above).
- Comment-only proof: `assert-comment-only-diff` green (above).
- Real-LLM trajectory / screenshots / device capture: **N/A** — comment-only
  documentation pass, zero runtime behavior change.

Refs #12275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
