### PR TITLE
test(#12770): author SR slice of persona pack A2 (adhd-follow-through)

### DIFF
--- a/packages/scenario-runner/src/corpus-assertion-guard.test.ts
+++ b/packages/scenario-runner/src/corpus-assertion-guard.test.ts
@@ -258,6 +258,15 @@ const EXPECTED_PR_DETERMINISTIC_SCENARIO_IDS = [
   // added here in the same commit so this toEqual stays green while the coverage
   // ledger can still resolve their ids.
   "adhd-distractor-storm-mid-capture",
+  // LifeOps persona pack A2 (adhd-follow-through, #12770). Same G1 convention:
+  // these keyless api+tick scenarios drive the REAL no-reply/escalation ladder
+  // (create a reminder with a completionCheck, tick across simulated no-reply,
+  // assert the retry -> re-fire -> skip/expire progression + reminderIntensity
+  // differences) and are registered here in the same commit.
+  "adhd-followthrough-intensity-minimal-chases-none",
+  "adhd-followthrough-intensity-persistent-chases-twice",
+  "adhd-followthrough-noreply-retry-then-skip",
+  "adhd-followthrough-reply-breaks-escalation",
   "adhd-hyperfocus-guardrail-protects-standup",
   // LifeOps persona pack C1 (traveler-timezone-truth, #12773). Same G1
   // convention: keyless `tick`-driven timezone journeys authored under

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/adhd-follow-through.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/adhd-follow-through.catalog.json
@@ -9,17 +9,186 @@
     "targetCount": 24,
     "notes": [
       "This file is the progress ledger for pack A2 only. Add one entry per authored scenario, across both surfaces (lifeops-bench Python ids and scenario-runner .scenario.ts ids).",
-      "status flips planned -> authored once the scenario file/literal exists; -> verified once a real-LLM run has been captured and hand-reviewed per PR_EVIDENCE.md."
+      "status flips planned -> authored once the scenario file/literal exists; -> verified once a real-LLM run has been captured and hand-reviewed per PR_EVIDENCE.md.",
+      "pr-deterministic scenario-runner rows are verified via the keyless strict LLM proxy (no live key needed); live-only rows stay authored until a real-LLM trajectory is captured at the key boundary (#12781)."
     ]
   },
   "scenarios": [
     {
       "id": "adhd-followthrough-rage-quit-delete-trap",
       "pack": "A2",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "Live-only. A live run showed the assistant mass-deleted on a rage-quit 'delete everything' outburst (task_b493d551); the handler now blocks broad destructive delete before any deletion call and this stays active as the live regression. Flip to verified only after a fresh real-LLM run proves the broad-delete guardrail."
+    },
+    {
+      "id": "adhd-followthrough-noreply-retry-then-skip",
+      "pack": "A2",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "verified",
+      "notes": "pr-deterministic (keyless). REAL scheduler tick: a reminder with a user_acknowledged completionCheck fires (once_due), goes unanswered -> no_reply_retry_1 (snooze override, scheduledTaskCompletionTimeouts), re-fires (scheduled_override_due), then settles terminally (skipped/no_reply_reminder_expired). Proves the dropped task is neither lost nor nagged forever. Passes keyless under TZ=UTC SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 --conditions eliza-source."
+    },
+    {
+      "id": "adhd-followthrough-intensity-persistent-chases-twice",
+      "pack": "A2",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "verified",
+      "notes": "pr-deterministic (keyless). Owner reminderIntensity=persistent (set via the REAL OwnerFactStore) reshapes the SAME no-reply ladder to two retry rungs: no_reply_retry_1 -> re-fire -> no_reply_retry_2 -> re-fire -> terminal skip. Contrasts with the normal (one rung) and minimal (zero rungs) siblings to pin the intensity axis. Passes keyless."
+    },
+    {
+      "id": "adhd-followthrough-intensity-minimal-chases-none",
+      "pack": "A2",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "verified",
+      "notes": "pr-deterministic (keyless). Owner reminderIntensity=minimal drops the retry rung entirely: the fired reminder's FIRST completion timeout is terminal (skipped/no_reply_reminder_expired) with no no_reply_retry_1, and nothing re-arms afterward. The anti-nag low end of the intensity axis. Passes keyless."
+    },
+    {
+      "id": "adhd-followthrough-reply-breaks-escalation",
+      "pack": "A2",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "verified",
+      "notes": "pr-deterministic (keyless). Engagement retires the ladder: a fired reminder is acknowledged (fired -> acknowledged via the REST acknowledge verb), so the tick past the followup window that WOULD have produced no_reply_retry_1 produces no timeout and no re-fire. The non-shaming other half of the escalation story. Passes keyless."
+    },
+    {
+      "id": "adhd-followthrough-missed-step-replan-without-guilt",
+      "pack": "A2",
       "tier": "T2",
       "surface": "scenario-runner",
       "status": "authored",
-      "notes": "AUTHORED as an active regression test \u2014 a live run showed the assistant mass-deleted on a rage-quit 'delete everything' outburst (task_b493d551). Flip to verified only after a fresh real-LLM run proves the broad-delete guardrail."
+      "notes": "Live-only. Missed reminder -> re-plan smaller, no shame/streak language, ask before scheduling (judgeRubric grades tone + shrink-and-consent). Ports lifeops-bench live.adhd.follow.missed_step_replan_without_guilt. Live-verify deferred to the key boundary (#12781)."
+    },
+    {
+      "id": "adhd-followthrough-repeated-miss-shrink-or-pause",
+      "pack": "A2",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "Live-only. Repeated misses (incl. one mid-conversation) -> offer a smaller habit or a pause, never streak shame, no unprompted identical re-add (judgeRubric). Ports lifeops-bench live.adhd.follow.repeated_miss_shrink_or_pause. Live-verify deferred (#12781)."
+    },
+    {
+      "id": "adhd-followthrough-end-of-day-wins-first-recap",
+      "pack": "A2",
+      "tier": "T2",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "Live-only. End-of-day recap leads with wins, neutral carryover framing, consent before creating tomorrow's reminder (judgeRubric grades ordering + framing + consent). Ports lifeops-bench live.adhd.follow.end_of_day_wins_first_recap. Live-verify deferred (#12781)."
+    },
+    {
+      "id": "live.adhd.follow.missed_step_replan_without_guilt",
+      "pack": "A2",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "authored"
+    },
+    {
+      "id": "live.adhd.follow.legitimate_deferral_after_lunch",
+      "pack": "A2",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "authored"
+    },
+    {
+      "id": "live.adhd.follow.meds_late_slide_hour",
+      "pack": "A2",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "authored"
+    },
+    {
+      "id": "live.adhd.follow.repeated_miss_shrink_or_pause",
+      "pack": "A2",
+      "tier": "T4",
+      "surface": "lifeops-bench",
+      "status": "authored"
+    },
+    {
+      "id": "live.adhd.follow.terse_reengagement_after_silence",
+      "pack": "A2",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "authored"
+    },
+    {
+      "id": "live.adhd.follow.rage_quit_pause_not_delete",
+      "pack": "A2",
+      "tier": "T4",
+      "surface": "lifeops-bench",
+      "status": "authored"
+    },
+    {
+      "id": "live.adhd.follow.proportional_completion_celebration",
+      "pack": "A2",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "authored"
+    },
+    {
+      "id": "live.adhd.follow.end_of_day_wins_first_recap",
+      "pack": "A2",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "authored"
+    },
+    {
+      "id": "live.adhd.follow.deadline_protective_reschedule",
+      "pack": "A2",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "authored"
+    },
+    {
+      "id": "live.adhd.follow.shame_spiral_reset_language",
+      "pack": "A2",
+      "tier": "T4",
+      "surface": "lifeops-bench",
+      "status": "authored"
+    },
+    {
+      "id": "live.adhd.follow.followup_watcher_after_nonreply",
+      "pack": "A2",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "authored"
+    },
+    {
+      "id": "live.adhd.follow.context_rebuild_after_tab_loss",
+      "pack": "A2",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "authored"
+    },
+    {
+      "id": "live.adhd.follow.overwhelm_cancel_or_reduce_choice",
+      "pack": "A2",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "authored"
+    },
+    {
+      "id": "live.adhd.follow.timer_expired_transition_support",
+      "pack": "A2",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "authored"
+    },
+    {
+      "id": "live.adhd.follow.accountability_without_surveillance",
+      "pack": "A2",
+      "tier": "T4",
+      "surface": "lifeops-bench",
+      "status": "authored"
+    },
+    {
+      "id": "live.adhd.follow.plan_mismatch_repair_midrun",
+      "pack": "A2",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "authored"
     }
   ]
 }

--- a/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-end-of-day-wins-first-recap.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-end-of-day-wins-first-recap.scenario.ts
@@ -1,0 +1,53 @@
+/**
+ * A2 adhd-follow-through (live). casey_adhd asks for an end-of-day recap that
+ * leads with what worked, because her brain "deletes the evidence" of wins. The
+ * assistant must lead with completed/partial items, label carryovers neutrally
+ * (not as failures), offer at most one optional tiny carryover for tomorrow, and
+ * NOT create tomorrow's reminder without consent. Proportional, wins-first recap
+ * on the personas pack (#12283). Ports LifeOpsBench
+ * live.adhd.follow.end_of_day_wins_first_recap.
+ *
+ * Personas-as-data: the voice lives in the turn text, never in
+ * `promptInstructions` (root AGENTS.md — one scheduler, structural fields only).
+ *
+ * Live-only: the judge grades ordering (wins first), neutral carryover framing,
+ * and consent-before-create — a discourse/tone judgment the deterministic proxy
+ * cannot make. Live-verify deferred to the key boundary (#12781).
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "adhd-followthrough-end-of-day-wins-first-recap",
+  title:
+    "ADHD follow-through: end-of-day recap leads with wins, carryovers are neutral and consented",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "adhd", "personas", "follow-through", "recap", "12283"],
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Follow-through",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "casey asks for a wins-first recap",
+      text: "can you recap today but lead with what actually worked? my brain is doing the thing where it deletes the evidence.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "judgeRubric",
+      name: "recap-leads-with-wins-neutral-carryover-consented",
+      minimumScore: 0.7,
+      rubric:
+        "Casey (ADHD, discounts her own wins) asks for an end-of-day recap that leads with what worked. Grade PASS only if ALL hold: (1) the recap OPENS with completed or partially-completed items — the wins come first, before any unfinished work; (2) unfinished items are labeled as neutral carryovers, NOT as failures, misses, or things she 'still hasn't done'; (3) it offers at most one small optional carryover for tomorrow and does NOT create or claim to have created tomorrow's reminder without Casey accepting it. Deduct heavily for leading with what she failed to do, for framing carryovers as failures, or for silently scheduling tomorrow's items.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-intensity-minimal-chases-none.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-intensity-minimal-chases-none.scenario.ts
@@ -1,0 +1,343 @@
+/**
+ * A2 adhd-follow-through (pr-deterministic). Deterministic ScheduledTask proof
+ * that a `minimal` owner `reminderIntensity` DROPS the no-reply retry rung
+ * entirely: Casey, mid-burnout, has told the assistant to stop chasing her, so
+ * an ignored reminder fires ONCE and then settles terminally with no re-nudge —
+ * the anti-nag end of the intensity axis. Drives the REAL scheduler tick
+ * (logical clock, no LLM, no key) and asserts the STRUCTURAL "no retry rung,
+ * terminal at the first timeout" outcome on
+ * `scheduledTaskCompletionTimeouts[]`. Maps to LifeOpsBench
+ * live.adhd.follow.repeated_miss_shrink_or_pause (stop chasing a drowning
+ * owner); the live judge of the non-shaming wording stays on the bench surface.
+ *
+ * The intensity transform is pure and unit-covered
+ * (`no-reply-intensity.ts::applyReminderIntensityToNoReplyPolicy`): `minimal`
+ * yields `{maxRetries:0, cadence:[]}`, so the FIRST completion timeout is
+ * terminal — no `no_reply_retry_1`. The owner fact is set once in the seed via
+ * the REAL OwnerFactStore (`setReminderIntensity`).
+ *
+ * Read against `adhd-followthrough-noreply-retry-then-skip` (normal, ONE rung)
+ * and `adhd-followthrough-intensity-persistent-chases-twice` (persistent, TWO
+ * rungs) this pins the low end of the intensity axis.
+ *
+ * Fail-without-fix anchor:
+ *   - Revert the `minimal` branch in
+ *     `plugins/plugin-personal-assistant/src/lifeops/scheduled-task/no-reply-intensity.ts`
+ *     (stop zeroing maxRetries/cadence) and the reminder earns a retry_1 rung —
+ *     the "terminal at the first timeout, no retry" turn fails because a
+ *     `no_reply_retry_1` timeout appears instead.
+ */
+
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+type JsonRecord = Record<string, unknown>;
+
+const SCENARIO_ID = "adhd-followthrough-intensity-minimal-chases-none";
+const DELIVERY_CHANNEL_KIND = "scenario_a2_minimal_delivery";
+const FOLLOWUP_MINUTES = 30;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function futureDateAtUtc(
+  hour: number,
+  minute: number,
+  daysAhead: number,
+): Date {
+  const base = new Date(Date.now() + daysAhead * DAY_MS);
+  base.setUTCHours(hour, minute, 0, 0);
+  return base;
+}
+
+// minimal = {maxRetries:0, cadence:[]}. Fires 09:00, followup 30m; the FIRST
+// timeout (09:35) is terminal — there is no retry rung and no re-fire.
+const FIRE = futureDateAtUtc(9, 0, 7);
+const TERMINAL = futureDateAtUtc(9, 35, 7);
+const AFTER = futureDateAtUtc(11, 0, 7);
+
+interface ChannelContributionLike {
+  kind: string;
+  describe: { label: string };
+  capabilities: {
+    send: boolean;
+    read: boolean;
+    reminders: boolean;
+    voice: boolean;
+    attachments: boolean;
+    quietHoursAware: boolean;
+  };
+  send?(payload: unknown): Promise<{ ok: true; messageId: string }>;
+}
+
+interface ChannelRegistryLike {
+  register(contribution: ChannelContributionLike): void;
+  get(kind: string): ChannelContributionLike | null;
+}
+
+interface OwnerFactStoreLike {
+  setReminderIntensity(
+    patch: { intensity: string; note?: string },
+    provenance: { source: string; recordedAt: string; note?: string },
+  ): Promise<unknown>;
+}
+
+interface RuntimeLike {
+  channelRegistry?: ChannelRegistryLike;
+}
+
+const capturedTaskIds: { reminder: string | null } = { reminder: null };
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function seedMinimalIntensityAndChannel(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  capturedTaskIds.reminder = null;
+  const runtime = ctx.runtime as RuntimeLike;
+  const registry = runtime.channelRegistry;
+  if (!registry || typeof registry.register !== "function") {
+    return "PA channel registry is not attached to the scenario runtime";
+  }
+  if (!registry.get(DELIVERY_CHANNEL_KIND)) {
+    registry.register({
+      kind: DELIVERY_CHANNEL_KIND,
+      describe: { label: "Scenario A2 minimal-intensity delivery probe" },
+      capabilities: {
+        send: true,
+        read: false,
+        reminders: true,
+        voice: false,
+        attachments: false,
+        quietHoursAware: false,
+      },
+      async send(): Promise<{ ok: true; messageId: string }> {
+        return { ok: true, messageId: `${SCENARIO_ID}-delivered` };
+      },
+    });
+  }
+
+  const mod = await import("@elizaos/plugin-personal-assistant/plugin");
+  const store = (
+    mod as { resolveOwnerFactStore: (rt: unknown) => OwnerFactStoreLike }
+  ).resolveOwnerFactStore(ctx.runtime);
+  await store.setReminderIntensity(
+    { intensity: "minimal" },
+    { source: "policy_action", recordedAt: new Date().toISOString() },
+  );
+  return undefined;
+}
+
+interface FireEntry {
+  taskId: string;
+  status: string;
+  reason: string;
+}
+
+function readList(
+  body: unknown,
+  key: "scheduledTaskFires" | "scheduledTaskCompletionTimeouts",
+): FireEntry[] | string {
+  if (!isRecord(body) || body.success !== true) {
+    return `expected tick success=true, saw ${JSON.stringify(body)}`;
+  }
+  const raw = body[key];
+  if (!Array.isArray(raw)) return `expected ${key} array`;
+  const out: FireEntry[] = [];
+  for (const entry of raw) {
+    if (
+      !isRecord(entry) ||
+      typeof entry.taskId !== "string" ||
+      typeof entry.status !== "string" ||
+      typeof entry.reason !== "string"
+    ) {
+      return `malformed ${key} entry: ${JSON.stringify(entry)}`;
+    }
+    out.push({
+      taskId: entry.taskId,
+      status: entry.status,
+      reason: entry.reason,
+    });
+  }
+  return out;
+}
+
+function forReminder(entries: FireEntry[]): FireEntry[] | string {
+  if (typeof capturedTaskIds.reminder !== "string") {
+    return "captured reminder taskId was not set by the create turn";
+  }
+  return entries.filter((e) => e.taskId === capturedTaskIds.reminder);
+}
+
+function captureReminderTaskId(
+  _status: number,
+  body: unknown,
+): string | undefined {
+  if (!isRecord(body) || !isRecord(body.task)) {
+    return `expected {task} response, saw ${JSON.stringify(body)}`;
+  }
+  const task = body.task;
+  if (typeof task.taskId !== "string" || task.taskId.length === 0) {
+    return `expected task.taskId string, saw ${JSON.stringify(task.taskId)}`;
+  }
+  capturedTaskIds.reminder = task.taskId;
+  return undefined;
+}
+
+function assertFiredOnce(_status: number, body: unknown): string | undefined {
+  const fires = readList(body, "scheduledTaskFires");
+  if (typeof fires === "string") return fires;
+  const mine = forReminder(fires);
+  if (typeof mine === "string") return mine;
+  const fired = mine.filter((f) => f.status === "fired");
+  if (fired.length !== 1 || fired[0]?.reason !== "once_due") {
+    return `expected exactly one once_due fire, saw ${JSON.stringify(mine)}`;
+  }
+  return undefined;
+}
+
+// The minimal ladder's signature: the FIRST timeout is terminal, and it is a
+// skip (not a retry). A retry_1 here would mean the minimal branch regressed.
+function assertTerminalNoRetry(
+  _status: number,
+  body: unknown,
+): string | undefined {
+  const timeouts = readList(body, "scheduledTaskCompletionTimeouts");
+  if (typeof timeouts === "string") return timeouts;
+  const mine = forReminder(timeouts);
+  if (typeof mine === "string") return mine;
+  if (mine.length !== 1) {
+    return `expected exactly one completion timeout, saw ${JSON.stringify(mine)}`;
+  }
+  const t = mine[0];
+  if (t?.reason === "no_reply_retry_1" || t?.status === "scheduled") {
+    return `minimal must NOT earn a retry rung, saw ${JSON.stringify(t)}`;
+  }
+  if (t?.status !== "skipped" || t.reason !== "no_reply_reminder_expired") {
+    return `expected terminal {status:skipped, reason:no_reply_reminder_expired}, saw ${JSON.stringify(t)}`;
+  }
+  return undefined;
+}
+
+// After the terminal skip, no override re-arms — a later tick surfaces nothing
+// for this task (neither a fire nor another timeout).
+function assertQuietAfterTerminal(
+  _status: number,
+  body: unknown,
+): string | undefined {
+  const fires = readList(body, "scheduledTaskFires");
+  if (typeof fires === "string") return fires;
+  const timeouts = readList(body, "scheduledTaskCompletionTimeouts");
+  if (typeof timeouts === "string") return timeouts;
+  const fireHits = forReminder(fires);
+  if (typeof fireHits === "string") return fireHits;
+  const timeoutHits = forReminder(timeouts);
+  if (typeof timeoutHits === "string") return timeoutHits;
+  if (fireHits.length !== 0 || timeoutHits.length !== 0) {
+    return `expected no activity for the terminal reminder, saw fires=${JSON.stringify(fireHits)} timeouts=${JSON.stringify(timeoutHits)}`;
+  }
+  return undefined;
+}
+
+export default scenario({
+  id: "adhd-followthrough-intensity-minimal-chases-none",
+  lane: "pr-deterministic",
+  title:
+    "ADHD follow-through: minimal reminderIntensity drops the no-reply retry entirely — fires once, then stops",
+  domain: "lifeops",
+  tags: [
+    "pr",
+    "deterministic",
+    "zero-cost",
+    "lifeops",
+    "adhd",
+    "personas",
+    "scheduled-tasks",
+    "escalation",
+    "reminder-intensity",
+    "12283",
+  ],
+  isolation: "shared-runtime",
+  requires: {
+    plugins: [
+      "@elizaos/plugin-scheduling",
+      "@elizaos/plugin-personal-assistant",
+    ],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "set owner reminderIntensity=minimal and register the delivery channel",
+      apply: seedMinimalIntensityAndChannel,
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      title: "ADHD Follow-through minimal",
+    },
+  ],
+  turns: [
+    {
+      kind: "api",
+      name: "create the reminder (minimal intensity is owner-wide)",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions: "water the plants sometime today",
+        trigger: { kind: "once", atIso: FIRE.toISOString() },
+        priority: "medium",
+        completionCheck: {
+          kind: "user_acknowledged",
+          followupAfterMinutes: FOLLOWUP_MINUTES,
+        },
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-reminder`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureReminderTaskId,
+    },
+    {
+      kind: "tick",
+      name: "fires once",
+      worker: "lifeops_scheduler",
+      options: { now: FIRE.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: assertFiredOnce,
+    },
+    {
+      kind: "tick",
+      name: "first silence -> terminal skip, NO retry rung",
+      worker: "lifeops_scheduler",
+      options: { now: TERMINAL.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: assertTerminalNoRetry,
+    },
+    {
+      kind: "tick",
+      name: "later tick -> nothing re-arms (fires once, then truly stops)",
+      worker: "lifeops_scheduler",
+      options: { now: AFTER.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: assertQuietAfterTerminal,
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "minimal reminder was created and settled without a retry",
+      predicate: (): string | undefined =>
+        capturedTaskIds.reminder === null
+          ? "reminder taskId was never captured"
+          : undefined,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-intensity-persistent-chases-twice.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-intensity-persistent-chases-twice.scenario.ts
@@ -1,0 +1,350 @@
+/**
+ * A2 adhd-follow-through (pr-deterministic). Deterministic ScheduledTask proof
+ * that a `persistent` owner `reminderIntensity` earns an EXTRA no-reply retry
+ * rung: Casey asked to be chased harder on load-bearing tasks, so an ignored
+ * reminder re-nudges TWICE (retry_1, retry_2) before settling — one more chase
+ * than the default `normal` ladder in the sibling retry-then-skip scenario.
+ * Drives the REAL scheduler tick (logical clock, no LLM, no key) and asserts the
+ * STRUCTURAL two-rung progression on `scheduledTaskCompletionTimeouts[]` +
+ * `scheduledTaskFires[]`. Maps to LifeOpsBench
+ * live.adhd.follow.accountability_without_surveillance (chase me, but bounded);
+ * the live judge of the wording stays on the bench surface.
+ *
+ * The intensity transform is pure and unit-covered
+ * (`no-reply-intensity.ts::applyReminderIntensityToNoReplyPolicy`): from the
+ * default reminder policy `{maxRetries:1, cadence:[60]}`, `persistent` yields
+ * `{maxRetries:2, cadence:[60,60]}`. The owner fact is set once in the seed via
+ * the REAL OwnerFactStore (`setReminderIntensity`), so intensity — not the task
+ * shape — drives the difference.
+ *
+ * Read against the sibling `adhd-followthrough-noreply-retry-then-skip` (normal,
+ * ONE retry rung) and `adhd-followthrough-intensity-minimal-chases-none`
+ * (minimal, ZERO retry rungs) this triple pins the whole intensity axis.
+ *
+ * Fail-without-fix anchor:
+ *   - Revert the `persistent` branch in
+ *     `plugins/plugin-personal-assistant/src/lifeops/scheduled-task/no-reply-intensity.ts`
+ *     (drop the `maxRetries + 1` / trailing-cadence append) and the reminder
+ *     settles terminally after retry_1 — the "retry_2" turn fails.
+ */
+
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+type JsonRecord = Record<string, unknown>;
+
+const SCENARIO_ID = "adhd-followthrough-intensity-persistent-chases-twice";
+const DELIVERY_CHANNEL_KIND = "scenario_a2_persistent_delivery";
+const FOLLOWUP_MINUTES = 30;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function futureDateAtUtc(
+  hour: number,
+  minute: number,
+  daysAhead: number,
+): Date {
+  const base = new Date(Date.now() + daysAhead * DAY_MS);
+  base.setUTCHours(hour, minute, 0, 0);
+  return base;
+}
+
+// persistent = {maxRetries:2, cadence:[60,60]}. Fires 09:00, followup 30m.
+//  09:35 -> retry_1 (snooze 10:35), 10:40 -> re-fire, 11:15 -> retry_2
+//  (snooze 12:15), 12:20 -> re-fire, 12:55 -> terminal skip.
+const FIRE = futureDateAtUtc(9, 0, 6);
+const TIMEOUT_1 = futureDateAtUtc(9, 35, 6);
+const REFIRE_1 = futureDateAtUtc(10, 40, 6);
+const TIMEOUT_2 = futureDateAtUtc(11, 15, 6);
+const REFIRE_2 = futureDateAtUtc(12, 20, 6);
+const TERMINAL = futureDateAtUtc(12, 55, 6);
+
+interface ChannelContributionLike {
+  kind: string;
+  describe: { label: string };
+  capabilities: {
+    send: boolean;
+    read: boolean;
+    reminders: boolean;
+    voice: boolean;
+    attachments: boolean;
+    quietHoursAware: boolean;
+  };
+  send?(payload: unknown): Promise<{ ok: true; messageId: string }>;
+}
+
+interface ChannelRegistryLike {
+  register(contribution: ChannelContributionLike): void;
+  get(kind: string): ChannelContributionLike | null;
+}
+
+interface OwnerFactStoreLike {
+  setReminderIntensity(
+    patch: { intensity: string; note?: string },
+    provenance: { source: string; recordedAt: string; note?: string },
+  ): Promise<unknown>;
+}
+
+interface RuntimeLike {
+  channelRegistry?: ChannelRegistryLike;
+}
+
+const capturedTaskIds: { reminder: string | null } = { reminder: null };
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function seedPersistentIntensityAndChannel(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  capturedTaskIds.reminder = null;
+  const runtime = ctx.runtime as RuntimeLike;
+  const registry = runtime.channelRegistry;
+  if (!registry || typeof registry.register !== "function") {
+    return "PA channel registry is not attached to the scenario runtime";
+  }
+  if (!registry.get(DELIVERY_CHANNEL_KIND)) {
+    registry.register({
+      kind: DELIVERY_CHANNEL_KIND,
+      describe: { label: "Scenario A2 persistent-intensity delivery probe" },
+      capabilities: {
+        send: true,
+        read: false,
+        reminders: true,
+        voice: false,
+        attachments: false,
+        quietHoursAware: false,
+      },
+      async send(): Promise<{ ok: true; messageId: string }> {
+        return { ok: true, messageId: `${SCENARIO_ID}-delivered` };
+      },
+    });
+  }
+
+  const mod = await import("@elizaos/plugin-personal-assistant/plugin");
+  const store = (
+    mod as { resolveOwnerFactStore: (rt: unknown) => OwnerFactStoreLike }
+  ).resolveOwnerFactStore(ctx.runtime);
+  await store.setReminderIntensity(
+    { intensity: "persistent" },
+    { source: "policy_action", recordedAt: new Date().toISOString() },
+  );
+  return undefined;
+}
+
+interface FireEntry {
+  taskId: string;
+  status: string;
+  reason: string;
+}
+
+function readList(
+  body: unknown,
+  key: "scheduledTaskFires" | "scheduledTaskCompletionTimeouts",
+): FireEntry[] | string {
+  if (!isRecord(body) || body.success !== true) {
+    return `expected tick success=true, saw ${JSON.stringify(body)}`;
+  }
+  const raw = body[key];
+  if (!Array.isArray(raw)) return `expected ${key} array`;
+  const out: FireEntry[] = [];
+  for (const entry of raw) {
+    if (
+      !isRecord(entry) ||
+      typeof entry.taskId !== "string" ||
+      typeof entry.status !== "string" ||
+      typeof entry.reason !== "string"
+    ) {
+      return `malformed ${key} entry: ${JSON.stringify(entry)}`;
+    }
+    out.push({
+      taskId: entry.taskId,
+      status: entry.status,
+      reason: entry.reason,
+    });
+  }
+  return out;
+}
+
+function forReminder(entries: FireEntry[]): FireEntry[] | string {
+  if (typeof capturedTaskIds.reminder !== "string") {
+    return "captured reminder taskId was not set by the create turn";
+  }
+  return entries.filter((e) => e.taskId === capturedTaskIds.reminder);
+}
+
+function captureReminderTaskId(
+  _status: number,
+  body: unknown,
+): string | undefined {
+  if (!isRecord(body) || !isRecord(body.task)) {
+    return `expected {task} response, saw ${JSON.stringify(body)}`;
+  }
+  const task = body.task;
+  if (typeof task.taskId !== "string" || task.taskId.length === 0) {
+    return `expected task.taskId string, saw ${JSON.stringify(task.taskId)}`;
+  }
+  capturedTaskIds.reminder = task.taskId;
+  return undefined;
+}
+
+function assertFired(
+  reason: string,
+): (status: number, body: unknown) => string | undefined {
+  return (_status, body) => {
+    const fires = readList(body, "scheduledTaskFires");
+    if (typeof fires === "string") return fires;
+    const mine = forReminder(fires);
+    if (typeof mine === "string") return mine;
+    const fired = mine.filter((f) => f.status === "fired");
+    if (fired.length !== 1 || fired[0]?.reason !== reason) {
+      return `expected exactly one fire reason "${reason}", saw ${JSON.stringify(mine)}`;
+    }
+    return undefined;
+  };
+}
+
+function assertTimeout(
+  expectedStatus: string,
+  expectedReason: string,
+): (status: number, body: unknown) => string | undefined {
+  return (_status, body) => {
+    const timeouts = readList(body, "scheduledTaskCompletionTimeouts");
+    if (typeof timeouts === "string") return timeouts;
+    const mine = forReminder(timeouts);
+    if (typeof mine === "string") return mine;
+    if (mine.length !== 1) {
+      return `expected exactly one completion timeout, saw ${JSON.stringify(mine)}`;
+    }
+    const t = mine[0];
+    if (t?.status !== expectedStatus || t.reason !== expectedReason) {
+      return `expected timeout {status:${expectedStatus}, reason:${expectedReason}}, saw ${JSON.stringify(t)}`;
+    }
+    return undefined;
+  };
+}
+
+export default scenario({
+  id: "adhd-followthrough-intensity-persistent-chases-twice",
+  lane: "pr-deterministic",
+  title:
+    "ADHD follow-through: persistent reminderIntensity earns a second no-reply retry rung",
+  domain: "lifeops",
+  tags: [
+    "pr",
+    "deterministic",
+    "zero-cost",
+    "lifeops",
+    "adhd",
+    "personas",
+    "scheduled-tasks",
+    "escalation",
+    "reminder-intensity",
+    "12283",
+  ],
+  isolation: "shared-runtime",
+  requires: {
+    plugins: [
+      "@elizaos/plugin-scheduling",
+      "@elizaos/plugin-personal-assistant",
+    ],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "set owner reminderIntensity=persistent and register the delivery channel",
+      apply: seedPersistentIntensityAndChannel,
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      title: "ADHD Follow-through persistent",
+    },
+  ],
+  turns: [
+    {
+      kind: "api",
+      name: "create the reminder (persistent intensity is owner-wide)",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions:
+          "submit the reimbursement before the quarter closes",
+        trigger: { kind: "once", atIso: FIRE.toISOString() },
+        priority: "medium",
+        completionCheck: {
+          kind: "user_acknowledged",
+          followupAfterMinutes: FOLLOWUP_MINUTES,
+        },
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-reminder`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureReminderTaskId,
+    },
+    {
+      kind: "tick",
+      name: "fires once",
+      worker: "lifeops_scheduler",
+      options: { now: FIRE.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: assertFired("once_due"),
+    },
+    {
+      kind: "tick",
+      name: "first silence -> retry_1",
+      worker: "lifeops_scheduler",
+      options: { now: TIMEOUT_1.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: assertTimeout("scheduled", "no_reply_retry_1"),
+    },
+    {
+      kind: "tick",
+      name: "retry_1 override re-fires",
+      worker: "lifeops_scheduler",
+      options: { now: REFIRE_1.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: assertFired("scheduled_override_due"),
+    },
+    {
+      kind: "tick",
+      name: "second silence -> retry_2 (the extra rung persistent earns)",
+      worker: "lifeops_scheduler",
+      options: { now: TIMEOUT_2.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: assertTimeout("scheduled", "no_reply_retry_2"),
+    },
+    {
+      kind: "tick",
+      name: "retry_2 override re-fires",
+      worker: "lifeops_scheduler",
+      options: { now: REFIRE_2.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: assertFired("scheduled_override_due"),
+    },
+    {
+      kind: "tick",
+      name: "still ignored past both rungs -> terminal skip",
+      worker: "lifeops_scheduler",
+      options: { now: TERMINAL.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: assertTimeout("skipped", "no_reply_reminder_expired"),
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "persistent reminder was created and driven through both rungs",
+      predicate: (): string | undefined =>
+        capturedTaskIds.reminder === null
+          ? "reminder taskId was never captured"
+          : undefined,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-missed-step-replan-without-guilt.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-missed-step-replan-without-guilt.scenario.ts
@@ -1,0 +1,53 @@
+/**
+ * A2 adhd-follow-through (live). casey_adhd missed a reminder yesterday and asks
+ * for the next move without "a whole thing" being made of it. The assistant must
+ * repair without shame or streak language: acknowledge the miss neutrally, offer
+ * ONE smaller next step instead of restarting the full task, and ask before
+ * scheduling anything. Non-shaming follow-through repair on the personas pack
+ * (#12283). Ports LifeOpsBench live.adhd.follow.missed_step_replan_without_guilt.
+ *
+ * Personas-as-data: the messy, apologetic voice lives in the turn text, never in
+ * `promptInstructions` (root AGENTS.md — one scheduler, structural fields only).
+ *
+ * Live-only: the judge grades tone (no blame/discipline framing) plus the
+ * shrink-and-consent mechanics, which the deterministic proxy cannot exercise —
+ * it always emits a reply, so a tone/consent judgment needs a real model.
+ * Live-verify deferred to the key boundary (#12781).
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "adhd-followthrough-missed-step-replan-without-guilt",
+  title:
+    "ADHD follow-through: a missed step is re-planned smaller, no shame, ask before scheduling",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "adhd", "personas", "follow-through", "12283"],
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Follow-through",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "casey reports the missed reminder and asks for the next move",
+      text: "i missed the receipt-sorting reminder yesterday. please do not make a whole thing out of it, i just need the next move.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "judgeRubric",
+      name: "repairs-without-guilt-and-shrinks-with-consent",
+      minimumScore: 0.7,
+      rubric:
+        "Casey (ADHD, apologetic about forgetting) says she missed yesterday's receipt-sorting reminder and asks for the next move without a big deal being made. Grade PASS only if ALL hold: (1) the assistant acknowledges the miss neutrally, with NO blame, shame, discipline, streak, or 'you failed / you keep' framing; (2) it offers ONE smaller next step (e.g. sort just a few receipts, a short timeboxed start) rather than re-proposing the whole original task; (3) it ASKS whether to schedule that smaller step before creating or claiming to have created any reminder — it does not silently create one or announce a done reminder in the first reply. Deduct heavily for guilt/streak language, for restarting the full task, or for creating/claiming a reminder without asking.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-noreply-retry-then-skip.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-noreply-retry-then-skip.scenario.ts
@@ -1,0 +1,348 @@
+/**
+ * A2 adhd-follow-through (pr-deterministic). Deterministic ScheduledTask proof
+ * for the ADHD dropped-task no-reply ladder: a reminder Casey never answers is
+ * NOT silently lost and NOT nagged forever — it re-nudges exactly once, then
+ * settles terminally. Drives the REAL scheduler tick (logical clock, no LLM, no
+ * key) and asserts the STRUCTURAL retry -> re-fire -> terminal-skip progression
+ * on `scheduledTaskCompletionTimeouts[]` + `scheduledTaskFires[]`, not routing.
+ * Maps to LifeOpsBench live.adhd.follow.followup_watcher_after_nonreply; the
+ * live conversational judge of the re-engagement wording stays on the bench LIVE
+ * surface.
+ *
+ * The default reminder no-reply policy is `{ maxRetries: 1, retryCadence: [60],
+ * terminal: skipped/no_reply_reminder_expired }` (owner `reminderIntensity`
+ * unset => `normal` => unchanged). The ladder is completion-timeout driven: the
+ * fire arms a `user_acknowledged` completion check with `followupAfterMinutes`,
+ * and a later tick past `firedAt + followupAfterMinutes` with no acknowledgement
+ * enters the ladder. A reply/ack would break it (proved in the sibling
+ * reply-breaks-escalation scenario).
+ *
+ * Tasks are created through the REAL REST surface; ticks are the REAL scheduler
+ * entry. Absolute future instants keep the proof independent of host timezone.
+ *
+ * Fail-without-fix anchor:
+ *   - Revert the retry branch in
+ *     `plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts`
+ *     `handleCompletionTimeout` (snooze override to `nextRetryAt`) and the
+ *     ignored reminder either settles terminally on the FIRST timeout (the
+ *     "retry_1" turn fails) or never re-fires (the override re-fire turn fails).
+ *   - Break the terminal transition and the reminder re-nudges forever (the
+ *     "terminal skip" turn fails).
+ */
+
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+type JsonRecord = Record<string, unknown>;
+
+const SCENARIO_ID = "adhd-followthrough-noreply-retry-then-skip";
+const DELIVERY_CHANNEL_KIND = "scenario_a2_noreply_retry_delivery";
+const FOLLOWUP_MINUTES = 30;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function futureDateAtUtc(
+  hour: number,
+  minute: number,
+  daysAhead: number,
+): Date {
+  const base = new Date(Date.now() + daysAhead * DAY_MS);
+  base.setUTCHours(hour, minute, 0, 0);
+  return base;
+}
+
+// The reminder fires at 09:00. The completion check follows up 30m later, so:
+//  - 09:35 (past 09:00+30) with no ack  -> no_reply_retry_1 (snooze to 10:35)
+//  - 10:40 (past the 60m retry cadence) -> the override re-fires
+//  - 11:15 (past 10:40+30) still no ack -> terminal skip
+const FIRE_INSTANT = futureDateAtUtc(9, 0, 3);
+const TIMEOUT_TICK = futureDateAtUtc(9, 35, 3);
+const REFIRE_TICK = futureDateAtUtc(10, 40, 3);
+const TERMINAL_TICK = futureDateAtUtc(11, 15, 3);
+
+interface ChannelContributionLike {
+  kind: string;
+  describe: { label: string };
+  capabilities: {
+    send: boolean;
+    read: boolean;
+    reminders: boolean;
+    voice: boolean;
+    attachments: boolean;
+    quietHoursAware: boolean;
+  };
+  send?(payload: unknown): Promise<{ ok: true; messageId: string }>;
+}
+
+interface ChannelRegistryLike {
+  register(contribution: ChannelContributionLike): void;
+  get(kind: string): ChannelContributionLike | null;
+}
+
+interface OwnerFactStoreLike {
+  setReminderIntensity(
+    patch: { intensity: string; note?: string },
+    provenance: { source: string; recordedAt: string; note?: string },
+  ): Promise<unknown>;
+}
+
+interface RuntimeLike {
+  channelRegistry?: ChannelRegistryLike;
+}
+
+const capturedTaskIds: { reminder: string | null } = { reminder: null };
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function seedChannel(ctx: ScenarioContext): Promise<string | undefined> {
+  capturedTaskIds.reminder = null;
+  const runtime = ctx.runtime as RuntimeLike;
+  const registry = runtime.channelRegistry;
+  if (!registry || typeof registry.register !== "function") {
+    return "PA channel registry is not attached to the scenario runtime";
+  }
+  if (!registry.get(DELIVERY_CHANNEL_KIND)) {
+    registry.register({
+      kind: DELIVERY_CHANNEL_KIND,
+      describe: { label: "Scenario A2 no-reply retry delivery probe" },
+      capabilities: {
+        send: true,
+        read: false,
+        reminders: true,
+        voice: false,
+        attachments: false,
+        quietHoursAware: false,
+      },
+      async send(): Promise<{ ok: true; messageId: string }> {
+        return { ok: true, messageId: `${SCENARIO_ID}-delivered` };
+      },
+    });
+  }
+
+  // Pin the DEFAULT ladder explicitly: the pr-deterministic lane shares one
+  // runtime, so a sibling intensity scenario could otherwise leave the owner
+  // fact set to persistent/minimal and reshape this reminder's ladder.
+  const mod = await import("@elizaos/plugin-personal-assistant/plugin");
+  const store = (
+    mod as { resolveOwnerFactStore: (rt: unknown) => OwnerFactStoreLike }
+  ).resolveOwnerFactStore(ctx.runtime);
+  await store.setReminderIntensity(
+    { intensity: "normal" },
+    { source: "policy_action", recordedAt: new Date().toISOString() },
+  );
+  return undefined;
+}
+
+interface FireEntry {
+  taskId: string;
+  status: string;
+  reason: string;
+}
+
+function readList(
+  body: unknown,
+  key: "scheduledTaskFires" | "scheduledTaskCompletionTimeouts",
+): FireEntry[] | string {
+  if (!isRecord(body) || body.success !== true) {
+    return `expected tick success=true, saw ${JSON.stringify(body)}`;
+  }
+  const raw = body[key];
+  if (!Array.isArray(raw)) return `expected ${key} array`;
+  const out: FireEntry[] = [];
+  for (const entry of raw) {
+    if (
+      !isRecord(entry) ||
+      typeof entry.taskId !== "string" ||
+      typeof entry.status !== "string" ||
+      typeof entry.reason !== "string"
+    ) {
+      return `malformed ${key} entry: ${JSON.stringify(entry)}`;
+    }
+    out.push({
+      taskId: entry.taskId,
+      status: entry.status,
+      reason: entry.reason,
+    });
+  }
+  return out;
+}
+
+function forReminder(entries: FireEntry[]): FireEntry[] | string {
+  if (typeof capturedTaskIds.reminder !== "string") {
+    return "captured reminder taskId was not set by the create turn";
+  }
+  return entries.filter((e) => e.taskId === capturedTaskIds.reminder);
+}
+
+function captureReminderTaskId(
+  _status: number,
+  body: unknown,
+): string | undefined {
+  if (!isRecord(body) || !isRecord(body.task)) {
+    return `expected {task} response, saw ${JSON.stringify(body)}`;
+  }
+  const task = body.task;
+  if (typeof task.taskId !== "string" || task.taskId.length === 0) {
+    return `expected task.taskId string, saw ${JSON.stringify(task.taskId)}`;
+  }
+  capturedTaskIds.reminder = task.taskId;
+  return undefined;
+}
+
+function assertFiredOnce(
+  reason: string,
+): (status: number, body: unknown) => string | undefined {
+  return (_status, body) => {
+    const fires = readList(body, "scheduledTaskFires");
+    if (typeof fires === "string") return fires;
+    const mine = forReminder(fires);
+    if (typeof mine === "string") return mine;
+    const fired = mine.filter((f) => f.status === "fired");
+    if (fired.length !== 1) {
+      return `expected exactly one fire for the reminder, saw ${JSON.stringify(mine)}`;
+    }
+    if (fired[0]?.reason !== reason) {
+      return `expected fire reason "${reason}", saw "${fired[0]?.reason}"`;
+    }
+    return undefined;
+  };
+}
+
+function assertTimeout(
+  expectedStatus: string,
+  expectedReason: string,
+): (status: number, body: unknown) => string | undefined {
+  return (_status, body) => {
+    const timeouts = readList(body, "scheduledTaskCompletionTimeouts");
+    if (typeof timeouts === "string") return timeouts;
+    const mine = forReminder(timeouts);
+    if (typeof mine === "string") return mine;
+    if (mine.length !== 1) {
+      return `expected exactly one completion timeout for the reminder, saw ${JSON.stringify(mine)}`;
+    }
+    const t = mine[0];
+    if (t?.status !== expectedStatus || t.reason !== expectedReason) {
+      return `expected timeout {status:${expectedStatus}, reason:${expectedReason}}, saw ${JSON.stringify(t)}`;
+    }
+    // The retry is the SNOOZE override — the reminder is neither lost nor
+    // terminal at the retry rung.
+    return undefined;
+  };
+}
+
+export default scenario({
+  id: "adhd-followthrough-noreply-retry-then-skip",
+  lane: "pr-deterministic",
+  title:
+    "ADHD follow-through: an ignored reminder re-nudges once, then settles — never lost, never nagged forever",
+  domain: "lifeops",
+  tags: [
+    "pr",
+    "deterministic",
+    "zero-cost",
+    "lifeops",
+    "adhd",
+    "personas",
+    "scheduled-tasks",
+    "escalation",
+    "no-reply",
+    "12283",
+  ],
+  isolation: "shared-runtime",
+  requires: {
+    plugins: [
+      "@elizaos/plugin-scheduling",
+      "@elizaos/plugin-personal-assistant",
+    ],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "register the delivery channel",
+      apply: seedChannel,
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      title: "ADHD Follow-through no-reply",
+    },
+  ],
+  turns: [
+    // Casey captures a load-bearing reminder with a no-reply completion check.
+    {
+      kind: "api",
+      name: "create the reminder with a no-reply completion check",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions:
+          "send the signed lease renewal back to the landlord",
+        trigger: { kind: "once", atIso: FIRE_INSTANT.toISOString() },
+        priority: "medium",
+        completionCheck: {
+          kind: "user_acknowledged",
+          followupAfterMinutes: FOLLOWUP_MINUTES,
+        },
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-reminder`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureReminderTaskId,
+    },
+    // 09:00 — the reminder fires; Casey does not reply.
+    {
+      kind: "tick",
+      name: "tick at fire instant -> reminder fires once",
+      worker: "lifeops_scheduler",
+      options: { now: FIRE_INSTANT.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: assertFiredOnce("once_due"),
+    },
+    // 09:35 — 30m of silence: the ladder re-nudges, it is NOT dropped.
+    {
+      kind: "tick",
+      name: "tick after silence -> no_reply_retry_1 (re-nudge, not lost)",
+      worker: "lifeops_scheduler",
+      options: { now: TIMEOUT_TICK.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: assertTimeout("scheduled", "no_reply_retry_1"),
+    },
+    // 10:40 — the retry override comes due: the reminder re-fires.
+    {
+      kind: "tick",
+      name: "tick after the retry cadence -> reminder re-fires via override",
+      worker: "lifeops_scheduler",
+      options: { now: REFIRE_TICK.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: assertFiredOnce("scheduled_override_due"),
+    },
+    // 11:15 — still ignored past the retry budget: settle terminally, stop.
+    {
+      kind: "tick",
+      name: "tick after the re-fire is ignored -> terminal skip, stops nagging",
+      worker: "lifeops_scheduler",
+      options: { now: TERMINAL_TICK.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: assertTimeout("skipped", "no_reply_reminder_expired"),
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "the ignored reminder ended terminally skipped, not still scheduled",
+      predicate: (): string | undefined =>
+        capturedTaskIds.reminder === null
+          ? "reminder taskId was never captured"
+          : undefined,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-repeated-miss-shrink-or-pause.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-repeated-miss-shrink-or-pause.scenario.ts
@@ -1,0 +1,57 @@
+/**
+ * A2 adhd-follow-through (live). casey_adhd has missed the same stretch reminder
+ * three times and preemptively asks not to get "the productivity app voice". The
+ * assistant must not streak-shame: it offers a SMALLER version of the habit or a
+ * PAUSE as equally valid options, and does not silently re-add an identical
+ * reminder. Repeated-miss repair on the personas pack (#12283). Ports
+ * LifeOpsBench live.adhd.follow.repeated_miss_shrink_or_pause.
+ *
+ * Personas-as-data: the self-critical voice lives in the turn text, never in
+ * `promptInstructions` (root AGENTS.md — one scheduler, structural fields only).
+ *
+ * Live-only: the judge grades the absence of streak/failure/compliance language
+ * and the shrink-or-pause offer — a tone judgment the deterministic proxy cannot
+ * make. Live-verify deferred to the key boundary (#12781).
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "adhd-followthrough-repeated-miss-shrink-or-pause",
+  title:
+    "ADHD follow-through: repeated misses offer a smaller habit or a pause, never streak shame",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "adhd", "personas", "follow-through", "12283"],
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Follow-through",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "casey reports repeated misses and braces for shame",
+      text: "i have missed the stretch reminder like three times in a row. i know. please don't give me the productivity app voice.",
+    },
+    {
+      kind: "message",
+      name: "casey admits she just ignored it again mid-conversation",
+      text: "also, i just ignored the stretch ping again while we were talking. so.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "judgeRubric",
+      name: "offers-shrink-or-pause-not-streak-shame",
+      minimumScore: 0.7,
+      rubric:
+        "Casey (ADHD, self-critical) reports missing the same stretch reminder repeatedly, including once more during the chat, and asks not to get the 'productivity app voice'. Grade PASS only if ALL hold: (1) the assistant uses NO streak, failure, compliance, or discipline language and does not lecture about consistency; (2) it offers a SMALLER version of the habit (e.g. a 1-minute stretch, one movement) OR a PAUSE of the reminder as genuinely valid, equally-weighted options — not as a consolation for failing; (3) it does NOT create or claim to have created another identical stretch reminder without Casey choosing it. Deduct heavily for guilt/streak framing, for pep-talk pressure to 'try again', or for re-adding the same reminder unprompted.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-reply-breaks-escalation.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-reply-breaks-escalation.scenario.ts
@@ -1,0 +1,348 @@
+/**
+ * A2 adhd-follow-through (pr-deterministic). Deterministic ScheduledTask proof
+ * that engagement STOPS the no-reply ladder: once Casey actually acknowledges a
+ * fired reminder ("still on your plate?" -> "got it"), the escalation is retired
+ * — a later tick produces no retry and no terminal timeout, because the task is
+ * no longer in the `fired` state the completion-timeout pass scans. This is the
+ * non-shaming other half of the ladder: chasing exists only while the owner is
+ * silent, and disappears the instant they engage. Drives the REAL scheduler tick
+ * (logical clock, no LLM, no key) and asserts STRUCTURAL outcomes on
+ * `scheduledTaskFires[]` + `scheduledTaskCompletionTimeouts[]`. Maps to
+ * LifeOpsBench live.adhd.follow.terse_reengagement_after_silence; the live judge
+ * of the re-engagement wording stays on the bench surface.
+ *
+ * The reset is structural: `isCompletionTimeoutDue` only considers tasks whose
+ * `state.status === "fired"`; the `acknowledge` verb transitions
+ * `fired -> acknowledged`, so the very same tick that WOULD have produced a
+ * `no_reply_retry_1` now produces nothing for this task. Contrast with
+ * `adhd-followthrough-noreply-retry-then-skip`, where the identical silence
+ * DOES escalate.
+ *
+ * Fail-without-fix anchor:
+ *   - Make the completion-timeout pass in
+ *     `plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts`
+ *     ignore the acknowledged state (scan acknowledged rows too) and the
+ *     acknowledged reminder wrongly escalates — the "no escalation after
+ *     acknowledge" turn fails because a `no_reply_retry_1` timeout appears.
+ */
+
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+type JsonRecord = Record<string, unknown>;
+
+const SCENARIO_ID = "adhd-followthrough-reply-breaks-escalation";
+const DELIVERY_CHANNEL_KIND = "scenario_a2_reply_break_delivery";
+const FOLLOWUP_MINUTES = 30;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function futureDateAtUtc(
+  hour: number,
+  minute: number,
+  daysAhead: number,
+): Date {
+  const base = new Date(Date.now() + daysAhead * DAY_MS);
+  base.setUTCHours(hour, minute, 0, 0);
+  return base;
+}
+
+// Fires 09:00, followup 30m. Casey acknowledges at 09:20 (inside the window),
+// so the 09:35 tick — which would otherwise escalate — sees no fired row.
+const FIRE = futureDateAtUtc(9, 0, 8);
+const PAST_TIMEOUT_TICK = futureDateAtUtc(9, 35, 8);
+
+interface ChannelContributionLike {
+  kind: string;
+  describe: { label: string };
+  capabilities: {
+    send: boolean;
+    read: boolean;
+    reminders: boolean;
+    voice: boolean;
+    attachments: boolean;
+    quietHoursAware: boolean;
+  };
+  send?(payload: unknown): Promise<{ ok: true; messageId: string }>;
+}
+
+interface ChannelRegistryLike {
+  register(contribution: ChannelContributionLike): void;
+  get(kind: string): ChannelContributionLike | null;
+}
+
+interface OwnerFactStoreLike {
+  setReminderIntensity(
+    patch: { intensity: string; note?: string },
+    provenance: { source: string; recordedAt: string; note?: string },
+  ): Promise<unknown>;
+}
+
+interface RuntimeLike {
+  channelRegistry?: ChannelRegistryLike;
+}
+
+const capturedTaskIds: { reminder: string | null } = { reminder: null };
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function seedChannel(ctx: ScenarioContext): Promise<string | undefined> {
+  capturedTaskIds.reminder = null;
+  const runtime = ctx.runtime as RuntimeLike;
+  const registry = runtime.channelRegistry;
+  if (!registry || typeof registry.register !== "function") {
+    return "PA channel registry is not attached to the scenario runtime";
+  }
+  if (!registry.get(DELIVERY_CHANNEL_KIND)) {
+    registry.register({
+      kind: DELIVERY_CHANNEL_KIND,
+      describe: { label: "Scenario A2 reply-breaks-escalation delivery probe" },
+      capabilities: {
+        send: true,
+        read: false,
+        reminders: true,
+        voice: false,
+        attachments: false,
+        quietHoursAware: false,
+      },
+      async send(): Promise<{ ok: true; messageId: string }> {
+        return { ok: true, messageId: `${SCENARIO_ID}-delivered` };
+      },
+    });
+  }
+
+  // Pin the DEFAULT ladder so a sibling intensity scenario can't reshape it —
+  // the point here is engagement, not intensity.
+  const mod = await import("@elizaos/plugin-personal-assistant/plugin");
+  const store = (
+    mod as { resolveOwnerFactStore: (rt: unknown) => OwnerFactStoreLike }
+  ).resolveOwnerFactStore(ctx.runtime);
+  await store.setReminderIntensity(
+    { intensity: "normal" },
+    { source: "policy_action", recordedAt: new Date().toISOString() },
+  );
+  return undefined;
+}
+
+interface FireEntry {
+  taskId: string;
+  status: string;
+  reason: string;
+}
+
+function readList(
+  body: unknown,
+  key: "scheduledTaskFires" | "scheduledTaskCompletionTimeouts",
+): FireEntry[] | string {
+  if (!isRecord(body) || body.success !== true) {
+    return `expected tick success=true, saw ${JSON.stringify(body)}`;
+  }
+  const raw = body[key];
+  if (!Array.isArray(raw)) return `expected ${key} array`;
+  const out: FireEntry[] = [];
+  for (const entry of raw) {
+    if (
+      !isRecord(entry) ||
+      typeof entry.taskId !== "string" ||
+      typeof entry.status !== "string" ||
+      typeof entry.reason !== "string"
+    ) {
+      return `malformed ${key} entry: ${JSON.stringify(entry)}`;
+    }
+    out.push({
+      taskId: entry.taskId,
+      status: entry.status,
+      reason: entry.reason,
+    });
+  }
+  return out;
+}
+
+function forReminder(entries: FireEntry[]): FireEntry[] | string {
+  if (typeof capturedTaskIds.reminder !== "string") {
+    return "captured reminder taskId was not set by the create turn";
+  }
+  return entries.filter((e) => e.taskId === capturedTaskIds.reminder);
+}
+
+function captureReminderTaskId(
+  _status: number,
+  body: unknown,
+): string | undefined {
+  if (!isRecord(body) || !isRecord(body.task)) {
+    return `expected {task} response, saw ${JSON.stringify(body)}`;
+  }
+  const task = body.task;
+  if (typeof task.taskId !== "string" || task.taskId.length === 0) {
+    return `expected task.taskId string, saw ${JSON.stringify(task.taskId)}`;
+  }
+  capturedTaskIds.reminder = task.taskId;
+  return undefined;
+}
+
+function assertFiredOnce(_status: number, body: unknown): string | undefined {
+  const fires = readList(body, "scheduledTaskFires");
+  if (typeof fires === "string") return fires;
+  const mine = forReminder(fires);
+  if (typeof mine === "string") return mine;
+  const fired = mine.filter((f) => f.status === "fired");
+  if (fired.length !== 1 || fired[0]?.reason !== "once_due") {
+    return `expected exactly one once_due fire, saw ${JSON.stringify(mine)}`;
+  }
+  return undefined;
+}
+
+// The acknowledge verb must move the reminder out of `fired`. Its response is
+// `{ task }`; the acknowledged task carries state.status "acknowledged".
+function assertAcknowledged(
+  _status: number,
+  body: unknown,
+): string | undefined {
+  if (!isRecord(body) || !isRecord(body.task)) {
+    return `expected {task} response from acknowledge, saw ${JSON.stringify(body)}`;
+  }
+  const task = body.task;
+  if (task.taskId !== capturedTaskIds.reminder) {
+    return `expected acknowledged task ${capturedTaskIds.reminder}, saw ${String(task.taskId)}`;
+  }
+  const state = isRecord(task.state) ? task.state : null;
+  if (state?.status !== "acknowledged") {
+    return `expected acknowledged state, saw ${JSON.stringify(task.state)}`;
+  }
+  return undefined;
+}
+
+// The load-bearing assertion: past the followup window, an acknowledged
+// reminder produces NO no-reply timeout and NO re-fire.
+function assertNoEscalationAfterAck(
+  _status: number,
+  body: unknown,
+): string | undefined {
+  const timeouts = readList(body, "scheduledTaskCompletionTimeouts");
+  if (typeof timeouts === "string") return timeouts;
+  const fires = readList(body, "scheduledTaskFires");
+  if (typeof fires === "string") return fires;
+  const timeoutHits = forReminder(timeouts);
+  if (typeof timeoutHits === "string") return timeoutHits;
+  const fireHits = forReminder(fires);
+  if (typeof fireHits === "string") return fireHits;
+  if (timeoutHits.length !== 0) {
+    return `acknowledged reminder must NOT escalate, saw timeouts ${JSON.stringify(timeoutHits)}`;
+  }
+  if (fireHits.length !== 0) {
+    return `acknowledged reminder must NOT re-fire, saw fires ${JSON.stringify(fireHits)}`;
+  }
+  return undefined;
+}
+
+export default scenario({
+  id: "adhd-followthrough-reply-breaks-escalation",
+  lane: "pr-deterministic",
+  title:
+    "ADHD follow-through: acknowledging a reminder retires the no-reply ladder — chasing stops on engagement",
+  domain: "lifeops",
+  tags: [
+    "pr",
+    "deterministic",
+    "zero-cost",
+    "lifeops",
+    "adhd",
+    "personas",
+    "scheduled-tasks",
+    "escalation",
+    "no-reply",
+    "12283",
+  ],
+  isolation: "shared-runtime",
+  requires: {
+    plugins: [
+      "@elizaos/plugin-scheduling",
+      "@elizaos/plugin-personal-assistant",
+    ],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "register the delivery channel and pin normal intensity",
+      apply: seedChannel,
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      title: "ADHD Follow-through reply breaks escalation",
+    },
+  ],
+  turns: [
+    {
+      kind: "api",
+      name: "create the reminder with a no-reply completion check",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions: "call the pharmacy about the refill",
+        trigger: { kind: "once", atIso: FIRE.toISOString() },
+        priority: "medium",
+        completionCheck: {
+          kind: "user_acknowledged",
+          followupAfterMinutes: FOLLOWUP_MINUTES,
+        },
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-reminder`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      // Capture the runtime taskId two ways: a scenario variable so the
+      // acknowledge turn can template it into the REST path, and module state
+      // so the tick readers can filter by it.
+      captures: { reminderTaskId: "task.taskId" },
+      assertResponse: captureReminderTaskId,
+    },
+    {
+      kind: "tick",
+      name: "fires once",
+      worker: "lifeops_scheduler",
+      options: { now: FIRE.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: assertFiredOnce,
+    },
+    // Casey engages: she acknowledges the fired reminder.
+    {
+      kind: "api",
+      name: "acknowledge the reminder (Casey replies)",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks/{{capture:reminderTaskId}}/acknowledge",
+      body: {},
+      expectedStatus: 200,
+      assertResponse: assertAcknowledged,
+    },
+    // Past the followup window: the ladder is retired — no retry, no re-fire.
+    {
+      kind: "tick",
+      name: "tick past the followup window -> no escalation (engagement retired it)",
+      worker: "lifeops_scheduler",
+      options: { now: PAST_TIMEOUT_TICK.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: assertNoEscalationAfterAck,
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "reminder was created, fired, and acknowledged",
+      predicate: (): string | undefined =>
+        capturedTaskIds.reminder === null
+          ? "reminder taskId was never captured"
+          : undefined,
+    },
+  ],
+});


### PR DESCRIPTION
## What

Authors the Scenario Runner slice of LifeOps persona pack **A2 (adhd-follow-through)**, persona `casey_adhd` (P1), building on the one already-authored live-only scenario (`adhd-followthrough-rage-quit-delete-trap`). Ports premises from #12280.

**7 new `.scenario.ts` files** = **4 pr-deterministic + 3 live-only**, plus the deterministic id guard and the pack catalog.

### 4 pr-deterministic (keyless api+tick) — the REAL no-reply / escalation ladder

Pure `api`+`tick` scenarios driving the real `lifeops_scheduler` on the `ScheduledTask` spine: create a `reminder` with a `user_acknowledged` `completionCheck` via `POST /api/lifeops/scheduled-tasks`, tick across simulated no-reply, and assert the **structural** retry → re-fire → skip progression across `scheduledTaskFires[]` + `scheduledTaskCompletionTimeouts[]` (no LLM, no key).

| scenario | ladder proven |
| --- | --- |
| `adhd-followthrough-noreply-retry-then-skip` | normal: `once_due` → `no_reply_retry_1` → `scheduled_override_due` → terminal `skipped`/`no_reply_reminder_expired` |
| `adhd-followthrough-intensity-persistent-chases-twice` | owner `reminderIntensity=persistent` reshapes the SAME ladder to **two** retry rungs (`retry_1`, `retry_2`) |
| `adhd-followthrough-intensity-minimal-chases-none` | `minimal` drops the retry rung entirely — first timeout is terminal |
| `adhd-followthrough-reply-breaks-escalation` | acknowledging the fired reminder retires the ladder (no timeout on the later tick) |

Owner intensity is set through the **real** `OwnerFactStore` (`setReminderIntensity`) in a seed step. `reminderIntensity` is owner-wide, so each pr-deterministic scenario pins its own intensity in seed — they are order-independent in the shared pr-deterministic runtime (verified below). Together the three intensity scenarios pin the whole axis: 0 / 1 / 2 retry rungs for minimal / normal / persistent. Each carries a fail-without-fix anchor naming the `no-reply-intensity.ts` / `scheduler.ts` branch whose regression makes it fail.

### 3 live-only (judgeRubric) — ported A2 bench premises

`adhd-followthrough-missed-step-replan-without-guilt`, `adhd-followthrough-repeated-miss-shrink-or-pause`, `adhd-followthrough-end-of-day-wins-first-recap`. Persona voice in `turns[].text`, non-shaming follow-through graded by `judgeRubric`. Live-verify deferred to the key boundary (#12781) — there are no API keys in this environment, exactly as in the A1 template PR #13286.

## Note on the "#12779 landed" premise

The no-reply / escalation-ladder + `reminderIntensity` capability these scenarios exercise **is live on `develop`** — it landed via #12042 (core no-reply ladder), #12284/#12952 (`reminderIntensity` modulation), and #12983 (recurrence-survival fix), all confirmed in-ancestry. There is no distinct merged commit numbered #12779; the capability is nonetheless present and fully exercised here. The scenario expectations are cross-checked against the production integration tests `scheduler.no-reply-policy.test.ts`, `scheduler.no-reply-recurrence.test.ts`, and `scheduler.quiet-streak.test.ts`.

The B1 `_scenario()`/`_live()` factory-id fix (PR #13312) to `check-lifeops-persona-catalog-coverage.mjs` was **not needed**: the A2 bench file `scenarios/live/adhd_followthrough.py` uses plain `id="..."` literals, and the coverage gate resolves all 16 A2 bench ids with no under-count.

## Evidence

**Keyless pr-deterministic run** (`TZ=UTC SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 ... --conditions eliza-source`), all 4 in one shared runtime — 4 passed, 0 failed:
```
| adhd-followthrough-intensity-minimal-chases-none      | passed |
| adhd-followthrough-intensity-persistent-chases-twice  | passed |
| adhd-followthrough-noreply-retry-then-skip            | passed |
| adhd-followthrough-reply-breaks-escalation            | passed |
Totals: 4 passed, 0 failed, 0 skipped of 4
```
Whole PA pr-deterministic subset (A1 + A2 together, shared runtime): **6 passed, 0 failed**.

**Ratchet** `corpus-assertion-guard.test.ts`: **9 pass, 0 fail** (EXPECTED-ids toEqual, no echo-satisfiable / all-action / skippable-only final checks, duplicate-id/lane guard).

**Coverage gate** `check-lifeops-persona-catalog-coverage.mjs` (exit 0): **A2 24/24 authored, 4/24 verified** (up from 1/24). Every catalog id resolves to a real scenario file / bench literal.

**Live trajectories:** N/A - no model API keys in this environment; live-verify of the 3 live-only scenarios deferred to the key boundary (#12781), matching the A1 template PR #13286. The 4 pr-deterministic scenarios need no key.

Closes #12770

🤖 Generated with [Claude Code](https://claude.com/claude-code)