### PR TITLE
fix(#12748): fallback-slop sweep — social/media/market/safety plugins (non-route)

### DIFF
--- a/plugins/plugin-blocker/src/services/website-blocker/engine.ts
+++ b/plugins/plugin-blocker/src/services/website-blocker/engine.ts
@@ -1502,6 +1502,9 @@ async function lookupResolvedAddressesForWebsiteBlock(
     });
     return [...new Set(results.map((entry) => entry.address))];
   } catch {
+    // error-policy:J4 resolved-IP sinkholing is supplementary; the hostname block
+    // in the hosts file is the primary mechanism, so an unresolvable name degrades
+    // to no extra IP rules rather than failing the whole block.
     return [];
   }
 }

--- a/plugins/plugin-facewear/src/__tests__/xr-pipeline-error-paths.test.ts
+++ b/plugins/plugin-facewear/src/__tests__/xr-pipeline-error-paths.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Failure-path tests for the XR vision + audio pipelines: a model failure must
+ * surface observably (propagate / reportError) instead of being swallowed into a
+ * misleading "no frame" / silent no-op.
+ */
+import { ModelType } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { AudioPipeline } from "../services/audio-pipeline.ts";
+import { VisionPipeline } from "../services/vision-pipeline.ts";
+
+describe("VisionPipeline.describeFrame failure path", () => {
+	it("propagates a model failure instead of returning null", async () => {
+		const pipeline = new VisionPipeline();
+		pipeline.storeFrame(
+			"conn-1",
+			{ type: "frame", ts: Date.now(), width: 4, height: 4, format: "jpeg" },
+			Buffer.from([1, 2, 3, 4]),
+		);
+
+		const modelError = new Error("vision model unavailable");
+		const runtime = {
+			useModel: vi.fn().mockRejectedValue(modelError),
+		};
+
+		await expect(
+			pipeline.describeFrame(runtime as never, "conn-1"),
+		).rejects.toBe(modelError);
+		expect(runtime.useModel).toHaveBeenCalledWith(
+			ModelType.IMAGE_DESCRIPTION,
+			expect.anything(),
+		);
+	});
+
+	it("still returns null when there is no fresh frame (genuine empty)", async () => {
+		const pipeline = new VisionPipeline();
+		const runtime = { useModel: vi.fn() };
+		await expect(
+			pipeline.describeFrame(runtime as never, "missing"),
+		).resolves.toBeNull();
+		expect(runtime.useModel).not.toHaveBeenCalled();
+	});
+});
+
+describe("AudioPipeline.flush failure path", () => {
+	it("reports a transcription failure via runtime.reportError", async () => {
+		const reportError = vi.fn();
+		const onTranscript = vi.fn().mockResolvedValue(undefined);
+		const runtime = {
+			useModel: vi.fn().mockRejectedValue(new Error("transcription down")),
+			reportError,
+		};
+
+		const pipeline = new AudioPipeline(runtime as never, onTranscript);
+		pipeline.push(
+			"conn-1",
+			{
+				type: "audio",
+				ts: Date.now(),
+				sampleRate: 16000,
+				encoding: "webm-opus",
+			},
+			Buffer.alloc(1024),
+		);
+
+		await pipeline.flush("conn-1");
+
+		expect(runtime.useModel).toHaveBeenCalledWith(
+			ModelType.TRANSCRIPTION,
+			expect.any(Buffer),
+		);
+		expect(reportError).toHaveBeenCalledWith(
+			"AudioPipeline.flush",
+			expect.any(Error),
+			{ connectionId: "conn-1" },
+		);
+		expect(onTranscript).not.toHaveBeenCalled();
+	});
+});

--- a/plugins/plugin-facewear/src/register.ts
+++ b/plugins/plugin-facewear/src/register.ts
@@ -2,6 +2,7 @@
  * Facewear settings registration adds the wearables section to GUI hosts and
  * terminal view renderers to Node hosts.
  */
+import { logger } from "@elizaos/core";
 import { registerSettingsSection } from "@elizaos/ui/components/settings/settings-section-registry";
 import { Glasses } from "lucide-react";
 import { WearablesSettingsSection } from "./components/WearablesSettingsSection.tsx";
@@ -29,7 +30,9 @@ if (typeof window === "undefined") {
 			m.registerFacewearTerminalView();
 			m.registerSmartglassesTerminalView();
 		})
-		.catch(() => {
-			// Terminal rendering is best-effort; never block plugin load.
+		.catch((err) => {
+			// error-policy:J6 terminal rendering is best-effort and must never
+			// block plugin load; log so a genuine import failure stays visible.
+			logger.warn({ err }, "[facewear] terminal view registration failed");
 		});
 }

--- a/plugins/plugin-facewear/src/services/audio-pipeline.ts
+++ b/plugins/plugin-facewear/src/services/audio-pipeline.ts
@@ -3,7 +3,7 @@
  * needed, and routes speech through the runtime transcription model.
  */
 import type { IAgentRuntime } from "@elizaos/core";
-import { ModelType } from "@elizaos/core";
+import { logger, ModelType } from "@elizaos/core";
 import type { XRAudioHeader } from "../protocol/xr.ts";
 
 // Whisper expects raw Float32 PCM to arrive in a WAV container.
@@ -110,8 +110,14 @@ export class AudioPipeline {
 				await this.onTranscript(connectionId, text);
 			}
 		} catch (err) {
-			// log but don't crash the pipeline
-			console.error("[plugin-facewear/xr] transcription error:", err);
+			// error-policy:J7 transcription runs in a fire-and-forget flush loop
+			// (timer + close handlers); surface the failure observably without
+			// killing the loop.
+			logger.warn(
+				{ err, connectionId },
+				"[AudioPipeline] transcription failed",
+			);
+			this.runtime.reportError("AudioPipeline.flush", err, { connectionId });
 		}
 	}
 

--- a/plugins/plugin-facewear/src/services/vision-pipeline.ts
+++ b/plugins/plugin-facewear/src/services/vision-pipeline.ts
@@ -43,16 +43,14 @@ export class VisionPipeline {
 
 		const dataUrl = `data:image/${frame.header.format};base64,${frame.data.toString("base64")}`;
 
-		try {
-			const description = await runtime.useModel(ModelType.IMAGE_DESCRIPTION, {
-				imageUrl: dataUrl,
-				prompt: prompt ?? "Describe what you see in this image concisely.",
-			});
-			return typeof description === "string" ? description : null;
-		} catch (err) {
-			console.error("[plugin-facewear/xr] vision error:", err);
-			return null;
-		}
+		// A model failure must surface as an action error via the planner loop, not
+		// be swallowed into `null` — which the caller renders as "no recent frame"
+		// and hides the real failure. A `null` return means only "no fresh frame".
+		const description = await runtime.useModel(ModelType.IMAGE_DESCRIPTION, {
+			imageUrl: dataUrl,
+			prompt: prompt ?? "Describe what you see in this image concisely.",
+		});
+		return typeof description === "string" ? description : null;
 	}
 
 	clear(connectionId: string): void {

--- a/plugins/plugin-facewear/src/services/xr-session-service.ts
+++ b/plugins/plugin-facewear/src/services/xr-session-service.ts
@@ -12,6 +12,7 @@ import type {
 import {
 	ChannelType,
 	createMessageMemory,
+	logger,
 	ModelType,
 	Service,
 } from "@elizaos/core";
@@ -78,11 +79,11 @@ export class XRSessionService extends Service {
 
 		this.wss.on("connection", (ws) => this.onConnect(runtime, ws));
 		this.wss.on("error", (err) =>
-			console.error("[plugin-facewear/xr] WebSocket server error:", err),
+			runtime.reportError("XRSessionService.wss", err),
 		);
 
-		console.info(
-			`[plugin-facewear/xr] WebSocket server listening on ws://localhost:${port}`,
+		logger.info(
+			`[XRSessionService] WebSocket server listening on ws://localhost:${port}`,
 		);
 	}
 
@@ -202,7 +203,10 @@ export class XRSessionService extends Service {
 					this.handleTextMessage(runtime, connId, ws, data.toString("utf8"));
 				}
 			} catch (err) {
-				console.error("[plugin-facewear/xr] message handler error:", err);
+				// error-policy:J1 per-message transport boundary — a single
+				// malformed/failed frame must not tear down the ws message loop;
+				// reportError surfaces it to the agent/owner.
+				runtime.reportError("XRSessionService.message", err, { connId });
 			}
 		});
 
@@ -211,11 +215,11 @@ export class XRSessionService extends Service {
 			this.audioPipeline.clear(connId);
 			this.visionPipeline.clear(connId);
 			this.connections.delete(connId);
-			console.info(`[plugin-facewear/xr] device disconnected: ${connId}`);
+			logger.info(`[XRSessionService] device disconnected: ${connId}`);
 		});
 
 		ws.on("error", (err) =>
-			console.error(`[plugin-facewear/xr] ws error on ${connId}:`, err),
+			logger.warn({ err, connId }, "[XRSessionService] ws connection error"),
 		);
 	}
 
@@ -241,9 +245,7 @@ export class XRSessionService extends Service {
 			this.connections.set(connId, conn);
 			ws.send(JSON.stringify({ type: "ready", sessionId: connId }));
 			void this.ensureEntities(runtime, conn);
-			console.info(
-				`[plugin-facewear/xr] ${msg.deviceType} connected: ${connId}`,
-			);
+			logger.info(`[XRSessionService] ${msg.deviceType} connected: ${connId}`);
 			return;
 		}
 
@@ -263,24 +265,19 @@ export class XRSessionService extends Service {
 		}
 
 		if (msg.type === "view_ready") {
-			console.info(
-				`[plugin-facewear/xr] view ready on ${connId}: ${msg.viewId}`,
-			);
+			logger.info(`[XRSessionService] view ready on ${connId}: ${msg.viewId}`);
 			return;
 		}
 
 		if (msg.type === "view_closed") {
-			console.info(
-				`[plugin-facewear/xr] view closed on ${connId}: ${msg.viewId}`,
-			);
+			logger.info(`[XRSessionService] view closed on ${connId}: ${msg.viewId}`);
 			return;
 		}
 
 		if (msg.type === "view_event") {
-			console.info(
-				`[plugin-facewear/xr] view event on ${connId}:`,
-				msg.viewId,
-				msg.event,
+			logger.info(
+				{ connId, viewId: msg.viewId, event: msg.event },
+				"[XRSessionService] view event",
 			);
 			return;
 		}
@@ -422,7 +419,11 @@ export class XRSessionService extends Service {
 					: Buffer.from(audio as ArrayBuffer);
 				this.sendAudio(connectionId, audioBuf);
 			} catch (err) {
-				console.error("[plugin-facewear/xr] TTS error:", err);
+				// error-policy:J7 the text reply is already delivered; TTS is a
+				// background enhancement whose failure must surface but must not
+				// block persisting the agent response memory below.
+				logger.warn({ err, connectionId }, "[XRSessionService] TTS failed");
+				runtime.reportError("XRSessionService.tts", err, { connectionId });
 			}
 
 			// Persist agent response as memory
@@ -465,7 +466,12 @@ export class XRSessionService extends Service {
 			await runtime.addParticipant(conn.entityId, conn.roomId);
 			await runtime.addParticipant(runtime.agentId, conn.roomId);
 		} catch (err) {
-			console.error("[plugin-facewear/xr] entity setup error:", err);
+			// error-policy:J7 fire-and-forget bootstrap (called via `void`); a
+			// failure here breaks downstream memory writes for this session, so
+			// surface it observably rather than swallowing it silently.
+			runtime.reportError("XRSessionService.ensureEntities", err, {
+				connId: conn.id,
+			});
 		}
 	}
 }

--- a/plugins/plugin-hyperliquid/__tests__/perpetual-market.test.ts
+++ b/plugins/plugin-hyperliquid/__tests__/perpetual-market.test.ts
@@ -266,6 +266,22 @@ describe("perpetualMarketAction handler", () => {
 		expect(data.target).toBe("hyperliquid");
 	});
 
+	it("surfaces a failure when a 200 response carries a non-JSON body instead of fabricating an empty read", async () => {
+		globalThis.fetch = vi.fn(
+			async () =>
+				new Response("<html>gateway error</html>", {
+					status: 200,
+					headers: { "content-type": "text/html" },
+				}),
+		) as unknown as typeof fetch;
+		const service = await startService();
+		const { result } = await invoke(
+			{ action: "read", kind: "status" },
+			service,
+		);
+		expect(result.success).toBe(false);
+	});
+
 	it("place_order reports read-only app execution", async () => {
 		installFetchMock({
 			"/api/hyperliquid/status": {

--- a/plugins/plugin-hyperliquid/src/actions/perpetual-market.ts
+++ b/plugins/plugin-hyperliquid/src/actions/perpetual-market.ts
@@ -189,15 +189,19 @@ async function fetchHyperliquidJson<T>(path: string): Promise<T> {
 		headers: { accept: "application/json", ...buildAuthHeaders() },
 		signal: AbortSignal.timeout(ACTION_TIMEOUT_MS),
 	});
-	const payload = (await response.json().catch(() => null)) as T;
 	if (!response.ok) {
+		// error-policy:J3 error bodies are untrusted and often non-JSON; parse
+		// best-effort only to lift an error message, then fail.
+		const errorPayload = await response.json().catch(() => null);
 		const message =
-			payload && typeof payload === "object" && "error" in payload
-				? String((payload as { error?: unknown }).error)
+			errorPayload &&
+			typeof errorPayload === "object" &&
+			"error" in errorPayload
+				? String((errorPayload as { error?: unknown }).error)
 				: `Hyperliquid API request failed with ${response.status}`;
 		throw new Error(message);
 	}
-	return payload;
+	return (await response.json()) as T;
 }
 
 async function emit(
@@ -476,6 +480,9 @@ async function handlePlaceOrderOperation(
 			"/api/hyperliquid/status",
 		);
 	} catch {
+		// error-policy:J4 status probe only enriches the disabled-order message;
+		// placement is read-only regardless, so a missing status degrades to the
+		// default reason without hiding a trade result.
 		status = null;
 	}
 	const reason = status?.executionBlockedReason ?? PLACE_ORDER_DISABLED_REASON;

--- a/plugins/plugin-instagram/src/service.ts
+++ b/plugins/plugin-instagram/src/service.ts
@@ -250,6 +250,9 @@ export class InstagramService extends Service {
         getUserContext: serviceInstance.getConnectorUserContext.bind(serviceInstance),
         getUser: async (handlerRuntime, params) => {
           if (params.username || params.handle) {
+            // error-policy:J4 no concrete Instagram client backend is bundled, so
+            // the username lookup throws by design; treat it as an unresolved
+            // user and fall through to the local entity lookup below.
             const user = await accountService
               .getUserByUsername(String(params.username ?? params.handle))
               .catch(() => null);
@@ -276,6 +279,8 @@ export class InstagramService extends Service {
           if (!entityId) {
             return null;
           }
+          // error-policy:J4 an unresolved entity degrades to the connector user
+          // context lookup below; a null here means "not found in the store".
           const entity =
             typeof handlerRuntime.getEntityById === "function"
               ? await handlerRuntime.getEntityById(entityId as UUID).catch(() => null)
@@ -750,6 +755,9 @@ export class InstagramService extends Service {
         .slice(0, limit);
     }
 
+    // error-policy:J4 this package ships the connector surface without a concrete
+    // Instagram client backend, so a platform fetch throws by design; degrade to
+    // the local message cache below rather than treating it as a hard failure.
     const platformMessages = await this.getThreadMessages(threadId).catch(() => []);
     if (platformMessages.length > 0) {
       const roomId =

--- a/plugins/plugin-shopify/src/providers/store-context.ts
+++ b/plugins/plugin-shopify/src/providers/store-context.ts
@@ -48,8 +48,23 @@ export const storeContextProvider: Provider = {
     try {
       const [shop, productCount, orderCount] = await Promise.all([
         svc.getShop(),
-        svc.getProductCount().catch(() => null),
-        svc.getOrderCount().catch(() => null),
+        // error-policy:J7 counts are supplementary context enrichment; surface a
+        // fetch failure via reportError and omit the line rather than blocking
+        // the whole provider on a secondary metric.
+        svc.getProductCount().catch((error) => {
+          runtime.reportError(
+            "ShopifyStoreContextProvider.getProductCount",
+            error,
+          );
+          return null;
+        }),
+        svc.getOrderCount().catch((error) => {
+          runtime.reportError(
+            "ShopifyStoreContextProvider.getOrderCount",
+            error,
+          );
+          return null;
+        }),
       ]);
 
       const contextText = [

--- a/plugins/plugin-shopify/src/shopify-view-helpers.test.ts
+++ b/plugins/plugin-shopify/src/shopify-view-helpers.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+//
+// Failure-path coverage for the Shopify terminal fetch helper: a malformed body
+// on an otherwise-OK response must surface, not be fabricated into null.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchShopifyTuiJson } from "./shopify-view-helpers";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("fetchShopifyTuiJson", () => {
+  it("returns null for a 404", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response("", { status: 404 }),
+    ) as unknown as typeof fetch;
+    await expect(fetchShopifyTuiJson("/api/shopify/x")).resolves.toBeNull();
+  });
+
+  it("throws the error message from a non-OK JSON body", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "rate limited" }), {
+          status: 429,
+          headers: { "content-type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
+    await expect(fetchShopifyTuiJson("/api/shopify/x")).rejects.toThrow(
+      /rate limited/,
+    );
+  });
+
+  it("surfaces a malformed body on a 200 instead of fabricating null", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response("<html>proxy error</html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
+    ) as unknown as typeof fetch;
+    await expect(fetchShopifyTuiJson("/api/shopify/x")).rejects.toThrow();
+  });
+});

--- a/plugins/plugin-shopify/src/shopify-view-helpers.ts
+++ b/plugins/plugin-shopify/src/shopify-view-helpers.ts
@@ -14,15 +14,17 @@ import type {
 export async function fetchShopifyTuiJson<T>(url: string): Promise<T | null> {
   const response = await fetch(url);
   if (response.status === 404) return null;
-  const data = await response.json().catch(() => null);
   if (!response.ok) {
+    // error-policy:J3 error bodies may be non-JSON; parse best-effort only to
+    // lift an error message, then fail.
+    const errorData = await response.json().catch(() => null);
     const message =
-      data && typeof data === "object" && "error" in data
-        ? String(data.error)
+      errorData && typeof errorData === "object" && "error" in errorData
+        ? String((errorData as { error?: unknown }).error)
         : `Shopify request failed with ${response.status}`;
     throw new Error(message);
   }
-  return data as T;
+  return (await response.json()) as T;
 }
 
 export async function postShopifyTuiJson(

--- a/plugins/plugin-social-alpha/src/clients.failure.test.ts
+++ b/plugins/plugin-social-alpha/src/clients.failure.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Failure-path coverage for the market-data clients: a transport failure must
+ * surface, and must never be laundered into an "empty result" that reads as a
+ * token with no pairs (error-policy sweep, #12748).
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { DexscreenerClient } from "./clients";
+
+function createRuntime(): IAgentRuntime {
+	return {
+		getSetting: () => undefined,
+		getCache: async () => undefined,
+		setCache: async () => undefined,
+	} as unknown as IAgentRuntime;
+}
+
+describe("DexscreenerClient.search", () => {
+	it("propagates a transport failure instead of returning empty pairs", async () => {
+		const client = new DexscreenerClient(createRuntime());
+		const request = vi.fn().mockRejectedValue(new Error("network down"));
+		(client as unknown as { request: typeof request }).request = request;
+
+		await expect(client.search("So1111")).rejects.toThrow("network down");
+	});
+
+	it("returns a genuine empty result when the API responds with no pairs", async () => {
+		const client = new DexscreenerClient(createRuntime());
+		const request = vi.fn().mockResolvedValue({ pairs: undefined });
+		(client as unknown as { request: typeof request }).request = request;
+
+		const result = await client.search("So1111");
+		expect(result).toEqual({ schemaVersion: "1.0.0", pairs: [] });
+	});
+});

--- a/plugins/plugin-social-alpha/src/clients.ts
+++ b/plugins/plugin-social-alpha/src/clients.ts
@@ -1,4 +1,4 @@
-import type { IAgentRuntime } from "@elizaos/core";
+import { type IAgentRuntime, logger } from "@elizaos/core";
 import BigNumber from "bignumber.js";
 import * as dotenv from "dotenv";
 import { BTC_ADDRESS, ETH_ADDRESS, SOL_ADDRESS } from "./config";
@@ -180,15 +180,16 @@ export const http = {
 					const delay = calculateDelay(attempt, retryOptions);
 					const errorMessage =
 						error instanceof Error ? error.message : String(error);
-					console.warn(
-						`Request failed with error: ${errorMessage}. ` +
+					logger.warn(
+						`[http] Request failed with error: ${errorMessage}. ` +
 							`Retrying in ${delay}ms (attempt ${attempt}/${retryOptions.maxRetries})`,
 					);
 					await sleep(delay);
 					attempt++;
 					continue;
 				}
-				console.error(`Request failed after ${attempt} attempts:`, error);
+				// error-policy:J2 add attempt context, then rethrow to the caller
+				logger.error(`[http] Request failed after ${attempt} attempts:`, error);
 
 				throw error;
 			}
@@ -363,27 +364,18 @@ export class DexscreenerClient {
 		address: string,
 		options?: DexscreenerOptions,
 	): Promise<DexScreenerData> {
-		try {
-			const data = await this.request<DexScreenerData>(
-				"latest/dex/search",
-				{
-					q: address,
-				},
-				options,
-			);
+		// A transport/HTTP failure propagates (masking it as an empty result would
+		// make a failed lookup indistinguishable from a token that has no pairs).
+		// Only a successful response with no pairs is a genuine empty result.
+		const data = await this.request<DexScreenerData>(
+			"latest/dex/search",
+			{
+				q: address,
+			},
+			options,
+		);
 
-			if (!data?.pairs) {
-				throw new Error("No DexScreener data available");
-			}
-
-			return data;
-		} catch (error) {
-			console.error("Error fetching DexScreener data:", error);
-			return {
-				schemaVersion: "1.0.0",
-				pairs: [],
-			};
-		}
+		return data?.pairs ? data : { schemaVersion: "1.0.0", pairs: [] };
 	}
 
 	/**
@@ -526,8 +518,11 @@ export class HeliusClient {
 
 			return holders;
 		} catch (error) {
-			console.error("Error fetching holder list from Helius:", error);
-			throw new Error("Failed to fetch holder list from Helius.");
+			// error-policy:J2 add context and preserve cause on rethrow
+			logger.error("[HeliusClient] Error fetching holder list:", error);
+			throw new Error("Failed to fetch holder list from Helius.", {
+				cause: error,
+			});
 		}
 	}
 }
@@ -760,7 +755,8 @@ export class BirdeyeClient {
 		);
 
 		if (!res.success || !res.data) {
-			console.error({ res });
+			// error-policy:J1 boundary — Birdeye HTTP envelope indicates failure
+			logger.error("[BirdeyeClient] request failed", { path, res });
 			throw new Error(`Birdeye request failed:${path}`);
 		}
 
@@ -1006,7 +1002,8 @@ export class BirdeyeClient {
 
 			return portfolio;
 		} catch (error) {
-			console.error("Error fetching portfolio:", error);
+			// error-policy:J2 add context, then rethrow to the caller
+			logger.error("[BirdeyeClient] Error fetching portfolio:", error);
 			throw error;
 		}
 	}

--- a/plugins/plugin-social-alpha/src/events.ts
+++ b/plugins/plugin-social-alpha/src/events.ts
@@ -26,6 +26,7 @@ function logValue(value: unknown): string {
 	try {
 		return JSON.stringify(value);
 	} catch {
+		// error-policy:J3 value may be non-serializable (circular); String() is a valid representation
 		return String(value);
 	}
 }
@@ -96,6 +97,7 @@ function parseJsonObject<T extends Record<string, unknown>>(
 			? (parsed as T)
 			: null;
 	} catch {
+		// error-policy:J3 untrusted LLM/string input; malformed JSON is an invalid result, not a failure
 		return null;
 	}
 }

--- a/plugins/plugin-social-alpha/src/frontend/LeaderboardView.helpers.ts
+++ b/plugins/plugin-social-alpha/src/frontend/LeaderboardView.helpers.ts
@@ -57,6 +57,8 @@ export async function hasWalletConfigured(): Promise<boolean> {
 		const addresses = await client.getWalletAddresses();
 		return Boolean(addresses?.evmAddress || addresses?.solanaAddress);
 	} catch {
+		// error-policy:J4 wallet gate degrades closed — an unreachable API reads as
+		// "not configured" and shows the wallet-required state (never a false-open)
 		return false;
 	}
 }

--- a/plugins/plugin-social-alpha/src/frontend/SocialAlphaView.tsx
+++ b/plugins/plugin-social-alpha/src/frontend/SocialAlphaView.tsx
@@ -154,6 +154,7 @@ export function SocialAlphaView(props: SocialAlphaViewProps = {}): ReactNode {
 						prev.kind === "ready" ? { kind: "ready", entries } : prev,
 					);
 				})
+				// error-policy:J5 transient background-poll failure; errors surface via the explicit load()/Retry path above
 				.catch(() => {});
 		}, POLL_INTERVAL_MS);
 		return () => clearInterval(id);

--- a/plugins/plugin-social-alpha/src/providers/socialAlphaProvider.ts
+++ b/plugins/plugin-social-alpha/src/providers/socialAlphaProvider.ts
@@ -25,6 +25,7 @@ function logValue(value: unknown): string {
 	try {
 		return JSON.stringify(value);
 	} catch {
+		// error-policy:J3 value may be non-serializable (circular); String() is a valid representation
 		return String(value);
 	}
 }
@@ -247,6 +248,8 @@ export const socialAlphaProvider: Provider = {
 					senderProfile = component.data as UserTrustProfile;
 				}
 			} catch (err) {
+				// error-policy:J4 optional context section degrades to omitted; the
+				// outer handler is the boundary that reports a real generation failure
 				logger.debug(
 					`[socialAlphaProvider] No profile for sender ${senderId}: ${err}`,
 				);
@@ -283,6 +286,8 @@ export const socialAlphaProvider: Provider = {
 			try {
 				leaderboard = await service.getLeaderboardData(runtime);
 			} catch (err) {
+				// error-policy:J4 leaderboard section is optional context; degrades to
+				// omitted rather than failing the whole provider render
 				logger.debug(
 					`[socialAlphaProvider] Error fetching leaderboard: ${err}`,
 				);
@@ -343,10 +348,9 @@ export const socialAlphaProvider: Provider = {
 				values,
 			};
 		} catch (error) {
-			logger.error(
-				"[socialAlphaProvider] Error generating provider data:",
-				error,
-			);
+			// error-policy:J4 provider boundary — degrade to empty context rather than
+			// failing the agent turn; reportError surfaces it to the agent/owner
+			runtime.reportError("socialAlphaProvider", error);
 			return { text: "", values: {} };
 		}
 	},

--- a/plugins/plugin-social-alpha/src/register.ts
+++ b/plugins/plugin-social-alpha/src/register.ts
@@ -8,10 +8,13 @@
  * a no-op (a DOM is present), so the same import is safe everywhere.
  */
 
+import { logger } from "@elizaos/core";
+
 if (typeof window === "undefined") {
 	void import("./register-terminal-view.js")
 		.then((m) => m.registerSocialAlphaTerminalView())
-		.catch(() => {
-			// Terminal rendering is best-effort; never block plugin load.
+		// error-policy:J5 optional terminal-view registration; suppression is observed via this debug log and never blocks plugin load
+		.catch((err) => {
+			logger.debug(`[social-alpha] Terminal view registration skipped: ${err}`);
 		});
 }

--- a/plugins/plugin-social-alpha/src/schemas.ts
+++ b/plugins/plugin-social-alpha/src/schemas.ts
@@ -1,3 +1,4 @@
+import { logger } from "@elizaos/core";
 import { z } from "zod";
 import type {
 	TransactionType as DomainTransactionType,
@@ -413,7 +414,8 @@ export function transformTokenRecommendation(
 			),
 		});
 	} catch (error) {
-		console.error("Error transforming token recommendation:", error);
-		throw error; // Re-throw the error instead of returning null
+		// error-policy:J2 add context, then rethrow (never return a null/partial record)
+		logger.error("[schemas] Error transforming token recommendation:", error);
+		throw error;
 	}
 }

--- a/plugins/plugin-social-alpha/src/service.getCurrentPrice.test.ts
+++ b/plugins/plugin-social-alpha/src/service.getCurrentPrice.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Failure-path coverage for CommunityInvestorService.getCurrentPrice. A price
+ * lookup failure previously returned a fabricated 0, which reads as a -100%
+ * return in P&L/trust scoring. It must now surface (reportError) and rethrow
+ * (error-policy sweep, #12748).
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { CommunityInvestorService } from "./service";
+
+function createRuntime(reportError: ReturnType<typeof vi.fn>): IAgentRuntime {
+	return {
+		agentId: "00000000-0000-0000-0000-000000000001",
+		getSetting: (key: string) =>
+			key === "BIRDEYE_API_KEY" ? "test-birdeye-key" : undefined,
+		getCache: async () => undefined,
+		setCache: async () => undefined,
+		useModel: async () => [0.1, 0.2, 0.3],
+		searchMemories: async () => [],
+		ensureWorldExists: async () => undefined,
+		ensureRoomExists: async () => undefined,
+		registerTaskWorker: () => undefined,
+		getTasks: async () => [],
+		createTask: async () => undefined,
+		reportError,
+	} as unknown as IAgentRuntime;
+}
+
+describe("CommunityInvestorService.getCurrentPrice", () => {
+	it("surfaces and rethrows a price fetch failure instead of returning 0", async () => {
+		const reportError = vi.fn();
+		const service = new CommunityInvestorService(createRuntime(reportError));
+
+		(
+			service as unknown as {
+				birdeyeClient: { fetchPrice: () => Promise<number> };
+			}
+		).birdeyeClient = {
+			fetchPrice: vi.fn().mockRejectedValue(new Error("birdeye 503")),
+		};
+
+		await expect(
+			service.getCurrentPrice(
+				"solana",
+				"So11111111111111111111111111111111111111112",
+			),
+		).rejects.toThrow("birdeye 503");
+		expect(reportError).toHaveBeenCalledWith(
+			"CommunityInvestorService.getCurrentPrice",
+			expect.any(Error),
+			expect.objectContaining({ chain: "solana" }),
+		);
+	});
+});

--- a/plugins/plugin-social-alpha/src/service.ts
+++ b/plugins/plugin-social-alpha/src/service.ts
@@ -25,6 +25,7 @@ function logValue(value: unknown): string {
 	try {
 		return JSON.stringify(value);
 	} catch {
+		// error-policy:J3 value may be non-serializable (circular); String() is a valid representation
 		return String(value);
 	}
 }
@@ -140,6 +141,7 @@ function parseJsonObject<T extends Record<string, unknown>>(
 			? (parsed as T)
 			: null;
 	} catch {
+		// error-policy:J3 untrusted LLM/string input; malformed JSON is an invalid result, not a failure
 		return null;
 	}
 }
@@ -961,8 +963,18 @@ export class CommunityInvestorService
 			}
 			throw new Error(`Chain ${chain} not supported for price fetching`);
 		} catch (error) {
-			logger.error(`Error fetching current price for ${tokenAddress}:`, error);
-			return 0;
+			// A fabricated 0 here silently corrupts P&L/trust scoring (it reads as a
+			// -100% return in calculatePositionPerformance). Surface the failure to
+			// the agent and rethrow so the caller's boundary handles it.
+			this.runtime.reportError(
+				"CommunityInvestorService.getCurrentPrice",
+				error,
+				{
+					chain,
+					tokenAddress,
+				},
+			);
+			throw error;
 		}
 	}
 

--- a/plugins/plugin-social-alpha/src/services/historicalPriceService.ts
+++ b/plugins/plugin-social-alpha/src/services/historicalPriceService.ts
@@ -1,4 +1,4 @@
-import type { IAgentRuntime } from "@elizaos/core";
+import { type IAgentRuntime, logger } from "@elizaos/core";
 import { BirdeyeClient, DexscreenerClient } from "../clients.ts";
 import { SupportedChain } from "../types.ts";
 
@@ -118,8 +118,8 @@ export class HistoricalPriceService {
 		} catch (error: unknown) {
 			// If OHLCV fails, try to get current price at least
 			const message = error instanceof Error ? error.message : String(error);
-			console.warn(
-				`OHLCV failed for ${address}, trying current price:`,
+			logger.warn(
+				`[HistoricalPriceService] OHLCV failed for ${address}, trying current price:`,
 				message,
 			);
 
@@ -143,8 +143,8 @@ export class HistoricalPriceService {
 					};
 				}
 			} catch (priceError) {
-				console.error(
-					`Failed to get any price data for ${address}:`,
+				logger.error(
+					`[HistoricalPriceService] Failed to get any price data for ${address}:`,
 					priceError,
 				);
 			}
@@ -251,7 +251,10 @@ export class HistoricalPriceService {
 				fetchedAt: Date.now(),
 			};
 		} catch (error) {
-			console.error(`Error fetching Dexscreener data for ${address}:`, error);
+			logger.error(
+				`[HistoricalPriceService] Error fetching Dexscreener data for ${address}:`,
+				error,
+			);
 			return null;
 		}
 	}
@@ -391,8 +394,8 @@ export class HistoricalPriceService {
 			const minLiquidityRatio = 10000 / 1000000; // $10k per $1M market cap
 
 			if (marketCap > 0 && liquidityUsd / marketCap < minLiquidityRatio) {
-				console.warn(
-					`Token ${symbol} has insufficient liquidity ratio: ${liquidityUsd / marketCap}`,
+				logger.warn(
+					`[HistoricalPriceService] Token ${symbol} has insufficient liquidity ratio: ${liquidityUsd / marketCap}`,
 				);
 			}
 
@@ -407,7 +410,10 @@ export class HistoricalPriceService {
 				createdAt: bestMatch.pairCreatedAt,
 			};
 		} catch (error) {
-			console.error(`Error finding best token match for ${symbol}:`, error);
+			logger.error(
+				`[HistoricalPriceService] Error finding best token match for ${symbol}:`,
+				error,
+			);
 			return null;
 		}
 	}

--- a/plugins/plugin-social-alpha/src/services/priceEnrichmentService.ts
+++ b/plugins/plugin-social-alpha/src/services/priceEnrichmentService.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { IAgentRuntime } from "@elizaos/core";
+import { type IAgentRuntime, logger } from "@elizaos/core";
 import { BirdeyeClient, DexscreenerClient } from "../clients.ts";
 import type { TokenAPIData } from "../types.ts";
 import { SupportedChain } from "../types.ts";
@@ -94,16 +94,16 @@ export class PriceEnrichmentService {
 					const batchData = JSON.parse(content) as TradingCall[];
 					allCalls.push(...batchData);
 				} catch (error) {
-					console.error(`Error loading batch file ${file}:`, error);
+					logger.error(`Error loading batch file ${file}:`, error);
 				}
 			}
 
-			console.log(
+			logger.info(
 				`Loaded ${allCalls.length} trading calls from ${batchFiles.length} batch files`,
 			);
 			return allCalls;
 		} catch (error) {
-			console.error("Error loading batch files:", error);
+			logger.error("Error loading batch files:", error);
 			return [];
 		}
 	}
@@ -145,7 +145,7 @@ export class PriceEnrichmentService {
 
 			return null;
 		} catch (error) {
-			console.error(`Error resolving token for call ${call.callId}:`, error);
+			logger.error(`Error resolving token for call ${call.callId}:`, error);
 			return null;
 		}
 	}
@@ -213,7 +213,7 @@ export class PriceEnrichmentService {
 				worstPriceTimestamp: worstPrice.timestamp,
 			};
 		} catch (error) {
-			console.error(`Error getting price data for ${tokenAddress}:`, error);
+			logger.error(`Error getting price data for ${tokenAddress}:`, error);
 			return null;
 		}
 	}
@@ -277,7 +277,7 @@ export class PriceEnrichmentService {
 			enrichedCall.enrichmentStatus = "success";
 			enrichedCall.enrichedAt = Date.now();
 		} catch (error) {
-			console.error(`Error enriching call ${call.callId}:`, error);
+			logger.error(`Error enriching call ${call.callId}:`, error);
 			enrichedCall.enrichmentStatus = "failed";
 			enrichedCall.enrichmentError =
 				error instanceof Error ? error.message : "Unknown error";
@@ -301,7 +301,7 @@ export class PriceEnrichmentService {
 		let failureCount = 0;
 		let resolvedTokenCount = 0;
 
-		console.log(
+		logger.info(
 			`Starting enrichment of ${calls.length} calls in batches of ${batchSize}`,
 		);
 
@@ -313,7 +313,7 @@ export class PriceEnrichmentService {
 			const batchNumber = Math.floor(i / batchSize) + 1;
 			const totalBatches = Math.ceil(calls.length / batchSize);
 
-			console.log(
+			logger.info(
 				`Processing batch ${batchNumber}/${totalBatches} (${((batchNumber / totalBatches) * 100).toFixed(1)}%)`,
 			);
 
@@ -345,10 +345,10 @@ export class PriceEnrichmentService {
 				const remaining = totalBatches - batchNumber;
 				const eta = remaining / rate; // minutes
 
-				console.log(
+				logger.info(
 					`📊 Progress: ${successCount} success, ${failureCount} failed, ${resolvedTokenCount} tokens resolved`,
 				);
-				console.log(
+				logger.info(
 					`⏱️  Time: ${elapsed.toFixed(1)}min elapsed, ~${eta.toFixed(1)}min remaining`,
 				);
 			}
@@ -368,14 +368,14 @@ export class PriceEnrichmentService {
 		);
 
 		const totalTime = (Date.now() - startTime) / 1000 / 60;
-		console.log(`\n✅ Enrichment complete in ${totalTime.toFixed(2)} minutes!`);
-		console.log(
+		logger.info(`\n✅ Enrichment complete in ${totalTime.toFixed(2)} minutes!`);
+		logger.info(
 			`📈 Results: ${successCount} success (${((successCount / calls.length) * 100).toFixed(1)}%), ${failureCount} failed`,
 		);
-		console.log(
+		logger.info(
 			`🎯 Tokens resolved: ${resolvedTokenCount} (${((resolvedTokenCount / calls.length) * 100).toFixed(1)}%)`,
 		);
-		console.log(
+		logger.info(
 			`💾 Saved ${enrichedCalls.length} enriched calls to ${completeOutputFile}`,
 		);
 	}
@@ -529,7 +529,7 @@ export class PriceEnrichmentService {
 
 			return null;
 		} catch (error) {
-			console.error(`Error getting token info for ${address}:`, error);
+			logger.error(`Error getting token info for ${address}:`, error);
 			return null;
 		}
 	}
@@ -559,10 +559,10 @@ export class PriceEnrichmentService {
 				return dexscreenerResult;
 			}
 
-			console.warn(`Could not resolve token symbol: ${symbol} on ${chain}`);
+			logger.warn(`Could not resolve token symbol: ${symbol} on ${chain}`);
 			return null;
 		} catch (error) {
-			console.error(`Error searching for token ${symbol}:`, error);
+			logger.error(`Error searching for token ${symbol}:`, error);
 			return null;
 		}
 	}
@@ -1058,7 +1058,7 @@ export class PriceEnrichmentService {
 
 			return null;
 		} catch (error) {
-			console.error(`Error searching DexScreener for symbol ${symbol}:`, error);
+			logger.error(`Error searching DexScreener for symbol ${symbol}:`, error);
 			return null;
 		}
 	}

--- a/plugins/plugin-social-alpha/src/services/simulationRunner.ts
+++ b/plugins/plugin-social-alpha/src/services/simulationRunner.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import type { UUID } from "@elizaos/core";
+import { logger, type UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { Conviction, SupportedChain } from "../types";
 import type { SimulatedActorV2 } from "./simulationActorsV2";
@@ -136,7 +136,7 @@ export class SimulationRunner {
 	}
 
 	async runSimulation(config: SimulationConfig): Promise<SimulationResult> {
-		console.log("🚀 Starting comprehensive market simulation...");
+		logger.info("🚀 Starting comprehensive market simulation...");
 
 		// Initialize result containers
 		const calls: SimulatedCallData[] = [];
@@ -226,7 +226,7 @@ export class SimulationRunner {
 			);
 		}
 
-		console.log(
+		logger.info(
 			`✅ Simulation complete: ${stepCount} time steps, ${calls.length} calls generated`,
 		);
 
@@ -340,7 +340,7 @@ export class SimulationRunner {
 			tokens.push(token);
 		}
 
-		console.log(
+		logger.info(
 			`📊 Generated ${tokens.length} tokens with scenarios:`,
 			tokens.reduce(
 				(acc, t) => {
@@ -1148,7 +1148,7 @@ export class SimulationRunner {
 			JSON.stringify(Array.from(result.actorPerformance.entries()), null, 2),
 		);
 
-		console.log(`📁 Results cached to ${outputDir}`);
+		logger.info(`📁 Results cached to ${outputDir}`);
 	}
 
 	async loadCachedSimulation(
@@ -1179,7 +1179,7 @@ export class SimulationRunner {
 				actorPerformance: new Map(JSON.parse(perfData)),
 			};
 		} catch (error) {
-			console.error("Failed to load cached simulation:", error);
+			logger.error("Failed to load cached simulation:", error);
 			return null;
 		}
 	}

--- a/plugins/plugin-social-alpha/src/services/trustScoreOptimizer.ts
+++ b/plugins/plugin-social-alpha/src/services/trustScoreOptimizer.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import type { UUID } from "@elizaos/core";
+import { logger, type UUID } from "@elizaos/core";
 import { BalancedTrustScoreCalculator } from "./balancedTrustScoreCalculator";
 import {
 	type ActorConfig,
@@ -90,7 +90,7 @@ export class TrustScoreOptimizer {
 		simulationConfig?: SimulationConfig,
 		useCache: boolean = true,
 	): Promise<OptimizationResult> {
-		console.log("🔄 Starting trust score optimization cycle...");
+		logger.info("🔄 Starting trust score optimization cycle...");
 
 		// 1. Get or generate simulation data
 		const simulationData = await this.getSimulationData(
@@ -133,13 +133,13 @@ export class TrustScoreOptimizer {
 			const cached =
 				await this.simulationRunner.loadCachedSimulation(defaultOutputDir);
 			if (cached) {
-				console.log("📂 Loaded cached simulation data");
+				logger.info("📂 Loaded cached simulation data");
 				return cached;
 			}
 		}
 
 		// Generate new simulation
-		console.log("🎲 Generating new simulation data...");
+		logger.info("🎲 Generating new simulation data...");
 
 		const simulationConfig: SimulationConfig = config || {
 			startTime: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000), // 30 days ago
@@ -807,14 +807,14 @@ export class TrustScoreOptimizer {
 		const dataPath = path.join(logDir, `optimization-data-${timestamp}.json`);
 		await fs.writeFile(dataPath, JSON.stringify(result, null, 2));
 
-		console.log(`\n📊 Optimization Report Summary:`);
-		console.log(`   MAE: ${result.accuracy.mae.toFixed(2)}`);
-		console.log(`   RMSE: ${result.accuracy.rmse.toFixed(2)}`);
-		console.log(`   Correlation: ${result.accuracy.correlation.toFixed(3)}`);
-		console.log(
+		logger.info(`\n📊 Optimization Report Summary:`);
+		logger.info(`   MAE: ${result.accuracy.mae.toFixed(2)}`);
+		logger.info(`   RMSE: ${result.accuracy.rmse.toFixed(2)}`);
+		logger.info(`   Correlation: ${result.accuracy.correlation.toFixed(3)}`);
+		logger.info(
 			`   Ranking Accuracy: ${result.accuracy.rankingAccuracy.toFixed(1)}%`,
 		);
-		console.log(`\n📁 Full report saved to: ${reportPath}`);
+		logger.info(`\n📁 Full report saved to: ${reportPath}`);
 	}
 
 	/**
@@ -824,7 +824,7 @@ export class TrustScoreOptimizer {
 		parameterRanges: Partial<Record<keyof TrustScoreParameters, number[]>>,
 		simulationConfig?: SimulationConfig,
 	): Promise<TrustScoreParameters> {
-		console.log("🔍 Starting parameter optimization via grid search...");
+		logger.info("🔍 Starting parameter optimization via grid search...");
 
 		let bestParams = { ...this.currentParams };
 		let bestScore = Infinity;
@@ -836,7 +836,7 @@ export class TrustScoreOptimizer {
 		const paramCombinations =
 			this.generateParameterCombinations(parameterRanges);
 
-		console.log(
+		logger.info(
 			`Testing ${paramCombinations.length} parameter combinations...`,
 		);
 
@@ -851,12 +851,12 @@ export class TrustScoreOptimizer {
 			if (accuracy.mae < bestScore) {
 				bestScore = accuracy.mae;
 				bestParams = { ...params };
-				console.log(`New best MAE: ${bestScore.toFixed(2)}`);
+				logger.info(`New best MAE: ${bestScore.toFixed(2)}`);
 			}
 		}
 
 		this.currentParams = bestParams;
-		console.log("✅ Optimization complete. Best parameters:", bestParams);
+		logger.info("✅ Optimization complete. Best parameters:", bestParams);
 
 		return bestParams;
 	}

--- a/plugins/plugin-telegram-standalone/src/handler.ts
+++ b/plugins/plugin-telegram-standalone/src/handler.ts
@@ -261,6 +261,8 @@ export async function handleTelegramStandaloneMessage(
     });
   } catch (outerErr) {
     logger.warn(`[telegram-standalone] Telegram handler error: ${formatError(outerErr)}`);
+    // error-policy:J6 best-effort user-facing error notice; the underlying
+    // failure is already logged above, so a failed reply has nowhere left to go.
     await ctx.reply("Sorry, I encountered an error processing your message.").catch(() => {});
   }
 }

--- a/plugins/plugin-wallet-ui/src/InventoryView.helpers.ts
+++ b/plugins/plugin-wallet-ui/src/InventoryView.helpers.ts
@@ -126,11 +126,11 @@ export async function loadWalletTuiState() {
     walletNfts,
     marketOverview,
   ] = await Promise.all([
-    client.getWalletAddresses().catch(() => null),
-    client.getWalletConfig().catch(() => null),
-    client.getWalletBalances().catch(() => null),
-    client.getWalletNfts().catch(() => null),
-    client.getWalletMarketOverview().catch(() => null),
+    client.getWalletAddresses(),
+    client.getWalletConfig(),
+    client.getWalletBalances(),
+    client.getWalletNfts(),
+    client.getWalletMarketOverview(),
   ]);
   const summary = summarizeWalletBalances(walletBalances);
   return {

--- a/plugins/plugin-wallet-ui/src/InventoryView.interact.test.ts
+++ b/plugins/plugin-wallet-ui/src/InventoryView.interact.test.ts
@@ -188,4 +188,13 @@ describe("wallet interact capabilities", () => {
   it("rejects unknown interact capabilities", async () => {
     await expect(interact("nope")).rejects.toThrow(/Unsupported capability/);
   });
+
+  it("surfaces a wallet-balance load failure instead of rendering an empty $0 wallet", async () => {
+    walletClient.getWalletBalances.mockRejectedValue(
+      new Error("wallet RPC unavailable"),
+    );
+    await expect(
+      interact("terminal-wallet-state", { limit: 2 }),
+    ).rejects.toThrow(/wallet RPC unavailable/);
+  });
 });

--- a/plugins/plugin-x/src/base.ts
+++ b/plugins/plugin-x/src/base.ts
@@ -912,7 +912,10 @@ export class ClientBase {
         this.formatTweetToInteraction(tweet),
       );
     } catch (error) {
-      logger.error("Error fetching Twitter interactions:", errorDetail(error));
+      // error-policy:J7 a mentions/interactions fetch failure must surface to the
+      // agent rather than reading as no interactions; degrade to an empty list
+      // after reporting.
+      this.runtime.reportError("XClientBase.getInteractions", error);
       return [];
     }
   }

--- a/plugins/plugin-x/src/client/accounts.ts
+++ b/plugins/plugin-x/src/client/accounts.ts
@@ -198,7 +198,10 @@ async function readRuntimeAccountRecord(
         },
       };
     }
-  } catch {}
+  } catch {
+    // error-policy:J4 this account source did not resolve; fall through to the
+    // next lookup strategy below.
+  }
 
   try {
     const store = accountRuntime.getConnectorAccountStore?.("x");

--- a/plugins/plugin-x/src/interactions.ts
+++ b/plugins/plugin-x/src/interactions.ts
@@ -1279,10 +1279,12 @@ ${tweet.text}`;
 
         await createMemorySafe(this.runtime, responseMemory, "messages");
 
-        // Return the created memory
         return [responseMemory];
       } catch (error) {
-        logger.error("Error in tweet reply callback:", errorMessage(error));
+        // error-policy:J7 the reply was already sent; a failure recording its
+        // memory must surface to the agent rather than vanishing. Degrade to no
+        // recorded memory after reporting.
+        this.runtime.reportError("XInteractions.replyCallback", error);
         return [];
       }
     };

--- a/plugins/plugin-x/src/services/MessageService.ts
+++ b/plugins/plugin-x/src/services/MessageService.ts
@@ -123,7 +123,9 @@ export class TwitterMessageService implements IMessageService {
 
       return messages;
     } catch (error) {
-      logger.error("Error fetching messages:", this.errorDetail(error));
+      // error-policy:J7 a DM fetch failure must surface to the agent (RECENT_ERRORS)
+      // rather than reading as an empty inbox; degrade to no messages after reporting.
+      this.client.runtime.reportError("XMessageService.getMessages", error);
       return [];
     }
   }
@@ -208,7 +210,9 @@ export class TwitterMessageService implements IMessageService {
 
       return message;
     } catch (error) {
-      logger.error("Error fetching message:", this.errorDetail(error));
+      // error-policy:J7 a message-fetch failure must surface to the agent rather
+      // than reading as "no such message"; degrade to null after reporting.
+      this.client.runtime.reportError("XMessageService.getMessage", error);
       return null;
     }
   }

--- a/plugins/plugin-x/src/services/PostService.test.ts
+++ b/plugins/plugin-x/src/services/PostService.test.ts
@@ -37,4 +37,27 @@ describe("TwitterPostService inverse post actions", () => {
 
     expect(unretweet).toHaveBeenCalledWith("tweet-2");
   });
+
+  it("surfaces a getPosts fetch failure via reportError instead of silently returning []", async () => {
+    const reportError = vi.fn();
+    const getUserTweets = vi
+      .fn()
+      .mockRejectedValue(new Error("twitter 429 rate limited"));
+    const failing = new TwitterPostService({
+      runtime: { reportError },
+      twitterClient: { getUserTweets },
+    } as unknown as ClientBase);
+
+    const posts = await failing.getPosts({
+      agentId: "00000000-0000-0000-0000-000000000001" as UUID,
+      userId: "123",
+      limit: 5,
+    });
+
+    expect(posts).toEqual([]);
+    expect(reportError).toHaveBeenCalledWith(
+      "XPostService.getPosts",
+      expect.any(Error),
+    );
+  });
 });

--- a/plugins/plugin-x/src/services/PostService.ts
+++ b/plugins/plugin-x/src/services/PostService.ts
@@ -236,7 +236,9 @@ export class TwitterPostService implements IPostService {
 
       return post;
     } catch (error) {
-      logger.error("Error fetching post:", this.errorDetail(error));
+      // error-policy:J7 a post-fetch failure must surface to the agent rather than
+      // reading as "no such post"; degrade to null after reporting.
+      this.client.runtime.reportError("XPostService.getPost", error);
       return null;
     }
   }
@@ -301,7 +303,9 @@ export class TwitterPostService implements IPostService {
 
       return posts;
     } catch (error) {
-      logger.error("Error fetching posts:", this.errorDetail(error));
+      // error-policy:J7 a posts-fetch failure must surface to the agent rather than
+      // reading as an empty timeline; degrade to no posts after reporting.
+      this.client.runtime.reportError("XPostService.getPosts", error);
       return [];
     }
   }
@@ -380,7 +384,9 @@ export class TwitterPostService implements IPostService {
 
       return posts;
     } catch (error) {
-      logger.error("Error fetching mentions:", this.errorDetail(error));
+      // error-policy:J7 a mentions-fetch failure must surface to the agent rather
+      // than reading as no mentions; degrade to an empty list after reporting.
+      this.client.runtime.reportError("XPostService.getMentions", error);
       return [];
     }
   }

--- a/plugins/plugin-x/src/services/x.service.ts
+++ b/plugins/plugin-x/src/services/x.service.ts
@@ -1000,7 +1000,15 @@ export class XService extends Service {
     const messages = await this.listRecentDirectMessages(
       accountId,
       clampLimit(params.limit, 25, 50),
-    ).catch(() => []);
+    ).catch((error) => {
+      // error-policy:J7 a DM fetch failure (expired token, rate limit) must
+      // surface to the agent rather than reading as an empty inbox; degrade to
+      // no messages after reporting.
+      runtime.reportError("XService.fetchConnectorMessages", error, {
+        accountId,
+      });
+      return [];
+    });
 
     return messages
       .filter((message) => !targetUserId || message.senderId === targetUserId)
@@ -1053,7 +1061,15 @@ export class XService extends Service {
   ): Promise<MessageConnectorTarget[]> {
     const accountId = this.resolveAccountId(_context.target, _context);
     const messages = await this.listRecentDirectMessages(accountId, 25).catch(
-      () => [],
+      (error) => {
+        // error-policy:J7 a DM fetch failure must surface to the agent rather
+        // than reading as no recent targets; degrade to an empty list after
+        // reporting.
+        this.runtime.reportError("XService.listRecentConnectorTargets", error, {
+          accountId,
+        });
+        return [];
+      },
     );
     const seen = new Set<string>();
     const targets: MessageConnectorTarget[] = [];
@@ -1106,6 +1122,8 @@ export class XService extends Service {
         metadata: { xUserId: profile.id, bio: profile.bio, accountId },
       };
     } catch {
+      // error-policy:J4 an unresolved handle (unknown user) yields no context;
+      // fetchProfile throwing IS the "not found" answer for this lookup.
       return null;
     }
   }

--- a/plugins/plugin-xr/src/__tests__/audio-pipeline.test.ts
+++ b/plugins/plugin-xr/src/__tests__/audio-pipeline.test.ts
@@ -6,6 +6,7 @@ import { AudioPipeline } from "../services/audio-pipeline.ts";
 function makeRuntime(transcriptResult = "hello world"): IAgentRuntime {
 	return {
 		useModel: vi.fn().mockResolvedValue(transcriptResult),
+		reportError: vi.fn(),
 	} as unknown as IAgentRuntime;
 }
 
@@ -67,6 +68,28 @@ describe("AudioPipeline", () => {
 		pipeline.push("conn1", header, Buffer.alloc(1024));
 		await pipeline.flush("conn1");
 
+		expect(onTranscript).not.toHaveBeenCalled();
+	});
+
+	it("surfaces a transcription failure via runtime.reportError instead of swallowing it", async () => {
+		const boom = new Error("TRANSCRIPTION model unavailable");
+		(runtime.useModel as ReturnType<typeof vi.fn>).mockRejectedValue(boom);
+		const header = {
+			type: "audio" as const,
+			ts: 0,
+			sampleRate: 16000,
+			encoding: "webm-opus" as const,
+		};
+		pipeline.push("conn1", header, Buffer.alloc(1024, 0x55));
+
+		// flush must not throw — the streaming loop keeps running…
+		await expect(pipeline.flush("conn1")).resolves.toBeUndefined();
+		// …but the failure must surface observably, not read as "no speech".
+		expect(runtime.reportError).toHaveBeenCalledWith(
+			"AudioPipeline.flush",
+			boom,
+			{ connectionId: "conn1" },
+		);
 		expect(onTranscript).not.toHaveBeenCalled();
 	});
 

--- a/plugins/plugin-xr/src/services/audio-pipeline.ts
+++ b/plugins/plugin-xr/src/services/audio-pipeline.ts
@@ -107,8 +107,11 @@ export class AudioPipeline {
 				await this.onTranscript(connectionId, text);
 			}
 		} catch (err) {
-			// log but don't crash the pipeline
-			console.error("[plugin-xr] transcription error:", err);
+			// error-policy:J7 diagnostics-must-not-kill-the-loop — one utterance's
+			// TRANSCRIPTION failure must not tear down the streaming audio pipeline,
+			// but a systemic model misconfiguration must not stay invisible (it was
+			// only console.error before). Surface it so it reaches the error surface.
+			this.runtime.reportError("AudioPipeline.flush", err, { connectionId });
 		}
 	}
 

--- a/plugins/plugin-xr/src/services/xr-session-service.ts
+++ b/plugins/plugin-xr/src/services/xr-session-service.ts
@@ -8,6 +8,7 @@ import type {
 import {
 	ChannelType,
 	createMessageMemory,
+	logger,
 	ModelType,
 	Service,
 } from "@elizaos/core";
@@ -69,11 +70,13 @@ export class XRSessionService extends Service {
 
 		this.wss.on("connection", (ws: WebSocket) => this.onConnect(runtime, ws));
 		this.wss.on("error", (err: Error) =>
-			console.error("[plugin-xr] WebSocket server error:", err),
+			// A server-level socket error (e.g. port already in use) is systemic and
+			// must surface to the agent/owner, not just a log line.
+			runtime.reportError("XRSessionService.wss", err),
 		);
 
-		console.info(
-			`[plugin-xr] WebSocket server listening on ws://localhost:${port}`,
+		logger.info(
+			`[XRSessionService] WebSocket server listening on ws://localhost:${port}`,
 		);
 	}
 
@@ -194,7 +197,10 @@ export class XRSessionService extends Service {
 					this.handleTextMessage(runtime, connId, ws, raw);
 				}
 			} catch (err) {
-				console.error("[plugin-xr] message handler error:", err);
+				// error-policy:J1 boundary translation — the WS message transport
+				// boundary. A single malformed/failed frame from an untrusted headset
+				// client must not kill the connection, but the failure must surface.
+				runtime.reportError("XRSessionService.onMessage", err, { connId });
 			}
 		});
 
@@ -203,11 +209,14 @@ export class XRSessionService extends Service {
 			this.audioPipeline.clear(connId);
 			this.visionPipeline.clear(connId);
 			this.connections.delete(connId);
-			console.info(`[plugin-xr] device disconnected: ${connId}`);
+			logger.info(`[XRSessionService] device disconnected: ${connId}`);
 		});
 
 		ws.on("error", (err: Error) =>
-			console.error(`[plugin-xr] ws error on ${connId}:`, err),
+			// error-policy:J5 unhandled-rejection suppression — a per-connection ws
+			// transport error (ECONNRESET etc.) precedes 'close'; the session is torn
+			// down there. Log so it is observable without escalating benign drops.
+			logger.warn(`[XRSessionService] ws error on ${connId}:`, err),
 		);
 	}
 
@@ -233,7 +242,7 @@ export class XRSessionService extends Service {
 			this.connections.set(connId, conn);
 			ws.send(JSON.stringify({ type: "ready", sessionId: connId }));
 			void this.ensureEntities(runtime, conn);
-			console.info(`[plugin-xr] ${msg.deviceType} connected: ${connId}`);
+			logger.info(`[XRSessionService] ${msg.deviceType} connected: ${connId}`);
 			return;
 		}
 
@@ -243,18 +252,18 @@ export class XRSessionService extends Service {
 		}
 
 		if (msg.type === "view_ready") {
-			console.info(`[plugin-xr] view ready on ${connId}: ${msg.viewId}`);
+			logger.info(`[XRSessionService] view ready on ${connId}: ${msg.viewId}`);
 			return;
 		}
 
 		if (msg.type === "view_closed") {
-			console.info(`[plugin-xr] view closed on ${connId}: ${msg.viewId}`);
+			logger.info(`[XRSessionService] view closed on ${connId}: ${msg.viewId}`);
 			return;
 		}
 
 		if (msg.type === "view_event") {
-			console.info(
-				`[plugin-xr] view event on ${connId}:`,
+			logger.info(
+				`[XRSessionService] view event on ${connId}:`,
 				msg.viewId,
 				msg.event,
 			);
@@ -338,7 +347,10 @@ export class XRSessionService extends Service {
 					: Buffer.from(audio as ArrayBuffer);
 				this.sendAudio(connectionId, audioBuf);
 			} catch (err) {
-				console.error("[plugin-xr] TTS error:", err);
+				// error-policy:J7 diagnostics-must-not-kill-the-loop — TEXT_TO_SPEECH
+				// failure must not drop the (already-sent) text response, but a
+				// systemic model misconfiguration must not stay invisible.
+				runtime.reportError("XRSessionService.tts", err, { connectionId });
 			}
 
 			// Persist agent response as memory
@@ -382,7 +394,12 @@ export class XRSessionService extends Service {
 			await runtime.addParticipant(conn.entityId, conn.roomId);
 			await runtime.addParticipant(runtime.agentId, conn.roomId);
 		} catch (err) {
-			console.error("[plugin-xr] entity setup error:", err);
+			// error-policy:J7 diagnostics-must-not-kill-the-loop — entity/room setup
+			// runs fire-and-forget off the hello handshake; a failure here silently
+			// breaks memory persistence for the session, so it must surface.
+			runtime.reportError("XRSessionService.ensureEntities", err, {
+				connId: conn.id,
+			});
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Completes the fallback-slop long-tail sweep for the social/media/market/safety plugins (#12748, parent #12182). Fabricating-catch and swallow-only sites triaged against the error-policy rubric — failures now surface observably.

### Behavior fixes (failures no longer masquerade as empty/zero/success)
- **plugin-facewear** vision-pipeline: `describeFrame` no longer swallows an IMAGE_DESCRIPTION model failure into `null` (which `XR_QUERY_VISION` rendered as the false "No recent camera frame available") — it propagates so the failure reaches the planner loop; `null` is reserved for a genuinely missing/stale frame.
- **plugin-facewear** audio-pipeline / xr-session-service: transcription, TTS, entity-bootstrap, per-message and wss handlers now `runtime.reportError` instead of swallowing.
- **plugin-social-alpha**: `getCurrentPrice` surfaces (`reportError`) + rethrows a price-fetch failure instead of returning a **fabricated `0`** (which read as a −100% return in P&L/trust scoring); `DexscreenerClient.search` propagates a transport failure instead of empty pairs.
- **plugin-wallet-ui**: a wallet-balance load failure surfaces instead of rendering an empty **$0** wallet.
- **plugin-hyperliquid**: a 200 response with a non-JSON body surfaces instead of a fabricated empty read.
- **plugin-x** PostService: a `getPosts` fetch failure surfaces via `reportError` instead of silently returning `[]`.
- **plugin-shopify** view-helpers: 404 → null, non-OK body throws the message, malformed 200 body surfaces instead of null.

`console`→logger: 13 server-side `console.*` in plugin-facewear converted to the `@elizaos/core` logger / `runtime.reportError`. Browser/WebXR client bundles (`app-xr`) keep `console` — it is the only sink there (documented).

## Validation
- **Real failure-path tests added and PASSING locally**: facewear `xr-pipeline-error-paths` (3/3), social-alpha `clients.failure` (2/2) + `getCurrentPrice` fabricated-0 (1/1), shopify `view-helpers` (3/3). wallet-ui / hyperliquid / plugin-x provider-error tests run in CI (a sparse review worktree can't build `@elizaos/ui` / resolve all msw deps).
- `node packages/scripts/error-policy-ratchet.mjs` → **`no new fallback-slop in touched files`**.
- `bunx @biomejs/biome check` on changed files → clean.

### Scoped-out (triaged + documented, not left untriaged)
plugin-social-alpha's ~18 internal read helpers (`getPositionsByEntity`, `getTransactionsByToken`, `getEntityMetrics`, …) catch → `logger.error` → return `[]`/`null` feeding trust/P&L. They **already surface observably via `logger.error`**; converting the 3900-line financial service to rethrow/`reportError` is a dedicated tested pass, not a blind mass-rethrow here. Only the unambiguous score-corrupting `getCurrentPrice` (fabricated `0`) was fixed in this sweep.

## Evidence rows
- Real-LLM trajectory — N/A (connector/service error-handling; failure-path tests exercise the real reject → surface paths). Screenshots/video — N/A (error events/states surfaced to listeners, verified by test).

Closes #12748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)