### PR TITLE
fix(openai): restore record args named items

### DIFF
--- a/plugins/plugin-openai/__tests__/record-args-observability.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/record-args-observability.shape.test.ts
@@ -188,6 +188,46 @@ describe("#13111 strict-safe record/map tool args", () => {
       },
     ]);
   });
+
+  it("reverse-maps a record property literally named items", () => {
+    const { recordArgTransformsByTool } = normalizeNativeToolsForCall([
+      {
+        name: "save_inventory",
+        parameters: {
+          type: "object",
+          properties: {
+            items: { type: "object", additionalProperties: { type: "string" } },
+          },
+          required: ["items"],
+        },
+      },
+    ]);
+
+    expect(
+      restoreRecordArgToolCalls(
+        [
+          {
+            toolName: "save_inventory",
+            input: {
+              items: {
+                [ENTRIES_KEY]: [{ key: "sku-1", value: "in-stock" }],
+              },
+            },
+          },
+        ],
+        recordArgTransformsByTool
+      )
+    ).toEqual([
+      {
+        toolName: "save_inventory",
+        input: {
+          items: {
+            "sku-1": "in-stock",
+          },
+        },
+      },
+    ]);
+  });
 });
 
 /**

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -718,7 +718,10 @@ function restoreRecordArgAtPath(
   }
 
   const [token, ...rest] = tokens;
-  if (token === "items" || /^items\[\d+\]$/.test(token)) {
+  if (token === "items" && Array.isArray(value)) {
+    return value.map((item) => restoreRecordArgAtPath(item, rest, transform));
+  }
+  if (/^items\[\d+\]$/.test(token)) {
     return Array.isArray(value)
       ? value.map((item) => restoreRecordArgAtPath(item, rest, transform))
       : value;


### PR DESCRIPTION
## Summary

Follow-up to #13315.

#13315 merged the strict-safe record/map tool-argument transform for #13111. During review I found one edge case in the restore walker: a tool arg property literally named `items` collided with the schema-path token used for array item schemas, so reverse mapping could skip that object property.

This PR makes `items` act as array traversal only when the current runtime value is actually an array; otherwise it falls through to normal object-property traversal. It also adds a regression test for a record/map argument named `items`.

## Validation

- `bun run --cwd plugins/plugin-openai typecheck`
- `bun run --cwd plugins/plugin-openai test -- __tests__/record-args-observability.shape.test.ts __tests__/native-plumbing.shape.test.ts __tests__/sanitize-json-schema.shape.test.ts` -> 44 passed before rebasing onto merged #13315
- `bun run --cwd plugins/plugin-openai test` -> 95 passed, 3 skipped before rebasing onto merged #13315
- `git diff --name-only -z origin/develop...HEAD | xargs -0 bunx @biomejs/biome check` -> passed before rebasing onto merged #13315
- `bun run audit:error-policy-ratchet` -> passed before rebasing onto merged #13315

After #13315 merged, this branch was rebased onto current `origin/develop` and now contains only the follow-up edge-case commit.