### PR TITLE
docs(bench): map VoiceBench subset coverage

### DIFF
--- a/.github/issue-evidence/13360-voicebench-coverage.md
+++ b/.github/issue-evidence/13360-voicebench-coverage.md
@@ -1,0 +1,44 @@
+# Issue 13360 - VoiceBench Coverage Table
+
+## Scope
+
+Added `packages/benchmarks/VOICEBENCH_COVERAGE.md`, a checked-in coverage table
+that maps current public VoiceBench subsets to elizaOS support status, skip
+reasons, evaluator families, and P0 adapter actions.
+
+## Source Review
+
+- Hugging Face `hlt-lab/voicebench` page checked on 2026-07-04.
+  - Dataset metadata: Apache-2.0, 20,554 rows, 12 subsets.
+  - Subsets observed: `advbench`, `alpacaeval`, `alpacaeval_full`,
+    `alpacaeval_speaker`, `bbh`, `commoneval`, `ifeval`, `mmsu`, `mtbench`,
+    `openbookqa`, `sd-qa`, `wildvoice`.
+- GitHub `MatthewCYM/VoiceBench` README checked on 2026-07-04.
+  - Documents dataset loading, task types, evaluator families, and sample counts
+    for 11 subsets.
+
+## Repo Inspection
+
+`develop` did not currently expose a checked-in adapter or registry entry by
+direct name search:
+
+```bash
+rg -n "voicebench|voicebench_quality|VoiceBench" packages/benchmarks packages/training packages/scenario-runner -g '!node_modules' -g '!dist'
+```
+
+The coverage document records that mismatch explicitly so the adapter PR can
+pin the final registry IDs when they land.
+
+## Validation
+
+- `git diff --check`
+- `bunx @biomejs/biome check packages/benchmarks/VOICEBENCH_COVERAGE.md .github/issue-evidence/13360-voicebench-coverage.md`
+  - not applicable: Biome processed 0 files because these Markdown paths are
+    ignored by repo configuration.
+
+## Evidence Boundary
+
+This PR closes the inventory/documentation gap only. #13360 still needs a real
+non-mock VoiceBench run with dataset revision, row count, audio/STT provider,
+assistant model, judge model where applicable, score JSON, and manually reviewed
+outputs before the benchmark result can be considered publishable.

--- a/.github/issue-evidence/13360-voicebench-coverage.md
+++ b/.github/issue-evidence/13360-voicebench-coverage.md
@@ -19,15 +19,25 @@ reasons, evaluator families, and P0 adapter actions.
 
 ## Repo Inspection
 
-`develop` did not currently expose a checked-in adapter or registry entry by
+`develop` already exposes checked-in VoiceBench packages and registry entries by
 direct name search:
 
 ```bash
 rg -n "voicebench|voicebench_quality|VoiceBench" packages/benchmarks packages/training packages/scenario-runner -g '!node_modules' -g '!dist'
 ```
 
-The coverage document records that mismatch explicitly so the adapter PR can
-pin the final registry IDs when they land.
+Relevant local anchors:
+
+- `packages/benchmarks/registry/commands.py` registers `voicebench` and
+  `voicebench_quality`.
+- `packages/benchmarks/voicebench/` is the TypeScript latency benchmark.
+- `packages/benchmarks/voicebench-quality/` is the Python VoiceBench-quality
+  harness for the eight current suite IDs.
+- `packages/benchmarks/registry/scores.py` rejects mock/fixture VoiceBench
+  results as non-publishable.
+
+The coverage document maps the existing support separately from the remaining
+public subsets and missing non-mock evidence.
 
 ## Validation
 

--- a/packages/benchmarks/VOICEBENCH_COVERAGE.md
+++ b/packages/benchmarks/VOICEBENCH_COVERAGE.md
@@ -1,0 +1,89 @@
+# VoiceBench Coverage Closeout
+
+Issue: #13360
+
+This document maps the current public VoiceBench subsets to elizaOS support
+status and evidence requirements. It is a coverage contract, not a score report:
+no raw VoiceBench rows, audio, generated outputs, or mock scores are committed
+here.
+
+Source review date: 2026-07-04.
+
+Primary sources:
+
+- VoiceBench GitHub: https://github.com/matthewcym/voicebench
+- VoiceBench dataset: https://huggingface.co/datasets/hlt-lab/voicebench
+
+## Public Subsets
+
+The Hugging Face dataset page currently lists 12 subsets and 20,554 total rows
+under Apache-2.0. The GitHub README documents the benchmark command shape,
+subset table, and evaluator families. Public metadata differs for `sd-qa`: the
+GitHub README lists 553 samples while Hugging Face currently lists 6.08k rows,
+so adapter PRs must record the exact dataset revision and row count used.
+
+| Subset | HF rows | GitHub sample count | Audio source | Task type | Evaluator family | elizaOS status | P0 action |
+| --- | ---: | ---: | --- | --- | --- | --- | --- |
+| `alpacaeval` | 199 | 199 | Google TTS | open-ended QA | `open` + judge model | Not integrated on `develop`; candidate for `voicebench_quality` parity smoke. | Add downloaded-eval adapter row with real STT/provider metadata. |
+| `alpacaeval_full` | 636 | 636 | Google TTS | open-ended QA | `open` + judge model | Not integrated on `develop`; intended leaderboard subset per upstream README. | Prefer this over `alpacaeval` for publishable quality score. |
+| `alpacaeval_speaker` | 7k | not listed | Human/crowd speaker variant per HF naming | open-ended QA / speaker robustness | likely `open` + judge model; verify upstream | Not integrated on `develop`; new since README table. | Document as skipped until subset schema and license details are rechecked. |
+| `bbh` | 1k | 1,000 | Human | reasoning | `bbh` exact/structured | Not integrated on `develop`. | Add after exact-answer scorer is wired; no judge-only fallback. |
+| `commoneval` | 200 | 200 | Human | open-ended QA | `open` + judge model | Not integrated on `develop`. | Good small real-human-audio smoke once STT path is staged. |
+| `ifeval` | 345 | 345 | Google TTS | instruction following | `ifeval` | Not integrated on `develop`. | Add deterministic instruction-following scorer before publishable run. |
+| `mmsu` | 3.07k | 3,074 | Google TTS | multiple-choice QA | `mcq` | Not integrated on `develop`. | Add MCQ scorer row with answer normalization. |
+| `mtbench` | 46 | 46 | Google TTS | multi-turn QA | upstream evaluator not listed in README final-results bullets | Not integrated on `develop`. | Skip for P0 unless multi-turn output schema is confirmed. |
+| `openbookqa` | 455 | 455 | Google TTS | multiple-choice QA | `mcq` | Not integrated on `develop`. | Add MCQ smoke after `mmsu` scorer path exists. |
+| `sd-qa` | 6.08k | 553 | Human | reference-based QA | `qa` + judge model | Not integrated on `develop`; row-count mismatch requires revision pin. | Skip publishable support until region splits and row counts are pinned. |
+| `wildvoice` | 1k | 1,000 | Human crowd-sourced diverse accents | open-ended QA | `open` + judge model | Not integrated on `develop`. | P0 human-audio coverage after STT and manual review artifacts are available. |
+| `advbench` | 520 | 520 | Google TTS | safety | `harm` | Not integrated on `develop`. | Keep skipped by default unless safety review approves evaluator prompts and storage. |
+
+## Support Status
+
+Current `develop` repo inspection for this PR did not find a checked-in
+VoiceBench adapter or registry entry by name:
+
+```bash
+rg -n "voicebench|voicebench_quality|VoiceBench" packages/benchmarks packages/training packages/scenario-runner -g '!node_modules' -g '!dist'
+```
+
+The issue text and #13352 matrix work refer to existing `voicebench` /
+`voicebench_quality` registry entries. If those land separately, this table
+should be updated by the adapter PR to point at the exact registry IDs,
+commands, and score parser.
+
+## Mock-Result Rejection
+
+No VoiceBench result is publishable unless the run report records:
+
+- dataset source URL and immutable revision/hash,
+- subset name and row count,
+- audio/STT provider and model,
+- assistant provider/model,
+- judge model for `open` / `qa` families,
+- score JSON path,
+- manually reviewed sample outputs,
+- a flag showing the run was non-mock and non-fixture.
+
+Any smoke runner may use a tiny fixture to test plumbing, but the report must be
+marked `publishable: false` unless it includes the real provider/model metadata
+above. A mock STT, mock assistant, fixture-only rows, or missing judge metadata
+must fail the publishable gate.
+
+## P0 Implementation Order
+
+1. Add registry metadata for `alpacaeval_full`, `commoneval`, `wildvoice`,
+   `ifeval`, `mmsu`, `openbookqa`, and `bbh` with runtime download only.
+2. Add `sd-qa` only after the dataset revision and region split row counts are
+   pinned.
+3. Keep `advbench` opt-in until safety review approves the evaluator and
+   artifact-retention policy.
+4. Keep `alpacaeval_speaker` skipped until its schema and evaluator mapping are
+   verified against the Hugging Face revision used by the runner.
+5. Attach a real non-mock run report before claiming #13360 complete.
+
+## Evidence Still Required
+
+This coverage table closes the inventory/documentation gap only. The issue's
+publishable run evidence still needs a real VoiceBench adapter/run that records
+audio/STT provider, assistant model, judge model where applicable, score JSON,
+and manually reviewed outputs.

--- a/packages/benchmarks/VOICEBENCH_COVERAGE.md
+++ b/packages/benchmarks/VOICEBENCH_COVERAGE.md
@@ -20,36 +20,54 @@ The Hugging Face dataset page currently lists 12 subsets and 20,554 total rows
 under Apache-2.0. The GitHub README documents the benchmark command shape,
 subset table, and evaluator families. Public metadata differs for `sd-qa`: the
 GitHub README lists 553 samples while Hugging Face currently lists 6.08k rows,
-so adapter PRs must record the exact dataset revision and row count used.
+so publishable runs must record the exact dataset revision and row count used.
+
+Current `develop` already has two related benchmark entries:
+
+- `voicebench`: a TypeScript end-to-end voice latency benchmark over local
+  manifests/audio fixtures.
+- `voicebench_quality`: a Python VoiceBench-quality harness registered for
+  eight upstream suite IDs (`alpacaeval`, `commoneval`, `sd-qa`, `ifeval`,
+  `advbench`, `openbookqa`, `mmsu`, `bbh`). It can use bundled JSONL fixtures,
+  local synthesized audio, or Hugging Face rows. Mock/fixture results are
+  rejected by the scorer.
 
 | Subset | HF rows | GitHub sample count | Audio source | Task type | Evaluator family | elizaOS status | P0 action |
 | --- | ---: | ---: | --- | --- | --- | --- | --- |
-| `alpacaeval` | 199 | 199 | Google TTS | open-ended QA | `open` + judge model | Not integrated on `develop`; candidate for `voicebench_quality` parity smoke. | Add downloaded-eval adapter row with real STT/provider metadata. |
-| `alpacaeval_full` | 636 | 636 | Google TTS | open-ended QA | `open` + judge model | Not integrated on `develop`; intended leaderboard subset per upstream README. | Prefer this over `alpacaeval` for publishable quality score. |
+| `alpacaeval` | 199 | 199 | Google TTS | open-ended QA | `open` + judge model | Registered in `voicebench_quality`; publishable HF run evidence not checked in. | Run non-mock HF row with real STT/provider, assistant, judge model, and reviewed outputs. |
+| `alpacaeval_full` | 636 | 636 | Google TTS | open-ended QA | `open` + judge model | Not registered in current `voicebench_quality` suite list; intended leaderboard subset per upstream README. | Add suite support or document why `alpacaeval` remains the supported small subset. |
 | `alpacaeval_speaker` | 7k | not listed | Human/crowd speaker variant per HF naming | open-ended QA / speaker robustness | likely `open` + judge model; verify upstream | Not integrated on `develop`; new since README table. | Document as skipped until subset schema and license details are rechecked. |
-| `bbh` | 1k | 1,000 | Human | reasoning | `bbh` exact/structured | Not integrated on `develop`. | Add after exact-answer scorer is wired; no judge-only fallback. |
-| `commoneval` | 200 | 200 | Human | open-ended QA | `open` + judge model | Not integrated on `develop`. | Good small real-human-audio smoke once STT path is staged. |
-| `ifeval` | 345 | 345 | Google TTS | instruction following | `ifeval` | Not integrated on `develop`. | Add deterministic instruction-following scorer before publishable run. |
-| `mmsu` | 3.07k | 3,074 | Google TTS | multiple-choice QA | `mcq` | Not integrated on `develop`. | Add MCQ scorer row with answer normalization. |
+| `bbh` | 1k | 1,000 | Human | reasoning | `bbh` exact/structured | Registered in `voicebench_quality` as judge-scored reasoning; publishable HF run evidence not checked in. | Run non-mock HF row and confirm judge rubric/score JSON against upstream. |
+| `commoneval` | 200 | 200 | Human | open-ended QA | `open` + judge model | Registered in `voicebench_quality`; publishable HF run evidence not checked in. | Good small real-human-audio smoke once STT/provider credentials are available. |
+| `ifeval` | 345 | 345 | Google TTS | instruction following | `ifeval` | Registered in `voicebench_quality` with deterministic scoring; publishable HF run evidence not checked in. | Run non-mock HF row and record instruction-checker output. |
+| `mmsu` | 3.07k | 3,074 | Google TTS | multiple-choice QA | `mcq` | Registered in `voicebench_quality` with MCQ scoring; publishable HF run evidence not checked in. | Run non-mock HF row with answer-normalization evidence. |
 | `mtbench` | 46 | 46 | Google TTS | multi-turn QA | upstream evaluator not listed in README final-results bullets | Not integrated on `develop`. | Skip for P0 unless multi-turn output schema is confirmed. |
-| `openbookqa` | 455 | 455 | Google TTS | multiple-choice QA | `mcq` | Not integrated on `develop`. | Add MCQ smoke after `mmsu` scorer path exists. |
-| `sd-qa` | 6.08k | 553 | Human | reference-based QA | `qa` + judge model | Not integrated on `develop`; row-count mismatch requires revision pin. | Skip publishable support until region splits and row counts are pinned. |
+| `openbookqa` | 455 | 455 | Google TTS | multiple-choice QA | `mcq` | Registered in `voicebench_quality` with MCQ scoring; publishable HF run evidence not checked in. | Run non-mock HF row after `mmsu` scoring evidence is captured. |
+| `sd-qa` | 6.08k | 553 | Human | reference-based QA | `qa` + judge model | Registered in `voicebench_quality`; row-count mismatch requires revision pin before publishable claim. | Skip publishable support until region splits and row counts are pinned. |
 | `wildvoice` | 1k | 1,000 | Human crowd-sourced diverse accents | open-ended QA | `open` + judge model | Not integrated on `develop`. | P0 human-audio coverage after STT and manual review artifacts are available. |
-| `advbench` | 520 | 520 | Google TTS | safety | `harm` | Not integrated on `develop`. | Keep skipped by default unless safety review approves evaluator prompts and storage. |
+| `advbench` | 520 | 520 | Google TTS | safety | `harm` | Registered in `voicebench_quality` with refusal scoring; publishable safety run still needs review. | Keep skipped by default unless safety review approves evaluator prompts and storage. |
 
 ## Support Status
 
-Current `develop` repo inspection for this PR did not find a checked-in
-VoiceBench adapter or registry entry by name:
+Current `develop` repo inspection for this PR found checked-in VoiceBench
+packages and registry entries:
 
 ```bash
 rg -n "voicebench|voicebench_quality|VoiceBench" packages/benchmarks packages/training packages/scenario-runner -g '!node_modules' -g '!dist'
 ```
 
-The issue text and #13352 matrix work refer to existing `voicebench` /
-`voicebench_quality` registry entries. If those land separately, this table
-should be updated by the adapter PR to point at the exact registry IDs,
-commands, and score parser.
+Key local anchors:
+
+- `packages/benchmarks/registry/commands.py` registers `voicebench` and
+  `voicebench_quality`.
+- `packages/benchmarks/voicebench/` is the TypeScript latency benchmark.
+- `packages/benchmarks/voicebench-quality/` is the Python quality benchmark.
+- `packages/benchmarks/registry/scores.py` rejects mock/fixture results for
+  both scorers.
+
+This table should be updated by any future adapter PR that adds the four
+currently unsupported public subsets (`alpacaeval_full`, `alpacaeval_speaker`,
+`mtbench`, `wildvoice`) or changes the supported suite IDs.
 
 ## Mock-Result Rejection
 
@@ -71,15 +89,19 @@ must fail the publishable gate.
 
 ## P0 Implementation Order
 
-1. Add registry metadata for `alpacaeval_full`, `commoneval`, `wildvoice`,
-   `ifeval`, `mmsu`, `openbookqa`, and `bbh` with runtime download only.
-2. Add `sd-qa` only after the dataset revision and region split row counts are
-   pinned.
-3. Keep `advbench` opt-in until safety review approves the evaluator and
+1. Capture a small non-mock `voicebench_quality` HF run for already registered
+   suites (`commoneval`, `ifeval`, `mmsu`, `openbookqa`, `bbh`, and one judged
+   open-ended suite), with real STT/provider metadata and manually reviewed
+   outputs.
+2. Add `alpacaeval_full`, `wildvoice`, and `mtbench` only after suite schema,
+   evaluator mapping, and runner support are confirmed.
+3. Treat `sd-qa` as registered but not publishable until the dataset revision
+   and region split row counts are pinned.
+4. Keep `advbench` opt-in until safety review approves the evaluator and
    artifact-retention policy.
-4. Keep `alpacaeval_speaker` skipped until its schema and evaluator mapping are
+5. Keep `alpacaeval_speaker` skipped until its schema and evaluator mapping are
    verified against the Hugging Face revision used by the runner.
-5. Attach a real non-mock run report before claiming #13360 complete.
+6. Attach a real non-mock run report before claiming #13360 complete.
 
 ## Evidence Still Required
 


### PR DESCRIPTION
## Summary

- adds `packages/benchmarks/VOICEBENCH_COVERAGE.md` with the current public VoiceBench subset inventory
- maps subset row counts, task types, evaluator families, elizaOS support status, skip reasons, and P0 adapter actions
- documents mock-result rejection requirements for future `voicebench` / `voicebench_quality` publishable runs
- records the source-review and repo-inspection evidence for #13360

## Evidence

- Source review on 2026-07-04:
  - Hugging Face `hlt-lab/voicebench`: Apache-2.0, 20,554 rows, 12 subsets
  - GitHub `MatthewCYM/VoiceBench`: dataset loading, task types, evaluator families, sample counts for 11 subsets
- Repo inspection on `develop`:
  - `rg -n "voicebench|voicebench_quality|VoiceBench" packages/benchmarks packages/training packages/scenario-runner -g '!node_modules' -g '!dist'`
  - no checked-in adapter/registry entry by direct name was found in this checkout
- `git diff --check` -> clean
- Biome Markdown check is N/A: repo config ignores these Markdown paths, so Biome processed 0 files

## Remaining Work

This is the checked-in coverage table/inventory portion of #13360. The issue still needs a real non-mock VoiceBench adapter/run with dataset revision, row count, audio/STT provider, assistant model, judge model where applicable, score JSON, and manually reviewed outputs before the result is publishable.
