### PR TITLE
fix: repair wave-2 fallback-sweep regressions (test mocks + typecheck)

### DIFF
--- a/packages/app-core/src/api/database-rows-compat-routes.test.ts
+++ b/packages/app-core/src/api/database-rows-compat-routes.test.ts
@@ -18,19 +18,28 @@ import { handleDatabaseRowsCompatRoute } from "./database-rows-compat-routes";
 // `ensureOwner` dependency seam is also covered so local route tests can avoid
 // pulling the full auth graph when they do not need it.
 
-const mocks = vi.hoisted(() => ({
-  executeRawSql: vi.fn(),
-  findActiveSession: vi.fn(async (store, sessionId) => {
-    const findSession = (
-      store as { findSession?: (id: string) => Promise<unknown> }
-    )?.findSession;
-    return typeof findSession === "function"
-      ? ((await findSession.call(store, sessionId)) ?? null)
-      : null;
-  }),
-  findIdentity: vi.fn(),
-  verifyCsrfToken: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  // Reset the shared module registry during hoist so this file's `./auth/*`
+  // mocks bind to a fresh auth graph. Under app-core's `isolate:false` runner a
+  // preceding suite (e.g. dev-route-catalog) can otherwise leave a cached
+  // `./auth/sessions` mock in place, and the real `ensureRouteMinRole` would
+  // resolve that stale `findActiveSession` instead of the one mocked below.
+  // Mirrors ensure-route-min-role.test.ts.
+  vi.resetModules();
+  return {
+    executeRawSql: vi.fn(),
+    findActiveSession: vi.fn(async (store, sessionId) => {
+      const findSession = (
+        store as { findSession?: (id: string) => Promise<unknown> }
+      )?.findSession;
+      return typeof findSession === "function"
+        ? ((await findSession.call(store, sessionId)) ?? null)
+        : null;
+    }),
+    findIdentity: vi.fn(),
+    verifyCsrfToken: vi.fn(),
+  };
+});
 
 vi.mock("@elizaos/core", () => ({
   ElizaError: class ElizaError extends Error {

--- a/packages/ui/src/hooks/useWhatsAppPairing.test.tsx
+++ b/packages/ui/src/hooks/useWhatsAppPairing.test.tsx
@@ -11,7 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const getWhatsAppStatus = vi.fn();
 const stopWhatsAppPairing = vi.fn();
 const disconnectWhatsApp = vi.fn();
-const onWsEvent = vi.fn(() => () => {});
+const onWsEvent = vi.fn<(...args: unknown[]) => () => void>(() => () => {});
 
 vi.mock("../api/client", () => ({
   client: {


### PR DESCRIPTION
## Summary

Five fallback-slop-sweep PRs (#13278, #13271, #13270, #13287, #13277) merged into `develop` despite non-merge review verdicts. This PR verifies each finding against **current** `develop` and repairs only the genuinely-red, PR-introduced regressions. **No fail-fast / `reportError` conversion is reverted** — those were verified correct.

Two of the five were real reds; three were already green on current develop (the review verdicts were written against earlier PR commits that the merged tree superseded). Each finding was verified by running the actual suite/typecheck on this branch (based on current `develop`) before any change.

## Per-finding verdicts

### 1. #13278 (app-core auth) — REAL, FIXED (root cause differed from the report)
The reported cause (a missing `denyOnAuthStoreError` export on the full-replacement `vi.mock('./auth/sessions')` factories) was **already resolved** — all three factories (`ensure-route-min-role.test.ts`, `auth-pairing-routes.test.ts`, `database-rows-compat-routes.test.ts`) already export it.

The **actual** red: app-core's `vitest.config.ts` runs with `isolate: false` + `maxWorkers: 1`, so every test file shares one module registry. `src/api/database-rows-compat-routes.test.ts` failed **5 tests** (OWNER-gate reads returned 401 instead of 200/403). It imports the *real* `ensureRouteMinRole` from `./auth.ts` and mocks only the session-lookup primitives — but a preceding suite (`dev-route-catalog.test.ts`) leaves a cached `./auth/sessions` mock whose `findActiveSession → null`, so the real guard resolved that stale mock instead of this file's.

**Fix:** call `vi.resetModules()` inside the file's `vi.hoisted(...)` block so its `./auth/*` mocks bind to a fresh auth graph — the exact pattern the sibling `ensure-route-min-role.test.ts` already uses and which keeps it immune. Self-contained to the one wave-2 file; no production code, no other test file, and no fail-fast conversion touched.

*(An earlier attempt to instead align the mismatched `vi.mock` specifiers to `.js` was rejected: it only shifted the cross-file contamination — it fixed `database-rows` but broke `auth-store-failure.test.ts`, which imports the real `denyOnAuthStoreError` and started picking up a leaked stub. The `resetModules` fix leaves every other suite at its passing baseline.)*

### 2. #13271 (agent) — NOT REAL (already correct in merged tree)
The reported `hasRoleAccess: (...args: unknown[]) => hasRoleAccess(...args)` TS2556 line **does not exist** in the merged `packages/agent/src/security/access.test.ts` (it uses a typed `runtimeWith(...)` helper). `packages/agent` typecheck reports no TS2556; its only errors are environmental TS2307 "cannot find `@elizaos/plugin-streaming`/`-vision`/…" for optional plugins not built in an isolated worktree — unrelated to #13271. All #13271 suites pass. No change.

### 3. #13270 (app plugins B) — NOT REAL (green)
PR touched only `plugin-agent-skills` and `plugin-browser`. `plugin-browser` 148/148 pass, `plugin-agent-skills` 42/42 pass. No change.

### 4. #13287 (app plugins A) — NOT REAL (field present)
`goal: doc.task.goal` is present on current develop in `orchestrator-task-service.ts` (7 occurrences incl. the completion-consumer site ~line 2709). The stale merge did not drop it. No change.

### 5. #13277 (ui) — REAL, FIXED
`packages/ui/src/hooks/useWhatsAppPairing.test.tsx(21,50): error TS2556` — the `onWsEvent` mock (`vi.fn(() => () => {})`) has a zero-arg signature, and the mock-factory wrapper `(...args: unknown[]) => onWsEvent(...args)` spreads `unknown[]` into it. `bun run --cwd packages/ui typecheck` failed on exactly this line. **Fix:** type the mock with a rest-param signature (`vi.fn<(...args: unknown[]) => () => void>(...)`). (The other three `vi.fn()` mocks default to rest params and did not error.)

## Verification (this branch, based on current develop)

```
# Finding 1 — full app-core src/api suite (real isolate:false ordering), 3 consecutive isolated runs
$ node ../scripts/run-vitest.mjs run --config vitest.config.ts src/api
  Test Files  42 passed (42)   Tests  292 passed (292)     # was: 1 failed file, 5 tests failed

# Finding 5 — ui typecheck + hook test
$ bun run --cwd packages/ui typecheck        → exit 0, 0 errors   # was: 1 error TS2556
$ vitest run src/hooks/useWhatsAppPairing.test.tsx → 3 passed

# Findings 2/3/4 (verified green, unchanged)
$ packages/agent typecheck → no TS2556 (only environmental TS2307 for optional plugins)
$ plugin-browser → 148 passed ;  plugin-agent-skills → 42 passed
$ orchestrator-task-service.ts → `goal: doc.task.goal` present (7×)
```

## Files changed
- `packages/app-core/src/api/database-rows-compat-routes.test.ts` — `vi.resetModules()` in the hoisted block (immunize against `isolate:false` cross-file mock leak)
- `packages/ui/src/hooks/useWhatsAppPairing.test.tsx` — typed `onWsEvent` mock signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
