### PR TITLE
fix(cloud): surface withheld signup grants

### DIFF
--- a/packages/cloud/api/auth/siwe/verify/route.ts
+++ b/packages/cloud/api/auth/siwe/verify/route.ts
@@ -56,7 +56,15 @@ app.post("/", async (c) => {
     return c.json({ error: "SIWE verification failed" }, 401);
   }
 
-  const { user, isNewAccount } = await findOrCreateUserByWalletAddress(address);
+  const {
+    user,
+    isNewAccount,
+    initialCreditsGranted,
+    initialFreeCreditsUsd,
+    welcomeBonusWithheld,
+    welcomeBonusWithheldReason,
+    welcomeBonusWithheldMessage,
+  } = await findOrCreateUserByWalletAddress(address);
   if (!user.organization_id) {
     return c.json(
       { error: "Organization creation failed - please try again" },
@@ -77,6 +85,11 @@ app.post("/", async (c) => {
     apiKey: plainKey,
     address: getAddress(address),
     isNewAccount,
+    initialCreditsGranted,
+    initialFreeCreditsUsd,
+    welcomeBonusWithheld: welcomeBonusWithheld === true,
+    welcomeBonusWithheldReason,
+    welcomeBonusWithheldMessage,
     user: {
       id: user.id,
       wallet_address: user.wallet_address,

--- a/packages/cloud/api/auth/steward-nonce-exchange/route.ts
+++ b/packages/cloud/api/auth/steward-nonce-exchange/route.ts
@@ -496,6 +496,11 @@ app.post("/", async (c) => {
     stewardUserId: claims.userId,
     expiresAt: exchange.data.expiresAt,
     expiresIn: exchange.data.expiresIn,
+    initialCreditsGranted: cloudUser.initialCreditsGranted,
+    initialFreeCreditsUsd: cloudUser.initialFreeCreditsUsd,
+    welcomeBonusWithheld: cloudUser.welcomeBonusWithheld === true,
+    welcomeBonusWithheldReason: cloudUser.welcomeBonusWithheldReason,
+    welcomeBonusWithheldMessage: cloudUser.welcomeBonusWithheldMessage,
     ...(shouldReturnClientToken(c, isProduction)
       ? { token, refreshToken }
       : {}),

--- a/packages/cloud/api/auth/steward-session/route.ts
+++ b/packages/cloud/api/auth/steward-session/route.ts
@@ -308,6 +308,11 @@ app.post("/", async (c) => {
       ok: true,
       userId: cloudUser.id,
       stewardUserId: claims.userId,
+      initialCreditsGranted: cloudUser.initialCreditsGranted,
+      initialFreeCreditsUsd: cloudUser.initialFreeCreditsUsd,
+      welcomeBonusWithheld: cloudUser.welcomeBonusWithheld === true,
+      welcomeBonusWithheldReason: cloudUser.welcomeBonusWithheldReason,
+      welcomeBonusWithheldMessage: cloudUser.welcomeBonusWithheldMessage,
     };
     return c.json(response);
   } catch {

--- a/packages/cloud/api/v1/agents/route.test.ts
+++ b/packages/cloud/api/v1/agents/route.test.ts
@@ -15,10 +15,19 @@ const findOrCreateUserByWalletAddress = mock(async (walletAddress: string) => ({
     wallet_address: walletAddress,
   },
 }));
-const grantInitialCreditsToWalletAccount = mock(async () => ({
-  initialCreditsGranted: true,
-  initialFreeCreditsUsd: 5,
-}));
+type InitialCreditGrantMockResult = {
+  initialCreditsGranted: boolean;
+  initialFreeCreditsUsd: number;
+  welcomeBonusWithheld?: boolean;
+  welcomeBonusWithheldReason?: "ip_daily_cap";
+  welcomeBonusWithheldMessage?: string;
+};
+const grantInitialCreditsToWalletAccount = mock(
+  async (): Promise<InitialCreditGrantMockResult> => ({
+    initialCreditsGranted: true,
+    initialFreeCreditsUsd: 5,
+  }),
+);
 type CreditGateResult = { allowed: boolean; balance: number; error?: string };
 
 const checkAgentCreditGate = mock(
@@ -751,6 +760,70 @@ describe("service agent provisioning route", () => {
     expect(checkAgentCreditGate).toHaveBeenCalledWith("agent-wallet-org");
     expect(checkProvisioningWorkerHealth).toHaveBeenCalledTimes(1);
     expect(createCharacter).toHaveBeenCalledTimes(1);
+    expect(deleteCharacter).toHaveBeenCalledWith("character-1");
+    expect(createAgent).not.toHaveBeenCalled();
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+  });
+
+  test("explains insufficient credits after a same-session welcome bonus withhold", async () => {
+    grantInitialCreditsToWalletAccount.mockResolvedValueOnce({
+      initialCreditsGranted: false,
+      initialFreeCreditsUsd: 0,
+      welcomeBonusWithheld: true,
+      welcomeBonusWithheldReason: "ip_daily_cap",
+      welcomeBonusWithheldMessage:
+        "Welcome credit unavailable because this network reached the daily free-credit limit. Add funds to start an agent.",
+    });
+    checkAgentCreditGate.mockResolvedValueOnce({
+      allowed: false,
+      balance: 0,
+      error: "Insufficient credits",
+    });
+
+    const response = await app.fetch(
+      new Request("https://api.example.test/", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "X-Service-Key": "svc",
+        },
+        body: JSON.stringify({
+          tokenContractAddress: "0x0000000000000000000000000000000000000009",
+          chain: "bsc",
+          chainId: 56,
+          tokenName: "Waifu Smoke",
+          tokenTicker: "WSMOKE",
+          launchType: "native",
+          character: { name: "Smoke Agent" },
+          account: {
+            primaryWalletAddress: "0x0000000000000000000000000000000000000001",
+            chainType: "evm",
+          },
+          billing: {
+            mode: "owner_credits",
+            initialReserveUsd: 5,
+          },
+          container: {
+            image: "registry.example.test/waifu-agent:latest",
+          },
+        }),
+      }),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(402);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      code: "insufficient_credits",
+      error:
+        "Welcome credit unavailable because this network reached the daily free-credit limit. Add funds to start an agent.",
+      requiredBalance: 0.1,
+      currentBalance: 0,
+      welcomeBonusWithheld: true,
+      welcomeBonusWithheldReason: "ip_daily_cap",
+    });
+    expect(grantInitialCreditsToWalletAccount).toHaveBeenCalledTimes(1);
+    expect(checkAgentCreditGate).toHaveBeenCalledWith("agent-wallet-org");
     expect(deleteCharacter).toHaveBeenCalledWith("character-1");
     expect(createAgent).not.toHaveBeenCalled();
     expect(enqueueAgentProvision).not.toHaveBeenCalled();

--- a/packages/cloud/api/v1/agents/route.ts
+++ b/packages/cloud/api/v1/agents/route.ts
@@ -309,6 +309,9 @@ app.post("/", async (c) => {
 
     let initialCreditsGranted = false;
     let initialFreeCreditsUsd = 0;
+    let welcomeBonusWithheld = false;
+    let welcomeBonusWithheldReason: "ip_daily_cap" | undefined;
+    let welcomeBonusWithheldMessage: string | undefined;
     let agent: Awaited<
       ReturnType<typeof elizaSandboxService.createAgent>
     >["agent"];
@@ -321,6 +324,9 @@ app.post("/", async (c) => {
         });
         initialCreditsGranted = creditGrant.initialCreditsGranted;
         initialFreeCreditsUsd = creditGrant.initialFreeCreditsUsd;
+        welcomeBonusWithheld = creditGrant.welcomeBonusWithheld === true;
+        welcomeBonusWithheldReason = creditGrant.welcomeBonusWithheldReason;
+        welcomeBonusWithheldMessage = creditGrant.welcomeBonusWithheldMessage;
       }
 
       const creditCheck = await checkAgentCreditGate(ownerOrganizationId);
@@ -334,6 +340,12 @@ app.post("/", async (c) => {
               orgId: ownerOrganizationId,
               serviceOrgId: identity.organizationId,
               walletOwned: Boolean(walletAccount),
+            },
+            {
+              welcomeBonusWithheldReason: welcomeBonusWithheld
+                ? welcomeBonusWithheldReason
+                : undefined,
+              welcomeBonusWithheldMessage,
             },
           ),
           402,
@@ -506,6 +518,9 @@ app.post("/", async (c) => {
                 isNewAccount: walletAccount.isNewAccount,
                 initialCreditsGranted,
                 initialFreeCreditsUsd,
+                welcomeBonusWithheld,
+                welcomeBonusWithheldReason,
+                welcomeBonusWithheldMessage,
               }
             : null,
         },
@@ -579,6 +594,9 @@ app.post("/", async (c) => {
               isNewAccount: walletAccount.isNewAccount,
               initialCreditsGranted,
               initialFreeCreditsUsd,
+              welcomeBonusWithheld,
+              welcomeBonusWithheldReason,
+              welcomeBonusWithheldMessage,
             }
           : null,
       },

--- a/packages/cloud/shared/src/lib/services/agent-billing-gate-402.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-billing-gate-402.test.ts
@@ -27,6 +27,28 @@ describe("insufficientCreditsBody", () => {
     expect(body.success).toBe(false);
     expect(body.code).toBe("insufficient_credits");
   });
+
+  test("explains a zero balance caused by a withheld welcome bonus", () => {
+    const body = insufficientCreditsBody(
+      { balance: 0, error: "Insufficient credits" },
+      {
+        welcomeBonusWithheldReason: "ip_daily_cap",
+        welcomeBonusWithheldMessage:
+          "Welcome credit unavailable because this network reached the daily free-credit limit. Add funds to start an agent.",
+      },
+    );
+
+    expect(body).toStrictEqual({
+      success: false,
+      code: "insufficient_credits",
+      error:
+        "Welcome credit unavailable because this network reached the daily free-credit limit. Add funds to start an agent.",
+      requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
+      currentBalance: 0,
+      welcomeBonusWithheld: true,
+      welcomeBonusWithheldReason: "ip_daily_cap",
+    });
+  });
 });
 
 describe("insufficientCredits402", () => {

--- a/packages/cloud/shared/src/lib/services/agent-billing-gate-402.ts
+++ b/packages/cloud/shared/src/lib/services/agent-billing-gate-402.ts
@@ -11,6 +11,7 @@
 import { AGENT_PRICING } from "../constants/agent-pricing";
 import { logger } from "../utils/logger";
 import type { CreditGateResult } from "./agent-billing-gate";
+import type { SignupGrantWithheldReason } from "./signup-grant-guard";
 
 export interface InsufficientCreditsBody {
   success: false;
@@ -18,18 +19,36 @@ export interface InsufficientCreditsBody {
   error: string;
   requiredBalance: number;
   currentBalance: number;
+  welcomeBonusWithheld?: boolean;
+  welcomeBonusWithheldReason?: SignupGrantWithheldReason;
+}
+
+export interface InsufficientCreditsContext {
+  welcomeBonusWithheldReason?: SignupGrantWithheldReason;
+  welcomeBonusWithheldMessage?: string;
 }
 
 /** Build the canonical 402 body from a denied `checkAgentCreditGate` result. */
 export function insufficientCreditsBody(
   creditCheck: Pick<CreditGateResult, "balance" | "error">,
+  context: InsufficientCreditsContext = {},
 ): InsufficientCreditsBody {
+  const welcomeBonusWithheld = context.welcomeBonusWithheldReason && creditCheck.balance === 0;
   return {
     success: false,
     code: "insufficient_credits",
-    error: creditCheck.error ?? "Insufficient credits",
+    error: welcomeBonusWithheld
+      ? (context.welcomeBonusWithheldMessage ??
+        "Welcome credit unavailable for this signup. Add funds to start an agent.")
+      : (creditCheck.error ?? "Insufficient credits"),
     requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
     currentBalance: creditCheck.balance,
+    ...(welcomeBonusWithheld
+      ? {
+          welcomeBonusWithheld: true,
+          welcomeBonusWithheldReason: context.welcomeBonusWithheldReason,
+        }
+      : {}),
   };
 }
 
@@ -42,11 +61,15 @@ export function insufficientCredits402(
   creditCheck: Pick<CreditGateResult, "balance" | "error">,
   warn: string,
   logContext: Record<string, unknown>,
+  context: InsufficientCreditsContext = {},
 ): InsufficientCreditsBody {
   logger.warn(warn, {
     ...logContext,
     balance: creditCheck.balance,
     required: AGENT_PRICING.MINIMUM_DEPOSIT,
+    ...(context.welcomeBonusWithheldReason
+      ? { welcomeBonusWithheldReason: context.welcomeBonusWithheldReason }
+      : {}),
   });
-  return insufficientCreditsBody(creditCheck);
+  return insufficientCreditsBody(creditCheck, context);
 }

--- a/packages/cloud/shared/src/lib/services/signup-grant-guard.test.ts
+++ b/packages/cloud/shared/src/lib/services/signup-grant-guard.test.ts
@@ -11,6 +11,8 @@ interface GrantRow {
   ip: string;
 }
 
+type TxResult = boolean | { granted?: boolean };
+
 // Committed grant rows, visible to every new transaction's COUNT.
 let committedGrants: GrantRow[] = [];
 // Per-lock-key queue of waiters, enforcing FIFO mutual exclusion.
@@ -19,7 +21,7 @@ const lockHolders = new Map<string, Promise<void>>();
 let executedSql: string[] = [];
 
 function sqlText(query: unknown): string {
-  // drizzle `sql` template → the queryChunks carry the static text; we only need
+  // drizzle `sql` template -> the queryChunks carry the static text; we only need
   // to recognize which statement ran, so stringify and scan.
   return JSON.stringify(query);
 }
@@ -68,7 +70,7 @@ function extractIp(query: unknown, prefix: string): string | undefined {
 // Mock dbWrite.transaction with advisory-lock-aware serialization: a transaction
 // whose lock key is already held waits behind the current holder; on commit its
 // pending grant rows become visible and the lock is released to the next waiter.
-const transaction = mock(async (fn: (tx: FakeTx) => Promise<boolean>): Promise<boolean> => {
+const transaction = mock(async (fn: (tx: FakeTx) => Promise<TxResult>): Promise<TxResult> => {
   const tx = new FakeTx();
   // Run the body to discover the lock key (the advisory-lock execute sets tx.ip),
   // but gate the *grant + count* behind the lock by re-entering once acquired.
@@ -81,7 +83,7 @@ const transaction = mock(async (fn: (tx: FakeTx) => Promise<boolean>): Promise<b
 // Serialize transaction bodies that share a lock key. Because the ip isn't known
 // until the lock statement runs inside the body, we wrap the body so the first
 // `pg_advisory_xact_lock` call blocks until the prior same-ip tx has committed.
-async function runSerialized(tx: FakeTx, fn: (tx: FakeTx) => Promise<boolean>): Promise<boolean> {
+async function runSerialized(tx: FakeTx, fn: (tx: FakeTx) => Promise<TxResult>): Promise<TxResult> {
   let release!: () => void;
   const held = new Promise<void>((r) => {
     release = r;
@@ -110,10 +112,11 @@ async function runSerialized(tx: FakeTx, fn: (tx: FakeTx) => Promise<boolean>): 
   };
 
   try {
-    const granted = await fn(tx);
+    const result = await fn(tx);
     // Commit: a granted body's row becomes visible to subsequent counts.
+    const granted = result === true || (typeof result === "object" && result?.granted === true);
     if (granted && tx.ip) committedGrants.push({ ip: tx.ip });
-    return granted;
+    return result;
   } finally {
     release(); // release the advisory lock to the next same-ip waiter
   }
@@ -127,9 +130,41 @@ mock.module("../utils/logger", () => ({
   logger: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} },
 }));
 
-const { runWithSignupGrantIpCap, FREE_GRANT_IP_LIMITS } = await import("./signup-grant-guard");
+const { runWithSignupGrantIpCap, resolveSignupGrantIpLimits, FREE_GRANT_IP_LIMITS } = await import(
+  "./signup-grant-guard"
+);
 
 const CAP = FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY;
+
+describe("resolveSignupGrantIpLimits", () => {
+  test("uses safe defaults when env is unset or invalid", () => {
+    expect(resolveSignupGrantIpLimits({})).toEqual({
+      MAX_FREE_GRANTS_PER_IP_DAILY: 3,
+      WINDOW_HOURS: 24,
+    });
+    expect(
+      resolveSignupGrantIpLimits({
+        MAX_FREE_GRANTS_PER_IP_DAILY: "0",
+        FREE_GRANT_IP_WINDOW_HOURS: "nope",
+      }),
+    ).toEqual({
+      MAX_FREE_GRANTS_PER_IP_DAILY: 3,
+      WINDOW_HOURS: 24,
+    });
+  });
+
+  test("accepts positive integer cap and window overrides", () => {
+    expect(
+      resolveSignupGrantIpLimits({
+        MAX_FREE_GRANTS_PER_IP_DAILY: "12",
+        FREE_GRANT_IP_WINDOW_HOURS: "6",
+      }),
+    ).toEqual({
+      MAX_FREE_GRANTS_PER_IP_DAILY: 12,
+      WINDOW_HOURS: 6,
+    });
+  });
+});
 
 describe("runWithSignupGrantIpCap (anti-sybil free-grant cap)", () => {
   beforeEach(() => {
@@ -182,7 +217,7 @@ describe("runWithSignupGrantIpCap (anti-sybil free-grant cap)", () => {
 
   // The regression: with the cap one slot below the limit, fire TWO simultaneous
   // same-IP grant attempts. The advisory lock must serialize them so the second
-  // sees the first's committed row and is denied — only ONE grant lands. The old
+  // sees the first's committed row and is denied -- only ONE grant lands. The old
   // count-then-insert guard (no lock) let both read `count < cap` and both grant.
   test("two concurrent same-IP attempts cannot both pass the cap (TOCTOU)", async () => {
     // Seed CAP-1 so exactly one more grant is permitted.

--- a/packages/cloud/shared/src/lib/services/signup-grant-guard.ts
+++ b/packages/cloud/shared/src/lib/services/signup-grant-guard.ts
@@ -26,10 +26,41 @@ import type { DbTransaction } from "../../db/client";
 import { dbWrite } from "../../db/client";
 import { logger } from "../utils/logger";
 
-export const FREE_GRANT_IP_LIMITS = {
-  /** Max free welcome-bonus grants per source IP per rolling 24h. */
-  MAX_FREE_GRANTS_PER_IP_DAILY: 3,
-} as const;
+type SignupGrantIpLimitEnv = {
+  [key: string]: string | undefined;
+  MAX_FREE_GRANTS_PER_IP_DAILY?: string;
+  FREE_GRANT_IP_WINDOW_HOURS?: string;
+};
+
+export function resolveSignupGrantIpLimits(env: SignupGrantIpLimitEnv = process.env): {
+  MAX_FREE_GRANTS_PER_IP_DAILY: number;
+  WINDOW_HOURS: number;
+} {
+  return {
+    /** Max free welcome-bonus grants per source IP per rolling 24h. */
+    MAX_FREE_GRANTS_PER_IP_DAILY: readPositiveIntEnv(env.MAX_FREE_GRANTS_PER_IP_DAILY, 3),
+    /** Rolling cap window in hours. */
+    WINDOW_HOURS: readPositiveIntEnv(env.FREE_GRANT_IP_WINDOW_HOURS, 24),
+  };
+}
+
+export const FREE_GRANT_IP_LIMITS = resolveSignupGrantIpLimits();
+
+export type SignupGrantWithheldReason = "ip_daily_cap";
+
+export interface SignupGrantDecision {
+  granted: boolean;
+  withheldReason?: SignupGrantWithheldReason;
+  withheldMessage?: string;
+  cap?: number;
+  windowHours?: number;
+}
+
+function readPositiveIntEnv(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 function maskIp(ip: string): string {
   // IPv4: keep the first two octets; otherwise just the prefix.
@@ -55,12 +86,26 @@ export async function runWithSignupGrantIpCap(
   ip: string | undefined,
   grant: (tx?: DbTransaction) => Promise<void>,
 ): Promise<boolean> {
+  return (await runWithSignupGrantIpCapDetailed(ip, grant)).granted;
+}
+
+/**
+ * Detailed variant of `runWithSignupGrantIpCap` for signup routes that must
+ * tell the caller whether a $0 new org means "empty balance" or "welcome
+ * bonus withheld by anti-sybil policy".
+ */
+export async function runWithSignupGrantIpCapDetailed(
+  ip: string | undefined,
+  grant: (tx?: DbTransaction) => Promise<void>,
+): Promise<SignupGrantDecision> {
   if (!ip) {
     await grant();
-    return true;
+    return { granted: true };
   }
 
-  const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const windowHours = FREE_GRANT_IP_LIMITS.WINDOW_HOURS;
+  const cap = FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY;
+  const dayAgo = new Date(Date.now() - windowHours * 60 * 60 * 1000);
 
   return await dbWrite.transaction(async (tx) => {
     // Serialize same-IP grant attempts: the lock is held for the whole
@@ -77,19 +122,27 @@ export async function runWithSignupGrantIpCap(
     `);
 
     const granted = Number((result.rows[0] as { count: string } | undefined)?.count ?? 0);
-    if (granted >= FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY) {
+    if (granted >= cap) {
       logger.warn(
         "[SignupGrantGuard] Per-IP daily free-grant cap reached; withholding welcome bonus",
         {
           ip: maskIp(ip),
           granted,
-          cap: FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY,
+          cap,
+          windowHours,
         },
       );
-      return false;
+      return {
+        granted: false,
+        withheldReason: "ip_daily_cap",
+        withheldMessage:
+          "Welcome credit unavailable because this network reached the daily free-credit limit. Add funds to start an agent.",
+        cap,
+        windowHours,
+      };
     }
 
     await grant(tx);
-    return true;
+    return { granted: true };
   });
 }

--- a/packages/cloud/shared/src/lib/services/wallet-signup.ts
+++ b/packages/cloud/shared/src/lib/services/wallet-signup.ts
@@ -13,7 +13,10 @@ import { getClientIp } from "../runtime/request-context";
 import { logger } from "../utils/logger";
 import { creditsService } from "./credits";
 import { organizationsService } from "./organizations";
-import { runWithSignupGrantIpCap } from "./signup-grant-guard";
+import {
+  runWithSignupGrantIpCapDetailed,
+  type SignupGrantWithheldReason,
+} from "./signup-grant-guard";
 import { usersService } from "./users";
 
 export const INITIAL_FREE_CREDITS = ((): number => {
@@ -30,21 +33,31 @@ export interface FindOrCreateWalletOptions {
   requireInitialCredits?: boolean;
 }
 
+export interface InitialCreditGrantMetadata {
+  initialCreditsGranted: boolean;
+  initialFreeCreditsUsd: number;
+  welcomeBonusWithheld?: boolean;
+  welcomeBonusWithheldReason?: SignupGrantWithheldReason;
+  welcomeBonusWithheldMessage?: string;
+}
+
 async function grantWalletSignupCredits(params: {
   organizationId: string;
   amount: number;
   chain: "evm" | "solana";
   idempotencyKey: string;
   requireInitialCredits: boolean;
-}): Promise<boolean> {
-  if (params.amount <= 0) return false;
+}): Promise<InitialCreditGrantMetadata> {
+  if (params.amount <= 0) {
+    return { initialCreditsGranted: false, initialFreeCreditsUsd: 0 };
+  }
 
   // Anti-sybil: withhold the bonus when this IP has hit the daily free-grant
   // cap. The cap check and the grant run under a per-IP advisory lock so
   // concurrent same-IP signups cannot each pass the cap before any commits.
   const signupIp = getClientIp();
   try {
-    return await runWithSignupGrantIpCap(signupIp, async (tx) => {
+    const decision = await runWithSignupGrantIpCapDetailed(signupIp, async (tx) => {
       await creditsService.addCredits({
         organizationId: params.organizationId,
         amount: params.amount,
@@ -54,12 +67,23 @@ async function grantWalletSignupCredits(params: {
         db: tx,
       });
     });
+    return {
+      initialCreditsGranted: decision.granted,
+      initialFreeCreditsUsd: decision.granted ? params.amount : 0,
+      ...(decision.withheldReason
+        ? {
+            welcomeBonusWithheld: true,
+            welcomeBonusWithheldReason: decision.withheldReason,
+            welcomeBonusWithheldMessage: decision.withheldMessage,
+          }
+        : {}),
+    };
   } catch (err) {
     logger.error("[WalletSignup] Failed to grant initial credits:", err);
     if (params.requireInitialCredits) {
       throw err;
     }
-    return false;
+    return { initialCreditsGranted: false, initialFreeCreditsUsd: 0 };
   }
 }
 
@@ -71,10 +95,13 @@ export async function grantInitialCreditsToWalletAccount(params: {
 }): Promise<{
   initialCreditsGranted: boolean;
   initialFreeCreditsUsd: number;
+  welcomeBonusWithheld?: boolean;
+  welcomeBonusWithheldReason?: SignupGrantWithheldReason;
+  welcomeBonusWithheldMessage?: string;
 }> {
   const address = getAddress(params.walletAddress);
   const normalized = address.toLowerCase();
-  const granted =
+  const grantResult =
     INITIAL_FREE_CREDITS > 0
       ? await grantWalletSignupCredits({
           organizationId: params.organizationId,
@@ -83,12 +110,9 @@ export async function grantInitialCreditsToWalletAccount(params: {
           idempotencyKey: `wallet-signup:evm:${normalized}`,
           requireInitialCredits: params.requireInitialCredits === true,
         })
-      : false;
+      : { initialCreditsGranted: false, initialFreeCreditsUsd: 0 };
 
-  return {
-    initialCreditsGranted: granted,
-    initialFreeCreditsUsd: granted ? INITIAL_FREE_CREDITS : 0,
-  };
+  return grantResult;
 }
 
 /**
@@ -104,6 +128,9 @@ export async function findOrCreateUserByWalletAddress(
   isNewAccount: boolean;
   initialCreditsGranted?: boolean;
   initialFreeCreditsUsd?: number;
+  welcomeBonusWithheld?: boolean;
+  welcomeBonusWithheldReason?: SignupGrantWithheldReason;
+  welcomeBonusWithheldMessage?: string;
 }> {
   const address = getAddress(walletAddress);
   const normalized = address.toLowerCase();
@@ -140,7 +167,7 @@ export async function findOrCreateUserByWalletAddress(
       // Note: Skip initial credits for raced org - first creator already granted them
     }
   }
-  const initialCreditsGranted =
+  const initialCreditGrant =
     grantInitialCredits && INITIAL_FREE_CREDITS > 0
       ? await grantWalletSignupCredits({
           organizationId: org.id,
@@ -149,7 +176,7 @@ export async function findOrCreateUserByWalletAddress(
           idempotencyKey: `wallet-signup:evm:${normalized}`,
           requireInitialCredits,
         })
-      : false;
+      : { initialCreditsGranted: false, initialFreeCreditsUsd: 0 };
 
   try {
     const created = await usersRepository.create({
@@ -168,8 +195,7 @@ export async function findOrCreateUserByWalletAddress(
     return {
       user,
       isNewAccount: true,
-      initialCreditsGranted,
-      initialFreeCreditsUsd: initialCreditsGranted ? INITIAL_FREE_CREDITS : 0,
+      ...initialCreditGrant,
     };
   } catch (e) {
     /* WHY handle unique violation: two concurrent signups for same wallet; second should see the first's user. */
@@ -195,6 +221,9 @@ export async function findOrCreateSolanaUserByWalletAddress(
   isNewAccount: boolean;
   initialCreditsGranted?: boolean;
   initialFreeCreditsUsd?: number;
+  welcomeBonusWithheld?: boolean;
+  welcomeBonusWithheldReason?: SignupGrantWithheldReason;
+  welcomeBonusWithheldMessage?: string;
 }> {
   const address = walletAddress.trim();
   if (!address) {
@@ -228,7 +257,7 @@ export async function findOrCreateSolanaUserByWalletAddress(
       }
     }
   }
-  const initialCreditsGranted =
+  const initialCreditGrant =
     grantInitialCredits && INITIAL_FREE_CREDITS > 0
       ? await grantWalletSignupCredits({
           organizationId: org.id,
@@ -237,7 +266,7 @@ export async function findOrCreateSolanaUserByWalletAddress(
           idempotencyKey: `wallet-signup:solana:${address}`,
           requireInitialCredits,
         })
-      : false;
+      : { initialCreditsGranted: false, initialFreeCreditsUsd: 0 };
 
   try {
     const created = await usersRepository.create({
@@ -253,8 +282,7 @@ export async function findOrCreateSolanaUserByWalletAddress(
     return {
       user,
       isNewAccount: true,
-      initialCreditsGranted,
-      initialFreeCreditsUsd: initialCreditsGranted ? INITIAL_FREE_CREDITS : 0,
+      ...initialCreditGrant,
     };
   } catch (e) {
     const isUniqueViolation =

--- a/packages/cloud/shared/src/lib/steward-sync-grant.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-grant.test.ts
@@ -174,7 +174,11 @@ describe("syncUserFromSteward — initial-credits grant fallback", () => {
     ).toHaveLength(0);
     // No grant failure surfaced.
     expect(loggerErrorCalls.some((c) => c.message.includes("addCredits failed"))).toBe(false);
-    expect(result).toBe(finalUserWithOrg as never);
+    expect(result).toMatchObject({
+      ...finalUserWithOrg,
+      initialCreditsGranted: true,
+      initialFreeCreditsUsd: 5,
+    });
   });
 
   test("ledger failure: rolls back the org and does not write an unledgered balance", async () => {

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -18,7 +18,10 @@ import { discordService } from "./services/discord";
 import { emailService } from "./services/email";
 import { invitesService } from "./services/invites";
 import { organizationsService } from "./services/organizations";
-import { runWithSignupGrantIpCap } from "./services/signup-grant-guard";
+import {
+  runWithSignupGrantIpCapDetailed,
+  type SignupGrantWithheldReason,
+} from "./services/signup-grant-guard";
 import { usersService } from "./services/users";
 import { getInitialCredits } from "./signup-credits";
 import type { UserWithOrganization } from "./types";
@@ -27,6 +30,16 @@ import { getRandomUserAvatar } from "./utils/default-user-avatar";
 import { logger } from "./utils/logger";
 
 export { DEFAULT_INITIAL_CREDITS, getInitialCredits } from "./signup-credits";
+
+export interface SignupWelcomeBonusMetadata {
+  initialCreditsGranted?: boolean;
+  initialFreeCreditsUsd?: number;
+  welcomeBonusWithheld?: boolean;
+  welcomeBonusWithheldReason?: SignupGrantWithheldReason;
+  welcomeBonusWithheldMessage?: string;
+}
+
+export type StewardSyncedUser = UserWithOrganization & SignupWelcomeBonusMetadata;
 
 const STEWARD_IDENTITY_UNIQUE_CONSTRAINT = "user_identities_steward_user_id_unique";
 
@@ -214,9 +227,7 @@ export interface StewardSyncParams {
  * 4. Check for wallet-only Steward session -> link to existing wallet user if possible
  * 5. Create new user + organization
  */
-export async function syncUserFromSteward(
-  params: StewardSyncParams,
-): Promise<UserWithOrganization> {
+export async function syncUserFromSteward(params: StewardSyncParams): Promise<StewardSyncedUser> {
   const { stewardUserId, walletChainType } = params;
   const email = params.email?.toLowerCase().trim();
   const walletAddress = params.walletAddress?.toLowerCase();
@@ -479,12 +490,15 @@ export async function syncUserFromSteward(
   // created (at $0) and the signup proceeds.
   const initialCredits = getInitialCredits();
   const signupIp = getClientIp();
+  let initialCreditsGranted = false;
+  let initialFreeCreditsUsd = 0;
+  let welcomeBonusWithheld: SignupWelcomeBonusMetadata | null = null;
 
   if (initialCredits > 0) {
     try {
       // The cap check and the grant run under a per-IP advisory lock so
       // concurrent same-IP signups cannot each pass the cap before any commits.
-      await runWithSignupGrantIpCap(signupIp, async (tx) => {
+      const grantDecision = await runWithSignupGrantIpCapDetailed(signupIp, async (tx) => {
         await creditsService.addCredits({
           organizationId: organization.id,
           amount: initialCredits,
@@ -497,6 +511,15 @@ export async function syncUserFromSteward(
           db: tx,
         });
       });
+      initialCreditsGranted = grantDecision.granted;
+      initialFreeCreditsUsd = grantDecision.granted ? initialCredits : 0;
+      if (grantDecision.withheldReason) {
+        welcomeBonusWithheld = {
+          welcomeBonusWithheld: true,
+          welcomeBonusWithheldReason: grantDecision.withheldReason,
+          welcomeBonusWithheldMessage: grantDecision.withheldMessage,
+        };
+      }
     } catch (error) {
       logger.error(
         `[StewardSync] addCredits failed for new org ${organization.id} (initialCredits=${initialCredits}); rolling back signup organization: ${describeSyncError(error)}`,
@@ -646,7 +669,7 @@ export async function syncUserFromSteward(
       email: recipientEmail,
       userName: name || "there",
       organizationName: userWithOrg.organization?.name || "",
-      creditBalance: initialCredits,
+      creditBalance: initialFreeCreditsUsd,
     }).catch((error) => {
       logger.error("[StewardSync] Failed to send welcome email:", { error });
     });
@@ -685,7 +708,12 @@ export async function syncUserFromSteward(
   await ensureUserHasApiKey(userWithOrg.id, userWithOrg.organization?.id || "");
   await ensureDefaultCharacter(userWithOrg.id, userWithOrg.organization?.id || "");
 
-  return userWithOrg;
+  return {
+    ...userWithOrg,
+    initialCreditsGranted,
+    initialFreeCreditsUsd,
+    ...(welcomeBonusWithheld ?? {}),
+  };
 }
 
 /**

--- a/packages/shared/src/steward-session-client/index.ts
+++ b/packages/shared/src/steward-session-client/index.ts
@@ -70,6 +70,11 @@ export interface StewardSessionResponse {
   ok: true;
   userId: string;
   stewardUserId: string;
+  initialCreditsGranted?: boolean;
+  initialFreeCreditsUsd?: number;
+  welcomeBonusWithheld?: boolean;
+  welcomeBonusWithheldReason?: "ip_daily_cap";
+  welcomeBonusWithheldMessage?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #13308.

- makes the free signup grant IP cap env-tunable with `MAX_FREE_GRANTS_PER_IP_DAILY` and `FREE_GRANT_IP_WINDOW_HOURS`
- returns detailed grant decisions from the signup grant guard so wallet/steward signup can distinguish granted, withheld, and failed grant paths
- surfaces `initialCreditsGranted`, `initialFreeCreditsUsd`, and welcome-bonus-withheld metadata through wallet/steward auth responses and wallet-owned agent provisioning responses
- makes same-session zero-balance agent provisioning 402s self-explanatory when the welcome bonus was withheld by the IP cap

## Validation

Rebased on latest `origin/develop` before opening.

- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/signup-grant-guard.ts packages/cloud/shared/src/lib/services/signup-grant-guard.test.ts packages/cloud/shared/src/lib/services/wallet-signup.ts packages/cloud/shared/src/lib/steward-sync.ts packages/cloud/shared/src/lib/steward-sync-grant.test.ts packages/cloud/shared/src/lib/services/agent-billing-gate-402.ts packages/cloud/shared/src/lib/services/agent-billing-gate-402.test.ts packages/cloud/api/v1/agents/route.ts packages/cloud/api/v1/agents/route.test.ts packages/cloud/api/auth/siwe/verify/route.ts packages/cloud/api/auth/steward-session/route.ts packages/cloud/api/auth/steward-nonce-exchange/route.ts packages/shared/src/steward-session-client/index.ts`
- `git diff --check origin/develop...HEAD`
- `TMPDIR=/private/tmp/codex-test-tmp bun test packages/cloud/shared/src/lib/services/signup-grant-guard.test.ts packages/cloud/shared/src/lib/services/agent-billing-gate-402.test.ts`
- `TMPDIR=/private/tmp/codex-test-tmp bun test packages/cloud/api/v1/agents/route.test.ts`
- `TMPDIR=/private/tmp/codex-test-tmp bun test packages/cloud/shared/src/lib/steward-sync-grant.test.ts`
- `TMPDIR=/private/tmp/codex-test-tmp bun test packages/cloud/shared/src/lib/services/__tests__/wallet-signup-owner-role.test.ts`
- `bun run --cwd packages/shared typecheck`

Filtered typecheck runs:

- `bun run --cwd packages/cloud/api typecheck` still fails only on existing unrelated app-core `@elizaos/auth/*` missing modules / implicit anys and ElevenLabs missing package / unknown-error typing; no changed-file errors.
- `bun run --cwd packages/cloud/shared typecheck` still fails only on existing unrelated app-core `@elizaos/auth/*` missing modules / implicit anys; no changed-file errors.
