### PR TITLE
fix(#12744): fallback-slop sweep — work/productivity plugins (non-route)

### DIFF
--- a/plugins/plugin-contacts/src/providers/contacts.test.ts
+++ b/plugins/plugin-contacts/src/providers/contacts.test.ts
@@ -70,4 +70,28 @@ describe("androidContacts provider", () => {
       starred: true,
     });
   });
+
+  it("reports the failure and surfaces it in the result when the bridge rejects", async () => {
+    const boom = new Error("contacts permission denied");
+    contactsMock.listContacts.mockRejectedValue(boom);
+    const reportError = vi.fn();
+
+    const result = await contactsProvider.get(
+      { reportError } as unknown as IAgentRuntime,
+      {} as Memory,
+      {} as State,
+    );
+
+    // Native-bridge failure surfaces observably (RECENT_ERRORS) and in the
+    // provider values — never a silently fabricated empty contact list.
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError.mock.calls[0]?.[1]).toBe(boom);
+    expect(result.values).toMatchObject({
+      contactsAvailable: false,
+      contactsCount: 0,
+      contactsError: "contacts permission denied",
+    });
+    const data = result.data as { error?: string };
+    expect(data.error).toBe("contacts permission denied");
+  });
 });

--- a/plugins/plugin-contacts/src/providers/contacts.ts
+++ b/plugins/plugin-contacts/src/providers/contacts.ts
@@ -51,7 +51,7 @@ export const contactsProvider: Provider = {
   cacheStable: false,
 
   get: async (
-    _runtime: IAgentRuntime,
+    runtime: IAgentRuntime,
     _message: Memory,
     _state: State,
   ): Promise<ProviderResult> => {
@@ -81,6 +81,11 @@ export const contactsProvider: Provider = {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
 
+      // error-policy:J4 explicit user-facing degrade — a native address-book
+      // read failure is surfaced to the planner via `contactsError`/`error`
+      // (never a fabricated empty contact list); reportError also makes it
+      // observable in RECENT_ERRORS + owner-escalation.
+      runtime.reportError?.(CONTACTS_PROVIDER_NAME, error);
       return {
         text: "",
         values: {

--- a/plugins/plugin-inbox/src/providers/cross-channel-context.ts
+++ b/plugins/plugin-inbox/src/providers/cross-channel-context.ts
@@ -24,7 +24,6 @@ import type {
   ProviderResult,
   State,
 } from "@elizaos/core";
-import { logger } from "@elizaos/core";
 import { InboxRepository } from "../inbox/repository.ts";
 import type { TriageEntry } from "../inbox/types.ts";
 
@@ -49,7 +48,8 @@ async function resolveSenderLabel(
       name =
         entity?.names?.[0] ?? (typeof metaName === "string" ? metaName : null);
     } catch {
-      // entity lookup is best-effort
+      // error-policy:J4 explicit user-facing degrade — sender display-name
+      // enrichment is optional; on failure we proceed with the raw entityId.
     }
   }
 
@@ -135,7 +135,12 @@ export const crossChannelContextProvider: Provider = {
     let repo: InboxRepository;
     try {
       repo = new InboxRepository(runtime);
-    } catch {
+    } catch (error) {
+      // error-policy:J4 explicit user-facing degrade — if the inbox store is
+      // unavailable this provider omits cross-channel context (empty, never a
+      // fabricated "no related messages"); reportError makes the failure
+      // observable in RECENT_ERRORS instead of being silently swallowed.
+      runtime.reportError?.("cross-channel-context.provider", error);
       return EMPTY;
     }
 
@@ -148,7 +153,10 @@ export const crossChannelContextProvider: Provider = {
         limit: MAX_ENTRIES,
       });
     } catch (error) {
-      logger.debug("[cross-channel-context] DB query failed:", String(error));
+      // error-policy:J4 explicit user-facing degrade — a store-read failure
+      // omits cross-channel context (empty, never a fabricated "no related
+      // messages"); reportError surfaces it observably in RECENT_ERRORS.
+      runtime.reportError?.("cross-channel-context.provider", error);
       return EMPTY;
     }
 

--- a/plugins/plugin-inbox/src/providers/inbox-triage.ts
+++ b/plugins/plugin-inbox/src/providers/inbox-triage.ts
@@ -13,7 +13,6 @@ import type {
   ProviderResult,
   State,
 } from "@elizaos/core";
-import { logger } from "@elizaos/core";
 import { InboxRepository } from "../inbox/repository.ts";
 import type { TriageEntry } from "../inbox/types.ts";
 
@@ -59,7 +58,12 @@ export const inboxTriageProvider: Provider = {
     let repo: InboxRepository;
     try {
       repo = new InboxRepository(runtime);
-    } catch {
+    } catch (error) {
+      // error-policy:J4 explicit user-facing degrade — if the inbox store is
+      // unavailable this provider omits the triage summary (empty, never a
+      // fabricated "no items pending"); reportError makes the failure
+      // observable in RECENT_ERRORS instead of being silently swallowed.
+      runtime.reportError?.("inbox-triage.provider", error);
       return EMPTY;
     }
 
@@ -74,10 +78,10 @@ export const inboxTriageProvider: Provider = {
         repo.getRecentAutoReplies(5),
       ]);
     } catch (error) {
-      logger.debug(
-        "[inbox-triage-provider] DB query failed (schema may not exist yet):",
-        String(error),
-      );
+      // error-policy:J4 explicit user-facing degrade — a store-read failure
+      // omits the triage summary (empty, never a fabricated "no items
+      // pending"); reportError surfaces it observably in RECENT_ERRORS.
+      runtime.reportError?.("inbox-triage.provider", error);
       return EMPTY;
     }
 

--- a/plugins/plugin-inbox/test/inbox-triage-provider.test.ts
+++ b/plugins/plugin-inbox/test/inbox-triage-provider.test.ts
@@ -129,11 +129,22 @@ describe("inboxTriage provider", () => {
     expect(data.urgentItems).toHaveLength(1);
   });
 
-  it("returns empty when the DB query throws (schema not yet migrated)", async () => {
+  it("reports the failure and degrades to empty when the DB query throws", async () => {
+    const boom = new Error("relation does not exist");
     const runtime = makeRuntime(() => {
-      throw new Error("relation does not exist");
+      throw boom;
     });
+    const reportError = vi.fn();
+    (runtime as unknown as { reportError: typeof reportError }).reportError =
+      reportError;
+
     const result = await inboxTriageProvider.get(runtime, message, state);
+
+    // A store-read failure surfaces observably instead of being swallowed at
+    // debug level, but still degrades to an empty digest (never a fabricated
+    // "no items pending").
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError.mock.calls[0]?.[1]).toBe(boom);
     expect(result.text).toBe("");
     expect(result.values?.inboxUnresolved).toBe(0);
   });

--- a/plugins/plugin-mcp/__tests__/provider-error.test.ts
+++ b/plugins/plugin-mcp/__tests__/provider-error.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Failure-path test for the MCP provider: when the service's getProviderData
+ * throws, the provider must surface the failure via runtime.reportError and
+ * render a distinguishable error state, never mask it as a healthy "no servers"
+ * result (error-policy J7, #12744).
+ */
+
+import type { IAgentRuntime, Memory, State } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { provider } from "../src/provider.js";
+import { MCP_SERVICE_NAME } from "../src/types.js";
+
+const HEALTHY_EMPTY = "No MCP servers are available.";
+
+function runtimeWithService(service: unknown, reportError: () => void): IAgentRuntime {
+  return {
+    getService: (name: string) => (name === MCP_SERVICE_NAME ? service : undefined),
+    reportError,
+  } as unknown as IAgentRuntime;
+}
+
+describe("MCP provider failure path", () => {
+  it("reports the failure and does not render a healthy-empty result when getProviderData throws", async () => {
+    const boom = new Error("provider data unavailable");
+    const service = {
+      getProviderData: () => {
+        throw boom;
+      },
+    };
+    const reportError = vi.fn();
+    const runtime = runtimeWithService(service, reportError);
+
+    const result = await provider.get(runtime, {} as Memory, {} as State);
+
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError).toHaveBeenCalledWith("MCP.provider", boom);
+    expect(result.text).not.toBe(HEALTHY_EMPTY);
+    expect(result.data?.error).toBe("provider data unavailable");
+  });
+
+  it("renders the healthy-empty result only when the service is genuinely absent", async () => {
+    const reportError = vi.fn();
+    const runtime = {
+      getService: () => undefined,
+      reportError,
+    } as unknown as IAgentRuntime;
+
+    const result = await provider.get(runtime, {} as Memory, {} as State);
+
+    expect(reportError).not.toHaveBeenCalled();
+    expect(result.text).toBe(HEALTHY_EMPTY);
+  });
+});

--- a/plugins/plugin-mcp/src/actions/mcp.ts
+++ b/plugins/plugin-mcp/src/actions/mcp.ts
@@ -214,6 +214,8 @@ async function handleCallTool(
       success: true,
     };
   } catch (error) {
+    // error-policy:J4 action boundary — handleMcpError logs, replies to the user,
+    // and returns success:false with the error; no fabricated success value.
     return await handleMcpError(
       composedState,
       mcpProvider,
@@ -338,6 +340,8 @@ async function handleReadResource(
       success: true,
     };
   } catch (error) {
+    // error-policy:J4 action boundary — handleMcpError logs, replies to the user,
+    // and returns success:false with the error; no fabricated success value.
     return await handleMcpError(
       composedState,
       mcpProvider,

--- a/plugins/plugin-mcp/src/provider.ts
+++ b/plugins/plugin-mcp/src/provider.ts
@@ -66,10 +66,14 @@ export const provider: Provider = {
         text: formatMcpServersForPrompt(mcp),
       };
     } catch (error) {
+      // error-policy:J7 provider must not kill the turn; surface the failure via
+      // reportError (RECENT_ERRORS + owner escalation) and render a distinguishable
+      // error state instead of masking it as a healthy "no servers" result.
+      runtime.reportError("MCP.provider", error);
       return {
         values: {},
         data: { error: error instanceof Error ? error.message : String(error) },
-        text: "No MCP servers are available.",
+        text: "MCP server information is temporarily unavailable due to an error.",
       };
     }
   },

--- a/plugins/plugin-mcp/src/service.ts
+++ b/plugins/plugin-mcp/src/service.ts
@@ -286,6 +286,8 @@ export class McpService extends Service {
     if (state.pingInterval) clearInterval(state.pingInterval);
     state.pingInterval = setInterval(() => {
       this.sendPing(name).catch((err: Error) => {
+        // error-policy:J5 fire-and-forget ping; the rejection is observed in
+        // handlePingFailure, which counts failures and drives disconnection.
         logger.warn({ error: err.message, serverName: name }, `Ping failed for ${name}`);
         this.handlePingFailure(name, err);
       });
@@ -335,6 +337,8 @@ export class McpService extends Service {
         try {
           await this.initializeConnection(name, JSON.parse(config));
         } catch (err) {
+          // error-policy:J5 background reconnect; failure is observed in
+          // handleDisconnection, which records lastError and backs off (capped).
           this.handleDisconnection(name, err);
         }
       }

--- a/plugins/plugin-mcp/src/utils/json.ts
+++ b/plugins/plugin-mcp/src/utils/json.ts
@@ -75,6 +75,8 @@ export function parseStructuredModelOutput<T = Record<string, unknown>>(input: s
   try {
     return parseJSON<T>(input);
   } catch {
+    // error-policy:J3 untrusted model output — accumulate the parse failure and
+    // rethrow a typed error below; never returns a fabricated object.
     errors.push("JSON object parse failed");
   }
 

--- a/plugins/plugin-mcp/src/utils/wrapper.ts
+++ b/plugins/plugin-mcp/src/utils/wrapper.ts
@@ -55,6 +55,8 @@ export async function withModelRetry<T>({
         : input;
     validationResult = validationFn(parsedInput);
   } catch (error) {
+    // error-policy:J3 untrusted model output — a parse failure becomes an explicit
+    // invalid ValidationResult that drives the re-prompt/retry loop below.
     const errorMessage = error instanceof Error ? error.message : String(error);
     validationResult = { success: false, error: errorMessage };
   }

--- a/plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts
+++ b/plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts
@@ -257,6 +257,29 @@ describe("createMeetingTranscriptionPipeline", () => {
     ]);
   });
 
+  it("surfaces an ASR window failure via runtime.reportError (not a silent empty transcript)", async () => {
+    const backend = new ScriptedBackend();
+    backend.failNext(1);
+    const reportError = vi.fn();
+    const pipeline = createMeetingTranscriptionPipeline(
+      options({ runtime: { reportError } as unknown as IAgentRuntime }),
+      backend,
+    );
+
+    pipeline.pushSpeakerAudio("t0", seconds(2));
+    await tick(2000); // ASR rejects — window dropped, failure must be reported
+
+    expect(reportError).toHaveBeenCalledTimes(1);
+    const [scope, err, context] = reportError.mock.calls[0];
+    expect(scope).toBe("MeetingPipeline.transcribe");
+    expect((err as Error).message).toBe("scripted ASR failure");
+    expect(context).toMatchObject({ sessionId: SESSION_ID, speakerKey: "t0" });
+
+    // Dropping the window still yields an empty (not fabricated) transcript.
+    const segments = await pipeline.finalize();
+    expect(segments).toEqual([]);
+  });
+
   it("flushSpeaker (sink) force-finalizes a speaker's forming transcript", async () => {
     const backend = new ScriptedBackend();
     backend.enqueue({ text: "handing over to bob now" });

--- a/plugins/plugin-meetings/src/pipeline/pipeline.ts
+++ b/plugins/plugin-meetings/src/pipeline/pipeline.ts
@@ -282,10 +282,20 @@ class MeetingPipeline implements MeetingTranscriptionPipeline {
           segments,
         );
       } catch (err) {
+        // error-policy:J7 a single ASR window failing (already retried in the
+        // backend) must not stall live transcription — drop the window and let
+        // the stream keep moving. But surface the failure via reportError so a
+        // *systemically* broken TRANSCRIPTION model becomes observable to the
+        // agent/owner (RECENT_ERRORS + escalation) instead of silently yielding
+        // an empty transcript.
         logger.error(
           { err },
           `[MeetingPipeline] ASR failed for speaker ${speakerKey}; window dropped`,
         );
+        this.options.runtime.reportError?.("MeetingPipeline.transcribe", err, {
+          sessionId: this.options.sessionId,
+          speakerKey,
+        });
         // Clear the in-flight flag so the stream keeps moving.
         this.manager.handleTranscriptionResult(speakerKey, "");
       }

--- a/plugins/plugin-meetings/src/platforms/zoom/strategies.ts
+++ b/plugins/plugin-meetings/src/platforms/zoom/strategies.ts
@@ -598,7 +598,13 @@ export function createZoomStrategies(
             speakerName.toLowerCase().includes(botName.toLowerCase());
           attributor.onActiveSpeakerPoll(isBotTile ? null : speakerName);
 
-          // Roster from visible tile names (excluding the bot).
+          // Roster from visible tile names (excluding the bot). A transient DOM
+          // read failure (page navigating, execution context destroyed) yields
+          // null — NOT an empty roster. Treating a failed read as `[]` would
+          // spuriously fire participantLeft for everyone and trip the alone
+          // auto-leave timeout; skip this poll tick and re-read on the next one
+          // (removal is owned by startRemovalMonitor). Mirrors the msteams
+          // roster guard.
           const tileNames = await page
             .evaluate((footerSelector: string) => {
               return Array.from(
@@ -607,7 +613,8 @@ export function createZoomStrategies(
                 .map((s) => s.textContent?.trim())
                 .filter((n): n is string => !!n);
             }, zoomParticipantNameSelector)
-            .catch(() => [] as string[]);
+            .catch(() => null);
+          if (tileNames === null) continue;
           const nowMs = Date.now();
           const current = new Set(
             tileNames.filter(

--- a/plugins/plugin-relationships/src/providers/entity-graph.ts
+++ b/plugins/plugin-relationships/src/providers/entity-graph.ts
@@ -23,7 +23,6 @@ import type {
   ProviderResult,
   State,
 } from "@elizaos/core";
-import { logger } from "@elizaos/core";
 import { SELF_ENTITY_ID } from "@elizaos/shared";
 
 import { RELATIONSHIPS_CONTEXTS, RELATIONSHIPS_LOG_PREFIX } from "../types.js";
@@ -124,10 +123,12 @@ export const entityGraphProvider: Provider = {
         },
       };
     } catch (error) {
-      logger.error(
-        `${RELATIONSHIPS_LOG_PREFIX} ENTITY_GRAPH projection failed:`,
-        error instanceof Error ? error.message : String(error),
-      );
+      // error-policy:J4 explicit user-facing degrade — a knowledge-graph read
+      // failure omits the graph projection from planner context (an empty
+      // projection, never a fabricated "no known entities"), and reportError
+      // makes the underlying failure observable in RECENT_ERRORS +
+      // owner-escalation instead of being silently swallowed at debug level.
+      runtime.reportError?.(`${RELATIONSHIPS_LOG_PREFIX} ENTITY_GRAPH`, error);
       return { text: "", data: { entities: [], relationships: [] } };
     }
   },

--- a/plugins/plugin-relationships/test/entity-graph-provider.test.ts
+++ b/plugins/plugin-relationships/test/entity-graph-provider.test.ts
@@ -95,6 +95,39 @@ describe("ENTITY_GRAPH provider", () => {
     expect(result.data).toEqual({ entities: [], relationships: [] });
   });
 
+  it("reports the failure and degrades to empty when a store read rejects", async () => {
+    const boom = new Error("entity store unavailable");
+    const service = {
+      getEntityStore: () => ({
+        list: vi.fn(async () => {
+          throw boom;
+        }),
+      }),
+      getRelationshipStore: () => ({ list: vi.fn(async () => []) }),
+    };
+    mocks.resolveKnowledgeGraphService.mockReturnValue(service);
+    const reportError = vi.fn();
+    const failingRuntime = {
+      agentId: "agent-1" as UUID,
+      reportError,
+    } as unknown as IAgentRuntime;
+
+    const result = await entityGraphProvider.get(
+      failingRuntime,
+      message,
+      state,
+    );
+
+    // Failure surfaces observably — never a silent debug-swallow.
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError.mock.calls[0]?.[1]).toBe(boom);
+    // Degrades to an empty projection (never a fabricated populated graph).
+    expect(result).toEqual({
+      text: "",
+      data: { entities: [], relationships: [] },
+    });
+  });
+
   it("projects entities + ego edges and resolves target names", async () => {
     const { service, entityStore, relationshipStore } = makeService({
       entities: [


### PR DESCRIPTION
## Summary

Completes the fallback-slop long-tail sweep for the work/productivity connector plugins (#12744, parent #12182). Fabricating-catch and healthy-empty-masks-failure sites were triaged against the error-policy rubric; failures now surface observably.

### Behavior fixes — failures surface instead of masquerading as empty/success
- **plugin-meetings** pipeline: the ASR-window catch now `runtime.reportError("MeetingPipeline.transcribe", …)` (J7) so a systemically broken TRANSCRIPTION model surfaces to agent/owner instead of silently emitting an empty transcript (drop-window-to-keep-stream kept).
- **plugin-meetings** zoom roster: `.catch(() => [])` → `.catch(() => null)` + `continue`, so a transient DOM read failure is no longer misread as "everyone left" (which spuriously fired participantLeft-for-all + tripped the alone auto-leave timeout) — mirrors the existing msteams null guard.
- **plugin-mcp** provider: `get()` masked a thrown `getProviderData()` as the healthy-empty "No MCP servers are available." text; now `reportError` (J7) + renders a **distinguishable error state** (three-state rule).
- **plugin-relationships / plugin-inbox / plugin-contacts** providers: analogous surface-the-failure fixes over previously-swallowed provider loads.

### Annotations (justified keeps)
plugin-mcp actions (J4 → `handleMcpError`), ping/reconnect (J5, observed in `handlePingFailure`/`handleDisconnection`), wrapper/json parse (J3 → explicit invalid `ValidationResult`).

### Documented kept handlers (per the batch's "documented in the PR" clause)
The ~55 `.catch(() => false/null/0)` sites in plugin-meetings' **platform-automation modules** (Playwright DOM presence/state probes + self-healing retry-loop reads, e.g. `isVisible().catch(()=>false)`, `liveAudioCount.catch(()=>0)`) are **best-effort probes where the rejection IS the negative answer** — not failed-loaded-data masking. They are documented here as J5-class kept handlers rather than annotated inline, to avoid comment churn.

## Validation
- **Real failure-path tests added** (DoD law 2): meetings pipeline (ASR reject → `reportError`, finalize yields `[]` **dropped not fabricated**), mcp `provider-error`, relationships/inbox/contacts provider-error. **plugin-meetings suite passes 12/12 locally**; the other provider tests are standard and run in CI (a sparse review worktree can't resolve their cross-package vitest configs).
- `node packages/scripts/error-policy-ratchet.mjs` → **`no new fallback-slop in touched files`**.
- `bunx @biomejs/biome check` on changed files → clean.

## Evidence rows
- Real-LLM trajectory — N/A (connector/provider error-handling; the failure-path tests exercise the real reject → reportError path). Screenshots/video — N/A (no UI-render change).

Closes #12744.

🤖 Generated with [Claude Code](https://claude.com/claude-code)