### PR TITLE
fix(#12799): finish plugin-agent-orchestrator fallback-slop sweep (triage + 12 observability/fail-safe fixes)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/actions/common.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/common.ts
@@ -296,6 +296,7 @@ export async function resolveOriginatingRequestText(
       ),
     ]);
   } catch {
+    // error-policy:J4 optional last-resort room read; failure degrades to the direct message text (a real value, not fabricated)
     return direct;
   }
   const latestUserText = recent
@@ -393,6 +394,7 @@ export async function waitForSpawnSlot(
         (s) => !TERMINAL_SESSION_STATUSES.has(String(s.status)),
       ).length;
     } catch {
+      // error-policy:J4 session-state read failed → fail-open (don't block the spawn); no data fabricated
       // If we can't read session state, don't block the spawn.
       return;
     }

--- a/plugins/plugin-agent-orchestrator/src/actions/elizaos-capability.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/elizaos-capability.ts
@@ -213,6 +213,8 @@ export const elizaOsCapabilityAction: Action = {
         },
       };
     } catch (error) {
+      // error-policy:J1 boundary — a broker exec failure becomes a structured
+      // action failure ({success:false}) surfaced to the user, not swallowed.
       const text = failureText(error);
       await emit(callback, text);
       return { success: false, error: text, text };

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -446,6 +446,8 @@ async function ensureDistinctTaskRoom(
     } as Room);
     return roomId;
   } catch (error) {
+    // error-policy:J4 task-room mint failed → documented single-room (origin)
+    // fallback (same as the opt-out env); warned, so the degrade is observable.
     coreLogger.warn(
       `[TASKS] distinct task room creation failed, using origin room: ${
         error instanceof Error ? error.message : String(error)
@@ -602,6 +604,7 @@ async function runPromptViaSmithers(
       durationMs: Date.now() - startedAt,
     });
   } catch (error) {
+    // error-policy:J2 emit an observable 'error' session event, then rethrow.
     emitSessionEvent(service, session.sessionId, "error", {
       message: failureMessage(error),
     });
@@ -642,6 +645,7 @@ async function runPromptAndClose(
       stopReason: result.stopReason,
     });
   } catch (error) {
+    // error-policy:J2 emit an observable 'error' session event, then rethrow.
     emitSessionEvent(service, session.sessionId, "error", {
       message: failureMessage(error),
     });
@@ -921,6 +925,8 @@ async function runCreate(
       threadId = detail?.id ?? null;
     }
   } catch (error) {
+    // error-policy:J4 durable-thread mint failed → omit the task widget (threadId
+    // null); the spawned agents already succeeded, and the failure is warned.
     logger(runtime).warn(
       `[TASKS:create] durable task thread creation failed: ${
         error instanceof Error ? error.message : String(error)
@@ -963,6 +969,8 @@ async function runCreate(
           ...(model ? { model } : {}),
         });
       } catch (error) {
+        // error-policy:J7 per-session attach is best-effort widget bookkeeping;
+        // warned, never demotes the already-succeeded spawn.
         logger(runtime).warn(
           `[TASKS:create] attachSession failed for ${session.sessionId} on task ${threadId}: ${
             error instanceof Error ? error.message : String(error)
@@ -1312,6 +1320,8 @@ async function runSpawnAgent(
       },
     };
   } catch (error) {
+    // error-policy:J1 spawn action boundary → user-facing error message + a
+    // structured failure result.
     const messageTextValue = failureMessage(error);
     const code = isAuthError(error) ? "INVALID_CREDENTIALS" : messageTextValue;
     await callbackText(
@@ -1397,6 +1407,7 @@ async function runSend(
     );
     return errorResult("NO_INPUT");
   } catch (error) {
+    // error-policy:J1 send action boundary → user-facing error + structured failure.
     const msg = failureMessage(error);
     await callbackText(callback, `Failed to send to agent: ${msg}`);
     return { success: false, error: msg };
@@ -1514,6 +1525,7 @@ async function runStopAgent(
       data: { sessionId: target.id, agentType: String(target.agentType) },
     };
   } catch (error) {
+    // error-policy:J1 stop action boundary → user-facing error + structured failure.
     const msg = failureMessage(error);
     await callbackText(callback, `Failed to stop agent: ${msg}`);
     return { success: false, error: msg };
@@ -1665,6 +1677,7 @@ async function runCancel(
       },
     };
   } catch (error) {
+    // error-policy:J1 cancel action boundary → user-facing error + structured failure.
     const msg = failureMessage(error);
     await callbackText(callback, `Failed to cancel task: ${msg}`);
     return { success: false, error: msg };
@@ -2038,6 +2051,7 @@ async function runHistory(
         },
       };
     } catch (error) {
+      // error-policy:J1 history action boundary → user-facing error + structured failure.
       const msg = failureMessage(error);
       if (callback)
         await callback({ text: `Failed to read task history: ${msg}` });
@@ -2204,6 +2218,8 @@ async function runControl(
       try {
         resumedTask = await taskService.resumeTask(controlTaskId);
       } catch (err) {
+        // error-policy:J1 control action boundary → warns + user-facing error +
+        // structured failure result.
         const errMsg = err instanceof Error ? err.message : String(err);
         coreLogger.warn(`[TASKS:control] resume failed: ${errMsg}`);
         const out = `Failed to resume coding task ${controlTaskId}: ${errMsg}`;
@@ -2475,6 +2491,7 @@ async function runProvisionWorkspace(
       },
     };
   } catch (error) {
+    // error-policy:J1 provision action boundary → user-facing error + structured failure.
     const errorMessage = error instanceof Error ? error.message : String(error);
     if (callback)
       await callback({
@@ -2630,6 +2647,7 @@ async function runSubmitWorkspace(
       },
     };
   } catch (error) {
+    // error-policy:J1 submit action boundary → user-facing error + structured failure.
     const errorMessage = error instanceof Error ? error.message : String(error);
     if (callback)
       await callback({ text: `Failed to finalize workspace: ${errorMessage}` });
@@ -2905,6 +2923,7 @@ async function handleIssueAction(
         return { success: false, error: "UNKNOWN_OPERATION" };
     }
   } catch (error) {
+    // error-policy:J1 issue-operation boundary → user-facing error + structured failure.
     const errorMessage = error instanceof Error ? error.message : String(error);
     if (callback)
       await callback({ text: `Issue operation failed: ${errorMessage}` });
@@ -3063,6 +3082,8 @@ async function runTaskLifecycleControl(
       data: { actionName, taskId, task: result },
     };
   } catch (err) {
+    // error-policy:J1 lifecycle action boundary → warns + user-facing error +
+    // structured failure result.
     const errMsg = err instanceof Error ? err.message : String(err);
     coreLogger.warn(`[${actionName}] failed: ${errMsg}`);
     const out = `Failed to ${op} coding task ${taskId}: ${errMsg}`;

--- a/plugins/plugin-agent-orchestrator/src/api/agent-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/agent-routes.ts
@@ -110,6 +110,8 @@ async function resolveSafeVenvPath(
       );
     }
   } catch (err) {
+    // error-policy:J3 expected-ENOENT (venv candidate not created yet) validates
+    // the parent instead; any other errno rethrows.
     const maybeErr = err as NodeJS.ErrnoException;
     if (maybeErr.code !== "ENOENT") throw err;
     const parentReal = await realpath(path.dirname(resolved));
@@ -128,6 +130,7 @@ async function fileExists(filePath: string): Promise<boolean> {
     await access(filePath);
     return true;
   } catch {
+    // error-policy:J3 existence probe — inaccessible path is a typed "absent".
     return false;
   }
 }
@@ -146,6 +149,7 @@ async function resolveRequirementsPath(
       const candidateReal = await realpath(candidate);
       if (isPathInside(workdirReal, candidateReal)) return candidateReal;
     } catch {
+      // error-policy:J3 malformed/inaccessible candidate is treated as not-a-match.
       // Ignore malformed candidate and keep scanning.
     }
   }
@@ -263,6 +267,7 @@ export async function handleAgentRoutes(
         [];
       sendJson(res, results);
     } catch (error) {
+      // error-policy:J1 route boundary — service failure becomes a 500 response.
       sendError(
         res,
         error instanceof Error ? error.message : "Preflight check failed",
@@ -328,6 +333,7 @@ export async function handleAgentRoutes(
         byAgentType,
       });
     } catch (error) {
+      // error-policy:J1 route boundary — service failure becomes a 500 response.
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to load metrics",
@@ -383,6 +389,7 @@ export async function handleAgentRoutes(
       );
       sendJson(res, { success: true, scratch });
     } catch (error) {
+      // error-policy:J1 route boundary — maps failure to 404/500 response.
       const message = error instanceof Error ? error.message : String(error);
       const status = message.includes("not found") ? 404 : 500;
       sendError(res, message, status);
@@ -421,6 +428,7 @@ export async function handleAgentRoutes(
         files: [],
       });
     } catch (error) {
+      // error-policy:J1 route boundary — service failure becomes a 500 response.
       sendError(
         res,
         error instanceof Error
@@ -440,6 +448,7 @@ export async function handleAgentRoutes(
       const presets = listPresets();
       sendJson(res, presets);
     } catch (error) {
+      // error-policy:J1 route boundary — import/list failure becomes a 500 response.
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to list presets",
@@ -490,6 +499,7 @@ export async function handleAgentRoutes(
     try {
       sendJson(res, { agentType, preset, transport: "acp" });
     } catch (error) {
+      // error-policy:J1 route boundary — service failure becomes a 500 response.
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to generate config",
@@ -511,6 +521,7 @@ export async function handleAgentRoutes(
       const sessions = await ctx.acpService.listSessions();
       sendJson(res, sessions);
     } catch (error) {
+      // error-policy:J1 route boundary — service failure becomes a 500 response.
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to list agents",
@@ -552,6 +563,7 @@ export async function handleAgentRoutes(
         try {
           workdir = await resolveAllowedWorkdir(workdir);
         } catch (error) {
+          // error-policy:J1 route boundary — invalid workdir becomes a 403 response.
           sendError(
             res,
             error instanceof Error ? error.message : "invalid workdir",
@@ -577,6 +589,8 @@ export async function handleAgentRoutes(
         try {
           await runBenchmarkPreflight(workdir);
         } catch (preflightError) {
+          // error-policy:J4 benchmark preflight is a best-effort venv pre-warm;
+          // failure degrades to on-demand install and the spawn still proceeds.
           logger.warn(
             `[coding-agent] benchmark preflight failed for ${workdir}: ${
               preflightError instanceof Error
@@ -662,6 +676,7 @@ export async function handleAgentRoutes(
         201,
       );
     } catch (error) {
+      // error-policy:J1 route boundary — spawn failure becomes a 500 response.
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to spawn agent",
@@ -743,6 +758,7 @@ export async function handleAgentRoutes(
         return true;
       }
     } catch (error) {
+      // error-policy:J1 route boundary — send failure becomes a 500 response.
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to send input",
@@ -766,6 +782,7 @@ export async function handleAgentRoutes(
       await ctx.acpService.stopSession(sessionId);
       sendJson(res, { success: true, sessionId });
     } catch (error) {
+      // error-policy:J1 route boundary — stop failure becomes a 500 response.
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to stop agent",
@@ -796,6 +813,7 @@ export async function handleAgentRoutes(
       const output = await ctx.acpService.getSessionOutput?.(sessionId, lines);
       sendJson(res, { sessionId, output });
     } catch (error) {
+      // error-policy:J1 route boundary — service failure becomes a 500 response.
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to get output",
@@ -820,6 +838,7 @@ export async function handleAgentRoutes(
       const output = await ctx.acpService.getSessionOutput(sessionId, 500);
       sendJson(res, { sessionId, output });
     } catch (error) {
+      // error-policy:J1 route boundary — service failure becomes a 500 response.
       sendError(
         res,
         error instanceof Error

--- a/plugins/plugin-agent-orchestrator/src/api/bridge-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/bridge-routes.ts
@@ -225,6 +225,8 @@ async function handlePost(
   try {
     body = await parseBody(req);
   } catch (error) {
+    // error-policy:J3 untrusted-input sanitizing; a malformed request body is an
+    // explicit invalid result (400), never a fabricated success.
     sendJson(
       res,
       {

--- a/plugins/plugin-agent-orchestrator/src/api/credential-prompt.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/credential-prompt.ts
@@ -229,6 +229,7 @@ export async function emitCredentialPrompt(input: {
     );
     return true;
   } catch (error) {
+    // error-policy:J4 best-effort chat delivery unavailable → warn + honest false; credential request itself proceeds
     // Posting the prompt is a non-critical side-effect of the credential
     // bridge; never let a delivery failure break the request itself.
     logger.warn(
@@ -269,6 +270,7 @@ export async function emitCredentialResolved(input: {
     );
     return true;
   } catch (error) {
+    // error-policy:J4 best-effort follow-up delivery unavailable → warn + honest false
     logger.warn(
       `[credential-prompt] failed to post resolution follow-up: ${
         error instanceof Error ? error.message : String(error)

--- a/plugins/plugin-agent-orchestrator/src/api/issue-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/issue-routes.ts
@@ -60,6 +60,7 @@ export async function handleIssueRoutes(
       });
       sendJson(res, issues);
     } catch (error) {
+      // error-policy:J1 route boundary — translate to structured HTTP 500
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to list issues",
@@ -93,6 +94,7 @@ export async function handleIssueRoutes(
       });
       sendJson(res, issue, 201);
     } catch (error) {
+      // error-policy:J1 route boundary — translate to structured HTTP 500
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to create issue",
@@ -118,6 +120,7 @@ export async function handleIssueRoutes(
       const issue = await ctx.workspaceService.getIssue(repo, issueNumber);
       sendJson(res, issue);
     } catch (error) {
+      // error-policy:J1 route boundary — translate to structured HTTP 500
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to get issue",
@@ -153,6 +156,7 @@ export async function handleIssueRoutes(
       );
       sendJson(res, comment, 201);
     } catch (error) {
+      // error-policy:J1 route boundary — translate to structured HTTP 500
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to add comment",
@@ -178,6 +182,7 @@ export async function handleIssueRoutes(
       const issue = await ctx.workspaceService.closeIssue(repo, issueNumber);
       sendJson(res, issue);
     } catch (error) {
+      // error-policy:J1 route boundary — translate to structured HTTP 500
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to close issue",

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -108,6 +108,7 @@ async function parseOptionalBody(
   try {
     return await parseBody(req);
   } catch {
+    // error-policy:J3 unparseable request body → null; callers emit an explicit 400.
     return null;
   }
 }
@@ -153,6 +154,8 @@ export async function handleOrchestratorRoutes(
   try {
     return await dispatchOrchestratorRoutes(req, res, pathname, ctx);
   } catch (error) {
+    // error-policy:J1 single route boundary — any thrown service call becomes a
+    // 500 response instead of an unhandled rejection.
     if (!res.headersSent) {
       sendError(
         res,
@@ -381,6 +384,7 @@ async function dispatchOrchestratorRoutes(
       try {
         deleted = await service.deleteTask(taskId);
       } catch (error) {
+        // error-policy:J1 route boundary — service failure becomes a 500 response.
         sendError(
           res,
           error instanceof Error ? error.message : "Failed to delete task",
@@ -402,6 +406,7 @@ async function dispatchOrchestratorRoutes(
       try {
         task = await service.pauseTask(taskId);
       } catch (error) {
+        // error-policy:J1 route boundary — service failure becomes a 500 response.
         sendError(
           res,
           error instanceof Error ? error.message : "Failed to pause task",
@@ -434,6 +439,7 @@ async function dispatchOrchestratorRoutes(
       try {
         task = await service.archiveTask(taskId);
       } catch (error) {
+        // error-policy:J1 route boundary — service failure becomes a 500 response.
         sendError(
           res,
           error instanceof Error ? error.message : "Failed to archive task",
@@ -542,6 +548,8 @@ async function dispatchOrchestratorRoutes(
           verifier: LLM_GOAL_VERIFIER_NAME,
         })
         .catch((error: unknown) => {
+          // error-policy:J1 route boundary — validation failure becomes a 409 response;
+          // the undefined sentinel is checked below to end the request.
           sendError(
             res,
             error instanceof Error ? error.message : "Validation failed",
@@ -575,6 +583,8 @@ async function dispatchOrchestratorRoutes(
           humanOverride: body.humanOverride === true,
         })
         .catch((error: unknown) => {
+          // error-policy:J1 route boundary — validation failure becomes a 409 response;
+          // the undefined sentinel is checked below to end the request.
           sendError(
             res,
             error instanceof Error ? error.message : "Validation failed",
@@ -626,6 +636,7 @@ async function dispatchOrchestratorRoutes(
             metadata: isRecord(body.metadata) ? body.metadata : undefined,
           });
         } catch (error) {
+          // error-policy:J1 route boundary — failure becomes a 409/500 response.
           sendError(
             res,
             error instanceof Error
@@ -673,6 +684,7 @@ async function dispatchOrchestratorRoutes(
           agent: asAgentOptions(body.agent),
         });
       } catch (error) {
+        // error-policy:J1 route boundary — failure becomes a 409/500 response.
         sendError(
           res,
           error instanceof Error ? error.message : "Failed to retry turn",
@@ -724,6 +736,7 @@ async function dispatchOrchestratorRoutes(
           agent: asAgentOptions(body.agent),
         });
       } catch (error) {
+        // error-policy:J1 route boundary — failure becomes a 409/500 response.
         sendError(
           res,
           error instanceof Error ? error.message : "Failed to rerun from event",
@@ -756,6 +769,7 @@ async function dispatchOrchestratorRoutes(
           agent: asAgentOptions(body.agent),
         });
       } catch (error) {
+        // error-policy:J1 route boundary — failure becomes a 409/500 response.
         sendError(
           res,
           error instanceof Error ? error.message : "Failed to restart task",
@@ -798,6 +812,7 @@ async function dispatchOrchestratorRoutes(
           agent: asAgentOptions(body.agent),
         });
       } catch (error) {
+        // error-policy:J1 route boundary — failure becomes a 409/500 response.
         sendError(
           res,
           error instanceof Error
@@ -907,6 +922,7 @@ async function dispatchOrchestratorRoutes(
             task: asString(body.task),
           });
         } catch (error) {
+          // error-policy:J1 route boundary — spawn failure becomes a 500 response.
           sendError(
             res,
             error instanceof Error ? error.message : "Failed to spawn agent",
@@ -932,6 +948,7 @@ async function dispatchOrchestratorRoutes(
         try {
           stopped = await service.stopTaskAgent(taskId, sessionId);
         } catch (error) {
+          // error-policy:J1 route boundary — stop failure becomes a 500 response.
           sendError(
             res,
             error instanceof Error ? error.message : "Failed to stop agent",

--- a/plugins/plugin-agent-orchestrator/src/api/route-utils.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/route-utils.ts
@@ -56,6 +56,8 @@ export async function parseBody(
       try {
         resolve(body ? JSON.parse(body) : {});
       } catch {
+        // error-policy:J3 untrusted-input sanitizing; malformed JSON rejects with
+        // a typed invalid-body error, never a fabricated empty object.
         reject(new Error("Invalid JSON body"));
       }
     });

--- a/plugins/plugin-agent-orchestrator/src/api/workspace-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/workspace-routes.ts
@@ -68,6 +68,7 @@ export async function handleWorkspaceRoutes(
         201,
       );
     } catch (error) {
+      // error-policy:J1 route boundary → 500 structured error response
       sendError(
         res,
         error instanceof Error
@@ -92,6 +93,7 @@ export async function handleWorkspaceRoutes(
       const status = await ctx.workspaceService.getStatus(workspaceId);
       sendJson(res, status);
     } catch (error) {
+      // error-policy:J1 route boundary → 500 structured error response
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to get workspace",
@@ -121,6 +123,7 @@ export async function handleWorkspaceRoutes(
 
       sendJson(res, result);
     } catch (error) {
+      // error-policy:J1 route boundary → 500 structured error response
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to commit",
@@ -151,6 +154,7 @@ export async function handleWorkspaceRoutes(
 
       sendJson(res, result);
     } catch (error) {
+      // error-policy:J1 route boundary → 500 structured error response
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to push",
@@ -189,6 +193,7 @@ export async function handleWorkspaceRoutes(
 
       sendJson(res, result, 201);
     } catch (error) {
+      // error-policy:J1 route boundary → 500 structured error response
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to create PR",
@@ -211,6 +216,7 @@ export async function handleWorkspaceRoutes(
       await ctx.workspaceService.removeWorkspace(workspaceId);
       sendJson(res, { success: true, workspaceId });
     } catch (error) {
+      // error-policy:J1 route boundary → 500 structured error response
       sendError(
         res,
         error instanceof Error ? error.message : "Failed to remove workspace",

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
@@ -157,6 +157,7 @@ function bodyIsOnlyUrls(text: string): boolean {
       try {
         return new URL(line).toString().length > 0;
       } catch {
+        // error-policy:J3 model text probed for URL-only lines; a parse failure means the line is not a URL (explicit invalid), not a fabricated result.
         return false;
       }
     })
@@ -185,6 +186,7 @@ function userFacingVerifiedUrl(urls: readonly string[]): string | undefined {
       try {
         return { url, parsed: new URL(url) };
       } catch {
+        // error-policy:J3 untrusted candidate URL parsed; unparseable entries are dropped as invalid, never treated as valid.
         return undefined;
       }
     })
@@ -215,6 +217,7 @@ function parseUrl(value: string): URL | undefined {
   try {
     return new URL(value);
   } catch {
+    // error-policy:J3 untrusted string probed as a URL; a parse failure returns the explicit "not a URL" signal (undefined).
     return undefined;
   }
 }

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -260,6 +260,8 @@ export function createAgentOrchestratorPlugin(): Plugin {
         // Strip the runtime reference before persisting — it's a live object,
         // not serialisable data, and not useful in a flat audit log.
         const { runtime: _runtime, ...persisted } = payload;
+        // error-policy:J7 best-effort audit-log write; a failed append warns and
+        // does not fabricate the handler's result.
         await appendAuditLine(auditLogPath, persisted).catch((err) =>
           runtime.logger?.warn?.(
             {
@@ -311,6 +313,8 @@ export function createAgentOrchestratorPlugin(): Plugin {
       setTimeout(() => {
         void (async () => {
           for (const sType of types) {
+            // error-policy:J7 eager-start is an optimization; a failed load warns
+            // and the service still lazily starts on first getService.
             await runtime.getServiceLoadPromise(sType).catch((err: unknown) =>
               runtime.logger?.warn?.(
                 {
@@ -384,6 +388,8 @@ export function createAgentOrchestratorPlugin(): Plugin {
                   try {
                     await svc?.sendPrompt(sessionId, queued);
                   } catch (err) {
+                    // error-policy:J7 inbox-flush loop must survive a transient
+                    // send failure; the message is requeued (never dropped) + warned.
                     // Lost the race back to busy — requeue and re-arm rather
                     // than drop the user's message.
                     subAgentInbox.enqueue(sessionId, queued);
@@ -412,6 +418,8 @@ export function createAgentOrchestratorPlugin(): Plugin {
               }
             });
           }
+          // error-policy:J7 best-effort orphan-session recovery at boot; a failure
+          // warns and does not abort the init chain.
           void acp?.resumeOrphanedBusySessions?.().catch((err: unknown) =>
             runtime.logger?.warn?.(
               {
@@ -442,6 +450,8 @@ export function createAgentOrchestratorPlugin(): Plugin {
         try {
           disposeProgressHook();
         } catch (err) {
+          // error-policy:J6 best-effort teardown; a throwing disposer warns and
+          // does not block the rest of dispose.
           runtime.logger?.warn?.(
             {
               src: "@elizaos/plugin-agent-orchestrator",
@@ -456,7 +466,7 @@ export function createAgentOrchestratorPlugin(): Plugin {
         try {
           disposeInboxFlush();
         } catch {
-          // listener already detached
+          // error-policy:J6 best-effort teardown; listener already detached.
         }
         disposeInboxFlush = undefined;
       }
@@ -673,6 +683,8 @@ function withSpawnAckTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {
     timer = setTimeout(() => resolve(fallback), SPAWN_ACK_TIMEOUT_MS);
     (timer as { unref?: () => void }).unref?.();
   });
+  // error-policy:J4 spawn-ack model rejection/timeout degrades to the neutral
+  // literal ack; a cosmetic UX line, never fabricated data.
   return Promise.race([promise.catch(() => fallback), timeout]).finally(() => {
     if (timer) clearTimeout(timer);
   });
@@ -1160,6 +1172,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         );
         return result ?? undefined;
       } catch {
+        // error-policy:J4 thread redirect failed; the message still delivers via
+        // the original main-channel send below.
         return originalSend(target, content);
       }
     };
@@ -1227,7 +1241,9 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         // TASKS_LIST_AGENTS to ask "where are you?" on demand.
         const raw =
           typeof acp.getSessionOutput === "function"
-            ? await acp.getSessionOutput(sessionId, 200).catch(() => "")
+            ? // error-policy:J7 best-effort heartbeat read; a failed read degrades
+              // to "" so the tick is skipped rather than posting a false status.
+              await acp.getSessionOutput(sessionId, 200).catch(() => "")
             : "";
         const cleaned = stripToolTranscripts(raw);
         const tools = toolHistory.get(sessionId) ?? [];
@@ -1249,6 +1265,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
             prompt: filledPrompt,
             maxTokens: 80,
           })
+          // error-policy:J7 best-effort heartbeat summary; a failed model call
+          // degrades to "" and the tick is skipped, never a fabricated status.
           .catch(() => "");
         const trimmedSummary = summary.trim().replace(/\s+/g, " ");
         if (trimmedSummary.length === 0) return;
@@ -1267,7 +1285,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         lastHeartbeatPostAt.set(sessionId, now);
         await emitProgress(sessionId, { source, roomId }, text, label);
       } catch {
-        // best-effort heartbeat — never crash
+        // error-policy:J7 heartbeat interval must not crash the loop; the tick is
+        // a cosmetic status post — best-effort, never fabricated.
       }
     }, intervalMs);
     heartbeatTimers.set(sessionId, timer);
@@ -1318,6 +1337,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         SPAWN_ACK_FALLBACK,
       );
     } catch {
+      // error-policy:J4 ack generation failure degrades to the neutral literal;
+      // a cosmetic UX line, never data.
       return SPAWN_ACK_FALLBACK;
     }
   };
@@ -1366,7 +1387,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
     try {
       await runtime.addReactionOnTarget(target, messageId, emoji);
     } catch {
-      // best-effort: reactions are visual sugar, never block the flow
+      // error-policy:J4 reactions are non-essential visual sugar; a failed add
+      // degrades silently and must not block the flow.
     }
   }
 
@@ -1424,7 +1446,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         }
       }
     } catch {
-      // best-effort resolution — fall back to the bare target below
+      // error-policy:J4 room lookup unavailable degrades to the bare
+      // { source, roomId } target below — no worse than before.
     }
     emitTargetCacheByKey.set(key, resolved);
     if (emitTargetCacheByKey.size > 512) {
@@ -1695,6 +1718,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
               threadCacheByKey.set(cacheKey, thread);
               evictOldest(threadCacheByKey);
             } catch (err: unknown) {
+              // error-policy:J4 thread creation unavailable degrades to
+              // main-channel edits; the failure is warned.
               runtime.logger?.warn?.(
                 {
                   src: "@elizaos/plugin-agent-orchestrator",
@@ -1713,6 +1738,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
             const threadRoomId = createUniqueUuid(runtime, thread.threadId);
             await acp
               ?.updateSessionMetadata(sessionId, { threadRoomId })
+              // error-policy:J7 best-effort thread-binding write; a failed update
+              // warns (observable) and does not abort thread setup.
               .catch((err: unknown) =>
                 runtime.logger?.warn?.(
                   {
@@ -1735,14 +1762,16 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
                 );
                 newState.lastText = displayText;
               } catch {
-                // best-effort: cached thread may have been archived; on next
-                // call we'll attempt re-create lazily via the same path.
+                // error-policy:J4 cached thread may be archived; the post degrades
+                // and the next call lazily re-creates via the same path.
               }
             }
           }
         }
       }
     } catch (err: unknown) {
+      // error-policy:J7 progress narration must not kill the event loop; the
+      // failure is warned once (then debug) and the first-post claim released.
       // Release the first-post claim on failure so a retry can post the ACK
       // (on success it was already released once state was recorded).
       firstPostInFlight.delete(sessionId);
@@ -1807,7 +1836,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
             transientContent(completionText, "sub_agent_complete"),
           );
         } catch {
-          // ignore: reaction below is the secondary signal
+          // error-policy:J4 completion edit failed; the ✅ reaction below is the
+          // secondary completion signal.
         }
       } else {
         // Capability-poor surface (no edit): emitProgress was silenced
@@ -1819,7 +1849,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
             transientContent(completionText, "sub_agent_complete"),
           );
         } catch {
-          // best-effort
+          // error-policy:J4 best-effort completion notice on a no-edit surface;
+          // the synthesis evaluator remains the canonical outcome message.
         }
       }
     }
@@ -1861,7 +1892,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
           ),
         );
       } catch {
-        // best-effort
+        // error-policy:J4 best-effort terminal-failure notice on a no-edit
+        // surface; a failed post degrades silently.
       }
     }
   }
@@ -2201,6 +2233,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         );
         await emitProgress(sessionId, { source, roomId }, text, label);
       } catch (err) {
+        // error-policy:J7 background session-event handler must not kill the ACP
+        // event stream; the failure is warned (observable).
         runtime.logger?.warn?.(
           {
             src: "@elizaos/plugin-agent-orchestrator",
@@ -2215,7 +2249,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
     try {
       unsubscribeSessionEvents();
     } catch {
-      // best-effort: AcpService may already be torn down
+      // error-policy:J6 best-effort teardown; AcpService may already be torn down.
     }
     // Drain pending timers so they don't fire after the hook is dead —
     // those callbacks reference state we're about to drop and would call
@@ -2240,7 +2274,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
       try {
         restoreSend();
       } catch {
-        // best-effort: another wrapper may have chained over ours
+        // error-policy:J6 best-effort teardown; another wrapper may have chained
+        // over ours.
       }
     }
   };

--- a/plugins/plugin-agent-orchestrator/src/providers/action-examples.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/action-examples.ts
@@ -106,6 +106,7 @@ export const codingAgentExamplesProvider: Provider = {
         text: detailedText,
       };
     } catch (err) {
+      // error-policy:J4 best-effort prompt enrichment; framework/auth state unavailable → prompt proceeds without examples
       logger(runtime).debug?.(
         { error: err },
         "[codingAgentExamplesProvider] failed to build examples",

--- a/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
@@ -32,6 +32,7 @@ function stalledSessionIds(runtime: IAgentRuntime): Set<string> {
   try {
     return new Set(watchdog.getStalledSessionIds());
   } catch {
+    // error-policy:J4 watchdog is optional; an unavailable getter degrades to no stalled set (a supplementary planner signal, not the session list itself)
     return new Set();
   }
 }
@@ -59,6 +60,7 @@ function approachingCapBySession(
       if (!map.has(id) || kind === "round-trip") map.set(id, kind);
     }
   } catch {
+    // error-policy:J4 watchdog is optional; an unavailable getter degrades to no approaching-cap set (a supplementary planner signal, not the session list itself)
     return new Map();
   }
   return map;
@@ -153,6 +155,7 @@ export const activeSubAgentsProvider: Provider = {
             const tail = summarizeOutputTail(raw);
             if (tail) liveByName.set(session.id, tail);
           } catch {
+            // error-policy:J4 live-tail is per-session enrichment; unavailable output degrades to structural status only
             // ignore — fall back to structural status only
           }
         }),

--- a/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
@@ -118,9 +118,18 @@ export const activeSubAgentsProvider: Provider = {
     if (!service || typeof service.listSessions !== "function") {
       return emptyResult();
     }
-    const all = await Promise.resolve(service.listSessions()).catch(
-      () => [] as SessionInfo[],
-    );
+    let all: SessionInfo[] | undefined;
+    try {
+      all = await Promise.resolve(service.listSessions());
+    } catch (error) {
+      // error-policy:J4 the session list is the ground truth the planner reads
+      // to decide spawn-vs-reuse-vs-wait; a failed load must NOT read as "no
+      // sub-agents" (that would let the planner spawn a duplicate over a
+      // still-running worker). Surface it observably via reportError and
+      // degrade to an explicit "temporarily unavailable" note.
+      runtime.reportError(PROVIDER_NAME, error, { operation: "listSessions" });
+      return unavailableResult();
+    }
     // Provider surfaces ONLY active sessions — the sub-agent currently
     // running is the ground truth. Past sessions (any terminal status,
     // including errored) are intentionally excluded: surfacing them mixes
@@ -206,6 +215,20 @@ function emptyResult() {
     text: "",
     values: { activeSubAgents: "" },
     data: { sessions: [] },
+  };
+}
+
+// Distinct from emptyResult: the load failed, so the planner must NOT treat the
+// absence of listed sessions as "no active sub-agents". The note keeps the
+// failure visible in-context (the reportError call already surfaced it via
+// RECENT_ERRORS) so a duplicate spawn over a live worker is avoided.
+function unavailableResult() {
+  const text =
+    "## Active sub-agent sessions\nSub-agent session state is temporarily unavailable (failed to load). Do not assume there are no active sub-agents — retry before spawning a new one.";
+  return {
+    text,
+    values: { activeSubAgents: text },
+    data: { sessions: [], unavailable: true },
   };
 }
 

--- a/plugins/plugin-agent-orchestrator/src/services/acceptance-criteria.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acceptance-criteria.ts
@@ -256,6 +256,7 @@ export async function generateDefaultAcceptanceCriteria(
     const refined = normalizeCriteria(candidates, fallback);
     return refined.length >= MIN_CRITERIA ? refined : fallback;
   } catch {
+    // error-policy:J4 optional model refinement of an external dep; any failure degrades to the designed deterministic static template
     // Defensive: criteria generation must never break task creation.
     return fallback;
   }

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -174,6 +174,8 @@ export class NativeAcpClient {
       try {
         this.opts.onStderr?.(text);
       } catch {
+        // error-policy:J7 diagnostics-must-not-kill-the-loop — a consumer
+        // onStderr observer throw must not tear down the agent stderr stream.
         // best-effort observability; swallow
       }
     });
@@ -334,6 +336,8 @@ export class NativeAcpClient {
     try {
       this.opts.onEvent?.(message);
     } catch {
+      // error-policy:J7 diagnostics-must-not-kill-the-loop — onEvent is
+      // best-effort trajectory capture; a consumer throw must not break ACP I/O.
       // best-effort observer; swallow so ACP I/O keeps flowing
     }
   }
@@ -359,6 +363,8 @@ export class NativeAcpClient {
     try {
       message = JSON.parse(line) as AcpJsonRpcMessage;
     } catch {
+      // error-policy:J3 untrusted-input sanitizing — a non-JSON line on the
+      // subprocess stdout stream is dropped rather than crashing the reader.
       return;
     }
     this.emitEvent(message);
@@ -387,6 +393,8 @@ export class NativeAcpClient {
       );
       this.respond(id, result ?? {});
     } catch (err) {
+      // error-policy:J1 boundary translation — a client-request handler fault
+      // is returned to the ACP peer as a structured JSON-RPC error response.
       this.respondError(id, err, jsonRpcCodeForError(err, method));
     }
   }
@@ -661,6 +669,8 @@ export class NativeAcpClient {
     ensureResolvedInsideRoot(root, parent, requested ?? filePath);
     const existing = await lstat(filePath).catch(
       (err: NodeJS.ErrnoException) => {
+        // error-policy:J3 untrusted-input sanitizing — an ENOENT probe miss
+        // means "no existing file" (undefined); any other stat error rethrows.
         if (err.code === "ENOENT") return undefined;
         throw err;
       },
@@ -812,6 +822,8 @@ function compactJson(value: unknown): string | undefined {
       ? `${serialized.slice(0, limit)}…`
       : serialized;
   } catch {
+    // error-policy:J3 untrusted-input sanitizing — an unserializable diagnostic
+    // value (e.g. a circular error.data) yields no compact detail, not a crash.
     return undefined;
   }
 }
@@ -944,7 +956,8 @@ function signalTerminal(
       return;
     }
   } catch {
-    // Fall back to signaling the direct child below.
+    // error-policy:J6 best-effort teardown — process-group kill can ESRCH on an
+    // already-dead child; fall back to signaling the direct child below.
   }
   if (!proc.killed) proc.kill(signal);
 }

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -442,6 +442,8 @@ export class AcpService extends Service {
             "errored",
             "Sub-agent was mid-flight when the runtime restarted. No automatic action taken.",
           )
+          // error-policy:J7 reconcile status-write; warn-logged and retried by
+          // the next health-check tick, so it must not abort the orphan sweep.
           .catch((err) =>
             this.log("warn", "failed to mark orphaned session errored", {
               sessionId: s.id,
@@ -564,6 +566,8 @@ export class AcpService extends Service {
           .updateStatus(s.id, "errored", message)
           .then(() => true)
           .catch((err) => {
+            // error-policy:J7 status-write inside the health-check loop; warn +
+            // return false gates emission and retries next tick — never fabricates.
             this.log("warn", "health-check: failed to mark errored", {
               sessionId: s.id,
               err,
@@ -623,6 +627,8 @@ export class AcpService extends Service {
       const st = await stat(this.acpxSessionStateFile(acpxSessionId));
       return { exists: true, mtimeMs: st.mtimeMs };
     } catch {
+      // error-policy:J3 stat probe — a missing state file is an explicit "absent"
+      // ({exists:false}) the callers branch on, not a masked failure.
       return { exists: false, mtimeMs: 0 };
     }
   }
@@ -776,6 +782,8 @@ export class AcpService extends Service {
           model: opts.model,
         })
           .catch((err: unknown) => {
+            // error-policy:J5 fire-and-forget initial prompt; the underlying
+            // failure is also surfaced by sendPrompt (errored status + error event).
             this.log("error", "initial prompt failed", {
               sessionId: id,
               agentType,
@@ -849,6 +857,8 @@ export class AcpService extends Service {
         model: opts.model,
       })
         .catch((err: unknown) => {
+          // error-policy:J5 fire-and-forget initial prompt; the underlying
+          // failure is also surfaced by sendPrompt (errored status + error event).
           this.log("error", "initial prompt failed", {
             sessionId: id,
             agentType,
@@ -904,6 +914,8 @@ export class AcpService extends Service {
         await this.store.updateStatus(sessionId, "busy");
         return await this.sendNativePrompt(session, text, opts, startedAt);
       } catch (err) {
+        // error-policy:J2 release the synchronous busy-claim on the pre-prompt
+        // error path, then propagate the original error unchanged.
         this.nativePromptSessionIds.delete(sessionId);
         throw err;
       }
@@ -1072,6 +1084,8 @@ export class AcpService extends Service {
 
   async deleteSession(sessionId: string): Promise<void> {
     await this.closeSession(sessionId).catch((err: unknown) => {
+      // error-policy:J6 best-effort close before delete; a teardown failure must
+      // not block removing the session record + satellite maps below.
       this.log("warn", "deleteSession close failed", {
         sessionId,
         error: errorMessage(err),
@@ -1137,6 +1151,8 @@ export class AcpService extends Service {
             ? session.metadata.label
             : undefined,
       });
+      // error-policy:J5 fire-and-forget resume; the real failure is surfaced by
+      // sendPrompt (errored status + error event), this only logs the rejection.
       void this.sendPrompt(session.id, ORPHAN_RESUME_PROMPT).catch(
         (err: unknown) =>
           this.log("warn", "orphan resume sendPrompt failed", {
@@ -1190,6 +1206,8 @@ export class AcpService extends Service {
       if (!stateOk) continue;
       const workdirOk = await stat(session.workdir)
         .then((s) => s.isDirectory())
+        // error-policy:J3 stat probe — a vanished workdir is the explicit "not
+        // resumable" signal (false → continue), not a masked failure.
         .catch(() => false);
       if (workdirOk) return session;
     }
@@ -1277,6 +1295,8 @@ export class AcpService extends Service {
       return;
     }
     await this.closeSession(sessionId).catch((err: unknown) => {
+      // error-policy:J6 best-effort teardown of the initial-task session; a close
+      // failure must not abort the fire-and-forget completion path.
       this.log("warn", "initial task session close failed", {
         sessionId,
         error: errorMessage(err),
@@ -1630,6 +1650,9 @@ export class AcpService extends Service {
       }
       return promptResult;
     } catch (err) {
+      // error-policy:J1 native-transport boundary — translates a prompt failure
+      // into a structured PromptResult (errored store + error event), never a
+      // fake success.
       const message = errorMessage(err);
       if (this.nativeStoppingSessionIds.has(session.id)) {
         await this.store.updateStatus(session.id, "stopped");
@@ -1984,6 +2007,8 @@ export class AcpService extends Service {
     try {
       return JSON.parse(line) as AcpJsonRpcMessage;
     } catch {
+      // error-policy:J3 untrusted subprocess stdout — a malformed NDJSON line is
+      // an explicit invalid (null) result the caller skips.
       this.log("warn", "malformed acpx NDJSON line ignored", {
         sessionId,
         line: line.slice(0, 200),
@@ -2009,6 +2034,8 @@ export class AcpService extends Service {
     ) {
       void this.store
         .update(localSessionId, { acpxSessionId: protocolSessionId })
+        // error-policy:J7 acpxSessionId mirror-write inside the sync event
+        // handler; warn-logged, the emitted event is the primary signal.
         .catch((err) =>
           this.log("warn", "failed to persist acpxSessionId", {
             sessionId: localSessionId,
@@ -2021,6 +2048,8 @@ export class AcpService extends Service {
       try {
         callback(event, sessionId);
       } catch (err) {
+        // error-policy:J7 isolate a throwing subscriber so the remaining ACP
+        // callbacks still run; the failure is warn-logged.
         this.log("warn", "ACP event callback failed", {
           sessionId,
           error: errorMessage(err),
@@ -2077,6 +2106,8 @@ export class AcpService extends Service {
             message: description,
             request: params,
           });
+        // error-policy:J7 status mirror-write; the "blocked"/"login_required"
+        // events already fired above, this only warns if the durable mirror lags.
         void this.store.updateStatus(sessionId, "blocked").catch((err) =>
           this.log("warn", "failed to persist blocked status", {
             sessionId,
@@ -2211,6 +2242,8 @@ export class AcpService extends Service {
           isTerminalStatus
         ) {
           this.emitSessionEvent(sessionId, "tool_running", { toolCall });
+          // error-policy:J7 status mirror-write; the tool_running event already
+          // fired above, this only warns if the durable mirror lags.
           void this.store.updateStatus(sessionId, "tool_running").catch((err) =>
             this.log("warn", "failed to persist tool_running status", {
               sessionId,
@@ -2319,6 +2352,8 @@ export class AcpService extends Service {
       try {
         callback(sessionId, event, data);
       } catch (err) {
+        // error-policy:J7 isolate a throwing subscriber so the remaining session
+        // callbacks still run; the failure is warn-logged.
         this.log("warn", "session event callback failed", {
           sessionId,
           event,
@@ -2645,6 +2680,8 @@ export class AcpService extends Service {
         reason,
       });
     } catch (err) {
+      // error-policy:J6 best-effort lease release on an already-terminal session;
+      // a broker error is warn-logged, never thrown.
       this.log("warn", "model-gateway lease revoke failed", {
         sessionId,
         leaseId: lease.leaseId,
@@ -3278,6 +3315,8 @@ function parseJsonRecord(text: string): Record<string, unknown> | undefined {
   try {
     return asRecord(JSON.parse(text));
   } catch {
+    // error-policy:J3 untrusted text — a parse failure is an explicit "not a
+    // record" (undefined) result the caller branches on.
     return undefined;
   }
 }
@@ -3405,6 +3444,8 @@ function isPidAlive(pid: number): boolean {
     process.kill(pid, 0);
     return true;
   } catch {
+    // error-policy:J3 liveness probe — a throw means the pid is gone (explicit
+    // false), not a masked failure.
     return false;
   }
 }
@@ -3422,6 +3463,8 @@ function killProcessTree(
       process.kill(-proc.pid, signal);
       return;
     } catch {
+      // error-policy:J6 best-effort process-group kill; fall through to a direct
+      // signal on the lead process.
       // Group may already be gone, or the platform doesn't support it
       // (Windows). Fall through to a direct signal on the lead process.
     }
@@ -3431,6 +3474,8 @@ function killProcessTree(
   try {
     proc.kill(signal);
   } catch {
+    // error-policy:J6 best-effort termination; nothing left to do if the lead
+    // process is already gone.
     // Best-effort termination only.
   }
 }
@@ -3471,6 +3516,8 @@ export async function scanAndUnlinkOlderThanDetailed(
   try {
     entries = await readdir(dir);
   } catch {
+    // error-policy:J3 an absent GC directory is the expected shape → explicit
+    // zero-work result (documented contract), not a masked read failure.
     return { deleted: 0, lingering: 0 };
   }
   const matching = entries.filter(predicate);
@@ -3490,6 +3537,8 @@ export async function scanAndUnlinkOlderThanDetailed(
           lingering++;
         }
       } catch {
+        // error-policy:J6 best-effort per-file GC; a vanished/locked file is
+        // skipped so the sweep continues.
         // best-effort
       }
     }),

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -399,7 +399,19 @@ export class AcpService extends Service {
   }
 
   private async reconcileOrphanedSessions(): Promise<void> {
-    const all = await this.store.list().catch(() => [] as SessionInfo[]);
+    let all: SessionInfo[];
+    try {
+      all = await this.store.list();
+    } catch (err) {
+      // error-policy:J7 store read failed; a fabricated empty set would make
+      // this reconcile pass a no-op and silently strand orphaned sessions.
+      // Surface it and skip this cycle — the next health-check tick retries.
+      this.runtime.reportError("AcpService.reconcileOrphanedSessions", err, {
+        phase: "store.list",
+      });
+      this.log("warn", "reconcile: store read failed, skipping cycle", { err });
+      return;
+    }
     const orphaned = all.filter(
       (s) => !TERMINAL_SESSION_STATUSES.has(s.status),
     );
@@ -511,7 +523,26 @@ export class AcpService extends Service {
   // but orchestrator never persisted — crash between spawn and store.create).
   private async cleanReverseOrphanedAcpxFiles(): Promise<void> {
     const sessionsDir = join(this.acpxStateRoot(), "sessions");
-    const sessions = await this.store.list().catch(() => [] as SessionInfo[]);
+    let sessions: SessionInfo[];
+    try {
+      sessions = await this.store.list();
+    } catch (err) {
+      // error-policy:J7 store read failed; DATA-LOSS GUARD. A fabricated empty
+      // tracked set makes every stream file look orphaned, so the scan below
+      // would delete live sessions' stream files. Surface and return without
+      // scanning or deleting anything — the next tick retries with real data.
+      this.runtime.reportError(
+        "AcpService.cleanReverseOrphanedAcpxFiles",
+        err,
+        { phase: "store.list" },
+      );
+      this.log(
+        "warn",
+        "reverse-orphan scan: store read failed, skipping delete pass",
+        { err },
+      );
+      return;
+    }
     const trackedAcpxIds = new Set(
       sessions.map((s) => s.acpxSessionId).filter(Boolean) as string[],
     );
@@ -535,7 +566,21 @@ export class AcpService extends Service {
 
   private async runHealthCheck(): Promise<void> {
     if (!this.started) return;
-    const sessions = await this.store.list().catch(() => [] as SessionInfo[]);
+    let sessions: SessionInfo[];
+    try {
+      sessions = await this.store.list();
+    } catch (err) {
+      // error-policy:J7 store read failed; a fabricated empty set would skip
+      // the heal pass silently and drop the sweep below. Surface it and skip
+      // this tick — the next health-check interval retries.
+      this.runtime.reportError("AcpService.runHealthCheck", err, {
+        phase: "store.list",
+      });
+      this.log("warn", "health-check: store read failed, skipping heal pass", {
+        err,
+      });
+      return;
+    }
     const liveCutoffMs = Date.now() - RECONCILE_LIVE_WINDOW_MS;
     let healed = 0;
     for (const s of sessions) {
@@ -593,9 +638,21 @@ export class AcpService extends Service {
     // and the per-session maps don't grow without bound. sweepStale removes only
     // stopped/errored sessions older than the window; clear their satellite map
     // entries (output buffers, changed paths, native clients) in lockstep.
-    const swept = await this.store
-      .sweepStale(ACP_SESSION_RETENTION_MS)
-      .catch(() => [] as string[]);
+    let swept: string[];
+    try {
+      swept = await this.store.sweepStale(ACP_SESSION_RETENTION_MS);
+    } catch (err) {
+      // error-policy:J7 retention sweep failed; this must not abort the health
+      // loop. Report it (so the missed satellite-map reclaim is observable) and
+      // treat this tick's reclaim set as empty — the next tick retries.
+      this.runtime.reportError("AcpService.runHealthCheck", err, {
+        phase: "store.sweepStale",
+      });
+      this.log("warn", "health-check: sweepStale failed, skipping reclaim", {
+        err,
+      });
+      swept = [];
+    }
     for (const id of swept) {
       this.outputBuffers.delete(id);
       this.changedPathsBySession.delete(id);
@@ -1129,7 +1186,22 @@ export class AcpService extends Service {
     if (typeof this.sendPrompt !== "function") {
       return { resumed: 0, skipped: 0 };
     }
-    const sessions = await this.store.list().catch(() => [] as SessionInfo[]);
+    let sessions: SessionInfo[];
+    try {
+      sessions = await this.store.list();
+    } catch (err) {
+      // error-policy:J1 boundary; this is the public resume entry point. A
+      // fabricated empty list would report {resumed:0} as if there were nothing
+      // to recover. Surface the read failure and return the same zero shape so
+      // the caller sees "resumed nothing" without the false all-clear.
+      this.runtime.reportError("AcpService.resumeOrphanedBusySessions", err, {
+        phase: "store.list",
+      });
+      this.log("warn", "orphan resume: store read failed, skipping scan", {
+        err,
+      });
+      return { resumed: 0, skipped: 0 };
+    }
     let resumed = 0;
     let skipped = 0;
     for (const session of sessions) {

--- a/plugins/plugin-agent-orchestrator/src/services/active-session-forward.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/active-session-forward.ts
@@ -73,6 +73,7 @@ export function createActiveSessionForwardHandler(
       if (!acp) return;
       const sessions = await Promise.resolve(acp.listSessions()).catch(
         (err: unknown) => {
+          // error-policy:J4 listSessions unavailable → skip mid-task forward; logged
           runtime.logger?.warn?.(
             { src: SRC, err: err instanceof Error ? err.message : String(err) },
             "active-session forward listSessions failed",
@@ -150,6 +151,7 @@ export function createActiveSessionForwardHandler(
         try {
           await acp.sendPrompt(active.id, payload);
         } catch (err) {
+          // error-policy:J4 sendPrompt failed → requeue for flush-listener retry; user text never dropped
           subAgentInbox.enqueue(active.id, payload);
           runtime.logger?.warn?.(
             {
@@ -177,6 +179,7 @@ export function createActiveSessionForwardHandler(
           // planner pipeline runs on this same MESSAGE_RECEIVED and routes the
           // user's redirect; we do not re-deliver to the dead session.
           subAgentInbox.clear(active.id);
+          // error-policy:J6 best-effort session cancel on interrupt; warn only
           await acp.cancelSession?.(active.id)?.catch?.((err: unknown) =>
             runtime.logger?.warn?.(
               {
@@ -202,6 +205,7 @@ export function createActiveSessionForwardHandler(
         }
       }
     } catch (err) {
+      // error-policy:J1 event-listener boundary; one bad message must not crash the MESSAGE_RECEIVED bus
       runtime.logger?.warn?.(
         { src: SRC, err: err instanceof Error ? err.message : String(err) },
         "active-session forward listener threw",

--- a/plugins/plugin-agent-orchestrator/src/services/audit.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/audit.ts
@@ -50,8 +50,16 @@ export async function emitTaskAudit(
   };
   try {
     await runtime.emitEvent(TASK_AUDIT_EVENT, envelope);
-  } catch {
-    // best-effort: audit emission must never break the action it audits
+  } catch (error) {
+    // error-policy:J7 audit emission is best-effort — it must never break the
+    // action it audits — but a dropped TASK_AUDIT event is a security-relevant
+    // gap, so surface it observably (log + ERROR_REPORTED + RECENT_ERRORS)
+    // rather than swallowing it silently.
+    runtime.reportError("[emitTaskAudit]", error, {
+      action: payload.action,
+      outcome: payload.outcome,
+      source: payload.source,
+    });
   }
 }
 

--- a/plugins/plugin-agent-orchestrator/src/services/audit.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/audit.ts
@@ -74,6 +74,7 @@ async function rotateIfTooLarge(path: string): Promise<void> {
     const st = await stat(path);
     size = st.size;
   } catch {
+    // error-policy:J4 stat failed → file absent → no rotation needed; first append creates it
     return; // file doesn't exist yet — first append creates it
   }
   if (size < AUDIT_LOG_MAX_BYTES) return;
@@ -82,6 +83,7 @@ async function rotateIfTooLarge(path: string): Promise<void> {
     // than two files. Anyone needing deeper history can ship logs elsewhere.
     await rename(path, `${path}.1`);
   } catch {
+    // error-policy:J4 rename/rotation failed → degrade to unrotated append (documented: prefer growth over losing audit entries)
     // best-effort: if rotation fails we still append; growing past the cap
     // is preferable to losing audit entries entirely.
   }

--- a/plugins/plugin-agent-orchestrator/src/services/built-apps-registry.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/built-apps-registry.ts
@@ -105,6 +105,8 @@ export function deriveBuiltApp(
     try {
       parsed = new URL(url);
     } catch {
+      // error-policy:J3 untrusted URL string — an unparseable candidate is
+      // skipped, exactly the "not this URL" signal the scan wants.
       continue;
     }
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") continue;
@@ -224,6 +226,8 @@ export async function registerBuiltAppsForCompletion(
     });
     return record;
   } catch (err) {
+    // error-policy:J7 the built-app registry is a side-record on the completion
+    // path; a failure warns and must not break completion delivery to the user.
     log?.("warn", "built-app registration failed", {
       sessionId: session.id,
       error: err instanceof Error ? err.message : String(err),

--- a/plugins/plugin-agent-orchestrator/src/services/codex-sandbox.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/codex-sandbox.ts
@@ -87,6 +87,7 @@ export function detectLandlockAvailability(
       .filter(Boolean);
     return enabled.includes("landlock") ? "available" : "unavailable";
   } catch {
+    // error-policy:J3 LSM probe read failed → explicit "unknown" (never a fabricated available/unavailable).
     return "unknown";
   }
 }

--- a/plugins/plugin-agent-orchestrator/src/services/coding-account-selection.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/coding-account-selection.ts
@@ -16,6 +16,7 @@ import {
   type CodingAgentSelectorBridge,
   type CodingProviderAvailability,
   getCodingAgentSelectorBridge,
+  logger,
 } from "@elizaos/core";
 
 // The bridge symbol + contract are single-sourced in `@elizaos/core`; re-export
@@ -284,9 +285,24 @@ export async function reportCodingAccountFailure(
     } else {
       await bridge.markNeedsReauth(meta.providerId, meta.accountId, detail);
     }
-  } catch {
-    // Pool feedback is best-effort — a failure to record must not break the
-    // error path that is already surfacing the underlying problem.
+  } catch (err) {
+    // error-policy:J7 diagnostics-must-not-kill-the-loop — pool feedback is
+    // best-effort so a failed mark must not break the error path already
+    // surfacing the underlying problem, but a silently-lost mark means the
+    // selector keeps handing out the dud account. This module has no runtime
+    // handle to call runtime.reportError; the caller (sub-agent-router) does
+    // and observes the failover itself, so warn via the structured logger to
+    // make the lost mark observable instead of swallowing it.
+    logger.warn(
+      {
+        src: "acpx:coding-account-selection",
+        providerId: meta.providerId,
+        accountId: meta.accountId,
+        kind,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      "[CodingAccountSelection] failed to record account failure",
+    );
   }
 }
 

--- a/plugins/plugin-agent-orchestrator/src/services/coding-backend-routing.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/coding-backend-routing.ts
@@ -122,6 +122,8 @@ function readCodingRoutingEntry(
     const fromEnv = parseCodingAxis(JSON.parse(rawEnv));
     return fromEnv ? { routing: fromEnv, source: "env" } : undefined;
   } catch (err) {
+    // error-policy:J3 untrusted env JSON; a parse failure warns and resolves to
+    // undefined (no routing), never a fabricated policy.
     logger.warn(
       `[backend-routing] failed to parse ELIZA_BACKEND_ROUTING: ${
         (err as Error).message

--- a/plugins/plugin-agent-orchestrator/src/services/completion-envelope.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-envelope.ts
@@ -136,6 +136,7 @@ export function parseCompletionEnvelope(text: string): CompletionEnvelopeParse {
   try {
     raw = JSON.parse(candidate);
   } catch {
+    // error-policy:J3 untrusted sub-agent output; JSON.parse failure → explicit invalid envelope
     // A fenced json block that doesn't parse IS a (broken) attempt — block it.
     return { present: true, ok: false, errors: ["envelope is not valid JSON"] };
   }

--- a/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
@@ -143,6 +143,7 @@ function isLoopbackUrl(value: string): boolean {
     const host = new URL(value).hostname.toLowerCase();
     return host === "localhost" || host === "127.0.0.1" || host === "::1";
   } catch {
+    // error-policy:J3 unparseable URL string is an explicit not-loopback result
     return false;
   }
 }

--- a/plugins/plugin-agent-orchestrator/src/services/config-env.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/config-env.ts
@@ -27,6 +27,8 @@ function readConfig(): Record<string, unknown> | undefined {
     const raw = readFileSync(configPath, "utf-8");
     return JSON.parse(raw);
   } catch {
+    // error-policy:J3 optional config file absent (ENOENT) or unparseable → undefined
+    // "not configured"; callers fall back to process.env, never a fake-valid default.
     return undefined;
   }
 }

--- a/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
@@ -376,6 +376,8 @@ export function parseJudgeResponse(
   try {
     parsed = JSON.parse(jsonSlice);
   } catch {
+    // error-policy:J3 untrusted-input sanitizing — an unparseable model verdict
+    // fails closed (passed:false, all criteria unmet), never a fake-valid pass.
     return {
       passed: false,
       summary: MALFORMED_RESPONSE_SUMMARY,
@@ -448,6 +450,8 @@ export async function verifyGoalCompletion(
     });
     raw = typeof result === "string" ? result : String(result);
   } catch (err) {
+    // error-policy:J1 boundary translation — a failed verifier model call
+    // becomes a structured fail verdict naming the error, never a fake pass.
     const detail = err instanceof Error ? err.message : String(err);
     return {
       passed: false,
@@ -529,6 +533,8 @@ async function recordVerifierBoundary(
     await recorder.recordStage(trajectoryId, stage);
     await recorder.endTrajectory(trajectoryId, "finished");
   } catch (err) {
+    // error-policy:J7 diagnostics-must-not-kill-the-loop — a trajectory-recorder
+    // fault is warned and must never alter or block the verifier verdict.
     runtime.logger?.warn?.(
       { err: err instanceof Error ? err.message : String(err) },
       "[goal-llm-verifier] failed to record verifier trajectory (non-fatal)",

--- a/plugins/plugin-agent-orchestrator/src/services/independent-verifier.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/independent-verifier.ts
@@ -137,6 +137,8 @@ export async function runIndependentVerification(
   try {
     completion = await deps.spawnAndAwait(prompt);
   } catch (error) {
+    // error-policy:J1 boundary — a verifier spawn failure becomes an explicit
+    // inconclusive verdict (never a false pass), so the caller keeps validating.
     return {
       passed: false,
       unmet: [],

--- a/plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts
@@ -239,6 +239,7 @@ export async function decideInterruptionWithModel(
     );
     return verdict ?? baseline;
   } catch {
+    // error-policy:J4 model unavailable/unparseable → deterministic regex baseline; never regresses pure path
     return baseline;
   }
 }

--- a/plugins/plugin-agent-orchestrator/src/services/model-gateway-lease.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/model-gateway-lease.ts
@@ -149,6 +149,7 @@ export class HttpModelGatewayLeaseBroker implements ModelGatewayLeaseBroker {
       body: JSON.stringify(request),
     });
     if (!res.ok) {
+      // error-policy:J3 best-effort read of untrusted error body for context; failure → empty detail, error still thrown below
       const detail = (await res.text().catch(() => "")).slice(0, 200);
       throw new Error(
         `lease mint failed: HTTP ${res.status}${detail ? ` ${detail}` : ""}`,
@@ -177,6 +178,7 @@ export class HttpModelGatewayLeaseBroker implements ModelGatewayLeaseBroker {
     // A 404 means the lease is already gone (expired/revoked) — the desired
     // end state, so treat it as success.
     if (!res.ok && res.status !== 404) {
+      // error-policy:J3 best-effort read of untrusted error body for context; failure → empty detail, error still thrown below
       const detail = (await res.text().catch(() => "")).slice(0, 200);
       throw new Error(
         `lease revoke failed: HTTP ${res.status}${detail ? ` ${detail}` : ""}`,
@@ -301,6 +303,7 @@ export async function mintSpawnLease(input: {
     });
     return { kind: "leased", lease };
   } catch (err) {
+    // error-policy:J4 broker mint failed → strict rethrows; non-strict warns + degrades to the documented static gateway token (unchanged E2 behavior)
     const message = err instanceof Error ? err.message : String(err);
     if (strict) {
       throw new Error(

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -396,6 +396,8 @@ function stringifyEventData(data: Record<string, unknown>): string {
   try {
     return truncate(JSON.stringify(data), 1500);
   } catch {
+    // error-policy:J3 arbitrary event data may be non-serializable (circular);
+    // empty means "no minable text from this event", not a masked failure.
     return "";
   }
 }
@@ -690,6 +692,8 @@ export class OrchestratorTaskService extends Service {
         this.subscribeToAcp(acp);
       }
     } catch (error) {
+      // error-policy:J7 background ACP bind; the failure is warned and observable
+      // and must not crash service start.
       this.log(
         "warn",
         "ACP service did not become available; session events will not be recorded",
@@ -738,7 +742,8 @@ export class OrchestratorTaskService extends Service {
       try {
         listener();
       } catch {
-        // ignore
+        // error-policy:J7 change-ping fan-out; a broken SSE subscriber must not
+        // abort the write that emitted the ping or the other subscribers.
       }
     }
   }
@@ -968,6 +973,8 @@ export class OrchestratorTaskService extends Service {
         },
       });
     } catch (err) {
+      // error-policy:J7 best-effort mirror on the task_complete path; debug-logged
+      // and must not break the event-bridge write. The DTO simply omits the diff.
       this.log("debug", "mirror change-set to store failed", {
         sessionId,
         error: err instanceof Error ? err.message : String(err),
@@ -1025,6 +1032,8 @@ export class OrchestratorTaskService extends Service {
       void this.writeEvidenceTrajectory(taskId, sessionId, bundle);
       return buildCompletionEvidenceString(bundle);
     } catch (err) {
+      // error-policy:J7 fire-and-forget on the task_complete path; on failure it
+      // degrades to the bare summary (the prior behavior), never throws.
       this.log("debug", "build completion evidence failed", {
         taskId,
         sessionId,
@@ -1226,6 +1235,8 @@ export class OrchestratorTaskService extends Service {
       });
       this.emitChange(taskId);
     } catch (err) {
+      // error-policy:J7 trajectory write is fire-and-forget; a failed write only
+      // means the artifact never lands, debug-logged, never breaks completion.
       this.log("debug", "persist evidence trajectory failed", {
         taskId,
         sessionId,
@@ -1249,7 +1260,8 @@ export class OrchestratorTaskService extends Service {
       const workdir = str(live?.workdir);
       if (workdir) dir = join(workdir, ".eliza", "trajectories");
     } catch {
-      // best-effort — keep the home-scoped task dir
+      // error-policy:J4 the ACP workdir lookup is optional enrichment; on failure
+      // fall back to the documented home-scoped trajectory dir.
     }
     return join(dir, "completion-evidence.jsonl");
   }
@@ -1270,7 +1282,8 @@ export class OrchestratorTaskService extends Service {
         if (fromLive) return fromLive;
       }
     } catch {
-      // best-effort — fall through to the store-session copy
+      // error-policy:J4 the live ACP read is optional; fall through to the
+      // mirrored store-session change-set copy.
     }
     const stored = doc.sessions.find(
       (session) => session.sessionId === sessionId,
@@ -1948,6 +1961,8 @@ export class OrchestratorTaskService extends Service {
         attempt: attempts,
       });
     } catch (err) {
+      // error-policy:J7 auto-verify is fire-and-forget from the event bridge; a
+      // failure warns and must not break the session-event write path.
       this.log("warn", "auto goal verification failed", {
         taskId,
         sessionId,
@@ -2056,6 +2071,8 @@ export class OrchestratorTaskService extends Service {
       );
       await this.store.updateTask(taskId, { status: "active" });
     } catch (sendErr) {
+      // error-policy:J1 boundary — a failed corrective send becomes a structured
+      // escalation (event + waiting_on_user), never a silent stall.
       // The kept-alive session could not take the follow-up — escalate rather
       // than silently leaving the task stuck in `validating`.
       await this.store.addEvent({
@@ -2191,6 +2208,8 @@ export class OrchestratorTaskService extends Service {
       try {
         await acp.stopSession(verifierSessionId);
       } catch (stopErr) {
+        // error-policy:J6 best-effort teardown of the ephemeral verifier session;
+        // a failed stop is warned and must not mask the verdict.
         this.log("warn", "failed to stop independent verifier session", {
           sessionId: verifierSessionId,
           error: stopErr instanceof Error ? stopErr.message : String(stopErr),
@@ -2267,6 +2286,8 @@ export class OrchestratorTaskService extends Service {
           await acp.sendToSession(session.sessionId, followUp);
           forwardedTo.push(session.sessionId);
         } catch (err) {
+          // error-policy:J1 per-session relay failure is collected into the
+          // structured failedTo result and the session marked send_failed.
           const error = err instanceof Error ? err.message : String(err);
           failedTo.push({ sessionId: session.sessionId, error });
           await this.store.updateSession(session.sessionId, {
@@ -2289,6 +2310,8 @@ export class OrchestratorTaskService extends Service {
         });
         forwardedTo.push("auto-spawned");
       } catch (err) {
+        // error-policy:J1 auto-spawn failure is reported through the structured
+        // failedTo result, not swallowed.
         const error = err instanceof Error ? err.message : String(err);
         failedTo.push({ sessionId: "(auto-spawn)", error });
         this.log("warn", "auto-spawn on user message failed", { error });
@@ -2671,6 +2694,8 @@ export class OrchestratorTaskService extends Service {
         });
         await writeFile(join(workdir, "SKILLS.md"), manifest.markdown, "utf8");
       } catch (err) {
+        // error-policy:J7 SKILLS.md scaffolding is best-effort; a failed write is
+        // warned and the spawn proceeds without it.
         this.runtime.logger?.warn?.(
           { src: "orchestrator-task-service", taskId, workdir },
           `failed to write SKILLS.md: ${err instanceof Error ? err.message : String(err)}`,
@@ -2774,6 +2799,9 @@ export class OrchestratorTaskService extends Service {
       await this.advanceTaskStatus(taskId, "active");
       return this.getTask(taskId);
     } catch (err) {
+      // error-policy:J4 the ACP spawn already succeeded (session is live); a
+      // failed durable write degrades to a truthful live-session detail below,
+      // never a false 500/404.
       this.log("warn", "spawn succeeded but recording the session failed", {
         taskId,
         sessionId: result.sessionId,
@@ -2916,6 +2944,8 @@ export class OrchestratorTaskService extends Service {
     try {
       await acp.sendToSession(sessionId, followUp);
     } catch (err) {
+      // error-policy:J2 mark the session send_failed for observability, then
+      // rethrow the original failure so the caller sees it.
       await this.store.updateSession(sessionId, { status: "send_failed" });
       throw err;
     }
@@ -2936,6 +2966,8 @@ export class OrchestratorTaskService extends Service {
     try {
       await acp.stopSession(sessionId);
     } catch (err) {
+      // error-policy:J2 mark the session stop_failed for observability, then
+      // rethrow the original failure so the caller sees it.
       await this.store.updateSession(sessionId, {
         status: "stop_failed",
       });
@@ -3177,6 +3209,8 @@ export class OrchestratorTaskService extends Service {
         try {
           await acp.stopSession(session.sessionId);
         } catch (err) {
+          // error-policy:J1 collect per-session stop failures; the loop throws a
+          // structured RecoveryConflictError afterward when any session failed.
           const error = err instanceof Error ? err.message : String(err);
           failures.push({ sessionId: session.sessionId, error });
           await this.store.updateSession(session.sessionId, {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -1379,8 +1379,21 @@ export class OrchestratorTaskService extends Service {
           detail,
         );
       }
-    } catch {
-      // best-effort — account health is advisory for selection
+    } catch (err) {
+      // error-policy:J7 account-health marking is advisory for session
+      // selection and must not fail the caller, but a swallowed failure leaves
+      // a rate-limited/needs-reauth account looking healthy and eligible for
+      // reuse — report it so the agent sees it and the mutation isn't lost.
+      this.runtime.reportError(
+        "OrchestratorTask.markSessionAccountUnhealthy",
+        err,
+        { sessionId, reason },
+      );
+      this.log("warn", "failed to mark session account unhealthy", {
+        sessionId,
+        reason,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -599,6 +599,8 @@ export class FileTaskStore extends InMemoryTaskStore {
           this.hydrate([]);
         }
       } catch (error) {
+        // error-policy:J3 persisted-store load: ENOENT = no file yet, any other
+        // read/parse error warns and starts empty (observable recovery).
         const code =
           isRecord(error) && typeof error.code === "string" ? error.code : "";
         if (code !== "ENOENT") {
@@ -707,6 +709,8 @@ export class FileTaskStore extends InMemoryTaskStore {
           }
         }
       } catch (error) {
+        // error-policy:J3 persisted-merge read: ENOENT skipped, corrupt/unreadable
+        // file warns and re-seeds the merge from in-memory state (observable).
         const code =
           isRecord(error) && typeof error.code === "string" ? error.code : "";
         if (code !== "ENOENT") {
@@ -755,6 +759,8 @@ export class FileTaskStore extends InMemoryTaskStore {
         await pending.writeFile(`${process.pid}\n${Date.now()}\n`, "utf8");
         handle = pending;
       } catch (error) {
+        // error-policy:J3 lock-acquire: EEXIST (lock held) is retried until the
+        // deadline; every other error is rethrown below (fail-fast).
         if (pending) {
           // error-policy:J6 best-effort teardown — unwind a partial lock
           // acquire; the original acquire error below is authoritative and is
@@ -783,6 +789,8 @@ export class FileTaskStore extends InMemoryTaskStore {
       if (Date.now() - info.mtimeMs < FILE_LOCK_STALE_MS) return;
       await rm(this.lockFile, { force: true });
     } catch (error) {
+      // error-policy:J3 stale-lock stat: ENOENT = lock already gone (fine); any
+      // other stat error is rethrown (fail-fast).
       const code =
         isRecord(error) && typeof error.code === "string" ? error.code : "";
       if (code !== "ENOENT") throw error;

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -1329,6 +1329,7 @@ async function askParentAgent(request: {
   });
 
   await request.runtime.createMemory(memory, "messages").catch((error) => {
+    // error-policy:J7 request memory persistence is auxiliary; handleMessage runs off the in-memory `memory` below regardless, and the warn keeps a failed write observable.
     getLogger(request.runtime)?.warn?.(
       {
         src: LOG_PREFIX,
@@ -1468,6 +1469,7 @@ async function runSpawnSubAgent(request: {
       data: { ...data, parentTaskId, nestingDepth: childDepth },
     };
   } catch (error) {
+    // error-policy:J1 boundary — translates a spawn failure into the structured {success:false} result the child sub-agent reads.
     const message = error instanceof Error ? error.message : String(error);
     log?.error?.(
       {
@@ -1537,6 +1539,7 @@ export async function runParentAgentBroker(
         sessionId: request.sessionId,
       });
     } catch (error) {
+      // error-policy:J1 boundary — translates a Cloud command fault into the structured {success:false} broker result.
       const message =
         error instanceof Error
           ? error.message
@@ -1603,6 +1606,7 @@ export async function runParentAgentBroker(
       },
     };
   } catch (error) {
+    // error-policy:J1 boundary — translates an ask-mode failure into the structured {success:false} broker result.
     const message =
       error instanceof Error
         ? error.message

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-dispatch.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-dispatch.ts
@@ -68,6 +68,8 @@ async function deliverReplyToChild(
       await acp.sendToSession(sessionId, reply);
       return true;
     } catch (err) {
+      // error-policy:J1 transport-delivery boundary; a terminal send failure
+      // warns and returns the structured false (delivery failed) below.
       if (isSessionBusyError(err) && Date.now() < deadline) {
         await delay(REPLY_DELIVERY_POLL_MS);
         continue;
@@ -149,7 +151,8 @@ export function extractParentAgentDirective(
             };
           }
         } catch {
-          // Balanced but not valid JSON — drop it (caller trims past the marker).
+          // error-policy:J3 untrusted streamed directive; malformed JSON resolves
+          // to null so the caller drops it (trims past the marker).
         }
         return null;
       }
@@ -190,6 +193,8 @@ export async function dispatchParentAgentDirective(
     ok = result.success;
     reply = result.text;
   } catch (err) {
+    // error-policy:J1 broker boundary; the failure becomes a structured
+    // { ok: false } result plus a child-facing error reply, logged at error.
     reply = `parent-agent bridge error: ${err instanceof Error ? err.message : String(err)}`;
     log?.error?.({ src: DISPATCH_LOG_SRC, sessionId }, reply);
   }

--- a/plugins/plugin-agent-orchestrator/src/services/repo-input.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/repo-input.ts
@@ -55,6 +55,7 @@ export function normalizeRepositoryInput(repo: string): string {
         }
       }
     } catch {
+      // error-policy:J3 untrusted repo input; URL parse failure → pass raw through to downstream assertSafeGitRemote validation
       return withoutTrailingSlash;
     }
     return withoutTrailingSlash;

--- a/plugins/plugin-agent-orchestrator/src/services/screenshot-delivery.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/screenshot-delivery.ts
@@ -72,6 +72,7 @@ function getFileSize(path: string): number | undefined {
   try {
     return statSync(path).size;
   } catch {
+    // error-policy:J3 unreadable/absent path → undefined size → selector skips it rather than dispatching a doomed send
     return undefined;
   }
 }
@@ -159,6 +160,7 @@ export async function deliverScreenshots(
     });
     return attachments.length;
   } catch (error) {
+    // error-policy:J4 screenshot delivery is a best-effort side channel; a connector send failure is warned and degrades to 0 delivered so it never breaks the completion flow
     logger.warn(
       `[screenshot-delivery] failed to deliver ${attachments.length} screenshot(s): ${
         error instanceof Error ? error.message : String(error)

--- a/plugins/plugin-agent-orchestrator/src/services/session-event-queue.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/session-event-queue.ts
@@ -66,6 +66,8 @@ export class SessionEventQueue {
         try {
           await this.handler(event);
         } catch (err) {
+          // error-policy:J7 per-session FIFO drain must not stall on one bad
+          // event; warn-observable and subsequent events keep flowing.
           logger.warn(
             `[SessionEventQueue] handler error for session ${sessionId}: ${err instanceof Error ? err.message : String(err)}`,
           );

--- a/plugins/plugin-agent-orchestrator/src/services/session-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/session-store.ts
@@ -578,6 +578,7 @@ export class FileSessionStore extends InMemorySessionStore {
           );
         }
       } catch (error) {
+        // error-policy:J3 store-file read/JSON.parse fallback: absent (ENOENT) starts empty on first run; a non-ENOENT unreadable/corrupt file is warned before starting empty
         const code =
           isRecord(error) && typeof error.code === "string"
             ? error.code
@@ -638,6 +639,7 @@ export class FileSessionStore extends InMemorySessionStore {
         this.lockFile,
       );
     } catch (error) {
+      // error-policy:J3 stat probe of the lock file: a missing lock (ENOENT) is a benign no-op, every other error rethrows
       const code =
         isRecord(error) && typeof error.code === "string"
           ? error.code

--- a/plugins/plugin-agent-orchestrator/src/services/skill-lifeops-context-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/skill-lifeops-context-broker.ts
@@ -28,9 +28,9 @@ async function rewriteBrokerActionText(args: {
 }): Promise<string> {
   const text = args.text.trim();
   if (!text) return args.text;
-  const fallback = () =>
-    `I ran ${args.actionName} and got a LifeOps action result, but I couldn't format the details cleanly here.`;
-  if (typeof args.runtime.useModel !== "function") return fallback();
+  // Degrade to the raw LifeOps payload, never a canned string: `text` is the
+  // real data the sub-agent requested and must survive a formatting failure.
+  if (typeof args.runtime.useModel !== "function") return text;
   try {
     const raw = await args.runtime.useModel(ModelType.TEXT_SMALL, {
       prompt: [
@@ -58,9 +58,18 @@ async function rewriteBrokerActionText(args: {
     const parsed = JSON.parse(String(raw).trim()) as { response?: unknown };
     return typeof parsed.response === "string" && parsed.response.trim()
       ? parsed.response.trim()
-      : fallback();
-  } catch {
-    return fallback();
+      : text;
+  } catch (error) {
+    // error-policy:J4 degrade to raw text, observable — a rewrite-model or
+    // JSON.parse fault returns the untouched LifeOps payload (never a canned
+    // string that silently drops the sub-agent's data) and reports the failure
+    // so the agent (RECENT_ERRORS) and owner see the formatter is down.
+    args.runtime.reportError?.(
+      "AgentOrchestrator.LifeOpsContextBroker",
+      error,
+      { actionName: args.actionName, reason: "broker_text_rewrite_failed" },
+    );
+    return text;
   }
 }
 

--- a/plugins/plugin-agent-orchestrator/src/services/skill-lifeops-context-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/skill-lifeops-context-broker.ts
@@ -578,6 +578,8 @@ export async function runLifeOpsContextBroker(
       },
     };
   } catch (error) {
+    // error-policy:J1 boundary translation — a delegated-action fault is logged
+    // and returned as a structured success:false broker result.
     const message =
       error instanceof Error
         ? error.message

--- a/plugins/plugin-agent-orchestrator/src/services/smithers-task-runner.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/smithers-task-runner.ts
@@ -105,6 +105,8 @@ async function resolvePluginRoot(): Promise<string> {
       };
       if (manifest.name === "@elizaos/plugin-agent-orchestrator") return dir;
     } catch {
+      // error-policy:J3 a missing/unreadable package.json at this level is the
+      // expected "not the root here" probe result → keep walking up.
       // keep walking up to the plugin root
     }
     const parent = dirname(dir);
@@ -293,6 +295,7 @@ export async function runTaskWithSmithers(
     try {
       proc.kill("SIGKILL");
     } catch {
+      // error-policy:J6 best-effort abort kill; the subprocess is already gone.
       // already gone
     }
   };
@@ -376,6 +379,8 @@ export async function runTaskWithSmithers(
           record(request.kind, request.ctx, output);
           writeResponse({ requestId: request.requestId, ok: true, output });
         })
+        // error-policy:J1 boundary — translates an executor step failure into a
+        // structured StepResponse (ok:false) the subprocess step rejects on.
         .catch((error: unknown) =>
           writeResponse({
             requestId: request.requestId,
@@ -397,6 +402,8 @@ export async function runTaskWithSmithers(
     try {
       message = JSON.parse(trimmed) as StepRequest;
     } catch {
+      // error-policy:J3 untrusted subprocess stdout — a non-JSON line is ignored
+      // (Smithers shares stdout with its own logging).
       return;
     }
     if (message.type === "executeStep") dispatchStep(message);

--- a/plugins/plugin-agent-orchestrator/src/services/spend-allowance.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/spend-allowance.ts
@@ -342,6 +342,7 @@ export function addSessionSpendUsd(
   sessionSpendUsd.set(sessionId, next);
   if (safe > 0 && ledgerBackend) {
     void ledgerBackend.save(sessionId, next).catch((err) => {
+      // error-policy:J4 persist best-effort; cap still enforced from in-memory total; logged
       logger.warn(
         { src: "spend-allowance", sessionId, err: errorMessage(err) },
         "[spend-allowance] failed to persist session spend",

--- a/plugins/plugin-agent-orchestrator/src/services/ssrf-guard.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/ssrf-guard.ts
@@ -228,6 +228,7 @@ export async function assertHostAllowed(
   try {
     records = await hostResolver(host);
   } catch (err) {
+    // error-policy:J1 DNS resolution failure on an untrusted host → fail-closed structured SsrfBlockedError (never allow an unresolvable host)
     const reason = err instanceof Error ? err.message : String(err);
     throw new SsrfBlockedError(
       host,
@@ -262,6 +263,7 @@ export async function assertUrlAllowed(
   try {
     parsed = typeof url === "string" ? new URL(url) : url;
   } catch {
+    // error-policy:J3 unparseable untrusted URL → explicit typed SsrfBlockedError (invalid/blocked)
     throw new SsrfBlockedError(String(url), `unparseable URL ${String(url)}`);
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
@@ -419,6 +421,7 @@ export async function safeFetch(
     try {
       next = new URL(location, current);
     } catch {
+      // error-policy:J3 unparseable redirect target → explicit typed SsrfBlockedError (invalid/blocked)
       throw new SsrfBlockedError(
         current,
         `unparseable redirect target ${location}`,

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
@@ -162,7 +162,8 @@ export async function writeWorkspaceIdentity(workdir: string): Promise<void> {
       `[sub-agent-identity] scaffolded operating manual into bare workspace ${workdir}`,
     );
   } catch (err) {
-    // Best-effort: a missing manual degrades context but must not abort a spawn.
+    // error-policy:J7 identity scaffold is best-effort; a failure warns and must
+    // not abort the spawn — a missing manual only degrades context.
     logger.warn(
       { error: err },
       `[sub-agent-identity] could not scaffold identity into ${workdir}`,

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -1844,9 +1844,21 @@ Do not report done until every referenced URL in the final page resolves without
       (this.runtime.getService("ACP_SUBPROCESS_SERVICE") as AcpService | null);
     if (!service?.listSessions) return false;
     const currentCreatedAt = sessionTimeMs(session.createdAt);
-    const sessions = await service
-      .listSessions()
-      .catch(() => [] as SessionInfo[]);
+    let sessions: SessionInfo[];
+    try {
+      sessions = await service.listSessions();
+    } catch (err) {
+      // error-policy:J1 The sole caller uses this predicate to decide whether to
+      // SUPPRESS a stale verification-failure post (a would-be duplicate). A
+      // failed session read must not read as "no newer continuation" (false),
+      // which would let the duplicate through; surface it observably via
+      // reportError and fail safe toward NOT double-posting by treating the
+      // uncertainty as "a newer continuation exists" (true).
+      this.runtime.reportError("sub-agent-router.hasNewerContinuation", err, {
+        sessionId: session.id,
+      });
+      return true;
+    }
     return sessions.some((candidate) =>
       isNewerContinuationSession(candidate, session, origin, currentCreatedAt),
     );

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -372,6 +372,7 @@ function comparableUrlTarget(url: string): string | undefined {
     const pathname = parsed.pathname.replace(/\/+$/, "") || "/";
     return `${pathname}${parsed.search}${parsed.hash}`;
   } catch {
+    // error-policy:J3 URL parse of untrusted narration; unparseable → undefined.
     return undefined;
   }
 }
@@ -461,6 +462,7 @@ function appRoutePathPrefix(url: string): string | undefined {
     if (!match) return undefined;
     return match[0].endsWith("/") ? match[0] : `${match[0]}/`;
   } catch {
+    // error-policy:J3 URL parse of untrusted narration; unparseable → undefined.
     return undefined;
   }
 }
@@ -696,6 +698,8 @@ export class SubAgentRouter extends Service {
         this.acp = acp;
         this.unsubscribe = acp.onSessionEvent((sid, event, data) => {
           this.handleEvent(sid, event, data).catch((err) => {
+            // error-policy:J1 outermost handler for the ACP session-event stream
+            // (a transport boundary); logs the event failure at error level.
             this.log("error", "router event failed", {
               sessionId: sid,
               event,
@@ -1020,6 +1024,7 @@ export class SubAgentRouter extends Service {
         count: nextCount,
         cap: this.loopState.roundTripCap,
       });
+      // error-policy:J6 best-effort teardown; force-stop failure is warned.
       await acp.stopSession(sessionId).catch((err) =>
         this.log("warn", "force-stop after cap failed", {
           sessionId,
@@ -1056,6 +1061,8 @@ export class SubAgentRouter extends Service {
         },
       })
       .catch((err) => {
+        // error-policy:J7 background event-routing: createEntity failure is warned;
+        // the downstream memory insert self-guards, so it must not abort handleEvent.
         this.log("warn", "createEntity for sub-agent failed", {
           sessionId,
           event,
@@ -1097,6 +1104,8 @@ export class SubAgentRouter extends Service {
           });
         }
       } catch (err) {
+        // error-policy:J7 change-set capture is best-effort narration enrichment;
+        // debug-logged, the completion still posts without the diff.
         this.log("debug", "change-set capture failed", {
           sessionId,
           error: err instanceof Error ? err.message : String(err),
@@ -1314,6 +1323,7 @@ export class SubAgentRouter extends Service {
           },
         })
         .catch((err: unknown) => {
+          // error-policy:J7 notification is a best-effort side-channel; debug-logged.
           this.log("debug", "notification emit failed", {
             sessionId,
             error: err instanceof Error ? err.message : String(err),
@@ -1347,6 +1357,8 @@ export class SubAgentRouter extends Service {
         this.runtime
           .addParticipant(subAgentEntityId, target.roomId)
           .catch((err) => {
+            // error-policy:J7 best-effort room participation; warned, one target's
+            // failure must not abort the fan-out.
             this.log("warn", "addParticipant for sub-agent failed", {
               sessionId,
               event,
@@ -1472,6 +1484,8 @@ export class SubAgentRouter extends Service {
         await this.runtime.messageService
           .handleMessage(this.runtime, memory, replyCallback)
           .catch((err) => {
+            // error-policy:J7 per-target delivery: logs the failure at error level
+            // and continues the target loop; the subscription .catch is the boundary.
             this.log("error", "handleMessage for sub-agent post failed", {
               sessionId,
               event,
@@ -1490,6 +1504,8 @@ export class SubAgentRouter extends Service {
           },
         );
         await this.runtime.createMemory(memory, "messages").catch((err) => {
+          // error-policy:J7 fallback createMemory is best-effort in the background
+          // router post; warned, does not abort the loop.
           this.log("warn", "createMemory for sub-agent post failed", {
             sessionId,
             event,
@@ -1549,6 +1565,8 @@ export class SubAgentRouter extends Service {
         },
         threadedResponse,
       ).catch((err) => {
+        // error-policy:J1 reply-delivery boundary; warns and returns an empty
+        // delivered list on failure (honest "0 delivered").
         this.log("warn", "sub-agent reply delivery failed", {
           sessionId,
           source,
@@ -1654,6 +1672,8 @@ export class SubAgentRouter extends Service {
       const rows = bridge.describe()[agentType.toLowerCase()] ?? [];
       return rows.some((row) => row.healthy > 0);
     } catch {
+      // error-policy:J3 account-bridge probe failure → fail-safe "no healthy
+      // account"; declines failover so the task's honest failure reaches the user.
       return false;
     }
   }
@@ -1693,6 +1713,8 @@ export class SubAgentRouter extends Service {
         [HANDED_OFF_SUCCESSOR_META_KEY]: successorSessionId,
       });
     } catch {
+      // error-policy:J6 best-effort handoff marker; a missed stamp only risks the
+      // prior duplicate-post, never a dropped terminal.
       // best-effort — see doc comment
     }
   }
@@ -2497,6 +2519,7 @@ function isBareRouteMappingPrefix(
   try {
     parsed = new URL(url);
   } catch {
+    // error-policy:J3 URL parse of untrusted narration; unparseable → not a match.
     return false;
   }
   const urlPath = parsed.pathname.endsWith("/")
@@ -2507,6 +2530,7 @@ function isBareRouteMappingPrefix(
     try {
       prefix = new URL(mapping.urlPrefix);
     } catch {
+      // error-policy:J3 URL parse of untrusted route prefix; unparseable → no match.
       return false;
     }
     if (parsed.origin !== prefix.origin) return false;
@@ -2528,6 +2552,7 @@ function routeMatchForUrl(
       parsed = new URL(url);
       prefix = new URL(mapping.urlPrefix);
     } catch {
+      // error-policy:J3 URL parse of untrusted narration; unparseable → skip mapping.
       continue;
     }
     if (parsed.origin !== prefix.origin) continue;
@@ -2551,6 +2576,7 @@ function urlForRouteMapping(
       : `${mapping.urlPrefix}/`;
     return new URL(relativePath, prefix).toString();
   } catch {
+    // error-policy:J3 URL construction from untrusted route input; failure → undefined.
     return undefined;
   }
 }
@@ -2942,6 +2968,8 @@ export async function annotateUnverifiedUrls(
       }
       return { status: null, servedLive: true };
     } catch (err) {
+      // error-policy:J3 untrusted-URL liveness probe: SSRF-block/fetch failure →
+      // explicit unreachable status, never a fabricated "live".
       // A blocked non-public host is not a reachable artifact; report it as
       // such (it must never be surfaced to the user as "live").
       const reason =
@@ -3160,6 +3188,7 @@ function mappedLocalTarget(
     parsed = new URL(url);
     prefix = new URL(mapping.urlPrefix);
   } catch {
+    // error-policy:J3 URL parse of untrusted narration; unparseable → undefined.
     return undefined;
   }
   if (parsed.origin !== prefix.origin) return undefined;
@@ -3226,6 +3255,7 @@ async function detectCachedMiss(
   try {
     busted = new URL(url);
   } catch {
+    // error-policy:J3 URL parse of untrusted narration; unparseable → null (no probe).
     return null;
   }
   // Some static hosts/CDNs serve a stale cached 404 without useful cache
@@ -3275,6 +3305,7 @@ export function extractSubResources(html: string, pageUrl: string): string[] {
         refs.add(resolved.toString());
       }
     } catch {
+      // error-policy:J3 URL parse of an untrusted HTML ref; unparseable → skip.
       // unparseable ref — skip
     }
   };

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -354,6 +354,7 @@ export class SwarmCoordinatorService
       try {
         unsub();
       } catch (err) {
+        // error-policy:J6 teardown — an unsubscribe fault during stop() is warned and must not block the rest of stop() cleanup.
         logger.warn(
           `[SwarmCoordinator] AcpService unsubscribe threw during stop(): ${
             err instanceof Error ? err.message : String(err)
@@ -468,6 +469,7 @@ export class SwarmCoordinatorService
       const origin = await taskService.getTaskOriginTarget(threadId);
       return origin ? { roomId: origin.roomId } : null;
     } catch {
+      // error-policy:J4 degrade — null is this reader's designed "no origin" signal; the connector-route caller falls back to its own per-task room.
       return null;
     }
   }
@@ -836,6 +838,7 @@ export class SwarmCoordinatorService
     try {
       sessionMeta = await this.getEnrichmentMetadata(sessionId);
     } catch {
+      // error-policy:J4 fail-open degrade — empty metadata reads as "not router-owned / not handed-off", so a terminal still synthesizes rather than silencing a genuine stop.
       sessionMeta = { metadata: {} };
     }
     const meta = sessionMeta.metadata;
@@ -1097,6 +1100,7 @@ export class SwarmCoordinatorService
       try {
         listener(swarmEvent);
       } catch (err) {
+        // error-policy:J7 fan-out isolation — one throwing subscriber is warned and must not stop delivery to the remaining listeners.
         logger.warn(
           `[SwarmCoordinator] subscriber threw: ${
             err instanceof Error ? err.message : String(err)
@@ -1110,6 +1114,7 @@ export class SwarmCoordinatorService
       try {
         this.wsBroadcast(swarmEvent);
       } catch (err) {
+        // error-policy:J7 fan-out isolation — a ws-broadcast fault is warned and must not stop in-process subscriber delivery of the same event.
         logger.warn(
           `[SwarmCoordinator] wsBroadcast threw: ${
             err instanceof Error ? err.message : String(err)
@@ -1149,6 +1154,7 @@ export class SwarmCoordinatorService
         return session.metadata;
       }
     } catch {
+      // error-policy:J4 fail-open degrade — an unreadable session yields {}, treated as not-superseded so a genuine stop is never silenced.
       // fall through to empty — fail open (treat unknown as not-superseded)
     }
     return {};
@@ -1214,6 +1220,7 @@ export class SwarmCoordinatorService
         record.agentType = sessionMeta.agentType;
       }
     } catch {
+      // error-policy:J4 additive degrade — on failure the real raw record is returned un-enriched, never a fabricated empty.
       // Best-effort enrichment only; raw data is still useful to consumers.
     }
     return record;
@@ -1304,6 +1311,7 @@ export class SwarmCoordinatorService
         },
       );
     } catch (err) {
+      // error-policy:J1 boundary — translates a validator fault into a structured escalation result (verdict fail) dispatched below.
       logger.warn(
         `[SwarmCoordinator] custom validator failed: ${
           err instanceof Error ? err.message : String(err)
@@ -1390,6 +1398,7 @@ export class SwarmCoordinatorService
         await acp
           .sendPrompt(sessionId, decision.response.trim())
           .catch((err: unknown) => {
+            // error-policy:J7 a failed decision-response send is warned/observable and must not wedge the decision-routing loop.
             logger.warn(
               `[SwarmCoordinator] failed to send decision response: ${
                 err instanceof Error ? err.message : String(err)
@@ -1398,6 +1407,7 @@ export class SwarmCoordinatorService
           });
       }
     } catch (err) {
+      // error-policy:J7 event-handler boundary — a decision-callback fault is warned (in-flight cleared in finally) so the event stream keeps flowing.
       logger.warn(
         `[SwarmCoordinator] agent decision callback failed: ${
           err instanceof Error ? err.message : String(err)

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -365,13 +365,16 @@ function safeGetSetting(
     const fromConfig = readConfigEnvKey(key);
     if (fromConfig?.trim()) return fromConfig.trim();
   } catch {
-    // ignore — fall through to runtime
+    // error-policy:J4 config-file source unavailable degrades to the runtime
+    // setting source below.
   }
   if (!runtime) return undefined;
   try {
     const value = runtime.getSetting(key);
     return typeof value === "string" && value.trim() ? value.trim() : undefined;
   } catch {
+    // error-policy:J4 optional setting lookup; an unavailable store degrades to
+    // undefined (not configured), which callers resolve to a default.
     return undefined;
   }
 }
@@ -696,7 +699,8 @@ async function computeTaskAgentFrameworkState(
         }
       }
     } catch {
-      // Keep status surfaces alive even if preflight fails transiently.
+      // error-policy:J4 ACP preflight probe failed transiently; discovery degrades
+      // to static filesystem/env detection so status surfaces stay alive.
     }
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
@@ -238,6 +238,7 @@ export function resolveWorkdirByConvention(
         .filter((e) => e.isDirectory() && !e.name.startsWith("."))
         .map((e) => e.name);
     } catch {
+      // error-policy:J4 configured workspace root may not exist; unreadable root → skip, degrade to default workdir
       continue;
     }
     for (const name of entries) {
@@ -330,6 +331,7 @@ function parseWorkdirRoutes(raw: string | undefined): WorkdirRoute[] {
         (entry.urlMappings === undefined || Array.isArray(entry.urlMappings)),
     );
   } catch (err) {
+    // error-policy:J3 untrusted config; TASK_AGENT_WORKDIR_ROUTES parse failure → warn + no routes
     logger.warn(
       `[workdir-routes] Failed to parse TASK_AGENT_WORKDIR_ROUTES: ${(err as Error).message}`,
     );

--- a/plugins/plugin-agent-orchestrator/src/services/task-policy.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-policy.ts
@@ -153,10 +153,19 @@ function getConnectorFromBridgeMetadata(message: Memory): string | null {
   return null;
 }
 
+// Fail-closed sentinel: distinct from `null`. A `null` connector means "genuine
+// client-chat, no connector policy" and requireTaskAgentAccess treats it as the
+// permissive GUEST default. An infra failure resolving the source must NOT read
+// as that default, so it returns this symbol instead and the caller denies on it.
+const SOURCE_RESOLUTION_FAILED: unique symbol = Symbol(
+  "task-policy.source-resolution-failed",
+);
+type ConnectorSource = string | null | typeof SOURCE_RESOLUTION_FAILED;
+
 async function resolveConnectorSource(
   runtime: IAgentRuntime,
   message: Memory,
-): Promise<string | null> {
+): Promise<ConnectorSource> {
   const content = message.content as Record<string, unknown> | undefined;
   const directSource =
     typeof content?.source === "string" &&
@@ -173,8 +182,17 @@ async function resolveConnectorSource(
     if (typeof room?.source === "string" && room.source.trim().length > 0) {
       return room.source;
     }
-  } catch {
-    // Ignore room lookup failures and fall through to null.
+  } catch (error) {
+    // error-policy:J1 room-source lookup failed at an infra boundary. Returning
+    // null here would read as "genuine client-chat" → the permissive GUEST
+    // default in requireTaskAgentAccess, silently opening task-agent
+    // create/interact to any caller on a transient DB/room error. Surface the
+    // failure (reportError → RECENT_ERRORS + ERROR_REPORTED) and fail closed via
+    // the sentinel, which the caller translates to access-denied.
+    runtime.reportError("task-policy.resolveConnectorSource", error, {
+      roomId: message.roomId,
+    });
+    return SOURCE_RESOLUTION_FAILED;
   }
 
   return null;
@@ -263,7 +281,20 @@ export async function requireTaskAgentAccess(
     };
   }
 
-  const connector = await resolveConnectorSource(runtime, message);
+  const resolvedSource = await resolveConnectorSource(runtime, message);
+  if (resolvedSource === SOURCE_RESOLUTION_FAILED) {
+    // Infra failure resolving the request source: deny rather than fall through
+    // to the permissive GUEST default. reportError already surfaced the cause.
+    return {
+      allowed: false,
+      connector: null,
+      requiredRole: "OWNER",
+      actualRole: "GUEST",
+      reason:
+        "Task-agent access denied: unable to resolve the request source (infrastructure error).",
+    };
+  }
+  const connector: string | null = resolvedSource;
   const policy = parseTaskAgentPolicy(runtime);
   const connectorPolicy = connector
     ? normalizeConnectorPolicy(policy.connectors?.[connector])

--- a/plugins/plugin-agent-orchestrator/src/services/task-policy.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-policy.ts
@@ -97,6 +97,7 @@ function parseTaskAgentPolicy(runtime: IAgentRuntime): TaskAgentPolicyConfig {
     try {
       parsed = JSON.parse(configured);
     } catch {
+      // error-policy:J3 malformed operator policy JSON → conservative built-in default (fails closed, same as an absent setting)
       return DEFAULT_POLICY;
     }
   }
@@ -202,6 +203,7 @@ async function resolveSenderRole(
           return await localRolesModule.checkSenderRole(runtime, message);
         }
       } catch {
+        // error-policy:J4 optional local roles module unresolvable here → fall through to the installed @elizaos/core import below
         // fall through to the installed package import below
       }
     }
@@ -218,6 +220,7 @@ async function resolveSenderRole(
       return await rolesModule.checkSenderRole(runtime, message);
     }
   } catch {
+    // error-policy:J4 roles package unavailable (standalone tests) → null role → caller denies any non-GUEST requirement (fails closed)
     // Package not available in standalone tests.
   }
   return null;

--- a/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
@@ -166,6 +166,8 @@ export async function runSupervisorTick(
       seen.set(roomId, digest);
       posted.push(roomId);
     } catch (error) {
+      // error-policy:J7 per-room send loop must not die on one delivery failure;
+      // seen is left unset so the next tick retries — warn-observable, self-healing.
       // A delivery failure must not abort the rest of the tick or poison the
       // dedup cache (so the next tick retries this room).
       logger.warn(
@@ -293,6 +295,8 @@ export class TaskSupervisorService extends Service {
         const handled = await sink(target, content);
         if (handled !== false) return handled;
       } catch (error) {
+        // error-policy:J4 one delivery sink unavailable → warn and fail over to
+        // the next sink/fallback; if every path fails the function throws below.
         logger.warn(
           `[TaskSupervisorService] digest sink failed for ${target.source}: ${
             error instanceof Error ? error.message : String(error)
@@ -350,6 +354,9 @@ export class TaskSupervisorService extends Service {
       }
       return result;
     } catch (error) {
+      // error-policy:J7 fire-and-forget background tick — catch keeps the interval
+      // alive and prevents a per-tick unhandled rejection; warn-observable, empty
+      // result is void-consumed by the timer (not read as real "nothing posted").
       logger.warn(
         `[TaskSupervisorService] tick failed: ${
           error instanceof Error ? error.message : String(error)

--- a/plugins/plugin-agent-orchestrator/src/services/task-watchdog-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-watchdog-service.ts
@@ -291,6 +291,7 @@ export class TaskWatchdogService extends Service {
           )}s) — prodding`,
         );
       } catch (error) {
+        // error-policy:J7 watchdog loop must survive a single failed prod; the failure is warned and retried next tick
         // Prod failed; un-mark so the next tick retries.
         this.prodded.delete(s.id);
         logger.warn(
@@ -356,6 +357,7 @@ export class TaskWatchdogService extends Service {
       try {
         await this.postCapWarning(warning, metaById.get(warning.id));
       } catch (error) {
+        // error-policy:J7 watchdog loop must survive a single failed warning delivery; the failure is warned and retried next tick
         // Delivery failed; un-mark so the next tick retries.
         this.warned.delete(key);
         logger.warn(

--- a/plugins/plugin-agent-orchestrator/src/services/trajectory-feedback.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/trajectory-feedback.ts
@@ -384,6 +384,9 @@ export async function queryPastExperience(
       .sort((a, b) => b.timestamp - a.timestamp)
       .slice(0, maxEntries);
   } catch (err) {
+    // error-policy:J4 explicit degrade — optional spawn-time experience
+    // enrichment; a trajectory-DB read failure is logged and degrades to no
+    // injected context, the same functional state as no past experience.
     // Non-critical — log and return empty
     elizaLogger.error(
       `[trajectory-feedback] Failed to query past experience: ${err}`,

--- a/plugins/plugin-agent-orchestrator/src/services/workdir-validation.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workdir-validation.ts
@@ -58,9 +58,13 @@ export async function resolveAllowedWorkdir(
   const workspaceBaseDir = path.join(os.homedir(), ".eliza", "workspaces");
   const workspaceBaseDirResolved = path.resolve(workspaceBaseDir);
   const cwdResolved = path.resolve(process.cwd());
+  // error-policy:J3 canonicalize the base root; a not-yet-created root degrades
+  // to its lexical resolved form for the prefix comparison below.
   const workspaceBaseDirReal = await realpath(workspaceBaseDirResolved).catch(
     () => workspaceBaseDirResolved,
   );
+  // error-policy:J3 canonicalize cwd; falls back to its lexical resolved form if
+  // realpath can't resolve it.
   const cwdReal = await realpath(cwdResolved).catch(() => cwdResolved);
 
   // Also allow any explicitly-configured workspace root. This keeps the HTTP
@@ -73,6 +77,8 @@ export async function resolveAllowedWorkdir(
     const raw = process.env[key]?.trim();
     if (!raw) continue;
     const rootResolved = path.resolve(raw);
+    // error-policy:J3 canonicalize a configured root; a not-yet-created root
+    // degrades to its lexical resolved form for the prefix comparison.
     const rootReal = await realpath(rootResolved).catch(() => rootResolved);
     configuredRoots.push(rootReal);
   }

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
@@ -403,6 +403,7 @@ function captureToolPathOnlyChangeSet(
         }
       }
     } catch {
+      // error-policy:J4 unreadable file → omit from diff preview; still listed in changedFiles
       fileDiff = "";
     }
     if (fileDiff) diff = diff ? `${diff}\n${fileDiff}` : fileDiff;
@@ -442,6 +443,7 @@ export function verifyChangedFilesOnDisk(
             : ("other" as const),
       };
     } catch (err) {
+      // error-policy:J3 stat probe failure → explicit exists:false result with error; surfaced via missingFiles
       return {
         path: rel,
         absolutePath,

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-lifecycle.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-lifecycle.ts
@@ -39,6 +39,7 @@ export async function removeScratchDir(
     await fs.promises.rm(resolved, { recursive: true, force: true });
     log(`Removed scratch dir ${resolved}`);
   } catch (err) {
+    // error-policy:J6 best-effort scratch-dir teardown; rm failure is logged and non-fatal
     log(
       `[CodingWorkspaceService] Failed to remove scratch dir ${resolved}: ${err}`,
     );
@@ -61,6 +62,7 @@ export async function gcOrphanedWorkspaces(
   try {
     entries = await fs.promises.readdir(baseDir, { withFileTypes: true });
   } catch {
+    // error-policy:J4 base dir absent (readdir failed) → nothing to GC; designed no-op
     // Base dir doesn't exist yet — nothing to clean
     return;
   }
@@ -89,6 +91,7 @@ export async function gcOrphanedWorkspaces(
         skipped++;
       }
     } catch (err) {
+      // error-policy:J6 best-effort GC cleanup; per-entry stat/rm failure is logged and skipped so the loop continues
       // Stat or remove failed — skip
       log(`GC: skipping ${entry.name}: ${err}`);
       skipped++;

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
@@ -148,6 +148,8 @@ function lookupDefaultBranch(
       // subsequent clone rejects it as the hard gate. See assertSafeGitRemote.
       assertSafeGitRemote(repoUrl);
     } catch {
+      // error-policy:J3 untrusted remote failed validation; treat it as an
+      // unresolved default branch (resolve null) — the clone is the hard gate.
       resolve(null);
       return;
     }
@@ -367,6 +369,8 @@ export class CodingWorkspaceService {
 
     // Run startup GC in background (non-blocking)
     this.gcOrphanedWorkspaces().catch((err) => {
+      // error-policy:J6 background startup GC of orphaned workspaces; warn-only
+      // and must not block initialization.
       logger.warn(
         `[CodingWorkspaceService] Startup GC failed: ${
           err instanceof Error ? err.message : String(err)
@@ -427,6 +431,8 @@ export class CodingWorkspaceService {
       try {
         await this.removeWorkspace(id);
       } catch (err) {
+        // error-policy:J6 best-effort teardown; a workspace that won't clean up is
+        // logged and the remaining ones are still torn down.
         this.log(`Error cleaning up workspace ${id}: ${err}`);
       }
     }
@@ -763,6 +769,8 @@ export class CodingWorkspaceService {
       try {
         callback(event);
       } catch (err) {
+        // error-policy:J7 workspace-event fan-out; a broken subscriber must not
+        // abort dispatch to the others.
         this.log(`Event callback error: ${err}`);
       }
     }
@@ -843,6 +851,8 @@ export class CodingWorkspaceService {
       if (this.scratchDecisionCallback) {
         this.log(`Firing scratch decision prompt for "${label}" at ${dirPath}`);
         this.scratchDecisionCallback(record).catch((err) => {
+          // error-policy:J7 the scratch-decision prompt is fire-and-forget; a
+          // failed send is warned and observable.
           logger.warn(
             `[CodingWorkspaceService] Failed to send scratch decision prompt: ${err}`,
           );
@@ -890,6 +900,8 @@ export class CodingWorkspaceService {
     try {
       await fs.rename(record.path, targetPath);
     } catch (error) {
+      // error-policy:J4 only the expected EXDEV (cross-device) error degrades to a
+      // copy+remove; every other error rethrows (fail-fast).
       const isExdev =
         typeof error === "object" &&
         error !== null &&
@@ -1030,6 +1042,8 @@ export class CodingWorkspaceService {
         if (record?.status !== "pending_decision") return;
         await this.removeScratchDir(record.path);
       } catch (error) {
+        // error-policy:J6 best-effort scheduled scratch-dir cleanup; a failure is
+        // warned and the timer/map bookkeeping still runs in finally.
         logger.warn(
           `[CodingWorkspaceService] scratch cleanup failed for ${sessionId}: ${String(error)}`,
         );
@@ -1067,6 +1081,8 @@ export class CodingWorkspaceService {
       try {
         await fs.access(candidate);
       } catch {
+        // error-policy:J3 fs.access throwing (ENOENT) is the existence probe's
+        // "free slot" answer — return this candidate path.
         return candidate;
       }
     }

--- a/plugins/plugin-agent-orchestrator/src/setup-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/setup-routes.ts
@@ -50,6 +50,7 @@ function codingAgentRouteHandler(): LegacyRouteHandler {
       try {
         await agentRuntime.getServiceLoadPromise("ACP_SUBPROCESS_SERVICE");
       } catch {
+        // error-policy:J4 service load failure degrades to downstream 503
         // Service start failed — downstream handlers will surface 503.
       }
     }


### PR DESCRIPTION
## Summary

Completes **#12799** — `plugin-agent-orchestrator` was the one plugin of the four ("app plugins A") left un-swept (computeruse / coding-tools / shell were already done). This triages every error handler and fixes the genuine fabrication slop.

### Annotation (comment-only, 255 sites / 55 files)
Every justified-keep handler now carries a grep-able `// error-policy:J<N>` tag (J1 boundaries, J2 rethrows, J3 parse/probe, J4 degrades, J5 rejection-suppression, J6 teardown, J7 diagnostics). Proven comment-only by `scripts/assert-comment-only-diff.mjs`.

### Fabrication fixes (12 sites — swallowed failures → observable / fail-safe)
The triage pass flagged 12 sites that fabricated a result on failure. Each now surfaces via `runtime.reportError` (logs + `ERROR_REPORTED` + `RECENT_ERRORS` provider); happy paths are unchanged. Two were real bugs:

- **`task-policy.ts` — access-control fail-open (security).** `resolveConnectorSource` swallowed a `getRoom()` infra error and returned `null`, which `requireTaskAgentAccess` treated as the permissive GUEST default → task-agent create/interact silently opened to any caller on a transient DB error. Now returns a `SOURCE_RESOLUTION_FAILED` sentinel that the caller **denies** on. Genuine `null` (real client-chat) is unaffected.
- **`acp-service.ts:cleanReverseOrphanedAcpxFiles` — data loss.** A failed `store.list()` produced an empty tracked set, so every live session's `.stream.ndjson` older than 24h looked orphaned and got `unlink()`ed. Now **returns early before any scan/delete** on a store-read failure.

Plus 10 more: `acp-service` reconcile/health-check/sweep/resume store reads (no longer silent no-ops), `sub-agent-router.hasNewerContinuation` (fails safe toward *not* double-posting), the `active-sub-agents` provider, `audit` event emission, `coding-account-selection` pool feedback, `orchestrator-task-service` account-health, and the `skill-lifeops` broker (now preserves the real payload instead of a canned message).

## Evidence

- **Comment-only annotation portion:** `assert-comment-only-diff.mjs` → OK (every code token identical) for the annotation commits.
- **Ratchet:** `error-policy-ratchet` → `no new fallback-slop in touched files` (the fixes *remove* empty catches).
- **Tests — no regression:** all unit tests covering the changed files pass in isolation — `acp-service`, `task-policy`, `coding-account-selection`, `active-sub-agents`, `account-failure-propagation`, `account-failover-respawn`, `orchestrator-task-service`, `router-loop-guard`, `sub-agent-failure-evaluator` (~171 tests, green). Baseline confirmed: the same files pass on `origin/develop` in isolation; the full-suite timeouts are sparse-worktree import contention (`import 1160s`), reproducible on develop, not from this change.
- **Typecheck:** no error references a changed file (pre-existing missing-`.d.ts` errors are in untouched e2e scripts only).
- Real-LLM trajectory / UI / audio: **N/A — server-side error-handling change; observability verified via reportError call sites + unit tests.**

Closes #12799