### PR TITLE
test(core): use source imports for provider gate coverage

### DIFF
--- a/packages/core/src/runtime/context-gates.test.ts
+++ b/packages/core/src/runtime/context-gates.test.ts
@@ -6,13 +6,13 @@
  */
 import { describe, expect, it } from "vitest";
 import type { AgentContext } from "../types/contexts";
-import type { RoleGateRole } from "./context-gates";
+import type { RoleGateRole } from "./context-gates.ts";
 import {
 	filterByContextGate,
 	filterProvidersByContextGate,
 	normalizeGateRole,
 	resolveProviderContextGate,
-} from "./context-gates";
+} from "./context-gates.ts";
 
 /**
  * Tests for the role-gate normalizer (#8801 / #9943). normalizeGateRole canon-

--- a/packages/core/src/runtime/context-gates.ts
+++ b/packages/core/src/runtime/context-gates.ts
@@ -12,7 +12,7 @@ import type {
 	RoleGate,
 	RoleGateRole,
 } from "../types/contexts";
-import { lookupProviderCatalogContexts } from "../utils/context-catalog";
+import { lookupProviderCatalogContexts } from "../utils/context-catalog.ts";
 import { normalizeContextList } from "./context-normalization";
 
 // #9948: single source of truth for role ranking — delegates to CANONICAL_ROLE_RANK.

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -60,7 +60,7 @@ import {
 	type CandidateActionBackstopRule,
 	getCandidateActionBackstopRules,
 } from "../runtime/candidate-action-backstop";
-import { filterProvidersByContextGate } from "../runtime/context-gates";
+import { filterProvidersByContextGate } from "../runtime/context-gates.ts";
 import { computePrefixHashes, hashString } from "../runtime/context-hash";
 import {
 	appendContextEvent,


### PR DESCRIPTION
## Summary
- make provider-gate tests import `context-gates.ts` explicitly
- make `message.ts` and `context-gates.ts` import source modules explicitly so Vitest does not resolve stale side-by-side JS emits

Follow-up to #13283.

## Verification
- TMPDIR=/private/tmp/codex-test-tmp bun run --cwd packages/core test -- src/runtime/context-gates.test.ts src/services/message.planner-provider-selection.test.ts
- TMPDIR=/private/tmp/codex-test-tmp bunx biome check packages/core/src/runtime/context-gates.test.ts packages/core/src/runtime/context-gates.ts packages/core/src/services/message.ts
- TMPDIR=/private/tmp/codex-test-tmp bun run --cwd packages/core typecheck
- git diff --check origin/develop...HEAD