### PR TITLE
fix(#12746): tunnel stop fails closed instead of faking teardown of a live tunnel

### DIFF
--- a/plugins/plugin-tunnel/src/__tests__/unit/local-tunnel-service-stop.test.ts
+++ b/plugins/plugin-tunnel/src/__tests__/unit/local-tunnel-service-stop.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Failure-path tests for LocalTunnelService.stopTunnel().
+ *
+ * Regression cover for #12746 (#12275-H): a failed `tailscale serve/funnel
+ * reset` MUST NOT fabricate a clean teardown. The public tunnel is still
+ * exposed on the tailnet, so stopTunnel() has to fail closed — throw, keep the
+ * service active, and never log "tunnel stopped". Isolated in its own file so
+ * the `node:child_process` module mock does not leak into the sibling suite.
+ */
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { IAgentRuntime } from '@elizaos/core';
+
+type SpawnScript = (cmd: string, args: string[]) => { code: number | null; stderr: string };
+
+// Default: every spawned command succeeds. Individual tests override to
+// simulate a failing `serve reset`.
+let spawnScript: SpawnScript = () => ({ code: 0, stderr: '' });
+
+mock.module('node:child_process', () => {
+  const { EventEmitter } = require('node:events');
+  const actual = require('node:child_process');
+  return {
+    ...actual,
+    default: actual,
+    spawn: (cmd: string, args: string[]) => {
+      const child: {
+        stdout: InstanceType<typeof EventEmitter>;
+        stderr: InstanceType<typeof EventEmitter>;
+        on: (event: string, cb: (arg: unknown) => void) => void;
+        emit: (event: string, arg?: unknown) => void;
+      } = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      queueMicrotask(() => {
+        // `which tailscale` — report installed so start()'s guard passes.
+        if (cmd === 'which') {
+          child.emit('exit', 0);
+          return;
+        }
+        const { code, stderr } = spawnScript(cmd, args);
+        if (stderr) child.stderr.emit('data', Buffer.from(stderr));
+        child.emit('exit', code);
+      });
+      return child;
+    },
+  };
+});
+
+// Import AFTER the module mock is registered so the service picks up mocked spawn.
+const { LocalTunnelService } = await import('../../services/LocalTunnelService');
+
+function runtime(): IAgentRuntime {
+  return {
+    getSetting: mock(() => null),
+  } as unknown as IAgentRuntime;
+}
+
+/**
+ * Build a service whose install probe passes, then seed the private state so it
+ * reports an active tunnel (state that would exist right after a successful
+ * `startTunnel`). This exercises stopTunnel() without needing to script the
+ * full serve + `status --json` DNSName startup handshake.
+ */
+async function activeService(): Promise<InstanceType<typeof LocalTunnelService>> {
+  const svc = new LocalTunnelService(runtime());
+  await svc.start();
+  (svc as unknown as { tunnelUrl: string | null }).tunnelUrl = 'https://device.example.ts.net';
+  (svc as unknown as { tunnelPort: number | null }).tunnelPort = 8080;
+  return svc;
+}
+
+describe('LocalTunnelService.stopTunnel fail-closed (#12746)', () => {
+  beforeEach(() => {
+    spawnScript = () => ({ code: 0, stderr: '' });
+  });
+
+  it('throws and stays active when `tailscale serve reset` exits non-zero (tunnel still exposed)', async () => {
+    const svc = await activeService();
+    expect(svc.isActive()).toBe(true);
+
+    spawnScript = (_cmd, args) => {
+      if (args[0] === 'serve' && args[1] === 'reset') {
+        return { code: 1, stderr: 'failed to connect to local tailscaled' };
+      }
+      return { code: 0, stderr: '' };
+    };
+
+    await expect(svc.stopTunnel()).rejects.toThrow(/serve reset exited with code 1/);
+
+    // Fail closed: state preserved, service still reports active + exposed URL.
+    expect(svc.isActive()).toBe(true);
+    expect(svc.getUrl()).toBe('https://device.example.ts.net');
+    expect(svc.getStatus().active).toBe(true);
+  });
+
+  it('names the still-exposed URL in the thrown error', async () => {
+    const svc = await activeService();
+
+    spawnScript = (_cmd, args) => {
+      if (args[0] === 'serve' && args[1] === 'reset') {
+        return { code: 1, stderr: 'tailscaled offline' };
+      }
+      return { code: 0, stderr: '' };
+    };
+
+    await expect(svc.stopTunnel()).rejects.toThrow(
+      /Tunnel may still be exposed on https:\/\/device\.example\.ts\.net/
+    );
+  });
+
+  it('tears down cleanly and reports inactive when reset exits zero', async () => {
+    const svc = await activeService();
+
+    spawnScript = () => ({ code: 0, stderr: '' });
+
+    await expect(svc.stopTunnel()).resolves.toBeUndefined();
+    expect(svc.isActive()).toBe(false);
+    expect(svc.getUrl()).toBeNull();
+    expect(svc.getStatus().active).toBe(false);
+  });
+});

--- a/plugins/plugin-tunnel/src/__tests__/unit/local-tunnel-service.test.ts
+++ b/plugins/plugin-tunnel/src/__tests__/unit/local-tunnel-service.test.ts
@@ -182,6 +182,51 @@ describe('plugin-tunnel stop/status/provider/config behavior', () => {
     });
   });
 
+  it('reports a structured failure (not a fabricated "stopped") when the service fails to tear down (#12746)', async () => {
+    const service = tunnelService({
+      isActive: mock(() => true),
+      getStatus: mock(() => ({
+        active: true,
+        url: 'https://device.example.ts.net',
+        port: 8080,
+        startedAt: new Date('2026-01-01T00:00:00.000Z'),
+        provider: 'tailscale',
+        backend: 'local-cli',
+      })),
+      stopTunnel: mock(async () => {
+        throw new Error(
+          'tailscale serve reset exited with code 1: tailscaled offline. Tunnel may still be exposed on https://device.example.ts.net.'
+        );
+      }),
+    });
+    const callback = mock(async () => {}) as HandlerCallback;
+
+    const result = await handleStopTunnel(
+      runtime(service),
+      message,
+      undefined,
+      undefined,
+      callback
+    );
+
+    expect(service.stopTunnel).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(false);
+    expect(result).toMatchObject({
+      success: false,
+      data: {
+        action: 'tunnel_stop_failed',
+        previousUrl: 'https://device.example.ts.net',
+        previousPort: 8080,
+      },
+    });
+    expect(result.error).toContain('tunnel stop failed');
+    // The user is warned the tunnel may still be exposed, never told it stopped.
+    const callbackArg = (callback as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0][0] as { text: string };
+    expect(callbackArg.text).toContain('may still be exposed');
+    expect(callbackArg.text).not.toContain('Tunnel stopped');
+  });
+
   it('reports status and provider state without mutating inactive services', async () => {
     const service = tunnelService({
       isActive: mock(() => false),

--- a/plugins/plugin-tunnel/src/actions/stop-tunnel.ts
+++ b/plugins/plugin-tunnel/src/actions/stop-tunnel.ts
@@ -39,7 +39,30 @@ export async function handleStopTunnel(
   const previousUrl = status.url;
   const previousPort = status.port;
 
-  await tunnelService.stopTunnel();
+  try {
+    await tunnelService.stopTunnel();
+  } catch (error) {
+    // The tunnel service failed to tear down (e.g. `tailscale serve reset`
+    // returned non-zero). The tunnel may still be EXPOSED, so surface a
+    // structured failure instead of fabricating a "stopped" success — the
+    // model/user must not believe a live public tunnel is closed.
+    const detail = error instanceof Error ? error.message : String(error);
+    elizaLogger.error(`[stop-tunnel] failed to stop tunnel: ${detail}`);
+    if (callback) {
+      await callback({
+        text: `Failed to stop the tunnel. It may still be exposed on port ${previousPort} (${previousUrl}). ${detail}`,
+      });
+    }
+    return {
+      success: false,
+      error: `tunnel stop failed: ${detail}`,
+      data: {
+        action: 'tunnel_stop_failed',
+        previousUrl: previousUrl ?? '',
+        previousPort: previousPort ?? 0,
+      },
+    };
+  }
 
   if (callback) {
     await callback({

--- a/plugins/plugin-tunnel/src/services/LocalTunnelService.ts
+++ b/plugins/plugin-tunnel/src/services/LocalTunnelService.ts
@@ -173,10 +173,39 @@ export class LocalTunnelService extends Service implements ITunnelService {
     this.isShuttingDown = true;
     elizaLogger.info('[LocalTunnelService] stopping tunnel');
 
-    if (this.useFunnel) {
-      await runCommand('tailscale', ['funnel', 'reset']);
-    } else {
-      await runCommand('tailscale', ['serve', 'reset']);
+    const resetVerb = this.useFunnel ? 'funnel' : 'serve';
+
+    let result: SpawnResult;
+    try {
+      result = await runCommand('tailscale', [resetVerb, 'reset']);
+    } catch (error) {
+      // Fail closed: the reset never ran (e.g. the tailscale binary vanished or
+      // the process errored before exit), so the tunnel is almost certainly
+      // STILL EXPOSED on the network. Do NOT cleanup()/report success — that
+      // would fabricate a teardown of a live public tunnel. Leave state intact
+      // (url/port preserved, isActive() true again) so the caller surfaces the
+      // failure and can retry.
+      this.isShuttingDown = false;
+      const detail = error instanceof Error ? error.message : String(error);
+      elizaLogger.error(
+        `[LocalTunnelService] tailscale ${resetVerb} reset failed to spawn: ${detail}`
+      );
+      throw new Error(
+        `tailscale ${resetVerb} reset failed to spawn: ${detail}. Tunnel may still be exposed on ${this.tunnelUrl ?? 'the tailnet'}.`
+      );
+    }
+
+    if (result.code !== 0) {
+      // The reset command ran but the tailscale daemon rejected it (non-zero
+      // exit). The serve/funnel config was not torn down, so the tunnel is
+      // still live. Fail closed instead of masquerading as "stopped".
+      this.isShuttingDown = false;
+      elizaLogger.error(
+        `[LocalTunnelService] tailscale ${resetVerb} reset exited with code ${result.code}: ${result.stderr.trim()}`
+      );
+      throw new Error(
+        `tailscale ${resetVerb} reset exited with code ${result.code}: ${result.stderr.trim()}. Tunnel may still be exposed on ${this.tunnelUrl ?? 'the tailnet'}.`
+      );
     }
 
     this.cleanup();


### PR DESCRIPTION
Part of #12746 (#12275-H, infra/connectivity fallback-slop sweep). Distinct slice from the prior `plugin-streaming` slice (#13138).

## The bug (fabricated success on an exposure path)
`LocalTunnelService.stopTunnel()` runs `tailscale serve|funnel reset` but **ignores its exit code**, then unconditionally `cleanup()`s state and logs `"tunnel stopped"`:

```ts
if (this.useFunnel) {
  await runCommand('tailscale', ['funnel', 'reset']);
} else {
  await runCommand('tailscale', ['serve', 'reset']);
}
this.cleanup();               // clears url/port, sets inactive
elizaLogger.info('[LocalTunnelService] tunnel stopped');
```

If the reset exits non-zero (tailscaled offline, permission error, daemon down) the serve/funnel config is **not** torn down, so the tunnel is **still exposed on the tailnet** — but the service reports a clean teardown. `handleStopTunnel` then returns `success: true` and tells the user/model *"Tunnel stopped"* over a live public tunnel. This is precisely the "must not masquerade as success" defect #12746 (#12275-H) calls out for connectivity paths.

## Fix — fail closed
- `stopTunnel()` now checks the reset exit code (and catches a spawn error). On failure it **throws** an observable error that names the still-exposed URL, **leaves state intact** (`isActive()` stays true, `url`/`port` preserved), and does **not** `cleanup()`. Only a zero-exit reset tears down and reports stopped.
- `handleStopTunnel()` wraps `stopTunnel()` and returns a structured `{ success: false, error, data.action: 'tunnel_stop_failed' }` with a callback warning the tunnel *may still be exposed on port X* — never a fabricated "Tunnel stopped".

## Tests (bun:test)
- **New** `src/__tests__/unit/local-tunnel-service-stop.test.ts` (3 tests): non-zero `serve reset` → `stopTunnel()` throws and the service stays active/exposed; the thrown error names the exposed URL; a zero-exit reset tears down to inactive. Uses a scoped `node:child_process` spawn mock that **spreads the real module** so sibling importers keep `exec`/etc.
- **New** action-level case in `local-tunnel-service.test.ts`: a rejecting `stopTunnel()` yields `success:false` + `tunnel_stop_failed` + a *"may still be exposed"* callback, and asserts the callback never says *"Tunnel stopped"*.

## Evidence
- `bun test src/__tests__/unit/` → **22/22 pass** (incl. the 4 new/changed cases).
- `bun run typecheck` (tsgo --noEmit) → **clean**.
- `biome check` on all touched files → **clean**.
- `codex review --uncommitted` → **clean, no findings** ("The new failure path preserves active tunnel state and returns a structured stop failure").

Route files untouched (owned by #12275-F).

-- [sol-orch]