### PR TITLE
feat(bench): add Sierra-style synthetic fixtures

### DIFF
--- a/.github/issue-evidence/13361-sierra-style-fixtures.md
+++ b/.github/issue-evidence/13361-sierra-style-fixtures.md
@@ -1,0 +1,31 @@
+# Issue 13361 - Sierra-Style Synthetic Fixtures
+
+## Scope
+
+Added eliza-owned synthetic benchmark fixtures inspired by Sierra tau-Knowledge
+and tau-Voice methodology without committing Sierra source data.
+
+## Validation
+
+- `bunx vitest run packages/lifeops-bench/src/__tests__/sierra-style-fixtures.test.ts --config packages/lifeops-bench/vitest.config.ts`
+  - 1 file, 3 tests passed.
+- `bunx @biomejs/biome check packages/lifeops-bench/src/sierra-style-fixtures.ts packages/lifeops-bench/src/__tests__/sierra-style-fixtures.test.ts packages/lifeops-bench/src/README.md`
+  - clean.
+- `bunx tsc --ignoreConfig --noEmit --strict --target ES2022 --module ESNext --moduleResolution bundler --skipLibCheck --types node packages/lifeops-bench/src/sierra-style-fixtures.ts packages/lifeops-bench/src/__tests__/sierra-style-fixtures.test.ts`
+  - clean.
+- `git diff --check`
+  - clean.
+
+## Package Typecheck Note
+
+`bun run --cwd packages/lifeops-bench typecheck` is blocked in this checkout by
+pre-existing unresolved workspace/provider imports outside the new fixture
+files, including `@elizaos/auth/*`, `@elizaos/vault`, `@elizaos/agent`,
+`@elizaos/plugin-groq`, `@elizaos/plugin-openai`, and
+`@elizaos/plugin-anthropic`.
+
+## Evidence Boundary
+
+The committed tests prove the fixture contracts, deterministic backend-state
+scoring, and required voice report fields. Publishable voice evidence still
+requires real provider/model voice runs and manually reviewed artifacts.

--- a/packages/lifeops-bench/src/README.md
+++ b/packages/lifeops-bench/src/README.md
@@ -20,6 +20,7 @@ This directory contains:
 |---|---|
 | `server.ts` | HTTP server for benchmark traffic. Initializes `AgentRuntime`, handles benchmark sessions, and routes each message through `runtime.messageService.handleMessage(...)`. |
 | `mock-plugin.ts` | Deterministic mock benchmark plugin loaded when `ELIZA_BENCH_MOCK=true`. Diagnostic only; mock runs are not valid release evidence. |
+| `sierra-style-fixtures.ts` | eliza-owned synthetic knowledge and voice-interruption fixture contracts inspired by Sierra tau-Knowledge / tau-Voice methodology, with no Sierra raw data. |
 | `TESTING_PROTOCOL.md` | Benchmark action/testing protocol (required checks). |
 
 The Python client side can live in a local adapter directory such as `benchmarks/eliza-adapter/`.
@@ -48,6 +49,22 @@ bun run benchmark:watch
 # see the full benchmark testing/checklist protocol
 cat src/TESTING_PROTOCOL.md
 ```
+
+## Sierra-Style Synthetic Fixtures
+
+`sierra-style-fixtures.ts` defines two eliza-owned benchmark contracts:
+
+- `createSierraStyleKnowledgeFixture()` returns a deterministic LifeWorld task
+  where scoring is based on backend end state: a calendar event, draft email,
+  and reminder must exist with exact target fields.
+- `SIERRA_STYLE_VOICE_INTERRUPTION_FIXTURE` describes a synthetic voice task
+  covering interruption recovery, background noise, dropped-frame windows,
+  auth-code/email/name spelling, pass@1, and required report fields.
+
+These fixtures borrow methodology shape only. They do not commit Sierra data,
+and fixture smoke tests are not release-quality evidence. Publishable voice
+results still need real model/voice runs with provider/model, STT/TTS/VAD
+configuration, pass@1, recovery categories, and manually reviewed outputs.
 
 ## HTTP API
 

--- a/packages/lifeops-bench/src/__tests__/sierra-style-fixtures.test.ts
+++ b/packages/lifeops-bench/src/__tests__/sierra-style-fixtures.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies the synthetic Sierra-style fixture contracts with deterministic
+ * backend state and report validation checks.
+ */
 import { describe, expect, it } from "vitest";
 import { LifeOpsFakeBackend } from "../lifeops-fake-backend.js";
 import {

--- a/packages/lifeops-bench/src/__tests__/sierra-style-fixtures.test.ts
+++ b/packages/lifeops-bench/src/__tests__/sierra-style-fixtures.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { LifeOpsFakeBackend } from "../lifeops-fake-backend.js";
+import {
+  createSierraStyleKnowledgeFixture,
+  SIERRA_STYLE_VOICE_INTERRUPTION_FIXTURE,
+  type SierraStyleVoiceReport,
+  scoreSierraStyleKnowledgeFixture,
+  validateSierraStyleVoiceReport,
+} from "../sierra-style-fixtures.js";
+
+describe("Sierra-style benchmark fixtures", () => {
+  it("scores a deterministic knowledge-grounded backend end state", () => {
+    const fixture = createSierraStyleKnowledgeFixture();
+    const backend = new LifeOpsFakeBackend(fixture.world);
+
+    expect(
+      scoreSierraStyleKnowledgeFixture(fixture, backend.toDocument()),
+    ).toMatchObject({
+      pass: false,
+      checks: {
+        calendarEventCreated: false,
+        draftEmailCreated: false,
+        reminderCreated: false,
+      },
+    });
+
+    backend.applyAction("calendar.create_event", {
+      calendar_id: "cal_primary",
+      title: fixture.requiredEndState.calendarEvent.title,
+      start: fixture.requiredEndState.calendarEvent.start,
+      end: fixture.requiredEndState.calendarEvent.end,
+      attendees: fixture.requiredEndState.calendarEvent.attendees,
+    });
+    backend.applyAction("mail.create_draft", {
+      to_emails: [fixture.requiredEndState.draftEmail.to],
+      subject: "Blue Harbor review details",
+      body: "Confirming BH-7421 for 15:30 UTC.",
+    });
+    backend.applyAction("reminders.create", {
+      title: fixture.requiredEndState.reminder.title,
+      due_at: fixture.requiredEndState.reminder.dueAt,
+    });
+
+    expect(
+      scoreSierraStyleKnowledgeFixture(fixture, backend.toDocument()),
+    ).toEqual({
+      pass: true,
+      checks: {
+        calendarEventCreated: true,
+        draftEmailCreated: true,
+        reminderCreated: true,
+      },
+    });
+  });
+
+  it("declares voice interruption, noise, dropped-frame, spelling, and pass@1 report requirements", () => {
+    const fixture = SIERRA_STYLE_VOICE_INTERRUPTION_FIXTURE;
+
+    expect(fixture.methodology).toEqual({
+      inspiration: "sierra_tau_voice",
+      dataPolicy: "eliza_owned_synthetic_only",
+      sourceData: "none",
+    });
+    expect(fixture.simulation.turns.some((turn) => turn.interruptionAtMs)).toBe(
+      true,
+    );
+    expect(
+      fixture.simulation.turns.some((turn) => turn.background !== "none"),
+    ).toBe(true);
+    expect(
+      fixture.simulation.turns.some(
+        (turn) => (turn.droppedFrameWindowsMs?.length ?? 0) > 0,
+      ),
+    ).toBe(true);
+    expect(
+      fixture.simulation.authOrSpellingTargets.map((target) => target.kind),
+    ).toEqual(["auth_code", "email", "proper_name"]);
+    expect(fixture.passCriteria.requiredFailureCategories).toEqual([
+      "interruption_recovery",
+      "background_noise",
+      "dropped_frame",
+      "auth_code_spelling",
+      "email_spelling",
+      "multi_step_completion",
+    ]);
+  });
+
+  it("validates publishable voice reports include model, voice config, pass@1, categories, and reviewed outputs", () => {
+    const fixture = SIERRA_STYLE_VOICE_INTERRUPTION_FIXTURE;
+    const passingReport: SierraStyleVoiceReport = {
+      provider: "local",
+      model: "eliza-1-asr",
+      voiceConfig: {
+        stt: "fused-local-asr",
+        tts: "kokoro",
+        vad: "silero",
+        noiseProfile: "cafe_babble+keyboard+dropped_frames",
+      },
+      passAt1: true,
+      recoveryCategories: fixture.passCriteria.requiredFailureCategories,
+      manuallyReviewedOutputs: [
+        ".github/issue-evidence/13361-sierra-style-voice/run-001.json",
+      ],
+    };
+
+    expect(validateSierraStyleVoiceReport(fixture, passingReport)).toEqual([]);
+
+    expect(
+      validateSierraStyleVoiceReport(fixture, {
+        ...passingReport,
+        provider: "",
+        passAt1: false,
+        recoveryCategories: ["interruption_recovery"],
+        manuallyReviewedOutputs: [],
+      }),
+    ).toEqual([
+      "provider is required",
+      "passAt1 must be true for this fixture",
+      "missing recovery category: background_noise",
+      "missing recovery category: dropped_frame",
+      "missing recovery category: auth_code_spelling",
+      "missing recovery category: email_spelling",
+      "missing recovery category: multi_step_completion",
+      "manuallyReviewedOutputs must include at least one artifact",
+    ]);
+  });
+});

--- a/packages/lifeops-bench/src/sierra-style-fixtures.ts
+++ b/packages/lifeops-bench/src/sierra-style-fixtures.ts
@@ -1,0 +1,377 @@
+import type { LifeWorldDocument } from "./lifeops-fake-backend.js";
+
+export type SierraStyleFailureCategory =
+  | "interruption_recovery"
+  | "background_noise"
+  | "dropped_frame"
+  | "auth_code_spelling"
+  | "email_spelling"
+  | "multi_step_completion";
+
+export interface SierraStyleKnowledgeFixture {
+  id: string;
+  methodology: {
+    inspiration: "sierra_tau_knowledge";
+    dataPolicy: "eliza_owned_synthetic_only";
+    sourceData: "none";
+  };
+  world: LifeWorldDocument;
+  userPrompt: string;
+  requiredEndState: {
+    calendarEvent: {
+      title: string;
+      start: string;
+      end: string;
+      attendees: string[];
+    };
+    draftEmail: {
+      to: string;
+      subjectIncludes: string;
+      bodyIncludes: string[];
+    };
+    reminder: {
+      title: string;
+      dueAt: string;
+    };
+  };
+}
+
+export interface SierraStyleKnowledgeScore {
+  pass: boolean;
+  checks: {
+    calendarEventCreated: boolean;
+    draftEmailCreated: boolean;
+    reminderCreated: boolean;
+  };
+}
+
+export interface SierraStyleVoiceFixture {
+  id: string;
+  methodology: {
+    inspiration: "sierra_tau_voice";
+    dataPolicy: "eliza_owned_synthetic_only";
+    sourceData: "none";
+  };
+  taskPrompt: string;
+  simulation: {
+    voiceProfile: string;
+    turns: Array<{
+      speaker: "user" | "assistant";
+      text: string;
+      interruptionAtMs?: number;
+      background?: "none" | "cafe_babble" | "keyboard" | "fan_hvac";
+      droppedFrameWindowsMs?: Array<[number, number]>;
+    }>;
+    authOrSpellingTargets: Array<{
+      kind: "auth_code" | "email" | "proper_name";
+      spoken: string;
+      expectedNormalized: string;
+    }>;
+  };
+  expectedReportFields: Array<keyof SierraStyleVoiceReport>;
+  passCriteria: {
+    passAt1: true;
+    requiredFailureCategories: SierraStyleFailureCategory[];
+    requiredManualReview: true;
+  };
+}
+
+export interface SierraStyleVoiceReport {
+  provider: string;
+  model: string;
+  voiceConfig: {
+    stt: string;
+    tts: string;
+    vad: string;
+    noiseProfile: string;
+  };
+  passAt1: boolean;
+  recoveryCategories: SierraStyleFailureCategory[];
+  manuallyReviewedOutputs: string[];
+}
+
+export function createSierraStyleKnowledgeFixture(): SierraStyleKnowledgeFixture {
+  const world: LifeWorldDocument = {
+    seed: 13361,
+    now_iso: "2026-07-04T09:00:00Z",
+    stores: {
+      contact: {
+        c_amelia: {
+          id: "c_amelia",
+          display_name: "Amelia Chen",
+          given_name: "Amelia",
+          family_name: "Chen",
+          primary_email: "amelia.chen@example.test",
+          phones: [],
+          company: "Northstar Ops",
+          role: "Launch reviewer",
+          relationship: "work",
+          importance: 9,
+          tags: ["launch", "reviewer"],
+          birthday: null,
+        },
+      },
+      email: {
+        e_launch: {
+          id: "e_launch",
+          thread_id: "thread_launch",
+          folder: "inbox",
+          from_email: "amelia.chen@example.test",
+          to_emails: ["owner@example.test"],
+          cc_emails: [],
+          subject: "Launch packet review",
+          body_plain:
+            "Please book a 30 minute Blue Harbor launch review at 15:30 UTC on July 8 and send me a draft with the deck code BH-7421.",
+          sent_at: "2026-07-04T08:45:00Z",
+          received_at: "2026-07-04T08:45:00Z",
+          is_read: false,
+          is_starred: true,
+          labels: ["launch"],
+          attachments: [],
+        },
+      },
+      email_thread: {
+        thread_launch: {
+          id: "thread_launch",
+          subject: "Launch packet review",
+          message_ids: ["e_launch"],
+          participants: ["amelia.chen@example.test", "owner@example.test"],
+          last_activity_at: "2026-07-04T08:45:00Z",
+        },
+      },
+      chat_message: {},
+      conversation: {},
+      calendar_event: {
+        ev_focus: {
+          id: "ev_focus",
+          calendar_id: "cal_primary",
+          title: "Focus block",
+          description: "",
+          location: null,
+          start: "2026-07-08T13:00:00Z",
+          end: "2026-07-08T14:00:00Z",
+          all_day: false,
+          attendees: [],
+          status: "confirmed",
+          visibility: "default",
+          recurrence_rule: null,
+          source: "google",
+        },
+      },
+      calendar: {
+        cal_primary: {
+          id: "cal_primary",
+          name: "Work",
+          color: "#4285F4",
+          owner: "owner@example.test",
+          source: "google",
+          is_primary: true,
+        },
+      },
+      reminder: {},
+      reminder_list: {
+        list_default: {
+          id: "list_default",
+          name: "Reminders",
+          source: "apple-reminders",
+        },
+      },
+      note: {
+        note_launch_context: {
+          id: "note_launch_context",
+          title: "Blue Harbor launch context",
+          body_markdown:
+            "Blue Harbor review requires Amelia Chen, deck code BH-7421, and a same-day follow-up reminder.",
+          tags: ["launch", "blue-harbor"],
+          created_at: "2026-07-03T12:00:00Z",
+          updated_at: "2026-07-03T12:00:00Z",
+          source: "notes",
+        },
+      },
+      transaction: {},
+      account: {},
+      subscription: {},
+      health_metric: {},
+      location_point: {},
+    },
+  };
+
+  return {
+    id: "sierra-style-knowledge-blue-harbor",
+    methodology: {
+      inspiration: "sierra_tau_knowledge",
+      dataPolicy: "eliza_owned_synthetic_only",
+      sourceData: "none",
+    },
+    world,
+    userPrompt:
+      "Use my current knowledge and inbox to prepare the Blue Harbor launch review.",
+    requiredEndState: {
+      calendarEvent: {
+        title: "Blue Harbor launch review",
+        start: "2026-07-08T15:30:00Z",
+        end: "2026-07-08T16:00:00Z",
+        attendees: ["amelia.chen@example.test"],
+      },
+      draftEmail: {
+        to: "amelia.chen@example.test",
+        subjectIncludes: "Blue Harbor",
+        bodyIncludes: ["BH-7421", "15:30"],
+      },
+      reminder: {
+        title: "Follow up on Blue Harbor launch review",
+        dueAt: "2026-07-08T17:00:00Z",
+      },
+    },
+  };
+}
+
+export function scoreSierraStyleKnowledgeFixture(
+  fixture: SierraStyleKnowledgeFixture,
+  world: LifeWorldDocument,
+): SierraStyleKnowledgeScore {
+  const calendarEventCreated = Object.values(world.stores.calendar_event).some(
+    (event) =>
+      event.status === "confirmed" &&
+      event.title === fixture.requiredEndState.calendarEvent.title &&
+      event.start === fixture.requiredEndState.calendarEvent.start &&
+      event.end === fixture.requiredEndState.calendarEvent.end &&
+      fixture.requiredEndState.calendarEvent.attendees.every((attendee) =>
+        event.attendees.includes(attendee),
+      ),
+  );
+
+  const draftEmailCreated = Object.values(world.stores.email).some(
+    (email) =>
+      email.folder === "drafts" &&
+      email.to_emails.includes(fixture.requiredEndState.draftEmail.to) &&
+      email.subject.includes(
+        fixture.requiredEndState.draftEmail.subjectIncludes,
+      ) &&
+      fixture.requiredEndState.draftEmail.bodyIncludes.every((needle) =>
+        email.body_plain.includes(needle),
+      ),
+  );
+
+  const reminderCreated = Object.values(world.stores.reminder).some(
+    (reminder) =>
+      reminder.completed_at === null &&
+      reminder.title === fixture.requiredEndState.reminder.title &&
+      reminder.due_at === fixture.requiredEndState.reminder.dueAt,
+  );
+
+  return {
+    pass: calendarEventCreated && draftEmailCreated && reminderCreated,
+    checks: {
+      calendarEventCreated,
+      draftEmailCreated,
+      reminderCreated,
+    },
+  };
+}
+
+export const SIERRA_STYLE_VOICE_INTERRUPTION_FIXTURE: SierraStyleVoiceFixture =
+  {
+    id: "sierra-style-voice-interruption-blue-harbor",
+    methodology: {
+      inspiration: "sierra_tau_voice",
+      dataPolicy: "eliza_owned_synthetic_only",
+      sourceData: "none",
+    },
+    taskPrompt:
+      "Complete the Blue Harbor launch review setup while recovering from interruption, noise, dropped frames, and spelled credentials.",
+    simulation: {
+      voiceProfile: "synthetic-us-en-neutral-owner",
+      turns: [
+        {
+          speaker: "user",
+          text: "Schedule the Blue Harbor review with Amelia Chen next Wednesday at three thirty UTC.",
+          background: "cafe_babble",
+        },
+        {
+          speaker: "assistant",
+          text: "I can set that up and draft the follow-up.",
+          interruptionAtMs: 620,
+        },
+        {
+          speaker: "user",
+          text: "Wait, include the deck code B H seven four two one and email amelia dot chen at example dot test.",
+          background: "keyboard",
+          droppedFrameWindowsMs: [
+            [1180, 1260],
+            [2140, 2220],
+          ],
+        },
+      ],
+      authOrSpellingTargets: [
+        {
+          kind: "auth_code",
+          spoken: "B H seven four two one",
+          expectedNormalized: "BH-7421",
+        },
+        {
+          kind: "email",
+          spoken: "amelia dot chen at example dot test",
+          expectedNormalized: "amelia.chen@example.test",
+        },
+        {
+          kind: "proper_name",
+          spoken: "Amelia Chen",
+          expectedNormalized: "Amelia Chen",
+        },
+      ],
+    },
+    expectedReportFields: [
+      "provider",
+      "model",
+      "voiceConfig",
+      "passAt1",
+      "recoveryCategories",
+      "manuallyReviewedOutputs",
+    ],
+    passCriteria: {
+      passAt1: true,
+      requiredFailureCategories: [
+        "interruption_recovery",
+        "background_noise",
+        "dropped_frame",
+        "auth_code_spelling",
+        "email_spelling",
+        "multi_step_completion",
+      ],
+      requiredManualReview: true,
+    },
+  };
+
+export function validateSierraStyleVoiceReport(
+  fixture: SierraStyleVoiceFixture,
+  report: SierraStyleVoiceReport,
+): string[] {
+  const errors: string[] = [];
+  if (!report.provider.trim()) errors.push("provider is required");
+  if (!report.model.trim()) errors.push("model is required");
+  if (!report.voiceConfig.stt.trim())
+    errors.push("voiceConfig.stt is required");
+  if (!report.voiceConfig.tts.trim())
+    errors.push("voiceConfig.tts is required");
+  if (!report.voiceConfig.vad.trim())
+    errors.push("voiceConfig.vad is required");
+  if (!report.voiceConfig.noiseProfile.trim()) {
+    errors.push("voiceConfig.noiseProfile is required");
+  }
+  if (report.passAt1 !== fixture.passCriteria.passAt1) {
+    errors.push("passAt1 must be true for this fixture");
+  }
+  for (const category of fixture.passCriteria.requiredFailureCategories) {
+    if (!report.recoveryCategories.includes(category)) {
+      errors.push(`missing recovery category: ${category}`);
+    }
+  }
+  if (
+    fixture.passCriteria.requiredManualReview &&
+    report.manuallyReviewedOutputs.length === 0
+  ) {
+    errors.push("manuallyReviewedOutputs must include at least one artifact");
+  }
+  return errors;
+}

--- a/packages/lifeops-bench/src/sierra-style-fixtures.ts
+++ b/packages/lifeops-bench/src/sierra-style-fixtures.ts
@@ -1,3 +1,7 @@
+/**
+ * Defines eliza-owned synthetic LifeOps benchmark contracts shaped after public
+ * knowledge and voice-interruption benchmark methodology.
+ */
 import type { LifeWorldDocument } from "./lifeops-fake-backend.js";
 
 export type SierraStyleFailureCategory =


### PR DESCRIPTION
## Summary

- adds eliza-owned synthetic Sierra-style knowledge and voice-interruption fixture contracts under `packages/lifeops-bench`
- adds deterministic backend-state scoring for the knowledge task: calendar event, draft email, and reminder end state
- adds a voice fixture/report contract covering interruption recovery, background noise, dropped frames, auth-code/email/name spelling, pass@1, recovery categories, and manual-review artifacts
- documents the no-Sierra-data boundary and the real-run evidence boundary

## Evidence

- `bunx vitest run packages/lifeops-bench/src/__tests__/sierra-style-fixtures.test.ts --config packages/lifeops-bench/vitest.config.ts` -> 1 file, 3 tests passed
- `bunx @biomejs/biome check packages/lifeops-bench/src/sierra-style-fixtures.ts packages/lifeops-bench/src/__tests__/sierra-style-fixtures.test.ts packages/lifeops-bench/src/README.md` -> clean
- `bunx tsc --ignoreConfig --noEmit --strict --target ES2022 --module ESNext --moduleResolution bundler --skipLibCheck --types node packages/lifeops-bench/src/sierra-style-fixtures.ts packages/lifeops-bench/src/__tests__/sierra-style-fixtures.test.ts` -> clean
- `git diff --check` -> clean

## Typecheck Note

`bun run --cwd packages/lifeops-bench typecheck` is currently blocked in this checkout by pre-existing unresolved workspace/provider imports outside the new fixture files: `@elizaos/auth/*`, `@elizaos/vault`, `@elizaos/agent`, `@elizaos/plugin-groq`, `@elizaos/plugin-openai`, and `@elizaos/plugin-anthropic`.

Closes #13361.
