### PR TITLE
fix(#13107): switch saved runtimes non-destructively

### DIFF
--- a/packages/ui/src/components/settings/RuntimeSettingsSection.test.tsx
+++ b/packages/ui/src/components/settings/RuntimeSettingsSection.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+/**
+ * Covers the Settings > Runtime cloud/local rows: when a matching saved
+ * profile exists, switching must use the non-destructive runtime switch instead
+ * of re-entering first-run and clearing the active runtime state.
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentProfile } from "../../state/agent-profile-types";
+
+const mocks = vi.hoisted(() => ({
+  loadAgentProfileRegistry: vi.fn(),
+  switchRuntimeNonDestructive: vi.fn(() => ({ ok: true })),
+  reloadIntoFirstRunRuntime: vi.fn(),
+  refetchRuntimeMode: vi.fn(),
+  loadPersistedActiveServer: vi.fn(),
+  isStoreBuild: vi.fn(() => false),
+  isAndroidCloudBuild: vi.fn(() => false),
+}));
+
+vi.mock("../../agent-surface", () => ({
+  useAgentElement: () => ({ ref: undefined, agentProps: {} }),
+}));
+
+vi.mock("../../bridge/electrobun-rpc", () => ({
+  inspectExistingElizaInstall: vi.fn(),
+  migrateDesktopStateDir: vi.fn(),
+  pickDesktopWorkspaceFolder: vi.fn(),
+}));
+
+vi.mock("../../bridge/electrobun-runtime", () => ({
+  isElectrobunRuntime: () => false,
+}));
+
+vi.mock("../../build-variant", () => ({
+  isStoreBuild: mocks.isStoreBuild,
+}));
+
+vi.mock("../../platform/android-runtime", () => ({
+  isAndroidCloudBuild: mocks.isAndroidCloudBuild,
+}));
+
+vi.mock("../../hooks/useRuntimeMode", () => ({
+  useRuntimeMode: () => ({
+    state: { phase: "unavailable" },
+    mode: null,
+    isLocalOnly: false,
+    isCloudMode: false,
+    isRemoteMode: false,
+    refetch: mocks.refetchRuntimeMode,
+  }),
+}));
+
+vi.mock("../../state", () => ({
+  loadAgentProfileRegistry: mocks.loadAgentProfileRegistry,
+  switchRuntimeNonDestructive: mocks.switchRuntimeNonDestructive,
+  useAppSelector: (
+    selector: (state: {
+      t: (key: string, options?: { defaultValue?: string }) => string;
+    }) => unknown,
+  ) =>
+    selector({
+      t: (_key, options) => options?.defaultValue ?? _key,
+    }),
+}));
+
+vi.mock("../../state/persistence", () => ({
+  loadPersistedActiveServer: mocks.loadPersistedActiveServer,
+}));
+
+vi.mock("../../first-run/reload-into-first-run-runtime", () => ({
+  reloadIntoFirstRunRuntime: mocks.reloadIntoFirstRunRuntime,
+}));
+
+import { RuntimeSettingsSection } from "./RuntimeSettingsSection";
+
+const LOCAL_PROFILE: AgentProfile = {
+  id: "local-1",
+  label: "This device",
+  kind: "local",
+  createdAt: "2026-06-01T00:00:00.000Z",
+};
+
+const CLOUD_PROFILE: AgentProfile = {
+  id: "cloud-1",
+  label: "Cloud agent",
+  kind: "cloud",
+  apiBase: "https://x.agent.elizacloud.ai",
+  accessToken: "cloud-token",
+  createdAt: "2026-06-02T00:00:00.000Z",
+};
+
+const MOBILE_LOCAL_PROFILE: AgentProfile = {
+  id: "mobile-local-1",
+  label: "On-device agent",
+  kind: "remote",
+  apiBase: "eliza-local-agent://ipc",
+  createdAt: "2026-06-03T00:00:00.000Z",
+};
+
+function seedRegistry(
+  profiles: AgentProfile[],
+  activeProfileId: string | null,
+) {
+  mocks.loadAgentProfileRegistry.mockReturnValue({
+    version: 1,
+    activeProfileId,
+    profiles,
+  });
+}
+
+function clickRuntimeRow(name: string) {
+  fireEvent.click(screen.getByRole("button", { name }));
+}
+
+describe("RuntimeSettingsSection runtime switching", () => {
+  beforeEach(() => {
+    mocks.loadAgentProfileRegistry.mockReset();
+    mocks.switchRuntimeNonDestructive.mockReset();
+    mocks.switchRuntimeNonDestructive.mockReturnValue({ ok: true });
+    mocks.reloadIntoFirstRunRuntime.mockReset();
+    mocks.refetchRuntimeMode.mockReset();
+    mocks.loadPersistedActiveServer.mockReset();
+    mocks.loadPersistedActiveServer.mockReturnValue(null);
+    mocks.isStoreBuild.mockReturnValue(false);
+    mocks.isAndroidCloudBuild.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("switches to a saved cloud profile without re-entering first-run", () => {
+    seedRegistry([LOCAL_PROFILE, CLOUD_PROFILE], "local-1");
+
+    render(<RuntimeSettingsSection />);
+    clickRuntimeRow("Cloud agent");
+
+    expect(mocks.switchRuntimeNonDestructive).toHaveBeenCalledWith("cloud-1");
+    expect(mocks.reloadIntoFirstRunRuntime).not.toHaveBeenCalled();
+    expect(mocks.refetchRuntimeMode).toHaveBeenCalledTimes(1);
+  });
+
+  it("switches to a saved desktop local profile without re-entering first-run", () => {
+    seedRegistry([CLOUD_PROFILE, LOCAL_PROFILE], "cloud-1");
+
+    render(<RuntimeSettingsSection />);
+    clickRuntimeRow("Local");
+
+    expect(mocks.switchRuntimeNonDestructive).toHaveBeenCalledWith("local-1");
+    expect(mocks.reloadIntoFirstRunRuntime).not.toHaveBeenCalled();
+    expect(mocks.refetchRuntimeMode).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a mobile IPC profile as the saved local runtime", () => {
+    seedRegistry([CLOUD_PROFILE, MOBILE_LOCAL_PROFILE], "cloud-1");
+
+    render(<RuntimeSettingsSection />);
+    clickRuntimeRow("Local");
+
+    expect(mocks.switchRuntimeNonDestructive).toHaveBeenCalledWith(
+      "mobile-local-1",
+    );
+    expect(mocks.reloadIntoFirstRunRuntime).not.toHaveBeenCalled();
+    expect(mocks.refetchRuntimeMode).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when the user clicks the already-active cloud row", () => {
+    seedRegistry([LOCAL_PROFILE, CLOUD_PROFILE], "cloud-1");
+    mocks.loadPersistedActiveServer.mockReturnValue({
+      id: "cloud:agent-1",
+      label: "Cloud agent",
+      kind: "cloud",
+      apiBase: "https://x.agent.elizacloud.ai",
+      accessToken: "cloud-token",
+    });
+
+    render(<RuntimeSettingsSection />);
+    clickRuntimeRow("Cloud agent");
+
+    expect(mocks.switchRuntimeNonDestructive).not.toHaveBeenCalled();
+    expect(mocks.reloadIntoFirstRunRuntime).not.toHaveBeenCalled();
+    expect(mocks.refetchRuntimeMode).not.toHaveBeenCalled();
+  });
+
+  it("falls back to first-run when no saved cloud profile exists", () => {
+    seedRegistry([LOCAL_PROFILE], "local-1");
+
+    render(<RuntimeSettingsSection />);
+    clickRuntimeRow("Cloud agent");
+
+    expect(mocks.switchRuntimeNonDestructive).not.toHaveBeenCalled();
+    expect(mocks.reloadIntoFirstRunRuntime).toHaveBeenCalledWith("cloud");
+    expect(mocks.refetchRuntimeMode).not.toHaveBeenCalled();
+  });
+
+  it("falls back to first-run when no saved local profile exists", () => {
+    seedRegistry([CLOUD_PROFILE], "cloud-1");
+
+    render(<RuntimeSettingsSection />);
+    clickRuntimeRow("Local");
+
+    expect(mocks.switchRuntimeNonDestructive).not.toHaveBeenCalled();
+    expect(mocks.reloadIntoFirstRunRuntime).toHaveBeenCalledWith("local");
+    expect(mocks.refetchRuntimeMode).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/settings/RuntimeSettingsSection.tsx
+++ b/packages/ui/src/components/settings/RuntimeSettingsSection.tsx
@@ -26,10 +26,16 @@ import {
 } from "../../first-run/reload-into-first-run-runtime";
 import { useRuntimeMode } from "../../hooks/useRuntimeMode";
 import { isAndroidCloudBuild } from "../../platform/android-runtime";
-import { useAppSelector } from "../../state";
+import {
+  type AgentProfile,
+  loadAgentProfileRegistry,
+  switchRuntimeNonDestructive,
+  useAppSelector,
+} from "../../state";
 import {
   type AgentRuntimeTargetKind,
   inferAgentRuntimeTarget,
+  isLocalAgentApiBase,
 } from "../../state/agent-runtime-target";
 import { loadPersistedActiveServer } from "../../state/persistence";
 import { Input } from "../ui/input";
@@ -89,9 +95,51 @@ type RuntimeAction = {
 const STORE_LOCAL_DISABLED_DOCS_URL =
   "https://github.com/eliza-ai/eliza/blob/develop/docs/desktop/build-variants.md";
 
+function profileMatchesRuntimeTarget(
+  profile: AgentProfile,
+  target: FirstRunReloadTarget,
+): boolean {
+  if (target === "cloud") {
+    return profile.kind === "cloud";
+  }
+  if (target === "local") {
+    return (
+      profile.kind === "local" ||
+      (profile.kind === "remote" && isLocalAgentApiBase(profile.apiBase))
+    );
+  }
+  return false;
+}
+
+function profileRecency(profile: AgentProfile): number {
+  const value = Date.parse(profile.lastConnectedAt ?? profile.createdAt);
+  return Number.isFinite(value) ? value : 0;
+}
+
+export function findSavedRuntimeProfileForTarget(
+  target: FirstRunReloadTarget,
+): AgentProfile | null {
+  if (target === "remote") return null;
+
+  const registry = loadAgentProfileRegistry();
+  const activeProfile = registry.profiles.find(
+    (profile) => profile.id === registry.activeProfileId,
+  );
+  if (activeProfile && profileMatchesRuntimeTarget(activeProfile, target)) {
+    return activeProfile;
+  }
+
+  return (
+    registry.profiles
+      .filter((profile) => profileMatchesRuntimeTarget(profile, target))
+      .sort((a, b) => profileRecency(b) - profileRecency(a))[0] ?? null
+  );
+}
+
 export function RuntimeSettingsSection() {
   const t = useAppSelector((s) => s.t);
-  const { state: runtimeModeState } = useRuntimeMode();
+  const { state: runtimeModeState, refetch: refetchRuntimeMode } =
+    useRuntimeMode();
   const advancedEnabled = useAdvancedSettingsEnabled();
   const [migrationMessage, setMigrationMessage] = useState<string | null>(null);
   const [migrationBusy, setMigrationBusy] = useState(false);
@@ -156,18 +204,34 @@ export function RuntimeSettingsSection() {
     return base;
   }, [t, cloudOnly, storeBuild, localDisabledReason]);
 
-  const handleSwitch = useCallback((target: FirstRunReloadTarget) => {
-    // Cloud/local re-enter the first-run runtime picker. Remote no longer routes
-    // through first-run (post-#9952 there is no remote URL capture there);
-    // instead it reveals an inline "connect a remote agent" form that points the
-    // app straight at a host via the hardened CONNECT_EVENT path.
-    if (target === "remote") {
-      setRemoteError(null);
-      setRemoteFormOpen((open) => !open);
-      return;
-    }
-    reloadIntoFirstRunRuntime(target);
-  }, []);
+  const handleSwitch = useCallback(
+    (target: FirstRunReloadTarget) => {
+      // Remote no longer routes through first-run (post-#9952 there is no
+      // remote URL capture there); instead it reveals an inline "connect a
+      // remote agent" form that points the app straight at a host via the
+      // hardened CONNECT_EVENT path.
+      if (target === "remote") {
+        setRemoteError(null);
+        setRemoteFormOpen((open) => !open);
+        return;
+      }
+      if (currentRuntime.kind === target) {
+        return;
+      }
+
+      const savedProfile = findSavedRuntimeProfileForTarget(target);
+      if (savedProfile) {
+        const result = switchRuntimeNonDestructive(savedProfile.id);
+        if (result.ok) {
+          refetchRuntimeMode();
+          return;
+        }
+      }
+
+      reloadIntoFirstRunRuntime(target);
+    },
+    [currentRuntime.kind, refetchRuntimeMode],
+  );
 
   const handleConnectRemote = useCallback(() => {
     let normalized: string;


### PR DESCRIPTION
Summary
- Use saved agent profiles for Settings cloud/local runtime switches before falling back to first-run.
- Treat local IPC/loopback remote profiles as local so mobile and desktop local profiles switch in place.
- Make already-active cloud/local rows a no-op and refresh runtime mode after a successful in-place switch.
- Add jsdom coverage for saved-profile, no-profile, cloud, local, mobile IPC, and active-row cases.

Tests
- TMPDIR=/private/tmp/codex-test-tmp bun run --cwd packages/ui test -- src/components/settings/RuntimeSettingsSection.test.tsx
- TMPDIR=/private/tmp/codex-test-tmp bun run --cwd packages/ui test -- src/components/settings/RuntimeSettingsSection.test.tsx src/state/switch-runtime.test.ts src/components/cockpit/MyRuntimesContainer.test.tsx src/state/startup-phase-hydrate.switch.test.ts
- bunx @biomejs/biome check packages/ui/src/components/settings/RuntimeSettingsSection.tsx packages/ui/src/components/settings/RuntimeSettingsSection.test.tsx
- bun run audit:error-policy-ratchet
- bun run --cwd packages/ui typecheck (fails on existing src/hooks/useWhatsAppPairing.test.tsx:21 TS2556)

Closes #13107