### PR TITLE
fix(#13106): make My Runtimes the runtime switcher

### DIFF
--- a/packages/ui/src/components/settings/RuntimeSettingsSection.test.tsx
+++ b/packages/ui/src/components/settings/RuntimeSettingsSection.test.tsx
@@ -1,21 +1,16 @@
 // @vitest-environment jsdom
 /**
- * Covers the Settings > Runtime cloud/local rows: when a matching saved
- * profile exists, switching must use the non-destructive runtime switch instead
- * of re-entering first-run and clearing the active runtime state.
+ * RuntimeSettingsSection is now a status/entry-point surface. My Runtimes owns
+ * saved local/cloud/remote switching and remote host add, so this section must
+ * not keep its own duplicate remote-connect form or coarse switcher.
  */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentProfile } from "../../state/agent-profile-types";
 
 const mocks = vi.hoisted(() => ({
-  loadAgentProfileRegistry: vi.fn(),
-  switchRuntimeNonDestructive: vi.fn(() => ({ ok: true })),
-  reloadIntoFirstRunRuntime: vi.fn(),
-  refetchRuntimeMode: vi.fn(),
-  loadPersistedActiveServer: vi.fn(),
   isStoreBuild: vi.fn(() => false),
-  isAndroidCloudBuild: vi.fn(() => false),
+  isElectrobunRuntime: vi.fn(() => false),
+  loadPersistedActiveServer: vi.fn(),
 }));
 
 vi.mock("../../agent-surface", () => ({
@@ -29,15 +24,11 @@ vi.mock("../../bridge/electrobun-rpc", () => ({
 }));
 
 vi.mock("../../bridge/electrobun-runtime", () => ({
-  isElectrobunRuntime: () => false,
+  isElectrobunRuntime: mocks.isElectrobunRuntime,
 }));
 
 vi.mock("../../build-variant", () => ({
   isStoreBuild: mocks.isStoreBuild,
-}));
-
-vi.mock("../../platform/android-runtime", () => ({
-  isAndroidCloudBuild: mocks.isAndroidCloudBuild,
 }));
 
 vi.mock("../../hooks/useRuntimeMode", () => ({
@@ -47,20 +38,24 @@ vi.mock("../../hooks/useRuntimeMode", () => ({
     isLocalOnly: false,
     isCloudMode: false,
     isRemoteMode: false,
-    refetch: mocks.refetchRuntimeMode,
+    refetch: vi.fn(),
   }),
 }));
 
 vi.mock("../../state", () => ({
-  loadAgentProfileRegistry: mocks.loadAgentProfileRegistry,
-  switchRuntimeNonDestructive: mocks.switchRuntimeNonDestructive,
   useAppSelector: (
     selector: (state: {
-      t: (key: string, options?: { defaultValue?: string }) => string;
+      t: (
+        key: string,
+        options?: { defaultValue?: string; mode?: string },
+      ) => string;
     }) => unknown,
   ) =>
     selector({
-      t: (_key, options) => options?.defaultValue ?? _key,
+      t: (key, options) => {
+        const value = options?.defaultValue ?? key;
+        return options?.mode ? value.replace("{{mode}}", options.mode) : value;
+      },
     }),
 }));
 
@@ -68,140 +63,54 @@ vi.mock("../../state/persistence", () => ({
   loadPersistedActiveServer: mocks.loadPersistedActiveServer,
 }));
 
-vi.mock("../../first-run/reload-into-first-run-runtime", () => ({
-  reloadIntoFirstRunRuntime: mocks.reloadIntoFirstRunRuntime,
-}));
-
 import { RuntimeSettingsSection } from "./RuntimeSettingsSection";
 
-const LOCAL_PROFILE: AgentProfile = {
-  id: "local-1",
-  label: "This device",
-  kind: "local",
-  createdAt: "2026-06-01T00:00:00.000Z",
-};
-
-const CLOUD_PROFILE: AgentProfile = {
-  id: "cloud-1",
-  label: "Cloud agent",
-  kind: "cloud",
-  apiBase: "https://x.agent.elizacloud.ai",
-  accessToken: "cloud-token",
-  createdAt: "2026-06-02T00:00:00.000Z",
-};
-
-const MOBILE_LOCAL_PROFILE: AgentProfile = {
-  id: "mobile-local-1",
-  label: "On-device agent",
-  kind: "remote",
-  apiBase: "eliza-local-agent://ipc",
-  createdAt: "2026-06-03T00:00:00.000Z",
-};
-
-function seedRegistry(
-  profiles: AgentProfile[],
-  activeProfileId: string | null,
-) {
-  mocks.loadAgentProfileRegistry.mockReturnValue({
-    version: 1,
-    activeProfileId,
-    profiles,
-  });
-}
-
-function clickRuntimeRow(name: string) {
-  fireEvent.click(screen.getByRole("button", { name }));
-}
-
-describe("RuntimeSettingsSection runtime switching", () => {
+describe("RuntimeSettingsSection IA", () => {
   beforeEach(() => {
-    mocks.loadAgentProfileRegistry.mockReset();
-    mocks.switchRuntimeNonDestructive.mockReset();
-    mocks.switchRuntimeNonDestructive.mockReturnValue({ ok: true });
-    mocks.reloadIntoFirstRunRuntime.mockReset();
-    mocks.refetchRuntimeMode.mockReset();
-    mocks.loadPersistedActiveServer.mockReset();
-    mocks.loadPersistedActiveServer.mockReturnValue(null);
+    window.history.replaceState(null, "", "#runtime");
     mocks.isStoreBuild.mockReturnValue(false);
-    mocks.isAndroidCloudBuild.mockReturnValue(false);
+    mocks.isElectrobunRuntime.mockReturnValue(false);
+    mocks.loadPersistedActiveServer.mockReset();
+    mocks.loadPersistedActiveServer.mockReturnValue({
+      id: "cloud:agent-1",
+      label: "Trading bot",
+      kind: "cloud",
+      apiBase: "https://x.agent.elizacloud.ai",
+    });
   });
 
   afterEach(() => {
     cleanup();
+    window.history.replaceState(null, "", "#");
   });
 
-  it("switches to a saved cloud profile without re-entering first-run", () => {
-    seedRegistry([LOCAL_PROFILE, CLOUD_PROFILE], "local-1");
-
+  it("shows current runtime status and a single My Runtimes entry point", () => {
     render(<RuntimeSettingsSection />);
-    clickRuntimeRow("Cloud agent");
 
-    expect(mocks.switchRuntimeNonDestructive).toHaveBeenCalledWith("cloud-1");
-    expect(mocks.reloadIntoFirstRunRuntime).not.toHaveBeenCalled();
-    expect(mocks.refetchRuntimeMode).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Current mode: Trading bot")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /My Runtimes/ })).toBeTruthy();
   });
 
-  it("switches to a saved desktop local profile without re-entering first-run", () => {
-    seedRegistry([CLOUD_PROFILE, LOCAL_PROFILE], "cloud-1");
+  it("opens the canonical My Runtimes section through settings hash navigation", () => {
+    const onHashChange = vi.fn();
+    window.addEventListener("hashchange", onHashChange);
+    try {
+      render(<RuntimeSettingsSection />);
 
-    render(<RuntimeSettingsSection />);
-    clickRuntimeRow("Local");
+      fireEvent.click(screen.getByRole("button", { name: /My Runtimes/ }));
 
-    expect(mocks.switchRuntimeNonDestructive).toHaveBeenCalledWith("local-1");
-    expect(mocks.reloadIntoFirstRunRuntime).not.toHaveBeenCalled();
-    expect(mocks.refetchRuntimeMode).toHaveBeenCalledTimes(1);
+      expect(window.location.hash).toBe("#my-runtimes");
+      expect(onHashChange).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener("hashchange", onHashChange);
+    }
   });
 
-  it("treats a mobile IPC profile as the saved local runtime", () => {
-    seedRegistry([CLOUD_PROFILE, MOBILE_LOCAL_PROFILE], "cloud-1");
-
+  it("does not expose the old standalone remote-connect controls", () => {
     render(<RuntimeSettingsSection />);
-    clickRuntimeRow("Local");
 
-    expect(mocks.switchRuntimeNonDestructive).toHaveBeenCalledWith(
-      "mobile-local-1",
-    );
-    expect(mocks.reloadIntoFirstRunRuntime).not.toHaveBeenCalled();
-    expect(mocks.refetchRuntimeMode).toHaveBeenCalledTimes(1);
-  });
-
-  it("does nothing when the user clicks the already-active cloud row", () => {
-    seedRegistry([LOCAL_PROFILE, CLOUD_PROFILE], "cloud-1");
-    mocks.loadPersistedActiveServer.mockReturnValue({
-      id: "cloud:agent-1",
-      label: "Cloud agent",
-      kind: "cloud",
-      apiBase: "https://x.agent.elizacloud.ai",
-      accessToken: "cloud-token",
-    });
-
-    render(<RuntimeSettingsSection />);
-    clickRuntimeRow("Cloud agent");
-
-    expect(mocks.switchRuntimeNonDestructive).not.toHaveBeenCalled();
-    expect(mocks.reloadIntoFirstRunRuntime).not.toHaveBeenCalled();
-    expect(mocks.refetchRuntimeMode).not.toHaveBeenCalled();
-  });
-
-  it("falls back to first-run when no saved cloud profile exists", () => {
-    seedRegistry([LOCAL_PROFILE], "local-1");
-
-    render(<RuntimeSettingsSection />);
-    clickRuntimeRow("Cloud agent");
-
-    expect(mocks.switchRuntimeNonDestructive).not.toHaveBeenCalled();
-    expect(mocks.reloadIntoFirstRunRuntime).toHaveBeenCalledWith("cloud");
-    expect(mocks.refetchRuntimeMode).not.toHaveBeenCalled();
-  });
-
-  it("falls back to first-run when no saved local profile exists", () => {
-    seedRegistry([CLOUD_PROFILE], "cloud-1");
-
-    render(<RuntimeSettingsSection />);
-    clickRuntimeRow("Local");
-
-    expect(mocks.switchRuntimeNonDestructive).not.toHaveBeenCalled();
-    expect(mocks.reloadIntoFirstRunRuntime).toHaveBeenCalledWith("local");
-    expect(mocks.refetchRuntimeMode).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: "Remote" })).toBeNull();
+    expect(screen.queryByTestId("settings-remote-address")).toBeNull();
+    expect(screen.queryByTestId("settings-remote-connect")).toBeNull();
   });
 });

--- a/packages/ui/src/components/settings/RuntimeSettingsSection.tsx
+++ b/packages/ui/src/components/settings/RuntimeSettingsSection.tsx
@@ -1,13 +1,12 @@
 /**
  * Settings → Runtime section (the `runtime` section id). Shows where the agent
  * currently runs (local / remote / cloud, from `GET /api/runtime/mode` with a
- * local heuristic fallback) and lets the user switch targets: connect to a
- * remote agent URL+token, or migrate the desktop state dir / pick a workspace
- * folder via the Electrobun bridge. The Local option is hidden on builds that
- * ship without an on-device runtime (store build, Android cloud build).
+ * local heuristic fallback) and points runtime switching to the canonical
+ * My Runtimes section. Store builds keep the one-time desktop-state import
+ * behind Advanced because that is a migration tool, not a switcher.
  */
 
-import { Cloud, Laptop, type LucideIcon, RadioTower } from "lucide-react";
+import { Server } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import {
@@ -17,136 +16,50 @@ import {
 } from "../../bridge/electrobun-rpc";
 import { isElectrobunRuntime } from "../../bridge/electrobun-runtime";
 import { isStoreBuild } from "../../build-variant";
-import { CONNECT_EVENT, dispatchAppEvent } from "../../events";
-import { normalizeRemoteAgentUrl } from "../../first-run/adopt-remote-first-run";
 import { readPersistedMobileRuntimeMode } from "../../first-run/mobile-runtime-mode";
-import {
-  type FirstRunReloadTarget,
-  reloadIntoFirstRunRuntime,
-} from "../../first-run/reload-into-first-run-runtime";
 import { useRuntimeMode } from "../../hooks/useRuntimeMode";
-import { isAndroidCloudBuild } from "../../platform/android-runtime";
-import {
-  type AgentProfile,
-  loadAgentProfileRegistry,
-  switchRuntimeNonDestructive,
-  useAppSelector,
-} from "../../state";
+import { useAppSelector } from "../../state";
 import {
   type AgentRuntimeTargetKind,
   inferAgentRuntimeTarget,
-  isLocalAgentApiBase,
 } from "../../state/agent-runtime-target";
 import { loadPersistedActiveServer } from "../../state/persistence";
-import { Input } from "../ui/input";
 import { AdvancedToggle } from "./AdvancedToggle";
 import { useAdvancedSettingsEnabled } from "./AdvancedToggle.hooks";
 import { SettingsActionButton } from "./settings-agent-rows";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
 
-function RuntimeModeRow({
-  target,
-  icon,
-  label,
-  description,
-  active,
-  disabled,
-  onSelect,
-}: {
-  target: FirstRunReloadTarget;
-  icon: LucideIcon;
-  label: string;
-  description?: string;
-  active: boolean;
-  disabled: boolean;
-  onSelect: () => void;
-}) {
-  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
-    id: `runtime-mode-${target}`,
-    role: "card",
-    label,
-    description,
-    group: "runtime-mode",
-    status: active ? "active" : "inactive",
-    onActivate: disabled ? undefined : onSelect,
-  });
-  return (
-    <SettingsRow
-      icon={icon}
-      label={label}
-      description={description}
-      active={active}
-      disabled={disabled}
-      onClick={onSelect}
-      buttonRef={ref}
-      buttonProps={agentProps}
-    />
-  );
-}
-
-type RuntimeAction = {
-  target: FirstRunReloadTarget;
-  label: string;
-  icon: LucideIcon;
-  disabled?: boolean;
-  disabledReason?: string;
-};
-
 const STORE_LOCAL_DISABLED_DOCS_URL =
   "https://github.com/eliza-ai/eliza/blob/develop/docs/desktop/build-variants.md";
+const MY_RUNTIMES_SECTION_ID = "my-runtimes";
 
-function profileMatchesRuntimeTarget(
-  profile: AgentProfile,
-  target: FirstRunReloadTarget,
-): boolean {
-  if (target === "cloud") {
-    return profile.kind === "cloud";
+function openSettingsSection(sectionId: string): void {
+  if (typeof window === "undefined") return;
+  const nextHash = `#${sectionId}`;
+  if (window.location.hash !== nextHash) {
+    window.history.replaceState(null, "", nextHash);
   }
-  if (target === "local") {
-    return (
-      profile.kind === "local" ||
-      (profile.kind === "remote" && isLocalAgentApiBase(profile.apiBase))
-    );
-  }
-  return false;
-}
-
-function profileRecency(profile: AgentProfile): number {
-  const value = Date.parse(profile.lastConnectedAt ?? profile.createdAt);
-  return Number.isFinite(value) ? value : 0;
-}
-
-export function findSavedRuntimeProfileForTarget(
-  target: FirstRunReloadTarget,
-): AgentProfile | null {
-  if (target === "remote") return null;
-
-  const registry = loadAgentProfileRegistry();
-  const activeProfile = registry.profiles.find(
-    (profile) => profile.id === registry.activeProfileId,
-  );
-  if (activeProfile && profileMatchesRuntimeTarget(activeProfile, target)) {
-    return activeProfile;
-  }
-
-  return (
-    registry.profiles
-      .filter((profile) => profileMatchesRuntimeTarget(profile, target))
-      .sort((a, b) => profileRecency(b) - profileRecency(a))[0] ?? null
-  );
+  window.dispatchEvent(new Event("hashchange"));
 }
 
 export function RuntimeSettingsSection() {
   const t = useAppSelector((s) => s.t);
-  const { state: runtimeModeState, refetch: refetchRuntimeMode } =
-    useRuntimeMode();
+  const { state: runtimeModeState } = useRuntimeMode();
   const advancedEnabled = useAdvancedSettingsEnabled();
   const [migrationMessage, setMigrationMessage] = useState<string | null>(null);
   const [migrationBusy, setMigrationBusy] = useState(false);
-  const [remoteFormOpen, setRemoteFormOpen] = useState(false);
-  const [remoteUrl, setRemoteUrl] = useState("");
-  const [remoteToken, setRemoteToken] = useState("");
-  const [remoteError, setRemoteError] = useState<string | null>(null);
+  const handleOpenMyRuntimes = useCallback(() => {
+    openSettingsSection(MY_RUNTIMES_SECTION_ID);
+  }, []);
+  const { ref: manageRuntimesRef, agentProps: manageRuntimesAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "runtime-manage-runtimes",
+      role: "button",
+      label: "My Runtimes",
+      description: "Open the canonical runtime list and switcher",
+      group: "runtime",
+      onActivate: handleOpenMyRuntimes,
+    });
 
   // Prefer the authoritative server snapshot (`GET /api/runtime/mode`); fall
   // back to the local heuristic when it is loading or unreachable.
@@ -162,102 +75,6 @@ export function RuntimeSettingsSection() {
   }, [runtimeModeState]);
 
   const storeBuild = isStoreBuild();
-  const localDisabledReason = storeBuild
-    ? t("settings.runtime.localDisabledStore", {
-        defaultValue:
-          "Local agent requires the direct download build. Open docs for details.",
-      })
-    : undefined;
-
-  // The Play-Store Android build (`build:android:cloud`) ships without an
-  // on-device agent runtime, so the Local option must be hidden there.
-  const cloudOnly = isAndroidCloudBuild();
-
-  const actions = useMemo<RuntimeAction[]>(() => {
-    const base: RuntimeAction[] = [
-      {
-        target: "cloud",
-        label: t("settings.runtime.cloudLabel", {
-          defaultValue: "Cloud agent",
-        }),
-        icon: Cloud,
-      },
-    ];
-    if (!cloudOnly) {
-      base.push({
-        target: "local",
-        label: t("settings.runtime.localLabel", {
-          defaultValue: "Local",
-        }),
-        icon: Laptop,
-        disabled: storeBuild,
-        disabledReason: localDisabledReason,
-      });
-    }
-    base.push({
-      target: "remote",
-      label: t("settings.runtime.remoteLabel", {
-        defaultValue: "Remote",
-      }),
-      icon: RadioTower,
-    });
-    return base;
-  }, [t, cloudOnly, storeBuild, localDisabledReason]);
-
-  const handleSwitch = useCallback(
-    (target: FirstRunReloadTarget) => {
-      // Remote no longer routes through first-run (post-#9952 there is no
-      // remote URL capture there); instead it reveals an inline "connect a
-      // remote agent" form that points the app straight at a host via the
-      // hardened CONNECT_EVENT path.
-      if (target === "remote") {
-        setRemoteError(null);
-        setRemoteFormOpen((open) => !open);
-        return;
-      }
-      if (currentRuntime.kind === target) {
-        return;
-      }
-
-      const savedProfile = findSavedRuntimeProfileForTarget(target);
-      if (savedProfile) {
-        const result = switchRuntimeNonDestructive(savedProfile.id);
-        if (result.ok) {
-          refetchRuntimeMode();
-          return;
-        }
-      }
-
-      reloadIntoFirstRunRuntime(target);
-    },
-    [currentRuntime.kind, refetchRuntimeMode],
-  );
-
-  const handleConnectRemote = useCallback(() => {
-    let normalized: string;
-    try {
-      normalized = normalizeRemoteAgentUrl(remoteUrl);
-    } catch (error) {
-      setRemoteError(
-        error instanceof Error
-          ? error.message
-          : t("settings.runtime.remoteInvalidUrl", {
-              defaultValue: "Enter a valid remote agent URL.",
-            }),
-      );
-      return;
-    }
-    setRemoteError(null);
-    // skipConfirm: the user explicitly typed this URL in trusted Settings, so the
-    // OS-deep-link confirmation prompt is redundant. completeFirstRun: adopt the
-    // remote as the active runtime and land on home.
-    dispatchAppEvent(CONNECT_EVENT, {
-      gatewayUrl: normalized,
-      token: remoteToken.trim() || undefined,
-      completeFirstRun: true,
-      skipConfirm: true,
-    });
-  }, [remoteUrl, remoteToken, t]);
 
   const handleImportDirectState = useCallback(async () => {
     setMigrationBusy(true);
@@ -332,96 +149,23 @@ export function RuntimeSettingsSection() {
           mode: currentRuntime.label,
         })}
       >
-        {actions.map((action) => {
-          const active = currentRuntime.kind === action.target;
-          const disabled = action.disabled === true;
-          return (
-            <RuntimeModeRow
-              key={action.target}
-              target={action.target}
-              icon={action.icon}
-              label={action.label}
-              description={disabled ? action.disabledReason : undefined}
-              active={active}
-              disabled={disabled}
-              onSelect={() => handleSwitch(action.target)}
-            />
-          );
-        })}
-
-        {remoteFormOpen ? (
-          <SettingsRow
-            label={t("settings.runtime.remoteConnectLabel", {
-              defaultValue: "Connect a remote agent",
-            })}
-            description={t("settings.runtime.remoteConnectHelp", {
-              defaultValue:
-                "Enter the agent's URL — add an access token only if the host requires one.",
-            })}
-            stacked
-          >
-            <div className="flex flex-col gap-2">
-              <Input
-                type="url"
-                inputMode="url"
-                autoCapitalize="none"
-                autoCorrect="off"
-                spellCheck={false}
-                value={remoteUrl}
-                onChange={(event) => {
-                  setRemoteUrl(event.target.value);
-                  setRemoteError(null);
-                }}
-                placeholder="https://agent.example.com"
-                hasError={Boolean(remoteError)}
-                data-testid="settings-remote-address"
-                aria-label={t("settings.runtime.remoteConnectLabel", {
-                  defaultValue: "Connect a remote agent",
-                })}
-              />
-              <Input
-                type="password"
-                autoCapitalize="none"
-                autoCorrect="off"
-                spellCheck={false}
-                value={remoteToken}
-                onChange={(event) => setRemoteToken(event.target.value)}
-                placeholder={t("settings.runtime.remoteTokenPlaceholder", {
-                  defaultValue: "Access token (optional)",
-                })}
-                data-testid="settings-remote-token"
-                aria-label={t("settings.runtime.remoteTokenPlaceholder", {
-                  defaultValue: "Access token (optional)",
-                })}
-              />
-              {remoteError ? (
-                <p className="text-xs text-destructive" role="alert">
-                  {remoteError}
-                </p>
-              ) : null}
-              <SettingsActionButton
-                agentId="runtime-connect-remote"
-                agentLabel={t("settings.runtime.remoteConnectAction", {
-                  defaultValue: "Connect",
-                })}
-                type="button"
-                onClick={handleConnectRemote}
-                disabled={!remoteUrl.trim()}
-                className="h-11 w-fit rounded-md px-4 text-sm"
-                data-testid="settings-remote-connect"
-              >
-                {t("settings.runtime.remoteConnectAction", {
-                  defaultValue: "Connect",
-                })}
-              </SettingsActionButton>
-            </div>
-          </SettingsRow>
-        ) : null}
+        <SettingsRow
+          icon={Server}
+          label={t("settings.runtime.manageRuntimesLabel", {
+            defaultValue: "My Runtimes",
+          })}
+          description={t("settings.runtime.manageRuntimesHelp", {
+            defaultValue: "Saved local, cloud, and remote agents.",
+          })}
+          onClick={handleOpenMyRuntimes}
+          buttonRef={manageRuntimesRef}
+          buttonProps={manageRuntimesAgentProps}
+        />
       </SettingsGroup>
 
-      {/* The default surface is the runtime-mode picker above. The one-time
-          sandbox-import migration is an expert operation, so it lives behind the
-          shared advanced toggle rather than cluttering a fresh user's view. */}
+      {/* The default surface is runtime status above. The one-time sandbox-import
+          migration is an expert operation, so it lives behind the shared
+          advanced toggle rather than cluttering a fresh user's view. */}
       {storeBuild ? (
         <SettingsGroup>
           <SettingsRow


### PR DESCRIPTION
Summary
- Make Runtime a current-mode status and entry-point section instead of a duplicate local/cloud/remote switcher.
- Route runtime management to My Runtimes, which remains the canonical saved local/cloud/remote list, switcher, and remote-host add surface.
- Remove the standalone Runtime remote-connect form while keeping store-build sandbox import behind Advanced.
- Update RuntimeSettingsSection tests to pin the new IA and absence of duplicate remote controls.

Tests
- TMPDIR=/private/tmp/codex-test-tmp bun run --cwd packages/ui test -- src/components/settings/RuntimeSettingsSection.test.tsx src/components/cockpit/MyRuntimesContainer.test.tsx src/components/cockpit/MyRuntimesSection.test.tsx src/components/settings/settings-sections.registration.test.ts
- bunx @biomejs/biome check packages/ui/src/components/settings/RuntimeSettingsSection.tsx packages/ui/src/components/settings/RuntimeSettingsSection.test.tsx
- bun run audit:error-policy-ratchet
- bun run --cwd packages/ui typecheck (fails on existing src/hooks/useWhatsAppPairing.test.tsx:21 TS2556)

Visual check
- In-app browser screenshot could not be captured in this session because the browser plugin exposed no browser targets (agent.browsers.list() returned []).

Closes #13106