### PR TITLE
fix(#12746): fallback-slop sweep — infra/connectivity plugins (non-route)

### DIFF
--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -1532,6 +1532,7 @@ async function resolveSingleShellTargetView({
 		explicit?.toLowerCase() === "current" ||
 		(!explicit && /\bcurrent\b/i.test(requestText))
 	) {
+		// error-policy:J4 current-view read over loopback; unreachable -> null -> resolve to "none"
 		const currentView = await client.getCurrentView().catch(() => null);
 		if (!currentView?.viewId) return { kind: "none" };
 		return {
@@ -2431,6 +2432,7 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 					return prefetchedViews;
 				};
 				const getCurrentView = async () => {
+					// error-policy:J4 current-view read over loopback; unreachable -> null -> resolver degrades to no current-view context
 					prefetchedCurrentView ??= await client
 						.getCurrentView()
 						.catch(() => null);

--- a/plugins/plugin-background-runner/__tests__/unit/bg-scheduler.test.ts
+++ b/plugins/plugin-background-runner/__tests__/unit/bg-scheduler.test.ts
@@ -4,6 +4,7 @@
  * Capacitor bridge or real OS scheduler.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { IBgTaskScheduler, ScheduleOptions } from '../../src';
 import {
   BACKGROUND_RUNNER_SERVICE_TYPE,
   BgTaskSchedulerService,
@@ -115,6 +116,55 @@ describe('plugin-background-runner: CapacitorBgScheduler', () => {
         onWake: async () => {},
       })
     ).rejects.toThrow(/outside Capacitor/);
+  });
+});
+
+describe('plugin-background-runner: onWake failure surfaces to the agent', () => {
+  // Captures the onWake callback wired at start() so a wake can be driven directly.
+  class CapturingScheduler implements IBgTaskScheduler {
+    readonly kind = 'interval' as const;
+    onWake: (() => Promise<void>) | null = null;
+    async schedule(options: ScheduleOptions): Promise<void> {
+      this.onWake = options.onWake;
+    }
+    async cancel(): Promise<void> {}
+    isScheduled(): boolean {
+      return this.onWake !== null;
+    }
+  }
+
+  class TestService extends BgTaskSchedulerService {
+    readonly capturing = new CapturingScheduler();
+    protected override async buildScheduler(): Promise<IBgTaskScheduler> {
+      return this.capturing;
+    }
+  }
+
+  test('a runDueTasks rejection is reported via runtime.reportError and re-thrown', async () => {
+    const reported: Array<{ scope: string; error: unknown }> = [];
+    const boom = new Error('task dispatch exploded');
+    const runtime = {
+      serverless: false,
+      reportError: (scope: string, error: unknown) => {
+        reported.push({ scope, error });
+      },
+      getService: () => ({
+        runDueTasks: async () => {
+          throw boom;
+        },
+      }),
+    } as unknown as ConstructorParameters<typeof TestService>[0];
+
+    const service = new TestService(runtime);
+    await service.start();
+    const onWake = service.capturing.onWake;
+    expect(onWake).not.toBeNull();
+
+    // The wake must reject (host stays aware) AND the failure must be reported.
+    await expect((onWake as () => Promise<void>)()).rejects.toBe(boom);
+    expect(reported.length).toBe(1);
+    expect(reported[0]?.scope).toBe('BgTaskSchedulerService.onWake');
+    expect(reported[0]?.error).toBe(boom);
   });
 });
 

--- a/plugins/plugin-background-runner/src/services/BgTaskSchedulerService.ts
+++ b/plugins/plugin-background-runner/src/services/BgTaskSchedulerService.ts
@@ -84,9 +84,10 @@ export class BgTaskSchedulerService extends Service {
   }
 
   /**
-   * Wake-up handler. Drives core's TaskService once, then returns. Errors
-   * surface — the host (Capacitor runner shim or interval) is responsible for
-   * logging; we re-throw to keep the failure observable.
+   * Wake-up handler. Drives core's TaskService once, then returns. A dispatch
+   * failure is reported to the agent (RECENT_ERRORS / owner escalation) so the
+   * background runner cannot silently stall, then re-thrown so the host
+   * (Capacitor runner shim or interval scheduler) also observes it.
    */
   private async onWake(): Promise<void> {
     const service = this.runtime.getService(ServiceType.TASK);
@@ -100,7 +101,15 @@ export class BgTaskSchedulerService extends Service {
       );
       return;
     }
-    await service.runDueTasks();
+    try {
+      await service.runDueTasks();
+    } catch (error) {
+      // error-policy:J2 add scope + surface the wake failure to the agent, then rethrow to the host
+      this.runtime.reportError('BgTaskSchedulerService.onWake', error, {
+        label: BgTaskSchedulerService.RUNNER_LABEL,
+      });
+      throw error;
+    }
   }
 
   /**

--- a/plugins/plugin-background-runner/src/services/IntervalBgScheduler.ts
+++ b/plugins/plugin-background-runner/src/services/IntervalBgScheduler.ts
@@ -30,6 +30,8 @@ export class IntervalBgScheduler implements IBgTaskScheduler {
     );
     this.currentLabel = options.label;
     this.timer = setInterval(() => {
+      // error-policy:J7 the interval must survive a failed wake; onWake already
+      // reported the failure to the agent via runtime.reportError, we log the host-side copy
       options.onWake().catch((error) => {
         elizaLogger.error(
           { err: error, label: options.label },

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
@@ -9,9 +9,12 @@
  * the exact response shapes the UI consumes.
  */
 
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
 import type { TranscriptSegment } from "@elizaos/shared/transcripts";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	handleDirectCoreRoute,
 	type IosBridgeBackend,
@@ -448,6 +451,105 @@ describe("iOS bridge — browser workspace routes", () => {
 			"/api/browser-workspace/tabs/nope/show",
 		);
 		expect(res.status).toBe(404);
+	});
+});
+
+describe("iOS bridge — conversation message failure surfacing", () => {
+	// A failed `createMemory` write is best-effort secondary persistence
+	// (error-policy:J6): it must not drop the reply, but the failure must surface
+	// observably (stderr) rather than be silently swallowed.
+	function createMessageServiceRuntime(
+		onCreateMemory: () => Promise<UUID>,
+	): IAgentRuntime {
+		return {
+			agentId: AGENT_ID,
+			character: { name: "Eliza" },
+			async ensureConnection(): Promise<void> {},
+			createMemory: onCreateMemory,
+			messageService: {
+				async handleMessage(
+					_runtime: IAgentRuntime,
+					_message: Memory,
+					onResponse: (content: { text?: string }) => Promise<unknown>,
+				): Promise<void> {
+					await onResponse({ text: "hello from the local agent" });
+				},
+			},
+		} as unknown as IAgentRuntime;
+	}
+
+	function seedConversation(backend: IosBridgeBackend, id: string): void {
+		backend.conversations.set(id, {
+			id,
+			title: "Test Chat",
+			roomId: "00000000-0000-0000-0000-0000000000cc" as UUID,
+			createdAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		});
+	}
+
+	// Point the local-inference state dir at an empty temp dir so no real
+	// on-disk model registry diverts the reply through the native-llama path;
+	// with zero installed models the deterministic messageService path runs.
+	let prevStateDir: string | undefined;
+	beforeEach(() => {
+		prevStateDir = process.env.ELIZA_STATE_DIR;
+		process.env.ELIZA_STATE_DIR = mkdtempSync(
+			path.join(tmpdir(), "ios-bridge-conv-"),
+		);
+	});
+	afterEach(() => {
+		if (prevStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+		else process.env.ELIZA_STATE_DIR = prevStateDir;
+		vi.restoreAllMocks();
+	});
+
+	it("surfaces a rejected createMemory to stderr but still returns the reply", async () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const runtime = createMessageServiceRuntime(() =>
+			Promise.reject(new Error("db offline")),
+		);
+		const backend = makeBackend(runtime);
+		seedConversation(backend, "conv-fail-1");
+
+		const { status, json } = await call(
+			backend,
+			"POST",
+			"/api/conversations/conv-fail-1/messages",
+			{ text: "hi there" },
+		);
+
+		// The reply is produced despite the persistence failure (J6 continues).
+		expect(status).toBe(200);
+		expect(json.reply).toBe("hello from the local agent");
+		// The failure is observable, not swallowed.
+		expect(errorSpy).toHaveBeenCalledWith(
+			"[ios-bridge] createMemory(messages) failed:",
+			"db offline",
+		);
+	});
+
+	it("does not log when createMemory succeeds", async () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const runtime = createMessageServiceRuntime(() =>
+			Promise.resolve(crypto.randomUUID() as UUID),
+		);
+		const backend = makeBackend(runtime);
+		seedConversation(backend, "conv-ok-1");
+
+		const { status, json } = await call(
+			backend,
+			"POST",
+			"/api/conversations/conv-ok-1/messages",
+			{ text: "hi there" },
+		);
+
+		expect(status).toBe(200);
+		expect(json.reply).toBe("hello from the local agent");
+		expect(errorSpy).not.toHaveBeenCalledWith(
+			"[ios-bridge] createMemory(messages) failed:",
+			expect.anything(),
+		);
 	});
 });
 

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -588,6 +588,8 @@ async function startIosBridgeBackend(): Promise<IosBridgeBackend> {
 		dispatchRoute,
 		conversations: new Map(),
 		close: async () => {
+			// error-policy:J6 best-effort teardown — the backend is shutting down; a
+			// failed unload cannot be acted on and must not block close.
 			await unloadNativeLlamaModel().catch(() => undefined);
 		},
 	};
@@ -670,6 +672,10 @@ function ensureIosBridgeBackendStarted(
 			throw error;
 		},
 	);
+	// error-policy:J5 the boot failure is observed via `host.bootError` (set in
+	// the rejection handler above) and rethrown to every `awaitIosBridgeBackend`
+	// caller; this catch only silences the unhandled-rejection warning on the
+	// cached promise handle.
 	host.backendPromise.catch(() => {
 		return undefined;
 	});
@@ -2427,6 +2433,8 @@ async function unloadNativeLlamaModel(): Promise<void> {
 	nativeLlamaState.loadedAt = null;
 	nativeLlamaState.status = "idle";
 	if (contextId != null) {
+		// error-policy:J6 best-effort teardown — the local state is already reset
+		// above; a failed native free must not leave unload half-done.
 		await callIosHost("llama_free", { context_id: contextId }, 30_000).catch(
 			() => undefined,
 		);
@@ -2699,8 +2707,16 @@ function installKeepAwakeBridge(): void {
 	g.__ELIZA_BRIDGE__ = g.__ELIZA_BRIDGE__ ?? {};
 	if (typeof g.__ELIZA_BRIDGE__.keep_awake_set === "function") return;
 	g.__ELIZA_BRIDGE__.keep_awake_set = (enabled: unknown): boolean => {
+		// error-policy:J5 fire-and-forget native hint; the WebView contract returns
+		// synchronously, but a rejected host call is surfaced to stderr (stdout is
+		// the reserved bridge protocol channel) instead of being silently dropped.
 		void callIosHost("keep_awake_set", { enabled: Boolean(enabled) }).catch(
-			() => undefined,
+			(error) => {
+				console.error(
+					"[ios-bridge] keep_awake_set failed:",
+					error instanceof Error ? error.message : String(error),
+				);
+			},
 		);
 		return true;
 	};
@@ -2756,6 +2772,15 @@ async function nativeHardwareInfo(): Promise<Record<string, unknown>> {
 			? (result as Record<string, unknown>)
 			: {};
 	} catch (error) {
+		// error-policy:J4 native hardware-info IPC unavailable → a designed
+		// "unknown hardware" degrade whose `error` field carries the failure.
+		// Surfaced observably to stderr (stdout is the bridge protocol channel) so
+		// the IPC failure is not silent; RAM-gating callers treat the zeroed
+		// reading as "cannot verify" rather than a genuine zero.
+		console.error(
+			"[ios-bridge] hardware info unavailable:",
+			error instanceof Error ? error.message : String(error),
+		);
 		return {
 			backend: "unknown",
 			total_ram_gb: 0,
@@ -3086,6 +3111,9 @@ function startNativeModelDownload(modelId: string): NativeDownloadJob {
 		updatedAt: now,
 	};
 	nativeDownloadState.set(model.id, job);
+	// error-policy:J5 fire-and-forget; runNativeModelDownload records failure on
+	// the job (state:"failed" + error message) which the WebView polls via the
+	// download-status route, so this only suppresses the detached-promise warning.
 	void runNativeModelDownload(model).catch(() => {});
 	return job;
 }
@@ -3770,8 +3798,14 @@ async function handleDirectConversationMessage(
 
 	try {
 		await runtime.createMemory?.(message, "messages");
-	} catch {
-		// Best effort. Some adapters persist inside messageService.
+	} catch (error) {
+		// error-policy:J6 best-effort secondary persistence — some adapters already
+		// persist the message inside messageService; a duplicate/failed write here
+		// must not drop the reply, but the failure is surfaced to stderr.
+		console.error(
+			"[ios-bridge] createMemory(messages) failed:",
+			error instanceof Error ? error.message : String(error),
+		);
 	}
 
 	// Track cumulative streamed text so incremental model chunks accumulate into

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -2085,6 +2085,9 @@ function registerMobileDeviceBridgeModels(
 		!resolveLocalLoadArgs("TEXT_SMALL") &&
 		process.env.ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD?.trim() !== "1"
 	) {
+		// error-policy:J5 fire-and-forget pre-warm; the failure is surfaced via
+		// logger.warn and the real generate() call retries the download on demand
+		// (same idempotency guard), so registration must not block on it.
 		downloadRecommendedModelFor("TEXT_SMALL").catch((err) =>
 			logger.warn(
 				`[mobile-device-bridge] Background chat-model download failed: ${(err as Error).message}`,
@@ -2125,6 +2128,9 @@ function registerMobileDeviceBridgeModels(
 	) {
 		// Kick off the embedding-model download in the background so it's
 		// ready by the time the WebView issues a real embed request.
+		// error-policy:J5 fire-and-forget pre-warm; surfaced via logger.warn and the
+		// first real embed request re-triggers the download, so registration of the
+		// TEXT_EMBEDDING handler must not block on it.
 		downloadRecommendedModelFor("TEXT_EMBEDDING").catch((err) =>
 			logger.warn(
 				`[mobile-device-bridge] Background embedding-model download failed: ${(err as Error).message}`,

--- a/plugins/plugin-elizacloud/__tests__/unit/cloud-voice-catalog.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/cloud-voice-catalog.test.ts
@@ -16,7 +16,8 @@
  * `createElizaCloudClient`. After each test we restore the factory.
  */
 import type { IAgentRuntime } from "@elizaos/core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { logger } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   type CloudVoiceClient,
@@ -271,18 +272,24 @@ describe("fetchCloudVoiceCatalog", () => {
     expect(calls.user).toBe(2);
   });
 
-  it("isolates per-endpoint failures — one endpoint erroring still returns the other's voices", async () => {
+  it("isolates per-endpoint failures — one endpoint erroring still returns the other's voices and warns", async () => {
     const { client } = makeFakeClient({
       premade: PREMADE_VOICES_PAYLOAD,
       userError: new Error("user endpoint down"),
     });
     setCloudVoiceClientFactoryForTesting(() => client);
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 
     const voices = await fetchCloudVoiceCatalog(makeRuntime());
-    // Only premade voices come back; the user endpoint failure is swallowed.
+    // Only premade voices come back; the user endpoint failure degrades to
+    // empty for that endpoint only.
     expect(voices.map((v) => v.id).sort()).toEqual(
       ["21m00Tcm4TlvDq8ikWAM", "EXAVITQu4vr4xnSDxMaL", "minimal-id-voice"].sort()
     );
+    // The failed endpoint must surface observably — not be silently swallowed
+    // as an empty list (error-policy: "not loaded" must never read as "empty").
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("user endpoint down"));
+    warnSpy.mockRestore();
   });
 
   it("returns empty array when both endpoints fail", async () => {

--- a/plugins/plugin-elizacloud/src/cloud-voice-catalog.ts
+++ b/plugins/plugin-elizacloud/src/cloud-voice-catalog.ts
@@ -202,8 +202,11 @@ async function fetchEndpointVoices(
     }
     return normalized;
   } catch (err) {
+    // error-policy:J4 one endpoint degrades to empty so the other still
+    // populates the catalog (see fetchCloudVoiceCatalog); warn so a sustained
+    // upstream outage is visible rather than buried as a silently-empty list.
     const message = err instanceof Error ? err.message : String(err);
-    logger.debug(
+    logger.warn(
       `[ELIZAOS_CLOUD] voice catalog ${endpoint} fetch failed: ${message}`,
     );
     return [];

--- a/plugins/plugin-elizacloud/src/lib/cloud-connection.ts
+++ b/plugins/plugin-elizacloud/src/lib/cloud-connection.ts
@@ -340,9 +340,13 @@ async function fetchCloudCreditsByApiKey(
   }
 
   const creditResponse = (await response.json().catch((err: unknown) => {
-    console.warn(
-      "[cloud-connection] Failed to parse credit balance response JSON:",
-      err,
+    // error-policy:J3 untrusted upstream body; unparseable JSON becomes an
+    // empty shape so balance resolves to null and surfaces as "unexpected
+    // response" / the HTTP-status error below — never a fabricated balance.
+    logger.warn(
+      `[cloud-connection] Failed to parse credit balance response JSON: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
     );
     return {};
   })) as {

--- a/plugins/plugin-elizacloud/src/lib/config-env.ts
+++ b/plugins/plugin-elizacloud/src/lib/config-env.ts
@@ -112,6 +112,9 @@ let writeChain: Promise<unknown> = Promise.resolve();
 
 function serialise<T>(fn: () => Promise<T>): Promise<T> {
   const next = writeChain.then(fn, fn);
+  // error-policy:J5 the returned `next` is where the caller observes this
+  // rejection; the chain copy is swallowed only so one failed write does not
+  // poison the serialisation of subsequent writes.
   writeChain = next.catch(() => undefined);
   return next;
 }

--- a/plugins/plugin-task-coordinator/src/register.ts
+++ b/plugins/plugin-task-coordinator/src/register.ts
@@ -5,6 +5,7 @@
  * (the Node agent / terminal host), lazily registers the two tri-modal views
  * into the terminal registry so they render inline in the terminal.
  */
+import { logger } from "@elizaos/core";
 import "./register-slots.js";
 
 // In a terminal host (the Node agent, no DOM), register the unified
@@ -16,7 +17,14 @@ if (typeof window === "undefined") {
       m.registerOrchestratorTerminalView();
       m.registerTaskCoordinatorTerminalView();
     })
-    .catch(() => {
-      // Terminal rendering is best-effort; never block plugin load.
+    .catch((err: unknown) => {
+      // error-policy:J4 terminal rendering is best-effort and must not block
+      // plugin load, but the failure must be visible — the two views silently
+      // not rendering in the terminal is otherwise indistinguishable from idle.
+      logger.warn(
+        `[task-coordinator] Failed to register terminal views: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
     });
 }


### PR DESCRIPTION
## Summary

Completes the fallback-slop long-tail sweep for the infra/connectivity plugins (#12746, parent #12182). Per the issue's explicit requirement, background-runner / native-bridge / cloud-connectivity failures now surface observably instead of masquerading as idle/empty/success.

### Behavior fixes
- **plugin-background-runner** (`BgTaskSchedulerService.onWake`): a `runDueTasks` rejection is now `runtime.reportError`-reported **and** re-thrown — a broken scheduled-task run surfaces to agent/owner instead of a silently-swallowed background tick.
- **plugin-capacitor-bridge** (iOS JSON-RPC bridge): three fully-swallowed native rejections now emit an observable **stderr** diagnostic — `keep_awake_set`, the `nativeHardwareInfo` IPC failure (designed unknown-hardware J4 degrade kept but now logged), and the `handleDirectConversationMessage` `createMemory` write. Logging goes to **stderr, not the `@elizaos/core` logger, by design**: stdout is the reserved JSON-RPC protocol channel on both the android and iOS bridges.
- **plugin-elizacloud** (`cloud-voice-catalog`): a failed per-endpoint SDK route now surfaces via `logger.warn` (upstream error observable) rather than silently degrading to an empty catalog.

### Annotations (justified keeps, grep-able `// error-policy:J<N>`)
capacitor-bridge teardown/fire-and-forget paths (J5/J6, each naming where the rejection is observed), app-control loopback-read heuristics (J4), task-coordinator/elizacloud best-effort paths.

## Validation
- **Real failure-path tests added and PASSING locally**: `plugin-background-runner` bg-scheduler (runDueTasks reject → reportError + rethrow — 0 fail), `plugin-capacitor-bridge` bridge.routes (createMemory reject → diagnostic, reply still returned — **17/17**), `plugin-elizacloud` cloud-voice-catalog (endpoint reject → observable warn, not silent empty — **9/9**).
- `node packages/scripts/error-policy-ratchet.mjs` → **`no new fallback-slop in touched files`**.
- `bunx @biomejs/biome check` on changed files → clean.

### Flagged for follow-up (out of fabricating-catch scope)
`plugin-elizacloud/src/services/cloud-container.ts` `startPolling()` schedules `poll()` via `setTimeout` with no error handler — a transient `getContainer()` rejection becomes an unhandled rejection that silently stops deployment tracking (a missing-handler design gap, not a fabricating catch).

## Evidence rows
- Real-LLM trajectory — N/A (infra/connectivity error-handling; failure-path tests exercise the real reject paths). Screenshots/video — N/A (no UI-render change).

Closes #12746.

🤖 Generated with [Claude Code](https://claude.com/claude-code)