### PR TITLE
fix(#12267): deep fallback-slop sweep slice 2/3 — convert empty-catch/fabricated-default/promise-swallow to fail-fast

### DIFF
--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -1431,6 +1431,9 @@ export class ElizaClient {
           const parsed = JSON.parse(queued) as { type?: unknown };
           return parsed.type !== "active-conversation";
         } catch {
+          // error-policy:J3 an unparseable queued frame can't be classified as a
+          // superseded active-conversation update, so keep it in the send queue
+          // rather than silently dropping a message we failed to inspect.
           return true;
         }
       });
@@ -1602,6 +1605,7 @@ export class ElizaClient {
       // body and frees the connection) and returning whatever streamed so far as
       // an interrupted (`completed: false`) turn.
       if (signal?.aborted) {
+        // error-policy:J6 best-effort teardown of an already-aborted reader.
         void reader.cancel("elizaos-sse-client-abort").catch(() => {});
         break;
       }
@@ -1643,6 +1647,7 @@ export class ElizaClient {
         // A client abort wins over everything else: cancel the reader and stop —
         // the partial streamed so far is returned as an interrupted turn.
         if (signal?.aborted) {
+          // error-policy:J6 best-effort teardown of an already-aborted reader.
           void reader.cancel("elizaos-sse-client-abort").catch(() => {});
           break;
         }
@@ -1656,6 +1661,7 @@ export class ElizaClient {
           streamState.doneFailureKind =
             streamState.doneFailureKind ?? "provider_issue";
         }
+        // error-policy:J6 best-effort teardown after a stalled/dropped stream.
         void reader.cancel("elizaos-sse-idle-timeout").catch(() => {});
         break;
       }
@@ -1670,6 +1676,7 @@ export class ElizaClient {
           if (!line.startsWith("data:")) continue;
           if (applyStreamChatDataLine(line, streamState, onToken, onStatus)) {
             buffer = "";
+            // error-policy:J6 best-effort teardown once the terminal event lands.
             void reader.cancel("elizaos-sse-terminal-done").catch(() => {});
             break;
           }

--- a/packages/ui/src/api/ios-local-agent-transport.ts
+++ b/packages/ui/src/api/ios-local-agent-transport.ts
@@ -780,6 +780,9 @@ async function getFullBunRuntime(): Promise<FullBunRuntimePlugin | null> {
       // the raw Capacitor proxy — awaiting the proxy deadlocks; see the
       // comment inside it).
       const runtime = await importFullBunRuntimePlugin();
+      // error-policy:J4 status probe — an unreachable/not-yet-booted engine is
+      // the expected "not ready" shape; null falls through to start() below,
+      // where a genuine start() failure is NOT caught and surfaces to the user.
       const currentStatus = await runtime.getStatus().catch(() => null);
       if (currentStatus?.ready && currentStatus.engine === "bun") {
         recordIosNativeAgentBootPhase("ready");

--- a/packages/ui/src/cloud-ui/runtime/navigation.ts
+++ b/packages/ui/src/cloud-ui/runtime/navigation.ts
@@ -37,7 +37,10 @@ function normalizeInternalHref(href: string): string {
     if (url.origin === window.location.origin) {
       return `${url.pathname}${url.search}${url.hash}`;
     }
-  } catch {}
+  } catch {
+    // error-policy:J3 unparseable href is untrusted input → return it verbatim
+    // for the caller to route; never fabricate a normalized path from garbage.
+  }
   return href;
 }
 

--- a/packages/ui/src/cloud/account-security/components/profile-form.tsx
+++ b/packages/ui/src/cloud/account-security/components/profile-form.tsx
@@ -74,6 +74,8 @@ async function updateProfile(formData: FormData): Promise<ProfileActionResult> {
     });
     const body = (await res
       .json()
+      // error-policy:J3 a non-JSON/empty body is an explicit "invalid" signal;
+      // the `!body?.success` check below turns it into a user-facing error.
       .catch(() => null)) as ProfileMutationBody | null;
     if (!body?.success) {
       return {
@@ -103,6 +105,8 @@ async function updateEmail(formData: FormData): Promise<ProfileActionResult> {
     });
     const body = (await res
       .json()
+      // error-policy:J3 a non-JSON/empty body is an explicit "invalid" signal;
+      // the `!body?.success` check below turns it into a user-facing error.
       .catch(() => null)) as ProfileMutationBody | null;
     if (!body?.success) {
       return { success: false, error: body?.error ?? "Failed to update email" };
@@ -127,6 +131,8 @@ async function uploadAvatar(formData: FormData): Promise<AvatarUploadResult> {
     });
     const body = (await res
       .json()
+      // error-policy:J3 a non-JSON/empty body is an explicit "invalid" signal;
+      // the `!body?.success` check below turns it into a user-facing error.
       .catch(() => null)) as ProfileMutationBody | null;
     if (body?.success && typeof body.avatarUrl === "string") {
       return {

--- a/packages/ui/src/cloud/applications/NativeAppsStudio.tsx
+++ b/packages/ui/src/cloud/applications/NativeAppsStudio.tsx
@@ -270,6 +270,8 @@ export default function NativeAppsStudio(): React.JSX.Element {
       const token = readStoredStewardToken()?.trim() ?? null;
       if (shouldRefreshBeforeRender(token)) {
         const refreshed = await Promise.race([
+          // error-policy:J4 best-effort pre-render token refresh; on failure or
+          // timeout the page still boots with the existing token (below).
           refreshCloudStewardSession({
             endpoint: resolveNativeStewardRefreshEndpoint(),
           }).catch(() => null),
@@ -283,7 +285,8 @@ export default function NativeAppsStudio(): React.JSX.Element {
           try {
             window.dispatchEvent(new CustomEvent("steward-token-sync"));
           } catch {
-            // best-effort
+            // error-policy:J6 best-effort notify; token is already persisted, so
+            // a missing CustomEvent constructor (SSR/old runtime) is non-fatal.
           }
         }
       }

--- a/packages/ui/src/cloud/shell/StewardProviderShared.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.ts
@@ -129,6 +129,8 @@ function stewardSessionClearUrls(): string[] {
 
 export function clearServerStewardSessionCookies(): void {
   for (const url of stewardSessionClearUrls()) {
+    // error-policy:J6 best-effort logout teardown across every session endpoint;
+    // the authoritative local token is cleared separately by the caller.
     fetch(url, { method: "DELETE", credentials: "include" }).catch(() => {});
   }
 }

--- a/packages/ui/src/components/chat/AppsSection.catalog-load-error.test.tsx
+++ b/packages/ui/src/components/chat/AppsSection.catalog-load-error.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+//
+// Real error-path coverage for the sidebar catalog load in AppsSection
+// (issue #12267): a failed `loadMergedCatalogApps()` used to be swallowed by
+// `.catch(() => undefined)`, leaving an empty catalog indistinguishable from a
+// genuinely empty one (view-audit §6.D). The failure now logs at error while
+// the section still degrades to running/favorited apps. State + catalog-loader
+// mocked; logger spied.
+
+import { logger } from "@elizaos/logger";
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  loadMergedCatalogApps: vi.fn(),
+  store: {
+    favoriteApps: [] as unknown[],
+    appRuns: [] as unknown[],
+    setTab: vi.fn(),
+    setState: vi.fn(),
+    setActionNotice: vi.fn(),
+    t: (s: string) => s,
+  },
+}));
+
+vi.mock("../apps/catalog-loader", () => ({
+  loadMergedCatalogApps: mocks.loadMergedCatalogApps,
+}));
+vi.mock("../../state", () => ({
+  useAppSelectorShallow: (sel: (s: unknown) => unknown) => sel(mocks.store),
+}));
+
+import { AppsSection } from "./AppsSection";
+
+const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+beforeEach(() => {
+  mocks.loadMergedCatalogApps.mockReset();
+  warnSpy.mockReset();
+});
+
+describe("AppsSection — catalog load failure surfaces", () => {
+  it("logs when the catalog load rejects rather than silently emptying", async () => {
+    mocks.loadMergedCatalogApps.mockRejectedValue(new Error("catalog 500"));
+
+    render(<AppsSection />);
+
+    await waitFor(() => {
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(warnSpy.mock.calls[0]?.[1]).toContain(
+      "catalog load failed",
+    );
+  });
+
+  it("does not log when the catalog load succeeds", async () => {
+    mocks.loadMergedCatalogApps.mockResolvedValue([]);
+
+    render(<AppsSection />);
+
+    // Give the effect a tick to settle.
+    await waitFor(() => {
+      expect(mocks.loadMergedCatalogApps).toHaveBeenCalled();
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/settings/SecretsManagerSection.tsx
+++ b/packages/ui/src/components/settings/SecretsManagerSection.tsx
@@ -341,6 +341,9 @@ function VaultBody({
         client.rawRequest("/api/secrets/routing", undefined, {
           allowNonOk: true,
         }),
+        // error-policy:J4 agents/apps are optional cross-reference enrichment;
+        // null degrades those columns while the core secrets panels below still
+        // fail hard on a bad backends/preferences/methods response.
         client
           .rawRequest("/api/agents", undefined, { allowNonOk: true })
           .catch(() => null),

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1927,6 +1927,8 @@ export function ContinuousChatOverlay({
             if (cancelled) handle.remove();
             else handles.push(handle);
           })
+          // error-policy:J6 best-effort native listener registration; the
+          // visualViewport path (outer catch) covers keyboard insets otherwise.
           .catch(() => {});
         void Keyboard.addListener("keyboardWillHide", () => {
           setNativeKeyboardHeight(0);
@@ -1935,6 +1937,8 @@ export function ContinuousChatOverlay({
             if (cancelled) handle.remove();
             else handles.push(handle);
           })
+          // error-policy:J6 best-effort native listener registration; the
+          // visualViewport path (outer catch) covers keyboard insets otherwise.
           .catch(() => {});
       })
       .catch(() => {

--- a/packages/ui/src/services/local-inference/downloader.ts
+++ b/packages/ui/src/services/local-inference/downloader.ts
@@ -783,6 +783,8 @@ export class Downloader {
         // treated as invalid and replaced by the fresh bundle artifact.
       }
     } else {
+      // error-policy:J6 best-effort cleanup of a stale staging file before the
+      // fresh download re-creates it; force already ignores a missing path.
       await fsp.rm(stagingPath, { force: true }).catch(() => undefined);
     }
 

--- a/packages/ui/src/state/useDataLoaders.refresh-404-error.test.tsx
+++ b/packages/ui/src/state/useDataLoaders.refresh-404-error.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+//
+// Real error-path coverage for the 404 stale-conversation recovery in
+// useDataLoaders (issue #12267): when the follow-up conversation-list refresh
+// itself fails, the failure must be logged (no longer swallowed by
+// `.catch(() => null)`) while the UI still degrades by clearing the dangling
+// active conversation id. Deterministic in-memory client mock; the logger is
+// spied to assert the failure surfaces.
+
+import { logger } from "@elizaos/logger";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  client: {
+    getConversationMessages: vi.fn(),
+    listConversations: vi.fn(),
+    getConfig: vi.fn(async () => ({ ui: {} })),
+  },
+}));
+
+vi.mock("../api", () => ({ client: mocks.client }));
+
+import { type DataLoadersDeps, useDataLoaders } from "./useDataLoaders";
+
+const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+function makeDeps() {
+  const activeConversationIdRef = { current: "conv-gone" as string | null };
+  const setActiveConversationId = vi.fn((v: string | null) => {
+    activeConversationIdRef.current = v;
+  });
+  const noop = () => {};
+  const deps = {
+    autonomousStoreRef: { current: {} },
+    autonomousEventsRef: { current: [] },
+    autonomousLatestEventIdRef: { current: null },
+    autonomousRunHealthByRunIdRef: { current: {} },
+    autonomousReplayInFlightRef: { current: false },
+    setAutonomousEvents: noop,
+    setAutonomousLatestEventId: noop,
+    setAutonomousRunHealthByRunId: noop,
+    activeConversationIdRef,
+    conversationMessagesRef: { current: [] },
+    greetingFiredRef: { current: false },
+    setConversations: vi.fn(),
+    setActiveConversationId,
+    setConversationMessages: vi.fn(),
+    loadWalletConfig: async () => {},
+    agentStatus: null,
+    characterData: null,
+    characterDraft: null,
+    loadCharacter: async () => {},
+    selectedVrmIndex: 0,
+    firstRunComplete: false,
+    uiLanguage: "en",
+    setOwnerNameState: noop,
+  } as unknown as DataLoadersDeps;
+  return { deps, activeConversationIdRef, setActiveConversationId };
+}
+
+beforeEach(() => {
+  mocks.client.getConversationMessages.mockReset();
+  mocks.client.listConversations.mockReset();
+  warnSpy.mockReset();
+});
+
+describe("useDataLoaders — 404 refresh failure surfaces instead of swallowing", () => {
+  it("logs the refresh failure and still clears the dangling active id", async () => {
+    // The conversation is gone (404) …
+    mocks.client.getConversationMessages.mockRejectedValue(
+      Object.assign(new Error("not found"), { status: 404 }),
+    );
+    // … and the recovery list refresh is also down (transport 500).
+    mocks.client.listConversations.mockRejectedValue(
+      Object.assign(new Error("boom"), { status: 500 }),
+    );
+
+    const { deps, activeConversationIdRef } = makeDeps();
+    const { result } = renderHook(() => useDataLoaders(deps));
+
+    let outcome: { ok: boolean } | undefined;
+    await act(async () => {
+      outcome = (await result.current.loadConversationMessages("conv-gone")) as {
+        ok: boolean;
+      };
+    });
+
+    // Failure is now observable — not swallowed by `.catch(() => null)`.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[1]).toContain(
+      "conversation-list refresh after 404 failed",
+    );
+    // …and the UI still degrades: the dangling active conversation is cleared.
+    expect(activeConversationIdRef.current).toBeNull();
+    expect(outcome?.ok).toBe(false);
+  });
+
+  it("a healthy refresh does not log an error and adopts the refreshed list", async () => {
+    mocks.client.getConversationMessages.mockRejectedValue(
+      Object.assign(new Error("not found"), { status: 404 }),
+    );
+    mocks.client.listConversations.mockResolvedValue({
+      conversations: [{ id: "conv-new", title: "New" }],
+    });
+
+    const { deps, activeConversationIdRef } = makeDeps();
+    const { result } = renderHook(() => useDataLoaders(deps));
+
+    await act(async () => {
+      await result.current.loadConversationMessages("conv-gone");
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    // Active id moved to the first surviving conversation, not silently nulled.
+    expect(activeConversationIdRef.current).toBe("conv-new");
+  });
+});

--- a/packages/ui/src/state/usePluginsSkillsState.ts
+++ b/packages/ui/src/state/usePluginsSkillsState.ts
@@ -487,6 +487,9 @@ export function usePluginsSkillsState({
       setActionNotice(`Skill "${name}" created.`, "success");
       await refreshSkills();
       if (result.path)
+        // error-policy:J6 best-effort post-success open of the just-created skill;
+        // creation already surfaced its own success notice, so a failed open must
+        // not be rethrown into the outer catch and flip it to a failure notice.
         await client.openSkill(result.skill?.id ?? name).catch(() => undefined);
     } catch (err) {
       setActionNotice(

--- a/packages/ui/src/state/useWalletState.capability-write-error.test.tsx
+++ b/packages/ui/src/state/useWalletState.capability-write-error.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+//
+// Real error-path coverage for capability-toggle persistence in useWalletState
+// (issue #12267): the optimistic local toggle is applied immediately, but the
+// server `updateConfig` write used to be swallowed by `.catch(() => {})`, so a
+// failed sync silently reverted on the next hydration. The write now logs at
+// error while keeping the optimistic UI. Deterministic client + persistence
+// mocks; logger spied to assert the failure surfaces.
+
+import { logger } from "@elizaos/logger";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  client: {
+    updateConfig: vi.fn(),
+    getConfig: vi.fn(async () => ({ ui: {} })),
+  },
+  persistence: {
+    loadWalletEnabled: vi.fn(() => false),
+    loadBrowserEnabled: vi.fn(() => false),
+    loadComputerUseEnabled: vi.fn(() => false),
+    saveWalletEnabled: vi.fn(),
+    saveBrowserEnabled: vi.fn(),
+    saveComputerUseEnabled: vi.fn(),
+  },
+}));
+
+vi.mock("../api", () => ({ client: mocks.client }));
+vi.mock("./persistence", () => mocks.persistence);
+vi.mock("../utils/desktop-dialogs", () => ({
+  confirmDesktopAction: vi.fn(async () => true),
+}));
+
+import { useWalletState } from "./useWalletState";
+
+const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+function renderWalletState() {
+  return renderHook(() =>
+    useWalletState({
+      setActionNotice: vi.fn(),
+      promptModal: vi.fn(async () => null),
+      agentName: undefined,
+      characterName: undefined,
+      hydrateServerConfig: false,
+    }),
+  );
+}
+
+beforeEach(() => {
+  mocks.client.updateConfig.mockReset();
+  errorSpy.mockReset();
+  mocks.persistence.saveWalletEnabled.mockReset();
+});
+
+describe("useWalletState — capability write failure surfaces", () => {
+  it("logs when the server config write rejects but keeps the optimistic toggle", async () => {
+    mocks.client.updateConfig.mockRejectedValue(new Error("network down"));
+    const { result } = renderWalletState();
+
+    await act(async () => {
+      result.current.setWalletEnabled(true);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Optimistic local + localStorage update still applied.
+    expect(result.current.state.walletEnabled).toBe(true);
+    expect(mocks.persistence.saveWalletEnabled).toHaveBeenCalledWith(true);
+    // The lost sync write is now observable rather than swallowed.
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0]?.[1]).toContain(
+      "failed to persist wallet capability toggle",
+    );
+  });
+
+  it("does not log when the server config write succeeds", async () => {
+    mocks.client.updateConfig.mockResolvedValue(undefined);
+    const { result } = renderWalletState();
+
+    await act(async () => {
+      result.current.setWalletEnabled(true);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.state.walletEnabled).toBe(true);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/state/useWalletState.ts
+++ b/packages/ui/src/state/useWalletState.ts
@@ -27,6 +27,7 @@ import type {
   WalletPrimaryMap,
   WalletSource,
 } from "@elizaos/shared";
+import { logger } from "@elizaos/logger";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   client,
@@ -85,7 +86,14 @@ export function useWalletState({
     saveWalletEnabled(v);
     void client
       .updateConfig({ ui: { capabilities: { wallet: v } } })
-      .catch(() => {});
+      .catch((err) => {
+        // Optimistic local toggle already applied; a lost server write would
+        // silently revert on the next getConfig hydration, so make it observable.
+        logger.error(
+          { err },
+          "[useWalletState] failed to persist wallet capability toggle to server config",
+        );
+      });
   }, []);
 
   const [browserEnabled, setBrowserEnabledRaw] = useState(loadBrowserEnabled);
@@ -94,7 +102,12 @@ export function useWalletState({
     saveBrowserEnabled(v);
     void client
       .updateConfig({ ui: { capabilities: { browser: v } } })
-      .catch(() => {});
+      .catch((err) => {
+        logger.error(
+          { err },
+          "[useWalletState] failed to persist browser capability toggle to server config",
+        );
+      });
   }, []);
 
   const [computerUseEnabled, setComputerUseEnabledRaw] = useState(
@@ -105,7 +118,12 @@ export function useWalletState({
     saveComputerUseEnabled(v);
     void client
       .updateConfig({ ui: { capabilities: { computerUse: v } } })
-      .catch(() => {});
+      .catch((err) => {
+        logger.error(
+          { err },
+          "[useWalletState] failed to persist computerUse capability toggle to server config",
+        );
+      });
   }, []);
 
   // ── Hydrate capability flags from server config on mount ──────────
@@ -133,6 +151,8 @@ export function useWalletState({
           saveComputerUseEnabled(caps.computerUse);
         }
       })
+      // error-policy:J4 offline/stale hydration degrades to the localStorage
+      // fallback the capability toggles were seeded from (comment above).
       .catch(() => {});
     return () => {
       cancelled = true;

--- a/packages/ui/src/utils/image-attachment.ts
+++ b/packages/ui/src/utils/image-attachment.ts
@@ -348,6 +348,8 @@ async function fileToChatAttachment(file: File): Promise<ImageAttachment> {
   if (imageNeedsReencode(file.type, data.length)) {
     ({ data, mimeType } = await reencodeImageToChatCap(file));
   }
+  // error-policy:J4 the thumbnail is optional preview enrichment; null omits it
+  // while the full-resolution attachment (already read above) still sends.
   const thumbnail = await createImageThumbnail(file).catch(() => null);
   return {
     data,


### PR DESCRIPTION
## Deep fallback-slop sweep — slice 2/3 (`packages/ui` + `packages/app`)

Part of #12267 (parent #12182). This is the deep clear-slop pass over a disjoint
third of the suspect-file union (`index % 3 == 2`), using the foundation on
`develop` (#12263: `ElizaError`, error-policy J1–J7 rubric, diff-scoped
`audit:error-policy-ratchet`). Client UI code has no `runtime.reportError`, so
the escalation surface is the user's screen / the frontend logger.

### Per-category tally (my final diff, after rebase onto `develop`)

| category | count | disposition |
|---|---|---|
| **empty catch** | 1 | `navigation.ts` `normalizeInternalHref` → annotated **J3** (unparseable href → return verbatim); strict `catch {}` grep now **0** in the file |
| **fabricated-healthy-on-error** | 1 | `client-base.ts` queue-filter `catch { return true }` → annotated **J3** (unclassifiable queued frame is *kept*, not dropped) — a conservative keep, not a faked success |
| **promise-swallow converted** | 3 | `useWalletState.ts` capability-toggle server writes (`wallet`/`browser`/`computerUse`): `.catch(() => {})` → `logger.error` so a lost sync write (which silently reverts on next hydration) is observable |
| **justified J-annotations added** | 20 sites | see below |

Several sites in this slice (`useDataLoaders` 404-refresh, `AppsSection`
catalog load, `useChatSend` abort/stop, `startup-phase-poll`,
`use-first-run-conductor`, `wallet-balance`) were converted/annotated by a
**parallel #12267 wave** that landed on `develop` during this work
(`9b628aae23`). I rebased and took `develop`'s already-merged versions for every
conflict (they log at `warn`/`debug` with J-annotations — equal or better than
mine). That wave shipped those conversions **without tests**; the two
error-path tests here are the only coverage for them.

### J-annotations added (20 sites)

- **J3** (parse → explicit invalid, never fake-valid): `navigation.ts` href;
  `client-base.ts` queue-filter predicate; `profile-form.tsx` ×3 (`res.json()`
  → `!body?.success` error result).
- **J4** (designed, distinguishable degrade / optional enrichment):
  `ios-local-agent-transport.ts` status probe (null → `start()`, whose failure
  is *not* caught); `NativeAppsStudio.tsx` pre-render token refresh;
  `SecretsManagerSection.tsx` optional agents/apps cross-reference;
  `useWalletState.ts` offline hydration → localStorage fallback;
  `image-attachment.ts` optional thumbnail.
- **J6** (best-effort teardown): `client-base.ts` `reader.cancel()` ×4;
  `NativeAppsStudio.tsx` token-sync `CustomEvent`; `StewardProviderShared.ts`
  logout cookie clear; `ContinuousChatOverlay.tsx` native keyboard listener
  registration ×2; `downloader.ts` staging-file cleanup;
  `usePluginsSkillsState.ts` post-create skill open.

### Deliberately deferred (ambiguous — next pass)

Per the slice brief, `return null/[]/false` catches where masking-a-failure vs
legitimate-absence needs per-site judgment (**56** sites in these files) and
`?? <lit>` / `|| <lit>` defaults (**80** sites) are **not** touched this pass —
they are the judgment-heavy categories, not clear slop. No over-removal: every
feature-detection `return false`, not-found `return null`, and designed degrade
was left intact.

### Ratchet (diff-scoped, `bun run audit:error-policy-ratchet`)

`no new fallback-slop in touched files` — every touched file's `emptyCatch`
count is **unchanged** (before→after equal, never up); e.g. `navigation.ts`
1→1 at the AST level (the annotated J3 block is intentionally empty), while the
strict `catch\s*{\s*}` grep drops 1→0. `serverConsole` 0→0 everywhere.

### Tests

Three real error-path tests (drive a client whose fetch actually rejects /
returns 500, assert the failure surfaces and the legit path still returns its
value — no test asserts the old fabricated default):

- `useWalletState.capability-write-error.test.tsx` — covers **my** conversion:
  `updateConfig` rejects → `logger.error` fires, optimistic toggle + localStorage
  still applied; success path logs nothing.
- `useDataLoaders.refresh-404-error.test.tsx` — 404 + failing list refresh →
  `logger.warn` fires and the dangling active id is still cleared; healthy
  refresh logs nothing and adopts the new list.
- `AppsSection.catalog-load-error.test.tsx` — catalog load rejects → `logger.warn`
  fires (broken catalog distinguishable from empty); success logs nothing.

**Verify status — `verifyGreen=false` (environment, not correctness):** this
isolated **sparse** worktree cannot execute `packages/ui` React-render tests —
`react` aliases to `dist/node_modules/react` while `@testing-library`'s
`react-dom/client` loads the `.bun` dev copy, so *every* hook-render test fails
with `Cannot read properties of null (reading 'useState')`. The **unmodified**
baseline `useDataLoaders.conversation-cache.test.tsx` fails identically, proving
this is a pre-existing harness limitation, not this change. The tests are
type-shape-correct (fixed `result.current.state.walletEnabled` access under
typecheck). The changes are annotation + added-`logger` only (no control-flow
removed), so they cannot break existing green suites. CI (full install) will run
all three.

Refs #12267

🤖 Generated with [Claude Code](https://claude.com/claude-code)
