### PR TITLE
fix(computeruse): reject malformed AT-SPI scan payloads

### DIFF
--- a/plugins/plugin-computeruse/src/actor/brain.ts
+++ b/plugins/plugin-computeruse/src/actor/brain.ts
@@ -273,7 +273,8 @@ export class Brain {
     sceneSignature: string,
   ): BrainOutput | null {
     for (let i = this.dhashCache.length - 1; i >= 0; i--) {
-      const entry = this.dhashCache[i]!;
+      const entry = this.dhashCache[i];
+      if (!entry) continue;
       if (
         entry.goal === goal &&
         entry.sceneSignature === sceneSignature &&

--- a/plugins/plugin-computeruse/src/scene/a11y-provider.error-policy.test.ts
+++ b/plugins/plugin-computeruse/src/scene/a11y-provider.error-policy.test.ts
@@ -224,6 +224,10 @@ describe("scan payload parsers (untrusted embedded-script output)", () => {
     expect(() => parseLinuxAtspiPayload("[]")).toThrow();
     expect(() => parseLinuxAtspiPayload("not json")).toThrow();
     expect(() => parseLinuxAtspiPayload("")).toThrow();
+    expect(() => parseLinuxAtspiPayload("{}")).toThrow();
+    expect(() =>
+      parseLinuxAtspiPayload(JSON.stringify({ nodes: [] })),
+    ).toThrow();
   });
 });
 

--- a/plugins/plugin-computeruse/src/scene/a11y-provider.ts
+++ b/plugins/plugin-computeruse/src/scene/a11y-provider.ts
@@ -418,14 +418,26 @@ export function parseLinuxAtspiPayload(text: string): {
   if (obj.unavailable === true) {
     return { nodes: [], failedWindows: 0, totalWindows: 0, unavailable: true };
   }
-  const rawNodes = Array.isArray(obj.nodes) ? obj.nodes : [];
-  const nodes = rawNodes
+  if (!Array.isArray(obj.nodes)) {
+    throw new Error("AT-SPI payload is missing a nodes array");
+  }
+  const failedWindows = Number(obj.failed);
+  const totalWindows = Number(obj.total);
+  if (
+    !Number.isFinite(failedWindows) ||
+    !Number.isFinite(totalWindows) ||
+    failedWindows < 0 ||
+    totalWindows < 0
+  ) {
+    throw new Error("AT-SPI payload is missing valid failed/total counts");
+  }
+  const nodes = obj.nodes
     .filter((n) => n && typeof n === "object")
     .map((n, i) => mapAtspiNode(n as Record<string, unknown>, i));
   return {
     nodes,
-    failedWindows: Number(obj.failed) || 0,
-    totalWindows: Number(obj.total) || 0,
+    failedWindows,
+    totalWindows,
     unavailable: false,
     ...(typeof obj.error === "string" && obj.error !== ""
       ? { error: obj.error }


### PR DESCRIPTION
Follow-up to #13323 / #12273 found during cross-review before the branch merged. The merged Linux AT-SPI parser still accepted malformed object payloads like `{}` or `{ "nodes": [] }` as a clean empty scan by defaulting missing `failed`/`total` to zero. That recreates the same risk class: untrusted AT-SPI output can look like a healthy empty desktop.

## Change

- `parseLinuxAtspiPayload` now accepts only:
  - the explicit designed failover `{ unavailable: true }`, or
  - a real scan object with `nodes` array plus finite non-negative `failed` and `total` counts.
- Malformed objects throw, so the caller records `stats.error` and the scene builder reports `Computeruse.a11yScan` instead of fabricating a clean scan.
- Removed one non-null assertion in touched `brain.ts` so changed-file Biome is clean.

## Verification

- `TMPDIR=/private/tmp/codex-test-tmp bun run --cwd plugins/plugin-computeruse test -- src/scene/a11y-provider.error-policy.test.ts` -> 14 passed, 1 skipped
- `bun run --cwd plugins/plugin-computeruse typecheck` -> passed
- `git diff --name-only -z origin/develop...HEAD | xargs -0 bunx @biomejs/biome check` -> passed
- `git diff --check origin/develop...HEAD` -> passed
- `bun run audit:error-policy-ratchet` -> passed

Advances #12273.