### PR TITLE
feat(#12777,#12778): adaptive window-span learning + schedule-style spine-read (D1/D2 gap-fill)

### DIFF
--- a/plugins/plugin-personal-assistant/src/activity-profile/analyzer.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/analyzer.ts
@@ -741,6 +741,10 @@ export function analyzeMessages(
     typicalLastActiveHour,
     typicalWakeHour,
     typicalSleepHour,
+    // Surface the observed distributions (ascending) so the window learner can
+    // derive the active-band width from their spread rather than a fixed span.
+    wakeHours,
+    sleepHours,
     hasSleepData,
     isCurrentlySleeping,
     lastSleepSignalAt,

--- a/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.ts
@@ -206,6 +206,11 @@ export async function executeProactiveTask(
       {
         typicalWakeHour: profile.typicalWakeHour,
         typicalSleepHour: profile.typicalSleepHour,
+        // Feed the observed distributions so the morning/evening band width is
+        // learned (IQR-clamped) rather than fixed; sparse samples fall back to
+        // the historical fixed spans inside deriveWindowsFromRhythm.
+        wakeHours: profile.wakeHours,
+        sleepHours: profile.sleepHours,
       },
       now,
     );

--- a/plugins/plugin-personal-assistant/src/activity-profile/types.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/types.ts
@@ -100,6 +100,15 @@ export interface ActivityProfile {
   typicalLastActiveHour: number | null;
   typicalWakeHour: number | null;
   typicalSleepHour: number | null;
+  /**
+   * Observed wake-boundary hours (session start hours + health wake hours),
+   * ascending. Surfaced additively so the window learner can derive the
+   * active-band WIDTH (IQR) instead of assuming a fixed span. Optional for
+   * back-compat with profiles/records built before this field landed.
+   */
+  wakeHours?: number[];
+  /** Observed sleep-boundary hours (session end + health sleep hours), ascending. */
+  sleepHours?: number[];
   hasSleepData: boolean;
   isCurrentlySleeping: boolean;
   lastSleepSignalAt: number | null;

--- a/plugins/plugin-personal-assistant/src/activity-profile/window-learning.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/window-learning.test.ts
@@ -129,6 +129,108 @@ describe("deriveWindowsFromRhythm (pure mapping)", () => {
   });
 });
 
+describe("deriveWindowsFromRhythm (adaptive span from observed distribution)", () => {
+  /** Width, in whole hours, of a same-day HH:00 window (end - start). */
+  function widthHours(w?: { startLocal: string; endLocal: string }): number {
+    if (!w) return Number.NaN;
+    const [sh] = w.startLocal.split(":").map(Number);
+    const [eh] = w.endLocal.split(":").map(Number);
+    return (eh as number) - (sh as number);
+  }
+
+  // A TIGHT owner: wakes ~7 every day, winds down ~22 every day.
+  const tight = {
+    typicalWakeHour: 7,
+    typicalSleepHour: 22,
+    wakeHours: [7, 7, 7, 8, 7, 7],
+    sleepHours: [22, 22, 21, 22, 22, 22],
+  };
+  // A WIDE owner: wake scattered 6..12, wind-down scattered 20..26(=02).
+  const wide = {
+    typicalWakeHour: 9,
+    typicalSleepHour: 23,
+    wakeHours: [6, 7, 9, 10, 12],
+    sleepHours: [20, 22, 23, 24, 26],
+  };
+
+  it("narrows the morning span for a tight distribution vs a wide one", () => {
+    const t = deriveWindowsFromRhythm(tight);
+    const w = deriveWindowsFromRhythm(wide);
+    expect(widthHours(t.morningWindow)).toBeLessThan(
+      widthHours(w.morningWindow),
+    );
+    // Tight IQR≈0 clamps to the 1h floor; explicit 07:00–08:00.
+    expect(t.morningWindow).toEqual({ startLocal: "07:00", endLocal: "08:00" });
+    // Wide IQR = 3 → 09:00–12:00.
+    expect(w.morningWindow).toEqual({ startLocal: "09:00", endLocal: "12:00" });
+  });
+
+  it("narrows the evening span for a tight distribution vs a wide one", () => {
+    const t = deriveWindowsFromRhythm(tight);
+    const w = deriveWindowsFromRhythm(wide);
+    expect(widthHours(t.eveningWindow)).toBeLessThan(
+      widthHours(w.eveningWindow),
+    );
+    expect(t.eveningWindow).toEqual({ startLocal: "21:00", endLocal: "22:00" });
+    expect(w.eveningWindow).toEqual({ startLocal: "21:00", endLocal: "23:00" });
+  });
+
+  it("keeps every learned span inside [1,6] and every window non-inverted", () => {
+    for (const sample of [tight, wide]) {
+      const windows = deriveWindowsFromRhythm(sample);
+      for (const win of [windows.morningWindow, windows.eveningWindow]) {
+        const width = widthHours(win);
+        expect(width).toBeGreaterThanOrEqual(1);
+        expect(width).toBeLessThanOrEqual(6);
+        // Non-inverted: end strictly after start (positive width).
+        expect(width).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("a tight learned morning span is strictly narrower than the fixed 3h fallback", () => {
+    const t = deriveWindowsFromRhythm(tight);
+    expect(widthHours(t.morningWindow)).toBe(1);
+    expect(widthHours(t.morningWindow)).toBeLessThan(3);
+  });
+
+  it("still refuses a wrapping window even with a distribution present", () => {
+    // wake 23:00, span clamps to ≥1h → band [23:00, 24:00) inverts to
+    // start(23) >= end(00): unsatisfiable, must be declined.
+    const windows = deriveWindowsFromRhythm({
+      typicalWakeHour: 23,
+      typicalSleepHour: null,
+      wakeHours: [22, 23, 23, 24],
+    });
+    expect(windows.morningWindow).toBeUndefined();
+  });
+
+  it("falls back to the fixed 3h/2h spans when there are <2 samples", () => {
+    // Single-sample distribution → no spread → fixed fallback (matches the
+    // legacy no-array path exactly).
+    const oneSample = deriveWindowsFromRhythm({
+      typicalWakeHour: 7,
+      typicalSleepHour: 23,
+      wakeHours: [7],
+      sleepHours: [23],
+    });
+    expect(oneSample.morningWindow).toEqual({
+      startLocal: "07:00",
+      endLocal: "10:00",
+    });
+    expect(oneSample.eveningWindow).toEqual({
+      startLocal: "21:00",
+      endLocal: "23:00",
+    });
+    // No arrays at all → identical fixed fallback.
+    const noArrays = deriveWindowsFromRhythm({
+      typicalWakeHour: 7,
+      typicalSleepHour: 23,
+    });
+    expect(noArrays).toEqual(oneSample);
+  });
+});
+
 describe("resolveWindowPatch (override + idempotency policy)", () => {
   it("writes both windows when facts are empty (default → learned)", () => {
     const patch = resolveWindowPatch(

--- a/plugins/plugin-personal-assistant/src/activity-profile/window-learning.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/window-learning.ts
@@ -38,6 +38,19 @@ export interface LearnedWindows {
 export interface RhythmSample {
   typicalWakeHour: number | null;
   typicalSleepHour: number | null;
+  /**
+   * Observed wake-boundary hours (session start hours + health wake hours),
+   * surfaced additively by the analyzer. When ≥2 samples are present the
+   * morning span is LEARNED from their spread (IQR) instead of a fixed
+   * default; absent/sparse falls back to {@link FALLBACK_MORNING_SPAN_HOURS}.
+   */
+  wakeHours?: number[];
+  /**
+   * Observed sleep-boundary hours (session end + health sleep hours). Drives
+   * the learned evening span the same way; falls back to
+   * {@link FALLBACK_EVENING_SPAN_HOURS} when sparse.
+   */
+  sleepHours?: number[];
 }
 
 /**
@@ -47,18 +60,63 @@ export interface RhythmSample {
 const USER_OWNED_SOURCES = new Set(["first_run", "profile_save"]);
 
 /**
- * Morning window duration: from wake hour to `wake + MORNING_SPAN_HOURS`. The
- * span is the flexible band inside which a `during_window: "morning"` task may
- * fire, not a fixed instant.
+ * Clamp band for a LEARNED span. The span is the flexible band inside which a
+ * `during_window` task may fire. A very-regular owner (IQR≈0) yields a tight
+ * window (never 0 — that would invert); a scattered owner yields a wider, more
+ * forgiving band, capped so it never swallows the whole day.
  */
-const MORNING_SPAN_HOURS = 3;
+const MIN_SPAN_HOURS = 1;
+const MAX_SPAN_HOURS = 6;
 
 /**
- * Evening window: `[sleep - EVENING_LEAD_HOURS, sleep)`. The band closes at the
- * observed sleep hour so a `during_window: "evening"` task lands before the
- * user winds down, and starts a couple hours earlier so it stays flexible.
+ * Morning-window fallback span, used ONLY when there is no observed
+ * distribution to learn from (<2 samples). Preserves the historical
+ * `wake → wake + 3h` behaviour for back-compat.
  */
-const EVENING_LEAD_HOURS = 2;
+const FALLBACK_MORNING_SPAN_HOURS = 3;
+
+/**
+ * Evening-window fallback span: `[sleep - 2h, sleep)`. The band closes at the
+ * observed sleep hour so a `during_window: "evening"` task lands before the
+ * user winds down. Used only when there is no distribution to learn from.
+ */
+const FALLBACK_EVENING_SPAN_HOURS = 2;
+
+/**
+ * Linear-interpolated percentile of an ascending numeric sample (`p` in
+ * `[0,1]`). Matches the robust-spread definition proven in the D1 prototype.
+ */
+function percentile(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 0) return Number.NaN;
+  if (sortedAsc.length === 1) return sortedAsc[0] as number;
+  const idx = p * (sortedAsc.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  const frac = idx - lo;
+  return (
+    (sortedAsc[lo] as number) +
+    ((sortedAsc[hi] as number) - (sortedAsc[lo] as number)) * frac
+  );
+}
+
+/**
+ * Learn a span from the observed active-band width. Uses the inter-quartile
+ * range (p75 − p25) as a robust "width of the band", clamped to
+ * `[MIN_SPAN_HOURS, MAX_SPAN_HOURS]`. Needs ≥2 finite samples to have a spread;
+ * otherwise returns the supplied fallback (back-compat with the fixed spans).
+ */
+function deriveSpanHours(
+  hours: number[] | undefined,
+  fallbackSpan: number,
+): number {
+  const clean = (hours ?? [])
+    .filter((h) => Number.isFinite(h))
+    .sort((a, b) => a - b);
+  if (clean.length < 2) return fallbackSpan;
+  const iqr = percentile(clean, 0.75) - percentile(clean, 0.25);
+  if (!Number.isFinite(iqr)) return fallbackSpan;
+  return Math.min(MAX_SPAN_HOURS, Math.max(MIN_SPAN_HOURS, iqr));
+}
 
 function clampHour(hour: number): number {
   // Wrap into [0, 24). Sessions that end after midnight produce a
@@ -93,10 +151,14 @@ function validSameDayWindow(
 
 /**
  * Map observed wake/sleep hours into flexible morning/evening windows. Pure:
- * no store access, no clock. Returns only the windows the sample can support
- * AND that resolve to a valid (non-inverted) `during_window` band — an edge
- * chronotype whose derived band would wrap past midnight is skipped, never
- * written as an unsatisfiable window.
+ * no store access, no clock. The band WIDTH is learned from the observed
+ * activity distribution (IQR of the wake/sleep samples, clamped to
+ * `[MIN_SPAN_HOURS, MAX_SPAN_HOURS]`) when ≥2 samples exist, and falls back to
+ * the historical fixed spans otherwise. Returns only the windows the sample can
+ * support AND that resolve to a valid (non-inverted) `during_window` band — an
+ * edge chronotype whose derived band would wrap past midnight is skipped, never
+ * written as an unsatisfiable window (the resolver has no wraparound; the
+ * clamped span keeps this guard intact for every chronotype).
  */
 export function deriveWindowsFromRhythm(sample: RhythmSample): LearnedWindows {
   const result: LearnedWindows = {};
@@ -105,9 +167,10 @@ export function deriveWindowsFromRhythm(sample: RhythmSample): LearnedWindows {
     typeof sample.typicalWakeHour === "number" &&
     Number.isFinite(sample.typicalWakeHour)
   ) {
+    const span = deriveSpanHours(sample.wakeHours, FALLBACK_MORNING_SPAN_HOURS);
     const morning = validSameDayWindow(
       sample.typicalWakeHour,
-      sample.typicalWakeHour + MORNING_SPAN_HOURS,
+      sample.typicalWakeHour + span,
     );
     if (morning) result.morningWindow = morning;
   }
@@ -116,8 +179,12 @@ export function deriveWindowsFromRhythm(sample: RhythmSample): LearnedWindows {
     typeof sample.typicalSleepHour === "number" &&
     Number.isFinite(sample.typicalSleepHour)
   ) {
+    const span = deriveSpanHours(
+      sample.sleepHours,
+      FALLBACK_EVENING_SPAN_HOURS,
+    );
     const evening = validSameDayWindow(
-      sample.typicalSleepHour - EVENING_LEAD_HOURS,
+      sample.typicalSleepHour - span,
       sample.typicalSleepHour,
     );
     if (evening) result.eveningWindow = evening;

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/fact-store.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/fact-store.ts
@@ -984,5 +984,12 @@ export function ownerFactsToView(
       tz: facts.quietHours.value.timezone,
     };
   }
+  // Learned schedule-shape facts (#12778): surface the queryable structural
+  // classifications onto the spine view so gates/routing (via
+  // `defaultOwnerFactsProvider`) can read them. Provenance is dropped — readers
+  // want the value — but the store guarantees these are `agent_inferred` and
+  // never clobber a user-set fact.
+  if (facts.scheduleStyle) view.scheduleStyle = facts.scheduleStyle.value;
+  if (facts.chronotype) view.chronotype = facts.chronotype.value;
   return view;
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/schedule-style-view.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/schedule-style-view.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Spine-read coverage for the learned schedule-shape facts (#12778).
+ *
+ * #13233 landed the `scheduleStyle` / `chronotype` owner facts + their
+ * `agent_inferred` writer, but did NOT wire them onto the scheduling spine's
+ * `OwnerFactsView`. This exercises `ownerFactsToView` directly, asserting the
+ * mapper now projects both facts onto the view the runner / gates read via
+ * `defaultOwnerFactsProvider`, completing "queryable structural facts".
+ *
+ * Pure transform — no runtime graph. The view type is the real
+ * `@elizaos/plugin-scheduling` `OwnerFactsView`, so this also proves the spine
+ * contract actually carries the fields (a compile error here would mean the
+ * view was never widened).
+ */
+import type { OwnerFactsView } from "@elizaos/plugin-scheduling";
+import { describe, expect, it } from "vitest";
+import {
+  type OwnerFactProvenance,
+  type OwnerFacts,
+  ownerFactsToView,
+} from "./fact-store.ts";
+
+const NOW = new Date("2026-07-04T12:00:00.000Z");
+
+const inferred: OwnerFactProvenance = {
+  source: "agent_inferred",
+  recordedAt: "2026-07-01T00:00:00.000Z",
+  note: "learned from schedule-insight regularity",
+};
+
+describe("ownerFactsToView — schedule-style spine read (#12778)", () => {
+  it("projects scheduleStyle and chronotype onto the spine view", () => {
+    const facts: OwnerFacts = {
+      scheduleStyle: { value: "irregular", provenance: inferred },
+      chronotype: { value: "late", provenance: inferred },
+    };
+    const view: OwnerFactsView = ownerFactsToView(facts, NOW);
+    expect(view.scheduleStyle).toBe("irregular");
+    expect(view.chronotype).toBe("late");
+  });
+
+  it("carries each classification value the writer can emit", () => {
+    for (const style of ["regular", "irregular", "rotating"] as const) {
+      const view = ownerFactsToView(
+        { scheduleStyle: { value: style, provenance: inferred } },
+        NOW,
+      );
+      expect(view.scheduleStyle).toBe(style);
+    }
+    for (const chrono of ["early", "intermediate", "late"] as const) {
+      const view = ownerFactsToView(
+        { chronotype: { value: chrono, provenance: inferred } },
+        NOW,
+      );
+      expect(view.chronotype).toBe(chrono);
+    }
+  });
+
+  it("omits the fields when the facts are absent (absence != a value)", () => {
+    const view = ownerFactsToView({}, NOW);
+    expect(view.scheduleStyle).toBeUndefined();
+    expect(view.chronotype).toBeUndefined();
+  });
+
+  it("drops provenance but preserves the value (readers want the value)", () => {
+    const view = ownerFactsToView(
+      {
+        scheduleStyle: { value: "rotating", provenance: inferred },
+        chronotype: { value: "early", provenance: inferred },
+      },
+      NOW,
+    );
+    // The view is provenance-free by contract; only the raw classification
+    // reaches the spine.
+    expect(view).toMatchObject({
+      scheduleStyle: "rotating",
+      chronotype: "early",
+    });
+    expect(JSON.stringify(view)).not.toContain("agent_inferred");
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/types.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/types.ts
@@ -321,6 +321,15 @@ export interface OwnerFactsView {
     sampleCount?: number;
     windowDays?: number;
   };
+  /**
+   * Learned day-to-day schedule shape, derived from observed sleep regularity
+   * (`rotating` = a two-band shift-work pattern, distinct from merely noisy
+   * `irregular`). Structural owner fact the spine can gate/route on. Absent
+   * until enough evidence accrues.
+   */
+  scheduleStyle?: "regular" | "irregular" | "rotating";
+  /** Learned chronotype from the owner's mid-sleep point (MCTQ-style terciles). */
+  chronotype?: "early" | "intermediate" | "late";
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes the two D1/D2 sub-capabilities that the merged runtime PRs (#13233 D2-facts, #13235 D1-anchor+D2-bus, #13237 D3) did **not** cover, completing the outer done-when of **#12777** and **#12778**. Additive, structural, contract-clean.

### 1. Adaptive window-span learning (#12777)
`window-learning.ts` learned only the window *anchor*, using a fixed `MORNING_SPAN_HOURS=3` / `EVENING_LEAD_HOURS=2` *width* for everyone. Now the span is learned from the observed activity distribution: `clamp(IQR(p75−p25), 1, 6)`, with the fixed spans demoted to fallbacks used only when `<2` samples exist. `analyzer.ts` already computed `wakeHours`/`sleepHours` but discarded them — now surfaced additively and threaded through `proactive-worker.ts → learnRhythmWindows`. The `validSameDayWindow` no-inverted/no-wrapping guard is unchanged (the plugin-scheduling resolver can't handle wraparound), and writes stay `agent_inferred` + clobber-guarded.

### 2. Schedule-style facts spine-read (#12778)
#13233 landed the `OwnerFacts.scheduleStyle`/`chronotype` writer but did **not** wire them to the scheduling spine — `OwnerFactsView` lacked the fields and `ownerFactsToView` didn't emit them, so the facts were invisible to scheduling logic. This adds `scheduleStyle?`/`chronotype?` to `OwnerFactsView` (plugin-scheduling `types.ts`, inline unions matching the writer) and emits them in `ownerFactsToView`, completing #12778's "queryable structural facts" done-when.

### Scope note — travelActive is already done (not re-implemented)
The original gap list included a travelActive writer, but this tree already has a real, wired one: `reconcileTravelActive` (`reminders-service.ts`) opens/clears a provisional `activeTravel` window from device-timezone divergence (IANA-string compare, DST-safe; never rewrites the home `timezone` fact; self-clears on return), and `ownerFactsToView` already derives `travelActive` from it. Building a second ring-buffer detector writing the same fact would violate the one-mechanism contract, so it was **deliberately not added**. The `during_travel` gate flip is covered by existing passing tests.

## Tests (10 new, all green)
- `window-learning.test.ts` (+6): tight vs wide distribution narrows/widens the span; every span ∈ [1,6] and non-inverted; a tight learned span is strictly narrower than the 3h fallback; still refuses wrapping windows; falls back to fixed spans when <2 samples.
- `schedule-style-view.test.ts` (+4): projects scheduleStyle/chronotype onto the spine view; carries every classification value; omits fields when absent; drops provenance but preserves value.

## Evidence
- `bun run --cwd plugins/plugin-personal-assistant lint:default-packs` → **clean, 0 findings**
- Targeted PA tests (window-learning + schedule-style-view) → **23 passed**
- PA `src/activity-profile` + `src/lifeops/owner` → **74 passed**; `activity-gates` → **11 passed**
- `plugin-scheduling` full suite → **241 passed** (incl. `during_travel` runner)
- `build:types` → passed; `plugin-scheduling` isolated `tsgo --noEmit` → clean (validates the `OwnerFactsView` change)
- Full-PA `tsc --noEmit` and a handful of PA vitest files fail **pre-existing/environmental** reasons (unbuilt workspace deps `@elizaos/plugin-app-manager` etc.; develop's own `travel_reconcile` test cache-mock gap) — all reproduce on develop and touch **none** of the 8 files changed here. **N/A** — not introduced by this change.
- Live-LLM trajectory: **N/A** — pure structural window-math + view-projection change with no model call; unit + integration coverage above is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)