### PR TITLE
fix(#12273): computeruse cross-review follow-up — Linux AT-SPI scan-failure parity, J4 re-verdicts (W1-I / PR #13228)

### DIFF
--- a/.github/issue-evidence/12273-computeruse-triage.md
+++ b/.github/issue-evidence/12273-computeruse-triage.md
@@ -18,6 +18,16 @@ report pipeline failures; process/window enumeration failures warn instead of re
 as an empty machine; approval-mode load/persist failures surfaced; COMPUTER_USE_AGENT
 returns `result.error` on non-finish; progress-callback failures reportError'd (J7).
 
+Follow-up (cross-review of PR #13228): the Linux AT-SPI tier now has full parity with
+the macOS/Windows tiers — scan stats are recorded unconditionally (an all-windows-failed
+scan no longer discards its counts), the embedded Python distinguishes the designed
+bindings-absent failover (`{"unavailable": true}` → compositor tier, no error) from a
+mid-scan crash (partial counts + `error`, never a clean `{failed:0,total:0}`), and a
+python3/exec/parse failure sets `stats.error` so the scene-builder emits ERROR_REPORTED.
+The `tryCaptureWaylandPortal` catches (capture.ts/screenshot.ts) and the Brain imageless
+catch are re-verdicted below from `rethrow` to J4: each keeps a narrow rethrow
+(permission-denied / imagePolicy=never) but otherwise degrades along a designed tier.
+
 | site | verdict |
 |---|---|
 | `src/actions/clipboard.ts:181` | J1 (annotated at site) |
@@ -32,8 +42,8 @@ returns `result.error` on non-finish; progress-callback failures reportError'd (
 | `src/actor/aosp-input-actor.ts:172` | J1 (annotated at site) |
 | `src/actor/aosp-input-actor.ts:202` | J1 (annotated at site) |
 | `src/actor/brain.ts:343` | J3 (annotated at site) |
-| `src/actor/brain.ts:373` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
-| `src/actor/brain.ts:566` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
+| `src/actor/brain.ts:373` | J4 (annotated at site) — rethrows under imagePolicy=never (no tier left); otherwise designed degrade to the pixels-escalation tier |
+| `src/actor/brain.ts:568` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
 | `src/actor/cascade.ts:394` | J4 (annotated at site) |
 | `src/actor/cascade.ts:432` | J4 (annotated at site) |
 | `src/actor/computer-interface.ts:202` | J4 (annotated at site) |
@@ -64,8 +74,8 @@ returns `result.error` on non-finish; progress-callback failures reportError'd (
 | `src/platform/capture.ts:113` | J6 (annotated at site) |
 | `src/platform/capture.ts:152` | J6 (annotated at site) |
 | `src/platform/capture.ts:178` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
-| `src/platform/capture.ts:308` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
-| `src/platform/capture.ts:381` | J4 (annotated at site) |
+| `src/platform/capture.ts:308` | J4 (annotated at site) — permission-denied rethrows (terminal); other portal failures advance the capture-tier failover to the X11 tools tier |
+| `src/platform/capture.ts:387` | J4 (annotated at site) |
 | `src/platform/clipboard.ts:118` | J4 (annotated at site) |
 | `src/platform/clipboard.ts:159` | J4 (annotated at site) |
 | `src/platform/desktop.ts:906` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
@@ -124,9 +134,9 @@ returns `result.error` on non-finish; progress-callback failures reportError'd (
 | `src/platform/screenshot.ts:69` | J6 (annotated at site) |
 | `src/platform/screenshot.ts:72` | J6 (annotated at site) |
 | `src/platform/screenshot.ts:113` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
-| `src/platform/screenshot.ts:191` | rethrow — propagates (context-adding or permission-classifying throw); no swallow |
-| `src/platform/screenshot.ts:203` | J4 (annotated at site) |
-| `src/platform/screenshot.ts:235` | J4 (annotated at site) |
+| `src/platform/screenshot.ts:191` | J4 (annotated at site) — permission-denied rethrows (terminal); other portal failures advance the capture-tier failover to the X11 tools tier |
+| `src/platform/screenshot.ts:209` | J4 (annotated at site) |
+| `src/platform/screenshot.ts:241` | J4 (annotated at site) |
 | `src/platform/security.ts:239` | J3 (annotated at site) |
 | `src/platform/security.ts:350` | J3 (annotated at site) |
 | `src/platform/security.ts:379` | J3 (annotated at site) |
@@ -190,16 +200,16 @@ returns `result.error` on non-finish; progress-callback failures reportError'd (
 | `src/sandbox/docker-backend.ts:354` | J6 (annotated at site) |
 | `src/sandbox/docker-backend.ts:397` | J3 (annotated at site) |
 | `src/sandbox/remote-guest.ts:160` | J1 (annotated at site) |
-| `src/scene/a11y-provider.ts:227` | J4 (annotated at site) |
-| `src/scene/a11y-provider.ts:255` | J4 (annotated at site) |
-| `src/scene/a11y-provider.ts:270` | J4 (annotated at site) |
-| `src/scene/a11y-provider.ts:293` | J3 (annotated at site) |
-| `src/scene/a11y-provider.ts:342` | J3 (annotated at site) |
-| `src/scene/a11y-provider.ts:492` | FIXED (exemplar 2) — embedded JXA per-window catch now COUNTS the miss (`failed += 1`); reported once per scan via runtime.reportError("Computeruse.a11yScan", …). |
-| `src/scene/a11y-provider.ts:494` | FIXED (exemplar 2) — embedded JXA per-process catch now counts the miss; reported once per scan. |
-| `src/scene/a11y-provider.ts:511` | J4 (annotated at site) |
-| `src/scene/a11y-provider.ts:612` | FIXED — embedded PS UIA per-element catch now counts the miss (`$failed++`); reported once per scan. |
-| `src/scene/a11y-provider.ts:628` | J4 (annotated at site) |
+| `src/scene/a11y-provider.ts:230` | J4 (annotated at site) — python3 dying is recorded in scan stats (stats.error → one reportError per scan) before the failover to the compositor tier |
+| `src/scene/a11y-provider.ts:266` | J4 (annotated at site) |
+| `src/scene/a11y-provider.ts:281` | J4 (annotated at site) |
+| `src/scene/a11y-provider.ts:304` | J3 (annotated at site) |
+| `src/scene/a11y-provider.ts:353` | J3 (annotated at site) |
+| `src/scene/a11y-provider.ts:542` | FIXED (exemplar 2) — embedded JXA per-window catch now COUNTS the miss (`failed += 1`); reported once per scan via runtime.reportError("Computeruse.a11yScan", …). |
+| `src/scene/a11y-provider.ts:544` | FIXED (exemplar 2) — embedded JXA per-process catch now counts the miss; reported once per scan. |
+| `src/scene/a11y-provider.ts:561` | J4 (annotated at site) |
+| `src/scene/a11y-provider.ts:662` | FIXED — embedded PS UIA per-element catch now counts the miss (`$failed++`); reported once per scan. |
+| `src/scene/a11y-provider.ts:678` | J4 (annotated at site) |
 | `src/scene/apps.ts:172` | J4 (annotated at site) |
 | `src/scene/ocr-adapter.ts:110` | J4 (annotated at site) |
 | `src/scene/ocr-adapter.ts:132` | J4 (annotated at site) |

--- a/plugins/plugin-computeruse/src/actor/brain.ts
+++ b/plugins/plugin-computeruse/src/actor/brain.ts
@@ -373,8 +373,10 @@ export class Brain {
       } catch (err) {
         // "never" has no pixels to fall back to — surface the failure.
         if (this.imagePolicy === "never") throw err;
-        // Otherwise degrade to the escalation (pixels) path rather than crash
-        // the whole CUA loop if the text model is unavailable.
+        // error-policy:J4 designed degrade — the imageless pass is a
+        // token-saving optimization tier; when the text model is unavailable
+        // the loop escalates to the pixels pass below instead of crashing,
+        // and a failure there still throws to the caller.
         logger.debug(
           `[computeruse/brain] imageless planning pass failed (${
             err instanceof Error ? err.message : String(err)

--- a/plugins/plugin-computeruse/src/platform/capture.ts
+++ b/plugins/plugin-computeruse/src/platform/capture.ts
@@ -306,7 +306,13 @@ function tryCaptureWaylandPortal(tmpFile: string): boolean {
     captureWaylandPortalScreenshot(tmpFile);
     return true;
   } catch (error) {
+    // Permission denial is terminal — no other tier can succeed, and the
+    // classified error is what the caller surfaces.
     if (isPermissionDeniedError(error)) throw error;
+    // error-policy:J4 capture-tier failover — a non-permission portal failure
+    // (helper missing, DBus timeout) advances the chain to the X11 tools
+    // tier; when every tier fails the caller throws "No screenshot tool
+    // available", so the miss never fabricates a capture.
     return false;
   }
 }

--- a/plugins/plugin-computeruse/src/platform/screenshot.ts
+++ b/plugins/plugin-computeruse/src/platform/screenshot.ts
@@ -189,7 +189,13 @@ function tryCaptureWaylandPortal(tmpFile: string): boolean {
     captureWaylandPortalScreenshot(tmpFile);
     return true;
   } catch (error) {
+    // Permission denial is terminal — no other tier can succeed, and the
+    // classified error is what the caller surfaces.
     if (isPermissionDeniedError(error)) throw error;
+    // error-policy:J4 capture-tier failover — a non-permission portal failure
+    // (helper missing, DBus timeout) advances the chain to the X11 tools
+    // tier; when every tier fails the caller throws "No screenshot tool
+    // available", so the miss never fabricates a capture.
     return false;
   }
 }

--- a/plugins/plugin-computeruse/src/scene/a11y-provider.error-policy.test.ts
+++ b/plugins/plugin-computeruse/src/scene/a11y-provider.error-policy.test.ts
@@ -17,7 +17,9 @@ import {
   type A11yScanStats,
   type AccessibilityProvider,
   DarwinAccessibilityProvider,
+  LinuxAccessibilityProvider,
   parseDarwinA11yPayload,
+  parseLinuxAtspiPayload,
   parseWindowsUiaPayload,
   WindowsAccessibilityProvider,
 } from "./a11y-provider.js";
@@ -95,6 +97,22 @@ describe("accessibility provider snapshot failure surfacing", () => {
     },
   );
 
+  it.skipIf(process.platform === "linux")(
+    "Linux provider on an AT-SPI-less host degrades by design: [] with no fabricated scan stats",
+    async () => {
+      // Real path, no mocks: on macOS/Windows hosts python3 either does not
+      // exist (early return) or genuinely lacks the gi/Atspi bindings, so the
+      // embedded script prints the designed {"unavailable": true} failover
+      // payload. Neither case is a failure, so no error may be fabricated —
+      // the compositor tiers (hyprctl/swaymsg absent here) then yield [].
+      const provider = new LinuxAccessibilityProvider();
+      const nodes = await provider.snapshot();
+
+      expect(nodes).toEqual([]);
+      expect(provider.lastScanStats()).toBeNull();
+    },
+  );
+
   it.skipIf(onWindows)(
     "Windows provider surfaces the PowerShell failure via logger.warn, records scan stats, and still returns []",
     async () => {
@@ -165,6 +183,48 @@ describe("scan payload parsers (untrusted embedded-script output)", () => {
   it("parseWindowsUiaPayload throws on a bare-array payload instead of fabricating an empty scan", () => {
     expect(() => parseWindowsUiaPayload("[]")).toThrow();
   });
+
+  it("parseLinuxAtspiPayload preserves the counts when every window failed (an all-miss scan is not a clean empty desktop)", () => {
+    const parsed = parseLinuxAtspiPayload(
+      JSON.stringify({ nodes: [], failed: 4, total: 4 }),
+    );
+    expect(parsed.nodes).toEqual([]);
+    expect(parsed.failedWindows).toBe(4);
+    expect(parsed.totalWindows).toBe(4);
+    expect(parsed.unavailable).toBe(false);
+    expect(parsed.error).toBeUndefined();
+  });
+
+  it("parseLinuxAtspiPayload carries a mid-scan crash message alongside the counts accumulated before the crash", () => {
+    const parsed = parseLinuxAtspiPayload(
+      JSON.stringify({
+        nodes: [
+          { role: "frame", label: "Files", bbox: [0, 0, 10, 10], actions: [] },
+        ],
+        failed: 1,
+        total: 3,
+        error: "atspi bus vanished",
+      }),
+    );
+    expect(parsed.nodes).toHaveLength(1);
+    expect(parsed.failedWindows).toBe(1);
+    expect(parsed.totalWindows).toBe(3);
+    expect(parsed.error).toBe("atspi bus vanished");
+  });
+
+  it("parseLinuxAtspiPayload flags the designed bindings-absent failover distinctly from a crash", () => {
+    const parsed = parseLinuxAtspiPayload(
+      JSON.stringify({ nodes: [], unavailable: true }),
+    );
+    expect(parsed.unavailable).toBe(true);
+    expect(parsed.error).toBeUndefined();
+  });
+
+  it("parseLinuxAtspiPayload throws on a non-object or empty payload instead of fabricating an empty scan", () => {
+    expect(() => parseLinuxAtspiPayload("[]")).toThrow();
+    expect(() => parseLinuxAtspiPayload("not json")).toThrow();
+    expect(() => parseLinuxAtspiPayload("")).toThrow();
+  });
 });
 
 describe("SceneBuilder reports a11y scan failures once per scan", () => {
@@ -227,6 +287,34 @@ describe("SceneBuilder reports a11y scan failures once per scan", () => {
       provider: "darwin",
     });
     expect(String((scanReports[0]?.error as Error).message)).toContain("4/6");
+  });
+
+  it("an all-windows-failed scan (empty node list, non-zero counts) is reported, not read as a clean empty desktop", async () => {
+    // The Linux AT-SPI regression class this guards: a scan that attempted N
+    // windows and read none of them previously discarded its counts because
+    // stats were only recorded when nodes came back.
+    const provider: AccessibilityProvider = {
+      name: "linux",
+      available: () => true,
+      snapshot: async (): Promise<SceneAxNode[]> => [],
+      lastScanStats: (): A11yScanStats => ({
+        failedWindows: 5,
+        totalWindows: 5,
+      }),
+    };
+    const { builder, reports } = makeBuilderWith(provider);
+
+    await builder.tick("agent-turn");
+
+    const scanReports = reports.filter(
+      (r) => r.scope === "Computeruse.a11yScan",
+    );
+    expect(scanReports).toHaveLength(1);
+    expect(scanReports[0]?.context).toMatchObject({
+      failedWindows: 5,
+      totalWindows: 5,
+      provider: "linux",
+    });
   });
 
   it("a clean scan produces no report", async () => {

--- a/plugins/plugin-computeruse/src/scene/a11y-provider.ts
+++ b/plugins/plugin-computeruse/src/scene/a11y-provider.ts
@@ -140,7 +140,10 @@ export class LinuxAccessibilityProvider implements AccessibilityProvider {
     // Try AT-SPI first (richest data on X11 / GNOME-Wayland), then fall
     // back to compositor-specific IPC. Scan stats come from the AT-SPI tier
     // (the only tier that can count per-window misses); the compositor tiers
-    // report null (unknown) rather than a fabricated clean count.
+    // report null (unknown) rather than a fabricated clean count. An AT-SPI
+    // failure recorded in the stats deliberately survives a compositor-tier
+    // success: the compositor fallback only yields window shells, so a broken
+    // AT-SPI stack still degrades the scene and is reported once per scan.
     this.lastStats = null;
     const atspiNodes = this.tryAtspi();
     if (atspiNodes.length > 0) return atspiNodes;
@@ -153,17 +156,23 @@ export class LinuxAccessibilityProvider implements AccessibilityProvider {
     // Per-window failures inside the AT-SPI walk are COUNTED (not silently
     // degraded) so a scan that drops or half-reads windows is reported once
     // per scan by the scene-builder instead of read as an emptier desktop
-    // (#12273). The module-level except keeps the designed failover contract:
-    // AT-SPI unavailable (no gi bindings) -> empty payload -> compositor tier.
+    // (#12273). The Python side distinguishes the designed failover (gi/Atspi
+    // bindings absent -> {"unavailable": true} -> compositor tier, no error)
+    // from a mid-scan crash, which ships the counts accumulated before the
+    // crash plus the message so it cannot read as a clean empty payload.
     const py = `
 import json, sys
 try:
     import gi
     gi.require_version('Atspi', '2.0')
     from gi.repository import Atspi
-    out = []
-    failed = 0
-    total = 0
+except Exception:
+    print(json.dumps({"nodes": [], "unavailable": True}))
+    sys.exit(0)
+out = []
+failed = 0
+total = 0
+try:
     desktop = Atspi.get_desktop(0)
     for i in range(desktop.get_child_count()):
         app = desktop.get_child_at_index(i)
@@ -200,7 +209,7 @@ try:
                 failed += 1
     print(json.dumps({"nodes": out, "failed": failed, "total": total}))
 except Exception as e:
-    print(json.dumps({"nodes": [], "failed": 0, "total": 0}))
+    print(json.dumps({"nodes": out, "failed": failed, "total": total, "error": str(e)}))
 `;
     try {
       const text = execFileSync("python3", ["-c", py], {
@@ -208,25 +217,27 @@ except Exception as e:
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
       });
-      const parsed: unknown = JSON.parse(text || '{"nodes":[]}');
-      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-        return [];
-      }
-      const obj = parsed as Record<string, unknown>;
-      const rawNodes = Array.isArray(obj.nodes) ? obj.nodes : [];
-      const nodes = rawNodes
-        .filter((n) => n && typeof n === "object")
-        .map((n, i) => mapAtspiNode(n as Record<string, unknown>, i));
-      if (nodes.length > 0) {
-        this.lastStats = {
-          failedWindows: Number(obj.failed) || 0,
-          totalWindows: Number(obj.total) || 0,
-        };
-      }
-      return nodes;
-    } catch {
-      // error-policy:J4 AT-SPI probe; empty result advances the failover chain
-      // to the Wayland compositor tier (see snapshot()).
+      const payload = parseLinuxAtspiPayload(text);
+      if (payload.unavailable) return [];
+      this.lastStats = {
+        failedWindows: payload.failedWindows,
+        totalWindows: payload.totalWindows,
+        ...(payload.error !== undefined
+          ? { error: `AT-SPI scan crashed mid-walk: ${payload.error}` }
+          : {}),
+      };
+      return payload.nodes;
+    } catch (err) {
+      // error-policy:J4 empty result advances the failover chain to the
+      // Wayland compositor tier (see snapshot()), but python3 dying (timeout,
+      // non-zero exit, unparseable output) is a failure, not an AT-SPI-less
+      // host — record it in the scan stats (the scene-builder reports it once
+      // per scan) and warn, instead of reading as an empty desktop.
+      const message = err instanceof Error ? err.message : String(err);
+      this.lastStats = { failedWindows: 0, totalWindows: 0, error: message };
+      logger.warn(
+        `[LinuxAccessibilityProvider] AT-SPI snapshot failed; falling back to compositor tier: ${message}`,
+      );
       return [];
     }
   }
@@ -381,6 +392,45 @@ export function parseSwayTree(text: string): SceneAxNode[] {
   };
   visit(raw, "");
   return out;
+}
+
+/**
+ * Parse the AT-SPI scan payload into nodes + scan stats. Exported so the
+ * untrusted-output seam is testable without python3/AT-SPI. `unavailable`
+ * marks the designed failover (gi/Atspi bindings absent → compositor tier,
+ * not an error); a mid-scan crash instead carries `error` plus the counts
+ * accumulated before the crash, so it can never read as a clean empty scan.
+ * Throws on an unrecognizable payload — the caller's catch treats that as a
+ * whole-scan failure rather than fabricating an empty-but-healthy result.
+ */
+export function parseLinuxAtspiPayload(text: string): {
+  nodes: SceneAxNode[];
+  failedWindows: number;
+  totalWindows: number;
+  unavailable: boolean;
+  error?: string;
+} {
+  const parsed: unknown = JSON.parse(text);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("AT-SPI payload is not a {nodes,failed,total} object");
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (obj.unavailable === true) {
+    return { nodes: [], failedWindows: 0, totalWindows: 0, unavailable: true };
+  }
+  const rawNodes = Array.isArray(obj.nodes) ? obj.nodes : [];
+  const nodes = rawNodes
+    .filter((n) => n && typeof n === "object")
+    .map((n, i) => mapAtspiNode(n as Record<string, unknown>, i));
+  return {
+    nodes,
+    failedWindows: Number(obj.failed) || 0,
+    totalWindows: Number(obj.total) || 0,
+    unavailable: false,
+    ...(typeof obj.error === "string" && obj.error !== ""
+      ? { error: obj.error }
+      : {}),
+  };
 }
 
 function mapAtspiNode(raw: Record<string, unknown>, idx: number): SceneAxNode {


### PR DESCRIPTION
Follow-up to #13228 (chunk W1-I of the #12273 sweep, merged before the cross-review findings could land on its branch). Addresses all three cross-review findings. Advances #12273.

## What landed

**[med] Linux AT-SPI tier could read a broken scan as a clean empty desktop** (`src/scene/a11y-provider.ts`) — the exemplar-2 class #13228 fixed on macOS/Windows, now fixed on Linux with full parity:

- Scan stats are recorded **unconditionally** — previously `lastStats` was only set when `nodes.length > 0`, so a scan that attempted N windows and read none of them discarded its counts and produced no `ERROR_REPORTED`.
- The embedded Python no longer collapses every module-level failure into a clean `{"failed":0,"total":0}` payload. It now distinguishes:
  - the **designed failover** — gi/Atspi bindings absent → `{"unavailable": true}` → compositor tier, no error (the pre-existing failover contract, kept);
  - a **mid-scan crash** — ships the counts accumulated before the crash plus the crash message, so it can never read as a clean empty scan.
- The TS-side catch (python3 timeout / non-zero exit / unparseable output) now sets `stats.error` and `logger.warn`s before failing over to the compositor tier — parity with `DarwinAccessibilityProvider` / `WindowsAccessibilityProvider`, so the scene-builder emits one `Computeruse.a11yScan` `ERROR_REPORTED` per scan.
- The AT-SPI payload handling is extracted as `parseLinuxAtspiPayload` — an exported untrusted-output seam mirroring `parseDarwinA11yPayload` / `parseWindowsUiaPayload`, throwing on unrecognizable payloads.
- An AT-SPI failure recorded in the stats deliberately survives a compositor-tier success (documented in `snapshot()`): the compositor fallback only yields window shells, so a broken AT-SPI stack still degrades the scene and is reported.

**[low] `tryCaptureWaylandPortal` misfiled as pure rethrow** (`src/platform/capture.ts:308`, `src/platform/screenshot.ts:191`) — both catches keep the terminal permission-denied rethrow but swallow other portal failures into the capture-tier failover (`return false` → X11 tools tier → caller throws "No screenshot tool available" if every tier fails). Both now carry `// error-policy:J4 capture-tier failover` annotations and the two triage rows are corrected from `rethrow` to J4.

**[low] Brain imageless-planning catch misfiled as pure rethrow** (`src/actor/brain.ts:373`) — rethrows only under `imagePolicy === "never"` (no tier left) and otherwise degrades to the pixels-escalation tier by design. Now annotated `// error-policy:J4 designed degrade` and the triage row corrected from `rethrow` to J4.

**Inventory** (`.github/issue-evidence/12273-computeruse-triage.md`): the three re-verdicted rows carry their narrow-rethrow caveats, line numbers re-derived for all rows in the four touched files, and a follow-up note documents the Linux parity fix.

## Tests (real error paths, no mocking the failing dependency)

- `parseLinuxAtspiPayload`: all-windows-failed scan preserves counts (the exact regression); mid-scan crash carries `error` + partial counts; bindings-absent failover flagged distinctly; throws on non-object/empty payloads.
- `LinuxAccessibilityProvider.snapshot()` real-path test (non-Linux hosts): runs the real embedded Python — python3 genuinely lacks gi bindings → the designed `unavailable` payload → `[]` with **no fabricated scan stats**.
- SceneBuilder: an all-windows-failed scan (`{failedWindows: 5, totalWindows: 5}`, empty node list) produces exactly one `Computeruse.a11yScan` report — previously this shape was unreachable because the provider discarded the stats.

## Verification

- `bun run --cwd plugins/plugin-computeruse test`: **745 passed | 15 skipped | 1 failed** — the only failure is `android-bridge.test.ts` BIND_VOICE_INTERACTION, pre-existing by construction: the manifest it reads is untouched by this diff and contains the string on current `origin/develop` (same baseline the #13228 cross-review recorded at 739 passed; +6 tests from this PR).
- `bun run --cwd plugins/plugin-computeruse typecheck`: PASS · `lint:check`: exit 0.
- `bun run audit:error-policy-ratchet`: PASS (`emptyCatch 3->3 / 4->4 / 0->0` in touched files; "no new fallback-slop in touched files").
- Issue verify greps: 0 `console.*` in src; only `ps-host.ts:95` string-literal empty catch (exempt); `error-policy:J` annotations 172 → **175**.
- Full workspace `typecheck`+`lint` (turbo `--continue`, complete failure set): **570/578 tasks pass**; the 8 failures are all pre-existing develop drift, none in this diff's scope: `cloud-api#typecheck`, `electrobun#lint`, `electrobun#typecheck` (documented KNOWN-RED baseline), `plugin-capacitor-bridge#typecheck`, `plugin-sub-agent-claude-code#typecheck`, `tui#lint`, `ui#lint`, `ui#typecheck`. Pre-existing by construction: `git diff origin/develop` for this branch touches only `plugins/plugin-computeruse/**` + the evidence doc — every failing package has zero diff vs `origin/develop` and no dependency on plugin-computeruse. Sample reproduction for `tui#lint`: `git show origin/develop:packages/tui/src/autocomplete.ts | sed -n 5,8p` shows bare `"fs"`/`"os"`/`"path"` imports (landed in 07266319b, PR #12961) that fail biome `lint/style/useNodejsImportProtocol`. This PR's touched package is 100% green on typecheck + lint + test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
