### PR TITLE
fix(#12799): surface AVAILABLE_AGENTS framework-probe failures instead of silent absence

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts
@@ -7,17 +7,20 @@ import { describe, expect, it, vi } from "vitest";
 // Control the framework-state probe so we can drive its failure path
 // deterministically without touching the filesystem / env discovery it does.
 const getTaskAgentFrameworkStateMock = vi.fn();
-vi.mock("../../src/services/task-agent-frameworks.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<
-      typeof import("../../src/services/task-agent-frameworks.js")
-    >();
-  return {
-    ...actual,
-    getTaskAgentFrameworkState: (...args: unknown[]) =>
-      getTaskAgentFrameworkStateMock(...args),
-  };
-});
+vi.mock(
+  "../../src/services/task-agent-frameworks.js",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../src/services/task-agent-frameworks.js")
+      >();
+    return {
+      ...actual,
+      getTaskAgentFrameworkState: (...args: unknown[]) =>
+        getTaskAgentFrameworkStateMock(...args),
+    };
+  },
+);
 
 import { availableAgentsProvider } from "../../src/providers/available-agents.js";
 import {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts
@@ -2,7 +2,23 @@
  * Verifies availableAgentsProvider.
  * Deterministic unit test of pure helpers; no runtime, no live model.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// Control the framework-state probe so we can drive its failure path
+// deterministically without touching the filesystem / env discovery it does.
+const getTaskAgentFrameworkStateMock = vi.fn();
+vi.mock("../../src/services/task-agent-frameworks.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../../src/services/task-agent-frameworks.js")
+    >();
+  return {
+    ...actual,
+    getTaskAgentFrameworkState: (...args: unknown[]) =>
+      getTaskAgentFrameworkStateMock(...args),
+  };
+});
+
 import { availableAgentsProvider } from "../../src/providers/available-agents.js";
 import {
   memory,
@@ -11,6 +27,10 @@ import {
   session,
   state,
 } from "../../src/test-utils/action-test-utils.js";
+
+// Default: an empty, healthy framework state (probe succeeded, nothing extra
+// installed) so the pre-existing behavioural assertions below are unaffected.
+getTaskAgentFrameworkStateMock.mockResolvedValue({ frameworks: [] });
 
 describe("availableAgentsProvider", () => {
   it("returns service unavailable data", async () => {
@@ -46,6 +66,47 @@ describe("availableAgentsProvider", () => {
         workdir: "/tmp/acp",
       },
     ]);
+  });
+
+  it("surfaces a thrown framework probe as a visible degrade instead of silent absence", async () => {
+    // A framework probe THROW = broken backend, not "opencode absent".
+    // Swallowing it into a healthy-looking null (old `.catch(() => null)`)
+    // let the planner read the same slate as genuine absence and silently
+    // drop opencode with no signal (#12273 healthy-empty-from-catch).
+    const probeError = new Error("framework discovery filesystem walk failed");
+    getTaskAgentFrameworkStateMock.mockRejectedValueOnce(probeError);
+    const reportError = vi.fn();
+    const runtime = runtimeWith(serviceMock());
+    (runtime as unknown as { reportError: unknown }).reportError = reportError;
+
+    const result = await availableAgentsProvider.get(runtime, memory(), state);
+
+    // Failure is observable to the RECENT_ERRORS provider / developer, not
+    // swallowed.
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError.mock.calls[0]?.[0]).toBe(
+      "AgentOrchestrator.AVAILABLE_AGENTS",
+    );
+    expect(reportError.mock.calls[0]?.[1]).toBe(probeError);
+    // The context is flagged degraded so a probe crash is distinct from a
+    // healthy "nothing extra installed" state.
+    expect(result.data?.frameworkProbeFailed).toBe(true);
+    // The planner sees the degrade in-band, not a clean slate.
+    expect(result.text).toContain("framework probe unavailable");
+    // Still returns a usable result (no crash); adapter inventory + sessions
+    // from the service side are unaffected.
+    expect(result.data?.serviceAvailable).toBe(true);
+  });
+
+  it("does not flag degraded when the framework probe succeeds", async () => {
+    getTaskAgentFrameworkStateMock.mockResolvedValueOnce({ frameworks: [] });
+    const result = await availableAgentsProvider.get(
+      runtimeWith(serviceMock()),
+      memory(),
+      state,
+    );
+    expect(result.data?.frameworkProbeFailed).toBe(false);
+    expect(result.text).not.toContain("framework probe unavailable");
   });
 
   it("caps rendered sessions while keeping all structured session data", async () => {

--- a/plugins/plugin-agent-orchestrator/src/providers/available-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/available-agents.ts
@@ -10,9 +10,13 @@ import {
   getAcpService,
   labelFor,
   listSessionsWithin,
+  reportProviderFetchFailure,
   shortId,
 } from "../actions/common.js";
-import { getTaskAgentFrameworkState } from "../services/task-agent-frameworks.js";
+import {
+  getTaskAgentFrameworkState,
+  type TaskAgentFrameworkState,
+} from "../services/task-agent-frameworks.js";
 import {
   type SessionInfo,
   TERMINAL_SESSION_STATUSES,
@@ -59,20 +63,48 @@ export const availableAgentsProvider: Provider = {
       };
     }
 
+    // opencode is wired through the shell adapter (not in
+    // `coding-agent-adapters`'s registry), so `checkAvailableAgents`
+    // misses it. Query the framework-state directly so the planner sees
+    // opencode in its action context when authReady — otherwise the
+    // model reads "no compatible agent available" and refuses to spawn.
+    //
+    // A THROWN framework probe is a broken backend, NOT "opencode absent":
+    // swallowing it into `null` renders the same as a clean "opencode not
+    // installed" slate, so the planner can't distinguish a real probe crash
+    // from genuine absence and silently drops opencode from its options with
+    // no signal (#12273 healthy-empty-from-catch). Surface it — warn +
+    // reportError via reportProviderFetchFailure — and flag the context
+    // degraded so the failure is visible instead of masquerading as absence.
+    let frameworkProbeFailed = false;
     const [agents, sessions, frameworkState] = await Promise.all([
       service.checkAvailableAgents?.() ??
         service.getAvailableAgents?.() ??
         Promise.resolve([]),
       listSessionsWithin(service, 2000),
-      // opencode is wired through the shell adapter (not in
-      // `coding-agent-adapters`'s registry), so `checkAvailableAgents`
-      // misses it. Query the framework-state directly so the planner sees
-      // opencode in its action context when authReady — otherwise the
-      // model reads "no compatible agent available" and refuses to spawn.
-      getTaskAgentFrameworkState(runtime).catch(() => null),
+      getTaskAgentFrameworkState(runtime).catch(
+        (error): TaskAgentFrameworkState | null => {
+          // error-policy:J7 framework probe threw — backend down, not
+          // "opencode absent". Surface it + degrade instead of a silent null.
+          reportProviderFetchFailure(
+            runtime,
+            "AVAILABLE_AGENTS",
+            "getTaskAgentFrameworkState",
+            error,
+          );
+          frameworkProbeFailed = true;
+          return null;
+        },
+      ),
     ]);
 
     const lines = ["# acpx task agents"];
+    if (frameworkProbeFailed) {
+      lines.push(
+        "",
+        "> framework probe unavailable — adapter inventory below may be incomplete (a shell-adapter backend such as opencode could be installed but undetected). This is a probe failure, not confirmed absence.",
+      );
+    }
     const opencodeFramework = frameworkState?.frameworks.find(
       (framework) => framework.id === "opencode",
     );
@@ -138,6 +170,7 @@ export const availableAgentsProvider: Provider = {
           workdir: session.workdir,
         })),
         serviceAvailable: true,
+        frameworkProbeFailed,
       },
     };
   },


### PR DESCRIPTION
## Problem (#12799 / #12273 fallback-slop, app plugins A)

`availableAgentsProvider` (`plugins/plugin-agent-orchestrator/src/providers/available-agents.ts`) queried `getTaskAgentFrameworkState(runtime)` with a bare `.catch(() => null)`.

A **thrown** framework probe — a broken ACP/shell backend or a crashed filesystem/env discovery walk — was swallowed into the **same `null`** that a healthy "nothing extra installed" state also produces. So the planner could not distinguish a probe crash from genuine absence:

- opencode (wired through the shell adapter, invisible to `checkAvailableAgents`) was silently dropped from the action context;
- the model then reads *"no compatible agent available"* and refuses to spawn, with **no signal** that anything actually failed.

That is a textbook #12273 healthy-empty-from-catch: a swallowed backend failure that disables planner self-recovery.

## Fix

On a thrown probe:
- report it observably via the existing `reportProviderFetchFailure` helper (`logger.warn` + `runtime.reportError` → `RECENT_ERRORS` provider / owner escalation), annotated `// error-policy:J7`;
- flag the context **degraded**: a visible in-band `> framework probe unavailable …` notice in the provider text **and** `frameworkProbeFailed` in `data`, so an unavailable-backend state is distinct from a designed-absent one.

The non-throwing `null` fallthrough is kept so the render still succeeds (fails soft on the *display*, but the failure is now surfaced, not masqueraded as absence).

## Tests / evidence

Added 2 error-path cases to `__tests__/unit/available-agents.test.ts`:
- **rejected probe** → asserts `reportError` fires with scope `AgentOrchestrator.AVAILABLE_AGENTS` + the original error, `data.frameworkProbeFailed === true`, the degrade notice renders, and the provider still returns a usable result;
- **successful probe** → does **not** flag degraded and emits no notice.

- `available-agents.test.ts`: **5/5 green** (3 existing + 2 new).
- `plugin-agent-orchestrator` `tsgo --noEmit`: **clean, 0 errors**.
- `codex review --uncommitted`: **clean — "I did not find a discrete introduced bug worth flagging."**

Unrelated pre-existing suite failures on this box (credential-proxy env, loopback lease mint, 20-60s `verify-*` timeout suites) are network/timeout-dependent and touch none of the changed paths.

## Scope note

Non-overlapping with the prior #12799 slices — #13130 (shell-history provider), #13250 (coding-context provider), #13239 (coding-tools + shell action layer). This is the last orchestrator provider still swallowing the framework probe.

-- [sol-orch]