### PR TITLE
fix(#13105): unify remote runtime URL trust

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1838,7 +1838,6 @@ export function App() {
           kind: "remote",
           apiBase: payload.gatewayUrl,
           token: typeof payload.token === "string" ? payload.token : null,
-          allowPublicHttps: true,
         });
         persistMobileRuntimeModeForServerTarget("remote");
         setState("firstRunRuntimeTarget", "remote");

--- a/packages/ui/src/components/cockpit/MyRuntimesContainer.test.tsx
+++ b/packages/ui/src/components/cockpit/MyRuntimesContainer.test.tsx
@@ -28,7 +28,7 @@ vi.mock("../../state", () => ({
   addAgentProfile: mocks.addAgentProfile,
   switchRuntimeNonDestructive: mocks.switchRuntimeNonDestructive,
 }));
-vi.mock("../../state/startup-phase-restore", () => ({
+vi.mock("../../state/runtime-url-trust", () => ({
   isTrustedRestoreApiBaseUrl: mocks.isTrustedRestoreApiBaseUrl,
 }));
 vi.mock("../../build-variant", () => ({

--- a/packages/ui/src/components/cockpit/MyRuntimesContainer.tsx
+++ b/packages/ui/src/components/cockpit/MyRuntimesContainer.tsx
@@ -12,7 +12,7 @@ import {
   loadAgentProfileRegistry,
   switchRuntimeNonDestructive,
 } from "../../state";
-import { isTrustedRestoreApiBaseUrl } from "../../state/startup-phase-restore";
+import { isTrustedRestoreApiBaseUrl } from "../../state/runtime-url-trust";
 import { MyRuntimesSection } from "./MyRuntimesSection";
 
 export interface MyRuntimesContainerProps {

--- a/packages/ui/src/platform/browser-launch.test.ts
+++ b/packages/ui/src/platform/browser-launch.test.ts
@@ -8,7 +8,10 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { applyLaunchConnectionFromUrl } from "./browser-launch";
+import {
+  applyLaunchConnection,
+  applyLaunchConnectionFromUrl,
+} from "./browser-launch";
 
 const mocks = vi.hoisted(() => ({
   createPersistedActiveServer: vi.fn((input) => ({
@@ -46,6 +49,7 @@ vi.mock("../state/agent-profiles", () => ({
 describe("browser launch connection handling", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
     mocks.createPersistedActiveServer.mockImplementation((input) => ({
       id: "test-server",
@@ -71,22 +75,20 @@ describe("browser launch connection handling", () => {
     expect(mocks.savePersistedActiveServer).not.toHaveBeenCalled();
   });
 
-  it("allows the configured cloud API host without accepting arbitrary public HTTPS", async () => {
+  it("allows trusted private apiBase parameters and syncs the profile registry", async () => {
     window.history.replaceState(
       null,
       "",
-      "http://localhost/?apiBase=https%3A%2F%2Fapi.elizacloud.ai%2Fv1%2F",
+      "http://localhost/?apiBase=http%3A%2F%2F100.96.0.1%3A31337%2Fv1%2F",
     );
 
     await expect(applyLaunchConnectionFromUrl()).resolves.toBe(true);
 
-    expect(mocks.setBaseUrl).toHaveBeenCalledWith(
-      "https://api.elizacloud.ai/v1",
-    );
+    expect(mocks.setBaseUrl).toHaveBeenCalledWith("http://100.96.0.1:31337/v1");
     expect(mocks.setToken).toHaveBeenCalledWith(null);
     expect(mocks.savePersistedActiveServer).toHaveBeenCalledWith(
       expect.objectContaining({
-        apiBase: "https://api.elizacloud.ai/v1",
+        apiBase: "http://100.96.0.1:31337/v1",
         kind: "remote",
       }),
     );
@@ -95,32 +97,25 @@ describe("browser launch connection handling", () => {
     expect(mocks.upsertAndActivateAgentProfile).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: "remote",
-        apiBase: "https://api.elizacloud.ai/v1",
+        apiBase: "http://100.96.0.1:31337/v1",
       }),
     );
     expect(window.location.href).toBe("http://localhost/");
   });
 
-  it("allows dedicated cloud agent apiBase parameters", async () => {
+  it("rejects public cloud apiBase parameters outside the managed launch-session flow", async () => {
     window.history.replaceState(
       null,
       "",
       "http://localhost/?apiBase=https%3A%2F%2Fagent-1.elizacloud.ai%2F",
     );
 
-    await expect(applyLaunchConnectionFromUrl()).resolves.toBe(true);
+    await expect(applyLaunchConnectionFromUrl()).rejects.toThrow(
+      "Rejected invalid launch apiBase",
+    );
 
-    expect(mocks.setBaseUrl).toHaveBeenCalledWith(
-      "https://agent-1.elizacloud.ai",
-    );
-    expect(mocks.setToken).toHaveBeenCalledWith(null);
-    expect(mocks.savePersistedActiveServer).toHaveBeenCalledWith(
-      expect.objectContaining({
-        apiBase: "https://agent-1.elizacloud.ai",
-        kind: "remote",
-      }),
-    );
-    expect(window.location.href).toBe("http://localhost/");
+    expect(mocks.setBaseUrl).not.toHaveBeenCalled();
+    expect(mocks.savePersistedActiveServer).not.toHaveBeenCalled();
   });
 
   it("rejects unconfigured public HTTPS apiBase parameters", async () => {
@@ -136,6 +131,43 @@ describe("browser launch connection handling", () => {
 
     expect(mocks.setBaseUrl).not.toHaveBeenCalled();
     expect(mocks.savePersistedActiveServer).not.toHaveBeenCalled();
+  });
+
+  it("rejects Settings-style remote connect calls to arbitrary public HTTPS", () => {
+    expect(() =>
+      applyLaunchConnection({
+        kind: "remote",
+        apiBase: "https://agent.attacker.example/",
+        token: "secret-token",
+      }),
+    ).toThrow("Rejected invalid launch apiBase");
+
+    expect(mocks.setBaseUrl).not.toHaveBeenCalled();
+    expect(mocks.setToken).not.toHaveBeenCalled();
+    expect(mocks.savePersistedActiveServer).not.toHaveBeenCalled();
+  });
+
+  it("allows Settings-style remote connect calls to trusted private URLs", () => {
+    expect(
+      applyLaunchConnection({
+        kind: "remote",
+        apiBase: "https://my-box.local:31337/",
+        token: " secret-token ",
+      }),
+    ).toEqual({
+      apiBase: "https://my-box.local:31337",
+      token: "secret-token",
+    });
+
+    expect(mocks.setBaseUrl).toHaveBeenCalledWith("https://my-box.local:31337");
+    expect(mocks.setToken).toHaveBeenCalledWith("secret-token");
+    expect(mocks.savePersistedActiveServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accessToken: "secret-token",
+        apiBase: "https://my-box.local:31337",
+        kind: "remote",
+      }),
+    );
   });
 
   it("rejects configured cloud API hosts over plaintext HTTP", async () => {
@@ -194,5 +226,32 @@ describe("browser launch connection handling", () => {
       }),
     );
     expect(window.location.href).toBe("http://localhost/");
+  });
+
+  it("rejects managed cloud launch sessions that return a non-cloud public runtime URL", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        success: true,
+        data: {
+          connection: {
+            apiBase: "https://agent.attacker.example",
+            token: "runtime-token",
+          },
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    window.history.replaceState(
+      null,
+      "",
+      "http://localhost/?cloudLaunchSession=launch-1&cloudLaunchBase=https%3A%2F%2Fapi.elizacloud.ai",
+    );
+
+    await expect(applyLaunchConnectionFromUrl()).rejects.toThrow(
+      "Rejected invalid launch apiBase",
+    );
+
+    expect(mocks.setBaseUrl).not.toHaveBeenCalled();
+    expect(mocks.savePersistedActiveServer).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/platform/browser-launch.ts
+++ b/packages/ui/src/platform/browser-launch.ts
@@ -9,6 +9,7 @@ import {
   createPersistedActiveServer,
   savePersistedActiveServer,
 } from "../state/persistence";
+import { isTrustedRestoreApiBaseUrl } from "../state/runtime-url-trust";
 import { isDedicatedCloudAgentBase } from "../utils/cloud-agent-base";
 
 const TRUSTED_CLOUD_LAUNCH_HOSTS = new Set([
@@ -26,25 +27,6 @@ function getSearchParams(): URLSearchParams {
   return new URLSearchParams(
     window.location.search || window.location.hash.split("?")[1] || "",
   );
-}
-
-function isAllowedHttpHost(host: string): boolean {
-  return (
-    /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host) ||
-    /^192\.168\.\d{1,3}\.\d{1,3}$/.test(host) ||
-    /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(host) ||
-    /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3}$/.test(host) ||
-    host.endsWith(".local") ||
-    host.endsWith(".internal") ||
-    host.endsWith(".ts.net") ||
-    host === "localhost" ||
-    host === "127.0.0.1" ||
-    host === "::1"
-  );
-}
-
-function isCurrentHost(host: string): boolean {
-  return typeof window !== "undefined" && host === window.location.hostname;
 }
 
 function isConfiguredCloudHost(host: string): boolean {
@@ -67,7 +49,7 @@ function isTrustedCloudLaunchHost(host: string): boolean {
 
 function normalizeLaunchApiBase(
   apiBase: string,
-  options: { allowPublicHttps?: boolean } = {},
+  options: { kind?: "cloud" | "remote" } = {},
 ): string {
   const trimmed = apiBase.trim();
   if (!trimmed) {
@@ -82,13 +64,11 @@ function normalizeLaunchApiBase(
   try {
     const parsed = new URL(trimmed);
     if (
-      (parsed.protocol === "https:" &&
-        (options.allowPublicHttps ||
-          isAllowedHttpHost(parsed.hostname) ||
-          isConfiguredCloudHost(parsed.hostname) ||
-          isDedicatedCloudAgentBase(parsed.toString()) ||
-          isCurrentHost(parsed.hostname))) ||
-      (parsed.protocol === "http:" && isAllowedHttpHost(parsed.hostname))
+      isTrustedRestoreApiBaseUrl(parsed.toString()) ||
+      (options.kind === "cloud" &&
+        parsed.protocol === "https:" &&
+        (isConfiguredCloudHost(parsed.hostname) ||
+          isDedicatedCloudAgentBase(parsed.toString())))
     ) {
       return stripTrailingSlashes(parsed.toString());
     }
@@ -104,11 +84,8 @@ function normalizeLaunchApiBase(
 function normalizeLaunchBaseUrl(baseUrl: string): string {
   const parsed = new URL(baseUrl);
   if (
-    (parsed.protocol === "https:" &&
-      (isAllowedHttpHost(parsed.hostname) ||
-        isCurrentHost(parsed.hostname) ||
-        isTrustedCloudLaunchHost(parsed.hostname))) ||
-    (parsed.protocol === "http:" && isAllowedHttpHost(parsed.hostname))
+    isTrustedRestoreApiBaseUrl(parsed.toString()) ||
+    (parsed.protocol === "https:" && isTrustedCloudLaunchHost(parsed.hostname))
   ) {
     parsed.pathname = "";
     parsed.search = "";
@@ -186,7 +163,7 @@ async function exchangeCloudLaunchSession(
 
     return {
       apiBase: normalizeLaunchApiBase(payload.data.connection.apiBase, {
-        allowPublicHttps: true,
+        kind: "cloud",
       }),
       token,
     };
@@ -199,14 +176,13 @@ export function applyLaunchConnection(args: {
   apiBase: string;
   token?: string | null;
   kind?: "cloud" | "remote";
-  allowPublicHttps?: boolean;
 }): { apiBase: string; token: string | null } {
+  const kind = args.kind ?? "remote";
   const normalizedApiBase = normalizeLaunchApiBase(args.apiBase, {
-    allowPublicHttps: args.allowPublicHttps === true,
+    kind,
   });
   const token = args.token?.trim() || null;
 
-  const kind = args.kind ?? "remote";
   client.setBaseUrl(normalizedApiBase);
   client.setToken(token);
   const persisted = createPersistedActiveServer({
@@ -245,7 +221,6 @@ export async function applyLaunchConnectionFromUrl(): Promise<boolean> {
       kind: "cloud",
       apiBase: connection.apiBase,
       token: connection.token,
-      allowPublicHttps: true,
     });
     stripLaunchParams();
     return true;
@@ -263,7 +238,7 @@ export async function applyLaunchConnectionFromUrl(): Promise<boolean> {
 
   applyLaunchConnection({
     kind: "remote",
-    apiBase: normalizeLaunchApiBase(apiBase),
+    apiBase,
     token: null,
   });
   stripLaunchParams();

--- a/packages/ui/src/state/AppContext.tsx
+++ b/packages/ui/src/state/AppContext.tsx
@@ -63,9 +63,9 @@ import {
   createPersistedActiveServer,
   savePersistedActiveServer,
 } from "./persistence";
+import { isTrustedRestoreApiBaseUrl } from "./runtime-url-trust";
 import { deriveUiShellModeForTab } from "./shell-routing";
 import type { RuntimeTarget } from "./startup-coordinator";
-import { isTrustedRestoreApiBaseUrl } from "./startup-phase-restore";
 import { useTranslation } from "./TranslationContext.hooks";
 import { TranslationProvider } from "./TranslationProvider";
 import { useAppLifecycleEvents } from "./useAppLifecycleEvents";

--- a/packages/ui/src/state/runtime-url-trust.ts
+++ b/packages/ui/src/state/runtime-url-trust.ts
@@ -1,0 +1,66 @@
+/**
+ * Canonical trust gate for persisted/user-entered remote runtime API bases.
+ *
+ * Remote runtime records are localStorage-backed and can also be created from
+ * connect events. Only dial — and attach a bearer token to — loopback,
+ * same-origin, private/LAN, CGNAT/Tailscale, or the mobile IPC pseudo-base.
+ */
+import { isMobileLocalAgentIpcBase } from "../first-run/mobile-runtime-mode";
+
+function isLoopbackHostname(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  return h === "127.0.0.1" || h === "localhost" || h === "::1";
+}
+
+export function isTrustedRestoreApiBaseUrl(
+  apiBase: string | undefined,
+): boolean {
+  if (!apiBase) return false;
+  // The bundled on-device agent's IPC pseudo-base (eliza-local-agent://ipc) is
+  // in-process: no network dial, no attacker-choosable host, no bearer-token
+  // exfiltration surface.
+  if (isMobileLocalAgentIpcBase(apiBase)) return true;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(apiBase);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return false;
+  }
+
+  const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (isLoopbackHostname(host) || host === "0.0.0.0") return true;
+  if (
+    typeof window !== "undefined" &&
+    host === window.location.hostname.toLowerCase()
+  ) {
+    return true;
+  }
+  // IPv6 ULA (fc00::/7) / link-local (fe80::/10).
+  if (
+    host.includes(":") &&
+    (host.startsWith("fc") || host.startsWith("fd") || host.startsWith("fe80:"))
+  ) {
+    return true;
+  }
+
+  // RFC1918 / CGNAT (Tailscale) / link-local IPv4 + private name suffixes.
+  return (
+    /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host) ||
+    /^192\.168\.\d{1,3}\.\d{1,3}$/.test(host) ||
+    /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(host) ||
+    /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3}$/.test(host) ||
+    /^169\.254\.\d{1,3}\.\d{1,3}$/.test(host) ||
+    host === "local" ||
+    host === "internal" ||
+    host === "lan" ||
+    host === "ts.net" ||
+    host.endsWith(".local") ||
+    host.endsWith(".lan") ||
+    host.endsWith(".internal") ||
+    host.endsWith(".ts.net")
+  );
+}

--- a/packages/ui/src/state/startup-phase-restore.trust.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.trust.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
-import { isTrustedRestoreApiBaseUrl } from "./startup-phase-restore";
+import { isTrustedRestoreApiBaseUrl } from "./runtime-url-trust";
 
 /**
  * The persisted active-server / agent-profile record is localStorage-backed and

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -27,7 +27,6 @@ import {
   ANDROID_LOCAL_AGENT_LABEL,
   ANDROID_LOCAL_AGENT_SERVER_ID,
   IOS_LOCAL_AGENT_IPC_BASE,
-  isMobileLocalAgentIpcBase,
   isMobileLocalAgentUrl,
   MOBILE_LOCAL_AGENT_LABEL,
   MOBILE_LOCAL_AGENT_SERVER_ID,
@@ -57,6 +56,7 @@ import {
   savePersistedActiveServer,
   savePersistedFirstRunComplete,
 } from "./persistence";
+import { isTrustedRestoreApiBaseUrl } from "./runtime-url-trust";
 import type { StartupEvent } from "./startup-coordinator";
 import { buildStaticFirstRunOptions } from "./startup-first-run-options";
 
@@ -192,74 +192,6 @@ function isMobileLocalActiveServer(server: PersistedActiveServer): boolean {
 function isLoopbackHostname(hostname: string): boolean {
   const h = hostname.toLowerCase();
   return h === "127.0.0.1" || h === "localhost" || h === "::1";
-}
-
-/**
- * Whether a persisted `remote` apiBase is safe to dial at restore. The persisted
- * active-server record lives in localStorage (mirrored to native Preferences),
- * so an XSS or a malicious same-origin plugin view could have written it. Only
- * dial — and attach the bearer token to — a trusted host; otherwise the record
- * is dropped and the app falls back to first-run (fail closed) rather than
- * silently connecting to an attacker-chosen server at boot.
- *
- * Trust mirrors the app's full policy (createUrlTrustPolicy in
- * `packages/app/src/url-trust-policy.ts`, which `@elizaos/ui` cannot import):
- * loopback, the current page origin, and private/LAN/CGNAT/link-local hosts —
- * never an arbitrary public host. Keep the private-host set in sync with
- * `isTrustedPrivateHttpHost` there. `local`/`cloud` records use their own
- * validated branches in {@link applyRestoredConnection} and are not gated here.
- */
-export function isTrustedRestoreApiBaseUrl(
-  apiBase: string | undefined,
-): boolean {
-  if (!apiBase) return false;
-  // The bundled on-device agent's IPC pseudo-base (eliza-local-agent://ipc) is
-  // in-process: no network dial, no attacker-choosable host, no bearer-token
-  // exfiltration surface. Its custom scheme fails the http/https gate below,
-  // and without this allowance EVERY relaunch of a local-mode phone dropped
-  // its saved on-device server and silently un-completed first-run (the iOS
-  // boot-to-onboarding bounce found via the #11110 device boot trace).
-  if (isMobileLocalAgentIpcBase(apiBase)) return true;
-  let parsed: URL;
-  try {
-    parsed = new URL(apiBase);
-  } catch {
-    return false;
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    return false;
-  }
-  const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  if (isLoopbackHostname(host) || host === "0.0.0.0") return true;
-  if (
-    typeof window !== "undefined" &&
-    host === window.location.hostname.toLowerCase()
-  ) {
-    return true;
-  }
-  // IPv6 ULA (fc00::/7) / link-local (fe80::/10).
-  if (
-    host.includes(":") &&
-    (host.startsWith("fc") || host.startsWith("fd") || host.startsWith("fe80:"))
-  ) {
-    return true;
-  }
-  // RFC1918 / CGNAT (tailscale) / link-local IPv4 + private name suffixes.
-  return (
-    /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host) ||
-    /^192\.168\.\d{1,3}\.\d{1,3}$/.test(host) ||
-    /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(host) ||
-    /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3}$/.test(host) ||
-    /^169\.254\.\d{1,3}\.\d{1,3}$/.test(host) ||
-    host === "local" ||
-    host === "internal" ||
-    host === "lan" ||
-    host === "ts.net" ||
-    host.endsWith(".local") ||
-    host.endsWith(".lan") ||
-    host.endsWith(".internal") ||
-    host.endsWith(".ts.net")
-  );
 }
 
 // Re-resolve a persisted loopback apiBase against whatever port the

--- a/packages/ui/src/state/switch-runtime.test.ts
+++ b/packages/ui/src/state/switch-runtime.test.ts
@@ -44,7 +44,7 @@ vi.mock("./persistence", () => ({
   createPersistedActiveServer: mocks.createPersistedActiveServer,
   savePersistedActiveServer: mocks.savePersistedActiveServer,
 }));
-vi.mock("./startup-phase-restore", () => ({
+vi.mock("./runtime-url-trust", () => ({
   isTrustedRestoreApiBaseUrl: mocks.isTrustedRestoreApiBaseUrl,
 }));
 vi.mock("./ChatComposerContext.hooks", () => ({

--- a/packages/ui/src/state/switch-runtime.ts
+++ b/packages/ui/src/state/switch-runtime.ts
@@ -18,7 +18,7 @@ import {
   createPersistedActiveServer,
   savePersistedActiveServer,
 } from "./persistence";
-import { isTrustedRestoreApiBaseUrl } from "./startup-phase-restore";
+import { isTrustedRestoreApiBaseUrl } from "./runtime-url-trust";
 
 export type SwitchRuntimeResult =
   | { ok: true; profile: AgentProfile }

--- a/packages/ui/src/state/use-startup-shell-controller.ts
+++ b/packages/ui/src/state/use-startup-shell-controller.ts
@@ -166,7 +166,6 @@ export function useStartupShellController(): StartupShellController {
           kind: "remote",
           apiBase: payload.gatewayUrl,
           token: typeof payload.token === "string" ? payload.token : null,
-          allowPublicHttps: true,
         });
         persistMobileRuntimeModeForServerTarget("remote");
         setState("firstRunRuntimeTarget", "remote");


### PR DESCRIPTION
## Summary
- move the remote runtime URL trust rule into a shared UI predicate
- make browser/deep-link launch and Settings-style `CONNECT_EVENT` remote connects use the same private/trusted-only predicate as My Runtimes
- keep managed cloud launch-session URLs separate, while rejecting arbitrary public HTTPS runtime URLs
- update regression tests for public HTTPS rejection plus private/CGNAT/Tailscale-style acceptance

Fixes #13105

## Validation
- `TMPDIR=/private/tmp/codex-test-tmp bun run --cwd packages/ui test -- src/platform/browser-launch.test.ts src/state/startup-phase-restore.trust.test.ts src/state/switch-runtime.test.ts src/components/cockpit/MyRuntimesContainer.test.tsx src/state/startup-phase-hydrate.switch.test.ts`
- `git diff --name-only -z origin/develop...HEAD | xargs -0 bunx @biomejs/biome check`
- `bun run audit:error-policy-ratchet`

## Known baseline
- `bun run --cwd packages/ui typecheck` currently fails on unchanged develop file `src/hooks/useWhatsAppPairing.test.tsx:21` with TS2556 (`A spread argument must either have a tuple type or be passed to a rest parameter`).
