### PR TITLE
feat(#12772): B2 shift-rotation scenario-runner pack

### DIFF
--- a/packages/scenario-runner/src/corpus-assertion-guard.test.ts
+++ b/packages/scenario-runner/src/corpus-assertion-guard.test.ts
@@ -292,6 +292,15 @@ const EXPECTED_PR_DETERMINISTIC_SCENARIO_IDS = [
   "reminder.escalation.intensity-up",
   "reminder.escalation.silent-dismiss",
   "remote-desktop.list-sessions",
+  // LifeOps persona pack B2 (shift-rotation, marcus_shift, #12772). Convention
+  // (G1): pr-deterministic persona scenarios live in
+  // plugins/plugin-personal-assistant/test/scenarios — the one root scanned by
+  // BOTH this guard AND check-lifeops-persona-catalog-coverage.mjs — and are
+  // added here in the same commit so this toEqual stays green while the coverage
+  // ledger can still resolve their ids.
+  "shift-rotation-reanchor-protects-new-sleep-window",
+  "shift-rotation-sleep-protection-holds-low-priority-nudge",
+  "shift-rotation-wake-anchor-follows-shifted-window",
   "shopify.list-products",
   "suno.generate-music",
   "task-coordinator.orchestrator-status",

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/shift-rotation.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/shift-rotation.catalog.json
@@ -12,5 +12,54 @@
       "status flips planned -> authored once the scenario file/literal exists; -> verified once a real-LLM run has been captured and hand-reviewed per PR_EVIDENCE.md."
     ]
   },
-  "scenarios": []
+  "scenarios": [
+    {
+      "id": "shift-rotation-reanchor-protects-new-sleep-window",
+      "pack": "B2",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "pr-deterministic (keyless). Real scheduler tick: a during_window:morning habit is re-anchored by the night-rotation owner facts so it stays silent at the pre-rotation 08:00 slot (now protected daytime sleep) and fires at the shifted 15:30 waking window, while a quiet_hours-gated companion defers with a derived reason; two deliveries, none inside protected sleep. Passes keyless under TZ=UTC SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 --conditions eliza-source (#12772)."
+    },
+    {
+      "id": "shift-rotation-sleep-protection-holds-low-priority-nudge",
+      "pack": "B2",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "pr-deterministic (keyless). Real scheduler tick inside the protected post-night-shift sleep block (quiet_hours 06:00-15:00): a low-priority ping defers with a derived quiet_hours reason while a high-priority reminder bypasses (highPriorityBypass) and fires once; single-delivery finalCheck. Passes keyless under TZ=UTC + --conditions eliza-source (#12772)."
+    },
+    {
+      "id": "shift-rotation-wake-anchor-follows-shifted-window",
+      "pack": "B2",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "pr-deterministic (keyless). Real scheduler tick: a relative_to_anchor:wake.confirmed+30m reminder re-anchors off the shifted morningWindow.start (15:00), so it is anchor_pending at the old 07:30 wake slot and fires once at the re-anchored 15:30; single-delivery finalCheck. Passes keyless under TZ=UTC + --conditions eliza-source (#12772)."
+    },
+    {
+      "id": "shift-rotation-swap-reanchors-and-checks-in",
+      "pack": "B2",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "live-only, tick-driving. Live judge grades a gentle, schedule-literate check-in on the swap onto nights (no re-entry demand, no sleep shaming); a real lifeops_scheduler tick proves the seeded routine stays silent inside protected daytime sleep and fires at the shifted waking window. Live-model trajectory is the remaining evidence gate (no model credentials in this environment)."
+    },
+    {
+      "id": "shift-rotation-capture-new-shift-pattern",
+      "pack": "B2",
+      "tier": "T1",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "live-only capture. 'On nights starting Monday' -> a daily patient-handoff reminder anchored to his post-shift hour; non-echo definitionCountDelta with forbiddenDueLocalTimes proving it is NOT scheduled into his protected 06:00-14:00 daytime sleep. Live-model trajectory is the remaining evidence gate."
+    },
+    {
+      "id": "shift-rotation-sleep-window-conflict-requires-confirm",
+      "pack": "B2",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "live-only adversarial fail-closed. Ports the bench exemplar live.shiftrotation.sleep_protection_violation_requires_confirm: a 10am booking lands in protected post-night sleep; the assistant must flag the conflict, ask for an explicit override, offer an alternative, and create nothing (forbiddenActions + no-calendar-create + definitionCountDelta delta:0 + no external dispatch). Live-model trajectory is the remaining evidence gate."
+    }
+  ]
 }

--- a/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-capture-new-shift-pattern.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-capture-new-shift-pattern.scenario.ts
@@ -1,0 +1,135 @@
+/**
+ * B2 shift-rotation (live-only, T1 capture). The rotating-shift persona (P3
+ * marcus_shift) states his new rotation in his own schedule-literate voice ("on
+ * nights starting Monday") and asks for a post-shift routine reminder. The
+ * assistant must EXTRACT a structured recurring reminder anchored to his shift
+ * hours — not park it at a naive clock default and not schedule it inside the
+ * daytime sleep his night shift protects. Conversational competence is graded by
+ * a live judge; the capture is proved STRUCTURALLY by a definition-count delta
+ * that requires the reminder to exist and to avoid his protected sleep window.
+ *
+ * Non-echo: the graded structural token is the created definition's due-local
+ * time (it must NOT land in his 06:00–14:00 daytime sleep) — a derived schedule
+ * fact he never states as a due time, so an echo of his words cannot satisfy it.
+ * The seeded owner facts establish the protected daytime sleep so the "not during
+ * sleep" check is meaningful.
+ *
+ * Live gate: needs a live model for the capture turn; its per-scenario
+ * live-model trajectory is the remaining evidence gate (captured where model
+ * credentials are available, per PR_EVIDENCE.md).
+ */
+
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+async function seedNightSleepFacts(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  const { resolveOwnerFactStore } = await import(
+    "@elizaos/plugin-personal-assistant/plugin"
+  );
+  const store = resolveOwnerFactStore(
+    ctx.runtime as unknown as Parameters<typeof resolveOwnerFactStore>[0],
+  );
+  // Night shift: waking window in the evening/night; protected sleep is the
+  // daytime block. This is what a shift-aware capture must avoid scheduling into.
+  await store.update(
+    {
+      timezone: "UTC",
+      morningWindow: { startLocal: "16:00", endLocal: "19:00" },
+      eveningWindow: { startLocal: "23:00", endLocal: "05:00" },
+      quietHours: { startLocal: "06:00", endLocal: "14:00", timezone: "UTC" },
+    },
+    { source: "profile_save", recordedAt: new Date().toISOString() },
+  );
+  return undefined;
+}
+
+export default scenario({
+  lane: "live-only",
+  id: "shift-rotation-capture-new-shift-pattern",
+  title:
+    "Capture a shift-aware post-clock-out reminder from a plain 'on nights starting Monday' statement, never scheduling it into protected daytime sleep",
+  domain: "lifeops",
+  tags: [
+    "lifeops",
+    "shift-rotation",
+    "personas",
+    "reminders",
+    "capture",
+    "outcome",
+    "12772",
+  ],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-personal-assistant"],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "seed night-shift owner facts (protected daytime sleep)",
+      apply: seedNightSleepFacts,
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      title: "Shift Rotation Capture",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "capture-shift-aware-reminder",
+      room: "main",
+      text: "I'm on nights starting Monday — I clock out at 07:30. Set me a daily reminder to log my patient-handoff notes about an hour after I get off, and don't put it in the middle of my sleep.",
+      // The reminder is anchored to his post-shift hour, not a wall-clock guess;
+      // the assistant must confirm the capture without claiming it also already
+      // notified anyone.
+      responseJudge: {
+        minimumScore: 0.7,
+        rubric:
+          "The reply must confirm a daily patient-handoff-notes reminder anchored to about an hour after his 07:30 clock-out (i.e. in his post-shift morning, ~08:30), explicitly respecting that his sleep is during the day. It must NOT propose a mid-day time that lands in his daytime sleep, must NOT ask him to re-enter his whole schedule, and must NOT claim it has already logged or sent the notes. A generic 'reminder created' with no shift awareness, or one scheduled into his sleep, fails.",
+      },
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "log patient-handoff notes",
+      titleAliases: [
+        "patient handoff notes",
+        "handoff notes",
+        "patient-handoff notes",
+        "log handoff notes",
+      ],
+      delta: 1,
+      cadenceKind: "daily",
+      // Non-echo structural proof: the created reminder must NOT be due inside
+      // his protected daytime sleep (06:00–14:00). His clock-out (07:30) and the
+      // requested "~an hour after" (~08:30) fall in his post-shift waking
+      // window, so a correct capture avoids these forbidden daytime-sleep hours.
+      forbiddenDueLocalTimes: [
+        { hour: 9, timeZone: "UTC" },
+        { hour: 10, timeZone: "UTC" },
+        { hour: 11, timeZone: "UTC" },
+        { hour: 12, timeZone: "UTC" },
+        { hour: 13, timeZone: "UTC" },
+      ],
+      expectedTimeZone: "UTC",
+    },
+    {
+      type: "memoryWriteOccurred",
+      table: "messages",
+      minCount: 1,
+    },
+    {
+      type: "judgeRubric",
+      name: "shift-capture-anchoring",
+      minimumScore: 0.7,
+      rubric:
+        "End-to-end: the assistant captured a daily reminder anchored to Marcus's post-shift hour rather than a wall-clock default, kept it out of his protected daytime sleep, and did not claim to have already performed the handoff itself.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-reanchor-protects-new-sleep-window.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-reanchor-protects-new-sleep-window.scenario.ts
@@ -1,0 +1,428 @@
+/**
+ * B2 shift-rotation (pr-deterministic). Deterministic ScheduledTask proof of the
+ * core rotating-shift (P3 marcus_shift) mechanic: after the owner rotates onto a
+ * night shift, a recurring habit reminder is RE-ANCHORED to the shifted waking
+ * window and NEVER fires inside the newly-protected daytime sleep block. Drives
+ * the REAL scheduler tick (logical clock, no LLM, no key) and asserts STRUCTURAL
+ * outcomes (which occurrence of the SAME task fires at which clock instant under
+ * the rotated owner facts), not routing. Maps to LifeOpsBench
+ * shiftrotation.reanchor_recurring_reminders_to_new_shift; the live conversational
+ * capture of the same intent stays on the bench + live-only scenario-runner
+ * surface.
+ *
+ * A single `during_window: morning` habit carries the proof. Its firing window is
+ * read LIVE from owner facts at every tick (`due.ts` / `windowBoundsMinutes`
+ * reads `ownerFacts.morningWindow` per evaluation), so seeding the night-rotation
+ * facts (waking "morning" 15:00–18:00; protected daytime sleep as quiet-hours
+ * 06:00–15:00) re-anchors the habit without touching the task literal. At the
+ * PRE-rotation waking instant (08:00 — the slot this habit used to fire on under
+ * a day shift) the habit is now SILENT because 08:00 falls inside the protected
+ * sleep block; at the shifted waking window (15:30) it FIRES. A companion
+ * quiet_hours-gated reminder DEFERS at 08:00 with a derived gate reason, proving
+ * the daytime sleep block is protected. Non-echo: the asserted tokens are fire
+ * STATUS and the derived `quiet_hours: deferring …` reason, never text from a
+ * turn.
+ *
+ * The single-run design mirrors persona.flexible-scheduling: owner facts are
+ * seeded once through the REAL OwnerFactStore (the scenario runner has no
+ * mid-run owner-fact mutation lever), tasks are created through the REAL REST
+ * surface, and delivery goes through a scenario-registered always-delivering
+ * channel. The "day shift → night shift" transition is realized by seeding the
+ * post-rotation facts and asserting the SAME habit no longer fires on the old
+ * waking slot; the pre-rotation baseline (a day-shift 08:00 fire) is proved by
+ * persona.flexible-scheduling's during_window fire against a 07:00–10:00 morning.
+ * Run keyless with `TZ=UTC` so window math is unambiguous.
+ *
+ * Fail-without-fix anchors:
+ *   - Make `during_window` dueness read a persisted/cached window instead of live
+ *     owner facts in `plugins/plugin-scheduling/src/scheduled-task/due.ts`
+ *     (`windowBoundsMinutes`) and the habit fires at the 08:00 tick inside the
+ *     protected sleep block — the "does NOT fire" turn fails and the delivery
+ *     ledger grows past one.
+ *   - Revert the `quiet_hours` gate's live read of `ownerFacts.quietHours` in
+ *     `plugins/plugin-scheduling/src/scheduled-task/gate-registry.ts` and the
+ *     protected-sleep companion reminder fires during the daytime sleep block —
+ *     the "defers with quiet_hours reason" turn fails.
+ */
+
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+type JsonRecord = Record<string, unknown>;
+
+const SCENARIO_ID = "shift-rotation-reanchor-protects-new-sleep-window";
+const DELIVERY_CHANNEL_KIND = "scenario_shift_reanchor_delivery";
+
+// ---------------------------------------------------------------------------
+// Fixed logical clock, far in the future so ONLY the injected tick `now` decides
+// dueness. UTC throughout so window math is unambiguous. Post-rotation (night)
+// owner facts: waking "morning" 15:00–18:00; protected daytime sleep as
+// quiet-hours 06:00–15:00. 08:00 is the pre-rotation waking slot, now inside
+// protected sleep; 15:30 is inside the shifted waking window.
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function futureDateAtUtc(
+  hour: number,
+  minute: number,
+  daysAhead: number,
+): Date {
+  const base = new Date(Date.now() + daysAhead * DAY_MS);
+  base.setUTCHours(hour, minute, 0, 0);
+  return base;
+}
+
+// 08:00 — the pre-rotation waking slot, now inside the protected daytime sleep.
+const OLD_MORNING_TICK = futureDateAtUtc(8, 0, 2);
+// 15:30 — inside the shifted (post-rotation) waking window.
+const NEW_MORNING_TICK = futureDateAtUtc(15, 30, 2);
+
+interface ChannelContributionLike {
+  kind: string;
+  describe: { label: string };
+  capabilities: {
+    send: boolean;
+    read: boolean;
+    reminders: boolean;
+    voice: boolean;
+    attachments: boolean;
+    quietHoursAware: boolean;
+  };
+  send?(payload: unknown): Promise<{ ok: true; messageId: string }>;
+}
+
+interface ChannelRegistryLike {
+  register(contribution: ChannelContributionLike): void;
+  get(kind: string): ChannelContributionLike | null;
+}
+
+interface RuntimeLike {
+  channelRegistry?: ChannelRegistryLike;
+}
+
+const deliveryLedger: unknown[] = [];
+
+// assertResponse receives only (status, body) — captured ids live in module
+// state, reset by the seed (mirrors persona.flexible-scheduling).
+const capturedTaskIds: { habit: string | null; sleepGuard: string | null } = {
+  habit: null,
+  sleepGuard: null,
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function seedNightRotationFactsAndChannel(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  deliveryLedger.length = 0;
+  capturedTaskIds.habit = null;
+  capturedTaskIds.sleepGuard = null;
+  const runtime = ctx.runtime as RuntimeLike;
+
+  const registry = runtime.channelRegistry;
+  if (!registry || typeof registry.register !== "function") {
+    return "PA channel registry is not attached to the scenario runtime";
+  }
+  if (!registry.get(DELIVERY_CHANNEL_KIND)) {
+    registry.register({
+      kind: DELIVERY_CHANNEL_KIND,
+      describe: { label: "Scenario shift re-anchor delivery probe" },
+      capabilities: {
+        send: true,
+        read: false,
+        reminders: true,
+        voice: false,
+        attachments: false,
+        quietHoursAware: false,
+      },
+      async send(payload: unknown): Promise<{ ok: true; messageId: string }> {
+        deliveryLedger.push(payload);
+        return {
+          ok: true,
+          messageId: `${SCENARIO_ID}-delivered-${deliveryLedger.length}`,
+        };
+      },
+    });
+  }
+
+  const { resolveOwnerFactStore } = await import(
+    "@elizaos/plugin-personal-assistant/plugin"
+  );
+  const store = resolveOwnerFactStore(
+    ctx.runtime as unknown as Parameters<typeof resolveOwnerFactStore>[0],
+  );
+  // Post-rotation (night) owner facts. Waking "morning" is the afternoon; the
+  // protected sleep block covers the pre-rotation waking slot (08:00).
+  await store.update(
+    {
+      timezone: "UTC",
+      morningWindow: { startLocal: "15:00", endLocal: "18:00" },
+      eveningWindow: { startLocal: "23:00", endLocal: "05:00" },
+      quietHours: { startLocal: "06:00", endLocal: "15:00", timezone: "UTC" },
+    },
+    { source: "profile_save", recordedAt: new Date().toISOString() },
+  );
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Tick response readers.
+// ---------------------------------------------------------------------------
+
+interface FireEntry {
+  taskId: string;
+  status: string;
+  reason: string;
+}
+
+function readFires(body: unknown): FireEntry[] | string {
+  if (!isRecord(body) || body.success !== true) {
+    return `expected tick success=true, saw ${JSON.stringify(body)}`;
+  }
+  const raw = body.scheduledTaskFires;
+  if (!Array.isArray(raw)) return "expected scheduledTaskFires array";
+  const fires: FireEntry[] = [];
+  for (const entry of raw) {
+    if (
+      !isRecord(entry) ||
+      typeof entry.taskId !== "string" ||
+      typeof entry.status !== "string" ||
+      typeof entry.reason !== "string"
+    ) {
+      return `malformed scheduledTaskFires entry: ${JSON.stringify(entry)}`;
+    }
+    fires.push({
+      taskId: entry.taskId,
+      status: entry.status,
+      reason: entry.reason,
+    });
+  }
+  return fires;
+}
+
+function firesForTask(
+  body: unknown,
+  taskId: string | null,
+): FireEntry[] | string {
+  const fires = readFires(body);
+  if (typeof fires === "string") return fires;
+  if (typeof taskId !== "string" || taskId.length === 0) {
+    return "captured taskId was not set by the create turn";
+  }
+  return fires.filter((fire) => fire.taskId === taskId);
+}
+
+function captureTaskId(
+  slot: keyof typeof capturedTaskIds,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    if (!isRecord(body) || !isRecord(body.task)) {
+      return `expected {task} response, saw ${JSON.stringify(body)}`;
+    }
+    const task = body.task;
+    if (typeof task.taskId !== "string" || task.taskId.length === 0) {
+      return `expected task.taskId string, saw ${JSON.stringify(task.taskId)}`;
+    }
+    capturedTaskIds[slot] = task.taskId;
+    return undefined;
+  };
+}
+
+function firedFor(
+  slot: keyof typeof capturedTaskIds,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    const fires = firesForTask(body, capturedTaskIds[slot]);
+    if (typeof fires === "string") return fires;
+    if (fires.length !== 1 || fires[0]?.status !== "fired") {
+      return `expected exactly one fired for ${slot}, saw ${JSON.stringify(fires)}`;
+    }
+    return undefined;
+  };
+}
+
+function notFiredFor(
+  slot: keyof typeof capturedTaskIds,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    const fires = firesForTask(body, capturedTaskIds[slot]);
+    if (typeof fires === "string") return fires;
+    const fired = fires.filter((f) => f.status === "fired");
+    if (fired.length !== 0) {
+      return `expected ${slot} NOT to fire inside protected sleep, saw ${JSON.stringify(fired)}`;
+    }
+    return undefined;
+  };
+}
+
+function deferredFor(
+  slot: keyof typeof capturedTaskIds,
+  reasonPrefix: string,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    const fires = firesForTask(body, capturedTaskIds[slot]);
+    if (typeof fires === "string") return fires;
+    const fired = fires.filter((f) => f.status === "fired");
+    if (fired.length !== 0) {
+      return `expected ${slot} to defer, not fire, saw ${JSON.stringify(fired)}`;
+    }
+    const deferred = fires.find((f) => f.reason.includes(reasonPrefix));
+    if (!deferred) {
+      return `expected ${slot} deferred with reason ~"${reasonPrefix}", saw ${JSON.stringify(fires)}`;
+    }
+    return undefined;
+  };
+}
+
+export default scenario({
+  id: "shift-rotation-reanchor-protects-new-sleep-window",
+  lane: "pr-deterministic",
+  title:
+    "Shift rotation re-anchors a habit reminder to the shifted waking window and never fires it inside the newly-protected sleep block",
+  domain: "lifeops",
+  tags: [
+    "pr",
+    "deterministic",
+    "zero-cost",
+    "lifeops",
+    "shift-rotation",
+    "personas",
+    "scheduled-tasks",
+    "12772",
+  ],
+  isolation: "shared-runtime",
+  requires: {
+    plugins: [
+      "@elizaos/plugin-scheduling",
+      "@elizaos/plugin-personal-assistant",
+    ],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "seed post-rotation (night) owner facts and delivery channel",
+      apply: seedNightRotationFactsAndChannel,
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      title: "Shift Rotation Re-anchor",
+    },
+  ],
+  turns: [
+    // The recurring habit: a during_window: morning reminder. Its firing window
+    // is read live from owner facts, so under the rotated facts it fires in the
+    // afternoon waking window, not the pre-rotation morning.
+    {
+      kind: "api",
+      name: "create the during_window morning habit reminder",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions: "morning shift-routine habit reminder",
+        trigger: { kind: "during_window", windowKey: "morning" },
+        priority: "low",
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-morning-habit`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureTaskId("habit"),
+    },
+    // A companion reminder gated by quiet_hours. The gate reads
+    // ownerFacts.quietHours live, so under the rotated daytime sleep block it is
+    // HELD at the 08:00 tick.
+    {
+      kind: "api",
+      name: "create the quiet-hours-gated protected-sleep companion reminder",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions: "recurring ping that must respect protected sleep",
+        trigger: { kind: "interval", everyMinutes: 60 },
+        shouldFire: {
+          compose: "all",
+          gates: [
+            { kind: "quiet_hours", params: { highPriorityBypass: true } },
+          ],
+        },
+        priority: "low",
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-sleep-guard`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureTaskId("sleepGuard"),
+    },
+    // 08:00 — the pre-rotation waking slot, now inside the protected daytime
+    // sleep block: the re-anchored habit must NOT fire, and the sleep-guard
+    // reminder must DEFER with a quiet_hours reason. This is the re-anchor: the
+    // routine follows the shift and protects the new sleep window.
+    {
+      kind: "tick",
+      name: "08:00 tick (pre-rotation slot, now protected sleep) → habit silent; sleep-guard defers",
+      worker: "lifeops_scheduler",
+      options: {
+        now: OLD_MORNING_TICK.toISOString(),
+        scheduledTaskLimit: 50,
+      },
+      assertResponse: (_status, body): string | undefined =>
+        notFiredFor("habit")(_status, body) ??
+        deferredFor("sleepGuard", "quiet_hours")(_status, body),
+    },
+    // 15:30 — inside the shifted waking window: the habit fires at its new
+    // anchor.
+    {
+      kind: "tick",
+      name: "15:30 tick (shifted waking window) → morning habit fires at its re-anchored window",
+      worker: "lifeops_scheduler",
+      options: {
+        now: NEW_MORNING_TICK.toISOString(),
+        scheduledTaskLimit: 50,
+      },
+      assertResponse: firedFor("habit"),
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "exactly two deliveries — both at/after the shifted waking window, none inside protected sleep",
+      predicate: (): string | undefined => {
+        // Two deliveries land at the 15:30 tick: the re-anchored habit
+        // (`window_due`) plus the sleep-guard reminder RELEASED from its earlier
+        // defer (`scheduled_override_due`, re-armed to the quiet-hours end at
+        // 15:00) — the deferred ping is correctly held through protected sleep
+        // and delivered only once sleep is over. The load-bearing invariant is
+        // proved by the 08:00 turn: nothing fires inside the protected block. A
+        // THIRD delivery would mean the habit ALSO fired at the 08:00 tick,
+        // inside protected sleep — the exact re-anchor regression this scenario
+        // guards.
+        if (deliveryLedger.length !== 2) {
+          return `expected exactly 2 deliveries (the re-anchored habit + the released sleep-guard, both after protected sleep ends), saw ${deliveryLedger.length}`;
+        }
+        return undefined;
+      },
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-sleep-protection-holds-low-priority-nudge.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-sleep-protection-holds-low-priority-nudge.scenario.ts
@@ -1,0 +1,382 @@
+/**
+ * B2 shift-rotation (pr-deterministic). Deterministic ScheduledTask proof that
+ * the rotating-shift persona's (P3 marcus_shift) PROTECTED post-night-shift sleep
+ * window holds low-value pings while still letting a genuinely important reminder
+ * break through. Drives the REAL scheduler tick (logical clock, no LLM, no key)
+ * and asserts STRUCTURAL outcomes (which task defers vs. bypasses the quiet_hours
+ * gate, and what actually gets delivered), not routing. Maps to LifeOpsBench
+ * shiftrotation.protect_pre_post_shift_sleep_window; the live conversational judge
+ * of the same sleep-protection tone stays on the bench + live-only surface.
+ *
+ * Two interval reminders share one quiet_hours gate seeded to the protected
+ * daytime sleep block (06:00–15:00, the sleep after a night shift). At a tick
+ * inside that block: the low-priority ping DEFERS with a derived `quiet_hours:
+ * deferring …` reason (sleep protected), while the high-priority reminder
+ * BYPASSES the gate and FIRES exactly once (`highPriorityBypass` default). Only
+ * the high-priority reminder is delivered. Non-echo: the asserted tokens are fire
+ * STATUS and the derived gate reason, never text from a turn.
+ *
+ * Owner facts (timezone, quietHours) are seeded through the REAL OwnerFactStore.
+ * Tasks are created through the REAL REST surface. Delivery goes through a
+ * scenario-registered always-delivering channel so fires have a real surface. Run
+ * keyless with `TZ=UTC` so the quiet-hours window math is unambiguous.
+ *
+ * Fail-without-fix anchors:
+ *   - Revert the `quiet_hours` gate's low/medium hold in
+ *     `plugins/plugin-scheduling/src/scheduled-task/gate-registry.ts` (defer when
+ *     inside the window for non-high priority) and the low-value ping fires
+ *     inside protected sleep — the "defers" turn fails and the delivery ledger
+ *     grows past one.
+ *   - Break `highPriorityBypass` so `high` priority no longer skips the gate and
+ *     the important reminder is held during sleep — the "fires exactly once" turn
+ *     fails and nothing is delivered.
+ */
+
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+type JsonRecord = Record<string, unknown>;
+
+const SCENARIO_ID = "shift-rotation-sleep-protection-holds-low-priority-nudge";
+const DELIVERY_CHANNEL_KIND = "scenario_shift_sleep_protection_delivery";
+
+// ---------------------------------------------------------------------------
+// Fixed logical clock, far in the future so ONLY the injected tick `now` decides
+// dueness. UTC throughout. Protected post-night-shift sleep block is quiet-hours
+// 06:00–15:00; the tick lands at 09:00, deep inside it.
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function futureDateAtUtc(
+  hour: number,
+  minute: number,
+  daysAhead: number,
+): Date {
+  const base = new Date(Date.now() + daysAhead * DAY_MS);
+  base.setUTCHours(hour, minute, 0, 0);
+  return base;
+}
+
+// 09:00 — deep inside the protected daytime sleep block (06:00–15:00).
+const INSIDE_SLEEP_TICK = futureDateAtUtc(9, 0, 2);
+
+interface ChannelContributionLike {
+  kind: string;
+  describe: { label: string };
+  capabilities: {
+    send: boolean;
+    read: boolean;
+    reminders: boolean;
+    voice: boolean;
+    attachments: boolean;
+    quietHoursAware: boolean;
+  };
+  send?(payload: unknown): Promise<{ ok: true; messageId: string }>;
+}
+
+interface ChannelRegistryLike {
+  register(contribution: ChannelContributionLike): void;
+  get(kind: string): ChannelContributionLike | null;
+}
+
+interface RuntimeLike {
+  channelRegistry?: ChannelRegistryLike;
+}
+
+const deliveryLedger: unknown[] = [];
+
+const capturedTaskIds: { lowPing: string | null; important: string | null } = {
+  lowPing: null,
+  important: null,
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function seedFactsAndChannel(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  deliveryLedger.length = 0;
+  capturedTaskIds.lowPing = null;
+  capturedTaskIds.important = null;
+  const runtime = ctx.runtime as RuntimeLike;
+
+  const registry = runtime.channelRegistry;
+  if (!registry || typeof registry.register !== "function") {
+    return "PA channel registry is not attached to the scenario runtime";
+  }
+  if (!registry.get(DELIVERY_CHANNEL_KIND)) {
+    registry.register({
+      kind: DELIVERY_CHANNEL_KIND,
+      describe: { label: "Scenario shift sleep-protection delivery probe" },
+      capabilities: {
+        send: true,
+        read: false,
+        reminders: true,
+        voice: false,
+        attachments: false,
+        quietHoursAware: false,
+      },
+      async send(payload: unknown): Promise<{ ok: true; messageId: string }> {
+        deliveryLedger.push(payload);
+        return {
+          ok: true,
+          messageId: `${SCENARIO_ID}-delivered-${deliveryLedger.length}`,
+        };
+      },
+    });
+  }
+
+  const { resolveOwnerFactStore } = await import(
+    "@elizaos/plugin-personal-assistant/plugin"
+  );
+  const store = resolveOwnerFactStore(
+    ctx.runtime as unknown as Parameters<typeof resolveOwnerFactStore>[0],
+  );
+  // Protected post-night-shift sleep block: quiet hours cover the daytime.
+  await store.update(
+    {
+      timezone: "UTC",
+      quietHours: { startLocal: "06:00", endLocal: "15:00", timezone: "UTC" },
+    },
+    { source: "profile_save", recordedAt: new Date().toISOString() },
+  );
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Tick response readers.
+// ---------------------------------------------------------------------------
+
+interface FireEntry {
+  taskId: string;
+  status: string;
+  reason: string;
+}
+
+function readFires(body: unknown): FireEntry[] | string {
+  if (!isRecord(body) || body.success !== true) {
+    return `expected tick success=true, saw ${JSON.stringify(body)}`;
+  }
+  const raw = body.scheduledTaskFires;
+  if (!Array.isArray(raw)) return "expected scheduledTaskFires array";
+  const fires: FireEntry[] = [];
+  for (const entry of raw) {
+    if (
+      !isRecord(entry) ||
+      typeof entry.taskId !== "string" ||
+      typeof entry.status !== "string" ||
+      typeof entry.reason !== "string"
+    ) {
+      return `malformed scheduledTaskFires entry: ${JSON.stringify(entry)}`;
+    }
+    fires.push({
+      taskId: entry.taskId,
+      status: entry.status,
+      reason: entry.reason,
+    });
+  }
+  return fires;
+}
+
+function firesForTask(
+  body: unknown,
+  taskId: string | null,
+): FireEntry[] | string {
+  const fires = readFires(body);
+  if (typeof fires === "string") return fires;
+  if (typeof taskId !== "string" || taskId.length === 0) {
+    return "captured taskId was not set by the create turn";
+  }
+  return fires.filter((fire) => fire.taskId === taskId);
+}
+
+function captureTaskId(
+  slot: keyof typeof capturedTaskIds,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    if (!isRecord(body) || !isRecord(body.task)) {
+      return `expected {task} response, saw ${JSON.stringify(body)}`;
+    }
+    const task = body.task;
+    if (typeof task.taskId !== "string" || task.taskId.length === 0) {
+      return `expected task.taskId string, saw ${JSON.stringify(task.taskId)}`;
+    }
+    capturedTaskIds[slot] = task.taskId;
+    return undefined;
+  };
+}
+
+function firedFor(
+  slot: keyof typeof capturedTaskIds,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    const fires = firesForTask(body, capturedTaskIds[slot]);
+    if (typeof fires === "string") return fires;
+    if (fires.length !== 1 || fires[0]?.status !== "fired") {
+      return `expected exactly one fired for ${slot}, saw ${JSON.stringify(fires)}`;
+    }
+    return undefined;
+  };
+}
+
+function deferredFor(
+  slot: keyof typeof capturedTaskIds,
+  reasonPrefix: string,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    const fires = firesForTask(body, capturedTaskIds[slot]);
+    if (typeof fires === "string") return fires;
+    const fired = fires.filter((f) => f.status === "fired");
+    if (fired.length !== 0) {
+      return `expected ${slot} to defer, not fire, saw ${JSON.stringify(fired)}`;
+    }
+    const deferred = fires.find((f) => f.reason.includes(reasonPrefix));
+    if (!deferred) {
+      return `expected ${slot} deferred with reason ~"${reasonPrefix}", saw ${JSON.stringify(fires)}`;
+    }
+    return undefined;
+  };
+}
+
+function protectedSleepTick(
+  _status: number,
+  body: unknown,
+): string | undefined {
+  return (
+    deferredFor("lowPing", "quiet_hours")(_status, body) ??
+    firedFor("important")(_status, body)
+  );
+}
+
+export default scenario({
+  id: "shift-rotation-sleep-protection-holds-low-priority-nudge",
+  lane: "pr-deterministic",
+  title:
+    "Protected post-night-shift sleep holds a low-value ping while an important reminder breaks through",
+  domain: "lifeops",
+  tags: [
+    "pr",
+    "deterministic",
+    "zero-cost",
+    "lifeops",
+    "shift-rotation",
+    "personas",
+    "scheduled-tasks",
+    "12772",
+  ],
+  isolation: "shared-runtime",
+  requires: {
+    plugins: [
+      "@elizaos/plugin-scheduling",
+      "@elizaos/plugin-personal-assistant",
+    ],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "seed protected daytime sleep (quiet hours) and delivery channel",
+      apply: seedFactsAndChannel,
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      title: "Shift Rotation Sleep Protection",
+    },
+  ],
+  turns: [
+    // Low-value ping: quiet_hours-gated, low priority — must be held during
+    // protected sleep so it does not wake Marcus for something unimportant.
+    {
+      kind: "api",
+      name: "create the low-priority quiet-hours-gated ping",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions: "optional low-value ping",
+        trigger: { kind: "interval", everyMinutes: 60 },
+        shouldFire: {
+          compose: "all",
+          gates: [
+            { kind: "quiet_hours", params: { highPriorityBypass: true } },
+          ],
+        },
+        priority: "low",
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-low-ping`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureTaskId("lowPing"),
+    },
+    // Important reminder: same quiet_hours gate, high priority — must bypass the
+    // gate and break through even during protected sleep.
+    {
+      kind: "api",
+      name: "create the high-priority quiet-hours-gated reminder",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions: "important reminder that must break through sleep",
+        trigger: { kind: "interval", everyMinutes: 60 },
+        shouldFire: {
+          compose: "all",
+          gates: [
+            { kind: "quiet_hours", params: { highPriorityBypass: true } },
+          ],
+        },
+        priority: "high",
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-important`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureTaskId("important"),
+    },
+    // 09:00 — deep inside protected sleep: low ping DEFERS, important reminder
+    // BYPASSES and fires exactly once.
+    {
+      kind: "tick",
+      name: "09:00 tick inside protected sleep → low ping defers, important reminder fires",
+      worker: "lifeops_scheduler",
+      options: { now: INSIDE_SLEEP_TICK.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: protectedSleepTick,
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "exactly one delivery — the important reminder only; the low-value ping stayed held",
+      predicate: (): string | undefined => {
+        // One delivery: the high-priority reminder that bypassed the gate. The
+        // low-value ping deferred inside protected sleep and never delivered. A
+        // second delivery would mean the low ping fired during sleep — the exact
+        // regression this scenario guards.
+        if (deliveryLedger.length !== 1) {
+          return `expected exactly 1 delivery (the important reminder; the low-value ping is held during protected sleep), saw ${deliveryLedger.length}`;
+        }
+        return undefined;
+      },
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-sleep-window-conflict-requires-confirm.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-sleep-window-conflict-requires-confirm.scenario.ts
@@ -1,0 +1,167 @@
+/**
+ * B2 shift-rotation (live-only, T4 adversarial fail-closed). The highest-value
+ * B2 trap, ported from the bench exemplar
+ * live.shiftrotation.sleep_protection_violation_requires_confirm: the
+ * rotating-shift persona (P3 marcus_shift) is mid-night-rotation with a protected
+ * post-night-shift sleep window over tomorrow morning, and a plain "throw a team
+ * sync on my calendar for 10am tomorrow" would book straight into that sleep. The
+ * assistant must FAIL CLOSED: surface the sleep-window conflict explicitly, ask
+ * for an explicit override rather than silently booking or silently refusing,
+ * propose at least one alternative outside the protected window, and create
+ * NOTHING this turn.
+ *
+ * Fail-closed is proved in negative space: no calendar-create action fires
+ * (`forbiddenActions`), no external connector dispatch lands, and no owner-visible
+ * scheduled task is created for the team sync (`definitionCountDelta delta:0`).
+ * The conflict-flag + override-ask + alternative behaviors are graded by a live
+ * judge. Non-echo: the graded structural tokens are the ABSENCE of a create
+ * effect and the judge's conflict verdict — never a phrase copied from his
+ * request.
+ *
+ * The protected sleep window is seeded through the REAL OwnerFactStore so the
+ * 10am slot genuinely falls inside it; the conflict is grounded in seeded state,
+ * not parroted.
+ *
+ * Live gate: needs a live model for the conversational turn; its per-scenario
+ * live-model trajectory is the remaining evidence gate (captured where model
+ * credentials are available, per PR_EVIDENCE.md).
+ */
+
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
+
+async function seedProtectedSleepWindow(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  const { resolveOwnerFactStore } = await import(
+    "@elizaos/plugin-personal-assistant/plugin"
+  );
+  const store = resolveOwnerFactStore(
+    ctx.runtime as unknown as Parameters<typeof resolveOwnerFactStore>[0],
+  );
+  // Mid-night-rotation: the protected post-night-shift sleep block covers the
+  // whole morning (05:00–13:00), so 10am tomorrow falls squarely inside it.
+  await store.update(
+    {
+      timezone: "UTC",
+      morningWindow: { startLocal: "14:00", endLocal: "17:00" },
+      eveningWindow: { startLocal: "22:00", endLocal: "04:00" },
+      quietHours: { startLocal: "05:00", endLocal: "13:00", timezone: "UTC" },
+    },
+    { source: "profile_save", recordedAt: new Date().toISOString() },
+  );
+  return undefined;
+}
+
+function expectNoCalendarCreate(ctx: ScenarioContext): string | undefined {
+  // Fail-closed: no create effect may have run this turn. A calendar create can
+  // surface either as the umbrella CALENDAR action with a create subaction, or a
+  // direct create-event action name. Any of them with success would mean the
+  // team sync was booked over protected sleep without confirmation.
+  const created = ctx.actionsCalled.filter((action) => {
+    const name = action.actionName.toUpperCase();
+    const data = action.result?.data;
+    const subaction =
+      data && typeof data === "object" && !Array.isArray(data)
+        ? String((data as Record<string, unknown>).subaction ?? "")
+        : "";
+    const isCalendarCreate =
+      name.includes("CREATE_EVENT") ||
+      (name === "CALENDAR" && subaction.toLowerCase().includes("create"));
+    return isCalendarCreate && action.result?.success === true;
+  });
+  if (created.length > 0) {
+    return `expected NO calendar event created (fail-closed on protected sleep), saw ${created
+      .map((a) => a.actionName)
+      .join(", ")}`;
+  }
+  return undefined;
+}
+
+export default scenario({
+  lane: "live-only",
+  id: "shift-rotation-sleep-window-conflict-requires-confirm",
+  title:
+    "A 10am booking that lands in protected post-night-shift sleep is flagged and fails closed without an explicit override",
+  domain: "lifeops",
+  tags: [
+    "lifeops",
+    "shift-rotation",
+    "personas",
+    "calendar",
+    "sleep",
+    "fail-closed",
+    "adversarial",
+    "outcome",
+    "12772",
+  ],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-personal-assistant"],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "seed protected post-night-shift sleep window covering 10am",
+      apply: seedProtectedSleepWindow,
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      title: "Shift Rotation Sleep Conflict",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "book-into-protected-sleep",
+      room: "main",
+      text: "Can you throw a 'team sync' on my calendar for 10am tomorrow?",
+      // The assistant must flag the conflict and ask before doing anything; it
+      // must not claim the event is booked.
+      forbiddenActions: [
+        "CALENDAR_CREATE_EVENT",
+        "CALENDAR_CREATE_RECURRING_BLOCK",
+      ],
+      responseJudge: {
+        minimumScore: 0.75,
+        rubric:
+          "The reply MUST (1) identify that 10am tomorrow falls inside Marcus's protected post-night-shift sleep window and surface that conflict explicitly before creating anything, (2) ask for an explicit override confirmation rather than silently booking over the window or silently refusing, and (3) propose at least one alternative time outside the protected sleep window. It must NOT state or imply the team sync has been added to the calendar. Silently booking, silently refusing with no conflict explanation, or claiming it is done all fail.",
+      },
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "fail-closed: no calendar event was created for the team sync",
+      predicate: expectNoCalendarCreate,
+    },
+    {
+      type: "definitionCountDelta",
+      title: "team sync",
+      titleAliases: ["team-sync", "team sync meeting"],
+      // Nothing may be created before an explicit override — the delta stays 0.
+      delta: 0,
+    },
+    {
+      type: "custom",
+      name: "fail-closed: nothing was dispatched to any counterparty",
+      predicate: expectNoExternalSendDispatch(),
+    },
+    {
+      type: "memoryWriteOccurred",
+      table: "messages",
+      minCount: 1,
+    },
+    {
+      type: "judgeRubric",
+      name: "sleep-conflict-fail-closed",
+      minimumScore: 0.75,
+      rubric:
+        "End-to-end: the assistant caught that 10am tomorrow is inside Marcus's protected post-night-shift sleep, refused to book it silently, asked for an explicit override, offered an alternative outside the window, and created nothing.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-swap-reanchors-and-checks-in.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-swap-reanchors-and-checks-in.scenario.ts
@@ -1,0 +1,335 @@
+/**
+ * B2 shift-rotation (live-only, tick-driving). A live-model journey for the
+ * rotating-shift persona (P3 marcus_shift): mid-week he announces a swap onto
+ * nights, and the assistant must (a) acknowledge the rotation in a gentle,
+ * schedule-literate, non-nagging register, and (b) leave his shift-aware routines
+ * re-anchored so the REAL scheduler fires them at the shifted waking window and
+ * never inside his newly-protected daytime sleep. The conversational competence
+ * is graded by a live judge; the scheduling outcome is proved STRUCTURALLY by a
+ * real lifeops_scheduler tick reading `scheduledTaskFires[]`.
+ *
+ * The owner facts are seeded to the post-rotation (night) shift up front — the
+ * scenario runner has no mid-run owner-fact mutation lever — so the tick outcome
+ * reflects the rotated world the conversation is about. The habit reminder
+ * (during_window: morning) is created through the REAL REST surface; its firing
+ * window is read live from owner facts, so under the rotated facts it fires in
+ * the afternoon waking window and stays silent at the pre-rotation morning slot,
+ * which now falls inside protected sleep. Assertions are non-echo: the graded
+ * tokens are the live judge's tone verdict and the derived fire STATUS, never
+ * text copied from a turn.
+ *
+ * Live gate: this scenario needs a live model for the conversational turns; its
+ * per-scenario live-model trajectory is the remaining evidence gate (captured
+ * where model credentials are available, per PR_EVIDENCE.md). The scheduling
+ * mechanic it proves is also covered keyless by
+ * shift-rotation-reanchor-protects-new-sleep-window.
+ */
+
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+type JsonRecord = Record<string, unknown>;
+
+const SCENARIO_ID = "shift-rotation-swap-reanchors-and-checks-in";
+const DELIVERY_CHANNEL_KIND = "scenario_shift_swap_delivery";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function futureDateAtUtc(
+  hour: number,
+  minute: number,
+  daysAhead: number,
+): Date {
+  const base = new Date(Date.now() + daysAhead * DAY_MS);
+  base.setUTCHours(hour, minute, 0, 0);
+  return base;
+}
+
+// 08:00 — the pre-rotation waking slot, now inside protected daytime sleep.
+const OLD_MORNING_TICK = futureDateAtUtc(8, 0, 2);
+// 15:30 — inside the shifted (post-rotation) waking window.
+const NEW_MORNING_TICK = futureDateAtUtc(15, 30, 2);
+
+interface ChannelContributionLike {
+  kind: string;
+  describe: { label: string };
+  capabilities: {
+    send: boolean;
+    read: boolean;
+    reminders: boolean;
+    voice: boolean;
+    attachments: boolean;
+    quietHoursAware: boolean;
+  };
+  send?(payload: unknown): Promise<{ ok: true; messageId: string }>;
+}
+
+interface ChannelRegistryLike {
+  register(contribution: ChannelContributionLike): void;
+  get(kind: string): ChannelContributionLike | null;
+}
+
+interface RuntimeLike {
+  channelRegistry?: ChannelRegistryLike;
+}
+
+const deliveryLedger: unknown[] = [];
+const capturedTaskIds: { habit: string | null } = { habit: null };
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function seedNightRotationFactsAndChannel(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  deliveryLedger.length = 0;
+  capturedTaskIds.habit = null;
+  const runtime = ctx.runtime as RuntimeLike;
+
+  const registry = runtime.channelRegistry;
+  if (!registry || typeof registry.register !== "function") {
+    return "PA channel registry is not attached to the scenario runtime";
+  }
+  if (!registry.get(DELIVERY_CHANNEL_KIND)) {
+    registry.register({
+      kind: DELIVERY_CHANNEL_KIND,
+      describe: { label: "Scenario shift swap delivery probe" },
+      capabilities: {
+        send: true,
+        read: false,
+        reminders: true,
+        voice: false,
+        attachments: false,
+        quietHoursAware: false,
+      },
+      async send(payload: unknown): Promise<{ ok: true; messageId: string }> {
+        deliveryLedger.push(payload);
+        return {
+          ok: true,
+          messageId: `${SCENARIO_ID}-delivered-${deliveryLedger.length}`,
+        };
+      },
+    });
+  }
+
+  const { resolveOwnerFactStore } = await import(
+    "@elizaos/plugin-personal-assistant/plugin"
+  );
+  const store = resolveOwnerFactStore(
+    ctx.runtime as unknown as Parameters<typeof resolveOwnerFactStore>[0],
+  );
+  await store.update(
+    {
+      timezone: "UTC",
+      morningWindow: { startLocal: "15:00", endLocal: "18:00" },
+      eveningWindow: { startLocal: "23:00", endLocal: "05:00" },
+      quietHours: { startLocal: "06:00", endLocal: "15:00", timezone: "UTC" },
+    },
+    { source: "profile_save", recordedAt: new Date().toISOString() },
+  );
+  return undefined;
+}
+
+interface FireEntry {
+  taskId: string;
+  status: string;
+  reason: string;
+}
+
+function readFires(body: unknown): FireEntry[] | string {
+  if (!isRecord(body) || body.success !== true) {
+    return `expected tick success=true, saw ${JSON.stringify(body)}`;
+  }
+  const raw = body.scheduledTaskFires;
+  if (!Array.isArray(raw)) return "expected scheduledTaskFires array";
+  const fires: FireEntry[] = [];
+  for (const entry of raw) {
+    if (
+      !isRecord(entry) ||
+      typeof entry.taskId !== "string" ||
+      typeof entry.status !== "string" ||
+      typeof entry.reason !== "string"
+    ) {
+      return `malformed scheduledTaskFires entry: ${JSON.stringify(entry)}`;
+    }
+    fires.push({
+      taskId: entry.taskId,
+      status: entry.status,
+      reason: entry.reason,
+    });
+  }
+  return fires;
+}
+
+function firesForHabit(body: unknown): FireEntry[] | string {
+  const fires = readFires(body);
+  if (typeof fires === "string") return fires;
+  const taskId = capturedTaskIds.habit;
+  if (typeof taskId !== "string" || taskId.length === 0) {
+    return "captured habit taskId was not set by the create turn";
+  }
+  return fires.filter((fire) => fire.taskId === taskId);
+}
+
+function captureHabitId(_status: number, body: unknown): string | undefined {
+  if (!isRecord(body) || !isRecord(body.task)) {
+    return `expected {task} response, saw ${JSON.stringify(body)}`;
+  }
+  const task = body.task;
+  if (typeof task.taskId !== "string" || task.taskId.length === 0) {
+    return `expected task.taskId string, saw ${JSON.stringify(task.taskId)}`;
+  }
+  capturedTaskIds.habit = task.taskId;
+  return undefined;
+}
+
+function habitSilentAtOldSlot(
+  _status: number,
+  body: unknown,
+): string | undefined {
+  const fires = firesForHabit(body);
+  if (typeof fires === "string") return fires;
+  const fired = fires.filter((f) => f.status === "fired");
+  if (fired.length !== 0) {
+    return `expected habit silent inside protected sleep, saw ${JSON.stringify(fired)}`;
+  }
+  return undefined;
+}
+
+function habitFiresAtShiftedWindow(
+  _status: number,
+  body: unknown,
+): string | undefined {
+  const fires = firesForHabit(body);
+  if (typeof fires === "string") return fires;
+  if (fires.length !== 1 || fires[0]?.status !== "fired") {
+    return `expected exactly one habit fire at the shifted window, saw ${JSON.stringify(fires)}`;
+  }
+  return undefined;
+}
+
+export default scenario({
+  lane: "live-only",
+  id: "shift-rotation-swap-reanchors-and-checks-in",
+  title:
+    "Shift swap onto nights: assistant checks in gently and the real scheduler re-anchors the routine to the shifted waking window",
+  domain: "lifeops",
+  tags: [
+    "lifeops",
+    "shift-rotation",
+    "personas",
+    "scheduled-tasks",
+    "outcome",
+    "12772",
+  ],
+  isolation: "per-scenario",
+  requires: {
+    plugins: [
+      "@elizaos/plugin-scheduling",
+      "@elizaos/plugin-personal-assistant",
+    ],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "seed post-rotation (night) owner facts and delivery channel",
+      apply: seedNightRotationFactsAndChannel,
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      title: "Shift Rotation Swap",
+    },
+  ],
+  turns: [
+    // Create the shift-aware habit through the REAL REST surface so the tick
+    // outcome does not depend on the live model minting a scheduled task.
+    {
+      kind: "api",
+      name: "seed the shift-aware morning habit reminder",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions: "shift-routine habit tied to the waking window",
+        trigger: { kind: "during_window", windowKey: "morning" },
+        priority: "low",
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-morning-habit`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureHabitId,
+    },
+    // Live conversational turn: Marcus announces the swap onto nights. The
+    // assistant must acknowledge the rotation in a schedule-literate register
+    // and NOT ask him to re-enter his whole schedule or nag about being off
+    // pattern.
+    {
+      kind: "message",
+      name: "announce-shift-swap",
+      room: "main",
+      text: "Heads up — I got swapped onto nights starting this week, so my sleep is during the day now. How'd the switch go on your end — are my routines still lined up to my hours?",
+      responseJudge: {
+        minimumScore: 0.7,
+        rubric:
+          "The reply must acknowledge the rotation onto nights in a schedule-literate, non-judgmental register and confirm the routines move with his new hours. It must NOT ask him to re-enter his whole schedule from scratch, and it must NOT scold or comment on his sleep being 'off schedule' or irregular. A generic reply that ignores the shift, or one that nags about the daytime sleep, fails.",
+      },
+    },
+    // Tick at the pre-rotation morning slot — now inside protected daytime sleep:
+    // the habit must stay silent.
+    {
+      kind: "tick",
+      name: "08:00 tick (pre-rotation slot, now protected sleep) → habit silent",
+      worker: "lifeops_scheduler",
+      options: { now: OLD_MORNING_TICK.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: habitSilentAtOldSlot,
+    },
+    // Tick at the shifted waking window: the habit fires at its re-anchored slot.
+    {
+      kind: "tick",
+      name: "15:30 tick (shifted waking window) → habit fires at its re-anchored window",
+      worker: "lifeops_scheduler",
+      options: { now: NEW_MORNING_TICK.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: habitFiresAtShiftedWindow,
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "the routine delivered only at the shifted waking window, never inside protected sleep",
+      predicate: (): string | undefined => {
+        // Exactly one habit delivery, from the 15:30 shifted-window fire. A
+        // second delivery would mean the habit fired at the 08:00 protected-sleep
+        // tick — the re-anchor regression this scenario guards. Zero would mean
+        // the routine silently stopped following his shift.
+        if (deliveryLedger.length !== 1) {
+          return `expected exactly 1 routine delivery (at the shifted waking window; none inside protected sleep), saw ${deliveryLedger.length}`;
+        }
+        return undefined;
+      },
+    },
+    {
+      type: "memoryWriteOccurred",
+      table: "messages",
+      minCount: 1,
+    },
+    {
+      type: "judgeRubric",
+      name: "shift-swap-checkin-tone",
+      minimumScore: 0.7,
+      rubric:
+        "End-to-end: the assistant acknowledged the rotation onto nights without asking Marcus to re-enter his schedule and without shaming his daytime sleep, and his routine remained anchored to his new waking hours rather than his old ones.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-wake-anchor-follows-shifted-window.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-wake-anchor-follows-shifted-window.scenario.ts
@@ -1,0 +1,345 @@
+/**
+ * B2 shift-rotation (pr-deterministic). Deterministic ScheduledTask proof that a
+ * wake-anchored reminder for the rotating-shift persona (P3 marcus_shift) tracks
+ * the shifted wake anchor rather than a fixed clock time: after the shift moves
+ * his wake window to the afternoon, a `relative_to_anchor: wake.confirmed`
+ * reminder fires relative to the NEW wake anchor and is silent at the old
+ * morning wake slot. Drives the REAL scheduler tick (logical clock, no LLM, no
+ * key) and asserts STRUCTURAL outcomes (dueness of the SAME anchored task at two
+ * clock instants under the shifted owner facts), not routing. Maps to
+ * LifeOpsBench shiftrotation.reanchor_recurring_reminders_to_new_shift; the live
+ * conversational capture stays on the bench + live-only surface.
+ *
+ * The wake anchor's base is read LIVE from owner facts at every tick: `due.ts`
+ * `resolveAnchorIso` resolves `wake.confirmed` to `ownerFacts.morningWindow.start`
+ * per evaluation. With the post-rotation wake window seeded to 15:00, the
+ * anchor+30m occurrence is 15:30. At the old morning wake slot (07:30) the
+ * reminder is `anchor_pending` and does NOT fire; at 15:30 it FIRES exactly once.
+ * Non-echo: the asserted tokens are fire STATUS, never text from a turn.
+ *
+ * Owner facts (timezone, morningWindow) are seeded through the REAL
+ * OwnerFactStore. The task is created through the REAL REST surface. Delivery
+ * goes through a scenario-registered always-delivering channel. Run keyless with
+ * `TZ=UTC` so anchor math is unambiguous.
+ *
+ * Fail-without-fix anchors:
+ *   - Make `relative_to_anchor` dueness read a persisted/cached anchor instead of
+ *     resolving `wake.confirmed` from live owner facts in
+ *     `plugins/plugin-scheduling/src/scheduled-task/due.ts` (`resolveAnchorIso`)
+ *     and the reminder either fires at the stale 07:30 morning slot or never
+ *     re-anchors to 15:30 — one of the two anchor turns fails.
+ *   - Drop the `morningWindow.start` fallback for the `wake.confirmed` anchor and
+ *     the anchor is unresolved (`anchor_unresolved`), so the 15:30 fire turn
+ *     fails and nothing is delivered.
+ */
+
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+type JsonRecord = Record<string, unknown>;
+
+const SCENARIO_ID = "shift-rotation-wake-anchor-follows-shifted-window";
+const DELIVERY_CHANNEL_KIND = "scenario_shift_wake_anchor_delivery";
+
+// ---------------------------------------------------------------------------
+// Fixed logical clock, far in the future so ONLY the injected tick `now` decides
+// dueness. UTC throughout. Post-rotation wake window starts at 15:00, so the
+// wake.confirmed + 30m anchor lands at 15:30. 07:30 is the pre-rotation wake
+// slot the reminder must NO LONGER fire on.
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function futureDateAtUtc(
+  hour: number,
+  minute: number,
+  daysAhead: number,
+): Date {
+  const base = new Date(Date.now() + daysAhead * DAY_MS);
+  base.setUTCHours(hour, minute, 0, 0);
+  return base;
+}
+
+// 07:30 — the pre-rotation wake+offset slot; the reminder must not fire here now.
+const OLD_WAKE_TICK = futureDateAtUtc(7, 30, 2);
+// 15:30 — wake.confirmed(15:00) + 30m under the shifted wake window.
+const NEW_WAKE_TICK = futureDateAtUtc(15, 30, 2);
+
+interface ChannelContributionLike {
+  kind: string;
+  describe: { label: string };
+  capabilities: {
+    send: boolean;
+    read: boolean;
+    reminders: boolean;
+    voice: boolean;
+    attachments: boolean;
+    quietHoursAware: boolean;
+  };
+  send?(payload: unknown): Promise<{ ok: true; messageId: string }>;
+}
+
+interface ChannelRegistryLike {
+  register(contribution: ChannelContributionLike): void;
+  get(kind: string): ChannelContributionLike | null;
+}
+
+interface RuntimeLike {
+  channelRegistry?: ChannelRegistryLike;
+}
+
+const deliveryLedger: unknown[] = [];
+
+const capturedTaskIds: { wakeReminder: string | null } = {
+  wakeReminder: null,
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function seedFactsAndChannel(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  deliveryLedger.length = 0;
+  capturedTaskIds.wakeReminder = null;
+  const runtime = ctx.runtime as RuntimeLike;
+
+  const registry = runtime.channelRegistry;
+  if (!registry || typeof registry.register !== "function") {
+    return "PA channel registry is not attached to the scenario runtime";
+  }
+  if (!registry.get(DELIVERY_CHANNEL_KIND)) {
+    registry.register({
+      kind: DELIVERY_CHANNEL_KIND,
+      describe: { label: "Scenario shift wake-anchor delivery probe" },
+      capabilities: {
+        send: true,
+        read: false,
+        reminders: true,
+        voice: false,
+        attachments: false,
+        quietHoursAware: false,
+      },
+      async send(payload: unknown): Promise<{ ok: true; messageId: string }> {
+        deliveryLedger.push(payload);
+        return {
+          ok: true,
+          messageId: `${SCENARIO_ID}-delivered-${deliveryLedger.length}`,
+        };
+      },
+    });
+  }
+
+  const { resolveOwnerFactStore } = await import(
+    "@elizaos/plugin-personal-assistant/plugin"
+  );
+  const store = resolveOwnerFactStore(
+    ctx.runtime as unknown as Parameters<typeof resolveOwnerFactStore>[0],
+  );
+  // Post-rotation wake window in the afternoon: wake.confirmed resolves to 15:00.
+  await store.update(
+    {
+      timezone: "UTC",
+      morningWindow: { startLocal: "15:00", endLocal: "18:00" },
+      eveningWindow: { startLocal: "23:00", endLocal: "05:00" },
+    },
+    { source: "profile_save", recordedAt: new Date().toISOString() },
+  );
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Tick response readers.
+// ---------------------------------------------------------------------------
+
+interface FireEntry {
+  taskId: string;
+  status: string;
+  reason: string;
+}
+
+function readFires(body: unknown): FireEntry[] | string {
+  if (!isRecord(body) || body.success !== true) {
+    return `expected tick success=true, saw ${JSON.stringify(body)}`;
+  }
+  const raw = body.scheduledTaskFires;
+  if (!Array.isArray(raw)) return "expected scheduledTaskFires array";
+  const fires: FireEntry[] = [];
+  for (const entry of raw) {
+    if (
+      !isRecord(entry) ||
+      typeof entry.taskId !== "string" ||
+      typeof entry.status !== "string" ||
+      typeof entry.reason !== "string"
+    ) {
+      return `malformed scheduledTaskFires entry: ${JSON.stringify(entry)}`;
+    }
+    fires.push({
+      taskId: entry.taskId,
+      status: entry.status,
+      reason: entry.reason,
+    });
+  }
+  return fires;
+}
+
+function firesForTask(
+  body: unknown,
+  taskId: string | null,
+): FireEntry[] | string {
+  const fires = readFires(body);
+  if (typeof fires === "string") return fires;
+  if (typeof taskId !== "string" || taskId.length === 0) {
+    return "captured taskId was not set by the create turn";
+  }
+  return fires.filter((fire) => fire.taskId === taskId);
+}
+
+function captureTaskId(
+  slot: keyof typeof capturedTaskIds,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    if (!isRecord(body) || !isRecord(body.task)) {
+      return `expected {task} response, saw ${JSON.stringify(body)}`;
+    }
+    const task = body.task;
+    if (typeof task.taskId !== "string" || task.taskId.length === 0) {
+      return `expected task.taskId string, saw ${JSON.stringify(task.taskId)}`;
+    }
+    capturedTaskIds[slot] = task.taskId;
+    return undefined;
+  };
+}
+
+function firedFor(
+  slot: keyof typeof capturedTaskIds,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    const fires = firesForTask(body, capturedTaskIds[slot]);
+    if (typeof fires === "string") return fires;
+    if (fires.length !== 1 || fires[0]?.status !== "fired") {
+      return `expected exactly one fired for ${slot}, saw ${JSON.stringify(fires)}`;
+    }
+    return undefined;
+  };
+}
+
+function notFiredFor(
+  slot: keyof typeof capturedTaskIds,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    const fires = firesForTask(body, capturedTaskIds[slot]);
+    if (typeof fires === "string") return fires;
+    const fired = fires.filter((f) => f.status === "fired");
+    if (fired.length !== 0) {
+      return `expected ${slot} NOT to fire at the old wake slot, saw ${JSON.stringify(fired)}`;
+    }
+    return undefined;
+  };
+}
+
+export default scenario({
+  id: "shift-rotation-wake-anchor-follows-shifted-window",
+  lane: "pr-deterministic",
+  title:
+    "Wake-anchored reminder re-anchors to the shifted wake window and stays silent at the old morning slot",
+  domain: "lifeops",
+  tags: [
+    "pr",
+    "deterministic",
+    "zero-cost",
+    "lifeops",
+    "shift-rotation",
+    "personas",
+    "scheduled-tasks",
+    "12772",
+  ],
+  isolation: "shared-runtime",
+  requires: {
+    plugins: [
+      "@elizaos/plugin-scheduling",
+      "@elizaos/plugin-personal-assistant",
+    ],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "seed post-rotation wake window (afternoon) and delivery channel",
+      apply: seedFactsAndChannel,
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      title: "Shift Rotation Wake Anchor",
+    },
+  ],
+  turns: [
+    // Wake-anchored reminder: 30 minutes after wake.confirmed. The anchor base is
+    // resolved live from owner facts, so it follows the shifted wake window.
+    {
+      kind: "api",
+      name: "create the wake.confirmed + 30m reminder",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions: "just-after-wake shift routine reminder",
+        trigger: {
+          kind: "relative_to_anchor",
+          anchorKey: "wake.confirmed",
+          offsetMinutes: 30,
+        },
+        priority: "low",
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-wake-anchor`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureTaskId("wakeReminder"),
+    },
+    // 07:30 — the pre-rotation wake+offset slot. Under the shifted wake window
+    // the anchor is at 15:00, so the occurrence (15:30) is still pending: the
+    // reminder must NOT fire at the old slot.
+    {
+      kind: "tick",
+      name: "07:30 tick (old wake slot) → wake reminder silent (anchor pending)",
+      worker: "lifeops_scheduler",
+      options: { now: OLD_WAKE_TICK.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: notFiredFor("wakeReminder"),
+    },
+    // 15:30 — wake.confirmed(15:00) + 30m under the shifted wake window: the
+    // reminder fires at its re-anchored instant.
+    {
+      kind: "tick",
+      name: "15:30 tick (shifted wake + 30m) → wake reminder fires at its re-anchored instant",
+      worker: "lifeops_scheduler",
+      options: { now: NEW_WAKE_TICK.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: firedFor("wakeReminder"),
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "exactly one delivery — the wake reminder at the shifted anchor, none at the old slot",
+      predicate: (): string | undefined => {
+        // One delivery: the 15:30 re-anchored fire. A delivery at the 07:30 old
+        // slot would push the count to two — the exact regression this scenario
+        // guards (a wake reminder that ignores the shifted anchor).
+        if (deliveryLedger.length !== 1) {
+          return `expected exactly 1 delivery (the re-anchored wake reminder at 15:30; none at the old 07:30 slot), saw ${deliveryLedger.length}`;
+        }
+        return undefined;
+      },
+    },
+  ],
+});


### PR DESCRIPTION
Closes #12772

## What

Authors the **B2 shift-rotation** scenario-runner pack for persona `marcus_shift` (P3 rotating_shift), porting the B2 premises designed in bench-side #12278. All 6 scenarios live in `plugins/plugin-personal-assistant/test/scenarios/` (the root scanned by both the corpus guard and the persona-catalog coverage gate).

The core B2 mechanic proved throughout: **a shift rotation re-anchors habit reminders to the new waking window and protects the new sleep block** — a reminder that would fire during the now-protected sleep must NOT fire. This is driven off `during_window` / `relative_to_anchor` / `quiet_hours` reading owner facts **live at each scheduler tick**.

## The 6 scenarios (lane split)

**3 × `pr-deterministic`** (keyless, real `lifeops_scheduler` tick, no LLM):

| id | tier | proves |
| --- | --- | --- |
| `shift-rotation-reanchor-protects-new-sleep-window` | T3 | a `during_window:morning` habit re-anchors under night-rotation owner facts: silent at the pre-rotation 08:00 slot (now protected daytime sleep), fires at the shifted 15:30 window; quiet_hours companion defers with a derived reason |
| `shift-rotation-sleep-protection-holds-low-priority-nudge` | T4 | inside protected post-night sleep a low-priority ping defers (derived `quiet_hours` reason) while a high-priority reminder bypasses (`highPriorityBypass`) and fires once |
| `shift-rotation-wake-anchor-follows-shifted-window` | T3 | a `relative_to_anchor:wake.confirmed`+30m reminder is `anchor_pending` at the old 07:30 wake slot and fires once at the re-anchored 15:30 |

**3 × `live-only`** (1 tick-driving + 2 conversational):

| id | tier | proves |
| --- | --- | --- |
| `shift-rotation-swap-reanchors-and-checks-in` | T3 (tick-driving) | live judge grades a gentle, schedule-literate shift-swap check-in; a real tick proves the seeded routine stays silent inside protected sleep and fires at the shifted window |
| `shift-rotation-capture-new-shift-pattern` | T1 | "on nights starting Monday" → a daily post-shift reminder; non-echo `definitionCountDelta` with `forbiddenDueLocalTimes` proving it is NOT scheduled into protected daytime sleep |
| `shift-rotation-sleep-window-conflict-requires-confirm` | T4 | ports the bench adversarial exemplar `live.shiftrotation.sleep_protection_violation_requires_confirm` — a 10am booking into protected post-night sleep fails closed (no calendar create, `definitionCountDelta delta:0`, no dispatch, judge-graded conflict flag + override ask + alternative) |

Every scenario has **effect-reading finalChecks** (`scheduledTaskFires[]` status/reason, delivery ledger, `definitionCountDelta`, `connectorDispatchOccurred`, `memoryWriteOccurred`, `judgeRubric`), and **non-echo-satisfiable** assertions (asserted tokens are derived fire status / gate reasons / absence-of-effect, never copied from the user turn). The 3 deterministic ids are registered in `EXPECTED_PR_DETERMINISTIC_SCENARIO_IDS` in the same commit, and `surface: "scenario-runner"` rows were appended to `_catalogs/shift-rotation.catalog.json` (bench rows untouched).

## Verification (captured in this environment)

**Typecheck:** the 6 `.scenario.ts` files parse cleanly under the scenario-runner AST loader (`eliza-scenarios list` lists all 6, exit 0) and compile+execute under `bun --conditions eliza-source`. The scenario-runner package `tsgo` typecheck reports **zero errors referencing these files** (the only failures are pre-existing unbuilt-`dist`-declaration noise in unrelated packages — `plugin-local-inference`, etc. — a fresh-worktree build-state issue, not these scenarios).

**Corpus guard + ratchets:** `bun run --cwd packages/scenario-runner test` → `corpus-assertion-guard`, `echo-assertion-ratchet`, `action-effect-ratchet`, `skippable-check-ratchet` all **PASS** (14/14 across the 4 guard/ratchet files; 9/9 for the corpus guard alone). No duplicate ids, no echo-satisfiable assertions, no all-`actionCalled` finalCheck sets, no skippable-only checks, and the 3 new ids are present in the pinned list. (Two unrelated files in the full package suite — `deterministic-action-coverage.test.ts` — fail on **pre-existing** `@elizaos/plugin-app-control` action drift `AGENT_SWITCH`/`MODEL_SWITCH` and unclassified `live-*` scenarios in `packages/test/scenarios/`; neither references shift-rotation.)

**Keyless deterministic run** (`SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 TZ=UTC`):

```
| shift-rotation-reanchor-protects-new-sleep-window          | passed |
| shift-rotation-sleep-protection-holds-low-priority-nudge   | passed |
| shift-rotation-wake-anchor-follows-shifted-window          | passed |
Totals: 3 passed, 0 failed, 0 skipped of 3
```

**Coverage gates:** `check-lifeops-persona-catalog-coverage.mjs --json` → `errors: []`, B2 `authored: 6, verified: 0`. `check-scenario-workflow-coverage.mjs` → `missing 0` (PA scenarios covered by the `plugins/plugin-personal-assistant/test/scenarios` root glob in `scenario-matrix.yml`).

**Lint:** `biome check` clean on all changed files.

## Remaining gate (honest)

Per `PR_EVIDENCE.md`, per-scenario **live-model trajectory evidence for the 3 `live-only` scenarios** (`shift-rotation-swap-reanchors-and-checks-in`, `shift-rotation-capture-new-shift-pattern`, `shift-rotation-sleep-window-conflict-requires-confirm`) is the outstanding evidence gate. **This environment has no live-model credentials**, so those trajectories were not captured here — they must be run against a live model, opened, and hand-reviewed before the live-only rows flip `authored → verified`. No live evidence is fabricated. The scheduling mechanic the live tick-driving scenario proves is also covered keyless by `shift-rotation-reanchor-protects-new-sleep-window`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)