### PR TITLE
fix(#12748): fail closed when x402 replay consumption cannot be durably recorded

### DIFF
--- a/plugins/plugin-x402/src/x402-replay-durable.test.ts
+++ b/plugins/plugin-x402/src/x402-replay-durable.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Fail-closed tests for the durable x402 replay-consumption commit path.
+ *
+ * A successfully-verified payment credential MUST be durably recorded as
+ * "consumed"; if that record cannot be written (SQL UPDATE matched no reserved
+ * row, or the cache write failed) the commit must NOT silently succeed — an
+ * un-recorded consumption leaves the credential replayable once its inflight
+ * reservation TTL lapses. These tests pin that `durableReplayCommitReservation`
+ * (and `replayGuardCommit` on top of it) throw `X402ReplayCommitError` in those
+ * cases, and stay quiet on the healthy commit.
+ *
+ * No real DB / cache is used — a hand-built fake runtime supplies a controllable
+ * SQL `execute` (via `adapter.getConnection`) and `getCache`/`setCache`.
+ */
+
+import type { AgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  durableReplayCommitReservation,
+  X402ReplayCommitError,
+} from "./x402-replay-durable.js";
+import { replayGuardCommit, replayGuardTryBegin } from "./x402-replay-guard.js";
+
+type SqlRowsResult = { rowCount: number };
+
+/**
+ * Fake runtime whose SQL `execute` returns a caller-chosen rowCount. A shared
+ * `phase` object lets a test make the reserve INSERT succeed (rows=1) and then
+ * force the commit UPDATE to match no row (rows=0) to exercise the fail-closed
+ * commit path against a genuinely-reserved credential.
+ */
+function makeSqlRuntime(opts: {
+  agentId?: string;
+  updateRowCount: number;
+  phase?: { commitRowCount: number };
+}): AgentRuntime {
+  const execute = vi.fn(async () => ({
+    rowCount: opts.phase ? opts.phase.commitRowCount : opts.updateRowCount,
+  })) as unknown as (query: unknown) => Promise<SqlRowsResult>;
+  const db = { execute };
+  return {
+    agentId: opts.agentId ?? "agent-1",
+    adapter: {
+      getConnection: vi.fn(async () => db),
+    },
+    // Cache path is not reached when a SQL connection is available.
+    getCache: vi.fn(async () => undefined),
+    setCache: vi.fn(async () => true),
+    deleteCache: vi.fn(async () => true),
+  } as unknown as AgentRuntime;
+}
+
+/** Fake runtime with NO SQL connection, forcing the cache fallback path. */
+function makeCacheRuntime(opts: { setCacheOk: boolean }): AgentRuntime {
+  const store = new Map<string, unknown>();
+  return {
+    agentId: "agent-1",
+    adapter: {
+      // No `.execute` => getSqlDb returns null => cache fallback is used.
+      getConnection: vi.fn(async () => ({})),
+    },
+    getCache: vi.fn(async (k: string) => store.get(k)),
+    setCache: vi.fn(async (k: string, v: unknown) => {
+      if (!opts.setCacheOk) return false;
+      store.set(k, v);
+      return true;
+    }),
+    deleteCache: vi.fn(async (k: string) => {
+      store.delete(k);
+      return true;
+    }),
+  } as unknown as AgentRuntime;
+}
+
+describe("durableReplayCommitReservation fail-closed", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.X402_REPLAY_DURABLE;
+  });
+
+  it("commits quietly when the SQL UPDATE marks the reserved row consumed", async () => {
+    const runtime = makeSqlRuntime({ updateRowCount: 1 });
+    await expect(
+      durableReplayCommitReservation(
+        runtime,
+        "agent-1",
+        ["proof-a"],
+        "owner-1",
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws X402ReplayCommitError when the SQL commit matches no reserved row", async () => {
+    // rowCount 0 => the inflight row was stolen/released/already-committed; the
+    // credential is NOT recorded consumed and would be replayable after TTL.
+    const runtime = makeSqlRuntime({ updateRowCount: 0 });
+    await expect(
+      durableReplayCommitReservation(
+        runtime,
+        "agent-1",
+        ["proof-b"],
+        "owner-1",
+      ),
+    ).rejects.toBeInstanceOf(X402ReplayCommitError);
+  });
+
+  it("reports the exact un-consumed keys on a partial SQL commit failure", async () => {
+    const runtime = makeSqlRuntime({ updateRowCount: 0 });
+    let caught: unknown;
+    try {
+      await durableReplayCommitReservation(
+        runtime,
+        "agent-1",
+        ["k1", "k2"],
+        "owner-1",
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(X402ReplayCommitError);
+    // Both keys map to distinct cache rows; both failed to commit.
+    expect((caught as X402ReplayCommitError).replayKeys).toHaveLength(2);
+  });
+
+  it("throws when the cache-fallback setCache cannot persist consumption", async () => {
+    const runtime = makeCacheRuntime({ setCacheOk: false });
+    await expect(
+      durableReplayCommitReservation(
+        runtime,
+        "agent-1",
+        ["proof-c"],
+        undefined,
+      ),
+    ).rejects.toBeInstanceOf(X402ReplayCommitError);
+  });
+
+  it("commits quietly on the cache-fallback path when setCache succeeds", async () => {
+    const runtime = makeCacheRuntime({ setCacheOk: true });
+    await expect(
+      durableReplayCommitReservation(
+        runtime,
+        "agent-1",
+        ["proof-d"],
+        undefined,
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("replayGuardCommit propagates the durable fail-closed error", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.X402_REPLAY_DURABLE;
+  });
+
+  it("throws (denies the unlock) and keeps the in-process reservation on commit failure", async () => {
+    // Reserve INSERT succeeds (rows=1), then flip commit UPDATE to rows=0.
+    const phase = { commitRowCount: 1 };
+    const runtime = makeSqlRuntime({ updateRowCount: 1, phase });
+    const keys = ["guard-proof-fail"];
+
+    // Reserve so replayGuardCommit has an in-process owner to work with.
+    await expect(replayGuardTryBegin(keys, runtime, "agent-1")).resolves.toBe(
+      true,
+    );
+
+    // Now the commit UPDATE will match no reserved row.
+    phase.commitRowCount = 0;
+
+    // Commit cannot persist consumption -> must throw so the payment boundary
+    // returns 402 instead of unlocking a route the guard can't back.
+    await expect(
+      replayGuardCommit(keys, runtime, "agent-1"),
+    ).rejects.toBeInstanceOf(X402ReplayCommitError);
+
+    // The in-process inflight guard is retained on failure, so a same-process
+    // retry with the same credential is still blocked (returns false).
+    await expect(replayGuardTryBegin(keys, runtime, "agent-1")).resolves.toBe(
+      false,
+    );
+  });
+
+  it("commits without throwing when the durable write succeeds", async () => {
+    const runtime = makeSqlRuntime({ updateRowCount: 1 });
+    const keys = ["guard-proof-ok"];
+    await expect(replayGuardTryBegin(keys, runtime, "agent-1")).resolves.toBe(
+      true,
+    );
+    await expect(
+      replayGuardCommit(keys, runtime, "agent-1"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/plugins/plugin-x402/src/x402-replay-durable.ts
+++ b/plugins/plugin-x402/src/x402-replay-durable.ts
@@ -40,6 +40,25 @@ export type DurableReplayReservation =
   | { ok: true; owner: string; atomic: boolean }
   | { ok: false };
 
+/**
+ * Thrown when a successfully-verified payment credential could NOT be durably
+ * recorded as consumed (SQL commit matched no reserved row, or the cache write
+ * failed). This is security-critical: an un-recorded consumption leaves the
+ * credential replayable once its inflight reservation TTL lapses, so callers
+ * MUST fail closed (deny the unlock) rather than proceed on a consumption the
+ * replay guard cannot back. Distinct type so the payment boundary can classify
+ * it precisely rather than treating it as a generic verification error.
+ * error-policy:J4 fail-closed.
+ */
+export class X402ReplayCommitError extends Error {
+  readonly replayKeys: string[];
+  constructor(message: string, replayKeys: string[]) {
+    super(message);
+    this.name = "X402ReplayCommitError";
+    this.replayKeys = replayKeys;
+  }
+}
+
 type QueryableDb = {
   execute: (query: unknown) => Promise<unknown>;
 };
@@ -146,6 +165,7 @@ async function commitSqlReservations(
     state: "consumed",
     consumedAt: Date.now(),
   };
+  const uncommitted: string[] = [];
   for (const cacheKey of cacheKeys) {
     const result = await db.execute(sql`
       UPDATE cache
@@ -157,10 +177,23 @@ async function commitSqlReservations(
       RETURNING key
     `);
     if (!resultHadRows(result)) {
+      // error-policy:J4 fail-closed — the reserved 'inflight' row we owned was
+      // NOT transitioned to 'consumed' (stolen after TTL, released, or already
+      // committed by a racing request). Do NOT silently continue: an
+      // un-consumed credential becomes replayable once any lingering inflight
+      // reservation lapses. Record it and throw so the payment boundary denies
+      // the unlock instead of granting access the guard can't back.
       logger.error(
         `[x402] durable replay: failed to commit reserved replay key ${cacheKey}`,
       );
+      uncommitted.push(cacheKey);
     }
+  }
+  if (uncommitted.length > 0) {
+    throw new X402ReplayCommitError(
+      `durable replay: ${uncommitted.length} replay key(s) not marked consumed on commit`,
+      uncommitted,
+    );
   }
 }
 
@@ -319,18 +352,30 @@ export async function durableReplayCommitReservation(
     state: "consumed",
     consumedAt: Date.now(),
   };
+  const uncommitted: string[] = [];
   for (const replayKey of keys) {
     const ok = await runtime.setCache(
       durableReplayCacheKey(agentId, replayKey),
       payload,
     );
     if (!ok) {
+      // error-policy:J4 fail-closed — same invariant as the SQL path: a
+      // credential we could not persist as 'consumed' stays replayable. Surface
+      // + throw so the caller denies the unlock rather than fabricating a
+      // durable consumption that never landed.
       logger.error(
         `[x402] durable replay: setCache failed for replay key ${replayKey.slice(
           0,
           80,
-        )} (payment may be retryable if this persists)`,
+        )} (consumption not persisted — failing closed)`,
       );
+      uncommitted.push(replayKey);
     }
+  }
+  if (uncommitted.length > 0) {
+    throw new X402ReplayCommitError(
+      `durable replay: ${uncommitted.length} replay key(s) not persisted as consumed`,
+      uncommitted,
+    );
   }
 }

--- a/plugins/plugin-x402/src/x402-replay-guard.ts
+++ b/plugins/plugin-x402/src/x402-replay-guard.ts
@@ -152,18 +152,24 @@ export async function replayGuardCommit(
       break;
     }
   }
-  for (const k of keys) {
-    inflight.delete(k);
-    durableReservationOwners.delete(k);
-  }
   if (useDurable && keys.length > 0 && runtime) {
+    // Persist the durable consumption FIRST. If it throws (error-policy:J4
+    // fail-closed from the durable layer — consumption could not be recorded),
+    // leave the in-process inflight guard intact so a same-process retry is
+    // still blocked, and let the error propagate so the payment boundary denies
+    // the unlock rather than granting access the guard can't back.
     await durableReplayCommitReservation(
       runtime,
       agentId,
       keys,
       ownerConsistent ? owner : undefined,
     );
-  } else if (!useDurable) {
+  }
+  for (const k of keys) {
+    inflight.delete(k);
+    durableReservationOwners.delete(k);
+  }
+  if (!useDurable) {
     for (const k of keys) consumedMemory.set(k, exp);
   }
 }


### PR DESCRIPTION
## #12748 (#12275-J) — social/media/market/safety plugin non-route sweep

Payment/market slice for `plugin-x402`, whose replay guard is the double-spend defense for x402-gated paid routes. This slice fixes a **fail-open in the durable replay commit path**.

### The bug

The durable replay guard is two-phase: reserve a payment credential as `inflight` (with a TTL), then on successful verification `commit` it to `consumed`. The commit phase silently swallowed persistence failures:

- `commitSqlReservations` only `logger.error`'d when its `UPDATE ... RETURNING key` matched **no reserved row** (the inflight row was stolen after TTL, released, or already committed by a racing request).
- `durableReplayCommitReservation`'s cache-fallback only logged when `setCache` returned `false`.

In both cases `replayGuardCommit` returned normally, so `verifyPayment`'s `finishVerified` fabricated a **verified** result and the paid route **unlocked over a credential the guard never recorded as consumed**. Because the lingering `inflight` reservation carries a TTL, that same credential becomes **replayable once the TTL lapses** — one payment can unlock a paid route twice.

### The fix (`error-policy:J4` fail-closed)

- `commitSqlReservations` / `durableReplayCommitReservation` now collect the un-persisted keys and **throw a distinct `X402ReplayCommitError`** instead of logging-and-continuing.
- `replayGuardCommit` persists the durable consumption **first** and only clears the in-process `inflight` guard **after** success, so a same-process retry stays blocked if the commit throws.
- The throw propagates out of `verifyPayment` to the `payment-wrapper` boundary, which **already returns HTTP 402 on a thrown verification error** → the unlock is **denied** rather than granted on an unbacked consumption.

Money already settled at commit time, so denying the unlock is the security-correct choice for a replay guard: never grant access backed by a consumption record we couldn't write. The failure stays loud (`logger.error`) and is observably surfaced as `402`.

### Tests — `plugins/plugin-x402/src/x402-replay-durable.test.ts` (7 new)

- SQL commit matching no reserved row throws `X402ReplayCommitError`
- partial SQL commit failure reports the **exact** un-consumed keys
- cache-fallback `setCache` failure throws
- healthy SQL commit + healthy cache commit stay quiet (no false-positive throw)
- `replayGuardCommit` propagates the throw **and** retains the in-process reservation (same-credential retry still returns `false`)
- healthy durable commit does not throw

### Evidence

- `plugin-x402` suite **19/19** green (12 pre-existing + 7 new)
- `tsgo --noEmit` clean
- biome clean
- codex review clean — *"The changes make durable replay commits fail closed and propagate that failure through the replay guard. I did not find a discrete introduced bug in the modified code paths."*
- Route files untouched (owned by #12275-F). Prior #12275-J slices: #13136 (polymarket), #13244 (hyperliquid).

-- [sol-orch]
