### PR TITLE
ci(#13373): add All Tests Passed aggregate check

### DIFF
--- a/.github/issue-evidence/13373-all-tests-passed.md
+++ b/.github/issue-evidence/13373-all-tests-passed.md
@@ -1,0 +1,24 @@
+# 13373 All Tests Passed Aggregate
+
+## Change
+
+- Added `.github/workflows/test.yml` job `all-tests-passed` with visible check
+  name `All Tests Passed`.
+- The job depends only on `ci-ok` and fails unless `ci-ok` succeeds, so it
+  inherits the existing non-vacuous aggregate over server, client, XR, plugin,
+  integration, desktop, zero-key, cloud-live, provider-live, and live-artifact
+  validation lanes.
+- Added script contract coverage so the exact check name and dependency on
+  `ci-ok` cannot be removed silently.
+
+## Local Verification
+
+- `bun test packages/scripts/__tests__/test-task-pool.test.ts`
+- `node packages/scripts/ci-workflow-dedup-contract.mjs`
+- `bunx @biomejs/biome check .github/workflows/test.yml packages/scripts/__tests__/test-task-pool.test.ts packages/scripts/ci-workflow-dedup-contract.mjs .github/issue-evidence/13373-all-tests-passed.md`
+- `git diff --check origin/develop...HEAD`
+
+## Follow-Up
+
+After this PR opens, the PR status rollup must show `All Tests Passed` as a real
+GitHub check context before repo admins add it to ruleset `18511808`.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1325,3 +1325,21 @@ jobs:
             exit 1
           fi
           echo "All required test jobs passed. Required develop ruleset check: ci-ok."
+
+  all-tests-passed:
+    name: All Tests Passed
+    if: ${{ !cancelled() && always() }}
+    needs:
+      - ci-ok
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check aggregate test result
+        shell: bash
+        run: |
+          set -u
+          echo "ci-ok: ${{ needs.ci-ok.result }}"
+          if [ "${{ needs.ci-ok.result }}" != "success" ]; then
+            echo "::error title=All Tests Passed::ci-ok finished with '${{ needs.ci-ok.result }}' (expected success)"
+            exit 1
+          fi
+          echo "All required test jobs passed."

--- a/packages/scripts/__tests__/test-task-pool.test.ts
+++ b/packages/scripts/__tests__/test-task-pool.test.ts
@@ -316,6 +316,9 @@ describe("CI plugin sharding contract", () => {
     expect(testWorkflow).toMatch(
       /ci-ok:[\s\S]*?needs:[\s\S]*?-\s+plugin-tests-status/,
     );
+    expect(testWorkflow).toMatch(
+      /all-tests-passed:\s+name:\s+All Tests Passed[\s\S]*?needs:[\s\S]*?-\s+ci-ok/,
+    );
   });
 
   test("Quality workflow gates develop PRs with static scans and lint", () => {

--- a/packages/scripts/ci-workflow-dedup-contract.mjs
+++ b/packages/scripts/ci-workflow-dedup-contract.mjs
@@ -83,10 +83,16 @@ assertDeepEqual(
   ["develop"],
   "test.yml merge queue branches",
 );
+assertIncludes(tests, "name: ci-ok", "test.yml required aggregate status");
 assertIncludes(
   tests,
-  "name: ci-ok",
-  "test.yml required aggregate status",
+  "name: All Tests Passed",
+  "test.yml branch-protection aggregate status",
+);
+assertIncludes(
+  tests,
+  "needs:\n      - ci-ok",
+  "test.yml All Tests Passed depends on ci-ok",
 );
 assertIncludes(
   tests,


### PR DESCRIPTION
## Summary

- Adds a real `All Tests Passed` GitHub check context to `.github/workflows/test.yml`.
- Keeps the existing non-vacuous `ci-ok` aggregate as the source of truth; `All Tests Passed` depends on `ci-ok` and fails unless `ci-ok` succeeds.
- Adds contract coverage so the exact check name and dependency on `ci-ok` cannot be removed silently.

## Validation

- `bun test packages/scripts/__tests__/test-task-pool.test.ts` — 28 pass, 0 fail
- `node packages/scripts/ci-workflow-dedup-contract.mjs` — pass
- `bunx @biomejs/biome check .github/workflows/test.yml packages/scripts/__tests__/test-task-pool.test.ts packages/scripts/ci-workflow-dedup-contract.mjs .github/issue-evidence/13373-all-tests-passed.md` — pass with one pre-existing warning in `ci-workflow-dedup-contract.mjs` about the literal `${GITHUB_EVENT_NAME}` shell string
- `git diff --check origin/develop...HEAD && git diff --check` — pass
- `actionlint .github/workflows/test.yml` attempted; it reports the pre-existing custom self-hosted runner label `hetzner-robot`, not the new aggregate job

## Evidence

- `.github/issue-evidence/13373-all-tests-passed.md`

## Remaining Admin Step

After this PR emits the `All Tests Passed` context in its status rollup, repo admins can add that exact context to ruleset `18511808`.

Closes #13373.
