### PR TITLE
fix(core): keep undeclared, uncataloged providers ungated at the planner context filter (#13204 follow-up)

### DIFF
--- a/packages/core/src/runtime/context-gates.test.ts
+++ b/packages/core/src/runtime/context-gates.test.ts
@@ -130,14 +130,61 @@ describe("filterProvidersByContextGate — full declared contextGate honored (#1
 		).toEqual([]);
 	});
 
-	it("defaults an undeclared, uncataloged provider to the general context", () => {
-		const undeclared = { name: "TOTALLY_UNDECLARED_SIGNAL" };
+	it("keeps an undeclared, uncataloged provider on every turn — prior inclusion parity (#13204 follow-up)", () => {
+		// A plugin provider that declares nothing (no contexts, no contextGate)
+		// and has no catalog entry — the TWITTER_IDENTITY shape. Before #13203's
+		// provider-specific resolver, the selection filter (filterByContextGate)
+		// gated only on the contexts the object carries, so this class was
+		// included on every turn. Undeclared must stay on the safe side: only an
+		// explicitly declared gate/contexts or a catalog entry may exclude a
+		// provider from a turn.
+		const undeclared = { name: "TWITTER_IDENTITY" };
+		for (const turn of [["general"], ["messaging"], []] as AgentContext[][]) {
+			expect(filterProvidersByContextGate([undeclared], turn)).toEqual(
+				filterByContextGate([undeclared], turn),
+			);
+			expect(filterProvidersByContextGate([undeclared], turn)).toEqual([
+				undeclared,
+			]);
+		}
+	});
+
+	it("fail-open on contexts never waives an undeclared provider's roleGate", () => {
+		const gated = {
+			name: "UNDECLARED_ADMIN_SIGNAL",
+			roleGate: { minRole: "ADMIN" as RoleGateRole },
+		};
 		expect(
-			filterProvidersByContextGate([undeclared], ["general"] as AgentContext[]),
-		).toEqual([undeclared]);
-		expect(
-			filterProvidersByContextGate([undeclared], ["wallet"] as AgentContext[]),
+			filterProvidersByContextGate([gated], ["messaging"] as AgentContext[], [
+				"USER",
+			]),
 		).toEqual([]);
+		expect(
+			filterProvidersByContextGate([gated], ["messaging"] as AgentContext[], [
+				"ADMIN",
+			]),
+		).toEqual([gated]);
+	});
+
+	it("still leans a provider whose contexts were materialized at registration", () => {
+		// The wrapped registration path (plugin-lifecycle) materializes the
+		// undeclared class to ["general"]; a provider carrying that resolution
+		// stays leaned off narrow turns — the fail-open default above applies
+		// only to providers that reach the filter with no contexts at all.
+		const materialized = {
+			name: "TWITTER_IDENTITY",
+			contexts: ["general"] as AgentContext[],
+		};
+		expect(
+			filterProvidersByContextGate([materialized], [
+				"messaging",
+			] as AgentContext[]),
+		).toEqual([]);
+		expect(
+			filterProvidersByContextGate([materialized], [
+				"general",
+			] as AgentContext[]),
+		).toEqual([materialized]);
 	});
 
 	it("keeps declared-contexts providers on their declared routing (hot-path parity)", () => {

--- a/packages/core/src/runtime/context-gates.ts
+++ b/packages/core/src/runtime/context-gates.ts
@@ -12,7 +12,7 @@ import type {
 	RoleGate,
 	RoleGateRole,
 } from "../types/contexts";
-import { resolveProviderContexts } from "../utils/context-catalog";
+import { lookupProviderCatalogContexts } from "../utils/context-catalog";
 import { normalizeContextList } from "./context-normalization";
 
 // #9948: single source of truth for role ranking — delegates to CANONICAL_ROLE_RANK.
@@ -143,8 +143,15 @@ export interface ProviderContextGateCandidate extends ContextGateCandidate {
  * verbatim — `filterByContextGate`'s `{contexts, roleGate}` reduction silently
  * dropped anyOf/allOf/noneOf, so a world-style `contextGate: { anyOf: [...] }`
  * provider lost its gate on the v5 planner selection path. Providers declaring
- * no gate terms resolve declared `contexts` → catalog (PROVIDER_CONTEXT_MAP) →
- * `["general"]`.
+ * no gate terms resolve declared `contexts` → catalog (PROVIDER_CONTEXT_MAP);
+ * a provider with neither declares no routing at all, and stays UNGATED
+ * (#13204 follow-up): the pre-#13203 selection filter included that class on
+ * every turn, and an injected `["general"]` here would silently drop
+ * undeclared plugin providers (TWITTER_IDENTITY-shaped) from the narrow turns
+ * they rode before. Only an explicit declaration or catalog entry may gate a
+ * provider out; the wrapped registration path still materializes the
+ * `["general"]` lean onto `contexts` (plugin-lifecycle), which this resolver
+ * honors as declared.
  *
  * #12087 Item 14 preserved: a contextGate adds context requirements; it does
  * not waive the provider's top-level roleGate unless it declares its own.
@@ -170,7 +177,16 @@ export function resolveProviderContextGate(
 		};
 	}
 
-	return { contexts: resolveProviderContexts(provider), roleGate };
+	const declared = (provider.contexts ?? []).filter((context) =>
+		Boolean(context),
+	);
+	return {
+		contexts:
+			declared.length > 0
+				? declared
+				: lookupProviderCatalogContexts(provider.name),
+		roleGate,
+	};
 }
 
 /**

--- a/packages/core/src/services/message.planner-provider-selection.test.ts
+++ b/packages/core/src/services/message.planner-provider-selection.test.ts
@@ -104,6 +104,33 @@ describe("selectV5PlannerStateProviderNames — declared contextGate honored (#1
 		expect(select([declared], ["wallet"])).not.toContain("DECLARED_SIGNAL");
 	});
 
+	it("keeps an undeclared, uncataloged plugin provider on narrow turns (#13204 follow-up)", () => {
+		// TWITTER_IDENTITY shape: a plugin provider with no contexts, no
+		// contextGate, and no catalog entry. Hosts that bypass the wrapped
+		// registration path hand the selection exactly this object; the pre-#13203
+		// filter included it on every turn, and undeclared must keep that safe
+		// default — only a declared gate/contexts or catalog entry may gate it out.
+		const undeclared = provider({ name: "TWITTER_IDENTITY", dynamic: true });
+		expect(select([undeclared], ["messaging"])).toContain("TWITTER_IDENTITY");
+		expect(select([undeclared], ["general"])).toContain("TWITTER_IDENTITY");
+		expect(select([undeclared], [])).toContain("TWITTER_IDENTITY");
+	});
+
+	it("keeps the registration-materialized general lean for providers that carry it (#13204 follow-up)", () => {
+		// The wrapped registration path materializes the undeclared class to
+		// ["general"] (plugin-lifecycle); those providers stay off narrow turns.
+		const materialized = provider({
+			name: "NOISY_PLUGIN_SIGNAL",
+			contexts: ["general"],
+		});
+		expect(select([materialized], ["wallet"])).not.toContain(
+			"NOISY_PLUGIN_SIGNAL",
+		);
+		expect(select([materialized], ["general"])).toContain(
+			"NOISY_PLUGIN_SIGNAL",
+		);
+	});
+
 	it("composes RECENT_ERRORS on every turn via alwaysInResponseState (#13203)", () => {
 		// RECENT_ERRORS is uncataloged and declares no contexts; without the
 		// always-on opt-in it would resolve to ["general"] and miss the narrow


### PR DESCRIPTION
Follow-up to #13203 (landed via #13223, supersedes #13204). `[core-brain]`

## The gap

`resolveProviderContextGate` resolved a provider that declares **no contexts, no contextGate, and has no catalog entry** to an injected `["general"]`. On the v5 planner selection path that silently gates the undeclared plugin-provider class (the `TWITTER_IDENTITY` shape: a dynamic plugin provider that declares nothing) off narrow turns — turns the pre-#13203 selection filter (`filterByContextGate`, which gates only on the contexts the object carries) included them on.

Repro on `develop` (before this fix):

```ts
const undeclared = { name: "TWITTER_IDENTITY" }; // no contexts / gate / catalog entry
filterByContextGate([undeclared], ["messaging"]);          // [provider]  (pre-#13203 filter: included)
filterProvidersByContextGate([undeclared], ["messaging"]); // []          (leaned out — the gap)
```

## The fix (structural, one function)

Undeclared defaults to the **safe side**: `resolveProviderContextGate`'s no-gate-terms branch now resolves declared `contexts` → catalog (`PROVIDER_CONTEXT_MAP`) → **ungated** (no context terms → included), instead of → `["general"]`. Only an explicit declaration or a catalog entry may gate a provider out of a turn.

Everything #13223 fixed is preserved:
- declared `contextGate` anyOf/allOf/noneOf honored verbatim (unchanged);
- catalog routing for undeclared-but-cataloged names (`AVAILABLE_AGENTS`/`ACTIVE_SUB_AGENTS` → code/automation) unchanged;
- `roleGate` enforcement is not waived by the fail-open contexts (new regression test);
- the wrapped registration path (plugin-lifecycle) still materializes the `["general"]` lean onto `contexts`, and the resolver honors that as declared — **registered** providers keep today's lean, so no context-flood regression on the live path. The fail-open covers exactly the class that reaches the filter without materialized contexts.

## Tests

New tests fail on `develop` before the fix, pass after:
- `context-gates.test.ts` — undeclared/uncataloged provider kept on general, narrow, and empty turns with `filterByContextGate` parity (prior inclusion); roleGate still enforced under fail-open; registration-materialized `["general"]` still leaned off narrow turns.
- `message.planner-provider-selection.test.ts` — `selectV5PlannerStateProviderNames` keeps the undeclared class on narrow turns; materialized `["general"]` providers stay off narrow turns.

## Verification

- Gap proof: 3 new tests failed on unmodified develop (`3 failed | 20 passed`), all pass after the fix.
- `vitest run` packages/core `src/runtime` + `src/utils`: 102 files, 1097/1097 passed.
- `vitest run` packages/core `src/services`: 29 files, 366/366 passed.
- Gate-adjacent surface (context-gates, planner-selection, context-catalog, context-registry, plugin-lifecycle role-gate): 45/45 → 48/48 with new tests.
- `tsgo --noEmit -p packages/core/tsconfig.json`: zero delta (the same 4 pre-existing module-resolution errors appear with and without this diff in the sandbox env; none touch changed files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
