### PR TITLE
fix(meetings): enforce meeting duration caps

### DIFF
--- a/.github/issue-evidence/12100-meeting-duration-cap.md
+++ b/.github/issue-evidence/12100-meeting-duration-cap.md
@@ -3,9 +3,11 @@
 ## Local proof captured
 
 - `bunx vitest run plugins/plugin-meetings/src/service.test.ts plugins/plugin-meetings/src/routes/meetings-routes.test.ts packages/shared/src/meetings.test.ts`
-  - Result: 3 files passed, 33 tests passed.
+  - Result: 3 files passed, 36 tests passed.
 - `bun run --cwd packages/shared typecheck`
-  - Result: clean.
+  - Result: blocked in this checkout by pre-existing logger declaration
+    resolution for `adze`, `adze/dist/log.js`, and `fast-redact`; no reported
+    error was in `packages/shared/src/meetings.ts`.
 - `bun run --cwd plugins/plugin-meetings typecheck`
   - Result: clean.
 - `bunx @biomejs/biome check packages/shared/src/meetings.ts plugins/plugin-meetings/src/routes/meetings-routes.ts plugins/plugin-meetings/src/service.ts plugins/plugin-meetings/src/service.test.ts plugins/plugin-meetings/src/routes/meetings-routes.test.ts`
@@ -20,6 +22,8 @@
 - Callers may request a lower per-session `maxDurationMs`.
 - Requests above the configured `ELIZA_MEETINGS_MAX_DURATION_MS` fail before a bot launches.
 - When the cap is reached, the service transitions to leaving, aborts the adapter signal, finalizes the pipeline, and records `endReason: "duration_cap_reached"`.
+- The duration-cap reason wins even when the adapter resolves `requested_stop`
+  synchronously from the abort signal.
 
 ## Evidence not captured
 

--- a/.github/issue-evidence/12100-meeting-duration-cap.md
+++ b/.github/issue-evidence/12100-meeting-duration-cap.md
@@ -16,6 +16,7 @@
 ## Contract covered by tests
 
 - Every `MeetingJoinRequest` resolves to a bounded `maxDurationMs`.
+- The production default cap is 60 minutes.
 - Callers may request a lower per-session `maxDurationMs`.
 - Requests above the configured `ELIZA_MEETINGS_MAX_DURATION_MS` fail before a bot launches.
 - When the cap is reached, the service transitions to leaving, aborts the adapter signal, finalizes the pipeline, and records `endReason: "duration_cap_reached"`.

--- a/.github/issue-evidence/12100-meeting-duration-cap.md
+++ b/.github/issue-evidence/12100-meeting-duration-cap.md
@@ -1,0 +1,27 @@
+# Issue 12100 Evidence: Meeting Duration Cap Contract
+
+## Local proof captured
+
+- `bunx vitest run plugins/plugin-meetings/src/service.test.ts plugins/plugin-meetings/src/routes/meetings-routes.test.ts packages/shared/src/meetings.test.ts`
+  - Result: 3 files passed, 33 tests passed.
+- `bun run --cwd packages/shared typecheck`
+  - Result: clean.
+- `bun run --cwd plugins/plugin-meetings typecheck`
+  - Result: clean.
+- `bunx @biomejs/biome check packages/shared/src/meetings.ts plugins/plugin-meetings/src/routes/meetings-routes.ts plugins/plugin-meetings/src/service.ts plugins/plugin-meetings/src/service.test.ts plugins/plugin-meetings/src/routes/meetings-routes.test.ts`
+  - Result: clean.
+- `git diff --check`
+  - Result: clean.
+
+## Contract covered by tests
+
+- Every `MeetingJoinRequest` resolves to a bounded `maxDurationMs`.
+- Callers may request a lower per-session `maxDurationMs`.
+- Requests above the configured `ELIZA_MEETINGS_MAX_DURATION_MS` fail before a bot launches.
+- When the cap is reached, the service transitions to leaving, aborts the adapter signal, finalizes the pipeline, and records `endReason: "duration_cap_reached"`.
+
+## Evidence not captured
+
+- Cloud credit reservation rows and reconciliation: N/A in this environment; the cloud-money reservation contract and test org were not provided.
+- Insufficient-credit and cap-reached billing rows: N/A in this environment; no credit setup or metered Cloud test org was provided.
+- Live meeting route logs/transcript/manual review: N/A in this environment; no approved live fixture/credential set was provided.

--- a/packages/shared/src/meetings.ts
+++ b/packages/shared/src/meetings.ts
@@ -63,8 +63,8 @@ export const DEFAULT_MEETING_AUTO_LEAVE: MeetingAutoLeaveConfig = {
   everyoneLeftTimeoutMs: 2 * 60 * 1000,
 };
 
-/** Default upper bound for a browser-bot meeting session: 2 hours. */
-export const DEFAULT_MEETING_MAX_DURATION_MS = 2 * 60 * 60 * 1000;
+/** Default upper bound for a browser-bot meeting session: 60 minutes. */
+export const DEFAULT_MEETING_MAX_DURATION_MS = 60 * 60 * 1000;
 
 /** Input contract to start a bot (the request side of POST /api/meetings). */
 export interface MeetingJoinRequest {

--- a/packages/shared/src/meetings.ts
+++ b/packages/shared/src/meetings.ts
@@ -38,6 +38,7 @@ export type MeetingSessionStatus =
 export type MeetingEndReason =
   | "normal_completion"
   | "requested_stop"
+  | "duration_cap_reached"
   | "removed_by_admin"
   | "left_alone_timeout"
   | "startup_alone_timeout"
@@ -62,6 +63,9 @@ export const DEFAULT_MEETING_AUTO_LEAVE: MeetingAutoLeaveConfig = {
   everyoneLeftTimeoutMs: 2 * 60 * 1000,
 };
 
+/** Default upper bound for a browser-bot meeting session: 2 hours. */
+export const DEFAULT_MEETING_MAX_DURATION_MS = 2 * 60 * 60 * 1000;
+
 /** Input contract to start a bot (the request side of POST /api/meetings). */
 export interface MeetingJoinRequest {
   platform: MeetingPlatform;
@@ -73,6 +77,11 @@ export interface MeetingJoinRequest {
   autoLeave?: Partial<MeetingAutoLeaveConfig>;
   /** Retain the meeting audio on the transcript record (default true). */
   retainAudio?: boolean;
+  /**
+   * Optional lower per-session cap in milliseconds. The service rejects values
+   * above its configured maximum before launching the bot.
+   */
+  maxDurationMs?: number;
   /** Calendar event that prompted the join, when auto-joined. */
   calendarEventId?: string;
 }
@@ -110,6 +119,8 @@ export interface MeetingSession {
   transcriptId?: string;
   participants: MeetingParticipant[];
   calendarEventId?: string;
+  /** Maximum duration approved for this session, in milliseconds. */
+  maxDurationMs?: number;
   metadata?: Record<string, unknown>;
 }
 

--- a/plugins/plugin-meetings/src/routes/meetings-routes.test.ts
+++ b/plugins/plugin-meetings/src/routes/meetings-routes.test.ts
@@ -85,6 +85,22 @@ describe("/api/meetings routes", () => {
     expect(zoom.status).toBe(422);
   });
 
+  it("POST rejects invalid duration caps before launching", async () => {
+    const { fake, ctx, adapter } = makeHarness();
+    fake.settings.ELIZA_MEETINGS_MAX_DURATION_MS = "1000";
+    const post = route("POST", "/api/meetings");
+
+    const overCap = await post(
+      ctx({ body: { meetingUrl: MEET_URL, maxDurationMs: 1001 } }),
+    );
+
+    expect(overCap.status).toBe(400);
+    expect((overCap.body as { code: string }).code).toBe(
+      "invalid_duration_cap",
+    );
+    expect(adapter.session).toBeNull();
+  });
+
   it("GET lists all and ?active=1 filters; GET/:id and DELETE/:id round-trip", async () => {
     const { ctx, adapter } = makeHarness();
     const post = route("POST", "/api/meetings");

--- a/plugins/plugin-meetings/src/routes/meetings-routes.ts
+++ b/plugins/plugin-meetings/src/routes/meetings-routes.ts
@@ -35,6 +35,7 @@ export interface CreateMeetingRequest {
   botName?: string;
   language?: string;
   retainAudio?: boolean;
+  maxDurationMs?: number;
   calendarEventId?: string;
 }
 
@@ -43,6 +44,7 @@ const joinErrorStatus: Record<MeetingJoinError["code"], number> = {
   unsupported_platform: 422,
   unsupported_host: 422,
   already_joined: 409,
+  invalid_duration_cap: 400,
 };
 
 const createRoute: Route = {
@@ -81,6 +83,7 @@ const createRoute: Route = {
       botName: body.botName,
       language: body.language,
       retainAudio: body.retainAudio,
+      maxDurationMs: body.maxDurationMs,
       calendarEventId: body.calendarEventId,
     };
     try {

--- a/plugins/plugin-meetings/src/service.test.ts
+++ b/plugins/plugin-meetings/src/service.test.ts
@@ -3,6 +3,7 @@
  * single-bot-per-meeting enforcement, roster, transcript persistence, and
  * listing. Deterministic: fake runtime plus scripted adapter/pipeline.
  */
+import { DEFAULT_MEETING_MAX_DURATION_MS } from "@elizaos/shared";
 import { describe, expect, it, vi } from "vitest";
 import { MeetingJoinError, MeetingService } from "./service.js";
 import {
@@ -135,6 +136,24 @@ describe("MeetingService.requestJoin — validation", () => {
     ).rejects.toMatchObject({ code: "invalid_duration_cap" });
     expect(service.listSessions()).toHaveLength(0);
     expect(adapter.session).toBeNull();
+  });
+
+  it("uses the production default 60-minute cap and accepts lower requested caps", async () => {
+    const { service } = makeService();
+
+    const defaulted = await service.requestJoin({
+      platform: "google_meet",
+      meetingUrl: MEET_URL,
+    });
+    expect(defaulted.maxDurationMs).toBe(60 * 60 * 1000);
+    expect(defaulted.maxDurationMs).toBe(DEFAULT_MEETING_MAX_DURATION_MS);
+
+    const lower = await service.requestJoin({
+      platform: "google_meet",
+      meetingUrl: "https://meet.google.com/aaa-bbbb-ccc",
+      maxDurationMs: 15 * 60 * 1000,
+    });
+    expect(lower.maxDurationMs).toBe(15 * 60 * 1000);
   });
 });
 

--- a/plugins/plugin-meetings/src/service.test.ts
+++ b/plugins/plugin-meetings/src/service.test.ts
@@ -3,7 +3,7 @@
  * single-bot-per-meeting enforcement, roster, transcript persistence, and
  * listing. Deterministic: fake runtime plus scripted adapter/pipeline.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { MeetingJoinError, MeetingService } from "./service.js";
 import {
   makeFakeRuntime,
@@ -120,6 +120,22 @@ describe("MeetingService.requestJoin — validation", () => {
     expect(service.listSessions({ active: true })).toHaveLength(1);
     expect(calls).toBe(2);
   });
+
+  it("rejects requested duration caps above the configured maximum before launch", async () => {
+    const adapter = new ScriptedAdapter("google_meet");
+    const { fake, service } = makeService([adapter]);
+    fake.settings.ELIZA_MEETINGS_MAX_DURATION_MS = "1000";
+
+    await expect(
+      service.requestJoin({
+        platform: "google_meet",
+        meetingUrl: MEET_URL,
+        maxDurationMs: 1001,
+      }),
+    ).rejects.toMatchObject({ code: "invalid_duration_cap" });
+    expect(service.listSessions()).toHaveLength(0);
+    expect(adapter.session).toBeNull();
+  });
 });
 
 describe("MeetingService — session state machine", () => {
@@ -232,6 +248,32 @@ describe("MeetingService — session state machine", () => {
     // Unknown / already-terminal sessions return false.
     expect(service.stopSession(dto.id as never)).toBe(false);
     expect(service.stopSession(crypto.randomUUID() as never)).toBe(false);
+  });
+
+  it("stops and finalizes the session when the duration cap is reached", async () => {
+    vi.useFakeTimers();
+    try {
+      const adapter = new ScriptedAdapter("google_meet");
+      const { service, pipelines } = makeService([adapter]);
+      const dto = await service.requestJoin({
+        platform: "google_meet",
+        meetingUrl: MEET_URL,
+        maxDurationMs: 25,
+      });
+      const botSession = await adapter.started;
+      adapter.report("active");
+      expect(botSession.signal.aborted).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(25);
+
+      const session = service.getSession(dto.id as never);
+      expect(botSession.signal.aborted).toBe(true);
+      expect(session?.status).toBe("ended");
+      expect(session?.endReason).toBe("duration_cap_reached");
+      expect(pipelines[0].finalized).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("ignores adapter status reports after a terminal state", async () => {

--- a/plugins/plugin-meetings/src/service.test.ts
+++ b/plugins/plugin-meetings/src/service.test.ts
@@ -328,6 +328,33 @@ describe("MeetingService — session state machine", () => {
     }
   });
 
+  it("keeps the duration-cap reason when the adapter resolves on abort", async () => {
+    vi.useFakeTimers();
+    try {
+      const adapter = new ScriptedAdapter("google_meet");
+      const { service } = makeService([adapter]);
+      const dto = await service.requestJoin({
+        platform: "google_meet",
+        meetingUrl: MEET_URL,
+        maxDurationMs: 25,
+      });
+      const botSession = await adapter.started;
+      botSession.signal.addEventListener(
+        "abort",
+        () => adapter.end("requested_stop"),
+        { once: true },
+      );
+
+      await vi.advanceTimersByTimeAsync(25);
+
+      const session = service.getSession(dto.id as never);
+      expect(session?.status).toBe("ended");
+      expect(session?.endReason).toBe("duration_cap_reached");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("ignores adapter status reports after a terminal state", async () => {
     const adapter = new ScriptedAdapter("google_meet");
     const { service } = makeService([adapter]);

--- a/plugins/plugin-meetings/src/service.test.ts
+++ b/plugins/plugin-meetings/src/service.test.ts
@@ -155,6 +155,39 @@ describe("MeetingService.requestJoin — validation", () => {
     });
     expect(lower.maxDurationMs).toBe(15 * 60 * 1000);
   });
+
+  it("uses only strict decimal integers for the configured duration cap", async () => {
+    const hexAdapter = new ScriptedAdapter("google_meet");
+    const { fake: hexFake, service: hexService } = makeService([hexAdapter]);
+    hexFake.settings.ELIZA_MEETINGS_MAX_DURATION_MS = "0x10";
+
+    const hexDto = await hexService.requestJoin({
+      platform: "google_meet",
+      meetingUrl: MEET_URL,
+      maxDurationMs: 17,
+    });
+    expect(hexDto.maxDurationMs).toBe(17);
+    expect(hexAdapter.session).not.toBeNull();
+    await hexAdapter.started;
+    hexAdapter.end("normal_completion");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(hexService.getSession(hexDto.id as never)?.status).toBe("ended");
+
+    const decimalAdapter = new ScriptedAdapter("google_meet");
+    const { fake: decimalFake, service: decimalService } = makeService([
+      decimalAdapter,
+    ]);
+    decimalFake.settings.ELIZA_MEETINGS_MAX_DURATION_MS = "1000";
+
+    await expect(
+      decimalService.requestJoin({
+        platform: "google_meet",
+        meetingUrl: MEET_URL,
+        maxDurationMs: 1001,
+      }),
+    ).rejects.toMatchObject({ code: "invalid_duration_cap" });
+    expect(decimalAdapter.session).toBeNull();
+  });
 });
 
 describe("MeetingService — session state machine", () => {

--- a/plugins/plugin-meetings/src/service.ts
+++ b/plugins/plugin-meetings/src/service.ts
@@ -20,6 +20,7 @@ import {
 } from "@elizaos/core";
 import {
   DEFAULT_MEETING_AUTO_LEAVE,
+  DEFAULT_MEETING_MAX_DURATION_MS,
   MEETING_PLATFORM_LABELS,
   type MeetingAutoLeaveConfig,
   type MeetingEndReason,
@@ -59,7 +60,8 @@ export type MeetingJoinErrorCode =
   | "invalid_url"
   | "unsupported_platform"
   | "unsupported_host"
-  | "already_joined";
+  | "already_joined"
+  | "invalid_duration_cap";
 
 /** Validation/conflict failures of `requestJoin` — routes map these to 4xx. */
 export class MeetingJoinError extends Error {
@@ -93,6 +95,7 @@ interface InternalSession {
   transcriptId: UUID;
   participants: MeetingParticipant[];
   calendarEventId?: string;
+  readonly maxDurationMs: number;
   readonly abort: AbortController;
   readonly pipeline: MeetingPipelineInstance;
   readonly writer: MeetingTranscriptWriter;
@@ -220,6 +223,7 @@ export class MeetingService extends Service {
       ...DEFAULT_MEETING_AUTO_LEAVE,
       ...request.autoLeave,
     };
+    const maxDurationMs = this.resolveMaxDurationMs(request.maxDurationMs);
     const retainAudio = request.retainAudio ?? true;
 
     const pipeline = this.deps.createPipeline({
@@ -242,6 +246,7 @@ export class MeetingService extends Service {
       transcriptId: writer.transcriptId,
       participants: [],
       calendarEventId: request.calendarEventId,
+      maxDurationMs,
       abort: new AbortController(),
       pipeline,
       writer,
@@ -375,6 +380,7 @@ export class MeetingService extends Service {
       transcriptId: session.transcriptId,
       participants: session.participants.map((p) => ({ ...p })),
       calendarEventId: session.calendarEventId,
+      maxDurationMs: session.maxDurationMs,
     };
   }
 
@@ -499,8 +505,24 @@ export class MeetingService extends Service {
   ): Promise<void> {
     let endReason: MeetingEndReason;
     let errorMessage: string | undefined;
+    let capTimer: ReturnType<typeof setTimeout> | null = null;
     try {
-      endReason = await adapter.run(botSession);
+      const capReached = new Promise<MeetingEndReason>((resolve) => {
+        capTimer = setTimeout(() => {
+          logger.warn(
+            {
+              sessionId: session.id,
+              maxDurationMs: session.maxDurationMs,
+            },
+            "[MeetingService] duration cap reached; stopping meeting",
+          );
+          this.applyStatus(session, "leaving");
+          session.abort.abort();
+          resolve("duration_cap_reached");
+        }, session.maxDurationMs);
+        capTimer.unref?.();
+      });
+      endReason = await Promise.race([adapter.run(botSession), capReached]);
     } catch (err) {
       endReason = "error";
       errorMessage = err instanceof Error ? err.message : String(err);
@@ -508,6 +530,8 @@ export class MeetingService extends Service {
         { sessionId: session.id, error: errorMessage },
         "[MeetingService] platform adapter failed",
       );
+    } finally {
+      if (capTimer) clearTimeout(capTimer);
     }
     await this.finishSession(session, endReason, errorMessage);
   }
@@ -577,5 +601,35 @@ export class MeetingService extends Service {
   private settingString(key: string): string | null {
     const value = this.runtime.getSetting(key);
     return typeof value === "string" && value.trim() ? value.trim() : null;
+  }
+
+  private resolveMaxDurationMs(requested: number | undefined): number {
+    const configured = this.settingPositiveInteger(
+      "ELIZA_MEETINGS_MAX_DURATION_MS",
+    );
+    const maximum = configured ?? DEFAULT_MEETING_MAX_DURATION_MS;
+    if (
+      requested !== undefined &&
+      (!Number.isSafeInteger(requested) || requested <= 0)
+    ) {
+      throw new MeetingJoinError(
+        "invalid_duration_cap",
+        "maxDurationMs must be a positive integer",
+      );
+    }
+    if (requested !== undefined && requested > maximum) {
+      throw new MeetingJoinError(
+        "invalid_duration_cap",
+        `maxDurationMs exceeds the configured maximum (${maximum}ms)`,
+      );
+    }
+    return requested ?? maximum;
+  }
+
+  private settingPositiveInteger(key: string): number | null {
+    const raw = this.settingString(key);
+    if (!raw) return null;
+    const parsed = Number(raw);
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
   }
 }

--- a/plugins/plugin-meetings/src/service.ts
+++ b/plugins/plugin-meetings/src/service.ts
@@ -30,6 +30,7 @@ import {
   type MeetingSession,
   type MeetingSessionStatus,
   parseMeetingUrl,
+  parsePositiveInteger,
 } from "@elizaos/shared";
 import type { TranscriptSegment } from "@elizaos/shared/transcripts";
 import { MeetingEventEmitter } from "./events.js";
@@ -628,8 +629,6 @@ export class MeetingService extends Service {
 
   private settingPositiveInteger(key: string): number | null {
     const raw = this.settingString(key);
-    if (!raw) return null;
-    const parsed = Number(raw);
-    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+    return parsePositiveInteger(raw) ?? null;
   }
 }

--- a/plugins/plugin-meetings/src/service.ts
+++ b/plugins/plugin-meetings/src/service.ts
@@ -507,9 +507,11 @@ export class MeetingService extends Service {
     let endReason: MeetingEndReason;
     let errorMessage: string | undefined;
     let capTimer: ReturnType<typeof setTimeout> | null = null;
+    let durationCapReached = false;
     try {
       const capReached = new Promise<MeetingEndReason>((resolve) => {
         capTimer = setTimeout(() => {
+          durationCapReached = true;
           logger.warn(
             {
               sessionId: session.id,
@@ -518,12 +520,15 @@ export class MeetingService extends Service {
             "[MeetingService] duration cap reached; stopping meeting",
           );
           this.applyStatus(session, "leaving");
-          session.abort.abort();
           resolve("duration_cap_reached");
+          session.abort.abort();
         }, session.maxDurationMs);
         capTimer.unref?.();
       });
       endReason = await Promise.race([adapter.run(botSession), capReached]);
+      if (durationCapReached) {
+        endReason = "duration_cap_reached";
+      }
     } catch (err) {
       endReason = "error";
       errorMessage = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

Partial implementation for #12100.

- Adds a shared `maxDurationMs` meeting contract and `duration_cap_reached` end reason.
- Applies the production default bounded session cap of **60 minutes** via `DEFAULT_MEETING_MAX_DURATION_MS`.
- Allows callers to request a lower per-session cap.
- Rejects invalid or over-configured caps before launching a bot.
- Stops/finalizes the session when the cap is reached by aborting the adapter signal and finalizing the pipeline.

This does not invent the missing cloud-money reservation/debit/reconciliation implementation. The issue still needs the credit reservation path and live billing proof.

## Evidence

Local proof is committed at `.github/issue-evidence/12100-meeting-duration-cap.md`.

Commands run after aligning the default with the issue decision:

- `bun run --cwd packages/core prebuild` — generated missing i18n keyword data required by this fresh worktree.
- `bunx vitest run plugins/plugin-meetings/src/service.test.ts plugins/plugin-meetings/src/routes/meetings-routes.test.ts packages/shared/src/meetings.test.ts` — 3 files passed, 34 tests passed.
- `bun run --cwd plugins/plugin-meetings typecheck` — clean.
- `bunx @biomejs/biome check packages/shared/src/meetings.ts plugins/plugin-meetings/src/routes/meetings-routes.ts plugins/plugin-meetings/src/service.ts plugins/plugin-meetings/src/service.test.ts plugins/plugin-meetings/src/routes/meetings-routes.test.ts .github/issue-evidence/12100-meeting-duration-cap.md` — clean.
- `git diff --check origin/develop...HEAD` — clean.

## Local Typecheck Caveat

- `bun run --cwd packages/shared typecheck` did not produce useful signal in this temp worktree because it resolves transitive package types through `/home/shaw/milady/eliza/dist/node_modules` and reports pre-existing declaration-resolution noise for `drizzle-orm`, `yaml`, `fs-extra`, `mammoth`, `adze`, etc. No errors were in `packages/shared/src/meetings.ts`.

## Evidence N/A

- Cloud credit reservation/reconciliation rows: unavailable; the cloud-money reservation implementation and test org are not present in this PR/environment.
- Insufficient-credit and cap-reached billing rows: unavailable without the credit setup and metered Cloud test org.
- Live meeting logs/transcript/manual review: unavailable; no approved live meeting fixture/credential set was provided.