### PR TITLE
fix(#13372): clear stale iOS smoke defaults before reinstall

### DIFF
--- a/.github/issue-evidence/13372-ios-smoke-stale-defaults.md
+++ b/.github/issue-evidence/13372-ios-smoke-stale-defaults.md
@@ -1,0 +1,23 @@
+# Issue 13372 - iOS Smoke Stale Defaults Cleanup
+
+## Scope
+
+The simulator smoke harness now deletes the onboarding and attachment smoke
+request/result keys from the simulator defaults domain before reinstalling the
+iOS app. The existing post-install cleanup remains in place.
+
+This closes only the stale `eliza:ios-onboarding-smoke:request` harness hazard
+called out in #13372. It does not claim to fix the separate `ws://` mixed-content
+runtime failure from an `https://localhost` WKWebView origin.
+
+## Validation
+
+- `node --check packages/app/scripts/ios-onboarding-smoke.mjs`
+- `node --check packages/app/scripts/ios-attachment-smoke.mjs`
+- `bunx @biomejs/biome check packages/app/scripts/ios-onboarding-smoke.mjs packages/app/scripts/ios-attachment-smoke.mjs`
+- `git diff --check origin/develop...HEAD && git diff --check`
+
+## Evidence Boundary
+
+This is a script-only simulator harness cleanup. A live iOS simulator rerun is
+still required to prove the broader remote-host lane and mixed-content behavior.

--- a/packages/app/scripts/ios-attachment-smoke.mjs
+++ b/packages/app/scripts/ios-attachment-smoke.mjs
@@ -234,6 +234,22 @@ function defaultsDelete(udid, appId, key) {
   }
 }
 
+function deleteSimulatorPreferenceDomainKeys(udid, appId, keys) {
+  for (const key of keys) {
+    for (const nativeKey of preferenceNativeKeys(key)) {
+      tryRun("xcrun", [
+        "simctl",
+        "spawn",
+        udid,
+        "defaults",
+        "delete",
+        appId,
+        nativeKey,
+      ]);
+    }
+  }
+}
+
 function defaultsWriteString(udid, appId, key, value) {
   for (const [index, nativeKey] of preferenceNativeKeys(key).entries()) {
     const args = [
@@ -294,20 +310,22 @@ function flushPreferences(udid) {
   tryRun("xcrun", ["simctl", "spawn", udid, "killall", "cfprefsd"]);
 }
 
+const FIRST_RUN_STATE_KEYS = [
+  ONBOARDING_REQUEST_KEY,
+  ONBOARDING_RESULT_KEY,
+  ATTACHMENT_REQUEST_KEY,
+  ATTACHMENT_RESULT_KEY,
+  "elizaos:active-server",
+  "eliza:first-run-complete",
+  "eliza:setup:step",
+  "eliza:onboarding-complete",
+  "eliza:mobile-runtime-mode",
+  "eliza.background.config",
+  "elizaos:first-run:force-fresh",
+];
+
 function clearState(udid, appId) {
-  for (const key of [
-    ONBOARDING_REQUEST_KEY,
-    ONBOARDING_RESULT_KEY,
-    ATTACHMENT_REQUEST_KEY,
-    ATTACHMENT_RESULT_KEY,
-    "elizaos:active-server",
-    "eliza:first-run-complete",
-    "eliza:setup:step",
-    "eliza:onboarding-complete",
-    "eliza:mobile-runtime-mode",
-    "eliza.background.config",
-    "elizaos:first-run:force-fresh",
-  ]) {
+  for (const key of FIRST_RUN_STATE_KEYS) {
     defaultsDelete(udid, appId, key);
   }
 }
@@ -382,6 +400,8 @@ async function main() {
   removePathRecursive(resultDir);
   fs.mkdirSync(resultDir, { recursive: true });
 
+  deleteSimulatorPreferenceDomainKeys(udid, appId, FIRST_RUN_STATE_KEYS);
+  flushPreferences(udid);
   installLatestApp(udid, appId);
   tryRun("xcrun", ["simctl", "terminate", udid, appId]);
   clearState(udid, appId);

--- a/packages/app/scripts/ios-onboarding-smoke.mjs
+++ b/packages/app/scripts/ios-onboarding-smoke.mjs
@@ -232,6 +232,22 @@ function defaultsDelete(udid, appId, key) {
   }
 }
 
+function deleteSimulatorPreferenceDomainKeys(udid, appId, keys) {
+  for (const key of keys) {
+    for (const nativeKey of preferenceNativeKeys(key)) {
+      tryRun("xcrun", [
+        "simctl",
+        "spawn",
+        udid,
+        "defaults",
+        "delete",
+        appId,
+        nativeKey,
+      ]);
+    }
+  }
+}
+
 function defaultsWriteString(udid, appId, key, value) {
   const nativeKeys = preferenceNativeKeys(key);
   // Write through the simulator defaults domain. Host-path `defaults write`
@@ -300,20 +316,22 @@ function flushPreferences(udid) {
   tryRun("xcrun", ["simctl", "spawn", udid, "killall", "cfprefsd"]);
 }
 
+const FIRST_RUN_STATE_KEYS = [
+  REQUEST_KEY,
+  RESULT_KEY,
+  ATTACHMENT_REQUEST_KEY,
+  ATTACHMENT_RESULT_KEY,
+  "elizaos:active-server",
+  "eliza:first-run-complete",
+  "eliza:setup:step",
+  "eliza:onboarding-complete",
+  "eliza:mobile-runtime-mode",
+  "eliza.background.config",
+  "elizaos:first-run:force-fresh",
+];
+
 function clearFirstRunState(udid, appId) {
-  for (const key of [
-    REQUEST_KEY,
-    RESULT_KEY,
-    ATTACHMENT_REQUEST_KEY,
-    ATTACHMENT_RESULT_KEY,
-    "elizaos:active-server",
-    "eliza:first-run-complete",
-    "eliza:setup:step",
-    "eliza:onboarding-complete",
-    "eliza:mobile-runtime-mode",
-    "eliza.background.config",
-    "elizaos:first-run:force-fresh",
-  ]) {
+  for (const key of FIRST_RUN_STATE_KEYS) {
     defaultsDelete(udid, appId, key);
   }
 }
@@ -387,6 +405,8 @@ async function main() {
   removePathRecursive(resultDir);
   fs.mkdirSync(resultDir, { recursive: true });
 
+  deleteSimulatorPreferenceDomainKeys(udid, appId, FIRST_RUN_STATE_KEYS);
+  flushPreferences(udid);
   installLatestApp(udid, appId);
   tryRun("xcrun", ["simctl", "terminate", udid, appId]);
   clearFirstRunState(udid, appId);


### PR DESCRIPTION
## Summary
- clears the iOS onboarding/attachment smoke request/result and first-run defaults from the simulator defaults domain before reinstalling the app
- keeps the existing post-install container/domain cleanup in both iOS smoke scripts
- records the evidence boundary for #13372

This addresses the stale `eliza:ios-onboarding-smoke:request` harness hazard called out in #13372. It does **not** claim to fix the separate `ws://` mixed-content WKWebView backend connection issue.

## Validation
- `node --check packages/app/scripts/ios-onboarding-smoke.mjs`
- `node --check packages/app/scripts/ios-attachment-smoke.mjs`
- `bunx @biomejs/biome check packages/app/scripts/ios-onboarding-smoke.mjs packages/app/scripts/ios-attachment-smoke.mjs`
- `git diff --check origin/develop...HEAD && git diff --check`

## Evidence
- `.github/issue-evidence/13372-ios-smoke-stale-defaults.md`