### PR TITLE
fix(#13371): make character select post-onboarding only

### DIFF
--- a/.github/issue-evidence/13371-character-select-once.md
+++ b/.github/issue-evidence/13371-character-select-once.md
@@ -1,0 +1,37 @@
+# Issue #13371 — character select should not replay on every iOS launch
+
+Date: 2026-07-04
+
+## Change
+
+- Split first-run completion tracking into two refs:
+  - `completionCommittedRef`: durable recovery flag, still seeded from
+    `eliza:first-run-complete`.
+  - `completionJustCommittedRef`: in-memory one-shot handoff for the immediate
+    post-onboarding character-select route.
+- Startup hydration now consumes only the one-shot ref when deciding whether to
+  land on `character-select`.
+- A relaunch with persisted first-run completion now lands on the normal default
+  tab instead of replaying character select.
+
+## Verification
+
+- `bun run --cwd packages/ui test src/state/startup-phase-hydrate.character-select.test.ts src/state/first-run-completion-persist.test.tsx`
+  - 2 files passed, 9 tests passed.
+- `bunx @biomejs/biome check packages/ui/src/state/useFirstRunState.ts packages/ui/src/state/useFirstRunCallbacks.ts packages/ui/src/state/startup-phase-hydrate.ts packages/ui/src/state/AppContext.tsx packages/ui/src/state/first-run-completion-persist.test.tsx packages/ui/src/state/startup-phase-hydrate.character-select.test.ts --no-errors-on-unmatched`
+  - Passed.
+- `bun run --cwd packages/ui typecheck`
+  - Passed.
+- `git diff --check`
+  - Passed.
+
+## Not captured yet
+
+- Real iOS simulator relaunch walkthrough/video is not captured in this local
+  pass.
+- `bun run --cwd packages/app audit:app` was attempted and failed before
+  screenshots because the local Node executable is too old:
+  - `/opt/homebrew/bin/node` is `v23.3.0`
+  - `/usr/local/bin/node` is `v18.13.0`
+  - app-core runtime requires Node.js 24+ and reported:
+    `Invalid ELIZA_NODE_PATH=/opt/homebrew/bin/node: Node.js 23.3.0 is too old`

--- a/packages/ui/src/state/AppContext.tsx
+++ b/packages/ui/src/state/AppContext.tsx
@@ -649,6 +649,7 @@ function AppProviderInner({
       cloudProvisionedContainer: firstRunCloudProvisionedContainer,
     },
     completionCommittedRef: firstRunCompletionCommittedRefFromHook,
+    completionJustCommittedRef: firstRunCompletionJustCommittedRefFromHook,
   } = firstRun;
 
   const {
@@ -806,6 +807,8 @@ function AppProviderInner({
   const _restartNotificationSignatureRef = useRef<string | null>(null);
   const _heartbeatNotificationKeyRef = useRef<string | null>(null);
   const firstRunCompletionCommittedRef = firstRunCompletionCommittedRefFromHook;
+  const firstRunCompletionJustCommittedRef =
+    firstRunCompletionJustCommittedRefFromHook;
 
   // --- Confirm Modal ---
   const { modalProps } = useConfirm();
@@ -1493,6 +1496,7 @@ function AppProviderInner({
     setConversations,
     requestGreetingWhenRunningRef,
     firstRunCompletionCommittedRef,
+    firstRunCompletionJustCommittedRef,
     initialTabSetRef,
     activeConversationIdRef,
     elizaCloudPollInterval,

--- a/packages/ui/src/state/first-run-completion-persist.test.tsx
+++ b/packages/ui/src/state/first-run-completion-persist.test.tsx
@@ -68,11 +68,15 @@ describe("useFirstRunState seeds the completion ref from durable storage", () =>
     // A new process would create this ref anew; seeding it from the durable
     // flag is what keeps onboarding committed across the restart.
     expect(result.current.completionCommittedRef.current).toBe(true);
+    // The post-onboarding character-select handoff is intentionally not
+    // durable; a relaunch must go home/chat, not replay character select.
+    expect(result.current.completionJustCommittedRef.current).toBe(false);
   });
 
   it("a fresh mount with no prior onboarding starts uncommitted", () => {
     const { result } = renderHook(() => useFirstRunState());
     expect(result.current.completionCommittedRef.current).toBe(false);
+    expect(result.current.completionJustCommittedRef.current).toBe(false);
   });
 });
 

--- a/packages/ui/src/state/startup-phase-hydrate.character-select.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.character-select.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type HydratingDeps, runHydrating } from "./startup-phase-hydrate";
+
+const clientMock = vi.hoisted(() => ({
+  connectWs: vi.fn(),
+  getBaseUrl: vi.fn(() => "https://abc123.elizacloud.ai"),
+  getWalletAddresses: vi.fn(async () => ({})),
+}));
+
+vi.mock("../api", () => ({
+  client: clientMock,
+}));
+
+type TestHydratingDeps = HydratingDeps & {
+  firstRunCompletionCommittedRef: { current: boolean };
+  firstRunCompletionJustCommittedRef: { current: boolean };
+};
+
+function makeDeps(overrides: Partial<HydratingDeps> = {}): TestHydratingDeps {
+  const deps: HydratingDeps = {
+    setStartupError: vi.fn(),
+    setFirstRunLoading: vi.fn(),
+    hydrateInitialConversationState: vi.fn(async () => null),
+    requestGreetingWhenRunningRef: { current: vi.fn(async () => {}) },
+    loadWorkbench: vi.fn(async () => {}),
+    loadPlugins: vi.fn(async () => {}),
+    loadSkills: vi.fn(async () => {}),
+    loadCharacter: vi.fn(async () => {}),
+    loadWalletConfig: vi.fn(async () => {}),
+    loadInventory: vi.fn(async () => {}),
+    loadUpdateStatus: vi.fn(async () => {}),
+    checkExtensionStatus: vi.fn(async () => {}),
+    pollCloudCredits: vi.fn(),
+    fetchAutonomyReplay: vi.fn(async () => {}),
+    setSelectedVrmIndex: vi.fn(),
+    setWalletAddresses: vi.fn(),
+    setTab: vi.fn(),
+    setTabRaw: vi.fn(),
+    firstRunCompletionCommittedRef: { current: false },
+    firstRunCompletionJustCommittedRef: { current: false },
+    initialTabSetRef: { current: false },
+    ...overrides,
+  };
+  return deps as TestHydratingDeps;
+}
+
+describe("runHydrating character-select launch handoff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("does not treat a persisted first-run completion as a fresh character-select handoff", async () => {
+    const deps = makeDeps({
+      firstRunCompletionCommittedRef: { current: true },
+      firstRunCompletionJustCommittedRef: { current: false },
+    });
+    const dispatch = vi.fn();
+
+    await runHydrating(deps, dispatch, { current: false });
+
+    expect(deps.setTab).not.toHaveBeenCalledWith("character-select");
+    expect(deps.setTab).toHaveBeenCalledWith("chat");
+    expect(deps.firstRunCompletionCommittedRef.current).toBe(true);
+    expect(deps.firstRunCompletionJustCommittedRef.current).toBe(false);
+    expect(dispatch).toHaveBeenCalledWith({ type: "HYDRATION_COMPLETE" });
+  });
+
+  it("consumes a just-committed first-run completion as a one-shot character-select handoff", async () => {
+    const deps = makeDeps({
+      firstRunCompletionCommittedRef: { current: true },
+      firstRunCompletionJustCommittedRef: { current: true },
+    });
+
+    await runHydrating(deps, vi.fn(), { current: false });
+
+    expect(deps.setTab).toHaveBeenCalledWith("character-select");
+    expect(deps.firstRunCompletionJustCommittedRef.current).toBe(false);
+    expect(deps.firstRunCompletionCommittedRef.current).toBe(false);
+  });
+});

--- a/packages/ui/src/state/startup-phase-hydrate.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.ts
@@ -76,6 +76,7 @@ export interface HydratingDeps {
   setTab: (t: Tab) => void;
   setTabRaw: (t: Tab) => void;
   firstRunCompletionCommittedRef: React.MutableRefObject<boolean>;
+  firstRunCompletionJustCommittedRef: React.MutableRefObject<boolean>;
   initialTabSetRef: React.MutableRefObject<boolean>;
 }
 
@@ -270,7 +271,7 @@ export async function runHydrating(
   // contradicting each other (and sometimes stranding the user on character
   // select instead of the view they asked for).
   const shouldCharSelect =
-    (deps.firstRunCompletionCommittedRef.current ||
+    (deps.firstRunCompletionJustCommittedRef.current ||
       shouldStartAtCharacterSelectOnLaunch({
         firstRunNeedsOptions: false,
         navPath,
@@ -280,12 +281,14 @@ export async function runHydrating(
   if (!deps.initialTabSetRef.current) {
     deps.initialTabSetRef.current = true;
     if (shouldCharSelect) {
+      deps.firstRunCompletionJustCommittedRef.current = false;
       deps.firstRunCompletionCommittedRef.current = false;
       deps.setTab("character-select");
       void deps.loadCharacter();
     } else if (isRoot) {
       deps.setTab(resolveDefaultLandingTab());
     } else {
+      deps.firstRunCompletionJustCommittedRef.current = false;
       deps.firstRunCompletionCommittedRef.current = false;
     }
   }

--- a/packages/ui/src/state/useFirstRunCallbacks.ts
+++ b/packages/ui/src/state/useFirstRunCallbacks.ts
@@ -38,11 +38,15 @@ export function useFirstRunCallbacks(deps: FirstRunCallbacksDeps) {
     loadCharacter,
   } = deps;
 
-  const { completionCommittedRef: firstRunCompletionCommittedRef } = firstRun;
+  const {
+    completionCommittedRef: firstRunCompletionCommittedRef,
+    completionJustCommittedRef: firstRunCompletionJustCommittedRef,
+  } = firstRun;
 
   const completeFirstRun = useCallback(
     (landingTab: Tab = defaultLandingTab) => {
       firstRunCompletionCommittedRef.current = true;
+      firstRunCompletionJustCommittedRef.current = true;
       setPostFirstRunChecklistDismissed(false);
       setFirstRunComplete(true);
       coordinatorFirstRunCompleteRef.current?.();
@@ -59,6 +63,7 @@ export function useFirstRunCallbacks(deps: FirstRunCallbacksDeps) {
       loadCharacter,
       coordinatorFirstRunCompleteRef,
       initialTabSetRef,
+      firstRunCompletionJustCommittedRef,
     ],
   );
 

--- a/packages/ui/src/state/useFirstRunState.ts
+++ b/packages/ui/src/state/useFirstRunState.ts
@@ -223,8 +223,10 @@ export interface FirstRunStateHook {
   state: FirstRunState;
   dispatch: React.Dispatch<FirstRunAction>;
 
-  /** Tracks whether first-run completion has been committed this session. */
+  /** Tracks whether first-run completion has been committed durably. */
   completionCommittedRef: React.RefObject<boolean>;
+  /** One-shot in-memory handoff for post-onboarding landing behavior. */
+  completionJustCommittedRef: React.RefObject<boolean>;
 }
 
 export function useFirstRunState(cloudOnly?: boolean): FirstRunStateHook {
@@ -241,11 +243,13 @@ export function useFirstRunState(cloudOnly?: boolean): FirstRunStateHook {
   // with the `hadPrior` protection the restore/poll phases read from the same
   // durable store.
   const completionCommittedRef = useRef(loadPersistedFirstRunComplete());
+  const completionJustCommittedRef = useRef(false);
 
   return {
     state,
     dispatch,
     completionCommittedRef,
+    completionJustCommittedRef,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes #13371 by separating two first-run completion signals that had been sharing one ref:

- `completionCommittedRef` remains the durable recovery signal seeded from `eliza:first-run-complete`.
- `completionJustCommittedRef` is a new in-memory one-shot handoff for the immediate post-onboarding character-select route.

Startup hydration now consumes only the one-shot ref for `character-select`, so a cold relaunch with persisted first-run completion lands on the normal default tab instead of replaying character select every launch.

## Evidence

Added `.github/issue-evidence/13371-character-select-once.md`.

Commands run locally from `/tmp/eliza-13371`:

- `bun run --cwd packages/ui test src/state/startup-phase-hydrate.character-select.test.ts src/state/first-run-completion-persist.test.tsx`
  - 2 files passed, 9 tests passed.
- `bunx @biomejs/biome check packages/ui/src/state/useFirstRunState.ts packages/ui/src/state/useFirstRunCallbacks.ts packages/ui/src/state/startup-phase-hydrate.ts packages/ui/src/state/AppContext.tsx packages/ui/src/state/first-run-completion-persist.test.tsx packages/ui/src/state/startup-phase-hydrate.character-select.test.ts --no-errors-on-unmatched`
  - Passed.
- `bun run --cwd packages/ui typecheck`
  - Passed.
- `git diff --check`
  - Passed.

## Audit / device evidence gap

- Real iOS simulator relaunch walkthrough/video was not captured in this local pass.
- `bun run --cwd packages/app audit:app` was attempted but failed before screenshots because the local Node executable is too old:
  - `/opt/homebrew/bin/node` is `v23.3.0`
  - `/usr/local/bin/node` is `v18.13.0`
  - app-core requires Node.js 24+ and reported `Invalid ELIZA_NODE_PATH=/opt/homebrew/bin/node: Node.js 23.3.0 is too old`.

This PR should not be merged as fully evidenced until app audit and/or simulator relaunch evidence is captured on a Node 24-capable runner.
