### PR TITLE
fix: upgrade kept fact row on dedupe hit + revive dead oauth-header regression test

### DIFF
--- a/packages/agent/test/api/accounts-routes.test.ts
+++ b/packages/agent/test/api/accounts-routes.test.ts
@@ -1,6 +1,8 @@
 /** Exercises account API route behavior with deterministic auth and storage fixtures. */
 import { IncomingMessage, ServerResponse } from "node:http";
 import { Socket } from "node:net";
+import { listAccounts, saveAccount } from "@elizaos/auth/account-storage";
+import { getAccessToken } from "@elizaos/auth/credentials";
 import type { LinkedAccountConfig } from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AccountsRouteContext } from "../../src/api/accounts-routes";
@@ -8,35 +10,30 @@ import {
   _resetAccountsRoutesPoolCache,
   handleAccountsRoutes,
 } from "../../src/api/accounts-routes";
-import { listAccounts, saveAccount } from "../../src/auth/account-storage.js";
-import { getAccessToken } from "../../src/auth/credentials.ts";
+import {
+  _resetAgentHostBridge,
+  defaultAgentHostBridge,
+  setAgentHostBridge,
+} from "../../src/runtime/host-bridge.ts";
 
-const poolMock = vi.hoisted(() => ({
+const poolMock = {
   list: vi.fn(),
   get: vi.fn(),
   upsert: vi.fn(),
   deleteMetadata: vi.fn(),
   refreshUsage: vi.fn(),
-}));
+};
 
-vi.mock("@elizaos/app-core", () => ({
-  getDefaultAccountPool: () => poolMock,
-}));
-
-vi.mock("@elizaos/app-core/account-pool", () => ({
-  getDefaultAccountPool: () => poolMock,
-}));
-
-vi.mock("../../src/auth/account-storage.js", () => ({
+vi.mock("@elizaos/auth/account-storage", () => ({
   deleteAccount: vi.fn(),
   listAccounts: vi.fn(() => []),
   loadAccount: vi.fn(() => null),
   saveAccount: vi.fn(),
 }));
 
-vi.mock("../../src/auth/credentials.ts", async (importOriginal) => {
+vi.mock("@elizaos/auth/credentials", async (importOriginal) => {
   const actual =
-    await importOriginal<typeof import("../../src/auth/credentials.ts")>();
+    await importOriginal<typeof import("@elizaos/auth/credentials")>();
   return { ...actual, getAccessToken: vi.fn(async () => null) };
 });
 
@@ -92,11 +89,19 @@ describe("accounts routes provider-scoped account resolution", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     _resetAccountsRoutesPoolCache();
+    // The routes read the pool through the host-bridge seam (not an
+    // @elizaos/app-core import), so the fixture pool is installed the same
+    // way a real host installs it.
+    setAgentHostBridge({
+      ...defaultAgentHostBridge,
+      getDefaultAccountPool: () => poolMock,
+    });
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
+    _resetAgentHostBridge();
   });
 
   it("sends the oauth beta header when testing an anthropic subscription", async () => {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -77,7 +77,10 @@ import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "./runtime/builtin-fie
 import { ChatPreHandlerRegistry } from "./runtime/chat-pre-handler-registry";
 import { ContextRegistry } from "./runtime/context-registry";
 import { DEFAULT_CONTEXT_DEFINITIONS } from "./runtime/default-contexts";
-import { findEquivalentFactId } from "./runtime/fact-write-dedupe";
+import {
+	findEquivalentFact,
+	mergeStrongerFactMetadata,
+} from "./runtime/fact-write-dedupe";
 import type { ResponseHandlerEvaluator } from "./runtime/response-handler-evaluators";
 import type { ResponseHandlerFieldEvaluator } from "./runtime/response-handler-field-evaluator";
 import { ResponseHandlerFieldRegistry } from "./runtime/response-handler-field-registry";
@@ -9736,9 +9739,18 @@ ${section_end}`;
 		// similarity check needs an embedding (absent inline on fact writes) and
 		// is bypassed whenever callers pass `unique` — so without this guard the
 		// same claim lands as multiple rows (see runtime/fact-write-dedupe.ts).
+		// A dedupe hit may still carry new information: stronger metadata on the
+		// incoming occurrence (higher confidence, an explicit kind, a fresher
+		// validity timestamp) upgrades the kept row instead of being dropped.
 		if (tableName === "facts") {
-			const equivalentId = await findEquivalentFactId(this, memory);
-			if (equivalentId) return equivalentId;
+			const equivalent = await findEquivalentFact(this, memory);
+			if (equivalent?.id) {
+				const upgraded = mergeStrongerFactMetadata(equivalent, memory);
+				if (upgraded) {
+					await this.updateMemory({ id: equivalent.id, metadata: upgraded });
+				}
+				return equivalent.id;
+			}
 		}
 
 		const ids = await this.adapter.createMemories([

--- a/packages/core/src/runtime/__tests__/fact-write-dedupe.test.ts
+++ b/packages/core/src/runtime/__tests__/fact-write-dedupe.test.ts
@@ -89,7 +89,11 @@ function makeState(): State {
 	};
 }
 
-function makeFact(text: string, entityId: UUID = USER): Memory {
+function makeFact(
+	text: string,
+	entityId: UUID = USER,
+	metadata?: Memory["metadata"],
+): Memory {
 	return {
 		id: crypto.randomUUID() as UUID,
 		entityId,
@@ -97,6 +101,7 @@ function makeFact(text: string, entityId: UUID = USER): Memory {
 		roomId: ROOM,
 		content: { text, type: "fact" },
 		createdAt: Date.now(),
+		...(metadata ? { metadata } : {}),
 	};
 }
 
@@ -143,6 +148,87 @@ describe("fact write-time dedupe (runtime.createMemory)", () => {
 		await runtime.createMemory(makeFact("!!!"), "facts", true);
 		await runtime.createMemory(makeFact("???"), "facts", true);
 		expect(await readFactRows(runtime)).toHaveLength(2);
+	});
+
+	it("a duplicate with stronger metadata upgrades the kept row", async () => {
+		const runtime = makeRuntime();
+		const firstId = await runtime.createMemory(
+			makeFact("nubs plays guitar", USER, {
+				type: "custom",
+				source: "facts_and_relationships_stage",
+				kind: "current",
+				confidence: 0.4,
+				validAt: "2026-07-01T00:00:00.000Z",
+			}),
+			"facts",
+			true,
+		);
+		const secondId = await runtime.createMemory(
+			makeFact("Nubs plays guitar.", USER, {
+				type: "custom",
+				confidence: 0.9,
+				validAt: "2026-07-04T00:00:00.000Z",
+			}),
+			"facts",
+			true,
+		);
+		expect(secondId).toBe(firstId);
+		const rows = await readFactRows(runtime);
+		expect(rows).toHaveLength(1);
+		const meta = rows[0].metadata as Record<string, unknown>;
+		expect(meta.confidence).toBe(0.9);
+		expect(meta.validAt).toBe("2026-07-04T00:00:00.000Z");
+		// Untouched kept-row fields survive the upgrade.
+		expect(meta.kind).toBe("current");
+		expect(meta.source).toBe("facts_and_relationships_stage");
+	});
+
+	it("a duplicate with weaker metadata is a plain skip", async () => {
+		const runtime = makeRuntime();
+		await runtime.createMemory(
+			makeFact("nubs plays guitar", USER, {
+				type: "custom",
+				kind: "durable",
+				confidence: 0.9,
+				validAt: "2026-07-04T00:00:00.000Z",
+			}),
+			"facts",
+			true,
+		);
+		await runtime.createMemory(
+			makeFact("nubs plays guitar", USER, {
+				type: "custom",
+				kind: "current",
+				confidence: 0.4,
+				validAt: "2026-07-01T00:00:00.000Z",
+			}),
+			"facts",
+			true,
+		);
+		const rows = await readFactRows(runtime);
+		expect(rows).toHaveLength(1);
+		const meta = rows[0].metadata as Record<string, unknown>;
+		expect(meta.confidence).toBe(0.9);
+		// An already-set kind is never flipped by a duplicate.
+		expect(meta.kind).toBe("durable");
+		expect(meta.validAt).toBe("2026-07-04T00:00:00.000Z");
+	});
+
+	it("an explicit kind fills a kept row that has none", async () => {
+		const runtime = makeRuntime();
+		await runtime.createMemory(
+			makeFact("nubs plays guitar", USER, { type: "custom" }),
+			"facts",
+			true,
+		);
+		await runtime.createMemory(
+			makeFact("nubs plays guitar", USER, { type: "custom", kind: "current" }),
+			"facts",
+			true,
+		);
+		const rows = await readFactRows(runtime);
+		expect(rows).toHaveLength(1);
+		expect((rows[0].metadata as Record<string, unknown>).kind).toBe("current");
 	});
 });
 

--- a/packages/core/src/runtime/fact-write-dedupe.ts
+++ b/packages/core/src/runtime/fact-write-dedupe.ts
@@ -2,7 +2,9 @@
  * Structural write-time dedupe for the `facts` table: before a fact insert,
  * find an existing row with the same normalized text in the same
  * room + entity scope so `runtime.createMemory` can skip the write and return
- * the existing row's id.
+ * the existing row's id — after folding any stronger metadata the new
+ * occurrence carries (higher confidence, an explicit kind, a fresher validity
+ * timestamp) into the kept row, so a dedupe hit never drops new information.
  *
  * This guard exists because nothing else structurally prevents duplicate fact
  * rows. The adapter-level similarity check requires an embedding (facts
@@ -20,8 +22,7 @@
  * error) on rooms with very deep fact history.
  */
 
-import type { Memory } from "../types/memory";
-import type { UUID } from "../types/primitives";
+import type { FactMetadata, Memory, MemoryMetadata } from "../types/memory";
 import type { IAgentRuntime } from "../types/runtime";
 
 const DEDUPE_CANDIDATE_POOL = 120;
@@ -39,15 +40,15 @@ export function normalizeFactTextKey(value: string): string {
 }
 
 /**
- * Returns the id of an existing `facts` row equivalent to `memory`
- * (same normalized text, same room, same entity), or null when the write
- * should proceed. Rows sharing `memory.id` are ignored — same-id idempotence
- * is the adapter's contract, not a duplicate.
+ * Returns the existing `facts` row equivalent to `memory` (same normalized
+ * text, same room, same entity), or null when the write should proceed. Rows
+ * sharing `memory.id` are ignored — same-id idempotence is the adapter's
+ * contract, not a duplicate.
  */
-export async function findEquivalentFactId(
+export async function findEquivalentFact(
 	runtime: Pick<IAgentRuntime, "getMemories">,
 	memory: Memory,
-): Promise<UUID | null> {
+): Promise<Memory | null> {
 	const text =
 		typeof memory.content?.text === "string" ? memory.content.text : "";
 	const key = normalizeFactTextKey(text);
@@ -64,7 +65,59 @@ export async function findEquivalentFactId(
 		if ((candidate.entityId ?? null) !== (memory.entityId ?? null)) continue;
 		const candidateText =
 			typeof candidate.content?.text === "string" ? candidate.content.text : "";
-		if (normalizeFactTextKey(candidateText) === key) return candidate.id;
+		if (normalizeFactTextKey(candidateText) === key) return candidate;
 	}
 	return null;
+}
+
+function readFactMetadata(memory: Memory): FactMetadata {
+	const meta = memory.metadata;
+	if (!meta || typeof meta !== "object" || Array.isArray(meta)) return {};
+	return meta as FactMetadata;
+}
+
+/**
+ * Field-wise "stronger metadata" merge for a dedupe hit: returns the kept
+ * row's full metadata with the incoming occurrence's stronger fields applied,
+ * or null when the incoming occurrence adds nothing (plain skip). Stronger
+ * means, per field:
+ *
+ * - `confidence` — strictly higher (or present where the kept row has none).
+ * - `kind` — present where the kept row has none. The FACTS reader defaults a
+ *   missing kind to `durable`, so an explicit stamp is always more precise;
+ *   an already-set kind is never flipped here (durable/current transitions
+ *   belong to the reflection pass).
+ * - `validAt` / `lastConfirmedAt` — strictly more recent (or newly present):
+ *   a re-asserted `current` fact should not keep decaying from its first
+ *   observation's timestamp.
+ */
+export function mergeStrongerFactMetadata(
+	existing: Memory,
+	incoming: Memory,
+): MemoryMetadata | null {
+	const kept = readFactMetadata(existing);
+	const next = readFactMetadata(incoming);
+	const upgrades: FactMetadata = {};
+
+	if (
+		typeof next.confidence === "number" &&
+		Number.isFinite(next.confidence) &&
+		(typeof kept.confidence !== "number" || next.confidence > kept.confidence)
+	) {
+		upgrades.confidence = next.confidence;
+	}
+	if (next.kind && !kept.kind) {
+		upgrades.kind = next.kind;
+	}
+	for (const field of ["validAt", "lastConfirmedAt"] as const) {
+		const incomingAt = Date.parse(next[field] ?? "");
+		if (Number.isNaN(incomingAt)) continue;
+		const keptAt = Date.parse(kept[field] ?? "");
+		if (Number.isNaN(keptAt) || incomingAt > keptAt) {
+			upgrades[field] = next[field];
+		}
+	}
+
+	if (Object.keys(upgrades).length === 0) return null;
+	return { ...existing.metadata, ...upgrades } as MemoryMetadata;
 }


### PR DESCRIPTION
Follow-up hygiene pair from the punch-list sweep — both verified real on current develop before changing anything.

## (a) #11971's oauth-header regression test went dead in the #12201 auth extraction

`packages/agent/test/api/accounts-routes.test.ts` still imported `../../src/auth/{credentials,account-storage}` and mocked `@elizaos/app-core` for the account pool. #12201 moved `packages/agent/src/auth/*` into `@elizaos/auth` and switched pool acquisition to the `getAgentHostBridge()` seam, so the suite failed at module load — **0 of its 6 tests ran**, including the `anthropic-beta: oauth-2025-04-20` regression guard. The production fix itself survived (`accounts-routes.ts` `probeAnthropicUsage`); only the guard was dead.

Fix: repoint the imports/mocks to `@elizaos/auth/*` and install the fixture pool through the public `setAgentHostBridge` seam (the same way a real host installs it), reset via `_resetAgentHostBridge()`.

**Proof the guard bites again:** with the beta header deleted from `probeAnthropicUsage`, the test fails; with develop's code it passes.

```
before (develop): Error: Cannot find module '/src/auth/account-storage.js' — Tests: no tests
after:            Test Files 1 passed — Tests 6 passed (6)
header removed:   Tests 1 failed | 5 passed — the oauth-header guard
```

## (b) fact write-dedupe (#12850) dropped stronger metadata on a duplicate

`runtime.createMemory` skipped the insert on a dedupe hit and returned the kept id — even when the new occurrence carried stronger metadata. A re-extracted fact with higher confidence, an explicit `kind` (the FACTS reader defaults missing kind to `durable`), or a fresher `validAt` lost that information, and a re-asserted `current` fact kept decaying from its first observation's timestamp.

Fix (structural, in `fact-write-dedupe.ts`): `findEquivalentFact` now returns the kept row; `mergeStrongerFactMetadata` does a field-wise stronger-only merge — `confidence` strictly higher, `kind` fill-only (an already-set kind is never flipped; durable/current transitions stay with the reflection pass), `validAt`/`lastConfirmedAt` strictly more recent. On upgrade the kept row is patched via `runtime.updateMemory`; otherwise the hit stays a plain skip.

**Tests** (real `AgentRuntime` + `InMemoryDatabaseAdapter`, no mocks): stronger-metadata duplicate upgrades the kept row (fails on develop's skip-only behavior), weaker duplicate is a plain skip, explicit kind fills an unkinded row (fails on develop). All 6 pre-existing dedupe/stage tests unchanged and green.

## Verification

- `packages/core` runtime suite: **842/842** passed (67 files), advanced-capabilities: **137/137**.
- `packages/agent` `test/api/accounts-routes.test.ts`: **6/6** (was 0 runnable).
- `tsgo --noEmit` packages/core: **0 errors**; packages/agent: 67 errors, byte-identical with and without this diff (pre-existing unbuilt-dep artifacts in files this PR does not touch).
- Adversarial: both new guards demonstrated to fail on the pre-fix behavior (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
