### PR TITLE
ci(#13373): add cross-workflow All Tests Passed aggregate

### DIFF
--- a/.github/issue-evidence/13373-all-tests-passed-cross-workflow.md
+++ b/.github/issue-evidence/13373-all-tests-passed-cross-workflow.md
@@ -1,0 +1,55 @@
+# Issue #13373 - All Tests Passed Cross-Workflow Aggregate
+
+## Scope
+
+Added `.github/workflows/all-tests-passed.yml`, a real `All Tests Passed`
+check-run context that polls the existing protected PR contexts across
+workflows:
+
+- `Develop Gate (lint)`
+- `Develop Gate (secret scan + UI determinism)`
+- `Format + Type Safety Ratchet`
+- `Homepage Build (PR smoke)`
+- `gitleaks`
+- `coverage on changed files`
+- `check-pr-title`
+- `stale-base guard`
+
+The aggregate fails closed on missing, failed, cancelled, timed-out, or
+incorrectly skipped checks. The only missing/skipped allowlist is the explicit
+`Quality (Extended)` `paths-ignore` case when every changed file matches that
+workflow's ignored paths.
+
+## Local Verification
+
+Run from isolated worktree `/tmp/eliza-13373-all-tests.yBis1T`:
+
+- `actionlint .github/workflows/all-tests-passed.yml` - pass
+- `node packages/scripts/all-tests-passed-workflow-contract.mjs` - pass
+- `bunx @biomejs/biome check packages/scripts/all-tests-passed-workflow-contract.mjs` - pass
+- `node packages/scripts/audit-scripts.mjs --json` - pass: `{"ok":true,"failures":[]}`
+- `git diff --check` - pass
+
+Full `bun run verify` was not run in this fresh isolated worktree because it has
+no `node_modules`. The touched surface is CI YAML plus one dependency-free Node
+contract script, covered by the focused checks above. The final proof is the
+real PR check run emitted by GitHub Actions.
+
+## Live GitHub API Check
+
+Checked an active same-repo PR (#13370) to confirm the aggregate must poll the
+PR head SHA, not the synthetic merge SHA:
+
+- PR head `a5fb55f0b68e6bb786966d2c6da401179727c6e4`: check-runs API returned
+  76 runs and included `Develop Gate (lint)`, `gitleaks`, and `check-pr-title`.
+- PR synthetic merge `056bd395ef21fde2c0cd0fa69a88951cdb786bdc`: check-runs
+  API returned 0 runs.
+- PR head commit-status API returned only external `CodeRabbit`; Actions jobs
+  are check runs, so the aggregate reads check runs first and statuses second.
+
+## Evidence N/A
+
+- UI screenshots/video: N/A - no product UI changes.
+- Live model trajectories: N/A - no agent, prompt, model, provider, or action
+  behavior changed.
+- Backend/frontend logs: N/A - GitHub Actions workflow-only change.

--- a/.github/workflows/all-tests-passed.yml
+++ b/.github/workflows/all-tests-passed.yml
@@ -1,0 +1,234 @@
+name: All Tests Passed
+
+on:
+  pull_request:
+    branches: [main, develop]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  workflow_dispatch:
+
+concurrency:
+  group: all-tests-passed-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  checks: read
+  statuses: read
+  pull-requests: read
+
+jobs:
+  all-tests-passed:
+    name: All Tests Passed
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    env:
+      HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      POLL_TIMEOUT_SECONDS: ${{ vars.ALL_TESTS_PASSED_TIMEOUT_SECONDS || '5400' }}
+      POLL_INTERVAL_SECONDS: ${{ vars.ALL_TESTS_PASSED_INTERVAL_SECONDS || '30' }}
+      REQUIRED_CONTEXTS: |
+        Develop Gate (lint)
+        Develop Gate (secret scan + UI determinism)
+        Format + Type Safety Ratchet
+        Homepage Build (PR smoke)
+        gitleaks
+        coverage on changed files
+        check-pr-title
+        stale-base guard
+      QUALITY_PATH_IGNORED_CONTEXTS: |
+        Develop Gate (lint)
+        Develop Gate (secret scan + UI determinism)
+        Format + Type Safety Ratchet
+        Homepage Build (PR smoke)
+    steps:
+      - name: Checkout aggregate contract
+        # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 1
+
+      - name: Verify aggregate workflow contract
+        run: node packages/scripts/all-tests-passed-workflow-contract.mjs
+
+      - name: Wait for required PR checks
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          map_contexts() {
+            sed '/^[[:space:]]*$/d' | sed 's/[[:space:]]*$//'
+          }
+
+          mapfile -t required_contexts < <(printf '%s\n' "$REQUIRED_CONTEXTS" | map_contexts)
+          mapfile -t quality_path_ignored_contexts < <(printf '%s\n' "$QUALITY_PATH_IGNORED_CONTEXTS" | map_contexts)
+
+          if [ "${#required_contexts[@]}" -eq 0 ]; then
+            echo "::error title=All Tests Passed::REQUIRED_CONTEXTS is empty"
+            exit 1
+          fi
+
+          for context in "${required_contexts[@]}"; do
+            if [ "$context" = "All Tests Passed" ]; then
+              echo "::error title=All Tests Passed::aggregate cannot require itself"
+              exit 1
+            fi
+          done
+
+          declare -A required_lookup=()
+          for context in "${required_contexts[@]}"; do
+            required_lookup["$context"]=1
+          done
+
+          declare -A missing_or_skipped_allowed=()
+
+          quality_path_ignored=false
+          if [ -n "$PR_NUMBER" ]; then
+            mapfile -t changed_files < <(gh api --paginate "repos/${GH_REPO}/pulls/${PR_NUMBER}/files?per_page=100" --jq '.[].filename')
+            if [ "${#changed_files[@]}" -gt 0 ]; then
+              quality_path_ignored=true
+              for file in "${changed_files[@]}"; do
+                case "$file" in
+                  AGENTS.md|CHANGELOG.md|LICENSE|.github/pull_request_template.md|docs/*|packages/docs/*|.github/ISSUE_TEMPLATE/*|*.md)
+                    ;;
+                  *)
+                    quality_path_ignored=false
+                    break
+                    ;;
+                esac
+              done
+            fi
+          fi
+
+          if [ "$quality_path_ignored" = "true" ]; then
+            for context in "${quality_path_ignored_contexts[@]}"; do
+              if [ -z "${required_lookup[$context]+x}" ]; then
+                echo "::error title=All Tests Passed::path-ignore allowlist contains non-required context '$context'"
+                exit 1
+              fi
+              missing_or_skipped_allowed["$context"]="Quality (Extended) paths-ignore matched every changed file"
+            done
+          fi
+
+          deadline=$(( $(date +%s) + POLL_TIMEOUT_SECONDS ))
+          attempt=1
+
+          while true; do
+            checks_tsv="$(mktemp)"
+            statuses_tsv="$(mktemp)"
+            trap 'rm -f "$checks_tsv" "$statuses_tsv"' EXIT
+
+            gh api --paginate "repos/${GH_REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" \
+              --jq '.check_runs[] | [.name, .status, (.conclusion // ""), (.started_at // .completed_at // .created_at // "")] | @tsv' \
+              > "$checks_tsv"
+
+            gh api "repos/${GH_REPO}/commits/${HEAD_SHA}/status" \
+              --jq '.statuses[] | [.context, .state, (.updated_at // .created_at // "")] | @tsv' \
+              > "$statuses_tsv"
+
+            declare -A check_status=()
+            declare -A check_conclusion=()
+            declare -A check_stamp=()
+            while IFS=$'\t' read -r name status conclusion stamp; do
+              [ -n "$name" ] || continue
+              if [ -z "${check_stamp[$name]+x}" ] || [[ "$stamp" > "${check_stamp[$name]}" ]]; then
+                check_status["$name"]="$status"
+                check_conclusion["$name"]="$conclusion"
+                check_stamp["$name"]="$stamp"
+              fi
+            done < "$checks_tsv"
+
+            declare -A status_state=()
+            declare -A status_stamp=()
+            while IFS=$'\t' read -r context state stamp; do
+              [ -n "$context" ] || continue
+              if [ -z "${status_stamp[$context]+x}" ] || [[ "$stamp" > "${status_stamp[$context]}" ]]; then
+                status_state["$context"]="$state"
+                status_stamp["$context"]="$stamp"
+              fi
+            done < "$statuses_tsv"
+
+            ok=0
+            pending=0
+            bad=0
+            messages=()
+
+            for context in "${required_contexts[@]}"; do
+              if [ -n "${check_status[$context]+x}" ]; then
+                status="${check_status[$context]}"
+                conclusion="${check_conclusion[$context]}"
+                if [ "$status" = "completed" ] && [ "$conclusion" = "success" ]; then
+                  ok=$((ok + 1))
+                  messages+=("PASS check-run '$context' concluded success")
+                elif [ "$status" = "completed" ] && { [ "$conclusion" = "skipped" ] || [ "$conclusion" = "neutral" ]; } && [ -n "${missing_or_skipped_allowed[$context]+x}" ]; then
+                  ok=$((ok + 1))
+                  messages+=("PASS check-run '$context' concluded ${conclusion}: ${missing_or_skipped_allowed[$context]}")
+                elif [ "$status" = "completed" ]; then
+                  bad=$((bad + 1))
+                  messages+=("FAIL check-run '$context' concluded ${conclusion:-unknown}")
+                else
+                  pending=$((pending + 1))
+                  messages+=("WAIT check-run '$context' is $status")
+                fi
+              elif [ -n "${status_state[$context]+x}" ]; then
+                state="${status_state[$context]}"
+                if [ "$state" = "success" ]; then
+                  ok=$((ok + 1))
+                  messages+=("PASS commit status '$context' is success")
+                elif { [ "$state" = "pending" ] || [ "$state" = "neutral" ]; } && [ -n "${missing_or_skipped_allowed[$context]+x}" ]; then
+                  ok=$((ok + 1))
+                  messages+=("PASS commit status '$context' is ${state}: ${missing_or_skipped_allowed[$context]}")
+                elif [ "$state" = "pending" ]; then
+                  pending=$((pending + 1))
+                  messages+=("WAIT commit status '$context' is pending")
+                else
+                  bad=$((bad + 1))
+                  messages+=("FAIL commit status '$context' is ${state:-unknown}")
+                fi
+              elif [ -n "${missing_or_skipped_allowed[$context]+x}" ]; then
+                ok=$((ok + 1))
+                messages+=("PASS missing '$context': ${missing_or_skipped_allowed[$context]}")
+              else
+                pending=$((pending + 1))
+                messages+=("WAIT missing required context '$context'")
+              fi
+            done
+
+            {
+              echo "### All Tests Passed aggregate"
+              echo
+              echo "- Head SHA: \`${HEAD_SHA}\`"
+              echo "- Required contexts: ${#required_contexts[@]}"
+              echo "- Passing contexts: ${ok}"
+              echo "- Pending contexts: ${pending}"
+              echo "- Failed contexts: ${bad}"
+              if [ "$quality_path_ignored" = "true" ]; then
+                echo "- Quality path-ignore: matched all changed files"
+              fi
+              echo
+              printf '%s\n' "${messages[@]}" | sed 's/^/- /'
+            } > "$GITHUB_STEP_SUMMARY"
+
+            printf 'All Tests Passed poll attempt %s: ok=%s pending=%s failed=%s\n' "$attempt" "$ok" "$pending" "$bad"
+            printf '%s\n' "${messages[@]}"
+
+            if [ "$bad" -gt 0 ]; then
+              echo "::error title=All Tests Passed::one or more required contexts failed"
+              exit 1
+            fi
+            if [ "$pending" -eq 0 ]; then
+              echo "All required contexts passed."
+              exit 0
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error title=All Tests Passed::timed out waiting for required contexts"
+              exit 1
+            fi
+
+            rm -f "$checks_tsv" "$statuses_tsv"
+            trap - EXIT
+            attempt=$((attempt + 1))
+            sleep "$POLL_INTERVAL_SECONDS"
+          done

--- a/packages/scripts/all-tests-passed-workflow-contract.mjs
+++ b/packages/scripts/all-tests-passed-workflow-contract.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * Contract for the protected-branch aggregate check (#13373).
+ *
+ * The `All Tests Passed` workflow is allowed to be the human-friendly required
+ * context only if it is a real aggregate over the checks already enforced by
+ * the develop ruleset. This script keeps that workflow from drifting into a
+ * self-referential or vacuous green check.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+
+const REQUIRED_CONTEXTS = [
+  "Develop Gate (lint)",
+  "Develop Gate (secret scan + UI determinism)",
+  "Format + Type Safety Ratchet",
+  "Homepage Build (PR smoke)",
+  "gitleaks",
+  "coverage on changed files",
+  "check-pr-title",
+  "stale-base guard",
+];
+
+const QUALITY_PATH_IGNORED_CONTEXTS = [
+  "Develop Gate (lint)",
+  "Develop Gate (secret scan + UI determinism)",
+  "Format + Type Safety Ratchet",
+  "Homepage Build (PR smoke)",
+];
+
+function read(rel) {
+  return readFileSync(resolve(repoRoot, rel), "utf8");
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function assertIncludes(text, fragment, message) {
+  assert(text.includes(fragment), `${message}: missing ${fragment}`);
+}
+
+function extractLiteralBlock(text, key) {
+  const lines = text.split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim() === `${key}: |`);
+  assert(start >= 0, `missing ${key} literal block`);
+
+  const indent = lines[start].match(/^\s*/)[0].length;
+  const values = [];
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!line.trim()) continue;
+    const currentIndent = line.match(/^\s*/)[0].length;
+    if (currentIndent <= indent) break;
+    values.push(line.trimEnd().trimStart());
+  }
+  return values;
+}
+
+function assertListEqual(actual, expected, label) {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  assert(
+    actualJson === expectedJson,
+    `${label}: expected ${expectedJson}, got ${actualJson}`,
+  );
+}
+
+function assertWorkflowOwnsContext(workflowRel, fragment, context) {
+  const workflow = read(workflowRel);
+  assertIncludes(workflow, fragment, `${workflowRel} context ${context}`);
+}
+
+const workflow = read(".github/workflows/all-tests-passed.yml");
+
+assertIncludes(workflow, "name: All Tests Passed", "workflow name");
+assertIncludes(workflow, "  pull_request:", "pull_request trigger");
+assertIncludes(workflow, "    branches: [main, develop]", "PR branches");
+assertIncludes(workflow, "  workflow_dispatch:", "manual dispatch trigger");
+assertIncludes(workflow, "  checks: read", "checks permission");
+assertIncludes(workflow, "  statuses: read", "statuses permission");
+assertIncludes(workflow, "  pull-requests: read", "pull request permission");
+assertIncludes(workflow, "  all-tests-passed:", "aggregate job key");
+assertIncludes(workflow, "    name: All Tests Passed", "aggregate job name");
+assertIncludes(workflow, "    timeout-minutes: 90", "aggregate timeout");
+assertIncludes(
+  workflow,
+  "node packages/scripts/all-tests-passed-workflow-contract.mjs",
+  "self contract step",
+);
+assertIncludes(
+  workflow,
+  "commits/$" + "{HEAD_SHA}/check-runs?per_page=100",
+  "check-run API poll",
+);
+assertIncludes(
+  workflow,
+  "commits/$" + "{HEAD_SHA}/status",
+  "commit-status API poll",
+);
+assertIncludes(
+  workflow,
+  "pulls/$" + "{PR_NUMBER}/files?per_page=100",
+  "PR files API for paths-ignore detection",
+);
+assertIncludes(
+  workflow,
+  'if [ "$context" = "All Tests Passed" ]; then',
+  "self-dependency guard",
+);
+assertIncludes(
+  workflow,
+  "missing_or_skipped_allowed",
+  "explicit missing/skipped allowlist",
+);
+
+const requiredContexts = extractLiteralBlock(workflow, "REQUIRED_CONTEXTS");
+assertListEqual(requiredContexts, REQUIRED_CONTEXTS, "required contexts");
+assert(
+  !requiredContexts.includes("All Tests Passed"),
+  "required contexts must not include the aggregate check itself",
+);
+
+const qualityIgnoredContexts = extractLiteralBlock(
+  workflow,
+  "QUALITY_PATH_IGNORED_CONTEXTS",
+);
+assertListEqual(
+  qualityIgnoredContexts,
+  QUALITY_PATH_IGNORED_CONTEXTS,
+  "quality paths-ignore contexts",
+);
+for (const context of qualityIgnoredContexts) {
+  assert(
+    requiredContexts.includes(context),
+    `paths-ignore context is not required: ${context}`,
+  );
+}
+
+assertWorkflowOwnsContext(
+  ".github/workflows/quality.yml",
+  "name: Develop Gate (lint)",
+  "Develop Gate (lint)",
+);
+assertWorkflowOwnsContext(
+  ".github/workflows/quality.yml",
+  "name: Develop Gate (secret scan + UI determinism)",
+  "Develop Gate (secret scan + UI determinism)",
+);
+assertWorkflowOwnsContext(
+  ".github/workflows/quality.yml",
+  "name: Format + Type Safety Ratchet",
+  "Format + Type Safety Ratchet",
+);
+assertWorkflowOwnsContext(
+  ".github/workflows/quality.yml",
+  "name: Homepage Build (PR smoke)",
+  "Homepage Build (PR smoke)",
+);
+assertWorkflowOwnsContext(
+  ".github/workflows/gitleaks.yml",
+  "name: gitleaks",
+  "gitleaks",
+);
+assertWorkflowOwnsContext(
+  ".github/workflows/coverage-gate.yml",
+  "name: coverage on changed files",
+  "coverage on changed files",
+);
+assertWorkflowOwnsContext(
+  ".github/workflows/pr.yaml",
+  "  check-pr-title:",
+  "check-pr-title",
+);
+assertWorkflowOwnsContext(
+  ".github/workflows/stale-base-guard.yml",
+  "name: stale-base guard",
+  "stale-base guard",
+);
+
+console.log("all-tests-passed workflow contract passed");


### PR DESCRIPTION
## Summary

- Adds a real `All Tests Passed` workflow/job context that polls the existing protected PR contexts across workflows: Quality, gitleaks, coverage, PR title, and stale-base.
- Fails closed when any required context is missing, pending past timeout, failed, cancelled, timed out, or skipped without an explicit allowlist reason.
- Adds `packages/scripts/all-tests-passed-workflow-contract.mjs` so the aggregate cannot drift into requiring itself or dropping protected contexts silently.
- Records evidence in `.github/issue-evidence/13373-all-tests-passed-cross-workflow.md`.

## Relationship to #13381

#13381 adds `All Tests Passed` as a thin `ci-ok` alias inside `test.yml`. That does not cover the current cross-workflow protected contexts from the ruleset (`Develop Gate`, `gitleaks`, `coverage on changed files`, `check-pr-title`, `stale-base guard`). This PR is the non-vacuous cross-workflow aggregate needed before repo admins can safely enforce the `All Tests Passed` context.

## Validation

- `actionlint .github/workflows/all-tests-passed.yml` - pass
- `node packages/scripts/all-tests-passed-workflow-contract.mjs` - pass
- `bunx @biomejs/biome check packages/scripts/all-tests-passed-workflow-contract.mjs` - pass
- `node packages/scripts/audit-scripts.mjs --json` - pass: `{"ok":true,"failures":[]}`
- `git diff --check HEAD~1..HEAD` - pass

Full `bun run verify` was not run in the fresh isolated worktree because it has no `node_modules`; this change is limited to CI YAML, one dependency-free Node contract script, and evidence markdown. The PR's own GitHub Actions run is the required live proof for the new context.

## Evidence

- `.github/issue-evidence/13373-all-tests-passed-cross-workflow.md`

## Remaining Admin Step

Do not add the required ruleset context until this PR is merged and the workflow exists on `develop`. After merge, a repo admin should add exact context `All Tests Passed` to ruleset `18511808` and confirm a real PR status rollup shows it passing only after the upstream protected contexts pass or are explicitly path-filtered.

Closes #13373.
