### PR TITLE
test(#12776): accept promoted resolve-request action names

### DIFF
--- a/plugins/plugin-personal-assistant/test/scenarios/_helpers/approval-outcome.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/_helpers/approval-outcome.ts
@@ -54,7 +54,16 @@ function resultData(
 function resolveRequestCalls(
   ctx: ScenarioContext,
 ): ReadonlyArray<CapturedActionLite> {
-  return ctx.actionsCalled.filter((a) => a.actionName === "RESOLVE_REQUEST");
+  // RESOLVE_REQUEST is registered via `promoteSubactionsToActions`, so a live
+  // model may select the umbrella OR a promoted subaction name
+  // (RESOLVE_REQUEST_APPROVE / RESOLVE_REQUEST_REJECT / ...). All of them run
+  // the same resolver; match the whole family so the outcome predicates read
+  // the decision wherever the router landed it.
+  return ctx.actionsCalled.filter(
+    (a) =>
+      a.actionName === "RESOLVE_REQUEST" ||
+      a.actionName.startsWith("RESOLVE_REQUEST_"),
+  );
 }
 
 function stateOf(action: CapturedActionLite): string {

--- a/plugins/plugin-personal-assistant/test/scenarios/f1-cross-persona-wrong-recipient-highstakes.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/f1-cross-persona-wrong-recipient-highstakes.scenario.ts
@@ -82,14 +82,13 @@ export default scenario({
   ],
   finalChecks: [
     {
+      // RESOLVE_REQUEST is promoted via `promoteSubactionsToActions`, so the
+      // live router may land on the umbrella or a promoted subaction name;
+      // accept the reject-path family. The success + rejected-state outcome is
+      // asserted by the queue-reading predicate below, which matches the same
+      // family.
       type: "selectedAction",
-      actionName: ["RESOLVE_REQUEST"],
-    },
-    {
-      type: "actionCalled",
-      actionName: "RESOLVE_REQUEST",
-      status: "success",
-      minCount: 1,
+      actionName: ["RESOLVE_REQUEST", "RESOLVE_REQUEST_REJECT"],
     },
     {
       type: "custom",


### PR DESCRIPTION
Advances #12776 by keeping the deterministic scenario fix from the prior live-run review while removing unsupported live-verification catalog flips.

## What changed

- `approval-outcome.ts` now matches the full `RESOLVE_REQUEST` action family (`RESOLVE_REQUEST` plus promoted names like `RESOLVE_REQUEST_REJECT`). `RESOLVE_REQUEST` is registered through promoted subactions, so a live or routed model can select the promoted action name even though the same resolver handles the outcome.
- `f1-cross-persona-wrong-recipient-highstakes.scenario.ts` now accepts either `RESOLVE_REQUEST` or `RESOLVE_REQUEST_REJECT` for the selected-action check.
- The scenario still relies on the stronger approval-queue predicate to prove the request is rejected and no gated side effect or external dispatch happens.
- The F1 catalog rows remain `authored`; this PR no longer claims live verification without committed trajectory/report artifacts.

## Verification

- `bunx @biomejs/biome check plugins/plugin-personal-assistant/test/scenarios/_helpers/approval-outcome.ts plugins/plugin-personal-assistant/test/scenarios/f1-cross-persona-wrong-recipient-highstakes.scenario.ts` — pass
- `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --json` — `errors: []` (F1 remains 32 authored / 24 verified)
- `bun test packages/scenario-runner/src/corpus-assertion-guard.test.ts` — 9 tests passed

## Evidence notes

N/A for live-model trajectory verification in this narrowed PR. The original catalog verification flips require committed `eliza-scenarios` reports, run-viewer artifacts, and native JSONL trajectories before they should merge.
