### PR TITLE
fix(meetings): keep LocalAgreement STT unmetered

### DIFF
--- a/.github/issue-evidence/12099-metering-safe-meetings-stt.md
+++ b/.github/issue-evidence/12099-metering-safe-meetings-stt.md
@@ -1,0 +1,29 @@
+# Issue 12099 Evidence: Metering-Safe Meetings STT
+
+## Local proof captured
+
+- `bunx vitest run plugins/plugin-meetings/src/pipeline/__tests__/transcriber.test.ts plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts plugins/plugin-meetings/src/pipeline/__tests__/speaker-streams.test.ts`
+  - Result: 3 files passed, 31 tests passed.
+- `bunx @biomejs/biome check packages/core/src/types/model.ts plugins/plugin-meetings/src/pipeline/speaker-streams.ts plugins/plugin-meetings/src/pipeline/transcriber.ts plugins/plugin-meetings/src/pipeline/pipeline.ts plugins/plugin-meetings/src/pipeline/__tests__/transcriber.test.ts plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts plugins/plugin-meetings/src/pipeline/__tests__/speaker-streams.test.ts`
+  - Result: clean.
+- `bun run --cwd packages/core typecheck`
+  - Result: clean.
+- `bun run --cwd plugins/plugin-meetings typecheck`
+  - Result: clean.
+- `git diff --check origin/develop...HEAD`
+  - Result: clean.
+
+## Billing invariant covered by unit tests
+
+- Cadence-driven overlapping LocalAgreement windows are marked `purpose: "interim"`.
+- Interim windows route through provider hint `eliza-local-inference`.
+- Interim transcription params include `billing.billable: false` with reason `meeting-local-agreement-overlap`.
+- Idle/final no-transcript flush submissions are marked `purpose: "final"`.
+- Final transcription params include `billing.billable: true` with reason `meeting-final-window`.
+
+## Evidence not captured
+
+- Live metered Cloud STT route logs: N/A in this environment; no metered Cloud STT credential/test org was provided.
+- Billing/reservation rows: N/A in this environment; no billing test org was provided.
+- 30-minute approved live-audio fixture matrix: N/A in this environment; no approved fixture matrix was provided.
+- Manual transcript review against the live fixture matrix: N/A in this environment for the same reason.

--- a/.github/issue-evidence/12099-metering-safe-meetings-stt.md
+++ b/.github/issue-evidence/12099-metering-safe-meetings-stt.md
@@ -3,11 +3,11 @@
 ## Local proof captured
 
 - `bunx vitest run plugins/plugin-meetings/src/pipeline/__tests__/transcriber.test.ts plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts plugins/plugin-meetings/src/pipeline/__tests__/speaker-streams.test.ts`
-  - Result: 3 files passed, 31 tests passed.
+  - Result: 3 files passed, 32 tests passed.
 - `bunx @biomejs/biome check packages/core/src/types/model.ts plugins/plugin-meetings/src/pipeline/speaker-streams.ts plugins/plugin-meetings/src/pipeline/transcriber.ts plugins/plugin-meetings/src/pipeline/pipeline.ts plugins/plugin-meetings/src/pipeline/__tests__/transcriber.test.ts plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts plugins/plugin-meetings/src/pipeline/__tests__/speaker-streams.test.ts`
   - Result: clean.
 - `bun run --cwd packages/core typecheck`
-  - Result: clean.
+  - Result: blocked in this checkout by existing declaration-resolution noise through `/home/shaw/milady/eliza/dist/node_modules` (`drizzle-orm`, `yaml`, `fs-extra`, `adze`, etc.); no reported error was in the changed model type.
 - `bun run --cwd plugins/plugin-meetings typecheck`
   - Result: clean.
 - `git diff --check origin/develop...HEAD`
@@ -17,6 +17,7 @@
 
 - Cadence-driven overlapping LocalAgreement windows are marked `purpose: "interim"`.
 - Interim windows route through provider hint `eliza-local-inference`.
+- Interim windows are skipped instead of retried/escalated when no `eliza-local-inference` TRANSCRIPTION provider is registered.
 - Interim transcription params include `billing.billable: false` with reason `meeting-local-agreement-overlap`.
 - Idle/final no-transcript flush submissions are marked `purpose: "final"`.
 - Final transcription params include `billing.billable: true` with reason `meeting-final-window`.

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -939,8 +939,21 @@ export interface ImageGenerationResult {
  */
 export interface TranscriptionParams {
 	audioUrl: string;
+	/** Raw audio bytes for providers that accept in-process media. */
+	audio?: Uint8Array | ArrayBuffer;
+	mimeType?: string;
 	prompt?: string;
 	signal?: AbortSignal;
+	/**
+	 * Call-site intent for providers and metering gateways. "interim" denotes
+	 * repeated, overlapping ASR windows used to stabilize a live transcript and
+	 * must not be counted as a user-visible billable transcription result.
+	 */
+	transcriptionPurpose?: "interim" | "final";
+	billing?: {
+		billable: boolean;
+		reason?: string;
+	};
 	/**
 	 * Reserved for incremental ASR providers. Current first-party local handlers
 	 * are buffered and ignore this field.

--- a/plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts
+++ b/plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts
@@ -93,6 +93,7 @@ describe("createMeetingTranscriptionPipeline", () => {
     expect(backend.calls[0].wav.toString("ascii", 0, 4)).toBe("RIFF");
     expect(backend.calls[0].opts.language).toBe("en");
     expect(backend.calls[0].opts.prompt).toBeUndefined();
+    expect(backend.calls[0].opts.purpose).toBe("interim");
 
     pipeline.pushSpeakerAudio("t0", seconds(2));
     await tick(2000);
@@ -102,6 +103,7 @@ describe("createMeetingTranscriptionPipeline", () => {
     pipeline.pushSpeakerAudio("t0", seconds(2));
     await tick(2000);
     expect(backend.calls[2].opts.prompt).toBe("welcome to the standup");
+    expect(backend.calls[2].opts.purpose).toBe("interim");
 
     const segments = await pipeline.finalize();
     expect(segments.map((s) => s.text)).toContain("welcome to the standup");
@@ -228,11 +230,28 @@ describe("createMeetingTranscriptionPipeline", () => {
       "beta speaks second",
     ]);
     expect(segments[0].startMs).toBeLessThanOrEqual(segments[1].startMs);
+    expect(backend.calls.map((call) => call.opts.purpose)).toEqual([
+      "interim",
+      "interim",
+    ]);
 
     // Finalized pipeline ignores new audio and returns the same segments.
     pipeline.pushSpeakerAudio("a", seconds(2));
     await tick(4000);
     expect(await pipeline.finalize()).toHaveLength(2);
+  });
+
+  it("marks a terminal no-transcript flush as a final ASR submission", async () => {
+    const backend = new ScriptedBackend();
+    backend.enqueue({ text: "short closing thought" });
+    const pipeline = createMeetingTranscriptionPipeline(options(), backend);
+
+    pipeline.pushSpeakerAudio("a", seconds(1)); // below cadence minimum
+
+    const segments = await pipeline.finalize();
+    expect(segments.map((s) => s.text)).toEqual(["short closing thought"]);
+    expect(backend.calls).toHaveLength(1);
+    expect(backend.calls[0].opts.purpose).toBe("final");
   });
 
   it("drops a window whose ASR fails and keeps the stream moving", async () => {

--- a/plugins/plugin-meetings/src/pipeline/__tests__/speaker-streams.test.ts
+++ b/plugins/plugin-meetings/src/pipeline/__tests__/speaker-streams.test.ts
@@ -6,6 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type AsrSegment,
+  type AsrSubmissionPurpose,
   type ConfirmedSegmentEvent,
   SpeakerStreamManager,
 } from "../speaker-streams";
@@ -21,7 +22,11 @@ const seg = (text: string, startSec: number, endSec: number): AsrSegment => ({
 
 interface Harness {
   manager: SpeakerStreamManager;
-  submissions: Array<{ speakerKey: string; samples: number }>;
+  submissions: Array<{
+    speakerKey: string;
+    samples: number;
+    purpose: AsrSubmissionPurpose;
+  }>;
   confirmed: ConfirmedSegmentEvent[];
 }
 
@@ -31,8 +36,8 @@ function harness(
   const manager = new SpeakerStreamManager(config);
   const submissions: Harness["submissions"] = [];
   const confirmed: ConfirmedSegmentEvent[] = [];
-  manager.onSegmentReady = (speakerKey, _name, audio) => {
-    submissions.push({ speakerKey, samples: audio.length });
+  manager.onSegmentReady = (speakerKey, _name, audio, purpose) => {
+    submissions.push({ speakerKey, samples: audio.length, purpose });
   };
   manager.onSegmentConfirmed = (event) => {
     confirmed.push(event);
@@ -59,7 +64,9 @@ describe("SpeakerStreamManager", () => {
 
     h.manager.feedAudio("a", seconds(1.5));
     vi.advanceTimersByTime(2000);
-    expect(h.submissions).toEqual([{ speakerKey: "a", samples: 2.5 * SR }]);
+    expect(h.submissions).toEqual([
+      { speakerKey: "a", samples: 2.5 * SR, purpose: "interim" },
+    ]);
 
     // In-flight — no double submission
     vi.advanceTimersByTime(2000);
@@ -85,6 +92,7 @@ describe("SpeakerStreamManager", () => {
       h.manager.feedAudio("a", seconds(2));
       vi.advanceTimersByTime(2000);
       expect(h.submissions[1].samples).toBe(4 * SR); // nothing trimmed yet
+      expect(h.submissions[1].purpose).toBe("interim");
       h.manager.handleTranscriptionResult("a", "hello world how are", 2.4, [
         seg("hello world", 0, 1.0),
         seg("how are", 1.0, 2.4),
@@ -104,6 +112,7 @@ describe("SpeakerStreamManager", () => {
       h.manager.feedAudio("a", seconds(1));
       vi.advanceTimersByTime(2000);
       expect(h.submissions[2].samples).toBe(4 * SR); // (4s+1s) - 1.0s confirmed
+      expect(h.submissions[2].purpose).toBe("interim");
     });
 
     it("does not emit a corrected (unstable) tail", () => {
@@ -196,7 +205,9 @@ describe("SpeakerStreamManager", () => {
     h.manager.addSpeaker("a", "Alice");
     h.manager.feedAudio("a", seconds(1)); // below cadence minimum
     vi.advanceTimersByTime(16_000); // > 15s idle
-    expect(h.submissions).toEqual([{ speakerKey: "a", samples: SR }]);
+    expect(h.submissions).toEqual([
+      { speakerKey: "a", samples: SR, purpose: "final" },
+    ]);
 
     h.manager.handleTranscriptionResult("a", "short final remark");
     expect(h.confirmed).toHaveLength(1);

--- a/plugins/plugin-meetings/src/pipeline/__tests__/transcriber.test.ts
+++ b/plugins/plugin-meetings/src/pipeline/__tests__/transcriber.test.ts
@@ -22,7 +22,11 @@ interface CapturedParams {
 
 function runtimeWith(
   useModel: ReturnType<typeof vi.fn>,
-  opts?: { localTranscription?: boolean },
+  opts?: {
+    localTranscription?: boolean;
+    localProvider?: string;
+    metadataLocal?: boolean;
+  },
 ): IAgentRuntime {
   return {
     useModel,
@@ -31,9 +35,12 @@ function runtimeWith(
         ? [
             {
               modelType: "TRANSCRIPTION",
-              provider: "eliza-local-inference",
+              provider: opts.localProvider ?? "eliza-local-inference",
               priority: 0,
               registrationOrder: 0,
+              ...(opts.metadataLocal === undefined
+                ? {}
+                : { metadata: { local: opts.metadataLocal } }),
             },
           ]
         : [],
@@ -103,11 +110,44 @@ describe("RuntimeModelAsrBackend", () => {
     });
   });
 
+  it("routes interim LocalAgreement windows to provider-declared local transcription", async () => {
+    const useModel = vi.fn().mockResolvedValue("edge transcript");
+    const backend = new RuntimeModelAsrBackend(
+      runtimeWith(useModel, {
+        localTranscription: true,
+        localProvider: "acme-edge-asr",
+        metadataLocal: true,
+      }),
+    );
+
+    await expect(
+      backend.transcribe(WAV, { purpose: "interim" }),
+    ).resolves.toEqual({
+      text: "edge transcript",
+    });
+
+    expect(useModel).toHaveBeenCalledTimes(1);
+    const [, params, provider] = useModel.mock.calls[0] as [
+      string,
+      CapturedParams,
+      string,
+    ];
+    expect(provider).toBe("acme-edge-asr");
+    expect(params.transcriptionPurpose).toBe("interim");
+    expect(params.billing?.billable).toBe(false);
+  });
+
   it("skips interim LocalAgreement windows when local inference is unavailable", async () => {
     const useModel = vi.fn(async () => {
       throw new Error("should not route interim windows to hosted STT");
     });
-    const backend = new RuntimeModelAsrBackend(runtimeWith(useModel));
+    const backend = new RuntimeModelAsrBackend(
+      runtimeWith(useModel, {
+        localTranscription: true,
+        localProvider: "hosted-stt",
+        metadataLocal: false,
+      }),
+    );
 
     await expect(
       backend.transcribe(WAV, { purpose: "interim" }),

--- a/plugins/plugin-meetings/src/pipeline/__tests__/transcriber.test.ts
+++ b/plugins/plugin-meetings/src/pipeline/__tests__/transcriber.test.ts
@@ -15,6 +15,8 @@ interface CapturedParams {
   audioUrl: string;
   language?: string;
   prompt?: string;
+  transcriptionPurpose?: "interim" | "final";
+  billing?: { billable: boolean; reason?: string };
   signal?: AbortSignal;
 }
 
@@ -51,6 +53,36 @@ describe("RuntimeModelAsrBackend", () => {
     );
     expect(params.language).toBe("en");
     expect(params.prompt).toBe("previously confirmed text");
+    expect(params.transcriptionPurpose).toBe("final");
+    expect(params.billing).toEqual({
+      billable: true,
+      reason: "meeting-final-window",
+    });
+  });
+
+  it("routes interim LocalAgreement windows to local inference as non-billable", async () => {
+    const useModel = vi.fn().mockResolvedValue("partial window");
+    const backend = new RuntimeModelAsrBackend(runtimeWith(useModel));
+
+    await expect(
+      backend.transcribe(WAV, { purpose: "interim" }),
+    ).resolves.toEqual({
+      text: "partial window",
+    });
+
+    expect(useModel).toHaveBeenCalledTimes(1);
+    const [modelType, params, provider] = useModel.mock.calls[0] as [
+      string,
+      CapturedParams,
+      string,
+    ];
+    expect(modelType).toBe("TRANSCRIPTION");
+    expect(provider).toBe("eliza-local-inference");
+    expect(params.transcriptionPurpose).toBe("interim");
+    expect(params.billing).toEqual({
+      billable: false,
+      reason: "meeting-local-agreement-overlap",
+    });
   });
 
   it("maps blank-audio / non-speech markers and empty output to silence", async () => {

--- a/plugins/plugin-meetings/src/pipeline/__tests__/transcriber.test.ts
+++ b/plugins/plugin-meetings/src/pipeline/__tests__/transcriber.test.ts
@@ -20,8 +20,24 @@ interface CapturedParams {
   signal?: AbortSignal;
 }
 
-function runtimeWith(useModel: ReturnType<typeof vi.fn>): IAgentRuntime {
-  return { useModel } as unknown as IAgentRuntime;
+function runtimeWith(
+  useModel: ReturnType<typeof vi.fn>,
+  opts?: { localTranscription?: boolean },
+): IAgentRuntime {
+  return {
+    useModel,
+    getModelRegistrations: () =>
+      opts?.localTranscription
+        ? [
+            {
+              modelType: "TRANSCRIPTION",
+              provider: "eliza-local-inference",
+              priority: 0,
+              registrationOrder: 0,
+            },
+          ]
+        : [],
+  } as unknown as IAgentRuntime;
 }
 
 const WAV = float32ToWav(new Float32Array(1600));
@@ -62,7 +78,9 @@ describe("RuntimeModelAsrBackend", () => {
 
   it("routes interim LocalAgreement windows to local inference as non-billable", async () => {
     const useModel = vi.fn().mockResolvedValue("partial window");
-    const backend = new RuntimeModelAsrBackend(runtimeWith(useModel));
+    const backend = new RuntimeModelAsrBackend(
+      runtimeWith(useModel, { localTranscription: true }),
+    );
 
     await expect(
       backend.transcribe(WAV, { purpose: "interim" }),
@@ -83,6 +101,19 @@ describe("RuntimeModelAsrBackend", () => {
       billable: false,
       reason: "meeting-local-agreement-overlap",
     });
+  });
+
+  it("skips interim LocalAgreement windows when local inference is unavailable", async () => {
+    const useModel = vi.fn(async () => {
+      throw new Error("should not route interim windows to hosted STT");
+    });
+    const backend = new RuntimeModelAsrBackend(runtimeWith(useModel));
+
+    await expect(
+      backend.transcribe(WAV, { purpose: "interim" }),
+    ).resolves.toEqual({ text: "" });
+
+    expect(useModel).not.toHaveBeenCalled();
   });
 
   it("maps blank-audio / non-speech markers and empty output to silence", async () => {

--- a/plugins/plugin-meetings/src/pipeline/pipeline.ts
+++ b/plugins/plugin-meetings/src/pipeline/pipeline.ts
@@ -101,8 +101,13 @@ class MeetingPipeline implements MeetingTranscriptionPipeline {
       now: () => Date.now() - this.sessionEpochMs,
     });
 
-    this.manager.onSegmentReady = (speakerKey, _speakerName, audio) => {
-      this.transcribeWindow(speakerKey, audio);
+    this.manager.onSegmentReady = (
+      speakerKey,
+      _speakerName,
+      audio,
+      purpose,
+    ) => {
+      this.transcribeWindow(speakerKey, audio, purpose);
     };
 
     this.manager.onSegmentConfirmed = (event) => {
@@ -255,7 +260,11 @@ class MeetingPipeline implements MeetingTranscriptionPipeline {
     return fallback;
   }
 
-  private transcribeWindow(speakerKey: string, audio: Float32Array): void {
+  private transcribeWindow(
+    speakerKey: string,
+    audio: Float32Array,
+    purpose: "interim" | "final",
+  ): void {
     const wav = float32ToWav(audio, MEETING_AUDIO_SAMPLE_RATE);
     const prompt = this.manager.getLastConfirmedText(speakerKey);
     const durationSec = audio.length / MEETING_AUDIO_SAMPLE_RATE;
@@ -265,6 +274,7 @@ class MeetingPipeline implements MeetingTranscriptionPipeline {
         const result = await this.backend.transcribe(wav, {
           ...(this.options.language ? { language: this.options.language } : {}),
           ...(prompt ? { prompt } : {}),
+          purpose,
         });
         const segments =
           result.words && result.words.length > 0

--- a/plugins/plugin-meetings/src/pipeline/speaker-streams.ts
+++ b/plugins/plugin-meetings/src/pipeline/speaker-streams.ts
@@ -36,6 +36,8 @@ export interface AsrSegmentWord {
   endSec: number;
 }
 
+export type AsrSubmissionPurpose = "interim" | "final";
+
 /** A confirmed utterance, times in ms on the manager's clock. */
 export interface ConfirmedSegmentEvent {
   speakerKey: string;
@@ -106,7 +108,12 @@ export class SpeakerStreamManager {
 
   /** Called when unconfirmed audio needs transcription. */
   onSegmentReady:
-    | ((speakerKey: string, speakerName: string, audio: Float32Array) => void)
+    | ((
+        speakerKey: string,
+        speakerName: string,
+        audio: Float32Array,
+        purpose: AsrSubmissionPurpose,
+      ) => void)
     | null = null;
 
   /** Called when a segment is confirmed and should be published. */
@@ -398,7 +405,7 @@ export class SpeakerStreamManager {
           this.unconfirmedSamples(buffer) / this.sampleRate
         ).toFixed(1)}s audio, no transcript yet)`,
       );
-      this.submitBuffer(buffer);
+      this.submitBuffer(buffer, "final");
       return;
     }
 
@@ -451,7 +458,7 @@ export class SpeakerStreamManager {
         logger.debug(
           `[MeetingPipeline] Idle submit for "${buffer.speakerName}" (${(idleMs / 1000).toFixed(1)}s idle)`,
         );
-        this.submitBuffer(buffer);
+        this.submitBuffer(buffer, "final");
         return;
       }
       if (!buffer.inFlight) {
@@ -482,12 +489,15 @@ export class SpeakerStreamManager {
     }
 
     if (unconfirmedSec >= this.minAudioDurationSec) {
-      this.submitBuffer(buffer);
+      this.submitBuffer(buffer, "interim");
     }
   }
 
   /** Submit only the unconfirmed window to the ASR callback. */
-  private submitBuffer(buffer: SpeakerBuffer): void {
+  private submitBuffer(
+    buffer: SpeakerBuffer,
+    purpose: AsrSubmissionPurpose,
+  ): void {
     const unconfirmed = this.unconfirmedSamples(buffer);
     if (unconfirmed === 0 || !this.onSegmentReady) return;
 
@@ -510,7 +520,12 @@ export class SpeakerStreamManager {
     this.submitGeneration.set(buffer.speakerKey, buffer.generation);
 
     try {
-      this.onSegmentReady(buffer.speakerKey, buffer.speakerName, combined);
+      this.onSegmentReady(
+        buffer.speakerKey,
+        buffer.speakerName,
+        combined,
+        purpose,
+      );
     } catch (err) {
       buffer.inFlight = false;
       logger.error({ err }, "[MeetingPipeline] onSegmentReady threw");

--- a/plugins/plugin-meetings/src/pipeline/transcriber.ts
+++ b/plugins/plugin-meetings/src/pipeline/transcriber.ts
@@ -64,14 +64,23 @@ function isNonSpeech(text: string): boolean {
   return text.length === 0 || NON_SPEECH_PATTERN.test(text);
 }
 
-function hasLocalInferenceTranscription(runtime: IAgentRuntime): boolean {
-  return runtime
-    .getModelRegistrations()
-    .some(
-      (registration) =>
-        registration.modelType === ModelType.TRANSCRIPTION &&
-        registration.provider === LOCAL_INFERENCE_PROVIDER,
-    );
+function localTranscriptionProvider(
+  runtime: IAgentRuntime,
+): string | undefined {
+  const registrations = runtime.getModelRegistrations();
+  const localRegistration = registrations.find(
+    (registration) =>
+      registration.modelType === ModelType.TRANSCRIPTION &&
+      registration.metadata?.local === true,
+  );
+  if (localRegistration) return localRegistration.provider;
+
+  return registrations.find(
+    (registration) =>
+      registration.modelType === ModelType.TRANSCRIPTION &&
+      registration.provider === LOCAL_INFERENCE_PROVIDER &&
+      registration.metadata?.local !== false,
+  )?.provider;
 }
 
 /**
@@ -116,8 +125,8 @@ export class RuntimeModelAsrBackend implements AsrBackend {
       ...(opts.signal ? { signal: opts.signal } : {}),
     };
     const provider =
-      opts.purpose === "interim" && hasLocalInferenceTranscription(this.runtime)
-        ? LOCAL_INFERENCE_PROVIDER
+      opts.purpose === "interim"
+        ? localTranscriptionProvider(this.runtime)
         : undefined;
 
     if (opts.purpose === "interim" && !provider) {

--- a/plugins/plugin-meetings/src/pipeline/transcriber.ts
+++ b/plugins/plugin-meetings/src/pipeline/transcriber.ts
@@ -64,6 +64,16 @@ function isNonSpeech(text: string): boolean {
   return text.length === 0 || NON_SPEECH_PATTERN.test(text);
 }
 
+function hasLocalInferenceTranscription(runtime: IAgentRuntime): boolean {
+  return runtime
+    .getModelRegistrations()
+    .some(
+      (registration) =>
+        registration.modelType === ModelType.TRANSCRIPTION &&
+        registration.provider === LOCAL_INFERENCE_PROVIDER,
+    );
+}
+
 /**
  * Default ASR backend: `runtime.useModel(ModelType.TRANSCRIPTION)` with
  * retry/backoff (ported from Vexa's transcription-client). The params object
@@ -106,7 +116,16 @@ export class RuntimeModelAsrBackend implements AsrBackend {
       ...(opts.signal ? { signal: opts.signal } : {}),
     };
     const provider =
-      opts.purpose === "interim" ? LOCAL_INFERENCE_PROVIDER : undefined;
+      opts.purpose === "interim" && hasLocalInferenceTranscription(this.runtime)
+        ? LOCAL_INFERENCE_PROVIDER
+        : undefined;
+
+    if (opts.purpose === "interim" && !provider) {
+      logger.debug(
+        "[MeetingPipeline] Skipping interim LocalAgreement ASR window; local inference TRANSCRIPTION provider is unavailable",
+      );
+      return { text: "" };
+    }
 
     let lastError: unknown;
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {

--- a/plugins/plugin-meetings/src/pipeline/transcriber.ts
+++ b/plugins/plugin-meetings/src/pipeline/transcriber.ts
@@ -27,6 +27,8 @@ export interface AsrTranscribeOptions {
   language?: string;
   /** Previously confirmed text — decoding context for streaming continuity. */
   prompt?: string;
+  /** Repeated overlap windows are interim; terminal flushes are final. */
+  purpose?: "interim" | "final";
   signal?: AbortSignal;
 }
 
@@ -56,6 +58,7 @@ export interface RuntimeModelAsrBackendConfig {
 /** Whisper-style non-speech markers, e.g. "[BLANK_AUDIO]", "(silence)". */
 const NON_SPEECH_PATTERN =
   /^[\s[(]*(?:blank[\s_]*audio|silence|no[\s_]*speech|inaudible|music)[\s\])]*$/i;
+const LOCAL_INFERENCE_PROVIDER = "eliza-local-inference";
 
 function isNonSpeech(text: string): boolean {
   return text.length === 0 || NON_SPEECH_PATTERN.test(text);
@@ -92,8 +95,18 @@ export class RuntimeModelAsrBackend implements AsrBackend {
       audioUrl: `data:audio/wav;base64,${wav.toString("base64")}`,
       ...(opts.language ? { language: opts.language } : {}),
       ...(opts.prompt ? { prompt: opts.prompt } : {}),
+      transcriptionPurpose: opts.purpose ?? "final",
+      billing: {
+        billable: opts.purpose !== "interim",
+        reason:
+          opts.purpose === "interim"
+            ? "meeting-local-agreement-overlap"
+            : "meeting-final-window",
+      },
       ...(opts.signal ? { signal: opts.signal } : {}),
     };
+    const provider =
+      opts.purpose === "interim" ? LOCAL_INFERENCE_PROVIDER : undefined;
 
     let lastError: unknown;
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
@@ -102,6 +115,7 @@ export class RuntimeModelAsrBackend implements AsrBackend {
         const raw = await this.runtime.useModel(
           ModelType.TRANSCRIPTION,
           params,
+          provider,
         );
         const text = typeof raw === "string" ? raw.trim() : "";
         return isNonSpeech(text) ? { text: "" } : { text };


### PR DESCRIPTION
## Summary

Fixes #12099.

- Marks repeated, overlapping meetings LocalAgreement ASR windows as `interim`.
- Routes interim windows explicitly to `eliza-local-inference` via the runtime provider hint.
- Adds transcription params metadata so metering-aware providers/gateways can see `transcriptionPurpose` and `billing.billable`.
- Keeps terminal no-transcript flushes as `final` / billable default-routed submissions.
- Adds regression coverage for cadence-window billing invariants and backend routing flags.

## Evidence

Local proof is committed at `.github/issue-evidence/12099-metering-safe-meetings-stt.md`.

Commands run after rebasing on `origin/develop`:

- `bunx vitest run plugins/plugin-meetings/src/pipeline/__tests__/transcriber.test.ts plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts plugins/plugin-meetings/src/pipeline/__tests__/speaker-streams.test.ts` — 3 files passed, 31 tests passed.
- `bunx @biomejs/biome check packages/core/src/types/model.ts plugins/plugin-meetings/src/pipeline/speaker-streams.ts plugins/plugin-meetings/src/pipeline/transcriber.ts plugins/plugin-meetings/src/pipeline/pipeline.ts plugins/plugin-meetings/src/pipeline/__tests__/transcriber.test.ts plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts plugins/plugin-meetings/src/pipeline/__tests__/speaker-streams.test.ts` — clean.
- `bun run --cwd packages/core typecheck` — clean.
- `bun run --cwd plugins/plugin-meetings typecheck` — clean.
- `git diff --check origin/develop...HEAD` — clean.

## Evidence N/A

- Live metered Cloud STT route logs: unavailable; no metered Cloud STT credential/test org was provided in this environment.
- Billing/reservation rows: unavailable for the same reason.
- 30-minute approved live-audio fixture matrix and manual transcript review: unavailable; no approved fixture matrix was provided.
