### PR TITLE
fix(#12787): expose MCP community registry load failures

### DIFF
--- a/packages/cloud/api/__tests__/mcp-registry-community-availability.test.ts
+++ b/packages/cloud/api/__tests__/mcp-registry-community-availability.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression coverage for the public MCP catalog's community registry degrade path.
+ *
+ * The platform registry should remain available when the live community lookup
+ * fails, but clients must be able to distinguish "community unavailable" from
+ * a genuinely empty community registry.
+ */
+
+import { expect, mock, test } from "bun:test";
+
+const getCurrentUser = mock(async () => null);
+mock.module("@/lib/auth/workers-hono-auth", () => ({ getCurrentUser }));
+
+const listPublic = mock();
+const toRegistryFormat = mock();
+mock.module("@/lib/services/user-mcps", () => ({
+  userMcpsService: {
+    listPublic,
+    toRegistryFormat,
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: mock(),
+    error: mock(),
+    info: mock(),
+    warn: mock(),
+  },
+}));
+
+const registryRoute = (await import("../mcp/registry/route")).default;
+
+async function getRegistry() {
+  return await registryRoute.request("/", undefined, {
+    NEXT_PUBLIC_APP_URL: "https://app.example.test",
+  });
+}
+
+test("marks community registry unavailable when the optional live lookup fails", async () => {
+  listPublic.mockRejectedValueOnce(new Error("community registry unavailable"));
+
+  const response = await getRegistry();
+  expect(response.status).toBe(200);
+
+  const body = (await response.json()) as {
+    registry: Array<{ source: string }>;
+    platformMcps: number;
+    communityMcps: number;
+    communityRegistryAvailable: boolean;
+  };
+
+  expect(body.platformMcps).toBeGreaterThan(0);
+  expect(body.registry.some((entry) => entry.source === "platform")).toBe(true);
+  expect(body.communityMcps).toBe(0);
+  expect(body.communityRegistryAvailable).toBe(false);
+});
+
+test("keeps empty community registry distinct from a failed community lookup", async () => {
+  listPublic.mockResolvedValueOnce([]);
+
+  const response = await getRegistry();
+  expect(response.status).toBe(200);
+
+  const body = (await response.json()) as {
+    communityMcps: number;
+    communityRegistryAvailable: boolean;
+  };
+
+  expect(body.communityMcps).toBe(0);
+  expect(body.communityRegistryAvailable).toBe(true);
+});

--- a/packages/cloud/api/mcp/registry/route.ts
+++ b/packages/cloud/api/mcp/registry/route.ts
@@ -456,8 +456,11 @@ app.get("/", async (c) => {
       }),
     );
 
-    // Fetch user MCPs (public, live)
+    // Fetch user MCPs (public, live). The community subset is an enhancement on
+    // top of the always-available built-in registry, so a lookup failure/timeout
+    // degrades to built-in-only rather than 500-ing the whole public catalog.
     let userMcpRegistry: UserRegistryEntry[] = [];
+    let communityRegistryAvailable = true;
     try {
       const userMcps = await withRegistryTimeout(
         userMcpsService.listPublic({
@@ -477,7 +480,10 @@ app.get("/", async (c) => {
         };
       });
     } catch (error) {
-      // If user MCPs fail to load, continue with built-in only
+      // error-policy:J4 explicit degrade: the built-in catalog stays served, but
+      // the response marks this as a failed load rather than a genuinely-empty
+      // community registry.
+      communityRegistryAvailable = false;
       logger.warn("[MCP Registry] Failed to load user MCPs", {
         error: error instanceof Error ? error.message : String(error),
       });
@@ -526,6 +532,7 @@ app.get("/", async (c) => {
       totalInRegistry: registry.length,
       platformMcps: builtInRegistry.length,
       communityMcps: userMcpRegistry.length,
+      communityRegistryAvailable,
       appliedFilters: {
         category: category !== "all" ? category : null,
         status: status !== "all" ? status : null,


### PR DESCRIPTION
## Summary

- Adds an explicit `communityRegistryAvailable` boolean to the public MCP registry response.
- Keeps the built-in platform MCP catalog available when the optional community registry lookup fails.
- Makes the degrade observable so `communityMcps: 0` no longer conflates an empty community registry with a failed live lookup.

## Validation

- `bun test packages/cloud/api/__tests__/mcp-registry-community-availability.test.ts` -> 2 passed.
- `bunx @biomejs/biome check packages/cloud/api/mcp/registry/route.ts packages/cloud/api/__tests__/mcp-registry-community-availability.test.ts` -> passed.
- `git diff --check` -> passed.

## Evidence

- Real route handler is exercised by the new unit test with the community service rejecting and with an empty successful community result.
- No model behavior, app UI, DB migration, or billing path changes. Screenshots/video/trajectories: N/A.

Refs #12787; this is the MCP registry route slice only, not the entire cloud API fallback-slop sweep.