### PR TITLE
fix(#12657): own basic-capabilities config in the declaring plugin, delete name-keyed registerPlugin branch

### DIFF
--- a/packages/core/src/features/basic-capabilities/capability-registration.test.ts
+++ b/packages/core/src/features/basic-capabilities/capability-registration.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Regression coverage for capability configuration living in the declaring
+ * plugin instead of a central name-keyed branch in `registerPlugin` (#12657).
+ *
+ * Boots real AgentRuntimes (no DB, migrations skipped) and asserts that the
+ * capability config the runtime resolves — from explicit constructor options
+ * AND from the character-settings fallback that used to live only inside the
+ * deleted `plugin.name === "basic-capabilities"` branch — is reflected in the
+ * actions the runtime actually registers. A source guard proves the name-keyed
+ * special case is gone from the executable registration path.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { AgentRuntime } from "../../runtime.ts";
+import type { Character } from "../../types/agent.ts";
+import {
+	type CapabilitySettingFlags,
+	type ExplicitCapabilityOptions,
+	resolveCapabilityConfig,
+} from "./index.ts";
+
+const ADVANCED_ACTION = "ROLE";
+const BASIC_ACTION = "REPLY";
+
+function actionNames(runtime: AgentRuntime): Set<string> {
+	return new Set(runtime.actions.map((action) => action.name));
+}
+
+async function bootRuntime(
+	opts: ConstructorParameters<typeof AgentRuntime>[0],
+): Promise<AgentRuntime> {
+	const runtime = new AgentRuntime({ logLevel: "fatal", ...opts });
+	await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+	return runtime;
+}
+
+describe("resolveCapabilityConfig", () => {
+	it("prefers explicit options over character settings", () => {
+		const options: ExplicitCapabilityOptions = {
+			disableBasic: false,
+			enableExtended: false,
+		};
+		const settings: CapabilitySettingFlags = {
+			DISABLE_BASIC_CAPABILITIES: "true",
+			ENABLE_EXTENDED_CAPABILITIES: "true",
+		};
+
+		const config = resolveCapabilityConfig(options, settings);
+
+		expect(config.disableBasic).toBe(false);
+		expect(config.enableExtended).toBe(false);
+	});
+
+	it("falls back to character settings when an option is unspecified", () => {
+		const config = resolveCapabilityConfig(
+			{},
+			{
+				ENABLE_EXTENDED_CAPABILITIES: "true",
+				ENABLE_AUTONOMY: true,
+			},
+		);
+
+		expect(config.enableExtended).toBe(true);
+		expect(config.enableAutonomy).toBe(true);
+		// Unspecified everywhere resolves to a concrete false, never undefined,
+		// so the plugin factory receives a fully-resolved config.
+		expect(config.disableBasic).toBe(false);
+		expect(config.enableTrust).toBe(false);
+	});
+
+	it("treats ADVANCED_CAPABILITIES as an alias for ENABLE_EXTENDED_CAPABILITIES", () => {
+		expect(
+			resolveCapabilityConfig({}, { ADVANCED_CAPABILITIES: "true" })
+				.enableExtended,
+		).toBe(true);
+	});
+
+	it("resolves an empty config to all-off (except forced flags left to caller)", () => {
+		const config = resolveCapabilityConfig({}, undefined);
+		expect(config).toEqual({
+			disableBasic: false,
+			enableExtended: false,
+			skipCharacterProvider: false,
+			enableAutonomy: false,
+			enableTrust: false,
+			enableSecretsManager: false,
+			enablePluginManager: false,
+		});
+	});
+});
+
+describe("basic-capabilities registration through the declaring plugin", () => {
+	it("registers only basic actions with the default config", async () => {
+		const runtime = await bootRuntime({
+			character: { name: "cap-default" } as Character,
+		});
+		const names = actionNames(runtime);
+		expect(names.has(BASIC_ACTION)).toBe(true);
+		expect(names.has(ADVANCED_ACTION)).toBe(false);
+	});
+
+	// The drift/fallback mode that made the central coupling unsafe: extended
+	// capabilities requested ONLY through character settings (not a constructor
+	// option). This path used to be re-derived inside the name-keyed branch;
+	// it now flows through resolveCapabilityConfig in the constructor.
+	it("enables advanced actions from ENABLE_EXTENDED_CAPABILITIES character settings", async () => {
+		const runtime = await bootRuntime({
+			character: {
+				name: "cap-extended-via-settings",
+				settings: { ENABLE_EXTENDED_CAPABILITIES: "true" },
+			} as Character,
+		});
+		const names = actionNames(runtime);
+		expect(names.has(ADVANCED_ACTION)).toBe(true);
+		expect(names.has(BASIC_ACTION)).toBe(true);
+	});
+
+	it("enables advanced actions from the ADVANCED_CAPABILITIES alias setting", async () => {
+		const runtime = await bootRuntime({
+			character: {
+				name: "cap-extended-via-alias",
+				settings: { ADVANCED_CAPABILITIES: true },
+			} as Character,
+		});
+		expect(actionNames(runtime).has(ADVANCED_ACTION)).toBe(true);
+	});
+
+	it("lets an explicit constructor option enable advanced actions", async () => {
+		const runtime = await bootRuntime({
+			character: { name: "cap-extended-via-opt" } as Character,
+			enableExtendedCapabilities: true,
+		});
+		expect(actionNames(runtime).has(ADVANCED_ACTION)).toBe(true);
+	});
+
+	it("lets a constructor option override an on character setting (explicit wins)", async () => {
+		const runtime = await bootRuntime({
+			character: {
+				name: "cap-opt-overrides-setting",
+				settings: { ENABLE_EXTENDED_CAPABILITIES: "true" },
+			} as Character,
+			enableExtendedCapabilities: false,
+		});
+		expect(actionNames(runtime).has(ADVANCED_ACTION)).toBe(false);
+	});
+
+	it("drops basic actions when disableBasic is requested via character settings", async () => {
+		const runtime = await bootRuntime({
+			character: {
+				name: "cap-disable-basic",
+				settings: { DISABLE_BASIC_CAPABILITIES: "true" },
+			} as Character,
+		});
+		expect(actionNames(runtime).has(BASIC_ACTION)).toBe(false);
+	});
+});
+
+describe("name-keyed special case is gone from the registration path", () => {
+	it("does not branch on plugin.name === 'basic-capabilities' in runtime.ts", () => {
+		const runtimeSource = readFileSync(
+			fileURLToPath(new URL("../../runtime.ts", import.meta.url)),
+			"utf8",
+		);
+		expect(runtimeSource).not.toMatch(
+			/plugin\.name\s*===\s*["']basic-capabilities["']/,
+		);
+		expect(runtimeSource).not.toMatch(
+			/name\s*===\s*["']basic-capabilities["']/,
+		);
+	});
+});

--- a/packages/core/src/features/basic-capabilities/index.ts
+++ b/packages/core/src/features/basic-capabilities/index.ts
@@ -1449,6 +1449,81 @@ export interface CapabilityConfig {
 	enablePluginManager?: boolean;
 }
 
+/**
+ * Explicit (constructor-level) capability toggles a runtime already knows,
+ * before the character-settings fallback is applied. Every field is a resolved
+ * boolean or `undefined` ("not specified") — `undefined` defers to the matching
+ * character setting; a concrete boolean overrides it.
+ */
+export interface ExplicitCapabilityOptions {
+	disableBasic?: boolean;
+	enableExtended?: boolean;
+	advancedCapabilities?: boolean;
+	skipCharacterProvider?: boolean;
+	enableAutonomy?: boolean;
+	enableTrust?: boolean;
+	enableSecretsManager?: boolean;
+	enablePluginManager?: boolean;
+}
+
+/**
+ * The subset of character settings that toggle capabilities. Each is the
+ * character-file fallback for the matching explicit option; string `"true"` and
+ * boolean `true` both count as on, everything else off. Kept structural (no
+ * import of the full `CharacterSettings`) so this feature module stays free of a
+ * back-edge to the agent-type surface.
+ */
+export interface CapabilitySettingFlags {
+	DISABLE_BASIC_CAPABILITIES?: boolean | string;
+	ENABLE_EXTENDED_CAPABILITIES?: boolean | string;
+	ADVANCED_CAPABILITIES?: boolean | string;
+	ENABLE_AUTONOMY?: boolean | string;
+	ENABLE_TRUST?: boolean | string;
+	ENABLE_SECRETS_MANAGER?: boolean | string;
+	ENABLE_PLUGIN_MANAGER?: boolean | string;
+}
+
+const isSettingEnabled = (value: boolean | string | undefined): boolean =>
+	value === true || value === "true";
+
+/**
+ * Resolve the complete capability configuration a runtime should build its
+ * basic-capabilities plugin from. Explicit constructor options win; where an
+ * option is unspecified the matching character setting decides.
+ *
+ * This is the single source of truth for capability resolution: the runtime
+ * calls it once at construction and hands the resulting config to
+ * {@link createBasicCapabilitiesPlugin}. Registration then carries no knowledge
+ * of capability flags — the declaring plugin already reflects them — which is
+ * why `registerPlugin` needs no name-keyed special case.
+ */
+export function resolveCapabilityConfig(
+	options: ExplicitCapabilityOptions,
+	settings: CapabilitySettingFlags | undefined,
+): CapabilityConfig {
+	return {
+		disableBasic:
+			options.disableBasic ??
+			isSettingEnabled(settings?.DISABLE_BASIC_CAPABILITIES),
+		enableExtended:
+			options.enableExtended ??
+			options.advancedCapabilities ??
+			(isSettingEnabled(settings?.ENABLE_EXTENDED_CAPABILITIES) ||
+				isSettingEnabled(settings?.ADVANCED_CAPABILITIES)),
+		skipCharacterProvider: options.skipCharacterProvider ?? false,
+		enableAutonomy:
+			options.enableAutonomy ?? isSettingEnabled(settings?.ENABLE_AUTONOMY),
+		enableTrust:
+			options.enableTrust ?? isSettingEnabled(settings?.ENABLE_TRUST),
+		enableSecretsManager:
+			options.enableSecretsManager ??
+			isSettingEnabled(settings?.ENABLE_SECRETS_MANAGER),
+		enablePluginManager:
+			options.enablePluginManager ??
+			isSettingEnabled(settings?.ENABLE_PLUGIN_MANAGER),
+	};
+}
+
 // Autonomy capabilities - opt-in
 // Provides autonomous operation with continuous agent thinking loop
 const autonomyCapabilities = {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -38,7 +38,9 @@ import { InMemoryDatabaseAdapter } from "./database/inMemoryAdapter";
 import { type ReportedError, toElizaError } from "./errors";
 import {
 	type CapabilityConfig,
+	type CapabilitySettingFlags,
 	createBasicCapabilitiesPlugin,
+	resolveCapabilityConfig,
 } from "./features/basic-capabilities/index";
 import {
 	INFERENCE_MARKS,
@@ -1057,19 +1059,25 @@ export class AgentRuntime implements IAgentRuntime {
 			this.isAnonymousCharacter = true;
 		}
 
-		// Store capability options for use in initialize()
-		// When character is anonymous, also signal to skip the character provider
-		// Support both enableExtendedCapabilities and advancedCapabilities as aliases
-		this.capabilityOptions = {
-			disableBasic: opts.disableBasicCapabilities,
-			enableExtended: opts.enableExtendedCapabilities,
-			advancedCapabilities: opts.advancedCapabilities,
-			skipCharacterProvider: this.isAnonymousCharacter,
-			enableAutonomy: opts.enableAutonomy,
-			enableTrust: opts.enableTrust,
-			enableSecretsManager: opts.enableSecretsManager,
-			enablePluginManager: opts.enablePluginManager,
-		};
+		// Resolve the full capability config once, at construction: explicit
+		// constructor options win, and any option left unspecified falls back to
+		// the matching character setting. initialize() then builds the
+		// basic-capabilities plugin from this config, so registerPlugin needs no
+		// name-keyed branch to re-derive it. Anonymous characters have no character
+		// provider to inject, so skipCharacterProvider is forced on.
+		this.capabilityOptions = resolveCapabilityConfig(
+			{
+				disableBasic: opts.disableBasicCapabilities,
+				enableExtended: opts.enableExtendedCapabilities,
+				advancedCapabilities: opts.advancedCapabilities,
+				skipCharacterProvider: this.isAnonymousCharacter,
+				enableAutonomy: opts.enableAutonomy,
+				enableTrust: opts.enableTrust,
+				enableSecretsManager: opts.enableSecretsManager,
+				enablePluginManager: opts.enablePluginManager,
+			},
+			character.settings as CapabilitySettingFlags | undefined,
+		);
 		this.nativeFeatureOptions = {
 			documents: opts.enableDocuments,
 			relationships: opts.enableRelationships,
@@ -1846,67 +1854,13 @@ export class AgentRuntime implements IAgentRuntime {
 			return;
 		}
 
-		// Handle capability-aware registration for basic-capabilities plugin
-		let pluginToRegister = plugin;
-		if (plugin.name === "basic-capabilities") {
-			const settings = this.character.settings;
-			// Constructor options take precedence over character settings
-			const disableBasic =
-				this.capabilityOptions.disableBasic ??
-				(settings?.DISABLE_BASIC_CAPABILITIES === true ||
-					settings?.DISABLE_BASIC_CAPABILITIES === "true");
-			// Support both enableExtended/enableExtendedCapabilities and advancedCapabilities as aliases
-			const enableExtended =
-				this.capabilityOptions.enableExtended ??
-				this.capabilityOptions.advancedCapabilities ??
-				(settings?.ENABLE_EXTENDED_CAPABILITIES === true ||
-					settings?.ENABLE_EXTENDED_CAPABILITIES === "true" ||
-					settings?.ADVANCED_CAPABILITIES === true ||
-					settings?.ADVANCED_CAPABILITIES === "true");
-			const skipCharacterProvider =
-				this.capabilityOptions.skipCharacterProvider ?? false;
-			const enableAutonomy =
-				this.capabilityOptions.enableAutonomy ??
-				(settings?.ENABLE_AUTONOMY === true ||
-					settings?.ENABLE_AUTONOMY === "true");
-			const enableTrust =
-				this.capabilityOptions.enableTrust ??
-				(settings?.ENABLE_TRUST === true || settings?.ENABLE_TRUST === "true");
-			const enableSecretsManager =
-				this.capabilityOptions.enableSecretsManager ??
-				(settings?.ENABLE_SECRETS_MANAGER === true ||
-					settings?.ENABLE_SECRETS_MANAGER === "true");
-			const enablePluginManager =
-				this.capabilityOptions.enablePluginManager ??
-				(settings?.ENABLE_PLUGIN_MANAGER === true ||
-					settings?.ENABLE_PLUGIN_MANAGER === "true");
-
-			if (
-				disableBasic ||
-				enableExtended ||
-				skipCharacterProvider ||
-				enableAutonomy ||
-				enableTrust ||
-				enableSecretsManager ||
-				enablePluginManager
-			) {
-				const config: CapabilityConfig = {
-					disableBasic,
-					enableExtended,
-					skipCharacterProvider,
-					enableAutonomy,
-					enableTrust,
-					enableSecretsManager,
-					enablePluginManager,
-				};
-				const configuredPlugin = createBasicCapabilitiesPlugin(config);
-				pluginToRegister = {
-					...configuredPlugin,
-					events: plugin.events ?? configuredPlugin.events,
-				};
-			}
-		}
-
+		// Registration is purely structural: whatever plugin the caller declares —
+		// including basic-capabilities, already built from the resolved capability
+		// config by initialize() — is registered as-is. No name-keyed branch
+		// re-derives or rebuilds a specific plugin; capability configuration is
+		// owned by the declaring plugin (via resolveCapabilityConfig +
+		// createBasicCapabilitiesPlugin), not by this method.
+		const pluginToRegister = plugin;
 		(this.plugins as Plugin[]).push(pluginToRegister);
 		this.logger.debug(
 			{ src: "agent", agentId: this.agentId, plugin: pluginToRegister.name },


### PR DESCRIPTION
## What & why

Arch-audit item #12089(7): *"basic-capabilities mega-plugin assembled by central flag factory and rebuilt by a name-keyed branch in registerPlugin."*

`registerPlugin` carried a `plugin.name === "basic-capabilities"` special case that **re-derived** the capability config from character settings + capability options and **rebuilt** the plugin with `createBasicCapabilitiesPlugin(config)` — throwing away the plugin it was handed. But `initialize()` already builds a correctly-configured basic-capabilities plugin from `this.capabilityOptions` and passes *that* into `registerPlugin`. So config resolution was split across two code paths (the constructor's opts-only `capabilityOptions` vs. the branch's opts+settings re-derivation) that had to stay in sync. That split is the drift/fallback mode the audit flagged as unsafe central coupling.

## The change (why it's simpler)

- New `resolveCapabilityConfig(options, settings)` helper in `features/basic-capabilities/index.ts`, next to the factory it feeds. It is the **single source of truth** for capability resolution: explicit constructor options win; any option left unspecified falls back to the matching character setting. Returns a fully-resolved `CapabilityConfig` (concrete booleans, never `undefined`).
- The runtime constructor calls it once, folding in the character-settings fallback that previously lived only inside the deleted branch.
- `registerPlugin` is now **purely structural** — it registers whatever plugin it is handed, no name-keyed branch. Capability configuration is owned by the declaring plugin (via `resolveCapabilityConfig` + `createBasicCapabilitiesPlugin`), not by a central name list in the register method.

Net: the register path drops from ~60 lines of flag fan-out to a structural pass-through (`+103 / -74`).

## Grep proof — the name-keyed branch is gone from the executable path

```
$ grep -rn 'plugin.name === "basic-capabilities"' packages/core/src/runtime.ts
grep-exit=1   # no matches — branch removed
```

A committed source-guard test (`capability-registration.test.ts`) also asserts `runtime.ts` contains no `/(plugin\.)?name\s*===\s*["']basic-capabilities["']/`, so the removal is mechanically enforced against regression.

## Tests

New `packages/core/src/features/basic-capabilities/capability-registration.test.ts` covers:
- `resolveCapabilityConfig` unit behavior: option-over-setting precedence, settings fallback, `ADVANCED_CAPABILITIES` alias, empty→all-off.
- Registration through the declaring plugin: default (basic only), **settings-only extended (the drift/fallback mode)**, alias setting, constructor-opt extended, opt-overrides-setting, and `disableBasic` via settings — each asserted against the runtime's actually-registered actions.
- Source guard proving the name-keyed branch is gone.

```
# bun test src/features/basic-capabilities/capability-registration.test.ts
 11 pass / 0 fail  (18 expect() calls)

# existing basic-capabilities + runtime/plugin-lifecycle suites
 control-transport + dm-owner-grant: 5 pass / 0 fail
 runtime-report-error + plugin-action-context/component-override/action-role-policy + core-security-hooks: 23 pass / 0 fail
```

Pre-existing, unrelated failures under the local `bun test` runner: 5 in `process-attachments-documents.test.ts` (`vi.stubGlobal` is undefined under Bun — present on `origin/develop` too) and 1 `linkExtractionEvaluator` test that needs a live TEXT_SMALL model. Neither touches the registration path.

**Verification note:** `bun run --cwd packages/core typecheck` fails in this isolated worktree with `TS2688 Cannot find type definition file for 'node'` — `@types/node` resolves via Node ancestor-walk to the parent eliza tree but `tsgo` does not walk the same way. This is an isolated-worktree tooling limitation, not a code defect; typecheck defers to CI. Runtime types are exercised by the passing tests (Bun transpiles + imports the new symbols).

Closes #12657

🤖 Generated with [Claude Code](https://claude.com/claude-code)