### PR TITLE
fix(#12788): fail closed on corrupt app credit reads

### DIFF
--- a/packages/cloud/shared/src/db/repositories/app-credit-balances-numeric.ts
+++ b/packages/cloud/shared/src/db/repositories/app-credit-balances-numeric.ts
@@ -1,0 +1,17 @@
+/**
+ * Numeric parsing boundary for app credit balance rows and aggregate reads.
+ */
+
+export function parseAppCreditBalanceNumber(
+  value: string | number | null | undefined,
+  fieldName: string,
+): number {
+  if (value === null || value === undefined || String(value).trim() === "") {
+    throw new Error(`Unable to read app credit balance ${fieldName}`);
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Unable to read app credit balance ${fieldName}`);
+  }
+  return parsed;
+}

--- a/packages/cloud/shared/src/db/repositories/app-credit-balances-numeric.ts
+++ b/packages/cloud/shared/src/db/repositories/app-credit-balances-numeric.ts
@@ -6,7 +6,10 @@ export function parseAppCreditBalanceNumber(
   value: string | number | null | undefined,
   fieldName: string,
 ): number {
-  if (value === null || value === undefined || String(value).trim() === "") {
+  if (value === null || value === undefined) {
+    throw new Error(`Unable to read app credit balance ${fieldName}`);
+  }
+  if (typeof value === "string" && !/^[+-]?(?:\d+|\d*\.\d+)$/.test(value.trim())) {
     throw new Error(`Unable to read app credit balance ${fieldName}`);
   }
   const parsed = Number(value);

--- a/packages/cloud/shared/src/db/repositories/app-credit-balances.test.ts
+++ b/packages/cloud/shared/src/db/repositories/app-credit-balances.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Fail-closed coverage for app credit balance numeric reads (#12788).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { parseAppCreditBalanceNumber } from "./app-credit-balances-numeric";
+
+describe("parseAppCreditBalanceNumber", () => {
+  test("parses valid Drizzle numeric strings", () => {
+    expect(parseAppCreditBalanceNumber("12.50", "credit_balance")).toBe(12.5);
+  });
+
+  test("parses valid numeric aggregate values", () => {
+    expect(parseAppCreditBalanceNumber(3, "userCount")).toBe(3);
+  });
+
+  test("throws on null instead of fabricating zero", () => {
+    expect(() => parseAppCreditBalanceNumber(null, "totalBalance")).toThrow(/totalBalance/);
+  });
+
+  test("throws on undefined instead of fabricating zero", () => {
+    expect(() => parseAppCreditBalanceNumber(undefined, "totalSpent")).toThrow(/totalSpent/);
+  });
+
+  test("throws on non-numeric strings instead of returning NaN", () => {
+    expect(() => parseAppCreditBalanceNumber("not-a-number", "credit_balance")).toThrow(
+      /credit_balance/,
+    );
+  });
+
+  test("throws on partially numeric corrupt strings", () => {
+    expect(() => parseAppCreditBalanceNumber("12.5oops", "totalPurchased")).toThrow(
+      /totalPurchased/,
+    );
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/app-credit-balances.test.ts
+++ b/packages/cloud/shared/src/db/repositories/app-credit-balances.test.ts
@@ -10,6 +10,10 @@ describe("parseAppCreditBalanceNumber", () => {
     expect(parseAppCreditBalanceNumber("12.50", "credit_balance")).toBe(12.5);
   });
 
+  test("parses valid decimal strings with surrounding whitespace", () => {
+    expect(parseAppCreditBalanceNumber(" 12.50 ", "credit_balance")).toBe(12.5);
+  });
+
   test("parses valid numeric aggregate values", () => {
     expect(parseAppCreditBalanceNumber(3, "userCount")).toBe(3);
   });
@@ -32,5 +36,10 @@ describe("parseAppCreditBalanceNumber", () => {
     expect(() => parseAppCreditBalanceNumber("12.5oops", "totalPurchased")).toThrow(
       /totalPurchased/,
     );
+  });
+
+  test("throws on JavaScript-only numeric strings", () => {
+    expect(() => parseAppCreditBalanceNumber("0x10", "credit_balance")).toThrow(/credit_balance/);
+    expect(() => parseAppCreditBalanceNumber("1e3", "credit_balance")).toThrow(/credit_balance/);
   });
 });

--- a/packages/cloud/shared/src/db/repositories/app-credit-balances.ts
+++ b/packages/cloud/shared/src/db/repositories/app-credit-balances.ts
@@ -1,4 +1,6 @@
-// Persists app credit balances records for cloud services through the shared DB boundary.
+/**
+ * Persists app credit balance rows and aggregate balance reads for cloud services.
+ */
 import { and, desc, eq, sql } from "drizzle-orm";
 import { dbRead, dbWrite } from "../helpers";
 import {
@@ -6,6 +8,7 @@ import {
   appCreditBalances,
   type NewAppCreditBalance,
 } from "../schemas/app-credit-balances";
+import { parseAppCreditBalanceNumber } from "./app-credit-balances-numeric";
 
 export type { AppCreditBalance, NewAppCreditBalance };
 
@@ -66,7 +69,8 @@ export class AppCreditBalancesRepository {
    */
   async getBalance(appId: string, userId: string): Promise<number> {
     const balance = await this.findByAppAndUser(appId, userId);
-    return balance ? Number(balance.credit_balance) : 0;
+    // error-policy:J6 no per-app credit row means the user has not prepaid for this app.
+    return balance ? parseAppCreditBalanceNumber(balance.credit_balance, "credit_balance") : 0;
   }
 
   /**
@@ -89,10 +93,10 @@ export class AppCreditBalancesRepository {
       .where(eq(appCreditBalances.app_id, appId));
 
     return {
-      totalBalance: Number(result[0]?.totalBalance || 0),
-      totalPurchased: Number(result[0]?.totalPurchased || 0),
-      totalSpent: Number(result[0]?.totalSpent || 0),
-      userCount: Number(result[0]?.userCount || 0),
+      totalBalance: parseAppCreditBalanceNumber(result[0]?.totalBalance, "totalBalance"),
+      totalPurchased: parseAppCreditBalanceNumber(result[0]?.totalPurchased, "totalPurchased"),
+      totalSpent: parseAppCreditBalanceNumber(result[0]?.totalSpent, "totalSpent"),
+      userCount: parseAppCreditBalanceNumber(result[0]?.userCount, "userCount"),
     };
   }
 
@@ -194,7 +198,7 @@ export class AppCreditBalancesRepository {
 
       return {
         balance: updated,
-        newBalance: Number(updated.credit_balance),
+        newBalance: parseAppCreditBalanceNumber(updated.credit_balance, "credit_balance"),
       };
     });
   }
@@ -229,7 +233,7 @@ export class AppCreditBalancesRepository {
         };
       }
 
-      const currentBalance = Number(balance.credit_balance);
+      const currentBalance = parseAppCreditBalanceNumber(balance.credit_balance, "credit_balance");
 
       if (currentBalance < amount) {
         return {

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
@@ -598,6 +598,14 @@ describe("checkBalance — reads the org ledger", () => {
       "Unable to read organization credit_balance",
     );
   });
+
+  test("rejects JavaScript-only org balance strings", async () => {
+    findOrgById.mockResolvedValue({ id: ORG_ID, credit_balance: "0x10" });
+
+    await expect(freshService().checkBalance(APP_ID, USER_ID, 40)).rejects.toThrow(
+      "Unable to read organization credit_balance",
+    );
+  });
 });
 
 // The per-inference billing PRICE quoted on the LLM hot path

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
@@ -228,6 +228,23 @@ describe("processPurchase — funds the org ledger (#8253)", () => {
     expect(result.creditsAdded).toBe(0);
     expect(result.newBalance).toBe(42.5); // read straight off the org row
   });
+
+  test("webhook retry dedup fails closed on a corrupt org balance", async () => {
+    findTransactionByPaymentIntent.mockResolvedValue({ id: "existing-tx" });
+    findOrgById.mockResolvedValue({ id: ORG_ID, credit_balance: "42.50oops" });
+
+    await expect(
+      freshService().processPurchase({
+        appId: APP_ID,
+        userId: USER_ID,
+        organizationId: ORG_ID,
+        purchaseAmount: 10,
+        stripePaymentIntentId: "pi_123",
+      }),
+    ).rejects.toThrow("Unable to read organization credit_balance");
+
+    expect(addCredits).not.toHaveBeenCalled();
+  });
 });
 
 describe("deductCredits — debits the same org ledger", () => {
@@ -462,6 +479,24 @@ describe("reconcileCredits — charges/refunds the estimate↔actual delta (#914
     });
   });
 
+  test("no-op reconciliation fails closed on a corrupt org balance", async () => {
+    findOrgById.mockResolvedValue({ id: ORG_ID, credit_balance: "42.50oops" });
+
+    await expect(
+      freshService().reconcileCredits({
+        appId: APP_ID,
+        userId: USER_ID,
+        estimatedBaseCost: 1,
+        actualBaseCost: 1,
+        description: "recon",
+        reservationTransactionId: "app-hold-1",
+      }),
+    ).rejects.toThrow("Unable to read organization credit_balance");
+
+    expect(reserveAndDeductCredits).not.toHaveBeenCalled();
+    expect(refundCredits).not.toHaveBeenCalled();
+  });
+
   test("charges the markup'd delta to the org when actual exceeds estimated", async () => {
     const result = await freshService().reconcileCredits({
       appId: APP_ID,
@@ -554,6 +589,14 @@ describe("checkBalance — reads the org ledger", () => {
 
     const tooMuch = await freshService().checkBalance(APP_ID, USER_ID, 50);
     expect(tooMuch.sufficient).toBe(false);
+  });
+
+  test("fails closed when the org balance is corrupt", async () => {
+    findOrgById.mockResolvedValue({ id: ORG_ID, credit_balance: "42.50oops" });
+
+    await expect(freshService().checkBalance(APP_ID, USER_ID, 40)).rejects.toThrow(
+      "Unable to read organization credit_balance",
+    );
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -78,6 +78,17 @@ async function invalidateAppCacheKeys(appId: string, slug?: string): Promise<voi
   await Promise.all(promises);
 }
 
+function parseOrgCreditBalance(value: string | number | null | undefined): number {
+  if (value === null || value === undefined || String(value).trim() === "") {
+    throw new Error("Unable to read organization credit_balance");
+  }
+  const balance = Number(value);
+  if (!Number.isFinite(balance)) {
+    throw new Error("Unable to read organization credit_balance");
+  }
+  return balance;
+}
+
 /**
  * Threshold for reconciliation - differences below this are ignored (6 decimal precision)
  */
@@ -311,7 +322,9 @@ export class AppCreditsService {
   /** The org credit balance — the single ledger app purchases fund and app inference debits (#8253). */
   private async readOrgBalance(organizationId: string): Promise<number> {
     const org = await organizationsRepository.findById(organizationId);
-    return org ? Number.parseFloat(String(org.credit_balance)) : 0;
+    // error-policy:J6 missing org preserves the existing no-credit result path; a present
+    // org with corrupt money data must fail closed.
+    return org ? parseOrgCreditBalance(org.credit_balance) : 0;
   }
 
   async processPurchase(params: AppCreditPurchaseParams): Promise<AppCreditPurchaseResult> {
@@ -836,11 +849,6 @@ export class AppCreditsService {
       }
     };
 
-    const readOrgBalance = async (): Promise<number> => {
-      const org = await organizationsRepository.findById(organizationId);
-      return org ? Number.parseFloat(String(org.credit_balance)) : 0;
-    };
-
     // Skip reconciliation for negligible differences
     if (Math.abs(baseCostDifference) < RECONCILIATION_THRESHOLD) {
       await markReservationSettled("no_adjustment");
@@ -849,7 +857,7 @@ export class AppCreditsService {
         difference: 0,
         action: "none",
         adjustedAmount: 0,
-        newBalance: await readOrgBalance(),
+        newBalance: await this.readOrgBalance(organizationId),
       };
     }
 
@@ -863,7 +871,7 @@ export class AppCreditsService {
         difference: baseCostDifference,
         action: "none",
         adjustedAmount: 0,
-        newBalance: await readOrgBalance(),
+        newBalance: await this.readOrgBalance(organizationId),
       };
     }
 
@@ -1214,7 +1222,9 @@ export class AppCreditsService {
       return { sufficient: false, balance: 0, required: requiredAmount };
     }
     const org = await organizationsRepository.findById(user.organization_id);
-    const balance = org ? Number.parseFloat(String(org.credit_balance)) : 0;
+    // error-policy:J6 missing org keeps the existing insufficient-credit result; corrupt
+    // present money data is not a zero balance.
+    const balance = org ? parseOrgCreditBalance(org.credit_balance) : 0;
     return {
       sufficient: balance >= requiredAmount,
       balance,

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -79,7 +79,10 @@ async function invalidateAppCacheKeys(appId: string, slug?: string): Promise<voi
 }
 
 function parseOrgCreditBalance(value: string | number | null | undefined): number {
-  if (value === null || value === undefined || String(value).trim() === "") {
+  if (value === null || value === undefined) {
+    throw new Error("Unable to read organization credit_balance");
+  }
+  if (typeof value === "string" && !/^[+-]?(?:\d+|\d*\.\d+)$/.test(value.trim())) {
     throw new Error("Unable to read organization credit_balance");
   }
   const balance = Number(value);


### PR DESCRIPTION
## Summary

- fail closed when app credit balance repository reads encounter null/blank/non-numeric numeric fields instead of coercing them to zero or NaN
- preserve the documented no-row app balance behavior as a zero-credit result with an `error-policy:J6` annotation
- fail closed on corrupt organization credit balances in app-credit purchase dedup, no-op reconciliation, and balance checks

## Evidence

- `bun test packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts packages/cloud/shared/src/db/repositories/app-credit-balances.test.ts` — 35 tests, 138 assertions passed
- `bunx @biomejs/biome check packages/cloud/shared/src/db/repositories/app-credit-balances.ts packages/cloud/shared/src/db/repositories/app-credit-balances-numeric.ts packages/cloud/shared/src/db/repositories/app-credit-balances.test.ts packages/cloud/shared/src/lib/services/app-credits.ts packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts` — passed
- `git diff --check` — passed
- `bun run audit:error-policy-ratchet` — passed

## Typecheck

- `bun run --cwd packages/cloud/shared typecheck 2>&1 | rg "app-credit-balances|app-credits"` still reports the package's existing local declaration-resolution noise for `dist/node_modules/drizzle-orm` and pre-existing implicit `tx` errors in `app-credit-balances.ts`; no new touched-logic type errors were identified beyond that environment issue.

## Evidence N/A

- UI screenshots/video: N/A - backend DB/service numeric read boundary only.
- Live model trajectories: N/A - no agent/action/prompt/model behavior changed.
- Cloud stack request logs/DB rows: N/A - this slice is covered by focused service and parser tests; it does not add or change a route surface.
