### PR TITLE
fix(#12266): deep fallback-slop sweep slice 1/2 — empty-catch/fabricated-default/promise-swallow to fail-fast

### DIFF
--- a/packages/app-core/platforms/electrobun/remotes/local-model/src/bun/model-service.ts
+++ b/packages/app-core/platforms/electrobun/remotes/local-model/src/bun/model-service.ts
@@ -90,6 +90,10 @@ export class ModelRemoteService {
     params: { apiBase?: string } = {},
   ): Promise<LocalModelCatalogEntry[]> {
     const api = this.api(params.apiBase);
+    // error-policy:J4 the catalog aggregates independent sources so the local
+    // model UI still renders when one is unreachable: an offline runtime hub → no
+    // remote entries, an unreadable install dir → no installed rows, an
+    // unknown active status → the built-in eliza-1 catalog still shows.
     const runtime = await api.catalog().catch(() => null);
     const installed = await this.installed(params).catch(() => []);
     const active = await this.active(params).catch(() => ({

--- a/packages/app-core/platforms/electrobun/src/cloud-auth-window.ts
+++ b/packages/app-core/platforms/electrobun/src/cloud-auth-window.ts
@@ -80,7 +80,7 @@ const TRUSTED_ELIZA_WINDOW_PRELOAD = `(() => {
     try {
       window.close = closeSelf;
       globalThis.close = closeSelf;
-    } catch {}
+    } catch { /* error-policy:J6 best-effort window.close override in injected auth-window script; last-resort assignment may be blocked on a locked page */ }
   }
 })();`;
 

--- a/packages/app-core/platforms/electrobun/src/native/agent-state-dir.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/agent-state-dir.test.ts
@@ -1,7 +1,12 @@
-/** Exercises agent state dir behavior with deterministic app-core test fixtures. */
-import { describe, expect, it } from "vitest";
+/** Exercises agent state dir behavior with deterministic app-core test fixtures
+ *  against the real filesystem (temp dirs, real stat errors — no mocks). */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   applyPackagedStartupEmbeddingWarmupPolicy,
+  migrateDesktopStateDirFromPath,
   prependDesktopChildPathDirectory,
   resolveDesktopChildNamespace,
   resolveDesktopChildStateDir,
@@ -23,6 +28,48 @@ describe("desktop agent state dir", () => {
         env: { ELIZA_STATE_DIR: "/tmp/eliza-state" } as NodeJS.ProcessEnv,
       }),
     ).toBe("/tmp/eliza-state");
+  });
+});
+
+describe("migrateDesktopStateDirFromPath — source stat failures", () => {
+  let tmpRoot: string;
+  let targetDir: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-migrate-"));
+    targetDir = path.join(tmpRoot, "target-state");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("reports a genuinely-absent source as a successful skip", () => {
+    const missing = path.join(tmpRoot, "does-not-exist");
+    const result = migrateDesktopStateDirFromPath(missing, {
+      env: { ELIZA_STATE_DIR: targetDir } as NodeJS.ProcessEnv,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.migrated).toBe(false);
+    expect(result.skippedReason).toBe("source-missing");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("surfaces a non-ENOENT stat failure as ok:false, not a fake skip", () => {
+    // A regular file used as a path *component* makes statSync throw ENOTDIR —
+    // a real error that must NOT be fabricated into "source-missing" success.
+    const filePath = path.join(tmpRoot, "not-a-dir");
+    fs.writeFileSync(filePath, "x");
+    const source = path.join(filePath, "child");
+
+    const result = migrateDesktopStateDirFromPath(source, {
+      env: { ELIZA_STATE_DIR: targetDir } as NodeJS.ProcessEnv,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.migrated).toBe(false);
+    expect(result.skippedReason).toBeUndefined();
+    expect(result.error).toBeTruthy();
   });
 });
 

--- a/packages/app-core/platforms/electrobun/src/native/agent.ts
+++ b/packages/app-core/platforms/electrobun/src/native/agent.ts
@@ -497,13 +497,26 @@ export function migrateDesktopStateDirFromPath(
         skippedReason: "source-not-directory",
       };
     }
-  } catch {
+  } catch (err) {
+    // Only a genuinely-absent source is a successful no-op. Any other stat
+    // failure (permissions, ENOTDIR, IO) is a real error and must not be
+    // fabricated into a "source-missing" success — that would silently drop a
+    // migration the user expected to happen.
+    if ((err as NodeJS.ErrnoException | null)?.code === "ENOENT") {
+      return {
+        ok: true,
+        migrated: false,
+        fromPath: source,
+        toPath: target,
+        skippedReason: "source-missing",
+      };
+    }
     return {
-      ok: true,
+      ok: false,
       migrated: false,
       fromPath: source,
       toPath: target,
-      skippedReason: "source-missing",
+      error: err instanceof Error ? err.message : String(err),
     };
   }
 
@@ -1104,6 +1117,7 @@ async function waitForHealthy(
         signal: AbortSignal.timeout(2_000),
       });
       if (response.ok) {
+        // error-policy:J3 health body may be non-JSON mid-boot; null → not-ready
         const health = (await response.json().catch(() => null)) as {
           ready?: boolean;
           agentState?: string;
@@ -1168,6 +1182,7 @@ async function isStartupStatusReachable(
       headers,
       signal: AbortSignal.timeout(2_000),
     });
+    // error-policy:J3 status body may be non-JSON mid-boot; null → inspected below
     const body = await response.json().catch(() => null);
     if (response.ok) return true;
     return isNonFatalStartupStatus(body);
@@ -2461,6 +2476,7 @@ export class AgentManager {
         // Process may have already exited between check and kill
       }
       // Wait briefly for SIGKILL to take effect
+      // error-policy:J6 teardown — we only await that the killed child settles
       await Promise.race([proc.exited.catch(() => {}), Bun.sleep(1_000)]);
     }
 

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -1571,6 +1571,8 @@ X-GNOME-Autostart-enabled=true
       return;
     }
     this.appExitStarted = true;
+    // error-policy:J6 teardown — surfacing the window before shutdown is
+    // best-effort; a failed show must not block the exit sequence.
     await this.showWindow().catch(() => {});
     this.send("desktopShutdownStarted", { reason });
     await new Promise((resolve) => setTimeout(resolve, 150));
@@ -1859,6 +1861,8 @@ X-GNOME-Autostart-enabled=true
   /** Match the Dock icon to full-window presence; only in dockless mode. */
   private syncTrayFirstDock(): void {
     if (!this.trayFirstMode) return;
+    // error-policy:J6 best-effort cosmetic Dock-icon sync; a transient failure
+    // self-corrects on the next window-presence change.
     void this.setDockIconVisibility({
       visible: this.fullWindowKeys.size > 0,
     }).catch(() => {});

--- a/packages/app-core/platforms/electrobun/src/native/gateway.ts
+++ b/packages/app-core/platforms/electrobun/src/native/gateway.ts
@@ -44,7 +44,14 @@ async function loadDiscoveryModule(): Promise<boolean> {
       bonjourModule = (await import(pkg)) as BonjourModuleProvider;
       logger.info(`[Gateway] Loaded ${pkg} module`);
       return true;
-    } catch {}
+    } catch (err) {
+      // Probe each optional mDNS backend in turn. A not-installed module is
+      // expected (we fall through to the next); a module that IS present but
+      // throws on import is a real problem, so keep it out of the silent void.
+      logger.debug(
+        `[Gateway] mDNS module "${pkg}" unavailable: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   logger.warn(

--- a/packages/app-core/scripts/check-real-local-provisioning.ts
+++ b/packages/app-core/scripts/check-real-local-provisioning.ts
@@ -79,6 +79,8 @@ async function main(): Promise<void> {
     assert.equal(after.complete, true, "first-run must report complete");
     console.log("[local-prov] PASS provisioning: first-run completed");
   } finally {
+    // error-policy:J6 best-effort teardown of the harness fixtures; a cleanup
+    // failure must not mask the assertion outcome that preceded it.
     await server.close().catch(() => undefined);
     await runtimeResult.cleanup().catch(() => undefined);
     await configEnv.restore().catch(() => undefined);

--- a/packages/app-core/src/api/auth/embed-session-token.ts
+++ b/packages/app-core/src/api/auth/embed-session-token.ts
@@ -167,6 +167,8 @@ export function verifyEmbedSessionToken(
       Buffer.from(payload, "base64url").toString("utf8"),
     ) as EmbedSessionClaims;
   } catch {
+    // error-policy:J3 untrusted token payload — a malformed base64/JSON segment
+    // yields a null (invalid token) result, never fabricated claims.
     return null;
   }
   if (

--- a/packages/app-core/src/api/cloud-pair-route.ts
+++ b/packages/app-core/src/api/cloud-pair-route.ts
@@ -263,6 +263,8 @@ export async function handleCloudPairRoute(
     clearTimeout(timeoutId);
     status = resp.status;
     if (resp.ok) {
+      // error-policy:J3 a 2xx with a non-JSON body → null, surfaced as a failed
+      // exchange by the null-check that follows.
       exchanged = (await resp.json().catch(() => null)) as PairResponse | null;
     } else {
       logger.warn(

--- a/packages/app-core/src/api/secrets-inventory-routes.ts
+++ b/packages/app-core/src/api/secrets-inventory-routes.ts
@@ -579,6 +579,8 @@ async function readJsonBody(
   try {
     return JSON.parse(body);
   } catch {
+    // error-policy:J3 untrusted request body — malformed JSON is an explicit
+    // null "invalid" signal the caller rejects, not a fabricated value.
     return null;
   }
 }

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -1136,6 +1136,8 @@ export function patchHttpCreateServerForCompat(): () => void {
           const u = new URL(ref);
           return isAllowedOrigin(ref, corsAllowedPorts) ? u.origin : null;
         } catch {
+          // error-policy:J3 untrusted Referer header — an unparseable URL is
+          // treated as "no allowed origin" (request is denied below).
           return null;
         }
       })();

--- a/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
+++ b/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
@@ -276,6 +276,9 @@ export function DesktopTrayRuntime() {
         }
       };
 
+      // error-policy:J6 best-effort UI dispatch from a DOM event handler; a
+      // failed tray action leaves the window in its current (visible) state,
+      // which the user sees and can retry — nothing to unwind here.
       void run().catch(() => {});
     };
 

--- a/packages/app-core/src/services/coding-account-bridge.ts
+++ b/packages/app-core/src/services/coding-account-bridge.ts
@@ -136,6 +136,8 @@ function jwtExpiryMs(accessToken: string): number | null {
       ? payload.exp * 1000
       : null;
   } catch {
+    // error-policy:J3 untrusted JWT payload — an undecodable segment yields a
+    // null expiry (caller treats as "unknown/expired"), not a fake timestamp.
     return null;
   }
 }
@@ -178,6 +180,8 @@ export async function adoptRotatedCodexTokens(
         readFileSync(authPath, "utf-8"),
       ) as MaterializedCodexAuthJson;
     } catch {
+      // error-policy:J3 externally-maintained auth.json — an unreadable/malformed
+      // file means "no usable credential", handled as a false refresh result.
       return false;
     }
     const tokens = parsed?.tokens;

--- a/packages/app-core/src/services/phrase-chunked-tts.ts
+++ b/packages/app-core/src/services/phrase-chunked-tts.ts
@@ -199,8 +199,8 @@ export class PhraseChunkedTts {
     }
     const tail = this.chunker.flushPending();
     if (tail) this.dispatchPhrase(tail);
-    // Settle every TTS call; rethrow the first error if any (unless caller
-    // chose to swallow).
+    // error-policy:J5 the per-call rejection is observed via `firstError`,
+    // rethrown below; this only settles all in-flight calls before checking.
     await Promise.all(this.inflight.map((p) => p.catch(() => undefined)));
     if (this.firstError !== null) throw this.firstError;
   }

--- a/packages/app-core/src/services/update-notifier.ts
+++ b/packages/app-core/src/services/update-notifier.ts
@@ -37,5 +37,7 @@ export function scheduleUpdateNotification(): void {
           `${theme.muted("Run")} ${theme.command("eliza update")} ${theme.muted("to install")}\n\n`,
       );
     })
+    // error-policy:J6 fire-and-forget update check; a network/registry failure
+    // must never disrupt CLI startup and there is nothing to notify about.
     .catch(() => {});
 }

--- a/packages/shared/src/checkout/index.ts
+++ b/packages/shared/src/checkout/index.ts
@@ -70,6 +70,8 @@ export async function createStripeCheckoutSession(
     body: JSON.stringify(request),
   });
 
+  // error-policy:J3 a non-JSON checkout body → null; the failure is surfaced by
+  // the throw below when `response.ok` is false or `body.url` is absent.
   const body = (await response
     .json()
     .catch(() => null)) as StripeCheckoutResponse | null;

--- a/packages/shared/src/utils/browser-tabs-renderer-registry.ts
+++ b/packages/shared/src/utils/browser-tabs-renderer-registry.ts
@@ -325,7 +325,7 @@ export const BROWSER_TAB_PRELOAD_SCRIPT = `
         fireMouseEvent(target, "mousedown", x, y, button, 1);
         // Most form controls expect focus between mousedown and click.
         if (typeof target.focus === "function") {
-          try { target.focus({ preventScroll: true }); } catch (_e) { try { target.focus(); } catch (_e2) {} }
+          try { target.focus({ preventScroll: true }); } catch (_e) { try { target.focus(); } catch (_e2) { /* error-policy:J6 best-effort DOM emulation on foreign page */ } }
         }
         firePointerEvent(target, "pointerup", x, y, button, 0);
         fireMouseEvent(target, "mouseup", x, y, button, 0);
@@ -375,13 +375,13 @@ export const BROWSER_TAB_PRELOAD_SCRIPT = `
       if (!target) return Promise.resolve();
       const opts = options || {};
       const delay = Math.max(0, Math.min(200, typeof opts.perCharDelayMs === "number" ? opts.perCharDelayMs : 18));
-      try { target.focus({ preventScroll: true }); } catch (_e) { try { target.focus(); } catch (_e2) {} }
+      try { target.focus({ preventScroll: true }); } catch (_e) { try { target.focus(); } catch (_e2) { /* error-policy:J6 best-effort DOM emulation on foreign page */ } }
       if (opts.replace) {
         try {
           if (typeof target.setSelectionRange === "function") {
             target.setSelectionRange(0, (target.value || "").length);
           }
-        } catch (_e) {}
+        } catch (_e) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
         setNativeValue(target, "");
         target.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
       }
@@ -396,7 +396,7 @@ export const BROWSER_TAB_PRELOAD_SCRIPT = `
         fireKey(target, "keydown", ch);
         try {
           target.dispatchEvent(new InputEvent("beforeinput", { bubbles: true, cancelable: true, composed: true, data: ch, inputType: "insertText" }));
-        } catch (_e) {}
+        } catch (_e) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
         const next = (target.value || "") + ch;
         setNativeValue(target, next);
         try {
@@ -440,7 +440,7 @@ export const BROWSER_TAB_PRELOAD_SCRIPT = `
       const dt = new DataTransfer();
       dt.items.add(file);
       target.files = dt.files;
-      try { target.focus({ preventScroll: true }); } catch (_e) {}
+      try { target.focus({ preventScroll: true }); } catch (_e) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
       target.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
       target.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
       return { name: file.name, size: file.size, type: file.type };
@@ -626,7 +626,7 @@ export const BROWSER_TAB_PRELOAD_SCRIPT = `
             evmChainId = next;
             ethereum.chainId = formatChainId(evmChainId);
             for (const listener of Array.from(eventListeners.chainChanged)) {
-              try { listener(ethereum.chainId); } catch (_e) {}
+              try { listener(ethereum.chainId); } catch (_e) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
             }
             return result;
           });
@@ -635,11 +635,11 @@ export const BROWSER_TAB_PRELOAD_SCRIPT = `
           return callHost("evm", method, params).then((accounts) => {
             ethereum.selectedAddress = Array.isArray(accounts) ? (accounts[0] || null) : null;
             for (const listener of Array.from(eventListeners.accountsChanged)) {
-              try { listener(accounts); } catch (_e) {}
+              try { listener(accounts); } catch (_e) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
             }
             if (ethereum.selectedAddress) {
               for (const listener of Array.from(eventListeners.connect)) {
-                try { listener({ chainId: ethereum.chainId }); } catch (_e) {}
+                try { listener({ chainId: ethereum.chainId }); } catch (_e) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
               }
             }
             return accounts;
@@ -690,7 +690,7 @@ export const BROWSER_TAB_PRELOAD_SCRIPT = `
       const set = eventListeners[event];
       if (!set) return;
       for (const listener of Array.from(set)) {
-        try { listener(payload); } catch (_e) {}
+        try { listener(payload); } catch (_e) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
       }
     };
 
@@ -703,7 +703,7 @@ export const BROWSER_TAB_PRELOAD_SCRIPT = `
     } catch (_err) {
       // Some pages freeze window.ethereum after their wallet detected it;
       // fall back to direct assignment when defineProperty is blocked.
-      try { window.ethereum = ethereum; } catch (_e) {}
+      try { window.ethereum = ethereum; } catch (_e) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
     }
 
     // ── Solana (Phantom-shaped + Wallet Standard) ──
@@ -806,7 +806,7 @@ export const BROWSER_TAB_PRELOAD_SCRIPT = `
           this.publicKey = makePublicKey(result.publicKey);
           this.isConnected = true;
           for (const listener of Array.from(solanaListeners.connect)) {
-            try { listener(this.publicKey); } catch (_e) {}
+            try { listener(this.publicKey); } catch (_e) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
           }
         }
         return { publicKey: this.publicKey };
@@ -815,7 +815,7 @@ export const BROWSER_TAB_PRELOAD_SCRIPT = `
         this.publicKey = null;
         this.isConnected = false;
         for (const listener of Array.from(solanaListeners.disconnect)) {
-          try { listener(); } catch (_e) {}
+          try { listener(); } catch (_e) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
         }
       },
       signMessage: async function (message, _encoding) {
@@ -898,12 +898,12 @@ export const BROWSER_TAB_PRELOAD_SCRIPT = `
         if (ctor && typeof ctor.deserialize === "function") {
           return ctor.deserialize(bytes);
         }
-      } catch (_err) {}
+      } catch (_err) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
       try {
         if (ctor && typeof ctor.from === "function") {
           return ctor.from(bytes);
         }
-      } catch (_err) {}
+      } catch (_err) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
       return {
         serialize: () => bytes,
         __signedBytes: bytes,
@@ -1025,18 +1025,18 @@ export const BROWSER_TAB_PRELOAD_SCRIPT = `
       const register = (api) => {
         try {
           api.register(wallet);
-        } catch (_err) {}
+        } catch (_err) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
       };
       const fireRegister = () => {
         try {
           window.dispatchEvent(new CustomEvent("wallet-standard:register-wallet", { detail: register }));
-        } catch (_err) {}
+        } catch (_err) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
       };
       try {
         window.addEventListener("wallet-standard:app-ready", (event) => {
           if (event && event.detail) register(event.detail);
         });
-      } catch (_err) {}
+      } catch (_err) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
       fireRegister();
       if (document.readyState === "loading") {
         document.addEventListener("DOMContentLoaded", fireRegister, { once: true });
@@ -1053,13 +1053,13 @@ export const BROWSER_TAB_PRELOAD_SCRIPT = `
         configurable: true,
       });
     } catch (_err) {
-      try { window.solana = solana; } catch (_e) {}
+      try { window.solana = solana; } catch (_e) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
     }
     try {
       const phantomNs = window.phantom || {};
       phantomNs.solana = solana;
       window.phantom = phantomNs;
-    } catch (_err) {}
+    } catch (_err) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
 
     // Announce the provider per EIP-6963 (https://eips.ethereum.org/EIPS/eip-6963).
     // Keys:
@@ -1079,7 +1079,7 @@ export const BROWSER_TAB_PRELOAD_SCRIPT = `
           provider: ethereum,
         });
         window.dispatchEvent(new CustomEvent("eip6963:announceProvider", { detail: detail }));
-      } catch (_err) {}
+      } catch (_err) { /* error-policy:J6 best-effort DOM/wallet emulation on foreign page */ }
     };
     window.addEventListener("eip6963:requestProvider", announceEthereum);
     setTimeout(announceEthereum, 0);


### PR DESCRIPTION
## Deep fallback-slop sweep — slice 1/2 (#12266, parent #12182)

Uses the #12263 foundation (`ElizaError`, `runtime.reportError`, the J1–J7 rubric, diff-scoped `audit:error-policy-ratchet`). This is **slice 1 of 2** of the app-core + shared + logger + prompts batch: I re-derived the suspect-file union (empty catch ∪ promise-swallow ∪ return-default) over the slice root and handled the odd-indexed half; the parallel slice handles the rest.

### Per-category tally (this slice)

| category | converted | annotated (J-kept) | deferred |
|---|---|---|---|
| empty catch | 1 (gateway observability) | 21 (J6: 20 browser-tabs foreign-page emulation + 1 injected auth-window) | — |
| fabricated-healthy-on-error | 1 (agent state-dir migration) | — | — |
| promise-swallow | 0 | 11 (J3 parse ×5, J4 catalog degrade ×1, J5 settle ×1, J6 teardown/UI ×4) | 4 (auth null-fallthrough) |
| return null/false/[] catches | — | — | 58 (per-site judgment, next pass) |

### Behavior change (tested)

**`migrateDesktopStateDirFromPath`** (`platforms/electrobun/src/native/agent.ts`) caught **any** source `statSync` failure and fabricated a `{ ok: true, skippedReason: "source-missing" }` success. A permission / `ENOTDIR` / IO error therefore silently dropped a migration the user expected. Now only `ENOENT` is a successful skip; every other error returns `{ ok: false, error }`. Real-fs regression test added (a regular file used as a path component → `ENOTDIR`) in `agent-state-dir.test.ts` — the `ok:false` assertion fails on the old code.

### Observability

`gateway.ts` optional mDNS-module probe: empty `catch {}` → `logger.debug(err)` so a module that is present but throws on import is no longer swallowed while the loop falls through to the next optional dep.

### Annotations (no behavior change — document J-category handlers, drop the ratchet count)

- **J3** untrusted-input parse → explicit invalid signal: `checkout`, `cloud-pair-route`, `secrets-inventory-routes` (body), `server.ts` (Referer URL), `coding-account-bridge` (jwt + `auth.json`), `embed-session-token`, electrobun agent health/status bodies.
- **J4** designed aggregation degrade: local-model catalog merge (offline hub → built-in eliza-1 catalog still renders).
- **J5** rejection observed elsewhere: `phrase-chunked-tts` (settled, rethrown via `firstError`).
- **J6** best-effort teardown / foreign-page DOM emulation / UI dispatch: `desktop` showWindow-on-exit + Dock sync, agent child-kill race, `check-real-local-provisioning` teardown, `DesktopTrayRuntime` dispatch, `update-notifier`, `cloud-auth-window` injected script, `browser-tabs-renderer-registry` (20 wallet/DOM emulation catches on foreign pages — the outer `typeRealistic`/`setFileInput` wrappers still reject on total failure, verified).

### Deferred (per-site judgment, next pass — no over-removal)

`return null/false/[]` absence catches (58 sites — probe/parse/not-found semantics) and the `auth-context`/`auth-session` `.catch(() => null)` session-lookup null-fallthroughs (security-sensitive; `null == unauthenticated` is intentional design). These need the ambiguous-site judgment pass, not the clear-slop pass.

### Ratchet (diff-scoped, authoritative)

`bun run audit:error-policy-ratchet` → **no new fallback-slop in touched files**; touched-file empty-catch total **17 → 16** (gateway `1 → 0`; all other files equal, never up). Zero server-side `console.*` added.

### Tests

- `packages/shared` — **1192 passed**.
- electrobun suite — **486 passed** (incl. the new migration test).
- Touched app-core/src/scripts edits are **comment-only** (no code-token change). The app-core main-suite reds (`background-tasks-routes`, `automations-compat-routes`, `run-node-supervisor`) are **pre-existing** load-timeout / real-process / live flakes in files this branch does not touch — `background-tasks-routes` passes in isolation (10s vs 240s under load); the other two fail identically on develop.
- shared + electrobun typecheck clean for touched files; the 23 app-core `tsgo` errors are pre-existing missing-optional-dep (`@elizaos/capacitor-bun-runtime`, `@elizaos/plugin-meetings`) errors, none in touched files.

Biome per-batch override left in place (slice 2 + out-of-suspect empty catches in `agent`/`desktop`/`server` still rely on it until the batch is complete).

Refs #12266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
