### PR TITLE
fix meeting parity matrix reporting

### DIFF
--- a/.github/issue-evidence/12501-parity-matrix-report.md
+++ b/.github/issue-evidence/12501-parity-matrix-report.md
@@ -1,0 +1,139 @@
+# Issue #12501 - Cloud/local/hybrid parity matrix
+
+## Agent-completed work
+
+- Added a required `parity_matrix` manifest section to
+  `packages/benchmarks/meeting-transcription-proof`.
+- Added all nine #12501 lanes:
+  - `local_asr_local_llm_local_tts`
+  - `local_asr_cloud_llm_local_tts`
+  - `cloud_asr_cloud_llm_cloud_tts`
+  - `cloud_asr_local_llm_local_tts`
+  - `native_talkmode_stt_tts`
+  - `browser_web_speech_fallback`
+  - `offline_mode`
+  - `degraded_network_mode`
+  - `mobile_bridge_local_inference`
+- Validates same scenario ids and artifact schema for non-skipped lanes.
+- Requires WER, CER, DER, JER, cpWER, WDER, TTFA, final transcript latency,
+  first note latency, CPU, memory, battery delta, thermal state, cloud cost,
+  network bytes, failure/retry/dropout rates, and privacy mode per non-skipped
+  lane.
+- Requires per-lane baseline comparisons and rejects a passing lane with a
+  regression.
+- Requires explicit `skip_reason` for skipped lanes and keeps skipped lanes out
+  of pass counts.
+- Makes real reports publishable only when all nine lanes pass with no skips,
+  no failures, no baseline regressions, and desktop/mobile/cloud evidence
+  platform coverage.
+- Updated the registry scorer so orchestrated benchmark results enforce the same
+  parity matrix publishability gate.
+
+## Commands run
+
+```bash
+python -m json.tool \
+  packages/benchmarks/meeting-transcription-proof/fixtures/mock-meeting-manifest.json \
+  >/tmp/mtp-fixture-json-check.json
+```
+
+Result: passed.
+
+```bash
+PYTHONPATH=packages/benchmarks/meeting-transcription-proof \
+  python -m py_compile \
+  packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/cli.py
+```
+
+Result: passed.
+
+```bash
+PYTHONPATH=packages/benchmarks/meeting-transcription-proof \
+  pytest packages/benchmarks/meeting-transcription-proof/tests -q
+```
+
+Result: `37 passed`.
+
+```bash
+pytest packages/benchmarks/tests/test_registry_scores.py -q
+```
+
+Result: `12 passed`.
+
+```bash
+PYTHONPATH=packages \
+  python -m benchmarks.orchestrator run \
+  --benchmarks meeting_transcription_proof \
+  --provider eliza \
+  --model eliza \
+  --extra '{"lane":"mocked_plumbing"}' \
+  --force
+```
+
+Result: succeeded with `score=1.0`.
+
+```bash
+bun install
+```
+
+Result: passed after syncing artifacts to `2026-06-18.1`.
+
+```bash
+bun run verify
+```
+
+Result: failed outside this PR at `@elizaos/electrobun#lint`.
+
+Failure:
+
+```text
+packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts
+Formatter would reflow the ELIZA_VOICE_LIVE_RUNTIME env object and two
+voiceTurnSignal casts.
+```
+
+Manual inspection result: the failing file is unrelated to the benchmark
+parity matrix changes in this PR. The command was rerun after the final rebase
+onto `origin/develop` and failed at the same electrobun formatter gate. Because
+several lint tasks run with `--write`, verify also produced unrelated
+auto-format churn before failing; that generated churn was restored and is not
+part of this PR.
+
+## Smoke report inspected
+
+Generated report:
+`/tmp/mtp-12501/meeting-transcription-proof-report.json`
+
+Observed summary:
+
+```json
+{
+  "lane": "mocked_plumbing",
+  "publishable": false,
+  "score": 1.0,
+  "parity_summary": {
+    "required_lane_count": 9,
+    "pass_count": 1,
+    "fail_count": 0,
+    "skip_count": 8,
+    "non_skipped_lane_count": 1,
+    "scenario_count": 20,
+    "baseline_regression_count": 0,
+    "publishable": false,
+    "evidence_platforms": ["cloud", "desktop", "mobile"]
+  }
+}
+```
+
+Manual inspection result: the mocked lane remains non-publishable and skipped
+parity lanes are explicit, named, and not counted as passes.
+
+## Human-blocked evidence
+
+N/A for this PR because no live meeting providers, native device, mobile
+simulator/device capture, browser Web Speech session, network shaping, cloud
+provider billing logs, or local fused inference runtime were available to this
+agent. The follow-up human issue must provide the real desktop/mobile/cloud
+audio-video captures, resource logs, metrics JSON, baseline comparison artifacts,
+and provider cost/network records required to produce a publishable
+`real_product` parity matrix.

--- a/packages/benchmarks/meeting-transcription-proof/AGENTS.md
+++ b/packages/benchmarks/meeting-transcription-proof/AGENTS.md
@@ -138,6 +138,23 @@ and malformed artifact shapes. QA checklist rows must produce machine-readable
 verdicts for permission denied, capture stopped, speaker correction, delete
 audio, and share/privacy state.
 
+## Parity Matrix Contract
+
+The real lane requires a `parity_matrix` for the cloud/local/hybrid lanes from
+#12501: local ASR+LLM+TTS, local ASR+cloud LLM+local TTS, cloud ASR+LLM+TTS,
+cloud ASR+local LLM+local TTS, native TalkMode STT/TTS, browser Web Speech
+fallback, offline mode, degraded network mode, and mobile bridge/local
+inference. Every non-skipped lane must use the same scenario ids and artifact
+schema, cover the full required scenario corpus, include WER, CER, DER, JER,
+cpWER, WDER, TTFA, final transcript latency, first note latency, CPU, memory,
+battery, thermal state, cloud cost, network bytes, failure/retry/dropout rates,
+and privacy mode, plus a baseline comparison. A passing lane cannot carry a
+baseline regression. Skipped lanes must set `status: "skip"` and a non-empty
+`skip_reason`; skips are never counted as passes. Real reports are publishable
+only when all nine parity lanes pass, no lane is skipped or failed, no baseline
+regression is present, and the evidence platforms cover desktop, mobile, and
+cloud captures.
+
 ## Evidence
 
 Mocked reports prove plumbing only. Real reports must reference reviewed audio,

--- a/packages/benchmarks/meeting-transcription-proof/CLAUDE.md
+++ b/packages/benchmarks/meeting-transcription-proof/CLAUDE.md
@@ -138,6 +138,23 @@ and malformed artifact shapes. QA checklist rows must produce machine-readable
 verdicts for permission denied, capture stopped, speaker correction, delete
 audio, and share/privacy state.
 
+## Parity Matrix Contract
+
+The real lane requires a `parity_matrix` for the cloud/local/hybrid lanes from
+#12501: local ASR+LLM+TTS, local ASR+cloud LLM+local TTS, cloud ASR+LLM+TTS,
+cloud ASR+local LLM+local TTS, native TalkMode STT/TTS, browser Web Speech
+fallback, offline mode, degraded network mode, and mobile bridge/local
+inference. Every non-skipped lane must use the same scenario ids and artifact
+schema, cover the full required scenario corpus, include WER, CER, DER, JER,
+cpWER, WDER, TTFA, final transcript latency, first note latency, CPU, memory,
+battery, thermal state, cloud cost, network bytes, failure/retry/dropout rates,
+and privacy mode, plus a baseline comparison. A passing lane cannot carry a
+baseline regression. Skipped lanes must set `status: "skip"` and a non-empty
+`skip_reason`; skips are never counted as passes. Real reports are publishable
+only when all nine parity lanes pass, no lane is skipped or failed, no baseline
+regression is present, and the evidence platforms cover desktop, mobile, and
+cloud captures.
+
 ## Evidence
 
 Mocked reports prove plumbing only. Real reports must reference reviewed audio,

--- a/packages/benchmarks/meeting-transcription-proof/README.md
+++ b/packages/benchmarks/meeting-transcription-proof/README.md
@@ -176,6 +176,21 @@ and malformed artifact shapes. QA checklist rows must produce machine-readable
 verdicts for permission denied, capture stopped, speaker correction, delete
 audio, and share/privacy state.
 
+Real manifests must include a `parity_matrix` for the cloud/local/hybrid lanes
+from #12501: local ASR+LLM+TTS, local ASR+cloud LLM+local TTS, cloud
+ASR+LLM+TTS, cloud ASR+local LLM+local TTS, native TalkMode STT/TTS, browser
+Web Speech fallback, offline mode, degraded network mode, and mobile
+bridge/local inference. Every non-skipped lane must use the same scenario ids
+and artifact schema, cover the full required scenario corpus, include WER, CER,
+DER, JER, cpWER, WDER, TTFA, final transcript latency, first note latency, CPU,
+memory, battery, thermal state, cloud cost, network bytes, failure/retry/dropout
+rates, and privacy mode, plus a baseline comparison. A passing lane cannot carry
+a baseline regression. Skipped lanes must set `status: "skip"` and a non-empty
+`skip_reason`; skips are never counted as passes. Real reports are publishable
+only when all nine parity lanes pass, no lane is skipped or failed, no baseline
+regression is present, and the evidence platforms cover desktop, mobile, and
+cloud captures.
+
 ## Fixture Manifest
 
 `fixtures/mock-meeting-manifest.json` describes the minimum canonical meeting

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/cli.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/cli.py
@@ -409,6 +409,54 @@ RATIO_METRICS = {
 }
 LATENCY_METRICS = {"end_of_turn_latency_ms", "barge_in_latency_ms", "p95_end_to_end_latency_ms"}
 KNOWN_METRICS = REQUIRED_QUALITY_METRICS | REQUIRED_DETAILED_METRICS
+REQUIRED_PARITY_LANES = {
+    "local_asr_local_llm_local_tts",
+    "local_asr_cloud_llm_local_tts",
+    "cloud_asr_cloud_llm_cloud_tts",
+    "cloud_asr_local_llm_local_tts",
+    "native_talkmode_stt_tts",
+    "browser_web_speech_fallback",
+    "offline_mode",
+    "degraded_network_mode",
+    "mobile_bridge_local_inference",
+}
+PARITY_LANE_STATUSES = {"pass", "fail", "skip"}
+REQUIRED_PARITY_ARTIFACT_SCHEMA = {
+    "baseline_comparison",
+    "metrics_json",
+    "privacy_mode",
+    "resource_logs",
+    "transcript_artifact",
+}
+REQUIRED_PARITY_EVIDENCE = {
+    "baseline_comparison",
+    "metrics_json",
+    "resource_logs",
+}
+PARITY_REQUIRED_EVIDENCE_PLATFORMS = {"cloud", "desktop", "mobile"}
+PARITY_EVIDENCE_PLATFORMS = PARITY_REQUIRED_EVIDENCE_PLATFORMS | {"browser", "native"}
+PARITY_RATIO_METRICS = {"wer", "cer", "der", "jer", "cp_wer", "wder", "failure_rate", "dropout_rate"}
+PARITY_NON_NEGATIVE_METRICS = {
+    "ttfa_ms",
+    "final_transcript_latency_ms",
+    "first_note_latency_ms",
+    "cpu_percent",
+    "memory_mb",
+    "cloud_cost_usd",
+    "network_bytes",
+    "retry_count",
+}
+PARITY_NUMERIC_METRICS = PARITY_RATIO_METRICS | PARITY_NON_NEGATIVE_METRICS | {"battery_percent_delta"}
+PARITY_STRING_METRICS = {"thermal_state", "privacy_mode"}
+REQUIRED_PARITY_METRICS = PARITY_NUMERIC_METRICS | PARITY_STRING_METRICS
+PARITY_PRIVACY_MODES = {
+    "browser_fallback",
+    "cloud_processed",
+    "hybrid_local_cloud",
+    "local_only",
+    "native_device",
+    "offline_local",
+}
 
 
 def _package_root() -> Path:
@@ -427,6 +475,12 @@ def _as_set(value: Any, *, field: str) -> set[str]:
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
         raise ValueError(f"{field} must be a string array")
     return {item for item in value if item}
+
+
+def _require_string(value: Any, *, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
 
 
 def _require_number(metrics: dict[str, Any], key: str) -> float:
@@ -1292,6 +1346,193 @@ def _validate_qa_review_checklist(manifest: dict[str, Any]) -> tuple[list[dict[s
     return sorted(normalized, key=lambda item: item["id"]), referenced_evidence
 
 
+def _validate_parity_metrics(raw_metrics: Any, *, field: str) -> dict[str, float | str]:
+    if not isinstance(raw_metrics, dict):
+        raise ValueError(f"{field} must be an object")
+    missing_metrics = REQUIRED_PARITY_METRICS - set(raw_metrics)
+    if missing_metrics:
+        raise ValueError(f"{field} missing metrics: {sorted(missing_metrics)}")
+
+    metrics: dict[str, float | str] = {}
+    for key in sorted(PARITY_RATIO_METRICS):
+        metrics[key] = _require_ratio_value(f"{field}.{key}", raw_metrics.get(key))
+    for key in sorted(PARITY_NON_NEGATIVE_METRICS):
+        value = raw_metrics.get(key)
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise ValueError(f"{field}.{key} must be numeric")
+        number = float(value)
+        if number < 0:
+            raise ValueError(f"{field}.{key} must be non-negative")
+        metrics[key] = number
+    battery_delta = raw_metrics.get("battery_percent_delta")
+    if isinstance(battery_delta, bool) or not isinstance(battery_delta, int | float):
+        raise ValueError(f"{field}.battery_percent_delta must be numeric")
+    if float(battery_delta) < -100 or float(battery_delta) > 100:
+        raise ValueError(f"{field}.battery_percent_delta must be in [-100, 100]")
+    metrics["battery_percent_delta"] = float(battery_delta)
+
+    thermal_state = _require_string(raw_metrics.get("thermal_state"), field=f"{field}.thermal_state")
+    metrics["thermal_state"] = thermal_state
+    privacy_mode = _require_string(raw_metrics.get("privacy_mode"), field=f"{field}.privacy_mode")
+    if privacy_mode not in PARITY_PRIVACY_MODES:
+        raise ValueError(f"{field}.privacy_mode must be one of {sorted(PARITY_PRIVACY_MODES)}")
+    metrics["privacy_mode"] = privacy_mode
+    return metrics
+
+
+def _validate_parity_baseline(raw_baseline: Any, *, field: str, status: str) -> dict[str, Any]:
+    if not isinstance(raw_baseline, dict):
+        raise ValueError(f"{field} must be an object")
+    baseline_id = _require_string(raw_baseline.get("baseline_id"), field=f"{field}.baseline_id")
+    comparison_report = _require_string(raw_baseline.get("comparison_report"), field=f"{field}.comparison_report")
+    regression = raw_baseline.get("regression")
+    if not isinstance(regression, bool):
+        raise ValueError(f"{field}.regression must be a boolean")
+    if status == "pass" and regression:
+        raise ValueError(f"{field}.regression cannot be true for a passing parity lane")
+    return {
+        "baseline_id": baseline_id,
+        "comparison_report": comparison_report,
+        "regression": regression,
+    }
+
+
+def _validate_parity_matrix(manifest: dict[str, Any], *, lane: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    matrix = manifest.get("parity_matrix")
+    if not isinstance(matrix, list) or not matrix:
+        raise ValueError("parity_matrix must be a non-empty array")
+
+    lane_ids: set[str] = set()
+    pass_count = 0
+    fail_count = 0
+    skip_count = 0
+    baseline_regression_count = 0
+    evidence_platforms: set[str] = set()
+    reference_scenario_ids: set[str] | None = None
+    reference_artifact_schema: set[str] | None = None
+    normalized: list[dict[str, Any]] = []
+
+    for index, row in enumerate(matrix):
+        if not isinstance(row, dict):
+            raise ValueError(f"parity_matrix[{index}] must be an object")
+        lane_id = _require_string(row.get("id"), field=f"parity_matrix[{index}].id")
+        lane_ids.add(lane_id)
+        status = _require_string(row.get("status"), field=f"parity_matrix[{index}].status")
+        if status not in PARITY_LANE_STATUSES:
+            raise ValueError(f"parity_matrix[{index}].status must be one of {sorted(PARITY_LANE_STATUSES)}")
+
+        scenario_ids = _as_set(row.get("scenario_ids"), field=f"parity_matrix[{index}].scenario_ids")
+        if not scenario_ids:
+            raise ValueError(f"parity_matrix[{index}].scenario_ids must be non-empty")
+        unknown_scenarios = scenario_ids - REQUIRED_SCENARIOS
+        if unknown_scenarios:
+            raise ValueError(f"parity_matrix[{index}] references unknown scenarios: {sorted(unknown_scenarios)}")
+
+        artifact_schema = _as_set(row.get("artifact_schema"), field=f"parity_matrix[{index}].artifact_schema")
+        if not artifact_schema:
+            raise ValueError(f"parity_matrix[{index}].artifact_schema must be non-empty")
+
+        normalized_row: dict[str, Any] = {
+            "id": lane_id,
+            "status": status,
+            "scenario_ids": sorted(scenario_ids),
+            "artifact_schema": sorted(artifact_schema),
+        }
+
+        if status == "skip":
+            skip_count += 1
+            normalized_row["skip_reason"] = _require_string(
+                row.get("skip_reason"),
+                field=f"parity_matrix[{index}].skip_reason",
+            )
+            normalized.append(normalized_row)
+            continue
+
+        if scenario_ids != REQUIRED_SCENARIOS:
+            missing_scenarios = REQUIRED_SCENARIOS - scenario_ids
+            raise ValueError(f"parity_matrix[{index}] missing required scenarios: {sorted(missing_scenarios)}")
+        missing_artifact_schema = REQUIRED_PARITY_ARTIFACT_SCHEMA - artifact_schema
+        if missing_artifact_schema:
+            raise ValueError(f"parity_matrix[{index}] missing artifact schema: {sorted(missing_artifact_schema)}")
+
+        if reference_scenario_ids is None:
+            reference_scenario_ids = set(scenario_ids)
+        elif scenario_ids != reference_scenario_ids:
+            raise ValueError("parity_matrix non-skipped lanes must use the same scenario ids")
+        if reference_artifact_schema is None:
+            reference_artifact_schema = set(artifact_schema)
+        elif artifact_schema != reference_artifact_schema:
+            raise ValueError("parity_matrix non-skipped lanes must use the same artifact schema")
+
+        metrics = _validate_parity_metrics(row.get("metrics"), field=f"parity_matrix[{index}].metrics")
+        baseline = _validate_parity_baseline(
+            row.get("baseline"),
+            field=f"parity_matrix[{index}].baseline",
+            status=status,
+        )
+        if baseline["regression"]:
+            baseline_regression_count += 1
+        evidence = _as_set(row.get("evidence"), field=f"parity_matrix[{index}].evidence")
+        missing_evidence = REQUIRED_PARITY_EVIDENCE - evidence
+        if missing_evidence:
+            raise ValueError(f"parity_matrix[{index}] missing evidence: {sorted(missing_evidence)}")
+        row_platforms = _as_set(row.get("evidence_platforms"), field=f"parity_matrix[{index}].evidence_platforms")
+        if not row_platforms:
+            raise ValueError(f"parity_matrix[{index}].evidence_platforms must be non-empty")
+        unknown_platforms = row_platforms - PARITY_EVIDENCE_PLATFORMS
+        if unknown_platforms:
+            raise ValueError(f"parity_matrix[{index}] references unknown evidence platforms: {sorted(unknown_platforms)}")
+        evidence_platforms.update(row_platforms)
+
+        if status == "pass":
+            pass_count += 1
+        else:
+            fail_count += 1
+        normalized_row.update(
+            {
+                "metrics": metrics,
+                "baseline": baseline,
+                "evidence": sorted(evidence),
+                "evidence_platforms": sorted(row_platforms),
+            }
+        )
+        normalized.append(normalized_row)
+
+    missing_lanes = REQUIRED_PARITY_LANES - lane_ids
+    if missing_lanes:
+        raise ValueError(f"parity_matrix missing lanes: {sorted(missing_lanes)}")
+    unknown_lanes = lane_ids - REQUIRED_PARITY_LANES
+    if unknown_lanes:
+        raise ValueError(f"parity_matrix contains unknown lanes: {sorted(unknown_lanes)}")
+    if len(lane_ids) != len(matrix):
+        raise ValueError("parity_matrix contains duplicate lanes")
+    if reference_scenario_ids is None:
+        raise ValueError("parity_matrix must have at least one non-skipped lane")
+    missing_platforms = PARITY_REQUIRED_EVIDENCE_PLATFORMS - evidence_platforms
+    if lane == "real_product" and missing_platforms:
+        raise ValueError(f"parity_matrix missing evidence platforms: {sorted(missing_platforms)}")
+
+    summary = {
+        "required_lane_count": len(REQUIRED_PARITY_LANES),
+        "pass_count": pass_count,
+        "fail_count": fail_count,
+        "skip_count": skip_count,
+        "non_skipped_lane_count": pass_count + fail_count,
+        "scenario_count": len(reference_scenario_ids),
+        "artifact_schema": sorted(reference_artifact_schema or []),
+        "evidence_platforms": sorted(evidence_platforms),
+        "baseline_regression_count": baseline_regression_count,
+        "publishable": (
+            pass_count == len(REQUIRED_PARITY_LANES)
+            and fail_count == 0
+            and skip_count == 0
+            and baseline_regression_count == 0
+            and not (PARITY_REQUIRED_EVIDENCE_PLATFORMS - evidence_platforms)
+        ),
+    }
+    return sorted(normalized, key=lambda row: row["id"]), summary
+
+
 def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Path) -> dict[str, Any]:
     if lane not in LANES:
         raise ValueError(f"lane must be one of {sorted(LANES)}")
@@ -1357,6 +1598,7 @@ def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Pat
     qa_review_checklist, qa_evidence_types = _validate_qa_review_checklist(manifest)
 
     metric_values = _validate_metrics(manifest.get("metrics"), lane=lane)
+    parity_matrix, parity_matrix_summary = _validate_parity_matrix(manifest, lane=lane)
 
     evidence_files: dict[str, str] = {}
     provider_mode = str(manifest.get("provider_mode") or "").strip().lower()
@@ -1421,6 +1663,8 @@ def validate_manifest(manifest: dict[str, Any], *, lane: str, manifest_path: Pat
         "adversarial_cases": adversarial_cases,
         "qa_review_checklist": qa_review_checklist,
         "metrics": metric_values,
+        "parity_matrix": parity_matrix,
+        "parity_matrix_summary": parity_matrix_summary,
         "evidence_files": evidence_files,
         "provider_mode": provider_mode,
     }
@@ -1435,7 +1679,7 @@ def build_report(*, lane: str, manifest_path: Path) -> dict[str, Any]:
         publishable = False
     else:
         score = min(metrics[key] for key in REQUIRED_QUALITY_METRICS)
-        publishable = True
+        publishable = validation["parity_matrix_summary"]["publishable"]
     return {
         "kind": "meeting_transcription_proof_report",
         "version": 1,

--- a/packages/benchmarks/meeting-transcription-proof/fixtures/mock-meeting-manifest.json
+++ b/packages/benchmarks/meeting-transcription-proof/fixtures/mock-meeting-manifest.json
@@ -1030,6 +1030,125 @@
       "failure_policy": "share controls must distinguish transcript, notes, audio, and generated artifacts"
     }
   ],
+  "parity_matrix": [
+    {
+      "id": "local_asr_local_llm_local_tts",
+      "status": "pass",
+      "scenario_ids": [
+        "clean_single_speaker",
+        "zoom_bot",
+        "zoom_bot_free",
+        "google_meet_bot",
+        "google_meet_bot_free",
+        "on_device_capture",
+        "cloud_agent_capture",
+        "hybrid_local_cloud",
+        "multiple_people_single_stream",
+        "shared_room_microphone",
+        "speech_over_music",
+        "speech_over_noise",
+        "speech_over_babble",
+        "overlapped_speech",
+        "far_field_room",
+        "known_speaker_recognition",
+        "unknown_speaker_creation",
+        "speaker_name_correction",
+        "voice_profile_deletion",
+        "transcript_sharing_export_delete"
+      ],
+      "artifact_schema": [
+        "baseline_comparison",
+        "metrics_json",
+        "privacy_mode",
+        "resource_logs",
+        "transcript_artifact"
+      ],
+      "metrics": {
+        "wer": 0.0,
+        "cer": 0.0,
+        "der": 0.0,
+        "jer": 0.0,
+        "cp_wer": 0.0,
+        "wder": 0.0,
+        "ttfa_ms": 0,
+        "final_transcript_latency_ms": 0,
+        "first_note_latency_ms": 0,
+        "cpu_percent": 0,
+        "memory_mb": 0,
+        "battery_percent_delta": 0,
+        "thermal_state": "fixture",
+        "cloud_cost_usd": 0.0,
+        "network_bytes": 0,
+        "failure_rate": 0.0,
+        "retry_count": 0,
+        "dropout_rate": 0.0,
+        "privacy_mode": "local_only"
+      },
+      "baseline": {
+        "baseline_id": "fixture-parity-baseline",
+        "comparison_report": "fixture-baseline-comparison.json",
+        "regression": false
+      },
+      "evidence": ["metrics_json", "resource_logs", "baseline_comparison"],
+      "evidence_platforms": ["desktop", "mobile", "cloud"]
+    },
+    {
+      "id": "local_asr_cloud_llm_local_tts",
+      "status": "skip",
+      "scenario_ids": ["clean_single_speaker"],
+      "artifact_schema": ["baseline_comparison", "metrics_json", "privacy_mode", "resource_logs", "transcript_artifact"],
+      "skip_reason": "mock fixture does not call cloud LLM providers"
+    },
+    {
+      "id": "cloud_asr_cloud_llm_cloud_tts",
+      "status": "skip",
+      "scenario_ids": ["clean_single_speaker"],
+      "artifact_schema": ["baseline_comparison", "metrics_json", "privacy_mode", "resource_logs", "transcript_artifact"],
+      "skip_reason": "mock fixture does not call cloud ASR, LLM, or TTS providers"
+    },
+    {
+      "id": "cloud_asr_local_llm_local_tts",
+      "status": "skip",
+      "scenario_ids": ["clean_single_speaker"],
+      "artifact_schema": ["baseline_comparison", "metrics_json", "privacy_mode", "resource_logs", "transcript_artifact"],
+      "skip_reason": "mock fixture does not call cloud ASR providers"
+    },
+    {
+      "id": "native_talkmode_stt_tts",
+      "status": "skip",
+      "scenario_ids": ["clean_single_speaker"],
+      "artifact_schema": ["baseline_comparison", "metrics_json", "privacy_mode", "resource_logs", "transcript_artifact"],
+      "skip_reason": "mock fixture does not drive native TalkMode"
+    },
+    {
+      "id": "browser_web_speech_fallback",
+      "status": "skip",
+      "scenario_ids": ["clean_single_speaker"],
+      "artifact_schema": ["baseline_comparison", "metrics_json", "privacy_mode", "resource_logs", "transcript_artifact"],
+      "skip_reason": "mock fixture does not invoke browser Web Speech"
+    },
+    {
+      "id": "offline_mode",
+      "status": "skip",
+      "scenario_ids": ["clean_single_speaker"],
+      "artifact_schema": ["baseline_comparison", "metrics_json", "privacy_mode", "resource_logs", "transcript_artifact"],
+      "skip_reason": "mock fixture does not disable networking or prove offline execution"
+    },
+    {
+      "id": "degraded_network_mode",
+      "status": "skip",
+      "scenario_ids": ["clean_single_speaker"],
+      "artifact_schema": ["baseline_comparison", "metrics_json", "privacy_mode", "resource_logs", "transcript_artifact"],
+      "skip_reason": "mock fixture does not apply network shaping"
+    },
+    {
+      "id": "mobile_bridge_local_inference",
+      "status": "skip",
+      "scenario_ids": ["clean_single_speaker"],
+      "artifact_schema": ["baseline_comparison", "metrics_json", "privacy_mode", "resource_logs", "transcript_artifact"],
+      "skip_reason": "mock fixture does not run a mobile bridge or local inference runtime"
+    }
+  ],
   "metrics": {
     "transcript_quality": 1.0,
     "diarization_quality": 1.0,

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_cli.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from elizaos_meeting_transcription_proof.cli import build_report
+from elizaos_meeting_transcription_proof.cli import REQUIRED_PARITY_LANES, build_report
 
 
 FIXTURE_MANIFEST = Path(__file__).resolve().parents[1] / "fixtures" / "mock-meeting-manifest.json"
@@ -51,6 +51,85 @@ def _fixture_qa_review_checklist() -> list[object]:
     return json.loads(FIXTURE_MANIFEST.read_text(encoding="utf-8"))["qa_review_checklist"]
 
 
+def _fixture_parity_matrix() -> list[object]:
+    return json.loads(FIXTURE_MANIFEST.read_text(encoding="utf-8"))["parity_matrix"]
+
+
+def _parity_metrics(lane_id: str) -> dict[str, object]:
+    privacy_mode_by_lane = {
+        "browser_web_speech_fallback": "browser_fallback",
+        "cloud_asr_cloud_llm_cloud_tts": "cloud_processed",
+        "cloud_asr_local_llm_local_tts": "hybrid_local_cloud",
+        "degraded_network_mode": "hybrid_local_cloud",
+        "local_asr_cloud_llm_local_tts": "hybrid_local_cloud",
+        "local_asr_local_llm_local_tts": "local_only",
+        "mobile_bridge_local_inference": "native_device",
+        "native_talkmode_stt_tts": "native_device",
+        "offline_mode": "offline_local",
+    }
+    cloud_lanes = {"cloud_asr_cloud_llm_cloud_tts", "cloud_asr_local_llm_local_tts", "degraded_network_mode"}
+    return {
+        "wer": 0.09,
+        "cer": 0.04,
+        "der": 0.18,
+        "jer": 0.22,
+        "cp_wer": 0.13,
+        "wder": 0.2,
+        "ttfa_ms": 420,
+        "final_transcript_latency_ms": 1300,
+        "first_note_latency_ms": 2500,
+        "cpu_percent": 42.5,
+        "memory_mb": 768,
+        "battery_percent_delta": 2.5,
+        "thermal_state": "nominal",
+        "cloud_cost_usd": 0.021 if lane_id in cloud_lanes else 0.0,
+        "network_bytes": 348160 if lane_id in cloud_lanes else 8192,
+        "failure_rate": 0.0,
+        "retry_count": 0,
+        "dropout_rate": 0.0,
+        "privacy_mode": privacy_mode_by_lane[lane_id],
+    }
+
+
+def _all_pass_parity_matrix() -> list[object]:
+    scenario_ids = [scenario["id"] for scenario in _fixture_scenarios() if isinstance(scenario, dict)]
+    artifact_schema = [
+        "baseline_comparison",
+        "metrics_json",
+        "privacy_mode",
+        "resource_logs",
+        "transcript_artifact",
+    ]
+    platform_by_lane = {
+        "browser_web_speech_fallback": ["browser", "desktop"],
+        "cloud_asr_cloud_llm_cloud_tts": ["cloud", "desktop"],
+        "cloud_asr_local_llm_local_tts": ["cloud", "desktop"],
+        "degraded_network_mode": ["cloud", "desktop"],
+        "local_asr_cloud_llm_local_tts": ["cloud", "desktop"],
+        "local_asr_local_llm_local_tts": ["desktop", "native"],
+        "mobile_bridge_local_inference": ["mobile", "native"],
+        "native_talkmode_stt_tts": ["mobile", "native"],
+        "offline_mode": ["desktop", "mobile", "native"],
+    }
+    return [
+        {
+            "id": lane_id,
+            "status": "pass",
+            "scenario_ids": scenario_ids,
+            "artifact_schema": artifact_schema,
+            "metrics": _parity_metrics(lane_id),
+            "baseline": {
+                "baseline_id": "meeting-parity-2026-07",
+                "comparison_report": f"baseline-comparison-{lane_id}.json",
+                "regression": False,
+            },
+            "evidence": ["metrics_json", "resource_logs", "baseline_comparison"],
+            "evidence_platforms": platform_by_lane[lane_id],
+        }
+        for lane_id in sorted(REQUIRED_PARITY_LANES)
+    ]
+
+
 def _base_manifest(provider_mode: str = "real_zoom_meet") -> dict[str, object]:
     return {
         "provider_mode": provider_mode,
@@ -82,6 +161,7 @@ def _base_manifest(provider_mode: str = "real_zoom_meet") -> dict[str, object]:
         "baseline_comparisons": _fixture_baseline_comparisons(),
         "adversarial_cases": _fixture_adversarial_cases(),
         "qa_review_checklist": _fixture_qa_review_checklist(),
+        "parity_matrix": _all_pass_parity_matrix(),
         "metrics": {
             "transcript_quality": 0.91,
             "diarization_quality": 0.82,
@@ -144,6 +224,107 @@ def test_mocked_plumbing_fixture_is_not_publishable() -> None:
     assert len(report["baseline_comparisons"]) == len(_fixture_baseline_comparisons())
     assert len(report["adversarial_cases"]) == len(_fixture_adversarial_cases())
     assert len(report["qa_review_checklist"]) == len(_fixture_qa_review_checklist())
+    assert report["parity_matrix_summary"]["pass_count"] == 1
+    assert report["parity_matrix_summary"]["skip_count"] == len(REQUIRED_PARITY_LANES) - 1
+    assert report["parity_matrix_summary"]["publishable"] is False
+
+
+def test_mocked_plumbing_fixture_reports_explicit_parity_skips() -> None:
+    report = build_report(lane="mocked_plumbing", manifest_path=FIXTURE_MANIFEST)
+
+    skipped = [row for row in report["parity_matrix"] if row["status"] == "skip"]
+
+    assert skipped
+    assert all(row.get("skip_reason") for row in skipped)
+    assert report["parity_matrix_summary"]["pass_count"] < len(REQUIRED_PARITY_LANES)
+
+
+def test_real_lane_requires_parity_matrix_all_lanes(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    manifest_data["parity_matrix"] = [
+        row for row in _all_pass_parity_matrix() if isinstance(row, dict) and row["id"] != "offline_mode"
+    ]
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="parity_matrix missing lanes"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_parity_matrix_rejects_unknown_lane(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    matrix = _all_pass_parity_matrix()
+    matrix.append({**matrix[0], "id": "imaginary_lane"})
+    manifest_data["parity_matrix"] = matrix
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="parity_matrix contains unknown lanes"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_parity_matrix_requires_skip_reason(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    matrix = _all_pass_parity_matrix()
+    assert isinstance(matrix[0], dict)
+    matrix[0] = {**matrix[0], "status": "skip"}
+    manifest_data["parity_matrix"] = matrix
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match=r"parity_matrix\[0\]\.skip_reason must be a non-empty string"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_parity_matrix_requires_same_scenario_corpus(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    matrix = _all_pass_parity_matrix()
+    assert isinstance(matrix[0], dict)
+    scenario_ids = matrix[0]["scenario_ids"]
+    assert isinstance(scenario_ids, list)
+    matrix[0] = {**matrix[0], "scenario_ids": scenario_ids[:-1]}
+    manifest_data["parity_matrix"] = matrix
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="missing required scenarios"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_parity_matrix_requires_same_artifact_schema(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    matrix = _all_pass_parity_matrix()
+    assert isinstance(matrix[0], dict)
+    artifact_schema = matrix[0]["artifact_schema"]
+    assert isinstance(artifact_schema, list)
+    matrix[0] = {**matrix[0], "artifact_schema": [*artifact_schema, "lane_specific_extra"]}
+    manifest_data["parity_matrix"] = matrix
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="non-skipped lanes must use the same artifact schema"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_parity_matrix_requires_baseline_comparison(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    matrix = _all_pass_parity_matrix()
+    assert isinstance(matrix[0], dict)
+    matrix[0] = {key: value for key, value in matrix[0].items() if key != "baseline"}
+    manifest_data["parity_matrix"] = matrix
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match=r"parity_matrix\[0\]\.baseline must be an object"):
+        build_report(lane="real_product", manifest_path=manifest)
+
+
+def test_parity_matrix_rejects_pass_with_regression(tmp_path: Path) -> None:
+    manifest_data = _base_manifest()
+    matrix = _all_pass_parity_matrix()
+    assert isinstance(matrix[0], dict)
+    baseline = matrix[0]["baseline"]
+    assert isinstance(baseline, dict)
+    matrix[0] = {**matrix[0], "baseline": {**baseline, "regression": True}}
+    manifest_data["parity_matrix"] = matrix
+    manifest = _write_manifest(tmp_path, manifest_data)
+
+    with pytest.raises(ValueError, match="regression cannot be true for a passing parity lane"):
+        build_report(lane="real_product", manifest_path=manifest)
 
 
 def test_real_lane_requires_non_mock_provider(tmp_path: Path) -> None:
@@ -767,6 +948,10 @@ def test_real_lane_scores_lowest_required_quality_and_resolves_evidence(tmp_path
     assert report["score"] == pytest.approx(0.77)
     assert report["metrics"]["wer"] == pytest.approx(0.09)
     assert report["metrics"]["p95_end_to_end_latency_ms"] == pytest.approx(1300)
+    assert report["parity_matrix_summary"]["pass_count"] == len(REQUIRED_PARITY_LANES)
+    assert report["parity_matrix_summary"]["fail_count"] == 0
+    assert report["parity_matrix_summary"]["skip_count"] == 0
+    assert report["parity_matrix_summary"]["publishable"] is True
     assert {dataset["id"] for dataset in report["dataset_sources"]} >= {"musan", "libricss", "chime6", "misp_meeting"}
     assert {path["id"] for path in report["capture_paths"]} >= {"zoom_bot", "google_meet_bot_free", "on_device_capture"}
     assert {operation["id"] for operation in report["speaker_operations"]} >= {

--- a/packages/benchmarks/registry/scores.py
+++ b/packages/benchmarks/registry/scores.py
@@ -948,6 +948,32 @@ MEETING_PROOF_REQUIRED_GENERATED_ARTIFACT_SCORE_IDS = {
     "source_grounding",
 }
 
+_MEETING_PROOF_REQUIRED_PARITY_LANES = {
+    "local_asr_local_llm_local_tts",
+    "local_asr_cloud_llm_local_tts",
+    "cloud_asr_cloud_llm_cloud_tts",
+    "cloud_asr_local_llm_local_tts",
+    "native_talkmode_stt_tts",
+    "browser_web_speech_fallback",
+    "offline_mode",
+    "degraded_network_mode",
+    "mobile_bridge_local_inference",
+}
+
+_MEETING_PROOF_REQUIRED_PARITY_EVIDENCE_PLATFORMS = {"cloud", "desktop", "mobile"}
+_MEETING_PROOF_REQUIRED_PARITY_ARTIFACT_SCHEMA = {
+    "baseline_comparison",
+    "metrics_json",
+    "privacy_mode",
+    "resource_logs",
+    "transcript_artifact",
+}
+_MEETING_PROOF_REQUIRED_PARITY_EVIDENCE = {
+    "baseline_comparison",
+    "metrics_json",
+    "resource_logs",
+}
+
 
 def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtraction:
     """Extract the #12486 meeting transcription proof score.
@@ -1029,6 +1055,11 @@ def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtrac
         qa_human_pass_count = sum(
             1 for item in qa_items if isinstance(item, dict) and item.get("verdict") == "pass"
         )
+    parity_summary_raw = root.get("parity_matrix_summary")
+    parity_summary = parity_summary_raw if isinstance(parity_summary_raw, dict) else {}
+    parity_pass_count = int(parity_summary.get("pass_count") or 0)
+    parity_fail_count = int(parity_summary.get("fail_count") or 0)
+    parity_skip_count = int(parity_summary.get("skip_count") or 0)
     publishable = root.get("publishable") is True
     if lane == "real_product":
         if not publishable:
@@ -1083,6 +1114,120 @@ def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtrac
             raise ValueError("meeting_transcription_proof: real lane requires QA checklist verdicts")
         if qa_machine_pass_count != qa_count or qa_human_pass_count != qa_count:
             raise ValueError("meeting_transcription_proof: real lane requires passing QA checklist verdicts")
+        parity_matrix = expect_list(
+            get_required(root, "parity_matrix", ctx="meeting_transcription_proof:root"),
+            ctx="meeting_transcription_proof:parity_matrix",
+        )
+        parity_summary = expect_dict(
+            get_required(root, "parity_matrix_summary", ctx="meeting_transcription_proof:root"),
+            ctx="meeting_transcription_proof:parity_matrix_summary",
+        )
+        parity_lane_ids: set[str] = set()
+        row_evidence_platforms: set[str] = set()
+        for index, row_raw in enumerate(parity_matrix):
+            row = expect_dict(row_raw, ctx=f"meeting_transcription_proof:parity_matrix[{index}]")
+            lane_id = str(get_required(row, "id", ctx=f"meeting_transcription_proof:parity_matrix[{index}]"))
+            parity_lane_ids.add(lane_id)
+            status = str(get_required(row, "status", ctx=f"meeting_transcription_proof:parity_matrix[{index}]"))
+            if status != "pass":
+                raise ValueError("meeting_transcription_proof: real lane requires all parity rows to pass")
+            artifact_schema = {
+                str(item)
+                for item in expect_list(
+                    get_required(
+                        row,
+                        "artifact_schema",
+                        ctx=f"meeting_transcription_proof:parity_matrix[{index}]",
+                    ),
+                    ctx=f"meeting_transcription_proof:parity_matrix[{index}].artifact_schema",
+                )
+            }
+            missing_artifact_schema = _MEETING_PROOF_REQUIRED_PARITY_ARTIFACT_SCHEMA - artifact_schema
+            if missing_artifact_schema:
+                raise ValueError(
+                    "meeting_transcription_proof: real lane parity row missing artifact schema "
+                    f"{sorted(missing_artifact_schema)}"
+                )
+            evidence = {
+                str(item)
+                for item in expect_list(
+                    get_required(row, "evidence", ctx=f"meeting_transcription_proof:parity_matrix[{index}]"),
+                    ctx=f"meeting_transcription_proof:parity_matrix[{index}].evidence",
+                )
+            }
+            missing_evidence = _MEETING_PROOF_REQUIRED_PARITY_EVIDENCE - evidence
+            if missing_evidence:
+                raise ValueError(
+                    "meeting_transcription_proof: real lane parity row missing evidence "
+                    f"{sorted(missing_evidence)}"
+                )
+            baseline = expect_dict(
+                get_required(row, "baseline", ctx=f"meeting_transcription_proof:parity_matrix[{index}]"),
+                ctx=f"meeting_transcription_proof:parity_matrix[{index}].baseline",
+            )
+            if baseline.get("regression") is True:
+                raise ValueError("meeting_transcription_proof: real lane parity row has baseline regression")
+            row_platforms = {
+                str(item)
+                for item in expect_list(
+                    get_required(
+                        row,
+                        "evidence_platforms",
+                        ctx=f"meeting_transcription_proof:parity_matrix[{index}]",
+                    ),
+                    ctx=f"meeting_transcription_proof:parity_matrix[{index}].evidence_platforms",
+                )
+            }
+            row_evidence_platforms.update(row_platforms)
+        missing_parity_lanes = _MEETING_PROOF_REQUIRED_PARITY_LANES - parity_lane_ids
+        if missing_parity_lanes:
+            raise ValueError(
+                "meeting_transcription_proof: real lane requires parity lanes "
+                f"{sorted(missing_parity_lanes)}"
+            )
+        unknown_parity_lanes = parity_lane_ids - _MEETING_PROOF_REQUIRED_PARITY_LANES
+        if unknown_parity_lanes:
+            raise ValueError(
+                "meeting_transcription_proof: real lane has unknown parity lanes "
+                f"{sorted(unknown_parity_lanes)}"
+            )
+        parity_pass_count = int(
+            expect_float(
+                get_required(parity_summary, "pass_count", ctx="meeting_transcription_proof:parity_matrix_summary"),
+                ctx="meeting_transcription_proof:parity_matrix_summary.pass_count",
+            )
+        )
+        parity_fail_count = int(
+            expect_float(
+                get_required(parity_summary, "fail_count", ctx="meeting_transcription_proof:parity_matrix_summary"),
+                ctx="meeting_transcription_proof:parity_matrix_summary.fail_count",
+            )
+        )
+        parity_skip_count = int(
+            expect_float(
+                get_required(parity_summary, "skip_count", ctx="meeting_transcription_proof:parity_matrix_summary"),
+                ctx="meeting_transcription_proof:parity_matrix_summary.skip_count",
+            )
+        )
+        if (
+            parity_pass_count != len(_MEETING_PROOF_REQUIRED_PARITY_LANES)
+            or parity_fail_count != 0
+            or parity_skip_count != 0
+            or parity_summary.get("publishable") is not True
+        ):
+            raise ValueError("meeting_transcription_proof: real lane requires complete parity matrix")
+        evidence_platforms = expect_list(
+            get_required(parity_summary, "evidence_platforms", ctx="meeting_transcription_proof:parity_matrix_summary"),
+            ctx="meeting_transcription_proof:parity_matrix_summary.evidence_platforms",
+        )
+        missing_platforms = _MEETING_PROOF_REQUIRED_PARITY_EVIDENCE_PLATFORMS - (
+            {str(platform) for platform in evidence_platforms} | row_evidence_platforms
+        )
+        if missing_platforms:
+            raise ValueError(
+                "meeting_transcription_proof: real lane requires parity evidence platforms "
+                f"{sorted(missing_platforms)}"
+            )
     elif publishable:
         raise ValueError("meeting_transcription_proof: mocked lane cannot be publishable")
 
@@ -1124,6 +1269,9 @@ def _score_from_meeting_transcription_proof_json(data: JSONValue) -> ScoreExtrac
             "room_feed_heuristic_recall": metrics.get("room_feed_heuristic_recall") or 0,
             "visual_acoustic_disagreement_rate": metrics.get("visual_acoustic_disagreement_rate") or 0,
             **generated_artifact_metrics,
+            "parity_pass_count": parity_pass_count,
+            "parity_fail_count": parity_fail_count,
+            "parity_skip_count": parity_skip_count,
             "provider_mode": root.get("provider_mode") or "",
         },
     )

--- a/packages/benchmarks/tests/test_registry_scores.py
+++ b/packages/benchmarks/tests/test_registry_scores.py
@@ -212,6 +212,45 @@ def _meeting_transcription_real_evidence() -> dict[str, str]:
     }
 
 
+def _meeting_transcription_parity_lanes() -> list[str]:
+    return [
+        "browser_web_speech_fallback",
+        "cloud_asr_cloud_llm_cloud_tts",
+        "cloud_asr_local_llm_local_tts",
+        "degraded_network_mode",
+        "local_asr_cloud_llm_local_tts",
+        "local_asr_local_llm_local_tts",
+        "mobile_bridge_local_inference",
+        "native_talkmode_stt_tts",
+        "offline_mode",
+    ]
+
+
+def _meeting_transcription_parity_matrix() -> list[dict[str, object]]:
+    return [
+        {
+            "id": lane,
+            "status": "pass",
+            "scenario_ids": ["zoom_bot_free"],
+            "artifact_schema": [
+                "baseline_comparison",
+                "metrics_json",
+                "privacy_mode",
+                "resource_logs",
+                "transcript_artifact",
+            ],
+            "baseline": {
+                "baseline_id": "meeting-parity-2026-07",
+                "comparison_report": f"baseline-comparison-{lane}.json",
+                "regression": False,
+            },
+            "evidence": ["baseline_comparison", "metrics_json", "resource_logs"],
+            "evidence_platforms": ["cloud", "desktop", "mobile"],
+        }
+        for lane in _meeting_transcription_parity_lanes()
+    ]
+
+
 def _meeting_transcription_real_report() -> dict[str, object]:
     return {
         "kind": "meeting_transcription_proof_report",
@@ -231,6 +270,15 @@ def _meeting_transcription_real_report() -> dict[str, object]:
         "baseline_comparisons": _meeting_baseline_comparisons(),
         "adversarial_cases": _meeting_adversarial_cases(),
         "qa_review_checklist": _meeting_qa_checklist(),
+        "parity_matrix": _meeting_transcription_parity_matrix(),
+        "parity_matrix_summary": {
+            "required_lane_count": 9,
+            "pass_count": 9,
+            "fail_count": 0,
+            "skip_count": 0,
+            "publishable": True,
+            "evidence_platforms": ["cloud", "desktop", "mobile"],
+        },
     }
 
 
@@ -343,6 +391,38 @@ def test_meeting_transcription_real_lane_requires_passing_qa_verdicts() -> None:
         _score_from_meeting_transcription_proof_json(report)
 
 
+def test_meeting_transcription_real_lane_requires_parity_matrix() -> None:
+    report = _meeting_transcription_real_report()
+    report.pop("parity_matrix")
+
+    with pytest.raises(ValueError, match="parity_matrix"):
+        _score_from_meeting_transcription_proof_json(report)
+
+
+def test_meeting_transcription_real_lane_rejects_skipped_parity_lanes() -> None:
+    report = _meeting_transcription_real_report()
+    summary = report["parity_matrix_summary"]
+    assert isinstance(summary, dict)
+    summary["pass_count"] = 8
+    summary["skip_count"] = 1
+    summary["publishable"] = False
+
+    with pytest.raises(ValueError, match="complete parity matrix"):
+        _score_from_meeting_transcription_proof_json(report)
+
+
+def test_meeting_transcription_real_lane_rejects_malformed_parity_rows() -> None:
+    report = _meeting_transcription_real_report()
+    parity_matrix = report["parity_matrix"]
+    assert isinstance(parity_matrix, list)
+    first = parity_matrix[0]
+    assert isinstance(first, dict)
+    first.pop("status")
+
+    with pytest.raises(ValueError, match="status"):
+        _score_from_meeting_transcription_proof_json(report)
+
+
 def test_meeting_transcription_real_lane_score_is_publishable_with_evidence() -> None:
     extraction = _score_from_meeting_transcription_proof_json(_meeting_transcription_real_report())
 
@@ -363,3 +443,5 @@ def test_meeting_transcription_real_lane_score_is_publishable_with_evidence() ->
     assert extraction.metrics["qa_checklist_count"] == 5
     assert extraction.metrics["qa_machine_pass_count"] == 5
     assert extraction.metrics["qa_human_pass_count"] == 5
+    assert extraction.metrics["parity_pass_count"] == 9
+    assert extraction.metrics["parity_skip_count"] == 0


### PR DESCRIPTION
## Summary

- Adds the #12501 cloud/local/hybrid `parity_matrix` contract to the meeting transcription proof benchmark.
- Enforces all nine required lanes, same non-skipped scenario ids and artifact schema, lane metrics, baseline comparisons, explicit skip reasons, and desktop/mobile/cloud evidence platform coverage.
- Updates the registry scorer, fixture, tests, and local docs so direct CLI and orchestrated benchmark paths share the same publishability gate.
- Adds `.github/issue-evidence/12501-parity-matrix-report.md` with the reviewed agent-run evidence and human-blocked evidence list.

## Validation

- `python -m json.tool packages/benchmarks/meeting-transcription-proof/fixtures/mock-meeting-manifest.json >/tmp/mtp-fixture-json-check.json`
- `PYTHONPATH=packages/benchmarks/meeting-transcription-proof python -m py_compile packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/cli.py`
- `PYTHONPATH=packages/benchmarks/meeting-transcription-proof pytest packages/benchmarks/meeting-transcription-proof/tests -q` (`37 passed`)
- `pytest packages/benchmarks/tests/test_registry_scores.py -q` (`12 passed`)
- `PYTHONPATH=packages python -m benchmarks.orchestrator run --benchmarks meeting_transcription_proof --provider eliza --model eliza --extra '{"lane":"mocked_plumbing"}' --force` (succeeded, `score=1.0`)
- `bun install` passed after rebase; artifacts already synced to `2026-06-18.1`.

## Known verify blocker

- `bun run verify` fails outside this PR at `@elizaos/electrobun#lint` because `packages/app-core/platforms/electrobun/src/voice/voice-service.test.ts` needs formatter-only changes around the `ELIZA_VOICE_LIVE_RUNTIME` env object and two `voiceTurnSignal` casts.
- Several workspace lint tasks run with `--write`; their unrelated auto-format churn was restored before pushing.

## Human proof still required

This PR makes the matrix enforceable but does not claim publishable real-product proof. A human still needs live provider/device/network evidence for the nine real lanes, including desktop/mobile/cloud audio-video captures, resource logs, metrics JSON, baseline comparisons, billing/network records, and reviewed artifacts.
