### PR TITLE
test(#12771): author SR slice of persona pack B1 (night-owl-anchored-day)

### DIFF
--- a/packages/scenario-runner/src/corpus-assertion-guard.test.ts
+++ b/packages/scenario-runner/src/corpus-assertion-guard.test.ts
@@ -260,6 +260,11 @@ const EXPECTED_PR_DETERMINISTIC_SCENARIO_IDS = [
   "adhd-distractor-storm-mid-capture",
   "adhd-hyperfocus-guardrail-protects-standup",
   "agent-orchestrator.list-agents",
+  // LifeOps persona pack B1 (night-owl-anchored-day, #12771). Same G1
+  // convention as A1: authored under the SCANNED root
+  // packages/test/scenarios/lifeops.personas and added here in the same commit.
+  "persona.night-owl-anchored-day",
+  "persona.night-owl-quiet-hours-sleep-protection",
   "ainex.stand",
   "anthropic-proxy.proxy-status",
   "benchmarks.osworld-action",

--- a/packages/scripts/check-lifeops-persona-catalog-coverage.mjs
+++ b/packages/scripts/check-lifeops-persona-catalog-coverage.mjs
@@ -102,10 +102,22 @@ function loadScenarioRunnerIds() {
 function loadLifeOpsBenchIds() {
   const ids = new Map();
   const files = walkFiles(PYTHON_SCENARIO_ROOT, (file) => file.endsWith(".py"));
-  const idPattern = /\bid\s*=\s*["']([^"']+)["']/g;
+  // Two id-declaration forms coexist in the bench corpus: the explicit
+  // `id="..."` keyword on inline `Scenario(...)` literals, and the positional
+  // first argument of the per-pack scenario factories (`_scenario(...)` /
+  // `_live(...)`) some packs use to build their `SCENARIOS` list (e.g.
+  // night_owl_anchored_day.py). Both resolve real, registered scenarios, so the
+  // coverage gate must see both — matching only `id=` silently under-counts the
+  // factory packs. `_anchor(...)`/`_definition(...)` helpers also take a leading
+  // string, so the factory pattern is scoped to the scenario-builder names.
+  const idKeywordPattern = /\bid\s*=\s*["']([^"']+)["']/g;
+  const factoryIdPattern = /\b_(?:scenario|live)\(\s*["']([^"']+)["']/g;
   for (const file of files) {
     const source = readFileSync(file, "utf8");
-    for (const match of source.matchAll(idPattern)) {
+    for (const match of source.matchAll(idKeywordPattern)) {
+      ids.set(match[1], toPosix(path.relative(REPO_ROOT, file)));
+    }
+    for (const match of source.matchAll(factoryIdPattern)) {
       ids.set(match[1], toPosix(path.relative(REPO_ROOT, file)));
     }
   }

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/night-owl-anchored-day.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/night-owl-anchored-day.catalog.json
@@ -20,6 +20,174 @@
       "surface": "scenario-runner",
       "status": "authored",
       "notes": "Follow-up to #12972: the first live report resolved 2026-07-04T13:00:00Z to 09:00 America/New_York, so it is not verified until recaptured with the structural forbiddenDueLocalTimes check passing."
+    },
+    {
+      "id": "persona.night-owl-anchored-day",
+      "pack": "B1",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "verified",
+      "notes": "pr-deterministic (keyless). Real scheduler tick: a during_window brief fires inside her seeded noon window (12:00-14:00) and a wake-anchored reminder fires relative to the wake anchor, while a neurotypical 09:00 tick fires NOTHING; two-delivery finalCheck. Passes keyless under TZ=UTC SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 --conditions eliza-source."
+    },
+    {
+      "id": "persona.night-owl-quiet-hours-sleep-protection",
+      "pack": "B1",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "verified",
+      "notes": "pr-deterministic (keyless). Real scheduler tick at 08:00 inside her seeded 04:00-11:30 quiet hours: a low-value quiet-hours-gated reminder is HELD while a high-priority one breaks through via highPriorityBypass; single-delivery finalCheck. Passes keyless under TZ=UTC + --conditions eliza-source."
+    },
+    {
+      "id": "night-owl-wake-confirmation-fires-brief",
+      "pack": "B1",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "Live-only. 'Just got up, what's on deck' IS the wake-confirmation anchor and must fire the brief this turn: definitionCountDelta{daily brief, delta:1, forbiddenDueLocalTimes 09:00} proves the anchored (not-9am) brief, judge grades the fire-on-wake + no-wall-clock-question behavior. Live-verify deferred (#12781)."
+    },
+    {
+      "id": "night-owl-observed-wake-drift-adaptation",
+      "pack": "B1",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "Live-only. Reported wake drift (12:10->12:45->1:05) updates the anchor, not a stale 11:30: definitionCountDelta{wake at 11:30, delta:0} proves no new fixed-time definition was minted to paper over the drift; judge grades the anchor-tracks-drift + no-judgment behavior. Live-verify deferred (#12781)."
+    },
+    {
+      "id": "night-owl-end-of-evening-nudge",
+      "pack": "B1",
+      "tier": "T2",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "Live-only. End-of-evening stretch nudge follows her pre-sleep boundary, not 5pm/midnight: definitionCountDelta{stretch, delta:1, forbiddenDueLocalTimes 17:00 & 00:00} proves a flexible non-fixed nudge; judge grades the owner-relative day-boundary anchor. Live-verify deferred (#12781)."
+    },
+    {
+      "id": "night-owl-contradiction-reconciles-anchor",
+      "pack": "B1",
+      "tier": "T2",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "Live-only. 'Sleeping earlier now, don't assume 11:30' updates the single quiet-hours rule in place: definitionCountDelta{quiet hours, delta:1} proves convergence to one rule (not a second layered definition); judge grades update-not-stack + stale-baseline-dropped. Live-verify deferred (#12781)."
+    },
+    {
+      "id": "night-owl-reject-wall-clock-repair",
+      "pack": "B1",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "Live-only rejection trap. A mistaken 9am build-check proposal is rejected and repaired to after-wake: definitionCountDelta{check the build, delta:1, forbiddenDueLocalTimes 09:00} proves NO 9am survives in state; judge grades the non-defensive anchor-relative repair. Live-verify deferred (#12781)."
+    },
+    {
+      "id": "nightowl.anchored.wake_relative_deploy_ping",
+      "pack": "B1",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "verified"
+    },
+    {
+      "id": "nightowl.anchored.wake_relative_morning_brief",
+      "pack": "B1",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "verified"
+    },
+    {
+      "id": "nightowl.anchored.decent_hour_definition",
+      "pack": "B1",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "verified"
+    },
+    {
+      "id": "nightowl.anchored.sleep_protection_quiet_window",
+      "pack": "B1",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "verified"
+    },
+    {
+      "id": "nightowl.anchored.correct_assumed_9am_default",
+      "pack": "B1",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "verified"
+    },
+    {
+      "id": "nightowl.anchored.morning_brief_first_hour_after_wake",
+      "pack": "B1",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "verified"
+    },
+    {
+      "id": "nightowl.anchored.ambiguous_morning_uses_anchor",
+      "pack": "B1",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "verified"
+    },
+    {
+      "id": "nightowl.anchored.dedup_wake_anchored_reminders",
+      "pack": "B1",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "verified"
+    },
+    {
+      "id": "nightowl.anchored.local_wake_pattern_capture",
+      "pack": "B1",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "verified"
+    },
+    {
+      "id": "nightowl.anchored.multi_day_quiet_hours_consistency",
+      "pack": "B1",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "verified"
+    },
+    {
+      "id": "live.nightowl.wake_confirmation_fires_brief",
+      "pack": "B1",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "verified"
+    },
+    {
+      "id": "live.nightowl.observed_wake_drift_adaptation",
+      "pack": "B1",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "verified"
+    },
+    {
+      "id": "live.nightowl.disruption_does_not_interrupt_anchor_capture",
+      "pack": "B1",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "verified"
+    },
+    {
+      "id": "live.nightowl.end_of_her_evening_nudge",
+      "pack": "B1",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "verified"
+    },
+    {
+      "id": "live.nightowl.contradiction_reconciles_anchor",
+      "pack": "B1",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "verified"
+    },
+    {
+      "id": "live.nightowl.reject_wall_clock_repair",
+      "pack": "B1",
+      "tier": "T4",
+      "surface": "lifeops-bench",
+      "status": "verified"
     }
   ]
 }

--- a/plugins/plugin-personal-assistant/test/scenarios/night-owl-contradiction-reconciles-anchor.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/night-owl-contradiction-reconciles-anchor.scenario.ts
@@ -1,0 +1,78 @@
+/**
+ * B1 night-owl-anchored-day (live). noor_night first states her sleep window,
+ * then contradicts it a beat later ("actually I've been sleeping earlier this
+ * week, don't assume 11:30 anymore"). The assistant must UPDATE the single
+ * quiet-hours/anchor rule in place, not layer a second conflicting rule on top.
+ * Exercises contradiction reconciliation on the personas pack (#12283); maps to
+ * LifeOpsBench live.nightowl.contradiction_reconciles_anchor.
+ *
+ * Personas-as-data: the correction lives in the turn text, never in
+ * `promptInstructions` (root AGENTS.md — one scheduler, structural fields only).
+ *
+ * OUTCOME (not echo): definitionCountDelta{delta:1} on the quiet-hours rule
+ * proves the correction converged to ONE rule (an update, not a second layered
+ * definition), and the judge grades that the old 11:30 assumption was replaced
+ * rather than duplicated. Asserted concepts are derived from the response.
+ *
+ * Live-verify note (#12781): whether the update mutates the existing definition
+ * or replaces it is confirmed at live capture; the load-bearing outcome (exactly
+ * one surviving quiet-hours rule, not two conflicting ones) does not depend on it.
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "night-owl-contradiction-reconciles-anchor",
+  title:
+    "Night owl: 'sleeping earlier now' updates the one rule, does not layer a second",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "night-owl", "personas", "12283"],
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Night owl day",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "noor states her quiet-hours window",
+      text: "keep my quiet hours from when i crash to when i'm up — i've been going down around 4 and surfacing near 11:30.",
+    },
+    {
+      kind: "message",
+      name: "noor contradicts it a beat later",
+      text: "actually scratch part of that. i've been crashing earlier this week, more like 2. don't keep assuming 11:30 either. update the one rule, don't stack another one on top of it.",
+      responseJudge: {
+        minimumScore: 0.6,
+        rubric:
+          "The owner first gave a quiet-hours window, then corrected it (crashing earlier, ~2, and stop assuming 11:30), explicitly asking to UPDATE the single existing rule and NOT stack a second one. Grade PASS only if the assistant revised the one quiet-hours/anchor rule in place to the new timing and confirmed the correction, without creating a second conflicting rule. Deduct heavily if it layered an additional quiet-hours definition or kept the stale 11:30 assumption alongside the new one.",
+      },
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "quiet hours",
+      titleAliases: [
+        "quiet hours window",
+        "sleep window",
+        "do not disturb",
+        "quiet window",
+      ],
+      delta: 1,
+    },
+    {
+      type: "judgeRubric",
+      name: "single-rule-updated-not-layered",
+      minimumScore: 0.6,
+      rubric:
+        "End-to-end: after the contradiction, exactly ONE quiet-hours/sleep rule remains and it reflects the corrected earlier-crash timing — the assistant updated in place rather than adding a second conflicting rule, and dropped the stale 11:30 assumption. Grade PASS only if there is a single reconciled rule. Deduct heavily for two coexisting rules or a retained 11:30.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/night-owl-end-of-evening-nudge.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/night-owl-end-of-evening-nudge.scenario.ts
@@ -1,0 +1,72 @@
+/**
+ * B1 night-owl-anchored-day (live). noor_night wants a nudge "by my evening" if
+ * she hasn't stretched — and her evening is her own pre-sleep window, not
+ * calendar midnight. The assistant must anchor the nudge to her sleep/evening
+ * boundary rather than a default clock hour, and keep it flexible. Exercises
+ * owner-relative day-boundary reasoning on the personas pack (#12283); maps to
+ * LifeOpsBench live.nightowl.end_of_her_evening_nudge.
+ *
+ * Personas-as-data: the day-boundary framing lives in the turn text, never in
+ * `promptInstructions` (root AGENTS.md — one scheduler, structural fields only).
+ *
+ * OUTCOME (not echo): definitionCountDelta proves a stretch nudge was actually
+ * created AND that it was NOT pinned to a calendar-evening 17:00 or to midnight,
+ * and the judge grades that the anchor is her pre-sleep window. Asserted concepts
+ * are derived from the response, not copied from the user turn.
+ *
+ * Live-verify note (#12781): the exact anchor encoding (evening window vs.
+ * relative-to-bedtime) is confirmed at live capture; the load-bearing outcome
+ * (a flexible nudge, not a fixed 5pm/midnight time) does not depend on it.
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "night-owl-end-of-evening-nudge",
+  title:
+    "Night owl: an end-of-evening nudge follows her sleep boundary, not midnight",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "night-owl", "personas", "12283"],
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Night owl day",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "noor asks for a stretch nudge by her evening",
+      text: "if i haven't stretched by my evening, nudge me. and by evening i mean right before i actually go to sleep — not 5pm, not midnight. my day runs late.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "stretch",
+      titleAliases: [
+        "stretch nudge",
+        "stretch reminder",
+        "do a stretch",
+        "stretching",
+      ],
+      delta: 1,
+      forbiddenDueLocalTimes: [
+        { hour: 17, minute: 0 },
+        { hour: 0, minute: 0 },
+      ],
+    },
+    {
+      type: "judgeRubric",
+      name: "nudge-anchored-to-her-presleep-window",
+      minimumScore: 0.6,
+      rubric:
+        "The owner (night owl, late day) asked to be nudged to stretch by 'her evening', explicitly meaning her own pre-sleep window — not 5pm and not calendar midnight. Grade PASS only if the assistant created or clearly set up a stretch nudge anchored to her evening/pre-sleep boundary (asking for or using her sleep/evening anchor) rather than a fixed default clock hour. Deduct heavily if it pinned the nudge to 5pm, midnight, or another hardcoded time, or ignored the owner-relative day boundary.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/night-owl-observed-wake-drift-adaptation.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/night-owl-observed-wake-drift-adaptation.scenario.ts
@@ -1,0 +1,73 @@
+/**
+ * B1 night-owl-anchored-day (live). noor_night reports her observed wake time
+ * drifting later across the week (12:10 → 12:45 → 1:05). The assistant must
+ * treat these as observations that UPDATE her wake anchor estimate, not keep
+ * acting on a stale 11:30 assumption — and must not moralize about the later
+ * hours. Exercises longitudinal anchor adaptation on the personas pack (#12283);
+ * maps to LifeOpsBench live.nightowl.observed_wake_drift_adaptation.
+ *
+ * Personas-as-data: the drift framing lives in the turn text, never in
+ * `promptInstructions` (root AGENTS.md — one scheduler, structural fields only).
+ *
+ * OUTCOME (not echo): the judge grades the load-bearing behavior — the anchor
+ * baseline moves with the observations and the stale 11:30 is dropped — while
+ * definitionCountDelta{delta:0} on a fixed-11:30 reminder proves the assistant
+ * did NOT paper over the drift by minting a new hardcoded-time definition. The
+ * asserted concepts are derived from the response, not copied from the turn text.
+ *
+ * Live-verify note (#12781): whether the update lands as an OwnerFact wake-anchor
+ * revision or a reworded single definition is confirmed at live capture; the
+ * load-bearing negative (no new fixed-11:30 definition) does not depend on that.
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "night-owl-observed-wake-drift-adaptation",
+  title: "Night owl: observed wake drift updates the anchor, not a stale 11:30",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "night-owl", "personas", "12283"],
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Night owl day",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "noor reports her wake times drifting later",
+      text: "heads up, my wake time's been sliding. i got up 12:10 monday, 12:45 yesterday, 1:05 today. stop acting like i'm still an 11:30 person — track where it's actually landing.",
+      responseJudge: {
+        minimumScore: 0.6,
+        rubric:
+          "The owner (night owl) reports her observed wake time drifting later across three days and asks the assistant to track the real trend, not a stale 11:30 baseline. Grade PASS only if the assistant treats the reported times as observations that update her wake-anchor estimate (acknowledging the shift toward a later baseline) rather than continuing to assume 11:30. It must NOT judge or comment negatively on the later wake times. Deduct heavily if it keeps the old 11:30 estimate unchanged or lectures her about sleeping in.",
+      },
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "wake at 11:30",
+      titleAliases: [
+        "11:30 wake",
+        "wake up 11:30",
+        "morning at 11:30",
+        "fixed wake time",
+      ],
+      delta: 0,
+    },
+    {
+      type: "judgeRubric",
+      name: "anchor-tracks-drift-drops-stale-baseline",
+      minimumScore: 0.6,
+      rubric:
+        "The assistant updated its model of the owner's wake time to follow the reported later drift and explicitly stopped relying on the old 11:30 assumption, without layering a brand-new fixed-time rule and without any judgment about the later hours. Grade PASS only if the stale baseline was abandoned in favor of the observed trend. Deduct heavily for retaining 11:30, creating a new hardcoded wake time, or moralizing.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/night-owl-reject-wall-clock-repair.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/night-owl-reject-wall-clock-repair.scenario.ts
@@ -1,0 +1,80 @@
+/**
+ * B1 night-owl-anchored-day (live, T4 rejection trap). The assistant proposes a
+ * wall-clock 9am reminder by mistake; noor_night rejects it ("no. after i'm up.
+ * fix it.") and the assistant must repair the definition to anchor-relative
+ * (after-wake) semantics, keeping NO 9am due time. Exercises correction-honoring
+ * on the personas pack (#12283); maps to LifeOpsBench
+ * live.nightowl.reject_wall_clock_repair.
+ *
+ * Personas-as-data: the correction lives in the turn text, never in
+ * `promptInstructions` (root AGENTS.md — one scheduler, structural fields only).
+ *
+ * OUTCOME (not echo): definitionCountDelta with forbiddenDueLocalTimes 09:00
+ * proves the final build-check reminder carries NO 9am due time (the correction
+ * actually landed in state), and the judge grades that the repair is
+ * anchor-relative and non-defensive. Asserted concepts are derived from the
+ * response, not copied from the user turn.
+ *
+ * Live-verify note (#12781): the exact repaired-anchor encoding is confirmed at
+ * live capture; the load-bearing outcome (no surviving 9am due time) does not
+ * depend on it.
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "night-owl-reject-wall-clock-repair",
+  title:
+    "Night owl: a mistaken 9am proposal is repaired to after-wake, no 9am survives",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "night-owl", "personas", "12283"],
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Night owl day",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "noor asks for a build-check reminder",
+      text: "remind me to check the build tomorrow. and remember i run late — my morning is whenever i actually get up, not some office hour.",
+    },
+    {
+      kind: "message",
+      name: "noor rejects a mistaken 9am proposal",
+      text: "if you just set that for 9am, no. i'm asleep at 9. after i'm up. fix it so it's anchored to my wake, not a clock time.",
+      responseJudge: {
+        minimumScore: 0.6,
+        rubric:
+          "The owner asked for a build-check reminder and warned that her morning is whenever she actually wakes, not an office hour; she then rejects any 9am setting and asks to anchor it to her wake instead. Grade PASS only if the assistant accepts the correction without defensiveness and changes the reminder to after-wake / anchor-relative semantics, removing any 9am (or other fixed morning) clock time. Deduct heavily if it keeps a 9am time, argues, or leaves the reminder pinned to a fixed clock.",
+      },
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "check the build",
+      titleAliases: [
+        "build check",
+        "check build",
+        "build reminder",
+        "verify the build",
+      ],
+      delta: 1,
+      forbiddenDueLocalTimes: [{ hour: 9, minute: 0 }],
+    },
+    {
+      type: "judgeRubric",
+      name: "repaired-to-anchor-no-9am-survives",
+      minimumScore: 0.6,
+      rubric:
+        "End-to-end: the final build-check reminder is anchored to the owner's wake (after she gets up) and carries NO 9am or other fixed morning clock time — the assistant honored the rejection and repaired the definition rather than preserving the wall-clock proposal. Grade PASS only if the repaired reminder is anchor-relative with no surviving 9am. Deduct heavily for a retained 9am time or a defensive/unchanged reminder.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/night-owl-wake-confirmation-fires-brief.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/night-owl-wake-confirmation-fires-brief.scenario.ts
@@ -1,0 +1,81 @@
+/**
+ * B1 night-owl-anchored-day (live). noor_night's morning brief is anchored to
+ * her wake CONFIRMATION, not a clock time — so the message "just woke up, what's
+ * on deck" IS the anchor event and must surface the day's brief content in THIS
+ * turn, not defer it to a later poll or ask what time it is. Exercises
+ * wake-confirmation firing on the personas pack (#12283); maps to LifeOpsBench
+ * live.nightowl.wake_confirmation_fires_brief.
+ *
+ * Personas-as-data: the night-owl framing lives in the turn text, never in
+ * `promptInstructions` (root AGENTS.md — one scheduler, structural fields only).
+ *
+ * OUTCOME (not echo): the judge grades the load-bearing behavior — the brief
+ * fires on the wake signal, without a wall-clock question and without scolding
+ * the late wake time. The asserted concepts ("brief", "what's on deck") are the
+ * agent's derived response, not tokens the check copies from the user turn.
+ *
+ * Live-verify note (#12781): the exact seeding of the pre-existing wake-anchored
+ * brief definition and the fired-content assertion are confirmed at live capture;
+ * live-verify defers to the key boundary.
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "night-owl-wake-confirmation-fires-brief",
+  title:
+    "Night owl: 'just woke up' is the anchor event and fires the brief now",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "night-owl", "personas", "12283"],
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Night owl day",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "noor sets up the wake-anchored brief",
+      text: "set me up a daily brief, but anchor it to when i actually get up — the first time i tell you i'm awake, not some fixed hour. i keep really weird hours.",
+    },
+    {
+      kind: "message",
+      name: "noor reports she just woke up — the anchor event",
+      text: "ok. just got up. what's on deck for me",
+      responseJudge: {
+        minimumScore: 0.6,
+        rubric:
+          "The owner earlier asked for a daily brief anchored to her wake confirmation (she keeps irregular night-owl hours). This message ('just got up, what's on deck') IS the wake-confirmation anchor event. Grade PASS only if the assistant treats it as the trigger and surfaces the day's brief / agenda content in THIS turn. It must NOT ask what time it is or cite a wall-clock hour as the reason to (not) fire, and must NOT scold or comment on how late she woke up. Deduct heavily if it defers the brief to a later fixed time or ignores the wake signal.",
+      },
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "daily brief",
+      titleAliases: [
+        "brief",
+        "morning brief",
+        "daily briefing",
+        "wake brief",
+        "agenda",
+      ],
+      delta: 1,
+      cadenceKind: "daily",
+      forbiddenDueLocalTimes: [{ hour: 9, minute: 0 }],
+    },
+    {
+      type: "judgeRubric",
+      name: "wake-signal-fires-brief-no-wall-clock",
+      minimumScore: 0.6,
+      rubric:
+        "End-to-end: the assistant created a wake-anchored (not fixed-clock) daily brief, and when the owner said she just got up it delivered the brief content on that wake signal. Grade PASS only if the brief is anchored to her wake event (never pinned to 9am or a default morning hour) AND the wake message actually produced the brief this turn. Deduct heavily if the brief was locked to a fixed clock time or the wake report did not fire it.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/persona.night-owl-anchored-day.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/persona.night-owl-anchored-day.scenario.ts
@@ -1,0 +1,403 @@
+/**
+ * B1 night-owl-anchored-day (pr-deterministic). Deterministic ScheduledTask
+ * proof for noor_night's anchored day: reminders fire relative to HER schedule,
+ * not a hardcoded 9am. Two anchored triggers are exercised against a fixed
+ * logical clock (no LLM, no key):
+ *
+ *   1. a `during_window` "morning brief" fires INSIDE her owner-defined morning
+ *      window (12:00–14:00, i.e. noon, not the neurotypical 07:00) and NOT at a
+ *      wall-clock 09:00 tick — the flexible-window primitive tracks owner facts;
+ *   2. a `relative_to_anchor` reminder fires relative to her wake-confirmation
+ *      anchor + offset, again independent of any fixed clock time.
+ *
+ * Asserts STRUCTURAL outcomes (which task fires, and that a 09:00 tick fires
+ * NOTHING), never routing. Owner facts (timezone + a noon morning window) are
+ * seeded through the REAL OwnerFactStore; tasks are created through the REAL
+ * REST surface; delivery goes through a scenario-registered always-delivering
+ * channel so fires have a real surface. Run keyless with `TZ=UTC` so window math
+ * is unambiguous.
+ *
+ * Maps to LifeOpsBench nightowl.anchored.morning_brief_first_hour_after_wake /
+ * wake_relative_deploy_ping; the live conversational judge of "anchor, don't
+ * assume 9am" stays on the bench LIVE surface. The realization of the bench
+ * capture in the deterministic surface is "exactly one real fire+delivery of the
+ * anchored task at HER instant, none at the 9am tick" — the scheduler-side analog
+ * the keyless proxy can prove, since LifeOps definitions are only created through
+ * a live model call.
+ *
+ * Fail-without-fix anchors:
+ *   - Revert the `during_window` window resolution in
+ *     `plugins/plugin-scheduling/src/scheduled-task/next-fire-at.ts` so the brief
+ *     ignores the seeded owner window and reverts to a default morning hour, and
+ *     the 09:00 tick fires it (the "nothing fires at 9am" turn fails) while the
+ *     noon tick does not (the "fires inside her window" turn fails).
+ *   - Revert `relative_to_anchor` offset handling so the wake reminder no longer
+ *     tracks the wake anchor and the noon-window fire turn fails.
+ */
+
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+type JsonRecord = Record<string, unknown>;
+
+const SCENARIO_ID = "persona.night-owl-anchored-day";
+const DELIVERY_CHANNEL_KIND = "scenario_night_owl_delivery";
+
+// ---------------------------------------------------------------------------
+// Fixed logical clock, far in the future so ONLY the injected tick `now` decides
+// dueness. Timezone UTC so window math is unambiguous. Noor's morning window is
+// 12:00–14:00 (noon is "morning" for a night owl); the wake anchor falls back to
+// morningWindow.start (12:00) when no explicit wake confirmation is recorded.
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function futureDateAtUtc(
+  hour: number,
+  minute: number,
+  daysAhead: number,
+): Date {
+  const base = new Date(Date.now() + daysAhead * DAY_MS);
+  base.setUTCHours(hour, minute, 0, 0);
+  return base;
+}
+
+// Two days ahead so each task's schedule-time next_fire_at is well before every
+// tick. 09:00 is the neurotypical-default trap; noon is inside Noor's window.
+const NEUROTYPICAL_9AM_TICK = futureDateAtUtc(9, 0, 2); // 09:00 — she is asleep
+// 12:35 is inside her window (12:00–14:00) AND strictly after the wake anchor
+// occurrence (morningWindow.start 12:00 + 30m offset = 12:30), so both fire.
+const INSIDE_HER_MORNING_TICK = futureDateAtUtc(12, 35, 2);
+
+interface ChannelContributionLike {
+  kind: string;
+  describe: { label: string };
+  capabilities: {
+    send: boolean;
+    read: boolean;
+    reminders: boolean;
+    voice: boolean;
+    attachments: boolean;
+    quietHoursAware: boolean;
+  };
+  send?(payload: unknown): Promise<{ ok: true; messageId: string }>;
+}
+
+interface ChannelRegistryLike {
+  register(contribution: ChannelContributionLike): void;
+  get(kind: string): ChannelContributionLike | null;
+}
+
+interface RuntimeLike {
+  channelRegistry?: ChannelRegistryLike;
+}
+
+const deliveryLedger: unknown[] = [];
+
+// assertResponse receives only (status, body) — captured ids live in module
+// state, reset by the seed (mirrors persona.flexible-scheduling).
+const capturedTaskIds: { brief: string | null; wake: string | null } = {
+  brief: null,
+  wake: null,
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function seedFactsAndChannel(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  deliveryLedger.length = 0;
+  capturedTaskIds.brief = null;
+  capturedTaskIds.wake = null;
+  const runtime = ctx.runtime as RuntimeLike;
+
+  const registry = runtime.channelRegistry;
+  if (!registry || typeof registry.register !== "function") {
+    return "PA channel registry is not attached to the scenario runtime";
+  }
+  if (!registry.get(DELIVERY_CHANNEL_KIND)) {
+    registry.register({
+      kind: DELIVERY_CHANNEL_KIND,
+      describe: { label: "Scenario night-owl delivery probe" },
+      capabilities: {
+        send: true,
+        read: false,
+        reminders: true,
+        voice: false,
+        attachments: false,
+        quietHoursAware: false,
+      },
+      async send(payload: unknown): Promise<{ ok: true; messageId: string }> {
+        deliveryLedger.push(payload);
+        return {
+          ok: true,
+          messageId: `${SCENARIO_ID}-delivered-${deliveryLedger.length}`,
+        };
+      },
+    });
+  }
+
+  // Seed owner facts through the REAL store: a NOON morning window — the whole
+  // point of the pack. during_window / relative_to_anchor read this at tick time.
+  const { resolveOwnerFactStore } = await import(
+    "@elizaos/plugin-personal-assistant/plugin"
+  );
+  const store = resolveOwnerFactStore(
+    ctx.runtime as unknown as Parameters<typeof resolveOwnerFactStore>[0],
+  );
+  await store.update(
+    {
+      timezone: "UTC",
+      morningWindow: { startLocal: "12:00", endLocal: "14:00" },
+      eveningWindow: { startLocal: "20:00", endLocal: "23:00" },
+      quietHours: { startLocal: "04:00", endLocal: "11:30", timezone: "UTC" },
+    },
+    { source: "profile_save", recordedAt: new Date().toISOString() },
+  );
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Tick response readers.
+// ---------------------------------------------------------------------------
+
+interface FireEntry {
+  taskId: string;
+  status: string;
+  reason: string;
+}
+
+function readFires(body: unknown): FireEntry[] | string {
+  if (!isRecord(body) || body.success !== true) {
+    return `expected tick success=true, saw ${JSON.stringify(body)}`;
+  }
+  const raw = body.scheduledTaskFires;
+  if (!Array.isArray(raw)) return "expected scheduledTaskFires array";
+  const fires: FireEntry[] = [];
+  for (const entry of raw) {
+    if (
+      !isRecord(entry) ||
+      typeof entry.taskId !== "string" ||
+      typeof entry.status !== "string" ||
+      typeof entry.reason !== "string"
+    ) {
+      return `malformed scheduledTaskFires entry: ${JSON.stringify(entry)}`;
+    }
+    fires.push({
+      taskId: entry.taskId,
+      status: entry.status,
+      reason: entry.reason,
+    });
+  }
+  return fires;
+}
+
+function firesForTask(
+  body: unknown,
+  taskId: string | null,
+): FireEntry[] | string {
+  const fires = readFires(body);
+  if (typeof fires === "string") return fires;
+  if (typeof taskId !== "string" || taskId.length === 0) {
+    return "captured taskId was not set by the create turn";
+  }
+  return fires.filter((fire) => fire.taskId === taskId);
+}
+
+function captureTaskId(
+  slot: keyof typeof capturedTaskIds,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    if (!isRecord(body) || !isRecord(body.task)) {
+      return `expected {task} response, saw ${JSON.stringify(body)}`;
+    }
+    const task = body.task;
+    if (typeof task.taskId !== "string" || task.taskId.length === 0) {
+      return `expected task.taskId string, saw ${JSON.stringify(task.taskId)}`;
+    }
+    capturedTaskIds[slot] = task.taskId;
+    return undefined;
+  };
+}
+
+function firedFor(
+  slot: keyof typeof capturedTaskIds,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    const fires = firesForTask(body, capturedTaskIds[slot]);
+    if (typeof fires === "string") return fires;
+    if (fires.length !== 1 || fires[0]?.status !== "fired") {
+      return `expected exactly one fired for ${slot}, saw ${JSON.stringify(fires)}`;
+    }
+    return undefined;
+  };
+}
+
+function notFiredFor(
+  slot: keyof typeof capturedTaskIds,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    const fires = firesForTask(body, capturedTaskIds[slot]);
+    if (typeof fires === "string") return fires;
+    const fired = fires.filter((f) => f.status === "fired");
+    if (fired.length !== 0) {
+      return `expected ${slot} NOT to fire at the 9am tick, saw ${JSON.stringify(fired)}`;
+    }
+    return undefined;
+  };
+}
+
+// At the neurotypical 09:00 tick, NEITHER anchored task may fire — that is the
+// whole point: her day is not pinned to a default morning hour.
+function neitherFiresAt9am(_status: number, body: unknown): string | undefined {
+  return (
+    notFiredFor("brief")(_status, body) ?? notFiredFor("wake")(_status, body)
+  );
+}
+
+// Both anchored reminders fire in the SAME tick inside her noon window: the
+// during_window brief and the wake-anchored (wake.confirmed + 30m) reminder are
+// both due at 12:35 — proving both anchor to HER schedule, not a fixed clock.
+function bothFireInHerWindow(
+  _status: number,
+  body: unknown,
+): string | undefined {
+  return firedFor("brief")(_status, body) ?? firedFor("wake")(_status, body);
+}
+
+export default scenario({
+  // Literal (not SCENARIO_ID) so the corpus guard + coverage gate, which read
+  // the id statically, resolve it.
+  id: "persona.night-owl-anchored-day",
+  lane: "pr-deterministic",
+  title:
+    "Night owl anchored day: brief fires in her noon window and a wake-anchored reminder fires relative to wake — never at 9am",
+  domain: "lifeops",
+  tags: [
+    "pr",
+    "deterministic",
+    "zero-cost",
+    "lifeops",
+    "night-owl",
+    "personas",
+    "scheduled-tasks",
+    "12283",
+  ],
+  isolation: "shared-runtime",
+  requires: {
+    plugins: [
+      "@elizaos/plugin-scheduling",
+      "@elizaos/plugin-personal-assistant",
+    ],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "seed owner facts (noon morning window) and delivery channel",
+      apply: seedFactsAndChannel,
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      title: "Night Owl Anchored Day",
+    },
+  ],
+  turns: [
+    // The morning brief is a during_window task tied to HER morning window.
+    {
+      kind: "api",
+      name: "create the during_window morning brief",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions: "morning brief, whenever her morning actually is",
+        trigger: { kind: "during_window", windowKey: "morning" },
+        priority: "low",
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-morning-brief`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureTaskId("brief"),
+    },
+    // The deploy-check reminder is anchored to wake + 30m, not a wall clock.
+    {
+      kind: "api",
+      name: "create the wake-anchored deploy reminder",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions: "ping about the deploy, an hour after she is up",
+        trigger: {
+          kind: "relative_to_anchor",
+          anchorKey: "wake.confirmed",
+          offsetMinutes: 30,
+        },
+        priority: "low",
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-wake-deploy`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureTaskId("wake"),
+    },
+    // The neurotypical 9am tick: she is asleep. NOTHING anchored may fire.
+    {
+      kind: "tick",
+      name: "tick at 09:00 (the neurotypical default) → nothing fires",
+      worker: "lifeops_scheduler",
+      options: {
+        now: NEUROTYPICAL_9AM_TICK.toISOString(),
+        scheduledTaskLimit: 50,
+      },
+      assertResponse: neitherFiresAt9am,
+    },
+    // Inside her noon window: BOTH the during_window brief and the
+    // wake-anchored reminder (morningWindow.start 12:00 + 30m = 12:30, now past)
+    // are due at the same tick — each anchors to her schedule, not to 9am.
+    {
+      kind: "tick",
+      name: "tick at 12:35 (inside her window / after wake anchor) → both fire",
+      worker: "lifeops_scheduler",
+      options: {
+        now: INSIDE_HER_MORNING_TICK.toISOString(),
+        scheduledTaskLimit: 50,
+      },
+      assertResponse: bothFireInHerWindow,
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "both anchored reminders delivered — in her window, never at 9am",
+      predicate: (): string | undefined => {
+        // brief fire + wake fire = exactly 2 deliveries; nothing delivered at
+        // the 9am tick (that turn asserted no fires).
+        if (deliveryLedger.length !== 2) {
+          return `expected exactly 2 deliveries (brief + wake, both in her noon window), saw ${deliveryLedger.length}`;
+        }
+        return undefined;
+      },
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/persona.night-owl-quiet-hours-sleep-protection.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/persona.night-owl-quiet-hours-sleep-protection.scenario.ts
@@ -1,0 +1,381 @@
+/**
+ * B1 night-owl-anchored-day (pr-deterministic). Deterministic ScheduledTask
+ * proof for noor_night's sleep-protection window: her quiet hours run 04:00–11:30
+ * (a delayed sleep phase, not the neurotypical 22:00–06:00), and a low-value
+ * reminder that lands inside that window is HELD, while a high-priority reminder
+ * breaks through. Drives the REAL scheduler tick (logical clock, no LLM, no key)
+ * and asserts STRUCTURAL outcomes (which task defers vs. fires, and what actually
+ * gets delivered), not routing.
+ *
+ * Owner facts (timezone + her 04:00–11:30 quiet hours) are seeded through the
+ * REAL OwnerFactStore. Tasks are created through the REAL REST surface. Delivery
+ * goes through a scenario-registered always-delivering channel so fires have a
+ * real surface. Run keyless with `TZ=UTC` so quiet-hours window math is
+ * unambiguous.
+ *
+ * Maps to LifeOpsBench nightowl.anchored.sleep_protection_quiet_window /
+ * multi_day_quiet_hours_consistency; the live conversational judge of "protect
+ * her sleep, don't schedule fake morning stuff in there" stays on the bench LIVE
+ * surface. The realization of the bench capture in the deterministic surface is
+ * "the low-value reminder is held while she sleeps, and only the high-priority
+ * one is delivered" — the scheduler-side analog the keyless proxy can prove,
+ * since LifeOps definitions are only created through a live model call.
+ *
+ * Fail-without-fix anchors:
+ *   - Revert the `quiet_hours` gate's window read so it ignores the seeded
+ *     04:00–11:30 owner window (or reverts to a default 22:00–06:00) and the
+ *     low-value reminder fires at 08:00 while she sleeps — the "defers, not
+ *     fires" turn fails and the delivery ledger grows past one.
+ *   - Break `highPriorityBypass` so the high-priority reminder is also held
+ *     during quiet hours — the "high priority breaks through" turn fails.
+ */
+
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+type JsonRecord = Record<string, unknown>;
+
+const SCENARIO_ID = "persona.night-owl-quiet-hours-sleep-protection";
+const DELIVERY_CHANNEL_KIND = "scenario_night_owl_quiet_delivery";
+
+// ---------------------------------------------------------------------------
+// Fixed logical clock, far in the future so ONLY the injected tick `now` decides
+// dueness. Timezone UTC. Noor's quiet hours are 04:00–11:30 — 08:00 is squarely
+// inside them (she is asleep), so a quiet-hours-gated reminder must be held.
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function futureDateAtUtc(
+  hour: number,
+  minute: number,
+  daysAhead: number,
+): Date {
+  const base = new Date(Date.now() + daysAhead * DAY_MS);
+  base.setUTCHours(hour, minute, 0, 0);
+  return base;
+}
+
+const INSIDE_HER_SLEEP_TICK = futureDateAtUtc(8, 0, 2); // 08:00 — she is asleep
+
+interface ChannelContributionLike {
+  kind: string;
+  describe: { label: string };
+  capabilities: {
+    send: boolean;
+    read: boolean;
+    reminders: boolean;
+    voice: boolean;
+    attachments: boolean;
+    quietHoursAware: boolean;
+  };
+  send?(payload: unknown): Promise<{ ok: true; messageId: string }>;
+}
+
+interface ChannelRegistryLike {
+  register(contribution: ChannelContributionLike): void;
+  get(kind: string): ChannelContributionLike | null;
+}
+
+interface RuntimeLike {
+  channelRegistry?: ChannelRegistryLike;
+}
+
+const deliveryLedger: unknown[] = [];
+
+// assertResponse receives only (status, body) — captured ids live in module
+// state, reset by the seed (mirrors persona.flexible-scheduling).
+const capturedTaskIds: {
+  lowValue: string | null;
+  highPriority: string | null;
+} = { lowValue: null, highPriority: null };
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function seedFactsAndChannel(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  deliveryLedger.length = 0;
+  capturedTaskIds.lowValue = null;
+  capturedTaskIds.highPriority = null;
+  const runtime = ctx.runtime as RuntimeLike;
+
+  const registry = runtime.channelRegistry;
+  if (!registry || typeof registry.register !== "function") {
+    return "PA channel registry is not attached to the scenario runtime";
+  }
+  if (!registry.get(DELIVERY_CHANNEL_KIND)) {
+    registry.register({
+      kind: DELIVERY_CHANNEL_KIND,
+      describe: { label: "Scenario night-owl quiet-hours delivery probe" },
+      capabilities: {
+        send: true,
+        read: false,
+        reminders: true,
+        voice: false,
+        attachments: false,
+        quietHoursAware: false,
+      },
+      async send(payload: unknown): Promise<{ ok: true; messageId: string }> {
+        deliveryLedger.push(payload);
+        return {
+          ok: true,
+          messageId: `${SCENARIO_ID}-delivered-${deliveryLedger.length}`,
+        };
+      },
+    });
+  }
+
+  // Seed owner facts through the REAL store: her DELAYED-PHASE quiet hours,
+  // 04:00–11:30 — the whole point of the pack. The quiet_hours gate reads this.
+  const { resolveOwnerFactStore } = await import(
+    "@elizaos/plugin-personal-assistant/plugin"
+  );
+  const store = resolveOwnerFactStore(
+    ctx.runtime as unknown as Parameters<typeof resolveOwnerFactStore>[0],
+  );
+  await store.update(
+    {
+      timezone: "UTC",
+      quietHours: { startLocal: "04:00", endLocal: "11:30", timezone: "UTC" },
+    },
+    { source: "profile_save", recordedAt: new Date().toISOString() },
+  );
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Tick response readers.
+// ---------------------------------------------------------------------------
+
+interface FireEntry {
+  taskId: string;
+  status: string;
+  reason: string;
+}
+
+function readFires(body: unknown): FireEntry[] | string {
+  if (!isRecord(body) || body.success !== true) {
+    return `expected tick success=true, saw ${JSON.stringify(body)}`;
+  }
+  const raw = body.scheduledTaskFires;
+  if (!Array.isArray(raw)) return "expected scheduledTaskFires array";
+  const fires: FireEntry[] = [];
+  for (const entry of raw) {
+    if (
+      !isRecord(entry) ||
+      typeof entry.taskId !== "string" ||
+      typeof entry.status !== "string" ||
+      typeof entry.reason !== "string"
+    ) {
+      return `malformed scheduledTaskFires entry: ${JSON.stringify(entry)}`;
+    }
+    fires.push({
+      taskId: entry.taskId,
+      status: entry.status,
+      reason: entry.reason,
+    });
+  }
+  return fires;
+}
+
+function firesForTask(
+  body: unknown,
+  taskId: string | null,
+): FireEntry[] | string {
+  const fires = readFires(body);
+  if (typeof fires === "string") return fires;
+  if (typeof taskId !== "string" || taskId.length === 0) {
+    return "captured taskId was not set by the create turn";
+  }
+  return fires.filter((fire) => fire.taskId === taskId);
+}
+
+function captureTaskId(
+  slot: keyof typeof capturedTaskIds,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    if (!isRecord(body) || !isRecord(body.task)) {
+      return `expected {task} response, saw ${JSON.stringify(body)}`;
+    }
+    const task = body.task;
+    if (typeof task.taskId !== "string" || task.taskId.length === 0) {
+      return `expected task.taskId string, saw ${JSON.stringify(task.taskId)}`;
+    }
+    capturedTaskIds[slot] = task.taskId;
+    return undefined;
+  };
+}
+
+function firedFor(
+  slot: keyof typeof capturedTaskIds,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    const fires = firesForTask(body, capturedTaskIds[slot]);
+    if (typeof fires === "string") return fires;
+    if (fires.length !== 1 || fires[0]?.status !== "fired") {
+      return `expected exactly one fired for ${slot}, saw ${JSON.stringify(fires)}`;
+    }
+    return undefined;
+  };
+}
+
+function deferredFor(
+  slot: keyof typeof capturedTaskIds,
+  reasonPrefix: string,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    const fires = firesForTask(body, capturedTaskIds[slot]);
+    if (typeof fires === "string") return fires;
+    const fired = fires.filter((f) => f.status === "fired");
+    if (fired.length !== 0) {
+      return `expected ${slot} to defer, not fire, saw ${JSON.stringify(fired)}`;
+    }
+    const deferred = fires.find((f) => f.reason.includes(reasonPrefix));
+    if (!deferred) {
+      return `expected ${slot} deferred with reason ~"${reasonPrefix}", saw ${JSON.stringify(fires)}`;
+    }
+    return undefined;
+  };
+}
+
+// One tick inside her sleep window: the low-value reminder is HELD by quiet
+// hours; the high-priority reminder bypasses and fires.
+function protectsSleep(_status: number, body: unknown): string | undefined {
+  return (
+    deferredFor("lowValue", "quiet_hours")(_status, body) ??
+    firedFor("highPriority")(_status, body)
+  );
+}
+
+export default scenario({
+  // Literal (not SCENARIO_ID) so the corpus guard + coverage gate, which read
+  // the id statically, resolve it.
+  id: "persona.night-owl-quiet-hours-sleep-protection",
+  lane: "pr-deterministic",
+  title:
+    "Night owl sleep protection: a low-value reminder is held in her 04:00–11:30 quiet hours; only a high-priority one breaks through",
+  domain: "lifeops",
+  tags: [
+    "pr",
+    "deterministic",
+    "zero-cost",
+    "lifeops",
+    "night-owl",
+    "personas",
+    "scheduled-tasks",
+    "12283",
+  ],
+  isolation: "shared-runtime",
+  requires: {
+    plugins: [
+      "@elizaos/plugin-scheduling",
+      "@elizaos/plugin-personal-assistant",
+    ],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "seed owner facts (04:00–11:30 quiet hours) and delivery channel",
+      apply: seedFactsAndChannel,
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      title: "Night Owl Sleep Protection",
+    },
+  ],
+  turns: [
+    // A low-value reminder gated by quiet_hours: it must be HELD while she sleeps.
+    {
+      kind: "api",
+      name: "create the low-value reminder (quiet-hours gated)",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions: "optional: tidy the desktop when convenient",
+        trigger: { kind: "interval", everyMinutes: 60 },
+        shouldFire: {
+          compose: "all",
+          gates: [
+            { kind: "quiet_hours", params: { highPriorityBypass: true } },
+          ],
+        },
+        priority: "low",
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-low-value`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureTaskId("lowValue"),
+    },
+    // A high-priority reminder gated by the SAME quiet_hours gate: it must break
+    // through via highPriorityBypass even while she sleeps.
+    {
+      kind: "api",
+      name: "create the high-priority reminder (same gate, bypasses)",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions: "urgent: the on-call page needs an ack",
+        trigger: { kind: "interval", everyMinutes: 60 },
+        shouldFire: {
+          compose: "all",
+          gates: [
+            { kind: "quiet_hours", params: { highPriorityBypass: true } },
+          ],
+        },
+        priority: "high",
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-high-priority`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureTaskId("highPriority"),
+    },
+    // A single tick at 08:00, deep inside her 04:00–11:30 sleep window: the
+    // low-value reminder defers on quiet_hours; the high-priority one fires.
+    {
+      kind: "tick",
+      name: "tick at 08:00 (inside her sleep window) → low held, high fires",
+      worker: "lifeops_scheduler",
+      options: {
+        now: INSIDE_HER_SLEEP_TICK.toISOString(),
+        scheduledTaskLimit: 50,
+      },
+      assertResponse: protectsSleep,
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "exactly one delivery — the high-priority reminder, never the low-value one",
+      predicate: (): string | undefined => {
+        if (deliveryLedger.length !== 1) {
+          return `expected exactly 1 delivery (the high-priority reminder; the low-value one is held in her sleep window), saw ${deliveryLedger.length}`;
+        }
+        return undefined;
+      },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Completes the scenario-runner (TypeScript) slice of LifeOps persona pack **B1 — night-owl-anchored-day** (persona `noor_night`, #12771), mirroring the A1 pack convention (#13286).

Coverage gate: B1 **1/24 → 24/24 authored** (18 verified).

### What
- **Authored 7 new scenario-runner scenarios** (2 pr-deterministic + 5 live-only), on top of the 1 pre-existing B1 SR scenario (`night-owl-flexible-habit-any-time-today`), for **8 total**.
- **pr-deterministic** (keyless, real `lifeops_scheduler` tick, no LLM):
  - `persona.night-owl-anchored-day` — a `during_window` "morning brief" fires inside her seeded **noon** window (12:00–14:00) and a `relative_to_anchor` wake reminder fires relative to the wake anchor, while a neurotypical **09:00** tick fires **NOTHING** (two-delivery `custom` finalCheck).
  - `persona.night-owl-quiet-hours-sleep-protection` — at 08:00 inside her seeded **04:00–11:30** quiet hours a low-value reminder is **HELD** while a high-priority one breaks through via `highPriorityBypass` (single-delivery `custom` finalCheck).
  - Both authored under `plugins/plugin-personal-assistant/test/scenarios/` (the one root scanned by **both** `corpus-assertion-guard.test.ts` **and** the coverage gate — the **G1** convention A1 established) and added to `EXPECTED_PR_DETERMINISTIC_SCENARIO_IDS` in the same commit.
- **live-only** (`status: "authored"`, live-verify deferred to the key boundary #12781): `night-owl-wake-confirmation-fires-brief`, `night-owl-observed-wake-drift-adaptation`, `night-owl-end-of-evening-nudge`, `night-owl-contradiction-reconciles-anchor`, `night-owl-reject-wall-clock-repair` (T4 rejection trap). Each has effect-reading `finalChecks` (`definitionCountDelta` + `judgeRubric`), non-echo-satisfiable, personas-as-data in `turns[].text` (never `promptInstructions`). Premises ported from #12278.
- **Catalog:** appended 7 new `surface: "scenario-runner"` rows + registered all **16** existing `surface: "lifeops-bench"` Python ids (append-only; **no** `lifeops-bench/**` file touched). 8 SR + 16 bench = 24 = target.
- **Coverage gate fix:** taught `check-lifeops-persona-catalog-coverage.mjs` to also resolve the positional-first-arg ids of the `_scenario()`/`_live()` bench factories — B1's bench file uses factories, not inline `id="..."`, so the old `id=`-only regex silently under-counted them. Scoped to the scenario-builder names so `_anchor()`/`_definition()` helper strings are not mis-read as ids. Not a `lifeops-bench/**` edit.

### D7 / crisis-guard boundary
No scenario tests a not-built crisis guard. The rejection-trap scenario asserts an anchor-relative repair outcome only.

## Evidence
- **Coverage gate** → B1 **24/24 authored, 18/24 verified**; all ids resolve exactly once (exit 0).
- **Keyless pr-deterministic runs** (`TZ=UTC SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 --conditions eliza-source --lane pr-deterministic`): **2 passed, 0 failed** — `persona.night-owl-anchored-day` (452ms) + `persona.night-owl-quiet-hours-sleep-protection` (329ms). Referenced code paths (`during_window`/`relative_to_anchor` next-fire-at, `quiet_hours` gate + `highPriorityBypass`) are all real.
- **Ratchets + guard** (`corpus-assertion-guard` + `echo-assertion-ratchet` + `action-effect-ratchet` + `skippable-check-ratchet`) → **14 passed, 0 failed** (baselines unchanged; new pr-det ids in `EXPECTED`).
- **Live-only:** the 5 live-only scenarios load cleanly (valid `id` / `lane: live-only` / 2 finalChecks each) and are `status: "authored"`, not `verified` — there are no API keys in this environment, so **live-verify is deferred to the key boundary (#12781)**, exactly as #13286 did.

Closes #12771

🤖 Generated with [Claude Code](https://claude.com/claude-code)