### PR TITLE
fix(app): remove stale launch trust override

### DIFF
--- a/packages/app/src/deep-link-handler.ts
+++ b/packages/app/src/deep-link-handler.ts
@@ -199,7 +199,6 @@ export function createDeepLinkHandler(ctx: DeepLinkHandlerContext) {
       kind: "remote",
       apiBase: validatedUrl.href,
       token: null,
-      allowPublicHttps: true,
     });
     dispatchAppEvent(CONNECT_EVENT, {
       gatewayUrl: connection.apiBase,

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1710,7 +1710,6 @@ function connectFirstRunRemoteDeepLink(rawApiBase: string): void {
     kind: "remote",
     apiBase: validatedUrl.href,
     token: null,
-    allowPublicHttps: true,
   });
   const dispatchConnect = () => {
     dispatchAppEvent(CONNECT_EVENT, {
@@ -1858,7 +1857,6 @@ function handleDeepLink(url: string): void {
             kind: "remote",
             apiBase: validatedUrl.href,
             token: null,
-            allowPublicHttps: true,
           });
           dispatchAppEvent(CONNECT_EVENT, {
             gatewayUrl: connection.apiBase,


### PR DESCRIPTION
## Summary
- remove the deleted `allowPublicHttps` option from app deep-link launch call sites after #13301
- keeps `packages/app` compiling against the unified remote runtime trust API

## Validation
- `bunx @biomejs/biome check packages/app/src/main.tsx packages/app/src/deep-link-handler.ts packages/ui/src/App.tsx packages/ui/src/components/cockpit/MyRuntimesContainer.test.tsx packages/ui/src/components/cockpit/MyRuntimesContainer.tsx packages/ui/src/platform/browser-launch.test.ts packages/ui/src/platform/browser-launch.ts packages/ui/src/state/AppContext.tsx packages/ui/src/state/runtime-url-trust.ts packages/ui/src/state/startup-phase-restore.trust.test.ts packages/ui/src/state/startup-phase-restore.ts packages/ui/src/state/switch-runtime.test.ts packages/ui/src/state/switch-runtime.ts packages/ui/src/state/use-startup-shell-controller.ts`
- `bun run --cwd packages/ui test -- src/platform/browser-launch.test.ts src/state/startup-phase-restore.trust.test.ts src/state/switch-runtime.test.ts`
- `bun run --cwd packages/app typecheck 2>&1 | rg "allowPublicHttps|deep-link-handler\.ts|main\.tsx\(1713|main\.tsx\(1861|browser-launch" || true` — no stale option diagnostics; only unrelated `lucide-react` declaration output when filtering browser-launch

## Local blockers
- `bun run --cwd packages/app test -- src/deep-link-handler.test.ts` does not load in this sparse install: Vite cannot resolve `@elizaos/capacitor-bun-runtime` from `packages/ui/src/api/ios-local-agent-transport.ts`.
- `bun run --cwd packages/app audit:app` stops before screenshots because the sparse checkout lacks `plugins/plugin-native-contacts/src/index.ts`, which `plugins/plugin-contacts` imports during view build.
