### PR TITLE
ci: restore develop coverage + affected PR lane + exhaustive scheduled matrix with vacuous-green guards (#12191)

### DIFF
--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -46,29 +46,16 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Persist Turbo's *local* filesystem cache across runs using GitHub Actions
-    # cache (free, no third-party SaaS remote cache). Turbo caches typecheck /
-    # build / lint / format:check results keyed by task inputs, so unchanged
-    # packages are replayed from cache instead of rerun — which keeps the full
-    # 14-way typecheck off the runner (it was OOM/SIGTERM-killing the test job on
-    # cold runs). The primary key is derived from Turbo-relevant content instead
-    # of github.sha so it can hit across commits while still rotating after real
-    # input changes; Turbo's own task hashes still decide whether each restored
-    # cache entry is reusable. Cache failures are non-fatal; a miss just means no
-    # speedup.
-    - name: Compute Turbo cache key
-      id: turbo_cache_key
-      shell: bash
-      run: node packages/scripts/turbo-cache-key.mjs --github-output
-
-    - name: Restore Turbo cache (GitHub Actions)
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
-      with:
-        path: .turbo
-        key: turbo-${{ runner.os }}-${{ github.job }}-${{ steps.turbo_cache_key.outputs.turbo_cache_key }}
-        restore-keys: |
-          turbo-${{ runner.os }}-${{ github.job }}-
-          turbo-${{ runner.os }}-
+    # Persist Turbo's local filesystem cache (.turbo) through the pinned
+    # GitHub-native shim (#12341) — the single Turbo cache regime, replacing the
+    # Vercel SaaS remote cache. The shim keys on the deterministic
+    # turbo-cache-key hash with no github.job fragment, so one entry is shared
+    # across every job instead of the ~30-way fragmentation the old per-job key
+    # caused; Turbo re-validates task hashes on restore, so a cross-job hit is
+    # always safe. This keeps the full 14-way typecheck off the runner on warm
+    # caches (cold ran it OOM/SIGTERM). No SaaS, no secrets; a miss is non-fatal.
+    - name: Restore Turbo cache (GitHub-native)
+      uses: ./.github/actions/turbo-cache-github
 
     - name: Setup Python
       if: ${{ inputs.setup-python == 'true' }}

--- a/.github/issue-evidence/12191-ci-baseline.md
+++ b/.github/issue-evidence/12191-ci-baseline.md
@@ -64,8 +64,47 @@ serialization or latest-only semantics and are not develop coverage).
 - `ci-ok` `strict_results` now includes `push`, so a skipped real lane on
   `develop` fails the aggregate instead of passing silently.
 
-## After metrics (to be filled by phase 5, #12342)
+## What phases 4/5 added on top of phase 1
 
-Re-run the same `gh run list` census once the change has been on `develop` long
-enough to accumulate completed push runs; record completion rate, cancel rate,
-wall-clock p50/p95, and billable-minute deltas against this baseline.
+- **Phase 4 (#12341):** the whole repo is off the Vercel SaaS Turbo remote
+  cache and on the GitHub-native cache (`setup-bun-workspace` →
+  `turbo-cache-github` shim). 0 workflows wire `TURBO_TOKEN` / `TURBO_TEAM` /
+  `TURBO_CACHE: remote:rw` (was ~20). `ci-workflow-dedup-contract.mjs` now
+  forbids the SaaS env and requires the GitHub-native cache on the publish
+  paths. PR-lane `typecheck` (ci.yaml) and `lint` (quality.yml) run through
+  `turbo --affected` scoped to the PR merge base.
+- **Phase 5 (#12342):** `develop-exhaustive.yml` — an un-cancellable scheduled
+  orchestrator (06:00/18:00 UTC, own concurrency group) — invokes the platform
+  lanes test.yml's schedule does not cover (Windows / mobile / scenario / the 3
+  UI gates / keyless harness / docker / dev / electrobun) via `workflow_call`,
+  then runs `ci-full-matrix-proof.mjs`. The proof fails on a missing lane, a
+  PR-only-pinned lane, a dropped reusable-workflow `uses:` or `workflow_call`
+  trigger, a plan-floor breach, or a zero-collected lane
+  (`run-all-tests.mjs --min-tasks`).
+
+## After metrics — the exact post-merge census a reviewer runs
+
+These require live `develop` CI data accumulated after merge; run once the
+branch has been on `develop` long enough:
+
+```bash
+# Completed-vs-cancelled develop push coverage (phase-1 target: >0 completed).
+gh run list --repo elizaos/eliza --workflow test.yml --branch develop \
+  --event push --limit 200 --json conclusion,createdAt
+
+# The un-cancellable scheduled exhaustive lane completes >=2x/day, never
+# cancelled by pushes (phase-5 DoD: 7 consecutive days).
+gh run list --repo elizaos/eliza --workflow develop-exhaustive.yml \
+  --event schedule --limit 20 --json conclusion,createdAt
+gh run list --repo elizaos/eliza --workflow ci-full-matrix-proof.yml \
+  --event schedule --limit 20 --json conclusion,createdAt
+
+# Turbo cache-hit parity on a representative develop PR (phase-4 DoD):
+# grep the affected typecheck/lint step logs for ">>> FULL TURBO" / cache hits.
+gh run view <pr-run-id> --log | grep -iE 'cache hit|FULL TURBO|>>> '
+```
+
+Record completion rate, cancel rate, wall-clock p50/p95, and billable-minute
+deltas against the phase-1 numbers above. The mechanisms are verified in the
+#12191 PR (contract negative tests + live guard fail-loud demos); these metrics
+are the only observation-gated items.

--- a/.github/workflows/CHANGELOG.md
+++ b/.github/workflows/CHANGELOG.md
@@ -29,6 +29,22 @@ do not have to carry CI-only history.
   graph. A shallow clone degrades to running everything, so scoping never
   under-checks.
 
+### Added
+
+- `develop-exhaustive.yml` (#12342, epic #12191 phase 5): an un-cancellable
+  scheduled orchestrator (06:00/18:00 UTC, dedicated concurrency group) that
+  invokes every platform lane test.yml's schedule does not cover — Windows,
+  mobile, scenario, the three UI gates, keyless harness, docker, dev
+  onboarding, electrobun/desktop — via `workflow_call`, then runs the matrix
+  proof. A skipped or failed reusable lane fails the run (a coverage gap is not
+  a pass). Added a bare `workflow_call:` trigger to each of those 10 workflows
+  so they are reusable.
+
+  Why: the scheduled exhaustive lane is the "prove develop runs the full
+  matrix" DoD. `ci-full-matrix-proof.mjs` + `ci-lane-manifest.json` gained a
+  `reusableWorkflows` check so dropping a lane's `uses:` or a workflow's
+  `workflow_call` trigger fails the proof statically, before the run.
+
 ## 2026-06-29
 
 ### Changed

--- a/.github/workflows/CHANGELOG.md
+++ b/.github/workflows/CHANGELOG.md
@@ -4,6 +4,31 @@ This changelog tracks meaningful CI policy and workflow-architecture changes.
 It is intentionally scoped to `.github/workflows` so product/package changelogs
 do not have to carry CI-only history.
 
+## 2026-07-04
+
+### Changed
+
+- Migrated the whole repo off the Vercel SaaS Turbo remote cache onto the
+  GitHub-native cache (#12341, epic #12191 phase 4). Removed every
+  `TURBO_TOKEN` / `TURBO_TEAM` / `TURBO_CACHE: remote:rw` env from all
+  workflows (108 lines across 11 files) and routed `setup-bun-workspace`'s
+  Turbo cache through the pinned `turbo-cache-github` shim, whose single
+  per-hash key replaces the former per-job-name key that fragmented the cache
+  across ~30 job names.
+
+  Why: project guidance is GitHub-native caching only; the SaaS env was
+  redundant with the `.turbo` `actions/cache` layer that already ran in the
+  shared setup action. `ci-workflow-dedup-contract.mjs` now **forbids** the
+  SaaS env anywhere and **requires** the GitHub-native cache on the publish
+  paths (nightly/release) — the inverse of its previous assertion, which
+  pinned the SaaS wiring.
+
+- PR-lane `typecheck` (`ci.yaml`) and `lint` (`quality.yml`) now run through
+  `turbo --affected` scoped to the PR merge base (`TURBO_SCM_BASE`), with full
+  history fetched so scoping resolves; `push`/`merge_group` still run the full
+  graph. A shallow clone degrades to running everything, so scoping never
+  under-checks.
+
 ## 2026-06-29
 
 ### Changed

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -235,9 +235,13 @@ Use `bunx lerna publish` from the repo root when automation is not sufficient (s
 
 | Secret | Purpose |
 |--------|---------|
-| `TURBO_TOKEN` | Turborepo remote caching |
 | `PHALA_CLOUD_API_KEY` | TEE deployment |
 | `GH_PAT` | Cross-repo operations |
+
+Turbo caching is GitHub-native (`.github/actions/turbo-cache-github` via
+`setup-bun-workspace`) — no Vercel SaaS remote cache, so `TURBO_TOKEN` /
+`TURBO_TEAM` are no longer used and are banned by
+`ci-workflow-dedup-contract.mjs` (#12341).
 
 ## Package dependencies
 

--- a/.github/workflows/app-aesthetic-audit.yml
+++ b/.github/workflows/app-aesthetic-audit.yml
@@ -43,9 +43,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
       # Keyless: the ui-smoke stub is forced when CI=true (shouldForceStubStack).
       ELIZA_UI_SMOKE_FORCE_STUB: "1"
       ELIZA_AUDIT_APP_STRICT: ${{ github.event.inputs.strict == 'true' && '1' || '0' }}

--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -62,9 +62,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
       PGLITE_WASM_MODE: node
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -137,9 +134,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
       PGLITE_WASM_MODE: node
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -205,9 +199,6 @@ jobs:
     timeout-minutes: 45
     env:
       ELIZA_UI_SMOKE_CLOUD_LIVE: "1"
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
       PGLITE_WASM_MODE: node
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -268,10 +259,6 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_android_local_chat }}
     runs-on: ubuntu-24.04
     timeout-minutes: 90
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -330,9 +317,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
       PGLITE_WASM_MODE: node
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,12 +24,13 @@ jobs:
     env:
       # Baseline CI is secret-free. Live/provider-key E2E runs in dedicated
       # opt-in or post-merge workflows, not in the PR test job.
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
       PGLITE_WASM_MODE: node
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          # Full history so `turbo run typecheck --affected` can resolve the PR
+          # merge base (#12341); a shallow clone degrades to typechecking all.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -53,7 +54,16 @@ jobs:
       - name: Build packages
         run: bun run build:core
 
-      - name: Run typecheck
+      # PR lane: typecheck only the merge base's dependency cone; on push to
+      # main typecheck the whole workspace (#12341).
+      - name: Run typecheck (affected — PR)
+        if: github.event_name == 'pull_request'
+        run: NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck --concurrency=8 --affected
+        env:
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+
+      - name: Run typecheck (full — push)
+        if: github.event_name != 'pull_request'
         run: bun run typecheck
 
       - name: Run tests
@@ -83,10 +93,6 @@ jobs:
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'main')
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
@@ -159,10 +165,6 @@ jobs:
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'main')
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
@@ -193,10 +195,6 @@ jobs:
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'main')
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -206,9 +206,6 @@ jobs:
     needs: migrate-db
     if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.migrate-db.result == 'success' }}
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-api
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}
     steps:
@@ -551,9 +548,6 @@ jobs:
     needs: migrate-db
     if: ${{ !cancelled() && (needs.migrate-db.result == 'success' || (github.event_name == 'pull_request' && needs.migrate-db.result == 'skipped')) }}
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-console
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}
     steps:
@@ -911,9 +905,6 @@ jobs:
     needs: migrate-db
     if: ${{ !cancelled() && (needs.migrate-db.result == 'success' || (github.event_name == 'pull_request' && needs.migrate-db.result == 'skipped')) }}
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-app
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}
     steps:

--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -1,6 +1,8 @@
 name: Dev Smoke
 
 on:
+  # Reusable entry for the scheduled exhaustive develop lane (#12342).
+  workflow_call:
   pull_request:
     branches: [main, develop]
     types: [opened, synchronize, reopened, ready_for_review, labeled]

--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -79,9 +79,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 35
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
       PGLITE_WASM_MODE: node
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/develop-exhaustive.yml
+++ b/.github/workflows/develop-exhaustive.yml
@@ -1,0 +1,158 @@
+name: Develop Exhaustive Lane
+
+# Un-cancellable scheduled run of the FULL develop matrix (#12342, epic #12191
+# phase 5). test.yml's own 09:17 schedule already covers the unit / e2e /
+# plugin / desktop / zero-key lanes; this orchestrator adds the platform lanes
+# that otherwise only run path-gated on PRs — Windows, mobile, scenario, the
+# three UI gates, the keyless harness, docker, dev onboarding, and the
+# electrobun/desktop contract — by invoking each via `workflow_call` so no step
+# is duplicated. workflow_call bypasses the per-workflow path filters, and a
+# schedule-origin event makes every called workflow's
+# `github.event_name != 'pull_request'` job gate evaluate true, so the lanes run
+# unfiltered (exhaustive). The final proof job statically asserts the committed
+# manifest still matches test.yml AND that every required reusable workflow is
+# wired here and declares workflow_call, then fails the run if any reusable lane
+# did not succeed — a skipped or failed platform lane is a coverage gap, not a
+# pass.
+
+on:
+  schedule:
+    # Twice daily, offset from test.yml (09:17) and ci-full-matrix-proof (03:13/
+    # 15:13) so the three scheduled signals do not stampede the runner pool.
+    - cron: "0 6 * * *"
+    - cron: "0 18 * * *"
+  workflow_dispatch:
+
+# Dedicated group, never cancelled by push/PR traffic: the whole point is a
+# completed daily coverage signal (#12337/#12342).
+concurrency:
+  group: develop-exhaustive-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: read
+  actions: read
+
+jobs:
+  windows:
+    name: Windows full matrix
+    uses: ./.github/workflows/windows-ci.yml
+    secrets: inherit
+  mobile:
+    name: Mobile build smoke
+    uses: ./.github/workflows/mobile-build-smoke.yml
+    secrets: inherit
+  scenario:
+    name: Scenario deterministic E2E
+    uses: ./.github/workflows/scenario-pr.yml
+    secrets: inherit
+  ui-e2e:
+    name: UI e2e gate
+    uses: ./.github/workflows/ui-e2e-gate.yml
+    secrets: inherit
+  ui-fixture:
+    name: UI fixture e2e
+    uses: ./.github/workflows/ui-fixture-e2e.yml
+    secrets: inherit
+  ui-story:
+    name: UI story gate
+    uses: ./.github/workflows/ui-story-gate.yml
+    secrets: inherit
+  keyless-harness:
+    name: Keyless harness E2E
+    uses: ./.github/workflows/keyless-harness-e2e.yml
+    secrets: inherit
+  docker:
+    name: Docker image smoke
+    uses: ./.github/workflows/docker-ci-smoke.yml
+    secrets: inherit
+  dev-onboarding:
+    name: Dev onboarding smoke
+    uses: ./.github/workflows/dev-smoke.yml
+    secrets: inherit
+  electrobun:
+    name: Electrobun desktop release
+    uses: ./.github/workflows/test-electrobun-release.yml
+    secrets: inherit
+
+  matrix-proof:
+    name: Exhaustive lane matrix proof
+    needs:
+      - windows
+      - mobile
+      - scenario
+      - ui-e2e
+      - ui-fixture
+      - ui-story
+      - keyless-harness
+      - docker
+      - dev-onboarding
+      - electrobun
+    # Run even when a reusable lane failed so the proof enumerates every lane
+    # and the result check below can name the offender; only a cancel skips it.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-24.04
+    env:
+      CI: "true"
+      BUN_VERSION: "1.3.14"
+      NODE_VERSION: "24.15.0"
+      NODE_NO_WARNINGS: "1"
+      NODE_OPTIONS: "--max-old-space-size=8192"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Assert every reusable lane succeeded (skipped/failed == gap)
+        env:
+          RESULTS: >-
+            windows=${{ needs.windows.result }}
+            mobile=${{ needs.mobile.result }}
+            scenario=${{ needs.scenario.result }}
+            ui-e2e=${{ needs.ui-e2e.result }}
+            ui-fixture=${{ needs.ui-fixture.result }}
+            ui-story=${{ needs.ui-story.result }}
+            keyless-harness=${{ needs.keyless-harness.result }}
+            docker=${{ needs.docker.result }}
+            dev-onboarding=${{ needs.dev-onboarding.result }}
+            electrobun=${{ needs.electrobun.result }}
+        run: |
+          fail=0
+          for pair in $RESULTS; do
+            lane="${pair%%=*}"
+            result="${pair##*=}"
+            if [ "$result" = "success" ]; then
+              echo "lane $lane: success"
+            else
+              echo "::error::exhaustive lane $lane did not succeed (result=$result) — a skipped or failed platform lane is a coverage gap, not a pass"
+              fail=1
+            fi
+          done
+          exit "$fail"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --frozen-lockfile --ignore-scripts
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Validate GitHub-native turbo cache contract
+        run: node packages/scripts/ci-turbo-cache-contract.mjs
+
+      - name: Validate workflow dedup contract
+        run: node packages/scripts/ci-workflow-dedup-contract.mjs
+
+      - name: Capture exhaustive test plan
+        run: node packages/scripts/run-all-tests.mjs --plan=json > /tmp/full-matrix-plan.json
+
+      - name: Prove exhaustive lane coverage (manifest + reusable wiring)
+        run: node packages/scripts/ci-full-matrix-proof.mjs --plan-file /tmp/full-matrix-plan.json

--- a/.github/workflows/docker-ci-smoke.yml
+++ b/.github/workflows/docker-ci-smoke.yml
@@ -1,6 +1,8 @@
 name: Docker CI Smoke
 
 on:
+  # Reusable entry for the scheduled exhaustive develop lane (#12342).
+  workflow_call:
   pull_request:
     branches: [develop]
     types: [opened, synchronize, reopened, ready_for_review, labeled]

--- a/.github/workflows/keyless-harness-e2e.yml
+++ b/.github/workflows/keyless-harness-e2e.yml
@@ -26,7 +26,7 @@ on:
 
 concurrency:
   group: keyless-harness-e2e-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/keyless-harness-e2e.yml
+++ b/.github/workflows/keyless-harness-e2e.yml
@@ -17,6 +17,8 @@ name: Keyless Harness E2E
 # least one per-plugin proof participates in the required `test-status` gate.
 
 on:
+  # Reusable entry for the scheduled exhaustive develop lane (#12342).
+  workflow_call:
   pull_request:
     branches: [main, develop]
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/lifeops-quality-bench.yml
+++ b/.github/workflows/lifeops-quality-bench.yml
@@ -50,9 +50,6 @@ jobs:
     timeout-minutes: 45
     env:
       PGLITE_WASM_MODE: node
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:

--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -1,6 +1,8 @@
 name: Mobile Build Smoke Test
 
 on:
+  # Reusable entry for the scheduled exhaustive develop lane (#12342).
+  workflow_call:
   pull_request:
     branches: [main, develop]
     types: [opened, synchronize, reopened, ready_for_review, labeled]

--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: mobile-smoke-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   BUN_VERSION: "canary"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,14 +26,6 @@ env:
   NODE_OPTIONS: "--max-old-space-size=4096"
   BUN_VERSION: "canary"
   NODE_VERSION: "24.15.0"
-  # Share Turbo's remote cache across the nightly build invocations
-  # (build-and-test, the desktop matrix, publish-npm) so unchanged packages
-  # replay from the same cache ci.yaml/test.yml populate. No-op on forks and
-  # when the secret is absent (Turbo falls back to the local .turbo cache that
-  # setup-bun-workspace already restores).
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-  TURBO_CACHE: remote:rw
 
 permissions:
   contents: write

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -253,14 +253,14 @@ jobs:
     name: Develop Gate (lint)
     runs-on: ubuntu-24.04
     timeout-minutes: 25
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: false
+          # Full history so `turbo run lint --affected` can resolve the PR's
+          # merge base (#12341); on a shallow clone turbo safely degrades to
+          # linting the whole graph.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -278,5 +278,16 @@ jobs:
           skip-avatar-clone: "true"
           no-vision-deps: "true"
 
-      - name: Run lint
+      # PR lane: lint only the packages in the merge base's dependency cone; on
+      # push/merge_group lint the whole graph (exhaustive + turbo cache seeding).
+      # Turbo re-derives per-task hashes, so affected scoping never under-lints a
+      # genuinely changed package (#12341).
+      - name: Run lint (affected — PR)
+        if: github.event_name == 'pull_request'
+        run: node packages/scripts/run-turbo.mjs run lint --affected
+        env:
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+
+      - name: Run lint (full — push/merge_group)
+        if: github.event_name != 'pull_request'
         run: bun run lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,13 +71,6 @@ jobs:
         !(github.ref_type == 'tag' && contains(github.ref_name || '', '-alpha'))
       }}
 
-    env:
-      # Replay the publish-critical build graph from Turbo's remote cache
-      # instead of rebuilding it cold on every release. No-op when the secret
-      # is absent (Turbo falls back to the local .turbo cache restored below).
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
 
     steps:
       - name: Checkout code

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -6,6 +6,8 @@ name: Scenario PR E2E
 # coverage, and a real scenario turn work without paid model credentials.
 
 on:
+  # Reusable entry for the scheduled exhaustive develop lane (#12342).
+  workflow_call:
   pull_request:
     branches: [main, develop]
     types: [opened, synchronize, reopened, ready_for_review, labeled]

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   group: scenario-pr-e2e-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CI: "true"

--- a/.github/workflows/test-electrobun-release.yml
+++ b/.github/workflows/test-electrobun-release.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: test-electrobun-release-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/test-electrobun-release.yml
+++ b/.github/workflows/test-electrobun-release.yml
@@ -1,6 +1,8 @@
 name: Validate Electrobun Release Workflow
 
 on:
+  # Reusable entry for the scheduled exhaustive develop lane (#12342).
+  workflow_call:
   pull_request:
     branches: [main, develop]
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,9 +108,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
       PGLITE_WASM_MODE: node
       # The TUI e2e capture test writes its .cast / viewport / scrollback
       # artifacts here during `test:server`; the upload step below attaches them.
@@ -240,10 +237,6 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.client == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -410,9 +403,6 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
       TEST_SHARD: ${{ matrix.shard }}/4
       # Share compiled rust artifacts across all plugin crates so the
       # `elizaos = "2.0.0"` crate (and its sqlx/hyper/etc transitive deps)
@@ -523,9 +513,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
       PGLITE_WASM_MODE: node
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -606,9 +593,6 @@ jobs:
       XAI_API_KEY: ""
       NVIDIA_API_KEY: ""
       ELIZAOS_CLOUD_API_KEY: ""
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -669,9 +653,6 @@ jobs:
       XAI_API_KEY: ""
       NVIDIA_API_KEY: ""
       ELIZAOS_CLOUD_API_KEY: ""
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -747,9 +728,6 @@ jobs:
       XAI_API_KEY: ""
       NVIDIA_API_KEY: ""
       ELIZAOS_CLOUD_API_KEY: ""
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -809,9 +787,6 @@ jobs:
       XAI_API_KEY: ""
       NVIDIA_API_KEY: ""
       ELIZAOS_CLOUD_API_KEY: ""
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -957,10 +932,6 @@ jobs:
     outputs:
       skip: ${{ steps.cloud.outputs.skip }}
       capability_skip: ${{ steps.cloud.outputs.capability_skip }}
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
     steps:
       - name: Check cloud secrets
         id: cloud
@@ -1089,10 +1060,6 @@ jobs:
     timeout-minutes: 45
     outputs:
       skip: ${{ steps.providers.outputs.skip }}
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
     steps:
       - name: Check provider endpoint secrets
         id: providers
@@ -1216,9 +1183,6 @@ jobs:
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/ui-e2e-gate.yml
+++ b/.github/workflows/ui-e2e-gate.yml
@@ -13,6 +13,8 @@ name: UI Fixture E2E
 # chat-ambient/onboarding have their own follow-ups.
 
 on:
+  # Reusable entry for the scheduled exhaustive develop lane (#12342).
+  workflow_call:
   pull_request:
     branches: [main, develop]
     paths:

--- a/.github/workflows/ui-fixture-e2e.yml
+++ b/.github/workflows/ui-fixture-e2e.yml
@@ -17,6 +17,8 @@ name: UI Fixture E2E
 # documents the skip instead of silently not existing.
 
 on:
+  # Reusable entry for the scheduled exhaustive develop lane (#12342).
+  workflow_call:
   pull_request:
     branches: [main, develop]
     paths:

--- a/.github/workflows/ui-story-gate.yml
+++ b/.github/workflows/ui-story-gate.yml
@@ -8,6 +8,8 @@ name: UI Story Gate
 # packages/ui/test/story-gate/README.md.
 
 on:
+  # Reusable entry for the scheduled exhaustive develop lane (#12342).
+  workflow_call:
   pull_request:
     branches: [main, develop]
     paths:

--- a/.github/workflows/ui-story-gate.yml
+++ b/.github/workflows/ui-story-gate.yml
@@ -35,10 +35,6 @@ jobs:
   story-gate:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -14,6 +14,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
+  # Reusable entry for the scheduled exhaustive develop lane (#12342).
+  workflow_call:
   push:
     branches: [main, develop]
     paths:

--- a/packages/scripts/__tests__/ci-full-matrix-proof.test.ts
+++ b/packages/scripts/__tests__/ci-full-matrix-proof.test.ts
@@ -86,19 +86,31 @@ const HEALTHY_PLAN = {
   ],
 };
 
-function runProof({ workflow, manifest, plan }) {
+function runProof({ workflow, manifest, plan, orchestrator, reusables }) {
   const dir = mkdtempSync(join(tmpdir(), "ci-matrix-proof-"));
   try {
     const workflowPath = join(dir, "test.yml");
     const manifestPath = join(dir, "manifest.json");
     const planPath = join(dir, "plan.json");
     writeFileSync(workflowPath, workflow);
-    // The manifest's `workflow` field is resolved relative to the repo root, so
-    // point it at the fixture via an absolute path for the test.
-    writeFileSync(
-      manifestPath,
-      JSON.stringify({ ...manifest, workflow: workflowPath }),
-    );
+    // The manifest's path fields are resolved relative to the repo root, so
+    // point them at the fixtures via absolute paths for the test.
+    const resolved = { ...manifest, workflow: workflowPath };
+    if (orchestrator) {
+      const orchestratorPath = join(dir, "develop-exhaustive.yml");
+      writeFileSync(orchestratorPath, orchestrator);
+      resolved.exhaustiveOrchestrator = orchestratorPath;
+    }
+    if (reusables) {
+      resolved.reusableWorkflows = Object.entries(reusables).map(
+        ([basename, content]) => {
+          const p = join(dir, basename);
+          writeFileSync(p, content);
+          return { workflow: p, name: basename };
+        },
+      );
+    }
+    writeFileSync(manifestPath, JSON.stringify(resolved));
     writeFileSync(planPath, JSON.stringify(plan));
 
     const result = spawnSync(
@@ -208,6 +220,85 @@ describe("ci-full-matrix-proof", () => {
     expect(result.stderr).toContain(
       'script lane "test:e2e" collected zero tasks',
     );
+  });
+
+  const CALLABLE_WORKFLOW = `name: Reusable
+on:
+  workflow_call:
+  pull_request:
+jobs:
+  x:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo ok
+`;
+
+  const NON_CALLABLE_WORKFLOW = `name: Reusable
+on:
+  pull_request:
+jobs:
+  x:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo ok
+`;
+
+  function orchestrator(basenames) {
+    const lanes = basenames
+      .map(
+        (b, i) =>
+          `  lane${i}:\n    uses: ./.github/workflows/${b}\n    secrets: inherit`,
+      )
+      .join("\n");
+    return `name: Develop Exhaustive\non:\n  schedule:\n    - cron: "0 6 * * *"\njobs:\n${lanes}\n`;
+  }
+
+  test("passes when the orchestrator wires every reusable lane and each is callable", () => {
+    const result = runProof({
+      workflow: HEALTHY_WORKFLOW,
+      manifest: HEALTHY_MANIFEST,
+      plan: HEALTHY_PLAN,
+      orchestrator: orchestrator(["windows-ci.yml", "scenario-pr.yml"]),
+      reusables: {
+        "windows-ci.yml": CALLABLE_WORKFLOW,
+        "scenario-pr.yml": CALLABLE_WORKFLOW,
+      },
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("PASS every expected lane accounted for");
+  });
+
+  test("fails when the orchestrator drops a reusable lane's uses:", () => {
+    const result = runProof({
+      workflow: HEALTHY_WORKFLOW,
+      manifest: HEALTHY_MANIFEST,
+      plan: HEALTHY_PLAN,
+      // Only wires windows-ci; scenario-pr is listed but not invoked.
+      orchestrator: orchestrator(["windows-ci.yml"]),
+      reusables: {
+        "windows-ci.yml": CALLABLE_WORKFLOW,
+        "scenario-pr.yml": CALLABLE_WORKFLOW,
+      },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("missing reusable lane");
+    expect(result.stderr).toContain("scenario-pr.yml");
+  });
+
+  test("fails when a listed reusable workflow no longer declares workflow_call", () => {
+    const result = runProof({
+      workflow: HEALTHY_WORKFLOW,
+      manifest: HEALTHY_MANIFEST,
+      plan: HEALTHY_PLAN,
+      orchestrator: orchestrator(["windows-ci.yml", "scenario-pr.yml"]),
+      reusables: {
+        "windows-ci.yml": CALLABLE_WORKFLOW,
+        "scenario-pr.yml": NON_CALLABLE_WORKFLOW,
+      },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("reusable workflow not callable");
+    expect(result.stderr).toContain("scenario-pr.yml");
   });
 
   test("proves the real committed manifest against the real workflow + plan", () => {

--- a/packages/scripts/__tests__/ci-full-matrix-proof.test.ts
+++ b/packages/scripts/__tests__/ci-full-matrix-proof.test.ts
@@ -226,6 +226,9 @@ describe("ci-full-matrix-proof", () => {
 on:
   workflow_call:
   pull_request:
+concurrency:
+  group: reusable-\${{ github.ref }}
+  cancel-in-progress: \${{ github.event_name == 'pull_request' }}
 jobs:
   x:
     runs-on: ubuntu-24.04
@@ -236,6 +239,20 @@ jobs:
   const NON_CALLABLE_WORKFLOW = `name: Reusable
 on:
   pull_request:
+jobs:
+  x:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo ok
+`;
+
+  const CANCELLING_CALLABLE_WORKFLOW = `name: Reusable
+on:
+  workflow_call:
+  pull_request:
+concurrency:
+  group: reusable-\${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   x:
     runs-on: ubuntu-24.04
@@ -298,6 +315,24 @@ jobs:
     });
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("reusable workflow not callable");
+    expect(result.stderr).toContain("scenario-pr.yml");
+  });
+
+  test("fails when a reusable workflow can cancel scheduled exhaustive coverage", () => {
+    const result = runProof({
+      workflow: HEALTHY_WORKFLOW,
+      manifest: HEALTHY_MANIFEST,
+      plan: HEALTHY_PLAN,
+      orchestrator: orchestrator(["windows-ci.yml", "scenario-pr.yml"]),
+      reusables: {
+        "windows-ci.yml": CALLABLE_WORKFLOW,
+        "scenario-pr.yml": CANCELLING_CALLABLE_WORKFLOW,
+      },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "reusable workflow can cancel scheduled coverage",
+    );
     expect(result.stderr).toContain("scenario-pr.yml");
   });
 

--- a/packages/scripts/__tests__/ci-full-matrix-proof.test.ts
+++ b/packages/scripts/__tests__/ci-full-matrix-proof.test.ts
@@ -172,6 +172,18 @@ describe("ci-full-matrix-proof", () => {
     expect(result.stderr).toContain("client-tests");
   });
 
+  test("fails when the aggregate status job drops a lane dependency", () => {
+    const workflow = HEALTHY_WORKFLOW.replace("      - client-tests\n", "");
+    const result = runProof({
+      workflow,
+      manifest: HEALTHY_MANIFEST,
+      plan: HEALTHY_PLAN,
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("aggregate drift");
+    expect(result.stderr).toContain("client-tests");
+  });
+
   test("fails when the plan collected fewer tasks than the floor", () => {
     const plan = {
       ...HEALTHY_PLAN,

--- a/packages/scripts/__tests__/ci-workflow-dedup-contract.test.ts
+++ b/packages/scripts/__tests__/ci-workflow-dedup-contract.test.ts
@@ -1,0 +1,161 @@
+// Pins the workflow-dedup + GitHub-native cache contract (#10096/#12341)
+// against synthetic repo trees: the branch-split fixtures pass, re-adding the
+// Vercel SaaS remote-cache env fails, and a publish path that drops the
+// GitHub-native cache fails. Also runs the shipped contract against the real
+// repo so the guard stays true as the migration proceeds. Deterministic — no
+// workflow is executed.
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const { runContract, findSaasRemoteCache } = await import(
+  new URL("../ci-workflow-dedup-contract.mjs", import.meta.url).href
+);
+
+const REAL_REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+// Minimal but valid branch-split fixtures. Formatting matches what the
+// contract's inline-branches parser expects (`  <event>:` then
+// `    branches: [...]`).
+const CI_YAML = `name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: ./.github/actions/setup-bun-workspace
+`;
+
+const TEST_YML = `name: Tests
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+  merge_group:
+    branches: [develop]
+jobs:
+  ci-ok:
+    name: ci-ok
+    runs-on: ubuntu-24.04
+    steps:
+      - run: |
+          if [ "\${GITHUB_EVENT_NAME}" = "merge_group" ]; then
+            echo bypass
+          fi
+`;
+
+const SCENARIO_PR_YML = `name: Scenario PR
+on:
+  pull_request:
+    branches: [main, develop]
+jobs:
+  x:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo ok
+`;
+
+const NIGHTLY_YML = `name: Nightly
+on:
+  schedule:
+    - cron: "0 4 * * *"
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: ./.github/actions/setup-bun-workspace
+`;
+
+const RELEASE_YAML = `name: Release
+on:
+  workflow_dispatch:
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: ./.github/actions/setup-bun-workspace
+`;
+
+function baseWorkflows() {
+  return {
+    "ci.yaml": CI_YAML,
+    "test.yml": TEST_YML,
+    "scenario-pr.yml": SCENARIO_PR_YML,
+    "nightly.yml": NIGHTLY_YML,
+    "release.yaml": RELEASE_YAML,
+  };
+}
+
+function buildRepo(workflows) {
+  const root = mkdtempSync(join(tmpdir(), "dedup-contract-"));
+  mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+  for (const [name, content] of Object.entries(workflows)) {
+    writeFileSync(join(root, ".github", "workflows", name), content);
+  }
+  return root;
+}
+
+function withRepo(workflows, fn) {
+  const root = buildRepo(workflows);
+  try {
+    return fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("ci-workflow-dedup-contract", () => {
+  test("a clean branch-split repo with no SaaS env passes", () => {
+    withRepo(baseWorkflows(), (root) => {
+      expect(runContract(root)).toEqual({ ok: true });
+    });
+  });
+
+  test("re-adding the SaaS remote cache to any workflow fails the contract", () => {
+    const workflows = baseWorkflows();
+    workflows["scenario-pr.yml"] = SCENARIO_PR_YML.replace(
+      "  x:",
+      "  x:\n    env:\n      TURBO_TOKEN: \${{ secrets.TURBO_TOKEN }}",
+    );
+    withRepo(workflows, (root) => {
+      expect(() => runContract(root)).toThrow(/SaaS Turbo remote cache is banned/);
+    });
+  });
+
+  test("a publish path that drops the GitHub-native cache fails the contract", () => {
+    const workflows = baseWorkflows();
+    workflows["nightly.yml"] = NIGHTLY_YML.replace(
+      "      - uses: ./.github/actions/setup-bun-workspace",
+      "      - run: echo no-cache",
+    );
+    withRepo(workflows, (root) => {
+      expect(() => runContract(root)).toThrow(/GitHub-native turbo cache/);
+    });
+  });
+
+  test("findSaasRemoteCache reports the offending file + marker", () => {
+    const workflows = baseWorkflows();
+    workflows["release.yaml"] = RELEASE_YAML.replace(
+      "  publish:",
+      "  publish:\n    env:\n      TURBO_CACHE: remote:rw",
+    );
+    withRepo(workflows, (root) => {
+      const hits = findSaasRemoteCache(root);
+      expect(hits).toEqual([
+        { file: ".github/workflows/release.yaml", label: "TURBO_CACHE: remote" },
+      ]);
+    });
+  });
+
+  test("the real repo satisfies the contract (branch split + no SaaS)", () => {
+    expect(runContract(REAL_REPO_ROOT)).toEqual({ ok: true });
+    expect(findSaasRemoteCache(REAL_REPO_ROOT)).toEqual([]);
+  });
+});

--- a/packages/scripts/ci-full-matrix-proof.mjs
+++ b/packages/scripts/ci-full-matrix-proof.mjs
@@ -5,12 +5,18 @@
  * scheduled full-matrix run cannot silently drop coverage or report vacuous
  * green.
  *
- * It cross-checks three independent sources of truth:
+ * It cross-checks four independent sources of truth:
  *   1. `packages/scripts/ci-lane-manifest.json` — the committed expectation.
  *   2. `.github/workflows/test.yml` — every manifest lane must exist as a job
  *      and must not be gated so it can never run on the exhaustive (non-PR)
  *      event, which would turn a "required" lane into a permanent skip.
- *   3. `run-all-tests.mjs --plan=json` — the discovered task plan must clear the
+ *   3. `.github/workflows/develop-exhaustive.yml` — the scheduled orchestrator
+ *      must still invoke every manifest `reusableWorkflows` lane via
+ *      `workflow_call`, and each of those workflows must still declare a
+ *      `workflow_call` trigger. A dropped `uses:` or a removed trigger silently
+ *      strips a platform lane (Windows/mobile/scenario/UI/desktop) from the
+ *      exhaustive matrix and fails the job.
+ *   4. `run-all-tests.mjs --plan=json` — the discovered task plan must clear the
  *      manifest floors (total tasks/packages, per-script-lane presence, and the
  *      set of required core packages). A pointed-at-a-nonexistent-glob lane or a
  *      deleted core package collapses one of these and fails the job.
@@ -192,6 +198,62 @@ function checkWorkflowLanes(manifest, violations, laneReport) {
   }
 }
 
+// The scheduled exhaustive orchestrator (develop-exhaustive.yml) must keep
+// invoking every platform lane the manifest lists, and each of those workflows
+// must still declare a `workflow_call` trigger — otherwise the orchestrator
+// silently drops that lane's coverage. Both halves are checked statically so a
+// dropped `uses:` or a removed trigger fails without waiting for the run.
+function checkReusableWorkflows(manifest, violations, laneReport) {
+  if (
+    !manifest.exhaustiveOrchestrator ||
+    !Array.isArray(manifest.reusableWorkflows)
+  ) {
+    return;
+  }
+  const orchestratorPath = resolve(repoRoot, manifest.exhaustiveOrchestrator);
+  let orchestratorText;
+  try {
+    orchestratorText = readFileSync(orchestratorPath, "utf8");
+  } catch {
+    violations.push(
+      `missing exhaustive orchestrator: ${manifest.exhaustiveOrchestrator} not found`,
+    );
+    return;
+  }
+
+  for (const reusable of manifest.reusableWorkflows) {
+    const basename = reusable.workflow.split("/").pop();
+    const usesRef = `./.github/workflows/${basename}`;
+    if (!orchestratorText.includes(`uses: ${usesRef}`)) {
+      violations.push(
+        `missing reusable lane: ${manifest.exhaustiveOrchestrator} does not invoke ${usesRef} (${reusable.name})`,
+      );
+      laneReport.push({ lane: basename, name: reusable.name, status: "NOT-WIRED" });
+      continue;
+    }
+    let declaresWorkflowCall = false;
+    try {
+      declaresWorkflowCall = /^\s{2}workflow_call:/m.test(
+        readFileSync(resolve(repoRoot, reusable.workflow), "utf8"),
+      );
+    } catch {
+      violations.push(
+        `missing reusable workflow: ${reusable.workflow} (${reusable.name}) not found`,
+      );
+      laneReport.push({ lane: basename, name: reusable.name, status: "MISSING" });
+      continue;
+    }
+    if (!declaresWorkflowCall) {
+      violations.push(
+        `reusable workflow not callable: ${reusable.workflow} does not declare a workflow_call trigger, so ${manifest.exhaustiveOrchestrator} cannot invoke it`,
+      );
+      laneReport.push({ lane: basename, name: reusable.name, status: "NO-CALL" });
+      continue;
+    }
+    laneReport.push({ lane: basename, name: reusable.name, status: "OK" });
+  }
+}
+
 function checkPlanFloors(manifest, plan, violations, floorReport) {
   const floors = manifest.planFloors;
   const summary = plan.summary || {};
@@ -314,6 +376,7 @@ export function runProof(options) {
   const floorReport = [];
 
   checkWorkflowLanes(manifest, violations, laneReport);
+  checkReusableWorkflows(manifest, violations, laneReport);
   checkPlanFloors(manifest, plan, violations, floorReport);
 
   return { manifest, plan, violations, laneReport, floorReport };

--- a/packages/scripts/ci-full-matrix-proof.mjs
+++ b/packages/scripts/ci-full-matrix-proof.mjs
@@ -141,6 +141,69 @@ function extractJobBlock(workflowText, jobKey) {
   return body.join("\n");
 }
 
+function extractWorkflowJobKeys(workflowText) {
+  const keys = [];
+  for (const line of workflowText.split(/\r?\n/)) {
+    const match = line.match(/^ {2}([A-Za-z0-9_-]+):\s*$/);
+    if (match) keys.push(match[1]);
+  }
+  return keys;
+}
+
+function parseNeeds(jobBlock) {
+  const lines = jobBlock.split(/\r?\n/);
+  const needs = new Set();
+  const needsLineIndex = lines.findIndex((line) => /^ {4}needs:\s*/.test(line));
+  if (needsLineIndex < 0) return needs;
+
+  const inline = lines[needsLineIndex].replace(/^ {4}needs:\s*/, "").trim();
+  if (inline.startsWith("[") && inline.endsWith("]")) {
+    for (const value of inline
+      .slice(1, -1)
+      .split(",")
+      .map((item) => item.trim().replace(/^['"]|['"]$/g, ""))
+      .filter(Boolean)) {
+      needs.add(value);
+    }
+    return needs;
+  }
+  if (inline) {
+    needs.add(inline.replace(/^['"]|['"]$/g, ""));
+    return needs;
+  }
+
+  for (let i = needsLineIndex + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (/^ {4}\S/.test(line)) break;
+    const match = line.match(/^ {6}-\s*([A-Za-z0-9_-]+)\s*$/);
+    if (match) needs.add(match[1]);
+  }
+  return needs;
+}
+
+function buildNeedsGraph(workflowText) {
+  const graph = new Map();
+  for (const jobKey of extractWorkflowJobKeys(workflowText)) {
+    const block = extractJobBlock(workflowText, jobKey);
+    if (block) graph.set(jobKey, parseNeeds(block));
+  }
+  return graph;
+}
+
+function collectTransitiveNeeds(graph, root) {
+  const visited = new Set();
+  const stack = [...(graph.get(root) ?? [])];
+  while (stack.length > 0) {
+    const job = stack.pop();
+    if (!job || visited.has(job)) continue;
+    visited.add(job);
+    for (const next of graph.get(job) ?? []) {
+      if (!visited.has(next)) stack.push(next);
+    }
+  }
+  return visited;
+}
+
 // A lane job is "exhaustively runnable" when its `if:` does not force a skip on
 // non-PR events. The repo convention gates PR runs with
 // `github.event_name != 'pull_request' || needs.changes.outputs.<x> == 'true'`,
@@ -195,6 +258,19 @@ function checkWorkflowLanes(manifest, violations, laneReport) {
       violations.push(
         `missing aggregate: job "${manifest.aggregateStatusJob}" not found in ${manifest.workflow}`,
       );
+    } else {
+      const graph = buildNeedsGraph(workflowText);
+      const reachable = collectTransitiveNeeds(
+        graph,
+        manifest.aggregateStatusJob,
+      );
+      for (const lane of manifest.workflowLanes) {
+        if (!reachable.has(lane.job)) {
+          violations.push(
+            `aggregate drift: job "${manifest.aggregateStatusJob}" does not need lane "${lane.job}" (${lane.name}) directly or through an aggregate dependency`,
+          );
+        }
+      }
     }
   }
 }

--- a/packages/scripts/ci-full-matrix-proof.mjs
+++ b/packages/scripts/ci-full-matrix-proof.mjs
@@ -13,9 +13,10 @@
  *   3. `.github/workflows/develop-exhaustive.yml` — the scheduled orchestrator
  *      must still invoke every manifest `reusableWorkflows` lane via
  *      `workflow_call`, and each of those workflows must still declare a
- *      `workflow_call` trigger. A dropped `uses:` or a removed trigger silently
- *      strips a platform lane (Windows/mobile/scenario/UI/desktop) from the
- *      exhaustive matrix and fails the job.
+ *      `workflow_call` trigger without unconditional concurrency cancellation.
+ *      A dropped `uses:`, removed trigger, or reusable lane that can cancel a
+ *      prior scheduled run silently strips platform coverage (Windows/mobile/
+ *      scenario/UI/desktop) from the exhaustive matrix and fails the job.
  *   4. `run-all-tests.mjs --plan=json` — the discovered task plan must clear the
  *      manifest floors (total tasks/packages, per-script-lane presence, and the
  *      set of required core packages). A pointed-at-a-nonexistent-glob lane or a
@@ -228,26 +229,49 @@ function checkReusableWorkflows(manifest, violations, laneReport) {
       violations.push(
         `missing reusable lane: ${manifest.exhaustiveOrchestrator} does not invoke ${usesRef} (${reusable.name})`,
       );
-      laneReport.push({ lane: basename, name: reusable.name, status: "NOT-WIRED" });
+      laneReport.push({
+        lane: basename,
+        name: reusable.name,
+        status: "NOT-WIRED",
+      });
       continue;
     }
+    let reusableText;
     let declaresWorkflowCall = false;
     try {
-      declaresWorkflowCall = /^\s{2}workflow_call:/m.test(
-        readFileSync(resolve(repoRoot, reusable.workflow), "utf8"),
-      );
+      reusableText = readFileSync(resolve(repoRoot, reusable.workflow), "utf8");
+      declaresWorkflowCall = /^\s{2}workflow_call:/m.test(reusableText);
     } catch {
       violations.push(
         `missing reusable workflow: ${reusable.workflow} (${reusable.name}) not found`,
       );
-      laneReport.push({ lane: basename, name: reusable.name, status: "MISSING" });
+      laneReport.push({
+        lane: basename,
+        name: reusable.name,
+        status: "MISSING",
+      });
       continue;
     }
     if (!declaresWorkflowCall) {
       violations.push(
         `reusable workflow not callable: ${reusable.workflow} does not declare a workflow_call trigger, so ${manifest.exhaustiveOrchestrator} cannot invoke it`,
       );
-      laneReport.push({ lane: basename, name: reusable.name, status: "NO-CALL" });
+      laneReport.push({
+        lane: basename,
+        name: reusable.name,
+        status: "NO-CALL",
+      });
+      continue;
+    }
+    if (/^\s{2}cancel-in-progress:\s*true\s*$/m.test(reusableText)) {
+      violations.push(
+        `reusable workflow can cancel scheduled coverage: ${reusable.workflow} has unconditional cancel-in-progress: true; gate cancellation to pull_request so ${manifest.exhaustiveOrchestrator} remains uncancellable`,
+      );
+      laneReport.push({
+        lane: basename,
+        name: reusable.name,
+        status: "CANCELS",
+      });
       continue;
     }
     laneReport.push({ lane: basename, name: reusable.name, status: "OK" });

--- a/packages/scripts/ci-lane-manifest.json
+++ b/packages/scripts/ci-lane-manifest.json
@@ -68,5 +68,49 @@
       "@elizaos/skills"
     ],
     "nonEmptyScriptLanes": ["test", "test:e2e", "test:integration"]
-  }
+  },
+  "$reusableComment": "The platform lanes the scheduled exhaustive orchestrator (develop-exhaustive.yml) must invoke via workflow_call so the full develop matrix runs unfiltered. ci-full-matrix-proof.mjs fails if the orchestrator drops a lane's `uses:` or a listed workflow stops declaring a workflow_call trigger. These are the lanes test.yml's own schedule does not cover: Windows, mobile, scenario, UI gates, keyless harness, docker, dev, desktop/electrobun.",
+  "exhaustiveOrchestrator": ".github/workflows/develop-exhaustive.yml",
+  "reusableWorkflows": [
+    {
+      "workflow": ".github/workflows/windows-ci.yml",
+      "name": "Windows full matrix"
+    },
+    {
+      "workflow": ".github/workflows/mobile-build-smoke.yml",
+      "name": "Mobile build smoke"
+    },
+    {
+      "workflow": ".github/workflows/scenario-pr.yml",
+      "name": "Scenario deterministic E2E"
+    },
+    {
+      "workflow": ".github/workflows/ui-e2e-gate.yml",
+      "name": "UI e2e gate"
+    },
+    {
+      "workflow": ".github/workflows/ui-fixture-e2e.yml",
+      "name": "UI fixture e2e"
+    },
+    {
+      "workflow": ".github/workflows/ui-story-gate.yml",
+      "name": "UI story gate"
+    },
+    {
+      "workflow": ".github/workflows/keyless-harness-e2e.yml",
+      "name": "Keyless harness E2E"
+    },
+    {
+      "workflow": ".github/workflows/docker-ci-smoke.yml",
+      "name": "Docker image smoke"
+    },
+    {
+      "workflow": ".github/workflows/dev-smoke.yml",
+      "name": "Dev onboarding smoke"
+    },
+    {
+      "workflow": ".github/workflows/test-electrobun-release.yml",
+      "name": "Electrobun desktop release"
+    }
+  ]
 }

--- a/packages/scripts/ci-workflow-dedup-contract.mjs
+++ b/packages/scripts/ci-workflow-dedup-contract.mjs
@@ -1,20 +1,53 @@
 #!/usr/bin/env node
 /**
- * Contract check for #10096's workflow-dedup slice.
+ * Contract for #10096's workflow-dedup split and the #12341 GitHub-native cache
+ * migration — the two invariants that keep CI de-duplicated and on one cache
+ * regime. Run in test.yml's `changes` job; a violation fails the branch's CI.
  *
- * Keep automatic branch coverage split by responsibility:
- * - ci.yaml owns the main branch gate.
- * - test.yml owns the broader develop branch test orchestrator.
- * - scenario-pr.yml keeps zero-key deterministic PR E2E on both main/develop.
- * - nightly/release publish workflows keep Turbo remote-cache env wiring.
+ * Branch coverage stays split by responsibility, so a check never runs twice
+ * across the split:
+ *   - ci.yaml owns the main-branch gate (main only).
+ *   - test.yml owns the develop test orchestrator and the merge-queue `ci-ok`
+ *     aggregate (develop push/PR/merge_group).
+ *   - scenario-pr.yml keeps zero-key deterministic PR E2E on both main+develop.
+ *
+ * Cache regime (#12341): the whole repo is on the GitHub-native Turbo cache
+ * (setup-bun-workspace → the pinned `turbo-cache-github` shim). NO workflow may
+ * wire the Vercel SaaS remote cache (`TURBO_TOKEN`/`TURBO_TEAM`/
+ * `TURBO_CACHE: remote:rw`); nightly.yml and release.yaml — the publish paths
+ * that formerly pinned that env — must instead route through
+ * setup-bun-workspace for the cache. Re-adding the SaaS env to any workflow, or
+ * dropping the GitHub-native cache from a publish path, fails this contract.
+ * This flips the pre-migration assertion, which required the SaaS wiring here.
  */
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const repoRoot = resolve(new URL("../..", import.meta.url).pathname);
+const DEFAULT_REPO_ROOT = resolve(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "..",
+  "..",
+);
 
-function read(rel) {
-  return readFileSync(resolve(repoRoot, rel), "utf8");
+const WORKFLOW_DIR = ".github/workflows";
+
+// SaaS remote-cache wiring as actual YAML (key: value), not prose that merely
+// names the env — a description mentioning TURBO_TOKEN must not trip the guard.
+const SAAS_MARKERS = [
+  { label: "TURBO_TOKEN", pattern: /\bTURBO_TOKEN:\s*\$\{\{/ },
+  { label: "TURBO_TEAM", pattern: /\bTURBO_TEAM:\s*\$\{\{/ },
+  { label: "TURBO_CACHE: remote", pattern: /\bTURBO_CACHE:\s*remote:/ },
+];
+
+function firstSaasMarker(text) {
+  return SAAS_MARKERS.find(({ pattern }) => pattern.test(text))?.label ?? null;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
 }
 
 function parseInlineBranches(text, eventName, workflowRel) {
@@ -55,76 +88,102 @@ function assertIncludes(text, fragment, message) {
   }
 }
 
-const ci = read(".github/workflows/ci.yaml");
-assertDeepEqual(
-  parseInlineBranches(ci, "push", ".github/workflows/ci.yaml"),
-  ["main"],
-  "ci.yaml push branches",
-);
-assertDeepEqual(
-  parseInlineBranches(ci, "pull_request", ".github/workflows/ci.yaml"),
-  ["main"],
-  "ci.yaml PR branches",
-);
-
-const tests = read(".github/workflows/test.yml");
-assertDeepEqual(
-  parseInlineBranches(tests, "push", ".github/workflows/test.yml"),
-  ["develop"],
-  "test.yml push branches",
-);
-assertDeepEqual(
-  parseInlineBranches(tests, "pull_request", ".github/workflows/test.yml"),
-  ["develop"],
-  "test.yml PR branches",
-);
-assertDeepEqual(
-  parseInlineBranches(tests, "merge_group", ".github/workflows/test.yml"),
-  ["develop"],
-  "test.yml merge queue branches",
-);
-assertIncludes(
-  tests,
-  "name: ci-ok",
-  "test.yml required aggregate status",
-);
-assertIncludes(
-  tests,
-  'if [ "${GITHUB_EVENT_NAME}" = "merge_group" ]; then',
-  "test.yml merge queue path-gate bypass",
-);
-
-const scenarioPr = read(".github/workflows/scenario-pr.yml");
-assertDeepEqual(
-  parseInlineBranches(
-    scenarioPr,
-    "pull_request",
-    ".github/workflows/scenario-pr.yml",
-  ),
-  ["main", "develop"],
-  "scenario-pr.yml PR branches",
-);
-
-for (const workflowRel of [
-  ".github/workflows/nightly.yml",
-  ".github/workflows/release.yaml",
-]) {
-  const workflow = read(workflowRel);
-  assertIncludes(
-    workflow,
-    "TURBO_TOKEN: $" + "{{ secrets.TURBO_TOKEN }}",
-    `${workflowRel} remote cache token`,
-  );
-  assertIncludes(
-    workflow,
-    "TURBO_TEAM: $" + "{{ vars.TURBO_TEAM }}",
-    `${workflowRel} remote cache team`,
-  );
-  assertIncludes(
-    workflow,
-    "TURBO_CACHE: remote:rw",
-    `${workflowRel} remote cache mode`,
-  );
+// Every workflow that wires the SaaS remote cache, as { file, label } rows.
+// Exported so the test can prove the guard fires on a re-added env without
+// standing up the full branch-split fixture tree.
+export function findSaasRemoteCache(repoRoot = DEFAULT_REPO_ROOT) {
+  const dir = resolve(repoRoot, WORKFLOW_DIR);
+  const violations = [];
+  for (const name of readdirSync(dir)) {
+    if (!name.endsWith(".yml") && !name.endsWith(".yaml")) continue;
+    const label = firstSaasMarker(readFileSync(resolve(dir, name), "utf8"));
+    if (label !== null) {
+      violations.push({ file: `${WORKFLOW_DIR}/${name}`, label });
+    }
+  }
+  return violations;
 }
 
-console.log("ci workflow dedup contract passed");
+export function runContract(repoRoot = DEFAULT_REPO_ROOT) {
+  const read = (rel) => readFileSync(resolve(repoRoot, rel), "utf8");
+
+  // --- Branch-split invariant (#10096). ---
+  const ci = read(".github/workflows/ci.yaml");
+  assertDeepEqual(
+    parseInlineBranches(ci, "push", ".github/workflows/ci.yaml"),
+    ["main"],
+    "ci.yaml push branches",
+  );
+  assertDeepEqual(
+    parseInlineBranches(ci, "pull_request", ".github/workflows/ci.yaml"),
+    ["main"],
+    "ci.yaml PR branches",
+  );
+
+  const tests = read(".github/workflows/test.yml");
+  assertDeepEqual(
+    parseInlineBranches(tests, "push", ".github/workflows/test.yml"),
+    ["develop"],
+    "test.yml push branches",
+  );
+  assertDeepEqual(
+    parseInlineBranches(tests, "pull_request", ".github/workflows/test.yml"),
+    ["develop"],
+    "test.yml PR branches",
+  );
+  assertDeepEqual(
+    parseInlineBranches(tests, "merge_group", ".github/workflows/test.yml"),
+    ["develop"],
+    "test.yml merge queue branches",
+  );
+  assertIncludes(tests, "name: ci-ok", "test.yml required aggregate status");
+  assertIncludes(
+    tests,
+    'if [ "${GITHUB_EVENT_NAME}" = "merge_group" ]; then',
+    "test.yml merge queue path-gate bypass",
+  );
+
+  const scenarioPr = read(".github/workflows/scenario-pr.yml");
+  assertDeepEqual(
+    parseInlineBranches(
+      scenarioPr,
+      "pull_request",
+      ".github/workflows/scenario-pr.yml",
+    ),
+    ["main", "develop"],
+    "scenario-pr.yml PR branches",
+  );
+
+  // --- Cache-regime invariant (#12341): one GitHub-native cache, no SaaS. ---
+  const saas = findSaasRemoteCache(repoRoot);
+  assert(
+    saas.length === 0,
+    `SaaS Turbo remote cache is banned (#12341); found ${saas
+      .map(({ file, label }) => `${file} (${label})`)
+      .join(", ")}. Use the GitHub-native cache via setup-bun-workspace.`,
+  );
+
+  // The publish paths must still get a Turbo cache — the GitHub-native one.
+  for (const workflowRel of [
+    ".github/workflows/nightly.yml",
+    ".github/workflows/release.yaml",
+  ]) {
+    assertIncludes(
+      read(workflowRel),
+      "setup-bun-workspace",
+      `${workflowRel} GitHub-native turbo cache (setup-bun-workspace)`,
+    );
+  }
+
+  return { ok: true };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    runContract();
+    console.log("ci workflow dedup contract passed");
+  } catch (error) {
+    console.error(`[ci-workflow-dedup-contract] FAIL ${error.message}`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
Completes the three uncontested sub-issues of the #12191 CI redesign in dependency order, **building on the foundations concurrent sessions already merged** (#13263 phase-1, #13332 proof/shim/guard, #12725 merge-queue) rather than redoing them. Every mechanism here is verified locally; the purely runtime metrics are called out as observation-gated.

## Phase 1 — develop coverage restore (#12337) — already landed, verified not redone

Landed on `develop` via **#13263** before this branch was cut. Verified on the merge base:
- `test.yml` concurrency is re-keyed `group: test-${{ github.event.pull_request.number || github.run_id }}` + `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` — develop pushes and the scheduled run each get their own group and complete; only PRs cancel superseded runs.
- The `ci-ok` aggregate's `strict_results` now includes `push` (plus `merge_group`/`schedule`/`workflow_dispatch`), so a real lane returning `skipped` on a strict event fails the aggregate instead of passing vacuously.
- Baseline committed at `.github/issue-evidence/12191-ci-baseline.md` (last 200 develop-push `test.yml` runs: 199 cancelled / **0 completed** — the coverage gap phase 1 closes).

This PR builds on that; it does not touch the phase-1 concurrency wiring.

## Phase 4 — affected PR lane + one GitHub-native cache (#12341)

The #13332 foundation added the pinned `turbo-cache-github` shim + `ci-turbo-cache-contract.mjs` but **deferred the risky migration**. This PR does it:

- **Removed every Vercel SaaS remote-cache env** (`TURBO_TOKEN` / `TURBO_TEAM` / `TURBO_CACHE: remote:rw`) from all workflows — 108 lines across 11 files (app-aesthetic-audit, app-live-e2e, ci, cloud-cf-deploy, dev-smoke, lifeops-quality-bench, nightly, quality, release, test, ui-story-gate). Empty `env:` blocks and stale turbo-remote comments removed with them. **Census: 0 SaaS refs in `.github/workflows`.**
- **Routed `setup-bun-workspace`'s Turbo cache through the pinned shim** — one deterministic per-hash key shared across jobs replaces the per-job-name key that fragmented the cache ~30 ways.
- **Flipped `ci-workflow-dedup-contract.mjs`**: it now **forbids** the SaaS env in every workflow and **requires** the GitHub-native cache on the publish paths (nightly/release) — the inverse of its old "pin the SaaS wiring" assertion. Made importable; added `ci-workflow-dedup-contract.test.ts` proving a re-added SaaS env and a dropped publish-path cache both fail.
- **PR-lane `typecheck` (ci.yaml) + `lint` (quality.yml)** now run `turbo --affected` scoped to the PR merge base (`TURBO_SCM_BASE` + `fetch-depth: 0`); `push`/`merge_group` run the full graph. A shallow clone degrades to running everything, so scoping never under-checks.

## Phase 5 — exhaustive scheduled develop lane + proof (#12342)

The #13332 foundation added `ci-full-matrix-proof.mjs` + `ci-lane-manifest.json` + the `--min-tasks` vacuous-green guard but the lane itself only covered `test.yml`. This PR adds the real platform matrix:

- **`develop-exhaustive.yml`** — un-cancellable scheduled orchestrator (06:00/18:00 UTC, dedicated concurrency group, `cancel-in-progress: false`) that invokes via `workflow_call` the platform lanes `test.yml`'s schedule does not cover: **Windows full matrix, mobile, scenario, the 3 UI gates, keyless harness, docker, dev onboarding, electrobun/desktop**. A schedule-origin event makes each called workflow's non-PR job gate run unfiltered. A results step fails the run if any reusable lane did not succeed (**skipped/failed == coverage gap, not a pass**).
- Added a bare `workflow_call:` trigger to the 10 reused workflows (purely additive).
- **`ci-full-matrix-proof.mjs` + manifest gained a `reusableWorkflows` check**: the proof fails statically if the orchestrator drops a lane's `uses:` or a reused workflow stops declaring `workflow_call`. Positive + two negative fixture tests added.

## Guard fail-loud demos (live, real repo)

| Guard | Trigger | Result |
| --- | --- | --- |
| dedup contract | re-add `TURBO_TOKEN` to any workflow | exit 1 — "SaaS Turbo remote cache is banned" |
| matrix proof | drop a reusable `uses:` from the orchestrator | exit 1 — "missing reusable lane: ... windows-ci.yml (NOT-WIRED)" |
| matrix proof | remove `workflow_call:` from a reused workflow | exit 1 — "reusable workflow not callable: ... keyless-harness-e2e.yml" |
| vacuous-green | `run-all-tests.mjs --filter=__no_such__ --min-tasks=1` | exit 3 — "VACUOUS-GREEN GUARD collected 0 task(s)" |
| all restored | — | contracts + proof exit 0 |

## Verification (now)

- `ci-workflow-dedup-contract.mjs`, `ci-turbo-cache-contract.mjs`, `ci-full-matrix-proof.mjs` all pass on the real repo (proof validates 10 test.yml lanes + 10 reusable lanes + plan floors).
- 25 script tests green (`ci-full-matrix-proof` 10, `ci-turbo-cache-contract` 5, `ci-workflow-dedup-contract` 5, vacuous-green guard 5).
- `turbo --affected` verified: scopes to 1 package vs the full ~220 against `origin/develop`.
- All 151 workflows parse; `actionlint` clean on every touched workflow (only pre-existing self-hosted-label + SC2034 warnings unrelated to these edits).
- `biome lint` exit 0 on all touched scripts (only pre-existing warnings).

## Observable only post-merge on develop (exact census a reviewer runs)

These need live develop CI data and are documented in `12191-ci-baseline.md`:
- **Uncancelled coverage** — `gh run list --workflow test.yml --branch develop --event push --json conclusion` shows completed runs.
- **Exhaustive lane** — `gh run list --workflow develop-exhaustive.yml --event schedule` completes ≥2×/day for 7 days, never cancelled.
- **Affected cache hits** — the affected typecheck/lint step logs show cache hits on a representative develop PR.

## Known gotchas designed around

- **Concurrency-cancel churn** — scheduled/exhaustive runs use dedicated groups with `cancel-in-progress: false`; use check-runs API conclusion, not `gh pr checks`, to read them.
- **Skipped==pass** — the exhaustive orchestrator's result step and the proof both red on a skipped real lane.
- **Vacuous-green** — the `--min-tasks` guard reds a zero-collected lane; the proof floors guard whole-plan collapse.
- **GitHub-native cache only** — no SaaS; the dedup contract enforces it repo-wide.
- **Zombie self-hosted runner** (eliza-robot-11) is infra, not addressed here.

Closes #12337 #12341 #12342. Part of #12191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)