### PR TITLE
fix(ui): keep chat panel within the visible viewport so revealed message actions stay hittable

### DIFF
--- a/packages/app-core/platforms/ios/App/AppUITests/GestureSemanticsUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/GestureSemanticsUITests.swift
@@ -56,6 +56,16 @@ final class GestureSemanticsUITests: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
+        // Pin the simulated device orientation to portrait BEFORE launch. Every
+        // geometry contract in this suite (detent heights, the bubble being
+        // tappable above the keyboard right after send, composer keyboard
+        // clearance) assumes portrait phone metrics: a 393pt-tall landscape
+        // window with the ~276pt keyboard up leaves ~117pt of visual viewport —
+        // physically not enough for composer + a hittable message bubble, so
+        // the tap-to-reveal legs cannot hold there. A physical device lying
+        // flat (faceUp) launches the app in whatever orientation it last
+        // latched, which made this suite nondeterministic on the device lane.
+        XCUIDevice.shared.orientation = .portrait
     }
 
     // MARK: - Tests

--- a/packages/app-core/platforms/ios/App/AppUITests/GestureSemanticsUITests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/GestureSemanticsUITests.swift
@@ -731,12 +731,25 @@ final class GestureSemanticsUITests: XCTestCase {
             ))
     }
 
+    /// The last USER bubble. User and assistant turns carry the SAME
+    /// "Show/Hide message actions" label (the text child is name-hidden), so
+    /// alignment is the only AX-visible discriminator: user turns are
+    /// right-aligned, assistant turns left-aligned. When a live agent replies
+    /// before the tap lands, the last bubble by index is the assistant's —
+    /// whose action row has no Edit affordance — so prefer the last bubble
+    /// whose center sits right of the window midline, falling back to the
+    /// plain last bubble on a reply-less (model-less) boot.
     private func lastMessageBubble(in app: XCUIApplication) throws -> XCUIElement {
         let bubbles = messageBubbles(in: app)
         let count = bubbles.count
         guard count > 0 else {
             attachAccessibilitySnapshot(of: app, named: "ax-hierarchy-no-bubble")
             throw XCTSkip("no message bubble exposed in the AX tree")
+        }
+        let windowMidX = app.windows.firstMatch.frame.midX
+        for index in stride(from: count - 1, through: 0, by: -1) {
+            let bubble = bubbles.element(boundBy: index)
+            if bubble.frame.midX > windowMidX { return bubble }
         }
         return bubbles.element(boundBy: count - 1)
     }

--- a/packages/ui/src/components/shell/chat-panel-layout.test.ts
+++ b/packages/ui/src/components/shell/chat-panel-layout.test.ts
@@ -150,16 +150,69 @@ describe("resolveChatPanelLayout", () => {
     expect(panelTopFromBottom(input, panelMaxH)).toBe(SCREEN_H);
   });
 
-  it("clamps to a minimum usable height on a tiny viewport", () => {
-    const { panelMaxH } = resolveChatPanelLayout({
+  it("prefers a usable height on a tight viewport by eating the top margin", () => {
+    // 260px of space: the 200px preference wins over (260-12-72)=176, and the
+    // whole 200 still fits on screen — the floor may consume the top margin.
+    const input: ChatPanelLayoutInput = {
+      viewportH: 260,
+      bottomPad: 12,
+      keyboardInset: 0,
+      effectiveKeyboardInset: 0,
+      safeAreaTopPx: 0,
+      fullBleed: false,
+    };
+    const { panelMaxH } = resolveChatPanelLayout(input);
+    expect(panelMaxH).toBe(200);
+    expect(panelTopFromBottom(input, panelMaxH)).toBeLessThanOrEqual(260);
+  });
+
+  it("never sizes the panel beyond the viewport on a tiny viewport", () => {
+    // A 120px viewport cannot hold a 200px panel: a bottom-anchored panel
+    // taller than the screen puts its top (grabber/header/thread) off-screen
+    // above, which is strictly worse than a short panel.
+    const input: ChatPanelLayoutInput = {
       viewportH: 120,
       bottomPad: 12,
       keyboardInset: 0,
       effectiveKeyboardInset: 0,
       safeAreaTopPx: 0,
       fullBleed: false,
-    });
-    expect(panelMaxH).toBe(200);
+    };
+    const { panelMaxH } = resolveChatPanelLayout(input);
+    expect(panelMaxH).toBe(120 - 12);
+    expect(panelTopFromBottom(input, panelMaxH)).toBeLessThanOrEqual(120);
+  });
+
+  it("keeps the whole panel on-screen on a landscape phone with the keyboard up (device failure geometry)", () => {
+    // Real numbers from the iPhone 15 Pro failure (GestureSemanticsUITests/
+    // testMessageEditAffordanceRevealsViaTouch): 852x393 landscape window,
+    // 276pt keyboard intrusion reported by the visual viewport (117pt left),
+    // 12px composer-focused bottom padding, no top safe-area in landscape.
+    // The old MIN floor produced a 200px panel whose top landed 95px above the
+    // window — the AX tree showed every message bubble (and the grabber and
+    // header) at negative y, unhittable.
+    const input: ChatPanelLayoutInput = {
+      viewportH: 117,
+      bottomPad: 12,
+      keyboardInset: 276,
+      effectiveKeyboardInset: 276,
+      safeAreaTopPx: 0,
+      fullBleed: false,
+    };
+    const { panelMaxH } = resolveChatPanelLayout(input);
+    expect(panelMaxH).toBe(117 - 12);
+    // Screen height = visual viewport (117) + keyboard (276) = 393. The panel
+    // top must land at or below the screen top.
+    expect(panelTopFromBottom(input, panelMaxH)).toBeLessThanOrEqual(393);
+  });
+
+  it("demonstrates the pre-fix landscape-keyboard geometry pushed the panel top off-screen", () => {
+    // Old formula: max(MIN, viewportH - bottomPad - topMargin - unreportedLift)
+    // = max(200, 117-12-72-0) = 200 → top at 276+12+200 = 488 on a 393pt-tall
+    // screen: 95px of panel (grabber, header, the entire thread window) above
+    // the top edge — matching the -96px panel top in the device AX dump.
+    const buggyPanelMaxH = Math.max(200, 117 - 12 - SHEET_TOP_MARGIN);
+    expect(276 + 12 + buggyPanelMaxH).toBeGreaterThan(393);
   });
 
   it("treats a non-finite safe-area measurement as zero", () => {

--- a/packages/ui/src/components/shell/chat-panel-layout.ts
+++ b/packages/ui/src/components/shell/chat-panel-layout.ts
@@ -17,8 +17,14 @@ export const SHEET_TOP_MARGIN = 72;
 // doesn't butt directly against the Dynamic Island / status bar.
 const SAFE_AREA_TOP_BUFFER = 8;
 
-// The panel can never shrink below this — a tiny viewport still shows a usable
-// composer + a sliver of thread rather than collapsing to nothing.
+// The panel prefers not to shrink below this — on a tight viewport it eats the
+// top margin (rather than collapsing to nothing) before giving up height. It is
+// a PREFERENCE, not a hard floor: the panel may never exceed the space that
+// actually exists on screen (see the cap in resolveChatPanelLayout), because a
+// bottom-anchored panel taller than the viewport puts its top — the grabber,
+// header, and the entire thread window — above the screen where nothing can be
+// seen or tapped (observed on a landscape iPhone with the keyboard up: ~117px
+// of visual viewport, a 200px panel, and every message bubble unhittable).
 const MIN_PANEL_HEIGHT = 200;
 
 export interface ChatPanelLayoutInput {
@@ -97,12 +103,19 @@ export function resolveChatPanelLayout(
     ? 0
     : Math.max(SHEET_TOP_MARGIN, safeTop + SAFE_AREA_TOP_BUFFER);
 
-  const panelMaxH = Math.max(
-    MIN_PANEL_HEIGHT,
-    viewportH -
-      (fullBleed ? 0 : bottomPad) -
-      topMargin -
-      unreportedKeyboardLift,
+  // Everything the lifted, bottom-anchored panel can occupy without its top
+  // edge leaving the screen. The MIN_PANEL_HEIGHT preference may consume the
+  // topMargin, but never exceed this — otherwise the grabber/header/thread land
+  // off-screen above the viewport (the landscape-phone + keyboard failure:
+  // 393pt-tall window, ~276pt keyboard, 117pt visual viewport).
+  const availableH = Math.max(
+    0,
+    viewportH - (fullBleed ? 0 : bottomPad) - unreportedKeyboardLift,
+  );
+
+  const panelMaxH = Math.min(
+    availableH,
+    Math.max(MIN_PANEL_HEIGHT, availableH - topMargin),
   );
 
   return { topMargin, panelMaxH };


### PR DESCRIPTION
## Root cause

On a physical iPhone 15 Pro, `AppUITests/GestureSemanticsUITests/testMessageEditAffordanceRevealsViaTouch` failed reproducibly: after tapping a user message bubble, the revealed `Show message actions` affordance existed at AX frame `{{655,-59},{136,40}}` — off-screen above the top edge of the 393×852 window. Two compounding causes:

1. **Panel sized taller than the on-screen viewport.** `resolveChatPanelLayout` (`packages/ui/src/components/shell/chat-panel-layout.ts`) applied `MIN_PANEL_HEIGHT = 200` as a hard floor: `panelMaxH = max(200, viewportH - bottomPad - topMargin - unreportedLift)`. On a landscape phone with the soft keyboard up (393pt-tall window, ~276pt keyboard, ~117pt visual viewport) the bottom-anchored sheet got a 200px `panelMaxH`, pushing its top ~95px above the screen: the grabber, header, and the entire thread window — including the revealed action row — landed at negative y, present in the AX tree but invisible and unhittable.
2. **The test never pinned orientation.** A physical device lying flat (faceUp) launches the app in whatever orientation it last latched, so the suite nondeterministically ran with landscape metrics (the x=655 in the failure frame) — geometry no layout can satisfy (composer + a hittable bubble in a 117pt visual viewport).

## Fix

- `packages/ui/src/components/shell/chat-panel-layout.ts` — `MIN_PANEL_HEIGHT` becomes a preference, not a hard floor: `panelMaxH = min(availableH, max(MIN, availableH - topMargin))` where `availableH` is the hard on-screen space above the lifted bottom. The preference may still eat the top margin, but the panel top can never leave the screen. Normal portrait/desktop geometry is byte-identical (the cap only binds when `availableH < 200`).
- `packages/app-core/platforms/ios/App/AppUITests/GestureSemanticsUITests.swift` — pin `XCUIDevice.shared.orientation = .portrait` in `setUpWithError` so every geometry contract in the suite runs against portrait phone metrics deterministically.
- `packages/app-core/platforms/ios/App/AppUITests/GestureSemanticsUITests.swift` — `lastMessageBubble` now targets the last **user** bubble (right-of-midline; user and assistant turns expose the identical `Show/Hide message actions` AX label, so alignment is the only discriminator). With a live agent replying before the tap, `boundBy count-1` picked the assistant reply, whose action row has no Edit affordance — a harness false-negative on any responsive-agent boot; on a reply-less device boot the behavior is unchanged.

## Before evidence (device failure)

Physical iPhone 15 Pro, prior run:

```
AppUITests/GestureSemanticsUITests/testMessageEditAffordanceRevealsViaTouch
FAILED: 'Show message actions' exists but is off-screen
AX frame: {{655, -59}, {136, 40}}   (y = -59 — above the screen top; x = 655 — landscape coordinates on a 393×852 portrait viewport)
```

## After evidence (iPhone 16 Pro simulator, renderer rebuilt from this branch)

Renderer rebuilt with `bun run --cwd packages/app build:ios:local:sim:full-bun` and reinstalled on the booted sim before capture (the fix is in `packages/ui` and bakes into the web bundle at build time; fresh asset timestamps confirmed in `App.app/public/assets`).

```
Test Case '-[AppUITests.GestureSemanticsUITests testMessageEditAffordanceRevealsViaTouch]' passed (45.877 seconds)
Executed 1 test, with 0 failures
```

AX proof the reveal chain is on-screen and hittable end-to-end (from the passing run's attachments — `edit-10-action-row-revealed.png`, `edit-20-editor-open.png`, `ax-hierarchy-editor`):

```
TextView {{114.0, 585.0}, {241.0, 36.0}}, label: 'Edit message', value: edit me please, Keyboard Focused
```

— the same reveal→Edit→prefilled-editor chain whose first link previously sat at y = −59. The bubble, the revealed action row, and the inline editor all land at positive on-screen coordinates in portrait.

Regression checks on the same sim build:

```
Test Case '-[AppUITests.BootCaptureUITests testComposerAcceptsTypedText]' passed (23.211 seconds)
```

```
Test Case '-[AppUITests.GestureSemanticsUITests testChatSheetDetentFlickCycle]' skipped (66.221 seconds)
  "could not settle the chat sheet to the collapsed detent (reads 'full') — precondition, not the gesture under test"
```

The detent skip is an app-state precondition (the reconstructed sim install boots with the first-run/tutorial surface pinning the sheet open, and post-onboarding boots land on the Character Select view — pre-existing develop boot-routing behavior unrelated to this branch). Detent geometry itself is covered by the unit lane: the layout change is provably byte-identical at portrait sim geometry (`availableH = 840 ≥ 200`, so `min(availableH, old) = old`), and all 41 shell test files (673 tests, incl. the `useShellController` detent math) pass.

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Unit tests (layout solver) | `bun run --cwd packages/ui test src/components/shell/chat-panel-layout.test.ts` | 12/12 pass (incl. the exact 852×393-landscape + 276pt-keyboard device geometry) |
| Shell suite | `bun run --cwd packages/ui test src/components/shell/` | 41 files, 673 passed / 7 skipped |
| Typecheck | `bun run --cwd packages/ui typecheck` | pass |
| Lint (changed files) | `biome check` on both changed ui files | clean |
| Error-policy ratchet | `bun run audit:error-policy-ratchet` | `no new fallback-slop in touched files` |
| Sim: target test | `node scripts/ios-device-capture.mjs --platform sim --only-testing AppUITests/GestureSemanticsUITests/testMessageEditAffordanceRevealsViaTouch` | **passed** (45.9s) |
| Sim: composer typed text | same harness, `AppUITests/BootCaptureUITests/testComposerAcceptsTypedText` | **passed** (23.2s) |
| Sim: detent flick cycle | same harness, `AppUITests/GestureSemanticsUITests/testChatSheetDetentFlickCycle` | skipped at app-state precondition (see above); detent math covered by unit lane |
| Physical device re-verify (iPhone 15 Pro) | `ios-device-capture.mjs --platform device` | in progress in parent session on iPhone 15 Pro |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
