### PR TITLE
perf(app): iOS startup + view performance — take vendor-crypto off the boot path (iOS −15.5% / web −29% eager JS)

### DIFF
--- a/packages/app/scripts/verify-chunk-safety.mjs
+++ b/packages/app/scripts/verify-chunk-safety.mjs
@@ -146,6 +146,87 @@ console.log(
   `[verify-chunk-safety] OK: bn.js/crypto graph is confined to lazy vendor chunks (${referencedFiles.size} current chunks scanned).`,
 );
 
+// ── Boot-path eagerness guard ──
+// Confinement alone is not enough: `vendor-crypto` can be perfectly confined
+// yet still be a STATIC import of the entry chunk, which makes the browser
+// fetch + parse the whole multi-MB wallet graph before first paint on every
+// boot (web and the Capacitor iOS/Android WebView alike). The known cause is a
+// manual-chunk pin on a first-party module: Rollup folds a pinned module's
+// entire dependency subtree into the manual chunk, so pinning an app component
+// drags the shared @elizaos/core + UI graph — which the entry needs — into
+// `vendor-crypto`, and the entry then imports the chunk statically (#13187
+// residual). This guard walks the entry's static-import closure and fails if
+// any heavyweight lazy-by-design vendor chunk is reachable without a dynamic
+// `import()` boundary.
+const MUST_STAY_LAZY = /^vendor-(crypto|solana|wallet|three|vrm|draco|phonemizer)-/;
+
+function collectEntryStaticClosure() {
+  let indexHtml;
+  try {
+    indexHtml = readFileSync(indexHtmlPath, "utf8");
+  } catch {
+    return null;
+  }
+  const entryMatch = indexHtml.match(
+    /<script[^>]*type="module"[^>]*src="(?:\/?|\.\/)?(assets\/[^"]+\.js)"/,
+  );
+  if (!entryMatch) return null;
+  const entryFile = entryMatch[1].slice("assets/".length);
+
+  const seen = new Set([entryFile]);
+  const pending = [entryFile];
+  // Static edges only: `from"./x.js"`, bare `import"./x.js"`, and
+  // `export…from"./x.js"`. Dynamic `import("./x.js")` has a paren after
+  // `import`, so it never matches — dynamic boundaries end the walk.
+  const staticImportRe = /(?:from|import)\s*["'](\.\/[^"']+\.js)["']/g;
+  while (pending.length > 0) {
+    const file = pending.pop();
+    const filePath = path.join(distAssets, file);
+    if (!existsSync(filePath)) continue;
+    const body = readFileSync(filePath, "utf8");
+    let m = staticImportRe.exec(body);
+    while (m !== null) {
+      const dep = path.posix.normalize(m[1]).replace(/^\.\//, "");
+      if (dep.endsWith(".js") && !seen.has(dep)) {
+        seen.add(dep);
+        pending.push(dep);
+      }
+      m = staticImportRe.exec(body);
+    }
+    staticImportRe.lastIndex = 0;
+  }
+  return { entryFile, closure: seen };
+}
+
+const entryClosure = collectEntryStaticClosure();
+if (entryClosure) {
+  const eagerHeavy = [...entryClosure.closure].filter((f) =>
+    MUST_STAY_LAZY.test(f),
+  );
+  if (eagerHeavy.length > 0) {
+    console.error(
+      `[verify-chunk-safety] FAIL: lazy-by-design vendor chunk(s) are in the entry's STATIC import closure (fetched+parsed on every boot before first paint):`,
+    );
+    for (const f of eagerHeavy) console.error(`  - ${f}`);
+    console.error(
+      "\nMost likely a manual-chunk pin on a first-party source module: Rollup\n" +
+        "folds a pinned module's whole dependency subtree into the manual chunk,\n" +
+        "which captures the shared core/UI graph the entry needs and anchors the\n" +
+        "chunk into the boot path. Pin only node_modules/facade ids (see\n" +
+        "vite/wallet-chunk-matcher.ts) and keep first-party consumers behind\n" +
+        "dynamic import() boundaries. Do NOT deploy this bundle.",
+    );
+    process.exit(1);
+  }
+  console.log(
+    `[verify-chunk-safety] OK: entry static closure (${entryClosure.closure.size} chunks from ${entryClosure.entryFile}) contains no lazy-by-design vendor chunk.`,
+  );
+} else {
+  console.warn(
+    "[verify-chunk-safety] note: no module-script entry found in dist/index.html — skipping the eagerness guard.",
+  );
+}
+
 // ── Web SPA base regression guard ──
 // build:web sets ELIZA_WEB_ABSOLUTE_BASE=1 → Vite base "/". A relative base
 // ("./assets/…") boots fine at depth-1 routes (/, /login) but 404s its bundle

--- a/packages/app/scripts/verify-chunk-safety.mjs
+++ b/packages/app/scripts/verify-chunk-safety.mjs
@@ -158,7 +158,8 @@ console.log(
 // residual). This guard walks the entry's static-import closure and fails if
 // any heavyweight lazy-by-design vendor chunk is reachable without a dynamic
 // `import()` boundary.
-const MUST_STAY_LAZY = /^vendor-(crypto|solana|wallet|three|vrm|draco|phonemizer)-/;
+const MUST_STAY_LAZY =
+  /^vendor-(crypto|solana|wallet|three|vrm|draco|phonemizer)-/;
 
 function collectEntryStaticClosure() {
   let indexHtml;

--- a/packages/app/test/verify-chunk-safety.test.ts
+++ b/packages/app/test/verify-chunk-safety.test.ts
@@ -101,3 +101,71 @@ describe("verify-chunk-safety gate", () => {
     expect(output).toContain("OK");
   });
 });
+
+// The eagerness guard walks the entry's STATIC import closure from the
+// index.html module script; a confined-but-eager vendor-crypto (the #13187
+// manual-chunk fold: a pinned first-party module drags the shared core/UI
+// graph into vendor-crypto, so the entry statically imports the multi-MB
+// chunk at boot) must fail even though confinement passes.
+describe("verify-chunk-safety eagerness guard", () => {
+  function writeIndexHtml(entryFile: string): void {
+    writeFileSync(
+      join(workDir, "dist", "index.html"),
+      `<!doctype html><html><head><script type="module" crossorigin src="/assets/${entryFile}"></script></head><body></body></html>`,
+      "utf8",
+    );
+  }
+
+  it("FAILS when the entry statically imports vendor-crypto", () => {
+    writeChunk(
+      "index-D9yqvBmw.js",
+      'import{a}from"./vendor-crypto-DRnRpPYP.js";export const app=a;',
+    );
+    writeChunk(
+      "vendor-crypto-DRnRpPYP.js",
+      `export const a=1;function bn(){return ${CRYPTO_MARKER}}`,
+    );
+    writeIndexHtml("index-D9yqvBmw.js");
+
+    const { status, output } = runGate();
+    expect(status).toBe(1);
+    expect(output).toContain("STATIC import closure");
+    expect(output).toContain("vendor-crypto-DRnRpPYP.js");
+  });
+
+  it("FAILS when vendor-crypto is reached transitively through an eager sibling chunk", () => {
+    writeChunk(
+      "index-D9yqvBmw.js",
+      'import{s}from"./shared-Cabc1234.js";export const app=s;',
+    );
+    writeChunk(
+      "shared-Cabc1234.js",
+      'export{a as s}from"./vendor-crypto-DRnRpPYP.js";',
+    );
+    writeChunk(
+      "vendor-crypto-DRnRpPYP.js",
+      `export const a=1;function bn(){return ${CRYPTO_MARKER}}`,
+    );
+    writeIndexHtml("index-D9yqvBmw.js");
+
+    const { status, output } = runGate();
+    expect(status).toBe(1);
+    expect(output).toContain("vendor-crypto-DRnRpPYP.js");
+  });
+
+  it("PASSES when vendor-crypto is only reachable through a dynamic import()", () => {
+    writeChunk(
+      "index-D9yqvBmw.js",
+      'export const load=()=>import("./vendor-crypto-DRnRpPYP.js");',
+    );
+    writeChunk(
+      "vendor-crypto-DRnRpPYP.js",
+      `export const a=1;function bn(){return ${CRYPTO_MARKER}}`,
+    );
+    writeIndexHtml("index-D9yqvBmw.js");
+
+    const { status, output } = runGate();
+    expect(status).toBe(0);
+    expect(output).toContain("entry static closure");
+  });
+});

--- a/packages/app/test/wallet-optimized-chunk-matcher.test.ts
+++ b/packages/app/test/wallet-optimized-chunk-matcher.test.ts
@@ -59,11 +59,21 @@ describe("wallet optimized-deps chunk matcher", () => {
     }
   });
 
-  it("matches the direct crypto billing card that imports both wallet stacks", () => {
-    expect(
-      VENDOR_OPTIMIZED_WALLET_TEST.test(
-        "/repo/packages/ui/src/cloud/billing/components/direct-crypto-credit-card.tsx",
-      ),
-    ).toBe(true);
+  it("never matches first-party source (the manual-chunk fold would anchor vendor-crypto into the entry)", () => {
+    // Rollup folds a pinned module's whole dependency subtree into the manual
+    // chunk. Pinning an app component (the old direct-crypto-credit-card pin)
+    // dragged the shared @elizaos/core + UI graph into vendor-crypto, forcing
+    // the entry to statically import the multi-MB wallet chunk on every boot
+    // (#13187 residual). First-party consumers stay behind dynamic import()
+    // boundaries instead; scripts/verify-chunk-safety.mjs gates the bundle.
+    const firstPartyIds = [
+      "/repo/packages/ui/src/cloud/billing/components/direct-crypto-credit-card.tsx",
+      "/repo/packages/ui/src/cloud/billing/wallet/steward-wallet-providers.tsx",
+      "/repo/packages/core/dist/browser/index.browser.js",
+    ];
+
+    for (const id of firstPartyIds) {
+      expect(VENDOR_OPTIMIZED_WALLET_TEST.test(id), id).toBe(false);
+    }
   });
 });

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1407,6 +1407,23 @@ function resolveManualChunk(id: string): string | undefined {
     return "runtime-shims";
   }
 
+  // Self-contained leaf libraries needed EAGERLY by @elizaos/core's browser
+  // SOURCE graph (`utils/crypto-compat.ts` → @noble; runtime/services → uuid),
+  // which mobile builds bundle via USE_CORE_SOURCE_BROWSER_ENTRY, and that the
+  // pinned wallet stack also uses. Without an explicit assignment the
+  // manual-chunk fold captures them into `vendor-crypto`, anchoring the whole
+  // wallet chunk into the mobile entry's static import closure. They import
+  // nothing outside themselves, so the vendor-crypto → vendor-boot-leaves edge
+  // cannot form the cross-chunk init cycle the crypto pin guards against. On
+  // web (core resolves to its prebuilt dist bundle, which inlines these) the
+  // chunk is only reachable from vendor-crypto and stays lazy.
+  if (
+    normalizedId.includes("/node_modules/@noble/") ||
+    /\/node_modules\/uuid\//.test(normalizedId)
+  ) {
+    return "vendor-boot-leaves";
+  }
+
   if (VENDOR_OPTIMIZED_WALLET_TEST.test(normalizedId)) {
     return "vendor-crypto";
   }

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1389,6 +1389,24 @@ const VENDOR_DRACO_TEST = /\/node_modules\/draco3d(gltf)?\//;
 function resolveManualChunk(id: string): string | undefined {
   const normalizedId = id.split(path.sep).join("/");
 
+  // Build-generated leaf shims shared by the eager entry graph AND the pinned
+  // vendor-crypto graph: Vite's dynamic-import preload helper, the node-builtin
+  // browser stubs, and the buffer ESM shim. All are self-contained (no
+  // imports), so they can never form a cross-chunk cycle. Without an explicit
+  // assignment, Rollup FOLDS them into `vendor-crypto` (a pinned module's
+  // unassigned dependencies join the manual chunk), and any eager module that
+  // needs one — e.g. @elizaos/core's browser bundle importing the buffer shim,
+  // or any dynamic-importing entry module needing the preload helper — then
+  // statically imports the whole multi-MB wallet chunk at boot. The eagerness
+  // guard in scripts/verify-chunk-safety.mjs fails the build on that regression.
+  if (
+    normalizedId.includes("vite/preload-helper") ||
+    normalizedId.includes("native-stub:") ||
+    normalizedId.includes(BUFFER_ESM_SHIM_ID)
+  ) {
+    return "runtime-shims";
+  }
+
   if (VENDOR_OPTIMIZED_WALLET_TEST.test(normalizedId)) {
     return "vendor-crypto";
   }

--- a/packages/app/vite/wallet-chunk-matcher.ts
+++ b/packages/app/vite/wallet-chunk-matcher.ts
@@ -1,10 +1,16 @@
 // Vite's optimized-deps cache flattens scoped package names by replacing `/`
 // with `_` (for example `@solana/wallet-adapter-react-ui` becomes
 // `@solana_wallet-adapter-react-ui.js`). Rollup can also create virtual/CJS
-// facade ids named after wallet entry points such as `useWalletModal`. The
-// direct crypto billing card imports both the Solana modal and EVM wallet stack,
-// so pin that route-local component with the same graph as well. Otherwise
-// Rollup can emit an eager helper chunk named after `useWalletModal` and put the
-// bn.js graph there.
+// facade ids named after wallet entry points such as `useWalletModal`; pin
+// those facades into `vendor-crypto` too so the bn.js graph can never land in
+// an eager helper chunk named after a wallet entry point.
+//
+// This matcher must pin ONLY node_modules/facade ids — never first-party
+// source. Rollup folds a pinned module's whole dependency subtree into the
+// manual chunk (unless a dependency is itself pinned elsewhere), so pinning an
+// app component drags the shared UI/core graph the entry needs into
+// `vendor-crypto` and forces the entry to statically import the multi-MB
+// wallet chunk at boot. `scripts/verify-chunk-safety.mjs` gates both hazards:
+// bn.js confinement AND entry-chunk eagerness.
 export const VENDOR_OPTIMIZED_WALLET_TEST =
-  /(?:\/node_modules\/\.vite\/deps\/(?:@solana_[^/]*|@wagmi_[^/]*|@rainbow-me_[^/]*|@walletconnect_[^/]*|@reown_[^/]*|@coinbase_wallet[^/]*|useWalletModal(?:[._-]|$)|wagmi(?:[._-]|$)|viem(?:[._-]|$)|mipd(?:[._-]|$)|eventemitter3(?:[._-]|$)|bn(?:\.js|_js)?(?:[._-]|$)|elliptic(?:[._-]|$)|secp256k1(?:[._-]|$)|buffer(?:[._-]|$)|safe[-_]buffer(?:[._-]|$)|hash[-_]base(?:[._-]|$)|create[-_]hash(?:[._-]|$)|create[-_]hmac(?:[._-]|$)|sha(?:\.js|_js)?(?:[._-]|$))|(?:^|[\0/])useWalletModal(?:[._?/-]|$)|\/packages\/ui\/src\/cloud\/billing\/components\/direct-crypto-credit-card\.tsx(?:[?/-]|$))/;
+  /(?:\/node_modules\/\.vite\/deps\/(?:@solana_[^/]*|@wagmi_[^/]*|@rainbow-me_[^/]*|@walletconnect_[^/]*|@reown_[^/]*|@coinbase_wallet[^/]*|useWalletModal(?:[._-]|$)|wagmi(?:[._-]|$)|viem(?:[._-]|$)|mipd(?:[._-]|$)|eventemitter3(?:[._-]|$)|bn(?:\.js|_js)?(?:[._-]|$)|elliptic(?:[._-]|$)|secp256k1(?:[._-]|$)|buffer(?:[._-]|$)|safe[-_]buffer(?:[._-]|$)|hash[-_]base(?:[._-]|$)|create[-_]hash(?:[._-]|$)|create[-_]hmac(?:[._-]|$)|sha(?:\.js|_js)?(?:[._-]|$))|(?:^|[\0/])useWalletModal(?:[._?/-]|$))/;

--- a/packages/ui/src/cloud/public-pages/index.ts
+++ b/packages/ui/src/cloud/public-pages/index.ts
@@ -11,6 +11,13 @@
  *
  * The page components + the domain's lib helpers are also re-exported for hosts
  * that want to mount a page directly (e.g. tests) rather than via the registry.
+ *
+ * StewardLoginSection is deliberately NOT re-exported: it imports the
+ * wagmi/RainbowKit/Solana wallet stack, and a static re-export here would drag
+ * that multi-MB graph into every chunk that loads this barrel (register-all →
+ * the cloud router shell). LoginPage already code-splits it behind React.lazy
+ * with a designed fallback — import it from
+ * "./pages/login/steward-login-section" directly if a host ever needs it.
  */
 
 export { useMetaTag, usePageTitle } from "./lib/use-page-title";
@@ -27,7 +34,6 @@ export { default as InviteAcceptPage } from "./pages/invite/invite-accept-page";
 export { default as PrivacyPolicyPage } from "./pages/legal/privacy-policy-page";
 export { default as TermsOfServicePage } from "./pages/legal/terms-of-service-page";
 export { default as LoginPage } from "./pages/login/login-page";
-export { default as StewardLoginSection } from "./pages/login/steward-login-section";
 export { default as AppChargePaymentPage } from "./pages/payment/app-charge-page";
 export { default as PaymentRequestPage } from "./pages/payment/payment-request-page";
 export { default as PaymentSuccessPage } from "./pages/payment/payment-success-page";


### PR DESCRIPTION
Continues the #13187 iOS-startup work; implements the residual that PR #13216 flagged as the largest remaining startup lever: the entry chunk statically imported the entire `vendor-crypto` manual chunk, so every boot — web and the Capacitor iOS WebView — fetched **and parsed** the multi-MB wallet graph before first paint.

## Root cause

Rollup's `manualChunks` folds a pinned module's **entire dependency subtree** into the manual chunk (unless a dependency is itself pinned elsewhere). Three pins/omissions exploited that:

1. **A first-party component was pinned into `vendor-crypto`** (`packages/ui/src/cloud/billing/components/direct-crypto-credit-card.tsx` in `vite/wallet-chunk-matcher.ts`). Its dependency tree is the shared app graph, so the fold captured `@elizaos/core`'s browser bundle (3.6 MB), the `en.json` i18n catalog (479 KB), and dozens of shared UI modules into `vendor-crypto` — and since the entry needs that shared graph, the entry statically imported the whole 6.1 MB chunk at boot. The component is already behind a `React.lazy` boundary in `billing-tab.tsx`; the pin is simply removed and every wallet `node_modules`/facade id stays pinned, so the bn.js confinement the pin exists for is unchanged.
2. **Build-generated leaf shims were folded the same way** — Vite's dynamic-import preload helper, the `native-stub:` node-builtin stubs, and the buffer ESM shim are shared by the eager entry graph and the pinned crypto graph. They now get an explicit tiny `runtime-shims` chunk (40 KB raw / 11 KB gz). All are self-contained leaves, so no cross-chunk init cycle (the hazard the vendor-crypto pin guards) is possible.
3. **iOS-only: core's browser *source* graph eagerly imports `@noble/*` and `uuid`** (mobile builds bundle core from source via `USE_CORE_SOURCE_BROWSER_ENTRY`; `utils/crypto-compat.ts` → @noble, runtime/services → uuid). `@noble` was regex-pinned into `vendor-crypto` and `uuid` was folded there as a wagmi dependency, so the iOS entry statically imported a 3.8 MB wallet chunk that no iOS route can even reach. Both are self-contained leaves, now explicitly assigned to `vendor-boot-leaves` (28 KB). On web (core resolves to its prebuilt dist bundle, which inlines them) the chunk stays lazy.

Plus one lazy-path fix: the cloud public-pages barrel statically re-exported `StewardLoginSection` (the wagmi/RainbowKit/Solana consumer), dragging the wallet graph into the `register-all` → CloudRouterShell chunk on web. `LoginPage` already lazy-loads the section behind a designed fallback (`StewardLoginSectionFallback`); the barrel re-export had zero consumers and is removed with a comment explaining why it must not come back.

## Regression guard

`scripts/verify-chunk-safety.mjs` previously asserted only *confinement* (bn.js marker stays in `vendor-*` chunks) — a confined-but-eager `vendor-crypto` passed. It now also walks the entry's **static** import closure from `dist/index.html` and fails the build when any lazy-by-design vendor chunk (`crypto|solana|wallet|three|vrm|draco|phonemizer`) is reachable without a dynamic `import()` boundary. Three new test lanes in `test/verify-chunk-safety.test.ts` cover direct, transitive, and dynamic-only reachability; the gate caught two intermediate regressions during this work (the shim fold and the iOS @noble/uuid fold) before they could ship. The `wallet-optimized-chunk-matcher` test lane that asserted the old first-party pin now asserts the inverse invariant (the matcher must never match first-party source).

## Before/after bundle numbers

BEFORE measured at merge-base `b5243cea75c`; AFTER at this branch (rebased onto `a60edb63bd6`). "Eager boot JS" = every JS chunk referenced from `dist/index.html` (module script + modulepreload = fetched and parsed before first paint). Production builds: web `build:web`, iOS `ELIZA_CAPACITOR_BUILD_TARGET=ios vite build` (the bundle Capacitor bakes into the IPA).

| Build | Metric | Before | After | Δ |
| --- | --- | --- | --- | --- |
| iOS | eager boot JS raw | 7,050,359 B | 5,960,962 B | **−1,089,397 B (−15.5%)** |
| iOS | eager boot JS gzip | 2,448,454 B | 2,138,221 B | **−310,233 B (−12.7%)** |
| iOS | vendor-crypto | 3,829,952 B **eager** | 38,862 B **lazy** | off the boot path |
| iOS | total JS | 15,220,003 B (198 chunks) | 15,234,342 B (224 chunks) | +14,339 B (+0.09%) |
| web | eager boot JS raw | 9,362,940 B | 6,639,609 B | **−2,723,331 B (−29.1%)** |
| web | eager boot JS gzip | 3,097,430 B | 2,322,323 B | **−775,107 B (−25.0%)** |
| web | vendor-crypto | 6,108,213 B **eager** | 1,191,115 B **lazy** | off the boot path |
| web | total JS | 21,216,416 B (392 chunks) | 21,248,158 B (438 chunks) | +31,742 B (+0.15%) |

Composition proof: BEFORE, the entry chunk opened with a static `import{…}from"./vendor-crypto-*.js"` carrying hundreds of bindings (core's exports lived inside vendor-crypto); AFTER, grep confirms no static `vendor-crypto` import in either target's entry — it appears only behind dynamic `import()`. The rollup-visualizer stats confirmed `packages/core/dist/browser/index.browser.js` (3.6 MB) + `packages/ui/src/i18n/locales/en.json` (479 KB) + 389 other first-party modules were inside vendor-crypto before and are out after.

## Audit findings (no code change needed)

- **Native launch path** (`AppDelegate` / `SceneDelegate` / `ElizaBridgeViewController` / `AgentWatchdog` / `ElizaStartupTrace`, re-audited after the #12185 Live-Activity/keyboard/widgets landings): `didFinishLaunchingWithOptions` does boot-trace sink registration (file I/O on a `.utility` queue), a method swizzle, notification-delegate + background-runner registration, and watchdog observer registration with probes deferred by `discoveryProbeDelay`. No deferable synchronous main-thread work; **no Swift change shipped** → xcodebuild lane N/A.
- **AppWindowRenderer residual from #13242**: already resolved on develop — `packages/app-core/src/runtime/desktop/AppWindowRenderer.tsx` is fully tree-shaken out of the app build (absent from every chunk in the visualizer stats), and its page views (ChatView, TrajectoriesView, RuntimeView, …) each live in their own lazy chunk.
- **Views (chat thread / launcher / views host)**: no verifiable render/effect/scroll hazard fixable without speculative memoization — `ContinuousChatOverlay` memoizes `visibleMessages` + derived topic groupings, scroll sync is a passive `visualViewport` listener, and the i18n catalog loads only `en` eagerly with other locales behind dynamic import. The chunk-graph fix is the view-performance win: route-view lazy chunks no longer compete with a 6 MB boot parse.

## Verification

- `bun run --cwd packages/app typecheck` — green (after rebasing onto develop for eb47533a93f, which fixed a develop-side `allowPublicHttps` type error).
- `bun run --cwd packages/ui typecheck` — 1 pre-existing failure only (`src/hooks/useWhatsAppPairing.test.tsx(21,50)` TS2556 spread-arg; file byte-identical to `origin/develop`).
- Biome on every touched file — clean. `bun run audit:error-policy-ratchet` — no new fallback-slop.
- `bun run --cwd packages/app test` — `verify-chunk-safety` (7/7 incl. 3 new eagerness lanes), `first-paint-guard` (5/5), `wallet-optimized-chunk-matcher` (5/5 with the inverted lane) all green. Remaining 10 failures are pre-existing repo-state ratchet debt unrelated to this diff (chat-gesture matrix missing a row for `NotificationCenter.tsx`, launcher-interaction matrix roster drift, route/HMR coverage missing the `plugin-scheduling` manifest — same class PR #13242 documented at its base).
- `verify-chunk-safety` gates (confinement + new eagerness + SPA base) — **OK on both final builds** (web and iOS target).
- Playwright ui-smoke (`CI=true bun run --cwd packages/app test:e2e test/ui-smoke/assistant-home-flow.spec.ts --project=chromium`): 2 passed / 3 failed — the **identical 3-failed/2-passed split PR #13242 recorded at a pristine develop base**; failures are locator drift (Settings button role, view-pill attribute, push-to-talk element handle), zero chunk-load or module-fetch errors in the run. The 2 passing flows drive first-run → assistant home → chat through the rebuilt chunk graph end-to-end.
- xcodebuild: N/A — no Swift source changed (audit found no deferable main-thread launch work).
- UI screenshots/video: N/A — no pixel change; no new loading state introduced (the only lazy boundary this touches, LoginPage → StewardLoginSection, already ships its designed fallback).

## Not done / residuals

- The web entry chunk is now one 6.3 MB file (core dist bundle + i18n moved in from vendor-crypto — bytes that were already parsed at boot before, now without the extra 4.9 MB of wallet code riding along). Splitting core into its own cache-stable eager chunk (`vendor-eliza-core`) would improve caching granularity but not boot parse cost; left out to keep this change minimal.
- The 10 pre-existing ratchet-test failures above are develop-tip debt owned by their respective surfaces (gesture matrix, plugin-view manifests).
- On-device iOS cold-launch timing (ElizaStartupTrace deltas before/after) not captured — no signing-capable device in this environment; the renderer-parse reduction is machine-verified by the bundle numbers + eagerness gate instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
