### PR TITLE
test(agent-skills): stub resolveStateDir in core mock

### DIFF
--- a/plugins/plugin-agent-skills/src/__tests__/core-test-mock.ts
+++ b/plugins/plugin-agent-skills/src/__tests__/core-test-mock.ts
@@ -92,6 +92,7 @@ vi.mock("@elizaos/core", () => {
 			}
 			async stop() {}
 		},
+		resolveStateDir: vi.fn(() => "/tmp/elizaos-test-state"),
 		logger,
 	};
 });


### PR DESCRIPTION
## What

Follow-up to #13270: the newly merged `skill-discovery-helpers.test.ts` imports code paths that reach `packages/skills`, which now expects `@elizaos/core.resolveStateDir`. The `plugin-agent-skills` Vitest setup hand-mocks `@elizaos/core`, so the focused test failed during import with:

```text
No "resolveStateDir" export is defined on the "@elizaos/core" mock
```

This adds a deterministic `resolveStateDir` stub to the package test mock.

## Validation

```text
bun run --cwd plugins/plugin-agent-skills test src/api/skill-discovery-helpers.test.ts
Test Files  1 passed (1)
Tests       7 passed (7)

bunx @biomejs/biome check plugins/plugin-agent-skills/src/__tests__/core-test-mock.ts
Checked 1 file in 16ms. No fixes applied.
```

Evidence N/A: test-harness-only fix; no runtime/UI behavior.
