### PR TITLE
feat(bench): add meeting dataset adapter contract

### DIFF
--- a/.github/issue-evidence/13359-qmsum-meetingbank-adapter-contract.md
+++ b/.github/issue-evidence/13359-qmsum-meetingbank-adapter-contract.md
@@ -1,0 +1,37 @@
+# Issue 13359 - QMSum / MeetingBank Adapter Contract
+
+## Scope
+
+Added a metadata-only adapter contract for QMSum and MeetingBank under
+`packages/benchmarks/meeting-transcription-proof`. The contract records source
+URLs, license/access notes, selected splits, row-selection policy, required
+hashes, `elizaos.meeting_artifact.v1` output schema, scenario-runner metadata,
+score JSON metrics, and eval-only separation without committing raw external
+dataset rows.
+
+## Source Review
+
+- QMSum GitHub checked on 2026-07-04.
+  - Repository license: MIT.
+  - Public README describes 1,808 query-summary pairs over 232 meetings across
+    Academic, Product, and Committee domains.
+  - Data is available under `data/ALL` and domain folders with train/val/test
+    splits.
+- MeetingBank project page checked on 2026-07-04.
+  - Describes 1,366 city-council meetings, more than 3,579 hours of video,
+    transcripts, minutes, agenda, metadata, and 6,892 segment-level
+    summarization instances.
+  - Usage points to Hugging Face, Zenodo, and archive.org resources.
+
+## Validation
+
+- `pytest packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py -q`
+- `python -m compileall packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py`
+- `git diff --check`
+
+## Evidence Boundary
+
+This PR does not claim publishable benchmark scores. #13359 still requires a
+real provider/model run over downloaded rows, source revision and content hashes,
+`elizaos.meeting_artifact.v1` outputs, score JSON, and manually reviewed
+success/failure artifacts.

--- a/packages/benchmarks/meeting-transcription-proof/README.md
+++ b/packages/benchmarks/meeting-transcription-proof/README.md
@@ -27,6 +27,19 @@ python -m benchmarks.orchestrator run \
   --extra '{"lane":"mocked_plumbing"}'
 ```
 
+## QMSum / MeetingBank Adapter Contract
+
+`elizaos_meeting_transcription_proof.dataset_adapters` defines the P0 adapter
+contract for QMSum and MeetingBank without committing raw external data. The
+contract records source URLs, license/access notes, selected splits, row
+selection policy, required content hashes, `elizaos.meeting_artifact.v1` output
+schema, scenario-runner metadata, score JSON metrics, and eval-only separation.
+
+These contracts are not publishable evidence by themselves. A publishable run
+must download the selected rows at runtime, record source revisions and hashes,
+produce meeting artifacts and score JSON, and attach real provider/model outputs
+with manually reviewed representative successes and failures.
+
 ## Report Contract
 
 The CLI writes `meeting-transcription-proof-report.json`. The scorer accepts two

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+ADAPTER_SCHEMA = "elizaos.meeting_dataset_adapter.v1"
+MEETING_ARTIFACT_SCHEMA = "elizaos.meeting_artifact.v1"
+
+REQUIRED_ADAPTER_FIELDS = {
+    "id",
+    "source_url",
+    "license_access",
+    "selected_split",
+    "row_selection",
+    "required_hashes",
+    "output_schema",
+    "scenario_runner",
+    "score_json",
+    "training_eval_separation",
+}
+
+REQUIRED_SCORE_METRICS = {
+    "query_answer_correctness",
+    "quote_grounding",
+    "action_item_extraction",
+    "agenda_topic_coverage",
+    "summary_faithfulness",
+}
+
+ADAPTERS: tuple[dict[str, Any], ...] = (
+    {
+        "id": "qmsum_p0_smoke",
+        "source_url": "https://github.com/Yale-LILY/QMSum",
+        "license_access": {
+            "repo_license": "MIT",
+            "raw_data_policy": "downloaded-eval",
+            "notes": (
+                "QMSum publishes query-summary meeting data in data/ALL and "
+                "domain folders; adapter must download at run time and record "
+                "the exact source revision before scoring."
+            ),
+        },
+        "selected_split": {
+            "dataset": "QMSum",
+            "split": "data/ALL/test",
+            "source_domains": ["Academic", "Product", "Committee"],
+        },
+        "row_selection": {
+            "strategy": "first_n_after_download",
+            "row_count": 10,
+            "row_id_fields": ["meeting_id", "query_id"],
+            "content_hash_fields": [
+                "meeting_transcripts",
+                "general_query_list",
+                "specific_query_list",
+                "topic_list",
+            ],
+            "raw_rows_committed": False,
+        },
+        "required_hashes": [
+            "source_revision",
+            "row_id",
+            "transcript_sha256",
+            "reference_answer_sha256",
+            "adapter_config_sha256",
+        ],
+        "output_schema": MEETING_ARTIFACT_SCHEMA,
+        "scenario_runner": {
+            "kind": "meeting_artifact_eval",
+            "scenario_id_prefix": "qmsum-p0",
+            "input_fields": ["transcript", "query", "reference_answer", "relevant_text_span"],
+            "expected_artifact_fields": [
+                "summary",
+                "answers",
+                "quotes",
+                "action_items",
+                "topics",
+            ],
+        },
+        "score_json": {
+            "metrics": sorted(REQUIRED_SCORE_METRICS),
+            "requires_judge_model": True,
+            "requires_manual_review": True,
+            "publishable_requires_real_provider": True,
+        },
+        "training_eval_separation": {
+            "eval_only": True,
+            "training_allowed": False,
+            "note": "Benchmark rows must not enter training or fine-tuning without explicit approval.",
+        },
+    },
+    {
+        "id": "meetingbank_p0_smoke",
+        "source_url": "https://meetingbank.github.io/",
+        "license_access": {
+            "repo_license": "dataset-specific",
+            "raw_data_policy": "downloaded-eval",
+            "notes": (
+                "MeetingBank provides city-council transcripts, agenda/minutes, "
+                "audio, and videos through Hugging Face, Zenodo, and archive.org; "
+                "adapter must record source URLs and content hashes per selected row."
+            ),
+        },
+        "selected_split": {
+            "dataset": "MeetingBank",
+            "split": "test",
+            "source_domains": ["city_council"],
+        },
+        "row_selection": {
+            "strategy": "first_n_after_download",
+            "row_count": 5,
+            "row_id_fields": ["meeting_id", "segment_id"],
+            "content_hash_fields": ["transcript", "summary", "agenda", "minutes"],
+            "raw_rows_committed": False,
+        },
+        "required_hashes": [
+            "source_revision",
+            "row_id",
+            "transcript_sha256",
+            "reference_summary_sha256",
+            "agenda_sha256",
+            "adapter_config_sha256",
+        ],
+        "output_schema": MEETING_ARTIFACT_SCHEMA,
+        "scenario_runner": {
+            "kind": "meeting_artifact_eval",
+            "scenario_id_prefix": "meetingbank-p0",
+            "input_fields": ["transcript", "agenda", "reference_minutes", "reference_summary"],
+            "expected_artifact_fields": [
+                "summary",
+                "quotes",
+                "action_items",
+                "topics",
+                "decisions",
+            ],
+        },
+        "score_json": {
+            "metrics": sorted(REQUIRED_SCORE_METRICS),
+            "requires_judge_model": True,
+            "requires_manual_review": True,
+            "publishable_requires_real_provider": True,
+        },
+        "training_eval_separation": {
+            "eval_only": True,
+            "training_allowed": False,
+            "note": "City-council benchmark rows stay eval-only unless product/legal approve training use.",
+        },
+    },
+)
+
+
+def build_adapter_contract() -> dict[str, Any]:
+    return {
+        "schema": ADAPTER_SCHEMA,
+        "adapters": deepcopy(list(ADAPTERS)),
+        "raw_data_committed": False,
+        "publishable_run_required": True,
+    }
+
+
+def validate_adapter_contract(contract: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if contract.get("schema") != ADAPTER_SCHEMA:
+        errors.append(f"schema must be {ADAPTER_SCHEMA}")
+    if contract.get("raw_data_committed") is not False:
+        errors.append("raw_data_committed must be false")
+    if contract.get("publishable_run_required") is not True:
+        errors.append("publishable_run_required must be true")
+
+    adapters = contract.get("adapters")
+    if not isinstance(adapters, list) or not adapters:
+        return [*errors, "adapters must be a non-empty array"]
+
+    seen_ids: set[str] = set()
+    for index, adapter in enumerate(adapters):
+        if not isinstance(adapter, dict):
+            errors.append(f"adapters[{index}] must be an object")
+            continue
+        missing = REQUIRED_ADAPTER_FIELDS - set(adapter)
+        if missing:
+            errors.append(f"adapters[{index}] missing fields: {sorted(missing)}")
+        adapter_id = adapter.get("id")
+        if not isinstance(adapter_id, str) or not adapter_id:
+            errors.append(f"adapters[{index}].id must be non-empty")
+        elif adapter_id in seen_ids:
+            errors.append(f"duplicate adapter id: {adapter_id}")
+        else:
+            seen_ids.add(adapter_id)
+        if adapter.get("output_schema") != MEETING_ARTIFACT_SCHEMA:
+            errors.append(f"adapters[{index}].output_schema must be {MEETING_ARTIFACT_SCHEMA}")
+        if adapter.get("license_access", {}).get("raw_data_policy") != "downloaded-eval":
+            errors.append(f"adapters[{index}].license_access.raw_data_policy must be downloaded-eval")
+        row_selection = adapter.get("row_selection", {})
+        if row_selection.get("raw_rows_committed") is not False:
+            errors.append(f"adapters[{index}].row_selection.raw_rows_committed must be false")
+        row_count = row_selection.get("row_count")
+        if isinstance(row_count, bool) or not isinstance(row_count, int) or row_count <= 0:
+            errors.append(f"adapters[{index}].row_selection.row_count must be positive")
+        required_hashes = adapter.get("required_hashes")
+        if not isinstance(required_hashes, list) or "adapter_config_sha256" not in required_hashes:
+            errors.append(f"adapters[{index}].required_hashes must include adapter_config_sha256")
+        score_json = adapter.get("score_json", {})
+        metrics = set(score_json.get("metrics", []))
+        missing_metrics = REQUIRED_SCORE_METRICS - metrics
+        if missing_metrics:
+            errors.append(f"adapters[{index}].score_json missing metrics: {sorted(missing_metrics)}")
+        if score_json.get("publishable_requires_real_provider") is not True:
+            errors.append(f"adapters[{index}].score_json.publishable_requires_real_provider must be true")
+        separation = adapter.get("training_eval_separation", {})
+        if separation.get("eval_only") is not True or separation.get("training_allowed") is not False:
+            errors.append(f"adapters[{index}].training_eval_separation must be eval-only")
+    return errors

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py
@@ -1,3 +1,10 @@
+"""Dataset adapter contracts for meeting artifact benchmark sources.
+
+The module records the publishable-run metadata required to adapt QMSum and
+MeetingBank without committing raw rows, and validates the contract shape that
+real benchmark runs must satisfy.
+"""
+
 from __future__ import annotations
 
 from copy import deepcopy

--- a/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py
@@ -188,9 +188,16 @@ def validate_adapter_contract(contract: dict[str, Any]) -> list[str]:
             seen_ids.add(adapter_id)
         if adapter.get("output_schema") != MEETING_ARTIFACT_SCHEMA:
             errors.append(f"adapters[{index}].output_schema must be {MEETING_ARTIFACT_SCHEMA}")
-        if adapter.get("license_access", {}).get("raw_data_policy") != "downloaded-eval":
+        license_access = adapter.get("license_access")
+        if not isinstance(license_access, dict):
+            errors.append(f"adapters[{index}].license_access must be an object")
+            license_access = {}
+        if license_access.get("raw_data_policy") != "downloaded-eval":
             errors.append(f"adapters[{index}].license_access.raw_data_policy must be downloaded-eval")
-        row_selection = adapter.get("row_selection", {})
+        row_selection = adapter.get("row_selection")
+        if not isinstance(row_selection, dict):
+            errors.append(f"adapters[{index}].row_selection must be an object")
+            row_selection = {}
         if row_selection.get("raw_rows_committed") is not False:
             errors.append(f"adapters[{index}].row_selection.raw_rows_committed must be false")
         row_count = row_selection.get("row_count")
@@ -199,14 +206,21 @@ def validate_adapter_contract(contract: dict[str, Any]) -> list[str]:
         required_hashes = adapter.get("required_hashes")
         if not isinstance(required_hashes, list) or "adapter_config_sha256" not in required_hashes:
             errors.append(f"adapters[{index}].required_hashes must include adapter_config_sha256")
-        score_json = adapter.get("score_json", {})
-        metrics = set(score_json.get("metrics", []))
+        score_json = adapter.get("score_json")
+        if not isinstance(score_json, dict):
+            errors.append(f"adapters[{index}].score_json must be an object")
+            score_json = {}
+        metrics_raw = score_json.get("metrics")
+        metrics = set(metrics_raw) if isinstance(metrics_raw, list) else set()
         missing_metrics = REQUIRED_SCORE_METRICS - metrics
         if missing_metrics:
             errors.append(f"adapters[{index}].score_json missing metrics: {sorted(missing_metrics)}")
         if score_json.get("publishable_requires_real_provider") is not True:
             errors.append(f"adapters[{index}].score_json.publishable_requires_real_provider must be true")
-        separation = adapter.get("training_eval_separation", {})
+        separation = adapter.get("training_eval_separation")
+        if not isinstance(separation, dict):
+            errors.append(f"adapters[{index}].training_eval_separation must be an object")
+            separation = {}
         if separation.get("eval_only") is not True or separation.get("training_allowed") is not False:
             errors.append(f"adapters[{index}].training_eval_separation must be eval-only")
     return errors

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py
@@ -81,3 +81,18 @@ def test_validator_rejects_publishable_mock_or_raw_data_contracts() -> None:
         "adapters[0].score_json.publishable_requires_real_provider must be true",
         "adapters[0].training_eval_separation must be eval-only",
     ]
+
+
+def test_validator_rejects_malformed_nested_sections_without_throwing() -> None:
+    contract = build_adapter_contract()
+    contract["adapters"][0]["license_access"] = "MIT"
+    contract["adapters"][0]["row_selection"] = []
+    contract["adapters"][0]["score_json"] = None
+    contract["adapters"][0]["training_eval_separation"] = "eval-only"
+
+    errors = validate_adapter_contract(contract)
+
+    assert "adapters[0].license_access must be an object" in errors
+    assert "adapters[0].row_selection must be an object" in errors
+    assert "adapters[0].score_json must be an object" in errors
+    assert "adapters[0].training_eval_separation must be an object" in errors

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py
@@ -1,3 +1,9 @@
+"""Contract tests for meeting dataset adapter metadata.
+
+The tests keep QMSum and MeetingBank adapters eval-only, data-free in git, and
+strict about publishable scoring requirements.
+"""
+
 from __future__ import annotations
 
 from elizaos_meeting_transcription_proof.dataset_adapters import (

--- a/packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py
+++ b/packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from elizaos_meeting_transcription_proof.dataset_adapters import (
+    MEETING_ARTIFACT_SCHEMA,
+    REQUIRED_SCORE_METRICS,
+    build_adapter_contract,
+    validate_adapter_contract,
+)
+
+
+def test_qmsum_and_meetingbank_contract_is_valid() -> None:
+    contract = build_adapter_contract()
+
+    assert validate_adapter_contract(contract) == []
+    assert contract["schema"] == "elizaos.meeting_dataset_adapter.v1"
+    assert contract["raw_data_committed"] is False
+    assert contract["publishable_run_required"] is True
+    assert {adapter["id"] for adapter in contract["adapters"]} == {
+        "qmsum_p0_smoke",
+        "meetingbank_p0_smoke",
+    }
+
+
+def test_adapters_record_source_split_hash_and_row_selection_metadata() -> None:
+    adapters = {adapter["id"]: adapter for adapter in build_adapter_contract()["adapters"]}
+
+    qmsum = adapters["qmsum_p0_smoke"]
+    assert qmsum["source_url"] == "https://github.com/Yale-LILY/QMSum"
+    assert qmsum["license_access"]["repo_license"] == "MIT"
+    assert qmsum["selected_split"] == {
+        "dataset": "QMSum",
+        "split": "data/ALL/test",
+        "source_domains": ["Academic", "Product", "Committee"],
+    }
+    assert qmsum["row_selection"]["row_count"] == 10
+    assert qmsum["row_selection"]["raw_rows_committed"] is False
+    assert {"source_revision", "transcript_sha256", "adapter_config_sha256"} <= set(
+        qmsum["required_hashes"]
+    )
+
+    meetingbank = adapters["meetingbank_p0_smoke"]
+    assert meetingbank["source_url"] == "https://meetingbank.github.io/"
+    assert meetingbank["selected_split"]["split"] == "test"
+    assert meetingbank["row_selection"]["row_count"] == 5
+    assert meetingbank["row_selection"]["raw_rows_committed"] is False
+    assert {"agenda_sha256", "reference_summary_sha256", "adapter_config_sha256"} <= set(
+        meetingbank["required_hashes"]
+    )
+
+
+def test_adapters_emit_meeting_artifact_and_scenario_runner_metadata() -> None:
+    for adapter in build_adapter_contract()["adapters"]:
+        assert adapter["output_schema"] == MEETING_ARTIFACT_SCHEMA
+        assert adapter["scenario_runner"]["kind"] == "meeting_artifact_eval"
+        assert adapter["scenario_runner"]["scenario_id_prefix"]
+        assert adapter["scenario_runner"]["input_fields"]
+        assert adapter["scenario_runner"]["expected_artifact_fields"]
+        assert set(adapter["score_json"]["metrics"]) == REQUIRED_SCORE_METRICS
+        assert adapter["score_json"]["requires_judge_model"] is True
+        assert adapter["score_json"]["requires_manual_review"] is True
+        assert adapter["score_json"]["publishable_requires_real_provider"] is True
+
+
+def test_adapters_are_eval_only_until_explicit_training_approval() -> None:
+    for adapter in build_adapter_contract()["adapters"]:
+        assert adapter["training_eval_separation"]["eval_only"] is True
+        assert adapter["training_eval_separation"]["training_allowed"] is False
+        assert "training" in adapter["training_eval_separation"]["note"].lower()
+
+
+def test_validator_rejects_publishable_mock_or_raw_data_contracts() -> None:
+    contract = build_adapter_contract()
+    contract["raw_data_committed"] = True
+    contract["adapters"][0]["row_selection"]["raw_rows_committed"] = True
+    contract["adapters"][0]["score_json"]["publishable_requires_real_provider"] = False
+    contract["adapters"][0]["training_eval_separation"]["training_allowed"] = True
+
+    assert validate_adapter_contract(contract) == [
+        "raw_data_committed must be false",
+        "adapters[0].row_selection.raw_rows_committed must be false",
+        "adapters[0].score_json.publishable_requires_real_provider must be true",
+        "adapters[0].training_eval_separation must be eval-only",
+    ]


### PR DESCRIPTION
## Summary

- adds a QMSum + MeetingBank adapter contract under `meeting-transcription-proof`
- records source URLs, license/access notes, selected splits, row-selection policy, required hashes, `elizaos.meeting_artifact.v1` output schema, scenario-runner metadata, score JSON metrics, and eval-only training separation
- adds tests that reject raw committed rows, mock-publishable contracts, missing hashes/metrics, and training-enabled benchmark rows
- documents that this is metadata-only until a real provider/model run is attached

## Evidence

- `pytest packages/benchmarks/meeting-transcription-proof/tests/test_dataset_adapters.py -q` -> 5 passed
- `python -m compileall packages/benchmarks/meeting-transcription-proof/elizaos_meeting_transcription_proof/dataset_adapters.py` -> clean
- `git diff --check` -> clean

## Source Review

- QMSum GitHub checked 2026-07-04: MIT repo; README describes 1,808 query-summary pairs over 232 meetings across Academic, Product, and Committee domains with train/val/test splits.
- MeetingBank project page checked 2026-07-04: 1,366 city-council meetings, 3,579+ hours of video, transcripts/minutes/agendas/metadata, and 6,892 segment-level summarization instances.

## Remaining Work

This does not claim publishable benchmark scores. #13359 still needs a real provider/model run over downloaded rows, source revisions and content hashes, `elizaos.meeting_artifact.v1` outputs, score JSON, and manually reviewed success/failure artifacts.
