### PR TITLE
fix(#12747): annotate native-bridge justified keeps per J1-J7 (finish the sweep #13275 missed)

### DIFF
--- a/plugins/plugin-native-activity-tracker/src/index.ts
+++ b/plugins/plugin-native-activity-tracker/src/index.ts
@@ -81,6 +81,7 @@ function parseCollectorLine(line: string): ParsedCollectorLine {
   try {
     parsed = JSON.parse(trimmed);
   } catch {
+    // error-policy:J3 malformed collector line; return an explicit "ignored" parse result
     return { kind: "ignored" };
   }
   if (!parsed || typeof parsed !== "object") return { kind: "ignored" };

--- a/plugins/plugin-native-camera/src/web.ts
+++ b/plugins/plugin-native-camera/src/web.ts
@@ -401,6 +401,7 @@ export class CameraWeb extends WebPlugin {
       if (overLimit) {
         autoStopping = true;
         this.stopRecording().catch((err) => {
+          // error-policy:J6 best-effort auto-stop teardown; the rejection is logged here
           console.error("[Camera] Auto-stop recording failed:", err);
         });
       }
@@ -570,6 +571,7 @@ export class CameraWeb extends WebPlugin {
         ],
       });
     } catch (e) {
+      // error-policy:J2 add focus-point context to the applyConstraints failure and rethrow
       throw new Error(
         `Failed to set focus point: ${e instanceof Error ? e.message : "unknown error"}`,
       );
@@ -600,6 +602,7 @@ export class CameraWeb extends WebPlugin {
         ],
       });
     } catch (e) {
+      // error-policy:J2 add exposure-point context to the applyConstraints failure and rethrow
       throw new Error(
         `Failed to set exposure point: ${e instanceof Error ? e.message : "unknown error"}`,
       );
@@ -632,6 +635,7 @@ export class CameraWeb extends WebPlugin {
       });
       cameraStatus = cameraResult.state as "granted" | "denied" | "prompt";
     } catch (err) {
+      // error-policy:J4 Permissions API cannot query camera in this browser; keep the "prompt" default
       console.debug("[Camera] permissions.query('camera') not supported:", err);
     }
 
@@ -641,6 +645,7 @@ export class CameraWeb extends WebPlugin {
       });
       microphoneStatus = micResult.state as "granted" | "denied" | "prompt";
     } catch (err) {
+      // error-policy:J4 Permissions API cannot query microphone in this browser; keep the "prompt" default
       console.debug(
         "[Camera] permissions.query('microphone') not supported:",
         err,
@@ -671,6 +676,7 @@ export class CameraWeb extends WebPlugin {
       cameraStatus = "granted";
       microphoneStatus = "granted";
     } catch {
+      // error-policy:J4 combined camera+mic prompt was denied; retry each capability separately
       try {
         const videoStream = await getMediaDevices().getUserMedia({
           video: true,
@@ -680,6 +686,7 @@ export class CameraWeb extends WebPlugin {
         });
         cameraStatus = "granted";
       } catch {
+        // error-policy:J4 camera permission denied
         cameraStatus = "denied";
       }
 
@@ -692,6 +699,7 @@ export class CameraWeb extends WebPlugin {
         });
         microphoneStatus = "granted";
       } catch {
+        // error-policy:J4 microphone permission denied
         microphoneStatus = "denied";
       }
     }

--- a/plugins/plugin-native-canvas/src/web.ts
+++ b/plugins/plugin-native-canvas/src/web.ts
@@ -881,6 +881,7 @@ export class CanvasWeb extends WebPlugin {
           clearInterval(checkReady);
           this.notifyListeners("webViewReady", { url: options.url, title });
         } catch {
+          // error-policy:J4 cross-origin popup blocks title reads; degrade to a ready event with no title
           // Cross-origin: fire ready without title
           clearInterval(checkReady);
           this.notifyListeners("webViewReady", { url: options.url, title: "" });
@@ -915,6 +916,7 @@ export class CanvasWeb extends WebPlugin {
       try {
         title = iframe.contentDocument?.title || "";
       } catch {
+        // error-policy:J4 cross-origin iframe blocks title reads; degrade to an empty title
         // Cross-origin: title inaccessible
       }
       this.notifyListeners("webViewReady", { url: options.url, title });
@@ -1015,6 +1017,7 @@ export class CanvasWeb extends WebPlugin {
         }
       }
     } catch {
+      // error-policy:J4 cross-origin/serialization blocks capture; degrade to the unavailable frame below
       // Cross-origin or serialization failed — fall through to an unavailable frame.
     }
 

--- a/plugins/plugin-native-desktop/src/web.ts
+++ b/plugins/plugin-native-desktop/src/web.ts
@@ -49,6 +49,7 @@ function assertSafeExternalUrl(url: unknown): string {
   try {
     parsed = new URL(url);
   } catch {
+    // error-policy:J3 untrusted url failed to parse; throw an explicit validation error
     throw new Error("url must be a valid external URL");
   }
   if (!SAFE_EXTERNAL_PROTOCOLS.has(parsed.protocol)) {
@@ -152,6 +153,7 @@ async function queryBrowserPermission(
     const status = mapBrowserPermissionState(result.state);
     return status ? stateFromStatus(id, status) : null;
   } catch {
+    // error-policy:J4 Permissions API cannot query this permission here; return null (unknown state)
     return null;
   }
 }
@@ -173,6 +175,7 @@ async function requestBrowserPermission(
         track.stop();
       }
     } catch {
+      // error-policy:J4 getUserMedia rejection is expected on denial; the real state is re-read below
       // Query below returns denied when the browser recorded a denial.
     }
     const checked = await queryBrowserPermission(id);

--- a/plugins/plugin-native-gateway/src/web.ts
+++ b/plugins/plugin-native-gateway/src/web.ts
@@ -84,6 +84,7 @@ function assertGatewayUrl(url: unknown): string {
   try {
     parsed = new URL(url);
   } catch {
+    // error-policy:J3 untrusted url failed to parse; throw an explicit validation error
     throw new Error("url must be a valid WebSocket URL");
   }
   if (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") {
@@ -329,6 +330,7 @@ export class GatewayWeb extends WebPlugin {
     try {
       parsedValue = JSON.parse(raw) as JsonValue;
     } catch (err) {
+      // error-policy:J3 untrusted gateway frame failed to parse; drop it with an observable warn
       // A frame the gateway sent us failed to parse. Dropping it silently would
       // masquerade a protocol/transport fault as an idle connection, so surface
       // it the same way the sequence-gap and socket-error paths do.

--- a/plugins/plugin-native-macosalarm/src/actions.ts
+++ b/plugins/plugin-native-macosalarm/src/actions.ts
@@ -224,6 +224,7 @@ async function runSet(
       },
     };
   } catch (err) {
+    // error-policy:J1 action boundary translates helper unavailability/failure into a structured ActionResult
     if (err instanceof MacosAlarmHelperUnavailableError) {
       logger.warn(`[ALARM/set] helper unavailable: ${err.reason}`);
       if (callback) {
@@ -292,6 +293,7 @@ async function runCancel(
       data: { actionName: "ALARM", subaction: "cancel", id: cancelled.id },
     };
   } catch (err) {
+    // error-policy:J1 action boundary translates helper unavailability/failure into a structured ActionResult
     if (err instanceof MacosAlarmHelperUnavailableError) {
       logger.warn(`[ALARM/cancel] helper unavailable: ${err.reason}`);
       return {
@@ -346,6 +348,7 @@ async function runList(
       },
     };
   } catch (err) {
+    // error-policy:J1 action boundary translates helper unavailability/failure into a structured ActionResult
     if (err instanceof MacosAlarmHelperUnavailableError) {
       logger.warn(`[ALARM/list] helper unavailable: ${err.reason}`);
       return {

--- a/plugins/plugin-native-mobile-agent-bridge/src/web.ts
+++ b/plugins/plugin-native-mobile-agent-bridge/src/web.ts
@@ -13,6 +13,7 @@ function assertRelayUrl(value: unknown): string {
   try {
     parsed = new URL(value);
   } catch {
+    // error-policy:J3 untrusted relayUrl failed to parse; throw an explicit validation error
     throw new Error("relayUrl must be a valid URL");
   }
   if (

--- a/plugins/plugin-native-network-policy/src/web.ts
+++ b/plugins/plugin-native-network-policy/src/web.ts
@@ -47,6 +47,7 @@ function readNavigatorSaveData(): boolean | null {
     const saveData = nav?.connection?.saveData;
     return typeof saveData === "boolean" ? saveData : null;
   } catch {
+    // error-policy:J4 Network Information API unavailable; return null (unknown), never a fabricated false
     return null;
   }
 }

--- a/plugins/plugin-native-screencapture/src/web.ts
+++ b/plugins/plugin-native-screencapture/src/web.ts
@@ -220,6 +220,7 @@ export class ScreenCaptureWeb extends WebPlugin {
     this.mediaStream.getVideoTracks()[0].addEventListener("ended", () => {
       if (this.isRecording) {
         this.stopRecording().catch((err: unknown) => {
+          // error-policy:J1 surface the auto-stop failure to listeners as a structured error event
           this.notifyListeners("error", {
             code: "AUTO_STOP_FAILED",
             message: `Auto-stop on track end failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -264,6 +265,7 @@ export class ScreenCaptureWeb extends WebPlugin {
       if (overLimit) {
         autoStopping = true;
         this.stopRecording().catch((err: unknown) => {
+          // error-policy:J1 surface the auto-stop failure to listeners as a structured error event
           this.notifyListeners("error", {
             code: "AUTO_STOP_FAILED",
             message: `Auto-stop recording failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -420,6 +422,7 @@ export class ScreenCaptureWeb extends WebPlugin {
       });
       microphone = result.state as "granted" | "denied" | "prompt";
     } catch {
+      // error-policy:J4 Permissions API cannot query microphone here; keep the "prompt" default
       // Permissions API may not support microphone query in this browser
     }
 
@@ -449,6 +452,7 @@ export class ScreenCaptureWeb extends WebPlugin {
       });
       microphone = "granted";
     } catch {
+      // error-policy:J4 microphone permission denied
       microphone = "denied";
     }
 

--- a/plugins/plugin-native-settings/src/components/DeviceSettingsAppView.tsx
+++ b/plugins/plugin-native-settings/src/components/DeviceSettingsAppView.tsx
@@ -99,6 +99,7 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
       setSystemStatus(statusResult);
       setBrightness(clampUnit(settingsResult.brightness));
     } catch (err) {
+      // error-policy:J4 surface the load failure into the view's error state (three-state UI)
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoading(false);
@@ -145,6 +146,7 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
       setBrightness(clampUnit(next.brightness));
       setNotice("Brightness updated.");
     } catch (err) {
+      // error-policy:J4 surface the brightness-save failure into the view's error state
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setSaving(null);
@@ -183,6 +185,7 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
           `${VOLUME_LABELS[volume.stream] ?? volume.stream} volume updated.`,
         );
       } catch (err) {
+        // error-policy:J4 surface the volume-save failure into the view's error state
         setError(err instanceof Error ? err.message : String(err));
       } finally {
         setSaving(null);
@@ -201,6 +204,7 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
       setSystemStatus(next);
       setNotice(`${ROLE_LABELS[role]} role updated.`);
     } catch (err) {
+      // error-policy:J4 surface the role-request failure into the view's error state
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setSaving(null);
@@ -220,6 +224,7 @@ export function DeviceSettingsAppView({ exitToApps, t }: OverlayAppContext) {
         if (action === "sound") await System.openSoundSettings();
         if (action === "network") await System.openNetworkSettings();
       } catch (err) {
+        // error-policy:J4 surface the open-settings failure into the view's error state
         setError(err instanceof Error ? err.message : String(err));
         return;
       }

--- a/plugins/plugin-native-swabble/src/web.ts
+++ b/plugins/plugin-native-swabble/src/web.ts
@@ -366,6 +366,7 @@ export class SwabbleWeb extends WebPlugin {
           return result;
         }
       } catch {
+        // error-policy:J4 native desktop bridge failed; degrade to the Web Speech API path below
         // Fall through to Web Speech API
       }
     }
@@ -576,6 +577,7 @@ export class SwabbleWeb extends WebPlugin {
         microphone = result.state;
       }
     } catch {
+      // error-policy:J4 Permissions API cannot query microphone here; keep the "prompt" default
       /* permissions.query not supported for microphone in some browsers */
     }
     let speechRecognition: SwabblePermissionStatus["speechRecognition"] =
@@ -607,6 +609,7 @@ export class SwabbleWeb extends WebPlugin {
       });
       return this.checkPermissions();
     } catch {
+      // error-policy:J4 mic prompt denied/unavailable; report the denied permission status
       return {
         microphone: "denied",
         speechRecognition: "denied",
@@ -629,6 +632,7 @@ export class SwabbleWeb extends WebPlugin {
         }));
       return { devices: audioInputs };
     } catch {
+      // error-policy:J4 enumerateDevices unavailable; same designed empty-list state as the no-API path
       return { devices: [] };
     }
   }

--- a/plugins/plugin-native-talkmode/src/web.ts
+++ b/plugins/plugin-native-talkmode/src/web.ts
@@ -102,6 +102,7 @@ export class TalkModeWeb extends WebPlugin {
         try {
           this.recognition?.start();
         } catch (err) {
+          // error-policy:J6 best-effort restart of a stopped recognizer; genuine failures are warned
           const msg = err instanceof Error ? err.message : String(err);
           if (!msg.includes("already started")) {
             console.warn("[TalkMode] Failed to restart recognition:", msg);
@@ -114,6 +115,7 @@ export class TalkModeWeb extends WebPlugin {
       this.recognition.start();
       return { started: true };
     } catch (error) {
+      // error-policy:J1 boundary translates a recognizer start failure into a structured { started:false } result
       const message =
         error instanceof Error ? error.message : "Failed to start";
       return { started: false, error: message };
@@ -250,6 +252,7 @@ export class TalkModeWeb extends WebPlugin {
         microphone = result.state;
       }
     } catch {
+      // error-policy:J4 Permissions API cannot query microphone here; keep the "prompt" default
       // Permissions API may not support microphone query
     }
 
@@ -279,6 +282,7 @@ export class TalkModeWeb extends WebPlugin {
         track.stop();
       });
     } catch {
+      // error-policy:J4 mic prompt denied/unavailable; the real state is re-read by checkPermissions below
       // Permission denied or error
     }
 


### PR DESCRIPTION
## Summary

Finishes the **#12747** native-bridge fallback-slop sweep. PR #13275 claimed it complete ("0 empty catches remain in scope") but **never touched `plugin-native-canvas` or `plugin-native-talkmode`** and left un-annotated keeps across camera, screencapture, settings, gateway, activity-tracker, mobile-agent-bridge, network-policy, swabble, desktop, and macosalarm.

Triages the **39 remaining error handlers across 12 files**. Every one is a **justified keep** (no fabrication slop, no lost write/mutation):

| Category | Examples |
|---|---|
| J1 boundary → structured failure / error event | macosalarm actions (→ `ActionResult{success:false}`), screencapture auto-stop (→ error event), talkmode start (→ `{started:false,error}`) |
| J2 context-adding rethrow | camera focus/exposure `applyConstraints` failures |
| J3 untrusted-input sanitizing | URL validation, malformed frame/line drop |
| J4 designed web degrade | cross-origin title/capture inaccessible, Permissions API unsupported, `getUserMedia`-denied → `"denied"`, native API unavailable → view error state |
| J6 best-effort teardown | recognizer restart, recording auto-stop |

## Evidence

- **Comment-only** — `node scripts/assert-comment-only-diff.mjs` → `OK — 12 source file(s) changed; every code token identical to origin/develop. Comments only.` Zero behavior change.
- **Coverage** — re-census of the non-route native scope: **0 un-annotated empty catches remain.**
- **Ratchet** — `error-policy-ratchet` reports no new fallback-slop.
- Real-LLM / UI / device evidence: **N/A — comment-only annotation change, machine-verified.**

Closes #12747