### PR TITLE
test(scripts): align workflow aggregate guard

### DIFF
--- a/packages/scripts/__tests__/test-task-pool.test.ts
+++ b/packages/scripts/__tests__/test-task-pool.test.ts
@@ -314,7 +314,7 @@ describe("CI plugin sharding contract", () => {
       /plugin-tests-status:\s+name:\s+Plugin Tests[\s\S]*?needs:[\s\S]*?-\s+plugin-tests/,
     );
     expect(testWorkflow).toMatch(
-      /test-status:[\s\S]*?needs:[\s\S]*?-\s+plugin-tests-status/,
+      /ci-ok:[\s\S]*?needs:[\s\S]*?-\s+plugin-tests-status/,
     );
   });
 


### PR DESCRIPTION
## What

Updates the `test-task-pool` workflow contract test to assert the current Tests workflow aggregate job, `ci-ok`, depends on `plugin-tests-status`.

This was exposed while validating #13331 after it merged: `packages/scripts/__tests__/test-task-pool.test.ts` still expected the old `test-status` aggregate even though `.github/workflows/test.yml` now uses `ci-ok`.

## Evidence

- `bun test packages/scripts/__tests__/test-task-pool.test.ts` — 28 passed, 0 failed.
- `bunx @biomejs/biome check packages/scripts/__tests__/test-task-pool.test.ts` — clean.
- `git diff --check` — clean.

N/A: UI screenshots, model trajectories, audio, domain artifacts (test-only script-contract fix).