### PR TITLE
test(agent-orchestrator): use vitest mock for available agents provider

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/available-agents.test.ts
@@ -2,18 +2,15 @@
  * Verifies availableAgentsProvider.
  * Deterministic unit test of pure helpers; no runtime, no live model.
  */
-import { mock } from "bun:test";
 import { describe, expect, it, vi } from "vitest";
 
 // Control the framework-state probe so we can drive its failure path
 // deterministically without touching the filesystem / env discovery it does.
 const getTaskAgentFrameworkStateMock = vi.fn();
-mock.module("../../src/services/task-agent-frameworks.js", () => {
-  return {
-    getTaskAgentFrameworkState: (...args: unknown[]) =>
-      getTaskAgentFrameworkStateMock(...args),
-  };
-});
+vi.mock("../../src/services/task-agent-frameworks.js", () => ({
+  getTaskAgentFrameworkState: (...args: unknown[]) =>
+    getTaskAgentFrameworkStateMock(...args),
+}));
 
 import {
   memory,


### PR DESCRIPTION
## Summary

Fixes the `available-agents.test.ts` harness after #13289 introduced `import { mock } from "bun:test"`, which the package's Vitest command cannot resolve.

The test still installs the framework-state mock before dynamically importing `availableAgentsProvider`, but uses `vi.mock(...)` so it runs under the existing Vitest harness.

## Verification

```bash
bun run --cwd plugins/plugin-agent-orchestrator test -- __tests__/unit/available-agents.test.ts
```

Result: 1 test file passed, 5 tests passed.
