### PR TITLE
fix(cloud): isolate agent auto-start env parsing

### DIFF
--- a/packages/cloud/services/agent-server/__tests__/unit/config.test.ts
+++ b/packages/cloud/services/agent-server/__tests__/unit/config.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   ensureServerName,
   getAdvertisedServerUrl,
+  getAutoStartAgentConfig,
   normalizeServerName,
 } from "../../src/config";
 
@@ -41,6 +42,33 @@ describe("ensureServerName", () => {
 
     expect(ensureServerName(env)).toBe("8baf830a-2dc3-465d-b7ed-725fae3eaa56");
     expect(env.SERVER_NAME).toBe("8baf830a-2dc3-465d-b7ed-725fae3eaa56");
+  });
+});
+
+describe("getAutoStartAgentConfig", () => {
+  test("does not treat CHARACTER as a cloud character override", () => {
+    expect(getAutoStartAgentConfig({ CHARACTER: "Nyx" })).toBeUndefined();
+  });
+
+  test("requires CHARACTER_REF when AGENT_ID requests auto-start", () => {
+    expect(() =>
+      getAutoStartAgentConfig({
+        AGENT_ID: "agent-1",
+        CHARACTER: "Nyx",
+      }),
+    ).toThrow("CHARACTER_REF is required when AGENT_ID is set");
+  });
+
+  test("uses explicit AGENT_ID and CHARACTER_REF for auto-start", () => {
+    expect(
+      getAutoStartAgentConfig({
+        AGENT_ID: " agent-1 ",
+        CHARACTER_REF: " character-template-1 ",
+      }),
+    ).toEqual({
+      agentId: "agent-1",
+      characterRef: "character-template-1",
+    });
   });
 });
 

--- a/packages/cloud/services/agent-server/src/config.ts
+++ b/packages/cloud/services/agent-server/src/config.ts
@@ -1,6 +1,11 @@
 // Runs the hosted agent-server config boundary for cloud runtime containers.
 type Env = Record<string, string | undefined>;
 
+export interface AutoStartAgentConfig {
+  agentId: string;
+  characterRef: string;
+}
+
 export function normalizeServerName(
   value: string | undefined,
 ): string | undefined {
@@ -40,6 +45,20 @@ export function getRequiredEnv(name: string, env: Env = process.env): string {
     throw new Error(`Missing required env var: ${name}`);
   }
   return value;
+}
+
+export function getAutoStartAgentConfig(
+  env: Env = process.env,
+): AutoStartAgentConfig | undefined {
+  const agentId = env.AGENT_ID?.trim();
+  if (!agentId) return undefined;
+
+  const characterRef = env.CHARACTER_REF?.trim();
+  if (!characterRef) {
+    throw new Error("CHARACTER_REF is required when AGENT_ID is set");
+  }
+
+  return { agentId, characterRef };
 }
 
 function withoutTrailingSlash(value: string): string {

--- a/packages/cloud/services/agent-server/src/index.ts
+++ b/packages/cloud/services/agent-server/src/index.ts
@@ -1,7 +1,11 @@
 // Runs the hosted agent-server index boundary for cloud runtime containers.
 import { Elysia } from "elysia";
 import { AgentManager } from "./agent-manager";
-import { ensureServerName, getRequiredEnv } from "./config";
+import {
+  ensureServerName,
+  getAutoStartAgentConfig,
+  getRequiredEnv,
+} from "./config";
 import { logger } from "./logger";
 import { getRedis } from "./redis";
 import { createRoutes } from "./routes";
@@ -30,8 +34,11 @@ for (const key of required) {
   }
 }
 
-if (process.env.AGENT_ID && !process.env.CHARACTER_REF) {
-  logger.error("CHARACTER_REF is required when AGENT_ID is set");
+let autoStartAgent: ReturnType<typeof getAutoStartAgentConfig>;
+try {
+  autoStartAgent = getAutoStartAgentConfig();
+} catch (err) {
+  logger.error(err instanceof Error ? err.message : String(err));
   process.exit(1);
 }
 
@@ -42,9 +49,8 @@ const manager = new AgentManager();
 // Initialize manager before accepting connections
 await manager.initialize();
 
-const agentId = process.env.AGENT_ID;
-const characterRef = process.env.CHARACTER_REF;
-if (agentId && characterRef) {
+if (autoStartAgent) {
+  const { agentId, characterRef } = autoStartAgent;
   await manager.startAgent(agentId, characterRef);
   logger.info("Auto-started agent", {
     agentId,


### PR DESCRIPTION
## Summary
- add a typed helper for cloud agent-server auto-start env parsing
- require `CHARACTER_REF` only when `AGENT_ID` requests auto-start
- keep `CHARACTER` from being treated as a cloud auto-start override

## Validation
- `bun test packages/cloud/services/agent-server/__tests__/unit/config.test.ts` — 12 pass
- `bun run --cwd packages/cloud/services/agent-server typecheck`
- `bun run --cwd packages/cloud/services/agent-server lint`

## Evidence
- N/A UI screenshots/video: backend config-only change
- N/A live model trajectory: no model/action/provider behavior changed
- N/A DB/domain artifact: no persistence or migration change
