### PR TITLE
test(#12772): register B2 shift-rotation LifeOpsBench ids — pack 6/22 → 22/22

### DIFF
--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/shift-rotation.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/shift-rotation.catalog.json
@@ -60,6 +60,134 @@
       "surface": "scenario-runner",
       "status": "authored",
       "notes": "live-only adversarial fail-closed. Ports the bench exemplar live.shiftrotation.sleep_protection_violation_requires_confirm: a 10am booking lands in protected post-night sleep; the assistant must flag the conflict, ask for an explicit override, offer an alternative, and create nothing (forbiddenActions + no-calendar-create + definitionCountDelta delta:0 + no external dispatch). Live-model trajectory is the remaining evidence gate."
+    },
+    {
+      "id": "shiftrotation.capture_nights_starting_monday",
+      "pack": "B2",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "authored",
+      "notes": "LifeOpsBench static (scenarios/shift_rotation.py). Plain 'on nights starting Monday' statement moves planning assumptions onto that week; ground-truth CALENDAR update_preferences with a post_night_shift_sleep blackout. authored (no captured real-LLM run)."
+    },
+    {
+      "id": "shiftrotation.protect_post_shift_sleep_window",
+      "pack": "B2",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "authored",
+      "notes": "LifeOpsBench static (scenarios/shift_rotation.py). Protects 08:00-14:00 post-night-shift as quiet_hours with requiresOverride; ground-truth LIFE_CREATE quiet_hours definition. authored (no captured real-LLM run)."
+    },
+    {
+      "id": "shiftrotation.normalize_d_e_n_week_pattern",
+      "pack": "B2",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "authored",
+      "notes": "LifeOpsBench static (scenarios/shift_rotation.py). Normalizes the D D E E N N off rotation for the week so the owner does not re-enter daily; ground-truth CALENDAR update_preferences. authored (no captured real-LLM run)."
+    },
+    {
+      "id": "shiftrotation.reanchor_recurring_reminders_new_shift",
+      "pack": "B2",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "authored",
+      "notes": "LifeOpsBench static (scenarios/shift_rotation.py). Shift change re-anchors existing recurring reminders to evening hours instead of duplicating them (policy reanchor_existing). authored (no captured real-LLM run)."
+    },
+    {
+      "id": "shiftrotation.tomorrow_resolves_against_shift_boundary",
+      "pack": "B2",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "authored",
+      "notes": "LifeOpsBench static (scenarios/shift_rotation.py). 'Tomorrow after shift' resolves against the night-shift boundary, not midnight; ground-truth LIFE_CREATE anchored to post_night_shift. authored (no captured real-LLM run)."
+    },
+    {
+      "id": "shiftrotation.quiet_hours_move_with_rotation",
+      "pack": "B2",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "authored",
+      "notes": "LifeOpsBench static (scenarios/shift_rotation.py). Moving-quiet-hours policy: protected sleep tracks whichever shift (day/evening/night) the owner is on that week. authored (no captured real-LLM run)."
+    },
+    {
+      "id": "shiftrotation.forward_rotation_transition_leniency",
+      "pack": "B2",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "authored",
+      "notes": "LifeOpsBench static (scenarios/shift_rotation.py). Forward-rotation-aware planning avoids stacking errands right after the first evening shift on the transition day. authored (no captured real-LLM run)."
+    },
+    {
+      "id": "shiftrotation.dedup_habit_survives_shift_change",
+      "pack": "B2",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "authored",
+      "notes": "LifeOpsBench static (scenarios/shift_rotation.py). Hydration habit re-anchors to nights via dedupeKey without creating a duplicate definition (policy reanchor_existing). authored (no captured real-LLM run)."
+    },
+    {
+      "id": "live.shiftrotation.sleep_protection_violation_requires_confirm",
+      "pack": "B2",
+      "tier": "T4",
+      "surface": "lifeops-bench",
+      "status": "authored",
+      "notes": "LifeOpsBench live (scenarios/live/shift_rotation.py). Verbatim issue exemplar: a booking inside protected post-night sleep must be flagged and fail closed without an explicit override. Ported to the live-only scenario-runner shift-rotation-sleep-window-conflict-requires-confirm. authored (live-model run is the #12781 gate)."
+    },
+    {
+      "id": "live.shiftrotation.night_to_day_transition_plan",
+      "pack": "B2",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "authored",
+      "notes": "LifeOpsBench live (scenarios/live/shift_rotation.py). Plans recovery sleep while rotating from nights to a Monday day shift. authored (live-model run is the #12781 gate)."
+    },
+    {
+      "id": "live.shiftrotation.swap_shift_chain_replan",
+      "pack": "B2",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "authored",
+      "notes": "LifeOpsBench live (scenarios/live/shift_rotation.py). A confirmed shift swap cascades through the surrounding sleep and family windows. Premise shared with live-only scenario-runner shift-rotation-swap-reanchors-and-checks-in. authored (live-model run is the #12781 gate)."
+    },
+    {
+      "id": "live.shiftrotation.medication_cadence_across_rotation",
+      "pack": "B2",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "authored",
+      "notes": "LifeOpsBench live (scenarios/live/shift_rotation.py). Medication reminder follows wake timing across evening and night rotations. authored (live-model run is the #12781 gate)."
+    },
+    {
+      "id": "live.shiftrotation.family_event_vs_recovery_sleep",
+      "pack": "B2",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "authored",
+      "notes": "LifeOpsBench live (scenarios/live/shift_rotation.py). Balances a family event against post-night-shift recovery sleep. authored (live-model run is the #12781 gate)."
+    },
+    {
+      "id": "live.shiftrotation.short_notice_overtime_triage",
+      "pack": "B2",
+      "tier": "T4",
+      "surface": "lifeops-bench",
+      "status": "authored",
+      "notes": "LifeOpsBench live (scenarios/live/shift_rotation.py). A staffing overtime request landing during protected sleep must be triaged safely (adversarial protected-sleep interruption). authored (live-model run is the #12781 gate)."
+    },
+    {
+      "id": "live.shiftrotation.week_at_a_time_brief_after_handoff",
+      "pack": "B2",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "authored",
+      "notes": "LifeOpsBench live (scenarios/live/shift_rotation.py). A weekly post-handoff brief covers rotation, sleep, meds, and family conflicts. authored (live-model run is the #12781 gate)."
+    },
+    {
+      "id": "live.shiftrotation.focus_between_evening_shifts",
+      "pack": "B2",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "authored",
+      "notes": "LifeOpsBench live (scenarios/live/shift_rotation.py). Finds one admin focus block before an evening shift without cutting into sleep, commute, or meal prep. authored (live-model run is the #12781 gate)."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Completes the last incomplete LifeOps persona pack. All other packs (A1, A2, B1, C1, D1, E1, F1) are already at 100% on develop; **B2 shift-rotation was the sole gap at 6/22**.

develop already has 6 substantive scenario-runner scenarios for B2 (reanchor-protects-new-sleep-window, sleep-protection-holds-low-priority-nudge, wake-anchor-follows-shifted-window, swap-reanchors-and-checks-in, capture-new-shift-pattern, sleep-window-conflict-requires-confirm) — but the pack's LifeOpsBench scenarios were never registered in the coverage ledger. This registers them.

## What
- Registered the **16 real `shift_rotation.py` ids** (8 static `shiftrotation.*` + 8 `live.shiftrotation.*`) as `surface:"lifeops-bench"` catalog rows. Each grep-verified to resolve to a Python literal (e.g. `live.shiftrotation.night_to_day_transition_plan` @ `live/shift_rotation.py:50`). Append-only JSON; **no `lifeops-bench/**` files touched** (honors the child-issue rule).
- `status:"authored"`, **not** `"verified"` — `verified` requires a captured real-LLM run + hand-review; these bench scenarios have none. (Same honesty standard applied in #13286/A1.)

## Evidence
- `check-lifeops-persona-catalog-coverage.mjs` → **B2 22/22 authored, `errors: []`** (all 22 ids resolve exactly once). Repo total reaches **212/212 authored**.
- No new `.scenario.ts` or shared-file (`EXPECTED`, ratchets) changes — pure ledger registration, so no guard/ratchet impact.
- Live-LLM "verified" status on the bench + live-only rows defers to the live-model-key boundary (#12781).

Closes #12772.

🤖 Generated with [Claude Code](https://claude.com/claude-code)