### PR TITLE
test: cover remote deep-link profile registry sync

### DIFF
--- a/packages/app/src/deep-link-handler.test.ts
+++ b/packages/app/src/deep-link-handler.test.ts
@@ -9,13 +9,24 @@
  * untrusted or unconfigured hosts are ignored. Runs under jsdom with `window`,
  * `location.hash`, and event listeners; dispatch seams are `vi.fn()` spies.
  */
-import { NAVIGATE_VIEW_EVENT } from "@elizaos/ui/events";
+import { CONNECT_EVENT, NAVIGATE_VIEW_EVENT } from "@elizaos/ui/events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createDeepLinkHandler,
   type DeepLinkHandlerContext,
   isTrustedAppLink,
 } from "./deep-link-handler";
+
+const mocks = vi.hoisted(() => ({
+  applyLaunchConnection: vi.fn(() => ({
+    apiBase: "http://100.96.0.1:31337/v1",
+    token: null,
+  })),
+}));
+
+vi.mock("@elizaos/ui/platform/browser-launch", () => ({
+  applyLaunchConnection: mocks.applyLaunchConnection,
+}));
 
 function makeHandler(over: Partial<DeepLinkHandlerContext> = {}) {
   const dispatchShareTarget = vi.fn();
@@ -43,6 +54,11 @@ function makeHandler(over: Partial<DeepLinkHandlerContext> = {}) {
 
 beforeEach(() => {
   window.location.hash = "";
+  vi.clearAllMocks();
+  mocks.applyLaunchConnection.mockReturnValue({
+    apiBase: "http://100.96.0.1:31337/v1",
+    token: null,
+  });
 });
 
 describe("isTrustedAppLink", () => {
@@ -173,6 +189,57 @@ describe("createDeepLinkHandler — universal (https) app links", () => {
     const { handle } = makeHandler({ appLinkHosts: undefined });
     handle("https://eliza.app/wallet");
     expect(window.location.hash).toBe("");
+  });
+});
+
+describe("createDeepLinkHandler — remote runtime connect links", () => {
+  it("routes trusted connect links through the registry-sync launch seam", () => {
+    const { handle } = makeHandler();
+    const seen: unknown[] = [];
+    const onConnect = (event: Event) => {
+      seen.push((event as CustomEvent).detail);
+    };
+    document.addEventListener(CONNECT_EVENT, onConnect);
+    try {
+      handle(
+        "elizaos://connect?url=http%3A%2F%2F100.96.0.1%3A31337%2Fv1%2F&token=attacker-token",
+      );
+    } finally {
+      document.removeEventListener(CONNECT_EVENT, onConnect);
+    }
+
+    expect(mocks.applyLaunchConnection).toHaveBeenCalledWith({
+      kind: "remote",
+      apiBase: "http://100.96.0.1:31337/v1/",
+      token: null,
+    });
+    expect(seen).toEqual([
+      {
+        gatewayUrl: "http://100.96.0.1:31337/v1",
+        token: undefined,
+      },
+    ]);
+  });
+
+  it("rejects untrusted connect links before persisting or dispatching", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { handle } = makeHandler({
+      trustPolicy: { isTrustedDeepLinkApiBaseUrl: () => false } as never,
+    });
+    const onConnect = vi.fn();
+    document.addEventListener(CONNECT_EVENT, onConnect);
+    try {
+      handle("elizaos://connect?url=https%3A%2F%2Fagent.attacker.example");
+      expect(mocks.applyLaunchConnection).not.toHaveBeenCalled();
+      expect(onConnect).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("Rejected untrusted gateway URL host"),
+        "agent.attacker.example",
+      );
+    } finally {
+      document.removeEventListener(CONNECT_EVENT, onConnect);
+      warn.mockRestore();
+    }
   });
 });
 

--- a/packages/ui/src/platform/browser-launch.test.ts
+++ b/packages/ui/src/platform/browser-launch.test.ts
@@ -168,6 +168,13 @@ describe("browser launch connection handling", () => {
         kind: "remote",
       }),
     );
+    expect(mocks.upsertAndActivateAgentProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accessToken: "secret-token",
+        apiBase: "https://my-box.local:31337",
+        kind: "remote",
+      }),
+    );
   });
 
   it("rejects configured cloud API hosts over plaintext HTTP", async () => {


### PR DESCRIPTION
## Summary
- add app-shell deep-link coverage that trusted `connect` links route through `applyLaunchConnection`, the shared profile-registry sync path
- assert OS-delivered `connect` tokens are discarded and untrusted links never persist or dispatch
- tighten direct remote launch coverage so Settings-style remote connections upsert the active profile registry entry

Closes #13108

## Tests
- `TMPDIR=/private/tmp/codex-test-tmp bun run --cwd packages/app test -- src/deep-link-handler.test.ts`
- `TMPDIR=/private/tmp/codex-test-tmp bun run --cwd packages/ui test -- src/platform/browser-launch.test.ts src/first-run/__tests__/deep-link-entry.test.ts`
- `bunx @biomejs/biome check packages/app/src/deep-link-handler.test.ts packages/ui/src/platform/browser-launch.test.ts`
- `bun run audit:error-policy-ratchet`
- `git diff --check`

## Known baseline failures
- `bun run --cwd packages/app typecheck` fails on existing missing plugin dependency types (`fflate`, `@vscode/ripgrep`, `puppeteer-core`, `@nut-tree-fork/nut-js`, `phonemizer`, `llama-cpp-capacitor`) and existing plugin type errors.
- `bun run --cwd packages/ui typecheck` still fails on the pre-existing `src/hooks/useWhatsAppPairing.test.tsx:21` TS2556 spread-argument error.