### PR TITLE
fix(#12273): deep fallback-slop sweep slice 1/2 — fail-fast on fabricated-healthy + annotate J-handlers

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/actions/elizaos-capability.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/elizaos-capability.ts
@@ -75,6 +75,8 @@ async function isExecutable(path: string): Promise<boolean> {
     await access(path, constants.X_OK);
     return true;
   } catch {
+    // error-policy:J3 existence/permission probe; not-executable is exactly the
+    // false result the caller wants, not a swallowed failure.
     return false;
   }
 }

--- a/plugins/plugin-agent-orchestrator/src/api/bridge-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/bridge-routes.ts
@@ -144,6 +144,8 @@ function decodeSegment(raw: string): string | null {
   try {
     decoded = decodeURIComponent(raw);
   } catch {
+    // error-policy:J3 untrusted-input sanitizing; a malformed percent-encoding
+    // is an explicit invalid segment (null), rejected by the caller.
     return null;
   }
   if (!decoded || decoded.includes("/") || decoded.includes("..")) return null;

--- a/plugins/plugin-agent-orchestrator/src/api/parent-context-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/parent-context-routes.ts
@@ -81,6 +81,8 @@ function parseSessionId(raw: string): string | null {
   try {
     decoded = decodeURIComponent(raw);
   } catch {
+    // error-policy:J3 untrusted-input sanitizing; a malformed percent-encoding
+    // is an explicit invalid session id (null), rejected by the caller.
     return null;
   }
   if (!decoded || decoded.includes("/") || decoded.includes("..")) {
@@ -423,6 +425,9 @@ export async function handleParentContextRoutes(
     sendJson(res, await withBridgeTimeout(listActiveWorkspaceContext(ctx)));
     return true;
   } catch (error) {
+    // error-policy:J1 route boundary — translate any failure into a structured
+    // HTTP error response (typed BridgeRouteError code, else a 503), never a
+    // success; `return true` means "request handled", not "succeeded".
     if (error instanceof BridgeRouteError) {
       sendBridgeError(res, error.code, error.message, error.status);
       return true;

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -353,6 +353,9 @@ export function createAgentOrchestratorPlugin(): Plugin {
                   const svc = runtime.getService<AcpService>(
                     AcpService.serviceType,
                   );
+                  // error-policy:J3 session lookup on a deferred flush timer; a
+                  // missing/failed lookup degrades to null and the guard below
+                  // treats it as "terminal", cancelling the flush cleanly.
                   const session = svc
                     ? await svc.getSession(sessionId).catch(() => null)
                     : null;
@@ -1291,6 +1294,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
     label: string,
   ): Promise<string> => {
     try {
+      // error-policy:J3 session lookup for a best-effort ack label; an
+      // unavailable session degrades to the passed `label`, never a fake ack.
       const session = await acp.getSession(sessionId).catch(() => null);
       const meta = (session?.metadata ?? {}) as Record<string, unknown>;
       const task =

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -69,6 +69,9 @@ export function parseAcpMcpServersEnv(
   try {
     parsed = JSON.parse(raw);
   } catch {
+    // error-policy:J3 untrusted-input sanitizing — a malformed opt-in env value
+    // is dropped to the documented empty default (see header), never a fake
+    // config; the common (unset) path already returns [] above.
     return [];
   }
   if (!Array.isArray(parsed)) return [];
@@ -238,6 +241,8 @@ export class NativeAcpClient {
         },
         this.opts.timeoutMs,
         () => {
+          // error-policy:J6 best-effort teardown — cancelling a timed-out
+          // prompt; a cancel that itself fails cannot rescue the turn.
           void this.cancel(sessionId).catch(() => undefined);
         },
       ),
@@ -248,12 +253,17 @@ export class NativeAcpClient {
   }
 
   async cancel(sessionId: string): Promise<void> {
+    // error-policy:J6 best-effort teardown — if the request/cancel round-trip
+    // fails, fall back to a fire-and-forget cancel notification; neither path
+    // can do more than ask a possibly-dead subprocess to stop.
     await this.request("session/cancel", { sessionId }, 5_000).catch(() => {
       void this.notify("session/cancel", { sessionId }).catch(() => undefined);
     });
   }
 
   async closeSession(sessionId: string): Promise<void> {
+    // error-policy:J6 best-effort teardown — closing an ACP session; a failed
+    // close leaves nothing the caller can act on.
     await this.request("session/close", { sessionId }, 5_000).catch(
       () => undefined,
     );

--- a/plugins/plugin-agent-orchestrator/src/services/coding-account-selection.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/coding-account-selection.ts
@@ -105,6 +105,9 @@ export async function selectCodingAccount(
   try {
     selection = await bridge.select(agentType, opts);
   } catch {
+    // error-policy:J4 designed degrade — a select fault degrades to
+    // single-account (null); the degraded-vs-benign distinction is surfaced to
+    // operators by diagnoseCodingAccountFallback (#9960), not swallowed here.
     return null;
   }
   if (!selection) return null;
@@ -133,6 +136,9 @@ export function diagnoseCodingAccountFallback(
   try {
     rows = bridge.describe()[agentType.toLowerCase()] ?? [];
   } catch {
+    // error-policy:J4 designed degrade — if the pool cannot be described there
+    // is no healthy/total signal to diagnose, so no false single-account
+    // warning is raised (benign path returns null; see header).
     return null;
   }
   const total = rows.reduce((sum, r) => sum + r.total, 0);

--- a/plugins/plugin-agent-orchestrator/src/services/json-model-output.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/json-model-output.ts
@@ -18,6 +18,8 @@ export function parseJsonObjectResponse<T = Record<string, unknown>>(
     }
     return parsed as T;
   } catch {
+    // error-policy:J3 parse of untrusted model output; unparseable text is an
+    // explicit "no object" (null) the caller handles, never a fake object.
     return null;
   }
 }

--- a/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
@@ -125,6 +125,7 @@ function isCerebrasBaseUrl(value: string | undefined): boolean {
     const hostname = new URL(value).hostname.toLowerCase();
     return hostname === "cerebras.ai" || hostname.endsWith(".cerebras.ai");
   } catch {
+    // error-policy:J3 URL parse; an unparseable base URL is not a Cerebras host.
     return false;
   }
 }

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -756,6 +756,9 @@ export class FileTaskStore extends InMemoryTaskStore {
         handle = pending;
       } catch (error) {
         if (pending) {
+          // error-policy:J6 best-effort teardown — unwind a partial lock
+          // acquire; the original acquire error below is authoritative and is
+          // rethrown once retries are exhausted.
           await pending.close().catch(() => {});
           await rm(this.lockFile, { force: true }).catch(() => {});
         }
@@ -857,6 +860,9 @@ export class RuntimeDbTaskStore {
       const parsed: unknown = JSON.parse(row.document);
       return normalizeTaskDocument(parsed);
     } catch {
+      // error-policy:J3 parse of a persisted task-document row; a corrupt row
+      // yields an explicit "not a document" (null) so one bad row cannot crash
+      // a list/scan, never a fabricated empty document.
       return null;
     }
   }
@@ -1059,6 +1065,10 @@ export class RuntimeDbTaskStore {
       );
       return this.matchSession(fallbackRows, sessionId);
     } catch {
+      // error-policy:J4 designed degrade — see the rationale above (#11778): on
+      // the session-event hot path a fallback-query failure must degrade to
+      // "session not found yet" (null), never poison the caller and silently
+      // drop all further telemetry for the session.
       return null;
     }
   }

--- a/plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts
@@ -384,6 +384,8 @@ function parseLlmScores(raw: string): LlmScoreEntry[] {
   try {
     parsed = JSON.parse(payload);
   } catch {
+    // error-policy:J3 parse of untrusted model output; unparseable text yields
+    // an explicit empty recommendation set, never fabricated recommendations.
     return [];
   }
   if (!Array.isArray(parsed)) return [];

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -381,6 +381,7 @@ function isLoopbackUrl(url: string): boolean {
     const host = new URL(url).hostname.toLowerCase();
     return host === "localhost" || host === "::1" || host.startsWith("127.");
   } catch {
+    // error-policy:J3 URL parse of untrusted input; unparseable = not loopback.
     return false;
   }
 }
@@ -425,6 +426,7 @@ function isTelemetryReportUrl(url: string): boolean {
       parsed.pathname.startsWith("/report/")
     );
   } catch {
+    // error-policy:J3 URL parse of untrusted input; unparseable = no match.
     return false;
   }
 }
@@ -445,6 +447,7 @@ function filterToReferencedAppRoute(
       const pathname = new URL(url).pathname;
       return [...routePrefixes].some((prefix) => pathname.startsWith(prefix));
     } catch {
+      // error-policy:J3 URL parse of untrusted input; unparseable = no match.
       return false;
     }
   });
@@ -895,6 +898,7 @@ export class SubAgentRouter extends Service {
           });
           this.loopState = state;
           if (decision.kind === "already_terminal") {
+            // error-policy:J6 best-effort teardown of an already-dead session.
             await acp.stopSession(sessionId).catch(() => {});
             return;
           }
@@ -905,12 +909,14 @@ export class SubAgentRouter extends Service {
             );
             if (respawned) {
               this.verifyRetryHandedOffSessions.add(sessionId);
+              // error-policy:J6 best-effort teardown; the respawn is authoritative.
               await acp.stopSession(sessionId).catch(() => {});
               return;
             }
           } else if (decision.kind === "terminal_failure") {
             accountFailoverExhausted = failureKind;
             accountFailoverCount = decision.count;
+            // error-policy:J6 best-effort teardown of the failed session.
             await acp.stopSession(sessionId).catch(() => {});
           }
         }
@@ -936,6 +942,7 @@ export class SubAgentRouter extends Service {
         // Cap exhausted and already reported once for this lineage: stop the
         // dead session and drop silently — the user already got one honest
         // failure (eliza#7967).
+        // error-policy:J6 best-effort teardown of an already-dead session.
         await acp.stopSession(sessionId).catch(() => {});
         return;
       }
@@ -945,6 +952,8 @@ export class SubAgentRouter extends Service {
         // the user is not left with a silent hang. The completion-claim slot is
         // task_complete-only, so an error never routes through it.
         stateLostRespawnCount = decision.count;
+        // error-policy:J6 best-effort teardown; the forced terminal narration
+        // below is the authoritative user-facing outcome.
         await acp.stopSession(sessionId).catch(() => {});
         this.log(
           "warn",
@@ -967,6 +976,7 @@ export class SubAgentRouter extends Service {
         const respawned = await this.respawnStateLost(session);
         if (respawned) {
           this.verifyRetryHandedOffSessions.add(sessionId);
+          // error-policy:J6 best-effort teardown; the respawn is authoritative.
           await acp.stopSession(sessionId).catch(() => {});
           return;
         }
@@ -1883,6 +1893,8 @@ Do not report done until every referenced URL in the final page resolves without
           sessionId,
           `parent-agent bridge: round-trip cap (${this.loopState.roundTripCap}) reached for this session; not running further USE_SKILL parent-agent requests.`,
         )
+        // error-policy:J6 best-effort final notice; the cap is already enforced
+        // by the `return` below, so a failed notice changes nothing.
         .catch(() => undefined);
       return;
     }
@@ -3226,6 +3238,8 @@ async function detectCachedMiss(
   const bustedRes = await safeFetch(busted.toString(), {
     method: "GET",
     signal,
+    // error-policy:J3 existence probe; an unreachable cache-bust URL is an
+    // explicit "unknown" (null), handled by the guard below — not a fake hit.
   }).catch(() => null);
   if (!bustedRes) return null;
   return bustedRes.status >= 200 && bustedRes.status < 300

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -490,6 +490,8 @@ function readJsonFile(filePath: string): unknown {
   try {
     return JSON.parse(fs.readFileSync(filePath, "utf8"));
   } catch {
+    // error-policy:J3 read+parse of an optional config/credentials file; a
+    // missing or malformed file is an explicit null the callers guard on.
     return null;
   }
 }
@@ -550,6 +552,8 @@ function hasClaudeSubscriptionAuth(): boolean {
     if (!raw) return false;
     return Boolean(extractOauthAccessToken(JSON.parse(raw)));
   } catch {
+    // error-policy:J3 keychain-credential probe; no entry / lookup failure means
+    // no subscription auth is present (false), not a swallowed error.
     return false;
   }
 }
@@ -625,6 +629,8 @@ function hasBinaryOnPath(binaryName: string): boolean {
     });
     return true;
   } catch {
+    // error-policy:J3 binary existence probe (`which`/`where`); a non-zero exit
+    // or missing command means the binary is absent (false).
     return false;
   }
 }

--- a/plugins/plugin-agent-orchestrator/src/services/workdir-validation.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workdir-validation.ts
@@ -48,6 +48,8 @@ export async function resolveAllowedWorkdir(
   rawWorkdir: string,
 ): Promise<string> {
   const resolved = path.resolve(rawWorkdir);
+  // error-policy:J3 existence probe — a non-resolvable path is an explicit
+  // "absent" (null); the failure is surfaced by the throw immediately below.
   const resolvedReal = await realpath(resolved).catch(() => null);
   if (!resolvedReal) {
     throw new Error("workdir must exist");

--- a/plugins/plugin-personal-assistant/src/actions/lib/extract-task-plan.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/extract-task-plan.ts
@@ -602,6 +602,8 @@ export async function extractUnlockModeWithLlm(args: {
           : undefined,
     };
   } catch {
+    // error-policy:J3 extraction from untrusted model output; a model or parse
+    // failure yields an explicit "no unlock plan" (null), never a fabricated one.
     return null;
   }
 }

--- a/plugins/plugin-personal-assistant/src/actions/prioritize.ts
+++ b/plugins/plugin-personal-assistant/src/actions/prioritize.ts
@@ -500,6 +500,8 @@ function parseRanking(raw: unknown): readonly RawRankingEntry[] {
     try {
       return JSON.parse(slice);
     } catch {
+      // error-policy:J3 parse of untrusted model output; unparseable ranking
+      // text is an explicit null (→ empty ranking), never a fabricated ranking.
       return null;
     }
   })();

--- a/plugins/plugin-personal-assistant/src/activity-profile/activity-tracker-service.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/activity-tracker-service.ts
@@ -59,6 +59,8 @@ async function loadActivityTrackerModule(): Promise<ActivityTrackerModule | null
       "@elizaos/native-activity-tracker"
     )) as ActivityTrackerModule;
   } catch {
+    // error-policy:J4 optional native dependency; when the platform-specific
+    // module is absent the tracker is unavailable (null), a designed degrade.
     return null;
   }
 }

--- a/plugins/plugin-personal-assistant/src/hooks/useGoogleLifeOpsConnector.ts
+++ b/plugins/plugin-personal-assistant/src/hooks/useGoogleLifeOpsConnector.ts
@@ -506,6 +506,8 @@ function parseRefreshEnvelope(rawValue: string): RefreshEnvelope | null {
   try {
     return readRefreshEnvelope(JSON.parse(rawValue));
   } catch {
+    // error-policy:J3 parse of a stored/untrusted envelope string; a malformed
+    // value is an explicit "no envelope" (null), never a fabricated one.
     return null;
   }
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/autofill-whitelist.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/autofill-whitelist.ts
@@ -23,6 +23,8 @@ export function extractRegistrableDomain(input: string): string | null {
     try {
       host = new URL(trimmed).hostname;
     } catch {
+      // error-policy:J3 URL parse of untrusted input; an unparseable URL yields
+      // an explicit "no registrable domain" (null).
       return null;
     }
   } else {

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.ts
@@ -105,6 +105,9 @@ export class GoogleDomain {
     try {
       return getConnectorAccountManager(this.ctx.runtime);
     } catch {
+      // error-policy:J4 designed degrade; when no connector-account manager is
+      // registered the Google domain reports "unavailable" (null), never a fake
+      // manager. Callers render an explicit unavailable connector state.
       return null;
     }
   }

--- a/plugins/plugin-personal-assistant/src/lifeops/screen-context.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/screen-context.ts
@@ -303,6 +303,8 @@ async function readOcrText(
     const text = await ocr.extractText(frameBytes);
     return normalizeText(text) || null;
   } catch {
+    // error-policy:J4 best-effort OCR degrade; a failed extraction yields "no
+    // text read" (null) and screen context proceeds without OCR, by design.
     return null;
   }
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/time/timezone.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/time/timezone.ts
@@ -64,6 +64,9 @@ function supportedTimeZoneValues(): string[] {
   try {
     return valuesFn("timeZone");
   } catch {
+    // error-policy:J3 runtime-capability probe; an engine that lacks
+    // Intl.supportedValuesOf("timeZone") yields an empty enumeration, and
+    // callers fall back to their own timezone list.
     return [];
   }
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/time/timezone.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/time/timezone.ts
@@ -126,10 +126,13 @@ export function extractExplicitTimeZoneFromText(
     return null;
   }
 
-  let match: RegExpExecArray | null;
   const ianaPattern = new RegExp(IANA_TIME_ZONE_PATTERN);
   ianaPattern.lastIndex = 0;
-  while ((match = ianaPattern.exec(value)) !== null) {
+  for (
+    let match = ianaPattern.exec(value);
+    match !== null;
+    match = ianaPattern.exec(value)
+  ) {
     const normalized = normalizeExplicitTimeZoneToken(match[1] ?? match[0]);
     if (normalized) {
       return normalized;

--- a/plugins/plugin-personal-assistant/src/routes/cloud-features-routes.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/cloud-features-routes.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Error-path tests for the Cloud features proxy (`fetchCloudFeatures`).
+ *
+ * Guards the #12182 fast-fail conversion: a 200 response whose body is not
+ * valid JSON is an upstream contract violation and must surface as an error, not
+ * fabricate a "synced, zero features" success. Uses a stubbed `globalThis.fetch`
+ * (no live Cloud) — the parse boundary under test is deterministic.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  type CloudFeaturesRouteState,
+  fetchCloudFeatures,
+} from "./cloud-features-routes.js";
+
+const BASE_STATE: CloudFeaturesRouteState = {
+  config: { cloud: { apiKey: "test-cloud-key", baseUrl: "https://cloud.example.com" } },
+  runtime: null,
+};
+
+let originalFetch: typeof globalThis.fetch;
+let originalElizaDev: string | undefined;
+
+function stubFetch(response: Partial<Response> & { json?: () => Promise<unknown> }) {
+  const mock = vi.fn(async () => response as unknown as Response);
+  globalThis.fetch = mock as unknown as typeof globalThis.fetch;
+  return mock;
+}
+
+beforeAll(() => {
+  originalFetch = globalThis.fetch;
+  // Bypass validateCloudBaseUrl's DNS resolution for the public test host.
+  originalElizaDev = process.env.ELIZA_DEV;
+  process.env.ELIZA_DEV = "1";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+  if (originalElizaDev === undefined) delete process.env.ELIZA_DEV;
+  else process.env.ELIZA_DEV = originalElizaDev;
+});
+
+describe("fetchCloudFeatures", () => {
+  it("surfaces an unparseable 200 body as an error instead of zero features", async () => {
+    stubFetch({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("Unexpected token < in JSON at position 0");
+      },
+    });
+
+    const result = await fetchCloudFeatures(BASE_STATE);
+
+    expect(result.status).toBe(502);
+    expect(result.error).toMatch(/not valid JSON/i);
+    expect(result.rows).toHaveLength(0);
+  });
+
+  it("returns parsed rows with no error when the 200 body is valid JSON", async () => {
+    stubFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        features: [
+          { featureKey: "not_a_real_feature", enabled: true },
+        ],
+      }),
+    });
+
+    const result = await fetchCloudFeatures(BASE_STATE);
+
+    expect(result.status).toBe(200);
+    expect(result.error).toBeNull();
+    // Unknown feature keys are dropped by parseCloudFeatures; the point is that
+    // a well-formed body is NOT treated as an error (no over-removal).
+    expect(Array.isArray(result.rows)).toBe(true);
+  });
+
+  it("treats a genuinely empty but valid feature list as success, not an error", async () => {
+    stubFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({ features: [] }),
+    });
+
+    const result = await fetchCloudFeatures(BASE_STATE);
+
+    expect(result.status).toBe(200);
+    expect(result.error).toBeNull();
+    expect(result.rows).toHaveLength(0);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/routes/cloud-features-routes.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/cloud-features-routes.test.ts
@@ -7,21 +7,33 @@
  * (no live Cloud) — the parse boundary under test is deterministic.
  */
 
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import {
   type CloudFeaturesRouteState,
   fetchCloudFeatures,
 } from "./cloud-features-routes.js";
 
 const BASE_STATE: CloudFeaturesRouteState = {
-  config: { cloud: { apiKey: "test-cloud-key", baseUrl: "https://cloud.example.com" } },
+  config: {
+    cloud: { apiKey: "test-cloud-key", baseUrl: "https://cloud.example.com" },
+  },
   runtime: null,
 };
 
 let originalFetch: typeof globalThis.fetch;
 let originalElizaDev: string | undefined;
 
-function stubFetch(response: Partial<Response> & { json?: () => Promise<unknown> }) {
+function stubFetch(
+  response: Partial<Response> & { json?: () => Promise<unknown> },
+) {
   const mock = vi.fn(async () => response as unknown as Response);
   globalThis.fetch = mock as unknown as typeof globalThis.fetch;
   return mock;
@@ -66,9 +78,7 @@ describe("fetchCloudFeatures", () => {
       ok: true,
       status: 200,
       json: async () => ({
-        features: [
-          { featureKey: "not_a_real_feature", enabled: true },
-        ],
+        features: [{ featureKey: "not_a_real_feature", enabled: true }],
       }),
     });
 

--- a/plugins/plugin-personal-assistant/src/routes/cloud-features-routes.ts
+++ b/plugins/plugin-personal-assistant/src/routes/cloud-features-routes.ts
@@ -110,7 +110,7 @@ interface FetchCloudFeaturesResult {
   readonly error: string | null;
 }
 
-async function fetchCloudFeatures(
+export async function fetchCloudFeatures(
   state: CloudFeaturesRouteState,
 ): Promise<FetchCloudFeaturesResult> {
   const apiKey = resolveProxyApiKey(state);
@@ -139,7 +139,23 @@ async function fetchCloudFeatures(
       error: body || `Cloud features request failed (${upstream.status})`,
     };
   }
-  const payload = await upstream.json().catch(() => null);
+  let payload: unknown;
+  try {
+    payload = await upstream.json();
+  } catch (error) {
+    // A 200 whose body is not valid JSON is an upstream contract violation, not
+    // an empty feature set. Surfacing it as a 502 keeps "sync failed"
+    // distinguishable from "synced, zero features": a silent `[]` here would
+    // report success while skipping every flag the corrupt response omitted
+    // (parent #12182 — "not loaded" must never read as "empty").
+    return {
+      status: 502,
+      rows: [],
+      error: `Cloud features response was not valid JSON (${
+        error instanceof Error ? error.message : String(error)
+      }).`,
+    };
+  }
   return { status: 200, rows: parseCloudFeatures(payload), error: null };
 }
 


### PR DESCRIPTION
## Fallback slop sweep (#12182) — app plugins A, disjoint file-slice 1/2

Deep fallback-slop sweep of one disjoint file-slice (index%2==1 of the sorted
suspect list) over the six app-plugins-A trees. Behavior-changing where the slop
is unambiguous; precise-on-ambiguity elsewhere. Uses the #12263 foundation
(`ElizaError`, `runtime.reportError`, diff-scoped `audit:error-policy-ratchet`).

### Suspect derivation

Re-derived the full slice suspect list (empty-catch + `.catch(()=>{}|null|undefined)`
+ return-default catches over the six trees, non-test `.ts/.tsx`, sorted -u = **55
files**), then took `index%2==1` → **27 files** in this slice.

### Per-category tally

| Category | Count | Action |
|---|---|---|
| empty catch (real) | 0 | none — the only `catch {}` hits are inside embedded PowerShell string literals in `plugin-coding-tools/src/actions/bash.ts` (exempt per the issue) |
| fabricated-healthy-on-error | **1 converted** | `cloud-features-routes.ts` |
| promise-swallow | 0 convert / annotated | every `.catch(()=>…)` in-slice is J6 teardown, J3 probe, or J5 (already annotated) |
| justified handlers annotated | **40** `// error-policy:J<N>` | J1/J3/J4/J6 |
| ambiguous — deferred | 4 return-null/[]/`?? <lit>` sites | per-site judgment, out of this clear-slop pass |

### The one conversion — fabricated-healthy fast-fail

`plugins/plugin-personal-assistant/src/routes/cloud-features-routes.ts`

A Cloud `/api/v1/features` **200** whose body was not valid JSON was swallowed
(`await upstream.json().catch(() => null)`) and returned as
`{ status: 200, rows: [], error: null }` — a "synced, zero features" **success**.
Downstream `handleSync` then promotes the Cloud-default-on flags and **skips**
every flag the corrupt response omitted, logging "synced 0 feature(s)". A broken
upstream read was indistinguishable from an empty feature set (the parent's
banned "not loaded" == "empty" conflation).

Now a 200 with an unparseable body returns `status: 502` + the parse error, so
"sync failed" is distinguishable from "synced, zero features". `fetchCloudFeatures`
is exported and covered by a **real error-path test** (no mocking of the parse
boundary under test):

- unparseable 200 → `502` + `error` matches `/not valid JSON/`, `rows` empty
- well-formed 200 → `200`, `error: null` (legit path preserved — no over-removal)
- genuinely empty-but-valid `{ features: [] }` → `200`, `error: null` (a real
  empty result is **not** an error)

### Annotated justified handlers (kept — 40 sites)

- **J6 best-effort teardown**: ACP `cancel`/`closeSession`/`stopSession` on
  dead/failed sessions (`acp-native-transport.ts`, `sub-agent-router.ts` ×6),
  partial-lock unwind (`orchestrator-task-store.ts`), final cap notice.
- **J3 untrusted-input / parse / probe**: `decodeURIComponent` (parent-context &
  bridge routes), `new URL(...)` guards, `which`/`where` + `access(X_OK)` binary
  probes, model-output JSON parse (`json-model-output`, `skill-recommender`,
  `prioritize`, `extract-task-plan`), stored task-doc parse, `realpath`
  existence probe (throws after), MCP-servers env parse, `Intl.supportedValuesOf`
  capability probe.
- **J4 designed degrade**: optional native `import`, best-effort OCR, connector-
  unavailable, coding-account fallback (with `diagnoseCodingAccountFallback`
  surfacing the degraded case, #9960), session-event hot-path degrade (#11778).
- **J1 route boundary**: `parent-context-routes` outer handler → structured HTTP
  error (`return true` = handled, not succeeded).

Deferred (counted, not touched this pass): ambiguous `return null/[]/false` where
masking-a-failure vs legitimate-absence needs per-site judgment (owner-profile
config read/write, continuity-probe presence scan), and `?? <lit>` load defaults.

### Ratchet — emptyCatch before → after (touched files)

`bun run audit:error-policy-ratchet`: every touched file **emptyCatch 0 → 0,
serverConsole 0 → 0** → **no new fallback-slop in touched files**. (No empty
catch or `console.*` added; the slice had zero real empty catches to remove.)

### Test results

- **plugin-agent-orchestrator**: full suite **1627 passed | 8 skipped** (all
  edits here are comment-only annotations).
- **plugin-personal-assistant**: new `cloud-features-routes.test.ts` **3/3
  passed**; 37 runnable scoped tests green. The remaining PA test files fail
  only at **import time** on packages excluded by this worktree's sparse checkout
  (`@elizaos/plugin-blocker`, `@elizaos/plugin-phone`, `@elizaos/macosreminders`,
  `@elizaos/app-core/api/auth`) — an environment artifact identical on clean
  `origin/develop`, not a regression from this change (all non-route edits are
  comment-only).
- Typecheck of the changed files is clean (`cloud-features-routes.ts` has zero
  errors); the only reported errors are pre-existing missing-module / implicit-
  `any` diagnostics in untouched lines of sparse-excluded-dependency files.

Refs #12273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
