### PR TITLE
fix(training): make quant kernel-manifest CI resolve real repo root

### DIFF
--- a/.github/workflows/training-stack.yml
+++ b/.github/workflows/training-stack.yml
@@ -97,21 +97,23 @@ jobs:
         # All pytest files in scripts/ that don't need GPU. test_reward_fn
         # may be a no-op in some branches; we still surface its result.
         #
-        # We ALSO mount the local-inference plugin's kernel-reference tree at
-        # /workspace/kernel-refs and point ELIZA_KERNEL_REF_DIR at it, so
-        # test_recipes_smoke.py's C-reference byte-exact parity tests actually
-        # COMPILE-AND-RUN in CI instead of silently skipping (they used to skip
-        # against a nonexistent path — a false green). The CPU image ships a C
-        # compiler (cc) for exactly this.
+        # Mount the whole workspace at /workspace/repo and run from
+        # packages/training inside it. The quant recipe gate anchors its kernel
+        # sources at the repo root (_kernel_manifest.py resolves parents[4];
+        # test_recipes_smoke.py resolves _HERE.parents[3]) to hash/compile
+        # plugins/plugin-local-inference/native/{reference,verify} and
+        # packages/native/plugins/*. A packages/training-only mount left that
+        # anchor at the container root, so the manifest hash checks hard-failed
+        # ("kernel hash source missing") and the C-reference parity tests
+        # silently skipped — a false green. The CPU image ships a C compiler
+        # (cc) so the parity tests compile-and-run for real.
         run: |
           docker run --rm \
-            -v "${{ github.workspace }}/packages/training:/workspace/live" \
-            -v "${{ github.workspace }}/plugins/plugin-local-inference/native:/workspace/kernel-refs:ro" \
-            -e PYTHONPATH=/workspace/live/scripts \
-            -e ELIZA_KERNEL_REF_DIR=/workspace/kernel-refs \
+            -v "${{ github.workspace }}:/workspace/repo" \
+            -e PYTHONPATH=/workspace/repo/packages/training/scripts \
             eliza-training-cpu:ci \
             -c "set -e; \
-                cd /workspace/live; \
+                cd /workspace/repo/packages/training; \
                 pytest -xvs \
                   scripts/test_default_thought_leak.py \
                   scripts/test_eliza_record.py \


### PR DESCRIPTION
## Problem

`training-stack.yml` `cpu-smoke` → **Run pure-python test suite** has been **red on develop** (nightly `Build & Test` and every `training-stack` run) since the quant-codebook pin refactor (#12320 / #12727):

```
RuntimeError: kernel hash source missing: plugins/plugin-local-inference/native/reference/turbo_kernels.c
FAILED scripts/quantization/test_recipes_smoke.py::test_recipe_sidecar_manifest_fragment_complete
```

The step mounted only `packages/training` at `/workspace/live`, but the quant recipe gate anchors its kernel sources at the **repo root**:
- `_kernel_manifest.py` → `Path(__file__).resolve().parents[4]`
- `test_recipes_smoke.py` → `_HERE.parents[3]`

to hash/compile `plugins/plugin-local-inference/native/{reference,verify}` and `packages/native/plugins/*`. Inside the container that anchor resolved to the container root `/`, so:
- The manifest hash checks **hard-failed** (`kernel hash source missing`).
- The C-reference byte-exact parity tests **silently skipped** — a false green, despite the step comment claiming they compile-and-run.

The pin refactor dropped the old `ELIZA_KERNEL_REF_DIR` override *and* added new `packages/native/plugins/*` sources that were never mounted, so no partial mount worked.

## Fix

Mount the **whole workspace** at `/workspace/repo` and run from `packages/training` inside it, so the repo-root anchor resolves for real (`parents[4]` / `_HERE.parents[3]` → `/workspace/repo`). Both source trees are then present. **No Python change** — the pinned sha256 already match the source files on develop.

## Verification

```
$ cd packages/training && PYTHONPATH=scripts python3 -m pytest -q scripts/quantization/test_recipes_smoke.py
......s................................................              [100%]
53 passed, 1 skipped
```

Run from the repo root (the container's equivalent layout after this change). Pinned-hash check locally: all three pins (`turbo3/4/tcq`, `polar_q4`, `qjl1_256`) match their source files' sha256 on develop. The CPU image ships `cc`, so the parity tests compile-and-run. `actionlint` clean; YAML valid.

This restores the coverage the step comment always promised (parity tests run instead of silently skipping), and turns the develop nightly `Build & Test` green.

## Evidence
CI-config-only change. N/A for UI screenshots, model trajectories, audio, or product domain artifacts. The failing/passing test output above is the domain artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)