### PR TITLE
fix(#13395): use lifecycle scenario categories for metrics

### DIFF
--- a/.github/issue-evidence/13395-orchestrator-lifecycle-category-metrics.md
+++ b/.github/issue-evidence/13395-orchestrator-lifecycle-category-metrics.md
@@ -1,0 +1,73 @@
+# Issue 13395 - Orchestrator Lifecycle Category Metrics
+
+## Scope
+
+Fix lifecycle benchmark category metrics so they use the scenario's explicit
+`category` field instead of substring matching against `scenario_id`.
+
+## Validation
+
+```bash
+PYTHONPATH=packages python3 -m pytest packages/benchmarks/orchestrator_lifecycle/tests/test_evaluator.py -q
+```
+
+Result:
+
+```text
+13 passed in 0.09s
+```
+
+```bash
+PYTHONPATH=packages python3 -m pytest packages/benchmarks/orchestrator_lifecycle/tests/ -q
+```
+
+Result:
+
+```text
+27 passed in 0.32s
+```
+
+Smoke report:
+
+```bash
+PYTHONPATH=packages python3 -m benchmarks.orchestrator_lifecycle.cli \
+  --mode simulate \
+  --max-scenarios 3 \
+  --output /tmp/olc-13395-smoke
+```
+
+Result:
+
+```text
+Mode: simulate
+Scenarios: 3
+Harness self-check pass rate: 100.0%
+Report: /tmp/olc-13395-smoke/orchestrator-lifecycle-20260704_141739.json
+```
+
+Inspected report snippet:
+
+```json
+{
+  "scored": false,
+  "metrics": {
+    "overall_score": null,
+    "scenario_pass_rate": 1.0,
+    "total_scenarios": 3,
+    "passed_scenarios": 3,
+    "clarification_success_rate": 0.0,
+    "status_accuracy_rate": 1.0,
+    "interruption_handling_rate": 1.0,
+    "completion_summary_quality": 0.0
+  },
+  "scenario_categories": [
+    ["cancel_task", "interrupt", 1.0],
+    ["cancel_then_undo_resume", "interrupt", 1.0],
+    ["check_in_while_running", "status", 1.0]
+  ]
+}
+```
+
+The status metric includes `check_in_while_running` through its structural
+`category: "status"` field even though the scenario ID does not contain
+`status`.

--- a/packages/benchmarks/orchestrator_lifecycle/evaluator.py
+++ b/packages/benchmarks/orchestrator_lifecycle/evaluator.py
@@ -125,6 +125,7 @@ class LifecycleEvaluator:
         return ScenarioResult(
             scenario_id=scenario.scenario_id,
             title=scenario.title,
+            category=scenario.category,
             passed=passed,
             score=score,
             checks_passed=checks_passed,
@@ -138,23 +139,18 @@ class LifecycleEvaluator:
         passed = sum(1 for r in results if r.passed)
         overall = (sum(r.score for r in results) / total) if total > 0 else 0.0
 
-        def _rate(tag: str) -> float:
-            tagged = [r for r in results if tag in r.scenario_id]
+        def _rate(category: str) -> float:
+            tagged = [r for r in results if r.category == category]
             if not tagged:
                 return 0.0
             return sum(r.score for r in tagged) / len(tagged)
 
         clarification = _rate("clarification")
         status = _rate("status")
-        interruption = (
-            _rate("pause")
-            + _rate("resume")
-            + _rate("cancel")
-            + _rate("interrupt")
-        ) / 4
+        interruption = _rate("interrupt")
         # No inflation fallback: a category with no scenarios (or all-failing
         # scenarios) reports its real rate, never the overall score.
-        summary = _rate("summary")
+        summary = _rate("completion_summary")
         return LifecycleMetrics(
             overall_score=overall,
             scenario_pass_rate=(passed / total) if total > 0 else 0.0,

--- a/packages/benchmarks/orchestrator_lifecycle/tests/test_evaluator.py
+++ b/packages/benchmarks/orchestrator_lifecycle/tests/test_evaluator.py
@@ -15,11 +15,15 @@ from benchmarks.orchestrator_lifecycle.evaluator import LifecycleEvaluator
 from benchmarks.orchestrator_lifecycle.types import Scenario, ScenarioTurn, TurnRecord
 
 
-def _scenario(turns: list[ScenarioTurn], scenario_id: str = "case") -> Scenario:
+def _scenario(
+    turns: list[ScenarioTurn],
+    scenario_id: str = "case",
+    category: str = "test",
+) -> Scenario:
     return Scenario(
         scenario_id=scenario_id,
         title=scenario_id,
-        category="test",
+        category=category,
         turns=turns,
     )
 
@@ -278,6 +282,7 @@ def test_summary_metric_reports_real_rate_never_overall_fallback() -> None:
             )
         ],
         scenario_id="cancel_task",
+        category="interrupt",
     )
     summary_scenario = _scenario(
         [
@@ -288,6 +293,7 @@ def test_summary_metric_reports_real_rate_never_overall_fallback() -> None:
             )
         ],
         scenario_id="final_stakeholder_summary",
+        category="completion_summary",
     )
     cancel_pass = evaluator.evaluate_scenario(
         cancel_scenario, [TurnRecord(reply_text="Shut down.", events=["cancel"])]
@@ -299,6 +305,50 @@ def test_summary_metric_reports_real_rate_never_overall_fallback() -> None:
     metrics = evaluator.compute_metrics([cancel_pass, summary_fail])
     assert metrics.overall_score == 0.5
     assert metrics.completion_summary_quality == 0.0
+
+
+def test_category_metrics_use_structural_category_not_id_substrings() -> None:
+    evaluator = LifecycleEvaluator()
+    status_scenario = _scenario(
+        [
+            ScenarioTurn(
+                actor="user",
+                message="How is it going? Give me a status update.",
+                expected_behaviors=["report_active_subagent_status"],
+            )
+        ],
+        scenario_id="check_in_while_running",
+        category="status",
+    )
+    clarification_scenario = _scenario(
+        [
+            ScenarioTurn(
+                actor="user",
+                message="Please handle this status-looking request without details.",
+                expected_behaviors=["ask_clarifying_question_before_start"],
+            )
+        ],
+        scenario_id="status_named_but_not_status_category",
+        category="clarification",
+    )
+    status_pass = evaluator.evaluate_scenario(
+        status_scenario,
+        [
+            TurnRecord(
+                reply_text="Collection done, analysis running.",
+                events=["status_query"],
+            )
+        ],
+    )
+    clarification_fail = evaluator.evaluate_scenario(
+        clarification_scenario,
+        [TurnRecord(reply_text="I will start now.", events=["spawn"])],
+    )
+    metrics = evaluator.compute_metrics([status_pass, clarification_fail])
+    assert status_pass.category == "status"
+    assert clarification_fail.category == "clarification"
+    assert metrics.status_accuracy_rate == 1.0
+    assert metrics.clarification_success_rate == 0.0
 
 
 def test_compute_metrics_aggregates_pass_rate() -> None:

--- a/packages/benchmarks/orchestrator_lifecycle/types.py
+++ b/packages/benchmarks/orchestrator_lifecycle/types.py
@@ -57,6 +57,7 @@ class TurnRecord:
 class ScenarioResult:
     scenario_id: str
     title: str
+    category: str
     passed: bool
     score: float
     checks_passed: int


### PR DESCRIPTION
## Summary

- carries each lifecycle scenario's explicit `category` into `ScenarioResult`
- computes clarification/status/interrupt/summary rates from the structural category field instead of `scenario_id` substrings
- adds regression coverage for `check_in_while_running` so the status metric cannot omit a status scenario because its ID lacks `status`
- records validation evidence under `.github/issue-evidence/13395-orchestrator-lifecycle-category-metrics.md`

## Validation

```bash
PYTHONPATH=packages python3 -m pytest packages/benchmarks/orchestrator_lifecycle/tests/test_evaluator.py -q
# 13 passed in 0.20s

PYTHONPATH=packages python3 -m pytest packages/benchmarks/orchestrator_lifecycle/tests/ -q
# 27 passed in 0.32s

PYTHONPATH=packages python3 -m benchmarks.orchestrator_lifecycle.cli \
  --mode simulate \
  --max-scenarios 3 \
  --output /tmp/olc-13395-smoke
```

Smoke report inspected: `check_in_while_running` appears with `category: "status"` and `status_accuracy_rate: 1.0` in simulate mode.

Fixes #13395.
