### PR TITLE
fix(#12266): wave-3 fallback-slop — annotate J3/J4 return-default catches (slice 1/2)

### DIFF
--- a/packages/app-core/platforms/electrobun/scripts/postwrap-sign-runtime-macos.ts
+++ b/packages/app-core/platforms/electrobun/scripts/postwrap-sign-runtime-macos.ts
@@ -218,6 +218,7 @@ function resolveDeveloperId(
     const match = output.match(/"([^"]*Developer ID Application[^"]*)"/);
     return match?.[1] ?? null;
   } catch {
+    // error-policy:J4 signing identity absent when `security find-identity` fails
     return null;
   }
 }

--- a/packages/app-core/platforms/electrobun/src/api-base.ts
+++ b/packages/app-core/platforms/electrobun/src/api-base.ts
@@ -51,6 +51,7 @@ export function normalizeApiBase(raw: string | undefined): string | null {
     }
     return parsed.origin;
   } catch {
+    // error-policy:J3 malformed API base URL is not a valid origin
     return null;
   }
 }
@@ -269,6 +270,7 @@ export function resolveHttpLoopbackRendererOriginForApiClient(
     if (!isLoopbackHttpHostname(u.hostname)) return null;
     return u.origin;
   } catch {
+    // error-policy:J3 malformed renderer URL is not a loopback origin
     return null;
   }
 }

--- a/packages/app-core/platforms/electrobun/src/cloud-auth-window.ts
+++ b/packages/app-core/platforms/electrobun/src/cloud-auth-window.ts
@@ -96,6 +96,7 @@ export function isTrustedElizaUrl(value: string): boolean {
       (suffix) => hostname === suffix || hostname.endsWith(`.${suffix}`),
     );
   } catch {
+    // error-policy:J3 untrusted/unparseable URL rejected (fail-closed)
     return false;
   }
 }
@@ -149,6 +150,7 @@ function isTrustedElizaCloseMessage(event: HostMessageEventLike): boolean {
       const parsed = JSON.parse(detail) as { type?: unknown };
       return parsed.type === TRUSTED_ELIZA_CLOSE_MESSAGE_TYPE;
     } catch {
+      // error-policy:J3 malformed close-message JSON is not a trusted signal
       return false;
     }
   }

--- a/packages/app-core/platforms/electrobun/src/dashboard-rpc.ts
+++ b/packages/app-core/platforms/electrobun/src/dashboard-rpc.ts
@@ -285,6 +285,7 @@ async function readJsonEndpoint<T>(
     if (!response.ok) return null;
     return parse(await response.json());
   } catch {
+    // error-policy:J4 loopback endpoint unreachable -> caller degrades to no data
     return null;
   }
 }

--- a/packages/app-core/platforms/electrobun/src/database/pglite-paths.ts
+++ b/packages/app-core/platforms/electrobun/src/database/pglite-paths.ts
@@ -48,6 +48,7 @@ function parentWritable(targetPath: string): boolean {
     fs.accessSync(parent, fs.constants.W_OK);
     return true;
   } catch {
+    // error-policy:J4 parent dir not creatable/writable -> reported as not writable
     return false;
   }
 }

--- a/packages/app-core/platforms/electrobun/src/first-run-rpc.ts
+++ b/packages/app-core/platforms/electrobun/src/first-run-rpc.ts
@@ -39,6 +39,7 @@ async function fetchJson<T>(
     if (!response.ok) return null;
     return (await response.json()) as T;
   } catch {
+    // error-policy:J4 loopback agent unreachable -> caller degrades to no data
     return null;
   }
 }

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -2918,6 +2918,7 @@ function wasStartupCrashAlreadyPrompted(updatedAt: string): boolean {
     const markerPath = resolveStartupCrashPromptMarkerPath();
     return fs.readFileSync(markerPath, "utf8").trim() === updatedAt;
   } catch {
+    // error-policy:J4 crash-prompt marker absent/unreadable -> treated as not yet prompted
     return false;
   }
 }

--- a/packages/app-core/platforms/electrobun/src/menu-reset-from-main.ts
+++ b/packages/app-core/platforms/electrobun/src/menu-reset-from-main.ts
@@ -183,6 +183,7 @@ export async function runMainMenuResetAfterApiBaseResolved(
       const payload = (await res.json()) as { complete?: unknown };
       return typeof payload.complete === "boolean" ? payload.complete : null;
     } catch {
+      // error-policy:J4 first-run status endpoint unreachable -> unknown
       return null;
     }
   };

--- a/packages/app-core/platforms/electrobun/src/native/browser-workspace.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-workspace.ts
@@ -404,6 +404,7 @@ $bmp.Dispose()`;
     const buf = fs.readFileSync(tmpPath);
     return buf.length > 100 ? { data: buf.toString("base64") } : null;
   } catch {
+    // error-policy:J4 screen capture unavailable -> no image
     return null;
   } finally {
     try {

--- a/packages/app-core/platforms/electrobun/src/native/credentials.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.ts
@@ -66,6 +66,7 @@ function readJsonFile<T>(filePath: string): T | null {
     const content = fs.readFileSync(filePath, "utf8");
     return JSON.parse(content) as T;
   } catch {
+    // error-policy:J3 absent/invalid JSON credential file
     return null;
   }
 }
@@ -95,6 +96,7 @@ async function isCliInstalled(name: string): Promise<boolean> {
     await proc.exited;
     return proc.exitCode === 0;
   } catch {
+    // error-policy:J4 CLI absent (spawn probe)
     return false;
   }
 }
@@ -112,6 +114,7 @@ async function readKeychainCredential(service: string): Promise<string | null> {
     const trimmed = output.trim();
     return trimmed.length > 0 ? trimmed : null;
   } catch {
+    // error-policy:J4 keychain credential absent
     return null;
   }
 }
@@ -391,6 +394,7 @@ function decryptChromiumCookieValue(
     ]);
     return decrypted.toString("utf8");
   } catch {
+    // error-policy:J3 cookie ciphertext not decryptable -> not decodable
     return null;
   }
 }

--- a/packages/app-core/platforms/electrobun/src/native/editor-bridge.ts
+++ b/packages/app-core/platforms/electrobun/src/native/editor-bridge.ts
@@ -167,6 +167,7 @@ function isExecutable(p: string): boolean {
     fs.accessSync(p, fs.constants.X_OK);
     return true;
   } catch {
+    // error-policy:J4 path not executable (access probe)
     return false;
   }
 }
@@ -181,6 +182,7 @@ function isCommandOnPath(cmd: string): boolean {
     });
     return result.status === 0;
   } catch {
+    // error-policy:J4 command not on PATH (spawn probe)
     return false;
   }
 }

--- a/packages/app-core/platforms/electrobun/src/renderer-api-proxy.ts
+++ b/packages/app-core/platforms/electrobun/src/renderer-api-proxy.ts
@@ -25,6 +25,7 @@ export function shouldProxyToApiBase(apiBase: string | undefined): boolean {
   try {
     scheme = new URL(apiBase).protocol;
   } catch {
+    // error-policy:J3 malformed api base URL -> proxy inert
     return false;
   }
   return scheme === "http:" || scheme === "https:";

--- a/packages/app-core/platforms/electrobun/src/screen-capture-bridge-server.ts
+++ b/packages/app-core/platforms/electrobun/src/screen-capture-bridge-server.ts
@@ -97,6 +97,7 @@ function isLoopbackHttpBase(value: string | undefined): boolean {
         parsed.hostname === "::1")
     );
   } catch {
+    // error-policy:J3 malformed URL is not a loopback base
     return false;
   }
 }

--- a/packages/app-core/platforms/electrobun/src/startup-trace.ts
+++ b/packages/app-core/platforms/electrobun/src/startup-trace.ts
@@ -196,6 +196,7 @@ function readStartupTraceBootstrapFile(
     }
     return bootstrap;
   } catch {
+    // error-policy:J3 invalid bootstrap JSON -> no bootstrap
     return null;
   }
 }

--- a/packages/app-core/platforms/electrobun/src/update-rpc.ts
+++ b/packages/app-core/platforms/electrobun/src/update-rpc.ts
@@ -108,6 +108,7 @@ export const readUpdateStatusViaHttp: UpdateStatusReader = async (
     if (!response.ok) return null;
     return parseUpdateStatusSnapshot(await response.json());
   } catch {
+    // error-policy:J4 update-status endpoint unreachable -> unknown
     return null;
   }
 };

--- a/packages/app-core/platforms/electrobun/src/windows-cef-profile.ts
+++ b/packages/app-core/platforms/electrobun/src/windows-cef-profile.ts
@@ -72,6 +72,7 @@ function readVersionFromJson(
       ? trimToNull(parsed.version)
       : null;
   } catch {
+    // error-policy:J3 invalid version JSON -> no version
     return null;
   }
 }

--- a/packages/app-core/scripts/voice-e2e-hardware.ts
+++ b/packages/app-core/scripts/voice-e2e-hardware.ts
@@ -416,6 +416,7 @@ function fsProbe() {
       try {
         return fs.statSync(p).size;
       } catch {
+        // error-policy:J4 stat unavailable (fs probe)
         return null;
       }
     },
@@ -427,6 +428,7 @@ function fsProbe() {
         fs.closeSync(fd);
         return buf.toString("utf8");
       } catch {
+        // error-policy:J4 header bytes unreadable (fs probe)
         return null;
       }
     },

--- a/packages/app-core/src/api/auth/embed-handshake.ts
+++ b/packages/app-core/src/api/auth/embed-handshake.ts
@@ -152,6 +152,7 @@ function parseTelegramUserId(userField: string | null): string | null {
   try {
     parsed = JSON.parse(userField);
   } catch {
+    // error-policy:J3 malformed Telegram user field -> invalid
     return null;
   }
   if (

--- a/packages/app-core/src/api/server-cors.ts
+++ b/packages/app-core/src/api/server-cors.ts
@@ -148,6 +148,7 @@ export function isAllowedOrigin(
     const port = u.port || (u.protocol === "https:" ? "443" : "80");
     return isLocal && ports.has(port);
   } catch {
+    // error-policy:J3 unparseable origin rejected (fail-closed)
     return false;
   }
 }

--- a/packages/app-core/src/connectors/capacitor-sqlite.ts
+++ b/packages/app-core/src/connectors/capacitor-sqlite.ts
@@ -171,6 +171,7 @@ export async function isSqliteAvailable(): Promise<boolean> {
     });
     return true;
   } catch {
+    // error-policy:J4 SQLite native plugin unavailable (probe)
     return false;
   }
 }

--- a/packages/app-core/src/platform/native-library-policy.ts
+++ b/packages/app-core/src/platform/native-library-policy.ts
@@ -36,6 +36,7 @@ function realpath(value: string): string | null {
     try {
       return realpathSync(value);
     } catch {
+      // error-policy:J4 path does not resolve on either realpath
       return null;
     }
   }

--- a/packages/app-core/src/runtime/dev-settings-figlet-heading.ts
+++ b/packages/app-core/src/runtime/dev-settings-figlet-heading.ts
@@ -24,6 +24,7 @@ function loadFiglet(): FigletModule | null {
   try {
     return require("figlet") as FigletModule;
   } catch {
+    // error-policy:J4 optional figlet module absent
     return null;
   }
 }

--- a/packages/app-core/src/security/platform-secure-store-node.ts
+++ b/packages/app-core/src/security/platform-secure-store-node.ts
@@ -159,6 +159,7 @@ class MacOSKeychainPlatformSecureStore implements PlatformSecureStore {
       await execFileAsync("security", ["-h"], { encoding: "utf8" });
       return true;
     } catch {
+      // error-policy:J4 keychain tool unavailable (probe)
       return false;
     }
   }

--- a/packages/app-core/src/services/cloud-jwks-store.ts
+++ b/packages/app-core/src/services/cloud-jwks-store.ts
@@ -85,6 +85,7 @@ function parseEnvelope(raw: string): JwksCacheEnvelope | null {
   try {
     parsed = JSON.parse(raw);
   } catch {
+    // error-policy:J3 invalid JWKS cache JSON -> no envelope
     return null;
   }
   if (!parsed || typeof parsed !== "object") return null;

--- a/packages/app-core/src/services/steward-credentials.ts
+++ b/packages/app-core/src/services/steward-credentials.ts
@@ -103,6 +103,7 @@ function readCredentialsFile():
       fs.readFileSync(credPath, "utf-8"),
     ) as Partial<PersistedStewardCredentials> & StewardCredentialsMetadata;
   } catch {
+    // error-policy:J3 absent/invalid credentials JSON
     return null;
   }
 }

--- a/packages/app-core/src/services/tunnel-to-mobile/tunnel-to-mobile-client.ts
+++ b/packages/app-core/src/services/tunnel-to-mobile/tunnel-to-mobile-client.ts
@@ -236,6 +236,7 @@ export class TunnelToMobileClient {
       this.socket.send(JSON.stringify(frame));
       return true;
     } catch {
+      // error-policy:J4 frame send failed -> reported to caller as false
       return false;
     }
   }

--- a/packages/shared/src/config/config-catalog.ts
+++ b/packages/shared/src/config/config-catalog.ts
@@ -345,6 +345,7 @@ export const builtInValidators: Record<string, ValidationFunction> = {
     try {
       return new RegExp(args.pattern).test(value);
     } catch {
+      // error-policy:J3 invalid user-supplied regex -> validation fails
       return false;
     }
   },
@@ -366,6 +367,7 @@ export const builtInValidators: Record<string, ValidationFunction> = {
       new URL(value);
       return true;
     } catch {
+      // error-policy:J3 invalid user-supplied URL -> validation fails
       return false;
     }
   },

--- a/packages/shared/src/lifeops-normalize/time-zone.ts
+++ b/packages/shared/src/lifeops-normalize/time-zone.ts
@@ -17,6 +17,7 @@ export function isValidTimeZone(timeZone: string): boolean {
     new Intl.DateTimeFormat("en-US", { timeZone }).format(new Date());
     return true;
   } catch {
+    // error-policy:J3 invalid IANA time zone -> false
     return false;
   }
 }

--- a/packages/shared/src/local-inference-gpu/gpu-tier-detect.ts
+++ b/packages/shared/src/local-inference-gpu/gpu-tier-detect.ts
@@ -84,6 +84,7 @@ export function detectNvidiaGpu(): DetectedGpu | null {
 
     return { name, vram_mb, cuda_compute };
   } catch {
+    // error-policy:J4 nvidia-smi unavailable/unparseable -> no discrete GPU
     // nvidia-smi not found, timed out, or any other error.
     return null;
   }

--- a/packages/shared/src/local-inference/verify.ts
+++ b/packages/shared/src/local-inference/verify.ts
@@ -48,6 +48,7 @@ async function fileExists(path: string): Promise<boolean> {
     const stat = await fsp.stat(path);
     return stat.isFile();
   } catch {
+    // error-policy:J4 stat unavailable -> file absent
     return false;
   }
 }
@@ -63,6 +64,7 @@ async function isGgufHeader(path: string): Promise<boolean> {
       await fd.close();
     }
   } catch {
+    // error-policy:J3 unreadable/short file is not a GGUF header
     return false;
   }
 }

--- a/packages/shared/src/meetings.ts
+++ b/packages/shared/src/meetings.ts
@@ -153,6 +153,7 @@ function safeDecodeUriComponent(value: string): string | null {
   try {
     return decodeURIComponent(value);
   } catch {
+    // error-policy:J3 malformed percent-escape -> not a recognizable link
     return null;
   }
 }

--- a/packages/shared/src/steward-session-client/steward-oauth-pkce.ts
+++ b/packages/shared/src/steward-session-client/steward-oauth-pkce.ts
@@ -89,6 +89,7 @@ function consumeStoredPkceVerifier(storage: Storage): string | null {
     storage.removeItem(STEWARD_PKCE_VERIFIER_STORAGE_KEY);
     return parseStoredPkceVerifier(verifier);
   } catch {
+    // error-policy:J4 web storage unavailable -> no verifier
     return null;
   }
 }

--- a/packages/shared/src/utils/assistant-text.ts
+++ b/packages/shared/src/utils/assistant-text.ts
@@ -184,6 +184,7 @@ function tryParseObject(input: string): Record<string, unknown> | null {
       ? (parsed as Record<string, unknown>)
       : null;
   } catch {
+    // error-policy:J3 input is not a JSON object
     return null;
   }
 }

--- a/packages/shared/src/utils/eliza-root.ts
+++ b/packages/shared/src/utils/eliza-root.ts
@@ -16,6 +16,7 @@ async function readPackageName(dir: string): Promise<string | null> {
     const parsed = JSON.parse(raw) as { name?: unknown };
     return typeof parsed.name === "string" ? parsed.name : null;
   } catch {
+    // error-policy:J3 absent/invalid package.json
     return null;
   }
 }
@@ -26,6 +27,7 @@ function readPackageNameSync(dir: string): string | null {
     const parsed = JSON.parse(raw) as { name?: unknown };
     return typeof parsed.name === "string" ? parsed.name : null;
   } catch {
+    // error-policy:J3 absent/invalid package.json
     return null;
   }
 }


### PR DESCRIPTION
Slice **1/2** of the wave-3 return-default fallback-slop sweep for `packages/{app-core,shared,logger,prompts}` (#12266, part of #12182). Focus: leftover **empty catches** + **return-default catches** (a `catch` whose body `return null|[]|false|{}|0|''` with no `throw`) — the judgment-heavy category the earlier slices (#13278, #13298) explicitly deferred.

Foundation #12263 (`ElizaError`, `runtime.reportError`, diff-scoped `audit:error-policy-ratchet`) is on develop and was used as the rubric.

## Slice derivation

Suspect-file union = `rg -l` of empty-catch ∪ return-default-catch over the slice root, non-test `.ts/.tsx`, sorted `-u` = **72 files**. This PR handles the odd-indexed half (`index % 2 == 1`) = **36 files**, of which 34 carried an actionable site. Parallel slice 2 takes the even half.

## Per-category tally

| category | count |
|---|---|
| **Converted** (fabricated-default → fail-fast) | **0** |
| **Annotated J3/J4** (kept + `// error-policy:J<N>`) | **44** |
| **Left ambiguous / exempt** | **1** |

Every return-default catch in this half is a legitimate **parse/validate helper** (J3 → explicit typed-invalid) or a **reachability/availability probe / designed degrade** (J4 → unavailable state). None fabricate a success value or mask a real failure as fake data: the return types are `X | null` / `boolean`, and callers branch on the honest "unavailable" signal. Per the wave protocol (**precision over volume; convert only clear fabrication**) that is the correct shape — a large annotate count and zero conversions.

- **J3 (21)** — URL/JSON/regex/decode of untrusted input → typed-invalid: `normalizeApiBase`, `isTrustedElizaUrl` (fail-closed), `isTrustedElizaCloseMessage`, `parseStartupTraceBootstrap`, `readVersionFromJson`, `readJsonFile`, `decryptChromiumCookieValue`, `parseTelegramUserId`, `server-cors` origin check (fail-closed), `shouldProxyToApiBase`, `isLoopbackHttpBase`, `parseEnvelope`, `readCredentialsFile`, config-catalog `pattern`/`url` validators, `isValidTimeZone`, `safeDecodeUriComponent`, `tryParseObject`, `readPackageName[Sync]`, `isGgufHeader`, `resolveHttpLoopbackRendererOriginForApiClient`.
- **J4 (23)** — loopback fetch / spawn / access probes and degrade paths → unavailable: `readJsonEndpoint`, `fetchJson`, `readUpdateStatusViaHttp`, `readOnboardingComplete`, screenshot capture, `wasStartupCrashAlreadyPrompted`, `parentWritable`, `isCliInstalled`, `readKeychainCredential`, `isExecutable`, `isCommandOnPath`, `isSqliteAvailable`, `realpath`, secure-store `isAvailable`, `gpu-tier-detect`, `fileExists`, `sendFrame` (surfaces failure as `false`), `consumeStoredPkceVerifier`, voice-e2e fs probes, `resolveDeveloperId`, `loadFiglet`.
- **Left (1)** — `screencapture.ts:643` `catch(e){return null}` lives inside the `captureGameScript` **browser-injected string literal** (foreign-page DOM, J6-by-construction); the AST ratchet ignores string content and annotating inside injected JS is not meaningful.

The single "empty catch" match in the slice (`first-run-routes.ts:115`) is comment text inside a JSDoc block, not a real catch — no action.

## Verification

- `assert-comment-only-diff` → **OK**: code token stream byte-for-byte identical to `origin/develop` across all 34 files. Purely additive `//` annotations, so **typecheck and every existing test are unchanged by construction** — no behavior touched, no conversion to test.
- `audit:error-policy-ratchet` → **no new fallback-slop in touched files** (empty-catch / server-console counts unchanged).
- No `console.*` added; logger-only respected (no logging added at all).

Because there are zero conversions, there is no new runtime path to add a real-error-path test for; the deferred fabrication sites (if any) live in slice 2 / the deeper `?? <lit>` wave.

Refs #12266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
