### PR TITLE
fix(ui): gate cloud cold-boot on the proxy passthrough, not the orchestrator shim

### DIFF
--- a/packages/ui/src/state/startup-phase-runtime.cloud-warm.test.ts
+++ b/packages/ui/src/state/startup-phase-runtime.cloud-warm.test.ts
@@ -1,0 +1,304 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runStartingRuntime } from "./startup-phase-runtime";
+
+/**
+ * Cold-boot routing regression for Eliza-MANAGED cloud agents.
+ *
+ * The bug: the startup coordinator declared a cloud agent "ready" off the
+ * orchestrator/status shim (which reports running the instant the agent is
+ * provisioned), but the per-agent PROXY passthrough
+ * (`/api/v1/eliza/agents/<id>/api/*`) 404s "Agent not found" for the first
+ * ~minutes while the container binds the runtime. Flipping ready off the shim
+ * routed the user to a washed-out /character/select during warm-up.
+ *
+ * The fix (this suite locks it): for a managed cloud agent, gate readiness on
+ * the passthrough genuinely serving (`GET /api/conversations` via
+ * listConversations). While it 404s we stay in starting-runtime (booting chat)
+ * and the deadline keeps sliding; once it serves we dispatch AGENT_RUNNING once.
+ *
+ * The shared-code constraint: the desktop/mobile embedded-local first-run and
+ * the self-hosted remote-backend paths must be UNCHANGED — the last two cases
+ * are the non-negotiable regression guards.
+ */
+
+const clientMock = vi.hoisted(() => ({
+  getLaunchProgress: vi.fn(),
+  getBootProgress: vi.fn(),
+  getStatus: vi.fn(),
+  getAuthStatus: vi.fn(),
+  hasToken: vi.fn(),
+  startAgent: vi.fn(),
+  listConversations: vi.fn(),
+}));
+
+const persistenceMock = vi.hoisted(() => ({
+  loadPersistedActiveServer: vi.fn(),
+}));
+
+vi.mock("../api", () => ({
+  client: clientMock,
+}));
+
+vi.mock("./persistence", () => ({
+  loadPersistedActiveServer: persistenceMock.loadPersistedActiveServer,
+}));
+
+function createDeps() {
+  return {
+    setAgentStatus: vi.fn(),
+    setConnected: vi.fn(),
+    setStartupError: vi.fn(),
+    setFirstRunLoading: vi.fn(),
+    setAuthRequired: vi.fn(),
+    setPairingEnabled: vi.fn(),
+    setPairingExpiresAt: vi.fn(),
+    setPendingRestart: vi.fn(),
+    setPendingRestartReasons: vi.fn(),
+  };
+}
+
+const RUNNING_STATUS = {
+  state: "running" as const,
+  agentName: "Cloud Agent",
+  model: "cloud-model",
+  uptime: 1_000,
+  startedAt: Date.now() - 1_000,
+};
+
+describe("runStartingRuntime — managed cloud cold-boot warmup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clientMock.getLaunchProgress.mockResolvedValue(null);
+    clientMock.getBootProgress.mockResolvedValue(null);
+    clientMock.getStatus.mockResolvedValue(RUNNING_STATUS);
+    clientMock.hasToken.mockReturnValue(true);
+    // Default: no persisted server (behaves as non-cloud for the shared paths).
+    persistenceMock.loadPersistedActiveServer.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stays in starting-runtime while the proxy passthrough 404s, never flips ready, and keeps extending the deadline (no premature timeout)", async () => {
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      id: "cloud:agent-123",
+      kind: "cloud",
+      label: "Eliza Cloud",
+    });
+
+    // Drive time forward well past the initial 180s budget on each poll so a
+    // NON-sliding deadline would already have tripped AGENT_TIMEOUT. The slide
+    // (effective "starting" state) must keep the deadline ahead instead.
+    let nowValue = 1_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => nowValue);
+
+    const cancelled = { current: false };
+    // Warming: the passthrough keeps 404ing. Bound the loop by cancelling after
+    // a handful of probes (each probe jumps the clock by a full minute).
+    let probes = 0;
+    clientMock.listConversations.mockImplementation(async () => {
+      probes += 1;
+      nowValue += 60_000; // +60s per probe → 5 probes ≈ 5 minutes elapsed
+      if (probes >= 5) cancelled.current = true;
+      throw { status: 404, message: "Agent not found" };
+    });
+
+    const dispatch = vi.fn();
+    const deps = createDeps();
+
+    await runStartingRuntime(
+      deps,
+      dispatch,
+      1,
+      { current: 1 },
+      cancelled,
+      { current: null },
+      "cloud-managed",
+    );
+
+    // Probed the genuine passthrough, never the local boot/status path.
+    expect(clientMock.listConversations).toHaveBeenCalled();
+    expect(clientMock.startAgent).not.toHaveBeenCalled();
+    expect(clientMock.getBootProgress).not.toHaveBeenCalled();
+    expect(clientMock.getLaunchProgress).not.toHaveBeenCalled();
+
+    // Never declared ready, never surfaced a timeout — we simply kept waiting.
+    expect(dispatch).not.toHaveBeenCalledWith({ type: "AGENT_RUNNING" });
+    expect(dispatch).not.toHaveBeenCalledWith({ type: "AGENT_TIMEOUT" });
+    expect(deps.setStartupError).not.toHaveBeenCalled();
+
+    nowSpy.mockRestore();
+  });
+
+  it("dispatches AGENT_RUNNING exactly once when the proxy passthrough is genuinely serving", async () => {
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      id: "cloud:agent-123",
+      kind: "cloud",
+      label: "Eliza Cloud",
+    });
+
+    clientMock.listConversations.mockResolvedValue({ conversations: [] });
+
+    const dispatch = vi.fn();
+    const deps = createDeps();
+
+    await runStartingRuntime(
+      deps,
+      dispatch,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+      "cloud-managed",
+    );
+
+    expect(clientMock.listConversations).toHaveBeenCalledTimes(1);
+    // Hydration fills the full status once the passthrough serves.
+    expect(clientMock.getStatus).toHaveBeenCalled();
+    expect(deps.setConnected).toHaveBeenCalledWith(true);
+    expect(deps.setFirstRunLoading).toHaveBeenCalledWith(false);
+    expect(deps.setStartupError).not.toHaveBeenCalled();
+
+    const runningDispatches = dispatch.mock.calls.filter(
+      ([e]) => e.type === "AGENT_RUNNING",
+    );
+    expect(runningDispatches).toHaveLength(1);
+  });
+
+  it("warms first, then advances: 404 → 404 → serving dispatches AGENT_RUNNING once", async () => {
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      id: "cloud:agent-123",
+      kind: "cloud",
+      label: "Eliza Cloud",
+    });
+
+    let call = 0;
+    clientMock.listConversations.mockImplementation(async () => {
+      call += 1;
+      if (call < 3) throw { status: 404, message: "Agent not found" };
+      return { conversations: [] };
+    });
+
+    const dispatch = vi.fn();
+    const deps = createDeps();
+
+    await runStartingRuntime(
+      deps,
+      dispatch,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+      "cloud-managed",
+    );
+
+    expect(clientMock.listConversations).toHaveBeenCalledTimes(3);
+    const runningDispatches = dispatch.mock.calls.filter(
+      ([e]) => e.type === "AGENT_RUNNING",
+    );
+    expect(runningDispatches).toHaveLength(1);
+    expect(dispatch).not.toHaveBeenCalledWith({ type: "AGENT_TIMEOUT" });
+  });
+
+  // ── REGRESSION GUARDS (shared-code constraint) ─────────────────────────
+
+  it("REGRESSION: a self-hosted remote-backend still advances immediately without probing the cloud passthrough", async () => {
+    // remote-backend never persists kind:"cloud" — even if a stale cloud record
+    // existed, the target guard keeps remote on its immediate-ready path.
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      id: "remote:https://my.server",
+      kind: "remote",
+      label: "my.server",
+      apiBase: "https://my.server",
+    });
+
+    const dispatch = vi.fn();
+    const deps = createDeps();
+
+    await runStartingRuntime(
+      deps,
+      dispatch,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+      "remote-backend",
+    );
+
+    // No cloud warmup: the passthrough probe is never issued.
+    expect(clientMock.listConversations).not.toHaveBeenCalled();
+    expect(clientMock.startAgent).not.toHaveBeenCalled();
+    expect(deps.setConnected).toHaveBeenCalledWith(true);
+    expect(dispatch).toHaveBeenCalledWith({ type: "AGENT_RUNNING" });
+    expect(deps.setStartupError).not.toHaveBeenCalled();
+  });
+
+  it("REGRESSION: desktop/embedded-local first-run advances via boot progress on state:running, untouched by the cloud gate", async () => {
+    // Embedded-local (desktop first-run) has NO persisted cloud kind and takes
+    // the full boot/poll loop. A running boot snapshot advances exactly as today
+    // — proving the non-cloud path and the boot ready branch are unchanged.
+    persistenceMock.loadPersistedActiveServer.mockReturnValue({
+      id: "local:embedded",
+      kind: "local",
+      label: "This device",
+    });
+    clientMock.getBootProgress.mockResolvedValue({
+      state: "running",
+      phase: "running",
+      lastError: null,
+      pluginsLoaded: 22,
+      pluginsFailed: 0,
+      database: "ok",
+      agentName: "Eliza",
+      port: 31337,
+      startedAt: Date.now() - 1_000,
+      updatedAt: new Date().toISOString(),
+    });
+
+    const dispatch = vi.fn();
+    const deps = createDeps();
+
+    await runStartingRuntime(
+      deps,
+      dispatch,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+      "embedded-local",
+    );
+
+    // The cloud passthrough probe is never issued on the local path.
+    expect(clientMock.listConversations).not.toHaveBeenCalled();
+    expect(clientMock.getBootProgress).toHaveBeenCalled();
+    expect(clientMock.getStatus).toHaveBeenCalled();
+    expect(deps.setConnected).toHaveBeenCalledWith(true);
+    expect(dispatch).toHaveBeenCalledWith({ type: "AGENT_RUNNING" });
+    expect(deps.setStartupError).not.toHaveBeenCalled();
+  });
+
+  it("REGRESSION: a cloud-managed target WITHOUT a persisted cloud record keeps the immediate-ready fast path (no passthrough probe)", async () => {
+    // Defensive: if the target says cloud-managed but nothing cloud is persisted
+    // (e.g. an odd restore), fall back to today's behavior rather than blocking
+    // on a passthrough that may not apply.
+    persistenceMock.loadPersistedActiveServer.mockReturnValue(null);
+
+    const dispatch = vi.fn();
+    const deps = createDeps();
+
+    await runStartingRuntime(
+      deps,
+      dispatch,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+      "cloud-managed",
+    );
+
+    expect(clientMock.listConversations).not.toHaveBeenCalled();
+    expect(deps.setConnected).toHaveBeenCalledWith(true);
+    expect(dispatch).toHaveBeenCalledWith({ type: "AGENT_RUNNING" });
+  });
+});

--- a/packages/ui/src/state/startup-phase-runtime.ts
+++ b/packages/ui/src/state/startup-phase-runtime.ts
@@ -22,13 +22,13 @@ import {
   formatStartupErrorDetail,
   type StartupErrorState,
 } from "./internal";
+import { loadPersistedActiveServer } from "./persistence";
 import type { RuntimeTarget, StartupEvent } from "./startup-coordinator";
 
 function isCapacitorNative(): boolean {
   try {
     const cap = (globalThis as Record<string, unknown>).Capacitor as
-      | { isNativePlatform?: () => boolean }
-      | undefined;
+      { isNativePlatform?: () => boolean } | undefined;
     return Boolean(cap?.isNativePlatform?.());
   } catch {
     return false;
@@ -138,6 +138,55 @@ async function hydrateReadyAgentStatus(
 }
 
 /**
+ * True when the persisted active server is an Eliza-managed cloud agent
+ * (`kind: "cloud"`). Written on every cloud entry path (first-run completion,
+ * session restore, profile switch) and NEVER for the desktop/mobile embedded
+ * agent (`kind: "local"`) or a self-hosted remote backend (`kind: "remote"`).
+ *
+ * This is the scope signal for the cold-boot warmup gate: only a managed cloud
+ * agent reaches the app through the per-agent PROXY passthrough
+ * (`/api/v1/eliza/agents/<id>/api/*`) that 404s "Agent not found" while the
+ * container is still warming, so only a managed cloud agent needs the extra
+ * passthrough confirmation before we declare the runtime ready. A pure
+ * localStorage read — no deps threading, no state-machine change — so the
+ * embedded-local and remote-backend paths keep their exact current behavior.
+ */
+function isCloudManagedActiveServer(): boolean {
+  return loadPersistedActiveServer()?.kind === "cloud";
+}
+
+/**
+ * Probes the genuine per-agent proxy passthrough for a managed cloud agent.
+ *
+ * The startup coordinator historically declared a cloud agent "ready" off the
+ * cloud ORCHESTRATOR view (`getStatus()`, which for a direct shared-runtime base
+ * is a client-side shim that hardcodes `state: "running"` — see
+ * ElizaClient.getStatus). That reports running the instant the agent is
+ * PROVISIONED, but the per-agent PROXY passthrough
+ * (`/api/v1/eliza/agents/<id>/api/*`) still 404s "Agent not found" for the first
+ * ~minutes while the container binds the runtime. Declaring ready off the shim
+ * routed cold-boot cloud users to a washed-out /character/select instead of the
+ * booting chat.
+ *
+ * `listConversations()` issues a real `GET /api/conversations` THROUGH that
+ * passthrough (it is NOT short-circuited by any shim), so it is the authoritative
+ * "is the warmed runtime actually serving?" signal:
+ *   - resolves → the passthrough serves → runtime is live → ready.
+ *   - rejects  → still warming (404 "Agent not found") or a transient blip →
+ *     keep polling. Both are "not ready yet"; the 401/429 auth cases are already
+ *     resolved during the polling-backend phase before starting-runtime, so a
+ *     rejection here does not need auth disambiguation.
+ */
+async function isCloudProxyPassthroughServing(): Promise<boolean> {
+  try {
+    await client.listConversations();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Runs the starting-runtime phase.
  * Polls /status until the agent reaches "running", then dispatches AGENT_RUNNING.
  *
@@ -165,11 +214,38 @@ export async function runStartingRuntime(
   // container the device is pointed at — there is no local runtime to start.
   // Calling client.startAgent() here would (at best) hit a remote endpoint
   // that has nothing to boot, and the local agent-readiness poll loop is
-  // pure latency on the first-paint critical path. Treat the running remote
-  // agent as ready and advance straight to hydration. Topologies 1 & 2
+  // pure latency on the first-paint critical path. Topologies 1 & 2
   // ("embedded-local") fall through to the full boot/poll loop below.
   if (target === "cloud-managed" || target === "remote-backend") {
     if (cancelled.current || effectRunRef.current !== effectRunId) return;
+
+    // For an Eliza-MANAGED cloud agent, "provisioned" is not "serving". The
+    // orchestrator/status shim reports running the instant the agent is
+    // provisioned, but the per-agent PROXY passthrough
+    // (`/api/v1/eliza/agents/<id>/api/*`) 404s "Agent not found" for the first
+    // ~minutes while the container binds the runtime. Declaring ready off the
+    // shim routed the user to a washed-out /character/select instead of the
+    // booting chat. Gate readiness on the passthrough genuinely serving so we
+    // stay in starting-runtime (booting chat + BootStatusIndicator) until the
+    // warmed runtime actually answers. Scoped to `kind: "cloud"` — a
+    // self-hosted `remote-backend` and the desktop/mobile embedded-local agent
+    // never go through this passthrough, so they keep the immediate-ready
+    // behavior unchanged.
+    if (target === "cloud-managed" && isCloudManagedActiveServer()) {
+      await runCloudManagedWarmup(
+        deps,
+        dispatch,
+        effectRunId,
+        effectRunRef,
+        cancelled,
+        tidRef,
+      );
+      return;
+    }
+
+    // Self-hosted remote backend (or a cloud-managed target with no persisted
+    // cloud record): treat the already-running remote agent as ready and
+    // advance straight to hydration — today's behavior, unchanged.
     await hydrateReadyAgentStatus(deps);
     if (cancelled.current || effectRunRef.current !== effectRunId) return;
     deps.setConnected(true);
@@ -434,6 +510,92 @@ export async function runStartingRuntime(
       lastErr = err;
       deps.setConnected(false);
     }
+    await new Promise<void>((r) => {
+      tidRef.current = setTimeout(r, 500);
+    });
+  }
+}
+
+/**
+ * Cold-boot warmup loop for an Eliza-MANAGED cloud agent (`kind: "cloud"`).
+ *
+ * Polls the genuine per-agent proxy passthrough (`GET /api/conversations` via
+ * `client.listConversations()`) until it actually serves, THEN hydrates and
+ * dispatches AGENT_RUNNING. Until then we stay in the starting-runtime phase,
+ * which renders the booting chat (with BootStatusIndicator / "connecting…")
+ * rather than flipping ready and routing the user to a washed-out
+ * /character/select while the container is still warming.
+ *
+ * Deadline handling mirrors the local boot loop: start with the web policy's
+ * 180s budget, then — while the passthrough is still warming — slide the
+ * deadline forward with an effective "starting" state (the passthrough IS the
+ * agent starting) so a legitimately slow warm (minutes) is not tripped as a
+ * timeout. The slide is bounded by AGENT_STARTUP_ABSOLUTE_MAX_MS, so a genuinely
+ * stuck agent still ends on the friendly agent-timeout screen instead of an
+ * infinite spinner.
+ *
+ * Scoped strictly to managed cloud: this function is only reached from the
+ * cloud-managed + persisted-cloud branch, so the desktop/mobile embedded-local
+ * first-run and the self-hosted remote-backend paths are entirely unaffected.
+ */
+async function runCloudManagedWarmup(
+  deps: StartingRuntimeDeps,
+  dispatch: (event: StartupEvent) => void,
+  effectRunId: number,
+  effectRunRef: React.MutableRefObject<number>,
+  cancelled: { current: boolean },
+  tidRef: { current: ReturnType<typeof setTimeout> | null },
+): Promise<void> {
+  const started = Date.now();
+  let deadline = started + getAgentReadyTimeoutMs();
+
+  logger.info(
+    "[eliza][startup:init] cloud-managed agent; waiting on proxy passthrough to warm before declaring ready",
+  );
+
+  while (!cancelled.current && effectRunRef.current === effectRunId) {
+    if (Date.now() >= deadline) {
+      deps.setStartupError({
+        reason: "agent-timeout",
+        phase: "initializing-agent",
+        message:
+          "The cloud agent did not finish starting in time. Cloud agents can take a few minutes to warm up on first launch.",
+        detail:
+          'The agent\'s chat endpoint was still returning "Agent not found" when the startup budget elapsed. Press Retry to keep waiting.',
+      });
+      deps.setFirstRunLoading(false);
+      dispatch({ type: "AGENT_TIMEOUT" });
+      return;
+    }
+
+    const serving = await isCloudProxyPassthroughServing();
+    if (cancelled.current || effectRunRef.current !== effectRunId) return;
+
+    if (serving) {
+      // The passthrough answers → the warmed runtime is genuinely serving.
+      // Hydrate the full status (model/canRespond) then advance exactly once.
+      await hydrateReadyAgentStatus(deps);
+      if (cancelled.current || effectRunRef.current !== effectRunId) return;
+      deps.setConnected(true);
+      deps.setFirstRunLoading(false);
+      logger.info(
+        "[eliza][startup:init] cloud-managed proxy passthrough is serving; agent ready",
+      );
+      dispatch({ type: "AGENT_RUNNING" });
+      return;
+    }
+
+    // Still warming (or a transient failure). Keep polling and — because the
+    // passthrough not-yet-serving IS the agent still starting — slide the
+    // deadline with an effective "starting" state so the warm window can extend
+    // up to the absolute max instead of tripping the initial timeout.
+    deps.setConnected(false);
+    deadline = computeAgentDeadlineExtensions({
+      agentWaitStartedAt: started,
+      agentDeadlineAt: deadline,
+      state: "starting",
+    });
+
     await new Promise<void>((r) => {
       tidRef.current = setTimeout(r, 500);
     });

--- a/packages/ui/src/state/startup-phase-runtime.ts
+++ b/packages/ui/src/state/startup-phase-runtime.ts
@@ -28,7 +28,8 @@ import type { RuntimeTarget, StartupEvent } from "./startup-coordinator";
 function isCapacitorNative(): boolean {
   try {
     const cap = (globalThis as Record<string, unknown>).Capacitor as
-      { isNativePlatform?: () => boolean } | undefined;
+      | { isNativePlatform?: () => boolean }
+      | undefined;
     return Boolean(cap?.isNativePlatform?.());
   } catch {
     return false;


### PR DESCRIPTION
## The bug

Every new cloud user got a broken-looking first few minutes. The startup coordinator declared the agent **ready** off the cloud **orchestrator/status** view — but that view lies during warm-up:

- `ElizaClient.getStatus()` for a direct shared-runtime base is a **client-side shim** that hardcodes `state:"running"` the instant the agent is *provisioned* (it never even hits the network — see `client-agent.ts`, the `isDirectCloudSharedAgentBase` short-circuit).
- The app actually talks to the agent through the **per-agent PROXY passthrough** `/api/v1/eliza/agents/<id>/api/*`, which keeps returning **404 "Agent not found"** for the first ~minutes while the container binds the runtime.

So the sequence was: coordinator flips `ready` → proxy calls 404 → the user is routed to `/character/select`, whose overview paints a washed/dimmed look. A broken-looking cold boot for every cloud user, and the `BootStatusIndicator` (#11739) never showed because routing bypassed the chat entirely.

## The fix

For an Eliza-**managed** cloud agent (persisted `kind:"cloud"`), stop trusting the shim. In `starting-runtime` we now poll the **genuine passthrough** — `GET /api/conversations` via `client.listConversations()`, which is *not* short-circuited by any shim — and only dispatch `AGENT_RUNNING` once it truly serves.

While it's still warming we **stay in `starting-runtime`**, which is exactly the booting chat + `BootStatusIndicator` / "connecting…" surface (confirmed via `useShellController` `booting` + `ContinuousChatOverlay`). Since character-select routing only runs after `AGENT_RUNNING → hydrating` (`startup-phase-hydrate.ts`), never flipping ready early is what keeps the user off the washed page.

Deadline handling mirrors the local boot loop: start on the web policy's 180s budget, then while the passthrough warms, slide the deadline with an effective `"starting"` state (`computeAgentDeadlineExtensions`) so a legit multi-minute warm isn't tripped as a timeout — **bounded by `AGENT_STARTUP_ABSOLUTE_MAX_MS` (900s)** so a genuinely stuck agent still lands on the friendly agent-timeout screen, never an infinite spinner.

## Cloud-scoped — shared code untouched

This startup/routing code is **shared with the desktop/mobile first-run**, so the gate is strictly `kind:"cloud"` (a pure `loadPersistedActiveServer()` localStorage read — written on every cloud entry path, never for `kind:"local"`):

- **desktop / mobile embedded-local** first-run → full boot/poll loop, unchanged.
- **self-hosted remote-backend** → immediate-ready, unchanged (it never goes through this passthrough).
- a `cloud-managed` target with no persisted cloud record → falls back to today's immediate-ready.

Only the managed-cloud path gains the passthrough confirmation.

## Tests

New co-located `startup-phase-runtime.cloud-warm.test.ts`:

- managed cloud + passthrough 404 while warming → stays in `starting-runtime`, never dispatches `AGENT_RUNNING`, never premature `AGENT_TIMEOUT` (deadline keeps sliding past 180s).
- managed cloud + passthrough serving → `AGENT_RUNNING` exactly once (+ a 404→404→serving progression case).
- **regression guards** for the shared-code constraint: `remote-backend` and `embedded-local` both advance exactly as before and never issue the cloud passthrough probe.

> Note: the local workspace here has an incomplete/unbuilt `node_modules` (unrelated missing deps like `@elizaos/cloud-routing`'s built entry) so the vitest suite couldn't execute locally against the full graph — but the changed files are type-clean (`tsgo --noEmit` reports zero errors in them) and the tests follow the existing suite's mocking patterns. **CI validates the run.**