### PR TITLE
refactor(agent): generic plugin preflight hook, drop resolver name special-cases (#12665)

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -61,11 +61,11 @@ export {
   PROVIDER_PLUGIN_MAP,
 } from "./plugin-collector.ts";
 
+import { STATIC_ELIZA_PLUGIN_LOADERS } from "./plugin-types.ts";
+
 export {
   CUSTOM_PLUGINS_DIRNAME,
   EJECTED_PLUGINS_DIRNAME,
-  ensureBrowserServerLink,
-  findPluginBrowserStagehandDir,
   findRuntimePluginExport,
   mergeDropInPlugins,
   type PluginModuleShape,
@@ -436,6 +436,14 @@ const BLOCKING_STATIC_PLUGIN_LOADERS: Readonly<
     load: () => getPluginLocalEmbedding(),
   },
 };
+
+// Expose the required SQL loader to the resolver as a generic bundle-inlined
+// fallback. On mobile the static registry can be empty when loadSinglePlugin
+// runs first (Bun.build TLA scheduling), and there is no node_modules tree to
+// dynamic-import from. Registering the memoized loader here — keyed by name in a
+// shared map — lets the resolver recover without a `=== "@elizaos/plugin-sql"`
+// branch. Ownership of the fallback stays with this loader table (#12665).
+STATIC_ELIZA_PLUGIN_LOADERS["@elizaos/plugin-sql"] = () => getPluginSql();
 
 function buildBlockingStaticRegistrations(): CoreStaticPluginRegistration[] {
   return BLOCKING_CORE_PLUGINS.map((packageName) => {

--- a/packages/agent/src/runtime/plugin-resolver-preflight.test.ts
+++ b/packages/agent/src/runtime/plugin-resolver-preflight.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Regression coverage for the generic plugin `preflight` hook and the
+ * name-agnostic static-loader fallback that replaced the resolver's
+ * `=== "@elizaos/plugin-browser"` / `=== "@elizaos/plugin-sql"` special cases
+ * (#12665). Deterministic: fake plugin modules seeded into the shared static
+ * registry, no live model and no disk fixtures.
+ *
+ * Also asserts (by reading the resolver source) that the two literal
+ * plugin-name branches are gone from the executable path — the grep guard the
+ * issue requires.
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Plugin } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ElizaConfig } from "../config/config.ts";
+import { resolvePlugins } from "./plugin-resolver.ts";
+import {
+  STATIC_ELIZA_PLUGIN_LOADERS,
+  STATIC_ELIZA_PLUGINS,
+} from "./plugin-types.ts";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+
+// Deny the full default core/view set so the load set is exactly the one plugin
+// each test allows. This isolates loadSinglePlugin's behavior for the plugin
+// under test from the dozens of real plugins the default config seeds.
+async function denyAllDefaultsExcept(allow: string[]): Promise<ElizaConfig> {
+  const { CORE_PLUGINS, MOBILE_VIEW_PLUGINS, OPTIONAL_CORE_PLUGINS } =
+    await import("./core-plugins.ts");
+  const deny = [
+    ...CORE_PLUGINS,
+    ...MOBILE_VIEW_PLUGINS,
+    ...OPTIONAL_CORE_PLUGINS,
+  ].filter((name) => !allow.includes(name));
+  return {
+    plugins: { allow, deny },
+  } as unknown as ElizaConfig;
+}
+
+const seededRegistryKeys: string[] = [];
+const seededLoaderKeys: string[] = [];
+
+function seedStaticPlugin(name: string, plugin: Plugin): void {
+  STATIC_ELIZA_PLUGINS[name] = { default: plugin };
+  seededRegistryKeys.push(name);
+}
+
+function seedStaticLoader(name: string, load: () => Promise<unknown>): void {
+  STATIC_ELIZA_PLUGIN_LOADERS[name] = load;
+  seededLoaderKeys.push(name);
+}
+
+beforeEach(() => {
+  seededRegistryKeys.length = 0;
+  seededLoaderKeys.length = 0;
+});
+
+afterEach(() => {
+  for (const key of seededRegistryKeys) delete STATIC_ELIZA_PLUGINS[key];
+  for (const key of seededLoaderKeys) delete STATIC_ELIZA_PLUGIN_LOADERS[key];
+});
+
+describe("generic plugin preflight hook", () => {
+  it("invokes preflight() for a plugin that declares one, before init", async () => {
+    const calls: string[] = [];
+    const name = "@thirdparty/plugin-preflight-fixture";
+    const plugin: Plugin = {
+      name,
+      description: "preflight fixture",
+      preflight: () => {
+        calls.push("preflight");
+      },
+      init: () => {
+        calls.push("init");
+      },
+    };
+    seedStaticPlugin(name, plugin);
+
+    const resolved = await resolvePlugins(await denyAllDefaultsExcept([name]));
+
+    expect(resolved.map((p) => p.name)).toContain(name);
+    // preflight ran, and ran before init would (init fires later at runtime).
+    expect(calls).toEqual(["preflight"]);
+  });
+
+  it("resolves a plugin with no preflight without error", async () => {
+    const name = "@thirdparty/plugin-no-preflight-fixture";
+    const plugin: Plugin = {
+      name,
+      description: "no-preflight fixture",
+      actions: [],
+    };
+    seedStaticPlugin(name, plugin);
+
+    const resolved = await resolvePlugins(await denyAllDefaultsExcept([name]));
+
+    expect(resolved.map((p) => p.name)).toContain(name);
+  });
+
+  it("awaits an async preflight() before completing the load", async () => {
+    let preflightDone = false;
+    const name = "@thirdparty/plugin-async-preflight-fixture";
+    const plugin: Plugin = {
+      name,
+      description: "async preflight fixture",
+      actions: [],
+      preflight: async () => {
+        await Promise.resolve();
+        preflightDone = true;
+      },
+    };
+    seedStaticPlugin(name, plugin);
+
+    const resolved = await resolvePlugins(await denyAllDefaultsExcept([name]));
+
+    expect(resolved.map((p) => p.name)).toContain(name);
+    expect(preflightDone).toBe(true);
+  });
+});
+
+describe("name-agnostic static-loader fallback", () => {
+  it("loads a plugin via STATIC_ELIZA_PLUGIN_LOADERS when the registry is empty", async () => {
+    let loaderCalls = 0;
+    const name = "@thirdparty/plugin-loader-fixture";
+    const plugin: Plugin = {
+      name,
+      description: "static loader fixture",
+      actions: [],
+    };
+    // Registry intentionally NOT seeded — only the on-demand loader is, mirroring
+    // the Bun.build TLA race where STATIC_ELIZA_PLUGINS is empty at load time.
+    seedStaticLoader(name, async () => {
+      loaderCalls += 1;
+      return { default: plugin };
+    });
+
+    const resolved = await resolvePlugins(await denyAllDefaultsExcept([name]));
+
+    expect(resolved.map((p) => p.name)).toContain(name);
+    expect(loaderCalls).toBe(1);
+  });
+
+  it("prefers the static registry over the loader when both are present", async () => {
+    let loaderCalls = 0;
+    const name = "@thirdparty/plugin-registry-wins-fixture";
+    const registryPlugin: Plugin = {
+      name,
+      description: "registry plugin",
+      actions: [],
+    };
+    seedStaticPlugin(name, registryPlugin);
+    seedStaticLoader(name, async () => {
+      loaderCalls += 1;
+      return {
+        default: { name, description: "loader plugin", actions: [] } as Plugin,
+      };
+    });
+
+    const resolved = await resolvePlugins(await denyAllDefaultsExcept([name]));
+
+    expect(resolved.map((p) => p.name)).toContain(name);
+    // Registry is the fast path; the loader fallback must not run.
+    expect(loaderCalls).toBe(0);
+  });
+});
+
+describe("no name-keyed special cases remain in the resolver (grep guard)", () => {
+  it("plugin-resolver.ts has no === plugin-browser / plugin-sql branches", async () => {
+    const source = await readFile(
+      path.join(thisDir, "plugin-resolver.ts"),
+      "utf8",
+    );
+    expect(source).not.toContain('=== "@elizaos/plugin-browser"');
+    expect(source).not.toContain('=== "@elizaos/plugin-sql"');
+    // The generic replacements ARE present.
+    expect(source).toContain("STATIC_ELIZA_PLUGIN_LOADERS[pluginName]");
+    expect(source).toContain("pluginInstance.preflight?.()");
+  });
+});

--- a/packages/agent/src/runtime/plugin-resolver.ts
+++ b/packages/agent/src/runtime/plugin-resolver.ts
@@ -48,7 +48,6 @@ import {
 import {
   CUSTOM_PLUGINS_DIRNAME,
   EJECTED_PLUGINS_DIRNAME,
-  ensureBrowserServerLink,
   findRuntimePluginExport,
   mergeDropInPlugins,
   type PluginModuleShape,
@@ -56,6 +55,7 @@ import {
   repairBrokenInstallRecord,
   resolveElizaPluginImportSpecifier,
   resolvePackageEntry,
+  STATIC_ELIZA_PLUGIN_LOADERS,
   STATIC_ELIZA_PLUGINS,
   scanDropInPlugins,
 } from "./plugin-types.ts";
@@ -1830,32 +1830,6 @@ export async function resolvePlugins(
         );
       };
 
-    // Pre-flight: opportunistically prepare special plugin dependencies.
-    // For plugin-browser, stagehand-server is only needed by the optional
-    // `stagehand` backend. The app workspace and Chrome/Safari bridge backends
-    // do not require it, and native mobile should prefer the app browser
-    // surface anyway.
-    if (pluginName === "@elizaos/plugin-browser") {
-      if (!ensureBrowserServerLink()) {
-        const platform = (
-          process.env.ELIZA_MOBILE_PLATFORM ??
-          process.env.ELIZA_PLATFORM ??
-          process.env.CAPACITOR_PLATFORM ??
-          ""
-        ).toLowerCase();
-        const mobile =
-          platform === "ios" || platform === "android" || platform === "mobile";
-        const message =
-          "[eliza] plugin-browser: stagehand-server binary not found — loading app workspace and bridge browser backends anyway. " +
-          "The optional `stagehand` fallback will stay disabled until plugins/plugin-browser/stagehand-server is built or a STAGEHAND_SERVER_URL is configured.";
-        if (mobile) {
-          logger.debug(`${message} Native mobile prefers the app browser.`);
-        } else {
-          logger.info(message);
-        }
-      }
-    }
-
     try {
       let mod: PluginModuleShape;
 
@@ -1874,16 +1848,15 @@ export async function resolvePlugins(
         // This keeps local node_modules links working while avoiding staging
         // bugs in workspace packages with nested symlinked dependencies.
         mod = staticElizaPlugin as PluginModuleShape;
-      } else if (pluginName === "@elizaos/plugin-sql") {
-        // Mobile bundles run without a node_modules tree. The static plugin
-        // registry is the normal fast path, but use a literal import fallback
-        // so Bun can still inline the required SQL plugin if module init order
-        // leaves the registry empty.
-        const sqlPluginModule = await import(
-          /* @vite-ignore */ "@elizaos/plugin-sql"
-        );
+      } else if (STATIC_ELIZA_PLUGIN_LOADERS[pluginName]) {
+        // Mobile bundles run without a node_modules tree. The static registry is
+        // the normal fast path, but a Bun.build TLA scheduling quirk can dispatch
+        // this load before `ensureCoreStaticPluginsRegistered()` has populated it.
+        // The declaring loader table in eliza.ts registers a memoized fallback
+        // loader here so we recover generically — no per-plugin name branch.
+        const loadedModule = await STATIC_ELIZA_PLUGIN_LOADERS[pluginName]();
         mod = Object.fromEntries(
-          Object.entries(sqlPluginModule),
+          Object.entries(loadedModule as Record<string, unknown>),
         ) as PluginModuleShape;
       } else if (workspaceOverridePath) {
         const shouldPreferRepoNodeModules =
@@ -1980,6 +1953,11 @@ export async function resolvePlugins(
       const pluginInstance = findRuntimePluginExport(mod);
 
       if (pluginInstance) {
+        // Generic pre-init hook: a plugin owning a load-time dependency (e.g.
+        // plugin-browser's optional stagehand-server) prepares it here, before
+        // its services start. Runs for every plugin that declares `preflight`,
+        // so the resolver no longer special-cases any plugin by name (#12665).
+        await pluginInstance.preflight?.();
         // Wrap the plugin's init function with an error boundary.
         // Core plugins re-throw on init failure; optional plugins degrade gracefully.
         const wrappedPlugin = wrapPluginWithErrorBoundary(

--- a/packages/agent/src/runtime/plugin-types.ts
+++ b/packages/agent/src/runtime/plugin-types.ts
@@ -7,14 +7,12 @@
  * @module plugin-types
  */
 import type { Dirent } from "node:fs";
-import { existsSync, symlinkSync } from "node:fs";
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
-import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { logger, type Plugin } from "@elizaos/core";
-import { formatError } from "@elizaos/shared";
+import type { Plugin } from "@elizaos/core";
 
 import type { ElizaConfig } from "../config/config.ts";
 import type { PluginInstallRecord } from "../config/types.eliza.ts";
@@ -51,6 +49,23 @@ export interface PluginModuleShape {
  * circular dependency.
  */
 export const STATIC_ELIZA_PLUGINS: Record<string, unknown> = {};
+
+/**
+ * On-demand loaders for statically-bundled plugins, keyed by registry name.
+ *
+ * `STATIC_ELIZA_PLUGINS` is normally populated ahead of resolution by
+ * `ensureCoreStaticPluginsRegistered()` in eliza.ts. But a Bun.build TLA
+ * scheduling quirk can dispatch `loadSinglePlugin(name)` before that registration
+ * has run, leaving the entry undefined in the mobile bundle. eliza.ts registers a
+ * memoized loader here for each such plugin; the resolver consults this map
+ * generically when `STATIC_ELIZA_PLUGINS[name]` is empty, instead of branching on
+ * a literal plugin name. Ownership of *which* plugins have a bundle-inlined
+ * fallback stays with the declaring loader table in eliza.ts.
+ */
+export const STATIC_ELIZA_PLUGIN_LOADERS: Record<
+  string,
+  () => Promise<unknown>
+> = {};
 
 /** Subdirectory under the Eliza state dir for drop-in custom plugins. */
 export const CUSTOM_PLUGINS_DIRNAME = "plugins/custom";
@@ -216,114 +231,6 @@ export function resolveElizaPluginImportSpecifier(
   const indexPath = path.resolve(distRoot, "plugins", shortName, "index.js");
 
   return existsSync(indexPath) ? pathToFileURL(indexPath).href : pluginName;
-}
-
-export function findPluginBrowserStagehandDir(startDir: string): string | null {
-  let dir = path.resolve(startDir);
-  for (let depth = 0; depth < 14; depth++) {
-    const candidate = path.join(
-      dir,
-      "plugins",
-      "plugin-browser",
-      "stagehand-server",
-    );
-    const distIndex = path.join(candidate, "dist", "index.js");
-    const srcEntry = path.join(candidate, "src", "index.ts");
-    if (existsSync(distIndex) || existsSync(srcEntry)) {
-      return candidate;
-    }
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return null;
-}
-
-/**
- * `@elizaos/plugin-browser` expects `dist/server/` with the stagehand binary
- * tree inside the npm package, but the published tarball does not ship it.
- * When missing, symlink to a repo checkout at `plugins/plugin-browser/stagehand-server`
- * (discovered via {@link findPluginBrowserStagehandDir}) so the plugin's
- * process-manager can spawn the server.
- *
- * **Why:** Without the symlink, browser automation fails at runtime even when
- * the user built stagehand locally -- the plugin only looks under its package root.
- *
- * @returns `true` when `dist/server` already resolves or symlink succeeded.
- */
-export function ensureBrowserServerLink(): boolean {
-  try {
-    // Resolve the plugin-browser package root via its package.json.
-    const req = createRequire(import.meta.url);
-    const pkgJsonPath = req.resolve("@elizaos/plugin-browser/package.json");
-    const pluginRoot = path.dirname(pkgJsonPath);
-    const serverDir = path.join(pluginRoot, "dist", "server");
-    const serverIndex = path.join(serverDir, "dist", "index.js");
-
-    // Already linked / available -- nothing to do.
-    if (existsSync(serverIndex)) return true;
-
-    const thisDir = path.dirname(fileURLToPath(import.meta.url));
-    const stagehandDir = findPluginBrowserStagehandDir(thisDir);
-    if (!stagehandDir) {
-      logger.debug(
-        "[eliza] plugin-browser: no stagehand-server under plugins/plugin-browser — " +
-          "run node scripts/link-browser-server.mjs or add the plugin checkout",
-      );
-      return false;
-    }
-    const stagehandIndex = path.join(stagehandDir, "dist", "index.js");
-
-    // Auto-build if source exists but dist doesn't
-    if (
-      !existsSync(stagehandIndex) &&
-      existsSync(path.join(stagehandDir, "src", "index.ts"))
-    ) {
-      logger.info(
-        `[eliza] Stagehand server not built — attempting auto-build...`,
-      );
-      try {
-        const cp = createRequire(import.meta.url)(
-          "node:child_process",
-        ) as typeof import("node:child_process");
-        if (!existsSync(path.join(stagehandDir, "node_modules"))) {
-          cp.execSync("bun install --ignore-scripts", {
-            cwd: stagehandDir,
-            stdio: "ignore",
-            timeout: 60_000,
-          });
-        }
-        // Prefer local tsc binary, fall back to bunx
-        const localTsc = path.join(stagehandDir, "node_modules", ".bin", "tsc");
-        const tscCmd = existsSync(localTsc) ? localTsc : "bunx tsc";
-        cp.execSync(tscCmd, {
-          cwd: stagehandDir,
-          stdio: "ignore",
-          timeout: 60_000,
-        });
-        logger.info(`[eliza] Stagehand server built successfully`);
-      } catch (buildErr) {
-        logger.debug(`[eliza] Auto-build failed: ${formatError(buildErr)}`);
-      }
-    }
-
-    if (!existsSync(stagehandIndex)) {
-      logger.debug(
-        "[eliza] plugin-browser: stagehand-server present but dist/index.js missing — build it",
-      );
-      return false;
-    }
-
-    // Create symlink: dist/server -> stagehand-server
-    symlinkSync(stagehandDir, serverDir, "dir");
-    logger.info(
-      `[eliza] Linked browser server: ${serverDir} -> ${stagehandDir}`,
-    );
-    return true;
-  } catch (err) {
-    logger.debug(`[eliza] Could not link browser server: ${formatError(err)}`);
-    return false;
-  }
 }
 
 /** @internal Exported for testing. */

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -1203,6 +1203,21 @@ export interface Plugin {
 	/** Remote-mode configuration. Required when {@link Plugin.mode} is `"remote"`. */
 	remote?: RemotePluginConfig;
 
+	/**
+	 * Optional pre-initialization hook invoked by the plugin resolver once the
+	 * plugin module has loaded, before `init` runs. Use it to prepare a
+	 * plugin-owned load-time dependency that must exist before the plugin's
+	 * services start — for example linking or building a companion binary the
+	 * plugin's own service spawns lazily later.
+	 *
+	 * The resolver calls this generically for every plugin that declares it, so
+	 * package-specific preparation lives with the plugin instead of a name-keyed
+	 * branch in the resolver. A missing optional dependency should degrade (log
+	 * and return) rather than throw: `preflight` prepares, it does not gate the
+	 * load. Reserve throwing for a genuinely fatal precondition.
+	 */
+	preflight?: () => Promise<void> | void;
+
 	// Initialize plugin with runtime services
 	init?: (
 		config: Record<string, string>,

--- a/plugins/plugin-browser/src/plugin.ts
+++ b/plugins/plugin-browser/src/plugin.ts
@@ -33,6 +33,7 @@ import {
 } from "./routes/bridge.js";
 import { browserWorkspaceRoutes } from "./routes/workspace-setup.js";
 import { browserBridgeSchema } from "./schema.js";
+import { preflightStagehandServer } from "./targets/stagehand-target.js";
 
 function json(res: http.ServerResponse, data: unknown, status = 200): void {
   httpSendJson(res, data, status);
@@ -243,6 +244,9 @@ export const browserPlugin: Plugin = {
   routes: [...browserBridgePluginRoutes, ...browserWorkspaceRoutes],
   services: [BrowserService as ServiceClass],
   providers: [browserWorkspaceProvider],
+  // Prepare the optional local stagehand-server before services start. Owned
+  // here so the resolver no longer special-cases this plugin by name (#12665).
+  preflight: () => preflightStagehandServer(),
   actions: [
     ...promoteSubactionsToActions(browserAction),
     ...promoteSubactionsToActions(manageBrowserBridgeAction),

--- a/plugins/plugin-browser/src/targets/stagehand-target.test.ts
+++ b/plugins/plugin-browser/src/targets/stagehand-target.test.ts
@@ -1,9 +1,15 @@
 /**
- * Stagehand browser target tests for environment detection and command forwarding.
+ * Stagehand browser target tests: environment detection, command forwarding, and
+ * the load-time preflight the plugin resolver invokes generically (#12665). The
+ * preflight moved out of the resolver's `=== "@elizaos/plugin-browser"` branch
+ * into this plugin, so its degrade-when-missing behavior is covered here.
  */
 
 import { describe, expect, it } from "vitest";
-import { maybeCreateStagehandTarget } from "./stagehand-target.js";
+import {
+  maybeCreateStagehandTarget,
+  preflightStagehandServer,
+} from "./stagehand-target.js";
 
 const COMMAND_URL = "https://stagehand.example/api/browser-command";
 
@@ -51,5 +57,40 @@ describe("Stagehand browser target platform gating", () => {
       }),
     ).toBe(10);
     await expect(target.available()).resolves.toBe(true);
+  });
+});
+
+describe("preflightStagehandServer degrade-when-missing", () => {
+  it("returns without throwing when no stagehand-server is discoverable", () => {
+    // Point discovery at a directory with no stagehand-server checkout under it,
+    // so ensureLocalStagehandServer() finds nothing. The optional stagehand
+    // backend degrades (logs) rather than blocking the plugin load.
+    expect(() =>
+      preflightStagehandServer({
+        ELIZA_BROWSER_STAGEHAND_DIR: "/nonexistent/stagehand-server",
+      }),
+    ).not.toThrow();
+  });
+
+  it("is a no-op when stagehand is disabled", () => {
+    // ELIZA_BROWSER_STAGEHAND_ENABLED=false short-circuits before any disk work.
+    expect(() =>
+      preflightStagehandServer({ ELIZA_BROWSER_STAGEHAND_ENABLED: "false" }),
+    ).not.toThrow();
+  });
+
+  it("is a no-op when auto-setup is disabled", () => {
+    expect(() =>
+      preflightStagehandServer({ ELIZA_BROWSER_STAGEHAND_AUTO_SETUP: "false" }),
+    ).not.toThrow();
+  });
+
+  it("degrades on mobile without throwing", () => {
+    expect(() =>
+      preflightStagehandServer({
+        ELIZA_MOBILE_PLATFORM: "ios",
+        ELIZA_BROWSER_STAGEHAND_DIR: "/nonexistent/stagehand-server",
+      }),
+    ).not.toThrow();
   });
 });

--- a/plugins/plugin-browser/src/targets/stagehand-target.ts
+++ b/plugins/plugin-browser/src/targets/stagehand-target.ts
@@ -30,6 +30,37 @@ const STAGEHAND_BASE_URL_ENV = [
 const STAGEHAND_AUTO_SETUP_ENV = "ELIZA_BROWSER_STAGEHAND_AUTO_SETUP";
 const STAGEHAND_ALLOW_MOBILE_ENV = "ELIZA_BROWSER_ALLOW_STAGEHAND_ON_MOBILE";
 
+/**
+ * Prepare the optional local stagehand-server before the browser service starts.
+ *
+ * Registered as `browserPlugin.preflight`; the plugin resolver invokes it
+ * generically at load time. The stagehand backend is optional — the app
+ * workspace and Chrome/Safari bridge backends do not need it — so a missing or
+ * unbuildable server degrades with a log line and never blocks the load. The
+ * server is also discovered/built lazily by {@link maybeCreateStagehandTarget}
+ * on first use; running the same preparation here surfaces the "stagehand
+ * unavailable" notice at boot instead of on the first browser command.
+ */
+export function preflightStagehandServer(
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (isDisabled(env.ELIZA_BROWSER_STAGEHAND_ENABLED)) return;
+  if (isDisabled(env[STAGEHAND_AUTO_SETUP_ENV])) return;
+
+  if (ensureLocalStagehandServer(env)) return;
+
+  const message =
+    "[BrowserService] stagehand-server not available — the app workspace and " +
+    "Chrome/Safari bridge browser backends load anyway. The optional stagehand " +
+    "fallback stays disabled until plugins/plugin-browser/stagehand-server is " +
+    "built or a STAGEHAND_SERVER_URL is configured.";
+  if (isMobileRuntime(env)) {
+    logger.debug(`${message} Native mobile prefers the app browser.`);
+  } else {
+    logger.info(message);
+  }
+}
+
 export async function maybeCreateStagehandTarget(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<BrowserTarget | null> {


### PR DESCRIPTION
## What & why

The generic plugin resolver (`packages/agent/src/runtime/plugin-resolver.ts`) special-cased two plugins by literal name inside `loadSinglePlugin`:

- `pluginName === "@elizaos/plugin-browser"` → ran a stagehand-server preflight (`ensureBrowserServerLink`) + degrade log.
- `pluginName === "@elizaos/plugin-sql"` → a literal-import fallback (`import("@elizaos/plugin-sql")`).

Both made a plugin's registration/initialization behavior owned by a central name list in the resolver rather than by the declaring plugin — the coupling arch-audit #12089 item 15 flags. This PR removes both literal branches and gives that ownership back to the plugins.

## Changes (simpler because…)

- **Generic `preflight` hook.** Added an optional typed `preflight?()` lifecycle field to the `Plugin` type (`packages/core/src/types/plugin.ts`). The resolver now calls `pluginInstance.preflight?.()` generically for **every** plugin, after the module loads and before init. No plugin names in the resolver.
- **Browser preflight moved into the plugin.** `preflightStagehandServer` now lives in `plugins/plugin-browser/src/targets/stagehand-target.ts` and is wired as `browserPlugin.preflight`. It reuses the plugin's own `ensureLocalStagehandServer` / `findStagehandDir` discovery (which already resolves `stagehand-server` directly and lazily at first use) and degrades — logs, never throws — when the optional server is missing.
- **SQL fallback folded into a name-agnostic loader registry.** New `STATIC_ELIZA_PLUGIN_LOADERS` map in the cycle-free `plugin-types.ts`. `eliza.ts` — which already owns the memoized `getPluginSql()` loader (with its workspace-source fallback) — registers the fallback there. The resolver consults the map generically when the static registry is empty (the documented Bun.build TLA scheduling race), keyed by a name **lookup**, not a `=== "..."` branch.
- **Dead code removed.** `ensureBrowserServerLink` / `findPluginBrowserStagehandDir` (and their only-here imports: `symlinkSync`, `createRequire`, `logger`, `formatError`) are gone from `plugin-types.ts`, plus their dead re-exports from `eliza.ts`. plugin-browser resolves `stagehand-server` directly and no longer reads the legacy `dist/server` symlink (verified: no `dist/server` references remain in plugin-browser src).

The resulting resolver has one generic code path per concern instead of two hidden name-keyed branches; each plugin owns its own load-time preparation.

## Grep proof (name literals gone from the resolver)

```
$ grep -n '=== "@elizaos/plugin-browser"\|=== "@elizaos/plugin-sql"' packages/agent/src/runtime/plugin-resolver.ts
(no matches)
$ grep -n 'pluginName === "@elizaos' packages/agent/src/runtime/plugin-resolver.ts
(no matches)
$ grep -rn 'ensureBrowserServerLink\|findPluginBrowserStagehandDir' packages/ plugins/ --include='*.ts'
(no matches — fully removed)
```

A test also asserts this mechanically (`plugin-resolver-preflight.test.ts` grep guard), and confirms the generic replacements (`STATIC_ELIZA_PLUGIN_LOADERS[pluginName]`, `pluginInstance.preflight?.()`) are present.

## Tests

New/updated focused, deterministic regression tests (no live model, no disk fixtures):

- `packages/agent/src/runtime/plugin-resolver-preflight.test.ts` (new):
  - generic `preflight()` is invoked (sync + async, awaited, before init) for a plugin that declares one; a plugin without one still resolves;
  - a plugin resolves via `STATIC_ELIZA_PLUGIN_LOADERS` when the static registry is empty (the sql drift/fallback mode that made the central coupling unsafe), and the registry wins over the loader when both are present (loader must not run);
  - grep guard that the two name literals are gone from the resolver's executable path.
- `plugins/plugin-browser/src/targets/stagehand-target.test.ts` (extended): `preflightStagehandServer` degrades without throwing when no server is discoverable, is a no-op when disabled / auto-setup off, and degrades on mobile.

### Test output

```
# packages/agent — resolver suites
Ran 13 tests across 4 files  (plugin-resolver + prune + failed-plugins + cold-import) → 13 pass, 0 fail
# packages/agent — new preflight suite
Ran 6 tests across 1 file → 6 pass, 0 fail
# plugins/plugin-browser — stagehand target suite
Ran 6 tests across 1 file → 6 pass, 0 fail
```

Biome clean on all 8 touched files. `typecheck` in this isolated worktree reports only 4 ambient `TS2688` "Cannot find type definition file for 'bun'/'node'/'react'/'react-dom'" errors (missing `@types/*` because the worktree shares the parent tree's node_modules) — zero errors reference the touched files. CI is the authoritative typecheck/test gate.

Closes #12665

🤖 Generated with [Claude Code](https://claude.com/claude-code)