### PR TITLE
test(agent-orchestrator): use bun-compatible available agents mock

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts
@@ -7,20 +7,10 @@ import { describe, expect, it, vi } from "vitest";
 // Control the framework-state probe so we can drive its failure path
 // deterministically without touching the filesystem / env discovery it does.
 const getTaskAgentFrameworkStateMock = vi.fn();
-vi.mock(
-  "../../src/services/task-agent-frameworks.js",
-  async (importOriginal) => {
-    const actual =
-      await importOriginal<
-        typeof import("../../src/services/task-agent-frameworks.js")
-      >();
-    return {
-      ...actual,
-      getTaskAgentFrameworkState: (...args: unknown[]) =>
-        getTaskAgentFrameworkStateMock(...args),
-    };
-  },
-);
+vi.mock("../../src/services/task-agent-frameworks.js", () => ({
+  getTaskAgentFrameworkState: (...args: unknown[]) =>
+    getTaskAgentFrameworkStateMock(...args),
+}));
 
 import { availableAgentsProvider } from "../../src/providers/available-agents.js";
 import {


### PR DESCRIPTION
Follow-up to #13279. The merged available-agents test used a Vitest-style partial mock factory that receives `importOriginal`; under this repo's `bun test` runner that argument is undefined, so the focused test fails before assertions.\n\nThis replaces the partial mock with the one export the test actually needs, `getTaskAgentFrameworkState`, keeping the provider under test real.\n\nValidation:\n- Before this branch on current `develop`: `bun test plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts` failed with `TypeError: importOriginal is not a function`.\n- After this branch: `bun test plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts` — 5/5 pass.\n- `bunx biome check plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts plugins/plugin-agent-orchestrator/src/providers/available-agents.ts` — pass.\n- `git diff --check origin/develop...HEAD && git diff --check` — pass.\n\nPackage typecheck note: `bun run --cwd plugins/plugin-agent-orchestrator typecheck` is currently blocked in this sparse checkout by pre-existing missing `@elizaos/auth/*` and logger dependency declarations outside the changed files.