### PR TITLE
fix(#12265): wave-3 fallback-slop — fabricated-default catches to fail-fast, annotate J3/J4 degrades

### DIFF
--- a/packages/agent/src/api/media-store.test.ts
+++ b/packages/agent/src/api/media-store.test.ts
@@ -39,6 +39,7 @@ const {
   sniffMarkupMime,
   readStoredMediaBytes,
   writeStoredMediaFile,
+  deleteMediaFile,
 } = await import("./media-store.ts");
 
 function mediaPath(fileName: string): string {
@@ -654,6 +655,60 @@ describe("writeStoredMediaFile fast-fail (#12265)", () => {
         }
         expect(caught).toBeInstanceOf(ElizaError);
         expect((caught as ElizaError).code).toBe("MEDIA_STORE_WRITE_FAILED");
+      } finally {
+        fs.chmodSync(roMedia, 0o755);
+        fs.rmSync(roRoot, { recursive: true, force: true });
+        process.env.ELIZA_STATE_DIR = prev;
+      }
+    },
+  );
+});
+
+// deleteMediaFile: a traversal/invalid name and a missing file both still
+// return false (idempotent), but a genuine unlink failure (EACCES/EPERM) now
+// throws a typed MEDIA_STORE_DELETE_FAILED instead of being swallowed into a
+// fabricated "false" — which the DELETE /api/files route would mistranslate
+// into a misleading 404 for a file that exists but could not be removed.
+describe("deleteMediaFile fast-fail (#12265)", () => {
+  it("returns true when a stored file is removed", () => {
+    const name = `${"c".repeat(64)}.bin`;
+    expect(writeStoredMediaFile(name, Buffer.from("bye"))).toBe(true);
+    expect(deleteMediaFile(name)).toBe(true);
+    expect(readStoredMediaBytes(name)).toBeNull();
+  });
+
+  it("returns false for a traversal-rejecting name without touching the fs", () => {
+    expect(deleteMediaFile("../../etc/passwd")).toBe(false);
+  });
+
+  it("returns false when the file is already absent (idempotent delete)", () => {
+    const name = `${"d".repeat(64)}.bin`;
+    expect(deleteMediaFile(name)).toBe(false);
+  });
+
+  it.skipIf(typeof process.getuid === "function" && process.getuid() === 0)(
+    "throws MEDIA_STORE_DELETE_FAILED when the store dir is read-only",
+    () => {
+      // Real permission failure: a populated media/ dir stripped of write perms
+      // makes unlink throw EACCES/EPERM (not ENOENT). root bypasses mode bits.
+      const prev = process.env.ELIZA_STATE_DIR;
+      const roRoot = fs.mkdtempSync(path.join(os.tmpdir(), "media-store-del-ro-"));
+      const roMedia = path.join(roRoot, "media");
+      fs.mkdirSync(roMedia, { recursive: true });
+      const name = `${"f".repeat(64)}.bin`;
+      fs.writeFileSync(path.join(roMedia, name), "x");
+      fs.chmodSync(roMedia, 0o555);
+      process.env.ELIZA_STATE_DIR = roRoot;
+      try {
+        let caught: unknown;
+        try {
+          deleteMediaFile(name);
+        } catch (err) {
+          caught = err;
+        }
+        expect(caught).toBeInstanceOf(ElizaError);
+        expect((caught as ElizaError).code).toBe("MEDIA_STORE_DELETE_FAILED");
+        expect((caught as ElizaError).cause).toBeDefined();
       } finally {
         fs.chmodSync(roMedia, 0o755);
         fs.rmSync(roRoot, { recursive: true, force: true });

--- a/packages/agent/src/api/media-store.test.ts
+++ b/packages/agent/src/api/media-store.test.ts
@@ -692,7 +692,9 @@ describe("deleteMediaFile fast-fail (#12265)", () => {
       // Real permission failure: a populated media/ dir stripped of write perms
       // makes unlink throw EACCES/EPERM (not ENOENT). root bypasses mode bits.
       const prev = process.env.ELIZA_STATE_DIR;
-      const roRoot = fs.mkdtempSync(path.join(os.tmpdir(), "media-store-del-ro-"));
+      const roRoot = fs.mkdtempSync(
+        path.join(os.tmpdir(), "media-store-del-ro-"),
+      );
       const roMedia = path.join(roRoot, "media");
       fs.mkdirSync(roMedia, { recursive: true });
       const name = `${"f".repeat(64)}.bin`;

--- a/packages/agent/src/api/media-store.ts
+++ b/packages/agent/src/api/media-store.ts
@@ -602,10 +602,10 @@ export function listMediaFiles(): MediaFileInfo[] {
  */
 export function deleteMediaFile(fileName: string): boolean {
   if (!MEDIA_FILE_NAME.test(fileName)) return false;
-  const dir = mediaDir();
-  const filePath = path.join(dir, fileName);
-  if (path.dirname(filePath) !== dir) return false;
   try {
+    const dir = mediaDir();
+    const filePath = path.join(dir, fileName);
+    if (path.dirname(filePath) !== dir) return false;
     fs.unlinkSync(filePath);
     return true;
   } catch (err) {

--- a/packages/agent/src/api/media-store.ts
+++ b/packages/agent/src/api/media-store.ts
@@ -602,14 +602,25 @@ export function listMediaFiles(): MediaFileInfo[] {
  */
 export function deleteMediaFile(fileName: string): boolean {
   if (!MEDIA_FILE_NAME.test(fileName)) return false;
+  const dir = mediaDir();
+  const filePath = path.join(dir, fileName);
+  if (path.dirname(filePath) !== dir) return false;
   try {
-    const dir = mediaDir();
-    const filePath = path.join(dir, fileName);
-    if (path.dirname(filePath) !== dir) return false;
     fs.unlinkSync(filePath);
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+    // Absence is idempotent: the file is already gone, so a delete has nothing
+    // to remove — report "not removed" without erroring.
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    // error-policy:J2 context-adding rethrow — a real unlink failure
+    // (EACCES/EPERM/EIO) is distinct from absence; swallowing it as `false`
+    // makes DELETE /api/files answer 404 "not found" for a file that exists but
+    // could not be removed. Surface it to the route boundary (→ 500).
+    throw new ElizaError(`media delete failed for ${fileName}`, {
+      code: "MEDIA_STORE_DELETE_FAILED",
+      cause: err,
+      context: { fileName },
+    });
   }
 }
 


### PR DESCRIPTION
## Wave-3 fallback-slop sweep — `packages/agent` (return-default + empty catches)

Part of #12265 (parent #12182). Focus for this wave: leftover **empty catches** and
**return-default catches** (a `catch` whose body returns `null|[]|false|{}|0|''` with no
`throw`) — the judgment-heavy category. Precision over volume: convert only clear
fabrication, keep legitimate absence / designed degrade / typed-invalid.

### Slice re-derivation (develop @ `b87980a5f0`)

- **Empty catches:** `rg -lU 'catch\s*(\([^)]*\))?\s*\{\s*\}'` over `packages/agent/**`
  non-test `.ts/.tsx` → **0 files** (prior waves already cleared them).
- **Return-default catches:** ~52 files; ~130 unannotated sites after prior waves.

Walking those sites, the overwhelming majority are **legitimate** and not slop:
predicates returning `false` (`isGitAvailable`, `hasSearchCategory`, `hasRegisteredHandler`),
cache-miss reads returning `null` (`readFileCache`), untrusted-input parse returning an
explicit invalid result (`storeDataUrl`, connection-string host parse), network/registry
"unavailable" degrades, and boot-path optional-plugin absence — all of which the rubric says
to **keep** (J3/J4) or leave, never convert to a throw. The flagship files
(`media-store.ts`, `page-scoped-context.ts`, most of `runtime/eliza.ts`) were already
annotated J2/J3/J4/J6 by earlier waves.

### Converted (fabricated-default → fail-fast): 1

**`packages/agent/src/api/media-store.ts` — `deleteMediaFile`**

```ts
// BEFORE — every unlink failure (EACCES/EPERM/EIO) fabricated as `false`
try { fs.unlinkSync(filePath); return true; } catch { return false; }
```

`false` is the route's "not removed" signal: `DELETE /api/files/:filename` maps it to
**404 "not found"** (`files-routes.ts:53`). So a file that *exists* but cannot be removed
(read-only fs, permission loss, EIO) was reported to the caller as *absent* — a lie that
hides a real I/O failure and matches exactly the media-store degrade pattern the issue flags.

```ts
// AFTER — absence is idempotent; a real failure is typed and surfaced
try {
  fs.unlinkSync(filePath);
  return true;
} catch (err) {
  if ((err as NodeJS.ErrnoException).code === "ENOENT") return false; // already gone
  // error-policy:J2 context-adding rethrow
  throw new ElizaError(`media delete failed for ${fileName}`, {
    code: "MEDIA_STORE_DELETE_FAILED", cause: err, context: { fileName },
  });
}
```

The throw propagates to the hono J1 boundary (`hono-adapter.ts:141` `.catch(... 500 ...)`)
→ a **500**, not a misleading 404. This mirrors the file's own established
`readStoredMediaBytes` / `writeStoredMediaFile` J2 rethrow pattern (ENOENT → null/false,
real I/O failure → typed `ElizaError`) already landed under #12265.

### Annotated (J-kept): 1

The converted site carries `// error-policy:J2 context-adding rethrow`.

### Left untouched (ambiguous / legit degrade — not this wave): ~129

Return-default sites that are legitimate predicates, cache-misses, untrusted-input parses,
network/registry degrades, or boot-path optional-plugin absence. Converting any of these to a
throw would be over-removal (the issue's #1 risk) and would red existing behavior. Left for a
dedicated annotation pass rather than mass-touched here — the diff-scoped ratchet does not
require annotating files this PR does not otherwise change.

### Tests (real fs, no mocks)

New `deleteMediaFile fast-fail (#12265)` block in `media-store.test.ts`:

- returns `true` on a real successful delete;
- returns `false` for a traversal-rejecting name (no fs touch);
- returns `false` when the file is already absent (idempotent);
- **throws `MEDIA_STORE_DELETE_FAILED`** against a real read-only `media/` dir holding the
  file (chmod `0o555`) — asserts the typed `ElizaError` + preserved `cause`, never the old
  fabricated `false`. (skipped only under uid 0, which bypasses mode bits.)

```
vitest run packages/agent/src/api/media-store.test.ts
Test Files  1 passed (1)      Tests  53 passed (53)   (4 new; read-only throw path executed, 0 skipped as non-root)
```

### Verify

- `bun run audit:error-policy-ratchet` → **pass**: `media-store.ts: emptyCatch 5->5,
  serverConsole 0->0 — no new fallback-slop in touched files`.
- `tsgo --noEmit -p packages/agent/tsconfig.json` → **0 errors on `media-store.ts`** (the
  other reported errors are pre-existing workspace `.d.ts` resolution artifacts of the
  symlinked-node_modules verify setup, present on `develop`, unrelated to this diff).

### Evidence

- Real induced-failure test output above (read-only fs → typed throw). N/A for live-LLM
  trajectory / screenshots — this is a server-side I/O error-policy change with no
  agent-prompt or UI surface.

Refs #12265

🤖 Generated with [Claude Code](https://claude.com/claude-code)
