### PR TITLE
fix(#13372): avoid mixed-content websocket failure

### DIFF
--- a/.github/issue-evidence/13372-ios-sim-ws-mixed-content.md
+++ b/.github/issue-evidence/13372-ios-sim-ws-mixed-content.md
@@ -1,0 +1,28 @@
+# Issue #13372 — iOS simulator mixed-content WebSocket fallback
+
+Date: 2026-07-04
+
+## Change
+
+- `packages/ui/src/api/client-base.ts` now treats an insecure `ws://` target from
+  an `https:` page origin as connected-over-REST instead of opening the socket.
+- This avoids WKWebView/browser mixed-content blocking consuming all reconnect
+  attempts and showing the fatal "Lost backend connection" overlay while the
+  HTTP/SSE API remains reachable.
+- `packages/ui/src/api/client-base-websocket.test.ts` pins the jsdom origin to
+  `https://localhost/` and covers the `http://127.0.0.1:31338` agent-base case.
+
+## Verification
+
+- `bun run --cwd packages/ui test src/api/client-base-websocket.test.ts`
+  - 1 file passed, 12 tests passed.
+- `bunx @biomejs/biome check packages/ui/src/api/client-base.ts packages/ui/src/api/client-base-websocket.test.ts --no-errors-on-unmatched`
+  - Passed.
+- `bun run --cwd packages/ui typecheck`
+  - Passed.
+
+## Not captured
+
+- Real iOS simulator walkthrough/video was not captured in this local pass. The
+  code path is covered by the HTTPS-origin WebSocket unit regression; mobile
+  smoke evidence should be captured before merging if a simulator is available.

--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+// @vitest-environment-options {"url":"https://localhost/"}
 
 /**
  * Unit coverage for the base client's WebSocket lifecycle and the
@@ -109,6 +110,23 @@ describe("ElizaClient websocket connection policy", () => {
     expect(createdUrls).toHaveLength(1);
     expect(createdUrls[0]).toContain("wss://agent.example.test/ws?");
     expect(createdUrls[0]).toContain("token=agent-token");
+  });
+
+  it("does not open mixed-content ws from an https origin", () => {
+    const createdUrls = stubWebSocket();
+
+    const client = new ElizaClient("http://127.0.0.1:31338", "agent-token");
+
+    client.connectWs();
+
+    expect(window.location.protocol).toBe("https:");
+    expect(createdUrls).toEqual([]);
+    expect(client.getConnectionState()).toEqual({
+      state: "connected",
+      reconnectAttempt: 0,
+      maxReconnectAttempts: 15,
+      disconnectedAt: null,
+    });
   });
 
   it("treats a dedicated cloud agent base as connected without opening a websocket (its /ws is not proxied)", () => {

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -381,6 +381,12 @@ function getInjectedWsBase(): string | undefined {
   return undefined;
 }
 
+function isMixedContentWebSocketBlocked(wsProtocol: "ws:" | "wss:"): boolean {
+  if (wsProtocol !== "ws:") return false;
+  if (typeof window === "undefined") return false;
+  return window.location?.protocol === "https:";
+}
+
 // ---------------------------------------------------------------------------
 // Network status — listens for the bridged Capacitor `networkStatusChange`
 // event so the WS reconnect scheduler can park itself during airplane mode
@@ -1171,6 +1177,22 @@ export class ElizaClient {
     }
 
     if (!host) return;
+
+    // WKWebView and browsers on an HTTPS origin block insecure `ws://` as mixed
+    // content before the backend can answer. REST/SSE remains usable in that
+    // remote-host simulator lane, so degrade to connected-over-REST instead of
+    // burning the reconnect budget and surfacing the fatal lost-connection
+    // overlay against a healthy agent.
+    if (isMixedContentWebSocketBlocked(wsProtocol)) {
+      this.backoffMs = 500;
+      this.reconnectAttempt = 0;
+      this.disconnectedAt = null;
+      if (this.connectionState !== "connected") {
+        this.connectionState = "connected";
+        this.emitConnectionStateChange();
+      }
+      return;
+    }
 
     // On Capacitor native (iosScheme/androidScheme = "https"), the origin host
     // is a synthetic bundle host (e.g. "localhost" with no server behind it).


### PR DESCRIPTION
## Summary

Fixes #13372 by preventing the UI client from opening an insecure `ws://` connection when the renderer is running from an `https:` origin. WKWebView blocks that attempt as mixed content before the backend can answer, which previously burned through the reconnect budget and showed the fatal lost-backend overlay even though REST/SSE remained reachable.

The client now degrades that exact case to the same connected-over-REST state used by other REST-only agent bases.

## Evidence

Added `.github/issue-evidence/13372-ios-sim-ws-mixed-content.md`.

Commands run locally from `/tmp/eliza-13372`:

- `bun run --cwd packages/ui test src/api/client-base-websocket.test.ts`
  - 1 file passed, 12 tests passed.
- `bunx @biomejs/biome check packages/ui/src/api/client-base.ts packages/ui/src/api/client-base-websocket.test.ts --no-errors-on-unmatched`
  - Passed.
- `bun run --cwd packages/ui typecheck`
  - Passed.
- `git diff --check`
  - Passed.

## Not captured

A real iOS simulator walkthrough/video was not captured in this local pass. The regression is covered at the client policy level with jsdom origin pinned to `https://localhost/`; simulator smoke evidence should still be captured before merge if an iOS simulator lane is available.
