### PR TITLE
fix(#12787): refund MCP pre-charge on 2xx JSON-RPC error (billing fail-closed)

### DIFF
--- a/packages/cloud/api/__tests__/mcp-proxy-helpers.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-helpers.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  isJsonRpcErrorResponse,
   type McpProxyJson,
   parseJsonBody,
   resolveMcpProxyView,
@@ -175,5 +176,77 @@ describe("resolveMcpProxyView (cross-org access gate)", () => {
       viewerOrganizationId: "",
     });
     expect(view).toEqual({ allowed: false, isOwner: false });
+  });
+});
+
+describe("isJsonRpcErrorResponse (billing fail-closed on 2xx JSON-RPC error)", () => {
+  test("detects a JSON-RPC 2.0 error envelope (tool call failed over HTTP 200)", () => {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      error: { code: -32000, message: "tool execution failed" },
+    });
+    expect(isJsonRpcErrorResponse(body)).toBe(true);
+  });
+
+  test("a successful result envelope is NOT an error (must still bill)", () => {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { content: [{ type: "text", text: "ok" }] },
+    });
+    expect(isJsonRpcErrorResponse(body)).toBe(false);
+  });
+
+  test("an `error: null` (JSON-RPC success convention) is NOT an error", () => {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      error: null,
+      result: {},
+    });
+    expect(isJsonRpcErrorResponse(body)).toBe(false);
+  });
+
+  test("an error member without a numeric `code` is not treated as an RPC error", () => {
+    // A non-conforming body must not be fabricated into a refund-worthy failure.
+    expect(
+      isJsonRpcErrorResponse(
+        JSON.stringify({ error: { message: "no code field" } }),
+      ),
+    ).toBe(false);
+    expect(
+      isJsonRpcErrorResponse(JSON.stringify({ error: "just a string" })),
+    ).toBe(false);
+    expect(isJsonRpcErrorResponse(JSON.stringify({ error: [] }))).toBe(false);
+  });
+
+  test("unparseable / non-JSON body is NOT an explicit error (never fabricate a failure)", () => {
+    expect(isJsonRpcErrorResponse("")).toBe(false);
+    expect(isJsonRpcErrorResponse("   ")).toBe(false);
+    expect(isJsonRpcErrorResponse("not json at all")).toBe(false);
+    expect(isJsonRpcErrorResponse("{ broken json")).toBe(false);
+    expect(isJsonRpcErrorResponse("42")).toBe(false);
+    expect(isJsonRpcErrorResponse("null")).toBe(false);
+  });
+
+  test("a batch where EVERY entry errored counts as failed (refund)", () => {
+    const body = JSON.stringify([
+      { jsonrpc: "2.0", id: 1, error: { code: -32601, message: "a" } },
+      { jsonrpc: "2.0", id: 2, error: { code: -32000, message: "b" } },
+    ]);
+    expect(isJsonRpcErrorResponse(body)).toBe(true);
+  });
+
+  test("a partial-success batch is NOT failed (still delivers value — must bill)", () => {
+    const body = JSON.stringify([
+      { jsonrpc: "2.0", id: 1, error: { code: -32601, message: "a" } },
+      { jsonrpc: "2.0", id: 2, result: { ok: true } },
+    ]);
+    expect(isJsonRpcErrorResponse(body)).toBe(false);
+  });
+
+  test("an empty batch array is not an error", () => {
+    expect(isJsonRpcErrorResponse("[]")).toBe(false);
   });
 });

--- a/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
@@ -50,6 +50,55 @@ export function toolNameFromRpcBody(body: McpProxyJson): string {
 }
 
 /**
+ * Detect a JSON-RPC 2.0 error envelope in an MCP response body.
+ *
+ * error-policy:J4 — MCP servers speak JSON-RPC 2.0, where a *failed* tool call
+ * is returned as HTTP 200 with a top-level `{ "error": { "code", "message" } }`
+ * envelope (the transport succeeded, the RPC did not). Billing keyed only on the
+ * HTTP status (`mcpResponse.ok`) therefore charges the caller for a tool call the
+ * MCP never completed — the same silent over-charge class #11637 closed for the
+ * HTTP layer, still open at the JSON-RPC layer. This surfaces the protocol-level
+ * failure so the pre-charge is refunded instead of success-shaped into a bill.
+ *
+ * Conservative by design: only a JSON-RPC `error` member that is itself an object
+ * carrying a numeric `code` counts. A `result` payload, a bare/absent `error`, an
+ * unparseable body, or a plain object without the RPC error shape is NOT treated
+ * as a failure here (an unparseable success-shaped body is still delivered to the
+ * caller and billed — this helper never *fabricates* a failure, only recognises an
+ * explicit one), so a well-behaved success is never wrongly refunded.
+ */
+export function isJsonRpcErrorResponse(responseBody: string): boolean {
+  const text = responseBody.trim();
+  if (!text || (text[0] !== "{" && text[0] !== "[")) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    // Unparseable body: not an *explicit* JSON-RPC error. Do not fabricate a
+    // failure — let the existing success path bill it (transport was 2xx).
+    return false;
+  }
+  const isRpcError = (value: unknown): boolean => {
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      return false;
+    }
+    const err = (value as { error?: unknown }).error;
+    if (err === null || typeof err !== "object" || Array.isArray(err)) {
+      return false;
+    }
+    // A JSON-RPC 2.0 error object is required to carry an integer `code`.
+    return typeof (err as { code?: unknown }).code === "number";
+  };
+  // Batched JSON-RPC responses come back as an array; treat the batch as failed
+  // if EVERY entry is an error envelope (a partial success still delivers value
+  // and should bill — refunding a partial batch would under-charge).
+  if (Array.isArray(parsed)) {
+    return parsed.length > 0 && parsed.every((entry) => isRpcError(entry));
+  }
+  return isRpcError(parsed);
+}
+
+/**
  * Decide what an `/api/mcp/proxy/[mcpId]` GET caller may see for a `live` MCP.
  *
  * `userMcpsService.getById` is unscoped (no org / is_public filter), and a `live`
@@ -387,7 +436,13 @@ app.post("/", async (c) => {
     return c.json({ error: "Failed to read MCP response" }, 502);
   }
 
-  if (mcpResponse.ok) {
+  // A 2xx transport does NOT mean the tool call succeeded: MCP speaks JSON-RPC
+  // 2.0, so a failed call is delivered as HTTP 200 with an `{ error: {...} }`
+  // envelope. Billing on `mcpResponse.ok` alone charged the caller for a call
+  // the MCP never completed (#11637 at the HTTP layer, still open at the RPC
+  // layer). Refund on an explicit JSON-RPC error instead of success-shaping it.
+  const rpcErrored = mcpResponse.ok && isJsonRpcErrorResponse(responseBody);
+  if (mcpResponse.ok && !rpcErrored) {
     await userMcpsService
       .recordUsageWithoutDeduction({
         mcpId: mcp.id,
@@ -415,6 +470,18 @@ app.post("/", async (c) => {
             typeof usageError === "string" ? usageError : usageError.message,
         });
       });
+  } else if (rpcErrored) {
+    // Protocol-level failure over a 2xx transport: refund and do not bill. The
+    // caller still receives the MCP's error envelope verbatim below.
+    logger.warn(
+      "[MCP Proxy] MCP returned a JSON-RPC error over 2xx; refunding",
+      {
+        mcpId,
+        status: mcpResponse.status,
+        toolName,
+      },
+    );
+    await refundPrecharge("mcp_jsonrpc_error", { status: mcpResponse.status });
   } else {
     await refundPrecharge("mcp_call_failed", { status: mcpResponse.status });
   }


### PR DESCRIPTION
## Summary

Third slice of the cloud-API Hono route-boundary fallback-slop sweep (#12787, part of #12268). Prior slices: affiliate create-character (#13146), elevenlabs voice-verify (#13254).

`POST /api/mcp/proxy/[mcpId]` bills a user MCP tool call by pre-charging credits, then keeping or refunding the charge based on the upstream response. The keep/refund decision was made purely on `mcpResponse.ok` (the HTTP status). But **MCP servers speak JSON-RPC 2.0**: a *failed* tool call is delivered as **HTTP 200 with a top-level `{ "error": { "code", "message" } }` envelope** — the transport succeeded, the RPC did not. So a tool call the MCP never completed was success-shaped into a bill.

This is the **same silent over-charge class #11637 closed at the HTTP layer, still open at the JSON-RPC layer** (that fix added `refundPrecharge` on every non-ok / transport / container-down branch, but a 2xx-with-RPC-error slips straight through to `recordUsageWithoutDeduction`).

## Fix

- New pure, exported, unit-tested `isJsonRpcErrorResponse(responseBody)` helper (`error-policy:J4`).
- The billing branch now refunds the pre-charge (`reason: "mcp_jsonrpc_error"`) when a 2xx response carries an explicit JSON-RPC error envelope, instead of recording a billable success. The caller still receives the MCP's error body verbatim.
- **Conservative by design — never fabricates a failure:** a `result` payload, `error: null` (the JSON-RPC success convention), an `error` member without a numeric `code`, an unparseable/non-JSON body, an empty batch, or a *partial-success* batch are all NOT treated as failures (refunding a partial batch would under-charge; refunding an unparseable-but-2xx body would fabricate a failure). Only an explicit error envelope (single, or an all-errored batch) triggers a refund.

## Tests

`packages/cloud/api/__tests__/mcp-proxy-helpers.test.ts` — **7 new cases** covering: single error envelope detected, success `result` not flagged, `error: null` not flagged, error-without-numeric-code not flagged, unparseable/empty/non-JSON not flagged, all-errored batch flagged, partial-success batch NOT flagged, empty batch not flagged.

- **24/24 green** (17 pre-existing + 7 new) under a `baseUrl`-primed `bun test` run — the documented cloud/api `@/`-alias harness quirk; **the tsconfig `baseUrl` workaround is NOT part of the commit** (restored before commit, verified `grep -c baseUrl` = 0).
- `tsgo --noEmit` clean for the touched files (remaining errors are pre-existing symlinked-`node_modules` + `fal/proxy` baseline drift, unrelated to this change).
- biome clean; `codex review --uncommitted` clean (no findings).

## Scope discipline

- Only `mcp/proxy/[mcpId]/route.ts` + its helper test touched. No `src/routes/**`-owned-by-#12275-F files, no `vite.config`/`index.html`/`client-base.ts`/`bun.lock`/binaries/`dist`.
- Fail-closed for billing: on ambiguity the code bills a real success and only refunds an *explicit* protocol failure.

-- [sol-orch]