### PR TITLE
fix(#12267): deep fallback-slop sweep slice 1/3 — convert empty-catch/fabricated-default/promise-swallow to fail-fast

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -363,6 +363,8 @@ function scheduleRouteViewChunkPrefetch(): () => void {
       scheduledId = null;
       if (cancelled) return;
       const load = loaders.shift();
+      // error-policy:J6 best-effort chunk prefetch; a failed warm-up is harmless
+      // because React.lazy re-loads the chunk on-demand when the route mounts.
       if (load) void load().catch(() => {});
       scheduleNext();
     };

--- a/packages/ui/src/api/ios-local-agent-kernel.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.ts
@@ -1820,6 +1820,9 @@ async function listInstalledModels(): Promise<InstalledModel[]> {
 
 async function hardwareProbe(): Promise<HardwareProbe> {
   const llama = await loadCapacitorLlama();
+  // error-policy:J4 designed degrade — a failed native hardware probe falls back
+  // to the browser's own capability APIs (navigator.hardwareConcurrency, etc.)
+  // rather than blocking model load; conservative defaults are intentional.
   const hardware = await llama?.getHardwareInfo?.().catch(() => null);
   const cpuCores = hardware?.cpuCores ?? navigator.hardwareConcurrency ?? 0;
   const platform = normalizeMobilePlatform(hardware?.platform);
@@ -1972,6 +1975,9 @@ async function ensureActiveModelLoadedImpl(): Promise<void> {
   const hardware = await hardwareProbe();
   const loadOptions = buildMobileLoadOptions(model, installed, hardware);
   const signature = runtimeSignature(loadOptions);
+  // error-policy:J4 designed degrade — if the native "is model loaded?" probe
+  // fails we treat it as not-loaded and (re)load below; the conservative path is
+  // safe (a redundant load), whereas trusting a failed probe could skip loading.
   const loaded = await llama.isLoaded?.().catch(() => null);
   if (
     loaded?.loaded &&
@@ -2295,6 +2301,9 @@ async function probeAgentCloudPaired(
       signal: controller.signal,
     });
   } catch (err) {
+    // error-policy:J1 boundary translation — the IPC fetch failure becomes a
+    // typed CloudPairedProbe "unknown" result carrying the reason, not a
+    // fabricated paired/unpaired verdict the caller would trust.
     return {
       kind: "unknown",
       reason: err instanceof Error ? err.message : String(err),
@@ -2305,6 +2314,8 @@ async function probeAgentCloudPaired(
   if (!response.ok) {
     return { kind: "unknown", reason: `auth-status http ${response.status}` };
   }
+  // error-policy:J3 parse-sanitize — non-JSON/empty body becomes null and is
+  // rejected as a typed "unknown" auth-status result below, never fabricated.
   const body: unknown = await response.json().catch(() => null);
   if (!body || typeof body !== "object") {
     return { kind: "unknown", reason: "auth-status non-object body" };
@@ -2363,6 +2374,8 @@ async function sendPromptToIosCloud(
     throw new Error(`Cloud bridge failed: HTTP ${response.status}`);
   }
 
+  // error-policy:J3 parse-sanitize — non-JSON/empty body becomes null and is
+  // rejected as an explicit error below (res.ok was already asserted above).
   const body = asRecord(await response.json().catch(() => null));
   if (!body) {
     throw new Error("Cloud bridge returned a non-object response.");
@@ -2903,6 +2916,9 @@ function startDownload(model: CatalogModel): DownloadJob {
           etaMs: 0,
         });
         if (activeState.status === "idle" || !activeState.modelId) {
+          // error-policy:J6 best-effort convenience auto-activate after a
+          // successful download; a failure leaves the model installed-but-idle
+          // for explicit activation, it does not fail the completed download.
           await activateModel(model.id, textPath).catch(() => undefined);
         }
         return;
@@ -2964,6 +2980,9 @@ function startDownload(model: CatalogModel): DownloadJob {
         etaMs: 0,
       });
       if (activeState.status === "idle" || !activeState.modelId) {
+        // error-policy:J6 best-effort convenience auto-activate after a
+        // successful download; a failure leaves the model installed-but-idle
+        // for explicit activation, it does not fail the completed download.
         await activateModel(model.id, path).catch(() => undefined);
       }
     } catch (error) {

--- a/packages/ui/src/api/native-agent-stream.ts
+++ b/packages/ui/src/api/native-agent-stream.ts
@@ -132,6 +132,9 @@ export async function createNativeStreamingResponse(
     resolveHead = resolve;
     rejectHead = reject;
   });
+  // error-policy:J5 unhandled-rejection guard; the rejection IS observed by the
+  // caller that consumes the returned `head` promise (line 207) — this keepalive
+  // catch only prevents a spurious unhandledrejection if head settles first.
   void head.catch(() => {});
   let headSettled = false;
 

--- a/packages/ui/src/cloud/instances/lib/use-job-poller.ts
+++ b/packages/ui/src/cloud/instances/lib/use-job-poller.ts
@@ -143,6 +143,8 @@ export function useJobPoller(options: UseJobPollerOptions = {}) {
               continue;
             }
 
+            // error-policy:J3 parse-sanitize — non-JSON/empty body becomes null;
+            // a missing status below simply skips this poll tick (continue).
             const data = await res.json().catch(() => null);
             const nextStatus = data?.data?.status as JobStatus | undefined;
             const nextError = data?.data?.error;

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
@@ -103,6 +103,8 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
             return;
           }
 
+          // error-policy:J3 parse-sanitize — non-JSON/empty body becomes null;
+          // res.status drives the branches below, the code field is advisory.
           const body = (await res.json().catch(() => null)) as {
             code?: string;
           } | null;
@@ -168,6 +170,8 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
             credentials: "include",
           });
           if (res.ok) {
+            // error-policy:J3 parse-sanitize — non-JSON/empty body becomes null;
+            // only a well-formed { token } is written, else the refresh no-ops.
             const body = (await res.json().catch(() => null)) as {
               token?: string;
             } | null;

--- a/packages/ui/src/components/apps/FullscreenView.tsx
+++ b/packages/ui/src/components/apps/FullscreenView.tsx
@@ -1255,7 +1255,8 @@ export function FullscreenView() {
         }
       })
       .catch(() => {
-        // fall through — iframe fallback is still rendered
+        // error-policy:J4 designed degrade — native canvas window unavailable,
+        // the iframe fallback is still rendered so the game stays playable.
       });
 
     return () => {
@@ -1266,6 +1267,8 @@ export function FullscreenView() {
           rpcMethod: "canvasDestroyWindow",
           ipcChannel: "canvas:destroyWindow",
           params: { id: gameWindowIdRef.current },
+          // error-policy:J6 best-effort teardown on unmount; the window is
+          // discarded regardless and a failed destroy has no further recourse.
         }).catch(() => {});
         gameWindowIdRef.current = null;
         setGameWindowId(null);

--- a/packages/ui/src/components/character/CharacterEditor.tsx
+++ b/packages/ui/src/components/character/CharacterEditor.tsx
@@ -6,6 +6,7 @@
  * entry. Kept statically imported in App.tsx (not lazy) so first-run onboarding
  * can land here without a chunk fetch.
  */
+import { logger } from "@elizaos/logger";
 import { getStylePresets } from "@elizaos/shared";
 import { useAgentElement } from "../../agent-surface";
 import type { CharacterData } from "../../api/client";
@@ -743,7 +744,15 @@ export function CharacterEditor({
                 tts: persistedVoiceConfig,
               },
             })
-            .catch(() => {});
+            .catch((err) => {
+              // The voice switch already applied in-session (event above); this
+              // persists it. A silent failure would desync the next reload from
+              // what the user sees — surface it (Save re-persists on demand).
+              logger.error(
+                { err },
+                "[CharacterEditor] failed to persist voice config",
+              );
+            });
         }
       }
       if (applyDefaults) {

--- a/packages/ui/src/components/composites/chat/permission-card.tsx
+++ b/packages/ui/src/components/composites/chat/permission-card.tsx
@@ -134,6 +134,9 @@ export function PermissionCard({
       .then((next) => {
         if (!cancelled) setState(next);
       })
+      // error-policy:J5 unhandled-rejection guard; the live permission state is
+      // ALSO delivered by registry.subscribe below, so a transient initial-check
+      // failure resolves as soon as the next subscription event arrives.
       .catch(() => {});
     const unsubscribe = registry.subscribe((states) => {
       const next = states.find((s) => s.id === permission);

--- a/packages/ui/src/components/pages/CameraPageView.tsx
+++ b/packages/ui/src/components/pages/CameraPageView.tsx
@@ -75,6 +75,7 @@ export function CameraPageView(): React.JSX.Element {
           mirror: false,
         });
         if (cancelled) {
+          // error-policy:J6 best-effort teardown of a preview that raced an unmount.
           await Camera.stopPreview().catch(() => {});
           return;
         }
@@ -92,6 +93,8 @@ export function CameraPageView(): React.JSX.Element {
 
     return () => {
       cancelled = true;
+      // error-policy:J6 best-effort teardown on unmount; the preview is gone
+      // regardless and a failed stop has no further recourse.
       void Camera.stopPreview().catch(() => {});
     };
   }, []);

--- a/packages/ui/src/components/pages/trigger-form-utils.ts
+++ b/packages/ui/src/components/pages/trigger-form-utils.ts
@@ -321,6 +321,8 @@ export function validateCronExpression(
     CronExpressionParser.parse(trimmed);
     return { ok: true, message: null };
   } catch (err) {
+    // error-policy:J3 parse-sanitize — invalid user cron input yields an explicit
+    // typed { ok: false, message } the form renders, never a fake-valid pass.
     return {
       ok: false,
       message: err instanceof Error ? err.message : String(err),

--- a/packages/ui/src/components/shell/BugReportModal.tsx
+++ b/packages/ui/src/components/shell/BugReportModal.tsx
@@ -158,6 +158,8 @@ export function BugReportModal() {
             : {}),
         }));
       })
+      // error-policy:J6 best-effort form prefill; on failure the reporter still
+      // types the environment fields manually (no fabricated/masked data).
       .catch(() => {});
     if (desktopRuntime) {
       loadDesktopBugReportDiagnostics()
@@ -177,6 +179,8 @@ export function BugReportModal() {
             }));
           }
         })
+        // error-policy:J6 best-effort desktop-diagnostics prefill; on failure the
+        // logs/environment fields stay empty for the reporter to fill manually.
         .catch(() => {});
     }
     setTimeout(() => descRef.current?.focus(), 50);

--- a/packages/ui/src/components/shell/usePromptSuggestions.ts
+++ b/packages/ui/src/components/shell/usePromptSuggestions.ts
@@ -256,6 +256,9 @@ function requestModelSet(
       rememberModelSet(key, set);
       return set;
     })
+    // error-policy:J4 designed degrade — null signals "no model suggestions",
+    // identical to the heuristic-tier branch above; the caller then renders the
+    // deterministic heuristic set instead of an error.
     .catch(() => null)
     .finally(() => {
       inFlightModelSets.delete(key);

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -421,6 +421,9 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     if (!sharedAudioCtx) {
       sharedAudioCtx = new AudioContext({ latencyHint: "interactive" });
     }
+    // error-policy:J5 unhandled-rejection guard; resume() may reject on a context
+    // that re-suspended, but the unlock generation bump below still re-arms audio
+    // and the real playback path surfaces any persistent failure.
     void sharedAudioCtx.resume().catch(() => {});
     setVoiceUnlockedGeneration((g) => g + 1);
     setNeedsAudioUnlock(false);
@@ -909,6 +912,9 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         await ensureTalkModeListeners();
         const talkMode = getTalkModePlugin();
         const browserSpeechSupported = !!getSpeechRecognitionCtor();
+        // error-policy:J4 designed degrade — a failed permission probe reads as
+        // null and is treated as "maybe supported", deferring the real decision
+        // to the actual speech attempt rather than falsely disabling voice.
         let permissions = await talkMode.checkPermissions().catch(() => null);
         const nativeSpeechSupported =
           permissions?.speechRecognition !== "not_supported";
@@ -1115,6 +1121,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     // actually silences the agent. Without this the awaited TalkMode.speak()
     // plays to completion and the agent talks over the user.
     if (Capacitor.isNativePlatform()) {
+      // error-policy:J6 best-effort interrupt/teardown of in-flight native speak
+      // for barge-in; if the stop fails there is no further recourse here.
       void getTalkModePlugin()
         .stopSpeaking?.()
         .catch(() => {});
@@ -1368,6 +1376,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       source.connect(analyser);
       analyser.connect(ctx.destination);
       audioSourceRef.current = source;
+      // error-policy:J6 best-effort visualizer tap; if attaching the frame pump
+      // fails, audio still plays — the tap only drives the waveform decoration.
       const playbackTap = await getPlaybackFramePump()
         .tapSource(ctx, source, audioBuffer)
         .catch(() => null);
@@ -1552,6 +1562,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       source.connect(analyser);
       analyser.connect(ctx.destination);
       audioSourceRef.current = source;
+      // error-policy:J6 best-effort visualizer tap; if attaching the frame pump
+      // fails, audio still plays — the tap only drives the waveform decoration.
       const playbackTap = await getPlaybackFramePump()
         .tapSource(ctx, source, audioBuffer)
         .catch(() => null);

--- a/packages/ui/src/services/local-inference/service.ts
+++ b/packages/ui/src/services/local-inference/service.ts
@@ -8,6 +8,7 @@
  */
 
 import type { AgentRuntime } from "@elizaos/core";
+import { logger } from "@elizaos/logger";
 import { ActiveModelCoordinator } from "./active-model";
 import { readEffectiveAssignments, setAssignment } from "./assignments";
 import { registerBundledModels } from "./bundled-models";
@@ -67,7 +68,15 @@ export class LocalInferenceService {
     if (!this.bundledBootstrap) {
       this.bundledBootstrap = registerBundledModels()
         .then(() => undefined)
-        .catch(() => undefined);
+        .catch((err) => {
+          // Boot proceeds with the registry as-is, but a failed bundled-model
+          // registration means AOSP/manifest-staged models silently won't
+          // appear — surface it so on-device installs are debuggable.
+          logger.error(
+            { err },
+            "[LocalInferenceService] bundled-model registration failed",
+          );
+        });
     }
     return this.bundledBootstrap;
   }

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -254,7 +254,9 @@ describe("notification-store", () => {
     __ingestNotificationForTests(makeNotification({ id: "r1" }), 1);
     await markNotificationRead("r1");
     // Write failed → item must return to unread, not stay optimistically read.
-    const stored = __getStateForTests().notifications.find((n) => n.id === "r1");
+    const stored = __getStateForTests().notifications.find(
+      (n) => n.id === "r1",
+    );
     expect(stored?.readAt).toBeFalsy();
     expect(__getStateForTests().unreadCount).toBe(1);
   });
@@ -264,9 +266,9 @@ describe("notification-store", () => {
     __ingestNotificationForTests(makeNotification({ id: "r2" }), 1);
     await removeNotification("r2");
     // Failed delete must NOT leave the item visibly gone-but-still-on-server.
-    expect(
-      __getStateForTests().notifications.some((n) => n.id === "r2"),
-    ).toBe(true);
+    expect(__getStateForTests().notifications.some((n) => n.id === "r2")).toBe(
+      true,
+    );
     expect(__getStateForTests().unreadCount).toBe(1);
   });
 
@@ -285,8 +287,8 @@ describe("notification-store", () => {
     __ingestNotificationForTests(makeNotification({ id: "a2" }), 2);
     await markAllNotificationsRead();
     expect(__getStateForTests().unreadCount).toBe(2);
-    expect(
-      __getStateForTests().notifications.every((n) => !n.readAt),
-    ).toBe(true);
+    expect(__getStateForTests().notifications.every((n) => !n.readAt)).toBe(
+      true,
+    );
   });
 });

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -248,4 +248,45 @@ describe("notification-store", () => {
     await clearNotifications();
     expect(clearNotificationsApi).toHaveBeenCalledTimes(1);
   });
+
+  it("reverts the optimistic read when the write rejects (no silent divergence)", async () => {
+    markNotificationReadApi.mockRejectedValueOnce(new Error("500"));
+    __ingestNotificationForTests(makeNotification({ id: "r1" }), 1);
+    await markNotificationRead("r1");
+    // Write failed → item must return to unread, not stay optimistically read.
+    const stored = __getStateForTests().notifications.find((n) => n.id === "r1");
+    expect(stored?.readAt).toBeFalsy();
+    expect(__getStateForTests().unreadCount).toBe(1);
+  });
+
+  it("restores a removed notification when the delete rejects", async () => {
+    removeNotificationApi.mockRejectedValueOnce(new Error("network"));
+    __ingestNotificationForTests(makeNotification({ id: "r2" }), 1);
+    await removeNotification("r2");
+    // Failed delete must NOT leave the item visibly gone-but-still-on-server.
+    expect(
+      __getStateForTests().notifications.some((n) => n.id === "r2"),
+    ).toBe(true);
+    expect(__getStateForTests().unreadCount).toBe(1);
+  });
+
+  it("restores the inbox when clear rejects", async () => {
+    clearNotificationsApi.mockRejectedValueOnce(new Error("boom"));
+    __ingestNotificationForTests(makeNotification({ id: "c1" }), 1);
+    __ingestNotificationForTests(makeNotification({ id: "c2" }), 2);
+    await clearNotifications();
+    expect(__getStateForTests().notifications).toHaveLength(2);
+    expect(__getStateForTests().unreadCount).toBe(2);
+  });
+
+  it("reverts markAll when the write rejects", async () => {
+    markAllNotificationsReadApi.mockRejectedValueOnce(new Error("down"));
+    __ingestNotificationForTests(makeNotification({ id: "a1" }), 1);
+    __ingestNotificationForTests(makeNotification({ id: "a2" }), 2);
+    await markAllNotificationsRead();
+    expect(__getStateForTests().unreadCount).toBe(2);
+    expect(
+      __getStateForTests().notifications.every((n) => !n.readAt),
+    ).toBe(true);
+  });
 });

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -11,6 +11,7 @@ import {
   type NotificationPriority,
   type UUID,
 } from "@elizaos/core";
+import { logger } from "@elizaos/logger";
 import { useSyncExternalStore } from "react";
 import { client } from "../../api/client";
 import { invokeDesktopBridgeRequest } from "../../bridge/electrobun-rpc";
@@ -100,7 +101,8 @@ async function fireDesktopNotification(
       silent: notification.priority === "low",
     },
   }).catch(() => {
-    /* desktop bridge absent (web/mobile) — handled by other sinks */
+    // error-policy:J6 best-effort OS-interrupt sink; desktop bridge absent on
+    // web/mobile — the inbox + other sinks still deliver.
   });
 }
 
@@ -117,6 +119,9 @@ function deliver(notification: AgentNotification): void {
   // interruptive priorities even when focused.
   if (!focused || interruptive) {
     void fireDesktopNotification(notification);
+    // error-policy:J6 best-effort OS-interrupt sink; the inbox (set separately
+    // in ingest) is the source of truth, so a failed native alert must not
+    // disturb delivery. Absent on web/desktop-without-bridge.
     void showNativeNotification({
       id: notification.id,
       title: notification.title,
@@ -270,33 +275,72 @@ export function registerNotificationToastSink(sink: ToastSink | null): void {
 
 // ── Mutations (optimistic; backed by the HTTP API) ──────────────────────────
 
+/**
+ * Roll the optimistic state back to `previous` and log at error level when a
+ * mutation's HTTP write fails. Reverting is the user-visible surfacing: a
+ * failed "mark read" returns the item to unread and a failed delete makes it
+ * reappear, so the inbox never silently diverges from server truth. Callers
+ * fire-and-forget (`void`), so this never rethrows.
+ */
+function revertMutation(
+  previous: NotificationState,
+  op: string,
+  err: unknown,
+): void {
+  setState({
+    notifications: previous.notifications,
+    unreadCount: previous.unreadCount,
+  });
+  logger.error({ err }, `[notification-store] ${op} failed; reverted`);
+}
+
 export async function markNotificationRead(id: string): Promise<void> {
+  const previous = state;
   const now = Date.now();
   const notifications = state.notifications.map((n) =>
     n.id === id && !n.readAt ? { ...n, readAt: now } : n,
   );
   setState({ notifications, unreadCount: countUnread(notifications) });
-  await client.markNotificationRead(id).catch(() => {});
+  try {
+    await client.markNotificationRead(id);
+  } catch (err) {
+    revertMutation(previous, "markNotificationRead", err);
+  }
 }
 
 export async function markAllNotificationsRead(): Promise<void> {
+  const previous = state;
   const now = Date.now();
   const notifications = state.notifications.map((n) =>
     n.readAt ? n : { ...n, readAt: now },
   );
   setState({ notifications, unreadCount: 0 });
-  await client.markAllNotificationsRead().catch(() => {});
+  try {
+    await client.markAllNotificationsRead();
+  } catch (err) {
+    revertMutation(previous, "markAllNotificationsRead", err);
+  }
 }
 
 export async function removeNotification(id: string): Promise<void> {
+  const previous = state;
   const notifications = state.notifications.filter((n) => n.id !== id);
   setState({ notifications, unreadCount: countUnread(notifications) });
-  await client.removeNotification(id).catch(() => {});
+  try {
+    await client.removeNotification(id);
+  } catch (err) {
+    revertMutation(previous, "removeNotification", err);
+  }
 }
 
 export async function clearNotifications(): Promise<void> {
+  const previous = state;
   setState({ notifications: [], unreadCount: 0 });
-  await client.clearNotifications().catch(() => {});
+  try {
+    await client.clearNotifications();
+  } catch (err) {
+    revertMutation(previous, "clearNotifications", err);
+  }
 }
 
 // ── React binding ───────────────────────────────────────────────────────────

--- a/packages/ui/src/state/startup-phase-runtime.ts
+++ b/packages/ui/src/state/startup-phase-runtime.ts
@@ -245,6 +245,9 @@ export async function runStartingRuntime(
       // error-policy:J4 boot poll — the API is expected to be unreachable
       // while the backend comes up; the loop's deadline surfaces a visible
       // startup error (setStartupError) when it never recovers
+      // error-policy:J4 bounded-retry-then-error — a transient probe failure
+      // reads as null and the loop retries; a persistent failure surfaces via the
+      // deadline check above (setStartupError), so it is not silently masked.
       const launchProgress = await client.getLaunchProgress().catch(() => null);
       if (launchProgress) {
         const launchStatus = mapLaunchProgressToAgentStatus(launchProgress);
@@ -303,6 +306,9 @@ export async function runStartingRuntime(
       }
 
       // error-policy:J4 boot poll — same deadline-guarded probe as above
+      // error-policy:J4 bounded-retry-then-error — same as the launch-progress
+      // probe above: null is retried within the deadline, a persistent failure
+      // surfaces via setStartupError, never a fabricated healthy state.
       const bootProgress = await client.getBootProgress().catch(() => null);
       if (bootProgress) {
         const bootStatus = mapBootProgressToAgentStatus(bootProgress);

--- a/packages/ui/src/state/use-startup-shell-controller.ts
+++ b/packages/ui/src/state/use-startup-shell-controller.ts
@@ -70,6 +70,9 @@ function needsBootstrapSession(): boolean {
   try {
     return !sessionStorage.getItem("eliza_session");
   } catch {
+    // error-policy:J3 sessionStorage may be unavailable (privacy mode / disabled
+    // storage); assume a bootstrap session is needed — the safe branch that runs
+    // setup rather than skipping it on an unreadable store.
     return true;
   }
 }

--- a/packages/ui/src/state/useChatCallbacks.ts
+++ b/packages/ui/src/state/useChatCallbacks.ts
@@ -159,7 +159,14 @@ async function resolveRestoredConversationWithMessages(
     restoredMessages = filterRenderableConversationMessages(
       (await api.getConversationMessages(restoredConversation.id)).messages,
     );
-  } catch {
+  } catch (err) {
+    // error-policy:J4 explicit not-loaded signal — messagesLoaded:false is the
+    // distinguishable "load failed" state (not healthy-empty); the caller renders
+    // it differently from a genuinely empty conversation.
+    logger.warn(
+      { err, conversationId: restoredConversation.id },
+      "[useChatCallbacks] failed to load restored conversation messages",
+    );
     return {
       conversation: restoredConversation,
       messages: [],

--- a/packages/ui/src/voice/aec-loop-harness.ts
+++ b/packages/ui/src/voice/aec-loop-harness.ts
@@ -240,6 +240,8 @@ async function postJson(path: string, body: unknown): Promise<unknown> {
   });
   // error-policy:J3 body parse is best-effort context for the thrown error;
   // non-2xx always throws below with the status either way
+  // error-policy:J3 parse-sanitize — an empty/non-JSON body becomes null; the
+  // HTTP status is the real signal (thrown below), the body is only diagnostic.
   const json: unknown = await res.json().catch(() => null);
   if (!res.ok) {
     throw new Error(`${path} -> ${res.status} ${JSON.stringify(json)}`);
@@ -253,6 +255,8 @@ async function getJson(path: string): Promise<unknown> {
   });
   // error-policy:J3 body parse is best-effort context for the thrown error;
   // non-2xx always throws below with the status either way
+  // error-policy:J3 parse-sanitize — an empty/non-JSON body becomes null; the
+  // HTTP status is the real signal (thrown below), the body is only diagnostic.
   const json: unknown = await res.json().catch(() => null);
   if (!res.ok) {
     throw new Error(`${path} -> ${res.status} ${JSON.stringify(json)}`);


### PR DESCRIPTION
## Deep fallback-slop sweep — slice 1/3 (client degrade rules)

Part of #12182 fallback-slop sweep; batch **#12267** (`packages/ui` + `packages/app` client degrade rules). Uses the foundation (#12263) error policy now on `develop`. Client code has no `runtime.reportError`, so the escalation surface here is the **user's screen** (revert / error state) and the structured `logger`.

Converts the **unambiguous slop** categories thoroughly and annotates justified J-category keeps with grep-able `// error-policy:J<N>` comments. Deferred the judgment-heavy categories (see below) for a per-site pass.

### Per-category tally (this slice)

| Category | Count | What changed |
|---|---|---|
| **empty catch** (`catch {}`) | 0 | none in this slice (the only truly-empty catch in the slice root fell to another slice) |
| **fabricated-healthy-on-error to fail-fast** | 1 | `useChatCallbacks` restored-conversation load now `logger.warn`s (the existing `messagesLoaded:false` is the distinguishable not-loaded signal) |
| **promise-swallow to surface/propagate** | 4 | notification-store `markNotificationRead` / `markAllNotificationsRead` / `removeNotification` / `clearNotifications`: swallowed optimistic writes now **revert-on-failure + `logger.error`**, so a failed read/delete/clear no longer leaves the inbox silently diverged from server truth |
| **swallow to observable log** | 2 | local-inference bundled-model registration + CharacterEditor voice-config persist now `logger.error` on failure |
| **justified (J1-J7) annotated** | 30 | see below |
| **ambiguousLeft (deferred)** | ~40 | bare `return null/[]/false` catches + `?? <lit>` where masking-vs-absence needs per-site judgment |

### Justified keeps annotated (no behavior change)
- **J1** ios cloud-paired probe to typed `"unknown"` result (not a fabricated verdict).
- **J3** response-body parse-sanitize (`json().catch(()=>null)` then null-checked), cron-parse to typed invalid, sessionStorage-unavailable to safe default.
- **J4** designed degrades: native canvas to iframe, hardware/permission probe fallbacks, heuristic-suggestion fallback, bounded-retry-then-error startup probes.
- **J5** unhandled-rejection guards: stream-head keepalive (observed by the returned promise), permission re-check (observed via `registry.subscribe`), audio-context resume.
- **J6** best-effort teardown/interrupt/prefetch/prefill: camera `stopPreview`, talkmode `stopSpeaking` barge-in, route chunk prefetch, bug-report form prefill, OS notification sinks, model auto-activate, playback visualizer tap.

### Ratchet (diff-scoped)
`bun run audit:error-policy-ratchet` -> **no new fallback-slop in touched files.** Every touched file's `emptyCatch` count is unchanged (down-or-equal, never up): **19 -> 19** across the touched set; `serverConsole` 0 -> 0.

### Tests
Real error-path tests added to `notification-store.test.ts` (4): each drives a **rejected** write and asserts the optimistic state **reverts** (item returns to unread / reappears / inbox restored) rather than fabricating success — no test asserts the old swallowed-success behavior. `notification-store` 17/17 green; `aec-loop-harness` / `native-agent-stream` / `startup-phase-runtime` logic suites green (24/24).

**Note on React component suites:** this machine's current `dist/node_modules` state fails every React-render test with `TypeError: Cannot read properties of null (reading 'useContext')` (react/react-dom dual-instance) — reproduced on an **untouched** `RoleGate.test.tsx` in the main tree, so it is environmental and independent of this change. All non-React logic suites among the touched files pass. Changes to component files are annotation-only or added `logger.*` inside existing catch blocks (no control-flow/render change any test asserts).

**Slice note:** `develop` advanced under this branch (sibling sweeps landing every few minutes), so the `index % 3` partition drifted; 3 originally-targeted files were already converted on `develop` and skipped. All 19 touched files are still live suspect files with real slop.

Refs #12267

Generated with [Claude Code](https://claude.com/claude-code)