### PR TITLE
fix(#12674): generic navigate-view payload; plugin-owned Phone/Messages handoff

### DIFF
--- a/packages/ui/src/app-navigate-view.test.ts
+++ b/packages/ui/src/app-navigate-view.test.ts
@@ -6,9 +6,12 @@
  * views or desktop tabs. Pure functions + injected bridge, no runtime.
  */
 
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { createNavigateViewEvent } from "@elizaos/shared/events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  __setNavigateViewPayloadForTests,
   consumeNavigateViewPayload,
   createNavigateViewHandler,
   type DesktopBridgeRequest,
@@ -410,6 +413,65 @@ describe("App navigate-view shell handler", () => {
       consumeNavigateViewPayload<{ rowId: string }>("remote-ledger"),
     ).toEqual({ rowId: "row-7" });
     expect(consumeNavigateViewPayload("remote-ledger")).toBeNull();
+  });
+
+  it("delivers a plugin-shaped deep-link payload to any target view id", () => {
+    // A plugin's own navigate helper dispatches with the view id it targets and
+    // a payload shape the view claims — the core stays generic, no view is
+    // special-cased. Mirrors the Contacts→Phone/Messages handoff (#12674).
+    const fixture = createHandlerFixture([
+      view({ id: "phone", label: "Phone", path: "/phone" }),
+    ]);
+
+    fixture.handler(
+      navigateEvent({
+        viewId: "phone",
+        viewPath: "/phone",
+        payload: { number: "+15550100" },
+      }),
+    );
+
+    expect(
+      consumeNavigateViewPayload<{ number: string }>("phone"),
+    ).toEqual({ number: "+15550100" });
+    // Single-shot: a later plain navigation to the same view does not re-seed.
+    expect(consumeNavigateViewPayload("phone")).toBeNull();
+  });
+
+  it("returns null before a payload is seeded (no stale one-shot state)", () => {
+    expect(consumeNavigateViewPayload("messages")).toBeNull();
+    __setNavigateViewPayloadForTests("messages", { recipient: "+15550100" });
+    expect(
+      consumeNavigateViewPayload<{ recipient: string }>("messages"),
+    ).toEqual({ recipient: "+15550100" });
+    expect(consumeNavigateViewPayload("messages")).toBeNull();
+  });
+
+  // Regression guard for #12674: the core navigate module must not name the
+  // Phone/Messages view ids or hold plugin-specific module-global one-shot
+  // state. The generic `payload` channel + per-plugin navigate helpers replace
+  // it. This asserts the removed special case cannot silently return.
+  it("holds no hardcoded Phone/Messages special case or one-shot globals", () => {
+    // Vitest runs with cwd at the package root (packages/ui); the guarded
+    // module is a fixed source path from there.
+    const source = readFileSync(
+      resolve(process.cwd(), "src/app-navigate-view.ts"),
+      "utf8",
+    );
+    for (const banned of [
+      "pendingPhoneNumber",
+      "pendingMessageRecipient",
+      "consumePendingPhoneNumber",
+      "consumePendingMessageRecipient",
+      "navigateToPhoneWithNumber",
+      "navigateToMessagesWithNumber",
+      "normalizePhoneNumber",
+    ]) {
+      expect(source).not.toContain(banned);
+    }
+    // No view id is literally special-cased by the payload channel.
+    expect(source).not.toContain('"phone"');
+    expect(source).not.toContain('"messages"');
   });
 
   it("navigates browser history for normal view navigation", () => {

--- a/packages/ui/src/app-navigate-view.ts
+++ b/packages/ui/src/app-navigate-view.ts
@@ -3,10 +3,7 @@
  * entry the agent's view actions and the shell use to switch views.
  */
 import { logger } from "@elizaos/logger";
-import {
-  dispatchNavigateViewEvent,
-  type NavigateViewDetail,
-} from "@elizaos/shared/events";
+import type { NavigateViewDetail } from "@elizaos/shared/events";
 import type { ViewRegistryEntry } from "./hooks/useAvailableViews";
 import { type Tab, tabFromPath } from "./navigation";
 
@@ -19,29 +16,17 @@ export type ActiveViewLayout = {
   placement?: string;
 };
 
-const pendingNavigateViewPayloads = new Map<string, unknown>();
-
-// Cross-view phone-number handoff.
+// Cross-view navigation payload channel.
 //
-// `NavigateViewDetail` (and `createNavigateViewHandler`) route only by view
-// id/path — there is no payload channel that reaches a *mounted* target view.
-// So when one in-app surface wants to open the Phone or Messages view
-// pre-seeded with a number (e.g. a Contacts "Call"/"Message" control, or a
-// phone-recent row), we stash the number here before dispatching the navigate
-// event, and the target view consumes it on mount/focus. The handoff is
-// single-shot: each `consume*` clears the value so a later plain navigation to
-// that view does not re-seed a stale number.
-
-/** Strip whitespace/separators, keeping a leading + and digits. */
-function normalizePhoneNumber(input: string): string {
-  const trimmed = input.trim();
-  if (!trimmed) return "";
-  const leadingPlus = trimmed.startsWith("+") ? "+" : "";
-  return `${leadingPlus}${trimmed.replace(/[^0-9]/g, "")}`;
-}
-
-let pendingPhoneNumber: string | null = null;
-let pendingMessageRecipient: string | null = null;
+// `NavigateViewDetail.payload` is an opaque, view-owned deep-link value:
+// `createNavigateViewHandler` stashes it here keyed by target `viewId` before
+// switching views, and the target view claims it on mount/focus via
+// `consumeNavigateViewPayload<T>()`, narrowing the value at that boundary. The
+// handoff is single-shot — `consume` deletes the entry so a later plain
+// navigation to the same view does not re-seed a stale payload. The channel is
+// generic: no view id is special-cased here, and the plugin that owns a view
+// ships its own navigate helper that constructs the payload shape it expects.
+const pendingNavigateViewPayloads = new Map<string, unknown>();
 
 export function consumeNavigateViewPayload<T = unknown>(
   viewId: string,
@@ -62,39 +47,6 @@ export function __setNavigateViewPayloadForTests(
 function storeNavigateViewPayload(detail: NavigateViewDetail): void {
   if (!detail.viewId || detail.payload === undefined) return;
   pendingNavigateViewPayloads.set(detail.viewId, detail.payload);
-}
-
-export function consumePendingPhoneNumber(): string | null {
-  const number = pendingPhoneNumber;
-  pendingPhoneNumber = null;
-  return number;
-}
-
-export function consumePendingMessageRecipient(): string | null {
-  const address = pendingMessageRecipient;
-  pendingMessageRecipient = null;
-  return address;
-}
-
-/**
- * Open the Phone view via the navigation bus, pre-seeding the dialer with
- * `number`. Used by Contacts "Call" controls and phone-recent rows.
- */
-export function navigateToPhoneWithNumber(number: string): void {
-  if (typeof window === "undefined") return;
-  pendingPhoneNumber = normalizePhoneNumber(number) || null;
-  dispatchNavigateViewEvent({ viewId: "phone", viewPath: "/phone" });
-}
-
-/**
- * Open the Messages view via the navigation bus, pre-seeding the composer "To"
- * field with `address`. Used by Contacts "Message" controls.
- */
-export function navigateToMessagesWithNumber(address: string): void {
-  if (typeof window === "undefined") return;
-  const trimmed = address.trim();
-  pendingMessageRecipient = trimmed || null;
-  dispatchNavigateViewEvent({ viewId: "messages", viewPath: "/messages" });
 }
 
 export type DesktopTabOpen = (

--- a/plugins/plugin-contacts/src/components/ContactsAppView.tsx
+++ b/plugins/plugin-contacts/src/components/ContactsAppView.tsx
@@ -43,6 +43,10 @@ import {
   useRef,
   useState,
 } from "react";
+import {
+  navigateToMessagesWithNumber,
+  navigateToPhoneWithNumber,
+} from "./contacts-navigate.ts";
 
 type Mode = "list" | "detail" | "new";
 
@@ -57,32 +61,6 @@ const EMPTY_FORM: NewContactForm = {
   phoneNumber: "",
   emailAddress: "",
 };
-
-function navigateToPhoneWithNumber(number: string): void {
-  if (typeof window === "undefined") return;
-  window.dispatchEvent(
-    new CustomEvent("eliza:navigate:view", {
-      detail: {
-        viewId: "phone",
-        viewPath: "/phone",
-        payload: { number },
-      },
-    }),
-  );
-}
-
-function navigateToMessagesWithNumber(recipient: string): void {
-  if (typeof window === "undefined") return;
-  window.dispatchEvent(
-    new CustomEvent("eliza:navigate:view", {
-      detail: {
-        viewId: "messages",
-        viewPath: "/messages",
-        payload: { recipient },
-      },
-    }),
-  );
-}
 
 function getInitials(name: string): string {
   const parts = name.trim().split(/\s+/).filter(Boolean);

--- a/plugins/plugin-contacts/src/components/ContactsView.tsx
+++ b/plugins/plugin-contacts/src/components/ContactsView.tsx
@@ -30,38 +30,16 @@ import {
   type ContactsSnapshot,
   ContactsSpatialView,
 } from "./ContactsSpatialView.tsx";
+import {
+  navigateToMessagesWithNumber,
+  navigateToPhoneWithNumber,
+} from "./contacts-navigate.ts";
 
 const EMPTY_FORM: ContactsFormDraft = {
   displayName: "",
   phoneNumber: "",
   emailAddress: "",
 };
-
-function navigateToPhoneWithNumber(number: string): void {
-  if (typeof window === "undefined") return;
-  window.dispatchEvent(
-    new CustomEvent("eliza:navigate:view", {
-      detail: {
-        viewId: "phone",
-        viewPath: "/phone",
-        payload: { number },
-      },
-    }),
-  );
-}
-
-function navigateToMessagesWithNumber(recipient: string): void {
-  if (typeof window === "undefined") return;
-  window.dispatchEvent(
-    new CustomEvent("eliza:navigate:view", {
-      detail: {
-        viewId: "messages",
-        viewPath: "/messages",
-        payload: { recipient },
-      },
-    }),
-  );
-}
 
 export function ContactsView() {
   const [contacts, setContacts] = useState<ContactSummary[]>([]);

--- a/plugins/plugin-contacts/src/components/contacts-navigate.test.ts
+++ b/plugins/plugin-contacts/src/components/contacts-navigate.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+// Unit coverage for the plugin-owned Contacts navigate helpers (#12674): each
+// helper dispatches the shared navigate-view event with the target view id and
+// the deep-link payload shape that view claims. Real event bus, no mocks — the
+// generic core channel replaced the old hardcoded Phone/Messages special case.
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  navigateToMessagesWithNumber,
+  navigateToPhoneWithNumber,
+} from "./contacts-navigate.ts";
+
+function captureNavigateEvents(run: () => void): CustomEvent[] {
+  const events: CustomEvent[] = [];
+  const listener = (e: Event) => events.push(e as CustomEvent);
+  window.addEventListener("eliza:navigate:view", listener);
+  try {
+    run();
+  } finally {
+    window.removeEventListener("eliza:navigate:view", listener);
+  }
+  return events;
+}
+
+describe("Contacts navigate helpers", () => {
+  afterEach(() => {
+    // The window bus is process-global; nothing to reset, but keep the hook so
+    // added assertions on module state stay isolated.
+  });
+
+  it("navigateToPhoneWithNumber opens the Phone view pre-seeding the dialer", () => {
+    const events = captureNavigateEvents(() =>
+      navigateToPhoneWithNumber("+15550100"),
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]?.detail).toEqual({
+      viewId: "phone",
+      viewPath: "/phone",
+      payload: { number: "+15550100" },
+    });
+  });
+
+  it("navigateToMessagesWithNumber opens the Messages view pre-seeding the composer", () => {
+    const events = captureNavigateEvents(() =>
+      navigateToMessagesWithNumber("+15550100"),
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]?.detail).toEqual({
+      viewId: "messages",
+      viewPath: "/messages",
+      payload: { recipient: "+15550100" },
+    });
+  });
+});

--- a/plugins/plugin-contacts/src/components/contacts-navigate.ts
+++ b/plugins/plugin-contacts/src/components/contacts-navigate.ts
@@ -1,0 +1,36 @@
+/**
+ * Plugin-owned navigate helpers for the Contacts surface's Call/Text handoffs.
+ *
+ * Contacts owns no Phone or Messages view, so it hands off intent through the
+ * shared navigate-view bus: it constructs the deep-link payload the target
+ * view's own `consumeNavigateViewPayload<T>()` claims on mount. The payload
+ * shapes here (`{ number }` for the Phone dialer, `{ recipient }` for the
+ * Messages composer) are the contract those views read; the shared core
+ * (`@elizaos/ui/app-navigate-view`) stays generic and names no view id. Keeping
+ * this next to the components that call it — rather than in the shared core —
+ * is the point of the #12674 audit item.
+ */
+
+import { dispatchNavigateViewEvent } from "@elizaos/ui/events";
+
+/** Deep-link payload the Phone view claims to pre-seed its dialer. */
+export type PhoneNavigatePayload = { number: string };
+
+/** Deep-link payload the Messages view claims to pre-seed its composer "To". */
+export type MessagesNavigatePayload = { recipient: string };
+
+/** Open the Phone view via the navigation bus, pre-seeding the dialer. */
+export function navigateToPhoneWithNumber(number: string): void {
+  const payload: PhoneNavigatePayload = { number };
+  dispatchNavigateViewEvent({ viewId: "phone", viewPath: "/phone", payload });
+}
+
+/** Open the Messages view via the navigation bus, pre-seeding the composer. */
+export function navigateToMessagesWithNumber(recipient: string): void {
+  const payload: MessagesNavigatePayload = { recipient };
+  dispatchNavigateViewEvent({
+    viewId: "messages",
+    viewPath: "/messages",
+    payload,
+  });
+}


### PR DESCRIPTION
## What & why

Audit item #12089 (28): the shared navigate module `packages/ui/src/app-navigate-view.ts` special-cased the **Phone** and **Messages** view ids and held a **module-global one-shot side channel** (`pendingPhoneNumber` / `pendingMessageRecipient` + `consumePendingPhoneNumber` / `consumePendingMessageRecipient` / `navigateToPhoneWithNumber` / `navigateToMessagesWithNumber` / `normalizePhoneNumber`) to seed those two views on navigation. That coupled the generic shell to two specific plugins and drove cross-view intent through mutable module globals — the exact "central name-keyed special case + global singleton side channel" the audit flags.

**Redesign — generic payload channel, plugin-owned helpers:**

- Core now routes intent **only** through the already-present generic `NavigateViewDetail.payload` channel: `createNavigateViewHandler` stashes the opaque payload keyed by target `viewId`, and the target view claims it via `consumeNavigateViewPayload<T>()`, **narrowing at that boundary** (validate-at-boundary, not `any`). No view id is named in core anymore; no plugin-specific one-shot globals remain.
- The **Contacts** plugin (the only producer of the handoff) ships its own typed navigate helpers in `plugins/plugin-contacts/src/components/contacts-navigate.ts` that construct the `{ number }` / `{ recipient }` payloads the Phone/Messages views read. `ContactsView` and `ContactsAppView` import them instead of each duplicating an inline raw-`CustomEvent` dispatch.
- **Phone/Messages views already consumed the generic payload** (`consumeNavigateViewPayload<PhoneNavigatePayload>("phone")` / `("messages")`) and already own their own number normalization — no change needed there, no behavior change (dropping the core-side `normalizePhoneNumber` is safe because `PhoneView` normalizes on consume via `normalizeNumber`).

**Simpler because:** the shared shell has zero knowledge of Phone/Messages; one generic payload path replaces a bespoke two-view side channel; ownership of each view's deep-link shape sits with the plugin that owns the view.

## Grep proof — old central special case is gone from executable paths

```
$ grep -nE "pendingPhoneNumber|pendingMessageRecipient|consumePendingPhoneNumber|consumePendingMessageRecipient|navigateToPhoneWithNumber|navigateToMessagesWithNumber|normalizePhoneNumber|\"phone\"|\"messages\"" packages/ui/src/app-navigate-view.ts
NONE FOUND — core is generic, no Phone/Messages special case, no one-shot globals
```

A vitest source-guard (`app-navigate-view.test.ts` → "holds no hardcoded Phone/Messages special case or one-shot globals") asserts this mechanically so the special case cannot silently return.

## Tests

Focused regression coverage:
- **`packages/ui/src/app-navigate-view.test.ts`** — a plugin-shaped deep-link payload reaches any target view id and is single-shot (no stale re-seed); `consume` returns `null` before seed; source-guard proving the removed symbols/ids are absent.
- **`plugins/plugin-contacts/src/components/contacts-navigate.test.ts`** (new) — the plugin-owned helpers dispatch the correct typed payloads (`{ number }` → phone, `{ recipient }` → messages) over the real event bus.
- Existing `ContactsView`/`ContactsAppView`/`PhoneView`/`MessagesView` tests still exercise the full handoff end-to-end.

```
packages/ui       app-navigate-view.test.ts        18 passed
plugins/plugin-contacts  contacts-navigate.test.ts + ContactsView.test.tsx   15 passed
plugins/plugin-contacts  ContactsAppView.test.ts   14 passed
plugins/plugin-phone     PhoneView.test.tsx        14 passed
plugins/plugin-messages  MessagesView.test.tsx     11 passed
```

Typecheck of my changed files is clean (`bun run --cwd packages/ui typecheck` reports zero errors for `app-navigate-view*` / `contacts-navigate*`). The two remaining `packages/ui` tsc errors (`useWhatsAppPairing.test.tsx` spread-arg, `immersive-fixture.ts` missing `iwer`) are **pre-existing on `develop`** and untouched by this PR. CI is the gate for full-repo verify (isolated worktree needed the generated `core/i18n` file regenerated locally to run scoped tests).

## Evidence

| Type | Status |
| --- | --- |
| UI screenshots / video | **N/A** — pure navigation-plumbing refactor; no rendered/visual change. The user-facing Call/Text → dialer/composer behavior is unchanged and covered by the rendered-DOM `ContactsView`/`PhoneView`/`MessagesView` tests above. |
| Real-LLM trajectories | **N/A** — no agent/action/provider/prompt/model change. |
| Backend logs | **N/A** — client-side navigation only. |
| Regression tests | Attached above (all green). |

Closes #12674

🤖 Generated with [Claude Code](https://claude.com/claude-code)
