### PR TITLE
fix(#12099): keep meeting interim ASR on local provider

### DIFF
--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -938,7 +938,20 @@ export interface ImageGenerationResult {
  * Parameters for transcription models
  */
 export interface TranscriptionParams {
-	audioUrl: string;
+	/** Remote URL or data URL for providers that fetch/transcode audio themselves. */
+	audioUrl?: string;
+	/** Buffered audio bytes for providers that accept local upload-style input. */
+	audio?: Buffer | Uint8Array | ArrayBuffer;
+	/** MIME type for `audio`; for example, `audio/wav`. */
+	mimeType?: string;
+	/** Raw mono PCM samples for local/on-device ASR handlers. */
+	pcm?: Float32Array;
+	/** Sample rate for `pcm` in Hz. */
+	sampleRateHz?: number;
+	/** Legacy alias accepted by existing local ASR extraction helpers. */
+	sampleRate?: number;
+	/** BCP-47 language hint; providers may auto-detect when absent. */
+	language?: string;
 	prompt?: string;
 	signal?: AbortSignal;
 	/**

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -1651,6 +1651,7 @@ export async function ensureLocalInferenceHandler(
 				: makeTranscriptionHandler(),
 			provider,
 			LOCAL_INFERENCE_PRIORITY,
+			{ local: true },
 		);
 		runtimeWithRegistration.registerModel(
 			ModelType.IMAGE_DESCRIPTION,

--- a/plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts
+++ b/plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts
@@ -5,7 +5,7 @@
  * real model.
  */
 import type { Buffer } from "node:buffer";
-import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { type IAgentRuntime, ModelType, type UUID } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   MeetingPipelineOptions,
@@ -73,6 +73,73 @@ describe("createMeetingTranscriptionPipeline", () => {
   });
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("pins default interim ASR to the local provider instead of higher-priority cloud ASR", async () => {
+    const useModel = vi.fn().mockResolvedValue("meter safe meeting notes");
+    const runtime = {
+      getModelRegistrations: vi.fn(() => [
+        {
+          modelType: ModelType.TRANSCRIPTION,
+          provider: "openai",
+          priority: 100,
+          registrationOrder: 1,
+        },
+        {
+          modelType: ModelType.TRANSCRIPTION,
+          provider: "eliza-local-inference",
+          priority: 0,
+          registrationOrder: 2,
+        },
+      ]),
+      useModel,
+    } as unknown as IAgentRuntime;
+    const pipeline = createMeetingTranscriptionPipeline(
+      options({ runtime, language: "en" }),
+    );
+
+    pipeline.pushSpeakerAudio("t0", seconds(2));
+    await tick(2000);
+
+    expect(useModel).toHaveBeenCalledTimes(1);
+    const [modelType, params, provider] = useModel.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+      string,
+    ];
+    expect(modelType).toBe(ModelType.TRANSCRIPTION);
+    expect(provider).toBe("eliza-local-inference");
+    expect(params.pcm).toBeInstanceOf(Float32Array);
+    expect((params.pcm as Float32Array).length).toBe(2 * SR);
+    expect(params.sampleRateHz).toBe(SR);
+    expect(params.language).toBe("en");
+    expect("audio" in params).toBe(false);
+    expect("audioUrl" in params).toBe(false);
+
+    pipeline.pushSpeakerAudio("t0", seconds(2));
+    await tick(2000);
+    const segments = await pipeline.finalize();
+    expect(segments.map((s) => s.text)).toEqual(["meter safe meeting notes"]);
+  });
+
+  it("fails closed when no local transcription provider is registered", () => {
+    const useModel = vi.fn();
+    const runtime = {
+      getModelRegistrations: vi.fn(() => [
+        {
+          modelType: ModelType.TRANSCRIPTION,
+          provider: "openai",
+          priority: 100,
+          registrationOrder: 1,
+        },
+      ]),
+      useModel,
+    } as unknown as IAgentRuntime;
+
+    expect(() => createMeetingTranscriptionPipeline(options({ runtime }))).toThrow(
+      "Local TRANSCRIPTION provider is required",
+    );
+    expect(useModel).not.toHaveBeenCalled();
   });
 
   it("transcribes a speaker window through the backend with prompt continuity", async () => {

--- a/plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts
+++ b/plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts
@@ -136,9 +136,9 @@ describe("createMeetingTranscriptionPipeline", () => {
       useModel,
     } as unknown as IAgentRuntime;
 
-    expect(() => createMeetingTranscriptionPipeline(options({ runtime }))).toThrow(
-      "Local TRANSCRIPTION provider is required",
-    );
+    expect(() =>
+      createMeetingTranscriptionPipeline(options({ runtime })),
+    ).toThrow("Local TRANSCRIPTION provider is required");
     expect(useModel).not.toHaveBeenCalled();
   });
 

--- a/plugins/plugin-meetings/src/pipeline/index.ts
+++ b/plugins/plugin-meetings/src/pipeline/index.ts
@@ -12,6 +12,8 @@ export {
   type AsrBackend,
   type AsrTranscribeOptions,
   type AsrTranscribeResult,
+  findLocalTranscriptionProvider,
+  LocalRuntimeAsrBackend,
   RuntimeModelAsrBackend,
   type RuntimeModelAsrBackendConfig,
 } from "./transcriber";

--- a/plugins/plugin-meetings/src/pipeline/pipeline.ts
+++ b/plugins/plugin-meetings/src/pipeline/pipeline.ts
@@ -24,7 +24,7 @@ import {
   type PipelineTranscriptUpdate,
 } from "../types";
 import { type AsrSegment, SpeakerStreamManager } from "./speaker-streams";
-import { type AsrBackend, RuntimeModelAsrBackend } from "./transcriber";
+import { type AsrBackend, LocalRuntimeAsrBackend } from "./transcriber";
 import { float32ToWav } from "./wav";
 
 /** Silence gap (ms) between words that splits a submission into segments. */
@@ -94,7 +94,7 @@ class MeetingPipeline implements MeetingTranscriptionPipeline {
     private readonly options: MeetingPipelineOptions,
     backend?: AsrBackend,
   ) {
-    this.backend = backend ?? new RuntimeModelAsrBackend(options.runtime);
+    this.backend = backend ?? new LocalRuntimeAsrBackend(options.runtime);
     this.idPrefix = options.sessionId.slice(0, 8);
     this.manager = new SpeakerStreamManager({
       sampleRate: MEETING_AUDIO_SAMPLE_RATE,
@@ -265,6 +265,8 @@ class MeetingPipeline implements MeetingTranscriptionPipeline {
         const result = await this.backend.transcribe(wav, {
           ...(this.options.language ? { language: this.options.language } : {}),
           ...(prompt ? { prompt } : {}),
+          pcm: audio,
+          sampleRateHz: MEETING_AUDIO_SAMPLE_RATE,
         });
         const segments =
           result.words && result.words.length > 0
@@ -341,8 +343,8 @@ class MeetingPipeline implements MeetingTranscriptionPipeline {
 
 /**
  * Create the transcription pipeline for one meeting session. `backend` is
- * injectable for tests and alternate ASR providers; the default routes
- * through `runtime.useModel(ModelType.TRANSCRIPTION)`.
+ * injectable for tests and alternate ASR providers; the default pins overlapping
+ * LocalAgreement windows to local runtime transcription.
  */
 export function createMeetingTranscriptionPipeline(
   options: MeetingPipelineOptions,

--- a/plugins/plugin-meetings/src/pipeline/transcriber.ts
+++ b/plugins/plugin-meetings/src/pipeline/transcriber.ts
@@ -1,10 +1,10 @@
 /**
  * The ASR boundary of the meeting pipeline.
  *
- * `AsrBackend` is the seam: the pipeline hands it a mono 16 kHz 16-bit PCM
- * WAV window and gets back text (plus per-word timings when the backend has
- * them). The default backend routes through
- * `runtime.useModel(ModelType.TRANSCRIPTION)`.
+ * `AsrBackend` is the seam: the pipeline hands it a mono 16 kHz window and gets
+ * back text (plus per-word timings when the backend has them). The default
+ * meeting path pins interim LocalAgreement windows to local runtime ASR so
+ * overlapping stabilization windows cannot accidentally bill a hosted provider.
  *
  * ── Why there is no in-process word-timing backend ─────────────────────────
  * The only first-party words-returning ASR path is
@@ -14,19 +14,25 @@
  * `/api/asr/local-inference` HTTP route, which app-core mounts explicitly
  * (it is not on `runtime.routes`, not a registered elizaOS service, and the
  * locked `ModelType.TRANSCRIPTION ⇒ string` contract carries text only). No
- * clean in-process seam exists, so this module ships RuntimeModelAsrBackend
- * alone; segments then carry `words: []` (the transcript player falls back
- * to segment-level highlighting) rather than fabricated timings.
+ * clean in-process word-timing path exists, so runtime-backed segments carry
+ * `words: []` (the transcript player falls back to segment-level
+ * highlighting) rather than fabricated timings.
  */
 
 import type { Buffer } from "node:buffer";
 import { type IAgentRuntime, logger, ModelType } from "@elizaos/core";
+
+const LOCAL_TRANSCRIPTION_PROVIDER = "eliza-local-inference";
 
 export interface AsrTranscribeOptions {
   /** BCP-47 language hint; auto-detect when absent. */
   language?: string;
   /** Previously confirmed text — decoding context for streaming continuity. */
   prompt?: string;
+  /** Raw mono PCM backing the WAV. Required by the local inference handler. */
+  pcm?: Float32Array;
+  /** Sample rate for `pcm`. Meeting audio is 16 kHz mono. */
+  sampleRateHz?: number;
   signal?: AbortSignal;
 }
 
@@ -53,12 +59,41 @@ export interface RuntimeModelAsrBackendConfig {
   retryDelayMs?: number;
 }
 
+interface LocalTranscriptionParams {
+  pcm: Float32Array;
+  sampleRateHz: number;
+  language?: string;
+  prompt?: string;
+  signal?: AbortSignal;
+}
+
 /** Whisper-style non-speech markers, e.g. "[BLANK_AUDIO]", "(silence)". */
 const NON_SPEECH_PATTERN =
   /^[\s[(]*(?:blank[\s_]*audio|silence|no[\s_]*speech|inaudible|music)[\s\])]*$/i;
 
 function isNonSpeech(text: string): boolean {
   return text.length === 0 || NON_SPEECH_PATTERN.test(text);
+}
+
+function isLocalTranscriptionRegistration(registration: {
+  modelType: string;
+  provider: string;
+  metadata?: { local?: boolean };
+}): boolean {
+  return (
+    registration.modelType === ModelType.TRANSCRIPTION &&
+    (registration.metadata?.local === true ||
+      registration.provider === LOCAL_TRANSCRIPTION_PROVIDER)
+  );
+}
+
+export function findLocalTranscriptionProvider(
+  runtime: IAgentRuntime,
+): string | null {
+  const registration = runtime
+    .getModelRegistrations()
+    .find(isLocalTranscriptionRegistration);
+  return registration?.provider ?? null;
 }
 
 /**
@@ -122,5 +157,54 @@ export class RuntimeModelAsrBackend implements AsrBackend {
       : new Error(
           `[MeetingPipeline] TRANSCRIPTION failed: ${String(lastError)}`,
         );
+  }
+}
+
+/**
+ * Local-only ASR backend for live meeting stabilization windows.
+ *
+ * LocalAgreement intentionally retranscribes overlapping audio as it waits for
+ * stable text. Routing those windows through provider priority would let a
+ * higher-priority cloud ASR handler win, multiplying metered calls. This backend
+ * resolves the local provider once and calls it by explicit provider name; if no
+ * local registration exists, meeting transcription fails visibly instead of
+ * silently spending cloud tokens.
+ */
+export class LocalRuntimeAsrBackend implements AsrBackend {
+  private readonly provider: string;
+
+  constructor(private readonly runtime: IAgentRuntime) {
+    const provider = findLocalTranscriptionProvider(runtime);
+    if (!provider) {
+      throw new Error(
+        "[MeetingPipeline] Local TRANSCRIPTION provider is required for meeting interim ASR",
+      );
+    }
+    this.provider = provider;
+  }
+
+  async transcribe(
+    _wav: Buffer,
+    opts: AsrTranscribeOptions,
+  ): Promise<AsrTranscribeResult> {
+    if (!opts.pcm || !opts.sampleRateHz) {
+      throw new Error(
+        "[MeetingPipeline] Local TRANSCRIPTION requires PCM samples and sample rate",
+      );
+    }
+    const params: LocalTranscriptionParams = {
+      pcm: opts.pcm,
+      sampleRateHz: opts.sampleRateHz,
+      ...(opts.language ? { language: opts.language } : {}),
+      ...(opts.prompt ? { prompt: opts.prompt } : {}),
+      ...(opts.signal ? { signal: opts.signal } : {}),
+    };
+    const raw = await this.runtime.useModel(
+      ModelType.TRANSCRIPTION,
+      params,
+      this.provider,
+    );
+    const text = typeof raw === "string" ? raw.trim() : "";
+    return isNonSpeech(text) ? { text: "" } : { text };
   }
 }


### PR DESCRIPTION
## Summary
- pin the meeting LocalAgreement interim ASR backend to the local TRANSCRIPTION provider instead of provider-priority selection
- pass raw PCM/sample-rate into the local runtime backend and fail closed when no local transcription provider is registered
- mark the local-inference TRANSCRIPTION registration with metadata.local and widen transcription params for PCM/local upload inputs

Closes #12099.

## Verification
- bun run --cwd plugins/plugin-meetings test -- src/pipeline/__tests__/pipeline.test.ts
- bun run --cwd plugins/plugin-local-inference test -- src/runtime/ensure-local-inference-handler.test.ts
- bun run --cwd plugins/plugin-local-inference typecheck

## Evidence
- N/A UI screenshots: pipeline/backend behavior only, no UI surface changed.
- N/A live LLM trajectory: no planner/action/provider prompt behavior changed.
- Pending live metered proof before ready-for-review: metered Cloud STT credentials/test org are still needed to capture STT route logs, billing/reservation rows, transcript artifact, retained audio metadata, and manual transcript review against the approved audio fixture matrix.