### PR TITLE
fix(test): use Bun module mock for available agents provider

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts
@@ -2,27 +2,19 @@
  * Verifies availableAgentsProvider.
  * Deterministic unit test of pure helpers; no runtime, no live model.
  */
+import { mock } from "bun:test";
 import { describe, expect, it, vi } from "vitest";
 
 // Control the framework-state probe so we can drive its failure path
 // deterministically without touching the filesystem / env discovery it does.
 const getTaskAgentFrameworkStateMock = vi.fn();
-vi.mock(
-  "../../src/services/task-agent-frameworks.js",
-  async (importOriginal) => {
-    const actual =
-      await importOriginal<
-        typeof import("../../src/services/task-agent-frameworks.js")
-      >();
-    return {
-      ...actual,
-      getTaskAgentFrameworkState: (...args: unknown[]) =>
-        getTaskAgentFrameworkStateMock(...args),
-    };
-  },
-);
+mock.module("../../src/services/task-agent-frameworks.js", () => {
+  return {
+    getTaskAgentFrameworkState: (...args: unknown[]) =>
+      getTaskAgentFrameworkStateMock(...args),
+  };
+});
 
-import { availableAgentsProvider } from "../../src/providers/available-agents.js";
 import {
   memory,
   runtimeWith,
@@ -30,6 +22,10 @@ import {
   session,
   state,
 } from "../../src/test-utils/action-test-utils.js";
+
+const { availableAgentsProvider } = await import(
+  "../../src/providers/available-agents.js"
+);
 
 // Default: an empty, healthy framework state (probe succeeded, nothing extra
 // installed) so the pre-existing behavioural assertions below are unaffected.


### PR DESCRIPTION
Follow-up to #13279. The merged test used Vitest partial mock `importOriginal`, but this repo lane runs under Bun where that callback is undefined. This switches the test to Bun `mock.module` and imports the provider after the mock is registered.

Checks run:
- `bun test plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts` (5 pass)
- `bunx @biomejs/biome check --write plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts`
- `git diff --check github/develop...HEAD` and `git diff --check`
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` (exit 0)